### PR TITLE
fix(commerce): sanitize payment command failures

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/storefront-payment-command-error-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/storefront-payment-command-error-safety-source-review.json
@@ -1,0 +1,86 @@
+{
+  "schema_version": 1,
+  "status": "commerce_storefront_payment_command_error_safety_source_reviewed_unvalidated",
+  "reviewed_at_utc": "2026-07-30T17:07:00Z",
+  "review_base": "1a39055c4d64bb6c19c81c34a4e0371f1ca262e1",
+  "scope": "Commerce storefront payment collection command public transport envelope",
+  "reviewed_sources": [
+    "crates/rustok-commerce/docs/implementation-plan.md",
+    "crates/rustok-commerce/storefront/src/transport/mod.rs",
+    "crates/rustok-commerce/storefront/src/transport/aggregate_error_safety.rs",
+    "crates/rustok-payment/storefront/src/transport.rs",
+    "crates/rustok-payment/storefront/src/transport/graphql_adapter.rs",
+    "crates/rustok-payment/storefront/src/transport/graphql_error_safety.rs",
+    "crates/rustok-payment/storefront/src/transport/native_server_adapter/server_functions.rs",
+    "crates/rustok-ui-transport/src/lib.rs",
+    "crates/rustok-commerce/storefront/Cargo.toml",
+    "scripts/verify/verify-commerce-storefront-aggregate-error-safety.mjs",
+    "scripts/verify/verify-commerce-storefront-transport-error-safety.mjs"
+  ],
+  "findings": [
+    {
+      "id": "payment-command-public-display-leak",
+      "severity": "confirmed",
+      "finding": "create_storefront_payment_collection converted the payment owner UiTransportError through ApiError::from, publishing the full transport display with path metadata and nested owner message."
+    },
+    {
+      "id": "owner-error-safety",
+      "severity": "preserved",
+      "finding": "Payment native and GraphQL adapters already produce bounded validation and static runtime envelopes before the final Commerce wrapper."
+    },
+    {
+      "id": "validation-compatibility",
+      "severity": "preserved",
+      "finding": "Both payment owner paths use the exact cart_id must be a valid UUID validation envelope, allowing a structural Commerce mapping to Invalid cart selection."
+    },
+    {
+      "id": "minimal-boundary-fix",
+      "severity": "selected",
+      "finding": "A Commerce-owned context around the payment command wrapper is the smallest compatible fix; payment mutation, metadata, DTO, owner adapters, and the two remaining Commerce command wrappers do not need changes."
+    },
+    {
+      "id": "safe-request-shape",
+      "severity": "confirmed",
+      "finding": "Diagnostics retain only correlation, tenant/cart/metadata field lengths, path, fallback, stable code, and the private UiTransportError; no raw cart or metadata value is recorded as a structured field."
+    }
+  ],
+  "changed_files_expected": [
+    "crates/rustok-commerce/contracts/evidence/storefront-payment-command-error-safety-source-review.json",
+    "crates/rustok-commerce/contracts/evidence/storefront-payment-command-error-safety-source.json",
+    "crates/rustok-commerce/docs/storefront-payment-collection-command-error-safety.md",
+    "crates/rustok-commerce/storefront/src/transport/mod.rs",
+    "crates/rustok-commerce/storefront/src/transport/payment_collection_command_error_safety.rs",
+    "scripts/verify/verify-commerce-storefront-aggregate-error-safety.mjs",
+    "scripts/verify/verify-commerce-storefront-payment-command-error-safety.mjs",
+    "scripts/verify/verify-commerce-storefront-transport-error-safety.mjs"
+  ],
+  "preserved": [
+    "PaymentCollectionCreateRequest and response DTOs",
+    "payment-owned command metadata",
+    "payment GraphQL mutation and native server function",
+    "payment owner validation and static runtime messages",
+    "native versus GraphQL feature selection",
+    "absence of native-to-GraphQL fallback",
+    "shipping option selection wrapper",
+    "checkout completion wrapper"
+  ],
+  "remaining_scope": [
+    "Commerce storefront shipping selection command public envelope",
+    "Commerce storefront checkout completion command public envelope",
+    "Pricing storefront and other remaining ecommerce adapters",
+    "remaining non-PortError public envelopes"
+  ],
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "native_runtime_proven": false,
+    "graphql_runtime_proven": false,
+    "browser_runtime_proven": false,
+    "mounted_parity_proven": false
+  }
+}

