### PR TITLE
fix(payment): sanitize storefront GraphQL failures

### DIFF
--- a/crates/rustok-payment/contracts/evidence/payment-storefront-graphql-error-safety-source-review.json
+++ b/crates/rustok-payment/contracts/evidence/payment-storefront-graphql-error-safety-source-review.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": 1,
+  "reviewed_at": "2026-07-30",
+  "status": "payment_storefront_graphql_error_safety_source_reviewed_unvalidated",
+  "base_main": "3b11116c73b93894ee5e7228ac0b119b57eedf52",
+  "reviewed_sources": [
+    "crates/rustok-commerce/docs/implementation-plan.md",
+    "crates/rustok-payment/storefront/Cargo.toml",
+    "crates/rustok-payment/storefront/src/transport.rs",
+    "crates/rustok-payment/storefront/src/transport/graphql_adapter.rs",
+    "crates/rustok-payment/storefront/src/transport/native_server_adapter/server_functions.rs",
+    "crates/rustok-graphql/src/lib.rs",
+    "crates/rustok-ui-transport/src/lib.rs",
+    "scripts/verify/verify-payment-storefront-native-error-safety.mjs"
+  ],
+  "findings": {
+    "master_mapper_cleanup_open": true,
+    "graphql_adapter_private": true,
+    "raw_graphql_display_handoffs": 3,
+    "ui_transport_preserves_graphql_display": true,
+    "native_transport_has_static_owner_envelopes": true,
+    "graphql_http_error_variants_reviewed": [
+      "Network",
+      "Http",
+      "Unauthorized",
+      "Graphql"
+    ],
+    "graphql_http_error_display_round_trip_available": true,
+    "covered_public_operations": [
+      "create_payment_collection",
+      "fetch_payment_collection",
+      "fetch_refund_summary"
+    ],
+    "native_calls_preserved": true,
+    "transport_selection_preserved": true,
+    "graphql_queries_preserved": true,
+    "request_response_dtos_preserved": true,
+    "validation_errors_pass_through": true,
+    "raw_tenant_slug_excluded_from_diagnostics": true,
+    "graphql_variables_excluded_from_diagnostics": true
+  },
+  "execution": {
+    "commands": [],
+    "tests": [],
+    "verifiers": [],
+    "cargo": [],
+    "format": [],
+    "workflows": [],
+    "ci": []
+  },
+  "nonclaims": [
+    "No focused verifier was executed.",
+    "No Cargo command or test was executed.",
+    "No browser, GraphQL server, mounted transport, workflow, or CI behavior was proven.",
+    "The generic rustok-graphql client and rustok-ui-transport envelope were not changed.",
+    "The broad ecommerce correlation-safe mapper cleanup remains open."
+  ]
+}

--- a/crates/rustok-payment/contracts/evidence/payment-storefront-graphql-error-safety-source.json
+++ b/crates/rustok-payment/contracts/evidence/payment-storefront-graphql-error-safety-source.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-30",
+  "status": "payment_storefront_graphql_error_safety_source_unvalidated",
+  "scope": "payment-owned storefront GraphQL transport consumer for refund summary and payment collection read/create",
+  "source_contract": {
+    "private_graphql_adapter_preserved": true,
+    "public_consumer_safety_policy": true,
+    "typed_graphql_error_round_trip": true,
+    "unique_call_correlation": true,
+    "tenant_configuration_shape_logging": true,
+    "network_static_public_envelope": true,
+    "http_static_public_envelope": true,
+    "unauthorized_static_public_envelope": true,
+    "graphql_rejection_static_public_envelope": true,
+    "unknown_static_public_envelope": true,
+    "validation_error_pass_through": true,
+    "native_transport_changed": false,
+    "transport_selection_changed": false,
+    "request_response_dto_changed": false,
+    "graphql_query_changed": false,
+    "raw_graphql_error_public": false,
+    "raw_tenant_slug_logged": false
+  },
+  "stable_public_messages": {
+    "network_unavailable": "Payment storefront is temporarily unavailable",
+    "http_unavailable": "Payment storefront is temporarily unavailable",
+    "authentication_required": "Payment storefront authentication is required",
+    "graphql_request_rejected": "Payment storefront request could not be completed",
+    "unknown_failure": "Payment storefront request could not be completed"
+  },
+  "covered_operations": [
+    "create_storefront_payment_collection",
+    "read_storefront_payment_collection",
+    "read_storefront_order_refunds"
+  ],
+  "suggested_execution": [
+    "node scripts/verify/verify-payment-storefront-graphql-error-safety.mjs",
+    "node scripts/verify/verify-payment-storefront-native-error-safety.mjs",
+    "node scripts/verify/verify-payment-storefront-boundary.mjs",
+    "node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs",
+    "cargo check -p rustok-payment-storefront",
+    "cargo check -p rustok-payment-storefront --features hydrate",
+    "cargo check -p rustok-payment-storefront --features ssr"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "browser_runtime_proven": false,
+    "graphql_runtime_proven": false,
+    "mounted_parity_proven": false
+  }
+}

