### PR TITLE
fix(product): sanitize storefront GraphQL failures

### DIFF
--- a/crates/rustok-product/contracts/evidence/storefront-graphql-error-safety-source-review.json
+++ b/crates/rustok-product/contracts/evidence/storefront-graphql-error-safety-source-review.json
@@ -1,0 +1,71 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-30",
+  "status": "product_storefront_graphql_error_safety_source_reviewed_unvalidated",
+  "base_main_sha": "aef96f57d3babc2efdc65cc0c57cfea6fb48b5ad",
+  "reviewed_sources": [
+    "crates/rustok-commerce/docs/implementation-plan.md",
+    "crates/rustok-product/storefront/Cargo.toml",
+    "crates/rustok-product/storefront/src/catalog_controls.rs",
+    "crates/rustok-product/storefront/src/core.rs",
+    "crates/rustok-product/storefront/src/transport/mod.rs",
+    "crates/rustok-product/storefront/src/transport/graphql_adapter.rs",
+    "crates/rustok-product/storefront/src/transport/graphql_error_safety.rs",
+    "crates/rustok-product/storefront/src/transport/catalog_list_native.rs",
+    "crates/rustok-product/storefront/src/transport/native_server_adapter.rs",
+    "crates/rustok-ui-transport/src/lib.rs",
+    "crates/rustok-graphql/src/lib.rs",
+    "scripts/verify/verify-product-storefront-boundary.mjs",
+    "scripts/verify/verify-product-storefront-catalog-native-error-safety.mjs"
+  ],
+  "findings": [
+    {
+      "id": "product-storefront-graphql-public-detail",
+      "severity": "p1",
+      "finding": "The product storefront facade delegated both selected GraphQL closures directly to the private adapter, whose GraphqlHttpError conversion retained display text in UiTransportError.graphql_error.",
+      "resolution": "Create owner-specific per-call contexts at the public consumer boundary and map only ApiError::Graphql to static public envelopes."
+    },
+    {
+      "id": "product-storefront-multi-request-catalog",
+      "severity": "contract",
+      "finding": "fetch_products may execute catalog list, selected detail, and pricing GraphQL requests under one public operation.",
+      "resolution": "Sanitize once at the facade operation boundary without changing the four private GraphQL documents, request order, DTO mapping, or pricing-context construction."
+    },
+    {
+      "id": "product-storefront-correlation-context",
+      "severity": "contract",
+      "finding": "The client-side GraphQL path had no product-owner correlation event and could expose raw query or HTTP detail.",
+      "resolution": "Generate a unique per-call correlation id and retain only optional-field presence, string lengths, and collection counts in internal diagnostics."
+    }
+  ],
+  "preserved_behavior": [
+    "explicit feature-based transport selection",
+    "no native-to-GraphQL fallback",
+    "private GraphQL adapter and four documents",
+    "typed catalog controls and pagination constants",
+    "product detail and pricing request order",
+    "request and response DTOs",
+    "pricing-context derivation",
+    "native catalog-list and search-options paths",
+    "native error-safety policy"
+  ],
+  "execution": {
+    "commands": [],
+    "tests": [],
+    "verifiers": [],
+    "cargo": [],
+    "format": [],
+    "workflows": [],
+    "ci": []
+  },
+  "claims": {
+    "source_reviewed": true,
+    "source_ready": true,
+    "compiled": false,
+    "runtime_verified": false,
+    "mounted_parity_verified": false,
+    "ffa_promoted": false,
+    "fba_promoted": false,
+    "production_promoted": false
+  }
+}

