### PR TITLE
test(blog): add comment projection restart harness

### DIFF
--- a/crates/rustok-blog/contracts/blog-fba-registry.json
+++ b/crates/rustok-blog/contracts/blog-fba-registry.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 12,
+  "schema_version": 13,
   "module": "blog",
   "role": "consumer",
   "status": "boundary_ready",
@@ -113,6 +113,7 @@
         "self_test": "scripts/verify/verify-blog-comments-event-projection.test.mjs",
         "unit_test": "crates/rustok-blog/src/services/comment_projection.rs",
         "postgres_test": "crates/rustok-blog/tests/comment_projection_postgres_test.rs",
+        "restart_test": "crates/rustok-blog/tests/comment_projection_restart_postgres_test.rs",
         "evidence": "crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json"
       },
       "category_search_reindex": {
@@ -181,6 +182,13 @@
       "runtime_status": "not_run",
       "environment": "RUSTOK_BLOG_TEST_DATABASE_URL",
       "command": "RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test"
+    },
+    "restart_harness": {
+      "path": "crates/rustok-blog/tests/comment_projection_restart_postgres_test.rs",
+      "status": "executable_no_run",
+      "runtime_status": "not_run",
+      "environment": "RUSTOK_BLOG_TEST_DATABASE_URL",
+      "command": "RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test"
     }
   },
   "contract_tests": {

--- a/crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "module": "blog",
   "surface": "comments_event_projection",
   "status": "source_verified_no_compile",
@@ -43,6 +43,17 @@
       "delete_before_create_stays_non_negative_and_replays_in_order",
       "missing_post_replay_commits_only_after_source_appears",
       "outbox_failure_rolls_back_counter_and_delivery_before_retry"
+    ]
+  },
+  "restart_harness": {
+    "status": "executable_no_run",
+    "runtime_status": "not_run",
+    "path": "crates/rustok-blog/tests/comment_projection_restart_postgres_test.rs",
+    "environment": "RUSTOK_BLOG_TEST_DATABASE_URL",
+    "command": "RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test",
+    "isolation": "unique_schema_new_connection",
+    "cases": [
+      "restarted_handler_reuses_delivery_ledger_without_reapplying_counter"
     ]
   },
   "cases": [
@@ -95,6 +106,10 @@
       "expected": "the retained PostgreSQL target removes the outbox table, expects counter and delivery rollback, recreates the table, and replays the same envelope"
     },
     {
+      "name": "postgres_restart_replay",
+      "expected": "the retained restart target opens a new database connection and handler over the same schema, replays the same envelope, and expects one durable application"
+    },
+    {
       "name": "module_listener_registration",
       "expected": "Blog registers BlogCommentProjectionHandler through the module event-listener registry"
     }
@@ -102,10 +117,12 @@
   "runtime_promotion_requirements": [
     "execute cargo test -p rustok-blog --lib services::comment_projection::tests",
     "execute the env-gated PostgreSQL comment_projection_postgres_test target and retain its output",
+    "execute the env-gated PostgreSQL comment_projection_restart_postgres_test target and retain its output",
     "retain proof that duplicate and out-of-order comment.created/comment.deleted deliveries match the source harness assertions",
     "retain proof that the counter, delivery ledger, and BlogPostUpdated outbox row commit or roll back together",
     "retain missing-post retry and later recovery evidence",
+    "retain restarted-handler replay evidence across a new database connection",
     "retain concurrent optimistic-update exhaustion and retry evidence",
-    "retain host event-dispatch registration and restart recovery evidence"
+    "retain host event-dispatch registration and process restart recovery evidence"
   ]
 }

--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -97,7 +97,7 @@ identity, and commits the tenant-scoped optimistic count update, delivery row,
 and `BlogPostUpdated` outbox publication in one transaction. `project()` and
 `EventHandler::handles()` share the pure `comment_projection_change` classifier,
 and the pure counter transition floors deletes at zero while saturating count and
-version overflow. Evidence schema v3 is retained at
+version overflow. Evidence schema v4 is retained at
 `crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json`,
 guarded by `scripts/verify/verify-blog-comments-event-projection.mjs` and focused
 fixture `scripts/verify/verify-blog-comments-event-projection.test.mjs`. The Rust
@@ -115,11 +115,22 @@ creation, and rollback/retry when the outbox table is unavailable. The suggested
 command is
 `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test`.
 The target is registered as `executable_no_run`; no PostgreSQL result is recorded.
+
+The retained restart target is
+`crates/rustok-blog/tests/comment_projection_restart_postgres_test.rs`. It applies
+one envelope, drops the first handler, opens a new PostgreSQL connection against
+the same isolated schema, creates a new handler, and replays the same envelope.
+The written assertions require one counter transition, one durable delivery row,
+and one outbox row. Its suggested command is
+`RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test`.
+This target is also `executable_no_run`; it represents handler/connection
+re-instantiation, not retained proof of a process or host restart.
+
 Exact commands `verify:blog:comments-event-projection` and
 `test:verify:blog:comments-event-projection` run after the Comments port gate in
 the Blog FBA chains. Overall status remains `source_verified_no_compile`;
-concurrent optimistic exhaustion, host dispatch, restart recovery, and all
-execution evidence remain pending.
+concurrent optimistic exhaustion, host dispatch, process-level restart recovery,
+and all execution evidence remain pending.
 
 Blog categories use the exclusive `blog_categories:*` permission resource.
 `CategoryService::new(db, event_bus)` is the only owner constructor. Category
@@ -249,14 +260,22 @@ schema v12, and retains the target in the focused and aggregate source gates. No
 Rust test, verifier, compile, PostgreSQL, workflow, browser, or CI execution is
 recorded.
 
+The continuation audit at `069a9a7c74dbf0971c724d2f35ad0b9aa11d345b`
+found that restart recovery was still represented only as an open runtime result.
+Slice 46 adds a dedicated env-gated PostgreSQL target that replays one envelope
+through a new database connection and a newly constructed handler over the same
+durable delivery ledger. Projection evidence advances to schema v4 and Blog
+registry to schema v13; focused, shared-chain, and aggregate guards retain the
+new target without recording execution or claiming process-level restart proof.
+
 ## FFA/FBA status
 
 - FFA status: `in_progress`.
 - FBA status: `boundary_ready` (`core_transport_ui`).
