### PR TITLE
fix(profiles): make locale Search invalidation atomic

### DIFF
--- a/crates/rustok-forum/contracts/forum-search-public-author-summary.json
+++ b/crates/rustok-forum/contracts/forum-search-public-author-summary.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "task": "FORUM-23A",
-  "latest_slice": "FORUM-23A4",
+  "latest_slice": "FORUM-23A5",
   "upstream_task": "FORUM-20BQ",
   "status": "source_complete_execution_pending",
   "scope": "Project privacy-aware public author summaries into Forum topic and approved-reply Search documents and durably redact them after Profiles owner changes",
@@ -13,6 +13,7 @@
   "profiles_visibility_event_owner": "crates/rustok-profiles/src/visibility_write.rs",
   "profiles_handle_event_owner": "crates/rustok-profiles/src/handle_write.rs",
   "profiles_content_event_owner": "crates/rustok-profiles/src/content_write.rs",
+  "profiles_locale_event_owner": "crates/rustok-profiles/src/locale_write.rs",
   "profiles_media_event_owner": "crates/rustok-profiles/src/media_write.rs",
   "search_inbox": "crates/rustok-search/src/forum_inbox.rs",
   "search_ingestion": "crates/rustok-search/src/ingestion.rs",
@@ -49,6 +50,9 @@
     "handle_event_failure_rolls_back_owner_write": true,
     "profile_content_write_and_event_are_atomic": true,
     "content_event_failure_rolls_back_owner_write": true,
+    "profile_locale_write_and_event_are_atomic": true,
+    "locale_event_failure_rolls_back_owner_write": true,
+    "locale_write_does_not_create_translations": true,
     "profile_media_write_and_event_are_atomic": true,
     "media_event_failure_rolls_back_owner_write": true,
     "remaining_profile_summary_write_and_event_pairs_are_atomic": false,
@@ -71,7 +75,7 @@
   "remaining_scope": [
     "replace remaining wall-clock Forum projection ordering with owner-issued monotonic revisions",
     "define an owner-ordered profile or account deletion projection invalidation contract",
-    "make profile upsert and locale summary update events atomic with their owner writes",
+    "make profile upsert summary update event atomic with its owner writes",
     "add bounded category-subtree tag locale date solved kind channel/group and attachment filters",
     "add member index projections",
     "capture maintainer-executed PostgreSQL rebuild redaction and query evidence"
@@ -94,7 +98,7 @@
     "UserDeleted is sufficient to prove Profiles state has already been removed",
     "account deletion redaction is complete",
     "all ProfileUpdated owner writes are transactionally coupled to outbox publication",
-    "profile upsert and locale updates are transactionally coupled to ProfileUpdated publication",
+    "profile upsert is transactionally coupled to ProfileUpdated publication",
     "general cross-producer owner revision ordering is complete"
   ],
   "downstream_task": "FORUM-23B"

--- a/crates/rustok-forum/docs/forum-23a-search-public-author-summary.md
+++ b/crates/rustok-forum/docs/forum-23a-search-public-author-summary.md
@@ -4,7 +4,7 @@ Date: 2026-07-30
 
 Status: `source_complete_execution_pending`
 
-Latest slice: `FORUM-23A4`
+Latest slice: `FORUM-23A5`
 
 This slice advances the canonical `FORUM-23` visibility-aware Search track. Public Forum topic
 and approved-reply documents obtain author presentation from the Profiles owner instead of
@@ -61,15 +61,23 @@ publication fails, the media owner write is rolled back. A new public avatar the
 commit while Forum Search retains the previous `avatar_media_id` because its invalidation was lost.
 Banner remains owner data and is never serialized into Forum Search.
 
-Visibility, handle, content, and media paths use the shared transactional publisher in
+`FORUM-23A5` applies the same rule to `update_my_profile_locale`. The preferred locale is normalized
+before the owner transaction. The tenant-scoped profile row, revision timestamp, and durable
+`ProfileUpdated` envelope then commit together. If publication fails, the locale write is rolled
+back. The path preserves the existing selection-only rule: changing preferred locale does not copy,
+insert, or update localized display content. A locale change can therefore switch the public
+fallback `display_name` without leaving Forum Search on the previous owner presentation because its
+invalidation was lost.
+
+Visibility, handle, content, locale, and media paths use the shared transactional publisher in
 `crates/rustok-profiles/src/profile_updated_event.rs`, so their event envelope and retryable error
