### PR TITLE
fix(payment): retain checkout execution admission context

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/payment-checkout-execution-admission-context-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/payment-checkout-execution-admission-context-source-review.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "1.0.0",
+  "status": "payment_checkout_execution_admission_context_source_reviewed_unvalidated",
+  "captured_at": "2026-07-30",
+  "base_main_sha": "8b4e9ef48c380a584cd3a30bed6b63193f4d9475",
+  "review": {
+    "public_port_signatures_preserved": true,
+    "prepare_authorize_capture_read_operations_preserved": true,
+    "read_policy_preserved": true,
+    "write_policy_and_write_semantics_preserved": true,
+    "admission_helpers_use_inspect_err": true,
+    "port_error_kind_code_message_retryability_preserved": true,
+    "owner_delegation_order_preserved": true,
+    "post_delegation_local_mapper_preserved": true,
+    "safe_request_fact_policy_preserved": true,
+    "compensation_source_not_modified": true
+  },
+  "execution": {
+    "commands_run": [],
+    "tests_run": [],
+    "verifiers_run": [],
+    "cargo_run": false,
+    "formatting_run": false,
+    "workflow_or_ci_run": false
+  },
+  "limitations": [
+    "No compiler evidence has been retained.",
+    "No policy or write-semantics failure trace has been retained.",
+    "The updated source guard has not been executed.",
+    "CheckoutPaymentCompensationPort admission remains a separate open mapper-cleanup slice."
+  ]
+}

--- a/crates/rustok-commerce/contracts/evidence/payment-checkout-execution-admission-context-source.json
+++ b/crates/rustok-commerce/contracts/evidence/payment-checkout-execution-admission-context-source.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": "1.0.0",
+  "status": "payment_checkout_execution_admission_context_source_unvalidated",
+  "captured_at": "2026-07-30",
+  "scope": {
+    "owner": "rustok_payment",
+    "boundary": "checkout_payment_execution_port",
+    "consumer": "rustok_commerce staged checkout",
+    "operations": [
+      "prepare_checkout_collection",
+      "authorize_checkout_collection",
+      "capture_checkout_collection",
+      "read_checkout_collection"
+    ]
+  },
+  "source_claims": {
+    "read_policy_rejections_are_context_logged": true,
+    "write_policy_rejections_are_context_logged": true,
+    "write_semantics_rejections_are_context_logged": true,
+    "original_port_error_is_returned_without_remap": true,
+    "correlation_tenant_actor_channel_locale_are_retained": true,
+    "causation_trace_idempotency_deadline_are_retained": true,
+    "typed_kind_code_message_and_retryability_are_retained": true,
+    "existing_owner_delegation_and_local_outcome_mapping_are_preserved": true,
+    "raw_request_strings_and_metadata_are_not_logged": true,
+    "checkout_payment_compensation_admission_is_out_of_scope": true
+  },
+  "validation": {
+    "focused_verifier_executed": false,
+    "aggregate_verifier_executed": false,
+    "cargo_check_executed": false,
+    "tests_executed": false,
+    "runtime_failure_injection_executed": false,
+    "ci_executed": false
+  },
+  "reviewed_sources": [
+    "crates/rustok-commerce/docs/implementation-plan.md",
+    "crates/rustok-payment/src/checkout_execution.rs",
+    "crates/rustok-payment/src/checkout_execution/port_impl.rs",
+    "crates/rustok-payment/src/checkout_execution/validation_errors.rs",
+    "crates/rustok-payment/src/checkout_compensation.rs",
+    "scripts/verify/verify-payment-checkout-execution-local-context.mjs"
+  ],
+  "promotion_gate": "No FFA, FBA, transport, runtime, browser, SSR, or production status is promoted from this source inspection."
+}