--- a/crates/rustok-commerce/contracts/evidence/storefront-payment-command-error-safety-source.json
+++ b/crates/rustok-commerce/contracts/evidence/storefront-payment-command-error-safety-source.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": 1,
+  "status": "commerce_storefront_payment_command_error_safety_source_unvalidated",
+  "generated_at_utc": "2026-07-30T17:07:00Z",
+  "scope": "Commerce-owned create_storefront_payment_collection public transport envelope",
+  "operation": "create_storefront_payment_collection",
+  "boundary": "commerce_storefront_payment_collection_public_transport",
+  "public_messages": {
+    "invalid_cart_selection": "Invalid cart selection",
+    "payment_collection_unavailable": "Storefront payment collection is temporarily unavailable"
+  },
+  "source_contract": {
+    "context_before_owner_call": true,
+    "unique_correlation_id": true,
+    "cart_validation_static_public_envelope": true,
+    "unavailable_static_public_envelope": true,
+    "failed_path_api_error_variant_preserved": true,
+    "ui_transport_display_public": false,
+    "raw_request_values_logged": false,
+    "private_transport_error_diagnostics": true,
+    "payment_owner_transport_changed": false,
+    "shipping_wrapper_changed": false,
+    "checkout_wrapper_changed": false,
+    "fallback_added": false
+  },
+  "safe_diagnostics": [
+    "owner",
+    "owner_operation",
+    "correlation_id",
+    "tenant_slug_configured",
+    "tenant_slug_length",
+    "cart_id_length",
+    "source_module_length",
+    "source_surface_length",
+    "command_length",
+    "owner_module_length",
+    "failed_path",
+    "fallback_attempted",
+    "stable_code",
+    "boundary",
+    "private_ui_transport_error"
+  ],
+  "forbidden_public_or_structured_request_values": [
+    "tenant_slug",
+    "cart_id",
+    "metadata.source_module",
+    "metadata.source_surface",
+    "metadata.command",
+    "metadata.owner_module",
+    "native_error",
+    "graphql_error",
+    "UiTransportError display"
+  ],
+  "preserved": [
+    "PaymentCollectionCreateRequest DTO",
+    "payment-owned command metadata",
+    "payment native and GraphQL adapters",
+    "payment GraphQL mutation and variables",
+    "payment owner validation and runtime mapping",
+    "native versus GraphQL feature selection",
+    "absence of fallback",
+    "shipping option selection wrapper",
+    "checkout completion wrapper"
+  ],
+  "remaining_scope": [
+    "replace generic UiTransportError display mapping for select_storefront_shipping_option",
+    "replace generic UiTransportError display mapping for complete_storefront_checkout",
+    "finish remaining ecommerce adapters and non-PortError public envelopes"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "focused_verifier_run": false,
+    "aggregate_verifier_run": false,
+    "broad_ecommerce_verifier_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "native_runtime_proven": false,
+    "graphql_runtime_proven": false,
+    "browser_runtime_proven": false,
+    "mounted_parity_proven": false
+  },
+  "execution": []
+}

