### PR TITLE
feat(index): add fenced replay cancellation

### DIFF
--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -26,7 +26,7 @@ pull requests record checks and PostgreSQL runs that were not executed.
 ## Current state
 
 - Rewrite status: `in_progress`
-- Current milestone: `M6 - bounded multi-page replay runner (source complete; cancellation, scheduling, and retained evidence open)`
+- Current milestone: `M6 - bounded multi-page replay cancellation (source complete; in-page interruption, scheduling, and retained evidence open)`
 - FFA status: `in_progress`
 - FBA status: `in_progress`
 - M0 code reset: `complete`
@@ -66,7 +66,7 @@ pull requests record checks and PostgreSQL runs that were not executed.
 - M5/M6 bounded source replay contract: `source_complete_worker_pending`
 - M6 one-page replay and durable checkpoint progression: `source_complete`
 - M6 replay job leases and checkpoint attempt fencing: `source_complete_owner_execution_pending`
-- M6 bounded multi-page replay runner: `source_complete_owner_execution_pending`
+- M6 bounded multi-page replay and cancellation: `source_complete_owner_execution_pending`
 - Production persistence: mutation writes, schema/index coordination, fail-closed
   partition admission, snapshot/query/mutation/maintenance/cutover evidence tooling,
   full-capture orchestration, exact-byte packet assembly, retained bundle review,
@@ -80,10 +80,11 @@ pull requests record checks and PostgreSQL runs that were not executed.
   row adaptation, source-owned schema publication, shared query-runtime composition,
   bounded source replay/load contracts, one-page replay mutation application, durable
   rebuild checkpoint progression, schema-scoped rebuild job claims, lease/heartbeat,
-  attempt fencing, fenced checkpoint writes, bounded multi-page execution, and
-  immediate pending resume are implemented; one retained admitted packet, live
-  PostgreSQL/reference equivalence, cancellation, retry/backoff, dead-letter scheduling,
-  host scheduling, freshness/recovery evidence, authoritative consumer cutover, and
+  attempt fencing, fenced checkpoint writes, bounded multi-page execution, immediate
+  pending resume, durable cancellation requests, and fenced between-page terminal
+  cancellation are implemented; one retained admitted packet, live PostgreSQL/reference
+  equivalence, in-page interruption, retry/backoff, dead-letter scheduling, host
+  scheduling, freshness/recovery evidence, authoritative consumer cutover, and
   production partition lifecycle remain open
 
 The production crate contains the generic domain/application core, seven canonical
@@ -100,7 +101,7 @@ repeatable-read page/count snapshot, source-owned schema and replay catalogs, a
 neutral bounded `IndexSource` scan/load boundary, a one-page replay executor,
 `PostgresIndexReplayJobStore` for durable fenced schema-scoped rebuild ownership,
 a lease-bound PostgreSQL rebuild-checkpoint adapter, and
-`PostgresIndexReplayRunner` for bounded heartbeat/yield/resume execution.
+`PostgresIndexReplayRunner` for bounded heartbeat/yield/cancellation execution.
 Owner-operated evidence tools live under `ops/benches`; they do not become runtime
 storage code.
 
@@ -444,26 +445,30 @@ database, or transport causes stay in owner logs.
 - [x] Bind checkpoint reads and writes to the active `(job_id, worker_id, attempt_count)`
       and require a durable null-cursor checkpoint before terminal success.
 - [x] Add bounded multi-page execution with heartbeat cadence and immediate pending resume.
+- [x] Add durable cancellation requests and fenced between-page terminal cancellation.
 - [ ] Bind job requests directly to the materialized source registry in server composition.
-- [ ] Add cancellation, dry-run, and targeted/full/shadow rebuild modes.
+- [ ] Add in-page interruption/timeouts, dry-run, and targeted/full/shadow rebuild modes.
 - [ ] Add bounded retry/backoff, dead-letter state, and global scheduling ownership.
 - [ ] Add locale/partition replay checkpoint dimensions.
 - [ ] Add reconciliation and drift repair.
 - [ ] Cover crash, lease expiry, restart, cancellation, and incremental/full
       equivalence with retained PostgreSQL evidence.
 
-The one-page executor, replay job store, checkpoint adapter, and bounded multi-page
-runner are source complete. `PostgresIndexReplayJobStore` serializes one tenant/schema
-claim, validates the exact `index_replay_job_v1` request and active persisted schema,
-reclaims expired attempts with an incremented fence, and rejects stale heartbeat or
+The one-page executor, replay job store, checkpoint adapter, bounded multi-page runner,
+and cancellation path are source complete. `PostgresIndexReplayJobStore` serializes one
+tenant/schema claim, validates the exact `index_replay_job_v1` request and active persisted
+schema, reclaims expired attempts with an incremented fence, and rejects stale heartbeat or
 terminal updates. `PostgresIndexReplayCheckpointStore` is constructed from the acquired
 lease; it locks and validates that exact attempt before every checkpoint read or write.
-`PostgresIndexReplayRunner` resolves the source from the materialized registry, executes
-at most 1024 pages, heartbeats between pages, completes only after a durable JSON null
-cursor, and returns unfinished work to immediately claimable `pending` state while
-preserving the same job UUID and checkpoint. A later claim increments the attempt fence.
-Cancellation, automatic retry/backoff, dead-letter scheduling, host scheduling, and
-retained multi-instance PostgreSQL evidence remain open.
+`PostgresIndexReplayRunner` resolves the source from the materialized registry, executes at
+most 1024 pages, heartbeats between pages, completes only after a durable JSON null cursor,
+and returns unfinished work to immediately claimable `pending` state while preserving the
+same job UUID and checkpoint. `request_cancel` terminalizes pending jobs immediately and
+marks running jobs for observation before/after pages; success, failure, and yield all require
+`cancel_requested = FALSE`, so cancellation committed first cannot be overwritten. A running
+cancel request survives reclaim and is terminalized by the next fenced attempt before source
+access. In-page interruption, automatic retry/backoff, dead-letter scheduling, host scheduling,
+and retained multi-instance PostgreSQL evidence remain open.
 
 ### M7 - First vertical slice
 
@@ -612,7 +617,10 @@ node scripts/verify/verify-index-replay-multipage-runner.mjs
   registry-derived source ownership, between-page heartbeat cadence, accumulated page/
   mutation outcomes, terminal failure classification, graceful lease-loss handling,
   null-cursor completion, and immediate `pending` yield/resume with attempt fencing.
-- Repository test/fixture suites, verifiers, cancellation, automatic retry/backoff,
+- 2026-07-30: added durable pending/running cancellation requests, typed terminal and
+  not-found outcomes, cancellation observation before/after bounded pages, cancellation
+  persistence across reclaim, and cancel-first fenced success/failure/yield transitions.
+- Repository test/fixture suites, verifiers, in-page interruption, automatic retry/backoff,
   dead-letter and host scheduling, live freshness/recovery evidence, one admitted
   PostgreSQL/reference equivalence bundle, and one real full PostgreSQL partition packet
   remain for the owner to execute and admit before authoritative consumer or production
@@ -623,10 +631,10 @@ node scripts/verify/verify-index-replay-multipage-runner.mjs
 - Cycle: `cycle-001`
 - Status: `blocked`
 - Last verified at (UTC): `2026-07-30`
