### PR TITLE
fix(payment): retain checkout compensation admission context

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/payment-checkout-compensation-admission-context-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/payment-checkout-compensation-admission-context-source-review.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": 1,
+  "status": "payment_checkout_compensation_admission_context_source_reviewed_unvalidated",
+  "reviewed_at": "2026-07-30",
+  "base_main_sha": "43b77b303569ea1e4c38db78c18f2a30ebe0c217",
+  "reviewed_sources": [
+    "crates/rustok-commerce/docs/implementation-plan.md",
+    "crates/rustok-api/src/ports.rs",
+    "crates/rustok-payment/src/lib.rs",
+    "crates/rustok-payment/src/checkout_compensation.rs",
+    "crates/rustok-payment/src/checkout_compensation_context.rs",
+    "crates/rustok-payment/src/checkout_compensation_api.rs",
+    "scripts/verify/verify-payment-checkout-compensation-local-context.mjs"
+  ],
+  "findings": [
+    "The master ecommerce plan still keeps payment execution and compensation mapper cleanup open.",
+    "The persistent compensation owner returned write-policy and write-semantics errors before provider or lifecycle work.",
+    "The context wrapper retained safe request facts but previously excluded admission envelopes.",
+    "The public module path exposed the persistent implementation type and factory as a diagnostic bypass.",
+    "No production source outside the wrapper referenced crate::checkout_compensation internals.",
+    "PortContext admission envelopes are stable sanitized PortError pairs for missing idempotency and deadline semantics."
+  ],
+  "reviewed_contract": {
+    "persistent_source_private": true,
+    "public_module_facade_present": true,
+    "root_and_module_wrapper_parity": true,
+    "admission_mapping_exact": true,
+    "same_port_error_returned": true,
+    "provider_and_lifecycle_source_unchanged": true
+  },
+  "executed_commands": [],
+  "validation": {
+    "focused_verifier": false,
+    "cargo": false,
+    "tests": false,
+    "runtime": false,
+    "ci": false
+  }
+}

--- a/crates/rustok-commerce/contracts/evidence/payment-checkout-compensation-admission-context-source.json
+++ b/crates/rustok-commerce/contracts/evidence/payment-checkout-compensation-admission-context-source.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": 1,
+  "status": "payment_checkout_compensation_admission_context_source_unvalidated",
+  "owner": "rustok_payment",
+  "consumer": "rustok_commerce.checkout_compensation",
+  "boundary": "checkout_payment_compensation_port",
+  "operation": "compensate_checkout_payment",
+  "scope": {
+    "public_root_type": "rustok_payment::InProcessCheckoutPaymentCompensationPort",
+    "public_root_factory": "rustok_payment::in_process_checkout_payment_compensation_port",
+    "public_module_type": "rustok_payment::checkout_compensation::InProcessCheckoutPaymentCompensationPort",
+    "public_module_factory": "rustok_payment::checkout_compensation::in_process_checkout_payment_compensation_port",
+    "persistent_source": "crates/rustok-payment/src/checkout_compensation.rs",
+    "context_wrapper": "crates/rustok-payment/src/checkout_compensation_context.rs",
+    "public_facade": "crates/rustok-payment/src/checkout_compensation_api.rs"
+  },
+  "admission_envelopes": [
+    {
+      "code": "port.idempotency_key_required",
+      "message": "write port calls require a non-empty idempotency key",
+      "local_operation": "admit_write_idempotency"
+    },
+    {
+      "code": "port.deadline_required",
+      "message": "port calls require deadline semantics",
+      "local_operation": "admit_deadline"
+    }
+  ],
+  "contract": {
+    "persistent_module_publicly_reachable": false,
+    "root_and_module_paths_use_context_wrapper": true,
+    "exact_code_and_message_matching": true,
+    "same_port_error_returned": true,
+    "raw_reason_logged": false,
+    "raw_metadata_logged": false,
+    "tenant_and_causation_duplicate_mapping": false
+  },
+  "validation": {
+    "focused_verifier": false,
+    "aggregate_verifier": false,
+    "cargo_check_payment": false,
+    "cargo_check_commerce": false,
+    "tests": false,
+    "provider_replay": false,
+    "restart": false,
+    "remote_profile": false,
+    "mounted_transport_parity": false,
+    "ci": false
+  },
+  "nonclaims": [
+    "No verifier, compiler, test, provider, restart, remote-profile, transport, or CI command was executed.",
+    "No payment lifecycle, provider execution, idempotency, persistence, or public PortError semantics were changed.",
+    "The broad ecommerce correlation-safe mapper cleanup remains open."
+  ]
+}

