### PR TITLE
fix(commerce): sanitize admin promotion client errors

### DIFF
--- a/crates/rustok-commerce/admin/src/transport/mod.rs
+++ b/crates/rustok-commerce/admin/src/transport/mod.rs
@@ -7,6 +7,7 @@ mod native_server_adapter;
 mod native_server_adapter;
 mod order_change;
 mod promotion;
+mod promotion_client_error_safety;
 mod shipping_profile;
 
 pub use order_change::{apply_order_change, cancel_order_change, fetch_order_changes};

--- a/crates/rustok-commerce/admin/src/transport/promotion.rs
+++ b/crates/rustok-commerce/admin/src/transport/promotion.rs
@@ -1,4 +1,5 @@
 use super::native_server_adapter::{self, ApiError};
+use super::promotion_client_error_safety::PromotionClientErrorContext;
 use crate::model::{
     CommerceAdminCartSnapshot, CommerceCartPromotionDraft, CommerceCartPromotionPreview,
 };
@@ -7,14 +8,20 @@ pub async fn preview_cart_promotion(
     cart_id: String,
     draft: CommerceCartPromotionDraft,
 ) -> Result<CommerceCartPromotionPreview, ApiError> {
-    native_server_adapter::preview_cart_promotion(cart_id, draft).await
+    let context = PromotionClientErrorContext::for_preview(cart_id.as_str());
+    native_server_adapter::preview_cart_promotion(cart_id, draft)
+        .await
+        .map_err(|promotion_error| context.map_error(promotion_error))
 }
 
 pub async fn apply_cart_promotion(
     cart_id: String,
     draft: CommerceCartPromotionDraft,
 ) -> Result<CommerceAdminCartSnapshot, ApiError> {
-    native_server_adapter::apply_cart_promotion(cart_id, draft).await
+    let context = PromotionClientErrorContext::for_apply(cart_id.as_str());
+    native_server_adapter::apply_cart_promotion(cart_id, draft)
+        .await
+        .map_err(|promotion_error| context.map_error(promotion_error))
 }
 
 #[cfg(test)]

--- a/crates/rustok-commerce/admin/src/transport/promotion_client_error_safety.rs
+++ b/crates/rustok-commerce/admin/src/transport/promotion_client_error_safety.rs
@@ -1,0 +1,61 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::native_server_adapter::ApiError;
+
+const COMMERCE_ADMIN_PROMOTION_CLIENT_OWNER: &str =
+    "rustok_commerce.admin_promotion_transport";
+const COMMERCE_ADMIN_PROMOTION_CLIENT_BOUNDARY: &str =
+    "commerce_admin_promotion_client_transport";
+const COMMERCE_ADMIN_PROMOTION_CLIENT_PUBLIC_MESSAGE: &str =
+    "Commerce admin promotion request could not be completed";
+
+pub(super) struct PromotionClientErrorContext {
+    operation: &'static str,
+    correlation_id: String,
+    cart_id_length: usize,
+    payload_present: bool,
+}
+
+impl PromotionClientErrorContext {
+    pub(super) fn for_preview(cart_id: &str) -> Self {
+        Self::new("preview_cart_promotion", cart_id)
+    }
+
+    pub(super) fn for_apply(cart_id: &str) -> Self {
+        Self::new("apply_cart_promotion", cart_id)
+    }
+
+    fn new(operation: &'static str, cart_id: &str) -> Self {
+        Self {
+            operation,
+            correlation_id: promotion_client_correlation_id(operation),
+            cart_id_length: cart_id.chars().count(),
+            payload_present: true,
+        }
+    }
+
+    pub(super) fn map_error(&self, error: ApiError) -> ApiError {
+        tracing::error!(
+            raw_error = ?error,
+            owner = COMMERCE_ADMIN_PROMOTION_CLIENT_OWNER,
+            owner_operation = self.operation,
+            correlation_id = %self.correlation_id,
+            cart_id_present = self.cart_id_length > 0,
+            cart_id_length = self.cart_id_length,
+            payload_present = self.payload_present,
+            code = "commerce.admin_promotion_client_transport_failed",
+            boundary = COMMERCE_ADMIN_PROMOTION_CLIENT_BOUNDARY,
+            "commerce admin promotion client transport request failed"
+        );
+
+        ApiError::ServerFn(COMMERCE_ADMIN_PROMOTION_CLIENT_PUBLIC_MESSAGE.to_string())
+    }
+}
+
+fn promotion_client_correlation_id(operation: &'static str) -> String {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("commerce-admin-promotion-client:{operation}:{timestamp}")
+}

