### PR TITLE
fix(cart): sanitize storefront native client errors

### DIFF
--- a/crates/rustok-cart/contracts/evidence/storefront-native-client-error-safety-source-review.json
+++ b/crates/rustok-cart/contracts/evidence/storefront-native-client-error-safety-source-review.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-31",
+  "status": "storefront_native_client_error_safety_source_reviewed_unvalidated",
+  "review": {
+    "native_context_before_call": true,
+    "native_final_mapper_count": 3,
+    "graphql_mapper_count_preserved": 3,
+    "selected_transport_path_preserved": true,
+    "validation_variant_preserved": true,
+    "technical_variants_fail_closed": true,
+    "static_public_message": true,
+    "raw_error_private_to_tracing": true,
+    "request_values_logged": false,
+    "native_adapters_outside_diff": true,
+    "server_functions_outside_diff": true,
+    "request_response_dto_outside_diff": true,
+    "ui_transport_error_type_preserved": true,
+    "existing_transport_tests_preserved": true,
+    "broad_ecommerce_cleanup_remains_open": true
+  },
+  "execution": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false
+  }
+}

--- a/crates/rustok-cart/contracts/evidence/storefront-native-client-error-safety-source.json
+++ b/crates/rustok-cart/contracts/evidence/storefront-native-client-error-safety-source.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-31",
+  "status": "storefront_native_client_error_safety_source_unvalidated",
+  "scope": "cart storefront fetch, decrement, and remove native client transport aggregation",
+  "source_contract": {
+    "operation_count": 3,
+    "transport_selection_changed": false,
+    "graphql_transport_changed": false,
+    "native_adapters_changed": false,
+    "server_functions_changed": false,
+    "request_response_dto_changed": false,
+    "ui_transport_error_contract_preserved": true,
+    "validation_message_preserved": true,
+    "technical_native_error_public": false,
+    "static_technical_public_message": true,
+    "context_created_before_native_call": true,
+    "original_error_logged_privately": true,
+    "per_call_correlation_logging": true,
+    "safe_request_shape_only": true,
+    "cart_id_values_logged": false,
+    "line_item_id_values_logged": false,
+    "locale_values_logged": false,
+    "fallback_enabled": false,
+    "broad_ecommerce_cleanup_closed": false
+  },
+  "stable_public_messages": {
+    "technical_native_failure": "Cart storefront request could not be completed",
+    "validation": "preserved from CartCoreError::Validation"
+  },
+  "suggested_execution": [
+    "node scripts/verify/verify-cart-storefront-native-client-error-safety.mjs",
+    "node scripts/verify/verify-cart-storefront-native-error-safety.mjs",
+    "node scripts/verify/verify-cart-storefront-graphql-error-safety.mjs",
+    "node scripts/verify/verify-cart-storefront-boundary.mjs",
+    "cargo check -p rustok-cart-storefront",
+    "cargo check -p rustok-cart-storefront --features hydrate",
+    "cargo check -p rustok-cart-storefront --features ssr"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "hydrate_compile_proven": false,
+    "ssr_compile_proven": false,
+    "browser_runtime_proven": false,
+    "mounted_runtime_proven": false
+  }
+}

--- a/crates/rustok-cart/docs/implementation-plan.md
+++ b/crates/rustok-cart/docs/implementation-plan.md
@@ -1,6 +1,6 @@
 # Implementation plan for `rustok-cart`
 
-Last reviewed: 2026-07-23
+Last reviewed: 2026-07-31
 
 ## Current state
 
@@ -51,6 +51,10 @@ transport `status` fields remain strings for backward compatibility.
 - Storefront repricing calls the pricing-owned `PricingReadPort` with a
   variant-first request and full resolved-price projection; it no longer calls
   `PricingService::resolve_variant_price` directly.
+- Storefront native client error safety: `source_ready_unvalidated` — fetch,
+  decrement, and remove preserve validation messages while technical native
+  failures are remapped before `UiTransportError` aggregation to one static
+  public envelope with correlation-aware, shape-only private diagnostics.
 - The compiled commerce checkout channel-inventory regression executes the
   in-process cart checkout provider before product and inventory preflight.
   It is bounded provider-consumer evidence; lifecycle recovery and fallback

