### PR TITLE
feat(index): admit Product channel relation epochs

### DIFF
--- a/crates/rustok-distribution/src/product_index/mod.rs
+++ b/crates/rustok-distribution/src/product_index/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod graph;
 mod product;
+pub(crate) mod relation_admission;
 #[path = "../product_variant_index.rs"]
 mod variant;
 

--- a/crates/rustok-distribution/src/product_index/relation_admission.rs
+++ b/crates/rustok-distribution/src/product_index/relation_admission.rs
@@ -191,7 +191,7 @@ mod tests {
     }
 
     #[test]
-    fn canonical_membership_and_retry_identity_are_stable() {
+    fn product_sales_channel_relation_canonical_membership_and_retry_identity_are_stable() {
         let first = snapshot(
             7,
             "en-US",
@@ -220,7 +220,7 @@ mod tests {
     }
 
     #[test]
-    fn relation_change_requires_a_strictly_larger_epoch() {
+    fn product_sales_channel_relation_change_requires_a_strictly_larger_epoch() {
         let previous = snapshot(8, "en-US", [Uuid::from_u128(3)]);
         let changed_same_epoch = snapshot(8, "en-US", [Uuid::from_u128(4)]);
         let regressed = snapshot(7, "en-US", [Uuid::from_u128(4)]);
@@ -245,7 +245,7 @@ mod tests {
     }
 
     #[test]
-    fn invalid_identity_and_duplicate_membership_fail_closed() {
+    fn product_sales_channel_relation_invalid_identity_and_duplicates_fail_closed() {
         assert_eq!(
             ProductSalesChannelRelationEpoch::new(0),
             Err(ProductSalesChannelRelationAdmissionError::ZeroEpoch)
@@ -283,7 +283,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_membership_is_valid_but_scope_cannot_change() {
+    fn product_sales_channel_relation_empty_membership_is_valid_but_scope_cannot_change() {
         let previous = snapshot(1, "en-US", []);
         let other_locale = snapshot(2, "fr-FR", []);
 

--- a/crates/rustok-distribution/src/product_index/relation_admission.rs
+++ b/crates/rustok-distribution/src/product_index/relation_admission.rs
@@ -1,0 +1,296 @@
+//! Admission contract for a future Product -> SalesChannel Index relation.
+//!
+//! Production persistence and source wiring are intentionally pending. Keeping this contract
+//! compiled before wiring prevents Product or Channel owner revisions from being combined through
+//! lossy `max`, hash, or pair encodings that can fail to advance after a relation-only change.
+#![allow(dead_code)]
+
+use rustok_index::{IndexSourceEventIdError, LocaleKey, derive_index_source_event_id};
+use thiserror::Error;
+use uuid::Uuid;
+
+const PRODUCT_SALES_CHANNEL_RELATION_EVENT_DOMAIN_V1: &str =
+    "rustok-distribution.product-sales-channel-relation-v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct ProductSalesChannelRelationEpoch(u64);
+
+impl ProductSalesChannelRelationEpoch {
+    pub(crate) fn new(value: u64) -> Result<Self, ProductSalesChannelRelationAdmissionError> {
+        if value == 0 {
+            return Err(ProductSalesChannelRelationAdmissionError::ZeroEpoch);
+        }
+        Ok(Self(value))
+    }
+
+    pub(crate) fn get(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProductSalesChannelRelationAdmission {
+    Initial,
+    Retry,
+    Advanced,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProductSalesChannelRelationSnapshot {
+    tenant_id: Uuid,
+    product_id: Uuid,
+    locale: LocaleKey,
+    epoch: ProductSalesChannelRelationEpoch,
+    channel_ids: Vec<Uuid>,
+    event_id: Uuid,
+}
+
+impl ProductSalesChannelRelationSnapshot {
+    pub(crate) fn new(
+        tenant_id: Uuid,
+        product_id: Uuid,
+        locale: LocaleKey,
+        epoch: ProductSalesChannelRelationEpoch,
+        channel_ids: impl IntoIterator<Item = Uuid>,
+    ) -> Result<Self, ProductSalesChannelRelationAdmissionError> {
+        if tenant_id.is_nil() {
+            return Err(ProductSalesChannelRelationAdmissionError::NilTenantId);
+        }
+        if product_id.is_nil() {
+            return Err(ProductSalesChannelRelationAdmissionError::NilProductId);
+        }
+
+        let mut channel_ids = channel_ids.into_iter().collect::<Vec<_>>();
+        if channel_ids.iter().any(Uuid::is_nil) {
+            return Err(ProductSalesChannelRelationAdmissionError::NilChannelId);
+        }
+        channel_ids.sort_unstable();
+        if channel_ids.windows(2).any(|pair| pair[0] == pair[1]) {
+            return Err(ProductSalesChannelRelationAdmissionError::DuplicateChannelId);
+        }
+
+        let event_id = derive_index_source_event_id(
+            PRODUCT_SALES_CHANNEL_RELATION_EVENT_DOMAIN_V1,
+            tenant_id,
+            product_id,
+            Some(&locale),
+            epoch.get(),
+        )?;
+
+        Ok(Self {
+            tenant_id,
+            product_id,
+            locale,
+            epoch,
+            channel_ids,
+            event_id,
+        })
+    }
+
+    pub(crate) fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub(crate) fn product_id(&self) -> Uuid {
+        self.product_id
+    }
+
+    pub(crate) fn locale(&self) -> &LocaleKey {
+        &self.locale
+    }
+
+    pub(crate) fn epoch(&self) -> ProductSalesChannelRelationEpoch {
+        self.epoch
+    }
+
+    pub(crate) fn channel_ids(&self) -> &[Uuid] {
+        &self.channel_ids
+    }
+
+    pub(crate) fn event_id(&self) -> Uuid {
+        self.event_id
+    }
+
+    pub(crate) fn admit(
+        previous: Option<&Self>,
+        next: &Self,
+    ) -> Result<ProductSalesChannelRelationAdmission, ProductSalesChannelRelationAdmissionError>
+    {
+        let Some(previous) = previous else {
+            return Ok(ProductSalesChannelRelationAdmission::Initial);
+        };
+        if previous.tenant_id != next.tenant_id
+            || previous.product_id != next.product_id
+            || previous.locale != next.locale
+        {
+            return Err(ProductSalesChannelRelationAdmissionError::ScopeChanged);
+        }
+        if next.epoch < previous.epoch {
+            return Err(ProductSalesChannelRelationAdmissionError::EpochRegressed {
+                previous: previous.epoch.get(),
+                next: next.epoch.get(),
+            });
+        }
+        if next.epoch == previous.epoch {
+            if next.channel_ids != previous.channel_ids || next.event_id != previous.event_id {
+                return Err(
+                    ProductSalesChannelRelationAdmissionError::SameEpochMembershipChanged,
+                );
+            }
+            return Ok(ProductSalesChannelRelationAdmission::Retry);
+        }
+        Ok(ProductSalesChannelRelationAdmission::Advanced)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub(crate) enum ProductSalesChannelRelationAdmissionError {
+    #[error("Product-SalesChannel relation epoch must be positive")]
+    ZeroEpoch,
+    #[error("Product-SalesChannel relation tenant id must not be nil")]
+    NilTenantId,
+    #[error("Product-SalesChannel relation product id must not be nil")]
+    NilProductId,
+    #[error("Product-SalesChannel relation channel id must not be nil")]
+    NilChannelId,
+    #[error("Product-SalesChannel relation channel ids must be unique")]
+    DuplicateChannelId,
+    #[error("Product-SalesChannel relation admission cannot change tenant, product, or locale")]
+    ScopeChanged,
+    #[error(
+        "Product-SalesChannel relation epoch regressed: previous={previous}, next={next}"
+    )]
+    EpochRegressed { previous: u64, next: u64 },
+    #[error("Product-SalesChannel membership changed without advancing its relation epoch")]
+    SameEpochMembershipChanged,
+    #[error(transparent)]
+    EventIdentity(#[from] IndexSourceEventIdError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn locale(value: &str) -> LocaleKey {
+        LocaleKey::new(value).unwrap()
+    }
+
+    fn snapshot(
+        epoch: u64,
+        locale: &str,
+        channel_ids: impl IntoIterator<Item = Uuid>,
+    ) -> ProductSalesChannelRelationSnapshot {
+        ProductSalesChannelRelationSnapshot::new(
+            Uuid::from_u128(1),
+            Uuid::from_u128(2),
+            self::locale(locale),
+            ProductSalesChannelRelationEpoch::new(epoch).unwrap(),
+            channel_ids,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn canonical_membership_and_retry_identity_are_stable() {
+        let first = snapshot(
+            7,
+            "en-US",
+            [Uuid::from_u128(4), Uuid::from_u128(3)],
+        );
+        let retry = snapshot(
+            7,
+            "en-US",
+            [Uuid::from_u128(3), Uuid::from_u128(4)],
+        );
+
+        assert_eq!(first, retry);
+        assert_eq!(
+            first.channel_ids(),
+            &[Uuid::from_u128(3), Uuid::from_u128(4)]
+        );
+        assert!(!first.event_id().is_nil());
+        assert_eq!(
+            ProductSalesChannelRelationSnapshot::admit(None, &first),
+            Ok(ProductSalesChannelRelationAdmission::Initial)
+        );
+        assert_eq!(
+            ProductSalesChannelRelationSnapshot::admit(Some(&first), &retry),
+            Ok(ProductSalesChannelRelationAdmission::Retry)
+        );
+    }
+
+    #[test]
+    fn relation_change_requires_a_strictly_larger_epoch() {
+        let previous = snapshot(8, "en-US", [Uuid::from_u128(3)]);
+        let changed_same_epoch = snapshot(8, "en-US", [Uuid::from_u128(4)]);
+        let regressed = snapshot(7, "en-US", [Uuid::from_u128(4)]);
+        let advanced = snapshot(9, "en-US", [Uuid::from_u128(4)]);
+
+        assert_eq!(
+            ProductSalesChannelRelationSnapshot::admit(Some(&previous), &changed_same_epoch),
+            Err(ProductSalesChannelRelationAdmissionError::SameEpochMembershipChanged)
+        );
+        assert_eq!(
+            ProductSalesChannelRelationSnapshot::admit(Some(&previous), &regressed),
+            Err(ProductSalesChannelRelationAdmissionError::EpochRegressed {
+                previous: 8,
+                next: 7,
+            })
+        );
+        assert_eq!(
+            ProductSalesChannelRelationSnapshot::admit(Some(&previous), &advanced),
+            Ok(ProductSalesChannelRelationAdmission::Advanced)
+        );
+        assert_ne!(previous.event_id(), advanced.event_id());
+    }
+
+    #[test]
+    fn invalid_identity_and_duplicate_membership_fail_closed() {
+        assert_eq!(
+            ProductSalesChannelRelationEpoch::new(0),
+            Err(ProductSalesChannelRelationAdmissionError::ZeroEpoch)
+        );
+        assert_eq!(
+            ProductSalesChannelRelationSnapshot::new(
+                Uuid::nil(),
+                Uuid::from_u128(2),
+                locale("en-US"),
+                ProductSalesChannelRelationEpoch::new(1).unwrap(),
+                [],
+            ),
+            Err(ProductSalesChannelRelationAdmissionError::NilTenantId)
+        );
+        assert_eq!(
+            ProductSalesChannelRelationSnapshot::new(
+                Uuid::from_u128(1),
+                Uuid::from_u128(2),
+                locale("en-US"),
+                ProductSalesChannelRelationEpoch::new(1).unwrap(),
+                [Uuid::nil()],
+            ),
+            Err(ProductSalesChannelRelationAdmissionError::NilChannelId)
+        );
+        assert_eq!(
+            ProductSalesChannelRelationSnapshot::new(
+                Uuid::from_u128(1),
+                Uuid::from_u128(2),
+                locale("en-US"),
+                ProductSalesChannelRelationEpoch::new(1).unwrap(),
+                [Uuid::from_u128(3), Uuid::from_u128(3)],
+            ),
+            Err(ProductSalesChannelRelationAdmissionError::DuplicateChannelId)
+        );
+    }
+
+    #[test]
+    fn empty_membership_is_valid_but_scope_cannot_change() {
+        let previous = snapshot(1, "en-US", []);
+        let other_locale = snapshot(2, "fr-FR", []);
+
+        assert!(previous.channel_ids().is_empty());
+        assert_eq!(
+            ProductSalesChannelRelationSnapshot::admit(Some(&previous), &other_locale),
+            Err(ProductSalesChannelRelationAdmissionError::ScopeChanged)
+        );
+    }
+}

--- a/crates/rustok-index/docs/m7-product-sales-channel-relation-admission.md
+++ b/crates/rustok-index/docs/m7-product-sales-channel-relation-admission.md
@@ -1,0 +1,81 @@
+# Product to SalesChannel relation admission
+
+Status: `source_contract_complete_persistence_and_wiring_pending`
+
+## Problem
+
+The Product Index source currently owns Product scalar state, ProductVariant links, and
+Product-owned channel visibility metadata. A real `IndexLink` from Product to the
+SalesChannel schema is different: Channel create, delete, reassignment, or identity
+changes can alter the resolved relation without changing `Product.index_revision`.
+Re-emitting the same Product source version would be treated as duplicate or stale and
+could retain obsolete links.
+
+A relation version must therefore not be derived with `max(product_revision,
+channel_revision)`, a hash, truncated pairing function, timestamp, row count, or the
+current Product revision. Independent owner counters do not guarantee that any of
+those encodings advances for every relation-only change.
+
+## Compiled admission contract
+
+`rustok-distribution::product_index::relation_admission` now defines the bounded
+pre-persistence contract:
+
+- `ProductSalesChannelRelationEpoch` is a positive `u64` intended to be persisted by
+  the eventual authoritative relation owner;
+- `ProductSalesChannelRelationSnapshot` is scoped by exact tenant, product, and
+  canonical locale;
+- channel UUIDs must be non-nil, unique, and are sorted canonically;
+- an empty set is valid and represents removal of all Product-to-Channel links;
+- event identity is derived with the versioned
+  `rustok-distribution.product-sales-channel-relation-v1` domain and the exact
+  relation epoch;
+- an identical epoch is accepted only for an identical retry;
+- changed membership under the same epoch fails closed;
+- epoch regression and tenant/product/locale scope changes fail closed;
+- a strictly greater epoch is admitted as an advanced relation snapshot.
+
+The locale dimension is retained because Product Index records are locale-required.
+One durable relation epoch may fan out to each current Product locale, but every
+locale-specific mutation gets its own stable Index event identity.
+
+## Production admission requirements
+
+The relation must remain unwired until one authoritative owner provides all of the
+following atomically:
+
+1. durable epoch storage for the exact tenant/product relation identity;
+2. a strictly monotonic increment on assignment create/delete, Channel deletion,
+   Channel identity movement, and any change that alters the resolved target set;
+3. one transaction boundary that commits membership and the new epoch together;
+4. bounded current-state scan and targeted-load access ordered by relation identity
+   and epoch;
+5. retained delete/empty-membership state so removed links replay after restart;
+6. stable event identity and source-version reuse for retries of the same epoch;
+7. acknowledgement or reconciliation semantics for changes committed after a replay
+   page was read;
+8. PostgreSQL evidence for concurrent assignment, delete/recreate, restart, retry,
+   out-of-order delivery, and locale fan-out.
+
+## Explicit non-claims
+
+This slice does not add a Product-to-SalesChannel `IndexLink`, schema version, source
+query, migration, relation owner table, event consumer, checkpoint dimension, or
+Storefront cutover. It does not select which source module owns the durable epoch.
+
+The existing `allowed_channel_slugs` Product field remains Product-owned visibility
+metadata and is not evidence that the cross-owner relation epoch exists.
+
+The canonical M7 Product/Variant/Channel link item remains open until persistence,
+source wiring, tombstone behavior, incremental ingestion, and retained PostgreSQL
+evidence satisfy the requirements above.
+
+## Maintainer validation
+
+Execution is maintainer-owned. Suggested commands:
+
+```bash
+cargo test -p rustok-distribution product_sales_channel_relation -- --nocapture
+cargo check -p rustok-distribution --all-targets
+node scripts/verify/verify-index-product-channel-relation-admission.mjs
+```

--- a/scripts/verify/verify-index-product-channel-relation-admission.mjs
+++ b/scripts/verify/verify-index-product-channel-relation-admission.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-channel-relation-admission] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
+  'pub(crate) mod relation_admission;',
+]);
+
+const admissionPath =
+  'crates/rustok-distribution/src/product_index/relation_admission.rs';
+const admission = requireMarkers(admissionPath, [
+  'PRODUCT_SALES_CHANNEL_RELATION_EVENT_DOMAIN_V1',
+  'rustok-distribution.product-sales-channel-relation-v1',
+  'ProductSalesChannelRelationEpoch',
+  'ProductSalesChannelRelationSnapshot',
+  'ProductSalesChannelRelationAdmission::Initial',
+  'ProductSalesChannelRelationAdmission::Retry',
+  'ProductSalesChannelRelationAdmission::Advanced',
+  'SameEpochMembershipChanged',
+  'EpochRegressed',
+  'channel_ids.sort_unstable();',
+  'channel_ids.windows(2)',
+  'derive_index_source_event_id(',
+  'Some(&locale)',
+  'epoch.get()',
+  'canonical_membership_and_retry_identity_are_stable',
+  'relation_change_requires_a_strictly_larger_epoch',
+  'invalid_identity_and_duplicate_membership_fail_closed',
+  'empty_membership_is_valid_but_scope_cannot_change',
+]);
+
+for (const forbidden of [
+  'SystemTime',
+  'Instant',
+  'DefaultHasher',
+  'wrapping_',
+  'saturating_',
+  'product_revision.max',
+  'channel_revision.max',
+  'Utc::now',
+  'CURRENT_TIMESTAMP',
+]) {
+  if (admission.includes(forbidden)) {
+    fail(`${admissionPath} contains forbidden revision derivation ${forbidden}`);
+  }
+}
+
+const graphPath = 'crates/rustok-distribution/src/product_index/graph.rs';
+const graph = read(graphPath);
+for (const forbidden of [
+  'sales_channel',
+  'link_name("channels")',
+  'product_sales_channel_relation_epoch',
+]) {
+  if (graph.includes(forbidden)) {
+    fail(
+      `${graphPath} wires Product-to-SalesChannel links before durable epoch admission: ${forbidden}`,
+    );
+  }
+}
+
+requireMarkers(
+  'crates/rustok-index/docs/m7-product-sales-channel-relation-admission.md',
+  [
+    'Status: `source_contract_complete_persistence_and_wiring_pending`',
+    'must therefore not be derived with `max(product_revision,',
+    '`ProductSalesChannelRelationEpoch`',
+    '`ProductSalesChannelRelationSnapshot`',
+    'an identical epoch is accepted only for an identical retry',
+    'changed membership under the same epoch fails closed',
+    'durable epoch storage for the exact tenant/product relation identity',
+    'This slice does not add a Product-to-SalesChannel `IndexLink`',
+    'The canonical M7 Product/Variant/Channel link item remains open',
+    'Execution is maintainer-owned',
+  ],
+);
+
+console.log('[verify-index-product-channel-relation-admission] OK');

--- a/scripts/verify/verify-index-product-channel-relation-admission.mjs
+++ b/scripts/verify/verify-index-product-channel-relation-admission.mjs
@@ -39,10 +39,10 @@ const admission = requireMarkers(admissionPath, [
   'derive_index_source_event_id(',
   'Some(&locale)',
   'epoch.get()',
-  'canonical_membership_and_retry_identity_are_stable',
-  'relation_change_requires_a_strictly_larger_epoch',
-  'invalid_identity_and_duplicate_membership_fail_closed',
-  'empty_membership_is_valid_but_scope_cannot_change',
+  'product_sales_channel_relation_canonical_membership_and_retry_identity_are_stable',
+  'product_sales_channel_relation_change_requires_a_strictly_larger_epoch',
+  'product_sales_channel_relation_invalid_identity_and_duplicates_fail_closed',
+  'product_sales_channel_relation_empty_membership_is_valid_but_scope_cannot_change',
 ]);
 
 for (const forbidden of [


### PR DESCRIPTION
## Summary

- add a compiled admission contract for a future Product-to-SalesChannel Index relation
- require a positive durable `ProductSalesChannelRelationEpoch` instead of deriving relation versions from independent Product/Channel revisions
- canonicalize the relation snapshot by exact tenant, product, locale, and sorted unique non-nil channel UUIDs
- derive one stable locale-specific Index event UUID from the relation epoch
- accept an equal epoch only for an identical retry
- fail closed when membership changes without an epoch advance, when the epoch regresses, or when tenant/product/locale scope changes
- retain an empty channel set as the explicit remove-all-links snapshot
- add focused unit regressions, an admission document, and a standalone fail-closed verifier

## Correctness boundary

A future Product-to-SalesChannel `IndexLink` cannot safely reuse `Product.index_revision`. Channel assignment, Channel deletion/recreation, or target identity changes may alter the resolved relation while Product revision stays unchanged. A later replay would then be duplicate/stale and could retain obsolete links.

This contract explicitly rejects replacing durable relation ownership with:

- `max(product_revision, channel_revision)`
- hashes or truncated pair encodings
- timestamps or current row counts
- Product revision alone

Independent counters do not guarantee that those values advance on every relation-only change.

## Admission semantics

`ProductSalesChannelRelationSnapshot::admit` returns:

- `Initial` when no prior snapshot exists
- `Retry` only when scope, epoch, canonical membership, and event identity are identical
- `Advanced` only when the same scope presents a strictly greater epoch

It rejects:

- zero epoch
- nil tenant/product/channel identities
- duplicate channel UUIDs
- scope movement across tenant, product, or locale
- epoch regression
- changed membership under the same epoch

The event identity uses the versioned domain `rustok-distribution.product-sales-channel-relation-v1` and the exact tenant/product/locale/epoch tuple.

## Production requirements still open

This PR intentionally does not add a Product-to-SalesChannel schema link or source query. Production wiring remains blocked until an authoritative owner provides:

- durable per-product relation epoch storage
- atomic membership plus epoch commits
- strict bumps for assignment create/delete, Channel deletion/recreation, and target-set changes
- bounded scan and targeted load
- retained empty-membership/delete replay
- incremental acknowledgement or reconciliation
- PostgreSQL concurrency, retry, restart, out-of-order, and locale fan-out evidence

The current Product-owned `allowed_channel_slugs` visibility field is not treated as this cross-owner relation epoch.

## Compatibility

- no migration or table-shape change
- no Product, ProductVariant, SalesChannel schema fingerprint change
- no existing source, cursor, mutation, checkpoint, or event-domain change
- no Storefront or Search cutover
- no implementation-plan edit while PR #2636 owns the canonical plan
- no changed-file overlap with open Index PRs #2636, #2639, #2642, #2644, #2648, or #2649

## Validation

Not run per maintainer instruction:

- Cargo formatting/checks/tests/Clippy
- JavaScript verifier
- PostgreSQL relation, concurrency, restart, or replay execution
- CI workflows

Suggested maintainer commands:

```bash
cargo test -p rustok-distribution product_sales_channel_relation -- --nocapture
cargo check -p rustok-distribution --all-targets
node scripts/verify/verify-index-product-channel-relation-admission.mjs
```

## Branch state

Merge base: `main` at `f10e07e705e2313ba8214913826c311076e1973c`
Branch: `agent/index-m7-product-channel-relation-admission-20260731`

`main` subsequently advanced through unrelated Order diagnostic and Blog dispatcher-harness commits. The connector produced six sequential commits; squash merge is recommended after maintainer validation.