### PR TITLE
feat(index): add bounded replay and fenced job ownership

### DIFF
--- a/crates/rustok-index/CRATE_API.md
+++ b/crates/rustok-index/CRATE_API.md
@@ -11,8 +11,11 @@ The domain/application contract remains database independent. M3 owns the canoni
 PostgreSQL storage, mutation, schema-registration, lease, secondary-index, and measured
 partition-admission boundaries. M4 owns typed query planning, controlled SQL compilation,
 strict decoding, PostgreSQL execution, source-owned schema catalog composition, and the
-neutral shared query runtime. Source-specific Product, Content, Flex, search, migration,
-and scheduler implementations remain outside the engine core.
+neutral shared query runtime. M5/M6 own the neutral replay-source catalog, bounded scan/load
+contracts, one-page replay orchestration, durable schema-scoped replay job ownership, and
+lease-fenced rebuild checkpoints. Source-specific Product, Content, Flex, search,
+migration, scheduler, and long-running worker implementations remain outside the engine
+core.
 
 ## Primary Public Types
 
@@ -36,6 +39,16 @@ and scheduler implementations remain outside the engine core.
 - `IndexSchemaSourceCatalog`, `IndexSchemaSourceDescriptor`, `IndexSchemaSourceError`
 - `SharedIndexSchemaRegistry`
 - `register_index_schema_source`, `materialize_index_schema_registry`
+- `IndexSource`, `IndexSourceCatalog`, `IndexSourceDescriptor`, `SharedIndexSourceRegistry`
+- `IndexSourceCursor`, `IndexSourceScanRequest`, `IndexSourcePage`
+- `IndexSourceLoadRequest`, `IndexSourceLoadBatch`
+- `IndexSourceFailure`, `IndexSourceFailureKind`, `IndexSourceError`
+- `register_index_source`, `materialize_index_source_registry`
+- `IndexReplayWorker`, `IndexReplayPageRequest`, `IndexReplayPageOutcome`,
+  `IndexReplayPageStatus`
+- `IndexReplayCheckpointKey`, `IndexReplayCheckpoint`, `IndexReplayCheckpointStore`
+- `IndexReplayMutationSink`, `IndexReplayMutationOutcome`
+- `IndexReplayFailure`, `IndexReplayFailureKind`, `IndexReplayError`
 - `RecordValidationError`, `QueryValidationError`, `AggregateOrderValidationError`
 - `IndexCursor`, `CursorCodec`, `CursorCodecError`, `CursorValidationError`
 - `ExecutableQueryPlan`, `PlannedJoin`, `PlannedField`, `PlannedManyProjection`, `PlannedOrder`
@@ -55,6 +68,9 @@ and scheduler implementations remain outside the engine core.
 - `materialize_postgres_index_query_runtime`
 - `IndexQueryRuntimeCompositionError`
 - `PostgresMutationStore`, `MutationDelivery`, `MutationApplyOutcome`, `MutationStorageError`
+- `PostgresIndexReplayJobStore`, `IndexReplayJobLeaseRequest`, `IndexReplayJobLease`
+- `IndexReplayJobAcquireOutcome`, `IndexReplayJobError`
+- `PostgresIndexReplayCheckpointStore`
 - `PostgresSchemaRegistrationStore`, `PersistedSchemaRegistrationOutcome`, `SchemaRegistrationError`
 - `PostgresSchemaLeaseStore`, `SchemaApplicationLeaseRequest`, `SchemaApplicationLease`
 - `SchemaLeaseAcquireOutcome`, `SchemaLeaseError`
@@ -85,11 +101,11 @@ pages, exact count, query-scoped keyset pagination for ordinary order expression
 lookahead, strict row decoding, and PostgreSQL execution through one read-only repeatable-read
 snapshot.
 
-Source modules now publish generic schema contracts through `IndexSchemaSourceCatalog`.
-The catalog fixes one owner for every exact schema reference and for the complete schema
-identity across versions. `rustok-distribution` materializes all contributions through one
-atomic `SchemaRegistry::register_batch` and publishes `SharedIndexSchemaRegistry` only for a
-non-empty valid catalog. Social Graph is the first source owner.
+Source modules publish generic schema contracts through `IndexSchemaSourceCatalog`. The
+catalog fixes one owner for every exact schema reference and for the complete schema identity
+across versions. `rustok-distribution` materializes all contributions through one atomic
+`SchemaRegistry::register_batch` and publishes `SharedIndexSchemaRegistry` only for a non-empty
+valid catalog. Social Graph is the first source owner.
 
 The server composes `SharedIndexQueryRuntime` through the Index-owned
 `materialize_postgres_index_query_runtime`. The materializer binds the exact immutable shared
@@ -97,6 +113,33 @@ registry to the host `DatabaseConnection`, refuses duplicate runtime publication
 SQL, and transfers the neutral capability through `ModuleRuntimeExtensions` and
 `HostRuntimeContext`. Runtime presence does not claim PostgreSQL backend support for a test
 connection, persisted tenant schema readiness, authorization, or successful query execution.
+
+M5/M6 source replay is source complete through the fenced one-page boundary.
+`IndexSourceCatalog` fixes one replay source for every exact schema and complete schema identity
+across versions, and materialization requires the corresponding owner-published schema with the
+same owner. Cursor scans, targeted loads, cursor bytes, page/key counts, tenant/schema scope,
+returned keys, and continuation progress are bounded.
+
+`IndexReplayWorker::run_next_page` reads one checkpoint, scans one page, validates every
+non-nil unique event UUID before the first write, applies mutations sequentially through an
+`IndexReplayMutationSink`, and commits the next checkpoint only after all mutation results are
+durable. Stable event UUIDs are delivery identities, so a checkpoint failure safely repeats the
+old page through inbox deduplication. Checkpoint watermarks remain monotonic and completion is a
+JSON null cursor.
+
+`PostgresIndexReplayJobStore` owns one schema-scoped `rebuild` job for an exact
+tenant/source/schema. It validates the `index_replay_job_v1` request and active persisted schema,
+serializes acquisition with an advisory lock, heartbeats an unexpired lease, reclaims expired
+work with an incremented attempt fence, and rejects stale heartbeat or terminal updates.
+`PostgresIndexReplayCheckpointStore` requires an acquired `IndexReplayJobLease`; both reads and
+writes lock and validate the exact `(job_id, worker_id, attempt_count)` before accessing the
+checkpoint. Terminal success requires the same active lease and an exact durable null-cursor
+checkpoint.
+
+A scheduler, bounded multi-page runner, cancellation, retry/backoff/dead-letter policy,
+locale/partition replay dimensions, direct server binding of job requests to the materialized
+source registry, production source adapters, and retained multi-instance PostgreSQL evidence
+remain open.
 
 Exact Decimal tagged-order transport is source-complete. Aggregate cursor continuation,
 retained PostgreSQL/reference aggregate evidence, additional source schemas, transport
@@ -117,21 +160,56 @@ builders or DTOs.
 
 ### Schema source and runtime composition
 
-- `IndexModule::register_runtime_extensions` seeds `IndexSchemaSourceCatalog`.
+- `IndexModule::register_runtime_extensions` seeds `IndexSchemaSourceCatalog` and
+  `IndexSourceCatalog`.
 - `register_index_schema_source` accepts one owner slug and one validated generic schema.
-- Duplicate exact references fail even when fingerprints match.
-- Different owners cannot split versions of one `(module, entity)` identity.
+- Duplicate exact schema references fail even when fingerprints match.
+- Different owners cannot split versions of one `(module, entity)` schema identity.
 - `materialize_index_schema_registry` returns `None` for an absent or empty catalog.
-- Non-empty materialization uses one atomic registration batch so cross-source links validate
-  without partial registry state.
+- Non-empty schema materialization uses one atomic registration batch so cross-source links
+  validate without partial registry state.
 - `SharedIndexSchemaRegistry` wraps the exact immutable `Arc<SchemaRegistry>`; its constructor
   is not public.
+- `register_index_source` accepts one owner, one bounded source name, exact schema references,
+  and one neutral `IndexSource` implementation.
+- One exact schema and complete schema identity cannot move between replay sources across
+  versions.
+- Replay-source materialization rejects unpublished schemas and schema/source owner drift.
 - `SharedIndexQueryRuntime` exposes only the transport-neutral `IndexQueryPort` capability.
 - `materialize_postgres_index_query_runtime` is the production constructor for the PostgreSQL
   runtime and fails when the runtime is already present.
 - Runtime composition performs no SQL and does not replace tenant-scoped persisted schema
   registration or preflight.
-- Executable hosts transfer the capability through the existing typed runtime-extension seam.
+- Executable hosts transfer capabilities through the existing typed runtime-extension seam.
+
+### Replay source, job, and checkpoint
+
+- `IndexSourceCursor` rejects JSON null and encoded values above 8 KiB, including during
+  deserialization.
+- `IndexSourceScanRequest` carries one non-nil tenant, one exact schema, one optional opaque
+  cursor, and a limit from 1 through 1000.
+- Scan pages cannot exceed the request, escape tenant/schema scope, repeat entity keys, return an
+  empty continuation page, or return the same continuation cursor.
+- `IndexSourceLoadRequest` carries one to 256 unique keys from one tenant and exact schema.
+- Targeted load results cannot exceed the request, return another key, or duplicate a key.
+- `IndexReplayWorker::run_next_page` validates all page event UUIDs before the first mutation
+  write, applies mutations sequentially, and commits the checkpoint last.
+- A replay source must return the same non-nil event UUID for the same logical mutation and source
+  version when a page is retried.
+- `IndexReplayJobLeaseRequest` validates tenant, source name, worker ID, schema, and whole-second
+  lease duration from 1 through 86400 seconds.
+- Job requests use the exact `index_replay_job_v1` JSON contract and require an active persisted
+  schema.
+- A non-expired owner returns `Busy`; an expired running attempt is reclaimed with an incremented
+  attempt count; a succeeded job returns `AlreadyComplete`.
+- Heartbeat and terminal updates require the exact job, worker, attempt, running state, and
+  unexpired lease.
+- `PostgresIndexReplayCheckpointStore::new` requires the acquired replay job lease.
+- Checkpoint key tenant/source/schema must match the lease, and the exact active job attempt is
+  row-locked before checkpoint read or write.
+- A stale attempt cannot advance a checkpoint after reclaim.
+- Successful job completion requires the active attempt and the exact rebuild checkpoint with a
+  JSON null cursor.
 
 ### Query input and execution
 
@@ -168,7 +246,8 @@ builders or DTOs.
   schema and calculated fingerprint.
 - `PostgresMutationStore` applies one `MutationDelivery` with inbox deduplication, complete
   entity-key serialization, monotonic source versions, tombstones, and atomic link replacement.
-- `SchemaApplicationLeaseRequest` and `SecondaryIndexRequest` use exact worker/attempt fencing.
+- `SchemaApplicationLeaseRequest`, `SecondaryIndexRequest`, and `IndexReplayJobLeaseRequest` use
+  exact worker/attempt fencing.
 - Partition admission requires one exact retained evidence identity, non-zero coverage groups,
   100% tenant-predicate coverage, parity, catch-up, integrity, regression, WAL, skew, and lock
   gates before producing shadow-only planning output.
@@ -188,6 +267,10 @@ builders or DTOs.
 - Ordering through `many` paths requires an explicit supported `min` / `max` mode; implicit
   first-row, link-ordinal, and storage-order semantics remain forbidden.
 - Source versions and tombstones prevent stale mutation overwrite.
+- Replay sources cannot escape the requested tenant/schema or return unbounded pages/loads.
+- Replay event IDs are non-nil and unique inside one page and remain stable across retry.
+- Durable replay checkpoint progression is ordered after mutation outcomes and fenced by the
+  active replay job attempt.
 - Generic engine types remain source-domain agnostic.
 - Runtime composition is not an authorization decision or persisted-readiness assertion.
 
@@ -215,9 +298,15 @@ builders or DTOs.
 
 - `DomainError` defines identifier, schema-shape, and query-shape failures.
 - `SchemaRegistryError` defines atomic registration and graph failures.
-- `IndexSchemaSourceError` defines invalid owner identity, duplicate exact ownership, owner drift
-  across schema versions, empty materialization, invalid schema, and registry failures.
-- `IndexQueryRuntimeCompositionError` currently rejects duplicate shared runtime materialization.
+- `IndexSchemaSourceError` defines invalid schema-owner identity, duplicate exact ownership,
+  owner drift across schema versions, empty materialization, invalid schema, and registry failures.
+- `IndexSourceError` defines replay-source ownership conflicts, cursor/page/load bounds, result
+  scope drift, continuation failures, and bounded source failures.
+- `IndexReplayError` defines checkpoint identity, page event identity, mutation, and checkpoint
+  progression failures.
+- `IndexReplayJobError` defines job request, schema readiness, stored job, checkpoint completion,
+  lease loss, and storage failures.
+- `IndexQueryRuntimeCompositionError` rejects duplicate shared runtime materialization.
 - `RecordValidationError`, `QueryValidationError`, and `AggregateOrderValidationError` define
   registry-backed data/query failures and the bounded aggregate-order policy.
 - `CursorCodecError` and `CursorValidationError` separate malformed cursors from scope, schema,
@@ -229,13 +318,18 @@ builders or DTOs.
 - `IndexQueryExecutionError` separates unsupported backend, missing/inactive/drifted persisted
   schemas, build/decode failures, missing counts, invalid driver columns, contract preparation,
   and storage operations while keeping top-level display bounded.
-- Storage, lease, secondary-index, and partition errors retain their typed ownership and evidence
-  boundaries; transport adapters must not expose raw database details.
+- Storage, lease, replay, secondary-index, and partition errors retain their typed ownership and
+  evidence boundaries; transport adapters must not expose raw database details.
 
 ## Common AI Mistakes
 
 - Adding Product, Content, Flex, Pricing, Inventory, or other source fields to engine enums.
 - Reading source-module tables from Index or writing Index tables from source modules.
+- Letting source modules own `index_jobs` or `index_checkpoints` writes.
+- Creating an unfenced `PostgresIndexReplayCheckpointStore` without an acquired job lease.
+- Advancing a checkpoint before every page mutation result is durable.
+- Generating a new event UUID when replaying the same logical mutation and source version.
+- Treating one-page replay and durable leases as a completed scheduler or multi-page worker.
 - Treating in-memory registry composition as tenant-scoped persisted schema readiness.
 - Constructing an ad hoc `SchemaRegistry` or `SharedIndexSchemaRegistry` in server/consumer code.
 - Calling `PostgresIndexQueryPort::new` outside the Index-owned runtime materializer.

--- a/crates/rustok-index/Cargo.toml
+++ b/crates/rustok-index/Cargo.toml
@@ -12,6 +12,7 @@ rustok-core.workspace = true
 async-trait.workspace = true
 sea-orm.workspace = true
 sea-orm-migration.workspace = true
+tracing.workspace = true
 
 # Domain and application core
 base64.workspace = true

--- a/crates/rustok-index/README.md
+++ b/crates/rustok-index/README.md
@@ -3,16 +3,16 @@
 ## Purpose
 
 `rustok-index` is RusToK's cross-module relational Index Engine. Source modules
-publish generic schemas, records, mutations, and links; Index materializes them
-into optimized storage and executes filtering, projection, sorting, counting,
-and pagination without runtime fan-out to source modules.
+publish generic schemas, records, mutations, links, and bounded replay sources;
+Index materializes them into optimized storage and executes filtering, projection,
+sorting, counting, and pagination without runtime fan-out to source modules.
 
 Backward compatibility with the rejected source-specific implementation is not
 a rewrite goal.
 
 ## Responsibilities
 
-- Own the generic schema and link registry.
+- Own the generic schema, link, and replay-source registries.
 - Own incremental ingestion, deduplication, rebuild, reconciliation, and drift
   control.
 - Own PostgreSQL index storage and distributed coordination.
@@ -27,9 +27,10 @@ a rewrite goal.
 
 - Index core must not depend on Product, Content, Flex, Pricing, Inventory, or
   other source-domain crates.
-- Source modules own conversion from domain state/events into generic records and
-  mutations.
+- Source modules own conversion from domain state/events into generic records,
+  mutations, and bounded replay/load adapters.
 - Index must not read source-module tables directly.
+- Source modules do not write Index storage, job, or checkpoint tables.
 - `rustok-search` owns ranking, typo tolerance, autocomplete, synonyms, search
   UX, and external search-engine connectors.
 - The selected JSONB regression DDL lives under `ops/benches`; it is not a
@@ -38,7 +39,7 @@ a rewrite goal.
 
 ## Rewrite status
 
-- Current milestone: `M4 - Query engine v1`
+- Current milestone: `M6 - fenced replay job ownership`
 - FFA status: `in_progress`
 - FBA status: `in_progress`
 - M0 code reset: complete
@@ -59,7 +60,11 @@ a rewrite goal.
 - M4 explicit many-link aggregate ordering and Decimal tagged wire: source complete
 - M4 PostgreSQL query port and row adapter: source complete
 - M4 source-owned registry and server query-runtime composition: source complete
+- M5/M6 bounded source registry and replay/load contracts: source complete
+- M6 one-page replay and durable checkpoint progression: source complete
+- M6 replay job leases and checkpoint attempt fencing: source complete, owner execution pending
 - Real retained PostgreSQL packet execution: open
+- Bounded multi-page replay, cancellation, retry scheduling, and Product adapters: open
 - Query-port authorization/consumer cutover and live equivalence evidence: open
 
 All legacy ports, adapters, source indexers, projections, migrations, runtime
@@ -72,7 +77,7 @@ and validates the nine-file retained bundle, renders a read-only review, emits a
 admitted-only archive manifest outside the bundle, and verifies the saved manifest
 against an exact recursive filesystem snapshot.
 
-M4 now provides deterministic typed planning, controlled PostgreSQL compilation,
+M4 provides deterministic typed planning, controlled PostgreSQL compilation,
 correlated many-link filtering, nested many-link projection aggregation, explicit bounded
 `MIN` / `MAX` many-link ordering for integer, Decimal, string, and timestamp, strict result
 decoding, lookahead pagination, exact count, scoped cursors for ordinary order expressions,
@@ -81,6 +86,26 @@ server-owned neutral query runtime. Decimal aggregate ordering remains numeric w
 hidden tagged value uses an exact JSON string. Aggregate cursor continuation,
 PostgreSQL/reference aggregate evidence, storefront/admin/search authorization and consumer
 cutover, and production partition cutover remain open.
+
+M5/M6 adds a neutral `IndexSource` boundary with bounded opaque cursor scans and targeted
+loads, exact schema/source ownership, page and key limits, continuation progress checks,
+and bounded retryable/permanent source failures. `IndexReplayWorker::run_next_page`
+validates the complete page event-identity set before any write, applies mutations through
+`PostgresMutationStore`, and advances the durable rebuild checkpoint only after every
+mutation result is committed. Stable event UUID delivery IDs make retry after checkpoint
+failure idempotent through the existing inbox contract.
+
+`PostgresIndexReplayJobStore` owns one schema-scoped `rebuild` job per tenant/source/schema.
+It validates the exact `index_replay_job_v1` request and active persisted schema, serializes
+claims with a PostgreSQL advisory lock, heartbeats an unexpired lease, reclaims expired
+work with an incremented attempt fence, and rejects stale terminal updates.
+`PostgresIndexReplayCheckpointStore` is constructed from the acquired
+`IndexReplayJobLease`; every checkpoint read or write locks and validates the exact
+`(job_id, worker_id, attempt_count)` first. A stale worker may finish an already-started
+idempotent mutation transaction, but it cannot advance the durable cursor. Successful
+job completion requires an active lease and the exact durable rebuild checkpoint with a
+JSON null cursor. A scheduler, bounded multi-page loop, cancellation, backoff/dead-letter
+policy, locale/partition replay dimensions, and production source adapters remain open.
 
 The module-owned migration source creates:
 
@@ -165,6 +190,12 @@ registry to the host database and publishes `SharedIndexQueryRuntime` through
 `ModuleRuntimeExtensions`. Composition performs no SQL and does not claim tenant schema
 readiness; execution still fails closed through the query-port preflight.
 
+`IndexSourceCatalog` separately fixes one replay source for each exact schema and the
+complete schema identity across versions. Materialization requires the corresponding
+owner-published schema and exact owner match. The application replay boundary remains
+database independent; PostgreSQL mutation, job, and checkpoint adapters are composed
+outside it.
+
 ## Current entry points
 
 - `IndexModule`
@@ -174,6 +205,12 @@ readiness; execution still fails closed through the query-port preflight.
 - `PostgresMutationStore`, `MutationDelivery`, and `MutationApplyOutcome`
 - `PostgresSchemaLeaseStore`, `SchemaApplicationLeaseRequest`,
   `SchemaApplicationLease`, and `SchemaLeaseAcquireOutcome`
+- `PostgresIndexReplayJobStore`, `IndexReplayJobLeaseRequest`,
+  `IndexReplayJobLease`, and `IndexReplayJobAcquireOutcome`
+- `PostgresIndexReplayCheckpointStore`, `IndexReplayWorker`,
+  `IndexReplayCheckpoint`, and `IndexReplayPageOutcome`
+- `IndexSource`, `IndexSourceCatalog`, `SharedIndexSourceRegistry`,
+  `IndexSourceScanRequest`, and `IndexSourceLoadRequest`
 - `SecondaryIndexPlan`, `SecondaryIndexSpec`, `SecondaryIndexRequest`,
   `SecondaryIndexLease`, and `PostgresSecondaryIndexManager`
 - `PartitionAdmissionPolicy`, `PartitionEvidence`, `PartitionAdmissionOutcome`,
@@ -224,9 +261,15 @@ readiness; execution still fails closed through the query-port preflight.
 - PostgreSQL-only query execution with exact persisted schema preflight, one
   read-only repeatable-read page/count snapshot, exhaustive bind conversion, and
   compiler-metadata-driven row mapping;
-- deterministic source ownership, atomic cross-source registry materialization,
-  no false empty runtime, one Index-owned PostgreSQL runtime constructor, and neutral
-  capability transfer into `HostRuntimeContext`.
+- deterministic source-schema and replay-source ownership, atomic registry
+  materialization, bounded cursor/page/key contracts, and no false empty runtime;
+- full-page event UUID validation before mutation persistence, stable replay delivery
+  identity, mutation-before-checkpoint ordering, monotonic checkpoint watermarks, and
+  duplicate-safe replay after checkpoint failure;
+- durable schema-scoped rebuild exclusion, lease heartbeat, expired-attempt reclaim,
+  attempt fencing, stale checkpoint-writer rejection, and null-cursor-gated success;
+- one Index-owned PostgreSQL query-runtime constructor and neutral capability transfer
+  into `HostRuntimeContext`.
 
 ## M2 benchmark
 
@@ -245,6 +288,8 @@ DDL remains benchmark-only and must not be copied into production migrations.
 
 - [Module documentation](./docs/README.md)
 - [Live implementation plan](./docs/implementation-plan.md)
+- [M5/M6 bounded source replay contract](./docs/m5-m6-source-replay-contract.md)
+- [M6 replay job lease and fencing boundary](./docs/m6-replay-job-leases.md)
 - [M4 source-owned schema registry](./docs/m4-source-schema-registry.md)
 - [M4 query runtime composition](./docs/m4-query-runtime-composition.md)
 - [M4 PostgreSQL query port contract](./docs/m4-postgres-query-port.md)

--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -1,34 +1,38 @@
 # Documentation `rustok-index`
 
 `rustok-index` is the platform-owned cross-module relational Index Engine. Source
-modules publish generic schemas, records, mutations, and links; Index materializes
-them into optimized relational storage and serves structured cross-module queries
-without runtime fan-out.
+modules publish generic schemas, records, mutations, links, and bounded replay
+sources; Index materializes them into PostgreSQL and serves structured cross-module
+queries without runtime fan-out.
 
 ## Purpose
 
-- publish canonical schema, mutation, query, source, and rebuild contracts;
-- keep ingestion, storage, planning, rebuild, and consistency semantics inside
-  the module;
-- provide server, storefront, admin, and `rustok-search` with a stable substrate
-  for cross-module filtering, projection, sorting, count, and pagination;
+- publish canonical schema, mutation, query, source, replay, and rebuild contracts;
+- keep ingestion, storage, planning, rebuild, checkpoint, and consistency semantics
+  inside the module;
+- provide server, storefront, admin, and `rustok-search` with a stable substrate for
+  cross-module filtering, projection, sorting, count, and pagination;
 - scale reads and rebuilds independently from source-module query paths.
 
 ## Responsibility Zone
 
 - versioned schema and link registry;
+- source-schema and replay-source ownership registries;
 - generic records and mutations;
 - explicit tenant/locale query scope;
 - registry-backed record and query validation;
 - deterministic link graph and field paths;
 - versioned keyset cursors;
 - incremental ingestion and inbox deduplication;
+- bounded source scans and targeted loads;
+- one-page replay mutation/checkpoint progression;
+- durable schema-scoped replay jobs, lease/heartbeat, and attempt fencing;
 - PostgreSQL storage and distributed coordination;
 - schema application and secondary-index lifecycle;
 - measured partition admission and shadow planning;
 - retained partition evidence preparation, snapshot/query/mutation/maintenance
-  capture, assembly, and validation;
-- SQL planning/compilation;
+  capture, assembly, review, archive verification, and validation;
+- SQL planning, compilation, execution, and result decoding;
 - rebuild, checkpointing, reconciliation, and drift repair;
 - operator health, lag, failure, and rebuild controls.
 
@@ -38,27 +42,32 @@ without runtime fan-out.
 - typo tolerance, synonyms, autocomplete, and search UX;
 - external search-engine connectors;
 - source-module table reads from Index core;
+- source-owned writes to Index storage, job, or checkpoint tables;
 - source-specific Product, Content, or Flex logic in the engine;
+- a production scheduler or unbounded replay loop in the current M6 slice;
 - destructive partition cutover without retained PostgreSQL evidence.
 
 ## Integration
 
-- source modules publish generic schemas, records, mutations, and rebuild streams;
-- `IndexModule` contributes the canonical production migrations through the platform
-  migration composition;
-- server, storefront, admin, and `rustok-search` consume stable Index ports rather
-  than reading Index tables directly;
+- source modules publish generic schemas and bounded replay/load adapters through
+  `ModuleRuntimeExtensions`;
+- source events become generic `IndexMutation` values with stable event UUID delivery
+  identities;
+- `IndexModule` contributes canonical production migrations through platform migration
+  composition;
+- server, storefront, admin, and `rustok-search` consume stable Index ports rather than
+  reading Index tables directly;
 - benchmark DDL and evidence remain isolated under `ops/benches` and never become
   runtime migrations.
 
 ## Rewrite policy
 
-Backward compatibility with the rejected implementation is not a goal.
-Conflicting code is deleted instead of preserved through compatibility layers.
-M0 removed the complete source-specific implementation and its migrations,
-contracts, runtime scheduler, server wiring, and admin table reads.
+Backward compatibility with the rejected implementation is not a goal. Conflicting
+code is deleted instead of preserved through compatibility layers. M0 removed the
+complete source-specific implementation and its migrations, contracts, runtime
+scheduler, server wiring, and admin table reads.
 
-## Implemented core
+## M1 generic core
 
 M1 provides:
 
@@ -71,7 +80,6 @@ M1 provides:
 - typed root and linked field paths;
 - explicit tenant and locale query scope;
 - select/filter/order/operator/type validation and bounded query complexity;
-- rejection of ambiguous ordering through `many` links;
 - checksummed postcard/Base64 keyset cursors bound to query scope and schema
   fingerprint;
 - a test-only mutation/query reference engine and property invariants for later
@@ -79,147 +87,141 @@ M1 provides:
 
 ## M2 storage benchmark
 
-Benchmark code lives outside the production crate in
-`ops/benches/src/index_storage`. Candidate DDL is not a production migration or
-runtime storage contract.
+Benchmark code lives outside the production crate in `ops/benches/src/index_storage`.
+Candidate DDL is not a production migration or runtime storage contract.
 
 The read/query harness provides deterministic scale datasets, selected-layout read
 workloads, cardinality checks, result-digest parity, load/size measurement, and full
 JSON `EXPLAIN (ANALYZE, BUFFERS, WAL)` evidence. The transactional mutation harness
-provides update/delete workloads, affected entity/link parity, rollback isolation,
-and node-level WAL evidence. The persistent maintenance harness provides committed
-churn, exact cardinality guards, schema-size/table-stat snapshots, and ordinary
+provides update/delete workloads, affected entity/link parity, rollback isolation, and
+node-level WAL evidence. The persistent maintenance harness provides committed churn,
+exact cardinality guards, schema-size/table-stat snapshots, and ordinary
 `VACUUM (ANALYZE)` duration.
 
 Replacement same-commit evidence selected JSONB over typed EAV and hot projection.
 Rejected candidate implementations were deleted. The remaining JSONB path is a
-selected-layout regression harness, not production persistence. Partitioning was
-not part of M2 evidence, so the canonical relations remain unpartitioned by
-default.
+selected-layout regression harness, not production persistence. Partitioning was not
+part of M2 evidence, so canonical relations remain unpartitioned by default.
 
 ## M3 PostgreSQL storage engine
 
-The module-owned migration source creates seven generic tables without
-source-domain columns or benchmark schemas:
+The module-owned migration source creates seven generic tables without source-domain
+columns or benchmark schemas:
 
 - `index_schemas` stores exact versioned schema JSON and fingerprints;
-- `index_entities` stores the JSONB payload/tombstone envelope with complete
-  tenant, module, entity, schema-version, entity-ID, and locale identity;
-- `index_links` stores ordered independent links bound to the source entity's
-  exact full-range `DECIMAL(20,0)` source version;
-- `index_inbox` stores deduplication, mutation identity, processing leases, and
-  terminal outcomes;
+- `index_entities` stores the JSONB payload/tombstone envelope with complete tenant,
+  module, entity, schema-version, entity-ID, and locale identity;
+- `index_links` stores ordered independent links bound to the source entity's exact
+  full-range `DECIMAL(20,0)` source version;
+- `index_inbox` stores deduplication, mutation identity, processing leases, and terminal
+  outcomes;
 - `index_checkpoints` stores ingestion and rebuild cursors;
 - `index_jobs` stores bounded durable schema/index/rebuild/reconciliation work;
 - `index_consistency_findings` stores open/resolved drift findings.
 
-`PostgresMutationStore` validates each `MutationDelivery`, claims the composite
-inbox identity, serializes the complete entity key with a transaction-scoped
-advisory lock, applies monotonic entity/tombstone and ordered-link replacement,
-and completes the inbox in one transaction. Exact redelivery is idempotent,
-stale delivery is terminally ignored, payload reuse fails closed, and write
-failure rolls back the inbox claim.
+`PostgresMutationStore` validates each `MutationDelivery`, claims the composite inbox
+identity, serializes the complete entity key with a transaction-scoped advisory lock,
+applies monotonic entity/tombstone and ordered-link replacement, and completes the
+inbox in one transaction. Exact redelivery is idempotent, stale delivery is terminally
+ignored, payload reuse fails closed, and write failure rolls back the inbox claim.
 
 `PostgresSchemaLeaseStore` coordinates exact tenant/schema application through
-`schema_apply` jobs. It verifies persisted active schema/fingerprint state,
-returns `Busy` or terminal `AlreadyApplied`, reclaims expired work with incremented
-attempt fencing, and requires the exact current worker/attempt for heartbeat and
-completion.
+`schema_apply` jobs. It verifies persisted active schema/fingerprint state, returns
+`Busy` or terminal `AlreadyApplied`, reclaims expired work with incremented attempt
+fencing, and requires the exact current worker/attempt for heartbeat and completion.
 
 `SecondaryIndexPlan` derives deterministic indexes from the exact schema contract.
 Scalar filterable/sortable fields use typed partial B-tree expressions. Filterable
-`many` fields use field-local JSONB containment GIN. Expressions follow the
-production tagged `IndexValue` payload through each field's `value` member. Stable
-names bind tenant, schema identity/version/fingerprint, field type/cardinality,
-index kind, and payload contract.
-
-`PostgresSecondaryIndexManager` coordinates ensure, reindex, and retirement with
-`secondary_index` jobs, transaction advisory locking, expiry reclaim, heartbeat,
-and attempt fencing. PostgreSQL execution uses `CREATE INDEX CONCURRENTLY`,
-`REINDEX INDEX CONCURRENTLY`, and `DROP INDEX CONCURRENTLY`. Owner comments bind
-each index to its full definition hash, and completion checks `indisready` plus
-`indisvalid`. Retirement remains available after schema retirement. SQLite is
-contract-test-only.
+`many` fields use field-local JSONB containment GIN. `PostgresSecondaryIndexManager`
+coordinates ensure, reindex, and retirement through fenced `secondary_index` jobs and
+verifies PostgreSQL catalog readiness before completion.
 
 `evaluate_partition_admission` compares one unpartitioned baseline with one exact
-SHA-256 identified tenant-hash shadow packet under an explicit policy. It checks
-measured rows, bytes, tenants, tenant-predicate coverage, entity/link digests,
-catch-up, foreign keys, orphan links, query-plan regressions, p95 query/mutation
-regressions, WAL amplification, partition-size skew, and cutover-lock duration.
-Any failed gate returns `KeepUnpartitioned` with typed reasons.
+SHA-256 identified tenant-hash shadow packet under an explicit policy. It checks scale,
+tenant-predicate coverage, entity/link parity, catch-up, foreign keys, orphan links,
+query-plan regressions, p95 query/mutation regressions, WAL amplification,
+partition-size skew, and cutover-lock duration. An admitted plan emits shadow-only DDL
+and cannot rename, drop, or alter production relations.
 
-An admitted `PartitionShadowPlan` derives stable names and bootstrap SQL only for
-shadow hash-partition parents and children. Hash modulus must be a power of two
-from 2 through 128. The plan cannot rename, drop, or alter production entity/link
-relations. Production copy/checkpoint, constraint/index attachment, replay or
-dual-write, durable global operation ownership, cutover, and rollback remain open
-M3 work.
+Owner-operated tooling captures and validates the retained partition bundle. Snapshot,
+query, mutation/WAL, maintenance, and rollback-only cutover runners remain isolated
+from production lifecycle code. Assembly and review bind exact bytes, canonical paths,
+file identity, metadata fingerprints, and recursive directory inventory. Every archive
+verification receipt keeps `production_lifecycle_authorized: false`.
 
-Partition evidence tooling binds one immutable manifest to a SHA-256 `evidence_id`,
-emits deterministic shadow-only bootstrap SQL, and validates exact
-query/mutation/maintenance/cutover repetition groups. The capture/assembly layer
-reads six retained raw JSON artifacts once, confines unique relative paths to one
-bundle, rejects symbolic links and aliases, calculates exact-byte SHA-256 hashes,
-and publishes a structurally validated packet without accepting precomputed packet
-fields or pass flags.
+Real PostgreSQL packet execution and admission remain owner-operated and open.
 
-The owner-operated partition snapshot runner captures `baseline.json` and
-`shadow.json` from one PostgreSQL repeatable-read snapshot. It requires an explicit
-shadow-copy opt-in, PostgreSQL 16 with JIT disabled, ordinary unpartitioned
-canonical relations, deterministic evidence-ID-bound names, and a reviewed tenant
-query audit. It creates and fills only shadow parents/children, attaches a
-shadow-only source-version uniqueness/FK contract, calculates logical SHA-256
-parity, physical child sizes, orphan state, and post-copy catch-up, and publishes
-the pair without overwriting retained evidence.
+## M4 query engine
 
-The owner-operated query evidence runner validates the same manifest and shadow
-catalog, enables partition pruning, and executes exactly the manifest query run
-count inside one read-only repeatable-read transaction. It requires result digest
-parity, retains full baseline/shadow JSON EXPLAIN samples, alternates measurement
-order, calculates p95, normalizes logical plan identity with
-`normalized_partition_plan_v1`, and fails unless every shadow query reads exactly
-one child per used logical relation. It publishes `query.json` without overwrite.
+M4 provides:
 
-The owner-operated mutation/WAL evidence runner revalidates the manifest and
-shadow catalog, requires canonical/shadow count parity and byte-for-byte matching
-generic anchors, and builds exactly the manifest mutation run count. Every
-validation and EXPLAIN write runs under a savepoint in one rollback-only
-repeatable-read transaction; the savepoint and outer transaction are both rolled
-back. It requires one affected row on both sides, alternates measurement order,
-calculates p95, retains full JSON EXPLAIN samples, records conservative maximum
-per-sample plan-node WAL bytes, proves single-child shadow pruning, and publishes
-`mutation.json` without overwrite. The mutation slice recorded that maintenance and cutover evidence remain open.
+- deterministic validated executable plans and stable relation aliases;
+- controlled PostgreSQL SQL with ordered typed binds;
+- root and one-link projection, filtering, ordering, exact count, keyset, and bounded
+  offset pagination;
+- correlated many-link `EXISTS` filtering without duplicate root rows;
+- deterministic nested many-link JSONB projection aggregates;
+- explicit bounded many-link `MIN` / `MAX` ordering for integer, Decimal, string, and
+  timestamp terminals;
+- exact Decimal tagged string transport without float conversion;
+- strict compiler-metadata-driven row decoding, one-row lookahead, exact-count decoding,
+  and scoped next-cursor construction;
+- `PostgresIndexQueryPort`, which verifies every persisted tenant schema and executes
+  page/count inside one read-only repeatable-read transaction;
+- source-owned schema publication and one shared immutable query runtime.
 
-The owner-operated maintenance evidence runner revalidates the manifest, canonical
-relations, and retained snapshot shadow, then creates one deterministic evidence-only
-schema. It builds isomorphic ordinary and tenant-hash-partitioned clone pairs without
-production constraints or indexes, disables autovacuum on every physical clone, and
-copies logically identical source rows. It commits identical generic entity update
-and link delete/reinsert churn only into those clones. For exactly the manifest
-maintenance run count, it captures pre-cleanup `pg_stat_user_tables` dead tuples,
-alternates side order, times ordinary `VACUUM (ANALYZE)` over every physical table,
-requires zero estimated dead tuples and equal logical digests after cleanup, and
-publishes `maintenance.json` without overwrite. Canonical and retained snapshot
-relations are checked unchanged before and after. Real execution is still an owner
-step, and cutover evidence remains open.
+Authentication and transport policy remain caller responsibilities. Retained live
+PostgreSQL/reference equivalence, authoritative consumers, aggregate cursor
+continuation, and production partition cutover remain open.
 
-The repository owner still executes and
-retains the PostgreSQL packet. The real query, mutation,
-maintenance, and cutover measurements remain open. Real mutation, maintenance, and cutover evidence remain
-owner-operated until the matching raw artifacts are retained and validated.
+## M5/M6 source replay and rebuild ownership
 
-Final validation calculates tenant coverage, digest parity, latency regression,
-WAL amplification, partition skew, lock duration, rollback state, and typed
-rejection reasons. The repository owner still executes and retains the complete
-PostgreSQL packet.
+`IndexSourceCatalog` fixes one bounded replay source for every exact schema and the
+complete schema identity across versions. Materialization requires the corresponding
+owner-published schema and exact owner match. `IndexSource::scan` and `load` keep the
+application boundary database independent while bounding cursor bytes, page/key counts,
+tenant/schema scope, returned identities, and continuation progress.
 
-PostgreSQL Testcontainers/concurrency evidence, production query execution, and
-batch ingestion remain later M3/M4/M5 slices.
+`IndexReplayWorker::run_next_page` executes exactly one page. It validates every
+non-nil unique event UUID before the first mutation write, applies mutations sequentially
+through `PostgresMutationStore`, and commits the next cursor only after all mutation
+results are durable. Stable event UUIDs make retry after checkpoint failure idempotent
+through `index_inbox`. Source-version watermarks cannot regress, and JSON null is the
+completed cursor.
+
+`PostgresIndexReplayJobStore` owns one exact tenant/source/schema `rebuild` job using the
+`index_replay_job_v1` request contract. It:
+
+- requires an active persisted schema;
+- serializes acquisition with a PostgreSQL advisory lock;
+- returns `Busy` for an active owner;
+- heartbeats only the exact unexpired worker/attempt;
+- reclaims an expired running attempt with incremented `attempt_count`;
+- rejects stale heartbeat, failure, and success;
+- requires an exact durable null-cursor checkpoint before terminal success.
+
+`PostgresIndexReplayCheckpointStore` is constructed from an acquired
+`IndexReplayJobLease`. Every checkpoint read/write first locks and validates the exact
+`(job_id, worker_id, attempt_count)`. Another tenant/source/schema is rejected before
+the database transaction. After reclaim, the old worker cannot advance the durable
+cursor.
+
+Still open:
+
+- direct server-composition binding between job requests and the materialized replay
+  source registry;
+- bounded multi-page execution with heartbeat cadence and graceful lease loss;
+- cancellation, resume commands, dry-run, targeted/full/shadow modes;
+- retry/backoff/dead-letter scheduling and global scheduler ownership;
+- locale/partition replay dimensions;
+- Product and later source adapters;
+- retained crash/reclaim/restart and multi-instance PostgreSQL evidence;
+- reconciliation and drift repair.
 
 ## Status
 
 - Rewrite: `in_progress`
-- Current milestone: `M3 - PostgreSQL storage engine`
+- Current milestone: `M6 - fenced replay job ownership`
 - FFA: `in_progress`
 - FBA: `in_progress`
 - M0 code reset: `complete`
@@ -231,46 +233,33 @@ batch ingestion remain later M3/M4/M5 slices.
 - M3 atomic mutation persistence: `complete`
 - M3 schema-application leases: `complete`
 - M3 secondary-index lifecycle: `complete`
-- M3 partition admission and shadow planning: `complete`
-- M3 partition evidence packet tooling: `complete`
-- M3 partition evidence capture/assembly: `complete`
-- M3 partition baseline/shadow snapshot runner: `complete`
-- M3 partition query evidence runner: `complete`
-- M3 partition mutation/WAL evidence runner: `complete`
-- M3 partition maintenance evidence runner: `complete`
-- Production persistence: mutation writes, schema/index coordination, partition
-  admission, snapshot/query/mutation/maintenance capture, evidence assembly, and
-  evidence validation implemented; query adapter, real retained packet execution,
-  cutover evidence remains open, and production partition lifecycle is not yet
-  implemented
+- M3 partition admission and evidence tooling: `complete`
+- M3 retained packet execution: `open`
+- M4 query engine and PostgreSQL adapter: `source_complete`
+- M4 retained live PostgreSQL/reference equivalence: `open`
+- M5/M6 bounded source replay contract: `source_complete`
+- M6 one-page replay/checkpoint progression: `source_complete`
+- M6 job leases and checkpoint attempt fencing: `source_complete_owner_execution_pending`
+- M6 multi-page runner/cancellation/retry scheduling: `open`
+- Production consumer and partition lifecycle cutover: `forbidden_pending_evidence`
 
 ## Verification
 
-The repository owner runs the checks and database evidence during this rewrite:
+The repository owner runs checks and database evidence during this rewrite:
 
 - `cargo fmt --all -- --check`
 - `cargo check --workspace --all-targets --all-features`
 - `cargo clippy --workspace --all-targets --all-features -- -D warnings`
 - `cargo xtask module validate index`
 - `cargo xtask module test index`
-- `cargo check -p rustok-benchmarks --bin index-partition-snapshot-capture`
-- `cargo test -p rustok-benchmarks partition_snapshot`
-- `cargo check -p rustok-benchmarks --bin index-partition-query-evidence`
-- `cargo test -p rustok-benchmarks partition_query`
-- `cargo check -p rustok-benchmarks --bin index-partition-mutation-evidence`
-- `cargo test -p rustok-benchmarks partition_mutation`
-- `cargo check -p rustok-benchmarks --bin index-partition-maintenance-evidence`
-- `cargo test -p rustok-benchmarks partition_maintenance`
+- `cargo test -p rustok-index source_registry --lib -- --nocapture`
+- `cargo test -p rustok-index source_replay --lib -- --nocapture`
+- `cargo test -p rustok-index source_replay_job --lib -- --nocapture`
+- `node scripts/verify/verify-index-query-contract.mjs`
+- `node scripts/verify/verify-index-source-replay-contract.mjs`
+- `node scripts/verify/verify-index-replay-job-leases.mjs`
 - `node scripts/verify/index-storage-tooling.mjs contract`
 - `node scripts/verify/index-storage-tooling.mjs fixtures`
-- `node --test scripts/verify/index-partition-evidence-assembly.test.mjs`
-- `node scripts/verify/verify-index-secondary-index-lifecycle.mjs`
-- `node scripts/verify/verify-index-partition-admission.mjs`
-- `node scripts/verify/verify-index-partition-evidence.mjs`
-- `node scripts/verify/verify-index-partition-snapshot-capture.mjs`
-- `node scripts/verify/verify-index-partition-query-evidence.mjs`
-- `node scripts/verify/verify-index-partition-mutation-evidence.mjs`
-- `node scripts/verify/verify-index-partition-maintenance-evidence.mjs`
 - `npm run verify:index:fba`
 - `npm run verify:index:runtime-fallback-smoke`
 
@@ -278,6 +267,12 @@ The repository owner runs the checks and database evidence during this rewrite:
 
 - [Crate README](../README.md)
 - [Live implementation plan](./implementation-plan.md)
+- [M5/M6 bounded source replay contract](./m5-m6-source-replay-contract.md)
+- [M6 replay job lease and fencing boundary](./m6-replay-job-leases.md)
+- [M4 source-owned schema registry](./m4-source-schema-registry.md)
+- [M4 query runtime composition](./m4-query-runtime-composition.md)
+- [M4 PostgreSQL query port](./m4-postgres-query-port.md)
+- [M4 many-link aggregate ordering](./m4-many-link-aggregate-ordering.md)
 - [M2 storage benchmark contract](./storage-benchmark.md)
 - [M2 storage evidence comparison](./storage-comparison.md)
 - [M2 storage operational review](./storage-operational-review.md)

--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -26,7 +26,7 @@ pull requests record checks and PostgreSQL runs that were not executed.
 ## Current state
 
 - Rewrite status: `in_progress`
-- Current milestone: `M5/M6 - bounded replay page progression (source complete; fenced jobs, multi-page ownership, and retained evidence open)`
+- Current milestone: `M6 - fenced replay job ownership (source complete; multi-page execution, cancellation, and retained evidence open)`
 - FFA status: `in_progress`
 - FBA status: `in_progress`
 - M0 code reset: `complete`
@@ -64,7 +64,8 @@ pull requests record checks and PostgreSQL runs that were not executed.
 - M4 first Social Graph privacy parity shadow: `source_complete_metrics_evidence_tooling_execution_pending`
 - M5 inbox deduplication and monotonic source-version persistence: `complete`
 - M5/M6 bounded source replay contract: `source_complete_worker_pending`
-- M6 one-page replay and durable checkpoint progression: `source_complete_fenced_job_worker_pending`
+- M6 one-page replay and durable checkpoint progression: `source_complete`
+- M6 replay job leases and checkpoint attempt fencing: `source_complete_owner_execution_pending`
 - Production persistence: mutation writes, schema/index coordination, fail-closed
   partition admission, snapshot/query/mutation/maintenance/cutover evidence tooling,
   full-capture orchestration, exact-byte packet assembly, retained bundle review,
@@ -76,11 +77,12 @@ pull requests record checks and PostgreSQL runs that were not executed.
   lookahead, tagged row decoding, exact-count decoding, scoped next-cursor construction,
   persisted-schema query preflight, PostgreSQL page/count execution, compiler-driven
   row adaptation, source-owned schema publication, shared query-runtime composition,
-  bounded source replay/load contracts, one-page replay mutation application, and
-  durable rebuild checkpoint progression are implemented; one retained admitted
-  packet, live PostgreSQL/reference equivalence, fenced multi-page ingestion/rebuild
-  workers, freshness/recovery evidence, authoritative consumer cutover, and production
-  partition lifecycle remain open
+  bounded source replay/load contracts, one-page replay mutation application, durable
+  rebuild checkpoint progression, schema-scoped rebuild job claims, lease/heartbeat,
+  attempt fencing, and fenced checkpoint writes are implemented; one retained admitted
+  packet, live PostgreSQL/reference equivalence, bounded multi-page ingestion/rebuild
+  runners, cancellation, freshness/recovery evidence, authoritative consumer cutover,
+  and production partition lifecycle remain open
 
 The production crate contains the generic domain/application core, seven canonical
 M3 tables, an atomic mutation adapter, durable schema leases, secondary-index
@@ -93,9 +95,10 @@ many-link MIN/MAX aggregate ordering, a strict compiled-row decoder with aligned
 nested identities/values, lookahead pagination, and scoped cursor construction,
 `PostgresIndexQueryPort` for exact-schema-preflighted execution in one read-only
 repeatable-read page/count snapshot, source-owned schema and replay catalogs, a
-neutral bounded `IndexSource` scan/load boundary, and a one-page replay executor with
-a PostgreSQL rebuild-checkpoint adapter. Owner-operated evidence tools live under
-`ops/benches`; they do not become runtime storage code.
+neutral bounded `IndexSource` scan/load boundary, a one-page replay executor,
+`PostgresIndexReplayJobStore` for durable fenced schema-scoped rebuild ownership, and
+a lease-bound PostgreSQL rebuild-checkpoint adapter. Owner-operated evidence tools
+live under `ops/benches`; they do not become runtime storage code.
 
 ## Ownership
 
@@ -137,6 +140,7 @@ crates/rustok-index/src/
   infrastructure/postgres/
     mutation_store.rs
     source_replay.rs
+    source_replay_job.rs
     schema_lease.rs
     secondary_index.rs
     partition_admission.rs
@@ -430,19 +434,29 @@ database, or transport causes stay in owner logs.
       commits checkpoints only after durable mutation results.
 - [x] Reject nil/duplicate replay event UUIDs and require stable event identity across
       retries for the same logical mutation and source version.
-- [ ] Add durable jobs, leases, heartbeat, attempt fencing, and global ownership.
+- [x] Add durable schema-scoped rebuild jobs, lease/heartbeat, reclaim, attempt fencing,
+      exact request validation, and terminal-state fencing.
+- [x] Bind checkpoint reads and writes to the active `(job_id, worker_id, attempt_count)`
+      and require a durable null-cursor checkpoint before terminal success.
+- [ ] Bind job requests directly to the materialized source registry in server composition.
 - [ ] Add cancellation, bounded multi-page resume, dry-run, targeted/full/shadow rebuild.
+- [ ] Add bounded retry/backoff, dead-letter state, and global scheduling ownership.
 - [ ] Add locale/partition replay checkpoint dimensions.
 - [ ] Add reconciliation and drift repair.
 - [ ] Cover crash, lease expiry, restart, cancellation, and incremental/full
-      equivalence.
+      equivalence with retained PostgreSQL evidence.
 
-The one-page executor and PostgreSQL checkpoint adapter are source complete. They
-reserve empty locale/partition dimensions, apply one page sequentially, and write the
-next cursor only after every mutation result is durable. A checkpoint failure safely
-replays the previous cursor through stable event delivery IDs and the existing inbox
-deduplication contract. No fenced job runner, scheduler, lease owner, long-running
-production command, retry/dead-letter loop, or concurrent checkpoint writer is claimed.
+The one-page executor, replay job store, and PostgreSQL checkpoint adapter are source
+complete. `PostgresIndexReplayJobStore` serializes one tenant/source/schema claim,
+validates the exact `index_replay_job_v1` request and active persisted schema, reclaims
+expired attempts with an incremented fence, and rejects stale heartbeat or terminal
+updates. `PostgresIndexReplayCheckpointStore` is constructed from the acquired lease;
+it locks and validates that exact attempt before every checkpoint read or write. A
+stale worker may finish an already-started idempotent mutation transaction, but it
+cannot advance the durable cursor. Terminal success requires the same active lease and
+an exact durable rebuild checkpoint with a JSON null cursor. No scheduler, multi-page
+loop, cancellation command, retry/dead-letter policy, production source adapter, or
+retained multi-instance PostgreSQL evidence is claimed.
 
 ### M7 - First vertical slice
 
@@ -497,6 +511,7 @@ cargo test -p rustok-index postgres_compiler_tests -- --nocapture
 cargo test -p rustok-index postgres_query_result_tests -- --nocapture
 cargo test -p rustok-index source_registry --lib -- --nocapture
 cargo test -p rustok-index source_replay --lib -- --nocapture
+cargo test -p rustok-index source_replay_job --lib -- --nocapture
 cargo xtask module validate index
 cargo xtask module test index
 npm run verify:index:fba
@@ -539,6 +554,7 @@ node scripts/verify/verify-index-postgres-query-compiler.mjs
 node scripts/verify/verify-index-query-result-decoder.mjs
 node scripts/verify/verify-index-many-link-filtering.mjs
 node scripts/verify/verify-index-source-replay-contract.mjs
+node scripts/verify/verify-index-replay-job-leases.mjs
 ```
 
 ## Progress log
@@ -578,21 +594,26 @@ node scripts/verify/verify-index-source-replay-contract.mjs
 - 2026-07-30: added the one-page replay executor, stable replay event checks,
   `PostgresMutationStore` sink composition, durable rebuild-checkpoint read/write
   adapter, post-mutation checkpoint ordering, completion no-op, and replay-after-
-  checkpoint-failure contracts. Fenced jobs and multi-page ownership remain open.
-- Repository test/fixture suites, verifiers, the fenced multi-page replay job worker,
-  live freshness/recovery evidence, one admitted PostgreSQL/reference equivalence
-  bundle, and one real full PostgreSQL partition packet remain for the owner to execute
-  and admit before authoritative consumer or production partition cutover.
+  checkpoint-failure contracts.
+- 2026-07-30: added schema-scoped durable rebuild job claims, advisory-lock exclusion,
+  lease/heartbeat, expired-attempt reclaim, attempt fencing, exact request validation,
+  lease-bound checkpoint reads/writes, stale-writer rejection, and null-cursor-gated
+  terminal success. Multi-page execution and cancellation remain open.
+- Repository test/fixture suites, verifiers, the bounded multi-page replay runner,
+  cancellation, live freshness/recovery evidence, one admitted PostgreSQL/reference
+  equivalence bundle, and one real full PostgreSQL partition packet remain for the
+  owner to execute and admit before authoritative consumer or production partition
+  cutover.
 
 ## Periodic release verification handoff
 
 - Cycle: `cycle-001`
 - Status: `blocked`
 - Last verified at (UTC): `2026-07-30`
-- Scope inspected: `Index ownership, migrations, mutation/version ordering, query execution, partition evidence guards, Social Graph consumer authority, privacy shadow deadline behavior, source replay ownership, replay checkpoint ordering, and source/search/server boundaries`
+- Scope inspected: `Index ownership, migrations, mutation/version ordering, query execution, partition evidence guards, Social Graph consumer authority, privacy shadow deadline behavior, source replay ownership, replay checkpoint ordering, replay job attempt fencing, and source/search/server boundaries`
 - Findings: `P0=0, P1=2, P2=0, P3=1`
-- Fixed in this pass: `bounded the non-authoritative Social Graph privacy comparison by the remaining caller deadline while preserving the owner result; repaired stale Index scale/FBA and retained-artifact guards; added a canonical bounded source replay/load registry; added one-page replay mutation application with stable event checks and checkpoint progression only after durable mutation outcomes`
-- Remaining risks or blockers: `one retained admitted real PostgreSQL partition packet is absent; live PostgreSQL/reference query equivalence remains open; no fenced index_jobs owner, lease/heartbeat, multi-page loop, cancellation, or concurrent checkpoint fencing exists; no retained per-tenant freshness/watermark, lag, negative-result safety, outage/restart/backlog catch-up, or replay-repair evidence exists; consumer and production partition cutover remain forbidden`
-- Evidence: `PR #2544 merged as b647a5a17f27b34a07c20cd57525ed1806994c49; same-SHA Index Storage Scale Run Contract and full Scale Evidence contract passed JavaScript syntax, workflow contracts, repository contracts, direct validator arguments and fixture suites; source replay registry and one-page checkpoint progression are added in the current draft PR without implementation-agent test execution; general CI/Hardening received no jobs; Rust-hosted smoke previously stopped before compilation because Cargo.lock required an Athanor update under --locked`
-- Next action: `implement fenced durable rebuild job claims, lease/heartbeat and bounded multi-page resume, then add the first Product source adapter and execute retained PostgreSQL packet, live query equivalence, and per-tenant freshness/outage/recovery evidence before reconsidering authoritative consumers or partition lifecycle`
+- Fixed in this pass: `bounded the non-authoritative Social Graph privacy comparison by the remaining caller deadline while preserving the owner result; repaired stale Index scale/FBA and retained-artifact guards; added a canonical bounded source replay/load registry; added one-page replay mutation application with stable event checks and checkpoint progression only after durable mutation outcomes; added schema-scoped rebuild job claims with lease/heartbeat, expired-attempt reclaim, attempt fencing, fenced checkpoint access, and durable null-cursor-gated success`
+- Remaining risks or blockers: `one retained admitted real PostgreSQL partition packet is absent; live PostgreSQL/reference query equivalence remains open; no bounded multi-page loop, cancellation, retry/backoff, dead-letter policy, locale/partition checkpoint dimensions, or production source adapter exists; no retained per-tenant freshness/watermark, lag, negative-result safety, outage/restart/backlog catch-up, or replay-repair evidence exists; consumer and production partition cutover remain forbidden`
+- Evidence: `PR #2544 merged as b647a5a17f27b34a07c20cd57525ed1806994c49; same-SHA Index Storage Scale Run Contract and full Scale Evidence contract passed JavaScript syntax, workflow contracts, repository contracts, direct validator arguments and fixture suites; source replay registry, one-page checkpoint progression, and replay job fencing are added in the current draft PR without implementation-agent test execution; general CI/Hardening received no jobs; Rust-hosted smoke previously stopped before compilation because Cargo.lock required an Athanor update under --locked`
+- Next action: `bind replay job acquisition to the materialized source registry and implement a bounded multi-page runner with heartbeat cadence and graceful lease loss, then add the first Product source adapter and execute retained PostgreSQL packet, live query equivalence, and per-tenant freshness/outage/recovery evidence before reconsidering authoritative consumers or partition lifecycle`
 - Resume command: `cargo fmt --all -- --check && cargo check -p rustok-index --all-targets && node scripts/verify/verify-index-query-contract.mjs && node scripts/verify/index-storage-tooling.mjs contract && node scripts/verify/index-storage-tooling.mjs fixtures`

--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -16,12 +16,12 @@ autocomplete, search UX, and external search-engine connectors remain owned by
 The project is in early development. Backward compatibility with the rejected
 implementation is not a goal. Prefer clean replacement over compatibility layers.
 Index core must not import source-domain semantics or query source-module tables.
-Benchmark/evidence code remains outside production migrations and runtime composition.
-Partition cutover remains forbidden until one retained real PostgreSQL packet satisfies
-the explicit admission policy.
+Benchmark/evidence code remains outside production migrations and runtime
+composition. Partition cutover remains forbidden until one retained real
+PostgreSQL packet satisfies the explicit admission policy.
 
-The repository owner performs test, benchmark, and evidence execution. Commits and pull
-requests record checks and PostgreSQL runs that were not executed.
+The repository owner performs test, benchmark, and evidence execution. Commits and
+pull requests record checks and PostgreSQL runs that were not executed.
 
 ## Current state
 
@@ -64,26 +64,48 @@ requests record checks and PostgreSQL runs that were not executed.
 - M4 first Social Graph privacy parity shadow: `source_complete_metrics_evidence_tooling_execution_pending`
 - M5 inbox deduplication and monotonic source-version persistence: `complete`
 - M5/M6 bounded source replay contract: `source_complete_worker_pending`
+- Production persistence: mutation writes, schema/index coordination, fail-closed
+  partition admission, snapshot/query/mutation/maintenance/cutover evidence tooling,
+  full-capture orchestration, exact-byte packet assembly, retained bundle review,
+  admitted archive manifest generation, saved-manifest verification, recursive
+  filesystem integrity checks, typed executable query planning, controlled projection,
+  root/one-link filtering, ordering, exact-count, keyset, bounded-offset SQL
+  compilation, correlated many-link filtering, deterministic nested many-link
+  projection aggregation, explicit bounded many-link MIN/MAX ordering, one-row page
+  lookahead, tagged row decoding, exact-count decoding, scoped next-cursor construction,
+  persisted-schema query preflight, PostgreSQL page/count execution, compiler-driven
+  row adaptation, source-owned schema publication, shared query-runtime composition,
+  and bounded source replay/load contracts are implemented; one retained admitted
+  packet, live PostgreSQL/reference equivalence, durable ingestion/rebuild workers,
+  freshness/recovery evidence, authoritative consumer cutover, and production
+  partition lifecycle remain open
 
-Production persistence, typed planning/compilation/decoding, explicit many-link MIN/MAX
-aggregate ordering with the exact Decimal string wire, source-owned schema publication,
-shared query-runtime composition, and the default-off Social Graph privacy parity shadow
-are source complete. The new neutral replay boundary provides one schema-owned source,
-bounded scan/load requests, opaque bounded cursors, result-scope validation, and retryable
-versus permanent failure classification. One retained admitted partition packet, live
-PostgreSQL/reference equivalence, durable ingestion/rebuild workers, freshness and recovery
-evidence, authoritative consumer cutover, and production partition lifecycle remain open.
+The production crate contains the generic domain/application core, seven canonical
+M3 tables, an atomic mutation adapter, durable schema leases, secondary-index
+lifecycle management, measured partition admission that emits shadow bootstrap
+plans only, an M4 typed structural query planner with deterministic relation aliases,
+a controlled PostgreSQL compiler for root/one-link projection, filtering, ordering,
+exact count, keyset and bounded offset plus duplicate-free correlated many-link
+filtering, deterministic nested many-link projection aggregates, and explicit
+many-link MIN/MAX aggregate ordering, a strict compiled-row decoder with aligned
+nested identities/values, lookahead pagination, and scoped cursor construction,
+`PostgresIndexQueryPort` for exact-schema-preflighted execution in one read-only
+repeatable-read page/count snapshot, source-owned schema and replay catalogs, and a
+neutral bounded `IndexSource` scan/load boundary. Owner-operated evidence tools live
+under `ops/benches`; they do not become runtime storage code.
 
-## Ownership and architecture
+## Ownership
 
 Index owns schema/link/source registration, generic records and mutations, ingestion,
-inbox deduplication, PostgreSQL storage, query validation/planning/compilation, filtering,
-projection, sorting, counting, pagination, rebuild, checkpointing, reconciliation, drift
-repair, distributed coordination, and operator diagnostics.
+inbox deduplication, PostgreSQL storage, query validation/planning/compilation,
+filtering, projection, sorting, counting, pagination, rebuild, checkpointing,
+reconciliation, drift repair, distributed coordination, and operator diagnostics.
 
-Source modules own normalized domain data, schema declarations, conversion to generic Index
-records/mutations, bounded `IndexSource::scan` and targeted `load` adapters, and source
-ordering/version information.
+Source modules own normalized domain data, schema declarations, conversion to
+generic Index records/mutations, bounded `IndexSource::scan` and targeted `load`
+adapters, and source ordering and version information.
+
+## Target architecture
 
 ```text
 source modules
@@ -96,16 +118,51 @@ source modules
     -> server, storefront, admin, and rustok-search
 ```
 
-Use workspace `sea-orm`/SeaQuery for PostgreSQL, `tokio`/`futures-util` for bounded async
-work, `serde`/`postcard` for contracts, `thiserror` for typed failures,
-`tracing`/telemetry/prometheus for observability, `petgraph` for deterministic graph
-resolution, ICU4X for locale canonicalization, and `sha2` for schema, cursor, plan, and
-retained-evidence identities.
+```text
+crates/rustok-index/src/
+  domain/
+  application/
+    planner.rs
+    postgres_compiler.rs
+    postgres_query_sql.rs
+    postgres_query_result.rs
+    query_port.rs
+    source_schema_registry.rs
+    source_registry.rs
+  migrations/
+  infrastructure/postgres/
+    mutation_store.rs
+    schema_lease.rs
+    secondary_index.rs
+    partition_admission.rs
+    query_port.rs
+  api/
 
-Forbidden in Index core: source-domain dependencies, ranking/search libraries, a second
-database stack, unvalidated JSON-only public queries, unbounded rebuild ID collection,
-direct source-table reads, source-owned writes to Index tables, and destructive partition
-cutover without retained evidence and rollback proof.
+ops/benches/src/index_storage/
+  runner.rs
+  mutation_runner.rs
+  maintenance_runner.rs
+  partition_snapshot.rs
+  partition_query.rs
+  partition_mutation.rs
+  partition_maintenance.rs
+  partition_cutover.rs
+  partition_capture.rs
+```
+
+## Library decisions
+
+Use workspace `sea-orm`/SeaQuery for PostgreSQL, `tokio`/`futures-util` for bounded
+async work, `serde`/`postcard` for contracts, `thiserror` for typed failures,
+`tracing`/telemetry/prometheus for observability, `petgraph` for deterministic graph
+resolution, ICU4X for locale canonicalization, and `sha2` for schema, cursor, plan,
+and retained-evidence identities. Add Testcontainers, retry, cancellation, or
+snapshot libraries only when their slices require them.
+
+Forbidden in Index core: source-domain dependencies, ranking/search libraries, a
+second database stack, unvalidated JSON-only public queries, unbounded rebuild ID
+collection, direct source-table reads, source-owned writes to Index tables, and
+destructive partition cutover without retained evidence and rollback proof.
 
 ## Milestones
 
@@ -123,27 +180,34 @@ cutover without retained evidence and rollback proof.
 - [x] Add `IndexValue`, `IndexRecord`, `IndexMutation`, `IndexSchema`, and links.
 - [x] Add stable order-independent SHA-256 schema fingerprints.
 - [x] Add atomic registration and deterministic link-path resolution.
-- [x] Validate records, mutations, queries, types, operators, cardinality, tenant/locale
-      scope, and complexity.
+- [x] Validate records, mutations, queries, types, operators, cardinality, tenant/
+      locale scope, and complexity.
 - [x] Add checksummed query-scoped keyset cursors.
 - [x] Add a test-only reference engine and property invariants.
 
 ### M2 - PostgreSQL storage benchmark
 
-- [x] Define the benchmark contract and keep candidate DDL outside production migrations.
+- [x] Define the benchmark contract and keep candidate DDL outside production
+      migrations.
 - [x] Add deterministic `smoke`, `100k`, and `1m` dataset presets.
 - [x] Prototype JSONB entity rows plus typed expression/GIN indexes.
-- [x] Compare JSONB, typed EAV, and specialized hot projection using equal result digests,
-      cardinality, planner/session metadata, WAL, buffers, relation size, churn, and
-      VACUUM evidence.
-- [x] Run and archive replacement 100k Product-locale row evidence.
-- [x] Run and archive replacement 1m Product-locale row evidence.
+- [x] Compare JSONB, typed EAV, and specialized hot projection using equal result
+      digests, cardinality, planner/session metadata, WAL, buffers, relation size,
+      churn, and VACUUM evidence.
+- [x] Run and archive replacement 100k Product-locale row read, mutation, and
+      maintenance evidence from the accepted same-commit packet.
+- [x] Run and archive replacement 1m Product-locale row read, mutation, and
+      maintenance evidence from the same accepted commit.
+- [x] Compare warm/cold buffers, planner stability, execution latency, ingestion
+      throughput, relation size, WAL, dead tuples, vacuum behavior, and operational
+      complexity.
 - [x] Record the selected model and rejected alternatives in an ADR.
 - [x] Delete benchmark prototypes that are not selected.
 
-M2 is complete. The JSONB harness is selected-layout regression evidence, not production
-persistence. Canonical production tables remain unpartitioned until separate shadow
-evidence is retained and admitted.
+M2 is complete. The remaining JSONB benchmark path is a selected-layout regression
+harness; it is not production persistence and does not reopen the accepted storage
+decision. Partitioning was not measured by M2, so canonical production tables remain
+unpartitioned until separate shadow evidence is retained and admitted.
 
 ### M3 - PostgreSQL storage engine
 
@@ -172,29 +236,33 @@ evidence is retained and admitted.
 - [ ] Add partition copy/checkpoints, constraints/index attachment, replay/dual-write,
       cutover, rollback, and durable global operation ownership.
 - [ ] Add PostgreSQL Testcontainers fixtures.
-- [ ] Cover migration-from-zero, stale mutation, redelivery, rollback, concurrency, and
-      tenant/locale isolation in PostgreSQL.
+- [ ] Cover migration-from-zero, stale mutation, redelivery, rollback, concurrency,
+      and tenant/locale isolation in PostgreSQL.
 
 #### Retained repository contract wording
+
+The following wording remains explicit because repository guards bind the completed
+slices and still-open owner evidence to these exact architectural boundaries:
 
 - [x] Add locking/leases for schema application.
 - [x] Add secondary-index planning and lifecycle management.
 - [x] Add tenant/schema/entity/locale keys and source-version guards.
 - [x] Add immutable partition evidence manifest, measured packet validator, and
       owner-operated runbook.
-- [x] Add exact-byte raw-artifact capture assembly with bundle confinement and no-clobber
-      packet publication.
-- [x] Add read-only retained bundle review, admitted archive manifest, and saved-manifest
-      verification receipt.
+- [x] Add exact-byte raw-artifact capture assembly with bundle confinement and
+      no-clobber packet publication.
+- [x] Add read-only retained bundle review, admitted archive manifest, and
+      saved-manifest verification receipt.
 - [x] Bind retained verification to an exact recursive filesystem snapshot and refuse
       post-inspection drift.
 - [ ] Execute retained PostgreSQL partition baseline/shadow evidence.
 - [ ] Execute retained PostgreSQL query, mutation, maintenance, and cutover evidence.
 - [ ] Execute retained PostgreSQL mutation, maintenance, and cutover evidence.
 
-Partition admission remains fail-closed across tenant-predicate coverage, query/mutation
-latency and plan stability, WAL amplification, skew, and cutover lock evidence. Admitted
-plans emit shadow-only DDL. They never rename, drop, or alter production relations.
+Partition admission remains fail-closed across tenant-predicate coverage,
+query/mutation latency and plan stability, WAL amplification, skew, and cutover lock
+evidence. Admitted plans emit shadow-only DDL. They never rename, drop, or alter production
+relations.
 
 #### Completed M3 slices
 
@@ -202,20 +270,54 @@ plans emit shadow-only DDL. They never rename, drop, or alter production relatio
    schema, entity, locale, and full-range non-negative source-version identity.
 2. `PostgresMutationStore` validates deliveries, claims the composite inbox key,
    serializes the entity key, and applies entity/tombstone/link replacement atomically.
-3. `PostgresSchemaLeaseStore` provides durable schema-application exclusion, reclaim,
-   heartbeat, terminal completion, and attempt fencing.
+3. `PostgresSchemaLeaseStore` provides durable schema-application exclusion,
+   reclaim, heartbeat, terminal completion, and attempt fencing.
 4. `SecondaryIndexPlan` and `PostgresSecondaryIndexManager` derive typed/GIN indexes,
    coordinate concurrent ensure/reindex/retire work, and verify catalog readiness.
-5. `PartitionAdmissionPolicy` and `PartitionShadowPlan` implement measured, fail-closed
-   admission and deterministic shadow-only hash partition DDL.
+5. `PartitionAdmissionPolicy` and `PartitionShadowPlan` implement measured,
+   fail-closed admission and deterministic shadow-only hash partition DDL.
 6. Immutable manifest preparation and packet validation bind commit, image, modulus,
    repetitions, thresholds, evidence identity, raw hashes, and calculated reasons.
-7. Exact-byte capture assembly reads six unique confined raw files once, validates the
-   packet, and refuses overwrite or aliases.
-8. Snapshot/query/mutation/maintenance/cutover runners retain parity, plans, latency,
-   WAL, skew, maintenance, and rollback-only lock evidence without touching canonical DDL.
-9. Full-capture orchestration, retained review, admitted-only archive manifests, and
-   saved-manifest receipts fail closed on identity, inventory, metadata, alias, or byte drift.
+7. `index_partition_capture_v1` assembly reads six unique confined raw files once,
+   calculates exact-byte hashes, validates the packet, and refuses overwrite/aliases.
+8. The snapshot runner creates evidence-bound shadow parents/children, copies one
+   repeatable-read baseline, attaches shadow integrity, records parity/size/catch-up,
+   and publishes `baseline.json` plus `shadow.json` without touching canonical DDL.
+9. The query runner validates the shadow catalog, executes exact tenant-scoped runs
+   read-only, proves semantic parity and one-child pruning, retains full EXPLAIN JSON,
+   calculates p95 and normalized plan digests, and publishes `query.json` once.
+10. The mutation/WAL runner validates the same manifest and catalog, requires count
+    parity and matching generic anchors, executes rollback-only mutation samples,
+    proves one-child shadow pruning, retains EXPLAIN JSON and WAL evidence, and
+    publishes `mutation.json` without overwrite. Real database execution remains an
+    owner step.
+11. The maintenance runner revalidates the manifest and retained shadow catalog,
+    creates isolated ordinary and tenant-hash clone pairs, applies identical committed
+    churn only to those clones, times ordinary `VACUUM (ANALYZE)`, proves production
+    and retained snapshot-shadow relations unchanged, and publishes
+    `maintenance.json` without overwrite. Real database execution remains an owner
+    step.
+12. The cutover rehearsal runner validates production and retained shadow identities,
+    creates deterministic evidence-only ordinary clones, measures `ACCESS EXCLUSIVE`
+    lock acquisition, performs rename swaps only inside rollback-only transactions,
+    proves clone OIDs/names and production relations unchanged, and publishes
+    `cutover.json` without overwrite. Real database execution remains an owner step.
+13. The full-capture orchestrator requires one explicit owner opt-in, one immutable
+    manifest, one database URL, and a fresh empty output directory. It sequentially
+    runs all five evidence commands, finalizes `capture.json` with PostgreSQL identity
+    and run provenance, assembles exact retained bytes into `partition-packet.json`,
+    validates `admission.json`, and refuses partial-output reuse or resume.
+14. The retained bundle review inspects exactly nine authoritative files, recalculates
+    exact-byte packet assembly and admission, rejects aliases or drift, and renders a
+    deterministic read-only owner report without editing the bundle.
+15. The archive tooling emits a deterministic admitted-only manifest outside the
+    immutable bundle and verifies a saved manifest into a read-only receipt with
+    `production_lifecycle_authorized: false`.
+16. Retained verification binds every authoritative file and required directory to
+    stable-descriptor bytes, filesystem identity, metadata fingerprints, canonical
+    paths, and an exact recursive inventory. It rereads the saved manifest and fails
+    closed on replacement, metadata, inventory, alias, or post-inspection byte drift
+    while keeping public manifest and receipt schemas unchanged.
 
 ### M4 - Query engine v1
 
@@ -223,8 +325,8 @@ plans emit shadow-only DDL. They never rename, drop, or alter production relatio
 - [x] Resolve explicit link paths and assign stable aliases.
 - [x] Capture typed referenced-field contracts in executable plans.
 - [x] Compile plans through SeaQuery or controlled SQL.
-- [x] Support root and one-cardinality-link projection, filtering, sorting, exact count,
-      and keyset pagination.
+- [x] Support root and one-cardinality-link projection, filtering, sorting, exact
+      count, and keyset pagination.
 - [x] Keep offset pagination bounded and compatibility-only.
 - [x] Add deterministic root/one-link result decoding and cursor construction.
 - [x] Add explicit many-link `EXISTS` filtering.
@@ -237,64 +339,115 @@ plans emit shadow-only DDL. They never rename, drop, or alter production relatio
       default-off owner-authoritative Social Graph privacy parity shadow.
 - [ ] Execute PostgreSQL/reference-engine equivalence capture and admit retained live evidence.
 
+The first M4 slice is database independent. `SchemaRegistry::plan_query` validates
+before planning, assigns stable `t0`, `t1`, ... aliases from sorted explicit link
+prefixes, and captures every referenced field with type, cardinality, nullability,
+path, alias, and propagated many-link traversal state. It groups selected many fields
+by terminal relation path while preserving first path appearance and field order. The
+typed plan fingerprint uses the versioned `rustok-index-query-plan-v4` domain.
+
+The controlled compiler emits ordered typed binds, deterministic identity/projection/
+order columns, exact tenant/schema/locale/live-row scope, all current typed filters,
+reference-compatible null ordering, validated lexicographic keyset predicates with an
+ascending root `entity_id` tie-breaker, bounded offset pagination, and an optional
+separate exact-count statement without pagination leakage. Opaque continuation tokens
+must pass `SchemaRegistry::compile_postgres_query`, which validates checksum, scope,
+schema fingerprint, order arity, and order-value types before SQL emission.
+
+Each selected many path compiles as one correlated JSONB aggregate outside the outer
+rowset. Aggregate items preserve the complete linked entity identity chain and aligned
+tagged field values, are ordered by stored link ordinal plus target identity/locale at
+each hop, and produce an empty array when no reachable row exists. Many aggregates do
+not alter root pagination, lookahead, or exact-count cardinality.
+
+The result handoff uses `SchemaRegistry::compile_postgres_page_query` to increase only
+the validated page-limit bind by one. `decode_postgres_query_page` rechecks the plan
+fingerprint, deterministic scalar and many-relation column contracts, page size, row
+count, tagged `IndexValue` type/cardinality/nullability, relation identities, nested
+identity/value arity, duplicate/nil nested identities, and optional count. It removes
+the lookahead row, reports `has_more`, preserves flat and nested selection order, and
+emits a query-scoped cursor from the last retained root identity plus hidden order
+values. Offset pages use the same lookahead rule but do not synthesize a cursor.
+
+Many-link filtering compiles every atomic predicate through an independent nested
+correlated `EXISTS` chain. Many paths never enter the outer rowset, so root pagination,
+lookahead, result decoding, and exact count stay duplicate free. Positive operators use
+any-match semantics; `IsNull` checks for the absence of a reachable non-null value;
+`Ne` requires at least one stored reachable value and rejects any null or equal value.
+This matches the test-only reference engine's flattened path-value semantics.
+
+`IndexQueryPort` is the transport-neutral owner boundary for executing one structured
+query. `PostgresIndexQueryPort` owns one immutable `Arc<SchemaRegistry>` and one
+PostgreSQL connection. It derives every root/source/target schema used by the plan,
+requires an exact active tenant-scoped `index_schemas` row with matching fingerprint
+and schema JSON, executes the page and optional exact count in one read-only
+repeatable-read transaction, converts every `PostgresBindValue` to a SeaORM value, and
+maps only compiler-declared UUID/JSONB/bigint aliases into `CompiledPostgresRow` before
+calling the strict decoder. Authentication and transport policy remain caller-owned.
+
 Many-link ordering is admitted only through caller-explicit `min_asc`, `min_desc`,
-`max_asc`, and `max_desc`. Integer, string, timestamp, and Decimal terminals retain typed
-PostgreSQL aggregation and ordering; Decimal encodes only the hidden aggregate order value
-through the exact tagged string wire. UUID aggregate ordering, implicit first-row semantics,
-and aggregate cursor continuation remain fail closed. Aggregate ordering is
-bounded-offset-only and does not change root cardinality or exact count.
+`max_asc`, and `max_desc`. Integer, string, timestamp, and Decimal terminals retain
+typed PostgreSQL aggregation and ordering; Decimal encodes only the hidden aggregate
+order value through the exact tagged string wire. UUID aggregate ordering, implicit
+first-row semantics, and aggregate cursor continuation remain fail closed. Aggregate
+ordering is bounded-offset-only and does not change root cardinality or exact count.
 
 Source-owned schema publication, shared query-runtime composition, retained plan/SQL
-snapshots, and the first default-off Social Graph privacy parity shadow are source complete.
-The shadow is non-authoritative, records bounded parity observations, uses only the caller's
-remaining deadline budget, and always returns the owner result. Live metrics/evidence
-execution and authoritative consumer cutover remain open.
+snapshots, and the first default-off Social Graph privacy parity shadow are source
+complete. The shadow is non-authoritative, records bounded parity observations, uses
+only the caller's remaining deadline budget, and always returns the owner result.
+Live metrics/evidence execution, PostgreSQL/reference-engine equivalence admission,
+and authoritative consumer cutover remain open.
 
 ### M5 - Incremental ingestion
 
 - [x] Add a source replay registry with bounded failure classification.
 - [ ] Add a mutation-source event registry and broker acknowledgement orchestration.
 - [x] Add inbox deduplication and monotonic source versions.
-- [ ] Add batch transactions, retry policy, bounded backoff, dead-letter state, and lag
-      metrics around the source contracts.
+- [ ] Add batch transactions, retry classification, bounded backoff, dead-letter state,
+      and lag metrics around the source contracts.
 - [ ] Protect the complete event-to-ack path against out-of-order update/delete delivery.
 - [ ] Cover crash between commit and acknowledgement.
 
-The source registry fixes one source owner for every exact schema and the complete schema
-identity across versions. It materializes only when every source schema is published by the
-same module owner. Source failures expose only bounded machine-readable codes classified as
-retryable or permanent; raw source or storage causes stay in owner logs.
+The source registry fixes one replay source for every exact schema and the complete
+schema identity across versions. Materialization requires every replay schema to exist
+in the source-owned schema catalog with the same module owner. Source failures expose
+only bounded machine-readable codes classified as retryable or permanent; raw source,
+database, or transport causes stay in owner logs.
 
 ### M6 - Rebuild and reconciliation
 
 - [x] Add cursor-based `IndexSource::scan` and targeted `load` contracts.
-- [x] Bound cursor bytes, scan pages, targeted key counts, tenant/schema scope, uniqueness,
-      and continuation progress; never collect all IDs first.
+- [x] Bound cursor bytes, scan pages, targeted key counts, tenant/schema scope,
+      uniqueness, and continuation progress; never collect all IDs first.
 - [ ] Add durable jobs, checkpoints, leases, heartbeat, and ownership.
-- [ ] Add a bounded worker that applies pages through `PostgresMutationStore` and commits
-      checkpoints only after durable mutation results.
+- [ ] Add a bounded worker that applies source pages through `PostgresMutationStore` and
+      commits checkpoints only after durable mutation results.
 - [ ] Add cancellation, resume, dry-run, targeted/full/shadow rebuild.
 - [ ] Add reconciliation and drift repair.
-- [ ] Cover crash, lease expiry, restart, cancellation, and incremental/full equivalence.
+- [ ] Cover crash, lease expiry, restart, cancellation, and incremental/full
+      equivalence.
 
-No durable job runner, checkpoint writer, scheduler, or production replay command is claimed
-by the source-complete contract. The existing `index_jobs` and `index_checkpoints` tables are
-reserved persistence foundations until a fenced worker owns their state transitions.
+No durable job runner, checkpoint writer, scheduler, or production replay command is
+claimed by this source-complete contract. The existing `index_jobs` and
+`index_checkpoints` tables remain persistence foundations until a fenced worker owns
+their transitions.
 
 ### M7 - First vertical slice
 
 Entities: Product, ProductVariant, SalesChannel.
 
 - [ ] Register owner-published schemas, links, and bounded source adapters.
-- [ ] Implement incremental mutations and rebuild sources.
-- [ ] Support tenant, locale, status, projection, link filters, sorting, and cursor pagination.
+- [ ] Implement mutations and rebuild sources.
+- [ ] Support tenant, locale, status, projection, link filters, sorting, and cursor
+      pagination.
 - [ ] Move one Storefront query to Index.
 - [ ] Prove no source-module filtering fan-out.
 
 ### M8 - Commerce scale slice
 
-- [ ] Add Pricing, Inventory, Category, Collection, Tags, Region/Currency, and Marketplace
-      Seller schemas/sources.
+- [ ] Add Pricing, Inventory, Category, Collection, Tags, Region/Currency, and
+      Marketplace Seller schemas/sources.
 - [ ] Filter by price, stock, category, channel, and seller in one query.
 - [ ] Add cardinality and load benchmarks.
 
@@ -313,48 +466,107 @@ Entities: Product, ProductVariant, SalesChannel.
 
 ### M11 - Admin and cutover
 
-- [ ] Expose schema, partition, lag, inbox, failure, rebuild, drift, and query diagnostics.
+- [ ] Expose schema, partition, lag, inbox, failure, rebuild, drift, and query
+      diagnostics.
 - [ ] Add rebuild/cancel/retry commands.
 - [ ] Publish new FBA contracts and runtime evidence.
 - [ ] Migrate consumers and delete final compatibility code.
 - [ ] Promote FBA only after compiled/live evidence.
 
-## Verification handoff
-
-The owner runs formatting, Cargo checks/tests, PostgreSQL fixtures, evidence capture,
-admission, and CI. Targeted source guards include:
+## Verification
 
 ```bash
-node scripts/verify/verify-index-fba.mjs
-node scripts/verify/verify-index-query-contract.mjs
-node scripts/verify/verify-index-source-replay-contract.mjs
-node scripts/verify/verify-index-query-snapshots.mjs
-node scripts/verify/verify-index-many-link-aggregate-ordering.mjs
-node scripts/verify/verify-index-decimal-aggregate-wire.mjs
-node scripts/verify/verify-index-source-schema-registry.mjs
-node scripts/verify/verify-index-query-runtime-composition.mjs
-node scripts/verify/verify-index-social-graph-privacy-consumer.mjs
+cargo fmt --all -- --check
+cargo check --workspace --all-targets --all-features
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo nextest run --workspace --all-targets --all-features
+cargo test --workspace --doc --all-features
+cargo test -p rustok-index planner_tests -- --nocapture
+cargo test -p rustok-index postgres_compiler_tests -- --nocapture
+cargo test -p rustok-index postgres_query_result_tests -- --nocapture
+cargo test -p rustok-index source_registry --lib -- --nocapture
 cargo xtask module validate index
+cargo xtask module test index
+npm run verify:index:fba
+npm run verify:index:runtime-fallback-smoke
+node scripts/verify/index-storage-tooling.mjs contract
+node scripts/verify/index-storage-tooling.mjs fixtures
+node --test scripts/verify/index-partition-evidence.test.mjs
+node --test scripts/verify/index-partition-evidence-assembly.test.mjs
+cargo check -p rustok-benchmarks --bin index-partition-snapshot-capture
+cargo test -p rustok-benchmarks partition_snapshot
+cargo check -p rustok-benchmarks --bin index-partition-query-evidence
+cargo test -p rustok-benchmarks partition_query
+cargo check -p rustok-benchmarks --bin index-partition-mutation-evidence
+cargo test -p rustok-benchmarks partition_mutation
+cargo check -p rustok-benchmarks --bin index-partition-maintenance-evidence
+cargo test -p rustok-benchmarks partition_maintenance
+cargo check -p rustok-benchmarks --bin index-partition-cutover-evidence
+cargo test -p rustok-benchmarks partition_cutover
+cargo check -p rustok-benchmarks --bin index-partition-capture-finalize
+```
+
+Targeted M3/M4/M5/M6 guards:
+
+```bash
+node scripts/verify/verify-index-mutation-storage.mjs
+node scripts/verify/verify-index-schema-leases.mjs
+node scripts/verify/verify-index-secondary-index-lifecycle.mjs
+node scripts/verify/verify-index-partition-admission.mjs
+node scripts/verify/verify-index-partition-evidence.mjs
+node scripts/verify/verify-index-partition-snapshot-capture.mjs
+node scripts/verify/verify-index-partition-query-evidence.mjs
+node scripts/verify/verify-index-partition-mutation-evidence.mjs
+node scripts/verify/verify-index-partition-maintenance-evidence.mjs
+node scripts/verify/verify-index-partition-cutover-evidence.mjs
+node scripts/verify/verify-index-partition-full-capture.mjs
+node scripts/verify/verify-index-partition-post-inspection-drift.mjs
+node scripts/verify/verify-index-query-contract.mjs
+node scripts/verify/verify-index-query-planner.mjs
+node scripts/verify/verify-index-postgres-query-compiler.mjs
+node scripts/verify/verify-index-query-result-decoder.mjs
+node scripts/verify/verify-index-many-link-filtering.mjs
+node scripts/verify/verify-index-source-replay-contract.mjs
 ```
 
 ## Progress log
 
-- 2026-07-23 through 2026-07-28: completed the destructive reset, M1 domain core,
-  selected-layout M2 evidence, and source-complete M3 storage/evidence tooling.
-- 2026-07-29: completed typed M4 planning, controlled SQL, filters, projection,
-  pagination, strict decoding, PostgreSQL query-port source, retained v4 snapshots,
-  source-owned schema publication, shared query-runtime composition, and the first
-  default-off owner-authoritative Social Graph privacy parity shadow.
-- 2026-07-30: completed explicit many-link MIN/MAX aggregate ordering for integer,
-  string, timestamp, and Decimal terminals; locked Decimal aggregate order values to the
-  exact tagged string wire; retained metrics/two-snapshot shadow evidence tooling; and
-  bounded each non-authoritative comparison by the caller's remaining deadline.
+- 2026-07-23: completed the destructive reset and generic M1 core.
+- 2026-07-24 through 2026-07-27: completed M2 comparison, archived replacement
+  evidence, accepted JSONB, and removed rejected prototypes.
+- 2026-07-27: completed canonical M3 schema, atomic mutation persistence, schema
+  leases, secondary-index lifecycle, partition admission/planning, immutable packet
+  tooling, exact-byte assembly, baseline/shadow snapshot capture, query evidence
+  capture, rollback-only mutation/WAL evidence capture, and isolated ordinary-VACUUM
+  maintenance evidence capture.
+- 2026-07-28: completed rollback-only cutover rehearsal evidence, full retained packet
+  owner orchestration with PostgreSQL identity-bound capture finalization, read-only
+  retained bundle review, admitted archive manifest generation, saved-manifest
+  verification receipts, and exact recursive filesystem snapshot enforcement.
+- 2026-07-29: rechecked the merged M3 source boundary, completed deterministic typed
+  M4 planning, controlled projection SQL, root/one-link filters, ordering, separate
+  exact count, validated lexicographic keyset continuation, bounded offset
+  compatibility, one-row page lookahead, deterministic tagged-row decoding, exact
+  count decoding, relation identity reconstruction, scoped next-cursor creation,
+  correlated many-link `EXISTS` filtering with duplicate-free root count/pagination,
+  deterministic nested many-link projection aggregation with aligned identity/value
+  decoding, and PostgreSQL `IndexQueryPort` source with exact persisted-schema
+  preflight, one repeatable-read page/count snapshot, exhaustive bind conversion, and
+  compiler-metadata-driven row adaptation.
+- 2026-07-30: completed retained v4 plan/SQL snapshots, explicit many-link MIN/MAX
+  aggregate ordering for integer, string, timestamp, and Decimal terminals, exact
+  Decimal tagged string wire, source-owned schema publication, shared query-runtime
+  composition, and the first default-off Social Graph privacy parity shadow.
+- 2026-07-30: bounded the non-authoritative Social Graph privacy shadow by the caller's
+  remaining deadline and repaired stale Index repository/evidence guards and retained
+  fixtures. No authoritative cutover or live PostgreSQL evidence is claimed.
 - 2026-07-30: added the neutral bounded replay source registry, opaque JSON cursor and
   scan/load contracts, exact schema-owner materialization, tenant/schema/result bounds,
   continuation-progress checks, and retryable/permanent source failure classification.
-- Repository test/fixture suites, the durable replay worker, live freshness/recovery
-  evidence, authoritative cutover, PostgreSQL/reference equivalence, and one real full
-  PostgreSQL partition packet remain owner-executed gates.
+- Repository test/fixture suites, verifiers, the durable replay worker, live
+  freshness/recovery evidence, one admitted PostgreSQL/reference equivalence bundle,
+  and one real full PostgreSQL partition packet remain for the owner to execute and
+  admit before authoritative consumer or production partition cutover.
 
 ## Periodic release verification handoff
 
@@ -363,8 +575,8 @@ cargo xtask module validate index
 - Last verified at (UTC): `2026-07-30`
 - Scope inspected: `Index ownership, migrations, mutation/version ordering, query execution, partition evidence guards, Social Graph consumer authority, privacy shadow deadline behavior, source replay ownership, and source/search/server boundaries`
 - Findings: `P0=0, P1=2, P2=0, P3=1`
-- Fixed in this pass: `bounded the non-authoritative Social Graph privacy comparison by the remaining caller deadline; repaired stale Index scale/FBA guards; added a canonical bounded source replay/load registry with strict schema ownership, request/result bounds, continuation progress, and retryable/permanent failure classification`
-- Remaining risks or blockers: `one retained admitted real PostgreSQL partition packet is absent; live PostgreSQL/reference query equivalence remains open; the new source contract has no fenced durable job/checkpoint worker; no retained per-tenant freshness/watermark, lag, negative-result safety, outage/restart/backlog catch-up, or replay-repair evidence exists; consumer and production partition cutover remain forbidden`
-- Evidence: `PR #2544 merged as b647a5a17f27b34a07c20cd57525ed1806994c49; same-SHA Index Storage Scale Run Contract and full Scale Evidence contract passed JavaScript syntax, workflow contracts, repository contracts, direct validator arguments and fixture suites; source replay contract added in the current draft PR without implementation-agent test execution; general CI/Hardening received no jobs; Rust-hosted smoke previously stopped before compilation because Cargo.lock required an Athanor update under --locked`
-- Next action: `implement fenced durable rebuild jobs/checkpoints and the first Product source adapter, then execute retained PostgreSQL packet, live query equivalence, and per-tenant freshness/outage/recovery evidence before reconsidering authoritative consumers or partition lifecycle`
+- Fixed in this pass: `bounded the non-authoritative Social Graph privacy comparison by the remaining caller deadline while preserving the owner result; repaired stale Index scale/FBA and retained-artifact guards; added a canonical bounded source replay/load registry with exact schema ownership, request/result bounds, continuation progress, and retryable/permanent failure classification`
+- Remaining risks or blockers: `one retained admitted real PostgreSQL partition packet is absent; live PostgreSQL/reference query equivalence remains open; the source contract has no fenced durable job/checkpoint worker; no retained per-tenant freshness/watermark, lag, negative-result safety, outage/restart/backlog catch-up, or replay-repair evidence exists; consumer and production partition cutover remain forbidden`
+- Evidence: `PR #2544 merged as b647a5a17f27b34a07c20cd57525ed1806994c49; same-SHA Index Storage Scale Run Contract and full Scale Evidence contract passed JavaScript syntax, workflow contracts, repository contracts, direct validator arguments and fixture suites; source replay contract is added in the current draft PR without implementation-agent test execution; general CI/Hardening received no jobs; Rust-hosted smoke previously stopped before compilation because Cargo.lock required an Athanor update under --locked`
+- Next action: `implement fenced durable rebuild jobs/checkpoints and the first Product source adapter, then execute the retained PostgreSQL packet, live query equivalence, and per-tenant freshness/outage/recovery evidence before reconsidering authoritative consumers or partition lifecycle`
 - Resume command: `cargo fmt --all -- --check && cargo check -p rustok-index --all-targets && node scripts/verify/verify-index-query-contract.mjs && node scripts/verify/index-storage-tooling.mjs contract && node scripts/verify/index-storage-tooling.mjs fixtures`

--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -26,7 +26,7 @@ pull requests record checks and PostgreSQL runs that were not executed.
 ## Current state
 
 - Rewrite status: `in_progress`
-- Current milestone: `M5/M6 - bounded source replay owner contract (source complete; durable worker and retained evidence open)`
+- Current milestone: `M5/M6 - bounded replay page progression (source complete; fenced jobs, multi-page ownership, and retained evidence open)`
 - FFA status: `in_progress`
 - FBA status: `in_progress`
 - M0 code reset: `complete`
@@ -64,6 +64,7 @@ pull requests record checks and PostgreSQL runs that were not executed.
 - M4 first Social Graph privacy parity shadow: `source_complete_metrics_evidence_tooling_execution_pending`
 - M5 inbox deduplication and monotonic source-version persistence: `complete`
 - M5/M6 bounded source replay contract: `source_complete_worker_pending`
+- M6 one-page replay and durable checkpoint progression: `source_complete_fenced_job_worker_pending`
 - Production persistence: mutation writes, schema/index coordination, fail-closed
   partition admission, snapshot/query/mutation/maintenance/cutover evidence tooling,
   full-capture orchestration, exact-byte packet assembly, retained bundle review,
@@ -75,9 +76,10 @@ pull requests record checks and PostgreSQL runs that were not executed.
   lookahead, tagged row decoding, exact-count decoding, scoped next-cursor construction,
   persisted-schema query preflight, PostgreSQL page/count execution, compiler-driven
   row adaptation, source-owned schema publication, shared query-runtime composition,
-  and bounded source replay/load contracts are implemented; one retained admitted
-  packet, live PostgreSQL/reference equivalence, durable ingestion/rebuild workers,
-  freshness/recovery evidence, authoritative consumer cutover, and production
+  bounded source replay/load contracts, one-page replay mutation application, and
+  durable rebuild checkpoint progression are implemented; one retained admitted
+  packet, live PostgreSQL/reference equivalence, fenced multi-page ingestion/rebuild
+  workers, freshness/recovery evidence, authoritative consumer cutover, and production
   partition lifecycle remain open
 
 The production crate contains the generic domain/application core, seven canonical
@@ -90,9 +92,10 @@ filtering, deterministic nested many-link projection aggregates, and explicit
 many-link MIN/MAX aggregate ordering, a strict compiled-row decoder with aligned
 nested identities/values, lookahead pagination, and scoped cursor construction,
 `PostgresIndexQueryPort` for exact-schema-preflighted execution in one read-only
-repeatable-read page/count snapshot, source-owned schema and replay catalogs, and a
-neutral bounded `IndexSource` scan/load boundary. Owner-operated evidence tools live
-under `ops/benches`; they do not become runtime storage code.
+repeatable-read page/count snapshot, source-owned schema and replay catalogs, a
+neutral bounded `IndexSource` scan/load boundary, and a one-page replay executor with
+a PostgreSQL rebuild-checkpoint adapter. Owner-operated evidence tools live under
+`ops/benches`; they do not become runtime storage code.
 
 ## Ownership
 
@@ -103,7 +106,7 @@ reconciliation, drift repair, distributed coordination, and operator diagnostics
 
 Source modules own normalized domain data, schema declarations, conversion to
 generic Index records/mutations, bounded `IndexSource::scan` and targeted `load`
-adapters, and source ordering and version information.
+adapters, stable replay event identities, and source ordering and version information.
 
 ## Target architecture
 
@@ -129,9 +132,11 @@ crates/rustok-index/src/
     query_port.rs
     source_schema_registry.rs
     source_registry.rs
+    source_replay.rs
   migrations/
   infrastructure/postgres/
     mutation_store.rs
+    source_replay.rs
     schema_lease.rs
     secondary_index.rs
     partition_admission.rs
@@ -420,18 +425,24 @@ database, or transport causes stay in owner logs.
 - [x] Add cursor-based `IndexSource::scan` and targeted `load` contracts.
 - [x] Bound cursor bytes, scan pages, targeted key counts, tenant/schema scope,
       uniqueness, and continuation progress; never collect all IDs first.
-- [ ] Add durable jobs, checkpoints, leases, heartbeat, and ownership.
-- [ ] Add a bounded worker that applies source pages through `PostgresMutationStore` and
+- [x] Add a durable rebuild checkpoint read/write adapter over `index_checkpoints`.
+- [x] Add a bounded worker that applies source pages through `PostgresMutationStore` and
       commits checkpoints only after durable mutation results.
-- [ ] Add cancellation, resume, dry-run, targeted/full/shadow rebuild.
+- [x] Reject nil/duplicate replay event UUIDs and require stable event identity across
+      retries for the same logical mutation and source version.
+- [ ] Add durable jobs, leases, heartbeat, attempt fencing, and global ownership.
+- [ ] Add cancellation, bounded multi-page resume, dry-run, targeted/full/shadow rebuild.
+- [ ] Add locale/partition replay checkpoint dimensions.
 - [ ] Add reconciliation and drift repair.
 - [ ] Cover crash, lease expiry, restart, cancellation, and incremental/full
       equivalence.
 
-No durable job runner, checkpoint writer, scheduler, or production replay command is
-claimed by this source-complete contract. The existing `index_jobs` and
-`index_checkpoints` tables remain persistence foundations until a fenced worker owns
-their transitions.
+The one-page executor and PostgreSQL checkpoint adapter are source complete. They
+reserve empty locale/partition dimensions, apply one page sequentially, and write the
+next cursor only after every mutation result is durable. A checkpoint failure safely
+replays the previous cursor through stable event delivery IDs and the existing inbox
+deduplication contract. No fenced job runner, scheduler, lease owner, long-running
+production command, retry/dead-letter loop, or concurrent checkpoint writer is claimed.
 
 ### M7 - First vertical slice
 
@@ -485,6 +496,7 @@ cargo test -p rustok-index planner_tests -- --nocapture
 cargo test -p rustok-index postgres_compiler_tests -- --nocapture
 cargo test -p rustok-index postgres_query_result_tests -- --nocapture
 cargo test -p rustok-index source_registry --lib -- --nocapture
+cargo test -p rustok-index source_replay --lib -- --nocapture
 cargo xtask module validate index
 cargo xtask module test index
 npm run verify:index:fba
@@ -563,20 +575,24 @@ node scripts/verify/verify-index-source-replay-contract.mjs
 - 2026-07-30: added the neutral bounded replay source registry, opaque JSON cursor and
   scan/load contracts, exact schema-owner materialization, tenant/schema/result bounds,
   continuation-progress checks, and retryable/permanent source failure classification.
-- Repository test/fixture suites, verifiers, the durable replay worker, live
-  freshness/recovery evidence, one admitted PostgreSQL/reference equivalence bundle,
-  and one real full PostgreSQL partition packet remain for the owner to execute and
-  admit before authoritative consumer or production partition cutover.
+- 2026-07-30: added the one-page replay executor, stable replay event checks,
+  `PostgresMutationStore` sink composition, durable rebuild-checkpoint read/write
+  adapter, post-mutation checkpoint ordering, completion no-op, and replay-after-
+  checkpoint-failure contracts. Fenced jobs and multi-page ownership remain open.
+- Repository test/fixture suites, verifiers, the fenced multi-page replay job worker,
+  live freshness/recovery evidence, one admitted PostgreSQL/reference equivalence
+  bundle, and one real full PostgreSQL partition packet remain for the owner to execute
+  and admit before authoritative consumer or production partition cutover.
 
 ## Periodic release verification handoff
 
 - Cycle: `cycle-001`
 - Status: `blocked`
 - Last verified at (UTC): `2026-07-30`
-- Scope inspected: `Index ownership, migrations, mutation/version ordering, query execution, partition evidence guards, Social Graph consumer authority, privacy shadow deadline behavior, source replay ownership, and source/search/server boundaries`
+- Scope inspected: `Index ownership, migrations, mutation/version ordering, query execution, partition evidence guards, Social Graph consumer authority, privacy shadow deadline behavior, source replay ownership, replay checkpoint ordering, and source/search/server boundaries`
 - Findings: `P0=0, P1=2, P2=0, P3=1`
-- Fixed in this pass: `bounded the non-authoritative Social Graph privacy comparison by the remaining caller deadline while preserving the owner result; repaired stale Index scale/FBA and retained-artifact guards; added a canonical bounded source replay/load registry with exact schema ownership, request/result bounds, continuation progress, and retryable/permanent failure classification`
-- Remaining risks or blockers: `one retained admitted real PostgreSQL partition packet is absent; live PostgreSQL/reference query equivalence remains open; the source contract has no fenced durable job/checkpoint worker; no retained per-tenant freshness/watermark, lag, negative-result safety, outage/restart/backlog catch-up, or replay-repair evidence exists; consumer and production partition cutover remain forbidden`
-- Evidence: `PR #2544 merged as b647a5a17f27b34a07c20cd57525ed1806994c49; same-SHA Index Storage Scale Run Contract and full Scale Evidence contract passed JavaScript syntax, workflow contracts, repository contracts, direct validator arguments and fixture suites; source replay contract is added in the current draft PR without implementation-agent test execution; general CI/Hardening received no jobs; Rust-hosted smoke previously stopped before compilation because Cargo.lock required an Athanor update under --locked`
-- Next action: `implement fenced durable rebuild jobs/checkpoints and the first Product source adapter, then execute the retained PostgreSQL packet, live query equivalence, and per-tenant freshness/outage/recovery evidence before reconsidering authoritative consumers or partition lifecycle`
+- Fixed in this pass: `bounded the non-authoritative Social Graph privacy comparison by the remaining caller deadline while preserving the owner result; repaired stale Index scale/FBA and retained-artifact guards; added a canonical bounded source replay/load registry; added one-page replay mutation application with stable event checks and checkpoint progression only after durable mutation outcomes`
+- Remaining risks or blockers: `one retained admitted real PostgreSQL partition packet is absent; live PostgreSQL/reference query equivalence remains open; no fenced index_jobs owner, lease/heartbeat, multi-page loop, cancellation, or concurrent checkpoint fencing exists; no retained per-tenant freshness/watermark, lag, negative-result safety, outage/restart/backlog catch-up, or replay-repair evidence exists; consumer and production partition cutover remain forbidden`
+- Evidence: `PR #2544 merged as b647a5a17f27b34a07c20cd57525ed1806994c49; same-SHA Index Storage Scale Run Contract and full Scale Evidence contract passed JavaScript syntax, workflow contracts, repository contracts, direct validator arguments and fixture suites; source replay registry and one-page checkpoint progression are added in the current draft PR without implementation-agent test execution; general CI/Hardening received no jobs; Rust-hosted smoke previously stopped before compilation because Cargo.lock required an Athanor update under --locked`
+- Next action: `implement fenced durable rebuild job claims, lease/heartbeat and bounded multi-page resume, then add the first Product source adapter and execute retained PostgreSQL packet, live query equivalence, and per-tenant freshness/outage/recovery evidence before reconsidering authoritative consumers or partition lifecycle`
 - Resume command: `cargo fmt --all -- --check && cargo check -p rustok-index --all-targets && node scripts/verify/verify-index-query-contract.mjs && node scripts/verify/index-storage-tooling.mjs contract && node scripts/verify/index-storage-tooling.mjs fixtures`

--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -3,9 +3,9 @@
 ## Mission
 
 `rustok-index` is the platform-owned cross-module relational index and query engine.
-Source modules publish generic schemas, records, mutations, and links; Index
-materializes them into PostgreSQL and executes structured filtering, projection,
-sorting, counting, and pagination without runtime fan-out to source tables.
+Source modules publish generic schemas, records, mutations, links, and bounded replay
+sources; Index materializes them into PostgreSQL and executes structured filtering,
+projection, sorting, counting, and pagination without runtime fan-out to source tables.
 
 `rustok-index` is not a search engine. Ranking, relevance, typo tolerance, synonyms,
 autocomplete, search UX, and external search-engine connectors remain owned by
@@ -16,17 +16,17 @@ autocomplete, search UX, and external search-engine connectors remain owned by
 The project is in early development. Backward compatibility with the rejected
 implementation is not a goal. Prefer clean replacement over compatibility layers.
 Index core must not import source-domain semantics or query source-module tables.
-Benchmark/evidence code remains outside production migrations and runtime
-composition. Partition cutover remains forbidden until one retained real
-PostgreSQL packet satisfies the explicit admission policy.
+Benchmark/evidence code remains outside production migrations and runtime composition.
+Partition cutover remains forbidden until one retained real PostgreSQL packet satisfies
+the explicit admission policy.
 
-The repository owner performs test, benchmark, and evidence execution. Commits and
-pull requests record checks and PostgreSQL runs that were not executed.
+The repository owner performs test, benchmark, and evidence execution. Commits and pull
+requests record checks and PostgreSQL runs that were not executed.
 
 ## Current state
 
 - Rewrite status: `in_progress`
-- Current milestone: `M4 - Query engine v1 (PostgreSQL query port source added; M3 retained packet owner gate remains open)`
+- Current milestone: `M5/M6 - bounded source replay owner contract (source complete; durable worker and retained evidence open)`
 - FFA status: `in_progress`
 - FBA status: `in_progress`
 - M0 code reset: `complete`
@@ -58,47 +58,36 @@ pull requests record checks and PostgreSQL runs that were not executed.
 - M4 many-link `EXISTS` filtering: `complete`
 - M4 nested many-link projection aggregation: `complete`
 - M4 PostgreSQL query port and strict row adapter: `source_complete`
-- Production persistence: mutation writes, schema/index coordination, fail-closed
-  partition admission, snapshot/query/mutation/maintenance/cutover evidence tooling,
-  full-capture orchestration, exact-byte packet assembly, retained bundle review,
-  admitted archive manifest generation, saved-manifest verification, recursive
-  filesystem integrity checks, typed executable query planning, controlled projection,
-  root/one-link filtering, ordering, exact-count, keyset, bounded-offset SQL
-  compilation, correlated many-link filtering, deterministic nested many-link
-  projection aggregation, one-row page lookahead, tagged row decoding, exact-count
-  decoding, scoped next-cursor construction, persisted-schema query preflight,
-  PostgreSQL page/count execution, and compiler-driven row adaptation are implemented;
-  one retained admitted packet, server/consumer query-port composition,
-  PostgreSQL/reference equivalence, and production partition lifecycle remain open
+- M4 retained plan/SQL snapshots: `source_complete`
+- M4 explicit many-link aggregate ordering: `source_complete`
+- M4 source-owned schema catalog and shared query runtime: `source_complete`
+- M4 first Social Graph privacy parity shadow: `source_complete_metrics_evidence_tooling_execution_pending`
+- M5 inbox deduplication and monotonic source-version persistence: `complete`
+- M5/M6 bounded source replay contract: `source_complete_worker_pending`
 
-The production crate contains the generic domain/application core, seven canonical
-M3 tables, an atomic mutation adapter, durable schema leases, secondary-index
-lifecycle management, measured partition admission that emits shadow bootstrap
-plans only, an M4 typed structural query planner with deterministic relation aliases,
-a controlled PostgreSQL compiler for root/one-link projection, filtering, ordering,
-exact count, keyset and bounded offset plus duplicate-free correlated many-link
-filtering and nested many-link projection aggregates, a strict compiled-row decoder
-with aligned nested identities/values, lookahead pagination, and scoped cursor
-construction, and `PostgresIndexQueryPort` for exact-schema-preflighted execution in
-one read-only repeatable-read page/count snapshot. Owner-operated evidence tools live
-under `ops/benches`; they do not become runtime storage code.
+Production persistence, typed planning/compilation/decoding, explicit many-link MIN/MAX
+aggregate ordering with the exact Decimal string wire, source-owned schema publication,
+shared query-runtime composition, and the default-off Social Graph privacy parity shadow
+are source complete. The new neutral replay boundary provides one schema-owned source,
+bounded scan/load requests, opaque bounded cursors, result-scope validation, and retryable
+versus permanent failure classification. One retained admitted partition packet, live
+PostgreSQL/reference equivalence, durable ingestion/rebuild workers, freshness and recovery
+evidence, authoritative consumer cutover, and production partition lifecycle remain open.
 
-## Ownership
+## Ownership and architecture
 
-Index owns schema/link registration, generic records and mutations, ingestion,
-inbox deduplication, PostgreSQL storage, query validation/planning/compilation,
-filtering, projection, sorting, counting, pagination, rebuild, checkpointing,
-reconciliation, drift repair, distributed coordination, and operator diagnostics.
+Index owns schema/link/source registration, generic records and mutations, ingestion,
+inbox deduplication, PostgreSQL storage, query validation/planning/compilation, filtering,
+projection, sorting, counting, pagination, rebuild, checkpointing, reconciliation, drift
+repair, distributed coordination, and operator diagnostics.
 
-Source modules own normalized domain data, schema declarations, conversion to
-generic Index records/mutations, rebuild scan/load adapters, and source ordering and
-version information.
-
-## Target architecture
+Source modules own normalized domain data, schema declarations, conversion to generic Index
+records/mutations, bounded `IndexSource::scan` and targeted `load` adapters, and source
+ordering/version information.
 
 ```text
 source modules
-    -> IndexSource / IndexMutation
+    -> IndexSchemaSourceCatalog / IndexSourceCatalog / IndexMutation
     -> ingestion and rebuild engines
     -> PostgreSQL index storage
     -> schema/link registry and query planner
@@ -107,49 +96,16 @@ source modules
     -> server, storefront, admin, and rustok-search
 ```
 
-```text
-crates/rustok-index/src/
-  domain/
-  application/
-    planner.rs
-    postgres_compiler.rs
-    postgres_query_sql.rs
-    postgres_query_result.rs
-    query_port.rs
-  migrations/
-  infrastructure/postgres/
-    mutation_store.rs
-    schema_lease.rs
-    secondary_index.rs
-    partition_admission.rs
-    query_port.rs
-  api/
-
-ops/benches/src/index_storage/
-  runner.rs
-  mutation_runner.rs
-  maintenance_runner.rs
-  partition_snapshot.rs
-  partition_query.rs
-  partition_mutation.rs
-  partition_maintenance.rs
-  partition_cutover.rs
-  partition_capture.rs
-```
-
-## Library decisions
-
-Use workspace `sea-orm`/SeaQuery for PostgreSQL, `tokio`/`futures-util` for bounded
-async work, `serde`/`postcard` for contracts, `thiserror` for typed failures,
+Use workspace `sea-orm`/SeaQuery for PostgreSQL, `tokio`/`futures-util` for bounded async
+work, `serde`/`postcard` for contracts, `thiserror` for typed failures,
 `tracing`/telemetry/prometheus for observability, `petgraph` for deterministic graph
-resolution, ICU4X for locale canonicalization, and `sha2` for schema, cursor, plan,
-and retained-evidence identities. Add Testcontainers, retry, cancellation, or
-snapshot libraries only when their slices require them.
+resolution, ICU4X for locale canonicalization, and `sha2` for schema, cursor, plan, and
+retained-evidence identities.
 
-Forbidden in Index core: source-domain dependencies, ranking/search libraries, a
-second database stack, unvalidated JSON-only public queries, unbounded rebuild ID
-collection, direct source-table reads, and destructive partition cutover without
-retained evidence and rollback proof.
+Forbidden in Index core: source-domain dependencies, ranking/search libraries, a second
+database stack, unvalidated JSON-only public queries, unbounded rebuild ID collection,
+direct source-table reads, source-owned writes to Index tables, and destructive partition
+cutover without retained evidence and rollback proof.
 
 ## Milestones
 
@@ -167,34 +123,27 @@ retained evidence and rollback proof.
 - [x] Add `IndexValue`, `IndexRecord`, `IndexMutation`, `IndexSchema`, and links.
 - [x] Add stable order-independent SHA-256 schema fingerprints.
 - [x] Add atomic registration and deterministic link-path resolution.
-- [x] Validate records, mutations, queries, types, operators, cardinality, tenant/
-      locale scope, and complexity.
+- [x] Validate records, mutations, queries, types, operators, cardinality, tenant/locale
+      scope, and complexity.
 - [x] Add checksummed query-scoped keyset cursors.
 - [x] Add a test-only reference engine and property invariants.
 
 ### M2 - PostgreSQL storage benchmark
 
-- [x] Define the benchmark contract and keep candidate DDL outside production
-      migrations.
+- [x] Define the benchmark contract and keep candidate DDL outside production migrations.
 - [x] Add deterministic `smoke`, `100k`, and `1m` dataset presets.
 - [x] Prototype JSONB entity rows plus typed expression/GIN indexes.
-- [x] Compare JSONB, typed EAV, and specialized hot projection using equal result
-      digests, cardinality, planner/session metadata, WAL, buffers, relation size,
-      churn, and VACUUM evidence.
-- [x] Run and archive replacement 100k Product-locale row read, mutation, and
-      maintenance evidence from the accepted same-commit packet.
-- [x] Run and archive replacement 1m Product-locale row read, mutation, and
-      maintenance evidence from the same accepted commit.
-- [x] Compare warm/cold buffers, planner stability, execution latency, ingestion
-      throughput, relation size, WAL, dead tuples, vacuum behavior, and operational
-      complexity.
+- [x] Compare JSONB, typed EAV, and specialized hot projection using equal result digests,
+      cardinality, planner/session metadata, WAL, buffers, relation size, churn, and
+      VACUUM evidence.
+- [x] Run and archive replacement 100k Product-locale row evidence.
+- [x] Run and archive replacement 1m Product-locale row evidence.
 - [x] Record the selected model and rejected alternatives in an ADR.
 - [x] Delete benchmark prototypes that are not selected.
 
-M2 is complete. The remaining JSONB benchmark path is a selected-layout regression
-harness; it is not production persistence and does not reopen the accepted storage
-decision. Partitioning was not measured by M2, so canonical production tables remain
-unpartitioned until separate shadow evidence is retained and admitted.
+M2 is complete. The JSONB harness is selected-layout regression evidence, not production
+persistence. Canonical production tables remain unpartitioned until separate shadow
+evidence is retained and admitted.
 
 ### M3 - PostgreSQL storage engine
 
@@ -223,33 +172,29 @@ unpartitioned until separate shadow evidence is retained and admitted.
 - [ ] Add partition copy/checkpoints, constraints/index attachment, replay/dual-write,
       cutover, rollback, and durable global operation ownership.
 - [ ] Add PostgreSQL Testcontainers fixtures.
-- [ ] Cover migration-from-zero, stale mutation, redelivery, rollback, concurrency,
-      and tenant/locale isolation in PostgreSQL.
+- [ ] Cover migration-from-zero, stale mutation, redelivery, rollback, concurrency, and
+      tenant/locale isolation in PostgreSQL.
 
 #### Retained repository contract wording
-
-The following wording remains explicit because repository guards bind the completed
-slices and still-open owner evidence to these exact architectural boundaries:
 
 - [x] Add locking/leases for schema application.
 - [x] Add secondary-index planning and lifecycle management.
 - [x] Add tenant/schema/entity/locale keys and source-version guards.
 - [x] Add immutable partition evidence manifest, measured packet validator, and
       owner-operated runbook.
-- [x] Add exact-byte raw-artifact capture assembly with bundle confinement and
-      no-clobber packet publication.
-- [x] Add read-only retained bundle review, admitted archive manifest, and
-      saved-manifest verification receipt.
+- [x] Add exact-byte raw-artifact capture assembly with bundle confinement and no-clobber
+      packet publication.
+- [x] Add read-only retained bundle review, admitted archive manifest, and saved-manifest
+      verification receipt.
 - [x] Bind retained verification to an exact recursive filesystem snapshot and refuse
       post-inspection drift.
 - [ ] Execute retained PostgreSQL partition baseline/shadow evidence.
 - [ ] Execute retained PostgreSQL query, mutation, maintenance, and cutover evidence.
 - [ ] Execute retained PostgreSQL mutation, maintenance, and cutover evidence.
 
-Partition admission remains fail-closed across tenant-predicate coverage,
-query/mutation latency and plan stability, WAL amplification, skew, and cutover lock
-evidence. Admitted plans emit shadow-only DDL. They never rename, drop, or alter production
-relations.
+Partition admission remains fail-closed across tenant-predicate coverage, query/mutation
+latency and plan stability, WAL amplification, skew, and cutover lock evidence. Admitted
+plans emit shadow-only DDL. They never rename, drop, or alter production relations.
 
 #### Completed M3 slices
 
@@ -257,54 +202,20 @@ relations.
    schema, entity, locale, and full-range non-negative source-version identity.
 2. `PostgresMutationStore` validates deliveries, claims the composite inbox key,
    serializes the entity key, and applies entity/tombstone/link replacement atomically.
-3. `PostgresSchemaLeaseStore` provides durable schema-application exclusion,
-   reclaim, heartbeat, terminal completion, and attempt fencing.
+3. `PostgresSchemaLeaseStore` provides durable schema-application exclusion, reclaim,
+   heartbeat, terminal completion, and attempt fencing.
 4. `SecondaryIndexPlan` and `PostgresSecondaryIndexManager` derive typed/GIN indexes,
    coordinate concurrent ensure/reindex/retire work, and verify catalog readiness.
-5. `PartitionAdmissionPolicy` and `PartitionShadowPlan` implement measured,
-   fail-closed admission and deterministic shadow-only hash partition DDL.
+5. `PartitionAdmissionPolicy` and `PartitionShadowPlan` implement measured, fail-closed
+   admission and deterministic shadow-only hash partition DDL.
 6. Immutable manifest preparation and packet validation bind commit, image, modulus,
    repetitions, thresholds, evidence identity, raw hashes, and calculated reasons.
-7. `index_partition_capture_v1` assembly reads six unique confined raw files once,
-   calculates exact-byte hashes, validates the packet, and refuses overwrite/aliases.
-8. The snapshot runner creates evidence-bound shadow parents/children, copies one
-   repeatable-read baseline, attaches shadow integrity, records parity/size/catch-up,
-   and publishes `baseline.json` plus `shadow.json` without touching canonical DDL.
-9. The query runner validates the shadow catalog, executes exact tenant-scoped runs
-   read-only, proves semantic parity and one-child pruning, retains full EXPLAIN JSON,
-   calculates p95 and normalized plan digests, and publishes `query.json` once.
-10. The mutation/WAL runner validates the same manifest and catalog, requires count
-    parity and matching generic anchors, executes rollback-only mutation samples,
-    proves one-child shadow pruning, retains EXPLAIN JSON and WAL evidence, and
-    publishes `mutation.json` without overwrite. Real database execution remains an
-    owner step.
-11. The maintenance runner revalidates the manifest and retained shadow catalog,
-    creates isolated ordinary and tenant-hash clone pairs, applies identical committed
-    churn only to those clones, times ordinary `VACUUM (ANALYZE)`, proves production
-    and retained snapshot-shadow relations unchanged, and publishes
-    `maintenance.json` without overwrite. Real database execution remains an owner
-    step.
-12. The cutover rehearsal runner validates production and retained shadow identities,
-    creates deterministic evidence-only ordinary clones, measures `ACCESS EXCLUSIVE`
-    lock acquisition, performs rename swaps only inside rollback-only transactions,
-    proves clone OIDs/names and production relations unchanged, and publishes
-    `cutover.json` without overwrite. Real database execution remains an owner step.
-13. The full-capture orchestrator requires one explicit owner opt-in, one immutable
-    manifest, one database URL, and a fresh empty output directory. It sequentially
-    runs all five evidence commands, finalizes `capture.json` with PostgreSQL identity
-    and run provenance, assembles exact retained bytes into `partition-packet.json`,
-    validates `admission.json`, and refuses partial-output reuse or resume.
-14. The retained bundle review inspects exactly nine authoritative files, recalculates
-    exact-byte packet assembly and admission, rejects aliases or drift, and renders a
-    deterministic read-only owner report without editing the bundle.
-15. The archive tooling emits a deterministic admitted-only manifest outside the
-    immutable bundle and verifies a saved manifest into a read-only receipt with
-    `production_lifecycle_authorized: false`.
-16. Retained verification binds every authoritative file and required directory to
-    stable-descriptor bytes, filesystem identity, metadata fingerprints, canonical
-    paths, and an exact recursive inventory. It rereads the saved manifest and fails
-    closed on replacement, metadata, inventory, alias, or post-inspection byte drift
-    while keeping public manifest and receipt schemas unchanged.
+7. Exact-byte capture assembly reads six unique confined raw files once, validates the
+   packet, and refuses overwrite or aliases.
+8. Snapshot/query/mutation/maintenance/cutover runners retain parity, plans, latency,
+   WAL, skew, maintenance, and rollback-only lock evidence without touching canonical DDL.
+9. Full-capture orchestration, retained review, admitted-only archive manifests, and
+   saved-manifest receipts fail closed on identity, inventory, metadata, alias, or byte drift.
 
 ### M4 - Query engine v1
 
@@ -312,100 +223,78 @@ relations.
 - [x] Resolve explicit link paths and assign stable aliases.
 - [x] Capture typed referenced-field contracts in executable plans.
 - [x] Compile plans through SeaQuery or controlled SQL.
-- [x] Support root and one-cardinality-link projection, filtering, sorting, exact
-      count, and keyset pagination.
+- [x] Support root and one-cardinality-link projection, filtering, sorting, exact count,
+      and keyset pagination.
 - [x] Keep offset pagination bounded and compatibility-only.
 - [x] Add deterministic root/one-link result decoding and cursor construction.
 - [x] Add explicit many-link `EXISTS` filtering.
 - [x] Add nested many-link projection aggregation.
 - [x] Add PostgreSQL `IndexQueryPort` execution and strict SeaORM row adaptation.
-- [ ] Add plan/SQL snapshots and PostgreSQL/reference-engine equivalence tests.
+- [x] Add retained v4 plan/SQL snapshots and synchronized source guards.
+- [x] Add explicit many-link MIN/MAX aggregate ordering for integer, string, timestamp,
+      and Decimal terminals under bounded offset pagination.
+- [x] Publish source-owned schemas, compose one shared query runtime, and stage the first
+      default-off owner-authoritative Social Graph privacy parity shadow.
+- [ ] Execute PostgreSQL/reference-engine equivalence capture and admit retained live evidence.
 
-The first M4 slice is database independent. `SchemaRegistry::plan_query` validates
-before planning, assigns stable `t0`, `t1`, ... aliases from sorted explicit link
-prefixes, and captures every referenced field with type, cardinality, nullability,
-path, alias, and propagated many-link traversal state. It groups selected many fields
-by terminal relation path while preserving first path appearance and field order. The
-typed plan fingerprint uses the versioned `rustok-index-query-plan-v4` domain.
+Many-link ordering is admitted only through caller-explicit `min_asc`, `min_desc`,
+`max_asc`, and `max_desc`. Integer, string, timestamp, and Decimal terminals retain typed
+PostgreSQL aggregation and ordering; Decimal encodes only the hidden aggregate order value
+through the exact tagged string wire. UUID aggregate ordering, implicit first-row semantics,
+and aggregate cursor continuation remain fail closed. Aggregate ordering is
+bounded-offset-only and does not change root cardinality or exact count.
 
-The controlled compiler emits ordered typed binds, deterministic identity/projection/
-order columns, exact tenant/schema/locale/live-row scope, all current typed filters,
-reference-compatible null ordering, validated lexicographic keyset predicates with an
-ascending root `entity_id` tie-breaker, bounded offset pagination, and an optional
-separate exact-count statement without pagination leakage. Opaque continuation tokens
-must pass `SchemaRegistry::compile_postgres_query`, which validates checksum, scope,
-schema fingerprint, order arity, and order-value types before SQL emission.
-
-Each selected many path compiles as one correlated JSONB aggregate outside the outer
-rowset. Aggregate items preserve the complete linked entity identity chain and aligned
-tagged field values, are ordered by stored link ordinal plus target identity/locale at
-each hop, and produce an empty array when no reachable row exists. Many aggregates do
-not alter root pagination, lookahead, or exact-count cardinality.
-
-The result handoff uses `SchemaRegistry::compile_postgres_page_query` to increase only
-the validated page-limit bind by one. `decode_postgres_query_page` rechecks the plan
-fingerprint, deterministic scalar and many-relation column contracts, page size, row
-count, tagged `IndexValue` type/cardinality/nullability, relation identities, nested
-identity/value arity, duplicate/nil nested identities, and optional count. It removes
-the lookahead row, reports `has_more`, preserves flat and nested selection order, and
-emits a query-scoped cursor from the last retained root identity plus hidden order
-values. Offset pages use the same lookahead rule but do not synthesize a cursor.
-
-Many-link filtering compiles every atomic predicate through an independent nested
-correlated `EXISTS` chain. Many paths never enter the outer rowset, so root pagination,
-lookahead, result decoding, and exact count stay duplicate free. Positive operators use
-any-match semantics; `IsNull` checks for the absence of a reachable non-null value;
-`Ne` requires at least one stored reachable value and rejects any null or equal value.
-This matches the test-only reference engine's flattened path-value semantics.
-
-`IndexQueryPort` is the transport-neutral owner boundary for executing one structured
-query. `PostgresIndexQueryPort` owns one immutable `Arc<SchemaRegistry>` and one
-PostgreSQL connection. It derives every root/source/target schema used by the plan,
-requires an exact active tenant-scoped `index_schemas` row with matching fingerprint
-and schema JSON, executes the page and optional exact count in one read-only
-repeatable-read transaction, converts every `PostgresBindValue` to a SeaORM value, and
-maps only compiler-declared UUID/JSONB/bigint aliases into `CompiledPostgresRow` before
-calling the strict decoder. Authentication and transport policy remain caller-owned.
-
-Many-link ordering remains rejected until an aggregate ordering policy exists.
-Server/storefront/admin/search composition, source schema/mutation publication,
-consumer cutover, plan/SQL snapshots, live PostgreSQL execution evidence, and
-PostgreSQL/reference-engine equivalence remain open.
+Source-owned schema publication, shared query-runtime composition, retained plan/SQL
+snapshots, and the first default-off Social Graph privacy parity shadow are source complete.
+The shadow is non-authoritative, records bounded parity observations, uses only the caller's
+remaining deadline budget, and always returns the owner result. Live metrics/evidence
+execution and authoritative consumer cutover remain open.
 
 ### M5 - Incremental ingestion
 
-- [ ] Add source and mutation registries.
-- [ ] Add inbox deduplication and monotonic source versions.
-- [ ] Add batch transactions, retry classification, backoff, dead-letter state, and
-      lag metrics.
-- [ ] Protect against out-of-order update/delete delivery.
+- [x] Add a source replay registry with bounded failure classification.
+- [ ] Add a mutation-source event registry and broker acknowledgement orchestration.
+- [x] Add inbox deduplication and monotonic source versions.
+- [ ] Add batch transactions, retry policy, bounded backoff, dead-letter state, and lag
+      metrics around the source contracts.
+- [ ] Protect the complete event-to-ack path against out-of-order update/delete delivery.
 - [ ] Cover crash between commit and acknowledgement.
+
+The source registry fixes one source owner for every exact schema and the complete schema
+identity across versions. It materializes only when every source schema is published by the
+same module owner. Source failures expose only bounded machine-readable codes classified as
+retryable or permanent; raw source or storage causes stay in owner logs.
 
 ### M6 - Rebuild and reconciliation
 
-- [ ] Add cursor-based `IndexSource::scan` and targeted `load`.
+- [x] Add cursor-based `IndexSource::scan` and targeted `load` contracts.
+- [x] Bound cursor bytes, scan pages, targeted key counts, tenant/schema scope, uniqueness,
+      and continuation progress; never collect all IDs first.
 - [ ] Add durable jobs, checkpoints, leases, heartbeat, and ownership.
-- [ ] Add bounded streaming; never collect all IDs first.
+- [ ] Add a bounded worker that applies pages through `PostgresMutationStore` and commits
+      checkpoints only after durable mutation results.
 - [ ] Add cancellation, resume, dry-run, targeted/full/shadow rebuild.
 - [ ] Add reconciliation and drift repair.
-- [ ] Cover crash, lease expiry, restart, cancellation, and incremental/full
-      equivalence.
+- [ ] Cover crash, lease expiry, restart, cancellation, and incremental/full equivalence.
+
+No durable job runner, checkpoint writer, scheduler, or production replay command is claimed
+by the source-complete contract. The existing `index_jobs` and `index_checkpoints` tables are
+reserved persistence foundations until a fenced worker owns their state transitions.
 
 ### M7 - First vertical slice
 
 Entities: Product, ProductVariant, SalesChannel.
 
-- [ ] Register owner-published schemas and links.
-- [ ] Implement mutations and rebuild sources.
-- [ ] Support tenant, locale, status, projection, link filters, sorting, and cursor
-      pagination.
+- [ ] Register owner-published schemas, links, and bounded source adapters.
+- [ ] Implement incremental mutations and rebuild sources.
+- [ ] Support tenant, locale, status, projection, link filters, sorting, and cursor pagination.
 - [ ] Move one Storefront query to Index.
 - [ ] Prove no source-module filtering fan-out.
 
 ### M8 - Commerce scale slice
 
-- [ ] Add Pricing, Inventory, Category, Collection, Tags, Region/Currency, and
-      Marketplace Seller schemas/sources.
+- [ ] Add Pricing, Inventory, Category, Collection, Tags, Region/Currency, and Marketplace
+      Seller schemas/sources.
 - [ ] Filter by price, stock, category, channel, and seller in one query.
 - [ ] Add cardinality and load benchmarks.
 
@@ -424,109 +313,58 @@ Entities: Product, ProductVariant, SalesChannel.
 
 ### M11 - Admin and cutover
 
-- [ ] Expose schema, partition, lag, inbox, failure, rebuild, drift, and query
-      diagnostics.
+- [ ] Expose schema, partition, lag, inbox, failure, rebuild, drift, and query diagnostics.
 - [ ] Add rebuild/cancel/retry commands.
 - [ ] Publish new FBA contracts and runtime evidence.
 - [ ] Migrate consumers and delete final compatibility code.
 - [ ] Promote FBA only after compiled/live evidence.
 
-## Verification
+## Verification handoff
+
+The owner runs formatting, Cargo checks/tests, PostgreSQL fixtures, evidence capture,
+admission, and CI. Targeted source guards include:
 
 ```bash
-cargo fmt --all -- --check
-cargo check --workspace --all-targets --all-features
-cargo clippy --workspace --all-targets --all-features -- -D warnings
-cargo nextest run --workspace --all-targets --all-features
-cargo test --workspace --doc --all-features
-cargo test -p rustok-index planner_tests -- --nocapture
-cargo test -p rustok-index postgres_compiler_tests -- --nocapture
-cargo test -p rustok-index postgres_query_result_tests -- --nocapture
+node scripts/verify/verify-index-fba.mjs
+node scripts/verify/verify-index-query-contract.mjs
+node scripts/verify/verify-index-source-replay-contract.mjs
+node scripts/verify/verify-index-query-snapshots.mjs
+node scripts/verify/verify-index-many-link-aggregate-ordering.mjs
+node scripts/verify/verify-index-decimal-aggregate-wire.mjs
+node scripts/verify/verify-index-source-schema-registry.mjs
+node scripts/verify/verify-index-query-runtime-composition.mjs
+node scripts/verify/verify-index-social-graph-privacy-consumer.mjs
 cargo xtask module validate index
-cargo xtask module test index
-npm run verify:index:fba
-npm run verify:index:runtime-fallback-smoke
-node scripts/verify/index-storage-tooling.mjs contract
-node scripts/verify/index-storage-tooling.mjs fixtures
-node --test scripts/verify/index-partition-evidence.test.mjs
-node --test scripts/verify/index-partition-evidence-assembly.test.mjs
-cargo check -p rustok-benchmarks --bin index-partition-snapshot-capture
-cargo test -p rustok-benchmarks partition_snapshot
-cargo check -p rustok-benchmarks --bin index-partition-query-evidence
-cargo test -p rustok-benchmarks partition_query
-cargo check -p rustok-benchmarks --bin index-partition-mutation-evidence
-cargo test -p rustok-benchmarks partition_mutation
-cargo check -p rustok-benchmarks --bin index-partition-maintenance-evidence
-cargo test -p rustok-benchmarks partition_maintenance
-cargo check -p rustok-benchmarks --bin index-partition-cutover-evidence
-cargo test -p rustok-benchmarks partition_cutover
-cargo check -p rustok-benchmarks --bin index-partition-capture-finalize
-```
-
-Targeted M3/M4 guards:
-
-```bash
-node scripts/verify/verify-index-mutation-storage.mjs
-node scripts/verify/verify-index-schema-leases.mjs
-node scripts/verify/verify-index-secondary-index-lifecycle.mjs
-node scripts/verify/verify-index-partition-admission.mjs
-node scripts/verify/verify-index-partition-evidence.mjs
-node scripts/verify/verify-index-partition-snapshot-capture.mjs
-node scripts/verify/verify-index-partition-query-evidence.mjs
-node scripts/verify/verify-index-partition-mutation-evidence.mjs
-node scripts/verify/verify-index-partition-maintenance-evidence.mjs
-node scripts/verify/verify-index-partition-cutover-evidence.mjs
-node scripts/verify/verify-index-partition-full-capture.mjs
-node scripts/verify/verify-index-partition-post-inspection-drift.mjs
-node scripts/verify/verify-index-query-planner.mjs
-node scripts/verify/verify-index-postgres-query-compiler.mjs
-node scripts/verify/verify-index-query-result-decoder.mjs
-node scripts/verify/verify-index-many-link-filtering.mjs
 ```
 
 ## Progress log
 
-- 2026-07-23: completed the destructive reset and generic M1 core.
-- 2026-07-24 through 2026-07-27: completed M2 comparison, archived replacement
-  evidence, accepted JSONB, and removed rejected prototypes.
-- 2026-07-27: completed canonical M3 schema, atomic mutation persistence, schema
-  leases, secondary-index lifecycle, partition admission/planning, immutable packet
-  tooling, exact-byte assembly, baseline/shadow snapshot capture, query evidence
-  capture, rollback-only mutation/WAL evidence capture, and isolated ordinary-VACUUM
-  maintenance evidence capture.
-- 2026-07-28: completed rollback-only cutover rehearsal evidence, full retained packet
-  owner orchestration with PostgreSQL identity-bound capture finalization, read-only
-  retained bundle review, admitted archive manifest generation, saved-manifest
-  verification receipts, and exact recursive filesystem snapshot enforcement.
-- 2026-07-29: rechecked the merged M3 source boundary, completed deterministic typed
-  M4 planning, controlled projection SQL, root/one-link filters, ordering, separate
-  exact count, validated lexicographic keyset continuation, bounded offset
-  compatibility, one-row page lookahead, deterministic tagged-row decoding, exact
-  count decoding, relation identity reconstruction, scoped next-cursor creation,
-  correlated many-link `EXISTS` filtering with duplicate-free root count/pagination,
-  deterministic nested many-link projection aggregation with aligned identity/value
-  decoding, and PostgreSQL `IndexQueryPort` source with exact persisted-schema
-  preflight, one repeatable-read page/count snapshot, exhaustive bind conversion, and
-  compiler-metadata-driven row adaptation. Server/consumer composition, plan/SQL
-  snapshots, live PostgreSQL execution, and PostgreSQL/reference equivalence remain
-  open.
-- 2026-07-30: bounded the non-authoritative Social Graph privacy shadow by the caller's
-  remaining deadline and repaired stale Index repository/evidence guards and retained
-  fixtures. No authoritative cutover, replay entrypoint, or live PostgreSQL evidence is
-  claimed by this change.
-- Repository test/fixture suites, verifiers, and one real full PostgreSQL partition
-  packet remain for the owner to execute and admit before production partition
-  lifecycle work begins.
+- 2026-07-23 through 2026-07-28: completed the destructive reset, M1 domain core,
+  selected-layout M2 evidence, and source-complete M3 storage/evidence tooling.
+- 2026-07-29: completed typed M4 planning, controlled SQL, filters, projection,
+  pagination, strict decoding, PostgreSQL query-port source, retained v4 snapshots,
+  source-owned schema publication, shared query-runtime composition, and the first
+  default-off owner-authoritative Social Graph privacy parity shadow.
+- 2026-07-30: completed explicit many-link MIN/MAX aggregate ordering for integer,
+  string, timestamp, and Decimal terminals; locked Decimal aggregate order values to the
+  exact tagged string wire; retained metrics/two-snapshot shadow evidence tooling; and
+  bounded each non-authoritative comparison by the caller's remaining deadline.
+- 2026-07-30: added the neutral bounded replay source registry, opaque JSON cursor and
+  scan/load contracts, exact schema-owner materialization, tenant/schema/result bounds,
+  continuation-progress checks, and retryable/permanent source failure classification.
+- Repository test/fixture suites, the durable replay worker, live freshness/recovery
+  evidence, authoritative cutover, PostgreSQL/reference equivalence, and one real full
+  PostgreSQL partition packet remain owner-executed gates.
 
 ## Periodic release verification handoff
 
 - Cycle: `cycle-001`
 - Status: `blocked`
 - Last verified at (UTC): `2026-07-30`
-- Scope inspected: `Index ownership, migrations, mutation/version ordering, query execution, partition evidence guards, Social Graph consumer authority, privacy shadow deadline behavior, and source/search/server boundaries`
+- Scope inspected: `Index ownership, migrations, mutation/version ordering, query execution, partition evidence guards, Social Graph consumer authority, privacy shadow deadline behavior, source replay ownership, and source/search/server boundaries`
 - Findings: `P0=0, P1=2, P2=0, P3=1`
-- Fixed in this pass: `bounded the non-authoritative Social Graph privacy comparison by the remaining caller deadline while preserving the owner result; repaired stale Index scale/FBA and retained-artifact guards so current accepted M2/M4 contracts execute again`
-- Remaining risks or blockers: `one retained admitted real PostgreSQL partition packet is absent; live PostgreSQL/reference query equivalence remains open; no retained per-tenant freshness/watermark, lag, negative-result safety, outage/restart/backlog catch-up, or replay-repair evidence exists; consumer and production partition cutover remain forbidden`
-- Evidence: `PR #2544 merged as b647a5a17f27b34a07c20cd57525ed1806994c49; same-SHA Index Storage Scale Run Contract and full Scale Evidence contract passed JavaScript syntax, workflow contracts, repository contracts, direct validator arguments and fixture suites; general CI/Hardening received no jobs; Rust-hosted smoke stopped before compilation because Cargo.lock required an Athanor update under --locked`
-- Next action: `execute the retained PostgreSQL packet, live query equivalence and per-tenant freshness/outage/recovery evidence; add a canonical bounded replay/rebuild owner path before reconsidering authoritative consumers or partition lifecycle`
-- Resume command: `cargo fmt --all -- --check && cargo check -p rustok-social-graph --all-targets --all-features && node scripts/verify/verify-index-query-contract.mjs && node scripts/verify/index-storage-tooling.mjs contract && node scripts/verify/index-storage-tooling.mjs fixtures`
+- Fixed in this pass: `bounded the non-authoritative Social Graph privacy comparison by the remaining caller deadline; repaired stale Index scale/FBA guards; added a canonical bounded source replay/load registry with strict schema ownership, request/result bounds, continuation progress, and retryable/permanent failure classification`
+- Remaining risks or blockers: `one retained admitted real PostgreSQL partition packet is absent; live PostgreSQL/reference query equivalence remains open; the new source contract has no fenced durable job/checkpoint worker; no retained per-tenant freshness/watermark, lag, negative-result safety, outage/restart/backlog catch-up, or replay-repair evidence exists; consumer and production partition cutover remain forbidden`
+- Evidence: `PR #2544 merged as b647a5a17f27b34a07c20cd57525ed1806994c49; same-SHA Index Storage Scale Run Contract and full Scale Evidence contract passed JavaScript syntax, workflow contracts, repository contracts, direct validator arguments and fixture suites; source replay contract added in the current draft PR without implementation-agent test execution; general CI/Hardening received no jobs; Rust-hosted smoke previously stopped before compilation because Cargo.lock required an Athanor update under --locked`
+- Next action: `implement fenced durable rebuild jobs/checkpoints and the first Product source adapter, then execute retained PostgreSQL packet, live query equivalence, and per-tenant freshness/outage/recovery evidence before reconsidering authoritative consumers or partition lifecycle`
+- Resume command: `cargo fmt --all -- --check && cargo check -p rustok-index --all-targets && node scripts/verify/verify-index-query-contract.mjs && node scripts/verify/index-storage-tooling.mjs contract && node scripts/verify/index-storage-tooling.mjs fixtures`

--- a/crates/rustok-index/docs/m5-m6-source-replay-contract.md
+++ b/crates/rustok-index/docs/m5-m6-source-replay-contract.md
@@ -1,0 +1,83 @@
+# M5/M6 bounded source replay contract
+
+This slice establishes the source-owned read boundary used by future incremental ingestion,
+rebuild, reconciliation, and repair workers. It does not create or claim a durable worker,
+checkpoint writer, scheduler, replay command, or production consumer cutover.
+
+## Ownership
+
+- Source modules own normalized state and implement `IndexSource`.
+- Index owns source registration, schema/source ownership validation, request bounds,
+  continuation safety, returned-mutation scope validation, persistence, checkpoints, jobs,
+  leases, retry policy, and operator controls.
+- Index core never imports source-domain crates and never reads source tables directly.
+
+## Registration
+
+`IndexSourceCatalog` is seeded beside `IndexSchemaSourceCatalog` during module runtime
+registration. A source module registers:
+
+- one bounded lowercase owner module slug;
+- one unique bounded source name;
+- one or more exact `SchemaRef` values;
+- one `IndexSource` implementation.
+
+One exact schema and one complete `(module, entity)` identity cannot move between replay
+sources across versions. Materialization checks every replay schema against the source-owned
+schema catalog and rejects missing schemas or owner drift. An absent or empty source catalog
+materializes to `None`; merely publishing a schema does not falsely claim rebuild readiness.
+
+## Cursor-based scan
+
+`IndexSource::scan` receives `IndexSourceScanRequest` with one non-nil tenant, one exact schema,
+an optional opaque JSON cursor, and a limit from 1 through 1000. Cursor JSON is non-null and at
+most 8 KiB when encoded.
+
+`IndexSourcePage` is accepted only when:
+
+- the mutation count does not exceed the requested limit;
+- every mutation stays in the requested tenant and exact schema;
+- entity keys are unique within the page;
+- an empty page does not advertise continuation;
+- a continuation cursor differs from the request cursor.
+
+`None` means the scan is complete. The contract therefore supports bounded streaming without
+collecting every source ID before work begins.
+
+## Targeted load
+
+`IndexSource::load` receives one to 256 unique `EntityKey` values from exactly one non-nil
+tenant and exact schema. A returned mutation must correspond to one requested key, and each key
+may appear at most once. Missing keys are permitted so deletion or authorization-safe absence
+can be represented by the owner adapter's chosen mutation semantics without widening the
+requested scope.
+
+## Failures
+
+Source adapters expose only a bounded machine-readable code and classify it as `Retryable` or
+`Permanent`. Raw database, transport, or source-domain errors must remain in owner logs and must
+not cross this neutral contract.
+
+The future durable worker will map retryable failures to bounded backoff and permanent failures
+to durable terminal state. This slice deliberately does not define that policy yet.
+
+## Still open
+
+- mutation-source event registry and broker acknowledgement orchestration;
+- batch persistence across source pages;
+- durable `index_jobs` / `index_checkpoints` ownership, fencing, heartbeat, cancellation, and
+  resume;
+- dry-run, targeted/full/shadow rebuild commands;
+- reconciliation, drift repair, retained freshness/outage/recovery evidence, and incremental /
+  rebuild equivalence;
+- source adapters for Product and later vertical slices.
+
+## Owner validation
+
+```bash
+node scripts/verify/verify-index-source-replay-contract.mjs
+cargo check -p rustok-index --all-targets
+cargo test -p rustok-index source_registry --lib -- --nocapture
+```
+
+These commands remain maintainer-run for this slice.

--- a/crates/rustok-index/docs/m5-m6-source-replay-contract.md
+++ b/crates/rustok-index/docs/m5-m6-source-replay-contract.md
@@ -1,15 +1,16 @@
 # M5/M6 bounded source replay contract
 
-This slice establishes the source-owned read boundary used by future incremental ingestion,
-rebuild, reconciliation, and repair workers. It does not create or claim a durable worker,
-checkpoint writer, scheduler, replay command, or production consumer cutover.
+This slice establishes the source-owned read boundary used by incremental ingestion,
+rebuild, reconciliation, and repair workers. It also adds one bounded replay-page
+executor and PostgreSQL checkpoint adapter. It does not claim fenced job ownership,
+a scheduler, a long-running replay command, or production consumer cutover.
 
 ## Ownership
 
 - Source modules own normalized state and implement `IndexSource`.
 - Index owns source registration, schema/source ownership validation, request bounds,
-  continuation safety, returned-mutation scope validation, persistence, checkpoints, jobs,
-  leases, retry policy, and operator controls.
+  continuation safety, returned-mutation scope validation, persistence, checkpoints,
+  jobs, leases, retry policy, and operator controls.
 - Index core never imports source-domain crates and never reads source tables directly.
 
 ## Registration
@@ -23,15 +24,16 @@ registration. A source module registers:
 - one `IndexSource` implementation.
 
 One exact schema and one complete `(module, entity)` identity cannot move between replay
-sources across versions. Materialization checks every replay schema against the source-owned
-schema catalog and rejects missing schemas or owner drift. An absent or empty source catalog
-materializes to `None`; merely publishing a schema does not falsely claim rebuild readiness.
+sources across versions. Materialization checks every replay schema against the
+source-owned schema catalog and rejects missing schemas or owner drift. An absent or
+empty source catalog materializes to `None`; merely publishing a schema does not falsely
+claim rebuild readiness.
 
 ## Cursor-based scan
 
-`IndexSource::scan` receives `IndexSourceScanRequest` with one non-nil tenant, one exact schema,
-an optional opaque JSON cursor, and a limit from 1 through 1000. Cursor JSON is non-null and at
-most 8 KiB when encoded.
+`IndexSource::scan` receives `IndexSourceScanRequest` with one non-nil tenant, one exact
+schema, an optional opaque JSON cursor, and a limit from 1 through 1000. Cursor JSON is
+non-null and at most 8 KiB when encoded.
 
 `IndexSourcePage` is accepted only when:
 
@@ -41,35 +43,59 @@ most 8 KiB when encoded.
 - an empty page does not advertise continuation;
 - a continuation cursor differs from the request cursor.
 
-`None` means the scan is complete. The contract therefore supports bounded streaming without
-collecting every source ID before work begins.
+`None` means the scan is complete. The contract therefore supports bounded streaming
+without collecting every source ID before work begins.
 
 ## Targeted load
 
-`IndexSource::load` receives one to 256 unique `EntityKey` values from exactly one non-nil
-tenant and exact schema. A returned mutation must correspond to one requested key, and each key
-may appear at most once. Missing keys are permitted so deletion or authorization-safe absence
-can be represented by the owner adapter's chosen mutation semantics without widening the
-requested scope.
+`IndexSource::load` receives one to 256 unique `EntityKey` values from exactly one
+non-nil tenant and exact schema. A returned mutation must correspond to one requested
+key, and each key may appear at most once. Missing keys are permitted so deletion or
+authorization-safe absence can be represented by the owner adapter's chosen mutation
+semantics without widening the requested scope.
+
+## One-page replay progression
+
+`IndexReplayWorker::run_next_page` executes exactly one bounded source page:
+
+1. Resolve the registered source for the exact schema.
+2. Read the durable rebuild checkpoint identified by tenant, source, schema, and bounded
+   partition key.
+3. Return `AlreadyComplete` without calling the source when the stored cursor is complete.
+4. Scan from the stored opaque cursor.
+5. Apply mutations sequentially through `PostgresMutationStore`, using each mutation
+   event UUID as the stable delivery ID.
+6. Commit the next cursor only after every mutation result is durable.
+
+Applied, duplicate, and stale mutation outcomes are counted separately. A failure after
+one or more mutation commits but before checkpoint commit does not lose progress safety:
+the page is retried from the previous cursor and the existing inbox identity makes the
+same event deliveries idempotent.
+
+`PostgresIndexReplayCheckpointStore` writes the existing `index_checkpoints` rebuild
+row. JSON `null` represents a completed cursor. Empty final pages preserve the last
+stored source version and delivery ID through `COALESCE`, while still marking the cursor
+complete. This adapter does not claim a job lease or global worker owner.
 
 ## Failures
 
-Source adapters expose only a bounded machine-readable code and classify it as `Retryable` or
-`Permanent`. Raw database, transport, or source-domain errors must remain in owner logs and must
-not cross this neutral contract.
+Source adapters and replay dependencies expose only a bounded machine-readable code and
+classify it as `Retryable` or `Permanent`. Raw database, transport, or source-domain
+errors remain in owner logs and do not cross the neutral contract.
 
-The future durable worker will map retryable failures to bounded backoff and permanent failures
-to durable terminal state. This slice deliberately does not define that policy yet.
+Mutation validation/delivery rejection is permanent. Transient storage, concurrent
+mutation, inbox-completion, and checkpoint I/O failures are retryable. The future fenced
+job worker will map retryable failures to bounded backoff and permanent failures to
+durable terminal state; this slice does not define that scheduling policy.
 
 ## Still open
 
 - mutation-source event registry and broker acknowledgement orchestration;
-- batch persistence across source pages;
-- durable `index_jobs` / `index_checkpoints` ownership, fencing, heartbeat, cancellation, and
-  resume;
-- dry-run, targeted/full/shadow rebuild commands;
-- reconciliation, drift repair, retained freshness/outage/recovery evidence, and incremental /
-  rebuild equivalence;
+- fenced `index_jobs` claims, leases, heartbeat, cancellation, and global ownership;
+- a bounded multi-page loop, resume command, dry-run, targeted/full/shadow modes, and
+  retry/dead-letter scheduling;
+- reconciliation, drift repair, retained freshness/outage/recovery evidence, and
+  incremental/rebuild equivalence;
 - source adapters for Product and later vertical slices.
 
 ## Owner validation
@@ -78,6 +104,7 @@ to durable terminal state. This slice deliberately does not define that policy y
 node scripts/verify/verify-index-source-replay-contract.mjs
 cargo check -p rustok-index --all-targets
 cargo test -p rustok-index source_registry --lib -- --nocapture
+cargo test -p rustok-index source_replay --lib -- --nocapture
 ```
 
 These commands remain maintainer-run for this slice.

--- a/crates/rustok-index/docs/m5-m6-source-replay-contract.md
+++ b/crates/rustok-index/docs/m5-m6-source-replay-contract.md
@@ -2,8 +2,9 @@
 
 This slice establishes the source-owned read boundary used by incremental ingestion,
 rebuild, reconciliation, and repair workers. It also adds one bounded replay-page
-executor and PostgreSQL checkpoint adapter. It does not claim fenced job ownership,
-a scheduler, a long-running replay command, or production consumer cutover.
+executor, schema-scoped durable replay job claims, and a lease-bound PostgreSQL
+checkpoint adapter. It does not claim a scheduler, multi-page replay loop,
+cancellation command, or production consumer cutover.
 
 ## Ownership
 
@@ -82,12 +83,24 @@ The checkpoint source-version watermark is inherited from the stored row and adv
 with the maximum observed page version; a lower-version or empty final page cannot
 regress it. The last delivery ID is likewise retained for an empty final page.
 
-`PostgresIndexReplayCheckpointStore` writes the existing `index_checkpoints` rebuild
-row. JSON `null` represents a completed cursor. Empty final pages preserve the last
-stored source version and delivery ID through `COALESCE`, while still marking the cursor
-complete. The locale and partition storage dimensions remain the reserved empty values
-until a separately admitted locale/partition replay contract exists. This adapter does
-not claim a job lease or global worker owner.
+## Fenced job and checkpoint ownership
+
+`PostgresIndexReplayJobStore` owns one exact tenant/source/schema rebuild job. It
+validates the `index_replay_job_v1` request, requires an active persisted schema,
+serializes acquisition with a PostgreSQL advisory lock, heartbeats an unexpired lease,
+and reclaims expired attempts with an incremented attempt fence.
+
+`PostgresIndexReplayCheckpointStore` is constructed from the acquired
+`IndexReplayJobLease`. Before each checkpoint read or write it validates and locks the
+exact `(job_id, worker_id, attempt_count)`. Another tenant, source, or schema is rejected
+before opening the transaction. A stale worker may complete an already-started
+idempotent mutation write, but it cannot advance the durable cursor.
+
+The checkpoint row uses JSON `null` for completion. Locale and partition dimensions
+remain reserved empty values until separately admitted contracts exist. A replay job
+can enter `succeeded` only while its lease remains active and its exact durable rebuild
+checkpoint exists with a null cursor. See
+[`m6-replay-job-leases.md`](./m6-replay-job-leases.md) for the full fencing boundary.
 
 ## Failures
 
@@ -96,16 +109,18 @@ classify it as `Retryable` or `Permanent`. Raw database, transport, or source-do
 errors remain in owner logs and do not cross the neutral contract.
 
 Mutation validation/delivery rejection is permanent. Transient storage, concurrent
-mutation, inbox-completion, and checkpoint I/O failures are retryable. The future fenced
-job worker will map retryable failures to bounded backoff and permanent failures to
-durable terminal state; this slice does not define that scheduling policy.
+mutation, inbox-completion, and checkpoint I/O failures are retryable. Lease loss is
+terminal for the current attempt. A future bounded multi-page runner will map retryable
+failures to bounded backoff and permanent failures to durable terminal state; this
+slice does not define that scheduling policy.
 
 ## Still open
 
 - mutation-source event registry and broker acknowledgement orchestration;
-- fenced `index_jobs` claims, leases, heartbeat, cancellation, and global ownership;
-- a bounded multi-page loop, resume command, dry-run, targeted/full/shadow modes, and
-  retry/dead-letter scheduling;
+- binding replay job requests directly to the materialized source registry in server
+  composition;
+- a bounded multi-page loop, heartbeat cadence, graceful lease loss, cancellation,
+  resume command, dry-run, targeted/full/shadow modes, and retry/dead-letter scheduling;
 - locale/partition replay checkpoint dimensions;
 - reconciliation, drift repair, retained freshness/outage/recovery evidence, and
   incremental/rebuild equivalence;
@@ -115,9 +130,11 @@ durable terminal state; this slice does not define that scheduling policy.
 
 ```bash
 node scripts/verify/verify-index-source-replay-contract.mjs
+node scripts/verify/verify-index-replay-job-leases.mjs
 cargo check -p rustok-index --all-targets
 cargo test -p rustok-index source_registry --lib -- --nocapture
 cargo test -p rustok-index source_replay --lib -- --nocapture
+cargo test -p rustok-index source_replay_job --lib -- --nocapture
 ```
 
 These commands remain maintainer-run for this slice.

--- a/crates/rustok-index/docs/m5-m6-source-replay-contract.md
+++ b/crates/rustok-index/docs/m5-m6-source-replay-contract.md
@@ -60,12 +60,14 @@ semantics without widening the requested scope.
 
 1. Resolve the registered source for the exact schema.
 2. Read the durable rebuild checkpoint identified by tenant, source, and exact schema.
-3. Return `AlreadyComplete` without calling the source when the stored cursor is complete.
-4. Scan from the stored opaque cursor.
-5. Reject nil or duplicate event UUIDs before persistence.
-6. Apply mutations sequentially through `PostgresMutationStore`, using each mutation
+3. Fail closed if the checkpoint store returns another replay identity.
+4. Return `AlreadyComplete` without calling the source when the stored cursor is complete.
+5. Scan from the stored opaque cursor.
+6. Validate every page event UUID before the first mutation write; nil or duplicate IDs
+   reject the whole page.
+7. Apply mutations sequentially through `PostgresMutationStore`, using each mutation
    event UUID as the stable delivery ID.
-7. Commit the next cursor only after every mutation result is durable.
+8. Commit the next cursor only after every mutation result is durable.
 
 A source adapter must return the same non-nil event UUID for the same logical entity
 mutation and source version whenever a page is retried. This makes the replay delivery
@@ -75,6 +77,10 @@ Applied, duplicate, and stale mutation outcomes are counted separately. A failur
 one or more mutation commits but before checkpoint commit does not lose progress safety:
 the page is retried from the previous cursor and the existing inbox identity makes the
 same stable event deliveries idempotent.
+
+The checkpoint source-version watermark is inherited from the stored row and advanced
+with the maximum observed page version; a lower-version or empty final page cannot
+regress it. The last delivery ID is likewise retained for an empty final page.
 
 `PostgresIndexReplayCheckpointStore` writes the existing `index_checkpoints` rebuild
 row. JSON `null` represents a completed cursor. Empty final pages preserve the last

--- a/crates/rustok-index/docs/m5-m6-source-replay-contract.md
+++ b/crates/rustok-index/docs/m5-m6-source-replay-contract.md
@@ -59,23 +59,29 @@ semantics without widening the requested scope.
 `IndexReplayWorker::run_next_page` executes exactly one bounded source page:
 
 1. Resolve the registered source for the exact schema.
-2. Read the durable rebuild checkpoint identified by tenant, source, schema, and bounded
-   partition key.
+2. Read the durable rebuild checkpoint identified by tenant, source, and exact schema.
 3. Return `AlreadyComplete` without calling the source when the stored cursor is complete.
 4. Scan from the stored opaque cursor.
-5. Apply mutations sequentially through `PostgresMutationStore`, using each mutation
+5. Reject nil or duplicate event UUIDs before persistence.
+6. Apply mutations sequentially through `PostgresMutationStore`, using each mutation
    event UUID as the stable delivery ID.
-6. Commit the next cursor only after every mutation result is durable.
+7. Commit the next cursor only after every mutation result is durable.
+
+A source adapter must return the same non-nil event UUID for the same logical entity
+mutation and source version whenever a page is retried. This makes the replay delivery
+identity stable without importing source-domain identifiers into Index core.
 
 Applied, duplicate, and stale mutation outcomes are counted separately. A failure after
 one or more mutation commits but before checkpoint commit does not lose progress safety:
 the page is retried from the previous cursor and the existing inbox identity makes the
-same event deliveries idempotent.
+same stable event deliveries idempotent.
 
 `PostgresIndexReplayCheckpointStore` writes the existing `index_checkpoints` rebuild
 row. JSON `null` represents a completed cursor. Empty final pages preserve the last
 stored source version and delivery ID through `COALESCE`, while still marking the cursor
-complete. This adapter does not claim a job lease or global worker owner.
+complete. The locale and partition storage dimensions remain the reserved empty values
+until a separately admitted locale/partition replay contract exists. This adapter does
+not claim a job lease or global worker owner.
 
 ## Failures
 
@@ -94,6 +100,7 @@ durable terminal state; this slice does not define that scheduling policy.
 - fenced `index_jobs` claims, leases, heartbeat, cancellation, and global ownership;
 - a bounded multi-page loop, resume command, dry-run, targeted/full/shadow modes, and
   retry/dead-letter scheduling;
+- locale/partition replay checkpoint dimensions;
 - reconciliation, drift repair, retained freshness/outage/recovery evidence, and
   incremental/rebuild equivalence;
 - source adapters for Product and later vertical slices.

--- a/crates/rustok-index/docs/m6-replay-job-leases.md
+++ b/crates/rustok-index/docs/m6-replay-job-leases.md
@@ -23,9 +23,14 @@ The persisted schema must exist and remain active before a job can be acquired.
 
 ## Claim and fencing
 
-Acquisition serializes the tenant/source/schema scope with a PostgreSQL transaction
-advisory lock. A pending job becomes claimable after `available_at`; a running job
-becomes reclaimable after `lease_expires_at`. Reclaim increments `attempt_count`.
+Acquisition serializes the complete tenant/exact-schema scope with a PostgreSQL
+transaction advisory lock before validating the stored source owner. The lock is
+intentionally broader than the request source name: two concurrent requests that claim
+different source names for the same schema cannot create parallel jobs. Once serialized,
+a source mismatch fails closed.
+
+A pending job becomes claimable after `available_at`; a running job becomes reclaimable
+after `lease_expires_at`. Reclaim increments `attempt_count`.
 
 Every heartbeat and terminal update matches all of:
 

--- a/crates/rustok-index/docs/m6-replay-job-leases.md
+++ b/crates/rustok-index/docs/m6-replay-job-leases.md
@@ -1,0 +1,88 @@
+# M6 fenced replay job leases
+
+Status: `source_complete_owner_execution_pending`
+
+This slice adds durable ownership for one schema-scoped rebuild job. It does not add a
+scheduler, multi-page loop, cancellation command, backoff policy, or production source
+adapter.
+
+## Job identity
+
+`PostgresIndexReplayJobStore` owns `index_jobs` rows with:
+
+- `kind = 'rebuild'`;
+- `scope_kind = 'schema'`;
+- one tenant and exact `SchemaRef`;
+- the exact `index_replay_job_v1` request contract;
+- one bounded source name and worker identity.
+
+The source name remains part of the request payload because the canonical `index_jobs`
+scope columns describe the schema, while replay ownership is fixed by
+`IndexSourceCatalog`. A stored row with another source or request shape fails closed.
+The persisted schema must exist and remain active before a job can be acquired.
+
+## Claim and fencing
+
+Acquisition serializes the tenant/source/schema scope with a PostgreSQL transaction
+advisory lock. A pending job becomes claimable after `available_at`; a running job
+becomes reclaimable after `lease_expires_at`. Reclaim increments `attempt_count`.
+
+Every heartbeat and terminal update matches all of:
+
+- tenant and job UUID;
+- `kind = 'rebuild'` and `state = 'running'`;
+- lease owner;
+- attempt count;
+- an unexpired lease.
+
+An expired attempt therefore cannot heartbeat, fail, or complete after a newer worker
+has reclaimed the same job.
+
+## Fenced checkpoint progression
+
+`PostgresIndexReplayCheckpointStore` is constructed from an acquired
+`IndexReplayJobLease`. It rejects another tenant, source, or schema before opening a
+transaction. Both checkpoint reads and writes lock and validate the active replay job
+attempt before accessing `index_checkpoints`.
+
+Checkpoint writes use the order:
+
+1. lock and validate the current `(job_id, worker_id, attempt_count)`;
+2. upsert the exact rebuild checkpoint;
+3. commit the transaction.
+
+A stale worker may still finish an already-started idempotent mutation transaction, but
+it cannot advance the durable cursor. The existing inbox delivery identity and
+monotonic source-version rules make such mutation replay safe.
+
+## Terminal success
+
+A replay job can enter `succeeded` only while its lease is active and the durable exact
+checkpoint exists with a JSON `null` cursor. Missing or continuing checkpoints are
+rejected. Job completion and checkpoint validation use one transaction and lock job
+then checkpoint in the same order as checkpoint progression.
+
+A failed terminal job remains retained as evidence and permits a later acquisition to
+create a new job UUID. Retry timing and dead-letter policy remain outside this slice.
+
+## Still open
+
+- binding job acquisition directly to the materialized source registry in server
+  composition;
+- a bounded multi-page runner with heartbeat cadence and graceful lease loss;
+- cancellation observation and terminal cancellation;
+- bounded retry/backoff and dead-letter policy;
+- locale and partition checkpoint dimensions;
+- Product and later source adapters;
+- retained PostgreSQL crash/reclaim/restart evidence and multi-instance tests.
+
+## Owner validation
+
+```bash
+node scripts/verify/verify-index-replay-job-leases.mjs
+node scripts/verify/verify-index-source-replay-contract.mjs
+cargo check -p rustok-index --all-targets
+cargo test -p rustok-index source_replay_job --lib -- --nocapture
+```
+
+These commands are maintainer-run for this slice.

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -26,6 +26,8 @@ mod postgres_query_result_tests;
 mod query_snapshot_tests;
 #[cfg(test)]
 mod reference;
+#[cfg(test)]
+mod source_replay_tests;
 
 pub use aggregate_ordering::AggregateOrderValidationError;
 pub use cursor::{CursorCodec, CursorCodecError, CursorValidationError, IndexCursor};

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -8,6 +8,7 @@ mod query_port;
 mod query_runtime;
 mod registry;
 mod source_registry;
+mod source_replay;
 mod source_schema_registry;
 mod validation;
 
@@ -55,6 +56,12 @@ pub use source_registry::{
     IndexSourceFailure, IndexSourceFailureKind, IndexSourceLoadBatch, IndexSourceLoadRequest,
     IndexSourcePage, IndexSourceScanRequest, SharedIndexSourceRegistry,
     materialize_index_source_registry, register_index_source,
+};
+pub use source_replay::{
+    IndexReplayCheckpoint, IndexReplayCheckpointKey, IndexReplayCheckpointStore, IndexReplayError,
+    IndexReplayFailure, IndexReplayFailureKind, IndexReplayMutationOutcome,
+    IndexReplayMutationSink, IndexReplayPageOutcome, IndexReplayPageRequest,
+    IndexReplayPageStatus, IndexReplayWorker,
 };
 pub use source_schema_registry::{
     IndexSchemaSourceCatalog, IndexSchemaSourceDescriptor, IndexSchemaSourceError,

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -7,6 +7,7 @@ mod postgres_query_sql;
 mod query_port;
 mod query_runtime;
 mod registry;
+mod source_registry;
 mod source_schema_registry;
 mod validation;
 
@@ -48,6 +49,12 @@ pub use query_port::{
 pub use query_runtime::SharedIndexQueryRuntime;
 pub use registry::{
     LinkPathStep, RegisteredSchema, RegistrationOutcome, SchemaRegistry, SchemaRegistryError,
+};
+pub use source_registry::{
+    IndexSource, IndexSourceCatalog, IndexSourceCursor, IndexSourceDescriptor, IndexSourceError,
+    IndexSourceFailure, IndexSourceFailureKind, IndexSourceLoadBatch, IndexSourceLoadRequest,
+    IndexSourcePage, IndexSourceScanRequest, SharedIndexSourceRegistry,
+    materialize_index_source_registry, register_index_source,
 };
 pub use source_schema_registry::{
     IndexSchemaSourceCatalog, IndexSchemaSourceDescriptor, IndexSchemaSourceError,

--- a/crates/rustok-index/src/application/source_registry.rs
+++ b/crates/rustok-index/src/application/source_registry.rs
@@ -6,7 +6,7 @@ use std::{
 
 use async_trait::async_trait;
 use rustok_core::ModuleRuntimeExtensions;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de::Error as _};
 use serde_json::Value as JsonValue;
 use thiserror::Error;
 use uuid::Uuid;
@@ -21,7 +21,11 @@ const MAX_SCAN_BATCH_SIZE: usize = 1_000;
 const MAX_LOAD_KEYS: usize = 256;
 const MAX_FAILURE_CODE_BYTES: usize = 128;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Opaque, source-owned continuation state with a stable JSON persistence boundary.
+///
+/// Construction and deserialization both reject JSON null and encoded values above
+/// 8 KiB so a durable worker cannot bypass the bound by restoring a checkpoint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(transparent)]
 pub struct IndexSourceCursor(JsonValue);
 
@@ -47,6 +51,16 @@ impl IndexSourceCursor {
 
     pub fn into_value(self) -> JsonValue {
         self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for IndexSourceCursor {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = JsonValue::deserialize(deserializer)?;
+        Self::new(value).map_err(D::Error::custom)
     }
 }
 
@@ -241,7 +255,7 @@ impl IndexSourceFailure {
         code: impl Into<String>,
     ) -> Result<Self, IndexSourceError> {
         let code = code.into();
-        if !valid_bounded_name(&code, MAX_FAILURE_CODE_BYTES) {
+        if !valid_machine_name(&code, MAX_FAILURE_CODE_BYTES) {
             return Err(IndexSourceError::InvalidFailureCode(code));
         }
         Ok(Self { kind, code })
@@ -368,10 +382,10 @@ impl IndexSourceCatalog {
     ) -> Result<(), IndexSourceError> {
         let owner_module = owner_module.into();
         let source_name = source_name.into();
-        if !valid_bounded_name(&owner_module, MAX_SOURCE_NAME_BYTES) {
+        if !valid_owner_module(&owner_module) {
             return Err(IndexSourceError::InvalidOwnerModule(owner_module));
         }
-        if !valid_bounded_name(&source_name, MAX_SOURCE_NAME_BYTES) {
+        if !valid_machine_name(&source_name, MAX_SOURCE_NAME_BYTES) {
             return Err(IndexSourceError::InvalidSourceName(source_name));
         }
         if self.sources.contains_key(&source_name) {
@@ -725,13 +739,22 @@ fn validate_load_batch(
     Ok(())
 }
 
-fn valid_bounded_name(value: &str, max_bytes: usize) -> bool {
+fn valid_owner_module(value: &str) -> bool {
+    valid_bounded_ascii(value, MAX_SOURCE_NAME_BYTES, false)
+}
+
+fn valid_machine_name(value: &str, max_bytes: usize) -> bool {
+    valid_bounded_ascii(value, max_bytes, true)
+}
+
+fn valid_bounded_ascii(value: &str, max_bytes: usize, allow_dot: bool) -> bool {
     !value.is_empty()
         && value.len() <= max_bytes
         && value.bytes().all(|byte| {
             byte.is_ascii_lowercase()
                 || byte.is_ascii_digit()
-                || matches!(byte, b'-' | b'_' | b'.')
+                || matches!(byte, b'-' | b'_')
+                || (allow_dot && byte == b'.')
         })
 }
 
@@ -828,9 +851,12 @@ mod tests {
     fn cursor_and_scan_limits_are_bounded() {
         assert!(IndexSourceCursor::new(JsonValue::Null).is_err());
         assert!(IndexSourceCursor::new(JsonValue::String("x".repeat(MAX_CURSOR_BYTES))).is_err());
-        assert!(
-            IndexSourceScanRequest::new(Uuid::new_v4(), schema_ref(1), None, 0).is_err()
-        );
+        assert!(serde_json::from_value::<IndexSourceCursor>(JsonValue::Null).is_err());
+        assert!(serde_json::from_value::<IndexSourceCursor>(JsonValue::String(
+            "x".repeat(MAX_CURSOR_BYTES)
+        ))
+        .is_err());
+        assert!(IndexSourceScanRequest::new(Uuid::new_v4(), schema_ref(1), None, 0).is_err());
         assert!(IndexSourceScanRequest::new(
             Uuid::new_v4(),
             schema_ref(1),

--- a/crates/rustok-index/src/application/source_registry.rs
+++ b/crates/rustok-index/src/application/source_registry.rs
@@ -1,0 +1,855 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use rustok_core::ModuleRuntimeExtensions;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::domain::{EntityKey, IndexMutation, SchemaIdentity, SchemaRef};
+
+use super::IndexSchemaSourceCatalog;
+
+const MAX_SOURCE_NAME_BYTES: usize = 128;
+const MAX_CURSOR_BYTES: usize = 8 * 1024;
+const MAX_SCAN_BATCH_SIZE: usize = 1_000;
+const MAX_LOAD_KEYS: usize = 256;
+const MAX_FAILURE_CODE_BYTES: usize = 128;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct IndexSourceCursor(JsonValue);
+
+impl IndexSourceCursor {
+    pub fn new(value: JsonValue) -> Result<Self, IndexSourceError> {
+        if value.is_null() {
+            return Err(IndexSourceError::NullCursor);
+        }
+        let encoded = serde_json::to_vec(&value)
+            .map_err(|_| IndexSourceError::CursorSerializationFailed)?;
+        if encoded.len() > MAX_CURSOR_BYTES {
+            return Err(IndexSourceError::CursorTooLarge {
+                actual: encoded.len(),
+                max: MAX_CURSOR_BYTES,
+            });
+        }
+        Ok(Self(value))
+    }
+
+    pub fn value(&self) -> &JsonValue {
+        &self.0
+    }
+
+    pub fn into_value(self) -> JsonValue {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexSourceScanRequest {
+    tenant_id: Uuid,
+    schema: SchemaRef,
+    cursor: Option<IndexSourceCursor>,
+    limit: usize,
+}
+
+impl IndexSourceScanRequest {
+    pub fn new(
+        tenant_id: Uuid,
+        schema: SchemaRef,
+        cursor: Option<IndexSourceCursor>,
+        limit: usize,
+    ) -> Result<Self, IndexSourceError> {
+        if tenant_id.is_nil() {
+            return Err(IndexSourceError::NilTenantId);
+        }
+        if !(1..=MAX_SCAN_BATCH_SIZE).contains(&limit) {
+            return Err(IndexSourceError::InvalidScanLimit {
+                actual: limit,
+                max: MAX_SCAN_BATCH_SIZE,
+            });
+        }
+        Ok(Self {
+            tenant_id,
+            schema,
+            cursor,
+            limit,
+        })
+    }
+
+    pub fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    pub fn cursor(&self) -> Option<&IndexSourceCursor> {
+        self.cursor.as_ref()
+    }
+
+    pub fn limit(&self) -> usize {
+        self.limit
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexSourceLoadRequest {
+    tenant_id: Uuid,
+    schema: SchemaRef,
+    keys: Vec<EntityKey>,
+}
+
+impl IndexSourceLoadRequest {
+    pub fn new(keys: Vec<EntityKey>) -> Result<Self, IndexSourceError> {
+        let Some(first) = keys.first() else {
+            return Err(IndexSourceError::EmptyLoadKeys);
+        };
+        if keys.len() > MAX_LOAD_KEYS {
+            return Err(IndexSourceError::TooManyLoadKeys {
+                actual: keys.len(),
+                max: MAX_LOAD_KEYS,
+            });
+        }
+        if first.tenant_id.is_nil() {
+            return Err(IndexSourceError::NilTenantId);
+        }
+
+        let tenant_id = first.tenant_id;
+        let schema = first.schema.clone();
+        let mut unique = BTreeSet::new();
+        for (position, key) in keys.iter().enumerate() {
+            if key.tenant_id != tenant_id || key.schema != schema {
+                return Err(IndexSourceError::MixedLoadScope { position });
+            }
+            if !unique.insert(key.clone()) {
+                return Err(IndexSourceError::DuplicateLoadKey { position });
+            }
+        }
+
+        Ok(Self {
+            tenant_id,
+            schema,
+            keys,
+        })
+    }
+
+    pub fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    pub fn keys(&self) -> &[EntityKey] {
+        &self.keys
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexSourcePage {
+    mutations: Vec<IndexMutation>,
+    next_cursor: Option<IndexSourceCursor>,
+}
+
+impl IndexSourcePage {
+    pub fn new(
+        request: &IndexSourceScanRequest,
+        mutations: Vec<IndexMutation>,
+        next_cursor: Option<IndexSourceCursor>,
+    ) -> Result<Self, IndexSourceError> {
+        let page = Self {
+            mutations,
+            next_cursor,
+        };
+        validate_scan_page(request, &page)?;
+        Ok(page)
+    }
+
+    pub fn mutations(&self) -> &[IndexMutation] {
+        &self.mutations
+    }
+
+    pub fn next_cursor(&self) -> Option<&IndexSourceCursor> {
+        self.next_cursor.as_ref()
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.next_cursor.is_none()
+    }
+
+    pub fn into_parts(self) -> (Vec<IndexMutation>, Option<IndexSourceCursor>) {
+        (self.mutations, self.next_cursor)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexSourceLoadBatch {
+    mutations: Vec<IndexMutation>,
+}
+
+impl IndexSourceLoadBatch {
+    pub fn new(
+        request: &IndexSourceLoadRequest,
+        mutations: Vec<IndexMutation>,
+    ) -> Result<Self, IndexSourceError> {
+        let batch = Self { mutations };
+        validate_load_batch(request, &batch)?;
+        Ok(batch)
+    }
+
+    pub fn mutations(&self) -> &[IndexMutation] {
+        &self.mutations
+    }
+
+    pub fn into_mutations(self) -> Vec<IndexMutation> {
+        self.mutations
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexSourceFailureKind {
+    Retryable,
+    Permanent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("Index source reported a {kind:?} failure ({code})")]
+pub struct IndexSourceFailure {
+    kind: IndexSourceFailureKind,
+    code: String,
+}
+
+impl IndexSourceFailure {
+    pub fn retryable(code: impl Into<String>) -> Result<Self, IndexSourceError> {
+        Self::new(IndexSourceFailureKind::Retryable, code)
+    }
+
+    pub fn permanent(code: impl Into<String>) -> Result<Self, IndexSourceError> {
+        Self::new(IndexSourceFailureKind::Permanent, code)
+    }
+
+    fn new(
+        kind: IndexSourceFailureKind,
+        code: impl Into<String>,
+    ) -> Result<Self, IndexSourceError> {
+        let code = code.into();
+        if !valid_bounded_name(&code, MAX_FAILURE_CODE_BYTES) {
+            return Err(IndexSourceError::InvalidFailureCode(code));
+        }
+        Ok(Self { kind, code })
+    }
+
+    pub fn kind(&self) -> IndexSourceFailureKind {
+        self.kind
+    }
+
+    pub fn code(&self) -> &str {
+        &self.code
+    }
+}
+
+#[async_trait]
+pub trait IndexSource: Send + Sync {
+    async fn scan(
+        &self,
+        request: IndexSourceScanRequest,
+    ) -> Result<IndexSourcePage, IndexSourceFailure>;
+
+    async fn load(
+        &self,
+        request: IndexSourceLoadRequest,
+    ) -> Result<IndexSourceLoadBatch, IndexSourceFailure>;
+}
+
+#[derive(Clone)]
+pub struct IndexSourceDescriptor {
+    owner_module: String,
+    source_name: String,
+    schemas: Vec<SchemaRef>,
+    source: Arc<dyn IndexSource>,
+}
+
+impl IndexSourceDescriptor {
+    pub fn owner_module(&self) -> &str {
+        &self.owner_module
+    }
+
+    pub fn source_name(&self) -> &str {
+        &self.source_name
+    }
+
+    pub fn schemas(&self) -> &[SchemaRef] {
+        &self.schemas
+    }
+}
+
+impl fmt::Debug for IndexSourceDescriptor {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("IndexSourceDescriptor")
+            .field("owner_module", &self.owner_module)
+            .field("source_name", &self.source_name)
+            .field("schemas", &self.schemas)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct IndexSourceCatalog {
+    sources: BTreeMap<String, IndexSourceDescriptor>,
+    schema_sources: BTreeMap<SchemaRef, String>,
+    identity_sources: BTreeMap<SchemaIdentity, (String, String)>,
+}
+
+impl fmt::Debug for IndexSourceCatalog {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("IndexSourceCatalog")
+            .field("sources", &self.sources)
+            .field("schema_sources", &self.schema_sources)
+            .finish()
+    }
+}
+
+impl IndexSourceCatalog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn len(&self) -> usize {
+        self.sources.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.sources.is_empty()
+    }
+
+    pub fn get(&self, source_name: &str) -> Option<&IndexSourceDescriptor> {
+        self.sources.get(source_name)
+    }
+
+    pub fn source_for_schema(&self, schema: &SchemaRef) -> Option<&IndexSourceDescriptor> {
+        self.schema_sources
+            .get(schema)
+            .and_then(|source_name| self.sources.get(source_name))
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &IndexSourceDescriptor> {
+        self.sources.values()
+    }
+
+    pub fn register<S>(
+        &mut self,
+        owner_module: impl Into<String>,
+        source_name: impl Into<String>,
+        schemas: impl IntoIterator<Item = SchemaRef>,
+        source: S,
+    ) -> Result<(), IndexSourceError>
+    where
+        S: IndexSource + 'static,
+    {
+        self.register_boxed(owner_module, source_name, schemas, Arc::new(source))
+    }
+
+    pub fn register_boxed(
+        &mut self,
+        owner_module: impl Into<String>,
+        source_name: impl Into<String>,
+        schemas: impl IntoIterator<Item = SchemaRef>,
+        source: Arc<dyn IndexSource>,
+    ) -> Result<(), IndexSourceError> {
+        let owner_module = owner_module.into();
+        let source_name = source_name.into();
+        if !valid_bounded_name(&owner_module, MAX_SOURCE_NAME_BYTES) {
+            return Err(IndexSourceError::InvalidOwnerModule(owner_module));
+        }
+        if !valid_bounded_name(&source_name, MAX_SOURCE_NAME_BYTES) {
+            return Err(IndexSourceError::InvalidSourceName(source_name));
+        }
+        if self.sources.contains_key(&source_name) {
+            return Err(IndexSourceError::DuplicateSourceName(source_name));
+        }
+
+        let mut unique_schemas = BTreeSet::new();
+        for schema in schemas {
+            if !unique_schemas.insert(schema.clone()) {
+                return Err(IndexSourceError::DuplicateSchemaDeclaration {
+                    source_name,
+                    schema,
+                });
+            }
+        }
+        if unique_schemas.is_empty() {
+            return Err(IndexSourceError::EmptySchemaSet(source_name));
+        }
+
+        for schema in &unique_schemas {
+            if let Some(existing_source) = self.schema_sources.get(schema) {
+                return Err(IndexSourceError::SchemaSourceConflict {
+                    schema: schema.clone(),
+                    existing_source: existing_source.clone(),
+                    incoming_source: source_name.clone(),
+                });
+            }
+            if let Some((existing_owner, existing_source)) =
+                self.identity_sources.get(&schema.identity())
+            {
+                if existing_owner != &owner_module || existing_source != &source_name {
+                    return Err(IndexSourceError::SchemaIdentitySourceConflict {
+                        identity: schema.identity(),
+                        existing_owner: existing_owner.clone(),
+                        existing_source: existing_source.clone(),
+                        incoming_owner: owner_module.clone(),
+                        incoming_source: source_name.clone(),
+                    });
+                }
+            }
+        }
+
+        let schemas = unique_schemas.into_iter().collect::<Vec<_>>();
+        for schema in &schemas {
+            self.schema_sources
+                .insert(schema.clone(), source_name.clone());
+            self.identity_sources.insert(
+                schema.identity(),
+                (owner_module.clone(), source_name.clone()),
+            );
+        }
+        self.sources.insert(
+            source_name.clone(),
+            IndexSourceDescriptor {
+                owner_module,
+                source_name,
+                schemas,
+                source,
+            },
+        );
+        Ok(())
+    }
+
+    pub fn materialize(
+        &self,
+        schema_catalog: &IndexSchemaSourceCatalog,
+    ) -> Result<SharedIndexSourceRegistry, IndexSourceError> {
+        for descriptor in self.sources.values() {
+            for schema in &descriptor.schemas {
+                let published = schema_catalog.get(schema).ok_or_else(|| {
+                    IndexSourceError::UnpublishedSourceSchema {
+                        source_name: descriptor.source_name.clone(),
+                        schema: schema.clone(),
+                    }
+                })?;
+                if published.owner_module != descriptor.owner_module {
+                    return Err(IndexSourceError::SourceSchemaOwnerMismatch {
+                        source_name: descriptor.source_name.clone(),
+                        schema: schema.clone(),
+                        schema_owner: published.owner_module.clone(),
+                        source_owner: descriptor.owner_module.clone(),
+                    });
+                }
+            }
+        }
+
+        Ok(SharedIndexSourceRegistry(Arc::new(IndexSourceRegistry {
+            sources: self.sources.clone(),
+            schema_sources: self.schema_sources.clone(),
+        })))
+    }
+}
+
+#[derive(Clone)]
+struct IndexSourceRegistry {
+    sources: BTreeMap<String, IndexSourceDescriptor>,
+    schema_sources: BTreeMap<SchemaRef, String>,
+}
+
+#[derive(Clone)]
+pub struct SharedIndexSourceRegistry(Arc<IndexSourceRegistry>);
+
+impl fmt::Debug for SharedIndexSourceRegistry {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SharedIndexSourceRegistry")
+            .field("source_count", &self.len())
+            .finish()
+    }
+}
+
+impl SharedIndexSourceRegistry {
+    pub fn len(&self) -> usize {
+        self.0.sources.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.sources.is_empty()
+    }
+
+    pub fn get(&self, source_name: &str) -> Option<&IndexSourceDescriptor> {
+        self.0.sources.get(source_name)
+    }
+
+    pub fn source_for_schema(&self, schema: &SchemaRef) -> Option<&IndexSourceDescriptor> {
+        self.0
+            .schema_sources
+            .get(schema)
+            .and_then(|source_name| self.0.sources.get(source_name))
+    }
+
+    pub async fn scan(
+        &self,
+        request: IndexSourceScanRequest,
+    ) -> Result<IndexSourcePage, IndexSourceError> {
+        let descriptor = self.source_for_schema(request.schema()).ok_or_else(|| {
+            IndexSourceError::UnknownSchemaSource(request.schema().clone())
+        })?;
+        let page = descriptor
+            .source
+            .scan(request.clone())
+            .await
+            .map_err(|failure| IndexSourceError::SourceFailure {
+                source_name: descriptor.source_name.clone(),
+                failure,
+            })?;
+        validate_scan_page(&request, &page)?;
+        Ok(page)
+    }
+
+    pub async fn load(
+        &self,
+        request: IndexSourceLoadRequest,
+    ) -> Result<IndexSourceLoadBatch, IndexSourceError> {
+        let descriptor = self.source_for_schema(request.schema()).ok_or_else(|| {
+            IndexSourceError::UnknownSchemaSource(request.schema().clone())
+        })?;
+        let batch = descriptor
+            .source
+            .load(request.clone())
+            .await
+            .map_err(|failure| IndexSourceError::SourceFailure {
+                source_name: descriptor.source_name.clone(),
+                failure,
+            })?;
+        validate_load_batch(&request, &batch)?;
+        Ok(batch)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum IndexSourceError {
+    #[error("Index source owner module is invalid: {0}")]
+    InvalidOwnerModule(String),
+    #[error("Index source name is invalid: {0}")]
+    InvalidSourceName(String),
+    #[error("Index source failure code is invalid: {0}")]
+    InvalidFailureCode(String),
+    #[error("Index source {0} declares no schemas")]
+    EmptySchemaSet(String),
+    #[error("Index source name is already registered: {0}")]
+    DuplicateSourceName(String),
+    #[error("Index source {source_name} declares schema {schema} more than once")]
+    DuplicateSchemaDeclaration {
+        source_name: String,
+        schema: SchemaRef,
+    },
+    #[error(
+        "Index schema {schema} has multiple replay sources: existing={existing_source}, incoming={incoming_source}"
+    )]
+    SchemaSourceConflict {
+        schema: SchemaRef,
+        existing_source: String,
+        incoming_source: String,
+    },
+    #[error(
+        "Index schema identity {identity} changes replay source: existing={existing_owner}/{existing_source}, incoming={incoming_owner}/{incoming_source}"
+    )]
+    SchemaIdentitySourceConflict {
+        identity: SchemaIdentity,
+        existing_owner: String,
+        existing_source: String,
+        incoming_owner: String,
+        incoming_source: String,
+    },
+    #[error("Index source catalog exists without an Index schema source catalog")]
+    MissingSchemaCatalog,
+    #[error("Index source {source_name} declares unpublished schema {schema}")]
+    UnpublishedSourceSchema {
+        source_name: String,
+        schema: SchemaRef,
+    },
+    #[error(
+        "Index source {source_name} owner does not match schema {schema}: schema={schema_owner}, source={source_owner}"
+    )]
+    SourceSchemaOwnerMismatch {
+        source_name: String,
+        schema: SchemaRef,
+        schema_owner: String,
+        source_owner: String,
+    },
+    #[error("Index source cursor cannot be JSON null")]
+    NullCursor,
+    #[error("Index source cursor serialization failed")]
+    CursorSerializationFailed,
+    #[error("Index source cursor is too large: actual={actual}, max={max}")]
+    CursorTooLarge { actual: usize, max: usize },
+    #[error("Index source request tenant cannot be nil")]
+    NilTenantId,
+    #[error("Index source scan limit is invalid: actual={actual}, max={max}")]
+    InvalidScanLimit { actual: usize, max: usize },
+    #[error("Index source targeted load requires at least one entity key")]
+    EmptyLoadKeys,
+    #[error("Index source targeted load has too many keys: actual={actual}, max={max}")]
+    TooManyLoadKeys { actual: usize, max: usize },
+    #[error("Index source targeted load key at position {position} has another tenant or schema")]
+    MixedLoadScope { position: usize },
+    #[error("Index source targeted load key at position {position} is duplicated")]
+    DuplicateLoadKey { position: usize },
+    #[error("No Index source owns schema {0}")]
+    UnknownSchemaSource(SchemaRef),
+    #[error("Index source scan batch exceeds its request: actual={actual}, max={max}")]
+    ScanBatchTooLarge { actual: usize, max: usize },
+    #[error("Index source scan mutation at position {position} escapes the requested tenant/schema")]
+    ScanMutationScopeMismatch { position: usize },
+    #[error("Index source scan mutation at position {position} duplicates an entity key")]
+    DuplicateScanMutationKey { position: usize },
+    #[error("Index source scan returned an empty page with a continuation cursor")]
+    EmptyScanContinuation,
+    #[error("Index source scan continuation cursor did not advance")]
+    ScanCursorDidNotAdvance,
+    #[error("Index source targeted load returned too many mutations: actual={actual}, max={max}")]
+    LoadBatchTooLarge { actual: usize, max: usize },
+    #[error("Index source targeted load mutation at position {position} was not requested")]
+    LoadMutationNotRequested { position: usize },
+    #[error("Index source targeted load mutation at position {position} duplicates an entity key")]
+    DuplicateLoadMutationKey { position: usize },
+    #[error("Index source {source_name} failed")]
+    SourceFailure {
+        source_name: String,
+        #[source]
+        failure: IndexSourceFailure,
+    },
+}
+
+pub fn register_index_source<S>(
+    extensions: &mut ModuleRuntimeExtensions,
+    owner_module: impl Into<String>,
+    source_name: impl Into<String>,
+    schemas: impl IntoIterator<Item = SchemaRef>,
+    source: S,
+) -> Result<(), IndexSourceError>
+where
+    S: IndexSource + 'static,
+{
+    extensions
+        .get_or_insert_with::<IndexSourceCatalog, _>(IndexSourceCatalog::new)
+        .register(owner_module, source_name, schemas, source)
+}
+
+pub fn materialize_index_source_registry(
+    extensions: &ModuleRuntimeExtensions,
+) -> Result<Option<SharedIndexSourceRegistry>, IndexSourceError> {
+    let Some(catalog) = extensions.get::<IndexSourceCatalog>() else {
+        return Ok(None);
+    };
+    if catalog.is_empty() {
+        return Ok(None);
+    }
+    let schema_catalog = extensions
+        .get::<IndexSchemaSourceCatalog>()
+        .ok_or(IndexSourceError::MissingSchemaCatalog)?;
+    catalog.materialize(schema_catalog).map(Some)
+}
+
+fn validate_scan_page(
+    request: &IndexSourceScanRequest,
+    page: &IndexSourcePage,
+) -> Result<(), IndexSourceError> {
+    if page.mutations.len() > request.limit {
+        return Err(IndexSourceError::ScanBatchTooLarge {
+            actual: page.mutations.len(),
+            max: request.limit,
+        });
+    }
+
+    let mut keys = BTreeSet::new();
+    for (position, mutation) in page.mutations.iter().enumerate() {
+        let key = mutation.key();
+        if key.tenant_id != request.tenant_id || key.schema != request.schema {
+            return Err(IndexSourceError::ScanMutationScopeMismatch { position });
+        }
+        if !keys.insert(key.clone()) {
+            return Err(IndexSourceError::DuplicateScanMutationKey { position });
+        }
+    }
+
+    if let Some(next_cursor) = &page.next_cursor {
+        if page.mutations.is_empty() {
+            return Err(IndexSourceError::EmptyScanContinuation);
+        }
+        if request.cursor.as_ref() == Some(next_cursor) {
+            return Err(IndexSourceError::ScanCursorDidNotAdvance);
+        }
+    }
+    Ok(())
+}
+
+fn validate_load_batch(
+    request: &IndexSourceLoadRequest,
+    batch: &IndexSourceLoadBatch,
+) -> Result<(), IndexSourceError> {
+    if batch.mutations.len() > request.keys.len() {
+        return Err(IndexSourceError::LoadBatchTooLarge {
+            actual: batch.mutations.len(),
+            max: request.keys.len(),
+        });
+    }
+
+    let requested = request.keys.iter().cloned().collect::<BTreeSet<_>>();
+    let mut returned = BTreeSet::new();
+    for (position, mutation) in batch.mutations.iter().enumerate() {
+        let key = mutation.key();
+        if !requested.contains(key) {
+            return Err(IndexSourceError::LoadMutationNotRequested { position });
+        }
+        if !returned.insert(key.clone()) {
+            return Err(IndexSourceError::DuplicateLoadMutationKey { position });
+        }
+    }
+    Ok(())
+}
+
+fn valid_bounded_name(value: &str, max_bytes: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= max_bytes
+        && value.bytes().all(|byte| {
+            byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || matches!(byte, b'-' | b'_' | b'.')
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        EntityName, FieldCardinality, FieldName, IndexField, IndexSchema, IndexValueType,
+        LocaleMode, ModuleName, SchemaVersion,
+    };
+
+    struct NoopSource;
+
+    #[async_trait]
+    impl IndexSource for NoopSource {
+        async fn scan(
+            &self,
+            request: IndexSourceScanRequest,
+        ) -> Result<IndexSourcePage, IndexSourceFailure> {
+            Ok(IndexSourcePage::new(&request, Vec::new(), None).expect("valid empty final page"))
+        }
+
+        async fn load(
+            &self,
+            request: IndexSourceLoadRequest,
+        ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+            Ok(IndexSourceLoadBatch::new(&request, Vec::new()).expect("valid empty load"))
+        }
+    }
+
+    fn schema_ref(version: u32) -> SchemaRef {
+        SchemaRef {
+            module: ModuleName::new("rustok-product").unwrap(),
+            entity: EntityName::new("product").unwrap(),
+            version: SchemaVersion::new(version),
+        }
+    }
+
+    fn schema(version: u32) -> IndexSchema {
+        IndexSchema {
+            reference: schema_ref(version),
+            locale_mode: LocaleMode::None,
+            fields: vec![IndexField {
+                name: FieldName::new("id").unwrap(),
+                value_type: IndexValueType::Uuid,
+                cardinality: FieldCardinality::One,
+                nullable: false,
+                selectable: true,
+                filterable: true,
+                sortable: true,
+            }],
+            links: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn source_materialization_requires_exact_schema_owner() {
+        let mut schemas = IndexSchemaSourceCatalog::new();
+        schemas.register("product", schema(1)).unwrap();
+
+        let mut sources = IndexSourceCatalog::new();
+        sources
+            .register("product", "product-primary", [schema_ref(1)], NoopSource)
+            .unwrap();
+        let shared = sources.materialize(&schemas).unwrap();
+
+        assert_eq!(shared.len(), 1);
+        assert_eq!(
+            shared
+                .source_for_schema(&schema_ref(1))
+                .expect("source")
+                .source_name(),
+            "product-primary"
+        );
+    }
+
+    #[test]
+    fn schema_identity_cannot_move_between_replay_sources() {
+        let mut sources = IndexSourceCatalog::new();
+        sources
+            .register("product", "product-primary", [schema_ref(1)], NoopSource)
+            .unwrap();
+        let error = sources
+            .register("product", "product-secondary", [schema_ref(2)], NoopSource)
+            .expect_err("schema identity replay source must stay stable");
+
+        assert!(matches!(
+            error,
+            IndexSourceError::SchemaIdentitySourceConflict { .. }
+        ));
+    }
+
+    #[test]
+    fn cursor_and_scan_limits_are_bounded() {
+        assert!(IndexSourceCursor::new(JsonValue::Null).is_err());
+        assert!(IndexSourceCursor::new(JsonValue::String("x".repeat(MAX_CURSOR_BYTES))).is_err());
+        assert!(
+            IndexSourceScanRequest::new(Uuid::new_v4(), schema_ref(1), None, 0).is_err()
+        );
+        assert!(IndexSourceScanRequest::new(
+            Uuid::new_v4(),
+            schema_ref(1),
+            None,
+            MAX_SCAN_BATCH_SIZE + 1,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn targeted_load_is_one_bounded_tenant_schema_scope() {
+        let tenant_id = Uuid::new_v4();
+        let key = EntityKey {
+            tenant_id,
+            schema: schema_ref(1),
+            entity_id: Uuid::new_v4(),
+            locale: None,
+        };
+        assert!(IndexSourceLoadRequest::new(vec![key.clone()]).is_ok());
+        assert!(IndexSourceLoadRequest::new(vec![key.clone(), key]).is_err());
+    }
+}

--- a/crates/rustok-index/src/application/source_replay.rs
+++ b/crates/rustok-index/src/application/source_replay.rs
@@ -1,4 +1,8 @@
-use std::{fmt, sync::Arc};
+use std::{
+    collections::BTreeSet,
+    fmt,
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use thiserror::Error;
@@ -10,7 +14,7 @@ use super::{
     IndexSourceCursor, IndexSourceError, IndexSourceScanRequest, SharedIndexSourceRegistry,
 };
 
-const MAX_PARTITION_KEY_BYTES: usize = 191;
+const MAX_SOURCE_NAME_BYTES: usize = 128;
 const MAX_DELIVERY_ID_BYTES: usize = 191;
 const MAX_FAILURE_CODE_BYTES: usize = 128;
 
@@ -68,7 +72,6 @@ impl IndexReplayFailure {
 pub struct IndexReplayPageRequest {
     tenant_id: Uuid,
     schema: SchemaRef,
-    partition_key: String,
     limit: usize,
 }
 
@@ -76,22 +79,13 @@ impl IndexReplayPageRequest {
     pub fn new(
         tenant_id: Uuid,
         schema: SchemaRef,
-        partition_key: impl Into<String>,
         limit: usize,
     ) -> Result<Self, IndexReplayError> {
-        if tenant_id.is_nil() {
-            return Err(IndexReplayError::NilTenantId);
-        }
-        let partition_key = partition_key.into();
-        validate_optional_storage_key(
-            "partition key",
-            &partition_key,
-            MAX_PARTITION_KEY_BYTES,
-        )?;
+        IndexSourceScanRequest::new(tenant_id, schema.clone(), None, limit)
+            .map_err(IndexReplayError::SourceContract)?;
         Ok(Self {
             tenant_id,
             schema,
-            partition_key,
             limit,
         })
     }
@@ -104,10 +98,6 @@ impl IndexReplayPageRequest {
         &self.schema
     }
 
-    pub fn partition_key(&self) -> &str {
-        &self.partition_key
-    }
-
     pub fn limit(&self) -> usize {
         self.limit
     }
@@ -118,7 +108,6 @@ pub struct IndexReplayCheckpointKey {
     tenant_id: Uuid,
     source_name: String,
     schema: SchemaRef,
-    partition_key: String,
 }
 
 impl IndexReplayCheckpointKey {
@@ -126,26 +115,18 @@ impl IndexReplayCheckpointKey {
         tenant_id: Uuid,
         source_name: impl Into<String>,
         schema: SchemaRef,
-        partition_key: impl Into<String>,
     ) -> Result<Self, IndexReplayError> {
         if tenant_id.is_nil() {
             return Err(IndexReplayError::NilTenantId);
         }
         let source_name = source_name.into();
-        if !valid_machine_name(&source_name, MAX_FAILURE_CODE_BYTES) {
+        if !valid_machine_name(&source_name, MAX_SOURCE_NAME_BYTES) {
             return Err(IndexReplayError::InvalidSourceName(source_name));
         }
-        let partition_key = partition_key.into();
-        validate_optional_storage_key(
-            "partition key",
-            &partition_key,
-            MAX_PARTITION_KEY_BYTES,
-        )?;
         Ok(Self {
             tenant_id,
             source_name,
             schema,
-            partition_key,
         })
     }
 
@@ -159,10 +140,6 @@ impl IndexReplayCheckpointKey {
 
     pub fn schema(&self) -> &SchemaRef {
         &self.schema
-    }
-
-    pub fn partition_key(&self) -> &str {
-        &self.partition_key
     }
 }
 
@@ -337,7 +314,6 @@ where
             request.tenant_id(),
             descriptor.source_name(),
             request.schema().clone(),
-            request.partition_key(),
         )?;
         let current = self
             .checkpoint_store
@@ -376,8 +352,17 @@ where
         let mut stale_count = 0;
         let mut max_source_version = None;
         let mut last_delivery_id = None;
+        let mut event_ids = BTreeSet::new();
 
         for (position, mutation) in page.mutations().iter().enumerate() {
+            let event_id = mutation.event_id();
+            if event_id.is_nil() {
+                return Err(IndexReplayError::NilReplayEventId { position });
+            }
+            if !event_ids.insert(event_id) {
+                return Err(IndexReplayError::DuplicateReplayEventId { position, event_id });
+            }
+
             let outcome = self
                 .mutation_sink
                 .apply_replay_mutation(
@@ -392,11 +377,11 @@ where
                 IndexReplayMutationOutcome::Duplicate => duplicate_count += 1,
                 IndexReplayMutationOutcome::StaleIgnored => stale_count += 1,
             }
-            max_source_version = Some(
-                max_source_version
-                    .map_or(mutation.source_version(), |current: u64| current.max(mutation.source_version())),
-            );
-            last_delivery_id = Some(mutation.event_id().to_string());
+            max_source_version = Some(max_source_version.map_or(
+                mutation.source_version(),
+                |current: u64| current.max(mutation.source_version()),
+            ));
+            last_delivery_id = Some(event_id.to_string());
         }
 
         let (mutations, next_cursor) = page.into_parts();
@@ -443,6 +428,10 @@ pub enum IndexReplayError {
     UnknownSchemaSource(SchemaRef),
     #[error(transparent)]
     SourceContract(IndexSourceError),
+    #[error("Index replay mutation at position {position} has a nil event id")]
+    NilReplayEventId { position: usize },
+    #[error("Index replay mutation at position {position} duplicates event id {event_id}")]
+    DuplicateReplayEventId { position: usize, event_id: Uuid },
     #[error("Index replay mutation at position {position} failed")]
     MutationFailed {
         position: usize,
@@ -466,14 +455,6 @@ fn validate_required_storage_key(
             reason: "must not be empty",
         });
     }
-    validate_optional_storage_key(field, value, max_bytes)
-}
-
-fn validate_optional_storage_key(
-    field: &'static str,
-    value: &str,
-    max_bytes: usize,
-) -> Result<(), IndexReplayError> {
     if value.len() > max_bytes {
         return Err(IndexReplayError::InvalidStorageKey {
             field,

--- a/crates/rustok-index/src/application/source_replay.rs
+++ b/crates/rustok-index/src/application/source_replay.rs
@@ -158,12 +158,22 @@ impl IndexReplayCheckpoint {
         source_version: Option<u64>,
         last_delivery_id: Option<String>,
     ) -> Result<Self, IndexReplayError> {
+        if source_version == Some(0) {
+            return Err(IndexReplayError::ZeroCheckpointSourceVersion);
+        }
         if let Some(delivery_id) = &last_delivery_id {
             validate_required_storage_key(
                 "last delivery id",
                 delivery_id,
                 MAX_DELIVERY_ID_BYTES,
             )?;
+            let parsed = Uuid::parse_str(delivery_id)
+                .map_err(|_| IndexReplayError::InvalidCheckpointDeliveryId(delivery_id.clone()))?;
+            if parsed.is_nil() {
+                return Err(IndexReplayError::InvalidCheckpointDeliveryId(
+                    delivery_id.clone(),
+                ));
+            }
         }
         Ok(Self {
             key,
@@ -321,15 +331,23 @@ where
             .await
             .map_err(IndexReplayError::CheckpointReadFailed)?;
 
-        if let Some(checkpoint) = current.as_ref().filter(|checkpoint| checkpoint.is_complete()) {
-            return Ok(IndexReplayPageOutcome {
-                status: IndexReplayPageStatus::AlreadyComplete,
-                checkpoint: checkpoint.clone(),
-                mutation_count: 0,
-                applied_count: 0,
-                duplicate_count: 0,
-                stale_count: 0,
-            });
+        if let Some(checkpoint) = &current {
+            if checkpoint.key() != &checkpoint_key {
+                return Err(IndexReplayError::CheckpointIdentityMismatch {
+                    expected: checkpoint_key,
+                    actual: checkpoint.key().clone(),
+                });
+            }
+            if checkpoint.is_complete() {
+                return Ok(IndexReplayPageOutcome {
+                    status: IndexReplayPageStatus::AlreadyComplete,
+                    checkpoint: checkpoint.clone(),
+                    mutation_count: 0,
+                    applied_count: 0,
+                    duplicate_count: 0,
+                    stale_count: 0,
+                });
+            }
         }
 
         let scan_request = IndexSourceScanRequest::new(
@@ -347,6 +365,17 @@ where
             .await
             .map_err(IndexReplayError::SourceContract)?;
 
+        let mut event_ids = BTreeSet::new();
+        for (position, mutation) in page.mutations().iter().enumerate() {
+            let event_id = mutation.event_id();
+            if event_id.is_nil() {
+                return Err(IndexReplayError::NilReplayEventId { position });
+            }
+            if !event_ids.insert(event_id) {
+                return Err(IndexReplayError::DuplicateReplayEventId { position, event_id });
+            }
+        }
+
         let mut applied_count = 0;
         let mut duplicate_count = 0;
         let mut stale_count = 0;
@@ -356,17 +385,8 @@ where
         let mut last_delivery_id = current
             .as_ref()
             .and_then(|checkpoint| checkpoint.last_delivery_id().map(str::to_owned));
-        let mut event_ids = BTreeSet::new();
 
         for (position, mutation) in page.mutations().iter().enumerate() {
-            let event_id = mutation.event_id();
-            if event_id.is_nil() {
-                return Err(IndexReplayError::NilReplayEventId { position });
-            }
-            if !event_ids.insert(event_id) {
-                return Err(IndexReplayError::DuplicateReplayEventId { position, event_id });
-            }
-
             let outcome = self
                 .mutation_sink
                 .apply_replay_mutation(
@@ -385,7 +405,7 @@ where
                 mutation.source_version(),
                 |current| current.max(mutation.source_version()),
             ));
-            last_delivery_id = Some(event_id.to_string());
+            last_delivery_id = Some(mutation.event_id().to_string());
         }
 
         let (mutations, next_cursor) = page.into_parts();
@@ -428,10 +448,19 @@ pub enum IndexReplayError {
         field: &'static str,
         reason: &'static str,
     },
+    #[error("Index replay checkpoint source version must be greater than zero")]
+    ZeroCheckpointSourceVersion,
+    #[error("Index replay checkpoint delivery id is not a non-nil UUID: {0}")]
+    InvalidCheckpointDeliveryId(String),
     #[error("No Index replay source owns schema {0}")]
     UnknownSchemaSource(SchemaRef),
     #[error(transparent)]
     SourceContract(IndexSourceError),
+    #[error("Index replay checkpoint identity does not match the requested replay scope")]
+    CheckpointIdentityMismatch {
+        expected: IndexReplayCheckpointKey,
+        actual: IndexReplayCheckpointKey,
+    },
     #[error("Index replay mutation at position {position} has a nil event id")]
     NilReplayEventId { position: usize },
     #[error("Index replay mutation at position {position} duplicates event id {event_id}")]

--- a/crates/rustok-index/src/application/source_replay.rs
+++ b/crates/rustok-index/src/application/source_replay.rs
@@ -1,0 +1,506 @@
+use std::{fmt, sync::Arc};
+
+use async_trait::async_trait;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::{IndexMutation, SchemaRef, SchemaRegistry};
+
+use super::{
+    IndexSourceCursor, IndexSourceError, IndexSourceScanRequest, SharedIndexSourceRegistry,
+};
+
+const MAX_PARTITION_KEY_BYTES: usize = 191;
+const MAX_DELIVERY_ID_BYTES: usize = 191;
+const MAX_FAILURE_CODE_BYTES: usize = 128;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexReplayFailureKind {
+    Retryable,
+    Permanent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("Index replay dependency reported a {kind:?} failure ({code})")]
+pub struct IndexReplayFailure {
+    kind: IndexReplayFailureKind,
+    code: String,
+}
+
+impl IndexReplayFailure {
+    pub fn retryable(code: impl Into<String>) -> Result<Self, IndexReplayError> {
+        Self::new(IndexReplayFailureKind::Retryable, code)
+    }
+
+    pub fn permanent(code: impl Into<String>) -> Result<Self, IndexReplayError> {
+        Self::new(IndexReplayFailureKind::Permanent, code)
+    }
+
+    fn new(
+        kind: IndexReplayFailureKind,
+        code: impl Into<String>,
+    ) -> Result<Self, IndexReplayError> {
+        let code = code.into();
+        if !valid_machine_name(&code, MAX_FAILURE_CODE_BYTES) {
+            return Err(IndexReplayError::InvalidFailureCode(code));
+        }
+        Ok(Self { kind, code })
+    }
+
+    pub(crate) fn retryable_static(code: &'static str) -> Self {
+        Self::retryable(code).expect("static replay failure code is valid")
+    }
+
+    pub(crate) fn permanent_static(code: &'static str) -> Self {
+        Self::permanent(code).expect("static replay failure code is valid")
+    }
+
+    pub fn kind(&self) -> IndexReplayFailureKind {
+        self.kind
+    }
+
+    pub fn code(&self) -> &str {
+        &self.code
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexReplayPageRequest {
+    tenant_id: Uuid,
+    schema: SchemaRef,
+    partition_key: String,
+    limit: usize,
+}
+
+impl IndexReplayPageRequest {
+    pub fn new(
+        tenant_id: Uuid,
+        schema: SchemaRef,
+        partition_key: impl Into<String>,
+        limit: usize,
+    ) -> Result<Self, IndexReplayError> {
+        if tenant_id.is_nil() {
+            return Err(IndexReplayError::NilTenantId);
+        }
+        let partition_key = partition_key.into();
+        validate_optional_storage_key(
+            "partition key",
+            &partition_key,
+            MAX_PARTITION_KEY_BYTES,
+        )?;
+        Ok(Self {
+            tenant_id,
+            schema,
+            partition_key,
+            limit,
+        })
+    }
+
+    pub fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    pub fn partition_key(&self) -> &str {
+        &self.partition_key
+    }
+
+    pub fn limit(&self) -> usize {
+        self.limit
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct IndexReplayCheckpointKey {
+    tenant_id: Uuid,
+    source_name: String,
+    schema: SchemaRef,
+    partition_key: String,
+}
+
+impl IndexReplayCheckpointKey {
+    pub fn new(
+        tenant_id: Uuid,
+        source_name: impl Into<String>,
+        schema: SchemaRef,
+        partition_key: impl Into<String>,
+    ) -> Result<Self, IndexReplayError> {
+        if tenant_id.is_nil() {
+            return Err(IndexReplayError::NilTenantId);
+        }
+        let source_name = source_name.into();
+        if !valid_machine_name(&source_name, MAX_FAILURE_CODE_BYTES) {
+            return Err(IndexReplayError::InvalidSourceName(source_name));
+        }
+        let partition_key = partition_key.into();
+        validate_optional_storage_key(
+            "partition key",
+            &partition_key,
+            MAX_PARTITION_KEY_BYTES,
+        )?;
+        Ok(Self {
+            tenant_id,
+            source_name,
+            schema,
+            partition_key,
+        })
+    }
+
+    pub fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub fn source_name(&self) -> &str {
+        &self.source_name
+    }
+
+    pub fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    pub fn partition_key(&self) -> &str {
+        &self.partition_key
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexReplayCheckpoint {
+    key: IndexReplayCheckpointKey,
+    cursor: Option<IndexSourceCursor>,
+    source_version: Option<u64>,
+    last_delivery_id: Option<String>,
+}
+
+impl IndexReplayCheckpoint {
+    pub fn new(
+        key: IndexReplayCheckpointKey,
+        cursor: Option<IndexSourceCursor>,
+        source_version: Option<u64>,
+        last_delivery_id: Option<String>,
+    ) -> Result<Self, IndexReplayError> {
+        if let Some(delivery_id) = &last_delivery_id {
+            validate_required_storage_key(
+                "last delivery id",
+                delivery_id,
+                MAX_DELIVERY_ID_BYTES,
+            )?;
+        }
+        Ok(Self {
+            key,
+            cursor,
+            source_version,
+            last_delivery_id,
+        })
+    }
+
+    pub fn key(&self) -> &IndexReplayCheckpointKey {
+        &self.key
+    }
+
+    pub fn cursor(&self) -> Option<&IndexSourceCursor> {
+        self.cursor.as_ref()
+    }
+
+    pub fn source_version(&self) -> Option<u64> {
+        self.source_version
+    }
+
+    pub fn last_delivery_id(&self) -> Option<&str> {
+        self.last_delivery_id.as_deref()
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.cursor.is_none()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexReplayMutationOutcome {
+    Applied,
+    Duplicate,
+    StaleIgnored,
+}
+
+#[async_trait]
+pub trait IndexReplayMutationSink: Send + Sync {
+    async fn apply_replay_mutation(
+        &self,
+        registry: &SchemaRegistry,
+        source_name: &str,
+        mutation: &IndexMutation,
+    ) -> Result<IndexReplayMutationOutcome, IndexReplayFailure>;
+}
+
+#[async_trait]
+pub trait IndexReplayCheckpointStore: Send + Sync {
+    async fn load_replay_checkpoint(
+        &self,
+        key: &IndexReplayCheckpointKey,
+    ) -> Result<Option<IndexReplayCheckpoint>, IndexReplayFailure>;
+
+    async fn commit_replay_checkpoint(
+        &self,
+        checkpoint: &IndexReplayCheckpoint,
+    ) -> Result<(), IndexReplayFailure>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexReplayPageStatus {
+    Advanced,
+    Complete,
+    AlreadyComplete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexReplayPageOutcome {
+    status: IndexReplayPageStatus,
+    checkpoint: IndexReplayCheckpoint,
+    mutation_count: usize,
+    applied_count: usize,
+    duplicate_count: usize,
+    stale_count: usize,
+}
+
+impl IndexReplayPageOutcome {
+    pub fn status(&self) -> IndexReplayPageStatus {
+        self.status
+    }
+
+    pub fn checkpoint(&self) -> &IndexReplayCheckpoint {
+        &self.checkpoint
+    }
+
+    pub fn mutation_count(&self) -> usize {
+        self.mutation_count
+    }
+
+    pub fn applied_count(&self) -> usize {
+        self.applied_count
+    }
+
+    pub fn duplicate_count(&self) -> usize {
+        self.duplicate_count
+    }
+
+    pub fn stale_count(&self) -> usize {
+        self.stale_count
+    }
+}
+
+pub struct IndexReplayWorker<M, C> {
+    sources: SharedIndexSourceRegistry,
+    schema_registry: Arc<SchemaRegistry>,
+    mutation_sink: M,
+    checkpoint_store: C,
+}
+
+impl<M, C> fmt::Debug for IndexReplayWorker<M, C> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("IndexReplayWorker")
+            .field("sources", &self.sources)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<M, C> IndexReplayWorker<M, C>
+where
+    M: IndexReplayMutationSink,
+    C: IndexReplayCheckpointStore,
+{
+    pub fn new(
+        sources: SharedIndexSourceRegistry,
+        schema_registry: Arc<SchemaRegistry>,
+        mutation_sink: M,
+        checkpoint_store: C,
+    ) -> Self {
+        Self {
+            sources,
+            schema_registry,
+            mutation_sink,
+            checkpoint_store,
+        }
+    }
+
+    pub async fn run_next_page(
+        &self,
+        request: IndexReplayPageRequest,
+    ) -> Result<IndexReplayPageOutcome, IndexReplayError> {
+        let descriptor = self
+            .sources
+            .source_for_schema(request.schema())
+            .ok_or_else(|| IndexReplayError::UnknownSchemaSource(request.schema().clone()))?;
+        let checkpoint_key = IndexReplayCheckpointKey::new(
+            request.tenant_id(),
+            descriptor.source_name(),
+            request.schema().clone(),
+            request.partition_key(),
+        )?;
+        let current = self
+            .checkpoint_store
+            .load_replay_checkpoint(&checkpoint_key)
+            .await
+            .map_err(IndexReplayError::CheckpointReadFailed)?;
+
+        if let Some(checkpoint) = current.as_ref().filter(|checkpoint| checkpoint.is_complete()) {
+            return Ok(IndexReplayPageOutcome {
+                status: IndexReplayPageStatus::AlreadyComplete,
+                checkpoint: checkpoint.clone(),
+                mutation_count: 0,
+                applied_count: 0,
+                duplicate_count: 0,
+                stale_count: 0,
+            });
+        }
+
+        let scan_request = IndexSourceScanRequest::new(
+            request.tenant_id(),
+            request.schema().clone(),
+            current
+                .as_ref()
+                .and_then(|checkpoint| checkpoint.cursor().cloned()),
+            request.limit(),
+        )
+        .map_err(IndexReplayError::SourceContract)?;
+        let page = self
+            .sources
+            .scan(scan_request)
+            .await
+            .map_err(IndexReplayError::SourceContract)?;
+
+        let mut applied_count = 0;
+        let mut duplicate_count = 0;
+        let mut stale_count = 0;
+        let mut max_source_version = None;
+        let mut last_delivery_id = None;
+
+        for (position, mutation) in page.mutations().iter().enumerate() {
+            let outcome = self
+                .mutation_sink
+                .apply_replay_mutation(
+                    self.schema_registry.as_ref(),
+                    descriptor.source_name(),
+                    mutation,
+                )
+                .await
+                .map_err(|failure| IndexReplayError::MutationFailed { position, failure })?;
+            match outcome {
+                IndexReplayMutationOutcome::Applied => applied_count += 1,
+                IndexReplayMutationOutcome::Duplicate => duplicate_count += 1,
+                IndexReplayMutationOutcome::StaleIgnored => stale_count += 1,
+            }
+            max_source_version = Some(
+                max_source_version
+                    .map_or(mutation.source_version(), |current: u64| current.max(mutation.source_version())),
+            );
+            last_delivery_id = Some(mutation.event_id().to_string());
+        }
+
+        let (mutations, next_cursor) = page.into_parts();
+        let checkpoint = IndexReplayCheckpoint::new(
+            checkpoint_key,
+            next_cursor,
+            max_source_version,
+            last_delivery_id,
+        )?;
+        self.checkpoint_store
+            .commit_replay_checkpoint(&checkpoint)
+            .await
+            .map_err(IndexReplayError::CheckpointCommitFailed)?;
+
+        Ok(IndexReplayPageOutcome {
+            status: if checkpoint.is_complete() {
+                IndexReplayPageStatus::Complete
+            } else {
+                IndexReplayPageStatus::Advanced
+            },
+            checkpoint,
+            mutation_count: mutations.len(),
+            applied_count,
+            duplicate_count,
+            stale_count,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum IndexReplayError {
+    #[error("Index replay tenant cannot be nil")]
+    NilTenantId,
+    #[error("Index replay source name is invalid: {0}")]
+    InvalidSourceName(String),
+    #[error("Index replay failure code is invalid: {0}")]
+    InvalidFailureCode(String),
+    #[error("Index replay {field} is invalid: {reason}")]
+    InvalidStorageKey {
+        field: &'static str,
+        reason: &'static str,
+    },
+    #[error("No Index replay source owns schema {0}")]
+    UnknownSchemaSource(SchemaRef),
+    #[error(transparent)]
+    SourceContract(IndexSourceError),
+    #[error("Index replay mutation at position {position} failed")]
+    MutationFailed {
+        position: usize,
+        #[source]
+        failure: IndexReplayFailure,
+    },
+    #[error("Index replay checkpoint read failed")]
+    CheckpointReadFailed(#[source] IndexReplayFailure),
+    #[error("Index replay checkpoint commit failed")]
+    CheckpointCommitFailed(#[source] IndexReplayFailure),
+}
+
+fn validate_required_storage_key(
+    field: &'static str,
+    value: &str,
+    max_bytes: usize,
+) -> Result<(), IndexReplayError> {
+    if value.is_empty() {
+        return Err(IndexReplayError::InvalidStorageKey {
+            field,
+            reason: "must not be empty",
+        });
+    }
+    validate_optional_storage_key(field, value, max_bytes)
+}
+
+fn validate_optional_storage_key(
+    field: &'static str,
+    value: &str,
+    max_bytes: usize,
+) -> Result<(), IndexReplayError> {
+    if value.len() > max_bytes {
+        return Err(IndexReplayError::InvalidStorageKey {
+            field,
+            reason: "exceeds the storage limit",
+        });
+    }
+    if value.trim() != value {
+        return Err(IndexReplayError::InvalidStorageKey {
+            field,
+            reason: "must not contain leading or trailing whitespace",
+        });
+    }
+    if value.chars().any(char::is_control) {
+        return Err(IndexReplayError::InvalidStorageKey {
+            field,
+            reason: "must not contain control characters",
+        });
+    }
+    Ok(())
+}
+
+fn valid_machine_name(value: &str, max_bytes: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= max_bytes
+        && value.bytes().all(|byte| {
+            byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || matches!(byte, b'-' | b'_' | b'.')
+        })
+}

--- a/crates/rustok-index/src/application/source_replay.rs
+++ b/crates/rustok-index/src/application/source_replay.rs
@@ -350,8 +350,12 @@ where
         let mut applied_count = 0;
         let mut duplicate_count = 0;
         let mut stale_count = 0;
-        let mut max_source_version = None;
-        let mut last_delivery_id = None;
+        let mut max_source_version = current
+            .as_ref()
+            .and_then(IndexReplayCheckpoint::source_version);
+        let mut last_delivery_id = current
+            .as_ref()
+            .and_then(|checkpoint| checkpoint.last_delivery_id().map(str::to_owned));
         let mut event_ids = BTreeSet::new();
 
         for (position, mutation) in page.mutations().iter().enumerate() {
@@ -379,7 +383,7 @@ where
             }
             max_source_version = Some(max_source_version.map_or(
                 mutation.source_version(),
-                |current: u64| current.max(mutation.source_version()),
+                |current| current.max(mutation.source_version()),
             ));
             last_delivery_id = Some(event_id.to_string());
         }

--- a/crates/rustok-index/src/application/source_replay_tests.rs
+++ b/crates/rustok-index/src/application/source_replay_tests.rs
@@ -214,8 +214,9 @@ async fn replay_page_commits_checkpoint_after_mutations() {
     assert_eq!(outcome.applied_count(), 1);
     assert_eq!(*order.lock().unwrap(), vec!["mutation", "checkpoint"]);
     let stored = checkpoint.lock().unwrap().clone().unwrap();
+    let expected_delivery_id = event_id.to_string();
     assert!(stored.is_complete());
-    assert_eq!(stored.last_delivery_id(), Some(event_id.to_string().as_str()));
+    assert_eq!(stored.last_delivery_id(), Some(expected_delivery_id.as_str()));
 }
 
 #[tokio::test]
@@ -284,8 +285,43 @@ async fn completed_checkpoint_skips_the_source() {
 }
 
 #[tokio::test]
-async fn nil_replay_event_is_rejected_before_persistence() {
+async fn checkpoint_watermark_never_regresses() {
     let tenant_id = Uuid::from_u128(4);
+    let event_id = Uuid::from_u128(10);
+    let key = IndexReplayCheckpointKey::new(tenant_id, "product-primary", schema_ref()).unwrap();
+    let cursor = IndexSourceCursor::new(serde_json::json!({ "offset": 1 })).unwrap();
+    let checkpoint = Arc::new(Mutex::new(Some(
+        IndexReplayCheckpoint::new(
+            key,
+            Some(cursor),
+            Some(9),
+            Some(Uuid::from_u128(5).to_string()),
+        )
+        .unwrap(),
+    )));
+    let worker = worker(
+        tenant_id,
+        event_id,
+        Arc::new(AtomicUsize::new(0)),
+        Arc::new(AtomicUsize::new(0)),
+        Arc::new(Mutex::new(Vec::new())),
+        checkpoint.clone(),
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(Mutex::new(Vec::new())),
+    );
+
+    let outcome = worker
+        .run_next_page(IndexReplayPageRequest::new(tenant_id, schema_ref(), 10).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.checkpoint().source_version(), Some(9));
+    assert_eq!(checkpoint.lock().unwrap().as_ref().unwrap().source_version(), Some(9));
+}
+
+#[tokio::test]
+async fn nil_replay_event_is_rejected_before_persistence() {
+    let tenant_id = Uuid::from_u128(5);
     let mutation_calls = Arc::new(AtomicUsize::new(0));
     let checkpoint = Arc::new(Mutex::new(None));
     let worker = worker(

--- a/crates/rustok-index/src/application/source_replay_tests.rs
+++ b/crates/rustok-index/src/application/source_replay_tests.rs
@@ -43,6 +43,7 @@ impl IndexSource for ReplaySource {
 #[derive(Clone)]
 struct RecordingMutationSink {
     calls: Arc<AtomicUsize>,
+    event_ids: Arc<Mutex<Vec<Uuid>>>,
     order: Arc<Mutex<Vec<&'static str>>>,
 }
 
@@ -52,9 +53,10 @@ impl IndexReplayMutationSink for RecordingMutationSink {
         &self,
         _registry: &SchemaRegistry,
         _source_name: &str,
-        _mutation: &IndexMutation,
+        mutation: &IndexMutation,
     ) -> Result<IndexReplayMutationOutcome, IndexReplayFailure> {
         self.order.lock().unwrap().push("mutation");
+        self.event_ids.lock().unwrap().push(mutation.event_id());
         let call = self.calls.fetch_add(1, Ordering::SeqCst);
         Ok(if call == 0 {
             IndexReplayMutationOutcome::Applied
@@ -118,9 +120,9 @@ fn schema() -> IndexSchema {
     }
 }
 
-fn mutation(tenant_id: Uuid, entity_id: Uuid) -> IndexMutation {
+fn mutation(tenant_id: Uuid, entity_id: Uuid, event_id: Uuid) -> IndexMutation {
     IndexMutation::Upsert {
-        event_id: Uuid::from_u128(10),
+        event_id,
         record: IndexRecord {
             key: EntityKey {
                 tenant_id,
@@ -140,8 +142,10 @@ fn mutation(tenant_id: Uuid, entity_id: Uuid) -> IndexMutation {
 
 fn worker(
     tenant_id: Uuid,
+    event_id: Uuid,
     source_calls: Arc<AtomicUsize>,
     mutation_calls: Arc<AtomicUsize>,
+    event_ids: Arc<Mutex<Vec<Uuid>>>,
     checkpoint: Arc<Mutex<Option<IndexReplayCheckpoint>>>,
     fail_next_commit: Arc<AtomicBool>,
     order: Arc<Mutex<Vec<&'static str>>>,
@@ -157,7 +161,7 @@ fn worker(
             [schema_ref()],
             ReplaySource {
                 calls: source_calls,
-                mutation: mutation(tenant_id, Uuid::from_u128(20)),
+                mutation: mutation(tenant_id, Uuid::from_u128(20), event_id),
             },
         )
         .unwrap();
@@ -171,6 +175,7 @@ fn worker(
         Arc::new(registry),
         RecordingMutationSink {
             calls: mutation_calls,
+            event_ids,
             order: order.clone(),
         },
         RecordingCheckpointStore {
@@ -184,46 +189,55 @@ fn worker(
 #[tokio::test]
 async fn replay_page_commits_checkpoint_after_mutations() {
     let tenant_id = Uuid::from_u128(1);
+    let event_id = Uuid::from_u128(10);
     let source_calls = Arc::new(AtomicUsize::new(0));
     let mutation_calls = Arc::new(AtomicUsize::new(0));
     let checkpoint = Arc::new(Mutex::new(None));
     let order = Arc::new(Mutex::new(Vec::new()));
     let worker = worker(
         tenant_id,
+        event_id,
         source_calls,
         mutation_calls,
+        Arc::new(Mutex::new(Vec::new())),
         checkpoint.clone(),
         Arc::new(AtomicBool::new(false)),
         order.clone(),
     );
 
     let outcome = worker
-        .run_next_page(IndexReplayPageRequest::new(tenant_id, schema_ref(), "", 10).unwrap())
+        .run_next_page(IndexReplayPageRequest::new(tenant_id, schema_ref(), 10).unwrap())
         .await
         .unwrap();
 
     assert_eq!(outcome.status(), IndexReplayPageStatus::Complete);
     assert_eq!(outcome.applied_count(), 1);
     assert_eq!(*order.lock().unwrap(), vec!["mutation", "checkpoint"]);
-    assert!(checkpoint.lock().unwrap().as_ref().unwrap().is_complete());
+    let stored = checkpoint.lock().unwrap().clone().unwrap();
+    assert!(stored.is_complete());
+    assert_eq!(stored.last_delivery_id(), Some(event_id.to_string().as_str()));
 }
 
 #[tokio::test]
-async fn checkpoint_failure_replays_the_page_through_inbox_identity() {
+async fn checkpoint_failure_replays_the_same_event_delivery() {
     let tenant_id = Uuid::from_u128(2);
+    let event_id = Uuid::from_u128(10);
     let source_calls = Arc::new(AtomicUsize::new(0));
     let mutation_calls = Arc::new(AtomicUsize::new(0));
+    let event_ids = Arc::new(Mutex::new(Vec::new()));
     let checkpoint = Arc::new(Mutex::new(None));
     let fail_next_commit = Arc::new(AtomicBool::new(true));
     let worker = worker(
         tenant_id,
+        event_id,
         source_calls.clone(),
         mutation_calls.clone(),
+        event_ids.clone(),
         checkpoint.clone(),
         fail_next_commit,
         Arc::new(Mutex::new(Vec::new())),
     );
-    let request = IndexReplayPageRequest::new(tenant_id, schema_ref(), "", 10).unwrap();
+    let request = IndexReplayPageRequest::new(tenant_id, schema_ref(), 10).unwrap();
 
     assert!(matches!(
         worker.run_next_page(request.clone()).await,
@@ -235,39 +249,62 @@ async fn checkpoint_failure_replays_the_page_through_inbox_identity() {
     assert_eq!(outcome.duplicate_count(), 1);
     assert_eq!(source_calls.load(Ordering::SeqCst), 2);
     assert_eq!(mutation_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(*event_ids.lock().unwrap(), vec![event_id, event_id]);
 }
 
 #[tokio::test]
 async fn completed_checkpoint_skips_the_source() {
     let tenant_id = Uuid::from_u128(3);
+    let event_id = Uuid::from_u128(10);
     let source_calls = Arc::new(AtomicUsize::new(0));
     let mutation_calls = Arc::new(AtomicUsize::new(0));
-    let key = IndexReplayCheckpointKey::new(
-        tenant_id,
-        "product-primary",
-        schema_ref(),
-        "",
-    )
-    .unwrap();
+    let key = IndexReplayCheckpointKey::new(tenant_id, "product-primary", schema_ref()).unwrap();
     let checkpoint = Arc::new(Mutex::new(Some(
-        IndexReplayCheckpoint::new(key, None, Some(7), Some(Uuid::from_u128(10).to_string()))
-            .unwrap(),
+        IndexReplayCheckpoint::new(key, None, Some(7), Some(event_id.to_string())).unwrap(),
     )));
     let worker = worker(
         tenant_id,
+        event_id,
         source_calls.clone(),
         mutation_calls.clone(),
+        Arc::new(Mutex::new(Vec::new())),
         checkpoint,
         Arc::new(AtomicBool::new(false)),
         Arc::new(Mutex::new(Vec::new())),
     );
 
     let outcome = worker
-        .run_next_page(IndexReplayPageRequest::new(tenant_id, schema_ref(), "", 10).unwrap())
+        .run_next_page(IndexReplayPageRequest::new(tenant_id, schema_ref(), 10).unwrap())
         .await
         .unwrap();
 
     assert_eq!(outcome.status(), IndexReplayPageStatus::AlreadyComplete);
     assert_eq!(source_calls.load(Ordering::SeqCst), 0);
     assert_eq!(mutation_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn nil_replay_event_is_rejected_before_persistence() {
+    let tenant_id = Uuid::from_u128(4);
+    let mutation_calls = Arc::new(AtomicUsize::new(0));
+    let checkpoint = Arc::new(Mutex::new(None));
+    let worker = worker(
+        tenant_id,
+        Uuid::nil(),
+        Arc::new(AtomicUsize::new(0)),
+        mutation_calls.clone(),
+        Arc::new(Mutex::new(Vec::new())),
+        checkpoint.clone(),
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(Mutex::new(Vec::new())),
+    );
+
+    assert!(matches!(
+        worker
+            .run_next_page(IndexReplayPageRequest::new(tenant_id, schema_ref(), 10).unwrap())
+            .await,
+        Err(IndexReplayError::NilReplayEventId { position: 0 })
+    ));
+    assert_eq!(mutation_calls.load(Ordering::SeqCst), 0);
+    assert!(checkpoint.lock().unwrap().is_none());
 }

--- a/crates/rustok-index/src/application/source_replay_tests.rs
+++ b/crates/rustok-index/src/application/source_replay_tests.rs
@@ -1,0 +1,273 @@
+use std::{
+    collections::BTreeMap,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+};
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::domain::{
+    EntityKey, EntityName, FieldCardinality, FieldName, IndexField, IndexRecord, IndexSchema,
+    IndexValue, IndexValueType, LocaleMode, ModuleName, SchemaRef, SchemaVersion,
+};
+
+use super::*;
+
+struct ReplaySource {
+    calls: Arc<AtomicUsize>,
+    mutation: IndexMutation,
+}
+
+#[async_trait]
+impl IndexSource for ReplaySource {
+    async fn scan(
+        &self,
+        request: IndexSourceScanRequest,
+    ) -> Result<IndexSourcePage, IndexSourceFailure> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(IndexSourcePage::new(&request, vec![self.mutation.clone()], None)
+            .expect("bounded replay page"))
+    }
+
+    async fn load(
+        &self,
+        request: IndexSourceLoadRequest,
+    ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+        Ok(IndexSourceLoadBatch::new(&request, Vec::new()).expect("empty targeted load"))
+    }
+}
+
+#[derive(Clone)]
+struct RecordingMutationSink {
+    calls: Arc<AtomicUsize>,
+    order: Arc<Mutex<Vec<&'static str>>>,
+}
+
+#[async_trait]
+impl IndexReplayMutationSink for RecordingMutationSink {
+    async fn apply_replay_mutation(
+        &self,
+        _registry: &SchemaRegistry,
+        _source_name: &str,
+        _mutation: &IndexMutation,
+    ) -> Result<IndexReplayMutationOutcome, IndexReplayFailure> {
+        self.order.lock().unwrap().push("mutation");
+        let call = self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(if call == 0 {
+            IndexReplayMutationOutcome::Applied
+        } else {
+            IndexReplayMutationOutcome::Duplicate
+        })
+    }
+}
+
+#[derive(Clone)]
+struct RecordingCheckpointStore {
+    checkpoint: Arc<Mutex<Option<IndexReplayCheckpoint>>>,
+    fail_next_commit: Arc<AtomicBool>,
+    order: Arc<Mutex<Vec<&'static str>>>,
+}
+
+#[async_trait]
+impl IndexReplayCheckpointStore for RecordingCheckpointStore {
+    async fn load_replay_checkpoint(
+        &self,
+        _key: &IndexReplayCheckpointKey,
+    ) -> Result<Option<IndexReplayCheckpoint>, IndexReplayFailure> {
+        Ok(self.checkpoint.lock().unwrap().clone())
+    }
+
+    async fn commit_replay_checkpoint(
+        &self,
+        checkpoint: &IndexReplayCheckpoint,
+    ) -> Result<(), IndexReplayFailure> {
+        self.order.lock().unwrap().push("checkpoint");
+        if self.fail_next_commit.swap(false, Ordering::SeqCst) {
+            return Err(IndexReplayFailure::retryable("checkpoint_unavailable").unwrap());
+        }
+        *self.checkpoint.lock().unwrap() = Some(checkpoint.clone());
+        Ok(())
+    }
+}
+
+fn schema_ref() -> SchemaRef {
+    SchemaRef {
+        module: ModuleName::new("rustok-product").unwrap(),
+        entity: EntityName::new("product").unwrap(),
+        version: SchemaVersion::new(1),
+    }
+}
+
+fn schema() -> IndexSchema {
+    IndexSchema {
+        reference: schema_ref(),
+        locale_mode: LocaleMode::None,
+        fields: vec![IndexField {
+            name: FieldName::new("id").unwrap(),
+            value_type: IndexValueType::Uuid,
+            cardinality: FieldCardinality::One,
+            nullable: false,
+            selectable: true,
+            filterable: true,
+            sortable: true,
+        }],
+        links: Vec::new(),
+    }
+}
+
+fn mutation(tenant_id: Uuid, entity_id: Uuid) -> IndexMutation {
+    IndexMutation::Upsert {
+        event_id: Uuid::from_u128(10),
+        record: IndexRecord {
+            key: EntityKey {
+                tenant_id,
+                schema: schema_ref(),
+                entity_id,
+                locale: None,
+            },
+            source_version: 7,
+            fields: BTreeMap::from([(
+                FieldName::new("id").unwrap(),
+                IndexValue::Uuid(entity_id),
+            )]),
+            links: Vec::new(),
+        },
+    }
+}
+
+fn worker(
+    tenant_id: Uuid,
+    source_calls: Arc<AtomicUsize>,
+    mutation_calls: Arc<AtomicUsize>,
+    checkpoint: Arc<Mutex<Option<IndexReplayCheckpoint>>>,
+    fail_next_commit: Arc<AtomicBool>,
+    order: Arc<Mutex<Vec<&'static str>>>,
+) -> IndexReplayWorker<RecordingMutationSink, RecordingCheckpointStore> {
+    let mut schema_catalog = IndexSchemaSourceCatalog::new();
+    schema_catalog.register("product", schema()).unwrap();
+
+    let mut source_catalog = IndexSourceCatalog::new();
+    source_catalog
+        .register(
+            "product",
+            "product-primary",
+            [schema_ref()],
+            ReplaySource {
+                calls: source_calls,
+                mutation: mutation(tenant_id, Uuid::from_u128(20)),
+            },
+        )
+        .unwrap();
+    let sources = source_catalog.materialize(&schema_catalog).unwrap();
+
+    let mut registry = SchemaRegistry::new();
+    registry.register(schema()).unwrap();
+
+    IndexReplayWorker::new(
+        sources,
+        Arc::new(registry),
+        RecordingMutationSink {
+            calls: mutation_calls,
+            order: order.clone(),
+        },
+        RecordingCheckpointStore {
+            checkpoint,
+            fail_next_commit,
+            order,
+        },
+    )
+}
+
+#[tokio::test]
+async fn replay_page_commits_checkpoint_after_mutations() {
+    let tenant_id = Uuid::from_u128(1);
+    let source_calls = Arc::new(AtomicUsize::new(0));
+    let mutation_calls = Arc::new(AtomicUsize::new(0));
+    let checkpoint = Arc::new(Mutex::new(None));
+    let order = Arc::new(Mutex::new(Vec::new()));
+    let worker = worker(
+        tenant_id,
+        source_calls,
+        mutation_calls,
+        checkpoint.clone(),
+        Arc::new(AtomicBool::new(false)),
+        order.clone(),
+    );
+
+    let outcome = worker
+        .run_next_page(IndexReplayPageRequest::new(tenant_id, schema_ref(), "", 10).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.status(), IndexReplayPageStatus::Complete);
+    assert_eq!(outcome.applied_count(), 1);
+    assert_eq!(*order.lock().unwrap(), vec!["mutation", "checkpoint"]);
+    assert!(checkpoint.lock().unwrap().as_ref().unwrap().is_complete());
+}
+
+#[tokio::test]
+async fn checkpoint_failure_replays_the_page_through_inbox_identity() {
+    let tenant_id = Uuid::from_u128(2);
+    let source_calls = Arc::new(AtomicUsize::new(0));
+    let mutation_calls = Arc::new(AtomicUsize::new(0));
+    let checkpoint = Arc::new(Mutex::new(None));
+    let fail_next_commit = Arc::new(AtomicBool::new(true));
+    let worker = worker(
+        tenant_id,
+        source_calls.clone(),
+        mutation_calls.clone(),
+        checkpoint.clone(),
+        fail_next_commit,
+        Arc::new(Mutex::new(Vec::new())),
+    );
+    let request = IndexReplayPageRequest::new(tenant_id, schema_ref(), "", 10).unwrap();
+
+    assert!(matches!(
+        worker.run_next_page(request.clone()).await,
+        Err(IndexReplayError::CheckpointCommitFailed(_))
+    ));
+    assert!(checkpoint.lock().unwrap().is_none());
+
+    let outcome = worker.run_next_page(request).await.unwrap();
+    assert_eq!(outcome.duplicate_count(), 1);
+    assert_eq!(source_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(mutation_calls.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn completed_checkpoint_skips_the_source() {
+    let tenant_id = Uuid::from_u128(3);
+    let source_calls = Arc::new(AtomicUsize::new(0));
+    let mutation_calls = Arc::new(AtomicUsize::new(0));
+    let key = IndexReplayCheckpointKey::new(
+        tenant_id,
+        "product-primary",
+        schema_ref(),
+        "",
+    )
+    .unwrap();
+    let checkpoint = Arc::new(Mutex::new(Some(
+        IndexReplayCheckpoint::new(key, None, Some(7), Some(Uuid::from_u128(10).to_string()))
+            .unwrap(),
+    )));
+    let worker = worker(
+        tenant_id,
+        source_calls.clone(),
+        mutation_calls.clone(),
+        checkpoint,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(Mutex::new(Vec::new())),
+    );
+
+    let outcome = worker
+        .run_next_page(IndexReplayPageRequest::new(tenant_id, schema_ref(), "", 10).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.status(), IndexReplayPageStatus::AlreadyComplete);
+    assert_eq!(source_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(mutation_calls.load(Ordering::SeqCst), 0);
+}

--- a/crates/rustok-index/src/infrastructure/postgres/mod.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/mod.rs
@@ -5,6 +5,7 @@ mod query_runtime;
 mod schema_lease;
 mod schema_registration;
 mod secondary_index;
+mod source_replay;
 
 #[cfg(test)]
 mod mutation_store_tests;
@@ -44,3 +45,4 @@ pub use secondary_index::{
     SecondaryIndexExecutionOutcome, SecondaryIndexKind, SecondaryIndexLease,
     SecondaryIndexOperation, SecondaryIndexPlan, SecondaryIndexRequest, SecondaryIndexSpec,
 };
+pub use source_replay::PostgresIndexReplayCheckpointStore;

--- a/crates/rustok-index/src/infrastructure/postgres/mod.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/mod.rs
@@ -6,6 +6,7 @@ mod schema_lease;
 mod schema_registration;
 mod secondary_index;
 mod source_replay;
+mod source_replay_job;
 
 #[cfg(test)]
 mod mutation_store_tests;
@@ -19,6 +20,8 @@ mod schema_lease_tests;
 mod schema_registration_tests;
 #[cfg(test)]
 mod secondary_index_tests;
+#[cfg(test)]
+mod source_replay_job_tests;
 
 pub use mutation_store::{
     MutationApplyOutcome, MutationDelivery, MutationStorageError, PostgresMutationStore,
@@ -46,3 +49,7 @@ pub use secondary_index::{
     SecondaryIndexOperation, SecondaryIndexPlan, SecondaryIndexRequest, SecondaryIndexSpec,
 };
 pub use source_replay::PostgresIndexReplayCheckpointStore;
+pub use source_replay_job::{
+    IndexReplayJobAcquireOutcome, IndexReplayJobError, IndexReplayJobLease,
+    IndexReplayJobLeaseRequest, PostgresIndexReplayJobStore,
+};

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay.rs
@@ -76,7 +76,9 @@ impl IndexReplayCheckpointStore for PostgresIndexReplayCheckpointStore {
             .map_err(|error| checkpoint_contract_failure("checkpoint_cursor_invalid", error))?;
         let source_version_text: Option<String> = row
             .try_get("", "source_version_text")
-            .map_err(|error| checkpoint_contract_failure("checkpoint_source_version_invalid", error))?;
+            .map_err(|error| {
+                checkpoint_contract_failure("checkpoint_source_version_invalid", error)
+            })?;
         let source_version = source_version_text
             .map(|value| {
                 value.parse::<u64>().map_err(|error| {
@@ -170,7 +172,11 @@ fn checkpoint_storage_failure(
     code: &'static str,
     error: impl std::fmt::Display,
 ) -> IndexReplayFailure {
-    tracing::error!(error = %error, replay_failure_code = code, "Index replay checkpoint storage failed");
+    tracing::error!(
+        error = %error,
+        replay_failure_code = code,
+        "Index replay checkpoint storage failed"
+    );
     IndexReplayFailure::retryable_static(code)
 }
 
@@ -178,7 +184,11 @@ fn checkpoint_contract_failure(
     code: &'static str,
     error: impl std::fmt::Display,
 ) -> IndexReplayFailure {
-    tracing::error!(error = %error, replay_failure_code = code, "Index replay checkpoint contract failed");
+    tracing::error!(
+        error = %error,
+        replay_failure_code = code,
+        "Index replay checkpoint contract failed"
+    );
     IndexReplayFailure::permanent_static(code)
 }
 
@@ -228,7 +238,7 @@ fn checkpoint_key_values(
         key.schema().entity.as_str().to_owned().into(),
         i64::from(key.schema().version.get()).into(),
         "".into(),
-        key.partition_key().to_owned().into(),
+        "".into(),
     ]
 }
 

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay.rs
@@ -1,0 +1,247 @@
+use async_trait::async_trait;
+use rust_decimal::Decimal;
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DbBackend, Statement, Value as SqlValue,
+};
+use serde_json::Value as JsonValue;
+
+use crate::{
+    IndexMutation, IndexReplayCheckpoint, IndexReplayCheckpointKey, IndexReplayCheckpointStore,
+    IndexReplayFailure, IndexReplayMutationOutcome, IndexReplayMutationSink, SchemaRegistry,
+};
+
+use super::mutation_store::{
+    MutationApplyOutcome, MutationDelivery, MutationStorageError, PostgresMutationStore,
+};
+
+#[async_trait]
+impl IndexReplayMutationSink for PostgresMutationStore {
+    async fn apply_replay_mutation(
+        &self,
+        registry: &SchemaRegistry,
+        source_name: &str,
+        mutation: &IndexMutation,
+    ) -> Result<IndexReplayMutationOutcome, IndexReplayFailure> {
+        let delivery = MutationDelivery::from_event(source_name, mutation.clone())
+            .map_err(classify_mutation_failure)?;
+        self.apply(registry, &delivery)
+            .await
+            .map(|outcome| match outcome {
+                MutationApplyOutcome::Applied { .. } => IndexReplayMutationOutcome::Applied,
+                MutationApplyOutcome::Duplicate { .. } => IndexReplayMutationOutcome::Duplicate,
+                MutationApplyOutcome::StaleIgnored { .. } => {
+                    IndexReplayMutationOutcome::StaleIgnored
+                }
+            })
+            .map_err(classify_mutation_failure)
+    }
+}
+
+#[derive(Clone)]
+pub struct PostgresIndexReplayCheckpointStore {
+    db: DatabaseConnection,
+}
+
+impl PostgresIndexReplayCheckpointStore {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+}
+
+#[async_trait]
+impl IndexReplayCheckpointStore for PostgresIndexReplayCheckpointStore {
+    async fn load_replay_checkpoint(
+        &self,
+        key: &IndexReplayCheckpointKey,
+    ) -> Result<Option<IndexReplayCheckpoint>, IndexReplayFailure> {
+        let backend = self.db.get_database_backend();
+        ensure_supported_backend(backend)?;
+        let row = self
+            .db
+            .query_one(Statement::from_sql_and_values(
+                backend,
+                select_checkpoint_sql(backend),
+                checkpoint_key_values(key, backend),
+            ))
+            .await
+            .map_err(|error| checkpoint_storage_failure("checkpoint_read_failed", error))?;
+        let Some(row) = row else {
+            return Ok(None);
+        };
+
+        let cursor_json: JsonValue = row
+            .try_get("", "cursor")
+            .map_err(|error| checkpoint_contract_failure("checkpoint_cursor_invalid", error))?;
+        let cursor = serde_json::from_value(cursor_json)
+            .map_err(|error| checkpoint_contract_failure("checkpoint_cursor_invalid", error))?;
+        let source_version_text: Option<String> = row
+            .try_get("", "source_version_text")
+            .map_err(|error| checkpoint_contract_failure("checkpoint_source_version_invalid", error))?;
+        let source_version = source_version_text
+            .map(|value| {
+                value.parse::<u64>().map_err(|error| {
+                    checkpoint_contract_failure("checkpoint_source_version_invalid", error)
+                })
+            })
+            .transpose()?;
+        let last_delivery_id: Option<String> = row
+            .try_get("", "last_delivery_id")
+            .map_err(|error| checkpoint_contract_failure("checkpoint_delivery_invalid", error))?;
+
+        IndexReplayCheckpoint::new(key.clone(), cursor, source_version, last_delivery_id)
+            .map(Some)
+            .map_err(|error| checkpoint_contract_failure("checkpoint_contract_invalid", error))
+    }
+
+    async fn commit_replay_checkpoint(
+        &self,
+        checkpoint: &IndexReplayCheckpoint,
+    ) -> Result<(), IndexReplayFailure> {
+        let backend = self.db.get_database_backend();
+        ensure_supported_backend(backend)?;
+        let cursor = serde_json::to_value(checkpoint.cursor())
+            .map_err(|error| checkpoint_contract_failure("checkpoint_cursor_invalid", error))?;
+        let mut values = checkpoint_key_values(checkpoint.key(), backend);
+        values.push(SqlValue::Json(Some(Box::new(cursor))));
+        values.push(optional_source_version_value(
+            checkpoint.source_version(),
+            backend,
+        )?);
+        values.push(
+            checkpoint
+                .last_delivery_id()
+                .map(str::to_owned)
+                .into(),
+        );
+
+        self.db
+            .execute(Statement::from_sql_and_values(
+                backend,
+                upsert_checkpoint_sql(backend),
+                values,
+            ))
+            .await
+            .map_err(|error| checkpoint_storage_failure("checkpoint_commit_failed", error))?;
+        Ok(())
+    }
+}
+
+fn classify_mutation_failure(error: MutationStorageError) -> IndexReplayFailure {
+    let (retryable, code) = match &error {
+        MutationStorageError::Validation(_)
+        | MutationStorageError::InvalidDelivery { .. }
+        | MutationStorageError::DeliveryConflict
+        | MutationStorageError::DeliveryRejected
+        | MutationStorageError::InvalidStoredSourceVersion { .. }
+        | MutationStorageError::SqliteSourceVersionOutOfRange { .. }
+        | MutationStorageError::Serialization(_) => (false, "mutation_rejected"),
+        MutationStorageError::DeliveryInProgress { .. }
+        | MutationStorageError::Storage(_)
+        | MutationStorageError::ConcurrentMutationConflict
+        | MutationStorageError::InboxCompletionLost => (true, "mutation_storage_retryable"),
+    };
+    tracing::error!(
+        error = ?error,
+        replay_failure_code = code,
+        replay_failure_retryable = retryable,
+        "Index replay mutation persistence failed"
+    );
+    if retryable {
+        IndexReplayFailure::retryable_static(code)
+    } else {
+        IndexReplayFailure::permanent_static(code)
+    }
+}
+
+fn ensure_supported_backend(backend: DbBackend) -> Result<(), IndexReplayFailure> {
+    match backend {
+        DbBackend::Postgres => Ok(()),
+        DbBackend::Sqlite if cfg!(test) => Ok(()),
+        backend => {
+            tracing::error!(?backend, "Index replay checkpoint backend is unsupported");
+            Err(IndexReplayFailure::permanent_static(
+                "checkpoint_backend_unsupported",
+            ))
+        }
+    }
+}
+
+fn checkpoint_storage_failure(
+    code: &'static str,
+    error: impl std::fmt::Display,
+) -> IndexReplayFailure {
+    tracing::error!(error = %error, replay_failure_code = code, "Index replay checkpoint storage failed");
+    IndexReplayFailure::retryable_static(code)
+}
+
+fn checkpoint_contract_failure(
+    code: &'static str,
+    error: impl std::fmt::Display,
+) -> IndexReplayFailure {
+    tracing::error!(error = %error, replay_failure_code = code, "Index replay checkpoint contract failed");
+    IndexReplayFailure::permanent_static(code)
+}
+
+fn placeholder_prefix(backend: DbBackend) -> &'static str {
+    match backend {
+        DbBackend::Postgres => "$",
+        DbBackend::Sqlite => "?",
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+fn uuid_value(value: uuid::Uuid, backend: DbBackend) -> SqlValue {
+    match backend {
+        DbBackend::Postgres => value.into(),
+        DbBackend::Sqlite => value.to_string().into(),
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+fn optional_source_version_value(
+    source_version: Option<u64>,
+    backend: DbBackend,
+) -> Result<SqlValue, IndexReplayFailure> {
+    match backend {
+        DbBackend::Postgres => Ok(source_version.map(Decimal::from).into()),
+        DbBackend::Sqlite => source_version
+            .map(|value| {
+                i64::try_from(value).map_err(|error| {
+                    checkpoint_contract_failure("checkpoint_source_version_invalid", error)
+                })
+            })
+            .transpose()
+            .map(Into::into),
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+fn checkpoint_key_values(
+    key: &IndexReplayCheckpointKey,
+    backend: DbBackend,
+) -> Vec<SqlValue> {
+    vec![
+        uuid_value(key.tenant_id(), backend),
+        "rebuild".into(),
+        key.source_name().to_owned().into(),
+        key.schema().module.as_str().to_owned().into(),
+        key.schema().entity.as_str().to_owned().into(),
+        i64::from(key.schema().version.get()).into(),
+        "".into(),
+        key.partition_key().to_owned().into(),
+    ]
+}
+
+fn select_checkpoint_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    format!(
+        "SELECT cursor, CAST(source_version AS TEXT) AS source_version_text, last_delivery_id FROM index_checkpoints WHERE tenant_id = {prefix}1 AND checkpoint_kind = {prefix}2 AND source_name = {prefix}3 AND module_name = {prefix}4 AND entity_name = {prefix}5 AND schema_version = {prefix}6 AND locale_key = {prefix}7 AND partition_key = {prefix}8 LIMIT 1"
+    )
+}
+
+fn upsert_checkpoint_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    format!(
+        "INSERT INTO index_checkpoints (tenant_id, checkpoint_kind, source_name, module_name, entity_name, schema_version, locale_key, partition_key, cursor, source_version, last_delivery_id) VALUES ({prefix}1, {prefix}2, {prefix}3, {prefix}4, {prefix}5, {prefix}6, {prefix}7, {prefix}8, {prefix}9, {prefix}10, {prefix}11) ON CONFLICT (tenant_id, checkpoint_kind, source_name, module_name, entity_name, schema_version, locale_key, partition_key) DO UPDATE SET cursor = excluded.cursor, source_version = COALESCE(excluded.source_version, index_checkpoints.source_version), last_delivery_id = COALESCE(excluded.last_delivery_id, index_checkpoints.last_delivery_id), updated_at = CURRENT_TIMESTAMP"
+    )
+}

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay.rs
@@ -1,7 +1,8 @@
 use async_trait::async_trait;
 use rust_decimal::Decimal;
 use sea_orm::{
-    ConnectionTrait, DatabaseConnection, DbBackend, Statement, Value as SqlValue,
+    ConnectionTrait, DatabaseConnection, DbBackend, Statement, TransactionTrait,
+    Value as SqlValue,
 };
 use serde_json::Value as JsonValue;
 
@@ -10,8 +11,13 @@ use crate::{
     IndexReplayFailure, IndexReplayMutationOutcome, IndexReplayMutationSink, SchemaRegistry,
 };
 
-use super::mutation_store::{
-    MutationApplyOutcome, MutationDelivery, MutationStorageError, PostgresMutationStore,
+use super::{
+    mutation_store::{
+        MutationApplyOutcome, MutationDelivery, MutationStorageError, PostgresMutationStore,
+    },
+    source_replay_job::{
+        assert_active_replay_job_lease, IndexReplayJobError, IndexReplayJobLease,
+    },
 };
 
 #[async_trait]
@@ -40,11 +46,16 @@ impl IndexReplayMutationSink for PostgresMutationStore {
 #[derive(Clone)]
 pub struct PostgresIndexReplayCheckpointStore {
     db: DatabaseConnection,
+    lease: IndexReplayJobLease,
 }
 
 impl PostgresIndexReplayCheckpointStore {
-    pub fn new(db: DatabaseConnection) -> Self {
-        Self { db }
+    pub fn new(db: DatabaseConnection, lease: IndexReplayJobLease) -> Self {
+        Self { db, lease }
+    }
+
+    pub fn lease(&self) -> &IndexReplayJobLease {
+        &self.lease
     }
 }
 
@@ -54,77 +65,173 @@ impl IndexReplayCheckpointStore for PostgresIndexReplayCheckpointStore {
         &self,
         key: &IndexReplayCheckpointKey,
     ) -> Result<Option<IndexReplayCheckpoint>, IndexReplayFailure> {
-        let backend = self.db.get_database_backend();
-        ensure_supported_backend(backend)?;
-        let row = self
+        validate_checkpoint_identity(&self.lease, key)?;
+        let transaction = self
             .db
-            .query_one(Statement::from_sql_and_values(
-                backend,
-                select_checkpoint_sql(backend),
-                checkpoint_key_values(key, backend),
-            ))
+            .begin()
             .await
             .map_err(|error| checkpoint_storage_failure("checkpoint_read_failed", error))?;
-        let Some(row) = row else {
-            return Ok(None);
-        };
+        let result = async {
+            let backend = transaction.get_database_backend();
+            ensure_supported_backend(backend)?;
+            assert_active_replay_job_lease(&transaction, &self.lease, backend)
+                .await
+                .map_err(classify_job_lease_failure)?;
+            let row = transaction
+                .query_one(Statement::from_sql_and_values(
+                    backend,
+                    select_checkpoint_sql(backend),
+                    checkpoint_key_values(key, backend),
+                ))
+                .await
+                .map_err(|error| checkpoint_storage_failure("checkpoint_read_failed", error))?;
+            let Some(row) = row else {
+                return Ok(None);
+            };
 
-        let cursor_json: JsonValue = row
-            .try_get("", "cursor")
-            .map_err(|error| checkpoint_contract_failure("checkpoint_cursor_invalid", error))?;
-        let cursor = serde_json::from_value(cursor_json)
-            .map_err(|error| checkpoint_contract_failure("checkpoint_cursor_invalid", error))?;
-        let source_version_text: Option<String> = row
-            .try_get("", "source_version_text")
-            .map_err(|error| {
-                checkpoint_contract_failure("checkpoint_source_version_invalid", error)
+            let cursor_json: JsonValue = row.try_get("", "cursor").map_err(|error| {
+                checkpoint_contract_failure("checkpoint_cursor_invalid", error)
             })?;
-        let source_version = source_version_text
-            .map(|value| {
-                value.parse::<u64>().map_err(|error| {
+            let cursor = serde_json::from_value(cursor_json).map_err(|error| {
+                checkpoint_contract_failure("checkpoint_cursor_invalid", error)
+            })?;
+            let source_version_text: Option<String> = row
+                .try_get("", "source_version_text")
+                .map_err(|error| {
                     checkpoint_contract_failure("checkpoint_source_version_invalid", error)
+                })?;
+            let source_version = source_version_text
+                .map(|value| {
+                    value.parse::<u64>().map_err(|error| {
+                        checkpoint_contract_failure("checkpoint_source_version_invalid", error)
+                    })
                 })
-            })
-            .transpose()?;
-        let last_delivery_id: Option<String> = row
-            .try_get("", "last_delivery_id")
-            .map_err(|error| checkpoint_contract_failure("checkpoint_delivery_invalid", error))?;
+                .transpose()?;
+            let last_delivery_id: Option<String> = row.try_get("", "last_delivery_id").map_err(
+                |error| checkpoint_contract_failure("checkpoint_delivery_invalid", error),
+            )?;
 
-        IndexReplayCheckpoint::new(key.clone(), cursor, source_version, last_delivery_id)
-            .map(Some)
-            .map_err(|error| checkpoint_contract_failure("checkpoint_contract_invalid", error))
+            IndexReplayCheckpoint::new(key.clone(), cursor, source_version, last_delivery_id)
+                .map(Some)
+                .map_err(|error| {
+                    checkpoint_contract_failure("checkpoint_contract_invalid", error)
+                })
+        }
+        .await;
+
+        match result {
+            Ok(checkpoint) => {
+                transaction
+                    .commit()
+                    .await
+                    .map_err(|error| checkpoint_storage_failure("checkpoint_read_failed", error))?;
+                Ok(checkpoint)
+            }
+            Err(error) => {
+                transaction
+                    .rollback()
+                    .await
+                    .map_err(|rollback| {
+                        checkpoint_storage_failure("checkpoint_read_rollback_failed", rollback)
+                    })?;
+                Err(error)
+            }
+        }
     }
 
     async fn commit_replay_checkpoint(
         &self,
         checkpoint: &IndexReplayCheckpoint,
     ) -> Result<(), IndexReplayFailure> {
-        let backend = self.db.get_database_backend();
-        ensure_supported_backend(backend)?;
-        let cursor = serde_json::to_value(checkpoint.cursor())
-            .map_err(|error| checkpoint_contract_failure("checkpoint_cursor_invalid", error))?;
-        let mut values = checkpoint_key_values(checkpoint.key(), backend);
-        values.push(SqlValue::Json(Some(Box::new(cursor))));
-        values.push(optional_source_version_value(
-            checkpoint.source_version(),
-            backend,
-        )?);
-        values.push(
-            checkpoint
-                .last_delivery_id()
-                .map(str::to_owned)
-                .into(),
-        );
-
-        self.db
-            .execute(Statement::from_sql_and_values(
-                backend,
-                upsert_checkpoint_sql(backend),
-                values,
-            ))
+        validate_checkpoint_identity(&self.lease, checkpoint.key())?;
+        let transaction = self
+            .db
+            .begin()
             .await
             .map_err(|error| checkpoint_storage_failure("checkpoint_commit_failed", error))?;
-        Ok(())
+        let result = async {
+            let backend = transaction.get_database_backend();
+            ensure_supported_backend(backend)?;
+            assert_active_replay_job_lease(&transaction, &self.lease, backend)
+                .await
+                .map_err(classify_job_lease_failure)?;
+            let cursor = serde_json::to_value(checkpoint.cursor()).map_err(|error| {
+                checkpoint_contract_failure("checkpoint_cursor_invalid", error)
+            })?;
+            let mut values = checkpoint_key_values(checkpoint.key(), backend);
+            values.push(SqlValue::Json(Some(Box::new(cursor))));
+            values.push(optional_source_version_value(
+                checkpoint.source_version(),
+                backend,
+            )?);
+            values.push(
+                checkpoint
+                    .last_delivery_id()
+                    .map(str::to_owned)
+                    .into(),
+            );
+
+            transaction
+                .execute(Statement::from_sql_and_values(
+                    backend,
+                    upsert_checkpoint_sql(backend),
+                    values,
+                ))
+                .await
+                .map_err(|error| checkpoint_storage_failure("checkpoint_commit_failed", error))?;
+            Ok(())
+        }
+        .await;
+
+        match result {
+            Ok(()) => transaction
+                .commit()
+                .await
+                .map_err(|error| checkpoint_storage_failure("checkpoint_commit_failed", error)),
+            Err(error) => {
+                transaction
+                    .rollback()
+                    .await
+                    .map_err(|rollback| {
+                        checkpoint_storage_failure("checkpoint_commit_rollback_failed", rollback)
+                    })?;
+                Err(error)
+            }
+        }
+    }
+}
+
+fn validate_checkpoint_identity(
+    lease: &IndexReplayJobLease,
+    key: &IndexReplayCheckpointKey,
+) -> Result<(), IndexReplayFailure> {
+    if key.tenant_id() != lease.tenant_id()
+        || key.source_name() != lease.source_name()
+        || key.schema() != lease.schema()
+    {
+        return Err(IndexReplayFailure::permanent_static(
+            "checkpoint_lease_identity_mismatch",
+        ));
+    }
+    Ok(())
+}
+
+fn classify_job_lease_failure(error: IndexReplayJobError) -> IndexReplayFailure {
+    let (retryable, code) = match &error {
+        IndexReplayJobError::Storage(_) => (true, "checkpoint_lease_storage_retryable"),
+        IndexReplayJobError::LeaseLost => (false, "checkpoint_lease_lost"),
+        _ => (false, "checkpoint_lease_contract_invalid"),
+    };
+    tracing::error!(
+        error = ?error,
+        replay_failure_code = code,
+        replay_failure_retryable = retryable,
+        "Index replay checkpoint lease validation failed"
+    );
+    if retryable {
+        IndexReplayFailure::retryable_static(code)
+    } else {
+        IndexReplayFailure::permanent_static(code)
     }
 }
 

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_job.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_job.rs
@@ -338,7 +338,7 @@ impl PostgresIndexReplayJobStore {
             attempt_count = 1;
             let job_request = json!({
                 "contract": REPLAY_JOB_REQUEST_CONTRACT,
-                "source_name": request.source_name,
+                "source_name": request.source_name.clone(),
             });
             transaction
                 .execute(Statement::from_sql_and_values(
@@ -518,9 +518,8 @@ async fn lock_replay_scope(
         return Ok(());
     }
     let lock_key = format!(
-        "{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}",
+        "{}\u{1f}{}\u{1f}{}\u{1f}{}",
         request.tenant_id,
-        request.source_name,
         request.schema.module.as_str(),
         request.schema.entity.as_str(),
         request.schema.version.get(),
@@ -581,15 +580,13 @@ fn validate_source_name(source_name: &str) -> Result<(), IndexReplayJobError> {
 }
 
 fn validate_worker_id(worker_id: &str) -> Result<(), IndexReplayJobError> {
-    validate_storage_text(worker_id, MAX_WORKER_ID_BYTES).map_err(|reason| {
-        IndexReplayJobError::InvalidWorkerId { reason }
-    })
+    validate_storage_text(worker_id, MAX_WORKER_ID_BYTES)
+        .map_err(|reason| IndexReplayJobError::InvalidWorkerId { reason })
 }
 
 fn validate_error_code(error_code: &str) -> Result<(), IndexReplayJobError> {
-    validate_storage_text(error_code, MAX_ERROR_CODE_BYTES).map_err(|reason| {
-        IndexReplayJobError::InvalidErrorCode { reason }
-    })
+    validate_storage_text(error_code, MAX_ERROR_CODE_BYTES)
+        .map_err(|reason| IndexReplayJobError::InvalidErrorCode { reason })
 }
 
 fn validate_storage_text(value: &str, max_bytes: usize) -> Result<(), &'static str> {

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_job.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_job.rs
@@ -1,0 +1,770 @@
+use std::time::Duration;
+
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, QueryResult, Statement,
+    TransactionTrait, Value as SqlValue,
+};
+use serde_json::{json, Value as JsonValue};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::SchemaRef;
+
+const REPLAY_JOB_REQUEST_CONTRACT: &str = "index_replay_job_v1";
+const MAX_SOURCE_NAME_BYTES: usize = 128;
+const MAX_WORKER_ID_BYTES: usize = 191;
+const MAX_ERROR_CODE_BYTES: usize = 128;
+const MAX_LEASE_SECONDS: u64 = 86_400;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexReplayJobLeaseRequest {
+    tenant_id: Uuid,
+    schema: SchemaRef,
+    source_name: String,
+    worker_id: String,
+    lease_seconds: u64,
+}
+
+impl IndexReplayJobLeaseRequest {
+    pub fn new(
+        tenant_id: Uuid,
+        schema: SchemaRef,
+        source_name: impl Into<String>,
+        worker_id: impl Into<String>,
+        lease_duration: Duration,
+    ) -> Result<Self, IndexReplayJobError> {
+        if tenant_id.is_nil() {
+            return Err(IndexReplayJobError::NilTenantId);
+        }
+        let source_name = source_name.into();
+        validate_source_name(&source_name)?;
+        let worker_id = worker_id.into();
+        validate_worker_id(&worker_id)?;
+        let lease_seconds = validate_lease_duration(lease_duration)?;
+        Ok(Self {
+            tenant_id,
+            schema,
+            source_name,
+            worker_id,
+            lease_seconds,
+        })
+    }
+
+    pub fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    pub fn source_name(&self) -> &str {
+        &self.source_name
+    }
+
+    pub fn worker_id(&self) -> &str {
+        &self.worker_id
+    }
+
+    pub fn lease_duration(&self) -> Duration {
+        Duration::from_secs(self.lease_seconds)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexReplayJobLease {
+    tenant_id: Uuid,
+    job_id: Uuid,
+    schema: SchemaRef,
+    source_name: String,
+    worker_id: String,
+    attempt_count: u32,
+}
+
+impl IndexReplayJobLease {
+    pub fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub fn job_id(&self) -> Uuid {
+        self.job_id
+    }
+
+    pub fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    pub fn source_name(&self) -> &str {
+        &self.source_name
+    }
+
+    pub fn worker_id(&self) -> &str {
+        &self.worker_id
+    }
+
+    pub fn attempt_count(&self) -> u32 {
+        self.attempt_count
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IndexReplayJobAcquireOutcome {
+    Acquired(IndexReplayJobLease),
+    Busy,
+    AlreadyComplete { job_id: Uuid },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum IndexReplayJobError {
+    #[error("Index replay job tenant id must not be nil")]
+    NilTenantId,
+    #[error("invalid Index replay source name: {reason}")]
+    InvalidSourceName { reason: &'static str },
+    #[error("invalid Index replay worker id: {reason}")]
+    InvalidWorkerId { reason: &'static str },
+    #[error("Index replay lease duration must be a whole number of seconds between 1 and 86400")]
+    InvalidLeaseDuration,
+    #[error("invalid Index replay error code: {reason}")]
+    InvalidErrorCode { reason: &'static str },
+    #[error("Index replay schema is not persisted for this tenant: {0}")]
+    SchemaNotRegistered(SchemaRef),
+    #[error("Index replay schema is retired: {0}")]
+    SchemaRetired(SchemaRef),
+    #[error("stored Index replay job is invalid: {0}")]
+    InvalidStoredJob(String),
+    #[error("Index replay completion checkpoint is missing")]
+    CheckpointMissing,
+    #[error("Index replay completion checkpoint still has a continuation cursor")]
+    CheckpointIncomplete,
+    #[error("Index replay job lease ownership was lost")]
+    LeaseLost,
+    #[error("Index replay job storage operation failed")]
+    Storage(String),
+}
+
+#[derive(Clone)]
+pub struct PostgresIndexReplayJobStore {
+    db: DatabaseConnection,
+}
+
+impl PostgresIndexReplayJobStore {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    pub async fn acquire(
+        &self,
+        request: &IndexReplayJobLeaseRequest,
+    ) -> Result<IndexReplayJobAcquireOutcome, IndexReplayJobError> {
+        let transaction = self.db.begin().await.map_err(storage_error)?;
+        let result = self.acquire_in_transaction(&transaction, request).await;
+        match result {
+            Ok(outcome) => {
+                transaction.commit().await.map_err(storage_error)?;
+                Ok(outcome)
+            }
+            Err(error) => {
+                transaction.rollback().await.map_err(storage_error)?;
+                Err(error)
+            }
+        }
+    }
+
+    pub async fn heartbeat(
+        &self,
+        lease: &IndexReplayJobLease,
+        lease_duration: Duration,
+    ) -> Result<(), IndexReplayJobError> {
+        let lease_seconds = validate_lease_duration(lease_duration)?;
+        let backend = self.db.get_database_backend();
+        ensure_supported_backend(backend)?;
+        let updated = self
+            .db
+            .execute(Statement::from_sql_and_values(
+                backend,
+                heartbeat_sql(backend),
+                vec![
+                    uuid_value(lease.tenant_id, backend),
+                    uuid_value(lease.job_id, backend),
+                    lease.worker_id.clone().into(),
+                    i64::from(lease.attempt_count).into(),
+                    i64::try_from(lease_seconds)
+                        .map_err(|_| IndexReplayJobError::InvalidLeaseDuration)?
+                        .into(),
+                ],
+            ))
+            .await
+            .map_err(storage_error)?;
+        if updated.rows_affected() != 1 {
+            return Err(IndexReplayJobError::LeaseLost);
+        }
+        Ok(())
+    }
+
+    pub async fn succeed(&self, lease: &IndexReplayJobLease) -> Result<(), IndexReplayJobError> {
+        let transaction = self.db.begin().await.map_err(storage_error)?;
+        let result = async {
+            let backend = transaction.get_database_backend();
+            ensure_supported_backend(backend)?;
+            assert_active_replay_job_lease(&transaction, lease, backend).await?;
+            require_complete_checkpoint(&transaction, lease, backend).await?;
+            finish_job(&transaction, lease, "succeeded", None, None, backend).await
+        }
+        .await;
+        match result {
+            Ok(()) => {
+                transaction.commit().await.map_err(storage_error)?;
+                Ok(())
+            }
+            Err(error) => {
+                transaction.rollback().await.map_err(storage_error)?;
+                Err(error)
+            }
+        }
+    }
+
+    pub async fn fail(
+        &self,
+        lease: &IndexReplayJobLease,
+        error_code: impl Into<String>,
+        error_details: JsonValue,
+    ) -> Result<(), IndexReplayJobError> {
+        let error_code = error_code.into();
+        validate_error_code(&error_code)?;
+        let backend = self.db.get_database_backend();
+        ensure_supported_backend(backend)?;
+        let updated = self
+            .db
+            .execute(Statement::from_sql_and_values(
+                backend,
+                finish_job_sql(backend),
+                vec![
+                    "failed".into(),
+                    Some(error_code).into(),
+                    SqlValue::Json(Some(Box::new(error_details))),
+                    uuid_value(lease.tenant_id, backend),
+                    uuid_value(lease.job_id, backend),
+                    lease.worker_id.clone().into(),
+                    i64::from(lease.attempt_count).into(),
+                ],
+            ))
+            .await
+            .map_err(storage_error)?;
+        if updated.rows_affected() != 1 {
+            return Err(IndexReplayJobError::LeaseLost);
+        }
+        Ok(())
+    }
+
+    async fn acquire_in_transaction(
+        &self,
+        transaction: &DatabaseTransaction,
+        request: &IndexReplayJobLeaseRequest,
+    ) -> Result<IndexReplayJobAcquireOutcome, IndexReplayJobError> {
+        let backend = transaction.get_database_backend();
+        ensure_supported_backend(backend)?;
+        lock_replay_scope(transaction, request, backend).await?;
+        verify_schema_registration(transaction, request, backend).await?;
+
+        let rows = transaction
+            .query_all(Statement::from_sql_and_values(
+                backend,
+                select_replay_jobs_sql(backend),
+                replay_scope_values(request, backend),
+            ))
+            .await
+            .map_err(storage_error)?;
+
+        let mut claimable = None;
+        for row in rows {
+            let stored = stored_job(&row, backend)?;
+            if stored.source_name != request.source_name {
+                return Err(IndexReplayJobError::InvalidStoredJob(
+                    "request.source_name does not match the replay scope owner".to_owned(),
+                ));
+            }
+            match stored.state.as_str() {
+                "succeeded" => {
+                    return Ok(IndexReplayJobAcquireOutcome::AlreadyComplete {
+                        job_id: stored.job_id,
+                    });
+                }
+                "running" if !stored.claimable => {
+                    return Ok(IndexReplayJobAcquireOutcome::Busy);
+                }
+                "pending" if !stored.claimable => {
+                    return Ok(IndexReplayJobAcquireOutcome::Busy);
+                }
+                "pending" | "running" => {
+                    claimable = Some(stored);
+                    break;
+                }
+                state => {
+                    return Err(IndexReplayJobError::InvalidStoredJob(format!(
+                        "unexpected active state {state}"
+                    )));
+                }
+            }
+        }
+
+        let job_id;
+        let attempt_count;
+        if let Some(stored) = claimable {
+            job_id = stored.job_id;
+            attempt_count = stored.attempt_count.checked_add(1).ok_or_else(|| {
+                IndexReplayJobError::InvalidStoredJob("attempt count overflow".to_owned())
+            })?;
+            let claimed = transaction
+                .execute(Statement::from_sql_and_values(
+                    backend,
+                    claim_job_sql(backend),
+                    vec![
+                        uuid_value(request.tenant_id, backend),
+                        uuid_value(job_id, backend),
+                        request.worker_id.clone().into(),
+                        i64::from(attempt_count).into(),
+                        i64::try_from(request.lease_seconds)
+                            .map_err(|_| IndexReplayJobError::InvalidLeaseDuration)?
+                            .into(),
+                    ],
+                ))
+                .await
+                .map_err(storage_error)?;
+            if claimed.rows_affected() != 1 {
+                return Err(IndexReplayJobError::LeaseLost);
+            }
+        } else {
+            job_id = Uuid::new_v4();
+            attempt_count = 1;
+            let job_request = json!({
+                "contract": REPLAY_JOB_REQUEST_CONTRACT,
+                "source_name": request.source_name,
+            });
+            transaction
+                .execute(Statement::from_sql_and_values(
+                    backend,
+                    insert_job_sql(backend),
+                    vec![
+                        uuid_value(request.tenant_id, backend),
+                        uuid_value(job_id, backend),
+                        request.schema.module.as_str().to_owned().into(),
+                        request.schema.entity.as_str().to_owned().into(),
+                        i64::from(request.schema.version.get()).into(),
+                        SqlValue::Json(Some(Box::new(job_request))),
+                        request.worker_id.clone().into(),
+                        i64::try_from(request.lease_seconds)
+                            .map_err(|_| IndexReplayJobError::InvalidLeaseDuration)?
+                            .into(),
+                    ],
+                ))
+                .await
+                .map_err(storage_error)?;
+        }
+
+        Ok(IndexReplayJobAcquireOutcome::Acquired(IndexReplayJobLease {
+            tenant_id: request.tenant_id,
+            job_id,
+            schema: request.schema.clone(),
+            source_name: request.source_name.clone(),
+            worker_id: request.worker_id.clone(),
+            attempt_count,
+        }))
+    }
+}
+
+#[derive(Debug)]
+struct StoredJob {
+    job_id: Uuid,
+    state: String,
+    source_name: String,
+    attempt_count: u32,
+    claimable: bool,
+}
+
+fn stored_job(row: &QueryResult, backend: DbBackend) -> Result<StoredJob, IndexReplayJobError> {
+    let request: JsonValue = row.try_get("", "request").map_err(storage_error)?;
+    let object = request.as_object().ok_or_else(|| {
+        IndexReplayJobError::InvalidStoredJob("request must be a JSON object".to_owned())
+    })?;
+    if object.len() != 2
+        || object.get("contract").and_then(JsonValue::as_str)
+            != Some(REPLAY_JOB_REQUEST_CONTRACT)
+    {
+        return Err(IndexReplayJobError::InvalidStoredJob(
+            "request must use the exact index_replay_job_v1 contract".to_owned(),
+        ));
+    }
+    let source_name = object
+        .get("source_name")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| {
+            IndexReplayJobError::InvalidStoredJob(
+                "request.source_name must be a string".to_owned(),
+            )
+        })?
+        .to_owned();
+    validate_source_name(&source_name).map_err(|_| {
+        IndexReplayJobError::InvalidStoredJob(
+            "request.source_name is outside the replay source contract".to_owned(),
+        )
+    })?;
+    let attempt_count: i64 = row
+        .try_get("", "attempt_count_value")
+        .map_err(storage_error)?;
+    let attempt_count = u32::try_from(attempt_count).map_err(|_| {
+        IndexReplayJobError::InvalidStoredJob("attempt count is outside the u32 range".to_owned())
+    })?;
+    Ok(StoredJob {
+        job_id: stored_uuid(row, "job_id", backend)?,
+        state: row.try_get("", "state").map_err(storage_error)?,
+        source_name,
+        attempt_count,
+        claimable: row.try_get("", "claimable").map_err(storage_error)?,
+    })
+}
+
+pub(super) async fn assert_active_replay_job_lease(
+    transaction: &DatabaseTransaction,
+    lease: &IndexReplayJobLease,
+    backend: DbBackend,
+) -> Result<(), IndexReplayJobError> {
+    ensure_supported_backend(backend)?;
+    let row = transaction
+        .query_one(Statement::from_sql_and_values(
+            backend,
+            active_lease_sql(backend),
+            vec![
+                uuid_value(lease.tenant_id, backend),
+                uuid_value(lease.job_id, backend),
+                lease.worker_id.clone().into(),
+                i64::from(lease.attempt_count).into(),
+            ],
+        ))
+        .await
+        .map_err(storage_error)?;
+    let Some(row) = row else {
+        return Err(IndexReplayJobError::LeaseLost);
+    };
+    let active: bool = row.try_get("", "active").map_err(storage_error)?;
+    if !active {
+        return Err(IndexReplayJobError::LeaseLost);
+    }
+    Ok(())
+}
+
+async fn require_complete_checkpoint(
+    transaction: &DatabaseTransaction,
+    lease: &IndexReplayJobLease,
+    backend: DbBackend,
+) -> Result<(), IndexReplayJobError> {
+    let row = transaction
+        .query_one(Statement::from_sql_and_values(
+            backend,
+            complete_checkpoint_sql(backend),
+            vec![
+                uuid_value(lease.tenant_id, backend),
+                lease.source_name.clone().into(),
+                lease.schema.module.as_str().to_owned().into(),
+                lease.schema.entity.as_str().to_owned().into(),
+                i64::from(lease.schema.version.get()).into(),
+            ],
+        ))
+        .await
+        .map_err(storage_error)?
+        .ok_or(IndexReplayJobError::CheckpointMissing)?;
+    let cursor: JsonValue = row.try_get("", "cursor").map_err(storage_error)?;
+    if !cursor.is_null() {
+        return Err(IndexReplayJobError::CheckpointIncomplete);
+    }
+    Ok(())
+}
+
+async fn finish_job(
+    transaction: &DatabaseTransaction,
+    lease: &IndexReplayJobLease,
+    state: &'static str,
+    error_code: Option<String>,
+    error_details: Option<JsonValue>,
+    backend: DbBackend,
+) -> Result<(), IndexReplayJobError> {
+    let updated = transaction
+        .execute(Statement::from_sql_and_values(
+            backend,
+            finish_job_sql(backend),
+            vec![
+                state.into(),
+                error_code.into(),
+                SqlValue::Json(error_details.map(Box::new)),
+                uuid_value(lease.tenant_id, backend),
+                uuid_value(lease.job_id, backend),
+                lease.worker_id.clone().into(),
+                i64::from(lease.attempt_count).into(),
+            ],
+        ))
+        .await
+        .map_err(storage_error)?;
+    if updated.rows_affected() != 1 {
+        return Err(IndexReplayJobError::LeaseLost);
+    }
+    Ok(())
+}
+
+async fn lock_replay_scope(
+    transaction: &DatabaseTransaction,
+    request: &IndexReplayJobLeaseRequest,
+    backend: DbBackend,
+) -> Result<(), IndexReplayJobError> {
+    if backend == DbBackend::Sqlite {
+        return Ok(());
+    }
+    let lock_key = format!(
+        "{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}",
+        request.tenant_id,
+        request.source_name,
+        request.schema.module.as_str(),
+        request.schema.entity.as_str(),
+        request.schema.version.get(),
+    );
+    transaction
+        .execute(Statement::from_sql_and_values(
+            backend,
+            "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+            vec![lock_key.into()],
+        ))
+        .await
+        .map_err(storage_error)?;
+    Ok(())
+}
+
+async fn verify_schema_registration(
+    transaction: &DatabaseTransaction,
+    request: &IndexReplayJobLeaseRequest,
+    backend: DbBackend,
+) -> Result<(), IndexReplayJobError> {
+    let row = transaction
+        .query_one(Statement::from_sql_and_values(
+            backend,
+            select_schema_sql(backend),
+            replay_scope_values(request, backend),
+        ))
+        .await
+        .map_err(storage_error)?
+        .ok_or_else(|| IndexReplayJobError::SchemaNotRegistered(request.schema.clone()))?;
+    let status: String = row.try_get("", "status").map_err(storage_error)?;
+    if status != "active" {
+        return Err(IndexReplayJobError::SchemaRetired(request.schema.clone()));
+    }
+    Ok(())
+}
+
+fn validate_source_name(source_name: &str) -> Result<(), IndexReplayJobError> {
+    if source_name.is_empty() {
+        return Err(IndexReplayJobError::InvalidSourceName {
+            reason: "must not be empty",
+        });
+    }
+    if source_name.len() > MAX_SOURCE_NAME_BYTES {
+        return Err(IndexReplayJobError::InvalidSourceName {
+            reason: "exceeds the storage limit",
+        });
+    }
+    if !source_name.bytes().all(|byte| {
+        byte.is_ascii_lowercase()
+            || byte.is_ascii_digit()
+            || matches!(byte, b'-' | b'_' | b'.')
+    }) {
+        return Err(IndexReplayJobError::InvalidSourceName {
+            reason: "must be a lowercase machine name",
+        });
+    }
+    Ok(())
+}
+
+fn validate_worker_id(worker_id: &str) -> Result<(), IndexReplayJobError> {
+    validate_storage_text(worker_id, MAX_WORKER_ID_BYTES).map_err(|reason| {
+        IndexReplayJobError::InvalidWorkerId { reason }
+    })
+}
+
+fn validate_error_code(error_code: &str) -> Result<(), IndexReplayJobError> {
+    validate_storage_text(error_code, MAX_ERROR_CODE_BYTES).map_err(|reason| {
+        IndexReplayJobError::InvalidErrorCode { reason }
+    })
+}
+
+fn validate_storage_text(value: &str, max_bytes: usize) -> Result<(), &'static str> {
+    if value.is_empty() {
+        return Err("must not be empty");
+    }
+    if value.trim() != value {
+        return Err("must not contain leading or trailing whitespace");
+    }
+    if value.len() > max_bytes {
+        return Err("exceeds the storage limit");
+    }
+    if value.chars().any(char::is_control) {
+        return Err("must not contain control characters");
+    }
+    Ok(())
+}
+
+fn validate_lease_duration(lease_duration: Duration) -> Result<u64, IndexReplayJobError> {
+    if lease_duration.subsec_nanos() != 0 {
+        return Err(IndexReplayJobError::InvalidLeaseDuration);
+    }
+    let seconds = lease_duration.as_secs();
+    if seconds == 0 || seconds > MAX_LEASE_SECONDS {
+        return Err(IndexReplayJobError::InvalidLeaseDuration);
+    }
+    Ok(seconds)
+}
+
+fn ensure_supported_backend(backend: DbBackend) -> Result<(), IndexReplayJobError> {
+    match backend {
+        DbBackend::Postgres => Ok(()),
+        DbBackend::Sqlite if cfg!(test) => Ok(()),
+        backend => Err(IndexReplayJobError::Storage(format!(
+            "Index replay jobs do not support {backend:?}"
+        ))),
+    }
+}
+
+fn storage_error(error: impl std::fmt::Display) -> IndexReplayJobError {
+    IndexReplayJobError::Storage(error.to_string())
+}
+
+fn placeholder_prefix(backend: DbBackend) -> &'static str {
+    match backend {
+        DbBackend::Postgres => "$",
+        DbBackend::Sqlite => "?",
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+fn uuid_value(value: Uuid, backend: DbBackend) -> SqlValue {
+    match backend {
+        DbBackend::Postgres => value.into(),
+        DbBackend::Sqlite => value.to_string().into(),
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+fn stored_uuid(
+    row: &QueryResult,
+    column: &str,
+    backend: DbBackend,
+) -> Result<Uuid, IndexReplayJobError> {
+    match backend {
+        DbBackend::Postgres => row.try_get("", column).map_err(storage_error),
+        DbBackend::Sqlite => {
+            let value: String = row.try_get("", column).map_err(storage_error)?;
+            Uuid::parse_str(&value).map_err(storage_error)
+        }
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+fn replay_scope_values(
+    request: &IndexReplayJobLeaseRequest,
+    backend: DbBackend,
+) -> Vec<SqlValue> {
+    vec![
+        uuid_value(request.tenant_id, backend),
+        request.schema.module.as_str().to_owned().into(),
+        request.schema.entity.as_str().to_owned().into(),
+        i64::from(request.schema.version.get()).into(),
+    ]
+}
+
+fn select_schema_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    format!(
+        "SELECT status FROM index_schemas WHERE tenant_id = {prefix}1 AND module_name = {prefix}2 AND entity_name = {prefix}3 AND schema_version = {prefix}4 LIMIT 1"
+    )
+}
+
+fn select_replay_jobs_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    let (attempt_count, claimable) = match backend {
+        DbBackend::Postgres => (
+            "CAST(attempt_count AS BIGINT)",
+            "((state = 'pending' AND available_at <= CURRENT_TIMESTAMP) OR (state = 'running' AND lease_expires_at <= CURRENT_TIMESTAMP))",
+        ),
+        DbBackend::Sqlite => (
+            "CAST(attempt_count AS INTEGER)",
+            "CASE WHEN (state = 'pending' AND available_at <= CURRENT_TIMESTAMP) OR (state = 'running' AND lease_expires_at <= CURRENT_TIMESTAMP) THEN TRUE ELSE FALSE END",
+        ),
+        _ => unreachable!("unsupported database backend was validated"),
+    };
+    format!(
+        "SELECT job_id, state, request, {attempt_count} AS attempt_count_value, {claimable} AS claimable FROM index_jobs WHERE tenant_id = {prefix}1 AND module_name = {prefix}2 AND entity_name = {prefix}3 AND schema_version = {prefix}4 AND kind = 'rebuild' AND scope_kind = 'schema' AND state IN ('pending', 'running', 'succeeded') ORDER BY CASE state WHEN 'succeeded' THEN 0 WHEN 'running' THEN 1 ELSE 2 END, created_at DESC"
+    )
+}
+
+fn insert_job_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    let lease_expires = lease_expires_expression(backend, 8);
+    format!(
+        "INSERT INTO index_jobs (tenant_id, job_id, kind, state, scope_kind, module_name, entity_name, schema_version, request, attempt_count, available_at, lease_owner, lease_expires_at, heartbeat_at) VALUES ({prefix}1, {prefix}2, 'rebuild', 'running', 'schema', {prefix}3, {prefix}4, {prefix}5, {prefix}6, 1, CURRENT_TIMESTAMP, {prefix}7, {lease_expires}, CURRENT_TIMESTAMP)"
+    )
+}
+
+fn claim_job_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    let lease_expires = lease_expires_expression(backend, 5);
+    format!(
+        "UPDATE index_jobs SET state = 'running', lease_owner = {prefix}3, attempt_count = {prefix}4, lease_expires_at = {lease_expires}, heartbeat_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP, completed_at = NULL, last_error_code = NULL, last_error_details = NULL WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'rebuild' AND ((state = 'pending' AND available_at <= CURRENT_TIMESTAMP) OR (state = 'running' AND lease_expires_at <= CURRENT_TIMESTAMP))"
+    )
+}
+
+fn heartbeat_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    let lease_expires = lease_expires_expression(backend, 5);
+    format!(
+        "UPDATE index_jobs SET lease_expires_at = {lease_expires}, heartbeat_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'rebuild' AND state = 'running' AND lease_owner = {prefix}3 AND attempt_count = {prefix}4 AND lease_expires_at > CURRENT_TIMESTAMP"
+    )
+}
+
+fn finish_job_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    format!(
+        "UPDATE index_jobs SET state = {prefix}1, lease_owner = NULL, lease_expires_at = NULL, heartbeat_at = CURRENT_TIMESTAMP, last_error_code = {prefix}2, last_error_details = {prefix}3, completed_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE tenant_id = {prefix}4 AND job_id = {prefix}5 AND kind = 'rebuild' AND state = 'running' AND lease_owner = {prefix}6 AND attempt_count = {prefix}7 AND lease_expires_at > CURRENT_TIMESTAMP"
+    )
+}
+
+fn active_lease_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    let lock = match backend {
+        DbBackend::Postgres => " FOR UPDATE",
+        DbBackend::Sqlite => "",
+        _ => unreachable!("unsupported database backend was validated"),
+    };
+    format!(
+        "SELECT CASE WHEN lease_expires_at > CURRENT_TIMESTAMP THEN TRUE ELSE FALSE END AS active FROM index_jobs WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'rebuild' AND state = 'running' AND lease_owner = {prefix}3 AND attempt_count = {prefix}4 LIMIT 1{lock}"
+    )
+}
+
+fn complete_checkpoint_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    let lock = match backend {
+        DbBackend::Postgres => " FOR UPDATE",
+        DbBackend::Sqlite => "",
+        _ => unreachable!("unsupported database backend was validated"),
+    };
+    format!(
+        "SELECT cursor FROM index_checkpoints WHERE tenant_id = {prefix}1 AND checkpoint_kind = 'rebuild' AND source_name = {prefix}2 AND module_name = {prefix}3 AND entity_name = {prefix}4 AND schema_version = {prefix}5 AND locale_key = '' AND partition_key = '' LIMIT 1{lock}"
+    )
+}
+
+fn lease_expires_expression(backend: DbBackend, parameter: usize) -> String {
+    let prefix = placeholder_prefix(backend);
+    match backend {
+        DbBackend::Postgres => {
+            format!("CURRENT_TIMESTAMP + ({prefix}{parameter} * INTERVAL '1 second')")
+        }
+        DbBackend::Sqlite => {
+            format!("datetime('now', '+' || {prefix}{parameter} || ' seconds')")
+        }
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_job_tests.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_job_tests.rs
@@ -1,0 +1,316 @@
+use std::time::Duration;
+
+use rustok_core::MigrationSource;
+use sea_orm::{
+    ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement, Value as SqlValue,
+};
+use sea_orm_migration::SchemaManager;
+use serde_json::json;
+use uuid::Uuid;
+
+use super::{
+    IndexReplayJobAcquireOutcome, IndexReplayJobError, IndexReplayJobLease,
+    IndexReplayJobLeaseRequest, PostgresIndexReplayCheckpointStore, PostgresIndexReplayJobStore,
+};
+use crate::{
+    EntityName, FieldCardinality, FieldName, IndexField, IndexModule, IndexReplayCheckpoint,
+    IndexReplayCheckpointKey, IndexReplayCheckpointStore, IndexReplayFailureKind, IndexSchema,
+    IndexSourceCursor, IndexValueType, LocaleMode, ModuleName, SchemaRef, SchemaVersion,
+};
+
+const TENANT: &str = "11111111-1111-1111-1111-111111111111";
+const SOURCE: &str = "product-primary";
+
+struct Fixture {
+    db: DatabaseConnection,
+    jobs: PostgresIndexReplayJobStore,
+    schema: IndexSchema,
+}
+
+impl Fixture {
+    async fn new(status: &str) -> Self {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite should connect");
+        db.execute_unprepared("PRAGMA foreign_keys = ON")
+            .await
+            .expect("foreign keys should be enabled");
+        db.execute_unprepared("CREATE TABLE tenants (id TEXT PRIMARY KEY)")
+            .await
+            .expect("tenant fixture should be created");
+        db.execute_unprepared(&format!("INSERT INTO tenants (id) VALUES ('{TENANT}')"))
+            .await
+            .expect("tenant fixture should be inserted");
+        let manager = SchemaManager::new(&db);
+        for migration in IndexModule.migrations() {
+            migration
+                .up(&manager)
+                .await
+                .unwrap_or_else(|error| panic!("{} should apply: {error}", migration.name()));
+        }
+
+        let schema = schema();
+        let fingerprint = schema.fingerprint().unwrap().to_string();
+        let schema_json = serde_json::to_value(&schema).unwrap();
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO index_schemas (tenant_id, module_name, entity_name, schema_version, schema_fingerprint, schema_json, status) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            vec![
+                TENANT.to_owned().into(),
+                schema.reference.module.as_str().to_owned().into(),
+                schema.reference.entity.as_str().to_owned().into(),
+                i64::from(schema.reference.version.get()).into(),
+                fingerprint.into(),
+                SqlValue::Json(Some(Box::new(schema_json))),
+                status.to_owned().into(),
+            ],
+        ))
+        .await
+        .expect("schema fixture should persist");
+        let jobs = PostgresIndexReplayJobStore::new(db.clone());
+        Self { db, jobs, schema }
+    }
+
+    fn request(&self, worker: &str) -> IndexReplayJobLeaseRequest {
+        IndexReplayJobLeaseRequest::new(
+            Uuid::parse_str(TENANT).unwrap(),
+            self.schema.reference.clone(),
+            SOURCE,
+            worker,
+            Duration::from_secs(60),
+        )
+        .unwrap()
+    }
+
+    async fn acquire(&self, worker: &str) -> IndexReplayJobLease {
+        match self.jobs.acquire(&self.request(worker)).await.unwrap() {
+            IndexReplayJobAcquireOutcome::Acquired(lease) => lease,
+            outcome => panic!("replay job should be acquired, got {outcome:?}"),
+        }
+    }
+
+    fn checkpoint(
+        &self,
+        cursor: Option<IndexSourceCursor>,
+        source_version: u64,
+    ) -> IndexReplayCheckpoint {
+        IndexReplayCheckpoint::new(
+            IndexReplayCheckpointKey::new(
+                Uuid::parse_str(TENANT).unwrap(),
+                SOURCE,
+                self.schema.reference.clone(),
+            )
+            .unwrap(),
+            cursor,
+            Some(source_version),
+            Some(Uuid::from_u128(u128::from(source_version)).to_string()),
+        )
+        .unwrap()
+    }
+}
+
+fn schema() -> IndexSchema {
+    IndexSchema {
+        reference: SchemaRef {
+            module: ModuleName::new("catalog").unwrap(),
+            entity: EntityName::new("product").unwrap(),
+            version: SchemaVersion::INITIAL,
+        },
+        locale_mode: LocaleMode::Required,
+        fields: vec![IndexField {
+            name: FieldName::new("id").unwrap(),
+            value_type: IndexValueType::Uuid,
+            cardinality: FieldCardinality::One,
+            nullable: false,
+            selectable: true,
+            filterable: true,
+            sortable: false,
+        }],
+        links: Vec::new(),
+    }
+}
+
+async fn expire(db: &DatabaseConnection, lease: &IndexReplayJobLease) {
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        "UPDATE index_jobs SET lease_expires_at = datetime('now', '-1 second') WHERE tenant_id = ?1 AND job_id = ?2",
+        vec![TENANT.to_owned().into(), lease.job_id().to_string().into()],
+    ))
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn replay_job_excludes_other_workers_and_requires_complete_checkpoint() {
+    let fixture = Fixture::new("active").await;
+    let lease = fixture.acquire("worker-a").await;
+    assert_eq!(lease.attempt_count(), 1);
+    assert_eq!(
+        fixture.jobs.acquire(&fixture.request("worker-b")).await.unwrap(),
+        IndexReplayJobAcquireOutcome::Busy
+    );
+    assert_eq!(
+        fixture.jobs.succeed(&lease).await,
+        Err(IndexReplayJobError::CheckpointMissing)
+    );
+
+    let checkpoints = PostgresIndexReplayCheckpointStore::new(fixture.db.clone(), lease.clone());
+    checkpoints
+        .commit_replay_checkpoint(&fixture.checkpoint(
+            Some(IndexSourceCursor::new(json!({"after": 1})).unwrap()),
+            1,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        fixture.jobs.succeed(&lease).await,
+        Err(IndexReplayJobError::CheckpointIncomplete)
+    );
+
+    checkpoints
+        .commit_replay_checkpoint(&fixture.checkpoint(None, 2))
+        .await
+        .unwrap();
+    fixture
+        .jobs
+        .heartbeat(&lease, Duration::from_secs(120))
+        .await
+        .unwrap();
+    fixture.jobs.succeed(&lease).await.unwrap();
+    assert_eq!(
+        fixture.jobs.acquire(&fixture.request("worker-b")).await.unwrap(),
+        IndexReplayJobAcquireOutcome::AlreadyComplete {
+            job_id: lease.job_id(),
+        }
+    );
+    assert_eq!(
+        fixture
+            .jobs
+            .heartbeat(&lease, Duration::from_secs(60))
+            .await,
+        Err(IndexReplayJobError::LeaseLost)
+    );
+}
+
+#[tokio::test]
+async fn expired_replay_job_is_reclaimed_and_old_checkpoint_writer_is_fenced() {
+    let fixture = Fixture::new("active").await;
+    let first = fixture.acquire("worker-a").await;
+    let stale_checkpoints =
+        PostgresIndexReplayCheckpointStore::new(fixture.db.clone(), first.clone());
+    expire(&fixture.db, &first).await;
+
+    let second = fixture.acquire("worker-b").await;
+    assert_eq!(second.job_id(), first.job_id());
+    assert_eq!(second.attempt_count(), 2);
+
+    let failure = stale_checkpoints
+        .commit_replay_checkpoint(&fixture.checkpoint(None, 1))
+        .await
+        .expect_err("stale checkpoint writer must be fenced");
+    assert_eq!(failure.kind(), IndexReplayFailureKind::Permanent);
+    assert_eq!(failure.code(), "checkpoint_lease_lost");
+    assert_eq!(
+        fixture.jobs.succeed(&first).await,
+        Err(IndexReplayJobError::LeaseLost)
+    );
+
+    let active_checkpoints =
+        PostgresIndexReplayCheckpointStore::new(fixture.db.clone(), second.clone());
+    active_checkpoints
+        .commit_replay_checkpoint(&fixture.checkpoint(None, 2))
+        .await
+        .unwrap();
+    fixture.jobs.succeed(&second).await.unwrap();
+}
+
+#[tokio::test]
+async fn failed_terminal_replay_job_allows_a_new_job_identity() {
+    let fixture = Fixture::new("active").await;
+    let first = fixture.acquire("worker-a").await;
+    fixture
+        .jobs
+        .fail(&first, "index.replay_source_failed", json!({"retryable": false}))
+        .await
+        .unwrap();
+
+    let second = fixture.acquire("worker-b").await;
+    assert_ne!(second.job_id(), first.job_id());
+    assert_eq!(second.attempt_count(), 1);
+}
+
+#[tokio::test]
+async fn replay_job_schema_source_and_stored_request_fail_closed() {
+    let retired = Fixture::new("retired").await;
+    assert_eq!(
+        retired.jobs.acquire(&retired.request("worker-a")).await,
+        Err(IndexReplayJobError::SchemaRetired(
+            retired.schema.reference.clone()
+        ))
+    );
+
+    let active = Fixture::new("active").await;
+    assert!(matches!(
+        IndexReplayJobLeaseRequest::new(
+            Uuid::nil(),
+            active.schema.reference.clone(),
+            SOURCE,
+            "worker-a",
+            Duration::from_secs(60),
+        ),
+        Err(IndexReplayJobError::NilTenantId)
+    ));
+    assert!(matches!(
+        IndexReplayJobLeaseRequest::new(
+            Uuid::parse_str(TENANT).unwrap(),
+            active.schema.reference.clone(),
+            "Invalid Source",
+            "worker-a",
+            Duration::from_secs(60),
+        ),
+        Err(IndexReplayJobError::InvalidSourceName { .. })
+    ));
+    assert!(matches!(
+        IndexReplayJobLeaseRequest::new(
+            Uuid::parse_str(TENANT).unwrap(),
+            active.schema.reference.clone(),
+            SOURCE,
+            " worker-a ",
+            Duration::from_secs(60),
+        ),
+        Err(IndexReplayJobError::InvalidWorkerId { .. })
+    ));
+    assert!(matches!(
+        IndexReplayJobLeaseRequest::new(
+            Uuid::parse_str(TENANT).unwrap(),
+            active.schema.reference.clone(),
+            SOURCE,
+            "worker-a",
+            Duration::ZERO,
+        ),
+        Err(IndexReplayJobError::InvalidLeaseDuration)
+    ));
+
+    let lease = active.acquire("worker-a").await;
+    expire(&active.db, &lease).await;
+    active
+        .db
+        .execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "UPDATE index_jobs SET request = ?1 WHERE tenant_id = ?2 AND job_id = ?3",
+            vec![
+                SqlValue::Json(Some(Box::new(json!({
+                    "contract": "index_replay_job_v1",
+                    "source_name": "another-source"
+                })))),
+                TENANT.to_owned().into(),
+                lease.job_id().to_string().into(),
+            ],
+        ))
+        .await
+        .unwrap();
+    assert!(matches!(
+        active.jobs.acquire(&active.request("worker-b")).await,
+        Err(IndexReplayJobError::InvalidStoredJob(_))
+    ));
+}

--- a/crates/rustok-index/src/lib.rs
+++ b/crates/rustok-index/src/lib.rs
@@ -4,9 +4,10 @@
 //! core under [`domain`] and [`application`], the canonical M3 PostgreSQL
 //! storage-schema migrations, atomic mutation persistence, tenant-scoped source
 //! schema registration, bounded source replay/load contracts, one-page replay
-//! orchestration with durable checkpoint progression, durable schema-application
-//! leases, schema-derived secondary-index lifecycle, fail-closed measured partition
-//! admission, and the PostgreSQL execution adapter for structured Index queries.
+//! orchestration with durable fenced checkpoint progression, durable replay-job
+//! and schema-application leases, schema-derived secondary-index lifecycle,
+//! fail-closed measured partition admission, and the PostgreSQL execution adapter
+//! for structured Index queries.
 
 use async_trait::async_trait;
 use rustok_core::{
@@ -24,16 +25,17 @@ pub use application::*;
 pub use domain::*;
 pub use infrastructure::postgres::{
     evaluate_partition_admission, materialize_postgres_index_query_runtime,
-    IndexQueryRuntimeCompositionError, MutationApplyOutcome, MutationDelivery,
+    IndexQueryRuntimeCompositionError, IndexReplayJobAcquireOutcome, IndexReplayJobError,
+    IndexReplayJobLease, IndexReplayJobLeaseRequest, MutationApplyOutcome, MutationDelivery,
     MutationStorageError, PartitionAdmissionError, PartitionAdmissionOutcome,
     PartitionAdmissionPolicy, PartitionAdmissionReason, PartitionBaselineEvidence,
     PartitionEvidence, PartitionMeasurementCoverage, PartitionRelationPlan,
     PartitionShadowEvidence, PartitionShadowPlan, PartitionStrategy,
     PersistedSchemaRegistrationOutcome, PostgresIndexQueryPort,
-    PostgresIndexReplayCheckpointStore, PostgresMutationStore, PostgresSchemaLeaseStore,
-    PostgresSchemaRegistrationStore, PostgresSecondaryIndexManager, SchemaApplicationLease,
-    SchemaApplicationLeaseRequest, SchemaLeaseAcquireOutcome, SchemaLeaseError,
-    SchemaRegistrationError, SecondaryIndexClaimOutcome, SecondaryIndexError,
+    PostgresIndexReplayCheckpointStore, PostgresIndexReplayJobStore, PostgresMutationStore,
+    PostgresSchemaLeaseStore, PostgresSchemaRegistrationStore, PostgresSecondaryIndexManager,
+    SchemaApplicationLease, SchemaApplicationLeaseRequest, SchemaLeaseAcquireOutcome,
+    SchemaLeaseError, SchemaRegistrationError, SecondaryIndexClaimOutcome, SecondaryIndexError,
     SecondaryIndexExecutionOutcome, SecondaryIndexKind, SecondaryIndexLease,
     SecondaryIndexOperation, SecondaryIndexPlan, SecondaryIndexRequest, SecondaryIndexSpec,
 };

--- a/crates/rustok-index/src/lib.rs
+++ b/crates/rustok-index/src/lib.rs
@@ -3,10 +3,10 @@
 //! The active implementation contains the database-independent generic engine
 //! core under [`domain`] and [`application`], the canonical M3 PostgreSQL
 //! storage-schema migrations, atomic mutation persistence, tenant-scoped source
-//! schema registration, bounded source replay/load contracts, durable
-//! schema-application leases, schema-derived secondary-index lifecycle,
-//! fail-closed measured partition admission, and the PostgreSQL execution adapter
-//! for structured Index queries.
+//! schema registration, bounded source replay/load contracts, one-page replay
+//! orchestration with durable checkpoint progression, durable schema-application
+//! leases, schema-derived secondary-index lifecycle, fail-closed measured partition
+//! admission, and the PostgreSQL execution adapter for structured Index queries.
 
 use async_trait::async_trait;
 use rustok_core::{
@@ -29,10 +29,11 @@ pub use infrastructure::postgres::{
     PartitionAdmissionPolicy, PartitionAdmissionReason, PartitionBaselineEvidence,
     PartitionEvidence, PartitionMeasurementCoverage, PartitionRelationPlan,
     PartitionShadowEvidence, PartitionShadowPlan, PartitionStrategy,
-    PersistedSchemaRegistrationOutcome, PostgresIndexQueryPort, PostgresMutationStore,
-    PostgresSchemaLeaseStore, PostgresSchemaRegistrationStore, PostgresSecondaryIndexManager,
-    SchemaApplicationLease, SchemaApplicationLeaseRequest, SchemaLeaseAcquireOutcome,
-    SchemaLeaseError, SchemaRegistrationError, SecondaryIndexClaimOutcome, SecondaryIndexError,
+    PersistedSchemaRegistrationOutcome, PostgresIndexQueryPort,
+    PostgresIndexReplayCheckpointStore, PostgresMutationStore, PostgresSchemaLeaseStore,
+    PostgresSchemaRegistrationStore, PostgresSecondaryIndexManager, SchemaApplicationLease,
+    SchemaApplicationLeaseRequest, SchemaLeaseAcquireOutcome, SchemaLeaseError,
+    SchemaRegistrationError, SecondaryIndexClaimOutcome, SecondaryIndexError,
     SecondaryIndexExecutionOutcome, SecondaryIndexKind, SecondaryIndexLease,
     SecondaryIndexOperation, SecondaryIndexPlan, SecondaryIndexRequest, SecondaryIndexSpec,
 };

--- a/crates/rustok-index/src/lib.rs
+++ b/crates/rustok-index/src/lib.rs
@@ -3,9 +3,10 @@
 //! The active implementation contains the database-independent generic engine
 //! core under [`domain`] and [`application`], the canonical M3 PostgreSQL
 //! storage-schema migrations, atomic mutation persistence, tenant-scoped source
-//! schema registration, durable schema-application leases, schema-derived
-//! secondary-index lifecycle, fail-closed measured partition admission, and the
-//! PostgreSQL execution adapter for structured Index queries.
+//! schema registration, bounded source replay/load contracts, durable
+//! schema-application leases, schema-derived secondary-index lifecycle,
+//! fail-closed measured partition admission, and the PostgreSQL execution adapter
+//! for structured Index queries.
 
 use async_trait::async_trait;
 use rustok_core::{
@@ -65,6 +66,7 @@ impl RusToKModule for IndexModule {
         extensions: &mut ModuleRuntimeExtensions,
     ) -> rustok_core::Result<()> {
         extensions.get_or_insert_with::<IndexSchemaSourceCatalog, _>(IndexSchemaSourceCatalog::new);
+        extensions.get_or_insert_with::<IndexSourceCatalog, _>(IndexSourceCatalog::new);
         Ok(())
     }
 }

--- a/scripts/verify/verify-index-postgres-query-compiler.mjs
+++ b/scripts/verify/verify-index-postgres-query-compiler.mjs
@@ -57,7 +57,7 @@ const sql = requireMarkers(sqlPath, [
   'compile_keyset(plan, cursor, &mut bindings)?',
   'ASC NULLS LAST',
   'DESC NULLS FIRST',
-  'SELECT COUNT(*)::bigint AS \"__exact_count\"',
+  'SELECT COUNT(*)::bigint AS "__exact_count"',
   'format!("${}", self.values.len())',
 ]);
 
@@ -119,7 +119,8 @@ requireMarkers('crates/rustok-index/docs/m4-query-snapshots.md', [
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
   'M4 controlled PostgreSQL query compilation: `complete`',
   'M4 nested many-link projection aggregation: `complete`',
-  '- [ ] Add plan/SQL snapshots and PostgreSQL/reference-engine equivalence tests.',
+  '- [x] Add retained v4 plan/SQL snapshots and synchronized source guards.',
+  '- [ ] Execute PostgreSQL/reference-engine equivalence capture and admit retained live evidence.',
 ]);
 
 console.log('[verify-index-postgres-query-compiler] OK');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -17,6 +17,7 @@ const scripts = [
   'verify-index-query-equivalence-capture.mjs',
   'verify-index-query-equivalence-admission.mjs',
   'verify-index-source-schema-registry.mjs',
+  'verify-index-source-replay-contract.mjs',
   'verify-index-query-runtime-composition.mjs',
   'verify-index-social-graph-privacy-consumer.mjs',
   'verify-social-graph-privacy-shadow-evidence.mjs',

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -18,6 +18,7 @@ const scripts = [
   'verify-index-query-equivalence-admission.mjs',
   'verify-index-source-schema-registry.mjs',
   'verify-index-source-replay-contract.mjs',
+  'verify-index-replay-job-leases.mjs',
   'verify-index-query-runtime-composition.mjs',
   'verify-index-social-graph-privacy-consumer.mjs',
   'verify-social-graph-privacy-shadow-evidence.mjs',

--- a/scripts/verify/verify-index-query-equivalence-admission.mjs
+++ b/scripts/verify/verify-index-query-equivalence-admission.mjs
@@ -88,7 +88,8 @@ requireMarkers('crates/rustok-index/docs/m4-postgres-reference-equivalence.md', 
   'Not run by the implementation agent',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
-  '- [ ] Add plan/SQL snapshots and PostgreSQL/reference-engine equivalence tests.',
+  '- [x] Add retained v4 plan/SQL snapshots and synchronized source guards.',
+  '- [ ] Execute PostgreSQL/reference-engine equivalence capture and admit retained live evidence.',
 ]);
 
 console.log('[verify-index-query-equivalence-admission] OK');

--- a/scripts/verify/verify-index-query-equivalence-capture.mjs
+++ b/scripts/verify/verify-index-query-equivalence-capture.mjs
@@ -92,7 +92,8 @@ requireMarkers('crates/rustok-index/docs/m4-postgres-reference-equivalence.md', 
   'Not run by the implementation agent',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
-  '- [ ] Add plan/SQL snapshots and PostgreSQL/reference-engine equivalence tests.',
+  '- [x] Add retained v4 plan/SQL snapshots and synchronized source guards.',
+  '- [ ] Execute PostgreSQL/reference-engine equivalence capture and admit retained live evidence.',
 ]);
 
 console.log('[verify-index-query-equivalence-capture] OK');

--- a/scripts/verify/verify-index-query-planner.mjs
+++ b/scripts/verify/verify-index-query-planner.mjs
@@ -85,7 +85,8 @@ requireMarkers('crates/rustok-index/docs/m4-query-snapshots.md', [
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
   '### M4 - Query engine v1',
   '- [x] Add nested many-link projection aggregation.',
-  '- [ ] Add plan/SQL snapshots and PostgreSQL/reference-engine equivalence tests.',
+  '- [x] Add retained v4 plan/SQL snapshots and synchronized source guards.',
+  '- [ ] Execute PostgreSQL/reference-engine equivalence capture and admit retained live evidence.',
   'Partition cutover remains forbidden until one retained real',
 ]);
 

--- a/scripts/verify/verify-index-query-result-decoder.mjs
+++ b/scripts/verify/verify-index-query-result-decoder.mjs
@@ -101,7 +101,8 @@ requireMarkers('crates/rustok-index/docs/m4-query-snapshots.md', [
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
   'M4 deterministic PostgreSQL result decoding: `complete`',
   '- [x] Add nested many-link projection aggregation.',
-  '- [ ] Add plan/SQL snapshots and PostgreSQL/reference-engine equivalence tests.',
+  '- [x] Add retained v4 plan/SQL snapshots and synchronized source guards.',
+  '- [ ] Execute PostgreSQL/reference-engine equivalence capture and admit retained live evidence.',
 ]);
 
 console.log('[verify-index-query-result-decoder] OK');

--- a/scripts/verify/verify-index-query-snapshots.mjs
+++ b/scripts/verify/verify-index-query-snapshots.mjs
@@ -108,8 +108,9 @@ requireMarkers('crates/rustok-index/docs/m4-query-snapshots.md', [
   'Not run by the implementation agent',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
-  '- [ ] Add plan/SQL snapshots and PostgreSQL/reference-engine equivalence tests.',
-  'plan/SQL snapshots',
+  '- [x] Add retained v4 plan/SQL snapshots and synchronized source guards.',
+  '- [ ] Execute PostgreSQL/reference-engine equivalence capture and admit retained live evidence.',
+  'M4 retained plan/SQL snapshots: `source_complete`',
 ]);
 
 console.log('[verify-index-query-snapshots] OK');

--- a/scripts/verify/verify-index-replay-job-leases.mjs
+++ b/scripts/verify/verify-index-replay-job-leases.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-replay-job-leases] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const jobPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_job.rs';
+const job = requireMarkers(jobPath, [
+  'pub struct IndexReplayJobLeaseRequest',
+  'pub struct IndexReplayJobLease',
+  'pub enum IndexReplayJobAcquireOutcome',
+  'pub enum IndexReplayJobError',
+  'pub struct PostgresIndexReplayJobStore',
+  'pub async fn acquire(',
+  'pub async fn heartbeat(',
+  'pub async fn succeed(',
+  'pub async fn fail(',
+  'REPLAY_JOB_REQUEST_CONTRACT: &str = "index_replay_job_v1"',
+  'pg_advisory_xact_lock(hashtextextended($1, 0))',
+  "kind = 'rebuild'",
+  "scope_kind = 'schema'",
+  "state IN ('pending', 'running', 'succeeded')",
+  'attempt_count.checked_add(1)',
+  'lease_expires_at > CURRENT_TIMESTAMP',
+  'pub(super) async fn assert_active_replay_job_lease(',
+  'FOR UPDATE',
+  'require_complete_checkpoint(',
+  'CheckpointMissing',
+  'CheckpointIncomplete',
+  "checkpoint_kind = 'rebuild'",
+  "locale_key = '' AND partition_key = ''",
+]);
+
+for (const forbidden of [
+  'rustok_product',
+  'rustok_content',
+  'rustok_flex',
+  'tokio::spawn',
+  'loop {',
+  'cancel_requested = TRUE',
+  'DELETE FROM index_jobs',
+]) {
+  if (job.includes(forbidden)) fail(`${jobPath} contains forbidden marker ${forbidden}`);
+}
+
+const checkpointPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay.rs';
+const checkpoint = requireMarkers(checkpointPath, [
+  'pub struct PostgresIndexReplayCheckpointStore',
+  'lease: IndexReplayJobLease',
+  'pub fn new(db: DatabaseConnection, lease: IndexReplayJobLease)',
+  'validate_checkpoint_identity(&self.lease, key)?;',
+  'validate_checkpoint_identity(&self.lease, checkpoint.key())?;',
+  'assert_active_replay_job_lease(&transaction, &self.lease, backend)',
+  'checkpoint_lease_identity_mismatch',
+  'checkpoint_lease_lost',
+]);
+
+const checkpointLeasePosition = checkpoint.indexOf(
+  'assert_active_replay_job_lease(&transaction, &self.lease, backend)',
+);
+const checkpointWritePosition = checkpoint.indexOf('upsert_checkpoint_sql(backend)');
+if (
+  checkpointLeasePosition < 0
+  || checkpointWritePosition < 0
+  || checkpointLeasePosition > checkpointWritePosition
+) {
+  fail('checkpoint lease validation must occur before checkpoint persistence');
+}
+
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/source_replay_job_tests.rs', [
+  'replay_job_excludes_other_workers_and_requires_complete_checkpoint',
+  'expired_replay_job_is_reclaimed_and_old_checkpoint_writer_is_fenced',
+  'failed_terminal_replay_job_allows_a_new_job_identity',
+  'replay_job_schema_source_and_stored_request_fail_closed',
+  'IndexReplayJobAcquireOutcome::Busy',
+  'IndexReplayJobError::CheckpointMissing',
+  'IndexReplayJobError::CheckpointIncomplete',
+  'checkpoint_lease_lost',
+  'second.attempt_count(), 2',
+]);
+
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
+  'mod source_replay_job;',
+  'mod source_replay_job_tests;',
+  'PostgresIndexReplayJobStore',
+  'IndexReplayJobLeaseRequest',
+  'IndexReplayJobAcquireOutcome',
+]);
+
+requireMarkers('crates/rustok-index/src/lib.rs', [
+  'PostgresIndexReplayJobStore',
+  'IndexReplayJobLease',
+  'IndexReplayJobLeaseRequest',
+  'IndexReplayJobAcquireOutcome',
+]);
+
+requireMarkers('crates/rustok-index/docs/m6-replay-job-leases.md', [
+  'Status: `source_complete_owner_execution_pending`',
+  '`index_replay_job_v1`',
+  'attempt count',
+  'it cannot advance the durable cursor',
+  'JSON `null` cursor',
+  'maintainer-run',
+]);
+
+console.log('[verify-index-replay-job-leases] OK');

--- a/scripts/verify/verify-index-replay-job-leases.mjs
+++ b/scripts/verify/verify-index-replay-job-leases.mjs
@@ -117,4 +117,17 @@ requireMarkers('crates/rustok-index/docs/m6-replay-job-leases.md', [
   'maintainer-run',
 ]);
 
+requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
+  '- M6 replay job leases and checkpoint attempt fencing: `source_complete_owner_execution_pending`',
+  '- [x] Add durable schema-scoped rebuild jobs, lease/heartbeat, reclaim, attempt fencing,',
+  '- [x] Bind checkpoint reads and writes to the active `(job_id, worker_id, attempt_count)`',
+  '- [ ] Add cancellation, bounded multi-page resume, dry-run, targeted/full/shadow rebuild.',
+  'node scripts/verify/verify-index-replay-job-leases.mjs',
+]);
+
+requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
+  "'verify-index-source-replay-contract.mjs'",
+  "'verify-index-replay-job-leases.mjs'",
+]);
+
 console.log('[verify-index-replay-job-leases] OK');

--- a/scripts/verify/verify-index-replay-job-leases.mjs
+++ b/scripts/verify/verify-index-replay-job-leases.mjs
@@ -57,6 +57,24 @@ for (const forbidden of [
   if (job.includes(forbidden)) fail(`${jobPath} contains forbidden marker ${forbidden}`);
 }
 
+const lockStart = job.indexOf('async fn lock_replay_scope(');
+const lockEnd = job.indexOf('async fn verify_schema_registration(', lockStart);
+if (lockStart < 0 || lockEnd <= lockStart) {
+  fail(`${jobPath} lost the replay scope lock boundary`);
+}
+const lockBody = job.slice(lockStart, lockEnd);
+for (const marker of [
+  'request.tenant_id',
+  'request.schema.module.as_str()',
+  'request.schema.entity.as_str()',
+  'request.schema.version.get()',
+]) {
+  if (!lockBody.includes(marker)) fail(`replay scope lock is missing ${marker}`);
+}
+if (lockBody.includes('request.source_name')) {
+  fail('replay claims must serialize the complete schema scope before source-owner validation');
+}
+
 const checkpointPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay.rs';
 const checkpoint = requireMarkers(checkpointPath, [
   'pub struct PostgresIndexReplayCheckpointStore',
@@ -123,6 +141,27 @@ requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
   '- [x] Bind checkpoint reads and writes to the active `(job_id, worker_id, attempt_count)`',
   '- [ ] Add cancellation, bounded multi-page resume, dry-run, targeted/full/shadow rebuild.',
   'node scripts/verify/verify-index-replay-job-leases.mjs',
+]);
+
+requireMarkers('crates/rustok-index/README.md', [
+  'Current milestone: `M6 - fenced replay job ownership`',
+  '`PostgresIndexReplayJobStore` owns one schema-scoped `rebuild` job',
+  '`PostgresIndexReplayCheckpointStore` is constructed from the acquired',
+  'stale checkpoint-writer rejection',
+]);
+
+requireMarkers('crates/rustok-index/docs/README.md', [
+  '## M5/M6 source replay and rebuild ownership',
+  '`index_replay_job_v1` request contract',
+  'After reclaim, the old worker cannot advance the durable',
+  'M6 job leases and checkpoint attempt fencing: `source_complete_owner_execution_pending`',
+]);
+
+requireMarkers('crates/rustok-index/CRATE_API.md', [
+  '`PostgresIndexReplayJobStore`, `IndexReplayJobLeaseRequest`, `IndexReplayJobLease`',
+  '`PostgresIndexReplayCheckpointStore`',
+  '### Replay source, job, and checkpoint',
+  'A stale attempt cannot advance a checkpoint after reclaim.',
 ]);
 
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [

--- a/scripts/verify/verify-index-source-replay-contract.mjs
+++ b/scripts/verify/verify-index-source-replay-contract.mjs
@@ -121,7 +121,12 @@ const postgres = requireMarkers(postgresPath, [
   'impl IndexReplayMutationSink for PostgresMutationStore',
   'MutationDelivery::from_event(source_name, mutation.clone())',
   'pub struct PostgresIndexReplayCheckpointStore',
+  'lease: IndexReplayJobLease',
+  'pub fn new(db: DatabaseConnection, lease: IndexReplayJobLease)',
   'impl IndexReplayCheckpointStore for PostgresIndexReplayCheckpointStore',
+  'validate_checkpoint_identity(&self.lease, key)?;',
+  'validate_checkpoint_identity(&self.lease, checkpoint.key())?;',
+  'assert_active_replay_job_lease(&transaction, &self.lease, backend)',
   'SELECT cursor, CAST(source_version AS TEXT)',
   'INSERT INTO index_checkpoints',
   '"rebuild".into()',
@@ -129,10 +134,12 @@ const postgres = requireMarkers(postgresPath, [
   'cursor = excluded.cursor',
   'COALESCE(excluded.source_version, index_checkpoints.source_version)',
   'COALESCE(excluded.last_delivery_id, index_checkpoints.last_delivery_id)',
+  'checkpoint_lease_identity_mismatch',
+  'checkpoint_lease_lost',
   'IndexReplayFailure::retryable_static',
   'IndexReplayFailure::permanent_static',
 ]);
-for (const forbidden of ['tokio::spawn', 'index_jobs', 'DELETE FROM index_checkpoints']) {
+for (const forbidden of ['tokio::spawn', 'DELETE FROM index_checkpoints']) {
   if (postgres.includes(forbidden)) {
     fail(`${postgresPath} contains forbidden scheduler/destructive marker ${forbidden}`);
   }
@@ -162,12 +169,15 @@ requireMarkers('crates/rustok-index/src/application/mod.rs', [
 ]);
 requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
   'mod source_replay;',
+  'mod source_replay_job;',
   'PostgresIndexReplayCheckpointStore',
+  'PostgresIndexReplayJobStore',
 ]);
 requireMarkers('crates/rustok-index/src/lib.rs', [
   'get_or_insert_with::<IndexSchemaSourceCatalog',
   'get_or_insert_with::<IndexSourceCatalog',
   'PostgresIndexReplayCheckpointStore',
+  'PostgresIndexReplayJobStore',
 ]);
 requireMarkers('crates/rustok-index/Cargo.toml', [
   'tracing.workspace = true',
@@ -181,23 +191,27 @@ requireMarkers('crates/rustok-index/docs/m5-m6-source-replay-contract.md', [
   'same non-nil event UUID for the same logical entity mutation and source version',
   'Commit the next cursor only after every mutation result is durable',
   'existing inbox identity makes the same stable event deliveries idempotent',
+  '`PostgresIndexReplayJobStore` owns one exact tenant/source/schema rebuild job',
+  '`PostgresIndexReplayCheckpointStore` is constructed from the acquired',
+  'it cannot advance the durable cursor',
   'reserved empty values',
-  'does not claim a job lease or global worker owner',
   'maintainer-run',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
   '- M5/M6 bounded source replay contract: `source_complete_worker_pending`',
-  '- M6 one-page replay and durable checkpoint progression: `source_complete_fenced_job_worker_pending`',
+  '- M6 one-page replay and durable checkpoint progression: `source_complete`',
+  '- M6 replay job leases and checkpoint attempt fencing: `source_complete_owner_execution_pending`',
   '- [x] Add a source replay registry with bounded failure classification.',
   '- [x] Add cursor-based `IndexSource::scan` and targeted `load` contracts.',
   '- [x] Add a durable rebuild checkpoint read/write adapter over `index_checkpoints`.',
   '- [x] Add a bounded worker that applies source pages through `PostgresMutationStore` and',
-  '- [ ] Add durable jobs, leases, heartbeat, attempt fencing, and global ownership.',
-  'No fenced job runner, scheduler, lease owner, long-running',
+  '- [x] Add durable schema-scoped rebuild jobs, lease/heartbeat, reclaim, attempt fencing,',
+  '- [ ] Add cancellation, bounded multi-page resume, dry-run, targeted/full/shadow rebuild.',
 ]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-source-schema-registry.mjs'",
   "'verify-index-source-replay-contract.mjs'",
+  "'verify-index-replay-job-leases.mjs'",
   "'verify-index-query-runtime-composition.mjs'",
 ]);
 

--- a/scripts/verify/verify-index-source-replay-contract.mjs
+++ b/scripts/verify/verify-index-source-replay-contract.mjs
@@ -74,12 +74,13 @@ const worker = requireMarkers(workerPath, [
   'pub struct IndexReplayWorker',
   'pub async fn run_next_page(',
   'load_replay_checkpoint(&checkpoint_key)',
+  'CheckpointIdentityMismatch',
   'IndexReplayPageStatus::AlreadyComplete',
   'let mut event_ids = BTreeSet::new();',
   'event_id.is_nil()',
   'DuplicateReplayEventId',
   '.apply_replay_mutation(',
-  'last_delivery_id = Some(event_id.to_string())',
+  'last_delivery_id = Some(mutation.event_id().to_string())',
   '.commit_replay_checkpoint(&checkpoint)',
   'IndexReplayPageStatus::Complete',
   'IndexReplayPageStatus::Advanced',
@@ -103,10 +104,16 @@ for (const forbidden of [
   }
 }
 const runStart = worker.indexOf('pub async fn run_next_page(');
+const validationPosition = worker.indexOf('let mut event_ids = BTreeSet::new();', runStart);
 const applyPosition = worker.indexOf('.apply_replay_mutation(', runStart);
 const commitPosition = worker.indexOf('.commit_replay_checkpoint(&checkpoint)', runStart);
-if (runStart < 0 || applyPosition < runStart || commitPosition <= applyPosition) {
-  fail(`${workerPath} does not commit the checkpoint after mutation application`);
+if (
+  runStart < 0
+  || validationPosition < runStart
+  || applyPosition <= validationPosition
+  || commitPosition <= applyPosition
+) {
+  fail(`${workerPath} must validate the full page, apply mutations, then commit the checkpoint`);
 }
 
 const postgresPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay.rs';
@@ -136,6 +143,7 @@ requireMarkers(testsPath, [
   'replay_page_commits_checkpoint_after_mutations',
   'checkpoint_failure_replays_the_same_event_delivery',
   'completed_checkpoint_skips_the_source',
+  'checkpoint_watermark_never_regresses',
   'nil_replay_event_is_rejected_before_persistence',
   'vec!["mutation", "checkpoint"]',
   'vec![event_id, event_id]',

--- a/scripts/verify/verify-index-source-replay-contract.mjs
+++ b/scripts/verify/verify-index-source-replay-contract.mjs
@@ -26,6 +26,8 @@ const registry = requireMarkers(registryPath, [
   'pub struct IndexSourceCatalog',
   'pub struct SharedIndexSourceRegistry',
   'pub struct IndexSourceCursor',
+  "impl<'de> Deserialize<'de> for IndexSourceCursor",
+  'Self::new(value).map_err(D::Error::custom)',
   'pub struct IndexSourceScanRequest',
   'pub struct IndexSourceLoadRequest',
   'pub struct IndexSourcePage',
@@ -46,6 +48,8 @@ const registry = requireMarkers(registryPath, [
   'register_index_source(',
   'source_materialization_requires_exact_schema_owner',
   'schema_identity_cannot_move_between_replay_sources',
+  'cursor_and_scan_limits_are_bounded',
+  'serde_json::from_value::<IndexSourceCursor>',
   'targeted_load_is_one_bounded_tenant_schema_scope',
 ]);
 

--- a/scripts/verify/verify-index-source-replay-contract.mjs
+++ b/scripts/verify/verify-index-source-replay-contract.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-source-replay-contract] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const registryPath = 'crates/rustok-index/src/application/source_registry.rs';
+const registry = requireMarkers(registryPath, [
+  'pub trait IndexSource: Send + Sync',
+  'async fn scan(',
+  'async fn load(',
+  'pub struct IndexSourceCatalog',
+  'pub struct SharedIndexSourceRegistry',
+  'pub struct IndexSourceCursor',
+  'pub struct IndexSourceScanRequest',
+  'pub struct IndexSourceLoadRequest',
+  'pub struct IndexSourcePage',
+  'pub struct IndexSourceLoadBatch',
+  'pub enum IndexSourceFailureKind',
+  'Retryable',
+  'Permanent',
+  'MAX_CURSOR_BYTES: usize = 8 * 1024',
+  'MAX_SCAN_BATCH_SIZE: usize = 1_000',
+  'MAX_LOAD_KEYS: usize = 256',
+  'SchemaIdentitySourceConflict',
+  'UnpublishedSourceSchema',
+  'SourceSchemaOwnerMismatch',
+  'EmptyScanContinuation',
+  'ScanCursorDidNotAdvance',
+  'LoadMutationNotRequested',
+  'materialize_index_source_registry(',
+  'register_index_source(',
+  'source_materialization_requires_exact_schema_owner',
+  'schema_identity_cannot_move_between_replay_sources',
+  'targeted_load_is_one_bounded_tenant_schema_scope',
+]);
+
+for (const forbidden of [
+  'DatabaseConnection',
+  'PostgresMutationStore',
+  'index_jobs',
+  'index_checkpoints',
+  'tokio::spawn',
+  'SELECT ',
+  'INSERT ',
+  'UPDATE ',
+  'DELETE ',
+]) {
+  if (registry.includes(forbidden)) {
+    fail(`${registryPath} contains forbidden storage/worker marker ${forbidden}`);
+  }
+}
+
+requireMarkers('crates/rustok-index/src/application/mod.rs', [
+  'mod source_registry;',
+  'IndexSourceCatalog',
+  'SharedIndexSourceRegistry',
+  'materialize_index_source_registry',
+  'register_index_source',
+]);
+requireMarkers('crates/rustok-index/src/lib.rs', [
+  'get_or_insert_with::<IndexSchemaSourceCatalog',
+  'get_or_insert_with::<IndexSourceCatalog',
+]);
+requireMarkers('crates/rustok-index/docs/m5-m6-source-replay-contract.md', [
+  'one to 256 unique `EntityKey` values',
+  'limit from 1 through 1000',
+  'at most 8 KiB',
+  '`Retryable` or',
+  '`Permanent`',
+  'does not define that policy yet',
+  'maintainer-run',
+]);
+requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
+  '- M5/M6 bounded source replay contract: `source_complete_worker_pending`',
+  '- [x] Add a source replay registry with bounded failure classification.',
+  '- [x] Add cursor-based `IndexSource::scan` and targeted `load` contracts.',
+  '- [ ] Add durable jobs, checkpoints, leases, heartbeat, and ownership.',
+  'No durable job runner, checkpoint writer, scheduler, or production replay command',
+]);
+requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
+  "'verify-index-source-schema-registry.mjs'",
+  "'verify-index-source-replay-contract.mjs'",
+  "'verify-index-query-runtime-composition.mjs'",
+]);
+
+console.log('[verify-index-source-replay-contract] OK');

--- a/scripts/verify/verify-index-source-replay-contract.mjs
+++ b/scripts/verify/verify-index-source-replay-contract.mjs
@@ -75,8 +75,11 @@ const worker = requireMarkers(workerPath, [
   'pub async fn run_next_page(',
   'load_replay_checkpoint(&checkpoint_key)',
   'IndexReplayPageStatus::AlreadyComplete',
+  'let mut event_ids = BTreeSet::new();',
+  'event_id.is_nil()',
+  'DuplicateReplayEventId',
   '.apply_replay_mutation(',
-  'mutation.event_id().to_string()',
+  'last_delivery_id = Some(event_id.to_string())',
   '.commit_replay_checkpoint(&checkpoint)',
   'IndexReplayPageStatus::Complete',
   'IndexReplayPageStatus::Advanced',
@@ -87,6 +90,7 @@ const worker = requireMarkers(workerPath, [
 for (const forbidden of [
   'DatabaseConnection',
   'PostgresMutationStore',
+  'partition_key',
   'index_jobs',
   'tokio::spawn',
   'SELECT ',
@@ -113,7 +117,7 @@ const postgres = requireMarkers(postgresPath, [
   'impl IndexReplayCheckpointStore for PostgresIndexReplayCheckpointStore',
   'SELECT cursor, CAST(source_version AS TEXT)',
   'INSERT INTO index_checkpoints',
-  "'rebuild'",
+  '"rebuild".into()',
   'ON CONFLICT (tenant_id, checkpoint_kind, source_name',
   'cursor = excluded.cursor',
   'COALESCE(excluded.source_version, index_checkpoints.source_version)',
@@ -127,9 +131,20 @@ for (const forbidden of ['tokio::spawn', 'index_jobs', 'DELETE FROM index_checkp
   }
 }
 
+const testsPath = 'crates/rustok-index/src/application/source_replay_tests.rs';
+requireMarkers(testsPath, [
+  'replay_page_commits_checkpoint_after_mutations',
+  'checkpoint_failure_replays_the_same_event_delivery',
+  'completed_checkpoint_skips_the_source',
+  'nil_replay_event_is_rejected_before_persistence',
+  'vec!["mutation", "checkpoint"]',
+  'vec![event_id, event_id]',
+]);
+
 requireMarkers('crates/rustok-index/src/application/mod.rs', [
   'mod source_registry;',
   'mod source_replay;',
+  'mod source_replay_tests;',
   'IndexSourceCatalog',
   'SharedIndexSourceRegistry',
   'IndexReplayWorker',
@@ -152,8 +167,10 @@ requireMarkers('crates/rustok-index/docs/m5-m6-source-replay-contract.md', [
   'at most 8 KiB',
   '`Retryable` or `Permanent`',
   '`IndexReplayWorker::run_next_page` executes exactly one bounded source page',
+  'same non-nil event UUID for the same logical entity mutation and source version',
   'Commit the next cursor only after every mutation result is durable',
-  'existing inbox identity makes the same event deliveries idempotent',
+  'existing inbox identity makes the same stable event deliveries idempotent',
+  'reserved empty values',
   'does not claim a job lease or global worker owner',
   'maintainer-run',
 ]);

--- a/scripts/verify/verify-index-source-replay-contract.mjs
+++ b/scripts/verify/verify-index-source-replay-contract.mjs
@@ -69,24 +69,92 @@ for (const forbidden of [
   }
 }
 
+const workerPath = 'crates/rustok-index/src/application/source_replay.rs';
+const worker = requireMarkers(workerPath, [
+  'pub struct IndexReplayWorker',
+  'pub async fn run_next_page(',
+  'load_replay_checkpoint(&checkpoint_key)',
+  'IndexReplayPageStatus::AlreadyComplete',
+  '.apply_replay_mutation(',
+  'mutation.event_id().to_string()',
+  '.commit_replay_checkpoint(&checkpoint)',
+  'IndexReplayPageStatus::Complete',
+  'IndexReplayPageStatus::Advanced',
+  'CheckpointReadFailed',
+  'MutationFailed',
+  'CheckpointCommitFailed',
+]);
+for (const forbidden of [
+  'DatabaseConnection',
+  'PostgresMutationStore',
+  'index_jobs',
+  'tokio::spawn',
+  'SELECT ',
+  'INSERT ',
+  'UPDATE ',
+  'DELETE ',
+]) {
+  if (worker.includes(forbidden)) {
+    fail(`${workerPath} contains forbidden infrastructure/scheduler marker ${forbidden}`);
+  }
+}
+const runStart = worker.indexOf('pub async fn run_next_page(');
+const applyPosition = worker.indexOf('.apply_replay_mutation(', runStart);
+const commitPosition = worker.indexOf('.commit_replay_checkpoint(&checkpoint)', runStart);
+if (runStart < 0 || applyPosition < runStart || commitPosition <= applyPosition) {
+  fail(`${workerPath} does not commit the checkpoint after mutation application`);
+}
+
+const postgresPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay.rs';
+const postgres = requireMarkers(postgresPath, [
+  'impl IndexReplayMutationSink for PostgresMutationStore',
+  'MutationDelivery::from_event(source_name, mutation.clone())',
+  'pub struct PostgresIndexReplayCheckpointStore',
+  'impl IndexReplayCheckpointStore for PostgresIndexReplayCheckpointStore',
+  'SELECT cursor, CAST(source_version AS TEXT)',
+  'INSERT INTO index_checkpoints',
+  "'rebuild'",
+  'ON CONFLICT (tenant_id, checkpoint_kind, source_name',
+  'cursor = excluded.cursor',
+  'COALESCE(excluded.source_version, index_checkpoints.source_version)',
+  'COALESCE(excluded.last_delivery_id, index_checkpoints.last_delivery_id)',
+  'IndexReplayFailure::retryable_static',
+  'IndexReplayFailure::permanent_static',
+]);
+for (const forbidden of ['tokio::spawn', 'index_jobs', 'DELETE FROM index_checkpoints']) {
+  if (postgres.includes(forbidden)) {
+    fail(`${postgresPath} contains forbidden scheduler/destructive marker ${forbidden}`);
+  }
+}
+
 requireMarkers('crates/rustok-index/src/application/mod.rs', [
   'mod source_registry;',
+  'mod source_replay;',
   'IndexSourceCatalog',
   'SharedIndexSourceRegistry',
+  'IndexReplayWorker',
+  'IndexReplayCheckpointStore',
   'materialize_index_source_registry',
   'register_index_source',
+]);
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
+  'mod source_replay;',
+  'PostgresIndexReplayCheckpointStore',
 ]);
 requireMarkers('crates/rustok-index/src/lib.rs', [
   'get_or_insert_with::<IndexSchemaSourceCatalog',
   'get_or_insert_with::<IndexSourceCatalog',
+  'PostgresIndexReplayCheckpointStore',
 ]);
 requireMarkers('crates/rustok-index/docs/m5-m6-source-replay-contract.md', [
   'one to 256 unique `EntityKey` values',
   'limit from 1 through 1000',
   'at most 8 KiB',
-  '`Retryable` or',
-  '`Permanent`',
-  'does not define that policy yet',
+  '`Retryable` or `Permanent`',
+  '`IndexReplayWorker::run_next_page` executes exactly one bounded source page',
+  'Commit the next cursor only after every mutation result is durable',
+  'existing inbox identity makes the same event deliveries idempotent',
+  'does not claim a job lease or global worker owner',
   'maintainer-run',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
@@ -94,7 +162,6 @@ requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
   '- [x] Add a source replay registry with bounded failure classification.',
   '- [x] Add cursor-based `IndexSource::scan` and targeted `load` contracts.',
   '- [ ] Add durable jobs, checkpoints, leases, heartbeat, and ownership.',
-  'No durable job runner, checkpoint writer, scheduler, or production replay command',
 ]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-source-schema-registry.mjs'",

--- a/scripts/verify/verify-index-source-replay-contract.mjs
+++ b/scripts/verify/verify-index-source-replay-contract.mjs
@@ -161,6 +161,9 @@ requireMarkers('crates/rustok-index/src/lib.rs', [
   'get_or_insert_with::<IndexSourceCatalog',
   'PostgresIndexReplayCheckpointStore',
 ]);
+requireMarkers('crates/rustok-index/Cargo.toml', [
+  'tracing.workspace = true',
+]);
 requireMarkers('crates/rustok-index/docs/m5-m6-source-replay-contract.md', [
   'one to 256 unique `EntityKey` values',
   'limit from 1 through 1000',
@@ -176,9 +179,13 @@ requireMarkers('crates/rustok-index/docs/m5-m6-source-replay-contract.md', [
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
   '- M5/M6 bounded source replay contract: `source_complete_worker_pending`',
+  '- M6 one-page replay and durable checkpoint progression: `source_complete_fenced_job_worker_pending`',
   '- [x] Add a source replay registry with bounded failure classification.',
   '- [x] Add cursor-based `IndexSource::scan` and targeted `load` contracts.',
-  '- [ ] Add durable jobs, checkpoints, leases, heartbeat, and ownership.',
+  '- [x] Add a durable rebuild checkpoint read/write adapter over `index_checkpoints`.',
+  '- [x] Add a bounded worker that applies source pages through `PostgresMutationStore` and',
+  '- [ ] Add durable jobs, leases, heartbeat, attempt fencing, and global ownership.',
+  'No fenced job runner, scheduler, lease owner, long-running',
 ]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-source-schema-registry.mjs'",

--- a/scripts/verify/verify-index-source-schema-registry.mjs
+++ b/scripts/verify/verify-index-source-schema-registry.mjs
@@ -99,6 +99,7 @@ for (const forbidden of [
 
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-source-schema-registry.mjs'",
+  "'verify-index-source-replay-contract.mjs'",
   "'verify-index-query-runtime-composition.mjs'",
 ]);
 requireMarkers('crates/rustok-index/docs/m4-source-schema-registry.md', [
@@ -115,7 +116,8 @@ requireMarkers('crates/rustok-index/docs/m4-query-planner.md', [
   'M4 server-owned shared query runtime composition: `source_complete_execution_pending`',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
-  '- [ ] Add plan/SQL snapshots and PostgreSQL/reference-engine equivalence tests.',
+  '- [x] Add retained v4 plan/SQL snapshots and synchronized source guards.',
+  '- [ ] Execute PostgreSQL/reference-engine equivalence capture and admit retained live evidence.',
 ]);
 
 console.log('[verify-index-source-schema-registry] OK');


### PR DESCRIPTION
## Summary

- add the neutral `IndexSource` boundary with bounded cursor-based `scan` and targeted `load`
- materialize one deterministic replay source for every exact schema and stable schema identity owner
- validate tenant/schema scope, page/key bounds, duplicate keys, empty continuation, cursor size, and cursor progress
- add `IndexReplayWorker::run_next_page` for exactly one bounded replay page
- validate the complete page event identity set before the first mutation write
- apply replay mutations sequentially through the existing `PostgresMutationStore` inbox/source-version contract
- commit the next cursor only after every mutation result is durable
- preserve monotonic source-version watermarks and last-delivery identity across lower-version or empty final pages
- add `PostgresIndexReplayJobStore` over the existing `index_jobs` table
- validate the exact `index_replay_job_v1` request and active persisted schema
- serialize claims by tenant and exact schema before validating the source owner
- provide lease heartbeat, expired-attempt reclaim, and incremented attempt fencing
- bind `PostgresIndexReplayCheckpointStore` to an acquired `IndexReplayJobLease`
- lock and validate the exact `(job_id, worker_id, attempt_count)` before every checkpoint read/write
- prevent a reclaimed worker from advancing the durable cursor
- require an active lease and an exact durable JSON-null checkpoint before terminal success
- retain failed terminal jobs while allowing a later job identity
- add SQLite contract fixtures, repository guards, public API docs, and the canonical M6 plan update

## Retry and fencing boundary

A replay source must return the same non-nil event UUID for the same logical entity mutation and source version when a page is retried. If mutation persistence succeeds but checkpoint persistence fails, the old cursor is retried and the stable inbox delivery identity makes prior writes duplicate-safe.

The checkpoint adapter is lease-bound. A stale worker may finish an already-started idempotent mutation transaction, but after expiry/reclaim it cannot read or advance the durable checkpoint, heartbeat the job, or publish a terminal result.

The PostgreSQL advisory lock is tenant + exact schema scoped rather than source-name scoped. Concurrent requests that incorrectly claim different sources for the same schema serialize first; the stored source mismatch then fails closed instead of creating parallel jobs.

## Explicitly not included

- a bounded multi-page loop or production scheduler
- cancellation observation or a cancel/resume command
- bounded retry/backoff or dead-letter scheduling
- direct server-composition binding between job requests and the materialized source registry
- locale/partition replay checkpoint dimensions
- Product or other source-domain adapters
- reconciliation or drift repair
- authoritative consumer or partition cutover
- live PostgreSQL/reference, crash/reclaim, freshness, outage, or recovery evidence

## Recheck findings addressed

- declared the missing production `tracing` dependency
- removed the unimplemented public replay `partition_key` surface
- moved nil/duplicate event validation ahead of every mutation write
- rejected checkpoint rows for another replay identity
- prevented source-version watermark regression
- retained delivery identity and watermark on an empty completion page
- fenced checkpoint reads and writes, not only terminal job state
- required a null-cursor checkpoint before successful completion
- changed claim locking from source-specific to complete schema scope to prevent mismatched-source insertion races
- synchronized `README.md`, `docs/README.md`, `CRATE_API.md`, the M5/M6 contract, the M6 fencing contract, the implementation plan, and repository guards

## Validation

Not run by the implementation agent, per owner request. The repository owner will run formatting, Cargo checks/tests, JavaScript verifiers, fixtures, and CI.

Suggested owner commands:

```bash
node scripts/verify/verify-index-replay-job-leases.mjs
node scripts/verify/verify-index-source-replay-contract.mjs
node scripts/verify/verify-index-query-contract.mjs
cargo check -p rustok-index --all-targets
cargo test -p rustok-index source_registry --lib -- --nocapture
cargo test -p rustok-index source_replay --lib -- --nocapture
cargo test -p rustok-index source_replay_job --lib -- --nocapture
```

## Target

Base: `main`
Branch: `agent/index-source-replay-contract-20260730`

The branch has accumulated parallel history while `main` moved quickly, but GitHub currently reports the PR as mergeable. Squash merge is recommended after owner validation.