### PR TITLE
fix(comments): narrow thread fallback error class

### DIFF
--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -64,8 +64,11 @@ guarded by `scripts/verify/verify-comments-thread-write-invariants.mjs` and focu
 self-test `scripts/verify/verify-comments-thread-write-invariants.test.mjs`. Exact
 commands `verify:comments:thread-write-invariants` and
 `test:verify:comments:thread-write-invariants` are registered in Comments registry
-schema v2 and the Comments FBA verify/test chains. Blog consumes the owner result;
-it does not duplicate thread locking or counter policy.
+schema v2 and the Comments FBA verify/test chains. Evidence schema v2 also locks
+an owner-classified tenant/target identity marker: canonical lookup occurs only
+for that expected first-thread conflict, while unrelated insert storage errors
+propagate as typed database failures. Blog consumes the owner result and does not
+duplicate thread locking, counter policy, or error classification.
 
 The Comments consumer call surface is now a first-class Blog source boundary.
 `CommentService` depends on `Arc<dyn CommentsThreadPort>`, uses the in-process
@@ -198,6 +201,14 @@ adds a focused fail-closed fixture and exact leaf commands, aligns the shared
 runtime-order evidence, upgrades Blog registry schema v10, and keeps the remote
 adapter plus degraded UI modes explicitly pending.
 
+The continuation audit at `6b5cd3f94265ff7ba382ca89916a73065806a0b5`
+found that the Comments owner still retried canonical lookup after every thread
+insert error. Slice 43 keeps classification with the provider: Comments emits a
+scope-specific identity-conflict marker, retries only that expected first-thread
+race, propagates unrelated storage errors, upgrades its retained invariant
+evidence to schema v2, and adds focused negatives. Blog receives the corrected
+typed provider result without adding a consumer-side classifier.
+
 ## FFA/FBA status
 
 - FFA status: `in_progress`.
@@ -233,9 +244,10 @@ adapter plus degraded UI modes explicitly pending.
 - Blog storefront richtext boundary: `source_verified_no_compile`.
 - AI Blog draft owner writes and shim: `source_verified_no_compile`.
 - Comments thread write invariants: Comments-owned `executable_no_run`; registry
-  schema v2, evidence, verifier, focused self-test, exact npm leaf commands, Rust
-  targets, and Comments FBA ordering are locked. PostgreSQL execution remains
-  maintainer-owned.
+  schema v2, evidence schema v2, owner identity classifier, guarded canonical
+  fallback, unrelated-storage propagation, verifier, focused self-test, exact npm
+  leaf commands, Rust targets, and Comments FBA ordering are locked. PostgreSQL
+  and injected storage-error execution remain maintainer-owned.
 - Category search reindex: `source_verified_no_compile`; evidence, verifier,
   self-test, npm leaf commands, and aggregate FBA registration are locked.
 - Canonical Search URL: Search-owned `source_verified_no_compile`; evidence,
@@ -368,6 +380,10 @@ adapter plus degraded UI modes explicitly pending.
     active `PortErrorKind` mapper and runtime-order evidence to `services/comment.rs`,
     registered a focused negative fixture plus exact verify/test commands in Blog
     registry schema v10, and kept the remote adapter and degraded UI modes pending.
+43. Kept thread-insert error classification with the Comments provider, added a
+    tenant/target-scoped identity-conflict classifier, narrowed canonical fallback,
+    propagated unrelated storage errors, upgraded owner evidence to schema v2, and
+    retained all runtime and PostgreSQL proof as maintainer-owned.
 
 ## Next results
 
@@ -388,8 +404,9 @@ adapter plus degraded UI modes explicitly pending.
    shared consumer runtime-order verifier, both thread invariant concurrency
    targets, and concurrent PostgreSQL create/delete transactions; cover the
    remote adapter, degraded UI modes, approved-only reads, moderation, pagination,
-   duplicate delivery, counters, first-thread identity, missing-post retry,
-   rollback, outbox publication, and restart recovery.
+   duplicate delivery, counters, first-thread identity, unrelated insert storage
+   error propagation, missing-post retry, rollback, outbox publication, and restart
+   recovery.
 6. **Execute and retain Blog article richtext cutover evidence.** Run the offline
    backfill in default dry-run mode, review its report, apply accepted conversion,
    execute the irreversible migration, reindex/rollback Search, and retain
