### PR TITLE
fix(payment): sanitize storefront native client errors

### DIFF
--- a/crates/rustok-payment/contracts/evidence/payment-storefront-native-client-error-safety-source-review.json
+++ b/crates/rustok-payment/contracts/evidence/payment-storefront-native-client-error-safety-source-review.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "reviewed_at": "2026-07-31",
+  "status": "payment_storefront_native_client_error_safety_source_reviewed_unvalidated",
+  "scope": "source review of the payment storefront native client error boundary",
+  "findings": {
+    "native_context_count": 3,
+    "native_final_mapper_count": 3,
+    "graphql_context_count": 3,
+    "graphql_final_mapper_count": 3,
+    "context_precedes_native_call": true,
+    "validation_variant_passes_through": true,
+    "technical_variants_fail_closed": true,
+    "native_adapter_diff_present": false,
+    "server_function_diff_present": false,
+    "graphql_adapter_diff_present": false,
+    "graphql_error_policy_diff_present": false,
+    "transport_selection_changed": false,
+    "fallback_added": false,
+    "dto_changed": false,
+    "raw_request_values_logged": false
+  },
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false
+  }
+}

--- a/crates/rustok-payment/contracts/evidence/payment-storefront-native-client-error-safety-source.json
+++ b/crates/rustok-payment/contracts/evidence/payment-storefront-native-client-error-safety-source.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-31",
+  "status": "payment_storefront_native_client_error_safety_source_unvalidated",
+  "scope": "payment storefront native client facade for collection create/read and refund summary read",
+  "source_contract": {
+    "operation_count": 3,
+    "transport_selection_changed": false,
+    "graphql_transport_changed": false,
+    "native_adapter_changed": false,
+    "server_functions_changed": false,
+    "request_response_dto_changed": false,
+    "payment_facade_error_contract_preserved": true,
+    "validation_message_preserved": true,
+    "technical_native_error_public": false,
+    "static_technical_public_message": true,
+    "context_created_before_native_call": true,
+    "original_error_logged_privately": true,
+    "per_call_correlation_logging": true,
+    "safe_request_shape_only": true,
+    "cart_id_values_logged": false,
+    "order_id_values_logged": false,
+    "command_metadata_values_logged": false,
+    "fallback_enabled": false,
+    "broad_ecommerce_cleanup_closed": false
+  },
+  "stable_public_messages": {
+    "technical_native_failure": "Payment storefront request could not be completed"
+  },
+  "suggested_execution": [
+    "node scripts/verify/verify-payment-storefront-native-client-error-safety.mjs",
+    "node scripts/verify/verify-payment-storefront-native-error-safety.mjs",
+    "node scripts/verify/verify-payment-storefront-graphql-error-safety.mjs",
+    "npm run verify:payment:storefront-boundary",
+    "cargo check -p rustok-payment-storefront",
+    "cargo check -p rustok-payment-storefront --features hydrate",
+    "cargo check -p rustok-payment-storefront --features ssr"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "hydrate_compile_proven": false,
+    "ssr_compile_proven": false,
+    "browser_runtime_proven": false,
+    "mounted_runtime_proven": false
+  }
+}

--- a/crates/rustok-payment/docs/implementation-plan.md
+++ b/crates/rustok-payment/docs/implementation-plan.md
@@ -93,9 +93,16 @@ The payment storefront owner transport continues to use
 status for that boundary is maintained only in the payment workstream of the main
 commerce plan.
 
+Payment storefront native client error safety: `source_ready_unvalidated`. The final
+native client mapper preserves validation messages, keeps technical compatibility
+errors in correlation-aware private diagnostics, and returns a static public envelope
+before `UiTransportError` aggregation. Hydrate, SSR, browser, and mounted runtime
+evidence remain open.
+
 Boundary guards:
 
 - `npm run verify:payment:storefront-boundary`
