### PR TITLE
feat(index): publish guarded replay runtime

### DIFF
--- a/apps/server/src/services/index_replay_runtime_composition.rs
+++ b/apps/server/src/services/index_replay_runtime_composition.rs
@@ -1,25 +1,130 @@
+use std::fmt;
+
+use rustok_api::{Permission, has_effective_permission};
 use rustok_core::ModuleRuntimeExtensions;
 use sea_orm::DatabaseConnection;
+use thiserror::Error;
+use uuid::Uuid;
 
-use crate::error::{Error, Result};
+use crate::error::{Error as ServerError, Result};
+use crate::services::rbac_request_scope::permissions_for;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndexReplayOperatorContext {
+    tenant_id: Uuid,
+    actor_id: Uuid,
+}
+
+impl IndexReplayOperatorContext {
+    pub fn new(tenant_id: Uuid, actor_id: Uuid) -> Result<Self, IndexReplayOperatorError> {
+        if tenant_id.is_nil() || actor_id.is_nil() {
+            return Err(IndexReplayOperatorError::InvalidContext);
+        }
+        Ok(Self {
+            tenant_id,
+            actor_id,
+        })
+    }
+
+    pub fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub fn actor_id(&self) -> Uuid {
+        self.actor_id
+    }
+
+    fn authorize_for(&self, requested_tenant: Uuid) -> Result<(), IndexReplayOperatorError> {
+        if requested_tenant != self.tenant_id {
+            return Err(IndexReplayOperatorError::TenantMismatch);
+        }
+        let permissions = permissions_for(&self.tenant_id, &self.actor_id)
+            .ok_or(IndexReplayOperatorError::MissingRequestAuthority)?;
+        if !has_effective_permission(&permissions, &Permission::MODULES_MANAGE) {
+            return Err(IndexReplayOperatorError::Forbidden);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum IndexReplayOperatorError {
+    #[error("Index replay operator tenant and actor must not be nil")]
+    InvalidContext,
+    #[error("Index replay request tenant does not match the authorized operator tenant")]
+    TenantMismatch,
+    #[error("Index replay operations require a request-bound effective permission snapshot")]
+    MissingRequestAuthority,
+    #[error("modules:manage is required for Index replay operations")]
+    Forbidden,
+    #[error(transparent)]
+    Replay(#[from] rustok_index::IndexReplayRunError),
+}
+
+/// Server-owned guarded operator boundary over the canonical Index replay runtime.
+///
+/// Transport adapters must provide an exact request-bound tenant/actor context. The boundary
+/// accepts only `modules:manage`, rejects cross-tenant requests before database access, and exposes
+/// no connection, source registry, scheduler, or worker-spawn handle.
+#[derive(Clone)]
+pub struct IndexReplayOperatorRuntime {
+    inner: rustok_index::SharedIndexReplayRuntime,
+}
+
+impl IndexReplayOperatorRuntime {
+    fn new(inner: rustok_index::SharedIndexReplayRuntime) -> Self {
+        Self { inner }
+    }
+
+    pub async fn run(
+        &self,
+        context: IndexReplayOperatorContext,
+        request: rustok_index::IndexReplayRunRequest,
+    ) -> Result<rustok_index::IndexReplayRunOutcome, IndexReplayOperatorError> {
+        context.authorize_for(request.page_request().tenant_id())?;
+        self.inner.run(request).await.map_err(Into::into)
+    }
+
+    pub async fn request_cancel(
+        &self,
+        context: IndexReplayOperatorContext,
+        job_id: Uuid,
+    ) -> Result<rustok_index::IndexReplayCancelOutcome, IndexReplayOperatorError> {
+        context.authorize_for(context.tenant_id())?;
+        self.inner
+            .request_cancel(context.tenant_id(), job_id)
+            .await
+            .map_err(Into::into)
+    }
+}
+
+impl fmt::Debug for IndexReplayOperatorRuntime {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("IndexReplayOperatorRuntime")
+            .finish_non_exhaustive()
+    }
+}
 
 /// Materializes the host-owned Index replay capability after all modules have registered sources.
 ///
 /// This function performs no database I/O and starts no worker. It only freezes the complete
 /// source catalog, binds the immutable schema/source registries to the host database, and publishes
-/// the bounded operator capability through `ModuleRuntimeExtensions`.
+/// the guarded bounded operator capability through `ModuleRuntimeExtensions`.
 pub(crate) fn materialize_index_replay_runtime(
     extensions: &mut ModuleRuntimeExtensions,
     db: DatabaseConnection,
 ) -> Result<()> {
-    if extensions.contains::<rustok_index::SharedIndexSourceRegistry>() {
-        return Err(Error::Message(
-            "shared Index source registry is already materialized".to_string(),
+    if extensions.contains::<rustok_index::SharedIndexSourceRegistry>()
+        || extensions.contains::<IndexReplayOperatorRuntime>()
+    {
+        return Err(ServerError::Message(
+            "shared Index replay runtime is already materialized".to_string(),
         ));
     }
 
     let sources = rustok_index::materialize_index_source_registry(extensions).map_err(|error| {
-        Error::Message(format!(
+        ServerError::Message(format!(
             "Index replay source registry materialization failed: {error}"
         ))
     })?;
@@ -27,18 +132,22 @@ pub(crate) fn materialize_index_replay_runtime(
         extensions.insert(sources);
     }
 
-    rustok_index::materialize_postgres_index_replay_runtime(extensions, db).map_err(|error| {
-        Error::Message(format!(
-            "Index replay runtime composition failed: {error}"
-        ))
-    })?;
+    let runtime = rustok_index::materialize_postgres_index_replay_runtime(extensions, db).map_err(
+        |error| ServerError::Message(format!("Index replay runtime composition failed: {error}")),
+    )?;
+    if let Some(runtime) = runtime {
+        extensions.insert(IndexReplayOperatorRuntime::new(runtime));
+    }
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use async_trait::async_trait;
-    use rustok_core::{MigrationSource, ModuleRegistry, ModuleRuntimeExtensions, RusToKModule};
+    use rustok_api::Permission;
+    use rustok_core::{
+        MigrationSource, ModuleRegistry, ModuleRuntimeExtensions, RusToKModule, UserRole,
+    };
     use rustok_index::{
         EntityName, FieldCardinality, FieldName, IndexField, IndexModule, IndexSchema, IndexSource,
         IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest, IndexSourcePage,
@@ -48,8 +157,13 @@ mod tests {
     };
     use sea_orm::Database;
     use sea_orm_migration::MigrationTrait;
+    use uuid::Uuid;
 
-    use super::materialize_index_replay_runtime;
+    use super::{
+        IndexReplayOperatorContext, IndexReplayOperatorError, IndexReplayOperatorRuntime,
+        materialize_index_replay_runtime,
+    };
+    use crate::services::rbac_request_scope::{RbacRequestScope, with_rbac_request_scope};
 
     struct DemoReplayModule;
     struct NoopSource;
@@ -158,10 +272,11 @@ mod tests {
             .expect("missing sources should remain optional");
         assert!(!extensions.contains::<SharedIndexSourceRegistry>());
         assert!(!extensions.contains::<SharedIndexReplayRuntime>());
+        assert!(!extensions.contains::<IndexReplayOperatorRuntime>());
     }
 
     #[tokio::test]
-    async fn complete_source_catalog_publishes_replay_runtime_to_host_context() {
+    async fn complete_source_catalog_publishes_guarded_runtime_to_host_context() {
         let registry = ModuleRegistry::new()
             .register(IndexModule)
             .register(DemoReplayModule);
@@ -177,9 +292,10 @@ mod tests {
             .expect("complete replay runtime should compose");
         assert!(extensions.contains::<SharedIndexSourceRegistry>());
         assert!(extensions.contains::<SharedIndexReplayRuntime>());
+        assert!(extensions.contains::<IndexReplayOperatorRuntime>());
 
         let host = extensions.apply_to_host_runtime(rustok_api::HostRuntimeContext::new(db));
-        assert!(host.shared_get::<SharedIndexReplayRuntime>().is_some());
+        assert!(host.shared_get::<IndexReplayOperatorRuntime>().is_some());
     }
 
     #[tokio::test]
@@ -198,5 +314,61 @@ mod tests {
         let error = materialize_index_replay_runtime(&mut extensions, db)
             .expect_err("duplicate replay materialization must fail");
         assert!(error.to_string().contains("already materialized"));
+    }
+
+    #[tokio::test]
+    async fn operator_authorization_requires_exact_tenant_actor_and_modules_manage() {
+        let tenant_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let context = IndexReplayOperatorContext::new(tenant_id, actor_id).unwrap();
+        assert!(matches!(
+            context.authorize_for(tenant_id),
+            Err(IndexReplayOperatorError::MissingRequestAuthority)
+        ));
+
+        with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_READ],
+                UserRole::Admin,
+            )),
+            async {
+                assert!(matches!(
+                    context.authorize_for(tenant_id),
+                    Err(IndexReplayOperatorError::Forbidden)
+                ));
+            },
+        )
+        .await;
+
+        with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_MANAGE],
+                UserRole::Admin,
+            )),
+            async {
+                assert!(context.authorize_for(tenant_id).is_ok());
+                assert!(matches!(
+                    context.authorize_for(Uuid::new_v4()),
+                    Err(IndexReplayOperatorError::TenantMismatch)
+                ));
+            },
+        )
+        .await;
+    }
+
+    #[test]
+    fn operator_context_rejects_nil_identity() {
+        assert!(matches!(
+            IndexReplayOperatorContext::new(Uuid::nil(), Uuid::new_v4()),
+            Err(IndexReplayOperatorError::InvalidContext)
+        ));
+        assert!(matches!(
+            IndexReplayOperatorContext::new(Uuid::new_v4(), Uuid::nil()),
+            Err(IndexReplayOperatorError::InvalidContext)
+        ));
     }
 }

--- a/apps/server/src/services/index_replay_runtime_composition.rs
+++ b/apps/server/src/services/index_replay_runtime_composition.rs
@@ -1,0 +1,202 @@
+use rustok_core::ModuleRuntimeExtensions;
+use sea_orm::DatabaseConnection;
+
+use crate::error::{Error, Result};
+
+/// Materializes the host-owned Index replay capability after all modules have registered sources.
+///
+/// This function performs no database I/O and starts no worker. It only freezes the complete
+/// source catalog, binds the immutable schema/source registries to the host database, and publishes
+/// the bounded operator capability through `ModuleRuntimeExtensions`.
+pub(crate) fn materialize_index_replay_runtime(
+    extensions: &mut ModuleRuntimeExtensions,
+    db: DatabaseConnection,
+) -> Result<()> {
+    if extensions.contains::<rustok_index::SharedIndexSourceRegistry>() {
+        return Err(Error::Message(
+            "shared Index source registry is already materialized".to_string(),
+        ));
+    }
+
+    let sources = rustok_index::materialize_index_source_registry(extensions).map_err(|error| {
+        Error::Message(format!(
+            "Index replay source registry materialization failed: {error}"
+        ))
+    })?;
+    if let Some(sources) = sources {
+        extensions.insert(sources);
+    }
+
+    rustok_index::materialize_postgres_index_replay_runtime(extensions, db).map_err(|error| {
+        Error::Message(format!(
+            "Index replay runtime composition failed: {error}"
+        ))
+    })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use rustok_core::{MigrationSource, ModuleRegistry, ModuleRuntimeExtensions, RusToKModule};
+    use rustok_index::{
+        EntityName, FieldCardinality, FieldName, IndexField, IndexModule, IndexSchema, IndexSource,
+        IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest, IndexSourcePage,
+        IndexSourceScanRequest, IndexValueType, LocaleMode, ModuleName, SchemaRef, SchemaVersion,
+        SharedIndexReplayRuntime, SharedIndexSchemaRegistry, SharedIndexSourceRegistry,
+        register_index_schema_source, register_index_source,
+    };
+    use sea_orm::Database;
+    use sea_orm_migration::MigrationTrait;
+
+    use super::materialize_index_replay_runtime;
+
+    struct DemoReplayModule;
+    struct NoopSource;
+
+    #[async_trait]
+    impl IndexSource for NoopSource {
+        async fn scan(
+            &self,
+            request: IndexSourceScanRequest,
+        ) -> Result<IndexSourcePage, IndexSourceFailure> {
+            Ok(IndexSourcePage::new(&request, Vec::new(), None)
+                .expect("empty final replay page should be valid"))
+        }
+
+        async fn load(
+            &self,
+            request: IndexSourceLoadRequest,
+        ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+            Ok(IndexSourceLoadBatch::new(&request, Vec::new())
+                .expect("empty targeted load should be valid"))
+        }
+    }
+
+    impl MigrationSource for DemoReplayModule {
+        fn migrations(&self) -> Vec<Box<dyn MigrationTrait>> {
+            Vec::new()
+        }
+    }
+
+    #[async_trait]
+    impl RusToKModule for DemoReplayModule {
+        fn slug(&self) -> &'static str {
+            "demo_replay"
+        }
+
+        fn name(&self) -> &'static str {
+            "Demo replay"
+        }
+
+        fn description(&self) -> &'static str {
+            "Test source-owned Index replay publisher"
+        }
+
+        fn version(&self) -> &'static str {
+            "0.1.0"
+        }
+
+        fn register_runtime_extensions(
+            &self,
+            extensions: &mut ModuleRuntimeExtensions,
+        ) -> rustok_core::Result<()> {
+            let schema = demo_schema();
+            register_index_schema_source(extensions, self.slug(), schema.clone()).map_err(
+                |error| {
+                    rustok_core::Error::Validation(format!(
+                        "demo replay schema registration failed: {error}"
+                    ))
+                },
+            )?;
+            register_index_source(
+                extensions,
+                self.slug(),
+                "demo-replay-primary",
+                [schema.reference],
+                NoopSource,
+            )
+            .map_err(|error| {
+                rustok_core::Error::Validation(format!(
+                    "demo replay source registration failed: {error}"
+                ))
+            })
+        }
+    }
+
+    fn demo_schema() -> IndexSchema {
+        IndexSchema {
+            reference: SchemaRef {
+                module: ModuleName::new("demo-replay").unwrap(),
+                entity: EntityName::new("item").unwrap(),
+                version: SchemaVersion::INITIAL,
+            },
+            locale_mode: LocaleMode::None,
+            fields: vec![IndexField {
+                name: FieldName::new("id").unwrap(),
+                value_type: IndexValueType::Uuid,
+                cardinality: FieldCardinality::One,
+                nullable: false,
+                selectable: true,
+                filterable: true,
+                sortable: true,
+            }],
+            links: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_replay_sources_do_not_publish_false_host_runtime() {
+        let registry = ModuleRegistry::new().register(IndexModule);
+        let mut extensions = rustok_distribution::build_runtime_extensions(&registry)
+            .expect("empty Index composition should build");
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+
+        materialize_index_replay_runtime(&mut extensions, db)
+            .expect("missing sources should remain optional");
+        assert!(!extensions.contains::<SharedIndexSourceRegistry>());
+        assert!(!extensions.contains::<SharedIndexReplayRuntime>());
+    }
+
+    #[tokio::test]
+    async fn complete_source_catalog_publishes_replay_runtime_to_host_context() {
+        let registry = ModuleRegistry::new()
+            .register(IndexModule)
+            .register(DemoReplayModule);
+        let mut extensions = rustok_distribution::build_runtime_extensions(&registry)
+            .expect("source schema composition should build");
+        assert!(extensions.contains::<SharedIndexSchemaRegistry>());
+        assert!(!extensions.contains::<SharedIndexSourceRegistry>());
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+
+        materialize_index_replay_runtime(&mut extensions, db.clone())
+            .expect("complete replay runtime should compose");
+        assert!(extensions.contains::<SharedIndexSourceRegistry>());
+        assert!(extensions.contains::<SharedIndexReplayRuntime>());
+
+        let host = extensions.apply_to_host_runtime(rustok_api::HostRuntimeContext::new(db));
+        assert!(host.shared_get::<SharedIndexReplayRuntime>().is_some());
+    }
+
+    #[tokio::test]
+    async fn duplicate_host_replay_materialization_fails_closed() {
+        let registry = ModuleRegistry::new()
+            .register(IndexModule)
+            .register(DemoReplayModule);
+        let mut extensions = rustok_distribution::build_runtime_extensions(&registry)
+            .expect("source schema composition should build");
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+        materialize_index_replay_runtime(&mut extensions, db.clone())
+            .expect("first replay materialization");
+
+        let error = materialize_index_replay_runtime(&mut extensions, db)
+            .expect_err("duplicate replay materialization must fail");
+        assert!(error.to_string().contains("already materialized"));
+    }
+}

--- a/apps/server/src/services/mod.rs
+++ b/apps/server/src/services/mod.rs
@@ -63,6 +63,7 @@ pub mod forum_search_inbox_worker;
 pub mod graphql_schema;
 pub mod iggy_connector_control_adapter;
 pub mod iggy_connector_settings_service;
+pub mod index_replay_runtime_composition;
 pub mod marketplace_catalog;
 pub mod marketplace_catalog_adapter;
 pub mod marketplace_catalog_cache;
@@ -92,7 +93,8 @@ pub mod module_event_dispatcher {
     };
 
     /// Adds host-owned adapters after module/distribution registration, materializes the
-    /// canonical Index query runtime, and then activates selected non-authoritative shadows.
+    /// canonical Index query and replay runtimes, and then activates selected
+    /// non-authoritative shadows.
     pub fn build_shared_runtime_extensions_with_host_providers(
         registry: &ModuleRegistry,
         settings: &RustokSettings,
@@ -109,6 +111,10 @@ pub mod module_event_dispatcher {
         let mut extensions = base.as_ref().clone();
         rustok_index::materialize_postgres_index_query_runtime(&mut extensions, db.clone()).map_err(
             |error| Error::Message(format!("Index query runtime composition failed: {error}")),
+        )?;
+        super::index_replay_runtime_composition::materialize_index_replay_runtime(
+            &mut extensions,
+            db.clone(),
         )?;
 
         #[cfg(all(
@@ -148,7 +154,10 @@ pub mod module_event_dispatcher {
     #[cfg(all(test, feature = "mod-social_graph"))]
     mod tests {
         use rustok_core::{ModuleRegistry, ModuleRuntimeExtensions};
-        use rustok_index::{IndexModule, SharedIndexQueryRuntime, SharedIndexSchemaRegistry};
+        use rustok_index::{
+            IndexModule, SharedIndexQueryRuntime, SharedIndexReplayRuntime,
+            SharedIndexSchemaRegistry,
+        };
         use sea_orm::Database;
 
         use super::build_shared_runtime_extensions_with_host_providers;
@@ -177,10 +186,12 @@ pub mod module_event_dispatcher {
 
             assert!(extensions.contains::<SharedIndexSchemaRegistry>());
             assert!(extensions.contains::<SharedIndexQueryRuntime>());
+            assert!(!extensions.contains::<SharedIndexReplayRuntime>());
             #[cfg(all(feature = "mod-notifications", feature = "mod-profiles"))]
             assert!(extensions.contains::<rustok_notifications::NotificationRecipientPolicyRuntime>());
             let host = extensions.apply_to_host_runtime(rustok_api::HostRuntimeContext::new(db));
             assert!(host.shared_get::<SharedIndexQueryRuntime>().is_some());
+            assert!(host.shared_get::<SharedIndexReplayRuntime>().is_none());
         }
 
         #[test]
@@ -258,6 +269,3 @@ pub mod user_admin_guard;
 pub mod user_field_service;
 
 pub mod field_definition_cache;
-pub mod field_definition_registry_bootstrap;
-pub mod flex_attached_values;
-pub mod flex_standalone_service;

--- a/crates/rustok-index/CRATE_API.md
+++ b/crates/rustok-index/CRATE_API.md
@@ -12,10 +12,10 @@ PostgreSQL storage, mutation, schema-registration, lease, secondary-index, and m
 partition-admission boundaries. M4 owns typed query planning, controlled SQL compilation,
 strict decoding, PostgreSQL execution, source-owned schema catalog composition, and the
 neutral shared query runtime. M5/M6 own the neutral replay-source catalog, bounded scan/load
-contracts, one-page replay orchestration, durable schema-scoped replay job ownership, and
-lease-fenced rebuild checkpoints. Source-specific Product, Content, Flex, search,
-migration, scheduler, and long-running worker implementations remain outside the engine
-core.
+contracts, one-page and bounded multi-page replay orchestration, durable schema-scoped replay
+job ownership, lease-fenced checkpoints, cancellation, and host-published replay capability.
+Source-specific Product, Content, Flex, search, scheduler, and long-running worker
+implementations remain outside the engine core.
 
 ## Primary Public Types
 
@@ -71,6 +71,12 @@ core.
 - `PostgresIndexReplayJobStore`, `IndexReplayJobLeaseRequest`, `IndexReplayJobLease`
 - `IndexReplayJobAcquireOutcome`, `IndexReplayJobError`
 - `PostgresIndexReplayCheckpointStore`
+- `PostgresIndexReplayRunner`, `IndexReplayRunRequest`, `IndexReplayRunOutcome`
+- `IndexReplayRunStatus`, `IndexReplayCancelOutcome`, `IndexReplayTerminalState`
+- `IndexReplayRunError`
+- `SharedIndexReplayRuntime`
+- `materialize_postgres_index_replay_runtime`
+- `IndexReplayRuntimeCompositionError`
 - `PostgresSchemaRegistrationStore`, `PersistedSchemaRegistrationOutcome`, `SchemaRegistrationError`
 - `PostgresSchemaLeaseStore`, `SchemaApplicationLeaseRequest`, `SchemaApplicationLease`
 - `SchemaLeaseAcquireOutcome`, `SchemaLeaseError`
@@ -81,6 +87,10 @@ core.
 - `PartitionMeasurementCoverage`, `PartitionShadowEvidence`, `PartitionEvidence`
 - `PartitionAdmissionReason`, `PartitionAdmissionOutcome`, `PartitionRelationPlan`
 - `PartitionShadowPlan`, `PartitionAdmissionError`, `evaluate_partition_admission`
+
+`IndexReplayOperatorRuntime`, `IndexReplayOperatorContext`, and
+`IndexReplayOperatorError` are server-owned guarded composition types. They are intentionally
+not part of the engine crate API.
 
 ## Contract Status
 
@@ -114,11 +124,12 @@ SQL, and transfers the neutral capability through `ModuleRuntimeExtensions` and
 `HostRuntimeContext`. Runtime presence does not claim PostgreSQL backend support for a test
 connection, persisted tenant schema readiness, authorization, or successful query execution.
 
-M5/M6 source replay is source complete through the fenced one-page boundary.
-`IndexSourceCatalog` fixes one replay source for every exact schema and complete schema identity
-across versions, and materialization requires the corresponding owner-published schema with the
-same owner. Cursor scans, targeted loads, cursor bytes, page/key counts, tenant/schema scope,
-returned keys, and continuation progress are bounded.
+M5/M6 replay source, execution, ownership, and cancellation are source complete through the
+bounded host-composition boundary. `IndexSourceCatalog` fixes one replay source for every exact
+schema and complete schema identity across versions. `materialize_index_source_registry`
+requires every source schema to be owner-published with the same owner and returns no false
+runtime for an absent or empty source catalog. Cursor scans, targeted loads, cursor bytes,
+page/key counts, tenant/schema scope, returned keys, and continuation progress are bounded.
 
 `IndexReplayWorker::run_next_page` reads one checkpoint, scans one page, validates every
 non-nil unique event UUID before the first write, applies mutations sequentially through an
@@ -136,10 +147,26 @@ writes lock and validate the exact `(job_id, worker_id, attempt_count)` before a
 checkpoint. Terminal success requires the same active lease and an exact durable null-cursor
 checkpoint.
 
-A scheduler, bounded multi-page runner, cancellation, retry/backoff/dead-letter policy,
-locale/partition replay dimensions, direct server binding of job requests to the materialized
-source registry, production source adapters, and retained multi-instance PostgreSQL evidence
-remain open.
+`PostgresIndexReplayRunner` resolves the source only from `SharedIndexSourceRegistry`, executes
+at most 1024 pages per invocation, heartbeats between pages, yields unfinished work to an
+immediately claimable pending attempt, and observes durable cancellation before and after page
+work. Cancellation committed first cannot be overwritten by success, failure, or yield.
+
+The server freezes `SharedIndexSourceRegistry` after module registration, calls
+`materialize_postgres_index_replay_runtime`, and publishes `SharedIndexReplayRuntime` only when
+both immutable schema and source registries exist. It then publishes the guarded
+`IndexReplayOperatorRuntime`, which requires an exact request-bound tenant/actor permission
+snapshot and `modules:manage` before delegating bounded run or cancellation. Transport adapters
+must not call the raw shared replay runtime directly.
+
+Runtime composition performs no SQL and starts no task. Runtime presence does not claim tenant
+schema readiness, source availability, scheduler ownership, graceful shutdown, command
+transport authorization, successful replay, or retained PostgreSQL evidence.
+
+Still open are in-page interruption/timeouts, authorized GraphQL/HTTP/CLI command surfaces,
+automatic retry/backoff and dead-letter state, host scheduling and task shutdown ownership,
+locale/partition replay dimensions, production source adapters, reconciliation/drift repair,
+and retained multi-instance PostgreSQL evidence.
 
 Exact Decimal tagged-order transport is source-complete. Aggregate cursor continuation,
 retained PostgreSQL/reference aggregate evidence, additional source schemas, transport
@@ -175,11 +202,16 @@ builders or DTOs.
 - One exact schema and complete schema identity cannot move between replay sources across
   versions.
 - Replay-source materialization rejects unpublished schemas and schema/source owner drift.
+- `materialize_index_source_registry` returns `None` for an absent or empty source catalog.
 - `SharedIndexQueryRuntime` exposes only the transport-neutral `IndexQueryPort` capability.
 - `materialize_postgres_index_query_runtime` is the production constructor for the PostgreSQL
-  runtime and fails when the runtime is already present.
-- Runtime composition performs no SQL and does not replace tenant-scoped persisted schema
-  registration or preflight.
+  query runtime and fails when the runtime is already present.
+- `SharedIndexReplayRuntime` exposes only bounded `run` and `request_cancel` operations.
+- `materialize_postgres_index_replay_runtime` requires the immutable source registry and fails
+  if the schema registry is missing or the replay runtime already exists.
+- The server publishes `IndexReplayOperatorRuntime` after the raw replay runtime and requires
+  an exact request-bound tenant/actor permission snapshot plus `modules:manage`.
+- Runtime composition performs no SQL and starts no task.
 - Executable hosts transfer capabilities through the existing typed runtime-extension seam.
 
 ### Replay source, job, and checkpoint
@@ -210,6 +242,11 @@ builders or DTOs.
 - A stale attempt cannot advance a checkpoint after reclaim.
 - Successful job completion requires the active attempt and the exact rebuild checkpoint with a
   JSON null cursor.
+- Bounded runs derive source ownership from the materialized registry, never caller input.
+- A run processes at most its validated page budget and heartbeats only between pages.
+- A cancellation request committed first wins over success, failure, and pending yield.
+- The guarded server runtime rejects cross-tenant invocation and missing request-bound authority
+  before delegating to the Index runtime.
 
 ### Query input and execution
 
@@ -271,8 +308,9 @@ builders or DTOs.
 - Replay event IDs are non-nil and unique inside one page and remain stable across retry.
 - Durable replay checkpoint progression is ordered after mutation outcomes and fenced by the
   active replay job attempt.
+- A guarded replay invocation cannot widen its request-bound tenant scope.
 - Generic engine types remain source-domain agnostic.
-- Runtime composition is not an authorization decision or persisted-readiness assertion.
+- Runtime composition is not a persisted-readiness assertion, scheduler, or evidence claim.
 
 ## Query Planning, Compilation, and Decoding
 
@@ -306,7 +344,11 @@ builders or DTOs.
   progression failures.
 - `IndexReplayJobError` defines job request, schema readiness, stored job, checkpoint completion,
   lease loss, and storage failures.
-- `IndexQueryRuntimeCompositionError` rejects duplicate shared runtime materialization.
+- `IndexReplayRunError` defines run bounds, cancellation identity, page failure, lease loss, and
+  replay job failures.
+- `IndexReplayRuntimeCompositionError` rejects duplicate runtime publication and a source runtime
+  without the immutable schema registry.
+- `IndexQueryRuntimeCompositionError` rejects duplicate shared query runtime materialization.
 - `RecordValidationError`, `QueryValidationError`, and `AggregateOrderValidationError` define
   registry-backed data/query failures and the bounded aggregate-order policy.
 - `CursorCodecError` and `CursorValidationError` separate malformed cursors from scope, schema,
@@ -329,10 +371,13 @@ builders or DTOs.
 - Creating an unfenced `PostgresIndexReplayCheckpointStore` without an acquired job lease.
 - Advancing a checkpoint before every page mutation result is durable.
 - Generating a new event UUID when replaying the same logical mutation and source version.
-- Treating one-page replay and durable leases as a completed scheduler or multi-page worker.
+- Treating a bounded replay runtime as a completed scheduler, retry policy, or background worker.
 - Treating in-memory registry composition as tenant-scoped persisted schema readiness.
 - Constructing an ad hoc `SchemaRegistry` or `SharedIndexSchemaRegistry` in server/consumer code.
 - Calling `PostgresIndexQueryPort::new` outside the Index-owned runtime materializer.
+- Calling `PostgresIndexReplayRunner::new` outside the Index-owned replay runtime materializer.
+- Letting GraphQL, HTTP, CLI, or admin transports call `SharedIndexReplayRuntime` instead of the
+  server-owned guarded `IndexReplayOperatorRuntime`.
 - Treating `SharedIndexQueryRuntime` presence as authorization or proof that a tenant query works.
 - Publishing a consumer query without owner/transport authorization and bounded error mapping.
 - Using plain `asc` / `desc`, link ordinal, first related row, or caller SQL as a many-order policy.

--- a/crates/rustok-index/README.md
+++ b/crates/rustok-index/README.md
@@ -19,8 +19,8 @@ a rewrite goal.
 - Validate and plan cross-module queries.
 - Compile projection, filtering, sorting, count, and pagination to Index storage
   queries.
-- Execute compiled queries through an Index-owned PostgreSQL port.
-- Publish stable query, source, rebuild, and operator contracts.
+- Execute compiled queries through Index-owned PostgreSQL ports.
+- Publish stable query, source, rebuild, replay-runtime, and operator contracts.
 - Keep product-facing relevance and ranking in `rustok-search`.
 
 ## Boundaries
@@ -36,10 +36,12 @@ a rewrite goal.
 - The selected JSONB regression DDL lives under `ops/benches`; it is not a
   production migration or runtime storage contract. Historical three-candidate
   evidence is archived under `docs/evidence/`.
+- Replay runtime composition does not create a scheduler, background task, or
+  transport authorization surface.
 
 ## Rewrite status
 
-- Current milestone: `M6 - fenced replay job ownership`
+- Current milestone: `M6 - replay runtime host composition and operator guard`
 - FFA status: `in_progress`
 - FBA status: `in_progress`
 - M0 code reset: complete
@@ -63,8 +65,11 @@ a rewrite goal.
 - M5/M6 bounded source registry and replay/load contracts: source complete
 - M6 one-page replay and durable checkpoint progression: source complete
 - M6 replay job leases and checkpoint attempt fencing: source complete, owner execution pending
+- M6 bounded multi-page replay and cancellation: source complete, owner execution pending
+- M6 replay runtime host composition and operator guard: source complete
 - Real retained PostgreSQL packet execution: open
-- Bounded multi-page replay, cancellation, retry scheduling, and Product adapters: open
+- In-page interruption, retry/dead-letter scheduling, host scheduler, command transports,
+  and Product adapters: open
 - Query-port authorization/consumer cutover and live equivalence evidence: open
 
 All legacy ports, adapters, source indexers, projections, migrations, runtime
@@ -104,8 +109,31 @@ work with an incremented attempt fence, and rejects stale terminal updates.
 `(job_id, worker_id, attempt_count)` first. A stale worker may finish an already-started
 idempotent mutation transaction, but it cannot advance the durable cursor. Successful
 job completion requires an active lease and the exact durable rebuild checkpoint with a
-JSON null cursor. A scheduler, bounded multi-page loop, cancellation, backoff/dead-letter
-policy, locale/partition replay dimensions, and production source adapters remain open.
+JSON null cursor.
+
+`PostgresIndexReplayRunner` resolves source ownership from `SharedIndexSourceRegistry`,
+processes at most the validated 1024-page invocation budget, heartbeats only between
+pages, yields unfinished work to an immediately claimable pending attempt, and observes
+durable cancellation before and after page execution. A cancellation committed first
+cannot be overwritten by success, failure, or yield.
+
+The server freezes `SharedIndexSourceRegistry` after all selected modules register sources
+and calls the Index-owned `materialize_postgres_index_replay_runtime`. This binds the exact
+immutable schema and source registries to the host database and publishes
+`SharedIndexReplayRuntime` through `ModuleRuntimeExtensions`. Composition performs no SQL
+and starts no task.
+
+The raw runtime is then wrapped by the server-owned `IndexReplayOperatorRuntime`. It
+requires a request-bound effective permission snapshot for an exact non-nil tenant/actor,
+rejects cross-tenant invocation, requires `modules:manage`, and exposes only bounded
+`run` and `request_cancel`. Future GraphQL, HTTP, CLI, or admin transports must consume this
+guarded operator runtime rather than the raw infrastructure capability.
+
+Runtime presence does not claim persisted tenant schema readiness, source availability,
+automatic retry, scheduler ownership, graceful shutdown, command authorization, successful
+replay, or retained PostgreSQL evidence. In-page interruption, retry/backoff/dead-letter
+policy, a global host scheduler and stop-handle ownership, locale/partition replay
+dimensions, production source adapters, and retained multi-instance evidence remain open.
 
 The module-owned migration source creates:
 
@@ -193,8 +221,8 @@ readiness; execution still fails closed through the query-port preflight.
 `IndexSourceCatalog` separately fixes one replay source for each exact schema and the
 complete schema identity across versions. Materialization requires the corresponding
 owner-published schema and exact owner match. The application replay boundary remains
-database independent; PostgreSQL mutation, job, and checkpoint adapters are composed
-outside it.
+database independent; PostgreSQL mutation, job, checkpoint, runner, and host runtime
+adapters are composed outside it.
 
 ## Current entry points
 
@@ -209,6 +237,12 @@ outside it.
   `IndexReplayJobLease`, and `IndexReplayJobAcquireOutcome`
 - `PostgresIndexReplayCheckpointStore`, `IndexReplayWorker`,
   `IndexReplayCheckpoint`, and `IndexReplayPageOutcome`
+- `PostgresIndexReplayRunner`, `IndexReplayRunRequest`, `IndexReplayRunOutcome`,
+  `IndexReplayCancelOutcome`, and `IndexReplayRunError`
+- `SharedIndexReplayRuntime`, `materialize_postgres_index_replay_runtime`, and
+  `IndexReplayRuntimeCompositionError`
+- server-owned `IndexReplayOperatorRuntime`, `IndexReplayOperatorContext`, and
+  `IndexReplayOperatorError`
 - `IndexSource`, `IndexSourceCatalog`, `SharedIndexSourceRegistry`,
   `IndexSourceScanRequest`, and `IndexSourceLoadRequest`
 - `SecondaryIndexPlan`, `SecondaryIndexSpec`, `SecondaryIndexRequest`,
@@ -268,8 +302,12 @@ outside it.
   duplicate-safe replay after checkpoint failure;
 - durable schema-scoped rebuild exclusion, lease heartbeat, expired-attempt reclaim,
   attempt fencing, stale checkpoint-writer rejection, and null-cursor-gated success;
+- bounded multi-page execution, immediate resume, durable cancellation, and
+  cancellation-first terminal ordering;
 - one Index-owned PostgreSQL query-runtime constructor and neutral capability transfer
-  into `HostRuntimeContext`.
+  into `HostRuntimeContext`;
+- one Index-owned replay-runtime constructor plus a server-owned request-bound
+  `modules:manage` operator guard, with no startup SQL or background task.
 
 ## M2 benchmark
 
@@ -290,6 +328,8 @@ DDL remains benchmark-only and must not be copied into production migrations.
 - [Live implementation plan](./docs/implementation-plan.md)
 - [M5/M6 bounded source replay contract](./docs/m5-m6-source-replay-contract.md)
 - [M6 replay job lease and fencing boundary](./docs/m6-replay-job-leases.md)
+- [M6 bounded multi-page replay runner](./docs/m6-bounded-multipage-runner.md)
+- [M6 replay runtime host composition](./docs/m6-replay-runtime-composition.md)
 - [M4 source-owned schema registry](./docs/m4-source-schema-registry.md)
 - [M4 query runtime composition](./docs/m4-query-runtime-composition.md)
 - [M4 PostgreSQL query port contract](./docs/m4-postgres-query-port.md)

--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -7,7 +7,7 @@ queries without runtime fan-out.
 
 ## Purpose
 
-- publish canonical schema, mutation, query, source, replay, and rebuild contracts;
+- publish canonical schema, mutation, query, source, replay, rebuild, and operator contracts;
 - keep ingestion, storage, planning, rebuild, checkpoint, and consistency semantics
   inside the module;
 - provide server, storefront, admin, and `rustok-search` with a stable substrate for
@@ -25,8 +25,9 @@ queries without runtime fan-out.
 - versioned keyset cursors;
 - incremental ingestion and inbox deduplication;
 - bounded source scans and targeted loads;
-- one-page replay mutation/checkpoint progression;
-- durable schema-scoped replay jobs, lease/heartbeat, and attempt fencing;
+- one-page and bounded multi-page replay progression;
+- durable schema-scoped replay jobs, lease/heartbeat, attempt fencing, and cancellation;
+- host-published replay runtime and request-bound operator guard;
 - PostgreSQL storage and distributed coordination;
 - schema application and secondary-index lifecycle;
 - measured partition admission and shadow planning;
@@ -44,7 +45,9 @@ queries without runtime fan-out.
 - source-module table reads from Index core;
 - source-owned writes to Index storage, job, or checkpoint tables;
 - source-specific Product, Content, or Flex logic in the engine;
-- a production scheduler or unbounded replay loop in the current M6 slice;
+- a production scheduler, automatic retry/dead-letter loop, or unbounded replay loop
+  in the current M6 slice;
+- transport command authorization beyond the server-owned operator capability;
 - destructive partition cutover without retained PostgreSQL evidence.
 
 ## Integration
@@ -55,6 +58,9 @@ queries without runtime fan-out.
   identities;
 - `IndexModule` contributes canonical production migrations through platform migration
   composition;
+- `rustok-distribution` materializes the immutable shared schema registry;
+- the server freezes the complete source registry, publishes query/replay capabilities,
+  and wraps replay invocation in an exact request-bound operator guard;
 - server, storefront, admin, and `rustok-search` consume stable Index ports rather than
   reading Index tables directly;
 - benchmark DDL and evidence remain isolated under `ops/benches` and never become
@@ -197,7 +203,7 @@ completed cursor.
 - returns `Busy` for an active owner;
 - heartbeats only the exact unexpired worker/attempt;
 - reclaims an expired running attempt with incremented `attempt_count`;
-- rejects stale heartbeat, failure, and success;
+- rejects stale heartbeat, failure, success, and cancellation publication;
 - requires an exact durable null-cursor checkpoint before terminal success.
 
 `PostgresIndexReplayCheckpointStore` is constructed from an acquired
@@ -206,22 +212,31 @@ completed cursor.
 the database transaction. After reclaim, the old worker cannot advance the durable
 cursor.
 
-Still open:
+`PostgresIndexReplayRunner` executes a validated page budget of at most 1024 pages,
+resolves the exact source from `SharedIndexSourceRegistry`, heartbeats only between
+pages, returns unfinished work to immediately claimable pending state, and aggregates
+mutation outcomes. Durable cancellation terminalizes pending jobs immediately, marks
+running jobs for observation before/after pages, survives reclaim, and wins over
+success/failure/yield when committed first.
 
-- direct server-composition binding between job requests and the materialized replay
-  source registry;
-- bounded multi-page execution with heartbeat cadence and graceful lease loss;
-- cancellation, resume commands, dry-run, targeted/full/shadow modes;
-- retry/backoff/dead-letter scheduling and global scheduler ownership;
-- locale/partition replay dimensions;
-- Product and later source adapters;
-- retained crash/reclaim/restart and multi-instance PostgreSQL evidence;
-- reconciliation and drift repair.
+The server materializes `SharedIndexSourceRegistry` only after all selected modules
+finish registration. `materialize_postgres_index_replay_runtime` then requires both
+immutable source and schema registries and publishes `SharedIndexReplayRuntime`.
+`IndexReplayOperatorRuntime` is the server-owned invocation boundary: it requires an
+exact request-bound tenant/actor permission snapshot, requires `modules:manage`, rejects
+cross-tenant run requests, and derives cancellation tenant only from the authorized
+context.
+
+Composition performs no SQL and starts no task. Transport adapters must not call the raw
+shared replay runtime directly. Host scheduling, graceful task shutdown, authorized
+GraphQL/HTTP/CLI commands, retry/backoff/dead-letter policy, in-page interruption,
+locale/partition replay dimensions, Product and later source adapters, retained
+crash/reclaim/restart evidence, reconciliation, and drift repair remain open.
 
 ## Status
 
 - Rewrite: `in_progress`
-- Current milestone: `M6 - fenced replay job ownership`
+- Current milestone: `M6 - replay runtime host composition and operator guard`
 - FFA: `in_progress`
 - FBA: `in_progress`
 - M0 code reset: `complete`
@@ -240,7 +255,9 @@ Still open:
 - M5/M6 bounded source replay contract: `source_complete`
 - M6 one-page replay/checkpoint progression: `source_complete`
 - M6 job leases and checkpoint attempt fencing: `source_complete_owner_execution_pending`
-- M6 multi-page runner/cancellation/retry scheduling: `open`
+- M6 bounded multi-page replay and cancellation: `source_complete_owner_execution_pending`
+- M6 replay runtime host composition and operator guard: `source_complete_owner_execution_pending`
+- M6 scheduler, graceful shutdown, retry/DLQ, commands, and source adapters: `open`
 - Production consumer and partition lifecycle cutover: `forbidden_pending_evidence`
 
 ## Verification
@@ -255,9 +272,14 @@ The repository owner runs checks and database evidence during this rewrite:
 - `cargo test -p rustok-index source_registry --lib -- --nocapture`
 - `cargo test -p rustok-index source_replay --lib -- --nocapture`
 - `cargo test -p rustok-index source_replay_job --lib -- --nocapture`
+- `cargo test -p rustok-index source_replay_runner --lib -- --nocapture`
+- `cargo test -p rustok-index replay_runtime --lib -- --nocapture`
+- `cargo test -p rustok-server index_replay_runtime_composition -- --nocapture`
 - `node scripts/verify/verify-index-query-contract.mjs`
 - `node scripts/verify/verify-index-source-replay-contract.mjs`
 - `node scripts/verify/verify-index-replay-job-leases.mjs`
+- `node scripts/verify/verify-index-replay-multipage-runner.mjs`
+- `node scripts/verify/verify-index-replay-runtime-composition.mjs`
 - `node scripts/verify/index-storage-tooling.mjs contract`
 - `node scripts/verify/index-storage-tooling.mjs fixtures`
 - `npm run verify:index:fba`
@@ -269,6 +291,8 @@ The repository owner runs checks and database evidence during this rewrite:
 - [Live implementation plan](./implementation-plan.md)
 - [M5/M6 bounded source replay contract](./m5-m6-source-replay-contract.md)
 - [M6 replay job lease and fencing boundary](./m6-replay-job-leases.md)
+- [M6 bounded multi-page replay runner](./m6-bounded-multipage-runner.md)
+- [M6 replay runtime host composition](./m6-replay-runtime-composition.md)
 - [M4 source-owned schema registry](./m4-source-schema-registry.md)
 - [M4 query runtime composition](./m4-query-runtime-composition.md)
 - [M4 PostgreSQL query port](./m4-postgres-query-port.md)
@@ -276,6 +300,7 @@ The repository owner runs checks and database evidence during this rewrite:
 - [M2 storage benchmark contract](./storage-benchmark.md)
 - [M2 storage evidence comparison](./storage-comparison.md)
 - [M2 storage operational review](./storage-operational-review.md)
+- [M2 replacement evidence runbook](./storage-evidence-runbook.md)
 - [M3 partition evidence runbook](./partition-evidence-runbook.md)
 - [Index Engine rewrite ADR](../../../DECISIONS/2026-07-23-index-engine-rewrite.md)
 - [Accepted storage ADR](../../../DECISIONS/2026-07-24-index-storage-layout.md)

--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -26,7 +26,7 @@ pull requests record checks and PostgreSQL runs that were not executed.
 ## Current state
 
 - Rewrite status: `in_progress`
-- Current milestone: `M6 - bounded multi-page replay cancellation (source complete; in-page interruption, scheduling, and retained evidence open)`
+- Current milestone: `M6 - replay runtime host composition and operator guard (source complete; scheduler, graceful shutdown, command transport, and retained evidence open)`
 - FFA status: `in_progress`
 - FBA status: `in_progress`
 - M0 code reset: `complete`
@@ -67,6 +67,7 @@ pull requests record checks and PostgreSQL runs that were not executed.
 - M6 one-page replay and durable checkpoint progression: `source_complete`
 - M6 replay job leases and checkpoint attempt fencing: `source_complete_owner_execution_pending`
 - M6 bounded multi-page replay and cancellation: `source_complete_owner_execution_pending`
+- M6 replay runtime host composition and operator guard: `source_complete_owner_execution_pending`
 - Production persistence: mutation writes, schema/index coordination, fail-closed
   partition admission, snapshot/query/mutation/maintenance/cutover evidence tooling,
   full-capture orchestration, exact-byte packet assembly, retained bundle review,
@@ -81,10 +82,12 @@ pull requests record checks and PostgreSQL runs that were not executed.
   bounded source replay/load contracts, one-page replay mutation application, durable
   rebuild checkpoint progression, schema-scoped rebuild job claims, lease/heartbeat,
   attempt fencing, fenced checkpoint writes, bounded multi-page execution, immediate
-  pending resume, durable cancellation requests, and fenced between-page terminal
-  cancellation are implemented; one retained admitted packet, live PostgreSQL/reference
-  equivalence, in-page interruption, retry/backoff, dead-letter scheduling, host
-  scheduling, freshness/recovery evidence, authoritative consumer cutover, and
+  pending resume, durable cancellation requests, fenced between-page terminal
+  cancellation, immutable source-registry host materialization, shared replay-runtime
+  publication, and request-bound operator authorization are implemented; one retained
+  admitted packet, live PostgreSQL/reference equivalence, in-page interruption,
+  retry/backoff, dead-letter scheduling, host scheduling, graceful task shutdown,
+  command transport, freshness/recovery evidence, authoritative consumer cutover, and
   production partition lifecycle remain open
 
 The production crate contains the generic domain/application core, seven canonical
@@ -100,10 +103,11 @@ nested identities/values, lookahead pagination, and scoped cursor construction,
 repeatable-read page/count snapshot, source-owned schema and replay catalogs, a
 neutral bounded `IndexSource` scan/load boundary, a one-page replay executor,
 `PostgresIndexReplayJobStore` for durable fenced schema-scoped rebuild ownership,
-a lease-bound PostgreSQL rebuild-checkpoint adapter, and
-`PostgresIndexReplayRunner` for bounded heartbeat/yield/cancellation execution.
-Owner-operated evidence tools live under `ops/benches`; they do not become runtime
-storage code.
+a lease-bound PostgreSQL rebuild-checkpoint adapter, `PostgresIndexReplayRunner` for
+bounded heartbeat/yield/cancellation execution, and `SharedIndexReplayRuntime` for
+host capability transfer. The server publishes `IndexReplayOperatorRuntime` as the
+request-bound authorization boundary. Owner-operated evidence tools live under
+`ops/benches`; they do not become runtime storage code.
 
 ## Ownership
 
@@ -147,11 +151,15 @@ crates/rustok-index/src/
     source_replay.rs
     source_replay_job.rs
     source_replay_runner.rs
+    replay_runtime.rs
     schema_lease.rs
     secondary_index.rs
     partition_admission.rs
     query_port.rs
   api/
+
+apps/server/src/services/
+  index_replay_runtime_composition.rs
 
 ops/benches/src/index_storage/
   runner.rs
@@ -446,29 +454,43 @@ database, or transport causes stay in owner logs.
       and require a durable null-cursor checkpoint before terminal success.
 - [x] Add bounded multi-page execution with heartbeat cadence and immediate pending resume.
 - [x] Add durable cancellation requests and fenced between-page terminal cancellation.
-- [ ] Bind job requests directly to the materialized source registry in server composition.
+- [x] Bind job requests directly to the materialized source registry in server composition.
 - [ ] Add in-page interruption/timeouts, dry-run, and targeted/full/shadow rebuild modes.
 - [ ] Add bounded retry/backoff, dead-letter state, and global scheduling ownership.
 - [ ] Add locale/partition replay checkpoint dimensions.
 - [ ] Add reconciliation and drift repair.
-- [ ] Cover crash, lease expiry, restart, cancellation, and incremental/full
+- [ ] Cover crash, lease expiry, restart, cancellation, authorization, and incremental/full
       equivalence with retained PostgreSQL evidence.
 
 The one-page executor, replay job store, checkpoint adapter, bounded multi-page runner,
-and cancellation path are source complete. `PostgresIndexReplayJobStore` serializes one
-tenant/schema claim, validates the exact `index_replay_job_v1` request and active persisted
-schema, reclaims expired attempts with an incremented fence, and rejects stale heartbeat or
-terminal updates. `PostgresIndexReplayCheckpointStore` is constructed from the acquired
-lease; it locks and validates that exact attempt before every checkpoint read or write.
+cancellation path, and host composition are source complete. `PostgresIndexReplayJobStore`
+serializes one tenant/schema claim, validates the exact `index_replay_job_v1` request and
+active persisted schema, reclaims expired attempts with an incremented fence, and rejects
+stale heartbeat or terminal updates. `PostgresIndexReplayCheckpointStore` is constructed
+from the acquired lease; it locks and validates that exact attempt before every checkpoint
+read or write.
+
 `PostgresIndexReplayRunner` resolves the source from the materialized registry, executes at
 most 1024 pages, heartbeats between pages, completes only after a durable JSON null cursor,
 and returns unfinished work to immediately claimable `pending` state while preserving the
 same job UUID and checkpoint. `request_cancel` terminalizes pending jobs immediately and
-marks running jobs for observation before/after pages; success, failure, and yield all require
-`cancel_requested = FALSE`, so cancellation committed first cannot be overwritten. A running
-cancel request survives reclaim and is terminalized by the next fenced attempt before source
-access. In-page interruption, automatic retry/backoff, dead-letter scheduling, host scheduling,
-and retained multi-instance PostgreSQL evidence remain open.
+marks running jobs for observation before/after pages; success, failure, and yield all
+require `cancel_requested = FALSE`, so cancellation committed first cannot be overwritten.
+A running cancel request survives reclaim and is terminalized by the next fenced attempt
+before source access.
+
+The server materializes `SharedIndexSourceRegistry` only after all selected modules have
+registered their source-owned schema and replay contracts. The Index-owned
+`materialize_postgres_index_replay_runtime` requires both immutable registries, performs no
+SQL, starts no task, and publishes only bounded `run` and `request_cancel` through
+`SharedIndexReplayRuntime`.
+
+`IndexReplayOperatorRuntime` requires an exact request-bound tenant/actor permission snapshot,
+requires `modules:manage`, rejects cross-tenant run requests before delegation, and derives
+cancel tenant scope only from the authorized context. GraphQL, HTTP, CLI, and admin transports
+must not call the raw replay runtime directly. In-page interruption, automatic retry/backoff,
+dead-letter scheduling, host scheduling, graceful task shutdown, command/audit transports,
+production source adapters, and retained multi-instance PostgreSQL evidence remain open.
 
 ### M7 - First vertical slice
 
@@ -525,6 +547,8 @@ cargo test -p rustok-index source_registry --lib -- --nocapture
 cargo test -p rustok-index source_replay --lib -- --nocapture
 cargo test -p rustok-index source_replay_job --lib -- --nocapture
 cargo test -p rustok-index source_replay_runner --lib -- --nocapture
+cargo test -p rustok-index replay_runtime --lib -- --nocapture
+cargo test -p rustok-server index_replay_runtime_composition -- --nocapture
 cargo xtask module validate index
 cargo xtask module test index
 npm run verify:index:fba
@@ -569,6 +593,7 @@ node scripts/verify/verify-index-many-link-filtering.mjs
 node scripts/verify/verify-index-source-replay-contract.mjs
 node scripts/verify/verify-index-replay-job-leases.mjs
 node scripts/verify/verify-index-replay-multipage-runner.mjs
+node scripts/verify/verify-index-replay-runtime-composition.mjs
 ```
 
 ## Progress log
@@ -620,8 +645,13 @@ node scripts/verify/verify-index-replay-multipage-runner.mjs
 - 2026-07-30: added durable pending/running cancellation requests, typed terminal and
   not-found outcomes, cancellation observation before/after bounded pages, cancellation
   persistence across reclaim, and cancel-first fenced success/failure/yield transitions.
+- 2026-07-30: materialized the immutable source registry in server composition, added
+  `SharedIndexReplayRuntime`, transferred it through the typed host seam, and published
+  `IndexReplayOperatorRuntime` with exact request-bound tenant/actor scope and
+  `modules:manage`. Composition performs no SQL and starts no task.
 - Repository test/fixture suites, verifiers, in-page interruption, automatic retry/backoff,
-  dead-letter and host scheduling, live freshness/recovery evidence, one admitted
+  dead-letter and host scheduling, graceful task shutdown, authorized command transports,
+  production source adapters, live freshness/recovery evidence, one admitted
   PostgreSQL/reference equivalence bundle, and one real full PostgreSQL partition packet
   remain for the owner to execute and admit before authoritative consumer or production
   partition cutover.
@@ -631,10 +661,10 @@ node scripts/verify/verify-index-replay-multipage-runner.mjs
 - Cycle: `cycle-001`
 - Status: `blocked`
 - Last verified at (UTC): `2026-07-30`
-- Scope inspected: `Index ownership, migrations, mutation/version ordering, query execution, partition evidence guards, Social Graph consumer authority, privacy shadow deadline behavior, source replay ownership, replay checkpoint ordering, replay job attempt fencing, bounded multi-page replay progression, cancellation ordering, and source/search/server boundaries`
+- Scope inspected: `Index ownership, migrations, mutation/version ordering, query execution, partition evidence guards, Social Graph consumer authority, privacy shadow deadline behavior, source replay ownership, replay checkpoint ordering, replay job attempt fencing, bounded multi-page replay progression, cancellation ordering, host replay composition, operator authorization, and source/search/server boundaries`
 - Findings: `P0=0, P1=2, P2=0, P3=1`
-- Fixed in this pass: `bounded the non-authoritative Social Graph privacy comparison by the remaining caller deadline while preserving the owner result; repaired stale Index scale/FBA and retained-artifact guards; added a canonical bounded source replay/load registry; added one-page replay mutation application with stable event checks and checkpoint progression only after durable mutation outcomes; added schema-scoped rebuild job claims with lease/heartbeat, expired-attempt reclaim, attempt fencing, fenced checkpoint access, durable null-cursor-gated success, bounded multi-page execution with between-page heartbeat and immediate pending resume, and durable cancel-first terminalization`
-- Remaining risks or blockers: `one retained admitted real PostgreSQL partition packet is absent; live PostgreSQL/reference query equivalence remains open; in-page interruption, automatic retry/backoff, dead-letter scheduling, host scheduling, locale/partition checkpoint dimensions, and production source adapters remain absent; no retained per-tenant freshness/watermark, lag, negative-result safety, outage/restart/backlog catch-up, cancellation, or replay-repair evidence exists; consumer and production partition cutover remain forbidden`
-- Evidence: `PR #2544 merged as b647a5a17f27b34a07c20cd57525ed1806994c49; PR #2554 merged as 5b9d49e65295819ee9e8e9c199688c0e2ac73d35; PR #2576 merged as aef96f57d3babc2efdc65cc0c57cfea6fb48b5ad; same-SHA Index Storage Scale Run Contract and full Scale Evidence contract passed JavaScript syntax, workflow contracts, repository contracts, direct validator arguments and fixture suites; source replay registry, one-page checkpoint progression, replay job fencing, bounded multi-page runner, and cancellation source are present without implementation-agent test execution; general CI/Hardening received no jobs; Rust-hosted smoke previously stopped before compilation because Cargo.lock required an Athanor update under --locked`
-- Next action: `bind the replay runner into host/server composition with explicit operator authorization and graceful shutdown ownership, then add the first Product source adapter before executing retained PostgreSQL packet, live query equivalence, and per-tenant freshness/outage/recovery evidence`
-- Resume command: `cargo fmt --all -- --check && cargo check -p rustok-index --all-targets && node scripts/verify/verify-index-query-contract.mjs && node scripts/verify/index-storage-tooling.mjs contract && node scripts/verify/index-storage-tooling.mjs fixtures`
+- Fixed in this pass: `bounded the non-authoritative Social Graph privacy comparison by the remaining caller deadline while preserving the owner result; repaired stale Index scale/FBA and retained-artifact guards; added a canonical bounded source replay/load registry; added one-page replay mutation application with stable event checks and checkpoint progression only after durable mutation outcomes; added schema-scoped rebuild job claims with lease/heartbeat, expired-attempt reclaim, attempt fencing, fenced checkpoint access, durable null-cursor-gated success, bounded multi-page execution with between-page heartbeat and immediate pending resume, durable cancel-first terminalization, immutable source-registry host materialization, one shared replay runtime, and a request-bound modules:manage operator guard`
+- Remaining risks or blockers: `one retained admitted real PostgreSQL partition packet is absent; live PostgreSQL/reference query equivalence remains open; in-page interruption, automatic retry/backoff, dead-letter scheduling, host scheduling, graceful task shutdown, authorized command transports, locale/partition checkpoint dimensions, and production source adapters remain absent; no retained per-tenant freshness/watermark, lag, negative-result safety, outage/restart/backlog catch-up, cancellation, authorization, or replay-repair evidence exists; consumer and production partition cutover remain forbidden`
+- Evidence: `PR #2544 merged as b647a5a17f27b34a07c20cd57525ed1806994c49; PR #2554 merged as 5b9d49e65295819ee9e8e9c199688c0e2ac73d35; PR #2576 merged as aef96f57d3babc2efdc65cc0c57cfea6fb48b5ad; PR #2578 merged as 9d725de7bac2039c86d5b5dffdf5d6be1b4812a8; same-SHA Index Storage Scale Run Contract and full Scale Evidence contract passed JavaScript syntax, workflow contracts, repository contracts, direct validator arguments and fixture suites; source replay registry, one-page checkpoint progression, replay job fencing, bounded multi-page runner, cancellation, shared replay runtime, and operator guard source are present without implementation-agent test execution; general CI/Hardening received no jobs; Rust-hosted smoke previously stopped before compilation because Cargo.lock required an Athanor update under --locked`
+- Next action: `add the first Product-owned schema/source adapter and bounded rebuild command surface, then implement scheduler/retry/shutdown ownership only after the source and operator command contracts are fixed; execute retained PostgreSQL packet, live query equivalence, and per-tenant freshness/outage/recovery evidence before authoritative cutover`
+- Resume command: `cargo fmt --all -- --check && cargo check -p rustok-index --all-targets && cargo check -p rustok-server --all-targets && node scripts/verify/verify-index-query-contract.mjs && node scripts/verify/index-storage-tooling.mjs contract && node scripts/verify/index-storage-tooling.mjs fixtures`

--- a/crates/rustok-index/docs/m6-replay-runtime-composition.md
+++ b/crates/rustok-index/docs/m6-replay-runtime-composition.md
@@ -1,0 +1,76 @@
+# M6 replay runtime host composition
+
+Status: `source_complete_owner_execution_pending`
+
+This slice publishes the bounded replay runner through the existing typed runtime-extension seam.
+It does not add a scheduler, background task, command transport, automatic retry, or source adapter.
+
+## Composition order
+
+The executable server composes replay only after all selected modules have registered their generic
+Index contracts:
+
+1. `rustok-distribution` builds module-owned `IndexSchemaSourceCatalog` and
+   `IndexSourceCatalog` contributions and materializes `SharedIndexSchemaRegistry`;
+2. the server materializes `SharedIndexSourceRegistry` from the complete source catalog and exact
+   schema-owner catalog;
+3. `materialize_postgres_index_replay_runtime` requires both immutable registries, binds them to the
+   host `DatabaseConnection`, and publishes `SharedIndexReplayRuntime`;
+4. the server wraps that infrastructure capability in `IndexReplayOperatorRuntime` before any
+   transport may run or cancel rebuild work;
+5. all typed values transfer through `ModuleRuntimeExtensions` and `HostRuntimeContext`.
+
+An absent or empty source catalog is valid and publishes neither source registry nor replay runtime.
+A source registry without a shared schema registry fails closed. Duplicate source, replay, or
+operator runtime materialization also fails startup.
+
+Composition performs no SQL and starts no task. Runtime presence therefore does not claim a
+supported production backend, persisted tenant schema readiness, source health, successful replay,
+or retained PostgreSQL evidence.
+
+## Operator authorization boundary
+
+`IndexReplayOperatorRuntime` is the server-owned invocation boundary. Every call requires an
+`IndexReplayOperatorContext` containing one non-nil tenant and actor. Before delegating to Index it:
+
+- requires a request-bound effective RBAC permission snapshot for that exact tenant/actor;
+- requires `modules:manage`;
+- rejects a run request whose tenant differs from the authorized operator tenant;
+- derives cancellation tenant scope only from the authorized context;
+- exposes only bounded `run` and `request_cancel` operations.
+
+Transport adapters must not retrieve or call `SharedIndexReplayRuntime` directly. Authentication,
+command input decoding, audit/event publication, and stable HTTP/GraphQL/CLI error mapping remain
+transport-owned later slices.
+
+## Task and shutdown boundary
+
+Neither materializer calls `tokio::spawn`, sleeps, loops, polls, or owns a stop handle. One explicit
+operator invocation runs at most the request's bounded page budget and returns. Graceful shutdown
+and task ownership remain open together with the future global scheduler; this source-complete host
+composition does not falsely claim them.
+
+## Still open
+
+- authorized GraphQL, HTTP, CLI, or admin command surfaces;
+- host scheduler, bounded retry/backoff, dead-letter state, and stop-handle ownership;
+- in-page source timeout/interruption;
+- dry-run and targeted/full/shadow modes;
+- locale/partition checkpoint dimensions;
+- Product and later production source adapters;
+- retained PostgreSQL authorization, cancellation, restart, and multi-instance evidence.
+
+## Owner validation
+
+```bash
+node scripts/verify/verify-index-replay-runtime-composition.mjs
+node scripts/verify/verify-index-replay-multipage-runner.mjs
+node scripts/verify/verify-index-replay-job-leases.mjs
+node scripts/verify/verify-index-query-contract.mjs
+cargo check -p rustok-index --all-targets
+cargo check -p rustok-server --all-targets
+cargo test -p rustok-index replay_runtime --lib -- --nocapture
+cargo test -p rustok-server index_replay_runtime_composition -- --nocapture
+```
+
+These commands are maintainer-run for this slice and were not executed by the implementation agent.

--- a/crates/rustok-index/src/infrastructure/postgres/mod.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/mod.rs
@@ -2,6 +2,7 @@ mod mutation_store;
 mod partition_admission;
 mod query_port;
 mod query_runtime;
+mod replay_runtime;
 mod schema_lease;
 mod schema_registration;
 mod secondary_index;
@@ -38,6 +39,10 @@ pub use partition_admission::{
 pub use query_port::PostgresIndexQueryPort;
 pub use query_runtime::{
     IndexQueryRuntimeCompositionError, materialize_postgres_index_query_runtime,
+};
+pub use replay_runtime::{
+    IndexReplayRuntimeCompositionError, SharedIndexReplayRuntime,
+    materialize_postgres_index_replay_runtime,
 };
 pub use schema_lease::{
     PostgresSchemaLeaseStore, SchemaApplicationLease, SchemaApplicationLeaseRequest,

--- a/crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs
@@ -1,0 +1,246 @@
+use std::{fmt, sync::Arc};
+
+use rustok_core::ModuleRuntimeExtensions;
+use sea_orm::DatabaseConnection;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::{
+    IndexReplayCancelOutcome, IndexReplayRunError, IndexReplayRunOutcome, IndexReplayRunRequest,
+    SharedIndexSchemaRegistry, SharedIndexSourceRegistry,
+};
+
+use super::PostgresIndexReplayRunner;
+
+/// Cloneable operator capability for bounded Index replay execution.
+///
+/// Construction is Index-owned so executable hosts publish one canonical runner assembled from
+/// the complete immutable schema/source registries. Consumers receive only bounded run and cancel
+/// operations; the database connection and registry internals remain private.
+#[derive(Clone)]
+pub struct SharedIndexReplayRuntime {
+    runner: Arc<PostgresIndexReplayRunner>,
+}
+
+impl SharedIndexReplayRuntime {
+    fn new(runner: PostgresIndexReplayRunner) -> Self {
+        Self {
+            runner: Arc::new(runner),
+        }
+    }
+
+    pub async fn run(
+        &self,
+        request: IndexReplayRunRequest,
+    ) -> Result<IndexReplayRunOutcome, IndexReplayRunError> {
+        self.runner.run(request).await
+    }
+
+    pub async fn request_cancel(
+        &self,
+        tenant_id: Uuid,
+        job_id: Uuid,
+    ) -> Result<IndexReplayCancelOutcome, IndexReplayRunError> {
+        self.runner.request_cancel(tenant_id, job_id).await
+    }
+}
+
+impl fmt::Debug for SharedIndexReplayRuntime {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SharedIndexReplayRuntime")
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum IndexReplayRuntimeCompositionError {
+    #[error("shared Index replay runtime is already materialized")]
+    AlreadyMaterialized,
+    #[error("shared Index source registry exists without the shared schema registry")]
+    MissingSchemaRegistry,
+}
+
+/// Materializes the canonical PostgreSQL-backed replay runtime from immutable source registries.
+///
+/// An absent source registry returns `Ok(None)` and never publishes a false replay capability.
+/// The function performs no database I/O, starts no scheduler, and makes no tenant readiness or
+/// operator-authorization claim. Those checks remain at invocation and transport boundaries.
+pub fn materialize_postgres_index_replay_runtime(
+    extensions: &mut ModuleRuntimeExtensions,
+    db: DatabaseConnection,
+) -> Result<Option<SharedIndexReplayRuntime>, IndexReplayRuntimeCompositionError> {
+    if extensions.contains::<SharedIndexReplayRuntime>() {
+        return Err(IndexReplayRuntimeCompositionError::AlreadyMaterialized);
+    }
+
+    let Some(sources) = extensions.get::<SharedIndexSourceRegistry>().cloned() else {
+        return Ok(None);
+    };
+    let schemas = extensions
+        .get::<SharedIndexSchemaRegistry>()
+        .cloned()
+        .ok_or(IndexReplayRuntimeCompositionError::MissingSchemaRegistry)?;
+
+    let runtime = SharedIndexReplayRuntime::new(PostgresIndexReplayRunner::new(
+        db,
+        sources,
+        schemas.shared(),
+    ));
+    extensions.insert(runtime.clone());
+    Ok(Some(runtime))
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use rustok_core::ModuleRuntimeExtensions;
+    use sea_orm::Database;
+
+    use crate::{
+        EntityName, FieldCardinality, FieldName, IndexField, IndexSchema, IndexSource,
+        IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest, IndexSourcePage,
+        IndexSourceScanRequest, IndexValueType, LocaleMode, ModuleName, SchemaRef, SchemaVersion,
+        SharedIndexReplayRuntime, materialize_index_schema_registry,
+        materialize_index_source_registry, register_index_schema_source, register_index_source,
+    };
+
+    use super::{
+        IndexReplayRuntimeCompositionError, materialize_postgres_index_replay_runtime,
+    };
+
+    struct NoopSource;
+
+    #[async_trait]
+    impl IndexSource for NoopSource {
+        async fn scan(
+            &self,
+            request: IndexSourceScanRequest,
+        ) -> Result<IndexSourcePage, IndexSourceFailure> {
+            Ok(IndexSourcePage::new(&request, Vec::new(), None)
+                .expect("empty final replay page should be valid"))
+        }
+
+        async fn load(
+            &self,
+            request: IndexSourceLoadRequest,
+        ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+            Ok(IndexSourceLoadBatch::new(&request, Vec::new())
+                .expect("empty targeted load should be valid"))
+        }
+    }
+
+    fn schema() -> IndexSchema {
+        IndexSchema {
+            reference: SchemaRef {
+                module: ModuleName::new("runtime-owner").unwrap(),
+                entity: EntityName::new("item").unwrap(),
+                version: SchemaVersion::INITIAL,
+            },
+            locale_mode: LocaleMode::None,
+            fields: vec![IndexField {
+                name: FieldName::new("id").unwrap(),
+                value_type: IndexValueType::Uuid,
+                cardinality: FieldCardinality::One,
+                nullable: false,
+                selectable: true,
+                filterable: true,
+                sortable: true,
+            }],
+            links: Vec::new(),
+        }
+    }
+
+    fn source_extensions() -> ModuleRuntimeExtensions {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        let schema = schema();
+        register_index_schema_source(&mut extensions, "runtime_owner", schema.clone()).unwrap();
+        register_index_source(
+            &mut extensions,
+            "runtime_owner",
+            "runtime-owner-primary",
+            [schema.reference],
+            NoopSource,
+        )
+        .unwrap();
+        extensions
+    }
+
+    async fn connection() -> sea_orm::DatabaseConnection {
+        Database::connect("sqlite::memory:")
+            .await
+            .expect("test connection should initialize")
+    }
+
+    #[tokio::test]
+    async fn missing_source_registry_does_not_publish_false_replay_runtime() {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        register_index_schema_source(&mut extensions, "runtime_owner", schema()).unwrap();
+        let schemas = materialize_index_schema_registry(&extensions)
+            .unwrap()
+            .expect("schema registry");
+        extensions.insert(schemas);
+
+        let runtime =
+            materialize_postgres_index_replay_runtime(&mut extensions, connection().await)
+                .expect("missing source registry should be accepted");
+        assert!(runtime.is_none());
+        assert!(!extensions.contains::<SharedIndexReplayRuntime>());
+    }
+
+    #[tokio::test]
+    async fn source_registry_without_shared_schema_registry_fails_closed() {
+        let mut extensions = source_extensions();
+        let sources = materialize_index_source_registry(&extensions)
+            .unwrap()
+            .expect("source registry");
+        extensions.insert(sources);
+
+        let error = materialize_postgres_index_replay_runtime(&mut extensions, connection().await)
+            .expect_err("partial replay composition must fail");
+        assert_eq!(
+            error,
+            IndexReplayRuntimeCompositionError::MissingSchemaRegistry
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_registries_materialize_one_shared_replay_runtime() {
+        let mut extensions = source_extensions();
+        let schemas = materialize_index_schema_registry(&extensions)
+            .unwrap()
+            .expect("schema registry");
+        let sources = materialize_index_source_registry(&extensions)
+            .unwrap()
+            .expect("source registry");
+        extensions.insert(schemas);
+        extensions.insert(sources);
+
+        let runtime =
+            materialize_postgres_index_replay_runtime(&mut extensions, connection().await)
+                .expect("replay runtime should materialize")
+                .expect("complete registries should publish a runtime");
+        assert!(extensions.contains::<SharedIndexReplayRuntime>());
+        assert!(format!("{runtime:?}").contains("SharedIndexReplayRuntime"));
+    }
+
+    #[tokio::test]
+    async fn duplicate_replay_runtime_materialization_fails_closed() {
+        let mut extensions = source_extensions();
+        let schemas = materialize_index_schema_registry(&extensions)
+            .unwrap()
+            .expect("schema registry");
+        let sources = materialize_index_source_registry(&extensions)
+            .unwrap()
+            .expect("source registry");
+        extensions.insert(schemas);
+        extensions.insert(sources);
+        materialize_postgres_index_replay_runtime(&mut extensions, connection().await)
+            .expect("first materialization")
+            .expect("runtime");
+
+        let error = materialize_postgres_index_replay_runtime(&mut extensions, connection().await)
+            .expect_err("duplicate materialization must fail");
+        assert_eq!(error, IndexReplayRuntimeCompositionError::AlreadyMaterialized);
+    }
+}

--- a/crates/rustok-index/src/lib.rs
+++ b/crates/rustok-index/src/lib.rs
@@ -5,10 +5,10 @@
 //! storage-schema migrations, atomic mutation persistence, tenant-scoped source
 //! schema registration, bounded source replay/load contracts, one-page replay
 //! orchestration with durable fenced checkpoint progression, bounded multi-page
-//! replay coordination with heartbeat/yield/cancellation semantics, durable
-//! replay-job and schema-application leases, schema-derived secondary-index
-//! lifecycle, fail-closed measured partition admission, and the PostgreSQL
-//! execution adapter for structured Index queries.
+//! replay coordination with heartbeat/yield/cancellation semantics, host-published
+//! replay and query capabilities, durable replay-job and schema-application leases,
+//! schema-derived secondary-index lifecycle, fail-closed measured partition
+//! admission, and the PostgreSQL execution adapter for structured Index queries.
 
 use async_trait::async_trait;
 use rustok_core::{
@@ -26,9 +26,10 @@ pub use application::*;
 pub use domain::*;
 pub use infrastructure::postgres::{
     evaluate_partition_admission, materialize_postgres_index_query_runtime,
-    IndexQueryRuntimeCompositionError, IndexReplayCancelOutcome, IndexReplayJobAcquireOutcome,
-    IndexReplayJobError, IndexReplayJobLease, IndexReplayJobLeaseRequest, IndexReplayRunError,
-    IndexReplayRunOutcome, IndexReplayRunRequest, IndexReplayRunStatus,
+    materialize_postgres_index_replay_runtime, IndexQueryRuntimeCompositionError,
+    IndexReplayCancelOutcome, IndexReplayJobAcquireOutcome, IndexReplayJobError,
+    IndexReplayJobLease, IndexReplayJobLeaseRequest, IndexReplayRunError, IndexReplayRunOutcome,
+    IndexReplayRunRequest, IndexReplayRunStatus, IndexReplayRuntimeCompositionError,
     IndexReplayTerminalState, MutationApplyOutcome, MutationDelivery, MutationStorageError,
     PartitionAdmissionError, PartitionAdmissionOutcome, PartitionAdmissionPolicy,
     PartitionAdmissionReason, PartitionBaselineEvidence, PartitionEvidence,
@@ -41,6 +42,7 @@ pub use infrastructure::postgres::{
     SchemaRegistrationError, SecondaryIndexClaimOutcome, SecondaryIndexError,
     SecondaryIndexExecutionOutcome, SecondaryIndexKind, SecondaryIndexLease,
     SecondaryIndexOperation, SecondaryIndexPlan, SecondaryIndexRequest, SecondaryIndexSpec,
+    SharedIndexReplayRuntime,
 };
 
 pub struct IndexModule;

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -20,6 +20,7 @@ const scripts = [
   'verify-index-source-replay-contract.mjs',
   'verify-index-replay-job-leases.mjs',
   'verify-index-replay-multipage-runner.mjs',
+  'verify-index-replay-runtime-composition.mjs',
   'verify-index-query-runtime-composition.mjs',
   'verify-index-social-graph-privacy-consumer.mjs',
   'verify-social-graph-privacy-shadow-evidence.mjs',

--- a/scripts/verify/verify-index-replay-runtime-composition.mjs
+++ b/scripts/verify/verify-index-replay-runtime-composition.mjs
@@ -28,7 +28,7 @@ const indexRuntime = requireMarkers(indexRuntimePath, [
   'MissingSchemaRegistry',
   'pub fn materialize_postgres_index_replay_runtime(',
   'extensions.get::<SharedIndexSourceRegistry>().cloned()',
-  'extensions.get::<SharedIndexSchemaRegistry>()',
+  '.get::<SharedIndexSchemaRegistry>()',
   'return Ok(None);',
   'PostgresIndexReplayRunner::new(',
   'extensions.insert(runtime.clone())',

--- a/scripts/verify/verify-index-replay-runtime-composition.mjs
+++ b/scripts/verify/verify-index-replay-runtime-composition.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-replay-runtime-composition] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const indexRuntimePath = 'crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs';
+const indexRuntime = requireMarkers(indexRuntimePath, [
+  'pub struct SharedIndexReplayRuntime',
+  'pub async fn run(',
+  'pub async fn request_cancel(',
+  'pub enum IndexReplayRuntimeCompositionError',
+  'AlreadyMaterialized',
+  'MissingSchemaRegistry',
+  'pub fn materialize_postgres_index_replay_runtime(',
+  'extensions.get::<SharedIndexSourceRegistry>().cloned()',
+  'extensions.get::<SharedIndexSchemaRegistry>()',
+  'return Ok(None);',
+  'PostgresIndexReplayRunner::new(',
+  'extensions.insert(runtime.clone())',
+  'missing_source_registry_does_not_publish_false_replay_runtime',
+  'source_registry_without_shared_schema_registry_fails_closed',
+  'complete_registries_materialize_one_shared_replay_runtime',
+  'duplicate_replay_runtime_materialization_fails_closed',
+]);
+for (const forbidden of [
+  'tokio::spawn',
+  'tokio::time::sleep',
+  'loop {',
+  '.query_one(',
+  '.query_all(',
+  '.execute(',
+  '.begin()',
+  'permissions_for(',
+  'Permission::',
+]) {
+  if (indexRuntime.includes(forbidden)) {
+    fail(`${indexRuntimePath} contains host/IO/scheduler marker ${forbidden}`);
+  }
+}
+
+const serverRuntimePath = 'apps/server/src/services/index_replay_runtime_composition.rs';
+const serverRuntime = requireMarkers(serverRuntimePath, [
+  'pub struct IndexReplayOperatorContext',
+  'pub struct IndexReplayOperatorRuntime',
+  'pub enum IndexReplayOperatorError',
+  'Permission::MODULES_MANAGE',
+  'permissions_for(&self.tenant_id, &self.actor_id)',
+  'requested_tenant != self.tenant_id',
+  'pub async fn run(',
+  'pub async fn request_cancel(',
+  'materialize_index_source_registry(extensions)',
+  'materialize_postgres_index_replay_runtime(extensions, db)',
+  'extensions.insert(IndexReplayOperatorRuntime::new(runtime))',
+  'missing_replay_sources_do_not_publish_false_host_runtime',
+  'complete_source_catalog_publishes_guarded_runtime_to_host_context',
+  'duplicate_host_replay_materialization_fails_closed',
+  'operator_authorization_requires_exact_tenant_actor_and_modules_manage',
+  'operator_context_rejects_nil_identity',
+]);
+for (const forbidden of [
+  'tokio::spawn',
+  'tokio::time::sleep',
+  'loop {',
+  'StopHandle',
+  'runs_background_workers',
+  'rustok_product',
+  'rustok_content',
+  'rustok_flex',
+]) {
+  if (serverRuntime.includes(forbidden)) {
+    fail(`${serverRuntimePath} contains scheduler/source-domain marker ${forbidden}`);
+  }
+}
+
+const sourceMaterialization = serverRuntime.indexOf('materialize_index_source_registry(extensions)');
+const replayMaterialization = serverRuntime.indexOf(
+  'materialize_postgres_index_replay_runtime(extensions, db)',
+  sourceMaterialization,
+);
+const operatorPublication = serverRuntime.indexOf(
+  'extensions.insert(IndexReplayOperatorRuntime::new(runtime))',
+  replayMaterialization,
+);
+if (
+  sourceMaterialization < 0
+  || replayMaterialization <= sourceMaterialization
+  || operatorPublication <= replayMaterialization
+) {
+  fail('server must freeze source registry before replay runtime and guarded operator publication');
+}
+
+const servicesPath = 'apps/server/src/services/mod.rs';
+const services = requireMarkers(servicesPath, [
+  'pub mod index_replay_runtime_composition;',
+  'materialize_postgres_index_query_runtime(&mut extensions, db.clone())',
+  'index_replay_runtime_composition::materialize_index_replay_runtime(',
+  'canonical Index query and replay runtimes',
+]);
+const queryRuntime = services.indexOf(
+  'materialize_postgres_index_query_runtime(&mut extensions, db.clone())',
+);
+const replayRuntime = services.indexOf(
+  'index_replay_runtime_composition::materialize_index_replay_runtime(',
+  queryRuntime,
+);
+const optionalShadow = services.indexOf('social_graph_index_privacy_shadow_enabled()', replayRuntime);
+if (queryRuntime < 0 || replayRuntime <= queryRuntime || optionalShadow <= replayRuntime) {
+  fail('server must publish query then replay capabilities before optional Index shadows');
+}
+
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
+  'mod replay_runtime;',
+  'SharedIndexReplayRuntime',
+  'IndexReplayRuntimeCompositionError',
+  'materialize_postgres_index_replay_runtime',
+]);
+requireMarkers('crates/rustok-index/src/lib.rs', [
+  'host-published',
+  'SharedIndexReplayRuntime',
+  'IndexReplayRuntimeCompositionError',
+  'materialize_postgres_index_replay_runtime',
+]);
+requireMarkers('crates/rustok-index/docs/m6-replay-runtime-composition.md', [
+  'Status: `source_complete_owner_execution_pending`',
+  '`IndexReplayOperatorRuntime`',
+  '`modules:manage`',
+  'Composition performs no SQL and starts no task.',
+  'Transport adapters must not retrieve or call `SharedIndexReplayRuntime` directly.',
+  'Graceful shutdown and task ownership remain open',
+  'maintainer-run',
+]);
+requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
+  '- M6 replay runtime host composition and operator guard: `source_complete_owner_execution_pending`',
+  '- [x] Bind job requests directly to the materialized source registry in server composition.',
+  '`IndexReplayOperatorRuntime` requires an exact request-bound tenant/actor permission snapshot',
+  'host scheduling, graceful task shutdown,',
+]);
+requireMarkers('crates/rustok-index/CRATE_API.md', [
+  '`SharedIndexReplayRuntime`',
+  '`materialize_postgres_index_replay_runtime`',
+  '`IndexReplayOperatorRuntime`',
+  'Runtime composition performs no SQL and starts no task.',
+]);
+requireMarkers('crates/rustok-index/README.md', [
+  'M6 replay runtime host composition and operator guard: source complete',
+  '`IndexReplayOperatorRuntime`',
+  '`modules:manage`',
+]);
+requireMarkers('crates/rustok-index/docs/README.md', [
+  'M6 replay runtime host composition and operator guard: `source_complete_owner_execution_pending`',
+  '[M6 replay runtime host composition](./m6-replay-runtime-composition.md)',
+]);
+requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
+  "'verify-index-replay-runtime-composition.mjs'",
+]);
+
+console.log('[verify-index-replay-runtime-composition] OK');


### PR DESCRIPTION
## Summary

- add Index-owned `SharedIndexReplayRuntime` over the bounded PostgreSQL replay runner
- materialize it only from immutable shared schema and source registries
- return no false runtime for an absent/empty source catalog and fail closed on partial or duplicate composition
- freeze `SharedIndexSourceRegistry` in server host composition after all selected modules register replay sources
- publish replay composition after the shared query runtime and before optional Index shadows
- add server-owned `IndexReplayOperatorRuntime` with exact non-nil tenant/actor context
- require a request-bound effective RBAC snapshot and `modules:manage`
- reject cross-tenant run requests before replay/database delegation
- derive cancellation tenant scope only from the authorized operator context
- transfer the guarded capability through `ModuleRuntimeExtensions` / `HostRuntimeContext`
- add unit fixtures, a fail-closed repository guard, M6 documentation, public API updates, and the canonical plan cursor

## Ordering and ownership boundary

Runtime composition performs no SQL and starts no task. It does not claim scheduler ownership, graceful shutdown, tenant schema readiness, source availability, successful replay, or retained PostgreSQL evidence.

GraphQL, HTTP, CLI, and admin transports must consume `IndexReplayOperatorRuntime`; they must not call `SharedIndexReplayRuntime` directly. Transport authentication, command decoding, audit/event publication, and stable transport error mapping remain later slices.

## Explicitly not included

- scheduler, polling loop, stop handle, or graceful task shutdown
- automatic retry/backoff or dead-letter state
- in-page timeout/interruption
- GraphQL/HTTP/CLI/admin rebuild commands
- dry-run or targeted/full/shadow mode selection
- locale/partition checkpoint dimensions
- Product or other production replay source adapters
- retained PostgreSQL authorization, restart, or multi-instance evidence

## Validation

Not run by the implementation agent, per owner request. The repository owner will run formatting, Cargo checks/tests, JavaScript guards, fixtures, and CI.

Suggested owner commands:

```bash
node scripts/verify/verify-index-replay-runtime-composition.mjs
node scripts/verify/verify-index-replay-multipage-runner.mjs
node scripts/verify/verify-index-replay-job-leases.mjs
node scripts/verify/verify-index-query-contract.mjs
cargo check -p rustok-index --all-targets
cargo check -p rustok-server --all-targets
cargo test -p rustok-index replay_runtime --lib -- --nocapture
cargo test -p rustok-server index_replay_runtime_composition -- --nocapture
```

## Branch policy

This slice started from the merge commit of PR #2578. Eighteen parallel commits added afterward do not touch Index or server replay-composition files. Squash merge is requested, followed by branch deletion and a new branch from the then-current `main`.