### PR TITLE
fix(pricing): sanitize admin GraphQL failures

### DIFF
--- a/crates/rustok-pricing/admin/Cargo.toml
+++ b/crates/rustok-pricing/admin/Cargo.toml
@@ -43,6 +43,7 @@ sea-orm = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 rust_decimal.workspace = true
+tracing.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/crates/rustok-pricing/admin/src/transport.rs
+++ b/crates/rustok-pricing/admin/src/transport.rs
@@ -1,4 +1,5 @@
 mod graphql_adapter;
+mod graphql_error_safety;
 mod native_server_adapter;
 
 use rustok_ui_transport::UiTransportPath;
@@ -26,7 +27,13 @@ pub async fn fetch_bootstrap(
         UiTransportPath::NativeServer => {
             native_server_adapter::fetch_bootstrap(token, tenant_slug).await
         }
-        UiTransportPath::Graphql => graphql_adapter::fetch_bootstrap(token, tenant_slug).await,
+        UiTransportPath::Graphql => {
+            let context =
+                graphql_error_safety::GraphqlCallContext::for_bootstrap(tenant_slug.as_deref());
+            graphql_adapter::fetch_bootstrap(token, tenant_slug)
+                .await
+                .map_err(|error| context.map_error(error))
+        }
     }
 }
 
@@ -47,6 +54,11 @@ pub async fn fetch_active_price_lists(
             .await
         }
         UiTransportPath::Graphql => {
+            let context = graphql_error_safety::GraphqlCallContext::for_active_price_lists(
+                tenant_slug.as_deref(),
+                channel_id.as_deref(),
+                channel_slug.as_deref(),
+            );
             graphql_adapter::fetch_active_price_lists(
                 token,
                 tenant_slug,
@@ -54,6 +66,7 @@ pub async fn fetch_active_price_lists(
                 graphql_adapter::sanitize_channel_slug(channel_slug),
             )
             .await
+            .map_err(|error| context.map_error(error))
         }
     }
 }
@@ -79,6 +92,13 @@ pub async fn fetch_products(
             .await
         }
         UiTransportPath::Graphql => {
+            let context = graphql_error_safety::GraphqlCallContext::for_products(
+                tenant_slug.as_deref(),
+                tenant_id.as_str(),
+                locale.as_deref(),
+                search.as_deref(),
+                status.as_deref(),
+            );
             graphql_adapter::fetch_products(
                 token,
                 tenant_slug,
@@ -88,6 +108,7 @@ pub async fn fetch_products(
                 status,
             )
             .await
+            .map_err(|error| context.map_error(error))
         }
     }
 }
@@ -124,6 +145,18 @@ pub async fn fetch_product(
             .await
         }
         UiTransportPath::Graphql => {
+            let context = graphql_error_safety::GraphqlCallContext::for_product(
+                tenant_slug.as_deref(),
+                tenant_id.as_str(),
+                id.as_str(),
+                locale.as_deref(),
+                currency_code.as_deref(),
+                region_id.as_deref(),
+                price_list_id.as_deref(),
+                channel_id.as_deref(),
+                channel_slug.as_deref(),
+                quantity.is_some(),
+            );
             let resolution_context = crate::core::sanitize_resolution_context(
                 currency_code,
                 region_id,
@@ -151,6 +184,7 @@ pub async fn fetch_product(
                 resolution_context.as_ref().map(|context| context.quantity),
             )
             .await
+            .map_err(|error| context.map_error(error))
         }
     }
 }