--- a/crates/rustok-commerce/docs/storefront-payment-collection-command-error-safety.md
+++ b/crates/rustok-commerce/docs/storefront-payment-collection-command-error-safety.md
@@ -1,0 +1,118 @@
+# Commerce storefront payment collection command error safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens only the final Commerce public envelope for:
+
+- `create_storefront_payment_collection`;
+- `crates/rustok-commerce/storefront/src/transport/mod.rs`;
+- `crates/rustok-commerce/storefront/src/transport/payment_collection_command_error_safety.rs`.
+
+The shipping-selection and checkout-completion wrappers remain open and continue to use the generic `From<UiTransportError>` conversion.
+
+## Confirmed gap
+
+The Payment owner already bounds its failures:
+
+- both native and GraphQL paths validate cart identity as `cart_id must be a valid UUID`;
+- native runtime failures use static payment storefront messages;
+- GraphQL network, HTTP, authentication, rejection, and unknown failures are mapped to static owner messages with private diagnostics.
+
+The Commerce facade nevertheless called:
+
+```rust
+create_payment_collection(request)
+    .await
+    .map_err(ApiError::from)
+```
+
+The generic conversion used `UiTransportError::to_string()`, which includes transport-path metadata and the nested owner message. The final Commerce response therefore republished the full transport display instead of an operation-owned envelope.
+
+## Implementation
+
+`PaymentCollectionCommandErrorContext` is created before the Payment owner call. Every command receives a unique correlation id in the namespace:
+
+```text
+commerce-storefront-payment:create_storefront_payment_collection:<uuid>
+```
+
+The final `UiTransportError` is mapped structurally.
+
+### Public policy
+
+| Condition | Public `ApiError` |
+| --- | --- |
+| Native or GraphQL cart UUID validation | `Validation("Invalid cart selection")` |
+| Native command failure | `ServerFn("Storefront payment collection is temporarily unavailable")` |
+| GraphQL command failure | `Graphql("Storefront payment collection is temporarily unavailable")` |
+
+The failed-path variant is preserved. No `UiTransportError` display value is copied into the public response.
+
+## Internal diagnostics
+
+The original `UiTransportError` remains available only as an internal tracing field. The event also records:
+
+- Commerce owner and operation;
+- unique correlation id;
+- whether a tenant slug is configured and its character length;
+- cart id character length;
+- character lengths for the four payment command metadata fields;
+- failed transport path;
+- fallback flag;
+- stable internal code;
+- boundary name.
+
+The structured fields do not include the tenant slug, cart id, source module, source surface, command, or owner module values.
+
+## Preserved behavior
+
+This slice does not change:
+
+- `PaymentCollectionCreateRequest`;
+- payment-owned command metadata;
+- the Payment GraphQL mutation, variables, or response mapping;
+- the Payment native server function;
+- owner validation, authentication, or runtime policy;
+- native versus GraphQL feature selection;
+- fallback behavior;
+- shipping option selection;
+- checkout completion;
+- FFA, FBA, browser, runtime, workflow, CI, or production status.
+
+## Static evidence
+
+Focused source evidence:
+
+- `crates/rustok-commerce/contracts/evidence/storefront-payment-command-error-safety-source.json`;
+- `crates/rustok-commerce/contracts/evidence/storefront-payment-command-error-safety-source-review.json`;
+- `scripts/verify/verify-commerce-storefront-payment-command-error-safety.mjs`.
+
+The focused verifier is imported by `scripts/verify/verify-commerce-storefront-transport-error-safety.mjs`. The earlier aggregate guard now requires exactly two remaining generic command mappings.
+
+All execution and runtime validation flags remain `false`. Source review alone does not prove native, GraphQL, browser, mounted, workflow, CI, or production behavior.
+
+## Remaining work
+
+The broad correlation-safe mapper cleanup remains open for:
+
+- `select_storefront_shipping_option` final Commerce public envelope;
+- `complete_storefront_checkout` final Commerce public envelope;
+- Pricing storefront and other ecommerce adapters;
+- remaining non-`PortError` public envelopes.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-commerce-storefront-payment-command-error-safety.mjs
+node scripts/verify/verify-commerce-storefront-aggregate-error-safety.mjs
+node scripts/verify/verify-commerce-storefront-transport-error-safety.mjs
+node scripts/verify/verify-commerce-storefront-transport-handoff.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-commerce-storefront
+cargo check -p rustok-commerce-storefront --features hydrate
+cargo check -p rustok-commerce-storefront --features ssr
+```

--- a/crates/rustok-commerce/storefront/src/transport/mod.rs
+++ b/crates/rustok-commerce/storefront/src/transport/mod.rs
@@ -1,6 +1,7 @@
 mod aggregate_error_safety;
 mod graphql_adapter;
 mod native_server_adapter;
+mod payment_collection_command_error_safety;
 mod shared_adapter;
 
 use crate::core::{
@@ -34,9 +35,13 @@ pub async fn fetch_storefront_commerce(
 pub async fn create_storefront_payment_collection(
     request: PaymentCollectionCommandRequest,
 ) -> Result<StorefrontCheckoutPaymentCollection, ApiError> {
+    let error_context =
+        payment_collection_command_error_safety::PaymentCollectionCommandErrorContext::new(
+            &request,
+        );
     create_payment_collection(request)
         .await
-        .map_err(ApiError::from)
+        .map_err(|error| error_context.map_error(error))
 }
 
 #[allow(dead_code)]

--- a/crates/rustok-commerce/storefront/src/transport/payment_collection_command_error_safety.rs
+++ b/crates/rustok-commerce/storefront/src/transport/payment_collection_command_error_safety.rs
@@ -1,0 +1,117 @@
+use rustok_ui_transport::{UiTransportError, UiTransportPath};
+use uuid::Uuid;
+
+use crate::core::PaymentCollectionCommandRequest;
+
+use super::shared_adapter::ApiError;
+
+const COMMERCE_STOREFRONT_PAYMENT_OWNER: &str = "rustok_commerce.storefront";
+const COMMERCE_STOREFRONT_PAYMENT_OPERATION: &str =
+    "create_storefront_payment_collection";
+const COMMERCE_STOREFRONT_PAYMENT_BOUNDARY: &str =
+    "commerce_storefront_payment_collection_public_transport";
+const CART_ID_UUID_VALIDATION: &str = "cart_id must be a valid UUID";
+const INVALID_CART_SELECTION: &str = "Invalid cart selection";
+const STOREFRONT_PAYMENT_COLLECTION_UNAVAILABLE: &str =
+    "Storefront payment collection is temporarily unavailable";
+
+pub(super) struct PaymentCollectionCommandErrorContext {
+    correlation_id: String,
+    tenant_slug_length: Option<usize>,
+    cart_id_length: usize,
+    source_module_length: usize,
+    source_surface_length: usize,
+    command_length: usize,
+    owner_module_length: usize,
+}
+
+impl PaymentCollectionCommandErrorContext {
+    pub(super) fn new(request: &PaymentCollectionCommandRequest) -> Self {
+        Self {
+            correlation_id: format!(
+                "commerce-storefront-payment:{COMMERCE_STOREFRONT_PAYMENT_OPERATION}:{}",
+                Uuid::new_v4()
+            ),
+            tenant_slug_length: configured_tenant_slug_length(),
+            cart_id_length: request.cart_id.chars().count(),
+            source_module_length: request.metadata.source_module.chars().count(),
+            source_surface_length: request.metadata.source_surface.chars().count(),
+            command_length: request.metadata.command.chars().count(),
+            owner_module_length: request.metadata.owner_module.chars().count(),
+        }
+    }
+
+    pub(super) fn map_error(&self, error: UiTransportError) -> ApiError {
+        if is_invalid_cart_selection(&error) {
+            tracing::warn!(
+                error = ?error,
+                owner = COMMERCE_STOREFRONT_PAYMENT_OWNER,
+                owner_operation = COMMERCE_STOREFRONT_PAYMENT_OPERATION,
+                correlation_id = %self.correlation_id,
+                tenant_slug_configured = self.tenant_slug_length.is_some(),
+                tenant_slug_length = ?self.tenant_slug_length,
+                cart_id_length = self.cart_id_length,
+                source_module_length = self.source_module_length,
+                source_surface_length = self.source_surface_length,
+                command_length = self.command_length,
+                owner_module_length = self.owner_module_length,
+                failed_path = error.failed_path.as_str(),
+                fallback_attempted = error.fallback_attempted,
+                code = "commerce.storefront_payment_collection_cart_id_invalid",
+                boundary = COMMERCE_STOREFRONT_PAYMENT_BOUNDARY,
+                "commerce storefront payment collection validation failed"
+            );
+            return ApiError::Validation(INVALID_CART_SELECTION.to_string());
+        }
+
+        tracing::error!(
+            error = ?error,
+            owner = COMMERCE_STOREFRONT_PAYMENT_OWNER,
+            owner_operation = COMMERCE_STOREFRONT_PAYMENT_OPERATION,
+            correlation_id = %self.correlation_id,
+            tenant_slug_configured = self.tenant_slug_length.is_some(),
+            tenant_slug_length = ?self.tenant_slug_length,
+            cart_id_length = self.cart_id_length,
+            source_module_length = self.source_module_length,
+            source_surface_length = self.source_surface_length,
+            command_length = self.command_length,
+            owner_module_length = self.owner_module_length,
+            failed_path = error.failed_path.as_str(),
+            fallback_attempted = error.fallback_attempted,
+            code = "commerce.storefront_payment_collection_unavailable",
+            boundary = COMMERCE_STOREFRONT_PAYMENT_BOUNDARY,
+            "commerce storefront payment collection command failed"
+        );
+
+        match error.failed_path {
+            UiTransportPath::NativeServer => {
+                ApiError::ServerFn(STOREFRONT_PAYMENT_COLLECTION_UNAVAILABLE.to_string())
+            }
+            UiTransportPath::Graphql => {
+                ApiError::Graphql(STOREFRONT_PAYMENT_COLLECTION_UNAVAILABLE.to_string())
+            }
+        }
+    }
+}
+
+fn is_invalid_cart_selection(error: &UiTransportError) -> bool {
+    [error.native_error.as_deref(), error.graphql_error.as_deref()]
+        .into_iter()
+        .flatten()
+        .any(|message| message == CART_ID_UUID_VALIDATION)
+}
+
+fn configured_tenant_slug_length() -> Option<usize> {
+    [
+        "RUSTOK_TENANT_SLUG",
+        "NEXT_PUBLIC_TENANT_SLUG",
+        "NEXT_PUBLIC_DEFAULT_TENANT_SLUG",
+    ]
+    .into_iter()
+    .find_map(|key| {
+        std::env::var(key).ok().and_then(|value| {
+            let value = value.trim();
+            (!value.is_empty()).then_some(value.chars().count())
+        })
+    })
+}

--- a/scripts/verify/verify-commerce-storefront-aggregate-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-aggregate-error-safety.mjs
@@ -93,9 +93,9 @@ requireText(
   "impl From<UiTransportError> for ApiError",
   `${transportPath}: generic command-wrapper mapper remains explicit debt`,
 );
-if (countText(transport, ".map_err(ApiError::from)") !== 3) {
+if (countText(transport, ".map_err(ApiError::from)") !== 2) {
   failures.push(
-    `${transportPath}: exactly three owner command wrappers must remain on the generic mapper`,
+    `${transportPath}: exactly shipping selection and checkout completion must remain on the generic mapper`,
   );
 }
 for (const marker of [
@@ -236,5 +236,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "✔ commerce storefront aggregate fetch uses correlation-safe static public envelopes; owner command wrappers and runtime evidence remain open",
+  "✔ commerce storefront aggregate fetch uses correlation-safe static public envelopes; shipping, checkout, and runtime evidence remain open",
 );

--- a/scripts/verify/verify-commerce-storefront-payment-command-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-payment-command-error-safety.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const countText = (source, value) => source.split(value).length - 1;
+
+const transportPath = "crates/rustok-commerce/storefront/src/transport/mod.rs";
+const safetyPath =
+  "crates/rustok-commerce/storefront/src/transport/payment_collection_command_error_safety.rs";
+const paymentTransportPath = "crates/rustok-payment/storefront/src/transport.rs";
+const paymentGraphqlPath =
+  "crates/rustok-payment/storefront/src/transport/graphql_adapter.rs";
+const paymentNativePath =
+  "crates/rustok-payment/storefront/src/transport/native_server_adapter/server_functions.rs";
+const cargoPath = "crates/rustok-commerce/storefront/Cargo.toml";
+const evidencePath =
+  "crates/rustok-commerce/contracts/evidence/storefront-payment-command-error-safety-source.json";
+const reviewPath =
+  "crates/rustok-commerce/contracts/evidence/storefront-payment-command-error-safety-source-review.json";
+const docPath =
+  "crates/rustok-commerce/docs/storefront-payment-collection-command-error-safety.md";
+const planPath = "crates/rustok-commerce/docs/implementation-plan.md";
+
+const transport = read(transportPath);
+const safety = read(safetyPath);
+const paymentTransport = read(paymentTransportPath);
+const paymentGraphql = read(paymentGraphqlPath);
+const paymentNative = read(paymentNativePath);
+const cargo = read(cargoPath);
+const evidence = JSON.parse(read(evidencePath));
+const review = JSON.parse(read(reviewPath));
+const doc = read(docPath);
+const plan = read(planPath);
+
+for (const marker of ["tracing.workspace = true", "uuid.workspace = true"]) {
+  requireText(cargo, marker, `${cargoPath}: dependency`);
+}
+
+requireText(
+  transport,
+  "mod payment_collection_command_error_safety;",
+  `${transportPath}: private payment command policy wiring`,
+);
+const commandStart = transport.indexOf(
+  "pub async fn create_storefront_payment_collection(",
+);
+const commandEnd = transport.indexOf(
+  "pub async fn select_storefront_shipping_option(",
+  commandStart,
+);
+if (commandStart < 0 || commandEnd < 0) {
+  failures.push(`${transportPath}: payment command function boundaries are missing`);
+} else {
+  const command = transport.slice(commandStart, commandEnd);
+  for (const marker of [
+    "PaymentCollectionCommandErrorContext::new(",
+    "&request,",
+    "create_payment_collection(request)",
+    ".map_err(|error| error_context.map_error(error))",
+  ]) requireText(command, marker, `${transportPath}: payment command boundary`);
+  forbidText(command, ".map_err(ApiError::from)", `${transportPath}: generic payment mapping`);
+  forbidText(command, "error.to_string()", `${transportPath}: direct payment display mapping`);
+}
+
+if (countText(transport, ".map_err(ApiError::from)") !== 2) {
+  failures.push(
+    `${transportPath}: exactly shipping selection and checkout completion must remain on the generic mapper`,
+  );
+}
+for (const marker of [
+  "select_shipping_option(request.owner_request)",
+  "complete_checkout(request).await.map_err(ApiError::from)",
+]) requireText(transport, marker, `${transportPath}: remaining command debt`);
+
+for (const [marker, label] of [
+  ["pub(super) struct PaymentCollectionCommandErrorContext", "private context"],
+  ["Uuid::new_v4()", "unique correlation id"],
+  [
+    '"commerce-storefront-payment:{COMMERCE_STOREFRONT_PAYMENT_OPERATION}:{}"',
+    "correlation namespace",
+  ],
+  ["pub(super) fn map_error(&self, error: UiTransportError)", "transport mapper"],
+  ["fn is_invalid_cart_selection(error: &UiTransportError)", "validation classifier"],
+  ['"cart_id must be a valid UUID"', "owner validation compatibility"],
+  ['"Invalid cart selection"', "validation public envelope"],
+  [
+    '"Storefront payment collection is temporarily unavailable"',
+    "unavailable public envelope",
+  ],
+  [
+    '"commerce.storefront_payment_collection_cart_id_invalid"',
+    "validation code",
+  ],
+  [
+    '"commerce.storefront_payment_collection_unavailable"',
+    "unavailable code",
+  ],
+  ["error = ?error", "private original transport diagnostics"],
+  ["correlation_id = %self.correlation_id", "correlation diagnostics"],
+  ["tenant_slug_length = ?self.tenant_slug_length", "tenant shape diagnostics"],
+  ["cart_id_length = self.cart_id_length", "cart shape diagnostics"],
+  ["source_module_length = self.source_module_length", "metadata shape diagnostics"],
+  ["source_surface_length = self.source_surface_length", "surface shape diagnostics"],
+  ["command_length = self.command_length", "command shape diagnostics"],
+  ["owner_module_length = self.owner_module_length", "owner shape diagnostics"],
+  ["failed_path = error.failed_path.as_str()", "failed path diagnostics"],
+  ["fallback_attempted = error.fallback_attempted", "fallback diagnostics"],
+  ["ApiError::Validation(INVALID_CART_SELECTION.to_string())", "validation mapping"],
+  ["ApiError::ServerFn(STOREFRONT_PAYMENT_COLLECTION_UNAVAILABLE.to_string())", "native mapping"],
+  ["ApiError::Graphql(STOREFRONT_PAYMENT_COLLECTION_UNAVAILABLE.to_string())", "GraphQL mapping"],
+]) requireText(safety, marker, `${safetyPath}: ${label}`);
+
+for (const marker of [
+  "cart_id = %",
+  "cart_id = ?",
+  "source_module = %",
+  "source_module = ?",
+  "source_surface = %",
+  "source_surface = ?",
+  "command = %",
+  "command = ?",
+  "owner_module = %",
+  "owner_module = ?",
+  "tenant_slug = %",
+  "tenant_slug = ?",
+  "request = ?request",
+  "ApiError::ServerFn(error.to_string())",
+  "ApiError::Graphql(error.to_string())",
+]) forbidText(safety, marker, `${safetyPath}: raw request or public display mapping`);
+
+for (const marker of [
+  "pub struct PaymentCollectionCreateRequest",
+  "pub cart_id: String",
+  "pub metadata: PaymentCollectionCommandMetadata",
+  "pub async fn create_payment_collection(",
+  '"create_storefront_payment_collection"',
+]) requireText(paymentTransport, marker, `${paymentTransportPath}: owner request/operation`);
+for (const marker of [
+  "CREATE_STOREFRONT_PAYMENT_COLLECTION_MUTATION",
+  "let cart_id = parse_cart_id(&request.cart_id)?;",
+  'PaymentTransportError::Validation(format!("{field} must be a valid UUID"))',
+]) requireText(paymentGraphql, marker, `${paymentGraphqlPath}: owner GraphQL contract`);
+for (const marker of [
+  "storefront_payment_create_collection_native(request)",
+  'ServerFnError::new("cart_id must be a valid UUID")',
+  '"Storefront payment collection is temporarily unavailable"',
+]) requireText(paymentNative, marker, `${paymentNativePath}: owner native contract`);
+
+if (evidence.schema_version !== 1) failures.push(`${evidencePath}: schema_version must be 1`);
+if (
+  evidence.status !==
+  "commerce_storefront_payment_command_error_safety_source_unvalidated"
+) failures.push(`${evidencePath}: status mismatch`);
+for (const [key, expected] of Object.entries({
+  context_before_owner_call: true,
+  unique_correlation_id: true,
+  cart_validation_static_public_envelope: true,
+  unavailable_static_public_envelope: true,
+  failed_path_api_error_variant_preserved: true,
+  ui_transport_display_public: false,
+  raw_request_values_logged: false,
+  private_transport_error_diagnostics: true,
+  payment_owner_transport_changed: false,
+  shipping_wrapper_changed: false,
+  checkout_wrapper_changed: false,
+  fallback_added: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${evidencePath}: source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "focused_verifier_run",
+  "aggregate_verifier_run",
+  "broad_ecommerce_verifier_run",
+  "workflow_checks_run",
+  "ci_run",
+  "native_runtime_proven",
+  "graphql_runtime_proven",
+  "browser_runtime_proven",
+  "mounted_parity_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${evidencePath}: validation.${key} must remain false`);
+  }
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push(`${evidencePath}: execution must remain empty`);
+}
+if (review.status !== "commerce_storefront_payment_command_error_safety_source_reviewed_unvalidated") {
+  failures.push(`${reviewPath}: status mismatch`);
+}
+requireText(doc, "Status: **source-ready / unvalidated**", `${docPath}: source status`);
+requireText(doc, "shipping-selection and checkout-completion wrappers remain open", `${docPath}: remaining wrapper scope`);
+requireText(
+  plan,
+  "Finish correlation-safe mapper cleanup",
+  `${planPath}: broad mapper cleanup must remain open`,
+);
+
+if (failures.length > 0) {
+  console.error("Commerce storefront payment command error-safety verification failed:");
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "✔ commerce storefront payment collection command uses correlation-safe static public envelopes; shipping, checkout, and runtime evidence remain open",
+);

