### PR TITLE
fix(payment): sanitize compensation wrapper diagnostics

### DIFF
--- a/crates/rustok-payment/contracts/evidence/checkout-compensation-wrapper-diagnostic-safety-source-review.json
+++ b/crates/rustok-payment/contracts/evidence/checkout-compensation-wrapper-diagnostic-safety-source-review.json
@@ -1,0 +1,26 @@
+{
+  "status": "payment_checkout_compensation_wrapper_diagnostic_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-payment/src/checkout_compensation_context.rs",
+    "crates/rustok-payment/src/checkout_compensation.rs",
+    "crates/rustok-payment/src/checkout_compensation_api.rs",
+    "crates/rustok-payment/src/lib.rs",
+    "crates/rustok-payment/docs/checkout-compensation-local-context.md",
+    "scripts/verify/verify-payment-checkout-compensation-local-context.mjs"
+  ],
+  "review_findings": {
+    "public_wrapper_construction_preserved": true,
+    "persistent_owner_delegation_preserved": true,
+    "stable_code_only_classifier_present": true,
+    "message_pair_classifier_removed_from_wrapper": true,
+    "same_port_error_returned": true,
+    "safe_context_shape_only": true,
+    "safe_request_shape_only": true,
+    "raw_identifier_logging_removed_from_wrapper": true,
+    "provider_cancel_and_replay_policy_preserved": true,
+    "persistent_owner_source_unchanged": true,
+    "persistent_owner_diagnostic_cleanup_complete": false,
+    "runtime_evidence_claimed": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed."
+}

--- a/crates/rustok-payment/contracts/evidence/checkout-compensation-wrapper-diagnostic-safety-source-review.json
+++ b/crates/rustok-payment/contracts/evidence/checkout-compensation-wrapper-diagnostic-safety-source-review.json
@@ -6,7 +6,10 @@
     "crates/rustok-payment/src/checkout_compensation_api.rs",
     "crates/rustok-payment/src/lib.rs",
     "crates/rustok-payment/docs/checkout-compensation-local-context.md",
-    "scripts/verify/verify-payment-checkout-compensation-local-context.mjs"
+    "crates/rustok-payment/docs/checkout-execution-local-context.md",
+    "crates/rustok-payment/docs/implementation-plan.md",
+    "scripts/verify/verify-payment-checkout-compensation-local-context.mjs",
+    "scripts/verify/verify-payment-checkout-execution-local-context.mjs"
   ],
   "review_findings": {
     "public_wrapper_construction_preserved": true,
@@ -20,6 +23,8 @@
     "provider_cancel_and_replay_policy_preserved": true,
     "persistent_owner_source_unchanged": true,
     "persistent_owner_diagnostic_cleanup_complete": false,
+    "execution_guard_aligned_with_current_wrapper": true,
+    "broad_commerce_cleanup_remains_open": true,
     "runtime_evidence_claimed": false
   },
   "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed."

--- a/crates/rustok-payment/contracts/evidence/checkout-compensation-wrapper-diagnostic-safety-source.json
+++ b/crates/rustok-payment/contracts/evidence/checkout-compensation-wrapper-diagnostic-safety-source.json
@@ -1,0 +1,53 @@
+{
+  "status": "payment_checkout_compensation_wrapper_diagnostic_safety_source_unvalidated",
+  "scope": {
+    "owner": "rustok_payment",
+    "operation": "compensate_checkout_payment",
+    "boundary": "checkout_payment_compensation_port",
+    "layer": "public_context_wrapper"
+  },
+  "source_contract": {
+    "stable_code_only_local_classification": true,
+    "human_message_control_flow": false,
+    "delegated_port_error_changed": false,
+    "public_code_changed": false,
+    "public_message_changed": false,
+    "public_kind_changed": false,
+    "public_retryability_changed": false,
+    "owner_delegation_changed": false,
+    "request_response_dto_changed": false,
+    "persistent_owner_source_changed": false,
+    "provider_cancel_policy_changed": false,
+    "provider_journal_policy_changed": false,
+    "raw_tenant_id_logged_by_wrapper": false,
+    "raw_actor_id_logged_by_wrapper": false,
+    "raw_channel_logged_by_wrapper": false,
+    "raw_locale_logged_by_wrapper": false,
+    "raw_causation_id_logged_by_wrapper": false,
+    "raw_traceparent_logged_by_wrapper": false,
+    "raw_idempotency_key_logged_by_wrapper": false,
+    "raw_checkout_operation_id_logged_by_wrapper": false,
+    "raw_collection_id_logged_by_wrapper": false,
+    "raw_reason_logged_by_wrapper": false,
+    "raw_metadata_logged_by_wrapper": false,
+    "safe_context_shape_logged": true,
+    "safe_request_shape_logged": true,
+    "correlation_id_logged": true,
+    "original_port_error_private": true,
+    "persistent_owner_diagnostic_cleanup_complete": false,
+    "broad_ecommerce_cleanup_closed": false
+  },
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "provider_replay_proven": false,
+    "restart_proven": false,
+    "remote_port_proven": false,
+    "mounted_runtime_proven": false
+  }
+}

--- a/crates/rustok-payment/docs/checkout-compensation-local-context.md
+++ b/crates/rustok-payment/docs/checkout-compensation-local-context.md
@@ -1,153 +1,136 @@
-# Payment checkout compensation local and admission context
+# Payment checkout compensation wrapper diagnostic safety
 
 Status: **source-ready / unvalidated**
 
 ## Scope
 
-This slice closes correlation-safe local context retention for the canonical payment compensation owner boundary:
+This slice hardens the public context wrapper around the canonical payment compensation owner boundary:
 
 - `CheckoutPaymentCompensationPort::compensate_checkout_payment`;
-- root `InProcessCheckoutPaymentCompensationPort`;
+- public `InProcessCheckoutPaymentCompensationPort`;
 - root `in_process_checkout_payment_compensation_port`;
 - the compatibility namespace `rustok_payment::checkout_compensation::*`.
 
-The persistent state machine in `checkout_compensation.rs` remains behaviorally unchanged. It is now loaded as a private module. Both the crate root and the public `checkout_compensation` namespace expose the context wrapper, so callers cannot bypass safe local diagnostics by choosing the legacy module path.
+The wrapper still delegates the original `PortContext` and request to the private persistent owner in
+`checkout_compensation.rs`. Provider cancellation, journal adoption, lifecycle policy, local
+cancellation, and reconciliation behavior remain in that persistent owner and are unchanged here.
 
-## Public module facade
+## Public construction
 
-`lib.rs` loads the sources as separate layers:
+`lib.rs` preserves the existing layered facade:
 
-- `checkout_compensation.rs` becomes private `checkout_compensation_persistent`;
+- `checkout_compensation.rs` is loaded privately as `checkout_compensation_persistent`;
 - `checkout_compensation_context.rs` owns the public wrapper implementation;
-- `checkout_compensation_api.rs` is the public module facade.
+- `checkout_compensation_api.rs` preserves the public module namespace;
+- crate-root exports resolve to the wrapper type and factory.
 
-The facade preserves the existing public names:
-
-- `CheckoutPaymentCompensationPort`;
-- `CheckoutPaymentCompensationRequest`;
-- `InProcessCheckoutPaymentCompensationPort`;
-- `in_process_checkout_payment_compensation_port`.
-
-The trait and request continue to be the original owner contracts. The public type and factory now always resolve to the context wrapper. The persistent implementation type and factory are not publicly re-exported.
+Callers therefore continue to use the same public trait, request, type, and factory names without a
+public persistent-implementation bypass.
 
 ## Delegation order
 
-The wrapper performs no new lifecycle or provider policy. Its source order is:
+The public operation keeps this source order:
 
-1. clone the incoming `PortContext` for diagnostics;
-2. retain safe request facts;
-3. delegate the original context and request to the unchanged persistent owner;
+1. clone the incoming `PortContext` for post-delegation diagnostics;
+2. retain safe request-shape facts;
+3. delegate the original context and request to the persistent owner;
 4. inspect only a returned `PortError`;
-5. classify only exact stable `code + message` pairs;
+5. classify known outcomes from stable `PortError.code`;
 6. return the same `PortError` unchanged.
 
-The persistent owner continues to own write policy, write semantics, tenant parsing, checkout-operation causation, optional-collection no-op behavior, identity validation, lifecycle admission, provider journal recovery, provider cancellation, local cancellation, and commit checkpointing.
+Human-readable `PortError.message` is not used as control flow. Unknown codes pass through without an
+additional wrapper event.
 
-## Admission outcomes
+The two previous message-specific labels behind
+`payment.checkout_compensation_state_conflict` are intentionally represented by one stable wrapper
+label, `apply_compensation_state`, because the public message is no longer a routing discriminator.
 
-The public wrapper now retains full context for the two stable admission envelopes returned before compensation work begins:
+## Safe wrapper context
 
