### PR TITLE
test(blog): add projection dispatcher delivery harness

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json
@@ -42,6 +42,18 @@
       "module_registers_comment_projection_handler_with_host_routing"
     ]
   },
+  "dispatcher_harness": {
+    "status": "executable_no_run",
+    "runtime_status": "not_run",
+    "path": "crates/rustok-blog/tests/comment_projection_postgres_test.rs",
+    "environment": "RUSTOK_BLOG_TEST_DATABASE_URL",
+    "command": "RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test event_dispatcher_routes_registered_handler_and_commits_projection -- --exact",
+    "isolation": "unique_schema_one_connection_pool",
+    "scope": "event_bus_dispatcher_module_registered_handler_transactional_commit",
+    "cases": [
+      "event_dispatcher_routes_registered_handler_and_commits_projection"
+    ]
+  },
   "postgres_harness": {
     "status": "executable_no_run",
     "runtime_status": "not_run",
@@ -105,6 +117,10 @@
       "expected": "the retained module test invokes BlogModule::register_event_listeners, extracts one blog_comment_projection handler, accepts Blog comment created/deleted events, and rejects a non-Blog target"
     },
     {
+      "name": "postgres_event_dispatcher_delivery",
+      "expected": "the retained PostgreSQL dispatcher case registers the Blog handler through BlogModule, publishes one envelope through EventBus and EventDispatcher, then expects the counter, delivery ledger, and outbox row to commit"
+    },
+    {
       "name": "postgres_duplicate_delivery",
       "expected": "the retained PostgreSQL target replays one envelope id and expects one counter transition, one delivery row, and one outbox row"
     },
@@ -132,6 +148,7 @@
   "runtime_promotion_requirements": [
     "execute cargo test -p rustok-blog --lib services::comment_projection::tests",
     "execute cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing",
+    "execute the env-gated PostgreSQL dispatcher case and retain EventBus/EventDispatcher delivery output",
     "execute the env-gated PostgreSQL comment_projection_postgres_test target and retain its output",
     "execute the env-gated PostgreSQL comment_projection_restart_postgres_test target and retain its output",
     "retain proof that duplicate and out-of-order comment.created/comment.deleted deliveries match the source harness assertions",
@@ -139,6 +156,6 @@
     "retain missing-post retry and later recovery evidence",
     "retain restarted-handler replay evidence across a new database connection",
     "retain concurrent optimistic-update exhaustion and retry evidence",
-    "retain actual host EventDispatcher delivery and process restart recovery evidence"
+    "retain process restart recovery evidence"
   ]
 }

--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -120,12 +120,24 @@ handler, verifies the `blog_comment_projection` identity, accepts Blog
 command is
 `cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing`.
 The target is `executable_no_run` and intentionally does not call `handle()`;
-actual host EventDispatcher delivery and database effects remain pending.
+EventBus/EventDispatcher delivery is covered by the separate PostgreSQL source
+target below.
+
+The retained dispatcher target is the filtered
+`event_dispatcher_routes_registered_handler_and_commits_projection` case in
+`crates/rustok-blog/tests/comment_projection_postgres_test.rs`. It builds the real
+module listener context, registers handlers through
+`BlogModule::register_event_listeners`, moves them into `EventDispatcher`, starts
+the subscriber, publishes one envelope through `EventBus`, waits for the durable
+delivery marker, and then requires one counter transition, one delivery row, and
+one outbox row. Its suggested command is
+`RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test event_dispatcher_routes_registered_handler_and_commits_projection -- --exact`.
+The target is `executable_no_run`; no dispatcher or PostgreSQL output is recorded.
 
 The retained PostgreSQL target is
 `crates/rustok-blog/tests/comment_projection_postgres_test.rs`. It uses
 `RUSTOK_BLOG_TEST_DATABASE_URL` (or PostgreSQL `DATABASE_URL`), a unique schema,
