### PR TITLE
fix(commerce): sanitize admin order-change client errors

### DIFF
--- a/crates/rustok-commerce/admin/src/transport/mod.rs
+++ b/crates/rustok-commerce/admin/src/transport/mod.rs
@@ -6,6 +6,7 @@ mod native_server_adapter;
 #[path = "native_server_adapter_ssr.rs"]
 mod native_server_adapter;
 mod order_change;
+mod order_change_client_error_safety;
 mod promotion;
 mod promotion_client_error_safety;
 mod shipping_profile;

--- a/crates/rustok-commerce/admin/src/transport/order_change.rs
+++ b/crates/rustok-commerce/admin/src/transport/order_change.rs
@@ -2,6 +2,7 @@ use super::{
     graphql_adapter,
     graphql_error_safety::{graphql_correlation_id, map_graphql_error},
     native_server_adapter,
+    order_change_client_error_safety::OrderChangeClientErrorContext,
 };
 use crate::model::{CommerceOrderChange, CommerceOrderChangeActionDraft, CommerceOrderChangeList};
 use native_server_adapter::ApiError;
@@ -34,8 +35,16 @@ pub async fn fetch_order_changes(
                 )
             })
     } else {
+        let context = OrderChangeClientErrorContext::for_fetch(
+            token.as_deref(),
+            tenant_slug.as_deref(),
+            tenant_id.as_str(),
+            order_id.as_deref(),
+            status.as_deref(),
+        );
         native_server_adapter::fetch_order_changes(token, tenant_slug, tenant_id, order_id, status)
             .await
+            .map_err(|order_change_error| context.map_error(order_change_error))
     }
 }
 
@@ -63,6 +72,12 @@ pub async fn apply_order_change(
                 )
             })
     } else {
+        let context = OrderChangeClientErrorContext::for_apply(
+            token.as_deref(),
+            tenant_slug.as_deref(),
+            tenant_id.as_str(),
+            order_change_id.as_str(),
+        );
         native_server_adapter::apply_order_change(
             token,
             tenant_slug,
@@ -71,6 +86,7 @@ pub async fn apply_order_change(
             draft,
         )
         .await
+        .map_err(|order_change_error| context.map_error(order_change_error))
     }
 }
 
@@ -98,6 +114,12 @@ pub async fn cancel_order_change(
                 )
             })
     } else {
+        let context = OrderChangeClientErrorContext::for_cancel(
+            token.as_deref(),
+            tenant_slug.as_deref(),
+            tenant_id.as_str(),
+            order_change_id.as_str(),
+        );
         native_server_adapter::cancel_order_change(
             token,
             tenant_slug,
@@ -106,6 +128,7 @@ pub async fn cancel_order_change(
             draft,
         )
         .await
+        .map_err(|order_change_error| context.map_error(order_change_error))
     }
 }
 

