### PR TITLE
fix(product): sanitize catalog option fallback errors

### DIFF
--- a/crates/rustok-product/admin/Cargo.toml
+++ b/crates/rustok-product/admin/Cargo.toml
@@ -39,3 +39,4 @@ serde_json.workspace = true
 uuid.workspace = true
 chrono.workspace = true
 rust_decimal.workspace = true
+tracing.workspace = true

--- a/crates/rustok-product/admin/src/catalog_transport.rs
+++ b/crates/rustok-product/admin/src/catalog_transport.rs
@@ -7,11 +7,72 @@ mod admin_catalog_graphql;
 #[path = "transport/admin_catalog_native.rs"]
 mod admin_catalog_native;
 
-pub use legacy::fetch_catalog_search_options;
 pub(crate) use legacy::*;
 
 use crate::catalog_controls::{ProductAdminListInput, build_product_admin_list_input};
-use crate::model::ProductList;
+use crate::model::{ProductCatalogSearchOptions, ProductList};
+
+const PRODUCT_ADMIN_CATALOG_OPTIONS_OWNER: &str = "rustok_product.admin";
+const PRODUCT_ADMIN_CATALOG_OPTIONS_OPERATION: &str = "fetch_catalog_search_options";
+const PRODUCT_ADMIN_CATALOG_OPTIONS_BOUNDARY: &str =
+    "product_admin_catalog_search_options_graphql_fallback";
+const PRODUCT_ADMIN_CATALOG_OPTIONS_PUBLIC_MESSAGE: &str =
+    "Product catalog search options are temporarily unavailable";
+
+struct CatalogSearchOptionsErrorContext {
+    correlation_id: String,
+    token_present: bool,
+    tenant_slug_length: Option<usize>,
+    locale_length: usize,
+}
+
+impl CatalogSearchOptionsErrorContext {
+    fn new(token: Option<&str>, tenant_slug: Option<&str>, locale: &str) -> Self {
+        Self {
+            correlation_id: format!(
+                "product-admin-catalog-options:{PRODUCT_ADMIN_CATALOG_OPTIONS_OPERATION}:{}",
+                uuid::Uuid::new_v4()
+            ),
+            token_present: token.is_some(),
+            tenant_slug_length: tenant_slug.map(|value| value.chars().count()),
+            locale_length: locale.chars().count(),
+        }
+    }
+
+    fn map_error(&self, raw_error: String) -> String {
+        tracing::error!(
+            raw_error = %raw_error,
+            owner = PRODUCT_ADMIN_CATALOG_OPTIONS_OWNER,
+            owner_operation = PRODUCT_ADMIN_CATALOG_OPTIONS_OPERATION,
+            correlation_id = %self.correlation_id,
+            token_present = self.token_present,
+            tenant_slug_present = self.tenant_slug_length.is_some(),
+            tenant_slug_length = ?self.tenant_slug_length,
+            locale_length = self.locale_length,
+            code = "product.admin_catalog_search_options_graphql_unavailable",
+            boundary = PRODUCT_ADMIN_CATALOG_OPTIONS_BOUNDARY,
+            "product admin catalog search options GraphQL fallback failed"
+        );
+
+        PRODUCT_ADMIN_CATALOG_OPTIONS_PUBLIC_MESSAGE.to_string()
+    }
+}
+
+pub async fn fetch_catalog_search_options(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    locale: String,
+) -> Result<ProductCatalogSearchOptions, String> {
+    let context = CatalogSearchOptionsErrorContext::new(
+        token.as_deref(),
+        tenant_slug.as_deref(),
+        locale.as_str(),
+    );
+
+    legacy::fetch_catalog_search_options(token, tenant_slug, locale)
+        .await
+        .map_err(|error| context.map_error(error))
+}
 
 pub(crate) async fn fetch_products(
     token: Option<String>,

--- a/crates/rustok-product/contracts/evidence/admin-catalog-search-options-error-safety-source-review.json
+++ b/crates/rustok-product/contracts/evidence/admin-catalog-search-options-error-safety-source-review.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": 1,
+  "reviewed_at_utc": "2026-07-30T19:18:00Z",
+  "review_base": "1c27a58320db2d91179beabfda064f22bcf82619",
+  "status": "product_admin_catalog_search_options_error_safety_source_reviewed_unvalidated",
+  "scope": "Product Admin catalog search-options public error boundary",
+  "reviewed_sources": [
+    "crates/rustok-commerce/docs/implementation-plan.md",
+    "crates/rustok-product/docs/implementation-plan.md",
+    "crates/rustok-product/admin/Cargo.toml",
+    "crates/rustok-product/admin/src/lib.rs",
+    "crates/rustok-product/admin/src/catalog_transport.rs",
+    "crates/rustok-product/admin/src/transport.rs",
+    "crates/rustok-product/admin/src/transport/native_server_adapter.rs",
+    "crates/rustok-product/admin/src/transport/graphql_adapter.rs",
+    "crates/rustok-product/admin/src/ui/catalog_admin.rs",
+    "scripts/verify/verify-product-admin-boundary.mjs"
+  ],
+  "findings": [
+    {
+      "id": "catalog-options-public-string-cause",
+      "severity": "confirmed",
+      "finding": "The Product Admin catalog search-options fallback converted three GraphQL failures with err.to_string() and returned the resulting String to the UI resource boundary. GraphQL server messages, HTTP status text, or transport classification could therefore become the public error value."
+    },
+    {
+      "id": "native-first-sequence",
+      "severity": "preserved",
+      "finding": "The native search-options endpoint remains the first attempt. Only after native failure does the legacy fallback load bootstrap, categories, and attributes in that order."
+    },
+    {
+      "id": "smallest-compatible-boundary",
+      "severity": "selected",
+      "finding": "The crate-root catalog transport wrapper is the smallest compatible public boundary because it receives the final String after the existing fallback sequence without changing owner calls, projections, or the UI result type."
+    },
+    {
+      "id": "private-cause-safe-shape",
+      "severity": "confirmed",
+      "finding": "The wrapper retains the captured String only in private tracing with a unique correlation id and token/tenant/locale shape facts. It exposes one static public message and does not log request values."
+    },
+    {
+      "id": "remaining-product-admin-scope",
+      "severity": "open",
+      "finding": "Other Product Admin reads and mutations still expose GraphqlHttpError directly and require separate bounded slices; this change does not claim broad Product Admin transport completion."
+    }
+  ],
+  "changed_files_expected": [
+    "crates/rustok-product/admin/Cargo.toml",
+    "crates/rustok-product/admin/src/catalog_transport.rs",
+    "crates/rustok-product/contracts/evidence/admin-catalog-search-options-error-safety-source.json",
+    "crates/rustok-product/contracts/evidence/admin-catalog-search-options-error-safety-source-review.json",
+    "crates/rustok-product/docs/admin-catalog-search-options-error-safety.md",
+    "scripts/verify/verify-product-admin-catalog-options-error-safety.mjs"
+  ],
+  "preserved": [
+    "native-first fallback order",
+    "GraphQL bootstrap, category, and attribute operations",
+    "search-option projection and labels",
+    "UI resource call shape",
+    "ProductCatalogSearchOptions DTO",
+    "no fallback or retry expansion"
+  ],
+  "remaining_scope": [
+    "other Product Admin GraphQL public envelopes",
+    "broader ecommerce correlation-safe mapper cleanup",
+    "focused verifier, Cargo, browser, and mounted fallback execution"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false
+  },
+  "execution": []
+}