-and a one-connection pool. Its four written cases cover duplicate-envelope
+and a one-connection pool. Its four direct-handler cases cover duplicate-envelope
 idempotency, delete-before-create ordering, missing-post replay after source
 creation, and rollback/retry when the outbox table is unavailable. The suggested
 command is
@@ -145,8 +157,8 @@ re-instantiation, not retained proof of a process or host restart.
 Exact commands `verify:blog:comments-event-projection` and
 `test:verify:blog:comments-event-projection` run after the Comments port gate in
 the Blog FBA chains. Overall status remains `source_verified_no_compile`;
-concurrent optimistic exhaustion, actual host EventDispatcher delivery,
-process-level restart recovery, and all execution evidence remain pending.
+concurrent optimistic exhaustion, dispatcher/PostgreSQL execution, process-level
+restart recovery, and all other execution evidence remain pending.
 
 Blog categories use the exclusive `blog_categories:*` permission resource.
 `CategoryService::new(db, event_bus)` is the only owner constructor. Category
@@ -302,17 +314,26 @@ focused negative fixture, and preserves Blog registry schema v13 plus package
 order. The target is source-only and does not claim actual host dispatcher, DB,
 or process-level execution.
 
+The continuation audit at `12f20d5e53b3f4a19ee9b1ab439900efdde3e33e`
+found that module registration and routing were retained, but actual delivery
+through `EventBus` and `EventDispatcher` still had no executable Blog target.
+Slice 49 adds a filtered env-gated PostgreSQL dispatcher case through the real
+module registration path, waits for the durable delivery marker, and asserts the
+counter, ledger, and outbox commit. Evidence schema v4 and Blog registry schema
+v13 remain compatible; focused guards retain the target without recording
+execution.
+
 ## FFA/FBA status
 
 - FFA status: `in_progress`.
 - FBA status: `boundary_ready` (`core_transport_ui`).
 - Blog FBA source-gate chain: `source_verified_no_compile`; registry schema v13
   locks exact verify/test order, source-gate paths, leaf npm commands, evidence,
-  self-tests, the Comments projection classifier, host registration, PostgreSQL,
-  and restart harnesses, and aggregate/consumer bindings for admin, storefront,
-  Comments port boundary, Comments event projection, category Search reindex,
-  GraphQL rate limiting, GraphQL richtext, AI richtext, offline backfill, Forum
-  ownership, and runtime order.
+  self-tests, the Comments projection classifier, host registration, dispatcher,
+  PostgreSQL, and restart harnesses, and aggregate/consumer bindings for admin,
+  storefront, Comments port boundary, Comments event projection, category Search
+  reindex, GraphQL rate limiting, GraphQL richtext, AI richtext, offline backfill,
+  Forum ownership, and runtime order.
 - Comments consumer port boundary: Blog-owned `source_verified_no_compile` for
   the in-process profile; all seven operations, approved public read, typed
   richtext projection, two-second deadlines, write idempotency, active typed
@@ -323,15 +344,17 @@ or process-level execution.
   comment-form fallback, browser/runtime evidence, and broader degraded UI modes
   remain planned or pending.
 - Comments event projection: Blog-owned `source_verified_no_compile`; evidence
-  schema v4, shared classifier/counter helpers, `executable_no_run` classifier and
-  module-registration Rust targets, PostgreSQL transaction and restart harnesses,
+  schema v4, shared classifier/counter helpers, `executable_no_run` classifier,
+  module-registration, dispatcher, PostgreSQL transaction, and restart targets,
   verifier, focused self-test, exact npm leaf commands, delivery-ledger identity,
