### PR TITLE
feat(index): add bounded multi-page replay runner

### DIFF
--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -26,7 +26,7 @@ pull requests record checks and PostgreSQL runs that were not executed.
 ## Current state
 
 - Rewrite status: `in_progress`
-- Current milestone: `M6 - fenced replay job ownership (source complete; multi-page execution, cancellation, and retained evidence open)`
+- Current milestone: `M6 - bounded multi-page replay runner (source complete; cancellation, scheduling, and retained evidence open)`
 - FFA status: `in_progress`
 - FBA status: `in_progress`
 - M0 code reset: `complete`
@@ -66,6 +66,7 @@ pull requests record checks and PostgreSQL runs that were not executed.
 - M5/M6 bounded source replay contract: `source_complete_worker_pending`
 - M6 one-page replay and durable checkpoint progression: `source_complete`
 - M6 replay job leases and checkpoint attempt fencing: `source_complete_owner_execution_pending`
+- M6 bounded multi-page replay runner: `source_complete_owner_execution_pending`
 - Production persistence: mutation writes, schema/index coordination, fail-closed
   partition admission, snapshot/query/mutation/maintenance/cutover evidence tooling,
   full-capture orchestration, exact-byte packet assembly, retained bundle review,
@@ -79,10 +80,11 @@ pull requests record checks and PostgreSQL runs that were not executed.
   row adaptation, source-owned schema publication, shared query-runtime composition,
   bounded source replay/load contracts, one-page replay mutation application, durable
   rebuild checkpoint progression, schema-scoped rebuild job claims, lease/heartbeat,
-  attempt fencing, and fenced checkpoint writes are implemented; one retained admitted
-  packet, live PostgreSQL/reference equivalence, bounded multi-page ingestion/rebuild
-  runners, cancellation, freshness/recovery evidence, authoritative consumer cutover,
-  and production partition lifecycle remain open
+  attempt fencing, fenced checkpoint writes, bounded multi-page execution, and
+  immediate pending resume are implemented; one retained admitted packet, live
+  PostgreSQL/reference equivalence, cancellation, retry/backoff, dead-letter scheduling,
+  host scheduling, freshness/recovery evidence, authoritative consumer cutover, and
+  production partition lifecycle remain open
 
 The production crate contains the generic domain/application core, seven canonical
 M3 tables, an atomic mutation adapter, durable schema leases, secondary-index
@@ -96,9 +98,11 @@ nested identities/values, lookahead pagination, and scoped cursor construction,
 `PostgresIndexQueryPort` for exact-schema-preflighted execution in one read-only
 repeatable-read page/count snapshot, source-owned schema and replay catalogs, a
 neutral bounded `IndexSource` scan/load boundary, a one-page replay executor,
-`PostgresIndexReplayJobStore` for durable fenced schema-scoped rebuild ownership, and
-a lease-bound PostgreSQL rebuild-checkpoint adapter. Owner-operated evidence tools
-live under `ops/benches`; they do not become runtime storage code.
+`PostgresIndexReplayJobStore` for durable fenced schema-scoped rebuild ownership,
+a lease-bound PostgreSQL rebuild-checkpoint adapter, and
+`PostgresIndexReplayRunner` for bounded heartbeat/yield/resume execution.
+Owner-operated evidence tools live under `ops/benches`; they do not become runtime
+storage code.
 
 ## Ownership
 
@@ -141,6 +145,7 @@ crates/rustok-index/src/
     mutation_store.rs
     source_replay.rs
     source_replay_job.rs
+    source_replay_runner.rs
     schema_lease.rs
     secondary_index.rs
     partition_admission.rs
@@ -438,25 +443,27 @@ database, or transport causes stay in owner logs.
       exact request validation, and terminal-state fencing.
 - [x] Bind checkpoint reads and writes to the active `(job_id, worker_id, attempt_count)`
       and require a durable null-cursor checkpoint before terminal success.
+- [x] Add bounded multi-page execution with heartbeat cadence and immediate pending resume.
 - [ ] Bind job requests directly to the materialized source registry in server composition.
-- [ ] Add cancellation, bounded multi-page resume, dry-run, targeted/full/shadow rebuild.
+- [ ] Add cancellation, dry-run, and targeted/full/shadow rebuild modes.
 - [ ] Add bounded retry/backoff, dead-letter state, and global scheduling ownership.
 - [ ] Add locale/partition replay checkpoint dimensions.
 - [ ] Add reconciliation and drift repair.
 - [ ] Cover crash, lease expiry, restart, cancellation, and incremental/full
       equivalence with retained PostgreSQL evidence.
 
-The one-page executor, replay job store, and PostgreSQL checkpoint adapter are source
-complete. `PostgresIndexReplayJobStore` serializes one tenant/source/schema claim,
-validates the exact `index_replay_job_v1` request and active persisted schema, reclaims
-expired attempts with an incremented fence, and rejects stale heartbeat or terminal
-updates. `PostgresIndexReplayCheckpointStore` is constructed from the acquired lease;
-it locks and validates that exact attempt before every checkpoint read or write. A
-stale worker may finish an already-started idempotent mutation transaction, but it
-cannot advance the durable cursor. Terminal success requires the same active lease and
-an exact durable rebuild checkpoint with a JSON null cursor. No scheduler, multi-page
-loop, cancellation command, retry/dead-letter policy, production source adapter, or
-retained multi-instance PostgreSQL evidence is claimed.
+The one-page executor, replay job store, checkpoint adapter, and bounded multi-page
+runner are source complete. `PostgresIndexReplayJobStore` serializes one tenant/schema
+claim, validates the exact `index_replay_job_v1` request and active persisted schema,
+reclaims expired attempts with an incremented fence, and rejects stale heartbeat or
+terminal updates. `PostgresIndexReplayCheckpointStore` is constructed from the acquired
+lease; it locks and validates that exact attempt before every checkpoint read or write.
+`PostgresIndexReplayRunner` resolves the source from the materialized registry, executes
+at most 1024 pages, heartbeats between pages, completes only after a durable JSON null
+cursor, and returns unfinished work to immediately claimable `pending` state while
+preserving the same job UUID and checkpoint. A later claim increments the attempt fence.
+Cancellation, automatic retry/backoff, dead-letter scheduling, host scheduling, and
+retained multi-instance PostgreSQL evidence remain open.
 
 ### M7 - First vertical slice
 
@@ -512,6 +519,7 @@ cargo test -p rustok-index postgres_query_result_tests -- --nocapture
 cargo test -p rustok-index source_registry --lib -- --nocapture
 cargo test -p rustok-index source_replay --lib -- --nocapture
 cargo test -p rustok-index source_replay_job --lib -- --nocapture
+cargo test -p rustok-index source_replay_runner --lib -- --nocapture
 cargo xtask module validate index
 cargo xtask module test index
 npm run verify:index:fba