--- a/crates/rustok-product/contracts/evidence/admin-catalog-search-options-error-safety-source.json
+++ b/crates/rustok-product/contracts/evidence/admin-catalog-search-options-error-safety-source.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": 1,
+  "generated_at_utc": "2026-07-30T19:18:00Z",
+  "status": "product_admin_catalog_search_options_error_safety_source_unvalidated",
+  "scope": "Product Admin catalog search-options GraphQL fallback public String envelope",
+  "operation": "fetch_catalog_search_options",
+  "boundary": "product_admin_catalog_search_options_graphql_fallback",
+  "public_message": "Product catalog search options are temporarily unavailable",
+  "source_contract": {
+    "native_first_preserved": true,
+    "graphql_bootstrap_categories_attributes_order_preserved": true,
+    "legacy_raw_error_capture_private": true,
+    "raw_graphql_error_public": false,
+    "unique_correlation_id": true,
+    "safe_request_shape_only": true,
+    "token_value_logged": false,
+    "tenant_slug_value_logged": false,
+    "locale_value_logged": false,
+    "public_result_type_changed": false,
+    "fallback_added": false,
+    "transport_selection_changed": false
+  },
+  "safe_diagnostics": [
+    "owner",
+    "owner_operation",
+    "correlation_id",
+    "token_present",
+    "tenant_slug_present",
+    "tenant_slug_length",
+    "locale_length",
+    "stable_code",
+    "boundary",
+    "private_raw_graphql_error"
+  ],
+  "forbidden_public_or_structured_values": [
+    "authentication token",
+    "tenant slug",
+    "locale value",
+    "tenant id",
+    "category ids",
+    "attribute codes",
+    "GraphQL server error message",
+    "HTTP status text"
+  ],
+  "preserved": [
+    "native catalog search-options attempt remains first",
+    "GraphQL fallback still resolves current tenant before categories and attributes",
+    "category option label precedence remains path then name then code",
+    "attribute options remain limited to filterable or sortable attributes",
+    "ProductCatalogSearchOptions and public Result value type remain unchanged",
+    "no additional fallback or retry is introduced"
+  ],
+  "remaining_scope": [
+    "other Product Admin GraphQL reads and mutations still return GraphqlHttpError directly",
+    "remaining ecommerce adapters and non-PortError public envelopes",
+    "focused verifier execution",
+    "default, hydrate, and SSR compilation",
+    "browser and mounted fallback evidence"
+  ],
+  "suggested_execution": [
+    "node scripts/verify/verify-product-admin-catalog-options-error-safety.mjs",
+    "node scripts/verify/verify-product-admin-boundary.mjs",
+    "node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs",
+    "cargo check -p rustok-product-admin",
+    "cargo check -p rustok-product-admin --features hydrate",
+    "cargo check -p rustok-product-admin --features ssr"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "focused_verifier_run": false,
+    "aggregate_verifier_run": false,
+    "broad_ecommerce_verifier_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "browser_runtime_proven": false,
+    "mounted_fallback_proven": false
+  },
+  "execution": []
+}

