### PR TITLE
fix(commerce): sanitize aggregate storefront failures

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/storefront-aggregate-error-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/storefront-aggregate-error-safety-source-review.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": 1,
+  "status": "commerce_storefront_aggregate_error_safety_source_reviewed_unvalidated",
+  "reviewed_at_utc": "2026-07-30T16:42:00Z",
+  "review_base": "31df77f3cd7b6294af04af81bf73eadb1a0c9e72",
+  "scope": "Commerce storefront aggregate fetch public transport envelope",
+  "reviewed_sources": [
+    "crates/rustok-commerce/docs/implementation-plan.md",
+    "crates/rustok-commerce/storefront/src/core/requests.rs",
+    "crates/rustok-commerce/storefront/src/transport/mod.rs",
+    "crates/rustok-commerce/storefront/src/transport/graphql_adapter.rs",
+    "crates/rustok-commerce/storefront/src/transport/native_server_adapter.rs",
+    "crates/rustok-commerce/storefront/src/transport/shared_adapter.rs",
+    "crates/rustok-ui-transport/src/lib.rs",
+    "crates/rustok-commerce/storefront/Cargo.toml",
+    "scripts/verify/verify-commerce-storefront-transport-error-safety.mjs"
+  ],
+  "findings": [
+    {
+      "id": "aggregate-public-display-leak",
+      "severity": "confirmed",
+      "finding": "fetch_storefront_commerce converted the final UiTransportError through ApiError::from, exposing the full transport Display envelope with path and nested error text."
+    },
+    {
+      "id": "downstream-owner-safety",
+      "severity": "preserved",
+      "finding": "Cart and Payment aggregate composition already mapped owner failures to static messages before the final Commerce transport wrapper."
+    },
+    {
+      "id": "validation-compatibility",
+      "severity": "preserved",
+      "finding": "Native Invalid cart selection and GraphQL cart_id UUID validation are recognized at the final aggregate boundary and unified as ApiError::Validation with a static public message."
+    },
+    {
+      "id": "minimal-boundary-fix",
+      "severity": "selected",
+      "finding": "A Commerce-owned aggregate context after execute_selected_transport is the smallest fix; private adapters, shared composition, DTOs, transport selection, and owner command wrappers do not need changes."
+    },
+    {
+      "id": "safe-request-shape",
+      "severity": "confirmed",
+      "finding": "Diagnostics retain only correlation, optional-field presence and lengths, path, fallback, stable code, and private UiTransportError diagnostics; raw tenant slug, cart id, and locale are not structured fields."
+    }
+  ],
+  "changed_files_expected": [
+    "crates/rustok-commerce/contracts/evidence/storefront-aggregate-error-safety-source-review.json",
+    "crates/rustok-commerce/contracts/evidence/storefront-aggregate-error-safety-source.json",
+    "crates/rustok-commerce/docs/storefront-aggregate-public-error-safety.md",
+    "crates/rustok-commerce/storefront/src/transport/aggregate_error_safety.rs",
+    "crates/rustok-commerce/storefront/src/transport/mod.rs",
+    "scripts/verify/verify-commerce-storefront-aggregate-error-safety.mjs",
+    "scripts/verify/verify-commerce-storefront-transport-error-safety.mjs"
+  ],
+  "preserved": [
+    "FetchCommerceRequest and StorefrontCommerceData DTOs",
+    "native and GraphQL aggregate adapters",
+    "Cart and Payment owner composition",
+    "native versus GraphQL transport selection",
+    "absence of native-to-GraphQL fallback",
+    "payment collection, shipping selection, and checkout completion command wrappers"
+  ],
+  "remaining_scope": [
+    "Commerce storefront payment collection command public envelope",
+    "Commerce storefront shipping selection command public envelope",
+    "Commerce storefront checkout completion command public envelope",
+    "remaining ecommerce adapters and non-PortError public envelopes"
+  ],
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "native_runtime_proven": false,
+    "graphql_runtime_proven": false,
+    "browser_runtime_proven": false,
+    "mounted_parity_proven": false
+  }
+}