-- Blog FBA source-gate chain: `source_verified_no_compile`; registry schema v12
+- Blog FBA source-gate chain: `source_verified_no_compile`; registry schema v13
   locks exact verify/test order, source-gate paths, leaf npm commands, evidence,
-  self-tests, the Comments projection unit and PostgreSQL harnesses, and
-  aggregate/consumer bindings for admin, storefront, Comments port boundary,
+  self-tests, the Comments projection unit, PostgreSQL, and restart harnesses,
+  and aggregate/consumer bindings for admin, storefront, Comments port boundary,
   Comments event projection, category Search reindex, GraphQL rate limiting,
   GraphQL richtext, AI richtext, offline backfill, Forum ownership, and runtime
   order.
@@ -267,13 +286,14 @@ recorded.
   ordering are locked. The remote adapter and degraded UI modes remain planned;
   runtime evidence is pending.
 - Comments event projection: Blog-owned `source_verified_no_compile`; evidence
-  schema v3, shared classifier/counter helpers, `executable_no_run` Rust unit and
-  PostgreSQL harnesses, verifier, focused self-test, exact npm leaf commands,
-  delivery-ledger identity, transactional outbox markers, and Blog FBA ordering
-  are locked. The PostgreSQL target writes duplicate, out-of-order, missing-post
-  replay, and outbox rollback/retry cases but has not been run. Concurrent
-  optimistic exhaustion, host dispatch, restart recovery, and all execution
-  evidence remain pending.
+  schema v4, shared classifier/counter helpers, `executable_no_run` Rust unit,
+  PostgreSQL transaction, and restart harnesses, verifier, focused self-test,
+  exact npm leaf commands, delivery-ledger identity, transactional outbox markers,
+  and Blog FBA ordering are locked. The PostgreSQL targets write duplicate,
+  out-of-order, missing-post replay, outbox rollback/retry, and new-connection
+  handler replay cases but have not been run. Concurrent optimistic exhaustion,
+  host dispatch, process-level restart recovery, and all execution evidence remain
+  pending.
 - Load protection: `implementation_ready`; mounted Redis evidence is pending.
 - Rate-limit harness: `executable_no_compile`; evidence, verifier, self-test,
   npm leaf commands, and aggregate FBA registration are locked; execution is
@@ -308,6 +328,7 @@ recorded.
 - `crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json`
 - `crates/rustok-blog/src/services/comment_projection.rs`
 - `crates/rustok-blog/tests/comment_projection_postgres_test.rs`
+- `crates/rustok-blog/tests/comment_projection_restart_postgres_test.rs`
 - `crates/rustok-comments/contracts/comments-fba-registry.json`
 - `crates/rustok-comments/contracts/evidence/comments-thread-write-invariants.json`
 - `crates/rustok-blog/contracts/evidence/blog-graphql-rate-limit-runtime-harness.json`
@@ -439,6 +460,10 @@ recorded.
     delete-before-create, missing-post replay, and outbox rollback/retry behavior;
     upgraded projection evidence to schema v3 and Blog registry schema v12, and
     retained the target in focused/aggregate source gates without running it.
+46. Added an env-gated PostgreSQL restart target that replays the same envelope
+    through a new database connection and newly constructed handler, upgraded
+    projection evidence to schema v4 and Blog registry schema v13, and retained
+    the target in focused/shared/aggregate gates without recording execution.
 
 ## Next results
 
@@ -457,13 +482,15 @@ recorded.
    real HTTP `Retry-After` matching GraphQL `retryAfter`.
 5. **Close comments runtime evidence.** Run the Comments port boundary fixture,
    shared consumer runtime-order verifier, Blog projection unit harness, the
-   `comment_projection_postgres_test` target, both thread invariant concurrency
-   targets, and concurrent PostgreSQL create/delete transactions. Retain the
-   written duplicate, delete-before-create, missing-post replay, and outbox
-   rollback/retry assertions; then cover concurrent optimistic exhaustion, host
-   dispatch, restart recovery, remote adapter parity, degraded UI modes,
-   approved-only reads, moderation, pagination, first-thread identity, and
-   unrelated insert storage error propagation.
+   `comment_projection_postgres_test` and
+   `comment_projection_restart_postgres_test` targets, both thread invariant
+   concurrency targets, and concurrent PostgreSQL create/delete transactions.
+   Retain the written duplicate, delete-before-create, missing-post replay,
+   outbox rollback/retry, and new-connection handler replay assertions; then cover
+   concurrent optimistic exhaustion, host dispatch, process-level restart
+   recovery, remote adapter parity, degraded UI modes, approved-only reads,
+   moderation, pagination, first-thread identity, and unrelated insert storage
+   error propagation.
 6. **Execute and retain Blog article richtext cutover evidence.** Run the offline
    backfill in default dry-run mode, review its report, apply accepted conversion,
    execute the irreversible migration, reindex/rollback Search, and retain