--- a/crates/rustok-product/docs/admin-catalog-search-options-error-safety.md
+++ b/crates/rustok-product/docs/admin-catalog-search-options-error-safety.md
@@ -1,0 +1,102 @@
+# Product Admin catalog search-options error safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens only the final public `String` error returned by Product Admin catalog search-option discovery:
+
+- `crates/rustok-product/admin/src/catalog_transport.rs`;
+- public `fetch_catalog_search_options` re-exported from the Product Admin crate root.
+
+The existing implementation in `transport.rs` remains the private compatibility executor. It still tries the native owner endpoint first and, only after native failure, performs the GraphQL fallback sequence:
+
+1. load the current tenant bootstrap;
+2. load catalog categories;
+3. load product attributes;
+4. build category and attribute search options.
+
+## Confirmed gap
+
+The compatibility executor converted each GraphQL failure with `err.to_string()` and returned `Result<ProductCatalogSearchOptions, String>`. The UI resource consumed that result directly.
+
+The captured string can include GraphQL server messages, HTTP status text, or transport classification details. Those values are useful for private diagnostics but are not a stable Product Admin public contract.
+
+## Boundary placement
+
+The crate-root catalog transport now owns a public wrapper around the unchanged compatibility executor. It creates `CatalogSearchOptionsErrorContext` before the native/GraphQL fallback begins.
+
+When the compatibility executor returns an error, the wrapper:
+
+- logs the captured string only in private tracing;
+- attaches a unique correlation id;
+- records only token presence, tenant-slug presence/length, and locale length;
+- returns `Product catalog search options are temporarily unavailable`.
+
+The public success DTO and `Result<_, String>` shape remain unchanged.
+
+## Correlation policy
+
+Each request receives an id in the namespace:
+
+```text
+product-admin-catalog-options:fetch_catalog_search_options:<uuid>
+```
+
+The stable internal code is:
+
+```text
+product.admin_catalog_search_options_graphql_unavailable
+```
+
+## Data minimization
+
+Structured diagnostics do not contain:
+
+- the authentication token;
+- tenant slug or tenant id;
+- locale value;
+- category ids;
+- attribute ids or codes;
+- option labels;
+- GraphQL variables or response data.
+
+Only presence and character-length facts are retained alongside the private captured error.
+
+## Preserved behavior
+
+This slice does not change:
+
+- the native-first fallback policy;
+- the native search-options server function;
+- GraphQL bootstrap, category, or attribute documents and variables;
+- tenant resolution order;
+- category label precedence (`path`, then `name`, then `code`);
+- filterable/sortable attribute selection;
+- `ProductCatalogSearchOptions` or its public re-export;
+- the UI resource call;
+- retries, transport selection, or fallback count;
+- Product FFA/FBA, browser, mounted, CI, or production status.
+
+## Static evidence
+
+- `crates/rustok-product/contracts/evidence/admin-catalog-search-options-error-safety-source.json`;
+- `crates/rustok-product/contracts/evidence/admin-catalog-search-options-error-safety-source-review.json`;
+- `scripts/verify/verify-product-admin-catalog-options-error-safety.mjs`.
+
+All execution fields remain false. Source review does not prove compilation, verifier execution, browser behavior, or mounted fallback behavior.
+
+## Remaining work
+
+The ecommerce correlation-safe mapper cleanup remains open for other Product Admin GraphQL reads and mutations, other owner adapters, and remaining non-`PortError` envelopes.
+
+## Suggested maintainer checks
+
+```bash
+node scripts/verify/verify-product-admin-catalog-options-error-safety.mjs
+node scripts/verify/verify-product-admin-boundary.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-product-admin
+cargo check -p rustok-product-admin --features hydrate
+cargo check -p rustok-product-admin --features ssr
+```

