### PR TITLE
fix(profiles): make public display-name invalidation atomic

### DIFF
--- a/crates/rustok-forum/contracts/forum-search-public-author-summary.json
+++ b/crates/rustok-forum/contracts/forum-search-public-author-summary.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "task": "FORUM-23A",
-  "latest_slice": "FORUM-23A2",
+  "latest_slice": "FORUM-23A3",
   "upstream_task": "FORUM-20BQ",
   "status": "source_complete_execution_pending",
   "scope": "Project privacy-aware public author summaries into Forum topic and approved-reply Search documents and durably redact them after Profiles owner changes",
@@ -12,6 +12,7 @@
   "profiles_transactional_event_owner": "crates/rustok-profiles/src/profile_updated_event.rs",
   "profiles_visibility_event_owner": "crates/rustok-profiles/src/visibility_write.rs",
   "profiles_handle_event_owner": "crates/rustok-profiles/src/handle_write.rs",
+  "profiles_content_event_owner": "crates/rustok-profiles/src/content_write.rs",
   "search_inbox": "crates/rustok-search/src/forum_inbox.rs",
   "search_ingestion": "crates/rustok-search/src/ingestion.rs",
   "owner_note": "crates/rustok-forum/docs/forum-23a-search-public-author-summary.md",
@@ -40,10 +41,13 @@
     "profile_updated_is_durable": true,
     "profile_updated_is_emitted_after_owner_write": true,
     "transactional_profile_event_publisher_is_shared": true,
+    "transactional_profile_event_publisher_accepts_owner_model": true,
     "profile_visibility_write_and_event_are_atomic": true,
     "visibility_event_failure_rolls_back_owner_write": true,
     "profile_handle_write_and_event_are_atomic": true,
     "handle_event_failure_rolls_back_owner_write": true,
+    "profile_content_write_and_event_are_atomic": true,
+    "content_event_failure_rolls_back_owner_write": true,
     "remaining_profile_summary_write_and_event_pairs_are_atomic": false,
     "author_scope_is_tenant_and_user_scoped": true,
     "author_scope_is_not_suppressed_by_forum_wall_clock_watermark": true,
@@ -64,7 +68,7 @@
   "remaining_scope": [
     "replace remaining wall-clock Forum projection ordering with owner-issued monotonic revisions",
     "define an owner-ordered profile or account deletion projection invalidation contract",
-    "make profile upsert content locale and media summary update events atomic with their owner writes",
+    "make profile upsert locale and media summary update events atomic with their owner writes",
     "add bounded category-subtree tag locale date solved kind channel/group and attachment filters",
     "add member index projections",
     "capture maintainer-executed PostgreSQL rebuild redaction and query evidence"
@@ -87,7 +91,7 @@
     "UserDeleted is sufficient to prove Profiles state has already been removed",
     "account deletion redaction is complete",
     "all ProfileUpdated owner writes are transactionally coupled to outbox publication",
-    "profile upsert content locale and media updates are transactionally coupled to ProfileUpdated publication",
+    "profile upsert locale and media updates are transactionally coupled to ProfileUpdated publication",
     "general cross-producer owner revision ordering is complete"
   ],
   "downstream_task": "FORUM-23B"

--- a/crates/rustok-forum/docs/forum-23a-search-public-author-summary.md
+++ b/crates/rustok-forum/docs/forum-23a-search-public-author-summary.md
@@ -4,10 +4,10 @@ Date: 2026-07-30
 
 Status: `source_complete_execution_pending`
 
-Latest slice: `FORUM-23A2`
+Latest slice: `FORUM-23A3`
 
 This slice advances the canonical `FORUM-23` visibility-aware Search track. Public Forum topic
-and approved-reply documents now obtain author presentation from the Profiles owner instead of
+and approved-reply documents obtain author presentation from the Profiles owner instead of
 serializing the raw Forum author identifier.
 
 The machine-readable contract is
@@ -43,32 +43,34 @@ that owner event as a Forum projection event whenever the Forum source is compos
 The privacy-critical `update_my_profile_visibility` path writes the new visibility and the
 `ProfileUpdated` outbox envelope in the same Profiles-owned database transaction. If outbox
 publication fails, the visibility write is explicitly rolled back and the mutation returns a
-retryable owner error. A successful private visibility change therefore cannot commit without the
-durable invalidation consumed by Forum Search.
+retryable owner error.
 
 `FORUM-23A2` applies the same owner rule to `update_my_profile_handle`. Handle normalization,
