### PR TITLE
feat(index): add bounded replay dry-run

### DIFF
--- a/crates/rustok-index/docs/m6-bounded-replay-dry-run.md
+++ b/crates/rustok-index/docs/m6-bounded-replay-dry-run.md
@@ -1,0 +1,65 @@
+# M6 bounded replay dry-run
+
+Status: `source_complete_host_guard_pending`
+
+This slice adds an Index-owned, side-effect-free validation runtime over the exact immutable
+`SharedIndexSourceRegistry` and `SharedIndexSchemaRegistry` used by production replay.
+
+## Contract
+
+`IndexReplayDryRunRequest` carries:
+
+- one non-nil tenant;
+- one exact registered schema;
+- one optional source-owned continuation cursor;
+- one source page limit already bounded by `IndexSourceScanRequest`;
+- one invocation budget from 1 through 1024 pages.
+
+`SharedIndexReplayDryRunRuntime::run` resolves source ownership only from the immutable registry,
+then scans at most the requested page budget. For every returned page it verifies:
+
+- the existing source-page tenant/schema, size, key uniqueness, and cursor-progress contract;
+- non-nil event UUIDs;
+- page-local event UUID uniqueness before accepting the page;
+- complete `SchemaRegistry::validate_mutation` validity for every upsert or delete.
+
+The outcome reports the stable source name, completion or bounded yield, a resume cursor only when
+unfinished, page/mutation/upsert/delete counts, and the maximum observed source version.
+
+## No-write boundary
+
+The dry-run runtime owns no database connection and receives no mutation sink, job store,
+checkpoint store, reconciliation progress store, scheduler, or task handle. It cannot write:
+
+- `index_entities` or `index_links`;
+- `index_inbox`;
+- `index_jobs`;
+- `index_checkpoints`;
+- reconciliation progress or terminal state.
+
+Materialization performs no source call and no database I/O. The capability is published only
+when both immutable registries exist; an absent source registry publishes nothing, and a source
+registry without its shared schema registry fails closed.
+
+A yielded run is resumed only by explicitly passing its returned opaque cursor into another
+bounded request. No durable cursor is implied.
+
+## Explicitly open
+
+- server-owned request-bound `modules:manage` delegation for dry-run invocation;
+- GraphQL, HTTP, CLI, or admin transport surfaces;
+- persisted dry-run reports or comparison snapshots;
+- cross-page duplicate event detection beyond one bounded page;
+- mutation/checkpoint timing simulation;
+- targeted-key, full, and shadow rebuild mode contracts;
+- cooperative in-page operator cancellation and source timeout integration;
+- retained PostgreSQL/source-adapter execution evidence.
+
+Transport code must not treat `SharedIndexReplayDryRunRuntime` as an authorized public endpoint.
+The raw capability is an engine seam awaiting the same server-owned guard used by executable
+replay.
+
+## Validation ownership
+
+Formatting, Cargo checks/tests, JavaScript verifiers, source-adapter execution, and PostgreSQL
+validation are maintainer-run. The implementation agent did not execute them.

--- a/crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs
@@ -6,8 +6,9 @@ use thiserror::Error;
 use uuid::Uuid;
 
 use crate::{
-    IndexReplayCancelOutcome, IndexReplayRunError, IndexReplayRunOutcome, IndexReplayRunRequest,
-    SharedIndexSchemaRegistry, SharedIndexSourceRegistry,
+    IndexReplayCancelOutcome, IndexReplayDryRunRuntimeCompositionError, IndexReplayRunError,
+    IndexReplayRunOutcome, IndexReplayRunRequest, SharedIndexSchemaRegistry,
+    SharedIndexSourceRegistry, materialize_index_replay_dry_run_runtime,
 };
 
 use super::PostgresIndexReplayRunner;
