### PR TITLE
fix(index): block replay scopes on failed jobs

### DIFF
--- a/crates/rustok-index/docs/m6-replay-dead-letter-admission.md
+++ b/crates/rustok-index/docs/m6-replay-dead-letter-admission.md
@@ -1,0 +1,64 @@
+# M6 replay dead-letter admission
+
+Status: `source_complete_operator_requeue_pending`
+
+This slice makes terminal replay failure fail closed at schema-scope admission. A durable
+`failed` rebuild job is treated as a dead letter instead of being ignored while a later
+invocation creates a fresh job identity.
+
+## Contract
+
+`PostgresIndexReplayJobStore::acquire` still serializes the exact tenant/schema scope
+before inspecting jobs. Selection now includes `failed` rebuild jobs and applies this
+precedence:
+
+1. `succeeded` proves the scope is already complete;
+2. an existing `running` or `pending` job remains authoritative and may be busy or
+   claimable;
+3. when neither successful nor active work exists, the newest `failed` job blocks
+   admission.
+
+The blocked call returns `IndexReplayJobError::DeadLettered` with only:
+
+- the existing job UUID;
+- the durable attempt count;
+- the optional bounded `last_error_code`.
+
+`last_error_details`, source/database/transport causes, tenant data, request data, and
+stack information are never returned from the admission error.
+
+## Identity and retry boundary
+
+A blocked scope does not insert another `index_jobs` row and does not reset the
+checkpoint. The existing failed job remains the durable diagnostic and operator
+decision point.
+
+This contract complements the separate retry-transition store:
+
+- retryable work may move the same job from `running` to delayed `pending`;
+- permanent or exhausted work may move it to `failed`;
+- once `failed` is authoritative and no active/succeeded job exists, ordinary replay
+  acquisition cannot bypass it with a new job UUID.
+
+Legacy scopes that already contain an active job plus an older failed job continue the
+active job because active work has higher precedence. A retained `succeeded` job always
+wins over older active or failed rows.
+
+## Explicitly open
+
+- an authorized operator inspect/requeue command;
+- an audit contract for who requeued a dead letter and why;
+- retry-budget reset or epoch semantics for manual requeue;
+- host scheduling of eligible `pending` jobs;
+- runner integration with the retry-transition store;
+- retained PostgreSQL evidence for failure, retry exhaustion, restart, concurrent
+  acquisition, and operator requeue.
+
+The combined implementation-plan item for bounded retry/backoff, dead-letter state,
+and global scheduling ownership remains open.
+
+## Validation ownership
+
+Formatting, Cargo checks/tests, JavaScript guards, workflow execution, and live
+PostgreSQL validation are maintainer-run. The implementation agent did not execute
+them.

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_job.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_job.rs
@@ -130,6 +130,14 @@ pub enum IndexReplayJobError {
     SchemaNotRegistered(SchemaRef),
     #[error("Index replay schema is retired: {0}")]
     SchemaRetired(SchemaRef),
+    #[error(
+        "Index replay scope is blocked by failed job {job_id} after attempt {attempt_count}"
+    )]
+    DeadLettered {
+        job_id: Uuid,
+        attempt_count: u32,
+        error_code: Option<String>,
+    },
     #[error("stored Index replay job is invalid: {0}")]
     InvalidStoredJob(String),
     #[error("Index replay completion checkpoint is missing")]
@@ -299,6 +307,13 @@ impl PostgresIndexReplayJobStore {
                     claimable = Some(stored);
                     break;
                 }