--- a/scripts/verify/verify-commerce-storefront-transport-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-transport-error-safety.mjs
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import './verify-commerce-storefront-aggregate-error-safety.mjs';
+import './verify-commerce-storefront-payment-command-error-safety.mjs';
 
 const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
 const rootPath = configuredRoot


### PR DESCRIPTION
## Summary
- add a Commerce-owned public error policy for `create_storefront_payment_collection`
- create a per-call context before the Payment owner call with a unique correlation id
- replace the final payment command `.map_err(ApiError::from)` with a structural `UiTransportError` mapper
- map the exact owner cart UUID validation envelope to `ApiError::Validation("Invalid cart selection")`
- map all other failures to `Storefront payment collection is temporarily unavailable` while preserving the failed-path `ServerFn` versus `Graphql` variant
- retain the original `UiTransportError` only in internal structured diagnostics
- record only safe request-shape facts: tenant/cart/metadata field lengths, failed path, fallback flag, stable code, boundary, and correlation id
- preserve the Payment owner DTO, command metadata, GraphQL mutation, native server function, validation/runtime policy, transport selection, and absence of fallback
- add a focused source verifier, include it in the Commerce storefront transport safety aggregate, reduce the prior generic-wrapper debt guard from three to two, and retain unvalidated source/review evidence plus documentation

