### PR TITLE
fix(commerce): sanitize checkout command failures

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/storefront-checkout-command-error-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/storefront-checkout-command-error-safety-source-review.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": 1,
+  "status": "commerce_storefront_checkout_command_error_safety_source_reviewed_unvalidated",
+  "reviewed_at_utc": "2026-07-30T18:08:00Z",
+  "review_base": "b8e1d12f16a49d7f146c16d729ece001817c4681",
+  "scope": "Commerce storefront checkout completion command public transport envelope",
+  "reviewed_sources": [
+    "crates/rustok-commerce/docs/implementation-plan.md",
+    "crates/rustok-commerce/storefront/src/core/requests.rs",
+    "crates/rustok-commerce/storefront/src/transport/mod.rs",
+    "crates/rustok-commerce/storefront/src/transport/aggregate_error_safety.rs",
+    "crates/rustok-commerce/storefront/src/transport/payment_collection_command_error_safety.rs",
+    "crates/rustok-commerce/storefront/src/transport/shipping_option_command_error_safety.rs",
+    "crates/rustok-order/storefront/src/transport.rs",
+    "crates/rustok-order/storefront/src/transport/graphql_adapter.rs",
+    "crates/rustok-order/storefront/src/transport/graphql_error_safety.rs",
+    "crates/rustok-order/storefront/src/transport/native_server_adapter/server_functions.rs",
+    "crates/rustok-ui-transport/src/lib.rs",
+    "crates/rustok-commerce/storefront/Cargo.toml",
+    "scripts/verify/verify-commerce-storefront-aggregate-error-safety.mjs",
+    "scripts/verify/verify-commerce-storefront-payment-command-error-safety.mjs",
+    "scripts/verify/verify-commerce-storefront-shipping-command-error-safety.mjs",
+    "scripts/verify/verify-commerce-storefront-transport-error-safety.mjs",
+    "scripts/verify/verify-commerce-storefront-transport-handoff.mjs"
+  ],
+  "findings": [
+    {
+      "id": "checkout-command-public-display-leak",
+      "severity": "confirmed",
+      "finding": "complete_storefront_checkout converted the Order UiTransportError through ApiError::from, exposing the full transport Display envelope and nested owner text."
+    },
+    {
+      "id": "owner-graphql-validation",
+      "severity": "confirmed",
+      "finding": "The Order GraphQL adapter emits bounded validation messages for cart UUID and idempotency-key shape before transport execution."
+    },
+    {
+      "id": "owner-native-safety",
+      "severity": "preserved",
+      "finding": "The Order native outer adapter already replaces server-function causes with Checkout transport is temporarily unavailable, while the inner native command uses Checkout request is invalid for request validation."
+    },
+    {
+      "id": "owner-graphql-safety",
+      "severity": "preserved",
+      "finding": "The Order GraphQL safety mapper already converts typed GraphqlHttpError variants to static public messages and internal correlation diagnostics."
+    },
+    {
+      "id": "validation-compatibility",
+      "severity": "selected",
+      "finding": "The Commerce mapper recognizes only the two current GraphQL validation envelopes plus the bounded native Checkout request is invalid envelope, then returns ApiError::Validation with Invalid checkout request."
+    },
+    {
+      "id": "generic-mapper-removal",
+      "severity": "selected",
+      "finding": "After the checkout wrapper adopts its own mapper, no Commerce storefront owner wrapper requires From<UiTransportError>; removing that implementation prevents later accidental public Display reuse."
+    },
+    {
+      "id": "safe-request-shape",
+      "severity": "confirmed",
+      "finding": "Diagnostics retain only correlation, tenant and request-field lengths, create_fulfillment, failed path, fallback, stable code, boundary, and private UiTransportError diagnostics."
+    }
+  ],
+  "changed_files_expected": [
+    "crates/rustok-commerce/contracts/evidence/storefront-checkout-command-error-safety-source-review.json",
+    "crates/rustok-commerce/contracts/evidence/storefront-checkout-command-error-safety-source.json",
+    "crates/rustok-commerce/docs/storefront-checkout-completion-command-error-safety.md",
+    "crates/rustok-commerce/storefront/src/transport/checkout_completion_command_error_safety.rs",
+    "crates/rustok-commerce/storefront/src/transport/mod.rs",
+    "scripts/verify/verify-commerce-storefront-aggregate-error-safety.mjs",
+    "scripts/verify/verify-commerce-storefront-checkout-command-error-safety.mjs",
+    "scripts/verify/verify-commerce-storefront-payment-command-error-safety.mjs",
+    "scripts/verify/verify-commerce-storefront-shipping-command-error-safety.mjs",
+    "scripts/verify/verify-commerce-storefront-transport-error-safety.mjs"
+  ],
+  "preserved": [
+    "Commerce CheckoutCompletionCommandRequest alias and Order CompleteCheckoutRequest DTO",
+    "Order idempotency-key generation and command metadata",
+    "Order GraphQL mutation, variables, response mapping, and GraphqlHttpError policy",
+    "Order native server function, staged checkout runtime call, and completion mapping",
+    "native versus GraphQL owner transport selection",
+    "absence of native-to-GraphQL fallback",
+    "Commerce aggregate, payment collection, and shipping selection policies"
+  ],
+  "remaining_scope": [
+    "Pricing storefront and other remaining ecommerce adapters",
+    "remaining non-PortError public envelopes"
+  ],
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "native_runtime_proven": false,
+    "graphql_runtime_proven": false,
+    "browser_runtime_proven": false,
+    "mounted_parity_proven": false
+  }
+}