@@ -481,6 +508,7 @@ should run the relevant subset, including:
 - `npm run test:verify:blog:comments-event-projection`
 - `cargo test -p rustok-blog --lib services::comment_projection::tests`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test`
+- `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test`
 - `npm run verify:blog:category-search-reindex`
 - `npm run test:verify:blog:category-search-reindex`
 - `npm run verify:blog:graphql-rate-limit`

--- a/crates/rustok-blog/tests/comment_projection_restart_postgres_test.rs
+++ b/crates/rustok-blog/tests/comment_projection_restart_postgres_test.rs
@@ -1,0 +1,252 @@
+use std::error::Error;
+
+use rustok_blog::services::BlogCommentProjectionHandler;
+use rustok_core::events::EventHandler;
+use rustok_events::{DomainEvent, EventEnvelope};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
+};
+use uuid::Uuid;
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";
+
+struct PostgresBlogProjectionRestartTestDb {
+    control: DatabaseConnection,
+    db: DatabaseConnection,
+    database_url: String,
+    schema_name: String,
+}
+
+impl PostgresBlogProjectionRestartTestDb {
+    async fn setup() -> TestResult<Option<Self>> {
+        let Some(database_url) = postgres_database_url() else {
+            eprintln!(
+                "{BLOG_TEST_DATABASE_ENV} is not set to a PostgreSQL URL; skipping Blog comment projection restart test"
+            );
+            return Ok(None);
+        };
+
+        let control = connect(&database_url).await?;
+        let schema_name = format!(
+            "rustok_blog_projection_restart_{}",
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let db = connect(&database_url).await?;
+        set_search_path(&db, &schema_name).await?;
+
+        if let Err(error) = create_projection_tables(&db).await {
+            let _ = control
+                .execute_unprepared(&format!(r#"DROP SCHEMA IF EXISTS "{schema_name}" CASCADE"#))
+                .await;
+            return Err(error.into());
+        }
+
+        Ok(Some(Self {
+            control,
+            db,
+            database_url,
+            schema_name,
+        }))
+    }
+
+    async fn restarted_connection(&self) -> TestResult<DatabaseConnection> {
+        let db = connect(&self.database_url).await?;
+        set_search_path(&db, &self.schema_name).await?;
+        Ok(db)
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn restarted_handler_reuses_delivery_ledger_without_reapplying_counter() -> TestResult<()> {
+    let Some(test_db) = PostgresBlogProjectionRestartTestDb::setup().await? else {
+        return Ok(());
+    };
+
+    let tenant_id = Uuid::new_v4();
+    let post_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    let envelope = EventEnvelope::new(
+        tenant_id,
+        Some(actor_id),
+        DomainEvent::CommentCreated {
+            comment_id: Uuid::new_v4(),
+            target_type: "blog_post".to_string(),
+            target_id: post_id,
+            author_id: actor_id,
+        },
+    );
+    insert_post(&test_db.db, tenant_id, post_id, actor_id).await?;
+
+    let first_handler = BlogCommentProjectionHandler::new(test_db.db.clone());
+    first_handler.handle(&envelope).await?;
+    drop(first_handler);
+
+    let restarted_db = test_db.restarted_connection().await?;
+    let restarted_handler = BlogCommentProjectionHandler::new(restarted_db.clone());
+    restarted_handler.handle(&envelope).await?;
+
+    assert_eq!(load_post_state(&restarted_db, tenant_id, post_id).await?, (1, 2));
+    assert_eq!(count_delivery(&restarted_db, envelope.id).await?, 1);
+    assert_eq!(count_outbox_events(&restarted_db).await?, 1);
+
+    drop(restarted_handler);
+    drop(restarted_db);
+    test_db.cleanup().await
+}
+
+async fn create_projection_tables(db: &DatabaseConnection) -> Result<(), sea_orm::DbErr> {
+    db.execute_unprepared(
+        r#"
+        CREATE TABLE blog_posts (
+            id UUID PRIMARY KEY,
+            tenant_id UUID NOT NULL,
+            author_id UUID NOT NULL,
+            category_id UUID NULL,
+            status TEXT NOT NULL,
+            slug TEXT NOT NULL,
+            metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+            featured_image_url TEXT NULL,
+            published_at TIMESTAMPTZ NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            archived_at TIMESTAMPTZ NULL,
+            comment_count INTEGER NOT NULL DEFAULT 0,
+            view_count INTEGER NOT NULL DEFAULT 0,
+            version INTEGER NOT NULL DEFAULT 1
+        );
+
+        CREATE TABLE blog_comment_projection_deliveries (
+            event_id UUID PRIMARY KEY,
+            tenant_id UUID NOT NULL,
+            comment_id UUID NOT NULL,
+            post_id UUID NOT NULL,
+            delta INTEGER NOT NULL,
+            processed_at TIMESTAMPTZ NOT NULL
+        );
+
+        CREATE TABLE sys_events (
+            id UUID PRIMARY KEY,
+            event_type TEXT NOT NULL,
+            schema_version SMALLINT NOT NULL,
+            payload JSONB NOT NULL,
+            status VARCHAR(32) NOT NULL,
+            retry_count INTEGER NOT NULL,
+            next_attempt_at TIMESTAMPTZ NULL,
+            last_error TEXT NULL,
+            claimed_by TEXT NULL,
+            claimed_at TIMESTAMPTZ NULL,
+            created_at TIMESTAMPTZ NOT NULL,
+            dispatched_at TIMESTAMPTZ NULL
+        );
+        "#,
+    )
+    .await?;
+    Ok(())
+}
+
+async fn insert_post(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    post_id: Uuid,
+    author_id: Uuid,
+) -> Result<(), sea_orm::DbErr> {
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+        INSERT INTO blog_posts (
+            id, tenant_id, author_id, status, slug, metadata,
+            comment_count, view_count, version
+        ) VALUES ($1, $2, $3, 'published', 'projection-restart-test', '{}'::jsonb, 0, 0, 1)
+        "#,
+        vec![post_id.into(), tenant_id.into(), author_id.into()],
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn load_post_state(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    post_id: Uuid,
+) -> Result<(i32, i32), sea_orm::DbErr> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+            SELECT comment_count, version
+            FROM blog_posts
+            WHERE tenant_id = $1 AND id = $2
+            "#,
+            vec![tenant_id.into(), post_id.into()],
+        ))
+        .await?
+        .expect("Blog post state should exist");
+    Ok((
+        row.try_get("", "comment_count")?,
+        row.try_get("", "version")?,
+    ))
+}
+
+async fn count_delivery(
+    db: &DatabaseConnection,
+    event_id: Uuid,
+) -> Result<i64, sea_orm::DbErr> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT COUNT(*)::bigint AS count FROM blog_comment_projection_deliveries WHERE event_id = $1",
+            vec![event_id.into()],
+        ))
+        .await?
+        .expect("delivery count query should return one row");
+    row.try_get("", "count")
+}
+
+async fn count_outbox_events(db: &DatabaseConnection) -> Result<i64, sea_orm::DbErr> {
+    let row = db
+        .query_one(Statement::from_string(
+            DbBackend::Postgres,
+            "SELECT COUNT(*)::bigint AS count FROM sys_events".to_string(),
+        ))
+        .await?
+        .expect("outbox count query should return one row");
+    row.try_get("", "count")
+}
+
+fn postgres_database_url() -> Option<String> {
+    std::env::var(BLOG_TEST_DATABASE_ENV)
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn set_search_path(db: &DatabaseConnection, schema_name: &str) -> TestResult<()> {
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}", public"#))
+        .await?;
+    Ok(())
+}

--- a/scripts/verify/blog-fba-verification-chain.mjs
+++ b/scripts/verify/blog-fba-verification-chain.mjs
@@ -44,6 +44,7 @@ export const BLOG_FBA_SOURCE_GATES = {
     self_test: 'scripts/verify/verify-blog-comments-event-projection.test.mjs',
     unit_test: 'crates/rustok-blog/src/services/comment_projection.rs',
     postgres_test: 'crates/rustok-blog/tests/comment_projection_postgres_test.rs',
+    restart_test: 'crates/rustok-blog/tests/comment_projection_restart_postgres_test.rs',
     evidence: 'crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json',
   },
   category_search_reindex: {
@@ -172,7 +173,8 @@ export function collectBlogFbaVerificationChainFailures({
       gate?.self_test !== expectedGate.self_test ||
       gate?.evidence !== expectedGate.evidence ||
       gate?.unit_test !== expectedGate.unit_test ||
-      gate?.postgres_test !== expectedGate.postgres_test
+      gate?.postgres_test !== expectedGate.postgres_test ||
+      gate?.restart_test !== expectedGate.restart_test
     ) {
       failures.push(`registry source gate ${gateName} path drift`);
     }
@@ -199,6 +201,7 @@ export function collectBlogFbaVerificationChainFailures({
       expectedGate.evidence,
       expectedGate.unit_test,
       expectedGate.postgres_test,
+      expectedGate.restart_test,
     ].filter(Boolean)) {
       if (!existsSync(filePath)) {
         failures.push(`registry source gate ${gateName} missing ${filePath}`);

--- a/scripts/verify/verify-blog-comments-event-projection.mjs
+++ b/scripts/verify/verify-blog-comments-event-projection.mjs
@@ -32,6 +32,7 @@ function requireNoMarker(source, marker, label) {
 const evidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json';
 const handlerPath = 'crates/rustok-blog/src/services/comment_projection.rs';
 const postgresHarnessPath = 'crates/rustok-blog/tests/comment_projection_postgres_test.rs';
+const restartHarnessPath = 'crates/rustok-blog/tests/comment_projection_restart_postgres_test.rs';
 const serviceExportPath = 'crates/rustok-blog/src/services/mod.rs';
 const entityPath = 'crates/rustok-blog/src/entities/blog_comment_projection_delivery.rs';
 const migrationPath = 'crates/rustok-blog/src/migrations/m20260716_000001_create_blog_comment_projection_deliveries.rs';
@@ -41,10 +42,12 @@ const registryPath = 'crates/rustok-blog/contracts/blog-fba-registry.json';
 const planPath = 'crates/rustok-blog/docs/implementation-plan.md';
 const harnessCommand = 'cargo test -p rustok-blog --lib services::comment_projection::tests';
 const postgresHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test';
+const restartHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test';
 const postgresHarnessEnvironment = 'RUSTOK_BLOG_TEST_DATABASE_URL';
 
 const handler = read(handlerPath);
 const postgresHarness = read(postgresHarnessPath);
+const restartHarness = read(restartHarnessPath);
 const serviceExport = read(serviceExportPath);
 const entity = read(entityPath);
 const migration = read(migrationPath);
@@ -141,6 +144,30 @@ requireNoMarker(postgresHarness, '#[ignore]', postgresHarnessPath);
 requireNoMarker(postgresHarness, 'runtime_verified', postgresHarnessPath);
 
 for (const marker of [
+  'const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";',
+  'struct PostgresBlogProjectionRestartTestDb',
+  'database_url: String',
+  'async fn restarted_connection(&self)',
+  'SET search_path TO',
+  'async fn restarted_handler_reuses_delivery_ledger_without_reapplying_counter()',
+  'let first_handler = BlogCommentProjectionHandler::new(test_db.db.clone());',
+  'first_handler.handle(&envelope).await?;',
+  'drop(first_handler);',
+  'let restarted_db = test_db.restarted_connection().await?;',
+  'let restarted_handler = BlogCommentProjectionHandler::new(restarted_db.clone());',
+  'restarted_handler.handle(&envelope).await?;',
+  'load_post_state(&restarted_db, tenant_id, post_id).await?, (1, 2)',
+  'count_delivery(&restarted_db, envelope.id).await?, 1',
+  'count_outbox_events(&restarted_db).await?, 1',
+  'CREATE TABLE blog_comment_projection_deliveries',
+  'CREATE TABLE sys_events',
+]) {
+  requireMarker(restartHarness, marker, restartHarnessPath);
+}
+requireNoMarker(restartHarness, '#[ignore]', restartHarnessPath);
+requireNoMarker(restartHarness, 'runtime_verified', restartHarnessPath);
+
+for (const marker of [
   '#[sea_orm(table_name = "blog_comment_projection_deliveries")]',
   '#[sea_orm(primary_key, auto_increment = false)]',
   'pub event_id: Uuid',
@@ -177,7 +204,7 @@ for (const marker of [
 }
 
 if (evidence) {
-  if (evidence.schema_version !== 3) failures.push(`${evidencePath}: schema_version drift`);
+  if (evidence.schema_version !== 4) failures.push(`${evidencePath}: schema_version drift`);
   if (
     evidence.module !== 'blog' ||
     evidence.surface !== 'comments_event_projection' ||
@@ -242,6 +269,23 @@ if (evidence) {
   ) {
     failures.push(`${evidencePath}: PostgreSQL harness case drift`);
   }
+  const restart = evidence.restart_harness ?? {};
+  if (
+    restart.status !== 'executable_no_run' ||
+    restart.runtime_status !== 'not_run' ||
+    restart.path !== restartHarnessPath ||
+    restart.environment !== postgresHarnessEnvironment ||
+    restart.command !== restartHarnessCommand ||
+    restart.isolation !== 'unique_schema_new_connection'
+  ) {
+    failures.push(`${evidencePath}: restart harness drift`);
+  }
+  if (
+    [...(restart.cases ?? [])].join('|') !==
+    'restarted_handler_reuses_delivery_ledger_without_reapplying_counter'
+  ) {
+    failures.push(`${evidencePath}: restart harness case drift`);
+  }
   const events = [...(evidence.events ?? [])].sort().join('|');
   if (events !== ['comment.created', 'comment.deleted'].sort().join('|')) {
     failures.push(`${evidencePath}: event set drift`);
@@ -260,6 +304,7 @@ if (evidence) {
     'postgres_out_of_order_delete_create',
     'postgres_missing_post_recovery',
     'postgres_outbox_rollback_recovery',
+    'postgres_restart_replay',
     'module_listener_registration',
   ]) {
     if (!cases.has(requiredCase)) failures.push(`${evidencePath}: missing case ${requiredCase}`);
@@ -267,7 +312,7 @@ if (evidence) {
 }
 
 if (registry) {
-  if (registry.schema_version !== 12) failures.push(`${registryPath}: schema_version drift`);
+  if (registry.schema_version !== 13) failures.push(`${registryPath}: schema_version drift`);
   if (registry.evidence?.comments_event_projection !== evidencePath) {
     failures.push(`${registryPath}: comments event projection evidence path drift`);
   }
@@ -297,12 +342,24 @@ if (registry) {
   ) {
     failures.push(`${registryPath}: event projection PostgreSQL harness drift`);
   }
+  if (
+    projection.restart_harness?.path !== restartHarnessPath ||
+    projection.restart_harness?.status !== 'executable_no_run' ||
+    projection.restart_harness?.runtime_status !== 'not_run' ||
+    projection.restart_harness?.environment !== postgresHarnessEnvironment ||
+    projection.restart_harness?.command !== restartHarnessCommand
+  ) {
+    failures.push(`${registryPath}: event projection restart harness drift`);
+  }
   const sourceGate = registry.verification_chain?.source_gates?.comments_event_projection;
   if (sourceGate?.unit_test !== handlerPath) {
     failures.push(`${registryPath}: comments event projection unit test path drift`);
   }
   if (sourceGate?.postgres_test !== postgresHarnessPath) {
     failures.push(`${registryPath}: comments event projection PostgreSQL test path drift`);
+  }
+  if (sourceGate?.restart_test !== restartHarnessPath) {
+    failures.push(`${registryPath}: comments event projection restart test path drift`);
   }
 }
 
@@ -313,6 +370,7 @@ for (const marker of [
   'source_verified_no_compile',
   'services::comment_projection::tests',
   'comment_projection_postgres_test',
+  'comment_projection_restart_postgres_test',
   'RUSTOK_BLOG_TEST_DATABASE_URL',
   'runtime delivery and recovery',
 ]) {
@@ -325,4 +383,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log('Blog comments event projection source contract, unit harness, and PostgreSQL target are consistent');
+console.log('Blog comments event projection source contract, unit harness, PostgreSQL target, and restart target are consistent');

--- a/scripts/verify/verify-blog-comments-event-projection.mjs
+++ b/scripts/verify/verify-blog-comments-event-projection.mjs
@@ -372,7 +372,7 @@ for (const marker of [
   'comment_projection_postgres_test',
   'comment_projection_restart_postgres_test',
   'RUSTOK_BLOG_TEST_DATABASE_URL',
-  'runtime delivery and recovery',
+  'process-level restart recovery',
 ]) {
   requireMarker(plan, marker, planPath);
 }

--- a/scripts/verify/verify-blog-comments-event-projection.test.mjs
+++ b/scripts/verify/verify-blog-comments-event-projection.test.mjs
@@ -26,14 +26,19 @@ function fixture({
   missingPostgresHarness = false,
   missingRollbackCase = false,
   missingPostgresRegistration = false,
+  missingRestartHarness = false,
+  missingRestartConnection = false,
+  missingRestartRegistration = false,
   statusDrift = false,
   harnessStatusDrift = false,
   postgresStatusDrift = false,
+  restartStatusDrift = false,
 } = {}) {
   const root = mkdtempSync(path.join(tmpdir(), 'rustok-blog-comments-projection-'));
   const evidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json';
   const handlerPath = 'crates/rustok-blog/src/services/comment_projection.rs';
   const postgresHarnessPath = 'crates/rustok-blog/tests/comment_projection_postgres_test.rs';
+  const restartHarnessPath = 'crates/rustok-blog/tests/comment_projection_restart_postgres_test.rs';
   const serviceExportPath = 'crates/rustok-blog/src/services/mod.rs';
   const entityPath = 'crates/rustok-blog/src/entities/blog_comment_projection_delivery.rs';
   const migrationPath = 'crates/rustok-blog/src/migrations/m20260716_000001_create_blog_comment_projection_deliveries.rs';
@@ -42,6 +47,7 @@ function fixture({
   const registryPath = 'crates/rustok-blog/contracts/blog-fba-registry.json';
   const harnessCommand = 'cargo test -p rustok-blog --lib services::comment_projection::tests';
   const postgresHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test';
+  const restartHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test';
 
   write(
     root,
@@ -113,6 +119,32 @@ count_outbox_events(&test_db.db)
     );
   }
 
+  if (!missingRestartHarness) {
+    write(
+      root,
+      restartHarnessPath,
+      `
+const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";
+struct PostgresBlogProjectionRestartTestDb
+database_url: String
+async fn restarted_connection(&self)
+SET search_path TO
+async fn restarted_handler_reuses_delivery_ledger_without_reapplying_counter()
+let first_handler = BlogCommentProjectionHandler::new(test_db.db.clone());
+first_handler.handle(&envelope).await?;
+drop(first_handler);
+${missingRestartConnection ? '' : 'let restarted_db = test_db.restarted_connection().await?;'}
+let restarted_handler = BlogCommentProjectionHandler::new(restarted_db.clone());
+restarted_handler.handle(&envelope).await?;
+load_post_state(&restarted_db, tenant_id, post_id).await?, (1, 2)
+count_delivery(&restarted_db, envelope.id).await?, 1
+count_outbox_events(&restarted_db).await?, 1
+CREATE TABLE blog_comment_projection_deliveries
+CREATE TABLE sys_events
+`,
+    );
+  }
+
   write(root, serviceExportPath, 'pub use comment_projection::BlogCommentProjectionHandler;');
   write(
     root,
@@ -158,7 +190,7 @@ registry.register(services::BlogCommentProjectionHandler::new(ctx.db.clone()));`
     root,
     evidencePath,
     JSON.stringify({
-      schema_version: 3,
+      schema_version: 4,
       module: 'blog',
       surface: 'comments_event_projection',
       status: statusDrift ? 'runtime_verified' : 'source_verified_no_compile',
@@ -201,6 +233,17 @@ registry.register(services::BlogCommentProjectionHandler::new(ctx.db.clone()));`
           'outbox_failure_rolls_back_counter_and_delivery_before_retry',
         ],
       },
+      restart_harness: {
+        status: restartStatusDrift ? 'executed' : 'executable_no_run',
+        runtime_status: restartStatusDrift ? 'passed' : 'not_run',
+        path: restartHarnessPath,
+        environment: 'RUSTOK_BLOG_TEST_DATABASE_URL',
+        command: restartHarnessCommand,
+        isolation: 'unique_schema_new_connection',
+        cases: [
+          'restarted_handler_reuses_delivery_ledger_without_reapplying_counter',
+        ],
+      },
       cases: [
         { name: 'shared_event_classifier' },
         { name: 'blog_post_target_filter' },
@@ -214,6 +257,7 @@ registry.register(services::BlogCommentProjectionHandler::new(ctx.db.clone()));`
         { name: 'postgres_out_of_order_delete_create' },
         { name: 'postgres_missing_post_recovery' },
         { name: 'postgres_outbox_rollback_recovery' },
+        { name: 'postgres_restart_replay' },
         { name: 'module_listener_registration' },
       ],
     }),
