### PR TITLE
feat(forum): filter Search by exact category

### DIFF
--- a/crates/rustok-forum/contracts/forum-search-exact-category-filter.json
+++ b/crates/rustok-forum/contracts/forum-search-exact-category-filter.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-23B1",
+  "status": "source_complete_execution_pending",
+  "scope": "Extend the existing bounded category_ids Search query contract so exact Forum category, topic, and approved-reply documents can be filtered without changing product category semantics",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "forum_projection_owner": "crates/rustok-forum/src/search_projection.rs",
+  "search_query_contract": "crates/rustok-search/src/engine.rs",
+  "search_graphql_input": "crates/rustok-search/src/graphql/types.rs",
+  "search_graphql_normalization": "crates/rustok-search/src/graphql/query.rs",
+  "postgres_filter_owner": "crates/rustok-search/src/pg_engine.rs",
+  "search_readme": "crates/rustok-search/README.md",
+  "owner_note": "crates/rustok-forum/docs/forum-23b1-exact-category-filter.md",
+  "verifier": "scripts/verify/verify-forum-search-exact-category-filter.mjs",
+  "query_boundary": {
+    "existing_category_ids_input_is_reused": true,
+    "graphql_field_added": false,
+    "category_id_count_remains_bounded_by_existing_limit": true,
+    "invalid_category_uuid_is_rejected_before_execution": true,
+    "storefront_published_only_policy_is_preserved": true,
+    "caller_can_constrain_forum_only_results_with_source_modules": true
+  },
+  "projection_boundary": {
+    "forum_category_matches_its_document_id": true,
+    "forum_topic_projects_exact_category_id_facet": true,
+    "forum_reply_projects_exact_topic_category_id_facet": true,
+    "category_filter_does_not_copy_category_tree_policy": true,
+    "pending_hidden_or_denied_documents_remain_absent_from_public_projection": true
+  },
+  "postgres_boundary": {
+    "product_category_exists_clause_is_preserved": true,
+    "forum_branch_is_source_module_scoped": true,
+    "forum_category_matches_uuid_document_id": true,
+    "forum_topic_and_reply_match_category_id_jsonb_facet": true,
+    "uuid_and_facet_values_use_bound_parameters": true,
+    "fts_ranked_cte_carries_facets": true,
+    "typo_ranked_cte_carries_facets": true,
+    "total_items_and_facets_use_the_same_filter_clause": true
+  },
+  "compatibility": {
+    "search_graphql_schema_changed": false,
+    "search_query_rust_shape_changed": false,
+    "product_category_filter_removed": false,
+    "forum_projection_shape_changed": false,
+    "database_migration_added": false,
+    "dependency_added": false,
+    "cargo_lock_changed": false
+  },
+  "remaining_scope": [
+    "expand an exact category into a bounded visibility-authorized category subtree",
+    "add exact public author tag locale date solved kind channel group and attachment-presence filters",
+    "add category facet aggregation and labels if a product surface requires them",
+    "capture maintainer-executed PostgreSQL query and result evidence"
+  ],
+  "verification": {
+    "execution_status": "not_run_by_implementation_agent",
+    "commands": [
+      "node scripts/verify/verify-forum-search-exact-category-filter.mjs",
+      "cargo test -p rustok-search category_filter_preserves_product_and_adds_exact_forum_scope -- --nocapture",
+      "cargo test -p rustok-search pg_engine -- --nocapture",
+      "cargo check -p rustok-search --all-targets",
+      "cargo xtask module validate search",
+      "cargo xtask module validate forum"
+    ]
+  },
+  "non_claims": {
+    "category_subtree_expansion_is_complete": true,
+    "category_descendants_are_resolved_at_query_time": true,
+    "category_facet_buckets_are_added": true,
+    "all_forum_filters_are_complete": true,
+    "runtime_verification_was_executed": true
+  },
+  "downstream_task": "FORUM-23B2"
+}

--- a/crates/rustok-forum/contracts/forum-search-exact-category-filter.json
+++ b/crates/rustok-forum/contracts/forum-search-exact-category-filter.json
@@ -10,6 +10,7 @@
   "search_graphql_normalization": "crates/rustok-search/src/graphql/query.rs",
   "postgres_filter_owner": "crates/rustok-search/src/pg_engine.rs",
   "search_readme": "crates/rustok-search/README.md",