--- a/crates/rustok-commerce/admin/src/transport/order_change_client_error_safety.rs
+++ b/crates/rustok-commerce/admin/src/transport/order_change_client_error_safety.rs
@@ -1,0 +1,128 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::native_server_adapter::ApiError;
+
+const COMMERCE_ADMIN_ORDER_CHANGE_CLIENT_OWNER: &str =
+    "rustok_commerce.admin_order_change_transport";
+const COMMERCE_ADMIN_ORDER_CHANGE_CLIENT_BOUNDARY: &str =
+    "commerce_admin_order_change_client_transport";
+const COMMERCE_ADMIN_ORDER_CHANGE_CLIENT_PUBLIC_MESSAGE: &str =
+    "Commerce admin order-change request could not be completed";
+
+pub(super) struct OrderChangeClientErrorContext {
+    operation: &'static str,
+    correlation_id: String,
+    token_present: bool,
+    tenant_slug_length: Option<usize>,
+    tenant_id_length: usize,
+    order_id_length: Option<usize>,
+    order_change_id_length: Option<usize>,
+    status_length: Option<usize>,
+    payload_present: bool,
+}
+
+impl OrderChangeClientErrorContext {
+    pub(super) fn for_fetch(
+        token: Option<&str>,
+        tenant_slug: Option<&str>,
+        tenant_id: &str,
+        order_id: Option<&str>,
+        status: Option<&str>,
+    ) -> Self {
+        Self {
+            operation: "fetch_order_changes",
+            correlation_id: order_change_client_correlation_id("fetch_order_changes"),
+            token_present: token.is_some(),
+            tenant_slug_length: tenant_slug.map(str::chars).map(Iterator::count),
+            tenant_id_length: tenant_id.chars().count(),
+            order_id_length: order_id.map(str::chars).map(Iterator::count),
+            order_change_id_length: None,
+            status_length: status.map(str::chars).map(Iterator::count),
+            payload_present: false,
+        }
+    }
+
+    pub(super) fn for_apply(
+        token: Option<&str>,
+        tenant_slug: Option<&str>,
+        tenant_id: &str,
+        order_change_id: &str,
+    ) -> Self {
+        Self::for_write(
+            "apply_order_change",
+            token,
+            tenant_slug,
+            tenant_id,
+            order_change_id,
+        )
+    }
+
+    pub(super) fn for_cancel(
+        token: Option<&str>,
+        tenant_slug: Option<&str>,
+        tenant_id: &str,
+        order_change_id: &str,
+    ) -> Self {
+        Self::for_write(
+            "cancel_order_change",
+            token,
+            tenant_slug,
+            tenant_id,
+            order_change_id,
+        )
+    }
+
+    fn for_write(
+        operation: &'static str,
+        token: Option<&str>,
+        tenant_slug: Option<&str>,
+        tenant_id: &str,
+        order_change_id: &str,
+    ) -> Self {
+        Self {
+            operation,
+            correlation_id: order_change_client_correlation_id(operation),
+            token_present: token.is_some(),
+            tenant_slug_length: tenant_slug.map(str::chars).map(Iterator::count),
+            tenant_id_length: tenant_id.chars().count(),
+            order_id_length: None,
+            order_change_id_length: Some(order_change_id.chars().count()),
+            status_length: None,
+            payload_present: true,
+        }
+    }
+
+    pub(super) fn map_error(&self, error: ApiError) -> ApiError {
+        tracing::error!(
+            raw_error = ?error,
+            owner = COMMERCE_ADMIN_ORDER_CHANGE_CLIENT_OWNER,
+            owner_operation = self.operation,
+            correlation_id = %self.correlation_id,
+            token_present = self.token_present,
+            tenant_slug_present = self.tenant_slug_length.is_some(),
+            tenant_slug_length = ?self.tenant_slug_length,
+            tenant_id_present = self.tenant_id_length > 0,
+            tenant_id_length = self.tenant_id_length,
+            order_id_present = self.order_id_length.is_some(),
+            order_id_length = ?self.order_id_length,
+            order_change_id_present = self.order_change_id_length.is_some(),
+            order_change_id_length = ?self.order_change_id_length,
+            status_present = self.status_length.is_some(),
+            status_length = ?self.status_length,
+            payload_present = self.payload_present,
+            code = "commerce.admin_order_change_client_transport_failed",
+            boundary = COMMERCE_ADMIN_ORDER_CHANGE_CLIENT_BOUNDARY,
+            "commerce admin order-change client transport request failed"
+        );
+
+        ApiError::ServerFn(COMMERCE_ADMIN_ORDER_CHANGE_CLIENT_PUBLIC_MESSAGE.to_string())
+    }
+}
+
+fn order_change_client_correlation_id(operation: &'static str) -> String {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("commerce-admin-order-change-client:{operation}:{timestamp}")
+}