@@ -222,13 +266,14 @@ registry.register(services::BlogCommentProjectionHandler::new(ctx.db.clone()));`
     root,
     registryPath,
     JSON.stringify({
-      schema_version: 12,
+      schema_version: 13,
       evidence: { comments_event_projection: evidencePath },
       verification_chain: {
         source_gates: {
           comments_event_projection: {
             unit_test: handlerPath,
             ...(missingPostgresRegistration ? {} : { postgres_test: postgresHarnessPath }),
+            ...(missingRestartRegistration ? {} : { restart_test: restartHarnessPath }),
           },
         },
       },
@@ -250,13 +295,20 @@ registry.register(services::BlogCommentProjectionHandler::new(ctx.db.clone()));`
           environment: 'RUSTOK_BLOG_TEST_DATABASE_URL',
           command: postgresHarnessCommand,
         },
+        restart_harness: {
+          path: restartHarnessPath,
+          status: restartStatusDrift ? 'executed' : 'executable_no_run',
+          runtime_status: restartStatusDrift ? 'passed' : 'not_run',
+          environment: 'RUSTOK_BLOG_TEST_DATABASE_URL',
+          command: restartHarnessCommand,
+        },
       },
     }),
   );
   write(
     root,
     'crates/rustok-blog/docs/implementation-plan.md',
-    'blog-comments-event-projection.json verify:blog:comments-event-projection test:verify:blog:comments-event-projection source_verified_no_compile services::comment_projection::tests comment_projection_postgres_test RUSTOK_BLOG_TEST_DATABASE_URL runtime delivery and recovery',
+    'blog-comments-event-projection.json verify:blog:comments-event-projection test:verify:blog:comments-event-projection source_verified_no_compile services::comment_projection::tests comment_projection_postgres_test comment_projection_restart_postgres_test RUSTOK_BLOG_TEST_DATABASE_URL runtime delivery and recovery',
   );
 
   return root;