--- a/crates/rustok-commerce/contracts/evidence/storefront-aggregate-error-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/storefront-aggregate-error-safety-source-review.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "status": "commerce_storefront_aggregate_error_safety_source_reviewed_unvalidated",
   "reviewed_at_utc": "2026-07-30T16:42:00Z",
-  "review_base": "31df77f3cd7b6294af04af81bf73eadb1a0c9e72",
+  "review_base": "9d725de7bac2039c86d5b5dffdf5d6be1b4812a8",
   "scope": "Commerce storefront aggregate fetch public transport envelope",
   "reviewed_sources": [
     "crates/rustok-commerce/docs/implementation-plan.md",

--- a/crates/rustok-commerce/contracts/evidence/storefront-aggregate-error-safety-source.json
+++ b/crates/rustok-commerce/contracts/evidence/storefront-aggregate-error-safety-source.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": 1,
+  "status": "commerce_storefront_aggregate_error_safety_source_unvalidated",
+  "generated_at_utc": "2026-07-30T16:42:00Z",
+  "scope": "Commerce-owned fetch_storefront_commerce public transport envelope",
+  "operation": "fetch_storefront_commerce",
+  "boundary": "commerce_storefront_aggregate_public_transport",
+  "public_messages": {
+    "invalid_cart_selection": "Invalid cart selection",
+    "aggregate_unavailable": "Storefront commerce data is temporarily unavailable"
+  },
+  "source_contract": {
+    "aggregate_fetch_context_before_transport": true,
+    "unique_correlation_id": true,
+    "cart_validation_static_public_envelope": true,
+    "unavailable_static_public_envelope": true,
+    "failed_path_api_error_variant_preserved": true,
+    "ui_transport_display_public": false,
+    "raw_request_values_logged": false,
+    "private_transport_error_diagnostics": true,
+    "owner_command_wrappers_changed": false,
+    "graphql_adapter_changed": false,
+    "native_adapter_changed": false,
+    "shared_aggregate_composition_changed": false,
+    "transport_selection_changed": false,
+    "fallback_added": false
+  },
+  "safe_diagnostics": [
+    "owner",
+    "owner_operation",
+    "correlation_id",
+    "tenant_slug_configured",
+    "tenant_slug_length",
+    "selected_cart_id_present",
+    "selected_cart_id_length",
+    "locale_present",
+    "locale_length",
+    "failed_path",
+    "fallback_attempted",
+    "stable_code",
+    "boundary",
+    "private_ui_transport_error"
+  ],
+  "forbidden_public_or_structured_request_values": [
+    "tenant_slug",
+    "selected_cart_id",
+    "locale",
+    "native_error",
+    "graphql_error",
+    "UiTransportError display"
+  ],
+  "remaining_scope": [
+    "replace generic UiTransportError display mapping for create_storefront_payment_collection",
+    "replace generic UiTransportError display mapping for select_storefront_shipping_option",
+    "replace generic UiTransportError display mapping for complete_storefront_checkout",
+    "finish remaining ecommerce adapters and non-PortError public envelopes"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "focused_verifier_run": false,
+    "aggregate_verifier_run": false,
+    "broad_ecommerce_verifier_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "native_runtime_proven": false,
+    "graphql_runtime_proven": false,
+    "browser_runtime_proven": false,
+    "mounted_parity_proven": false
+  },
+  "execution": []
+}

