### PR TITLE
test(blog): register comment projection unit harness

### DIFF
--- a/crates/rustok-blog/contracts/blog-fba-registry.json
+++ b/crates/rustok-blog/contracts/blog-fba-registry.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 10,
+  "schema_version": 11,
   "module": "blog",
   "role": "consumer",
   "status": "boundary_ready",
@@ -111,6 +111,7 @@
         "test_package_script": "test:verify:blog:comments-event-projection",
         "verifier": "scripts/verify/verify-blog-comments-event-projection.mjs",
         "self_test": "scripts/verify/verify-blog-comments-event-projection.test.mjs",
+        "unit_test": "crates/rustok-blog/src/services/comment_projection.rs",
         "evidence": "crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json"
       },
       "category_search_reindex": {
@@ -159,11 +160,20 @@
   },
   "event_projection": {
     "provider": "comments",
-    "events": ["comment.created", "comment.deleted"],
+    "events": [
+      "comment.created",
+      "comment.deleted"
+    ],
     "handler": "BlogCommentProjectionHandler",
     "delivery_ledger": "blog_comment_projection_deliveries",
     "publication": "BlogPostUpdated through rustok_outbox::TransactionalEventBus::publish_in_tx",
-    "status": "implemented_static_only"
+    "status": "implemented_static_only",
+    "runtime_status": "pending",
+    "source_harness": {
+      "path": "crates/rustok-blog/src/services/comment_projection.rs",
+      "status": "executable_no_run",
+      "command": "cargo test -p rustok-blog --lib services::comment_projection::tests"
+    }
   },
   "contract_tests": {
     "status": "source_verified_no_compile",

--- a/crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "module": "blog",
   "surface": "comments_event_projection",
   "status": "source_verified_no_compile",
@@ -19,7 +19,22 @@
     "module_registration": "crates/rustok-blog/src/lib.rs",
     "consumer_registry": "crates/rustok-blog/contracts/blog-fba-registry.json"
   },