--- a/crates/rustok-product/contracts/evidence/storefront-graphql-error-safety-source.json
+++ b/crates/rustok-product/contracts/evidence/storefront-graphql-error-safety-source.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-30",
+  "status": "product_storefront_graphql_error_safety_source_unvalidated",
+  "scope": "product-owned storefront GraphQL catalog, detail, pricing, and catalog-search-options transport",
+  "covered_operations": [
+    "fetch_products",
+    "fetch_catalog_search_options"
+  ],
+  "source_contract": {
+    "public_consumer_boundary_sanitized": true,
+    "private_graphql_adapter_changed": false,
+    "graphql_documents_changed": false,
+    "request_response_dto_changed": false,
+    "catalog_controls_changed": false,
+    "pricing_context_changed": false,
+    "native_paths_changed": false,
+    "transport_selection_changed": false,
+    "native_to_graphql_fallback_added": false,
+    "graphql_http_error_reparsed": true,
+    "network_static_public_envelope": true,
+    "http_static_public_envelope": true,
+    "unauthorized_static_public_envelope": true,
+    "graphql_rejection_static_public_envelope": true,
+    "unknown_static_public_envelope": true,
+    "correlation_logging": true,
+    "safe_request_shape_logging": true,
+    "raw_request_values_logged": false,
+    "raw_tenant_slug_logged": false,
+    "raw_graphql_error_public": false,
+    "non_graphql_errors_pass_through": true
+  },
+  "stable_public_messages": {
+    "network_or_http": "Product storefront is temporarily unavailable",
+    "unauthorized": "Product storefront authentication is required",
+    "graphql_rejection_or_unknown": "Product storefront request could not be completed"
+  },
+  "suggested_execution": [
+    "node scripts/verify/verify-product-storefront-graphql-error-safety.mjs",
+    "node scripts/verify/verify-product-storefront-catalog-native-error-safety.mjs",
+    "node scripts/verify/verify-product-storefront-boundary.mjs",
+    "node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs",
+    "cargo check -p rustok-product-storefront",
+    "cargo check -p rustok-product-storefront --features hydrate",
+    "cargo check -p rustok-product-storefront --features ssr"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "graphql_runtime_proven": false,
+    "browser_runtime_proven": false,
+    "mounted_parity_proven": false,
+    "production_proven": false
+  }
+}

