### PR TITLE
feat(blog): degrade unavailable storefront comments

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 3,
+  "schema_version": 2,
   "module": "blog",
   "role": "consumer",
   "provider": "comments",

--- a/crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "module": "blog",
   "role": "consumer",
   "provider": "comments",
@@ -11,7 +11,42 @@
   "source_contract": {
     "consumer_service": "crates/rustok-blog/src/services/comment.rs",
     "consumer_error_mapping": "crates/rustok-blog/src/services/comment.rs",
-    "provider_port_registry": "crates/rustok-comments/contracts/comments-fba-registry.json"
+    "provider_port_registry": "crates/rustok-comments/contracts/comments-fba-registry.json",
+    "graphql_owner": "crates/rustok-blog/src/graphql/types.rs",
+    "storefront_model": "crates/rustok-blog/storefront/src/model.rs",
+    "storefront_graphql": "crates/rustok-blog/storefront/src/transport/graphql_adapter.rs",
+    "storefront_native": "crates/rustok-blog/storefront/src/transport/native_server_adapter.rs",
+    "storefront_ui": "crates/rustok-blog/storefront/src/ui/leptos.rs"
+  },
+  "storefront_read_degradation": {
+    "status": "source_verified_no_compile",
+    "runtime_status": "not_run",
+    "operation": "list_public_comments_for_target",
+    "transports": [
+      "graphql",
+      "native_ssr"
+    ],
+    "availability_states": [
+      "AVAILABLE",
+      "UNAVAILABLE",
+      "TIMEOUT"
+    ],
+    "degraded_error_kinds": [
+      "ExternalService",
+      "Timeout"
+    ],
+    "propagated_error_policy": "all_other_blog_errors",
+    "degraded_payload": {
+      "items": [],
+      "total": 0
+    },
+    "ui_states": [
+      "comments_temporarily_unavailable_article_still_available",
+      "comments_timeout_article_still_available"
+    ],
+    "cached_thread_snapshot": "planned",
+    "comment_form_fallback": "planned",
+    "runtime_evidence": "pending"
   },
   "fallback_smoke": {
     "status": "planned",
@@ -60,7 +95,7 @@
           "with_error_code(error.code)"
         ],
         "degraded_mode": "show_cached_thread_snapshot",
-        "expected_consumer_behavior": "planned UI branch; source contract preserves typed unavailable/timeout/not-found errors while runtime fallback evidence remains pending"
+        "expected_consumer_behavior": "typed unavailable/timeout storefront state is source-verified; cached snapshot runtime fallback remains planned and not executed"
       }
     ],
     "runtime_evidence": "pending"

--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -93,9 +93,8 @@ projection. Typed storefront comments availability is source-verified across the
 owner GraphQL resolver, GraphQL client, native SSR adapter, shared DTO, and Leptos
 UI. Only `ExternalService` and `Timeout` become empty `UNAVAILABLE` or `TIMEOUT`
 comment payloads; every other `BlogError` remains fail-closed. The in-process
-source profile is verified, while the remote adapter and broader degraded UI modes
-remain planned. In particular, cached snapshot and comment-form fallback remain
-planned, and runtime evidence is pending.
+source profile is verified. The remote adapter and degraded UI modes remain planned.
+Cached snapshot and comment-form fallback remain planned, and runtime evidence is pending.
 
 Comments lifecycle projection into Blog-owned `comment_count` is a Blog consumer
 boundary. `BlogCommentProjectionHandler` accepts only `comment.created` and

--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -25,7 +25,9 @@ both transports. It renders server-rendered `RichTextView` HTML with exactly one
 `content.html` sink and uses server-derived plain text as fallback. The public
 comments projection is Comments-owned and approved-only, and storefront comment
 pagination is route-owned and bounded consistently across GraphQL and native
-SSR. The active DTO/UI path has no legacy body or format field.
+SSR. Public comment reads now carry typed `AVAILABLE`, `UNAVAILABLE`, or `TIMEOUT`
+availability across both transports, while the article remains renderable for the
+two degraded states. The active DTO/UI path has no legacy body or format field.
 
 The Blog admin uses typed `RichTextDocument` state and the owner
 `BlogRichTextEditor`. The fixed Article frame is isolated with an
@@ -87,8 +89,13 @@ rather than the legacy `CommentsError` conversion. The fail-closed gate is
 `scripts/verify/verify-blog-comments-port-boundary.test.mjs`; exact commands
 `verify:blog:comments-port-boundary` and
 `test:verify:blog:comments-port-boundary` run after storefront and before event
-projection. The in-process source profile is verified; the remote adapter and
-degraded UI modes remain planned, and runtime evidence is pending.
+projection. Typed storefront comments availability is source-verified across the
+owner GraphQL resolver, GraphQL client, native SSR adapter, shared DTO, and Leptos
+UI. Only `ExternalService` and `Timeout` become empty `UNAVAILABLE` or `TIMEOUT`
+comment payloads; every other `BlogError` remains fail-closed. The in-process
+source profile is verified, while the remote adapter and broader degraded UI modes
+remain planned. In particular, cached snapshot and comment-form fallback remain
+planned, and runtime evidence is pending.
 
 Comments lifecycle projection into Blog-owned `comment_count` is a Blog consumer
 boundary. `BlogCommentProjectionHandler` accepts only `comment.created` and
