### PR TITLE
test(blog): add projection concurrency harness

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json
@@ -54,6 +54,18 @@
       "event_dispatcher_routes_registered_handler_and_commits_projection"
     ]
   },
+  "concurrency_harness": {
+    "status": "executable_no_run",
+    "runtime_status": "not_run",
+    "path": "crates/rustok-blog/tests/comment_projection_postgres_test.rs",
+    "environment": "RUSTOK_BLOG_TEST_DATABASE_URL",
+    "command": "RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test concurrent_created_events_converge_without_lost_updates -- --exact",
+    "isolation": "unique_schema_four_independent_connections_barrier",
+    "scope": "concurrent_unique_envelopes_same_post_final_counter_delivery_outbox",
+    "cases": [
+      "concurrent_created_events_converge_without_lost_updates"
+    ]
+  },
   "postgres_harness": {
     "status": "executable_no_run",
     "runtime_status": "not_run",
@@ -121,6 +133,10 @@
       "expected": "the retained PostgreSQL dispatcher case registers the Blog handler through BlogModule, publishes one envelope through EventBus and EventDispatcher, then expects the counter, delivery ledger, and outbox row to commit"
     },
     {
+      "name": "postgres_concurrent_unique_deliveries",
+      "expected": "four handler instances start behind one barrier on four independent PostgreSQL connections, deliver unique envelopes to one post, and require count four, version five, four ledger rows, and four outbox rows without claiming observed retry count"
+    },
+    {
       "name": "postgres_duplicate_delivery",
       "expected": "the retained PostgreSQL target replays one envelope id and expects one counter transition, one delivery row, and one outbox row"
     },
@@ -149,13 +165,14 @@
     "execute cargo test -p rustok-blog --lib services::comment_projection::tests",
     "execute cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing",
     "execute the env-gated PostgreSQL dispatcher case and retain EventBus/EventDispatcher delivery output",
+    "execute the env-gated PostgreSQL concurrency case and retain four-connection convergence output",
     "execute the env-gated PostgreSQL comment_projection_postgres_test target and retain its output",
     "execute the env-gated PostgreSQL comment_projection_restart_postgres_test target and retain its output",
     "retain proof that duplicate and out-of-order comment.created/comment.deleted deliveries match the source harness assertions",
     "retain proof that the counter, delivery ledger, and BlogPostUpdated outbox row commit or roll back together",
     "retain missing-post retry and later recovery evidence",
     "retain restarted-handler replay evidence across a new database connection",
-    "retain concurrent optimistic-update exhaustion and retry evidence",
+    "retain explicit optimistic retry-count and exhaustion evidence",
     "retain process restart recovery evidence"
   ]
 }

--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -134,13 +134,25 @@ one outbox row. Its suggested command is
 `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test event_dispatcher_routes_registered_handler_and_commits_projection -- --exact`.
 The target is `executable_no_run`; no dispatcher or PostgreSQL output is recorded.
 
+The retained concurrency target is the filtered
+`concurrent_created_events_converge_without_lost_updates` case in
+`crates/rustok-blog/tests/comment_projection_postgres_test.rs`. It creates four
+independent PostgreSQL connections against one isolated schema, constructs one
+handler per connection, releases four unique `comment.created` envelopes through
+a shared barrier, and requires the shared post to finish at `comment_count = 4`
+and `version = 5` with four delivery-ledger rows and four outbox rows. Its
+suggested command is
+`RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test concurrent_created_events_converge_without_lost_updates -- --exact`.
+The target is `executable_no_run`. It records a written convergence contract, not
+an observed retry count or optimistic-exhaustion result.
+
 The retained PostgreSQL target is
 `crates/rustok-blog/tests/comment_projection_postgres_test.rs`. It uses
 `RUSTOK_BLOG_TEST_DATABASE_URL` (or PostgreSQL `DATABASE_URL`), a unique schema,
