### PR TITLE
fix(fulfillment): sanitize storefront native client errors

### DIFF
--- a/crates/rustok-fulfillment/contracts/evidence/storefront-native-client-error-safety-source-review.json
+++ b/crates/rustok-fulfillment/contracts/evidence/storefront-native-client-error-safety-source-review.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-31",
+  "status": "fulfillment_storefront_native_client_error_safety_source_reviewed_unvalidated",
+  "review": {
+    "public_operation": "select_shipping_option",
+    "native_validation_order": [
+      "cart UUID",
+      "shipping selection plan",
+      "selected shipping option UUID"
+    ],
+    "native_context_precedes_server_function_call": true,
+    "technical_mapping_follows_server_function_call": true,
+    "transport_facade_outside_diff": true,
+    "graphql_adapter_outside_diff": true,
+    "graphql_error_policy_outside_diff": true,
+    "server_functions_outside_diff": true,
+    "endpoint_outside_diff": true,
+    "request_response_dto_outside_diff": true,
+    "selection_plan_outside_diff": true,
+    "validation_messages_preserved": true,
+    "raw_request_values_in_diagnostics": false,
+    "broad_ecommerce_cleanup_still_open": true
+  },
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "source_review_only": true
+  }
+}

--- a/crates/rustok-fulfillment/contracts/evidence/storefront-native-client-error-safety-source.json
+++ b/crates/rustok-fulfillment/contracts/evidence/storefront-native-client-error-safety-source.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-31",
+  "status": "fulfillment_storefront_native_client_error_safety_source_unvalidated",
+  "scope": "fulfillment storefront select-shipping-option native client adapter final error boundary",
+  "source_contract": {
+    "operation_count": 1,
+    "transport_facade_changed": false,
+    "graphql_transport_changed": false,
+    "server_functions_changed": false,
+    "request_response_dto_changed": false,
+    "shipping_selection_policy_changed": false,
+    "native_adapter_final_mapping": true,
+    "validation_preflight_preserved": true,
+    "validation_order_preserved": true,
+    "cart_uuid_validation_message_preserved": true,
+    "selection_plan_validation_messages_preserved": true,
+    "shipping_option_uuid_validation_message_preserved": true,
+    "technical_native_error_public": false,
+    "static_technical_public_message": true,
+    "context_created_before_server_function_call": true,
+    "original_error_logged_privately": true,
+    "per_call_correlation_logging": true,
+    "safe_request_shape_only": true,
+    "cart_id_values_logged": false,
+    "shipping_profile_slug_values_logged": false,
+    "seller_id_values_logged": false,
+    "shipping_option_id_values_logged": false,
+    "delivery_group_values_logged": false,
+    "fallback_enabled": false,
+    "broad_ecommerce_cleanup_closed": false
+  },
+  "stable_public_message": "Shipping selection request could not be completed",
+  "suggested_execution": [
+    "node scripts/verify/verify-fulfillment-storefront-native-client-error-safety.mjs",
+    "node scripts/verify/verify-fulfillment-storefront-native-error-safety.mjs",
+    "node scripts/verify/verify-fulfillment-storefront-graphql-error-safety.mjs",
+    "npm run verify:fulfillment:storefront-boundary",
+    "cargo check -p rustok-fulfillment-storefront --all-features"
+  ],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "hydrate_compile_proven": false,
+    "ssr_compile_proven": false,
+    "browser_runtime_proven": false,
+    "mounted_runtime_proven": false
+  }
+}

--- a/crates/rustok-fulfillment/docs/storefront-native-error-safety.md
+++ b/crates/rustok-fulfillment/docs/storefront-native-error-safety.md
@@ -4,13 +4,16 @@ Status: **source-ready / unvalidated**
 
 ## Scope
 
-This slice hardens the fulfillment-owned native shipping-selection server-function adapter in:
+The fulfillment-owned native shipping-selection path has two source-only safety boundaries:
 
-- `crates/rustok-fulfillment/storefront/src/transport/native_server_adapter/server_functions.rs`.
+- mounted server-function safety in
+  `crates/rustok-fulfillment/storefront/src/transport/native_server_adapter/server_functions.rs`;
+- final native client-adapter safety in
+  `crates/rustok-fulfillment/storefront/src/transport/native_server_adapter/native_client_error_safety.rs`.
 
