### PR TITLE
fix(tenant): require transactional lifecycle events

### DIFF
--- a/crates/rustok-tenant/CRATE_API.md
+++ b/crates/rustok-tenant/CRATE_API.md
@@ -9,7 +9,9 @@
 - `TenantModule` implements `RusToKModule` with `ModuleKind::Core`.
 
 ## Events
-- Publishes: `tenant.created`, `tenant.updated`, `tenant.module.toggled` (via `TransactionalEventBus`, if passed to `TenantService::with_event_bus`).
+- Publishes: `tenant.created`, `tenant.updated`, `tenant.module.toggled`, `tenant.locale.enabled`, and `tenant.locale.disabled`.
+- Every owner mutation inserts its validated event into the canonical transactional outbox in the same database transaction through `TransactionalEventBus::publish_root_in_tx`.
+- Event publication is mandatory for `TenantService::new`; there is no host-configured or fail-open event-bus constructor.
 - Consumes: N/A.
 
 ## Dependencies on Other RusToK Crates
@@ -20,6 +22,7 @@
 ## Common AI Mistakes
 - Mixes up `tenant slug` and internal `tenant_id`.
 - Does not add tenant isolation in queries and access checks.
+- Constructs a parallel tenant writer or makes lifecycle event publication conditional on host wiring.
 
 ## Minimum Contract Set
 
@@ -32,7 +35,8 @@
 - Multi-tenant boundary invariants (tenant/resource isolation, auth context) are considered a mandatory part of the contract.
 
 ### Events / Outbox Side Effects
-- If the module publishes domain events, publication must go through the transactional outbox/transport contract without local workarounds.
+- Every tenant, tenant-module, or locale-policy mutation that changes owner state must publish its lifecycle event through the canonical transactional outbox before commit.
+- Installer/bootstrap calls to `TenantService::ensure_tenant` use the same owner transaction and event contract as ordinary tenant creation.
 - Event payload and event-type format must remain backward-compatible for cross-module consumers.
 
 ### Errors / Failure Codes

--- a/crates/rustok-tenant/README.md
+++ b/crates/rustok-tenant/README.md
@@ -11,7 +11,8 @@
 - Own the revisioned enabled/default/fallback locale-policy aggregate, including
   canonical tags, exactly one enabled default, valid enabled fallbacks, and
   cycle prevention.
-- Publish tenant lifecycle events (`tenant.created`, `tenant.updated`, `tenant.module.toggled`) via transactional outbox when `TenantService` is wired with `TransactionalEventBus`.
+- Publish tenant lifecycle and locale-policy events through the canonical transactional
+  outbox in the same owner transaction for every `TenantService` mutation.
 - Publish the typed `tenants:*` and `modules:*` RBAC surface.
 - Keep tenant admin read flows aligned with tenant-scoped RBAC checks for both tenant and module permissions.
 - Keep tenant admin native transport on `rustok_api::HostRuntimeContext`, not a host-wide `AppContext`.
@@ -19,8 +20,10 @@
 ## Interactions
 
 - Depends on `rustok-core` for module contracts and permission vocabulary.
-- Integrates with `rustok-outbox` (`TransactionalEventBus`) to persist tenant lifecycle events transactionally.
-- Used by `apps/server` tenant middleware, tenant admin flows, and module lifecycle orchestration.
+- Integrates with `rustok-outbox`; `TenantService` always calls
+  `TransactionalEventBus::publish_root_in_tx` before committing owner state.
+- Used by `apps/server` tenant middleware, tenant admin flows, installer provisioning,
+  and module lifecycle orchestration.
 - Tenant resolver invariants for `header`/`host`/`subdomain` resolution and disabled/not-found
   semantics are covered in `apps/server/tests/tenant_resolver_invariants_test.rs`.
 - Exposes `TenantReadPort` (`tenant.read_projection.v1`) for transport-neutral read projections by tenant id, slug, or domain with shared `rustok_api::PortContext`/`PortError` deadline semantics.
