### PR TITLE
feat(index): add SalesChannel replay source

### DIFF
--- a/crates/rustok-channel/README.md
+++ b/crates/rustok-channel/README.md
@@ -16,6 +16,9 @@
 - Back the shared request-level `ChannelContext` used by host transport layers.
 - Own the domain resolution pipeline (`RequestFacts -> ResolutionDecision`) that host middleware applies.
 - Own the durable database generation used to recover channel-resolution caches across serving replicas.
+- Own a positive monotonic `channels.index_revision` storage column. Every Channel update advances it exactly once; the value remains storage-internal and is not exposed through Channel DTOs or the SeaORM write model.
+- Publish only a neutral `ChannelRuntimeSelected` marker for selected cross-module composition. The Channel crate does not depend on `rustok-index` and does not construct generic Index mutations.
+- The selected `rustok-distribution` bridge publishes the non-localized `rustok-channel::sales_channel@1` schema and a bounded current-state source. Replay enumeration uses stable `channel_id` ordering, while `index_revision` is used only as generic mutation `source_version`. Hard-delete tombstones, versioned Product links, and authoritative consumer cutover remain later slices.
 - Ship the module-owned Leptos admin UI package for channel management.
 - Expose `ChannelReadPort` / `channel.read_projection.v1` as the FBA provider boundary for channel/default/host-target read projections, with deadline-aware read semantics and no-compile executable fallback smoke evidence until executable runtime smoke is available.
 
@@ -70,12 +73,14 @@ It does not yet provide:
 - `rustok-cache` supplies bounded invalidation transport; Redis PubSub is an acceleration path rather than the durable source of truth.
 - `rustok-api` hosts the shared `ChannelContext` and request-level contracts.
 - `rustok-auth` remains the source of truth for OAuth applications and tokens.
+- `rustok-distribution` consumes the neutral selection marker and Channel-owned table contract to publish generic SalesChannel Index schema/source capabilities; Index core and server remain Channel-agnostic.
 - Domain modules may gradually become channel-aware by reading channel context or channel bindings.
 - The Leptos admin UI lives in `crates/rustok-channel/admin` and is mounted by `apps/admin` through manifest-driven wiring.
 
 ## Entry points
 
 - `ChannelModule`
+- `ChannelRuntimeSelected`
 - `ChannelResolver`
 - `ChannelService`
 - `read_resolution_invalidation_generation`
@@ -92,4 +97,5 @@ It does not yet provide:
 
 - [Module docs](./docs/README.md)
 - [Implementation plan](./docs/implementation-plan.md)
+- [M7 SalesChannel Index source contract](../rustok-index/docs/m7-sales-channel-source.md)
 - [Platform docs index](../../docs/index.md)

--- a/crates/rustok-channel/src/lib.rs
+++ b/crates/rustok-channel/src/lib.rs
@@ -38,8 +38,15 @@ pub use services::ChannelService;
 pub use target_type::ChannelTargetType;
 
 use async_trait::async_trait;
-use rustok_core::module::{HealthStatus, MigrationSource, ModuleKind, RusToKModule};
+use rustok_core::{
+    ModuleRuntimeExtensions,
+    module::{HealthStatus, MigrationSource, ModuleKind, RusToKModule},
+};
 use sea_orm_migration::MigrationTrait;
+
+/// Typed marker proving that `ChannelModule` participated in runtime extension registration.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ChannelRuntimeSelected;
 
 pub struct ChannelModule;
 
@@ -73,6 +80,14 @@ impl RusToKModule for ChannelModule {
 
     fn kind(&self) -> ModuleKind {
         ModuleKind::Core
+    }
+
+    fn register_runtime_extensions(
+        &self,
+        extensions: &mut ModuleRuntimeExtensions,
+    ) -> rustok_core::Result<()> {
+        extensions.insert(ChannelRuntimeSelected);
+        Ok(())
     }
 
     async fn health(&self) -> HealthStatus {

--- a/crates/rustok-channel/src/migrations/m20260730_000010_add_channel_index_revision.rs
+++ b/crates/rustok-channel/src/migrations/m20260730_000010_add_channel_index_revision.rs
@@ -1,0 +1,69 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::DatabaseBackend;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() != DatabaseBackend::Postgres {
+            return Err(DbErr::Custom(
+                "rustok-channel migrations require PostgreSQL".to_owned(),
+            ));
+        }
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+ALTER TABLE channels
+    ADD COLUMN index_revision BIGINT NOT NULL DEFAULT 1,
+    ADD CONSTRAINT chk_channels_index_revision_positive CHECK (index_revision > 0);
+
+CREATE OR REPLACE FUNCTION rustok_channel_bump_index_revision()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.index_revision = 9223372036854775807 THEN
+        RAISE EXCEPTION 'channel index revision exhausted for channel %', OLD.id;
+    END IF;
+    NEW.index_revision := OLD.index_revision + 1;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_channels_bump_index_revision
+BEFORE UPDATE ON channels
+FOR EACH ROW
+EXECUTE FUNCTION rustok_channel_bump_index_revision();
+"#,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() != DatabaseBackend::Postgres {
+            return Err(DbErr::Custom(
+                "rustok-channel migrations require PostgreSQL".to_owned(),
+            ));
+        }
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+DROP TRIGGER IF EXISTS trg_channels_bump_index_revision ON channels;
+DROP FUNCTION IF EXISTS rustok_channel_bump_index_revision();
+ALTER TABLE channels
+    DROP CONSTRAINT IF EXISTS chk_channels_index_revision_positive,
+    DROP COLUMN IF EXISTS index_revision;
+"#,
+            )
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/rustok-channel/src/migrations/mod.rs
+++ b/crates/rustok-channel/src/migrations/mod.rs
@@ -9,6 +9,7 @@ mod m20260327_000006_add_channels_is_default;
 mod m20260327_000007_create_channel_resolution_policy_sets;
 mod m20260327_000008_create_channel_resolution_policy_rules;
 mod m20260716_000009_create_channel_resolution_invalidation_state;