-and a one-connection pool. Its four direct-handler cases cover duplicate-envelope
-idempotency, delete-before-create ordering, missing-post replay after source
-creation, and rollback/retry when the outbox table is unavailable. The suggested
-command is
+and a one-connection pool for each direct handler. Its four direct-handler cases
+cover duplicate-envelope idempotency, delete-before-create ordering, missing-post
+replay after source creation, and rollback/retry when the outbox table is
+unavailable. The suggested command is
 `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test`.
 The target is registered as `executable_no_run`; no PostgreSQL result is recorded.
 
@@ -157,8 +169,8 @@ re-instantiation, not retained proof of a process or host restart.
 Exact commands `verify:blog:comments-event-projection` and
 `test:verify:blog:comments-event-projection` run after the Comments port gate in
 the Blog FBA chains. Overall status remains `source_verified_no_compile`;
-concurrent optimistic exhaustion, dispatcher/PostgreSQL execution, process-level
-restart recovery, and all other execution evidence remain pending.
+measured optimistic retry-count/exhaustion, dispatcher/PostgreSQL execution,
+process-level restart recovery, and all other execution evidence remain pending.
 
 Blog categories use the exclusive `blog_categories:*` permission resource.
 `CategoryService::new(db, event_bus)` is the only owner constructor. Category
@@ -323,6 +335,14 @@ counter, ledger, and outbox commit. Evidence schema v4 and Blog registry schema
 v13 remain compatible; focused guards retain the target without recording
 execution.
 
+The continuation audit at `733359d7102013fa91e5fc7df0dbd2ac8f919e06`
+found that the optimistic counter loop still had no executable multi-connection
+convergence target. Slice 50 adds four independent PostgreSQL connections and
+handler instances synchronized by one barrier, delivers four unique envelopes to
+one Blog post, and retains final counter/version plus ledger/outbox cardinality in
+evidence and focused negative fixtures. It does not claim an observed retry count,
+retry exhaustion, or PostgreSQL execution.
+
 ## FFA/FBA status
 
 - FFA status: `in_progress`.
@@ -330,10 +350,10 @@ execution.
 - Blog FBA source-gate chain: `source_verified_no_compile`; registry schema v13
   locks exact verify/test order, source-gate paths, leaf npm commands, evidence,
   self-tests, the Comments projection classifier, host registration, dispatcher,
-  PostgreSQL, and restart harnesses, and aggregate/consumer bindings for admin,
-  storefront, Comments port boundary, Comments event projection, category Search
-  reindex, GraphQL rate limiting, GraphQL richtext, AI richtext, offline backfill,
-  Forum ownership, and runtime order.
+  concurrency, PostgreSQL, and restart harnesses, and aggregate/consumer bindings
+  for admin, storefront, Comments port boundary, Comments event projection,
+  category Search reindex, GraphQL rate limiting, GraphQL richtext, AI richtext,
+  offline backfill, Forum ownership, and runtime order.
 - Comments consumer port boundary: Blog-owned `source_verified_no_compile` for
   the in-process profile; all seven operations, approved public read, typed
   richtext projection, two-second deadlines, write idempotency, active typed
@@ -345,16 +365,17 @@ execution.
   remain planned or pending.
 - Comments event projection: Blog-owned `source_verified_no_compile`; evidence
   schema v4, shared classifier/counter helpers, `executable_no_run` classifier,
