### PR TITLE
fix(profiles): make self-service profile upsert invalidation atomic

### DIFF
--- a/crates/rustok-forum/contracts/forum-search-public-author-summary.json
+++ b/crates/rustok-forum/contracts/forum-search-public-author-summary.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "task": "FORUM-23A",
-  "latest_slice": "FORUM-23A5",
+  "latest_slice": "FORUM-23A6",
   "upstream_task": "FORUM-20BQ",
   "status": "source_complete_execution_pending",
   "scope": "Project privacy-aware public author summaries into Forum topic and approved-reply Search documents and durably redact them after Profiles owner changes",
@@ -15,6 +15,7 @@
   "profiles_content_event_owner": "crates/rustok-profiles/src/content_write.rs",
   "profiles_locale_event_owner": "crates/rustok-profiles/src/locale_write.rs",
   "profiles_media_event_owner": "crates/rustok-profiles/src/media_write.rs",
+  "profiles_upsert_event_owner": "crates/rustok-profiles/src/upsert_write.rs",
   "search_inbox": "crates/rustok-search/src/forum_inbox.rs",
   "search_ingestion": "crates/rustok-search/src/ingestion.rs",
   "owner_note": "crates/rustok-forum/docs/forum-23a-search-public-author-summary.md",
@@ -55,7 +56,11 @@
     "locale_write_does_not_create_translations": true,
     "profile_media_write_and_event_are_atomic": true,
     "media_event_failure_rolls_back_owner_write": true,
-    "remaining_profile_summary_write_and_event_pairs_are_atomic": false,
+    "profile_upsert_write_and_event_are_atomic": true,
+    "upsert_event_failure_rolls_back_owner_write": true,
+    "upsert_couples_profile_translation_tags_and_event": true,
+    "upsert_media_validation_precedes_owner_transaction": true,
+    "remaining_profile_summary_write_and_event_pairs_are_atomic": true,
     "author_scope_is_tenant_and_user_scoped": true,
     "author_scope_is_not_suppressed_by_forum_wall_clock_watermark": true,
     "author_change_rebuilds_current_forum_owner_state": true,