--- a/crates/rustok-product/docs/storefront-graphql-error-safety.md
+++ b/crates/rustok-product/docs/storefront-graphql-error-safety.md
@@ -1,0 +1,149 @@
+# Product storefront GraphQL error safety
+
+Status: source-unvalidated
+
+## Scope
+
+This source slice hardens the product-owned storefront GraphQL transport for two
+public operations:
+
+- `fetch_products`;
+- `fetch_catalog_search_options`.
+
+The storefront facade remains the public transport consumer. The low-level
+GraphQL adapter remains private and continues to own the catalog-list, selected
+product, pricing-product, and catalog-search-options documents, variables,
+response decoding, request ordering, and DTO mapping.
+
+## Previous gap
+
+Both selected GraphQL closures delegated directly to the private adapter. The
+adapter converted `GraphqlHttpError` into `ApiError::Graphql(value.to_string())`,
+and `execute_selected_transport` retained that display string in the public
+`UiTransportError.graphql_error` field.
+
+Consequently, server-provided GraphQL messages and HTTP detail could cross the
+storefront UI boundary without a product-owned public-envelope policy. The
+native catalog-list and catalog-search-options paths already had their own
+owner mappings, but those mappings did not cover the GraphQL path.
+
+## Public consumer policy
+
+`transport/mod.rs` now creates a private `GraphqlCallContext` before invoking
+each GraphQL adapter operation. The context reparses the adapter's display
+handoff through `GraphqlHttpError::from_str` and maps only `ApiError::Graphql`.
+
+The stable public messages are:
+
+| Typed failure | Public message |
+| --- | --- |
+| network | `Product storefront is temporarily unavailable` |
+| HTTP | `Product storefront is temporarily unavailable` |
+| unauthorized | `Product storefront authentication is required` |
+| GraphQL rejection | `Product storefront request could not be completed` |
+| unknown display envelope | `Product storefront request could not be completed` |
+
+`ApiError::ServerFn` is returned unchanged. This preserves the independent
+native transport policy.
+
+## Correlation diagnostics
+
+Every selected GraphQL call creates a unique correlation identifier using the
+owner operation and a new UUID. Internal tracing events retain:
+
+- owner `rustok_product.storefront`;
+- operation `fetch_products` or `fetch_catalog_search_options`;
+- boundary `product_storefront_graphql_transport`;
+- correlation identifier;
+- typed error kind and stable code;
+- raw and reparsed GraphQL cause for internal diagnosis;
+- whether a tenant slug is configured and its character length;
+- optional selected-handle, locale, currency, region, price-list, channel-id,
+  channel-slug, search, and category-id presence and character lengths;
+- quantity presence without its value;
+- sort-field and sort-direction presence;
+- attribute-filter count.
+
+The mapper does not log raw tenant slug, selected handle, locale, currency,
+region id, price-list id, channel id, channel slug, quantity, search text,
+category id, sort values, attribute-filter values, GraphQL endpoint, documents,
+variables, tokens, or returned product data.
+
+Technical network, HTTP, and unknown failures use error-level diagnostics.
+Unauthorized and ordinary GraphQL rejection use warning-level diagnostics.
+
+## Preserved behavior
+
+This slice does not change:
+
+- feature-based `NativeServer` versus `Graphql` selection;
+- the no-fallback transport policy;
+- the private GraphQL adapter;
+- `STOREFRONT_PRODUCTS_QUERY`;
+- `STOREFRONT_PRODUCT_QUERY`;
+- `STOREFRONT_PRICING_PRODUCT_QUERY`;
+- `STOREFRONT_CATALOG_SEARCH_OPTIONS_QUERY`;
+- typed `CatalogListInput` normalization;
+- fixed catalog page and page-size request values;
+- selected-product and pricing request order;
+- product request or response DTOs;
+- pricing-context construction;
+- native owner catalog-list execution;
+- native catalog-search-options server function;
+- native error-safety policy.
+
+The adapter still creates the exact typed GraphQL display handoff. Sanitization
+occurs once at the public consumer boundary, avoiding duplicate diagnostics and
+preserving adapter ownership.
+
+## Source guard
+
+The focused verifier is:
+
+```bash
+node scripts/verify/verify-product-storefront-graphql-error-safety.mjs
+```
+
+It checks the typed mapping policy, static public messages, stable codes,
+correlation and safe request-shape diagnostics, GraphQL-only remapping,
+private-adapter preservation, native-path preservation, evidence status, and
+validation nonclaims.
+
+The general owner boundary verifier imports the focused guard:
+
+```bash
+node scripts/verify/verify-product-storefront-boundary.mjs
+```
+
+## Evidence boundary
+
+Retained source evidence:
+
+- `crates/rustok-product/contracts/evidence/storefront-graphql-error-safety-source.json`;
+- `crates/rustok-product/contracts/evidence/storefront-graphql-error-safety-source-review.json`.
+
+The evidence establishes only that the source and guardrail are present and
+have been reviewed. It does not establish compilation, browser execution,
+GraphQL runtime behavior, mounted parity, workflow success, CI success, or
+production behavior.
+
+The broad ecommerce correlation-safe mapper cleanup remains open.
+
+No tests, verifiers, Cargo commands, formatting, workflows, or CI were run per
+maintainer instruction.
+
+## Suggested maintainer verification
+
+```bash
+node scripts/verify/verify-product-storefront-graphql-error-safety.mjs
+node scripts/verify/verify-product-storefront-catalog-native-error-safety.mjs
+node scripts/verify/verify-product-storefront-boundary.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-product-storefront
+cargo check -p rustok-product-storefront --features hydrate
+cargo check -p rustok-product-storefront --features ssr
+```
+
+Source readiness must remain separate from runtime or promotion claims until
+those commands and required mounted failure evidence are retained on the same
+revision.