+                "failed" => {
+                    return Err(IndexReplayJobError::DeadLettered {
+                        job_id: stored.job_id,
+                        attempt_count: stored.attempt_count,
+                        error_code: stored.last_error_code,
+                    });
+                }
                 state => {
                     return Err(IndexReplayJobError::InvalidStoredJob(format!(
                         "unexpected active state {state}"
@@ -379,6 +394,7 @@ struct StoredJob {
     source_name: String,
     attempt_count: u32,
     claimable: bool,
+    last_error_code: Option<String>,
 }
 
 fn stored_job(row: &QueryResult, backend: DbBackend) -> Result<StoredJob, IndexReplayJobError> {
@@ -414,12 +430,23 @@ fn stored_job(row: &QueryResult, backend: DbBackend) -> Result<StoredJob, IndexR
     let attempt_count = u32::try_from(attempt_count).map_err(|_| {
         IndexReplayJobError::InvalidStoredJob("attempt count is outside the u32 range".to_owned())
     })?;
+    let last_error_code: Option<String> = row
+        .try_get("", "last_error_code")
+        .map_err(storage_error)?;
+    if let Some(code) = &last_error_code {
+        validate_error_code(code).map_err(|_| {
+            IndexReplayJobError::InvalidStoredJob(
+                "last_error_code is outside the replay error contract".to_owned(),
+            )
+        })?;
+    }
     Ok(StoredJob {
         job_id: stored_uuid(row, "job_id", backend)?,
         state: row.try_get("", "state").map_err(storage_error)?,
         source_name,
         attempt_count,
         claimable: row.try_get("", "claimable").map_err(storage_error)?,
+        last_error_code,
     })
 }
 
@@ -694,7 +721,7 @@ fn select_replay_jobs_sql(backend: DbBackend) -> String {
         _ => unreachable!("unsupported database backend was validated"),
     };
     format!(
-        "SELECT job_id, state, request, {attempt_count} AS attempt_count_value, {claimable} AS claimable FROM index_jobs WHERE tenant_id = {prefix}1 AND module_name = {prefix}2 AND entity_name = {prefix}3 AND schema_version = {prefix}4 AND kind = 'rebuild' AND scope_kind = 'schema' AND state IN ('pending', 'running', 'succeeded') ORDER BY CASE state WHEN 'succeeded' THEN 0 WHEN 'running' THEN 1 ELSE 2 END, created_at DESC"
+        "SELECT job_id, state, request, last_error_code, {attempt_count} AS attempt_count_value, {claimable} AS claimable FROM index_jobs WHERE tenant_id = {prefix}1 AND module_name = {prefix}2 AND entity_name = {prefix}3 AND schema_version = {prefix}4 AND kind = 'rebuild' AND scope_kind = 'schema' AND state IN ('pending', 'running', 'succeeded', 'failed') ORDER BY CASE state WHEN 'succeeded' THEN 0 WHEN 'running' THEN 1 WHEN 'pending' THEN 2 ELSE 3 END, created_at DESC"
     )
 }
 

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_job_tests.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_job_tests.rs
@@ -225,18 +225,41 @@ async fn expired_replay_job_is_reclaimed_and_old_checkpoint_writer_is_fenced() {
 }
 
 #[tokio::test]
-async fn failed_terminal_replay_job_allows_a_new_job_identity() {
+async fn failed_terminal_replay_job_blocks_scope_without_raw_details() {
     let fixture = Fixture::new("active").await;
     let first = fixture.acquire("worker-a").await;
     fixture
         .jobs
-        .fail(&first, "index.replay_source_failed", json!({"retryable": false}))
+        .fail(
+            &first,
+            "index.replay_source_failed",
+            json!({"retryable": false, "private": "must-not-be-returned"}),
+        )
         .await
         .unwrap();
 
-    let second = fixture.acquire("worker-b").await;
-    assert_ne!(second.job_id(), first.job_id());
-    assert_eq!(second.attempt_count(), 1);
+    assert_eq!(
+        fixture.jobs.acquire(&fixture.request("worker-b")).await,
+        Err(IndexReplayJobError::DeadLettered {
+            job_id: first.job_id(),
+            attempt_count: 1,
+            error_code: Some("index.replay_source_failed".to_owned()),
+        })
+    );
+
+    let count: i64 = fixture
+        .db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT COUNT(*) AS job_count FROM index_jobs WHERE tenant_id = ?1 AND kind = 'rebuild'",
+            vec![TENANT.to_owned().into()],
+        ))
+        .await
+        .unwrap()
+        .unwrap()
+        .try_get("", "job_count")
+        .unwrap();
+    assert_eq!(count, 1);
 }
 
 #[tokio::test]

--- a/scripts/verify/verify-index-replay-dead-letter-admission.mjs
+++ b/scripts/verify/verify-index-replay-dead-letter-admission.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-replay-dead-letter-admission] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const jobPath =
+  'crates/rustok-index/src/infrastructure/postgres/source_replay_job.rs';
+const jobs = requireMarkers(jobPath, [
+  'DeadLettered {',
+  'job_id: Uuid,',
+  'attempt_count: u32,',
+  'error_code: Option<String>,',
+  '"failed" => {',
+  'error_code: stored.last_error_code,',
+  'last_error_code: Option<String>,',
+  'SELECT job_id, state, request, last_error_code',
+  "state IN ('pending', 'running', 'succeeded', 'failed')",
+  "WHEN 'succeeded' THEN 0 WHEN 'running' THEN 1 WHEN 'pending' THEN 2 ELSE 3",
+  'last_error_code is outside the replay error contract',
+]);
+const deadLetterStart = jobs.indexOf('"failed" => {');
+const deadLetterEnd = jobs.indexOf('state => {', deadLetterStart);
+if (deadLetterStart < 0 || deadLetterEnd <= deadLetterStart) {
+  fail(`${jobPath} dead-letter match block is missing`);
+}
+const deadLetterBlock = jobs.slice(deadLetterStart, deadLetterEnd);
+for (const forbidden of [
+  'last_error_details',
+  'error_details',
+  'INSERT INTO index_jobs',
+  'Storage(',
+]) {
+  if (deadLetterBlock.includes(forbidden)) {
+    fail(`${jobPath} dead-letter admission contains ${forbidden}`);
+  }
+}
+
+const testsPath =
+  'crates/rustok-index/src/infrastructure/postgres/source_replay_job_tests.rs';
+requireMarkers(testsPath, [
+  'failed_terminal_replay_job_blocks_scope_without_raw_details',
+  'Err(IndexReplayJobError::DeadLettered {',
+  'error_code: Some("index.replay_source_failed".to_owned()),',
+  'SELECT COUNT(*) AS job_count FROM index_jobs',
+  'assert_eq!(count, 1);',
+]);
+
+requireMarkers('crates/rustok-index/docs/m6-replay-dead-letter-admission.md', [
+  'Status: `source_complete_operator_requeue_pending`',
+  'A durable\n`failed` rebuild job is treated as a dead letter',
+  '`IndexReplayJobError::DeadLettered`',
+  '`last_error_details`',
+  'ordinary replay\n  acquisition cannot bypass it with a new job UUID',
+  'an authorized operator inspect/requeue command',
+  'combined implementation-plan item for bounded retry/backoff',
+  'maintainer-run',
+]);
+
+console.log('[verify-index-replay-dead-letter-admission] OK');


### PR DESCRIPTION
## Summary

- make `PostgresIndexReplayJobStore::acquire` include terminal `failed` rebuild jobs when resolving one tenant/schema replay scope
- preserve deterministic precedence: `succeeded`, then active `running`/`pending`, then the newest `failed` dead letter
- return typed `IndexReplayJobError::DeadLettered` instead of silently inserting a new `index_jobs` row after terminal failure
- expose only the existing job UUID, durable attempt count, and optional bounded `last_error_code`
- validate stored error codes and never return `last_error_details`, database/source/transport causes, request or tenant details, or stack information
- replace the old fixture that expected a new job identity with a fail-closed assertion that the scope remains blocked and the job-row count stays one
- add contract documentation and a standalone static verifier

## Admission semantics

The acquisition transaction still takes the existing schema-scope advisory lock before inspecting jobs. Selection now includes `failed` rows and orders them so:

1. a retained `succeeded` row remains authoritative completion;
2. an existing `running` or `pending` row remains authoritative work and is handled using the existing busy/reclaim rules;
3. only when there is no successful or active work does the newest `failed` row block admission.

The existing runner already propagates this through `IndexReplayRunError::Job(#[from] IndexReplayJobError)`, so no separate runner patch or new transport contract is required.

## Privacy boundary

`DeadLettered` contains only:

- `job_id`
- `attempt_count`
- optional validated `error_code`

Persisted `last_error_details` are deliberately not loaded or exposed through the error. The test stores a private marker in the details JSON and verifies that acquisition returns only the bounded fields.

## Scope boundaries

- no operator inspect/requeue command
- no audit record for requeue actor/reason
- no retry-budget reset or retry epoch for manual requeue
- no automatic host scheduling
- no runner wiring to the separate retry-transition store from PR #2644
- no retained PostgreSQL concurrency/restart/requeue evidence

The combined implementation-plan item for retry/backoff, dead-letter state, and global scheduling ownership remains open.

## Compatibility

- no migration or table-shape change
- no source schema, cursor, mutation, checkpoint, or event identity change
- no new Index dependency on Product or Channel
- legacy scopes that already contain an active job and an older failed row continue the active job because active work has higher precedence
- no changed-file overlap with open Index PRs #2636, #2639, #2642, or #2644

## Validation

Not run per maintainer instruction:

- Cargo formatting/checks/tests/Clippy
- JavaScript verifier
- PostgreSQL failure/concurrency/restart execution
- CI workflows

Suggested maintainer commands:

```bash
cargo test -p rustok-index failed_terminal_replay_job_blocks_scope_without_raw_details -- --nocapture
cargo check -p rustok-index --all-targets
node scripts/verify/verify-index-replay-dead-letter-admission.mjs
```

## Branch state

Base: `main` at `df2e19a31098e1747441d513726fc9f21c82059e`
Branch: `agent/index-m6-replay-dead-letter-admission-20260731`

The connector produced four small sequential commits; squash merge is recommended after maintainer validation.