-It covers host runtime dependency resolution, tenant and authentication context extraction, optional request-context diagnostics, and the Commerce checkout runtime call used to select a shipping option.
+The mounted boundary covers host runtime dependency resolution, tenant and authentication context extraction, optional request-context diagnostics, and the Commerce checkout runtime call. The client boundary prevents an unexpected server-function or framework string from becoming the selected native-path text inside public `UiTransportError`.
 
-## Delivered source contract
+## Mounted server-function contract
 
 Internal failures are retained only in server-side diagnostics with the available:
 
@@ -20,52 +23,62 @@ Internal failures are retained only in server-side diagnostics with the availabl
 - stable internal code and native boundary;
 - original internal error where one exists.
 
-Public `ServerFnError` messages are static for:
+Public `ServerFnError` messages remain static for missing runtime composition, tenant/authentication context extraction, and shipping-selection owner runtime failure. `RequestContext` remains optional for the owner call; failed extraction is logged and still results in `None`.
 
-- missing `TransactionalEventBus` runtime composition;
-- tenant-context extraction;
-- authentication-context extraction;
-- shipping-selection owner runtime failure.
+## Native client contract
 
-`RequestContext` remains optional for the owner call. A failed extraction is logged and still results in `None`, preserving the previous runtime behavior.
+The private native adapter now performs the same fail-fast validation order before the server-function call:
+
+1. cart UUID parsing;
+2. `build_shipping_selection_updates` selection-plan validation;
+3. selected shipping-option UUID parsing for the materialized updates.
+
+These failures return `ShippingSelectionTransportError::Validation` with the existing messages. After that preflight succeeds, the adapter creates one correlation-aware context and maps any remaining native transport failure to:
+
+`Shipping selection request could not be completed`
+
+The complete compatibility error remains private to structured diagnostics. Diagnostics record only operation, correlation id, stable code, boundary, identifier lengths, delivery-group/available-option counts, and seller/option presence. Cart ids, profile slugs, seller ids, option ids, delivery-group values, and request payloads are not logged.
 
 ## Preserved behavior
 
 This slice does not change:
 
-- `SelectShippingOptionRequest` or fulfillment storefront response types;
+- `select_shipping_option` public signature or `UiTransportError` result;
+- `SelectShippingOptionRequest`, delivery-group, update, or response types;
 - the `fulfillment/select-shipping-option` endpoint;
-- `build_shipping_selection_updates` validation messages;
-- cart and shipping-option UUID validation messages;
+- `build_shipping_selection_plan` or update materialization;
+- cart, selection-plan, and shipping-option validation messages;
 - `StorefrontShippingSelectionCommand` or its payload;
-- the outer `ShippingSelectionTransportError::ServerFn` wrapper;
-- the GraphQL adapter or native/GraphQL transport selection;
+- the mounted `ShippingSelectionTransportError::ServerFn(error.to_string())` compatibility wrapper;
+- the storefront transport facade, GraphQL adapter, GraphQL error policy, or native/GraphQL selection;
+- fallback policy;
 - fulfillment FBA or FFA status.
 
 ## Static evidence
 
-`scripts/verify/verify-fulfillment-storefront-native-error-safety.mjs` guards:
+The retained server-side guard remains:
 
-- the storefront diagnostics dependency;
-- exact endpoint and owner-operation markers;
-- static runtime, context, and owner public envelopes;
-- optional request-context preservation;
-- correlation, tenant, channel, locale, owner, code, and boundary logs;
-- removal of raw native owner/context error mapping;
-- unchanged validation and outer transport semantics;
-- source-only validation flags.
+- `scripts/verify/verify-fulfillment-storefront-native-error-safety.mjs`.
+
+The new focused guard is:
+
+- `scripts/verify/verify-fulfillment-storefront-native-client-error-safety.mjs`.
+
+It locks validation ordering and messages, adapter context placement, the static technical envelope, private raw-cause diagnostics, safe request-shape fields, unchanged facade/GraphQL/server-function source, source evidence statuses, and the still-open broad ecommerce mapper cleanup.
 
 ## Remaining gaps
 