--- a/crates/rustok-product/storefront/src/transport/graphql_error_safety.rs
+++ b/crates/rustok-product/storefront/src/transport/graphql_error_safety.rs
@@ -1,0 +1,216 @@
+use std::str::FromStr;
+
+use rustok_graphql::GraphqlHttpError;
+use uuid::Uuid;
+
+use crate::catalog_controls::CatalogListInput;
+use crate::core::FetchRequest;
+
+use super::native_server_adapter::ApiError;
+
+const PRODUCT_STOREFRONT_GRAPHQL_OWNER: &str = "rustok_product.storefront";
+const PRODUCT_STOREFRONT_GRAPHQL_BOUNDARY: &str = "product_storefront_graphql_transport";
+
+pub(super) struct GraphqlCallContext {
+    owner_operation: &'static str,
+    correlation_id: String,
+    tenant_slug_length: Option<usize>,
+    selected_handle_length: Option<usize>,
+    locale_length: Option<usize>,
+    currency_code_length: Option<usize>,
+    region_id_length: Option<usize>,
+    price_list_id_length: Option<usize>,
+    channel_id_length: Option<usize>,
+    channel_slug_length: Option<usize>,
+    quantity_present: bool,
+    search_length: Option<usize>,
+    category_id_length: Option<usize>,
+    sort_by_present: bool,
+    sort_direction_present: bool,
+    attribute_filter_count: usize,
+}
+
+impl GraphqlCallContext {
+    pub(super) fn fetch_products(request: &FetchRequest, controls: &CatalogListInput) -> Self {
+        Self {
+            owner_operation: "fetch_products",
+            correlation_id: correlation_id("fetch_products"),
+            tenant_slug_length: configured_tenant_slug_length(),
+            selected_handle_length: text_length(request.selected_handle.as_deref()),
+            locale_length: text_length(request.locale.as_deref()),
+            currency_code_length: text_length(request.currency_code.as_deref()),
+            region_id_length: text_length(request.region_id.as_deref()),
+            price_list_id_length: text_length(request.price_list_id.as_deref()),
+            channel_id_length: text_length(request.channel_id.as_deref()),
+            channel_slug_length: text_length(request.channel_slug.as_deref()),
+            quantity_present: request.quantity.is_some(),
+            search_length: text_length(controls.search.as_deref()),
+            category_id_length: text_length(controls.category_id.as_deref()),
+            sort_by_present: controls.sort_by.is_some(),
+            sort_direction_present: controls.sort_direction.is_some(),
+            attribute_filter_count: controls.attribute_filters.len(),
+        }
+    }
+
+    pub(super) fn fetch_catalog_search_options(locale: &str) -> Self {
+        Self {
+            owner_operation: "fetch_catalog_search_options",
+            correlation_id: correlation_id("fetch_catalog_search_options"),
+            tenant_slug_length: configured_tenant_slug_length(),
+            selected_handle_length: None,
+            locale_length: Some(locale.chars().count()),
+            currency_code_length: None,
+            region_id_length: None,
+            price_list_id_length: None,
+            channel_id_length: None,
+            channel_slug_length: None,
+            quantity_present: false,
+            search_length: None,
+            category_id_length: None,
+            sort_by_present: false,
+            sort_direction_present: false,
+            attribute_filter_count: 0,
+        }
+    }
+
+    pub(super) fn map_error(&self, error: ApiError) -> ApiError {
+        let ApiError::Graphql(raw_error) = error else {
+            return error;
+        };
+        let parsed_error = GraphqlHttpError::from_str(raw_error.as_str());
+        let (error_kind, code, public_message, technical_failure) = match &parsed_error {
+            Ok(GraphqlHttpError::Network) => (
+                "network",
+                "product.storefront_graphql_network_unavailable",
+                "Product storefront is temporarily unavailable",
+                true,
+            ),
+            Ok(GraphqlHttpError::Http(_)) => (
+                "http",
+                "product.storefront_graphql_http_unavailable",
+                "Product storefront is temporarily unavailable",
+                true,
+            ),
+            Ok(GraphqlHttpError::Unauthorized) => (
+                "unauthorized",
+                "product.storefront_graphql_authentication_required",
+                "Product storefront authentication is required",
+                false,
+            ),
+            Ok(GraphqlHttpError::Graphql(_)) => (
+                "graphql",
+                "product.storefront_graphql_request_rejected",
+                "Product storefront request could not be completed",
+                false,
+            ),
+            Err(_) => (
+                "unknown",
+                "product.storefront_graphql_unknown_failure",
+                "Product storefront request could not be completed",
+                true,
+            ),
+        };
+
+        if technical_failure {
+            tracing::error!(
+                raw_error = %raw_error,
+                parsed_error = ?parsed_error,
+                owner = PRODUCT_STOREFRONT_GRAPHQL_OWNER,
+                owner_operation = self.owner_operation,
+                correlation_id = %self.correlation_id,
+                tenant_slug_configured = self.tenant_slug_length.is_some(),
+                tenant_slug_length = ?self.tenant_slug_length,
+                selected_handle_present = self.selected_handle_length.is_some(),
+                selected_handle_length = ?self.selected_handle_length,
+                locale_present = self.locale_length.is_some(),
+                locale_length = ?self.locale_length,
+                currency_code_present = self.currency_code_length.is_some(),
+                currency_code_length = ?self.currency_code_length,
+                region_id_present = self.region_id_length.is_some(),
+                region_id_length = ?self.region_id_length,
+                price_list_id_present = self.price_list_id_length.is_some(),
+                price_list_id_length = ?self.price_list_id_length,
+                channel_id_present = self.channel_id_length.is_some(),
+                channel_id_length = ?self.channel_id_length,
+                channel_slug_present = self.channel_slug_length.is_some(),
+                channel_slug_length = ?self.channel_slug_length,
+                quantity_present = self.quantity_present,
+                search_present = self.search_length.is_some(),
+                search_length = ?self.search_length,
+                category_id_present = self.category_id_length.is_some(),
+                category_id_length = ?self.category_id_length,
+                sort_by_present = self.sort_by_present,
+                sort_direction_present = self.sort_direction_present,
+                attribute_filter_count = self.attribute_filter_count,
+                error_kind,
+                code,
+                boundary = PRODUCT_STOREFRONT_GRAPHQL_BOUNDARY,
+                "product storefront GraphQL transport failed"
+            );
+        } else {
+            tracing::warn!(
+                raw_error = %raw_error,
+                parsed_error = ?parsed_error,
+                owner = PRODUCT_STOREFRONT_GRAPHQL_OWNER,
+                owner_operation = self.owner_operation,
+                correlation_id = %self.correlation_id,
+                tenant_slug_configured = self.tenant_slug_length.is_some(),
+                tenant_slug_length = ?self.tenant_slug_length,
+                selected_handle_present = self.selected_handle_length.is_some(),
+                selected_handle_length = ?self.selected_handle_length,
+                locale_present = self.locale_length.is_some(),
+                locale_length = ?self.locale_length,
+                currency_code_present = self.currency_code_length.is_some(),
+                currency_code_length = ?self.currency_code_length,
+                region_id_present = self.region_id_length.is_some(),
+                region_id_length = ?self.region_id_length,
+                price_list_id_present = self.price_list_id_length.is_some(),
+                price_list_id_length = ?self.price_list_id_length,
+                channel_id_present = self.channel_id_length.is_some(),
+                channel_id_length = ?self.channel_id_length,
+                channel_slug_present = self.channel_slug_length.is_some(),
+                channel_slug_length = ?self.channel_slug_length,
+                quantity_present = self.quantity_present,
+                search_present = self.search_length.is_some(),
+                search_length = ?self.search_length,
+                category_id_present = self.category_id_length.is_some(),
+                category_id_length = ?self.category_id_length,
+                sort_by_present = self.sort_by_present,
+                sort_direction_present = self.sort_direction_present,
+                attribute_filter_count = self.attribute_filter_count,
+                error_kind,
+                code,
+                boundary = PRODUCT_STOREFRONT_GRAPHQL_BOUNDARY,
+                "product storefront GraphQL request was rejected"
+            );
+        }
+
+        ApiError::Graphql(public_message.to_string())
+    }
+}
+
+fn correlation_id(owner_operation: &str) -> String {
+    format!(
+        "product-storefront-graphql:{owner_operation}:{}",
+        Uuid::new_v4()
+    )
+}
+
+fn text_length(value: Option<&str>) -> Option<usize> {
+    value.map(|value| value.chars().count())
+}
+
+fn configured_tenant_slug_length() -> Option<usize> {
+    [
+        "RUSTOK_TENANT_SLUG",
+        "NEXT_PUBLIC_TENANT_SLUG",
+        "NEXT_PUBLIC_DEFAULT_TENANT_SLUG",
+    ]
+    .into_iter()
+    .find_map(|key| {
+        std::env::var(key).ok().and_then(|value| {
+            let value = value.trim();
+            (!value.is_empty()).then_some(value.chars().count())
+        })
+    })
+}