-- Scope inspected: `Index ownership, migrations, mutation/version ordering, query execution, partition evidence guards, Social Graph consumer authority, privacy shadow deadline behavior, source replay ownership, replay checkpoint ordering, replay job attempt fencing, bounded multi-page replay progression, and source/search/server boundaries`
+- Scope inspected: `Index ownership, migrations, mutation/version ordering, query execution, partition evidence guards, Social Graph consumer authority, privacy shadow deadline behavior, source replay ownership, replay checkpoint ordering, replay job attempt fencing, bounded multi-page replay progression, cancellation ordering, and source/search/server boundaries`
 - Findings: `P0=0, P1=2, P2=0, P3=1`
-- Fixed in this pass: `bounded the non-authoritative Social Graph privacy comparison by the remaining caller deadline while preserving the owner result; repaired stale Index scale/FBA and retained-artifact guards; added a canonical bounded source replay/load registry; added one-page replay mutation application with stable event checks and checkpoint progression only after durable mutation outcomes; added schema-scoped rebuild job claims with lease/heartbeat, expired-attempt reclaim, attempt fencing, fenced checkpoint access, durable null-cursor-gated success, and bounded multi-page execution with between-page heartbeat and immediate pending resume`
-- Remaining risks or blockers: `one retained admitted real PostgreSQL partition packet is absent; live PostgreSQL/reference query equivalence remains open; cancellation, automatic retry/backoff, dead-letter scheduling, host scheduling, locale/partition checkpoint dimensions, and production source adapters remain absent; no retained per-tenant freshness/watermark, lag, negative-result safety, outage/restart/backlog catch-up, or replay-repair evidence exists; consumer and production partition cutover remain forbidden`
-- Evidence: `PR #2544 merged as b647a5a17f27b34a07c20cd57525ed1806994c49; PR #2554 merged as 5b9d49e65295819ee9e8e9c199688c0e2ac73d35; same-SHA Index Storage Scale Run Contract and full Scale Evidence contract passed JavaScript syntax, workflow contracts, repository contracts, direct validator arguments and fixture suites; source replay registry, one-page checkpoint progression, replay job fencing, and bounded multi-page runner source are present without implementation-agent test execution; general CI/Hardening received no jobs; Rust-hosted smoke previously stopped before compilation because Cargo.lock required an Athanor update under --locked`
-- Next action: `add cancellation observation and terminal cancellation on the bounded runner, then bind it into host/server composition and add the first Product source adapter before executing retained PostgreSQL packet, live query equivalence, and per-tenant freshness/outage/recovery evidence`
+- Fixed in this pass: `bounded the non-authoritative Social Graph privacy comparison by the remaining caller deadline while preserving the owner result; repaired stale Index scale/FBA and retained-artifact guards; added a canonical bounded source replay/load registry; added one-page replay mutation application with stable event checks and checkpoint progression only after durable mutation outcomes; added schema-scoped rebuild job claims with lease/heartbeat, expired-attempt reclaim, attempt fencing, fenced checkpoint access, durable null-cursor-gated success, bounded multi-page execution with between-page heartbeat and immediate pending resume, and durable cancel-first terminalization`
+- Remaining risks or blockers: `one retained admitted real PostgreSQL partition packet is absent; live PostgreSQL/reference query equivalence remains open; in-page interruption, automatic retry/backoff, dead-letter scheduling, host scheduling, locale/partition checkpoint dimensions, and production source adapters remain absent; no retained per-tenant freshness/watermark, lag, negative-result safety, outage/restart/backlog catch-up, cancellation, or replay-repair evidence exists; consumer and production partition cutover remain forbidden`
+- Evidence: `PR #2544 merged as b647a5a17f27b34a07c20cd57525ed1806994c49; PR #2554 merged as 5b9d49e65295819ee9e8e9c199688c0e2ac73d35; PR #2576 merged as aef96f57d3babc2efdc65cc0c57cfea6fb48b5ad; same-SHA Index Storage Scale Run Contract and full Scale Evidence contract passed JavaScript syntax, workflow contracts, repository contracts, direct validator arguments and fixture suites; source replay registry, one-page checkpoint progression, replay job fencing, bounded multi-page runner, and cancellation source are present without implementation-agent test execution; general CI/Hardening received no jobs; Rust-hosted smoke previously stopped before compilation because Cargo.lock required an Athanor update under --locked`
+- Next action: `bind the replay runner into host/server composition with explicit operator authorization and graceful shutdown ownership, then add the first Product source adapter before executing retained PostgreSQL packet, live query equivalence, and per-tenant freshness/outage/recovery evidence`
 - Resume command: `cargo fmt --all -- --check && cargo check -p rustok-index --all-targets && node scripts/verify/verify-index-query-contract.mjs && node scripts/verify/index-storage-tooling.mjs contract && node scripts/verify/index-storage-tooling.mjs fixtures`

--- a/crates/rustok-index/docs/m6-bounded-multipage-runner.md
+++ b/crates/rustok-index/docs/m6-bounded-multipage-runner.md
@@ -3,9 +3,10 @@
 Status: `source_complete_owner_execution_pending`
 
 This slice composes the existing one-page replay worker, fenced rebuild jobs, mutation
-store, and lease-bound checkpoint store into one bounded PostgreSQL runner. It does not
-add a scheduler, background task, automatic retry/backoff, cancellation command, dry-run,
-or production source adapter.
+store, and lease-bound checkpoint store into one bounded PostgreSQL runner. It includes
+durable cancellation requests and between-page terminal cancellation. It does not add a
+scheduler, background task, automatic retry/backoff, in-page interruption, dry-run, or
+production source adapter.
 
 ## Request bounds
 
@@ -26,29 +27,52 @@ therefore uses the same source identity as page execution and checkpoint persist
 For an acquired `IndexReplayJobLease`, the runner:
 
 1. constructs `PostgresIndexReplayCheckpointStore` from that exact lease;
-2. executes no more than the requested page budget through
+2. observes and terminalizes a previously requested cancellation before each page;
+3. executes no more than the requested page budget through
    `IndexReplayWorker::run_next_page`;
-3. extends the lease between pages at the requested completed-page cadence;
-4. accumulates applied, duplicate, stale, mutation, page, and heartbeat counts;
-5. calls fenced terminal success only after the one-page worker persisted a JSON `null`
+4. extends the lease between pages at the requested completed-page cadence;
+5. observes cancellation again after heartbeat and after every completed page;
+6. accumulates applied, duplicate, stale, mutation, page, and heartbeat counts;
+7. calls fenced terminal success only after the one-page worker persisted a JSON `null`
    cursor;
-6. when the page budget ends with continuation, atomically returns the same job to
+8. when the page budget ends with continuation, atomically returns the same job to
    `pending`, clears lease ownership, and makes it immediately claimable for resume.
 
-A page itself is not interrupted by a heartbeat task. Operators must choose a lease
-longer than the maximum admitted source-page and mutation-commit duration. Heartbeats
-protect bounded work between pages; retained timing evidence remains an owner step.
+A page itself is not interrupted by a heartbeat or cancellation task. Operators must
+choose a lease longer than the maximum admitted source-page and mutation/checkpoint
+commit duration. A cancellation requested during a page is observed after that page's
+idempotent mutations and checkpoint are durable.
+
+## Cancellation contract
+
+`PostgresIndexReplayRunner::request_cancel` accepts one non-nil tenant and job UUID. It
+locks the exact `rebuild` job before changing state:
+
+- a `pending` job becomes terminal `cancelled` immediately;
+- a `running` job retains its current owner and records `cancel_requested = TRUE`;
+- `succeeded`, `failed`, and `cancelled` return their typed terminal state;
+- an unknown tenant/job pair returns `NotFound`.
+
+The active owner terminalizes a running request only when the exact job UUID, worker ID,
+attempt count, running state, and unexpired lease still match. Cancellation clears lease
+ownership, preserves the durable checkpoint, records `completed_at`, and stores no error
+payload.
+
+Success, page failure, and pending-yield SQL all require
+`cancel_requested = FALSE`. This makes cancellation linear with every competing terminal
+or resume transition: a cancellation committed first cannot be overwritten by success,
+failure, or `pending`; a terminal transition committed first makes a later request return
+that terminal state.
 
 ## Resume and attempt fencing
 
 A yielded job keeps the same job UUID and durable checkpoint, but the next acquisition