@@ -179,7 +186,7 @@ Forum ownership, and aggregate FBA evidence. It also found later commit
 `2f1a4f20f530b1ec8e3cee3c1f51efc36aa5017f` widening the private AI Blog shim
 with an unused `migrations` re-export. Slice 35 removes that drift, binds the
 exact owner-only surface to machine evidence and a negative fixture, reconciles
-the richtext source inventory, and registers the new gate in the Blog FBA
+the richtext inventory, and registers the new gate in the Blog FBA
 verify/test chain.
 
 The continuation audit at `ce3b1690bbf7d67e5ea80cad071180deae7e62dc`
@@ -268,6 +275,15 @@ durable delivery ledger. Projection evidence advances to schema v4 and Blog
 registry to schema v13; focused, shared-chain, and aggregate guards retain the
 new target without recording execution or claiming process-level restart proof.
 
+The continuation audit at `3e0fa3a33ad0419591b4f7fa36924fbad1dcd354`
+found that public Comments unavailability or timeout still failed the entire
+selected-article request in both native SSR and GraphQL. Slice 47 adds typed
+`AVAILABLE` / `UNAVAILABLE` / `TIMEOUT` transport parity, degrades only
+`ExternalService` and `Timeout` to an empty comment payload, renders explicit
+Leptos states while preserving the article, and extends the registered fallback
+evidence plus focused fail-closed fixture. Blog registry schema v13 and package
+order remain unchanged; no runtime or browser result is recorded.
+
 ## FFA/FBA status
 
 - FFA status: `in_progress`.
@@ -283,8 +299,11 @@ new target without recording execution or claiming process-level restart proof.
   the in-process profile; all seven operations, approved public read, typed
   richtext projection, two-second deadlines, write idempotency, active typed
   `PortErrorKind` mapping, exact npm leaf commands, focused fixture, and Blog FBA
-  ordering are locked. The remote adapter and degraded UI modes remain planned;
-  runtime evidence is pending.
+  ordering are locked. Typed storefront comments availability is retained across
+  GraphQL/native DTOs and Leptos UI; only external-service and timeout errors
+  degrade, while other errors propagate. The remote adapter, cached snapshot,
+  comment-form fallback, browser/runtime evidence, and broader degraded UI modes
+  remain planned or pending.
 - Comments event projection: Blog-owned `source_verified_no_compile`; evidence
   schema v4, shared classifier/counter helpers, `executable_no_run` Rust unit,
   PostgreSQL transaction, and restart harnesses, verifier, focused self-test,
@@ -326,6 +345,11 @@ new target without recording execution or claiming process-level restart proof.
 - `crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-consumer-runtime-order-smoke.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json`
+- `crates/rustok-blog/src/graphql/types.rs`
+- `crates/rustok-blog/storefront/src/model.rs`
+- `crates/rustok-blog/storefront/src/transport/graphql_adapter.rs`
+- `crates/rustok-blog/storefront/src/transport/native_server_adapter.rs`
+- `crates/rustok-blog/storefront/src/ui/leptos.rs`
 - `crates/rustok-blog/src/services/comment_projection.rs`
 - `crates/rustok-blog/tests/comment_projection_postgres_test.rs`
 - `crates/rustok-blog/tests/comment_projection_restart_postgres_test.rs`
@@ -464,6 +488,11 @@ new target without recording execution or claiming process-level restart proof.
     through a new database connection and newly constructed handler, upgraded
     projection evidence to schema v4 and Blog registry schema v13, and retained
     the target in focused/shared/aggregate gates without recording execution.
+47. Added typed storefront public-comments availability across GraphQL and native
+    SSR, degraded only external-service and timeout failures while propagating all
+    other Blog errors, rendered explicit Leptos unavailable/timeout states, and
+    extended fallback evidence plus focused negative fixtures without changing
+    Blog registry schema v13 or recording runtime execution.
 
 ## Next results
 
@@ -488,9 +517,10 @@ new target without recording execution or claiming process-level restart proof.
    Retain the written duplicate, delete-before-create, missing-post replay,
    outbox rollback/retry, and new-connection handler replay assertions; then cover
    concurrent optimistic exhaustion, host dispatch, process-level restart
-   recovery, remote adapter parity, degraded UI modes, approved-only reads,
-   moderation, pagination, first-thread identity, and unrelated insert storage
-   error propagation.
+   recovery, remote adapter parity, browser parity for typed unavailable/timeout
+   article rendering, cached thread snapshots, comment-form fallback,
+   approved-only reads, moderation, pagination, first-thread identity, and
+   unrelated insert storage error propagation.
 6. **Execute and retain Blog article richtext cutover evidence.** Run the offline
    backfill in default dry-run mode, review its report, apply accepted conversion,
    execute the irreversible migration, reindex/rollback Search, and retain

--- a/crates/rustok-blog/src/graphql/types.rs
+++ b/crates/rustok-blog/src/graphql/types.rs
@@ -3,14 +3,14 @@ use rustok_api::{
     AuthContext, Permission, RichTextDocument, RichTextView, TenantContext, graphql::GraphQLError,
     has_any_effective_permission,
 };
