### PR TITLE
feat(profiles): add event-aware public mutation facade

### DIFF
--- a/crates/rustok-forum/contracts/forum-search-profile-event-aware-mutation-api.json
+++ b/crates/rustok-forum/contracts/forum-search-profile-event-aware-mutation-api.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-23A9",
+  "status": "source_complete_execution_pending",
+  "scope": "Provide a public Profiles mutation API whose construction requires the durable event bus and route repository production profile writes through it",
+  "mutation_facade": "crates/rustok-profiles/src/mutations.rs",
+  "profiles_public_api": "crates/rustok-profiles/src/lib.rs",
+  "graphql_runtime": "crates/rustok-profiles/src/graphql/mutation.rs",
+  "cli_backfill_runtime": "crates/rustok-profiles/cli/src/lib.rs",
+  "legacy_source_gate_contract": "crates/rustok-forum/contracts/forum-search-profile-service-mutation-boundary.json",
+  "owner_note": "crates/rustok-forum/docs/forum-23a9-profile-event-aware-mutation-api.md",
+  "verifier": "scripts/verify/verify-forum-search-profile-event-aware-mutation-api.mjs",
+  "public_event_aware_methods": [
+    "upsert_profile_with_event",
+    "update_profile_handle_with_event",
+    "update_profile_content_with_event",
+    "update_profile_locale_with_event",
+    "update_profile_visibility_with_event",
+    "update_profile_media_with_event",
+    "backfill_profile_with_event"
+  ],
+  "mutation_api_boundary": {
+    "facade_is_publicly_exported": true,
+    "facade_constructor_requires_database_connection": true,
+    "facade_constructor_requires_transactional_event_bus": true,
+    "all_facade_mutations_are_event_named": true,
+    "facade_delegates_to_profiles_owned_atomic_helpers": true,
+    "graphql_self_service_uses_facade": true,
+    "graphql_self_service_actor_is_preserved": true,
+    "graphql_media_validation_precedes_facade_write": true,
+    "cli_backfill_uses_facade": true,
+    "cli_backfill_system_actor_semantics_are_preserved": true,
+    "legacy_repository_production_calls_remain_source_gated": true,
+    "compatible_free_backfill_helper_remains_event_aware": true
+  },
+  "compatibility": {
+    "legacy_profile_service_signatures_removed": false,
+    "public_backfill_helper_removed": false,
+    "graphql_schema_changed": false,
+    "forum_rest_changed": false,
+    "search_query_api_changed": false,
+    "search_document_schema_changed": false,
+    "database_migration_added": false,
+    "dependency_added": false,
+    "cargo_lock_changed": false
+  },
+  "remaining_scope": [
+    "deprecate remove or compile-time restrict legacy direct ProfileService mutation methods",
+    "define an owner-ordered profile or account deletion projection invalidation contract",
+    "replace remaining wall-clock Forum projection ordering with owner-issued monotonic revisions",
+    "add bounded category-subtree tag locale date solved kind channel group and attachment filters",
+    "add member index projections",
+    "capture maintainer-executed PostgreSQL rebuild redaction and query evidence"
+  ],
+  "verification": {
+    "execution_status": "not_run_by_implementation_agent",
+    "commands": [
+      "node scripts/verify/verify-forum-search-profile-event-aware-mutation-api.mjs",
+      "node scripts/verify/verify-forum-search-profile-service-mutation-boundary.mjs",
+      "node scripts/verify/verify-forum-search-public-author-summary.mjs",
+      "cargo check -p rustok-profiles --all-targets",
+      "cargo check -p rustok-profiles-cli --all-targets",
+      "cargo xtask module validate profiles",
+      "cargo xtask module validate forum"
+    ]
+  },
+  "non_claims": {
+    "legacy_profile_service_mutations_are_compile_time_private": true,
+    "external_downstream_crates_cannot_call_legacy_methods": true,
+    "all_profiles_owner_write_surfaces_are_event_intrinsic": true,
+    "runtime_verification_was_executed": true,
+    "account_deletion_redaction_is_complete": true,
+    "general_cross_producer_owner_revision_ordering_is_complete": true
+  },
+  "downstream_task": "FORUM-23A10"
+}

--- a/crates/rustok-forum/contracts/forum-search-profile-event-aware-mutation-api.json
+++ b/crates/rustok-forum/contracts/forum-search-profile-event-aware-mutation-api.json
@@ -5,6 +5,7 @@
   "scope": "Provide a public Profiles mutation API whose construction requires the durable event bus and route repository production profile writes through it",
   "mutation_facade": "crates/rustok-profiles/src/mutations.rs",
   "profiles_public_api": "crates/rustok-profiles/src/lib.rs",
+  "profiles_readme": "crates/rustok-profiles/README.md",
   "graphql_runtime": "crates/rustok-profiles/src/graphql/mutation.rs",
   "cli_backfill_runtime": "crates/rustok-profiles/cli/src/lib.rs",
   "legacy_source_gate_contract": "crates/rustok-forum/contracts/forum-search-profile-service-mutation-boundary.json",