-increments `attempt_count`. The old attempt cannot heartbeat, yield, fail, complete, or
-advance the checkpoint after the new attempt is claimed.
+increments `attempt_count`. The old attempt cannot heartbeat, yield, fail, complete,
+cancel, or advance the checkpoint after the new attempt is claimed.
 
-Yield uses all existing ownership predicates: tenant, job UUID, `kind = 'rebuild'`,
-`state = 'running'`, worker ID, attempt count, and an unexpired lease. If any predicate
-fails, the runner returns explicit lease loss and does not publish a false pending or
-terminal state.
+A running cancellation request survives lease expiry and reclaim. The next owner sees the
+persisted flag before reading the source and terminalizes the job with the incremented
+attempt fence.
 
 ## Failure boundary
 
@@ -57,21 +81,22 @@ Source, mutation, and checkpoint failures are recorded as one bounded
 detail object containing only the dependency code and retryable classification. No raw
 database, transport, or source-domain message is persisted.
 
-Checkpoint failures classified as `checkpoint_lease_lost`, heartbeat loss, terminal
-completion loss, and yield loss return explicit `IndexReplayRunError::LeaseLost` instead
-of attempting a stale failure write. A later owner reclaims the expired job through the
-existing attempt fence.
+Cancellation takes precedence when it races with page failure. Checkpoint failures
+classified as `checkpoint_lease_lost`, heartbeat loss, terminal completion loss, yield
+loss, and cancellation ownership loss return explicit `IndexReplayRunError::LeaseLost`
+instead of attempting a stale state write.
 
 ## Still open
 
-- cancellation request observation and terminal cancellation;
+- interruption or timeout of one currently executing source page;
 - automatic bounded retry/backoff and dead-letter scheduling;
-- a host scheduler, command surface, and graceful process shutdown ownership;
+- a host scheduler, command/transport authorization, and graceful process shutdown;
 - direct server-composition publication of the runner;
 - dry-run and targeted/full/shadow rebuild modes;
 - locale and partition checkpoint dimensions;
 - Product and later source adapters;
-- retained PostgreSQL crash, lease-expiry, restart, timing, and multi-instance evidence.
+- retained PostgreSQL cancellation, crash, lease-expiry, restart, timing, and
+  multi-instance evidence.
 
 ## Owner validation
 

--- a/crates/rustok-index/src/infrastructure/postgres/mod.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/mod.rs
@@ -57,6 +57,6 @@ pub use source_replay_job::{
     IndexReplayJobLeaseRequest, PostgresIndexReplayJobStore,
 };
 pub use source_replay_runner::{
-    IndexReplayRunError, IndexReplayRunOutcome, IndexReplayRunRequest, IndexReplayRunStatus,
-    PostgresIndexReplayRunner,
+    IndexReplayCancelOutcome, IndexReplayRunError, IndexReplayRunOutcome, IndexReplayRunRequest,
+    IndexReplayRunStatus, IndexReplayTerminalState, PostgresIndexReplayRunner,
 };

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use sea_orm::{
-    ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, QueryResult, Statement,
+    ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, Statement,
     TransactionTrait, Value as SqlValue,
 };
 use serde_json::{json, Value as JsonValue};

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs
@@ -1,6 +1,9 @@
 use std::{sync::Arc, time::Duration};
 
-use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement, Value as SqlValue};
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, QueryResult, Statement,
+    TransactionTrait, Value as SqlValue,
+};
 use serde_json::{json, Value as JsonValue};
 use thiserror::Error;
 use uuid::Uuid;
@@ -88,6 +91,7 @@ pub enum IndexReplayRunStatus {
     Busy,
     AlreadyComplete,
     Complete,
+    Cancelled,
     Yielded,
 }
 