--- a/crates/rustok-pricing/admin/src/transport/graphql_error_safety.rs
+++ b/crates/rustok-pricing/admin/src/transport/graphql_error_safety.rs
@@ -1,0 +1,221 @@
+use std::str::FromStr;
+
+use rustok_graphql::GraphqlHttpError;
+use uuid::Uuid;
+
+use super::native_server_adapter::ApiError;
+
+const PRICING_ADMIN_GRAPHQL_OWNER: &str = "rustok_pricing.admin";
+const PRICING_ADMIN_GRAPHQL_BOUNDARY: &str = "pricing_admin_graphql_transport";
+
+pub(super) struct GraphqlCallContext {
+    operation: &'static str,
+    correlation_id: String,
+    tenant_slug_length: Option<usize>,
+    tenant_id_length: Option<usize>,
+    resource_id_length: Option<usize>,
+    locale_length: Option<usize>,
+    search_length: Option<usize>,
+    status_length: Option<usize>,
+    currency_code_length: Option<usize>,
+    region_id_length: Option<usize>,
+    price_list_id_length: Option<usize>,
+    channel_id_length: Option<usize>,
+    channel_slug_length: Option<usize>,
+    quantity_present: bool,
+}
+
+impl GraphqlCallContext {
+    pub(super) fn for_bootstrap(tenant_slug: Option<&str>) -> Self {
+        Self::new("fetch_bootstrap", tenant_slug)
+    }
+
+    pub(super) fn for_active_price_lists(
+        tenant_slug: Option<&str>,
+        channel_id: Option<&str>,
+        channel_slug: Option<&str>,
+    ) -> Self {
+        let mut context = Self::new("fetch_active_price_lists", tenant_slug);
+        context.channel_id_length = text_length(channel_id);
+        context.channel_slug_length = text_length(channel_slug);
+        context
+    }
+
+    pub(super) fn for_products(
+        tenant_slug: Option<&str>,
+        tenant_id: &str,
+        locale: Option<&str>,
+        search: Option<&str>,
+        status: Option<&str>,
+    ) -> Self {
+        let mut context = Self::new("fetch_products", tenant_slug);
+        context.tenant_id_length = Some(tenant_id.chars().count());
+        context.locale_length = text_length(locale);
+        context.search_length = text_length(search);
+        context.status_length = text_length(status);
+        context
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn for_product(
+        tenant_slug: Option<&str>,
+        tenant_id: &str,
+        resource_id: &str,
+        locale: Option<&str>,
+        currency_code: Option<&str>,
+        region_id: Option<&str>,
+        price_list_id: Option<&str>,
+        channel_id: Option<&str>,
+        channel_slug: Option<&str>,
+        quantity_present: bool,
+    ) -> Self {
+        let mut context = Self::new("fetch_product", tenant_slug);
+        context.tenant_id_length = Some(tenant_id.chars().count());
+        context.resource_id_length = Some(resource_id.chars().count());
+        context.locale_length = text_length(locale);
+        context.currency_code_length = text_length(currency_code);
+        context.region_id_length = text_length(region_id);
+        context.price_list_id_length = text_length(price_list_id);
+        context.channel_id_length = text_length(channel_id);
+        context.channel_slug_length = text_length(channel_slug);
+        context.quantity_present = quantity_present;
+        context
+    }
+
+    fn new(operation: &'static str, tenant_slug: Option<&str>) -> Self {
+        Self {
+            operation,
+            correlation_id: format!("pricing-admin-graphql:{operation}:{}", Uuid::new_v4()),
+            tenant_slug_length: text_length(tenant_slug),
+            tenant_id_length: None,
+            resource_id_length: None,
+            locale_length: None,
+            search_length: None,
+            status_length: None,
+            currency_code_length: None,
+            region_id_length: None,
+            price_list_id_length: None,
+            channel_id_length: None,
+            channel_slug_length: None,
+            quantity_present: false,
+        }
+    }
+
+    pub(super) fn map_error(&self, error: ApiError) -> ApiError {
+        let ApiError::Graphql(raw_error) = error else {
+            return error;
+        };
+
+        let parsed_error = GraphqlHttpError::from_str(raw_error.as_str());
+        let (error_kind, code, public_message, technical_failure) = match &parsed_error {
+            Ok(GraphqlHttpError::Network) => (
+                "network",
+                "pricing.admin_graphql_network_unavailable",
+                "Pricing admin service is temporarily unavailable",
+                true,
+            ),
+            Ok(GraphqlHttpError::Http(_)) => (
+                "http",
+                "pricing.admin_graphql_http_unavailable",
+                "Pricing admin service is temporarily unavailable",
+                true,
+            ),
+            Ok(GraphqlHttpError::Unauthorized) => (
+                "unauthorized",
+                "pricing.admin_graphql_authentication_required",
+                "Pricing admin authentication is required",
+                false,
+            ),
+            Ok(GraphqlHttpError::Graphql(_)) => (
+                "graphql",
+                "pricing.admin_graphql_request_rejected",
+                "Pricing admin request could not be completed",
+                false,
+            ),
+            Err(_) => (
+                "unknown",
+                "pricing.admin_graphql_unknown_failure",
+                "Pricing admin request could not be completed",
+                true,
+            ),
+        };
+
+        if technical_failure {
+            tracing::error!(
+                raw_error = %raw_error,
+                parsed_error = ?parsed_error,
+                owner = PRICING_ADMIN_GRAPHQL_OWNER,
+                owner_operation = self.operation,
+                correlation_id = %self.correlation_id,
+                tenant_slug_present = self.tenant_slug_length.is_some(),
+                tenant_slug_length = ?self.tenant_slug_length,
+                tenant_id_present = self.tenant_id_length.is_some(),
+                tenant_id_length = ?self.tenant_id_length,
+                resource_id_present = self.resource_id_length.is_some(),
+                resource_id_length = ?self.resource_id_length,
+                locale_present = self.locale_length.is_some(),
+                locale_length = ?self.locale_length,
+                search_present = self.search_length.is_some(),
+                search_length = ?self.search_length,
+                status_present = self.status_length.is_some(),
+                status_length = ?self.status_length,
+                currency_code_present = self.currency_code_length.is_some(),
+                currency_code_length = ?self.currency_code_length,
+                region_id_present = self.region_id_length.is_some(),
+                region_id_length = ?self.region_id_length,
+                price_list_id_present = self.price_list_id_length.is_some(),
+                price_list_id_length = ?self.price_list_id_length,
+                channel_id_present = self.channel_id_length.is_some(),
+                channel_id_length = ?self.channel_id_length,
+                channel_slug_present = self.channel_slug_length.is_some(),
+                channel_slug_length = ?self.channel_slug_length,
+                quantity_present = self.quantity_present,
+                error_kind,
+                code,
+                boundary = PRICING_ADMIN_GRAPHQL_BOUNDARY,
+                "pricing admin GraphQL transport failed"
+            );
+        } else {
+            tracing::warn!(
+                raw_error = %raw_error,
+                parsed_error = ?parsed_error,
+                owner = PRICING_ADMIN_GRAPHQL_OWNER,
+                owner_operation = self.operation,
+                correlation_id = %self.correlation_id,
+                tenant_slug_present = self.tenant_slug_length.is_some(),
+                tenant_slug_length = ?self.tenant_slug_length,
+                tenant_id_present = self.tenant_id_length.is_some(),
+                tenant_id_length = ?self.tenant_id_length,
+                resource_id_present = self.resource_id_length.is_some(),
+                resource_id_length = ?self.resource_id_length,
+                locale_present = self.locale_length.is_some(),
+                locale_length = ?self.locale_length,
+                search_present = self.search_length.is_some(),
+                search_length = ?self.search_length,
+                status_present = self.status_length.is_some(),
+                status_length = ?self.status_length,
+                currency_code_present = self.currency_code_length.is_some(),
+                currency_code_length = ?self.currency_code_length,
+                region_id_present = self.region_id_length.is_some(),
+                region_id_length = ?self.region_id_length,
+                price_list_id_present = self.price_list_id_length.is_some(),
+                price_list_id_length = ?self.price_list_id_length,
+                channel_id_present = self.channel_id_length.is_some(),
+                channel_id_length = ?self.channel_id_length,
+                channel_slug_present = self.channel_slug_length.is_some(),
+                channel_slug_length = ?self.channel_slug_length,
+                quantity_present = self.quantity_present,
+                error_kind,
+                code,
+                boundary = PRICING_ADMIN_GRAPHQL_BOUNDARY,
+                "pricing admin GraphQL request was rejected"
+            );
+        }
+
+        ApiError::Graphql(public_message.to_string())
+    }
+}
+
+fn text_length(value: Option<&str>) -> Option<usize> {
+    value.map(|value| value.chars().count())
+}

--- a/crates/rustok-pricing/contracts/evidence/admin-graphql-error-safety-source-review.json
+++ b/crates/rustok-pricing/contracts/evidence/admin-graphql-error-safety-source-review.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": 1,
+  "reviewed_at_utc": "2026-07-30T18:45:00Z",
+  "status": "pricing_admin_graphql_error_safety_source_reviewed_unvalidated",
+  "scope": "Pricing admin GraphQL public error boundary",
+  "reviewed_sources": [
+    "crates/rustok-commerce/docs/implementation-plan.md",
+    "crates/rustok-pricing/docs/implementation-plan.md",
+    "crates/rustok-pricing/admin/Cargo.toml",
+    "crates/rustok-pricing/admin/src/transport.rs",
+    "crates/rustok-pricing/admin/src/transport/graphql_adapter.rs",
+    "crates/rustok-pricing/admin/src/transport/native_server_adapter.rs",
+    "crates/rustok-pricing/storefront/src/transport/graphql_error_safety.rs",
+    "crates/rustok-commerce/admin/src/transport/graphql_error_safety.rs",
+    "crates/rustok-graphql/src/lib.rs",
+    "scripts/verify/verify-pricing-admin-boundary.mjs"
+  ],
+  "findings": [
+    {
+      "id": "pricing-admin-graphql-display-public",
+      "severity": "confirmed",
+      "finding": "All four Pricing admin GraphQL reads converted GraphqlHttpError through ApiError::Graphql(value.to_string()) and returned that display directly from the selected transport facade. GraphQL server messages and HTTP status text could therefore reach the admin UI error envelope."
+    },
+    {
+      "id": "pricing-admin-final-facade-boundary",
+      "severity": "selected",
+      "finding": "The smallest compatible fix is a Pricing-owned per-call context in transport.rs. It sanitizes only ApiError::Graphql after the adapter call while preserving request validation and native behavior."
+    },
+    {
+      "id": "pricing-admin-safe-shape",
+      "severity": "confirmed",
+      "finding": "The new diagnostics retain a unique correlation id and only request-field presence or character lengths. Identifier, locale, search, status, money-context, channel, and quantity values are not recorded as structured fields."
+    },
+    {
+      "id": "pricing-admin-mutations-native-only",
+      "severity": "preserved",
+      "finding": "Variant price, discount, rule, and price-list scope mutations remain native-only and are outside this GraphQL read slice."
+    }
+  ],
+  "changed_files_expected": [
+    "crates/rustok-pricing/admin/Cargo.toml",
+    "crates/rustok-pricing/admin/src/transport.rs",
+    "crates/rustok-pricing/admin/src/transport/graphql_error_safety.rs",
+    "crates/rustok-pricing/contracts/evidence/admin-graphql-error-safety-source.json",
+    "crates/rustok-pricing/contracts/evidence/admin-graphql-error-safety-source-review.json",
+    "crates/rustok-pricing/docs/admin-graphql-error-safety.md",
+    "crates/rustok-pricing/docs/implementation-plan.md",
+    "scripts/verify/verify-pricing-admin-boundary.mjs",
+    "scripts/verify/verify-pricing-admin-graphql-error-safety.mjs"
+  ],
+  "remaining_scope": [
+    "remaining ecommerce adapters and non-PortError public envelopes",
+    "Pricing admin verifier and Cargo execution",
+    "GraphQL/browser runtime and mounted parity evidence"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "graphql_runtime_proven": false,
+    "browser_runtime_proven": false,
+    "mounted_parity_proven": false
+  },
+  "execution": []
+}