--- a/crates/rustok-commerce/docs/payment-checkout-compensation-admission-context.md
+++ b/crates/rustok-commerce/docs/payment-checkout-compensation-admission-context.md
@@ -1,0 +1,86 @@
+# Payment checkout compensation admission context
+
+Status: `payment_checkout_compensation_admission_context_source_unvalidated`
+
+## Problem
+
+The canonical payment compensation wrapper already retained correlation-safe local context for stable owner outcomes. Two gaps remained:
+
+1. write admission failures occurred before compensation lifecycle/provider work and were deliberately excluded from the wrapper mapper;
+2. the public `rustok_payment::checkout_compensation::*` namespace still exposed the persistent implementation type and factory, allowing callers to bypass the wrapper entirely.
+
+## Source change
+
+Payment compensation now has three explicit layers:
+
+- private persistent owner source: `checkout_compensation.rs`;
+- context wrapper: `checkout_compensation_context.rs`;
+- public compatibility facade: `checkout_compensation_api.rs`.
+
+Both the crate root and `rustok_payment::checkout_compensation::*` preserve the established public names while resolving the implementation type and factory to the context wrapper. The original trait and request DTO remain the owner contracts.
+
+## Covered admission outcomes
+
+The wrapper classifies only exact stable pairs:
+
+- `port.idempotency_key_required` plus `write port calls require a non-empty idempotency key` as `admit_write_idempotency`;
+- `port.deadline_required` plus `port calls require deadline semantics` as `admit_deadline`.
+
+The first remains a validation warning. The timeout-based deadline outcome remains a technical error. The original `PortError` is returned unchanged.
+
+## Diagnostics
+
+Admission and covered owner outcomes retain:
+
+- owner and public operation;
+- local operation and boundary;
+- correlation and tenant;
+- actor, channel, locale;
+- causation and traceparent;
+- idempotency key and deadline;
+- checkout operation and optional collection IDs;
+- reason length only;
+- metadata kind and entry count only;
+- typed error, code, message, kind, and retryability.
+
+Raw reason and metadata payloads are never logged.
+
+## Preserved behavior
+
+This slice does not change:
+
+- write policy or write semantics;
+- tenant or causation validation;
+- optional no-collection success;
+- collection lifecycle decisions;
+- captured-payment reconciliation routing;
+- provider selection, request, or idempotency key;
+- provider journal recovery and checkpoints;
+- local cancellation or race handling;
+- public DTOs or `PortError` values;
+- mounted Commerce compensation ordering.
+
+Tenant and causation errors remain pass-through to avoid duplicate diagnostics from the persistent owner.
+
+## Evidence boundary
+
+The focused verifier was updated to reject:
+
+- a public persistent compensation module;
+- root or module-path exports of the persistent type/factory;
+- loss of exact admission mapping;
+- raw reason or metadata logging;
+- changes to persistent provider/lifecycle markers.
+
+No verifier, Cargo, test, provider replay, restart, remote-profile, mounted transport, workflow, or CI command was run. The master ecommerce mapper-cleanup item remains open for other payment surfaces and remaining ecommerce adapters.
+
+## Suggested maintainer commands
+
+```bash
+node scripts/verify/verify-payment-checkout-compensation-local-context.mjs
+node scripts/verify/verify-commerce-checkout-compensation-payment-order-context.mjs
+node scripts/verify/verify-commerce-checkout-compensation-owner-boundary.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-payment --lib
+cargo check -p rustok-commerce --lib
+```

--- a/crates/rustok-payment/docs/checkout-compensation-local-context.md
+++ b/crates/rustok-payment/docs/checkout-compensation-local-context.md
@@ -1,50 +1,60 @@
-# Payment checkout compensation local outcome context
+# Payment checkout compensation local and admission context
 
 Status: **source-ready / unvalidated**
 
 ## Scope
 
-This slice closes stable local outcome context retention for the canonical root payment compensation
-construction used by mounted checkout compensation:
+This slice closes correlation-safe local context retention for the canonical payment compensation owner boundary:
 
 - `CheckoutPaymentCompensationPort::compensate_checkout_payment`;
 - root `InProcessCheckoutPaymentCompensationPort`;
