### PR TITLE
fix(fulfillment): sanitize storefront GraphQL failures

### DIFF
--- a/crates/rustok-fulfillment/contracts/evidence/storefront-graphql-error-safety-source-review.json
+++ b/crates/rustok-fulfillment/contracts/evidence/storefront-graphql-error-safety-source-review.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "reviewed_at": "2026-07-30",
+  "status": "fulfillment_storefront_graphql_error_safety_source_reviewed_unvalidated",
+  "base_main_sha": "83e3f7254bc30d46142c09259f80dc23d6aad0c4",
+  "scope": "fulfillment storefront shipping-selection GraphQL error boundary",
+  "reviewed_files": [
+    "crates/rustok-commerce/docs/implementation-plan.md",
+    "crates/rustok-fulfillment/storefront/Cargo.toml",
+    "crates/rustok-fulfillment/storefront/src/transport.rs",
+    "crates/rustok-fulfillment/storefront/src/transport/graphql_adapter.rs",
+    "crates/rustok-fulfillment/storefront/src/transport/native_server_adapter/server_functions.rs",
+    "crates/rustok-graphql/src/lib.rs",
+    "crates/rustok-ui-transport/src/lib.rs",
+    "scripts/verify/verify-fulfillment-storefront-boundary.mjs"
+  ],
+  "findings": [
+    {
+      "id": "fulfillment-storefront-graphql-raw-public-envelope",
+      "severity": "public_error_safety",
+      "finding": "The private GraphQL adapter converted GraphqlHttpError into ShippingSelectionTransportError::Graphql(error.to_string()), and the public facade passed that value directly into UiTransportError.graphql_error. GraphQL resolver text and HTTP detail could therefore reach the storefront caller."
+    },
+    {
+      "id": "fulfillment-storefront-native-already-sanitized",
+      "severity": "context",
+      "finding": "The native server-function path already retains internal diagnostics and static public messages under fulfillment_storefront_native_transport, so this slice is limited to the GraphQL path."
+    },
+    {
+      "id": "fulfillment-storefront-explicit-transport-selection",
+      "severity": "preservation",
+      "finding": "The facade intentionally selects one transport by feature profile and does not perform native-to-GraphQL fallback; that behavior must remain unchanged."
+    },
+    {
+      "id": "fulfillment-storefront-validation-pass-through",
+      "severity": "preservation",
+      "finding": "Local shipping-selection validation errors are user-actionable and are not GraphqlHttpError envelopes, so they remain unchanged."
+    }
+  ],
+  "implementation_review": {
+    "typed_graphql_variant_policy": true,
+    "static_public_graphql_messages": true,
+    "raw_graphql_detail_internal_only": true,
+    "per_call_correlation_id": true,
+    "safe_shape_only_request_facts": true,
+    "native_path_changed": false,
+    "validation_path_changed": false,
+    "graphql_adapter_changed": false,
+    "graphql_document_changed": false,
+    "transport_selection_changed": false,
+    "request_response_dto_changed": false
+  },
+  "execution": {
+    "commands_run": [],
+    "tests_run": [],
+    "verifiers_run": [],
+    "workflows_observed": [],
+    "ci_observed": []
+  },
+  "remaining_scope": [
+    "remaining ecommerce storefront and admin GraphQL adapters",
+    "remaining customer and non-PortError public envelopes",
+    "browser and mounted GraphQL runtime evidence",
+    "broad ecommerce correlation-safe mapper cleanup"
+  ]
+}

