### PR TITLE
fix(profiles): make CLI backfill invalidation atomic

### DIFF
--- a/crates/rustok-forum/contracts/forum-search-public-author-summary.json
+++ b/crates/rustok-forum/contracts/forum-search-public-author-summary.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "task": "FORUM-23A",
-  "latest_slice": "FORUM-23A6",
+  "latest_slice": "FORUM-23A7",
   "upstream_task": "FORUM-20BQ",
   "status": "source_complete_execution_pending",
   "scope": "Project privacy-aware public author summaries into Forum topic and approved-reply Search documents and durably redact them after Profiles owner changes",
@@ -16,6 +16,7 @@
   "profiles_locale_event_owner": "crates/rustok-profiles/src/locale_write.rs",
   "profiles_media_event_owner": "crates/rustok-profiles/src/media_write.rs",
   "profiles_upsert_event_owner": "crates/rustok-profiles/src/upsert_write.rs",
+  "profiles_cli_backfill_owner": "crates/rustok-profiles/cli/src/lib.rs",
   "search_inbox": "crates/rustok-search/src/forum_inbox.rs",
   "search_ingestion": "crates/rustok-search/src/ingestion.rs",
   "owner_note": "crates/rustok-forum/docs/forum-23a-search-public-author-summary.md",
@@ -45,6 +46,7 @@
     "profile_updated_is_emitted_after_owner_write": true,
     "transactional_profile_event_publisher_is_shared": true,
     "transactional_profile_event_publisher_accepts_owner_model": true,
+    "transactional_profile_event_publisher_accepts_system_actor": true,
     "profile_visibility_write_and_event_are_atomic": true,
     "visibility_event_failure_rolls_back_owner_write": true,
     "profile_handle_write_and_event_are_atomic": true,
@@ -60,6 +62,11 @@
     "upsert_event_failure_rolls_back_owner_write": true,
     "upsert_couples_profile_translation_tags_and_event": true,
     "upsert_media_validation_precedes_owner_transaction": true,
+    "profiles_cli_backfill_creation_and_event_are_atomic": true,
+    "profiles_cli_backfill_event_failure_rolls_back_owner_write": true,
+    "profiles_cli_backfill_requires_event_for_non_dry_run": true,
+    "profiles_cli_backfill_dry_run_emits_no_event": true,
+    "profiles_cli_backfill_skips_concurrent_existing_profile": true,
     "remaining_profile_summary_write_and_event_pairs_are_atomic": true,
     "author_scope_is_tenant_and_user_scoped": true,
     "author_scope_is_not_suppressed_by_forum_wall_clock_watermark": true,