@@ -555,6 +563,7 @@ node scripts/verify/verify-index-query-result-decoder.mjs
 node scripts/verify/verify-index-many-link-filtering.mjs
 node scripts/verify/verify-index-source-replay-contract.mjs
 node scripts/verify/verify-index-replay-job-leases.mjs
+node scripts/verify/verify-index-replay-multipage-runner.mjs
 ```
 
 ## Progress log
@@ -598,22 +607,26 @@ node scripts/verify/verify-index-replay-job-leases.mjs
 - 2026-07-30: added schema-scoped durable rebuild job claims, advisory-lock exclusion,
   lease/heartbeat, expired-attempt reclaim, attempt fencing, exact request validation,
   lease-bound checkpoint reads/writes, stale-writer rejection, and null-cursor-gated
-  terminal success. Multi-page execution and cancellation remain open.
-- Repository test/fixture suites, verifiers, the bounded multi-page replay runner,
-  cancellation, live freshness/recovery evidence, one admitted PostgreSQL/reference
-  equivalence bundle, and one real full PostgreSQL partition packet remain for the
-  owner to execute and admit before authoritative consumer or production partition
-  cutover.
+  terminal success.
+- 2026-07-30: added `PostgresIndexReplayRunner` with a 1024-page invocation bound,
+  registry-derived source ownership, between-page heartbeat cadence, accumulated page/
+  mutation outcomes, terminal failure classification, graceful lease-loss handling,
+  null-cursor completion, and immediate `pending` yield/resume with attempt fencing.
+- Repository test/fixture suites, verifiers, cancellation, automatic retry/backoff,
+  dead-letter and host scheduling, live freshness/recovery evidence, one admitted
+  PostgreSQL/reference equivalence bundle, and one real full PostgreSQL partition packet
+  remain for the owner to execute and admit before authoritative consumer or production
+  partition cutover.
 
 ## Periodic release verification handoff
 
 - Cycle: `cycle-001`
 - Status: `blocked`
 - Last verified at (UTC): `2026-07-30`
-- Scope inspected: `Index ownership, migrations, mutation/version ordering, query execution, partition evidence guards, Social Graph consumer authority, privacy shadow deadline behavior, source replay ownership, replay checkpoint ordering, replay job attempt fencing, and source/search/server boundaries`
+- Scope inspected: `Index ownership, migrations, mutation/version ordering, query execution, partition evidence guards, Social Graph consumer authority, privacy shadow deadline behavior, source replay ownership, replay checkpoint ordering, replay job attempt fencing, bounded multi-page replay progression, and source/search/server boundaries`
 - Findings: `P0=0, P1=2, P2=0, P3=1`
-- Fixed in this pass: `bounded the non-authoritative Social Graph privacy comparison by the remaining caller deadline while preserving the owner result; repaired stale Index scale/FBA and retained-artifact guards; added a canonical bounded source replay/load registry; added one-page replay mutation application with stable event checks and checkpoint progression only after durable mutation outcomes; added schema-scoped rebuild job claims with lease/heartbeat, expired-attempt reclaim, attempt fencing, fenced checkpoint access, and durable null-cursor-gated success`
-- Remaining risks or blockers: `one retained admitted real PostgreSQL partition packet is absent; live PostgreSQL/reference query equivalence remains open; no bounded multi-page loop, cancellation, retry/backoff, dead-letter policy, locale/partition checkpoint dimensions, or production source adapter exists; no retained per-tenant freshness/watermark, lag, negative-result safety, outage/restart/backlog catch-up, or replay-repair evidence exists; consumer and production partition cutover remain forbidden`
-- Evidence: `PR #2544 merged as b647a5a17f27b34a07c20cd57525ed1806994c49; same-SHA Index Storage Scale Run Contract and full Scale Evidence contract passed JavaScript syntax, workflow contracts, repository contracts, direct validator arguments and fixture suites; source replay registry, one-page checkpoint progression, and replay job fencing are added in the current draft PR without implementation-agent test execution; general CI/Hardening received no jobs; Rust-hosted smoke previously stopped before compilation because Cargo.lock required an Athanor update under --locked`
-- Next action: `bind replay job acquisition to the materialized source registry and implement a bounded multi-page runner with heartbeat cadence and graceful lease loss, then add the first Product source adapter and execute retained PostgreSQL packet, live query equivalence, and per-tenant freshness/outage/recovery evidence before reconsidering authoritative consumers or partition lifecycle`
+- Fixed in this pass: `bounded the non-authoritative Social Graph privacy comparison by the remaining caller deadline while preserving the owner result; repaired stale Index scale/FBA and retained-artifact guards; added a canonical bounded source replay/load registry; added one-page replay mutation application with stable event checks and checkpoint progression only after durable mutation outcomes; added schema-scoped rebuild job claims with lease/heartbeat, expired-attempt reclaim, attempt fencing, fenced checkpoint access, durable null-cursor-gated success, and bounded multi-page execution with between-page heartbeat and immediate pending resume`
+- Remaining risks or blockers: `one retained admitted real PostgreSQL partition packet is absent; live PostgreSQL/reference query equivalence remains open; cancellation, automatic retry/backoff, dead-letter scheduling, host scheduling, locale/partition checkpoint dimensions, and production source adapters remain absent; no retained per-tenant freshness/watermark, lag, negative-result safety, outage/restart/backlog catch-up, or replay-repair evidence exists; consumer and production partition cutover remain forbidden`
+- Evidence: `PR #2544 merged as b647a5a17f27b34a07c20cd57525ed1806994c49; PR #2554 merged as 5b9d49e65295819ee9e8e9c199688c0e2ac73d35; same-SHA Index Storage Scale Run Contract and full Scale Evidence contract passed JavaScript syntax, workflow contracts, repository contracts, direct validator arguments and fixture suites; source replay registry, one-page checkpoint progression, replay job fencing, and bounded multi-page runner source are present without implementation-agent test execution; general CI/Hardening received no jobs; Rust-hosted smoke previously stopped before compilation because Cargo.lock required an Athanor update under --locked`
+- Next action: `add cancellation observation and terminal cancellation on the bounded runner, then bind it into host/server composition and add the first Product source adapter before executing retained PostgreSQL packet, live query equivalence, and per-tenant freshness/outage/recovery evidence`
 - Resume command: `cargo fmt --all -- --check && cargo check -p rustok-index --all-targets && node scripts/verify/verify-index-query-contract.mjs && node scripts/verify/index-storage-tooling.mjs contract && node scripts/verify/index-storage-tooling.mjs fixtures`