-- root `in_process_checkout_payment_compensation_port`.
+- root `in_process_checkout_payment_compensation_port`;
+- the compatibility namespace `rustok_payment::checkout_compensation::*`.
 
-The existing persistent implementation in `checkout_compensation.rs` remains unchanged. A new root
-wrapper retains the delegated `PortContext` and safe request facts, calls the original owner, classifies
-only exact stable returned `PortError` envelopes, and returns the same error unchanged.
+The persistent state machine in `checkout_compensation.rs` remains behaviorally unchanged. It is now loaded as a private module. Both the crate root and the public `checkout_compensation` namespace expose the context wrapper, so callers cannot bypass safe local diagnostics by choosing the legacy module path.
 
-## Canonical root cutover
+## Public module facade
 
-The crate keeps `pub mod checkout_compensation`, so the existing module-path contracts, implementation
-type, and legacy factory remain available for compatibility. Root exports now separate contracts from
-construction:
+`lib.rs` loads the sources as separate layers:
 
-- `CheckoutPaymentCompensationPort` and `CheckoutPaymentCompensationRequest` continue to come from the
-  original module;
-- root `InProcessCheckoutPaymentCompensationPort` and
-  `in_process_checkout_payment_compensation_port` come from the context wrapper.
+- `checkout_compensation.rs` becomes private `checkout_compensation_persistent`;
+- `checkout_compensation_context.rs` owns the public wrapper implementation;
+- `checkout_compensation_api.rs` is the public module facade.
 
-The mounted commerce compensation service imports the root names, so its default factory and
-provider-registry constructor now use the wrapper without changing commerce source or public types.
-Direct callers that deliberately construct through `rustok_payment::checkout_compensation` remain an
-explicit bypass and are documented as remaining work.
+The facade preserves the existing public names:
+
+- `CheckoutPaymentCompensationPort`;
+- `CheckoutPaymentCompensationRequest`;
+- `InProcessCheckoutPaymentCompensationPort`;
+- `in_process_checkout_payment_compensation_port`.
+
+The trait and request continue to be the original owner contracts. The public type and factory now always resolve to the context wrapper. The persistent implementation type and factory are not publicly re-exported.
 
 ## Delegation order
 
-The wrapper performs no new admission or lifecycle policy. Its source order is:
+The wrapper performs no new lifecycle or provider policy. Its source order is:
 
 1. clone the incoming `PortContext` for diagnostics;
 2. retain safe request facts;
 3. delegate the original context and request to the unchanged persistent owner;
 4. inspect only a returned `PortError`;
-5. emit a local event only when the exact stable code and message are covered;
+5. classify only exact stable `code + message` pairs;
 6. return the same `PortError` unchanged.
 
-The persistent owner continues to own write policy, write semantics, tenant parsing, checkout-operation
-causation, optional-collection no-op behavior, identity validation, lifecycle admission, provider
-journal recovery, provider cancellation, local cancellation, and commit checkpointing.
+The persistent owner continues to own write policy, write semantics, tenant parsing, checkout-operation causation, optional-collection no-op behavior, identity validation, lifecycle admission, provider journal recovery, provider cancellation, local cancellation, and commit checkpointing.
+
+## Admission outcomes
+
+The public wrapper now retains full context for the two stable admission envelopes returned before compensation work begins:
+
+| Stable envelope | Local operation | Severity |
+| --- | --- | --- |
+| `port.idempotency_key_required` / `write port calls require a non-empty idempotency key` | `admit_write_idempotency` | warning |
+| `port.deadline_required` / `port calls require deadline semantics` | `admit_deadline` | error |
+
+The timeout kind for a missing deadline is classified as technical. A missing idempotency key remains an ordinary validation rejection. No code, message, kind, retryability, or execution order changes.
+
+Tenant parsing and checkout-operation causation errors remain pass-through. The persistent owner already emits their owner-local events; the wrapper deliberately avoids a duplicate local event for those outcomes.
 
 ## Retained request facts
 
@@ -56,38 +66,23 @@ Covered diagnostics retain:
 - metadata JSON kind;
 - object-field or array-element count when applicable.
 