-  module-registration, dispatcher, PostgreSQL transaction, and restart targets,
-  verifier, focused self-test, exact npm leaf commands, delivery-ledger identity,
-  transactional outbox markers, and Blog FBA ordering are locked. The registration
-  target verifies identity/routing only. The dispatcher source target passes one
-  envelope through `EventBus` and `EventDispatcher` into the module-registered
-  handler and waits for the durable commit, but it has not been run. The direct
-  PostgreSQL targets write duplicate, out-of-order, missing-post replay, outbox
-  rollback/retry, and new-connection handler replay cases but have not been run.
-  Concurrent optimistic exhaustion, process-level restart recovery, and all
-  execution evidence remain pending.
+  module-registration, dispatcher, concurrency, PostgreSQL transaction, and
+  restart targets, verifier, focused self-test, exact npm leaf commands,
+  delivery-ledger identity, transactional outbox markers, and Blog FBA ordering
+  are locked. The registration target verifies identity/routing only. The
+  dispatcher target passes one envelope through `EventBus` and `EventDispatcher`
+  into the module-registered handler and waits for the durable commit. The
+  concurrency target starts four independent PostgreSQL connections behind one
+  barrier and requires a four-count/five-version result with four delivery and
+  outbox rows. None of these targets has been run. Measured retry count,
+  optimistic exhaustion, process-level restart recovery, and all execution
+  evidence remain pending.
 - Load protection: `implementation_ready`; mounted Redis evidence is pending.
 - Rate-limit harness: `executable_no_compile`; evidence, verifier, self-test,
   npm leaf commands, and aggregate FBA registration are locked; execution is
@@ -546,6 +567,11 @@ execution.
     `EventDispatcher`, waits for the durable delivery marker, and retains
     counter/ledger/outbox assertions in evidence plus focused negative fixtures
     without changing registry schema v13 or recording execution.
+50. Added an executable-no-run four-connection PostgreSQL convergence case for
+    unique `comment.created` envelopes on one post, synchronized start with a
+    shared barrier, and retained final counter/version plus ledger/outbox
+    cardinality in evidence and focused fail-closed fixtures without claiming
+    measured retries, exhaustion, or execution.
 
 ## Next results
 
@@ -565,17 +591,19 @@ execution.
 5. **Close comments runtime evidence.** Run the Comments port boundary fixture,
    shared consumer runtime-order verifier, Blog projection classifier harness,
    module registration/routing harness, the filtered
-   `event_dispatcher_routes_registered_handler_and_commits_projection` case, the
-   complete `comment_projection_postgres_test` and
+   `event_dispatcher_routes_registered_handler_and_commits_projection` and
+   `concurrent_created_events_converge_without_lost_updates` cases, the complete
+   `comment_projection_postgres_test` and
    `comment_projection_restart_postgres_test` targets, both thread invariant
    concurrency targets, and concurrent PostgreSQL create/delete transactions.
-   Retain dispatcher delivery output, the written duplicate, delete-before-create,
-   missing-post replay, outbox rollback/retry, and new-connection handler replay
-   assertions; then cover concurrent optimistic exhaustion, process-level restart
-   recovery, remote adapter parity, browser parity for typed unavailable/timeout
-   article rendering, cached thread snapshots, comment-form fallback,
-   approved-only reads, moderation, pagination, first-thread identity, and
-   unrelated insert storage error propagation.
+   Retain dispatcher delivery output, four-connection convergence, the written
+   duplicate, delete-before-create, missing-post replay, outbox rollback/retry,
+   and new-connection handler replay assertions; then cover measured optimistic
+   retry count and exhaustion, process-level restart recovery, remote adapter
+   parity, browser parity for typed unavailable/timeout article rendering, cached
+   thread snapshots, comment-form fallback, approved-only reads, moderation,
+   pagination, first-thread identity, and unrelated insert storage error
+   propagation.
 6. **Execute and retain Blog article richtext cutover evidence.** Run the offline
    backfill in default dry-run mode, review its report, apply accepted conversion,
    execute the irreversible migration, reindex/rollback Search, and retain
@@ -594,6 +622,7 @@ should run the relevant subset, including:
 - `cargo test -p rustok-blog --lib services::comment_projection::tests`
 - `cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test event_dispatcher_routes_registered_handler_and_commits_projection -- --exact`