@@ -29,7 +32,9 @@
   different request.
 - `apps/server` locale middleware consumes `TenantLocalePolicyPort`; it does not
   query `tenant_locales` directly.
-- `apps/server` tenant resolver now consumes that owner port for cache-miss loads while retaining host-owned cache/coalescing/invalidation concerns.
+- `apps/server` tenant resolver consumes that owner port for cache-miss loads while retaining host-owned cache/coalescing/invalidation concerns.
+- Installer/bootstrap calls to `TenantService::ensure_tenant` use the same creation
+  transaction and `tenant.created` outbox contract as ordinary tenant creation.
 - Tenant provisioning/deprovisioning flows in the host use `TenantReadPort` for read-fact inspection/verification and are expected to invalidate tenant cache keys
   (`uuid` / `slug` / `host`) to avoid stale resolver state beyond TTL windows.
 - Exposes a module-owned Leptos admin overview through `rustok-tenant-admin`.
@@ -43,7 +48,7 @@
 ## Entry points
 
 - `TenantModule`
-- `TenantService` (including `TenantService::with_event_bus` for transactional outbox publishing)
+- `TenantService`
 - `TenantReadPort` / `TenantReadRequest` / `TenantReadSelector`
 - `TenantLocalePolicyPort` / `TenantLocalePolicyProjection`
 - `ReplaceTenantLocalePolicyRequest`

--- a/crates/rustok-tenant/docs/README.md
+++ b/crates/rustok-tenant/docs/README.md
@@ -14,7 +14,8 @@ domain contract and must not dissolve into middleware or host-specific logic.
 - tenant and tenant-module entities/DTOs/services;
 - public CRUD, legacy low-level module override and tenant settings contract;
 - schema guard for tenant settings (object JSON + depth/key/payload limits);
-- transactional outbox publication of tenant lifecycle events (`tenant.created`, `tenant.updated`, `tenant.module.toggled`) when wiring `TenantService` with `TransactionalEventBus`;
+- mandatory transactional outbox publication of tenant lifecycle and locale-policy
+  events from every owner mutation, including installer/bootstrap tenant creation;
 - tenant-scoped business rules consumed by other platform modules;
 - invariants of the multi-tenant model: `tenant_id`, tenant filtering and tenant-scoped module enablement.
 
@@ -22,7 +23,8 @@ domain contract and must not dissolve into middleware or host-specific logic.
 
 - `apps/server` owns only the middleware resolution entry point, cache infrastructure and runtime bootstrap around the tenant resolver path;
 - tenant context is resolved by `uuid`, `slug` or `host` before entering business logic; the module-owned `TenantReadPort` covers read projection lookup by id/slug/domain for host resolver/provisioning consumers; `apps/server` resolver uses this port on the cache-miss path instead of raw entity lookup, and installer provisioning/verification uses slug projection before create-candidate decisions and verify step;
-- outbox relay/dispatch infrastructure remains a host/runtime concern, but `rustok-tenant` must publish tenant lifecycle events through `TransactionalEventBus` without local bypasses;
+- outbox relay/dispatch infrastructure remains a host/runtime concern, but `rustok-tenant` always inserts each owner lifecycle event through `TransactionalEventBus::publish_root_in_tx` before the state transaction commits;
+- `TenantService::new` is the only service constructor; lifecycle publication cannot be disabled by omitted host wiring;
 - tenant admin read paths must go through tenant-scoped RBAC checks (`tenants:(read|list|manage)` + `modules:(read|list|manage)`) and remain synchronized with server adapters;
 - tenant admin native server-function transport consumes host-provided `rustok_api::HostRuntimeContext` for DB access and must not import a host-wide `AppContext`;
 - Redis/in-memory cache semantics and cross-instance invalidation belong to the host cache layer, but must remain synchronized with the module contract;