-The raw compensation reason and metadata value are deliberately not recorded. Metadata can contain
-arbitrary caller and provider data, and reason is an unvalidated string before owner normalization.
-Shape and size evidence preserves useful request context without copying payload content into logs.
+The raw compensation reason and metadata value are never recorded. Metadata can contain arbitrary caller and provider data, and reason is unvalidated before owner normalization.
 
-## Covered stable outcomes
+## Covered stable owner outcomes
 
-The mapper requires exact `code + message` pairs. Code-only matching is intentionally forbidden.
+The exact mapper also retains the existing local classification for:
 
-| Stable envelope | Local operation | Severity |
-| --- | --- | --- |
-| `payment.checkout_compensation_identity_invalid` / `checkout operation and payment collection identity must be non-nil UUIDs` | `validate_compensation_identity` | warning |
-| `payment.collection_not_found` / `payment collection was not found` | `load_collection` | warning |
-| `payment.checkout_compensation_manual_reconciliation` / `payment checkout compensation requires manual reconciliation` | `require_manual_reconciliation` | error |
-| `payment.checkout_compensation_state_conflict` / `payment collection changed while compensation was being applied` | `apply_compensation_state` | warning |
-| `payment.checkout_compensation_state_conflict` / `payment lifecycle conflicts with checkout compensation` | `apply_payment_lifecycle` | warning |
-| `payment.checkout_compensation_provider_state_conflict` / `payment provider cancellation is in an unsupported state` | `validate_provider_journal_state` | error |
-| `payment.checkout_compensation_metadata_invalid` / `payment compensation metadata must be a JSON object` | `validate_provider_metadata` | warning |
-| `payment.checkout_compensation_provider_identity_conflict` / `payment provider identity conflicts with the durable authorization` | `validate_provider_identity` | warning |
-| `payment.checkout_compensation_encoding_failed` / `payment compensation request could not be encoded` | `encode_provider_cancel_request` | error |
-| `payment.database_unavailable` / `payment storage is temporarily unavailable` | `owner_storage` | error |
-| `payment.checkout_compensation_validation` / `payment compensation request is invalid` | `validate_owner_request` | warning |
-| `payment.payment_not_found` / `payment was not found` | `load_payment` | warning |
-| `payment.refund_not_found` / `refund was not found` | `load_refund` | warning |
-| `payment.provider_unavailable` / `payment provider is temporarily unavailable` | `execute_provider_cancel` | error |
-| `payment.provider_rejected` / `payment provider rejected the requested operation` | `execute_provider_cancel` | warning |
-| `payment.provider_invalid_response` / `payment provider response could not be applied safely` | `normalize_provider_result` | error |
-| `payment.provider_not_configured` / `payment provider is not configured` | `resolve_provider` | error |
+- invalid compensation identity;
+- collection/payment/refund not found;
+- manual reconciliation;
+- payment and compensation lifecycle conflicts;
+- unsupported provider-journal state;
+- invalid provider metadata or conflicting provider identity;
+- provider request encoding failure;
+- storage unavailability and owner validation;
+- provider unavailable, rejected, invalid response, or missing configuration.
 
-Unavailable, timeout, and invariant kinds use error severity. Manual reconciliation and an unsupported
-durable provider-journal state also use error severity because they require operator or integrity
-attention despite being represented by conflict errors. Other validation, not-found, rejection,
-identity, lifecycle, and concurrent-state conflicts use warning severity.
+Unavailable, timeout, and invariant outcomes use error severity. Manual reconciliation and unsupported durable provider-journal state also use error severity. Ordinary validation, not-found, rejection, identity, lifecycle, and concurrent-state conflicts use warning severity.
 
 ## Retained diagnostic context
 
@@ -99,31 +94,14 @@ Covered outcomes record:
 - boundary `checkout_payment_compensation_port`;
 - correlation id and tenant id;
 - typed actor, channel, and locale;
-- causation id and traceparent when available;
-- idempotency key and deadline when available;
-- safe request facts described above;
+- causation id and traceparent;
+- idempotency key and deadline;
+- safe request facts;
 - exact stable code and message;
 - typed error kind and retryability;
 - the complete delegated `PortError`.
 