--- a/crates/rustok-commerce/contracts/evidence/admin-promotion-client-transport-error-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/admin-promotion-client-transport-error-safety-source-review.json
@@ -1,0 +1,30 @@
+{
+  "status": "commerce_admin_promotion_client_transport_error_safety_source_reviewed_unvalidated",
+  "reviewed_at": "2026-07-30",
+  "review_scope": [
+    "crates/rustok-commerce/admin/src/transport/mod.rs",
+    "crates/rustok-commerce/admin/src/transport/promotion.rs",
+    "crates/rustok-commerce/admin/src/transport/promotion_client_error_safety.rs",
+    "crates/rustok-commerce/admin/src/transport/native_server_adapter.rs",
+    "crates/rustok-commerce/admin/src/transport/native_server_adapter_ssr.rs"
+  ],
+  "findings": {
+    "two_promotion_facade_operations_mapped": true,
+    "context_created_before_native_call": true,
+    "native_api_error_contract_preserved": true,
+    "default_native_adapter_unchanged": true,
+    "ssr_native_adapter_unchanged": true,
+    "order_change_transport_unchanged": true,
+    "request_response_dtos_preserved": true,
+    "static_public_message_after_native_return": true,
+    "original_native_error_private_to_structured_diagnostics": true,
+    "safe_request_shape_logging_only": true,
+    "broad_ecommerce_mapper_cleanup_remains_open": true
+  },
+  "non_claims": [
+    "No test or verifier was executed",
+    "No Cargo compilation or formatting was executed",
+    "No hydrate, SSR, browser, or mounted promotion failure was exercised",
+    "No Commerce FFA or FBA status was promoted"
+  ]
+}

--- a/crates/rustok-commerce/contracts/evidence/admin-promotion-client-transport-error-safety-source.json
+++ b/crates/rustok-commerce/contracts/evidence/admin-promotion-client-transport-error-safety-source.json
@@ -1,0 +1,50 @@
+{
+  "status": "commerce_admin_promotion_client_transport_error_safety_source_unvalidated",
+  "reviewed_at": "2026-07-30",
+  "boundary": "commerce_admin_promotion_client_transport",
+  "public_error_type": "ApiError",
+  "public_message": "Commerce admin promotion request could not be completed",
+  "covered_operations": [
+    "preview_cart_promotion",
+    "apply_cart_promotion"
+  ],
+  "confirmed_gap": {
+    "native_api_error_returned_directly": true,
+    "native_error_payload_type": "ApiError::ServerFn(String)",
+    "facade_mapping_before_slice": false
+  },
+  "source_contract": {
+    "native_adapters_changed": false,
+    "server_functions_changed": false,
+    "order_change_transport_changed": false,
+    "request_response_dto_changed": false,
+    "api_error_contract_preserved": true,
+    "operation_count": 2,
+    "context_created_before_native_call": true,
+    "raw_native_error_public": false,
+    "static_public_message": true,
+    "original_error_logged_privately": true,
+    "per_call_correlation_logging": true,
+    "safe_request_shape_only": true,
+    "cart_id_values_logged": false,
+    "promotion_payload_values_logged": false
+  },
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "hydrate_compile_proven": false,
+    "ssr_compile_proven": false,
+    "mounted_runtime_proven": false
+  },
+  "remaining": [
+    "Run the focused promotion client transport verifier",
+    "Run the existing promotion native error-safety verifier",
+    "Compile the Commerce admin package for hydrate and ssr profiles",
+    "Retain mounted preview and apply failure evidence",
+    "Continue the broad ecommerce mapper cleanup in other owner and transport boundaries"
+  ]
+}