@@ -38,6 +40,7 @@ domain contract and must not dissolve into middleware or host-specific logic.
 - `cargo xtask module test tenant`
 - `npm run verify:tenant:fba`
 - `node --check scripts/verify/verify-tenant-fba.mjs`
+- `cargo test -p rustok-tenant --test integration tenant_mutations_always_publish_outbox_events -- --nocapture`
 - `cargo test -p rustok-tenant tenant_read_port --test integration` for FBA read-port runtime smoke (deadline, typed error mapping, slug/domain lookup, inactive degraded mode)
 - targeted tests for tenant CRUD, module toggles, resolver invariants and cache-aware integration path
 

--- a/crates/rustok-tenant/docs/implementation-plan.md
+++ b/crates/rustok-tenant/docs/implementation-plan.md
@@ -16,6 +16,12 @@ receipt, and emits tenant/locale events in the owner transaction. Server locale
 resolution loads this projection through the port and keeps only host-owned
 cache/invalidation behavior.
 
+Every tenant, tenant-module, and locale-policy mutation now writes its validated
+lifecycle event to the canonical outbox before committing the owner transaction.
+`TenantService::new` is the only constructor; event publication cannot be omitted
+by host wiring. Installer/bootstrap `ensure_tenant` calls therefore use the same
+`tenant.created` transaction as ordinary tenant creation.
+
 The host cache-miss resolver and installer provisioning/verification use
 `TenantReadPort` for typed id, slug, and domain reads. Idempotent installer
 tenant provisioning uses `TenantService::ensure_tenant`, so the host does not
@@ -38,6 +44,8 @@ runtime guardrail.
 
 Source evidence now covers:
 
+- mandatory same-transaction outbox insertion for ordinary and installer tenant
+  creation, tenant updates, low-level module overrides, and locale-policy changes;
 - two independent serving contexts whose real `content-language` values prove
   exact UUID invalidation leaves another tenant cached until a later wildcard
   clear;
@@ -54,9 +62,10 @@ Source evidence now covers:
   Redis tests, durable-before-apply ordering, durable-ahead full recovery and the
   prohibition on tracker rebaselining after regression.
 
-This evidence is source-complete but is not compiled or live verified on the
-current revision until the cache workflow reports successful compiled and Redis
-jobs.
+The lifecycle outbox regression is staged for same-SHA execution. Multi-replica
+cache evidence remains source-complete but is not compiled or live verified on
+the current revision until the cache workflow reports successful compiled and
+Redis jobs.
 
 ## FFA/FBA boundary
 
@@ -92,8 +101,9 @@ jobs.
 
 3. **Keep lifecycle and cache behavior synchronized.** Any change to create,
    update, deactivate, domain, locale, or module-toggle behavior must preserve
-   typed `TenantReadPort` use and the shared durable generation contract for UUID,
-   slug, host and locale cache views.
+   mandatory same-transaction outbox insertion, typed `TenantReadPort` use, and
+   the shared durable generation contract for UUID, slug, host and locale cache
+   views.
    **Depends on:** the server resolver/cache adapters and
    `ModuleLifecycleService`.
    **Done when:** targeted resolver/invalidation tests cover the changed state
@@ -120,6 +130,7 @@ jobs.
 - `npm run verify:tenant:admin-boundary`
 - `cargo xtask module validate tenant`
 - `cargo xtask module test tenant`
+- `cargo test -p rustok-tenant --test integration tenant_mutations_always_publish_outbox_events -- --nocapture`
 - `cargo test -p rustok-tenant tenant_read_port --test integration`
 - `cargo test -p rustok-tenant tenant_locale_policy --test integration`
 - `cargo test -p rustok-server --test tenant_locale_generation_guard`
@@ -144,10 +155,10 @@ jobs.
 - Cycle: `cycle-001`
 - Status: `in_progress`
 - Last verified at (UTC): `2026-07-30`