-| Stable envelope | Local operation | Severity |
-| --- | --- | --- |
-| `port.idempotency_key_required` / `write port calls require a non-empty idempotency key` | `admit_write_idempotency` | warning |
-| `port.deadline_required` / `port calls require deadline semantics` | `admit_deadline` | error |
+The per-call correlation id remains available for joining diagnostics. Other `PortContext` values are
+recorded only as shape facts:
 
-The timeout kind for a missing deadline is classified as technical. A missing idempotency key remains an ordinary validation rejection. No code, message, kind, retryability, or execution order changes.
+- tenant, actor-id, channel, locale, causation-id, traceparent, and idempotency-key lengths;
+- actor kind;
+- claim and role counts;
+- presence flags for optional values;
+- deadline milliseconds.
 
-Tenant parsing and checkout-operation causation errors remain pass-through. The persistent owner already emits their owner-local events; the wrapper deliberately avoids a duplicate local event for those outcomes.
+The wrapper no longer records raw tenant id, actor id, channel, locale, causation id, traceparent, or
+idempotency key.
 
-## Retained request facts
+Request facts are also shape-only:
 
-Covered diagnostics retain:
-
-- checkout operation id;
-- optional payment collection id;
-- optional compensation-reason character length;
+- checkout-operation UUID non-nil state;
+- collection-id presence and non-nil state;
+- reason presence and character length;
 - metadata JSON kind;
 - object-field or array-element count when applicable.
 
-The raw compensation reason and metadata value are never recorded. Metadata can contain arbitrary caller and provider data, and reason is unvalidated before owner normalization.
+The wrapper does not log checkout-operation ids, collection ids, reason text, or metadata values.
+The original typed `PortError` remains private to structured tracing.
 
-## Covered stable owner outcomes
+## Stable-code attribution
 
-The exact mapper also retains the existing local classification for:
+The wrapper recognizes stable codes for:
 
+- write idempotency and deadline admission;
 - invalid compensation identity;
-- collection/payment/refund not found;
+- collection, payment, and refund lookup;
 - manual reconciliation;
-- payment and compensation lifecycle conflicts;
+- compensation lifecycle/state conflicts;
 - unsupported provider-journal state;
-- invalid provider metadata or conflicting provider identity;
-- provider request encoding failure;
-- storage unavailability and owner validation;
-- provider unavailable, rejected, invalid response, or missing configuration.
+- provider metadata and provider identity validation;
+- provider cancel request encoding;
+- payment storage and owner validation;
+- provider unavailable, rejected, invalid response, and missing configuration outcomes.
 
-Unavailable, timeout, and invariant outcomes use error severity. Manual reconciliation and unsupported durable provider-journal state also use error severity. Ordinary validation, not-found, rejection, identity, lifecycle, and concurrent-state conflicts use warning severity.
+Unavailable, timeout, and invariant kinds use error severity. Manual reconciliation and unsupported
+provider-journal state also use error severity. Other recognized outcomes use warning severity.
 
-## Retained diagnostic context
+No public error is reconstructed. Code, message, kind, retryability, and return identity remain those
+of the delegated `PortError`.
 
-Covered outcomes record:
+## Preserved persistent-owner behavior
 
-- truthful owner `rustok_payment`;
-- public operation `compensate_checkout_payment`;
-- operation-specific local label;
-- boundary `checkout_payment_compensation_port`;
-- correlation id and tenant id;
-- typed actor, channel, and locale;
-- causation id and traceparent;
-- idempotency key and deadline;
-- safe request facts;
-- exact stable code and message;
-- typed error kind and retryability;
-- the complete delegated `PortError`.
-
-## Preserved behavior
-
-This work does not change:
+This slice does not change:
 
 - compensation request or response DTOs;
-- public codes, messages, kinds, or retryability;
-- write policy, write semantics, tenant, or causation validation;
+- write policy, deadline, idempotency, tenant, or causation admission;
 - optional missing-collection no-op behavior;
 - captured-payment refund-policy reconciliation;
 - payment collection lifecycle classification;
 - provider selection or manual-provider fallback;
 - canonical `payment_collection:{collection_id}:cancel` idempotency key;
 - provider request metadata and `cancel_payment_collection` marker;
-- provider journal begin, claim, replay, error, success, and reconciliation checkpoints;
+- provider journal begin, claim, replay, error, success, commit, or reconciliation transitions;
 - provider payment identity recovery;
 - local cancellation race handling;
 - final provider-operation commit checkpoint;
-- commerce payment-before-order-before-inventory-before-cart compensation ordering;
-- provider-registry constructor behavior.
+- provider-registry constructor behavior;
+- Commerce compensation ordering;
+- public `PortError` envelopes;
+- Payment FFA/FBA status.
 
 ## Static evidence
 
-`scripts/verify/verify-payment-checkout-compensation-local-context.mjs` guards:
+- `crates/rustok-payment/contracts/evidence/checkout-compensation-wrapper-diagnostic-safety-source.json`
+- `crates/rustok-payment/contracts/evidence/checkout-compensation-wrapper-diagnostic-safety-source-review.json`
+- `scripts/verify/verify-payment-checkout-compensation-local-context.mjs`
 
-- private persistent source and public facade module wiring;
-- root and module-path wrapper type/factory exports;
-- absence of a public persistent type/factory bypass;
-- wrapper constructor delegation for default and provider-registry construction;
-- context and safe-fact retention before unchanged owner delegation;
-- exact admission and owner-outcome classification;
-- same delegated `PortError` return;
-- length/shape-only payload evidence and absence of raw reason/metadata diagnostics;
-- complete `PortContext`, request-fact, and typed error fields;
-- tenant and causation pass-through;
-- unchanged persistent policy, provider idempotency key, journal, cancellation, and checkpoint markers;
-- mounted Commerce use of root contracts and wrapper construction.
+The focused verifier guards wrapper/facade construction, context and request shape, stable-code-only
+classification, absence of raw wrapper fields, unchanged persistent owner markers, same-error return,
+and source-only validation flags.
 
 ## Remaining gaps
 
-The ecommerce correlation-safe mapper task remains open for:
+The persistent owner in `checkout_compensation.rs` still contains raw tenant, causation,
+checkout-operation, collection, and provider-journal operation identifiers in owner-local diagnostics.
+It remains the next separate Payment compensation diagnostic-safety slice.
 
-- broader compensation tenant/causation diagnostic enrichment without duplicate events;
-- direct payment GraphQL and HTTP query/mutation envelopes;
-- remaining order, fulfillment, inventory, customer, tax, promotion, ecommerce adapter, and non-`PortError` envelopes;
-- compile, provider replay, restart, remote-port, and cross-transport runtime evidence.
-
-No FBA or FFA status is promoted from source inspection alone.
+The broad ecommerce correlation-safe mapper item also remains open for remaining owner adapters,
+non-`PortError` envelopes, and runtime evidence. No FBA or FFA status is promoted from source
+inspection.
 
 ## Suggested maintainer checks
 
@@ -155,7 +138,7 @@ These commands were intentionally not run by the implementation agent:
 
 ```bash
 node scripts/verify/verify-payment-checkout-compensation-local-context.mjs
-node scripts/verify/verify-commerce-checkout-compensation-payment-order-context.mjs
+node scripts/verify/verify-payment-checkout-execution-local-context.mjs
 node scripts/verify/verify-commerce-checkout-compensation-owner-boundary.mjs
 node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
 cargo check -p rustok-payment --lib

--- a/crates/rustok-payment/docs/checkout-execution-local-context.md
+++ b/crates/rustok-payment/docs/checkout-execution-local-context.md
@@ -65,7 +65,7 @@ This slice does not change:
 - `PaymentError` to public `PortError` mapping;
 - public codes, messages, kinds, or retryability;
 - successful results or replay adoption;
-- payment compensation source or contracts;
+- payment compensation persistent owner or contracts;
 - Payment FFA/FBA status.
 
 The original internal error remains private to structured tracing.
@@ -80,14 +80,20 @@ The verifier guards code-only classification, safe context/request shape, forbid
 value logging, unchanged public envelopes, unchanged owner delegation, and source-only
 validation flags.
 
+## Related compensation boundary
+
+The public Payment checkout compensation wrapper now also uses stable-code-only
+attribution and safe context/request shape. Its separate evidence is maintained in the
+compensation documentation and verifier.
+
+The private persistent compensation owner still contains raw owner-local identifier
+diagnostics and remains a separate cleanup. This execution slice does not claim that work.
+
 ## Remaining gaps
 
-Payment checkout compensation still uses message-pair classification and raw context/
-identifier diagnostics. It remains the next separate owner-boundary cleanup.
-
-The broad ecommerce correlation-safe mapper item also remains open for remaining owner
-adapters, non-`PortError` envelopes, and runtime evidence. No FBA or FFA status is
-promoted from source inspection.
+The broad ecommerce correlation-safe mapper item remains open for persistent compensation,
+remaining owner adapters, non-`PortError` envelopes, and runtime evidence. No FBA or FFA
+status is promoted from source inspection.
 
 ## Suggested maintainer checks
 
@@ -96,6 +102,7 @@ These commands were intentionally not run by the implementation agent:
 ```bash
 node scripts/verify/verify-payment-checkout-execution-local-context.mjs
 node scripts/verify/verify-payment-checkout-execution-error-safety.mjs