@@ -439,6 +456,7 @@ should run the relevant subset, including:
 - `cargo test -p rustok-server graphql_http_response_preserves_extension_headers`
 - `cargo test -p rustok-comments --test thread_write_invariants`
 - `cargo test -p rustok-comments --test thread_creation_concurrency`
+- Targeted injected storage-error coverage for Comments thread creation
 - `cargo test -p rustok-search engine::tests::canonical_url`
 - `cargo test -p rustok-search --test blog_ingestion_contract_test`
 - `RUSTOK_SEARCH_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-search --test blog_projection_postgres_test`

--- a/crates/rustok-comments/contracts/evidence/comments-thread-write-invariants.json
+++ b/crates/rustok-comments/contracts/evidence/comments-thread-write-invariants.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "module": "comments",
   "surface": "thread_write_invariants",
   "status": "executable_no_run",
@@ -8,6 +8,7 @@
   "production_contract": {
     "position_owner": "crates/rustok-comments/src/entities/comment.rs",
     "counter_and_identity_owner": "crates/rustok-comments/src/entities/comment_thread.rs",
+    "thread_service": "crates/rustok-comments/src/services.rs",
     "identity_lock_entity": "crates/rustok-comments/src/entities/comment_thread_identity_lock.rs",
     "counter_repair_migration": "crates/rustok-comments/src/migrations/m20260723_000008_repair_comment_thread_counters.rs",
     "identity_lock_migration": "crates/rustok-comments/src/migrations/m20260723_000009_add_comment_thread_identity_locks.rs",
@@ -42,6 +43,10 @@
       "expected": "a unique thread_id plus position index rejects direct Entity insert paths that bypass ActiveModelBehavior"
     },
     {
+      "name": "identity_conflict_only_fallback",
+      "expected": "find_or_create_thread_in_tx reloads the canonical thread only for the owner-classified tenant and target identity conflict and propagates every unrelated insert DbErr as CommentsError::Database"
+    },
+    {
       "name": "postgres_concurrent_create_delete",
       "expected": "two independent PostgreSQL connections preserve positions 1..3 and an exact active count across concurrent create/create and create/soft-delete phases"
     },
@@ -56,6 +61,7 @@
     "execute both env-gated PostgreSQL targets with RUSTOK_COMMENTS_TEST_DATABASE_URL",
     "retain final active-row count and gap-free unique position evidence",
     "retain one-thread evidence for concurrent first comments",
+    "retain unrelated insert DbErr propagation without CommentThreadNotFound remapping",
     "retain migration output for stale counters, duplicate positions, and identity-lock storage"
   ]
 }

--- a/crates/rustok-comments/docs/implementation-plan.md
+++ b/crates/rustok-comments/docs/implementation-plan.md
@@ -22,10 +22,11 @@ a counter write.
 First-thread creation has a separate owner identity lock. Before a transactional
 thread insert, `comment_thread::ActiveModelBehavior` upserts a persistent
 `comment_thread_identity_locks` row with `ON CONFLICT DO NOTHING`, locks that row,
-and checks for the canonical thread. A concurrent creator receives an intentional
-application `DbErr` before its SQL INSERT, leaving the PostgreSQL transaction
-usable by the existing `find_or_create_thread_in_tx` fallback. This prevents the
-old unique-violation/aborted-transaction failure mode without transport retries.
+and checks for the canonical thread. A concurrent creator receives an owner-
+classified application `DbErr` before its SQL INSERT, leaving the PostgreSQL
+transaction usable. `find_or_create_thread_in_tx` performs canonical lookup only
+for the exact tenant/target identity marker; unrelated storage errors propagate
+through `CommentsError::Database` instead of becoming `CommentThreadNotFound`.
 
 Append-only migrations repair historical counters, deterministically renumber
 historical positions, enforce `UNIQUE(thread_id, position)`, and create the unique
@@ -54,12 +55,14 @@ before the schema column is dropped.
 - Static and runtime-order evidence:
   `crates/rustok-comments/contracts/evidence/comments-contract-test-static-matrix.json`
   and `crates/rustok-comments/contracts/evidence/comments-provider-runtime-order-smoke.json`.
