### PR TITLE
fix(product): sanitize primary admin GraphQL mutations

### DIFF
--- a/crates/rustok-product/admin/src/catalog_transport.rs
+++ b/crates/rustok-product/admin/src/catalog_transport.rs
@@ -14,8 +14,8 @@ pub(crate) use legacy::*;
 use crate::catalog_controls::{ProductAdminListInput, build_product_admin_list_input};
 use crate::model::{
     CatalogCategoryList, ProductAdminBootstrap, ProductAttributeList, ProductAttributeSchemaList,
-    ProductAttributeValueItem, ProductCatalogSearchOptions, ProductDetail, ProductEffectiveForm,
-    ProductList, ProductPricingDetail, ShippingProfileList,
+    ProductAttributeValueItem, ProductCatalogSearchOptions, ProductDetail, ProductDraft,
+    ProductEffectiveForm, ProductList, ProductPricingDetail, ShippingProfileList,
 };
 use rustok_graphql::GraphqlHttpError;
 
@@ -305,4 +305,82 @@ pub(crate) async fn fetch_product_attribute_values(
     legacy::fetch_product_attribute_values(token, tenant_slug, tenant_id, product_id, locale)
         .await
         .map_err(|failure| context.map_error(failure))
+}
+
+pub(crate) async fn create_product(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    user_id: String,
+    draft: ProductDraft,
+) -> Result<ProductDetail, GraphqlHttpError> {
+    let context = graphql_error_safety::GraphqlMutationContext::for_create_product(
+        token.as_deref(),
+        tenant_slug.as_deref(),
+        tenant_id.as_str(),
+        user_id.as_str(),
+    );
+    legacy::create_product(token, tenant_slug, tenant_id, user_id, draft)
+        .await
+        .map_err(|mutation_error| context.map_error(mutation_error))
+}
+
+pub(crate) async fn update_product(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    user_id: String,
+    id: String,
+    draft: ProductDraft,
+) -> Result<ProductDetail, GraphqlHttpError> {
+    let context = graphql_error_safety::GraphqlMutationContext::for_update_product(
+        token.as_deref(),
+        tenant_slug.as_deref(),
+        tenant_id.as_str(),
+        user_id.as_str(),
+        id.as_str(),
+    );
+    legacy::update_product(token, tenant_slug, tenant_id, user_id, id, draft)
+        .await
+        .map_err(|mutation_error| context.map_error(mutation_error))
+}
+
+pub(crate) async fn change_product_status(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    user_id: String,
+    id: String,
+    status: &str,
+) -> Result<ProductDetail, GraphqlHttpError> {
+    let context = graphql_error_safety::GraphqlMutationContext::for_change_product_status(
+        token.as_deref(),
+        tenant_slug.as_deref(),
+        tenant_id.as_str(),
+        user_id.as_str(),
+        id.as_str(),
+        status,
+    );
+    legacy::change_product_status(token, tenant_slug, tenant_id, user_id, id, status)
+        .await
+        .map_err(|mutation_error| context.map_error(mutation_error))
+}
+
+pub(crate) async fn delete_product(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    user_id: String,
+    id: String,
+) -> Result<bool, GraphqlHttpError> {
+    let context = graphql_error_safety::GraphqlMutationContext::for_delete_product(
+        token.as_deref(),
+        tenant_slug.as_deref(),
+        tenant_id.as_str(),
+        user_id.as_str(),
+        id.as_str(),
+    );
+    legacy::delete_product(token, tenant_slug, tenant_id, user_id, id)
+        .await
+        .map_err(|mutation_error| context.map_error(mutation_error))
 }

--- a/crates/rustok-product/admin/src/transport/graphql_error_safety.rs
+++ b/crates/rustok-product/admin/src/transport/graphql_error_safety.rs
@@ -5,6 +5,8 @@ const PRODUCT_ADMIN_GRAPHQL_OWNER: &str = "rustok_product.admin";
 const PRODUCT_ADMIN_GRAPHQL_BOUNDARY: &str = "product_admin_primary_graphql_reads";
 const PRODUCT_ADMIN_CATEGORY_GRAPHQL_BOUNDARY: &str =
     "product_admin_category_graphql_reads";
+const PRODUCT_ADMIN_MUTATION_GRAPHQL_BOUNDARY: &str =
+    "product_admin_primary_graphql_mutations";
 const PRODUCT_ADMIN_HTTP_PUBLIC_MESSAGE: &str =
     "Product admin service is temporarily unavailable";
 const PRODUCT_ADMIN_GRAPHQL_PUBLIC_MESSAGE: &str =