--- a/crates/rustok-payment/docs/storefront-graphql-error-safety.md
+++ b/crates/rustok-payment/docs/storefront-graphql-error-safety.md
@@ -1,0 +1,147 @@
+# Payment storefront GraphQL error safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens the payment-owned storefront GraphQL transport used when
+`UiTransportPath::Graphql` is selected for:
+
+- `create_payment_collection`;
+- `fetch_payment_collection`;
+- `fetch_refund_summary`.
+
+The private low-level adapter, GraphQL documents, variables, DTO mapping, native
+server functions, and explicit transport selection remain unchanged.
+
+## Problem
+
+`rustok_graphql::execute` returns a typed `GraphqlHttpError`, but the private
+payment GraphQL adapter converted each failure to
+`PaymentTransportError::Graphql(error.to_string())`. The public transport facade
+then passed that display string into `UiTransportError.graphql_error`.
+
+That made GraphQL server messages and HTTP/client details part of a public UI
+transport envelope. Native storefront calls already used stable owner-owned
+messages, so the two payment transport paths had different error-safety policy.
+
+## Consumer safety boundary
+
+The low-level adapter remains private and unchanged. The public payment
+transport consumer now creates a `GraphqlCallContext` immediately before each
+GraphQL call and maps only a returned `PaymentTransportError::Graphql`.
+
+`PaymentTransportError::Validation` and `PaymentTransportError::ServerFn` are
+returned unchanged. There is no native-to-GraphQL fallback and transport
+selection remains explicit.
+
+## Typed policy
+
+The consumer reparses the private adapter display using
+`GraphqlHttpError::from_str`, whose display round-trip is owned by
+`rustok-graphql`.
+
+| Internal variant | Stable code | Public message | Severity |
+| --- | --- | --- | --- |
+| `Network` | `payment.storefront_graphql_network_unavailable` | `Payment storefront is temporarily unavailable` | error |
+| `Http(_)` | `payment.storefront_graphql_http_unavailable` | `Payment storefront is temporarily unavailable` | error |
+| `Unauthorized` | `payment.storefront_graphql_authentication_required` | `Payment storefront authentication is required` | warning |
+| `Graphql(_)` | `payment.storefront_graphql_request_rejected` | `Payment storefront request could not be completed` | warning |
+| unknown display | `payment.storefront_graphql_unknown_failure` | `Payment storefront request could not be completed` | error |
+
+The original raw display and parsed typed result remain internal diagnostic
+fields. Neither is copied into the returned `PaymentTransportError`.
+
+## Correlation and diagnostics
+
+Every selected GraphQL operation receives a unique correlation id with the
+shape:
+
+```text
+payment-storefront-graphql:{owner_operation}:{uuid}
+```
+
+Internal events include:
+
+- truthful owner `rustok_payment.storefront`;
+- exact owner operation;
+- correlation id;
+- tenant slug configured/not-configured fact;
+- trimmed tenant slug character length when configured;
+- typed error kind;
+- stable code;
+- boundary `payment_storefront_graphql_transport`;
+- raw and parsed error details for server diagnostics only.
+
+Diagnostics deliberately exclude:
+
+- the tenant slug value;
+- authentication tokens or authorization headers;
+- endpoint URLs;
+- GraphQL query text;
+- GraphQL variables;
+- cart or order request identifiers;
+- command metadata.
+
+## Covered operations
+
+The public facade maps the following owner operations:
+
+- `create_storefront_payment_collection`;
+- `read_storefront_payment_collection`;
+- `read_storefront_order_refunds`.
+
+The private adapter still executes the same named queries and mutation and
+preserves existing serialization and response mapping.
+
+## Preserved behavior
+
+This work does not change:
+
+- `PaymentTransportError` variants;
+- `UiTransportError` shape;
+- payment request or response DTOs;
+- GraphQL documents or variables;
+- configured tenant-slug lookup order;
+- decimal refund aggregation;
+- payment collection field mapping;
+- native server-function behavior;
+- feature-based native/GraphQL transport selection;
+- no-fallback behavior.
+
+## Static evidence
+
+`scripts/verify/verify-payment-storefront-graphql-error-safety.mjs` guards:
+
+- private adapter and safety-module visibility;
+- all three consumer mappings;
+- exact owner operations;
+- typed display parsing and all error variants;
+- stable codes and public messages;
+- correlation and tenant-shape diagnostics;
+- absence of raw tenant, query, variable, token, endpoint, request-id, and
+  metadata fields;
+- unchanged native calls and transport selection;
+- unchanged low-level GraphQL handoffs;
+- unvalidated evidence flags.
+
+## Remaining work
+
+The ecommerce correlation-safe mapper item remains open for other payment,
+fulfillment, order, customer, tax, promotion, ecommerce, and non-`PortError`
+public envelopes. This slice does not promote FFA, FBA, transport, browser,
+runtime, or production status.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-payment-storefront-graphql-error-safety.mjs
+node scripts/verify/verify-payment-storefront-native-error-safety.mjs
+node scripts/verify/verify-payment-storefront-boundary.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-payment-storefront
+cargo check -p rustok-payment-storefront --features hydrate
+cargo check -p rustok-payment-storefront --features ssr
+```

--- a/crates/rustok-payment/storefront/src/transport.rs
+++ b/crates/rustok-payment/storefront/src/transport.rs
@@ -1,4 +1,5 @@
 mod graphql_adapter;
+mod graphql_error_safety;
 mod native_server_adapter;
 
 use std::fmt::{Display, Formatter};
@@ -108,7 +109,14 @@ pub async fn create_payment_collection(
         "payment",
         selected_transport_path(),
         move || native_server_adapter::create_payment_collection(native_request),
-        move || graphql_adapter::create_payment_collection(request),
+        move || async move {
+            let context = graphql_error_safety::GraphqlCallContext::new(
+                "create_storefront_payment_collection",
+            );
+            graphql_adapter::create_payment_collection(request)
+                .await
+                .map_err(|error| context.map_error(error))
+        },
     )
     .await
 }
@@ -121,7 +129,14 @@ pub async fn fetch_payment_collection(
         "payment",
         selected_transport_path(),
         move || native_server_adapter::fetch_payment_collection(native_request),
-        move || graphql_adapter::fetch_payment_collection(request),
+        move || async move {
+            let context = graphql_error_safety::GraphqlCallContext::new(
+                "read_storefront_payment_collection",
+            );
+            graphql_adapter::fetch_payment_collection(request)
+                .await
+                .map_err(|error| context.map_error(error))
+        },
     )
     .await
 }
@@ -134,7 +149,14 @@ pub async fn fetch_refund_summary(
         "payment",
         selected_transport_path(),
         move || native_server_adapter::fetch_refund_summary(native_request),
-        move || graphql_adapter::fetch_refund_summary(request),
+        move || async move {
+            let context = graphql_error_safety::GraphqlCallContext::new(
+                "read_storefront_order_refunds",
+            );
+            graphql_adapter::fetch_refund_summary(request)
+                .await
+                .map_err(|error| context.map_error(error))
+        },
     )
     .await
 }

--- a/crates/rustok-payment/storefront/src/transport/graphql_error_safety.rs
+++ b/crates/rustok-payment/storefront/src/transport/graphql_error_safety.rs
@@ -1,0 +1,114 @@
+use std::str::FromStr;
+
+use rustok_graphql::GraphqlHttpError;
+use uuid::Uuid;
+
+use super::PaymentTransportError;
+
+const PAYMENT_STOREFRONT_GRAPHQL_OWNER: &str = "rustok_payment.storefront";
+const PAYMENT_STOREFRONT_GRAPHQL_BOUNDARY: &str = "payment_storefront_graphql_transport";
+
+pub(super) struct GraphqlCallContext {
+    owner_operation: &'static str,
+    correlation_id: String,
+    tenant_slug_length: Option<usize>,
+}
+
+impl GraphqlCallContext {
+    pub(super) fn new(owner_operation: &'static str) -> Self {
+        Self {
+            owner_operation,
+            correlation_id: format!(
+                "payment-storefront-graphql:{owner_operation}:{}",
+                Uuid::new_v4()
+            ),
+            tenant_slug_length: configured_tenant_slug_length(),
+        }
+    }
+
+    pub(super) fn map_error(&self, error: PaymentTransportError) -> PaymentTransportError {
+        let PaymentTransportError::Graphql(raw_error) = error else {
+            return error;
+        };
+        let parsed_error = GraphqlHttpError::from_str(raw_error.as_str());
+        let (error_kind, code, public_message, technical_failure) = match &parsed_error {
+            Ok(GraphqlHttpError::Network) => (
+                "network",
+                "payment.storefront_graphql_network_unavailable",
+                "Payment storefront is temporarily unavailable",
+                true,
+            ),
+            Ok(GraphqlHttpError::Http(_)) => (
+                "http",
+                "payment.storefront_graphql_http_unavailable",
+                "Payment storefront is temporarily unavailable",
+                true,
+            ),
+            Ok(GraphqlHttpError::Unauthorized) => (
+                "unauthorized",
+                "payment.storefront_graphql_authentication_required",
+                "Payment storefront authentication is required",
+                false,
+            ),
+            Ok(GraphqlHttpError::Graphql(_)) => (
+                "graphql",
+                "payment.storefront_graphql_request_rejected",
+                "Payment storefront request could not be completed",
+                false,
+            ),
+            Err(_) => (
+                "unknown",
+                "payment.storefront_graphql_unknown_failure",
+                "Payment storefront request could not be completed",
+                true,
+            ),
+        };
+
+        if technical_failure {
+            tracing::error!(
+                raw_error = %raw_error,
+                parsed_error = ?parsed_error,
+                owner = PAYMENT_STOREFRONT_GRAPHQL_OWNER,
+                owner_operation = self.owner_operation,
+                correlation_id = %self.correlation_id,
+                tenant_slug_configured = self.tenant_slug_length.is_some(),
+                tenant_slug_length = ?self.tenant_slug_length,
+                error_kind,
+                code,
+                boundary = PAYMENT_STOREFRONT_GRAPHQL_BOUNDARY,
+                "payment storefront GraphQL transport failed"
+            );
+        } else {
+            tracing::warn!(
+                raw_error = %raw_error,
+                parsed_error = ?parsed_error,
+                owner = PAYMENT_STOREFRONT_GRAPHQL_OWNER,
+                owner_operation = self.owner_operation,
+                correlation_id = %self.correlation_id,
+                tenant_slug_configured = self.tenant_slug_length.is_some(),
+                tenant_slug_length = ?self.tenant_slug_length,
+                error_kind,
+                code,
+                boundary = PAYMENT_STOREFRONT_GRAPHQL_BOUNDARY,
+                "payment storefront GraphQL request was rejected"
+            );
+        }
+
+        PaymentTransportError::Graphql(public_message.to_string())
+    }
+}
+
+fn configured_tenant_slug_length() -> Option<usize> {
+    [
+        "RUSTOK_TENANT_SLUG",
+        "NEXT_PUBLIC_TENANT_SLUG",
+        "NEXT_PUBLIC_DEFAULT_TENANT_SLUG",
+    ]
+    .into_iter()
+    .find_map(|key| {
+        std::env::var(key).ok().and_then(|value| {
+            let value = value.trim();
+            (!value.is_empty()).then_some(value.chars().count())
+        })
+    })
+}

--- a/scripts/verify/verify-payment-storefront-boundary.mjs
+++ b/scripts/verify/verify-payment-storefront-boundary.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import "./verify-payment-storefront-native-error-safety.mjs";
+import "./verify-payment-storefront-graphql-error-safety.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
@@ -47,6 +48,7 @@ const libPath = "crates/rustok-payment/storefront/src/lib.rs";
 const corePath = "crates/rustok-payment/storefront/src/core.rs";
 const transportPath = "crates/rustok-payment/storefront/src/transport.rs";
 const graphqlPath = "crates/rustok-payment/storefront/src/transport/graphql_adapter.rs";
+const graphqlSafetyPath = "crates/rustok-payment/storefront/src/transport/graphql_error_safety.rs";
 const nativeServerFunctionsPath = "crates/rustok-payment/storefront/src/transport/native_server_adapter/server_functions.rs";
 const cargoPath = "crates/rustok-payment/storefront/Cargo.toml";
 const uiPath = "crates/rustok-payment/storefront/src/ui/leptos.rs";
@@ -69,6 +71,7 @@ for (const filePath of [
   corePath,
   transportPath,
   graphqlPath,
+  graphqlSafetyPath,
   nativeServerFunctionsPath,
   cargoPath,
   uiPath,
@@ -93,6 +96,7 @@ const lib = readRepo(libPath);
 const core = readRepo(corePath);
 const transport = readRepo(transportPath);
 const graphql = readRepo(graphqlPath);
+const graphqlSafety = readRepo(graphqlSafetyPath);
 const nativeServerFunctions = readRepo(nativeServerFunctionsPath);
 const cargo = readRepo(cargoPath);
 const ui = readRepo(uiPath);
@@ -140,6 +144,7 @@ for (const marker of [
   "fetch_refund_summary",
   "create_payment_collection",
   "mod graphql_adapter;",
+  "mod graphql_error_safety;",
   "mod native_server_adapter;",
   "normalize_required",
 ]) {
@@ -152,6 +157,19 @@ for (const marker of ["STOREFRONT_REFUNDS_QUERY", "STOREFRONT_PAYMENT_COLLECTION
   assertContains(graphql, marker, `${graphqlPath}: payment must own GraphQL create/reuse marker ${marker}`);
 }
 assertNotContains(graphql, "rustok_commerce::", `${graphqlPath}: payment GraphQL adapter must not depend on commerce storefront internals`);
+for (const marker of [
+  "GraphqlHttpError::from_str",
+  "payment.storefront_graphql_network_unavailable",
+  "payment.storefront_graphql_http_unavailable",
+  "payment.storefront_graphql_authentication_required",
+  "payment.storefront_graphql_request_rejected",
+  "payment.storefront_graphql_unknown_failure",
+  "PaymentTransportError::Graphql(public_message.to_string())",
+]) {
+  assertContains(graphqlSafety, marker, `${graphqlSafetyPath}: expected GraphQL safety marker ${marker}`);
+}
+assertNotContains(graphqlSafety, "tenant_slug =", `${graphqlSafetyPath}: GraphQL diagnostics must not expose tenant slug values`);
+assertNotContains(graphqlSafety, "variables =", `${graphqlSafetyPath}: GraphQL diagnostics must not expose variables`);
 assertContains(nativeServerFunctions, "#[server", `${nativeServerFunctionsPath}: payment native server-functions adapter must own a server-function endpoint shell`);
 assertContains(nativeServerFunctions, "endpoint = \"payment/create-payment-collection\"", `${nativeServerFunctionsPath}: payment native server-functions adapter must expose the owner endpoint path`);
 assertContains(nativeServerFunctions, "endpoint = \"payment/payment-collection\"", `${nativeServerFunctionsPath}: payment native server-functions adapter must expose the owner read endpoint path`);

--- a/scripts/verify/verify-payment-storefront-graphql-error-safety.mjs
+++ b/scripts/verify/verify-payment-storefront-graphql-error-safety.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const rootPath = configuredRoot
+  ? path.resolve(configuredRoot)
+  : fileURLToPath(new URL('../../', import.meta.url));
+const read = (relativePath) => readFileSync(path.join(rootPath, relativePath), 'utf8');
+
+const cargo = read('crates/rustok-payment/storefront/Cargo.toml');
+const transport = read('crates/rustok-payment/storefront/src/transport.rs');
+const adapter = read('crates/rustok-payment/storefront/src/transport/graphql_adapter.rs');
+const safety = read(
+  'crates/rustok-payment/storefront/src/transport/graphql_error_safety.rs',
+);
+const evidence = JSON.parse(
+  read(
+    'crates/rustok-payment/contracts/evidence/payment-storefront-graphql-error-safety-source.json',
+  ),
+);
+
+const failures = [];
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const countText = (content, value) => content.split(value).length - 1;
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+for (const [value, label] of [
+  ['rustok-graphql.workspace = true', 'typed GraphQL dependency'],
+  ['tracing.workspace = true', 'structured diagnostics dependency'],
+  ['uuid.workspace = true', 'correlation dependency'],
+]) requireText(cargo, value, label);
+
+for (const [value, label] of [
+  ['mod graphql_adapter;', 'private GraphQL adapter'],
+  ['mod graphql_error_safety;', 'private GraphQL safety policy'],
+  ['mod native_server_adapter;', 'private native adapter'],
+  ['UiTransportPath::NativeServer', 'native selection'],
+  ['UiTransportPath::Graphql', 'GraphQL selection'],
+]) requireText(transport, value, label);
+
+const operations = [
+  {
+    start: 'pub async fn create_payment_collection(',
+    end: 'pub async fn fetch_payment_collection(',
+    ownerOperation: 'create_storefront_payment_collection',
+    graphqlCall: 'graphql_adapter::create_payment_collection(request)',
+    nativeCall: 'native_server_adapter::create_payment_collection(native_request)',
+    label: 'create payment collection',
+  },
+  {
+    start: 'pub async fn fetch_payment_collection(',
+    end: 'pub async fn fetch_refund_summary(',
+    ownerOperation: 'read_storefront_payment_collection',
+    graphqlCall: 'graphql_adapter::fetch_payment_collection(request)',
+    nativeCall: 'native_server_adapter::fetch_payment_collection(native_request)',
+    label: 'fetch payment collection',
+  },
+  {
+    start: 'pub async fn fetch_refund_summary(',
+    end: 'pub fn build_payment_collection_create_request(',
+    ownerOperation: 'read_storefront_order_refunds',
+    graphqlCall: 'graphql_adapter::fetch_refund_summary(request)',
+    nativeCall: 'native_server_adapter::fetch_refund_summary(native_request)',
+    label: 'fetch refund summary',
+  },
+];
+
+for (const operation of operations) {
+  const block = between(transport, operation.start, operation.end, operation.label);
+  for (const [value, detail] of [
+    ['let native_request = request.clone();', 'native request retention'],
+    [operation.nativeCall, 'unchanged native call'],
+    ['move || async move {', 'GraphQL consumer closure'],
+    ['graphql_error_safety::GraphqlCallContext::new(', 'call context construction'],
+    [`"${operation.ownerOperation}"`, 'exact owner operation'],
+    [operation.graphqlCall, 'unchanged GraphQL adapter call'],
+    ['.map_err(|error| context.map_error(error))', 'consumer safety mapping'],
+  ]) requireText(block, value, `${operation.label} ${detail}`);
+
+  const indexes = [
+    block.indexOf(operation.nativeCall),
+    block.indexOf('GraphqlCallContext::new('),
+    block.indexOf(operation.graphqlCall),
+    block.indexOf('context.map_error(error)'),
+  ];
+  if (!indexes.every((value, index) => value >= 0 && (index === 0 || indexes[index - 1] < value))) {
+    failures.push(`${operation.label}: expected native closure then context -> GraphQL call -> mapping order`);
+  }
+}
+
+if (countText(transport, 'GraphqlCallContext::new(') !== 3) {
+  failures.push('all three GraphQL public operations must construct a call context');
+}
+if (countText(transport, 'context.map_error(error)') !== 3) {
+  failures.push('all three GraphQL public operations must route errors through the safety policy');
+}
+if (countText(adapter, 'PaymentTransportError::Graphql(error.to_string())') !== 3) {
+  failures.push('private GraphQL adapter must preserve its three typed display handoffs');
+}
+
+for (const [value, label] of [
+  ['use std::str::FromStr;', 'display round-trip parser'],
+  ['use rustok_graphql::GraphqlHttpError;', 'typed GraphQL error'],
+  ['const PAYMENT_STOREFRONT_GRAPHQL_OWNER', 'owner constant'],
+  ['const PAYMENT_STOREFRONT_GRAPHQL_BOUNDARY', 'boundary constant'],
+  ['pub(super) struct GraphqlCallContext', 'private call context'],
+  ['payment-storefront-graphql:{owner_operation}:{}', 'unique correlation format'],
+  ['Uuid::new_v4()', 'unique correlation generation'],
+  ['let PaymentTransportError::Graphql(raw_error) = error else', 'non-GraphQL pass-through'],
+  ['return error;', 'same non-GraphQL error return'],
+  ['GraphqlHttpError::from_str(raw_error.as_str())', 'typed display parsing'],
+  ['Ok(GraphqlHttpError::Network)', 'network policy'],
+  ['Ok(GraphqlHttpError::Http(_))', 'HTTP policy'],
+  ['Ok(GraphqlHttpError::Unauthorized)', 'authentication policy'],
+  ['Ok(GraphqlHttpError::Graphql(_))', 'GraphQL rejection policy'],
+  ['Err(_)', 'unknown failure policy'],
+  ['tracing::error!(', 'technical diagnostics'],
+  ['tracing::warn!(', 'rejection diagnostics'],
+  ['raw_error = %raw_error', 'internal raw cause'],
+  ['parsed_error = ?parsed_error', 'typed internal cause'],
+  ['owner = PAYMENT_STOREFRONT_GRAPHQL_OWNER', 'truthful owner'],
+  ['owner_operation = self.owner_operation', 'exact owner operation'],
+  ['correlation_id = %self.correlation_id', 'correlation diagnostics'],
+  ['tenant_slug_configured = self.tenant_slug_length.is_some()', 'tenant configuration fact'],
+  ['tenant_slug_length = ?self.tenant_slug_length', 'tenant length fact'],
+  ['error_kind,', 'stable error kind'],
+  ['code,', 'stable public code'],
+  ['boundary = PAYMENT_STOREFRONT_GRAPHQL_BOUNDARY', 'boundary diagnostics'],
+  ['PaymentTransportError::Graphql(public_message.to_string())', 'static public GraphQL envelope'],
+]) requireText(safety, value, label);
+
+for (const [code, message, label] of [
+  ['payment.storefront_graphql_network_unavailable', 'Payment storefront is temporarily unavailable', 'network'],
+  ['payment.storefront_graphql_http_unavailable', 'Payment storefront is temporarily unavailable', 'HTTP'],
+  ['payment.storefront_graphql_authentication_required', 'Payment storefront authentication is required', 'authentication'],
+  ['payment.storefront_graphql_request_rejected', 'Payment storefront request could not be completed', 'GraphQL rejection'],
+  ['payment.storefront_graphql_unknown_failure', 'Payment storefront request could not be completed', 'unknown failure'],
+]) {
+  requireText(safety, `"${code}"`, `${label} code`);
+  requireText(safety, `"${message}"`, `${label} public message`);
+}
+
+for (const value of [
+  'tenant_slug =',
+  'tenant_slug = %',
+  'graphql_query',
+  'variables =',
+  'token =',
+  'authorization =',
+  'endpoint =',
+  'cart_id =',
+  'order_id =',
+  'metadata =',
+]) forbidText(safety, value, 'raw payment storefront GraphQL diagnostics');
+
+if (evidence.status !== 'payment_storefront_graphql_error_safety_source_unvalidated') {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  private_graphql_adapter_preserved: true,
+  public_consumer_safety_policy: true,
+  network_static_public_envelope: true,
+  http_static_public_envelope: true,
+  unauthorized_static_public_envelope: true,
+  graphql_rejection_static_public_envelope: true,
+  unknown_static_public_envelope: true,
+  validation_error_pass_through: true,
+  native_transport_changed: false,
+  transport_selection_changed: false,
+  request_response_dto_changed: false,
+  graphql_query_changed: false,
+  raw_graphql_error_public: false,
+  raw_tenant_slug_logged: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  'tests_run',
+  'cargo_run',
+  'format_run',
+  'verifiers_run',
+  'workflow_checks_run',
+  'ci_run',
+  'browser_runtime_proven',
+  'graphql_runtime_proven',
+  'mounted_parity_proven',
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Payment storefront GraphQL error-safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ payment storefront GraphQL failures retain internal typed diagnostics and expose only static transport messages; runtime evidence remains open',
+);


### PR DESCRIPTION
## Summary
- add a private payment storefront GraphQL error-safety policy at the public transport consumer boundary
- preserve the existing private low-level GraphQL adapter, queries, variables, DTOs, and explicit transport selection
- route all three payment storefront GraphQL operations through a per-call context with a unique correlation id
- reparse the adapter's `GraphqlHttpError` display handoff into typed network, HTTP, unauthorized, GraphQL rejection, and unknown policies
- keep raw GraphQL details in structured internal diagnostics only and expose static `PaymentTransportError::Graphql` messages through `UiTransportError.graphql_error`
- log only tenant-slug configured/length facts, never the raw slug, tokens, endpoint, query, variables, request ids, or command metadata
- pass non-GraphQL transport errors through unchanged
- add a focused source verifier, include it in the payment storefront boundary aggregate, and retain unvalidated source/review evidence plus documentation

## Covered operations
- `create_storefront_payment_collection`
- `read_storefront_payment_collection`
- `read_storefront_order_refunds`

## Public policy
- network / HTTP: `Payment storefront is temporarily unavailable`
- unauthorized: `Payment storefront authentication is required`
- GraphQL rejection / unknown: `Payment storefront request could not be completed`

## Preserved behavior
- no native-to-GraphQL fallback
- feature-based transport selection unchanged
- private adapter and all GraphQL documents unchanged
- payment request/response DTOs unchanged
- native server functions unchanged
- validation errors remain pass-through

## Evidence boundary
Source status is `payment_storefront_graphql_error_safety_source_unvalidated`. The broad ecommerce correlation-safe mapper cleanup remains open. No FFA, FBA, browser, GraphQL runtime, mounted parity, workflow, CI, or production status is promoted.

## Verification
The ecommerce master plan, payment storefront facade/private adapter/native safety contract, `GraphqlHttpError` variants and display round-trip, `UiTransportError` display preservation, final source files, and the seven-file branch diff were reviewed. `main` advanced by one unrelated tenant lifecycle commit; the PR has no overlapping files.

Tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run per maintainer instruction.