### PR TITLE
test(blog): retain projection host registration harness

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json
@@ -31,6 +31,17 @@
       "non_negative_saturating_counter_transition"
     ]
   },
+  "host_registration_harness": {
+    "status": "executable_no_run",
+    "runtime_status": "not_run",
+    "path": "crates/rustok-blog/src/lib.rs",
+    "module": "tests",
+    "command": "cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing",
+    "scope": "module_registry_handler_identity_and_routing_only",
+    "cases": [
+      "module_registers_comment_projection_handler_with_host_routing"
+    ]
+  },
   "postgres_harness": {
     "status": "executable_no_run",
     "runtime_status": "not_run",
@@ -90,6 +101,10 @@
       "expected": "the pure counter transition floors deletes at zero and saturates count and version overflow"
     },
     {
+      "name": "host_registration_routing_harness",
+      "expected": "the retained module test invokes BlogModule::register_event_listeners, extracts one blog_comment_projection handler, accepts Blog comment created/deleted events, and rejects a non-Blog target"
+    },
+    {
       "name": "postgres_duplicate_delivery",
       "expected": "the retained PostgreSQL target replays one envelope id and expects one counter transition, one delivery row, and one outbox row"
     },
@@ -116,6 +131,7 @@
   ],
   "runtime_promotion_requirements": [
     "execute cargo test -p rustok-blog --lib services::comment_projection::tests",
+    "execute cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing",
     "execute the env-gated PostgreSQL comment_projection_postgres_test target and retain its output",
     "execute the env-gated PostgreSQL comment_projection_restart_postgres_test target and retain its output",
     "retain proof that duplicate and out-of-order comment.created/comment.deleted deliveries match the source harness assertions",
@@ -123,6 +139,6 @@
     "retain missing-post retry and later recovery evidence",
     "retain restarted-handler replay evidence across a new database connection",
     "retain concurrent optimistic-update exhaustion and retry evidence",
-    "retain host event-dispatch registration and process restart recovery evidence"
+    "retain actual host EventDispatcher delivery and process restart recovery evidence"
   ]
 }

--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -112,6 +112,16 @@ source harness is the `services::comment_projection::tests` module in
 `executable_no_run` and suggested command
 `cargo test -p rustok-blog --lib services::comment_projection::tests`.
 
+The retained host registration target is the `tests` module in
+`crates/rustok-blog/src/lib.rs`. It creates the real module listener context,
+invokes `BlogModule::register_event_listeners`, extracts the single registered
+handler, verifies the `blog_comment_projection` identity, accepts Blog
+`comment.created` / `comment.deleted`, and rejects a non-Blog target. Its suggested
+command is
+`cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing`.
+The target is `executable_no_run` and intentionally does not call `handle()`;
+actual host EventDispatcher delivery and database effects remain pending.
+
 The retained PostgreSQL target is
 `crates/rustok-blog/tests/comment_projection_postgres_test.rs`. It uses
 `RUSTOK_BLOG_TEST_DATABASE_URL` (or PostgreSQL `DATABASE_URL`), a unique schema,
@@ -135,8 +145,8 @@ re-instantiation, not retained proof of a process or host restart.
 Exact commands `verify:blog:comments-event-projection` and
 `test:verify:blog:comments-event-projection` run after the Comments port gate in
 the Blog FBA chains. Overall status remains `source_verified_no_compile`;
-concurrent optimistic exhaustion, host dispatch, process-level restart recovery,
-and all execution evidence remain pending.
+concurrent optimistic exhaustion, actual host EventDispatcher delivery,
+process-level restart recovery, and all execution evidence remain pending.
 
 Blog categories use the exclusive `blog_categories:*` permission resource.
 `CategoryService::new(db, event_bus)` is the only owner constructor. Category
@@ -283,17 +293,26 @@ Leptos states while preserving the article, and extends the registered fallback
 evidence plus focused fail-closed fixture. Blog registry schema v13 and package
 order remain unchanged; no runtime or browser result is recorded.
 
