### PR TITLE
docs(verification): advance Search handoff to Tenant

### DIFF
--- a/crates/rustok-search/docs/implementation-plan.md
+++ b/crates/rustok-search/docs/implementation-plan.md
@@ -43,6 +43,23 @@ category, does not serialize bootstrap `search.api_key`, filters historical gene
 Search rows from list responses, and rejects generic Search reads and writes before
 database access.
 
+Periodic release verification found two unresolved runtime boundaries. Public
+GraphQL and native storefront Search accept `channel_id` from caller input rather
+than deriving it from trusted `RequestContext`, while `PgSearchEngine` applies the
+channel only to attribute filters, facets, and sorting—not to the ranked product
+result set. Product search documents also omit the canonical
+`metadata.channel_visibility.allowed_channel_slugs` projection, so an active
+product can remain searchable in a channel where the Commerce storefront would
+hide it.
+
+The durable projection contract is also incomplete. The generic
+`search_projection_inbox` and watermark schema exists, but only Forum events use
+it and its background reconciler. Content, Product, Blog, locale, tenant, and
+ordinary reindex work can still run directly through the process-local event
+handler. Terminal handler failure or broadcast lag is logged but has no durable
+Search consumer receipt, automatic retry lane, or guaranteed source rebuild, so a
+projection can remain stale after recovery.
+
 ## FFA/FBA status
 
 - FFA status: `phase_b_ready`.
@@ -77,6 +94,8 @@ database access.
   scope; enabling the module rebuilds it from retained owner rows.
 - Targeted Blog reindex deletes stale documents before source lookup, so a missing
   owner post cannot leave obsolete search data behind.
+- Storefront channel authority and product visibility remain `blocked`.
+- Durable non-Forum projection replay/recovery remains `blocked`.
 
 ## Deployment and connector boundary
 
@@ -124,20 +143,33 @@ rebuild behavior through replayable event transport.
 
 ## Next results
 
-1. **Execute canonical URL evidence.** Run core URL-policy tests, GraphQL
+1. **Close storefront channel authority and visibility.** Derive channel identity
+   from trusted `RequestContext` for GraphQL and native storefront surfaces,
+   denormalize canonical product channel visibility into Search-owned documents,
+   backfill existing documents safely, and make base results, totals, facets,
+   typo fallback, and attribute operations use one fail-closed channel predicate.
+   **Done when:** caller-supplied channel IDs cannot select another channel and a
+   restricted product is absent from every Search response outside its allowed
+   channel.
+2. **Generalize durable Search projection recovery.** Use the existing generic
+   inbox/watermark schema for Content, Product, Blog, locale, tenant, and reindex
+   events; add bounded retry, dead-letter diagnostics, ordered replay, restart and
+   lag recovery, and source-of-truth rebuild evidence.
+   **Done when:** terminal handler failure, transport lag, duplicate/out-of-order
+   delivery, and process restart cannot leave a stale projection without an
+   observable durable recovery action.
+3. **Execute canonical URL evidence.** Run core URL-policy tests, GraphQL
    storefront Search, native storefront Search, Search admin preview, and admin
    global search against projected product, content, and Blog documents. Retain
    proof that malformed Blog payloads remain non-navigable everywhere.
-2. **Verify click analytics.** Confirm every Search surface records the canonical
+4. **Verify click analytics.** Confirm every Search surface records the canonical
    href without reconstructing routes in analytics code.
-3. **Execute live Blog projection evidence.** Run routing and PostgreSQL harnesses
+5. **Execute live Blog projection evidence.** Run routing and PostgreSQL harnesses
    and retain migration/`pg_trgm`, event-delivery, targeted missing-post cleanup,
    module-disable cleanup, and category reindex results.
-4. **Execute live provider evidence.** Run query and suggestion providers under
+6. **Execute live provider evidence.** Run query and suggestion providers under
    deadline, error, locale, tenant, channel, ranking, and catalog-filter conditions.
-5. **Harden operations.** Add bounded ingestion/rebuild retry and DLQ behavior with
-   observable lag, consistency, and recovery outcomes.
-6. **Add external engines only as adapters.** Meilisearch, Typesense, or Algolia
+7. **Add external engines only as adapters.** Meilisearch, Typesense, or Algolia
    connectors must not bypass Search ports, owner URL mapping, or PostgreSQL
    baseline selection.
 
