### PR TITLE
fix(order): sanitize storefront GraphQL failures

### DIFF
--- a/crates/rustok-order/contracts/evidence/storefront-graphql-error-safety-source-review.json
+++ b/crates/rustok-order/contracts/evidence/storefront-graphql-error-safety-source-review.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-30",
+  "status": "order_storefront_graphql_error_safety_source_reviewed_unvalidated",
+  "base_main_sha": "5b9d49e65295819ee9e8e9c199688c0e2ac73d35",
+  "reviewed_sources": [
+    "crates/rustok-commerce/docs/implementation-plan.md",
+    "crates/rustok-order/storefront/Cargo.toml",
+    "crates/rustok-order/storefront/src/transport.rs",
+    "crates/rustok-order/storefront/src/transport/graphql_adapter.rs",
+    "crates/rustok-order/storefront/src/transport/graphql_error_safety.rs",
+    "crates/rustok-order/storefront/src/transport/native_server_adapter/server_functions.rs",
+    "crates/rustok-ui-transport/src/lib.rs",
+    "crates/rustok-graphql/src/lib.rs",
+    "scripts/verify/verify-order-storefront-boundary.mjs"
+  ],
+  "findings": [
+    {
+      "id": "order-storefront-graphql-public-detail",
+      "severity": "p1",
+      "finding": "The order storefront facade delegated its selected GraphQL closure directly to the private adapter, so GraphqlHttpError display text was retained in UiTransportError.graphql_error.",
+      "resolution": "Create a per-call owner context at the public consumer boundary and map only CheckoutCompletionTransportError::Graphql to static public envelopes."
+    },
+    {
+      "id": "order-storefront-validation-preservation",
+      "severity": "contract",
+      "finding": "Cart UUID and checkout idempotency-key validation execute inside the private adapter before the GraphQL request.",
+      "resolution": "Pass Validation and ServerFn variants through unchanged and leave the private adapter unmodified."
+    },
+    {
+      "id": "order-storefront-correlation-context",
+      "severity": "contract",
+      "finding": "The client-side GraphQL path had no owner correlation event for failures.",
+      "resolution": "Generate a unique per-call correlation id and retain only tenant configuration, identifier lengths, and create-fulfillment policy in internal diagnostics."
+    }
+  ],
+  "preserved_behavior": [
+    "explicit feature-based transport selection",
+    "no native-to-GraphQL fallback",
+    "private GraphQL mutation and variables",
+    "checkout completion request and response DTOs",
+    "cart UUID and idempotency-key validation",
+    "native server-function error policy",
+    "Commerce owner-facade delegation"
+  ],
+  "execution": {
+    "commands": [],
+    "tests": [],
+    "verifiers": [],
+    "cargo": [],
+    "format": [],
+    "workflows": [],
+    "ci": []
+  },
+  "claims": {
+    "source_reviewed": true,
+    "source_ready": true,
+    "compiled": false,
+    "runtime_verified": false,
+    "mounted_parity_verified": false,
+    "ffa_promoted": false,
+    "fba_promoted": false,
+    "production_promoted": false
+  }
+}