--- a/crates/rustok-index/docs/m6-bounded-multipage-runner.md
+++ b/crates/rustok-index/docs/m6-bounded-multipage-runner.md
@@ -1,0 +1,86 @@
+# M6 bounded multi-page replay runner
+
+Status: `source_complete_owner_execution_pending`
+
+This slice composes the existing one-page replay worker, fenced rebuild jobs, mutation
+store, and lease-bound checkpoint store into one bounded PostgreSQL runner. It does not
+add a scheduler, background task, automatic retry/backoff, cancellation command, dry-run,
+or production source adapter.
+
+## Request bounds
+
+`IndexReplayRunRequest` fixes one invocation to:
+
+- one non-nil tenant and exact `SchemaRef`;
+- one bounded worker identity and whole-second lease duration;
+- a source page limit already constrained to 1 through 1000;
+- 1 through 1024 pages per invocation;
+- a heartbeat cadence from 1 through the invocation page budget.
+
+The source name is never caller supplied. `PostgresIndexReplayRunner` resolves the exact
+owner from `SharedIndexSourceRegistry` before acquiring the durable job. The job request
+therefore uses the same source identity as page execution and checkpoint persistence.
+
+## Execution order
+
+For an acquired `IndexReplayJobLease`, the runner:
+
+1. constructs `PostgresIndexReplayCheckpointStore` from that exact lease;
+2. executes no more than the requested page budget through
+   `IndexReplayWorker::run_next_page`;
+3. extends the lease between pages at the requested completed-page cadence;
+4. accumulates applied, duplicate, stale, mutation, page, and heartbeat counts;
+5. calls fenced terminal success only after the one-page worker persisted a JSON `null`
+   cursor;
+6. when the page budget ends with continuation, atomically returns the same job to
+   `pending`, clears lease ownership, and makes it immediately claimable for resume.
+
+A page itself is not interrupted by a heartbeat task. Operators must choose a lease
+longer than the maximum admitted source-page and mutation-commit duration. Heartbeats
+protect bounded work between pages; retained timing evidence remains an owner step.
+
+## Resume and attempt fencing
+
+A yielded job keeps the same job UUID and durable checkpoint, but the next acquisition
+increments `attempt_count`. The old attempt cannot heartbeat, yield, fail, complete, or
+advance the checkpoint after the new attempt is claimed.
+
+Yield uses all existing ownership predicates: tenant, job UUID, `kind = 'rebuild'`,
+`state = 'running'`, worker ID, attempt count, and an unexpired lease. If any predicate
+fails, the runner returns explicit lease loss and does not publish a false pending or
+terminal state.
+
+## Failure boundary
+
+Source, mutation, and checkpoint failures are recorded as one bounded
+`index.replay_page_failed` terminal job error with an `index_replay_run_failure_v1`
+detail object containing only the dependency code and retryable classification. No raw
+database, transport, or source-domain message is persisted.
+
+Checkpoint failures classified as `checkpoint_lease_lost`, heartbeat loss, terminal
+completion loss, and yield loss return explicit `IndexReplayRunError::LeaseLost` instead
+of attempting a stale failure write. A later owner reclaims the expired job through the
+existing attempt fence.
+
+## Still open
+
+- cancellation request observation and terminal cancellation;
+- automatic bounded retry/backoff and dead-letter scheduling;
+- a host scheduler, command surface, and graceful process shutdown ownership;
+- direct server-composition publication of the runner;
+- dry-run and targeted/full/shadow rebuild modes;
+- locale and partition checkpoint dimensions;
+- Product and later source adapters;
+- retained PostgreSQL crash, lease-expiry, restart, timing, and multi-instance evidence.
+
+## Owner validation
+
+```bash
+node scripts/verify/verify-index-replay-multipage-runner.mjs
+node scripts/verify/verify-index-replay-job-leases.mjs
+node scripts/verify/verify-index-source-replay-contract.mjs
+cargo check -p rustok-index --all-targets
+cargo test -p rustok-index source_replay_runner --lib -- --nocapture
+```
+
+These commands are maintainer-run for this slice.

--- a/crates/rustok-index/src/infrastructure/postgres/mod.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/mod.rs
@@ -7,6 +7,7 @@ mod schema_registration;
 mod secondary_index;
 mod source_replay;
 mod source_replay_job;
+mod source_replay_runner;
 
 #[cfg(test)]
 mod mutation_store_tests;
@@ -22,6 +23,8 @@ mod schema_registration_tests;
 mod secondary_index_tests;
 #[cfg(test)]
 mod source_replay_job_tests;