--- a/crates/rustok-commerce/admin/src/transport/order_change_client_error_safety.rs
+++ b/crates/rustok-commerce/admin/src/transport/order_change_client_error_safety.rs
@@ -33,11 +33,11 @@ impl OrderChangeClientErrorContext {
             operation: "fetch_order_changes",
             correlation_id: order_change_client_correlation_id("fetch_order_changes"),
             token_present: token.is_some(),
-            tenant_slug_length: tenant_slug.map(str::chars).map(Iterator::count),
+            tenant_slug_length: tenant_slug.map(|value| value.chars().count()),
             tenant_id_length: tenant_id.chars().count(),
-            order_id_length: order_id.map(str::chars).map(Iterator::count),
+            order_id_length: order_id.map(|value| value.chars().count()),
             order_change_id_length: None,
-            status_length: status.map(str::chars).map(Iterator::count),
+            status_length: status.map(|value| value.chars().count()),
             payload_present: false,
         }
     }
@@ -83,7 +83,7 @@ impl OrderChangeClientErrorContext {
             operation,
             correlation_id: order_change_client_correlation_id(operation),
             token_present: token.is_some(),
-            tenant_slug_length: tenant_slug.map(str::chars).map(Iterator::count),
+            tenant_slug_length: tenant_slug.map(|value| value.chars().count()),
             tenant_id_length: tenant_id.chars().count(),
             order_id_length: None,
             order_change_id_length: Some(order_change_id.chars().count()),

--- a/crates/rustok-commerce/contracts/evidence/admin-order-change-client-transport-error-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/admin-order-change-client-transport-error-safety-source-review.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "status": "commerce_admin_order_change_client_transport_error_safety_source_reviewed_unvalidated",
+  "reviewed_boundary": "commerce_admin_order_change_client_transport",
+  "review_findings": [
+    "All three public order-change operations retain the existing Result success and ApiError contracts.",
+    "The GraphQL branches and their existing map_graphql_error calls are unchanged.",
+    "Each native branch creates an operation-specific context before moving request arguments into the unchanged adapter call.",
+    "Each native branch maps only the final returned ApiError to one static public message.",
+    "The original native error remains available only to structured tracing diagnostics.",
+    "Diagnostics retain only token presence and bounded string presence or character-length shape.",
+    "No token, tenant, order, status, or action-draft value is logged by the new client boundary.",
+    "Default and SSR native adapters, mounted endpoints, permissions, owner calls, and response mapping are outside the diff.",
+    "Promotion transport is outside the diff.",
+    "The broad ecommerce mapper cleanup remains open."
+  ],
+  "execution": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false
+  },
+  "review_note": "Source review corrected a generic iterator-count expression to explicit closures; no execution evidence is claimed."
+}

--- a/crates/rustok-commerce/contracts/evidence/admin-order-change-client-transport-error-safety-source.json
+++ b/crates/rustok-commerce/contracts/evidence/admin-order-change-client-transport-error-safety-source.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": 1,
+  "status": "commerce_admin_order_change_client_transport_error_safety_source_unvalidated",
+  "owner": "rustok-commerce",
+  "boundary": "commerce_admin_order_change_client_transport",
+  "public_message": "Commerce admin order-change request could not be completed",
+  "operations": [
+    "fetch_order_changes",
+    "apply_order_change",
+    "cancel_order_change"
+  ],
+  "source_contract": {
+    "native_adapters_changed": false,
+    "server_functions_changed": false,
+    "graphql_transport_changed": false,
+    "promotion_transport_changed": false,
+    "request_response_dto_changed": false,
+    "api_error_contract_preserved": true,
+    "operation_count": 3,
+    "context_created_before_native_call": true,
+    "raw_native_error_public": false,
+    "static_public_message": true,
+    "original_error_logged_privately": true,
+    "per_call_correlation_logging": true,
+    "safe_request_shape_only": true,
+    "token_values_logged": false,
+    "tenant_values_logged": false,
+    "order_values_logged": false,
+    "status_values_logged": false,
+    "action_payload_values_logged": false,
+    "broad_ecommerce_cleanup_closed": false
+  },
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "hydrate_compile_proven": false,
+    "ssr_compile_proven": false,
+    "mounted_runtime_proven": false
+  },
+  "notes": [
+    "The GraphQL branches retain their existing correlation-aware map_graphql_error policy.",
+    "Only final native ApiError results are remapped at the public order-change facade.",
+    "The shared default and SSR native adapters remain unchanged.",
+    "No FFA or FBA status is promoted from source inspection."
+  ]
+}