-duplicate-owner validation, the profile row update, and the `ProfileUpdated` outbox envelope now
-share one Profiles-owned transaction. If event publication fails, the handle write is rolled back;
-a successful public-handle change cannot commit while Forum Search retains only the previous
-handle because the invalidation event was lost.
+duplicate-owner validation, the profile row update, and the `ProfileUpdated` outbox envelope share
+one transaction. If event publication fails, the handle write is rolled back.
 
-Both paths use the shared transactional publisher in
+`FORUM-23A3` applies the same rule to `update_my_profile_content`. Display-name normalization, the
+profile revision timestamp, the selected localized display-name/biography row, and the durable
+`ProfileUpdated` envelope now commit together. A public display-name change therefore cannot
+commit while Forum Search retains the previous name because its invalidation was lost. The shared
+publisher now accepts the actual Profiles owner model returned by SeaORM, correcting the type
+boundary used by the earlier handle and visibility helpers.
+
+Visibility, handle, and content paths use the shared transactional publisher in
 `crates/rustok-profiles/src/profile_updated_event.rs`, so their event envelope and retryable error
-classification cannot drift independently. Profile upsert, display-content, locale, and media
-mutations still publish after their owner write and are not claimed to be transactionally coupled
-in this slice.
+classification cannot drift independently. Profile upsert, locale, and media mutations still
+publish after their owner writes and are not claimed to be transactionally coupled.
 
 The event is stored under `forum_author:<user_id>`. This scope is intentionally a redaction
 barrier: it is not stale-skipped against the unrelated full Forum wall-clock watermark. The
-consumer rebuilds the Forum tenant projection from current owner state, so a profile changed to
-private removes the previously stored public summary and a committed handle change replaces the
-old Search presentation.
+consumer rebuilds the Forum tenant projection from current owner state, so committed visibility,
+handle, and public display-name changes replace stale Search presentation.
 
 The existing tenant advisory lock, durable retry, dead-letter bound, and periodic/opportunistic
 inbox reconciliation remain unchanged. This slice does not claim that general Forum producer
-ordering is solved; owner-issued monotonic revisions remain the next ordering hardening task.
-It also does not treat `UserDeleted` as sufficient deletion evidence because that event does not
-prove that the Profiles owner has already removed or hidden its state.
+ordering is solved; owner-issued monotonic revisions remain an ordering-hardening task. It also
+does not treat `UserDeleted` as sufficient deletion evidence because that event does not prove
+that the Profiles owner has already removed or hidden its state.
 
 ## Search shape
 
@@ -92,8 +94,7 @@ Existing Search document rows are replaced by the next Forum rebuild or relevant
 
 - owner-issued monotonic projection revisions across Forum producers;
 - an owner-ordered profile or account deletion invalidation contract;
-- transactionally couple profile upsert, display-content, locale, and media summary updates to
-  their owner events;
+- transactionally couple profile upsert, locale, and media summary updates to their owner events;
 - bounded category-subtree, tag, locale, date, solved, kind, channel/group, attachment, and
   remaining author filters;
 - member Search projections;