--- a/crates/rustok-product/storefront/src/transport/mod.rs
+++ b/crates/rustok-product/storefront/src/transport/mod.rs
@@ -1,5 +1,6 @@
 mod catalog_list_native;
 mod graphql_adapter;
+mod graphql_error_safety;
 mod native_server_adapter;
 
 use crate::catalog_controls::CatalogListInput;
@@ -33,7 +34,13 @@ pub async fn fetch_products(
         "product",
         selected_transport_path(),
         move || catalog_list_native::fetch_products(native_request, native_controls),
-        move || graphql_adapter::fetch_products(request, controls),
+        move || async move {
+            let context =
+                graphql_error_safety::GraphqlCallContext::fetch_products(&request, &controls);
+            graphql_adapter::fetch_products(request, controls)
+                .await
+                .map_err(|error| context.map_error(error))
+        },
     )
     .await
 }
@@ -46,7 +53,13 @@ pub async fn fetch_catalog_search_options(
         "product",
         selected_transport_path(),
         move || native_server_adapter::fetch_catalog_search_options(native_locale),
-        move || graphql_adapter::fetch_catalog_search_options(locale),
+        move || async move {
+            let context =
+                graphql_error_safety::GraphqlCallContext::fetch_catalog_search_options(&locale);
+            graphql_adapter::fetch_catalog_search_options(locale)
+                .await
+                .map_err(|error| context.map_error(error))
+        },
     )
     .await
 }