--- a/crates/rustok-order/contracts/evidence/storefront-graphql-error-safety-source.json
+++ b/crates/rustok-order/contracts/evidence/storefront-graphql-error-safety-source.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-30",
+  "status": "order_storefront_graphql_error_safety_source_unvalidated",
+  "scope": "order-owned storefront GraphQL checkout completion transport",
+  "covered_operations": [
+    "complete_storefront_checkout"
+  ],
+  "source_contract": {
+    "public_consumer_boundary_sanitized": true,
+    "private_graphql_adapter_changed": false,
+    "graphql_document_changed": false,
+    "request_response_dto_changed": false,
+    "idempotency_validation_changed": false,
+    "native_server_functions_changed": false,
+    "transport_selection_changed": false,
+    "native_to_graphql_fallback_added": false,
+    "graphql_http_error_reparsed": true,
+    "network_static_public_envelope": true,
+    "http_static_public_envelope": true,
+    "unauthorized_static_public_envelope": true,
+    "graphql_rejection_static_public_envelope": true,
+    "unknown_static_public_envelope": true,
+    "correlation_logging": true,
+    "safe_request_shape_logging": true,
+    "raw_cart_id_logged": false,
+    "raw_idempotency_key_logged": false,
+    "raw_tenant_slug_logged": false,
+    "raw_command_metadata_logged": false,
+    "raw_graphql_error_public": false,
+    "non_graphql_errors_pass_through": true
+  },
+  "stable_public_messages": {
+    "network_or_http": "Checkout completion is temporarily unavailable",
+    "unauthorized": "Checkout authentication is required",
+    "graphql_rejection_or_unknown": "Checkout request could not be completed"
+  },
+  "suggested_execution": [
+    "node scripts/verify/verify-order-storefront-graphql-error-safety.mjs",
+    "node scripts/verify/verify-order-storefront-runtime-error-diagnostics.mjs",
+    "node scripts/verify/verify-order-storefront-boundary.mjs",
+    "node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs",
+    "cargo check -p rustok-order-storefront",
+    "cargo check -p rustok-order-storefront --features hydrate",
+    "cargo check -p rustok-order-storefront --features ssr"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "graphql_runtime_proven": false,
+    "browser_runtime_proven": false,
+    "mounted_parity_proven": false,
+    "production_proven": false
+  }
+}