--- a/crates/rustok-pricing/contracts/evidence/admin-graphql-error-safety-source.json
+++ b/crates/rustok-pricing/contracts/evidence/admin-graphql-error-safety-source.json
@@ -1,0 +1,110 @@
+{
+  "schema_version": 1,
+  "generated_at_utc": "2026-07-30T18:45:00Z",
+  "status": "pricing_admin_graphql_error_safety_source_unvalidated",
+  "scope": "Pricing-owned admin GraphQL public transport envelope",
+  "operations": [
+    "fetch_bootstrap",
+    "fetch_active_price_lists",
+    "fetch_products",
+    "fetch_product"
+  ],
+  "boundary": "pricing_admin_graphql_transport",
+  "public_messages": {
+    "unavailable": "Pricing admin service is temporarily unavailable",
+    "authentication_required": "Pricing admin authentication is required",
+    "request_rejected": "Pricing admin request could not be completed"
+  },
+  "source_contract": {
+    "context_before_each_graphql_call": true,
+    "unique_correlation_id_per_call": true,
+    "network_static_public_envelope": true,
+    "http_static_public_envelope": true,
+    "authentication_static_public_envelope": true,
+    "graphql_rejection_static_public_envelope": true,
+    "raw_graphql_http_display_public": false,
+    "raw_request_values_logged": false,
+    "private_graphql_error_diagnostics": true,
+    "request_validation_messages_preserved": true,
+    "native_adapter_changed": false,
+    "graphql_documents_changed": false,
+    "transport_selection_changed": false,
+    "fallback_added": false,
+    "native_only_mutations_changed": false
+  },
+  "safe_diagnostics": [
+    "owner",
+    "owner_operation",
+    "correlation_id",
+    "tenant_slug presence and length",
+    "tenant_id presence and length",
+    "resource_id presence and length",
+    "locale presence and length",
+    "search presence and length",
+    "status presence and length",
+    "currency_code presence and length",
+    "region_id presence and length",
+    "price_list_id presence and length",
+    "channel_id presence and length",
+    "channel_slug presence and length",
+    "quantity presence",
+    "error_kind",
+    "stable code",
+    "boundary",
+    "private raw and parsed GraphQL error"
+  ],
+  "forbidden_public_or_structured_values": [
+    "tenant_slug",
+    "tenant_id",
+    "product_id",
+    "locale",
+    "search",
+    "status",
+    "currency_code",
+    "region_id",
+    "price_list_id",
+    "channel_id",
+    "channel_slug",
+    "quantity",
+    "GraphqlHttpError display",
+    "GraphQL server error message",
+    "HTTP status text"
+  ],
+  "preserved": [
+    "Pricing admin GraphQL query documents and variables",
+    "bootstrap, active-price-list, product-list, and product-detail result mapping",
+    "request validation and normalization",
+    "native server-function read behavior",
+    "native-only Pricing admin mutations",
+    "native versus GraphQL selected transport",
+    "absence of fallback"
+  ],
+  "remaining_scope": [
+    "remaining ecommerce adapters and non-PortError public envelopes",
+    "Pricing admin focused verifier execution",
+    "Pricing admin Cargo compilation across default, hydrate, and SSR profiles",
+    "GraphQL/browser runtime and mounted parity evidence"
+  ],
+  "suggested_execution": [
+    "node scripts/verify/verify-pricing-admin-graphql-error-safety.mjs",
+    "node scripts/verify/verify-pricing-admin-boundary.mjs",
+    "node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs",
+    "cargo check -p rustok-pricing-admin",
+    "cargo check -p rustok-pricing-admin --features hydrate",
+    "cargo check -p rustok-pricing-admin --features ssr"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "focused_verifier_run": false,
+    "aggregate_verifier_run": false,
+    "broad_ecommerce_verifier_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "graphql_runtime_proven": false,
+    "browser_runtime_proven": false,
+    "mounted_parity_proven": false
+  },
+  "execution": []
+}