-- Scope inspected: `pending owner/runtime audit; tenant domain, locale-policy CAS, read ports, lifecycle events, resolver/cache generation, installer provisioning, module toggles and tenant-scoped RBAC consumers`
-- Findings: `P0=0, P1=0, P2=0, P3=0`
-- Fixed in this pass: `none; verification start marker only`
-- Remaining risks or blockers: `multi-replica Redis evidence is source-complete but unexecuted; ownership, lifecycle transactionality, cache generation, resolver trust, multilingual storage and cross-module consumers require current source inspection`
-- Evidence: `local owner plan and published TenantReadPort/TenantLocalePolicyPort boundaries reviewed before source work`
-- Next action: `inspect tenant migrations, command transactions/events, read and locale-policy ports, server resolution/cache invalidation, installer and module lifecycle consumers, then fix reproducible P0/P1 defects`
-- Resume command: `npm run verify:tenant:fba && npm run verify:tenant:admin-boundary && cargo xtask module validate tenant && cargo xtask module test tenant`
+- Scope inspected: `tenant owner CRUD, locale-policy CAS, lifecycle outbox publication, installer provisioning, read ports, FBA guard; resolver/cache generation, migrations, module lifecycle and RBAC consumers remain under audit`
+- Findings: `P0=0, P1=1, P2=0, P3=0`
+- Fixed in this pass: `removed the optional TransactionalEventBus constructor and made every TenantService mutation publish through TransactionalEventBus::publish_root_in_tx in the owner transaction, including installer ensure_tenant creation`
+- Remaining risks or blockers: `same-SHA targeted Rust evidence is pending; multi-replica Redis evidence is source-complete but unexecuted; migration constraints, resolver invalidation, lifecycle consumers, multilingual storage and RBAC parity require continued current-source inspection`
+- Evidence: `ordinary TenantService::new SQLite regression now verifies tenant.created, tenant.updated and tenant.module.toggled outbox rows; FBA guard forbids optional event_bus/with_event_bus and binds the installer seed path to TenantService::ensure_tenant`
+- Next action: `run same-SHA Tenant FBA and targeted integration evidence, merge the focused P1 fix, then inspect migrations, cache invalidation and module lifecycle consumers on a fresh branch`
+- Resume command: `npm run verify:tenant:fba && cargo test -p rustok-tenant --test integration tenant_mutations_always_publish_outbox_events -- --nocapture && cargo xtask module validate tenant`

