### PR TITLE
test(blog): add comment projection PostgreSQL harness

### DIFF
--- a/crates/rustok-blog/contracts/blog-fba-registry.json
+++ b/crates/rustok-blog/contracts/blog-fba-registry.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 11,
+  "schema_version": 12,
   "module": "blog",
   "role": "consumer",
   "status": "boundary_ready",
@@ -112,6 +112,7 @@
         "verifier": "scripts/verify/verify-blog-comments-event-projection.mjs",
         "self_test": "scripts/verify/verify-blog-comments-event-projection.test.mjs",
         "unit_test": "crates/rustok-blog/src/services/comment_projection.rs",
+        "postgres_test": "crates/rustok-blog/tests/comment_projection_postgres_test.rs",
         "evidence": "crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json"
       },
       "category_search_reindex": {
@@ -173,6 +174,13 @@
       "path": "crates/rustok-blog/src/services/comment_projection.rs",
       "status": "executable_no_run",
       "command": "cargo test -p rustok-blog --lib services::comment_projection::tests"
+    },
+    "postgres_harness": {
+      "path": "crates/rustok-blog/tests/comment_projection_postgres_test.rs",
+      "status": "executable_no_run",
+      "runtime_status": "not_run",
+      "environment": "RUSTOK_BLOG_TEST_DATABASE_URL",
+      "command": "RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test"
     }
   },
   "contract_tests": {

--- a/crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json
@@ -1,9 +1,10 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "module": "blog",
   "surface": "comments_event_projection",
   "status": "source_verified_no_compile",
   "compile_policy": "not_run_by_request",
+  "runtime_status": "pending",
   "owner": "rustok-blog",
   "provider": "rustok-comments",
   "events": [
@@ -28,6 +29,20 @@
       "shared_created_deleted_classifier",
       "non_blog_target_rejection",
       "non_negative_saturating_counter_transition"
+    ]
+  },
+  "postgres_harness": {
+    "status": "executable_no_run",
+    "runtime_status": "not_run",
+    "path": "crates/rustok-blog/tests/comment_projection_postgres_test.rs",
+    "environment": "RUSTOK_BLOG_TEST_DATABASE_URL",
+    "command": "RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test",
+    "isolation": "unique_schema_one_connection_pool",
+    "cases": [
+      "duplicate_delivery_updates_counter_and_outbox_once",
+      "delete_before_create_stays_non_negative_and_replays_in_order",
+      "missing_post_replay_commits_only_after_source_appears",
+      "outbox_failure_rolls_back_counter_and_delivery_before_retry"
     ]
   },
   "cases": [
@@ -64,13 +79,30 @@
       "expected": "the pure counter transition floors deletes at zero and saturates count and version overflow"
     },
     {
+      "name": "postgres_duplicate_delivery",
+      "expected": "the retained PostgreSQL target replays one envelope id and expects one counter transition, one delivery row, and one outbox row"
+    },
+    {
+      "name": "postgres_out_of_order_delete_create",
+      "expected": "the retained PostgreSQL target delivers delete before create and expects a non-negative count with monotonic versions"
+    },
+    {
+      "name": "postgres_missing_post_recovery",
+      "expected": "the retained PostgreSQL target expects no delivery or outbox commit while the post is missing, then replays the same envelope after source creation"
+    },
+    {
+      "name": "postgres_outbox_rollback_recovery",
+      "expected": "the retained PostgreSQL target removes the outbox table, expects counter and delivery rollback, recreates the table, and replays the same envelope"
+    },
+    {
       "name": "module_listener_registration",
       "expected": "Blog registers BlogCommentProjectionHandler through the module event-listener registry"
     }
   ],
   "runtime_promotion_requirements": [
     "execute cargo test -p rustok-blog --lib services::comment_projection::tests",
-    "execute duplicate and out-of-order comment.created/comment.deleted deliveries against PostgreSQL",
+    "execute the env-gated PostgreSQL comment_projection_postgres_test target and retain its output",
+    "retain proof that duplicate and out-of-order comment.created/comment.deleted deliveries match the source harness assertions",
     "retain proof that the counter, delivery ledger, and BlogPostUpdated outbox row commit or roll back together",
     "retain missing-post retry and later recovery evidence",
     "retain concurrent optimistic-update exhaustion and retry evidence",

--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -97,19 +97,29 @@ identity, and commits the tenant-scoped optimistic count update, delivery row,
 and `BlogPostUpdated` outbox publication in one transaction. `project()` and
 `EventHandler::handles()` share the pure `comment_projection_change` classifier,
 and the pure counter transition floors deletes at zero while saturating count and
-version overflow. Evidence schema v2 is retained at
+version overflow. Evidence schema v3 is retained at
 `crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json`,
 guarded by `scripts/verify/verify-blog-comments-event-projection.mjs` and focused
 fixture `scripts/verify/verify-blog-comments-event-projection.test.mjs`. The Rust
 source harness is the `services::comment_projection::tests` module in
 `crates/rustok-blog/src/services/comment_projection.rs`, with status
 `executable_no_run` and suggested command
-`cargo test -p rustok-blog --lib services::comment_projection::tests`. Exact
-commands `verify:blog:comments-event-projection` and
+`cargo test -p rustok-blog --lib services::comment_projection::tests`.
+
+The retained PostgreSQL target is
+`crates/rustok-blog/tests/comment_projection_postgres_test.rs`. It uses
+`RUSTOK_BLOG_TEST_DATABASE_URL` (or PostgreSQL `DATABASE_URL`), a unique schema,
+and a one-connection pool. Its four written cases cover duplicate-envelope
+idempotency, delete-before-create ordering, missing-post replay after source
+creation, and rollback/retry when the outbox table is unavailable. The suggested
+command is
+`RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test`.
+The target is registered as `executable_no_run`; no PostgreSQL result is recorded.
+Exact commands `verify:blog:comments-event-projection` and
 `test:verify:blog:comments-event-projection` run after the Comments port gate in
 the Blog FBA chains. Overall status remains `source_verified_no_compile`;
-runtime delivery and recovery, duplicate ledger behavior, rollback, restart, and
-PostgreSQL evidence are not recorded.
+concurrent optimistic exhaustion, host dispatch, restart recovery, and all
+execution evidence remain pending.
 
 Blog categories use the exclusive `blog_categories:*` permission resource.
 `CategoryService::new(db, event_bus)` is the only owner constructor. Category
@@ -230,16 +240,26 @@ evidence to schema v2 and Blog registry schema v11, and extends both the focused
 and aggregate fail-closed guards. No Rust test, verifier, compile, database,
 workflow, browser, or CI execution is recorded.
 
+The continuation audit at `a7be516f87195e6b940f8b1aeb2bc5135c289b4e`
+found that duplicate, out-of-order, missing-post recovery, and transactional
+rollback remained prose-only runtime requirements after the pure unit harness was
+added. Slice 45 adds an env-gated isolated PostgreSQL integration target with four
+written cases, upgrades projection evidence to schema v3 and Blog registry to
+schema v12, and retains the target in the focused and aggregate source gates. No
+Rust test, verifier, compile, PostgreSQL, workflow, browser, or CI execution is
+recorded.
+
 ## FFA/FBA status
 
 - FFA status: `in_progress`.
 - FBA status: `boundary_ready` (`core_transport_ui`).
-- Blog FBA source-gate chain: `source_verified_no_compile`; registry schema v11
+- Blog FBA source-gate chain: `source_verified_no_compile`; registry schema v12
   locks exact verify/test order, source-gate paths, leaf npm commands, evidence,
-  self-tests, the Comments projection unit harness, and aggregate/consumer
-  bindings for admin, storefront, Comments port boundary, Comments event
-  projection, category Search reindex, GraphQL rate limiting, GraphQL richtext,
-  AI richtext, offline backfill, Forum ownership, and runtime order.
+  self-tests, the Comments projection unit and PostgreSQL harnesses, and
+  aggregate/consumer bindings for admin, storefront, Comments port boundary,
+  Comments event projection, category Search reindex, GraphQL rate limiting,
+  GraphQL richtext, AI richtext, offline backfill, Forum ownership, and runtime
+  order.
 - Comments consumer port boundary: Blog-owned `source_verified_no_compile` for
   the in-process profile; all seven operations, approved public read, typed
   richtext projection, two-second deadlines, write idempotency, active typed
@@ -247,11 +267,13 @@ workflow, browser, or CI execution is recorded.
   ordering are locked. The remote adapter and degraded UI modes remain planned;
   runtime evidence is pending.
 - Comments event projection: Blog-owned `source_verified_no_compile`; evidence
-  schema v2, shared classifier/counter helpers, `executable_no_run` Rust unit
-  harness, verifier, focused self-test, exact npm leaf commands, delivery-ledger
-  identity, transactional outbox markers, and Blog FBA ordering are locked.
-  Duplicate, out-of-order, retry, rollback, restart, and PostgreSQL execution
-  remain pending.
+  schema v3, shared classifier/counter helpers, `executable_no_run` Rust unit and
+  PostgreSQL harnesses, verifier, focused self-test, exact npm leaf commands,
+  delivery-ledger identity, transactional outbox markers, and Blog FBA ordering
+  are locked. The PostgreSQL target writes duplicate, out-of-order, missing-post
+  replay, and outbox rollback/retry cases but has not been run. Concurrent
+  optimistic exhaustion, host dispatch, restart recovery, and all execution
+  evidence remain pending.
 - Load protection: `implementation_ready`; mounted Redis evidence is pending.
 - Rate-limit harness: `executable_no_compile`; evidence, verifier, self-test,
   npm leaf commands, and aggregate FBA registration are locked; execution is
@@ -284,6 +306,8 @@ workflow, browser, or CI execution is recorded.
 - `crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-consumer-runtime-order-smoke.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json`
+- `crates/rustok-blog/src/services/comment_projection.rs`
+- `crates/rustok-blog/tests/comment_projection_postgres_test.rs`
 - `crates/rustok-comments/contracts/comments-fba-registry.json`
 - `crates/rustok-comments/contracts/evidence/comments-thread-write-invariants.json`
 - `crates/rustok-blog/contracts/evidence/blog-graphql-rate-limit-runtime-harness.json`
@@ -411,6 +435,10 @@ workflow, browser, or CI execution is recorded.
     transition, added three Rust unit cases, upgraded event evidence to schema v2
     and Blog registry schema v11, and extended focused/aggregate source guards
     without recording execution.
+45. Added an env-gated isolated PostgreSQL event-projection target for duplicate,
+    delete-before-create, missing-post replay, and outbox rollback/retry behavior;
+    upgraded projection evidence to schema v3 and Blog registry schema v12, and
+    retained the target in focused/aggregate source gates without running it.
 
 ## Next results
 
@@ -428,12 +456,14 @@ workflow, browser, or CI execution is recorded.
    controller handoff, focused verifier, then Redis-backed host requests with a
    real HTTP `Retry-After` matching GraphQL `retryAfter`.
 5. **Close comments runtime evidence.** Run the Comments port boundary fixture,
-   shared consumer runtime-order verifier, the Blog projection unit harness, both
-   thread invariant concurrency targets, and concurrent PostgreSQL create/delete
-   transactions; cover the remote adapter, degraded UI modes, approved-only reads,
-   moderation, pagination, duplicate delivery, counters, first-thread identity,
-   unrelated insert storage error propagation, missing-post retry, rollback,
-   outbox publication, and restart recovery.
+   shared consumer runtime-order verifier, Blog projection unit harness, the
+   `comment_projection_postgres_test` target, both thread invariant concurrency
+   targets, and concurrent PostgreSQL create/delete transactions. Retain the
+   written duplicate, delete-before-create, missing-post replay, and outbox
+   rollback/retry assertions; then cover concurrent optimistic exhaustion, host
+   dispatch, restart recovery, remote adapter parity, degraded UI modes,
+   approved-only reads, moderation, pagination, first-thread identity, and
+   unrelated insert storage error propagation.
 6. **Execute and retain Blog article richtext cutover evidence.** Run the offline
    backfill in default dry-run mode, review its report, apply accepted conversion,
    execute the irreversible migration, reindex/rollback Search, and retain
@@ -450,6 +480,7 @@ should run the relevant subset, including:
 - `npm run verify:blog:comments-event-projection`
 - `npm run test:verify:blog:comments-event-projection`
 - `cargo test -p rustok-blog --lib services::comment_projection::tests`
+- `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test`
 - `npm run verify:blog:category-search-reindex`
 - `npm run test:verify:blog:category-search-reindex`
 - `npm run verify:blog:graphql-rate-limit`

--- a/crates/rustok-blog/tests/comment_projection_postgres_test.rs
+++ b/crates/rustok-blog/tests/comment_projection_postgres_test.rs
@@ -1,0 +1,398 @@
+use std::error::Error;
+
+use rustok_blog::services::BlogCommentProjectionHandler;
+use rustok_core::events::EventHandler;
+use rustok_events::{DomainEvent, EventEnvelope};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
+};
+use uuid::Uuid;
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";
+
+struct PostgresBlogProjectionTestDb {
+    control: DatabaseConnection,
+    db: DatabaseConnection,
+    schema_name: String,
+}
+
+impl PostgresBlogProjectionTestDb {
+    async fn setup(prefix: &str) -> TestResult<Option<Self>> {
+        let Some(database_url) = postgres_database_url() else {
+            eprintln!(
+                "{BLOG_TEST_DATABASE_ENV} is not set to a PostgreSQL URL; skipping Blog comment projection test"
+            );
+            return Ok(None);
+        };
+
+        let control = connect(&database_url).await?;
+        let schema_name = format!(
+            "rustok_blog_{}_{}",
+            sanitize_identifier(prefix),
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let db = connect(&database_url).await?;
+        set_search_path(&db, &schema_name).await?;
+
+        if let Err(error) = create_projection_tables(&db).await {
+            let _ = control
+                .execute_unprepared(&format!(r#"DROP SCHEMA IF EXISTS "{schema_name}" CASCADE"#))
+                .await;
+            return Err(error.into());
+        }
+
+        Ok(Some(Self {
+            control,
+            db,
+            schema_name,
+        }))
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn duplicate_delivery_updates_counter_and_outbox_once() -> TestResult<()> {
+    let Some(test_db) = PostgresBlogProjectionTestDb::setup("duplicate").await? else {
+        return Ok(());
+    };
+
+    let tenant_id = Uuid::new_v4();
+    let post_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    let comment_id = Uuid::new_v4();
+    insert_post(&test_db.db, tenant_id, post_id, actor_id, 0, 1).await?;
+
+    let envelope = comment_created_envelope(tenant_id, actor_id, comment_id, post_id);
+    let handler = BlogCommentProjectionHandler::new(test_db.db.clone());
+    handler.handle(&envelope).await?;
+    handler.handle(&envelope).await?;
+
+    assert_eq!(load_post_state(&test_db.db, tenant_id, post_id).await?, (1, 2));
+    assert_eq!(count_delivery(&test_db.db, envelope.id).await?, 1);
+    assert_eq!(count_outbox_events(&test_db.db).await?, 1);
+
+    test_db.cleanup().await
+}
+
+#[tokio::test]
+async fn delete_before_create_stays_non_negative_and_replays_in_order() -> TestResult<()> {
+    let Some(test_db) = PostgresBlogProjectionTestDb::setup("out_of_order").await? else {
+        return Ok(());
+    };
+
+    let tenant_id = Uuid::new_v4();
+    let post_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    insert_post(&test_db.db, tenant_id, post_id, actor_id, 0, 1).await?;
+
+    let handler = BlogCommentProjectionHandler::new(test_db.db.clone());
+    let deleted = EventEnvelope::new(
+        tenant_id,
+        Some(actor_id),
+        DomainEvent::CommentDeleted {
+            comment_id: Uuid::new_v4(),
+            target_type: "blog_post".to_string(),
+            target_id: post_id,
+            author_id: actor_id,
+        },
+    );
+    handler.handle(&deleted).await?;
+    assert_eq!(load_post_state(&test_db.db, tenant_id, post_id).await?, (0, 2));
+
+    let created = comment_created_envelope(
+        tenant_id,
+        actor_id,
+        Uuid::new_v4(),
+        post_id,
+    );
+    handler.handle(&created).await?;
+
+    assert_eq!(load_post_state(&test_db.db, tenant_id, post_id).await?, (1, 3));
+    assert_eq!(count_delivery(&test_db.db, deleted.id).await?, 1);
+    assert_eq!(count_delivery(&test_db.db, created.id).await?, 1);
+    assert_eq!(count_outbox_events(&test_db.db).await?, 2);
+
+    test_db.cleanup().await
+}
+
+#[tokio::test]
+async fn missing_post_replay_commits_only_after_source_appears() -> TestResult<()> {
+    let Some(test_db) = PostgresBlogProjectionTestDb::setup("missing_post").await? else {
+        return Ok(());
+    };
+
+    let tenant_id = Uuid::new_v4();
+    let post_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    let envelope = comment_created_envelope(
+        tenant_id,
+        actor_id,
+        Uuid::new_v4(),
+        post_id,
+    );
+    let handler = BlogCommentProjectionHandler::new(test_db.db.clone());
+
+    let error = handler
+        .handle(&envelope)
+        .await
+        .expect_err("missing Blog post must keep the delivery retryable");
+    assert!(error.to_string().contains("was not found"));
+    assert_eq!(count_delivery(&test_db.db, envelope.id).await?, 0);
+    assert_eq!(count_outbox_events(&test_db.db).await?, 0);
+
+    insert_post(&test_db.db, tenant_id, post_id, actor_id, 0, 1).await?;
+    handler.handle(&envelope).await?;
+
+    assert_eq!(load_post_state(&test_db.db, tenant_id, post_id).await?, (1, 2));
+    assert_eq!(count_delivery(&test_db.db, envelope.id).await?, 1);
+    assert_eq!(count_outbox_events(&test_db.db).await?, 1);
+
+    test_db.cleanup().await
+}
+
+#[tokio::test]
+async fn outbox_failure_rolls_back_counter_and_delivery_before_retry() -> TestResult<()> {
+    let Some(test_db) = PostgresBlogProjectionTestDb::setup("outbox_rollback").await? else {
+        return Ok(());
+    };
+
+    let tenant_id = Uuid::new_v4();
+    let post_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    insert_post(&test_db.db, tenant_id, post_id, actor_id, 0, 1).await?;
+
+    let envelope = comment_created_envelope(
+        tenant_id,
+        actor_id,
+        Uuid::new_v4(),
+        post_id,
+    );
+    let handler = BlogCommentProjectionHandler::new(test_db.db.clone());
+
+    test_db.db.execute_unprepared("DROP TABLE sys_events").await?;
+    handler
+        .handle(&envelope)
+        .await
+        .expect_err("missing outbox table must fail the projection transaction");
+
+    assert_eq!(load_post_state(&test_db.db, tenant_id, post_id).await?, (0, 1));
+    assert_eq!(count_delivery(&test_db.db, envelope.id).await?, 0);
+
+    create_outbox_table(&test_db.db).await?;
+    handler.handle(&envelope).await?;
+
+    assert_eq!(load_post_state(&test_db.db, tenant_id, post_id).await?, (1, 2));
+    assert_eq!(count_delivery(&test_db.db, envelope.id).await?, 1);
+    assert_eq!(count_outbox_events(&test_db.db).await?, 1);
+
+    test_db.cleanup().await
+}
+
+fn comment_created_envelope(
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    comment_id: Uuid,
+    post_id: Uuid,
+) -> EventEnvelope {
+    EventEnvelope::new(
+        tenant_id,
+        Some(actor_id),
+        DomainEvent::CommentCreated {
+            comment_id,
+            target_type: "blog_post".to_string(),
+            target_id: post_id,
+            author_id: actor_id,
+        },
+    )
+}
+
+async fn create_projection_tables(db: &DatabaseConnection) -> Result<(), sea_orm::DbErr> {
+    db.execute_unprepared(
+        r#"
+        CREATE TABLE blog_posts (
+            id UUID PRIMARY KEY,
+            tenant_id UUID NOT NULL,
+            author_id UUID NOT NULL,
+            category_id UUID NULL,
+            status TEXT NOT NULL,
+            slug TEXT NOT NULL,
+            metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+            featured_image_url TEXT NULL,
+            published_at TIMESTAMPTZ NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            archived_at TIMESTAMPTZ NULL,
+            comment_count INTEGER NOT NULL DEFAULT 0,
+            view_count INTEGER NOT NULL DEFAULT 0,
+            version INTEGER NOT NULL DEFAULT 1
+        );
+
+        CREATE TABLE blog_comment_projection_deliveries (
+            event_id UUID PRIMARY KEY,
+            tenant_id UUID NOT NULL,
+            comment_id UUID NOT NULL,
+            post_id UUID NOT NULL,
+            delta INTEGER NOT NULL,
+            processed_at TIMESTAMPTZ NOT NULL
+        );
+        "#,
+    )
+    .await?;
+    create_outbox_table(db).await
+}
+
+async fn create_outbox_table(db: &DatabaseConnection) -> Result<(), sea_orm::DbErr> {
+    db.execute_unprepared(
+        r#"
+        CREATE TABLE sys_events (
+            id UUID PRIMARY KEY,
+            event_type TEXT NOT NULL,
+            schema_version SMALLINT NOT NULL,
+            payload JSONB NOT NULL,
+            status VARCHAR(32) NOT NULL,
+            retry_count INTEGER NOT NULL,
+            next_attempt_at TIMESTAMPTZ NULL,
+            last_error TEXT NULL,
+            claimed_by TEXT NULL,
+            claimed_at TIMESTAMPTZ NULL,
+            created_at TIMESTAMPTZ NOT NULL,
+            dispatched_at TIMESTAMPTZ NULL
+        )
+        "#,
+    )
+    .await?;
+    Ok(())
+}
+
+async fn insert_post(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    post_id: Uuid,
+    author_id: Uuid,
+    comment_count: i32,
+    version: i32,
+) -> Result<(), sea_orm::DbErr> {
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+        INSERT INTO blog_posts (
+            id, tenant_id, author_id, status, slug, metadata,
+            comment_count, view_count, version
+        ) VALUES ($1, $2, $3, 'published', 'projection-test', '{}'::jsonb, $4, 0, $5)
+        "#,
+        vec![
+            post_id.into(),
+            tenant_id.into(),
+            author_id.into(),
+            comment_count.into(),
+            version.into(),
+        ],
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn load_post_state(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    post_id: Uuid,
+) -> Result<(i32, i32), sea_orm::DbErr> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+            SELECT comment_count, version
+            FROM blog_posts
+            WHERE tenant_id = $1 AND id = $2
+            "#,
+            vec![tenant_id.into(), post_id.into()],
+        ))
+        .await?
+        .expect("Blog post state should exist");
+    Ok((
+        row.try_get("", "comment_count")?,
+        row.try_get("", "version")?,
+    ))
+}
+
+async fn count_delivery(
+    db: &DatabaseConnection,
+    event_id: Uuid,
+) -> Result<i64, sea_orm::DbErr> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT COUNT(*)::bigint AS count FROM blog_comment_projection_deliveries WHERE event_id = $1",
+            vec![event_id.into()],
+        ))
+        .await?
+        .expect("delivery count query should return one row");
+    row.try_get("", "count")
+}
+
+async fn count_outbox_events(db: &DatabaseConnection) -> Result<i64, sea_orm::DbErr> {
+    let row = db
+        .query_one(Statement::from_string(
+            DbBackend::Postgres,
+            "SELECT COUNT(*)::bigint AS count FROM sys_events".to_string(),
+        ))
+        .await?
+        .expect("outbox count query should return one row");
+    row.try_get("", "count")
+}
+
+fn postgres_database_url() -> Option<String> {
+    std::env::var(BLOG_TEST_DATABASE_ENV)
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn set_search_path(db: &DatabaseConnection, schema_name: &str) -> TestResult<()> {
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}", public"#))
+        .await?;
+    Ok(())
+}
+
+fn sanitize_identifier(value: &str) -> String {
+    let normalized = value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    let normalized = normalized.trim_matches('_');
+    if normalized.is_empty() {
+        "test".to_string()
+    } else {
+        normalized.to_string()
+    }
+}