-## Pass-through behavior
-
-The wrapper does not classify:
-
-- policy rejection;
-- missing write semantics;
-- malformed tenant context;
-- checkout-operation causation mismatch;
-- any unrecognized code or message;
-- successful no-op compensation with no collection id;
-- successful already-cancelled recovery;
-- successful provider-journal replay or adoption;
-- successful provider and local cancellation.
-
-Pre-delegation owner diagnostics therefore remain the sole events for policy, tenant, and causation
-rejections. Successful and unknown outcomes do not receive an additional local event.
-
-## Preserved owner behavior
+## Preserved behavior
 
 This work does not change:
 
@@ -135,7 +113,7 @@ This work does not change:
 - payment collection lifecycle classification;
 - provider selection or manual-provider fallback;
 - canonical `payment_collection:{collection_id}:cancel` idempotency key;
-- provider request metadata and `cancel_payment_collection` operation marker;
+- provider request metadata and `cancel_payment_collection` marker;
 - provider journal begin, claim, replay, error, success, and reconciliation checkpoints;
 - provider payment identity recovery;
 - local cancellation race handling;
@@ -143,36 +121,30 @@ This work does not change:
 - commerce payment-before-order-before-inventory-before-cart compensation ordering;
 - provider-registry constructor behavior.
 
-The implementation in `checkout_compensation.rs` is unchanged.
-
 ## Static evidence
 
 `scripts/verify/verify-payment-checkout-compensation-local-context.mjs` guards:
 
-- legacy module compatibility plus canonical root type/factory cutover;
+- private persistent source and public facade module wiring;
+- root and module-path wrapper type/factory exports;
+- absence of a public persistent type/factory bypass;
 - wrapper constructor delegation for default and provider-registry construction;
 - context and safe-fact retention before unchanged owner delegation;
-- post-delegation-only mapping and same delegated error return;
-- typed identifiers plus length/shape-only payload evidence;
-- absence of raw reason or metadata fields in diagnostics;
-- exact stable code-and-message classification;
-- technical/integrity versus ordinary severity;
-- complete `PortContext`, request-fact, and `PortError` fields;
-- pass-through of tenant and causation envelopes;
+- exact admission and owner-outcome classification;
+- same delegated `PortError` return;
+- length/shape-only payload evidence and absence of raw reason/metadata diagnostics;
+- complete `PortContext`, request-fact, and typed error fields;
+- tenant and causation pass-through;
 - unchanged persistent policy, provider idempotency key, journal, cancellation, and checkpoint markers;
-- mounted commerce use of root contracts, wrapper type, and wrapper factory.
+- mounted Commerce use of root contracts and wrapper construction.
 
 ## Remaining gaps
 
 The ecommerce correlation-safe mapper task remains open for:
 
-- direct callers that deliberately bypass the root wrapper through
-  `rustok_payment::checkout_compensation`;
-- payment execution and compensation owner policy/tenant/causation diagnostics beyond existing owner
-  events;
+- broader compensation tenant/causation diagnostic enrichment without duplicate events;
 - direct payment GraphQL and HTTP query/mutation envelopes;
-- GraphQL customer reads and shared storefront customer lookup;
-- remaining customer, tax, promotion, ecommerce, and non-`PortError` envelopes;
+- remaining order, fulfillment, inventory, customer, tax, promotion, ecommerce adapter, and non-`PortError` envelopes;
 - compile, provider replay, restart, remote-port, and cross-transport runtime evidence.
 
 No FBA or FFA status is promoted from source inspection alone.

--- a/crates/rustok-payment/src/checkout_compensation_api.rs
+++ b/crates/rustok-payment/src/checkout_compensation_api.rs
@@ -1,0 +1,6 @@
+pub use crate::checkout_compensation_context::{
+    InProcessCheckoutPaymentCompensationPort, in_process_checkout_payment_compensation_port,
+};
+pub use crate::checkout_compensation_persistent::{
+    CheckoutPaymentCompensationPort, CheckoutPaymentCompensationRequest,
+};