--- a/crates/rustok-pricing/docs/admin-graphql-error-safety.md
+++ b/crates/rustok-pricing/docs/admin-graphql-error-safety.md
@@ -1,0 +1,105 @@
+# Pricing admin GraphQL error safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens the four Pricing admin GraphQL read operations selected by
+`crates/rustok-pricing/admin/src/transport.rs`:
+
+- `fetch_bootstrap`;
+- `fetch_active_price_lists`;
+- `fetch_products`;
+- `fetch_product`.
+
+The GraphQL documents, variables, request normalization, result mapping, native server
+functions, and native-only Pricing mutations remain unchanged.
+
+## Confirmed gap
+
+The Pricing admin GraphQL adapter captures `GraphqlHttpError` as
+`ApiError::Graphql(value.to_string())`. Before this slice, the selected transport facade
+returned that display directly. GraphQL server messages, HTTP status text, and transport
+classification details could therefore cross the final admin UI boundary.
+
+## Boundary placement
+
+Each GraphQL branch now creates a `GraphqlCallContext` before calling the adapter. The
+context receives the final `ApiError` after the adapter returns and before the admin UI can
+render it.
+
+Only `ApiError::Graphql` is reclassified. Existing `ApiError::ServerFn` request-validation
+results pass through unchanged.
+
+Every call receives a unique correlation id in the namespace:
+
+```text
+pricing-admin-graphql:<operation>:<uuid>
+```
+
+## Public policy
+
+| GraphQL condition | Public message |
+| --- | --- |
+| Network failure | `Pricing admin service is temporarily unavailable` |
+| Non-success HTTP response | `Pricing admin service is temporarily unavailable` |
+| Unauthorized response | `Pricing admin authentication is required` |
+| GraphQL response rejection | `Pricing admin request could not be completed` |
+| Unrecognized captured display | `Pricing admin request could not be completed` |
+
+No fallback is introduced, and the selected transport path remains unchanged.
+
+## Internal diagnostics
+
+The original captured GraphQL display and parsed `GraphqlHttpError` remain private tracing
+fields. Structured diagnostics record only:
+
+- owner, operation, boundary, stable code, error kind, and correlation id;
+- tenant slug presence and character length;
+- tenant id and requested resource id presence and character length;
+- locale, search, status, currency, region, price-list, channel id, and channel slug
+  presence and character length;
+- quantity presence.
+
+The actual tenant, identifier, locale, search, status, pricing-context, channel, or
+quantity values are not recorded as structured fields.
+
+## Preserved behavior
+
+This slice does not change:
+
+- Pricing admin GraphQL queries or variables;
+- bootstrap, active-price-list, product-list, or product-detail response mapping;
+- UUID, channel, resolution-context, locale, search, or status normalization;
+- native server-function reads;
+- variant price, discount, price-list rule, or price-list scope mutations;
+- native versus GraphQL selection;
+- fallback behavior;
+- FFA, FBA, browser, runtime, workflow, CI, or production status.
+
+## Static evidence
+
+- `crates/rustok-pricing/contracts/evidence/admin-graphql-error-safety-source.json`;
+- `crates/rustok-pricing/contracts/evidence/admin-graphql-error-safety-source-review.json`;
+- `scripts/verify/verify-pricing-admin-graphql-error-safety.mjs`.
+
+The focused verifier is imported by `scripts/verify/verify-pricing-admin-boundary.mjs`.
+All execution flags remain `false`; source review alone does not prove compilation,
+GraphQL/browser runtime, or mounted parity.
+
+## Remaining work
+
+The ecommerce correlation-safe mapper cleanup remains open for other storefront/admin
+adapters and non-`PortError` public envelopes, including inventory, customer, tax,
+promotion, and remaining owner-specific paths.
+
+## Suggested maintainer checks
+
+```bash
+node scripts/verify/verify-pricing-admin-graphql-error-safety.mjs
+node scripts/verify/verify-pricing-admin-boundary.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-pricing-admin
+cargo check -p rustok-pricing-admin --features hydrate
+cargo check -p rustok-pricing-admin --features ssr
+```