+node scripts/verify/verify-payment-checkout-compensation-local-context.mjs
 node scripts/verify/verify-commerce-checkout-owner-stage-boundary.mjs
 node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
 cargo check -p rustok-payment --lib

--- a/crates/rustok-payment/docs/implementation-plan.md
+++ b/crates/rustok-payment/docs/implementation-plan.md
@@ -104,14 +104,21 @@ tenant/causation, provider-result, owner-error, manual-reconciliation, and deleg
 outcome diagnostics now retain correlation plus safe context/request shape only.
 Local-operation attribution uses stable `PortError.code` and no longer depends on
 human-readable public messages. Public `PortError` envelopes and all execution
-semantics remain unchanged. Checkout compensation diagnostic cleanup remains open as
-a separate source slice.
+semantics remain unchanged.
+
+Payment checkout compensation wrapper diagnostic safety:
+`source_ready_unvalidated`. The public context wrapper uses stable-code-only local
+attribution, retains correlation plus safe context/request shape, and returns the
+same delegated `PortError`. The private persistent compensation owner remains
+behaviorally unchanged; its owner-local raw identifier diagnostics remain the next
+separate source cleanup.
 
 Boundary guards:
 
 - `npm run verify:payment:storefront-boundary`
 - `node scripts/verify/verify-payment-storefront-native-client-error-safety.mjs`
 - `node scripts/verify/verify-payment-checkout-execution-local-context.mjs`
+- `node scripts/verify/verify-payment-checkout-compensation-local-context.mjs`
 - `node scripts/verify/verify-commerce-checkout-compensation-owner-boundary.mjs`
 - `node scripts/verify/verify-commerce-checkout-owner-stage-boundary.mjs`
 - `node scripts/verify/verify-payment-typed-lifecycle-statuses.mjs`

--- a/crates/rustok-payment/src/checkout_compensation_context.rs
+++ b/crates/rustok-payment/src/checkout_compensation_context.rs
@@ -4,7 +4,6 @@ use async_trait::async_trait;
 use rustok_api::{PortContext, PortError, PortErrorKind};
 use sea_orm::DatabaseConnection;
 use serde_json::Value;
-use uuid::Uuid;
 
 use crate::checkout_compensation_persistent::{
     CheckoutPaymentCompensationPort, CheckoutPaymentCompensationRequest,
@@ -17,9 +16,29 @@ const PAYMENT_OWNER: &str = "rustok_payment";
 const COMPENSATE_CHECKOUT_PAYMENT_OPERATION: &str = "compensate_checkout_payment";
 const PAYMENT_COMPENSATION_BOUNDARY: &str = "checkout_payment_compensation_port";
 
+struct CheckoutPaymentCompensationContextFacts {
+    tenant_id_length: usize,
+    actor_kind: &'static str,
+    actor_id_length: usize,
+    claim_count: usize,
+    role_count: usize,
+    channel_present: bool,
+    channel_length: Option<usize>,
+    locale_length: usize,
+    causation_id_present: bool,
+    causation_id_length: Option<usize>,
+    traceparent_present: bool,
+    traceparent_length: Option<usize>,
+    idempotency_key_present: bool,
+    idempotency_key_length: Option<usize>,
+    deadline_ms: Option<u64>,
+}
+
 struct CheckoutPaymentCompensationDiagnosticFacts {
-    checkout_operation_id: Uuid,
-    collection_id: Option<Uuid>,
+    checkout_operation_id_non_nil: bool,
+    collection_id_present: bool,
+    collection_id_non_nil: Option<bool>,
+    reason_present: bool,
     reason_length: Option<usize>,
     metadata_kind: &'static str,
     metadata_entry_count: Option<usize>,
@@ -78,12 +97,50 @@ impl CheckoutPaymentCompensationPort for InProcessCheckoutPaymentCompensationPor
     }
 }
 
