### PR TITLE
fix(order): correlate storefront native client failures

### DIFF
--- a/crates/rustok-order/contracts/evidence/storefront-native-client-diagnostics-source-review.json
+++ b/crates/rustok-order/contracts/evidence/storefront-native-client-diagnostics-source-review.json
@@ -1,0 +1,33 @@
+{
+  "status": "order_storefront_native_client_diagnostics_source_reviewed_unvalidated",
+  "reviewed_boundary": "complete_checkout native compatibility wrapper",
+  "reviewed_files": [
+    "crates/rustok-order/storefront/src/transport/native_server_adapter.rs",
+    "crates/rustok-order/storefront/src/transport/native_server_adapter/native_client_error_safety.rs",
+    "crates/rustok-order/storefront/src/transport/native_server_adapter/server_functions.rs",
+    "crates/rustok-order/storefront/src/transport.rs",
+    "crates/rustok-order/storefront/src/transport/graphql_error_safety.rs",
+    "scripts/verify/verify-order-storefront-runtime-error-diagnostics.mjs",
+    "scripts/verify/verify-order-storefront-graphql-error-safety.mjs"
+  ],
+  "review_findings": {
+    "context_precedes_server_function_call": true,
+    "raw_error_is_private_diagnostic_only": true,
+    "public_message_is_unchanged": true,
+    "request_values_are_not_logged": true,
+    "transport_facade_is_outside_diff": true,
+    "graphql_policy_is_outside_diff": true,
+    "mounted_endpoint_and_runtime_mapper_are_preserved": true,
+    "checkout_command_and_dto_are_preserved": true,
+    "existing_source_guards_remain_applicable": true,
+    "runtime_validation_is_not_claimed": true
+  },
+  "execution": {
+    "commands_run": [],
+    "tests_run": false,
+    "verifiers_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "ci_run": false
+  }
+}

--- a/crates/rustok-order/contracts/evidence/storefront-native-client-diagnostics-source.json
+++ b/crates/rustok-order/contracts/evidence/storefront-native-client-diagnostics-source.json
@@ -1,0 +1,39 @@
+{
+  "status": "order_storefront_native_client_diagnostics_source_unvalidated",
+  "scope": "rustok-order storefront complete-checkout native client diagnostics",
+  "source_contract": {
+    "operation_count": 1,
+    "context_created_before_server_function_call": true,
+    "original_error_logged_privately": true,
+    "per_call_correlation_logging": true,
+    "safe_request_shape_only": true,
+    "cart_id_values_logged": false,
+    "idempotency_key_values_logged": false,
+    "command_metadata_values_logged": false,
+    "static_public_transport_message_preserved": true,
+    "public_transport_variant_preserved": true,
+    "transport_facade_changed": false,
+    "graphql_transport_changed": false,
+    "request_response_dto_changed": false,
+    "mounted_endpoint_changed": false,
+    "runtime_dependency_composition_changed": false,
+    "runtime_error_mapper_changed": false,
+    "checkout_command_payload_changed": false,
+    "validation_messages_changed": false,
+    "fallback_enabled": false,
+    "broad_ecommerce_cleanup_closed": false
+  },
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "hydrate_compile_proven": false,
+    "ssr_compile_proven": false,
+    "browser_runtime_proven": false,
+    "mounted_runtime_proven": false,
+    "remote_transport_proven": false
+  }
+}