@@ -340,6 +392,24 @@ test('rejects a registry without the PostgreSQL target', () => {
   );
 });
 
+test('rejects a missing restart harness source', () => {
+  expectRejected({ missingRestartHarness: true }, /expected file is missing/);
+});
+
+test('rejects restart coverage that reuses the original connection', () => {
+  expectRejected(
+    { missingRestartConnection: true },
+    /missing let restarted_db = test_db.restarted_connection\(\).await\?;/,
+  );
+});
+
+test('rejects a registry without the restart target', () => {
+  expectRejected(
+    { missingRestartRegistration: true },
+    /restart test path drift/,
+  );
+});
+
 test('rejects runtime status promotion without execution', () => {
   expectRejected({ statusDrift: true }, /status drift/);
 });
@@ -350,4 +420,8 @@ test('rejects source harness execution promotion without execution', () => {
 
 test('rejects PostgreSQL harness execution promotion without execution', () => {
   expectRejected({ postgresStatusDrift: true }, /PostgreSQL harness drift/);
+});
+
+test('rejects restart harness execution promotion without execution', () => {
+  expectRejected({ restartStatusDrift: true }, /restart harness drift/);
 });

--- a/scripts/verify/verify-blog-fba.mjs
+++ b/scripts/verify/verify-blog-fba.mjs
@@ -18,8 +18,10 @@ const consumerRuntimeOrderSmokePath = 'crates/rustok-blog/contracts/evidence/blo
 const commentsEventProjectionPath = 'crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json';
 const projectionHandlerPath = 'crates/rustok-blog/src/services/comment_projection.rs';
 const projectionPostgresHarnessPath = 'crates/rustok-blog/tests/comment_projection_postgres_test.rs';
+const projectionRestartHarnessPath = 'crates/rustok-blog/tests/comment_projection_restart_postgres_test.rs';
 const projectionHarnessCommand = 'cargo test -p rustok-blog --lib services::comment_projection::tests';
 const projectionPostgresHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test';
+const projectionRestartHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test';
 const projectionPostgresHarnessEnvironment = 'RUSTOK_BLOG_TEST_DATABASE_URL';
 const richtextInventoryPath = 'crates/rustok-blog/contracts/evidence/blog-richtext-cutover-inventory.json';
 const richtextInventoryDocPath = 'crates/rustok-blog/docs/richtext-cutover-inventory.md';
@@ -34,6 +36,7 @@ const runtimeSmoke = json(runtimeSmokePath);
 const consumerRuntimeOrderSmoke = json(consumerRuntimeOrderSmokePath);
 const commentsEventProjection = json(commentsEventProjectionPath);
 const projectionPostgresHarness = read(projectionPostgresHarnessPath);
+const projectionRestartHarness = read(projectionRestartHarnessPath);
 const richtextInventory = json(richtextInventoryPath);
 const categorySearchReindex = json(categorySearchReindexPath);
 const graphqlRateLimit = json(graphqlRateLimitPath);
@@ -41,7 +44,7 @@ const aiRichtextBoundary = json(aiRichtextBoundaryPath);
 const provider = json(providerPath);
 const packageJson = json(packageJsonPath);
 
-if (registry.schema_version !== 12) fail('registry schema_version drift');
+if (registry.schema_version !== 13) fail('registry schema_version drift');
 if (registry.module !== 'blog' || registry.role !== 'consumer' || !['in_progress', 'boundary_ready'].includes(registry.status)) fail('registry identity/status drift');
 for (const failure of collectBlogFbaVerificationChainFailures({
   registry,
@@ -52,7 +55,7 @@ for (const failure of collectBlogFbaVerificationChainFailures({
 }
 if (registry.consumer_profile !== 'blog_post_comments') fail('consumer profile drift');
 if (registry.evidence.comments_event_projection !== commentsEventProjectionPath) fail('comments event projection registry path drift');
-if (commentsEventProjection.schema_version !== 3) fail('comments event projection schema_version drift');
+if (commentsEventProjection.schema_version !== 4) fail('comments event projection schema_version drift');
 if (commentsEventProjection.module !== 'blog' || commentsEventProjection.surface !== 'comments_event_projection' || commentsEventProjection.owner !== 'rustok-blog' || commentsEventProjection.provider !== 'rustok-comments') fail('comments event projection identity drift');
 if (commentsEventProjection.status !== 'source_verified_no_compile' || commentsEventProjection.compile_policy !== 'not_run_by_request' || commentsEventProjection.runtime_status !== 'pending') fail('comments event projection status drift');
 if (
@@ -78,6 +81,19 @@ sameSet(
     'outbox_failure_rolls_back_counter_and_delivery_before_retry',
   ],
   'comments event projection PostgreSQL cases',
+);
+if (
+  commentsEventProjection.restart_harness?.status !== 'executable_no_run'
+  || commentsEventProjection.restart_harness?.runtime_status !== 'not_run'
+  || commentsEventProjection.restart_harness?.path !== projectionRestartHarnessPath
+  || commentsEventProjection.restart_harness?.environment !== projectionPostgresHarnessEnvironment
+  || commentsEventProjection.restart_harness?.command !== projectionRestartHarnessCommand
+  || commentsEventProjection.restart_harness?.isolation !== 'unique_schema_new_connection'
+) fail('comments event projection restart harness drift');
+sameSet(
+  commentsEventProjection.restart_harness?.cases ?? [],
+  ['restarted_handler_reuses_delivery_ledger_without_reapplying_counter'],
+  'comments event projection restart cases',
 );
 if (registry.evidence.richtext_cutover_inventory !== richtextInventoryPath) fail('richtext cutover inventory registry path drift');
 if (registry.evidence.richtext_cutover_inventory_doc !== richtextInventoryDocPath) fail('richtext cutover inventory doc registry path drift');
@@ -234,7 +250,7 @@ for (const smokeCase of runtimeSmoke.fallback_smoke.cases ?? []) {
     fail(`runtime smoke degraded mode drift for ${smokeCase.operation}`);
   }
   hasAll(service, smokeCase.source_markers ?? [], `runtime service smoke ${smokeCase.operation}`);
-  hasAll(errorMapping, smokeCase.typed_error_markers ?? [], `runtime error smoke ${smokeCase.operation}`);
+  hasAll(errorMapping, smokeCase.typed_error_markers ?? [], `runtime error smoke ${smokeCase.operation}:error`);
 }
 hasAll(service, ['in_process_comments_thread_port', 'CommentsThreadPort', 'comments_read_port_context', 'comments_write_port_context', 'comments_port_error_to_blog_error'], 'comments port consumer boundary');
 if (/\.comments\s*\.get_comment\s*\(/.test(service)) {
@@ -275,8 +291,16 @@ if (
   || projection.postgres_harness?.environment !== projectionPostgresHarnessEnvironment
   || projection.postgres_harness?.command !== projectionPostgresHarnessCommand
 ) fail('event projection registry PostgreSQL harness drift');
+if (
+  projection.restart_harness?.path !== projectionRestartHarnessPath
+  || projection.restart_harness?.status !== 'executable_no_run'
+  || projection.restart_harness?.runtime_status !== 'not_run'
+  || projection.restart_harness?.environment !== projectionPostgresHarnessEnvironment
+  || projection.restart_harness?.command !== projectionRestartHarnessCommand
+) fail('event projection registry restart harness drift');
 if (registry.verification_chain?.source_gates?.comments_event_projection?.unit_test !== projectionHandlerPath) fail('event projection source-gate unit test drift');
 if (registry.verification_chain?.source_gates?.comments_event_projection?.postgres_test !== projectionPostgresHarnessPath) fail('event projection source-gate PostgreSQL test drift');
+if (registry.verification_chain?.source_gates?.comments_event_projection?.restart_test !== projectionRestartHarnessPath) fail('event projection source-gate restart test drift');
 const projectionSource = read(projectionHandlerPath);
 hasAll(projectionSource, [
   'impl EventHandler for BlogCommentProjectionHandler',
@@ -305,16 +329,31 @@ hasAll(projectionPostgresHarness, [
   'CREATE TABLE sys_events',
 ], 'blog comment projection PostgreSQL target');
 hasNone(projectionPostgresHarness, ['#[ignore]', 'runtime_verified'], 'blog comment projection PostgreSQL target');
+hasAll(projectionRestartHarness, [
+  'const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";',
+  'struct PostgresBlogProjectionRestartTestDb',
+  'database_url: String',
+  'async fn restarted_connection(&self)',
+  'async fn restarted_handler_reuses_delivery_ledger_without_reapplying_counter()',
+  'let first_handler = BlogCommentProjectionHandler::new(test_db.db.clone());',
+  'drop(first_handler);',
+  'let restarted_db = test_db.restarted_connection().await?;',
+  'let restarted_handler = BlogCommentProjectionHandler::new(restarted_db.clone());',
+  'restarted_handler.handle(&envelope).await?;',
+  'count_delivery(&restarted_db, envelope.id).await?, 1',
+  'count_outbox_events(&restarted_db).await?, 1',
+], 'blog comment projection restart target');
+hasNone(projectionRestartHarness, ['#[ignore]', 'runtime_verified'], 'blog comment projection restart target');
 const migration = read('crates/rustok-blog/src/migrations/m20260716_000001_create_blog_comment_projection_deliveries.rs');
 hasAll(migration, ['BlogCommentProjectionDeliveries', 'EventId', 'TenantId', 'PostId'], 'blog comment projection migration');
 const moduleSource = read('crates/rustok-blog/src/lib.rs');
 hasAll(moduleSource, ['fn register_event_listeners(', 'BlogCommentProjectionHandler::new(ctx.db.clone())'], 'blog event-listener registration');
 
 const plan = read('crates/rustok-blog/docs/implementation-plan.md');
-hasAll(plan, ['- FBA status: `boundary_ready`', 'blog-fba-registry.json', commentsEventProjectionPath, categorySearchReindexPath, graphqlRateLimitPath, aiRichtextBoundaryPath, 'CommentsThreadPort', 'blog-comments-consumer-static-matrix.json', 'blog-comments-runtime-fallback-smoke.json', consumerRuntimeOrderSmokePath, 'verify:blog:comments-port-boundary', 'test:verify:blog:comments-port-boundary', 'verify:blog:comments-event-projection', 'test:verify:blog:comments-event-projection', 'services::comment_projection::tests', 'comment_projection_postgres_test', 'RUSTOK_BLOG_TEST_DATABASE_URL', 'registry schema v12', 'degraded UI modes remain planned'], 'local plan');
+hasAll(plan, ['- FBA status: `boundary_ready`', 'blog-fba-registry.json', commentsEventProjectionPath, categorySearchReindexPath, graphqlRateLimitPath, aiRichtextBoundaryPath, 'CommentsThreadPort', 'blog-comments-consumer-static-matrix.json', 'blog-comments-runtime-fallback-smoke.json', consumerRuntimeOrderSmokePath, 'verify:blog:comments-port-boundary', 'test:verify:blog:comments-port-boundary', 'verify:blog:comments-event-projection', 'test:verify:blog:comments-event-projection', 'services::comment_projection::tests', 'comment_projection_postgres_test', 'comment_projection_restart_postgres_test', 'RUSTOK_BLOG_TEST_DATABASE_URL', 'registry schema v13', 'degraded UI modes remain planned'], 'local plan');
 const central = read('docs/modules/registry.md');
 hasAll(central, ['| `blog` |', 'crates/rustok-blog/contracts/blog-fba-registry.json', 'blog-comments-runtime-fallback-smoke.json', consumerRuntimeOrderSmokePath, '`in_progress` | `boundary_ready`'], 'central registry');
 const unified = read('docs/research/fluid-backend-architecture-unified-plan.md');
 hasAll(unified, ['`blog`', 'CommentsThreadPort', 'blog-fba-registry.json'], 'unified plan');
 
-console.log('[verify-blog-fba] Blog FBA registry, exact admin/storefront/comments-port/comments-projection/category/rate-limit/GraphQL/AI richtext source-gate chain, Comments projection unit and PostgreSQL harnesses, consumer metadata, and no-compile evidence are consistent');
+console.log('[verify-blog-fba] Blog FBA registry, exact admin/storefront/comments-port/comments-projection/category/rate-limit/GraphQL/AI richtext source-gate chain, Comments projection unit, PostgreSQL, and restart harnesses, consumer metadata, and no-compile evidence are consistent');

--- a/scripts/verify/verify-blog-fba.test.mjs
+++ b/scripts/verify/verify-blog-fba.test.mjs
@@ -52,6 +52,7 @@ function canonicalExistingPaths() {
       gate.evidence,
       gate.unit_test,
       gate.postgres_test,
+      gate.restart_test,
     ].filter(Boolean)),
   ]);
 }
@@ -125,6 +126,17 @@ test('Blog FBA verification-chain policy rejects projection PostgreSQL-test path
   const registry = canonicalRegistry();
   registry.verification_chain.source_gates.comments_event_projection.postgres_test =
     'crates/rustok-blog/tests/wrong_projection_postgres_test.rs';
+  assert.ok(
+    failures({ registry }).includes(
+      'registry source gate comments_event_projection path drift',
+    ),
+  );
+});
+
+test('Blog FBA verification-chain policy rejects projection restart-test path drift', () => {
+  const registry = canonicalRegistry();
+  registry.verification_chain.source_gates.comments_event_projection.restart_test =
+    'crates/rustok-blog/tests/wrong_projection_restart_test.rs';
   assert.ok(
     failures({ registry }).includes(
       'registry source gate comments_event_projection path drift',
@@ -211,6 +223,16 @@ test('Blog FBA verification-chain policy rejects a missing projection PostgreSQL
   assert.ok(
     failures({ existingPaths }).includes(
       `registry source gate comments_event_projection missing ${BLOG_FBA_SOURCE_GATES.comments_event_projection.postgres_test}`,
+    ),
+  );
+});
+
+test('Blog FBA verification-chain policy rejects a missing projection restart target', () => {
+  const existingPaths = canonicalExistingPaths();
+  existingPaths.delete(BLOG_FBA_SOURCE_GATES.comments_event_projection.restart_test);
+  assert.ok(
+    failures({ existingPaths }).includes(
+      `registry source gate comments_event_projection missing ${BLOG_FBA_SOURCE_GATES.comments_event_projection.restart_test}`,
     ),
   );
 });


### PR DESCRIPTION
## Summary

- add an env-gated PostgreSQL restart target for the Blog-owned Comments event projection
- apply one envelope, drop the first handler, open a new connection to the same isolated schema, construct a new handler, and replay the same envelope
- retain single-application assertions for `comment_count`, the delivery ledger, and the `BlogPostUpdated` outbox row
- upgrade event-projection evidence to schema v4 and Blog FBA registry to schema v13
- register the restart target in the existing projection leaf, focused fixture, shared Blog chain policy, and aggregate Blog gate
- keep production handler behavior and package command order unchanged
- keep concurrent optimistic exhaustion, host dispatch, process-level restart recovery, and all execution evidence pending

## Why

After #2638, duplicate delivery, ordering, missing-post replay, and rollback/retry had an executable PostgreSQL target, but restart recovery remained only an open runtime requirement. This slice makes durable-ledger replay across a new connection and handler executable without claiming process-level restart proof or execution.

## Validation

Not run by request. No verifier, unit test, Rust test, compile, PostgreSQL, browser, workflow, or CI command was executed.

Suggested maintainer commands:

```bash
npm run verify:blog:comments-event-projection
npm run test:verify:blog:comments-event-projection
npm run verify:blog:fba
npm run test:verify:blog:fba
RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test
```