@@ -80,7 +87,7 @@
   "remaining_scope": [
     "replace remaining wall-clock Forum projection ordering with owner-issued monotonic revisions",
     "define an owner-ordered profile or account deletion projection invalidation contract",
-    "define durable Search invalidation for CLI backfill profile creation or prove rebuild coverage",
+    "consolidate or restrict direct non-event ProfileService mutation APIs",
     "add bounded category-subtree tag locale date solved kind channel/group and attachment filters",
     "add member index projections",
     "capture maintainer-executed PostgreSQL rebuild redaction and query evidence"
@@ -89,6 +96,7 @@
     "execution_status": "not_run_by_implementation_agent",
     "commands": [
       "cargo check -p rustok-profiles --all-targets",
+      "cargo check -p rustok-profiles-cli --all-targets",
       "cargo test -p rustok-profiles error -- --nocapture",
       "cargo test -p rustok-forum search_projection_author -- --nocapture",
       "cargo test -p rustok-search forum_inbox -- --nocapture",
@@ -102,8 +110,8 @@
   "non_claims": [
     "UserDeleted is sufficient to prove Profiles state has already been removed",
     "account deletion redaction is complete",
-    "CLI backfill profile creation publishes ProfileUpdated",
     "all Profiles owner writes trigger durable Forum Search invalidation",
+    "direct non-event ProfileService mutation APIs are production-inaccessible",
     "general cross-producer owner revision ordering is complete"
   ],
   "downstream_task": "FORUM-23B"

--- a/crates/rustok-forum/docs/forum-23a-search-public-author-summary.md
+++ b/crates/rustok-forum/docs/forum-23a-search-public-author-summary.md
@@ -4,7 +4,7 @@ Date: 2026-07-30
 
 Status: `source_complete_execution_pending`
 
-Latest slice: `FORUM-23A6`
+Latest slice: `FORUM-23A7`
 
 This slice advances the canonical `FORUM-23` visibility-aware Search track. Public Forum topic
 and approved-reply documents obtain author presentation from the Profiles owner instead of
@@ -37,9 +37,9 @@ empty author: it fails projection so the durable Search inbox can retry.
 ## Durable redaction
 
 Embedded summaries require invalidation when profile presentation changes. Profiles publishes
-`ProfileUpdated` for handle, display content, locale, visibility, media, and self-service upsert
-changes. Search treats that owner event as a Forum projection event whenever the Forum source is
-composed.
+`ProfileUpdated` for handle, display content, locale, visibility, media, self-service upsert, and
+CLI backfill creation. Search treats that owner event as a Forum projection event whenever the
+Forum source is composed.
 
 The privacy-critical `update_my_profile_visibility` path writes the new visibility and the
 `ProfileUpdated` outbox envelope in the same Profiles-owned database transaction. If outbox
@@ -75,17 +75,26 @@ replaces taxonomy-backed profile tags, and writes the durable `ProfileUpdated` e
 failure rolls back every owner row, including newly created profiles, translations, and tag
 relations. The GraphQL mutation no longer has a post-commit event publisher.
 
-All self-service mutations that emit `ProfileUpdated` now use the shared transactional publisher in
+`FORUM-23A7` applies the create-only variant of the same owner transaction to the Profiles CLI
+backfill. Non-dry-run backfill always constructs the outbox transport and cannot opt out of durable
+invalidation. The create-if-missing transaction rechecks profile absence, checks handle ownership,
+creates the profile and localized content, writes the `ProfileUpdated` envelope with a system actor,
+and commits last. Event failure rolls back the new profile. If a profile appears concurrently, the
+transaction is rolled back and the CLI reports the item as skipped without overwriting user-owned
+state. Dry-run still plans only and emits no event. The historical `--emit-events` option remains an
+accepted compatibility input, but it no longer disables events for writes.
+
+All self-service mutations and CLI backfill creation now use the shared transactional publisher in
 `crates/rustok-profiles/src/profile_updated_event.rs`, so their event envelope and retryable error
-classification cannot drift independently. This does not claim full owner-write coverage: the
-Profiles CLI/backfill path still calls the service upsert without publishing `ProfileUpdated` and
-requires a separate invalidation or rebuild proof.
+classification cannot drift independently. This does not claim every callable Profiles mutation API
+is event-coupled: direct non-event `ProfileService` mutation methods remain and require a separate
+restriction, consolidation, or production reachability proof.
 
 The event is stored under `forum_author:<user_id>`. This scope is intentionally a redaction
 barrier: it is not stale-skipped against the unrelated full Forum wall-clock watermark. The
 consumer rebuilds the Forum tenant projection from current owner state, so committed visibility,
-handle, public display-name, locale selection, avatar, and self-service upsert changes replace stale
-Search presentation.
+handle, public display-name, locale selection, avatar, self-service upsert, and CLI backfill changes
+replace stale Search presentation.
 
 The existing tenant advisory lock, durable retry, dead-letter bound, and periodic/opportunistic
 inbox reconciliation remain unchanged. This slice does not claim that general Forum producer
@@ -109,14 +118,15 @@ discovery contract are unchanged.
 
 No database migration, Search query API change, Forum GraphQL/REST change, Forum owner-storage
 change, Profiles owner-storage change, dependency change, or `Cargo.lock` change is introduced.
-Existing Search document rows are replaced by the next Forum rebuild or relevant durable event.
+The operational CLI safety rule is tightened: every non-dry-run profile creation now includes the
+durable event in the owner transaction. Existing Search document rows are replaced by the next
+Forum rebuild or relevant durable event.
 
 ## Remaining FORUM-23 scope
 
 - owner-issued monotonic projection revisions across Forum producers;
 - an owner-ordered profile or account deletion invalidation contract;
-- durable Search invalidation for CLI/backfill profile creation, or retained evidence that the
-  responsible rebuild always follows it;
+- consolidate or restrict direct non-event `ProfileService` mutation APIs;
 - bounded category-subtree, tag, locale, date, solved, kind, channel/group, attachment, and
   remaining author filters;
 - member Search projections;
@@ -130,6 +140,7 @@ Suggested commands:
 
 ```bash
 cargo check -p rustok-profiles --all-targets
+cargo check -p rustok-profiles-cli --all-targets
 cargo test -p rustok-profiles error -- --nocapture
 cargo test -p rustok-forum search_projection_author -- --nocapture
 cargo test -p rustok-search forum_inbox -- --nocapture

--- a/crates/rustok-profiles/cli/src/lib.rs
+++ b/crates/rustok-profiles/cli/src/lib.rs
@@ -12,10 +12,10 @@ use rustok_cli_core::{
 };
 use rustok_core::events::EventTransport;
 use rustok_customer::CustomerService;
-use rustok_events::DomainEvent;
 use rustok_outbox::{OutboxTransport, TransactionalEventBus};
 use rustok_profiles::{
     ProfileBackfillTimer, ProfileError, ProfileService, ProfileVisibility, ProfilesReader,
+    backfill_profile_with_event,
 };
 use rustok_runtime::{RuntimeComposition, db_clone};
 use rustok_tenant::{TenantReadPort, TenantReadRequest, TenantReadSelector, TenantService};
@@ -25,7 +25,6 @@ const BACKFILL_HOST_ERROR: &str = "profiles.backfill_host_unavailable";
 const BACKFILL_TENANT_READ_ERROR: &str = "profiles.backfill_tenant_read_failed";
 const BACKFILL_USER_READ_ERROR: &str = "profiles.backfill_user_read_failed";
 const BACKFILL_ENRICHMENT_READ_ERROR: &str = "profiles.backfill_enrichment_read_failed";
-const BACKFILL_EVENT_PUBLISH_ERROR: &str = "profiles.backfill_event_publish_failed";
 
 pub struct ProfilesCommandProvider {
     runtime: RuntimeComposition,
@@ -62,7 +61,7 @@ impl ProfilesCommandProvider {
         let limit = optional_u64(options, "limit")?.unwrap_or(500);
         let visibility = visibility(options)?;
         let dry_run = request.dry_run || flag(options, "dry_run");
-        let emit_events = flag(options, "emit_events");
+        let emit_events = !dry_run;
         let telemetry = ProfileBackfillTimer::start(tenant_id, dry_run, emit_events);
         let host = self.runtime.require_host().map_err(|error| {
             backfill_failed(
@@ -117,12 +116,10 @@ impl ProfilesCommandProvider {
             .into_iter()
             .map(|item| (item.user_id, item))
             .collect::<HashMap<_, _>>();
-        let event_bus = (!dry_run && emit_events).then(|| {
-            TransactionalEventBus::new(
-                Arc::new(OutboxTransport::new(db.clone())) as Arc<dyn EventTransport>
-            )
-        });
-        let profiles = ProfileService::new(db);
+        let event_bus = TransactionalEventBus::new(
+            Arc::new(OutboxTransport::new(db.clone())) as Arc<dyn EventTransport>
+        );
+        let profiles = ProfileService::new(db.clone());
         let existing = profiles
             .find_profile_summaries(
                 tenant.id,
@@ -165,44 +162,23 @@ impl ProfilesCommandProvider {
                 items.push(serde_json::json!({"user_id": user.id, "email": user.email, "handle": plan.handle, "display_name": plan.display_name, "preferred_locale": plan.preferred_locale, "action": "planned", "event_published": false}));
                 continue;
             }
-            let result = profiles
-                .backfill_profile(
-                    tenant.id,
-                    user.id,
-                    &user.email,
-                    display_name,
-                    Some(locale),
-                    visibility,
-                    Some(&tenant.default_locale),
-                )
-                .await
-                .map_err(|error| backfill_profile_failed(&telemetry, "profile_create", error))?;
-            let mut event_published = false;
+            let result = backfill_profile_with_event(
+                &db,
+                &event_bus,
+                tenant.id,
+                user.id,
+                &user.email,
+                display_name,
+                Some(locale),
+                visibility,
+                Some(&tenant.default_locale),
+            )
+            .await
+            .map_err(|error| backfill_profile_failed(&telemetry, "profile_create", error))?;
+            let event_published = result.created;
             if result.created {
                 created_profiles += 1;
-                if let Some(bus) = &event_bus {
-                    bus.publish(
-                        tenant.id,
-                        None,
-                        DomainEvent::ProfileUpdated {
-                            user_id: result.profile.user_id,
-                            handle: result.profile.handle.clone(),
-                            locale: result.profile.preferred_locale.clone(),
-                        },
-                    )
-                    .await
-                    .map_err(|error| {
-                        backfill_failed(
-                            &telemetry,
-                            "event_publish",
-                            BACKFILL_EVENT_PUBLISH_ERROR,
-                            true,
-                            error,
-                        )
-                    })?;
-                    published_events += 1;
-                    event_published = true;
-                }
+                published_events += 1;
             } else {
                 skipped_existing += 1;
             }

--- a/crates/rustok-profiles/cli/src/lib.rs
+++ b/crates/rustok-profiles/cli/src/lib.rs
@@ -146,18 +146,18 @@ impl ProfilesCommandProvider {
             let locale = enrichment
                 .and_then(|item| item.preferred_locale.as_deref())
                 .unwrap_or(&tenant.default_locale);
-            let plan = profiles
-                .plan_backfill_profile(
-                    tenant.id,
-                    user.id,
-                    &user.email,
-                    display_name,
-                    Some(locale),
-                    visibility,
-                )
-                .await
-                .map_err(|error| backfill_profile_failed(&telemetry, "profile_plan", error))?;
             if dry_run {
+                let plan = profiles
+                    .plan_backfill_profile(
+                        tenant.id,
+                        user.id,
+                        &user.email,
+                        display_name,
+                        Some(locale),
+                        visibility,
+                    )
+                    .await
+                    .map_err(|error| backfill_profile_failed(&telemetry, "profile_plan", error))?;
                 planned_creates += 1;
                 items.push(serde_json::json!({"user_id": user.id, "email": user.email, "handle": plan.handle, "display_name": plan.display_name, "preferred_locale": plan.preferred_locale, "action": "planned", "event_published": false}));
                 continue;

--- a/crates/rustok-profiles/src/lib.rs
+++ b/crates/rustok-profiles/src/lib.rs
@@ -43,6 +43,7 @@ pub use privacy::{
 };
 pub use reader::ProfilesReader;
 pub use services::{ProfileBackfillResult, ProfileService};
+pub use upsert_write::backfill_profile_with_event;
 
 pub struct ProfilesModule;
 

--- a/crates/rustok-profiles/src/profile_updated_event.rs
+++ b/crates/rustok-profiles/src/profile_updated_event.rs
@@ -14,6 +14,23 @@ pub(crate) async fn publish_profile_updated_in_tx(
     actor_id: Uuid,
     profile: &entities::profile::Model,
 ) -> ProfileResult<()> {
+    publish_profile_updated_with_actor_in_tx(
+        event_bus,
+        txn,
+        tenant_id,
+        Some(actor_id),
+        profile,
+    )
+    .await
+}
+
+pub(crate) async fn publish_profile_updated_with_actor_in_tx(
+    event_bus: &TransactionalEventBus,
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    actor_id: Option<Uuid>,
+    profile: &entities::profile::Model,
+) -> ProfileResult<()> {
     let timer = ProfileOperationTimer::start(
         ProfileOperation::PublishUpdatedEvent,
         tenant_id,
@@ -23,7 +40,7 @@ pub(crate) async fn publish_profile_updated_in_tx(
         .publish_in_tx(
             txn,
             tenant_id,
-            Some(actor_id),
+            actor_id,
             DomainEvent::ProfileUpdated {
                 user_id: profile.user_id,
                 handle: profile.handle.clone(),

--- a/crates/rustok-profiles/src/upsert_write.rs
+++ b/crates/rustok-profiles/src/upsert_write.rs
@@ -8,11 +8,25 @@ use sea_orm::{
 use uuid::Uuid;
 
 use crate::{
-    ProfileError, ProfileRecord, ProfileResult, ProfileService, ProfileStatus, UpsertProfileInput,
-    entities, profile_updated_event::publish_profile_updated_in_tx,
+    ProfileBackfillResult, ProfileError, ProfileRecord, ProfileResult, ProfileService,
+    ProfileStatus, ProfileVisibility, UpsertProfileInput, entities,
+    profile_updated_event::{
+        publish_profile_updated_in_tx, publish_profile_updated_with_actor_in_tx,
+    },
 };
 
 const PROFILE_SCOPE_VALUE: &str = "profiles";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExistingProfilePolicy {
+    Update,
+    Skip,
+}
+
+struct ProfileWriteOutcome {
+    profile: ProfileRecord,
+    created: bool,
+}
 
 pub(crate) async fn upsert_profile_with_event(
     db: &DatabaseConnection,
@@ -23,6 +37,91 @@ pub(crate) async fn upsert_profile_with_event(
     input: UpsertProfileInput,
     tenant_default_locale: Option<&str>,
 ) -> ProfileResult<ProfileRecord> {
+    let outcome = write_profile_with_event(
+        db,
+        event_bus,
+        tenant_id,
+        Some(actor_id),
+        user_id,
+        input,
+        tenant_default_locale,
+        ExistingProfilePolicy::Update,
+    )
+    .await?;
+    Ok(outcome.profile)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn backfill_profile_with_event(
+    db: &DatabaseConnection,
+    event_bus: &TransactionalEventBus,
+    tenant_id: Uuid,
+    user_id: Uuid,
+    email: &str,
+    display_name: Option<&str>,
+    preferred_locale: Option<&str>,
+    visibility: ProfileVisibility,
+    tenant_default_locale: Option<&str>,
+) -> ProfileResult<ProfileBackfillResult> {
+    let service = ProfileService::new(db.clone());
+    match service
+        .get_profile(
+            tenant_id,
+            user_id,
+            preferred_locale,
+            tenant_default_locale,
+        )
+        .await
+    {
+        Ok(profile) => {
+            return Ok(ProfileBackfillResult {
+                profile,
+                created: false,
+            });
+        }
+        Err(ProfileError::ProfileNotFound(_)) => {}
+        Err(error) => return Err(error),
+    }
+
+    let input = service
+        .plan_backfill_profile(
+            tenant_id,
+            user_id,
+            email,
+            display_name,
+            preferred_locale,
+            visibility,
+        )
+        .await?;
+    let outcome = write_profile_with_event(
+        db,
+        event_bus,
+        tenant_id,
+        None,
+        user_id,
+        input,
+        tenant_default_locale,
+        ExistingProfilePolicy::Skip,
+    )
+    .await?;
+
+    Ok(ProfileBackfillResult {
+        profile: outcome.profile,
+        created: outcome.created,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn write_profile_with_event(
+    db: &DatabaseConnection,
+    event_bus: &TransactionalEventBus,
+    tenant_id: Uuid,
+    actor_id: Option<Uuid>,
+    user_id: Uuid,
+    input: UpsertProfileInput,
+    tenant_default_locale: Option<&str>,
+    existing_policy: ExistingProfilePolicy,
+) -> ProfileResult<ProfileWriteOutcome> {
     let UpsertProfileInput {
         handle,
         display_name,
@@ -44,6 +143,21 @@ pub(crate) async fn upsert_profile_with_event(
         })?;
 
     let txn = db.begin().await?;
+    let existing = entities::profile::Entity::find_by_id(user_id)
+        .filter(entities::profile::Column::TenantId.eq(tenant_id))
+        .one(&txn)
+        .await?;
+    if existing_policy == ExistingProfilePolicy::Skip && existing.is_some() {
+        txn.rollback().await?;
+        let profile = ProfileService::new(db.clone())
+            .get_profile(tenant_id, user_id, None, tenant_default_locale)
+            .await?;
+        return Ok(ProfileWriteOutcome {
+            profile,
+            created: false,
+        });
+    }
+
     let handle_owner = entities::profile::Entity::find()
         .filter(entities::profile::Column::TenantId.eq(tenant_id))
         .filter(entities::profile::Column::Handle.eq(handle.clone()))
@@ -55,10 +169,7 @@ pub(crate) async fn upsert_profile_with_event(
         return Err(ProfileError::DuplicateHandle(handle));
     }
 
-    let existing = entities::profile::Entity::find_by_id(user_id)
-        .filter(entities::profile::Column::TenantId.eq(tenant_id))
-        .one(&txn)
-        .await?;
+    let created = existing.is_none();
     let now = Utc::now();
     let profile = match existing {
         Some(profile) => {
@@ -146,9 +257,16 @@ pub(crate) async fn upsert_profile_with_event(
         }
     }
 
-    if let Err(error) =
-        publish_profile_updated_in_tx(event_bus, &txn, tenant_id, actor_id, &profile).await
-    {
+    let publish_result = match actor_id {
+        Some(actor_id) => {
+            publish_profile_updated_in_tx(event_bus, &txn, tenant_id, actor_id, &profile).await
+        }
+        None => {
+            publish_profile_updated_with_actor_in_tx(event_bus, &txn, tenant_id, None, &profile)
+                .await
+        }
+    };
+    if let Err(error) = publish_result {
         tracing::error!(
             tenant_id = %tenant_id,
             user_id = %profile.user_id,
@@ -159,9 +277,10 @@ pub(crate) async fn upsert_profile_with_event(
     }
     txn.commit().await?;
 
-    ProfileService::new(db.clone())
+    let profile = ProfileService::new(db.clone())
         .get_profile(tenant_id, user_id, None, tenant_default_locale)
-        .await
+        .await?;
+    Ok(ProfileWriteOutcome { profile, created })
 }
 
 fn normalize_tag_names(tag_names: &[String]) -> Vec<String> {

--- a/scripts/verify/verify-forum-search-public-author-summary.mjs
+++ b/scripts/verify/verify-forum-search-public-author-summary.mjs
@@ -57,6 +57,7 @@ const profilesMediaWritePath = "crates/rustok-profiles/src/media_write.rs";
 const profilesUpsertWritePath = "crates/rustok-profiles/src/upsert_write.rs";
 const profilesVisibilityWritePath = "crates/rustok-profiles/src/visibility_write.rs";
 const profilesErrorPath = "crates/rustok-profiles/src/error.rs";
+const profilesCliBackfillPath = "crates/rustok-profiles/cli/src/lib.rs";
 const contractPath = "crates/rustok-forum/contracts/forum-search-public-author-summary.json";
 const notePath = "crates/rustok-forum/docs/forum-23a-search-public-author-summary.md";
 
@@ -76,6 +77,7 @@ const profilesMediaWrite = read(profilesMediaWritePath);
 const profilesUpsertWrite = read(profilesUpsertWritePath);
 const profilesVisibilityWrite = read(profilesVisibilityWritePath);
 const profilesError = read(profilesErrorPath);
+const profilesCliBackfill = read(profilesCliBackfillPath);
 const note = read(notePath);
 let contract = null;
 try {
@@ -148,6 +150,7 @@ requireAll(
     "mod profile_updated_event;",
     "mod upsert_write;",
     "mod visibility_write;",
+    "pub use upsert_write::backfill_profile_with_event;",
   ],
   profilesLibPath,
 );
@@ -192,6 +195,8 @@ requireAll(
   profilesUpdatedEvent,
   [
     "publish_profile_updated_in_tx",
+    "publish_profile_updated_with_actor_in_tx",
+    "actor_id: Option<Uuid>",
     "profile: &entities::profile::Model",
     ".publish_in_tx(",
     "DomainEvent::ProfileUpdated",
@@ -202,6 +207,12 @@ requireAll(
   profilesUpdatedEventPath,
 );
 rejectMarker(profilesUpdatedEvent, "profile: &ProfileRecord", profilesUpdatedEventPath);
+requireOrder(
+  profilesUpdatedEvent,
+  "publish_profile_updated_in_tx",
+  "publish_profile_updated_with_actor_in_tx",
+  profilesUpdatedEventPath,
+);
 
 function verifyTransactionalHelper(sourceText, helperPath, markers, writeMarker, logMarker) {
   requireAll(
@@ -283,6 +294,10 @@ verifyTransactionalHelper(
 requireAll(
   profilesUpsertWrite,
   [
+    "pub async fn backfill_profile_with_event(",
+    "ExistingProfilePolicy::Update",
+    "ExistingProfilePolicy::Skip",
+    "existing_policy == ExistingProfilePolicy::Skip && existing.is_some()",
     "ProfileService::normalize_handle(&handle)?",
     "ProfileService::normalize_display_name(&display_name)?",
     "ProfileService::normalize_locale(preferred_locale.as_deref())?",
@@ -297,10 +312,17 @@ requireAll(
     "TaxonomyTermKind::Tag",
     ".insert(&txn)",
     "publish_profile_updated_in_tx",
+    "publish_profile_updated_with_actor_in_tx",
     "txn.rollback().await?",
     "txn.commit().await?",
     "Profile upsert event publication failed; rolling back owner write",
   ],
+  profilesUpsertWritePath,
+);
+requireOrder(
+  profilesUpsertWrite,
+  "existing_policy == ExistingProfilePolicy::Skip && existing.is_some()",
+  "let handle_owner = entities::profile::Entity::find()",
   profilesUpsertWritePath,
 );
 requireOrder(
@@ -323,9 +345,43 @@ requireOrder(
 );
 requireOrder(
   profilesUpsertWrite,
-  "publish_profile_updated_in_tx",
+  "publish_profile_updated_with_actor_in_tx",
   "txn.commit().await?",
   profilesUpsertWritePath,
+);
+
+requireAll(
+  profilesCliBackfill,
+  [
+    "let emit_events = !dry_run;",
+    "TransactionalEventBus::new(",
+    "OutboxTransport::new(db.clone())",
+    "backfill_profile_with_event(",
+    "let event_published = result.created;",
+    "published_events += 1;",
+    '"event_published": false',
+    '"emit_events": emit_events',
+  ],
+  profilesCliBackfillPath,
+);
+rejectAll(
+  profilesCliBackfill,
+  [
+    'flag(options, "emit_events")',
+    "DomainEvent::ProfileUpdated",
+    "use rustok_events::DomainEvent;",
+    "BACKFILL_EVENT_PUBLISH_ERROR",
+    "if let Some(bus)",
+    "bus.publish(",
+    ".backfill_profile(",
+  ],
+  profilesCliBackfillPath,
+);
+requireOrder(
+  profilesCliBackfill,
+  "if dry_run",
+  "backfill_profile_with_event(",
+  profilesCliBackfillPath,
 );
 
 requireAll(
@@ -364,15 +420,16 @@ rejectMarker(ingestion, "DomainEvent::UserDeleted", ingestionPath);
 requireAll(
   note,
   [
-    "FORUM-23A6",
+    "FORUM-23A7",
     "ProfilePresentationService",
     "forum_author:<user_id>",
     "raw `payload.author_id`",
     "owner-issued monotonic",
     "upsert_my_profile",
-    "taxonomy-backed profile tags",
-    "post-commit event publisher",
-    "CLI/backfill",
+    "CLI backfill",
+    "system actor",
+    "--emit-events",
+    "direct non-event",
     "does not treat `UserDeleted`",
     "Not run by the implementation agent",
   ],
@@ -381,7 +438,7 @@ requireAll(
 
 if (contract) {
   if (contract.task !== "FORUM-23A") failures.push(`${contractPath}: unexpected task`);
-  if (contract.latest_slice !== "FORUM-23A6") {
+  if (contract.latest_slice !== "FORUM-23A7") {
     failures.push(`${contractPath}: unexpected latest slice`);
   }
   if (contract.status !== "source_complete_execution_pending") {
@@ -389,6 +446,9 @@ if (contract) {
   }
   if (contract.profiles_upsert_event_owner !== profilesUpsertWritePath) {
     failures.push(`${contractPath}: unexpected upsert event owner`);
+  }
+  if (contract.profiles_cli_backfill_owner !== profilesCliBackfillPath) {
+    failures.push(`${contractPath}: unexpected CLI backfill owner`);
   }
 
   for (const key of [
@@ -415,6 +475,7 @@ if (contract) {
     "profile_updated_is_emitted_after_owner_write",
     "transactional_profile_event_publisher_is_shared",
     "transactional_profile_event_publisher_accepts_owner_model",
+    "transactional_profile_event_publisher_accepts_system_actor",
     "profile_visibility_write_and_event_are_atomic",
     "visibility_event_failure_rolls_back_owner_write",
     "profile_handle_write_and_event_are_atomic",
@@ -430,6 +491,11 @@ if (contract) {
     "upsert_event_failure_rolls_back_owner_write",
     "upsert_couples_profile_translation_tags_and_event",
     "upsert_media_validation_precedes_owner_transaction",
+    "profiles_cli_backfill_creation_and_event_are_atomic",
+    "profiles_cli_backfill_event_failure_rolls_back_owner_write",
+    "profiles_cli_backfill_requires_event_for_non_dry_run",
+    "profiles_cli_backfill_dry_run_emits_no_event",
+    "profiles_cli_backfill_skips_concurrent_existing_profile",
     "remaining_profile_summary_write_and_event_pairs_are_atomic",
     "author_scope_is_tenant_and_user_scoped",
     "author_scope_is_not_suppressed_by_forum_wall_clock_watermark",
@@ -461,8 +527,8 @@ if (contract) {
 
   for (const nonClaim of [
     "account deletion redaction is complete",
-    "CLI backfill profile creation publishes ProfileUpdated",
     "all Profiles owner writes trigger durable Forum Search invalidation",
+    "direct non-event ProfileService mutation APIs are production-inaccessible",
   ]) {
     if (!contract.non_claims?.includes(nonClaim)) {
       failures.push(`${contractPath}: missing non-claim ${nonClaim}`);
@@ -470,10 +536,10 @@ if (contract) {
   }
   if (
     !contract.remaining_scope?.includes(
-      "define durable Search invalidation for CLI backfill profile creation or prove rebuild coverage",
+      "consolidate or restrict direct non-event ProfileService mutation APIs",
     )
   ) {
-    failures.push(`${contractPath}: missing backfill invalidation debt`);
+    failures.push(`${contractPath}: missing direct service mutation debt`);
   }
   if (contract.downstream_task !== "FORUM-23B") {
     failures.push(`${contractPath}: unexpected downstream task`);


### PR DESCRIPTION
## Summary

Implements `FORUM-23A7`, the next bounded public-author Search hardening slice.

- make every non-dry-run Profiles CLI backfill creation require a durable `ProfileUpdated` event;
- reuse the Profiles-owned compound upsert transaction for create-if-missing backfill writes;
- recheck profile absence inside the transaction so concurrent user creation is skipped rather than overwritten;
- write profile, localized content, taxonomy-backed tags, and the system-actor outbox envelope before commit;
- roll back the new profile when durable event publication fails;
- remove the CLI-owned post-commit `DomainEvent::ProfileUpdated` publisher and the unsafe `--emit-events` opt-out semantics;
- preserve dry-run planning with no owner write or event;
- keep direct non-event `ProfileService` mutation APIs as an explicit remaining non-claim;
- update the Forum public-author contract, owner note, and static verifier.

## Compatibility

No migration, public GraphQL schema, Search query API, dependency, or `Cargo.lock` change. The existing `--emit-events` option remains accepted by the normalized options adapter, but non-dry-run writes now always emit atomically.

## Verification

Not run by the implementation agent, per maintainer instruction. Suggested commands:

```bash
cargo check -p rustok-profiles --all-targets
cargo check -p rustok-profiles-cli --all-targets
cargo test -p rustok-profiles error -- --nocapture
cargo test -p rustok-forum search_projection_author -- --nocapture
cargo test -p rustok-search forum_inbox -- --nocapture
cargo test -p rustok-search ingestion -- --nocapture
node scripts/verify/verify-forum-search-public-author-summary.mjs
node scripts/verify/verify-forum-search-projection.mjs
cargo xtask module validate profiles
cargo xtask module validate forum
```

## Remaining

- consolidate or restrict direct non-event `ProfileService` mutation APIs;
- define owner-ordered profile/account deletion invalidation;
- replace remaining Forum wall-clock projection ordering with owner-issued revisions;
- add the remaining filters and member projections.