--- a/crates/rustok-profiles/src/content_write.rs
+++ b/crates/rustok-profiles/src/content_write.rs
@@ -1,0 +1,92 @@
+use chrono::Utc;
+use rustok_outbox::TransactionalEventBus;
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, Set,
+    TransactionTrait,
+};
+use uuid::Uuid;
+
+use crate::{
+    ProfileError, ProfileRecord, ProfileResult, ProfileService, entities,
+    profile_updated_event::publish_profile_updated_in_tx,
+};
+
+pub(crate) async fn update_profile_content_with_event(
+    db: &DatabaseConnection,
+    event_bus: &TransactionalEventBus,
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    user_id: Uuid,
+    display_name: &str,
+    bio: Option<&str>,
+    tenant_default_locale: Option<&str>,
+) -> ProfileResult<ProfileRecord> {
+    let display_name = ProfileService::normalize_display_name(display_name)?;
+    let txn = db.begin().await?;
+
+    let profile = entities::profile::Entity::find_by_id(user_id)
+        .filter(entities::profile::Column::TenantId.eq(tenant_id))
+        .one(&txn)
+        .await?
+        .ok_or(ProfileError::ProfileNotFound(user_id))?;
+    let translation_locale = ProfileService::normalize_locale(profile.preferred_locale.as_deref())?
+        .or(ProfileService::normalize_locale(tenant_default_locale)?)
+        .ok_or_else(|| {
+            ProfileError::InvalidLocale("effective profile locale is required".to_string())
+        })?;
+
+    let now = Utc::now();
+    let mut active: entities::profile::ActiveModel = profile.into();
+    active.updated_at = Set(now.into());
+    let profile = active.update(&txn).await?;
+
+    let translation = entities::profile_translation::Entity::find()
+        .filter(entities::profile_translation::Column::ProfileUserId.eq(user_id))
+        .filter(entities::profile_translation::Column::Locale.eq(translation_locale.clone()))
+        .one(&txn)
+        .await?;
+    match translation {
+        Some(translation) => {
+            let mut active: entities::profile_translation::ActiveModel = translation.into();
+            active.display_name = Set(display_name);
+            active.bio = Set(bio.map(str::to_string));
+            active.updated_at = Set(now.into());
+            active.update(&txn).await?;
+        }
+        None => {
+            entities::profile_translation::ActiveModel {
+                id: Set(Uuid::new_v4()),
+                profile_user_id: Set(user_id),
+                locale: Set(translation_locale.clone()),
+                display_name: Set(display_name),
+                bio: Set(bio.map(str::to_string)),
+                created_at: Set(now.into()),
+                updated_at: Set(now.into()),
+            }
+            .insert(&txn)
+            .await?;
+        }
+    }
+
+    if let Err(error) =
+        publish_profile_updated_in_tx(event_bus, &txn, tenant_id, actor_id, &profile).await
+    {
+        tracing::error!(
+            tenant_id = %tenant_id,
+            user_id = %profile.user_id,
+            "Profile content event publication failed; rolling back owner write"
+        );
+        txn.rollback().await?;
+        return Err(error);
+    }
+    txn.commit().await?;
+
+    ProfileService::new(db.clone())
+        .get_profile(
+            tenant_id,
+            user_id,
+            Some(translation_locale.as_str()),
+            tenant_default_locale,
+        )
+        .await
+}

--- a/crates/rustok-profiles/src/graphql/mutation.rs
+++ b/crates/rustok-profiles/src/graphql/mutation.rs
@@ -14,8 +14,9 @@ use uuid::Uuid;
 
 use crate::{
     ProfileError, ProfileMediaSlot, ProfileOperation, ProfileOperationTimer, ProfileRecord,
-    ProfileResult, ProfileService, handle_write::update_profile_handle_with_event,
-    validate_profile_media_asset, visibility_write::update_profile_visibility_with_event,
+    ProfileResult, ProfileService, content_write::update_profile_content_with_event,
+    handle_write::update_profile_handle_with_event, validate_profile_media_asset,
+    visibility_write::update_profile_visibility_with_event,
 };
 
 use super::{MODULE_SLUG, types::*};