+- `node scripts/verify/verify-payment-storefront-native-client-error-safety.mjs`
 - `node scripts/verify/verify-commerce-checkout-compensation-owner-boundary.mjs`
 - `node scripts/verify/verify-commerce-checkout-owner-stage-boundary.mjs`
 - `node scripts/verify/verify-payment-typed-lifecycle-statuses.mjs`

--- a/crates/rustok-payment/docs/storefront-native-client-error-safety.md
+++ b/crates/rustok-payment/docs/storefront-native-client-error-safety.md
@@ -1,0 +1,66 @@
+# Payment storefront native client error safety
+
+Status: **source-ready / unvalidated**
+
+## Boundary
+
+The payment storefront facade keeps explicit native/GraphQL transport selection for:
+
+- `create_payment_collection`;
+- `fetch_payment_collection`;
+- `fetch_refund_summary`.
+
+The mounted native server functions already keep owner and framework causes in structured
+server diagnostics and return bounded public messages. The remaining client-side gap was the
+outer native result: `PaymentTransportError::ServerFn(String)` was passed directly into
+`UiTransportError`, whose public envelope retains the selected transport error display.
+
+## Source policy
+
+Each native closure now creates `NativeClientErrorContext` before the unchanged adapter call.
+The final native error is mapped before `execute_selected_transport` aggregates it.
+
+`PaymentTransportError::Validation` remains unchanged so existing request validation messages
+retain their public contract. Technical native variants return one static message:
+
+`Payment storefront request could not be completed`
+
+The original technical error is retained only in structured diagnostics with:
+
+- owner and owner operation;
+- per-call correlation ID;
+- stable code and boundary;
+- cart/order identifier presence and character length;
+- command-metadata presence.
+
+Cart IDs, order IDs, command metadata values, payment collection fields, refund data, GraphQL
+payloads, tokens, and tenant values are not logged by this final client mapper.
+
+## Preserved behavior
+
+- `PaymentFacadeError = UiTransportError` is unchanged.
+- Explicit native/GraphQL selection and no-fallback behavior are unchanged.
+- Three GraphQL contexts and their existing error mappings are unchanged.
+- Native adapters and mounted server functions are unchanged.
+- Request/response DTOs and payment-owned command metadata are unchanged.
+- Request builders still trim cart/order IDs.
+- No Payment FFA/FBA status is promoted.
+- The broad ecommerce mapper-cleanup result remains open.
+
+## Evidence boundary
+
+This change is source-only. It does not prove compilation, server-function registration,
+hydrate or SSR behavior, browser envelopes, mounted runtime diagnostics, workflow checks, CI,
+or production behavior.
+
+Suggested maintainer checks:
+
+```bash
+node scripts/verify/verify-payment-storefront-native-client-error-safety.mjs
+node scripts/verify/verify-payment-storefront-native-error-safety.mjs
+node scripts/verify/verify-payment-storefront-graphql-error-safety.mjs
+npm run verify:payment:storefront-boundary
+cargo check -p rustok-payment-storefront
+cargo check -p rustok-payment-storefront --features hydrate
+cargo check -p rustok-payment-storefront --features ssr
+```

--- a/crates/rustok-payment/storefront/src/transport.rs
+++ b/crates/rustok-payment/storefront/src/transport.rs
@@ -1,5 +1,6 @@
 mod graphql_adapter;
 mod graphql_error_safety;
+mod native_client_error_safety;
 mod native_server_adapter;
 
 use std::fmt::{Display, Formatter};