--- a/crates/rustok-pricing/docs/implementation-plan.md
+++ b/crates/rustok-pricing/docs/implementation-plan.md
@@ -56,6 +56,14 @@ invokes the pricing owner service, returns the saved owner projection, and prese
 the effective locale plus fallback locale for rule updates. This is static boundary
 evidence only; no live provider-consumer transport execution has been recorded.
 
+Pricing storefront GraphQL public errors are source-hardened at the selected transport
+facade: captured network, HTTP, unauthorized, GraphQL-rejection, and unknown displays
+are mapped to static public messages with a per-call correlation id and bounded request
+shape diagnostics. Pricing admin GraphQL public errors now use the same owner policy for
+bootstrap, active-price-list, product-list, and product-detail reads. Request validation,
+GraphQL documents, native reads, and native-only mutations remain unchanged. Both slices
+are source-ready / unvalidated and do not promote runtime or mounted-parity status.
+
 ## FFA/FBA status
 
 - FFA status: `in_progress` — the owner UI surfaces exist and must retain
@@ -69,11 +77,17 @@ evidence only; no live provider-consumer transport execution has been recorded.
 - Evidence: `crates/rustok-pricing/contracts/pricing-fba-registry.json`,
   `crates/rustok-pricing/contracts/evidence/pricing-contract-test-static-matrix.json`,
   `crates/rustok-pricing/contracts/evidence/pricing-runtime-contract-smoke.json`,
+  `crates/rustok-pricing/contracts/evidence/storefront-graphql-error-safety-source.json`,
+  `crates/rustok-pricing/contracts/evidence/admin-graphql-error-safety-source.json`,
   `crates/rustok-pricing/docs/read-local-context.md`,
   `crates/rustok-pricing/docs/write-local-context.md`,
+  `crates/rustok-pricing/docs/storefront-graphql-error-safety.md`,
+  `crates/rustok-pricing/docs/admin-graphql-error-safety.md`,
   `scripts/verify/verify-pricing-read-local-context.mjs`,
   `scripts/verify/verify-pricing-write-local-context.mjs`,
   `scripts/verify/verify-commerce-domain-fba-runtime-smoke.mjs`,
+  `scripts/verify/verify-pricing-admin-graphql-error-safety.mjs`,
+  `scripts/verify/verify-pricing-storefront-graphql-error-safety.mjs`,
   `scripts/verify/verify-pricing-admin-boundary.mjs`, and
   `scripts/verify/verify-pricing-storefront-boundary.mjs`.
 
