### PR TITLE
fix(commerce): sanitize shipping command failures

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/storefront-shipping-command-error-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/storefront-shipping-command-error-safety-source-review.json
@@ -1,0 +1,92 @@
+{
+  "schema_version": 1,
+  "status": "commerce_storefront_shipping_command_error_safety_source_reviewed_unvalidated",
+  "reviewed_at_utc": "2026-07-30T17:50:00Z",
+  "review_base": "928d829b28fd3316cd0fc8297f59e454f17fc63c",
+  "scope": "Commerce storefront shipping option command public transport envelope",
+  "reviewed_sources": [
+    "crates/rustok-commerce/docs/implementation-plan.md",
+    "crates/rustok-commerce/storefront/src/core/requests.rs",
+    "crates/rustok-commerce/storefront/src/transport/mod.rs",
+    "crates/rustok-commerce/storefront/src/transport/aggregate_error_safety.rs",
+    "crates/rustok-commerce/storefront/src/transport/payment_collection_command_error_safety.rs",
+    "crates/rustok-fulfillment/storefront/src/transport.rs",
+    "crates/rustok-fulfillment/storefront/src/transport/graphql_adapter.rs",
+    "crates/rustok-fulfillment/storefront/src/transport/graphql_error_safety.rs",
+    "crates/rustok-fulfillment/storefront/src/transport/native_server_adapter/server_functions.rs",
+    "crates/rustok-ui-transport/src/lib.rs",
+    "crates/rustok-commerce/storefront/Cargo.toml",
+    "scripts/verify/verify-commerce-storefront-aggregate-error-safety.mjs",
+    "scripts/verify/verify-commerce-storefront-payment-command-error-safety.mjs",
+    "scripts/verify/verify-commerce-storefront-transport-error-safety.mjs"
+  ],
+  "findings": [
+    {
+      "id": "shipping-command-public-display-leak",
+      "severity": "confirmed",
+      "finding": "select_storefront_shipping_option converted the Fulfillment UiTransportError through ApiError::from, exposing the complete transport Display envelope and nested owner error text."
+    },
+    {
+      "id": "owner-technical-failure-safety",
+      "severity": "preserved",
+      "finding": "Fulfillment GraphQL and native technical failures already use bounded public messages before the Commerce wrapper."
+    },
+    {
+      "id": "owner-validation-identifiers",
+      "severity": "confirmed",
+      "finding": "Fulfillment validation can include cart id, selected option id, shipping profile slug, seller id, or unavailable option id text and therefore requires a Commerce-owned static validation envelope."
+    },
+    {
+      "id": "validation-compatibility",
+      "severity": "selected",
+      "finding": "The final mapper recognizes the two UUID messages plus the existing missing-delivery-group and unavailable-option message shapes, then returns ApiError::Validation with Invalid shipping selection."
+    },
+    {
+      "id": "minimal-boundary-fix",
+      "severity": "selected",
+      "finding": "A Commerce-owned context around the existing Fulfillment call is the smallest compatible fix; the owner request, selection planner, adapters, mutation, server function, DTOs, transport selection, and fallback behavior do not need changes."
+    },
+    {
+      "id": "safe-request-shape",
+      "severity": "confirmed",
+      "finding": "Diagnostics retain only correlation, tenant and request field lengths, counts, presence flags, failed path, fallback, stable code, and private UiTransportError diagnostics."
+    }
+  ],
+  "changed_files_expected": [
+    "crates/rustok-commerce/contracts/evidence/storefront-shipping-command-error-safety-source-review.json",
+    "crates/rustok-commerce/contracts/evidence/storefront-shipping-command-error-safety-source.json",
+    "crates/rustok-commerce/docs/storefront-shipping-option-command-error-safety.md",
+    "crates/rustok-commerce/storefront/src/transport/mod.rs",
+    "crates/rustok-commerce/storefront/src/transport/shipping_option_command_error_safety.rs",
+    "scripts/verify/verify-commerce-storefront-aggregate-error-safety.mjs",
+    "scripts/verify/verify-commerce-storefront-payment-command-error-safety.mjs",
+    "scripts/verify/verify-commerce-storefront-shipping-command-error-safety.mjs",
+    "scripts/verify/verify-commerce-storefront-transport-error-safety.mjs"
+  ],
+  "preserved": [
+    "Commerce SelectShippingOptionRequest wrapper and Fulfillment owner request DTO",
+    "Fulfillment selection planner and validation message production",
+    "Fulfillment GraphQL mutation, variables, and response mapping",
+    "Fulfillment native server function and owner runtime call",
+    "native versus GraphQL owner transport selection",
+    "absence of native-to-GraphQL fallback",
+    "Commerce payment collection and checkout completion wrappers"
+  ],
+  "remaining_scope": [
+    "Commerce storefront checkout completion public envelope",
+    "remaining ecommerce adapters and non-PortError public envelopes"
+  ],
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "native_runtime_proven": false,
+    "graphql_runtime_proven": false,
+    "browser_runtime_proven": false,
+    "mounted_parity_proven": false
+  }
+}