--- a/crates/rustok-order/docs/storefront-graphql-error-safety.md
+++ b/crates/rustok-order/docs/storefront-graphql-error-safety.md
@@ -1,0 +1,141 @@
+# Order storefront GraphQL error safety
+
+Status: source-unvalidated
+
+## Scope
+
+This source slice hardens the order-owned storefront GraphQL transport for the
+single public checkout-completion operation:
+
+- `complete_storefront_checkout`.
+
+The storefront facade remains the public transport consumer. The low-level
+GraphQL adapter remains private and continues to own the mutation document,
+variables, response decoding, cart UUID validation, checkout idempotency-key
+validation, and DTO mapping.
+
+## Previous gap
+
+The selected GraphQL closure delegated directly to the private adapter. The
+adapter converted `GraphqlHttpError` into
+`CheckoutCompletionTransportError::Graphql(error.to_string())`, and
+`execute_selected_transport` retained that display string in the public
+`UiTransportError.graphql_error` field.
+
+Consequently, server-provided GraphQL messages and HTTP status details could
+cross the storefront UI boundary without an order-owned public-envelope policy.
+The native server-function path already had a separate sanitized runtime policy,
+but that policy did not cover the GraphQL path.
+
+## Public consumer policy
+
+`transport.rs` now creates a private `GraphqlCallContext` before invoking the
+GraphQL adapter. The context reparses the adapter's display handoff through
+`GraphqlHttpError::from_str` and maps only the `Graphql` transport variant.
+
+The stable public messages are:
+
+| Typed failure | Public message |
+| --- | --- |
+| network | `Checkout completion is temporarily unavailable` |
+| HTTP | `Checkout completion is temporarily unavailable` |
+| unauthorized | `Checkout authentication is required` |
+| GraphQL rejection | `Checkout request could not be completed` |
+| unknown display envelope | `Checkout request could not be completed` |
+
+`Validation` and `ServerFn` variants are returned unchanged. This preserves the
+existing validation order and the independent native transport policy.
+
+## Correlation diagnostics
+
+Every selected GraphQL call creates a unique correlation identifier using the
+owner operation and a new UUID. Internal tracing events retain:
+
+- owner `rustok_order.storefront`;
+- owner operation `complete_storefront_checkout`;
+- boundary `order_storefront_graphql_transport`;
+- correlation identifier;
+- typed error kind and stable code;
+- raw and reparsed GraphQL cause for internal diagnosis;
+- whether a tenant slug is configured and its character length;
+- cart-id character length;
+- idempotency-key character length;
+- the `create_fulfillment` policy flag.
+
+The mapper does not log the raw tenant slug, cart id, idempotency key, command
+metadata, GraphQL endpoint, mutation, variables, tokens, or returned checkout
+objects.
+
+Technical network, HTTP, and unknown failures use error-level diagnostics.
+Unauthorized and ordinary GraphQL rejection use warning-level diagnostics.
+
+## Preserved behavior
+
+This slice does not change:
+
+- feature-based `NativeServer` versus `Graphql` selection;
+- the no-fallback transport policy;
+- the private GraphQL adapter;
+- `COMPLETE_STOREFRONT_CHECKOUT_MUTATION`;
+- GraphQL variables or response DTOs;
+- cart UUID validation;
+- the 1-to-191-byte checkout idempotency-key rule;
+- checkout command metadata;
+- native server functions or native runtime mapping;
+- Commerce delegation to the order-owned storefront facade.
+
+The adapter still creates the exact typed GraphQL display handoff. Sanitization
+occurs once at the public consumer boundary, avoiding duplicate diagnostics and
+preserving adapter ownership.
+
+## Source guard
+
+The focused verifier is:
+
+```bash
+node scripts/verify/verify-order-storefront-graphql-error-safety.mjs
+```
+
+It checks the typed mapping policy, static public messages, stable codes,
+correlation and safe request-shape diagnostics, GraphQL-only remapping,
+private-adapter preservation, native-path preservation, evidence status, and
+validation nonclaims.
+
+The general owner boundary verifier imports the focused guard:
+
+```bash
+node scripts/verify/verify-order-storefront-boundary.mjs
+```
+
+## Evidence boundary
+
+Retained source evidence:
+
+- `crates/rustok-order/contracts/evidence/storefront-graphql-error-safety-source.json`;
+- `crates/rustok-order/contracts/evidence/storefront-graphql-error-safety-source-review.json`.
+
+The evidence establishes only that the source and guardrail are present and
+have been reviewed. It does not establish compilation, browser execution,
+GraphQL runtime behavior, mounted Commerce parity, workflow success, CI success,
+or production behavior.
+
+The broad ecommerce correlation-safe mapper cleanup remains open.
+
+No tests, verifiers, Cargo commands, formatting, workflows, or CI were run per
+maintainer instruction.
+
+## Suggested maintainer verification
+
+```bash
+node scripts/verify/verify-order-storefront-graphql-error-safety.mjs
+node scripts/verify/verify-order-storefront-runtime-error-diagnostics.mjs
+node scripts/verify/verify-order-storefront-boundary.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-order-storefront
+cargo check -p rustok-order-storefront --features hydrate
+cargo check -p rustok-order-storefront --features ssr
+```
+
+Source readiness must remain separate from runtime or promotion claims until
+those commands and the required mounted failure evidence are retained on the
+same revision.

--- a/crates/rustok-order/storefront/src/transport.rs
+++ b/crates/rustok-order/storefront/src/transport.rs
@@ -1,4 +1,5 @@
 mod graphql_adapter;
+mod graphql_error_safety;
 mod native_server_adapter;
 
 use std::fmt::{Display, Formatter};
@@ -94,7 +95,12 @@ pub async fn complete_checkout(
         "order",
         selected_transport_path(),
         move || native_server_adapter::complete_checkout(native_request),
-        move || graphql_adapter::complete_checkout(request),
+        move || async move {
+            let context = graphql_error_safety::GraphqlCallContext::new(&request);
+            graphql_adapter::complete_checkout(request)
+                .await
+                .map_err(|error| context.map_error(error))
+        },
     )
     .await
 }