--- a/crates/rustok-fulfillment/contracts/evidence/storefront-graphql-error-safety-source.json
+++ b/crates/rustok-fulfillment/contracts/evidence/storefront-graphql-error-safety-source.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-30",
+  "status": "fulfillment_storefront_graphql_error_safety_source_unvalidated",
+  "scope": "fulfillment-owned storefront GraphQL shipping-selection transport",
+  "owner": "rustok_fulfillment.storefront",
+  "boundary": "fulfillment_storefront_graphql_transport",
+  "operations": [
+    "select_storefront_shipping_option"
+  ],
+  "source_contract": {
+    "graphql_variant_static_public_envelopes": true,
+    "typed_graphql_error_policy": true,
+    "per_call_correlation_id": true,
+    "safe_request_shape_logging": true,
+    "raw_graphql_detail_internal_only": true,
+    "validation_variant_changed": false,
+    "native_variant_changed": false,
+    "transport_selection_changed": false,
+    "graphql_document_changed": false,
+    "request_response_dto_changed": false,
+    "native_server_functions_changed": false,
+    "raw_graphql_detail_public": false
+  },
+  "stable_public_messages": {
+    "network_or_http": "Shipping selection is temporarily unavailable",
+    "unauthorized": "Shipping selection authentication is required",
+    "graphql_rejection_or_unknown": "Shipping selection request could not be completed"
+  },
+  "internal_diagnostics": {
+    "raw_graphql_error": true,
+    "parsed_graphql_error": true,
+    "owner_operation": true,
+    "correlation_id": true,
+    "tenant_slug_value": false,
+    "tenant_slug_configured_and_length": true,
+    "cart_id_value": false,
+    "cart_id_length": true,
+    "delivery_group_count": true,
+    "shipping_profile_slug_value": false,
+    "shipping_profile_slug_length": true,
+    "seller_id_value": false,
+    "seller_id_presence": true,
+    "shipping_option_id_value": false,
+    "shipping_option_id_presence": true
+  },
+  "suggested_execution": [
+    "node scripts/verify/verify-fulfillment-storefront-graphql-error-safety.mjs",
+    "node scripts/verify/verify-fulfillment-storefront-native-error-safety.mjs",
+    "node scripts/verify/verify-fulfillment-storefront-boundary.mjs",
+    "node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs",
+    "cargo check -p rustok-fulfillment-storefront",
+    "cargo check -p rustok-fulfillment-storefront --features hydrate",
+    "cargo check -p rustok-fulfillment-storefront --features ssr"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "browser_runtime_proven": false,
+    "graphql_runtime_proven": false,
+    "mounted_parity_proven": false
+  }
+}