@@ -103,19 +117,23 @@ evidence only; no live provider-consumer transport execution has been recorded.
    Dependency: the stable owner transport and product variant data. Verification:
    targeted pricing resolution and money-semantics tests.
 4. Prove canonical pricing diagnostics and retire compatibility bypasses.
-   **Status:** source-complete / unvalidated for root read and write construction.
-   Execute invalid-context, invalid-actor, product/variant mismatch, missing
-   price/list, duplicate identity, inventory conflict, storage, and invariant
-   scenarios and retain traces proving that raw handles, SKUs, UUID-bearing
-   messages, quantities, currencies, prices, and percentages do not cross the
-   canonical boundary. Audit direct `rustok_pricing::ports` callers and either
-   migrate or explicitly accept them. Shared `port.*` admission diagnostics,
-   runtime evidence, and remote-profile parity remain open.
+   **Status:** source-complete / unvalidated for root read/write construction and
+   storefront/admin GraphQL public error envelopes. Execute invalid-context,
+   invalid-actor, product/variant mismatch, missing price/list, duplicate identity,
+   inventory conflict, storage, invariant, network, HTTP, unauthorized, and GraphQL
+   rejection scenarios. Retain traces proving that raw handles, SKUs, UUID-bearing
+   messages, tenant identifiers, locale/search/status values, quantities, currencies,
+   prices, percentages, and GraphQL/HTTP cause text do not cross canonical public
+   boundaries. Audit direct `rustok_pricing::ports` callers and either migrate or
+   explicitly accept them. Shared `port.*` admission diagnostics, runtime evidence,
+   browser evidence, and remote-profile parity remain open.
 
 ## Verification
 
 - `npm run verify:pricing:admin-boundary`
 - `npm run verify:pricing:storefront-boundary`
+- `node scripts/verify/verify-pricing-admin-graphql-error-safety.mjs`
+- `node scripts/verify/verify-pricing-storefront-graphql-error-safety.mjs`
 - `node scripts/verify/verify-pricing-read-local-context.mjs`
 - `node scripts/verify/verify-pricing-write-local-context.mjs`
 - `npm run verify:ecommerce:fba`
@@ -128,5 +146,6 @@ evidence only; no live provider-consumer transport execution has been recorded.
   multi-layer promotions workflow.
 - Hosts only compose owner UI packages and pass effective locale, channel, and
   runtime context without creating package-local fallback chains.
-- Keep raw handles, SKUs, currency values, prices, percentages, and returned pricing
+- Keep raw handles, SKUs, tenant or resource identifiers, locale/search/status values,
+  currency values, prices, percentages, GraphQL/HTTP cause text, and returned pricing
   rows out of owner diagnostics; retain only typed identity and bounded shape facts.

--- a/scripts/verify/verify-pricing-admin-boundary.mjs
+++ b/scripts/verify/verify-pricing-admin-boundary.mjs
@@ -5,6 +5,8 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import "./verify-pricing-admin-graphql-error-safety.mjs";
+
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
   ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