+The continuation audit at `df2e19a31098e1747441d513726fc9f21c82059e`
+found that module listener registration was retained only as a production source
+marker: no executable harness passed through `BlogModule::register_event_listeners`
+and inspected the registered handler identity or routing behavior. Slice 48 adds
+that module-level Rust target, extends projection evidence schema v4 and its
+focused negative fixture, and preserves Blog registry schema v13 plus package
+order. The target is source-only and does not claim actual host dispatcher, DB,
+or process-level execution.
+
 ## FFA/FBA status
 
 - FFA status: `in_progress`.
 - FBA status: `boundary_ready` (`core_transport_ui`).
 - Blog FBA source-gate chain: `source_verified_no_compile`; registry schema v13
   locks exact verify/test order, source-gate paths, leaf npm commands, evidence,
-  self-tests, the Comments projection unit, PostgreSQL, and restart harnesses,
-  and aggregate/consumer bindings for admin, storefront, Comments port boundary,
-  Comments event projection, category Search reindex, GraphQL rate limiting,
-  GraphQL richtext, AI richtext, offline backfill, Forum ownership, and runtime
-  order.
+  self-tests, the Comments projection classifier, host registration, PostgreSQL,
+  and restart harnesses, and aggregate/consumer bindings for admin, storefront,
+  Comments port boundary, Comments event projection, category Search reindex,
+  GraphQL rate limiting, GraphQL richtext, AI richtext, offline backfill, Forum
+  ownership, and runtime order.
 - Comments consumer port boundary: Blog-owned `source_verified_no_compile` for
   the in-process profile; all seven operations, approved public read, typed
   richtext projection, two-second deadlines, write idempotency, active typed
@@ -304,14 +323,15 @@ order remain unchanged; no runtime or browser result is recorded.
   comment-form fallback, browser/runtime evidence, and broader degraded UI modes
   remain planned or pending.
 - Comments event projection: Blog-owned `source_verified_no_compile`; evidence
-  schema v4, shared classifier/counter helpers, `executable_no_run` Rust unit,
-  PostgreSQL transaction, and restart harnesses, verifier, focused self-test,
-  exact npm leaf commands, delivery-ledger identity, transactional outbox markers,
-  and Blog FBA ordering are locked. The PostgreSQL targets write duplicate,
-  out-of-order, missing-post replay, outbox rollback/retry, and new-connection
-  handler replay cases but have not been run. Concurrent optimistic exhaustion,
-  host dispatch, process-level restart recovery, and all execution evidence remain
-  pending.
+  schema v4, shared classifier/counter helpers, `executable_no_run` classifier and
+  module-registration Rust targets, PostgreSQL transaction and restart harnesses,
+  verifier, focused self-test, exact npm leaf commands, delivery-ledger identity,
+  transactional outbox markers, and Blog FBA ordering are locked. The host target
+  verifies module registry identity and routing only. The PostgreSQL targets write
+  duplicate, out-of-order, missing-post replay, outbox rollback/retry, and
+  new-connection handler replay cases but have not been run. Concurrent optimistic
+  exhaustion, actual host EventDispatcher delivery, process-level restart recovery,
+  and all execution evidence remain pending.
 - Load protection: `implementation_ready`; mounted Redis evidence is pending.
 - Rate-limit harness: `executable_no_compile`; evidence, verifier, self-test,
   npm leaf commands, and aggregate FBA registration are locked; execution is
@@ -344,6 +364,7 @@ order remain unchanged; no runtime or browser result is recorded.
 - `crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-consumer-runtime-order-smoke.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json`
+- `crates/rustok-blog/src/lib.rs`
 - `crates/rustok-blog/src/graphql/types.rs`
 - `crates/rustok-blog/storefront/src/model.rs`
 - `crates/rustok-blog/storefront/src/transport/graphql_adapter.rs`
@@ -492,6 +513,11 @@ order remain unchanged; no runtime or browser result is recorded.
     other Blog errors, rendered explicit Leptos unavailable/timeout states, and
     extended fallback evidence plus focused negative fixtures without changing
     Blog registry schema v13 or recording runtime execution.
+48. Added an executable-no-run module registration and routing harness through
+    `BlogModule::register_event_listeners`, retained handler identity and Blog-only
+    lifecycle routing in projection evidence schema v4 and focused negative
+    fixtures, and kept registry schema v13, package order, dispatcher execution,
+    database delivery, and process-level recovery unchanged or pending.
 
 ## Next results
 