--- a/crates/rustok-commerce/contracts/evidence/storefront-shipping-command-error-safety-source.json
+++ b/crates/rustok-commerce/contracts/evidence/storefront-shipping-command-error-safety-source.json
@@ -1,0 +1,83 @@
+{
+  "schema_version": 1,
+  "status": "commerce_storefront_shipping_command_error_safety_source_unvalidated",
+  "generated_at_utc": "2026-07-30T17:50:00Z",
+  "scope": "Commerce-owned select_storefront_shipping_option public transport envelope",
+  "operation": "select_storefront_shipping_option",
+  "boundary": "commerce_storefront_shipping_option_public_transport",
+  "public_messages": {
+    "invalid_shipping_selection": "Invalid shipping selection",
+    "shipping_selection_unavailable": "Shipping selection is temporarily unavailable"
+  },
+  "recognized_owner_validation_envelopes": [
+    "cart_id must be a valid UUID",
+    "selected_shipping_option_id must be a valid UUID",
+    "delivery group `<profile>`/<seller> is not present in the checkout cart",
+    "shipping option <option> is not available for shipping profile <profile>"
+  ],
+  "source_contract": {
+    "context_before_owner_call": true,
+    "unique_correlation_id": true,
+    "owner_validation_static_public_envelope": true,
+    "unavailable_static_public_envelope": true,
+    "failed_path_api_error_variant_preserved": true,
+    "ui_transport_display_public": false,
+    "raw_request_values_logged": false,
+    "private_transport_error_diagnostics": true,
+    "fulfillment_owner_transport_changed": false,
+    "payment_wrapper_changed": false,
+    "checkout_wrapper_changed": false,
+    "fallback_added": false
+  },
+  "safe_diagnostics": [
+    "owner",
+    "owner_operation",
+    "correlation_id",
+    "tenant_slug_configured",
+    "tenant_slug_length",
+    "cart_id_length",
+    "delivery_group_count",
+    "available_shipping_option_count",
+    "shipping_profile_slug_length",
+    "seller_id_present",
+    "seller_id_length",
+    "shipping_option_id_present",
+    "shipping_option_id_length",
+    "failed_path",
+    "fallback_attempted",
+    "stable_code",
+    "boundary",
+    "private_ui_transport_error"
+  ],
+  "forbidden_public_or_structured_request_values": [
+    "tenant_slug",
+    "cart_id",
+    "shipping_profile_slug",
+    "seller_id",
+    "shipping_option_id",
+    "available_shipping_option_ids",
+    "delivery_groups",
+    "native_error",
+    "graphql_error",
+    "UiTransportError display"
+  ],
+  "remaining_scope": [
+    "replace generic UiTransportError display mapping for complete_storefront_checkout",
+    "finish remaining ecommerce adapters and non-PortError public envelopes"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "focused_verifier_run": false,
+    "aggregate_verifier_run": false,
+    "broad_ecommerce_verifier_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "native_runtime_proven": false,
+    "graphql_runtime_proven": false,
+    "browser_runtime_proven": false,
+    "mounted_parity_proven": false
+  },
+  "execution": []
+}