-- Thread write invariant evidence:
+- Thread write invariant evidence schema v2:
   `crates/rustok-comments/contracts/evidence/comments-thread-write-invariants.json`
   with status `executable_no_run`.
 - Thread invariant source gate:
   `scripts/verify/verify-comments-thread-write-invariants.mjs` with focused
   self-test `scripts/verify/verify-comments-thread-write-invariants.test.mjs`.
+  It locks the identity-conflict-only fallback and verifies that unrelated
+  storage errors propagate; broad `Err(_)` fallback is forbidden.
 - Exact leaf commands: `verify:comments:thread-write-invariants` and
   `test:verify:comments:thread-write-invariants`; both are registered in
   `verify:comments:fba` / `test:verify:comments:fba` before the shared owner
@@ -84,6 +87,13 @@ evidence and Rust targets, but did not retain the JS self-test or an exact
 verification-chain contract; the root package had no named leaf commands and no
 Comments FBA test chain. Slice 11 registers those source assets without changing
 the owner behavior or promoting `executable_no_run` to executed evidence.
+
+The continuation audit at `6b5cd3f94265ff7ba382ca89916a73065806a0b5`
+found that `find_or_create_thread_in_tx` still reloaded the canonical thread after
+every insert `DbErr`. Slice 12 adds a tenant/target-scoped owner marker and
+classifier, narrows fallback to that exact identity conflict, propagates unrelated
+storage errors, upgrades retained evidence to schema v2, and adds focused negative
+guards without recording Rust or PostgreSQL execution.
 
 No verifier, Rust test, PostgreSQL target, compile, workflow, or CI execution is
 recorded by this source-only slice.
@@ -116,6 +126,10 @@ recorded by this source-only slice.
     Comments FBA source gate, added exact verify/test npm commands, and locked
     registry schema v2 plus aggregate order while preserving runtime execution as
     maintainer-owned.
+12. Added an owner-classified first-thread identity marker, narrowed the service
+    fallback to that exact tenant/target conflict, propagated every unrelated
+    insert `DbErr`, upgraded thread evidence to schema v2, and added focused
+    regression guards for the classifier, broad catch, and propagation branch.
 
 ## Open results
 
@@ -125,11 +139,13 @@ recorded by this source-only slice.
    **Done when:** runtime evidence confirms the owner locks under real concurrent
    PostgreSQL transactions.
 
-2. **Narrow the service fallback error class.** `find_or_create_thread_in_tx`
-   currently retries canonical lookup for every thread insert error. Preserve the
-   identity-conflict fallback while propagating unrelated infrastructure errors.
-   **Done when:** typed storage errors cannot be converted into a misleading
-   `CommentThreadNotFound`.
+2. **Execute fallback-class runtime evidence.** The source-level
+   identity-conflict-only fallback is complete. Inject or reproduce an unrelated
+   thread insert `DbErr` and retain evidence that it propagates as a database
+   failure rather than becoming `CommentThreadNotFound`; also retain the canonical
+   concurrent identity-conflict lookup path.
+   **Done when:** runtime evidence proves unrelated storage errors propagate and
+   the expected first-thread race still returns one canonical thread.
 
 3. **Implement and execute the Blog reply-count event projection.** Consume
    `comment.created` and `comment.deleted` idempotently, publish the Blog-owned
@@ -177,6 +193,7 @@ should run the relevant subset, including:
 - `cargo test -p rustok-comments --test thread_write_invariants`
 - `RUSTOK_COMMENTS_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-comments --test thread_write_invariants postgres_concurrent_creates_and_delete_preserve_thread_invariants`
 - `RUSTOK_COMMENTS_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-comments --test thread_creation_concurrency`
+- Targeted injected storage-error coverage for `find_or_create_thread_in_tx`
 - `npm run verify:comments:admin-boundary`
 - `cargo xtask module validate comments`
 - `cargo xtask module test comments`
@@ -193,5 +210,7 @@ should run the relevant subset, including:
 3. Status-only and metadata-only thread updates must not set `comment_count`.
 4. Preserve the identity-lock before first-thread insert and keep its unique
    `(tenant_id, target_type, target_id)` key.
-5. Keep migrations append-only and preserve both database uniqueness invariants.
-6. Update local/central contracts when the Comments boundary changes.
+5. Keep the owner-classified identity marker scoped to tenant and target, and never
+   restore a broad insert-error fallback.
+6. Keep migrations append-only and preserve both database uniqueness invariants.
+7. Update local/central contracts when the Comments boundary changes.

