### PR TITLE
feat(index): bound production source calls

### DIFF
--- a/crates/rustok-index/Cargo.toml
+++ b/crates/rustok-index/Cargo.toml
@@ -12,6 +12,7 @@ rustok-core.workspace = true
 async-trait.workspace = true
 sea-orm.workspace = true
 sea-orm-migration.workspace = true
+tokio.workspace = true
 tracing.workspace = true
 
 # Domain and application core
@@ -31,4 +32,3 @@ uuid.workspace = true
 [dev-dependencies]
 proptest.workspace = true
 rustok-events.workspace = true
-tokio.workspace = true

--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -28,6 +28,7 @@ This directory contains the detailed technical architecture documentation for `r
 
 - [Live Implementation Plan](./implementation-plan.md)
 - [M5/M6 Source Replay Contract](./m5-m6-source-replay-contract.md)
+- [M6 Bounded Source-call Timeout](./m6-source-call-timeout.md)
 - [M6 Replay Job Leases](./m6-replay-job-leases.md)
 - [M6 Bounded Multi-page Replay Runner](./m6-bounded-multipage-runner.md)
 - [M6 Replay Runtime Host Composition](./m6-replay-runtime-composition.md)

--- a/crates/rustok-index/docs/m6-source-call-timeout.md
+++ b/crates/rustok-index/docs/m6-source-call-timeout.md
@@ -25,9 +25,9 @@ production timeout policy.
 ## Lease boundary
 
 The source wrapper does not acquire, heartbeat, extend, or terminalize replay/reconciliation
-leases. Operators must configure a lease longer than the 30-second source deadline plus enough
-margin for mutation persistence, checkpoint/progress persistence, cancellation observation, and
-terminal state publication.
+leases; this source wrapper never extends or heartbeats a job lease. Operators must configure a
+lease longer than the 30-second source deadline plus enough margin for mutation persistence,
+checkpoint/progress persistence, cancellation observation, and terminal state publication.
 
 A source timeout can occur after earlier pages are durable. Replay retries remain safe because
 stable event UUIDs and `PostgresMutationStore` inbox deduplication already protect repeated page

--- a/crates/rustok-index/docs/m6-source-call-timeout.md
+++ b/crates/rustok-index/docs/m6-source-call-timeout.md
@@ -1,0 +1,54 @@
+# M6 bounded source-call timeout
+
+Status: `source_complete_owner_execution_pending`
+
+This slice adds a bounded cancellation boundary around every production
+`IndexSource::scan` and targeted `IndexSource::load` registered through the canonical
+`register_index_source` helper.
+
+## Contract
+
+- The default source-call deadline is `30 seconds`.
+- The wrapper applies to both cursor scans and targeted loads.
+- Expiry drops the owner source future; Index does not wait indefinitely for the source.
+- Scan expiry becomes retryable code `index_source_scan_timeout`.
+- Targeted-load expiry becomes retryable code `index_source_load_timeout`.
+- Raw database, transport, source, or timeout causes are not copied into the public failure.
+- Successful and owner-classified failed calls pass through unchanged.
+
+Selected Product, ProductVariant, and SalesChannel PostgreSQL sources already register through
+`register_index_source`, so they receive this boundary without source-domain changes. Future
+production bridges must use the same helper. Direct `IndexSourceCatalog::register` remains
+available for isolated fixtures and low-level contract tests and intentionally does not imply a
+production timeout policy.
+
+## Lease boundary
+
+The source wrapper does not acquire, heartbeat, extend, or terminalize replay/reconciliation
+leases. Operators must configure a lease longer than the 30-second source deadline plus enough
+margin for mutation persistence, checkpoint/progress persistence, cancellation observation, and
+terminal state publication.
+
+A source timeout can occur after earlier pages are durable. Replay retries remain safe because
+stable event UUIDs and `PostgresMutationStore` inbox deduplication already protect repeated page
+delivery. Reconciliation retains the same deterministic event identities and monotonic source
+versions.
+
+## Explicitly open
+
+- configurable per-source or per-run timeout policy;
+- timeout around mutation persistence and checkpoint/progress writes;
+- cooperative source cancellation tokens;
+- in-page operator cancellation rather than between-page observation;
+- automatic retry/backoff and dead-letter scheduling;
+- host scheduler and graceful shutdown ownership;
+- retained PostgreSQL timeout, retry, lease-expiry, and restart evidence.
+
+The canonical implementation-plan item for complete in-page interruption/timeouts remains open
+because this slice bounds owner source calls only; it does not claim full page or persistence
+interruption.
+
+## Validation ownership
+
+Formatting, Cargo checks/tests, JavaScript guards, workflow execution, and live PostgreSQL
+validation are maintainer-run. The implementation agent did not execute them.

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -11,6 +11,7 @@ mod source_event_id;
 mod source_registry;
 mod source_replay;
 mod source_schema_registry;
+mod source_timeout;
 mod validation;
 
 #[cfg(test)]
@@ -61,7 +62,7 @@ pub use source_registry::{
     IndexSource, IndexSourceCatalog, IndexSourceCursor, IndexSourceDescriptor, IndexSourceError,
     IndexSourceFailure, IndexSourceFailureKind, IndexSourceLoadBatch, IndexSourceLoadRequest,
     IndexSourcePage, IndexSourceScanRequest, SharedIndexSourceRegistry,
-    materialize_index_source_registry, register_index_source,
+    materialize_index_source_registry,
 };
 pub use source_replay::{
     IndexReplayCheckpoint, IndexReplayCheckpointKey, IndexReplayCheckpointStore, IndexReplayError,
@@ -73,4 +74,5 @@ pub use source_schema_registry::{
     IndexSchemaSourceCatalog, IndexSchemaSourceDescriptor, IndexSchemaSourceError,
     SharedIndexSchemaRegistry, materialize_index_schema_registry, register_index_schema_source,
 };
+pub use source_timeout::{DEFAULT_INDEX_SOURCE_CALL_TIMEOUT, register_index_source};
 pub use validation::{QueryValidationError, RecordValidationError};

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -74,5 +74,5 @@ pub use source_schema_registry::{
     IndexSchemaSourceCatalog, IndexSchemaSourceDescriptor, IndexSchemaSourceError,
     SharedIndexSchemaRegistry, materialize_index_schema_registry, register_index_schema_source,
 };
-pub use source_timeout::{DEFAULT_INDEX_SOURCE_CALL_TIMEOUT, register_index_source};
+pub use source_timeout::register_index_source;
 pub use validation::{QueryValidationError, RecordValidationError};

--- a/crates/rustok-index/src/application/source_timeout.rs
+++ b/crates/rustok-index/src/application/source_timeout.rs
@@ -12,9 +12,10 @@ use crate::SchemaRef;
 
 /// Default upper bound for one owner-source `scan` or targeted `load` call.
 ///
-/// The timeout is deliberately shorter than the minimum production replay lease
-/// recommended by the M6 run contract. A timed-out source call is cancelled by
-/// dropping its future and is reported through a bounded retryable failure code.
+/// A timed-out source call is cancelled by dropping its future and is reported
+/// through a bounded retryable failure code. Replay and reconciliation operators
+/// must configure leases longer than this bound plus their persistence margin;
+/// this source wrapper never extends or heartbeats a job lease.
 pub const DEFAULT_INDEX_SOURCE_CALL_TIMEOUT: Duration = Duration::from_secs(30);
 
 const INDEX_SOURCE_SCAN_TIMEOUT_CODE: &str = "index_source_scan_timeout";
@@ -97,7 +98,7 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
-    use crate::{EntityName, ModuleName, SchemaVersion};
+    use crate::{EntityName, IndexSourceFailureKind, ModuleName, SchemaVersion};
 
     struct PendingSource;
 
@@ -138,7 +139,7 @@ mod tests {
         .unwrap();
 
         let failure = source.scan(request).await.unwrap_err();
-        assert_eq!(failure.kind(), super::super::IndexSourceFailureKind::Retryable);
+        assert_eq!(failure.kind(), IndexSourceFailureKind::Retryable);
         assert_eq!(failure.code(), INDEX_SOURCE_SCAN_TIMEOUT_CODE);
     }
 
@@ -154,7 +155,7 @@ mod tests {
         let request = IndexSourceLoadRequest::new(vec![key]).unwrap();
 
         let failure = source.load(request).await.unwrap_err();
-        assert_eq!(failure.kind(), super::super::IndexSourceFailureKind::Retryable);
+        assert_eq!(failure.kind(), IndexSourceFailureKind::Retryable);
         assert_eq!(failure.code(), INDEX_SOURCE_LOAD_TIMEOUT_CODE);
     }
 }

--- a/crates/rustok-index/src/application/source_timeout.rs
+++ b/crates/rustok-index/src/application/source_timeout.rs
@@ -16,7 +16,7 @@ use crate::SchemaRef;
 /// through a bounded retryable failure code. Replay and reconciliation operators
 /// must configure leases longer than this bound plus their persistence margin;
 /// this source wrapper never extends or heartbeats a job lease.
-pub const DEFAULT_INDEX_SOURCE_CALL_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_INDEX_SOURCE_CALL_TIMEOUT: Duration = Duration::from_secs(30);
 
 const INDEX_SOURCE_SCAN_TIMEOUT_CODE: &str = "index_source_scan_timeout";
 const INDEX_SOURCE_LOAD_TIMEOUT_CODE: &str = "index_source_load_timeout";

--- a/crates/rustok-index/src/application/source_timeout.rs
+++ b/crates/rustok-index/src/application/source_timeout.rs
@@ -1,0 +1,160 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rustok_core::ModuleRuntimeExtensions;
+use tokio::time::timeout;
+
+use super::{
+    IndexSource, IndexSourceError, IndexSourceFailure, IndexSourceLoadBatch,
+    IndexSourceLoadRequest, IndexSourcePage, IndexSourceScanRequest,
+};
+use crate::SchemaRef;
+
+/// Default upper bound for one owner-source `scan` or targeted `load` call.
+///
+/// The timeout is deliberately shorter than the minimum production replay lease
+/// recommended by the M6 run contract. A timed-out source call is cancelled by
+/// dropping its future and is reported through a bounded retryable failure code.
+pub const DEFAULT_INDEX_SOURCE_CALL_TIMEOUT: Duration = Duration::from_secs(30);
+
+const INDEX_SOURCE_SCAN_TIMEOUT_CODE: &str = "index_source_scan_timeout";
+const INDEX_SOURCE_LOAD_TIMEOUT_CODE: &str = "index_source_load_timeout";
+
+#[derive(Debug)]
+struct TimedIndexSource<S> {
+    inner: S,
+    call_timeout: Duration,
+}
+
+impl<S> TimedIndexSource<S> {
+    fn new(inner: S, call_timeout: Duration) -> Self {
+        debug_assert!(!call_timeout.is_zero());
+        Self {
+            inner,
+            call_timeout,
+        }
+    }
+}
+
+#[async_trait]
+impl<S> IndexSource for TimedIndexSource<S>
+where
+    S: IndexSource,
+{
+    async fn scan(
+        &self,
+        request: IndexSourceScanRequest,
+    ) -> Result<IndexSourcePage, IndexSourceFailure> {
+        match timeout(self.call_timeout, self.inner.scan(request)).await {
+            Ok(result) => result,
+            Err(_) => Err(retryable_timeout(INDEX_SOURCE_SCAN_TIMEOUT_CODE)),
+        }
+    }
+
+    async fn load(
+        &self,
+        request: IndexSourceLoadRequest,
+    ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+        match timeout(self.call_timeout, self.inner.load(request)).await {
+            Ok(result) => result,
+            Err(_) => Err(retryable_timeout(INDEX_SOURCE_LOAD_TIMEOUT_CODE)),
+        }
+    }
+}
+
+/// Register one production source behind the canonical bounded call-timeout wrapper.
+///
+/// Direct `IndexSourceCatalog::register` remains available for isolated fixtures and
+/// low-level contract tests. Selected production bridges use this helper so a source
+/// backend cannot block replay, reconciliation, or targeted repair indefinitely.
+pub fn register_index_source<S>(
+    extensions: &mut ModuleRuntimeExtensions,
+    owner_module: impl Into<String>,
+    source_name: impl Into<String>,
+    schemas: impl IntoIterator<Item = SchemaRef>,
+    source: S,
+) -> Result<(), IndexSourceError>
+where
+    S: IndexSource + 'static,
+{
+    super::source_registry::register_index_source(
+        extensions,
+        owner_module,
+        source_name,
+        schemas,
+        TimedIndexSource::new(source, DEFAULT_INDEX_SOURCE_CALL_TIMEOUT),
+    )
+}
+
+fn retryable_timeout(code: &'static str) -> IndexSourceFailure {
+    IndexSourceFailure::retryable(code).expect("static Index source timeout code must be valid")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::pending;
+
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::{EntityName, ModuleName, SchemaVersion};
+
+    struct PendingSource;
+
+    #[async_trait]
+    impl IndexSource for PendingSource {
+        async fn scan(
+            &self,
+            _request: IndexSourceScanRequest,
+        ) -> Result<IndexSourcePage, IndexSourceFailure> {
+            pending().await
+        }
+
+        async fn load(
+            &self,
+            _request: IndexSourceLoadRequest,
+        ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+            pending().await
+        }
+    }
+
+    fn schema_ref() -> SchemaRef {
+        SchemaRef {
+            module: ModuleName::new("rustok-product").unwrap(),
+            entity: EntityName::new("product").unwrap(),
+            version: SchemaVersion::INITIAL,
+        }
+    }
+
+    #[tokio::test]
+    async fn timed_source_classifies_scan_timeout_as_retryable() {
+        let source = TimedIndexSource::new(PendingSource, Duration::from_millis(1));
+        let request = IndexSourceScanRequest::new(
+            Uuid::from_u128(1),
+            schema_ref(),
+            None,
+            1,
+        )
+        .unwrap();
+
+        let failure = source.scan(request).await.unwrap_err();
+        assert_eq!(failure.kind(), super::super::IndexSourceFailureKind::Retryable);
+        assert_eq!(failure.code(), INDEX_SOURCE_SCAN_TIMEOUT_CODE);
+    }
+
+    #[tokio::test]
+    async fn timed_source_classifies_targeted_load_timeout_as_retryable() {
+        let source = TimedIndexSource::new(PendingSource, Duration::from_millis(1));
+        let key = crate::EntityKey {
+            tenant_id: Uuid::from_u128(1),
+            schema: schema_ref(),
+            entity_id: Uuid::from_u128(2),
+            locale: None,
+        };
+        let request = IndexSourceLoadRequest::new(vec![key]).unwrap();
+
+        let failure = source.load(request).await.unwrap_err();
+        assert_eq!(failure.kind(), super::super::IndexSourceFailureKind::Retryable);
+        assert_eq!(failure.code(), INDEX_SOURCE_LOAD_TIMEOUT_CODE);
+    }
+}

--- a/scripts/verify/verify-index-source-replay-contract.mjs
+++ b/scripts/verify/verify-index-source-replay-contract.mjs
@@ -71,7 +71,7 @@ for (const forbidden of [
 
 const timeoutPath = 'crates/rustok-index/src/application/source_timeout.rs';
 const sourceTimeout = requireMarkers(timeoutPath, [
-  'pub const DEFAULT_INDEX_SOURCE_CALL_TIMEOUT: Duration = Duration::from_secs(30);',
+  'const DEFAULT_INDEX_SOURCE_CALL_TIMEOUT: Duration = Duration::from_secs(30);',
   'const INDEX_SOURCE_SCAN_TIMEOUT_CODE: &str = "index_source_scan_timeout";',
   'const INDEX_SOURCE_LOAD_TIMEOUT_CODE: &str = "index_source_load_timeout";',
   'struct TimedIndexSource<S>',
@@ -195,7 +195,7 @@ requireMarkers('crates/rustok-index/src/application/mod.rs', [
   'IndexReplayWorker',
   'IndexReplayCheckpointStore',
   'materialize_index_source_registry',
-  'pub use source_timeout::{DEFAULT_INDEX_SOURCE_CALL_TIMEOUT, register_index_source};',
+  'pub use source_timeout::register_index_source;',
 ]);
 requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
   'mod source_replay;',

--- a/scripts/verify/verify-index-source-replay-contract.mjs
+++ b/scripts/verify/verify-index-source-replay-contract.mjs
@@ -69,6 +69,35 @@ for (const forbidden of [
   }
 }
 
+const timeoutPath = 'crates/rustok-index/src/application/source_timeout.rs';
+const sourceTimeout = requireMarkers(timeoutPath, [
+  'pub const DEFAULT_INDEX_SOURCE_CALL_TIMEOUT: Duration = Duration::from_secs(30);',
+  'const INDEX_SOURCE_SCAN_TIMEOUT_CODE: &str = "index_source_scan_timeout";',
+  'const INDEX_SOURCE_LOAD_TIMEOUT_CODE: &str = "index_source_load_timeout";',
+  'struct TimedIndexSource<S>',
+  'tokio::time::timeout',
+  'timeout(self.call_timeout, self.inner.scan(request)).await',
+  'timeout(self.call_timeout, self.inner.load(request)).await',
+  'IndexSourceFailure::retryable(code)',
+  'super::source_registry::register_index_source(',
+  'TimedIndexSource::new(source, DEFAULT_INDEX_SOURCE_CALL_TIMEOUT)',
+  'timed_source_classifies_scan_timeout_as_retryable',
+  'timed_source_classifies_targeted_load_timeout_as_retryable',
+]);
+for (const forbidden of [
+  'DatabaseConnection',
+  'PostgresMutationStore',
+  'index_jobs',
+  'index_checkpoints',
+  'tokio::spawn',
+  'tracing::',
+  'format!(',
+]) {
+  if (sourceTimeout.includes(forbidden)) {
+    fail(`${timeoutPath} contains forbidden storage/scheduler/raw-detail marker ${forbidden}`);
+  }
+}
+
 const workerPath = 'crates/rustok-index/src/application/source_replay.rs';
 const worker = requireMarkers(workerPath, [
   'pub struct IndexReplayWorker',
@@ -159,13 +188,14 @@ requireMarkers(testsPath, [
 requireMarkers('crates/rustok-index/src/application/mod.rs', [
   'mod source_registry;',
   'mod source_replay;',
+  'mod source_timeout;',
   'mod source_replay_tests;',
   'IndexSourceCatalog',
   'SharedIndexSourceRegistry',
   'IndexReplayWorker',
   'IndexReplayCheckpointStore',
   'materialize_index_source_registry',
-  'register_index_source',
+  'pub use source_timeout::{DEFAULT_INDEX_SOURCE_CALL_TIMEOUT, register_index_source};',
 ]);
 requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
   'mod source_replay;',
@@ -180,6 +210,7 @@ requireMarkers('crates/rustok-index/src/lib.rs', [
   'PostgresIndexReplayJobStore',
 ]);
 requireMarkers('crates/rustok-index/Cargo.toml', [
+  'tokio.workspace = true',
   'tracing.workspace = true',
 ]);
 requireMarkers('crates/rustok-index/docs/m5-m6-source-replay-contract.md', [
@@ -196,6 +227,18 @@ requireMarkers('crates/rustok-index/docs/m5-m6-source-replay-contract.md', [
   'it cannot advance the durable cursor',
   'reserved empty values',
   'maintainer-run',
+]);
+requireMarkers('crates/rustok-index/docs/m6-source-call-timeout.md', [
+  'Status: `source_complete_owner_execution_pending`',
+  'The default source-call deadline is `30 seconds`.',
+  '`index_source_scan_timeout`',
+  '`index_source_load_timeout`',
+  'this source wrapper never extends or heartbeats a job lease',
+  'complete in-page interruption/timeouts remains open',
+  'maintainer-run',
+]);
+requireMarkers('crates/rustok-index/docs/README.md', [
+  '[M6 Bounded Source-call Timeout](./m6-source-call-timeout.md)',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
   '- M5/M6 bounded source replay contract: `source_complete_worker_pending`',


### PR DESCRIPTION
## Summary

- add an Index-owned timeout decorator around production `IndexSource::scan` and targeted `IndexSource::load`
- keep the existing public `register_index_source` API while routing selected production bridges through a 30-second bounded call policy
- classify scan/load expiry with stable retryable codes and never expose raw timeout, database, transport, or source details
- cover Product, ProductVariant, SalesChannel, and future selected bridges without source-domain changes
- add focused pending-source fixtures, contract documentation, and fail-closed repository guards
- move the already-locked workspace `tokio` dependency from dev-only to production for `tokio::time::timeout`

## Failure semantics

A timed-out source future is dropped. The wrapper does not acquire, extend, heartbeat, or terminalize replay/reconciliation leases. Operators must configure leases longer than the 30-second source deadline plus mutation/checkpoint/progress and terminal-publication margin.

Timeout codes:

- `index_source_scan_timeout`
- `index_source_load_timeout`

Both are retryable `IndexSourceFailure` values. Existing owner failures and successful results pass through unchanged.

## Scope boundary

This PR bounds owner source calls only. It does **not** claim complete in-page interruption:

- no timeout around mutation persistence or checkpoint/progress writes
- no cooperative cancellation token for source adapters
- no in-page operator cancellation
- no automatic retry/backoff or dead-letter scheduler
- no host task ownership or graceful shutdown
- no retained PostgreSQL timeout/restart evidence

The canonical M6 combined in-page interruption/timeouts plan item therefore remains open.

## Compatibility

- no schema, source name, cursor, event-domain, migration, or mutation wire change
- no Product/Channel dependency added to Index core
- no `Cargo.lock` change expected because `tokio` was already a workspace/dev dependency
- direct `IndexSourceCatalog::register` remains available for isolated fixtures; production bridges keep using the canonical helper

## Validation

Not run per maintainer instruction:

- Cargo formatting/checks/tests/Clippy
- JavaScript verifiers
- PostgreSQL source timeout, lease expiry, retry, reconciliation, or restart evidence
- CI workflows

Suggested maintainer commands:

```bash
cargo test -p rustok-index source_timeout -- --nocapture
cargo check -p rustok-index --all-targets
node scripts/verify/verify-index-source-replay-contract.mjs
node scripts/verify/verify-index-query-contract.mjs
```

## Branch state

Base: `main` at `069a9a7c74dbf0971c724d2f35ad0b9aa11d345b`
Branch: `agent/index-m6-source-call-timeout-20260731`

This slice has no changed-file overlap with the open SalesChannel tombstone PR #2636. Squash merge is recommended after maintainer validation.