--- a/crates/rustok-commerce/docs/admin-order-change-client-transport-error-safety.md
+++ b/crates/rustok-commerce/docs/admin-order-change-client-transport-error-safety.md
@@ -1,0 +1,75 @@
+# Commerce Admin order-change client transport error safety
+
+Status: **source-ready / unvalidated**
+
+## Boundary
+
+The public Commerce Admin order-change facade selects GraphQL only for the existing
+WASM non-hydrate profile. All other profiles call the shared native adapter. The
+GraphQL branches already use the correlation-aware `map_graphql_error` policy, while
+the native branches previously returned the shared `ApiError` unchanged.
+
+That shared compatibility error stores `ServerFn(String)`. A framework, transport,
+serialization, or unexpected server-function string could therefore become the
+operator-visible error after leaving an otherwise sanitized native server boundary.
+
+## Covered operations
+
+- `fetch_order_changes`
+- `apply_order_change`
+- `cancel_order_change`
+
+Each native branch now creates `OrderChangeClientErrorContext` before the unchanged
+adapter call and maps only the final returned `ApiError`.
+
+The final public message is always:
+
+`Commerce admin order-change request could not be completed`
+
+## Private diagnostics
+
+The mapper retains the original typed compatibility error only in structured tracing.
+It records:
+
+- owner operation and a per-call correlation ID;
+- stable code and transport boundary;
+- token presence;
+- tenant slug and tenant ID presence or character length;
+- order ID, order-change ID, and status presence or character length;
+- action payload presence.
+
+It does not record token, tenant slug, tenant ID, order ID, order-change ID, status,
+or action-draft values.
+
+## Preserved behavior
+
+This source slice does not change:
+
+- GraphQL transport selection or GraphQL error mapping;
+- the shared default or SSR native adapters;
+- mounted endpoints or server functions;
+- authentication, tenant, permission, or request-context policy;
+- order owner calls, transitions, or response mapping;
+- request or response DTOs;
+- the `Result<..., ApiError>` facade contract;
+- Commerce Admin promotion transport.
+
+## Evidence
+
+- `contracts/evidence/admin-order-change-client-transport-error-safety-source.json`
+- `contracts/evidence/admin-order-change-client-transport-error-safety-source-review.json`
+- `scripts/verify/verify-commerce-admin-order-change-client-transport-error-safety.mjs`
+
+The existing server-side source policy remains separately covered by
+`verify-commerce-admin-order-change-native-error-safety.mjs`.
+
+## Validation still required
+
+Per maintainer instruction, no tests, Node verifiers, Cargo commands, formatting,
+workflows, or CI were run for this slice. Maintainer execution should include the
+focused client and native guards, the aggregate Commerce/ecommerce guards, hydrate
+and SSR compilation, and mounted failure injection for all three operations.
+
+This source result does not promote Commerce FFA/FBA, browser, hydrate, SSR, mounted
+runtime, workflow, CI, or production status. The broad ecommerce correlation-safe
+mapper cleanup remains open for other owner and non-`PortError` envelopes.