@@ -75,7 +80,7 @@
   "remaining_scope": [
     "replace remaining wall-clock Forum projection ordering with owner-issued monotonic revisions",
     "define an owner-ordered profile or account deletion projection invalidation contract",
-    "make profile upsert summary update event atomic with its owner writes",
+    "define durable Search invalidation for CLI backfill profile creation or prove rebuild coverage",
     "add bounded category-subtree tag locale date solved kind channel/group and attachment filters",
     "add member index projections",
     "capture maintainer-executed PostgreSQL rebuild redaction and query evidence"
@@ -97,8 +102,8 @@
   "non_claims": [
     "UserDeleted is sufficient to prove Profiles state has already been removed",
     "account deletion redaction is complete",
-    "all ProfileUpdated owner writes are transactionally coupled to outbox publication",
-    "profile upsert is transactionally coupled to ProfileUpdated publication",
+    "CLI backfill profile creation publishes ProfileUpdated",
+    "all Profiles owner writes trigger durable Forum Search invalidation",
     "general cross-producer owner revision ordering is complete"
   ],
   "downstream_task": "FORUM-23B"

--- a/crates/rustok-forum/docs/forum-23a-search-public-author-summary.md
+++ b/crates/rustok-forum/docs/forum-23a-search-public-author-summary.md
@@ -4,7 +4,7 @@ Date: 2026-07-30
 
 Status: `source_complete_execution_pending`
 
-Latest slice: `FORUM-23A5`
+Latest slice: `FORUM-23A6`
 
 This slice advances the canonical `FORUM-23` visibility-aware Search track. Public Forum topic
 and approved-reply documents obtain author presentation from the Profiles owner instead of
@@ -37,8 +37,9 @@ empty author: it fails projection so the durable Search inbox can retry.
 ## Durable redaction
 
 Embedded summaries require invalidation when profile presentation changes. Profiles publishes
-`ProfileUpdated` for handle, display content, locale, visibility, and media changes. Search treats
-that owner event as a Forum projection event whenever the Forum source is composed.
+`ProfileUpdated` for handle, display content, locale, visibility, media, and self-service upsert
+changes. Search treats that owner event as a Forum projection event whenever the Forum source is
+composed.
 
 The privacy-critical `update_my_profile_visibility` path writes the new visibility and the
 `ProfileUpdated` outbox envelope in the same Profiles-owned database transaction. If outbox
@@ -65,19 +66,26 @@ Banner remains owner data and is never serialized into Forum Search.
 before the owner transaction. The tenant-scoped profile row, revision timestamp, and durable
 `ProfileUpdated` envelope then commit together. If publication fails, the locale write is rolled
 back. The path preserves the existing selection-only rule: changing preferred locale does not copy,
-insert, or update localized display content. A locale change can therefore switch the public
-fallback `display_name` without leaving Forum Search on the previous owner presentation because its
-invalidation was lost.
+insert, or update localized display content.
 
-Visibility, handle, content, locale, and media paths use the shared transactional publisher in
+`FORUM-23A6` applies the owner rule to `upsert_my_profile`. Media ownership is validated before the
+transaction. Inside one Profiles-owned transaction the path checks tenant-scoped handle ownership,
+creates or updates the profile row, upserts the selected localized display-name/biography row,
+replaces taxonomy-backed profile tags, and writes the durable `ProfileUpdated` envelope. Event
+failure rolls back every owner row, including newly created profiles, translations, and tag
+relations. The GraphQL mutation no longer has a post-commit event publisher.
+
+All self-service mutations that emit `ProfileUpdated` now use the shared transactional publisher in
 `crates/rustok-profiles/src/profile_updated_event.rs`, so their event envelope and retryable error
-classification cannot drift independently. Profile upsert still publishes after its owner writes
-and is not claimed to be transactionally coupled.
+classification cannot drift independently. This does not claim full owner-write coverage: the
+Profiles CLI/backfill path still calls the service upsert without publishing `ProfileUpdated` and
+requires a separate invalidation or rebuild proof.
 
 The event is stored under `forum_author:<user_id>`. This scope is intentionally a redaction
 barrier: it is not stale-skipped against the unrelated full Forum wall-clock watermark. The
 consumer rebuilds the Forum tenant projection from current owner state, so committed visibility,
-handle, public display-name, locale-selection, and avatar changes replace stale Search presentation.
+handle, public display-name, locale selection, avatar, and self-service upsert changes replace stale
+Search presentation.
 
 The existing tenant advisory lock, durable retry, dead-letter bound, and periodic/opportunistic
 inbox reconciliation remain unchanged. This slice does not claim that general Forum producer
@@ -107,7 +115,8 @@ Existing Search document rows are replaced by the next Forum rebuild or relevant
 
 - owner-issued monotonic projection revisions across Forum producers;
 - an owner-ordered profile or account deletion invalidation contract;
-- transactionally couple profile upsert to its owner event;
+- durable Search invalidation for CLI/backfill profile creation, or retained evidence that the
+  responsible rebuild always follows it;
 - bounded category-subtree, tag, locale, date, solved, kind, channel/group, attachment, and
   remaining author filters;
 - member Search projections;

--- a/crates/rustok-profiles/src/graphql/mutation.rs
+++ b/crates/rustok-profiles/src/graphql/mutation.rs
@@ -5,7 +5,6 @@ use rustok_api::{
     AuthContext, PortContext, PortError, PortErrorKind, TenantContext,
     graphql::{GraphQLError, require_module_enabled},
 };
-use rustok_events::DomainEvent;
 use rustok_media::{MediaAssetReadPort, MediaService};
 use rustok_outbox::TransactionalEventBus;
 use rustok_storage::StorageRuntime;
@@ -14,16 +13,15 @@ use uuid::Uuid;
 
 use crate::{
     ProfileError, ProfileMediaSlot, ProfileOperation, ProfileOperationTimer, ProfileRecord,
-    ProfileResult, ProfileService, content_write::update_profile_content_with_event,
+    ProfileResult, content_write::update_profile_content_with_event,
     handle_write::update_profile_handle_with_event, locale_write::update_profile_locale_with_event,
-    media_write::update_profile_media_with_event, validate_profile_media_asset,
-    visibility_write::update_profile_visibility_with_event,
+    media_write::update_profile_media_with_event, upsert_write::upsert_profile_with_event,
+    validate_profile_media_asset, visibility_write::update_profile_visibility_with_event,
 };
 
 use super::{MODULE_SLUG, types::*};
 
 const PROFILE_MEDIA_READ_DEADLINE: Duration = Duration::from_secs(2);
-const PROFILE_EVENT_PUBLISH_ERROR: &str = "profiles.event_publish_unavailable";
 
 #[derive(Default)]
 pub struct ProfilesMutation;
@@ -50,20 +48,21 @@ impl ProfilesMutation {
         )
         .await?;
 
-        let service = ProfileService::new(db.clone());
         let profile = observe_profile_write(
             ProfileOperation::Upsert,
             tenant.id,
             auth.user_id,
-            service.upsert_profile(
+            upsert_profile_with_event(
+                db,
+                event_bus,
                 tenant.id,
+                auth.user_id,
                 auth.user_id,
                 input.into(),
                 Some(tenant.default_locale.as_str()),
             ),
         )
         .await?;
-        publish_profile_updated(event_bus, tenant.id, auth.user_id, &profile).await?;
 
         Ok(profile.into())
     }
@@ -317,43 +316,6 @@ fn require_human_user(ctx: &Context<'_>) -> Result<AuthContext> {
         ));
     }
     Ok(auth)
