### PR TITLE
feat(forum): apply richer audience to Search category scope

### DIFF
--- a/crates/rustok-forum/contracts/forum-search-category-audience-scope.json
+++ b/crates/rustok-forum/contracts/forum-search-category-audience-scope.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-23B2B",
+  "status": "source_complete_execution_pending",
+  "scope": "Apply the complete delivered inherited Forum category audience decision before category subtrees are exposed to a Search caller",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "base_scope_owner": "crates/rustok-forum/src/services/category_search_scope.rs",
+  "audience_scope_owner": "crates/rustok-forum/src/services/category_search_audience_scope.rs",
+  "audience_visibility_owner": "crates/rustok-forum/src/services/category_audience_visibility.rs",
+  "owner_export": "crates/rustok-forum/src/services/mod.rs",
+  "owner_note": "crates/rustok-forum/docs/forum-23b2b-category-audience-scope.md",
+  "verifier": "scripts/verify/verify-forum-search-category-audience-scope.mjs",
+  "bounds": {
+    "raw_root_ids": 10,
+    "tenant_tree_nodes": 512,
+    "tree_depth": 16,
+    "expanded_ids": 512
+  },
+  "authorization": {
+    "requires_forum_categories_list": true,
+    "public_viewer_supported": true,
+    "authenticated_viewer_requires_exact_port_context": true,
+    "reuses_public_authenticated_floor": true,
+    "reuses_inherited_richer_category_layers": true,
+    "supports_role_selector": true,
+    "supports_trust_selector": true,
+    "supports_channel_selector": true,
+    "supports_group_selector": true,
+    "supports_explicit_allow_deny": true,
+    "missing_required_owner_facts_fail_closed": true,
+    "archived_category_is_excluded": true,
+    "denied_ancestor_prunes_descendants": true,
+    "denied_selected_root_is_not_found": true
+  },
+  "ordering": {
+    "raw_root_bound_is_checked_before_deduplication": true,
+    "requested_roots_preserve_first_occurrence_order": true,
+    "visible_children_preserve_canonical_tree_order": true,
+    "overlapping_roots_are_deduplicated": true,
+    "expanded_output_is_deterministic_preorder": true
+  },
+  "integration_boundary": {
+    "search_imports_forum": false,
+    "forum_imports_search": false,
+    "search_execution_is_added": false,
+    "public_search_transport_is_changed": false,
+    "host_composition_complete": false
+  },
+  "compatibility": {
+    "graphql_schema_changed": false,
+    "rest_schema_changed": false,
+    "search_query_shape_changed": false,
+    "forum_projection_shape_changed": false,
+    "database_migration_added": false,
+    "dependency_added": false,
+    "cargo_lock_changed": false,
+    "b2a_base_scope_preserved": true
+  },
+  "verification": {
+    "execution_status": "not_run_by_implementation_agent",
+    "commands": [
+      "cargo test -p rustok-forum category_search_audience_scope -- --nocapture",
+      "node scripts/verify/verify-forum-search-category-audience-scope.mjs",
+      "node scripts/verify/verify-forum-search-category-subtree-scope.mjs",
+      "cargo xtask module validate forum"
+    ]
+  },
+  "remaining_scope": [
+    "compose the richer owner-expanded IDs into an explicit Forum-only Search entrypoint before Search execution",
+    "apply exact topic-local narrowing and reply authorization to Search result eligibility",
+    "add author tag locale date solved kind channel group and attachment-presence filters",
+    "complete owner-issued projection revision ordering reconciliation and deletion or ACL cleanup",
+    "capture maintainer-executed PostgreSQL query and result evidence"
+  ],
+  "non_claims": [
+    "FORUM-23 is complete",
+    "storefrontSearch expands Forum category roots",
+    "topic-local audience narrowing is applied to Search",
+    "runtime verification was executed"
+  ]
+}

--- a/crates/rustok-forum/contracts/forum-search-category-audience-scope.json
+++ b/crates/rustok-forum/contracts/forum-search-category-audience-scope.json
@@ -5,7 +5,10 @@
   "scope": "Apply the complete delivered inherited Forum category audience decision before category subtrees are exposed to a Search caller",
   "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
   "base_scope_owner": "crates/rustok-forum/src/services/category_search_scope.rs",
+  "visible_tree_expander": "crates/rustok-forum/src/services/category_search_scope_visible.rs",
   "audience_scope_owner": "crates/rustok-forum/src/services/category_search_audience_scope.rs",
+  "audience_read_owner": "crates/rustok-forum/src/services/category_audience_read.rs",
+  "audience_read_search_extension": "crates/rustok-forum/src/services/category_audience_read_search.rs",
   "audience_visibility_owner": "crates/rustok-forum/src/services/category_audience_visibility.rs",
   "owner_export": "crates/rustok-forum/src/services/mod.rs",
   "owner_note": "crates/rustok-forum/docs/forum-23b2b-category-audience-scope.md",
@@ -20,6 +23,7 @@
     "requires_forum_categories_list": true,
     "public_viewer_supported": true,
     "authenticated_viewer_requires_exact_port_context": true,
+    "reuses_canonical_category_audience_read_owner": true,
     "reuses_public_authenticated_floor": true,
     "reuses_inherited_richer_category_layers": true,
     "supports_role_selector": true,
@@ -37,7 +41,8 @@
     "requested_roots_preserve_first_occurrence_order": true,
     "visible_children_preserve_canonical_tree_order": true,
     "overlapping_roots_are_deduplicated": true,
