### PR TITLE
fix(search): remove generic settings secret path

### DIFF
--- a/apps/server/src/services/settings_service.rs
+++ b/apps/server/src/services/settings_service.rs
@@ -5,17 +5,20 @@ use uuid::Uuid;
 use crate::models::platform_settings::{self, ActiveModel, Entity};
 use crate::services::server_runtime_context::ServerRuntimeContext;
 
-/// Known setting categories.
+/// Known generic platform-setting categories.
+///
+/// Search settings are intentionally absent. `rustok-search` owns its settings
+/// through `SearchSettingsService`; the generic platform table must not expose or
+/// persist runtime connector credentials such as `search.api_key`.
 pub mod category {
     pub const GENERAL: &str = "general";
     pub const EMAIL: &str = "email";
-    pub const SEARCH: &str = "search";
     pub const RATE_LIMIT: &str = "rate_limit";
     pub const FEATURES: &str = "features";
     pub const I18N: &str = "i18n";
     pub const OAUTH: &str = "oauth";
 
-    pub const ALL: &[&str] = &[GENERAL, EMAIL, SEARCH, RATE_LIMIT, FEATURES, I18N, OAUTH];
+    pub const ALL: &[&str] = &[GENERAL, EMAIL, RATE_LIMIT, FEATURES, I18N, OAUTH];
 }
 
 #[derive(Debug)]