--- a/scripts/verify/blog-fba-verification-chain.mjs
+++ b/scripts/verify/blog-fba-verification-chain.mjs
@@ -43,6 +43,7 @@ export const BLOG_FBA_SOURCE_GATES = {
     verifier: 'scripts/verify/verify-blog-comments-event-projection.mjs',
     self_test: 'scripts/verify/verify-blog-comments-event-projection.test.mjs',
     unit_test: 'crates/rustok-blog/src/services/comment_projection.rs',
+    postgres_test: 'crates/rustok-blog/tests/comment_projection_postgres_test.rs',
     evidence: 'crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json',
   },
   category_search_reindex: {
@@ -170,7 +171,8 @@ export function collectBlogFbaVerificationChainFailures({
       gate?.verifier !== expectedGate.verifier ||
       gate?.self_test !== expectedGate.self_test ||
       gate?.evidence !== expectedGate.evidence ||
-      gate?.unit_test !== expectedGate.unit_test
+      gate?.unit_test !== expectedGate.unit_test ||
+      gate?.postgres_test !== expectedGate.postgres_test
     ) {
       failures.push(`registry source gate ${gateName} path drift`);
     }
@@ -196,6 +198,7 @@ export function collectBlogFbaVerificationChainFailures({
       expectedGate.self_test,
       expectedGate.evidence,
       expectedGate.unit_test,
+      expectedGate.postgres_test,
     ].filter(Boolean)) {
       if (!existsSync(filePath)) {
         failures.push(`registry source gate ${gateName} missing ${filePath}`);

--- a/scripts/verify/verify-blog-comments-event-projection.mjs
+++ b/scripts/verify/verify-blog-comments-event-projection.mjs
@@ -31,6 +31,7 @@ function requireNoMarker(source, marker, label) {
 
 const evidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json';
 const handlerPath = 'crates/rustok-blog/src/services/comment_projection.rs';
+const postgresHarnessPath = 'crates/rustok-blog/tests/comment_projection_postgres_test.rs';
 const serviceExportPath = 'crates/rustok-blog/src/services/mod.rs';
 const entityPath = 'crates/rustok-blog/src/entities/blog_comment_projection_delivery.rs';
 const migrationPath = 'crates/rustok-blog/src/migrations/m20260716_000001_create_blog_comment_projection_deliveries.rs';
@@ -39,8 +40,11 @@ const modulePath = 'crates/rustok-blog/src/lib.rs';
 const registryPath = 'crates/rustok-blog/contracts/blog-fba-registry.json';
 const planPath = 'crates/rustok-blog/docs/implementation-plan.md';
 const harnessCommand = 'cargo test -p rustok-blog --lib services::comment_projection::tests';
+const postgresHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test';
+const postgresHarnessEnvironment = 'RUSTOK_BLOG_TEST_DATABASE_URL';
 
 const handler = read(handlerPath);
+const postgresHarness = read(postgresHarnessPath);
 const serviceExport = read(serviceExportPath);
 const entity = read(entityPath);
 const migration = read(migrationPath);
@@ -110,6 +114,33 @@ if (handlesStart === -1 || handleStart === -1) {
 }
 
 for (const marker of [
+  'const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";',
+  'struct PostgresBlogProjectionTestDb',
+  'CREATE SCHEMA',
+  'DROP SCHEMA IF EXISTS',
+  '.max_connections(1)',
+  'SET search_path TO',
+  'async fn duplicate_delivery_updates_counter_and_outbox_once()',
+  'handler.handle(&envelope).await?;',
+  'async fn delete_before_create_stays_non_negative_and_replays_in_order()',
+  'DomainEvent::CommentDeleted',
+  'async fn missing_post_replay_commits_only_after_source_appears()',
+  'missing Blog post must keep the delivery retryable',
+  'async fn outbox_failure_rolls_back_counter_and_delivery_before_retry()',
+  'DROP TABLE sys_events',
+  'missing outbox table must fail the projection transaction',
+  'create_outbox_table(&test_db.db).await?;',
+  'CREATE TABLE blog_comment_projection_deliveries',
+  'CREATE TABLE sys_events',
+  'count_delivery(&test_db.db, envelope.id)',
+  'count_outbox_events(&test_db.db)',
+]) {
+  requireMarker(postgresHarness, marker, postgresHarnessPath);
+}
+requireNoMarker(postgresHarness, '#[ignore]', postgresHarnessPath);
+requireNoMarker(postgresHarness, 'runtime_verified', postgresHarnessPath);
+
+for (const marker of [
   '#[sea_orm(table_name = "blog_comment_projection_deliveries")]',
   '#[sea_orm(primary_key, auto_increment = false)]',
   'pub event_id: Uuid',
@@ -146,7 +177,7 @@ for (const marker of [
 }
 
 if (evidence) {
-  if (evidence.schema_version !== 2) failures.push(`${evidencePath}: schema_version drift`);
+  if (evidence.schema_version !== 3) failures.push(`${evidencePath}: schema_version drift`);
   if (
     evidence.module !== 'blog' ||
     evidence.surface !== 'comments_event_projection' ||
@@ -157,6 +188,7 @@ if (evidence) {
   }
   if (evidence.status !== 'source_verified_no_compile') failures.push(`${evidencePath}: status drift`);
   if (evidence.compile_policy !== 'not_run_by_request') failures.push(`${evidencePath}: compile policy drift`);
+  if (evidence.runtime_status !== 'pending') failures.push(`${evidencePath}: runtime status drift`);
   const contract = evidence.production_contract ?? {};
   for (const [key, expected] of Object.entries({
     handler: handlerPath,
@@ -188,6 +220,28 @@ if (evidence) {
   ) {
     failures.push(`${evidencePath}: source harness case drift`);
   }
+  const postgres = evidence.postgres_harness ?? {};
+  if (
+    postgres.status !== 'executable_no_run' ||
+    postgres.runtime_status !== 'not_run' ||
+    postgres.path !== postgresHarnessPath ||
+    postgres.environment !== postgresHarnessEnvironment ||
+    postgres.command !== postgresHarnessCommand ||
+    postgres.isolation !== 'unique_schema_one_connection_pool'
+  ) {
+    failures.push(`${evidencePath}: PostgreSQL harness drift`);
+  }
+  const postgresCases = [...(postgres.cases ?? [])].sort().join('|');
+  if (
+    postgresCases !== [
+      'duplicate_delivery_updates_counter_and_outbox_once',
+      'delete_before_create_stays_non_negative_and_replays_in_order',
+      'missing_post_replay_commits_only_after_source_appears',
+      'outbox_failure_rolls_back_counter_and_delivery_before_retry',
+    ].sort().join('|')
+  ) {
+    failures.push(`${evidencePath}: PostgreSQL harness case drift`);
+  }
   const events = [...(evidence.events ?? [])].sort().join('|');
   if (events !== ['comment.created', 'comment.deleted'].sort().join('|')) {
     failures.push(`${evidencePath}: event set drift`);
@@ -202,6 +256,10 @@ if (evidence) {
     'tenant_scoped_optimistic_update',
     'missing_post_retry',
     'non_negative_count',
+    'postgres_duplicate_delivery',
+    'postgres_out_of_order_delete_create',
+    'postgres_missing_post_recovery',
+    'postgres_outbox_rollback_recovery',
     'module_listener_registration',
   ]) {
     if (!cases.has(requiredCase)) failures.push(`${evidencePath}: missing case ${requiredCase}`);
@@ -209,6 +267,7 @@ if (evidence) {
 }
 
 if (registry) {
+  if (registry.schema_version !== 12) failures.push(`${registryPath}: schema_version drift`);
   if (registry.evidence?.comments_event_projection !== evidencePath) {
     failures.push(`${registryPath}: comments event projection evidence path drift`);
   }
@@ -229,9 +288,21 @@ if (registry) {
   ) {
     failures.push(`${registryPath}: event projection source harness drift`);
   }
+  if (
+    projection.postgres_harness?.path !== postgresHarnessPath ||
+    projection.postgres_harness?.status !== 'executable_no_run' ||
+    projection.postgres_harness?.runtime_status !== 'not_run' ||
+    projection.postgres_harness?.environment !== postgresHarnessEnvironment ||
+    projection.postgres_harness?.command !== postgresHarnessCommand
+  ) {
+    failures.push(`${registryPath}: event projection PostgreSQL harness drift`);
+  }
   const sourceGate = registry.verification_chain?.source_gates?.comments_event_projection;
   if (sourceGate?.unit_test !== handlerPath) {
     failures.push(`${registryPath}: comments event projection unit test path drift`);
+  }
+  if (sourceGate?.postgres_test !== postgresHarnessPath) {
+    failures.push(`${registryPath}: comments event projection PostgreSQL test path drift`);
   }
 }
 
@@ -241,6 +312,8 @@ for (const marker of [
   'test:verify:blog:comments-event-projection',
   'source_verified_no_compile',
   'services::comment_projection::tests',
+  'comment_projection_postgres_test',
+  'RUSTOK_BLOG_TEST_DATABASE_URL',
   'runtime delivery and recovery',
 ]) {
   requireMarker(plan, marker, planPath);
@@ -252,4 +325,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log('Blog comments event projection source contract and unit harness are consistent');
+console.log('Blog comments event projection source contract, unit harness, and PostgreSQL target are consistent');

--- a/scripts/verify/verify-blog-comments-event-projection.test.mjs
+++ b/scripts/verify/verify-blog-comments-event-projection.test.mjs
@@ -23,12 +23,17 @@ function fixture({
   missingSharedClassifier = false,
   directHandlesClassifier = false,
   missingCounterHarness = false,
+  missingPostgresHarness = false,
+  missingRollbackCase = false,
+  missingPostgresRegistration = false,
   statusDrift = false,
   harnessStatusDrift = false,
+  postgresStatusDrift = false,
 } = {}) {
   const root = mkdtempSync(path.join(tmpdir(), 'rustok-blog-comments-projection-'));
   const evidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json';
   const handlerPath = 'crates/rustok-blog/src/services/comment_projection.rs';
+  const postgresHarnessPath = 'crates/rustok-blog/tests/comment_projection_postgres_test.rs';
   const serviceExportPath = 'crates/rustok-blog/src/services/mod.rs';
   const entityPath = 'crates/rustok-blog/src/entities/blog_comment_projection_delivery.rs';
   const migrationPath = 'crates/rustok-blog/src/migrations/m20260716_000001_create_blog_comment_projection_deliveries.rs';
@@ -36,6 +41,7 @@ function fixture({
   const modulePath = 'crates/rustok-blog/src/lib.rs';
   const registryPath = 'crates/rustok-blog/contracts/blog-fba-registry.json';
   const harnessCommand = 'cargo test -p rustok-blog --lib services::comment_projection::tests';
+  const postgresHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test';
 
   write(
     root,
@@ -77,6 +83,36 @@ fn ignores_non_blog_targets_and_unrelated_events()
 ${missingCounterHarness ? '' : 'fn counter_transition_is_non_negative_and_saturating()'}
 `,
   );
+
+  if (!missingPostgresHarness) {
+    write(
+      root,
+      postgresHarnessPath,
+      `
+const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";
+struct PostgresBlogProjectionTestDb
+CREATE SCHEMA
+DROP SCHEMA IF EXISTS
+.max_connections(1)
+SET search_path TO
+async fn duplicate_delivery_updates_counter_and_outbox_once()
+handler.handle(&envelope).await?;
+async fn delete_before_create_stays_non_negative_and_replays_in_order()
+DomainEvent::CommentDeleted
+async fn missing_post_replay_commits_only_after_source_appears()
+missing Blog post must keep the delivery retryable
+${missingRollbackCase ? '' : 'async fn outbox_failure_rolls_back_counter_and_delivery_before_retry()'}
+DROP TABLE sys_events
+missing outbox table must fail the projection transaction
+create_outbox_table(&test_db.db).await?;
+CREATE TABLE blog_comment_projection_deliveries
+CREATE TABLE sys_events
+count_delivery(&test_db.db, envelope.id)
+count_outbox_events(&test_db.db)
+`,
+    );
+  }
+
   write(root, serviceExportPath, 'pub use comment_projection::BlogCommentProjectionHandler;');
   write(
     root,
@@ -122,11 +158,12 @@ registry.register(services::BlogCommentProjectionHandler::new(ctx.db.clone()));`
     root,
     evidencePath,
     JSON.stringify({
-      schema_version: 2,
+      schema_version: 3,
       module: 'blog',
       surface: 'comments_event_projection',
       status: statusDrift ? 'runtime_verified' : 'source_verified_no_compile',
       compile_policy: 'not_run_by_request',
+      runtime_status: 'pending',
       owner: 'rustok-blog',
       provider: 'rustok-comments',
       events: ['comment.created', 'comment.deleted'],
@@ -150,6 +187,20 @@ registry.register(services::BlogCommentProjectionHandler::new(ctx.db.clone()));`
           'non_negative_saturating_counter_transition',
         ],
       },
+      postgres_harness: {
+        status: postgresStatusDrift ? 'executed' : 'executable_no_run',
+        runtime_status: postgresStatusDrift ? 'passed' : 'not_run',
+        path: postgresHarnessPath,
+        environment: 'RUSTOK_BLOG_TEST_DATABASE_URL',
+        command: postgresHarnessCommand,
+        isolation: 'unique_schema_one_connection_pool',
+        cases: [
+          'duplicate_delivery_updates_counter_and_outbox_once',
+          'delete_before_create_stays_non_negative_and_replays_in_order',
+          'missing_post_replay_commits_only_after_source_appears',
+          'outbox_failure_rolls_back_counter_and_delivery_before_retry',
+        ],
+      },
       cases: [
         { name: 'shared_event_classifier' },
         { name: 'blog_post_target_filter' },
@@ -159,6 +210,10 @@ registry.register(services::BlogCommentProjectionHandler::new(ctx.db.clone()));`
         { name: 'tenant_scoped_optimistic_update' },
         { name: 'missing_post_retry' },
         { name: 'non_negative_count' },
+        { name: 'postgres_duplicate_delivery' },
+        { name: 'postgres_out_of_order_delete_create' },
+        { name: 'postgres_missing_post_recovery' },
+        { name: 'postgres_outbox_rollback_recovery' },
         { name: 'module_listener_registration' },
       ],
     }),
@@ -167,10 +222,14 @@ registry.register(services::BlogCommentProjectionHandler::new(ctx.db.clone()));`
     root,
     registryPath,
     JSON.stringify({
+      schema_version: 12,
       evidence: { comments_event_projection: evidencePath },
       verification_chain: {
         source_gates: {
-          comments_event_projection: { unit_test: handlerPath },
+          comments_event_projection: {
+            unit_test: handlerPath,
+            ...(missingPostgresRegistration ? {} : { postgres_test: postgresHarnessPath }),
+          },
         },
       },
       event_projection: {
@@ -184,13 +243,20 @@ registry.register(services::BlogCommentProjectionHandler::new(ctx.db.clone()));`
           status: 'executable_no_run',
           command: harnessCommand,
         },
+        postgres_harness: {
+          path: postgresHarnessPath,
+          status: postgresStatusDrift ? 'executed' : 'executable_no_run',
+          runtime_status: postgresStatusDrift ? 'passed' : 'not_run',
+          environment: 'RUSTOK_BLOG_TEST_DATABASE_URL',
+          command: postgresHarnessCommand,
+        },
       },
     }),
   );
   write(
     root,
     'crates/rustok-blog/docs/implementation-plan.md',
-    'blog-comments-event-projection.json verify:blog:comments-event-projection test:verify:blog:comments-event-projection source_verified_no_compile services::comment_projection::tests runtime delivery and recovery',
+    'blog-comments-event-projection.json verify:blog:comments-event-projection test:verify:blog:comments-event-projection source_verified_no_compile services::comment_projection::tests comment_projection_postgres_test RUSTOK_BLOG_TEST_DATABASE_URL runtime delivery and recovery',
   );
 
   return root;
@@ -204,6 +270,17 @@ function run(root) {
   });
 }
 
+function expectRejected(options, pattern) {
+  const root = fixture(options);
+  try {
+    const result = run(root);
+    assert.notEqual(result.status, 0);
+    if (pattern) assert.match(result.stderr, pattern);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
 test('accepts the canonical Comments-to-Blog projection contract', () => {
   const root = fixture();
   try {
@@ -215,92 +292,62 @@ test('accepts the canonical Comments-to-Blog projection contract', () => {
 });
 
 test('rejects a projection without tenant scope', () => {
-  const root = fixture({ missingTenantScope: true });
-  try {
-    assert.notEqual(run(root).status, 0);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  expectRejected({ missingTenantScope: true });
 });
 
 test('rejects a projection without envelope-id delivery lookup', () => {
-  const root = fixture({ missingDeliveryLookup: true });
-  try {
-    assert.notEqual(run(root).status, 0);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  expectRejected({ missingDeliveryLookup: true });
 });
 
 test('rejects a projection without transactional outbox publication', () => {
-  const root = fixture({ missingOutbox: true });
-  try {
-    assert.notEqual(run(root).status, 0);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  expectRejected({ missingOutbox: true });
 });
 
 test('rejects missing module event-listener registration', () => {
-  const root = fixture({ missingRegistration: true });
-  try {
-    assert.notEqual(run(root).status, 0);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  expectRejected({ missingRegistration: true });
 });
 
 test('rejects project without the shared event classifier', () => {
-  const root = fixture({ missingSharedClassifier: true });
-  try {
-    const result = run(root);
-    assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /missing fn comment_projection_change/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  expectRejected({ missingSharedClassifier: true }, /missing fn comment_projection_change/);
 });
 
 test('rejects a separate EventHandler classifier', () => {
-  const root = fixture({ directHandlesClassifier: true });
-  try {
-    const result = run(root);
-    assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /forbidden matches!/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  expectRejected({ directHandlesClassifier: true }, /forbidden matches!/);
 });
 
 test('rejects a missing counter transition harness', () => {
-  const root = fixture({ missingCounterHarness: true });
-  try {
-    const result = run(root);
-    assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /missing fn counter_transition_is_non_negative_and_saturating/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  expectRejected(
+    { missingCounterHarness: true },
+    /missing fn counter_transition_is_non_negative_and_saturating/,
+  );
+});
+
+test('rejects a missing PostgreSQL harness source', () => {
+  expectRejected({ missingPostgresHarness: true }, /expected file is missing/);
+});
+
+test('rejects a PostgreSQL harness without rollback coverage', () => {
+  expectRejected(
+    { missingRollbackCase: true },
+    /missing async fn outbox_failure_rolls_back_counter_and_delivery_before_retry/,
+  );
+});
+
+test('rejects a registry without the PostgreSQL target', () => {
+  expectRejected(
+    { missingPostgresRegistration: true },
+    /PostgreSQL test path drift/,
+  );
 });
 
 test('rejects runtime status promotion without execution', () => {
-  const root = fixture({ statusDrift: true });
-  try {
-    const result = run(root);
-    assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /status drift/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  expectRejected({ statusDrift: true }, /status drift/);
 });
 
 test('rejects source harness execution promotion without execution', () => {
-  const root = fixture({ harnessStatusDrift: true });
-  try {
-    const result = run(root);
-    assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /source harness drift/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  expectRejected({ harnessStatusDrift: true }, /source harness drift/);
+});
+
+test('rejects PostgreSQL harness execution promotion without execution', () => {
+  expectRejected({ postgresStatusDrift: true }, /PostgreSQL harness drift/);
 });

--- a/scripts/verify/verify-blog-fba.mjs
+++ b/scripts/verify/verify-blog-fba.mjs
@@ -17,7 +17,10 @@ const runtimeSmokePath = 'crates/rustok-blog/contracts/evidence/blog-comments-ru
 const consumerRuntimeOrderSmokePath = 'crates/rustok-blog/contracts/evidence/blog-comments-consumer-runtime-order-smoke.json';
 const commentsEventProjectionPath = 'crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json';
 const projectionHandlerPath = 'crates/rustok-blog/src/services/comment_projection.rs';
+const projectionPostgresHarnessPath = 'crates/rustok-blog/tests/comment_projection_postgres_test.rs';
 const projectionHarnessCommand = 'cargo test -p rustok-blog --lib services::comment_projection::tests';
+const projectionPostgresHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test';
+const projectionPostgresHarnessEnvironment = 'RUSTOK_BLOG_TEST_DATABASE_URL';
 const richtextInventoryPath = 'crates/rustok-blog/contracts/evidence/blog-richtext-cutover-inventory.json';
 const richtextInventoryDocPath = 'crates/rustok-blog/docs/richtext-cutover-inventory.md';
 const categorySearchReindexPath = 'crates/rustok-blog/contracts/evidence/blog-category-search-reindex-contract.json';
@@ -30,6 +33,7 @@ const evidence = json(evidencePath);
 const runtimeSmoke = json(runtimeSmokePath);
 const consumerRuntimeOrderSmoke = json(consumerRuntimeOrderSmokePath);
 const commentsEventProjection = json(commentsEventProjectionPath);
+const projectionPostgresHarness = read(projectionPostgresHarnessPath);
 const richtextInventory = json(richtextInventoryPath);
 const categorySearchReindex = json(categorySearchReindexPath);
 const graphqlRateLimit = json(graphqlRateLimitPath);
@@ -37,7 +41,7 @@ const aiRichtextBoundary = json(aiRichtextBoundaryPath);
 const provider = json(providerPath);
 const packageJson = json(packageJsonPath);
 
-if (registry.schema_version !== 11) fail('registry schema_version drift');
+if (registry.schema_version !== 12) fail('registry schema_version drift');
 if (registry.module !== 'blog' || registry.role !== 'consumer' || !['in_progress', 'boundary_ready'].includes(registry.status)) fail('registry identity/status drift');
 for (const failure of collectBlogFbaVerificationChainFailures({
   registry,
@@ -48,15 +52,33 @@ for (const failure of collectBlogFbaVerificationChainFailures({
 }
 if (registry.consumer_profile !== 'blog_post_comments') fail('consumer profile drift');
 if (registry.evidence.comments_event_projection !== commentsEventProjectionPath) fail('comments event projection registry path drift');
-if (commentsEventProjection.schema_version !== 2) fail('comments event projection schema_version drift');
+if (commentsEventProjection.schema_version !== 3) fail('comments event projection schema_version drift');
 if (commentsEventProjection.module !== 'blog' || commentsEventProjection.surface !== 'comments_event_projection' || commentsEventProjection.owner !== 'rustok-blog' || commentsEventProjection.provider !== 'rustok-comments') fail('comments event projection identity drift');
-if (commentsEventProjection.status !== 'source_verified_no_compile' || commentsEventProjection.compile_policy !== 'not_run_by_request') fail('comments event projection status drift');
+if (commentsEventProjection.status !== 'source_verified_no_compile' || commentsEventProjection.compile_policy !== 'not_run_by_request' || commentsEventProjection.runtime_status !== 'pending') fail('comments event projection status drift');
 if (
   commentsEventProjection.source_harness?.status !== 'executable_no_run'
   || commentsEventProjection.source_harness?.path !== projectionHandlerPath
   || commentsEventProjection.source_harness?.module !== 'services::comment_projection::tests'
   || commentsEventProjection.source_harness?.command !== projectionHarnessCommand
 ) fail('comments event projection source harness drift');
+if (
+  commentsEventProjection.postgres_harness?.status !== 'executable_no_run'
+  || commentsEventProjection.postgres_harness?.runtime_status !== 'not_run'
+  || commentsEventProjection.postgres_harness?.path !== projectionPostgresHarnessPath
+  || commentsEventProjection.postgres_harness?.environment !== projectionPostgresHarnessEnvironment
+  || commentsEventProjection.postgres_harness?.command !== projectionPostgresHarnessCommand
+  || commentsEventProjection.postgres_harness?.isolation !== 'unique_schema_one_connection_pool'
+) fail('comments event projection PostgreSQL harness drift');
+sameSet(
+  commentsEventProjection.postgres_harness?.cases ?? [],
+  [
+    'duplicate_delivery_updates_counter_and_outbox_once',
+    'delete_before_create_stays_non_negative_and_replays_in_order',
+    'missing_post_replay_commits_only_after_source_appears',
+    'outbox_failure_rolls_back_counter_and_delivery_before_retry',
+  ],
+  'comments event projection PostgreSQL cases',
+);
 if (registry.evidence.richtext_cutover_inventory !== richtextInventoryPath) fail('richtext cutover inventory registry path drift');
 if (registry.evidence.richtext_cutover_inventory_doc !== richtextInventoryDocPath) fail('richtext cutover inventory doc registry path drift');
 if (registry.evidence.category_search_reindex !== categorySearchReindexPath) fail('category Search reindex registry path drift');
@@ -246,7 +268,15 @@ if (
   || projection.source_harness?.status !== 'executable_no_run'
   || projection.source_harness?.command !== projectionHarnessCommand
 ) fail('event projection registry source harness drift');
+if (
+  projection.postgres_harness?.path !== projectionPostgresHarnessPath
+  || projection.postgres_harness?.status !== 'executable_no_run'
+  || projection.postgres_harness?.runtime_status !== 'not_run'
+  || projection.postgres_harness?.environment !== projectionPostgresHarnessEnvironment
+  || projection.postgres_harness?.command !== projectionPostgresHarnessCommand
+) fail('event projection registry PostgreSQL harness drift');
 if (registry.verification_chain?.source_gates?.comments_event_projection?.unit_test !== projectionHandlerPath) fail('event projection source-gate unit test drift');
+if (registry.verification_chain?.source_gates?.comments_event_projection?.postgres_test !== projectionPostgresHarnessPath) fail('event projection source-gate PostgreSQL test drift');
 const projectionSource = read(projectionHandlerPath);
 hasAll(projectionSource, [
   'impl EventHandler for BlogCommentProjectionHandler',
@@ -261,16 +291,30 @@ hasAll(projectionSource, [
   'DomainEvent::BlogPostUpdated',
   '.publish_in_tx(',
 ], 'blog comment projection');
+hasAll(projectionPostgresHarness, [
+  'const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";',
+  'struct PostgresBlogProjectionTestDb',
+  '.max_connections(1)',
+  'SET search_path TO',
+  'async fn duplicate_delivery_updates_counter_and_outbox_once()',
+  'async fn delete_before_create_stays_non_negative_and_replays_in_order()',
+  'async fn missing_post_replay_commits_only_after_source_appears()',
+  'async fn outbox_failure_rolls_back_counter_and_delivery_before_retry()',
+  'DROP TABLE sys_events',
+  'CREATE TABLE blog_comment_projection_deliveries',
+  'CREATE TABLE sys_events',
+], 'blog comment projection PostgreSQL target');
+hasNone(projectionPostgresHarness, ['#[ignore]', 'runtime_verified'], 'blog comment projection PostgreSQL target');
 const migration = read('crates/rustok-blog/src/migrations/m20260716_000001_create_blog_comment_projection_deliveries.rs');
 hasAll(migration, ['BlogCommentProjectionDeliveries', 'EventId', 'TenantId', 'PostId'], 'blog comment projection migration');
 const moduleSource = read('crates/rustok-blog/src/lib.rs');
 hasAll(moduleSource, ['fn register_event_listeners(', 'BlogCommentProjectionHandler::new(ctx.db.clone())'], 'blog event-listener registration');
 
 const plan = read('crates/rustok-blog/docs/implementation-plan.md');
-hasAll(plan, ['- FBA status: `boundary_ready`', 'blog-fba-registry.json', commentsEventProjectionPath, categorySearchReindexPath, graphqlRateLimitPath, aiRichtextBoundaryPath, 'CommentsThreadPort', 'blog-comments-consumer-static-matrix.json', 'blog-comments-runtime-fallback-smoke.json', consumerRuntimeOrderSmokePath, 'verify:blog:comments-port-boundary', 'test:verify:blog:comments-port-boundary', 'verify:blog:comments-event-projection', 'test:verify:blog:comments-event-projection', 'services::comment_projection::tests', 'registry schema v11', 'degraded UI modes remain planned'], 'local plan');
+hasAll(plan, ['- FBA status: `boundary_ready`', 'blog-fba-registry.json', commentsEventProjectionPath, categorySearchReindexPath, graphqlRateLimitPath, aiRichtextBoundaryPath, 'CommentsThreadPort', 'blog-comments-consumer-static-matrix.json', 'blog-comments-runtime-fallback-smoke.json', consumerRuntimeOrderSmokePath, 'verify:blog:comments-port-boundary', 'test:verify:blog:comments-port-boundary', 'verify:blog:comments-event-projection', 'test:verify:blog:comments-event-projection', 'services::comment_projection::tests', 'comment_projection_postgres_test', 'RUSTOK_BLOG_TEST_DATABASE_URL', 'registry schema v12', 'degraded UI modes remain planned'], 'local plan');
 const central = read('docs/modules/registry.md');
 hasAll(central, ['| `blog` |', 'crates/rustok-blog/contracts/blog-fba-registry.json', 'blog-comments-runtime-fallback-smoke.json', consumerRuntimeOrderSmokePath, '`in_progress` | `boundary_ready`'], 'central registry');
 const unified = read('docs/research/fluid-backend-architecture-unified-plan.md');
 hasAll(unified, ['`blog`', 'CommentsThreadPort', 'blog-fba-registry.json'], 'unified plan');
 
-console.log('[verify-blog-fba] Blog FBA registry, exact admin/storefront/comments-port/comments-projection/category/rate-limit/GraphQL/AI richtext source-gate chain, Comments projection unit harness, consumer metadata, and no-compile evidence are consistent');
+console.log('[verify-blog-fba] Blog FBA registry, exact admin/storefront/comments-port/comments-projection/category/rate-limit/GraphQL/AI richtext source-gate chain, Comments projection unit and PostgreSQL harnesses, consumer metadata, and no-compile evidence are consistent');

--- a/scripts/verify/verify-blog-fba.test.mjs
+++ b/scripts/verify/verify-blog-fba.test.mjs
@@ -51,6 +51,7 @@ function canonicalExistingPaths() {
       gate.self_test,
       gate.evidence,
       gate.unit_test,
+      gate.postgres_test,
     ].filter(Boolean)),
   ]);
 }
@@ -113,6 +114,17 @@ test('Blog FBA verification-chain policy rejects projection unit-test path drift
   const registry = canonicalRegistry();
   registry.verification_chain.source_gates.comments_event_projection.unit_test =
     'crates/rustok-blog/src/services/wrong_projection.rs';
+  assert.ok(
+    failures({ registry }).includes(
+      'registry source gate comments_event_projection path drift',
+    ),
+  );
+});
+
+test('Blog FBA verification-chain policy rejects projection PostgreSQL-test path drift', () => {
+  const registry = canonicalRegistry();
+  registry.verification_chain.source_gates.comments_event_projection.postgres_test =
+    'crates/rustok-blog/tests/wrong_projection_postgres_test.rs';
   assert.ok(
     failures({ registry }).includes(
       'registry source gate comments_event_projection path drift',
@@ -189,6 +201,16 @@ test('Blog FBA verification-chain policy rejects a missing projection unit-test 
   assert.ok(
     failures({ existingPaths }).includes(
       `registry source gate comments_event_projection missing ${BLOG_FBA_SOURCE_GATES.comments_event_projection.unit_test}`,
+    ),
+  );
+});
+
+test('Blog FBA verification-chain policy rejects a missing projection PostgreSQL target', () => {
+  const existingPaths = canonicalExistingPaths();
+  existingPaths.delete(BLOG_FBA_SOURCE_GATES.comments_event_projection.postgres_test);
+  assert.ok(
+    failures({ existingPaths }).includes(
+      `registry source gate comments_event_projection missing ${BLOG_FBA_SOURCE_GATES.comments_event_projection.postgres_test}`,
     ),
   );
 });


### PR DESCRIPTION
## Summary

- add an env-gated PostgreSQL integration target for the Blog-owned Comments event projection
- retain four written scenarios: duplicate envelope idempotency, delete-before-create ordering, missing-post replay, and outbox-failure rollback/retry
- isolate each test in a unique schema with a one-connection pool and `RUSTOK_BLOG_TEST_DATABASE_URL` / PostgreSQL `DATABASE_URL`
- upgrade event-projection evidence to schema v3 and Blog FBA registry to schema v12
- register the PostgreSQL target in the existing projection leaf, shared Blog chain policy, focused fixture, and aggregate Blog gate
- keep production handler behavior and package command order unchanged
- keep concurrent optimistic exhaustion, host dispatch, restart recovery, and all execution evidence pending

## Why

After #2634, classification and counter transitions had an executable pure Rust harness, but duplicate delivery, out-of-order recovery, missing-post replay, and transaction rollback remained prose-only runtime requirements. The new target makes those assertions executable without claiming they have run.

## Validation

Not run by request. No verifier, unit test, Rust test, compile, PostgreSQL, browser, workflow, or CI command was executed.

Suggested maintainer commands:

```bash
npm run verify:blog:comments-event-projection
npm run test:verify:blog:comments-event-projection
npm run verify:blog:fba
npm run test:verify:blog:fba
cargo test -p rustok-blog --lib services::comment_projection::tests
RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test
```
