### PR TITLE
fix(customer): sanitize admin client transport errors

### DIFF
--- a/crates/rustok-customer/admin/src/transport/error_safety.rs
+++ b/crates/rustok-customer/admin/src/transport/error_safety.rs
@@ -1,0 +1,103 @@
+use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const CUSTOMER_ADMIN_CLIENT_OWNER: &str = "rustok_customer.admin";
+const CUSTOMER_ADMIN_CLIENT_BOUNDARY: &str = "customer_admin_client_transport";
+const CUSTOMER_ADMIN_CLIENT_PUBLIC_MESSAGE: &str =
+    "Customer admin request could not be completed";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ApiError {
+    ServerFn,
+}
+
+impl Display for ApiError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ServerFn => f.write_str(CUSTOMER_ADMIN_CLIENT_PUBLIC_MESSAGE),
+        }
+    }
+}
+
+impl std::error::Error for ApiError {}
+
+pub(super) struct CustomerAdminTransportErrorContext {
+    operation: &'static str,
+    correlation_id: String,
+    subject_id_length: Option<usize>,
+    search_length: Option<usize>,
+    pagination_present: bool,
+    payload_present: bool,
+}
+
+impl CustomerAdminTransportErrorContext {
+    pub(super) fn for_bootstrap() -> Self {
+        Self::new("fetch_bootstrap")
+    }
+
+    pub(super) fn for_customers(search: &str) -> Self {
+        let mut context = Self::new("fetch_customers");
+        context.search_length = Some(search.chars().count());
+        context.pagination_present = true;
+        context
+    }
+
+    pub(super) fn for_customer_detail(customer_id: &str) -> Self {
+        let mut context = Self::new("fetch_customer_detail");
+        context.subject_id_length = Some(customer_id.chars().count());
+        context
+    }
+
+    pub(super) fn for_create_customer() -> Self {
+        let mut context = Self::new("create_customer");
+        context.payload_present = true;
+        context
+    }
+
+    pub(super) fn for_update_customer(customer_id: &str) -> Self {
+        let mut context = Self::new("update_customer");
+        context.subject_id_length = Some(customer_id.chars().count());
+        context.payload_present = true;
+        context
+    }
+
+    fn new(operation: &'static str) -> Self {
+        Self {
+            operation,
+            correlation_id: customer_admin_client_correlation_id(operation),
+            subject_id_length: None,
+            search_length: None,
+            pagination_present: false,
+            payload_present: false,
+        }
+    }
+
+    pub(super) fn map_error<E: std::fmt::Debug>(&self, error: E) -> ApiError {
+        tracing::error!(
+            raw_error = ?error,
+            owner = CUSTOMER_ADMIN_CLIENT_OWNER,
+            owner_operation = self.operation,
+            correlation_id = %self.correlation_id,
+            subject_id_present = self.subject_id_length.is_some(),
+            subject_id_length = ?self.subject_id_length,
+            search_present = self.search_length.is_some(),
+            search_length = ?self.search_length,
+            pagination_present = self.pagination_present,
+            payload_present = self.payload_present,
+            code = "customer.admin_client_transport_failed",
+            boundary = CUSTOMER_ADMIN_CLIENT_BOUNDARY,
+            "customer admin client transport request failed"
+        );
+
+        ApiError::ServerFn
+    }
+}
+
+fn customer_admin_client_correlation_id(operation: &'static str) -> String {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("customer-admin-client:{operation}:{timestamp}")
+}

--- a/crates/rustok-customer/admin/src/transport/mod.rs
+++ b/crates/rustok-customer/admin/src/transport/mod.rs
@@ -1,12 +1,17 @@
+mod error_safety;
 mod native_server_adapter;
 
-pub use native_server_adapter::ApiError;
+pub use error_safety::ApiError;
 
 use crate::model::{CustomerAdminBootstrap, CustomerDetail, CustomerDraft, CustomerList};