@@ -290,6 +292,171 @@ impl GraphqlReadContext {
                 code,
                 boundary = self.boundary,
                 "product admin GraphQL read was rejected"
+            );
+        }
+
+        public_error
+    }
+}
+
+pub(super) struct GraphqlMutationContext {
+    operation: &'static str,
+    correlation_id: String,
+    token_present: bool,
+    tenant_slug_length: Option<usize>,
+    tenant_id_length: usize,
+    actor_id_length: usize,
+    resource_id_length: Option<usize>,
+    status_length: Option<usize>,
+    draft_present: bool,
+}
+
+impl GraphqlMutationContext {
+    pub(super) fn for_create_product(
+        token: Option<&str>,
+        tenant_slug: Option<&str>,
+        tenant_id: &str,
+        actor_id: &str,
+    ) -> Self {
+        let mut context = Self::new("create_product", token, tenant_slug, tenant_id, actor_id);
+        context.draft_present = true;
+        context
+    }
+
+    pub(super) fn for_update_product(
+        token: Option<&str>,
+        tenant_slug: Option<&str>,
+        tenant_id: &str,
+        actor_id: &str,
+        resource_id: &str,
+    ) -> Self {
+        let mut context = Self::new("update_product", token, tenant_slug, tenant_id, actor_id);
+        context.resource_id_length = Some(resource_id.chars().count());
+        context.draft_present = true;
+        context
+    }
+
+    pub(super) fn for_change_product_status(
+        token: Option<&str>,
+        tenant_slug: Option<&str>,
+        tenant_id: &str,
+        actor_id: &str,
+        resource_id: &str,
+        status: &str,
+    ) -> Self {
+        let mut context = Self::new(
+            "change_product_status",
+            token,
+            tenant_slug,
+            tenant_id,
+            actor_id,
+        );
+        context.resource_id_length = Some(resource_id.chars().count());
+        context.status_length = Some(status.chars().count());
+        context
+    }
+
+    pub(super) fn for_delete_product(
+        token: Option<&str>,
+        tenant_slug: Option<&str>,
+        tenant_id: &str,
+        actor_id: &str,
+        resource_id: &str,
+    ) -> Self {
+        let mut context = Self::new("delete_product", token, tenant_slug, tenant_id, actor_id);
+        context.resource_id_length = Some(resource_id.chars().count());
+        context
+    }
+
+    fn new(
+        operation: &'static str,
+        token: Option<&str>,
+        tenant_slug: Option<&str>,
+        tenant_id: &str,
+        actor_id: &str,
+    ) -> Self {
+        Self {
+            operation,
+            correlation_id: format!("product-admin-mutation:{operation}:{}", Uuid::new_v4()),
+            token_present: token.is_some(),
+            tenant_slug_length: text_length(tenant_slug),
+            tenant_id_length: tenant_id.chars().count(),
+            actor_id_length: actor_id.chars().count(),
+            resource_id_length: None,
+            status_length: None,
+            draft_present: false,
+        }
+    }
+
+    pub(super) fn map_error(&self, error: GraphqlHttpError) -> GraphqlHttpError {
+        let (error_kind, code, public_error, technical_failure) = match &error {
+            GraphqlHttpError::Network => (
+                "network",
+                "product.admin_graphql_network_unavailable",
+                GraphqlHttpError::Network,
+                true,
+            ),
+            GraphqlHttpError::Http(_) => (
+                "http",
+                "product.admin_graphql_http_unavailable",
+                GraphqlHttpError::Http(PRODUCT_ADMIN_HTTP_PUBLIC_MESSAGE.to_string()),
+                true,
+            ),
+            GraphqlHttpError::Unauthorized => (
+                "unauthorized",
+                "product.admin_graphql_authentication_required",
+                GraphqlHttpError::Unauthorized,
+                false,
+            ),
+            GraphqlHttpError::Graphql(_) => (
+                "graphql",
+                "product.admin_graphql_request_rejected",
+                GraphqlHttpError::Graphql(PRODUCT_ADMIN_GRAPHQL_PUBLIC_MESSAGE.to_string()),
+                false,
+            ),
+        };
+
+        if technical_failure {
+            tracing::error!(
+                raw_error = ?error,
+                owner = PRODUCT_ADMIN_GRAPHQL_OWNER,
+                owner_operation = self.operation,
+                correlation_id = %self.correlation_id,
+                token_present = self.token_present,
+                tenant_slug_present = self.tenant_slug_length.is_some(),
+                tenant_slug_length = ?self.tenant_slug_length,
+                tenant_id_length = self.tenant_id_length,
+                actor_id_length = self.actor_id_length,
+                resource_id_present = self.resource_id_length.is_some(),
+                resource_id_length = ?self.resource_id_length,
+                status_present = self.status_length.is_some(),
+                status_length = ?self.status_length,
+                draft_present = self.draft_present,
+                error_kind,
+                code,
+                boundary = PRODUCT_ADMIN_MUTATION_GRAPHQL_BOUNDARY,
+                "product admin GraphQL mutation failed"
+            );
+        } else {
+            tracing::warn!(
+                raw_error = ?error,
+                owner = PRODUCT_ADMIN_GRAPHQL_OWNER,
+                owner_operation = self.operation,
+                correlation_id = %self.correlation_id,
+                token_present = self.token_present,
+                tenant_slug_present = self.tenant_slug_length.is_some(),
+                tenant_slug_length = ?self.tenant_slug_length,
+                tenant_id_length = self.tenant_id_length,
+                actor_id_length = self.actor_id_length,
+                resource_id_present = self.resource_id_length.is_some(),
+                resource_id_length = ?self.resource_id_length,
+                status_present = self.status_length.is_some(),
+                status_length = ?self.status_length,
+                draft_present = self.draft_present,
+                error_kind,
+                code,
+                boundary = PRODUCT_ADMIN_MUTATION_GRAPHQL_BOUNDARY,
+                "product admin GraphQL mutation was rejected"
             );
         }
 

--- a/crates/rustok-product/contracts/evidence/admin-primary-graphql-mutation-error-safety-source-review.json
+++ b/crates/rustok-product/contracts/evidence/admin-primary-graphql-mutation-error-safety-source-review.json
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "reviewed_at_utc": "2026-07-30T19:52:00Z",
+  "review_base": "06c1aa0fa694cdaf5f8e88d3422777fd052ffd61",
+  "status": "product_admin_primary_graphql_mutation_error_safety_source_reviewed_unvalidated",
+  "scope": "Product Admin primary GraphQL mutation public error boundary",
+  "reviewed_sources": [
+    "crates/rustok-commerce/docs/implementation-plan.md",
+    "crates/rustok-product/docs/implementation-plan.md",
+    "crates/rustok-product/admin/src/catalog_transport.rs",
+    "crates/rustok-product/admin/src/transport.rs",
+    "crates/rustok-product/admin/src/transport/graphql_error_safety.rs",
+    "crates/rustok-product/admin/src/transport/graphql_adapter.rs",
+    "crates/rustok-product/admin/src/ui/leptos.rs",
+    "crates/rustok-graphql/src/lib.rs",
+    "scripts/verify/verify-product-admin-primary-read-error-safety.mjs",
+    "scripts/verify/verify-product-admin-category-read-error-safety.mjs"
+  ],
+  "findings": [
+    {
+      "id": "product-admin-primary-mutation-raw-graphql-errors",
+      "severity": "confirmed",
+      "finding": "create_product, update_product, change_product_status and delete_product delegated directly to the GraphQL adapter. Http carried response status text and Graphql carried the first server error message into UI command errors."
+    },
+    {
+      "id": "typed-envelope-compatible-fix",
+      "severity": "selected",
+      "finding": "The bounded fix keeps GraphqlHttpError as the result type, preserves Network and Unauthorized, and replaces only Http and Graphql payloads with the existing Product Admin static messages."
+    },
+    {
+      "id": "mutation-command-shapes-preserved",
+      "severity": "preserved",
+      "finding": "CreateProductInput, UpdateProductInput, status-only update construction, delete variables, tenant/user variables and response DTO mapping remain in the unchanged private GraphQL adapter."
+    },
+    {
+      "id": "safe-mutation-diagnostics",
+      "severity": "confirmed",
+      "finding": "The owner policy records token presence and character lengths for tenant, actor, resource and status fields plus draft presence. It does not structure raw request values or draft content."
+    },
+    {
+      "id": "prior-read-slices-preserved",
+      "severity": "preserved",
+      "finding": "Catalog-options, primary-read and category-read wrappers remain unchanged. Mutation wrappers use a distinct mapper variable so prior exact-count guards retain their original scopes."
+    }
+  ],
+  "changed_files_expected": [
+    "crates/rustok-product/admin/src/catalog_transport.rs",
+    "crates/rustok-product/admin/src/transport/graphql_error_safety.rs",
+    "crates/rustok-product/contracts/evidence/admin-primary-graphql-mutation-error-safety-source.json",
+    "crates/rustok-product/contracts/evidence/admin-primary-graphql-mutation-error-safety-source-review.json",
+    "crates/rustok-product/docs/admin-primary-graphql-mutation-error-safety.md",
+    "scripts/verify/verify-product-admin-primary-mutation-error-safety.mjs"
+  ],
+  "preserved": [
+    "GraphQL mutation documents and variables",
+    "mutation input and response mapping",
+    "primary mutation function result types",
+    "Product Admin UI command composition",
+    "absence of new retry or fallback paths",
+    "all previously merged read error-safety policies"
+  ],
+  "remaining_scope": [
+    "Product Admin category, schema and attribute-value GraphQL mutations",
+    "Product Admin focused verifier execution and Cargo compilation",
+    "browser and mounted transport evidence",
+    "remaining ecommerce non-PortError public envelopes"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "browser_runtime_proven": false,
+    "mounted_transport_proven": false
+  },
+  "execution": []
+}

--- a/crates/rustok-product/contracts/evidence/admin-primary-graphql-mutation-error-safety-source.json
+++ b/crates/rustok-product/contracts/evidence/admin-primary-graphql-mutation-error-safety-source.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": 1,
+  "generated_at_utc": "2026-07-30T19:52:00Z",
+  "status": "product_admin_primary_graphql_mutation_error_safety_source_unvalidated",
+  "scope": "Product Admin primary GraphQL mutation public envelopes",
+  "operations": [
+    "create_product",
+    "update_product",
+    "change_product_status",
+    "delete_product"
+  ],
+  "boundary": "product_admin_primary_graphql_mutations",
+  "public_policy": {
+    "network": "Network error",
+    "http": "Http error: Product admin service is temporarily unavailable",
+    "unauthorized": "Unauthorized",
+    "graphql": "GraphQL error: Product admin request could not be completed"
+  },
+  "source_contract": {
+    "context_before_graphql_call": true,
+    "unique_correlation_id": true,
+    "typed_graphql_error_classification": true,
+    "network_static_public_envelope": true,
+    "http_static_public_envelope": true,
+    "unauthorized_static_public_envelope": true,
+    "graphql_static_public_envelope": true,
+    "raw_http_status_public": false,
+    "raw_graphql_message_public": false,
+    "private_typed_error_diagnostics": true,
+    "safe_request_shape_only": true,
+    "result_types_changed": false,
+    "graphql_documents_changed": false,
+    "graphql_variables_changed": false,
+    "mutation_input_mapping_changed": false,
+    "owner_policy_changed": false,
+    "retry_added": false,
+    "fallback_added": false
+  },
+  "safe_diagnostics": [
+    "owner",
+    "owner_operation",
+    "correlation_id",
+    "token_present",
+    "tenant_slug_present",
+    "tenant_slug_length",
+    "tenant_id_length",
+    "actor_id_length",
+    "resource_id_present",
+    "resource_id_length",
+    "status_present",
+    "status_length",
+    "draft_present",
+    "error_kind",
+    "code",
+    "boundary",
+    "private_typed_graphql_error"
+  ],
+  "forbidden_public_or_structured_values": [
+    "token",
+    "tenant_slug",
+    "tenant_id",
+    "user_id",
+    "product_id",
+    "status",
+    "product draft fields",
+    "HTTP status text",
+    "GraphQL server message"
+  ],
+  "preserved": [
+    "ProductDetail and boolean mutation result types",
+    "CreateProductInput and UpdateProductInput construction",
+    "tenant and actor GraphQL variables",
+    "create, update, status and delete mutation documents",
+    "UI command composition",
+    "absence of retry or fallback behavior"
+  ],
+  "remaining_scope": [
+    "Product Admin category, schema and attribute-value GraphQL mutations",
+    "Product Admin browser and mounted transport evidence",
+    "remaining ecommerce non-PortError public envelopes"
+  ],
+  "suggested_execution": [
+    "node scripts/verify/verify-product-admin-primary-mutation-error-safety.mjs",
+    "node scripts/verify/verify-product-admin-category-read-error-safety.mjs",
+    "node scripts/verify/verify-product-admin-primary-read-error-safety.mjs",
+    "node scripts/verify/verify-product-admin-boundary.mjs",
+    "node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs",
+    "cargo check -p rustok-product-admin",
+    "cargo check -p rustok-product-admin --features hydrate",
+    "cargo check -p rustok-product-admin --features ssr"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "focused_verifier_run": false,
+    "read_verifiers_run": false,
+    "aggregate_verifier_run": false,
+    "broad_ecommerce_verifier_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "browser_runtime_proven": false,
+    "mounted_transport_proven": false
+  },
+  "execution": []
+}