@@ -164,12 +196,12 @@ rebuild behavior through replayable event transport.
 ## Periodic release verification handoff
 
 - Cycle: `cycle-001`
-- Status: `in_progress`
+- Status: `blocked`
 - Last verified at (UTC): `2026-07-30`
-- Scope inspected: `Search settings ownership, generic platform settings projection, owner Search GraphQL/settings service, FBA guard and carried event-delivery/rebuild concerns`
-- Findings: `P0=0, P1=1, P2=0, P3=0`
-- Fixed in this pass: `removed the non-authoritative generic platform_settings/search category, blocked read/write/list projection of historical generic Search rows, and added an owner-boundary FBA guard`
-- Remaining risks or blockers: `tenant/locale/channel isolation, event replay/rebuild, deletion, duplicate and out-of-order delivery, connector boundaries, click analytics and operational recovery still require source and live-evidence inspection`
-- Evidence: `source inspection confirms SearchSettingsService/search_settings is the owner path; the generic service now validates category before DB access and the standard Search FBA verifier rejects any restored rs.search projection`
-- Next action: `run same-SHA Search FBA and targeted settings tests, merge the focused P1 fix, then trace every ingestion/rebuild publisher-consumer path on a fresh branch`
-- Resume command: `cargo test -p rustok-server settings_service && npm run verify:search:fba && node scripts/verify/verify-search-blog-projection.mjs`
+- Scope inspected: `Search settings ownership, GraphQL/native storefront trust, PostgreSQL query channel semantics, product visibility projection, event dispatch, durable inbox/reconciliation, projection transactions, locale/delete/rebuild paths, connector and UI boundaries`
+- Findings: `P0=0, P1=3, P2=0, P3=1`
+- Fixed in this pass: `merged PR #2557 / commit 2a40ffc372449d6729b7d86fd6135b49555f7e9a, removing the non-authoritative generic platform_settings/search secret-bearing path and adding an owner-boundary guard`
+- Remaining risks or blockers: `P1: public GraphQL and native storefront Search trust caller channel_id and PgSearchEngine does not apply channel visibility to the base product result set; P1: non-Forum Search projections lack a durable consumer receipt, retry/DLQ lane and guaranteed replay/rebuild after terminal handler failure or broadcast lag; P3: projector_legacy.rs remains a production implementation behind a compatibility-named facade and should be replaced rather than wrapped`
+- Evidence: `source audit confirms RequestContext owns trusted channel id/slug, storefront Search instead passes normalized caller input, base FTS/typo CTEs filter only tenant/locale/query, and canonical Commerce visibility uses metadata.channel_visibility.allowed_channel_slugs; search_projection_inbox is generic but ForumProjectionInbox/Reconciler and its server worker are Forum-only; PR #2557 had a conflict-free three-file diff, while broad Cargo gates were blocked by unrelated repository compilation, Cargo.lock/Athanor, expired-advisory and invalid-MSRV workflow failures`
+- Next action: `on a fresh branch, implement one Search-owned denormalized channel-visibility contract across projector/backfill/query and trusted storefront adapters with PostgreSQL evidence; separately generalize the existing durable projection inbox/reconciler to every Search source and retain outage/restart/replay evidence`
+- Resume command: `rg "channel_id: input.channel_id" crates/rustok-search/src/graphql/query.rs crates/rustok-search/storefront/src/transport/native_server_adapter.rs && rg "query.channel_id" crates/rustok-search/src/pg_engine.rs && rg "let _ = handler.handle_with_retry|ForumProjectionInbox|ForumProjectionReconciler" crates/rustok-core/src/events/handler.rs crates/rustok-search/src apps/server/src/services`

--- a/crates/rustok-tenant/docs/implementation-plan.md
+++ b/crates/rustok-tenant/docs/implementation-plan.md
@@ -138,3 +138,16 @@ jobs.
    a public/runtime contract change.
 3. Update this status block and `docs/modules/registry.md` with a UI or
    transport boundary change.