+#[cfg(test)]
+mod source_replay_runner_tests;
 
 pub use mutation_store::{
     MutationApplyOutcome, MutationDelivery, MutationStorageError, PostgresMutationStore,
@@ -52,4 +55,8 @@ pub use source_replay::PostgresIndexReplayCheckpointStore;
 pub use source_replay_job::{
     IndexReplayJobAcquireOutcome, IndexReplayJobError, IndexReplayJobLease,
     IndexReplayJobLeaseRequest, PostgresIndexReplayJobStore,
+};
+pub use source_replay_runner::{
+    IndexReplayRunError, IndexReplayRunOutcome, IndexReplayRunRequest, IndexReplayRunStatus,
+    PostgresIndexReplayRunner,
 };

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs
@@ -1,0 +1,428 @@
+use std::{sync::Arc, time::Duration};
+
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement, Value as SqlValue};
+use serde_json::{json, Value as JsonValue};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::{
+    IndexReplayError, IndexReplayFailureKind, IndexReplayPageRequest, IndexReplayPageStatus,
+    IndexReplayWorker, IndexSourceError, IndexSourceFailureKind, SchemaRef, SchemaRegistry,
+    SharedIndexSourceRegistry,
+};
+
+use super::{
+    IndexReplayJobAcquireOutcome, IndexReplayJobError, IndexReplayJobLease,
+    IndexReplayJobLeaseRequest, PostgresIndexReplayCheckpointStore, PostgresIndexReplayJobStore,
+    PostgresMutationStore,
+};
+
+const MAX_PAGES_PER_RUN: usize = 1_024;
+const REPLAY_PAGE_FAILURE_CODE: &str = "index.replay_page_failed";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexReplayRunRequest {
+    page_request: IndexReplayPageRequest,
+    worker_id: String,
+    lease_duration: Duration,
+    max_pages: usize,
+    heartbeat_every_pages: usize,
+}
+
+impl IndexReplayRunRequest {
+    pub fn new(
+        tenant_id: Uuid,
+        schema: SchemaRef,
+        worker_id: impl Into<String>,
+        page_limit: usize,
+        max_pages: usize,
+        heartbeat_every_pages: usize,
+        lease_duration: Duration,
+    ) -> Result<Self, IndexReplayRunError> {
+        if !(1..=MAX_PAGES_PER_RUN).contains(&max_pages) {
+            return Err(IndexReplayRunError::InvalidMaxPages {
+                actual: max_pages,
+                max: MAX_PAGES_PER_RUN,
+            });
+        }
+        if heartbeat_every_pages == 0 || heartbeat_every_pages > max_pages {
+            return Err(IndexReplayRunError::InvalidHeartbeatCadence {
+                actual: heartbeat_every_pages,
+                max: max_pages,
+            });
+        }
+        let page_request = IndexReplayPageRequest::new(tenant_id, schema, page_limit)
+            .map_err(IndexReplayRunError::InvalidPageRequest)?;
+        Ok(Self {
+            page_request,
+            worker_id: worker_id.into(),
+            lease_duration,
+            max_pages,
+            heartbeat_every_pages,
+        })
+    }
+
+    pub fn page_request(&self) -> &IndexReplayPageRequest {
+        &self.page_request
+    }
+
+    pub fn worker_id(&self) -> &str {
+        &self.worker_id
+    }
+
+    pub fn lease_duration(&self) -> Duration {
+        self.lease_duration
+    }
+
+    pub fn max_pages(&self) -> usize {
+        self.max_pages
+    }
+
+    pub fn heartbeat_every_pages(&self) -> usize {
+        self.heartbeat_every_pages
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexReplayRunStatus {
+    Busy,
+    AlreadyComplete,
+    Complete,
+    Yielded,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexReplayRunOutcome {
+    status: IndexReplayRunStatus,
+    job_id: Option<Uuid>,
+    attempt_count: Option<u32>,
+    pages_processed: usize,
+    heartbeat_count: usize,
+    mutation_count: usize,
+    applied_count: usize,
+    duplicate_count: usize,
+    stale_count: usize,
+}
+
+impl IndexReplayRunOutcome {
+    pub fn status(&self) -> IndexReplayRunStatus {
+        self.status
+    }
+
+    pub fn job_id(&self) -> Option<Uuid> {
+        self.job_id
+    }
+
+    pub fn attempt_count(&self) -> Option<u32> {
+        self.attempt_count
+    }
+
+    pub fn pages_processed(&self) -> usize {
+        self.pages_processed
+    }
+
+    pub fn heartbeat_count(&self) -> usize {
+        self.heartbeat_count
+    }
+
+    pub fn mutation_count(&self) -> usize {
+        self.mutation_count
+    }
+
+    pub fn applied_count(&self) -> usize {
+        self.applied_count
+    }
+
+    pub fn duplicate_count(&self) -> usize {
+        self.duplicate_count
+    }
+
+    pub fn stale_count(&self) -> usize {
+        self.stale_count
+    }
+}
+
+#[derive(Clone)]
+pub struct PostgresIndexReplayRunner {
+    db: DatabaseConnection,
+    sources: SharedIndexSourceRegistry,
+    schema_registry: Arc<SchemaRegistry>,
+}
+
+impl PostgresIndexReplayRunner {
+    pub fn new(
+        db: DatabaseConnection,
+        sources: SharedIndexSourceRegistry,
+        schema_registry: Arc<SchemaRegistry>,
+    ) -> Self {
+        Self {
+            db,
+            sources,
+            schema_registry,
+        }
+    }
+
+    pub async fn run(
+        &self,
+        request: IndexReplayRunRequest,
+    ) -> Result<IndexReplayRunOutcome, IndexReplayRunError> {
+        let source_name = self
+            .sources
+            .source_for_schema(request.page_request().schema())
+            .ok_or_else(|| {
+                IndexReplayRunError::UnknownSchemaSource(
+                    request.page_request().schema().clone(),
+                )
+            })?
+            .source_name()
+            .to_owned();
+        let lease_request = IndexReplayJobLeaseRequest::new(
+            request.page_request().tenant_id(),
+            request.page_request().schema().clone(),
+            source_name,
+            request.worker_id().to_owned(),
+            request.lease_duration(),
+        )?;
+        let job_store = PostgresIndexReplayJobStore::new(self.db.clone());
+        let lease = match job_store.acquire(&lease_request).await? {
+            IndexReplayJobAcquireOutcome::Busy => {
+                return Ok(empty_outcome(IndexReplayRunStatus::Busy, None, None));
+            }
+            IndexReplayJobAcquireOutcome::AlreadyComplete { job_id } => {
+                return Ok(empty_outcome(
+                    IndexReplayRunStatus::AlreadyComplete,
+                    Some(job_id),
+                    None,
+                ));
+            }
+            IndexReplayJobAcquireOutcome::Acquired(lease) => lease,
+        };
+
+        let checkpoint_store =
+            PostgresIndexReplayCheckpointStore::new(self.db.clone(), lease.clone());
+        let worker = IndexReplayWorker::new(
+            self.sources.clone(),
+            self.schema_registry.clone(),
+            PostgresMutationStore::new(self.db.clone()),
+            checkpoint_store,
+        );
+
+        let mut aggregate = IndexReplayRunOutcome {
+            status: IndexReplayRunStatus::Yielded,
+            job_id: Some(lease.job_id()),
+            attempt_count: Some(lease.attempt_count()),
+            pages_processed: 0,
+            heartbeat_count: 0,
+            mutation_count: 0,
+            applied_count: 0,
+            duplicate_count: 0,
+            stale_count: 0,
+        };
+
+        for page_index in 0..request.max_pages() {
+            if page_index > 0 && page_index % request.heartbeat_every_pages() == 0 {
+                heartbeat(&job_store, &lease, request.lease_duration()).await?;
+                aggregate.heartbeat_count += 1;
+            }
+
+            let page = match worker.run_next_page(request.page_request().clone()).await {
+                Ok(page) => page,
+                Err(error) if replay_error_is_lease_lost(&error) => {
+                    return Err(lease_lost(&lease));
+                }
+                Err(error) => {
+                    let details = replay_failure_details(&error);
+                    match job_store
+                        .fail(&lease, REPLAY_PAGE_FAILURE_CODE, details)
+                        .await
+                    {
+                        Ok(()) => {
+                            return Err(IndexReplayRunError::PageFailed {
+                                job_id: lease.job_id(),
+                                error: Box::new(error),
+                            });
+                        }
+                        Err(IndexReplayJobError::LeaseLost) => {
+                            return Err(lease_lost(&lease));
+                        }
+                        Err(job_error) => return Err(IndexReplayRunError::Job(job_error)),
+                    }
+                }
+            };
+
+            if page.status() != IndexReplayPageStatus::AlreadyComplete {
+                aggregate.pages_processed += 1;
+            }
+            aggregate.mutation_count += page.mutation_count();
+            aggregate.applied_count += page.applied_count();
+            aggregate.duplicate_count += page.duplicate_count();
+            aggregate.stale_count += page.stale_count();
+
+            if matches!(
+                page.status(),
+                IndexReplayPageStatus::Complete | IndexReplayPageStatus::AlreadyComplete
+            ) {
+                match job_store.succeed(&lease).await {
+                    Ok(()) => {
+                        aggregate.status = IndexReplayRunStatus::Complete;
+                        return Ok(aggregate);
+                    }
+                    Err(IndexReplayJobError::LeaseLost) => return Err(lease_lost(&lease)),
+                    Err(error) => return Err(IndexReplayRunError::Job(error)),
+                }
+            }
+        }
+
+        yield_for_resume(&self.db, &lease).await?;
+        Ok(aggregate)
+    }
+}
+
+fn empty_outcome(
+    status: IndexReplayRunStatus,
+    job_id: Option<Uuid>,
+    attempt_count: Option<u32>,
+) -> IndexReplayRunOutcome {
+    IndexReplayRunOutcome {
+        status,
+        job_id,
+        attempt_count,
+        pages_processed: 0,
+        heartbeat_count: 0,
+        mutation_count: 0,
+        applied_count: 0,
+        duplicate_count: 0,
+        stale_count: 0,
+    }
+}
+
+async fn heartbeat(
+    job_store: &PostgresIndexReplayJobStore,
+    lease: &IndexReplayJobLease,
+    lease_duration: Duration,
+) -> Result<(), IndexReplayRunError> {
+    match job_store.heartbeat(lease, lease_duration).await {
+        Ok(()) => Ok(()),
+        Err(IndexReplayJobError::LeaseLost) => Err(lease_lost(lease)),
+        Err(error) => Err(IndexReplayRunError::Job(error)),
+    }
+}
+
+async fn yield_for_resume(
+    db: &DatabaseConnection,
+    lease: &IndexReplayJobLease,
+) -> Result<(), IndexReplayRunError> {
+    let backend = db.get_database_backend();
+    ensure_supported_backend(backend)?;
+    let updated = db
+        .execute(Statement::from_sql_and_values(
+            backend,
+            yield_job_sql(backend),
+            vec![
+                uuid_value(lease.tenant_id(), backend),
+                uuid_value(lease.job_id(), backend),
+                lease.worker_id().to_owned().into(),
+                i64::from(lease.attempt_count()).into(),
+            ],
+        ))
+        .await
+        .map_err(|error| IndexReplayRunError::Job(IndexReplayJobError::Storage(error.to_string())))?;
+    if updated.rows_affected() != 1 {
+        return Err(lease_lost(lease));
+    }
+    Ok(())
+}
+
+fn replay_error_is_lease_lost(error: &IndexReplayError) -> bool {
+    match error {
+        IndexReplayError::CheckpointReadFailed(failure)
+        | IndexReplayError::CheckpointCommitFailed(failure) => {
+            failure.code() == "checkpoint_lease_lost"
+        }
+        _ => false,
+    }
+}
+
+fn replay_failure_details(error: &IndexReplayError) -> JsonValue {
+    let (code, retryable) = match error {
+        IndexReplayError::SourceContract(IndexSourceError::SourceFailure { failure, .. }) => (
+            failure.code(),
+            failure.kind() == IndexSourceFailureKind::Retryable,
+        ),
+        IndexReplayError::MutationFailed { failure, .. }
+        | IndexReplayError::CheckpointReadFailed(failure)
+        | IndexReplayError::CheckpointCommitFailed(failure) => (
+            failure.code(),
+            failure.kind() == IndexReplayFailureKind::Retryable,
+        ),
+        IndexReplayError::SourceContract(_) => ("source_contract_invalid", false),
+        _ => ("replay_contract_invalid", false),
+    };
+    json!({
+        "contract": "index_replay_run_failure_v1",
+        "dependency_code": code,
+        "retryable": retryable,
+    })
+}
+
+fn ensure_supported_backend(backend: DbBackend) -> Result<(), IndexReplayRunError> {
+    match backend {
+        DbBackend::Postgres => Ok(()),
+        DbBackend::Sqlite if cfg!(test) => Ok(()),
+        backend => Err(IndexReplayRunError::Job(IndexReplayJobError::Storage(
+            format!("Index replay runner does not support {backend:?}"),
+        ))),
+    }
+}
+
+fn placeholder_prefix(backend: DbBackend) -> &'static str {
+    match backend {
+        DbBackend::Postgres => "$",
+        DbBackend::Sqlite => "?",
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+fn uuid_value(value: Uuid, backend: DbBackend) -> SqlValue {
+    match backend {
+        DbBackend::Postgres => value.into(),
+        DbBackend::Sqlite => value.to_string().into(),
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+fn yield_job_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    format!(
+        "UPDATE index_jobs SET state = 'pending', available_at = CURRENT_TIMESTAMP, lease_owner = NULL, lease_expires_at = NULL, heartbeat_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'rebuild' AND state = 'running' AND lease_owner = {prefix}3 AND attempt_count = {prefix}4 AND lease_expires_at > CURRENT_TIMESTAMP"
+    )
+}
+
+fn lease_lost(lease: &IndexReplayJobLease) -> IndexReplayRunError {
+    IndexReplayRunError::LeaseLost {
+        job_id: lease.job_id(),
+        attempt_count: lease.attempt_count(),
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum IndexReplayRunError {
+    #[error("Index replay run page request is invalid")]
+    InvalidPageRequest(#[source] IndexReplayError),
+    #[error("Index replay run max pages is invalid: actual={actual}, max={max}")]
+    InvalidMaxPages { actual: usize, max: usize },
+    #[error("Index replay heartbeat cadence is invalid: actual={actual}, max={max}")]
+    InvalidHeartbeatCadence { actual: usize, max: usize },
+    #[error("No Index replay source owns schema {0}")]
+    UnknownSchemaSource(SchemaRef),
+    #[error(transparent)]
+    Job(#[from] IndexReplayJobError),
+    #[error("Index replay job {job_id} lost attempt {attempt_count} ownership")]
+    LeaseLost { job_id: Uuid, attempt_count: u32 },
+    #[error("Index replay job {job_id} failed while processing a page")]
+    PageFailed {
+        job_id: Uuid,
+        #[source]
+        error: Box<IndexReplayError>,
+    },
+}

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_runner_tests.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_runner_tests.rs
@@ -1,0 +1,328 @@
+use std::{
+    collections::BTreeMap,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use rustok_core::MigrationSource;
+use sea_orm::{
+    ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement, Value as SqlValue,
+};
+use sea_orm_migration::SchemaManager;
+use serde_json::json;
+use uuid::Uuid;
+
+use super::{
+    IndexReplayRunError, IndexReplayRunRequest, IndexReplayRunStatus, PostgresIndexReplayRunner,
+};
+use crate::{
+    EntityKey, EntityName, FieldCardinality, FieldName, IndexField, IndexModule, IndexMutation,
+    IndexRecord, IndexSchema, IndexSchemaSourceCatalog, IndexSource, IndexSourceCatalog,
+    IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest, IndexSourcePage,
+    IndexSourceScanRequest, IndexValue, IndexValueType, LocaleMode, ModuleName, SchemaRef,
+    SchemaRegistry, SchemaVersion,
+};
+
+const TENANT: &str = "11111111-1111-1111-1111-111111111111";
+
+struct PagedSource {
+    db: DatabaseConnection,
+    calls: Arc<AtomicUsize>,
+    page_count: usize,
+    expire_lease_on_call: Option<usize>,
+}
+
+#[async_trait]
+impl IndexSource for PagedSource {
+    async fn scan(
+        &self,
+        request: IndexSourceScanRequest,
+    ) -> Result<IndexSourcePage, IndexSourceFailure> {
+        let call = self.calls.fetch_add(1, Ordering::SeqCst);
+        if self.expire_lease_on_call == Some(call) {
+            self.db
+                .execute(Statement::from_string(
+                    DbBackend::Sqlite,
+                    "UPDATE index_jobs SET lease_expires_at = datetime('now', '-1 second') WHERE kind = 'rebuild' AND state = 'running'".to_owned(),
+                ))
+                .await
+                .expect("test source should expire the active replay lease");
+        }
+
+        let page = request
+            .cursor()
+            .map(|cursor| {
+                cursor
+                    .value()
+                    .as_u64()
+                    .expect("test cursor should be an integer") as usize
+            })
+            .unwrap_or(0);
+        let entity_id = Uuid::from_u128(100 + page as u128);
+        let event_id = Uuid::from_u128(1_000 + page as u128);
+        let mutation = mutation(request.tenant_id(), entity_id, event_id, page as u64 + 1);
+        let next_cursor = if page + 1 < self.page_count {
+            Some(crate::IndexSourceCursor::new(json!(page + 1)).unwrap())
+        } else {
+            None
+        };
+        Ok(IndexSourcePage::new(&request, vec![mutation], next_cursor)
+            .expect("test source page should satisfy the bounded contract"))
+    }
+
+    async fn load(
+        &self,
+        request: IndexSourceLoadRequest,
+    ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+        Ok(IndexSourceLoadBatch::new(&request, Vec::new()).expect("empty targeted load"))
+    }
+}
+
+struct Fixture {
+    db: DatabaseConnection,
+    runner: PostgresIndexReplayRunner,
+    calls: Arc<AtomicUsize>,
+}
+
+impl Fixture {
+    async fn new(page_count: usize, expire_lease_on_call: Option<usize>) -> Self {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite should connect");
+        db.execute_unprepared("PRAGMA foreign_keys = ON")
+            .await
+            .expect("foreign keys should be enabled");
+        db.execute_unprepared("CREATE TABLE tenants (id TEXT PRIMARY KEY)")
+            .await
+            .expect("tenant fixture should be created");
+        db.execute_unprepared(&format!("INSERT INTO tenants (id) VALUES ('{TENANT}')"))
+            .await
+            .expect("tenant fixture should be inserted");
+        let manager = SchemaManager::new(&db);
+        for migration in IndexModule.migrations() {
+            migration
+                .up(&manager)
+                .await
+                .unwrap_or_else(|error| panic!("{} should apply: {error}", migration.name()));
+        }
+
+        let schema = schema();
+        let fingerprint = schema.fingerprint().unwrap().to_string();
+        let schema_json = serde_json::to_value(&schema).unwrap();
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO index_schemas (tenant_id, module_name, entity_name, schema_version, schema_fingerprint, schema_json, status) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'active')",
+            vec![
+                TENANT.to_owned().into(),
+                schema.reference.module.as_str().to_owned().into(),
+                schema.reference.entity.as_str().to_owned().into(),
+                i64::from(schema.reference.version.get()).into(),
+                fingerprint.into(),
+                SqlValue::Json(Some(Box::new(schema_json))),
+            ],
+        ))
+        .await
+        .expect("schema fixture should persist");
+
+        let mut schema_catalog = IndexSchemaSourceCatalog::new();
+        schema_catalog.register("product", schema.clone()).unwrap();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut source_catalog = IndexSourceCatalog::new();
+        source_catalog
+            .register(
+                "product",
+                "product-primary",
+                [schema.reference.clone()],
+                PagedSource {
+                    db: db.clone(),
+                    calls: calls.clone(),
+                    page_count,
+                    expire_lease_on_call,
+                },
+            )
+            .unwrap();
+        let sources = source_catalog.materialize(&schema_catalog).unwrap();
+        let mut registry = SchemaRegistry::new();
+        registry.register(schema).unwrap();
+        let runner = PostgresIndexReplayRunner::new(db.clone(), sources, Arc::new(registry));
+
+        Self { db, runner, calls }
+    }
+
+    fn request(
+        &self,
+        worker_id: &str,
+        max_pages: usize,
+        heartbeat_every_pages: usize,
+    ) -> IndexReplayRunRequest {
+        IndexReplayRunRequest::new(
+            Uuid::parse_str(TENANT).unwrap(),
+            schema_ref(),
+            worker_id,
+            10,
+            max_pages,
+            heartbeat_every_pages,
+            Duration::from_secs(60),
+        )
+        .unwrap()
+    }
+}
+
+fn schema_ref() -> SchemaRef {
+    SchemaRef {
+        module: ModuleName::new("rustok-product").unwrap(),
+        entity: EntityName::new("product").unwrap(),
+        version: SchemaVersion::INITIAL,
+    }
+}
+
+fn schema() -> IndexSchema {
+    IndexSchema {
+        reference: schema_ref(),
+        locale_mode: LocaleMode::None,
+        fields: vec![IndexField {
+            name: FieldName::new("id").unwrap(),
+            value_type: IndexValueType::Uuid,
+            cardinality: FieldCardinality::One,
+            nullable: false,
+            selectable: true,
+            filterable: true,
+            sortable: true,
+        }],
+        links: Vec::new(),
+    }
+}
+
+fn mutation(
+    tenant_id: Uuid,
+    entity_id: Uuid,
+    event_id: Uuid,
+    source_version: u64,
+) -> IndexMutation {
+    IndexMutation::Upsert {
+        event_id,
+        record: IndexRecord {
+            key: EntityKey {
+                tenant_id,
+                schema: schema_ref(),
+                entity_id,
+                locale: None,
+            },
+            source_version,
+            fields: BTreeMap::from([(
+                FieldName::new("id").unwrap(),
+                IndexValue::Uuid(entity_id),
+            )]),
+            links: Vec::new(),
+        },
+    }
+}
+
+async fn scalar_i64(db: &DatabaseConnection, sql: &str) -> i64 {
+    db.query_one(Statement::from_string(DbBackend::Sqlite, sql.to_owned()))
+        .await
+        .expect("scalar query should execute")
+        .expect("scalar query should return one row")
+        .try_get("", "value")
+        .expect("scalar value should be integer")
+}
+
+async fn scalar_string(db: &DatabaseConnection, sql: &str) -> String {
+    db.query_one(Statement::from_string(DbBackend::Sqlite, sql.to_owned()))
+        .await
+        .expect("scalar query should execute")
+        .expect("scalar query should return one row")
+        .try_get("", "value")
+        .expect("scalar value should be text")
+}
+
+#[tokio::test]
+async fn bounded_run_yields_pending_and_resumes_with_a_new_attempt() {
+    let fixture = Fixture::new(3, None).await;
+    let first = fixture.runner.run(fixture.request("worker-a", 2, 1)).await.unwrap();
+    assert_eq!(first.status(), IndexReplayRunStatus::Yielded);
+    assert_eq!(first.pages_processed(), 2);
+    assert_eq!(first.heartbeat_count(), 1);
+    assert_eq!(first.mutation_count(), 2);
+    assert_eq!(first.attempt_count(), Some(1));
+    assert_eq!(
+        scalar_i64(
+            &fixture.db,
+            "SELECT COUNT(*) AS value FROM index_jobs WHERE kind = 'rebuild' AND state = 'pending' AND lease_owner IS NULL AND lease_expires_at IS NULL AND completed_at IS NULL",
+        )
+        .await,
+        1,
+    );
+
+    let second = fixture.runner.run(fixture.request("worker-b", 2, 1)).await.unwrap();
+    assert_eq!(second.status(), IndexReplayRunStatus::Complete);
+    assert_eq!(second.job_id(), first.job_id());
+    assert_eq!(second.attempt_count(), Some(2));
+    assert_eq!(second.pages_processed(), 1);
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 3);
+    assert_eq!(
+        scalar_i64(
+            &fixture.db,
+            "SELECT COUNT(*) AS value FROM index_jobs WHERE kind = 'rebuild' AND state = 'succeeded' AND completed_at IS NOT NULL",
+        )
+        .await,
+        1,
+    );
+}
+
+#[tokio::test]
+async fn lease_loss_during_a_page_does_not_publish_failure_or_advance_cursor() {
+    let fixture = Fixture::new(2, Some(1)).await;
+    let error = fixture
+        .runner
+        .run(fixture.request("worker-a", 2, 1))
+        .await
+        .expect_err("expired attempt must stop without terminal publication");
+    assert!(matches!(error, IndexReplayRunError::LeaseLost { .. }));
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        scalar_i64(
+            &fixture.db,
+            "SELECT COUNT(*) AS value FROM index_jobs WHERE kind = 'rebuild' AND state = 'running' AND completed_at IS NULL AND last_error_code IS NULL",
+        )
+        .await,
+        1,
+    );
+    assert_eq!(
+        scalar_string(
+            &fixture.db,
+            "SELECT CAST(cursor AS TEXT) AS value FROM index_checkpoints WHERE checkpoint_kind = 'rebuild'",
+        )
+        .await,
+        "1",
+    );
+}
+
+#[test]
+fn run_request_bounds_pages_and_heartbeat_cadence() {
+    let tenant_id = Uuid::parse_str(TENANT).unwrap();
+    assert!(IndexReplayRunRequest::new(
+        tenant_id,
+        schema_ref(),
+        "worker-a",
+        10,
+        0,
+        1,
+        Duration::from_secs(60),
+    )
+    .is_err());
+    assert!(IndexReplayRunRequest::new(
+        tenant_id,
+        schema_ref(),
+        "worker-a",
+        10,
+        2,
+        3,
+        Duration::from_secs(60),
+    )
+    .is_err());
+}

--- a/crates/rustok-index/src/lib.rs
+++ b/crates/rustok-index/src/lib.rs
@@ -4,8 +4,9 @@
 //! core under [`domain`] and [`application`], the canonical M3 PostgreSQL
 //! storage-schema migrations, atomic mutation persistence, tenant-scoped source
 //! schema registration, bounded source replay/load contracts, one-page replay
-//! orchestration with durable fenced checkpoint progression, durable replay-job
-//! and schema-application leases, schema-derived secondary-index lifecycle,
+//! orchestration with durable fenced checkpoint progression, bounded multi-page
+//! replay coordination with heartbeat/yield semantics, durable replay-job and
+//! schema-application leases, schema-derived secondary-index lifecycle,
 //! fail-closed measured partition admission, and the PostgreSQL execution adapter
 //! for structured Index queries.
 
@@ -26,18 +27,20 @@ pub use domain::*;
 pub use infrastructure::postgres::{
     evaluate_partition_admission, materialize_postgres_index_query_runtime,
     IndexQueryRuntimeCompositionError, IndexReplayJobAcquireOutcome, IndexReplayJobError,
-    IndexReplayJobLease, IndexReplayJobLeaseRequest, MutationApplyOutcome, MutationDelivery,
+    IndexReplayJobLease, IndexReplayJobLeaseRequest, IndexReplayRunError, IndexReplayRunOutcome,
+    IndexReplayRunRequest, IndexReplayRunStatus, MutationApplyOutcome, MutationDelivery,
     MutationStorageError, PartitionAdmissionError, PartitionAdmissionOutcome,
     PartitionAdmissionPolicy, PartitionAdmissionReason, PartitionBaselineEvidence,
     PartitionEvidence, PartitionMeasurementCoverage, PartitionRelationPlan,
     PartitionShadowEvidence, PartitionShadowPlan, PartitionStrategy,
     PersistedSchemaRegistrationOutcome, PostgresIndexQueryPort,
-    PostgresIndexReplayCheckpointStore, PostgresIndexReplayJobStore, PostgresMutationStore,
-    PostgresSchemaLeaseStore, PostgresSchemaRegistrationStore, PostgresSecondaryIndexManager,
-    SchemaApplicationLease, SchemaApplicationLeaseRequest, SchemaLeaseAcquireOutcome,
-    SchemaLeaseError, SchemaRegistrationError, SecondaryIndexClaimOutcome, SecondaryIndexError,
-    SecondaryIndexExecutionOutcome, SecondaryIndexKind, SecondaryIndexLease,
-    SecondaryIndexOperation, SecondaryIndexPlan, SecondaryIndexRequest, SecondaryIndexSpec,
+    PostgresIndexReplayCheckpointStore, PostgresIndexReplayJobStore, PostgresIndexReplayRunner,
+    PostgresMutationStore, PostgresSchemaLeaseStore, PostgresSchemaRegistrationStore,
+    PostgresSecondaryIndexManager, SchemaApplicationLease, SchemaApplicationLeaseRequest,
+    SchemaLeaseAcquireOutcome, SchemaLeaseError, SchemaRegistrationError,
+    SecondaryIndexClaimOutcome, SecondaryIndexError, SecondaryIndexExecutionOutcome,
+    SecondaryIndexKind, SecondaryIndexLease, SecondaryIndexOperation, SecondaryIndexPlan,
+    SecondaryIndexRequest, SecondaryIndexSpec,
 };
 
 pub struct IndexModule;

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -19,6 +19,7 @@ const scripts = [
   'verify-index-source-schema-registry.mjs',
   'verify-index-source-replay-contract.mjs',
   'verify-index-replay-job-leases.mjs',
+  'verify-index-replay-multipage-runner.mjs',
   'verify-index-query-runtime-composition.mjs',
   'verify-index-social-graph-privacy-consumer.mjs',
   'verify-social-graph-privacy-shadow-evidence.mjs',

--- a/scripts/verify/verify-index-replay-multipage-runner.mjs
+++ b/scripts/verify/verify-index-replay-multipage-runner.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-replay-multipage-runner] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const runnerPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs';
+const runner = requireMarkers(runnerPath, [
+  'const MAX_PAGES_PER_RUN: usize = 1_024;',
+  'pub struct IndexReplayRunRequest',
+  'pub enum IndexReplayRunStatus',
+  'pub struct IndexReplayRunOutcome',
+  'pub struct PostgresIndexReplayRunner',
+  '.source_for_schema(request.page_request().schema())',
+  'IndexReplayJobLeaseRequest::new(',
+  'PostgresIndexReplayCheckpointStore::new(self.db.clone(), lease.clone())',
+  'for page_index in 0..request.max_pages()',
+  'page_index % request.heartbeat_every_pages() == 0',
+  'worker.run_next_page(request.page_request().clone())',
+  'job_store.succeed(&lease).await',
+  'yield_for_resume(&self.db, &lease).await?;',
+  "state = 'pending'",
+  "kind = 'rebuild'",
+  'lease_expires_at > CURRENT_TIMESTAMP',
+  'index_replay_run_failure_v1',
+  'checkpoint_lease_lost',
+  'IndexReplayRunError::LeaseLost',
+]);
+
+for (const forbidden of [
+  'tokio::spawn',
+  'loop {',
+  'tokio::time::sleep',
+  'cancel_requested',
+  'DELETE FROM index_jobs',
+  'rustok_product',
+  'rustok_content',
+  'rustok_flex',
+]) {
+  if (runner.includes(forbidden)) fail(`${runnerPath} contains forbidden marker ${forbidden}`);
+}
+
+const runLoop = runner.indexOf('for page_index in 0..request.max_pages()');
+const pageCall = runner.indexOf('worker.run_next_page(request.page_request().clone())', runLoop);
+const successCall = runner.indexOf('job_store.succeed(&lease).await', pageCall);
+const yieldCall = runner.indexOf('yield_for_resume(&self.db, &lease).await?;', successCall);
+if (runLoop < 0 || pageCall <= runLoop || successCall <= pageCall || yieldCall <= successCall) {
+  fail('runner must process bounded pages, complete on null cursor, then yield unfinished work');
+}
+
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/source_replay_runner_tests.rs', [
+  'bounded_run_yields_pending_and_resumes_with_a_new_attempt',
+  'lease_loss_during_a_page_does_not_publish_failure_or_advance_cursor',
+  'run_request_bounds_pages_and_heartbeat_cadence',
+  'IndexReplayRunStatus::Yielded',
+  'IndexReplayRunStatus::Complete',
+  'second.attempt_count(), Some(2)',
+  "state = 'pending'",
+  'last_error_code IS NULL',
+]);
+
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
+  'mod source_replay_runner;',
+  'mod source_replay_runner_tests;',
+  'PostgresIndexReplayRunner',
+  'IndexReplayRunRequest',
+  'IndexReplayRunOutcome',
+]);
+
+requireMarkers('crates/rustok-index/src/lib.rs', [
+  'bounded multi-page',
+  'PostgresIndexReplayRunner',
+  'IndexReplayRunRequest',
+  'IndexReplayRunStatus',
+]);
+
+requireMarkers('crates/rustok-index/docs/m6-bounded-multipage-runner.md', [
+  'Status: `source_complete_owner_execution_pending`',
+  '1 through 1024 pages per invocation',
+  'The source name is never caller supplied.',
+  'returns the same job to',
+  '`pending`',
+  '`index_replay_run_failure_v1`',
+  'cancellation request observation',
+  'maintainer-run',
+]);
+
+requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
+  '- M6 bounded multi-page replay runner: `source_complete_owner_execution_pending`',
+  '- [x] Add bounded multi-page execution with heartbeat cadence and immediate pending resume.',
+  'Cancellation, automatic retry/backoff, dead-letter scheduling, host scheduling, and',
+]);
+
+requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
+  "'verify-index-replay-job-leases.mjs'",
+  "'verify-index-replay-multipage-runner.mjs'",
+  "'verify-index-source-replay-contract.mjs'",
+]);
+
+console.log('[verify-index-replay-multipage-runner] OK');


