### PR TITLE
chore(forum): gate direct profile mutation call sites

### DIFF
--- a/crates/rustok-forum/contracts/forum-search-profile-service-mutation-boundary.json
+++ b/crates/rustok-forum/contracts/forum-search-profile-service-mutation-boundary.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-23A8",
+  "status": "source_complete_execution_pending",
+  "scope": "Prevent repository production code from bypassing durable Forum Search invalidation through direct non-event ProfileService mutation methods",
+  "owner_definition_path": "crates/rustok-profiles/src/services.rs",
+  "graphql_runtime_path": "crates/rustok-profiles/src/graphql/mutation.rs",
+  "cli_backfill_runtime_path": "crates/rustok-profiles/cli/src/lib.rs",
+  "source_gate_verifier": "scripts/verify/verify-forum-search-profile-service-mutation-boundary.mjs",
+  "owner_note": "crates/rustok-forum/docs/forum-23a8-profile-service-mutation-boundary.md",
+  "direct_non_event_methods": [
+    "upsert_profile",
+    "update_profile_handle",
+    "update_profile_content",
+    "update_profile_locale",
+    "update_profile_visibility",
+    "update_profile_media",
+    "backfill_profile"
+  ],
+  "transactional_runtime_helpers": [
+    "upsert_profile_with_event",
+    "update_profile_handle_with_event",
+    "update_profile_content_with_event",
+    "update_profile_locale_with_event",
+    "update_profile_visibility_with_event",
+    "update_profile_media_with_event",
+    "backfill_profile_with_event"
+  ],
+  "source_boundary": {
+    "repository_production_call_sites_are_forbidden": true,
+    "owner_definition_file_is_the_only_production_exemption": true,
+    "graphql_self_service_uses_transactional_helpers": true,
+    "cli_backfill_uses_transactional_helper": true,
+    "tests_may_use_direct_service_methods": true,
+    "test_fixture_example_and_benchmark_paths_are_excluded": true,
+    "ufcs_profile_service_calls_are_scanned": true,
+    "method_call_syntax_is_scanned": true
+  },
+  "call_site_review": {
+    "reviewed_ref": "31df77f3cd7b6294af04af81bf73eadb1a0c9e72",
+    "production_direct_call_count": 0,
+    "definition_file_count": 1,
+    "known_non_definition_call_sites_are_tests_or_verifiers": true
+  },
+  "compatibility": {
+    "public_rust_method_signatures_changed": false,
+    "forum_graphql_changed": false,
+    "forum_rest_changed": false,
+    "search_query_api_changed": false,
+    "search_document_schema_changed": false,
+    "database_migration_added": false,
+    "cargo_lock_changed": false
+  },
+  "remaining_scope": [
+    "replace the source-level gate with compile-time restricted or intrinsically event-aware ProfileService mutation APIs",
+    "define an owner-ordered profile or account deletion projection invalidation contract",
+    "replace remaining wall-clock Forum projection ordering with owner-issued monotonic revisions",
+    "add bounded category-subtree tag locale date solved kind channel group and attachment filters",
+    "add member index projections",
+    "capture maintainer-executed PostgreSQL rebuild redaction and query evidence"
+  ],
+  "verification": {
+    "execution_status": "not_run_by_implementation_agent",
+    "commands": [
+      "node scripts/verify/verify-forum-search-profile-service-mutation-boundary.mjs",
+      "node scripts/verify/verify-forum-search-public-author-summary.mjs",
+      "cargo check -p rustok-profiles --all-targets",
+      "cargo check -p rustok-profiles-cli --all-targets",
+      "cargo xtask module validate profiles",
+      "cargo xtask module validate forum"
+    ]
+  },
+  "non_claims": {
+    "direct_methods_are_compile_time_private": true,
+    "external_downstream_repositories_are_scanned": true,
+    "runtime_verification_was_executed": true,
+    "account_deletion_redaction_is_complete": true,
+    "general_cross_producer_owner_revision_ordering_is_complete": true
+  },
+  "downstream_task": "FORUM-23A9"
+}