--- a/crates/rustok-fulfillment/docs/storefront-graphql-error-safety.md
+++ b/crates/rustok-fulfillment/docs/storefront-graphql-error-safety.md
@@ -1,0 +1,149 @@
+# Fulfillment storefront GraphQL error safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice closes the public GraphQL error boundary for the fulfillment-owned storefront shipping-selection operation:
+
+- `select_storefront_shipping_option`;
+- public facade `rustok_fulfillment_storefront::transport::select_shipping_option`;
+- selected GraphQL transport path;
+- boundary `fulfillment_storefront_graphql_transport`.
+
+The private GraphQL adapter, native server functions, shipping-selection DTOs, selection planning, GraphQL document, feature-based transport selection, and Commerce compatibility delegation remain unchanged.
+
+## Problem
+
+The private GraphQL adapter intentionally converted `GraphqlHttpError` into the transport-owned variant:
+
+```text
+ShippingSelectionTransportError::Graphql(error.to_string())
+```
+
+Before this slice, the public transport facade delegated that variant directly to `execute_selected_transport`. `UiTransportError::graphql` stores the delegated display string in its public `graphql_error` field, so resolver messages and HTTP detail could reach the storefront caller.
+
+This is a non-`PortError` public-envelope gap in the ecommerce correlation-safe mapper cleanup.
+
+## Boundary policy
+
+The public facade now creates a `GraphqlCallContext` before invoking the private adapter. Only `ShippingSelectionTransportError::Graphql` is classified. Other variants are returned unchanged.
+
+The adapter display handoff is reparsed through the typed `GraphqlHttpError` contract:
+
+| Internal category | Internal code | Public message | Severity |
+| --- | --- | --- | --- |
+| network | `fulfillment.storefront_graphql_network_unavailable` | `Shipping selection is temporarily unavailable` | error |
+| non-success HTTP | `fulfillment.storefront_graphql_http_unavailable` | `Shipping selection is temporarily unavailable` | error |
+| unauthorized | `fulfillment.storefront_graphql_authentication_required` | `Shipping selection authentication is required` | warning |
+| GraphQL rejection | `fulfillment.storefront_graphql_request_rejected` | `Shipping selection request could not be completed` | warning |
+| unknown display handoff | `fulfillment.storefront_graphql_unknown_failure` | `Shipping selection request could not be completed` | error |
+
+The raw GraphQL detail is never copied into the returned `ShippingSelectionTransportError::Graphql`.
+
+## Correlation and diagnostics
+
+Each selected GraphQL invocation receives a generated correlation id with the fulfillment owner operation embedded in its prefix.
+
+Internal events retain:
+
+- owner `rustok_fulfillment.storefront`;
+- owner operation `select_storefront_shipping_option`;
+- boundary `fulfillment_storefront_graphql_transport`;
+- per-call correlation id;
+- parsed GraphQL error category;
+- stable internal code;
+- raw GraphQL display detail for operator diagnostics;
+- whether a tenant slug is configured and its character length;
+- cart-id character length;
+- delivery-group count;
+- shipping-profile-slug character length;
+- seller-id presence;
+- shipping-option-id presence.
+
+The events deliberately do not retain:
+
+- tenant slug value;
+- cart id value;
+- shipping profile slug value;
+- seller id value;
+- shipping option id value;
+- available option ids;
+- GraphQL endpoint;
+- query document or variables;
+- authorization token;
+- Commerce command metadata.
+
+## Public and transport stability
+
+This work does not change:
+
+- `ShippingSelectionTransportError` variants;
+- `UiTransportError` structure;
+- `SelectShippingOptionRequest` or delivery-group DTOs;
+- request normalization;
+- shipping-selection validation messages;
+- shipping-selection planning or update construction;
+- `SELECT_STOREFRONT_SHIPPING_OPTION_MUTATION`;
+- GraphQL variables or response mapping;
+- configured tenant-slug header selection;
+- native server-function endpoint or native safety policy;
+- feature-based `NativeServer` versus `Graphql` selection;
+- the no-fallback transport contract;
+- Commerce delegation to the fulfillment-owned facade.
+
+Validation errors remain pass-through because they are local, user-actionable failures and are not GraphQL runtime envelopes.
+
+## Static evidence
+
+`scripts/verify/verify-fulfillment-storefront-graphql-error-safety.mjs` guards:
+
+- private adapter, safety, and native module separation;
+- pre-call context construction and post-call GraphQL-only mapping;
+- typed `GraphqlHttpError` classification;
+- static public messages for every typed category;
+- error versus warning severity;
+- correlation and safe request-shape diagnostics;
+- absence of raw request identity fields in diagnostics;
+- unchanged private GraphQL adapter handoff and GraphQL document;
+- unchanged native path and transport variant;
+- unchanged explicit transport selection;
+- unvalidated evidence flags.
+
+The focused guard is imported by `verify-fulfillment-storefront-boundary.mjs` so the ordinary fulfillment storefront boundary check also rejects restoration of the raw public GraphQL mapping.
+
+Evidence files:
+
+- `crates/rustok-fulfillment/contracts/evidence/storefront-graphql-error-safety-source.json`;
+- `crates/rustok-fulfillment/contracts/evidence/storefront-graphql-error-safety-source-review.json`.
+
+## Evidence boundary
+
+The source status is `fulfillment_storefront_graphql_error_safety_source_unvalidated`.
+
+Source inspection does not prove:
+
+- compilation;
+- browser execution;
+- real network, HTTP, unauthorized, or GraphQL failure injection;
+- mounted Commerce parity;
+- native/GraphQL behavior parity;
+- workflow or CI success;
+- FFA or FBA promotion;
+- production readiness.
+
+The broad ecommerce correlation-safe mapper task remains open for remaining storefront/admin GraphQL adapters, customer and other non-`PortError` envelopes, and runtime evidence.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-fulfillment-storefront-graphql-error-safety.mjs
+node scripts/verify/verify-fulfillment-storefront-native-error-safety.mjs
+node scripts/verify/verify-fulfillment-storefront-boundary.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-fulfillment-storefront
+cargo check -p rustok-fulfillment-storefront --features hydrate
+cargo check -p rustok-fulfillment-storefront --features ssr
+```

--- a/crates/rustok-fulfillment/storefront/src/transport.rs
+++ b/crates/rustok-fulfillment/storefront/src/transport.rs
@@ -1,4 +1,5 @@
 mod graphql_adapter;
+mod graphql_error_safety;
 mod native_server_adapter;
 
 use std::fmt::{Display, Formatter};
@@ -81,7 +82,12 @@ pub async fn select_shipping_option(
         "fulfillment",
         selected_transport_path(),
         move || native_server_adapter::select_shipping_option(native_request),
-        move || graphql_adapter::select_shipping_option(request),
+        move || async move {
+            let context = graphql_error_safety::GraphqlCallContext::new(&request);
+            graphql_adapter::select_shipping_option(request)
+                .await
+                .map_err(|error| context.map_error(error))
+        },
     )
     .await
 }

--- a/crates/rustok-fulfillment/storefront/src/transport/graphql_error_safety.rs
+++ b/crates/rustok-fulfillment/storefront/src/transport/graphql_error_safety.rs
@@ -1,0 +1,138 @@
+use std::str::FromStr;
+
+use rustok_graphql::GraphqlHttpError;
+use uuid::Uuid;
+
+use super::{SelectShippingOptionRequest, ShippingSelectionTransportError};
+
+const FULFILLMENT_STOREFRONT_GRAPHQL_OWNER: &str = "rustok_fulfillment.storefront";
+const FULFILLMENT_STOREFRONT_GRAPHQL_OPERATION: &str = "select_storefront_shipping_option";
+const FULFILLMENT_STOREFRONT_GRAPHQL_BOUNDARY: &str =
+    "fulfillment_storefront_graphql_transport";
+
+pub(super) struct GraphqlCallContext {
+    correlation_id: String,
+    tenant_slug_length: Option<usize>,
+    cart_id_length: usize,
+    delivery_group_count: usize,
+    shipping_profile_slug_length: usize,
+    seller_id_present: bool,
+    shipping_option_id_present: bool,
+}
+
+impl GraphqlCallContext {
+    pub(super) fn new(request: &SelectShippingOptionRequest) -> Self {
+        Self {
+            correlation_id: format!(
+                "fulfillment-storefront-graphql:{}:{}",
+                FULFILLMENT_STOREFRONT_GRAPHQL_OPERATION,
+                Uuid::new_v4()
+            ),
+            tenant_slug_length: configured_tenant_slug_length(),
+            cart_id_length: request.cart_id.chars().count(),
+            delivery_group_count: request.delivery_groups.len(),
+            shipping_profile_slug_length: request.shipping_profile_slug.chars().count(),
+            seller_id_present: request.seller_id.is_some(),
+            shipping_option_id_present: request.shipping_option_id.is_some(),
+        }
+    }
+
+    pub(super) fn map_error(
+        &self,
+        error: ShippingSelectionTransportError,
+    ) -> ShippingSelectionTransportError {
+        let ShippingSelectionTransportError::Graphql(raw_error) = error else {
+            return error;
+        };
+        let parsed_error = GraphqlHttpError::from_str(raw_error.as_str());
+        let (error_kind, code, public_message, technical_failure) = match &parsed_error {
+            Ok(GraphqlHttpError::Network) => (
+                "network",
+                "fulfillment.storefront_graphql_network_unavailable",
+                "Shipping selection is temporarily unavailable",
+                true,
+            ),
+            Ok(GraphqlHttpError::Http(_)) => (
+                "http",
+                "fulfillment.storefront_graphql_http_unavailable",
+                "Shipping selection is temporarily unavailable",
+                true,
+            ),
+            Ok(GraphqlHttpError::Unauthorized) => (
+                "unauthorized",
+                "fulfillment.storefront_graphql_authentication_required",
+                "Shipping selection authentication is required",
+                false,
+            ),
+            Ok(GraphqlHttpError::Graphql(_)) => (
+                "graphql",
+                "fulfillment.storefront_graphql_request_rejected",
+                "Shipping selection request could not be completed",
+                false,
+            ),
+            Err(_) => (
+                "unknown",
+                "fulfillment.storefront_graphql_unknown_failure",
+                "Shipping selection request could not be completed",
+                true,
+            ),
+        };
+
+        if technical_failure {
+            tracing::error!(
+                raw_error = %raw_error,
+                parsed_error = ?parsed_error,
+                owner = FULFILLMENT_STOREFRONT_GRAPHQL_OWNER,
+                owner_operation = FULFILLMENT_STOREFRONT_GRAPHQL_OPERATION,
+                correlation_id = %self.correlation_id,
+                tenant_slug_configured = self.tenant_slug_length.is_some(),
+                tenant_slug_length = ?self.tenant_slug_length,
+                cart_id_length = self.cart_id_length,
+                delivery_group_count = self.delivery_group_count,
+                shipping_profile_slug_length = self.shipping_profile_slug_length,
+                seller_id_present = self.seller_id_present,
+                shipping_option_id_present = self.shipping_option_id_present,
+                error_kind,
+                code,
+                boundary = FULFILLMENT_STOREFRONT_GRAPHQL_BOUNDARY,
+                "fulfillment storefront GraphQL transport failed"
+            );
+        } else {
+            tracing::warn!(
+                raw_error = %raw_error,
+                parsed_error = ?parsed_error,
+                owner = FULFILLMENT_STOREFRONT_GRAPHQL_OWNER,
+                owner_operation = FULFILLMENT_STOREFRONT_GRAPHQL_OPERATION,
+                correlation_id = %self.correlation_id,
+                tenant_slug_configured = self.tenant_slug_length.is_some(),
+                tenant_slug_length = ?self.tenant_slug_length,
+                cart_id_length = self.cart_id_length,
+                delivery_group_count = self.delivery_group_count,
+                shipping_profile_slug_length = self.shipping_profile_slug_length,
+                seller_id_present = self.seller_id_present,
+                shipping_option_id_present = self.shipping_option_id_present,
+                error_kind,
+                code,
+                boundary = FULFILLMENT_STOREFRONT_GRAPHQL_BOUNDARY,
+                "fulfillment storefront GraphQL request was rejected"
+            );
+        }
+
+        ShippingSelectionTransportError::Graphql(public_message.to_string())
+    }
+}
+
+fn configured_tenant_slug_length() -> Option<usize> {
+    [
+        "RUSTOK_TENANT_SLUG",
+        "NEXT_PUBLIC_TENANT_SLUG",
+        "NEXT_PUBLIC_DEFAULT_TENANT_SLUG",
+    ]
+    .into_iter()
+    .find_map(|key| {
+        std::env::var(key).ok().and_then(|value| {
+            let value = value.trim();
+            (!value.is_empty()).then_some(value.chars().count())
+        })
+    })
+}

--- a/scripts/verify/verify-fulfillment-storefront-boundary.mjs
+++ b/scripts/verify/verify-fulfillment-storefront-boundary.mjs
@@ -7,6 +7,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import "./verify-fulfillment-storefront-native-error-safety.mjs";
+import "./verify-fulfillment-storefront-graphql-error-safety.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
@@ -134,6 +135,7 @@ for (const marker of [
   "build_shipping_selection_updates",
   "impl ShippingSelectionError",
   "mod graphql_adapter;",
+  "mod graphql_error_safety;",
   "mod native_server_adapter;",
 ]) {
   assertContains(transport, marker, `${transportPath}: expected owner transport facade marker ${marker}`);

--- a/scripts/verify/verify-fulfillment-storefront-graphql-error-safety.mjs
+++ b/scripts/verify/verify-fulfillment-storefront-graphql-error-safety.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const rootPath = configuredRoot
+  ? path.resolve(configuredRoot)
+  : fileURLToPath(new URL('../../', import.meta.url));
+const read = (relativePath) => readFileSync(path.join(rootPath, relativePath), 'utf8');
+
+const cargo = read('crates/rustok-fulfillment/storefront/Cargo.toml');
+const transport = read('crates/rustok-fulfillment/storefront/src/transport.rs');
+const safety = read(
+  'crates/rustok-fulfillment/storefront/src/transport/graphql_error_safety.rs',
+);
+const adapter = read(
+  'crates/rustok-fulfillment/storefront/src/transport/graphql_adapter.rs',
+);
+const native = read(
+  'crates/rustok-fulfillment/storefront/src/transport/native_server_adapter/server_functions.rs',
+);
+const evidence = JSON.parse(
+  read(
+    'crates/rustok-fulfillment/contracts/evidence/storefront-graphql-error-safety-source.json',
+  ),
+);
+
+const failures = [];
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [value, label] of [
+  ['rustok-graphql.workspace = true', 'typed GraphQL error dependency'],
+  ['tracing.workspace = true', 'structured diagnostics dependency'],
+  ['uuid.workspace = true', 'correlation id dependency'],
+]) requireText(cargo, value, label);
+
+for (const [value, label] of [
+  ['mod graphql_adapter;', 'private GraphQL adapter module'],
+  ['mod graphql_error_safety;', 'private GraphQL safety module'],
+  ['mod native_server_adapter;', 'private native adapter module'],
+  ['execute_selected_transport(', 'explicit selected transport'],
+  ['move || native_server_adapter::select_shipping_option(native_request)', 'unchanged native closure'],
+  ['let context = graphql_error_safety::GraphqlCallContext::new(&request);', 'pre-call GraphQL context'],
+  ['graphql_adapter::select_shipping_option(request)', 'unchanged GraphQL adapter call'],
+  ['.map_err(|error| context.map_error(error))', 'GraphQL safety mapping'],
+  ['UiTransportPath::NativeServer', 'native feature path'],
+  ['UiTransportPath::Graphql', 'GraphQL feature path'],
+]) requireText(transport, value, label);
+for (const value of [
+  'fallback_failed(',
+  'native_server_adapter::select_shipping_option(native_request).await',
+  'PaymentTransportError',
+]) forbidText(transport, value, 'transport selection drift');
+
+for (const [value, label] of [
+  ['use rustok_graphql::GraphqlHttpError;', 'typed GraphQL error policy'],
+  ['GraphqlHttpError::from_str(raw_error.as_str())', 'typed display handoff parsing'],
+  ['const FULFILLMENT_STOREFRONT_GRAPHQL_OWNER', 'GraphQL owner constant'],
+  ['const FULFILLMENT_STOREFRONT_GRAPHQL_OPERATION', 'GraphQL operation constant'],
+  ['const FULFILLMENT_STOREFRONT_GRAPHQL_BOUNDARY', 'GraphQL boundary constant'],
+  ['Uuid::new_v4()', 'per-call correlation id'],
+  ['let ShippingSelectionTransportError::Graphql(raw_error) = error else {', 'GraphQL-only mapping'],
+  ['return error;', 'non-GraphQL pass-through'],
+  ['GraphqlHttpError::Network', 'network policy'],
+  ['GraphqlHttpError::Http(_)', 'HTTP policy'],
+  ['GraphqlHttpError::Unauthorized', 'authentication policy'],
+  ['GraphqlHttpError::Graphql(_)', 'GraphQL rejection policy'],
+  ['"fulfillment.storefront_graphql_network_unavailable"', 'network stable code'],
+  ['"fulfillment.storefront_graphql_http_unavailable"', 'HTTP stable code'],
+  ['"fulfillment.storefront_graphql_authentication_required"', 'auth stable code'],
+  ['"fulfillment.storefront_graphql_request_rejected"', 'request stable code'],
+  ['"fulfillment.storefront_graphql_unknown_failure"', 'unknown stable code'],
+  ['"Shipping selection is temporarily unavailable"', 'technical public envelope'],
+  ['"Shipping selection authentication is required"', 'auth public envelope'],
+  ['"Shipping selection request could not be completed"', 'request public envelope'],
+  ['tracing::error!(', 'technical event severity'],
+  ['tracing::warn!(', 'ordinary event severity'],
+  ['raw_error = %raw_error', 'internal raw detail'],
+  ['parsed_error = ?parsed_error', 'typed internal error'],
+  ['owner = FULFILLMENT_STOREFRONT_GRAPHQL_OWNER', 'truthful owner'],
+  ['owner_operation = FULFILLMENT_STOREFRONT_GRAPHQL_OPERATION', 'exact operation'],
+  ['correlation_id = %self.correlation_id', 'correlation diagnostics'],
+  ['tenant_slug_configured = self.tenant_slug_length.is_some()', 'tenant configuration fact'],
+  ['tenant_slug_length = ?self.tenant_slug_length', 'tenant length fact'],
+  ['cart_id_length = self.cart_id_length', 'cart id length fact'],
+  ['delivery_group_count = self.delivery_group_count', 'delivery group count fact'],
+  ['shipping_profile_slug_length = self.shipping_profile_slug_length', 'profile length fact'],
+  ['seller_id_present = self.seller_id_present', 'seller presence fact'],
+  ['shipping_option_id_present = self.shipping_option_id_present', 'option presence fact'],
+  ['boundary = FULFILLMENT_STOREFRONT_GRAPHQL_BOUNDARY', 'GraphQL boundary diagnostics'],
+  ['ShippingSelectionTransportError::Graphql(public_message.to_string())', 'static GraphQL envelope'],
+]) requireText(safety, value, label);
+
+for (const value of [
+  'tenant_slug =',
+  'cart_id =',
+  'shipping_profile_slug =',
+  'seller_id =',
+  'shipping_option_id =',
+  'available_shipping_option_ids =',
+  'query =',
+  'variables =',
+  'endpoint =',
+  'token =',
+]) forbidText(safety, value, 'raw GraphQL request diagnostics');
+
+for (const [value, label] of [
+  ['SELECT_STOREFRONT_SHIPPING_OPTION_MUTATION', 'unchanged GraphQL document'],
+  ['GraphqlRequest::new(', 'unchanged GraphQL request construction'],
+  ['build_shipping_selection_updates(&request)?', 'unchanged validation order'],
+  ['configured_tenant_slug()', 'unchanged tenant header selection'],
+  ['ShippingSelectionTransportError::Graphql(error.to_string())', 'private display handoff'],
+]) requireText(adapter, value, label);
+for (const value of [
+  'graphql_error_safety',
+  'tracing::error!(',
+  'tracing::warn!(',
+]) forbidText(adapter, value, 'private adapter policy leakage');
+
+for (const [value, label] of [
+  ['FULFILLMENT_STOREFRONT_NATIVE_BOUNDARY', 'native safety boundary'],
+  ['ShippingSelectionTransportError::ServerFn(error.to_string())', 'native transport variant'],
+  ['select_storefront_shipping_option(', 'native owner call'],
+]) requireText(native, value, label);
+forbidText(native, 'graphql_error_safety', 'native GraphQL policy coupling');
+
+if (evidence.status !== 'fulfillment_storefront_graphql_error_safety_source_unvalidated') {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  graphql_variant_static_public_envelopes: true,
+  typed_graphql_error_policy: true,
+  per_call_correlation_id: true,
+  safe_request_shape_logging: true,
+  raw_graphql_detail_internal_only: true,
+  validation_variant_changed: false,
+  native_variant_changed: false,
+  transport_selection_changed: false,
+  graphql_document_changed: false,
+  request_response_dto_changed: false,
+  native_server_functions_changed: false,
+  raw_graphql_detail_public: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  'tests_run',
+  'cargo_run',
+  'format_run',
+  'verifiers_run',
+  'workflow_checks_run',
+  'ci_run',
+  'browser_runtime_proven',
+  'graphql_runtime_proven',
+  'mounted_parity_proven',
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Fulfillment storefront GraphQL error-safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ fulfillment storefront GraphQL failures retain typed internal diagnostics and static public envelopes; runtime evidence remains open',
+);


### PR DESCRIPTION
## Summary
- add a private fulfillment storefront GraphQL error-safety policy at the public transport consumer boundary
- preserve the existing private GraphQL adapter, mutation document, variables, DTOs, validation order, native server functions, and explicit transport selection
- route `select_storefront_shipping_option` through a per-call context with a unique correlation id
- reparse the adapter's `GraphqlHttpError` display handoff into typed network, HTTP, unauthorized, GraphQL rejection, and unknown policies
- keep raw GraphQL details in structured internal diagnostics only and expose static `ShippingSelectionTransportError::Graphql` messages through `UiTransportError.graphql_error`
- retain only safe request-shape facts: lengths, counts, and optional-field presence; never raw tenant/cart/profile/seller/option identifiers
- pass validation and native errors through unchanged
- add a focused source verifier, include it in the fulfillment storefront boundary aggregate, and retain unvalidated source/review evidence plus documentation

## Covered operation
- `select_storefront_shipping_option`

## Public policy
- network / HTTP: `Shipping selection is temporarily unavailable`
- unauthorized: `Shipping selection authentication is required`
- GraphQL rejection / unknown: `Shipping selection request could not be completed`

## Preserved behavior
- no native-to-GraphQL fallback
- feature-based transport selection unchanged
- private adapter and GraphQL document unchanged
- shipping-selection request/DTO/validation behavior unchanged
- native server functions and native error-safety policy unchanged
- Commerce compatibility delegation unchanged

## Evidence boundary
Source status is `fulfillment_storefront_graphql_error_safety_source_unvalidated`. The broad ecommerce correlation-safe mapper cleanup remains open. No FFA, FBA, browser, GraphQL runtime, mounted parity, workflow, CI, or production status is promoted.

## Verification
The ecommerce master plan, fulfillment storefront facade/private adapter/native safety contract, `GraphqlHttpError` variants and display handoff, `UiTransportError` public storage, final source files, and the seven-file ahead-only diff were reviewed.

Tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run per maintainer instruction.