--- a/crates/rustok-cart/docs/storefront-native-client-error-safety.md
+++ b/crates/rustok-cart/docs/storefront-native-client-error-safety.md
@@ -1,0 +1,68 @@
+# Cart storefront native client error safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice closes the final native client transport escape for the Cart storefront
+operations:
+
+- `fetch_cart`;
+- `decrement_line_item`;
+- `remove_line_item`.
+
+The mounted SSR adapter already returns static public envelopes and keeps owner and
+framework causes in structured server diagnostics. The hydrate/client compatibility
+adapter still exposes `ApiError::ServerFn(String)`, and `execute_selected_transport`
+records the error `Display` inside the public `UiTransportError`. An unexpected
+framework, serialization, or server-function string could therefore become visible
+after leaving the native adapter.
+
+## Client boundary
+
+Each native closure now creates `NativeClientErrorContext` before calling the
+unchanged native adapter. The final native `ApiError` is mapped before transport
+aggregation.
+
+`ApiError::Validation` is preserved unchanged because it carries the existing
+Cart core validation contract. Technical native variants fail closed to:
+
+`Cart storefront request could not be completed`
+
+The original technical error is retained only in structured diagnostics with:
+
+- owner and owner operation;
+- per-call correlation ID;
+- stable code and boundary;
+- selected cart, locale, cart, and line-item presence/character lengths.
+
+The diagnostic event does not contain cart IDs, line-item IDs, locale values, cart
+contents, pricing data, customer data, or other request payload values.
+
+## Preserved behavior
+
+- Explicit native/GraphQL transport selection is unchanged.
+- No fallback is introduced.
+- The three GraphQL call contexts and error mappings are unchanged.
+- `CartTransportError` remains the `UiTransportError` alias.
+- Request and response DTOs are unchanged.
+- The default and SSR native adapters and mounted server functions are unchanged.
+- Existing validation and transport-envelope test source is unchanged.
+
+## Evidence boundary
+
+This is source-only evidence. It does not prove compilation, hydrate/SSR behavior,
+browser rendering, mounted endpoint execution, diagnostic emission, workflows, CI,
+or production readiness. Cart FFA/FBA status is not promoted.
+
+Suggested checks:
+
+```bash
+node scripts/verify/verify-cart-storefront-native-client-error-safety.mjs
+node scripts/verify/verify-cart-storefront-native-error-safety.mjs
+node scripts/verify/verify-cart-storefront-graphql-error-safety.mjs
+node scripts/verify/verify-cart-storefront-boundary.mjs
+cargo check -p rustok-cart-storefront
+cargo check -p rustok-cart-storefront --features hydrate
+cargo check -p rustok-cart-storefront --features ssr
+```

--- a/crates/rustok-cart/storefront/src/transport/mod.rs
+++ b/crates/rustok-cart/storefront/src/transport/mod.rs
@@ -1,5 +1,6 @@
 mod graphql_adapter;
 mod graphql_error_safety;
+mod native_client_error_safety;
 #[cfg(not(feature = "ssr"))]
 mod native_server_adapter;
 #[cfg(feature = "ssr")]