@@ -59,6 +60,8 @@ pub enum IndexReplayRuntimeCompositionError {
     AlreadyMaterialized,
     #[error("shared Index source registry exists without the shared schema registry")]
     MissingSchemaRegistry,
+    #[error(transparent)]
+    DryRun(#[from] IndexReplayDryRunRuntimeCompositionError),
 }
 
 /// Materializes the canonical PostgreSQL-backed replay runtime from immutable source registries.
@@ -66,6 +69,7 @@ pub enum IndexReplayRuntimeCompositionError {
 /// An absent source registry returns `Ok(None)` and never publishes a false replay capability.
 /// The function performs no database I/O, starts no scheduler, and makes no tenant readiness or
 /// operator-authorization claim. Those checks remain at invocation and transport boundaries.
+/// The side-effect-free dry-run capability is published from the same immutable registry pair.
 pub fn materialize_postgres_index_replay_runtime(
     extensions: &mut ModuleRuntimeExtensions,
     db: DatabaseConnection,
@@ -82,6 +86,7 @@ pub fn materialize_postgres_index_replay_runtime(
         .cloned()
         .ok_or(IndexReplayRuntimeCompositionError::MissingSchemaRegistry)?;
 
+    materialize_index_replay_dry_run_runtime(extensions)?;
     let runtime = SharedIndexReplayRuntime::new(PostgresIndexReplayRunner::new(
         db,
         sources,
@@ -101,8 +106,9 @@ mod tests {
         EntityName, FieldCardinality, FieldName, IndexField, IndexSchema, IndexSource,
         IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest, IndexSourcePage,
         IndexSourceScanRequest, IndexValueType, LocaleMode, ModuleName, SchemaRef, SchemaVersion,
-        SharedIndexReplayRuntime, materialize_index_schema_registry,
-        materialize_index_source_registry, register_index_schema_source, register_index_source,
+        SharedIndexReplayDryRunRuntime, SharedIndexReplayRuntime,
+        materialize_index_schema_registry, materialize_index_source_registry,
+        register_index_schema_source, register_index_source,
     };
 
     use super::{
@@ -186,6 +192,7 @@ mod tests {
                 .expect("missing source registry should be accepted");
         assert!(runtime.is_none());
         assert!(!extensions.contains::<SharedIndexReplayRuntime>());
+        assert!(!extensions.contains::<SharedIndexReplayDryRunRuntime>());
     }
 
     #[tokio::test]
@@ -205,7 +212,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn complete_registries_materialize_one_shared_replay_runtime() {
+    async fn complete_registries_materialize_replay_and_dry_run_runtimes() {
         let mut extensions = source_extensions();
         let schemas = materialize_index_schema_registry(&extensions)
             .unwrap()
@@ -221,6 +228,7 @@ mod tests {
                 .expect("replay runtime should materialize")
                 .expect("complete registries should publish a runtime");
         assert!(extensions.contains::<SharedIndexReplayRuntime>());
+        assert!(extensions.contains::<SharedIndexReplayDryRunRuntime>());
         assert!(format!("{runtime:?}").contains("SharedIndexReplayRuntime"));
     }
 

--- a/crates/rustok-index/src/lib.rs
+++ b/crates/rustok-index/src/lib.rs
@@ -3,14 +3,15 @@
 //! The active implementation contains the database-independent generic engine
 //! core under [`domain`] and [`application`], the canonical M3 PostgreSQL
 //! storage-schema migrations, atomic mutation persistence, tenant-scoped source
-//! schema registration, bounded source replay/load contracts, one-page replay
-//! orchestration with durable fenced checkpoint progression, bounded multi-page
-//! replay coordination with heartbeat/yield/cancellation semantics, bounded
-//! multi-pass source reconciliation with durable pass/cursor progression,
-//! host-published replay and query capabilities, host-database-aware source factory
-//! composition, durable replay-job and schema-application leases, schema-derived
-//! secondary-index lifecycle, fail-closed measured partition admission, and the
-//! PostgreSQL execution adapter for structured Index queries.
+//! schema registration, bounded source replay/load contracts, bounded side-effect-free
+//! replay dry-run validation, one-page replay orchestration with durable fenced
+//! checkpoint progression, bounded multi-page replay coordination with
+//! heartbeat/yield/cancellation semantics, bounded multi-pass source reconciliation
+//! with durable pass/cursor progression, host-published replay and query capabilities,
+//! host-database-aware source factory composition, durable replay-job and
+//! schema-application leases, schema-derived secondary-index lifecycle, fail-closed
+//! measured partition admission, and the PostgreSQL execution adapter for structured
+//! Index queries.
 
 use async_trait::async_trait;
 use rustok_core::{
@@ -23,9 +24,11 @@ pub mod application;
 pub mod domain;
 pub mod infrastructure;
 pub mod migrations;
+pub mod replay_dry_run;
 
 pub use application::*;
 pub use domain::*;
+pub use replay_dry_run::*;
 pub use infrastructure::postgres::{
     evaluate_partition_admission, materialize_postgres_index_query_runtime,
     materialize_postgres_index_replay_runtime, materialize_postgres_index_sources,

--- a/crates/rustok-index/src/replay_dry_run.rs
+++ b/crates/rustok-index/src/replay_dry_run.rs
@@ -1,0 +1,513 @@
+use std::{collections::BTreeSet, fmt, sync::Arc};
+
+use rustok_core::ModuleRuntimeExtensions;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::{
+    IndexMutation, IndexSourceCursor, IndexSourceError, IndexSourceScanRequest,
+    RecordValidationError, SchemaRef, SchemaRegistry, SharedIndexSchemaRegistry,
+    SharedIndexSourceRegistry,
+};
+
+const MAX_DRY_RUN_PAGES: usize = 1_024;
+
+/// One bounded, side-effect-free replay validation request.
+///
+/// The request carries an optional source-owned continuation cursor so a large source can be
+/// inspected over multiple operator calls without creating a replay job or durable checkpoint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexReplayDryRunRequest {
+    tenant_id: Uuid,
+    schema: SchemaRef,
+    cursor: Option<IndexSourceCursor>,
+    page_limit: usize,
+    max_pages: usize,
+}
+
+impl IndexReplayDryRunRequest {
+    pub fn new(
+        tenant_id: Uuid,
+        schema: SchemaRef,
+        cursor: Option<IndexSourceCursor>,
+        page_limit: usize,
+        max_pages: usize,
+    ) -> Result<Self, IndexReplayDryRunError> {
+        IndexSourceScanRequest::new(tenant_id, schema.clone(), cursor.clone(), page_limit)
+            .map_err(IndexReplayDryRunError::InvalidRequest)?;
+        if !(1..=MAX_DRY_RUN_PAGES).contains(&max_pages) {
+            return Err(IndexReplayDryRunError::InvalidMaxPages {
+                actual: max_pages,
+                max: MAX_DRY_RUN_PAGES,
+            });
+        }
+        Ok(Self {
+            tenant_id,
+            schema,
+            cursor,
+            page_limit,
+            max_pages,
+        })
+    }
+
+    pub fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    pub fn cursor(&self) -> Option<&IndexSourceCursor> {
+        self.cursor.as_ref()
+    }
+
+    pub fn page_limit(&self) -> usize {
+        self.page_limit
+    }
+
+    pub fn max_pages(&self) -> usize {
+        self.max_pages
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexReplayDryRunStatus {
+    Complete,
+    Yielded,
+}
+
+/// Aggregate result of one bounded dry-run invocation.
+///
+/// No mutation, inbox delivery, job, checkpoint, or reconciliation progress is persisted by this
+/// capability. `next_cursor` is present only when the page budget was exhausted before completion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexReplayDryRunOutcome {
+    status: IndexReplayDryRunStatus,
+    source_name: String,
+    next_cursor: Option<IndexSourceCursor>,
+    pages_scanned: usize,
+    mutation_count: usize,
+    upsert_count: usize,
+    delete_count: usize,
+    max_source_version: Option<u64>,
+}
+
+impl IndexReplayDryRunOutcome {
+    pub fn status(&self) -> IndexReplayDryRunStatus {
+        self.status
+    }
+
+    pub fn source_name(&self) -> &str {
+        &self.source_name
+    }
+
+    pub fn next_cursor(&self) -> Option<&IndexSourceCursor> {
+        self.next_cursor.as_ref()
+    }
+
+    pub fn pages_scanned(&self) -> usize {
+        self.pages_scanned
+    }
+
+    pub fn mutation_count(&self) -> usize {
+        self.mutation_count
+    }
+
+    pub fn upsert_count(&self) -> usize {
+        self.upsert_count
+    }
+
+    pub fn delete_count(&self) -> usize {
+        self.delete_count
+    }
+
+    pub fn max_source_version(&self) -> Option<u64> {
+        self.max_source_version
+    }
+}
+
+/// Immutable, cloneable dry-run capability materialized from the complete source/schema set.
+#[derive(Clone)]
+pub struct SharedIndexReplayDryRunRuntime {
+    sources: SharedIndexSourceRegistry,
+    schemas: Arc<SchemaRegistry>,
+}
+
+impl SharedIndexReplayDryRunRuntime {
+    fn new(sources: SharedIndexSourceRegistry, schemas: Arc<SchemaRegistry>) -> Self {
+        Self { sources, schemas }
+    }
+
+    pub async fn run(
+        &self,
+        request: IndexReplayDryRunRequest,
+    ) -> Result<IndexReplayDryRunOutcome, IndexReplayDryRunError> {
+        let descriptor = self
+            .sources
+            .source_for_schema(request.schema())
+            .ok_or_else(|| IndexReplayDryRunError::UnknownSchemaSource(request.schema.clone()))?;
+        let source_name = descriptor.source_name().to_owned();
+        let mut cursor = request.cursor.clone();
+        let mut pages_scanned = 0usize;
+        let mut mutation_count = 0usize;
+        let mut upsert_count = 0usize;
+        let mut delete_count = 0usize;
+        let mut max_source_version = None::<u64>;
+
+        for page_index in 0..request.max_pages {
+            let scan_request = IndexSourceScanRequest::new(
+                request.tenant_id,
+                request.schema.clone(),
+                cursor.clone(),
+                request.page_limit,
+            )
+            .map_err(IndexReplayDryRunError::InvalidRequest)?;
+            let page = self
+                .sources
+                .scan(scan_request)
+                .await
+                .map_err(IndexReplayDryRunError::Source)?;
+
+            let mut event_ids = BTreeSet::new();
+            for (position, mutation) in page.mutations().iter().enumerate() {
+                let event_id = mutation.event_id();
+                if event_id.is_nil() {
+                    return Err(IndexReplayDryRunError::NilEventId {
+                        page_index,
+                        position,
+                    });
+                }
+                if !event_ids.insert(event_id) {
+                    return Err(IndexReplayDryRunError::DuplicateEventId {
+                        page_index,
+                        position,
+                        event_id,
+                    });
+                }
+                self.schemas.validate_mutation(mutation).map_err(|source| {
+                    IndexReplayDryRunError::InvalidMutation {
+                        page_index,
+                        position,
+                        source,
+                    }
+                })?;
+                match mutation {
+                    IndexMutation::Upsert { .. } => upsert_count += 1,
+                    IndexMutation::Delete { .. } => delete_count += 1,
+                }
+                max_source_version = Some(
+                    max_source_version
+                        .map_or(mutation.source_version(), |current| {
+                            current.max(mutation.source_version())
+                        }),
+                );
+            }
+
+            pages_scanned += 1;
+            mutation_count += page.mutations().len();
+            cursor = page.next_cursor().cloned();
+            if cursor.is_none() {
+                return Ok(IndexReplayDryRunOutcome {
+                    status: IndexReplayDryRunStatus::Complete,
+                    source_name,
+                    next_cursor: None,
+                    pages_scanned,
+                    mutation_count,
+                    upsert_count,
+                    delete_count,
+                    max_source_version,
+                });
+            }
+        }
+
+        Ok(IndexReplayDryRunOutcome {
+            status: IndexReplayDryRunStatus::Yielded,
+            source_name,
+            next_cursor: cursor,
+            pages_scanned,
+            mutation_count,
+            upsert_count,
+            delete_count,
+            max_source_version,
+        })
+    }
+}
+
+impl fmt::Debug for SharedIndexReplayDryRunRuntime {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SharedIndexReplayDryRunRuntime")
+            .field("sources", &self.sources)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum IndexReplayDryRunError {
+    #[error("Index replay dry-run request is invalid")]
+    InvalidRequest(#[source] IndexSourceError),
+    #[error("Index replay dry-run max pages is invalid: actual={actual}, max={max}")]
+    InvalidMaxPages { actual: usize, max: usize },
+    #[error("No Index replay source owns dry-run schema {0}")]
+    UnknownSchemaSource(SchemaRef),
+    #[error("Index replay dry-run source failed")]
+    Source(#[source] IndexSourceError),
+    #[error(
+        "Index replay dry-run mutation at page {page_index} position {position} has a nil event id"
+    )]
+    NilEventId {
+        page_index: usize,
+        position: usize,
+    },
+    #[error(
+        "Index replay dry-run mutation at page {page_index} position {position} duplicates event id {event_id}"
+    )]
+    DuplicateEventId {
+        page_index: usize,
+        position: usize,
+        event_id: Uuid,
+    },
+    #[error(
+        "Index replay dry-run mutation at page {page_index} position {position} violates the registered schema"
+    )]
+    InvalidMutation {
+        page_index: usize,
+        position: usize,
+        #[source]
+        source: RecordValidationError,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum IndexReplayDryRunRuntimeCompositionError {
+    #[error("shared Index replay dry-run runtime is already materialized")]
+    AlreadyMaterialized,
+    #[error("shared Index source registry exists without the shared schema registry")]
+    MissingSchemaRegistry,
+}
+
+/// Publishes one immutable dry-run runtime only after source factories and both shared registries
+/// have been materialized. This function performs no source call and no database I/O.
+pub fn materialize_index_replay_dry_run_runtime(
+    extensions: &mut ModuleRuntimeExtensions,
+) -> Result<Option<SharedIndexReplayDryRunRuntime>, IndexReplayDryRunRuntimeCompositionError> {
+    if extensions.contains::<SharedIndexReplayDryRunRuntime>() {
+        return Err(IndexReplayDryRunRuntimeCompositionError::AlreadyMaterialized);
+    }
+    let Some(sources) = extensions.get::<SharedIndexSourceRegistry>().cloned() else {
+        return Ok(None);
+    };
+    let schemas = extensions
+        .get::<SharedIndexSchemaRegistry>()
+        .cloned()
+        .ok_or(IndexReplayDryRunRuntimeCompositionError::MissingSchemaRegistry)?;
+    let runtime = SharedIndexReplayDryRunRuntime::new(sources, schemas.shared());
+    extensions.insert(runtime.clone());
+    Ok(Some(runtime))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use async_trait::async_trait;
+
+    use crate::{
+        EntityKey, EntityName, FieldCardinality, FieldName, IndexField, IndexRecord, IndexSchema,
+        IndexSource, IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest,
+        IndexSourcePage, IndexValue, IndexValueType, LocaleMode, ModuleName, SchemaVersion,
+        materialize_index_schema_registry, materialize_index_source_registry,
+        register_index_schema_source, register_index_source,
+    };
+
+    use super::*;
+
+    struct PagedSource {
+        page_count: usize,
+        invalid_record: bool,
+    }
+
+    #[async_trait]
+    impl IndexSource for PagedSource {
+        async fn scan(
+            &self,
+            request: IndexSourceScanRequest,
+        ) -> Result<IndexSourcePage, IndexSourceFailure> {
+            let page_index = request
+                .cursor()
+                .map(|cursor| cursor.value().as_u64().expect("integer cursor") as usize)
+                .unwrap_or(0);
+            let entity_id = Uuid::from_u128(100 + page_index as u128);
+            let fields = if self.invalid_record {
+                BTreeMap::new()
+            } else {
+                BTreeMap::from([(
+                    FieldName::new("id").unwrap(),
+                    IndexValue::Uuid(entity_id),
+                )])
+            };
+            let mutation = IndexMutation::Upsert {
+                event_id: Uuid::from_u128(1_000 + page_index as u128),
+                record: IndexRecord {
+                    key: EntityKey {
+                        tenant_id: request.tenant_id(),
+                        schema: request.schema().clone(),
+                        entity_id,
+                        locale: None,
+                    },
+                    source_version: page_index as u64 + 1,
+                    fields,
+                    links: Vec::new(),
+                },
+            };
+            let next_cursor = if page_index + 1 < self.page_count {
+                Some(IndexSourceCursor::new(serde_json::json!(page_index + 1)).unwrap())
+            } else {
+                None
+            };
+            Ok(IndexSourcePage::new(&request, vec![mutation], next_cursor).unwrap())
+        }
+
+        async fn load(
+            &self,
+            request: IndexSourceLoadRequest,
+        ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+            Ok(IndexSourceLoadBatch::new(&request, Vec::new()).unwrap())
+        }
+    }
+
+    fn schema() -> IndexSchema {
+        IndexSchema {
+            reference: SchemaRef {
+                module: ModuleName::new("dry-run-owner").unwrap(),
+                entity: EntityName::new("item").unwrap(),
+                version: SchemaVersion::INITIAL,
+            },
+            locale_mode: LocaleMode::None,
+            fields: vec![IndexField {
+                name: FieldName::new("id").unwrap(),
+                value_type: IndexValueType::Uuid,
+                cardinality: FieldCardinality::One,
+                nullable: false,
+                selectable: true,
+                filterable: true,
+                sortable: true,
+            }],
+            links: Vec::new(),
+        }
+    }
+
+    fn runtime(page_count: usize, invalid_record: bool) -> SharedIndexReplayDryRunRuntime {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        let schema = schema();
+        register_index_schema_source(&mut extensions, "dry_run_owner", schema.clone()).unwrap();
+        register_index_source(
+            &mut extensions,
+            "dry_run_owner",
+            "dry-run-primary",
+            [schema.reference.clone()],
+            PagedSource {
+                page_count,
+                invalid_record,
+            },
+        )
+        .unwrap();
+        let schemas = materialize_index_schema_registry(&extensions)
+            .unwrap()
+            .expect("schema registry");
+        let sources = materialize_index_source_registry(&extensions)
+            .unwrap()
+            .expect("source registry");
+        extensions.insert(schemas);
+        extensions.insert(sources);
+        materialize_index_replay_dry_run_runtime(&mut extensions)
+            .unwrap()
+            .expect("dry-run runtime")
+    }
+
+    #[tokio::test]
+    async fn bounded_dry_run_yields_a_resume_cursor_and_completes_without_state() {
+        let runtime = runtime(3, false);
+        let first = runtime
+            .run(
+                IndexReplayDryRunRequest::new(
+                    Uuid::from_u128(1),
+                    schema().reference,
+                    None,
+                    10,
+                    1,
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.status(), IndexReplayDryRunStatus::Yielded);
+        assert_eq!(first.pages_scanned(), 1);
+        assert_eq!(first.mutation_count(), 1);
+        assert_eq!(first.upsert_count(), 1);
+        assert_eq!(first.delete_count(), 0);
+        assert_eq!(first.max_source_version(), Some(1));
+
+        let second = runtime
+            .run(
+                IndexReplayDryRunRequest::new(
+                    Uuid::from_u128(1),
+                    schema().reference,
+                    first.next_cursor().cloned(),
+                    10,
+                    2,
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(second.status(), IndexReplayDryRunStatus::Complete);
+        assert!(second.next_cursor().is_none());
+        assert_eq!(second.pages_scanned(), 2);
+        assert_eq!(second.mutation_count(), 2);
+        assert_eq!(second.max_source_version(), Some(3));
+    }
+
+    #[tokio::test]
+    async fn dry_run_rejects_a_schema_invalid_mutation_before_any_persistence_boundary() {
+        let error = runtime(1, true)
+            .run(
+                IndexReplayDryRunRequest::new(
+                    Uuid::from_u128(1),
+                    schema().reference,
+                    None,
+                    10,
+                    1,
+                )
+                .unwrap(),
+            )
+            .await
+            .expect_err("missing required field must fail dry-run validation");
+        assert!(matches!(
+            error,
+            IndexReplayDryRunError::InvalidMutation { .. }
+        ));
+    }
+
+    #[test]
+    fn dry_run_request_bounds_page_budget() {
+        let tenant_id = Uuid::from_u128(1);
+        assert!(IndexReplayDryRunRequest::new(
+            tenant_id,
+            schema().reference,
+            None,
+            10,
+            0,
+        )
+        .is_err());
+        assert!(IndexReplayDryRunRequest::new(
+            tenant_id,
+            schema().reference,
+            None,
+            10,
+            MAX_DRY_RUN_PAGES + 1,
+        )
+        .is_err());
+    }
+}

--- a/scripts/verify/verify-index-replay-runtime-composition.mjs
+++ b/scripts/verify/verify-index-replay-runtime-composition.mjs
@@ -18,6 +18,56 @@ const requireMarkers = (relative, markers) => {
   return source;
 };
 
+const dryRunPath = 'crates/rustok-index/src/replay_dry_run.rs';
+const dryRun = requireMarkers(dryRunPath, [
+  'pub struct IndexReplayDryRunRequest',
+  'MAX_DRY_RUN_PAGES: usize = 1_024',
+  'pub enum IndexReplayDryRunStatus',
+  'Complete',
+  'Yielded',
+  'pub struct IndexReplayDryRunOutcome',
+  'pub struct SharedIndexReplayDryRunRuntime',
+  'pub async fn run(',
+  'source_for_schema(request.schema())',
+  'IndexSourceScanRequest::new(',
+  'let mut event_ids = BTreeSet::new();',
+  'event_id.is_nil()',
+  'DuplicateEventId',
+  'self.schemas.validate_mutation(mutation)',
+  'IndexMutation::Upsert',
+  'IndexMutation::Delete',
+  'next_cursor: cursor',
+  'pub fn materialize_index_replay_dry_run_runtime(',
+  'extensions.get::<SharedIndexSourceRegistry>().cloned()',
+  '.get::<SharedIndexSchemaRegistry>()',
+  'extensions.insert(runtime.clone())',
+  'bounded_dry_run_yields_a_resume_cursor_and_completes_without_state',
+  'dry_run_rejects_a_schema_invalid_mutation_before_any_persistence_boundary',
+  'dry_run_request_bounds_page_budget',
+]);
+for (const forbidden of [
+  'DatabaseConnection',
+  'PostgresMutationStore',
+  'PostgresIndexReplayJobStore',
+  'PostgresIndexReplayCheckpointStore',
+  'index_entities',
+  'index_links',
+  'index_inbox',
+  'index_jobs',
+  'index_checkpoints',
+  'tokio::spawn',
+  'tokio::time::sleep',
+  '.execute(',
+  '.begin()',
+  'INSERT ',
+  'UPDATE ',
+  'DELETE FROM',
+]) {
+  if (dryRun.includes(forbidden)) {
+    fail(`${dryRunPath} contains forbidden persistence/scheduler marker ${forbidden}`);
+  }
+}
+
 const indexRuntimePath = 'crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs';
 const indexRuntime = requireMarkers(indexRuntimePath, [
   'pub struct SharedIndexReplayRuntime',
@@ -26,15 +76,18 @@ const indexRuntime = requireMarkers(indexRuntimePath, [
   'pub enum IndexReplayRuntimeCompositionError',
   'AlreadyMaterialized',
   'MissingSchemaRegistry',
+  'DryRun(#[from] IndexReplayDryRunRuntimeCompositionError)',
   'pub fn materialize_postgres_index_replay_runtime(',
   'extensions.get::<SharedIndexSourceRegistry>().cloned()',
   '.get::<SharedIndexSchemaRegistry>()',
   'return Ok(None);',
+  'materialize_index_replay_dry_run_runtime(extensions)?;',
   'PostgresIndexReplayRunner::new(',
   'extensions.insert(runtime.clone())',
   'missing_source_registry_does_not_publish_false_replay_runtime',
   'source_registry_without_shared_schema_registry_fails_closed',
-  'complete_registries_materialize_one_shared_replay_runtime',
+  'complete_registries_materialize_replay_and_dry_run_runtimes',
+  'extensions.contains::<SharedIndexReplayDryRunRuntime>()',
   'duplicate_replay_runtime_materialization_fails_closed',
 ]);
 for (const forbidden of [
@@ -138,10 +191,22 @@ requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
   'materialize_postgres_index_replay_runtime',
 ]);
 requireMarkers('crates/rustok-index/src/lib.rs', [
-  'host-published',
+  'bounded side-effect-free',
+  'pub mod replay_dry_run;',
+  'pub use replay_dry_run::*;',
   'SharedIndexReplayRuntime',
   'IndexReplayRuntimeCompositionError',
   'materialize_postgres_index_replay_runtime',
+]);
+requireMarkers('crates/rustok-index/docs/m6-bounded-replay-dry-run.md', [
+  'Status: `source_complete_host_guard_pending`',
+  '`IndexReplayDryRunRequest`',
+  '`SharedIndexReplayDryRunRuntime::run`',
+  'one invocation budget from 1 through 1024 pages',
+  'complete `SchemaRegistry::validate_mutation` validity',
+  'No-write boundary',
+  'server-owned request-bound `modules:manage` delegation for dry-run invocation',
+  'maintainer-run',
 ]);
 requireMarkers('crates/rustok-index/docs/m6-replay-runtime-composition.md', [
   'Status: `source_complete_owner_execution_pending`',


### PR DESCRIPTION
## Summary

- add `SharedIndexReplayDryRunRuntime` over the exact immutable source/schema registries used by executable replay
- scan at most 1024 bounded source pages per invocation and return an opaque resume cursor when the page budget is exhausted
- validate source-page scope/progress, non-nil page-local unique event UUIDs, and complete `SchemaRegistry::validate_mutation` correctness
- report stable source identity, completion/yield status, page and mutation counts, upsert/delete counts, and maximum observed source version
- publish the dry-run capability during canonical replay-runtime materialization only when both immutable registries exist
- add focused resume, invalid-mutation, materialization, documentation, and fail-closed static contract coverage

## No-write boundary

The dry-run runtime owns no database connection and receives no mutation sink, replay job store, checkpoint store, reconciliation progress store, scheduler, or task handle. It does not create or update:

- `index_entities` / `index_links`
- `index_inbox`
- `index_jobs`
- `index_checkpoints`
- reconciliation progress or terminal state

A yielded run resumes only when the caller explicitly supplies the returned source cursor in another bounded request.

## Scope boundaries

- server-owned request-bound `modules:manage` delegation remains open
- no GraphQL, HTTP, CLI, or admin transport
- no persisted dry-run report
- no cross-page event-ID set or unbounded ID collection
- no targeted-key/full/shadow rebuild mode contract
- no mutation/checkpoint timing simulation
- no cooperative in-page operator cancellation
- no retained PostgreSQL/source-adapter execution evidence

`SharedIndexReplayDryRunRuntime` is an internal engine capability and must not be treated as an authorized public endpoint before the server guard is added.

## Product → SalesChannel follow-up

The initially considered relation slice was not published. Channel create/update/delete can change resolved Product links without increasing `Product.index_revision`; replaying the same Product source version would be deduplicated and could retain stale links. That relation requires a durable monotonic cross-owner revision contract first.

## Validation

Not run per maintainer instruction:

- Cargo formatting/checks/tests/Clippy
- JavaScript verifiers
- source-adapter or PostgreSQL execution
- CI workflows

Suggested maintainer commands:

```bash
cargo test -p rustok-index replay_dry_run -- --nocapture
cargo check -p rustok-index --all-targets
node scripts/verify/verify-index-replay-runtime-composition.mjs
node scripts/verify/verify-index-query-contract.mjs
```

## Branch state

Base commit: `04f75d12a7571d0f3811f53d4dfb5824dbd3a89d`
Branch: `agent/index-m6-bounded-dry-run-20260731`

`main` subsequently advanced by one unrelated Blog evidence commit. This branch has no changed-file overlap with open PRs #2636 or #2639.