-The master ecommerce mapper-cleanup task remains open for other ecommerce transports, compensation/execution adapters, remaining owner consumers, and non-`PortError` public envelopes. Compile, mounted parity, remote transport, and runtime evidence are also still open.
+The master ecommerce mapper-cleanup task remains open for fulfillment execution/recovery, other owner adapters, and non-`PortError` public envelopes. Compile, hydrate/SSR, mounted parity, remote transport, browser, workflow, CI, and production evidence also remain open.
 
 ## Suggested maintainer checks
 
 These commands were intentionally not run by the implementation agent:
 
 ```bash
+node scripts/verify/verify-fulfillment-storefront-native-client-error-safety.mjs
 node scripts/verify/verify-fulfillment-storefront-native-error-safety.mjs
-node scripts/verify/verify-fulfillment-storefront-boundary.mjs
+node scripts/verify/verify-fulfillment-storefront-graphql-error-safety.mjs
+npm run verify:fulfillment:storefront-boundary
 node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
 cargo check -p rustok-fulfillment-storefront --all-features
 ```

--- a/crates/rustok-fulfillment/storefront/src/transport/native_server_adapter.rs
+++ b/crates/rustok-fulfillment/storefront/src/transport/native_server_adapter.rs
@@ -1,9 +1,14 @@
+mod native_client_error_safety;
 mod server_functions;
 
+use self::native_client_error_safety::NativeClientErrorContext;
 use super::{SelectShippingOptionRequest, ShippingSelectionTransportError};
 
 pub async fn select_shipping_option(
     request: SelectShippingOptionRequest,
 ) -> Result<(), ShippingSelectionTransportError> {
-    server_functions::select_shipping_option_server(request).await
+    let context = NativeClientErrorContext::validate_and_new(&request)?;
+    server_functions::select_shipping_option_server(request)
+        .await
+        .map_err(|error| context.map_error(error))
 }

--- a/crates/rustok-fulfillment/storefront/src/transport/native_server_adapter/native_client_error_safety.rs
+++ b/crates/rustok-fulfillment/storefront/src/transport/native_server_adapter/native_client_error_safety.rs
@@ -1,0 +1,100 @@
+use uuid::Uuid;
+
+use super::super::{
+    SelectShippingOptionRequest, ShippingSelectionTransportError, build_shipping_selection_updates,
+};
+
+const FULFILLMENT_STOREFRONT_NATIVE_CLIENT_OWNER: &str = "rustok_fulfillment.storefront";
+const FULFILLMENT_STOREFRONT_NATIVE_CLIENT_OPERATION: &str =
+    "select_storefront_shipping_option";
+const FULFILLMENT_STOREFRONT_NATIVE_CLIENT_BOUNDARY: &str =
+    "fulfillment_storefront_native_client_transport";
+const FULFILLMENT_STOREFRONT_NATIVE_CLIENT_PUBLIC_MESSAGE: &str =
+    "Shipping selection request could not be completed";
+
+pub(super) struct NativeClientErrorContext {
+    correlation_id: String,
+    cart_id_length: usize,
+    delivery_group_count: usize,
+    shipping_profile_slug_length: usize,
+    seller_id_present: bool,
+    shipping_option_id_present: bool,
+    available_shipping_option_count: usize,
+}
+
+impl NativeClientErrorContext {
+    pub(super) fn validate_and_new(
+        request: &SelectShippingOptionRequest,
+    ) -> Result<Self, ShippingSelectionTransportError> {
+        Uuid::parse_str(request.cart_id.trim()).map_err(|_| {
+            ShippingSelectionTransportError::Validation(
+                "cart_id must be a valid UUID".to_string(),
+            )
+        })?;
+
+        let updates = build_shipping_selection_updates(request)?;
+        for update in updates {
+            if let Some(option_id) = update
+                .selected_shipping_option_id
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+            {
+                Uuid::parse_str(option_id.trim()).map_err(|_| {
+                    ShippingSelectionTransportError::Validation(
+                        "selected_shipping_option_id must be a valid UUID".to_string(),
+                    )
+                })?;
+            }
+        }
+
+        Ok(Self {
+            correlation_id: format!(
+                "fulfillment-storefront-native-client:{}:{}",
+                FULFILLMENT_STOREFRONT_NATIVE_CLIENT_OPERATION,
+                Uuid::new_v4()
+            ),
+            cart_id_length: request.cart_id.chars().count(),
+            delivery_group_count: request.delivery_groups.len(),
+            shipping_profile_slug_length: request.shipping_profile_slug.chars().count(),
+            seller_id_present: request.seller_id.is_some(),
+            shipping_option_id_present: request.shipping_option_id.is_some(),
+            available_shipping_option_count: request
+                .delivery_groups
+                .iter()
+                .map(|group| group.available_shipping_option_ids.len())
+                .sum(),
+        })
+    }
+
+    pub(super) fn map_error(
+        &self,
+        error: ShippingSelectionTransportError,
+    ) -> ShippingSelectionTransportError {
+        match error {
+            ShippingSelectionTransportError::Validation(message) => {
+                ShippingSelectionTransportError::Validation(message)
+            }
+            error => {
+                tracing::error!(
+                    raw_error = ?error,
+                    owner = FULFILLMENT_STOREFRONT_NATIVE_CLIENT_OWNER,
+                    owner_operation = FULFILLMENT_STOREFRONT_NATIVE_CLIENT_OPERATION,
+                    correlation_id = %self.correlation_id,
+                    cart_id_length = self.cart_id_length,
+                    delivery_group_count = self.delivery_group_count,
+                    shipping_profile_slug_length = self.shipping_profile_slug_length,
+                    seller_id_present = self.seller_id_present,
+                    shipping_option_id_present = self.shipping_option_id_present,
+                    available_shipping_option_count = self.available_shipping_option_count,
+                    code = "fulfillment.storefront_native_client_transport_failed",
+                    boundary = FULFILLMENT_STOREFRONT_NATIVE_CLIENT_BOUNDARY,
+                    "fulfillment storefront native client transport request failed"
+                );
+
+                ShippingSelectionTransportError::ServerFn(
+                    FULFILLMENT_STOREFRONT_NATIVE_CLIENT_PUBLIC_MESSAGE.to_string(),
+                )
+            }
+        }
+    }
+}