+- `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test concurrent_created_events_converge_without_lost_updates -- --exact`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test`
 - `npm run verify:blog:category-search-reindex`

--- a/crates/rustok-blog/tests/comment_projection_postgres_test.rs
+++ b/crates/rustok-blog/tests/comment_projection_postgres_test.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, io, time::Duration};
+use std::{error::Error, io, sync::Arc, time::Duration};
 
 use rustok_blog::{BlogModule, services::BlogCommentProjectionHandler};
 use rustok_core::{
@@ -9,15 +9,18 @@ use rustok_events::{DomainEvent, EventEnvelope};
 use sea_orm::{
     ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
 };
+use tokio::sync::Barrier;
 use uuid::Uuid;
 
 type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
 
 const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";
+const CONCURRENT_PROJECTION_DELIVERIES: usize = 4;
 
 struct PostgresBlogProjectionTestDb {
     control: DatabaseConnection,
     db: DatabaseConnection,
+    database_url: String,
     schema_name: String,
 }
 
@@ -53,8 +56,15 @@ impl PostgresBlogProjectionTestDb {
         Ok(Some(Self {
             control,
             db,
+            database_url,
             schema_name,
         }))
+    }
+
+    async fn isolated_connection(&self) -> TestResult<DatabaseConnection> {
+        let db = connect(&self.database_url).await?;
+        set_search_path(&db, &self.schema_name).await?;
+        Ok(db)
     }
 
     async fn cleanup(self) -> TestResult<()> {
@@ -138,6 +148,59 @@ async fn event_dispatcher_routes_registered_handler_and_commits_projection() -> 
     assert_eq!(count_outbox_events(&test_db.db).await?, 1);
 
     running.stop();
+    test_db.cleanup().await
+}
+
+#[tokio::test]
+async fn concurrent_created_events_converge_without_lost_updates() -> TestResult<()> {
+    let Some(test_db) = PostgresBlogProjectionTestDb::setup("concurrent_created").await? else {
+        return Ok(());
+    };
+
+    let tenant_id = Uuid::new_v4();
+    let post_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    insert_post(&test_db.db, tenant_id, post_id, actor_id, 0, 1).await?;
+
+    let envelopes = (0..CONCURRENT_PROJECTION_DELIVERIES)
+        .map(|_| comment_created_envelope(tenant_id, actor_id, Uuid::new_v4(), post_id))
+        .collect::<Vec<_>>();
+    let barrier = Arc::new(Barrier::new(envelopes.len()));
+    let mut tasks = Vec::with_capacity(envelopes.len());
+
+    for envelope in envelopes.iter().cloned() {
+        let db = test_db.isolated_connection().await?;
+        let barrier = Arc::clone(&barrier);
+        tasks.push(tokio::spawn(async move {
+            let handler = BlogCommentProjectionHandler::new(db);
+            barrier.wait().await;
+            handler.handle(&envelope).await
+        }));
+    }
+
+    for task in tasks {
+        task.await??;
+    }
+
+    assert_eq!(
+        load_post_state(&test_db.db, tenant_id, post_id).await?,
+        (
+            CONCURRENT_PROJECTION_DELIVERIES as i32,
+            CONCURRENT_PROJECTION_DELIVERIES as i32 + 1,
+        )
+    );
+    for envelope in &envelopes {
+        assert_eq!(count_delivery(&test_db.db, envelope.id).await?, 1);
+    }
+    assert_eq!(
+        count_all_deliveries(&test_db.db).await?,
+        CONCURRENT_PROJECTION_DELIVERIES as i64
+    );
+    assert_eq!(
+        count_outbox_events(&test_db.db).await?,
+        CONCURRENT_PROJECTION_DELIVERIES as i64
+    );
+
     test_db.cleanup().await
 }
 
@@ -413,6 +476,17 @@ async fn count_delivery(
         ))
         .await?
         .expect("delivery count query should return one row");
+    row.try_get("", "count")
+}
+
+async fn count_all_deliveries(db: &DatabaseConnection) -> Result<i64, sea_orm::DbErr> {
+    let row = db
+        .query_one(Statement::from_string(
+            DbBackend::Postgres,
+            "SELECT COUNT(*)::bigint AS count FROM blog_comment_projection_deliveries".to_string(),
+        ))
+        .await?
+        .expect("delivery total query should return one row");
     row.try_get("", "count")
 }
 

--- a/scripts/verify/verify-blog-comments-event-projection.mjs
+++ b/scripts/verify/verify-blog-comments-event-projection.mjs
@@ -43,6 +43,7 @@ const planPath = 'crates/rustok-blog/docs/implementation-plan.md';
 const harnessCommand = 'cargo test -p rustok-blog --lib services::comment_projection::tests';
 const hostRegistrationHarnessCommand = 'cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing';
 const dispatcherHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test event_dispatcher_routes_registered_handler_and_commits_projection -- --exact';
+const concurrencyHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test concurrent_created_events_converge_without_lost_updates -- --exact';
 const postgresHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test';
 const restartHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test';
 const postgresHarnessEnvironment = 'RUSTOK_BLOG_TEST_DATABASE_URL';
@@ -120,7 +121,10 @@ if (handlesStart === -1 || handleStart === -1) {
 
 for (const marker of [
   'const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";',
+  'const CONCURRENT_PROJECTION_DELIVERIES: usize = 4;',
   'struct PostgresBlogProjectionTestDb',
+  'database_url: String',
+  'async fn isolated_connection(&self)',
   'CREATE SCHEMA',
   'DROP SCHEMA IF EXISTS',
   '.max_connections(1)',
@@ -145,6 +149,13 @@ for (const marker of [
   'tokio::time::timeout(Duration::from_secs(5)',
   'count_delivery(db, event_id).await? == 1',
   'event dispatcher did not commit delivery',
+  'async fn concurrent_created_events_converge_without_lost_updates()',
+  'Arc::new(Barrier::new(envelopes.len()))',
+  'let db = test_db.isolated_connection().await?;',
+  'tasks.push(tokio::spawn(async move {',
+  'barrier.wait().await;',
+  'CONCURRENT_PROJECTION_DELIVERIES as i32',
+  'count_all_deliveries(&test_db.db).await?',
   'async fn delete_before_create_stays_non_negative_and_replays_in_order()',
   'DomainEvent::CommentDeleted',
   'async fn missing_post_replay_commits_only_after_source_appears()',
@@ -313,6 +324,24 @@ if (evidence) {
   ) {
     failures.push(`${evidencePath}: dispatcher harness case drift`);
   }
+  const concurrency = evidence.concurrency_harness ?? {};
+  if (
+    concurrency.status !== 'executable_no_run' ||
+    concurrency.runtime_status !== 'not_run' ||
+    concurrency.path !== postgresHarnessPath ||
+    concurrency.environment !== postgresHarnessEnvironment ||
+    concurrency.command !== concurrencyHarnessCommand ||
+    concurrency.isolation !== 'unique_schema_four_independent_connections_barrier' ||
+    concurrency.scope !== 'concurrent_unique_envelopes_same_post_final_counter_delivery_outbox'
+  ) {
+    failures.push(`${evidencePath}: concurrency harness drift`);
+  }
+  if (
+    [...(concurrency.cases ?? [])].join('|') !==
+    'concurrent_created_events_converge_without_lost_updates'
+  ) {
+    failures.push(`${evidencePath}: concurrency harness case drift`);
+  }
   const postgres = evidence.postgres_harness ?? {};
   if (
     postgres.status !== 'executable_no_run' ||
@@ -368,6 +397,7 @@ if (evidence) {
     'non_negative_count',
     'host_registration_routing_harness',
     'postgres_event_dispatcher_delivery',
+    'postgres_concurrent_unique_deliveries',
     'postgres_duplicate_delivery',
     'postgres_out_of_order_delete_create',
     'postgres_missing_post_recovery',
@@ -439,11 +469,13 @@ for (const marker of [
   'services::comment_projection::tests',
   'tests::module_registers_comment_projection_handler_with_host_routing',
   'event_dispatcher_routes_registered_handler_and_commits_projection',
+  'concurrent_created_events_converge_without_lost_updates',
   'comment_projection_postgres_test',
   'comment_projection_restart_postgres_test',
   'RUSTOK_BLOG_TEST_DATABASE_URL',
   'EventBus',
   'EventDispatcher',
+  'independent PostgreSQL connections',
   'process-level restart recovery',
 ]) {
   requireMarker(plan, marker, planPath);
@@ -455,4 +487,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log('Blog comments event projection classifier, registration, dispatcher, PostgreSQL, and restart harnesses are consistent');
+console.log('Blog comments event projection classifier, registration, dispatcher, concurrency, PostgreSQL, and restart harnesses are consistent');

--- a/scripts/verify/verify-blog-comments-event-projection.test.mjs
+++ b/scripts/verify/verify-blog-comments-event-projection.test.mjs
@@ -23,6 +23,8 @@ function fixture({
   missingHostHarness = false,
   missingDispatcherCase = false,
   missingDispatcherWait = false,
+  missingConcurrencyCase = false,
+  missingConcurrencyBarrier = false,
   missingSharedClassifier = false,
   directHandlesClassifier = false,
   missingCounterHarness = false,
@@ -36,6 +38,7 @@ function fixture({
   harnessStatusDrift = false,
   hostHarnessStatusDrift = false,
   dispatcherStatusDrift = false,
+  concurrencyStatusDrift = false,
   postgresStatusDrift = false,
   restartStatusDrift = false,
 } = {}) {
@@ -53,6 +56,7 @@ function fixture({
   const harnessCommand = 'cargo test -p rustok-blog --lib services::comment_projection::tests';
   const hostRegistrationHarnessCommand = 'cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing';
   const dispatcherHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test event_dispatcher_routes_registered_handler_and_commits_projection -- --exact';
+  const concurrencyHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test concurrent_created_events_converge_without_lost_updates -- --exact';
   const postgresHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test';
   const restartHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test';
 
@@ -120,6 +124,20 @@ tokio::time::timeout(Duration::from_secs(5)
 count_delivery(db, event_id).await? == 1
 event dispatcher did not commit delivery
 `;