@@ -142,6 +146,21 @@ impl IndexReplayRunOutcome {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexReplayTerminalState {
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexReplayCancelOutcome {
+    Requested,
+    Cancelled,
+    AlreadyTerminal(IndexReplayTerminalState),
+    NotFound,
+}
+
 #[derive(Clone)]
 pub struct PostgresIndexReplayRunner {
     db: DatabaseConnection,
@@ -159,6 +178,31 @@ impl PostgresIndexReplayRunner {
             db,
             sources,
             schema_registry,
+        }
+    }
+
+    pub async fn request_cancel(
+        &self,
+        tenant_id: Uuid,
+        job_id: Uuid,
+    ) -> Result<IndexReplayCancelOutcome, IndexReplayRunError> {
+        if tenant_id.is_nil() {
+            return Err(IndexReplayRunError::NilCancelTenantId);
+        }
+        if job_id.is_nil() {
+            return Err(IndexReplayRunError::NilCancelJobId);
+        }
+        let transaction = self.db.begin().await.map_err(job_storage_error)?;
+        let result = request_cancel_in_transaction(&transaction, tenant_id, job_id).await;
+        match result {
+            Ok(outcome) => {
+                transaction.commit().await.map_err(job_storage_error)?;
+                Ok(outcome)
+            }
+            Err(error) => {
+                transaction.rollback().await.map_err(job_storage_error)?;
+                Err(error)
+            }
         }
     }
 
@@ -220,9 +264,18 @@ impl PostgresIndexReplayRunner {
         };
 
         for page_index in 0..request.max_pages() {
+            if cancel_if_requested(&self.db, &lease).await? {
+                aggregate.status = IndexReplayRunStatus::Cancelled;
+                return Ok(aggregate);
+            }
+
             if page_index > 0 && page_index % request.heartbeat_every_pages() == 0 {
                 heartbeat(&job_store, &lease, request.lease_duration()).await?;
                 aggregate.heartbeat_count += 1;
+                if cancel_if_requested(&self.db, &lease).await? {
+                    aggregate.status = IndexReplayRunStatus::Cancelled;
+                    return Ok(aggregate);
+                }
             }
 
             let page = match worker.run_next_page(request.page_request().clone()).await {
@@ -231,21 +284,22 @@ impl PostgresIndexReplayRunner {
                     return Err(lease_lost(&lease));
                 }
                 Err(error) => {
+                    if cancel_if_requested(&self.db, &lease).await? {
+                        aggregate.status = IndexReplayRunStatus::Cancelled;
+                        return Ok(aggregate);
+                    }
                     let details = replay_failure_details(&error);
-                    match job_store
-                        .fail(&lease, REPLAY_PAGE_FAILURE_CODE, details)
-                        .await
-                    {
-                        Ok(()) => {
+                    match finish_failure(&self.db, &lease, details).await? {
+                        TerminalWriteOutcome::Written => {
                             return Err(IndexReplayRunError::PageFailed {
                                 job_id: lease.job_id(),
                                 error: Box::new(error),
                             });
                         }
-                        Err(IndexReplayJobError::LeaseLost) => {
-                            return Err(lease_lost(&lease));
+                        TerminalWriteOutcome::Cancelled => {
+                            aggregate.status = IndexReplayRunStatus::Cancelled;
+                            return Ok(aggregate);
                         }
-                        Err(job_error) => return Err(IndexReplayRunError::Job(job_error)),
                     }
                 }
             };
@@ -258,24 +312,42 @@ impl PostgresIndexReplayRunner {
             aggregate.duplicate_count += page.duplicate_count();
             aggregate.stale_count += page.stale_count();
 
+            if cancel_if_requested(&self.db, &lease).await? {
+                aggregate.status = IndexReplayRunStatus::Cancelled;
+                return Ok(aggregate);
+            }
+
             if matches!(
                 page.status(),
                 IndexReplayPageStatus::Complete | IndexReplayPageStatus::AlreadyComplete
             ) {
-                match job_store.succeed(&lease).await {
-                    Ok(()) => {
+                match finish_success(&self.db, &lease).await? {
+                    TerminalWriteOutcome::Written => {
                         aggregate.status = IndexReplayRunStatus::Complete;
                         return Ok(aggregate);
                     }
-                    Err(IndexReplayJobError::LeaseLost) => return Err(lease_lost(&lease)),
-                    Err(error) => return Err(IndexReplayRunError::Job(error)),
+                    TerminalWriteOutcome::Cancelled => {
+                        aggregate.status = IndexReplayRunStatus::Cancelled;
+                        return Ok(aggregate);
+                    }
                 }
             }
         }
 
-        yield_for_resume(&self.db, &lease).await?;
-        Ok(aggregate)
+        match yield_for_resume(&self.db, &lease).await? {
+            TerminalWriteOutcome::Written => Ok(aggregate),
+            TerminalWriteOutcome::Cancelled => {
+                aggregate.status = IndexReplayRunStatus::Cancelled;
+                Ok(aggregate)
+            }
+        }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TerminalWriteOutcome {
+    Written,
+    Cancelled,
 }
 
 fn empty_outcome(
@@ -308,29 +380,156 @@ async fn heartbeat(
     }
 }
 
+async fn request_cancel_in_transaction(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+    job_id: Uuid,
+) -> Result<IndexReplayCancelOutcome, IndexReplayRunError> {
+    let backend = transaction.get_database_backend();
+    ensure_supported_backend(backend)?;
+    let row = transaction
+        .query_one(Statement::from_sql_and_values(
+            backend,
+            select_cancel_job_sql(backend),
+            vec![uuid_value(tenant_id, backend), uuid_value(job_id, backend)],
+        ))
+        .await
+        .map_err(job_storage_error)?;
+    let Some(row) = row else {
+        return Ok(IndexReplayCancelOutcome::NotFound);
+    };
+    let state: String = row.try_get("", "state").map_err(job_storage_error)?;
+    match state.as_str() {
+        "pending" => {
+            let updated = transaction
+                .execute(Statement::from_sql_and_values(
+                    backend,
+                    cancel_pending_job_sql(backend),
+                    vec![uuid_value(tenant_id, backend), uuid_value(job_id, backend)],
+                ))
+                .await
+                .map_err(job_storage_error)?;
+            if updated.rows_affected() != 1 {
+                return Err(IndexReplayRunError::CancellationRace);
+            }
+            Ok(IndexReplayCancelOutcome::Cancelled)
+        }
+        "running" => {
+            let updated = transaction
+                .execute(Statement::from_sql_and_values(
+                    backend,
+                    request_running_cancel_sql(backend),
+                    vec![uuid_value(tenant_id, backend), uuid_value(job_id, backend)],
+                ))
+                .await
+                .map_err(job_storage_error)?;
+            if updated.rows_affected() != 1 {
+                return Err(IndexReplayRunError::CancellationRace);
+            }
+            Ok(IndexReplayCancelOutcome::Requested)
+        }
+        "succeeded" => Ok(IndexReplayCancelOutcome::AlreadyTerminal(
+            IndexReplayTerminalState::Succeeded,
+        )),
+        "failed" => Ok(IndexReplayCancelOutcome::AlreadyTerminal(
+            IndexReplayTerminalState::Failed,
+        )),
+        "cancelled" => Ok(IndexReplayCancelOutcome::AlreadyTerminal(
+            IndexReplayTerminalState::Cancelled,
+        )),
+        other => Err(IndexReplayRunError::InvalidStoredJobState(other.to_owned())),
+    }
+}
+
+async fn cancel_if_requested(
+    db: &DatabaseConnection,
+    lease: &IndexReplayJobLease,
+) -> Result<bool, IndexReplayRunError> {
+    let backend = db.get_database_backend();
+    ensure_supported_backend(backend)?;
+    let updated = db
+        .execute(Statement::from_sql_and_values(
+            backend,
+            cancel_active_job_sql(backend),
+            lease_values(lease, backend),
+        ))
+        .await
+        .map_err(job_storage_error)?;
+    Ok(updated.rows_affected() == 1)
+}
+
+async fn finish_success(
+    db: &DatabaseConnection,
+    lease: &IndexReplayJobLease,
+) -> Result<TerminalWriteOutcome, IndexReplayRunError> {
+    let backend = db.get_database_backend();
+    ensure_supported_backend(backend)?;
+    let mut values = lease_values(lease, backend);
+    values.push(lease.source_name().to_owned().into());
+    values.push(lease.schema().module.as_str().to_owned().into());
+    values.push(lease.schema().entity.as_str().to_owned().into());
+    values.push(i64::from(lease.schema().version.get()).into());
+    let updated = db
+        .execute(Statement::from_sql_and_values(
+            backend,
+            finish_success_sql(backend),
+            values,
+        ))
+        .await
+        .map_err(job_storage_error)?;
+    terminal_write_outcome(db, lease, updated.rows_affected()).await
+}
+
+async fn finish_failure(
+    db: &DatabaseConnection,
+    lease: &IndexReplayJobLease,
+    details: JsonValue,
+) -> Result<TerminalWriteOutcome, IndexReplayRunError> {
+    let backend = db.get_database_backend();
+    ensure_supported_backend(backend)?;
+    let mut values = lease_values(lease, backend);
+    values.push(REPLAY_PAGE_FAILURE_CODE.to_owned().into());
+    values.push(SqlValue::Json(Some(Box::new(details))));
+    let updated = db
+        .execute(Statement::from_sql_and_values(
+            backend,
+            finish_failure_sql(backend),
+            values,
+        ))
+        .await
+        .map_err(job_storage_error)?;
+    terminal_write_outcome(db, lease, updated.rows_affected()).await
+}
+
 async fn yield_for_resume(
     db: &DatabaseConnection,
     lease: &IndexReplayJobLease,
-) -> Result<(), IndexReplayRunError> {
+) -> Result<TerminalWriteOutcome, IndexReplayRunError> {
     let backend = db.get_database_backend();
     ensure_supported_backend(backend)?;
     let updated = db
         .execute(Statement::from_sql_and_values(
             backend,
             yield_job_sql(backend),
-            vec![
-                uuid_value(lease.tenant_id(), backend),
-                uuid_value(lease.job_id(), backend),
-                lease.worker_id().to_owned().into(),
-                i64::from(lease.attempt_count()).into(),
-            ],
+            lease_values(lease, backend),
         ))
         .await
-        .map_err(|error| IndexReplayRunError::Job(IndexReplayJobError::Storage(error.to_string())))?;
-    if updated.rows_affected() != 1 {
-        return Err(lease_lost(lease));
+        .map_err(job_storage_error)?;
+    terminal_write_outcome(db, lease, updated.rows_affected()).await
+}
+
+async fn terminal_write_outcome(
+    db: &DatabaseConnection,
+    lease: &IndexReplayJobLease,
+    rows_affected: u64,
+) -> Result<TerminalWriteOutcome, IndexReplayRunError> {
+    if rows_affected == 1 {
+        return Ok(TerminalWriteOutcome::Written);
     }
-    Ok(())
+    if cancel_if_requested(db, lease).await? {
+        return Ok(TerminalWriteOutcome::Cancelled);
+    }
+    Err(lease_lost(lease))
 }
 
 fn replay_error_is_lease_lost(error: &IndexReplayError) -> bool {
@@ -391,11 +590,76 @@ fn uuid_value(value: Uuid, backend: DbBackend) -> SqlValue {
     }
 }
 
+fn lease_values(lease: &IndexReplayJobLease, backend: DbBackend) -> Vec<SqlValue> {
+    vec![
+        uuid_value(lease.tenant_id(), backend),
+        uuid_value(lease.job_id(), backend),
+        lease.worker_id().to_owned().into(),
+        i64::from(lease.attempt_count()).into(),
+    ]
+}
+
+fn select_cancel_job_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    let lock = match backend {
+        DbBackend::Postgres => " FOR UPDATE",
+        DbBackend::Sqlite => "",
+        _ => unreachable!("unsupported database backend was validated"),
+    };
+    format!(
+        "SELECT state FROM index_jobs WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'rebuild' LIMIT 1{lock}"
+    )
+}
+
+fn cancel_pending_job_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    format!(
+        "UPDATE index_jobs SET state = 'cancelled', cancel_requested = TRUE, completed_at = CURRENT_TIMESTAMP, heartbeat_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP, last_error_code = NULL, last_error_details = NULL WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'rebuild' AND state = 'pending'"
+    )
+}
+
+fn request_running_cancel_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    format!(
+        "UPDATE index_jobs SET cancel_requested = TRUE, updated_at = CURRENT_TIMESTAMP WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'rebuild' AND state = 'running'"
+    )
+}
+
+fn cancel_active_job_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    format!(
+        "UPDATE index_jobs SET state = 'cancelled', lease_owner = NULL, lease_expires_at = NULL, heartbeat_at = CURRENT_TIMESTAMP, completed_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP, last_error_code = NULL, last_error_details = NULL WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'rebuild' AND state = 'running' AND lease_owner = {prefix}3 AND attempt_count = {prefix}4 AND lease_expires_at > CURRENT_TIMESTAMP AND cancel_requested = TRUE"
+    )
+}
+
+fn finish_success_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    let complete_cursor = match backend {
+        DbBackend::Postgres => "checkpoint.cursor = 'null'::jsonb",
+        DbBackend::Sqlite => "json_type(checkpoint.cursor) = 'null'",
+        _ => unreachable!("unsupported database backend was validated"),
+    };
+    format!(
+        "UPDATE index_jobs SET state = 'succeeded', lease_owner = NULL, lease_expires_at = NULL, heartbeat_at = CURRENT_TIMESTAMP, completed_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP, last_error_code = NULL, last_error_details = NULL WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'rebuild' AND state = 'running' AND lease_owner = {prefix}3 AND attempt_count = {prefix}4 AND lease_expires_at > CURRENT_TIMESTAMP AND cancel_requested = FALSE AND EXISTS (SELECT 1 FROM index_checkpoints AS checkpoint WHERE checkpoint.tenant_id = {prefix}1 AND checkpoint.checkpoint_kind = 'rebuild' AND checkpoint.source_name = {prefix}5 AND checkpoint.module_name = {prefix}6 AND checkpoint.entity_name = {prefix}7 AND checkpoint.schema_version = {prefix}8 AND checkpoint.locale_key = '' AND checkpoint.partition_key = '' AND {complete_cursor})"
+    )
+}
+
+fn finish_failure_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    format!(
+        "UPDATE index_jobs SET state = 'failed', lease_owner = NULL, lease_expires_at = NULL, heartbeat_at = CURRENT_TIMESTAMP, completed_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP, last_error_code = {prefix}5, last_error_details = {prefix}6 WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'rebuild' AND state = 'running' AND lease_owner = {prefix}3 AND attempt_count = {prefix}4 AND lease_expires_at > CURRENT_TIMESTAMP AND cancel_requested = FALSE"
+    )
+}
+
 fn yield_job_sql(backend: DbBackend) -> String {
     let prefix = placeholder_prefix(backend);
     format!(
-        "UPDATE index_jobs SET state = 'pending', available_at = CURRENT_TIMESTAMP, lease_owner = NULL, lease_expires_at = NULL, heartbeat_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'rebuild' AND state = 'running' AND lease_owner = {prefix}3 AND attempt_count = {prefix}4 AND lease_expires_at > CURRENT_TIMESTAMP"
+        "UPDATE index_jobs SET state = 'pending', available_at = CURRENT_TIMESTAMP, lease_owner = NULL, lease_expires_at = NULL, heartbeat_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'rebuild' AND state = 'running' AND lease_owner = {prefix}3 AND attempt_count = {prefix}4 AND lease_expires_at > CURRENT_TIMESTAMP AND cancel_requested = FALSE"
     )
+}
+
+fn job_storage_error(error: impl std::fmt::Display) -> IndexReplayRunError {
+    IndexReplayRunError::Job(IndexReplayJobError::Storage(error.to_string()))
 }
 
 fn lease_lost(lease: &IndexReplayJobLease) -> IndexReplayRunError {
@@ -413,8 +677,16 @@ pub enum IndexReplayRunError {
     InvalidMaxPages { actual: usize, max: usize },
     #[error("Index replay heartbeat cadence is invalid: actual={actual}, max={max}")]
     InvalidHeartbeatCadence { actual: usize, max: usize },
+    #[error("Index replay cancellation tenant id must not be nil")]
+    NilCancelTenantId,
+    #[error("Index replay cancellation job id must not be nil")]
+    NilCancelJobId,
     #[error("No Index replay source owns schema {0}")]
     UnknownSchemaSource(SchemaRef),
+    #[error("stored Index replay job has unsupported state {0}")]
+    InvalidStoredJobState(String),
+    #[error("Index replay cancellation lost a concurrent state transition")]
+    CancellationRace,
     #[error(transparent)]
     Job(#[from] IndexReplayJobError),
     #[error("Index replay job {job_id} lost attempt {attempt_count} ownership")]

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_runner_tests.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_runner_tests.rs
@@ -17,7 +17,9 @@ use serde_json::json;
 use uuid::Uuid;
 
 use super::{
-    IndexReplayRunError, IndexReplayRunRequest, IndexReplayRunStatus, PostgresIndexReplayRunner,
+    IndexReplayCancelOutcome, IndexReplayJobAcquireOutcome, IndexReplayJobLeaseRequest,
+    IndexReplayRunError, IndexReplayRunRequest, IndexReplayRunStatus, PostgresIndexReplayJobStore,
+    PostgresIndexReplayRunner,
 };
 use crate::{
     EntityKey, EntityName, FieldCardinality, FieldName, IndexField, IndexModule, IndexMutation,
@@ -34,6 +36,7 @@ struct PagedSource {
     calls: Arc<AtomicUsize>,
     page_count: usize,
     expire_lease_on_call: Option<usize>,
+    request_cancel_on_call: Option<usize>,
 }
 
 #[async_trait]
@@ -51,6 +54,15 @@ impl IndexSource for PagedSource {
                 ))
                 .await
                 .expect("test source should expire the active replay lease");
+        }
+        if self.request_cancel_on_call == Some(call) {
+            self.db
+                .execute(Statement::from_string(
+                    DbBackend::Sqlite,
+                    "UPDATE index_jobs SET cancel_requested = TRUE WHERE kind = 'rebuild' AND state = 'running'".to_owned(),
+                ))
+                .await
+                .expect("test source should request cancellation");
         }
 
         let page = request
@@ -89,7 +101,11 @@ struct Fixture {
 }
 
 impl Fixture {
-    async fn new(page_count: usize, expire_lease_on_call: Option<usize>) -> Self {
+    async fn new(
+        page_count: usize,
+        expire_lease_on_call: Option<usize>,
+        request_cancel_on_call: Option<usize>,
+    ) -> Self {
         let db = Database::connect("sqlite::memory:")
             .await
             .expect("in-memory sqlite should connect");
@@ -142,6 +158,7 @@ impl Fixture {
                     calls: calls.clone(),
                     page_count,
                     expire_lease_on_call,
+                    request_cancel_on_call,
                 },
             )
             .unwrap();
@@ -242,7 +259,7 @@ async fn scalar_string(db: &DatabaseConnection, sql: &str) -> String {
 
 #[tokio::test]
 async fn bounded_run_yields_pending_and_resumes_with_a_new_attempt() {
-    let fixture = Fixture::new(3, None).await;
+    let fixture = Fixture::new(3, None, None).await;
     let first = fixture.runner.run(fixture.request("worker-a", 2, 1)).await.unwrap();
     assert_eq!(first.status(), IndexReplayRunStatus::Yielded);
     assert_eq!(first.pages_processed(), 2);
@@ -267,7 +284,7 @@ async fn bounded_run_yields_pending_and_resumes_with_a_new_attempt() {
     assert_eq!(
         scalar_i64(
             &fixture.db,
-            "SELECT COUNT(*) AS value FROM index_jobs WHERE kind = 'rebuild' AND state = 'succeeded' AND completed_at IS NOT NULL",
+            "SELECT COUNT(*) AS value FROM index_jobs WHERE kind = 'rebuild' AND state = 'succeeded' AND completed_at IS NOT NULL AND cancel_requested = FALSE",
         )
         .await,
         1,
@@ -275,8 +292,103 @@ async fn bounded_run_yields_pending_and_resumes_with_a_new_attempt() {
 }
 
 #[tokio::test]
+async fn pending_cancel_request_terminalizes_without_a_worker() {
+    let fixture = Fixture::new(3, None, None).await;
+    let first = fixture.runner.run(fixture.request("worker-a", 1, 1)).await.unwrap();
+    assert_eq!(first.status(), IndexReplayRunStatus::Yielded);
+    let job_id = first.job_id().unwrap();
+    assert_eq!(
+        fixture
+            .runner
+            .request_cancel(Uuid::parse_str(TENANT).unwrap(), job_id)
+            .await
+            .unwrap(),
+        IndexReplayCancelOutcome::Cancelled,
+    );
+    assert_eq!(
+        scalar_i64(
+            &fixture.db,
+            "SELECT COUNT(*) AS value FROM index_jobs WHERE kind = 'rebuild' AND state = 'cancelled' AND cancel_requested = TRUE AND completed_at IS NOT NULL AND lease_owner IS NULL",
+        )
+        .await,
+        1,
+    );
+}
+
+#[tokio::test]
+async fn running_cancel_request_is_observed_after_the_current_page() {
+    let fixture = Fixture::new(3, None, Some(0)).await;
+    let outcome = fixture.runner.run(fixture.request("worker-a", 3, 1)).await.unwrap();
+    assert_eq!(outcome.status(), IndexReplayRunStatus::Cancelled);
+    assert_eq!(outcome.pages_processed(), 1);
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        scalar_i64(
+            &fixture.db,
+            "SELECT COUNT(*) AS value FROM index_jobs WHERE kind = 'rebuild' AND state = 'cancelled' AND cancel_requested = TRUE AND completed_at IS NOT NULL",
+        )
+        .await,
+        1,
+    );
+    assert_eq!(
+        scalar_string(
+            &fixture.db,
+            "SELECT CAST(cursor AS TEXT) AS value FROM index_checkpoints WHERE checkpoint_kind = 'rebuild'",
+        )
+        .await,
+        "1",
+    );
+}
+
+#[tokio::test]
+async fn requested_running_cancel_survives_reclaim_and_fences_the_old_attempt() {
+    let fixture = Fixture::new(3, None, None).await;
+    let job_store = PostgresIndexReplayJobStore::new(fixture.db.clone());
+    let lease_request = IndexReplayJobLeaseRequest::new(
+        Uuid::parse_str(TENANT).unwrap(),
+        schema_ref(),
+        "product-primary",
+        "worker-a",
+        Duration::from_secs(60),
+    )
+    .unwrap();
+    let first = match job_store.acquire(&lease_request).await.unwrap() {
+        IndexReplayJobAcquireOutcome::Acquired(lease) => lease,
+        outcome => panic!("first worker should acquire replay job, got {outcome:?}"),
+    };
+    assert_eq!(
+        fixture
+            .runner
+            .request_cancel(Uuid::parse_str(TENANT).unwrap(), first.job_id())
+            .await
+            .unwrap(),
+        IndexReplayCancelOutcome::Requested,
+    );
+    fixture
+        .db
+        .execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "UPDATE index_jobs SET lease_expires_at = datetime('now', '-1 second') WHERE tenant_id = ?1 AND job_id = ?2",
+            vec![TENANT.to_owned().into(), first.job_id().to_string().into()],
+        ))
+        .await
+        .unwrap();
+
+    let second = fixture.runner.run(fixture.request("worker-b", 3, 1)).await.unwrap();
+    assert_eq!(second.status(), IndexReplayRunStatus::Cancelled);
+    assert_eq!(second.job_id(), Some(first.job_id()));
+    assert_eq!(second.attempt_count(), Some(2));
+    assert_eq!(second.pages_processed(), 0);
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        job_store.heartbeat(&first, Duration::from_secs(60)).await,
+        Err(super::IndexReplayJobError::LeaseLost),
+    );
+}
+
+#[tokio::test]
 async fn lease_loss_during_a_page_does_not_publish_failure_or_advance_cursor() {
-    let fixture = Fixture::new(2, Some(1)).await;
+    let fixture = Fixture::new(2, Some(1), None).await;
     let error = fixture
         .runner
         .run(fixture.request("worker-a", 2, 1))

--- a/crates/rustok-index/src/lib.rs
+++ b/crates/rustok-index/src/lib.rs
@@ -5,10 +5,10 @@
 //! storage-schema migrations, atomic mutation persistence, tenant-scoped source
 //! schema registration, bounded source replay/load contracts, one-page replay
 //! orchestration with durable fenced checkpoint progression, bounded multi-page
-//! replay coordination with heartbeat/yield semantics, durable replay-job and
-//! schema-application leases, schema-derived secondary-index lifecycle,
-//! fail-closed measured partition admission, and the PostgreSQL execution adapter
-//! for structured Index queries.
+//! replay coordination with heartbeat/yield/cancellation semantics, durable
+//! replay-job and schema-application leases, schema-derived secondary-index
+//! lifecycle, fail-closed measured partition admission, and the PostgreSQL
+//! execution adapter for structured Index queries.
 
 use async_trait::async_trait;
 use rustok_core::{
@@ -26,21 +26,21 @@ pub use application::*;
 pub use domain::*;
 pub use infrastructure::postgres::{
     evaluate_partition_admission, materialize_postgres_index_query_runtime,
-    IndexQueryRuntimeCompositionError, IndexReplayJobAcquireOutcome, IndexReplayJobError,
-    IndexReplayJobLease, IndexReplayJobLeaseRequest, IndexReplayRunError, IndexReplayRunOutcome,
-    IndexReplayRunRequest, IndexReplayRunStatus, MutationApplyOutcome, MutationDelivery,
-    MutationStorageError, PartitionAdmissionError, PartitionAdmissionOutcome,
-    PartitionAdmissionPolicy, PartitionAdmissionReason, PartitionBaselineEvidence,
-    PartitionEvidence, PartitionMeasurementCoverage, PartitionRelationPlan,
-    PartitionShadowEvidence, PartitionShadowPlan, PartitionStrategy,
-    PersistedSchemaRegistrationOutcome, PostgresIndexQueryPort,
-    PostgresIndexReplayCheckpointStore, PostgresIndexReplayJobStore, PostgresIndexReplayRunner,
-    PostgresMutationStore, PostgresSchemaLeaseStore, PostgresSchemaRegistrationStore,
-    PostgresSecondaryIndexManager, SchemaApplicationLease, SchemaApplicationLeaseRequest,
-    SchemaLeaseAcquireOutcome, SchemaLeaseError, SchemaRegistrationError,
-    SecondaryIndexClaimOutcome, SecondaryIndexError, SecondaryIndexExecutionOutcome,
-    SecondaryIndexKind, SecondaryIndexLease, SecondaryIndexOperation, SecondaryIndexPlan,
-    SecondaryIndexRequest, SecondaryIndexSpec,
+    IndexQueryRuntimeCompositionError, IndexReplayCancelOutcome, IndexReplayJobAcquireOutcome,
+    IndexReplayJobError, IndexReplayJobLease, IndexReplayJobLeaseRequest, IndexReplayRunError,
+    IndexReplayRunOutcome, IndexReplayRunRequest, IndexReplayRunStatus,
+    IndexReplayTerminalState, MutationApplyOutcome, MutationDelivery, MutationStorageError,
+    PartitionAdmissionError, PartitionAdmissionOutcome, PartitionAdmissionPolicy,
+    PartitionAdmissionReason, PartitionBaselineEvidence, PartitionEvidence,
+    PartitionMeasurementCoverage, PartitionRelationPlan, PartitionShadowEvidence,
+    PartitionShadowPlan, PartitionStrategy, PersistedSchemaRegistrationOutcome,
+    PostgresIndexQueryPort, PostgresIndexReplayCheckpointStore, PostgresIndexReplayJobStore,
+    PostgresIndexReplayRunner, PostgresMutationStore, PostgresSchemaLeaseStore,
+    PostgresSchemaRegistrationStore, PostgresSecondaryIndexManager, SchemaApplicationLease,
+    SchemaApplicationLeaseRequest, SchemaLeaseAcquireOutcome, SchemaLeaseError,
+    SchemaRegistrationError, SecondaryIndexClaimOutcome, SecondaryIndexError,
+    SecondaryIndexExecutionOutcome, SecondaryIndexKind, SecondaryIndexLease,
+    SecondaryIndexOperation, SecondaryIndexPlan, SecondaryIndexRequest, SecondaryIndexSpec,
 };
 
 pub struct IndexModule;

--- a/scripts/verify/verify-index-replay-job-leases.mjs
+++ b/scripts/verify/verify-index-replay-job-leases.mjs
@@ -51,7 +51,6 @@ for (const forbidden of [
   'rustok_flex',
   'tokio::spawn',
   'loop {',
-  'cancel_requested = TRUE',
   'DELETE FROM index_jobs',
 ]) {
   if (job.includes(forbidden)) fail(`${jobPath} contains forbidden marker ${forbidden}`);
@@ -135,38 +134,25 @@ requireMarkers('crates/rustok-index/docs/m6-replay-job-leases.md', [
   'maintainer-run',
 ]);
 
+requireMarkers('crates/rustok-index/docs/m6-bounded-multipage-runner.md', [
+  '`PostgresIndexReplayRunner::request_cancel`',
+  'cancel_requested = FALSE',
+  'A running cancellation request survives lease expiry and reclaim.',
+]);
+
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
   '- M6 replay job leases and checkpoint attempt fencing: `source_complete_owner_execution_pending`',
+  '- M6 bounded multi-page replay and cancellation: `source_complete_owner_execution_pending`',
   '- [x] Add durable schema-scoped rebuild jobs, lease/heartbeat, reclaim, attempt fencing,',
   '- [x] Bind checkpoint reads and writes to the active `(job_id, worker_id, attempt_count)`',
-  '- [ ] Add cancellation, bounded multi-page resume, dry-run, targeted/full/shadow rebuild.',
+  '- [x] Add durable cancellation requests and fenced between-page terminal cancellation.',
   'node scripts/verify/verify-index-replay-job-leases.mjs',
-]);
-
-requireMarkers('crates/rustok-index/README.md', [
-  'Current milestone: `M6 - fenced replay job ownership`',
-  '`PostgresIndexReplayJobStore` owns one schema-scoped `rebuild` job',
-  '`PostgresIndexReplayCheckpointStore` is constructed from the acquired',
-  'stale checkpoint-writer rejection',
-]);
-
-requireMarkers('crates/rustok-index/docs/README.md', [
-  '## M5/M6 source replay and rebuild ownership',
-  '`index_replay_job_v1` request contract',
-  'After reclaim, the old worker cannot advance the durable',
-  'M6 job leases and checkpoint attempt fencing: `source_complete_owner_execution_pending`',
-]);
-
-requireMarkers('crates/rustok-index/CRATE_API.md', [
-  '`PostgresIndexReplayJobStore`, `IndexReplayJobLeaseRequest`, `IndexReplayJobLease`',
-  '`PostgresIndexReplayCheckpointStore`',
-  '### Replay source, job, and checkpoint',
-  'A stale attempt cannot advance a checkpoint after reclaim.',
 ]);
 
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-source-replay-contract.mjs'",
   "'verify-index-replay-job-leases.mjs'",
+  "'verify-index-replay-multipage-runner.mjs'",
 ]);
 
 console.log('[verify-index-replay-job-leases] OK');

--- a/scripts/verify/verify-index-replay-multipage-runner.mjs
+++ b/scripts/verify/verify-index-replay-multipage-runner.mjs
@@ -23,17 +23,25 @@ const runner = requireMarkers(runnerPath, [
   'const MAX_PAGES_PER_RUN: usize = 1_024;',
   'pub struct IndexReplayRunRequest',
   'pub enum IndexReplayRunStatus',
-  'pub struct IndexReplayRunOutcome',
+  'Cancelled,',
+  'pub enum IndexReplayCancelOutcome',
+  'pub enum IndexReplayTerminalState',
   'pub struct PostgresIndexReplayRunner',
+  'pub async fn request_cancel(',
   '.source_for_schema(request.page_request().schema())',
   'IndexReplayJobLeaseRequest::new(',
   'PostgresIndexReplayCheckpointStore::new(self.db.clone(), lease.clone())',
   'for page_index in 0..request.max_pages()',
   'page_index % request.heartbeat_every_pages() == 0',
   'worker.run_next_page(request.page_request().clone())',
-  'job_store.succeed(&lease).await',
-  'yield_for_resume(&self.db, &lease).await?;',
+  'cancel_if_requested(&self.db, &lease).await?',
+  'finish_success(&self.db, &lease).await?',
+  'finish_failure(&self.db, &lease, details).await?',
+  'yield_for_resume(&self.db, &lease).await?',
   "state = 'pending'",
+  "state = 'cancelled'",
+  'cancel_requested = TRUE',
+  'cancel_requested = FALSE',
   "kind = 'rebuild'",
   'lease_expires_at > CURRENT_TIMESTAMP',
   'index_replay_run_failure_v1',
@@ -45,7 +53,6 @@ for (const forbidden of [
   'tokio::spawn',
   'loop {',
   'tokio::time::sleep',
-  'cancel_requested',
   'DELETE FROM index_jobs',
   'rustok_product',
   'rustok_content',
@@ -55,21 +62,42 @@ for (const forbidden of [
 }
 
 const runLoop = runner.indexOf('for page_index in 0..request.max_pages()');
+const prePageCancel = runner.indexOf('cancel_if_requested(&self.db, &lease).await?', runLoop);
 const pageCall = runner.indexOf('worker.run_next_page(request.page_request().clone())', runLoop);
-const successCall = runner.indexOf('job_store.succeed(&lease).await', pageCall);
-const yieldCall = runner.indexOf('yield_for_resume(&self.db, &lease).await?;', successCall);
-if (runLoop < 0 || pageCall <= runLoop || successCall <= pageCall || yieldCall <= successCall) {
-  fail('runner must process bounded pages, complete on null cursor, then yield unfinished work');
+const postPageCancel = runner.indexOf('cancel_if_requested(&self.db, &lease).await?', pageCall);
+const successCall = runner.indexOf('finish_success(&self.db, &lease).await?', postPageCancel);
+const yieldCall = runner.indexOf('yield_for_resume(&self.db, &lease).await?', successCall);
+if (
+  runLoop < 0
+  || prePageCancel <= runLoop
+  || pageCall <= prePageCancel
+  || postPageCancel <= pageCall
+  || successCall <= postPageCancel
+  || yieldCall <= successCall
+) {
+  fail('runner must observe cancellation before/after pages, complete on null cursor, then yield');
+}
+
+for (const terminalSql of ['finish_success_sql', 'finish_failure_sql', 'yield_job_sql']) {
+  const start = runner.indexOf(`fn ${terminalSql}(`);
+  const end = runner.indexOf('\n}', start);
+  if (start < 0 || !runner.slice(start, end).includes('cancel_requested = FALSE')) {
+    fail(`${terminalSql} must make cancellation win over terminal or pending publication`);
+  }
 }
 
 requireMarkers('crates/rustok-index/src/infrastructure/postgres/source_replay_runner_tests.rs', [
   'bounded_run_yields_pending_and_resumes_with_a_new_attempt',
+  'pending_cancel_request_terminalizes_without_a_worker',
+  'running_cancel_request_is_observed_after_the_current_page',
+  'requested_running_cancel_survives_reclaim_and_fences_the_old_attempt',
   'lease_loss_during_a_page_does_not_publish_failure_or_advance_cursor',
   'run_request_bounds_pages_and_heartbeat_cadence',
-  'IndexReplayRunStatus::Yielded',
-  'IndexReplayRunStatus::Complete',
+  'IndexReplayCancelOutcome::Cancelled',
+  'IndexReplayCancelOutcome::Requested',
+  'IndexReplayRunStatus::Cancelled',
   'second.attempt_count(), Some(2)',
-  "state = 'pending'",
+  'cancel_requested = TRUE',
   'last_error_code IS NULL',
 ]);
 
@@ -79,30 +107,35 @@ requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
   'PostgresIndexReplayRunner',
   'IndexReplayRunRequest',
   'IndexReplayRunOutcome',
+  'IndexReplayCancelOutcome',
+  'IndexReplayTerminalState',
 ]);
 
 requireMarkers('crates/rustok-index/src/lib.rs', [
-  'bounded multi-page',
+  'heartbeat/yield/cancellation semantics',
   'PostgresIndexReplayRunner',
   'IndexReplayRunRequest',
   'IndexReplayRunStatus',
+  'IndexReplayCancelOutcome',
 ]);
 
 requireMarkers('crates/rustok-index/docs/m6-bounded-multipage-runner.md', [
   'Status: `source_complete_owner_execution_pending`',
   '1 through 1024 pages per invocation',
   'The source name is never caller supplied.',
-  'returns the same job to',
-  '`pending`',
-  '`index_replay_run_failure_v1`',
-  'cancellation request observation',
+  '`PostgresIndexReplayRunner::request_cancel`',
+  'a `pending` job becomes terminal `cancelled` immediately',
+  'cancel_requested = FALSE',
+  'A running cancellation request survives lease expiry and reclaim.',
+  'in-page interruption',
   'maintainer-run',
 ]);
 
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
-  '- M6 bounded multi-page replay runner: `source_complete_owner_execution_pending`',
+  '- M6 bounded multi-page replay and cancellation: `source_complete_owner_execution_pending`',
   '- [x] Add bounded multi-page execution with heartbeat cadence and immediate pending resume.',
-  'Cancellation, automatic retry/backoff, dead-letter scheduling, host scheduling, and',
+  '- [x] Add durable cancellation requests and fenced between-page terminal cancellation.',
+  'In-page interruption, automatic retry/backoff, dead-letter scheduling, host scheduling,',
 ]);
 
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [


### PR DESCRIPTION
## Summary

- add `PostgresIndexReplayRunner::request_cancel` for exact tenant/rebuild-job cancellation
- lock the target job before deciding the cancellation transition
- terminalize pending jobs immediately as `cancelled`
- persist `cancel_requested = TRUE` for running jobs without stealing their lease
- observe and terminalize cancellation before pages, after heartbeat, and after each durable page
- preserve the completed page's idempotent mutations and checkpoint when cancellation arrives during that page
- make cancellation win over success, page failure, and pending yield through `cancel_requested = FALSE` predicates
- retain exact job/worker/attempt/unexpired-lease fencing for active terminal cancellation
- preserve cancellation through lease expiry and reclaim so the next attempt cancels before source access
- add typed requested/cancelled/already-terminal/not-found outcomes and explicit cancellation validation errors
- add SQLite contract fixtures for pending cancellation, running between-page cancellation, reclaim, stale-attempt fencing, and existing lease-loss behavior
- update the M6 contract, canonical implementation plan, and replay guards

## Ordering boundary

Cancellation is linear with success, failure, and yield. If the cancellation request commits first, competing terminal or pending SQL cannot overwrite it. If success, failure, or cancellation already committed first, a later request returns the typed terminal state.

The runner does not interrupt an executing source page. A request arriving during a page is observed after that page's mutations and checkpoint are durable. Operators must keep the lease longer than one admitted page and its persistence work.

## Explicitly not included

- in-page interruption or source-call timeout
- automatic retry/backoff or dead-letter scheduling
- host/server scheduler composition and graceful shutdown ownership
- command/transport authorization
- dry-run or targeted/full/shadow mode selection
- locale/partition checkpoint dimensions
- Product or other production source adapters
- retained PostgreSQL cancellation, crash/restart, timing, or multi-instance evidence

## Validation

Not run by the implementation agent, per owner request. The repository owner will run formatting, Cargo checks/tests, JavaScript guards, fixtures, and CI.

Suggested owner commands:

```bash
node scripts/verify/verify-index-replay-multipage-runner.mjs
node scripts/verify/verify-index-replay-job-leases.mjs
node scripts/verify/verify-index-source-replay-contract.mjs
node scripts/verify/verify-index-query-contract.mjs
cargo check -p rustok-index --all-targets
cargo test -p rustok-index source_replay_runner --lib -- --nocapture
```

## Branch policy

This slice started from the merge commit of PR #2576. The ten parallel commits added afterward do not touch Index files. Squash merge is requested; the branch will then be deleted and the next slice will start from the then-current `main`.