@@ -30,6 +31,7 @@
     "graphql_media_validation_precedes_facade_write": true,
     "cli_backfill_uses_facade": true,
     "cli_backfill_system_actor_semantics_are_preserved": true,
+    "profiles_readme_documents_preferred_facade": true,
     "legacy_repository_production_calls_remain_source_gated": true,
     "compatible_free_backfill_helper_remains_event_aware": true
   },

--- a/crates/rustok-forum/docs/forum-23a9-profile-event-aware-mutation-api.md
+++ b/crates/rustok-forum/docs/forum-23a9-profile-event-aware-mutation-api.md
@@ -1,0 +1,91 @@
+# FORUM-23A9: event-aware Profiles mutation API
+
+Date: 2026-07-30
+
+Status: `source_complete_execution_pending`
+
+## Purpose
+
+`FORUM-23A1` through `FORUM-23A7` made the active GraphQL self-service and CLI backfill writes
+atomically publish `ProfileUpdated`. `FORUM-23A8` then added a repository source gate preventing
+production code from calling the older direct `ProfileService` mutation methods.
+
+This slice adds the stronger positive API boundary: a public `ProfileMutationService` whose
+constructor requires both a `DatabaseConnection` and a `TransactionalEventBus`. Every exposed
+mutation is explicitly event-named and delegates to the existing Profiles-owned atomic helper.
+
+The machine-readable contract is
+`crates/rustok-forum/contracts/forum-search-profile-event-aware-mutation-api.json`.
+
+## Public mutation facade
+
+`crates/rustok-profiles/src/mutations.rs` exports:
+
+- `upsert_profile_with_event`;
+- `update_profile_handle_with_event`;
+- `update_profile_content_with_event`;
+- `update_profile_locale_with_event`;
+- `update_profile_visibility_with_event`;
+- `update_profile_media_with_event`;
+- `backfill_profile_with_event`.
+
+The facade stores borrowed references to the database and durable event bus. Callers therefore
+cannot construct the preferred mutation surface without providing the outbox-capable runtime
+component. The facade does not duplicate owner logic: every method delegates to the already
+reviewed transaction that commits the profile owner rows only after the `ProfileUpdated` envelope
+has been persisted.
+
+## Runtime adoption
+
+GraphQL self-service now constructs `ProfileMutationService` from the request-scoped database and
+event bus. It still passes the authenticated human user as actor and target user. Avatar/banner
+ownership and access validation remains before the facade write, preserving the existing media
+boundary.
+
+Profiles CLI backfill constructs one facade for the command and uses its
+`backfill_profile_with_event` method. The underlying helper continues to publish with a system actor,
+recheck profile absence inside the transaction, and skip a concurrently created profile rather
+than overwriting it.
+
+The older public free `backfill_profile_with_event` helper remains exported as a compatibility
+surface. It is already event-aware and cannot perform a silent owner write.
+
+## Legacy boundary
+
+The older direct `ProfileService` mutation methods remain public for compatibility and tests. This
+slice does not claim that external downstream crates are compile-time prevented from invoking
+them. Repository production code remains protected by the `FORUM-23A8` source gate.
+
+The follow-up is to deprecate, remove, or compile-time restrict those legacy methods after callers
+have migrated to the facade. Until then, the claim is narrower: RusToK production GraphQL and CLI
+mutation entry points use the event-aware public API, while legacy bypass methods remain explicit
+debt rather than hidden risk.
+
+## Compatibility
+
+No legacy `ProfileService` signature, GraphQL schema, Forum REST contract, Search query or document
+schema, database migration, dependency, or `Cargo.lock` change is introduced.
+
+## Remaining FORUM-23 scope
+
+- deprecate, remove, or compile-time restrict legacy direct `ProfileService` mutations;
+- define owner-ordered profile or account deletion invalidation;
+- replace remaining Forum wall-clock ordering with owner-issued monotonic revisions;
+- add the remaining bounded filters and member projections;
+- capture maintainer-executed PostgreSQL rebuild, redaction, and query evidence.
+
+## Maintainer verification
+
+Not run by the implementation agent, per maintainer instruction.
+
+Suggested commands:
+
+```bash
+node scripts/verify/verify-forum-search-profile-event-aware-mutation-api.mjs
+node scripts/verify/verify-forum-search-profile-service-mutation-boundary.mjs
+node scripts/verify/verify-forum-search-public-author-summary.mjs
+cargo check -p rustok-profiles --all-targets
+cargo check -p rustok-profiles-cli --all-targets
+cargo xtask module validate profiles
+cargo xtask module validate forum
+```

--- a/crates/rustok-profiles/README.md
+++ b/crates/rustok-profiles/README.md
@@ -17,10 +17,11 @@
 - Consume Media-selected direct or immutable capability image descriptors without inventing storage or proxy URLs.
 - Publish `ProfileMediaPublicImageProvider` as the transport-neutral runtime seam for embedded or extracted Media presentation providers.
 - Provide explicit backfill helpers for provisioning missing profiles from existing user/customer data.