--- a/crates/rustok-commerce/docs/admin-promotion-client-transport-error-safety.md
+++ b/crates/rustok-commerce/docs/admin-promotion-client-transport-error-safety.md
@@ -1,0 +1,67 @@
+# Commerce Admin promotion client transport error safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This source slice covers the final Commerce Admin promotion facade in
+`crates/rustok-commerce/admin/src/transport/promotion.rs`.
+
+Covered operations:
+
+- `preview_cart_promotion`
+- `apply_cart_promotion`
+
+## Confirmed gap
+
+The mounted SSR promotion adapter already owns correlation-aware context and cart
+promotion `PortError` mapping. The public facade nevertheless returned the shared
+native `ApiError` directly. That type stores `ServerFn(String)`, so framework,
+serialization, transport, or unexpected server-function text could still become
+the displayed Admin error after leaving the native adapter.
+
+## Source policy
+
+Each promotion facade operation now creates a `PromotionClientErrorContext` before
+the unchanged native adapter call and maps only a final returned `ApiError`.
+
+The original typed native error is retained only in structured diagnostics with:
+
+- the Commerce Admin promotion consumer and exact operation;
+- a per-call correlation id;
+- the client transport boundary and a stable error code;
+- cart-id presence and character length;
+- promotion-payload presence.
+
+The cart id and promotion draft values, including scope, kind, source id, line item,
+discount, amount, metadata, and any other payload fields, are not logged by this
+client boundary.
+
+The existing public error contract remains `ApiError`, but preview and apply now
+return the same static final message:
+
+`Commerce admin promotion request could not be completed`
+
+## Preserved behavior
+
+This slice does not change:
+
+- the default or SSR native adapter files;
+- the two mounted promotion server-function endpoints;
+- owner `PortError` mapping and server-side diagnostics;
+- authentication, tenant, permission, channel, locale, or idempotency policy;
+- cart-promotion request parsing or normalization;
+- preview/apply owner calls, invocation order, or result DTOs;
+- order-change transport functions that share the native adapter;
+- the `ApiError` result type used by existing callers and tests.
+
+## Evidence boundary
+
+The retained JSON evidence is source-only. Tests, focused verifiers, Cargo,
+formatting, workflows, CI, hydrate compilation, SSR compilation, browser behavior,
+and mounted preview/apply failure behavior were not executed by this implementation
+agent.
+
+The broad ecommerce mapper-cleanup item remains open for tax, payment,
+fulfillment, order, remaining promotion paths, and other non-`PortError` public
+envelopes.