-use rustok_core::SecurityContext;
+use rustok_core::{SecurityContext, error::ErrorKind};
 use rustok_outbox::TransactionalEventBus;
 use rustok_profiles::graphql::GqlProfileSummary;
 use sea_orm::DatabaseConnection;
 use uuid::Uuid;
 
 use crate::{
-    BlogPostStatus, CommentListItem as DomainCommentListItem, CommentService,
+    BlogError, BlogPostStatus, CommentListItem as DomainCommentListItem, CommentService,
     CreatePostInput as DomainCreatePostInput, ListCommentsFilter,
     ModerateCommentStatus as DomainModerateCommentStatus, PostResponse, PostSummary,
     UpdatePostInput as DomainUpdatePostInput,
@@ -65,6 +65,17 @@ impl From<GqlModerateCommentStatus> for DomainModerateCommentStatus {
     }
 }
 
+#[derive(Enum, Copy, Clone, Eq, PartialEq)]
+#[graphql(
+    name = "BlogCommentsAvailability",
+    rename_items = "SCREAMING_SNAKE_CASE"
+)]
+pub enum GqlBlogCommentsAvailability {
+    Available,
+    Unavailable,
+    Timeout,
+}
+
 #[derive(SimpleObject)]
 #[graphql(complex)]
 pub struct GqlPost {
@@ -104,6 +115,7 @@ pub struct GqlPublicCommentListItem {
 
 #[derive(SimpleObject)]
 pub struct GqlPublicCommentList {
+    pub availability: GqlBlogCommentsAvailability,
     pub items: Vec<GqlPublicCommentListItem>,
     pub total: u64,
 }
@@ -142,22 +154,34 @@ impl GqlPost {
         let requested_locale = comment_locale(locale.as_deref(), &self.effective_locale);
         let fallback_locale = post_comment_fallback_locale(request_tenant, self);
 
-        let (items, total) = CommentService::new(db.clone(), event_bus.clone())
-            .list_for_post_with_locale_fallback(
-                self.tenant_id,
-                SecurityContext::public_read(),
-                self.id,
-                ListCommentsFilter {
-                    locale: Some(requested_locale),
-                    page: page.unwrap_or(1).max(1),
-                    per_page: per_page.unwrap_or(20).clamp(1, 100),
-                },
-                Some(fallback_locale),
-            )
-            .await
-            .map_err(|error| async_graphql::Error::new(error.to_string()))?;
+        let (items, total, availability) = match CommentService::new(
+            db.clone(),
+            event_bus.clone(),
+        )
+        .list_for_post_with_locale_fallback(
+            self.tenant_id,
+            SecurityContext::public_read(),
+            self.id,
+            ListCommentsFilter {
+                locale: Some(requested_locale),
+                page: page.unwrap_or(1).max(1),
+                per_page: per_page.unwrap_or(20).clamp(1, 100),
+            },
+            Some(fallback_locale),
+        )
+        .await
+        {
+            Ok((items, total)) => (items, total, GqlBlogCommentsAvailability::Available),
+            Err(error) => {
+                let Some(availability) = graphql_comments_read_availability(&error) else {
+                    return Err(async_graphql::Error::new(error.to_string()));
+                };
+                (Vec::new(), 0, availability)
+            }
+        };
 
         Ok(GqlPublicCommentList {
+            availability,
             items: items.into_iter().map(Into::into).collect(),
             total,
         })
@@ -198,6 +222,17 @@ impl GqlPost {
             items: items.into_iter().map(Into::into).collect(),
             total,
         })
+    }
+}
+
+fn graphql_comments_read_availability(error: &BlogError) -> Option<GqlBlogCommentsAvailability> {
+    let BlogError::Rich(error) = error else {
+        return None;
+    };
+    match error.kind {
+        ErrorKind::ExternalService => Some(GqlBlogCommentsAvailability::Unavailable),
+        ErrorKind::Timeout => Some(GqlBlogCommentsAvailability::Timeout),
+        _ => None,
     }
 }
 