--- a/scripts/verify/verify-fulfillment-storefront-native-client-error-safety.mjs
+++ b/scripts/verify/verify-fulfillment-storefront-native-client-error-safety.mjs
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const requireCount = (source, value, expected, label) => {
+  const count = source.split(value).length - 1;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+};
+
+const paths = {
+  transport: "crates/rustok-fulfillment/storefront/src/transport.rs",
+  adapter: "crates/rustok-fulfillment/storefront/src/transport/native_server_adapter.rs",
+  safety:
+    "crates/rustok-fulfillment/storefront/src/transport/native_server_adapter/native_client_error_safety.rs",
+  serverFunctions:
+    "crates/rustok-fulfillment/storefront/src/transport/native_server_adapter/server_functions.rs",
+  graphqlAdapter:
+    "crates/rustok-fulfillment/storefront/src/transport/graphql_adapter.rs",
+  graphqlSafety:
+    "crates/rustok-fulfillment/storefront/src/transport/graphql_error_safety.rs",
+  evidence:
+    "crates/rustok-fulfillment/contracts/evidence/storefront-native-client-error-safety-source.json",
+  review:
+    "crates/rustok-fulfillment/contracts/evidence/storefront-native-client-error-safety-source-review.json",
+  doc: "crates/rustok-fulfillment/docs/storefront-native-error-safety.md",
+  commercePlan: "crates/rustok-commerce/docs/implementation-plan.md",
+  nativeGuard: "scripts/verify/verify-fulfillment-storefront-native-error-safety.mjs",
+  graphqlGuard: "scripts/verify/verify-fulfillment-storefront-graphql-error-safety.mjs",
+};
+
+const transport = read(paths.transport);
+const adapter = read(paths.adapter);
+const safety = read(paths.safety);
+const serverFunctions = read(paths.serverFunctions);
+const graphqlAdapter = read(paths.graphqlAdapter);
+const graphqlSafety = read(paths.graphqlSafety);
+const evidence = JSON.parse(read(paths.evidence));
+const review = JSON.parse(read(paths.review));
+const doc = read(paths.doc);
+const commercePlan = read(paths.commercePlan);
+const nativeGuard = read(paths.nativeGuard);
+const graphqlGuard = read(paths.graphqlGuard);
+
+for (const [value, label] of [
+  ["mod graphql_adapter;", "GraphQL module"],
+  ["mod graphql_error_safety;", "GraphQL safety module"],
+  ["mod native_server_adapter;", "native adapter module"],
+  ["execute_selected_transport(", "explicit transport selection"],
+  [
+    "move || native_server_adapter::select_shipping_option(native_request)",
+    "unchanged native facade closure",
+  ],
+  [
+    "let context = graphql_error_safety::GraphqlCallContext::new(&request);",
+    "unchanged GraphQL context",
+  ],
+  ["graphql_adapter::select_shipping_option(request)", "unchanged GraphQL call"],
+  [".map_err(|error| context.map_error(error))", "unchanged GraphQL mapping"],
+  ["UiTransportPath::NativeServer", "native path"],
+  ["UiTransportPath::Graphql", "GraphQL path"],
+]) requireText(transport, value, `${paths.transport}: ${label}`);
+for (const value of [
+  "fallback_failed(",
+  "native_client_error_safety",
+  "NativeClientErrorContext",
+]) forbidText(transport, value, `${paths.transport}: facade must stay unchanged`);
+
+for (const [value, label] of [
+  ["mod native_client_error_safety;", "private safety module"],
+  ["mod server_functions;", "server-functions module"],
+  ["use self::native_client_error_safety::NativeClientErrorContext;", "context import"],
+  ["let context = NativeClientErrorContext::validate_and_new(&request)?;", "preflight context"],
+  ["server_functions::select_shipping_option_server(request)", "unchanged server call"],
+  [".map_err(|error| context.map_error(error))", "final native mapping"],
+]) requireText(adapter, value, `${paths.adapter}: ${label}`);
+
+const contextIndex = adapter.indexOf("NativeClientErrorContext::validate_and_new(&request)");
+const callIndex = adapter.indexOf("server_functions::select_shipping_option_server(request)");
+const mapIndex = adapter.indexOf("context.map_error(error)");
+if (!(contextIndex >= 0 && callIndex > contextIndex && mapIndex > callIndex)) {
+  failures.push(`${paths.adapter}: expected validation/context -> server call -> final mapping order`);
+}
+
+for (const [value, label] of [
+  [
+    'const FULFILLMENT_STOREFRONT_NATIVE_CLIENT_OWNER: &str = "rustok_fulfillment.storefront";',
+    "owner constant",
+  ],
+  [
+    '"select_storefront_shipping_option"',
+    "owner operation",
+  ],
+  [
+    '"fulfillment_storefront_native_client_transport"',
+    "client boundary",
+  ],
+  [
+    '"Shipping selection request could not be completed"',
+    "static technical public message",
+  ],
+  ["pub(super) struct NativeClientErrorContext", "private context"],
+  ["pub(super) fn validate_and_new(", "validation constructor"],
+  ["Uuid::parse_str(request.cart_id.trim())", "cart UUID preflight"],
+  ["let updates = build_shipping_selection_updates(request)?;", "selection-plan preflight"],
+  ["Uuid::parse_str(option_id.trim())", "selected-option UUID preflight"],
+  ['"cart_id must be a valid UUID"', "cart validation message"],
+  [
+    '"selected_shipping_option_id must be a valid UUID"',
+    "option validation message",
+  ],
+  ["ShippingSelectionTransportError::Validation(message) =>", "validation pass-through"],
+  ["raw_error = ?error", "private raw cause"],
+  ["correlation_id = %self.correlation_id", "correlation diagnostics"],
+  ["cart_id_length = self.cart_id_length", "cart length fact"],
+  ["delivery_group_count = self.delivery_group_count", "group count fact"],
+  [
+    "shipping_profile_slug_length = self.shipping_profile_slug_length",
+    "profile length fact",
+  ],
+  ["seller_id_present = self.seller_id_present", "seller presence fact"],
+  [
+    "shipping_option_id_present = self.shipping_option_id_present",
+    "option presence fact",
+  ],
+  [
+    "available_shipping_option_count = self.available_shipping_option_count",
+    "available-option count fact",
+  ],
+  [
+    'code = "fulfillment.storefront_native_client_transport_failed"',
+    "stable client code",
+  ],
+  ["boundary = FULFILLMENT_STOREFRONT_NATIVE_CLIENT_BOUNDARY", "boundary diagnostics"],
+  ["ShippingSelectionTransportError::ServerFn(", "static technical remap"],
+]) requireText(safety, value, `${paths.safety}: ${label}`);
+
+const cartValidationIndex = safety.indexOf("Uuid::parse_str(request.cart_id.trim())");
+const selectionValidationIndex = safety.indexOf("build_shipping_selection_updates(request)?");
+const optionValidationIndex = safety.indexOf("Uuid::parse_str(option_id.trim())");
+if (!(cartValidationIndex >= 0 && selectionValidationIndex > cartValidationIndex && optionValidationIndex > selectionValidationIndex)) {
+  failures.push(`${paths.safety}: native validation order must remain cart -> selection plan -> option`);
+}
+
+for (const value of [
+  "cart_id = %",
+  "cart_id = ?",
+  "shipping_profile_slug = %",
+  "shipping_profile_slug = ?",
+  "seller_id = %",
+  "seller_id = ?",
+  "shipping_option_id = %",
+  "shipping_option_id = ?",
+  "delivery_groups =",
+  "available_shipping_option_ids =",
+  "request = ?",
+  "error.to_string()",
+]) forbidText(safety, value, `${paths.safety}: raw request or error text`);
+
+for (const [value, label] of [
+  [
+    'endpoint = "fulfillment/select-shipping-option"',
+    "mounted endpoint",
+  ],
+  ["build_shipping_selection_updates(&request)", "server-side selection validation"],
+  [
+    'ServerFnError::new("cart_id must be a valid UUID")',
+    "server-side cart validation",
+  ],
+  [
+    'ServerFnError::new(format!("{field_name} must be a valid UUID"))',
+    "server-side option validation",
+  ],
+  ["select_storefront_shipping_option(", "owner runtime call"],
+  [
+    "ShippingSelectionTransportError::ServerFn(error.to_string())",
+    "compatibility handoff",
+  ],
+]) requireText(serverFunctions, value, `${paths.serverFunctions}: ${label}`);
+requireCount(
+  serverFunctions,
+  "ShippingSelectionTransportError::ServerFn(error.to_string())",
+  1,
+  `${paths.serverFunctions}: one compatibility handoff`,
+);
+
+requireText(
+  graphqlAdapter,
+  "ShippingSelectionTransportError::Graphql(error.to_string())",
+  `${paths.graphqlAdapter}: GraphQL handoff`,
+);
+requireText(
+  graphqlSafety,
+  "pub(super) struct GraphqlCallContext",
+  `${paths.graphqlSafety}: GraphQL policy`,
+);
+requireText(
+  nativeGuard,
+  "FULFILLMENT_STOREFRONT_NATIVE_OWNER",
+  `${paths.nativeGuard}: mounted native guard`,
+);
+requireText(
+  graphqlGuard,
+  "move || native_server_adapter::select_shipping_option(native_request)",
+  `${paths.graphqlGuard}: unchanged facade assertion`,
+);
+
+if (evidence.status !== "fulfillment_storefront_native_client_error_safety_source_unvalidated") {
+  failures.push(`${paths.evidence}: unexpected status ${evidence.status}`);
+}
+if (
+  review.status !==
+  "fulfillment_storefront_native_client_error_safety_source_reviewed_unvalidated"
+) {
+  failures.push(`${paths.review}: unexpected status ${review.status}`);
+}
+
+for (const [key, expected] of Object.entries({
+  operation_count: 1,
+  transport_facade_changed: false,
+  graphql_transport_changed: false,
+  server_functions_changed: false,
+  request_response_dto_changed: false,
+  shipping_selection_policy_changed: false,
+  native_adapter_final_mapping: true,
+  validation_preflight_preserved: true,
+  validation_order_preserved: true,
+  cart_uuid_validation_message_preserved: true,
+  selection_plan_validation_messages_preserved: true,
+  shipping_option_uuid_validation_message_preserved: true,
+  technical_native_error_public: false,
+  static_technical_public_message: true,
+  context_created_before_server_function_call: true,
+  original_error_logged_privately: true,
+  per_call_correlation_logging: true,
+  safe_request_shape_only: true,
+  cart_id_values_logged: false,
+  shipping_profile_slug_values_logged: false,
+  seller_id_values_logged: false,
+  shipping_option_id_values_logged: false,
+  delivery_group_values_logged: false,
+  fallback_enabled: false,
+  broad_ecommerce_cleanup_closed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "hydrate_compile_proven",
+  "ssr_compile_proven",
+  "browser_runtime_proven",
+  "mounted_runtime_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+
+requireText(doc, "Status: **source-ready / unvalidated**", `${paths.doc}: status`);
+requireText(
+  doc,
+  "Shipping selection request could not be completed",
+  `${paths.doc}: static public message`,
+);
+requireText(
+  commercePlan,
+  "Finish correlation-safe mapper cleanup",
+  `${paths.commercePlan}: broad ecommerce cleanup remains open`,
+);
+
+if (failures.length > 0) {
+  console.error("Fulfillment storefront native client error-safety verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "Fulfillment storefront native client technical failures use a correlation-safe static envelope while validation, GraphQL, and mounted server-function contracts remain unchanged; execution evidence remains open",
+);


### PR DESCRIPTION
## Summary
- close the final technical native-error escape before Fulfillment storefront `UiTransportError` aggregation
- cover the single `select_shipping_option` native operation
- preserve the existing facade and GraphQL closure literally unchanged
- perform native client preflight in the same order as the mounted server function: cart UUID, selection plan, selected option UUID
- preserve detailed validation messages as `ShippingSelectionTransportError::Validation`
- create a correlation-aware context only after validation succeeds
- retain post-preflight `ServerFn`/unexpected native errors only in structured diagnostics
- record operation, correlation id, stable code, boundary, identifier lengths, counts, and presence facts only
- return one static technical public message: `Shipping selection request could not be completed`
- preserve endpoint, DTOs, selection materialization, owner command, mounted server-side safety, GraphQL policy, transport selection, and no-fallback behavior
- add source evidence, source review, updated native safety documentation, and a focused verifier

## Confirmed gap
The mounted Fulfillment server function already uses static owner/runtime messages, but its compatibility wrapper collapses validation and technical failures into `ShippingSelectionTransportError::ServerFn(String)`. The public facade passed that value directly into `execute_selected_transport`, whose `UiTransportError` retains the selected native-path display text.

## Validation preservation
A blanket `ServerFn` remap would have hidden existing validation details. The private native adapter therefore mirrors the current mounted validation order before calling the server function:
1. parse `cart_id`;
2. run `build_shipping_selection_updates`;
3. parse every materialized selected shipping-option id.

The same cart, delivery-group/availability, and selected-option validation messages are returned through the typed `Validation` variant. Any failure after this preflight is treated as technical and fails closed.

## Diagnostics
The new client boundary logs the original compatibility error privately with owner operation, per-call correlation id, stable code, boundary, cart/profile identifier lengths, delivery-group and available-option counts, and seller/option presence. It does not log cart ids, profile slugs, seller ids, option ids, delivery-group values, request payloads, tenant values, or GraphQL data.

## Source review
- adapter context/preflight precedes the unchanged server-function call
- final technical mapping follows the call
- native validation order matches the mounted source
- `transport.rs` is outside the diff, so the direct native closure and GraphQL closure remain unchanged
- GraphQL adapter and GraphQL safety policy are outside the diff
- mounted server functions and endpoint are outside the diff
- request/response DTOs, selection-plan policy, and owner command are outside the diff
- existing native and GraphQL guards retain their prior structural expectations
- Fulfillment FFA/FBA status is not promoted
- the broad ecommerce mapper-cleanup item remains open

`main` advanced by one unrelated Forum Search authorization commit while the branch was prepared. The diff contains only six Fulfillment source/evidence files.

## Validation
Per maintainer instruction, tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run. Evidence remains source-ready / unvalidated and does not prove hydrate, SSR, browser, mounted runtime, remote transport, workflow, CI, or production behavior.

Suggested maintainer commands:
```bash
node scripts/verify/verify-fulfillment-storefront-native-client-error-safety.mjs
node scripts/verify/verify-fulfillment-storefront-native-error-safety.mjs
node scripts/verify/verify-fulfillment-storefront-graphql-error-safety.mjs
npm run verify:fulfillment:storefront-boundary
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-fulfillment-storefront --all-features
```