@@ -168,12 +171,14 @@ impl ValidatorRegistry {
 pub struct SettingsService;
 
 impl SettingsService {
-    /// Get settings for a single category with fallback.
+    /// Get settings for a single supported generic category with fallback.
     pub async fn get(
         ctx: &ServerRuntimeContext,
         tenant_id: Uuid,
         cat: &str,
     ) -> Result<Value, SettingsError> {
+        ensure_supported_category(cat)?;
+
         // 1. DB row
         if let Some(row) = Entity::find_by_category(ctx.db(), tenant_id, cat).await? {
             return Ok(row.settings);
@@ -189,7 +194,9 @@ impl SettingsService {
         Ok(serde_json::json!({}))
     }
 
-    /// List all categories for a tenant, filling gaps with fallbacks.
+    /// List all supported generic categories for a tenant, filling gaps with fallbacks.
+    ///
+    /// Historical rows for owner-specific categories are ignored rather than exposed.
     pub async fn get_all(
         ctx: &ServerRuntimeContext,
         tenant_id: Uuid,
@@ -197,7 +204,8 @@ impl SettingsService {
         let db_rows = Entity::find_all_for_tenant(ctx.db(), tenant_id).await?;
         let mut result: Vec<(String, Value)> = db_rows
             .into_iter()
-            .map(|r| (r.category, r.settings))
+            .filter(|row| category::ALL.contains(&row.category.as_str()))
+            .map(|row| (row.category, row.settings))
             .collect();
 
         // Fill in categories that are not yet in the DB
@@ -222,7 +230,7 @@ impl SettingsService {
         Ok(result)
     }
 
-    /// Upsert settings for a category.
+    /// Upsert settings for a supported generic category.
     ///
     /// Returns the stored `Value`.
     pub async fn update(
@@ -233,9 +241,7 @@ impl SettingsService {
         actor_id: Option<Uuid>,
         validators: &ValidatorRegistry,
     ) -> Result<Value, SettingsError> {
-        if !category::ALL.contains(&cat) {
-            return Err(SettingsError::InvalidCategory(cat.to_string()));
-        }
+        ensure_supported_category(cat)?;
 
         validators
             .validate(cat, &settings)
@@ -265,7 +271,6 @@ impl SettingsService {
         let rs = ctx.settings();
         match cat {
             category::EMAIL => serde_json::to_value(&rs.email).unwrap_or(Value::Null),
-            category::SEARCH => serde_json::to_value(&rs.search).unwrap_or(Value::Null),
             category::RATE_LIMIT => serde_json::to_value(&rs.rate_limit).unwrap_or(Value::Null),
             category::FEATURES => serde_json::to_value(&rs.features).unwrap_or(Value::Null),
             _ => Value::Null,
@@ -273,10 +278,27 @@ impl SettingsService {
     }
 }
 
+fn ensure_supported_category(cat: &str) -> Result<(), SettingsError> {
+    if category::ALL.contains(&cat) {
+        Ok(())
+    } else {
+        Err(SettingsError::InvalidCategory(cat.to_string()))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn generic_category_allowlist_excludes_search_owner_settings() {
+        assert!(!category::ALL.contains(&"search"));
+        assert!(matches!(
+            ensure_supported_category("search"),
+            Err(SettingsError::InvalidCategory(category)) if category == "search"
+        ));
+    }
 
     #[test]
     fn rate_limit_validator_rejects_non_positive_rps() {

--- a/crates/rustok-search/docs/implementation-plan.md
+++ b/crates/rustok-search/docs/implementation-plan.md
@@ -36,6 +36,13 @@ cleanup, and module-disabled cleanup followed by enable-time rebuild. Source-tab
 availability resolves through the active PostgreSQL `search_path` instead of
 hard-coding `public`.
 
+Search settings have one owner boundary. Tenant-effective settings are read and
+written through `SearchSettingsService` and the `search_settings` table. The
+server-wide generic `platform_settings` service no longer admits a `search`
+category, does not serialize bootstrap `search.api_key`, filters historical generic
+Search rows from list responses, and rejects generic Search reads and writes before
+database access.
+
 ## FFA/FBA status
 
 - FFA status: `phase_b_ready`.
@@ -64,6 +71,7 @@ hard-coding `public`.
   canonical URL guardrail.
 - Transport-local `derive_search_result_url`, `derive_admin_search_result_url`,
   `enrich_search_result_urls`, and Blog route constants are forbidden.
+- Generic `platform_settings/search` is forbidden by the Search FBA guard.
 - Blog projection table discovery and reads use the active `search_path`.
 - `TenantModuleToggled(blog, false)` deletes only the current tenant Blog search
   scope; enabling the module rebuilds it from retained owner rows.
@@ -110,6 +118,9 @@ rebuild behavior through replayable event transport.
     every transport-local URL implementation and require no transport fallback.
 11. Added canonical URL ownership to the standard Search FBA gate alongside the
     provider port, fallback, runtime contract, and invocation evidence.
+12. Removed the legacy generic `platform_settings/search` execution path and added
+    a fail-closed FBA ownership guard so runtime connector secrets stay inside the
+    Search owner boundary.
 
 ## Next results
 
@@ -132,6 +143,7 @@ rebuild behavior through replayable event transport.
 
 ## Verification
 
+- `cargo test -p rustok-server settings_service`
 - `cargo test -p rustok-search engine::tests::canonical_url`
 - `node scripts/verify/verify-search-canonical-url-contract.mjs`
 - `node scripts/verify/verify-search-canonical-url-contract.test.mjs`
@@ -154,10 +166,10 @@ rebuild behavior through replayable event transport.
 - Cycle: `cycle-001`
 - Status: `in_progress`
 - Last verified at (UTC): `2026-07-30`
-- Scope inspected: `owner README, module docs, current implementation plan, Index/Search boundary and carried event-delivery/rebuild concerns`
-- Findings: `P0=0, P1=0, P2=0, P3=0`
-- Fixed in this pass: `none; verification entrypoint only`
-- Remaining risks or blockers: `generic settings secret projection, tenant/locale/channel isolation, event replay/rebuild, deletion, duplicate and out-of-order delivery, connector boundaries, and operational recovery require source inspection`
-- Evidence: `current owner documentation and post-Index verification cursor read from main`
-- Next action: `trace settings serialization and every ingestion/rebuild publisher-consumer path; fix P0/P1 before running targeted static and Rust checks`
-- Resume command: `cargo xtask module validate search && npm run verify:search:fba && node scripts/verify/verify-search-blog-projection.mjs`
+- Scope inspected: `Search settings ownership, generic platform settings projection, owner Search GraphQL/settings service, FBA guard and carried event-delivery/rebuild concerns`
+- Findings: `P0=0, P1=1, P2=0, P3=0`
+- Fixed in this pass: `removed the non-authoritative generic platform_settings/search category, blocked read/write/list projection of historical generic Search rows, and added an owner-boundary FBA guard`
+- Remaining risks or blockers: `tenant/locale/channel isolation, event replay/rebuild, deletion, duplicate and out-of-order delivery, connector boundaries, click analytics and operational recovery still require source and live-evidence inspection`
+- Evidence: `source inspection confirms SearchSettingsService/search_settings is the owner path; the generic service now validates category before DB access and the standard Search FBA verifier rejects any restored rs.search projection`
+- Next action: `run same-SHA Search FBA and targeted settings tests, merge the focused P1 fix, then trace every ingestion/rebuild publisher-consumer path on a fresh branch`
+- Resume command: `cargo test -p rustok-server settings_service && npm run verify:search:fba && node scripts/verify/verify-search-blog-projection.mjs`

--- a/scripts/verify/verify-search-fba.mjs
+++ b/scripts/verify/verify-search-fba.mjs
@@ -60,6 +60,26 @@ hasAll(pgEngine, ['pub(crate) fn connection(&self) -> &DatabaseConnection', '&se
 const engine = read('crates/rustok-search/src/engine.rs');
 hasAll(engine, ['pub trait SearchEngine', 'Self::Postgres', 'Self::Meilisearch', 'Self::Typesense', 'Self::Algolia', 'pub fn canonical_search_result_url', 'BLOG_ENTITY_TYPE', 'valid_blog_slug'], 'engine connector and navigation boundary');
 
+const genericSettings = read('apps/server/src/services/settings_service.rs');
+hasAll(genericSettings, [
+  'ensure_supported_category(cat)?;',
+  '.filter(|row| category::ALL.contains(&row.category.as_str()))',
+  'generic_category_allowlist_excludes_search_owner_settings',
+  '`rustok-search` owns its settings',
+], 'generic platform settings boundary');
+hasNone(genericSettings, [
+  'pub const SEARCH',
+  'category::SEARCH',
+  'serde_json::to_value(&rs.search)',
+], 'generic platform settings boundary');
+const ownerSettings = read('crates/rustok-search/src/search_settings.rs');
+hasAll(ownerSettings, [
+  'pub struct SearchSettingsService',
+  'pub async fn load_effective',
+  'pub async fn save',
+  'table_name = "search_settings"',
+], 'Search-owned settings boundary');
+
 if (evidence.generated_from !== registryPath || evidence.status !== registry.contract_tests.status) fail('evidence header drift');
 const registryCases = registry.contract_tests.cases.map((c) => c.operation).sort().join('|');
 const evidenceCases = evidence.cases.map((c) => c.operation).sort().join('|');
@@ -123,4 +143,4 @@ hasAll(plan, ['- FBA status: `boundary_ready`', 'search-fba-registry.json', 'Sea
 const central = read('docs/modules/registry.md');
 hasAll(central, ['| `search` |', 'crates/rustok-search/contracts/search-fba-registry.json', '`phase_b_ready` | `boundary_ready`'], 'central registry');
 
-console.log('[verify-search-fba] Search provider metadata, port semantics, current-only canonical URL ownership, static evidence, and executable no-compile runtime contracts are consistent');
+console.log('[verify-search-fba] Search provider metadata, port semantics, owner-only settings, current-only canonical URL ownership, static evidence, and executable no-compile runtime contracts are consistent');


### PR DESCRIPTION
## Confirmed P1

The generic platform settings service admitted a `search` category and serialized the process bootstrap `SearchSettings`, including `search.api_key`, through tenant-scoped GraphQL reads and update echoes. This duplicated the Search-owned `SearchSettingsService`/`search_settings` boundary with a non-authoritative secret-bearing execution path.

## Fix

- remove `search` from the generic platform settings allowlist
- reject unsupported categories before database access on reads and writes
- filter historical generic Search rows from list responses
- remove the YAML fallback that serialized runtime `SearchSettings`
- retain `SearchSettingsService` and `search_settings` as the only Search settings owner
- add unit and Search FBA ownership guards
- document the current owner boundary while keeping the component verification handoff in progress

## Same-SHA evidence and limitations

- PR virtual merge is conflict-free and the diff is limited to three files
- Next frontend format, lint, typecheck, and build passed
- workspace documentation compilation progressed through the repository but failed in unrelated `rustok-marketplace-seller` lifetime/import errors and `rustok-profiles` event-type mismatches
- Rust-hosted browser smoke stopped before compilation because `cargo --locked` requires the existing Athanor/Cargo.lock update
- Repository Hardening stopped at the existing expired security-advisory exceptions before Search checks
- the MSRV job did not run Cargo because the workflow requests nonexistent Rust `1.100.0` and receives a 404
- Typos failed only on unrelated Forum identifiers, generated Richtext output, and existing repository artifacts; none of the three changed files were reported
- Formatting and general Cargo Check remained queued without runner execution
- `npm run verify:search:fba` was source-reviewed but did not execute because no dedicated workflow exists and the aggregate hardening gate stopped earlier

## Non-claims

This PR does not prove Search ingestion/rebuild durability, live Blog projection, connector runtime behavior, or outage/restart recovery. Those remain under the active `core/search` verification pass.