--- a/crates/rustok-commerce/docs/storefront-aggregate-public-error-safety.md
+++ b/crates/rustok-commerce/docs/storefront-aggregate-public-error-safety.md
@@ -1,0 +1,119 @@
+# Commerce storefront aggregate public error safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens only the Commerce-owned aggregate read:
+
+- `fetch_storefront_commerce`;
+- `crates/rustok-commerce/storefront/src/transport/mod.rs`;
+- `crates/rustok-commerce/storefront/src/transport/aggregate_error_safety.rs`.
+
+It does not change the payment-collection, shipping-selection, or checkout-completion command wrappers. Those wrappers still use the generic `From<UiTransportError>` conversion and remain explicit follow-up work under the broad ecommerce mapper-cleanup item.
+
+## Confirmed gap
+
+The native and GraphQL aggregate adapters already returned bounded `ApiError` values. Cart and Payment owner failures were mapped to static public messages inside the aggregate composition.
+
+The final Commerce facade nevertheless called:
+
+```rust
+.map_err(ApiError::from)
+```
+
+The generic conversion used `UiTransportError::to_string()`. Its public value includes transport-path metadata and the nested path error. The aggregate fetch therefore republished the entire final transport display through `ApiError::ServerFn` or `ApiError::Graphql` even though the underlying owner failures had already been sanitized.
+
+## Implementation
+
+`AggregateFetchErrorContext` is created before either transport closure runs. Each call receives a unique correlation id in the namespace:
+
+```text
+commerce-storefront-aggregate:fetch_storefront_commerce:<uuid>
+```
+
+After `execute_selected_transport`, the final `UiTransportError` is mapped by the Commerce-owned context instead of the generic `ApiError::from` implementation.
+
+### Public policy
+
+| Condition | Public `ApiError` |
+| --- | --- |
+| Native or GraphQL cart-selection validation | `Validation("Invalid cart selection")` |
+| Native aggregate failure | `ServerFn("Storefront commerce data is temporarily unavailable")` |
+| GraphQL aggregate failure | `Graphql("Storefront commerce data is temporarily unavailable")` |
+
+The validation classifier accepts the two existing bounded compatibility envelopes:
+
+- `Invalid cart selection` from the native aggregate server function;
+- `cart_id must be a valid UUID` from the GraphQL/shared aggregate path.
+
+No arbitrary nested transport text is forwarded to the public result.
+
+## Internal diagnostics
+
+The original `UiTransportError` is retained only as an internal structured tracing field. The event also records:
+
+- owner and owner operation;
+- unique correlation id;
+- whether a tenant slug is configured and its character length;
+- whether a selected cart id and locale are present and their character lengths;
+- failed transport path;
+- whether fallback was attempted;
+- stable internal code;
+- boundary name.
+
+The structured request fields do not contain the tenant slug, selected cart id, or locale values. The private error field may retain transport details for operators but is never copied into the public `ApiError`.
+
+## Preserved behavior
+
+This slice does not change:
+
+- `FetchCommerceRequest`;
+- `StorefrontCommerceData` and checkout DTOs;
+- the private GraphQL aggregate adapter;
+- the native aggregate server function;
+- Cart and Payment owner requests or response mapping;
+- native versus GraphQL feature selection;
+- fallback behavior;
+- payment collection creation;
+- shipping option selection;
+- checkout completion;
+- FFA, FBA, browser, runtime, workflow, CI, or production status.
+
+## Static evidence
+
+Focused source evidence:
+
+- `crates/rustok-commerce/contracts/evidence/storefront-aggregate-error-safety-source.json`;
+- `crates/rustok-commerce/contracts/evidence/storefront-aggregate-error-safety-source-review.json`;
+- `scripts/verify/verify-commerce-storefront-aggregate-error-safety.mjs`.
+
+The focused verifier is imported by:
+
+- `scripts/verify/verify-commerce-storefront-transport-error-safety.mjs`.
+
+All execution and runtime validation flags remain `false`. Source review alone does not prove native, GraphQL, browser, mounted, workflow, CI, or production behavior.
+
+## Remaining work
+
+The master correlation-safe mapper cleanup remains open for:
+
+- `create_storefront_payment_collection` final Commerce public envelope;
+- `select_storefront_shipping_option` final Commerce public envelope;
+- `complete_storefront_checkout` final Commerce public envelope;
+- Pricing storefront and other remaining ecommerce adapters;
+- remaining non-`PortError` public envelopes.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-commerce-storefront-aggregate-error-safety.mjs
+node scripts/verify/verify-commerce-storefront-transport-error-safety.mjs
+node scripts/verify/verify-commerce-storefront-transport-handoff.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-commerce-storefront
+cargo check -p rustok-commerce-storefront --features hydrate
+cargo check -p rustok-commerce-storefront --features ssr
+```

--- a/crates/rustok-commerce/storefront/src/transport/aggregate_error_safety.rs
+++ b/crates/rustok-commerce/storefront/src/transport/aggregate_error_safety.rs
@@ -92,7 +92,7 @@ fn is_invalid_cart_selection(error: &UiTransportError) -> bool {
     [error.native_error.as_deref(), error.graphql_error.as_deref()]
         .into_iter()
         .flatten()
-        .any(|message| matches!(message, INVALID_CART_SELECTION | CART_ID_UUID_VALIDATION))
+        .any(|message| message == INVALID_CART_SELECTION || message == CART_ID_UUID_VALIDATION)
 }
 
 fn configured_tenant_slug_length() -> Option<usize> {

--- a/crates/rustok-commerce/storefront/src/transport/aggregate_error_safety.rs
+++ b/crates/rustok-commerce/storefront/src/transport/aggregate_error_safety.rs
@@ -1,0 +1,111 @@
+use rustok_ui_transport::{UiTransportError, UiTransportPath};
+use uuid::Uuid;
+
+use crate::core::FetchCommerceRequest;
+
+use super::shared_adapter::ApiError;
+
+const COMMERCE_STOREFRONT_AGGREGATE_OWNER: &str = "rustok_commerce.storefront";
+const COMMERCE_STOREFRONT_AGGREGATE_OPERATION: &str = "fetch_storefront_commerce";
+const COMMERCE_STOREFRONT_AGGREGATE_BOUNDARY: &str =
+    "commerce_storefront_aggregate_public_transport";
+const INVALID_CART_SELECTION: &str = "Invalid cart selection";
+const CART_ID_UUID_VALIDATION: &str = "cart_id must be a valid UUID";
+const STOREFRONT_COMMERCE_UNAVAILABLE: &str =
+    "Storefront commerce data is temporarily unavailable";
+
+pub(super) struct AggregateFetchErrorContext {
+    correlation_id: String,
+    tenant_slug_length: Option<usize>,
+    selected_cart_id_length: Option<usize>,
+    locale_length: Option<usize>,
+}
+
+impl AggregateFetchErrorContext {
+    pub(super) fn new(request: &FetchCommerceRequest) -> Self {
+        Self {
+            correlation_id: format!(
+                "commerce-storefront-aggregate:{COMMERCE_STOREFRONT_AGGREGATE_OPERATION}:{}",
+                Uuid::new_v4()
+            ),
+            tenant_slug_length: configured_tenant_slug_length(),
+            selected_cart_id_length: request
+                .selected_cart_id
+                .as_deref()
+                .map(|value| value.chars().count()),
+            locale_length: request.locale.as_deref().map(|value| value.chars().count()),
+        }
+    }
+
+    pub(super) fn map_error(&self, error: UiTransportError) -> ApiError {
+        if is_invalid_cart_selection(&error) {
+            tracing::warn!(
+                error = ?error,
+                owner = COMMERCE_STOREFRONT_AGGREGATE_OWNER,
+                owner_operation = COMMERCE_STOREFRONT_AGGREGATE_OPERATION,
+                correlation_id = %self.correlation_id,
+                tenant_slug_configured = self.tenant_slug_length.is_some(),
+                tenant_slug_length = ?self.tenant_slug_length,
+                selected_cart_id_present = self.selected_cart_id_length.is_some(),
+                selected_cart_id_length = ?self.selected_cart_id_length,
+                locale_present = self.locale_length.is_some(),
+                locale_length = ?self.locale_length,
+                failed_path = error.failed_path.as_str(),
+                fallback_attempted = error.fallback_attempted,
+                code = "commerce.storefront_aggregate_cart_selection_invalid",
+                boundary = COMMERCE_STOREFRONT_AGGREGATE_BOUNDARY,
+                "commerce storefront aggregate request validation failed"
+            );
+            return ApiError::Validation(INVALID_CART_SELECTION.to_string());
+        }
+
+        tracing::error!(
+            error = ?error,
+            owner = COMMERCE_STOREFRONT_AGGREGATE_OWNER,
+            owner_operation = COMMERCE_STOREFRONT_AGGREGATE_OPERATION,
+            correlation_id = %self.correlation_id,
+            tenant_slug_configured = self.tenant_slug_length.is_some(),
+            tenant_slug_length = ?self.tenant_slug_length,
+            selected_cart_id_present = self.selected_cart_id_length.is_some(),
+            selected_cart_id_length = ?self.selected_cart_id_length,
+            locale_present = self.locale_length.is_some(),
+            locale_length = ?self.locale_length,
+            failed_path = error.failed_path.as_str(),
+            fallback_attempted = error.fallback_attempted,
+            code = "commerce.storefront_aggregate_unavailable",
+            boundary = COMMERCE_STOREFRONT_AGGREGATE_BOUNDARY,
+            "commerce storefront aggregate transport failed"
+        );
+
+        match error.failed_path {
+            UiTransportPath::NativeServer => {
+                ApiError::ServerFn(STOREFRONT_COMMERCE_UNAVAILABLE.to_string())
+            }
+            UiTransportPath::Graphql => {
+                ApiError::Graphql(STOREFRONT_COMMERCE_UNAVAILABLE.to_string())
+            }
+        }
+    }
+}
+
+fn is_invalid_cart_selection(error: &UiTransportError) -> bool {
+    [error.native_error.as_deref(), error.graphql_error.as_deref()]
+        .into_iter()
+        .flatten()
+        .any(|message| matches!(message, INVALID_CART_SELECTION | CART_ID_UUID_VALIDATION))
+}
+
+fn configured_tenant_slug_length() -> Option<usize> {
+    [
+        "RUSTOK_TENANT_SLUG",
+        "NEXT_PUBLIC_TENANT_SLUG",
+        "NEXT_PUBLIC_DEFAULT_TENANT_SLUG",
+    ]
+    .into_iter()
+    .find_map(|key| {
+        std::env::var(key).ok().and_then(|value| {
+            let value = value.trim();
+            (!value.is_empty()).then_some(value.chars().count())
+        })
+    })
+}

--- a/crates/rustok-commerce/storefront/src/transport/mod.rs
+++ b/crates/rustok-commerce/storefront/src/transport/mod.rs
@@ -1,3 +1,4 @@
+mod aggregate_error_safety;
 mod graphql_adapter;
 mod native_server_adapter;
 mod shared_adapter;
@@ -18,6 +19,7 @@ use shared_adapter::ApiError;
 pub async fn fetch_storefront_commerce(
     request: FetchCommerceRequest,
 ) -> Result<StorefrontCommerceData, ApiError> {
+    let error_context = aggregate_error_safety::AggregateFetchErrorContext::new(&request);
     let native_request = request.clone();
     execute_selected_transport(
         "commerce",
@@ -26,7 +28,7 @@ pub async fn fetch_storefront_commerce(
         move || graphql_adapter::fetch_storefront_commerce(request),
     )
     .await
-    .map_err(ApiError::from)
+    .map_err(|error| error_context.map_error(error))
 }
 
 pub async fn create_storefront_payment_collection(

--- a/scripts/verify/verify-commerce-storefront-aggregate-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-aggregate-error-safety.mjs
@@ -16,6 +16,7 @@ const requireText = (source, value, label) => {
 const forbidText = (source, value, label) => {
   if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
 };
+const countText = (source, value) => source.split(value).length - 1;
 
 const cargoPath = "crates/rustok-commerce/storefront/Cargo.toml";
 const transportPath = "crates/rustok-commerce/storefront/src/transport/mod.rs";
@@ -86,6 +87,22 @@ if (fetchStart < 0 || nextFunction < 0) {
     `${transportPath}: aggregate fetch direct error display mapping`,
   );
 }
+
+requireText(
+  transport,
+  "impl From<UiTransportError> for ApiError",
+  `${transportPath}: generic command-wrapper mapper remains explicit debt`,
+);
+if (countText(transport, ".map_err(ApiError::from)") !== 3) {
+  failures.push(
+    `${transportPath}: exactly three owner command wrappers must remain on the generic mapper`,
+  );
+}
+for (const marker of [
+  "create_storefront_payment_collection",
+  "select_storefront_shipping_option",
+  "complete_storefront_checkout",
+]) requireText(transport, marker, `${transportPath}: preserved owner command wrapper`);
 
 for (const [value, label] of [
   ["pub(super) struct AggregateFetchErrorContext", "private context"],

--- a/scripts/verify/verify-commerce-storefront-aggregate-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-aggregate-error-safety.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+const cargoPath = "crates/rustok-commerce/storefront/Cargo.toml";
+const transportPath = "crates/rustok-commerce/storefront/src/transport/mod.rs";
+const safetyPath =
+  "crates/rustok-commerce/storefront/src/transport/aggregate_error_safety.rs";
+const graphqlAdapterPath =
+  "crates/rustok-commerce/storefront/src/transport/graphql_adapter.rs";
+const nativeAdapterPath =
+  "crates/rustok-commerce/storefront/src/transport/native_server_adapter.rs";
+const sharedAdapterPath =
+  "crates/rustok-commerce/storefront/src/transport/shared_adapter.rs";
+const evidencePath =
+  "crates/rustok-commerce/contracts/evidence/storefront-aggregate-error-safety-source.json";
+
+const cargo = read(cargoPath);
+const transport = read(transportPath);
+const safety = read(safetyPath);
+const graphqlAdapter = read(graphqlAdapterPath);
+const nativeAdapter = read(nativeAdapterPath);
+const sharedAdapter = read(sharedAdapterPath);
+const evidence = JSON.parse(read(evidencePath));
+
+for (const [value, label] of [
+  ["tracing.workspace = true", "tracing dependency"],
+  ["uuid.workspace = true", "UUID dependency"],
+]) requireText(cargo, value, `${cargoPath}: ${label}`);
+
+requireText(
+  transport,
+  "mod aggregate_error_safety;",
+  `${transportPath}: private aggregate safety module wiring`,
+);
+const fetchStart = transport.indexOf("pub async fn fetch_storefront_commerce(");
+const nextFunction = transport.indexOf(
+  "pub async fn create_storefront_payment_collection(",
+  fetchStart,
+);
+if (fetchStart < 0 || nextFunction < 0) {
+  failures.push(`${transportPath}: aggregate fetch function boundaries are missing`);
+} else {
+  const aggregateFetch = transport.slice(fetchStart, nextFunction);
+  for (const [value, label] of [
+    [
+      "aggregate_error_safety::AggregateFetchErrorContext::new(&request)",
+      "pre-call error context",
+    ],
+    [
+      ".map_err(|error| error_context.map_error(error))",
+      "public aggregate error mapper",
+    ],
+    [
+      "native_server_adapter::fetch_storefront_commerce(native_request)",
+      "native aggregate call",
+    ],
+    [
+      "graphql_adapter::fetch_storefront_commerce(request)",
+      "GraphQL aggregate call",
+    ],
+  ]) requireText(aggregateFetch, value, `${transportPath}: ${label}`);
+  forbidText(
+    aggregateFetch,
+    ".map_err(ApiError::from)",
+    `${transportPath}: aggregate fetch raw transport display mapping`,
+  );
+  forbidText(
+    aggregateFetch,
+    "error.to_string()",
+    `${transportPath}: aggregate fetch direct error display mapping`,
+  );
+}
+
+for (const [value, label] of [
+  ["pub(super) struct AggregateFetchErrorContext", "private context"],
+  ["Uuid::new_v4()", "unique correlation id"],
+  [
+    '"commerce-storefront-aggregate:{COMMERCE_STOREFRONT_AGGREGATE_OPERATION}:{}"',
+    "correlation namespace",
+  ],
+  ["pub(super) fn map_error(&self, error: UiTransportError)", "UiTransport mapper"],
+  ["fn is_invalid_cart_selection(error: &UiTransportError)", "validation classifier"],
+  ['"Invalid cart selection"', "validation public envelope"],
+  ['"cart_id must be a valid UUID"', "GraphQL validation compatibility"],
+  [
+    '"Storefront commerce data is temporarily unavailable"',
+    "aggregate unavailable envelope",
+  ],
+  [
+    '"commerce.storefront_aggregate_cart_selection_invalid"',
+    "validation code",
+  ],
+  ['"commerce.storefront_aggregate_unavailable"', "unavailable code"],
+  ["error = ?error", "private original transport diagnostics"],
+  ["owner_operation = COMMERCE_STOREFRONT_AGGREGATE_OPERATION", "owner operation"],
+  ["correlation_id = %self.correlation_id", "correlation diagnostics"],
+  ["tenant_slug_length = ?self.tenant_slug_length", "tenant shape diagnostics"],
+  [
+    "selected_cart_id_length = ?self.selected_cart_id_length",
+    "cart shape diagnostics",
+  ],
+  ["locale_length = ?self.locale_length", "locale shape diagnostics"],
+  ["failed_path = error.failed_path.as_str()", "failed path diagnostics"],
+  ["fallback_attempted = error.fallback_attempted", "fallback diagnostics"],
+  ["ApiError::Validation(INVALID_CART_SELECTION.to_string())", "validation mapping"],
+  ["UiTransportPath::NativeServer", "native variant mapping"],
+  ["UiTransportPath::Graphql", "GraphQL variant mapping"],
+  [
+    "ApiError::ServerFn(STOREFRONT_COMMERCE_UNAVAILABLE.to_string())",
+    "native public mapping",
+  ],
+  [
+    "ApiError::Graphql(STOREFRONT_COMMERCE_UNAVAILABLE.to_string())",
+    "GraphQL public mapping",
+  ],
+]) requireText(safety, value, `${safetyPath}: ${label}`);
+
+for (const value of [
+  "selected_cart_id = %",
+  "selected_cart_id = ?",
+  "locale = %",
+  "locale = ?",
+  "tenant_slug = %",
+  "tenant_slug = ?",
+  "request = ?request",
+  "ApiError::ServerFn(error.to_string())",
+  "ApiError::Graphql(error.to_string())",
+  "ApiError::ServerFn(error.to_string",
+  "ApiError::Graphql(error.to_string",
+]) forbidText(safety, value, `${safetyPath}: raw public or sensitive mapping`);
+
+requireText(
+  graphqlAdapter,
+  "shared_adapter::fetch_storefront_commerce_graphql(request.selected_cart_id, request.locale)",
+  `${graphqlAdapterPath}: unchanged shared GraphQL aggregate delegation`,
+);
+requireText(
+  nativeAdapter,
+  "storefront_commerce_native(request.selected_cart_id, request.locale)",
+  `${nativeAdapterPath}: unchanged native aggregate delegation`,
+);
+requireText(
+  sharedAdapter,
+  "pub async fn fetch_storefront_commerce_graphql(",
+  `${sharedAdapterPath}: unchanged shared aggregate composition`,
+);
+
+if (evidence.schema_version !== 1) {
+  failures.push(`${evidencePath}: schema_version must be 1`);
+}
+if (
+  evidence.status !==
+  "commerce_storefront_aggregate_error_safety_source_unvalidated"
+) {
+  failures.push(`${evidencePath}: status mismatch`);
+}
+for (const [key, expected] of Object.entries({
+  aggregate_fetch_context_before_transport: true,
+  unique_correlation_id: true,
+  cart_validation_static_public_envelope: true,
+  unavailable_static_public_envelope: true,
+  failed_path_api_error_variant_preserved: true,
+  ui_transport_display_public: false,
+  raw_request_values_logged: false,
+  private_transport_error_diagnostics: true,
+  owner_command_wrappers_changed: false,
+  graphql_adapter_changed: false,
+  native_adapter_changed: false,
+  shared_aggregate_composition_changed: false,
+  transport_selection_changed: false,
+  fallback_added: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${evidencePath}: source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "focused_verifier_run",
+  "aggregate_verifier_run",
+  "broad_ecommerce_verifier_run",
+  "workflow_checks_run",
+  "ci_run",
+  "native_runtime_proven",
+  "graphql_runtime_proven",
+  "browser_runtime_proven",
+  "mounted_parity_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${evidencePath}: validation.${key} must remain false`);
+  }
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push(`${evidencePath}: execution must remain empty`);
+}
+
+if (failures.length > 0) {
+  console.error("Commerce storefront aggregate error-safety verification failed:");
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "✔ commerce storefront aggregate fetch uses correlation-safe static public envelopes; owner command wrappers and runtime evidence remain open",
+);