+
+## Periodic release verification handoff
+
+- Cycle: `cycle-001`
+- Status: `in_progress`
+- Last verified at (UTC): `2026-07-30`
+- Scope inspected: `pending owner/runtime audit; tenant domain, locale-policy CAS, read ports, lifecycle events, resolver/cache generation, installer provisioning, module toggles and tenant-scoped RBAC consumers`
+- Findings: `P0=0, P1=0, P2=0, P3=0`
+- Fixed in this pass: `none; verification start marker only`
+- Remaining risks or blockers: `multi-replica Redis evidence is source-complete but unexecuted; ownership, lifecycle transactionality, cache generation, resolver trust, multilingual storage and cross-module consumers require current source inspection`
+- Evidence: `local owner plan and published TenantReadPort/TenantLocalePolicyPort boundaries reviewed before source work`
+- Next action: `inspect tenant migrations, command transactions/events, read and locale-policy ports, server resolution/cache invalidation, installer and module lifecycle consumers, then fix reproducible P0/P1 defects`
+- Resume command: `npm run verify:tenant:fba && npm run verify:tenant:admin-boundary && cargo xtask module validate tenant && cargo xtask module test tenant`

--- a/docs/verification/PLATFORM_VERIFICATION_PLAN.md
+++ b/docs/verification/PLATFORM_VERIFICATION_PLAN.md
@@ -38,13 +38,13 @@ This block is the first place an agent reads after `docs/index.md`.
 
 - Cycle: `cycle-001`
 - Cycle status: `active`
-- Current item: `core/search`
-- Next item: `core/search`
+- Current item: `core/tenant`
+- Next item: `core/tenant`
 - Started at (UTC): `2026-07-20`
 - Last handoff at (UTC): `2026-07-30`
-- Carried release blockers: `core/auth P1: implicit refresh_token authority for auto-created OAuth applications whose persisted grant_types omit it; core/cache P1: failed Redis invalidations can become untracked when the bounded tombstone tracker is saturated, allowing stale shared reads after recovery; core/channel P1: channels.name and possibly tenant-visible policy-set names remain human-facing copy in language-neutral base rows; core/channel P1: tenant/concurrency invariant fixes are staged in draft PR #2469 but are not in main or same-SHA verified while Actions runs remain queued; core/email P1: settings:read exposed runtime smtp.password and native admin returned raw email settings, with secret-safe fixes staged only in draft PR #2490; core/email P1: delivery lacks a durable receipt/outbox, auth uses a detached server-owned bypass, saved tenant settings do not drive runtime SMTP, and historical secret-bearing rows lack an owned scrub migration; core/index P1: one retained admitted real PostgreSQL partition packet and live PostgreSQL/reference query equivalence are absent, and no retained per-tenant freshness, outage/restart, backlog catch-up or replay-repair evidence authorizes consumer or partition cutover; core/search P1: the generic settings projection serializes search.api_key; core/outbox P1: sys_events dispatched state proves transport acceptance only, while terminal local handler failure or broadcast lag lacks a durable consumer receipt, consumer DLQ, or automatic replay/rebuild contract and can leave Search or other projections stale`
+- Carried release blockers: `core/auth P1: implicit refresh_token authority for auto-created OAuth applications whose persisted grant_types omit it; core/cache P1: failed Redis invalidations can become untracked when the bounded tombstone tracker is saturated, allowing stale shared reads after recovery; core/channel P1: channels.name and possibly tenant-visible policy-set names remain human-facing copy in language-neutral base rows; core/channel P1: tenant/concurrency invariant fixes are staged in draft PR #2469 but are not in main or same-SHA verified while Actions runs remain queued; core/email P1: settings:read exposed runtime smtp.password and native admin returned raw email settings, with secret-safe fixes staged only in draft PR #2490; core/email P1: delivery lacks a durable receipt/outbox, auth uses a detached server-owned bypass, saved tenant settings do not drive runtime SMTP, and historical secret-bearing rows lack an owned scrub migration; core/index P1: one retained admitted real PostgreSQL partition packet and live PostgreSQL/reference query equivalence are absent, and no retained per-tenant freshness, outage/restart, backlog catch-up or replay-repair evidence authorizes consumer or partition cutover; core/search P1: public GraphQL/native storefront Search trust caller channel_id while PgSearchEngine does not enforce canonical product channel visibility on the base result set; core/search P1: Content/Product/Blog and shared Search projection events lack the durable inbox, retry/DLQ and automatic replay/rebuild contract currently implemented only for Forum; core/outbox P1: sys_events dispatched state proves transport acceptance only, while terminal local handler failure or broadcast lag lacks a durable consumer receipt, consumer DLQ, or automatic replay/rebuild contract and can leave Search or other projections stale`
 - Release readiness: `not_assessed`