--- a/scripts/verify/verify-product-admin-catalog-options-error-safety.mjs
+++ b/scripts/verify/verify-product-admin-catalog-options-error-safety.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+
+function requireText(source, value, label) {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+}
+
+function forbidText(source, value, label) {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+}
+
+function countText(source, value) {
+  return source.split(value).length - 1;
+}
+
+function between(source, start, end, label) {
+  const from = source.indexOf(start);
+  const to = source.indexOf(end, from + start.length);
+  if (from < 0 || to < 0) {
+    failures.push(`${label}: could not isolate ${start} before ${end}`);
+    return "";
+  }
+  return source.slice(from, to);
+}
+
+const paths = {
+  cargo: "crates/rustok-product/admin/Cargo.toml",
+  lib: "crates/rustok-product/admin/src/lib.rs",
+  publicTransport: "crates/rustok-product/admin/src/catalog_transport.rs",
+  legacyTransport: "crates/rustok-product/admin/src/transport.rs",
+  native: "crates/rustok-product/admin/src/transport/native_server_adapter.rs",
+  graphql: "crates/rustok-product/admin/src/transport/graphql_adapter.rs",
+  ui: "crates/rustok-product/admin/src/ui/catalog_admin.rs",
+  evidence:
+    "crates/rustok-product/contracts/evidence/admin-catalog-search-options-error-safety-source.json",
+  review:
+    "crates/rustok-product/contracts/evidence/admin-catalog-search-options-error-safety-source-review.json",
+  doc: "crates/rustok-product/docs/admin-catalog-search-options-error-safety.md",
+};
+
+const cargo = read(paths.cargo);
+const lib = read(paths.lib);
+const publicTransport = read(paths.publicTransport);
+const legacyTransport = read(paths.legacyTransport);
+const native = read(paths.native);
+const graphql = read(paths.graphql);
+const ui = read(paths.ui);
+const evidence = JSON.parse(read(paths.evidence));
+const review = JSON.parse(read(paths.review));
+const doc = read(paths.doc);
+
+requireText(cargo, "uuid.workspace = true", `${paths.cargo}: correlation UUID dependency`);
+requireText(cargo, "tracing.workspace = true", `${paths.cargo}: private diagnostics dependency`);
+
+requireText(
+  lib,
+  "pub use transport::fetch_catalog_search_options;",
+  `${paths.lib}: public Product Admin search-option contract`,
+);
+requireText(
+  ui,
+  "transport::fetch_catalog_search_options(token, tenant, locale).await",
+  `${paths.ui}: UI must consume the public wrapper`,
+);
+
+forbidText(
+  publicTransport,
+  "pub use legacy::fetch_catalog_search_options;",
+  `${paths.publicTransport}: raw legacy String must not be re-exported directly`,
+);
+for (const marker of [
+  "pub async fn fetch_catalog_search_options(",
+  "CatalogSearchOptionsErrorContext::new(",
+  "legacy::fetch_catalog_search_options(token, tenant_slug, locale)",
+  ".map_err(|error| context.map_error(error))",
+]) {
+  requireText(publicTransport, marker, `${paths.publicTransport}: final public error boundary`);
+}
+
+const wrapperStart = publicTransport.indexOf("pub async fn fetch_catalog_search_options(");
+const productsStart = publicTransport.indexOf("pub(crate) async fn fetch_products(", wrapperStart);
+if (wrapperStart < 0 || productsStart < 0) {
+  failures.push(`${paths.publicTransport}: public search-options wrapper boundaries are missing`);
+} else {
+  const wrapper = publicTransport.slice(wrapperStart, productsStart);
+  const contextIndex = wrapper.indexOf("CatalogSearchOptionsErrorContext::new(");
+  const callIndex = wrapper.indexOf("legacy::fetch_catalog_search_options(");
+  if (contextIndex < 0 || callIndex < 0 || contextIndex > callIndex) {
+    failures.push(`${paths.publicTransport}: correlation context must be created before fallback execution`);
+  }
+}
+
+for (const marker of [
+  "struct CatalogSearchOptionsErrorContext",
+  "uuid::Uuid::new_v4()",
+  '"product-admin-catalog-options:{PRODUCT_ADMIN_CATALOG_OPTIONS_OPERATION}:{}"',
+  "fn map_error(&self, raw_error: String) -> String",
+  "raw_error = %raw_error",
+  "correlation_id = %self.correlation_id",
+  "token_present = self.token_present",
+  "tenant_slug_length = ?self.tenant_slug_length",
+  "locale_length = self.locale_length",
+  'code = "product.admin_catalog_search_options_graphql_unavailable"',
+  '"Product catalog search options are temporarily unavailable"',
+  "PRODUCT_ADMIN_CATALOG_OPTIONS_PUBLIC_MESSAGE.to_string()",
+]) {
+  requireText(publicTransport, marker, `${paths.publicTransport}: correlation-safe static mapping`);
+}
+for (const marker of [
+  "token = %",
+  "token = ?",
+  "tenant_slug = %",
+  "tenant_slug = ?",
+  "locale = %",
+  "locale = ?",
+  "tenant_id = %",
+  "tenant_id = ?",
+]) {
+  forbidText(publicTransport, marker, `${paths.publicTransport}: raw request values must not be logged`);
+}
+
+const legacyBlock = between(
+  legacyTransport,
+  "pub async fn fetch_catalog_search_options(",
+  "fn first_non_empty",
+  paths.legacyTransport,
+);
+for (const marker of [
+  "native_server_adapter::fetch_catalog_search_options(locale.clone()).await",
+  "graphql_adapter::fetch_bootstrap(token.clone(), tenant_slug.clone())",
+  "graphql_adapter::fetch_catalog_categories(",
+  "graphql_adapter::fetch_product_attributes(token, tenant_slug, tenant_id, locale)",
+  "ProductCatalogSearchOptions {",
+  "first_non_empty([category.path, category.name, category.code])",
+  "attribute.is_filterable || attribute.is_sortable",
+]) {
+  requireText(legacyBlock, marker, `${paths.legacyTransport}: preserved fallback and projection contract`);
+}
+if (countText(legacyBlock, ".map_err(|err| err.to_string())?;") !== 3) {
+  failures.push(
+    `${paths.legacyTransport}: private compatibility executor must retain exactly three captured GraphQL String handoffs`,
+  );
+}
+const nativeIndex = legacyBlock.indexOf("native_server_adapter::fetch_catalog_search_options");
+const bootstrapIndex = legacyBlock.indexOf("graphql_adapter::fetch_bootstrap");
+const categoriesIndex = legacyBlock.indexOf("graphql_adapter::fetch_catalog_categories");
+const attributesIndex = legacyBlock.indexOf("graphql_adapter::fetch_product_attributes");
+if (
+  nativeIndex < 0 ||
+  bootstrapIndex < 0 ||
+  categoriesIndex < 0 ||
+  attributesIndex < 0 ||
+  !(nativeIndex < bootstrapIndex && bootstrapIndex < categoriesIndex && categoriesIndex < attributesIndex)
+) {
+  failures.push(`${paths.legacyTransport}: native/bootstrap/categories/attributes order drift`);
+}
+
+for (const marker of [
+  "pub(super) async fn fetch_catalog_search_options(",
+  "product_admin_catalog_search_options_native(locale)",
+]) {
+  requireText(native, marker, `${paths.native}: native-first owner endpoint`);
+}
+for (const marker of [
+  "pub type ApiError = GraphqlHttpError;",
+  "ProductAdminBootstrap",
+  "ProductAdminCatalogCategories",
+  "ProductAdminAttributes",
+]) {
+  requireText(graphql, marker, `${paths.graphql}: preserved GraphQL owner contracts`);
+}
+
+if (evidence.schema_version !== 1) failures.push(`${paths.evidence}: schema_version must be 1`);
+if (
+  evidence.status !==
+  "product_admin_catalog_search_options_error_safety_source_unvalidated"
+) {
+  failures.push(`${paths.evidence}: status mismatch`);
+}
+for (const [key, expected] of Object.entries({
+  native_first_preserved: true,
+  graphql_bootstrap_categories_attributes_order_preserved: true,
+  legacy_raw_error_capture_private: true,
+  raw_graphql_error_public: false,
+  unique_correlation_id: true,
+  safe_request_shape_only: true,
+  token_value_logged: false,
+  tenant_slug_value_logged: false,
+  locale_value_logged: false,
+  public_result_type_changed: false,
+  fallback_added: false,
+  transport_selection_changed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "focused_verifier_run",
+  "aggregate_verifier_run",
+  "broad_ecommerce_verifier_run",
+  "workflow_checks_run",
+  "ci_run",
+  "browser_runtime_proven",
+  "mounted_fallback_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push(`${paths.evidence}: execution must remain empty`);
+}
+if (
+  review.status !==
+  "product_admin_catalog_search_options_error_safety_source_reviewed_unvalidated"
+) {
+  failures.push(`${paths.review}: status mismatch`);
+}
+requireText(doc, "Status: **source-ready / unvalidated**", `${paths.doc}: source status`);
+requireText(
+  doc,
+  "Product catalog search options are temporarily unavailable",
+  `${paths.doc}: static public contract`,
+);
+requireText(doc, "native-first fallback policy", `${paths.doc}: preserved fallback policy`);
+
+if (failures.length > 0) {
+  console.error("Product Admin catalog search-options error-safety verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "Product Admin catalog search-option failures use one correlation-safe static public String; execution evidence remains open",
+);


### PR DESCRIPTION
## Summary
- wrap the public Product Admin `fetch_catalog_search_options` boundary instead of directly re-exporting the compatibility executor
- create one correlation context before the existing native-first fallback begins
- retain the final captured GraphQL String only in private structured diagnostics
- expose `Product catalog search options are temporarily unavailable` as the stable public error
- record only token presence, tenant-slug presence/length, locale length, stable code, boundary, and correlation id
- preserve the native-first path and the GraphQL bootstrap → categories → attributes sequence
- preserve category label precedence, filterable/sortable attribute selection, DTOs, UI call shape, fallback count, and retry behavior
- add source evidence, documentation, and a focused fail-closed verifier

## Confirmed gap
The compatibility executor converted all three GraphQL failures using `err.to_string()` and returned the String directly through the public crate-root transport re-export. GraphQL server messages, HTTP status text, or transport classification could therefore reach the Product Admin UI resource boundary.

## Scope boundary
This PR changes only the final catalog search-options error envelope. Other Product Admin GraphQL reads and mutations still return `GraphqlHttpError` directly and remain separate ecommerce mapper-cleanup work.

## Main drift
The branch started from `1c27a58320db2d91179beabfda064f22bcf82619`. Current `main` has one later Blog-only commit (#2598); it does not overlap Product Admin files.

## Validation
Per maintainer instruction, tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run. Evidence remains source-ready / unvalidated and does not promote Product FFA/FBA, browser, mounted fallback, workflow, CI, or production status.

Suggested maintainer commands:
```bash
node scripts/verify/verify-product-admin-catalog-options-error-safety.mjs
node scripts/verify/verify-product-admin-boundary.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-product-admin
cargo check -p rustok-product-admin --features hydrate
cargo check -p rustok-product-admin --features ssr
```