### PR TITLE
fix(inventory): sanitize admin client transport errors

### DIFF
--- a/crates/rustok-inventory/admin/src/transport/error_safety.rs
+++ b/crates/rustok-inventory/admin/src/transport/error_safety.rs
@@ -1,0 +1,144 @@
+use leptos::prelude::ServerFnError;
+use std::fmt::{Display, Formatter};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const INVENTORY_ADMIN_CLIENT_OWNER: &str = "rustok_inventory.admin";
+const INVENTORY_ADMIN_CLIENT_BOUNDARY: &str = "inventory_admin_client_transport";
+const INVENTORY_ADMIN_CLIENT_PUBLIC_MESSAGE: &str =
+    "Inventory admin request could not be completed";
+
+#[derive(Debug, Clone)]
+pub enum InventoryTransportError {
+    ServerFn(String),
+}
+
+impl Display for InventoryTransportError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ServerFn(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+impl std::error::Error for InventoryTransportError {}
+
+pub(super) struct InventoryTransportErrorContext {
+    operation: &'static str,
+    correlation_id: String,
+    tenant_id_length: Option<usize>,
+    subject_id_length: Option<usize>,
+    locale_length: Option<usize>,
+    search_length: Option<usize>,
+    status_length: Option<usize>,
+    numeric_input_present: bool,
+}
+
+impl InventoryTransportErrorContext {
+    pub(super) fn for_bootstrap() -> Self {
+        Self::new("fetch_bootstrap")
+    }
+
+    pub(super) fn for_products(
+        tenant_id: &str,
+        locale: Option<&str>,
+        search: Option<&str>,
+        status: Option<&str>,
+    ) -> Self {
+        let mut context = Self::new("fetch_products");
+        context.tenant_id_length = Some(tenant_id.chars().count());
+        context.locale_length = text_length(locale);
+        context.search_length = text_length(search);
+        context.status_length = text_length(status);
+        context
+    }
+
+    pub(super) fn for_product(tenant_id: &str, product_id: &str, locale: Option<&str>) -> Self {
+        let mut context = Self::new("fetch_product");
+        context.tenant_id_length = Some(tenant_id.chars().count());
+        context.subject_id_length = Some(product_id.chars().count());
+        context.locale_length = text_length(locale);
+        context
+    }
+
+    pub(super) fn for_set_variant_quantity(tenant_id: &str, variant_id: &str) -> Self {
+        Self::for_variant_input("set_variant_quantity", tenant_id, variant_id)
+    }
+
+    pub(super) fn for_adjust_variant_quantity(tenant_id: &str, variant_id: &str) -> Self {
+        Self::for_variant_input("adjust_variant_quantity", tenant_id, variant_id)
+    }
+
+    pub(super) fn for_reserve_variant_quantity(tenant_id: &str, variant_id: &str) -> Self {
+        Self::for_variant_input("reserve_variant_quantity", tenant_id, variant_id)
+    }
+
+    pub(super) fn for_check_variant_availability(tenant_id: &str, variant_id: &str) -> Self {
+        Self::for_variant_input("check_variant_availability", tenant_id, variant_id)
+    }
+
+    pub(super) fn for_release_reservation_quantity(tenant_id: &str, variant_id: &str) -> Self {
+        Self::for_variant_input("release_reservation_quantity", tenant_id, variant_id)
+    }
+
+    fn for_variant_input(
+        operation: &'static str,
+        tenant_id: &str,
+        variant_id: &str,
+    ) -> Self {
+        let mut context = Self::new(operation);
+        context.tenant_id_length = Some(tenant_id.chars().count());
+        context.subject_id_length = Some(variant_id.chars().count());
+        context.numeric_input_present = true;
+        context
+    }
+
+    fn new(operation: &'static str) -> Self {
+        Self {
+            operation,
+            correlation_id: inventory_admin_client_correlation_id(operation),
+            tenant_id_length: None,
+            subject_id_length: None,
+            locale_length: None,
+            search_length: None,
+            status_length: None,
+            numeric_input_present: false,
+        }
+    }
+
+    pub(super) fn map_error(&self, error: ServerFnError) -> InventoryTransportError {
+        tracing::error!(
+            raw_error = ?error,
+            owner = INVENTORY_ADMIN_CLIENT_OWNER,
+            owner_operation = self.operation,
+            correlation_id = %self.correlation_id,
+            tenant_id_present = self.tenant_id_length.is_some(),
+            tenant_id_length = ?self.tenant_id_length,
+            subject_id_present = self.subject_id_length.is_some(),
+            subject_id_length = ?self.subject_id_length,
+            locale_present = self.locale_length.is_some(),
+            locale_length = ?self.locale_length,
+            search_present = self.search_length.is_some(),
+            search_length = ?self.search_length,
+            status_present = self.status_length.is_some(),
+            status_length = ?self.status_length,
+            numeric_input_present = self.numeric_input_present,
+            code = "inventory.admin_client_transport_failed",
+            boundary = INVENTORY_ADMIN_CLIENT_BOUNDARY,
+            "inventory admin client transport request failed"
+        );
+
+        InventoryTransportError::ServerFn(INVENTORY_ADMIN_CLIENT_PUBLIC_MESSAGE.to_string())
+    }
+}
+
+fn inventory_admin_client_correlation_id(operation: &'static str) -> String {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("inventory-admin-client:{operation}:{timestamp}")
+}
+
+fn text_length(value: Option<&str>) -> Option<usize> {
+    value.map(|value| value.chars().count())
+}

--- a/crates/rustok-inventory/admin/src/transport/error_safety.rs
+++ b/crates/rustok-inventory/admin/src/transport/error_safety.rs
@@ -9,13 +9,13 @@ const INVENTORY_ADMIN_CLIENT_PUBLIC_MESSAGE: &str =
 
 #[derive(Debug, Clone)]
 pub enum InventoryTransportError {
-    ServerFn(String),
+    ServerFn,
 }
 
 impl Display for InventoryTransportError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::ServerFn(message) => write!(f, "{message}"),
+            Self::ServerFn => write!(f, "{INVENTORY_ADMIN_CLIENT_PUBLIC_MESSAGE}"),
         }
     }
 }
