### PR TITLE
test(comments): register identity classifier harness

### DIFF
--- a/crates/rustok-comments/contracts/comments-fba-registry.json
+++ b/crates/rustok-comments/contracts/comments-fba-registry.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "module": "comments",
   "role": "provider",
   "status": "boundary_ready",
@@ -65,6 +65,7 @@
     "thread_write_invariants": "crates/rustok-comments/contracts/evidence/comments-thread-write-invariants.json",
     "thread_write_invariants_runner": "scripts/verify/verify-comments-thread-write-invariants.mjs",
     "thread_write_invariants_self_test": "scripts/verify/verify-comments-thread-write-invariants.test.mjs",
+    "thread_insert_error_classifier_test": "crates/rustok-comments/src/entities/thread_insert_error_tests.rs",
     "thread_write_invariants_test": "crates/rustok-comments/tests/thread_write_invariants.rs",
     "thread_creation_concurrency_test": "crates/rustok-comments/tests/thread_creation_concurrency.rs"
   },
@@ -86,6 +87,7 @@
         "test_package_script": "test:verify:comments:thread-write-invariants",
         "verifier": "scripts/verify/verify-comments-thread-write-invariants.mjs",
         "self_test": "scripts/verify/verify-comments-thread-write-invariants.test.mjs",
+        "unit_test": "crates/rustok-comments/src/entities/thread_insert_error_tests.rs",
         "evidence": "crates/rustok-comments/contracts/evidence/comments-thread-write-invariants.json"
       }
     }

--- a/crates/rustok-comments/contracts/evidence/comments-thread-write-invariants.json
+++ b/crates/rustok-comments/contracts/evidence/comments-thread-write-invariants.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "module": "comments",
   "surface": "thread_write_invariants",
   "status": "executable_no_run",
@@ -9,6 +9,7 @@
     "position_owner": "crates/rustok-comments/src/entities/comment.rs",
     "counter_and_identity_owner": "crates/rustok-comments/src/entities/comment_thread.rs",
     "thread_service": "crates/rustok-comments/src/services.rs",
+    "classifier_unit_test": "crates/rustok-comments/src/entities/thread_insert_error_tests.rs",
     "identity_lock_entity": "crates/rustok-comments/src/entities/comment_thread_identity_lock.rs",
     "counter_repair_migration": "crates/rustok-comments/src/migrations/m20260723_000008_repair_comment_thread_counters.rs",
     "identity_lock_migration": "crates/rustok-comments/src/migrations/m20260723_000009_add_comment_thread_identity_locks.rs",
@@ -47,6 +48,10 @@
       "expected": "find_or_create_thread_in_tx reloads the canonical thread only for the owner-classified tenant and target identity conflict and propagates every unrelated insert DbErr as CommentsError::Database"
     },
     {
+      "name": "identity_conflict_marker_structure",
+      "expected": "the owner classifier accepts only the exact tenant and target scope followed by one valid canonical thread UUID; malformed, wrong-scope, and unrelated custom errors are rejected"
+    },
+    {
       "name": "postgres_concurrent_create_delete",
       "expected": "two independent PostgreSQL connections preserve positions 1..3 and an exact active count across concurrent create/create and create/soft-delete phases"
     },