+    const concurrencySource = missingConcurrencyCase
+      ? ''
+      : `
+const CONCURRENT_PROJECTION_DELIVERIES: usize = 4;
+database_url: String
+async fn isolated_connection(&self)
+async fn concurrent_created_events_converge_without_lost_updates()
+${missingConcurrencyBarrier ? '' : 'Arc::new(Barrier::new(envelopes.len()))'}
+let db = test_db.isolated_connection().await?;
+tasks.push(tokio::spawn(async move {
+barrier.wait().await;
+CONCURRENT_PROJECTION_DELIVERIES as i32
+count_all_deliveries(&test_db.db).await?
+`;
     write(
       root,
       postgresHarnessPath,
@@ -133,6 +151,7 @@ SET search_path TO
 async fn duplicate_delivery_updates_counter_and_outbox_once()
 handler.handle(&envelope).await?;
 ${dispatcherSource}
+${concurrencySource}
 async fn delete_before_create_stays_non_negative_and_replays_in_order()
 DomainEvent::CommentDeleted
 async fn missing_post_replay_commits_only_after_source_appears()
@@ -280,6 +299,16 @@ assert!(!handler.handles(&forum_created));
         scope: 'event_bus_dispatcher_module_registered_handler_transactional_commit',
         cases: ['event_dispatcher_routes_registered_handler_and_commits_projection'],
       },