+mod m20260730_000010_add_channel_index_revision;
 
 use rustok_core::MigrationDependencyDescriptor;
 use sea_orm_migration::MigrationTrait;
@@ -24,6 +25,7 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260327_000007_create_channel_resolution_policy_sets::Migration),
         Box::new(m20260327_000008_create_channel_resolution_policy_rules::Migration),
         Box::new(m20260716_000009_create_channel_resolution_invalidation_state::Migration),
+        Box::new(m20260730_000010_add_channel_index_revision::Migration),
     ]
 }
 

--- a/crates/rustok-channel/tests/index_selection.rs
+++ b/crates/rustok-channel/tests/index_selection.rs
@@ -1,0 +1,15 @@
+use rustok_channel::{ChannelModule, ChannelRuntimeSelected};
+use rustok_core::{ModuleRuntimeExtensions, RusToKModule};
+
+#[test]
+fn channel_module_publishes_only_a_typed_selection_marker_for_index_bridges() {
+    let mut extensions = ModuleRuntimeExtensions::default();
+    ChannelModule
+        .register_runtime_extensions(&mut extensions)
+        .expect("Channel runtime marker registration should succeed");
+
+    assert!(extensions.contains::<ChannelRuntimeSelected>());
+    let cargo = include_str!("../Cargo.toml");
+    assert!(!cargo.contains("rustok-index"));
+    assert!(!cargo.contains("register_index_schema_source"));
+}