-  transactional outbox markers, and Blog FBA ordering are locked. The host target
-  verifies module registry identity and routing only. The PostgreSQL targets write
-  duplicate, out-of-order, missing-post replay, outbox rollback/retry, and
-  new-connection handler replay cases but have not been run. Concurrent optimistic
-  exhaustion, actual host EventDispatcher delivery, process-level restart recovery,
-  and all execution evidence remain pending.
+  transactional outbox markers, and Blog FBA ordering are locked. The registration
+  target verifies identity/routing only. The dispatcher source target passes one
+  envelope through `EventBus` and `EventDispatcher` into the module-registered
+  handler and waits for the durable commit, but it has not been run. The direct
+  PostgreSQL targets write duplicate, out-of-order, missing-post replay, outbox
+  rollback/retry, and new-connection handler replay cases but have not been run.
+  Concurrent optimistic exhaustion, process-level restart recovery, and all
+  execution evidence remain pending.
 - Load protection: `implementation_ready`; mounted Redis evidence is pending.
 - Rate-limit harness: `executable_no_compile`; evidence, verifier, self-test,
   npm leaf commands, and aggregate FBA registration are locked; execution is
@@ -518,6 +541,11 @@ or process-level execution.
     lifecycle routing in projection evidence schema v4 and focused negative
     fixtures, and kept registry schema v13, package order, dispatcher execution,
     database delivery, and process-level recovery unchanged or pending.
+49. Added an executable-no-run PostgreSQL dispatcher case that registers the Blog
+    projection through `BlogModule`, publishes through `EventBus` and
+    `EventDispatcher`, waits for the durable delivery marker, and retains
+    counter/ledger/outbox assertions in evidence plus focused negative fixtures
+    without changing registry schema v13 or recording execution.
 
 ## Next results
 
@@ -536,16 +564,18 @@ or process-level execution.
    real HTTP `Retry-After` matching GraphQL `retryAfter`.
 5. **Close comments runtime evidence.** Run the Comments port boundary fixture,
    shared consumer runtime-order verifier, Blog projection classifier harness,
-   module registration/routing harness, the `comment_projection_postgres_test`
-   and `comment_projection_restart_postgres_test` targets, both thread invariant
+   module registration/routing harness, the filtered
+   `event_dispatcher_routes_registered_handler_and_commits_projection` case, the
+   complete `comment_projection_postgres_test` and
+   `comment_projection_restart_postgres_test` targets, both thread invariant
    concurrency targets, and concurrent PostgreSQL create/delete transactions.
-   Retain actual host EventDispatcher delivery, the written duplicate,
-   delete-before-create, missing-post replay, outbox rollback/retry, and
-   new-connection handler replay assertions; then cover concurrent optimistic
-   exhaustion, process-level restart recovery, remote adapter parity, browser
-   parity for typed unavailable/timeout article rendering, cached thread snapshots,
-   comment-form fallback, approved-only reads, moderation, pagination,
-   first-thread identity, and unrelated insert storage error propagation.
+   Retain dispatcher delivery output, the written duplicate, delete-before-create,
+   missing-post replay, outbox rollback/retry, and new-connection handler replay
+   assertions; then cover concurrent optimistic exhaustion, process-level restart
+   recovery, remote adapter parity, browser parity for typed unavailable/timeout
+   article rendering, cached thread snapshots, comment-form fallback,
+   approved-only reads, moderation, pagination, first-thread identity, and
+   unrelated insert storage error propagation.
 6. **Execute and retain Blog article richtext cutover evidence.** Run the offline
    backfill in default dry-run mode, review its report, apply accepted conversion,
    execute the irreversible migration, reindex/rollback Search, and retain
@@ -563,6 +593,7 @@ should run the relevant subset, including:
 - `npm run test:verify:blog:comments-event-projection`
 - `cargo test -p rustok-blog --lib services::comment_projection::tests`
 - `cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing`