@@ -33,7 +34,13 @@ pub async fn fetch_cart(request: CartFetchRequest) -> TransportResult<Storefront
     execute_selected_transport(
         "cart",
         selected_transport_path(),
-        move || native_server_adapter::fetch_cart(native_request),
+        move || async move {
+            let context =
+                native_client_error_safety::NativeClientErrorContext::fetch_cart(&native_request);
+            native_server_adapter::fetch_cart(native_request)
+                .await
+                .map_err(|error| context.map_error(error))
+        },
         move || async move {
             let context = graphql_error_safety::GraphqlCallContext::fetch_cart(&request);
             graphql_adapter::fetch_cart(request)
@@ -49,7 +56,14 @@ pub async fn decrement_line_item(request: CartLineItemDecrementRequest) -> Trans
     execute_selected_transport(
         "cart",
         selected_transport_path(),
-        move || native_server_adapter::decrement_line_item(native_request),
+        move || async move {
+            let context = native_client_error_safety::NativeClientErrorContext::decrement_line_item(
+                &native_request,
+            );
+            native_server_adapter::decrement_line_item(native_request)
+                .await
+                .map_err(|error| context.map_error(error))
+        },
         move || async move {
             let context = graphql_error_safety::GraphqlCallContext::decrement_line_item(&request);
             graphql_adapter::decrement_line_item(request)
@@ -65,7 +79,14 @@ pub async fn remove_line_item(request: CartLineItemMutationRequest) -> Transport
     execute_selected_transport(
         "cart",
         selected_transport_path(),
-        move || native_server_adapter::remove_line_item(native_request),
+        move || async move {
+            let context = native_client_error_safety::NativeClientErrorContext::remove_line_item(
+                &native_request,
+            );
+            native_server_adapter::remove_line_item(native_request)
+                .await
+                .map_err(|error| context.map_error(error))
+        },
         move || async move {
             let context = graphql_error_safety::GraphqlCallContext::remove_line_item(&request);
             graphql_adapter::remove_line_item(request)

--- a/crates/rustok-cart/storefront/src/transport/native_client_error_safety.rs
+++ b/crates/rustok-cart/storefront/src/transport/native_client_error_safety.rs
@@ -1,0 +1,105 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::core::{CartFetchRequest, CartLineItemDecrementRequest, CartLineItemMutationRequest};
+
+use super::native_server_adapter::ApiError;
+
+const CART_STOREFRONT_NATIVE_CLIENT_OWNER: &str = "rustok_cart.storefront";
+const CART_STOREFRONT_NATIVE_CLIENT_BOUNDARY: &str =
+    "cart_storefront_native_client_transport";
+const CART_STOREFRONT_NATIVE_CLIENT_PUBLIC_MESSAGE: &str =
+    "Cart storefront request could not be completed";
+
+pub(super) struct NativeClientErrorContext {
+    operation: &'static str,
+    correlation_id: String,
+    selected_cart_id_length: Option<usize>,
+    locale_length: Option<usize>,
+    cart_id_length: Option<usize>,
+    line_item_id_length: Option<usize>,
+}
+
+impl NativeClientErrorContext {
+    pub(super) fn fetch_cart(request: &CartFetchRequest) -> Self {
+        Self {
+            operation: "fetch_cart",
+            correlation_id: native_client_correlation_id("fetch_cart"),
+            selected_cart_id_length: request
+                .selected_cart_id
+                .as_deref()
+                .map(|value| value.chars().count()),
+            locale_length: request
+                .locale
+                .as_deref()
+                .map(|value| value.chars().count()),
+            cart_id_length: None,
+            line_item_id_length: None,
+        }
+    }
+
+    pub(super) fn decrement_line_item(request: &CartLineItemDecrementRequest) -> Self {
+        Self::line_item_operation(
+            "decrement_line_item",
+            request.cart_id.as_str(),
+            request.line_item_id.as_str(),
+        )
+    }
+
+    pub(super) fn remove_line_item(request: &CartLineItemMutationRequest) -> Self {
+        Self::line_item_operation(
+            "remove_line_item",
+            request.cart_id.as_str(),
+            request.line_item_id.as_str(),
+        )
+    }
+
+    fn line_item_operation(
+        operation: &'static str,
+        cart_id: &str,
+        line_item_id: &str,
+    ) -> Self {
+        Self {
+            operation,
+            correlation_id: native_client_correlation_id(operation),
+            selected_cart_id_length: None,
+            locale_length: None,
+            cart_id_length: Some(cart_id.chars().count()),
+            line_item_id_length: Some(line_item_id.chars().count()),
+        }
+    }
+
+    pub(super) fn map_error(&self, error: ApiError) -> ApiError {
+        match error {
+            ApiError::Validation(message) => ApiError::Validation(message),
+            error => {
+                tracing::error!(
+                    raw_error = ?error,
+                    owner = CART_STOREFRONT_NATIVE_CLIENT_OWNER,
+                    owner_operation = self.operation,
+                    correlation_id = %self.correlation_id,
+                    selected_cart_id_present = self.selected_cart_id_length.is_some(),
+                    selected_cart_id_length = ?self.selected_cart_id_length,
+                    locale_present = self.locale_length.is_some(),
+                    locale_length = ?self.locale_length,
+                    cart_id_present = self.cart_id_length.is_some(),
+                    cart_id_length = ?self.cart_id_length,
+                    line_item_id_present = self.line_item_id_length.is_some(),
+                    line_item_id_length = ?self.line_item_id_length,
+                    code = "cart.storefront_native_client_transport_failed",
+                    boundary = CART_STOREFRONT_NATIVE_CLIENT_BOUNDARY,
+                    "cart storefront native client transport request failed"
+                );
+
+                ApiError::ServerFn(CART_STOREFRONT_NATIVE_CLIENT_PUBLIC_MESSAGE.to_string())
+            }
+        }
+    }
+}
+
+fn native_client_correlation_id(operation: &'static str) -> String {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("cart-storefront-native-client:{operation}:{timestamp}")
+}

--- a/scripts/verify/verify-cart-storefront-graphql-error-safety.mjs
+++ b/scripts/verify/verify-cart-storefront-graphql-error-safety.mjs
@@ -48,9 +48,18 @@ for (const [value, label] of [
   ["graphql_adapter::decrement_line_item(request)", "decrement adapter preservation"],
   ["graphql_adapter::remove_line_item(request)", "remove adapter preservation"],
   [".map_err(|error| context.map_error(error))", "consumer-boundary mapping"],
-  ["move || native_server_adapter::fetch_cart(native_request)", "native fetch preservation"],
-  ["move || native_server_adapter::decrement_line_item(native_request)", "native decrement preservation"],
-  ["move || native_server_adapter::remove_line_item(native_request)", "native remove preservation"],
+  ["NativeClientErrorContext::fetch_cart(&native_request)", "native fetch context preservation"],
+  ["native_server_adapter::fetch_cart(native_request)", "native fetch preservation"],
+  [
+    "NativeClientErrorContext::decrement_line_item(",
+    "native decrement context preservation",
+  ],
+  [
+    "native_server_adapter::decrement_line_item(native_request)",
+    "native decrement preservation",
+  ],
+  ["NativeClientErrorContext::remove_line_item(", "native remove context preservation"],
+  ["native_server_adapter::remove_line_item(native_request)", "native remove preservation"],
 ]) requireText(transport, value, label);
 forbidText(transport, "move || graphql_adapter::", "unsanitized GraphQL closure");
 

--- a/scripts/verify/verify-cart-storefront-native-client-error-safety.mjs
+++ b/scripts/verify/verify-cart-storefront-native-client-error-safety.mjs
@@ -29,12 +29,8 @@ function functionBody(source, functionName) {
     return "";
   }
   const openBrace = source.indexOf("{", match.index);
-  if (openBrace < 0) {
-    failures.push(`missing body for ${functionName}`);
-    return "";
-  }
   let depth = 0;
-  for (let index = openBrace; index < source.length; index += 1) {
+  for (let index = openBrace; index >= 0 && index < source.length; index += 1) {
     if (source[index] === "{") depth += 1;
     if (source[index] === "}") {
       depth -= 1;
@@ -45,7 +41,7 @@ function functionBody(source, functionName) {
   return "";
 }
 
-const paths = {
+const files = {
   transport: "crates/rustok-cart/storefront/src/transport/mod.rs",
   safety: "crates/rustok-cart/storefront/src/transport/native_client_error_safety.rs",
   native: "crates/rustok-cart/storefront/src/transport/native_server_adapter.rs",
@@ -61,66 +57,43 @@ const paths = {
   graphqlGuard: "scripts/verify/verify-cart-storefront-graphql-error-safety.mjs",
 };
 
-const transport = read(paths.transport);
-const safety = read(paths.safety);
-const native = read(paths.native);
-const nativeSsr = read(paths.nativeSsr);
-const graphqlSafety = read(paths.graphqlSafety);
-const evidence = JSON.parse(read(paths.evidence));
-const review = JSON.parse(read(paths.review));
-const doc = read(paths.doc);
-const plan = read(paths.plan);
-const nativeGuard = read(paths.nativeGuard);
-const graphqlGuard = read(paths.graphqlGuard);
+const transport = read(files.transport);
+const safety = read(files.safety);
+const native = read(files.native);
+const nativeSsr = read(files.nativeSsr);
+const graphqlSafety = read(files.graphqlSafety);
+const evidence = JSON.parse(read(files.evidence));
+const review = JSON.parse(read(files.review));
+const doc = read(files.doc);
+const plan = read(files.plan);
+const nativeGuard = read(files.nativeGuard);
+const graphqlGuard = read(files.graphqlGuard);
 
-requireText(
-  transport,
+for (const marker of [
   "mod native_client_error_safety;",
-  `${paths.transport}: native client safety module wiring`,
-);
-requireText(
-  transport,
   "pub type CartTransportError = UiTransportError;",
-  `${paths.transport}: public transport error alias`,
-);
-requireText(
-  transport,
   "pub type TransportResult<T> = UiTransportResult<T>;",
-  `${paths.transport}: public result alias`,
-);
-requireText(
-  transport,
   "UiTransportPath::NativeServer",
-  `${paths.transport}: native transport selection`,
-);
-requireText(
-  transport,
   "UiTransportPath::Graphql",
-  `${paths.transport}: GraphQL transport selection`,
-);
-forbidText(
-  transport,
-  "fallback_attempted = true",
-  `${paths.transport}: no fallback may be introduced`,
-);
-
+]) requireText(transport, marker, `${files.transport}: preserved transport contract`);
+forbidText(transport, "fallback_attempted = true", `${files.transport}: fallback policy`);
 requireCount(
   transport,
   "native_client_error_safety::NativeClientErrorContext::",
   3,
-  `${paths.transport}: native client contexts`,
+  `${files.transport}: native contexts`,
 );
 requireCount(
   transport,
   "graphql_error_safety::GraphqlCallContext::",
   3,
-  `${paths.transport}: preserved GraphQL contexts`,
+  `${files.transport}: GraphQL contexts`,
 );
 requireCount(
   transport,
   ".map_err(|error| context.map_error(error))",
   6,
-  `${paths.transport}: three native and three GraphQL final mappings`,
+  `${files.transport}: native plus GraphQL final mappings`,
 );
 
 for (const [operation, nativeContext, nativeCall, graphqlContext, graphqlCall] of [
@@ -148,17 +121,13 @@ for (const [operation, nativeContext, nativeCall, graphqlContext, graphqlCall] o
 ]) {
   const body = functionBody(transport, operation);
   for (const marker of [nativeContext, nativeCall, graphqlContext, graphqlCall]) {
-    requireText(body, marker, `${paths.transport}: ${operation}`);
+    requireText(body, marker, `${files.transport}: ${operation}`);
   }
-  const nativeContextIndex = body.indexOf(nativeContext);
-  const nativeCallIndex = body.indexOf(nativeCall);
-  const graphqlContextIndex = body.indexOf(graphqlContext);
-  const graphqlCallIndex = body.indexOf(graphqlCall);
-  if (nativeContextIndex < 0 || nativeContextIndex > nativeCallIndex) {
-    failures.push(`${paths.transport}: ${operation} native context must precede call`);
+  if (body.indexOf(nativeContext) > body.indexOf(nativeCall)) {
+    failures.push(`${files.transport}: ${operation} native context must precede call`);
   }
-  if (graphqlContextIndex < 0 || graphqlContextIndex > graphqlCallIndex) {
-    failures.push(`${paths.transport}: ${operation} GraphQL context must precede call`);
+  if (body.indexOf(graphqlContext) > body.indexOf(graphqlCall)) {
+    failures.push(`${files.transport}: ${operation} GraphQL context must precede call`);
   }
 }
 
@@ -181,9 +150,7 @@ for (const marker of [
   'code = "cart.storefront_native_client_transport_failed"',
   "boundary = CART_STOREFRONT_NATIVE_CLIENT_BOUNDARY",
   "ApiError::ServerFn(CART_STOREFRONT_NATIVE_CLIENT_PUBLIC_MESSAGE.to_string())",
-]) {
-  requireText(safety, marker, `${paths.safety}: safe final mapping`);
-}
+]) requireText(safety, marker, `${files.safety}: safe final mapping`);
 
 for (const forbidden of [
   "selected_cart_id = %",
@@ -196,9 +163,7 @@ for (const forbidden of [
   "line_item_id = ?",
   "request = ?",
   "error.to_string()",
-]) {
-  forbidText(safety, forbidden, `${paths.safety}: raw request or error text`);
-}
+]) forbidText(safety, forbidden, `${files.safety}: raw request or error text`);
 
 for (const adapter of [native, nativeSsr]) {
   for (const marker of [
@@ -209,41 +174,38 @@ for (const adapter of [native, nativeSsr]) {
     "pub async fn fetch_cart(",
     "pub async fn decrement_line_item(",
     "pub async fn remove_line_item(",
-  ]) {
-    requireText(adapter, marker, "native adapter contract");
-  }
+  ]) requireText(adapter, marker, "native adapter contract");
 }
 requireText(
   nativeSsr,
   "CART_STOREFRONT_NATIVE_BOUNDARY",
-  `${paths.nativeSsr}: mounted server-side safe boundary`,
+  `${files.nativeSsr}: mounted safe boundary`,
 );
 requireText(
   graphqlSafety,
   "pub(super) struct GraphqlCallContext",
-  `${paths.graphqlSafety}: GraphQL safety policy`,
+  `${files.graphqlSafety}: GraphQL safety policy`,
 );
 requireText(
   nativeGuard,
-  "Cart storefront native error-safety source invariants passed",
-  `${paths.nativeGuard}: prior mounted native guard`,
+  "Cart storefront native error-safety verification failed:",
+  `${files.nativeGuard}: mounted native guard identity`,
 );
 requireText(
   graphqlGuard,
-  "Cart storefront GraphQL error-safety source invariants passed",
-  `${paths.graphqlGuard}: prior GraphQL guard`,
+  "Cart storefront GraphQL error-safety verification failed:",
+  `${files.graphqlGuard}: GraphQL guard identity`,
 );
 
 if (evidence.status !== "storefront_native_client_error_safety_source_unvalidated") {
-  failures.push(`${paths.evidence}: unexpected status ${evidence.status}`);
+  failures.push(`${files.evidence}: unexpected status ${evidence.status}`);
 }
 if (
   review.status !==
   "storefront_native_client_error_safety_source_reviewed_unvalidated"
 ) {
-  failures.push(`${paths.review}: unexpected status ${review.status}`);
+  failures.push(`${files.review}: unexpected status ${review.status}`);
 }
-
 for (const [key, expected] of Object.entries({
   operation_count: 3,
   transport_selection_changed: false,
@@ -266,10 +228,9 @@ for (const [key, expected] of Object.entries({
   broad_ecommerce_cleanup_closed: false,
 })) {
   if (evidence.source_contract?.[key] !== expected) {
-    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+    failures.push(`${files.evidence}: source_contract.${key} must be ${expected}`);
   }
 }
-
 for (const key of [
   "tests_run",
   "cargo_run",
@@ -283,20 +244,24 @@ for (const key of [
   "mounted_runtime_proven",
 ]) {
   if (evidence.validation?.[key] !== false) {
-    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+    failures.push(`${files.evidence}: validation.${key} must remain false`);
   }
 }
-
-requireText(doc, "Status: **source-ready / unvalidated**", `${paths.doc}: status`);
+requireText(doc, "Status: **source-ready / unvalidated**", `${files.doc}: status`);
 requireText(
   doc,
   "Cart storefront request could not be completed",
-  `${paths.doc}: static technical public message`,
+  `${files.doc}: static technical message`,
+);
+requireText(
+  plan,
+  "Storefront native client error safety: `source_ready_unvalidated`",
+  `${files.plan}: local source status`,
 );
 requireText(
   plan,
   "No verification command was executed in this source wave.",
-  `${paths.plan}: execution disclosure remains explicit`,
+  `${files.plan}: execution disclosure`,
 );
 
 if (failures.length > 0) {

--- a/scripts/verify/verify-cart-storefront-native-client-error-safety.mjs
+++ b/scripts/verify/verify-cart-storefront-native-client-error-safety.mjs
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const requireCount = (source, value, expected, label) => {
+  const count = source.split(value).length - 1;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+};
+
+function functionBody(source, functionName) {
+  const match = new RegExp(`pub\\s+async\\s+fn\\s+${functionName}\\s*\\(`).exec(source);
+  if (!match) {
+    failures.push(`missing function ${functionName}`);
+    return "";
+  }
+  const openBrace = source.indexOf("{", match.index);
+  if (openBrace < 0) {
+    failures.push(`missing body for ${functionName}`);
+    return "";
+  }
+  let depth = 0;
+  for (let index = openBrace; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(openBrace, index + 1);
+    }
+  }
+  failures.push(`unterminated body for ${functionName}`);
+  return "";
+}
+
+const paths = {
+  transport: "crates/rustok-cart/storefront/src/transport/mod.rs",
+  safety: "crates/rustok-cart/storefront/src/transport/native_client_error_safety.rs",
+  native: "crates/rustok-cart/storefront/src/transport/native_server_adapter.rs",
+  nativeSsr: "crates/rustok-cart/storefront/src/transport/native_server_adapter_ssr.rs",
+  graphqlSafety: "crates/rustok-cart/storefront/src/transport/graphql_error_safety.rs",
+  evidence:
+    "crates/rustok-cart/contracts/evidence/storefront-native-client-error-safety-source.json",
+  review:
+    "crates/rustok-cart/contracts/evidence/storefront-native-client-error-safety-source-review.json",
+  doc: "crates/rustok-cart/docs/storefront-native-client-error-safety.md",
+  plan: "crates/rustok-cart/docs/implementation-plan.md",
+  nativeGuard: "scripts/verify/verify-cart-storefront-native-error-safety.mjs",
+  graphqlGuard: "scripts/verify/verify-cart-storefront-graphql-error-safety.mjs",
+};
+
+const transport = read(paths.transport);
+const safety = read(paths.safety);
+const native = read(paths.native);
+const nativeSsr = read(paths.nativeSsr);
+const graphqlSafety = read(paths.graphqlSafety);
+const evidence = JSON.parse(read(paths.evidence));
+const review = JSON.parse(read(paths.review));
+const doc = read(paths.doc);
+const plan = read(paths.plan);
+const nativeGuard = read(paths.nativeGuard);
+const graphqlGuard = read(paths.graphqlGuard);
+
+requireText(
+  transport,
+  "mod native_client_error_safety;",
+  `${paths.transport}: native client safety module wiring`,
+);
+requireText(
+  transport,
+  "pub type CartTransportError = UiTransportError;",
+  `${paths.transport}: public transport error alias`,
+);
+requireText(
+  transport,
+  "pub type TransportResult<T> = UiTransportResult<T>;",
+  `${paths.transport}: public result alias`,
+);
+requireText(
+  transport,
+  "UiTransportPath::NativeServer",
+  `${paths.transport}: native transport selection`,
+);
+requireText(
+  transport,
+  "UiTransportPath::Graphql",
+  `${paths.transport}: GraphQL transport selection`,
+);
+forbidText(
+  transport,
+  "fallback_attempted = true",
+  `${paths.transport}: no fallback may be introduced`,
+);
+
+requireCount(
+  transport,
+  "native_client_error_safety::NativeClientErrorContext::",
+  3,
+  `${paths.transport}: native client contexts`,
+);
+requireCount(
+  transport,
+  "graphql_error_safety::GraphqlCallContext::",
+  3,
+  `${paths.transport}: preserved GraphQL contexts`,
+);
+requireCount(
+  transport,
+  ".map_err(|error| context.map_error(error))",
+  6,
+  `${paths.transport}: three native and three GraphQL final mappings`,
+);
+
+for (const [operation, nativeContext, nativeCall, graphqlContext, graphqlCall] of [
+  [
+    "fetch_cart",
+    "NativeClientErrorContext::fetch_cart",
+    "native_server_adapter::fetch_cart(native_request)",
+    "GraphqlCallContext::fetch_cart",
+    "graphql_adapter::fetch_cart(request)",
+  ],
+  [
+    "decrement_line_item",
+    "NativeClientErrorContext::decrement_line_item",
+    "native_server_adapter::decrement_line_item(native_request)",
+    "GraphqlCallContext::decrement_line_item",
+    "graphql_adapter::decrement_line_item(request)",
+  ],
+  [
+    "remove_line_item",
+    "NativeClientErrorContext::remove_line_item",
+    "native_server_adapter::remove_line_item(native_request)",
+    "GraphqlCallContext::remove_line_item",
+    "graphql_adapter::remove_line_item(request)",
+  ],
+]) {
+  const body = functionBody(transport, operation);
+  for (const marker of [nativeContext, nativeCall, graphqlContext, graphqlCall]) {
+    requireText(body, marker, `${paths.transport}: ${operation}`);
+  }
+  const nativeContextIndex = body.indexOf(nativeContext);
+  const nativeCallIndex = body.indexOf(nativeCall);
+  const graphqlContextIndex = body.indexOf(graphqlContext);
+  const graphqlCallIndex = body.indexOf(graphqlCall);
+  if (nativeContextIndex < 0 || nativeContextIndex > nativeCallIndex) {
+    failures.push(`${paths.transport}: ${operation} native context must precede call`);
+  }
+  if (graphqlContextIndex < 0 || graphqlContextIndex > graphqlCallIndex) {
+    failures.push(`${paths.transport}: ${operation} GraphQL context must precede call`);
+  }
+}
+
+for (const marker of [
+  'const CART_STOREFRONT_NATIVE_CLIENT_OWNER: &str = "rustok_cart.storefront";',
+  '"cart_storefront_native_client_transport"',
+  '"Cart storefront request could not be completed"',
+  "pub(super) struct NativeClientErrorContext",
+  'operation: "fetch_cart"',
+  '"decrement_line_item"',
+  '"remove_line_item"',
+  "ApiError::Validation(message) => ApiError::Validation(message)",
+  "raw_error = ?error",
+  "owner_operation = self.operation",
+  "correlation_id = %self.correlation_id",
+  "selected_cart_id_present = self.selected_cart_id_length.is_some()",
+  "locale_present = self.locale_length.is_some()",
+  "cart_id_present = self.cart_id_length.is_some()",
+  "line_item_id_present = self.line_item_id_length.is_some()",
+  'code = "cart.storefront_native_client_transport_failed"',
+  "boundary = CART_STOREFRONT_NATIVE_CLIENT_BOUNDARY",
+  "ApiError::ServerFn(CART_STOREFRONT_NATIVE_CLIENT_PUBLIC_MESSAGE.to_string())",
+]) {
+  requireText(safety, marker, `${paths.safety}: safe final mapping`);
+}
+
+for (const forbidden of [
+  "selected_cart_id = %",
+  "selected_cart_id = ?",
+  "locale = %",
+  "locale = ?",
+  "cart_id = %",
+  "cart_id = ?",
+  "line_item_id = %",
+  "line_item_id = ?",
+  "request = ?",
+  "error.to_string()",
+]) {
+  forbidText(safety, forbidden, `${paths.safety}: raw request or error text`);
+}
+
+for (const adapter of [native, nativeSsr]) {
+  for (const marker of [
+    "pub enum ApiError",
+    "Graphql(String)",
+    "ServerFn(String)",
+    "Validation(String)",
+    "pub async fn fetch_cart(",
+    "pub async fn decrement_line_item(",
+    "pub async fn remove_line_item(",
+  ]) {
+    requireText(adapter, marker, "native adapter contract");
+  }
+}
+requireText(
+  nativeSsr,
+  "CART_STOREFRONT_NATIVE_BOUNDARY",
+  `${paths.nativeSsr}: mounted server-side safe boundary`,
+);
+requireText(
+  graphqlSafety,
+  "pub(super) struct GraphqlCallContext",
+  `${paths.graphqlSafety}: GraphQL safety policy`,
+);
+requireText(
+  nativeGuard,
+  "Cart storefront native error-safety source invariants passed",
+  `${paths.nativeGuard}: prior mounted native guard`,
+);
+requireText(
+  graphqlGuard,
+  "Cart storefront GraphQL error-safety source invariants passed",
+  `${paths.graphqlGuard}: prior GraphQL guard`,
+);
+
+if (evidence.status !== "storefront_native_client_error_safety_source_unvalidated") {
+  failures.push(`${paths.evidence}: unexpected status ${evidence.status}`);
+}
+if (
+  review.status !==
+  "storefront_native_client_error_safety_source_reviewed_unvalidated"
+) {
+  failures.push(`${paths.review}: unexpected status ${review.status}`);
+}
+
+for (const [key, expected] of Object.entries({
+  operation_count: 3,
+  transport_selection_changed: false,
+  graphql_transport_changed: false,
+  native_adapters_changed: false,
+  server_functions_changed: false,
+  request_response_dto_changed: false,
+  ui_transport_error_contract_preserved: true,
+  validation_message_preserved: true,
+  technical_native_error_public: false,
+  static_technical_public_message: true,
+  context_created_before_native_call: true,
+  original_error_logged_privately: true,
+  per_call_correlation_logging: true,
+  safe_request_shape_only: true,
+  cart_id_values_logged: false,
+  line_item_id_values_logged: false,
+  locale_values_logged: false,
+  fallback_enabled: false,
+  broad_ecommerce_cleanup_closed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "hydrate_compile_proven",
+  "ssr_compile_proven",
+  "browser_runtime_proven",
+  "mounted_runtime_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+
+requireText(doc, "Status: **source-ready / unvalidated**", `${paths.doc}: status`);
+requireText(
+  doc,
+  "Cart storefront request could not be completed",
+  `${paths.doc}: static technical public message`,
+);
+requireText(
+  plan,
+  "No verification command was executed in this source wave.",
+  `${paths.plan}: execution disclosure remains explicit`,
+);
+
+if (failures.length > 0) {
+  console.error("Cart storefront native client error-safety verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "Cart storefront native client technical failures use a correlation-safe static envelope while validation and GraphQL contracts remain unchanged; execution evidence remains open",
+);


### PR DESCRIPTION
## Summary
- close the final technical native-error escape before Cart storefront `UiTransportError` aggregation
- cover `fetch_cart`, `decrement_line_item`, and `remove_line_item`
- create a per-call `NativeClientErrorContext` before each unchanged native adapter call
- preserve `ApiError::Validation` messages unchanged
- retain technical `ServerFn`/unexpected native errors only in structured diagnostics
- record operation, correlation id, stable code, boundary, and request-field presence/character lengths only
- return one static technical public message: `Cart storefront request could not be completed`
- preserve explicit native/GraphQL transport selection, no-fallback policy, GraphQL mappings, DTOs, `UiTransportError` aliases, adapters, server functions, and mounted SSR safety
- update the existing GraphQL source guard only for the new structural shape of native closures
- add source evidence, source review, documentation, local plan status, and a focused verifier

## Confirmed gap
The mounted SSR adapter is already source-hardened, but the hydrate/client compatibility adapter uses `ApiError::ServerFn(String)`. `execute_selected_transport` records the native error `Display` inside public `UiTransportError`, so unexpected framework, serialization, or server-function text could still become visible after leaving the native adapter.

## Boundary placement
Each native closure creates its context before moving the unchanged request into the adapter call and maps only the final native `ApiError` before transport aggregation. The GraphQL closure and its existing `GraphqlCallContext` remain unchanged.

## Error policy
`ApiError::Validation` remains unchanged to preserve the existing Cart core validation contract. Other native variants fail closed to the static message. The original technical error remains private to tracing.

## Diagnostics
The new boundary logs only safe shape metadata. It does not log selected cart IDs, cart IDs, line-item IDs, locale values, cart/customer/pricing data, or request payloads.

## Recheck findings
- three native contexts precede their adapter calls
- three native and three GraphQL final mappings are present
- transport selection and no-fallback semantics are unchanged
- default and SSR native adapters and mounted server functions are outside the diff
- GraphQL adapter and GraphQL error policy are outside the diff
- the existing GraphQL verifier was adjusted only because it asserted the former direct native-closure syntax
- existing validation and transport-envelope test source is unchanged
- Cart FFA/FBA status is not promoted
- the broad ecommerce public-error cleanup remains open

`main` advanced by three unrelated Forum Search and Index documentation commits while the branch was prepared. The compare contains only eight Cart source/evidence files.

## Validation
Per maintainer instruction, tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run. Evidence remains source-ready / unvalidated and does not prove hydrate, SSR, browser, mounted runtime, workflow, CI, or production behavior.

Suggested maintainer commands:
```bash
node scripts/verify/verify-cart-storefront-native-client-error-safety.mjs
node scripts/verify/verify-cart-storefront-native-error-safety.mjs
node scripts/verify/verify-cart-storefront-graphql-error-safety.mjs
node scripts/verify/verify-cart-storefront-boundary.mjs
cargo check -p rustok-cart-storefront
cargo check -p rustok-cart-storefront --features hydrate
cargo check -p rustok-cart-storefront --features ssr
```