--- a/scripts/verify/verify-commerce-admin-order-change-client-transport-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-order-change-client-transport-error-safety.mjs
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const requireCount = (source, value, expected, label) => {
+  const count = source.split(value).length - 1;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+};
+
+function functionBody(source, functionName) {
+  const match = new RegExp(`pub\\s+async\\s+fn\\s+${functionName}\\s*\\(`).exec(source);
+  if (!match) {
+    failures.push(`missing function ${functionName}`);
+    return "";
+  }
+  const openBrace = source.indexOf("{", match.index);
+  if (openBrace < 0) {
+    failures.push(`missing body for ${functionName}`);
+    return "";
+  }
+  let depth = 0;
+  for (let index = openBrace; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(openBrace, index + 1);
+    }
+  }
+  failures.push(`unterminated body for ${functionName}`);
+  return "";
+}
+
+const paths = {
+  routing: "crates/rustok-commerce/admin/src/transport/mod.rs",
+  facade: "crates/rustok-commerce/admin/src/transport/order_change.rs",
+  safety:
+    "crates/rustok-commerce/admin/src/transport/order_change_client_error_safety.rs",
+  native: "crates/rustok-commerce/admin/src/transport/native_server_adapter.rs",
+  nativeSsr:
+    "crates/rustok-commerce/admin/src/transport/native_server_adapter_ssr.rs",
+  evidence:
+    "crates/rustok-commerce/contracts/evidence/admin-order-change-client-transport-error-safety-source.json",
+  review:
+    "crates/rustok-commerce/contracts/evidence/admin-order-change-client-transport-error-safety-source-review.json",
+  doc: "crates/rustok-commerce/docs/admin-order-change-client-transport-error-safety.md",
+  commercePlan: "crates/rustok-commerce/docs/implementation-plan.md",
+  nativeGuard:
+    "scripts/verify/verify-commerce-admin-order-change-native-error-safety.mjs",
+};
+
+const routing = read(paths.routing);
+const facade = read(paths.facade);
+const safety = read(paths.safety);
+const native = read(paths.native);
+const nativeSsr = read(paths.nativeSsr);
+const evidence = JSON.parse(read(paths.evidence));
+const review = JSON.parse(read(paths.review));
+const doc = read(paths.doc);
+const commercePlan = read(paths.commercePlan);
+const nativeGuard = read(paths.nativeGuard);
+
+requireText(
+  routing,
+  "mod order_change_client_error_safety;",
+  `${paths.routing}: client error policy wiring`,
+);
+requireText(
+  routing,
+  "pub use order_change::{apply_order_change, cancel_order_change, fetch_order_changes};",
+  `${paths.routing}: order-change exports`,
+);
+
+for (const marker of [
+  "order_change_client_error_safety::OrderChangeClientErrorContext",
+  "Result<CommerceOrderChangeList, ApiError>",
+  "Result<CommerceOrderChange, ApiError>",
+  "if use_graphql_transport()",
+]) {
+  requireText(facade, marker, `${paths.facade}: preserved facade contract`);
+}
+requireCount(
+  facade,
+  "map_graphql_error(",
+  3,
+  `${paths.facade}: preserved GraphQL error mappings`,
+);
+requireCount(
+  facade,
+  ".map_err(|order_change_error| context.map_error(order_change_error))",
+  3,
+  `${paths.facade}: final native client mappings`,
+);
+
+for (const [operation, constructor, nativeCall] of [
+  [
+    "fetch_order_changes",
+    "OrderChangeClientErrorContext::for_fetch",
+    "native_server_adapter::fetch_order_changes(",
+  ],
+  [
+    "apply_order_change",
+    "OrderChangeClientErrorContext::for_apply",
+    "native_server_adapter::apply_order_change(",
+  ],
+  [
+    "cancel_order_change",
+    "OrderChangeClientErrorContext::for_cancel",
+    "native_server_adapter::cancel_order_change(",
+  ],
+]) {
+  const body = functionBody(facade, operation);
+  requireText(body, constructor, `${paths.facade}: ${operation} context`);
+  requireText(body, nativeCall, `${paths.facade}: ${operation} native call`);
+  requireText(
+    body,
+    ".map_err(|order_change_error| context.map_error(order_change_error))",
+    `${paths.facade}: ${operation} final mapping`,
+  );
+  const elseIndex = body.indexOf("} else {");
+  const contextIndex = body.indexOf(constructor);
+  const nativeIndex = body.indexOf(nativeCall);
+  if (
+    elseIndex < 0 ||
+    contextIndex < 0 ||
+    nativeIndex < 0 ||
+    contextIndex < elseIndex ||
+    contextIndex > nativeIndex
+  ) {
+    failures.push(
+      `${paths.facade}: ${operation} context must be inside the native branch before the adapter call`,
+    );
+  }
+}
+
+for (const marker of [
+  'const COMMERCE_ADMIN_ORDER_CHANGE_CLIENT_OWNER: &str =',
+  '"rustok_commerce.admin_order_change_transport"',
+  'const COMMERCE_ADMIN_ORDER_CHANGE_CLIENT_BOUNDARY: &str =',
+  '"commerce_admin_order_change_client_transport"',
+  '"Commerce admin order-change request could not be completed"',
+  "pub(super) struct OrderChangeClientErrorContext",
+  'operation: "fetch_order_changes"',
+  'Self::for_write(\n            "apply_order_change"',
+  'Self::for_write(\n            "cancel_order_change"',
+  "raw_error = ?error",
+  "owner_operation = self.operation",
+  "correlation_id = %self.correlation_id",
+  "token_present = self.token_present",
+  "tenant_slug_present = self.tenant_slug_length.is_some()",
+  "tenant_id_present = self.tenant_id_length > 0",
+  "order_id_present = self.order_id_length.is_some()",
+  "order_change_id_present = self.order_change_id_length.is_some()",
+  "status_present = self.status_length.is_some()",
+  "payload_present = self.payload_present",
+  'code = "commerce.admin_order_change_client_transport_failed"',
+  "boundary = COMMERCE_ADMIN_ORDER_CHANGE_CLIENT_BOUNDARY",
+  "ApiError::ServerFn(COMMERCE_ADMIN_ORDER_CHANGE_CLIENT_PUBLIC_MESSAGE.to_string())",
+]) {
+  requireText(safety, marker, `${paths.safety}: safe final mapping`);
+}
+
+for (const forbidden of [
+  "token = %",
+  "token = ?",
+  "tenant_slug = %",
+  "tenant_slug = ?",
+  "tenant_id = %",
+  "tenant_id = ?",
+  "order_id = %",
+  "order_id = ?",
+  "order_change_id = %",
+  "order_change_id = ?",
+  "status = %",
+  "status = ?",
+  "draft = ?",
+  "payload = ?",
+  "error.to_string()",
+]) {
+  forbidText(safety, forbidden, `${paths.safety}: raw request or error text`);
+}
+
+for (const source of [native, nativeSsr]) {
+  for (const [operation, nativeCall] of [
+    [
+      "fetch_order_changes",
+      "commerce_admin_order_changes_native(tenant_id, order_id, status)",
+    ],
+    [
+      "apply_order_change",
+      "commerce_admin_apply_order_change_native(tenant_id, id, draft)",
+    ],
+    [
+      "cancel_order_change",
+      "commerce_admin_cancel_order_change_native(tenant_id, id, draft)",
+    ],
+  ]) {
+    const body = functionBody(source, operation);
+    requireText(body, nativeCall, `native adapter: preserved ${operation} call`);
+    requireText(body, ".map_err(Into::into)", `native adapter: preserved ${operation} mapping`);
+  }
+}
+
+for (const endpoint of [
+  'endpoint = "commerce/admin/order-changes"',
+  'endpoint = "commerce/admin/apply-order-change"',
+  'endpoint = "commerce/admin/cancel-order-change"',
+]) {
+  requireText(nativeSsr, endpoint, `${paths.nativeSsr}: preserved endpoint`);
+}
+requireText(
+  nativeGuard,
+  "Commerce admin order-change native error-safety source invariants passed",
+  `${paths.nativeGuard}: prior server-side guard remains registered`,
+);
+
+if (
+  evidence.status !==
+  "commerce_admin_order_change_client_transport_error_safety_source_unvalidated"
+) {
+  failures.push(`${paths.evidence}: unexpected status ${evidence.status}`);
+}
+if (
+  review.status !==
+  "commerce_admin_order_change_client_transport_error_safety_source_reviewed_unvalidated"
+) {
+  failures.push(`${paths.review}: unexpected status ${review.status}`);
+}
+
+for (const [key, expected] of Object.entries({
+  native_adapters_changed: false,
+  server_functions_changed: false,
+  graphql_transport_changed: false,
+  promotion_transport_changed: false,
+  request_response_dto_changed: false,
+  api_error_contract_preserved: true,
+  operation_count: 3,
+  context_created_before_native_call: true,
+  raw_native_error_public: false,
+  static_public_message: true,
+  original_error_logged_privately: true,
+  per_call_correlation_logging: true,
+  safe_request_shape_only: true,
+  token_values_logged: false,
+  tenant_values_logged: false,
+  order_values_logged: false,
+  status_values_logged: false,
+  action_payload_values_logged: false,
+  broad_ecommerce_cleanup_closed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "hydrate_compile_proven",
+  "ssr_compile_proven",
+  "mounted_runtime_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+
+requireText(doc, "Status: **source-ready / unvalidated**", `${paths.doc}: status`);
+requireText(
+  doc,
+  "Commerce admin order-change request could not be completed",
+  `${paths.doc}: static public message`,
+);
+requireText(
+  commercePlan,
+  "Finish correlation-safe mapper cleanup",
+  `${paths.commercePlan}: broad ecommerce cleanup remains open`,
+);
+
+if (failures.length > 0) {
+  console.error("Commerce Admin order-change client transport error-safety verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "Commerce Admin order-change native failures use a correlation-safe static final envelope across three operations; execution evidence remains open",
+);


### PR DESCRIPTION
## Summary
- close the remaining raw native `ApiError` escape in the Commerce Admin order-change facade
- cover `fetch_order_changes`, `apply_order_change`, and `cancel_order_change`
- preserve the existing GraphQL transport branches and all three correlation-aware `map_graphql_error` calls
- create an operation-specific client context before each unchanged native adapter call
- retain the original native error only in structured diagnostics
- record operation, correlation id, stable code, boundary, token presence, bounded tenant/order/status lengths, and action-payload presence only
- return one static final public message: `Commerce admin order-change request could not be completed`
- preserve the shared `Result<…, ApiError>` contract, default/SSR native adapters, mounted endpoints, owner mappings, permissions, DTOs, and Commerce Admin promotion transport
- add source evidence, documentation, source review, and a focused fail-closed verifier

## Confirmed gap
The public facade already sanitized all GraphQL failures. Its native branches nevertheless returned the shared compatibility `ApiError` unchanged. Because that type stores `ServerFn(String)`, framework, transport, serialization, or unexpected server-function text could still become the operator-visible error after leaving the native adapter.

## Boundary placement
Each native branch creates `OrderChangeClientErrorContext` before moving its existing arguments into the adapter call and maps only the final returned `ApiError`. Transport selection, retries, request parsing, authentication, tenant and permission policy, owner calls, state transitions, response mapping, and invocation order are unchanged.

## Diagnostics
The client boundary logs safe shape metadata only. It does not log token, tenant slug/ID, order ID, order-change ID, status, or action-draft values. The original compatibility error remains private to tracing.

## Recheck findings
- the three GraphQL mapper callsites are unchanged
- the final native mapper appears exactly three times
- context construction is inside each native branch and precedes its adapter call
- success signatures, DTOs, and `ApiError` remain unchanged
- default and SSR native adapters are outside the diff
- the existing server-side order-change error-safety guard remains unchanged
- Commerce Admin promotion transport is outside the diff
- source review replaced a potentially brittle generic iterator-count expression with explicit closures
- the broad ecommerce mapper-cleanup item remains open

`main` advanced by one unrelated Blog FBA commit while the branch was prepared. The compare contains only seven Commerce order-change source/evidence files.

## Validation
Per maintainer instruction, tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run. Evidence remains source-ready / unvalidated and does not promote Commerce FFA/FBA, hydrate, SSR, browser, mounted runtime, workflow, CI, or production status.

Suggested maintainer commands:
```bash
node scripts/verify/verify-commerce-admin-order-change-client-transport-error-safety.mjs
node scripts/verify/verify-commerce-admin-order-change-native-error-safety.mjs
node scripts/verify/verify-commerce-admin-boundary.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-commerce-admin
cargo check -p rustok-commerce-admin --features hydrate
cargo check -p rustok-commerce-admin --features ssr
```