+fn checkout_payment_compensation_context_facts(
+    context: &PortContext,
+) -> CheckoutPaymentCompensationContextFacts {
+    let actor_kind = match &context.actor.kind {
+        rustok_api::PortActorKind::User => "user",
+        rustok_api::PortActorKind::Service => "service",
+        rustok_api::PortActorKind::System => "system",
+    };
+    CheckoutPaymentCompensationContextFacts {
+        tenant_id_length: context.tenant_id.chars().count(),
+        actor_kind,
+        actor_id_length: context.actor.id.chars().count(),
+        claim_count: context.claims.len(),
+        role_count: context.roles.len(),
+        channel_present: context.channel.is_some(),
+        channel_length: context.channel.as_ref().map(|value| value.chars().count()),
+        locale_length: context.locale.chars().count(),
+        causation_id_present: context.causation_id.is_some(),
+        causation_id_length: context
+            .causation_id
+            .as_ref()
+            .map(|value| value.chars().count()),
+        traceparent_present: context.traceparent.is_some(),
+        traceparent_length: context
+            .traceparent
+            .as_ref()
+            .map(|value| value.chars().count()),
+        idempotency_key_present: context.idempotency_key.is_some(),
+        idempotency_key_length: context
+            .idempotency_key
+            .as_ref()
+            .map(|value| value.chars().count()),
+        deadline_ms: context.deadline_ms,
+    }
+}
+
 fn checkout_payment_compensation_diagnostic_facts(
     request: &CheckoutPaymentCompensationRequest,
 ) -> CheckoutPaymentCompensationDiagnosticFacts {
     CheckoutPaymentCompensationDiagnosticFacts {
-        checkout_operation_id: request.checkout_operation_id,
-        collection_id: request.collection_id,
+        checkout_operation_id_non_nil: !request.checkout_operation_id.is_nil(),
+        collection_id_present: request.collection_id.is_some(),
+        collection_id_non_nil: request.collection_id.map(|value| !value.is_nil()),
+        reason_present: request.reason.is_some(),
         reason_length: request.reason.as_ref().map(|value| value.chars().count()),
         metadata_kind: payment_metadata_kind(&request.metadata),
         metadata_entry_count: match &request.metadata {
@@ -105,81 +162,50 @@ fn payment_metadata_kind(metadata: &Value) -> &'static str {
     }
 }
 
+fn checkout_payment_compensation_local_operation(code: &str) -> Option<&'static str> {
+    match code {
+        "port.idempotency_key_required" => Some("admit_write_idempotency"),
+        "port.deadline_required" => Some("admit_deadline"),
+        "payment.checkout_compensation_identity_invalid" => {
+            Some("validate_compensation_identity")
+        }
+        "payment.collection_not_found" => Some("load_collection"),
+        "payment.checkout_compensation_manual_reconciliation" => {
+            Some("require_manual_reconciliation")
+        }
+        "payment.checkout_compensation_state_conflict" => Some("apply_compensation_state"),
+        "payment.checkout_compensation_provider_state_conflict" => {
+            Some("validate_provider_journal_state")
+        }
+        "payment.checkout_compensation_metadata_invalid" => Some("validate_provider_metadata"),
+        "payment.checkout_compensation_provider_identity_conflict" => {
+            Some("validate_provider_identity")
+        }
+        "payment.checkout_compensation_encoding_failed" => {
+            Some("encode_provider_cancel_request")
+        }
+        "payment.database_unavailable" => Some("owner_storage"),
+        "payment.checkout_compensation_validation" => Some("validate_owner_request"),
+        "payment.payment_not_found" => Some("load_payment"),
+        "payment.refund_not_found" => Some("load_refund"),
+        "payment.provider_unavailable" | "payment.provider_rejected" => {
+            Some("execute_provider_cancel")
+        }
+        "payment.provider_invalid_response" => Some("normalize_provider_result"),
+        "payment.provider_not_configured" => Some("resolve_provider"),
+        _ => None,
+    }
+}
+
 fn map_checkout_payment_compensation_local_port_error(
     context: &PortContext,
     facts: &CheckoutPaymentCompensationDiagnosticFacts,
     error: PortError,
 ) -> PortError {
-    let local_operation = match (error.code.as_str(), error.message.as_str()) {
-        (
-            "port.idempotency_key_required",
-            "write port calls require a non-empty idempotency key",
-        ) => "admit_write_idempotency",
-        ("port.deadline_required", "port calls require deadline semantics") => {
-            "admit_deadline"
-        }
-        (
-            "payment.checkout_compensation_identity_invalid",
-            "checkout operation and payment collection identity must be non-nil UUIDs",
-        ) => "validate_compensation_identity",
-        ("payment.collection_not_found", "payment collection was not found") => {
-            "load_collection"
-        }
-        (
-            "payment.checkout_compensation_manual_reconciliation",
-            "payment checkout compensation requires manual reconciliation",
-        ) => "require_manual_reconciliation",
-        (
-            "payment.checkout_compensation_state_conflict",
-            "payment collection changed while compensation was being applied",
-        ) => "apply_compensation_state",
-        (
-            "payment.checkout_compensation_state_conflict",
-            "payment lifecycle conflicts with checkout compensation",
-        ) => "apply_payment_lifecycle",
-        (
-            "payment.checkout_compensation_provider_state_conflict",
-            "payment provider cancellation is in an unsupported state",
-        ) => "validate_provider_journal_state",
-        (
-            "payment.checkout_compensation_metadata_invalid",
-            "payment compensation metadata must be a JSON object",
-        ) => "validate_provider_metadata",
-        (
-            "payment.checkout_compensation_provider_identity_conflict",
-            "payment provider identity conflicts with the durable authorization",
-        ) => "validate_provider_identity",
-        (
-            "payment.checkout_compensation_encoding_failed",
-            "payment compensation request could not be encoded",
-        ) => "encode_provider_cancel_request",
-        (
-            "payment.database_unavailable",
-            "payment storage is temporarily unavailable",
-        ) => "owner_storage",
-        (
-            "payment.checkout_compensation_validation",
-            "payment compensation request is invalid",
-        ) => "validate_owner_request",
-        ("payment.payment_not_found", "payment was not found") => "load_payment",
-        ("payment.refund_not_found", "refund was not found") => "load_refund",
-        (
-            "payment.provider_unavailable",
-            "payment provider is temporarily unavailable",
-        ) => "execute_provider_cancel",
-        (
-            "payment.provider_rejected",
-            "payment provider rejected the requested operation",
-        ) => "execute_provider_cancel",
-        (
-            "payment.provider_invalid_response",
-            "payment provider response could not be applied safely",
-        ) => "normalize_provider_result",
-        (
-            "payment.provider_not_configured",
-            "payment provider is not configured",
-        ) => "resolve_provider",
-        _ => return error,
+    let Some(local_operation) =
+        checkout_payment_compensation_local_operation(error.code.as_str())
+    else {
+        return error;
     };
     let integrity_failure = matches!(
         local_operation,
@@ -190,6 +216,7 @@ fn map_checkout_payment_compensation_local_port_error(
             &error.kind,
             PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation
         );
+    let context_facts = checkout_payment_compensation_context_facts(context);
     if technical_failure {
         tracing::error!(
             error = ?error,
@@ -197,16 +224,25 @@ fn map_checkout_payment_compensation_local_port_error(
             operation = COMPENSATE_CHECKOUT_PAYMENT_OPERATION,
             local_operation,
             correlation_id = %context.correlation_id,
-            tenant_id = %context.tenant_id,
-            actor = ?context.actor,
-            channel = ?context.channel,
-            locale = %context.locale,
-            causation_id = ?context.causation_id,
-            traceparent = ?context.traceparent,
-            idempotency_key = ?context.idempotency_key,
-            deadline_ms = ?context.deadline_ms,
-            checkout_operation_id = %facts.checkout_operation_id,
-            collection_id = ?facts.collection_id,
+            tenant_id_length = context_facts.tenant_id_length,
+            actor_kind = context_facts.actor_kind,
+            actor_id_length = context_facts.actor_id_length,
+            claim_count = context_facts.claim_count,
+            role_count = context_facts.role_count,
+            channel_present = context_facts.channel_present,
+            channel_length = ?context_facts.channel_length,
+            locale_length = context_facts.locale_length,
+            causation_id_present = context_facts.causation_id_present,
+            causation_id_length = ?context_facts.causation_id_length,
+            traceparent_present = context_facts.traceparent_present,
+            traceparent_length = ?context_facts.traceparent_length,
+            idempotency_key_present = context_facts.idempotency_key_present,
+            idempotency_key_length = ?context_facts.idempotency_key_length,
+            deadline_ms = ?context_facts.deadline_ms,
+            checkout_operation_id_non_nil = facts.checkout_operation_id_non_nil,
+            collection_id_present = facts.collection_id_present,
+            collection_id_non_nil = ?facts.collection_id_non_nil,
+            reason_present = facts.reason_present,
             reason_length = ?facts.reason_length,
             metadata_kind = facts.metadata_kind,
             metadata_entry_count = ?facts.metadata_entry_count,
@@ -215,7 +251,7 @@ fn map_checkout_payment_compensation_local_port_error(
             error_kind = ?error.kind,
             retryable = error.retryable,
             boundary = PAYMENT_COMPENSATION_BOUNDARY,
-            "payment checkout compensation local technical outcome retained delegated context"
+            "payment checkout compensation local technical outcome retained safe context"
         );
     } else {
         tracing::warn!(
@@ -224,16 +260,25 @@ fn map_checkout_payment_compensation_local_port_error(
             operation = COMPENSATE_CHECKOUT_PAYMENT_OPERATION,
             local_operation,
             correlation_id = %context.correlation_id,
-            tenant_id = %context.tenant_id,
-            actor = ?context.actor,
-            channel = ?context.channel,
-            locale = %context.locale,
-            causation_id = ?context.causation_id,
-            traceparent = ?context.traceparent,
-            idempotency_key = ?context.idempotency_key,
-            deadline_ms = ?context.deadline_ms,
-            checkout_operation_id = %facts.checkout_operation_id,
-            collection_id = ?facts.collection_id,
+            tenant_id_length = context_facts.tenant_id_length,
+            actor_kind = context_facts.actor_kind,
+            actor_id_length = context_facts.actor_id_length,
+            claim_count = context_facts.claim_count,
+            role_count = context_facts.role_count,
+            channel_present = context_facts.channel_present,
+            channel_length = ?context_facts.channel_length,
+            locale_length = context_facts.locale_length,
+            causation_id_present = context_facts.causation_id_present,
+            causation_id_length = ?context_facts.causation_id_length,
+            traceparent_present = context_facts.traceparent_present,
+            traceparent_length = ?context_facts.traceparent_length,
+            idempotency_key_present = context_facts.idempotency_key_present,
+            idempotency_key_length = ?context_facts.idempotency_key_length,
+            deadline_ms = ?context_facts.deadline_ms,
+            checkout_operation_id_non_nil = facts.checkout_operation_id_non_nil,
+            collection_id_present = facts.collection_id_present,
+            collection_id_non_nil = ?facts.collection_id_non_nil,
+            reason_present = facts.reason_present,
             reason_length = ?facts.reason_length,
             metadata_kind = facts.metadata_kind,
             metadata_entry_count = ?facts.metadata_entry_count,
@@ -242,7 +287,7 @@ fn map_checkout_payment_compensation_local_port_error(
             error_kind = ?error.kind,
             retryable = error.retryable,
             boundary = PAYMENT_COMPENSATION_BOUNDARY,
-            "payment checkout compensation local outcome retained delegated context"
+            "payment checkout compensation local outcome retained safe context"
         );
     }
     error

--- a/scripts/verify/verify-payment-checkout-compensation-local-context.mjs
+++ b/scripts/verify/verify-payment-checkout-compensation-local-context.mjs
@@ -15,8 +15,21 @@ const api = read('crates/rustok-payment/src/checkout_compensation_api.rs');
 const wrapper = read('crates/rustok-payment/src/checkout_compensation_context.rs');
 const owner = read('crates/rustok-payment/src/checkout_compensation.rs');
 const commerce = read('crates/rustok-commerce/src/services/checkout_compensation_owner_ports.rs');
-const failures = [];
+const doc = read('crates/rustok-payment/docs/checkout-compensation-local-context.md');
+const paymentPlan = read('crates/rustok-payment/docs/implementation-plan.md');
+const commercePlan = read('crates/rustok-commerce/docs/implementation-plan.md');
+const evidence = JSON.parse(
+  read(
+    'crates/rustok-payment/contracts/evidence/checkout-compensation-wrapper-diagnostic-safety-source.json',
+  ),
+);
+const review = JSON.parse(
+  read(
+    'crates/rustok-payment/contracts/evidence/checkout-compensation-wrapper-diagnostic-safety-source-review.json',
+  ),
+);
 
+const failures = [];
 const requireText = (content, value, label) => {
   if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
 };
@@ -35,183 +48,269 @@ const between = (content, start, end, label) => {
 
 for (const [value, label] of [
   ['#[path = "checkout_compensation.rs"]\nmod checkout_compensation_persistent;', 'private persistent owner module'],
-  ['#[path = "checkout_compensation_api.rs"]\npub mod checkout_compensation;', 'public compensation API facade'],
-  ['mod checkout_compensation_context;', 'private context wrapper module'],
+  ['#[path = "checkout_compensation_api.rs"]\npub mod checkout_compensation;', 'public compensation facade'],
+  ['mod checkout_compensation_context;', 'private wrapper module'],
   ['pub use checkout_compensation::{', 'root facade export'],
-  ['CheckoutPaymentCompensationPort, CheckoutPaymentCompensationRequest,', 'root trait/request compatibility'],
+  ['CheckoutPaymentCompensationPort, CheckoutPaymentCompensationRequest,', 'root contracts'],
   ['InProcessCheckoutPaymentCompensationPort, in_process_checkout_payment_compensation_port,', 'root wrapper type/factory'],
 ]) requireText(lib, value, label);
 for (const value of [
   'pub mod checkout_compensation_persistent',
   'pub use checkout_compensation_persistent::',
   'pub use checkout_compensation_context::',
-]) forbidText(lib, value, 'persistent compensation bypass');
+]) forbidText(lib, value, 'persistent owner public bypass');
 
 for (const [value, label] of [
-  ['pub use crate::checkout_compensation_context::{', 'module-path wrapper export'],
-  ['InProcessCheckoutPaymentCompensationPort, in_process_checkout_payment_compensation_port,', 'module-path wrapper type/factory'],
-  ['pub use crate::checkout_compensation_persistent::{', 'module-path contract export'],
-  ['CheckoutPaymentCompensationPort, CheckoutPaymentCompensationRequest,', 'module-path trait/request compatibility'],
+  ['pub use crate::checkout_compensation_context::{', 'module wrapper export'],
+  ['InProcessCheckoutPaymentCompensationPort, in_process_checkout_payment_compensation_port,', 'module wrapper type/factory'],
+  ['pub use crate::checkout_compensation_persistent::{', 'module contract export'],
+  ['CheckoutPaymentCompensationPort, CheckoutPaymentCompensationRequest,', 'module contracts'],
 ]) requireText(api, value, label);
 for (const value of [
   'PersistentCheckoutPaymentCompensationPort',
   'checkout_compensation_persistent::InProcessCheckoutPaymentCompensationPort',
   'checkout_compensation_persistent::in_process_checkout_payment_compensation_port',
-]) forbidText(api, value, 'public persistent implementation exposure');
+]) forbidText(api, value, 'persistent implementation exposure');
 
 for (const [value, label] of [
   ['use crate::checkout_compensation_persistent::{', 'private persistent import'],
-  ['InProcessCheckoutPaymentCompensationPort as PersistentCheckoutPaymentCompensationPort', 'persistent owner alias'],
+  ['InProcessCheckoutPaymentCompensationPort as PersistentCheckoutPaymentCompensationPort', 'persistent alias'],
   ['inner: PersistentCheckoutPaymentCompensationPort', 'wrapper inner owner'],
   ['PersistentCheckoutPaymentCompensationPort::new(db)', 'default constructor delegation'],
-  ['PersistentCheckoutPaymentCompensationPort::with_provider_registry(', 'provider registry constructor delegation'],
-  ['pub fn in_process_checkout_payment_compensation_port(', 'canonical factory'],
+  ['PersistentCheckoutPaymentCompensationPort::with_provider_registry(', 'registry constructor delegation'],
+  ['pub fn in_process_checkout_payment_compensation_port(', 'canonical wrapper factory'],
   ['Arc::new(InProcessCheckoutPaymentCompensationPort::new(db))', 'factory wrapper construction'],
 ]) requireText(wrapper, value, label);
-forbidText(wrapper, 'use crate::checkout_compensation::{', 'wrapper import through public facade');
 
 const operation = between(
   wrapper,
   'async fn compensate_checkout_payment(',
-  'fn checkout_payment_compensation_diagnostic_facts(',
-  'compensation wrapper operation',
+  'fn checkout_payment_compensation_context_facts(',
+  'wrapper operation',
 );
 for (const [value, label] of [
-  ['let diagnostic_context = context.clone();', 'accepted context retention'],
-  ['let diagnostic_facts = checkout_payment_compensation_diagnostic_facts(&request);', 'safe request-fact retention'],
-  ['.inner\n            .compensate_checkout_payment(context, request)', 'unchanged owner delegation'],
+  ['let diagnostic_context = context.clone();', 'context retention'],
+  ['let diagnostic_facts = checkout_payment_compensation_diagnostic_facts(&request);', 'request-shape retention'],
+  ['.inner\n            .compensate_checkout_payment(context, request)', 'persistent delegation'],
   ['result.map_err(|error| {', 'post-delegation mapping'],
-  ['map_checkout_payment_compensation_local_port_error(', 'local mapper call'],
-  ['&diagnostic_context,', 'retained context mapper argument'],
-  ['&diagnostic_facts,', 'retained facts mapper argument'],
+  ['map_checkout_payment_compensation_local_port_error(', 'wrapper mapper'],
 ]) requireText(operation, value, label);
-const operationIndexes = [
+const order = [
   operation.indexOf('let diagnostic_context = context.clone();'),
   operation.indexOf('checkout_payment_compensation_diagnostic_facts(&request)'),
   operation.indexOf('.compensate_checkout_payment(context, request)'),
   operation.indexOf('result.map_err(|error| {'),
   operation.indexOf('map_checkout_payment_compensation_local_port_error('),
 ];
-if (!operationIndexes.every((value, index) => value >= 0 && (index === 0 || operationIndexes[index - 1] < value))) {
-  failures.push('compensation wrapper must retain context/facts before unchanged delegation and map only returned errors');
+if (!order.every((value, index) => value >= 0 && (index === 0 || order[index - 1] < value))) {
+  failures.push('wrapper must retain safe context/facts before unchanged delegation and map only returned errors');
 }
 
-const facts = between(
-  wrapper,
-  'fn checkout_payment_compensation_diagnostic_facts(',
-  'fn payment_metadata_kind(',
-  'safe compensation facts',
-);
-for (const [value, label] of [
-  ['checkout_operation_id: request.checkout_operation_id', 'checkout operation id fact'],
-  ['collection_id: request.collection_id', 'collection id fact'],
-  ['reason_length: request.reason.as_ref().map(|value| value.chars().count())', 'reason length fact'],
-  ['metadata_kind: payment_metadata_kind(&request.metadata)', 'metadata kind fact'],
-  ['Value::Object(entries) => Some(entries.len())', 'metadata object entry count'],
-  ['Value::Array(entries) => Some(entries.len())', 'metadata array entry count'],
-]) requireText(facts, value, label);
-for (const value of [
-  'reason: request.reason.clone()',
-  'metadata: request.metadata.clone()',
-  'reason: request.reason',
-  'metadata: request.metadata',
-]) forbidText(facts, value, 'raw compensation payload retention');
+for (const marker of [
+  'struct CheckoutPaymentCompensationContextFacts',
+  'tenant_id_length: context.tenant_id.chars().count()',
+  'actor_id_length: context.actor.id.chars().count()',
+  'claim_count: context.claims.len()',
+  'role_count: context.roles.len()',
+  'channel_present: context.channel.is_some()',
+  'locale_length: context.locale.chars().count()',
+  'causation_id_present: context.causation_id.is_some()',
+  'traceparent_present: context.traceparent.is_some()',
+  'idempotency_key_present: context.idempotency_key.is_some()',
+  'checkout_operation_id_non_nil: !request.checkout_operation_id.is_nil()',
+  'collection_id_present: request.collection_id.is_some()',
+  'collection_id_non_nil: request.collection_id.map(|value| !value.is_nil())',
+  'reason_present: request.reason.is_some()',
+  'reason_length: request.reason.as_ref().map(|value| value.chars().count())',
+  'metadata_kind: payment_metadata_kind(&request.metadata)',
+  'Value::Object(entries) => Some(entries.len())',
+  'Value::Array(entries) => Some(entries.len())',
+]) requireText(wrapper, marker, 'safe wrapper facts');
 
-const mapper = wrapper.slice(wrapper.indexOf('fn map_checkout_payment_compensation_local_port_error('));
-requireText(mapper, 'match (error.code.as_str(), error.message.as_str())', 'exact code-and-message matching');
-for (const [code, message, operationLabel] of [
-  ['port.idempotency_key_required', 'write port calls require a non-empty idempotency key', 'admit_write_idempotency'],
-  ['port.deadline_required', 'port calls require deadline semantics', 'admit_deadline'],
-  ['payment.checkout_compensation_identity_invalid', 'checkout operation and payment collection identity must be non-nil UUIDs', 'validate_compensation_identity'],
-  ['payment.collection_not_found', 'payment collection was not found', 'load_collection'],
-  ['payment.checkout_compensation_manual_reconciliation', 'payment checkout compensation requires manual reconciliation', 'require_manual_reconciliation'],
-  ['payment.checkout_compensation_state_conflict', 'payment collection changed while compensation was being applied', 'apply_compensation_state'],
-  ['payment.checkout_compensation_state_conflict', 'payment lifecycle conflicts with checkout compensation', 'apply_payment_lifecycle'],
-  ['payment.checkout_compensation_provider_state_conflict', 'payment provider cancellation is in an unsupported state', 'validate_provider_journal_state'],
-  ['payment.checkout_compensation_metadata_invalid', 'payment compensation metadata must be a JSON object', 'validate_provider_metadata'],
-  ['payment.checkout_compensation_provider_identity_conflict', 'payment provider identity conflicts with the durable authorization', 'validate_provider_identity'],
-  ['payment.checkout_compensation_encoding_failed', 'payment compensation request could not be encoded', 'encode_provider_cancel_request'],
-  ['payment.database_unavailable', 'payment storage is temporarily unavailable', 'owner_storage'],
-  ['payment.checkout_compensation_validation', 'payment compensation request is invalid', 'validate_owner_request'],
-  ['payment.payment_not_found', 'payment was not found', 'load_payment'],
-  ['payment.refund_not_found', 'refund was not found', 'load_refund'],
-  ['payment.provider_unavailable', 'payment provider is temporarily unavailable', 'execute_provider_cancel'],
-  ['payment.provider_rejected', 'payment provider rejected the requested operation', 'execute_provider_cancel'],
-  ['payment.provider_invalid_response', 'payment provider response could not be applied safely', 'normalize_provider_result'],
-  ['payment.provider_not_configured', 'payment provider is not configured', 'resolve_provider'],
-]) {
-  requireText(mapper, `"${code}"`, `${operationLabel} code`);
-  requireText(mapper, `"${message}"`, `${operationLabel} message`);
-  requireText(mapper, `"${operationLabel}"`, `${operationLabel} local operation`);
-}
-for (const [value, label] of [
-  ['_ => return error,', 'unknown error pass-through'],
-  ['"require_manual_reconciliation" | "validate_provider_journal_state"', 'integrity severity classification'],
-  ['PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation', 'technical severity classification'],
-  ['tracing::error!(', 'technical local event'],
-  ['tracing::warn!(', 'ordinary local event'],
-  ['error = ?error', 'complete delegated error'],
-  ['owner = PAYMENT_OWNER', 'truthful owner'],
-  ['operation = COMPENSATE_CHECKOUT_PAYMENT_OPERATION', 'exact public operation'],
-  ['local_operation,', 'local operation field'],
-  ['correlation_id = %context.correlation_id', 'correlation context'],
-  ['tenant_id = %context.tenant_id', 'tenant context'],
-  ['actor = ?context.actor', 'actor context'],
-  ['channel = ?context.channel', 'channel context'],
-  ['locale = %context.locale', 'locale context'],
-  ['causation_id = ?context.causation_id', 'causation context'],
-  ['traceparent = ?context.traceparent', 'trace context'],
-  ['idempotency_key = ?context.idempotency_key', 'idempotency context'],
-  ['deadline_ms = ?context.deadline_ms', 'deadline context'],
-  ['checkout_operation_id = %facts.checkout_operation_id', 'checkout operation context'],
-  ['collection_id = ?facts.collection_id', 'collection context'],
-  ['reason_length = ?facts.reason_length', 'reason length context'],
-  ['metadata_kind = facts.metadata_kind', 'metadata kind context'],
-  ['metadata_entry_count = ?facts.metadata_entry_count', 'metadata count context'],
-  ['internal_code = %error.code', 'stable error code'],
-  ['internal_message = %error.message', 'stable error message'],
-  ['error_kind = ?error.kind', 'typed error kind'],
-  ['retryable = error.retryable', 'retryability'],
-  ['boundary = PAYMENT_COMPENSATION_BOUNDARY', 'owner boundary'],
-  ['\n    error\n}', 'same delegated error return'],
-]) requireText(mapper, value, label);
-for (const value of [
-  'payment.tenant_id_invalid',
-  'payment.checkout_compensation_causation_invalid',
-]) forbidText(mapper, value, 'tenant and causation errors must remain owner pass-through');
-for (const value of ['reason =', 'metadata =']) forbidText(mapper, value, 'raw compensation payload diagnostics');
+for (const marker of [
+  'fn checkout_payment_compensation_local_operation(code: &str)',
+  'match code {',
+  'checkout_payment_compensation_local_operation(error.code.as_str())',
+  '"port.idempotency_key_required" => Some("admit_write_idempotency")',
+  '"port.deadline_required" => Some("admit_deadline")',
+  '"payment.checkout_compensation_identity_invalid"',
+  'Some("validate_compensation_identity")',
+  '"payment.checkout_compensation_state_conflict" => Some("apply_compensation_state")',
+  '"payment.checkout_compensation_provider_state_conflict"',
+  'Some("validate_provider_journal_state")',
+  '"payment.provider_unavailable" | "payment.provider_rejected"',
+  'Some("execute_provider_cancel")',
+  '"payment.provider_invalid_response" => Some("normalize_provider_result")',
+  '_ => None,',
+]) requireText(wrapper, marker, 'stable-code wrapper attribution');
+for (const forbidden of [
+  'error.message.as_str()',
+  'match (error.code.as_str(), error.message.as_str())',
+  'write port calls require a non-empty idempotency key',
+  'payment storage is temporarily unavailable',
+  'payment provider is temporarily unavailable',
+]) forbidText(wrapper, forbidden, 'message-independent wrapper classifier');
+
+for (const marker of [
+  'let context_facts = checkout_payment_compensation_context_facts(context);',
+  'correlation_id = %context.correlation_id',
+  'tenant_id_length = context_facts.tenant_id_length',
+  'actor_kind = context_facts.actor_kind',
+  'actor_id_length = context_facts.actor_id_length',
+  'claim_count = context_facts.claim_count',
+  'role_count = context_facts.role_count',
+  'channel_present = context_facts.channel_present',
+  'locale_length = context_facts.locale_length',
+  'causation_id_present = context_facts.causation_id_present',
+  'traceparent_present = context_facts.traceparent_present',
+  'idempotency_key_present = context_facts.idempotency_key_present',
+  'checkout_operation_id_non_nil = facts.checkout_operation_id_non_nil',
+  'collection_id_present = facts.collection_id_present',
+  'collection_id_non_nil = ?facts.collection_id_non_nil',
+  'reason_present = facts.reason_present',
+  'reason_length = ?facts.reason_length',
+  'metadata_kind = facts.metadata_kind',
+  'metadata_entry_count = ?facts.metadata_entry_count',
+  'internal_code = %error.code',
+  'internal_message = %error.message',
+  'error_kind = ?error.kind',
+  'retryable = error.retryable',
+  'boundary = PAYMENT_COMPENSATION_BOUNDARY',
+  '\n    error\n}',
+]) requireText(wrapper, marker, 'safe wrapper mapper');
+
+for (const forbidden of [
+  'tenant_id = %context.tenant_id',
+  'actor = ?context.actor',
+  'channel = ?context.channel',
+  'locale = %context.locale',
+  'causation_id = ?context.causation_id',
+  'traceparent = ?context.traceparent',
+  'idempotency_key = ?context.idempotency_key',
+  'checkout_operation_id = %',
+  'collection_id = ?',
+  'reason =',
+  'metadata =',
+]) forbidText(wrapper, forbidden, 'raw wrapper diagnostics');
 
 for (const [value, label] of [
-  ['pub trait CheckoutPaymentCompensationPort', 'persistent owner trait'],
-  ['pub struct CheckoutPaymentCompensationRequest', 'persistent request DTO'],
-  ['pub struct InProcessCheckoutPaymentCompensationPort', 'private persistent owner type'],
-  ['pub fn in_process_checkout_payment_compensation_port(', 'private persistent factory'],
+  ['pub trait CheckoutPaymentCompensationPort', 'persistent trait'],
+  ['pub struct CheckoutPaymentCompensationRequest', 'persistent request'],
   ['context.require_policy(PortCallPolicy::write())?;', 'persistent write policy'],
   ['context.require_write_semantics()?;', 'persistent write semantics'],
   ['parse_tenant_id(&context, owner_operation)?;', 'persistent tenant validation'],
   ['require_operation_context(&context, owner_operation, request.checkout_operation_id)?;', 'persistent causation validation'],
-  ['format!("payment_collection:{}:cancel", collection.id)', 'canonical cancel idempotency key'],
-  ['"operation": "cancel_payment_collection"', 'canonical provider metadata operation'],
-  ['.execute_cancel(provider_id.as_str(), provider_request)', 'provider cancel execution'],
+  ['format!("payment_collection:{}:cancel", collection.id)', 'canonical cancel key'],
+  ['"operation": "cancel_payment_collection"', 'canonical cancel metadata'],
+  ['.execute_cancel(provider_id.as_str(), provider_request)', 'provider cancel'],
   ['.mark_provider_succeeded(', 'provider success checkpoint'],
   ['.cancel_local_collection(', 'local cancellation'],
-  ['.mark_committed(outcome.operation_id)', 'provider commit checkpoint'],
+  ['.mark_committed(outcome.operation_id)', 'final commit checkpoint'],
 ]) requireText(owner, value, label);
+for (const marker of [
+  'tenant_id = %context.tenant_id',
+  'operation_id = %operation.id',
+  'checkout_operation_id = %checkout_operation_id',
+]) requireText(owner, marker, 'persistent owner diagnostic cleanup remains open');
 
 for (const [value, label] of [
-  ['use rustok_payment::{', 'commerce root payment imports'],
-  ['CheckoutPaymentCompensationPort, CheckoutPaymentCompensationRequest,', 'commerce root compensation contracts'],
-  ['InProcessCheckoutPaymentCompensationPort, PaymentCollectionStatusKind, PaymentProviderRegistry,', 'commerce root wrapper type'],
-  ['in_process_checkout_payment_compensation_port,', 'commerce root wrapper factory'],
+  ['use rustok_payment::{', 'commerce root imports'],
+  ['CheckoutPaymentCompensationPort, CheckoutPaymentCompensationRequest,', 'commerce contracts'],
+  ['InProcessCheckoutPaymentCompensationPort, PaymentCollectionStatusKind, PaymentProviderRegistry,', 'commerce wrapper type'],
+  ['in_process_checkout_payment_compensation_port,', 'commerce wrapper factory'],
 ]) requireText(commerce, value, label);
-forbidText(commerce, 'rustok_payment::checkout_compensation_persistent::', 'commerce private persistent construction');
+forbidText(commerce, 'rustok_payment::checkout_compensation_persistent::', 'commerce persistent bypass');
+
+if (evidence.status !== 'payment_checkout_compensation_wrapper_diagnostic_safety_source_unvalidated') {
+  failures.push(`unexpected evidence status: ${evidence.status}`);
+}
+if (
+  review.status !==
+  'payment_checkout_compensation_wrapper_diagnostic_safety_source_reviewed_unvalidated'
+) {
+  failures.push(`unexpected review status: ${review.status}`);
+}
+for (const [key, expected] of Object.entries({
+  stable_code_only_local_classification: true,
+  human_message_control_flow: false,
+  delegated_port_error_changed: false,
+  public_code_changed: false,
+  public_message_changed: false,
+  public_kind_changed: false,
+  public_retryability_changed: false,
+  owner_delegation_changed: false,
+  request_response_dto_changed: false,
+  persistent_owner_source_changed: false,
+  provider_cancel_policy_changed: false,
+  provider_journal_policy_changed: false,
+  raw_tenant_id_logged_by_wrapper: false,
+  raw_actor_id_logged_by_wrapper: false,
+  raw_channel_logged_by_wrapper: false,
+  raw_locale_logged_by_wrapper: false,
+  raw_causation_id_logged_by_wrapper: false,
+  raw_traceparent_logged_by_wrapper: false,
+  raw_idempotency_key_logged_by_wrapper: false,
+  raw_checkout_operation_id_logged_by_wrapper: false,
+  raw_collection_id_logged_by_wrapper: false,
+  raw_reason_logged_by_wrapper: false,
+  raw_metadata_logged_by_wrapper: false,
+  safe_context_shape_logged: true,
+  safe_request_shape_logged: true,
+  correlation_id_logged: true,
+  original_port_error_private: true,
+  persistent_owner_diagnostic_cleanup_complete: false,
+  broad_ecommerce_cleanup_closed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  'tests_run',
+  'cargo_run',
+  'format_run',
+  'verifiers_run',
+  'workflow_checks_run',
+  'ci_run',
+  'compile_proven',
+  'provider_replay_proven',
+  'restart_proven',
+  'remote_port_proven',
+  'mounted_runtime_proven',
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
+}
+
+for (const marker of [
+  'Status: **source-ready / unvalidated**',
+  'Human-readable `PortError.message` is not used as control flow.',
+  'The persistent owner in `checkout_compensation.rs` still contains raw tenant',
+  'No FBA or FFA status is promoted from source',
+]) requireText(doc, marker, 'compensation wrapper documentation');
+requireText(
+  paymentPlan,
+  'Payment checkout compensation wrapper diagnostic safety:',
+  'payment owner wrapper status',
+);
+requireText(
+  paymentPlan,
+  'its owner-local raw identifier diagnostics remain the next',
+  'persistent owner nonclaim',
+);
+requireText(
+  commercePlan,
+  'Finish correlation-safe mapper cleanup for order, payment execution/compensation,',
+  'broad ecommerce cleanup remains open',
+);
 
 if (failures.length > 0) {
-  console.error('Payment checkout compensation local-context verification failed:');
-  for (const failure of failures) console.error(`✗ ${failure}`);
+  console.error('Payment checkout compensation wrapper diagnostic-safety verification failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
 
 console.log(
-  '✔ Public payment compensation construction always uses the context wrapper, including exact admission outcomes, while persistent owner semantics and PortError results remain unchanged',
+  'Payment checkout compensation wrapper uses stable-code attribution and safe context/request shape while preserving persistent owner behavior and public PortError results; runtime evidence remains open',
 );

--- a/scripts/verify/verify-payment-checkout-execution-local-context.mjs
+++ b/scripts/verify/verify-payment-checkout-execution-local-context.mjs
@@ -28,7 +28,10 @@ const captureProvider = read(
 const providerHelpers = read(
   'crates/rustok-payment/src/checkout_execution/provider_helpers.rs',
 );
-const compensation = read('crates/rustok-payment/src/checkout_compensation_context.rs');
+const compensationWrapper = read(
+  'crates/rustok-payment/src/checkout_compensation_context.rs',
+);
+const compensationOwner = read('crates/rustok-payment/src/checkout_compensation.rs');
 const doc = read('crates/rustok-payment/docs/checkout-execution-local-context.md');
 const paymentPlan = read('crates/rustok-payment/docs/implementation-plan.md');
 const commercePlan = read('crates/rustok-commerce/docs/implementation-plan.md');
@@ -60,20 +63,20 @@ for (const marker of [
   'include!("checkout_execution/diagnostic_safety.rs");',
   'include!("checkout_execution/port_impl.rs");',
   'include!("checkout_execution/validation_errors.rs");',
-]) requireText(checkoutExecution, marker, 'checkout execution include topology');
+]) requireText(checkoutExecution, marker, 'execution include topology');
 
 for (const marker of [
   'async fn prepare_checkout_collection(',
   'async fn authorize_checkout_collection(',
   'async fn capture_checkout_collection(',
   'async fn read_checkout_collection(',
-]) requireText(types, marker, 'published checkout execution port');
+]) requireText(types, marker, 'published execution port');
 
 requireCount(
   portImpl,
   'map_checkout_payment_execution_local_port_error(',
   5,
-  'four mapper calls plus mapper definition',
+  'four mapper calls plus definition',
 );
 requireCount(
   portImpl,
@@ -120,7 +123,7 @@ for (const marker of [
   'provider_payment_id_present: provider_payment_id.is_some()',
   'fn checkout_payment_execution_local_operation(',
   'match code {',
-]) requireText(diagnosticSafety, marker, 'safe diagnostic source');
+]) requireText(diagnosticSafety, marker, 'execution safe diagnostic source');
 
 for (const [code, operation] of [
   ['payment.checkout_identity_invalid', 'validate_checkout_identity'],
@@ -138,17 +141,16 @@ for (const [code, operation] of [
   ['payment.checkout_execution_manual_reconciliation', 'require_manual_reconciliation'],
   ['payment.provider_not_configured', 'resolve_provider'],
 ]) {
-  requireText(diagnosticSafety, `"${code}"`, `stable code ${code}`);
-  requireText(diagnosticSafety, `"${operation}"`, `local operation ${operation}`);
+  requireText(diagnosticSafety, `"${code}"`, `execution code ${code}`);
+  requireText(diagnosticSafety, `"${operation}"`, `execution operation ${operation}`);
 }
-
 for (const forbidden of [
   'error.message.as_str()',
   'match (error.code.as_str(), error.message.as_str())',
   'checkout payment identity contains invalid UUID or amount fields',
   'payment storage is temporarily unavailable',
   'payment provider is temporarily unavailable',
-]) forbidText(diagnosticSafety, forbidden, 'message-independent classifier');
+]) forbidText(diagnosticSafety, forbidden, 'execution message-independent classifier');
 
 for (const marker of [
   'checkout_payment_execution_local_operation(operation, error.code.as_str())',
@@ -167,7 +169,7 @@ for (const marker of [
   'internal_message = %error.message',
   'boundary = PAYMENT_EXECUTION_BOUNDARY',
   '\n    error\n}',
-]) requireText(portImpl, marker, 'safe delegated outcome mapping');
+]) requireText(portImpl, marker, 'safe delegated execution outcome mapping');
 
 for (const marker of [
   'fn log_checkout_payment_execution_admission_rejection(',
@@ -188,7 +190,7 @@ for (const marker of [
   'PortError::not_found(',
   'PortError::conflict(',
   'PortError::invariant_violation(',
-]) requireText(validationErrors, marker, 'safe admission and owner mapping');
+]) requireText(validationErrors, marker, 'safe execution admission and owner mapping');
 
 const providerDiagnosticSource = `${prepareAuthorize}\n${captureProvider}\n${providerHelpers}`;
 for (const marker of [
@@ -208,11 +210,12 @@ for (const marker of [
   'payment.checkout_execution_reconciliation_checkpoint_failed',
   'payment.checkout_execution_provider_failure_checkpoint_failed',
   'payment.checkout_execution_provider_checkpoint_failed',
-]) requireText(providerDiagnosticSource, marker, 'safe provider checkpoint diagnostics');
+]) requireText(providerDiagnosticSource, marker, 'safe execution provider diagnostics');
 
 for (const [content, label] of [
-  [portImpl, 'delegated outcome diagnostics'],
-  [validationErrors, 'admission and owner diagnostics'],
+  [portImpl, 'execution delegated outcomes'],
+  [validationErrors, 'execution admission and owner diagnostics'],
+  [providerDiagnosticSource, 'execution provider diagnostics'],
 ]) {
   for (const forbidden of [
     'tenant_id = %context.tenant_id',
@@ -229,60 +232,42 @@ for (const [content, label] of [
     'customer_id = ?',
     'collection_id = ?',
     'request_amount = %',
-    'operation_id = %operation.id',
-    'currency_code =',
-    'order_plan_hash =',
-    'requested_provider_id =',
-    'provider_payment_id =',
-    'metadata =',
+    'operation_id = %journaled.operation_id',
+    'operation_id = %journal_operation.id',
+    'operation_id = %operation_id',
+    'provider_id = %provider_id',
   ]) forbidText(content, forbidden, label);
 }
 
+for (const marker of [
+  'fn checkout_payment_compensation_local_operation(code: &str)',
+  'checkout_payment_compensation_local_operation(error.code.as_str())',
+  'tenant_id_length = context_facts.tenant_id_length',
+  'checkout_operation_id_non_nil = facts.checkout_operation_id_non_nil',
+  'collection_id_present = facts.collection_id_present',
+  'boundary = PAYMENT_COMPENSATION_BOUNDARY',
+]) requireText(compensationWrapper, marker, 'current compensation wrapper safety');
 for (const forbidden of [
+  'match (error.code.as_str(), error.message.as_str())',
   'tenant_id = %context.tenant_id',
   'actor = ?context.actor',
-  'channel = ?context.channel',
-  'locale = %context.locale',
-  'causation_id = ?context.causation_id',
-  'traceparent = ?context.traceparent',
-  'idempotency_key = ?context.idempotency_key',
-  'operation_id = %journaled.operation_id',
-  'operation_id = %journal_operation.id',
-  'operation_id = %operation_id',
-  'provider_id = %provider_id',
-]) forbidText(providerDiagnosticSource, forbidden, 'provider checkpoint raw diagnostics');
-
+  'checkout_operation_id = %facts.checkout_operation_id',
+  'collection_id = ?facts.collection_id',
+]) forbidText(compensationWrapper, forbidden, 'current compensation wrapper raw diagnostics');
 for (const marker of [
-  'validate_identity(&request.identity)?;',
-  'PaymentCollectionStatusKind',
-  'payment_collection:{collection_id}:authorize',
-]) requireText(
-  `${prepareAuthorize}\n${captureProvider}\n${paymentPlan}`,
-  marker,
-  'preserved provider execution policy',
-);
-
-requireText(
-  compensation,
-  'match (error.code.as_str(), error.message.as_str())',
-  'compensation remains separate message-pair cleanup',
-);
-requireText(
-  compensation,
   'tenant_id = %context.tenant_id',
-  'compensation raw context remains explicitly outside this slice',
-);
+  'operation_id = %operation.id',
+]) requireText(compensationOwner, marker, 'persistent compensation cleanup remains open');
 
 if (evidence.status !== 'payment_checkout_execution_diagnostic_safety_source_unvalidated') {
-  failures.push(`unexpected evidence status: ${evidence.status}`);
+  failures.push(`unexpected execution evidence status: ${evidence.status}`);
 }
 if (
   review.status !==
   'payment_checkout_execution_diagnostic_safety_source_reviewed_unvalidated'
 ) {
-  failures.push(`unexpected review status: ${review.status}`);
+  failures.push(`unexpected execution review status: ${review.status}`);
 }
-
 for (const [key, expected] of Object.entries({
   stable_code_only_local_classification: true,
   human_message_control_flow: false,
@@ -316,10 +301,9 @@ for (const [key, expected] of Object.entries({
   broad_ecommerce_cleanup_closed: false,
 })) {
   if (evidence.source_contract?.[key] !== expected) {
-    failures.push(`evidence source_contract.${key} must be ${expected}`);
+    failures.push(`execution evidence source_contract.${key} must be ${expected}`);
   }
 }
-
 for (const key of [
   'tests_run',
   'cargo_run',
@@ -334,26 +318,26 @@ for (const key of [
   'mounted_runtime_proven',
 ]) {
   if (evidence.validation?.[key] !== false) {
-    failures.push(`evidence validation.${key} must remain false`);
+    failures.push(`execution evidence validation.${key} must remain false`);
   }
 }
 
 for (const marker of [
   'Status: **source-ready / unvalidated**',
   'Human-readable `PortError.message` is not used as control flow.',
-  'Payment checkout compensation still uses message-pair classification',
-  'No FBA or FFA status is promoted from source inspection.',
-]) requireText(doc, marker, 'diagnostic safety documentation');
-
+  'The public Payment checkout compensation wrapper now also uses stable-code-only',
+  'The private persistent compensation owner still contains raw owner-local identifier',
+  'No FBA or FFA',
+]) requireText(doc, marker, 'execution diagnostic documentation');
 requireText(
   paymentPlan,
   'Payment checkout execution diagnostic safety: `source_ready_unvalidated`',
-  'payment owner source status',
+  'execution owner status',
 );
 requireText(
   paymentPlan,
-  'Checkout compensation diagnostic cleanup remains open',
-  'compensation nonclaim',
+  'Payment checkout compensation wrapper diagnostic safety:',
+  'related compensation wrapper status',
 );
 requireText(
   commercePlan,
@@ -368,5 +352,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  'Payment checkout execution diagnostics use stable-code attribution and safe context/request shape while preserving public PortError behavior; execution evidence remains open',
+  'Payment checkout execution diagnostics remain stable-code and safe-shape; the compensation wrapper is also safe while persistent compensation diagnostics and runtime evidence remain open',
 );


### PR DESCRIPTION
## Summary
- harden the public `CheckoutPaymentCompensationPort` context wrapper without changing the private persistent owner state machine
- replace wrapper local-operation classification based on `(PortError.code, PortError.message)` with stable-code-only attribution
- collapse the two message-specific `payment.checkout_compensation_state_conflict` labels into one stable `apply_compensation_state` wrapper label
- retain the original delegated `PortError` code, message, kind, retryability, and return value unchanged
- record correlation plus safe context/request shape only
- remove raw tenant, actor, channel, locale, causation, traceparent, idempotency, checkout-operation, collection, reason, and metadata values from wrapper diagnostics
- preserve public facade construction, persistent owner delegation, provider cancel/replay policy, canonical cancel idempotency key, journal transitions, local cancellation, and public contracts
- add source evidence, source review, updated documentation and Payment plan status, and align both compensation and execution static guards

## Confirmed gap
The canonical public compensation wrapper always delegated to the private persistent owner and returned typed `PortError` envelopes, but its post-delegation mapper used human-readable public messages as control flow and copied raw `PortContext` plus payment UUIDs into wrapper diagnostics.

## Stable attribution
`checkout_payment_compensation_local_operation` now selects known local labels from stable `PortError.code`. Unknown codes pass through without an additional wrapper event. No public error is reconstructed or remapped.

## Safe wrapper diagnostics
The wrapper retains the per-call correlation id. Other context is represented only through lengths, counts, presence flags, actor kind, deadline, and UUID non-nil facts. Reason text and metadata values are not logged; only reason length, metadata kind, and entry count are retained.

## Preserved boundary
- `checkout_compensation.rs` is outside the diff and remains the private persistent owner
- write policy, tenant/causation admission, optional no-op behavior, lifecycle policy, provider cancel, provider identity recovery, journal begin/claim/replay/checkpoint/commit, local cancellation race handling, and reconciliation routing are unchanged
- `lib.rs`, `checkout_compensation_api.rs`, Commerce runtime composition, DTOs, and public exports are unchanged
- Payment FFA/FBA status is not promoted
- persistent owner-local raw identifier diagnostics remain the next separate cleanup
- the broad Commerce correlation-safe mapper item remains open

The branch is based on current `main` at `a7be516f87195e6b940f8b1aeb2bc5135c289b4e`. The diff contains eight Payment source/evidence files.

## Validation
Per maintainer instruction, tests, Node verifiers, Cargo commands, formatting, workflows, and CI were not run. Evidence remains source-ready / unvalidated and does not prove compilation, provider replay, process-exit, restart, mounted runtime, remote-port, workflow, CI, or production behavior.

Suggested maintainer commands:
```bash
node scripts/verify/verify-payment-checkout-compensation-local-context.mjs
node scripts/verify/verify-payment-checkout-execution-local-context.mjs
node scripts/verify/verify-commerce-checkout-compensation-owner-boundary.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-payment --lib
cargo check -p rustok-commerce --lib
```