--- a/crates/rustok-commerce/contracts/evidence/storefront-checkout-command-error-safety-source.json
+++ b/crates/rustok-commerce/contracts/evidence/storefront-checkout-command-error-safety-source.json
@@ -1,0 +1,90 @@
+{
+  "schema_version": 1,
+  "status": "commerce_storefront_checkout_command_error_safety_source_unvalidated",
+  "generated_at_utc": "2026-07-30T18:08:00Z",
+  "scope": "Commerce-owned complete_storefront_checkout public transport envelope",
+  "operation": "complete_storefront_checkout",
+  "boundary": "commerce_storefront_checkout_completion_public_transport",
+  "public_messages": {
+    "invalid_checkout_request": "Invalid checkout request",
+    "checkout_completion_unavailable": "Checkout completion is temporarily unavailable"
+  },
+  "recognized_owner_validation_envelopes": [
+    "cart_id must be a valid UUID",
+    "checkout idempotency key must contain 1 to 191 bytes",
+    "Checkout request is invalid"
+  ],
+  "source_contract": {
+    "context_before_owner_call": true,
+    "unique_correlation_id": true,
+    "owner_validation_static_public_envelope": true,
+    "unavailable_static_public_envelope": true,
+    "failed_path_api_error_variant_preserved": true,
+    "ui_transport_display_public": false,
+    "generic_ui_transport_mapper_removed": true,
+    "raw_request_values_logged": false,
+    "private_transport_error_diagnostics": true,
+    "order_owner_transport_changed": false,
+    "aggregate_wrapper_changed": false,
+    "payment_wrapper_changed": false,
+    "shipping_wrapper_changed": false,
+    "fallback_added": false
+  },
+  "safe_diagnostics": [
+    "owner",
+    "owner_operation",
+    "correlation_id",
+    "tenant_slug_configured",
+    "tenant_slug_length",
+    "cart_id_length",
+    "idempotency_key_length",
+    "source_module_length",
+    "source_surface_length",
+    "command_length",
+    "owner_module_length",
+    "create_fulfillment",
+    "failed_path",
+    "fallback_attempted",
+    "stable_code",
+    "boundary",
+    "private_ui_transport_error"
+  ],
+  "forbidden_public_or_structured_request_values": [
+    "tenant_slug",
+    "cart_id",
+    "idempotency_key",
+    "source_module",
+    "source_surface",
+    "command",
+    "owner_module",
+    "native_error",
+    "graphql_error",
+    "UiTransportError display"
+  ],
+  "commerce_storefront_wrapper_state": {
+    "aggregate_fetch_generic_mapper": false,
+    "payment_collection_generic_mapper": false,
+    "shipping_selection_generic_mapper": false,
+    "checkout_completion_generic_mapper": false,
+    "generic_from_ui_transport_error_present": false
+  },
+  "remaining_scope": [
+    "finish Pricing storefront and other remaining ecommerce adapters",
+    "finish remaining non-PortError public envelopes"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "focused_verifier_run": false,
+    "aggregate_verifier_run": false,
+    "broad_ecommerce_verifier_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "native_runtime_proven": false,
+    "graphql_runtime_proven": false,
+    "browser_runtime_proven": false,
+    "mounted_parity_proven": false
+  },
+  "execution": []
+}