--- a/scripts/verify/verify-commerce-storefront-transport-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-transport-error-safety.mjs
@@ -4,6 +4,8 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import './verify-commerce-storefront-aggregate-error-safety.mjs';
+
 const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
 const rootPath = configuredRoot
   ? path.resolve(configuredRoot)


### PR DESCRIPTION
## Summary
- add a Commerce-owned aggregate public error policy for `fetch_storefront_commerce`
- create a per-call context before transport execution with a unique correlation id
- replace the final aggregate `.map_err(ApiError::from)` with a structural `UiTransportError` mapper
- unify the existing native and GraphQL cart-selection validation envelopes as `ApiError::Validation("Invalid cart selection")`
- map all other aggregate failures to `Storefront commerce data is temporarily unavailable` while preserving the failed-path `ServerFn` versus `Graphql` variant
- retain the original `UiTransportError` only in internal structured diagnostics
- log only safe request-shape facts: tenant/cart/locale presence and lengths, failed path, fallback flag, stable code, owner operation, boundary, and correlation id
- preserve private adapters, Cart and Payment owner composition, DTOs, feature-selected transport path, and absence of fallback
- add a focused source verifier, import it from the existing Commerce storefront transport error-safety verifier, and retain unvalidated source/review evidence plus documentation

## Scope boundary
This PR changes only the Commerce-owned aggregate read. The three command wrappers remain on the generic `From<UiTransportError>` mapper and are explicit follow-up work:
- `create_storefront_payment_collection`
- `select_storefront_shipping_option`
- `complete_storefront_checkout`

## Public policy
- invalid cart selection: `Invalid cart selection`
- native aggregate failure: `Storefront commerce data is temporarily unavailable`
- GraphQL aggregate failure: `Storefront commerce data is temporarily unavailable`

## Preserved behavior
- `FetchCommerceRequest` and aggregate response DTOs unchanged
- native and GraphQL aggregate adapters unchanged
- Cart and Payment owner calls and response mapping unchanged
- transport selection unchanged
- no native-to-GraphQL fallback added
- command wrappers unchanged

## Evidence boundary
Source status is `commerce_storefront_aggregate_error_safety_source_unvalidated`. The broad ecommerce correlation-safe mapper cleanup remains open. No FFA, FBA, browser, native/GraphQL runtime, mounted parity, workflow, CI, or production status is promoted.

## Verification
The ecommerce master plan, Commerce aggregate facade, native/shared/GraphQL adapters, request DTO, `UiTransportError` display/storage contract, existing transport safety guard, final source files, and the seven-file diff were reviewed. The branch is based at `9d725de7bac2039c86d5b5dffdf5d6be1b4812a8`; the current one-commit main drift is Forum-only and does not overlap these files.

Tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run per maintainer instruction.