+use error_safety::CustomerAdminTransportErrorContext;
 use native_server_adapter as native;
 
 pub async fn fetch_bootstrap() -> Result<CustomerAdminBootstrap, ApiError> {
-    native::fetch_bootstrap().await
+    let context = CustomerAdminTransportErrorContext::for_bootstrap();
+    native::fetch_bootstrap()
+        .await
+        .map_err(|server_error| context.map_error(server_error))
 }
 
 pub async fn fetch_customers(
@@ -14,20 +19,33 @@ pub async fn fetch_customers(
     page: u64,
     per_page: u64,
 ) -> Result<CustomerList, ApiError> {
-    native::fetch_customers(search, page, per_page).await
+    let context = CustomerAdminTransportErrorContext::for_customers(search.as_str());
+    native::fetch_customers(search, page, per_page)
+        .await
+        .map_err(|server_error| context.map_error(server_error))
 }
 
 pub async fn fetch_customer_detail(customer_id: String) -> Result<CustomerDetail, ApiError> {
-    native::fetch_customer_detail(customer_id).await
+    let context =
+        CustomerAdminTransportErrorContext::for_customer_detail(customer_id.as_str());
+    native::fetch_customer_detail(customer_id)
+        .await
+        .map_err(|server_error| context.map_error(server_error))
 }
 
 pub async fn create_customer(payload: CustomerDraft) -> Result<CustomerDetail, ApiError> {
-    native::create_customer(payload).await
+    let context = CustomerAdminTransportErrorContext::for_create_customer();
+    native::create_customer(payload)
+        .await
+        .map_err(|server_error| context.map_error(server_error))
 }
 
 pub async fn update_customer(
     customer_id: String,
     payload: CustomerDraft,
 ) -> Result<CustomerDetail, ApiError> {
-    native::update_customer(customer_id, payload).await
+    let context = CustomerAdminTransportErrorContext::for_update_customer(customer_id.as_str());
+    native::update_customer(customer_id, payload)
+        .await
+        .map_err(|server_error| context.map_error(server_error))
 }

--- a/crates/rustok-customer/contracts/evidence/admin-client-transport-error-safety-source-review.json
+++ b/crates/rustok-customer/contracts/evidence/admin-client-transport-error-safety-source-review.json
@@ -1,0 +1,26 @@
+{
+  "status": "customer_admin_client_transport_error_safety_source_reviewed_unvalidated",
+  "reviewed_at": "2026-07-30",
+  "review_scope": [
+    "crates/rustok-customer/admin/src/transport/mod.rs",
+    "crates/rustok-customer/admin/src/transport/error_safety.rs",
+    "crates/rustok-customer/admin/src/transport/native_server_adapter.rs"
+  ],
+  "findings": {
+    "private_native_error_reexport_removed": true,
+    "five_facade_operations_mapped": true,
+    "native_server_adapter_unchanged": true,
+    "request_response_dtos_preserved": true,
+    "public_error_has_no_string_payload": true,
+    "static_public_message_preserved_across_operations": true,
+    "original_error_private_to_structured_diagnostics": true,
+    "safe_shape_logging_only": true,
+    "broad_ecommerce_mapper_cleanup_remains_open": true
+  },
+  "non_claims": [
+    "No test or verifier was executed",
+    "No Cargo compilation was executed",
+    "No browser or mounted server-function failure was exercised",
+    "No Customer FFA or FBA status was promoted"
+  ]
+}

--- a/crates/rustok-customer/contracts/evidence/admin-client-transport-error-safety-source.json
+++ b/crates/rustok-customer/contracts/evidence/admin-client-transport-error-safety-source.json
@@ -1,0 +1,53 @@
+{
+  "status": "customer_admin_client_transport_error_safety_source_unvalidated",
+  "reviewed_at": "2026-07-30",
+  "boundary": "customer_admin_client_transport",
+  "public_error_type": "ApiError",
+  "public_message": "Customer admin request could not be completed",
+  "covered_operations": [
+    "fetch_bootstrap",
+    "fetch_customers",
+    "fetch_customer_detail",
+    "create_customer",
+    "update_customer"
+  ],
+  "confirmed_gap": {
+    "raw_server_fn_string_public": true,
+    "source_pattern": "native_server_adapter::ApiError::ServerFn(value.to_string())",
+    "context_free_mapping": "public facade returned private native ApiError unchanged"
+  },
+  "source_contract": {
+    "native_server_adapter_changed": false,
+    "server_functions_changed": false,
+    "request_response_dto_changed": false,
+    "operation_count": 5,
+    "context_created_before_native_call": true,
+    "private_native_error_reexported": false,
+    "public_error_string_payload": false,
+    "static_public_message": true,
+    "original_error_logged_privately": true,
+    "per_call_correlation_logging": true,
+    "safe_request_shape_only": true,
+    "customer_id_values_logged": false,
+    "search_values_logged": false,
+    "payload_values_logged": false,
+    "pagination_values_logged": false
+  },
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "hydrate_compile_proven": false,
+    "ssr_compile_proven": false,
+    "mounted_runtime_proven": false
+  },
+  "remaining": [
+    "Run the focused source verifier",
+    "Compile the customer admin package for default, hydrate, and ssr profiles",
+    "Retain mounted browser and server-function failure evidence",
+    "Continue the broad ecommerce mapper cleanup in other owners"
+  ]
+}