--- a/crates/rustok-commerce/docs/storefront-checkout-completion-command-error-safety.md
+++ b/crates/rustok-commerce/docs/storefront-checkout-completion-command-error-safety.md
@@ -1,0 +1,162 @@
+# Commerce storefront checkout completion command error safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens only the Commerce-owned wrapper:
+
+- `complete_storefront_checkout`;
+- `crates/rustok-commerce/storefront/src/transport/mod.rs`;
+- `crates/rustok-commerce/storefront/src/transport/checkout_completion_command_error_safety.rs`.
+
+The aggregate read, payment-collection command, and shipping-selection command policies remain unchanged.
+
+After this slice, no Commerce storefront command wrapper remains on the generic mapper. The broad ecommerce correlation-safe mapper cleanup remains open for other module adapters and non-`PortError` public envelopes.
+
+## Confirmed gap
+
+The Order storefront owner returns a `UiTransportError` from its selected native or GraphQL transport. Commerce previously called:
+
+```rust
+complete_checkout(request).await.map_err(ApiError::from)
+```
+
+The generic `From<UiTransportError>` implementation copied `UiTransportError::to_string()` into the public `ApiError`. That display includes the failed transport path and the nested owner error text.
+
+The Order owner already bounds technical failures:
+
+- typed GraphQL failures become static checkout messages;
+- native server-function failures become `Checkout transport is temporarily unavailable`;
+- request validation is represented by bounded cart-ID and idempotency-key messages.
+
+The final Commerce wrapper nevertheless republished the complete transport display rather than applying its own public policy.
+
+## Implementation
+
+`CheckoutCompletionCommandErrorContext` is created before the Order owner call. Each command receives a unique correlation id in the namespace:
+
+```text
+commerce-storefront-checkout:complete_storefront_checkout:<uuid>
+```
+
+After `complete_checkout`, the final `UiTransportError` is mapped by the Commerce-owned context.
+
+The generic `impl From<UiTransportError> for ApiError` was removed from the Commerce storefront facade because no remaining Commerce owner wrapper uses it.
+
+### Public policy
+
+| Condition | Public `ApiError` |
+| --- | --- |
+| Recognized cart UUID or idempotency validation | `Validation("Invalid checkout request")` |
+| Bounded native `Checkout request is invalid` validation | `Validation("Invalid checkout request")` |
+| Native owner failure | `ServerFn("Checkout completion is temporarily unavailable")` |
+| GraphQL owner failure | `Graphql("Checkout completion is temporarily unavailable")` |
+
+Recognized validation envelopes are limited to:
+
+- `cart_id must be a valid UUID`;
+- `checkout idempotency key must contain 1 to 191 bytes`;
+- `Checkout request is invalid`.
+
+Arbitrary nested transport text is never forwarded to the public result.
+
+## Internal diagnostics
+
+The original `UiTransportError` is retained only as a private structured tracing field. The event also records:
+
+- Commerce owner and operation;
+- unique correlation id;
+- whether a tenant slug is configured and its character length;
+- cart-id character length;
+- idempotency-key character length;
+- source-module, source-surface, command, and owner-module character lengths;
+- the `create_fulfillment` boolean;
+- failed transport path;
+- fallback flag;
+- stable internal code;
+- boundary name.
+
+The structured request fields do not contain the tenant slug, cart ID, idempotency key, or command metadata values. The private error field may retain owner details for operators but is never copied into the public `ApiError`.
+
+## Preserved behavior
+
+This slice does not change:
+
+- the Commerce `CheckoutCompletionCommandRequest` alias;
+- the Order `CompleteCheckoutRequest` DTO;
+- cart-ID normalization;
+- idempotency-key generation;
+- Order-owned command metadata;
+- the GraphQL mutation, variables, or response mapping;
+- typed GraphQL error classification;
+- the native server function;
+- request, tenant, and authentication context extraction;
+- staged checkout orchestration;
+- payment, order, fulfillment, and adjustment result mapping;
+- native versus GraphQL feature selection;
+- fallback behavior;
+- aggregate Commerce reads;
+- payment collection creation;
+- shipping option selection;
+- FFA, FBA, browser, runtime, workflow, CI, or production status.
+
+## Commerce wrapper state
+
+All four Commerce storefront entry points now use boundary-owned public error policies:
+
+- aggregate storefront fetch;
+- payment collection creation;
+- shipping option selection;
+- checkout completion.
+
+The facade no longer contains:
+
+```rust
+impl From<UiTransportError> for ApiError
+```
+
+and contains no `.map_err(ApiError::from)` owner-wrapper call sites.
+
+## Static evidence
+
+Focused source evidence:
+
+- `crates/rustok-commerce/contracts/evidence/storefront-checkout-command-error-safety-source.json`;
+- `crates/rustok-commerce/contracts/evidence/storefront-checkout-command-error-safety-source-review.json`;
+- `scripts/verify/verify-commerce-storefront-checkout-command-error-safety.mjs`.
+
+The focused verifier is imported by:
+
+- `scripts/verify/verify-commerce-storefront-transport-error-safety.mjs`.
+
+The prior aggregate, payment-command, and shipping-command guards now require zero generic Commerce owner mappings and the absence of the generic `From<UiTransportError>` implementation.
+
+All execution and runtime validation flags remain `false`. Source review alone does not prove native, GraphQL, browser, mounted, workflow, CI, or production behavior.
+
+## Remaining work
+
+The master correlation-safe mapper cleanup remains open for:
+
+- Pricing storefront and other remaining ecommerce adapters;
+- remaining non-`PortError` public envelopes;
+- any runtime verification and deployment evidence owned by maintainers.
+
+Closing the Commerce storefront wrapper subset does not close the broad ecommerce plan item.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-commerce-storefront-checkout-command-error-safety.mjs
+node scripts/verify/verify-commerce-storefront-shipping-command-error-safety.mjs
+node scripts/verify/verify-commerce-storefront-payment-command-error-safety.mjs
+node scripts/verify/verify-commerce-storefront-aggregate-error-safety.mjs
+node scripts/verify/verify-commerce-storefront-transport-error-safety.mjs
+node scripts/verify/verify-commerce-storefront-transport-handoff.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-commerce-storefront
+cargo check -p rustok-commerce-storefront --features hydrate
+cargo check -p rustok-commerce-storefront --features ssr
+```

--- a/crates/rustok-commerce/storefront/src/transport/checkout_completion_command_error_safety.rs
+++ b/crates/rustok-commerce/storefront/src/transport/checkout_completion_command_error_safety.rs
@@ -109,12 +109,9 @@ fn is_invalid_checkout_request(error: &UiTransportError) -> bool {
         .into_iter()
         .flatten()
         .any(|message| {
-            matches!(
-                message,
-                CART_ID_UUID_VALIDATION
-                    | IDEMPOTENCY_KEY_VALIDATION
-                    | OWNER_INVALID_CHECKOUT_REQUEST
-            )
+            message == CART_ID_UUID_VALIDATION
+                || message == IDEMPOTENCY_KEY_VALIDATION
+                || message == OWNER_INVALID_CHECKOUT_REQUEST
         })
 }
 

--- a/crates/rustok-commerce/storefront/src/transport/checkout_completion_command_error_safety.rs
+++ b/crates/rustok-commerce/storefront/src/transport/checkout_completion_command_error_safety.rs
@@ -1,0 +1,134 @@
+use rustok_ui_transport::{UiTransportError, UiTransportPath};
+use uuid::Uuid;
+
+use crate::core::CheckoutCompletionCommandRequest;
+
+use super::shared_adapter::ApiError;
+
+const COMMERCE_STOREFRONT_CHECKOUT_OWNER: &str = "rustok_commerce.storefront";
+const COMMERCE_STOREFRONT_CHECKOUT_OPERATION: &str = "complete_storefront_checkout";
+const COMMERCE_STOREFRONT_CHECKOUT_BOUNDARY: &str =
+    "commerce_storefront_checkout_completion_public_transport";
+const CART_ID_UUID_VALIDATION: &str = "cart_id must be a valid UUID";
+const IDEMPOTENCY_KEY_VALIDATION: &str =
+    "checkout idempotency key must contain 1 to 191 bytes";
+const OWNER_INVALID_CHECKOUT_REQUEST: &str = "Checkout request is invalid";
+const INVALID_CHECKOUT_REQUEST: &str = "Invalid checkout request";
+const CHECKOUT_COMPLETION_UNAVAILABLE: &str =
+    "Checkout completion is temporarily unavailable";
+
+pub(super) struct CheckoutCompletionCommandErrorContext {
+    correlation_id: String,
+    tenant_slug_length: Option<usize>,
+    cart_id_length: usize,
+    idempotency_key_length: usize,
+    source_module_length: usize,
+    source_surface_length: usize,
+    command_length: usize,
+    owner_module_length: usize,
+    create_fulfillment: bool,
+}
+
+impl CheckoutCompletionCommandErrorContext {
+    pub(super) fn new(request: &CheckoutCompletionCommandRequest) -> Self {
+        Self {
+            correlation_id: format!(
+                "commerce-storefront-checkout:{COMMERCE_STOREFRONT_CHECKOUT_OPERATION}:{}",
+                Uuid::new_v4()
+            ),
+            tenant_slug_length: configured_tenant_slug_length(),
+            cart_id_length: request.cart_id.chars().count(),
+            idempotency_key_length: request.idempotency_key.chars().count(),
+            source_module_length: request.metadata.source_module.chars().count(),
+            source_surface_length: request.metadata.source_surface.chars().count(),
+            command_length: request.metadata.command.chars().count(),
+            owner_module_length: request.metadata.owner_module.chars().count(),
+            create_fulfillment: request.metadata.create_fulfillment,
+        }
+    }
+
+    pub(super) fn map_error(&self, error: UiTransportError) -> ApiError {
+        if is_invalid_checkout_request(&error) {
+            tracing::warn!(
+                error = ?error,
+                owner = COMMERCE_STOREFRONT_CHECKOUT_OWNER,
+                owner_operation = COMMERCE_STOREFRONT_CHECKOUT_OPERATION,
+                correlation_id = %self.correlation_id,
+                tenant_slug_configured = self.tenant_slug_length.is_some(),
+                tenant_slug_length = ?self.tenant_slug_length,
+                cart_id_length = self.cart_id_length,
+                idempotency_key_length = self.idempotency_key_length,
+                source_module_length = self.source_module_length,
+                source_surface_length = self.source_surface_length,
+                command_length = self.command_length,
+                owner_module_length = self.owner_module_length,
+                create_fulfillment = self.create_fulfillment,
+                failed_path = error.failed_path.as_str(),
+                fallback_attempted = error.fallback_attempted,
+                code = "commerce.storefront_checkout_request_invalid",
+                boundary = COMMERCE_STOREFRONT_CHECKOUT_BOUNDARY,
+                "commerce storefront checkout completion validation failed"
+            );
+            return ApiError::Validation(INVALID_CHECKOUT_REQUEST.to_string());
+        }
+
+        tracing::error!(
+            error = ?error,
+            owner = COMMERCE_STOREFRONT_CHECKOUT_OWNER,
+            owner_operation = COMMERCE_STOREFRONT_CHECKOUT_OPERATION,
+            correlation_id = %self.correlation_id,
+            tenant_slug_configured = self.tenant_slug_length.is_some(),
+            tenant_slug_length = ?self.tenant_slug_length,
+            cart_id_length = self.cart_id_length,
+            idempotency_key_length = self.idempotency_key_length,
+            source_module_length = self.source_module_length,
+            source_surface_length = self.source_surface_length,
+            command_length = self.command_length,
+            owner_module_length = self.owner_module_length,
+            create_fulfillment = self.create_fulfillment,
+            failed_path = error.failed_path.as_str(),
+            fallback_attempted = error.fallback_attempted,
+            code = "commerce.storefront_checkout_completion_unavailable",
+            boundary = COMMERCE_STOREFRONT_CHECKOUT_BOUNDARY,
+            "commerce storefront checkout completion command failed"
+        );
+
+        match error.failed_path {
+            UiTransportPath::NativeServer => {
+                ApiError::ServerFn(CHECKOUT_COMPLETION_UNAVAILABLE.to_string())
+            }
+            UiTransportPath::Graphql => {
+                ApiError::Graphql(CHECKOUT_COMPLETION_UNAVAILABLE.to_string())
+            }
+        }
+    }
+}
+
+fn is_invalid_checkout_request(error: &UiTransportError) -> bool {
+    [error.native_error.as_deref(), error.graphql_error.as_deref()]
+        .into_iter()
+        .flatten()
+        .any(|message| {
+            matches!(
+                message,
+                CART_ID_UUID_VALIDATION
+                    | IDEMPOTENCY_KEY_VALIDATION
+                    | OWNER_INVALID_CHECKOUT_REQUEST
+            )
+        })
+}
+
+fn configured_tenant_slug_length() -> Option<usize> {
+    [
+        "RUSTOK_TENANT_SLUG",
+        "NEXT_PUBLIC_TENANT_SLUG",
+        "NEXT_PUBLIC_DEFAULT_TENANT_SLUG",
+    ]
+    .into_iter()
+    .find_map(|key| {
+        std::env::var(key).ok().and_then(|value| {
+            let value = value.trim();
+            (!value.is_empty()).then_some(value.chars().count())
+        })
+    })
+}

--- a/crates/rustok-commerce/storefront/src/transport/mod.rs
+++ b/crates/rustok-commerce/storefront/src/transport/mod.rs
@@ -1,4 +1,5 @@
 mod aggregate_error_safety;
+mod checkout_completion_command_error_safety;
 mod graphql_adapter;
 mod native_server_adapter;
 mod payment_collection_command_error_safety;
@@ -15,7 +16,7 @@ use crate::model::{
 use rustok_fulfillment_storefront::transport::select_shipping_option;
 use rustok_order_storefront::transport::complete_checkout;
 use rustok_payment_storefront::transport::create_payment_collection;
-use rustok_ui_transport::{UiTransportError, UiTransportPath, execute_selected_transport};
+use rustok_ui_transport::{UiTransportPath, execute_selected_transport};
 use shared_adapter::ApiError;
 
 pub async fn fetch_storefront_commerce(
@@ -59,7 +60,13 @@ pub async fn select_storefront_shipping_option(
 pub async fn complete_storefront_checkout(
     request: CheckoutCompletionCommandRequest,
 ) -> Result<StorefrontCheckoutCompletion, ApiError> {
-    complete_checkout(request).await.map_err(ApiError::from)
+    let error_context =
+        checkout_completion_command_error_safety::CheckoutCompletionCommandErrorContext::new(
+            &request,
+        );
+    complete_checkout(request)
+        .await
+        .map_err(|error| error_context.map_error(error))
 }
 
 fn selected_transport_path() -> UiTransportPath {
@@ -70,15 +77,6 @@ fn selected_transport_path() -> UiTransportPath {
     #[cfg(not(any(feature = "ssr", feature = "hydrate")))]
     {
         UiTransportPath::Graphql
-    }
-}
-
-impl From<UiTransportError> for ApiError {
-    fn from(value: UiTransportError) -> Self {
-        match value.failed_path {
-            UiTransportPath::NativeServer => Self::ServerFn(value.to_string()),
-            UiTransportPath::Graphql => Self::Graphql(value.to_string()),
-        }
     }
 }
 

--- a/scripts/verify/verify-commerce-storefront-aggregate-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-aggregate-error-safety.mjs
@@ -88,14 +88,14 @@ if (fetchStart < 0 || nextFunction < 0) {
   );
 }
 
-requireText(
+forbidText(
   transport,
   "impl From<UiTransportError> for ApiError",
-  `${transportPath}: generic command-wrapper mapper remains explicit debt`,
+  `${transportPath}: generic UiTransportError display mapper`,
 );
-if (countText(transport, ".map_err(ApiError::from)") !== 1) {
+if (countText(transport, ".map_err(ApiError::from)") !== 0) {
   failures.push(
-    `${transportPath}: exactly checkout completion must remain on the generic mapper`,
+    `${transportPath}: no Commerce owner wrapper may remain on the generic mapper`,
   );
 }
 for (const marker of [
@@ -236,5 +236,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "✔ commerce storefront aggregate fetch uses correlation-safe static public envelopes; checkout and runtime evidence remain open",
+  "✔ commerce storefront aggregate fetch uses correlation-safe static public envelopes; no generic Commerce owner wrapper remains and runtime evidence stays open",
 );

--- a/scripts/verify/verify-commerce-storefront-checkout-command-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-checkout-command-error-safety.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const countText = (source, value) => source.split(value).length - 1;
+
+const transportPath = "crates/rustok-commerce/storefront/src/transport/mod.rs";
+const safetyPath =
+  "crates/rustok-commerce/storefront/src/transport/checkout_completion_command_error_safety.rs";
+const orderTransportPath = "crates/rustok-order/storefront/src/transport.rs";
+const orderGraphqlPath =
+  "crates/rustok-order/storefront/src/transport/graphql_adapter.rs";
+const orderGraphqlSafetyPath =
+  "crates/rustok-order/storefront/src/transport/graphql_error_safety.rs";
+const orderNativePath =
+  "crates/rustok-order/storefront/src/transport/native_server_adapter/server_functions.rs";
+const cargoPath = "crates/rustok-commerce/storefront/Cargo.toml";
+const evidencePath =
+  "crates/rustok-commerce/contracts/evidence/storefront-checkout-command-error-safety-source.json";
+const reviewPath =
+  "crates/rustok-commerce/contracts/evidence/storefront-checkout-command-error-safety-source-review.json";
+const docPath =
+  "crates/rustok-commerce/docs/storefront-checkout-completion-command-error-safety.md";
+const planPath = "crates/rustok-commerce/docs/implementation-plan.md";
+
+const transport = read(transportPath);
+const safety = read(safetyPath);
+const orderTransport = read(orderTransportPath);
+const orderGraphql = read(orderGraphqlPath);
+const orderGraphqlSafety = read(orderGraphqlSafetyPath);
+const orderNative = read(orderNativePath);
+const cargo = read(cargoPath);
+const evidence = JSON.parse(read(evidencePath));
+const review = JSON.parse(read(reviewPath));
+const doc = read(docPath);
+const plan = read(planPath);
+
+for (const marker of ["tracing.workspace = true", "uuid.workspace = true"]) {
+  requireText(cargo, marker, `${cargoPath}: dependency`);
+}
+
+requireText(
+  transport,
+  "mod checkout_completion_command_error_safety;",
+  `${transportPath}: private checkout command policy wiring`,
+);
+const commandStart = transport.indexOf(
+  "pub async fn complete_storefront_checkout(",
+);
+const commandEnd = transport.indexOf("fn selected_transport_path()", commandStart);
+if (commandStart < 0 || commandEnd < 0) {
+  failures.push(`${transportPath}: checkout command function boundaries are missing`);
+} else {
+  const command = transport.slice(commandStart, commandEnd);
+  for (const marker of [
+    "CheckoutCompletionCommandErrorContext::new(",
+    "&request,",
+    "complete_checkout(request)",
+    ".map_err(|error| error_context.map_error(error))",
+  ]) requireText(command, marker, `${transportPath}: checkout command boundary`);
+  forbidText(command, ".map_err(ApiError::from)", `${transportPath}: generic checkout mapping`);
+  forbidText(command, "error.to_string()", `${transportPath}: direct checkout display mapping`);
+}
+
+if (countText(transport, ".map_err(ApiError::from)") !== 0) {
+  failures.push(`${transportPath}: no Commerce owner wrapper may remain on ApiError::from`);
+}
+forbidText(
+  transport,
+  "impl From<UiTransportError> for ApiError",
+  `${transportPath}: generic UiTransportError display mapper`,
+);
+forbidText(
+  transport,
+  "UiTransportError, UiTransportPath",
+  `${transportPath}: stale generic mapper import`,
+);
+
+for (const [marker, label] of [
+  ["pub(super) struct CheckoutCompletionCommandErrorContext", "private context"],
+  ["Uuid::new_v4()", "unique correlation id"],
+  [
+    '"commerce-storefront-checkout:{COMMERCE_STOREFRONT_CHECKOUT_OPERATION}:{}"',
+    "correlation namespace",
+  ],
+  ["pub(super) fn map_error(&self, error: UiTransportError)", "transport mapper"],
+  ["fn is_invalid_checkout_request(error: &UiTransportError)", "validation classifier"],
+  ['"cart_id must be a valid UUID"', "cart UUID compatibility"],
+  [
+    '"checkout idempotency key must contain 1 to 191 bytes"',
+    "idempotency validation compatibility",
+  ],
+  ['"Checkout request is invalid"', "native validation compatibility"],
+  ['"Invalid checkout request"', "validation public envelope"],
+  [
+    '"Checkout completion is temporarily unavailable"',
+    "unavailable public envelope",
+  ],
+  [
+    '"commerce.storefront_checkout_request_invalid"',
+    "validation stable code",
+  ],
+  [
+    '"commerce.storefront_checkout_completion_unavailable"',
+    "unavailable stable code",
+  ],
+  ["error = ?error", "private original transport diagnostics"],
+  ["correlation_id = %self.correlation_id", "correlation diagnostics"],
+  ["tenant_slug_length = ?self.tenant_slug_length", "tenant shape diagnostics"],
+  ["cart_id_length = self.cart_id_length", "cart shape diagnostics"],
+  [
+    "idempotency_key_length = self.idempotency_key_length",
+    "idempotency shape diagnostics",
+  ],
+  ["source_module_length = self.source_module_length", "metadata module shape"],
+  ["source_surface_length = self.source_surface_length", "metadata surface shape"],
+  ["command_length = self.command_length", "metadata command shape"],
+  ["owner_module_length = self.owner_module_length", "metadata owner shape"],
+  ["create_fulfillment = self.create_fulfillment", "fulfillment flag"],
+  ["failed_path = error.failed_path.as_str()", "failed path diagnostics"],
+  ["fallback_attempted = error.fallback_attempted", "fallback diagnostics"],
+  [
+    "ApiError::Validation(INVALID_CHECKOUT_REQUEST.to_string())",
+    "validation mapping",
+  ],
+  [
+    "ApiError::ServerFn(CHECKOUT_COMPLETION_UNAVAILABLE.to_string())",
+    "native mapping",
+  ],
+  [
+    "ApiError::Graphql(CHECKOUT_COMPLETION_UNAVAILABLE.to_string())",
+    "GraphQL mapping",
+  ],
+]) requireText(safety, marker, `${safetyPath}: ${label}`);
+
+for (const marker of [
+  "cart_id = %",
+  "cart_id = ?",
+  "idempotency_key = %",
+  "idempotency_key = ?",
+  "source_module = %",
+  "source_module = ?",
+  "source_surface = %",
+  "source_surface = ?",
+  "command = %",
+  "command = ?",
+  "owner_module = %",
+  "owner_module = ?",
+  "tenant_slug = %",
+  "tenant_slug = ?",
+  "request = ?request",
+  "ApiError::ServerFn(error.to_string())",
+  "ApiError::Graphql(error.to_string())",
+]) forbidText(safety, marker, `${safetyPath}: raw request or public display mapping`);
+
+for (const marker of [
+  "pub struct CompleteCheckoutRequest",
+  "pub cart_id: String",
+  "pub idempotency_key: String",
+  "pub metadata: CheckoutCompletionCommandMetadata",
+  "pub async fn complete_checkout(",
+  '"complete_checkout"',
+  "create_fulfillment: true",
+]) requireText(orderTransport, marker, `${orderTransportPath}: owner request/operation`);
+for (const marker of [
+  "COMPLETE_STOREFRONT_CHECKOUT_MUTATION",
+  'CheckoutCompletionTransportError::Validation("cart_id must be a valid UUID".to_string())',
+  '"checkout idempotency key must contain 1 to 191 bytes"',
+  "metadata.create_fulfillment",
+]) requireText(orderGraphql, marker, `${orderGraphqlPath}: owner GraphQL contract`);
+for (const marker of [
+  '"Checkout completion is temporarily unavailable"',
+  '"Checkout authentication is required"',
+  '"Checkout request could not be completed"',
+]) requireText(orderGraphqlSafety, marker, `${orderGraphqlSafetyPath}: owner GraphQL safety`);
+for (const marker of [
+  "storefront_order_complete_checkout_native(request)",
+  'ServerFnError::new("Checkout request is invalid")',
+  '"Checkout transport is temporarily unavailable"',
+  "complete_storefront_checkout_with_product_port",
+]) requireText(orderNative, marker, `${orderNativePath}: owner native contract`);
+
+if (evidence.schema_version !== 1) failures.push(`${evidencePath}: schema_version must be 1`);
+if (
+  evidence.status !==
+  "commerce_storefront_checkout_command_error_safety_source_unvalidated"
+) failures.push(`${evidencePath}: status mismatch`);
+for (const [key, expected] of Object.entries({
+  context_before_owner_call: true,
+  unique_correlation_id: true,
+  owner_validation_static_public_envelope: true,
+  unavailable_static_public_envelope: true,
+  failed_path_api_error_variant_preserved: true,
+  ui_transport_display_public: false,
+  generic_ui_transport_mapper_removed: true,
+  raw_request_values_logged: false,
+  private_transport_error_diagnostics: true,
+  order_owner_transport_changed: false,
+  aggregate_wrapper_changed: false,
+  payment_wrapper_changed: false,
+  shipping_wrapper_changed: false,
+  fallback_added: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${evidencePath}: source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "focused_verifier_run",
+  "aggregate_verifier_run",
+  "broad_ecommerce_verifier_run",
+  "workflow_checks_run",
+  "ci_run",
+  "native_runtime_proven",
+  "graphql_runtime_proven",
+  "browser_runtime_proven",
+  "mounted_parity_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${evidencePath}: validation.${key} must remain false`);
+  }
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push(`${evidencePath}: execution must remain empty`);
+}
+if (
+  review.status !==
+  "commerce_storefront_checkout_command_error_safety_source_reviewed_unvalidated"
+) failures.push(`${reviewPath}: status mismatch`);
+requireText(doc, "Status: **source-ready / unvalidated**", `${docPath}: source status`);
+requireText(
+  doc,
+  "no Commerce storefront command wrapper remains on the generic mapper",
+  `${docPath}: completed Commerce wrapper scope`,
+);
+requireText(
+  plan,
+  "Finish correlation-safe mapper cleanup",
+  `${planPath}: broad mapper cleanup must remain open`,
+);
+
+if (failures.length > 0) {
+  console.error("Commerce storefront checkout command error-safety verification failed:");
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "✔ commerce storefront checkout completion uses correlation-safe static public envelopes; no generic Commerce owner wrapper remains and runtime evidence stays open",
+);