+  "search_plan": "crates/rustok-search/docs/implementation-plan.md",
   "owner_note": "crates/rustok-forum/docs/forum-23b1-exact-category-filter.md",
   "verifier": "scripts/verify/verify-forum-search-exact-category-filter.mjs",
   "query_boundary": {

--- a/crates/rustok-forum/docs/forum-23b1-exact-category-filter.md
+++ b/crates/rustok-forum/docs/forum-23b1-exact-category-filter.md
@@ -1,0 +1,70 @@
+# FORUM-23B1: exact category Search filter
+
+Date: 2026-07-30
+
+Status: `source_complete_execution_pending`
+
+## Purpose
+
+Forum Search already projects public category, topic, and approved-reply documents. Topic and reply documents carry the exact public category identifier in their bounded JSONB facets, while category documents retain their category identifier as the Search document identifier.
+
+The shared Search query contract already exposes a bounded `category_ids` input for product category filtering. B1 extends that existing contract rather than adding a Forum-only transport field.
+
+## Query contract
+
+`SearchPreviewInput.category_ids` remains the public GraphQL input. Existing normalization still:
+
+- accepts at most ten values;
+- parses every value as a UUID before query execution;
+- rejects invalid UUIDs;
+- applies the same input to preview, admin global Search, and public storefront Search;
+- preserves the storefront `published_only` policy.
+
+Callers that require only Forum documents should pair `category_ids` with `source_modules: ["forum"]`. A mixed-source query may intentionally return matching product and Forum documents because `category_ids` is a shared owner-neutral Search field.
+
+## PostgreSQL filter behavior
+
+`PgSearchEngine::build_filter_clause` retains the existing product branch based on `index_product_categories`. It adds a separate `source_module = 'forum'` branch:
+
+- `forum_category` documents match when `document_id` equals one of the requested category identifiers;
+- `forum_topic` and `forum_reply` documents match when `facets.category_id` equals one of the requested identifiers.
+
+UUID owner identifiers and their JSON string representations are inserted only as bound parameters. The query does not interpolate caller values into SQL.
+
+Both the full-text and typo-tolerant ranked CTEs now carry `search_documents.facets`. Total counting, paged result loading, and facet aggregation continue to use the same generated filter clause.
+
+## Projection authority
+
+Forum remains the source of category placement. Search reads only the already-authorized public projection:
+
+- category documents come from public category discovery;
+- topics come from public topic and category discovery;
+- replies require approved status and reauthorize their topic and category;
+- pending, hidden, denied, deleted, or otherwise non-public owner state is not made searchable by this filter.
+
+B1 does not copy category-tree visibility or placement policy into Search.
+
+## Scope boundary
+
+This is an exact-category foundation, not category-subtree completion. It does not resolve descendants, read the Forum category tree during a Search request, add category bucket labels, or implement the remaining author, tag, locale, date, solved, kind, channel/group, and attachment-presence filters.
+
+A bounded, visibility-authorized subtree expansion remains `FORUM-23B2`.
+
+## Compatibility
+
+No GraphQL field, Rust `SearchQuery` field, Search document shape, Forum projection shape, database migration, dependency, or `Cargo.lock` change is introduced. Existing product category filtering remains active.
+
+## Maintainer verification
+
+Not run by the implementation agent, per maintainer instruction.
+
+Suggested commands:
+
+```bash
+node scripts/verify/verify-forum-search-exact-category-filter.mjs
+cargo test -p rustok-search category_filter_preserves_product_and_adds_exact_forum_scope -- --nocapture
+cargo test -p rustok-search pg_engine -- --nocapture
+cargo check -p rustok-search --all-targets
+cargo xtask module validate search
+cargo xtask module validate forum
+```

--- a/crates/rustok-search/README.md
+++ b/crates/rustok-search/README.md
@@ -14,6 +14,10 @@ RusToK.
   analytics, diagnostics, and rebuild behavior.
 - Execute PostgreSQL FTS with `tsvector`, `websearch_to_tsquery`, `ts_rank_cd`,
   highlights, typo-tolerant fallback, filters, sorting, and facets.
+- Interpret the bounded `category_ids` query field across owner projections:
+  normalized product-category relations remain authoritative for products, while
+  public Forum category/topic/reply documents use their exact projected category
+  identity. Owner subtree expansion remains outside the Search engine.
 - Consume product-owned high-load projections from `rustok-index` without
   exposing index runtime types to Search consumers.
 - Consume Blog lifecycle and scoped rebuild events into Search-owned documents.
@@ -123,6 +127,10 @@ transport-local Blog route builder, or compatibility URL implementation.
 - Blog projection follows the active PostgreSQL `search_path` and removes stale
   documents before source lookup.
 - Product filters use normalized category, channel, and attribute projections.
+- Exact Forum category filtering reuses `category_ids`: category documents match
+  their document identifier and topic/reply documents match the public
+  `facets.category_id` value. Search does not resolve descendants or copy Forum
+  tree policy.
 - GraphQL and native Leptos transports expose the same normalized query/result
   fields.
 - The Search admin native adapter is split into focused API, read, write,
@@ -146,7 +154,9 @@ transport-local Blog route builder, or compatibility URL implementation.
 - `node scripts/verify/verify-search-canonical-url-contract.test.mjs`
 - `node scripts/verify/verify-search-blog-projection.mjs`
 - `node scripts/verify/verify-search-blog-projection.test.mjs`
+- `node scripts/verify/verify-forum-search-exact-category-filter.mjs`
 - `cargo test -p rustok-search engine::tests::canonical_url`
+- `cargo test -p rustok-search category_filter_preserves_product_and_adds_exact_forum_scope -- --nocapture`
 - `cargo xtask module validate search`
 
 ## Docs

--- a/crates/rustok-search/docs/implementation-plan.md
+++ b/crates/rustok-search/docs/implementation-plan.md
@@ -2,30 +2,31 @@
 
 ## Current state
 
-`rustok-search` owns normalized search documents, PostgreSQL FTS, catalog and Blog
-projection ingestion, analytics, dictionaries, query rules, rebuild/diagnostics,
-and module-owned admin/storefront surfaces. It remains separate from
-`rustok-index`; consumers depend on published Search contracts rather than index
-runtime types. The FFA split is `phase_b_ready` with focused core, transport, and
-UI packages.
+`rustok-search` owns normalized search documents, PostgreSQL FTS, catalog, Blog,
+and Forum projection ingestion, analytics, dictionaries, query rules,
+rebuild/diagnostics, and module-owned admin/storefront surfaces. It remains
+separate from `rustok-index`; consumers depend on published Search contracts
+rather than index runtime types. The FFA split is `phase_b_ready` with focused
+core, transport, and UI packages.
 
 Canonical result navigation has a single owner policy:
 `canonical_search_result_url` in `crates/rustok-search/src/engine.rs`. It derives
-product, content, and Blog URLs from normalized `SearchResultItem` values before
-transport serialization. Blog navigation requires the canonical
+product, content, Blog, and Forum URLs from normalized `SearchResultItem` values
+before transport serialization. Blog navigation requires the canonical
 `source_module=blog` / `entity_type=blog_post` pair and a bounded ASCII slug from
-the owner-projected payload. Missing, malformed, spoofed, traversal, whitespace,
-and overlong values fail closed. Content source-module values are bounded before
-they enter a query string.
+the owner-projected payload. Forum navigation requires canonical Forum
+source/entity pairs and validates reply payload identity. Missing, malformed,
+spoofed, traversal, whitespace, and overlong values fail closed. Content
+source-module values are bounded before they enter a query string.
 
 GraphQL Search, storefront native Search, Search admin preview, and admin global
 search all delegate to this single owner policy. The storefront transport facade
 returns the selected transport payload unchanged: there is no transport fallback,
-no post-processing navigation module, and no local Blog route builder. The Search
-admin native adapter is split into focused include-parts for API facade, read
-handlers, write handlers, normalization, execution pipeline, mapping, and support.
-Only the mapping part converts normalized results to admin DTOs, and it delegates
-URL resolution to `canonical_search_result_url`.
+no post-processing navigation module, and no local Blog or Forum route builder.
+The Search admin native adapter is split into focused include-parts for API
+facade, read handlers, write handlers, normalization, execution pipeline,
+mapping, and support. Only the mapping part converts normalized results to admin
+DTOs, and it delegates URL resolution to `canonical_search_result_url`.
 
 Blog ingestion has two executable, unrun harness layers. A routing target locks
 Blog lifecycle, module-toggle, and targeted/full reindex events. An env-gated
@@ -35,6 +36,14 @@ payload replacement, checks tenant-scoped full rebuild, targeted missing-post
 cleanup, and module-disabled cleanup followed by enable-time rebuild. Source-table
 availability resolves through the active PostgreSQL `search_path` instead of
 hard-coding `public`.
+
+Forum public category, topic, and approved-reply projections now support an exact
+category filter through the existing bounded `category_ids` query field. Product
+queries retain normalized `index_product_categories` matching. Forum category
+documents match their document identifier, while topic and reply documents match
+the owner-projected `facets.category_id`. Search does not resolve descendants or
+copy Forum category-tree policy; bounded subtree expansion remains Forum-owned
+follow-up work.
 
 Search settings have one owner boundary. Tenant-effective settings are read and
 written through `SearchSettingsService` and the `search_settings` table. The
@@ -83,6 +92,11 @@ projection can remain stale after recovery.
   `crates/rustok-search/contracts/evidence/search-blog-projection-postgres-harness.json`.
 - Blog projection harness status: `executable_no_run`; execution remains user-owned
   and requires `RUSTOK_SEARCH_TEST_DATABASE_URL` or PostgreSQL `DATABASE_URL`.
+- Exact Forum category filter status: `source_complete_execution_pending`.
+- Exact Forum category filter contract:
+  `crates/rustok-forum/contracts/forum-search-exact-category-filter.json`.
+- Exact Forum category filter guardrail:
+  `scripts/verify/verify-forum-search-exact-category-filter.mjs`.
 - GraphQL and all native/admin mappings use the same Search-owned URL function.
 - The removed storefront `transport/navigation.rs` path is forbidden by the
   canonical URL guardrail.
@@ -122,8 +136,9 @@ rebuild behavior through replayable event transport.
    handling, stale cleanup, and tenant isolation.
 2. Added isolated-schema PostgreSQL Blog projection harnesses and active
    `search_path` discovery.
-3. Added `canonical_search_result_url` with product, content, and Blog routing,
-   bounded slug validation, source/entity ownership, and query-injection guards.
+3. Added `canonical_search_result_url` with product, content, Blog, and Forum
+   routing, bounded payload validation, source/entity ownership, and
+   query-injection guards.
 4. Exported the owner policy and migrated GraphQL result projection.
 5. Migrated storefront native result projection to the owner policy.
 6. Removed storefront post-transport navigation enrichment and deleted its source
@@ -137,9 +152,12 @@ rebuild behavior through replayable event transport.
     every transport-local URL implementation and require no transport fallback.
 11. Added canonical URL ownership to the standard Search FBA gate alongside the
     provider port, fallback, runtime contract, and invocation evidence.
-12. Removed the legacy generic `platform_settings/search` execution path and added
-    a fail-closed FBA ownership guard so runtime connector secrets stay inside the
+12. Removed the generic `platform_settings/search` execution path and added a
+    fail-closed FBA ownership guard so runtime connector secrets stay inside the
     Search owner boundary.
+13. Reused bounded `category_ids` for exact Forum category, topic, and approved-reply
+    filtering while preserving product category relations, parameterized SQL, and
+    the shared FTS/typo filter path.
 
 ## Next results
 
@@ -158,18 +176,22 @@ rebuild behavior through replayable event transport.
    **Done when:** terminal handler failure, transport lag, duplicate/out-of-order
    delivery, and process restart cannot leave a stale projection without an
    observable durable recovery action.
-3. **Execute canonical URL evidence.** Run core URL-policy tests, GraphQL
+3. **Complete Forum category-subtree filtering.** Accept a bounded owner-authorized
+   category scope from Forum rather than reading its tree in Search. Preserve exact
+   matching as the fallback foundation and keep descendant count, visibility, and
+   request cost bounded.
+4. **Execute canonical URL evidence.** Run core URL-policy tests, GraphQL
    storefront Search, native storefront Search, Search admin preview, and admin
-   global search against projected product, content, and Blog documents. Retain
-   proof that malformed Blog payloads remain non-navigable everywhere.
-4. **Verify click analytics.** Confirm every Search surface records the canonical
+   global search against projected product, content, Blog, and Forum documents.
+   Retain proof that malformed owner payloads remain non-navigable everywhere.
+5. **Verify click analytics.** Confirm every Search surface records the canonical
    href without reconstructing routes in analytics code.
-5. **Execute live Blog projection evidence.** Run routing and PostgreSQL harnesses
+6. **Execute live Blog projection evidence.** Run routing and PostgreSQL harnesses
    and retain migration/`pg_trgm`, event-delivery, targeted missing-post cleanup,
    module-disable cleanup, and category reindex results.
-6. **Execute live provider evidence.** Run query and suggestion providers under
+7. **Execute live provider evidence.** Run query and suggestion providers under
    deadline, error, locale, tenant, channel, ranking, and catalog-filter conditions.
-7. **Add external engines only as adapters.** Meilisearch, Typesense, or Algolia
+8. **Add external engines only as adapters.** Meilisearch, Typesense, or Algolia
    connectors must not bypass Search ports, owner URL mapping, or PostgreSQL
    baseline selection.
 
@@ -177,6 +199,8 @@ rebuild behavior through replayable event transport.
 
 - `cargo test -p rustok-server settings_service`
 - `cargo test -p rustok-search engine::tests::canonical_url`
+- `cargo test -p rustok-search category_filter_preserves_product_and_adds_exact_forum_scope -- --nocapture`
+- `node scripts/verify/verify-forum-search-exact-category-filter.mjs`
 - `node scripts/verify/verify-search-canonical-url-contract.mjs`
 - `node scripts/verify/verify-search-canonical-url-contract.test.mjs`
 - `cargo test -p rustok-search --test blog_ingestion_contract_test`
@@ -192,6 +216,7 @@ rebuild behavior through replayable event transport.
 - [Crate README](../README.md)
 - [Search documentation](./README.md)
 - [Search FBA registry](../contracts/search-fba-registry.json)
+- [Forum exact-category contract](../../rustok-forum/contracts/forum-search-exact-category-filter.json)
 
 ## Periodic release verification handoff
 

--- a/crates/rustok-search/src/pg_engine.rs
+++ b/crates/rustok-search/src/pg_engine.rs
@@ -120,16 +120,39 @@ fn build_filter_clause(query: &SearchQuery, starting_param: usize) -> FilterClau
         ));
     }
     if !query.category_ids.is_empty() {
+        let category_params =
+            bind_uuid_list(&query.category_ids, &mut values, &mut next_param);
+        let category_facet_values = query
+            .category_ids
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        let category_facet_params =
+            bind_list(&category_facet_values, &mut values, &mut next_param);
         clauses.push(format!(
-            "entity_type = 'product' AND EXISTS (
-                SELECT 1
-                FROM index_product_categories ipc
-                WHERE ipc.tenant_id = $1
-                  AND ipc.product_id = id
-                  AND ($2 = '' OR ipc.locale = $2)
-                  AND ipc.category_id IN ({})
-            )",
-            bind_uuid_list(&query.category_ids, &mut values, &mut next_param)
+            "(
+                (
+                    entity_type = 'product'
+                    AND EXISTS (
+                        SELECT 1
+                        FROM index_product_categories ipc
+                        WHERE ipc.tenant_id = $1
+                          AND ipc.product_id = id
+                          AND ($2 = '' OR ipc.locale = $2)
+                          AND ipc.category_id IN ({category_params})
+                    )
+                )
+                OR (
+                    source_module = 'forum'
+                    AND (
+                        (entity_type = 'forum_category' AND id IN ({category_params}))
+                        OR (
+                            entity_type IN ('forum_topic', 'forum_reply')
+                            AND facets ->> 'category_id' IN ({category_facet_params})
+                        )
+                    )
+                )
+            )"
         ));
     }
     for filter in &query.attribute_filters {
@@ -426,6 +449,7 @@ fn build_fts_cte(profile: SearchRankingProfile) -> String {
                 ts_headline('simple', sd.body, q.ts_query) AS snippet,
                 __SCORE_SQL__ AS score,
                 sd.payload AS payload,
+                sd.facets AS facets,
                 sd.is_public AS is_public,
                 sd.updated_at AS updated_at
             FROM search_documents sd
@@ -480,6 +504,7 @@ fn build_typo_cte(profile: SearchRankingProfile) -> String {
                 ) AS snippet,
                 __SCORE_SQL__ AS score,
                 sd.payload AS payload,
+                sd.facets AS facets,
                 sd.is_public AS is_public,
                 sd.updated_at AS updated_at
             FROM search_documents sd
@@ -741,6 +766,29 @@ fn empty_facets() -> Vec<SearchFacetGroup> {
 mod tests {
     use super::{build_filter_clause, should_run_typo_fallback};
     use crate::{SearchRankingProfile, engine::SearchQuery};
+    use uuid::Uuid;
+
+    fn query_with_categories(category_ids: Vec<Uuid>) -> SearchQuery {
+        SearchQuery {
+            tenant_id: None,
+            locale: None,
+            channel_id: None,
+            original_query: "phone".to_string(),
+            query: "phone".to_string(),
+            ranking_profile: SearchRankingProfile::Balanced,
+            preset_key: None,
+            limit: 10,
+            offset: 0,
+            published_only: false,
+            entity_types: Vec::new(),
+            source_modules: Vec::new(),
+            statuses: Vec::new(),
+            category_ids,
+            attribute_filters: Vec::new(),
+            sort_attribute_code: None,
+            sort_desc: false,
+        }
+    }
 
     #[test]
     fn filter_clause_uses_bound_parameters() {
@@ -772,6 +820,23 @@ mod tests {
             "is_public = TRUE AND entity_type IN ($4) AND source_module IN ($5) AND status IN ($6)"
         );
         assert_eq!(filters.values.len(), 3);
+    }
+
+    #[test]
+    fn category_filter_preserves_product_and_adds_exact_forum_scope() {
+        let filters = build_filter_clause(&query_with_categories(vec![Uuid::from_u128(7)]), 4);
+
+        for marker in [
+            "entity_type = 'product'",
+            "ipc.category_id IN ($4)",
+            "source_module = 'forum'",
+            "entity_type = 'forum_category' AND id IN ($4)",
+            "entity_type IN ('forum_topic', 'forum_reply')",
+            "facets ->> 'category_id' IN ($5)",
+        ] {
+            assert!(filters.clause.contains(marker), "missing {marker}");
+        }
+        assert_eq!(filters.values.len(), 2);
     }
 
     #[test]

--- a/scripts/verify/verify-forum-search-exact-category-filter.mjs
+++ b/scripts/verify/verify-forum-search-exact-category-filter.mjs
@@ -15,6 +15,7 @@ const graphqlTypesPath = "crates/rustok-search/src/graphql/types.rs";
 const graphqlQueryPath = "crates/rustok-search/src/graphql/query.rs";
 const pgEnginePath = "crates/rustok-search/src/pg_engine.rs";
 const searchReadmePath = "crates/rustok-search/README.md";
+const searchPlanPath = "crates/rustok-search/docs/implementation-plan.md";
 const contractPath = "crates/rustok-forum/contracts/forum-search-exact-category-filter.json";
 const notePath = "crates/rustok-forum/docs/forum-23b1-exact-category-filter.md";
 const verifierPath = "scripts/verify/verify-forum-search-exact-category-filter.mjs";
@@ -72,6 +73,7 @@ const graphqlTypes = read(graphqlTypesPath);
 const graphqlQuery = read(graphqlQueryPath);
 const pgEngine = read(pgEnginePath);
 const searchReadme = read(searchReadmePath);
+const searchPlan = read(searchPlanPath);
 const note = read(notePath);
 const contract = parseJson(contractPath);
 
@@ -91,13 +93,14 @@ requireAll(
     'const FORUM_CATEGORY_ENTITY_TYPE: &str = "forum_category"',
     'const FORUM_TOPIC_ENTITY_TYPE: &str = "forum_topic"',
     'const FORUM_REPLY_ENTITY_TYPE: &str = "forum_reply"',
-    '"category_id": topic.category_id',
-    '"category_id": topic.category_id',
     'document_id: category.id',
     "Some(&[ReplyStatus::Approved])",
   ],
   projectionPath,
 );
+if ((projection.match(/"category_id": topic\.category_id/g) ?? []).length < 2) {
+  failures.push(`${projectionPath}: topic and reply documents must both project category_id`);
+}
 
 requireAll(
   queryContract,
@@ -175,6 +178,16 @@ requireAll(
   searchReadmePath,
 );
 requireAll(
+  searchPlan,
+  [
+    "Exact Forum category filter status: `source_complete_execution_pending`",
+    "forum-search-exact-category-filter.json",
+    "Reused bounded `category_ids` for exact Forum category",
+    "Complete Forum category-subtree filtering",
+  ],
+  searchPlanPath,
+);
+requireAll(
   note,
   [
     "FORUM-23B1",
@@ -203,6 +216,7 @@ if (contract) {
     search_graphql_normalization: graphqlQueryPath,
     postgres_filter_owner: pgEnginePath,
     search_readme: searchReadmePath,
+    search_plan: searchPlanPath,
     owner_note: notePath,
     verifier: verifierPath,
   };

--- a/scripts/verify/verify-forum-search-exact-category-filter.mjs
+++ b/scripts/verify/verify-forum-search-exact-category-filter.mjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(".");
+const failures = [];
+
+const planPath = "crates/rustok-forum/docs/implementation-plan.md";
+const projectionPath = "crates/rustok-forum/src/search_projection.rs";
+const queryContractPath = "crates/rustok-search/src/engine.rs";
+const graphqlTypesPath = "crates/rustok-search/src/graphql/types.rs";
+const graphqlQueryPath = "crates/rustok-search/src/graphql/query.rs";
+const pgEnginePath = "crates/rustok-search/src/pg_engine.rs";
+const searchReadmePath = "crates/rustok-search/README.md";
+const contractPath = "crates/rustok-forum/contracts/forum-search-exact-category-filter.json";
+const notePath = "crates/rustok-forum/docs/forum-23b1-exact-category-filter.md";
+const verifierPath = "scripts/verify/verify-forum-search-exact-category-filter.mjs";
+
+function read(relativePath) {
+  const target = path.join(root, relativePath);
+  if (!existsSync(target)) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return "";
+  }
+  return readFileSync(target, "utf8");
+}
+
+function parseJson(relativePath) {
+  try {
+    return JSON.parse(read(relativePath));
+  } catch (error) {
+    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function requireMarker(source, marker, label) {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+}
+
+function rejectMarker(source, marker, label) {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+}
+
+function requireAll(source, markers, label) {
+  for (const marker of markers) requireMarker(source, marker, label);
+}
+
+function requireOrder(source, markers, label) {
+  let previous = -1;
+  for (const marker of markers) {
+    const current = source.indexOf(marker, previous + 1);
+    if (current < 0) {
+      failures.push(`${label}: missing ordered marker ${marker}`);
+      return;
+    }
+    if (current <= previous) {
+      failures.push(`${label}: marker out of order ${marker}`);
+      return;
+    }
+    previous = current;
+  }
+}
+
+const plan = read(planPath);
+const projection = read(projectionPath);
+const queryContract = read(queryContractPath);
+const graphqlTypes = read(graphqlTypesPath);
+const graphqlQuery = read(graphqlQueryPath);
+const pgEngine = read(pgEnginePath);
+const searchReadme = read(searchReadmePath);
+const note = read(notePath);
+const contract = parseJson(contractPath);
+
+requireAll(
+  plan,
+  [
+    "## `FORUM-23` — search/index integration",
+    "Search filters include",
+    "category subtree, author, tag, locale, date, solved, kind, channel/group and",
+  ],
+  planPath,
+);
+
+requireAll(
+  projection,
+  [
+    'const FORUM_CATEGORY_ENTITY_TYPE: &str = "forum_category"',
+    'const FORUM_TOPIC_ENTITY_TYPE: &str = "forum_topic"',
+    'const FORUM_REPLY_ENTITY_TYPE: &str = "forum_reply"',
+    '"category_id": topic.category_id',
+    '"category_id": topic.category_id',
+    'document_id: category.id',
+    "Some(&[ReplyStatus::Approved])",
+  ],
+  projectionPath,
+);
+
+requireAll(
+  queryContract,
+  [
+    "pub struct SearchQuery",
+    "pub category_ids: Vec<Uuid>",
+  ],
+  queryContractPath,
+);
+requireAll(
+  graphqlTypes,
+  [
+    "pub struct SearchPreviewInput",
+    "pub category_ids: Option<Vec<String>>",
+  ],
+  graphqlTypesPath,
+);
+requireAll(
+  graphqlQuery,
+  [
+    'normalize_uuid_values("category_ids", input.category_ids)?',
+    "if values.len() > MAX_FILTER_VALUES",
+    "Uuid::parse_str(value.trim())",
+    "category_ids: input.category_ids",
+    "published_only: policy.published_only",
+  ],
+  graphqlQueryPath,
+);
+
+requireAll(
+  pgEngine,
+  [
+    "let category_params =",
+    "bind_uuid_list(&query.category_ids, &mut values, &mut next_param)",
+    ".map(ToString::to_string)",
+    "bind_list(&category_facet_values, &mut values, &mut next_param)",
+    "entity_type = 'product'",
+    "FROM index_product_categories ipc",
+    "ipc.category_id IN ({category_params})",
+    "source_module = 'forum'",
+    "entity_type = 'forum_category' AND id IN ({category_params})",
+    "entity_type IN ('forum_topic', 'forum_reply')",
+    "facets ->> 'category_id' IN ({category_facet_params})",
+    "sd.facets AS facets",
+    "category_filter_preserves_product_and_adds_exact_forum_scope",
+    '"ipc.category_id IN ($4)"',
+    '"facets ->> \'category_id\' IN ($5)"',
+    "assert_eq!(filters.values.len(), 2)",
+  ],
+  pgEnginePath,
+);
+requireOrder(
+  pgEngine,
+  [
+    "bind_uuid_list(&query.category_ids, &mut values, &mut next_param)",
+    "bind_list(&category_facet_values, &mut values, &mut next_param)",
+    "clauses.push(format!",
+  ],
+  pgEnginePath,
+);
+if ((pgEngine.match(/sd\.facets AS facets/g) ?? []).length !== 2) {
+  failures.push(`${pgEnginePath}: both ranked CTEs must carry facets`);
+}
+rejectMarker(pgEngine, "format!(query.category_ids", pgEnginePath);
+rejectMarker(pgEngine, "facets ->> 'category_id' = ANY('{", pgEnginePath);
+
+requireAll(
+  searchReadme,
+  [
+    "Interpret the bounded `category_ids` query field across owner projections",
+    "Exact Forum category filtering reuses `category_ids`",
+    "Search does not resolve descendants or copy Forum tree policy",
+    "verify-forum-search-exact-category-filter.mjs",
+  ],
+  searchReadmePath,
+);
+requireAll(
+  note,
+  [
+    "FORUM-23B1",
+    "exact-category foundation",
+    "source_modules: [\"forum\"]",
+    "index_product_categories",
+    "facets.category_id",
+    "bound parameters",
+    "not category-subtree completion",
+    "FORUM-23B2",
+    "Not run by the implementation agent",
+  ],
+  notePath,
+);
+
+if (contract) {
+  if (contract.task !== "FORUM-23B1") failures.push(`${contractPath}: unexpected task`);
+  if (contract.status !== "source_complete_execution_pending") {
+    failures.push(`${contractPath}: unexpected status`);
+  }
+  const expectedPaths = {
+    canonical_plan: planPath,
+    forum_projection_owner: projectionPath,
+    search_query_contract: queryContractPath,
+    search_graphql_input: graphqlTypesPath,
+    search_graphql_normalization: graphqlQueryPath,
+    postgres_filter_owner: pgEnginePath,
+    search_readme: searchReadmePath,
+    owner_note: notePath,
+    verifier: verifierPath,
+  };
+  for (const [key, expected] of Object.entries(expectedPaths)) {
+    if (contract[key] !== expected) failures.push(`${contractPath}: ${key} drift`);
+  }
+
+  for (const key of [
+    "existing_category_ids_input_is_reused",
+    "category_id_count_remains_bounded_by_existing_limit",
+    "invalid_category_uuid_is_rejected_before_execution",
+    "storefront_published_only_policy_is_preserved",
+    "caller_can_constrain_forum_only_results_with_source_modules",
+  ]) {
+    if (contract.query_boundary?.[key] !== true) {
+      failures.push(`${contractPath}: query boundary ${key} drift`);
+    }
+  }
+  if (contract.query_boundary?.graphql_field_added !== false) {
+    failures.push(`${contractPath}: GraphQL field addition must remain false`);
+  }
+
+  for (const key of [
+    "forum_category_matches_its_document_id",
+    "forum_topic_projects_exact_category_id_facet",
+    "forum_reply_projects_exact_topic_category_id_facet",
+    "category_filter_does_not_copy_category_tree_policy",
+    "pending_hidden_or_denied_documents_remain_absent_from_public_projection",
+  ]) {
+    if (contract.projection_boundary?.[key] !== true) {
+      failures.push(`${contractPath}: projection boundary ${key} drift`);
+    }
+  }
+
+  for (const key of [
+    "product_category_exists_clause_is_preserved",
+    "forum_branch_is_source_module_scoped",
+    "forum_category_matches_uuid_document_id",
+    "forum_topic_and_reply_match_category_id_jsonb_facet",
+    "uuid_and_facet_values_use_bound_parameters",
+    "fts_ranked_cte_carries_facets",
+    "typo_ranked_cte_carries_facets",
+    "total_items_and_facets_use_the_same_filter_clause",
+  ]) {
+    if (contract.postgres_boundary?.[key] !== true) {
+      failures.push(`${contractPath}: PostgreSQL boundary ${key} drift`);
+    }
+  }
+
+  for (const key of [
+    "search_graphql_schema_changed",
+    "search_query_rust_shape_changed",
+    "product_category_filter_removed",
+    "forum_projection_shape_changed",
+    "database_migration_added",
+    "dependency_added",
+    "cargo_lock_changed",
+  ]) {
+    if (contract.compatibility?.[key] !== false) {
+      failures.push(`${contractPath}: compatibility ${key} must remain false`);
+    }
+  }
+
+  for (const key of [
+    "category_subtree_expansion_is_complete",
+    "category_descendants_are_resolved_at_query_time",
+    "category_facet_buckets_are_added",
+    "all_forum_filters_are_complete",
+    "runtime_verification_was_executed",
+  ]) {
+    if (contract.non_claims?.[key] !== true) {
+      failures.push(`${contractPath}: non-claim ${key} drift`);
+    }
+  }
+  if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+    failures.push(`${contractPath}: execution status drift`);
+  }
+  if (contract.downstream_task !== "FORUM-23B2") {
+    failures.push(`${contractPath}: unexpected downstream task`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Forum exact category Search filter verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum exact category Search filter verification passed.");


### PR DESCRIPTION
## Summary

Implements `FORUM-23B1`, the exact-category Search filter foundation.

- reuse the existing bounded `category_ids` Search input instead of adding a Forum-only transport field;
- preserve normalized product-category filtering through `index_product_categories`;
- match public Forum category documents by their category document ID;
- match public Forum topic and approved-reply documents by projected `facets.category_id`;
- keep the Forum SQL branch constrained by `source_module = 'forum'`;
- bind both UUID identifiers and JSON facet strings as PostgreSQL parameters;
- carry JSONB facets through both FTS and typo-tolerant ranked CTEs so totals, items, and facet aggregation share one filter clause;
- add focused source tests for product preservation, exact Forum scope, and bind positions;
- add the B1 contract, owner note, Search README/implementation-plan updates, and a dedicated verifier.

## Scope boundary

This is exact-category filtering only. It does not resolve category descendants, read the Forum tree during a Search request, add category facet buckets, or complete the remaining author/tag/locale/date/solved/kind/channel/group/attachment filters. Bounded owner-authorized subtree expansion remains `FORUM-23B2`.

A mixed-source query may intentionally return matching product and Forum documents. Callers that need Forum-only results should combine `category_ids` with `source_modules: ["forum"]`.

## Compatibility

No GraphQL field, Rust `SearchQuery` field, Search document shape, Forum projection shape, database migration, dependency, or `Cargo.lock` change. Existing product category filtering remains active.

## Verification

Not run by the implementation agent, per maintainer instruction. Suggested commands:

```bash
node scripts/verify/verify-forum-search-exact-category-filter.mjs
cargo test -p rustok-search category_filter_preserves_product_and_adds_exact_forum_scope -- --nocapture
cargo test -p rustok-search pg_engine -- --nocapture
cargo check -p rustok-search --all-targets
cargo xtask module validate search
cargo xtask module validate forum
```

## Remaining

- bounded visibility-authorized Forum category-subtree expansion;
- exact public-author, tag, locale, date, solved, kind, channel/group, and attachment-presence filters;
- maintainer-executed PostgreSQL query/result evidence.