### PR TITLE
feat(index): add bounded source reconciliation

### DIFF
--- a/crates/rustok-index/docs/.keep-reconciliation-pr-scope
+++ b/crates/rustok-index/docs/.keep-reconciliation-pr-scope
@@ -1,0 +1,1 @@
+bounded-source-reconciliation-v1

--- a/crates/rustok-index/docs/.keep-reconciliation-pr-scope
+++ b/crates/rustok-index/docs/.keep-reconciliation-pr-scope
@@ -1,1 +1,0 @@
-bounded-source-reconciliation-v1

--- a/crates/rustok-index/docs/m7-product-reconciliation.md
+++ b/crates/rustok-index/docs/m7-product-reconciliation.md
@@ -1,0 +1,119 @@
+# M7 bounded Product source reconciliation
+
+Status: `source_complete_owner_execution_pending`
+
+This slice adds a generic, explicit, bounded reconciliation capability that can replay the
+already-published Product and ProductVariant sources through more than one complete cursor pass.
+It does not change either source, any Product schema fingerprint, source name, replay event
+identity, or owner revision contract.
+
+The capability is implemented by `PostgresIndexReconciliationRunner`. It resolves the source
+from `SharedIndexSourceRegistry`; callers provide only the tenant, exact schema, worker identity,
+page/pass bounds, heartbeat cadence, and lease duration.
+
+## Why a second pass exists
+
+A cursor-ordered rebuild can miss an identity inserted behind the current cursor while the first
+pass is running. Product uses `(product_id, locale)` and ProductVariant uses `variant_id`, so a
+new lower key cannot be discovered by continuing the same pass.
+
+A reconciliation job therefore performs a validated number of complete source passes. For the
+first Product admission workflow, two passes are the recommended minimum:
+
+1. the first pass replays the current owner projection;
+2. the second pass restarts at the beginning and catches identities that appeared behind the
+   first pass cursor, including retained Product or ProductVariant tombstones.
+
+Repeated mutations remain safe because owner sources derive deterministic event UUIDs from the
+exact tenant, entity, locale, schema-version domain, and source version. The Index mutation store
+terminally recognizes duplicate or stale delivery.
+
+## Durable job boundary
+
+Reconciliation uses the existing `index_jobs` table with:
+
+- `kind = 'reconcile'`;
+- `scope_kind = 'schema'`;
+- request contract `index_reconciliation_job_v1`;
+- cursor contract `index_reconciliation_cursor_v1`.
+
+The request stores the registry-resolved source name and requested pass count. A stored active or
+succeeded request that differs from the current source/pass contract fails closed.
+
+`index_jobs.cursor` stores only runner-owned state:
+
+- completed pass count;
+- the optional opaque source cursor for the current pass;
+- cumulative page, mutation, applied, duplicate, and stale counters.
+
+The source cursor remains an `IndexSourceCursor` and is never interpreted by Index. The existing
+`index_checkpoints` rebuild cursor is not reused or reset, so reconciliation cannot corrupt the
+M6 rebuild checkpoint or its succeeded job.
+
+## Bounded execution and recovery
+
+Each invocation validates:
+
+- page limit through `IndexSourceScanRequest`;
+- one through 1024 pages;
+- heartbeat cadence within the invocation page budget;
+- one through eight complete passes;
+- a whole-second lease from one through 86400 seconds.
+
+Every page is applied through `PostgresMutationStore`. The fenced job cursor is persisted only
+after every mutation result is durable. A crash before that cursor update repeats the page with
+the same deterministic delivery IDs. An expired attempt is reclaimed with an incremented
+attempt fence; the old worker cannot persist progress or terminal state.
+
+When the page budget is exhausted, the job yields to immediately claimable `pending` state. A
+later invocation resumes the exact pass and source cursor. The final pass and terminal job state
+are committed together. Cancellation is observed before and after page work and wins over
+progress, success, failure, or yield when committed first.
+
+The runner starts no task, sleeps nowhere, owns no retry schedule, and imports no Product,
+ProductVariant, SalesChannel, Search, or Storefront implementation.
+
+## Retained tombstones
+
+Product replay already exposes a tenant-scoped union of live rows and
+`product_index_tombstones`. ProductVariant replay does the same with
+`product_variant_index_tombstones`. Reconciliation calls those unchanged registered sources, so
+physical deletes and recreated identities participate in every pass without Index reading owner
+tables directly.
+
+Live/tombstone coexistence for one exact owner key remains a permanent source-record failure; the
+runner does not choose one side.
+
+## Concurrency limit
+
+Multi-pass reconciliation narrows but does not eliminate the live-write window. An identity can
+still be inserted behind the cursor during the final pass. This capability therefore does **not**
+claim a repeatable-read owner snapshot, source watermark, quiescence barrier, or authoritative
+consumer readiness.
+
+Admission still requires one of the following to be proven separately:
+
+- a repeatable-read/exported owner snapshot covering the whole pass;
+- an owner high-watermark plus a complete incremental catch-up;
+- an explicit write barrier/quiescence interval;
+- or retained evidence that another reconciliation after the write window converged.
+
+Until that proof and persisted tenant schema activation exist, Storefront must not cut over
+authoritatively to Product v2.
+
+## Explicitly open
+
+- automatic scheduling, retry/backoff, dead-letter policy, and graceful task shutdown;
+- a snapshot/watermark protocol that closes the final-pass concurrent-write window;
+- incremental Product/translation/ProductVariant event delivery and acknowledgement;
+- tombstone retention/purge admission against all relevant consumer checkpoints;
+- persisted per-tenant Product v2 and ProductVariant v2 schema application;
+- retained PostgreSQL insert-behind-cursor, delete/recreate, restart, lease-reclaim, drift, and
+  convergence evidence;
+- authoritative Storefront query cutover;
+- durable Product/ProductVariant-to-SalesChannel UUID relations and cross-owner revisions.
+
+## Validation ownership
+
+Formatting, Cargo checks/tests, JavaScript guards, PostgreSQL execution, and CI are
+maintainer-run. The implementation agent did not execute them.

--- a/crates/rustok-index/src/infrastructure/postgres/mod.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/mod.rs
@@ -7,6 +7,7 @@ mod schema_lease;
 mod schema_registration;
 mod secondary_index;
 mod source_factory;
+mod source_reconciliation_runner;
 mod source_replay;
 mod source_replay_job;
 mod source_replay_runner;
@@ -23,6 +24,8 @@ mod schema_lease_tests;
 mod schema_registration_tests;
 #[cfg(test)]
 mod secondary_index_tests;
+#[cfg(test)]
+mod source_reconciliation_runner_tests;
 #[cfg(test)]
 mod source_replay_job_tests;
 #[cfg(test)]
