### PR TITLE
fix(profiles): make public avatar invalidation atomic

### DIFF
--- a/crates/rustok-forum/contracts/forum-search-public-author-summary.json
+++ b/crates/rustok-forum/contracts/forum-search-public-author-summary.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "task": "FORUM-23A",
-  "latest_slice": "FORUM-23A3",
+  "latest_slice": "FORUM-23A4",
   "upstream_task": "FORUM-20BQ",
   "status": "source_complete_execution_pending",
   "scope": "Project privacy-aware public author summaries into Forum topic and approved-reply Search documents and durably redact them after Profiles owner changes",
@@ -13,6 +13,7 @@
   "profiles_visibility_event_owner": "crates/rustok-profiles/src/visibility_write.rs",
   "profiles_handle_event_owner": "crates/rustok-profiles/src/handle_write.rs",
   "profiles_content_event_owner": "crates/rustok-profiles/src/content_write.rs",
+  "profiles_media_event_owner": "crates/rustok-profiles/src/media_write.rs",
   "search_inbox": "crates/rustok-search/src/forum_inbox.rs",
   "search_ingestion": "crates/rustok-search/src/ingestion.rs",
   "owner_note": "crates/rustok-forum/docs/forum-23a-search-public-author-summary.md",
@@ -48,6 +49,8 @@
     "handle_event_failure_rolls_back_owner_write": true,
     "profile_content_write_and_event_are_atomic": true,
     "content_event_failure_rolls_back_owner_write": true,
+    "profile_media_write_and_event_are_atomic": true,
+    "media_event_failure_rolls_back_owner_write": true,
     "remaining_profile_summary_write_and_event_pairs_are_atomic": false,
     "author_scope_is_tenant_and_user_scoped": true,
     "author_scope_is_not_suppressed_by_forum_wall_clock_watermark": true,
@@ -68,7 +71,7 @@
   "remaining_scope": [
     "replace remaining wall-clock Forum projection ordering with owner-issued monotonic revisions",
     "define an owner-ordered profile or account deletion projection invalidation contract",
-    "make profile upsert locale and media summary update events atomic with their owner writes",
+    "make profile upsert and locale summary update events atomic with their owner writes",
     "add bounded category-subtree tag locale date solved kind channel/group and attachment filters",
     "add member index projections",
     "capture maintainer-executed PostgreSQL rebuild redaction and query evidence"
@@ -91,7 +94,7 @@
     "UserDeleted is sufficient to prove Profiles state has already been removed",
     "account deletion redaction is complete",
     "all ProfileUpdated owner writes are transactionally coupled to outbox publication",
-    "profile upsert locale and media updates are transactionally coupled to ProfileUpdated publication",
+    "profile upsert and locale updates are transactionally coupled to ProfileUpdated publication",
     "general cross-producer owner revision ordering is complete"
   ],
   "downstream_task": "FORUM-23B"

--- a/crates/rustok-forum/docs/forum-23a-search-public-author-summary.md
+++ b/crates/rustok-forum/docs/forum-23a-search-public-author-summary.md
@@ -4,7 +4,7 @@ Date: 2026-07-30
 
 Status: `source_complete_execution_pending`
 
-Latest slice: `FORUM-23A3`
+Latest slice: `FORUM-23A4`
 
 This slice advances the canonical `FORUM-23` visibility-aware Search track. Public Forum topic
 and approved-reply documents obtain author presentation from the Profiles owner instead of
@@ -51,20 +51,25 @@ one transaction. If event publication fails, the handle write is rolled back.
 
 `FORUM-23A3` applies the same rule to `update_my_profile_content`. Display-name normalization, the
 profile revision timestamp, the selected localized display-name/biography row, and the durable
-`ProfileUpdated` envelope now commit together. A public display-name change therefore cannot
-commit while Forum Search retains the previous name because its invalidation was lost. The shared
-publisher now accepts the actual Profiles owner model returned by SeaORM, correcting the type
-boundary used by the earlier handle and visibility helpers.
+`ProfileUpdated` envelope commit together. The shared publisher accepts the actual Profiles owner
+model returned by SeaORM, matching the handle and visibility helpers.
 