--- a/crates/rustok-commerce/docs/storefront-shipping-option-command-error-safety.md
+++ b/crates/rustok-commerce/docs/storefront-shipping-option-command-error-safety.md
@@ -1,0 +1,129 @@
+# Commerce storefront shipping option command error safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens only the Commerce-owned wrapper:
+
+- `select_storefront_shipping_option`;
+- `crates/rustok-commerce/storefront/src/transport/mod.rs`;
+- `crates/rustok-commerce/storefront/src/transport/shipping_option_command_error_safety.rs`.
+
+The checkout-completion wrapper remains open on the generic `From<UiTransportError>` mapper. The aggregate read and payment-collection command policies remain unchanged.
+
+## Confirmed gap
+
+The Fulfillment storefront owner already applies bounded public messages to technical GraphQL and native failures. Its facade nevertheless returns `UiTransportError`, and Commerce previously called:
+
+```rust
+.map_err(ApiError::from)
+```
+
+The generic conversion publishes `UiTransportError::to_string()`. That display includes the failed transport path and nested owner error text.
+
+Fulfillment validation also intentionally carries useful owner detail. Current messages include:
+
+- `cart_id must be a valid UUID`;
+- `selected_shipping_option_id must be a valid UUID`;
+- a missing delivery group message containing shipping profile and seller identifiers;
+- an unavailable option message containing option and shipping profile identifiers.
+
+Those messages remain available inside the owner boundary, but they are not suitable as the final Commerce public envelope.
+
+## Implementation
+
+`ShippingOptionCommandErrorContext` is created before the Fulfillment owner call. Each command receives a unique correlation id in the namespace:
+
+```text
+commerce-storefront-shipping:select_storefront_shipping_option:<uuid>
+```
+
+After `select_shipping_option`, the final `UiTransportError` is mapped by the Commerce-owned context instead of the generic `ApiError::from` implementation.
+
+### Public policy
+
+| Condition | Public `ApiError` |
+| --- | --- |
+| Recognized cart, option, delivery-group, or availability validation | `Validation("Invalid shipping selection")` |
+| Native owner failure | `ServerFn("Shipping selection is temporarily unavailable")` |
+| GraphQL owner failure | `Graphql("Shipping selection is temporarily unavailable")` |
+
+The validation classifier recognizes only the existing owner validation contracts. Arbitrary nested transport text is not forwarded to the public result.
+
+## Internal diagnostics
+
+The original `UiTransportError` is retained only as a private structured tracing field. The event also records:
+
+- Commerce owner and operation;
+- unique correlation id;
+- whether a tenant slug is configured and its character length;
+- cart id character length;
+- delivery-group count;
+- total available-option count;
+- target shipping-profile character length;
+- seller and shipping-option presence and character lengths;
+- failed transport path;
+- fallback flag;
+- stable internal code;
+- boundary name.
+
+The structured request fields do not contain tenant slug, cart id, shipping profile slug, seller id, shipping option id, delivery groups, or available option id values. The private error field may retain owner details for operators but is never copied into the public `ApiError`.
+
+## Preserved behavior
+
+This slice does not change:
+
+- the Commerce `SelectShippingOptionRequest` wrapper;
+- the Fulfillment `SelectShippingOptionRequest` DTO;
+- request normalization;
+- delivery-group matching and selection planning;
+- the GraphQL mutation, variables, or response mapping;
+- the native server function;
+- tenant, authentication, request-context, and owner-runtime mapping;
+- native versus GraphQL feature selection;
+- fallback behavior;
+- aggregate Commerce reads;
+- payment collection creation;
+- checkout completion;
+- FFA, FBA, browser, runtime, workflow, CI, or production status.
+
+## Static evidence
+
+Focused source evidence:
+
+- `crates/rustok-commerce/contracts/evidence/storefront-shipping-command-error-safety-source.json`;
+- `crates/rustok-commerce/contracts/evidence/storefront-shipping-command-error-safety-source-review.json`;
+- `scripts/verify/verify-commerce-storefront-shipping-command-error-safety.mjs`.
+
+The focused verifier is imported by:
+
+- `scripts/verify/verify-commerce-storefront-transport-error-safety.mjs`.
+
+The prior aggregate and payment-command guards now require exactly one remaining generic wrapper: checkout completion.
+
+All execution and runtime validation flags remain `false`. Source review alone does not prove native, GraphQL, browser, mounted, workflow, CI, or production behavior.
+
+## Remaining work
+
+The master correlation-safe mapper cleanup remains open for:
+
+- `complete_storefront_checkout` final Commerce public envelope;
+- Pricing storefront and other remaining ecommerce adapters;
+- remaining non-`PortError` public envelopes.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-commerce-storefront-shipping-command-error-safety.mjs
+node scripts/verify/verify-commerce-storefront-payment-command-error-safety.mjs
+node scripts/verify/verify-commerce-storefront-aggregate-error-safety.mjs
+node scripts/verify/verify-commerce-storefront-transport-error-safety.mjs
+node scripts/verify/verify-commerce-storefront-transport-handoff.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-commerce-storefront
+cargo check -p rustok-commerce-storefront --features hydrate
+cargo check -p rustok-commerce-storefront --features ssr
+```

--- a/crates/rustok-commerce/storefront/src/transport/mod.rs
+++ b/crates/rustok-commerce/storefront/src/transport/mod.rs
@@ -3,6 +3,7 @@ mod graphql_adapter;
 mod native_server_adapter;
 mod payment_collection_command_error_safety;
 mod shared_adapter;
+mod shipping_option_command_error_safety;
 
 use crate::core::{
     CheckoutCompletionCommandRequest, FetchCommerceRequest, PaymentCollectionCommandRequest,
@@ -48,9 +49,11 @@ pub async fn create_storefront_payment_collection(
 pub async fn select_storefront_shipping_option(
     request: SelectShippingOptionRequest,
 ) -> Result<(), ApiError> {
+    let error_context =
+        shipping_option_command_error_safety::ShippingOptionCommandErrorContext::new(&request);
     select_shipping_option(request.owner_request)
         .await
-        .map_err(ApiError::from)
+        .map_err(|error| error_context.map_error(error))
 }
 
 pub async fn complete_storefront_checkout(

--- a/crates/rustok-commerce/storefront/src/transport/shipping_option_command_error_safety.rs
+++ b/crates/rustok-commerce/storefront/src/transport/shipping_option_command_error_safety.rs
@@ -1,0 +1,148 @@
+use rustok_ui_transport::{UiTransportError, UiTransportPath};
+use uuid::Uuid;
+
+use crate::core::SelectShippingOptionRequest;
+
+use super::shared_adapter::ApiError;
+
+const COMMERCE_STOREFRONT_SHIPPING_OWNER: &str = "rustok_commerce.storefront";
+const COMMERCE_STOREFRONT_SHIPPING_OPERATION: &str = "select_storefront_shipping_option";
+const COMMERCE_STOREFRONT_SHIPPING_BOUNDARY: &str =
+    "commerce_storefront_shipping_option_public_transport";
+const CART_ID_UUID_VALIDATION: &str = "cart_id must be a valid UUID";
+const SELECTED_SHIPPING_OPTION_ID_UUID_VALIDATION: &str =
+    "selected_shipping_option_id must be a valid UUID";
+const INVALID_SHIPPING_SELECTION: &str = "Invalid shipping selection";
+const SHIPPING_SELECTION_UNAVAILABLE: &str = "Shipping selection is temporarily unavailable";
+
+pub(super) struct ShippingOptionCommandErrorContext {
+    correlation_id: String,
+    tenant_slug_length: Option<usize>,
+    cart_id_length: usize,
+    delivery_group_count: usize,
+    available_shipping_option_count: usize,
+    shipping_profile_slug_length: usize,
+    seller_id_length: Option<usize>,
+    shipping_option_id_length: Option<usize>,
+}
+
+impl ShippingOptionCommandErrorContext {
+    pub(super) fn new(request: &SelectShippingOptionRequest) -> Self {
+        let owner_request = &request.owner_request;
+        Self {
+            correlation_id: format!(
+                "commerce-storefront-shipping:{COMMERCE_STOREFRONT_SHIPPING_OPERATION}:{}",
+                Uuid::new_v4()
+            ),
+            tenant_slug_length: configured_tenant_slug_length(),
+            cart_id_length: owner_request.cart_id.chars().count(),
+            delivery_group_count: owner_request.delivery_groups.len(),
+            available_shipping_option_count: owner_request
+                .delivery_groups
+                .iter()
+                .map(|group| group.available_shipping_option_ids.len())
+                .sum(),
+            shipping_profile_slug_length: owner_request.shipping_profile_slug.chars().count(),
+            seller_id_length: owner_request
+                .seller_id
+                .as_deref()
+                .map(|value| value.chars().count()),
+            shipping_option_id_length: owner_request
+                .shipping_option_id
+                .as_deref()
+                .map(|value| value.chars().count()),
+        }
+    }
+
+    pub(super) fn map_error(&self, error: UiTransportError) -> ApiError {
+        if is_invalid_shipping_selection(&error) {
+            tracing::warn!(
+                error = ?error,
+                owner = COMMERCE_STOREFRONT_SHIPPING_OWNER,
+                owner_operation = COMMERCE_STOREFRONT_SHIPPING_OPERATION,
+                correlation_id = %self.correlation_id,
+                tenant_slug_configured = self.tenant_slug_length.is_some(),
+                tenant_slug_length = ?self.tenant_slug_length,
+                cart_id_length = self.cart_id_length,
+                delivery_group_count = self.delivery_group_count,
+                available_shipping_option_count = self.available_shipping_option_count,
+                shipping_profile_slug_length = self.shipping_profile_slug_length,
+                seller_id_present = self.seller_id_length.is_some(),
+                seller_id_length = ?self.seller_id_length,
+                shipping_option_id_present = self.shipping_option_id_length.is_some(),
+                shipping_option_id_length = ?self.shipping_option_id_length,
+                failed_path = error.failed_path.as_str(),
+                fallback_attempted = error.fallback_attempted,
+                code = "commerce.storefront_shipping_selection_invalid",
+                boundary = COMMERCE_STOREFRONT_SHIPPING_BOUNDARY,
+                "commerce storefront shipping selection validation failed"
+            );
+            return ApiError::Validation(INVALID_SHIPPING_SELECTION.to_string());
+        }
+
+        tracing::error!(
+            error = ?error,
+            owner = COMMERCE_STOREFRONT_SHIPPING_OWNER,
+            owner_operation = COMMERCE_STOREFRONT_SHIPPING_OPERATION,
+            correlation_id = %self.correlation_id,
+            tenant_slug_configured = self.tenant_slug_length.is_some(),
+            tenant_slug_length = ?self.tenant_slug_length,
+            cart_id_length = self.cart_id_length,
+            delivery_group_count = self.delivery_group_count,
+            available_shipping_option_count = self.available_shipping_option_count,
+            shipping_profile_slug_length = self.shipping_profile_slug_length,
+            seller_id_present = self.seller_id_length.is_some(),
+            seller_id_length = ?self.seller_id_length,
+            shipping_option_id_present = self.shipping_option_id_length.is_some(),
+            shipping_option_id_length = ?self.shipping_option_id_length,
+            failed_path = error.failed_path.as_str(),
+            fallback_attempted = error.fallback_attempted,
+            code = "commerce.storefront_shipping_selection_unavailable",
+            boundary = COMMERCE_STOREFRONT_SHIPPING_BOUNDARY,
+            "commerce storefront shipping selection command failed"
+        );
+
+        match error.failed_path {
+            UiTransportPath::NativeServer => {
+                ApiError::ServerFn(SHIPPING_SELECTION_UNAVAILABLE.to_string())
+            }
+            UiTransportPath::Graphql => {
+                ApiError::Graphql(SHIPPING_SELECTION_UNAVAILABLE.to_string())
+            }
+        }
+    }
+}
+
+fn is_invalid_shipping_selection(error: &UiTransportError) -> bool {
+    [error.native_error.as_deref(), error.graphql_error.as_deref()]
+        .into_iter()
+        .flatten()
+        .any(is_shipping_selection_validation_message)
+}
+
+fn is_shipping_selection_validation_message(message: &str) -> bool {
+    matches!(
+        message,
+        CART_ID_UUID_VALIDATION
+            | SELECTED_SHIPPING_OPTION_ID_UUID_VALIDATION
+            | INVALID_SHIPPING_SELECTION
+    ) || (message.starts_with("delivery group `")
+        && message.ends_with(" is not present in the checkout cart"))
+        || (message.starts_with("shipping option ")
+            && message.contains(" is not available for shipping profile "))
+}
+
+fn configured_tenant_slug_length() -> Option<usize> {
+    [
+        "RUSTOK_TENANT_SLUG",
+        "NEXT_PUBLIC_TENANT_SLUG",
+        "NEXT_PUBLIC_DEFAULT_TENANT_SLUG",
+    ]
+    .into_iter()
+    .find_map(|key| {
+        std::env::var(key).ok().and_then(|value| {
+            let value = value.trim();
+            (!value.is_empty()).then_some(value.chars().count())
+        })
+    })
+}