-classification cannot drift independently. Profile upsert and locale mutations still publish
-after their owner writes and are not claimed to be transactionally coupled.
+classification cannot drift independently. Profile upsert still publishes after its owner writes
+and is not claimed to be transactionally coupled.
 
 The event is stored under `forum_author:<user_id>`. This scope is intentionally a redaction
 barrier: it is not stale-skipped against the unrelated full Forum wall-clock watermark. The
 consumer rebuilds the Forum tenant projection from current owner state, so committed visibility,
-handle, public display-name, and avatar changes replace stale Search presentation.
+handle, public display-name, locale-selection, and avatar changes replace stale Search presentation.
 
 The existing tenant advisory lock, durable retry, dead-letter bound, and periodic/opportunistic
 inbox reconciliation remain unchanged. This slice does not claim that general Forum producer
@@ -99,7 +107,7 @@ Existing Search document rows are replaced by the next Forum rebuild or relevant
 
 - owner-issued monotonic projection revisions across Forum producers;
 - an owner-ordered profile or account deletion invalidation contract;
-- transactionally couple profile upsert and locale summary updates to their owner events;
+- transactionally couple profile upsert to its owner event;
 - bounded category-subtree, tag, locale, date, solved, kind, channel/group, attachment, and
   remaining author filters;
 - member Search projections;

--- a/crates/rustok-profiles/src/graphql/mutation.rs
+++ b/crates/rustok-profiles/src/graphql/mutation.rs
@@ -15,8 +15,9 @@ use uuid::Uuid;
 use crate::{
     ProfileError, ProfileMediaSlot, ProfileOperation, ProfileOperationTimer, ProfileRecord,
     ProfileResult, ProfileService, content_write::update_profile_content_with_event,
-    handle_write::update_profile_handle_with_event, media_write::update_profile_media_with_event,
-    validate_profile_media_asset, visibility_write::update_profile_visibility_with_event,
+    handle_write::update_profile_handle_with_event, locale_write::update_profile_locale_with_event,
+    media_write::update_profile_media_with_event, validate_profile_media_asset,
+    visibility_write::update_profile_visibility_with_event,
 };
 
 use super::{MODULE_SLUG, types::*};
@@ -138,21 +139,22 @@ impl ProfilesMutation {
         let db = ctx.data::<DatabaseConnection>()?;
         let event_bus = ctx.data::<TransactionalEventBus>()?;
         let tenant = ctx.data::<TenantContext>()?;
-        let service = ProfileService::new(db.clone());
 
         let profile = observe_profile_write(
             ProfileOperation::UpdateLocale,
             tenant.id,
             auth.user_id,
-            service.update_profile_locale(
+            update_profile_locale_with_event(
+                db,
+                event_bus,
                 tenant.id,
+                auth.user_id,
                 auth.user_id,
                 preferred_locale.as_deref(),
                 Some(tenant.default_locale.as_str()),
             ),
         )
         .await?;
-        publish_profile_updated(event_bus, tenant.id, auth.user_id, &profile).await?;
 
         Ok(profile.into())
     }

--- a/crates/rustok-profiles/src/lib.rs
+++ b/crates/rustok-profiles/src/lib.rs
@@ -10,6 +10,7 @@ pub mod error;
 pub mod graphql;
 mod handle_write;
 pub mod loader;
+mod locale_write;
 pub mod media;
 mod media_write;
 pub mod migrations;

--- a/crates/rustok-profiles/src/locale_write.rs
+++ b/crates/rustok-profiles/src/locale_write.rs
@@ -1,0 +1,66 @@
+use chrono::Utc;
+use rustok_outbox::TransactionalEventBus;
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, Set,
+    TransactionTrait,
+};
+use uuid::Uuid;
+
+use crate::{
+    ProfileError, ProfileRecord, ProfileResult, ProfileService, entities,
+    profile_updated_event::publish_profile_updated_in_tx,
+};
+
+pub(crate) async fn update_profile_locale_with_event(
+    db: &DatabaseConnection,
+    event_bus: &TransactionalEventBus,
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    user_id: Uuid,
+    preferred_locale: Option<&str>,
+    tenant_default_locale: Option<&str>,
+) -> ProfileResult<ProfileRecord> {
+    let preferred_locale = ProfileService::normalize_locale(preferred_locale)?;
+    let requested_locale = preferred_locale
+        .clone()
+        .or(ProfileService::normalize_locale(tenant_default_locale)?)
+        .ok_or_else(|| {
+            ProfileError::InvalidLocale("effective profile locale is required".to_string())
+        })?;
+
+    let txn = db.begin().await?;
+    let profile = entities::profile::Entity::find_by_id(user_id)
+        .filter(entities::profile::Column::TenantId.eq(tenant_id))
+        .one(&txn)
+        .await?
+        .ok_or(ProfileError::ProfileNotFound(user_id))?;
+
+    let mut active: entities::profile::ActiveModel = profile.into();
+    active.preferred_locale = Set(preferred_locale);
+    active.updated_at = Set(Utc::now().into());
+    let profile = active.update(&txn).await?;
+
+    // Locale preference changes selection policy only. They must never copy
+    // localized display copy into a different locale or create a translation.
+    if let Err(error) =
+        publish_profile_updated_in_tx(event_bus, &txn, tenant_id, actor_id, &profile).await
+    {
+        tracing::error!(
+            tenant_id = %tenant_id,
+            user_id = %profile.user_id,
+            "Profile locale event publication failed; rolling back owner write"
+        );
+        txn.rollback().await?;
+        return Err(error);
+    }
+    txn.commit().await?;
+
+    ProfileService::new(db.clone())
+        .get_profile(
+            tenant_id,
+            user_id,
+            Some(requested_locale.as_str()),
+            tenant_default_locale,
+        )
+        .await
+}