--- a/crates/rustok-forum/docs/forum-23a8-profile-service-mutation-boundary.md
+++ b/crates/rustok-forum/docs/forum-23a8-profile-service-mutation-boundary.md
@@ -1,0 +1,92 @@
+# FORUM-23A8: ProfileService mutation source boundary
+
+Date: 2026-07-30
+
+Status: `source_complete_execution_pending`
+
+## Purpose
+
+`FORUM-23A1` through `FORUM-23A7` made the active GraphQL self-service and Profiles CLI
+backfill paths couple owner writes to durable `ProfileUpdated` publication. The remaining risk was
+that repository production code could call the older direct mutation methods on `ProfileService`
+and bypass those transactional helpers.
+
+This slice adds a source-level production call-site gate for that risk. It does not change the
+public Rust signatures and does not make the methods compile-time private.
+
+The machine-readable contract is
+`crates/rustok-forum/contracts/forum-search-profile-service-mutation-boundary.json`.
+
+## Audited direct methods
+
+The audit covers:
+
+- `upsert_profile`;
+- `update_profile_handle`;
+- `update_profile_content`;
+- `update_profile_locale`;
+- `update_profile_visibility`;
+- `update_profile_media`;
+- `backfill_profile`.
+
+At main commit `31df77f3cd7b6294af04af81bf73eadb1a0c9e72`, repository search found definitions in
+`crates/rustok-profiles/src/services.rs` and non-definition call sites only in tests or verifier
+text. No production Rust caller was found.
+
+## Enforced boundary
+
+`scripts/verify/verify-forum-search-profile-service-mutation-boundary.mjs` recursively scans
+production `.rs` files under `apps/` and `crates/`. It rejects method-call syntax and
+`ProfileService::method` UFCS syntax for every audited direct method.
+
+The only production exemption is the owner definition file itself. Test, fixture, example, and
+benchmark paths remain available for compatibility with existing service-level tests.
+
+The verifier separately requires the active runtime paths to use the event-coupled helpers:
+
+- GraphQL self-service uses `upsert_profile_with_event` and the five focused update helpers;
+- CLI backfill uses `backfill_profile_with_event`.
+
+A future production call to a direct non-event method therefore fails source verification rather
+than silently bypassing Forum Search invalidation.
+
+## Claim boundary
+
+This is deliberately a source-level production call-site gate. It does not claim that:
+
+- the public methods are compile-time private;
+- external downstream repositories are scanned;
+- an external crate cannot call the methods;
+- runtime verification was executed by the implementation agent;
+- account deletion redaction or general producer ordering is complete.
+
+The stronger follow-up is to replace or restrict the direct APIs so event publication is intrinsic
+to the public mutation surface rather than enforced only by repository source policy.
+
+## Compatibility
+
+No public Rust method signature, GraphQL/REST contract, Search query or document schema, database
+migration, dependency, or `Cargo.lock` change is introduced.
+
+## Remaining FORUM-23 scope
+
+- replace this source gate with compile-time restricted or intrinsically event-aware mutation APIs;
+- define owner-ordered profile or account deletion invalidation;
+- replace remaining Forum wall-clock ordering with owner-issued monotonic revisions;
+- add the remaining bounded filters and member projections;
+- capture maintainer-executed PostgreSQL rebuild, redaction, and query evidence.
+
+## Maintainer verification
+
+Not run by the implementation agent, per maintainer instruction.
+
+Suggested commands:
+
+```bash
+node scripts/verify/verify-forum-search-profile-service-mutation-boundary.mjs
+node scripts/verify/verify-forum-search-public-author-summary.mjs
+cargo check -p rustok-profiles --all-targets
+cargo check -p rustok-profiles-cli --all-targets
+cargo xtask module validate profiles
+cargo xtask module validate forum
+```