--- a/crates/rustok-order/storefront/src/transport/graphql_error_safety.rs
+++ b/crates/rustok-order/storefront/src/transport/graphql_error_safety.rs
@@ -1,0 +1,129 @@
+use std::str::FromStr;
+
+use rustok_graphql::GraphqlHttpError;
+use uuid::Uuid;
+
+use super::{CheckoutCompletionTransportError, CompleteCheckoutRequest};
+
+const ORDER_STOREFRONT_GRAPHQL_OWNER: &str = "rustok_order.storefront";
+const ORDER_STOREFRONT_GRAPHQL_OPERATION: &str = "complete_storefront_checkout";
+const ORDER_STOREFRONT_GRAPHQL_BOUNDARY: &str = "order_storefront_graphql_transport";
+
+pub(super) struct GraphqlCallContext {
+    correlation_id: String,
+    tenant_slug_length: Option<usize>,
+    cart_id_length: usize,
+    idempotency_key_length: usize,
+    create_fulfillment: bool,
+}
+
+impl GraphqlCallContext {
+    pub(super) fn new(request: &CompleteCheckoutRequest) -> Self {
+        Self {
+            correlation_id: format!(
+                "order-storefront-graphql:{}:{}",
+                ORDER_STOREFRONT_GRAPHQL_OPERATION,
+                Uuid::new_v4()
+            ),
+            tenant_slug_length: configured_tenant_slug_length(),
+            cart_id_length: request.cart_id.chars().count(),
+            idempotency_key_length: request.idempotency_key.chars().count(),
+            create_fulfillment: request.metadata.create_fulfillment,
+        }
+    }
+
+    pub(super) fn map_error(
+        &self,
+        error: CheckoutCompletionTransportError,
+    ) -> CheckoutCompletionTransportError {
+        let CheckoutCompletionTransportError::Graphql(raw_error) = error else {
+            return error;
+        };
+        let parsed_error = GraphqlHttpError::from_str(raw_error.as_str());
+        let (error_kind, code, public_message, technical_failure) = match &parsed_error {
+            Ok(GraphqlHttpError::Network) => (
+                "network",
+                "order.storefront_graphql_network_unavailable",
+                "Checkout completion is temporarily unavailable",
+                true,
+            ),
+            Ok(GraphqlHttpError::Http(_)) => (
+                "http",
+                "order.storefront_graphql_http_unavailable",
+                "Checkout completion is temporarily unavailable",
+                true,
+            ),
+            Ok(GraphqlHttpError::Unauthorized) => (
+                "unauthorized",
+                "order.storefront_graphql_authentication_required",
+                "Checkout authentication is required",
+                false,
+            ),
+            Ok(GraphqlHttpError::Graphql(_)) => (
+                "graphql",
+                "order.storefront_graphql_request_rejected",
+                "Checkout request could not be completed",
+                false,
+            ),
+            Err(_) => (
+                "unknown",
+                "order.storefront_graphql_unknown_failure",
+                "Checkout request could not be completed",
+                true,
+            ),
+        };
+
+        if technical_failure {
+            tracing::error!(
+                raw_error = %raw_error,
+                parsed_error = ?parsed_error,
+                owner = ORDER_STOREFRONT_GRAPHQL_OWNER,
+                owner_operation = ORDER_STOREFRONT_GRAPHQL_OPERATION,
+                correlation_id = %self.correlation_id,
+                tenant_slug_configured = self.tenant_slug_length.is_some(),
+                tenant_slug_length = ?self.tenant_slug_length,
+                cart_id_length = self.cart_id_length,
+                idempotency_key_length = self.idempotency_key_length,
+                create_fulfillment = self.create_fulfillment,
+                error_kind,
+                code,
+                boundary = ORDER_STOREFRONT_GRAPHQL_BOUNDARY,
+                "order storefront GraphQL transport failed"
+            );
+        } else {
+            tracing::warn!(
+                raw_error = %raw_error,
+                parsed_error = ?parsed_error,
+                owner = ORDER_STOREFRONT_GRAPHQL_OWNER,
+                owner_operation = ORDER_STOREFRONT_GRAPHQL_OPERATION,
+                correlation_id = %self.correlation_id,
+                tenant_slug_configured = self.tenant_slug_length.is_some(),
+                tenant_slug_length = ?self.tenant_slug_length,
+                cart_id_length = self.cart_id_length,
+                idempotency_key_length = self.idempotency_key_length,
+                create_fulfillment = self.create_fulfillment,
+                error_kind,
+                code,
+                boundary = ORDER_STOREFRONT_GRAPHQL_BOUNDARY,
+                "order storefront GraphQL request was rejected"
+            );
+        }
+
+        CheckoutCompletionTransportError::Graphql(public_message.to_string())
+    }
+}
+
+fn configured_tenant_slug_length() -> Option<usize> {
+    [
+        "RUSTOK_TENANT_SLUG",
+        "NEXT_PUBLIC_TENANT_SLUG",
+        "NEXT_PUBLIC_DEFAULT_TENANT_SLUG",
+    ]
+    .into_iter()
+    .find_map(|key| {
+        std::env::var(key).ok().and_then(|value| {
+            let value = value.trim();
+            (!value.is_empty()).then_some(value.chars().count())
+        })
+    })
+}