+      concurrency_harness: {
+        status: concurrencyStatusDrift ? 'executed' : 'executable_no_run',
+        runtime_status: concurrencyStatusDrift ? 'passed' : 'not_run',
+        path: postgresHarnessPath,
+        environment: 'RUSTOK_BLOG_TEST_DATABASE_URL',
+        command: concurrencyHarnessCommand,
+        isolation: 'unique_schema_four_independent_connections_barrier',
+        scope: 'concurrent_unique_envelopes_same_post_final_counter_delivery_outbox',
+        cases: ['concurrent_created_events_converge_without_lost_updates'],
+      },
       postgres_harness: {
         status: postgresStatusDrift ? 'executed' : 'executable_no_run',
         runtime_status: postgresStatusDrift ? 'passed' : 'not_run',
@@ -314,6 +343,7 @@ assert!(!handler.handles(&forum_created));
         { name: 'non_negative_count' },
         { name: 'host_registration_routing_harness' },
         { name: 'postgres_event_dispatcher_delivery' },
+        { name: 'postgres_concurrent_unique_deliveries' },
         { name: 'postgres_duplicate_delivery' },
         { name: 'postgres_out_of_order_delete_create' },
         { name: 'postgres_missing_post_recovery' },
@@ -369,7 +399,7 @@ assert!(!handler.handles(&forum_created));
   write(
     root,
     'crates/rustok-blog/docs/implementation-plan.md',
-    'blog-comments-event-projection.json verify:blog:comments-event-projection test:verify:blog:comments-event-projection source_verified_no_compile services::comment_projection::tests tests::module_registers_comment_projection_handler_with_host_routing event_dispatcher_routes_registered_handler_and_commits_projection comment_projection_postgres_test comment_projection_restart_postgres_test RUSTOK_BLOG_TEST_DATABASE_URL EventBus EventDispatcher process-level restart recovery',
+    'blog-comments-event-projection.json verify:blog:comments-event-projection test:verify:blog:comments-event-projection source_verified_no_compile services::comment_projection::tests tests::module_registers_comment_projection_handler_with_host_routing event_dispatcher_routes_registered_handler_and_commits_projection concurrent_created_events_converge_without_lost_updates comment_projection_postgres_test comment_projection_restart_postgres_test RUSTOK_BLOG_TEST_DATABASE_URL EventBus EventDispatcher independent PostgreSQL connections process-level restart recovery',
   );
 
   return root;
@@ -441,6 +471,20 @@ test('rejects EventDispatcher coverage without durable delivery wait', () => {
   );
 });
 