--- a/scripts/verify/verify-forum-search-public-author-summary.mjs
+++ b/scripts/verify/verify-forum-search-public-author-summary.mjs
@@ -44,6 +44,7 @@ const profilesMutationPath = "crates/rustok-profiles/src/graphql/mutation.rs";
 const profilesUpdatedEventPath = "crates/rustok-profiles/src/profile_updated_event.rs";
 const profilesContentWritePath = "crates/rustok-profiles/src/content_write.rs";
 const profilesHandleWritePath = "crates/rustok-profiles/src/handle_write.rs";
+const profilesLocaleWritePath = "crates/rustok-profiles/src/locale_write.rs";
 const profilesMediaWritePath = "crates/rustok-profiles/src/media_write.rs";
 const profilesVisibilityWritePath = "crates/rustok-profiles/src/visibility_write.rs";
 const profilesErrorPath = "crates/rustok-profiles/src/error.rs";
@@ -61,6 +62,7 @@ const profilesMutation = read(profilesMutationPath);
 const profilesUpdatedEvent = read(profilesUpdatedEventPath);
 const profilesContentWrite = read(profilesContentWritePath);
 const profilesHandleWrite = read(profilesHandleWritePath);
+const profilesLocaleWrite = read(profilesLocaleWritePath);
 const profilesMediaWrite = read(profilesMediaWritePath);
 const profilesVisibilityWrite = read(profilesVisibilityWritePath);
 const profilesError = read(profilesErrorPath);