@@ -61,6 +64,11 @@ pub use source_factory::{
     PostgresIndexSourceFactory, PostgresIndexSourceFactoryCatalog,
     PostgresIndexSourceFactoryDescriptor, PostgresIndexSourceFactoryError,
     materialize_postgres_index_sources, register_postgres_index_source_factory,
+};
+pub use source_reconciliation_runner::{
+    IndexReconciliationCancelOutcome, IndexReconciliationRunError,
+    IndexReconciliationRunOutcome, IndexReconciliationRunRequest, IndexReconciliationRunStatus,
+    IndexReconciliationTerminalState, PostgresIndexReconciliationRunner,
 };
 pub use source_replay::PostgresIndexReplayCheckpointStore;
 pub use source_replay_job::{

--- a/crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner.rs
@@ -1,0 +1,1332 @@
+use std::{
+    collections::BTreeSet,
+    sync::Arc,
+    time::Duration,
+};
+
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, QueryResult, Statement,
+    TransactionTrait, Value as SqlValue,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value as JsonValue};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::{
+    IndexReplayFailure, IndexReplayFailureKind, IndexReplayMutationOutcome,
+    IndexReplayMutationSink, IndexSourceCursor, IndexSourceError, IndexSourceFailureKind,
+    IndexSourceScanRequest, SchemaRef, SchemaRegistry, SharedIndexSourceRegistry,
+};
+
+use super::PostgresMutationStore;
+
+const RECONCILIATION_JOB_REQUEST_CONTRACT: &str = "index_reconciliation_job_v1";
+const RECONCILIATION_JOB_CURSOR_CONTRACT: &str = "index_reconciliation_cursor_v1";
+const RECONCILIATION_FAILURE_CONTRACT: &str = "index_reconciliation_run_failure_v1";
+const RECONCILIATION_PAGE_FAILURE_CODE: &str = "index.reconciliation_page_failed";
+const MAX_PAGES_PER_RUN: usize = 1_024;
+const MAX_PASSES: u32 = 8;
+const MAX_SOURCE_NAME_BYTES: usize = 128;
+const MAX_WORKER_ID_BYTES: usize = 191;
+const MAX_LEASE_SECONDS: u64 = 86_400;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexReconciliationRunRequest {
+    tenant_id: Uuid,
+    schema: SchemaRef,
+    worker_id: String,
+    page_limit: usize,
+    max_pages: usize,
+    heartbeat_every_pages: usize,
+    pass_count: u32,
+    lease_seconds: u64,
+}
+
+impl IndexReconciliationRunRequest {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        tenant_id: Uuid,
+        schema: SchemaRef,
+        worker_id: impl Into<String>,
+        page_limit: usize,
+        max_pages: usize,
+        heartbeat_every_pages: usize,
+        pass_count: u32,
+        lease_duration: Duration,
+    ) -> Result<Self, IndexReconciliationRunError> {
+        IndexSourceScanRequest::new(tenant_id, schema.clone(), None, page_limit)
+            .map_err(IndexReconciliationRunError::InvalidPageRequest)?;
+        if !(1..=MAX_PAGES_PER_RUN).contains(&max_pages) {
+            return Err(IndexReconciliationRunError::InvalidMaxPages {
+                actual: max_pages,
+                max: MAX_PAGES_PER_RUN,
+            });
+        }
+        if heartbeat_every_pages == 0 || heartbeat_every_pages > max_pages {
+            return Err(IndexReconciliationRunError::InvalidHeartbeatCadence {
+                actual: heartbeat_every_pages,
+                max: max_pages,
+            });
+        }
+        if !(1..=MAX_PASSES).contains(&pass_count) {
+            return Err(IndexReconciliationRunError::InvalidPassCount {
+                actual: pass_count,
+                max: MAX_PASSES,
+            });
+        }
+        let worker_id = worker_id.into();
+        validate_storage_text(&worker_id, MAX_WORKER_ID_BYTES)
+            .map_err(|reason| IndexReconciliationRunError::InvalidWorkerId { reason })?;
+        let lease_seconds = validate_lease_duration(lease_duration)?;
+        Ok(Self {
+            tenant_id,
+            schema,
+            worker_id,
+            page_limit,
+            max_pages,
+            heartbeat_every_pages,
+            pass_count,
+            lease_seconds,
+        })
+    }
+
+    pub fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    pub fn worker_id(&self) -> &str {
+        &self.worker_id
+    }
+
+    pub fn page_limit(&self) -> usize {
+        self.page_limit
+    }
+
+    pub fn max_pages(&self) -> usize {
+        self.max_pages
+    }
+
+    pub fn heartbeat_every_pages(&self) -> usize {
+        self.heartbeat_every_pages
+    }
+
+    pub fn pass_count(&self) -> u32 {
+        self.pass_count
+    }
+
+    pub fn lease_duration(&self) -> Duration {
+        Duration::from_secs(self.lease_seconds)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexReconciliationRunStatus {
+    Busy,
+    AlreadyComplete,
+    Complete,
+    Cancelled,
+    Yielded,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexReconciliationRunOutcome {
+    status: IndexReconciliationRunStatus,
+    job_id: Option<Uuid>,
+    attempt_count: Option<u32>,
+    pages_processed: usize,
+    passes_completed: u32,
+    heartbeat_count: usize,
+    mutation_count: usize,
+    applied_count: usize,
+    duplicate_count: usize,
+    stale_count: usize,
+}
+
+impl IndexReconciliationRunOutcome {
+    pub fn status(&self) -> IndexReconciliationRunStatus {
+        self.status
+    }
+
+    pub fn job_id(&self) -> Option<Uuid> {
+        self.job_id
+    }
+
+    pub fn attempt_count(&self) -> Option<u32> {
+        self.attempt_count
+    }
+
+    pub fn pages_processed(&self) -> usize {
+        self.pages_processed
+    }
+
+    pub fn passes_completed(&self) -> u32 {
+        self.passes_completed
+    }
+
+    pub fn heartbeat_count(&self) -> usize {
+        self.heartbeat_count
+    }
+
+    pub fn mutation_count(&self) -> usize {
+        self.mutation_count
+    }
+
+    pub fn applied_count(&self) -> usize {
+        self.applied_count
+    }
+
+    pub fn duplicate_count(&self) -> usize {
+        self.duplicate_count
+    }
+
+    pub fn stale_count(&self) -> usize {
+        self.stale_count
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexReconciliationTerminalState {
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexReconciliationCancelOutcome {
+    Requested,
+    Cancelled,
+    AlreadyTerminal(IndexReconciliationTerminalState),
+    NotFound,
+}
+
+#[derive(Clone)]
+pub struct PostgresIndexReconciliationRunner {
+    db: DatabaseConnection,
+    sources: SharedIndexSourceRegistry,
+    schema_registry: Arc<SchemaRegistry>,
+}
+
+impl PostgresIndexReconciliationRunner {
+    pub fn new(
+        db: DatabaseConnection,
+        sources: SharedIndexSourceRegistry,
+        schema_registry: Arc<SchemaRegistry>,
+    ) -> Self {
+        Self {
+            db,
+            sources,
+            schema_registry,
+        }
+    }
+
+    pub async fn request_cancel(
+        &self,
+        tenant_id: Uuid,
+        job_id: Uuid,
+    ) -> Result<IndexReconciliationCancelOutcome, IndexReconciliationRunError> {
+        if tenant_id.is_nil() {
+            return Err(IndexReconciliationRunError::NilCancelTenantId);
+        }
+        if job_id.is_nil() {
+            return Err(IndexReconciliationRunError::NilCancelJobId);
+        }
+        let transaction = self.db.begin().await.map_err(storage_error)?;
+        let result = request_cancel_in_transaction(&transaction, tenant_id, job_id).await;
+        match result {
+            Ok(outcome) => {
+                transaction.commit().await.map_err(storage_error)?;
+                Ok(outcome)
+            }
+            Err(error) => {
+                transaction.rollback().await.map_err(storage_error)?;
+                Err(error)
+            }
+        }
+    }
+
+    pub async fn run(
+        &self,
+        request: IndexReconciliationRunRequest,
+    ) -> Result<IndexReconciliationRunOutcome, IndexReconciliationRunError> {
+        let source_name = self
+            .sources
+            .source_for_schema(request.schema())
+            .ok_or_else(|| IndexReconciliationRunError::UnknownSchemaSource(request.schema.clone()))?
+            .source_name()
+            .to_owned();
+        validate_source_name(&source_name)?;
+
+        let acquire_request = ReconciliationAcquireRequest {
+            tenant_id: request.tenant_id,
+            schema: request.schema.clone(),
+            source_name,
+            worker_id: request.worker_id.clone(),
+            pass_count: request.pass_count,
+            lease_seconds: request.lease_seconds,
+        };
+        let acquired = acquire_reconciliation_job(&self.db, &acquire_request).await?;
+        let (lease, mut state) = match acquired {
+            ReconciliationAcquireOutcome::Busy => {
+                return Ok(empty_outcome(IndexReconciliationRunStatus::Busy, None, None, 0));
+            }
+            ReconciliationAcquireOutcome::AlreadyComplete {
+                job_id,
+                completed_passes,
+            } => {
+                return Ok(empty_outcome(
+                    IndexReconciliationRunStatus::AlreadyComplete,
+                    Some(job_id),
+                    None,
+                    completed_passes,
+                ));
+            }
+            ReconciliationAcquireOutcome::Acquired { lease, state } => (lease, state),
+        };
+
+        let sink = PostgresMutationStore::new(self.db.clone());
+        let mut outcome = IndexReconciliationRunOutcome {
+            status: IndexReconciliationRunStatus::Yielded,
+            job_id: Some(lease.job_id),
+            attempt_count: Some(lease.attempt_count),
+            pages_processed: 0,
+            passes_completed: state.completed_passes,
+            heartbeat_count: 0,
+            mutation_count: 0,
+            applied_count: 0,
+            duplicate_count: 0,
+            stale_count: 0,
+        };
+
+        for page_index in 0..request.max_pages {
+            if cancel_if_requested(&self.db, &lease).await? {
+                outcome.status = IndexReconciliationRunStatus::Cancelled;
+                return Ok(outcome);
+            }
+            if page_index > 0 && page_index % request.heartbeat_every_pages == 0 {
+                heartbeat(&self.db, &lease, request.lease_duration()).await?;
+                outcome.heartbeat_count += 1;
+                if cancel_if_requested(&self.db, &lease).await? {
+                    outcome.status = IndexReconciliationRunStatus::Cancelled;
+                    return Ok(outcome);
+                }
+            }
+
+            let scan_request = IndexSourceScanRequest::new(
+                request.tenant_id,
+                request.schema.clone(),
+                state.source_cursor.clone(),
+                request.page_limit,
+            )
+            .map_err(IndexReconciliationRunError::InvalidPageRequest)?;
+            let page = match self.sources.scan(scan_request).await {
+                Ok(page) => page,
+                Err(error) => {
+                    let run_error = IndexReconciliationRunError::Source(error);
+                    return finish_page_error(&self.db, &lease, run_error).await;
+                }
+            };
+
+            let mut event_ids = BTreeSet::new();
+            for (position, mutation) in page.mutations().iter().enumerate() {
+                let event_id = mutation.event_id();
+                if event_id.is_nil() {
+                    let run_error = IndexReconciliationRunError::NilEventId { position };
+                    return finish_page_error(&self.db, &lease, run_error).await;
+                }
+                if !event_ids.insert(event_id) {
+                    let run_error =
+                        IndexReconciliationRunError::DuplicateEventId { position, event_id };
+                    return finish_page_error(&self.db, &lease, run_error).await;
+                }
+            }
+
+            let mut page_applied = 0usize;
+            let mut page_duplicates = 0usize;
+            let mut page_stale = 0usize;
+            for (position, mutation) in page.mutations().iter().enumerate() {
+                let result = sink
+                    .apply_replay_mutation(
+                        self.schema_registry.as_ref(),
+                        lease.source_name.as_str(),
+                        mutation,
+                    )
+                    .await;
+                match result {
+                    Ok(IndexReplayMutationOutcome::Applied) => page_applied += 1,
+                    Ok(IndexReplayMutationOutcome::Duplicate) => page_duplicates += 1,
+                    Ok(IndexReplayMutationOutcome::StaleIgnored) => page_stale += 1,
+                    Err(failure) => {
+                        let run_error =
+                            IndexReconciliationRunError::MutationFailed { position, failure };
+                        return finish_page_error(&self.db, &lease, run_error).await;
+                    }
+                }
+            }
+
+            let page_mutations = page.mutations().len();
+            let (_, next_cursor) = page.into_parts();
+            state.source_cursor = next_cursor;
+            state.pages_processed = checked_add_counter(state.pages_processed, 1)?;
+            state.mutation_count =
+                checked_add_counter(state.mutation_count, usize_to_u64(page_mutations)?)?;
+            state.applied_count =
+                checked_add_counter(state.applied_count, usize_to_u64(page_applied)?)?;
+            state.duplicate_count =
+                checked_add_counter(state.duplicate_count, usize_to_u64(page_duplicates)?)?;
+            state.stale_count =
+                checked_add_counter(state.stale_count, usize_to_u64(page_stale)?)?;
+
+            outcome.pages_processed += 1;
+            outcome.mutation_count += page_mutations;
+            outcome.applied_count += page_applied;
+            outcome.duplicate_count += page_duplicates;
+            outcome.stale_count += page_stale;
+
+            if state.source_cursor.is_none() {
+                state.completed_passes = state
+                    .completed_passes
+                    .checked_add(1)
+                    .ok_or(IndexReconciliationRunError::CounterOverflow)?;
+                outcome.passes_completed = state.completed_passes;
+            }
+
+            if cancel_if_requested(&self.db, &lease).await? {
+                outcome.status = IndexReconciliationRunStatus::Cancelled;
+                return Ok(outcome);
+            }
+
+            if state.completed_passes == request.pass_count {
+                match finish_success(&self.db, &lease, &state).await? {
+                    LeaseWriteOutcome::Written => {
+                        outcome.status = IndexReconciliationRunStatus::Complete;
+                        return Ok(outcome);
+                    }
+                    LeaseWriteOutcome::Cancelled => {
+                        outcome.status = IndexReconciliationRunStatus::Cancelled;
+                        return Ok(outcome);
+                    }
+                }
+            }
+
+            match persist_progress(&self.db, &lease, &state).await? {
+                LeaseWriteOutcome::Written => {}
+                LeaseWriteOutcome::Cancelled => {
+                    outcome.status = IndexReconciliationRunStatus::Cancelled;
+                    return Ok(outcome);
+                }
+            }
+        }
+
+        match yield_for_resume(&self.db, &lease).await? {
+            LeaseWriteOutcome::Written => Ok(outcome),
+            LeaseWriteOutcome::Cancelled => {
+                outcome.status = IndexReconciliationRunStatus::Cancelled;
+                Ok(outcome)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ReconciliationAcquireRequest {
+    tenant_id: Uuid,
+    schema: SchemaRef,
+    source_name: String,
+    worker_id: String,
+    pass_count: u32,
+    lease_seconds: u64,
+}
+
+#[derive(Debug, Clone)]
+struct ReconciliationLease {
+    tenant_id: Uuid,
+    job_id: Uuid,
+    schema: SchemaRef,
+    source_name: String,
+    worker_id: String,
+    attempt_count: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReconciliationJobRequest {
+    contract: String,
+    source_name: String,
+    pass_count: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReconciliationCursor {
+    contract: String,
+    completed_passes: u32,
+    source_cursor: Option<IndexSourceCursor>,
+    pages_processed: u64,
+    mutation_count: u64,
+    applied_count: u64,
+    duplicate_count: u64,
+    stale_count: u64,
+}
+
+impl ReconciliationCursor {
+    fn initial() -> Self {
+        Self {
+            contract: RECONCILIATION_JOB_CURSOR_CONTRACT.to_owned(),
+            completed_passes: 0,
+            source_cursor: None,
+            pages_processed: 0,
+            mutation_count: 0,
+            applied_count: 0,
+            duplicate_count: 0,
+            stale_count: 0,
+        }
+    }
+
+    fn validate(&self, pass_count: u32) -> Result<(), IndexReconciliationRunError> {
+        if self.contract != RECONCILIATION_JOB_CURSOR_CONTRACT {
+            return Err(IndexReconciliationRunError::InvalidStoredJob(
+                "cursor contract is invalid".to_owned(),
+            ));
+        }
+        if self.completed_passes > pass_count {
+            return Err(IndexReconciliationRunError::InvalidStoredJob(
+                "completed pass count exceeds the requested pass count".to_owned(),
+            ));
+        }
+        if self.completed_passes == pass_count && self.source_cursor.is_some() {
+            return Err(IndexReconciliationRunError::InvalidStoredJob(
+                "terminal reconciliation cursor retains source continuation".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+enum ReconciliationAcquireOutcome {
+    Acquired {
+        lease: ReconciliationLease,
+        state: ReconciliationCursor,
+    },
+    Busy,
+    AlreadyComplete {
+        job_id: Uuid,
+        completed_passes: u32,
+    },
+}
+
+#[derive(Debug)]
+struct StoredReconciliationJob {
+    job_id: Uuid,
+    state: String,
+    request: ReconciliationJobRequest,
+    cursor: ReconciliationCursor,
+    attempt_count: u32,
+    claimable: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LeaseWriteOutcome {
+    Written,
+    Cancelled,
+}
+
+async fn acquire_reconciliation_job(
+    db: &DatabaseConnection,
+    request: &ReconciliationAcquireRequest,
+) -> Result<ReconciliationAcquireOutcome, IndexReconciliationRunError> {
+    let transaction = db.begin().await.map_err(storage_error)?;
+    let result = acquire_in_transaction(&transaction, request).await;
+    match result {
+        Ok(outcome) => {
+            transaction.commit().await.map_err(storage_error)?;
+            Ok(outcome)
+        }
+        Err(error) => {
+            transaction.rollback().await.map_err(storage_error)?;
+            Err(error)
+        }
+    }
+}
+
+async fn acquire_in_transaction(
+    transaction: &DatabaseTransaction,
+    request: &ReconciliationAcquireRequest,
+) -> Result<ReconciliationAcquireOutcome, IndexReconciliationRunError> {
+    let backend = transaction.get_database_backend();
+    ensure_supported_backend(backend)?;
+    lock_reconciliation_scope(transaction, request, backend).await?;
+    verify_schema_registration(transaction, request, backend).await?;
+
+    let rows = transaction
+        .query_all(Statement::from_sql_and_values(
+            backend,
+            select_jobs_sql(backend),
+            scope_values(request, backend),
+        ))
+        .await
+        .map_err(storage_error)?;
+    let mut claimable = None;
+    for row in rows {
+        let stored = stored_job(&row, backend)?;
+        validate_stored_request(&stored, request)?;
+        match stored.state.as_str() {
+            "succeeded" => {
+                if stored.cursor.completed_passes != request.pass_count
+                    || stored.cursor.source_cursor.is_some()
+                {
+                    return Err(IndexReconciliationRunError::InvalidStoredJob(
+                        "succeeded reconciliation job has incomplete cursor state".to_owned(),
+                    ));
+                }
+                return Ok(ReconciliationAcquireOutcome::AlreadyComplete {
+                    job_id: stored.job_id,
+                    completed_passes: stored.cursor.completed_passes,
+                });
+            }
+            "running" | "pending" if !stored.claimable => {
+                return Ok(ReconciliationAcquireOutcome::Busy);
+            }
+            "running" | "pending" => {
+                claimable = Some(stored);
+                break;
+            }
+            state => {
+                return Err(IndexReconciliationRunError::InvalidStoredJob(format!(
+                    "unexpected active reconciliation state {state}"
+                )));
+            }
+        }
+    }
+
+    let (job_id, attempt_count, state) = if let Some(stored) = claimable {
+        let attempt_count = stored
+            .attempt_count
+            .checked_add(1)
+            .ok_or(IndexReconciliationRunError::CounterOverflow)?;
+        let updated = transaction
+            .execute(Statement::from_sql_and_values(
+                backend,
+                claim_job_sql(backend),
+                vec![
+                    uuid_value(request.tenant_id, backend),
+                    uuid_value(stored.job_id, backend),
+                    request.worker_id.clone().into(),
+                    i64::from(attempt_count).into(),
+                    i64::try_from(request.lease_seconds)
+                        .map_err(|_| IndexReconciliationRunError::InvalidLeaseDuration)?
+                        .into(),
+                ],
+            ))
+            .await
+            .map_err(storage_error)?;
+        if updated.rows_affected() != 1 {
+            return Err(IndexReconciliationRunError::LeaseLost {
+                job_id: stored.job_id,
+                attempt_count,
+            });
+        }
+        (stored.job_id, attempt_count, stored.cursor)
+    } else {
+        let job_id = Uuid::new_v4();
+        let state = ReconciliationCursor::initial();
+        let job_request = ReconciliationJobRequest {
+            contract: RECONCILIATION_JOB_REQUEST_CONTRACT.to_owned(),
+            source_name: request.source_name.clone(),
+            pass_count: request.pass_count,
+        };
+        let request_json = serde_json::to_value(job_request)
+            .map_err(|error| IndexReconciliationRunError::Storage(error.to_string()))?;
+        let cursor_json = serde_json::to_value(&state)
+            .map_err(|error| IndexReconciliationRunError::Storage(error.to_string()))?;
+        transaction
+            .execute(Statement::from_sql_and_values(
+                backend,
+                insert_job_sql(backend),
+                vec![
+                    uuid_value(request.tenant_id, backend),
+                    uuid_value(job_id, backend),
+                    request.schema.module.as_str().to_owned().into(),
+                    request.schema.entity.as_str().to_owned().into(),
+                    i64::from(request.schema.version.get()).into(),
+                    SqlValue::Json(Some(Box::new(request_json))),
+                    SqlValue::Json(Some(Box::new(cursor_json))),
+                    request.worker_id.clone().into(),
+                    i64::try_from(request.lease_seconds)
+                        .map_err(|_| IndexReconciliationRunError::InvalidLeaseDuration)?
+                        .into(),
+                ],
+            ))
+            .await
+            .map_err(storage_error)?;
+        (job_id, 1, state)
+    };
+
+    Ok(ReconciliationAcquireOutcome::Acquired {
+        lease: ReconciliationLease {
+            tenant_id: request.tenant_id,
+            job_id,
+            schema: request.schema.clone(),
+            source_name: request.source_name.clone(),
+            worker_id: request.worker_id.clone(),
+            attempt_count,
+        },
+        state,
+    })
+}
+
+fn validate_stored_request(
+    stored: &StoredReconciliationJob,
+    request: &ReconciliationAcquireRequest,
+) -> Result<(), IndexReconciliationRunError> {
+    if stored.request.contract != RECONCILIATION_JOB_REQUEST_CONTRACT
+        || stored.request.source_name != request.source_name
+        || stored.request.pass_count != request.pass_count
+    {
+        return Err(IndexReconciliationRunError::InvalidStoredJob(
+            "stored reconciliation request does not match the source/pass contract".to_owned(),
+        ));
+    }
+    validate_source_name(&stored.request.source_name)?;
+    stored.cursor.validate(stored.request.pass_count)
+}
+
+fn stored_job(
+    row: &QueryResult,
+    backend: DbBackend,
+) -> Result<StoredReconciliationJob, IndexReconciliationRunError> {
+    let request_json: JsonValue = row.try_get("", "request").map_err(storage_error)?;
+    let request: ReconciliationJobRequest = serde_json::from_value(request_json)
+        .map_err(|error| IndexReconciliationRunError::InvalidStoredJob(error.to_string()))?;
+    let cursor_json: JsonValue = row.try_get("", "cursor").map_err(storage_error)?;
+    let cursor: ReconciliationCursor = serde_json::from_value(cursor_json)
+        .map_err(|error| IndexReconciliationRunError::InvalidStoredJob(error.to_string()))?;
+    let attempt_count: i64 = row
+        .try_get("", "attempt_count_value")
+        .map_err(storage_error)?;
+    let attempt_count = u32::try_from(attempt_count).map_err(|_| {
+        IndexReconciliationRunError::InvalidStoredJob(
+            "attempt count is outside the u32 range".to_owned(),
+        )
+    })?;
+    Ok(StoredReconciliationJob {
+        job_id: stored_uuid(row, "job_id", backend)?,
+        state: row.try_get("", "state").map_err(storage_error)?,
+        request,
+        cursor,
+        attempt_count,
+        claimable: row.try_get("", "claimable").map_err(storage_error)?,
+    })
+}
+
+async fn lock_reconciliation_scope(
+    transaction: &DatabaseTransaction,
+    request: &ReconciliationAcquireRequest,
+    backend: DbBackend,
+) -> Result<(), IndexReconciliationRunError> {
+    if backend == DbBackend::Sqlite {
+        return Ok(());
+    }
+    let lock_key = format!(
+        "reconcile\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}",
+        request.tenant_id,
+        request.schema.module.as_str(),
+        request.schema.entity.as_str(),
+        request.schema.version.get(),
+    );
+    transaction
+        .execute(Statement::from_sql_and_values(
+            backend,
+            "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+            vec![lock_key.into()],
+        ))
+        .await
+        .map_err(storage_error)?;
+    Ok(())
+}
+
+async fn verify_schema_registration(
+    transaction: &DatabaseTransaction,
+    request: &ReconciliationAcquireRequest,
+    backend: DbBackend,
+) -> Result<(), IndexReconciliationRunError> {
+    let row = transaction
+        .query_one(Statement::from_sql_and_values(
+            backend,
+            select_schema_sql(backend),
+            scope_values(request, backend),
+        ))
+        .await
+        .map_err(storage_error)?
+        .ok_or_else(|| IndexReconciliationRunError::SchemaNotRegistered(request.schema.clone()))?;
+    let status: String = row.try_get("", "status").map_err(storage_error)?;
+    if status != "active" {
+        return Err(IndexReconciliationRunError::SchemaRetired(
+            request.schema.clone(),
+        ));
+    }
+    Ok(())
+}
+
+async fn persist_progress(
+    db: &DatabaseConnection,
+    lease: &ReconciliationLease,
+    state: &ReconciliationCursor,
+) -> Result<LeaseWriteOutcome, IndexReconciliationRunError> {
+    let backend = db.get_database_backend();
+    ensure_supported_backend(backend)?;
+    let state_json = serde_json::to_value(state)
+        .map_err(|error| IndexReconciliationRunError::Storage(error.to_string()))?;
+    let mut values = lease_values(lease, backend);
+    values.push(SqlValue::Json(Some(Box::new(state_json))));
+    let updated = db
+        .execute(Statement::from_sql_and_values(
+            backend,
+            persist_progress_sql(backend),
+            values,
+        ))
+        .await
+        .map_err(storage_error)?;
+    lease_write_outcome(db, lease, updated.rows_affected()).await
+}
+
+async fn heartbeat(
+    db: &DatabaseConnection,
+    lease: &ReconciliationLease,
+    duration: Duration,
+) -> Result<(), IndexReconciliationRunError> {
+    let seconds = validate_lease_duration(duration)?;
+    let backend = db.get_database_backend();
+    ensure_supported_backend(backend)?;
+    let mut values = lease_values(lease, backend);
+    values.push(
+        i64::try_from(seconds)
+            .map_err(|_| IndexReconciliationRunError::InvalidLeaseDuration)?
+            .into(),
+    );
+    let updated = db
+        .execute(Statement::from_sql_and_values(
+            backend,
+            heartbeat_sql(backend),
+            values,
+        ))
+        .await
+        .map_err(storage_error)?;
+    if updated.rows_affected() != 1 {
+        return Err(IndexReconciliationRunError::LeaseLost {
+            job_id: lease.job_id,
+            attempt_count: lease.attempt_count,
+        });
+    }
+    Ok(())
+}
+
+async fn finish_success(
+    db: &DatabaseConnection,
+    lease: &ReconciliationLease,
+    state: &ReconciliationCursor,
+) -> Result<LeaseWriteOutcome, IndexReconciliationRunError> {
+    let backend = db.get_database_backend();
+    ensure_supported_backend(backend)?;
+    let state_json = serde_json::to_value(state)
+        .map_err(|error| IndexReconciliationRunError::Storage(error.to_string()))?;
+    let mut values = lease_values(lease, backend);
+    values.push(SqlValue::Json(Some(Box::new(state_json))));
+    let updated = db
+        .execute(Statement::from_sql_and_values(
+            backend,
+            finish_success_sql(backend),
+            values,
+        ))
+        .await
+        .map_err(storage_error)?;
+    lease_write_outcome(db, lease, updated.rows_affected()).await
+}
+
+async fn finish_page_error(
+    db: &DatabaseConnection,
+    lease: &ReconciliationLease,
+    error: IndexReconciliationRunError,
+) -> Result<IndexReconciliationRunOutcome, IndexReconciliationRunError> {
+    let details = failure_details(&error);
+    match finish_failure(db, lease, details).await? {
+        LeaseWriteOutcome::Written => Err(error),
+        LeaseWriteOutcome::Cancelled => Ok(empty_outcome(
+            IndexReconciliationRunStatus::Cancelled,
+            Some(lease.job_id),
+            Some(lease.attempt_count),
+            0,
+        )),
+    }
+}
+
+async fn finish_failure(
+    db: &DatabaseConnection,
+    lease: &ReconciliationLease,
+    details: JsonValue,
+) -> Result<LeaseWriteOutcome, IndexReconciliationRunError> {
+    let backend = db.get_database_backend();
+    ensure_supported_backend(backend)?;
+    let mut values = lease_values(lease, backend);
+    values.push(RECONCILIATION_PAGE_FAILURE_CODE.to_owned().into());
+    values.push(SqlValue::Json(Some(Box::new(details))));
+    let updated = db
+        .execute(Statement::from_sql_and_values(
+            backend,
+            finish_failure_sql(backend),
+            values,
+        ))
+        .await
+        .map_err(storage_error)?;
+    lease_write_outcome(db, lease, updated.rows_affected()).await
+}
+
+async fn yield_for_resume(
+    db: &DatabaseConnection,
+    lease: &ReconciliationLease,
+) -> Result<LeaseWriteOutcome, IndexReconciliationRunError> {
+    let backend = db.get_database_backend();
+    ensure_supported_backend(backend)?;
+    let updated = db
+        .execute(Statement::from_sql_and_values(
+            backend,
+            yield_job_sql(backend),
+            lease_values(lease, backend),
+        ))
+        .await
+        .map_err(storage_error)?;
+    lease_write_outcome(db, lease, updated.rows_affected()).await
+}
+
+async fn request_cancel_in_transaction(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+    job_id: Uuid,
+) -> Result<IndexReconciliationCancelOutcome, IndexReconciliationRunError> {
+    let backend = transaction.get_database_backend();
+    ensure_supported_backend(backend)?;
+    let row = transaction
+        .query_one(Statement::from_sql_and_values(
+            backend,
+            select_cancel_job_sql(backend),
+            vec![uuid_value(tenant_id, backend), uuid_value(job_id, backend)],
+        ))
+        .await
+        .map_err(storage_error)?;
+    let Some(row) = row else {
+        return Ok(IndexReconciliationCancelOutcome::NotFound);
+    };
+    let state: String = row.try_get("", "state").map_err(storage_error)?;
+    match state.as_str() {
+        "pending" => {
+            let updated = transaction
+                .execute(Statement::from_sql_and_values(
+                    backend,
+                    cancel_pending_job_sql(backend),
+                    vec![uuid_value(tenant_id, backend), uuid_value(job_id, backend)],
+                ))
+                .await
+                .map_err(storage_error)?;
+            if updated.rows_affected() != 1 {
+                return Err(IndexReconciliationRunError::CancellationRace);
+            }
+            Ok(IndexReconciliationCancelOutcome::Cancelled)
+        }
+        "running" => {
+            let updated = transaction
+                .execute(Statement::from_sql_and_values(
+                    backend,
+                    request_running_cancel_sql(backend),
+                    vec![uuid_value(tenant_id, backend), uuid_value(job_id, backend)],
+                ))
+                .await
+                .map_err(storage_error)?;
+            if updated.rows_affected() != 1 {
+                return Err(IndexReconciliationRunError::CancellationRace);
+            }
+            Ok(IndexReconciliationCancelOutcome::Requested)
+        }
+        "succeeded" => Ok(IndexReconciliationCancelOutcome::AlreadyTerminal(
+            IndexReconciliationTerminalState::Succeeded,
+        )),
+        "failed" => Ok(IndexReconciliationCancelOutcome::AlreadyTerminal(
+            IndexReconciliationTerminalState::Failed,
+        )),
+        "cancelled" => Ok(IndexReconciliationCancelOutcome::AlreadyTerminal(
+            IndexReconciliationTerminalState::Cancelled,
+        )),
+        other => Err(IndexReconciliationRunError::InvalidStoredJobState(
+            other.to_owned(),
+        )),
+    }
+}
+
+async fn cancel_if_requested(
+    db: &DatabaseConnection,
+    lease: &ReconciliationLease,
+) -> Result<bool, IndexReconciliationRunError> {
+    let backend = db.get_database_backend();
+    ensure_supported_backend(backend)?;
+    let updated = db
+        .execute(Statement::from_sql_and_values(
+            backend,
+            cancel_active_job_sql(backend),
+            lease_values(lease, backend),
+        ))
+        .await
+        .map_err(storage_error)?;
+    Ok(updated.rows_affected() == 1)
+}
+
+async fn lease_write_outcome(
+    db: &DatabaseConnection,
+    lease: &ReconciliationLease,
+    rows_affected: u64,
+) -> Result<LeaseWriteOutcome, IndexReconciliationRunError> {
+    if rows_affected == 1 {
+        return Ok(LeaseWriteOutcome::Written);
+    }
+    if cancel_if_requested(db, lease).await? {
+        return Ok(LeaseWriteOutcome::Cancelled);
+    }
+    Err(IndexReconciliationRunError::LeaseLost {
+        job_id: lease.job_id,
+        attempt_count: lease.attempt_count,
+    })
+}
+
+fn failure_details(error: &IndexReconciliationRunError) -> JsonValue {
+    let (dependency_code, retryable) = match error {
+        IndexReconciliationRunError::Source(IndexSourceError::SourceFailure { failure, .. }) => (
+            failure.code(),
+            failure.kind() == IndexSourceFailureKind::Retryable,
+        ),
+        IndexReconciliationRunError::MutationFailed { failure, .. } => (
+            failure.code(),
+            failure.kind() == IndexReplayFailureKind::Retryable,
+        ),
+        IndexReconciliationRunError::Source(_) => ("source_contract_invalid", false),
+        _ => ("reconciliation_contract_invalid", false),
+    };
+    json!({
+        "contract": RECONCILIATION_FAILURE_CONTRACT,
+        "dependency_code": dependency_code,
+        "retryable": retryable,
+    })
+}
+
+fn empty_outcome(
+    status: IndexReconciliationRunStatus,
+    job_id: Option<Uuid>,
+    attempt_count: Option<u32>,
+    passes_completed: u32,
+) -> IndexReconciliationRunOutcome {
+    IndexReconciliationRunOutcome {
+        status,
+        job_id,
+        attempt_count,
+        pages_processed: 0,
+        passes_completed,
+        heartbeat_count: 0,
+        mutation_count: 0,
+        applied_count: 0,
+        duplicate_count: 0,
+        stale_count: 0,
+    }
+}
+
+fn validate_source_name(source_name: &str) -> Result<(), IndexReconciliationRunError> {
+    if source_name.is_empty()
+        || source_name.len() > MAX_SOURCE_NAME_BYTES
+        || !source_name.bytes().all(|byte| {
+            byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || matches!(byte, b'-' | b'_' | b'.')
+        })
+    {
+        return Err(IndexReconciliationRunError::InvalidSourceName);
+    }
+    Ok(())
+}
+
+fn validate_storage_text(value: &str, max_bytes: usize) -> Result<(), &'static str> {
+    if value.is_empty() {
+        return Err("must not be empty");
+    }
+    if value.trim() != value {
+        return Err("must not contain leading or trailing whitespace");
+    }
+    if value.len() > max_bytes {
+        return Err("exceeds the storage limit");
+    }
+    if value.chars().any(char::is_control) {
+        return Err("must not contain control characters");
+    }
+    Ok(())
+}
+
+fn validate_lease_duration(
+    lease_duration: Duration,
+) -> Result<u64, IndexReconciliationRunError> {
+    if lease_duration.subsec_nanos() != 0 {
+        return Err(IndexReconciliationRunError::InvalidLeaseDuration);
+    }
+    let seconds = lease_duration.as_secs();
+    if seconds == 0 || seconds > MAX_LEASE_SECONDS {
+        return Err(IndexReconciliationRunError::InvalidLeaseDuration);
+    }
+    Ok(seconds)
+}
+
+fn checked_add_counter(current: u64, increment: u64) -> Result<u64, IndexReconciliationRunError> {
+    current
+        .checked_add(increment)
+        .ok_or(IndexReconciliationRunError::CounterOverflow)
+}
+
+fn usize_to_u64(value: usize) -> Result<u64, IndexReconciliationRunError> {
+    u64::try_from(value).map_err(|_| IndexReconciliationRunError::CounterOverflow)
+}
+
+fn ensure_supported_backend(backend: DbBackend) -> Result<(), IndexReconciliationRunError> {
+    match backend {
+        DbBackend::Postgres => Ok(()),
+        DbBackend::Sqlite if cfg!(test) => Ok(()),
+        backend => Err(IndexReconciliationRunError::Storage(format!(
+            "Index reconciliation does not support {backend:?}"
+        ))),
+    }
+}
+
+fn storage_error(error: impl std::fmt::Display) -> IndexReconciliationRunError {
+    IndexReconciliationRunError::Storage(error.to_string())
+}
+
+fn placeholder_prefix(backend: DbBackend) -> &'static str {
+    match backend {
+        DbBackend::Postgres => "$",
+        DbBackend::Sqlite => "?",
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+fn uuid_value(value: Uuid, backend: DbBackend) -> SqlValue {
+    match backend {
+        DbBackend::Postgres => value.into(),
+        DbBackend::Sqlite => value.to_string().into(),
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+fn stored_uuid(
+    row: &QueryResult,
+    column: &str,
+    backend: DbBackend,
+) -> Result<Uuid, IndexReconciliationRunError> {
+    match backend {
+        DbBackend::Postgres => row.try_get("", column).map_err(storage_error),
+        DbBackend::Sqlite => {
+            let value: String = row.try_get("", column).map_err(storage_error)?;
+            Uuid::parse_str(&value).map_err(storage_error)
+        }
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+fn scope_values(request: &ReconciliationAcquireRequest, backend: DbBackend) -> Vec<SqlValue> {
+    vec![
+        uuid_value(request.tenant_id, backend),
+        request.schema.module.as_str().to_owned().into(),
+        request.schema.entity.as_str().to_owned().into(),
+        i64::from(request.schema.version.get()).into(),
+    ]
+}
+
+fn lease_values(lease: &ReconciliationLease, backend: DbBackend) -> Vec<SqlValue> {
+    vec![
+        uuid_value(lease.tenant_id, backend),
+        uuid_value(lease.job_id, backend),
+        lease.worker_id.clone().into(),
+        i64::from(lease.attempt_count).into(),
+    ]
+}
+
+fn select_schema_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    format!(
+        "SELECT status FROM index_schemas WHERE tenant_id = {prefix}1 AND module_name = {prefix}2 AND entity_name = {prefix}3 AND schema_version = {prefix}4 LIMIT 1"
+    )
+}
+
+fn select_jobs_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    let (attempt_count, claimable) = match backend {
+        DbBackend::Postgres => (
+            "CAST(attempt_count AS BIGINT)",
+            "((state = 'pending' AND available_at <= CURRENT_TIMESTAMP) OR (state = 'running' AND lease_expires_at <= CURRENT_TIMESTAMP))",
+        ),
+        DbBackend::Sqlite => (
+            "CAST(attempt_count AS INTEGER)",
+            "CASE WHEN (state = 'pending' AND available_at <= CURRENT_TIMESTAMP) OR (state = 'running' AND lease_expires_at <= CURRENT_TIMESTAMP) THEN TRUE ELSE FALSE END",
+        ),
+        _ => unreachable!("unsupported database backend was validated"),
+    };
+    format!(
+        "SELECT job_id, state, request, cursor, {attempt_count} AS attempt_count_value, {claimable} AS claimable FROM index_jobs WHERE tenant_id = {prefix}1 AND module_name = {prefix}2 AND entity_name = {prefix}3 AND schema_version = {prefix}4 AND kind = 'reconcile' AND scope_kind = 'schema' AND state IN ('pending', 'running', 'succeeded') ORDER BY CASE state WHEN 'succeeded' THEN 0 WHEN 'running' THEN 1 ELSE 2 END, created_at DESC"
+    )
+}
+
+fn insert_job_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    let lease_expires = lease_expires_expression(backend, 9);
+    format!(
+        "INSERT INTO index_jobs (tenant_id, job_id, kind, state, scope_kind, module_name, entity_name, schema_version, request, cursor, attempt_count, available_at, lease_owner, lease_expires_at, heartbeat_at) VALUES ({prefix}1, {prefix}2, 'reconcile', 'running', 'schema', {prefix}3, {prefix}4, {prefix}5, {prefix}6, {prefix}7, 1, CURRENT_TIMESTAMP, {prefix}8, {lease_expires}, CURRENT_TIMESTAMP)"
+    )
+}
+
+fn claim_job_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    let lease_expires = lease_expires_expression(backend, 5);
+    format!(
+        "UPDATE index_jobs SET state = 'running', lease_owner = {prefix}3, attempt_count = {prefix}4, lease_expires_at = {lease_expires}, heartbeat_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP, completed_at = NULL, last_error_code = NULL, last_error_details = NULL WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'reconcile' AND ((state = 'pending' AND available_at <= CURRENT_TIMESTAMP) OR (state = 'running' AND lease_expires_at <= CURRENT_TIMESTAMP))"
+    )
+}
+
+fn heartbeat_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    let lease_expires = lease_expires_expression(backend, 5);
+    format!(
+        "UPDATE index_jobs SET lease_expires_at = {lease_expires}, heartbeat_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'reconcile' AND state = 'running' AND lease_owner = {prefix}3 AND attempt_count = {prefix}4 AND lease_expires_at > CURRENT_TIMESTAMP AND cancel_requested = FALSE"
+    )
+}
+
+fn persist_progress_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    format!(
+        "UPDATE index_jobs SET cursor = {prefix}5, heartbeat_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'reconcile' AND state = 'running' AND lease_owner = {prefix}3 AND attempt_count = {prefix}4 AND lease_expires_at > CURRENT_TIMESTAMP AND cancel_requested = FALSE"
+    )
+}
+
+fn finish_success_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    format!(
+        "UPDATE index_jobs SET state = 'succeeded', cursor = {prefix}5, lease_owner = NULL, lease_expires_at = NULL, heartbeat_at = CURRENT_TIMESTAMP, completed_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP, last_error_code = NULL, last_error_details = NULL WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'reconcile' AND state = 'running' AND lease_owner = {prefix}3 AND attempt_count = {prefix}4 AND lease_expires_at > CURRENT_TIMESTAMP AND cancel_requested = FALSE"
+    )
+}
+
+fn finish_failure_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    format!(
+        "UPDATE index_jobs SET state = 'failed', lease_owner = NULL, lease_expires_at = NULL, heartbeat_at = CURRENT_TIMESTAMP, completed_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP, last_error_code = {prefix}5, last_error_details = {prefix}6 WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'reconcile' AND state = 'running' AND lease_owner = {prefix}3 AND attempt_count = {prefix}4 AND lease_expires_at > CURRENT_TIMESTAMP AND cancel_requested = FALSE"
+    )
+}
+
+fn yield_job_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    format!(
+        "UPDATE index_jobs SET state = 'pending', available_at = CURRENT_TIMESTAMP, lease_owner = NULL, lease_expires_at = NULL, heartbeat_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'reconcile' AND state = 'running' AND lease_owner = {prefix}3 AND attempt_count = {prefix}4 AND lease_expires_at > CURRENT_TIMESTAMP AND cancel_requested = FALSE"
+    )
+}
+
+fn select_cancel_job_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    let lock = match backend {
+        DbBackend::Postgres => " FOR UPDATE",
+        DbBackend::Sqlite => "",
+        _ => unreachable!("unsupported database backend was validated"),
+    };
+    format!(
+        "SELECT state FROM index_jobs WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'reconcile' LIMIT 1{lock}"
+    )
+}
+
+fn cancel_pending_job_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    format!(
+        "UPDATE index_jobs SET state = 'cancelled', cancel_requested = TRUE, completed_at = CURRENT_TIMESTAMP, heartbeat_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP, last_error_code = NULL, last_error_details = NULL WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'reconcile' AND state = 'pending'"
+    )
+}
+
+fn request_running_cancel_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    format!(
+        "UPDATE index_jobs SET cancel_requested = TRUE, updated_at = CURRENT_TIMESTAMP WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'reconcile' AND state = 'running'"
+    )
+}
+
+fn cancel_active_job_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    format!(
+        "UPDATE index_jobs SET state = 'cancelled', lease_owner = NULL, lease_expires_at = NULL, heartbeat_at = CURRENT_TIMESTAMP, completed_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP, last_error_code = NULL, last_error_details = NULL WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'reconcile' AND state = 'running' AND lease_owner = {prefix}3 AND attempt_count = {prefix}4 AND lease_expires_at > CURRENT_TIMESTAMP AND cancel_requested = TRUE"
+    )
+}
+
+fn lease_expires_expression(backend: DbBackend, seconds_parameter: usize) -> String {
+    let prefix = placeholder_prefix(backend);
+    match backend {
+        DbBackend::Postgres => {
+            format!("CURRENT_TIMESTAMP + ({prefix}{seconds_parameter} * INTERVAL '1 second')")
+        }
+        DbBackend::Sqlite => format!(
+            "datetime(CURRENT_TIMESTAMP, '+' || {prefix}{seconds_parameter} || ' seconds')"
+        ),
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum IndexReconciliationRunError {
+    #[error("Index reconciliation page request is invalid")]
+    InvalidPageRequest(#[source] IndexSourceError),
+    #[error("Index reconciliation max pages is invalid: actual={actual}, max={max}")]
+    InvalidMaxPages { actual: usize, max: usize },
+    #[error("Index reconciliation heartbeat cadence is invalid: actual={actual}, max={max}")]
+    InvalidHeartbeatCadence { actual: usize, max: usize },
+    #[error("Index reconciliation pass count is invalid: actual={actual}, max={max}")]
+    InvalidPassCount { actual: u32, max: u32 },
+    #[error("Index reconciliation worker id is invalid: {reason}")]
+    InvalidWorkerId { reason: &'static str },
+    #[error("Index reconciliation lease duration must be a whole number of seconds between 1 and 86400")]
+    InvalidLeaseDuration,
+    #[error("Index reconciliation source name is invalid")]
+    InvalidSourceName,
+    #[error("No Index source owns reconciliation schema {0}")]
+    UnknownSchemaSource(SchemaRef),
+    #[error("Index reconciliation schema is not persisted for this tenant: {0}")]
+    SchemaNotRegistered(SchemaRef),
+    #[error("Index reconciliation schema is retired: {0}")]
+    SchemaRetired(SchemaRef),
+    #[error("stored Index reconciliation job is invalid: {0}")]
+    InvalidStoredJob(String),
+    #[error("stored Index reconciliation job has unsupported state {0}")]
+    InvalidStoredJobState(String),
+    #[error("Index reconciliation cancellation tenant id must not be nil")]
+    NilCancelTenantId,
+    #[error("Index reconciliation cancellation job id must not be nil")]
+    NilCancelJobId,
+    #[error("Index reconciliation cancellation lost a concurrent state transition")]
+    CancellationRace,
+    #[error("Index reconciliation source failed")]
+    Source(#[source] IndexSourceError),
+    #[error("Index reconciliation mutation at position {position} has a nil event id")]
+    NilEventId { position: usize },
+    #[error("Index reconciliation mutation at position {position} duplicates event id {event_id}")]
+    DuplicateEventId { position: usize, event_id: Uuid },
+    #[error("Index reconciliation mutation at position {position} failed")]
+    MutationFailed {
+        position: usize,
+        #[source]
+        failure: IndexReplayFailure,
+    },
+    #[error("Index reconciliation durable counter overflowed")]
+    CounterOverflow,
+    #[error("Index reconciliation job {job_id} lost attempt {attempt_count} ownership")]
+    LeaseLost { job_id: Uuid, attempt_count: u32 },
+    #[error("Index reconciliation storage operation failed: {0}")]
+    Storage(String),
+}

--- a/crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner_tests.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner_tests.rs
@@ -1,0 +1,370 @@
+use std::{
+    collections::BTreeMap,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use rustok_core::MigrationSource;
+use sea_orm::{
+    ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement, Value as SqlValue,
+};
+use sea_orm_migration::SchemaManager;
+use serde_json::json;
+use uuid::Uuid;
+
+use super::{
+    IndexReconciliationRunRequest, IndexReconciliationRunStatus,
+    PostgresIndexReconciliationRunner,
+};
+use crate::{
+    EntityKey, EntityName, FieldCardinality, FieldName, IndexField, IndexModule, IndexMutation,
+    IndexRecord, IndexSchema, IndexSchemaSourceCatalog, IndexSource, IndexSourceCatalog,
+    IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest, IndexSourcePage,
+    IndexSourceScanRequest, IndexValue, IndexValueType, LocaleMode, ModuleName, SchemaRef,
+    SchemaRegistry, SchemaVersion,
+};
+
+const TENANT: &str = "11111111-1111-1111-1111-111111111111";
+
+struct ReconciliationSource {
+    ids: Arc<Mutex<Vec<u128>>>,
+    calls: Arc<AtomicUsize>,
+    injected: Arc<AtomicBool>,
+    inject_on_call: Option<usize>,
+}
+
+#[async_trait]
+impl IndexSource for ReconciliationSource {
+    async fn scan(
+        &self,
+        request: IndexSourceScanRequest,
+    ) -> Result<IndexSourcePage, IndexSourceFailure> {
+        let call = self.calls.fetch_add(1, Ordering::SeqCst);
+        if self.inject_on_call == Some(call) && !self.injected.swap(true, Ordering::SeqCst) {
+            self.ids
+                .lock()
+                .expect("source ids lock")
+                .push(50);
+        }
+        let after = request
+            .cursor()
+            .map(|cursor| {
+                cursor
+                    .value()
+                    .as_u64()
+                    .expect("test cursor should be a positive integer") as u128
+            })
+            .unwrap_or(0);
+        let mut ids = self.ids.lock().expect("source ids lock").clone();
+        ids.sort_unstable();
+        ids.dedup();
+        let visible = ids
+            .into_iter()
+            .filter(|id| *id > after)
+            .collect::<Vec<_>>();
+        let selected = visible
+            .iter()
+            .copied()
+            .take(request.limit())
+            .collect::<Vec<_>>();
+        let next_cursor = if visible.len() > selected.len() {
+            selected.last().copied().map(|id| {
+                crate::IndexSourceCursor::new(json!(id as u64))
+                    .expect("test cursor should be valid")
+            })
+        } else {
+            None
+        };
+        let mutations = selected
+            .into_iter()
+            .map(|id| mutation(request.tenant_id(), id))
+            .collect();
+        IndexSourcePage::new(&request, mutations, next_cursor)
+            .map_err(|_| IndexSourceFailure::permanent("fixture_page_invalid").unwrap())
+    }
+
+    async fn load(
+        &self,
+        request: IndexSourceLoadRequest,
+    ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+        Ok(IndexSourceLoadBatch::new(&request, Vec::new()).expect("empty targeted load"))
+    }
+}
+
+struct Fixture {
+    db: DatabaseConnection,
+    runner: PostgresIndexReconciliationRunner,
+    calls: Arc<AtomicUsize>,
+}
+
+impl Fixture {
+    async fn new(inject_on_call: Option<usize>) -> Self {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite should connect");
+        db.execute_unprepared("PRAGMA foreign_keys = ON")
+            .await
+            .expect("foreign keys should be enabled");
+        db.execute_unprepared("CREATE TABLE tenants (id TEXT PRIMARY KEY)")
+            .await
+            .expect("tenant fixture should be created");
+        db.execute_unprepared(&format!("INSERT INTO tenants (id) VALUES ('{TENANT}')"))
+            .await
+            .expect("tenant fixture should be inserted");
+        let manager = SchemaManager::new(&db);
+        for migration in IndexModule.migrations() {
+            migration
+                .up(&manager)
+                .await
+                .unwrap_or_else(|error| panic!("{} should apply: {error}", migration.name()));
+        }
+
+        let schema = schema();
+        let fingerprint = schema.fingerprint().unwrap().to_string();
+        let schema_json = serde_json::to_value(&schema).unwrap();
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO index_schemas (tenant_id, module_name, entity_name, schema_version, schema_fingerprint, schema_json, status) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'active')",
+            vec![
+                TENANT.to_owned().into(),
+                schema.reference.module.as_str().to_owned().into(),
+                schema.reference.entity.as_str().to_owned().into(),
+                i64::from(schema.reference.version.get()).into(),
+                fingerprint.into(),
+                SqlValue::Json(Some(Box::new(schema_json))),
+            ],
+        ))
+        .await
+        .expect("schema fixture should persist");
+
+        let mut schema_catalog = IndexSchemaSourceCatalog::new();
+        schema_catalog.register("product", schema.clone()).unwrap();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut source_catalog = IndexSourceCatalog::new();
+        source_catalog
+            .register(
+                "product",
+                "product-primary",
+                [schema.reference.clone()],
+                ReconciliationSource {
+                    ids: Arc::new(Mutex::new(vec![100, 200])),
+                    calls: calls.clone(),
+                    injected: Arc::new(AtomicBool::new(false)),
+                    inject_on_call,
+                },
+            )
+            .unwrap();
+        let sources = source_catalog.materialize(&schema_catalog).unwrap();
+        let mut registry = SchemaRegistry::new();
+        registry.register(schema).unwrap();
+        let runner =
+            PostgresIndexReconciliationRunner::new(db.clone(), sources, Arc::new(registry));
+        Self { db, runner, calls }
+    }
+
+    fn request(&self, worker: &str, max_pages: usize, pass_count: u32) -> IndexReconciliationRunRequest {
+        IndexReconciliationRunRequest::new(
+            Uuid::parse_str(TENANT).unwrap(),
+            schema_ref(),
+            worker,
+            1,
+            max_pages,
+            1,
+            pass_count,
+            Duration::from_secs(60),
+        )
+        .unwrap()
+    }
+}
+
+fn schema_ref() -> SchemaRef {
+    SchemaRef {
+        module: ModuleName::new("rustok-product").unwrap(),
+        entity: EntityName::new("product").unwrap(),
+        version: SchemaVersion::INITIAL,
+    }
+}
+
+fn schema() -> IndexSchema {
+    IndexSchema {
+        reference: schema_ref(),
+        locale_mode: LocaleMode::None,
+        fields: vec![IndexField {
+            name: FieldName::new("id").unwrap(),
+            value_type: IndexValueType::Uuid,
+            cardinality: FieldCardinality::One,
+            nullable: false,
+            selectable: true,
+            filterable: true,
+            sortable: true,
+        }],
+        links: Vec::new(),
+    }
+}
+
+fn mutation(tenant_id: Uuid, id: u128) -> IndexMutation {
+    let entity_id = Uuid::from_u128(id);
+    IndexMutation::Upsert {
+        event_id: Uuid::from_u128(10_000 + id),
+        record: IndexRecord {
+            key: EntityKey {
+                tenant_id,
+                schema: schema_ref(),
+                entity_id,
+                locale: None,
+            },
+            source_version: 1,
+            fields: BTreeMap::from([(
+                FieldName::new("id").unwrap(),
+                IndexValue::Uuid(entity_id),
+            )]),
+            links: Vec::new(),
+        },
+    }
+}
+
+async fn scalar_i64(db: &DatabaseConnection, sql: &str) -> i64 {
+    db.query_one(Statement::from_string(DbBackend::Sqlite, sql.to_owned()))
+        .await
+        .expect("scalar query should execute")
+        .expect("scalar query should return one row")
+        .try_get("", "value")
+        .expect("scalar value should be integer")
+}
+
+#[tokio::test]
+async fn two_pass_reconciliation_catches_insert_behind_first_cursor() {
+    let fixture = Fixture::new(Some(1)).await;
+    let outcome = fixture
+        .runner
+        .run(fixture.request("worker-a", 8, 2))
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.status(), IndexReconciliationRunStatus::Complete);
+    assert_eq!(outcome.passes_completed(), 2);
+    assert_eq!(outcome.pages_processed(), 5);
+    assert_eq!(outcome.mutation_count(), 5);
+    assert_eq!(outcome.applied_count(), 3);
+    assert_eq!(outcome.duplicate_count(), 2);
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 5);
+    assert_eq!(
+        scalar_i64(&fixture.db, "SELECT COUNT(*) AS value FROM index_entities").await,
+        3,
+    );
+    assert_eq!(
+        scalar_i64(
+            &fixture.db,
+            "SELECT CAST(json_extract(cursor, '$.completed_passes') AS INTEGER) AS value FROM index_jobs WHERE kind = 'reconcile' AND state = 'succeeded'",
+        )
+        .await,
+        2,
+    );
+
+    let repeated = fixture
+        .runner
+        .run(fixture.request("worker-b", 8, 2))
+        .await
+        .unwrap();
+    assert_eq!(
+        repeated.status(),
+        IndexReconciliationRunStatus::AlreadyComplete
+    );
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 5);
+}
+
+#[tokio::test]
+async fn bounded_reconciliation_yields_and_resumes_durable_pass_state() {
+    let fixture = Fixture::new(Some(1)).await;
+
+    let first = fixture
+        .runner
+        .run(fixture.request("worker-a", 2, 2))
+        .await
+        .unwrap();
+    assert_eq!(first.status(), IndexReconciliationRunStatus::Yielded);
+    assert_eq!(first.passes_completed(), 1);
+    assert_eq!(first.attempt_count(), Some(1));
+
+    let second = fixture
+        .runner
+        .run(fixture.request("worker-b", 2, 2))
+        .await
+        .unwrap();
+    assert_eq!(second.status(), IndexReconciliationRunStatus::Yielded);
+    assert_eq!(second.job_id(), first.job_id());
+    assert_eq!(second.passes_completed(), 1);
+    assert_eq!(second.attempt_count(), Some(2));
+
+    let third = fixture
+        .runner
+        .run(fixture.request("worker-c", 2, 2))
+        .await
+        .unwrap();
+    assert_eq!(third.status(), IndexReconciliationRunStatus::Complete);
+    assert_eq!(third.job_id(), first.job_id());
+    assert_eq!(third.passes_completed(), 2);
+    assert_eq!(third.attempt_count(), Some(3));
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 5);
+    assert_eq!(
+        scalar_i64(
+            &fixture.db,
+            "SELECT CAST(json_extract(cursor, '$.pages_processed') AS INTEGER) AS value FROM index_jobs WHERE kind = 'reconcile' AND state = 'succeeded'",
+        )
+        .await,
+        5,
+    );
+}
+
+#[test]
+fn reconciliation_request_bounds_pages_passes_and_heartbeat_cadence() {
+    let tenant_id = Uuid::parse_str(TENANT).unwrap();
+    assert!(IndexReconciliationRunRequest::new(
+        tenant_id,
+        schema_ref(),
+        "worker-a",
+        10,
+        0,
+        1,
+        2,
+        Duration::from_secs(60),
+    )
+    .is_err());
+    assert!(IndexReconciliationRunRequest::new(
+        tenant_id,
+        schema_ref(),
+        "worker-a",
+        10,
+        2,
+        3,
+        2,
+        Duration::from_secs(60),
+    )
+    .is_err());
+    assert!(IndexReconciliationRunRequest::new(
+        tenant_id,
+        schema_ref(),
+        "worker-a",
+        10,
+        2,
+        1,
+        0,
+        Duration::from_secs(60),
+    )
+    .is_err());
+    assert!(IndexReconciliationRunRequest::new(
+        tenant_id,
+        schema_ref(),
+        "worker-a",
+        10,
+        2,
+        1,
+        9,
+        Duration::from_secs(60),
+    )
+    .is_err());
+}

--- a/crates/rustok-index/src/lib.rs
+++ b/crates/rustok-index/src/lib.rs
@@ -5,11 +5,12 @@
 //! storage-schema migrations, atomic mutation persistence, tenant-scoped source
 //! schema registration, bounded source replay/load contracts, one-page replay
 //! orchestration with durable fenced checkpoint progression, bounded multi-page
-//! replay coordination with heartbeat/yield/cancellation semantics, host-published
-//! replay and query capabilities, host-database-aware source factory composition,
-//! durable replay-job and schema-application leases, schema-derived secondary-index
-//! lifecycle, fail-closed measured partition admission, and the PostgreSQL execution
-//! adapter for structured Index queries.
+//! replay coordination with heartbeat/yield/cancellation semantics, bounded
+//! multi-pass source reconciliation with durable pass/cursor progression,
+//! host-published replay and query capabilities, host-database-aware source factory
+//! composition, durable replay-job and schema-application leases, schema-derived
+//! secondary-index lifecycle, fail-closed measured partition admission, and the
+//! PostgreSQL execution adapter for structured Index queries.
 
 use async_trait::async_trait;
 use rustok_core::{
@@ -29,20 +30,24 @@ pub use infrastructure::postgres::{
     evaluate_partition_admission, materialize_postgres_index_query_runtime,
     materialize_postgres_index_replay_runtime, materialize_postgres_index_sources,
     register_postgres_index_source_factory, IndexQueryRuntimeCompositionError,
-    IndexReplayCancelOutcome, IndexReplayJobAcquireOutcome, IndexReplayJobError,
-    IndexReplayJobLease, IndexReplayJobLeaseRequest, IndexReplayRunError, IndexReplayRunOutcome,
-    IndexReplayRunRequest, IndexReplayRunStatus, IndexReplayRuntimeCompositionError,
-    IndexReplayTerminalState, MutationApplyOutcome, MutationDelivery, MutationStorageError,
-    PartitionAdmissionError, PartitionAdmissionOutcome, PartitionAdmissionPolicy,
-    PartitionAdmissionReason, PartitionBaselineEvidence, PartitionEvidence,
-    PartitionMeasurementCoverage, PartitionRelationPlan, PartitionShadowEvidence,
-    PartitionShadowPlan, PartitionStrategy, PersistedSchemaRegistrationOutcome,
-    PostgresIndexQueryPort, PostgresIndexReplayCheckpointStore, PostgresIndexReplayJobStore,
-    PostgresIndexReplayRunner, PostgresIndexSourceFactory, PostgresIndexSourceFactoryCatalog,
-    PostgresIndexSourceFactoryDescriptor, PostgresIndexSourceFactoryError, PostgresMutationStore,
-    PostgresSchemaLeaseStore, PostgresSchemaRegistrationStore, PostgresSecondaryIndexManager,
-    SchemaApplicationLease, SchemaApplicationLeaseRequest, SchemaLeaseAcquireOutcome,
-    SchemaLeaseError, SchemaRegistrationError, SecondaryIndexClaimOutcome, SecondaryIndexError,
+    IndexReconciliationCancelOutcome, IndexReconciliationRunError,
+    IndexReconciliationRunOutcome, IndexReconciliationRunRequest, IndexReconciliationRunStatus,
+    IndexReconciliationTerminalState, IndexReplayCancelOutcome, IndexReplayJobAcquireOutcome,
+    IndexReplayJobError, IndexReplayJobLease, IndexReplayJobLeaseRequest, IndexReplayRunError,
+    IndexReplayRunOutcome, IndexReplayRunRequest, IndexReplayRunStatus,
+    IndexReplayRuntimeCompositionError, IndexReplayTerminalState, MutationApplyOutcome,
+    MutationDelivery, MutationStorageError, PartitionAdmissionError, PartitionAdmissionOutcome,
+    PartitionAdmissionPolicy, PartitionAdmissionReason, PartitionBaselineEvidence,
+    PartitionEvidence, PartitionMeasurementCoverage, PartitionRelationPlan,
+    PartitionShadowEvidence, PartitionShadowPlan, PartitionStrategy,
+    PersistedSchemaRegistrationOutcome, PostgresIndexQueryPort,
+    PostgresIndexReconciliationRunner, PostgresIndexReplayCheckpointStore,
+    PostgresIndexReplayJobStore, PostgresIndexReplayRunner, PostgresIndexSourceFactory,
+    PostgresIndexSourceFactoryCatalog, PostgresIndexSourceFactoryDescriptor,
+    PostgresIndexSourceFactoryError, PostgresMutationStore, PostgresSchemaLeaseStore,
+    PostgresSchemaRegistrationStore, PostgresSecondaryIndexManager, SchemaApplicationLease,
+    SchemaApplicationLeaseRequest, SchemaLeaseAcquireOutcome, SchemaLeaseError,
+    SchemaRegistrationError, SecondaryIndexClaimOutcome, SecondaryIndexError,
     SecondaryIndexExecutionOutcome, SecondaryIndexKind, SecondaryIndexLease,
     SecondaryIndexOperation, SecondaryIndexPlan, SecondaryIndexRequest, SecondaryIndexSpec,
     SharedIndexReplayRuntime,

--- a/crates/rustok-product/README.md
+++ b/crates/rustok-product/README.md
@@ -62,9 +62,14 @@
 - The selected bridge emits `IndexMutation::Upsert` for live owner rows and
   `IndexMutation::Delete` for retained hard-delete identities without changing
   schema fingerprints, source names, cursor shapes, or replay event domains.
-  Incremental event ingestion, tombstone retention/purge admission, durable
-  Product/ProductVariant-to-SalesChannel relations, and authoritative Index
-  consumer cutover remain later Index/reconciliation slices.
+- The Index-owned bounded multi-pass reconciliation runner can restart these
+  unchanged sources from the beginning and catch live or retained identities
+  inserted behind an earlier cursor. It is explicit and crash-resumable, but it
+  does not establish a repeatable-read owner snapshot or close the final-pass
+  concurrent-write window.
+  Incremental event ingestion, snapshot/watermark admission, tombstone
+  retention/purge admission, durable Product/ProductVariant-to-SalesChannel
+  relations, and authoritative Index consumer cutover remain later slices.
 - Effective visibility is resolved as tri-state overrides with precedence
   `attribute defaults < schema/category overrides < channel settings`.
 - Virtual categories use a validated, bounded V1 rule contract over product
@@ -164,5 +169,6 @@
 See also `docs/README.md`, the Index
 [M7 Product source contract](../rustok-index/docs/m7-product-source.md),
 [M7 ProductVariant source contract](../rustok-index/docs/m7-product-variant-source.md),
-[M7 versioned Product graph contract](../rustok-index/docs/m7-product-graph-source.md), and
-[M7 Product tombstone replay contract](../rustok-index/docs/m7-product-tombstone-source.md).
+[M7 versioned Product graph contract](../rustok-index/docs/m7-product-graph-source.md),
+[M7 Product tombstone replay contract](../rustok-index/docs/m7-product-tombstone-source.md), and
+[M7 bounded Product reconciliation contract](../rustok-index/docs/m7-product-reconciliation.md).

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -20,6 +20,7 @@ const scripts = [
   'verify-index-source-replay-contract.mjs',
   'verify-index-replay-job-leases.mjs',
   'verify-index-replay-multipage-runner.mjs',
+  'verify-index-source-reconciliation.mjs',
   'verify-index-replay-runtime-composition.mjs',
   'verify-index-product-source.mjs',
   'verify-index-product-variant-source.mjs',

--- a/scripts/verify/verify-index-source-reconciliation.mjs
+++ b/scripts/verify/verify-index-source-reconciliation.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const resolve = (relative) => path.join(root, relative);
+const read = (relative) => fs.readFileSync(resolve(relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-source-reconciliation] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+const forbidMarkers = (relative, source, markers) => {
+  for (const marker of markers) {
+    if (source.includes(marker)) fail(`${relative} contains forbidden marker ${marker}`);
+  }
+};
+
+const runnerPath =
+  'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner.rs';
+const runner = requireMarkers(runnerPath, [
+  'RECONCILIATION_JOB_REQUEST_CONTRACT: &str = "index_reconciliation_job_v1"',
+  'RECONCILIATION_JOB_CURSOR_CONTRACT: &str = "index_reconciliation_cursor_v1"',
+  'const MAX_PAGES_PER_RUN: usize = 1_024;',
+  'const MAX_PASSES: u32 = 8;',
+  'pub struct IndexReconciliationRunRequest',
+  'pub enum IndexReconciliationRunStatus',
+  'pub struct IndexReconciliationRunOutcome',
+  'pub struct PostgresIndexReconciliationRunner',
+  '.source_for_schema(request.schema())',
+  'IndexSourceScanRequest::new(',
+  'self.sources.scan(scan_request).await',
+  '.apply_replay_mutation(',
+  'state.source_cursor = next_cursor;',
+  'state.completed_passes',
+  'persist_progress(&self.db, &lease, &state).await?',
+  'finish_success(&self.db, &lease, &state).await?',
+  'yield_for_resume(&self.db, &lease).await?',
+  'cancel_if_requested(&self.db, &lease).await?',
+  "kind = 'reconcile'",
+  "scope_kind = 'schema'",
+  'cursor = {prefix}5',
+  'attempt_count = {prefix}4',
+  'lease_expires_at > CURRENT_TIMESTAMP',
+  'pg_advisory_xact_lock(hashtextextended($1, 0))',
+  '#[serde(deny_unknown_fields)]',
+  'IndexReplayMutationOutcome::Duplicate',
+  'IndexReplayMutationOutcome::StaleIgnored',
+]);
+forbidMarkers(runnerPath, runner, [
+  'rustok_product',
+  'rustok_channel',
+  'rustok_search',
+  'product_index_tombstones',
+  'product_variant_index_tombstones',
+  'INSERT INTO index_entities',
+  'UPDATE index_entities',
+  'DELETE FROM index_entities',
+  'tokio::spawn',
+  'tokio::time::sleep',
+  'loop {',
+]);
+
+const sourceResolution = runner.indexOf('.source_for_schema(request.schema())');
+const storedRequest = runner.indexOf('ReconciliationJobRequest {');
+if (sourceResolution < 0 || storedRequest <= sourceResolution) {
+  fail('the source must be registry-resolved before its identity is stored in the job request');
+}
+const apply = runner.indexOf('.apply_replay_mutation(');
+const progress = runner.indexOf('persist_progress(&self.db, &lease, &state).await?');
+if (apply < 0 || progress <= apply) {
+  fail('durable job progress must follow mutation persistence');
+}
+
+requireMarkers(
+  'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner_tests.rs',
+  [
+    'two_pass_reconciliation_catches_insert_behind_first_cursor',
+    'bounded_reconciliation_yields_and_resumes_durable_pass_state',
+    'reconciliation_request_bounds_pages_passes_and_heartbeat_cadence',
+    'IndexReconciliationRunStatus::AlreadyComplete',
+    "json_extract(cursor, '$.completed_passes')",
+    "json_extract(cursor, '$.pages_processed')",
+    'assert_eq!(outcome.applied_count(), 3);',
+    'assert_eq!(outcome.duplicate_count(), 2);',
+  ],
+);
+
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
+  'mod source_reconciliation_runner;',
+  'mod source_reconciliation_runner_tests;',
+  'IndexReconciliationRunRequest',
+  'IndexReconciliationRunOutcome',
+  'PostgresIndexReconciliationRunner',
+]);
+requireMarkers('crates/rustok-index/src/lib.rs', [
+  'bounded multi-pass source reconciliation with durable pass/cursor progression',
+  'IndexReconciliationRunRequest',
+  'IndexReconciliationRunStatus',
+  'PostgresIndexReconciliationRunner',
+]);
+
+const operationsMigration = requireMarkers(
+  'crates/rustok-index/src/migrations/m20260727_000003_create_index_operations.rs',
+  [
+    'ColumnDef::new(IndexJobs::Cursor).json_binary()',
+    "kind IN ('schema_apply', 'secondary_index', 'rebuild', 'reconcile', 'consistency_check')",
+  ],
+);
+forbidMarkers(
+  'crates/rustok-index/src/migrations/m20260727_000003_create_index_operations.rs',
+  operationsMigration,
+  ['index_reconciliation_cursor_v1'],
+);
+
+requireMarkers('crates/rustok-index/docs/m7-product-reconciliation.md', [
+  'Status: `source_complete_owner_execution_pending`',
+  '`PostgresIndexReconciliationRunner`',
+  '`index_reconciliation_job_v1`',
+  '`index_reconciliation_cursor_v1`',
+  'two passes are the recommended minimum',
+  'narrows but does not eliminate the live-write window',
+  'does **not** claim a repeatable-read owner snapshot',
+  'maintainer-run',
+]);
+requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
+  "'verify-index-source-reconciliation.mjs'",
+]);
+
+console.log('[verify-index-source-reconciliation] OK');


### PR DESCRIPTION
## Summary

- add a generic bounded multi-pass source reconciliation runner
- catch identities inserted behind an earlier stable source cursor on a later pass
- persist crash-resumable pass/source-cursor state in the existing `index_jobs.cursor`
- reuse deterministic replay mutations and `PostgresMutationStore` idempotency
- keep the established M6 rebuild runner and rebuild checkpoints unchanged
- expose the capability through the `rustok-index` public API
- add focused fixtures, documentation, and repository guards

## Job boundary

Reconciliation uses the existing `index_jobs` schema:

- `kind = 'reconcile'`
- `scope_kind = 'schema'`
- request contract `index_reconciliation_job_v1`
- cursor contract `index_reconciliation_cursor_v1`

No migration is needed: `index_jobs` already permits `reconcile` and already owns a nullable JSON cursor.

The request stores the registry-resolved source name and validated pass count. Stored active/succeeded work that differs from that exact contract fails closed.

## Durable cursor

The runner-owned cursor stores:

- completed passes
- optional opaque `IndexSourceCursor` for the current pass
- cumulative page/mutation/applied/duplicate/stale counters

The existing `index_checkpoints` rebuild cursor is not read, reset, or repurposed. Reconciliation therefore cannot alter a completed M6 rebuild or its checkpoint identity.

## Bounded execution

`IndexReconciliationRunRequest` validates:

- source page limit through `IndexSourceScanRequest`
- 1–1024 pages per invocation
- heartbeat cadence within the page budget
- 1–8 complete passes
- whole-second lease duration from 1–86400 seconds

The runner resolves the source from `SharedIndexSourceRegistry`, validates all page event UUIDs before the first write, applies mutations through `PostgresMutationStore`, then persists the fenced job cursor. Page-budget exhaustion yields to immediately claimable pending state. Expired work is reclaimed with an incremented attempt fence; stale attempts cannot publish progress or terminal state.

Cancellation is observed before and after page work and wins over progress, success, failure, or yield when committed first.

## Product and tombstones

No Product-specific code exists in the runner. Product and ProductVariant sources already expose live rows plus their retained hard-delete tombstones. Running two complete passes against those unchanged registered sources catches a live or deleted identity that appeared behind the first pass cursor.

Deterministic source event IDs make repeated rows duplicate-safe; monotonic source versions make older rows stale-safe.

## Concurrency limit

This narrows but does not eliminate the concurrent-write window. An identity can still be inserted behind the cursor during the final pass. The PR therefore does **not** claim:

- a repeatable-read owner snapshot
- a source high-watermark
- a quiescence barrier
- persisted Product v2 tenant readiness
- authoritative Storefront cutover

Those require a later snapshot/watermark or retained convergence-evidence slice.

## Ownership boundary

`rustok-index` owns the generic reconciliation job, lease fencing, durable cursor, cancellation, and mutation application. It imports no Product, Channel, Search, Storefront, or tombstone table implementation.

The runner starts no task, owns no scheduler, performs no sleeps, and adds no dependency or `Cargo.lock` change.

## Static recheck findings addressed

- kept `PostgresIndexReplayRunner` and rebuild checkpoint code unchanged
- used the already-reserved `reconcile` job kind and existing job cursor column
- kept source cursors opaque and bounded by `IndexSourceCursor`
- persisted progress only after every mutation result is durable
- made page retry safe through deterministic delivery IDs
- kept pass/page/lease dimensions bounded
- retained cancellation and attempt fencing
- documented the unresolved final-pass concurrency window
- verified no changed-file overlap with the parallel `main` commits

## Explicitly open

- owner snapshot/exported-snapshot or high-watermark protocol
- incremental Product event catch-up and acknowledgement
- automatic retry/backoff/dead-letter scheduling and graceful task shutdown
- tombstone purge admission against all consumer checkpoints
- persisted Product/ProductVariant v2 tenant schema application
- retained PostgreSQL insert-behind-cursor, delete/recreate, restart, reclaim, drift, and convergence evidence
- authoritative Storefront cutover
- durable Product/ProductVariant-to-SalesChannel UUID relations

## Validation

Not run by the implementation agent, per owner request. The repository owner will run formatting, Cargo checks/tests, JavaScript guards, PostgreSQL checks, and CI.

Suggested owner commands:

```bash
node scripts/verify/verify-index-source-reconciliation.mjs
node scripts/verify/verify-index-query-contract.mjs
cargo check -p rustok-index --all-targets
cargo test -p rustok-index source_reconciliation_runner -- --nocapture
```

## Branch state

Base: `main`
Branch: `agent/index-m7-product-reconciliation-20260731`

Parallel commits since the merge base do not overlap this reconciliation slice. Squash merge is recommended after owner validation.