--- a/crates/rustok-commerce/docs/payment-checkout-execution-admission-context.md
+++ b/crates/rustok-commerce/docs/payment-checkout-execution-admission-context.md
@@ -1,0 +1,83 @@
+# Payment checkout execution admission context
+
+Status: source-complete / unvalidated
+
+## Scope
+
+This slice hardens admission diagnostics for the payment-owned
+`CheckoutPaymentExecutionPort` used by staged Commerce checkout.
+
+Covered operations:
+
+- `prepare_checkout_collection`
+- `authorize_checkout_collection`
+- `capture_checkout_collection`
+- `read_checkout_collection`
+
+The public port signatures, request/response types, read/write policies, write semantics,
+tenant and causation validation, owner delegation, provider journal behavior, lifecycle
+policy, idempotency, and returned `PortError` values are unchanged.
+
+## Previous gap
+
+The four public owner-port methods called `PortContext::require_policy` directly, and the
+three write methods called `require_write_semantics` directly. A rejected policy or
+missing write semantic returned before the existing local outcome mapper retained the
+owner operation and request context.
+
+The errors were already stable typed `PortError` values, so this was a diagnostic and
+correlation gap rather than a public-message sanitization change.
+
+## Source change
+
+Read admission now goes through `require_checkout_payment_read_admission`. Write
+admission now goes through `require_checkout_payment_write_admission`, which preserves
+both the write policy and non-empty write/idempotency semantics.
+
+Both helpers use `inspect_err`. They log the rejected typed error and return the exact
+same `PortError` without constructing or translating a public envelope.
+
+The admission event retains:
+
+- owner and exact owner operation;
+- policy versus write-semantics admission stage;
+- correlation ID and tenant;
+- actor, channel, and effective locale;
+- causation ID and traceparent;
+- idempotency key and deadline;
+- typed error kind, stable code/message, and retryability;
+- the `checkout_payment_execution_port` boundary.
+
+Unavailable, timeout, and invariant failures are emitted at error level. Ordinary policy
+or validation rejections are emitted at warning level.
+
+No checkout identity payload, currency string, plan hash, provider identity, metadata,
+or provider payload is added to the admission logs.
+
+## Preserved delegated outcome behavior
+
+After admission, the existing local-context mapper still retains only safe request facts
+for owner validation, storage, lifecycle, provider, and reconciliation outcomes. Unknown
+outcomes still pass through unchanged.
+
+## Evidence boundary
+
+The updated focused guard is:
+
+```text
+node scripts/verify/verify-payment-checkout-execution-local-context.mjs
+```
+
+It now requires contextual admission helpers, forbids direct public-method admission,
+checks that helpers use `inspect_err` rather than remapping, and retains the existing
+safe delegated-outcome checks.
+
+The verifier, Cargo, tests, formatting, workflows, CI, and runtime failure scenarios were
+not executed for this source slice.
+
+## Remaining work
+
+The master ecommerce correlation-safe mapper item remains open. In particular,
+`CheckoutPaymentCompensationPort` still performs policy and write-semantics admission
+directly and should be handled as a separate focused slice before the payment
+execution/compensation mapper work can be considered complete.