-Visibility, handle, and content paths use the shared transactional publisher in
+`FORUM-23A4` applies the owner rule to `update_my_profile_media`. Media ownership and access are
+validated before opening the Profiles transaction. The avatar/banner identifiers, profile revision
+timestamp, and durable `ProfileUpdated` envelope then commit in one transaction. If outbox
+publication fails, the media owner write is rolled back. A new public avatar therefore cannot
+commit while Forum Search retains the previous `avatar_media_id` because its invalidation was lost.
+Banner remains owner data and is never serialized into Forum Search.
+
+Visibility, handle, content, and media paths use the shared transactional publisher in
 `crates/rustok-profiles/src/profile_updated_event.rs`, so their event envelope and retryable error
-classification cannot drift independently. Profile upsert, locale, and media mutations still
-publish after their owner writes and are not claimed to be transactionally coupled.
+classification cannot drift independently. Profile upsert and locale mutations still publish
+after their owner writes and are not claimed to be transactionally coupled.
 
 The event is stored under `forum_author:<user_id>`. This scope is intentionally a redaction
 barrier: it is not stale-skipped against the unrelated full Forum wall-clock watermark. The
 consumer rebuilds the Forum tenant projection from current owner state, so committed visibility,
-handle, and public display-name changes replace stale Search presentation.
+handle, public display-name, and avatar changes replace stale Search presentation.
 
 The existing tenant advisory lock, durable retry, dead-letter bound, and periodic/opportunistic
 inbox reconciliation remain unchanged. This slice does not claim that general Forum producer
@@ -94,7 +99,7 @@ Existing Search document rows are replaced by the next Forum rebuild or relevant
 
 - owner-issued monotonic projection revisions across Forum producers;
 - an owner-ordered profile or account deletion invalidation contract;
-- transactionally couple profile upsert, locale, and media summary updates to their owner events;
+- transactionally couple profile upsert and locale summary updates to their owner events;
 - bounded category-subtree, tag, locale, date, solved, kind, channel/group, attachment, and
   remaining author filters;
 - member Search projections;

--- a/crates/rustok-profiles/src/graphql/mutation.rs
+++ b/crates/rustok-profiles/src/graphql/mutation.rs
@@ -15,8 +15,8 @@ use uuid::Uuid;
 use crate::{
     ProfileError, ProfileMediaSlot, ProfileOperation, ProfileOperationTimer, ProfileRecord,
     ProfileResult, ProfileService, content_write::update_profile_content_with_event,
-    handle_write::update_profile_handle_with_event, validate_profile_media_asset,
-    visibility_write::update_profile_visibility_with_event,
+    handle_write::update_profile_handle_with_event, media_write::update_profile_media_with_event,
+    validate_profile_media_asset, visibility_write::update_profile_visibility_with_event,
 };
 
 use super::{MODULE_SLUG, types::*};
@@ -207,13 +207,15 @@ impl ProfilesMutation {
         )
         .await?;
 
-        let service = ProfileService::new(db.clone());
         let profile = observe_profile_write(
             ProfileOperation::UpdateMedia,
             tenant.id,
             auth.user_id,
-            service.update_profile_media(
+            update_profile_media_with_event(
+                db,
+                event_bus,
                 tenant.id,
+                auth.user_id,
                 auth.user_id,
                 input.avatar_media_id,
                 input.banner_media_id,
@@ -221,7 +223,6 @@ impl ProfilesMutation {
             ),
         )
         .await?;
-        publish_profile_updated(event_bus, tenant.id, auth.user_id, &profile).await?;
 
         Ok(profile.into())
     }

--- a/crates/rustok-profiles/src/lib.rs
+++ b/crates/rustok-profiles/src/lib.rs
@@ -11,6 +11,7 @@ pub mod graphql;
 mod handle_write;
 pub mod loader;
 pub mod media;
+mod media_write;
 pub mod migrations;
 pub mod observability;
 pub mod presentation;

--- a/crates/rustok-profiles/src/media_write.rs
+++ b/crates/rustok-profiles/src/media_write.rs
@@ -1,0 +1,53 @@
+use chrono::Utc;
+use rustok_outbox::TransactionalEventBus;
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, Set,
+    TransactionTrait,
+};
+use uuid::Uuid;
+
+use crate::{
+    ProfileError, ProfileRecord, ProfileResult, ProfileService, entities,
+    profile_updated_event::publish_profile_updated_in_tx,
+};
+
+pub(crate) async fn update_profile_media_with_event(
+    db: &DatabaseConnection,
+    event_bus: &TransactionalEventBus,
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    user_id: Uuid,
+    avatar_media_id: Option<Uuid>,
+    banner_media_id: Option<Uuid>,
+    tenant_default_locale: Option<&str>,
+) -> ProfileResult<ProfileRecord> {
+    let txn = db.begin().await?;
+    let profile = entities::profile::Entity::find_by_id(user_id)
+        .filter(entities::profile::Column::TenantId.eq(tenant_id))
+        .one(&txn)
+        .await?
+        .ok_or(ProfileError::ProfileNotFound(user_id))?;
+
+    let mut active: entities::profile::ActiveModel = profile.into();
+    active.avatar_media_id = Set(avatar_media_id);
+    active.banner_media_id = Set(banner_media_id);
+    active.updated_at = Set(Utc::now().into());
+    let profile = active.update(&txn).await?;
+
+    if let Err(error) =
+        publish_profile_updated_in_tx(event_bus, &txn, tenant_id, actor_id, &profile).await
+    {
+        tracing::error!(
+            tenant_id = %tenant_id,
+            user_id = %profile.user_id,
+            "Profile media event publication failed; rolling back owner write"
+        );
+        txn.rollback().await?;
+        return Err(error);
+    }
+    txn.commit().await?;
+
+    ProfileService::new(db.clone())
+        .get_profile(tenant_id, user_id, None, tenant_default_locale)
+        .await
+}