@@ -121,6 +123,7 @@ for (const marker of [
 for (const marker of [
   "mod content_write;",
   "mod handle_write;",
+  "mod locale_write;",
   "mod media_write;",
   "mod profile_updated_event;",
   "mod visibility_write;",
@@ -130,10 +133,10 @@ for (const marker of [
 for (const marker of [
   "update_profile_content_with_event(",
   "update_profile_handle_with_event(",
+  "update_profile_locale_with_event(",
   "update_profile_media_with_event(",
   "update_profile_visibility_with_event(",
   "service.upsert_profile(",
-  "service.update_profile_locale(",
   "publish_profile_updated(event_bus, tenant.id, auth.user_id, &profile).await?",
   "DomainEvent::ProfileUpdated",
   "ProfileError::EventPublishUnavailable",
@@ -143,6 +146,7 @@ for (const marker of [
 for (const forbidden of [
   "service.update_profile_content(",
   "service.update_profile_handle(",
+  "service.update_profile_locale(",
   "service.update_profile_media(",
   "service.update_profile_visibility(",
 ]) {
@@ -216,6 +220,35 @@ requireOrder(
   "publish_profile_updated_in_tx",
   "txn.commit().await?",
   profilesHandleWritePath,
+);
+
+for (const marker of [
+  "ProfileService::normalize_locale(preferred_locale)?",
+  "ProfileService::normalize_locale(tenant_default_locale)?",
+  "db.begin().await?",
+  "Column::TenantId.eq(tenant_id)",
+  "active.preferred_locale = Set(preferred_locale)",
+  ".update(&txn).await?",
+  "selection policy only",
+  "publish_profile_updated_in_tx",
+  "txn.rollback().await?",
+  "txn.commit().await?",
+  "Profile locale event publication failed; rolling back owner write",
+]) {
+  requireMarker(profilesLocaleWrite, marker, profilesLocaleWritePath);
+}
+rejectMarker(profilesLocaleWrite, "profile_translation", profilesLocaleWritePath);
+requireOrder(
+  profilesLocaleWrite,
+  ".update(&txn).await?",
+  "publish_profile_updated_in_tx",
+  profilesLocaleWritePath,
+);
+requireOrder(
+  profilesLocaleWrite,
+  "publish_profile_updated_in_tx",
+  "txn.commit().await?",
+  profilesLocaleWritePath,
 );
 
 for (const marker of [
@@ -295,7 +328,7 @@ for (const marker of [
 rejectMarker(ingestion, "DomainEvent::UserDeleted", ingestionPath);
 
 for (const marker of [
-  "FORUM-23A4",
+  "FORUM-23A5",
   "ProfilePresentationService",
   "forum_author:<user_id>",
   "raw `payload.author_id`",
@@ -303,10 +336,11 @@ for (const marker of [
   "same Profiles-owned database transaction",
   "update_my_profile_handle",
   "update_my_profile_content",
+  "update_my_profile_locale",
   "update_my_profile_media",
   "shared transactional publisher",
   "actual Profiles owner model",
-  "Profile upsert and locale",
+  "Profile upsert still",
   "does not treat `UserDeleted`",
   "not run by the implementation agent",
 ]) {
@@ -315,7 +349,7 @@ for (const marker of [
 
 if (contract) {
   if (contract.task !== "FORUM-23A") failures.push(`${contractPath}: unexpected task`);
-  if (contract.latest_slice !== "FORUM-23A4") {
+  if (contract.latest_slice !== "FORUM-23A5") {
     failures.push(`${contractPath}: unexpected latest slice`);
   }
   if (contract.status !== "source_complete_execution_pending") {
@@ -349,6 +383,9 @@ if (contract) {
     "handle_event_failure_rolls_back_owner_write",
     "profile_content_write_and_event_are_atomic",
     "content_event_failure_rolls_back_owner_write",
+    "profile_locale_write_and_event_are_atomic",
+    "locale_event_failure_rolls_back_owner_write",
+    "locale_write_does_not_create_translations",
     "profile_media_write_and_event_are_atomic",
     "media_event_failure_rolls_back_owner_write",
     "author_scope_is_tenant_and_user_scoped",
@@ -383,7 +420,7 @@ if (contract) {
   for (const nonClaim of [
     "account deletion redaction is complete",
     "all ProfileUpdated owner writes are transactionally coupled to outbox publication",
-    "profile upsert and locale updates are transactionally coupled to ProfileUpdated publication",
+    "profile upsert is transactionally coupled to ProfileUpdated publication",
   ]) {
     if (!contract.non_claims?.includes(nonClaim)) {
       failures.push(`${contractPath}: missing non-claim ${nonClaim}`);


### PR DESCRIPTION
## Summary

Implements `FORUM-23A5`, the next bounded public-author Search hardening slice.

- normalize preferred locale before opening the Profiles owner transaction;
- write the tenant-scoped preferred locale, profile revision timestamp, and `ProfileUpdated` outbox envelope in one transaction;
- roll back the locale write when durable event publication fails;
- preserve the existing selection-only rule: locale changes never copy, insert, or update localized display content;
- route `update_my_profile_locale` through the atomic owner helper;
- update the Forum public-author contract, owner note, and static verifier.

## Compatibility

No migration, public GraphQL schema, Search query API, dependency, or `Cargo.lock` change.

## Verification

Not run by the implementation agent, per maintainer instruction. Suggested commands:

```bash
cargo check -p rustok-profiles --all-targets
cargo test -p rustok-profiles error -- --nocapture
cargo test -p rustok-forum search_projection_author -- --nocapture
cargo test -p rustok-search forum_inbox -- --nocapture
cargo test -p rustok-search ingestion -- --nocapture
node scripts/verify/verify-forum-search-public-author-summary.mjs
node scripts/verify/verify-forum-search-projection.mjs
cargo xtask module validate profiles
cargo xtask module validate forum
```

## Remaining

- atomically publish `ProfileUpdated` for the compound profile upsert write;
- define owner-ordered profile/account deletion invalidation;
- replace remaining Forum wall-clock projection ordering with owner-issued revisions;
- add the remaining filters and member projections.