--- a/crates/rustok-customer/docs/admin-client-transport-error-safety.md
+++ b/crates/rustok-customer/docs/admin-client-transport-error-safety.md
@@ -1,0 +1,64 @@
+# Customer Admin client transport error safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This source slice covers the public Customer Admin transport facade in
+`crates/rustok-customer/admin/src/transport/mod.rs`.
+
+Covered operations:
+
+- `fetch_bootstrap`
+- `fetch_customers`
+- `fetch_customer_detail`
+- `create_customer`
+- `update_customer`
+
+## Confirmed gap
+
+The private native adapter converts `ServerFnError` into
+`ApiError::ServerFn(value.to_string())`. The public facade previously re-exported
+that private error type and returned it unchanged, so framework, transport,
+serialization, or unexpected server-function text could become UI-visible.
+
+## Source policy
+
+The facade now exports a separate public `ApiError` whose `ServerFn` variant has
+no string payload. Its `Display` implementation always returns:
+
+`Customer admin request could not be completed`
+
+Each facade operation creates a `CustomerAdminTransportErrorContext` before the
+unchanged native adapter call and maps only the final private native error.
+
+The original error remains only in structured diagnostics with:
+
+- owner, exact facade operation, correlation id, boundary, and stable code;
+- customer-id and search presence/character length;
+- pagination and payload presence without their values.
+
+Customer ids, search text, pagination values, email, names, phone, locale,
+metadata, and draft contents are not written by the client transport mapper.
+
+## Preserved behavior
+
+This slice does not change:
+
+- the private native adapter or mounted server-function endpoints;
+- authentication, tenant, permission, and profile-audience policy;
+- customer owner calls or request order;
+- request and response DTOs;
+- Customer Admin native-only transport selection.
+
+The existing server-side native policy remains independent and unchanged.
+
+## Evidence boundary
+
+The retained JSON evidence is source-only. Tests, focused verifiers, Cargo,
+formatting, workflows, CI, hydrate compilation, SSR compilation, browser behavior,
+and mounted runtime failure behavior were not executed by this implementation
+agent.
+
+The broad ecommerce mapper-cleanup item remains open for other owners and other
+non-`PortError` public envelopes.