-}
-
-async fn publish_profile_updated(
-    event_bus: &TransactionalEventBus,
-    tenant_id: Uuid,
-    actor_id: Uuid,
-    profile: &ProfileRecord,
-) -> Result<()> {
-    let timer = ProfileOperationTimer::start(
-        ProfileOperation::PublishUpdatedEvent,
-        tenant_id,
-        profile.user_id,
-    );
-    let result = event_bus
-        .publish(
-            tenant_id,
-            Some(actor_id),
-            DomainEvent::ProfileUpdated {
-                user_id: profile.user_id,
-                handle: profile.handle.clone(),
-                locale: profile.preferred_locale.clone(),
-            },
-        )
-        .await;
-
-    match result {
-        Ok(()) => {
-            timer.finish_success();
-            Ok(())
-        }
-        Err(error) => {
-            timer.finish_failure(PROFILE_EVENT_PUBLISH_ERROR, true);
-            Err(<FieldError as GraphQLError>::internal_error(
-                &error.to_string(),
-            ))
-        }
-    }
 }
 
 fn map_profile_error(error: ProfileError) -> async_graphql::Error {

--- a/crates/rustok-profiles/src/lib.rs
+++ b/crates/rustok-profiles/src/lib.rs
@@ -20,6 +20,7 @@ mod profile_updated_event;
 pub mod privacy;
 pub mod reader;
 pub mod services;
+mod upsert_write;
 mod visibility_write;
 
 pub use dto::{ProfileStatus, ProfileSummary, ProfileVisibility, UpsertProfileInput};

--- a/crates/rustok-profiles/src/upsert_write.rs
+++ b/crates/rustok-profiles/src/upsert_write.rs
@@ -1,0 +1,182 @@
+use chrono::Utc;
+use rustok_outbox::TransactionalEventBus;
+use rustok_taxonomy::{TaxonomyService, TaxonomyTermKind};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, Set,
+    TransactionTrait,
+};
+use uuid::Uuid;
+
+use crate::{
+    ProfileError, ProfileRecord, ProfileResult, ProfileService, ProfileStatus, UpsertProfileInput,
+    entities, profile_updated_event::publish_profile_updated_in_tx,
+};
+
+const PROFILE_SCOPE_VALUE: &str = "profiles";
+
+pub(crate) async fn upsert_profile_with_event(
+    db: &DatabaseConnection,
+    event_bus: &TransactionalEventBus,
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    user_id: Uuid,
+    input: UpsertProfileInput,
+    tenant_default_locale: Option<&str>,
+) -> ProfileResult<ProfileRecord> {
+    let UpsertProfileInput {
+        handle,
+        display_name,
+        bio,
+        tags,
+        avatar_media_id,
+        banner_media_id,
+        preferred_locale,
+        visibility,
+    } = input;
+    let handle = ProfileService::normalize_handle(&handle)?;
+    let display_name = ProfileService::normalize_display_name(&display_name)?;
+    let preferred_locale = ProfileService::normalize_locale(preferred_locale.as_deref())?;
+    let translation_locale = preferred_locale
+        .clone()
+        .or(ProfileService::normalize_locale(tenant_default_locale)?)
+        .ok_or_else(|| {
+            ProfileError::InvalidLocale("effective profile locale is required".to_string())
+        })?;
+
+    let txn = db.begin().await?;
+    let handle_owner = entities::profile::Entity::find()
+        .filter(entities::profile::Column::TenantId.eq(tenant_id))
+        .filter(entities::profile::Column::Handle.eq(handle.clone()))
+        .one(&txn)
+        .await?;
+    if let Some(handle_owner) = handle_owner
+        && handle_owner.user_id != user_id
+    {
+        return Err(ProfileError::DuplicateHandle(handle));
+    }
+
+    let existing = entities::profile::Entity::find_by_id(user_id)
+        .filter(entities::profile::Column::TenantId.eq(tenant_id))
+        .one(&txn)
+        .await?;
+    let now = Utc::now();
+    let profile = match existing {
+        Some(profile) => {
+            let mut active: entities::profile::ActiveModel = profile.into();
+            active.handle = Set(handle);
+            active.avatar_media_id = Set(avatar_media_id);
+            active.banner_media_id = Set(banner_media_id);
+            active.preferred_locale = Set(preferred_locale);
+            active.visibility = Set(visibility);
+            active.status = Set(ProfileStatus::Active);
+            active.updated_at = Set(now.into());
+            active.update(&txn).await?
+        }
+        None => {
+            entities::profile::ActiveModel {
+                user_id: Set(user_id),
+                tenant_id: Set(tenant_id),
+                handle: Set(handle),
+                avatar_media_id: Set(avatar_media_id),
+                banner_media_id: Set(banner_media_id),
+                preferred_locale: Set(preferred_locale),
+                visibility: Set(visibility),
+                status: Set(ProfileStatus::Active),
+                created_at: Set(now.into()),
+                updated_at: Set(now.into()),
+            }
+            .insert(&txn)
+            .await?
+        }
+    };
+
+    let translation = entities::profile_translation::Entity::find()
+        .filter(entities::profile_translation::Column::ProfileUserId.eq(user_id))
+        .filter(entities::profile_translation::Column::Locale.eq(translation_locale.clone()))
+        .one(&txn)
+        .await?;
+    match translation {
+        Some(translation) => {
+            let mut active: entities::profile_translation::ActiveModel = translation.into();
+            active.display_name = Set(display_name.clone());
+            active.bio = Set(bio.clone());
+            active.updated_at = Set(now.into());
+            active.update(&txn).await?;
+        }
+        None => {
+            entities::profile_translation::ActiveModel {
+                id: Set(Uuid::new_v4()),
+                profile_user_id: Set(user_id),
+                locale: Set(translation_locale.clone()),
+                display_name: Set(display_name),
+                bio: Set(bio),
+                created_at: Set(now.into()),
+                updated_at: Set(now.into()),
+            }
+            .insert(&txn)
+            .await?;
+        }
+    }
+
+    entities::profile_tag::Entity::delete_many()
+        .filter(entities::profile_tag::Column::ProfileUserId.eq(user_id))
+        .exec(&txn)
+        .await?;
+    let tags = normalize_tag_names(&tags);
+    if !tags.is_empty() {
+        let term_ids = TaxonomyService::new(db.clone())
+            .ensure_terms_for_module_in_tx(
+                &txn,
+                tenant_id,
+                TaxonomyTermKind::Tag,
+                PROFILE_SCOPE_VALUE,
+                &translation_locale,
+                &tags,
+            )
+            .await?;
+        for (index, term_id) in term_ids.into_iter().enumerate() {
+            entities::profile_tag::ActiveModel {
+                profile_user_id: Set(user_id),
+                term_id: Set(term_id),
+                tenant_id: Set(tenant_id),
+                created_at: Set((now + chrono::Duration::microseconds(index as i64)).into()),
+            }
+            .insert(&txn)
+            .await?;
+        }
+    }
+
+    if let Err(error) =
+        publish_profile_updated_in_tx(event_bus, &txn, tenant_id, actor_id, &profile).await
+    {
+        tracing::error!(
+            tenant_id = %tenant_id,
+            user_id = %profile.user_id,
+            "Profile upsert event publication failed; rolling back owner write"
+        );
+        txn.rollback().await?;
+        return Err(error);
+    }
+    txn.commit().await?;
+
+    ProfileService::new(db.clone())
+        .get_profile(tenant_id, user_id, None, tenant_default_locale)
+        .await
+}
+
+fn normalize_tag_names(tag_names: &[String]) -> Vec<String> {
+    let mut normalized = Vec::new();
+    for tag_name in tag_names {
+        let trimmed = tag_name.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if !normalized
+            .iter()
+            .any(|existing: &String| existing.eq_ignore_ascii_case(trimmed))
+        {
+            normalized.push(trimmed.to_string());
+        }
+    }
+    normalized
+}