### PR DESCRIPTION
## Summary

- add `PostgresIndexReplayRunner` over the existing source registry, one-page worker, mutation store, fenced rebuild jobs, and lease-bound checkpoint store
- resolve the replay source from `SharedIndexSourceRegistry` instead of accepting a caller-supplied source name
- bound one invocation to 1 through 1024 pages and retain the existing 1 through 1000 mutation page limit
- heartbeat only between pages at a caller-selected completed-page cadence
- aggregate page, heartbeat, mutation, applied, duplicate, and stale counts
- complete the durable job only after the checkpoint contains a JSON-null cursor
- return unfinished work to immediately claimable `pending` state while preserving job UUID and checkpoint
- increment `attempt_count` on the next claim so the old attempt remains fenced
- persist bounded `index_replay_run_failure_v1` details for non-lease page failures
- return explicit lease loss without publishing stale pending or terminal state
- add SQLite contract fixtures, a fail-closed repository guard, dedicated M6 documentation, public exports, and the canonical plan update

## Explicitly not included

- cancellation observation or terminal cancellation
- automatic retry/backoff or dead-letter scheduling
- host/server scheduler composition or graceful shutdown ownership
- dry-run or targeted/full/shadow mode selection
- locale/partition checkpoint dimensions
- Product or other production source adapters
- retained PostgreSQL crash/restart/timing or multi-instance evidence

## Validation

Not run by the implementation agent, per owner request. The repository owner will run formatting, Cargo checks/tests, JavaScript guards, fixtures, and CI.

Suggested owner commands:

```bash
node scripts/verify/verify-index-replay-multipage-runner.mjs
node scripts/verify/verify-index-replay-job-leases.mjs
node scripts/verify/verify-index-source-replay-contract.mjs
node scripts/verify/verify-index-query-contract.mjs
cargo check -p rustok-index --all-targets
cargo test -p rustok-index source_replay_runner --lib -- --nocapture
```

## Branch policy

This branch was created from a fresh `main`. Parallel commits after branch creation do not touch Index files. Squash merge is requested, followed by branch deletion and a new branch from the then-current `main`.