--- a/scripts/verify/verify-product-storefront-boundary.mjs
+++ b/scripts/verify/verify-product-storefront-boundary.mjs
@@ -7,6 +7,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import "./verify-product-storefront-catalog-native-error-safety.mjs";
+import "./verify-product-storefront-graphql-error-safety.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
@@ -157,6 +158,7 @@ assertContains(transport, "CatalogListInput", `${transportPath}: transport facad
 assertContains(transport, "mod catalog_list_native;", `${transportPath}: transport facade must wire the owner-native catalog list path`);
 assertContains(transport, "catalog_list_native::fetch_products", `${transportPath}: selected native path must execute the owner-native catalog list`);
 assertContains(transport, "mod graphql_adapter;", `${transportPath}: transport facade must wire GraphQL adapter`);
+assertContains(transport, "mod graphql_error_safety;", `${transportPath}: transport facade must wire GraphQL error safety`);
 assertContains(transport, "mod native_server_adapter;", `${transportPath}: transport facade must wire native server adapter`);
 assertNotContains(transport, "crate::api", `${transportPath}: transport facade must not import legacy api module`);
 assertContains(graphqlAdapter, "GraphqlRequest", `${graphqlAdapterPath}: GraphQL adapter must expose GraphQL request path`);

--- a/scripts/verify/verify-product-storefront-graphql-error-safety.mjs
+++ b/scripts/verify/verify-product-storefront-graphql-error-safety.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+const transportPath = "crates/rustok-product/storefront/src/transport/mod.rs";
+const policyPath =
+  "crates/rustok-product/storefront/src/transport/graphql_error_safety.rs";
+const adapterPath =
+  "crates/rustok-product/storefront/src/transport/graphql_adapter.rs";
+const nativePath =
+  "crates/rustok-product/storefront/src/transport/native_server_adapter.rs";
+const evidencePath =
+  "crates/rustok-product/contracts/evidence/storefront-graphql-error-safety-source.json";
+
+const transport = read(transportPath);
+const policy = read(policyPath);
+const adapter = read(adapterPath);
+const native = read(nativePath);
+const evidence = JSON.parse(read(evidencePath));
+
+for (const [value, label] of [
+  ["mod graphql_error_safety;", "policy module wiring"],
+  ["GraphqlCallContext::fetch_products(&request, &controls)", "catalog operation context"],
+  ["GraphqlCallContext::fetch_catalog_search_options(&locale)", "search-options operation context"],
+  [".map_err(|error| context.map_error(error))", "facade error mapping"],
+  ["catalog_list_native::fetch_products(native_request, native_controls)", "native catalog path preservation"],
+  ["native_server_adapter::fetch_catalog_search_options(native_locale)", "native search-options path preservation"],
+]) requireText(transport, value, label);
+
+if ((transport.match(/\.map_err\(\|error\| context\.map_error\(error\)\)/g) || []).length !== 2) {
+  failures.push(`${transportPath}: expected exactly two GraphQL context mappings`);
+}
+
+for (const [value, label] of [
+  ["pub(super) struct GraphqlCallContext", "private call context"],
+  ["pub(super) fn fetch_products", "catalog context constructor"],
+  ["pub(super) fn fetch_catalog_search_options", "search-options context constructor"],
+  ["GraphqlHttpError::from_str", "typed display reparse"],
+  ["let ApiError::Graphql(raw_error) = error else", "GraphQL-only remap"],
+  ["return error;", "non-GraphQL pass-through"],
+  ["GraphqlHttpError::Network", "network policy"],
+  ["GraphqlHttpError::Http(_)", "HTTP policy"],
+  ["GraphqlHttpError::Unauthorized", "unauthorized policy"],
+  ["GraphqlHttpError::Graphql(_)", "GraphQL rejection policy"],
+  ["product.storefront_graphql_network_unavailable", "network code"],
+  ["product.storefront_graphql_http_unavailable", "HTTP code"],
+  ["product.storefront_graphql_authentication_required", "authentication code"],
+  ["product.storefront_graphql_request_rejected", "request rejection code"],
+  ["product.storefront_graphql_unknown_failure", "unknown code"],
+  ["Product storefront is temporarily unavailable", "temporary public envelope"],
+  ["Product storefront authentication is required", "authentication public envelope"],
+  ["Product storefront request could not be completed", "rejection public envelope"],
+  ["ApiError::Graphql(public_message.to_string())", "static public return"],
+  ["Uuid::new_v4()", "unique correlation id"],
+  ["owner = PRODUCT_STOREFRONT_GRAPHQL_OWNER", "owner diagnostics"],
+  ["owner_operation = self.owner_operation", "operation diagnostics"],
+  ["correlation_id = %self.correlation_id", "correlation diagnostics"],
+  ["raw_error = %raw_error", "private raw cause diagnostics"],
+  ["parsed_error = ?parsed_error", "typed cause diagnostics"],
+  ["tenant_slug_length", "safe tenant shape"],
+  ["selected_handle_length", "safe handle shape"],
+  ["locale_length", "safe locale shape"],
+  ["currency_code_length", "safe currency shape"],
+  ["region_id_length", "safe region shape"],
+  ["price_list_id_length", "safe price-list shape"],
+  ["channel_id_length", "safe channel-id shape"],
+  ["channel_slug_length", "safe channel-slug shape"],
+  ["quantity_present", "safe quantity presence"],
+  ["search_length", "safe search shape"],
+  ["category_id_length", "safe category shape"],
+  ["sort_by_present", "safe sort presence"],
+  ["sort_direction_present", "safe direction presence"],
+  ["attribute_filter_count", "safe filter count"],
+]) requireText(policy, value, label);
+
+for (const value of [
+  "selected_handle =",
+  "locale = %",
+  "currency_code = %",
+  "region_id = %",
+  "price_list_id = %",
+  "channel_id = %",
+  "channel_slug = %",
+  "quantity =",
+  "search = %",
+  "category_id = %",
+  "attribute_filters =",
+  "graphql_url",
+  "GraphqlRequest",
+]) forbidText(policy, value, "GraphQL safety policy");
+
+for (const [value, label] of [
+  ["impl From<rustok_graphql::GraphqlHttpError> for ApiError", "private typed handoff"],
+  ["Self::Graphql(value.to_string())", "private display handoff"],
+  ["STOREFRONT_PRODUCTS_QUERY", "catalog query preservation"],
+  ["STOREFRONT_PRODUCT_QUERY", "detail query preservation"],
+  ["STOREFRONT_PRICING_PRODUCT_QUERY", "pricing query preservation"],
+  ["STOREFRONT_CATALOG_SEARCH_OPTIONS_QUERY", "search-options query preservation"],
+]) requireText(adapter, value, label);
+
+requireText(native, "pub enum ApiError", "shared transport error contract");
+requireText(native, "Graphql(String)", "GraphQL error variant preservation");
+requireText(native, "ServerFn(String)", "native error variant preservation");
+
+if (evidence.status !== "product_storefront_graphql_error_safety_source_unvalidated") {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  public_consumer_boundary_sanitized: true,
+  private_graphql_adapter_changed: false,
+  graphql_documents_changed: false,
+  request_response_dto_changed: false,
+  catalog_controls_changed: false,
+  pricing_context_changed: false,
+  native_paths_changed: false,
+  transport_selection_changed: false,
+  native_to_graphql_fallback_added: false,
+  graphql_http_error_reparsed: true,
+  correlation_logging: true,
+  safe_request_shape_logging: true,
+  raw_request_values_logged: false,
+  raw_graphql_error_public: false,
+  non_graphql_errors_pass_through: true,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "graphql_runtime_proven",
+  "browser_runtime_proven",
+  "mounted_parity_proven",
+  "production_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Product storefront GraphQL error-safety verification failed:");
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "✔ product storefront GraphQL failures use static public envelopes with private correlated diagnostics; source evidence remains unvalidated",
+);


### PR DESCRIPTION
## Summary
- add a private product storefront GraphQL error-safety policy at the public transport consumer boundary
- preserve the existing private GraphQL adapter, four query documents, variables, response DTOs, typed catalog controls, pricing-context construction, native catalog-list path, native search-options path, and explicit transport selection
- route `fetch_products` and `fetch_catalog_search_options` through per-call contexts with unique correlation ids
- reparse the adapter's `GraphqlHttpError` display handoff into typed network, HTTP, unauthorized, GraphQL rejection, and unknown policies
- keep raw GraphQL details in structured internal diagnostics only and expose static `ApiError::Graphql` messages through `UiTransportError.graphql_error`
- retain only safe request-shape facts: tenant and optional-field lengths, presence flags, and collection counts; never raw identifiers, locale, search, filters, quantity, or GraphQL payloads
- pass non-GraphQL errors through unchanged
- add a focused source verifier, include it in the Product storefront boundary aggregate, and retain unvalidated source/review evidence plus documentation

## Covered operations
- `fetch_products`
- `fetch_catalog_search_options`

## Public policy
- network / HTTP: `Product storefront is temporarily unavailable`
- unauthorized: `Product storefront authentication is required`
- GraphQL rejection / unknown: `Product storefront request could not be completed`

## Preserved behavior
- no native-to-GraphQL fallback
- feature-based transport selection unchanged
- private adapter and all four GraphQL documents unchanged
- typed catalog controls and fixed pagination unchanged
- selected detail and pricing request order unchanged
- request/response DTOs and pricing-context derivation unchanged
- native catalog-list and search-options paths unchanged
- native error-safety policy unchanged

## Evidence boundary
Source status is `product_storefront_graphql_error_safety_source_unvalidated`. The broad ecommerce correlation-safe mapper cleanup remains open. No FFA, FBA, browser, GraphQL runtime, mounted parity, workflow, CI, or production status is promoted.

## Verification
The ecommerce master plan, Product storefront facade/private adapter/catalog controls/core request policy/native safety contract, `GraphqlHttpError` display handoff, `UiTransportError` public storage, final source files, and the seven-file diff were reviewed.

Tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run per maintainer instruction.