+- `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test event_dispatcher_routes_registered_handler_and_commits_projection -- --exact`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test`
 - `npm run verify:blog:category-search-reindex`

--- a/crates/rustok-blog/tests/comment_projection_postgres_test.rs
+++ b/crates/rustok-blog/tests/comment_projection_postgres_test.rs
@@ -1,7 +1,10 @@
-use std::error::Error;
+use std::{error::Error, io, time::Duration};
 
-use rustok_blog::services::BlogCommentProjectionHandler;
-use rustok_core::events::EventHandler;
+use rustok_blog::{BlogModule, services::BlogCommentProjectionHandler};
+use rustok_core::{
+    ModuleEventListenerContext, ModuleEventListenerRegistry, ModuleRuntimeExtensions, RusToKModule,
+    events::{DispatcherConfig, EventBus, EventDispatcher, EventHandler},
+};
 use rustok_events::{DomainEvent, EventEnvelope};
 use sea_orm::{
     ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
@@ -86,6 +89,55 @@ async fn duplicate_delivery_updates_counter_and_outbox_once() -> TestResult<()> 
     assert_eq!(count_delivery(&test_db.db, envelope.id).await?, 1);
     assert_eq!(count_outbox_events(&test_db.db).await?, 1);
 
+    test_db.cleanup().await
+}
+
+#[tokio::test]
+async fn event_dispatcher_routes_registered_handler_and_commits_projection() -> TestResult<()> {
+    let Some(test_db) = PostgresBlogProjectionTestDb::setup("dispatcher").await? else {
+        return Ok(());
+    };
+
+    let tenant_id = Uuid::new_v4();
+    let post_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    let comment_id = Uuid::new_v4();
+    insert_post(&test_db.db, tenant_id, post_id, actor_id, 0, 1).await?;
+
+    let extensions = ModuleRuntimeExtensions::default();
+    let context = ModuleEventListenerContext {
+        db: test_db.db.clone(),
+        extensions: &extensions,
+    };
+    let mut registry = ModuleEventListenerRegistry::new();
+    BlogModule.register_event_listeners(&mut registry, &context);
+
+    let bus = EventBus::new();
+    let mut dispatcher = EventDispatcher::with_config(
+        bus,
+        DispatcherConfig {
+            fail_fast: true,
+            max_concurrent: 1,
+            retry_count: 0,
+            retry_delay_ms: 0,
+            max_queue_depth: 128,
+        },
+    );
+    for handler in registry.into_handlers() {
+        dispatcher.register_boxed(handler);
+    }
+    assert_eq!(dispatcher.handler_count(), 1);
+
+    let envelope = comment_created_envelope(tenant_id, actor_id, comment_id, post_id);
+    let running = dispatcher.start();
+    running.bus().publish_envelope(envelope.clone())?;
+    wait_for_dispatch_commit(&test_db.db, envelope.id).await?;
+
+    assert_eq!(load_post_state(&test_db.db, tenant_id, post_id).await?, (1, 2));
+    assert_eq!(count_delivery(&test_db.db, envelope.id).await?, 1);
+    assert_eq!(count_outbox_events(&test_db.db).await?, 1);
+
+    running.stop();
     test_db.cleanup().await
 }
 
@@ -219,6 +271,25 @@ fn comment_created_envelope(
             author_id: actor_id,
         },
     )
+}
+
+async fn wait_for_dispatch_commit(db: &DatabaseConnection, event_id: Uuid) -> TestResult<()> {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if count_delivery(db, event_id).await? == 1 {
+                return Ok::<(), sea_orm::DbErr>(());
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!("event dispatcher did not commit delivery {event_id}"),
+        )
+    })??;
+    Ok(())
 }
 
 async fn create_projection_tables(db: &DatabaseConnection) -> Result<(), sea_orm::DbErr> {

--- a/scripts/verify/verify-blog-comments-event-projection.mjs
+++ b/scripts/verify/verify-blog-comments-event-projection.mjs
@@ -42,6 +42,7 @@ const registryPath = 'crates/rustok-blog/contracts/blog-fba-registry.json';
 const planPath = 'crates/rustok-blog/docs/implementation-plan.md';
 const harnessCommand = 'cargo test -p rustok-blog --lib services::comment_projection::tests';
 const hostRegistrationHarnessCommand = 'cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing';
+const dispatcherHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test event_dispatcher_routes_registered_handler_and_commits_projection -- --exact';
 const postgresHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test';
 const restartHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test';
 const postgresHarnessEnvironment = 'RUSTOK_BLOG_TEST_DATABASE_URL';
@@ -126,6 +127,24 @@ for (const marker of [
   'SET search_path TO',
   'async fn duplicate_delivery_updates_counter_and_outbox_once()',
   'handler.handle(&envelope).await?;',
+  'async fn event_dispatcher_routes_registered_handler_and_commits_projection()',
+  'let extensions = ModuleRuntimeExtensions::default();',
+  'BlogModule.register_event_listeners(&mut registry, &context);',
+  'let bus = EventBus::new();',
+  'let mut dispatcher = EventDispatcher::with_config(',
+  'fail_fast: true',
+  'max_concurrent: 1',
+  'retry_count: 0',
+  'dispatcher.register_boxed(handler);',
+  'assert_eq!(dispatcher.handler_count(), 1);',
+  'let running = dispatcher.start();',
+  'running.bus().publish_envelope(envelope.clone())?;',
+  'wait_for_dispatch_commit(&test_db.db, envelope.id).await?;',
+  'running.stop();',
+  'async fn wait_for_dispatch_commit(db: &DatabaseConnection, event_id: Uuid)',
+  'tokio::time::timeout(Duration::from_secs(5)',
+  'count_delivery(db, event_id).await? == 1',
+  'event dispatcher did not commit delivery',
   'async fn delete_before_create_stays_non_negative_and_replays_in_order()',
   'DomainEvent::CommentDeleted',
   'async fn missing_post_replay_commits_only_after_source_appears()',
@@ -276,6 +295,24 @@ if (evidence) {
   ) {
     failures.push(`${evidencePath}: host registration harness case drift`);
   }
+  const dispatcher = evidence.dispatcher_harness ?? {};
+  if (
+    dispatcher.status !== 'executable_no_run' ||
+    dispatcher.runtime_status !== 'not_run' ||
+    dispatcher.path !== postgresHarnessPath ||
+    dispatcher.environment !== postgresHarnessEnvironment ||
+    dispatcher.command !== dispatcherHarnessCommand ||
+    dispatcher.isolation !== 'unique_schema_one_connection_pool' ||
+    dispatcher.scope !== 'event_bus_dispatcher_module_registered_handler_transactional_commit'
+  ) {
+    failures.push(`${evidencePath}: dispatcher harness drift`);
+  }
+  if (
+    [...(dispatcher.cases ?? [])].join('|') !==
+    'event_dispatcher_routes_registered_handler_and_commits_projection'
+  ) {
+    failures.push(`${evidencePath}: dispatcher harness case drift`);
+  }
   const postgres = evidence.postgres_harness ?? {};
   if (
     postgres.status !== 'executable_no_run' ||
@@ -330,6 +367,7 @@ if (evidence) {
     'missing_post_retry',
     'non_negative_count',
     'host_registration_routing_harness',
+    'postgres_event_dispatcher_delivery',
     'postgres_duplicate_delivery',
     'postgres_out_of_order_delete_create',
     'postgres_missing_post_recovery',
@@ -400,10 +438,12 @@ for (const marker of [
   'source_verified_no_compile',
   'services::comment_projection::tests',
   'tests::module_registers_comment_projection_handler_with_host_routing',
+  'event_dispatcher_routes_registered_handler_and_commits_projection',
   'comment_projection_postgres_test',
   'comment_projection_restart_postgres_test',
   'RUSTOK_BLOG_TEST_DATABASE_URL',
-  'actual host EventDispatcher delivery',
+  'EventBus',
+  'EventDispatcher',
   'process-level restart recovery',
 ]) {
   requireMarker(plan, marker, planPath);
@@ -415,4 +455,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log('Blog comments event projection source contract, classifier, host registration, PostgreSQL, and restart harnesses are consistent');
+console.log('Blog comments event projection classifier, registration, dispatcher, PostgreSQL, and restart harnesses are consistent');

--- a/scripts/verify/verify-blog-comments-event-projection.test.mjs
+++ b/scripts/verify/verify-blog-comments-event-projection.test.mjs
@@ -21,6 +21,8 @@ function fixture({
   missingOutbox = false,
   missingRegistration = false,
   missingHostHarness = false,
+  missingDispatcherCase = false,
+  missingDispatcherWait = false,
   missingSharedClassifier = false,
   directHandlesClassifier = false,
   missingCounterHarness = false,
@@ -33,6 +35,7 @@ function fixture({
   statusDrift = false,
   harnessStatusDrift = false,
   hostHarnessStatusDrift = false,
+  dispatcherStatusDrift = false,
   postgresStatusDrift = false,
   restartStatusDrift = false,
 } = {}) {
@@ -49,6 +52,7 @@ function fixture({
   const registryPath = 'crates/rustok-blog/contracts/blog-fba-registry.json';
   const harnessCommand = 'cargo test -p rustok-blog --lib services::comment_projection::tests';
   const hostRegistrationHarnessCommand = 'cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing';
+  const dispatcherHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test event_dispatcher_routes_registered_handler_and_commits_projection -- --exact';
   const postgresHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test';
   const restartHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test';
 
@@ -94,6 +98,28 @@ ${missingCounterHarness ? '' : 'fn counter_transition_is_non_negative_and_satura
   );
 
   if (!missingPostgresHarness) {
+    const dispatcherSource = missingDispatcherCase
+      ? ''
+      : `
+async fn event_dispatcher_routes_registered_handler_and_commits_projection()
+let extensions = ModuleRuntimeExtensions::default();
+BlogModule.register_event_listeners(&mut registry, &context);
+let bus = EventBus::new();
+let mut dispatcher = EventDispatcher::with_config(
+fail_fast: true
+max_concurrent: 1
+retry_count: 0
+dispatcher.register_boxed(handler);
+assert_eq!(dispatcher.handler_count(), 1);
+let running = dispatcher.start();
+running.bus().publish_envelope(envelope.clone())?;
+${missingDispatcherWait ? '' : 'wait_for_dispatch_commit(&test_db.db, envelope.id).await?;'}
+running.stop();
+async fn wait_for_dispatch_commit(db: &DatabaseConnection, event_id: Uuid)
+tokio::time::timeout(Duration::from_secs(5)
+count_delivery(db, event_id).await? == 1
+event dispatcher did not commit delivery
+`;
     write(
       root,
       postgresHarnessPath,
@@ -106,6 +132,7 @@ DROP SCHEMA IF EXISTS
 SET search_path TO
 async fn duplicate_delivery_updates_counter_and_outbox_once()
 handler.handle(&envelope).await?;
+${dispatcherSource}
 async fn delete_before_create_stays_non_negative_and_replays_in_order()
 DomainEvent::CommentDeleted
 async fn missing_post_replay_commits_only_after_source_appears()
@@ -243,6 +270,16 @@ assert!(!handler.handles(&forum_created));
         scope: 'module_registry_handler_identity_and_routing_only',
         cases: ['module_registers_comment_projection_handler_with_host_routing'],
       },
+      dispatcher_harness: {
+        status: dispatcherStatusDrift ? 'executed' : 'executable_no_run',
+        runtime_status: dispatcherStatusDrift ? 'passed' : 'not_run',
+        path: postgresHarnessPath,
+        environment: 'RUSTOK_BLOG_TEST_DATABASE_URL',
+        command: dispatcherHarnessCommand,
+        isolation: 'unique_schema_one_connection_pool',
+        scope: 'event_bus_dispatcher_module_registered_handler_transactional_commit',
+        cases: ['event_dispatcher_routes_registered_handler_and_commits_projection'],
+      },
       postgres_harness: {
         status: postgresStatusDrift ? 'executed' : 'executable_no_run',
         runtime_status: postgresStatusDrift ? 'passed' : 'not_run',
@@ -276,6 +313,7 @@ assert!(!handler.handles(&forum_created));
         { name: 'missing_post_retry' },
         { name: 'non_negative_count' },
         { name: 'host_registration_routing_harness' },
+        { name: 'postgres_event_dispatcher_delivery' },
         { name: 'postgres_duplicate_delivery' },
         { name: 'postgres_out_of_order_delete_create' },
         { name: 'postgres_missing_post_recovery' },
@@ -331,7 +369,7 @@ assert!(!handler.handles(&forum_created));
   write(
     root,
     'crates/rustok-blog/docs/implementation-plan.md',
-    'blog-comments-event-projection.json verify:blog:comments-event-projection test:verify:blog:comments-event-projection source_verified_no_compile services::comment_projection::tests tests::module_registers_comment_projection_handler_with_host_routing comment_projection_postgres_test comment_projection_restart_postgres_test RUSTOK_BLOG_TEST_DATABASE_URL actual host EventDispatcher delivery process-level restart recovery',
+    'blog-comments-event-projection.json verify:blog:comments-event-projection test:verify:blog:comments-event-projection source_verified_no_compile services::comment_projection::tests tests::module_registers_comment_projection_handler_with_host_routing event_dispatcher_routes_registered_handler_and_commits_projection comment_projection_postgres_test comment_projection_restart_postgres_test RUSTOK_BLOG_TEST_DATABASE_URL EventBus EventDispatcher process-level restart recovery',
   );
 
   return root;
@@ -386,6 +424,20 @@ test('rejects missing module registration and routing harness', () => {
   expectRejected(
     { missingHostHarness: true },
     /missing async fn module_registers_comment_projection_handler_with_host_routing/,
+  );
+});
+
+test('rejects a missing EventDispatcher delivery case', () => {
+  expectRejected(
+    { missingDispatcherCase: true },
+    /missing async fn event_dispatcher_routes_registered_handler_and_commits_projection/,
+  );
+});
+
+test('rejects EventDispatcher coverage without durable delivery wait', () => {
+  expectRejected(
+    { missingDispatcherWait: true },
+    /missing wait_for_dispatch_commit\(&test_db.db, envelope.id\).await\?;/,
   );
 });
 
@@ -444,6 +496,10 @@ test('rejects source harness execution promotion without execution', () => {
 
 test('rejects host registration harness execution promotion without execution', () => {
   expectRejected({ hostHarnessStatusDrift: true }, /host registration harness drift/);
+});
+
+test('rejects dispatcher harness execution promotion without execution', () => {
+  expectRejected({ dispatcherStatusDrift: true }, /dispatcher harness drift/);
 });
 
 test('rejects PostgreSQL harness execution promotion without execution', () => {


### PR DESCRIPTION
## Summary

- add an executable-no-run PostgreSQL case that registers the Blog Comments projection through `BlogModule::register_event_listeners`
- move the registered handler into the real `EventDispatcher`, publish one envelope through `EventBus`, and wait for the durable delivery marker
- retain counter, delivery-ledger, and outbox commit assertions after dispatcher delivery
- record a separate dispatcher harness in Comments event-projection evidence schema v4
- extend the focused verifier and negative fixture for dispatcher construction, durable waiting, and false execution promotion
- keep Blog registry schema v13 and package command order unchanged
- keep PostgreSQL execution, concurrent optimistic exhaustion, and process-level restart recovery pending

## Validation

Not run by request. No verifier, Rust test, compile, PostgreSQL, browser, workflow, or CI command was executed.

Suggested maintainer commands:

```bash
RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test event_dispatcher_routes_registered_handler_and_commits_projection -- --exact
npm run verify:blog:comments-event-projection
npm run test:verify:blog:comments-event-projection
npm run verify:blog:fba
npm run test:verify:blog:fba
cargo check -p rustok-server --features mod-blog
```