+- Expose `ProfileMutationService` as the preferred production mutation boundary; its constructor requires a database connection and transactional event bus, and every mutation delegates to an owner-write/outbox transaction.
 - Expose a request-scoped GraphQL `ProfileSummaryLoader` for host applications that need DataLoader-based batching and caching.
 - Expose module-owned GraphQL transport for self-service and public profile lookups, including targeted profile update mutations.
 - Publish a module-owned Leptos storefront profile page with explicit native/GraphQL transport selection and follow/unfollow controls.
-- Publish `profile.updated` through the transactional outbox after successful profile writes.
+- Publish `ProfileUpdated` through the transactional outbox as part of active production profile-write transactions.
 - Emit stable owner-operation telemetry for self-service writes, event publication, and CLI backfill without logging profile copy, source email, generated handles, locale values, Media references, URLs, or provider/storage details.
 - Define reusable profile DTOs and reader contracts that groups, forum, blog, social, and commerce surfaces can consume.
 
@@ -46,6 +47,7 @@
 
 - `ProfilesModule`
 - `ProfileService`
+- `ProfileMutationService`
 - `ProfilesReader`
 - `ProfilePrivacyService`
 - `ProfilePrivacyReadPort`

--- a/crates/rustok-profiles/cli/src/lib.rs
+++ b/crates/rustok-profiles/cli/src/lib.rs
@@ -14,8 +14,8 @@ use rustok_core::events::EventTransport;
 use rustok_customer::CustomerService;
 use rustok_outbox::{OutboxTransport, TransactionalEventBus};
 use rustok_profiles::{
-    ProfileBackfillTimer, ProfileError, ProfileService, ProfileVisibility, ProfilesReader,
-    backfill_profile_with_event,
+    ProfileBackfillTimer, ProfileError, ProfileMutationService, ProfileService, ProfileVisibility,
+    ProfilesReader,
 };
 use rustok_runtime::{RuntimeComposition, db_clone};
 use rustok_tenant::{TenantReadPort, TenantReadRequest, TenantReadSelector, TenantService};
@@ -119,6 +119,7 @@ impl ProfilesCommandProvider {
         let event_bus = TransactionalEventBus::new(
             Arc::new(OutboxTransport::new(db.clone())) as Arc<dyn EventTransport>
         );
+        let profile_mutations = ProfileMutationService::new(&db, &event_bus);
         let profiles = ProfileService::new(db.clone());
         let existing = profiles
             .find_profile_summaries(
@@ -162,19 +163,18 @@ impl ProfilesCommandProvider {
                 items.push(serde_json::json!({"user_id": user.id, "email": user.email, "handle": plan.handle, "display_name": plan.display_name, "preferred_locale": plan.preferred_locale, "action": "planned", "event_published": false}));
                 continue;
             }
-            let result = backfill_profile_with_event(
-                &db,
-                &event_bus,
-                tenant.id,
-                user.id,
-                &user.email,
-                display_name,
-                Some(locale),
-                visibility,
-                Some(&tenant.default_locale),
-            )
-            .await
-            .map_err(|error| backfill_profile_failed(&telemetry, "profile_create", error))?;
+            let result = profile_mutations
+                .backfill_profile_with_event(
+                    tenant.id,
+                    user.id,
+                    &user.email,
+                    display_name,
+                    Some(locale),
+                    visibility,
+                    Some(&tenant.default_locale),
+                )
+                .await
+                .map_err(|error| backfill_profile_failed(&telemetry, "profile_create", error))?;
             let event_published = result.created;
             if result.created {
                 created_profiles += 1;
@@ -208,6 +208,7 @@ fn options(args: &serde_json::Value) -> CliCoreResult<&serde_json::Map<String, s
             message: "profiles backfill expects normalized command options".to_string(),
         })
 }
+
 fn required_uuid(
     options: &serde_json::Map<String, serde_json::Value>,
     key: &str,
@@ -224,6 +225,7 @@ fn required_uuid(
             })
         })
 }
+
 fn optional_u64(
     options: &serde_json::Map<String, serde_json::Value>,
     key: &str,
@@ -244,12 +246,14 @@ fn optional_u64(
         })
         .transpose()
 }
+
 fn flag(options: &serde_json::Map<String, serde_json::Value>, key: &str) -> bool {
     options
         .get(key)
         .and_then(serde_json::Value::as_str)
         .is_some_and(|value| matches!(value, "1" | "true" | "yes" | "on"))
 }
+
 fn visibility(
     options: &serde_json::Map<String, serde_json::Value>,
 ) -> CliCoreResult<ProfileVisibility> {
@@ -267,6 +271,7 @@ fn visibility(
         }),
     }
 }
+
 fn port_context(tenant_id: Uuid) -> PortContext {
     PortContext::new(
         tenant_id.to_string(),
@@ -276,6 +281,7 @@ fn port_context(tenant_id: Uuid) -> PortContext {
     )
     .with_deadline(Duration::from_secs(5))
 }
+
 fn display_name(item: &rustok_customer::CustomerProfileEnrichment) -> Option<String> {
     let first = item
         .first_name
@@ -294,6 +300,7 @@ fn display_name(item: &rustok_customer::CustomerProfileEnrichment) -> Option<Str
         (None, None) => None,
     }
 }