--- a/scripts/verify/verify-forum-search-public-author-summary.mjs
+++ b/scripts/verify/verify-forum-search-public-author-summary.mjs
@@ -44,6 +44,7 @@ const profilesMutationPath = "crates/rustok-profiles/src/graphql/mutation.rs";
 const profilesUpdatedEventPath = "crates/rustok-profiles/src/profile_updated_event.rs";
 const profilesContentWritePath = "crates/rustok-profiles/src/content_write.rs";
 const profilesHandleWritePath = "crates/rustok-profiles/src/handle_write.rs";
+const profilesMediaWritePath = "crates/rustok-profiles/src/media_write.rs";
 const profilesVisibilityWritePath = "crates/rustok-profiles/src/visibility_write.rs";
 const profilesErrorPath = "crates/rustok-profiles/src/error.rs";
 const contractPath = "crates/rustok-forum/contracts/forum-search-public-author-summary.json";
@@ -60,6 +61,7 @@ const profilesMutation = read(profilesMutationPath);
 const profilesUpdatedEvent = read(profilesUpdatedEventPath);
 const profilesContentWrite = read(profilesContentWritePath);
 const profilesHandleWrite = read(profilesHandleWritePath);
+const profilesMediaWrite = read(profilesMediaWritePath);
 const profilesVisibilityWrite = read(profilesVisibilityWritePath);
 const profilesError = read(profilesErrorPath);
 const note = read(notePath);