--- a/crates/rustok-payment/src/checkout_execution/port_impl.rs
+++ b/crates/rustok-payment/src/checkout_execution/port_impl.rs
@@ -26,8 +26,7 @@ impl CheckoutPaymentExecutionPort for InProcessCheckoutPaymentExecutionPort {
         request: PrepareCheckoutPaymentCollectionRequest,
     ) -> Result<PaymentCollectionResponse, PortError> {
         let owner_operation = PREPARE_CHECKOUT_COLLECTION_OPERATION;
-        context.require_policy(PortCallPolicy::write())?;
-        context.require_write_semantics()?;
+        require_checkout_payment_write_admission(&context, owner_operation)?;
         let tenant_id = parse_tenant_id(&context, owner_operation)?;
         require_operation_context(
             &context,
@@ -58,8 +57,7 @@ impl CheckoutPaymentExecutionPort for InProcessCheckoutPaymentExecutionPort {
         request: AuthorizeCheckoutPaymentCollectionRequest,
     ) -> Result<PaymentCollectionResponse, PortError> {
         let owner_operation = AUTHORIZE_CHECKOUT_COLLECTION_OPERATION;
-        context.require_policy(PortCallPolicy::write())?;
-        context.require_write_semantics()?;
+        require_checkout_payment_write_admission(&context, owner_operation)?;
         let tenant_id = parse_tenant_id(&context, owner_operation)?;
         require_operation_context(
             &context,
@@ -92,8 +90,7 @@ impl CheckoutPaymentExecutionPort for InProcessCheckoutPaymentExecutionPort {
         request: CaptureCheckoutPaymentCollectionRequest,
     ) -> Result<PaymentCollectionResponse, PortError> {
         let owner_operation = CAPTURE_CHECKOUT_COLLECTION_OPERATION;
-        context.require_policy(PortCallPolicy::write())?;
-        context.require_write_semantics()?;
+        require_checkout_payment_write_admission(&context, owner_operation)?;
         let tenant_id = parse_tenant_id(&context, owner_operation)?;
         require_operation_context(
             &context,
@@ -124,7 +121,7 @@ impl CheckoutPaymentExecutionPort for InProcessCheckoutPaymentExecutionPort {
         request: ReadCheckoutPaymentCollectionRequest,
     ) -> Result<PaymentCollectionResponse, PortError> {
         let owner_operation = READ_CHECKOUT_COLLECTION_OPERATION;
-        context.require_policy(PortCallPolicy::read())?;
+        require_checkout_payment_read_admission(&context, owner_operation)?;
         let tenant_id = parse_tenant_id(&context, owner_operation)?;
         require_operation_context(
             &context,

--- a/crates/rustok-payment/src/checkout_execution/validation_errors.rs
+++ b/crates/rustok-payment/src/checkout_execution/validation_errors.rs
@@ -82,6 +82,103 @@ fn merge_metadata(current: Value, patch: Value) -> Value {
     }
 }
 
+fn require_checkout_payment_read_admission(
+    context: &PortContext,
+    owner_operation: &'static str,
+) -> Result<(), PortError> {
+    context
+        .require_policy(PortCallPolicy::read())
+        .inspect_err(|error| {
+            log_checkout_payment_execution_admission_rejection(
+                context,
+                owner_operation,
+                "policy",
+                error,
+            );
+        })
+}
+
+fn require_checkout_payment_write_admission(
+    context: &PortContext,
+    owner_operation: &'static str,
+) -> Result<(), PortError> {
+    context
+        .require_policy(PortCallPolicy::write())
+        .inspect_err(|error| {
+            log_checkout_payment_execution_admission_rejection(
+                context,
+                owner_operation,
+                "policy",
+                error,
+            );
+        })?;
+    context.require_write_semantics().inspect_err(|error| {
+        log_checkout_payment_execution_admission_rejection(
+            context,
+            owner_operation,
+            "write_semantics",
+            error,
+        );
+    })
+}
+
+fn log_checkout_payment_execution_admission_rejection(
+    context: &PortContext,
+    owner_operation: &'static str,
+    admission: &'static str,
+    error: &PortError,
+) {
+    let technical_failure = matches!(
+        &error.kind,
+        PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation
+    );
+    if technical_failure {
+        tracing::error!(
+            error = ?error,
+            owner = "rustok_payment",
+            operation = owner_operation,
+            admission,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            actor = ?context.actor,
+            channel = ?context.channel,
+            locale = %context.locale,
+            causation_id = ?context.causation_id,
+            traceparent = ?context.traceparent,
+            idempotency_key = ?context.idempotency_key,
+            deadline_ms = ?context.deadline_ms,
+            internal_code = %error.code,
+            internal_message = %error.message,
+            error_kind = ?error.kind,
+            retryable = error.retryable,
+            boundary = "checkout_payment_execution_port",
+            "payment checkout execution admission failed"
+        );
+    } else {
+        tracing::warn!(
+            error = ?error,
+            owner = "rustok_payment",
+            operation = owner_operation,
+            admission,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            actor = ?context.actor,
+            channel = ?context.channel,
+            locale = %context.locale,
+            causation_id = ?context.causation_id,
+            traceparent = ?context.traceparent,
+            idempotency_key = ?context.idempotency_key,
+            deadline_ms = ?context.deadline_ms,
+            internal_code = %error.code,
+            internal_message = %error.message,
+            error_kind = ?error.kind,
+            retryable = error.retryable,
+            boundary = "checkout_payment_execution_port",
+            "payment checkout execution admission was rejected"
+        );
+    }
+}
+
 fn require_operation_context(
     context: &PortContext,
     owner_operation: &'static str,

--- a/scripts/verify/verify-payment-checkout-execution-local-context.mjs
+++ b/scripts/verify/verify-payment-checkout-execution-local-context.mjs
@@ -59,11 +59,11 @@ const captureOperation = between(
   'capture operation',
 );
 const readOperation = publicImpl.slice(publicImpl.indexOf('async fn read_checkout_collection('));
-const readHelper = between(
-  portImpl,
-  'impl InProcessCheckoutPaymentExecutionPort {',
-  'fn checkout_payment_execution_diagnostic_facts(',
-  'read owner helper',
+const admission = between(
+  errors,
+  'fn require_checkout_payment_read_admission(',
+  'fn require_operation_context(',
+  'checkout payment execution admission helpers',
 );
 const facts = between(
   portImpl,
@@ -79,8 +79,7 @@ for (const [block, config] of [
   [
     prepare,
     {
-      policy: 'context.require_policy(PortCallPolicy::write())?;',
-      semantics: 'context.require_write_semantics()?;',
+      admission: 'require_checkout_payment_write_admission(&context, owner_operation)?;',
       operation: 'PREPARE_CHECKOUT_COLLECTION_OPERATION',
       delegation: 'self.prepare(&context, owner_operation, tenant_id, request).await',
       collection: 'None,\n            None,\n            None,',
@@ -90,8 +89,7 @@ for (const [block, config] of [
   [
     authorize,
     {
-      policy: 'context.require_policy(PortCallPolicy::write())?;',
-      semantics: 'context.require_write_semantics()?;',
+      admission: 'require_checkout_payment_write_admission(&context, owner_operation)?;',
       operation: 'AUTHORIZE_CHECKOUT_COLLECTION_OPERATION',
       delegation: '.authorize(&context, owner_operation, tenant_id, request)',
       collection: 'Some(request.collection_id),',
@@ -101,8 +99,7 @@ for (const [block, config] of [
   [
     captureOperation,
     {
-      policy: 'context.require_policy(PortCallPolicy::write())?;',
-      semantics: 'context.require_write_semantics()?;',
+      admission: 'require_checkout_payment_write_admission(&context, owner_operation)?;',
       operation: 'CAPTURE_CHECKOUT_COLLECTION_OPERATION',
       delegation: 'self.capture(&context, owner_operation, tenant_id, request).await',
       collection: 'Some(request.collection_id),',
@@ -112,8 +109,7 @@ for (const [block, config] of [
   [
     readOperation,
     {
-      policy: 'context.require_policy(PortCallPolicy::read())?;',
-      semantics: null,
+      admission: 'require_checkout_payment_read_admission(&context, owner_operation)?;',
       operation: 'READ_CHECKOUT_COLLECTION_OPERATION',
       delegation: 'self.read(&context, owner_operation, tenant_id, request).await',
       collection: 'Some(request.collection_id),',
@@ -122,55 +118,84 @@ for (const [block, config] of [
   ],
 ]) {
   for (const [value, detail] of [
-    [config.policy, 'policy admission'],
+    [`let owner_operation = ${config.operation};`, 'owner operation'],
+    [config.admission, 'correlation-safe admission'],
     ['let tenant_id = parse_tenant_id(&context, owner_operation)?;', 'tenant validation'],
     ['require_operation_context(', 'causation validation'],
     ['let diagnostic_context = context.clone();', 'delegated context retention'],
     ['let diagnostic_facts = checkout_payment_execution_diagnostic_facts(', 'safe request retention'],
     [config.collection, 'collection/provider fact routing'],
-    ['let result = self', 'owner result retention'],
     [config.delegation, 'unchanged owner delegation'],
     ['result.map_err(|error| {', 'post-delegation mapping'],
     ['map_checkout_payment_execution_local_port_error(', 'local mapper call'],
-    ['&diagnostic_context,', 'retained context mapper argument'],
-    ['owner_operation,', 'exact operation mapper argument'],
-    ['&diagnostic_facts,', 'safe facts mapper argument'],
   ]) requireText(block, value, `${config.label} ${detail}`);
-  if (config.semantics) requireText(block, config.semantics, `${config.label} write semantics`);
-  else forbidText(block, 'require_write_semantics', `${config.label} must remain read-only`);
 
   const indexes = [
-    block.indexOf(config.policy),
+    block.indexOf(config.admission),
     block.indexOf('parse_tenant_id('),
     block.indexOf('require_operation_context('),
     block.indexOf('let diagnostic_context = context.clone();'),
     block.indexOf(config.delegation),
     block.indexOf('map_checkout_payment_execution_local_port_error('),
   ];
-  if (!indexes.every((value, index) => index === 0 || indexes[index - 1] < value)) {
+  if (!indexes.every((value, index) => value >= 0 && (index === 0 || indexes[index - 1] < value))) {
     failures.push(
       `${config.label}: expected admission -> tenant -> causation -> retention -> delegation -> mapping ordering`,
     );
   }
 }
 
+for (const value of [
+  'context.require_policy(PortCallPolicy::write())?;',
+  'context.require_policy(PortCallPolicy::read())?;',
+  'context.require_write_semantics()?;',
+]) forbidText(publicImpl, value, 'public execution admission must use contextual helpers');
+
 for (const [value, label] of [
-  ['async fn read(', 'private read helper'],
-  ['validate_identity(&request.identity)?;', 'read identity validation'],
-  ['.get_collection(tenant_id, request.collection_id)', 'read collection lookup'],
-  ['payment_error_to_port_error(context, owner_operation, error)', 'read owner error mapping'],
-  ['validate_collection(&collection, tenant_id, &request.identity)?;', 'read collection validation'],
-  ['Ok(collection)', 'read response preservation'],
-]) requireText(readHelper, value, label);
-const readIndexes = [
-  readHelper.indexOf('validate_identity(&request.identity)?;'),
-  readHelper.indexOf('.get_collection(tenant_id, request.collection_id)'),
-  readHelper.indexOf('validate_collection(&collection, tenant_id, &request.identity)?;'),
-  readHelper.indexOf('Ok(collection)'),
-];
-if (!readIndexes.every((value, index) => index === 0 || readIndexes[index - 1] < value)) {
-  failures.push('read helper must preserve validate identity -> load collection -> validate collection ordering');
+  ['fn require_checkout_payment_read_admission(', 'read admission helper'],
+  ['fn require_checkout_payment_write_admission(', 'write admission helper'],
+  ['.require_policy(PortCallPolicy::read())', 'read policy'],
+  ['.require_policy(PortCallPolicy::write())', 'write policy'],
+  ['context.require_write_semantics().inspect_err', 'write semantics retention'],
+  ['"policy"', 'policy admission kind'],
+  ['"write_semantics"', 'write semantics admission kind'],
+  ['fn log_checkout_payment_execution_admission_rejection(', 'admission logger'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation', 'technical severity'],
+  ['tracing::error!(', 'technical event'],
+  ['tracing::warn!(', 'ordinary event'],
+  ['error = ?error', 'original PortError'],
+  ['owner = "rustok_payment"', 'truthful owner'],
+  ['operation = owner_operation', 'owner operation context'],
+  ['admission,', 'admission classification'],
+  ['correlation_id = %context.correlation_id', 'correlation context'],
+  ['tenant_id = %context.tenant_id', 'tenant context'],
+  ['actor = ?context.actor', 'actor context'],
+  ['channel = ?context.channel', 'channel context'],
+  ['locale = %context.locale', 'locale context'],
+  ['causation_id = ?context.causation_id', 'causation context'],
+  ['traceparent = ?context.traceparent', 'trace context'],
+  ['idempotency_key = ?context.idempotency_key', 'idempotency context'],
+  ['deadline_ms = ?context.deadline_ms', 'deadline context'],
+  ['internal_code = %error.code', 'stable code'],
+  ['internal_message = %error.message', 'stable message'],
+  ['error_kind = ?error.kind', 'typed kind'],
+  ['retryable = error.retryable', 'retryability'],
+  ['boundary = "checkout_payment_execution_port"', 'owner boundary'],
+  ['"payment checkout execution admission failed"', 'technical message'],
+  ['"payment checkout execution admission was rejected"', 'ordinary message'],
+]) requireText(admission, value, label);
+
+const inspectErrCount = admission.match(/\.inspect_err\(\|error\|/g)?.length ?? 0;
+if (inspectErrCount !== 3) {
+  failures.push(`admission helpers must retain the original PortError through three inspect_err calls; found ${inspectErrCount}`);
 }
+for (const value of [
+  'PortError::new(',
+  'PortError::validation(',
+  'PortError::unavailable(',
+  'PortError::conflict(',
+  'map_err(',
+]) forbidText(admission, value, 'admission helpers must not remap public errors');
 
 for (const [value, label] of [
   ['checkout_operation_id: identity.checkout_operation_id', 'checkout operation fact'],
@@ -195,91 +220,23 @@ for (const [value, label] of [
   ['"payment.checkout_identity_invalid"', 'checkout identity code'],
   ['"validate_checkout_identity"', 'checkout identity local operation'],
   ['"payment.checkout_currency_invalid"', 'currency code'],
-  ['"validate_checkout_currency"', 'currency local operation'],
   ['"payment.checkout_plan_hash_invalid"', 'plan hash code'],
-  ['"validate_checkout_plan_hash"', 'plan hash local operation'],
-  ['"payment.checkout_collection_id_invalid"', 'collection id code'],
-  ['"validate_collection_id"', 'collection id local operation'],
-  ['"payment.checkout_collection_operation_conflict"', 'operation conflict code'],
-  ['"validate_collection_operation"', 'operation conflict local operation'],
-  ['"payment.checkout_collection_plan_conflict"', 'plan conflict code'],
-  ['"validate_collection_plan"', 'plan conflict local operation'],
   ['"payment.checkout_collection_identity_missing"', 'missing collection identity code'],
-  ['"require_collection_identity"', 'missing identity local operation'],
-  ['"payment.checkout_collection_identity_conflict"', 'collection identity conflict code'],
-  ['"validate_collection_identity"', 'collection identity local operation'],
-  ['"payment.checkout_authorize_state_conflict"', 'authorize lifecycle code'],
-  ['"validate_authorize_lifecycle"', 'authorize lifecycle local operation'],
-  ['"payment.checkout_capture_state_conflict"', 'capture lifecycle code'],
-  ['"validate_capture_lifecycle"', 'capture lifecycle local operation'],
-  ['"payment.checkout_authorize_request_invalid"', 'authorize request code'],
-  ['"validate_authorize_request"', 'authorize request local operation'],
-  ['"payment.provider_metadata_invalid"', 'provider metadata code'],
-  ['"validate_provider_metadata"', 'provider metadata local operation'],
-  ['"payment.provider_identity_conflict"', 'provider identity code'],
-  ['"validate_provider_identity"', 'provider identity local operation'],
-  ['"payment.provider_idempotency_key_required"', 'provider idempotency code'],
-  ['"require_provider_idempotency_key"', 'provider idempotency local operation'],
-  ['"payment.provider_request_encoding_failed"', 'provider encoding code'],
-  ['"encode_provider_request"', 'provider encoding local operation'],
   ['"payment.database_unavailable"', 'storage code'],
-  ['"owner_storage"', 'storage local operation'],
   ['"payment.checkout_execution_validation"', 'owner validation code'],
-  ['"validate_owner_request"', 'owner validation local operation'],
-  ['"payment.collection_not_found"', 'collection not-found code'],
-  ['"load_collection"', 'collection not-found local operation'],
   ['"payment.checkout_execution_state_conflict"', 'owner lifecycle code'],
-  ['"apply_payment_lifecycle"', 'owner lifecycle local operation'],
   ['"payment.provider_unavailable"', 'provider unavailable code'],
   ['"payment.provider_rejected"', 'provider rejected code'],
-  ['"execute_provider_operation"', 'provider execution local operation'],
   ['"payment.checkout_execution_manual_reconciliation"', 'manual reconciliation code'],
-  ['"require_manual_reconciliation"', 'manual reconciliation local operation'],
   ['"payment.provider_not_configured"', 'provider configuration code'],
-  ['"resolve_provider"', 'provider configuration local operation'],
-  ['"require_collection_identity" | "require_manual_reconciliation"', 'integrity severity classification'],
-  ['PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation', 'technical severity classification'],
   ['tracing::error!(', 'technical local event'],
   ['tracing::warn!(', 'ordinary local event'],
-  ['error = ?error', 'original delegated error'],
-  ['owner = "rustok_payment"', 'truthful owner'],
-  ['operation,', 'public operation'],
-  ['local_operation,', 'local operation'],
-  ['correlation_id = %context.correlation_id', 'correlation context'],
-  ['tenant_id = %context.tenant_id', 'tenant context'],
-  ['actor = ?context.actor', 'actor context'],
-  ['channel = ?context.channel', 'channel context'],
-  ['locale = %context.locale', 'locale context'],
-  ['causation_id = ?context.causation_id', 'causation context'],
-  ['traceparent = ?context.traceparent', 'trace context'],
-  ['idempotency_key = ?context.idempotency_key', 'idempotency context'],
-  ['deadline_ms = ?context.deadline_ms', 'deadline context'],
-  ['checkout_operation_id = %facts.checkout_operation_id', 'checkout operation context'],
-  ['cart_id = %facts.cart_id', 'cart context'],
-  ['order_id = %facts.order_id', 'order context'],
-  ['customer_id = ?facts.customer_id', 'customer context'],
-  ['collection_id = ?facts.collection_id', 'collection context'],
-  ['request_amount = %facts.amount', 'amount context'],
-  ['currency_code_length = facts.currency_code_length', 'currency length context'],
-  ['order_plan_hash_length = facts.order_plan_hash_length', 'plan hash length context'],
-  ['requested_provider_id_length = ?facts.requested_provider_id_length', 'provider id length context'],
-  ['provider_payment_id_length = ?facts.provider_payment_id_length', 'provider payment id length context'],
-  ['internal_code = %error.code', 'stable code'],
-  ['internal_message = %error.message', 'stable message'],
-  ['error_kind = ?error.kind', 'typed kind'],
-  ['retryable = error.retryable', 'retryability'],
-  ['boundary = "checkout_payment_execution_port"', 'owner boundary'],
+  ['owner = "rustok_payment"', 'truthful local owner'],
+  ['correlation_id = %context.correlation_id', 'local correlation context'],
+  ['boundary = "checkout_payment_execution_port"', 'local owner boundary'],
   ['\n    error\n}', 'same delegated error return'],
 ]) requireText(mapper, value, label);
 
-const unknownReturns = mapper.match(/_ => return error,/g)?.length ?? 0;
-if (unknownReturns !== 1) {
-  failures.push(`unknown local outcome pass-through count: expected 1, found ${unknownReturns}`);
-}
-for (const value of [
-  'payment.tenant_id_invalid',
-  'payment.checkout_operation_id_invalid',
-]) forbidText(mapper, value, 'admission and context errors must not be remapped locally');
 for (const value of [
   'currency_code =',
   'order_plan_hash =',
@@ -295,9 +252,6 @@ for (const [content, values, label] of [
       '"payment.checkout_identity_invalid"',
       '"payment.checkout_currency_invalid"',
       '"payment.checkout_plan_hash_invalid"',
-      '"payment.checkout_collection_operation_conflict"',
-      '"payment.checkout_collection_plan_conflict"',
-      '"payment.checkout_collection_identity_conflict"',
       '"payment.checkout_collection_identity_missing"',
     ],
     'identity source',
@@ -307,7 +261,6 @@ for (const [content, values, label] of [
     [
       'async fn prepare(',
       'validate_identity(&request.identity)?;',
-      '"payment.checkout_collection_id_invalid"',
       '"payment.checkout_authorize_state_conflict"',
       '"payment.checkout_authorize_request_invalid"',
     ],
@@ -317,22 +270,13 @@ for (const [content, values, label] of [
     capture,
     [
       'validate_identity(&request.identity)?;',
-      '"payment.checkout_collection_id_invalid"',
       '"payment.checkout_capture_state_conflict"',
       '"payment.provider_idempotency_key_required"',
       '"payment.provider_request_encoding_failed"',
     ],
     'capture source',
   ],
-  [
-    providerHelpers,
-    [
-      'insert_metadata_string(',
-      '"provider_payment_id"',
-      'manual_reconciliation(',
-    ],
-    'provider helper source',
-  ],
+  [providerHelpers, ['insert_metadata_string(', '"provider_payment_id"', 'manual_reconciliation('], 'provider helper source'],
   [
     errors,
     [
@@ -340,10 +284,6 @@ for (const [content, values, label] of [
       '"payment.provider_identity_conflict"',
       '"payment.checkout_execution_manual_reconciliation"',
       '"payment.database_unavailable"',
-      '"payment.checkout_execution_validation"',
-      '"payment.checkout_execution_state_conflict"',
-      '"payment.provider_unavailable"',
-      '"payment.provider_rejected"',
       '"payment.provider_not_configured"',
     ],
     'stable owner envelope source',
@@ -359,5 +299,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Payment checkout execution operations retain delegated context and safe request facts for stable local outcomes without exposing raw caller strings or changing PortError results',
+  '✔ Payment checkout execution admission and delegated outcomes retain correlation-safe owner context without remapping PortError results or exposing raw caller strings',
 );


### PR DESCRIPTION
## Summary
- route all four `CheckoutPaymentExecutionPort` operations through correlation-aware admission helpers
- preserve read policy for reads and write policy plus write semantics for prepare/authorize/capture
- log rejected typed `PortError` values with owner operation, admission stage, correlation, tenant, actor, channel, locale, causation, traceparent, idempotency, deadline, kind, code, message, and retryability
- use `inspect_err`, returning the exact original `PortError` without changing public envelopes
- preserve tenant/causation validation, owner delegation, provider behavior, lifecycle rules, idempotency, and the existing safe delegated-outcome mapper
- update the focused local-context source guard and retain unvalidated source/review evidence plus documentation

## Recheck
The ecommerce master plan still keeps payment execution/compensation mapper cleanup open. The delegated execution outcomes were already correlation-aware, but policy and write-semantics rejection happened before that mapper and lacked owner/request context.

## Scope
Covered operations:
- `prepare_checkout_collection`
- `authorize_checkout_collection`
- `capture_checkout_collection`
- `read_checkout_collection`

`CheckoutPaymentCompensationPort` remains explicitly out of scope and is the next focused slice.

## Evidence boundary
Source status is `payment_checkout_execution_admission_context_source_unvalidated`. No FFA, FBA, transport, runtime, browser, SSR, or production status is promoted.

## Verification
The current ecommerce plan, payment collection mapper, checkout execution entrypoint, validation/error mapper, existing local-context verifier, and compensation admission gap were re-read. The final branch is ahead-only from current `main` and contains six payment/Commerce evidence files.

Tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run per maintainer instruction.