--- a/crates/rustok-customer/docs/implementation-plan.md
+++ b/crates/rustok-customer/docs/implementation-plan.md
@@ -14,6 +14,8 @@ Canonical root `CustomerReadPort` construction now uses `InProcessCustomerReadPo
 
 The mounted customer-admin native bootstrap, list, detail, create, and update endpoints now use static public context and typed owner envelopes. Original framework, customer storage, and profile causes remain in bounded server diagnostics with per-call correlation, tenant, actor, optional customer, channel, locale, stable code, and boundary context. `RequestContext` remains diagnostic-only, so this source slice does not change operation admission or profile audience policy.
 
+The public customer-admin transport facade now applies a second fail-closed client boundary across the same five operations. It no longer re-exports the private native `ApiError::ServerFn(String)` type; the public `ApiError::ServerFn` has no payload and always displays `Customer admin request could not be completed`. The final private native error is retained only in structured client diagnostics with operation, correlation id, and bounded request-shape facts.
+
 ## FFA/FBA boundary
 
 - FFA status: `in_progress`
@@ -24,7 +26,8 @@ The mounted customer-admin native bootstrap, list, detail, create, and update en
 - Canonical root construction is `InProcessCustomerReadPort` / `in_process_customer_read_port`; `rustok_customer::ports` remains a compatibility path rather than the covered root entrypoint.
 - Static and source-locked runtime evidence: `crates/rustok-customer/contracts/evidence/customer-contract-test-static-matrix.json`, `crates/rustok-customer/contracts/evidence/customer-runtime-contract-smoke.json`, and `crates/rustok-customer/contracts/evidence/customer-read-projection-runtime-smoke.json`.
 - Customer-admin native error-safety source evidence is `crates/rustok-customer/contracts/evidence/admin-native-error-safety-source.json`; it remains explicitly unvalidated.
-- `scripts/verify/verify-customer-admin-boundary.mjs` locks the admin boundary; `node scripts/verify/verify-customer-admin-native-error-safety.mjs` locks the mounted static error envelopes; `node scripts/verify/verify-customer-fba-no-compile.mjs` locks no-compile provider metadata and promotion blockers; `node scripts/verify/verify-customer-read-local-context.mjs` locks canonical local context retention.
+- Admin client transport error safety: `source_ready_unvalidated`; evidence is `crates/rustok-customer/contracts/evidence/admin-client-transport-error-safety-source.json` with reviewed source handoff in `crates/rustok-customer/contracts/evidence/admin-client-transport-error-safety-source-review.json`.
+- `scripts/verify/verify-customer-admin-boundary.mjs` locks the admin boundary; `node scripts/verify/verify-customer-admin-native-error-safety.mjs` locks the mounted static error envelopes; `node scripts/verify/verify-customer-admin-client-transport-error-safety.mjs` locks the final payload-free client envelope; `node scripts/verify/verify-customer-fba-no-compile.mjs` locks no-compile provider metadata and promotion blockers; `node scripts/verify/verify-customer-read-local-context.mjs` locks canonical local context retention.
 
 ## Open results
 
@@ -55,14 +58,22 @@ The mounted customer-admin native bootstrap, list, detail, create, and update en
    **Remaining evidence:** run `verify-customer-admin-native-error-safety.mjs`, compile `rustok-customer-admin` with `ssr`, exercise all five endpoints against validation, not-found, duplicate, profile, and database failures, and retain server logs proving correlation without customer/profile payload leakage.
    **Done when:** source guard, compile, runtime envelope, tenant isolation, profile audience, restart, and remote-profile evidence are retained without promoting FFA/FBA from source inspection alone.
 
+6. **Validate the customer-admin final client transport envelope.**
+   **Status:** source-ready / unvalidated. The public facade maps every private native error through a per-call context and exposes only a payload-free `ApiError` with one static message.
+   **Remaining evidence:** run `verify-customer-admin-client-transport-error-safety.mjs`, compile default/hydrate/ssr profiles, and retain browser plus mounted failures proving the raw private native string never reaches the rendered admin error.
+   **Done when:** all five operations preserve their successful DTOs and server-side domain policy while framework and unexpected transport text remains private across serialization and display.
+
 ## Verification
 
 - `npm run verify:customer:admin-boundary`
 - `node scripts/verify/verify-customer-admin-native-error-safety.mjs`
+- `node scripts/verify/verify-customer-admin-client-transport-error-safety.mjs`
 - `node scripts/verify/verify-customer-read-local-context.mjs`
 - `node scripts/verify/verify-customer-read-policy-context.mjs`
 - `node scripts/verify/verify-customer-fba-no-compile.mjs`
 - `npm run verify:ecommerce:fba`
+- `cargo check -p rustok-customer-admin`
+- `cargo check -p rustok-customer-admin --features hydrate`
 - `cargo check -p rustok-customer-admin --features ssr`
 - `cargo xtask module validate customer`
 - `cargo xtask module test customer`

--- a/scripts/verify/verify-customer-admin-client-transport-error-safety.mjs
+++ b/scripts/verify/verify-customer-admin-client-transport-error-safety.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const requireCount = (source, value, expected, label) => {
+  const count = source.split(value).length - 1;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+};
+const between = (source, start, end, label) => {
+  const from = source.indexOf(start);
+  const to = source.indexOf(end, from + start.length);
+  if (from < 0 || to < 0) {
+    failures.push(`${label}: could not isolate ${start} before ${end}`);
+    return "";
+  }
+  return source.slice(from, to);
+};
+
+const paths = {
+  facade: "crates/rustok-customer/admin/src/transport/mod.rs",
+  safety: "crates/rustok-customer/admin/src/transport/error_safety.rs",
+  native: "crates/rustok-customer/admin/src/transport/native_server_adapter.rs",
+  evidence:
+    "crates/rustok-customer/contracts/evidence/admin-client-transport-error-safety-source.json",
+  review:
+    "crates/rustok-customer/contracts/evidence/admin-client-transport-error-safety-source-review.json",
+  doc: "crates/rustok-customer/docs/admin-client-transport-error-safety.md",
+  customerPlan: "crates/rustok-customer/docs/implementation-plan.md",
+  commercePlan: "crates/rustok-commerce/docs/implementation-plan.md",
+  nativeGuard: "scripts/verify/verify-customer-admin-native-error-safety.mjs",
+};
+
+const facade = read(paths.facade);
+const safety = read(paths.safety);
+const native = read(paths.native);
+const evidence = JSON.parse(read(paths.evidence));
+const review = JSON.parse(read(paths.review));
+const doc = read(paths.doc);
+const customerPlan = read(paths.customerPlan);
+const commercePlan = read(paths.commercePlan);
+const nativeGuard = read(paths.nativeGuard);
+
+for (const marker of [
+  "mod error_safety;",
+  "mod native_server_adapter;",
+  "pub use error_safety::ApiError;",
+  "use error_safety::CustomerAdminTransportErrorContext;",
+]) {
+  requireText(facade, marker, `${paths.facade}: client safety wiring`);
+}
+
+for (const forbidden of [
+  "pub use native_server_adapter::ApiError;",
+  ".map_err(Into::into)",
+  "ApiError::ServerFn(value.to_string())",
+]) {
+  forbidText(facade, forbidden, `${paths.facade}: private native error escape`);
+}
+
+requireCount(
+  facade,
+  ".map_err(|server_error| context.map_error(server_error))",
+  5,
+  `${paths.facade}: context-aware final mappings`,
+);
+
+const operations = [
+  ["fetch_bootstrap", "for_bootstrap", "native::fetch_bootstrap("],
+  ["fetch_customers", "for_customers", "native::fetch_customers("],
+  [
+    "fetch_customer_detail",
+    "for_customer_detail",
+    "native::fetch_customer_detail(",
+  ],
+  ["create_customer", "for_create_customer", "native::create_customer("],
+  ["update_customer", "for_update_customer", "native::update_customer("],
+];
+
+for (let index = 0; index < operations.length; index += 1) {
+  const [operation, constructor, call] = operations[index];
+  const start = `pub async fn ${operation}(`;
+  const end =
+    index + 1 < operations.length
+      ? `pub async fn ${operations[index + 1][0]}(`
+      : null;
+  const from = facade.indexOf(start);
+  const block =
+    end === null
+      ? from < 0
+        ? ""
+        : facade.slice(from)
+      : between(facade, start, end, `${paths.facade}: ${operation}`);
+  if (from < 0) failures.push(`${paths.facade}: missing ${start}`);
+  requireText(
+    block,
+    `CustomerAdminTransportErrorContext::${constructor}`,
+    `${paths.facade}: ${operation} context`,
+  );
+  requireText(block, call, `${paths.facade}: ${operation} native call`);
+  requireText(
+    block,
+    ".map_err(|server_error| context.map_error(server_error))",
+    `${paths.facade}: ${operation} mapping`,
+  );
+  const contextIndex = block.indexOf(
+    `CustomerAdminTransportErrorContext::${constructor}`,
+  );
+  const callIndex = block.indexOf(call);
+  if (contextIndex < 0 || callIndex < 0 || contextIndex > callIndex) {
+    failures.push(`${paths.facade}: ${operation} context must precede native call`);
+  }
+}
+
+for (const marker of [
+  'const CUSTOMER_ADMIN_CLIENT_OWNER: &str = "rustok_customer.admin";',
+  'const CUSTOMER_ADMIN_CLIENT_BOUNDARY: &str = "customer_admin_client_transport";',
+  '"Customer admin request could not be completed"',
+  "pub enum ApiError {",
+  "ServerFn,",
+  "Self::ServerFn => f.write_str(CUSTOMER_ADMIN_CLIENT_PUBLIC_MESSAGE)",
+  "pub(super) struct CustomerAdminTransportErrorContext",
+  "raw_error = ?error",
+  "owner_operation = self.operation",
+  "correlation_id = %self.correlation_id",
+  "subject_id_present = self.subject_id_length.is_some()",
+  "search_present = self.search_length.is_some()",
+  "pagination_present = self.pagination_present",
+  "payload_present = self.payload_present",
+  'code = "customer.admin_client_transport_failed"',
+  "boundary = CUSTOMER_ADMIN_CLIENT_BOUNDARY",
+  "ApiError::ServerFn",
+]) {
+  requireText(safety, marker, `${paths.safety}: fail-closed client mapping`);
+}
+
+for (const forbidden of [
+  "ServerFn(String)",
+  "ApiError::ServerFn(",
+  "customer_id = %",
+  "search = %",
+  "email = %",
+  "payload = ?",
+  "page =",
+  "per_page =",
+  "error.to_string()",
+]) {
+  forbidText(safety, forbidden, `${paths.safety}: public payload or raw request value`);
+}
+
+for (const operation of operations.map(([name]) => name)) {
+  requireText(safety, `"${operation}"`, `${paths.safety}: stable operation ${operation}`);
+}
+
+for (const marker of [
+  "pub enum ApiError",
+  "ServerFn(String)",
+  "Self::ServerFn(value.to_string())",
+  ".map_err(Into::into)",
+  'endpoint = "customer/bootstrap"',
+  'endpoint = "customer/list"',
+  'endpoint = "customer/detail"',
+  'endpoint = "customer/create"',
+  'endpoint = "customer/update"',
+]) {
+  requireText(native, marker, `${paths.native}: private compatibility source preserved`);
+}
+
+requireText(
+  nativeGuard,
+  "customer admin native transport uses static public envelopes",
+  `${paths.nativeGuard}: prior server-side policy remains registered`,
+);
+
+if (evidence.status !== "customer_admin_client_transport_error_safety_source_unvalidated") {
+  failures.push(`${paths.evidence}: unexpected status ${evidence.status}`);
+}
+if (
+  review.status !==
+  "customer_admin_client_transport_error_safety_source_reviewed_unvalidated"
+) {
+  failures.push(`${paths.review}: unexpected status ${review.status}`);
+}
+
+for (const [key, expected] of Object.entries({
+  native_server_adapter_changed: false,
+  server_functions_changed: false,
+  request_response_dto_changed: false,
+  operation_count: 5,
+  context_created_before_native_call: true,
+  private_native_error_reexported: false,
+  public_error_string_payload: false,
+  static_public_message: true,
+  original_error_logged_privately: true,
+  per_call_correlation_logging: true,
+  safe_request_shape_only: true,
+  customer_id_values_logged: false,
+  search_values_logged: false,
+  payload_values_logged: false,
+  pagination_values_logged: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "hydrate_compile_proven",
+  "ssr_compile_proven",
+  "mounted_runtime_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+
+requireText(doc, "Status: **source-ready / unvalidated**", `${paths.doc}: status`);
+requireText(doc, "Customer admin request could not be completed", `${paths.doc}: public message`);
+requireText(
+  customerPlan,
+  "Admin client transport error safety: `source_ready_unvalidated`",
+  `${paths.customerPlan}: local status`,
+);
+requireText(
+  customerPlan,
+  "verify-customer-admin-client-transport-error-safety.mjs",
+  `${paths.customerPlan}: local verifier`,
+);
+requireText(
+  commercePlan,
+  "Finish correlation-safe mapper cleanup",
+  `${paths.commercePlan}: broad ecommerce cleanup remains open`,
+);
+
+if (failures.length > 0) {
+  console.error("Customer Admin client transport error-safety verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "Customer Admin client transport errors use a payload-free static public envelope across five native operations; execution evidence remains open",
+);


### PR DESCRIPTION
## Summary
- close the raw private `ServerFnError` string escape at the public Customer Admin transport facade
- cover bootstrap, list, detail, create, and update operations
- stop re-exporting the private native `ApiError::ServerFn(String)` type
- add a public payload-free `ApiError::ServerFn` whose `Display` always returns `Customer admin request could not be completed`
- create a per-call client transport context before each unchanged native adapter call
- retain the private native error only in structured diagnostics
- record operation, correlation id, stable code, boundary, customer/search length shape, pagination presence, and payload presence only
- preserve the private native adapter, mounted endpoints, owner calls, authentication, tenant, permission, profile-audience policy, DTOs, and native-only transport selection
- add source evidence, documentation, local plan registration, and a focused fail-closed verifier

## Covered operations
- `fetch_bootstrap`
- `fetch_customers`
- `fetch_customer_detail`
- `create_customer`
- `update_customer`

## Confirmed gap
The private native adapter converts `ServerFnError` into `ApiError::ServerFn(value.to_string())`. The public facade previously re-exported that type and returned it unchanged, allowing framework, transport, serialization, or unexpected server-function text to become the displayed admin error despite the existing server-side static owner envelopes.

## Boundary placement
The private native compatibility type and all server functions are unchanged. The public facade now exports a separate error type and maps only the final private native error. No retry, fallback, endpoint, request, owner call, authorization, profile audience, normalization, or response mapping was added or reordered.

## Diagnostics
The client mapper records only customer/search presence and character lengths plus pagination/payload presence. Customer ids, search text, page/per-page values, email, names, phone, locale, metadata, and draft contents are not logged by this boundary.

## Recheck findings
- all five public facade functions create their context before the native call
- successful call signatures and DTOs are unchanged
- the private raw-string error is no longer re-exported
- the public error variant has no string payload
- the existing mounted native error-safety policy and verifier remain unchanged
- the broad ecommerce mapper-cleanup item remains open for other owners and non-`PortError` envelopes

`main` advanced by two unrelated README/merge commits while this branch was prepared. The compare contains only the seven Customer source/evidence files and no overlapping changes.

## Validation
Per maintainer instruction, tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run. Evidence remains source-ready / unvalidated and does not promote Customer FFA/FBA, hydrate, SSR, browser, mounted runtime, workflow, CI, or production status.

Suggested maintainer commands:
```bash
node scripts/verify/verify-customer-admin-client-transport-error-safety.mjs
node scripts/verify/verify-customer-admin-native-error-safety.mjs
npm run verify:customer:admin-boundary
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-customer-admin
cargo check -p rustok-customer-admin --features hydrate
cargo check -p rustok-customer-admin --features ssr
```