@@ -56,9 +61,11 @@
     }
   ],
   "runtime_promotion_requirements": [
+    "execute cargo test -p rustok-comments --lib thread_identity_conflict_classifier",
     "execute cargo test -p rustok-comments --test thread_write_invariants",
     "execute cargo test -p rustok-comments --test thread_creation_concurrency",
     "execute both env-gated PostgreSQL targets with RUSTOK_COMMENTS_TEST_DATABASE_URL",
+    "retain exact-scope and malformed-marker classifier output",
     "retain final active-row count and gap-free unique position evidence",
     "retain one-thread evidence for concurrent first comments",
     "retain unrelated insert DbErr propagation without CommentThreadNotFound remapping",

--- a/crates/rustok-comments/contracts/evidence/comments-thread-write-invariants.json
+++ b/crates/rustok-comments/contracts/evidence/comments-thread-write-invariants.json
@@ -9,6 +9,7 @@
     "position_owner": "crates/rustok-comments/src/entities/comment.rs",
     "counter_and_identity_owner": "crates/rustok-comments/src/entities/comment_thread.rs",
     "thread_service": "crates/rustok-comments/src/services.rs",
+    "entities_module": "crates/rustok-comments/src/entities/mod.rs",
     "classifier_unit_test": "crates/rustok-comments/src/entities/thread_insert_error_tests.rs",
     "identity_lock_entity": "crates/rustok-comments/src/entities/comment_thread_identity_lock.rs",
     "counter_repair_migration": "crates/rustok-comments/src/migrations/m20260723_000008_repair_comment_thread_counters.rs",
@@ -61,7 +62,7 @@
     }
   ],
   "runtime_promotion_requirements": [
-    "execute cargo test -p rustok-comments --lib thread_identity_conflict_classifier",
+    "execute cargo test -p rustok-comments --lib thread_insert_error_tests",
     "execute cargo test -p rustok-comments --test thread_write_invariants",
     "execute cargo test -p rustok-comments --test thread_creation_concurrency",
     "execute both env-gated PostgreSQL targets with RUSTOK_COMMENTS_TEST_DATABASE_URL",

--- a/crates/rustok-comments/docs/implementation-plan.md
+++ b/crates/rustok-comments/docs/implementation-plan.md
@@ -25,8 +25,10 @@ thread insert, `comment_thread::ActiveModelBehavior` upserts a persistent
 and checks for the canonical thread. A concurrent creator receives an owner-
 classified application `DbErr` before its SQL INSERT, leaving the PostgreSQL
 transaction usable. `find_or_create_thread_in_tx` performs canonical lookup only
-for the exact tenant/target identity marker; unrelated storage errors propagate
-through `CommentsError::Database` instead of becoming `CommentThreadNotFound`.
+for the exact tenant/target identity marker followed by one valid canonical thread
+UUID; malformed or wrong-scope markers are rejected. Unrelated storage errors
+propagate through `CommentsError::Database` instead of becoming
+`CommentThreadNotFound`.
 
 Append-only migrations repair historical counters, deterministically renumber
 historical positions, enforce `UNIQUE(thread_id, position)`, and create the unique
@@ -49,26 +51,32 @@ before the schema column is dropped.
 - Structural shape: `core_transport_ui`
 - FBA provider contract: `CommentsThreadPort` / `comments.thread.v1` in
   `crates/rustok-comments/contracts/comments-fba-registry.json`.
-- Comments FBA registry schema v2 locks the exact verify/test package order,
+- Comments FBA registry schema v3 locks the exact verify/test package order,
   thread-invariant leaf commands, verifier, focused self-test, evidence path,
-  and the shared owner runtime-order gate.
+  strict classifier unit harness, and the shared owner runtime-order gate.
 - Static and runtime-order evidence:
   `crates/rustok-comments/contracts/evidence/comments-contract-test-static-matrix.json`
   and `crates/rustok-comments/contracts/evidence/comments-provider-runtime-order-smoke.json`.
-- Thread write invariant evidence schema v2:
+- Thread write invariant evidence schema v3:
   `crates/rustok-comments/contracts/evidence/comments-thread-write-invariants.json`
   with status `executable_no_run`.
 - Thread invariant source gate:
   `scripts/verify/verify-comments-thread-write-invariants.mjs` with focused
   self-test `scripts/verify/verify-comments-thread-write-invariants.test.mjs`.
-  It locks the identity-conflict-only fallback and verifies that unrelated
-  storage errors propagate; broad `Err(_)` fallback is forbidden.
+  It locks the identity-conflict-only fallback, requires a valid canonical thread
+  UUID suffix, verifies that unrelated storage errors propagate, and forbids broad
+  `Err(_)` fallback or prefix-only classification.
+- Classifier unit harness:
+  `crates/rustok-comments/src/entities/thread_insert_error_tests.rs`; it records
+  exact-scope acceptance, malformed-owner rejection, wrong-scope rejection, and
+  unrelated `DbErr` preservation as database failure. It is written but not run.
 - Exact leaf commands: `verify:comments:thread-write-invariants` and
   `test:verify:comments:thread-write-invariants`; both are registered in
   `verify:comments:fba` / `test:verify:comments:fba` before the shared owner
   runtime-order gate.
 - Executable targets:
-  `crates/rustok-comments/tests/thread_write_invariants.rs` and
+  `crates/rustok-comments/src/entities/thread_insert_error_tests.rs`,
+  `crates/rustok-comments/tests/thread_write_invariants.rs`, and
   `crates/rustok-comments/tests/thread_creation_concurrency.rs`.
 - Both PostgreSQL targets use two independent one-connection pools, an isolated
   schema, and `RUSTOK_COMMENTS_TEST_DATABASE_URL` or PostgreSQL `DATABASE_URL`.
@@ -95,8 +103,13 @@ classifier, narrows fallback to that exact identity conflict, propagates unrelat
 storage errors, upgrades retained evidence to schema v2, and adds focused negative
 guards without recording Rust or PostgreSQL execution.
 
-No verifier, Rust test, PostgreSQL target, compile, workflow, or CI execution is
-recorded by this source-only slice.
+The continuation audit at `48d478dc2e4ef55dc6015ba8038dde59c908990a`
+found that the new classifier accepted any custom error beginning with the expected
+scope prefix, including a malformed or empty canonical-thread suffix, and had no
+Rust unit harness retained by the FBA source gate. Slice 13 requires one valid UUID
+suffix, adds `thread_insert_error_tests`, upgrades registry and evidence to schema
+v3, and adds focused regressions for prefix-only parsing and missing test source.
+No unit test, verifier, compile, database, workflow, or CI execution is recorded.
 
 ## Completed implementation slices
 
@@ -130,6 +143,9 @@ recorded by this source-only slice.
     fallback to that exact tenant/target conflict, propagated every unrelated
     insert `DbErr`, upgraded thread evidence to schema v2, and added focused
     regression guards for the classifier, broad catch, and propagation branch.
+13. Hardened the identity classifier from prefix-only matching to exact scope plus
+    a valid canonical thread UUID, added a four-case Rust unit harness, upgraded
+    registry/evidence schema v3, and retained the harness in the existing FBA leaf.
 
 ## Open results
 
@@ -139,13 +155,14 @@ recorded by this source-only slice.
    **Done when:** runtime evidence confirms the owner locks under real concurrent
    PostgreSQL transactions.
 
-2. **Execute fallback-class runtime evidence.** The source-level
-   identity-conflict-only fallback is complete. Inject or reproduce an unrelated
-   thread insert `DbErr` and retain evidence that it propagates as a database
-   failure rather than becoming `CommentThreadNotFound`; also retain the canonical
-   concurrent identity-conflict lookup path.
-   **Done when:** runtime evidence proves unrelated storage errors propagate and
-   the expected first-thread race still returns one canonical thread.
+2. **Execute fallback-class runtime evidence.** The strict source classifier and
+   pure Rust harness are written but not executed. Run the classifier harness,
+   inject or reproduce an unrelated thread insert `DbErr`, and retain evidence that
+   it propagates as a database failure rather than becoming
+   `CommentThreadNotFound`; also retain the canonical concurrent identity-conflict
+   lookup path.
+   **Done when:** executed evidence proves exact marker parsing, unrelated storage
+   error propagation, and one canonical thread for the expected first-thread race.
 
 3. **Implement and execute the Blog reply-count event projection.** Consume
    `comment.created` and `comment.deleted` idempotently, publish the Blog-owned
@@ -190,6 +207,7 @@ should run the relevant subset, including:
 - `npm run test:verify:comments:thread-write-invariants`
 - `npm run verify:comments:fba`
 - `npm run test:verify:comments:fba`
+- `cargo test -p rustok-comments --lib thread_identity_conflict_classifier`
 - `cargo test -p rustok-comments --test thread_write_invariants`
 - `RUSTOK_COMMENTS_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-comments --test thread_write_invariants postgres_concurrent_creates_and_delete_preserve_thread_invariants`
 - `RUSTOK_COMMENTS_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-comments --test thread_creation_concurrency`
@@ -210,7 +228,8 @@ should run the relevant subset, including:
 3. Status-only and metadata-only thread updates must not set `comment_count`.
 4. Preserve the identity-lock before first-thread insert and keep its unique
    `(tenant_id, target_type, target_id)` key.
-5. Keep the owner-classified identity marker scoped to tenant and target, and never
-   restore a broad insert-error fallback.
+5. Keep the owner-classified identity marker scoped to tenant and target, require
+   exactly one valid canonical thread UUID suffix, and never restore prefix-only or
+   broad insert-error fallback.
 6. Keep migrations append-only and preserve both database uniqueness invariants.
 7. Update local/central contracts when the Comments boundary changes.

--- a/crates/rustok-comments/docs/implementation-plan.md
+++ b/crates/rustok-comments/docs/implementation-plan.md
@@ -67,7 +67,8 @@ before the schema column is dropped.
   UUID suffix, verifies that unrelated storage errors propagate, and forbids broad
   `Err(_)` fallback or prefix-only classification.
 - Classifier unit harness:
-  `crates/rustok-comments/src/entities/thread_insert_error_tests.rs`; it records
+  `crates/rustok-comments/src/entities/thread_insert_error_tests.rs`, registered by
+  `#[cfg(test)] mod thread_insert_error_tests;` in the entities module. It records
   exact-scope acceptance, malformed-owner rejection, wrong-scope rejection, and
   unrelated `DbErr` preservation as database failure. It is written but not run.
 - Exact leaf commands: `verify:comments:thread-write-invariants` and
@@ -107,9 +108,10 @@ The continuation audit at `48d478dc2e4ef55dc6015ba8038dde59c908990a`
 found that the new classifier accepted any custom error beginning with the expected
 scope prefix, including a malformed or empty canonical-thread suffix, and had no
 Rust unit harness retained by the FBA source gate. Slice 13 requires one valid UUID
-suffix, adds `thread_insert_error_tests`, upgrades registry and evidence to schema
-v3, and adds focused regressions for prefix-only parsing and missing test source.
-No unit test, verifier, compile, database, workflow, or CI execution is recorded.
+suffix, adds and registers `thread_insert_error_tests`, upgrades registry and
+evidence to schema v3, and adds focused regressions for prefix-only parsing,
+missing test source, and missing test-module registration. No unit test, verifier,
+compile, database, workflow, or CI execution is recorded.
 
 ## Completed implementation slices
 
@@ -144,8 +146,9 @@ No unit test, verifier, compile, database, workflow, or CI execution is recorded
     insert `DbErr`, upgraded thread evidence to schema v2, and added focused
     regression guards for the classifier, broad catch, and propagation branch.
 13. Hardened the identity classifier from prefix-only matching to exact scope plus
-    a valid canonical thread UUID, added a four-case Rust unit harness, upgraded
-    registry/evidence schema v3, and retained the harness in the existing FBA leaf.
+    a valid canonical thread UUID, added and registered a four-case Rust unit
+    harness, upgraded registry/evidence schema v3, and retained the harness in the
+    existing FBA leaf.
 
 ## Open results
 
@@ -207,7 +210,7 @@ should run the relevant subset, including:
 - `npm run test:verify:comments:thread-write-invariants`
 - `npm run verify:comments:fba`
 - `npm run test:verify:comments:fba`
-- `cargo test -p rustok-comments --lib thread_identity_conflict_classifier`
+- `cargo test -p rustok-comments --lib thread_insert_error_tests`
 - `cargo test -p rustok-comments --test thread_write_invariants`
 - `RUSTOK_COMMENTS_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-comments --test thread_write_invariants postgres_concurrent_creates_and_delete_preserve_thread_invariants`
 - `RUSTOK_COMMENTS_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-comments --test thread_creation_concurrency`

--- a/crates/rustok-comments/src/entities/comment_thread.rs
+++ b/crates/rustok-comments/src/entities/comment_thread.rs
@@ -19,7 +19,13 @@ pub(crate) fn is_thread_identity_conflict(
     let expected_prefix = format!(
         "{THREAD_IDENTITY_CONFLICT_MARKER}:{tenant_id}:{target_type}:{target_id}:"
     );
-    matches!(error, DbErr::Custom(message) if message.starts_with(&expected_prefix))
+    let DbErr::Custom(message) = error else {
+        return false;
+    };
+    let Some(existing_thread_id) = message.strip_prefix(&expected_prefix) else {
+        return false;
+    };
+    Uuid::parse_str(existing_thread_id).is_ok()
 }
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]