-    "expanded_output_is_deterministic_preorder": true
+    "expanded_output_is_deterministic_preorder": true,
+    "shared_b2a_hierarchy_expander_is_reused": true
   },
   "integration_boundary": {
     "search_imports_forum": false,

--- a/crates/rustok-forum/docs/forum-23b2b-category-audience-scope.md
+++ b/crates/rustok-forum/docs/forum-23b2b-category-audience-scope.md
@@ -14,17 +14,17 @@ This slice adds the owner operation that applies those delivered audience rules 
 
 ## Owner contract
 
-`ForumSearchCategoryAudienceScopeService` exposes separate public and authenticated entrypoints.
+`ForumSearchCategoryAudienceScopeService` exposes separate public and authenticated entrypoints. It does not reimplement category policy: both paths obtain an already-pruned canonical tree from `ForumCategoryAudienceReadService`, and the Search-specific layer only selects roots and converts that visible tree into `ForumSearchCategoryScope`.
 
 The public entrypoint:
 
-- uses `SecurityContext::public_read()` and the public Forum audience viewer;
-- excludes authenticated-floor categories, archived categories, and every richer layer that requires an authenticated selector;
+- uses the public richer-audience category tree owner;
+- excludes authenticated-floor categories and every richer layer that requires an authenticated selector;
 - never invokes an optional trust, Channel, or Groups owner capability for an anonymous viewer.
 
 The authenticated entrypoint:
 
-- requires the existing `forum_categories:list` owner permission;
+- requires the existing `forum_categories:list` owner permission through the canonical category tree read;
 - requires an exact user `SecurityContext` and matching tenant/user `PortContext`;
 - reuses `ForumCategoryAudienceVisibilityService`, including inherited root-to-category conjunction semantics;
 - lets local explicit deny, explicit allow, and role decisions remain locally decidable;
@@ -35,11 +35,12 @@ Both entrypoints:
 
 - accept at most ten raw selected roots before deduplication;
 - reuse the canonical 512-node, depth-16 category tree;
-- exclude archived categories;
-- prune a denied ancestor together with all descendants;
+- exclude archived categories in the shared active-visible-tree expander;
+- prune a denied or archived ancestor together with all descendants;
 - return a denied, archived, missing, or foreign selected root as `CategoryNotFound`;
 - preserve selected-root first occurrence and canonical child order;
-- emit deterministic preorder IDs and deduplicate overlapping roots.
+- emit deterministic preorder IDs and deduplicate overlapping roots;
+- reuse the B2A `CategoryHierarchy` expansion algorithm instead of creating a second subtree implementation.
 
 ## Search integration boundary
 

--- a/crates/rustok-forum/docs/forum-23b2b-category-audience-scope.md
+++ b/crates/rustok-forum/docs/forum-23b2b-category-audience-scope.md
@@ -1,0 +1,77 @@
+# FORUM-23B2B: richer category audience scope for Search
+
+Date: 2026-07-30
+
+Status: `source_complete_execution_pending`
+
+Canonical roadmap: [`implementation-plan.md`](./implementation-plan.md)
+
+## Purpose
+
+`FORUM-23B2A` introduced a bounded Forum-owned category-subtree expansion, but intentionally covered only the inherited public/authenticated floor. Forum already owns richer inherited category audience layers for roles, trust, Channel membership, Groups membership, and explicit user allow/deny rules.
+
+This slice adds the owner operation that applies those delivered audience rules before a category subtree may be handed to Search. It prevents a future host Search composition from broadening an authenticated viewer beyond the exact category visibility used by Forum reads.
+
+## Owner contract
+
+`ForumSearchCategoryAudienceScopeService` exposes separate public and authenticated entrypoints.
+
+The public entrypoint:
+
+- uses `SecurityContext::public_read()` and the public Forum audience viewer;
+- excludes authenticated-floor categories, archived categories, and every richer layer that requires an authenticated selector;
+- never invokes an optional trust, Channel, or Groups owner capability for an anonymous viewer.
+
+The authenticated entrypoint:
+
+- requires the existing `forum_categories:list` owner permission;
+- requires an exact user `SecurityContext` and matching tenant/user `PortContext`;
+- reuses `ForumCategoryAudienceVisibilityService`, including inherited root-to-category conjunction semantics;
+- lets local explicit deny, explicit allow, and role decisions remain locally decidable;
+- invokes the shared owner facts capability only when unresolved trust, Channel, or Groups selectors require it;
+- fails closed with the existing typed capability error when required owner facts are unavailable.
+
+Both entrypoints:
+
+- accept at most ten raw selected roots before deduplication;
+- reuse the canonical 512-node, depth-16 category tree;
+- exclude archived categories;
+- prune a denied ancestor together with all descendants;
+- return a denied, archived, missing, or foreign selected root as `CategoryNotFound`;
+- preserve selected-root first occurrence and canonical child order;
+- emit deterministic preorder IDs and deduplicate overlapping roots.
+
+## Search integration boundary
+
+This service still does not execute Search and does not import `rustok-search`. It returns `ForumSearchCategoryScope`, the same owner result shape introduced in B2A.
+
+A later host-composed Forum-only Search entrypoint can call this owner first and then place `expanded_category_ids` into the existing Search `category_ids` field. The host must keep that expansion restricted to an explicit Forum-only source scope so product category semantics are not broadened.
+
+Topic-local audience narrowing and exact reply authorization are not category-tree properties. They remain separate Search result eligibility work and are not claimed here.
+
+## Compatibility and degraded mode
+
+No GraphQL or REST field, Search query shape, Forum projection shape, migration, dependency, or `Cargo.lock` change is introduced. The B2A public/authenticated-floor service remains available for internal callers that explicitly require only that delivered baseline.
+
+Public evaluation does not require optional audience facts. Authenticated evaluation remains operational for locally decidable rules when the facts provider is absent. A category layer that still requires trust, Channel, or Groups facts fails closed rather than appearing in Search.
+
+## Remaining work
+
+- compose this richer owner result into an explicit Forum-only Search entrypoint;
+- apply exact topic-local narrowing and reply authorization to Search result eligibility;
+- add author, tag, locale, date, solved, kind, channel/group, and attachment-presence filters;
+- complete owner-issued projection revision ordering, reconciliation, and deletion/ACL cleanup;
+- capture maintainer-executed PostgreSQL query and result evidence.
+
+## Maintainer verification
+
+Not run by the implementation agent, per maintainer instruction.
+
+Suggested commands:
+
+```bash
+cargo test -p rustok-forum category_search_audience_scope -- --nocapture
+node scripts/verify/verify-forum-search-category-audience-scope.mjs
+node scripts/verify/verify-forum-search-category-subtree-scope.mjs
+cargo xtask module validate forum
+```

--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -229,7 +229,7 @@ at the end of this file remain authoritative.
 | `FORUM-20` | `in_progress` | FORUM-20A-AZ provide inherited and richer category/topic visibility, recipient-aware Forum notification authorization, the Notifications inbox/group owner plane, authenticated storefront ports, native and GraphQL read/open/write transport parity, grouped UI and navigation, exact topic/reply create authorization, topic-local reply narrowing, inherited moderation audiences, and existing solution-route transport composition. FORUM-20BA synchronizes the canonical ledger and owner notes after FORUM-20AV-AZ. Remaining read/search/index/SEO/deep-link migration, visibility-scoped bulk read commands, future moderation transport reuse, scheduled reconciliation/redaction, delivery transports and PostgreSQL cross-consumer evidence remain. |
 | `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |
 | `FORUM-22` | `planned` | Topic kinds, wiki/announcement/Q&A policies and scheduled lifecycle. |
-| `FORUM-23` | `in_progress` | FORUM-23A through FORUM-23A11 harden public-author Search projections and durable privacy invalidation; FORUM-23B1 adds exact Forum category filtering; FORUM-23B2A publishes a bounded Forum-owned public/authenticated category-subtree scope. Host composition, richer audience authorization, remaining filters, owner revision ordering/reconciliation and maintainer runtime evidence remain. |
+| `FORUM-23` | `in_progress` | FORUM-23A through FORUM-23A11 harden public-author Search projections and durable privacy invalidation; FORUM-23B1 adds exact Forum category filtering; FORUM-23B2A publishes a bounded Forum-owned public/authenticated category-subtree scope; FORUM-23B2B applies the complete delivered richer category audience decision before subtree IDs leave Forum. Host composition, topic/reply Search eligibility, remaining filters, owner revision ordering/reconciliation and maintainer runtime evidence remain. |
 | `FORUM-24` | `planned` | Localized routes, canonical URLs and aliases. |
 | `FORUM-25` | `planned` | Full content/UI multilingual contract and RTL support. |
 | `FORUM-26` | `in_progress` | FORUM-26A-J provide authoritative Forum trust state/facts, posting-policy contracts, evaluation/composition, account-age, topics-read, approved-post and topic/reply create-window facts, plus pre-enforcement author/query-plan hardening. Active flags/moderation history, reputation, edit windows, bump age, policy persistence, owner enforcement, shared rate-limit execution, duplicate hashing, optional scoring, transports, UI and maintainer runtime evidence remain. |
@@ -1666,27 +1666,52 @@ attachment presence.
   `verify-forum-search-category-subtree-scope.mjs` lock the source boundary and
   record maintainer execution as pending.
 
+### Delivered in `FORUM-23B2B`
+
+- `ForumSearchCategoryAudienceScopeService` exposes separate public and exact
+  authenticated subtree entrypoints while preserving the B2A result shape and
+  raw-root/tree/output bounds;
+- the authenticated entrypoint binds the exact tenant/user `PortContext` and
+  reuses `ForumCategoryAudienceVisibilityService` for inherited role, trust,
+  Channel, Groups, and explicit user allow/deny category layers;
+- public evaluation never requires optional owner facts, locally decidable
+  authenticated rules avoid unnecessary provider calls, and unresolved trust or
+  membership selectors fail closed when the shared owner facts capability is
+  unavailable;
+- archived categories are excluded, a denied ancestor prunes its descendants,
+  and missing, foreign, archived, or denied selected roots remain
+  non-oracular `CategoryNotFound` results;
+- deterministic requested-root and canonical child order is retained while
+  overlapping visible roots are emitted once;
+- `forum-search-category-audience-scope.json`,
+  `forum-23b2b-category-audience-scope.md`, and
+  `verify-forum-search-category-audience-scope.mjs` lock the richer category
+  audience boundary without executing Search or changing a public transport.
+
 ### Compatibility and degraded mode
 
 No migration, backfill, GraphQL/REST field, Search query shape, Forum projection
-shape, dependency or `Cargo.lock` change is required by `FORUM-23B2A`. Exact
-category Search from `FORUM-23B1` remains available when the expansion owner is
-not composed; callers must not guess descendants or silently broaden the
-requested category. Search-disabled behavior remains a bounded SQL title/tag
+shape, dependency or `Cargo.lock` change is required by `FORUM-23B2A/B2B`.
+Exact category Search from `FORUM-23B1` remains available when an expansion
+owner is not composed; callers must not guess descendants or silently broaden
+the requested category. Search-disabled behavior remains a bounded SQL title/tag
 fallback or typed search-unavailable result, and core Forum reads remain
 available.
 
-The B2A owner currently composes only the delivered inherited
-public/authenticated category floor. Role, trust, Channel, Groups and explicit
-user audience facts must be applied before a richer authenticated Search surface
-claims complete visibility equivalence.
+The B2A public/authenticated-floor owner remains available for explicit baseline
+callers. B2B adds the complete delivered richer category audience decision.
+Public evaluation does not require optional audience facts; authenticated
+trust, Channel, or Groups selectors fail closed only when a required owner fact
+remains unresolved. Host composition remains open and must restrict subtree
+expansion to an explicit Forum-only Search scope so product category semantics
+are not broadened.
 
 ### Remaining scope
 
-- compose the owner-expanded category IDs into a Forum or host Search entrypoint
-  before executing the existing Search query;
-- apply the complete richer Forum audience decision to category, topic and reply
-  Search authorization;
+- compose the richer owner-expanded category IDs into an explicit Forum-only
+  host Search entrypoint before executing the existing Search query;
+- apply exact topic-local narrowing and reply authorization to Search result
+  eligibility;
 - add author, tag, locale, date, solved, kind, channel/group and
   attachment-presence query filters;
 - complete owner-issued monotonic projection revisions, durable inbox ordering,
@@ -1704,7 +1729,9 @@ documents.
 
 ```bash
 cargo test -p rustok-forum category_search_scope -- --nocapture
+cargo test -p rustok-forum category_search_audience_scope -- --nocapture
 node scripts/verify/verify-forum-search-category-subtree-scope.mjs
+node scripts/verify/verify-forum-search-category-audience-scope.mjs
 node scripts/verify/verify-forum-search-exact-category-filter.mjs
 cargo test -p rustok-search category_filter_preserves_product_and_adds_exact_forum_scope -- --nocapture
 cargo check -p rustok-search --all-targets
@@ -1712,8 +1739,8 @@ cargo xtask module validate forum
 cargo xtask module validate search
 ```
 
-The `FORUM-23B2A` source and contract records do not claim successful runtime
-verification until the maintainer runs the commands above.
+The `FORUM-23B2A/B2B` source and contract records do not claim successful
+runtime verification until the maintainer runs the commands above.
 
 ## `FORUM-24` — localized routes, canonical URLs and aliases
 
@@ -2484,8 +2511,10 @@ node scripts/verify/verify-forum-moderation-audience-policy.mjs
 node scripts/verify/verify-forum-moderation-audience-transport-composition.mjs
 node scripts/verify/verify-forum-audience-plan-sync.mjs
 cargo test -p rustok-forum category_search_scope -- --nocapture
+cargo test -p rustok-forum category_search_audience_scope -- --nocapture
 node scripts/verify/verify-forum-search-exact-category-filter.mjs
 node scripts/verify/verify-forum-search-category-subtree-scope.mjs
+node scripts/verify/verify-forum-search-category-audience-scope.mjs
 cargo test -p rustok-profiles
 npm run verify:media:fba
 npm run verify:outbox:fba
@@ -2542,8 +2571,9 @@ Recommended next slices:
     transports through the delivered context-aware owner boundary;
 13. continue `FORUM-26` with authoritative active-flag and moderation-history
     fact adapters, keeping every missing owner capability explicitly unavailable;
-14. continue `FORUM-23` with host-composed category-subtree Search execution,
-    then the remaining filters, owner revision ordering and reconciliation;
+14. continue `FORUM-23` with explicit Forum-only host-composed category-subtree
+    Search execution, then topic/reply eligibility, remaining filters, owner
+    revision ordering and reconciliation;
 15. `LINK-FORUM-01` and `LINK-FORUM-03` only after their owner contracts are
     stable.
 

--- a/crates/rustok-forum/src/services/category_audience_read_search.rs
+++ b/crates/rustok-forum/src/services/category_audience_read_search.rs
@@ -1,0 +1,50 @@
+impl ForumCategoryAudienceReadService {
+    /// Returns the canonical public category tree after every richer inherited
+    /// category audience layer has been evaluated.
+    pub async fn tree_public_storefront_visible_with_locale_fallback(
+        &self,
+        tenant_id: Uuid,
+        locale: &str,
+        fallback_locale: Option<&str>,
+    ) -> ForumResult<CategoryTreeResponse> {
+        let security = SecurityContext::public_read();
+        enforce_scope(&security, Resource::ForumCategories, Action::List)?;
+        let viewer = ForumCategoryAudienceViewer::public();
+        let mut tree = self
+            .category_service
+            .tree(
+                tenant_id,
+                security,
+                CategoryTreeQuery {
+                    locale: Some(locale.to_string()),
+                    fallback_locale: fallback_locale.map(ToOwned::to_owned),
+                },
+            )
+            .await?;
+
+        let mut category_ids = Vec::with_capacity(tree.total_nodes as usize);
+        collect_category_ids(&tree.roots, &mut category_ids);
+        if category_ids.len() > MAX_FORUM_CATEGORY_TREE_NODES as usize {
+            return Err(ForumError::Validation(format!(
+                "Forum category audience tree exceeds the bounded limit of {MAX_FORUM_CATEGORY_TREE_NODES} nodes"
+            )));
+        }
+
+        let mut visible_ids = HashSet::with_capacity(category_ids.len());
+        for category_id in category_ids {
+            if self
+                .visibility
+                .is_category_visible(tenant_id, category_id, &viewer)
+                .await?
+            {
+                visible_ids.insert(category_id);
+            }
+        }
+
+        tree.roots = prune_category_nodes(tree.roots, &visible_ids);
+        let (total_nodes, max_depth) = category_tree_stats(&tree.roots);
+        tree.total_nodes = total_nodes;
+        tree.max_depth = max_depth;
+        Ok(tree)
+    }
+}

--- a/crates/rustok-forum/src/services/category_search_audience_scope.rs
+++ b/crates/rustok-forum/src/services/category_search_audience_scope.rs
@@ -1,0 +1,319 @@
+use std::collections::HashSet;
+
+use rustok_api::{Action, PortContext, Resource};
+use rustok_core::SecurityContext;
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use crate::audience::SharedForumAudienceFactsPort;
+use crate::dto::{CategoryTreeNode, CategoryTreeQuery, MAX_FORUM_CATEGORY_TREE_NODES};
+use crate::error::{ForumError, ForumResult};
+
+use super::category_audience_visibility::{
+    ForumCategoryAudienceViewer, ForumCategoryAudienceVisibilityService,
+};
+use super::category_owner::CategoryService;
+use super::category_search_scope::{
+    ForumSearchCategoryScope, MAX_FORUM_SEARCH_CATEGORY_ROOTS,
+};
+use super::rbac::enforce_scope;
+
+/// Forum-owned category subtree scope after the complete delivered category
+/// audience decision has been applied for the exact viewer.
+pub struct ForumSearchCategoryAudienceScopeService {
+    categories: CategoryService,
+    visibility: ForumCategoryAudienceVisibilityService,
+}
+
+impl ForumSearchCategoryAudienceScopeService {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self::with_optional_audience_facts(db, None)
+    }
+
+    pub fn with_audience_facts(
+        db: DatabaseConnection,
+        facts_port: SharedForumAudienceFactsPort,
+    ) -> Self {
+        Self::with_optional_audience_facts(db, Some(facts_port))
+    }
+
+    fn with_optional_audience_facts(
+        db: DatabaseConnection,
+        facts_port: Option<SharedForumAudienceFactsPort>,
+    ) -> Self {
+        Self {
+            categories: CategoryService::new(db.clone()),
+            visibility: ForumCategoryAudienceVisibilityService::new(db, facts_port),
+        }
+    }
+
+    /// Expands public category roots after public/authenticated inheritance,
+    /// richer audience layers, archive state, and ancestor pruning.
+    pub async fn expand_public_visible_subtrees(
+        &self,
+        tenant_id: Uuid,
+        locale: &str,
+        fallback_locale: Option<&str>,
+        category_ids: &[Uuid],
+    ) -> ForumResult<ForumSearchCategoryScope> {
+        self.expand_visible_subtrees(
+            tenant_id,
+            SecurityContext::public_read(),
+            ForumCategoryAudienceViewer::public(),
+            locale,
+            fallback_locale,
+            category_ids,
+        )
+        .await
+    }
+
+    /// Expands authenticated category roots through the exact request-bound
+    /// audience facts context. Missing required facts fail closed.
+    pub async fn expand_authenticated_visible_subtrees(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        context: PortContext,
+        fallback_locale: Option<&str>,
+        category_ids: &[Uuid],
+    ) -> ForumResult<ForumSearchCategoryScope> {
+        let locale = context.locale.trim();
+        if locale.is_empty() {
+            return Err(ForumError::Validation(
+                "Forum Search category audience context locale is unavailable".to_string(),
+            ));
+        }
+        let viewer = ForumCategoryAudienceViewer::authenticated(security.clone(), context)?;
+        self.expand_visible_subtrees(
+            tenant_id,
+            security,
+            viewer,
+            locale,
+            fallback_locale,
+            category_ids,
+        )
+        .await
+    }
+
+    async fn expand_visible_subtrees(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        viewer: ForumCategoryAudienceViewer,
+        locale: &str,
+        fallback_locale: Option<&str>,
+        category_ids: &[Uuid],
+    ) -> ForumResult<ForumSearchCategoryScope> {
+        enforce_scope(&security, Resource::ForumCategories, Action::List)?;
+        let requested_category_ids = normalize_requested_category_ids(category_ids)?;
+        if requested_category_ids.is_empty() {
+            return Ok(ForumSearchCategoryScope {
+                requested_category_ids,
+                expanded_category_ids: Vec::new(),
+            });
+        }
+
+        let tree = self
+            .categories
+            .tree(
+                tenant_id,
+                security,
+                CategoryTreeQuery {
+                    locale: Some(locale.to_string()),
+                    fallback_locale: fallback_locale.map(ToOwned::to_owned),
+                },
+            )
+            .await?;
+        if tree.total_nodes > MAX_FORUM_CATEGORY_TREE_NODES as u32 {
+            return Err(ForumError::Validation(format!(
+                "Forum Search category audience scope exceeds the bounded limit of {MAX_FORUM_CATEGORY_TREE_NODES} nodes"
+            )));
+        }
+
+        let mut candidate_ids = Vec::with_capacity(tree.total_nodes as usize);
+        collect_category_ids(&tree.roots, &mut candidate_ids);
+        let mut visible_ids = HashSet::with_capacity(candidate_ids.len());
+        for category_id in candidate_ids {
+            let node = find_category_node(&tree.roots, category_id)
+                .expect("category identifier was collected from the same tree");
+            if !node.is_archived
+                && self
+                    .visibility
+                    .is_category_visible(tenant_id, category_id, &viewer)
+                    .await?
+            {
+                visible_ids.insert(category_id);
+            }
+        }
+
+        let visible_roots = prune_category_nodes(tree.roots, &visible_ids);
+        let expanded_category_ids = expand_requested_subtrees(
+            &visible_roots,
+            &requested_category_ids,
+        )?;
+
+        Ok(ForumSearchCategoryScope {
+            requested_category_ids,
+            expanded_category_ids,
+        })
+    }
+}
+
+fn normalize_requested_category_ids(category_ids: &[Uuid]) -> ForumResult<Vec<Uuid>> {
+    if category_ids.len() > MAX_FORUM_SEARCH_CATEGORY_ROOTS {
+        return Err(ForumError::Validation(format!(
+            "Forum Search category audience scope accepts at most {MAX_FORUM_SEARCH_CATEGORY_ROOTS} roots"
+        )));
+    }
+
+    let mut seen = HashSet::with_capacity(category_ids.len());
+    Ok(category_ids
+        .iter()
+        .copied()
+        .filter(|category_id| seen.insert(*category_id))
+        .collect())
+}
+
+fn collect_category_ids(nodes: &[CategoryTreeNode], output: &mut Vec<Uuid>) {
+    for node in nodes {
+        output.push(node.id);
+        collect_category_ids(&node.children, output);
+    }
+}
+
+fn find_category_node(nodes: &[CategoryTreeNode], category_id: Uuid) -> Option<&CategoryTreeNode> {
+    for node in nodes {
+        if node.id == category_id {
+            return Some(node);
+        }
+        if let Some(found) = find_category_node(&node.children, category_id) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn prune_category_nodes(
+    nodes: Vec<CategoryTreeNode>,
+    visible_ids: &HashSet<Uuid>,
+) -> Vec<CategoryTreeNode> {
+    nodes
+        .into_iter()
+        .filter_map(|mut node| {
+            if !visible_ids.contains(&node.id) {
+                return None;
+            }
+            node.children = prune_category_nodes(node.children, visible_ids);
+            node.children_count = node.children.len() as u32;
+            node.has_children = !node.children.is_empty();
+            Some(node)
+        })
+        .collect()
+}
+
+fn expand_requested_subtrees(
+    roots: &[CategoryTreeNode],
+    requested_category_ids: &[Uuid],
+) -> ForumResult<Vec<Uuid>> {
+    let mut expanded = Vec::new();
+    let mut visited = HashSet::new();
+    for category_id in requested_category_ids {
+        let node = find_category_node(roots, *category_id)
+            .ok_or(ForumError::CategoryNotFound(*category_id))?;
+        append_preorder(node, &mut visited, &mut expanded)?;
+    }
+    Ok(expanded)
+}
+
+fn append_preorder(
+    node: &CategoryTreeNode,
+    visited: &mut HashSet<Uuid>,
+    expanded: &mut Vec<Uuid>,
+) -> ForumResult<()> {
+    if !visited.insert(node.id) {
+        return Ok(());
+    }
+    if expanded.len() >= MAX_FORUM_CATEGORY_TREE_NODES as usize {
+        return Err(ForumError::Validation(format!(
+            "Forum Search category audience scope exceeds the bounded limit of {MAX_FORUM_CATEGORY_TREE_NODES} nodes"
+        )));
+    }
+    expanded.push(node.id);
+    for child in &node.children {
+        append_preorder(child, visited, expanded)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        expand_requested_subtrees, normalize_requested_category_ids, prune_category_nodes,
+    };
+    use crate::dto::CategoryTreeNode;
+    use crate::error::ForumError;
+    use std::collections::HashSet;
+    use uuid::Uuid;
+
+    fn id(value: u128) -> Uuid {
+        Uuid::from_u128(value)
+    }
+
+    fn node(value: u128, children: Vec<CategoryTreeNode>) -> CategoryTreeNode {
+        CategoryTreeNode {
+            id: id(value),
+            parent_id: None,
+            depth: 0,
+            position: value as i32,
+            requested_locale: "en".to_string(),
+            effective_locale: "en".to_string(),
+            available_locales: vec!["en".to_string()],
+            name: value.to_string(),
+            slug: value.to_string(),
+            description: None,
+            icon: None,
+            color: None,
+            moderated: false,
+            allows_topics: true,
+            archived_at: None,
+            is_archived: false,
+            topic_count: 0,
+            reply_count: 0,
+            is_subscribed: false,
+            has_children: !children.is_empty(),
+            children_count: children.len() as u32,
+            breadcrumbs: Vec::new(),
+            children,
+        }
+    }
+
+    #[test]
+    fn denied_parent_prunes_allowed_descendants() {
+        let roots = vec![node(1, vec![node(2, Vec::new())])];
+        let pruned = prune_category_nodes(roots, &HashSet::from([id(2)]));
+        assert!(pruned.is_empty());
+    }
+
+    #[test]
+    fn overlapping_visible_roots_expand_once() {
+        let roots = vec![node(1, vec![node(2, vec![node(3, Vec::new())])])];
+        let expanded = expand_requested_subtrees(&roots, &[id(1), id(2)])
+            .expect("visible roots should expand");
+        assert_eq!(expanded, vec![id(1), id(2), id(3)]);
+    }
+
+    #[test]
+    fn denied_selected_root_is_non_oracular() {
+        let error = expand_requested_subtrees(&[node(1, Vec::new())], &[id(2)])
+            .expect_err("missing visible root must fail closed");
+        assert!(matches!(error, ForumError::CategoryNotFound(value) if value == id(2)));
+    }
+
+    #[test]
+    fn raw_root_bound_is_checked_before_deduplication() {
+        let roots = vec![id(1); super::MAX_FORUM_SEARCH_CATEGORY_ROOTS + 1];
+        let error = normalize_requested_category_ids(&roots)
+            .expect_err("raw roots must remain bounded");
+        assert!(matches!(error, ForumError::Validation(message) if message.contains("at most")));
+    }
+}

--- a/crates/rustok-forum/src/services/category_search_audience_scope.rs
+++ b/crates/rustok-forum/src/services/category_search_audience_scope.rs
@@ -1,54 +1,44 @@
-use std::collections::HashSet;
-
-use rustok_api::{Action, PortContext, Resource};
+use rustok_api::PortContext;
 use rustok_core::SecurityContext;
 use sea_orm::DatabaseConnection;
 use uuid::Uuid;
 
 use crate::audience::SharedForumAudienceFactsPort;
-use crate::dto::{CategoryTreeNode, CategoryTreeQuery, MAX_FORUM_CATEGORY_TREE_NODES};
-use crate::error::{ForumError, ForumResult};
+use crate::dto::CategoryTreeQuery;
+use crate::error::ForumResult;
 
-use super::category_audience_visibility::{
-    ForumCategoryAudienceViewer, ForumCategoryAudienceVisibilityService,
-};
-use super::category_owner::CategoryService;
+use super::category_audience_read::ForumCategoryAudienceReadService;
 use super::category_search_scope::{
-    ForumSearchCategoryScope, MAX_FORUM_SEARCH_CATEGORY_ROOTS,
+    ForumSearchCategoryScope, expand_search_category_scope_from_visible_tree,
 };
-use super::rbac::enforce_scope;
 
 /// Forum-owned category subtree scope after the complete delivered category
 /// audience decision has been applied for the exact viewer.
 pub struct ForumSearchCategoryAudienceScopeService {
-    categories: CategoryService,
-    visibility: ForumCategoryAudienceVisibilityService,
+    category_reads: ForumCategoryAudienceReadService,
 }
 
 impl ForumSearchCategoryAudienceScopeService {
     pub fn new(db: DatabaseConnection) -> Self {
-        Self::with_optional_audience_facts(db, None)
+        Self {
+            category_reads: ForumCategoryAudienceReadService::new(db),
+        }
     }
 
     pub fn with_audience_facts(
         db: DatabaseConnection,
         facts_port: SharedForumAudienceFactsPort,
     ) -> Self {
-        Self::with_optional_audience_facts(db, Some(facts_port))
-    }
-
-    fn with_optional_audience_facts(
-        db: DatabaseConnection,
-        facts_port: Option<SharedForumAudienceFactsPort>,
-    ) -> Self {
         Self {
-            categories: CategoryService::new(db.clone()),
-            visibility: ForumCategoryAudienceVisibilityService::new(db, facts_port),
+            category_reads: ForumCategoryAudienceReadService::with_audience_facts(
+                db,
+                facts_port,
+            ),
         }
     }
 
-    /// Expands public category roots after public/authenticated inheritance,
-    /// richer audience layers, archive state, and ancestor pruning.
+    /// Expands public category roots after the complete inherited category
+    /// audience decision and archive pruning have already shaped the owner tree.
     pub async fn expand_public_visible_subtrees(
         &self,
         tenant_id: Uuid,
@@ -56,19 +46,20 @@ impl ForumSearchCategoryAudienceScopeService {
         fallback_locale: Option<&str>,
         category_ids: &[Uuid],
     ) -> ForumResult<ForumSearchCategoryScope> {
-        self.expand_visible_subtrees(
-            tenant_id,
-            SecurityContext::public_read(),
-            ForumCategoryAudienceViewer::public(),
-            locale,
-            fallback_locale,
-            category_ids,
-        )
-        .await
+        let tree = self
+            .category_reads
+            .tree_public_storefront_visible_with_locale_fallback(
+                tenant_id,
+                locale,
+                fallback_locale,
+            )
+            .await?;
+        expand_search_category_scope_from_visible_tree(&tree.roots, category_ids)
     }
 
     /// Expands authenticated category roots through the exact request-bound
-    /// audience facts context. Missing required facts fail closed.
+    /// audience context. Missing required owner facts fail closed in the
+    /// canonical category audience read owner before IDs reach Search.
     pub async fn expand_authenticated_visible_subtrees(
         &self,
         tenant_id: Uuid,
@@ -77,243 +68,18 @@ impl ForumSearchCategoryAudienceScopeService {
         fallback_locale: Option<&str>,
         category_ids: &[Uuid],
     ) -> ForumResult<ForumSearchCategoryScope> {
-        let locale = context.locale.trim().to_string();
-        if locale.is_empty() {
-            return Err(ForumError::Validation(
-                "Forum Search category audience context locale is unavailable".to_string(),
-            ));
-        }
-        let viewer = ForumCategoryAudienceViewer::authenticated(security.clone(), context)?;
-        self.expand_visible_subtrees(
-            tenant_id,
-            security,
-            viewer,
-            &locale,
-            fallback_locale,
-            category_ids,
-        )
-        .await
-    }
-
-    async fn expand_visible_subtrees(
-        &self,
-        tenant_id: Uuid,
-        security: SecurityContext,
-        viewer: ForumCategoryAudienceViewer,
-        locale: &str,
-        fallback_locale: Option<&str>,
-        category_ids: &[Uuid],
-    ) -> ForumResult<ForumSearchCategoryScope> {
-        enforce_scope(&security, Resource::ForumCategories, Action::List)?;
-        let requested_category_ids = normalize_requested_category_ids(category_ids)?;
-        if requested_category_ids.is_empty() {
-            return Ok(ForumSearchCategoryScope {
-                requested_category_ids,
-                expanded_category_ids: Vec::new(),
-            });
-        }
-
         let tree = self
-            .categories
-            .tree(
+            .category_reads
+            .tree_authenticated_owner_visible_with_audience_context(
                 tenant_id,
                 security,
+                context,
                 CategoryTreeQuery {
-                    locale: Some(locale.to_string()),
+                    locale: None,
                     fallback_locale: fallback_locale.map(ToOwned::to_owned),
                 },
             )
             .await?;
-        if tree.total_nodes > MAX_FORUM_CATEGORY_TREE_NODES as u32 {
-            return Err(ForumError::Validation(format!(
-                "Forum Search category audience scope exceeds the bounded limit of {MAX_FORUM_CATEGORY_TREE_NODES} nodes"
-            )));
-        }
-
-        let mut candidate_ids = Vec::with_capacity(tree.total_nodes as usize);
-        collect_category_ids(&tree.roots, &mut candidate_ids);
-        let mut visible_ids = HashSet::with_capacity(candidate_ids.len());
-        for category_id in candidate_ids {
-            let node = find_category_node(&tree.roots, category_id)
-                .expect("category identifier was collected from the same tree");
-            if !node.is_archived
-                && self
-                    .visibility
-                    .is_category_visible(tenant_id, category_id, &viewer)
-                    .await?
-            {
-                visible_ids.insert(category_id);
-            }
-        }
-
-        let visible_roots = prune_category_nodes(tree.roots, &visible_ids);
-        let expanded_category_ids = expand_requested_subtrees(
-            &visible_roots,
-            &requested_category_ids,
-        )?;
-
-        Ok(ForumSearchCategoryScope {
-            requested_category_ids,
-            expanded_category_ids,
-        })
-    }
-}
-
-fn normalize_requested_category_ids(category_ids: &[Uuid]) -> ForumResult<Vec<Uuid>> {
-    if category_ids.len() > MAX_FORUM_SEARCH_CATEGORY_ROOTS {
-        return Err(ForumError::Validation(format!(
-            "Forum Search category audience scope accepts at most {MAX_FORUM_SEARCH_CATEGORY_ROOTS} roots"
-        )));
-    }
-
-    let mut seen = HashSet::with_capacity(category_ids.len());
-    Ok(category_ids
-        .iter()
-        .copied()
-        .filter(|category_id| seen.insert(*category_id))
-        .collect())
-}
-
-fn collect_category_ids(nodes: &[CategoryTreeNode], output: &mut Vec<Uuid>) {
-    for node in nodes {
-        output.push(node.id);
-        collect_category_ids(&node.children, output);
-    }
-}
-
-fn find_category_node(nodes: &[CategoryTreeNode], category_id: Uuid) -> Option<&CategoryTreeNode> {
-    for node in nodes {
-        if node.id == category_id {
-            return Some(node);
-        }
-        if let Some(found) = find_category_node(&node.children, category_id) {
-            return Some(found);
-        }
-    }
-    None
-}
-
-fn prune_category_nodes(
-    nodes: Vec<CategoryTreeNode>,
-    visible_ids: &HashSet<Uuid>,
-) -> Vec<CategoryTreeNode> {
-    nodes
-        .into_iter()
-        .filter_map(|mut node| {
-            if !visible_ids.contains(&node.id) {
-                return None;
-            }
-            node.children = prune_category_nodes(node.children, visible_ids);
-            node.children_count = node.children.len() as u32;
-            node.has_children = !node.children.is_empty();
-            Some(node)
-        })
-        .collect()
-}
-
-fn expand_requested_subtrees(
-    roots: &[CategoryTreeNode],
-    requested_category_ids: &[Uuid],
-) -> ForumResult<Vec<Uuid>> {
-    let mut expanded = Vec::new();
-    let mut visited = HashSet::new();
-    for category_id in requested_category_ids {
-        let node = find_category_node(roots, *category_id)
-            .ok_or(ForumError::CategoryNotFound(*category_id))?;
-        append_preorder(node, &mut visited, &mut expanded)?;
-    }
-    Ok(expanded)
-}
-
-fn append_preorder(
-    node: &CategoryTreeNode,
-    visited: &mut HashSet<Uuid>,
-    expanded: &mut Vec<Uuid>,
-) -> ForumResult<()> {
-    if !visited.insert(node.id) {
-        return Ok(());
-    }
-    if expanded.len() >= MAX_FORUM_CATEGORY_TREE_NODES as usize {
-        return Err(ForumError::Validation(format!(
-            "Forum Search category audience scope exceeds the bounded limit of {MAX_FORUM_CATEGORY_TREE_NODES} nodes"
-        )));
-    }
-    expanded.push(node.id);
-    for child in &node.children {
-        append_preorder(child, visited, expanded)?;
-    }
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{
-        expand_requested_subtrees, normalize_requested_category_ids, prune_category_nodes,
-    };
-    use crate::dto::CategoryTreeNode;
-    use crate::error::ForumError;
-    use std::collections::HashSet;
-    use uuid::Uuid;
-
-    fn id(value: u128) -> Uuid {
-        Uuid::from_u128(value)
-    }
-
-    fn node(value: u128, children: Vec<CategoryTreeNode>) -> CategoryTreeNode {
-        CategoryTreeNode {
-            id: id(value),
-            parent_id: None,
-            depth: 0,
-            position: value as i32,
-            requested_locale: "en".to_string(),
-            effective_locale: "en".to_string(),
-            available_locales: vec!["en".to_string()],
-            name: value.to_string(),
-            slug: value.to_string(),
-            description: None,
-            icon: None,
-            color: None,
-            moderated: false,
-            allows_topics: true,
-            archived_at: None,
-            is_archived: false,
-            topic_count: 0,
-            reply_count: 0,
-            is_subscribed: false,
-            has_children: !children.is_empty(),
-            children_count: children.len() as u32,
-            breadcrumbs: Vec::new(),
-            children,
-        }
-    }
-
-    #[test]
-    fn denied_parent_prunes_allowed_descendants() {
-        let roots = vec![node(1, vec![node(2, Vec::new())])];
-        let pruned = prune_category_nodes(roots, &HashSet::from([id(2)]));
-        assert!(pruned.is_empty());
-    }
-
-    #[test]
-    fn overlapping_visible_roots_expand_once() {
-        let roots = vec![node(1, vec![node(2, vec![node(3, Vec::new())])])];
-        let expanded = expand_requested_subtrees(&roots, &[id(1), id(2)])
-            .expect("visible roots should expand");
-        assert_eq!(expanded, vec![id(1), id(2), id(3)]);
-    }
-
-    #[test]
-    fn denied_selected_root_is_non_oracular() {
-        let error = expand_requested_subtrees(&[node(1, Vec::new())], &[id(2)])
-            .expect_err("missing visible root must fail closed");
-        assert!(matches!(error, ForumError::CategoryNotFound(value) if value == id(2)));
-    }
-
-    #[test]
-    fn raw_root_bound_is_checked_before_deduplication() {
-        let roots = vec![id(1); super::MAX_FORUM_SEARCH_CATEGORY_ROOTS + 1];
-        let error = normalize_requested_category_ids(&roots)
-            .expect_err("raw roots must remain bounded");
-        assert!(matches!(error, ForumError::Validation(message) if message.contains("at most")));
+        expand_search_category_scope_from_visible_tree(&tree.roots, category_ids)
     }
 }

--- a/crates/rustok-forum/src/services/category_search_audience_scope.rs
+++ b/crates/rustok-forum/src/services/category_search_audience_scope.rs
@@ -77,7 +77,7 @@ impl ForumSearchCategoryAudienceScopeService {
         fallback_locale: Option<&str>,
         category_ids: &[Uuid],
     ) -> ForumResult<ForumSearchCategoryScope> {
-        let locale = context.locale.trim();
+        let locale = context.locale.trim().to_string();
         if locale.is_empty() {
             return Err(ForumError::Validation(
                 "Forum Search category audience context locale is unavailable".to_string(),
@@ -88,7 +88,7 @@ impl ForumSearchCategoryAudienceScopeService {
             tenant_id,
             security,
             viewer,
-            locale,
+            &locale,
             fallback_locale,
             category_ids,
         )

--- a/crates/rustok-forum/src/services/category_search_scope_visible.rs
+++ b/crates/rustok-forum/src/services/category_search_scope_visible.rs
@@ -1,7 +1,4 @@
-use std::collections::HashSet;
-
 use crate::dto::CategoryTreeNode;
-use crate::error::ForumResult;
 
 /// Converts an already-authorized canonical category tree into the bounded
 /// Search category scope without re-evaluating owner visibility policy.

--- a/crates/rustok-forum/src/services/category_search_scope_visible.rs
+++ b/crates/rustok-forum/src/services/category_search_scope_visible.rs
@@ -1,0 +1,40 @@
+use std::collections::HashSet;
+
+use crate::dto::CategoryTreeNode;
+use crate::error::ForumResult;
+
+/// Converts an already-authorized canonical category tree into the bounded
+/// Search category scope without re-evaluating owner visibility policy.
+pub(super) fn expand_search_category_scope_from_visible_tree(
+    roots: &[CategoryTreeNode],
+    category_ids: &[Uuid],
+) -> ForumResult<ForumSearchCategoryScope> {
+    let requested_category_ids = normalize_requested_category_ids(category_ids)?;
+    if requested_category_ids.is_empty() {
+        return Ok(ForumSearchCategoryScope {
+            requested_category_ids,
+            expanded_category_ids: Vec::new(),
+        });
+    }
+
+    let mut ordered_nodes = Vec::new();
+    collect_visible_nodes(roots, &mut ordered_nodes);
+    let hierarchy = CategoryHierarchy::from_ordered_nodes(ordered_nodes)?;
+    let expanded_category_ids =
+        hierarchy.expand_visible_subtrees(&requested_category_ids, &HashSet::new())?;
+
+    Ok(ForumSearchCategoryScope {
+        requested_category_ids,
+        expanded_category_ids,
+    })
+}
+
+fn collect_visible_nodes(
+    nodes: &[CategoryTreeNode],
+    output: &mut Vec<(Uuid, Option<Uuid>)>,
+) {
+    for node in nodes {
+        output.push((node.id, node.parent_id));
+        collect_visible_nodes(&node.children, output);
+    }
+}

--- a/crates/rustok-forum/src/services/category_search_scope_visible.rs
+++ b/crates/rustok-forum/src/services/category_search_scope_visible.rs
@@ -15,7 +15,7 @@ pub(super) fn expand_search_category_scope_from_visible_tree(
     }
 
     let mut ordered_nodes = Vec::new();
-    collect_visible_nodes(roots, &mut ordered_nodes);
+    collect_active_visible_nodes(roots, &mut ordered_nodes);
     let hierarchy = CategoryHierarchy::from_ordered_nodes(ordered_nodes)?;
     let expanded_category_ids =
         hierarchy.expand_visible_subtrees(&requested_category_ids, &HashSet::new())?;
@@ -26,12 +26,15 @@ pub(super) fn expand_search_category_scope_from_visible_tree(
     })
 }
 
-fn collect_visible_nodes(
+fn collect_active_visible_nodes(
     nodes: &[CategoryTreeNode],
     output: &mut Vec<(Uuid, Option<Uuid>)>,
 ) {
     for node in nodes {
+        if node.is_archived {
+            continue;
+        }
         output.push((node.id, node.parent_id));
-        collect_visible_nodes(&node.children, output);
+        collect_active_visible_nodes(&node.children, output);
     }
 }

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -31,8 +31,8 @@ mod category_policy;
 mod category_reply_create_audience;
 mod category_search_audience_scope;
 mod category_search_scope {
-    include!("category_search_scope.rs");
     include!("category_search_scope_visible.rs");
+    include!("category_search_scope.rs");
 }
 mod category_topic_create_audience;
 mod category_tree {

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -28,6 +28,7 @@ mod category_moderation_audience;
 mod category_owner;
 mod category_policy;
 mod category_reply_create_audience;
+mod category_search_audience_scope;
 mod category_search_scope;
 mod category_topic_create_audience;
 mod category_tree {
@@ -133,6 +134,7 @@ pub use category_reply_create_audience::{
     ForumCategoryReplyCreateAudiencePolicy, ForumCategoryReplyCreateAudiencePolicyLayer,
     ForumCategoryReplyCreateAudiencePolicyService, SetForumCategoryReplyCreateAudiencePolicyInput,
 };
+pub use category_search_audience_scope::ForumSearchCategoryAudienceScopeService;
 pub use category_search_scope::{
     ForumSearchCategoryScope, ForumSearchCategoryScopeService, MAX_FORUM_SEARCH_CATEGORY_ROOTS,
 };

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -13,6 +13,7 @@ mod category_audience {
 mod category_audience_read {
     include!("category_audience_read.rs");
     include!("category_audience_read_inline.rs");
+    include!("category_audience_read_search.rs");
 }
 mod category_audience_visibility;
 #[allow(clippy::collapsible_if)]
@@ -29,7 +30,10 @@ mod category_owner;
 mod category_policy;
 mod category_reply_create_audience;
 mod category_search_audience_scope;
-mod category_search_scope;
+mod category_search_scope {
+    include!("category_search_scope.rs");
+    include!("category_search_scope_visible.rs");
+}
 mod category_topic_create_audience;
 mod category_tree {
     include!("category_tree.rs");

--- a/scripts/verify/verify-forum-search-category-audience-scope.mjs
+++ b/scripts/verify/verify-forum-search-category-audience-scope.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(".");
+const failures = [];
+
+const planPath = "crates/rustok-forum/docs/implementation-plan.md";
+const servicePath = "crates/rustok-forum/src/services/category_search_audience_scope.rs";
+const visibilityPath = "crates/rustok-forum/src/services/category_audience_visibility.rs";
+const exportPath = "crates/rustok-forum/src/services/mod.rs";
+const contractPath = "crates/rustok-forum/contracts/forum-search-category-audience-scope.json";
+const notePath = "crates/rustok-forum/docs/forum-23b2b-category-audience-scope.md";
+const verifierPath = "scripts/verify/verify-forum-search-category-audience-scope.mjs";
+
+function read(relativePath) {
+  const target = path.join(root, relativePath);
+  if (!existsSync(target)) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return "";
+  }
+  return readFileSync(target, "utf8");
+}
+
+function parseJson(relativePath) {
+  try {
+    return JSON.parse(read(relativePath));
+  } catch (error) {
+    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function requireAll(source, markers, label) {
+  for (const marker of markers) {
+    if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+  }
+}
+
+function rejectAll(source, markers, label) {
+  for (const marker of markers) {
+    if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+  }
+}
+
+const plan = read(planPath);
+const service = read(servicePath);
+const visibility = read(visibilityPath);
+const ownerExport = read(exportPath);
+const note = read(notePath);
+const contract = parseJson(contractPath);
+
+requireAll(
+  service,
+  [
+    "pub struct ForumSearchCategoryAudienceScopeService",
+    "pub fn with_audience_facts",
+    "pub async fn expand_public_visible_subtrees",
+    "pub async fn expand_authenticated_visible_subtrees",
+    "ForumCategoryAudienceViewer::public()",
+    "ForumCategoryAudienceViewer::authenticated",
+    "Resource::ForumCategories, Action::List",
+    "ForumCategoryAudienceVisibilityService::new",
+    ".is_category_visible(tenant_id, category_id, &viewer)",
+    "if !node.is_archived",
+    "prune_category_nodes(tree.roots, &visible_ids)",
+    "ForumError::CategoryNotFound(*category_id)",
+    "MAX_FORUM_SEARCH_CATEGORY_ROOTS",
+    "MAX_FORUM_CATEGORY_TREE_NODES",
+    "denied_parent_prunes_allowed_descendants",
+    "overlapping_visible_roots_expand_once",
+    "raw_root_bound_is_checked_before_deduplication",
+  ],
+  servicePath,
+);
+rejectAll(
+  service,
+  [
+    "use rustok_search",
+    "PgSearchEngine",
+    "SearchQuery {",
+    "search_documents",
+    "forum_category_audience_policy::Entity",
+  ],
+  servicePath,
+);
+
+requireAll(
+  visibility,
+  [
+    "pub struct ForumCategoryAudienceVisibilityService",
+    "load_category_audience_policy",
+    "resolve_for_constraints",
+    "ForumAudienceEvaluator::decide",
+  ],
+  visibilityPath,
+);
+requireAll(
+  ownerExport,
+  [
+    "mod category_search_audience_scope;",
+    "pub use category_search_audience_scope::ForumSearchCategoryAudienceScopeService;",
+  ],
+  exportPath,
+);
+requireAll(
+  plan,
+  [
+    "## `FORUM-23` — search/index integration",
+    "FORUM-23B2B",
+    "richer category audience",
+    "Host composition",
+  ],
+  planPath,
+);
+requireAll(
+  note,
+  [
+    "FORUM-23B2B",
+    "role",
+    "trust",
+    "Channel",
+    "Groups",
+    "explicit user allow/deny",
+    "fails closed",
+    "Forum-only Search entrypoint",
+    "Not run by the implementation agent",
+  ],
+  notePath,
+);
+
+if (contract) {
+  if (contract.task !== "FORUM-23B2B") failures.push(`${contractPath}: unexpected task`);
+  if (contract.status !== "source_complete_execution_pending") {
+    failures.push(`${contractPath}: unexpected status`);
+  }
+  const expectedPaths = {
+    canonical_plan: planPath,
+    audience_scope_owner: servicePath,
+    audience_visibility_owner: visibilityPath,
+    owner_export: exportPath,
+    owner_note: notePath,
+    verifier: verifierPath,
+  };
+  for (const [key, expected] of Object.entries(expectedPaths)) {
+    if (contract[key] !== expected) failures.push(`${contractPath}: ${key} drift`);
+  }
+  for (const key of [
+    "requires_forum_categories_list",
+    "public_viewer_supported",
+    "authenticated_viewer_requires_exact_port_context",
+    "reuses_public_authenticated_floor",
+    "reuses_inherited_richer_category_layers",
+    "supports_role_selector",
+    "supports_trust_selector",
+    "supports_channel_selector",
+    "supports_group_selector",
+    "supports_explicit_allow_deny",
+    "missing_required_owner_facts_fail_closed",
+    "archived_category_is_excluded",
+    "denied_ancestor_prunes_descendants",
+    "denied_selected_root_is_not_found",
+  ]) {
+    if (contract.authorization?.[key] !== true) {
+      failures.push(`${contractPath}: authorization ${key} drift`);
+    }
+  }
+  for (const key of [
+    "graphql_schema_changed",
+    "rest_schema_changed",
+    "search_query_shape_changed",
+    "forum_projection_shape_changed",
+    "database_migration_added",
+    "dependency_added",
+    "cargo_lock_changed",
+  ]) {
+    if (contract.compatibility?.[key] !== false) {
+      failures.push(`${contractPath}: compatibility ${key} must remain false`);
+    }
+  }
+  if (contract.integration_boundary?.host_composition_complete !== false) {
+    failures.push(`${contractPath}: host composition must remain an explicit non-claim`);
+  }
+  if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
+    failures.push(`${contractPath}: execution status drift`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Forum richer Search category audience scope verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum richer Search category audience scope verification passed.");

--- a/scripts/verify/verify-forum-search-category-audience-scope.mjs
+++ b/scripts/verify/verify-forum-search-category-audience-scope.mjs
@@ -10,9 +10,16 @@ const failures = [];
 
 const planPath = "crates/rustok-forum/docs/implementation-plan.md";
 const servicePath = "crates/rustok-forum/src/services/category_search_audience_scope.rs";
+const audienceReadPath = "crates/rustok-forum/src/services/category_audience_read.rs";
+const audienceReadSearchPath =
+  "crates/rustok-forum/src/services/category_audience_read_search.rs";
 const visibilityPath = "crates/rustok-forum/src/services/category_audience_visibility.rs";
+const baseScopePath = "crates/rustok-forum/src/services/category_search_scope.rs";
+const visibleExpanderPath =
+  "crates/rustok-forum/src/services/category_search_scope_visible.rs";
 const exportPath = "crates/rustok-forum/src/services/mod.rs";
-const contractPath = "crates/rustok-forum/contracts/forum-search-category-audience-scope.json";
+const contractPath =
+  "crates/rustok-forum/contracts/forum-search-category-audience-scope.json";
 const notePath = "crates/rustok-forum/docs/forum-23b2b-category-audience-scope.md";
 const verifierPath = "scripts/verify/verify-forum-search-category-audience-scope.mjs";
 
@@ -48,7 +55,11 @@ function rejectAll(source, markers, label) {
 
 const plan = read(planPath);
 const service = read(servicePath);
+const audienceRead = read(audienceReadPath);
+const audienceReadSearch = read(audienceReadSearchPath);
 const visibility = read(visibilityPath);
+const baseScope = read(baseScopePath);
+const visibleExpander = read(visibleExpanderPath);
 const ownerExport = read(exportPath);
 const note = read(notePath);
 const contract = parseJson(contractPath);
@@ -57,22 +68,14 @@ requireAll(
   service,
   [
     "pub struct ForumSearchCategoryAudienceScopeService",
+    "ForumCategoryAudienceReadService",
     "pub fn with_audience_facts",
     "pub async fn expand_public_visible_subtrees",
     "pub async fn expand_authenticated_visible_subtrees",
-    "ForumCategoryAudienceViewer::public()",
-    "ForumCategoryAudienceViewer::authenticated",
-    "Resource::ForumCategories, Action::List",
-    "ForumCategoryAudienceVisibilityService::new",
-    ".is_category_visible(tenant_id, category_id, &viewer)",
-    "if !node.is_archived",
-    "prune_category_nodes(tree.roots, &visible_ids)",
-    "ForumError::CategoryNotFound(*category_id)",
-    "MAX_FORUM_SEARCH_CATEGORY_ROOTS",
-    "MAX_FORUM_CATEGORY_TREE_NODES",
-    "denied_parent_prunes_allowed_descendants",
-    "overlapping_visible_roots_expand_once",
-    "raw_root_bound_is_checked_before_deduplication",
+    "tree_public_storefront_visible_with_locale_fallback",
+    "tree_authenticated_owner_visible_with_audience_context",
+    "expand_search_category_scope_from_visible_tree",
+    "CategoryTreeQuery",
   ],
   servicePath,
 );
@@ -83,9 +86,44 @@ rejectAll(
     "PgSearchEngine",
     "SearchQuery {",
     "search_documents",
-    "forum_category_audience_policy::Entity",
+    "ForumCategoryAudienceVisibilityService",
+    "ForumCategoryAudienceViewer",
+    "forum_category::Entity",
+    "fn prune_category_nodes",
+    "fn collect_category_ids",
   ],
   servicePath,
+);
+
+requireAll(
+  audienceRead,
+  [
+    "pub struct ForumCategoryAudienceReadService",
+    "tree_authenticated_owner_visible_with_audience_context",
+    "ForumCategoryAudienceVisibilityService",
+    ".is_category_visible(tenant_id, category_id, &viewer)",
+    "prune_category_nodes",
+    "category_tree_stats",
+  ],
+  audienceReadPath,
+);
+requireAll(
+  audienceReadSearch,
+  [
+    "tree_public_storefront_visible_with_locale_fallback",
+    "SecurityContext::public_read()",
+    "Resource::ForumCategories, Action::List",
+    "ForumCategoryAudienceViewer::public()",
+    ".is_category_visible(tenant_id, category_id, &viewer)",
+    "prune_category_nodes(tree.roots, &visible_ids)",
+    "category_tree_stats(&tree.roots)",
+  ],
+  audienceReadSearchPath,
+);
+rejectAll(
+  audienceReadSearch,
+  ["use rustok_search", "SearchQuery {", "search_documents"],
+  audienceReadSearchPath,
 );
 
 requireAll(
@@ -98,21 +136,62 @@ requireAll(
   ],
   visibilityPath,
 );
+
+requireAll(
+  baseScope,
+  [
+    "pub const MAX_FORUM_SEARCH_CATEGORY_ROOTS: usize = 10",
+    "pub struct ForumSearchCategoryScope",
+    "struct CategoryHierarchy",
+    "fn normalize_requested_category_ids",
+    "fn expand_visible_subtrees",
+    "raw_root_bound_is_checked_before_deduplication",
+  ],
+  baseScopePath,
+);
+requireAll(
+  visibleExpander,
+  [
+    "expand_search_category_scope_from_visible_tree",
+    "normalize_requested_category_ids(category_ids)",
+    "collect_active_visible_nodes",
+    "if node.is_archived",
+    "CategoryHierarchy::from_ordered_nodes",
+    "hierarchy.expand_visible_subtrees",
+    "HashSet::new()",
+  ],
+  visibleExpanderPath,
+);
+rejectAll(
+  visibleExpander,
+  [
+    "use rustok_search",
+    "ForumCategoryAudienceVisibilityService",
+    "ForumCategoryAudienceViewer",
+    "forum_category::Entity",
+  ],
+  visibleExpanderPath,
+);
+
 requireAll(
   ownerExport,
   [
+    'include!("category_audience_read_search.rs")',
     "mod category_search_audience_scope;",
+    'include!("category_search_scope_visible.rs")',
+    'include!("category_search_scope.rs")',
     "pub use category_search_audience_scope::ForumSearchCategoryAudienceScopeService;",
   ],
   exportPath,
 );
+
 requireAll(
   plan,
   [
     "## `FORUM-23` — search/index integration",
     "FORUM-23B2B",
     "richer category audience",
-    "Host composition",
+    "Host composition remains open",
   ],
   planPath,
 );
@@ -120,12 +199,14 @@ requireAll(
   note,
   [
     "FORUM-23B2B",
+    "ForumCategoryAudienceReadService",
     "role",
     "trust",
     "Channel",
     "Groups",
     "explicit user allow/deny",
     "fails closed",
+    "B2A `CategoryHierarchy`",
     "Forum-only Search entrypoint",
     "Not run by the implementation agent",
   ],
@@ -133,13 +214,20 @@ requireAll(
 );
 
 if (contract) {
-  if (contract.task !== "FORUM-23B2B") failures.push(`${contractPath}: unexpected task`);
+  if (contract.task !== "FORUM-23B2B") {
+    failures.push(`${contractPath}: unexpected task`);
+  }
   if (contract.status !== "source_complete_execution_pending") {
     failures.push(`${contractPath}: unexpected status`);
   }
+
   const expectedPaths = {
     canonical_plan: planPath,
+    base_scope_owner: baseScopePath,
+    visible_tree_expander: visibleExpanderPath,
     audience_scope_owner: servicePath,
+    audience_read_owner: audienceReadPath,
+    audience_read_search_extension: audienceReadSearchPath,
     audience_visibility_owner: visibilityPath,
     owner_export: exportPath,
     owner_note: notePath,
@@ -148,10 +236,12 @@ if (contract) {
   for (const [key, expected] of Object.entries(expectedPaths)) {
     if (contract[key] !== expected) failures.push(`${contractPath}: ${key} drift`);
   }
+
   for (const key of [
     "requires_forum_categories_list",
     "public_viewer_supported",
     "authenticated_viewer_requires_exact_port_context",
+    "reuses_canonical_category_audience_read_owner",
     "reuses_public_authenticated_floor",
     "reuses_inherited_richer_category_layers",
     "supports_role_selector",
@@ -168,6 +258,20 @@ if (contract) {
       failures.push(`${contractPath}: authorization ${key} drift`);
     }
   }
+
+  for (const key of [
+    "raw_root_bound_is_checked_before_deduplication",
+    "requested_roots_preserve_first_occurrence_order",
+    "visible_children_preserve_canonical_tree_order",
+    "overlapping_roots_are_deduplicated",
+    "expanded_output_is_deterministic_preorder",
+    "shared_b2a_hierarchy_expander_is_reused",
+  ]) {
+    if (contract.ordering?.[key] !== true) {
+      failures.push(`${contractPath}: ordering ${key} drift`);
+    }
+  }
+
   for (const key of [
     "graphql_schema_changed",
     "rest_schema_changed",
@@ -181,8 +285,14 @@ if (contract) {
       failures.push(`${contractPath}: compatibility ${key} must remain false`);
     }
   }
+  if (contract.compatibility?.b2a_base_scope_preserved !== true) {
+    failures.push(`${contractPath}: B2A base scope must remain preserved`);
+  }
   if (contract.integration_boundary?.host_composition_complete !== false) {
     failures.push(`${contractPath}: host composition must remain an explicit non-claim`);
+  }
+  if (contract.integration_boundary?.search_execution_is_added !== false) {
+    failures.push(`${contractPath}: Search execution must remain absent`);
   }
   if (contract.verification?.execution_status !== "not_run_by_implementation_agent") {
     failures.push(`${contractPath}: execution status drift`);


### PR DESCRIPTION
## Summary

Implements `FORUM-23B2B`, the richer-audience owner boundary for Forum category-subtree Search scope.

- expose public and authenticated category-subtree expansion through `ForumSearchCategoryAudienceScopeService`;
- reuse `ForumCategoryAudienceReadService` as the single owner of the already-pruned category tree;
- reuse the delivered inherited public/authenticated floor plus role, trust, Channel, Groups, and explicit user allow/deny category layers;
- preserve exact tenant/user `PortContext` validation and fail closed when unresolved owner facts are unavailable;
- reuse the B2A `CategoryHierarchy` algorithm for root normalization, canonical preorder, overlap deduplication, and bounds;
- prune archived branches before Search identifiers are produced;
- keep Search owner-neutral: no Search import, execution, query-shape change, or public transport change;
- update the canonical Forum plan, owner note, machine contract, and static verifier.

## Why

`FORUM-23B2A` intentionally covered only the inherited public/authenticated category floor. Composing it directly into a public Search entrypoint would allow richer category audience policy to be bypassed. This slice closes that owner gap before host Search composition.

## Scope boundary

This PR does not execute Search, change `storefrontSearch`, or claim topic-local/reply Search eligibility. A later host-composed entrypoint must use this owner only for an explicit Forum-only source scope so product category semantics are not broadened.

## Compatibility

No migration, backfill, GraphQL/REST field, Search query shape, Forum projection shape, dependency, or `Cargo.lock` change.

## Verification

Not run by the implementation agent, per maintainer instruction. Suggested commands:

```bash
cargo test -p rustok-forum category_search_audience_scope -- --nocapture
node scripts/verify/verify-forum-search-category-audience-scope.mjs
node scripts/verify/verify-forum-search-category-subtree-scope.mjs
cargo xtask module validate forum
```