## Scope boundary
This PR changes only the Commerce payment collection creation wrapper. These two command wrappers remain explicit follow-up work on the generic mapper:
- `select_storefront_shipping_option`
- `complete_storefront_checkout`

## Public policy
- invalid cart UUID: `Invalid cart selection`
- native command failure: `Storefront payment collection is temporarily unavailable`
- GraphQL command failure: `Storefront payment collection is temporarily unavailable`

## Preserved behavior
- `PaymentCollectionCreateRequest` and response DTOs unchanged
- payment-owned command metadata unchanged
- Payment GraphQL mutation/variables/response mapping unchanged
- Payment native server function unchanged
- owner validation, authentication, and runtime mapping unchanged
- transport selection unchanged
- no native-to-GraphQL fallback added
- shipping and checkout wrappers unchanged

## Evidence boundary
Source status is `commerce_storefront_payment_command_error_safety_source_unvalidated`. The broad ecommerce correlation-safe mapper cleanup remains open. No FFA, FBA, browser, native/GraphQL runtime, mounted parity, workflow, CI, or production status is promoted.

## Verification
The ecommerce master plan, Commerce facade and aggregate policy, Payment storefront facade/private GraphQL/native adapters, payment request metadata, `UiTransportError` display/storage contract, existing Commerce guards, final source files, and the eight-file diff were reviewed. The branch is based at `1a39055c4d64bb6c19c81c34a4e0371f1ca262e1`; the current one-commit main drift is Blog-only and does not overlap these files.

Tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run per maintainer instruction.