--- a/crates/rustok-blog/storefront/src/model.rs
+++ b/crates/rustok-blog/storefront/src/model.rs
@@ -26,8 +26,19 @@ pub struct BlogPostListItem {
     pub published_at: Option<String>,
 }
 
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum BlogCommentsAvailability {
+    #[default]
+    Available,
+    Unavailable,
+    Timeout,
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BlogCommentList {
+    #[serde(default)]
+    pub availability: BlogCommentsAvailability,
     pub items: Vec<BlogCommentListItem>,
     pub total: u64,
 }

--- a/crates/rustok-blog/storefront/src/transport/graphql_adapter.rs
+++ b/crates/rustok-blog/storefront/src/transport/graphql_adapter.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{ApiError, configured_tenant_slug};
 
-const STOREFRONT_BLOG_QUERY: &str = "query StorefrontBlog($postSlug: String!, $filter: PostsFilter, $locale: String, $commentsPage: Int!, $commentsPerPage: Int!) { selectedPost: postBySlug(slug: $postSlug, locale: $locale) { id effectiveLocale title slug excerpt content { document html } contentPlainText status publishedAt tags featuredImageUrl publicComments(locale: $locale, page: $commentsPage, perPage: $commentsPerPage) { total items { id effectiveLocale authorId contentPreview parentCommentId createdAt } } } posts(filter: $filter) { total items { id title effectiveLocale slug excerpt status publishedAt } } }";
+const STOREFRONT_BLOG_QUERY: &str = "query StorefrontBlog($postSlug: String!, $filter: PostsFilter, $locale: String, $commentsPage: Int!, $commentsPerPage: Int!) { selectedPost: postBySlug(slug: $postSlug, locale: $locale) { id effectiveLocale title slug excerpt content { document html } contentPlainText status publishedAt tags featuredImageUrl publicComments(locale: $locale, page: $commentsPage, perPage: $commentsPerPage) { availability total items { id effectiveLocale authorId contentPreview parentCommentId createdAt } } } posts(filter: $filter) { total items { id title effectiveLocale slug excerpt status publishedAt } } }";
 
 #[derive(Debug, Deserialize)]
 struct StorefrontBlogResponse {

--- a/crates/rustok-blog/storefront/src/transport/native_server_adapter.rs
+++ b/crates/rustok-blog/storefront/src/transport/native_server_adapter.rs
@@ -4,7 +4,9 @@ use crate::core::BlogStorefrontFetchRequest;
 use crate::model::BlogPostListItem;
 use crate::model::StorefrontBlogData;
 #[cfg(feature = "ssr")]
-use crate::model::{BlogCommentList, BlogCommentListItem, BlogPostDetail, BlogPostList};
+use crate::model::{
+    BlogCommentList, BlogCommentListItem, BlogCommentsAvailability, BlogPostDetail, BlogPostList,
+};
 use leptos::prelude::*;
 
 use super::{ApiError, configured_tenant_slug};
@@ -139,23 +141,38 @@ async fn storefront_blog_native(
             });
 
         let selected_post = if let Some(post) = selected_post {
-            let (comments, total) = CommentService::new(runtime_ctx.db_clone(), event_bus.clone())
-                .list_for_post_with_locale_fallback(
-                    tenant_id,
-                    SecurityContext::public_read(),
-                    post.id,
-                    ListCommentsFilter {
-                        locale: Some(requested_locale.clone()),
-                        page: comments_page.max(1),
-                        per_page: COMMENTS_PAGE_SIZE,
-                    },
-                    Some(fallback_locale.as_str()),
-                )
-                .await
-                .map_err(ServerFnError::new)?;
-            let public_comments = BlogCommentList {
-                items: comments.into_iter().map(map_comment_list_item).collect(),
-                total,
+            let public_comments = match CommentService::new(
+                runtime_ctx.db_clone(),
+                event_bus.clone(),
+            )
+            .list_for_post_with_locale_fallback(
+                tenant_id,
+                SecurityContext::public_read(),
+                post.id,
+                ListCommentsFilter {
+                    locale: Some(requested_locale.clone()),
+                    page: comments_page.max(1),
+                    per_page: COMMENTS_PAGE_SIZE,
+                },
+                Some(fallback_locale.as_str()),
+            )
+            .await
+            {
+                Ok((comments, total)) => BlogCommentList {
+                    availability: BlogCommentsAvailability::Available,
+                    items: comments.into_iter().map(map_comment_list_item).collect(),
+                    total,
+                },
+                Err(error) => {
+                    let Some(availability) = comments_read_availability(&error) else {
+                        return Err(ServerFnError::new(error));
+                    };
+                    BlogCommentList {
+                        availability,
+                        items: Vec::new(),
+                        total: 0,
+                    }
+                }
             };
             Some(map_post_detail(post, public_comments))
         } else {
@@ -197,6 +214,22 @@ async fn storefront_blog_native(
         Err(ServerFnError::new(
             "blog/storefront-data requires the `ssr` feature",
         ))
+    }
+}
+
+#[cfg(feature = "ssr")]
+fn comments_read_availability(
+    error: &rustok_blog::BlogError,
+) -> Option<BlogCommentsAvailability> {
+    let rustok_blog::BlogError::Rich(error) = error else {
+        return None;
+    };
+    match error.kind {
+        rustok_core::error::ErrorKind::ExternalService => {
+            Some(BlogCommentsAvailability::Unavailable)
+        }
+        rustok_core::error::ErrorKind::Timeout => Some(BlogCommentsAvailability::Timeout),
+        _ => None,
     }
 }
 

--- a/crates/rustok-blog/storefront/src/ui/leptos.rs
+++ b/crates/rustok-blog/storefront/src/ui/leptos.rs
@@ -4,7 +4,8 @@ use rustok_ui_core::UiRouteContext;
 
 use crate::i18n::t;
 use crate::model::{
-    BlogCommentList, BlogCommentListItem, BlogPostDetail, BlogPostListItem, StorefrontBlogData,
+    BlogCommentList, BlogCommentListItem, BlogCommentsAvailability, BlogPostDetail,
+    BlogPostListItem, StorefrontBlogData,
 };
 use crate::{comments_pagination, core, transport};
 
@@ -242,6 +243,32 @@ fn PublicCommentsList(comments: BlogCommentList, comments_page: u64) -> impl Int
     let locale = use_context::<UiRouteContext>().unwrap_or_default().locale;
     let query_writer = use_route_query_writer();
     let title = t(locale.as_deref(), "blog.comments.title", "Comments");
+
+    if comments.availability != BlogCommentsAvailability::Available {
+        let message = match comments.availability {
+            BlogCommentsAvailability::Unavailable => t(
+                locale.as_deref(),
+                "blog.comments.unavailable",
+                "Comments are temporarily unavailable. The article is still available.",
+            ),
+            BlogCommentsAvailability::Timeout => t(
+                locale.as_deref(),
+                "blog.comments.timeout",
+                "Comments took too long to load. The article is still available.",
+            ),
+            BlogCommentsAvailability::Available => unreachable!(),
+        };
+        return view! {
+            <section class="mt-8 border-t border-border pt-6">
+                <h4 class="text-lg font-semibold text-foreground">{title}</h4>
+                <p class="mt-3 rounded-xl border border-border bg-muted/40 p-4 text-sm text-muted-foreground">
+                    {message}
+                </p>
+            </section>
+        }
+        .into_any();
+    }
+
     let total_label = core::count_label(
         comments.total,
         &t(locale.as_deref(), "blog.comments.total", "total"),

--- a/scripts/verify/verify-blog-comments-port-boundary.mjs
+++ b/scripts/verify/verify-blog-comments-port-boundary.mjs
@@ -111,7 +111,7 @@ if (evidence) {
 }
 
 if (fallbackEvidence) {
-  if (fallbackEvidence.schema_version !== 3) failures.push(`${fallbackEvidencePath}: schema_version drift`);
+  if (fallbackEvidence.schema_version !== 2) failures.push(`${fallbackEvidencePath}: schema_version drift`);
   if (
     fallbackEvidence.module !== 'blog' ||
     fallbackEvidence.role !== 'consumer' ||

--- a/scripts/verify/verify-blog-comments-port-boundary.mjs
+++ b/scripts/verify/verify-blog-comments-port-boundary.mjs
@@ -34,6 +34,10 @@ function requireMarker(source, marker, label) {
   if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
 }
 
+function requireNoMarker(source, marker, label) {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+}
+
 function sameSet(actual, expected) {
   return [...actual].sort().join('|') === [...expected].sort().join('|');
 }
@@ -41,6 +45,11 @@ function sameSet(actual, expected) {
 const evidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json';
 const fallbackEvidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json';
 const servicePath = 'crates/rustok-blog/src/services/comment.rs';
+const graphqlOwnerPath = 'crates/rustok-blog/src/graphql/types.rs';
+const storefrontModelPath = 'crates/rustok-blog/storefront/src/model.rs';
+const storefrontGraphqlPath = 'crates/rustok-blog/storefront/src/transport/graphql_adapter.rs';
+const storefrontNativePath = 'crates/rustok-blog/storefront/src/transport/native_server_adapter.rs';
+const storefrontUiPath = 'crates/rustok-blog/storefront/src/ui/leptos.rs';
 const providerRegistryPath = 'crates/rustok-comments/contracts/comments-fba-registry.json';
 const consumerRegistryPath = 'crates/rustok-blog/contracts/blog-fba-registry.json';
 const planPath = 'crates/rustok-blog/docs/implementation-plan.md';
@@ -59,6 +68,11 @@ const fallbackEvidence = json(fallbackEvidencePath);
 const providerRegistry = json(providerRegistryPath);
 const consumerRegistry = json(consumerRegistryPath);
 const service = read(servicePath);
+const graphqlOwner = read(graphqlOwnerPath);
+const storefrontModel = read(storefrontModelPath);
+const storefrontGraphql = read(storefrontGraphqlPath);
+const storefrontNative = read(storefrontNativePath);
+const storefrontUi = read(storefrontUiPath);
 const plan = read(planPath);
 
 if (evidence) {
@@ -97,7 +111,7 @@ if (evidence) {
 }
 
 if (fallbackEvidence) {
-  if (fallbackEvidence.schema_version !== 2) failures.push(`${fallbackEvidencePath}: schema_version drift`);
+  if (fallbackEvidence.schema_version !== 3) failures.push(`${fallbackEvidencePath}: schema_version drift`);
   if (
     fallbackEvidence.module !== 'blog' ||
     fallbackEvidence.role !== 'consumer' ||
@@ -110,11 +124,45 @@ if (fallbackEvidence) {
   if (fallbackEvidence.runner !== 'scripts/verify/verify-blog-comments-port-boundary.mjs') {
     failures.push(`${fallbackEvidencePath}: runner drift`);
   }
+  const expectedSources = {
+    consumer_service: servicePath,
+    consumer_error_mapping: servicePath,
+    provider_port_registry: providerRegistryPath,
+    graphql_owner: graphqlOwnerPath,
+    storefront_model: storefrontModelPath,
+    storefront_graphql: storefrontGraphqlPath,
+    storefront_native: storefrontNativePath,
+    storefront_ui: storefrontUiPath,
+  };
+  for (const [key, expected] of Object.entries(expectedSources)) {
+    if (fallbackEvidence.source_contract?.[key] !== expected) {
+      failures.push(`${fallbackEvidencePath}: ${key} source path drift`);
+    }
+  }
+  const readDegradation = fallbackEvidence.storefront_read_degradation ?? {};
   if (
-    fallbackEvidence.source_contract?.consumer_service !== servicePath ||
-    fallbackEvidence.source_contract?.consumer_error_mapping !== servicePath ||
-    fallbackEvidence.source_contract?.provider_port_registry !== providerRegistryPath
-  ) failures.push(`${fallbackEvidencePath}: active source path drift`);
+    readDegradation.status !== 'source_verified_no_compile' ||
+    readDegradation.runtime_status !== 'not_run' ||
+    readDegradation.operation !== 'list_public_comments_for_target' ||
+    readDegradation.propagated_error_policy !== 'all_other_blog_errors' ||
+    readDegradation.cached_thread_snapshot !== 'planned' ||
+    readDegradation.comment_form_fallback !== 'planned' ||
+    readDegradation.runtime_evidence !== 'pending'
+  ) failures.push(`${fallbackEvidencePath}: storefront read degradation status drift`);
+  if (!sameSet(readDegradation.transports ?? [], ['graphql', 'native_ssr'])) {
+    failures.push(`${fallbackEvidencePath}: storefront transport parity drift`);
+  }
+  if (!sameSet(readDegradation.availability_states ?? [], ['AVAILABLE', 'UNAVAILABLE', 'TIMEOUT'])) {
+    failures.push(`${fallbackEvidencePath}: availability state drift`);
+  }
+  if (!sameSet(readDegradation.degraded_error_kinds ?? [], ['ExternalService', 'Timeout'])) {
+    failures.push(`${fallbackEvidencePath}: degraded error-kind drift`);
+  }
+  if (
+    !Array.isArray(readDegradation.degraded_payload?.items) ||
+    readDegradation.degraded_payload.items.length !== 0 ||
+    readDegradation.degraded_payload?.total !== 0
+  ) failures.push(`${fallbackEvidencePath}: degraded payload drift`);
   if (
     fallbackEvidence.fallback_smoke?.status !== 'planned' ||
     fallbackEvidence.fallback_smoke?.runtime_evidence !== 'pending'
@@ -162,6 +210,55 @@ for (const marker of [
   'Self::ensure_blog_target(&existing)?',
 ]) requireMarker(service, marker, servicePath);
 
+for (const marker of [
+  'pub enum BlogCommentsAvailability',
+  '#[serde(rename_all = "SCREAMING_SNAKE_CASE")]',
+  'Available,',
+  'Unavailable,',
+  'Timeout,',
+  'pub availability: BlogCommentsAvailability',
+]) requireMarker(storefrontModel, marker, storefrontModelPath);
+
+for (const marker of [
+  'fn comments_read_availability(',
+  'rustok_core::error::ErrorKind::ExternalService',
+  'Some(BlogCommentsAvailability::Unavailable)',
+  'rustok_core::error::ErrorKind::Timeout',
+  'Some(BlogCommentsAvailability::Timeout)',
+  'let Some(availability) = comments_read_availability(&error) else',
+  'return Err(ServerFnError::new(error));',
+  'availability: BlogCommentsAvailability::Available',
+  'items: Vec::new()',
+  'total: 0',
+]) requireMarker(storefrontNative, marker, storefrontNativePath);
+requireNoMarker(storefrontNative, 'Err(_) => BlogCommentList', storefrontNativePath);
+
+for (const marker of [
+  'pub enum GqlBlogCommentsAvailability',
+  'pub availability: GqlBlogCommentsAvailability',
+  'fn graphql_comments_read_availability(error: &BlogError)',
+  'ErrorKind::ExternalService => Some(GqlBlogCommentsAvailability::Unavailable)',
+  'ErrorKind::Timeout => Some(GqlBlogCommentsAvailability::Timeout)',
+  'let Some(availability) = graphql_comments_read_availability(&error) else',
+  'return Err(async_graphql::Error::new(error.to_string()));',
+  'GqlBlogCommentsAvailability::Available',
+]) requireMarker(graphqlOwner, marker, graphqlOwnerPath);
+requireNoMarker(graphqlOwner, 'Err(_) => (Vec::new(), 0', graphqlOwnerPath);
+
+requireMarker(
+  storefrontGraphql,
+  'publicComments(locale: $locale, page: $commentsPage, perPage: $commentsPerPage) { availability total items',
+  storefrontGraphqlPath,
+);
+
+for (const marker of [
+  'comments.availability != BlogCommentsAvailability::Available',
+  'BlogCommentsAvailability::Unavailable',
+  'BlogCommentsAvailability::Timeout',
+  'Comments are temporarily unavailable. The article is still available.',
+  'Comments took too long to load. The article is still available.',
+]) requireMarker(storefrontUi, marker, storefrontUiPath);
+
 const directBypasses = [...service.matchAll(/\.comments\s*\.\s*([a-z_]+)\s*\(/g)].map((match) => match[1]);
 if (directBypasses.length > 0) {
   failures.push(`${servicePath}: direct CommentsService bypass ${directBypasses.sort().join('|')}`);
@@ -182,7 +279,8 @@ for (const marker of [
   'verify:blog:comments-port-boundary',
   'test:verify:blog:comments-port-boundary',
   'source_verified_no_compile',
-  'degraded UI modes remain planned',
+  'typed storefront comments availability',
+  'cached snapshot and comment-form fallback remain planned',
 ]) requireMarker(plan, marker, planPath);
 
 if (failures.length > 0) {
@@ -191,4 +289,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log('Blog Comments consumer port source boundary is consistent');
+console.log('Blog Comments consumer port and storefront read-degradation source boundary is consistent');

--- a/scripts/verify/verify-blog-comments-port-boundary.test.mjs
+++ b/scripts/verify/verify-blog-comments-port-boundary.test.mjs
@@ -29,6 +29,10 @@ function fixture({
   missingDeadline = false,
   missingIdempotency = false,
   missingPublicRead = false,
+  missingAvailabilityField = false,
+  broadNativeFallback = false,
+  missingGraphqlAvailability = false,
+  missingUiState = false,
   statusDrift = false,
   fallbackPromoted = false,
 } = {}) {
@@ -36,6 +40,11 @@ function fixture({
   const evidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json';
   const fallbackEvidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json';
   const servicePath = 'crates/rustok-blog/src/services/comment.rs';
+  const graphqlOwnerPath = 'crates/rustok-blog/src/graphql/types.rs';
+  const storefrontModelPath = 'crates/rustok-blog/storefront/src/model.rs';
+  const storefrontGraphqlPath = 'crates/rustok-blog/storefront/src/transport/graphql_adapter.rs';
+  const storefrontNativePath = 'crates/rustok-blog/storefront/src/transport/native_server_adapter.rs';
+  const storefrontUiPath = 'crates/rustok-blog/storefront/src/ui/leptos.rs';
   const providerRegistryPath = 'crates/rustok-comments/contracts/comments-fba-registry.json';
   const consumerRegistryPath = 'crates/rustok-blog/contracts/blog-fba-registry.json';
 
@@ -75,6 +84,69 @@ DomainCreateCommentInput
 TARGET_TYPE_BLOG_POST
 post_id
 ${directBypass ? '.comments.get_comment(' : ''}
+`,
+  );
+
+  write(
+    root,
+    storefrontModelPath,
+    `
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum BlogCommentsAvailability {
+Available,
+Unavailable,
+Timeout,
+}
+${missingAvailabilityField ? '' : 'pub availability: BlogCommentsAvailability'}
+`,
+  );
+  write(
+    root,
+    storefrontNativePath,
+    `
+fn comments_read_availability(
+rustok_core::error::ErrorKind::ExternalService
+Some(BlogCommentsAvailability::Unavailable)
+rustok_core::error::ErrorKind::Timeout
+Some(BlogCommentsAvailability::Timeout)
+let Some(availability) = comments_read_availability(&error) else
+return Err(ServerFnError::new(error));
+availability: BlogCommentsAvailability::Available
+items: Vec::new()
+total: 0
+${broadNativeFallback ? 'Err(_) => BlogCommentList' : ''}
+`,
+  );
+  write(
+    root,
+    graphqlOwnerPath,
+    `
+pub enum GqlBlogCommentsAvailability
+pub availability: GqlBlogCommentsAvailability
+fn graphql_comments_read_availability(error: &BlogError)
+ErrorKind::ExternalService => Some(GqlBlogCommentsAvailability::Unavailable)
+ErrorKind::Timeout => Some(GqlBlogCommentsAvailability::Timeout)
+${missingGraphqlAvailability ? '' : 'let Some(availability) = graphql_comments_read_availability(&error) else'}
+return Err(async_graphql::Error::new(error.to_string()));
+GqlBlogCommentsAvailability::Available
+`,
+  );
+  write(
+    root,
+    storefrontGraphqlPath,
+    'publicComments(locale: $locale, page: $commentsPage, perPage: $commentsPerPage) { availability total items',
+  );
+  write(
+    root,
+    storefrontUiPath,
+    missingUiState
+      ? ''
+      : `
+comments.availability != BlogCommentsAvailability::Available
+BlogCommentsAvailability::Unavailable
+BlogCommentsAvailability::Timeout
+Comments are temporarily unavailable. The article is still available.
+Comments took too long to load. The article is still available.
 `,
   );
 
@@ -118,7 +190,7 @@ ${directBypass ? '.comments.get_comment(' : ''}
     root,
     fallbackEvidencePath,
     JSON.stringify({
-      schema_version: 2,
+      schema_version: 3,
       module: 'blog',
       role: 'consumer',
       provider: 'comments',
@@ -131,6 +203,24 @@ ${directBypass ? '.comments.get_comment(' : ''}
         consumer_service: servicePath,
         consumer_error_mapping: servicePath,
         provider_port_registry: providerRegistryPath,
+        graphql_owner: graphqlOwnerPath,
+        storefront_model: storefrontModelPath,
+        storefront_graphql: storefrontGraphqlPath,
+        storefront_native: storefrontNativePath,
+        storefront_ui: storefrontUiPath,
+      },
+      storefront_read_degradation: {
+        status: 'source_verified_no_compile',
+        runtime_status: 'not_run',
+        operation: 'list_public_comments_for_target',
+        transports: ['graphql', 'native_ssr'],
+        availability_states: ['AVAILABLE', 'UNAVAILABLE', 'TIMEOUT'],
+        degraded_error_kinds: ['ExternalService', 'Timeout'],
+        propagated_error_policy: 'all_other_blog_errors',
+        degraded_payload: { items: [], total: 0 },
+        cached_thread_snapshot: 'planned',
+        comment_form_fallback: 'planned',
+        runtime_evidence: 'pending',
       },
       fallback_smoke: {
         status: 'planned',
@@ -155,13 +245,7 @@ ${directBypass ? '.comments.get_comment(' : ''}
     }),
   );
 
-  write(
-    root,
-    providerRegistryPath,
-    JSON.stringify({
-      ports: [{ name: 'CommentsThreadPort', operations }],
-    }),
-  );
+  write(root, providerRegistryPath, JSON.stringify({ ports: [{ name: 'CommentsThreadPort', operations }] }));
   write(
     root,
     consumerRegistryPath,
@@ -171,16 +255,14 @@ ${directBypass ? '.comments.get_comment(' : ''}
         status: 'source_verified_no_compile',
         runtime_status: 'pending',
         cases: operations.map((operation) => ({ operation })),
-        fallback_smoke: {
-          status: fallbackPromoted ? 'source_verified_no_compile' : 'planned',
-        },
+        fallback_smoke: { status: fallbackPromoted ? 'source_verified_no_compile' : 'planned' },
       },
     }),
   );
   write(
     root,
     'crates/rustok-blog/docs/implementation-plan.md',
-    'blog-comments-consumer-static-matrix.json blog-comments-runtime-fallback-smoke.json verify:blog:comments-port-boundary test:verify:blog:comments-port-boundary source_verified_no_compile degraded UI modes remain planned',
+    'blog-comments-consumer-static-matrix.json blog-comments-runtime-fallback-smoke.json verify:blog:comments-port-boundary test:verify:blog:comments-port-boundary source_verified_no_compile typed storefront comments availability cached snapshot and comment-form fallback remain planned',
   );
 
   return root;
@@ -229,13 +311,31 @@ test('rejects removal of the approved public-read port operation', () => {
   assert.notEqual(rejects({ missingPublicRead: true }).status, 0);
 });
 
+test('rejects a storefront model without typed availability', () => {
+  assert.notEqual(rejects({ missingAvailabilityField: true }).status, 0);
+});
+
+test('rejects broad native fallback for every error', () => {
+  const result = rejects({ broadNativeFallback: true });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /forbidden Err\(_\) => BlogCommentList/);
+});
+
+test('rejects GraphQL degradation without typed classification', () => {
+  assert.notEqual(rejects({ missingGraphqlAvailability: true }).status, 0);
+});
+
+test('rejects removal of the storefront unavailable and timeout state', () => {
+  assert.notEqual(rejects({ missingUiState: true }).status, 0);
+});
+
 test('rejects runtime status promotion without execution', () => {
   const result = rejects({ statusDrift: true });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /status drift/);
 });
 
-test('rejects source promotion of planned degraded UI modes', () => {
+test('rejects source promotion of planned cached snapshot and form fallback', () => {
   const result = rejects({ fallbackPromoted: true });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /contract-test status drift/);

--- a/scripts/verify/verify-blog-comments-port-boundary.test.mjs
+++ b/scripts/verify/verify-blog-comments-port-boundary.test.mjs
@@ -190,7 +190,7 @@ Comments took too long to load. The article is still available.
     root,
     fallbackEvidencePath,
     JSON.stringify({
-      schema_version: 3,
+      schema_version: 2,
       module: 'blog',
       role: 'consumer',
       provider: 'comments',


### PR DESCRIPTION
## Summary

- add typed `AVAILABLE`, `UNAVAILABLE`, and `TIMEOUT` availability to storefront public comments
- preserve selected-article rendering when the Comments provider returns typed external-service or timeout errors
- keep all other Blog errors fail-closed in native SSR and GraphQL
- request availability through the storefront GraphQL adapter and render explicit Leptos unavailable/timeout states
- extend the existing Blog Comments fallback evidence and focused guard without changing Blog registry schema v13 or package command order
- keep cached thread snapshots, comment-form fallback, remote adapter parity, and runtime/browser evidence pending

## Why

Public Comments unavailability or timeout previously failed the complete selected-article request in both native SSR and GraphQL. The source boundary now degrades only the two provider-availability error kinds while keeping article content available and preserving fail-closed behavior for validation, authorization, not-found, database, invariant, and other failures.

## Validation

Not run by request. No verifier, unit test, Rust test, compile, PostgreSQL, browser, workflow, or CI command was executed.

Suggested maintainer commands:

```bash
npm run verify:blog:comments-port-boundary
npm run test:verify:blog:comments-port-boundary
npm run verify:blog:storefront-boundary
npm run test:verify:blog:storefront-boundary
npm run verify:blog:fba
npm run test:verify:blog:fba
cargo check -p rustok-server --features mod-blog
cargo check -p rustok-blog-storefront --features ssr
cargo check -p rustok-blog-storefront --target wasm32-unknown-unknown --features hydrate
```