-- Environment notes: `cycle-001 core/auth default-feature rustok-server test reached rustok-admin linking and failed with rustc-LLVM out of memory; connector-only local targeted regressions for cache/channel/email/index could not run because github.com DNS resolution failed; channel Actions runs 30517068108 and 30517068093 remained queued; email Cargo jobs on SHA 53f84914b37d61b7b5078a3cba42caf65c96a65a had not started; Index same-SHA Scale Run Contract and full Scale Evidence repository/fixture contracts passed on PR #2544, while general CI/Hardening received no jobs and Rust-hosted smoke stopped before compilation because Cargo.lock required an Athanor update under --locked; dependency advisory exceptions expired on 2026-07-24; these conditions are not classified as product defects`
+- Environment notes: `cycle-001 core/auth default-feature rustok-server test reached rustok-admin linking and failed with rustc-LLVM out of memory; connector-only local targeted regressions for cache/channel/email/index/search could not run because github.com DNS resolution failed; channel Actions runs 30517068108 and 30517068093 remained queued; email Cargo jobs on SHA 53f84914b37d61b7b5078a3cba42caf65c96a65a had not started; Index same-SHA Scale Run Contract and full Scale Evidence repository/fixture contracts passed on PR #2544; Search PR #2557 merged a conflict-free three-file secret-boundary fix while broad Cargo gates stopped on unrelated repository compilation, Cargo.lock/Athanor, expired-advisory and invalid-MSRV workflow failures; dependency advisory exceptions expired on 2026-07-24; these conditions are not classified as product defects`
 
 Allowed cycle statuses are `ready`, `active`, and `closing`. An item uses `pending`,
 `in_progress`, `completed`, or `blocked` in its local handoff block. Only one item may
@@ -182,17 +182,18 @@ These are Core modules because the current `modules.toml` declares them with
 - [x] `core/channel` — `crates/rustok-channel` — blocked
 - [x] `core/email` — `crates/rustok-email` — blocked
 - [x] `core/index` — `crates/rustok-index` — blocked
-- [ ] `core/search` — `crates/rustok-search` — in_progress
+- [x] `core/search` — `crates/rustok-search` — blocked
 - [x] `core/outbox` — `crates/rustok-outbox` — blocked
-- [ ] `core/tenant` — `crates/rustok-tenant`
+- [ ] `core/tenant` — `crates/rustok-tenant` — in_progress
 - [ ] `core/rbac` — `crates/rustok-rbac`
 - [ ] Core interaction sweep — auth/tenant/RBAC generation and caches; channel/locale
   cache dimensions; transactional events/outbox; index/search replay and rebuild;
   Core module lifecycle and migration ordering.
 
 `core/outbox` was visited ahead of the normal cursor to remove a confirmed P0 tenant
-isolation defect. Outbox and Index must be revisited at the closing gate for their
-consumer-durability, freshness, replay, and retained-evidence blockers.
+isolation defect. Outbox, Index, and Search must be revisited at the closing gate for
+their consumer-durability, channel-visibility, freshness, replay, and retained-evidence
+blockers.
 
 For each manifest module, run at minimum:
 


### PR DESCRIPTION
## Verification handoff

- records the merged Search settings-secret P1 fix
- marks `core/search` visited and blocked on two exact runtime P1s: storefront channel authority/visibility and durable non-Forum projection replay
- records the production `projector_legacy.rs` path as P3 cleanup rather than pretending it is removed
- sets `core/tenant` to `in_progress` in its owner plan
- advances the master cursor to `core/tenant`
- removes the fixed `search.api_key` exposure from carried blockers while retaining the two unresolved Search blockers

No runtime code or workflow is changed.