@@ -127,7 +127,7 @@ impl InventoryTransportErrorContext {
             "inventory admin client transport request failed"
         );
 
-        InventoryTransportError::ServerFn(INVENTORY_ADMIN_CLIENT_PUBLIC_MESSAGE.to_string())
+        InventoryTransportError::ServerFn
     }
 }
 

--- a/crates/rustok-inventory/admin/src/transport/mod.rs
+++ b/crates/rustok-inventory/admin/src/transport/mod.rs
@@ -1,7 +1,9 @@
+mod error_safety;
 mod native_server_adapter;
 
-use leptos::prelude::*;
-use std::fmt::{Display, Formatter};
+pub use error_safety::InventoryTransportError;
+
+use error_safety::InventoryTransportErrorContext;
 
 use crate::core::{
     InventoryAdjustQuantityRequest, InventoryAvailabilityCheckRequest, InventoryProductRequest,
@@ -15,27 +17,6 @@ use crate::model::{
     InventoryProductList, InventoryQuantityWriteResult, InventoryReservationReleaseWriteResult,
     InventoryReservationWriteResult,
 };
-
-#[derive(Debug, Clone)]
-pub enum InventoryTransportError {
-    ServerFn(String),
-}
-
-impl Display for InventoryTransportError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::ServerFn(error) => write!(f, "{error}"),
-        }
-    }
-}
-
-impl std::error::Error for InventoryTransportError {}
-
-impl From<ServerFnError> for InventoryTransportError {
-    fn from(value: ServerFnError) -> Self {
-        Self::ServerFn(value.to_string())
-    }
-}
 
 fn products_request(
     tenant_id: String,
@@ -129,9 +110,10 @@ fn release_reservation_request(
 }
 
 pub async fn fetch_bootstrap() -> Result<InventoryAdminBootstrap, InventoryTransportError> {
+    let context = InventoryTransportErrorContext::for_bootstrap();
     native_server_adapter::fetch_bootstrap()
         .await
-        .map_err(Into::into)
+        .map_err(|server_error| context.map_error(server_error))
 }
 
 pub async fn fetch_products(
@@ -141,6 +123,12 @@ pub async fn fetch_products(
     status: Option<String>,
 ) -> Result<InventoryProductList, InventoryTransportError> {
     let request = products_request(tenant_id, locale, search, status);
+    let context = InventoryTransportErrorContext::for_products(
+        request.tenant_id.as_str(),
+        request.locale.as_deref(),
+        request.search.as_deref(),
+        request.status.as_deref(),
+    );
     native_server_adapter::fetch_products(
         request.tenant_id,
         request.locale,
@@ -148,7 +136,7 @@ pub async fn fetch_products(
         request.status,
     )
     .await
-    .map_err(Into::into)
+    .map_err(|server_error| context.map_error(server_error))
 }
 
 pub async fn fetch_product(
@@ -157,9 +145,14 @@ pub async fn fetch_product(
     locale: Option<String>,
 ) -> Result<Option<InventoryProductDetail>, InventoryTransportError> {
     let request = product_request(tenant_id, id, locale);
+    let context = InventoryTransportErrorContext::for_product(
+        request.tenant_id.as_str(),
+        request.id.as_str(),
+        request.locale.as_deref(),
+    );
     native_server_adapter::fetch_product(request.tenant_id, request.id, request.locale)
         .await
-        .map_err(Into::into)
+        .map_err(|server_error| context.map_error(server_error))
 }
 
 pub async fn set_variant_quantity(
@@ -168,13 +161,17 @@ pub async fn set_variant_quantity(
     quantity: i32,
 ) -> Result<InventoryQuantityWriteResult, InventoryTransportError> {
     let request = set_quantity_request(tenant_id, variant_id, quantity);
+    let context = InventoryTransportErrorContext::for_set_variant_quantity(
+        request.tenant_id.as_str(),
+        request.variant_id.as_str(),
+    );
     native_server_adapter::set_variant_quantity(
         request.tenant_id,
         request.variant_id,
         request.quantity,
     )
     .await
-    .map_err(Into::into)
+    .map_err(|server_error| context.map_error(server_error))
 }
 
 pub async fn adjust_variant_quantity(
@@ -183,13 +180,17 @@ pub async fn adjust_variant_quantity(
     adjustment: i32,
 ) -> Result<InventoryQuantityWriteResult, InventoryTransportError> {
     let request = adjust_quantity_request(tenant_id, variant_id, adjustment);
+    let context = InventoryTransportErrorContext::for_adjust_variant_quantity(
+        request.tenant_id.as_str(),
+        request.variant_id.as_str(),
+    );
     native_server_adapter::adjust_variant_quantity(
         request.tenant_id,
         request.variant_id,
         request.adjustment,
     )
     .await
-    .map_err(Into::into)
+    .map_err(|server_error| context.map_error(server_error))
 }
 
 pub async fn reserve_variant_quantity(
@@ -198,13 +199,17 @@ pub async fn reserve_variant_quantity(
     quantity: i32,
 ) -> Result<InventoryReservationWriteResult, InventoryTransportError> {
     let request = reserve_quantity_request(tenant_id, variant_id, quantity);
+    let context = InventoryTransportErrorContext::for_reserve_variant_quantity(
+        request.tenant_id.as_str(),
+        request.variant_id.as_str(),
+    );
     native_server_adapter::reserve_variant_quantity(
         request.tenant_id,
         request.variant_id,
         request.quantity,
     )
     .await
-    .map_err(Into::into)
+    .map_err(|server_error| context.map_error(server_error))
 }
 
 pub async fn check_variant_availability(
@@ -213,13 +218,17 @@ pub async fn check_variant_availability(
     requested_quantity: i32,
 ) -> Result<InventoryAvailabilityCheckResult, InventoryTransportError> {
     let request = availability_check_request(tenant_id, variant_id, requested_quantity);
+    let context = InventoryTransportErrorContext::for_check_variant_availability(
+        request.tenant_id.as_str(),
+        request.variant_id.as_str(),
+    );
     native_server_adapter::check_variant_availability(
         request.tenant_id,
         request.variant_id,
         request.requested_quantity,
     )
     .await
-    .map_err(Into::into)
+    .map_err(|server_error| context.map_error(server_error))
 }
 
 pub async fn release_reservation_quantity(
@@ -228,13 +237,17 @@ pub async fn release_reservation_quantity(
     quantity: i32,
 ) -> Result<InventoryReservationReleaseWriteResult, InventoryTransportError> {
     let request = release_reservation_request(tenant_id, variant_id, quantity);
+    let context = InventoryTransportErrorContext::for_release_reservation_quantity(
+        request.tenant_id.as_str(),
+        request.variant_id.as_str(),
+    );
     native_server_adapter::release_reservation_quantity(
         request.tenant_id,
         request.variant_id,
         request.quantity,
     )
     .await
-    .map_err(Into::into)
+    .map_err(|server_error| context.map_error(server_error))
 }
 
 #[cfg(test)]

--- a/crates/rustok-inventory/contracts/evidence/admin-client-transport-error-safety-source-review.json
+++ b/crates/rustok-inventory/contracts/evidence/admin-client-transport-error-safety-source-review.json
@@ -1,0 +1,27 @@
+{
+  "status": "inventory_admin_client_transport_error_safety_source_reviewed_unvalidated",
+  "reviewed_at": "2026-07-30",
+  "review_scope": [
+    "crates/rustok-inventory/admin/src/transport/mod.rs",
+    "crates/rustok-inventory/admin/src/transport/error_safety.rs",
+    "crates/rustok-inventory/admin/src/transport/native_server_adapter.rs"
+  ],
+  "findings": {
+    "public_raw_server_fn_conversion_removed": true,
+    "context_free_into_mapping_removed": true,
+    "eight_facade_operations_mapped": true,
+    "request_builders_preserved": true,
+    "native_server_adapter_unchanged": true,
+    "result_dtos_preserved": true,
+    "static_public_message_preserved_across_operations": true,
+    "original_error_private_to_structured_diagnostics": true,
+    "safe_shape_logging_only": true,
+    "broad_ecommerce_mapper_cleanup_remains_open": true
+  },
+  "non_claims": [
+    "No test or verifier was executed",
+    "No Cargo compilation was executed",
+    "No browser or mounted server-function failure was exercised",
+    "No Inventory FFA or FBA status was promoted"
+  ]
+}

--- a/crates/rustok-inventory/contracts/evidence/admin-client-transport-error-safety-source-review.json
+++ b/crates/rustok-inventory/contracts/evidence/admin-client-transport-error-safety-source-review.json
@@ -9,6 +9,7 @@
   "findings": {
     "public_raw_server_fn_conversion_removed": true,
     "context_free_into_mapping_removed": true,
+    "public_error_variant_has_no_string_payload": true,
     "eight_facade_operations_mapped": true,
     "request_builders_preserved": true,
     "native_server_adapter_unchanged": true,

--- a/crates/rustok-inventory/contracts/evidence/admin-client-transport-error-safety-source.json
+++ b/crates/rustok-inventory/contracts/evidence/admin-client-transport-error-safety-source.json
@@ -1,0 +1,55 @@
+{
+  "status": "inventory_admin_client_transport_error_safety_source_unvalidated",
+  "reviewed_at": "2026-07-30",
+  "boundary": "inventory_admin_client_transport",
+  "public_error_type": "InventoryTransportError",
+  "public_message": "Inventory admin request could not be completed",
+  "covered_operations": [
+    "fetch_bootstrap",
+    "fetch_products",
+    "fetch_product",
+    "set_variant_quantity",
+    "adjust_variant_quantity",
+    "reserve_variant_quantity",
+    "check_variant_availability",
+    "release_reservation_quantity"
+  ],
+  "confirmed_gap": {
+    "raw_server_fn_string_public": true,
+    "source_pattern": "InventoryTransportError::ServerFn(value.to_string())",
+    "context_free_mapping": ".map_err(Into::into)"
+  },
+  "source_contract": {
+    "server_functions_changed": false,
+    "request_normalization_changed": false,
+    "dto_changed": false,
+    "operation_count": 8,
+    "context_created_before_native_call": true,
+    "raw_server_fn_string_public": false,
+    "static_public_message": true,
+    "original_error_logged_privately": true,
+    "per_call_correlation_logging": true,
+    "safe_request_shape_only": true,
+    "tenant_values_logged": false,
+    "subject_values_logged": false,
+    "filter_values_logged": false,
+    "numeric_values_logged": false
+  },
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "hydrate_compile_proven": false,
+    "ssr_compile_proven": false,
+    "mounted_runtime_proven": false
+  },
+  "remaining": [
+    "Run the focused source verifier",
+    "Compile the inventory admin package for default, hydrate, and ssr profiles",
+    "Retain mounted browser and server-function failure evidence",
+    "Continue the broad ecommerce mapper cleanup in other owners"
+  ]
+}

--- a/crates/rustok-inventory/contracts/evidence/admin-client-transport-error-safety-source.json
+++ b/crates/rustok-inventory/contracts/evidence/admin-client-transport-error-safety-source.json
@@ -26,6 +26,7 @@
     "operation_count": 8,
     "context_created_before_native_call": true,
     "raw_server_fn_string_public": false,
+    "public_error_payload_constructible": false,
     "static_public_message": true,
     "original_error_logged_privately": true,
     "per_call_correlation_logging": true,

--- a/crates/rustok-inventory/docs/admin-client-transport-error-safety.md
+++ b/crates/rustok-inventory/docs/admin-client-transport-error-safety.md
@@ -1,0 +1,77 @@
+# Inventory Admin client transport error safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This source slice covers the public Inventory Admin transport facade in
+`crates/rustok-inventory/admin/src/transport/mod.rs`.
+
+Covered operations:
+
+- `fetch_bootstrap`
+- `fetch_products`
+- `fetch_product`
+- `set_variant_quantity`
+- `adjust_variant_quantity`
+- `reserve_variant_quantity`
+- `check_variant_availability`
+- `release_reservation_quantity`
+
+## Confirmed gap
+
+The facade previously implemented `From<ServerFnError>` by storing
+`value.to_string()` in `InventoryTransportError::ServerFn`. Every operation then
+used `.map_err(Into::into)`. A framework, transport, serialization, or unexpected
+server-function message could therefore become the public UI error text even when
+the mounted server function itself attempted to use a static owner envelope.
+
+## Source policy
+
+Each facade operation now creates an `InventoryTransportErrorContext` after the
+existing request normalization and before the unchanged native adapter call.
+Only a final returned `ServerFnError` is mapped.
+
+The original typed framework error is retained only in structured diagnostics
+with:
+
+- owner and exact operation;
+- a per-call correlation id;
+- the client transport boundary and a stable error code;
+- request-field presence and character lengths;
+- numeric-input presence without the quantity, adjustment, or requested quantity.
+
+Tenant, product, variant, locale, search, status, and numeric values are not
+written to the client transport diagnostic event.
+
+The public error remains `InventoryTransportError`, but its displayed message is
+always:
+
+`Inventory admin request could not be completed`
+
+## Preserved behavior
+
+This slice does not change:
+
+- mounted server-function endpoints;
+- authentication, tenant, permission, and owner policy;
+- `HostRuntimeContext` or event-bus composition;
+- request normalization;
+- read or write invocation order;
+- request and response DTOs;
+- Inventory Admin native-only transport selection.
+
+The server-side native adapter keeps its existing operation-specific static
+messages and owner diagnostics. The new facade policy is an independent final
+client boundary in case a framework or unexpected server-function string reaches
+the caller.
+
+## Evidence boundary
+
+The retained JSON evidence is source-only. Tests, focused verifiers, Cargo,
+formatting, workflows, CI, hydrate compilation, SSR compilation, browser behavior,
+and mounted runtime failure behavior were not executed by this implementation
+agent.
+
+The broad ecommerce mapper-cleanup item remains open for other owners and other
+non-`PortError` public envelopes.

--- a/crates/rustok-inventory/docs/admin-client-transport-error-safety.md
+++ b/crates/rustok-inventory/docs/admin-client-transport-error-safety.md
@@ -4,7 +4,7 @@ Status: **source-ready / unvalidated**
 
 ## Scope
 
-This source slice covers the public Inventory Admin transport facade in
+This source slice covers the eight public Inventory Admin transport operations in
 `crates/rustok-inventory/admin/src/transport/mod.rs`.
 
 Covered operations:
@@ -44,8 +44,8 @@ with:
 Tenant, product, variant, locale, search, status, and numeric values are not
 written to the client transport diagnostic event.
 
-The public error remains `InventoryTransportError`, but its displayed message is
-always:
+`InventoryTransportError::ServerFn` is now a unit variant. No caller can attach a
+raw string payload to the public error. Its displayed message is always:
 
 `Inventory admin request could not be completed`
 

--- a/crates/rustok-inventory/docs/implementation-plan.md
+++ b/crates/rustok-inventory/docs/implementation-plan.md
@@ -21,6 +21,15 @@ source contract is guarded by
 `scripts/verify/verify-inventory-admin-native-error-safety.mjs`; runtime evidence
 has not been executed or promoted.
 
+The Inventory admin client transport facade independently fails closed after the
+native call. All eight read/write operations create a per-call correlation
+context, retain the original `ServerFnError` only in structured diagnostics, and
+return one static `InventoryTransportError` message. Tenant, product, variant,
+locale, filter, and numeric request values are represented only by safe
+presence/length shape facts. This source contract is guarded by
+`scripts/verify/verify-inventory-admin-client-transport-error-safety.mjs` and
+remains unvalidated.
+
 `BootstrapService` owns default-location creation, initial item/level creation,
 variant-record cleanup, and batched available-quantity reads when product
 creates or deletes variants. This is a native transaction-sharing bootstrap
@@ -33,6 +42,7 @@ and reservation contracts remain inventory-owned.
 - FBA status: `boundary_ready`
 - Structural shape: `core_transport_ui`
 - Admin native error safety: `source_ready_unvalidated`
+- Admin client transport error safety: `source_ready_unvalidated`
 - FBA provider contract: `InventoryReservationPort` /
   `inventory.reservation.v1` in
   `crates/rustok-inventory/contracts/inventory-fba-registry.json`.
@@ -41,8 +51,12 @@ and reservation contracts remain inventory-owned.
   and `crates/rustok-inventory/contracts/evidence/inventory-runtime-contract-smoke.json`.
 - `scripts/verify/verify-inventory-admin-boundary.mjs` locks the native
   core/transport/UI split and absence of pre-FFA/GraphQL admin paths.
-- `scripts/verify/verify-inventory-admin-native-error-safety.mjs` locks static
-  public envelopes and private owner-cause diagnostics without claiming a
+- `scripts/verify/verify-inventory-admin-native-error-safety.mjs` locks mounted
+  static public envelopes and private owner-cause diagnostics without claiming a
+  runtime pass.
+- `scripts/verify/verify-inventory-admin-client-transport-error-safety.mjs` locks
+  the final facade mapping, per-operation correlation context, safe request-shape
+  diagnostics, and static `InventoryTransportError` text without claiming a
   runtime pass.
 
 ## Open results
@@ -63,21 +77,23 @@ and reservation contracts remain inventory-owned.
    read models cannot diverge from `InventoryService` policy.
 
 3. **Run the verification/CI evidence slice for `InventoryReservationPort` and
-   admin native error safety.** Execute the remote-adapter contract and fallback
-   profiles before a `boundary_ready` promotion; retain native-only admin
-   transport unless a public parity contract is introduced. Execute the focused
-   admin error-safety guard, compile the SSR package, and retain mounted failure
-   evidence before promoting its source-only status.
+   admin native/client error safety.** Execute the remote-adapter contract and
+   fallback profiles before a `boundary_ready` promotion; retain native-only
+   admin transport unless a public parity contract is introduced. Execute both
+   focused admin error-safety guards, compile the default/hydrate/SSR package,
+   and retain mounted browser plus server-function failure evidence before
+   promoting either source-only status.
    **Depends on:** a runtime-composed commerce consumer and remote adapter
    environment.
    **Done when:** deadline, idempotency, typed-error, degraded-mode, owner
-   invocation, and mounted public-envelope evidence covers every published port
-   operation and native admin endpoint.
+   invocation, client-facade sanitization, and mounted public-envelope evidence
+   covers every published port operation and native admin endpoint.
 
 ## Verification
 
 - `npm run verify:inventory:admin-boundary`
 - `node scripts/verify/verify-inventory-admin-native-error-safety.mjs`
+- `node scripts/verify/verify-inventory-admin-client-transport-error-safety.mjs`
 - `npm run verify:ecommerce:fba`
 - `cargo xtask module validate inventory`
 - `cargo xtask module test inventory`

--- a/scripts/verify/verify-inventory-admin-client-transport-error-safety.mjs
+++ b/scripts/verify/verify-inventory-admin-client-transport-error-safety.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const requireCount = (source, value, expected, label) => {
+  const count = source.split(value).length - 1;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+};
+const between = (source, start, end, label) => {
+  const from = source.indexOf(start);
+  const to = source.indexOf(end, from + start.length);
+  if (from < 0 || to < 0) {
+    failures.push(`${label}: could not isolate ${start} before ${end}`);
+    return "";
+  }
+  return source.slice(from, to);
+};
+
+const paths = {
+  facade: "crates/rustok-inventory/admin/src/transport/mod.rs",
+  safety: "crates/rustok-inventory/admin/src/transport/error_safety.rs",
+  native:
+    "crates/rustok-inventory/admin/src/transport/native_server_adapter.rs",
+  evidence:
+    "crates/rustok-inventory/contracts/evidence/admin-client-transport-error-safety-source.json",
+  review:
+    "crates/rustok-inventory/contracts/evidence/admin-client-transport-error-safety-source-review.json",
+  doc: "crates/rustok-inventory/docs/admin-client-transport-error-safety.md",
+  inventoryPlan: "crates/rustok-inventory/docs/implementation-plan.md",
+  commercePlan: "crates/rustok-commerce/docs/implementation-plan.md",
+  nativeGuard: "scripts/verify/verify-inventory-admin-native-error-safety.mjs",
+};
+
+const facade = read(paths.facade);
+const safety = read(paths.safety);
+const native = read(paths.native);
+const evidence = JSON.parse(read(paths.evidence));
+const review = JSON.parse(read(paths.review));
+const doc = read(paths.doc);
+const inventoryPlan = read(paths.inventoryPlan);
+const commercePlan = read(paths.commercePlan);
+const nativeGuard = read(paths.nativeGuard);
+
+for (const marker of [
+  "mod error_safety;",
+  "pub use error_safety::InventoryTransportError;",
+  "use error_safety::InventoryTransportErrorContext;",
+]) {
+  requireText(facade, marker, `${paths.facade}: error-safety module wiring`);
+}
+
+for (const forbidden of [
+  "impl From<ServerFnError> for InventoryTransportError",
+  "Self::ServerFn(value.to_string())",
+  ".map_err(Into::into)",
+]) {
+  forbidText(facade, forbidden, `${paths.facade}: raw context-free mapping`);
+}
+
+requireCount(
+  facade,
+  ".map_err(|server_error| context.map_error(server_error))",
+  8,
+  `${paths.facade}: context-aware operation mapping`,
+);
+
+const operations = [
+  ["fetch_bootstrap", "for_bootstrap", "native_server_adapter::fetch_bootstrap("],
+  ["fetch_products", "for_products", "native_server_adapter::fetch_products("],
+  ["fetch_product", "for_product", "native_server_adapter::fetch_product("],
+  [
+    "set_variant_quantity",
+    "for_set_variant_quantity",
+    "native_server_adapter::set_variant_quantity(",
+  ],
+  [
+    "adjust_variant_quantity",
+    "for_adjust_variant_quantity",
+    "native_server_adapter::adjust_variant_quantity(",
+  ],
+  [
+    "reserve_variant_quantity",
+    "for_reserve_variant_quantity",
+    "native_server_adapter::reserve_variant_quantity(",
+  ],
+  [
+    "check_variant_availability",
+    "for_check_variant_availability",
+    "native_server_adapter::check_variant_availability(",
+  ],
+  [
+    "release_reservation_quantity",
+    "for_release_reservation_quantity",
+    "native_server_adapter::release_reservation_quantity(",
+  ],
+];
+
+for (let index = 0; index < operations.length; index += 1) {
+  const [operation, constructor, call] = operations[index];
+  const start = `pub async fn ${operation}(`;
+  const end =
+    index + 1 < operations.length
+      ? `pub async fn ${operations[index + 1][0]}(`
+      : "#[cfg(test)]";
+  const block = between(facade, start, end, `${paths.facade}: ${operation}`);
+  requireText(
+    block,
+    `InventoryTransportErrorContext::${constructor}`,
+    `${paths.facade}: ${operation} context`,
+  );
+  requireText(block, call, `${paths.facade}: ${operation} native call`);
+  requireText(
+    block,
+    ".map_err(|server_error| context.map_error(server_error))",
+    `${paths.facade}: ${operation} final error mapping`,
+  );
+  const contextIndex = block.indexOf(`InventoryTransportErrorContext::${constructor}`);
+  const callIndex = block.indexOf(call);
+  if (contextIndex < 0 || callIndex < 0 || contextIndex > callIndex) {
+    failures.push(`${paths.facade}: ${operation} context must be created before native call`);
+  }
+}
+
+for (const marker of [
+  'const INVENTORY_ADMIN_CLIENT_OWNER: &str = "rustok_inventory.admin";',
+  'const INVENTORY_ADMIN_CLIENT_BOUNDARY: &str = "inventory_admin_client_transport";',
+  '"Inventory admin request could not be completed"',
+  "pub enum InventoryTransportError",
+  "pub(super) struct InventoryTransportErrorContext",
+  "raw_error = ?error",
+  "owner_operation = self.operation",
+  "correlation_id = %self.correlation_id",
+  "tenant_id_present = self.tenant_id_length.is_some()",
+  "tenant_id_length = ?self.tenant_id_length",
+  "subject_id_present = self.subject_id_length.is_some()",
+  "subject_id_length = ?self.subject_id_length",
+  "locale_present = self.locale_length.is_some()",
+  "search_present = self.search_length.is_some()",
+  "status_present = self.status_length.is_some()",
+  "numeric_input_present = self.numeric_input_present",
+  'code = "inventory.admin_client_transport_failed"',
+  "boundary = INVENTORY_ADMIN_CLIENT_BOUNDARY",
+  "InventoryTransportError::ServerFn(INVENTORY_ADMIN_CLIENT_PUBLIC_MESSAGE.to_string())",
+]) {
+  requireText(safety, marker, `${paths.safety}: safe public mapping`);
+}
+
+for (const forbidden of [
+  "tenant_id = %",
+  "subject_id = %",
+  "locale = %",
+  "search = %",
+  "status = %",
+  "quantity =",
+  "adjustment =",
+  "requested_quantity =",
+  "error.to_string()",
+]) {
+  forbidText(safety, forbidden, `${paths.safety}: raw request/public text`);
+}
+
+for (const operation of operations.map(([name]) => name)) {
+  requireText(
+    safety,
+    `"${operation}"`,
+    `${paths.safety}: stable operation ${operation}`,
+  );
+}
+
+for (const endpoint of [
+  'endpoint = "inventory/bootstrap"',
+  'endpoint = "inventory/products"',
+  'endpoint = "inventory/product"',
+  'endpoint = "inventory/variant/set-quantity"',
+  'endpoint = "inventory/variant/adjust-quantity"',
+  'endpoint = "inventory/variant/reserve-quantity"',
+  'endpoint = "inventory/variant/check-availability"',
+  'endpoint = "inventory/variant/release-reservation"',
+]) {
+  requireText(native, endpoint, `${paths.native}: preserved mounted endpoint`);
+}
+requireText(
+  nativeGuard,
+  "Inventory admin native endpoints use static public envelopes",
+  `${paths.nativeGuard}: prior native policy remains registered`,
+);
+
+if (evidence.status !== "inventory_admin_client_transport_error_safety_source_unvalidated") {
+  failures.push(`${paths.evidence}: unexpected status ${evidence.status}`);
+}
+if (
+  review.status !==
+  "inventory_admin_client_transport_error_safety_source_reviewed_unvalidated"
+) {
+  failures.push(`${paths.review}: unexpected status ${review.status}`);
+}
+for (const [key, expected] of Object.entries({
+  server_functions_changed: false,
+  request_normalization_changed: false,
+  dto_changed: false,
+  operation_count: 8,
+  context_created_before_native_call: true,
+  raw_server_fn_string_public: false,
+  static_public_message: true,
+  original_error_logged_privately: true,
+  per_call_correlation_logging: true,
+  safe_request_shape_only: true,
+  tenant_values_logged: false,
+  subject_values_logged: false,
+  filter_values_logged: false,
+  numeric_values_logged: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "hydrate_compile_proven",
+  "ssr_compile_proven",
+  "mounted_runtime_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+
+requireText(doc, "Status: **source-ready / unvalidated**", `${paths.doc}: status`);
+requireText(doc, "eight", `${paths.doc}: operation scope`);
+requireText(
+  doc,
+  "Inventory admin request could not be completed",
+  `${paths.doc}: static public message`,
+);
+requireText(
+  inventoryPlan,
+  "Admin client transport error safety: `source_ready_unvalidated`",
+  `${paths.inventoryPlan}: local status`,
+);
+requireText(
+  inventoryPlan,
+  "verify-inventory-admin-client-transport-error-safety.mjs",
+  `${paths.inventoryPlan}: local verifier`,
+);
+requireText(
+  commercePlan,
+  "Finish correlation-safe mapper cleanup",
+  `${paths.commercePlan}: broad ecommerce mapper cleanup remains open`,
+);
+
+if (failures.length > 0) {
+  console.error("Inventory Admin client transport error-safety verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "Inventory Admin client transport errors use correlation-safe static public text across eight native operations; execution evidence remains open",
+);

--- a/scripts/verify/verify-inventory-admin-client-transport-error-safety.mjs
+++ b/scripts/verify/verify-inventory-admin-client-transport-error-safety.mjs
@@ -141,6 +141,8 @@ for (const marker of [
   'const INVENTORY_ADMIN_CLIENT_BOUNDARY: &str = "inventory_admin_client_transport";',
   '"Inventory admin request could not be completed"',
   "pub enum InventoryTransportError",
+  "ServerFn,",
+  'Self::ServerFn => write!(f, "{INVENTORY_ADMIN_CLIENT_PUBLIC_MESSAGE}")',
   "pub(super) struct InventoryTransportErrorContext",
   "raw_error = ?error",
   "owner_operation = self.operation",
@@ -155,12 +157,13 @@ for (const marker of [
   "numeric_input_present = self.numeric_input_present",
   'code = "inventory.admin_client_transport_failed"',
   "boundary = INVENTORY_ADMIN_CLIENT_BOUNDARY",
-  "InventoryTransportError::ServerFn(INVENTORY_ADMIN_CLIENT_PUBLIC_MESSAGE.to_string())",
+  "InventoryTransportError::ServerFn",
 ]) {
   requireText(safety, marker, `${paths.safety}: safe public mapping`);
 }
 
 for (const forbidden of [
+  "ServerFn(String)",
   "tenant_id = %",
   "subject_id = %",
   "locale = %",
@@ -209,6 +212,9 @@ if (
 ) {
   failures.push(`${paths.review}: unexpected status ${review.status}`);
 }
+if (review.findings?.public_error_variant_has_no_string_payload !== true) {
+  failures.push(`${paths.review}: unit public error variant review is required`);
+}
 for (const [key, expected] of Object.entries({
   server_functions_changed: false,
   request_normalization_changed: false,
@@ -216,6 +222,7 @@ for (const [key, expected] of Object.entries({
   operation_count: 8,
   context_created_before_native_call: true,
   raw_server_fn_string_public: false,
+  public_error_payload_constructible: false,
   static_public_message: true,
   original_error_logged_privately: true,
   per_call_correlation_logging: true,
@@ -252,6 +259,7 @@ requireText(
   "Inventory admin request could not be completed",
   `${paths.doc}: static public message`,
 );
+requireText(doc, "unit variant", `${paths.doc}: fail-closed construction`);
 requireText(
   inventoryPlan,
   "Admin client transport error safety: `source_ready_unvalidated`",


### PR DESCRIPTION
## Summary
- close the remaining raw `ServerFnError::to_string()` leak in the public Inventory Admin client transport facade
- cover all eight native-only Inventory Admin read/write operations
- create a per-call error context after existing request normalization and before the unchanged native adapter call
- retain the original `ServerFnError` only in structured diagnostics
- record owner operation, correlation id, stable code, boundary, and safe request presence/length shape only
- return one static public message: `Inventory admin request could not be completed`
- make `InventoryTransportError::ServerFn` a unit variant so callers cannot attach a raw public string payload
- preserve mounted server functions, authentication/tenant/permission policy, request builders, invocation order, DTOs, and native-only transport selection
- add source evidence, documentation, local plan registration, and a focused fail-closed verifier

## Covered operations
- `fetch_bootstrap`
- `fetch_products`
- `fetch_product`
- `set_variant_quantity`
- `adjust_variant_quantity`
- `reserve_variant_quantity`
- `check_variant_availability`
- `release_reservation_quantity`

## Confirmed gap
The facade previously implemented `From<ServerFnError>` as `InventoryTransportError::ServerFn(value.to_string())`, and every operation used `.map_err(Into::into)`. Framework, transport, serialization, or unexpected server-function text could therefore become the displayed UI error even though the mounted native endpoint already attempted to provide static owner envelopes.

## Boundary placement
Each facade operation now builds its context from the already normalized request and maps only a final returned `ServerFnError`. The native server adapter is unchanged. No retry, fallback, endpoint, owner call, normalization, authorization, quantity policy, or response mapping was added or reordered.

## Diagnostics
The mapper retains only safe shape fields:
- tenant/subject/locale/search/status presence and character lengths
- numeric-input presence without quantity, adjustment, or requested quantity values

Tenant, product, variant, locale, search, status, and numeric values are not logged by the client transport mapper.

## Recheck findings
- the previous mounted native endpoint error-safety policy remains unchanged
- all eight facade functions use the distinct context-aware mapper
- the old `From<ServerFnError>` and `.map_err(Into::into)` paths are removed
- the public error variant has no string payload
- the broad ecommerce mapper-cleanup plan item remains open for other owners and non-`PortError` envelopes

`main` advanced by one unrelated Comments source-gate commit while this branch was prepared. The branch is one commit behind, and the compare contains only the seven Inventory source/evidence files.

## Validation
Per maintainer instruction, tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run. Evidence remains source-ready / unvalidated and does not promote Inventory FFA/FBA, hydrate, SSR, browser, mounted runtime, workflow, CI, or production status.

Suggested maintainer commands:
```bash
node scripts/verify/verify-inventory-admin-client-transport-error-safety.mjs
node scripts/verify/verify-inventory-admin-native-error-safety.mjs
npm run verify:inventory:admin-boundary
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-inventory-admin
cargo check -p rustok-inventory-admin --features hydrate
cargo check -p rustok-inventory-admin --features ssr
```