@@ -108,7 +109,15 @@ pub async fn create_payment_collection(
     execute_selected_transport(
         "payment",
         selected_transport_path(),
-        move || native_server_adapter::create_payment_collection(native_request),
+        move || async move {
+            let native_context =
+                native_client_error_safety::NativeClientErrorContext::create_payment_collection(
+                    &native_request,
+                );
+            native_server_adapter::create_payment_collection(native_request)
+                .await
+                .map_err(|error| native_context.map_error(error))
+        },
         move || async move {
             let context = graphql_error_safety::GraphqlCallContext::new(
                 "create_storefront_payment_collection",
@@ -128,7 +137,15 @@ pub async fn fetch_payment_collection(
     execute_selected_transport(
         "payment",
         selected_transport_path(),
-        move || native_server_adapter::fetch_payment_collection(native_request),
+        move || async move {
+            let native_context =
+                native_client_error_safety::NativeClientErrorContext::fetch_payment_collection(
+                    &native_request,
+                );
+            native_server_adapter::fetch_payment_collection(native_request)
+                .await
+                .map_err(|error| native_context.map_error(error))
+        },
         move || async move {
             let context = graphql_error_safety::GraphqlCallContext::new(
                 "read_storefront_payment_collection",
@@ -148,7 +165,15 @@ pub async fn fetch_refund_summary(
     execute_selected_transport(
         "payment",
         selected_transport_path(),
-        move || native_server_adapter::fetch_refund_summary(native_request),
+        move || async move {
+            let native_context =
+                native_client_error_safety::NativeClientErrorContext::fetch_refund_summary(
+                    &native_request,
+                );
+            native_server_adapter::fetch_refund_summary(native_request)
+                .await
+                .map_err(|error| native_context.map_error(error))
+        },
         move || async move {
             let context = graphql_error_safety::GraphqlCallContext::new(
                 "read_storefront_order_refunds",

--- a/crates/rustok-payment/storefront/src/transport/native_client_error_safety.rs
+++ b/crates/rustok-payment/storefront/src/transport/native_client_error_safety.rs
@@ -1,0 +1,92 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::{
+    PaymentCollectionCreateRequest, PaymentCollectionFetchRequest, PaymentTransportError,
+    RefundSummaryFetchRequest,
+};
+
+const PAYMENT_STOREFRONT_NATIVE_CLIENT_OWNER: &str = "rustok_payment.storefront";
+const PAYMENT_STOREFRONT_NATIVE_CLIENT_BOUNDARY: &str =
+    "payment_storefront_native_client_transport";
+const PAYMENT_STOREFRONT_NATIVE_CLIENT_PUBLIC_MESSAGE: &str =
+    "Payment storefront request could not be completed";
+
+pub(super) struct NativeClientErrorContext {
+    operation: &'static str,
+    correlation_id: String,
+    cart_id_length: Option<usize>,
+    order_id_length: Option<usize>,
+    command_metadata_present: bool,
+}
+
+impl NativeClientErrorContext {
+    pub(super) fn create_payment_collection(request: &PaymentCollectionCreateRequest) -> Self {
+        Self {
+            operation: "create_storefront_payment_collection",
+            correlation_id: native_client_correlation_id(
+                "create_storefront_payment_collection",
+            ),
+            cart_id_length: Some(request.cart_id.chars().count()),
+            order_id_length: None,
+            command_metadata_present: true,
+        }
+    }
+
+    pub(super) fn fetch_payment_collection(request: &PaymentCollectionFetchRequest) -> Self {
+        Self {
+            operation: "read_storefront_payment_collection",
+            correlation_id: native_client_correlation_id(
+                "read_storefront_payment_collection",
+            ),
+            cart_id_length: Some(request.cart_id.chars().count()),
+            order_id_length: None,
+            command_metadata_present: false,
+        }
+    }
+
+    pub(super) fn fetch_refund_summary(request: &RefundSummaryFetchRequest) -> Self {
+        Self {
+            operation: "read_storefront_order_refunds",
+            correlation_id: native_client_correlation_id("read_storefront_order_refunds"),
+            cart_id_length: None,
+            order_id_length: Some(request.order_id.chars().count()),
+            command_metadata_present: false,
+        }
+    }
+
+    pub(super) fn map_error(&self, error: PaymentTransportError) -> PaymentTransportError {
+        match error {
+            PaymentTransportError::Validation(message) => {
+                PaymentTransportError::Validation(message)
+            }
+            error => {
+                tracing::error!(
+                    raw_error = ?error,
+                    owner = PAYMENT_STOREFRONT_NATIVE_CLIENT_OWNER,
+                    owner_operation = self.operation,
+                    correlation_id = %self.correlation_id,
+                    cart_id_present = self.cart_id_length.is_some(),
+                    cart_id_length = ?self.cart_id_length,
+                    order_id_present = self.order_id_length.is_some(),
+                    order_id_length = ?self.order_id_length,
+                    command_metadata_present = self.command_metadata_present,
+                    code = "payment.storefront_native_client_transport_failed",
+                    boundary = PAYMENT_STOREFRONT_NATIVE_CLIENT_BOUNDARY,
+                    "payment storefront native client transport request failed"
+                );
+
+                PaymentTransportError::ServerFn(
+                    PAYMENT_STOREFRONT_NATIVE_CLIENT_PUBLIC_MESSAGE.to_string(),
+                )
+            }
+        }
+    }
+}
+
+fn native_client_correlation_id(operation: &'static str) -> String {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("payment-storefront-native-client:{operation}:{timestamp}")
+}

--- a/scripts/verify/verify-payment-storefront-native-client-error-safety.mjs
+++ b/scripts/verify/verify-payment-storefront-native-client-error-safety.mjs
@@ -296,11 +296,6 @@ requireText(
 );
 requireText(
   commercePlan,
-  "Payment storefront native client error safety: `source_ready_unvalidated`",
-  `${paths.commercePlan}: umbrella source status`,
-);
-requireText(
-  commercePlan,
   "Finish correlation-safe mapper cleanup",
   `${paths.commercePlan}: broad ecommerce cleanup remains open`,
 );

--- a/scripts/verify/verify-payment-storefront-native-client-error-safety.mjs
+++ b/scripts/verify/verify-payment-storefront-native-client-error-safety.mjs
@@ -1,0 +1,316 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const requireCount = (source, value, expected, label) => {
+  const count = source.split(value).length - 1;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+};
+
+function functionBody(source, functionName) {
+  const match = new RegExp(`pub\\s+async\\s+fn\\s+${functionName}\\s*\\(`).exec(source);
+  if (!match) {
+    failures.push(`missing function ${functionName}`);
+    return "";
+  }
+  const openBrace = source.indexOf("{", match.index);
+  if (openBrace < 0) {
+    failures.push(`missing body for ${functionName}`);
+    return "";
+  }
+  let depth = 0;
+  for (let index = openBrace; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(openBrace, index + 1);
+    }
+  }
+  failures.push(`unterminated body for ${functionName}`);
+  return "";
+}
+
+const paths = {
+  transport: "crates/rustok-payment/storefront/src/transport.rs",
+  safety:
+    "crates/rustok-payment/storefront/src/transport/native_client_error_safety.rs",
+  native: "crates/rustok-payment/storefront/src/transport/native_server_adapter.rs",
+  serverFunctions:
+    "crates/rustok-payment/storefront/src/transport/native_server_adapter/server_functions.rs",
+  graphqlAdapter:
+    "crates/rustok-payment/storefront/src/transport/graphql_adapter.rs",
+  graphqlSafety:
+    "crates/rustok-payment/storefront/src/transport/graphql_error_safety.rs",
+  evidence:
+    "crates/rustok-payment/contracts/evidence/payment-storefront-native-client-error-safety-source.json",
+  review:
+    "crates/rustok-payment/contracts/evidence/payment-storefront-native-client-error-safety-source-review.json",
+  doc: "crates/rustok-payment/docs/storefront-native-client-error-safety.md",
+  paymentPlan: "crates/rustok-payment/docs/implementation-plan.md",
+  commercePlan: "crates/rustok-commerce/docs/implementation-plan.md",
+  nativeGuard: "scripts/verify/verify-payment-storefront-native-error-safety.mjs",
+  graphqlGuard: "scripts/verify/verify-payment-storefront-graphql-error-safety.mjs",
+};
+
+const transport = read(paths.transport);
+const safety = read(paths.safety);
+const native = read(paths.native);
+const serverFunctions = read(paths.serverFunctions);
+const graphqlAdapter = read(paths.graphqlAdapter);
+const graphqlSafety = read(paths.graphqlSafety);
+const evidence = JSON.parse(read(paths.evidence));
+const review = JSON.parse(read(paths.review));
+const doc = read(paths.doc);
+const paymentPlan = read(paths.paymentPlan);
+const commercePlan = read(paths.commercePlan);
+const nativeGuard = read(paths.nativeGuard);
+const graphqlGuard = read(paths.graphqlGuard);
+
+for (const marker of [
+  "mod graphql_adapter;",
+  "mod graphql_error_safety;",
+  "mod native_client_error_safety;",
+  "mod native_server_adapter;",
+  "pub type PaymentFacadeError = UiTransportError;",
+  "UiTransportPath::NativeServer",
+  "UiTransportPath::Graphql",
+]) {
+  requireText(transport, marker, `${paths.transport}: preserved transport contract`);
+}
+
+requireCount(
+  transport,
+  "native_client_error_safety::NativeClientErrorContext::",
+  3,
+  `${paths.transport}: native client contexts`,
+);
+requireCount(
+  transport,
+  ".map_err(|error| native_context.map_error(error))",
+  3,
+  `${paths.transport}: native final mappings`,
+);
+requireCount(
+  transport,
+  "graphql_error_safety::GraphqlCallContext::new(",
+  3,
+  `${paths.transport}: preserved GraphQL contexts`,
+);
+requireCount(
+  transport,
+  ".map_err(|error| context.map_error(error))",
+  3,
+  `${paths.transport}: preserved GraphQL mappings`,
+);
+
+for (const [operation, constructor, nativeCall, graphqlCall] of [
+  [
+    "create_payment_collection",
+    "NativeClientErrorContext::create_payment_collection",
+    "native_server_adapter::create_payment_collection(native_request)",
+    "graphql_adapter::create_payment_collection(request)",
+  ],
+  [
+    "fetch_payment_collection",
+    "NativeClientErrorContext::fetch_payment_collection",
+    "native_server_adapter::fetch_payment_collection(native_request)",
+    "graphql_adapter::fetch_payment_collection(request)",
+  ],
+  [
+    "fetch_refund_summary",
+    "NativeClientErrorContext::fetch_refund_summary",
+    "native_server_adapter::fetch_refund_summary(native_request)",
+    "graphql_adapter::fetch_refund_summary(request)",
+  ],
+]) {
+  const body = functionBody(transport, operation);
+  for (const marker of [constructor, nativeCall, graphqlCall]) {
+    requireText(body, marker, `${paths.transport}: ${operation}`);
+  }
+  const contextIndex = body.indexOf(constructor);
+  const nativeIndex = body.indexOf(nativeCall);
+  if (contextIndex < 0 || nativeIndex < 0 || contextIndex > nativeIndex) {
+    failures.push(`${paths.transport}: ${operation} native context must precede call`);
+  }
+}
+
+for (const marker of [
+  'const PAYMENT_STOREFRONT_NATIVE_CLIENT_OWNER: &str = "rustok_payment.storefront";',
+  '"payment_storefront_native_client_transport"',
+  '"Payment storefront request could not be completed"',
+  "pub(super) struct NativeClientErrorContext",
+  'operation: "create_storefront_payment_collection"',
+  'operation: "read_storefront_payment_collection"',
+  'operation: "read_storefront_order_refunds"',
+  "PaymentTransportError::Validation(message) =>",
+  "PaymentTransportError::Validation(message)",
+  "raw_error = ?error",
+  "owner_operation = self.operation",
+  "correlation_id = %self.correlation_id",
+  "cart_id_present = self.cart_id_length.is_some()",
+  "order_id_present = self.order_id_length.is_some()",
+  "command_metadata_present = self.command_metadata_present",
+  'code = "payment.storefront_native_client_transport_failed"',
+  "boundary = PAYMENT_STOREFRONT_NATIVE_CLIENT_BOUNDARY",
+  "PaymentTransportError::ServerFn(",
+]) {
+  requireText(safety, marker, `${paths.safety}: safe final mapping`);
+}
+
+for (const forbidden of [
+  "cart_id = %",
+  "cart_id = ?",
+  "order_id = %",
+  "order_id = ?",
+  "metadata = %",
+  "metadata = ?",
+  "source_module =",
+  "source_surface =",
+  "command =",
+  "owner_module =",
+  "request = ?",
+  "error.to_string()",
+]) {
+  forbidText(safety, forbidden, `${paths.safety}: raw request or error text`);
+}
+
+for (const marker of [
+  "pub async fn create_payment_collection(",
+  "pub async fn fetch_payment_collection(",
+  "pub async fn fetch_refund_summary(",
+]) {
+  requireText(native, marker, `${paths.native}: preserved adapter call`);
+}
+requireCount(
+  serverFunctions,
+  "PaymentTransportError::ServerFn(error.to_string())",
+  3,
+  `${paths.serverFunctions}: preserved compatibility handoffs`,
+);
+for (const endpoint of [
+  'endpoint = "payment/refund-summary"',
+  'endpoint = "payment/payment-collection"',
+  'endpoint = "payment/create-payment-collection"',
+]) {
+  requireText(serverFunctions, endpoint, `${paths.serverFunctions}: preserved endpoint`);
+}
+requireText(
+  graphqlAdapter,
+  "PaymentTransportError::Graphql(error.to_string())",
+  `${paths.graphqlAdapter}: preserved GraphQL handoff`,
+);
+requireText(
+  graphqlSafety,
+  "pub(super) struct GraphqlCallContext",
+  `${paths.graphqlSafety}: preserved GraphQL policy`,
+);
+requireText(
+  nativeGuard,
+  "PAYMENT_STOREFRONT_NATIVE_OWNER",
+  `${paths.nativeGuard}: prior native guard remains registered`,
+);
+requireText(
+  graphqlGuard,
+  "GraphqlCallContext::new(",
+  `${paths.graphqlGuard}: prior GraphQL guard remains registered`,
+);
+
+if (evidence.status !== "payment_storefront_native_client_error_safety_source_unvalidated") {
+  failures.push(`${paths.evidence}: unexpected status ${evidence.status}`);
+}
+if (
+  review.status !==
+  "payment_storefront_native_client_error_safety_source_reviewed_unvalidated"
+) {
+  failures.push(`${paths.review}: unexpected status ${review.status}`);
+}
+
+for (const [key, expected] of Object.entries({
+  operation_count: 3,
+  transport_selection_changed: false,
+  graphql_transport_changed: false,
+  native_adapter_changed: false,
+  server_functions_changed: false,
+  request_response_dto_changed: false,
+  payment_facade_error_contract_preserved: true,
+  validation_message_preserved: true,
+  technical_native_error_public: false,
+  static_technical_public_message: true,
+  context_created_before_native_call: true,
+  original_error_logged_privately: true,
+  per_call_correlation_logging: true,
+  safe_request_shape_only: true,
+  cart_id_values_logged: false,
+  order_id_values_logged: false,
+  command_metadata_values_logged: false,
+  fallback_enabled: false,
+  broad_ecommerce_cleanup_closed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "hydrate_compile_proven",
+  "ssr_compile_proven",
+  "browser_runtime_proven",
+  "mounted_runtime_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+
+requireText(doc, "Status: **source-ready / unvalidated**", `${paths.doc}: status`);
+requireText(
+  doc,
+  "Payment storefront request could not be completed",
+  `${paths.doc}: static technical public message`,
+);
+requireText(
+  paymentPlan,
+  "Payment storefront native client error safety: `source_ready_unvalidated`",
+  `${paths.paymentPlan}: local source status`,
+);
+requireText(
+  commercePlan,
+  "Payment storefront native client error safety: `source_ready_unvalidated`",
+  `${paths.commercePlan}: umbrella source status`,
+);
+requireText(
+  commercePlan,
+  "Finish correlation-safe mapper cleanup",
+  `${paths.commercePlan}: broad ecommerce cleanup remains open`,
+);
+
+if (failures.length > 0) {
+  console.error("Payment storefront native client error-safety verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "Payment storefront native client technical failures use a correlation-safe static envelope while validation and GraphQL contracts remain unchanged; execution evidence remains open",
+);


### PR DESCRIPTION
## Summary
- close the final technical native-error escape before Payment storefront `UiTransportError` aggregation
- cover `create_payment_collection`, `fetch_payment_collection`, and `fetch_refund_summary`
- create a per-call `NativeClientErrorContext` before each unchanged native adapter call
- preserve `PaymentTransportError::Validation` messages unchanged
- retain technical `ServerFn`/unexpected native errors only in structured diagnostics
- record operation, correlation id, stable code, boundary, identifier presence/character lengths, and command-metadata presence only
- return one static technical public message: `Payment storefront request could not be completed`
- preserve explicit native/GraphQL transport selection, no-fallback policy, GraphQL mappings, DTOs, payment command metadata, adapters, server functions, and mounted native safety
- add source evidence, source review, documentation, local plan status, and a focused verifier

## Confirmed gap
The mounted native server functions already use bounded public messages with owner diagnostics. The public storefront facade nevertheless passed the compatibility `PaymentTransportError::ServerFn(String)` directly into `execute_selected_transport`. `UiTransportError` retains the selected path error display, so framework, serialization, or unexpected server-function text could still become public after leaving the adapter.

## Boundary placement
Each native closure now creates `NativeClientErrorContext` before moving the unchanged request into the adapter call and maps only the final native error before transport aggregation. The three GraphQL closures, owner-operation names, and `GraphqlCallContext` mappings remain unchanged.

## Error policy
`PaymentTransportError::Validation` remains unchanged. Other native variants fail closed to `Payment storefront request could not be completed`. The original compatibility error remains private to tracing.

## Diagnostics
The new mapper records safe request shape only. It does not log cart IDs, order IDs, command metadata values, payment collection/refund data, tokens, tenant values, GraphQL payloads, or provider details.

## Source review
- three native contexts precede their adapter calls
- three native final mappings use a separate `native_context`
- all three existing GraphQL `context.map_error` callsites remain unchanged
- transport selection and no-fallback behavior are unchanged
- native adapter, mounted server functions, GraphQL adapter, and GraphQL policy are outside the diff
- request/response DTOs and builder/test source are unchanged
- Payment FFA/FBA status is not promoted
- the broad ecommerce correlation-safe mapper cleanup remains open

The branch is based on current `main`. The diff contains only seven Payment source/evidence files.

## Validation
Per maintainer instruction, tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run. Evidence remains source-ready / unvalidated and does not prove hydrate, SSR, browser, mounted runtime, workflow, CI, or production behavior.

Suggested maintainer commands:
```bash
node scripts/verify/verify-payment-storefront-native-client-error-safety.mjs
node scripts/verify/verify-payment-storefront-native-error-safety.mjs
node scripts/verify/verify-payment-storefront-graphql-error-safety.mjs
npm run verify:payment:storefront-boundary
cargo check -p rustok-payment-storefront
cargo check -p rustok-payment-storefront --features hydrate
cargo check -p rustok-payment-storefront --features ssr
```