+
 fn backfill_port_failed(
     telemetry: &ProfileBackfillTimer,
     stage: &'static str,
@@ -303,6 +310,7 @@ fn backfill_port_failed(
     telemetry.finish_failure(stage, error_code, error.retryable);
     command_failed(error.message)
 }
+
 fn backfill_profile_failed(
     telemetry: &ProfileBackfillTimer,
     stage: &'static str,
@@ -311,6 +319,7 @@ fn backfill_profile_failed(
     telemetry.finish_failure(stage, error.code(), error.is_retryable());
     command_failed(error)
 }
+
 fn backfill_failed(
     telemetry: &ProfileBackfillTimer,
     stage: &'static str,
@@ -321,6 +330,7 @@ fn backfill_failed(
     telemetry.finish_failure(stage, error_code, retryable);
     command_failed(error)
 }
+
 fn command_failed(error: impl std::fmt::Display) -> CliCoreError {
     CliCoreError::CommandFailed {
         message: error.to_string(),

--- a/crates/rustok-profiles/src/graphql/mutation.rs
+++ b/crates/rustok-profiles/src/graphql/mutation.rs
@@ -12,11 +12,8 @@ use sea_orm::DatabaseConnection;
 use uuid::Uuid;
 
 use crate::{
-    ProfileError, ProfileMediaSlot, ProfileOperation, ProfileOperationTimer, ProfileRecord,
-    ProfileResult, content_write::update_profile_content_with_event,
-    handle_write::update_profile_handle_with_event, locale_write::update_profile_locale_with_event,
-    media_write::update_profile_media_with_event, upsert_write::upsert_profile_with_event,
-    validate_profile_media_asset, visibility_write::update_profile_visibility_with_event,
+    ProfileError, ProfileMediaSlot, ProfileMutationService, ProfileOperation,
+    ProfileOperationTimer, ProfileRecord, ProfileResult, validate_profile_media_asset,
 };
 
 use super::{MODULE_SLUG, types::*};
@@ -37,6 +34,7 @@ impl ProfilesMutation {
         let auth = require_human_user(ctx)?;
         let db = ctx.data::<DatabaseConnection>()?;
         let event_bus = ctx.data::<TransactionalEventBus>()?;
+        let mutations = ProfileMutationService::new(db, event_bus);
         let tenant = ctx.data::<TenantContext>()?;
 
         validate_profile_media_references(
@@ -52,9 +50,7 @@ impl ProfilesMutation {
             ProfileOperation::Upsert,
             tenant.id,
             auth.user_id,
-            upsert_profile_with_event(
-                db,
-                event_bus,
+            mutations.upsert_profile_with_event(
                 tenant.id,
                 auth.user_id,
                 auth.user_id,
@@ -76,15 +72,14 @@ impl ProfilesMutation {
         let auth = require_human_user(ctx)?;
         let db = ctx.data::<DatabaseConnection>()?;
         let event_bus = ctx.data::<TransactionalEventBus>()?;
+        let mutations = ProfileMutationService::new(db, event_bus);
         let tenant = ctx.data::<TenantContext>()?;
 
         let profile = observe_profile_write(
             ProfileOperation::UpdateHandle,
             tenant.id,
             auth.user_id,
-            update_profile_handle_with_event(
-                db,
-                event_bus,
+            mutations.update_profile_handle_with_event(
                 tenant.id,
                 auth.user_id,
                 auth.user_id,
@@ -106,15 +101,14 @@ impl ProfilesMutation {
         let auth = require_human_user(ctx)?;
         let db = ctx.data::<DatabaseConnection>()?;
         let event_bus = ctx.data::<TransactionalEventBus>()?;
+        let mutations = ProfileMutationService::new(db, event_bus);
         let tenant = ctx.data::<TenantContext>()?;
 
         let profile = observe_profile_write(
             ProfileOperation::UpdateContent,
             tenant.id,
             auth.user_id,
-            update_profile_content_with_event(
-                db,
-                event_bus,
+            mutations.update_profile_content_with_event(
                 tenant.id,
                 auth.user_id,
                 auth.user_id,
@@ -137,15 +131,14 @@ impl ProfilesMutation {
         let auth = require_human_user(ctx)?;
         let db = ctx.data::<DatabaseConnection>()?;
         let event_bus = ctx.data::<TransactionalEventBus>()?;
+        let mutations = ProfileMutationService::new(db, event_bus);
         let tenant = ctx.data::<TenantContext>()?;
 
         let profile = observe_profile_write(
             ProfileOperation::UpdateLocale,
             tenant.id,
             auth.user_id,
-            update_profile_locale_with_event(
-                db,
-                event_bus,
+            mutations.update_profile_locale_with_event(
                 tenant.id,
                 auth.user_id,
                 auth.user_id,
@@ -167,15 +160,14 @@ impl ProfilesMutation {
         let auth = require_human_user(ctx)?;
         let db = ctx.data::<DatabaseConnection>()?;
         let event_bus = ctx.data::<TransactionalEventBus>()?;
+        let mutations = ProfileMutationService::new(db, event_bus);
         let tenant = ctx.data::<TenantContext>()?;
 
         let profile = observe_profile_write(
             ProfileOperation::UpdateVisibility,
             tenant.id,
             auth.user_id,
-            update_profile_visibility_with_event(
-                db,
-                event_bus,
+            mutations.update_profile_visibility_with_event(
                 tenant.id,
                 auth.user_id,
                 auth.user_id,
@@ -197,6 +189,7 @@ impl ProfilesMutation {
         let auth = require_human_user(ctx)?;
         let db = ctx.data::<DatabaseConnection>()?;
         let event_bus = ctx.data::<TransactionalEventBus>()?;
+        let mutations = ProfileMutationService::new(db, event_bus);
         let tenant = ctx.data::<TenantContext>()?;
 
         validate_profile_media_references(
@@ -212,9 +205,7 @@ impl ProfilesMutation {
             ProfileOperation::UpdateMedia,
             tenant.id,
             auth.user_id,
-            update_profile_media_with_event(
-                db,
-                event_bus,
+            mutations.update_profile_media_with_event(
                 tenant.id,
                 auth.user_id,
                 auth.user_id,

--- a/crates/rustok-profiles/src/lib.rs
+++ b/crates/rustok-profiles/src/lib.rs
@@ -14,6 +14,7 @@ mod locale_write;
 pub mod media;
 mod media_write;
 pub mod migrations;
+pub mod mutations;
 pub mod observability;
 pub mod presentation;
 mod profile_updated_event;
@@ -31,6 +32,7 @@ pub use media::{
     ProfileImagePresentation, ProfileMediaPublicImageProvider, ProfileMediaSlot,
     profile_image_presentation, validate_profile_media_asset,
 };
+pub use mutations::ProfileMutationService;
 pub use observability::{
     PROFILE_BACKFILL_OPERATION, PROFILE_OPERATION_TARGET, ProfileBackfillTimer, ProfileOperation,
     ProfileOperationTimer,

--- a/crates/rustok-profiles/src/mutations.rs
+++ b/crates/rustok-profiles/src/mutations.rs
@@ -1,0 +1,184 @@
+use rustok_outbox::TransactionalEventBus;
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use crate::{
+    ProfileBackfillResult, ProfileRecord, ProfileResult, ProfileVisibility, UpsertProfileInput,
+    content_write::update_profile_content_with_event,
+    handle_write::update_profile_handle_with_event,
+    locale_write::update_profile_locale_with_event,
+    media_write::update_profile_media_with_event,
+    upsert_write::{backfill_profile_with_event, upsert_profile_with_event},
+    visibility_write::update_profile_visibility_with_event,
+};
+
+/// Public Profiles mutation facade whose construction requires the durable event bus.
+///
+/// Every method delegates to a Profiles-owned transaction that commits the owner write only after
+/// the corresponding `ProfileUpdated` outbox envelope has been persisted.
+#[derive(Clone, Copy)]
+pub struct ProfileMutationService<'a> {
+    db: &'a DatabaseConnection,
+    event_bus: &'a TransactionalEventBus,
+}
+
+impl<'a> ProfileMutationService<'a> {
+    pub fn new(db: &'a DatabaseConnection, event_bus: &'a TransactionalEventBus) -> Self {
+        Self { db, event_bus }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn upsert_profile_with_event(
+        &self,
+        tenant_id: Uuid,
+        actor_id: Uuid,
+        user_id: Uuid,
+        input: UpsertProfileInput,
+        tenant_default_locale: Option<&str>,
+    ) -> ProfileResult<ProfileRecord> {
+        upsert_profile_with_event(
+            self.db,
+            self.event_bus,
+            tenant_id,
+            actor_id,
+            user_id,
+            input,
+            tenant_default_locale,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn update_profile_handle_with_event(
+        &self,
+        tenant_id: Uuid,
+        actor_id: Uuid,
+        user_id: Uuid,
+        handle: &str,
+        tenant_default_locale: Option<&str>,
+    ) -> ProfileResult<ProfileRecord> {
+        update_profile_handle_with_event(
+            self.db,
+            self.event_bus,
+            tenant_id,
+            actor_id,
+            user_id,
+            handle,
+            tenant_default_locale,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn update_profile_content_with_event(
+        &self,
+        tenant_id: Uuid,
+        actor_id: Uuid,
+        user_id: Uuid,
+        display_name: &str,
+        bio: Option<&str>,
+        tenant_default_locale: Option<&str>,
+    ) -> ProfileResult<ProfileRecord> {
+        update_profile_content_with_event(
+            self.db,
+            self.event_bus,
+            tenant_id,
+            actor_id,
+            user_id,
+            display_name,
+            bio,
+            tenant_default_locale,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn update_profile_locale_with_event(
+        &self,
+        tenant_id: Uuid,
+        actor_id: Uuid,
+        user_id: Uuid,
+        preferred_locale: Option<&str>,
+        tenant_default_locale: Option<&str>,
+    ) -> ProfileResult<ProfileRecord> {
+        update_profile_locale_with_event(
+            self.db,
+            self.event_bus,
+            tenant_id,
+            actor_id,
+            user_id,
+            preferred_locale,
+            tenant_default_locale,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn update_profile_visibility_with_event(
+        &self,
+        tenant_id: Uuid,
+        actor_id: Uuid,
+        user_id: Uuid,
+        visibility: ProfileVisibility,
+        tenant_default_locale: Option<&str>,
+    ) -> ProfileResult<ProfileRecord> {
+        update_profile_visibility_with_event(
+            self.db,
+            self.event_bus,
+            tenant_id,
+            actor_id,
+            user_id,
+            visibility,
+            tenant_default_locale,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn update_profile_media_with_event(
+        &self,
+        tenant_id: Uuid,
+        actor_id: Uuid,
+        user_id: Uuid,
+        avatar_media_id: Option<Uuid>,
+        banner_media_id: Option<Uuid>,
+        tenant_default_locale: Option<&str>,
+    ) -> ProfileResult<ProfileRecord> {
+        update_profile_media_with_event(
+            self.db,
+            self.event_bus,
+            tenant_id,
+            actor_id,
+            user_id,
+            avatar_media_id,
+            banner_media_id,
+            tenant_default_locale,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn backfill_profile_with_event(
+        &self,
+        tenant_id: Uuid,
+        user_id: Uuid,
+        email: &str,
+        display_name: Option<&str>,
+        preferred_locale: Option<&str>,
+        visibility: ProfileVisibility,
+        tenant_default_locale: Option<&str>,
+    ) -> ProfileResult<ProfileBackfillResult> {
+        backfill_profile_with_event(
+            self.db,
+            self.event_bus,
+            tenant_id,
+            user_id,
+            email,
+            display_name,
+            preferred_locale,
+            visibility,
+            tenant_default_locale,
+        )
+        .await
+    }
+}

--- a/scripts/verify/verify-forum-search-profile-event-aware-mutation-api.mjs
+++ b/scripts/verify/verify-forum-search-profile-event-aware-mutation-api.mjs
@@ -10,6 +10,7 @@ const failures = [];
 
 const facadePath = "crates/rustok-profiles/src/mutations.rs";
 const profilesLibPath = "crates/rustok-profiles/src/lib.rs";
+const profilesReadmePath = "crates/rustok-profiles/README.md";
 const graphqlPath = "crates/rustok-profiles/src/graphql/mutation.rs";
 const cliPath = "crates/rustok-profiles/cli/src/lib.rs";
 const legacyGateContractPath =
@@ -58,6 +59,7 @@ function countOccurrences(source, marker) {
 
 const facade = read(facadePath);
 const profilesLib = read(profilesLibPath);
+const profilesReadme = read(profilesReadmePath);
 const graphql = read(graphqlPath);
 const cli = read(cliPath);
 const note = read(notePath);
@@ -107,6 +109,16 @@ for (const marker of [
 requireMarker(profilesLib, "pub mod mutations;", profilesLibPath);
 requireMarker(profilesLib, "pub use mutations::ProfileMutationService;", profilesLibPath);
 requireMarker(profilesLib, "pub use upsert_write::backfill_profile_with_event;", profilesLibPath);
+
+for (const marker of [
+  "ProfileMutationService",
+  "preferred production mutation boundary",
+  "transactional event bus",
+  "owner-write/outbox transaction",
+  "Publish `ProfileUpdated` through the transactional outbox as part of active production profile-write transactions.",
+]) {
+  requireMarker(profilesReadme, marker, profilesReadmePath);
+}
 
 for (const marker of [
   "ProfileMutationService",
@@ -173,6 +185,9 @@ if (contract) {
   if (contract.profiles_public_api !== profilesLibPath) {
     failures.push(`${contractPath}: unexpected Profiles public API path`);
   }
+  if (contract.profiles_readme !== profilesReadmePath) {
+    failures.push(`${contractPath}: unexpected Profiles README path`);
+  }
   if (contract.graphql_runtime !== graphqlPath) {
     failures.push(`${contractPath}: unexpected GraphQL runtime path`);
   }
@@ -197,6 +212,7 @@ if (contract) {
     "graphql_media_validation_precedes_facade_write",
     "cli_backfill_uses_facade",
     "cli_backfill_system_actor_semantics_are_preserved",
+    "profiles_readme_documents_preferred_facade",
     "legacy_repository_production_calls_remain_source_gated",
     "compatible_free_backfill_helper_remains_event_aware",
   ]) {

--- a/scripts/verify/verify-forum-search-profile-event-aware-mutation-api.mjs
+++ b/scripts/verify/verify-forum-search-profile-event-aware-mutation-api.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(".");
+const failures = [];
+
+const facadePath = "crates/rustok-profiles/src/mutations.rs";
+const profilesLibPath = "crates/rustok-profiles/src/lib.rs";
+const graphqlPath = "crates/rustok-profiles/src/graphql/mutation.rs";
+const cliPath = "crates/rustok-profiles/cli/src/lib.rs";
+const legacyGateContractPath =
+  "crates/rustok-forum/contracts/forum-search-profile-service-mutation-boundary.json";
+const contractPath =
+  "crates/rustok-forum/contracts/forum-search-profile-event-aware-mutation-api.json";
+const notePath = "crates/rustok-forum/docs/forum-23a9-profile-event-aware-mutation-api.md";
+
+const eventAwareMethods = [
+  "upsert_profile_with_event",
+  "update_profile_handle_with_event",
+  "update_profile_content_with_event",
+  "update_profile_locale_with_event",
+  "update_profile_visibility_with_event",
+  "update_profile_media_with_event",
+  "backfill_profile_with_event",
+];
+
+function read(relativePath) {
+  const target = path.join(root, relativePath);
+  if (!existsSync(target)) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return "";
+  }
+  return readFileSync(target, "utf8");
+}
+
+function requireMarker(source, marker, label) {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+}
+
+function rejectMarker(source, marker, label) {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+}
+
+function countOccurrences(source, marker) {
+  let count = 0;
+  let offset = 0;
+  while (true) {
+    const index = source.indexOf(marker, offset);
+    if (index < 0) return count;
+    count += 1;
+    offset = index + marker.length;
+  }
+}
+
+const facade = read(facadePath);
+const profilesLib = read(profilesLibPath);
+const graphql = read(graphqlPath);
+const cli = read(cliPath);
+const note = read(notePath);
+let contract = null;
+let legacyGateContract = null;
+try {
+  contract = JSON.parse(read(contractPath));
+} catch (error) {
+  failures.push(`${contractPath}: invalid JSON: ${error.message}`);
+}
+try {
+  legacyGateContract = JSON.parse(read(legacyGateContractPath));
+} catch (error) {
+  failures.push(`${legacyGateContractPath}: invalid JSON: ${error.message}`);
+}
+
+for (const marker of [
+  "pub struct ProfileMutationService<'a>",
+  "db: &'a DatabaseConnection",
+  "event_bus: &'a TransactionalEventBus",
+  "pub fn new(db: &'a DatabaseConnection, event_bus: &'a TransactionalEventBus)",
+  "Self { db, event_bus }",
+  "commits the owner write only after",
+]) {
+  requireMarker(facade, marker, facadePath);
+}
+
+for (const method of eventAwareMethods) {
+  requireMarker(facade, `pub async fn ${method}(`, facadePath);
+  if (countOccurrences(facade, `${method}(`) < 2) {
+    failures.push(`${facadePath}: ${method} must define the facade method and delegate to owner helper`);
+  }
+}
+for (const marker of [
+  "self.db",
+  "self.event_bus",
+  "upsert_write::{backfill_profile_with_event, upsert_profile_with_event}",
+  "content_write::update_profile_content_with_event",
+  "handle_write::update_profile_handle_with_event",
+  "locale_write::update_profile_locale_with_event",
+  "media_write::update_profile_media_with_event",
+  "visibility_write::update_profile_visibility_with_event",
+]) {
+  requireMarker(facade, marker, facadePath);
+}
+
+requireMarker(profilesLib, "pub mod mutations;", profilesLibPath);
+requireMarker(profilesLib, "pub use mutations::ProfileMutationService;", profilesLibPath);
+requireMarker(profilesLib, "pub use upsert_write::backfill_profile_with_event;", profilesLibPath);
+
+for (const marker of [
+  "ProfileMutationService",
+  "ProfileMutationService::new(db, event_bus)",
+  "mutations.upsert_profile_with_event(",
+  "mutations.update_profile_handle_with_event(",
+  "mutations.update_profile_content_with_event(",
+  "mutations.update_profile_locale_with_event(",
+  "mutations.update_profile_visibility_with_event(",
+  "mutations.update_profile_media_with_event(",
+  "validate_profile_media_references(",
+]) {
+  requireMarker(graphql, marker, graphqlPath);
+}
+for (const marker of [
+  "content_write::update_profile_content_with_event",
+  "handle_write::update_profile_handle_with_event",
+  "locale_write::update_profile_locale_with_event",
+  "media_write::update_profile_media_with_event",
+  "upsert_write::upsert_profile_with_event",
+  "visibility_write::update_profile_visibility_with_event",
+]) {
+  rejectMarker(graphql, marker, graphqlPath);
+}
+
+for (const marker of [
+  "ProfileMutationService",
+  "ProfileMutationService::new(&db, &event_bus)",
+  "profile_mutations",
+  ".backfill_profile_with_event(",
+  "let event_published = result.created;",
+]) {
+  requireMarker(cli, marker, cliPath);
+}
+rejectMarker(cli, "backfill_profile_with_event,", cliPath);
+rejectMarker(cli, "let result = backfill_profile_with_event(", cliPath);
+
+for (const marker of [
+  "FORUM-23A9",
+  "ProfileMutationService",
+  "DatabaseConnection",
+  "TransactionalEventBus",
+  "GraphQL self-service",
+  "CLI backfill",
+  "Legacy boundary",
+  "does not claim",
+  "Not run by the implementation agent",
+]) {
+  requireMarker(note, marker, notePath);
+}
+
+if (legacyGateContract?.task !== "FORUM-23A8") {
+  failures.push(`${legacyGateContractPath}: expected FORUM-23A8 source gate`);
+}
+
+if (contract) {
+  if (contract.task !== "FORUM-23A9") failures.push(`${contractPath}: unexpected task`);
+  if (contract.status !== "source_complete_execution_pending") {
+    failures.push(`${contractPath}: unexpected status`);
+  }
+  if (contract.mutation_facade !== facadePath) {
+    failures.push(`${contractPath}: unexpected mutation facade`);
+  }
+  if (contract.profiles_public_api !== profilesLibPath) {
+    failures.push(`${contractPath}: unexpected Profiles public API path`);
+  }
+  if (contract.graphql_runtime !== graphqlPath) {
+    failures.push(`${contractPath}: unexpected GraphQL runtime path`);
+  }
+  if (contract.cli_backfill_runtime !== cliPath) {
+    failures.push(`${contractPath}: unexpected CLI runtime path`);
+  }
+  if (contract.legacy_source_gate_contract !== legacyGateContractPath) {
+    failures.push(`${contractPath}: unexpected legacy source gate contract`);
+  }
+  if (JSON.stringify(contract.public_event_aware_methods) !== JSON.stringify(eventAwareMethods)) {
+    failures.push(`${contractPath}: public event-aware method inventory drift`);
+  }
+
+  for (const key of [
+    "facade_is_publicly_exported",
+    "facade_constructor_requires_database_connection",
+    "facade_constructor_requires_transactional_event_bus",
+    "all_facade_mutations_are_event_named",
+    "facade_delegates_to_profiles_owned_atomic_helpers",
+    "graphql_self_service_uses_facade",
+    "graphql_self_service_actor_is_preserved",
+    "graphql_media_validation_precedes_facade_write",
+    "cli_backfill_uses_facade",
+    "cli_backfill_system_actor_semantics_are_preserved",
+    "legacy_repository_production_calls_remain_source_gated",
+    "compatible_free_backfill_helper_remains_event_aware",
+  ]) {
+    if (contract.mutation_api_boundary?.[key] !== true) {
+      failures.push(`${contractPath}: mutation API boundary ${key} drift`);
+    }
+  }
+
+  for (const key of [
+    "legacy_profile_service_signatures_removed",
+    "public_backfill_helper_removed",
+    "graphql_schema_changed",
+    "forum_rest_changed",
+    "search_query_api_changed",
+    "search_document_schema_changed",
+    "database_migration_added",
+    "dependency_added",
+    "cargo_lock_changed",
+  ]) {
+    if (contract.compatibility?.[key] !== false) {
+      failures.push(`${contractPath}: compatibility ${key} must remain false`);
+    }
+  }
+
+  for (const key of [
+    "legacy_profile_service_mutations_are_compile_time_private",
+    "external_downstream_crates_cannot_call_legacy_methods",
+    "all_profiles_owner_write_surfaces_are_event_intrinsic",
+    "runtime_verification_was_executed",
+    "account_deletion_redaction_is_complete",
+    "general_cross_producer_owner_revision_ordering_is_complete",
+  ]) {
+    if (contract.non_claims?.[key] !== true) {
+      failures.push(`${contractPath}: non-claim ${key} drift`);
+    }
+  }
+
+  if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+    failures.push(`${contractPath}: execution status drift`);
+  }
+  if (contract.downstream_task !== "FORUM-23A10") {
+    failures.push(`${contractPath}: unexpected downstream task`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Profiles event-aware mutation API verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Profiles event-aware mutation API verification passed.");


### PR DESCRIPTION
## Summary

Implements `FORUM-23A9`, the next bounded Forum Search author-invalidation hardening slice.

- add public `ProfileMutationService`, whose constructor requires both `DatabaseConnection` and `TransactionalEventBus`;
- expose event-named methods for upsert, focused profile updates, and backfill;
- delegate every facade method to the existing Profiles-owned atomic owner-write/outbox helper;
- route GraphQL self-service through the facade while preserving authenticated actor IDs and pre-write media validation;
- route Profiles CLI backfill through one command-scoped facade while preserving system-actor and create-if-missing behavior;
- retain legacy `ProfileService` mutation signatures and the compatible free backfill helper;
- retain the `FORUM-23A8` source gate for legacy direct methods instead of claiming compile-time closure;
- update Profiles README, add a dedicated contract, owner note, and static verifier.

## Compatibility

No legacy `ProfileService` signature, GraphQL schema, Forum REST contract, Search query/document schema, migration, dependency, or `Cargo.lock` change.

## Verification

Not run by the implementation agent, per maintainer instruction. Suggested commands:

```bash
node scripts/verify/verify-forum-search-profile-event-aware-mutation-api.mjs
node scripts/verify/verify-forum-search-profile-service-mutation-boundary.mjs
node scripts/verify/verify-forum-search-public-author-summary.mjs
cargo check -p rustok-profiles --all-targets
cargo check -p rustok-profiles-cli --all-targets
cargo xtask module validate profiles
cargo xtask module validate forum
```

## Remaining

- deprecate, remove, or compile-time restrict legacy direct `ProfileService` mutation methods;
- define owner-ordered profile/account deletion invalidation;
- replace remaining Forum wall-clock ordering with owner-issued revisions;
- add the remaining filters and member projections.