--- a/crates/rustok-order/docs/storefront-native-client-diagnostics.md
+++ b/crates/rustok-order/docs/storefront-native-client-diagnostics.md
@@ -1,0 +1,79 @@
+# Order storefront native client diagnostics
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens the final native compatibility wrapper for the Order-owned storefront checkout completion operation:
+
+- `complete_checkout`;
+- `complete_checkout_server`;
+- the private `NativeClientDiagnosticContext`.
+
+The public native envelope was already static. This change replaces its uncorrelated outer log with a per-call, request-shape-only diagnostic boundary.
+
+## Delivered source contract
+
+`complete_checkout_server` creates `NativeClientDiagnosticContext` before moving the unchanged request into the generated server-function call. When that call fails, the wrapper records:
+
+- owner and exact owner operation;
+- per-call UUID correlation id;
+- stable internal code and client transport boundary;
+- cart-id and idempotency-key character lengths;
+- command metadata string-field lengths;
+- command-metadata presence;
+- the original generated server-function error as a private diagnostic.
+
+It does not log cart ids, idempotency keys, command metadata values, request payloads, checkout projections, tenant values, tokens, or provider details.
+
+## Public error policy
+
+The compatibility result remains:
+
+```text
+Checkout transport is temporarily unavailable
+```
+
+and remains represented as `CheckoutCompletionTransportError::ServerFn`. No new public error class, fallback, or message is introduced.
+
+## Preserved behavior
+
+This slice does not change:
+
+- `crates/rustok-order/storefront/src/transport.rs`;
+- explicit native/GraphQL transport selection or the no-fallback policy;
+- the GraphQL adapter or `GraphqlCallContext` policy;
+- `CompleteCheckoutRequest`, `CheckoutCompletion`, or adjustment DTOs;
+- `order/complete-checkout` endpoint identity;
+- mounted runtime dependency composition and context extraction;
+- cart-id and idempotency-key validation;
+- the Commerce staged checkout call or `StorefrontCheckoutCompletionCommand` payload;
+- the SSR runtime error mapper and its public code/message diagnostics;
+- Order FFA or FBA status.
+
+## Static evidence
+
+Source evidence is recorded in:
+
+- `crates/rustok-order/contracts/evidence/storefront-native-client-diagnostics-source.json`;
+- `crates/rustok-order/contracts/evidence/storefront-native-client-diagnostics-source-review.json`.
+
+The focused guard is:
+
+- `scripts/verify/verify-order-storefront-native-client-diagnostics.mjs`.
+
+## Remaining gaps
+
+Compilation, browser/hydrate behavior, mounted SSR behavior, remote transport parity, checkout execution and compensation evidence, and the wider ecommerce correlation-safe mapper cleanup remain open.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-order-storefront-native-client-diagnostics.mjs
+node scripts/verify/verify-order-storefront-runtime-error-diagnostics.mjs
+node scripts/verify/verify-order-storefront-graphql-error-safety.mjs
+node scripts/verify/verify-order-storefront-boundary.mjs
+cargo check -p rustok-order-storefront --all-features
+```

--- a/crates/rustok-order/storefront/src/transport/native_server_adapter.rs
+++ b/crates/rustok-order/storefront/src/transport/native_server_adapter.rs
@@ -1,3 +1,4 @@
+mod native_client_error_safety;
 mod server_functions;
 
 use super::{CheckoutCompletion, CheckoutCompletionTransportError, CompleteCheckoutRequest};

--- a/crates/rustok-order/storefront/src/transport/native_server_adapter/native_client_error_safety.rs
+++ b/crates/rustok-order/storefront/src/transport/native_server_adapter/native_client_error_safety.rs
@@ -1,0 +1,55 @@
+use uuid::Uuid;
+
+use super::super::CompleteCheckoutRequest;
+
+const ORDER_STOREFRONT_NATIVE_CLIENT_OWNER: &str = "rustok_order.storefront";
+const ORDER_STOREFRONT_NATIVE_CLIENT_OPERATION: &str = "complete_storefront_checkout";
+const ORDER_STOREFRONT_NATIVE_CLIENT_BOUNDARY: &str =
+    "order_storefront_native_client_transport";
+
+pub(super) struct NativeClientDiagnosticContext {
+    correlation_id: String,
+    cart_id_length: usize,
+    idempotency_key_length: usize,
+    source_module_length: usize,
+    source_surface_length: usize,
+    command_length: usize,
+    owner_module_length: usize,
+}
+
+impl NativeClientDiagnosticContext {
+    pub(super) fn new(request: &CompleteCheckoutRequest) -> Self {
+        Self {
+            correlation_id: format!(
+                "order-storefront-native-client:{}:{}",
+                ORDER_STOREFRONT_NATIVE_CLIENT_OPERATION,
+                Uuid::new_v4()
+            ),
+            cart_id_length: request.cart_id.chars().count(),
+            idempotency_key_length: request.idempotency_key.chars().count(),
+            source_module_length: request.metadata.source_module.chars().count(),
+            source_surface_length: request.metadata.source_surface.chars().count(),
+            command_length: request.metadata.command.chars().count(),
+            owner_module_length: request.metadata.owner_module.chars().count(),
+        }
+    }
+
+    pub(super) fn record_error<E: std::fmt::Debug>(&self, error: &E) {
+        tracing::error!(
+            raw_error = ?error,
+            owner = ORDER_STOREFRONT_NATIVE_CLIENT_OWNER,
+            owner_operation = ORDER_STOREFRONT_NATIVE_CLIENT_OPERATION,
+            correlation_id = %self.correlation_id,
+            cart_id_length = self.cart_id_length,
+            idempotency_key_length = self.idempotency_key_length,
+            source_module_length = self.source_module_length,
+            source_surface_length = self.source_surface_length,
+            command_length = self.command_length,
+            owner_module_length = self.owner_module_length,
+            command_metadata_present = true,
+            code = "order.storefront_native_client_transport_failed",
+            boundary = ORDER_STOREFRONT_NATIVE_CLIENT_BOUNDARY,
+            "order storefront native client transport request failed"
+        );
+    }
+}

--- a/crates/rustok-order/storefront/src/transport/native_server_adapter/server_functions.rs
+++ b/crates/rustok-order/storefront/src/transport/native_server_adapter/server_functions.rs
@@ -4,6 +4,7 @@ use serde_json::{Value, json};
 #[cfg(feature = "ssr")]
 use uuid::Uuid;
 
+use super::native_client_error_safety::NativeClientDiagnosticContext;
 #[cfg(feature = "ssr")]
 use super::super::CheckoutAdjustment;
 use super::super::{CheckoutCompletion, CheckoutCompletionTransportError, CompleteCheckoutRequest};
@@ -16,14 +17,11 @@ const ORDER_STOREFRONT_NATIVE_BOUNDARY: &str = "order_storefront_native_transpor
 pub async fn complete_checkout_server(
     request: CompleteCheckoutRequest,
 ) -> Result<CheckoutCompletion, CheckoutCompletionTransportError> {
+    let context = NativeClientDiagnosticContext::new(&request);
     storefront_order_complete_checkout_native(request)
         .await
         .map_err(|error| {
-            tracing::error!(
-                error = ?error,
-                operation = "complete_checkout_server",
-                "native checkout transport failed"
-            );
+            context.record_error(&error);
             CheckoutCompletionTransportError::ServerFn(
                 "Checkout transport is temporarily unavailable".to_string(),
             )
@@ -143,6 +141,7 @@ fn native_checkout_runtime_error(
         error = ?error,
         owner = ORDER_STOREFRONT_NATIVE_OWNER,
         owner_operation = "complete_storefront_checkout",
+        correlation_id = %request_context.correlation_id,
         tenant_id = %tenant_id,
         channel_id = ?request_context.channel_id,
         channel_slug = ?request_context.channel_slug,

--- a/scripts/verify/verify-order-storefront-native-client-diagnostics.mjs
+++ b/scripts/verify/verify-order-storefront-native-client-diagnostics.mjs
@@ -1,0 +1,281 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const requireCount = (source, value, expected, label) => {
+  const count = source.split(value).length - 1;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+};
+
+const paths = {
+  transport: "crates/rustok-order/storefront/src/transport.rs",
+  adapter: "crates/rustok-order/storefront/src/transport/native_server_adapter.rs",
+  context:
+    "crates/rustok-order/storefront/src/transport/native_server_adapter/native_client_error_safety.rs",
+  serverFunctions:
+    "crates/rustok-order/storefront/src/transport/native_server_adapter/server_functions.rs",
+  graphqlSafety:
+    "crates/rustok-order/storefront/src/transport/graphql_error_safety.rs",
+  evidence:
+    "crates/rustok-order/contracts/evidence/storefront-native-client-diagnostics-source.json",
+  review:
+    "crates/rustok-order/contracts/evidence/storefront-native-client-diagnostics-source-review.json",
+  doc: "crates/rustok-order/docs/storefront-native-client-diagnostics.md",
+  commercePlan: "crates/rustok-commerce/docs/implementation-plan.md",
+  runtimeGuard: "scripts/verify/verify-order-storefront-runtime-error-diagnostics.mjs",
+  graphqlGuard: "scripts/verify/verify-order-storefront-graphql-error-safety.mjs",
+};
+
+const transport = read(paths.transport);
+const adapter = read(paths.adapter);
+const context = read(paths.context);
+const serverFunctions = read(paths.serverFunctions);
+const graphqlSafety = read(paths.graphqlSafety);
+const evidence = JSON.parse(read(paths.evidence));
+const review = JSON.parse(read(paths.review));
+const doc = read(paths.doc);
+const commercePlan = read(paths.commercePlan);
+const runtimeGuard = read(paths.runtimeGuard);
+const graphqlGuard = read(paths.graphqlGuard);
+
+for (const marker of [
+  "mod graphql_adapter;",
+  "mod graphql_error_safety;",
+  "mod native_server_adapter;",
+  "move || native_server_adapter::complete_checkout(native_request)",
+  "let context = graphql_error_safety::GraphqlCallContext::new(&request);",
+  "graphql_adapter::complete_checkout(request)",
+  ".map_err(|error| context.map_error(error))",
+  "UiTransportPath::NativeServer",
+  "UiTransportPath::Graphql",
+]) {
+  requireText(transport, marker, `${paths.transport}: preserved storefront facade`);
+}
+for (const forbidden of ["fallback_failed(", "fallback_attempted = true"]) {
+  forbidText(transport, forbidden, `${paths.transport}: no fallback`);
+}
+
+for (const marker of [
+  "mod native_client_error_safety;",
+  "mod server_functions;",
+  "server_functions::complete_checkout_server(request).await",
+]) {
+  requireText(adapter, marker, `${paths.adapter}: native adapter wiring`);
+}
+
+for (const marker of [
+  "use super::native_client_error_safety::NativeClientDiagnosticContext;",
+  "let context = NativeClientDiagnosticContext::new(&request);",
+  "storefront_order_complete_checkout_native(request)",
+  "context.record_error(&error);",
+  "CheckoutCompletionTransportError::ServerFn(",
+  '"Checkout transport is temporarily unavailable".to_string()',
+]) {
+  requireText(serverFunctions, marker, `${paths.serverFunctions}: final native mapping`);
+}
+
+const contextIndex = serverFunctions.indexOf("NativeClientDiagnosticContext::new(&request)");
+const callIndex = serverFunctions.indexOf("storefront_order_complete_checkout_native(request)");
+const diagnosticIndex = serverFunctions.indexOf("context.record_error(&error)");
+const publicIndex = serverFunctions.indexOf(
+  '"Checkout transport is temporarily unavailable".to_string()',
+);
+if (
+  [contextIndex, callIndex, diagnosticIndex, publicIndex].some((value) => value < 0) ||
+  !(contextIndex < callIndex && callIndex < diagnosticIndex && diagnosticIndex < publicIndex)
+) {
+  failures.push(
+    `${paths.serverFunctions}: expected context -> generated call -> diagnostic -> static public mapping order`,
+  );
+}
+requireCount(
+  serverFunctions,
+  '"Checkout transport is temporarily unavailable".to_string()',
+  1,
+  `${paths.serverFunctions}: one preserved public transport message`,
+);
+
+for (const marker of [
+  'const ORDER_STOREFRONT_NATIVE_CLIENT_OWNER: &str = "rustok_order.storefront";',
+  'const ORDER_STOREFRONT_NATIVE_CLIENT_OPERATION: &str = "complete_storefront_checkout";',
+  '"order_storefront_native_client_transport"',
+  "pub(super) struct NativeClientDiagnosticContext",
+  "Uuid::new_v4()",
+  '"order-storefront-native-client:{}:{}"',
+  "cart_id_length: request.cart_id.chars().count()",
+  "idempotency_key_length: request.idempotency_key.chars().count()",
+  "source_module_length: request.metadata.source_module.chars().count()",
+  "source_surface_length: request.metadata.source_surface.chars().count()",
+  "command_length: request.metadata.command.chars().count()",
+  "owner_module_length: request.metadata.owner_module.chars().count()",
+  "raw_error = ?error",
+  "owner = ORDER_STOREFRONT_NATIVE_CLIENT_OWNER",
+  "owner_operation = ORDER_STOREFRONT_NATIVE_CLIENT_OPERATION",
+  "correlation_id = %self.correlation_id",
+  "cart_id_length = self.cart_id_length",
+  "idempotency_key_length = self.idempotency_key_length",
+  "source_module_length = self.source_module_length",
+  "source_surface_length = self.source_surface_length",
+  "command_length = self.command_length",
+  "owner_module_length = self.owner_module_length",
+  "command_metadata_present = true",
+  'code = "order.storefront_native_client_transport_failed"',
+  "boundary = ORDER_STOREFRONT_NATIVE_CLIENT_BOUNDARY",
+]) {
+  requireText(context, marker, `${paths.context}: correlation-safe diagnostic shape`);
+}
+
+for (const forbidden of [
+  "cart_id = %",
+  "cart_id = ?",
+  "idempotency_key = %",
+  "idempotency_key = ?",
+  "source_module = %",
+  "source_module = ?",
+  "source_surface = %",
+  "source_surface = ?",
+  "command = %",
+  "command = ?",
+  "owner_module = %",
+  "owner_module = ?",
+  "metadata = ?",
+  "request = ?",
+  "error.to_string()",
+]) {
+  forbidText(context, forbidden, `${paths.context}: raw request or error text`);
+}
+
+for (const marker of [
+  'endpoint = "order/complete-checkout"',
+  "shared_get::<TransactionalEventBus>()",
+  "shared_get::<PaymentProviderRegistry>()",
+  "shared_get::<ProductCatalogReadRuntime>()",
+  "extract::<rustok_api::RequestContext>()",
+  "extract::<rustok_api::TenantContext>()",
+  "extract::<rustok_api::OptionalAuthContext>()",
+  'ServerFnError::new("Checkout request is invalid")',
+  "StorefrontCheckoutCompletionCommand {",
+  '"source_module": metadata.source_module',
+  '"source_surface": metadata.source_surface',
+  '"command": metadata.command',
+  '"owner_module": metadata.owner_module',
+  '"create_fulfillment": metadata.create_fulfillment',
+  "native_checkout_runtime_error(&request_context, tenant.id, error)",
+  'ServerFnError::new(format!("{public_code}: {public_message}"))',
+]) {
+  requireText(serverFunctions, marker, `${paths.serverFunctions}: mounted runtime contract`);
+}
+requireCount(
+  serverFunctions,
+  'ServerFnError::new("Checkout request is invalid")',
+  2,
+  `${paths.serverFunctions}: preserved validation envelopes`,
+);
+
+requireText(
+  graphqlSafety,
+  "pub(super) struct GraphqlCallContext",
+  `${paths.graphqlSafety}: preserved GraphQL policy`,
+);
+requireText(
+  runtimeGuard,
+  "Order storefront runtime-error diagnostics verification failed",
+  `${paths.runtimeGuard}: existing SSR runtime guard`,
+);
+requireText(
+  graphqlGuard,
+  "Order storefront GraphQL error-safety verification failed",
+  `${paths.graphqlGuard}: existing GraphQL guard`,
+);
+
+if (evidence.status !== "order_storefront_native_client_diagnostics_source_unvalidated") {
+  failures.push(`${paths.evidence}: unexpected status ${evidence.status}`);
+}
+if (
+  review.status !==
+  "order_storefront_native_client_diagnostics_source_reviewed_unvalidated"
+) {
+  failures.push(`${paths.review}: unexpected status ${review.status}`);
+}
+
+for (const [key, expected] of Object.entries({
+  operation_count: 1,
+  context_created_before_server_function_call: true,
+  original_error_logged_privately: true,
+  per_call_correlation_logging: true,
+  safe_request_shape_only: true,
+  cart_id_values_logged: false,
+  idempotency_key_values_logged: false,
+  command_metadata_values_logged: false,
+  static_public_transport_message_preserved: true,
+  public_transport_variant_preserved: true,
+  transport_facade_changed: false,
+  graphql_transport_changed: false,
+  request_response_dto_changed: false,
+  mounted_endpoint_changed: false,
+  runtime_dependency_composition_changed: false,
+  runtime_error_mapper_changed: false,
+  checkout_command_payload_changed: false,
+  validation_messages_changed: false,
+  fallback_enabled: false,
+  broad_ecommerce_cleanup_closed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "hydrate_compile_proven",
+  "ssr_compile_proven",
+  "browser_runtime_proven",
+  "mounted_runtime_proven",
+  "remote_transport_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+
+requireText(doc, "Status: **source-ready / unvalidated**", `${paths.doc}: source status`);
+requireText(
+  doc,
+  "Checkout transport is temporarily unavailable",
+  `${paths.doc}: preserved public message`,
+);
+requireText(
+  commercePlan,
+  "Finish correlation-safe mapper cleanup",
+  `${paths.commercePlan}: broad ecommerce cleanup remains open`,
+);
+
+if (failures.length > 0) {
+  console.error("Order storefront native client diagnostics verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "Order storefront native client failures retain the static public envelope and use correlation-safe request-shape diagnostics; execution evidence remains open",
+);


### PR DESCRIPTION
## Summary
- replace the uncorrelated Order storefront outer native failure log with a per-call diagnostic context
- cover the single `complete_checkout` / `complete_checkout_server` compatibility boundary
- create `NativeClientDiagnosticContext` before moving the unchanged request into the generated server-function call
- retain the original generated `ServerFnError` only in structured diagnostics
- record owner, exact operation, UUID correlation id, stable code, boundary, and request-field character lengths only
- preserve the existing static public envelope: `Checkout transport is temporarily unavailable`
- preserve `CheckoutCompletionTransportError::ServerFn`, DTOs, transport selection, no-fallback behavior, GraphQL policy, endpoint, validation, runtime composition, staged checkout call, command payload, and SSR runtime error mapper
- add source evidence, source review, focused documentation, and a static verifier

## Confirmed gap
Unlike the recent Cart, Payment, and Fulfillment slices, Order storefront was already fail-closed publicly: `complete_checkout_server` returned one static transport message for generated server-function failures. Its outer diagnostic event, however, recorded only the raw error and a generic local operation string, with no per-call correlation or safe request-shape facts.

## Boundary placement
The native compatibility wrapper now constructs `NativeClientDiagnosticContext` from a borrowed request before the request is moved into `storefront_order_complete_checkout_native`. On failure, the context records the generated error privately and the existing static `ServerFn` envelope is returned unchanged.

## Diagnostics
The new event records cart-id, idempotency-key, and command-metadata string lengths. It does not log cart ids, idempotency keys, metadata values, request payloads, checkout projections, tenant values, tokens, or provider details.

## Source review
- context creation precedes the generated server-function call
- diagnostic recording follows the failed call and precedes the static public mapping
- the public variant and message are unchanged
- `transport.rs`, GraphQL adapter, and GraphQL safety policy are outside the diff
- mounted endpoint, dependency composition, context extraction, validation, checkout runtime invocation, command payload, and DTO mapping remain unchanged
- the existing SSR runtime diagnostic mapper and its public code/message envelope remain unchanged
- existing Order GraphQL and runtime diagnostics guards remain applicable
- Order FFA/FBA status is not promoted
- the broad ecommerce correlation-safe mapper cleanup remains open

The branch is based on current `main` at `7082e47699c7ec3c81d786d26fbea8c57800bc1b`. The diff contains seven Order source/evidence files.

## Validation
Per maintainer instruction, tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run. Evidence remains source-ready / unvalidated and does not prove hydrate, SSR, browser, mounted runtime, remote transport, workflow, CI, or production behavior.

Suggested maintainer commands:
```bash
node scripts/verify/verify-order-storefront-native-client-diagnostics.mjs
node scripts/verify/verify-order-storefront-runtime-error-diagnostics.mjs
node scripts/verify/verify-order-storefront-graphql-error-safety.mjs
node scripts/verify/verify-order-storefront-boundary.mjs
cargo check -p rustok-order-storefront --all-features
```