@@ -119,6 +121,7 @@ for (const marker of [
 for (const marker of [
   "mod content_write;",
   "mod handle_write;",
+  "mod media_write;",
   "mod profile_updated_event;",
   "mod visibility_write;",
 ]) {
@@ -127,10 +130,10 @@ for (const marker of [
 for (const marker of [
   "update_profile_content_with_event(",
   "update_profile_handle_with_event(",
+  "update_profile_media_with_event(",
   "update_profile_visibility_with_event(",
   "service.upsert_profile(",
   "service.update_profile_locale(",
-  "service.update_profile_media(",
   "publish_profile_updated(event_bus, tenant.id, auth.user_id, &profile).await?",
   "DomainEvent::ProfileUpdated",
   "ProfileError::EventPublishUnavailable",
@@ -140,6 +143,7 @@ for (const marker of [
 for (const forbidden of [
   "service.update_profile_content(",
   "service.update_profile_handle(",
+  "service.update_profile_media(",
   "service.update_profile_visibility(",
 ]) {
   rejectMarker(profilesMutation, forbidden, profilesMutationPath);
@@ -216,6 +220,31 @@ requireOrder(
 
 for (const marker of [
   "db.begin().await?",
+  "active.avatar_media_id = Set(avatar_media_id)",
+  "active.banner_media_id = Set(banner_media_id)",
+  ".update(&txn).await?",
+  "publish_profile_updated_in_tx",
+  "txn.rollback().await?",
+  "txn.commit().await?",
+  "Profile media event publication failed; rolling back owner write",
+]) {
+  requireMarker(profilesMediaWrite, marker, profilesMediaWritePath);
+}
+requireOrder(
+  profilesMediaWrite,
+  ".update(&txn).await?",
+  "publish_profile_updated_in_tx",
+  profilesMediaWritePath,
+);
+requireOrder(
+  profilesMediaWrite,
+  "publish_profile_updated_in_tx",
+  "txn.commit().await?",
+  profilesMediaWritePath,
+);
+
+for (const marker of [
+  "db.begin().await?",
   ".update(&txn).await?",
   "publish_profile_updated_in_tx",
   "txn.rollback().await?",
@@ -266,7 +295,7 @@ for (const marker of [
 rejectMarker(ingestion, "DomainEvent::UserDeleted", ingestionPath);
 
 for (const marker of [
-  "FORUM-23A3",
+  "FORUM-23A4",
   "ProfilePresentationService",
   "forum_author:<user_id>",
   "raw `payload.author_id`",
@@ -274,9 +303,10 @@ for (const marker of [
   "same Profiles-owned database transaction",
   "update_my_profile_handle",
   "update_my_profile_content",
+  "update_my_profile_media",
   "shared transactional publisher",
   "actual Profiles owner model",
-  "Profile upsert, locale, and media",
+  "Profile upsert and locale",
   "does not treat `UserDeleted`",
   "not run by the implementation agent",
 ]) {
@@ -285,7 +315,7 @@ for (const marker of [
 
 if (contract) {
   if (contract.task !== "FORUM-23A") failures.push(`${contractPath}: unexpected task`);
-  if (contract.latest_slice !== "FORUM-23A3") {
+  if (contract.latest_slice !== "FORUM-23A4") {
     failures.push(`${contractPath}: unexpected latest slice`);
   }
   if (contract.status !== "source_complete_execution_pending") {
@@ -319,6 +349,8 @@ if (contract) {
     "handle_event_failure_rolls_back_owner_write",
     "profile_content_write_and_event_are_atomic",
     "content_event_failure_rolls_back_owner_write",
+    "profile_media_write_and_event_are_atomic",
+    "media_event_failure_rolls_back_owner_write",
     "author_scope_is_tenant_and_user_scoped",
     "author_scope_is_not_suppressed_by_forum_wall_clock_watermark",
     "author_change_rebuilds_current_forum_owner_state",
@@ -351,7 +383,7 @@ if (contract) {
   for (const nonClaim of [
     "account deletion redaction is complete",
     "all ProfileUpdated owner writes are transactionally coupled to outbox publication",
-    "profile upsert locale and media updates are transactionally coupled to ProfileUpdated publication",
+    "profile upsert and locale updates are transactionally coupled to ProfileUpdated publication",
   ]) {
     if (!contract.non_claims?.includes(nonClaim)) {
       failures.push(`${contractPath}: missing non-claim ${nonClaim}`);


### PR DESCRIPTION
## Summary

Implements `FORUM-23A4`, the next bounded public-author Search hardening slice.

- validate avatar/banner media ownership before opening the Profiles owner transaction;
- write avatar/banner identifiers and the `ProfileUpdated` outbox envelope in the same Profiles-owned transaction;
- roll back the media owner write when durable event publication fails;
- route `update_my_profile_media` through the atomic owner helper;
- keep banner private to Profiles while protecting the public `avatar_media_id` embedded by Forum Search;
- update the Forum public-author contract, owner note, and static verifier.

## Compatibility

No migration, public GraphQL schema, Search query API, dependency, or `Cargo.lock` change.

## Verification

Not run by the implementation agent, per maintainer instruction. Suggested commands:

```bash
cargo check -p rustok-profiles --all-targets
cargo test -p rustok-profiles error -- --nocapture
cargo test -p rustok-forum search_projection_author -- --nocapture
cargo test -p rustok-search forum_inbox -- --nocapture
cargo test -p rustok-search ingestion -- --nocapture
node scripts/verify/verify-forum-search-public-author-summary.mjs
node scripts/verify/verify-forum-search-projection.mjs
cargo xtask module validate profiles
cargo xtask module validate forum
```

## Remaining

- atomically publish `ProfileUpdated` for profile upsert and locale writes;
- define owner-ordered profile/account deletion invalidation;
- replace remaining Forum wall-clock projection ordering with owner-issued revisions;
- add the remaining filters and member projections.