--- a/crates/rustok-comments/src/entities/comment_thread.rs
+++ b/crates/rustok-comments/src/entities/comment_thread.rs
@@ -7,6 +7,21 @@ use uuid::Uuid;
 
 use crate::dto::CommentThreadStatus;
 
+pub(crate) const THREAD_IDENTITY_CONFLICT_MARKER: &str =
+    "comment_thread_identity_conflict";
+
+pub(crate) fn is_thread_identity_conflict(
+    error: &DbErr,
+    tenant_id: Uuid,
+    target_type: &str,
+    target_id: Uuid,
+) -> bool {
+    let expected_prefix = format!(
+        "{THREAD_IDENTITY_CONFLICT_MARKER}:{tenant_id}:{target_type}:{target_id}:"
+    );
+    matches!(error, DbErr::Custom(message) if message.starts_with(&expected_prefix))
+}
+
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
 #[sea_orm(table_name = "comment_threads")]
 pub struct Model {
@@ -159,11 +174,11 @@ where
         .one(db)
         .await?
     {
-        // Returning an application DbErr before the INSERT statement keeps the
-        // surrounding PostgreSQL transaction usable. The service's existing
-        // find-or-create fallback then loads this canonical thread.
+        // Returning an owner-classified application DbErr before the INSERT keeps
+        // the surrounding PostgreSQL transaction usable. The service retries the
+        // canonical lookup only for this exact identity and propagates other errors.
         return Err(DbErr::Custom(format!(
-            "comment thread identity {target_type}:{target_id} already belongs to {}",
+            "{THREAD_IDENTITY_CONFLICT_MARKER}:{tenant_id}:{target_type}:{target_id}:{}",
             existing.id
         )));
     }

--- a/crates/rustok-comments/src/services.rs
+++ b/crates/rustok-comments/src/services.rs
@@ -850,16 +850,26 @@ impl CommentsService {
 
         match thread.insert(txn).await {
             Ok(thread) => Ok(thread),
-            Err(_) => comment_thread::Entity::find()
-                .filter(comment_thread::Column::TenantId.eq(tenant_id))
-                .filter(comment_thread::Column::TargetType.eq(target_type))
-                .filter(comment_thread::Column::TargetId.eq(target_id))
-                .one(txn)
-                .await?
-                .ok_or_else(|| CommentsError::CommentThreadNotFound {
-                    target_type: target_type.to_string(),
+            Err(error)
+                if comment_thread::is_thread_identity_conflict(
+                    &error,
+                    tenant_id,
+                    target_type,
                     target_id,
-                }),
+                ) =>
+            {
+                comment_thread::Entity::find()
+                    .filter(comment_thread::Column::TenantId.eq(tenant_id))
+                    .filter(comment_thread::Column::TargetType.eq(target_type))
+                    .filter(comment_thread::Column::TargetId.eq(target_id))
+                    .one(txn)
+                    .await?
+                    .ok_or_else(|| CommentsError::CommentThreadNotFound {
+                        target_type: target_type.to_string(),
+                        target_id,
+                    })
+            }
+            Err(error) => Err(error.into()),
         }
     }
 

--- a/scripts/verify/verify-comments-fba.mjs
+++ b/scripts/verify/verify-comments-fba.mjs
@@ -4,6 +4,7 @@ function read(path) { return fs.readFileSync(path, 'utf8'); }
 function json(path) { return JSON.parse(read(path)); }
 function fail(message) { console.error(`[verify-comments-fba] ${message}`); process.exit(1); }
 function hasAll(text, snippets, label) { for (const s of snippets) if (!text.includes(s)) fail(`${label} missing ${s}`); }
+function hasNone(text, snippets, label) { for (const s of snippets) if (text.includes(s)) fail(`${label} contains forbidden ${s}`); }
 function sameList(actual, expected) { return JSON.stringify(actual) === JSON.stringify(expected); }
 
 const registryPath = 'crates/rustok-comments/contracts/comments-fba-registry.json';
@@ -109,8 +110,10 @@ hasAll(services, [
   '.publish_in_tx(',
   'find_or_create_thread_in_tx',
   'match thread.insert(txn).await',
-  'Err(_) => comment_thread::Entity::find()',
+  'comment_thread::is_thread_identity_conflict(',
+  'Err(error) => Err(error.into())',
 ], 'comments owner service');
+hasNone(services, ['Err(_) => comment_thread::Entity::find()'], 'comments owner service');
 const lifecycleEvents = registry.events ?? [];
 if (lifecycleEvents.map(event => event.type).sort().join('|') !== 'comment.created|comment.deleted') fail('comments lifecycle event registry drift');
 for (const event of lifecycleEvents) {
@@ -158,6 +161,7 @@ if (registry.evidence.thread_write_invariants_runner !== threadWriteVerifierPath
 if (registry.evidence.thread_write_invariants_self_test !== threadWriteSelfTestPath) fail('thread write self-test path drift');
 if (registry.evidence.thread_write_invariants_test !== 'crates/rustok-comments/tests/thread_write_invariants.rs') fail('thread write test path drift');
 if (registry.evidence.thread_creation_concurrency_test !== 'crates/rustok-comments/tests/thread_creation_concurrency.rs') fail('thread creation test path drift');
+if (threadWriteEvidence.schema_version !== 2) fail('thread write evidence schema_version drift');
 if (threadWriteEvidence.module !== 'comments' || threadWriteEvidence.surface !== 'thread_write_invariants' || threadWriteEvidence.owner !== 'rustok-comments') fail('thread write evidence identity drift');
 if (threadWriteEvidence.status !== 'executable_no_run' || threadWriteEvidence.compile_policy !== 'not_run_by_request') fail('thread write evidence status drift');
 const threadWriteCases = threadWriteEvidence.cases.map(c => c.name).sort().join('|');
@@ -166,6 +170,7 @@ if (threadWriteCases !== [
   'exact_active_comment_count',
   'historical_counter_repair',
   'historical_position_repair',
+  'identity_conflict_only_fallback',
   'postgres_concurrent_create_delete',
   'postgres_concurrent_first_thread_creation',
   'serialized_position_allocation',
@@ -176,6 +181,7 @@ const threadContract = threadWriteEvidence.production_contract ?? {};
 for (const [key, expected] of Object.entries({
   position_owner: 'crates/rustok-comments/src/entities/comment.rs',
   counter_and_identity_owner: 'crates/rustok-comments/src/entities/comment_thread.rs',
+  thread_service: 'crates/rustok-comments/src/services.rs',
   identity_lock_entity: 'crates/rustok-comments/src/entities/comment_thread_identity_lock.rs',
   counter_repair_migration: 'crates/rustok-comments/src/migrations/m20260723_000008_repair_comment_thread_counters.rs',
   identity_lock_migration: 'crates/rustok-comments/src/migrations/m20260723_000009_add_comment_thread_identity_locks.rs',
@@ -198,15 +204,29 @@ hasAll(positionOwner, [
 ], 'comment position owner');
 const threadOwner = read(threadContract.counter_and_identity_owner);
 hasAll(threadOwner, [
+  'pub(crate) const THREAD_IDENTITY_CONFLICT_MARKER',
+  'pub(crate) fn is_thread_identity_conflict(',
+  'matches!(error, DbErr::Custom(message) if message.starts_with(&expected_prefix))',
   'serialize_thread_identity(db, &self).await?',
   'matches!(&self.comment_count, ActiveValue::Set(_))',
   'OnConflict::columns',
   'identity_lock::Entity::update_many()',
-  'comment thread identity {target_type}:{target_id} already belongs to',
+  '{THREAD_IDENTITY_CONFLICT_MARKER}:{tenant_id}:{target_type}:{target_id}:{}',
   'DeletedAt.is_null()',
   '.count(db)',
   'self.comment_count = Set(count)',
 ], 'comment thread owner');
+const threadService = read(threadContract.thread_service);
+hasAll(threadService, [
+  'match thread.insert(txn).await',
+  'comment_thread::is_thread_identity_conflict(',
+  '&error,',
+  'tenant_id,',
+  'target_type,',
+  'target_id,',
+  'Err(error) => Err(error.into())',
+], 'comment thread service fallback');
+hasNone(threadService, ['Err(_) => comment_thread::Entity::find()'], 'comment thread service fallback');
 const identityEntity = read(threadContract.identity_lock_entity);
 hasAll(identityEntity, [
   '#[sea_orm(table_name = "comment_thread_identity_locks")]',
@@ -263,6 +283,9 @@ hasAll(firstThreadTest, [
 const threadWriteVerifier = read(threadWriteVerifierPath);
 hasAll(threadWriteVerifier, [
   'identity_lock::Entity::update_many()',
+  'comment_thread::is_thread_identity_conflict(',
+  'Err(error) => Err(error.into())',
+  'identity_conflict_only_fallback',
   'postgres_concurrent_first_comments_share_one_thread',
   'status_only_thread_update_preserves_comment_count',
   'postgres_concurrent_creates_and_delete_preserve_thread_invariants',
@@ -272,6 +295,9 @@ hasAll(threadWriteSelfTest, [
   'thread write verifier accepts the owner invariant contract',
   'rejects position allocation without tenant lock',
   'rejects missing first-thread concurrency harness',
+  'rejects a broad insert fallback',
+  'rejects a missing identity-conflict classifier',
+  'rejects missing unrelated storage error propagation',
 ], 'thread write invariant self-test');
 
 const plan = read('crates/rustok-comments/docs/implementation-plan.md');
@@ -288,6 +314,8 @@ hasAll(plan, [
   'concurrent PostgreSQL',
   'identity-lock',
   'thread_creation_concurrency',
+  'identity-conflict-only fallback',
+  'unrelated storage errors propagate',
   'verify:comments:thread-write-invariants',
   'test:verify:comments:thread-write-invariants',
   'test:verify:comments:fba',
@@ -295,4 +323,4 @@ hasAll(plan, [
 const central = read('docs/modules/registry.md');
 hasAll(central, ['| `comments` |', 'crates/rustok-comments/contracts/comments-fba-registry.json', registry.evidence.runtime_order_smoke, '`in_progress` | `boundary_ready`'], 'central registry');
 
-console.log('[verify-comments-fba] comments FBA provider metadata, exact thread-invariant source-gate chain, runtime-order evidence, transactional thread writes, and first-thread identity serialization are consistent');
+console.log('[verify-comments-fba] comments FBA provider metadata, exact thread-invariant source-gate chain, runtime-order evidence, transactional thread writes, narrow identity-conflict fallback, and first-thread identity serialization are consistent');

--- a/scripts/verify/verify-comments-thread-write-invariants.mjs
+++ b/scripts/verify/verify-comments-thread-write-invariants.mjs
@@ -25,6 +25,10 @@ function requireMarker(source, marker, label) {
   if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
 }
 
+function requireNoMarker(source, marker, label) {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+}
+
 const commentPath = "crates/rustok-comments/src/entities/comment.rs";
 const threadPath = "crates/rustok-comments/src/entities/comment_thread.rs";
 const identityEntityPath =
@@ -73,6 +77,9 @@ for (const marker of [
 }
 
 for (const marker of [
+  "pub(crate) const THREAD_IDENTITY_CONFLICT_MARKER",
+  "pub(crate) fn is_thread_identity_conflict(",
+  "matches!(error, DbErr::Custom(message) if message.starts_with(&expected_prefix))",
   "impl ActiveModelBehavior for ActiveModel",
   "serialize_thread_identity(db, &self).await?",
   "matches!(&self.comment_count, ActiveValue::Set(_))",
@@ -84,7 +91,7 @@ for (const marker of [
   "self.comment_count = Set(count)",
   "OnConflict::columns",
   "identity_lock::Entity::update_many()",
-  "comment thread identity {target_type}:{target_id} already belongs to",
+  "{THREAD_IDENTITY_CONFLICT_MARKER}:{tenant_id}:{target_type}:{target_id}:{}",
 ]) {
   requireMarker(thread, marker, threadPath);
 }
@@ -110,12 +117,29 @@ if (counterHelperStart === -1) {
   );
   requireMarker(counterHelper, "active.update(txn).await?", `${servicesPath}: counter helper`);
 }
-for (const marker of [
-  "find_or_create_thread_in_tx",
-  "match thread.insert(txn).await",
-  "Err(_) => comment_thread::Entity::find()",
-]) {
-  requireMarker(services, marker, servicesPath);
+
+const findOrCreateStart = services.indexOf("async fn find_or_create_thread_in_tx");
+if (findOrCreateStart === -1) {
+  failures.push(`${servicesPath}: missing find_or_create_thread_in_tx`);
+} else {
+  const findOrCreateEnd = services.indexOf("\n    async fn next_position_in_tx", findOrCreateStart);
+  const findOrCreate = services.slice(
+    findOrCreateStart,
+    findOrCreateEnd === -1 ? services.length : findOrCreateEnd,
+  );
+  for (const marker of [
+    "match thread.insert(txn).await",
+    "Err(error)",
+    "comment_thread::is_thread_identity_conflict(",
+    "&error,",
+    "tenant_id,",
+    "target_type,",
+    "target_id,",
+    "Err(error) => Err(error.into())",
+  ]) {
+    requireMarker(findOrCreate, marker, `${servicesPath}: thread fallback`);
+  }
+  requireNoMarker(findOrCreate, "Err(_) =>", `${servicesPath}: thread fallback`);
 }
 
 for (const marker of [
@@ -182,7 +206,7 @@ for (const marker of [
 }
 
 if (evidence) {
-  if (evidence.schema_version !== 1) failures.push(`${evidencePath}: schema_version drift`);
+  if (evidence.schema_version !== 2) failures.push(`${evidencePath}: schema_version drift`);
   if (
     evidence.module !== "comments" ||
     evidence.surface !== "thread_write_invariants" ||
@@ -198,6 +222,7 @@ if (evidence) {
   for (const [key, expected] of Object.entries({
     position_owner: commentPath,
     counter_and_identity_owner: threadPath,
+    thread_service: servicesPath,
     identity_lock_entity: identityEntityPath,
     counter_repair_migration: counterMigrationPath,
     identity_lock_migration: identityMigrationPath,
@@ -216,6 +241,7 @@ if (evidence) {
     "historical_counter_repair",
     "historical_position_repair",
     "bulk_bypass_rejection",
+    "identity_conflict_only_fallback",
     "postgres_concurrent_create_delete",
     "postgres_concurrent_first_thread_creation",
   ]) {
@@ -232,6 +258,8 @@ for (const marker of [
   "concurrent PostgreSQL",
   "identity-lock",
   "thread_creation_concurrency",
+  "identity-conflict-only fallback",
+  "unrelated storage errors propagate",
 ]) {
   requireMarker(plan, marker, planPath);
 }

--- a/scripts/verify/verify-comments-thread-write-invariants.test.mjs
+++ b/scripts/verify/verify-comments-thread-write-invariants.test.mjs
@@ -25,6 +25,9 @@ function fixture({
   missingPostgresHarness = false,
   missingIdentityRowLock = false,
   missingFirstThreadHarness = false,
+  missingIdentityClassifier = false,
+  broadInsertFallback = false,
+  missingStoragePropagation = false,
 } = {}) {
   const root = mkdtempSync(path.join(tmpdir(), "rustok-comments-thread-invariants-"));
   const commentPath = "crates/rustok-comments/src/entities/comment.rs";
@@ -65,6 +68,16 @@ function fixture({
     root,
     threadPath,
     `
+      ${
+        missingIdentityClassifier
+          ? ""
+          : `
+            pub(crate) const THREAD_IDENTITY_CONFLICT_MARKER: &str = "comment_thread_identity_conflict";
+            pub(crate) fn is_thread_identity_conflict(error: &DbErr) {
+              matches!(error, DbErr::Custom(message) if message.starts_with(&expected_prefix));
+            }
+          `
+      }
       impl ActiveModelBehavior for ActiveModel {
         async fn before_save() {
           serialize_thread_identity(db, &self).await?;
@@ -82,7 +95,7 @@ function fixture({
       }
       OnConflict::columns;
       ${missingIdentityRowLock ? "" : "identity_lock::Entity::update_many();"}
-      comment thread identity {target_type}:{target_id} already belongs to
+      {THREAD_IDENTITY_CONFLICT_MARKER}:{tenant_id}:{target_type}:{target_id}:{}
     `,
   );
   write(
@@ -100,9 +113,26 @@ function fixture({
     root,
     servicesPath,
     `
-      find_or_create_thread_in_tx
-      match thread.insert(txn).await
-      Err(_) => comment_thread::Entity::find()
+      async fn find_or_create_thread_in_tx() {
+        match thread.insert(txn).await {
+          Ok(thread) => Ok(thread),
+          ${
+            broadInsertFallback
+              ? "Err(_) => comment_thread::Entity::find()"
+              : `
+                Err(error)
+                  if comment_thread::is_thread_identity_conflict(
+                    &error,
+                    tenant_id,
+                    target_type,
+                    target_id,
+                  ) => comment_thread::Entity::find(),
+                ${missingStoragePropagation ? "" : "Err(error) => Err(error.into()),"}
+              `
+          }
+        }
+      }
+      async fn next_position_in_tx() {}
       async fn update_thread_counters_in_tx() {
         active.update(txn).await?;
       }
@@ -189,7 +219,7 @@ function fixture({
     root,
     evidencePath,
     JSON.stringify({
-      schema_version: 1,
+      schema_version: 2,
       module: "comments",
       surface: "thread_write_invariants",
       status: "executable_no_run",
@@ -198,6 +228,7 @@ function fixture({
       production_contract: {
         position_owner: commentPath,
         counter_and_identity_owner: threadPath,
+        thread_service: servicesPath,
         identity_lock_entity: identityEntityPath,
         counter_repair_migration: counterMigrationPath,
         identity_lock_migration: identityMigrationPath,
@@ -213,6 +244,7 @@ function fixture({
         { name: "historical_counter_repair" },
         { name: "historical_position_repair" },
         { name: "bulk_bypass_rejection" },
+        { name: "identity_conflict_only_fallback" },
         { name: "postgres_concurrent_create_delete" },
         { name: "postgres_concurrent_first_thread_creation" },
       ],
@@ -221,7 +253,7 @@ function fixture({
   write(
     root,
     "crates/rustok-comments/docs/implementation-plan.md",
-    "comments-thread-write-invariants.json thread_write_invariants ActiveModelBehavior UNIQUE(thread_id, position) RUSTOK_COMMENTS_TEST_DATABASE_URL concurrent PostgreSQL identity-lock thread_creation_concurrency",
+    "comments-thread-write-invariants.json thread_write_invariants ActiveModelBehavior UNIQUE(thread_id, position) RUSTOK_COMMENTS_TEST_DATABASE_URL concurrent PostgreSQL identity-lock thread_creation_concurrency identity-conflict-only fallback unrelated storage errors propagate",
   );
 
   return root;
@@ -312,6 +344,39 @@ test("rejects missing first-thread concurrency harness", () => {
     const result = run(root);
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /missing postgres_concurrent_first_comments_share_one_thread/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects a broad insert fallback", () => {
+  const root = fixture({ broadInsertFallback: true });
+  try {
+    const result = run(root);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /forbidden Err\(_\) =>/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects a missing identity-conflict classifier", () => {
+  const root = fixture({ missingIdentityClassifier: true });
+  try {
+    const result = run(root);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /missing pub\(crate\) const THREAD_IDENTITY_CONFLICT_MARKER/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects missing unrelated storage error propagation", () => {
+  const root = fixture({ missingStoragePropagation: true });
+  try {
+    const result = run(root);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /missing Err\(error\) => Err\(error\.into\(\)\)/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- add a Comments-owned, tenant/target-scoped identity-conflict marker and classifier before canonical thread fallback
- narrow `find_or_create_thread_in_tx` so it reloads only for that expected first-thread conflict
- propagate every unrelated thread insert `DbErr` through `CommentsError::Database` instead of remapping it to `CommentThreadNotFound`
- upgrade the retained thread-write evidence to schema v2 and add the `identity_conflict_only_fallback` case
- extend the existing thread-invariant verifier and focused fixture with broad-catch, missing-classifier, and missing-propagation negatives
- bind the narrowed behavior into the aggregate Comments FBA verifier
- record Comments slice 12 and Blog slice 43 while keeping runtime/PostgreSQL proof pending

## Why

The persistent identity lock intentionally returns an application `DbErr` before the losing SQL insert so a concurrent first-thread creator can reuse the still-valid transaction and reload the canonical thread. The service previously treated every insert error as that expected race, which could hide an unrelated storage failure behind a misleading `CommentThreadNotFound`.

## Validation

Not run by request. No verifier, test, compile, database, browser, workflow, or CI command was executed.

Suggested maintainer commands:

```bash
npm run verify:comments:thread-write-invariants
npm run test:verify:comments:thread-write-invariants
npm run verify:comments:fba
npm run test:verify:comments:fba
cargo test -p rustok-comments --test thread_creation_concurrency
```