@@ -106,14 +107,16 @@ impl ProfilesMutation {
         let db = ctx.data::<DatabaseConnection>()?;
         let event_bus = ctx.data::<TransactionalEventBus>()?;
         let tenant = ctx.data::<TenantContext>()?;
-        let service = ProfileService::new(db.clone());
 
         let profile = observe_profile_write(
             ProfileOperation::UpdateContent,
             tenant.id,
             auth.user_id,
-            service.update_profile_content(
+            update_profile_content_with_event(
+                db,
+                event_bus,
                 tenant.id,
+                auth.user_id,
                 auth.user_id,
                 &input.display_name,
                 input.bio.as_deref(),
@@ -121,7 +124,6 @@ impl ProfilesMutation {
             ),
         )
         .await?;
-        publish_profile_updated(event_bus, tenant.id, auth.user_id, &profile).await?;
 
         Ok(profile.into())
     }

--- a/crates/rustok-profiles/src/lib.rs
+++ b/crates/rustok-profiles/src/lib.rs
@@ -3,6 +3,7 @@ use rustok_api::Permission;
 use rustok_core::{MigrationSource, RusToKModule};
 use sea_orm_migration::MigrationTrait;
 
+mod content_write;
 pub mod dto;
 pub mod entities;
 pub mod error;

--- a/crates/rustok-profiles/src/profile_updated_event.rs
+++ b/crates/rustok-profiles/src/profile_updated_event.rs
@@ -4,7 +4,7 @@ use sea_orm::DatabaseTransaction;
 use uuid::Uuid;
 
 use crate::{
-    ProfileError, ProfileOperation, ProfileOperationTimer, ProfileRecord, ProfileResult,
+    ProfileError, ProfileOperation, ProfileOperationTimer, ProfileResult, entities,
 };
 
 pub(crate) async fn publish_profile_updated_in_tx(
@@ -12,7 +12,7 @@ pub(crate) async fn publish_profile_updated_in_tx(
     txn: &DatabaseTransaction,
     tenant_id: Uuid,
     actor_id: Uuid,
-    profile: &ProfileRecord,
+    profile: &entities::profile::Model,
 ) -> ProfileResult<()> {
     let timer = ProfileOperationTimer::start(
         ProfileOperation::PublishUpdatedEvent,

--- a/scripts/verify/verify-forum-search-public-author-summary.mjs
+++ b/scripts/verify/verify-forum-search-public-author-summary.mjs
@@ -42,6 +42,7 @@ const profilesPath = "crates/rustok-profiles/src/presentation.rs";
 const profilesLibPath = "crates/rustok-profiles/src/lib.rs";
 const profilesMutationPath = "crates/rustok-profiles/src/graphql/mutation.rs";
 const profilesUpdatedEventPath = "crates/rustok-profiles/src/profile_updated_event.rs";
+const profilesContentWritePath = "crates/rustok-profiles/src/content_write.rs";
 const profilesHandleWritePath = "crates/rustok-profiles/src/handle_write.rs";
 const profilesVisibilityWritePath = "crates/rustok-profiles/src/visibility_write.rs";
 const profilesErrorPath = "crates/rustok-profiles/src/error.rs";
@@ -57,6 +58,7 @@ const profiles = read(profilesPath);
 const profilesLib = read(profilesLibPath);
 const profilesMutation = read(profilesMutationPath);
 const profilesUpdatedEvent = read(profilesUpdatedEventPath);
+const profilesContentWrite = read(profilesContentWritePath);
 const profilesHandleWrite = read(profilesHandleWritePath);
 const profilesVisibilityWrite = read(profilesVisibilityWritePath);
 const profilesError = read(profilesErrorPath);
@@ -115,6 +117,7 @@ for (const marker of [
   requireMarker(profiles, marker, profilesPath);
 }
 for (const marker of [
+  "mod content_write;",
   "mod handle_write;",
   "mod profile_updated_event;",
   "mod visibility_write;",
@@ -122,10 +125,10 @@ for (const marker of [
   requireMarker(profilesLib, marker, profilesLibPath);
 }
 for (const marker of [
+  "update_profile_content_with_event(",
   "update_profile_handle_with_event(",
   "update_profile_visibility_with_event(",
   "service.upsert_profile(",
-  "service.update_profile_content(",
   "service.update_profile_locale(",
   "service.update_profile_media(",
   "publish_profile_updated(event_bus, tenant.id, auth.user_id, &profile).await?",
@@ -135,6 +138,7 @@ for (const marker of [
   requireMarker(profilesMutation, marker, profilesMutationPath);
 }
 for (const forbidden of [
+  "service.update_profile_content(",
   "service.update_profile_handle(",
   "service.update_profile_visibility(",
 ]) {
@@ -143,6 +147,7 @@ for (const forbidden of [
 
 for (const marker of [
   "publish_profile_updated_in_tx",
+  "profile: &entities::profile::Model",
   ".publish_in_tx(",
   "DomainEvent::ProfileUpdated",
   "ProfileOperation::PublishUpdatedEvent",
@@ -151,6 +156,37 @@ for (const marker of [
 ]) {
   requireMarker(profilesUpdatedEvent, marker, profilesUpdatedEventPath);
 }
+rejectMarker(profilesUpdatedEvent, "profile: &ProfileRecord", profilesUpdatedEventPath);
+
+for (const marker of [
+  "ProfileService::normalize_display_name(display_name)?",
+  "db.begin().await?",
+  "Column::TenantId.eq(tenant_id)",
+  "Column::ProfileUserId.eq(user_id)",
+  "Column::Locale.eq(translation_locale.clone())",
+  "active.display_name = Set(display_name)",
+  "active.bio = Set(bio.map(str::to_string))",
+  ".update(&txn).await?",
+  ".insert(&txn)",
+  "publish_profile_updated_in_tx",
+  "txn.rollback().await?",
+  "txn.commit().await?",
+  "Profile content event publication failed; rolling back owner write",
+]) {
+  requireMarker(profilesContentWrite, marker, profilesContentWritePath);
+}
+requireOrder(
+  profilesContentWrite,
+  ".update(&txn).await?",
+  "publish_profile_updated_in_tx",
+  profilesContentWritePath,
+);
+requireOrder(
+  profilesContentWrite,
+  "publish_profile_updated_in_tx",
+  "txn.commit().await?",
+  profilesContentWritePath,
+);
 
 for (const marker of [
   "ProfileService::normalize_handle(handle)?",
@@ -230,15 +266,17 @@ for (const marker of [
 rejectMarker(ingestion, "DomainEvent::UserDeleted", ingestionPath);
 
 for (const marker of [
-  "FORUM-23A2",
+  "FORUM-23A3",
   "ProfilePresentationService",
   "forum_author:<user_id>",
   "raw `payload.author_id`",
   "owner-issued monotonic",
   "same Profiles-owned database transaction",
   "update_my_profile_handle",
+  "update_my_profile_content",
   "shared transactional publisher",
-  "Profile upsert, display-content, locale, and media",
+  "actual Profiles owner model",
+  "Profile upsert, locale, and media",
   "does not treat `UserDeleted`",
   "not run by the implementation agent",
 ]) {
@@ -247,7 +285,7 @@ for (const marker of [
 
 if (contract) {
   if (contract.task !== "FORUM-23A") failures.push(`${contractPath}: unexpected task`);
-  if (contract.latest_slice !== "FORUM-23A2") {
+  if (contract.latest_slice !== "FORUM-23A3") {
     failures.push(`${contractPath}: unexpected latest slice`);
   }
   if (contract.status !== "source_complete_execution_pending") {
@@ -274,10 +312,13 @@ if (contract) {
     "profile_updated_is_durable",
     "profile_updated_is_emitted_after_owner_write",
     "transactional_profile_event_publisher_is_shared",
+    "transactional_profile_event_publisher_accepts_owner_model",
     "profile_visibility_write_and_event_are_atomic",
     "visibility_event_failure_rolls_back_owner_write",
     "profile_handle_write_and_event_are_atomic",
     "handle_event_failure_rolls_back_owner_write",
+    "profile_content_write_and_event_are_atomic",
+    "content_event_failure_rolls_back_owner_write",
     "author_scope_is_tenant_and_user_scoped",
     "author_scope_is_not_suppressed_by_forum_wall_clock_watermark",
     "author_change_rebuilds_current_forum_owner_state",
@@ -310,7 +351,7 @@ if (contract) {
   for (const nonClaim of [
     "account deletion redaction is complete",
     "all ProfileUpdated owner writes are transactionally coupled to outbox publication",
-    "profile upsert content locale and media updates are transactionally coupled to ProfileUpdated publication",
+    "profile upsert locale and media updates are transactionally coupled to ProfileUpdated publication",
   ]) {
     if (!contract.non_claims?.includes(nonClaim)) {
       failures.push(`${contractPath}: missing non-claim ${nonClaim}`);


### PR DESCRIPTION
## Summary

Implements `FORUM-23A3`, the next bounded public-author Search hardening slice.

- write localized profile display content and the `ProfileUpdated` outbox envelope in the same Profiles-owned transaction;
- roll back the profile timestamp and localized display-name/biography write when durable event publication fails;
- preserve the existing preferred-locale then tenant-default locale selection;
- route `update_my_profile_content` through the atomic owner helper;
- correct the shared transactional publisher to accept the SeaORM profile owner model returned by `ActiveModel::update`;
- update the Forum public-author contract, owner note, and static verifier.

## Compatibility

No migration, public GraphQL schema, Search query API, dependency, or `Cargo.lock` change.

## Verification

Not run by the implementation agent, per maintainer instruction. Suggested commands:

```bash
cargo check -p rustok-profiles --all-targets
cargo test -p rustok-profiles error -- --nocapture
cargo test -p rustok-forum search_projection_author -- --nocapture
cargo test -p rustok-search forum_inbox -- --nocapture
cargo test -p rustok-search ingestion -- --nocapture
node scripts/verify/verify-forum-search-public-author-summary.mjs
node scripts/verify/verify-forum-search-projection.mjs
cargo xtask module validate profiles
cargo xtask module validate forum
```

## Remaining

- atomically publish `ProfileUpdated` for profile upsert, locale, and media writes;
- define owner-ordered profile/account deletion invalidation;
- replace remaining Forum wall-clock projection ordering with owner-issued revisions;
- add the remaining filters and member projections.