--- a/crates/rustok-comments/src/entities/mod.rs
+++ b/crates/rustok-comments/src/entities/mod.rs
@@ -2,3 +2,6 @@ pub mod comment;
 pub mod comment_body;
 pub mod comment_thread;
 pub mod comment_thread_identity_lock;
+
+#[cfg(test)]
+mod thread_insert_error_tests;

--- a/crates/rustok-comments/src/entities/thread_insert_error_tests.rs
+++ b/crates/rustok-comments/src/entities/thread_insert_error_tests.rs
@@ -1,0 +1,97 @@
+use sea_orm::DbErr;
+use uuid::Uuid;
+
+use super::comment_thread::{
+    THREAD_IDENTITY_CONFLICT_MARKER, is_thread_identity_conflict,
+};
+use crate::error::CommentsError;
+
+fn identity_conflict_error(
+    tenant_id: Uuid,
+    target_type: &str,
+    target_id: Uuid,
+    existing_thread_id: Uuid,
+) -> DbErr {
+    DbErr::Custom(format!(
+        "{THREAD_IDENTITY_CONFLICT_MARKER}:{tenant_id}:{target_type}:{target_id}:{existing_thread_id}"
+    ))
+}
+
+#[test]
+fn thread_identity_conflict_classifier_accepts_exact_scope_and_owner_uuid() {
+    let tenant_id = Uuid::new_v4();
+    let target_id = Uuid::new_v4();
+    let error = identity_conflict_error(
+        tenant_id,
+        "blog_post",
+        target_id,
+        Uuid::new_v4(),
+    );
+
+    assert!(is_thread_identity_conflict(
+        &error,
+        tenant_id,
+        "blog_post",
+        target_id,
+    ));
+}
+
+#[test]
+fn thread_identity_conflict_classifier_rejects_malformed_owner_uuid() {
+    let tenant_id = Uuid::new_v4();
+    let target_id = Uuid::new_v4();
+    let error = DbErr::Custom(format!(
+        "{THREAD_IDENTITY_CONFLICT_MARKER}:{tenant_id}:blog_post:{target_id}:not-a-uuid"
+    ));
+
+    assert!(!is_thread_identity_conflict(
+        &error,
+        tenant_id,
+        "blog_post",
+        target_id,
+    ));
+}
+
+#[test]
+fn thread_identity_conflict_classifier_rejects_wrong_scope() {
+    let tenant_id = Uuid::new_v4();
+    let target_id = Uuid::new_v4();
+    let error = identity_conflict_error(
+        tenant_id,
+        "blog_post",
+        target_id,
+        Uuid::new_v4(),
+    );
+
+    assert!(!is_thread_identity_conflict(
+        &error,
+        Uuid::new_v4(),
+        "blog_post",
+        target_id,
+    ));
+    assert!(!is_thread_identity_conflict(
+        &error,
+        tenant_id,
+        "catalog_item",
+        target_id,
+    ));
+    assert!(!is_thread_identity_conflict(
+        &error,
+        tenant_id,
+        "blog_post",
+        Uuid::new_v4(),
+    ));
+}
+
+#[test]
+fn unrelated_custom_error_remains_a_database_error() {
+    let error = CommentsError::from(DbErr::Custom(
+        "connection reset while inserting comment thread".to_string(),
+    ));
+
+    assert!(matches!(
+        error,
+        CommentsError::Database(DbErr::Custom(message))
+            if message == "connection reset while inserting comment thread"
+    ));
+}

--- a/scripts/verify/verify-comments-fba.mjs
+++ b/scripts/verify/verify-comments-fba.mjs
@@ -12,6 +12,7 @@ const evidencePath = 'crates/rustok-comments/contracts/evidence/comments-contrac
 const threadWriteEvidencePath = 'crates/rustok-comments/contracts/evidence/comments-thread-write-invariants.json';
 const threadWriteVerifierPath = 'scripts/verify/verify-comments-thread-write-invariants.mjs';
 const threadWriteSelfTestPath = 'scripts/verify/verify-comments-thread-write-invariants.test.mjs';