+  "source_harness": {
+    "status": "executable_no_run",
+    "path": "crates/rustok-blog/src/services/comment_projection.rs",
+    "module": "services::comment_projection::tests",
+    "command": "cargo test -p rustok-blog --lib services::comment_projection::tests",
+    "cases": [
+      "shared_created_deleted_classifier",
+      "non_blog_target_rejection",
+      "non_negative_saturating_counter_transition"
+    ]
+  },
   "cases": [
+    {
+      "name": "shared_event_classifier",
+      "expected": "project and EventHandler::handles use the same pure classifier for Comments lifecycle events"
+    },
     {
       "name": "blog_post_target_filter",
       "expected": "only Comments lifecycle events whose target_type is blog_post are projected"
@@ -46,7 +61,7 @@
     },
     {
       "name": "non_negative_count",
-      "expected": "delete projection floors the Blog-owned comment count at zero"
+      "expected": "the pure counter transition floors deletes at zero and saturates count and version overflow"
     },
     {
       "name": "module_listener_registration",
@@ -54,6 +69,7 @@
     }
   ],
   "runtime_promotion_requirements": [
+    "execute cargo test -p rustok-blog --lib services::comment_projection::tests",
     "execute duplicate and out-of-order comment.created/comment.deleted deliveries against PostgreSQL",
     "retain proof that the counter, delivery ledger, and BlogPostUpdated outbox row commit or roll back together",
     "retain missing-post retry and later recovery evidence",

--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -64,11 +64,12 @@ guarded by `scripts/verify/verify-comments-thread-write-invariants.mjs` and focu
 self-test `scripts/verify/verify-comments-thread-write-invariants.test.mjs`. Exact
 commands `verify:comments:thread-write-invariants` and
 `test:verify:comments:thread-write-invariants` are registered in Comments registry
-schema v2 and the Comments FBA verify/test chains. Evidence schema v2 also locks
-an owner-classified tenant/target identity marker: canonical lookup occurs only
-for that expected first-thread conflict, while unrelated insert storage errors
-propagate as typed database failures. Blog consumes the owner result and does not
-duplicate thread locking, counter policy, or error classification.
+schema v4 and the Comments FBA verify/test chains. Evidence schema v3 locks an
+owner-classified tenant/target identity marker with a valid canonical thread UUID,
+the registered Rust classifier harness, canonical lookup only for the expected
+first-thread conflict, and typed propagation of unrelated insert storage errors.
+Blog consumes the owner result and does not duplicate thread locking, counter
+policy, or error classification.
 
 The Comments consumer call surface is now a first-class Blog source boundary.
 `CommentService` depends on `Arc<dyn CommentsThreadPort>`, uses the in-process
@@ -93,14 +94,22 @@ Comments lifecycle projection into Blog-owned `comment_count` is a Blog consumer
 boundary. `BlogCommentProjectionHandler` accepts only `comment.created` and
 `comment.deleted` for `blog_post`, uses the envelope id as the durable delivery
 identity, and commits the tenant-scoped optimistic count update, delivery row,
-and `BlogPostUpdated` outbox publication in one transaction. The retained source
-evidence is `crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json`,
+and `BlogPostUpdated` outbox publication in one transaction. `project()` and
+`EventHandler::handles()` share the pure `comment_projection_change` classifier,
+and the pure counter transition floors deletes at zero while saturating count and
+version overflow. Evidence schema v2 is retained at
+`crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json`,
 guarded by `scripts/verify/verify-blog-comments-event-projection.mjs` and focused
-fixture `scripts/verify/verify-blog-comments-event-projection.test.mjs`. Exact
+fixture `scripts/verify/verify-blog-comments-event-projection.test.mjs`. The Rust
+source harness is the `services::comment_projection::tests` module in
+`crates/rustok-blog/src/services/comment_projection.rs`, with status
+`executable_no_run` and suggested command
+`cargo test -p rustok-blog --lib services::comment_projection::tests`. Exact
 commands `verify:blog:comments-event-projection` and
 `test:verify:blog:comments-event-projection` run after the Comments port gate in
-the Blog FBA chains. Status remains `source_verified_no_compile`; runtime delivery
-and recovery evidence is not recorded.
+the Blog FBA chains. Overall status remains `source_verified_no_compile`;
+runtime delivery and recovery, duplicate ledger behavior, rollback, restart, and
+PostgreSQL evidence are not recorded.
 
 Blog categories use the exclusive `blog_categories:*` permission resource.
 `CategoryService::new(db, event_bus)` is the only owner constructor. Category
@@ -209,26 +218,40 @@ race, propagates unrelated storage errors, upgrades its retained invariant
 evidence to schema v2, and adds focused negatives. Blog receives the corrected
 typed provider result without adding a consumer-side classifier.
 
+## 2026-07-31 source continuation audit
+
+The continuation audit at `ea72eb8679ccecc16fcfd3ae895e14333fa33232`
+found that the Comments event projection had a static transaction/ledger gate but
+no executable Rust harness for event classification or counter transition policy.
+`project()` and `EventHandler::handles()` also encoded classification separately,
+allowing future source drift between dispatch and projection. Slice 44 extracts a
+shared pure classifier and counter transition, adds three unit cases, upgrades the
+evidence to schema v2 and Blog registry schema v11, and extends both the focused
+and aggregate fail-closed guards. No Rust test, verifier, compile, database,
+workflow, browser, or CI execution is recorded.
+
 ## FFA/FBA status
 
 - FFA status: `in_progress`.
 - FBA status: `boundary_ready` (`core_transport_ui`).
-- Blog FBA source-gate chain: `source_verified_no_compile`; registry schema v10
+- Blog FBA source-gate chain: `source_verified_no_compile`; registry schema v11
   locks exact verify/test order, source-gate paths, leaf npm commands, evidence,
-  self-tests, and aggregate/consumer bindings for admin, storefront, Comments
-  port boundary, Comments event projection, category Search reindex, GraphQL rate
-  limiting, GraphQL richtext, AI richtext, offline backfill, Forum ownership, and
-  runtime order.
+  self-tests, the Comments projection unit harness, and aggregate/consumer
+  bindings for admin, storefront, Comments port boundary, Comments event
+  projection, category Search reindex, GraphQL rate limiting, GraphQL richtext,
+  AI richtext, offline backfill, Forum ownership, and runtime order.
 - Comments consumer port boundary: Blog-owned `source_verified_no_compile` for
   the in-process profile; all seven operations, approved public read, typed
   richtext projection, two-second deadlines, write idempotency, active typed
   `PortErrorKind` mapping, exact npm leaf commands, focused fixture, and Blog FBA
   ordering are locked. The remote adapter and degraded UI modes remain planned;
   runtime evidence is pending.
-- Comments event projection: Blog-owned `source_verified_no_compile`; evidence,
-  verifier, focused self-test, exact npm leaf commands, delivery-ledger identity,
-  transactional outbox markers, and Blog FBA ordering are locked. Duplicate,
-  out-of-order, retry, rollback, restart, and PostgreSQL execution remain pending.
+- Comments event projection: Blog-owned `source_verified_no_compile`; evidence
+  schema v2, shared classifier/counter helpers, `executable_no_run` Rust unit
+  harness, verifier, focused self-test, exact npm leaf commands, delivery-ledger
+  identity, transactional outbox markers, and Blog FBA ordering are locked.
+  Duplicate, out-of-order, retry, rollback, restart, and PostgreSQL execution
+  remain pending.
 - Load protection: `implementation_ready`; mounted Redis evidence is pending.
 - Rate-limit harness: `executable_no_compile`; evidence, verifier, self-test,
   npm leaf commands, and aggregate FBA registration are locked; execution is
@@ -244,7 +267,7 @@ typed provider result without adding a consumer-side classifier.
 - Blog storefront richtext boundary: `source_verified_no_compile`.
 - AI Blog draft owner writes and shim: `source_verified_no_compile`.
 - Comments thread write invariants: Comments-owned `executable_no_run`; registry
-  schema v2, evidence schema v2, owner identity classifier, guarded canonical
+  schema v4, evidence schema v3, owner identity classifier, guarded canonical
   fallback, unrelated-storage propagation, verifier, focused self-test, exact npm
   leaf commands, Rust targets, and Comments FBA ordering are locked. PostgreSQL
   and injected storage-error execution remain maintainer-owned.
@@ -384,6 +407,10 @@ typed provider result without adding a consumer-side classifier.
     tenant/target-scoped identity-conflict classifier, narrowed canonical fallback,
     propagated unrelated storage errors, upgraded owner evidence to schema v2, and
     retained all runtime and PostgreSQL proof as maintainer-owned.
+44. Extracted a shared pure Comments event classifier and saturating counter
+    transition, added three Rust unit cases, upgraded event evidence to schema v2
+    and Blog registry schema v11, and extended focused/aggregate source guards
+    without recording execution.
 
 ## Next results
 
@@ -401,12 +428,12 @@ typed provider result without adding a consumer-side classifier.
    controller handoff, focused verifier, then Redis-backed host requests with a
    real HTTP `Retry-After` matching GraphQL `retryAfter`.
 5. **Close comments runtime evidence.** Run the Comments port boundary fixture,
-   shared consumer runtime-order verifier, both thread invariant concurrency
-   targets, and concurrent PostgreSQL create/delete transactions; cover the
-   remote adapter, degraded UI modes, approved-only reads, moderation, pagination,
-   duplicate delivery, counters, first-thread identity, unrelated insert storage
-   error propagation, missing-post retry, rollback, outbox publication, and restart
-   recovery.
+   shared consumer runtime-order verifier, the Blog projection unit harness, both
+   thread invariant concurrency targets, and concurrent PostgreSQL create/delete
+   transactions; cover the remote adapter, degraded UI modes, approved-only reads,
+   moderation, pagination, duplicate delivery, counters, first-thread identity,
+   unrelated insert storage error propagation, missing-post retry, rollback,
+   outbox publication, and restart recovery.
 6. **Execute and retain Blog article richtext cutover evidence.** Run the offline
    backfill in default dry-run mode, review its report, apply accepted conversion,
    execute the irreversible migration, reindex/rollback Search, and retain
@@ -422,6 +449,7 @@ should run the relevant subset, including:
 - `npm run test:verify:blog:comments-port-boundary`
 - `npm run verify:blog:comments-event-projection`
 - `npm run test:verify:blog:comments-event-projection`
+- `cargo test -p rustok-blog --lib services::comment_projection::tests`
 - `npm run verify:blog:category-search-reindex`
 - `npm run test:verify:blog:category-search-reindex`
 - `npm run verify:blog:graphql-rate-limit`

--- a/crates/rustok-blog/src/services/comment_projection.rs
+++ b/crates/rustok-blog/src/services/comment_projection.rs
@@ -9,12 +9,53 @@ use sea_orm::{
     QueryFilter, Set, TransactionTrait, sea_query::Expr,
 };
 use std::sync::Arc;
+use uuid::Uuid;
 
 use crate::entities::{blog_comment_projection_delivery, blog_post};
 
 const BLOG_POST_TARGET_TYPE: &str = "blog_post";
 const FALLBACK_LOCALE: &str = "en";
 const MAX_PROJECTION_UPDATE_ATTEMPTS: usize = 8;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct CommentProjectionChange {
+    comment_id: Uuid,
+    post_id: Uuid,
+    delta: i32,
+}
+
+fn comment_projection_change(event: &DomainEvent) -> Option<CommentProjectionChange> {
+    match event {
+        DomainEvent::CommentCreated {
+            comment_id,
+            target_type,
+            target_id,
+            ..
+        } if target_type == BLOG_POST_TARGET_TYPE => Some(CommentProjectionChange {
+            comment_id: *comment_id,
+            post_id: *target_id,
+            delta: 1,
+        }),
+        DomainEvent::CommentDeleted {
+            comment_id,
+            target_type,
+            target_id,
+            ..
+        } if target_type == BLOG_POST_TARGET_TYPE => Some(CommentProjectionChange {
+            comment_id: *comment_id,
+            post_id: *target_id,
+            delta: -1,
+        }),
+        _ => None,
+    }
+}
+
+fn next_comment_projection_state(comment_count: i32, version: i32, delta: i32) -> (i32, i32) {
+    (
+        comment_count.saturating_add(delta).max(0),
+        version.saturating_add(1),
+    )
+}
 
 /// Projects Comments lifecycle events into Blog-owned reply-count state.
 ///
@@ -33,20 +74,8 @@ impl BlogCommentProjectionHandler {
     }
 
     async fn project(&self, envelope: &EventEnvelope) -> HandlerResult {
-        let (comment_id, post_id, delta) = match &envelope.event {
-            DomainEvent::CommentCreated {
-                comment_id,
-                target_type,
-                target_id,
-                ..
-            } if target_type == BLOG_POST_TARGET_TYPE => (*comment_id, *target_id, 1),
-            DomainEvent::CommentDeleted {
-                comment_id,
-                target_type,
-                target_id,
-                ..
-            } if target_type == BLOG_POST_TARGET_TYPE => (*comment_id, *target_id, -1),
-            _ => return Ok(()),
+        let Some(change) = comment_projection_change(&envelope.event) else {
+            return Ok(());
         };
 
         let txn = self.db.begin().await?;
@@ -59,7 +88,13 @@ impl BlogCommentProjectionHandler {
             return Ok(());
         }
 
-        update_comment_count_in_tx(&txn, envelope.tenant_id, post_id, delta).await?;
+        update_comment_count_in_tx(
+            &txn,
+            envelope.tenant_id,
+            change.post_id,
+            change.delta,
+        )
+        .await?;
 
         // The delivery marker is committed with the counter and outbox event. If
         // a concurrent duplicate wins this unique insert, this transaction rolls
@@ -67,9 +102,9 @@ impl BlogCommentProjectionHandler {
         blog_comment_projection_delivery::ActiveModel {
             event_id: Set(envelope.id),
             tenant_id: Set(envelope.tenant_id),
-            comment_id: Set(comment_id),
-            post_id: Set(post_id),
-            delta: Set(delta),
+            comment_id: Set(change.comment_id),
+            post_id: Set(change.post_id),
+            delta: Set(change.delta),
             processed_at: Set(Utc::now().into()),
         }
         .insert(&txn)
@@ -81,7 +116,7 @@ impl BlogCommentProjectionHandler {
                 envelope.tenant_id,
                 envelope.actor_id,
                 DomainEvent::BlogPostUpdated {
-                    post_id,
+                    post_id: change.post_id,
                     locale: FALLBACK_LOCALE.to_string(),
                 },
             )
@@ -93,8 +128,8 @@ impl BlogCommentProjectionHandler {
 
 async fn update_comment_count_in_tx(
     txn: &DatabaseTransaction,
-    tenant_id: uuid::Uuid,
-    post_id: uuid::Uuid,
+    tenant_id: Uuid,
+    post_id: Uuid,
     delta: i32,
 ) -> HandlerResult {
     for _ in 0..MAX_PROJECTION_UPDATE_ATTEMPTS {
@@ -108,8 +143,8 @@ async fn update_comment_count_in_tx(
             )));
         };
 
-        let next_comment_count = post.comment_count.saturating_add(delta).max(0);
-        let next_version = post.version.saturating_add(1);
+        let (next_comment_count, next_version) =
+            next_comment_projection_state(post.comment_count, post.version, delta);
         let result = blog_post::Entity::update_many()
             .col_expr(
                 blog_post::Column::CommentCount,
@@ -143,15 +178,79 @@ impl EventHandler for BlogCommentProjectionHandler {
     }
 
     fn handles(&self, event: &DomainEvent) -> bool {
-        matches!(
-            event,
-            DomainEvent::CommentCreated { target_type, .. }
-                | DomainEvent::CommentDeleted { target_type, .. }
-                if target_type == BLOG_POST_TARGET_TYPE
-        )
+        comment_projection_change(event).is_some()
     }
 
     async fn handle(&self, envelope: &EventEnvelope) -> HandlerResult {
         self.project(envelope).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(value: u128) -> Uuid {
+        Uuid::from_u128(value)
+    }
+
+    #[test]
+    fn classifies_blog_comment_lifecycle_events() {
+        let created = DomainEvent::CommentCreated {
+            comment_id: id(1),
+            target_type: BLOG_POST_TARGET_TYPE.to_string(),
+            target_id: id(2),
+            author_id: id(3),
+        };
+        let deleted = DomainEvent::CommentDeleted {
+            comment_id: id(4),
+            target_type: BLOG_POST_TARGET_TYPE.to_string(),
+            target_id: id(5),
+            author_id: id(6),
+        };
+
+        assert_eq!(
+            comment_projection_change(&created),
+            Some(CommentProjectionChange {
+                comment_id: id(1),
+                post_id: id(2),
+                delta: 1,
+            })
+        );
+        assert_eq!(
+            comment_projection_change(&deleted),
+            Some(CommentProjectionChange {
+                comment_id: id(4),
+                post_id: id(5),
+                delta: -1,
+            })
+        );
+    }
+
+    #[test]
+    fn ignores_non_blog_targets_and_unrelated_events() {
+        let other_target = DomainEvent::CommentCreated {
+            comment_id: id(7),
+            target_type: "forum_topic".to_string(),
+            target_id: id(8),
+            author_id: id(9),
+        };
+        let unrelated = DomainEvent::BlogPostUpdated {
+            post_id: id(10),
+            locale: "en".to_string(),
+        };
+
+        assert_eq!(comment_projection_change(&other_target), None);
+        assert_eq!(comment_projection_change(&unrelated), None);
+    }
+
+    #[test]
+    fn counter_transition_is_non_negative_and_saturating() {
+        assert_eq!(next_comment_projection_state(4, 11, 1), (5, 12));
+        assert_eq!(next_comment_projection_state(0, 11, -1), (0, 12));
+        assert_eq!(
+            next_comment_projection_state(i32::MAX, i32::MAX, 1),
+            (i32::MAX, i32::MAX)
+        );
     }
 }

--- a/scripts/verify/blog-fba-verification-chain.mjs
+++ b/scripts/verify/blog-fba-verification-chain.mjs
@@ -42,6 +42,7 @@ export const BLOG_FBA_SOURCE_GATES = {
     test_package_script: 'test:verify:blog:comments-event-projection',
     verifier: 'scripts/verify/verify-blog-comments-event-projection.mjs',
     self_test: 'scripts/verify/verify-blog-comments-event-projection.test.mjs',
+    unit_test: 'crates/rustok-blog/src/services/comment_projection.rs',
     evidence: 'crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json',
   },
   category_search_reindex: {
@@ -168,7 +169,8 @@ export function collectBlogFbaVerificationChainFailures({
     if (
       gate?.verifier !== expectedGate.verifier ||
       gate?.self_test !== expectedGate.self_test ||
-      gate?.evidence !== expectedGate.evidence
+      gate?.evidence !== expectedGate.evidence ||
+      gate?.unit_test !== expectedGate.unit_test
     ) {
       failures.push(`registry source gate ${gateName} path drift`);
     }
@@ -189,7 +191,12 @@ export function collectBlogFbaVerificationChainFailures({
       failures.push(`package source gate ${gateName} test command drift`);
     }
 
-    for (const filePath of [expectedGate.verifier, expectedGate.self_test, expectedGate.evidence]) {
+    for (const filePath of [
+      expectedGate.verifier,
+      expectedGate.self_test,
+      expectedGate.evidence,
+      expectedGate.unit_test,
+    ].filter(Boolean)) {
       if (!existsSync(filePath)) {
         failures.push(`registry source gate ${gateName} missing ${filePath}`);
       }

--- a/scripts/verify/verify-blog-comments-event-projection.mjs
+++ b/scripts/verify/verify-blog-comments-event-projection.mjs
@@ -38,6 +38,7 @@ const migrationRegistryPath = 'crates/rustok-blog/src/migrations/mod.rs';
 const modulePath = 'crates/rustok-blog/src/lib.rs';
 const registryPath = 'crates/rustok-blog/contracts/blog-fba-registry.json';
 const planPath = 'crates/rustok-blog/docs/implementation-plan.md';
+const harnessCommand = 'cargo test -p rustok-blog --lib services::comment_projection::tests';
 
 const handler = read(handlerPath);
 const serviceExport = read(serviceExportPath);
@@ -62,29 +63,51 @@ try {
 for (const marker of [
   'const BLOG_POST_TARGET_TYPE: &str = "blog_post";',
   'const MAX_PROJECTION_UPDATE_ATTEMPTS: usize = 8;',
+  'struct CommentProjectionChange',
+  'fn comment_projection_change(event: &DomainEvent) -> Option<CommentProjectionChange>',
   'DomainEvent::CommentCreated',
-  'if target_type == BLOG_POST_TARGET_TYPE => (*comment_id, *target_id, 1)',
+  'delta: 1',
   'DomainEvent::CommentDeleted',
-  'if target_type == BLOG_POST_TARGET_TYPE => (*comment_id, *target_id, -1)',
-  '_ => return Ok(())',
+  'delta: -1',
+  'fn next_comment_projection_state(comment_count: i32, version: i32, delta: i32)',
+  'comment_count.saturating_add(delta).max(0)',
+  'version.saturating_add(1)',
+  'let Some(change) = comment_projection_change(&envelope.event) else',
   'let txn = self.db.begin().await?;',
   'blog_comment_projection_delivery::Entity::find_by_id(envelope.id)',
-  'update_comment_count_in_tx(&txn, envelope.tenant_id, post_id, delta).await?;',
+  'change.post_id',
+  'change.delta',
   'event_id: Set(envelope.id)',
+  'comment_id: Set(change.comment_id)',
   '.insert(&txn)',
   '.publish_in_tx(',
   'DomainEvent::BlogPostUpdated',
   'txn.commit().await?;',
   'Column::TenantId.eq(tenant_id)',
   'Column::Version.eq(post.version)',
-  'post.comment_count.saturating_add(delta).max(0)',
+  'next_comment_projection_state(post.comment_count, post.version, delta)',
   'if result.rows_affected == 1',
   'Error::NotFound',
   'impl EventHandler for BlogCommentProjectionHandler',
+  'comment_projection_change(event).is_some()',
+  '#[cfg(test)]',
+  'fn classifies_blog_comment_lifecycle_events()',
+  'fn ignores_non_blog_targets_and_unrelated_events()',
+  'fn counter_transition_is_non_negative_and_saturating()',
 ]) {
   requireMarker(handler, marker, handlerPath);
 }
 requireNoMarker(handler, 'public.blog_posts', handlerPath);
+
+const handlesStart = handler.indexOf('fn handles(&self, event: &DomainEvent) -> bool');
+const handleStart = handler.indexOf('async fn handle(&self, envelope: &EventEnvelope)', handlesStart);
+if (handlesStart === -1 || handleStart === -1) {
+  failures.push(`${handlerPath}: missing EventHandler handles/handle boundary`);
+} else {
+  const handlesBody = handler.slice(handlesStart, handleStart);
+  requireMarker(handlesBody, 'comment_projection_change(event).is_some()', `${handlerPath}: handles`);
+  requireNoMarker(handlesBody, 'matches!(', `${handlerPath}: handles`);
+}
 
 for (const marker of [
   '#[sea_orm(table_name = "blog_comment_projection_deliveries")]',
@@ -123,7 +146,7 @@ for (const marker of [
 }
 
 if (evidence) {
-  if (evidence.schema_version !== 1) failures.push(`${evidencePath}: schema_version drift`);
+  if (evidence.schema_version !== 2) failures.push(`${evidencePath}: schema_version drift`);
   if (
     evidence.module !== 'blog' ||
     evidence.surface !== 'comments_event_projection' ||
@@ -146,12 +169,32 @@ if (evidence) {
   })) {
     if (contract[key] !== expected) failures.push(`${evidencePath}: ${key} drift`);
   }
+  const sourceHarness = evidence.source_harness ?? {};
+  if (
+    sourceHarness.status !== 'executable_no_run' ||
+    sourceHarness.path !== handlerPath ||
+    sourceHarness.module !== 'services::comment_projection::tests' ||
+    sourceHarness.command !== harnessCommand
+  ) {
+    failures.push(`${evidencePath}: source harness drift`);
+  }
+  const harnessCases = [...(sourceHarness.cases ?? [])].sort().join('|');
+  if (
+    harnessCases !== [
+      'shared_created_deleted_classifier',
+      'non_blog_target_rejection',
+      'non_negative_saturating_counter_transition',
+    ].sort().join('|')
+  ) {
+    failures.push(`${evidencePath}: source harness case drift`);
+  }
   const events = [...(evidence.events ?? [])].sort().join('|');
   if (events !== ['comment.created', 'comment.deleted'].sort().join('|')) {
     failures.push(`${evidencePath}: event set drift`);
   }
   const cases = new Set((evidence.cases ?? []).map((entry) => entry.name));
   for (const requiredCase of [
+    'shared_event_classifier',
     'blog_post_target_filter',
     'created_deleted_delta',
     'envelope_idempotency',
@@ -174,9 +217,21 @@ if (registry) {
     projection.provider !== 'comments' ||
     projection.handler !== 'BlogCommentProjectionHandler' ||
     projection.delivery_ledger !== 'blog_comment_projection_deliveries' ||
-    projection.status !== 'implemented_static_only'
+    projection.status !== 'implemented_static_only' ||
+    projection.runtime_status !== 'pending'
   ) {
     failures.push(`${registryPath}: event projection metadata drift`);
+  }
+  if (
+    projection.source_harness?.path !== handlerPath ||
+    projection.source_harness?.status !== 'executable_no_run' ||
+    projection.source_harness?.command !== harnessCommand
+  ) {
+    failures.push(`${registryPath}: event projection source harness drift`);
+  }
+  const sourceGate = registry.verification_chain?.source_gates?.comments_event_projection;
+  if (sourceGate?.unit_test !== handlerPath) {
+    failures.push(`${registryPath}: comments event projection unit test path drift`);
   }
 }
 
@@ -185,6 +240,7 @@ for (const marker of [
   'verify:blog:comments-event-projection',
   'test:verify:blog:comments-event-projection',
   'source_verified_no_compile',
+  'services::comment_projection::tests',
   'runtime delivery and recovery',
 ]) {
   requireMarker(plan, marker, planPath);
@@ -196,4 +252,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log('Blog comments event projection source contract is consistent');
+console.log('Blog comments event projection source contract and unit harness are consistent');

--- a/scripts/verify/verify-blog-comments-event-projection.test.mjs
+++ b/scripts/verify/verify-blog-comments-event-projection.test.mjs
@@ -20,7 +20,11 @@ function fixture({
   missingDeliveryLookup = false,
   missingOutbox = false,
   missingRegistration = false,
+  missingSharedClassifier = false,
+  directHandlesClassifier = false,
+  missingCounterHarness = false,
   statusDrift = false,
+  harnessStatusDrift = false,
 } = {}) {
   const root = mkdtempSync(path.join(tmpdir(), 'rustok-blog-comments-projection-'));
   const evidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json';
@@ -31,6 +35,7 @@ function fixture({
   const migrationRegistryPath = 'crates/rustok-blog/src/migrations/mod.rs';
   const modulePath = 'crates/rustok-blog/src/lib.rs';
   const registryPath = 'crates/rustok-blog/contracts/blog-fba-registry.json';
+  const harnessCommand = 'cargo test -p rustok-blog --lib services::comment_projection::tests';
 
   write(
     root,
@@ -38,22 +43,38 @@ function fixture({
     `
 const BLOG_POST_TARGET_TYPE: &str = "blog_post";
 const MAX_PROJECTION_UPDATE_ATTEMPTS: usize = 8;
-DomainEvent::CommentCreated if target_type == BLOG_POST_TARGET_TYPE => (*comment_id, *target_id, 1)
-DomainEvent::CommentDeleted if target_type == BLOG_POST_TARGET_TYPE => (*comment_id, *target_id, -1)
-_ => return Ok(())
+struct CommentProjectionChange
+${missingSharedClassifier ? '' : 'fn comment_projection_change(event: &DomainEvent) -> Option<CommentProjectionChange>'}
+DomainEvent::CommentCreated
+delta: 1
+DomainEvent::CommentDeleted
+delta: -1
+fn next_comment_projection_state(comment_count: i32, version: i32, delta: i32)
+comment_count.saturating_add(delta).max(0)
+version.saturating_add(1)
+${missingSharedClassifier ? '' : 'let Some(change) = comment_projection_change(&envelope.event) else'}
 let txn = self.db.begin().await?;
 ${missingDeliveryLookup ? '' : 'blog_comment_projection_delivery::Entity::find_by_id(envelope.id)'}
-update_comment_count_in_tx(&txn, envelope.tenant_id, post_id, delta).await?;
+update_comment_count_in_tx(&txn, envelope.tenant_id, change.post_id, change.delta).await?;
 event_id: Set(envelope.id)
+comment_id: Set(change.comment_id)
 .insert(&txn)
 ${missingOutbox ? '' : '.publish_in_tx( DomainEvent::BlogPostUpdated'}
 txn.commit().await?;
 ${missingTenantScope ? '' : 'Column::TenantId.eq(tenant_id)'}
 Column::Version.eq(post.version)
-post.comment_count.saturating_add(delta).max(0)
+next_comment_projection_state(post.comment_count, post.version, delta)
 if result.rows_affected == 1
 Error::NotFound
 impl EventHandler for BlogCommentProjectionHandler
+fn handles(&self, event: &DomainEvent) -> bool {
+  ${directHandlesClassifier ? 'matches!(event, DomainEvent::CommentCreated { .. })' : 'comment_projection_change(event).is_some()'}
+}
+async fn handle(&self, envelope: &EventEnvelope)
+#[cfg(test)]
+fn classifies_blog_comment_lifecycle_events()
+fn ignores_non_blog_targets_and_unrelated_events()
+${missingCounterHarness ? '' : 'fn counter_transition_is_non_negative_and_saturating()'}
 `,
   );
   write(root, serviceExportPath, 'pub use comment_projection::BlogCommentProjectionHandler;');
@@ -101,7 +122,7 @@ registry.register(services::BlogCommentProjectionHandler::new(ctx.db.clone()));`
     root,
     evidencePath,
     JSON.stringify({
-      schema_version: 1,
+      schema_version: 2,
       module: 'blog',
       surface: 'comments_event_projection',
       status: statusDrift ? 'runtime_verified' : 'source_verified_no_compile',
@@ -118,7 +139,19 @@ registry.register(services::BlogCommentProjectionHandler::new(ctx.db.clone()));`
         module_registration: modulePath,
         consumer_registry: registryPath,
       },
+      source_harness: {
+        status: harnessStatusDrift ? 'executed' : 'executable_no_run',
+        path: handlerPath,
+        module: 'services::comment_projection::tests',
+        command: harnessCommand,
+        cases: [
+          'shared_created_deleted_classifier',
+          'non_blog_target_rejection',
+          'non_negative_saturating_counter_transition',
+        ],
+      },
       cases: [
+        { name: 'shared_event_classifier' },
         { name: 'blog_post_target_filter' },
         { name: 'created_deleted_delta' },
         { name: 'envelope_idempotency' },
@@ -135,18 +168,29 @@ registry.register(services::BlogCommentProjectionHandler::new(ctx.db.clone()));`
     registryPath,
     JSON.stringify({
       evidence: { comments_event_projection: evidencePath },
+      verification_chain: {
+        source_gates: {
+          comments_event_projection: { unit_test: handlerPath },
+        },
+      },
       event_projection: {
         provider: 'comments',
         handler: 'BlogCommentProjectionHandler',
         delivery_ledger: 'blog_comment_projection_deliveries',
         status: 'implemented_static_only',
+        runtime_status: 'pending',
+        source_harness: {
+          path: handlerPath,
+          status: 'executable_no_run',
+          command: harnessCommand,
+        },
       },
     }),
   );
   write(
     root,
     'crates/rustok-blog/docs/implementation-plan.md',
-    'blog-comments-event-projection.json verify:blog:comments-event-projection test:verify:blog:comments-event-projection source_verified_no_compile runtime delivery and recovery',
+    'blog-comments-event-projection.json verify:blog:comments-event-projection test:verify:blog:comments-event-projection source_verified_no_compile services::comment_projection::tests runtime delivery and recovery',
   );
 
   return root;
@@ -206,12 +250,56 @@ test('rejects missing module event-listener registration', () => {
   }
 });
 
+test('rejects project without the shared event classifier', () => {
+  const root = fixture({ missingSharedClassifier: true });
+  try {
+    const result = run(root);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /missing fn comment_projection_change/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects a separate EventHandler classifier', () => {
+  const root = fixture({ directHandlesClassifier: true });
+  try {
+    const result = run(root);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /forbidden matches!/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects a missing counter transition harness', () => {
+  const root = fixture({ missingCounterHarness: true });
+  try {
+    const result = run(root);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /missing fn counter_transition_is_non_negative_and_saturating/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('rejects runtime status promotion without execution', () => {
   const root = fixture({ statusDrift: true });
   try {
     const result = run(root);
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /status drift/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects source harness execution promotion without execution', () => {
+  const root = fixture({ harnessStatusDrift: true });
+  try {
+    const result = run(root);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /source harness drift/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/verify/verify-blog-fba.mjs
+++ b/scripts/verify/verify-blog-fba.mjs
@@ -16,6 +16,8 @@ const evidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-consum
 const runtimeSmokePath = 'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json';
 const consumerRuntimeOrderSmokePath = 'crates/rustok-blog/contracts/evidence/blog-comments-consumer-runtime-order-smoke.json';
 const commentsEventProjectionPath = 'crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json';
+const projectionHandlerPath = 'crates/rustok-blog/src/services/comment_projection.rs';
+const projectionHarnessCommand = 'cargo test -p rustok-blog --lib services::comment_projection::tests';
 const richtextInventoryPath = 'crates/rustok-blog/contracts/evidence/blog-richtext-cutover-inventory.json';
 const richtextInventoryDocPath = 'crates/rustok-blog/docs/richtext-cutover-inventory.md';
 const categorySearchReindexPath = 'crates/rustok-blog/contracts/evidence/blog-category-search-reindex-contract.json';
@@ -35,7 +37,7 @@ const aiRichtextBoundary = json(aiRichtextBoundaryPath);
 const provider = json(providerPath);
 const packageJson = json(packageJsonPath);
 
-if (registry.schema_version !== 10) fail('registry schema_version drift');
+if (registry.schema_version !== 11) fail('registry schema_version drift');
 if (registry.module !== 'blog' || registry.role !== 'consumer' || !['in_progress', 'boundary_ready'].includes(registry.status)) fail('registry identity/status drift');
 for (const failure of collectBlogFbaVerificationChainFailures({
   registry,
@@ -46,8 +48,15 @@ for (const failure of collectBlogFbaVerificationChainFailures({
 }
 if (registry.consumer_profile !== 'blog_post_comments') fail('consumer profile drift');
 if (registry.evidence.comments_event_projection !== commentsEventProjectionPath) fail('comments event projection registry path drift');
+if (commentsEventProjection.schema_version !== 2) fail('comments event projection schema_version drift');
 if (commentsEventProjection.module !== 'blog' || commentsEventProjection.surface !== 'comments_event_projection' || commentsEventProjection.owner !== 'rustok-blog' || commentsEventProjection.provider !== 'rustok-comments') fail('comments event projection identity drift');
 if (commentsEventProjection.status !== 'source_verified_no_compile' || commentsEventProjection.compile_policy !== 'not_run_by_request') fail('comments event projection status drift');
+if (
+  commentsEventProjection.source_harness?.status !== 'executable_no_run'
+  || commentsEventProjection.source_harness?.path !== projectionHandlerPath
+  || commentsEventProjection.source_harness?.module !== 'services::comment_projection::tests'
+  || commentsEventProjection.source_harness?.command !== projectionHarnessCommand
+) fail('comments event projection source harness drift');
 if (registry.evidence.richtext_cutover_inventory !== richtextInventoryPath) fail('richtext cutover inventory registry path drift');
 if (registry.evidence.richtext_cutover_inventory_doc !== richtextInventoryDocPath) fail('richtext cutover inventory doc registry path drift');
 if (registry.evidence.category_search_reindex !== categorySearchReindexPath) fail('category Search reindex registry path drift');
@@ -63,6 +72,7 @@ const dependency = registry.provider_dependencies?.[0];
 if (!dependency) fail('missing comments provider dependency');
 if (dependency.module !== 'comments' || dependency.registry !== providerPath) fail('provider dependency identity drift');
 if (dependency.contract_version !== provider.contract_version || dependency.port !== 'CommentsThreadPort') fail('provider contract/port drift');
+if (provider.schema_version !== 4) fail('comments provider registry schema_version drift');
 if (provider.module !== 'comments' || provider.role !== 'provider' || !['in_progress', 'boundary_ready'].includes(provider.status)) fail('comments provider status drift');
 sameSet(dependency.operations, provider.ports?.[0]?.operations ?? [], 'consumer/provider operations');
 sameSet(dependency.fallback_profiles, provider.consumers?.find(c => c.module === 'blog')?.fallback_profiles ?? [], 'consumer/provider fallback profiles');
@@ -222,20 +232,45 @@ if (directCommentsCalls.length !== 0) {
 }
 hasAll(service, ['comments_thread_port', '.create_comment(', '.delete_comment('], 'comments port lifecycle migration');
 const projection = registry.event_projection;
-if (!projection || projection.provider !== 'comments' || projection.handler !== 'BlogCommentProjectionHandler' || projection.delivery_ledger !== 'blog_comment_projection_deliveries' || projection.status !== 'implemented_static_only') fail('event projection registry drift');
+if (
+  !projection
+  || projection.provider !== 'comments'
+  || projection.handler !== 'BlogCommentProjectionHandler'
+  || projection.delivery_ledger !== 'blog_comment_projection_deliveries'
+  || projection.status !== 'implemented_static_only'
+  || projection.runtime_status !== 'pending'
+) fail('event projection registry drift');
 sameSet(projection.events, ['comment.created', 'comment.deleted'], 'event projection event types');
-const projectionSource = read('crates/rustok-blog/src/services/comment_projection.rs');
-hasAll(projectionSource, ['impl EventHandler for BlogCommentProjectionHandler', 'DomainEvent::CommentCreated', 'DomainEvent::CommentDeleted', 'blog_comment_projection_delivery::Entity::find_by_id', 'DomainEvent::BlogPostUpdated', '.publish_in_tx('], 'blog comment projection');
+if (
+  projection.source_harness?.path !== projectionHandlerPath
+  || projection.source_harness?.status !== 'executable_no_run'
+  || projection.source_harness?.command !== projectionHarnessCommand
+) fail('event projection registry source harness drift');
+if (registry.verification_chain?.source_gates?.comments_event_projection?.unit_test !== projectionHandlerPath) fail('event projection source-gate unit test drift');
+const projectionSource = read(projectionHandlerPath);
+hasAll(projectionSource, [
+  'impl EventHandler for BlogCommentProjectionHandler',
+  'fn comment_projection_change(event: &DomainEvent) -> Option<CommentProjectionChange>',
+  'let Some(change) = comment_projection_change(&envelope.event) else',
+  'comment_projection_change(event).is_some()',
+  'fn next_comment_projection_state(comment_count: i32, version: i32, delta: i32)',
+  'fn classifies_blog_comment_lifecycle_events()',
+  'fn ignores_non_blog_targets_and_unrelated_events()',
+  'fn counter_transition_is_non_negative_and_saturating()',
+  'blog_comment_projection_delivery::Entity::find_by_id',
+  'DomainEvent::BlogPostUpdated',
+  '.publish_in_tx(',
+], 'blog comment projection');
 const migration = read('crates/rustok-blog/src/migrations/m20260716_000001_create_blog_comment_projection_deliveries.rs');
 hasAll(migration, ['BlogCommentProjectionDeliveries', 'EventId', 'TenantId', 'PostId'], 'blog comment projection migration');
 const moduleSource = read('crates/rustok-blog/src/lib.rs');
 hasAll(moduleSource, ['fn register_event_listeners(', 'BlogCommentProjectionHandler::new(ctx.db.clone())'], 'blog event-listener registration');
 
 const plan = read('crates/rustok-blog/docs/implementation-plan.md');
-hasAll(plan, ['- FBA status: `boundary_ready`', 'blog-fba-registry.json', commentsEventProjectionPath, categorySearchReindexPath, graphqlRateLimitPath, aiRichtextBoundaryPath, 'CommentsThreadPort', 'blog-comments-consumer-static-matrix.json', 'blog-comments-runtime-fallback-smoke.json', consumerRuntimeOrderSmokePath, 'verify:blog:comments-port-boundary', 'test:verify:blog:comments-port-boundary', 'verify:blog:comments-event-projection', 'test:verify:blog:comments-event-projection', 'degraded UI modes remain planned'], 'local plan');
+hasAll(plan, ['- FBA status: `boundary_ready`', 'blog-fba-registry.json', commentsEventProjectionPath, categorySearchReindexPath, graphqlRateLimitPath, aiRichtextBoundaryPath, 'CommentsThreadPort', 'blog-comments-consumer-static-matrix.json', 'blog-comments-runtime-fallback-smoke.json', consumerRuntimeOrderSmokePath, 'verify:blog:comments-port-boundary', 'test:verify:blog:comments-port-boundary', 'verify:blog:comments-event-projection', 'test:verify:blog:comments-event-projection', 'services::comment_projection::tests', 'registry schema v11', 'degraded UI modes remain planned'], 'local plan');
 const central = read('docs/modules/registry.md');
 hasAll(central, ['| `blog` |', 'crates/rustok-blog/contracts/blog-fba-registry.json', 'blog-comments-runtime-fallback-smoke.json', consumerRuntimeOrderSmokePath, '`in_progress` | `boundary_ready`'], 'central registry');
 const unified = read('docs/research/fluid-backend-architecture-unified-plan.md');
 hasAll(unified, ['`blog`', 'CommentsThreadPort', 'blog-fba-registry.json'], 'unified plan');
 
-console.log('[verify-blog-fba] Blog FBA registry, exact admin/storefront/comments-port/comments-projection/category/rate-limit/GraphQL/AI richtext source-gate chain, comments consumer metadata, and no-compile evidence are consistent');
+console.log('[verify-blog-fba] Blog FBA registry, exact admin/storefront/comments-port/comments-projection/category/rate-limit/GraphQL/AI richtext source-gate chain, Comments projection unit harness, consumer metadata, and no-compile evidence are consistent');

--- a/scripts/verify/verify-blog-fba.test.mjs
+++ b/scripts/verify/verify-blog-fba.test.mjs
@@ -50,7 +50,8 @@ function canonicalExistingPaths() {
       gate.verifier,
       gate.self_test,
       gate.evidence,
-    ]),
+      gate.unit_test,
+    ].filter(Boolean)),
   ]);
 }
 
@@ -106,6 +107,17 @@ test('Blog FBA verification-chain policy rejects source-gate path drift', () => 
   const registry = canonicalRegistry();
   registry.verification_chain.source_gates.storefront_boundary.evidence = 'wrong/storefront-evidence.json';
   assert.ok(failures({ registry }).includes('registry source gate storefront_boundary path drift'));
+});
+
+test('Blog FBA verification-chain policy rejects projection unit-test path drift', () => {
+  const registry = canonicalRegistry();
+  registry.verification_chain.source_gates.comments_event_projection.unit_test =
+    'crates/rustok-blog/src/services/wrong_projection.rs';
+  assert.ok(
+    failures({ registry }).includes(
+      'registry source gate comments_event_projection path drift',
+    ),
+  );
 });
 
 test('Blog FBA verification-chain policy rejects registry leaf-script drift', () => {
@@ -167,6 +179,16 @@ test('Blog FBA verification-chain policy rejects a missing leaf self-test file',
   assert.ok(
     failures({ existingPaths }).includes(
       `registry source gate richtext_offline_backfill missing ${BLOG_FBA_SOURCE_GATES.richtext_offline_backfill.self_test}`,
+    ),
+  );
+});
+
+test('Blog FBA verification-chain policy rejects a missing projection unit-test source', () => {
+  const existingPaths = canonicalExistingPaths();
+  existingPaths.delete(BLOG_FBA_SOURCE_GATES.comments_event_projection.unit_test);
+  assert.ok(
+    failures({ existingPaths }).includes(
+      `registry source gate comments_event_projection missing ${BLOG_FBA_SOURCE_GATES.comments_event_projection.unit_test}`,
     ),
   );
 });


### PR DESCRIPTION
## Summary

- extract one pure Comments lifecycle classifier and use it from both `project()` and `EventHandler::handles()`
- extract the Blog-owned comment-count/version transition with non-negative and saturating semantics
- add three inline Rust unit cases for create/delete classification, non-Blog rejection, and counter transitions
- upgrade Comments event-projection evidence to schema v2 and Blog FBA registry to schema v11
- retain the Rust harness as `executable_no_run` in the existing projection source gate and shared Blog chain policy
- extend focused and aggregate fail-closed guards for classifier drift, missing unit coverage, missing source registration, and false execution promotion
- reconcile stale Blog-plan references with Comments registry schema v4 and thread evidence schema v3

## Why

The projection transaction, delivery ledger, and outbox path were source-guarded, but event classification was encoded separately in `project()` and `handles()`. The leaf also had no executable Rust harness for classification and the pure counter transition, so dispatch and projection could drift while static markers continued to pass.

## Validation

Not run by request. No verifier, unit test, Rust test, compile, database, browser, workflow, or CI command was executed.

Suggested maintainer commands:

```bash
npm run verify:blog:comments-event-projection
npm run test:verify:blog:comments-event-projection
npm run verify:blog:fba
npm run test:verify:blog:fba
cargo test -p rustok-blog --lib services::comment_projection::tests
```

Duplicate delivery, out-of-order delivery, rollback, missing-post recovery, restart recovery, optimistic-update exhaustion, and PostgreSQL execution remain pending.