@@ -42,6 +44,7 @@ const files = {
   core: "crates/rustok-pricing/admin/src/core/mod.rs",
   ui: "crates/rustok-pricing/admin/src/ui/leptos.rs",
   transport: "crates/rustok-pricing/admin/src/transport.rs",
+  graphqlErrorSafety: "crates/rustok-pricing/admin/src/transport/graphql_error_safety.rs",
   nativeServerAdapter: "crates/rustok-pricing/admin/src/transport/native_server_adapter.rs",
   legacyApi: "crates/rustok-pricing/admin/src/api.rs",
   implementationPlan: "crates/rustok-pricing/docs/implementation-plan.md",
@@ -61,6 +64,7 @@ const lib = readRepo(files.lib);
 const core = readRepo(files.core);
 const ui = readRepo(files.ui);
 const transport = readRepo(files.transport);
+const graphqlErrorSafety = readRepo(files.graphqlErrorSafety);
 const nativeServerAdapter = readRepo(files.nativeServerAdapter);
 const implementationPlan = readRepo(files.implementationPlan);
 const registry = readRepo(files.registry);
@@ -81,14 +85,18 @@ for (const marker of ["crate::api", /(^|[^A-Za-z0-9_])api::/, "#[server"]) {
 }
 
 assertContains(transport, "mod native_server_adapter;", `${files.transport}: transport must wire native server adapter`);
+assertContains(transport, "mod graphql_error_safety;", `${files.transport}: transport must wire GraphQL error policy`);
 assertContains(transport, "native_server_adapter::", `${files.transport}: transport facade must delegate through adapter`);
 assertNotContains(transport, "crate::api", `${files.transport}: transport facade must not import legacy api module`);
 assertNotContains(transport, "#[server", `${files.transport}: transport facade must not own server functions`);
+assertContains(graphqlErrorSafety, "GraphqlHttpError::from_str", `${files.graphqlErrorSafety}: GraphQL policy must classify captured errors`);
+assertContains(graphqlErrorSafety, "Pricing admin request could not be completed", `${files.graphqlErrorSafety}: GraphQL policy must expose bounded messages`);
 assertContains(nativeServerAdapter, "pub enum ApiError", `${files.nativeServerAdapter}: adapter must own shared ApiError envelope`);
 assertContains(nativeServerAdapter, "#[server", `${files.nativeServerAdapter}: native server adapter must keep server functions`);
 assertNotContains(nativeServerAdapter, "GraphqlRequest", `${files.nativeServerAdapter}: native adapter must not execute the parallel GraphQL contract`);
 
 assertContains(implementationPlan, "verify-pricing-admin-boundary.mjs", `${files.implementationPlan}: local plan must mention pricing admin guardrail`);
+assertContains(implementationPlan, "admin GraphQL public errors", `${files.implementationPlan}: local plan must record GraphQL public error safety`);
 assertContains(registry, "verify-pricing-admin-boundary.mjs", `${files.registry}: central readiness board must mention pricing admin guardrail`);
 assertContains(packageJson, "verify:pricing:admin-boundary", `${files.packageJson}: package scripts must expose pricing admin boundary verification`);
 assertContains(packageJson, "test:verify:pricing:admin-boundary", `${files.packageJson}: package scripts must expose pricing admin fixture tests`);

--- a/scripts/verify/verify-pricing-admin-graphql-error-safety.mjs
+++ b/scripts/verify/verify-pricing-admin-graphql-error-safety.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const countText = (source, value) => source.split(value).length - 1;
+
+const cargoPath = "crates/rustok-pricing/admin/Cargo.toml";
+const transportPath = "crates/rustok-pricing/admin/src/transport.rs";
+const graphqlPath = "crates/rustok-pricing/admin/src/transport/graphql_adapter.rs";
+const safetyPath =
+  "crates/rustok-pricing/admin/src/transport/graphql_error_safety.rs";
+const nativePath =
+  "crates/rustok-pricing/admin/src/transport/native_server_adapter.rs";
+const evidencePath =
+  "crates/rustok-pricing/contracts/evidence/admin-graphql-error-safety-source.json";
+const reviewPath =
+  "crates/rustok-pricing/contracts/evidence/admin-graphql-error-safety-source-review.json";
+const docPath = "crates/rustok-pricing/docs/admin-graphql-error-safety.md";
+const planPath = "crates/rustok-pricing/docs/implementation-plan.md";
+
+const cargo = read(cargoPath);
+const transport = read(transportPath);
+const graphql = read(graphqlPath);
+const safety = read(safetyPath);
+const native = read(nativePath);
+const evidence = JSON.parse(read(evidencePath));
+const review = JSON.parse(read(reviewPath));
+const doc = read(docPath);
+const plan = read(planPath);
+
+requireText(cargo, "tracing.workspace = true", `${cargoPath}: all-profile tracing`);
+requireText(cargo, "uuid.workspace = true", `${cargoPath}: correlation UUID`);
+requireText(
+  transport,
+  "mod graphql_error_safety;",
+  `${transportPath}: private GraphQL policy module`,
+);
+
+for (const marker of [
+  "GraphqlCallContext::for_bootstrap",
+  "GraphqlCallContext::for_active_price_lists",
+  "GraphqlCallContext::for_products",
+  "GraphqlCallContext::for_product",
+]) requireText(transport, marker, `${transportPath}: per-operation context`);
+if (countText(transport, ".map_err(|error| context.map_error(error))") !== 4) {
+  failures.push(`${transportPath}: exactly four GraphQL reads must use the final public mapper`);
+}
+for (const marker of [
+  "graphql_adapter::fetch_bootstrap",
+  "graphql_adapter::fetch_active_price_lists",
+  "graphql_adapter::fetch_products",
+  "graphql_adapter::fetch_product",
+]) requireText(transport, marker, `${transportPath}: preserved GraphQL read`);
+for (const marker of [
+  "native_server_adapter::update_variant_price",
+  "native_server_adapter::preview_variant_discount",
+  "native_server_adapter::apply_variant_discount",
+  "native_server_adapter::update_price_list_rule",
+  "native_server_adapter::update_price_list_scope",
+]) requireText(transport, marker, `${transportPath}: preserved native-only mutation`);
+
+for (const marker of [
+  "impl From<rustok_graphql::GraphqlHttpError> for ApiError",
+  "Self::Graphql(value.to_string())",
+  ".map_err(ApiError::from)",
+  "BOOTSTRAP_QUERY",
+  "ACTIVE_PRICE_LISTS_QUERY",
+  "PRODUCTS_QUERY",
+  "PRODUCT_QUERY",
+]) requireText(graphql, marker, `${graphqlPath}: private GraphQL capture and contract`);
+
+for (const marker of [
+  "pub(super) struct GraphqlCallContext",
+  "pricing-admin-graphql:{operation}:{}",
+  "Uuid::new_v4()",
+  "GraphqlHttpError::from_str(raw_error.as_str())",
+  "Ok(GraphqlHttpError::Network)",
+  "Ok(GraphqlHttpError::Http(_))",
+  "Ok(GraphqlHttpError::Unauthorized)",
+  "Ok(GraphqlHttpError::Graphql(_))",
+  "Pricing admin service is temporarily unavailable",
+  "Pricing admin authentication is required",
+  "Pricing admin request could not be completed",
+  "pricing.admin_graphql_network_unavailable",
+  "pricing.admin_graphql_http_unavailable",
+  "pricing.admin_graphql_authentication_required",
+  "pricing.admin_graphql_request_rejected",
+  "pricing.admin_graphql_unknown_failure",
+  "raw_error = %raw_error",
+  "parsed_error = ?parsed_error",
+  "tenant_id_length = ?self.tenant_id_length",
+  "resource_id_length = ?self.resource_id_length",
+  "search_length = ?self.search_length",
+  "quantity_present = self.quantity_present",
+  "ApiError::Graphql(public_message.to_string())",
+]) requireText(safety, marker, `${safetyPath}: bounded GraphQL policy`);
+
+for (const marker of [
+  "tenant_slug = %",
+  "tenant_slug = ?",
+  "tenant_id = %",
+  "tenant_id = ?",
+  "resource_id = %",
+  "resource_id = ?",
+  "locale = %",
+  "locale = ?",
+  "search = %",
+  "search = ?",
+  "status = %",
+  "status = ?",
+  "currency_code = %",
+  "currency_code = ?",
+  "region_id = %",
+  "region_id = ?",
+  "price_list_id = %",
+  "price_list_id = ?",
+  "channel_id = %",
+  "channel_id = ?",
+  "channel_slug = %",
+  "channel_slug = ?",
+  "quantity = %",
+  "quantity = ?",
+]) forbidText(safety, marker, `${safetyPath}: raw request value diagnostics`);
+
+requireText(native, "pub enum ApiError", `${nativePath}: shared error envelope`);
+requireText(native, "pricing_admin_bootstrap_native", `${nativePath}: native read preserved`);
+requireText(native, "pricing_admin_update_variant_price_native", `${nativePath}: native write preserved`);
+
+if (evidence.schema_version !== 1) failures.push(`${evidencePath}: schema_version must be 1`);
+if (evidence.status !== "pricing_admin_graphql_error_safety_source_unvalidated") {
+  failures.push(`${evidencePath}: status mismatch`);
+}
+for (const [key, expected] of Object.entries({
+  context_before_each_graphql_call: true,
+  unique_correlation_id_per_call: true,
+  raw_graphql_http_display_public: false,
+  raw_request_values_logged: false,
+  private_graphql_error_diagnostics: true,
+  request_validation_messages_preserved: true,
+  native_adapter_changed: false,
+  graphql_documents_changed: false,
+  transport_selection_changed: false,
+  fallback_added: false,
+  native_only_mutations_changed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${evidencePath}: source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "focused_verifier_run",
+  "aggregate_verifier_run",
+  "broad_ecommerce_verifier_run",
+  "workflow_checks_run",
+  "ci_run",
+  "graphql_runtime_proven",
+  "browser_runtime_proven",
+  "mounted_parity_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${evidencePath}: validation.${key} must remain false`);
+  }
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push(`${evidencePath}: execution must remain empty`);
+}
+if (review.status !== "pricing_admin_graphql_error_safety_source_reviewed_unvalidated") {
+  failures.push(`${reviewPath}: status mismatch`);
+}
+requireText(doc, "Status: **source-ready / unvalidated**", `${docPath}: source status`);
+requireText(plan, "admin GraphQL public errors", `${planPath}: local plan record`);
+
+if (failures.length > 0) {
+  console.error("Pricing admin GraphQL error-safety verification failed:");
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "✔ Pricing admin GraphQL reads use correlation-safe static public envelopes; execution evidence remains maintainer-owned",
+);


### PR DESCRIPTION
## Summary
- add a Pricing-owned public error policy for the four admin GraphQL read operations
- create a per-call correlation context before each selected GraphQL adapter call
- classify captured `GraphqlHttpError` values as network, HTTP, unauthorized, GraphQL rejection, or unknown
- expose only static admin messages while retaining raw and parsed causes in private tracing diagnostics
- record only request-shape facts: field presence and character lengths, never tenant, identifier, locale, search, status, pricing-context, channel, or quantity values
- preserve request validation, GraphQL documents/variables, response mapping, native reads, native-only mutations, transport selection, and no-fallback behavior
- add source evidence, documentation, a focused verifier, and aggregate pricing-admin boundary wiring

## Covered operations
- `fetch_bootstrap`
- `fetch_active_price_lists`
- `fetch_products`
- `fetch_product`

## Public policy
- network / HTTP: `Pricing admin service is temporarily unavailable`
- unauthorized: `Pricing admin authentication is required`
- GraphQL rejection / unknown: `Pricing admin request could not be completed`

## Source review
Rechecked the ecommerce master cursor and the recent Commerce/Pricing storefront error-safety wave. Those paths remain bounded; the Pricing admin facade was the next independent raw `GraphqlHttpError.to_string()` handoff.

The branch is based on current `main` and is not behind it. The broad ecommerce correlation-safe mapper cleanup remains open for other adapters and non-`PortError` public envelopes.

## Validation
Per maintainer instruction, tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run. Evidence remains `source-ready / unvalidated` and does not promote FFA/FBA, browser, runtime, mounted-parity, or production status.

Suggested maintainer commands:
```bash
node scripts/verify/verify-pricing-admin-graphql-error-safety.mjs
node scripts/verify/verify-pricing-admin-boundary.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-pricing-admin
cargo check -p rustok-pricing-admin --features hydrate
cargo check -p rustok-pricing-admin --features ssr
```