--- a/crates/rustok-distribution/src/channel_index.rs
+++ b/crates/rustok-distribution/src/channel_index.rs
@@ -76,6 +76,7 @@ fn sales_channel_schema() -> Result<IndexSchema, SalesChannelIndexBridgeError> {
             .map_err(SalesChannelIndexBridgeError::InvalidContract)?,
         locale_mode: LocaleMode::None,
         fields: vec![
+            field("id", IndexValueType::Uuid, true, true)?,
             field("slug", IndexValueType::String, true, true)?,
             field("name", IndexValueType::String, true, true)?,
             field("is_active", IndexValueType::Boolean, true, true)?,
@@ -355,6 +356,7 @@ impl SalesChannelRow {
         )
         .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
         let fields = BTreeMap::from([
+            (field_name("id")?, IndexValue::Uuid(self.channel_id)),
             (field_name("slug")?, IndexValue::String(self.slug)),
             (field_name("name")?, IndexValue::String(self.name)),
             (field_name("is_active")?, IndexValue::Boolean(self.is_active)),
@@ -417,8 +419,12 @@ mod tests {
         let schema = sales_channel_schema().unwrap();
         assert_eq!(schema.reference, sales_channel_schema_ref().unwrap());
         assert_eq!(schema.locale_mode, LocaleMode::None);
-        assert_eq!(schema.fields.len(), 5);
+        assert_eq!(schema.fields.len(), 6);
         assert!(schema.links.is_empty());
+        assert!(schema
+            .fields
+            .iter()
+            .any(|field| field.name.as_str() == "id"));
         assert!(schema
             .fields
             .iter()

--- a/crates/rustok-distribution/src/channel_index.rs
+++ b/crates/rustok-distribution/src/channel_index.rs
@@ -1,0 +1,481 @@
+use std::collections::BTreeMap;
+
+use async_trait::async_trait;
+use rustok_core::ModuleRuntimeExtensions;
+use rustok_index::{
+    DomainError, EntityKey, EntityName, FieldCardinality, FieldName, IndexField, IndexMutation,
+    IndexRecord, IndexSchema, IndexSource, IndexSourceCursor, IndexSourceFailure,
+    IndexSourceLoadBatch, IndexSourceLoadRequest, IndexSourcePage, IndexSourceScanRequest,
+    IndexValue, IndexValueType, LocaleMode, ModuleName, PostgresIndexSourceFactory, SchemaRef,
+    SchemaVersion, derive_index_source_event_id, register_index_schema_source,
+    register_index_source, register_postgres_index_source_factory,
+};
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, QueryResult, Statement, Value};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use uuid::Uuid;
+
+pub(crate) const SALES_CHANNEL_INDEX_SOURCE: &str = "sales-channel-postgres-primary";
+const SALES_CHANNEL_INDEX_FACTORY: &str = "sales-channel-postgres-primary";
+const SALES_CHANNEL_EVENT_DOMAIN: &str = "rustok-channel.sales-channel-replay-v1";
+
+const SALES_CHANNEL_SELECT: &str = r#"
+SELECT
+    c.tenant_id,
+    c.id AS channel_id,
+    c.index_revision,
+    c.slug,
+    c.name,
+    c.is_active,
+    c.is_default,
+    c.status
+FROM channels c
+"#;
+
+#[derive(Debug, Error)]
+enum SalesChannelIndexBridgeError {
+    #[error("SalesChannel Index contract is invalid")]
+    InvalidContract(#[source] DomainError),
+    #[error("SalesChannel Index cursor is invalid")]
+    InvalidCursor,
+    #[error("SalesChannel Index source row is invalid")]
+    InvalidRow,
+}
+
+pub(crate) fn register(extensions: &mut ModuleRuntimeExtensions) -> rustok_core::Result<()> {
+    if !extensions.contains::<rustok_channel::ChannelRuntimeSelected>() {
+        return Ok(());
+    }
+
+    let schema = sales_channel_schema().map_err(|error| {
+        rustok_core::Error::Validation(format!(
+            "selected SalesChannel Index schema construction failed: {error}"
+        ))
+    })?;
+    register_index_schema_source(extensions, "channel", schema).map_err(|error| {
+        rustok_core::Error::Validation(format!(
+            "selected SalesChannel Index schema registration failed: {error}"
+        ))
+    })?;
+    register_postgres_index_source_factory(
+        extensions,
+        "channel",
+        SALES_CHANNEL_INDEX_FACTORY,
+        SalesChannelPostgresIndexSourceFactory,
+    )
+    .map_err(|error| {
+        rustok_core::Error::Validation(format!(
+            "selected SalesChannel Index source factory registration failed: {error}"
+        ))
+    })
+}
+
+fn sales_channel_schema() -> Result<IndexSchema, SalesChannelIndexBridgeError> {
+    let schema = IndexSchema {
+        reference: sales_channel_schema_ref()
+            .map_err(SalesChannelIndexBridgeError::InvalidContract)?,
+        locale_mode: LocaleMode::None,
+        fields: vec![
+            field("slug", IndexValueType::String, true, true)?,
+            field("name", IndexValueType::String, true, true)?,
+            field("is_active", IndexValueType::Boolean, true, true)?,
+            field("is_default", IndexValueType::Boolean, true, true)?,
+            field("status", IndexValueType::String, true, true)?,
+        ],
+        links: Vec::new(),
+    };
+    schema
+        .validate()
+        .map_err(SalesChannelIndexBridgeError::InvalidContract)?;
+    Ok(schema)
+}
+
+fn sales_channel_schema_ref() -> Result<SchemaRef, DomainError> {
+    Ok(SchemaRef {
+        module: ModuleName::new("rustok-channel")?,
+        entity: EntityName::new("sales_channel")?,
+        version: SchemaVersion::INITIAL,
+    })
+}
+
+fn field(
+    name: &str,
+    value_type: IndexValueType,
+    filterable: bool,
+    sortable: bool,
+) -> Result<IndexField, SalesChannelIndexBridgeError> {
+    Ok(IndexField {
+        name: FieldName::new(name).map_err(SalesChannelIndexBridgeError::InvalidContract)?,
+        value_type,
+        cardinality: FieldCardinality::One,
+        nullable: false,
+        selectable: true,
+        filterable,
+        sortable,
+    })
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SalesChannelPostgresIndexSourceFactory;
+
+impl PostgresIndexSourceFactory for SalesChannelPostgresIndexSourceFactory {
+    fn register_source(
+        &self,
+        extensions: &mut ModuleRuntimeExtensions,
+        db: DatabaseConnection,
+    ) -> Result<(), String> {
+        register_index_source(
+            extensions,
+            "channel",
+            SALES_CHANNEL_INDEX_SOURCE,
+            [sales_channel_schema_ref().map_err(|error| error.to_string())?],
+            SalesChannelPostgresIndexSource { db },
+        )
+        .map_err(|error| error.to_string())
+    }
+}
+
+#[derive(Clone, Debug)]
+struct SalesChannelPostgresIndexSource {
+    db: DatabaseConnection,
+}
+
+impl SalesChannelPostgresIndexSource {
+    fn validate_request(&self, schema: &SchemaRef) -> Result<(), IndexSourceFailure> {
+        if self.db.get_database_backend() != DbBackend::Postgres {
+            return Err(permanent("sales_channel_index_backend_unsupported"));
+        }
+        match sales_channel_schema_ref() {
+            Ok(expected) if &expected == schema => Ok(()),
+            Ok(_) => Err(permanent("sales_channel_index_schema_mismatch")),
+            Err(_) => Err(permanent("sales_channel_index_contract_invalid")),
+        }
+    }
+
+    async fn scan_rows(
+        &self,
+        request: &IndexSourceScanRequest,
+        cursor: Option<&SalesChannelCursor>,
+    ) -> Result<Vec<QueryResult>, IndexSourceFailure> {
+        let fetch_limit = i64::try_from(request.limit() + 1)
+            .expect("Index source page limit is bounded below i64::MAX");
+        let (sql, values): (String, Vec<Value>) = match cursor {
+            Some(cursor) => (
+                format!(
+                    "{SALES_CHANNEL_SELECT}\nWHERE c.tenant_id = $1\n  AND c.id > $2\nORDER BY c.id ASC\nLIMIT $3"
+                ),
+                vec![
+                    request.tenant_id().into(),
+                    cursor.channel_id.into(),
+                    fetch_limit.into(),
+                ],
+            ),
+            None => (
+                format!(
+                    "{SALES_CHANNEL_SELECT}\nWHERE c.tenant_id = $1\nORDER BY c.id ASC\nLIMIT $2"
+                ),
+                vec![request.tenant_id().into(), fetch_limit.into()],
+            ),
+        };
+        self.db
+            .query_all(Statement::from_sql_and_values(DbBackend::Postgres, sql, values))
+            .await
+            .map_err(|_| retryable("sales_channel_index_storage_unavailable"))
+    }
+
+    async fn load_rows(
+        &self,
+        request: &IndexSourceLoadRequest,
+    ) -> Result<Vec<QueryResult>, IndexSourceFailure> {
+        let mut values = Vec::<Value>::with_capacity(1 + request.keys().len());
+        values.push(request.tenant_id().into());
+        let mut rows = Vec::with_capacity(request.keys().len());
+        for (offset, key) in request.keys().iter().enumerate() {
+            if key.locale.is_some() {
+                return Err(permanent("sales_channel_index_locale_forbidden"));
+            }
+            let parameter = offset + 2;
+            rows.push(format!("(${parameter}::uuid)"));
+            values.push(key.entity_id.into());
+        }
+        let sql = format!(
+            "WITH requested(channel_id) AS (VALUES {})\n{SALES_CHANNEL_SELECT}\nJOIN requested r ON r.channel_id = c.id\nWHERE c.tenant_id = $1\nORDER BY c.id ASC",
+            rows.join(", ")
+        );
+        self.db
+            .query_all(Statement::from_sql_and_values(DbBackend::Postgres, sql, values))
+            .await
+            .map_err(|_| retryable("sales_channel_index_storage_unavailable"))
+    }
+}
+
+#[async_trait]
+impl IndexSource for SalesChannelPostgresIndexSource {
+    async fn scan(
+        &self,
+        request: IndexSourceScanRequest,
+    ) -> Result<IndexSourcePage, IndexSourceFailure> {
+        self.validate_request(request.schema())?;
+        let cursor = request
+            .cursor()
+            .map(SalesChannelCursor::decode)
+            .transpose()
+            .map_err(|_| permanent("sales_channel_index_cursor_invalid"))?;
+        let rows = self.scan_rows(&request, cursor.as_ref()).await?;
+        let has_more = rows.len() > request.limit();
+        let mut mutations = Vec::with_capacity(rows.len().min(request.limit()));
+        let mut next_cursor = None;
+        for row in rows.into_iter().take(request.limit()) {
+            let decoded = SalesChannelRow::decode(row, request.tenant_id())
+                .map_err(|_| permanent("sales_channel_index_record_invalid"))?;
+            if has_more {
+                next_cursor = Some(
+                    decoded
+                        .cursor()
+                        .encode()
+                        .map_err(|_| permanent("sales_channel_index_cursor_invalid"))?,
+                );
+            }
+            mutations.push(
+                decoded
+                    .into_mutation()
+                    .map_err(|_| permanent("sales_channel_index_record_invalid"))?,
+            );
+        }
+        IndexSourcePage::new(&request, mutations, next_cursor)
+            .map_err(|_| permanent("sales_channel_index_page_invalid"))
+    }
+
+    async fn load(
+        &self,
+        request: IndexSourceLoadRequest,
+    ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+        self.validate_request(request.schema())?;
+        let mutations = self
+            .load_rows(&request)
+            .await?
+            .into_iter()
+            .map(|row| {
+                SalesChannelRow::decode(row, request.tenant_id())
+                    .and_then(SalesChannelRow::into_mutation)
+                    .map_err(|_| permanent("sales_channel_index_record_invalid"))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        IndexSourceLoadBatch::new(&request, mutations)
+            .map_err(|_| permanent("sales_channel_index_batch_invalid"))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SalesChannelCursor {
+    channel_id: Uuid,
+}
+
+impl SalesChannelCursor {
+    fn decode(cursor: &IndexSourceCursor) -> Result<Self, SalesChannelIndexBridgeError> {
+        let decoded: Self = serde_json::from_value(cursor.value().clone())
+            .map_err(|_| SalesChannelIndexBridgeError::InvalidCursor)?;
+        if decoded.channel_id.is_nil() {
+            return Err(SalesChannelIndexBridgeError::InvalidCursor);
+        }
+        Ok(decoded)
+    }
+
+    fn encode(&self) -> Result<IndexSourceCursor, SalesChannelIndexBridgeError> {
+        let value = serde_json::to_value(self)
+            .map_err(|_| SalesChannelIndexBridgeError::InvalidCursor)?;
+        IndexSourceCursor::new(value).map_err(|_| SalesChannelIndexBridgeError::InvalidCursor)
+    }
+}
+
+#[derive(Debug)]
+struct SalesChannelRow {
+    tenant_id: Uuid,
+    channel_id: Uuid,
+    source_version: u64,
+    slug: String,
+    name: String,
+    is_active: bool,
+    is_default: bool,
+    status: String,
+}
+
+impl SalesChannelRow {
+    fn decode(
+        row: QueryResult,
+        expected_tenant: Uuid,
+    ) -> Result<Self, SalesChannelIndexBridgeError> {
+        let tenant_id = row
+            .try_get::<Uuid>("", "tenant_id")
+            .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
+        let channel_id = row
+            .try_get::<Uuid>("", "channel_id")
+            .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
+        let revision = row
+            .try_get::<i64>("", "index_revision")
+            .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
+        if tenant_id != expected_tenant
+            || tenant_id.is_nil()
+            || channel_id.is_nil()
+            || revision <= 0
+        {
+            return Err(SalesChannelIndexBridgeError::InvalidRow);
+        }
+        Ok(Self {
+            tenant_id,
+            channel_id,
+            source_version: u64::try_from(revision)
+                .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?,
+            slug: required_string(&row, "slug")?,
+            name: required_string(&row, "name")?,
+            is_active: row
+                .try_get::<bool>("", "is_active")
+                .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?,
+            is_default: row
+                .try_get::<bool>("", "is_default")
+                .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?,
+            status: required_string(&row, "status")?,
+        })
+    }
+
+    fn cursor(&self) -> SalesChannelCursor {
+        SalesChannelCursor {
+            channel_id: self.channel_id,
+        }
+    }
+
+    fn into_mutation(self) -> Result<IndexMutation, SalesChannelIndexBridgeError> {
+        let event_id = derive_index_source_event_id(
+            SALES_CHANNEL_EVENT_DOMAIN,
+            self.tenant_id,
+            self.channel_id,
+            None,
+            self.source_version,
+        )
+        .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
+        let fields = BTreeMap::from([
+            (field_name("slug")?, IndexValue::String(self.slug)),
+            (field_name("name")?, IndexValue::String(self.name)),
+            (field_name("is_active")?, IndexValue::Boolean(self.is_active)),
+            (
+                field_name("is_default")?,
+                IndexValue::Boolean(self.is_default),
+            ),
+            (field_name("status")?, IndexValue::String(self.status)),
+        ]);
+        Ok(IndexMutation::Upsert {
+            event_id,
+            record: IndexRecord {
+                key: EntityKey {
+                    tenant_id: self.tenant_id,
+                    schema: sales_channel_schema_ref()
+                        .map_err(SalesChannelIndexBridgeError::InvalidContract)?,
+                    entity_id: self.channel_id,
+                    locale: None,
+                },
+                source_version: self.source_version,
+                fields,
+                links: Vec::new(),
+            },
+        })
+    }
+}
+
+fn field_name(name: &str) -> Result<FieldName, SalesChannelIndexBridgeError> {
+    FieldName::new(name).map_err(SalesChannelIndexBridgeError::InvalidContract)
+}
+
+fn required_string(
+    row: &QueryResult,
+    column: &str,
+) -> Result<String, SalesChannelIndexBridgeError> {
+    let value = row
+        .try_get::<String>("", column)
+        .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
+    if value.is_empty() {
+        Err(SalesChannelIndexBridgeError::InvalidRow)
+    } else {
+        Ok(value)
+    }
+}
+
+fn retryable(code: &'static str) -> IndexSourceFailure {
+    IndexSourceFailure::retryable(code).expect("static SalesChannel retry code must be valid")
+}
+
+fn permanent(code: &'static str) -> IndexSourceFailure {
+    IndexSourceFailure::permanent(code).expect("static SalesChannel failure code must be valid")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selected_sales_channel_schema_is_nonlocalized_and_link_free() {
+        let schema = sales_channel_schema().unwrap();
+        assert_eq!(schema.reference, sales_channel_schema_ref().unwrap());
+        assert_eq!(schema.locale_mode, LocaleMode::None);
+        assert_eq!(schema.fields.len(), 5);
+        assert!(schema.links.is_empty());
+        assert!(schema
+            .fields
+            .iter()
+            .any(|field| field.name.as_str() == "slug"));
+        assert!(schema.fingerprint().is_ok());
+    }
+
+    #[test]
+    fn selected_sales_channel_cursor_rejects_nil_and_unknown_fields() {
+        for value in [
+            serde_json::json!({"channel_id": Uuid::nil()}),
+            serde_json::json!({"channel_id": Uuid::from_u128(2), "revision": 1}),
+        ] {
+            let cursor = IndexSourceCursor::new(value).unwrap();
+            assert!(SalesChannelCursor::decode(&cursor).is_err());
+        }
+    }
+
+    #[test]
+    fn selected_sales_channel_bridge_skips_partial_registry_without_channel_module() {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        extensions.insert(rustok_index::IndexSchemaSourceCatalog::new());
+        extensions.insert(rustok_index::PostgresIndexSourceFactoryCatalog::new());
+        register(&mut extensions).unwrap();
+        assert!(extensions
+            .get::<rustok_index::IndexSchemaSourceCatalog>()
+            .unwrap()
+            .is_empty());
+        assert!(extensions
+            .get::<rustok_index::PostgresIndexSourceFactoryCatalog>()
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn selected_sales_channel_bridge_registers_schema_and_factory() {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        extensions.insert(rustok_channel::ChannelRuntimeSelected);
+        extensions.insert(rustok_index::IndexSchemaSourceCatalog::new());
+        extensions.insert(rustok_index::PostgresIndexSourceFactoryCatalog::new());
+        register(&mut extensions).unwrap();
+        let schema = sales_channel_schema().unwrap();
+        assert_eq!(
+            extensions
+                .get::<rustok_index::IndexSchemaSourceCatalog>()
+                .unwrap()
+                .get(&schema.reference)
+                .unwrap()
+                .owner_module,
+            "channel"
+        );
+        assert_eq!(
+            extensions
+                .get::<rustok_index::PostgresIndexSourceFactoryCatalog>()
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+}

--- a/crates/rustok-distribution/src/lib.rs
+++ b/crates/rustok-distribution/src/lib.rs
@@ -4,6 +4,7 @@
 //! HTTP routing remains in `apps/server`; command providers remain in their
 //! module-local CLI adapters.
 
+mod channel_index;
 mod generated_promotions;
 mod generation;
 #[cfg(feature = "mod-product")]
@@ -66,10 +67,9 @@ fn register_runtime_bridges(extensions: &mut ModuleRuntimeExtensions) -> rustok_
 fn register_selected_index_bridges(
     extensions: &mut ModuleRuntimeExtensions,
 ) -> rustok_core::Result<()> {
+    channel_index::register(extensions)?;
     #[cfg(feature = "mod-product")]
     product_index::register(extensions)?;
-    #[cfg(not(feature = "mod-product"))]
-    let _ = extensions;
     Ok(())
 }
 

--- a/crates/rustok-distribution/tests/channel_index.rs
+++ b/crates/rustok-distribution/tests/channel_index.rs
@@ -1,0 +1,30 @@
+use rustok_distribution::{build_registry, build_runtime_extensions};
+use rustok_index::{
+    EntityName, ModuleName, PostgresIndexSourceFactoryCatalog, SchemaRef, SchemaVersion,
+    SharedIndexSchemaRegistry,
+};
+
+#[test]
+fn selected_channel_bridge_publishes_schema_and_source_factory() {
+    let registry = build_registry();
+    let extensions = build_runtime_extensions(&registry)
+        .expect("selected SalesChannel Index bridge should compose");
+    let schema = SchemaRef {
+        module: ModuleName::new("rustok-channel").unwrap(),
+        entity: EntityName::new("sales_channel").unwrap(),
+        version: SchemaVersion::INITIAL,
+    };
+
+    let shared = extensions
+        .get::<SharedIndexSchemaRegistry>()
+        .expect("selected SalesChannel schema should materialize");
+    assert!(shared.registry().get(&schema).is_some());
+
+    let factories = extensions
+        .get::<PostgresIndexSourceFactoryCatalog>()
+        .expect("selected SalesChannel source factory should remain available to the host");
+    assert!(factories.iter().any(|factory| {
+        factory.owner_module() == "channel"
+            && factory.factory_name() == "sales-channel-postgres-primary"
+    }));
+}

--- a/crates/rustok-index/docs/m7-sales-channel-source.md
+++ b/crates/rustok-index/docs/m7-sales-channel-source.md
@@ -22,19 +22,22 @@ execution. The server remains Channel-agnostic.
 
 ## Schema
 
-`rustok-channel::sales_channel@1` is `LocaleMode::None` and declares five required scalar
+`rustok-channel::sales_channel@1` is `LocaleMode::None` and declares six required scalar
 fields:
 
+- `id: uuid`
 - `slug: string`
 - `name: string`
 - `is_active: boolean`
 - `is_default: boolean`
 - `status: string`
 
-The schema is link-free. `settings` is intentionally omitted because the generic Index value
-contract does not currently expose a JSON field type. Channel targets, module bindings, OAuth
-applications, and resolution policies remain owner-domain data and are not flattened into this
-schema.
+The required `id` field duplicates `EntityKey.entity_id` intentionally so future link schemas
+can target stable Channel UUID identity without changing the already published v1 fingerprint.
+The schema itself is link-free. `settings` is intentionally omitted because the generic Index
+value contract does not currently expose a JSON field type. Channel targets, module bindings,
+OAuth applications, and resolution policies remain owner-domain data and are not flattened into
+this schema.
 
 ## Replay source
 

--- a/crates/rustok-index/docs/m7-sales-channel-source.md
+++ b/crates/rustok-index/docs/m7-sales-channel-source.md
@@ -1,0 +1,89 @@
+# M7 SalesChannel schema and bounded replay source
+
+Status: `source_complete_owner_execution_pending`
+
+This slice publishes the first Channel-owned current-state replay contract for
+`rustok-channel::sales_channel@1` without adding Channel semantics to Index core or the
+server.
+
+## Ownership
+
+`rustok-channel` owns the `channels` table, the `ChannelRuntimeSelected` composition marker,
+and the positive monotonic `channels.index_revision` storage contract. The owner crate does
+not depend on `rustok-index` and does not construct generic Index mutations.
+
+`rustok-distribution` owns the selected cross-module adapter because it already composes both
+Channel and Index. The adapter registers one schema and one host-database-aware source factory
+only when `ChannelModule` participated in runtime extension registration.
+
+`rustok-index` owns generic schema/source registration, deterministic event identity, immutable
+source registry materialization, replay jobs/checkpoints, mutation persistence, and query
+execution. The server remains Channel-agnostic.
+
+## Schema
+
+`rustok-channel::sales_channel@1` is `LocaleMode::None` and declares five required scalar
+fields:
+
+- `slug: string`
+- `name: string`
+- `is_active: boolean`
+- `is_default: boolean`
+- `status: string`
+
+The schema is link-free. `settings` is intentionally omitted because the generic Index value
+contract does not currently expose a JSON field type. Channel targets, module bindings, OAuth
+applications, and resolution policies remain owner-domain data and are not flattened into this
+schema.
+
+## Replay source
+
+The selected `sales-channel-postgres-primary` source:
+
+- reads only the Channel-owned `channels` table;
+- requires exact tenant and exact schema scope;
+- scans in stable `channel_id` UUID order with one-row lookahead;
+- persists an opaque cursor containing only `channel_id`;
+- never orders or paginates by mutable `index_revision`;
+- supports bounded targeted loads over exact non-localized entity keys;
+- rejects locale-bearing targeted keys;
+- rejects nil tenant/channel identities, non-positive revisions, and empty required strings;
+- emits generic `IndexMutation::Upsert` records with no links;
+- derives stable event UUIDs from tenant, channel, and source revision;
+- maps storage failures to one bounded retryable code and contract/backend failures to bounded
+  permanent codes.
+
+`index_revision` is the mutation `source_version`; it is not the scan cursor. A PostgreSQL
+trigger advances it exactly once for every Channel update and rejects revision exhaustion.
+The SeaORM owner model and public Channel DTOs do not expose the storage-internal column.
+
+## Composition
+
+The core distribution registers the Channel bridge before immutable schema registry
+materialization. Product bridges remain separately feature-gated. A partial/test registry that
+omits `ChannelModule` receives neither a false SalesChannel schema nor a false source factory.
+
+The host later constructs all selected PostgreSQL source factories atomically before freezing
+`SharedIndexSourceRegistry` and publishing the replay runtime. No scheduler or background task is
+started by this slice.
+
+## Explicitly open
+
+- Channel hard-delete tombstones;
+- incremental Channel event ingestion and broker acknowledgement;
+- persisted per-tenant schema application;
+- repeatable-read full-scan snapshot and concurrent-insert reconciliation semantics;
+- versioned Product/ProductVariant to SalesChannel links;
+- Channel target, binding, and resolution-policy schemas;
+- authoritative Storefront/Admin/Search consumer cutover;
+- retry/backoff/dead-letter scheduling and graceful host task ownership;
+- retained PostgreSQL replay, restart, drift, freshness, and equivalence evidence.
+
+Runtime capability presence does not establish persisted schema readiness. Consumers must not
+query this schema authoritatively until the exact tenant schema is applied and the relevant
+replay/evidence admission is complete.
+
+## Validation ownership
+
+Formatting, Cargo checks/tests, JavaScript guards, PostgreSQL execution, and CI are
+maintainer-run. The implementation agent did not execute them.

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -23,6 +23,7 @@ const scripts = [
   'verify-index-replay-runtime-composition.mjs',
   'verify-index-product-source.mjs',
   'verify-index-product-variant-source.mjs',
+  'verify-index-sales-channel-source.mjs',
   'verify-index-query-runtime-composition.mjs',
   'verify-index-social-graph-privacy-consumer.mjs',
   'verify-social-graph-privacy-shadow-evidence.mjs',

--- a/scripts/verify/verify-index-sales-channel-source.mjs
+++ b/scripts/verify/verify-index-sales-channel-source.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const resolve = (relative) => path.join(root, relative);
+const read = (relative) => fs.readFileSync(resolve(relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-sales-channel-source] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+const forbidMarkers = (relative, source, markers) => {
+  for (const marker of markers) {
+    if (source.includes(marker)) fail(`${relative} contains forbidden marker ${marker}`);
+  }
+};
+
+const channelCargo = read('crates/rustok-channel/Cargo.toml');
+forbidMarkers('crates/rustok-channel/Cargo.toml', channelCargo, [
+  'rustok-index',
+  'register_index_schema_source',
+]);
+
+const channelRootPath = 'crates/rustok-channel/src/lib.rs';
+const channelRoot = requireMarkers(channelRootPath, [
+  'pub struct ChannelRuntimeSelected;',
+  'fn register_runtime_extensions(',
+  'extensions.insert(ChannelRuntimeSelected);',
+]);
+forbidMarkers(channelRootPath, channelRoot, [
+  'rustok_index',
+  'register_index_schema_source',
+  'PostgresIndexSourceFactory',
+]);
+requireMarkers('crates/rustok-channel/tests/index_selection.rs', [
+  'channel_module_publishes_only_a_typed_selection_marker_for_index_bridges',
+  'assert!(extensions.contains::<ChannelRuntimeSelected>());',
+  'assert!(!cargo.contains("rustok-index"));',
+]);
+
+const migrationPath =
+  'crates/rustok-channel/src/migrations/m20260730_000010_add_channel_index_revision.rs';
+const migration = requireMarkers(migrationPath, [
+  'ALTER TABLE channels',
+  'ADD COLUMN index_revision BIGINT NOT NULL DEFAULT 1',
+  'chk_channels_index_revision_positive',
+  'OLD.index_revision = 9223372036854775807',
+  'NEW.index_revision := OLD.index_revision + 1;',
+  'trg_channels_bump_index_revision',
+  'BEFORE UPDATE ON channels',
+]);
+forbidMarkers(migrationPath, migration, [
+  'index_entities',
+  'index_links',
+  'index_jobs',
+  'index_checkpoints',
+]);
+requireMarkers('crates/rustok-channel/src/migrations/mod.rs', [
+  'mod m20260730_000010_add_channel_index_revision;',
+  'Box::new(m20260730_000010_add_channel_index_revision::Migration)',
+]);
+requireMarkers('crates/rustok-channel/src/migrations/m20260325_000001_create_channels.rs', [
+  '.name("idx_channels_tenant_slug")',
+  '.col(Channels::TenantId)',
+  '.col(Channels::Slug)',
+  '.unique()',
+]);
+
+const distributionRootPath = 'crates/rustok-distribution/src/lib.rs';
+const distributionRoot = requireMarkers(distributionRootPath, [
+  'mod channel_index;',
+  'register_selected_index_bridges(&mut extensions)?;',
+  'channel_index::register(extensions)?;',
+  'materialize_index_schema_sources(&mut extensions)?;',
+]);
+const bridgeCall = distributionRoot.indexOf('channel_index::register(extensions)?;');
+const schemaMaterialization = distributionRoot.indexOf(
+  'materialize_index_schema_sources(&mut extensions)?;',
+);
+if (bridgeCall < 0 || schemaMaterialization <= bridgeCall) {
+  fail('SalesChannel bridge must register before immutable schema materialization');
+}
+if (distributionRoot.includes('#[cfg(feature = "mod-product")]\nmod channel_index;')) {
+  fail('SalesChannel bridge must not be gated by the Product feature');
+}
+
+const sourcePath = 'crates/rustok-distribution/src/channel_index.rs';
+const source = requireMarkers(sourcePath, [
+  'SALES_CHANNEL_INDEX_SOURCE: &str = "sales-channel-postgres-primary"',
+  'SALES_CHANNEL_EVENT_DOMAIN: &str = "rustok-channel.sales-channel-replay-v1"',
+  'extensions.contains::<rustok_channel::ChannelRuntimeSelected>()',
+  'register_index_schema_source(extensions, "channel", schema)',
+  'register_postgres_index_source_factory(',
+  'entity: EntityName::new("sales_channel")?',
+  'locale_mode: LocaleMode::None',
+  'field("slug", IndexValueType::String, true, true)?',
+  'field("is_active", IndexValueType::Boolean, true, true)?',
+  'impl PostgresIndexSourceFactory for SalesChannelPostgresIndexSourceFactory',
+  'impl IndexSource for SalesChannelPostgresIndexSource',
+  'FROM channels c',
+  'c.index_revision,',
+  'c.id > $2',
+  'ORDER BY c.id ASC',
+  'request.limit() + 1',
+  'WITH requested(channel_id) AS (VALUES {})',
+  'JOIN requested r ON r.channel_id = c.id',
+  'sales_channel_index_locale_forbidden',
+  'derive_index_source_event_id(',
+  'locale: None',
+  'links: Vec::new()',
+  '#[serde(deny_unknown_fields)]',
+  'selected_sales_channel_schema_is_nonlocalized_and_link_free',
+  'selected_sales_channel_cursor_rejects_nil_and_unknown_fields',
+  'selected_sales_channel_bridge_skips_partial_registry_without_channel_module',
+  'selected_sales_channel_bridge_registers_schema_and_factory',
+]);
+forbidMarkers(sourcePath, source, [
+  'c.settings',
+  'IndexLink',
+  'IndexLinkValue',
+  'LocaleKey',
+  'ORDER BY c.index_revision',
+  '(c.index_revision, c.id)',
+  'SELECT *',
+  'index_entities',
+  'index_links',
+  'index_jobs',
+  'index_checkpoints',
+  'tokio::spawn',
+  'tokio::time::sleep',
+  'loop {',
+  'rustok_product',
+  'rustok_search',
+]);
+
+requireMarkers('crates/rustok-distribution/tests/channel_index.rs', [
+  'selected_channel_bridge_publishes_schema_and_source_factory',
+  'EntityName::new("sales_channel")',
+  'factory.owner_module() == "channel"',
+  'factory.factory_name() == "sales-channel-postgres-primary"',
+]);
+
+requireMarkers('crates/rustok-index/docs/m7-sales-channel-source.md', [
+  'Status: `source_complete_owner_execution_pending`',
+  '`rustok-channel::sales_channel@1`',
+  'stable `channel_id` UUID order',
+  '`index_revision` is the mutation `source_version`; it is not the scan cursor.',
+  'The schema is link-free.',
+  'Channel hard-delete tombstones',
+  'Runtime capability presence does not establish persisted schema readiness.',
+  'maintainer-run',
+]);
+requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
+  "'verify-index-sales-channel-source.mjs'",
+]);
+
+console.log('[verify-index-sales-channel-source] OK');

--- a/scripts/verify/verify-index-sales-channel-source.mjs
+++ b/scripts/verify/verify-index-sales-channel-source.mjs
@@ -41,6 +41,13 @@ forbidMarkers(channelRootPath, channelRoot, [
   'register_index_schema_source',
   'PostgresIndexSourceFactory',
 ]);
+const channelEntityPath = 'crates/rustok-channel/src/entities/channel.rs';
+const channelEntity = requireMarkers(channelEntityPath, [
+  'pub id: Uuid,',
+  'pub tenant_id: Uuid,',
+  'pub slug: String,',
+]);
+forbidMarkers(channelEntityPath, channelEntity, ['index_revision']);
 requireMarkers('crates/rustok-channel/tests/index_selection.rs', [
   'channel_module_publishes_only_a_typed_selection_marker_for_index_bridges',
   'assert!(extensions.contains::<ChannelRuntimeSelected>());',
@@ -102,8 +109,10 @@ const source = requireMarkers(sourcePath, [
   'register_postgres_index_source_factory(',
   'entity: EntityName::new("sales_channel")?',
   'locale_mode: LocaleMode::None',
+  'field("id", IndexValueType::Uuid, true, true)?',
   'field("slug", IndexValueType::String, true, true)?',
   'field("is_active", IndexValueType::Boolean, true, true)?',
+  'field_name("id")?, IndexValue::Uuid(self.channel_id)',
   'impl PostgresIndexSourceFactory for SalesChannelPostgresIndexSourceFactory',
   'impl IndexSource for SalesChannelPostgresIndexSource',
   'FROM channels c',
@@ -118,6 +127,7 @@ const source = requireMarkers(sourcePath, [
   'locale: None',
   'links: Vec::new()',
   '#[serde(deny_unknown_fields)]',
+  'assert_eq!(schema.fields.len(), 6);',
   'selected_sales_channel_schema_is_nonlocalized_and_link_free',
   'selected_sales_channel_cursor_rejects_nil_and_unknown_fields',
   'selected_sales_channel_bridge_skips_partial_registry_without_channel_module',
@@ -149,12 +159,21 @@ requireMarkers('crates/rustok-distribution/tests/channel_index.rs', [
   'factory.factory_name() == "sales-channel-postgres-primary"',
 ]);
 
+requireMarkers('crates/rustok-channel/README.md', [
+  '`channels.index_revision`',
+  '`ChannelRuntimeSelected`',
+  '`rustok-channel::sales_channel@1`',
+  'stable `channel_id` ordering',
+  'does not depend on `rustok-index`',
+]);
 requireMarkers('crates/rustok-index/docs/m7-sales-channel-source.md', [
   'Status: `source_complete_owner_execution_pending`',
   '`rustok-channel::sales_channel@1`',
+  '`id: uuid`',
+  'future link schemas can target stable Channel UUID identity',
   'stable `channel_id` UUID order',
   '`index_revision` is the mutation `source_version`; it is not the scan cursor.',
-  'The schema is link-free.',
+  'The schema itself is link-free.',
   'Channel hard-delete tombstones',
   'Runtime capability presence does not establish persisted schema readiness.',
   'maintainer-run',


### PR DESCRIPTION
## Summary

- add the non-localized `rustok-channel::sales_channel@1` schema through the core distribution bridge
- add a bounded PostgreSQL SalesChannel replay source with stable `channel_id` cursor pagination
- add exact targeted loads over non-localized Channel keys
- add Channel-owned positive monotonic `channels.index_revision`
- derive stable replay event identity from tenant, channel, and source revision
- publish only a neutral `ChannelRuntimeSelected` marker from `rustok-channel`
- keep Channel independent from Index and keep Index/server Channel-agnostic
- add M7 documentation, owner/composition fixtures, and repository guards

## Ownership boundary

`rustok-channel` owns the `channels` table, revision migration, and typed selection marker. It does not depend on `rustok-index` and does not construct generic Index mutations.

`rustok-distribution` owns the selected cross-module adapter because Channel and Index are both core dependencies there. The bridge is not gated by `mod-product`; it registers only when `ChannelModule` participated in runtime extension registration.

Index owns generic schema/source/runtime contracts, deterministic event identity, replay persistence, jobs, and checkpoints. Server composition still sees only generic source factories and immutable registries.

## SalesChannel contract

The source:

- publishes `LocaleMode::None`
- reads only `channels`
- exposes required `id`, `slug`, `name`, `is_active`, `is_default`, and `status` fields
- intentionally omits JSON `settings`, targets, bindings, OAuth apps, and resolution policies
- uses stable `channel_id` ordering with one-row lookahead
- supports bounded targeted loads over exact tenant/schema/entity keys
- rejects locale-bearing keys, nil identities, non-positive revisions, and empty required strings
- uses `index_revision` only as mutation `source_version`, never as the scan cursor
- emits generic `IndexMutation::Upsert` records with no links
- maps storage failures to a bounded retryable code and contract/backend failures to bounded permanent codes

The required UUID `id` field duplicates `EntityKey.entity_id` intentionally so future link schemas can target stable Channel identity without changing the SalesChannel v1 fingerprint.

## Explicitly open

- Channel hard-delete tombstones
- incremental Channel event ingestion and acknowledgement
- persisted per-tenant schema application
- repeatable-read full-scan snapshot/reconciliation semantics
- versioned Product/ProductVariant to SalesChannel links
- Channel target/binding/resolution-policy schemas
- authoritative consumer cutover and retained PostgreSQL evidence
- scheduler, retry/backoff/DLQ, and graceful task ownership

The composite M7 plan checkbox remains open because links, tombstones, incremental ingestion, query/cutover coverage, and retained evidence are not complete. The exact source status is recorded in `m7-sales-channel-source.md`.

## Recheck findings addressed

- made the first SalesChannel schema identity-ready before publication
- kept mutable revision out of enumeration cursor ordering
- kept the bridge independent from the Product feature
- made partial registries fail closed through `ChannelRuntimeSelected`
- kept storage revision out of the SeaORM owner model and public DTOs
- verified no changed-file overlap with parallel `main` commits
- left `Cargo.lock` unchanged

## Validation

Not run by the implementation agent, per owner request. The repository owner will run formatting, Cargo checks/tests, JavaScript guards, PostgreSQL checks, and CI.

Suggested owner commands:

```bash
node scripts/verify/verify-index-sales-channel-source.mjs
node scripts/verify/verify-index-query-contract.mjs
cargo check -p rustok-channel --all-targets
cargo check -p rustok-distribution --all-targets
cargo check -p rustok-server --all-targets
cargo test -p rustok-channel index_selection -- --nocapture
cargo test -p rustok-distribution channel_index -- --nocapture
```

## Branch state

Base: `main`
Branch: `agent/index-m7-sales-channel-source-20260730`

Parallel commits since the merge base do not overlap this Channel/Index source slice. Squash merge is recommended after owner validation.