@@ -509,17 +535,17 @@ order remain unchanged; no runtime or browser result is recorded.
    controller handoff, focused verifier, then Redis-backed host requests with a
    real HTTP `Retry-After` matching GraphQL `retryAfter`.
 5. **Close comments runtime evidence.** Run the Comments port boundary fixture,
-   shared consumer runtime-order verifier, Blog projection unit harness, the
-   `comment_projection_postgres_test` and
-   `comment_projection_restart_postgres_test` targets, both thread invariant
+   shared consumer runtime-order verifier, Blog projection classifier harness,
+   module registration/routing harness, the `comment_projection_postgres_test`
+   and `comment_projection_restart_postgres_test` targets, both thread invariant
    concurrency targets, and concurrent PostgreSQL create/delete transactions.
-   Retain the written duplicate, delete-before-create, missing-post replay,
-   outbox rollback/retry, and new-connection handler replay assertions; then cover
-   concurrent optimistic exhaustion, host dispatch, process-level restart
-   recovery, remote adapter parity, browser parity for typed unavailable/timeout
-   article rendering, cached thread snapshots, comment-form fallback,
-   approved-only reads, moderation, pagination, first-thread identity, and
-   unrelated insert storage error propagation.
+   Retain actual host EventDispatcher delivery, the written duplicate,
+   delete-before-create, missing-post replay, outbox rollback/retry, and
+   new-connection handler replay assertions; then cover concurrent optimistic
+   exhaustion, process-level restart recovery, remote adapter parity, browser
+   parity for typed unavailable/timeout article rendering, cached thread snapshots,
+   comment-form fallback, approved-only reads, moderation, pagination,
+   first-thread identity, and unrelated insert storage error propagation.
 6. **Execute and retain Blog article richtext cutover evidence.** Run the offline
    backfill in default dry-run mode, review its report, apply accepted conversion,
    execute the irreversible migration, reindex/rollback Search, and retain
@@ -536,6 +562,7 @@ should run the relevant subset, including:
 - `npm run verify:blog:comments-event-projection`
 - `npm run test:verify:blog:comments-event-projection`
 - `cargo test -p rustok-blog --lib services::comment_projection::tests`
+- `cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test`
 - `npm run verify:blog:category-search-reindex`