+const entitiesModulePath = 'crates/rustok-comments/src/entities/mod.rs';
 const classifierTestPath = 'crates/rustok-comments/src/entities/thread_insert_error_tests.rs';
 const packageJsonPath = 'package.json';
 const expectedVerifySteps = [
@@ -55,7 +56,7 @@ if (!sameList(packageJson.scripts?.['verify:comments:fba']?.split(' && ') ?? [],
 if (!sameList(packageJson.scripts?.['test:verify:comments:fba']?.split(' && ') ?? [], expectedTestSteps)) fail('package Comments FBA test chain drift');
 if (packageJson.scripts?.['verify:comments:thread-write-invariants'] !== `node ${threadWriteVerifierPath}`) fail('thread write leaf verifier command drift');
 if (packageJson.scripts?.['test:verify:comments:thread-write-invariants'] !== `node ${threadWriteSelfTestPath}`) fail('thread write leaf self-test command drift');
-for (const filePath of [threadWriteEvidencePath, threadWriteVerifierPath, threadWriteSelfTestPath, classifierTestPath]) {
+for (const filePath of [threadWriteEvidencePath, threadWriteVerifierPath, threadWriteSelfTestPath, entitiesModulePath, classifierTestPath]) {
   if (!fs.existsSync(filePath)) fail(`thread write source gate file is missing ${filePath}`);
 }
 
@@ -186,6 +187,7 @@ for (const [key, expected] of Object.entries({
   position_owner: 'crates/rustok-comments/src/entities/comment.rs',
   counter_and_identity_owner: 'crates/rustok-comments/src/entities/comment_thread.rs',
   thread_service: 'crates/rustok-comments/src/services.rs',
+  entities_module: entitiesModulePath,
   classifier_unit_test: classifierTestPath,
   identity_lock_entity: 'crates/rustok-comments/src/entities/comment_thread_identity_lock.rs',
   counter_repair_migration: 'crates/rustok-comments/src/migrations/m20260723_000008_repair_comment_thread_counters.rs',
@@ -235,6 +237,11 @@ hasAll(threadService, [
   'Err(error) => Err(error.into())',
 ], 'comment thread service fallback');
 hasNone(threadService, ['Err(_) => comment_thread::Entity::find()'], 'comment thread service fallback');
+const entitiesModule = read(threadContract.entities_module);
+hasAll(entitiesModule, [
+  '#[cfg(test)]',
+  'mod thread_insert_error_tests;',
+], 'thread insert error classifier module');
 const classifierTest = read(threadContract.classifier_unit_test);
 hasAll(classifierTest, [
   'thread_identity_conflict_classifier_accepts_exact_scope_and_owner_uuid',
@@ -299,6 +306,7 @@ hasAll(firstThreadTest, [
 const threadWriteVerifier = read(threadWriteVerifierPath);
 hasAll(threadWriteVerifier, [
   'identity_lock::Entity::update_many()',
+  'mod thread_insert_error_tests;',
   'message.strip_prefix(&expected_prefix)',
   'Uuid::parse_str(existing_thread_id).is_ok()',
   'thread_identity_conflict_classifier_rejects_malformed_owner_uuid',
@@ -319,6 +327,7 @@ hasAll(threadWriteSelfTest, [
   'rejects a missing identity-conflict classifier',
   'rejects a prefix-only identity-conflict classifier',
   'rejects a missing identity classifier unit harness',
+  'rejects an unregistered identity classifier unit harness',
   'rejects missing unrelated storage error propagation',
 ], 'thread write invariant self-test');
 
@@ -349,4 +358,4 @@ hasAll(plan, [
 const central = read('docs/modules/registry.md');
 hasAll(central, ['| `comments` |', 'crates/rustok-comments/contracts/comments-fba-registry.json', registry.evidence.runtime_order_smoke, '`in_progress` | `boundary_ready`'], 'central registry');
 
-console.log('[verify-comments-fba] comments FBA provider metadata, exact thread-invariant source-gate chain, runtime-order evidence, strict identity classifier harness, transactional thread writes, and first-thread identity serialization are consistent');
+console.log('[verify-comments-fba] comments FBA provider metadata, exact thread-invariant source-gate chain, runtime-order evidence, registered strict identity classifier harness, transactional thread writes, and first-thread identity serialization are consistent');

--- a/scripts/verify/verify-comments-fba.mjs
+++ b/scripts/verify/verify-comments-fba.mjs
@@ -12,6 +12,7 @@ const evidencePath = 'crates/rustok-comments/contracts/evidence/comments-contrac
 const threadWriteEvidencePath = 'crates/rustok-comments/contracts/evidence/comments-thread-write-invariants.json';
 const threadWriteVerifierPath = 'scripts/verify/verify-comments-thread-write-invariants.mjs';
 const threadWriteSelfTestPath = 'scripts/verify/verify-comments-thread-write-invariants.test.mjs';
+const classifierTestPath = 'crates/rustok-comments/src/entities/thread_insert_error_tests.rs';
 const packageJsonPath = 'package.json';
 const expectedVerifySteps = [
   'node scripts/verify/verify-comments-fba.mjs',
@@ -28,7 +29,7 @@ const runtimeSmoke = json(registry.evidence.runtime_order_smoke);
 const threadWriteEvidence = json(registry.evidence.thread_write_invariants);
 const packageJson = json(packageJsonPath);
 
-if (registry.schema_version !== 2) fail('registry schema_version drift');
+if (registry.schema_version !== 3) fail('registry schema_version drift');
 if (registry.module !== 'comments' || registry.role !== 'provider' || !['in_progress', 'boundary_ready'].includes(registry.status)) fail('registry identity/status drift');
 if (registry.contract_version !== 'comments.thread.v1') fail('contract_version drift');
 const port = registry.ports?.[0];
@@ -47,13 +48,14 @@ if (
   || threadWriteGate?.test_package_script !== 'test:verify:comments:thread-write-invariants'
   || threadWriteGate?.verifier !== threadWriteVerifierPath
   || threadWriteGate?.self_test !== threadWriteSelfTestPath
+  || threadWriteGate?.unit_test !== classifierTestPath
   || threadWriteGate?.evidence !== threadWriteEvidencePath
 ) fail('thread write source gate drift');
 if (!sameList(packageJson.scripts?.['verify:comments:fba']?.split(' && ') ?? [], expectedVerifySteps)) fail('package Comments FBA verify chain drift');
 if (!sameList(packageJson.scripts?.['test:verify:comments:fba']?.split(' && ') ?? [], expectedTestSteps)) fail('package Comments FBA test chain drift');
 if (packageJson.scripts?.['verify:comments:thread-write-invariants'] !== `node ${threadWriteVerifierPath}`) fail('thread write leaf verifier command drift');
 if (packageJson.scripts?.['test:verify:comments:thread-write-invariants'] !== `node ${threadWriteSelfTestPath}`) fail('thread write leaf self-test command drift');
-for (const filePath of [threadWriteEvidencePath, threadWriteVerifierPath, threadWriteSelfTestPath]) {
+for (const filePath of [threadWriteEvidencePath, threadWriteVerifierPath, threadWriteSelfTestPath, classifierTestPath]) {
   if (!fs.existsSync(filePath)) fail(`thread write source gate file is missing ${filePath}`);
 }
 
@@ -159,9 +161,10 @@ for (const c of runtimeSmoke.cases) {
 if (registry.evidence.thread_write_invariants !== threadWriteEvidencePath) fail('thread write evidence path drift');
 if (registry.evidence.thread_write_invariants_runner !== threadWriteVerifierPath) fail('thread write verifier path drift');
 if (registry.evidence.thread_write_invariants_self_test !== threadWriteSelfTestPath) fail('thread write self-test path drift');
+if (registry.evidence.thread_insert_error_classifier_test !== classifierTestPath) fail('thread insert classifier test path drift');
 if (registry.evidence.thread_write_invariants_test !== 'crates/rustok-comments/tests/thread_write_invariants.rs') fail('thread write test path drift');
 if (registry.evidence.thread_creation_concurrency_test !== 'crates/rustok-comments/tests/thread_creation_concurrency.rs') fail('thread creation test path drift');
-if (threadWriteEvidence.schema_version !== 2) fail('thread write evidence schema_version drift');
+if (threadWriteEvidence.schema_version !== 3) fail('thread write evidence schema_version drift');
 if (threadWriteEvidence.module !== 'comments' || threadWriteEvidence.surface !== 'thread_write_invariants' || threadWriteEvidence.owner !== 'rustok-comments') fail('thread write evidence identity drift');
 if (threadWriteEvidence.status !== 'executable_no_run' || threadWriteEvidence.compile_policy !== 'not_run_by_request') fail('thread write evidence status drift');
 const threadWriteCases = threadWriteEvidence.cases.map(c => c.name).sort().join('|');
@@ -170,6 +173,7 @@ if (threadWriteCases !== [
   'exact_active_comment_count',
   'historical_counter_repair',
   'historical_position_repair',
+  'identity_conflict_marker_structure',
   'identity_conflict_only_fallback',
   'postgres_concurrent_create_delete',
   'postgres_concurrent_first_thread_creation',
@@ -182,6 +186,7 @@ for (const [key, expected] of Object.entries({
   position_owner: 'crates/rustok-comments/src/entities/comment.rs',
   counter_and_identity_owner: 'crates/rustok-comments/src/entities/comment_thread.rs',
   thread_service: 'crates/rustok-comments/src/services.rs',
+  classifier_unit_test: classifierTestPath,
   identity_lock_entity: 'crates/rustok-comments/src/entities/comment_thread_identity_lock.rs',
   counter_repair_migration: 'crates/rustok-comments/src/migrations/m20260723_000008_repair_comment_thread_counters.rs',
   identity_lock_migration: 'crates/rustok-comments/src/migrations/m20260723_000009_add_comment_thread_identity_locks.rs',
@@ -206,7 +211,9 @@ const threadOwner = read(threadContract.counter_and_identity_owner);
 hasAll(threadOwner, [
   'pub(crate) const THREAD_IDENTITY_CONFLICT_MARKER',
   'pub(crate) fn is_thread_identity_conflict(',
-  'matches!(error, DbErr::Custom(message) if message.starts_with(&expected_prefix))',
+  'let DbErr::Custom(message) = error else',
+  'message.strip_prefix(&expected_prefix)',
+  'Uuid::parse_str(existing_thread_id).is_ok()',
   'serialize_thread_identity(db, &self).await?',
   'matches!(&self.comment_count, ActiveValue::Set(_))',
   'OnConflict::columns',
@@ -216,6 +223,7 @@ hasAll(threadOwner, [
   '.count(db)',
   'self.comment_count = Set(count)',
 ], 'comment thread owner');
+hasNone(threadOwner, ['message.starts_with(&expected_prefix)'], 'comment thread owner');
 const threadService = read(threadContract.thread_service);
 hasAll(threadService, [
   'match thread.insert(txn).await',
@@ -227,6 +235,14 @@ hasAll(threadService, [
   'Err(error) => Err(error.into())',
 ], 'comment thread service fallback');
 hasNone(threadService, ['Err(_) => comment_thread::Entity::find()'], 'comment thread service fallback');
+const classifierTest = read(threadContract.classifier_unit_test);
+hasAll(classifierTest, [
+  'thread_identity_conflict_classifier_accepts_exact_scope_and_owner_uuid',
+  'thread_identity_conflict_classifier_rejects_malformed_owner_uuid',
+  'thread_identity_conflict_classifier_rejects_wrong_scope',
+  'unrelated_custom_error_remains_a_database_error',
+  'CommentsError::Database(DbErr::Custom(message))',
+], 'thread insert error classifier test');
 const identityEntity = read(threadContract.identity_lock_entity);
 hasAll(identityEntity, [
   '#[sea_orm(table_name = "comment_thread_identity_locks")]',
@@ -283,8 +299,12 @@ hasAll(firstThreadTest, [
 const threadWriteVerifier = read(threadWriteVerifierPath);
 hasAll(threadWriteVerifier, [
   'identity_lock::Entity::update_many()',
+  'message.strip_prefix(&expected_prefix)',
+  'Uuid::parse_str(existing_thread_id).is_ok()',
+  'thread_identity_conflict_classifier_rejects_malformed_owner_uuid',
   'comment_thread::is_thread_identity_conflict(',
   'Err(error) => Err(error.into())',
+  'identity_conflict_marker_structure',
   'identity_conflict_only_fallback',
   'postgres_concurrent_first_comments_share_one_thread',
   'status_only_thread_update_preserves_comment_count',
@@ -297,24 +317,30 @@ hasAll(threadWriteSelfTest, [
   'rejects missing first-thread concurrency harness',
   'rejects a broad insert fallback',
   'rejects a missing identity-conflict classifier',
+  'rejects a prefix-only identity-conflict classifier',
+  'rejects a missing identity classifier unit harness',
   'rejects missing unrelated storage error propagation',
 ], 'thread write invariant self-test');
 
 const plan = read('crates/rustok-comments/docs/implementation-plan.md');
 hasAll(plan, [
   '- FBA status: `boundary_ready`',
+  'Comments FBA registry schema v3',
   'comments-fba-registry.json',
   'CommentsThreadPort',
   'comments-contract-test-static-matrix.json',
   registry.evidence.runtime_order_smoke,
   registry.evidence.thread_write_invariants,
+  registry.evidence.thread_insert_error_classifier_test,
   'ActiveModelBehavior',
   'UNIQUE(thread_id, position)',
   'RUSTOK_COMMENTS_TEST_DATABASE_URL',
   'concurrent PostgreSQL',
   'identity-lock',
   'thread_creation_concurrency',
+  'thread_insert_error_tests',
   'identity-conflict-only fallback',
+  'valid canonical thread UUID',
   'unrelated storage errors propagate',
   'verify:comments:thread-write-invariants',
   'test:verify:comments:thread-write-invariants',
@@ -323,4 +349,4 @@ hasAll(plan, [
 const central = read('docs/modules/registry.md');
 hasAll(central, ['| `comments` |', 'crates/rustok-comments/contracts/comments-fba-registry.json', registry.evidence.runtime_order_smoke, '`in_progress` | `boundary_ready`'], 'central registry');
 
-console.log('[verify-comments-fba] comments FBA provider metadata, exact thread-invariant source-gate chain, runtime-order evidence, transactional thread writes, narrow identity-conflict fallback, and first-thread identity serialization are consistent');
+console.log('[verify-comments-fba] comments FBA provider metadata, exact thread-invariant source-gate chain, runtime-order evidence, strict identity classifier harness, transactional thread writes, and first-thread identity serialization are consistent');

--- a/scripts/verify/verify-comments-thread-write-invariants.mjs
+++ b/scripts/verify/verify-comments-thread-write-invariants.mjs
@@ -31,6 +31,7 @@ function requireNoMarker(source, marker, label) {
 
 const commentPath = "crates/rustok-comments/src/entities/comment.rs";
 const threadPath = "crates/rustok-comments/src/entities/comment_thread.rs";
+const entitiesModulePath = "crates/rustok-comments/src/entities/mod.rs";
 const classifierTestPath =
   "crates/rustok-comments/src/entities/thread_insert_error_tests.rs";
 const identityEntityPath =
@@ -50,6 +51,7 @@ const planPath = "crates/rustok-comments/docs/implementation-plan.md";
 
 const comment = read(commentPath);
 const thread = read(threadPath);
+const entitiesModule = read(entitiesModulePath);
 const classifierTest = read(classifierTestPath);
 const identityEntity = read(identityEntityPath);
 const services = read(servicesPath);
@@ -105,6 +107,13 @@ requireNoMarker(
   "message.starts_with(&expected_prefix)",
   `${threadPath}: identity classifier`,
 );
+
+for (const marker of [
+  "#[cfg(test)]",
+  "mod thread_insert_error_tests;",
+]) {
+  requireMarker(entitiesModule, marker, entitiesModulePath);
+}
 
 for (const marker of [
   "thread_identity_conflict_classifier_accepts_exact_scope_and_owner_uuid",
@@ -245,6 +254,7 @@ if (evidence) {
     position_owner: commentPath,
     counter_and_identity_owner: threadPath,
     thread_service: servicesPath,
+    entities_module: entitiesModulePath,
     classifier_unit_test: classifierTestPath,
     identity_lock_entity: identityEntityPath,
     counter_repair_migration: counterMigrationPath,

--- a/scripts/verify/verify-comments-thread-write-invariants.mjs
+++ b/scripts/verify/verify-comments-thread-write-invariants.mjs
@@ -31,6 +31,8 @@ function requireNoMarker(source, marker, label) {
 
 const commentPath = "crates/rustok-comments/src/entities/comment.rs";
 const threadPath = "crates/rustok-comments/src/entities/comment_thread.rs";
+const classifierTestPath =
+  "crates/rustok-comments/src/entities/thread_insert_error_tests.rs";
 const identityEntityPath =
   "crates/rustok-comments/src/entities/comment_thread_identity_lock.rs";
 const servicesPath = "crates/rustok-comments/src/services.rs";
@@ -48,6 +50,7 @@ const planPath = "crates/rustok-comments/docs/implementation-plan.md";
 
 const comment = read(commentPath);
 const thread = read(threadPath);
+const classifierTest = read(classifierTestPath);
 const identityEntity = read(identityEntityPath);
 const services = read(servicesPath);
 const counterMigration = read(counterMigrationPath);
@@ -79,7 +82,9 @@ for (const marker of [
 for (const marker of [
   "pub(crate) const THREAD_IDENTITY_CONFLICT_MARKER",
   "pub(crate) fn is_thread_identity_conflict(",
-  "matches!(error, DbErr::Custom(message) if message.starts_with(&expected_prefix))",
+  "let DbErr::Custom(message) = error else",
+  "message.strip_prefix(&expected_prefix)",
+  "Uuid::parse_str(existing_thread_id).is_ok()",
   "impl ActiveModelBehavior for ActiveModel",
   "serialize_thread_identity(db, &self).await?",
   "matches!(&self.comment_count, ActiveValue::Set(_))",
@@ -94,6 +99,23 @@ for (const marker of [
   "{THREAD_IDENTITY_CONFLICT_MARKER}:{tenant_id}:{target_type}:{target_id}:{}",
 ]) {
   requireMarker(thread, marker, threadPath);
+}
+requireNoMarker(
+  thread,
+  "message.starts_with(&expected_prefix)",
+  `${threadPath}: identity classifier`,
+);
+
+for (const marker of [
+  "thread_identity_conflict_classifier_accepts_exact_scope_and_owner_uuid",
+  "thread_identity_conflict_classifier_rejects_malformed_owner_uuid",
+  "thread_identity_conflict_classifier_rejects_wrong_scope",
+  "unrelated_custom_error_remains_a_database_error",
+  "THREAD_IDENTITY_CONFLICT_MARKER",
+  "is_thread_identity_conflict(",
+  "CommentsError::Database(DbErr::Custom(message))",
+]) {
+  requireMarker(classifierTest, marker, classifierTestPath);
 }
 
 for (const marker of [
@@ -206,7 +228,7 @@ for (const marker of [
 }
 
 if (evidence) {
-  if (evidence.schema_version !== 2) failures.push(`${evidencePath}: schema_version drift`);
+  if (evidence.schema_version !== 3) failures.push(`${evidencePath}: schema_version drift`);
   if (
     evidence.module !== "comments" ||
     evidence.surface !== "thread_write_invariants" ||
@@ -223,6 +245,7 @@ if (evidence) {
     position_owner: commentPath,
     counter_and_identity_owner: threadPath,
     thread_service: servicesPath,
+    classifier_unit_test: classifierTestPath,
     identity_lock_entity: identityEntityPath,
     counter_repair_migration: counterMigrationPath,
     identity_lock_migration: identityMigrationPath,
@@ -242,6 +265,7 @@ if (evidence) {
     "historical_position_repair",
     "bulk_bypass_rejection",
     "identity_conflict_only_fallback",
+    "identity_conflict_marker_structure",
     "postgres_concurrent_create_delete",
     "postgres_concurrent_first_thread_creation",
   ]) {
@@ -258,7 +282,9 @@ for (const marker of [
   "concurrent PostgreSQL",
   "identity-lock",
   "thread_creation_concurrency",
+  "thread_insert_error_tests",
   "identity-conflict-only fallback",
+  "valid canonical thread UUID",
   "unrelated storage errors propagate",
 ]) {
   requireMarker(plan, marker, planPath);

--- a/scripts/verify/verify-comments-thread-write-invariants.test.mjs
+++ b/scripts/verify/verify-comments-thread-write-invariants.test.mjs
@@ -28,12 +28,14 @@ function fixture({
   missingIdentityClassifier = false,
   missingClassifierUuidValidation = false,
   missingClassifierUnitHarness = false,
+  missingClassifierTestRegistration = false,
   broadInsertFallback = false,
   missingStoragePropagation = false,
 } = {}) {
   const root = mkdtempSync(path.join(tmpdir(), "rustok-comments-thread-invariants-"));
   const commentPath = "crates/rustok-comments/src/entities/comment.rs";
   const threadPath = "crates/rustok-comments/src/entities/comment_thread.rs";
+  const entitiesModulePath = "crates/rustok-comments/src/entities/mod.rs";
   const classifierTestPath =
     "crates/rustok-comments/src/entities/thread_insert_error_tests.rs";
   const identityEntityPath =
@@ -110,6 +112,18 @@ function fixture({
       ${missingIdentityRowLock ? "" : "identity_lock::Entity::update_many();"}
       {THREAD_IDENTITY_CONFLICT_MARKER}:{tenant_id}:{target_type}:{target_id}:{}
     `,
+  );
+
+  write(
+    root,
+    entitiesModulePath,
+    missingClassifierTestRegistration
+      ? "pub mod comment_thread;"
+      : `
+          pub mod comment_thread;
+          #[cfg(test)]
+          mod thread_insert_error_tests;
+        `,
   );
 
   write(
@@ -266,6 +280,7 @@ function fixture({
         position_owner: commentPath,
         counter_and_identity_owner: threadPath,
         thread_service: servicesPath,
+        entities_module: entitiesModulePath,
         classifier_unit_test: classifierTestPath,
         identity_lock_entity: identityEntityPath,
         counter_repair_migration: counterMigrationPath,
@@ -381,6 +396,13 @@ test("rejects a missing identity classifier unit harness", () => {
   expectFailure(
     { missingClassifierUnitHarness: true },
     /missing thread_identity_conflict_classifier_accepts_exact_scope_and_owner_uuid/,
+  );
+});
+
+test("rejects an unregistered identity classifier unit harness", () => {
+  expectFailure(
+    { missingClassifierTestRegistration: true },
+    /missing #\[cfg\(test\)\]|missing mod thread_insert_error_tests;/,
   );
 });
 

--- a/scripts/verify/verify-comments-thread-write-invariants.test.mjs
+++ b/scripts/verify/verify-comments-thread-write-invariants.test.mjs
@@ -26,12 +26,16 @@ function fixture({
   missingIdentityRowLock = false,
   missingFirstThreadHarness = false,
   missingIdentityClassifier = false,
+  missingClassifierUuidValidation = false,
+  missingClassifierUnitHarness = false,
   broadInsertFallback = false,
   missingStoragePropagation = false,
 } = {}) {
   const root = mkdtempSync(path.join(tmpdir(), "rustok-comments-thread-invariants-"));
   const commentPath = "crates/rustok-comments/src/entities/comment.rs";
   const threadPath = "crates/rustok-comments/src/entities/comment_thread.rs";
+  const classifierTestPath =
+    "crates/rustok-comments/src/entities/thread_insert_error_tests.rs";
   const identityEntityPath =
     "crates/rustok-comments/src/entities/comment_thread_identity_lock.rs";
   const servicesPath = "crates/rustok-comments/src/services.rs";
@@ -64,20 +68,29 @@ function fixture({
       }
     `,
   );
+
+  const classifier = missingIdentityClassifier
+    ? ""
+    : missingClassifierUuidValidation
+      ? `
+          pub(crate) const THREAD_IDENTITY_CONFLICT_MARKER: &str = "comment_thread_identity_conflict";
+          pub(crate) fn is_thread_identity_conflict(error: &DbErr) {
+            matches!(error, DbErr::Custom(message) if message.starts_with(&expected_prefix));
+          }
+        `
+      : `
+          pub(crate) const THREAD_IDENTITY_CONFLICT_MARKER: &str = "comment_thread_identity_conflict";
+          pub(crate) fn is_thread_identity_conflict(error: &DbErr) {
+            let DbErr::Custom(message) = error else { return false; };
+            let Some(existing_thread_id) = message.strip_prefix(&expected_prefix) else { return false; };
+            Uuid::parse_str(existing_thread_id).is_ok();
+          }
+        `;
   write(
     root,
     threadPath,
     `
-      ${
-        missingIdentityClassifier
-          ? ""
-          : `
-            pub(crate) const THREAD_IDENTITY_CONFLICT_MARKER: &str = "comment_thread_identity_conflict";
-            pub(crate) fn is_thread_identity_conflict(error: &DbErr) {
-              matches!(error, DbErr::Custom(message) if message.starts_with(&expected_prefix));
-            }
-          `
-      }
+      ${classifier}
       impl ActiveModelBehavior for ActiveModel {
         async fn before_save() {
           serialize_thread_identity(db, &self).await?;
@@ -98,6 +111,23 @@ function fixture({
       {THREAD_IDENTITY_CONFLICT_MARKER}:{tenant_id}:{target_type}:{target_id}:{}
     `,
   );
+
+  write(
+    root,
+    classifierTestPath,
+    missingClassifierUnitHarness
+      ? ""
+      : `
+          thread_identity_conflict_classifier_accepts_exact_scope_and_owner_uuid
+          thread_identity_conflict_classifier_rejects_malformed_owner_uuid
+          thread_identity_conflict_classifier_rejects_wrong_scope
+          unrelated_custom_error_remains_a_database_error
+          THREAD_IDENTITY_CONFLICT_MARKER
+          is_thread_identity_conflict(
+          CommentsError::Database(DbErr::Custom(message))
+        `,
+  );
+
   write(
     root,
     identityEntityPath,
@@ -109,6 +139,7 @@ function fixture({
       impl ActiveModelBehavior for ActiveModel
     `,
   );
+
   write(
     root,
     servicesPath,
@@ -139,6 +170,7 @@ function fixture({
       fn next_item() {}
     `,
   );
+
   write(
     root,
     counterMigrationPath,
@@ -154,6 +186,7 @@ function fixture({
       ${nonUniqueIndex ? "" : ".unique();"}
     `,
   );
+
   write(
     root,
     identityMigrationPath,
@@ -166,6 +199,7 @@ function fixture({
       .unique()
     `,
   );
+
   write(
     root,
     migrationRegistryPath,
@@ -176,6 +210,7 @@ function fixture({
       Box::new(m20260723_000009_add_comment_thread_identity_locks::Migration)
     `,
   );
+
   write(
     root,
     writeTestPath,
@@ -198,6 +233,7 @@ function fixture({
       }
     `,
   );
+
   write(
     root,
     firstThreadTestPath,
@@ -215,11 +251,12 @@ function fixture({
         RUSTOK_COMMENTS_TEST_DATABASE_URL
       `,
   );
+
   write(
     root,
     evidencePath,
     JSON.stringify({
-      schema_version: 2,
+      schema_version: 3,
       module: "comments",
       surface: "thread_write_invariants",
       status: "executable_no_run",
@@ -229,6 +266,7 @@ function fixture({
         position_owner: commentPath,
         counter_and_identity_owner: threadPath,
         thread_service: servicesPath,
+        classifier_unit_test: classifierTestPath,
         identity_lock_entity: identityEntityPath,
         counter_repair_migration: counterMigrationPath,
         identity_lock_migration: identityMigrationPath,
@@ -245,15 +283,17 @@ function fixture({
         { name: "historical_position_repair" },
         { name: "bulk_bypass_rejection" },
         { name: "identity_conflict_only_fallback" },
+        { name: "identity_conflict_marker_structure" },
         { name: "postgres_concurrent_create_delete" },
         { name: "postgres_concurrent_first_thread_creation" },
       ],
     }),
   );
+
   write(
     root,
     "crates/rustok-comments/docs/implementation-plan.md",
-    "comments-thread-write-invariants.json thread_write_invariants ActiveModelBehavior UNIQUE(thread_id, position) RUSTOK_COMMENTS_TEST_DATABASE_URL concurrent PostgreSQL identity-lock thread_creation_concurrency identity-conflict-only fallback unrelated storage errors propagate",
+    "comments-thread-write-invariants.json thread_write_invariants ActiveModelBehavior UNIQUE(thread_id, position) RUSTOK_COMMENTS_TEST_DATABASE_URL concurrent PostgreSQL identity-lock thread_creation_concurrency thread_insert_error_tests identity-conflict-only fallback valid canonical thread UUID unrelated storage errors propagate",
   );
 
   return root;
@@ -267,6 +307,17 @@ function run(root) {
   });
 }
 
+function expectFailure(options, pattern) {
+  const root = fixture(options);
+  try {
+    const result = run(root);
+    assert.notEqual(result.status, 0);
+    if (pattern) assert.match(result.stderr, pattern);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
 test("thread write verifier accepts the owner invariant contract", () => {
   const root = fixture();
   try {
@@ -278,106 +329,64 @@ test("thread write verifier accepts the owner invariant contract", () => {
 });
 
 test("rejects position allocation without tenant lock", () => {
-  const root = fixture({ missingPositionTenantLock: true });
-  try {
-    const result = run(root);
-    assert.notEqual(result.status, 0);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  expectFailure({ missingPositionTenantLock: true });
 });
 
 test("rejects counter writes without activation guard", () => {
-  const root = fixture({ missingCounterActivationGuard: true });
-  try {
-    const result = run(root);
-    assert.notEqual(result.status, 0);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  expectFailure({ missingCounterActivationGuard: true });
 });
 
 test("rejects a counter owner without exact active count", () => {
-  const root = fixture({ missingExactCount: true });
-  try {
-    const result = run(root);
-    assert.notEqual(result.status, 0);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  expectFailure({ missingExactCount: true });
 });
 
 test("rejects a non-unique position index", () => {
-  const root = fixture({ nonUniqueIndex: true });
-  try {
-    const result = run(root);
-    assert.notEqual(result.status, 0);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  expectFailure({ nonUniqueIndex: true });
 });
 
 test("rejects missing PostgreSQL write concurrency harness", () => {
-  const root = fixture({ missingPostgresHarness: true });
-  try {
-    const result = run(root);
-    assert.notEqual(result.status, 0);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  expectFailure({ missingPostgresHarness: true });
 });
 
 test("rejects missing identity row lock", () => {
-  const root = fixture({ missingIdentityRowLock: true });
-  try {
-    const result = run(root);
-    assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /missing identity_lock::Entity::update_many/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  expectFailure({ missingIdentityRowLock: true }, /missing identity_lock::Entity::update_many/);
 });
 
 test("rejects missing first-thread concurrency harness", () => {
-  const root = fixture({ missingFirstThreadHarness: true });
-  try {
-    const result = run(root);
-    assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /missing postgres_concurrent_first_comments_share_one_thread/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  expectFailure(
+    { missingFirstThreadHarness: true },
+    /missing postgres_concurrent_first_comments_share_one_thread/,
+  );
 });
 
 test("rejects a broad insert fallback", () => {
-  const root = fixture({ broadInsertFallback: true });
-  try {
-    const result = run(root);
-    assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /forbidden Err\(_\) =>/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  expectFailure({ broadInsertFallback: true }, /forbidden Err\(_\) =>/);
 });
 
 test("rejects a missing identity-conflict classifier", () => {
-  const root = fixture({ missingIdentityClassifier: true });
-  try {
-    const result = run(root);
-    assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /missing pub\(crate\) const THREAD_IDENTITY_CONFLICT_MARKER/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  expectFailure(
+    { missingIdentityClassifier: true },
+    /missing pub\(crate\) const THREAD_IDENTITY_CONFLICT_MARKER/,
+  );
+});
+
+test("rejects a prefix-only identity-conflict classifier", () => {
+  expectFailure(
+    { missingClassifierUuidValidation: true },
+    /missing let DbErr::Custom\(message\) = error else|forbidden message\.starts_with/,
+  );
+});
+
+test("rejects a missing identity classifier unit harness", () => {
+  expectFailure(
+    { missingClassifierUnitHarness: true },
+    /missing thread_identity_conflict_classifier_accepts_exact_scope_and_owner_uuid/,
+  );
 });
 
 test("rejects missing unrelated storage error propagation", () => {
-  const root = fixture({ missingStoragePropagation: true });
-  try {
-    const result = run(root);
-    assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /missing Err\(error\) => Err\(error\.into\(\)\)/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  expectFailure(
+    { missingStoragePropagation: true },
+    /missing Err\(error\) => Err\(error\.into\(\)\)/,
+  );
 });


### PR DESCRIPTION
## Summary

- harden the Comments-owned first-thread identity-conflict classifier from prefix-only matching to exact tenant/target scope plus one valid canonical thread UUID
- add and register a four-case Rust unit harness covering valid markers, malformed UUID suffixes, wrong scope, and unrelated database errors
- retain the harness in the existing thread-write invariant source gate without adding new npm commands
- upgrade the Comments FBA registry and thread-write evidence to schema v3
- extend the current-only verifier and focused fixture to reject prefix-only classifiers, missing harness source, and missing `#[cfg(test)]` module registration
- keep fallback runtime, injected storage-error, PostgreSQL, compile, workflow, and CI evidence explicitly pending

## Why

The narrowed service fallback introduced in #2624 relied on a custom owner marker, but the classifier accepted any message beginning with the expected scope prefix. A malformed or empty canonical-thread suffix could therefore be treated as the expected first-thread race. The source gate also did not retain an executable Rust harness or prove that the harness module was registered.

## Validation

Not run by request. No verifier, unit test, Rust test, compile, database, browser, workflow, or CI command was executed.

Suggested maintainer commands:

```bash
npm run verify:comments:thread-write-invariants
npm run test:verify:comments:thread-write-invariants
npm run verify:comments:fba
npm run test:verify:comments:fba
cargo test -p rustok-comments --lib thread_insert_error_tests
```