--- a/scripts/verify/verify-forum-search-profile-service-mutation-boundary.mjs
+++ b/scripts/verify/verify-forum-search-profile-service-mutation-boundary.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+const root = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(".");
+const failures = [];
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-search-profile-service-mutation-boundary.json";
+const notePath =
+  "crates/rustok-forum/docs/forum-23a8-profile-service-mutation-boundary.md";
+const servicesPath = "crates/rustok-profiles/src/services.rs";
+const graphqlMutationPath = "crates/rustok-profiles/src/graphql/mutation.rs";
+const cliBackfillPath = "crates/rustok-profiles/cli/src/lib.rs";
+
+const directMethods = [
+  "upsert_profile",
+  "update_profile_handle",
+  "update_profile_content",
+  "update_profile_locale",
+  "update_profile_visibility",
+  "update_profile_media",
+  "backfill_profile",
+];
+const safeRuntimeMarkers = [
+  "upsert_profile_with_event(",
+  "update_profile_handle_with_event(",
+  "update_profile_content_with_event(",
+  "update_profile_locale_with_event(",
+  "update_profile_visibility_with_event(",
+  "update_profile_media_with_event(",
+  "backfill_profile_with_event(",
+];
+const skippedDirectoryNames = new Set([
+  ".git",
+  "target",
+  "node_modules",
+  "vendor",
+  "output",
+  "tests",
+  "test",
+  "fixtures",
+  "examples",
+  "benches",
+]);
+
+function read(relativePath) {
+  const target = path.join(root, relativePath);
+  if (!existsSync(target)) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return "";
+  }
+  return readFileSync(target, "utf8");
+}
+
+function requireMarker(source, marker, label) {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+}
+
+function rejectMarker(source, marker, label) {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+}
+
+function isTestLikeFile(relativePath) {
+  const normalized = relativePath.split(path.sep).join("/");
+  const segments = normalized.split("/");
+  if (segments.some((segment) => skippedDirectoryNames.has(segment))) return true;
+  const basename = path.posix.basename(normalized);
+  return /(?:^|_)(?:test|tests)\.rs$/.test(basename);
+}
+
+function collectRustFiles(relativeRoot, output = []) {
+  const absoluteRoot = path.join(root, relativeRoot);
+  if (!existsSync(absoluteRoot)) return output;
+  for (const entry of readdirSync(absoluteRoot)) {
+    if (skippedDirectoryNames.has(entry)) continue;
+    const relativePath = path.join(relativeRoot, entry);
+    const absolutePath = path.join(root, relativePath);
+    const stat = statSync(absolutePath);
+    if (stat.isDirectory()) {
+      collectRustFiles(relativePath, output);
+    } else if (entry.endsWith(".rs") && !isTestLikeFile(relativePath)) {
+      output.push(relativePath.split(path.sep).join("/"));
+    }
+  }
+  return output;
+}
+
+function lineForOffset(source, offset) {
+  return source.slice(0, offset).split("\n").length;
+}
+
+function findDirectCalls(source, method) {
+  const patterns = [
+    new RegExp(`\\.${method}\\s*\\(`, "g"),
+    new RegExp(`\\bProfileService\\s*::\\s*${method}\\s*\\(`, "g"),
+  ];
+  const matches = [];
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) {
+      matches.push({ offset: match.index ?? 0, text: match[0] });
+    }
+  }
+  return matches;
+}
+
+const services = read(servicesPath);
+const graphqlMutation = read(graphqlMutationPath);
+const cliBackfill = read(cliBackfillPath);
+const note = read(notePath);
+let contract = null;
+try {
+  contract = JSON.parse(read(contractPath));
+} catch (error) {
+  failures.push(`${contractPath}: invalid JSON: ${error.message}`);
+}
+
+for (const method of directMethods) {
+  requireMarker(services, `pub async fn ${method}(`, servicesPath);
+}
+for (const marker of safeRuntimeMarkers.slice(0, 6)) {
+  requireMarker(graphqlMutation, marker, graphqlMutationPath);
+}
+requireMarker(cliBackfill, safeRuntimeMarkers[6], cliBackfillPath);
+for (const method of directMethods) {
+  rejectMarker(graphqlMutation, `.${method}(`, graphqlMutationPath);
+  rejectMarker(cliBackfill, `.${method}(`, cliBackfillPath);
+}
+
+const productionRustFiles = [
+  ...collectRustFiles("apps"),
+  ...collectRustFiles("crates"),
+];
+for (const relativePath of productionRustFiles) {
+  if (relativePath === servicesPath) continue;
+  const source = readFileSync(path.join(root, relativePath), "utf8");
+  for (const method of directMethods) {
+    for (const match of findDirectCalls(source, method)) {
+      failures.push(
+        `${relativePath}:${lineForOffset(source, match.offset)}: direct non-event ProfileService call ${match.text.trim()}`,
+      );
+    }
+  }
+}
+
+for (const marker of [
+  "FORUM-23A8",
+  "source-level production call-site gate",
+  "does not make the methods compile-time private",
+  "GraphQL self-service",
+  "CLI backfill",
+  "Not run by the implementation agent",
+]) {
+  requireMarker(note, marker, notePath);
+}
+
+if (contract) {
+  if (contract.task !== "FORUM-23A8") failures.push(`${contractPath}: unexpected task`);
+  if (contract.status !== "source_complete_execution_pending") {
+    failures.push(`${contractPath}: unexpected status`);
+  }
+  if (contract.owner_definition_path !== servicesPath) {
+    failures.push(`${contractPath}: unexpected owner definition path`);
+  }
+  if (contract.source_gate_verifier !== path.relative(root, import.meta.filename ?? "")) {
+    // import.meta.filename is not available on every supported Node release, so the
+    // canonical path is checked explicitly below instead of relying on this branch.
+  }
+  if (
+    contract.source_gate_verifier !==
+    "scripts/verify/verify-forum-search-profile-service-mutation-boundary.mjs"
+  ) {
+    failures.push(`${contractPath}: unexpected source gate verifier`);
+  }
+  if (JSON.stringify(contract.direct_non_event_methods) !== JSON.stringify(directMethods)) {
+    failures.push(`${contractPath}: direct method inventory drift`);
+  }
+  for (const key of [
+    "repository_production_call_sites_are_forbidden",
+    "graphql_self_service_uses_transactional_helpers",
+    "cli_backfill_uses_transactional_helper",
+    "tests_may_use_direct_service_methods",
+  ]) {
+    if (contract.source_boundary?.[key] !== true) {
+      failures.push(`${contractPath}: source boundary ${key} drift`);
+    }
+  }
+  for (const key of [
+    "direct_methods_are_compile_time_private",
+    "external_downstream_repositories_are_scanned",
+    "runtime_verification_was_executed",
+  ]) {
+    if (contract.non_claims?.[key] !== true) {
+      failures.push(`${contractPath}: non-claim ${key} drift`);
+    }
+  }
+  if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+    failures.push(`${contractPath}: execution status drift`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Profiles direct mutation boundary verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Profiles direct mutation boundary verification passed.");

--- a/scripts/verify/verify-forum-search-profile-service-mutation-boundary.mjs
+++ b/scripts/verify/verify-forum-search-profile-service-mutation-boundary.mjs
@@ -165,10 +165,6 @@ if (contract) {
   if (contract.owner_definition_path !== servicesPath) {
     failures.push(`${contractPath}: unexpected owner definition path`);
   }
-  if (contract.source_gate_verifier !== path.relative(root, import.meta.filename ?? "")) {
-    // import.meta.filename is not available on every supported Node release, so the
-    // canonical path is checked explicitly below instead of relying on this branch.
-  }
   if (
     contract.source_gate_verifier !==
     "scripts/verify/verify-forum-search-profile-service-mutation-boundary.mjs"


### PR DESCRIPTION
## Summary

Implements `FORUM-23A8`, a bounded source-policy hardening slice for Forum Search author invalidation.

- audit the seven direct non-event `ProfileService` mutation methods at main commit `31df77f...`;
- record that repository non-definition call sites are currently limited to tests and verifier text;
- add a recursive source verifier for production Rust under `apps/` and `crates/`;
- reject both method-call and `ProfileService::method` UFCS syntax outside the Profiles owner definition file;
- require GraphQL self-service and CLI backfill to retain their transactional event-coupled helpers;
- preserve direct service methods for existing tests without claiming compile-time privacy;
- add a dedicated machine-readable contract and owner note with explicit source-level claim limits.

## Compatibility

No runtime implementation, public Rust signature, GraphQL/REST contract, Search schema, migration, dependency, or `Cargo.lock` change.

## Verification

Not run by the implementation agent, per maintainer instruction. Suggested commands:

```bash
node scripts/verify/verify-forum-search-profile-service-mutation-boundary.mjs
node scripts/verify/verify-forum-search-public-author-summary.mjs
cargo check -p rustok-profiles --all-targets
cargo check -p rustok-profiles-cli --all-targets
cargo xtask module validate profiles
cargo xtask module validate forum
```

## Remaining

- replace the source gate with compile-time restricted or intrinsically event-aware public mutation APIs;
- define owner-ordered profile/account deletion invalidation;
- replace remaining Forum wall-clock ordering with owner-issued revisions;
- add the remaining filters and member projections.