--- a/crates/rustok-blog/src/lib.rs
+++ b/crates/rustok-blog/src/lib.rs
@@ -157,6 +157,9 @@ impl MigrationSource for BlogModule {
 mod tests {
     use super::*;
     use rustok_api::{Action, Resource};
+    use rustok_events::DomainEvent;
+    use rustok_test_utils::setup_test_db;
+    use uuid::Uuid;
 
     #[test]
     fn module_metadata() {
@@ -209,6 +212,49 @@ mod tests {
     fn module_has_owned_migrations() {
         let module = BlogModule;
         assert!(!module.migrations().is_empty());
+    }
+
+    #[tokio::test]
+    async fn module_registers_comment_projection_handler_with_host_routing() {
+        let db = setup_test_db().await;
+        let extensions = ModuleRuntimeExtensions::default();
+        let context = ModuleEventListenerContext {
+            db,
+            extensions: &extensions,
+        };
+        let mut registry = ModuleEventListenerRegistry::new();
+
+        BlogModule.register_event_listeners(&mut registry, &context);
+
+        let handlers = registry.into_handlers();
+        assert_eq!(handlers.len(), 1);
+        let handler = handlers
+            .first()
+            .expect("Blog must register its Comments projection handler");
+        assert_eq!(handler.name(), "blog_comment_projection");
+
+        let blog_created = DomainEvent::CommentCreated {
+            comment_id: Uuid::from_u128(1),
+            target_type: "blog_post".to_string(),
+            target_id: Uuid::from_u128(2),
+            author_id: Uuid::from_u128(3),
+        };
+        let blog_deleted = DomainEvent::CommentDeleted {
+            comment_id: Uuid::from_u128(4),
+            target_type: "blog_post".to_string(),
+            target_id: Uuid::from_u128(5),
+            author_id: Uuid::from_u128(6),
+        };
+        let forum_created = DomainEvent::CommentCreated {
+            comment_id: Uuid::from_u128(7),
+            target_type: "forum_topic".to_string(),
+            target_id: Uuid::from_u128(8),
+            author_id: Uuid::from_u128(9),
+        };
+
+        assert!(handler.handles(&blog_created));
+        assert!(handler.handles(&blog_deleted));
+        assert!(!handler.handles(&forum_created));
     }
 }
 

--- a/scripts/verify/verify-blog-comments-event-projection.mjs
+++ b/scripts/verify/verify-blog-comments-event-projection.mjs
@@ -41,6 +41,7 @@ const modulePath = 'crates/rustok-blog/src/lib.rs';
 const registryPath = 'crates/rustok-blog/contracts/blog-fba-registry.json';
 const planPath = 'crates/rustok-blog/docs/implementation-plan.md';
 const harnessCommand = 'cargo test -p rustok-blog --lib services::comment_projection::tests';
+const hostRegistrationHarnessCommand = 'cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing';
 const postgresHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test';
 const restartHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test';
 const postgresHarnessEnvironment = 'RUSTOK_BLOG_TEST_DATABASE_URL';
@@ -199,9 +200,20 @@ requireMarker(serviceExport, 'pub use comment_projection::BlogCommentProjectionH
 for (const marker of [
   'fn register_event_listeners(',
   'registry.register(services::BlogCommentProjectionHandler::new(ctx.db.clone()));',
+  '#[tokio::test]',
+  'async fn module_registers_comment_projection_handler_with_host_routing()',
+  'let mut registry = ModuleEventListenerRegistry::new();',
+  'BlogModule.register_event_listeners(&mut registry, &context);',
+  'let handlers = registry.into_handlers();',
+  'assert_eq!(handlers.len(), 1);',
+  'assert_eq!(handler.name(), "blog_comment_projection");',
+  'assert!(handler.handles(&blog_created));',
+  'assert!(handler.handles(&blog_deleted));',
+  'assert!(!handler.handles(&forum_created));',
 ]) {
   requireMarker(moduleSource, marker, modulePath);
 }
+requireNoMarker(moduleSource, 'handler.handle(&', `${modulePath}: host registration harness`);
 
 if (evidence) {
   if (evidence.schema_version !== 4) failures.push(`${evidencePath}: schema_version drift`);
@@ -246,6 +258,23 @@ if (evidence) {
     ].sort().join('|')
   ) {
     failures.push(`${evidencePath}: source harness case drift`);
+  }
+  const hostRegistration = evidence.host_registration_harness ?? {};
+  if (
+    hostRegistration.status !== 'executable_no_run' ||
+    hostRegistration.runtime_status !== 'not_run' ||
+    hostRegistration.path !== modulePath ||
+    hostRegistration.module !== 'tests' ||
+    hostRegistration.command !== hostRegistrationHarnessCommand ||
+    hostRegistration.scope !== 'module_registry_handler_identity_and_routing_only'
+  ) {
+    failures.push(`${evidencePath}: host registration harness drift`);
+  }
+  if (
+    [...(hostRegistration.cases ?? [])].join('|') !==
+    'module_registers_comment_projection_handler_with_host_routing'
+  ) {
+    failures.push(`${evidencePath}: host registration harness case drift`);
   }
   const postgres = evidence.postgres_harness ?? {};
   if (
@@ -300,6 +329,7 @@ if (evidence) {
     'tenant_scoped_optimistic_update',
     'missing_post_retry',
     'non_negative_count',
+    'host_registration_routing_harness',
     'postgres_duplicate_delivery',
     'postgres_out_of_order_delete_create',
     'postgres_missing_post_recovery',
@@ -369,9 +399,11 @@ for (const marker of [
   'test:verify:blog:comments-event-projection',
   'source_verified_no_compile',
   'services::comment_projection::tests',
+  'tests::module_registers_comment_projection_handler_with_host_routing',
   'comment_projection_postgres_test',
   'comment_projection_restart_postgres_test',
   'RUSTOK_BLOG_TEST_DATABASE_URL',
+  'actual host EventDispatcher delivery',
   'process-level restart recovery',
 ]) {
   requireMarker(plan, marker, planPath);
@@ -383,4 +415,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log('Blog comments event projection source contract, unit harness, PostgreSQL target, and restart target are consistent');
+console.log('Blog comments event projection source contract, classifier, host registration, PostgreSQL, and restart harnesses are consistent');

--- a/scripts/verify/verify-blog-comments-event-projection.test.mjs
+++ b/scripts/verify/verify-blog-comments-event-projection.test.mjs
@@ -20,6 +20,7 @@ function fixture({
   missingDeliveryLookup = false,
   missingOutbox = false,
   missingRegistration = false,
+  missingHostHarness = false,
   missingSharedClassifier = false,
   directHandlesClassifier = false,
   missingCounterHarness = false,
@@ -31,6 +32,7 @@ function fixture({
   missingRestartRegistration = false,
   statusDrift = false,
   harnessStatusDrift = false,
+  hostHarnessStatusDrift = false,
   postgresStatusDrift = false,
   restartStatusDrift = false,
 } = {}) {
@@ -46,6 +48,7 @@ function fixture({
   const modulePath = 'crates/rustok-blog/src/lib.rs';
   const registryPath = 'crates/rustok-blog/contracts/blog-fba-registry.json';
   const harnessCommand = 'cargo test -p rustok-blog --lib services::comment_projection::tests';
+  const hostRegistrationHarnessCommand = 'cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing';
   const postgresHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test';
   const restartHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test';
 
@@ -178,14 +181,26 @@ mod m20260716_000001_create_blog_comment_projection_deliveries;
 Box::new(m20260716_000001_create_blog_comment_projection_deliveries::Migration)
 `,
   );
-  write(
-    root,
-    modulePath,
-    missingRegistration
-      ? ''
-      : `fn register_event_listeners(
-registry.register(services::BlogCommentProjectionHandler::new(ctx.db.clone()));`,
-  );
+  const registrationSource = missingRegistration
+    ? ''
+    : `fn register_event_listeners(
+registry.register(services::BlogCommentProjectionHandler::new(ctx.db.clone()));`;
+  const hostHarnessSource = missingHostHarness
+    ? ''
+    : `
+#[tokio::test]
+async fn module_registers_comment_projection_handler_with_host_routing() {
+let mut registry = ModuleEventListenerRegistry::new();
+BlogModule.register_event_listeners(&mut registry, &context);
+let handlers = registry.into_handlers();
+assert_eq!(handlers.len(), 1);
+assert_eq!(handler.name(), "blog_comment_projection");
+assert!(handler.handles(&blog_created));
+assert!(handler.handles(&blog_deleted));
+assert!(!handler.handles(&forum_created));
+}`;
+  write(root, modulePath, `${registrationSource}\n${hostHarnessSource}`);
+
   write(
     root,
     evidencePath,
@@ -219,6 +234,15 @@ registry.register(services::BlogCommentProjectionHandler::new(ctx.db.clone()));`
           'non_negative_saturating_counter_transition',
         ],
       },
+      host_registration_harness: {
+        status: hostHarnessStatusDrift ? 'executed' : 'executable_no_run',
+        runtime_status: hostHarnessStatusDrift ? 'passed' : 'not_run',
+        path: modulePath,
+        module: 'tests',
+        command: hostRegistrationHarnessCommand,
+        scope: 'module_registry_handler_identity_and_routing_only',
+        cases: ['module_registers_comment_projection_handler_with_host_routing'],
+      },
       postgres_harness: {
         status: postgresStatusDrift ? 'executed' : 'executable_no_run',
         runtime_status: postgresStatusDrift ? 'passed' : 'not_run',
@@ -240,9 +264,7 @@ registry.register(services::BlogCommentProjectionHandler::new(ctx.db.clone()));`
         environment: 'RUSTOK_BLOG_TEST_DATABASE_URL',
         command: restartHarnessCommand,
         isolation: 'unique_schema_new_connection',
-        cases: [
-          'restarted_handler_reuses_delivery_ledger_without_reapplying_counter',
-        ],
+        cases: ['restarted_handler_reuses_delivery_ledger_without_reapplying_counter'],
       },
       cases: [
         { name: 'shared_event_classifier' },
@@ -253,6 +275,7 @@ registry.register(services::BlogCommentProjectionHandler::new(ctx.db.clone()));`
         { name: 'tenant_scoped_optimistic_update' },
         { name: 'missing_post_retry' },
         { name: 'non_negative_count' },
+        { name: 'host_registration_routing_harness' },
         { name: 'postgres_duplicate_delivery' },
         { name: 'postgres_out_of_order_delete_create' },
         { name: 'postgres_missing_post_recovery' },
@@ -308,7 +331,7 @@ registry.register(services::BlogCommentProjectionHandler::new(ctx.db.clone()));`
   write(
     root,
     'crates/rustok-blog/docs/implementation-plan.md',
-    'blog-comments-event-projection.json verify:blog:comments-event-projection test:verify:blog:comments-event-projection source_verified_no_compile services::comment_projection::tests comment_projection_postgres_test comment_projection_restart_postgres_test RUSTOK_BLOG_TEST_DATABASE_URL runtime delivery and recovery',
+    'blog-comments-event-projection.json verify:blog:comments-event-projection test:verify:blog:comments-event-projection source_verified_no_compile services::comment_projection::tests tests::module_registers_comment_projection_handler_with_host_routing comment_projection_postgres_test comment_projection_restart_postgres_test RUSTOK_BLOG_TEST_DATABASE_URL actual host EventDispatcher delivery process-level restart recovery',
   );
 
   return root;
@@ -359,6 +382,13 @@ test('rejects missing module event-listener registration', () => {
   expectRejected({ missingRegistration: true });
 });
 
+test('rejects missing module registration and routing harness', () => {
+  expectRejected(
+    { missingHostHarness: true },
+    /missing async fn module_registers_comment_projection_handler_with_host_routing/,
+  );
+});
+
 test('rejects project without the shared event classifier', () => {
   expectRejected({ missingSharedClassifier: true }, /missing fn comment_projection_change/);
 });
@@ -386,10 +416,7 @@ test('rejects a PostgreSQL harness without rollback coverage', () => {
 });
 
 test('rejects a registry without the PostgreSQL target', () => {
-  expectRejected(
-    { missingPostgresRegistration: true },
-    /PostgreSQL test path drift/,
-  );
+  expectRejected({ missingPostgresRegistration: true }, /PostgreSQL test path drift/);
 });
 
 test('rejects a missing restart harness source', () => {
@@ -404,10 +431,7 @@ test('rejects restart coverage that reuses the original connection', () => {
 });
 
 test('rejects a registry without the restart target', () => {
-  expectRejected(
-    { missingRestartRegistration: true },
-    /restart test path drift/,
-  );
+  expectRejected({ missingRestartRegistration: true }, /restart test path drift/);
 });
 
 test('rejects runtime status promotion without execution', () => {
@@ -416,6 +440,10 @@ test('rejects runtime status promotion without execution', () => {
 
 test('rejects source harness execution promotion without execution', () => {
   expectRejected({ harnessStatusDrift: true }, /source harness drift/);
+});
+
+test('rejects host registration harness execution promotion without execution', () => {
+  expectRejected({ hostHarnessStatusDrift: true }, /host registration harness drift/);
 });
 
 test('rejects PostgreSQL harness execution promotion without execution', () => {


### PR DESCRIPTION
## Summary

- add an executable-no-run Rust harness through the real `BlogModule::register_event_listeners` path
- extract the registered handler and assert the `blog_comment_projection` identity
- retain Blog `comment.created` / `comment.deleted` routing and reject a non-Blog target without calling `handle()`
- extend Comments event-projection evidence schema v4 and its focused negative fixture
- keep Blog registry schema v13 and package command order unchanged
- keep actual host `EventDispatcher` delivery, database effects, concurrent exhaustion, and process-level restart recovery pending

## Why

The production module registered `BlogCommentProjectionHandler`, but the boundary was retained only through source markers. This adds a module-level executable target that crosses the real listener-registration API and checks handler identity plus routing without overstating runtime delivery proof.

## Validation

Not run by request. No verifier, Rust test, compile, PostgreSQL, browser, workflow, or CI command was executed.

Suggested maintainer commands:

```bash
cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing
npm run verify:blog:comments-event-projection
npm run test:verify:blog:comments-event-projection
npm run verify:blog:fba
npm run test:verify:blog:fba
cargo check -p rustok-server --features mod-blog
```