--- a/scripts/verify/verify-commerce-admin-promotion-client-transport-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-promotion-client-transport-error-safety.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const requireCount = (source, value, expected, label) => {
+  const count = source.split(value).length - 1;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+};
+
+function functionBody(source, functionName) {
+  const match = new RegExp(`pub\\s+async\\s+fn\\s+${functionName}\\s*\\(`).exec(source);
+  if (!match) {
+    failures.push(`missing function ${functionName}`);
+    return "";
+  }
+  const openBrace = source.indexOf("{", match.index);
+  if (openBrace < 0) {
+    failures.push(`missing body for ${functionName}`);
+    return "";
+  }
+  let depth = 0;
+  for (let index = openBrace; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(openBrace, index + 1);
+    }
+  }
+  failures.push(`unterminated body for ${functionName}`);
+  return "";
+}
+
+const paths = {
+  routing: "crates/rustok-commerce/admin/src/transport/mod.rs",
+  facade: "crates/rustok-commerce/admin/src/transport/promotion.rs",
+  safety:
+    "crates/rustok-commerce/admin/src/transport/promotion_client_error_safety.rs",
+  native: "crates/rustok-commerce/admin/src/transport/native_server_adapter.rs",
+  nativeSsr:
+    "crates/rustok-commerce/admin/src/transport/native_server_adapter_ssr.rs",
+  evidence:
+    "crates/rustok-commerce/contracts/evidence/admin-promotion-client-transport-error-safety-source.json",
+  review:
+    "crates/rustok-commerce/contracts/evidence/admin-promotion-client-transport-error-safety-source-review.json",
+  doc: "crates/rustok-commerce/docs/admin-promotion-client-transport-error-safety.md",
+  commercePlan: "crates/rustok-commerce/docs/implementation-plan.md",
+  nativeGuard:
+    "scripts/verify/verify-commerce-admin-promotion-native-error-safety.mjs",
+};
+
+const routing = read(paths.routing);
+const facade = read(paths.facade);
+const safety = read(paths.safety);
+const native = read(paths.native);
+const nativeSsr = read(paths.nativeSsr);
+const evidence = JSON.parse(read(paths.evidence));
+const review = JSON.parse(read(paths.review));
+const doc = read(paths.doc);
+const commercePlan = read(paths.commercePlan);
+const nativeGuard = read(paths.nativeGuard);
+
+requireText(
+  routing,
+  "mod promotion_client_error_safety;",
+  `${paths.routing}: client error policy wiring`,
+);
+requireText(
+  routing,
+  "pub use promotion::{apply_cart_promotion, preview_cart_promotion};",
+  `${paths.routing}: promotion exports`,
+);
+
+for (const marker of [
+  "use super::promotion_client_error_safety::PromotionClientErrorContext;",
+  "Result<CommerceCartPromotionPreview, ApiError>",
+  "Result<CommerceAdminCartSnapshot, ApiError>",
+]) {
+  requireText(facade, marker, `${paths.facade}: preserved facade contract`);
+}
+requireCount(
+  facade,
+  ".map_err(|promotion_error| context.map_error(promotion_error))",
+  2,
+  `${paths.facade}: final client mappings`,
+);
+
+for (const [operation, constructor, call] of [
+  [
+    "preview_cart_promotion",
+    "PromotionClientErrorContext::for_preview",
+    "native_server_adapter::preview_cart_promotion(",
+  ],
+  [
+    "apply_cart_promotion",
+    "PromotionClientErrorContext::for_apply",
+    "native_server_adapter::apply_cart_promotion(",
+  ],
+]) {
+  const body = functionBody(facade, operation);
+  requireText(body, constructor, `${paths.facade}: ${operation} context`);
+  requireText(body, call, `${paths.facade}: ${operation} native call`);
+  requireText(
+    body,
+    ".map_err(|promotion_error| context.map_error(promotion_error))",
+    `${paths.facade}: ${operation} final mapping`,
+  );
+  if (body.indexOf(constructor) > body.indexOf(call)) {
+    failures.push(`${paths.facade}: ${operation} context must precede native call`);
+  }
+}
+
+for (const marker of [
+  'const COMMERCE_ADMIN_PROMOTION_CLIENT_OWNER: &str =',
+  '"rustok_commerce.admin_promotion_transport"',
+  'const COMMERCE_ADMIN_PROMOTION_CLIENT_BOUNDARY: &str =',
+  '"commerce_admin_promotion_client_transport"',
+  '"Commerce admin promotion request could not be completed"',
+  "pub(super) struct PromotionClientErrorContext",
+  'Self::new("preview_cart_promotion", cart_id)',
+  'Self::new("apply_cart_promotion", cart_id)',
+  "raw_error = ?error",
+  "owner_operation = self.operation",
+  "correlation_id = %self.correlation_id",
+  "cart_id_present = self.cart_id_length > 0",
+  "cart_id_length = self.cart_id_length",
+  "payload_present = self.payload_present",
+  'code = "commerce.admin_promotion_client_transport_failed"',
+  "boundary = COMMERCE_ADMIN_PROMOTION_CLIENT_BOUNDARY",
+  "ApiError::ServerFn(COMMERCE_ADMIN_PROMOTION_CLIENT_PUBLIC_MESSAGE.to_string())",
+]) {
+  requireText(safety, marker, `${paths.safety}: safe final mapping`);
+}
+
+for (const forbidden of [
+  "cart_id = %",
+  "cart_id = ?",
+  "payload = ?",
+  "draft = ?",
+  "source_id =",
+  "line_item_id =",
+  "discount_percent =",
+  "amount =",
+  "metadata_json =",
+  "error.to_string()",
+]) {
+  forbidText(safety, forbidden, `${paths.safety}: raw request or error text`);
+}
+
+for (const source of [native, nativeSsr]) {
+  for (const [operation, nativeCall] of [
+    [
+      "preview_cart_promotion",
+      "commerce_admin_preview_cart_promotion_native(cart_id, payload)",
+    ],
+    [
+      "apply_cart_promotion",
+      "commerce_admin_apply_cart_promotion_native(cart_id, payload)",
+    ],
+  ]) {
+    const body = functionBody(source, operation);
+    requireText(body, nativeCall, `native adapter: preserved ${operation} call`);
+    requireText(body, ".map_err(Into::into)", `native adapter: preserved ${operation} mapping`);
+  }
+}
+
+for (const endpoint of [
+  'endpoint = "commerce/admin/preview-cart-promotion"',
+  'endpoint = "commerce/admin/apply-cart-promotion"',
+]) {
+  requireText(nativeSsr, endpoint, `${paths.nativeSsr}: preserved endpoint`);
+}
+requireText(
+  nativeGuard,
+  "Commerce admin promotion native error-safety source invariants passed",
+  `${paths.nativeGuard}: prior server-side guard remains registered`,
+);
+
+if (
+  evidence.status !==
+  "commerce_admin_promotion_client_transport_error_safety_source_unvalidated"
+) {
+  failures.push(`${paths.evidence}: unexpected status ${evidence.status}`);
+}
+if (
+  review.status !==
+  "commerce_admin_promotion_client_transport_error_safety_source_reviewed_unvalidated"
+) {
+  failures.push(`${paths.review}: unexpected status ${review.status}`);
+}
+
+for (const [key, expected] of Object.entries({
+  native_adapters_changed: false,
+  server_functions_changed: false,
+  order_change_transport_changed: false,
+  request_response_dto_changed: false,
+  api_error_contract_preserved: true,
+  operation_count: 2,
+  context_created_before_native_call: true,
+  raw_native_error_public: false,
+  static_public_message: true,
+  original_error_logged_privately: true,
+  per_call_correlation_logging: true,
+  safe_request_shape_only: true,
+  cart_id_values_logged: false,
+  promotion_payload_values_logged: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "hydrate_compile_proven",
+  "ssr_compile_proven",
+  "mounted_runtime_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+
+requireText(doc, "Status: **source-ready / unvalidated**", `${paths.doc}: status`);
+requireText(
+  doc,
+  "Commerce admin promotion request could not be completed",
+  `${paths.doc}: static public message`,
+);
+requireText(
+  commercePlan,
+  "Finish correlation-safe mapper cleanup",
+  `${paths.commercePlan}: broad ecommerce cleanup remains open`,
+);
+
+if (failures.length > 0) {
+  console.error("Commerce Admin promotion client transport error-safety verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "Commerce Admin promotion preview/apply failures use a correlation-safe static final envelope; execution evidence remains open",
+);


### PR DESCRIPTION
## Summary
- close the final raw native `ApiError` escape in the Commerce Admin promotion facade
- cover `preview_cart_promotion` and `apply_cart_promotion`
- create a per-call promotion client context before each unchanged native adapter call
- retain the original native error only in structured diagnostics
- record operation, correlation id, stable code, boundary, cart-id presence/length, and payload presence only
- return one static final public message: `Commerce admin promotion request could not be completed`
- preserve the existing `Result<…, ApiError>` contract, default/SSR native adapters, mounted endpoints, owner `PortError` mapping, permissions, context propagation, DTOs, and order-change transport
- add source evidence, documentation, source review, and a focused fail-closed verifier

## Confirmed gap
The mounted SSR adapter already uses correlation-aware owner and context error mapping. The public `promotion.rs` facade nevertheless returned the shared native `ApiError` unchanged. Since that compatibility type stores `ServerFn(String)`, framework, serialization, transport, or unexpected server-function text could still become the displayed Admin error after leaving the adapter.

## Boundary placement
Each facade operation now creates `PromotionClientErrorContext` before the existing native call and maps only the final returned `ApiError`. No retry, fallback, request parsing, authorization, owner call, idempotency, response mapping, or invocation order changed.

## Diagnostics
The new client boundary logs only safe shape metadata. It does not log the cart id or promotion draft values, including scope, kind, source id, line item, discount, amount, or metadata.

## Recheck findings
- context precedes the native call in both operations
- the final mapper appears exactly twice
- success signatures, DTOs, `ApiError`, and the existing test contract are preserved
- default and SSR native adapters are outside the diff
- the existing server-side promotion error-safety guard remains unchanged
- order-change transport sharing the native adapter is untouched
- the broad ecommerce mapper-cleanup item remains open

`main` advanced by three unrelated README/Index commits while the branch was prepared. The compare contains only the seven Commerce promotion source/evidence files.

## Validation
Per maintainer instruction, tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run. Evidence remains source-ready / unvalidated and does not promote Commerce FFA/FBA, hydrate, SSR, browser, mounted runtime, workflow, CI, or production status.

Suggested maintainer commands:
```bash
node scripts/verify/verify-commerce-admin-promotion-client-transport-error-safety.mjs
node scripts/verify/verify-commerce-admin-promotion-native-error-safety.mjs
node scripts/verify/verify-commerce-admin-boundary.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-commerce-admin
cargo check -p rustok-commerce-admin --features hydrate
cargo check -p rustok-commerce-admin --features ssr
```