--- a/scripts/verify/verify-forum-search-public-author-summary.mjs
+++ b/scripts/verify/verify-forum-search-public-author-summary.mjs
@@ -25,6 +25,14 @@ function rejectMarker(source, marker, label) {
   if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
 }
 
+function requireAll(source, markers, label) {
+  for (const marker of markers) requireMarker(source, marker, label);
+}
+
+function rejectAll(source, markers, label) {
+  for (const marker of markers) rejectMarker(source, marker, label);
+}
+
 function requireOrder(source, first, second, label) {
   const firstIndex = source.indexOf(first);
   const secondIndex = source.indexOf(second);
@@ -46,6 +54,7 @@ const profilesContentWritePath = "crates/rustok-profiles/src/content_write.rs";
 const profilesHandleWritePath = "crates/rustok-profiles/src/handle_write.rs";
 const profilesLocaleWritePath = "crates/rustok-profiles/src/locale_write.rs";
 const profilesMediaWritePath = "crates/rustok-profiles/src/media_write.rs";
+const profilesUpsertWritePath = "crates/rustok-profiles/src/upsert_write.rs";
 const profilesVisibilityWritePath = "crates/rustok-profiles/src/visibility_write.rs";
 const profilesErrorPath = "crates/rustok-profiles/src/error.rs";
 const contractPath = "crates/rustok-forum/contracts/forum-search-public-author-summary.json";
@@ -64,6 +73,7 @@ const profilesContentWrite = read(profilesContentWritePath);
 const profilesHandleWrite = read(profilesHandleWritePath);
 const profilesLocaleWrite = read(profilesLocaleWritePath);
 const profilesMediaWrite = read(profilesMediaWritePath);
+const profilesUpsertWrite = read(profilesUpsertWritePath);
 const profilesVisibilityWrite = read(profilesVisibilityWritePath);
 const profilesError = read(profilesErrorPath);
 const note = read(notePath);
@@ -74,287 +84,313 @@ try {
   failures.push(`${contractPath}: invalid JSON: ${error.message}`);
 }
 
-for (const marker of [
-  "ProfilePresentationService::new(db.clone())",
-  ".find_profile_summary(tenant_id, author_id, Some(locale), None)",
-  "public_author_payload",
-  '"user_id": summary.user_id',
-  '"handle": summary.handle',
-  '"display_name": summary.display_name',
-  '"avatar_media_id": summary.avatar_media_id',
-  "public_author_payload_exposes_only_the_safe_summary",
-  "absent_or_denied_author_is_not_serialized",
-]) {
-  requireMarker(author, marker, authorPath);
-}
-for (const forbidden of [
-  '"tags": summary.tags',
-  '"preferred_locale": summary.preferred_locale',
-  '"visibility": summary.visibility',
-]) {
-  rejectMarker(author, forbidden, authorPath);
-}
+requireAll(
+  author,
+  [
+    "ProfilePresentationService::new(db.clone())",
+    ".find_profile_summary(tenant_id, author_id, Some(locale), None)",
+    "public_author_payload",
+    '"user_id": summary.user_id',
+    '"handle": summary.handle',
+    '"display_name": summary.display_name',
+    '"avatar_media_id": summary.avatar_media_id',
+    "public_author_payload_exposes_only_the_safe_summary",
+    "absent_or_denied_author_is_not_serialized",
+  ],
+  authorPath,
+);
+rejectAll(
+  author,
+  [
+    '"tags": summary.tags',
+    '"preferred_locale": summary.preferred_locale',
+    '"visibility": summary.visibility',
+  ],
+  authorPath,
+);
 
-for (const marker of [
-  "load_public_author_summary",
-  "handle: author_handle",
-  "public_author_keywords",
-  '"author": author_payload',
-  '"author_id": author_id',
-  '"has_public_author": author_id.is_some()',
-]) {
-  requireMarker(source, marker, sourcePath);
-}
-for (const forbidden of [
-  '"author_id": topic.author_id',
-  '"author_id": reply.author_id',
-]) {
-  rejectMarker(source, forbidden, sourcePath);
-}
+requireAll(
+  source,
+  [
+    "load_public_author_summary",
+    "handle: author_handle",
+    "public_author_keywords",
+    '"author": author_payload',
+    '"author_id": author_id',
+    '"has_public_author": author_id.is_some()',
+  ],
+  sourcePath,
+);
+rejectAll(
+  source,
+  ['"author_id": topic.author_id', '"author_id": reply.author_id'],
+  sourcePath,
+);
 requireMarker(forumLib, "mod search_projection_author;", forumLibPath);
 
-for (const marker of [
-  "ProfilePrivacyService::new(self.db.clone())",
-  "ProfileAccessAudience::Anonymous",
-  "ProfilePrivacyDecision::Allow",
-]) {
-  requireMarker(profiles, marker, profilesPath);
-}
-for (const marker of [
-  "mod content_write;",
-  "mod handle_write;",
-  "mod locale_write;",
-  "mod media_write;",
-  "mod profile_updated_event;",
-  "mod visibility_write;",
-]) {
-  requireMarker(profilesLib, marker, profilesLibPath);
-}
-for (const marker of [
-  "update_profile_content_with_event(",
-  "update_profile_handle_with_event(",
-  "update_profile_locale_with_event(",
-  "update_profile_media_with_event(",
-  "update_profile_visibility_with_event(",
-  "service.upsert_profile(",
-  "publish_profile_updated(event_bus, tenant.id, auth.user_id, &profile).await?",
-  "DomainEvent::ProfileUpdated",
-  "ProfileError::EventPublishUnavailable",
-]) {
-  requireMarker(profilesMutation, marker, profilesMutationPath);
-}
-for (const forbidden of [
-  "service.update_profile_content(",
-  "service.update_profile_handle(",
-  "service.update_profile_locale(",
-  "service.update_profile_media(",
-  "service.update_profile_visibility(",
-]) {
-  rejectMarker(profilesMutation, forbidden, profilesMutationPath);
-}
+requireAll(
+  profiles,
+  [
+    "ProfilePrivacyService::new(self.db.clone())",
+    "ProfileAccessAudience::Anonymous",
+    "ProfilePrivacyDecision::Allow",
+  ],
+  profilesPath,
+);
 
-for (const marker of [
-  "publish_profile_updated_in_tx",
-  "profile: &entities::profile::Model",
-  ".publish_in_tx(",
-  "DomainEvent::ProfileUpdated",
-  "ProfileOperation::PublishUpdatedEvent",
-  "ProfileError::EventPublishUnavailable",
-  "Profile update event publication failed",
-]) {
-  requireMarker(profilesUpdatedEvent, marker, profilesUpdatedEventPath);
-}
+requireAll(
+  profilesLib,
+  [
+    "mod content_write;",
+    "mod handle_write;",
+    "mod locale_write;",
+    "mod media_write;",
+    "mod profile_updated_event;",
+    "mod upsert_write;",
+    "mod visibility_write;",
+  ],
+  profilesLibPath,
+);
+
+requireAll(
+  profilesMutation,
+  [
+    "upsert_profile_with_event(",
+    "update_profile_content_with_event(",
+    "update_profile_handle_with_event(",
+    "update_profile_locale_with_event(",
+    "update_profile_media_with_event(",
+    "update_profile_visibility_with_event(",
+    "validate_profile_media_references(",
+    "ProfileError::EventPublishUnavailable",
+  ],
+  profilesMutationPath,
+);
+rejectAll(
+  profilesMutation,
+  [
+    "service.upsert_profile(",
+    "service.update_profile_content(",
+    "service.update_profile_handle(",
+    "service.update_profile_locale(",
+    "service.update_profile_media(",
+    "service.update_profile_visibility(",
+    "async fn publish_profile_updated(",
+    "DomainEvent::ProfileUpdated",
+    "use rustok_events::DomainEvent;",
+  ],
+  profilesMutationPath,
+);
+requireOrder(
+  profilesMutation,
+  "validate_profile_media_references(",
+  "upsert_profile_with_event(",
+  profilesMutationPath,
+);
+
+requireAll(
+  profilesUpdatedEvent,
+  [
+    "publish_profile_updated_in_tx",
+    "profile: &entities::profile::Model",
+    ".publish_in_tx(",
+    "DomainEvent::ProfileUpdated",
+    "ProfileOperation::PublishUpdatedEvent",
+    "ProfileError::EventPublishUnavailable",
+    "Profile update event publication failed",
+  ],
+  profilesUpdatedEventPath,
+);
 rejectMarker(profilesUpdatedEvent, "profile: &ProfileRecord", profilesUpdatedEventPath);
 
-for (const marker of [
-  "ProfileService::normalize_display_name(display_name)?",
-  "db.begin().await?",
-  "Column::TenantId.eq(tenant_id)",
-  "Column::ProfileUserId.eq(user_id)",
-  "Column::Locale.eq(translation_locale.clone())",
-  "active.display_name = Set(display_name)",
-  "active.bio = Set(bio.map(str::to_string))",
+function verifyTransactionalHelper(sourceText, helperPath, markers, writeMarker, logMarker) {
+  requireAll(
+    sourceText,
+    [
+      "db.begin().await?",
+      ...markers,
+      writeMarker,
+      "publish_profile_updated_in_tx",
+      "txn.rollback().await?",
+      "txn.commit().await?",
+      logMarker,
+    ],
+    helperPath,
+  );
+  requireOrder(sourceText, writeMarker, "publish_profile_updated_in_tx", helperPath);
+  requireOrder(sourceText, "publish_profile_updated_in_tx", "txn.commit().await?", helperPath);
+}
+
+verifyTransactionalHelper(
+  profilesContentWrite,
+  profilesContentWritePath,
+  [
+    "ProfileService::normalize_display_name(display_name)?",
+    "Column::ProfileUserId.eq(user_id)",
+    "active.display_name = Set(display_name)",
+    "active.bio = Set(bio.map(str::to_string))",
+    ".insert(&txn)",
+  ],
   ".update(&txn).await?",
-  ".insert(&txn)",
-  "publish_profile_updated_in_tx",
-  "txn.rollback().await?",
-  "txn.commit().await?",
   "Profile content event publication failed; rolling back owner write",
-]) {
-  requireMarker(profilesContentWrite, marker, profilesContentWritePath);
-}
-requireOrder(
-  profilesContentWrite,
-  ".update(&txn).await?",
-  "publish_profile_updated_in_tx",
-  profilesContentWritePath,
-);
-requireOrder(
-  profilesContentWrite,
-  "publish_profile_updated_in_tx",
-  "txn.commit().await?",
-  profilesContentWritePath,
 );
 
-for (const marker of [
-  "ProfileService::normalize_handle(handle)?",
-  "db.begin().await?",
-  "Column::Handle.eq(handle.clone())",
-  "ProfileError::DuplicateHandle(handle)",
+verifyTransactionalHelper(
+  profilesHandleWrite,
+  profilesHandleWritePath,
+  [
+    "ProfileService::normalize_handle(handle)?",
+    "Column::Handle.eq(handle.clone())",
+    "ProfileError::DuplicateHandle(handle)",
+  ],
   ".update(&txn).await?",
-  "publish_profile_updated_in_tx",
-  "txn.rollback().await?",
-  "txn.commit().await?",
   "Profile handle event publication failed; rolling back owner write",
-]) {
-  requireMarker(profilesHandleWrite, marker, profilesHandleWritePath);
-}
-requireOrder(
-  profilesHandleWrite,
-  ".update(&txn).await?",
-  "publish_profile_updated_in_tx",
-  profilesHandleWritePath,
-);
-requireOrder(
-  profilesHandleWrite,
-  "publish_profile_updated_in_tx",
-  "txn.commit().await?",
-  profilesHandleWritePath,
 );
 
-for (const marker of [
-  "ProfileService::normalize_locale(preferred_locale)?",
-  "ProfileService::normalize_locale(tenant_default_locale)?",
-  "db.begin().await?",
-  "Column::TenantId.eq(tenant_id)",
-  "active.preferred_locale = Set(preferred_locale)",
+verifyTransactionalHelper(
+  profilesLocaleWrite,
+  profilesLocaleWritePath,
+  [
+    "ProfileService::normalize_locale(preferred_locale)?",
+    "ProfileService::normalize_locale(tenant_default_locale)?",
+    "active.preferred_locale = Set(preferred_locale)",
+    "selection policy only",
+  ],
   ".update(&txn).await?",
-  "selection policy only",
-  "publish_profile_updated_in_tx",
-  "txn.rollback().await?",
-  "txn.commit().await?",
   "Profile locale event publication failed; rolling back owner write",
-]) {
-  requireMarker(profilesLocaleWrite, marker, profilesLocaleWritePath);
-}
+);
 rejectMarker(profilesLocaleWrite, "profile_translation", profilesLocaleWritePath);
-requireOrder(
-  profilesLocaleWrite,
-  ".update(&txn).await?",
-  "publish_profile_updated_in_tx",
-  profilesLocaleWritePath,
-);
-requireOrder(
-  profilesLocaleWrite,
-  "publish_profile_updated_in_tx",
-  "txn.commit().await?",
-  profilesLocaleWritePath,
-);
 
-for (const marker of [
-  "db.begin().await?",
-  "active.avatar_media_id = Set(avatar_media_id)",
-  "active.banner_media_id = Set(banner_media_id)",
+verifyTransactionalHelper(
+  profilesMediaWrite,
+  profilesMediaWritePath,
+  [
+    "active.avatar_media_id = Set(avatar_media_id)",
+    "active.banner_media_id = Set(banner_media_id)",
+  ],
   ".update(&txn).await?",
-  "publish_profile_updated_in_tx",
-  "txn.rollback().await?",
-  "txn.commit().await?",
   "Profile media event publication failed; rolling back owner write",
-]) {
-  requireMarker(profilesMediaWrite, marker, profilesMediaWritePath);
-}
-requireOrder(
-  profilesMediaWrite,
-  ".update(&txn).await?",
-  "publish_profile_updated_in_tx",
-  profilesMediaWritePath,
-);
-requireOrder(
-  profilesMediaWrite,
-  "publish_profile_updated_in_tx",
-  "txn.commit().await?",
-  profilesMediaWritePath,
 );
 
-for (const marker of [
-  "db.begin().await?",
+verifyTransactionalHelper(
+  profilesVisibilityWrite,
+  profilesVisibilityWritePath,
+  ["active.visibility = Set(visibility)"],
   ".update(&txn).await?",
-  "publish_profile_updated_in_tx",
-  "txn.rollback().await?",
-  "txn.commit().await?",
   "Profile visibility event publication failed; rolling back owner write",
-]) {
-  requireMarker(profilesVisibilityWrite, marker, profilesVisibilityWritePath);
-}
-requireOrder(
-  profilesVisibilityWrite,
-  ".update(&txn).await?",
-  "publish_profile_updated_in_tx",
-  profilesVisibilityWritePath,
+);
+
+requireAll(
+  profilesUpsertWrite,
+  [
+    "ProfileService::normalize_handle(&handle)?",
+    "ProfileService::normalize_display_name(&display_name)?",
+    "ProfileService::normalize_locale(preferred_locale.as_deref())?",
+    "db.begin().await?",
+    "Column::TenantId.eq(tenant_id)",
+    "Column::Handle.eq(handle.clone())",
+    "ProfileError::DuplicateHandle(handle)",
+    "entities::profile::ActiveModel",
+    "entities::profile_translation::Entity::find()",
+    "entities::profile_tag::Entity::delete_many()",
+    "ensure_terms_for_module_in_tx",
+    "TaxonomyTermKind::Tag",
+    ".insert(&txn)",
+    "publish_profile_updated_in_tx",
+    "txn.rollback().await?",
+    "txn.commit().await?",
+    "Profile upsert event publication failed; rolling back owner write",
+  ],
+  profilesUpsertWritePath,
 );
 requireOrder(
-  profilesVisibilityWrite,
+  profilesUpsertWrite,
+  "entities::profile::ActiveModel",
+  "publish_profile_updated_in_tx",
+  profilesUpsertWritePath,
+);
+requireOrder(
+  profilesUpsertWrite,
+  "entities::profile_translation::Entity::find()",
+  "publish_profile_updated_in_tx",
+  profilesUpsertWritePath,
+);
+requireOrder(
+  profilesUpsertWrite,
+  "entities::profile_tag::Entity::delete_many()",
+  "publish_profile_updated_in_tx",
+  profilesUpsertWritePath,
+);
+requireOrder(
+  profilesUpsertWrite,
   "publish_profile_updated_in_tx",
   "txn.commit().await?",
-  profilesVisibilityWritePath,
+  profilesUpsertWritePath,
 );
 
-for (const marker of [
-  "EventPublishUnavailable",
-  '"profiles.event_publish_unavailable"',
-  "Self::PresentationUnavailable | Self::EventPublishUnavailable | Self::Database(_)",
-]) {
-  requireMarker(profilesError, marker, profilesErrorPath);
-}
+requireAll(
+  profilesError,
+  [
+    "EventPublishUnavailable",
+    '"profiles.event_publish_unavailable"',
+    "Self::PresentationUnavailable | Self::EventPublishUnavailable | Self::Database(_)",
+  ],
+  profilesErrorPath,
+);
 
-for (const marker of [
-  "Author(Uuid)",
-  "DomainEvent::ProfileUpdated { user_id, .. }",
-  "AUTHOR_SCOPE_PREFIX",
-  "scope_key.starts_with(AUTHOR_SCOPE_PREFIX)",
-  "return Ok(None);",
-  "profile_changes_have_redaction_barrier_scope",
-]) {
-  requireMarker(inbox, marker, inboxPath);
-}
+requireAll(
+  inbox,
+  [
+    "Author(Uuid)",
+    "DomainEvent::ProfileUpdated { user_id, .. }",
+    "AUTHOR_SCOPE_PREFIX",
+    "scope_key.starts_with(AUTHOR_SCOPE_PREFIX)",
+    "profile_changes_have_redaction_barrier_scope",
+  ],
+  inboxPath,
+);
 rejectMarker(inbox, "DomainEvent::UserDeleted", inboxPath);
-for (const marker of [
-  "DomainEvent::ProfileUpdated { .. }",
-  '"rebuild_forum_author_projection"',
-  "projector.rebuild_tenant(envelope.tenant_id).await",
-]) {
-  requireMarker(ingestion, marker, ingestionPath);
-}
+requireAll(
+  ingestion,
+  [
+    "DomainEvent::ProfileUpdated { .. }",
+    '"rebuild_forum_author_projection"',
+    "projector.rebuild_tenant(envelope.tenant_id).await",
+  ],
+  ingestionPath,
+);
 rejectMarker(ingestion, "DomainEvent::UserDeleted", ingestionPath);
 
-for (const marker of [
-  "FORUM-23A5",
-  "ProfilePresentationService",
-  "forum_author:<user_id>",
-  "raw `payload.author_id`",
-  "owner-issued monotonic",
-  "same Profiles-owned database transaction",
-  "update_my_profile_handle",
-  "update_my_profile_content",
-  "update_my_profile_locale",
-  "update_my_profile_media",
-  "shared transactional publisher",
-  "actual Profiles owner model",
-  "Profile upsert still",
-  "does not treat `UserDeleted`",
-  "not run by the implementation agent",
-]) {
-  requireMarker(note, marker, notePath);
-}
+requireAll(
+  note,
+  [
+    "FORUM-23A6",
+    "ProfilePresentationService",
+    "forum_author:<user_id>",
+    "raw `payload.author_id`",
+    "owner-issued monotonic",
+    "upsert_my_profile",
+    "taxonomy-backed profile tags",
+    "post-commit event publisher",
+    "CLI/backfill",
+    "does not treat `UserDeleted`",
+    "Not run by the implementation agent",
+  ],
+  notePath,
+);
 
 if (contract) {
   if (contract.task !== "FORUM-23A") failures.push(`${contractPath}: unexpected task`);
-  if (contract.latest_slice !== "FORUM-23A5") {
+  if (contract.latest_slice !== "FORUM-23A6") {
     failures.push(`${contractPath}: unexpected latest slice`);
   }
   if (contract.status !== "source_complete_execution_pending") {
     failures.push(`${contractPath}: unexpected status`);
   }
+  if (contract.profiles_upsert_event_owner !== profilesUpsertWritePath) {
+    failures.push(`${contractPath}: unexpected upsert event owner`);
+  }
+
   for (const key of [
     "anonymous_profiles_presentation_is_authoritative",
     "forum_does_not_copy_profile_privacy_policy",
@@ -366,12 +402,14 @@ if (contract) {
     "preferred_locale_is_not_serialized",
     "profile_visibility_is_not_serialized",
     "public_handle_populates_search_handle",
+    "public_handle_and_display_name_extend_keywords",
     "author_filter_value_is_populated_only_for_public_author",
   ]) {
     if (contract.projection_boundary?.[key] !== true) {
       failures.push(`${contractPath}: projection boundary ${key} drift`);
     }
   }
+
   for (const key of [
     "profile_updated_is_durable",
     "profile_updated_is_emitted_after_owner_write",
@@ -388,6 +426,11 @@ if (contract) {
     "locale_write_does_not_create_translations",
     "profile_media_write_and_event_are_atomic",
     "media_event_failure_rolls_back_owner_write",
+    "profile_upsert_write_and_event_are_atomic",
+    "upsert_event_failure_rolls_back_owner_write",
+    "upsert_couples_profile_translation_tags_and_event",
+    "upsert_media_validation_precedes_owner_transaction",
+    "remaining_profile_summary_write_and_event_pairs_are_atomic",
     "author_scope_is_tenant_and_user_scoped",
     "author_scope_is_not_suppressed_by_forum_wall_clock_watermark",
     "author_change_rebuilds_current_forum_owner_state",
@@ -398,12 +441,10 @@ if (contract) {
       failures.push(`${contractPath}: redaction boundary ${key} drift`);
     }
   }
-  if (contract.redaction_boundary?.remaining_profile_summary_write_and_event_pairs_are_atomic !== false) {
-    failures.push(`${contractPath}: remaining profile mutations must stay a non-claim`);
-  }
   if (contract.redaction_boundary?.schema_migration_added !== false) {
     failures.push(`${contractPath}: schema migration must remain absent`);
   }
+
   for (const key of [
     "forum_graphql_changed",
     "forum_rest_changed",
@@ -417,14 +458,22 @@ if (contract) {
       failures.push(`${contractPath}: compatibility ${key} must remain false`);
     }
   }
+
   for (const nonClaim of [
     "account deletion redaction is complete",
-    "all ProfileUpdated owner writes are transactionally coupled to outbox publication",
-    "profile upsert is transactionally coupled to ProfileUpdated publication",
+    "CLI backfill profile creation publishes ProfileUpdated",
+    "all Profiles owner writes trigger durable Forum Search invalidation",
   ]) {
     if (!contract.non_claims?.includes(nonClaim)) {
       failures.push(`${contractPath}: missing non-claim ${nonClaim}`);
     }
+  }
+  if (
+    !contract.remaining_scope?.includes(
+      "define durable Search invalidation for CLI backfill profile creation or prove rebuild coverage",
+    )
+  ) {
+    failures.push(`${contractPath}: missing backfill invalidation debt`);
   }
   if (contract.downstream_task !== "FORUM-23B") {
     failures.push(`${contractPath}: unexpected downstream task`);


### PR DESCRIPTION
## Summary

Implements `FORUM-23A6`, the next bounded public-author Search hardening slice.

- validate avatar/banner media ownership before opening the Profiles owner transaction;
- normalize handle, display name, and locale before owner writes;
- check tenant-scoped handle ownership, create/update the profile row, upsert localized content, replace taxonomy-backed tags, and write the `ProfileUpdated` outbox envelope in one transaction;
- roll back every upsert owner row when durable event publication fails;
- remove the GraphQL-owned post-commit `ProfileUpdated` publisher;
- keep CLI/backfill profile creation as an explicit remaining invalidation debt rather than claiming full owner-write coverage;
- update the Forum public-author contract, owner note, and static verifier.

## Compatibility

No migration, public GraphQL schema, Search query API, dependency, or `Cargo.lock` change.

## Verification

Not run by the implementation agent, per maintainer instruction. Suggested commands:

```bash
cargo check -p rustok-profiles --all-targets
cargo test -p rustok-profiles error -- --nocapture
cargo test -p rustok-forum search_projection_author -- --nocapture
cargo test -p rustok-search forum_inbox -- --nocapture
cargo test -p rustok-search ingestion -- --nocapture
node scripts/verify/verify-forum-search-public-author-summary.mjs
node scripts/verify/verify-forum-search-projection.mjs
cargo xtask module validate profiles
cargo xtask module validate forum
```

## Remaining

- define durable Search invalidation for CLI/backfill profile creation or prove rebuild coverage;
- define owner-ordered profile/account deletion invalidation;
- replace remaining Forum wall-clock projection ordering with owner-issued revisions;
- add the remaining filters and member projections.