+test('rejects a missing concurrent projection case', () => {
+  expectRejected(
+    { missingConcurrencyCase: true },
+    /missing async fn concurrent_created_events_converge_without_lost_updates/,
+  );
+});
+
+test('rejects concurrent projection coverage without a shared barrier', () => {
+  expectRejected(
+    { missingConcurrencyBarrier: true },
+    /missing Arc::new\(Barrier::new\(envelopes.len\(\)\)\)/,
+  );
+});
+
 test('rejects project without the shared event classifier', () => {
   expectRejected({ missingSharedClassifier: true }, /missing fn comment_projection_change/);
 });
@@ -500,6 +544,10 @@ test('rejects host registration harness execution promotion without execution', 
 
 test('rejects dispatcher harness execution promotion without execution', () => {
   expectRejected({ dispatcherStatusDrift: true }, /dispatcher harness drift/);
+});
+
+test('rejects concurrency harness execution promotion without execution', () => {
+  expectRejected({ concurrencyStatusDrift: true }, /concurrency harness drift/);
 });
 
 test('rejects PostgreSQL harness execution promotion without execution', () => {


### PR DESCRIPTION
## Summary

- add an env-gated PostgreSQL case with four independent connections and four handler instances targeting one Blog post
- synchronize four unique `comment.created` envelopes behind a shared barrier
- retain final `comment_count = 4`, `version = 5`, four delivery-ledger rows, and four outbox rows
- record a separate `concurrency_harness` in Comments event-projection evidence schema v4
- extend the focused verifier and negative fixture for independent connections, barrier synchronization, convergence assertions, and false execution promotion
- keep Blog registry schema v13 and package command order unchanged
- keep measured retry count, optimistic exhaustion, process-level restart recovery, and all runtime execution pending

## Validation

Not run by request. No verifier, Rust test, compile, PostgreSQL, browser, workflow, or CI command was executed.

Suggested maintainer commands:

```bash
RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test concurrent_created_events_converge_without_lost_updates -- --exact
npm run verify:blog:comments-event-projection
npm run test:verify:blog:comments-event-projection
npm run verify:blog:fba
npm run test:verify:blog:fba
cargo check -p rustok-server --features mod-blog
```