--- a/scripts/verify/verify-order-storefront-boundary.mjs
+++ b/scripts/verify/verify-order-storefront-boundary.mjs
@@ -7,6 +7,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import "./verify-order-storefront-runtime-error-diagnostics.mjs";
+import "./verify-order-storefront-graphql-error-safety.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
@@ -94,6 +95,7 @@ for (const marker of ["leptos::", "#[component]", "#[server", "GraphqlRequest", 
 for (const marker of ["CompleteCheckoutRequest", "CheckoutCompletion", "build_complete_checkout_request", "complete_checkout", "mod graphql_adapter;", "normalize_required"]) {
   assertContains(transport, marker, `${transportPath}: expected transport-owned request marker ${marker}`);
 }
+assertContains(transport, "mod graphql_error_safety;", `${transportPath}: order transport facade must wire GraphQL error safety`);
 assertContains(transport, "mod native_server_adapter;", `${transportPath}: order transport facade must wire native server adapter`);
 for (const marker of ["leptos::", "#[component]", "#[server", "GraphqlRequest", "web_sys::"]) {
   assertNotContains(transport, marker, `${transportPath}: transport facade must stay framework/native-endpoint free (${marker})`);

--- a/scripts/verify/verify-order-storefront-graphql-error-safety.mjs
+++ b/scripts/verify/verify-order-storefront-graphql-error-safety.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const rootPath = configuredRoot
+  ? path.resolve(configuredRoot)
+  : fileURLToPath(new URL('../../', import.meta.url));
+const read = (relativePath) => readFileSync(path.join(rootPath, relativePath), 'utf8');
+
+const cargo = read('crates/rustok-order/storefront/Cargo.toml');
+const transport = read('crates/rustok-order/storefront/src/transport.rs');
+const adapter = read('crates/rustok-order/storefront/src/transport/graphql_adapter.rs');
+const safety = read('crates/rustok-order/storefront/src/transport/graphql_error_safety.rs');
+const native = read(
+  'crates/rustok-order/storefront/src/transport/native_server_adapter/server_functions.rs',
+);
+const docs = read('crates/rustok-order/docs/storefront-graphql-error-safety.md');
+const evidence = JSON.parse(
+  read('crates/rustok-order/contracts/evidence/storefront-graphql-error-safety-source.json'),
+);
+
+const failures = [];
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const countText = (content, value) => content.split(value).length - 1;
+
+for (const [value, label] of [
+  ['rustok-graphql.workspace = true', 'typed GraphQL error dependency'],
+  ['tracing.workspace = true', 'structured diagnostics dependency'],
+  ['uuid.workspace = true', 'correlation id dependency'],
+]) requireText(cargo, value, label);
+
+for (const [value, label] of [
+  ['mod graphql_error_safety;', 'private GraphQL safety module'],
+  ['let context = graphql_error_safety::GraphqlCallContext::new(&request);', 'per-call context'],
+  ['graphql_adapter::complete_checkout(request)', 'private adapter delegation'],
+  ['.map_err(|error| context.map_error(error))', 'consumer-boundary mapper'],
+  ['move || native_server_adapter::complete_checkout(native_request)', 'native path preservation'],
+  ['selected_transport_path()', 'explicit selected transport'],
+]) requireText(transport, value, label);
+
+for (const [value, label] of [
+  ['pub(super) struct GraphqlCallContext', 'private call context'],
+  ['ORDER_STOREFRONT_GRAPHQL_OWNER', 'owner constant'],
+  ['ORDER_STOREFRONT_GRAPHQL_OPERATION', 'owner operation constant'],
+  ['ORDER_STOREFRONT_GRAPHQL_BOUNDARY', 'boundary constant'],
+  ['GraphqlHttpError::from_str(raw_error.as_str())', 'typed display reparse'],
+  ['let CheckoutCompletionTransportError::Graphql(raw_error) = error else', 'GraphQL-only mapping'],
+  ['return error;', 'non-GraphQL pass-through'],
+  ['Uuid::new_v4()', 'unique correlation id'],
+  ['correlation_id = %self.correlation_id', 'correlation diagnostics'],
+  ['tenant_slug_configured = self.tenant_slug_length.is_some()', 'tenant configured fact'],
+  ['tenant_slug_length = ?self.tenant_slug_length', 'tenant length fact'],
+  ['cart_id_length = self.cart_id_length', 'cart id length fact'],
+  ['idempotency_key_length = self.idempotency_key_length', 'idempotency length fact'],
+  ['create_fulfillment = self.create_fulfillment', 'fulfillment policy fact'],
+  ['raw_error = %raw_error', 'internal raw cause diagnostics'],
+  ['parsed_error = ?parsed_error', 'typed cause diagnostics'],
+  ['boundary = ORDER_STOREFRONT_GRAPHQL_BOUNDARY', 'boundary diagnostics'],
+]) requireText(safety, value, label);
+
+for (const [value, label] of [
+  ['order.storefront_graphql_network_unavailable', 'network stable code'],
+  ['order.storefront_graphql_http_unavailable', 'HTTP stable code'],
+  ['order.storefront_graphql_authentication_required', 'authentication stable code'],
+  ['order.storefront_graphql_request_rejected', 'GraphQL rejection stable code'],
+  ['order.storefront_graphql_unknown_failure', 'unknown stable code'],
+  ['Checkout completion is temporarily unavailable', 'technical public message'],
+  ['Checkout authentication is required', 'authentication public message'],
+  ['Checkout request could not be completed', 'rejection public message'],
+  ['CheckoutCompletionTransportError::Graphql(public_message.to_string())', 'static public envelope'],
+]) requireText(safety, value, label);
+
+for (const [value, label] of [
+  ['COMPLETE_STOREFRONT_CHECKOUT_MUTATION', 'checkout mutation'],
+  ['checkout idempotency key must contain 1 to 191 bytes', 'idempotency validation'],
+  ['cart_id must be a valid UUID', 'cart UUID validation'],
+  ['CheckoutCompletionTransportError::Graphql(error.to_string())', 'private adapter handoff'],
+  ['configured_tenant_slug()', 'tenant configuration handoff'],
+]) requireText(adapter, value, label);
+
+if (countText(adapter, 'CheckoutCompletionTransportError::Graphql(error.to_string())') !== 1) {
+  failures.push('private adapter must retain exactly one typed GraphQL display handoff');
+}
+if (countText(transport, 'graphql_error_safety::GraphqlCallContext::new(&request)') !== 1) {
+  failures.push('the sole public GraphQL operation must create exactly one call context');
+}
+
+for (const value of [
+  'move || graphql_adapter::complete_checkout(request)',
+  'UiTransportError::graphql("order", error)',
+]) forbidText(transport, value, 'unsanitized public GraphQL delegation');
+
+for (const value of [
+  'tenant_slug = %',
+  'cart_id = %',
+  'idempotency_key = %',
+  'metadata = ?',
+  'source_module = %',
+  'source_surface = %',
+  'command = %',
+  'owner_module = %',
+]) forbidText(safety, value, 'raw request diagnostics');
+
+for (const [value, label] of [
+  ['CheckoutCompletionTransportError::ServerFn(', 'native outer transport variant'],
+  ['Checkout transport is temporarily unavailable', 'native outer public message'],
+  ['native_checkout_runtime_error', 'native runtime mapper'],
+  ['complete_storefront_checkout', 'native owner operation'],
+]) requireText(native, value, label);
+
+for (const [value, label] of [
+  ['Status: source-unvalidated', 'documentation source status'],
+  ['The broad ecommerce correlation-safe mapper cleanup remains open.', 'broad-plan nonclaim'],
+  ['No tests, verifiers, Cargo commands, formatting, workflows, or CI were run', 'execution nonclaim'],
+]) requireText(docs, value, label);
+
+if (evidence.status !== 'order_storefront_graphql_error_safety_source_unvalidated') {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  public_consumer_boundary_sanitized: true,
+  private_graphql_adapter_changed: false,
+  graphql_document_changed: false,
+  request_response_dto_changed: false,
+  idempotency_validation_changed: false,
+  native_server_functions_changed: false,
+  transport_selection_changed: false,
+  native_to_graphql_fallback_added: false,
+  graphql_http_error_reparsed: true,
+  raw_cart_id_logged: false,
+  raw_idempotency_key_logged: false,
+  raw_tenant_slug_logged: false,
+  raw_command_metadata_logged: false,
+  raw_graphql_error_public: false,
+  non_graphql_errors_pass_through: true,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  'tests_run',
+  'cargo_run',
+  'format_run',
+  'verifiers_run',
+  'workflow_checks_run',
+  'ci_run',
+  'graphql_runtime_proven',
+  'browser_runtime_proven',
+  'mounted_parity_proven',
+  'production_proven',
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Order storefront GraphQL error-safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ order storefront GraphQL failures retain correlation diagnostics and static public envelopes; runtime evidence remains open',
+);


### PR DESCRIPTION
## Summary
- add a private order storefront GraphQL error-safety policy at the public transport consumer boundary
- preserve the existing private GraphQL adapter, checkout mutation, variables, response DTOs, cart UUID validation, idempotency validation, native server functions, and explicit transport selection
- route `complete_storefront_checkout` through a per-call context with a unique correlation id
- reparse the adapter's `GraphqlHttpError` display handoff into typed network, HTTP, unauthorized, GraphQL rejection, and unknown policies
- keep raw GraphQL details in structured internal diagnostics only and expose static `CheckoutCompletionTransportError::Graphql` messages through `UiTransportError.graphql_error`
- retain only safe request-shape facts: tenant/cart/idempotency lengths and the create-fulfillment policy; never raw identifiers, keys, or command metadata
- pass validation and native errors through unchanged
- add a focused source verifier, include it in the Order storefront boundary aggregate, and retain unvalidated source/review evidence plus documentation

## Covered operation
- `complete_storefront_checkout`

## Public policy
- network / HTTP: `Checkout completion is temporarily unavailable`
- unauthorized: `Checkout authentication is required`
- GraphQL rejection / unknown: `Checkout request could not be completed`

## Preserved behavior
- no native-to-GraphQL fallback
- feature-based transport selection unchanged
- private adapter and GraphQL document unchanged
- checkout completion request/response DTOs unchanged
- cart UUID and 1-to-191-byte idempotency-key validation unchanged
- native server functions and native runtime error policy unchanged
- Commerce owner-facade delegation unchanged

## Evidence boundary
Source status is `order_storefront_graphql_error_safety_source_unvalidated`. The broad ecommerce correlation-safe mapper cleanup remains open. No FFA, FBA, browser, GraphQL runtime, mounted parity, workflow, CI, or production status is promoted.

## Verification
The ecommerce master plan, Order storefront facade/private adapter/native runtime policy, `GraphqlHttpError` variants and display handoff, `UiTransportError` public storage, final source files, and the seven-file ahead-only diff were reviewed.

Tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run per maintainer instruction.