--- a/scripts/verify/verify-commerce-storefront-payment-command-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-payment-command-error-safety.mjs
@@ -76,14 +76,19 @@ if (commandStart < 0 || commandEnd < 0) {
   forbidText(command, "error.to_string()", `${transportPath}: direct payment display mapping`);
 }
 
-if (countText(transport, ".map_err(ApiError::from)") !== 1) {
+if (countText(transport, ".map_err(ApiError::from)") !== 0) {
   failures.push(
-    `${transportPath}: exactly checkout completion must remain on the generic mapper`,
+    `${transportPath}: no Commerce owner wrapper may remain on the generic mapper`,
   );
 }
+forbidText(
+  transport,
+  "impl From<UiTransportError> for ApiError",
+  `${transportPath}: generic UiTransportError display mapper`,
+);
 for (const marker of [
   "select_shipping_option(request.owner_request)",
-  "complete_checkout(request).await.map_err(ApiError::from)",
+  "complete_checkout(request)",
 ]) requireText(transport, marker, `${transportPath}: preserved later command boundary`);
 
 for (const [marker, label] of [
@@ -222,5 +227,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "✔ commerce storefront payment collection command uses correlation-safe static public envelopes; checkout and runtime evidence remain open",
+  "✔ commerce storefront payment collection command uses correlation-safe static public envelopes; no generic Commerce owner wrapper remains and runtime evidence stays open",
 );

--- a/scripts/verify/verify-commerce-storefront-shipping-command-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-shipping-command-error-safety.mjs
@@ -75,15 +75,20 @@ if (commandStart < 0 || commandEnd < 0) {
   forbidText(command, "error.to_string()", `${transportPath}: direct shipping display mapping`);
 }
 
-if (countText(transport, ".map_err(ApiError::from)") !== 1) {
+if (countText(transport, ".map_err(ApiError::from)") !== 0) {
   failures.push(
-    `${transportPath}: exactly checkout completion must remain on the generic mapper`,
+    `${transportPath}: no Commerce owner wrapper may remain on the generic mapper`,
   );
 }
+forbidText(
+  transport,
+  "impl From<UiTransportError> for ApiError",
+  `${transportPath}: generic UiTransportError display mapper`,
+);
 requireText(
   transport,
-  "complete_checkout(request).await.map_err(ApiError::from)",
-  `${transportPath}: remaining checkout command debt`,
+  "complete_checkout(request)",
+  `${transportPath}: preserved checkout command boundary`,
 );
 
 for (const [marker, label] of [
@@ -240,7 +245,7 @@ if (
   "commerce_storefront_shipping_command_error_safety_source_reviewed_unvalidated"
 ) failures.push(`${reviewPath}: status mismatch`);
 requireText(doc, "Status: **source-ready / unvalidated**", `${docPath}: source status`);
-requireText(doc, "checkout-completion wrapper remains open", `${docPath}: remaining wrapper scope`);
+requireText(doc, "checkout-completion wrapper remains open", `${docPath}: historical remaining wrapper scope`);
 requireText(
   plan,
   "Finish correlation-safe mapper cleanup",
@@ -254,5 +259,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "✔ commerce storefront shipping option command uses correlation-safe static public envelopes; checkout and runtime evidence remain open",
+  "✔ commerce storefront shipping option command uses correlation-safe static public envelopes; no generic Commerce owner wrapper remains and runtime evidence stays open",
 );

--- a/scripts/verify/verify-commerce-storefront-transport-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-transport-error-safety.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import './verify-commerce-storefront-aggregate-error-safety.mjs';
 import './verify-commerce-storefront-payment-command-error-safety.mjs';
 import './verify-commerce-storefront-shipping-command-error-safety.mjs';
+import './verify-commerce-storefront-checkout-command-error-safety.mjs';
 
 const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
 const rootPath = configuredRoot
@@ -188,5 +189,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ commerce storefront request/tenant context plus cart/payment transport failures retain actual request identity, static public envelopes, and no client-side raw causes; runtime evidence remains open',
+  '✔ commerce storefront request/tenant context plus aggregate, payment, shipping, and checkout transport failures retain static public envelopes and no client-side raw causes; runtime evidence remains open',
 );


### PR DESCRIPTION
## Summary
- add a Commerce-owned public error policy for `complete_storefront_checkout`
- create a per-call context before the Order owner call with a unique correlation id
- replace the final checkout `.map_err(ApiError::from)` with a structural `UiTransportError` mapper
- map the existing cart UUID, idempotency-key, and bounded native checkout validation contracts to `ApiError::Validation("Invalid checkout request")`
- map all other failures to `Checkout completion is temporarily unavailable` while preserving the failed-path `ServerFn` versus `Graphql` variant
- retain the original `UiTransportError` only in internal structured diagnostics
- record only safe request-shape facts: tenant/cart/idempotency/metadata lengths, create-fulfillment flag, failed path, fallback flag, stable code, boundary, and correlation id
- remove the now-unused generic `impl From<UiTransportError> for ApiError` from the Commerce storefront facade
- preserve the Order owner DTO, idempotency generation, GraphQL mutation and typed error policy, native server function, staged checkout orchestration, transport selection, and absence of fallback
- add focused source verification, include it in the Commerce transport safety aggregate, update the aggregate/payment/shipping guards to require zero generic owner mappings, and retain unvalidated source/review evidence plus documentation

## Scope boundary
This PR changes only the Commerce checkout-completion wrapper and removes the generic mapper that is no longer used. All four Commerce storefront entry points now apply boundary-owned public error policies:
- aggregate fetch
- payment collection creation
- shipping option selection
- checkout completion

The broad ecommerce correlation-safe mapper cleanup remains open for Pricing storefront, other remaining ecommerce adapters, and non-`PortError` public envelopes.

## Public policy
- recognized checkout request validation: `Invalid checkout request`
- native command failure: `Checkout completion is temporarily unavailable`
- GraphQL command failure: `Checkout completion is temporarily unavailable`

## Preserved behavior
- Commerce request alias and Order `CompleteCheckoutRequest` unchanged
- cart normalization, idempotency-key generation, and Order-owned metadata unchanged
- Order GraphQL mutation/variables/response mapping unchanged
- Order typed GraphQL error classification unchanged
- Order native server function and staged checkout runtime call unchanged
- transport selection unchanged
- no native-to-GraphQL fallback added
- Commerce aggregate, payment, and shipping policies unchanged

## Evidence boundary
Source status is `commerce_storefront_checkout_command_error_safety_source_unvalidated`. No FFA, FBA, browser, native/GraphQL runtime, mounted parity, workflow, CI, or production status is promoted.

## Verification
The ecommerce master plan, Commerce facade and prior policies, Order storefront facade/private GraphQL/native adapters, validation contracts, `UiTransportError` display/storage contract, existing Commerce guards, final source files, and the ten-file diff were reviewed. The branch is based at `b8e1d12f16a49d7f146c16d729ece001817c4681`; current main drift touches Blog, Forum/Search/Profiles/Customer, Cargo.lock, and Payment compensation, with no overlap in these Commerce storefront source or verifier files.

Tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run per maintainer instruction.