--- a/scripts/verify/verify-commerce-storefront-aggregate-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-aggregate-error-safety.mjs
@@ -93,9 +93,9 @@ requireText(
   "impl From<UiTransportError> for ApiError",
   `${transportPath}: generic command-wrapper mapper remains explicit debt`,
 );
-if (countText(transport, ".map_err(ApiError::from)") !== 2) {
+if (countText(transport, ".map_err(ApiError::from)") !== 1) {
   failures.push(
-    `${transportPath}: exactly shipping selection and checkout completion must remain on the generic mapper`,
+    `${transportPath}: exactly checkout completion must remain on the generic mapper`,
   );
 }
 for (const marker of [
@@ -236,5 +236,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "✔ commerce storefront aggregate fetch uses correlation-safe static public envelopes; shipping, checkout, and runtime evidence remain open",
+  "✔ commerce storefront aggregate fetch uses correlation-safe static public envelopes; checkout and runtime evidence remain open",
 );

--- a/scripts/verify/verify-commerce-storefront-payment-command-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-payment-command-error-safety.mjs
@@ -76,15 +76,15 @@ if (commandStart < 0 || commandEnd < 0) {
   forbidText(command, "error.to_string()", `${transportPath}: direct payment display mapping`);
 }
 
-if (countText(transport, ".map_err(ApiError::from)") !== 2) {
+if (countText(transport, ".map_err(ApiError::from)") !== 1) {
   failures.push(
-    `${transportPath}: exactly shipping selection and checkout completion must remain on the generic mapper`,
+    `${transportPath}: exactly checkout completion must remain on the generic mapper`,
   );
 }
 for (const marker of [
   "select_shipping_option(request.owner_request)",
   "complete_checkout(request).await.map_err(ApiError::from)",
-]) requireText(transport, marker, `${transportPath}: remaining command debt`);
+]) requireText(transport, marker, `${transportPath}: preserved later command boundary`);
 
 for (const [marker, label] of [
   ["pub(super) struct PaymentCollectionCommandErrorContext", "private context"],
@@ -208,7 +208,7 @@ if (review.status !== "commerce_storefront_payment_command_error_safety_source_r
   failures.push(`${reviewPath}: status mismatch`);
 }
 requireText(doc, "Status: **source-ready / unvalidated**", `${docPath}: source status`);
-requireText(doc, "shipping-selection and checkout-completion wrappers remain open", `${docPath}: remaining wrapper scope`);
+requireText(doc, "shipping-selection and checkout-completion wrappers remain open", `${docPath}: historical remaining wrapper scope`);
 requireText(
   plan,
   "Finish correlation-safe mapper cleanup",
@@ -222,5 +222,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "✔ commerce storefront payment collection command uses correlation-safe static public envelopes; shipping, checkout, and runtime evidence remain open",
+  "✔ commerce storefront payment collection command uses correlation-safe static public envelopes; checkout and runtime evidence remain open",
 );

--- a/scripts/verify/verify-commerce-storefront-shipping-command-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-shipping-command-error-safety.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const countText = (source, value) => source.split(value).length - 1;
+
+const transportPath = "crates/rustok-commerce/storefront/src/transport/mod.rs";
+const safetyPath =
+  "crates/rustok-commerce/storefront/src/transport/shipping_option_command_error_safety.rs";
+const fulfillmentTransportPath = "crates/rustok-fulfillment/storefront/src/transport.rs";
+const fulfillmentGraphqlPath =
+  "crates/rustok-fulfillment/storefront/src/transport/graphql_adapter.rs";
+const fulfillmentNativePath =
+  "crates/rustok-fulfillment/storefront/src/transport/native_server_adapter/server_functions.rs";
+const cargoPath = "crates/rustok-commerce/storefront/Cargo.toml";
+const evidencePath =
+  "crates/rustok-commerce/contracts/evidence/storefront-shipping-command-error-safety-source.json";
+const reviewPath =
+  "crates/rustok-commerce/contracts/evidence/storefront-shipping-command-error-safety-source-review.json";
+const docPath =
+  "crates/rustok-commerce/docs/storefront-shipping-option-command-error-safety.md";
+const planPath = "crates/rustok-commerce/docs/implementation-plan.md";
+
+const transport = read(transportPath);
+const safety = read(safetyPath);
+const fulfillmentTransport = read(fulfillmentTransportPath);
+const fulfillmentGraphql = read(fulfillmentGraphqlPath);
+const fulfillmentNative = read(fulfillmentNativePath);
+const cargo = read(cargoPath);
+const evidence = JSON.parse(read(evidencePath));
+const review = JSON.parse(read(reviewPath));
+const doc = read(docPath);
+const plan = read(planPath);
+
+for (const marker of ["tracing.workspace = true", "uuid.workspace = true"]) {
+  requireText(cargo, marker, `${cargoPath}: dependency`);
+}
+
+requireText(
+  transport,
+  "mod shipping_option_command_error_safety;",
+  `${transportPath}: private shipping command policy wiring`,
+);
+const commandStart = transport.indexOf(
+  "pub async fn select_storefront_shipping_option(",
+);
+const commandEnd = transport.indexOf(
+  "pub async fn complete_storefront_checkout(",
+  commandStart,
+);
+if (commandStart < 0 || commandEnd < 0) {
+  failures.push(`${transportPath}: shipping command function boundaries are missing`);
+} else {
+  const command = transport.slice(commandStart, commandEnd);
+  for (const marker of [
+    "ShippingOptionCommandErrorContext::new(&request)",
+    "select_shipping_option(request.owner_request)",
+    ".map_err(|error| error_context.map_error(error))",
+  ]) requireText(command, marker, `${transportPath}: shipping command boundary`);
+  forbidText(command, ".map_err(ApiError::from)", `${transportPath}: generic shipping mapping`);
+  forbidText(command, "error.to_string()", `${transportPath}: direct shipping display mapping`);
+}
+
+if (countText(transport, ".map_err(ApiError::from)") !== 1) {
+  failures.push(
+    `${transportPath}: exactly checkout completion must remain on the generic mapper`,
+  );
+}
+requireText(
+  transport,
+  "complete_checkout(request).await.map_err(ApiError::from)",
+  `${transportPath}: remaining checkout command debt`,
+);
+
+for (const [marker, label] of [
+  ["pub(super) struct ShippingOptionCommandErrorContext", "private context"],
+  ["Uuid::new_v4()", "unique correlation id"],
+  [
+    '"commerce-storefront-shipping:{COMMERCE_STOREFRONT_SHIPPING_OPERATION}:{}"',
+    "correlation namespace",
+  ],
+  ["pub(super) fn map_error(&self, error: UiTransportError)", "transport mapper"],
+  ["fn is_invalid_shipping_selection(error: &UiTransportError)", "validation classifier"],
+  ["fn is_shipping_selection_validation_message(message: &str)", "validation policy"],
+  ['"cart_id must be a valid UUID"', "cart UUID compatibility"],
+  [
+    '"selected_shipping_option_id must be a valid UUID"',
+    "shipping option UUID compatibility",
+  ],
+  ['message.starts_with("delivery group `")', "missing delivery group compatibility"],
+  [
+    'message.contains(" is not available for shipping profile ")',
+    "unavailable option compatibility",
+  ],
+  ['"Invalid shipping selection"', "validation public envelope"],
+  ['"Shipping selection is temporarily unavailable"', "unavailable public envelope"],
+  [
+    '"commerce.storefront_shipping_selection_invalid"',
+    "validation stable code",
+  ],
+  [
+    '"commerce.storefront_shipping_selection_unavailable"',
+    "unavailable stable code",
+  ],
+  ["error = ?error", "private original transport diagnostics"],
+  ["correlation_id = %self.correlation_id", "correlation diagnostics"],
+  ["tenant_slug_length = ?self.tenant_slug_length", "tenant shape diagnostics"],
+  ["cart_id_length = self.cart_id_length", "cart shape diagnostics"],
+  ["delivery_group_count = self.delivery_group_count", "group count diagnostics"],
+  [
+    "available_shipping_option_count = self.available_shipping_option_count",
+    "available option count diagnostics",
+  ],
+  [
+    "shipping_profile_slug_length = self.shipping_profile_slug_length",
+    "shipping profile shape diagnostics",
+  ],
+  ["seller_id_length = ?self.seller_id_length", "seller shape diagnostics"],
+  [
+    "shipping_option_id_length = ?self.shipping_option_id_length",
+    "shipping option shape diagnostics",
+  ],
+  ["failed_path = error.failed_path.as_str()", "failed path diagnostics"],
+  ["fallback_attempted = error.fallback_attempted", "fallback diagnostics"],
+  [
+    "ApiError::Validation(INVALID_SHIPPING_SELECTION.to_string())",
+    "validation mapping",
+  ],
+  [
+    "ApiError::ServerFn(SHIPPING_SELECTION_UNAVAILABLE.to_string())",
+    "native mapping",
+  ],
+  [
+    "ApiError::Graphql(SHIPPING_SELECTION_UNAVAILABLE.to_string())",
+    "GraphQL mapping",
+  ],
+]) requireText(safety, marker, `${safetyPath}: ${label}`);
+
+for (const marker of [
+  "cart_id = %",
+  "cart_id = ?",
+  "shipping_profile_slug = %",
+  "shipping_profile_slug = ?",
+  "seller_id = %",
+  "seller_id = ?",
+  "shipping_option_id = %",
+  "shipping_option_id = ?",
+  "available_shipping_option_ids =",
+  "delivery_groups =",
+  "tenant_slug = %",
+  "tenant_slug = ?",
+  "request = ?request",
+  "ApiError::ServerFn(error.to_string())",
+  "ApiError::Graphql(error.to_string())",
+]) forbidText(safety, marker, `${safetyPath}: raw request or public display mapping`);
+
+for (const marker of [
+  "pub struct SelectShippingOptionRequest",
+  "pub cart_id: String",
+  "pub delivery_groups: Vec<ShippingSelectionDeliveryGroup>",
+  "pub shipping_profile_slug: String",
+  "pub seller_id: Option<String>",
+  "pub shipping_option_id: Option<String>",
+  "pub async fn select_shipping_option(",
+  "build_shipping_selection_updates(&request)",
+]) requireText(fulfillmentTransport, marker, `${fulfillmentTransportPath}: owner request/plan`);
+for (const marker of [
+  "SELECT_STOREFRONT_SHIPPING_OPTION_MUTATION",
+  'parse_required_uuid(&request.cart_id, "cart_id")?',
+  '"selected_shipping_option_id"',
+  'ShippingSelectionTransportError::Validation(format!("{field_name} must be a valid UUID"))',
+]) requireText(fulfillmentGraphql, marker, `${fulfillmentGraphqlPath}: owner GraphQL contract`);
+for (const marker of [
+  "storefront_fulfillment_select_shipping_option_native(request)",
+  'ServerFnError::new("cart_id must be a valid UUID")',
+  '"selected_shipping_option_id"',
+  'ServerFnError::new("Shipping selection is temporarily unavailable")',
+]) requireText(fulfillmentNative, marker, `${fulfillmentNativePath}: owner native contract`);
+
+if (evidence.schema_version !== 1) failures.push(`${evidencePath}: schema_version must be 1`);
+if (
+  evidence.status !==
+  "commerce_storefront_shipping_command_error_safety_source_unvalidated"
+) failures.push(`${evidencePath}: status mismatch`);
+for (const [key, expected] of Object.entries({
+  context_before_owner_call: true,
+  unique_correlation_id: true,
+  owner_validation_static_public_envelope: true,
+  unavailable_static_public_envelope: true,
+  failed_path_api_error_variant_preserved: true,
+  ui_transport_display_public: false,
+  raw_request_values_logged: false,
+  private_transport_error_diagnostics: true,
+  fulfillment_owner_transport_changed: false,
+  payment_wrapper_changed: false,
+  checkout_wrapper_changed: false,
+  fallback_added: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${evidencePath}: source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "focused_verifier_run",
+  "aggregate_verifier_run",
+  "broad_ecommerce_verifier_run",
+  "workflow_checks_run",
+  "ci_run",
+  "native_runtime_proven",
+  "graphql_runtime_proven",
+  "browser_runtime_proven",
+  "mounted_parity_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${evidencePath}: validation.${key} must remain false`);
+  }
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push(`${evidencePath}: execution must remain empty`);
+}
+if (
+  review.status !==
+  "commerce_storefront_shipping_command_error_safety_source_reviewed_unvalidated"
+) failures.push(`${reviewPath}: status mismatch`);
+requireText(doc, "Status: **source-ready / unvalidated**", `${docPath}: source status`);
+requireText(doc, "checkout-completion wrapper remains open", `${docPath}: remaining wrapper scope`);
+requireText(
+  plan,
+  "Finish correlation-safe mapper cleanup",
+  `${planPath}: broad mapper cleanup must remain open`,
+);
+
+if (failures.length > 0) {
+  console.error("Commerce storefront shipping command error-safety verification failed:");
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "✔ commerce storefront shipping option command uses correlation-safe static public envelopes; checkout and runtime evidence remain open",
+);

--- a/scripts/verify/verify-commerce-storefront-transport-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-transport-error-safety.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 import './verify-commerce-storefront-aggregate-error-safety.mjs';
 import './verify-commerce-storefront-payment-command-error-safety.mjs';
+import './verify-commerce-storefront-shipping-command-error-safety.mjs';
 
 const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
 const rootPath = configuredRoot


### PR DESCRIPTION
## Summary
- add a Commerce-owned public error policy for `select_storefront_shipping_option`
- create a per-call context before the Fulfillment owner call with a unique correlation id
- replace the final shipping command `.map_err(ApiError::from)` with a structural `UiTransportError` mapper
- map the existing cart UUID, selected-option UUID, missing-delivery-group, and unavailable-option validation contracts to `ApiError::Validation("Invalid shipping selection")`
- map all other failures to `Shipping selection is temporarily unavailable` while preserving the failed-path `ServerFn` versus `Graphql` variant
- retain the original `UiTransportError` only in internal structured diagnostics
- record only safe request-shape facts: tenant and identifier lengths, delivery-group and option counts, presence flags, failed path, fallback flag, stable code, boundary, and correlation id
- preserve the Fulfillment owner DTO, request normalization, selection planner, GraphQL mutation, native server function, runtime policy, transport selection, and absence of fallback
- add a focused source verifier, include it in the Commerce storefront transport safety aggregate, reduce prior generic-wrapper debt guards from two to one, and retain unvalidated source/review evidence plus documentation

## Scope boundary
This PR changes only the Commerce shipping-option selection wrapper. One command wrapper remains explicit follow-up work on the generic mapper:
- `complete_storefront_checkout`

## Public policy
- recognized owner validation: `Invalid shipping selection`
- native command failure: `Shipping selection is temporarily unavailable`
- GraphQL command failure: `Shipping selection is temporarily unavailable`

## Preserved behavior
- Commerce and Fulfillment request DTOs unchanged
- request normalization and selection planning unchanged
- Fulfillment GraphQL mutation/variables/response mapping unchanged
- Fulfillment native server function unchanged
- owner tenant/auth/request-context/runtime mapping unchanged
- transport selection unchanged
- no native-to-GraphQL fallback added
- aggregate read, payment collection, and checkout completion wrappers unchanged

## Evidence boundary
Source status is `commerce_storefront_shipping_command_error_safety_source_unvalidated`. The broad ecommerce correlation-safe mapper cleanup remains open. No FFA, FBA, browser, native/GraphQL runtime, mounted parity, workflow, CI, or production status is promoted.

## Verification
The ecommerce master plan, Commerce facade and existing aggregate/payment policies, Fulfillment storefront facade/private GraphQL/native adapters, selection planner and validation contracts, `UiTransportError` display/storage contract, existing Commerce guards, final source files, and the nine-file diff were reviewed. The branch is based at `928d829b28fd3316cd0fc8297f59e454f17fc63c`; current main drift is Blog/Profiles/source-replay work and does not overlap these storefront files or guards.

Tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run per maintainer instruction.