--- a/crates/rustok-payment/src/checkout_compensation_context.rs
+++ b/crates/rustok-payment/src/checkout_compensation_context.rs
@@ -6,7 +6,7 @@ use sea_orm::DatabaseConnection;
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::checkout_compensation::{
+use crate::checkout_compensation_persistent::{
     CheckoutPaymentCompensationPort, CheckoutPaymentCompensationRequest,
     InProcessCheckoutPaymentCompensationPort as PersistentCheckoutPaymentCompensationPort,
 };
@@ -111,6 +111,13 @@ fn map_checkout_payment_compensation_local_port_error(
     error: PortError,
 ) -> PortError {
     let local_operation = match (error.code.as_str(), error.message.as_str()) {
+        (
+            "port.idempotency_key_required",
+            "write port calls require a non-empty idempotency key",
+        ) => "admit_write_idempotency",
+        ("port.deadline_required", "port calls require deadline semantics") => {
+            "admit_deadline"
+        }
         (
             "payment.checkout_compensation_identity_invalid",
             "checkout operation and payment collection identity must be non-nil UUIDs",

--- a/crates/rustok-payment/src/lib.rs
+++ b/crates/rustok-payment/src/lib.rs
@@ -3,6 +3,9 @@ use rustok_api::Permission;
 use rustok_core::{MigrationSource, RusToKModule};
 use sea_orm_migration::MigrationTrait;
 
+#[path = "checkout_compensation.rs"]
+mod checkout_compensation_persistent;
+#[path = "checkout_compensation_api.rs"]
 pub mod checkout_compensation;
 mod checkout_compensation_context;
 #[allow(dead_code)]
@@ -27,8 +30,6 @@ pub mod stripe_provider;
 
 pub use checkout_compensation::{
     CheckoutPaymentCompensationPort, CheckoutPaymentCompensationRequest,
-};
-pub use checkout_compensation_context::{
     InProcessCheckoutPaymentCompensationPort, in_process_checkout_payment_compensation_port,
 };
 pub use checkout_execution::*;

--- a/scripts/verify/verify-payment-checkout-compensation-local-context.mjs
+++ b/scripts/verify/verify-payment-checkout-compensation-local-context.mjs
@@ -11,6 +11,7 @@ const root = configuredRoot
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
 
 const lib = read('crates/rustok-payment/src/lib.rs');
+const api = read('crates/rustok-payment/src/checkout_compensation_api.rs');
 const wrapper = read('crates/rustok-payment/src/checkout_compensation_context.rs');
 const owner = read('crates/rustok-payment/src/checkout_compensation.rs');
 const commerce = read('crates/rustok-commerce/src/services/checkout_compensation_owner_ports.rs');
@@ -33,16 +34,33 @@ const between = (content, start, end, label) => {
 };
 
 for (const [value, label] of [
-  ['pub mod checkout_compensation;', 'legacy compensation module path'],
+  ['#[path = "checkout_compensation.rs"]\nmod checkout_compensation_persistent;', 'private persistent owner module'],
+  ['#[path = "checkout_compensation_api.rs"]\npub mod checkout_compensation;', 'public compensation API facade'],
   ['mod checkout_compensation_context;', 'private context wrapper module'],
-  ['pub use checkout_compensation::{', 'selective legacy contract export'],
+  ['pub use checkout_compensation::{', 'root facade export'],
   ['CheckoutPaymentCompensationPort, CheckoutPaymentCompensationRequest,', 'root trait/request compatibility'],
-  ['pub use checkout_compensation_context::{', 'canonical context wrapper export'],
-  ['InProcessCheckoutPaymentCompensationPort, in_process_checkout_payment_compensation_port,', 'root type/factory cutover'],
+  ['InProcessCheckoutPaymentCompensationPort, in_process_checkout_payment_compensation_port,', 'root wrapper type/factory'],
 ]) requireText(lib, value, label);
-forbidText(lib, 'pub use checkout_compensation::*;', 'legacy root glob bypass');
+for (const value of [
+  'pub mod checkout_compensation_persistent',
+  'pub use checkout_compensation_persistent::',
+  'pub use checkout_compensation_context::',
+]) forbidText(lib, value, 'persistent compensation bypass');
 
 for (const [value, label] of [
+  ['pub use crate::checkout_compensation_context::{', 'module-path wrapper export'],
+  ['InProcessCheckoutPaymentCompensationPort, in_process_checkout_payment_compensation_port,', 'module-path wrapper type/factory'],
+  ['pub use crate::checkout_compensation_persistent::{', 'module-path contract export'],
+  ['CheckoutPaymentCompensationPort, CheckoutPaymentCompensationRequest,', 'module-path trait/request compatibility'],
+]) requireText(api, value, label);
+for (const value of [
+  'PersistentCheckoutPaymentCompensationPort',
+  'checkout_compensation_persistent::InProcessCheckoutPaymentCompensationPort',
+  'checkout_compensation_persistent::in_process_checkout_payment_compensation_port',
+]) forbidText(api, value, 'public persistent implementation exposure');
+
+for (const [value, label] of [
+  ['use crate::checkout_compensation_persistent::{', 'private persistent import'],
   ['InProcessCheckoutPaymentCompensationPort as PersistentCheckoutPaymentCompensationPort', 'persistent owner alias'],
   ['inner: PersistentCheckoutPaymentCompensationPort', 'wrapper inner owner'],
   ['PersistentCheckoutPaymentCompensationPort::new(db)', 'default constructor delegation'],
@@ -50,6 +68,7 @@ for (const [value, label] of [
   ['pub fn in_process_checkout_payment_compensation_port(', 'canonical factory'],
   ['Arc::new(InProcessCheckoutPaymentCompensationPort::new(db))', 'factory wrapper construction'],
 ]) requireText(wrapper, value, label);
+forbidText(wrapper, 'use crate::checkout_compensation::{', 'wrapper import through public facade');
 
 const operation = between(
   wrapper,
@@ -98,15 +117,11 @@ for (const value of [
   'metadata: request.metadata',
 ]) forbidText(facts, value, 'raw compensation payload retention');
 
-const mapper = wrapper.slice(
-  wrapper.indexOf('fn map_checkout_payment_compensation_local_port_error('),
-);
-requireText(
-  mapper,
-  'match (error.code.as_str(), error.message.as_str())',
-  'exact code-and-message matching',
-);
+const mapper = wrapper.slice(wrapper.indexOf('fn map_checkout_payment_compensation_local_port_error('));
+requireText(mapper, 'match (error.code.as_str(), error.message.as_str())', 'exact code-and-message matching');
 for (const [code, message, operationLabel] of [
+  ['port.idempotency_key_required', 'write port calls require a non-empty idempotency key', 'admit_write_idempotency'],
+  ['port.deadline_required', 'port calls require deadline semantics', 'admit_deadline'],
   ['payment.checkout_compensation_identity_invalid', 'checkout operation and payment collection identity must be non-nil UUIDs', 'validate_compensation_identity'],
   ['payment.collection_not_found', 'payment collection was not found', 'load_collection'],
   ['payment.checkout_compensation_manual_reconciliation', 'payment checkout compensation requires manual reconciliation', 'require_manual_reconciliation'],
@@ -163,33 +178,24 @@ for (const [value, label] of [
 for (const value of [
   'payment.tenant_id_invalid',
   'payment.checkout_compensation_causation_invalid',
-]) forbidText(mapper, value, 'pre-delegation context errors must pass through');
-for (const value of [
-  'reason =',
-  'metadata =',
-]) forbidText(mapper, value, 'raw compensation payload diagnostics');
+]) forbidText(mapper, value, 'tenant and causation errors must remain owner pass-through');
+for (const value of ['reason =', 'metadata =']) forbidText(mapper, value, 'raw compensation payload diagnostics');
 
 for (const [value, label] of [
-  ['pub trait CheckoutPaymentCompensationPort', 'legacy owner trait'],
-  ['pub struct CheckoutPaymentCompensationRequest', 'legacy request DTO'],
-  ['pub struct InProcessCheckoutPaymentCompensationPort', 'legacy direct owner path'],
-  ['pub fn in_process_checkout_payment_compensation_port(', 'legacy module factory'],
-  ['context.require_policy(PortCallPolicy::write())?;', 'legacy write policy'],
-  ['context.require_write_semantics()?;', 'legacy write semantics'],
-  ['parse_tenant_id(&context, owner_operation)?;', 'legacy tenant validation'],
-  ['require_operation_context(&context, owner_operation, request.checkout_operation_id)?;', 'legacy causation validation'],
+  ['pub trait CheckoutPaymentCompensationPort', 'persistent owner trait'],
+  ['pub struct CheckoutPaymentCompensationRequest', 'persistent request DTO'],
+  ['pub struct InProcessCheckoutPaymentCompensationPort', 'private persistent owner type'],
+  ['pub fn in_process_checkout_payment_compensation_port(', 'private persistent factory'],
+  ['context.require_policy(PortCallPolicy::write())?;', 'persistent write policy'],
+  ['context.require_write_semantics()?;', 'persistent write semantics'],
+  ['parse_tenant_id(&context, owner_operation)?;', 'persistent tenant validation'],
+  ['require_operation_context(&context, owner_operation, request.checkout_operation_id)?;', 'persistent causation validation'],
   ['format!("payment_collection:{}:cancel", collection.id)', 'canonical cancel idempotency key'],
   ['"operation": "cancel_payment_collection"', 'canonical provider metadata operation'],
   ['.execute_cancel(provider_id.as_str(), provider_request)', 'provider cancel execution'],
   ['.mark_provider_succeeded(', 'provider success checkpoint'],
   ['.cancel_local_collection(', 'local cancellation'],
   ['.mark_committed(outcome.operation_id)', 'provider commit checkpoint'],
-  ['"payment.checkout_compensation_identity_invalid"', 'identity envelope source'],
-  ['"payment.checkout_compensation_provider_state_conflict"', 'provider state envelope source'],
-  ['"payment.checkout_compensation_metadata_invalid"', 'metadata envelope source'],
-  ['"payment.checkout_compensation_provider_identity_conflict"', 'provider identity envelope source'],
-  ['"payment.checkout_compensation_encoding_failed"', 'encoding envelope source'],
-  ['"payment.checkout_compensation_manual_reconciliation"', 'manual reconciliation envelope source'],
 ]) requireText(owner, value, label);
 
 for (const [value, label] of [
@@ -198,7 +204,7 @@ for (const [value, label] of [
   ['InProcessCheckoutPaymentCompensationPort, PaymentCollectionStatusKind, PaymentProviderRegistry,', 'commerce root wrapper type'],
   ['in_process_checkout_payment_compensation_port,', 'commerce root wrapper factory'],
 ]) requireText(commerce, value, label);
-forbidText(commerce, 'rustok_payment::checkout_compensation::', 'commerce direct legacy owner construction');
+forbidText(commerce, 'rustok_payment::checkout_compensation_persistent::', 'commerce private persistent construction');
 
 if (failures.length > 0) {
   console.error('Payment checkout compensation local-context verification failed:');
@@ -207,5 +213,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Canonical payment compensation root construction retains delegated context and safe request facts for exact stable local outcomes without changing persistent owner semantics',
+  '✔ Public payment compensation construction always uses the context wrapper, including exact admission outcomes, while persistent owner semantics and PortError results remain unchanged',
 );


### PR DESCRIPTION
## Summary
- route both root and `rustok_payment::checkout_compensation::*` public construction through the existing context wrapper
- load the persistent compensation implementation as a private module and expose a compatibility facade with the same trait, request, type, and factory names
- classify exact missing-idempotency and missing-deadline `PortError` envelopes with retained correlation, tenant, actor, channel, locale, causation, traceparent, idempotency, deadline, and safe request facts
- return the exact original `PortError` without changing codes, messages, kinds, retryability, policy, or execution order
- keep tenant and causation outcomes as owner pass-through to avoid duplicate diagnostics
- preserve provider selection, canonical cancel idempotency, journal recovery/checkpoints, lifecycle routing, local cancellation, and Commerce compensation ordering
- update the focused source guard, Payment owner documentation, Commerce evidence, and Commerce boundary documentation

## Recheck
The ecommerce master plan still keeps payment execution/compensation mapper cleanup open. The compensation context wrapper already mapped stable delegated outcomes, but it intentionally excluded admission errors, while the public module path still exposed the persistent implementation as a diagnostic bypass.

## Covered admission envelopes
- `port.idempotency_key_required` / `write port calls require a non-empty idempotency key`
- `port.deadline_required` / `port calls require deadline semantics`

## Public compatibility
The following names remain available at both the crate root and `rustok_payment::checkout_compensation`:
- `CheckoutPaymentCompensationPort`
- `CheckoutPaymentCompensationRequest`
- `InProcessCheckoutPaymentCompensationPort`
- `in_process_checkout_payment_compensation_port`

The type and factory now always resolve to the context wrapper. The persistent type/factory are private implementation details.

## Evidence boundary
Source status is `payment_checkout_compensation_admission_context_source_unvalidated`. The broad ecommerce mapper-cleanup item remains open. No FFA, FBA, runtime, provider, transport, or production status is promoted.

## Verification
The current ecommerce plan, `PortContext` admission envelopes, persistent compensation state machine, context wrapper, public module references, mounted Commerce imports, and final eight-file ahead-only diff were re-read.

Tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run per maintainer instruction.