--- a/crates/rustok-product/docs/admin-primary-graphql-mutation-error-safety.md
+++ b/crates/rustok-product/docs/admin-primary-graphql-mutation-error-safety.md
@@ -1,0 +1,106 @@
+# Product Admin primary GraphQL mutation error safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens the final public error envelope for four Product Admin mutations:
+
+- `create_product`;
+- `update_product`;
+- `change_product_status`;
+- `delete_product`.
+
+The boundary lives in:
+
+- `crates/rustok-product/admin/src/catalog_transport.rs`;
+- `crates/rustok-product/admin/src/transport/graphql_error_safety.rs`.
+
+The GraphQL mutation documents, variables, input builders, response DTOs and Product owner policy are unchanged.
+
+## Confirmed gap
+
+The four primary product commands delegated directly through the compatibility transport to the GraphQL adapter.
+
+`GraphqlHttpError::Http(String)` can contain HTTP status text and
+`GraphqlHttpError::Graphql(String)` can contain the first GraphQL server message. Those payloads could therefore reach Product Admin UI command errors.
+
+## Boundary placement
+
+A `GraphqlMutationContext` is created before each selected compatibility transport call. The wrapper maps only a final returned `GraphqlHttpError`.
+
+No retry, fallback, extra owner call, mutation document, variable or response mapping is introduced.
+
+## Public policy
+
+The result error type remains `GraphqlHttpError`.
+
+| Captured condition | Public error |
+| --- | --- |
+| Network failure | `Network error` |
+| HTTP failure | `Http error: Product admin service is temporarily unavailable` |
+| Unauthorized | `Unauthorized` |
+| GraphQL rejection | `GraphQL error: Product admin request could not be completed` |
+
+`Network` and `Unauthorized` remain fixed non-identifying variants. HTTP status text and GraphQL server messages are replaced with static Product Admin messages.
+
+## Internal diagnostics
+
+The original typed error remains available only to private tracing. Each event records:
+
+- owner, operation and boundary;
+- a unique correlation ID;
+- token presence, never the token value;
+- tenant-slug presence and length;
+- tenant-ID and actor-ID lengths;
+- product/resource-ID presence and length;
+- status presence and length;
+- whether a product draft was supplied;
+- error kind and stable code.
+
+Raw token, tenant slug, tenant ID, actor ID, product ID, status and draft content are not structured fields.
+
+## Preserved behavior
+
+This slice does not change:
+
+- `ProductDetail` or boolean mutation result types;
+- `CreateProductInput` or `UpdateProductInput` construction;
+- tenant/user GraphQL variables;
+- status-only update behavior;
+- delete-product variables;
+- UI save, status and delete command composition;
+- retries or fallback behavior;
+- previously merged Product Admin read error policies;
+- Product FFA/FBA, browser, mounted-runtime, workflow, CI or production status.
+
+## Static evidence
+
+- `crates/rustok-product/contracts/evidence/admin-primary-graphql-mutation-error-safety-source.json`;
+- `crates/rustok-product/contracts/evidence/admin-primary-graphql-mutation-error-safety-source-review.json`;
+- `scripts/verify/verify-product-admin-primary-mutation-error-safety.mjs`.
+
+All execution flags remain `false`. Source review does not prove compilation, browser behavior, mounted transport behavior, workflow execution, CI or production behavior.
+
+## Remaining work
+
+The ecommerce mapper cleanup remains open for:
+
+- Product Admin category, schema and attribute-value GraphQL mutations;
+- Product Admin browser and mounted transport evidence;
+- other ecommerce adapters and non-`PortError` public envelopes.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-product-admin-primary-mutation-error-safety.mjs
+node scripts/verify/verify-product-admin-category-read-error-safety.mjs
+node scripts/verify/verify-product-admin-primary-read-error-safety.mjs
+node scripts/verify/verify-product-admin-boundary.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-product-admin
+cargo check -p rustok-product-admin --features hydrate
+cargo check -p rustok-product-admin --features ssr
+```

--- a/scripts/verify/verify-product-admin-primary-mutation-error-safety.mjs
+++ b/scripts/verify/verify-product-admin-primary-mutation-error-safety.mjs
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const countText = (source, value) => source.split(value).length - 1;
+const between = (source, start, end, label) => {
+  const from = source.indexOf(start);
+  const to = source.indexOf(end, from + start.length);
+  if (from < 0 || to < 0) {
+    failures.push(`${label}: could not isolate ${start} before ${end}`);
+    return "";
+  }
+  return source.slice(from, to);
+};
+
+const paths = {
+  facade: "crates/rustok-product/admin/src/catalog_transport.rs",
+  safety: "crates/rustok-product/admin/src/transport/graphql_error_safety.rs",
+  legacy: "crates/rustok-product/admin/src/transport.rs",
+  graphql: "crates/rustok-product/admin/src/transport/graphql_adapter.rs",
+  graphqlHttp: "crates/rustok-graphql/src/lib.rs",
+  ui: "crates/rustok-product/admin/src/ui/leptos.rs",
+  primaryReadGuard: "scripts/verify/verify-product-admin-primary-read-error-safety.mjs",
+  categoryReadGuard: "scripts/verify/verify-product-admin-category-read-error-safety.mjs",
+  evidence:
+    "crates/rustok-product/contracts/evidence/admin-primary-graphql-mutation-error-safety-source.json",
+  review:
+    "crates/rustok-product/contracts/evidence/admin-primary-graphql-mutation-error-safety-source-review.json",
+  doc: "crates/rustok-product/docs/admin-primary-graphql-mutation-error-safety.md",
+  masterPlan: "crates/rustok-commerce/docs/implementation-plan.md",
+};
+
+const facade = read(paths.facade);
+const safety = read(paths.safety);
+const legacy = read(paths.legacy);
+const graphql = read(paths.graphql);
+const graphqlHttp = read(paths.graphqlHttp);
+const ui = read(paths.ui);
+const primaryReadGuard = read(paths.primaryReadGuard);
+const categoryReadGuard = read(paths.categoryReadGuard);
+const evidence = JSON.parse(read(paths.evidence));
+const review = JSON.parse(read(paths.review));
+const doc = read(paths.doc);
+const masterPlan = read(paths.masterPlan);
+
+requireText(facade, "ProductDetail, ProductDraft,", `${paths.facade}: ProductDraft wrapper import`);
+requireText(
+  facade,
+  "graphql_error_safety::GraphqlMutationContext",
+  `${paths.facade}: mutation policy wiring`,
+);
+
+const operations = [
+  {
+    name: "create_product",
+    start: "pub(crate) async fn create_product(",
+    end: "pub(crate) async fn update_product(",
+    context: "GraphqlMutationContext::for_create_product(",
+    call: "legacy::create_product(token, tenant_slug, tenant_id, user_id, draft)",
+  },
+  {
+    name: "update_product",
+    start: "pub(crate) async fn update_product(",
+    end: "pub(crate) async fn change_product_status(",
+    context: "GraphqlMutationContext::for_update_product(",
+    call: "legacy::update_product(token, tenant_slug, tenant_id, user_id, id, draft)",
+  },
+  {
+    name: "change_product_status",
+    start: "pub(crate) async fn change_product_status(",
+    end: "pub(crate) async fn delete_product(",
+    context: "GraphqlMutationContext::for_change_product_status(",
+    call: "legacy::change_product_status(token, tenant_slug, tenant_id, user_id, id, status)",
+  },
+];
+
+for (const operation of operations) {
+  const block = between(facade, operation.start, operation.end, paths.facade);
+  for (const marker of [
+    operation.context,
+    operation.call,
+    ".map_err(|mutation_error| context.map_error(mutation_error))",
+  ]) {
+    requireText(block, marker, `${paths.facade}: ${operation.name} final boundary`);
+  }
+  if (block.indexOf(operation.context) > block.indexOf(operation.call)) {
+    failures.push(`${paths.facade}: ${operation.name} context must precede the GraphQL call`);
+  }
+}
+
+const deleteStart = facade.indexOf("pub(crate) async fn delete_product(");
+const deleteBlock = deleteStart < 0 ? "" : facade.slice(deleteStart);
+for (const marker of [
+  "GraphqlMutationContext::for_delete_product(",
+  "legacy::delete_product(token, tenant_slug, tenant_id, user_id, id)",
+  ".map_err(|mutation_error| context.map_error(mutation_error))",
+]) {
+  requireText(deleteBlock, marker, `${paths.facade}: delete_product final boundary`);
+}
+if (
+  deleteBlock.indexOf("GraphqlMutationContext::for_delete_product(") >
+  deleteBlock.indexOf("legacy::delete_product(")
+) {
+  failures.push(`${paths.facade}: delete_product context must precede the GraphQL call`);
+}
+if (countText(facade, ".map_err(|mutation_error| context.map_error(mutation_error))") !== 4) {
+  failures.push(`${paths.facade}: expected exactly four primary mutation mappers`);
+}
+
+for (const [marker, label] of [
+  ["const PRODUCT_ADMIN_MUTATION_GRAPHQL_BOUNDARY", "mutation boundary"],
+  ['"product_admin_primary_graphql_mutations"', "mutation boundary identity"],
+  ["pub(super) struct GraphqlMutationContext", "private mutation context"],
+  ['"product-admin-mutation:{operation}:{}"', "mutation correlation namespace"],
+  ["pub(super) fn for_create_product(", "create context"],
+  ["pub(super) fn for_update_product(", "update context"],
+  ["pub(super) fn for_change_product_status(", "status context"],
+  ["pub(super) fn for_delete_product(", "delete context"],
+  ["pub(super) fn map_error(&self, error: GraphqlHttpError)", "typed mutation mapper"],
+  ["GraphqlHttpError::Network", "network classification"],
+  ["GraphqlHttpError::Http(_)", "HTTP classification"],
+  ["GraphqlHttpError::Unauthorized", "authentication classification"],
+  ["GraphqlHttpError::Graphql(_)", "GraphQL classification"],
+  ['"Product admin service is temporarily unavailable"', "HTTP public message"],
+  ['"Product admin request could not be completed"', "GraphQL public message"],
+  ['"product.admin_graphql_network_unavailable"', "network code"],
+  ['"product.admin_graphql_http_unavailable"', "HTTP code"],
+  ['"product.admin_graphql_authentication_required"', "auth code"],
+  ['"product.admin_graphql_request_rejected"', "GraphQL code"],
+  ["raw_error = ?error", "private typed diagnostics"],
+  ["correlation_id = %self.correlation_id", "correlation diagnostics"],
+  ["token_present = self.token_present", "token presence"],
+  ["tenant_slug_length = ?self.tenant_slug_length", "tenant slug shape"],
+  ["tenant_id_length = self.tenant_id_length", "tenant ID shape"],
+  ["actor_id_length = self.actor_id_length", "actor ID shape"],
+  ["resource_id_length = ?self.resource_id_length", "resource ID shape"],
+  ["status_length = ?self.status_length", "status shape"],
+  ["draft_present = self.draft_present", "draft presence"],
+  ["boundary = PRODUCT_ADMIN_MUTATION_GRAPHQL_BOUNDARY", "mutation boundary log"],
+]) {
+  requireText(safety, marker, `${paths.safety}: ${label}`);
+}
+
+for (const marker of [
+  "token = %",
+  "token = ?",
+  "tenant_slug = %",
+  "tenant_slug = ?",
+  "tenant_id = %",
+  "tenant_id = ?",
+  "actor_id = %",
+  "actor_id = ?",
+  "resource_id = %",
+  "resource_id = ?",
+  "status = %",
+  "status = ?",
+  "draft = %",
+  "draft = ?",
+]) {
+  forbidText(safety, marker, `${paths.safety}: raw mutation values must not be logged`);
+}
+
+for (const marker of [
+  "graphql_adapter::create_product(token, tenant_slug, tenant_id, user_id, draft).await",
+  "graphql_adapter::update_product(token, tenant_slug, tenant_id, user_id, id, draft).await",
+  "graphql_adapter::change_product_status(token, tenant_slug, tenant_id, user_id, id, status).await",
+  "graphql_adapter::delete_product(token, tenant_slug, tenant_id, user_id, id).await",
+]) {
+  requireText(legacy, marker, `${paths.legacy}: preserved private mutation delegation`);
+}
+
+for (const marker of [
+  "const CREATE_PRODUCT_MUTATION",
+  "const UPDATE_PRODUCT_MUTATION",
+  "const DELETE_PRODUCT_MUTATION",
+  "pub(super) async fn create_product(",
+  "pub(super) async fn update_product(",
+  "pub(super) async fn change_product_status(",
+  "pub(super) async fn delete_product(",
+  "build_create_product_input(draft)",
+  "status: Some(status.to_string())",
+  "extra: ProductIdVariables { id }",
+]) {
+  requireText(graphql, marker, `${paths.graphql}: preserved mutation contract`);
+}
+for (const marker of [
+  "pub enum GraphqlHttpError",
+  "Graphql(String)",
+  "Http(String)",
+  "Unauthorized",
+]) {
+  requireText(graphqlHttp, marker, `${paths.graphqlHttp}: typed GraphQL HTTP contract`);
+}
+for (const marker of [
+  "transport::create_product(",
+  "transport::update_product(",
+  "transport::change_product_status(",
+  "transport::delete_product(",
+]) {
+  requireText(ui, marker, `${paths.ui}: preserved UI mutation composition`);
+}
+requireText(
+  primaryReadGuard,
+  "Product Admin primary GraphQL read error-safety verification failed:",
+  `${paths.primaryReadGuard}: prior primary-read guard remains present`,
+);
+requireText(
+  categoryReadGuard,
+  "Product Admin category GraphQL read error-safety verification failed:",
+  `${paths.categoryReadGuard}: prior category-read guard remains present`,
+);
+
+if (evidence.schema_version !== 1) failures.push(`${paths.evidence}: schema_version must be 1`);
+if (
+  evidence.status !==
+  "product_admin_primary_graphql_mutation_error_safety_source_unvalidated"
+) {
+  failures.push(`${paths.evidence}: status mismatch`);
+}
+if (
+  JSON.stringify(evidence.operations) !==
+  JSON.stringify([
+    "create_product",
+    "update_product",
+    "change_product_status",
+    "delete_product",
+  ])
+) {
+  failures.push(`${paths.evidence}: operation scope drift`);
+}
+for (const [key, expected] of Object.entries({
+  context_before_graphql_call: true,
+  unique_correlation_id: true,
+  typed_graphql_error_classification: true,
+  network_static_public_envelope: true,
+  http_static_public_envelope: true,
+  unauthorized_static_public_envelope: true,
+  graphql_static_public_envelope: true,
+  raw_http_status_public: false,
+  raw_graphql_message_public: false,
+  private_typed_error_diagnostics: true,
+  safe_request_shape_only: true,
+  result_types_changed: false,
+  graphql_documents_changed: false,
+  graphql_variables_changed: false,
+  mutation_input_mapping_changed: false,
+  owner_policy_changed: false,
+  retry_added: false,
+  fallback_added: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "focused_verifier_run",
+  "read_verifiers_run",
+  "aggregate_verifier_run",
+  "broad_ecommerce_verifier_run",
+  "workflow_checks_run",
+  "ci_run",
+  "browser_runtime_proven",
+  "mounted_transport_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push(`${paths.evidence}: execution must remain empty`);
+}
+if (
+  review.status !==
+  "product_admin_primary_graphql_mutation_error_safety_source_reviewed_unvalidated"
+) {
+  failures.push(`${paths.review}: status mismatch`);
+}
+requireText(doc, "Status: **source-ready / unvalidated**", `${paths.doc}: source status`);
+requireText(doc, "Product admin service is temporarily unavailable", `${paths.doc}: HTTP policy`);
+requireText(doc, "Product admin request could not be completed", `${paths.doc}: GraphQL policy`);
+requireText(doc, "status-only update behavior", `${paths.doc}: preserved status behavior`);
+requireText(
+  masterPlan,
+  "Finish correlation-safe mapper cleanup",
+  `${paths.masterPlan}: broad ecommerce mapper cleanup remains open`,
+);
+
+if (failures.length > 0) {
+  console.error("Product Admin primary GraphQL mutation error-safety verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "Product Admin primary GraphQL mutations retain typed errors with correlation-safe static public payloads; execution evidence remains open",
+);


### PR DESCRIPTION
## Summary
- add a Product-owned typed public error policy for four primary Product Admin GraphQL mutations
- wrap `create_product`, `update_product`, `change_product_status`, and `delete_product` at the final facade boundary
- create a unique mutation correlation context before each existing compatibility call
- keep `GraphqlHttpError` as the result type
- preserve static `Network` and `Unauthorized` variants
- replace HTTP status text with `Product admin service is temporarily unavailable`
- replace GraphQL server messages with `Product admin request could not be completed`
- retain the original typed error only in private tracing diagnostics
- record token presence and request-field lengths only, never token, tenant, actor, product, status, or draft values
- preserve GraphQL documents, tenant/user variables, input builders, response DTOs, status-only updates, and delete variables
- add source evidence, documentation, and a focused fail-closed verifier

## Covered operations
- `create_product`
- `update_product`
- `change_product_status`
- `delete_product`

## Confirmed gap
These four commands delegated directly through the compatibility transport to the GraphQL adapter. `Http(String)` could expose response status text and `Graphql(String)` could expose the first server error message to Product Admin UI command handling.

## Boundary placement
Each public facade wrapper creates its context before the unchanged compatibility call and maps only a final returned error. No retry, fallback, extra owner call, mutation document, variable, input mapping, or response mapping was added or reordered.

## Recheck findings
The prior catalog-options, primary-read, and category-read policies remain intact. The mutation wrappers use a distinct `mutation_error` mapper marker, so prior exact-count guards retain their original scopes.

## Scope boundary
Category, schema, binding, and attribute-value GraphQL mutations remain separate ecommerce mapper-cleanup work, together with browser/mounted transport evidence and other ecommerce non-`PortError` public envelopes.

## Validation
Per maintainer instruction, tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run. Evidence remains source-ready / unvalidated and does not promote Product FFA/FBA, browser, mounted transport, workflow, CI, or production status.

Suggested maintainer commands:
```bash
node scripts/verify/verify-product-admin-primary-mutation-error-safety.mjs
node scripts/verify/verify-product-admin-category-read-error-safety.mjs
node scripts/verify/verify-product-admin-primary-read-error-safety.mjs
node scripts/verify/verify-product-admin-boundary.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-product-admin
cargo check -p rustok-product-admin --features hydrate
cargo check -p rustok-product-admin --features ssr
```