--- a/crates/rustok-tenant/src/services/tenant_service.rs
+++ b/crates/rustok-tenant/src/services/tenant_service.rs
@@ -31,22 +31,11 @@ pub type TenantResult<T> = Result<T, TenantError>;
 
 pub struct TenantService {
     db: DatabaseConnection,
-    event_bus: Option<TransactionalEventBus>,
 }
 
 impl TenantService {
     pub fn new(db: DatabaseConnection) -> Self {
-        Self {
-            db,
-            event_bus: None,
-        }
-    }
-
-    pub fn with_event_bus(db: DatabaseConnection, event_bus: TransactionalEventBus) -> Self {
-        Self {
-            db,
-            event_bus: Some(event_bus),
-        }
+        Self { db }
     }
 
     #[instrument(skip(self, input), fields(slug = %input.slug))]
@@ -511,14 +500,9 @@ impl TenantService {
     where
         C: sea_orm::ConnectionTrait,
     {
-        if let Some(event_bus) = &self.event_bus {
-            event_bus
-                .publish_in_tx(txn, tenant_id, None, event)
-                .await
-                .map_err(|error| TenantError::EventPublish(error.to_string()))?;
-        }
-
-        Ok(())
+        TransactionalEventBus::publish_root_in_tx(txn, tenant_id, None, event)
+            .await
+            .map_err(|error| TenantError::EventPublish(error.to_string()))
     }
 }
 

--- a/crates/rustok-tenant/tests/integration.rs
+++ b/crates/rustok-tenant/tests/integration.rs
@@ -1,7 +1,7 @@
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
 use rustok_outbox::entity as outbox_entity;
-use rustok_outbox::{OutboxTransport, SysEvents, TransactionalEventBus};
+use rustok_outbox::SysEvents;
 use rustok_tenant::{
     CreateTenantInput, PortActor, PortContext, PortErrorKind, ReplaceTenantLocalePolicyRequest,
     TenantError, TenantLocale, TenantLocalePolicyEntry, TenantLocalePolicyPort, TenantReadPort,
@@ -592,11 +592,9 @@ async fn tenant_locale_policy_rejects_und_invalid_fallback_and_key_reuse() {
 
 #[tokio::test]
 #[allow(deprecated)]
-async fn tenant_mutations_publish_outbox_events() {
+async fn tenant_mutations_always_publish_outbox_events() {
     let db = setup_db().await;
-    let transport = Arc::new(OutboxTransport::new(db.clone()));
-    let event_bus = TransactionalEventBus::new(transport);
-    let service = TenantService::with_event_bus(db.clone(), event_bus);
+    let service = TenantService::new(db.clone());
 
     let tenant = service
         .create_tenant(CreateTenantInput {

--- a/scripts/verify/verify-tenant-fba.mjs
+++ b/scripts/verify/verify-tenant-fba.mjs
@@ -16,9 +16,11 @@ const central = read('docs/modules/registry.md');
 const cargo = read('crates/rustok-tenant/Cargo.toml');
 const lib = read('crates/rustok-tenant/src/lib.rs');
 const ports = read('crates/rustok-tenant/src/ports.rs');
+const tenantService = read('crates/rustok-tenant/src/services/tenant_service.rs');
 const integrationTests = read('crates/rustok-tenant/tests/integration.rs');
 const serverTenantMiddleware = read('apps/server/src/middleware/tenant.rs');
 const serverInstallerCli = read('apps/server/src/installer_execution.rs');
+const installerPersistence = read('crates/rustok-installer-persistence/src/seaorm_ports.rs');
 
 if (registry.schema_version !== 1) fail('registry schema_version must be 1');
 if (registry.module !== 'tenant' || registry.role !== 'provider' || !['boundary_ready', 'transport_verified'].includes(registry.status)) fail('registry identity/status drift');
@@ -36,6 +38,27 @@ for (const marker of ['trait TenantReadPort', 'impl TenantReadPort for crate::Te
 }
 if (ports.includes('require_write_semantics()?')) fail('tenant read port must not require write idempotency');
 if (!ports.includes('Serialize, Deserialize')) fail('tenant FBA DTOs must be serializable');
+
+for (const marker of [
+  'pub struct TenantService {',
+  'TransactionalEventBus::publish_root_in_tx(txn, tenant_id, None, event)',
+  'DomainEvent::TenantCreated',
+  'DomainEvent::TenantUpdated',
+  'DomainEvent::TenantModuleToggled',
+]) {
+  if (!tenantService.includes(marker)) fail(`tenant lifecycle owner source missing ${marker}`);
+}
+for (const forbidden of [
+  'event_bus: Option<TransactionalEventBus>',
+  'pub fn with_event_bus',
+  'if let Some(event_bus)',
+]) {
+  if (tenantService.includes(forbidden)) fail(`tenant lifecycle publication contains fail-open compatibility path ${forbidden}`);
+}
+if (!installerPersistence.includes('TenantService::new(self.db.clone())') || !installerPersistence.includes('.ensure_tenant(CreateTenantInput')) {
+  fail('installer seed path must delegate tenant creation to TenantService');
+}
+
 if (!plan.includes(`- FBA status: \`${registry.status}\``) || !plan.includes(registryPath) || !plan.includes('TenantReadPort') || !plan.includes('tenant-contract-test-static-matrix.json')) fail('local plan FBA evidence drift');
 if (!central.includes('| `tenant` |') || !central.includes(registryPath) || !central.includes(`| \`tenant\` | admin | \`in_progress\` | \`${registry.status}\``)) fail('central readiness board drift');
 if (registry.status === 'transport_verified' && evidence.status !== 'runtime_verified') fail('transport_verified tenant requires runtime_verified evidence');
@@ -56,7 +79,9 @@ for (const marker of ['TenantReadPort', 'TenantService::new(ctx.db_clone())', 't
 for (const marker of ['TenantReadPort', 'TenantService::new(db.clone())', 'read_installer_tenant_by_slug(db, &plan.tenant.slug)', 'TenantReadSelector::Slug(slug.to_string())', 'include_inactive: true', '.with_deadline(INSTALLER_TENANT_READ_DEADLINE)', 'PortActor::service("rustok-installer.execution")', 'PortErrorKind::NotFound', 'treat missing tenant as create candidate']) {
   if (!serverInstallerCli.includes(marker)) fail(`server installer CLI missing ${marker}`);
 }
-for (const marker of ['tenant_read_port_requires_deadline_and_valid_slug', 'tenant_read_port_preserves_projection_and_inactive_degraded_mode', 'tenant_read_port_resolves_domain_and_validates_blank_domain', 'PortErrorKind::Timeout', 'PortErrorKind::Validation', 'PortErrorKind::NotFound', 'include_inactive: true', 'TenantReadSelector::Domain', 'tenant.domain_empty']) {
+for (const marker of ['tenant_read_port_requires_deadline_and_valid_slug', 'tenant_read_port_preserves_projection_and_inactive_degraded_mode', 'tenant_read_port_resolves_domain_and_validates_blank_domain', 'tenant_mutations_always_publish_outbox_events', 'PortErrorKind::Timeout', 'PortErrorKind::Validation', 'PortErrorKind::NotFound', 'include_inactive: true', 'TenantReadSelector::Domain', 'tenant.domain_empty']) {
   if (!integrationTests.includes(marker)) fail(`integration tests missing ${marker}`);
 }
-console.log('[verify-tenant-fba] Tenant FBA provider metadata, port semantics and static evidence are consistent');
+if (integrationTests.includes('TenantService::with_event_bus')) fail('integration evidence must exercise ordinary TenantService::new publication');
+
+console.log('[verify-tenant-fba] Tenant FBA provider metadata, port semantics, mandatory lifecycle outbox and static evidence are consistent');


### PR DESCRIPTION
## Confirmed P1

`TenantService::new` stored no event bus, and every mutation silently skipped lifecycle publication when the optional handle was absent. Production installer/bootstrap provisioning calls `TenantService::new(...).ensure_tenant`, so a tenant and its default locale could commit without a `tenant.created` outbox event, leaving cache, Search, and other consumers without a durable lifecycle signal.

## Fix

- remove the optional event-bus field and `with_event_bus` constructor
- make all tenant, tenant-module, and locale-policy mutations call `TransactionalEventBus::publish_root_in_tx` before commit
- cover the ordinary `TenantService::new` path with SQLite outbox regression evidence
- bind the Tenant FBA guard to the installer `ensure_tenant` consumer
- forbid optional/fail-open event publication from returning
- update owner API and implementation documentation

## Same-SHA evidence and limitations

- PR virtual merge is conflict-free and the diff is limited to seven Tenant-owned/verification files
- source/API review confirms `publish_root_in_tx` returns `Result<()>` and is valid for any SeaORM `ConnectionTrait`
- Rust-hosted browser smoke reached workspace compilation and failed only in unrelated `rustok-profiles` E0308 errors; no Tenant error was reported
- CI Formatting/Cargo jobs did not receive runners
- Repository Hardening jobs were created but remained queued, so `npm run verify:tenant:fba` did not execute
- the targeted SQLite integration test did not receive an independent runner; the test and static guard are retained for the next executable gate

## Non-claims

This PR does not complete the active Tenant verification pass. Multi-replica Redis/cache recovery, migration invariants, module lifecycle consumers, multilingual storage and RBAC parity remain under audit.