### PR TITLE
feat(index): publish reconciliation runtime

### DIFF
--- a/crates/rustok-index/docs/m6-reconciliation-runtime-composition.md
+++ b/crates/rustok-index/docs/m6-reconciliation-runtime-composition.md
@@ -1,0 +1,83 @@
+# M6 shared reconciliation runtime composition
+
+Status: `source_complete_server_guard_and_execution_pending`
+
+## Scope
+
+This slice publishes one cloneable Index-owned capability around the existing
+`PostgresIndexReconciliationRunner`:
+
+- `SharedIndexReconciliationRuntime::run`
+- `SharedIndexReconciliationRuntime::request_cancel`
+- `materialize_postgres_index_reconciliation_runtime`
+
+The runtime is assembled only from the immutable shared schema/source registries and
+the host database selected during composition. Callers do not receive the database
+connection, source catalog, schema registry, scheduler, or task handle.
+
+## Composition rules
+
+Materialization is fail-closed:
+
+1. a previously published reconciliation runtime returns `AlreadyMaterialized`;
+2. no shared source registry returns `Ok(None)` and publishes no false capability;
+3. a source registry without the shared schema registry returns
+   `MissingSchemaRegistry`;
+4. complete registries publish exactly one `SharedIndexReconciliationRuntime` in
+   `ModuleRuntimeExtensions`.
+
+Materialization performs no database I/O and starts no worker. Database access begins
+only when an authorized host later invokes the bounded runner.
+
+## Preserved runner contract
+
+This slice does not change the existing reconciliation state machine. It preserves:
+
+- bounded page and pass counts;
+- durable `index_jobs` reconciliation ownership;
+- source cursor and completed-pass progression;
+- lease, attempt, heartbeat, yield, cancellation, and terminal fencing;
+- mutation inbox deduplication and monotonic source-version guards;
+- bounded machine-readable failure diagnostics.
+
+## Explicit non-claims
+
+The capability is not yet published by `apps/server` and has no GraphQL, HTTP, CLI,
+admin, MCP, or scheduler transport. Request-bound tenant/actor authorization and
+`modules:manage` admission remain required before any executable host exposes it.
+
+The existing reconciliation runner replays authoritative current-state source
+mutations. This is not yet complete drift repair for rows that are absent from a
+source scan and have no retained owner tombstone. The following remain open:
+
+- authoritative orphan detection and removal;
+- source/index digest comparison;
+- targeted repair planning;
+- locale and partition checkpoint dimensions;
+- automatic scheduling and graceful shutdown;
+- retained PostgreSQL concurrency, restart, cancellation, and recovery evidence.
+
+The canonical M6 reconciliation and drift-repair item therefore remains open.
+
+## Compatibility
+
+- no migration or table-shape change;
+- no source, cursor, mutation, checkpoint, event identity, or schema change;
+- no Product, Channel, or other source-domain dependency added to Index core;
+- no root `lib.rs` re-export while the open dry-run PR owns that file;
+- consumers can use the capability through
+  `rustok_index::infrastructure::reconciliation` until a conflict-free root export is
+  added;
+- no changed-file overlap with open Index PRs #2636, #2639, #2642, #2644, #2648,
+  #2649, or #2652.
+
+## Maintainer validation
+
+Execution is maintainer-owned. Suggested commands were not run by the implementation
+agent:
+
+```bash
+cargo test -p rustok-index infrastructure::reconciliation::tests -- --nocapture
+cargo check -p rustok-index --all-targets
+node scripts/verify/verify-index-reconciliation-runtime.mjs
+```

--- a/crates/rustok-index/src/infrastructure/mod.rs
+++ b/crates/rustok-index/src/infrastructure/mod.rs
@@ -1,1 +1,2 @@
 pub mod postgres;
+pub mod reconciliation;

--- a/crates/rustok-index/src/infrastructure/reconciliation.rs
+++ b/crates/rustok-index/src/infrastructure/reconciliation.rs
@@ -1,0 +1,267 @@
+use std::{fmt, sync::Arc};
+
+use rustok_core::ModuleRuntimeExtensions;
+use sea_orm::DatabaseConnection;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::{
+    IndexReconciliationCancelOutcome, IndexReconciliationRunError,
+    IndexReconciliationRunOutcome, IndexReconciliationRunRequest,
+    PostgresIndexReconciliationRunner, SharedIndexSchemaRegistry, SharedIndexSourceRegistry,
+};
+
+/// Cloneable operator capability for bounded Index source reconciliation.
+///
+/// Construction remains Index-owned so hosts publish one canonical runner assembled from the
+/// complete immutable schema/source registries. Consumers receive only bounded run and cancel
+/// operations; the database connection and registry internals remain private.
+#[derive(Clone)]
+pub struct SharedIndexReconciliationRuntime {
+    runner: Arc<PostgresIndexReconciliationRunner>,
+}
+
+impl SharedIndexReconciliationRuntime {
+    fn new(runner: PostgresIndexReconciliationRunner) -> Self {
+        Self {
+            runner: Arc::new(runner),
+        }
+    }
+
+    pub async fn run(
+        &self,
+        request: IndexReconciliationRunRequest,
+    ) -> Result<IndexReconciliationRunOutcome, IndexReconciliationRunError> {
+        self.runner.run(request).await
+    }
+
+    pub async fn request_cancel(
+        &self,
+        tenant_id: Uuid,
+        job_id: Uuid,
+    ) -> Result<IndexReconciliationCancelOutcome, IndexReconciliationRunError> {
+        self.runner.request_cancel(tenant_id, job_id).await
+    }
+}
+
+impl fmt::Debug for SharedIndexReconciliationRuntime {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SharedIndexReconciliationRuntime")
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum IndexReconciliationRuntimeCompositionError {
+    #[error("shared Index reconciliation runtime is already materialized")]
+    AlreadyMaterialized,
+    #[error("shared Index source registry exists without the shared schema registry")]
+    MissingSchemaRegistry,
+}
+
+/// Materializes the canonical PostgreSQL-backed reconciliation runtime.
+///
+/// An absent source registry returns `Ok(None)` and never publishes a false capability. The
+/// function performs no database I/O, starts no scheduler, and makes no operator-authorization or
+/// drift-repair-completeness claim. Those checks remain at invocation and host boundaries.
+pub fn materialize_postgres_index_reconciliation_runtime(
+    extensions: &mut ModuleRuntimeExtensions,
+    db: DatabaseConnection,
+) -> Result<Option<SharedIndexReconciliationRuntime>, IndexReconciliationRuntimeCompositionError>
+{
+    if extensions.contains::<SharedIndexReconciliationRuntime>() {
+        return Err(IndexReconciliationRuntimeCompositionError::AlreadyMaterialized);
+    }
+
+    let Some(sources) = extensions.get::<SharedIndexSourceRegistry>().cloned() else {
+        return Ok(None);
+    };
+    let schemas = extensions
+        .get::<SharedIndexSchemaRegistry>()
+        .cloned()
+        .ok_or(IndexReconciliationRuntimeCompositionError::MissingSchemaRegistry)?;
+
+    let runtime = SharedIndexReconciliationRuntime::new(PostgresIndexReconciliationRunner::new(
+        db,
+        sources,
+        schemas.shared(),
+    ));
+    extensions.insert(runtime.clone());
+    Ok(Some(runtime))
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use rustok_core::ModuleRuntimeExtensions;
+    use sea_orm::Database;
+
+    use crate::{
+        EntityName, FieldCardinality, FieldName, IndexField, IndexSchema, IndexSource,
+        IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest, IndexSourcePage,
+        IndexSourceScanRequest, IndexValueType, LocaleMode, ModuleName, SchemaRef, SchemaVersion,
+        SharedIndexSchemaRegistry, SharedIndexSourceRegistry, materialize_index_schema_registry,
+        materialize_index_source_registry, register_index_schema_source, register_index_source,
+    };
+
+    use super::{
+        IndexReconciliationRuntimeCompositionError, SharedIndexReconciliationRuntime,
+        materialize_postgres_index_reconciliation_runtime,
+    };
+
+    struct NoopSource;
+
+    #[async_trait]
+    impl IndexSource for NoopSource {
+        async fn scan(
+            &self,
+            request: IndexSourceScanRequest,
+        ) -> Result<IndexSourcePage, IndexSourceFailure> {
+            Ok(IndexSourcePage::new(&request, Vec::new(), None)
+                .expect("empty final reconciliation page should be valid"))
+        }
+
+        async fn load(
+            &self,
+            request: IndexSourceLoadRequest,
+        ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+            Ok(IndexSourceLoadBatch::new(&request, Vec::new())
+                .expect("empty targeted load should be valid"))
+        }
+    }
+
+    fn schema() -> IndexSchema {
+        IndexSchema {
+            reference: SchemaRef {
+                module: ModuleName::new("reconciliation-owner").unwrap(),
+                entity: EntityName::new("item").unwrap(),
+                version: SchemaVersion::INITIAL,
+            },
+            locale_mode: LocaleMode::None,
+            fields: vec![IndexField {
+                name: FieldName::new("id").unwrap(),
+                value_type: IndexValueType::Uuid,
+                cardinality: FieldCardinality::One,
+                nullable: false,
+                selectable: true,
+                filterable: true,
+                sortable: true,
+            }],
+            links: Vec::new(),
+        }
+    }
+
+    fn source_extensions() -> ModuleRuntimeExtensions {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        let schema = schema();
+        register_index_schema_source(
+            &mut extensions,
+            "reconciliation_owner",
+            schema.clone(),
+        )
+        .unwrap();
+        register_index_source(
+            &mut extensions,
+            "reconciliation_owner",
+            "reconciliation-owner-primary",
+            [schema.reference],
+            NoopSource,
+        )
+        .unwrap();
+        extensions
+    }
+
+    async fn connection() -> sea_orm::DatabaseConnection {
+        Database::connect("sqlite::memory:")
+            .await
+            .expect("test connection should initialize")
+    }
+
+    #[tokio::test]
+    async fn missing_source_registry_does_not_publish_false_reconciliation_runtime() {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        register_index_schema_source(&mut extensions, "reconciliation_owner", schema()).unwrap();
+        let schemas = materialize_index_schema_registry(&extensions)
+            .unwrap()
+            .expect("schema registry");
+        extensions.insert(schemas);
+
+        let runtime = materialize_postgres_index_reconciliation_runtime(
+            &mut extensions,
+            connection().await,
+        )
+        .expect("missing source registry should be accepted");
+        assert!(runtime.is_none());
+        assert!(!extensions.contains::<SharedIndexReconciliationRuntime>());
+    }
+
+    #[tokio::test]
+    async fn source_registry_without_shared_schema_registry_fails_closed() {
+        let mut extensions = source_extensions();
+        let sources = materialize_index_source_registry(&extensions)
+            .unwrap()
+            .expect("source registry");
+        extensions.insert(sources);
+
+        let error = materialize_postgres_index_reconciliation_runtime(
+            &mut extensions,
+            connection().await,
+        )
+        .expect_err("partial reconciliation composition must fail");
+        assert_eq!(
+            error,
+            IndexReconciliationRuntimeCompositionError::MissingSchemaRegistry
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_registries_materialize_one_shared_reconciliation_runtime() {
+        let mut extensions = source_extensions();
+        let schemas = materialize_index_schema_registry(&extensions)
+            .unwrap()
+            .expect("schema registry");
+        let sources = materialize_index_source_registry(&extensions)
+            .unwrap()
+            .expect("source registry");
+        extensions.insert(schemas);
+        extensions.insert(sources);
+        assert!(extensions.contains::<SharedIndexSchemaRegistry>());
+        assert!(extensions.contains::<SharedIndexSourceRegistry>());
+
+        let runtime = materialize_postgres_index_reconciliation_runtime(
+            &mut extensions,
+            connection().await,
+        )
+        .expect("reconciliation runtime should materialize")
+        .expect("complete registries should publish a runtime");
+        assert!(extensions.contains::<SharedIndexReconciliationRuntime>());
+        assert!(format!("{runtime:?}").contains("SharedIndexReconciliationRuntime"));
+    }
+
+    #[tokio::test]
+    async fn duplicate_reconciliation_runtime_materialization_fails_closed() {
+        let mut extensions = source_extensions();
+        let schemas = materialize_index_schema_registry(&extensions)
+            .unwrap()
+            .expect("schema registry");
+        let sources = materialize_index_source_registry(&extensions)
+            .unwrap()
+            .expect("source registry");
+        extensions.insert(schemas);
+        extensions.insert(sources);
+        materialize_postgres_index_reconciliation_runtime(&mut extensions, connection().await)
+            .expect("first materialization")
+            .expect("runtime");
+
+        let error = materialize_postgres_index_reconciliation_runtime(
+            &mut extensions,
+            connection().await,
+        )
+        .expect_err("duplicate reconciliation materialization must fail");
+        assert_eq!(
+            error,
+            IndexReconciliationRuntimeCompositionError::AlreadyMaterialized
+        );
+    }
+}

--- a/scripts/verify/verify-index-reconciliation-runtime.mjs
+++ b/scripts/verify/verify-index-reconciliation-runtime.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-reconciliation-runtime] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+requireMarkers('crates/rustok-index/src/infrastructure/mod.rs', [
+  'pub mod postgres;',
+  'pub mod reconciliation;',
+]);
+
+const runtimePath = 'crates/rustok-index/src/infrastructure/reconciliation.rs';
+const runtime = requireMarkers(runtimePath, [
+  'pub struct SharedIndexReconciliationRuntime',
+  'runner: Arc<PostgresIndexReconciliationRunner>',
+  'pub async fn run(',
+  'pub async fn request_cancel(',
+  'pub enum IndexReconciliationRuntimeCompositionError',
+  'AlreadyMaterialized',
+  'MissingSchemaRegistry',
+  'pub fn materialize_postgres_index_reconciliation_runtime(',
+  'extensions.contains::<SharedIndexReconciliationRuntime>()',
+  'extensions.get::<SharedIndexSourceRegistry>().cloned()',
+  'extensions.get::<SharedIndexSchemaRegistry>()',
+  'PostgresIndexReconciliationRunner::new(',
+  'extensions.insert(runtime.clone());',
+  'missing_source_registry_does_not_publish_false_reconciliation_runtime',
+  'source_registry_without_shared_schema_registry_fails_closed',
+  'complete_registries_materialize_one_shared_reconciliation_runtime',
+  'duplicate_reconciliation_runtime_materialization_fails_closed',
+]);
+
+for (const forbidden of [
+  'tokio::spawn',
+  'std::thread::spawn',
+  'pub fn database',
+  'pub fn db(',
+  'pub fn sources(',
+  'pub fn schema_registry(',
+  'GraphQL',
+  'Http',
+  'Mcp',
+]) {
+  if (runtime.includes(forbidden)) {
+    fail(`${runtimePath} exposes or starts forbidden capability: ${forbidden}`);
+  }
+}
+
+const materializerStart = runtime.indexOf(
+  'pub fn materialize_postgres_index_reconciliation_runtime(',
+);
+const testsStart = runtime.indexOf('\n#[cfg(test)]', materializerStart);
+if (materializerStart < 0 || testsStart < 0) {
+  fail(`${runtimePath} does not contain a bounded materializer block`);
+}
+const materializer = runtime.slice(materializerStart, testsStart);
+for (const forbidden of [
+  '.begin().await',
+  '.execute(',
+  '.query_one(',
+  '.query_all(',
+  '.run(',
+  '.request_cancel(',
+]) {
+  if (materializer.includes(forbidden)) {
+    fail(`materializer performs forbidden runtime/database work: ${forbidden}`);
+  }
+}
+
+requireMarkers('crates/rustok-index/docs/m6-reconciliation-runtime-composition.md', [
+  'Status: `source_complete_server_guard_and_execution_pending`',
+  '`SharedIndexReconciliationRuntime::run`',
+  '`SharedIndexReconciliationRuntime::request_cancel`',
+  '`materialize_postgres_index_reconciliation_runtime`',
+  'publishes no false capability',
+  'Materialization performs no database I/O and starts no worker',
+  'not yet published by `apps/server`',
+  'not yet complete drift repair',
+  'The canonical M6 reconciliation and drift-repair item therefore remains open',
+  'Execution is maintainer-owned',
+]);
+
+console.log('[verify-index-reconciliation-runtime] OK');


### PR DESCRIPTION
## Summary

- add `SharedIndexReconciliationRuntime` as a cloneable Index-owned capability over the existing `PostgresIndexReconciliationRunner`
- expose only bounded `run` and `request_cancel` operations
- add `materialize_postgres_index_reconciliation_runtime` over the complete immutable shared source/schema registries and host database
- return `Ok(None)` and publish no false capability when no shared source registry exists
- fail closed when a source registry exists without the shared schema registry
- reject duplicate runtime materialization
- keep database connections, registries, scheduler ownership, and task handles private
- add focused composition tests, documentation, and a standalone fail-closed verifier

## Composition semantics

The materializer performs no database I/O and starts no task. It follows the same capability-publication boundary as the existing query/replay runtimes:

1. an already-published reconciliation runtime returns `AlreadyMaterialized`;
2. an absent source registry returns `Ok(None)`;
3. a source registry without the shared schema registry returns `MissingSchemaRegistry`;
4. complete registries publish exactly one `SharedIndexReconciliationRuntime` in `ModuleRuntimeExtensions`.

The runtime wraps the canonical PostgreSQL reconciliation runner and forwards only:

- `run(IndexReconciliationRunRequest)`
- `request_cancel(tenant_id, job_id)`

It does not expose the database connection, source catalog, schema registry, or a worker-spawn handle.

## Preserved reconciliation behavior

This slice does not change the existing reconciliation SQL/state machine. It preserves:

- bounded page and pass counts
- durable reconciliation job ownership
- source cursor and completed-pass progression
- lease, attempt, heartbeat, yield, cancellation, and terminal fencing
- mutation inbox deduplication and monotonic source-version guards
- bounded machine-readable failure diagnostics

## Scope boundaries

- no `apps/server` publication or request-bound `modules:manage` guard yet
- no GraphQL, HTTP, CLI, admin, MCP, or scheduler transport
- no automatic host scheduling or graceful task shutdown
- no source/index digest comparison
- no orphan detection/removal for rows absent from a source scan without tombstones
- no targeted drift-repair planner
- no locale/partition reconciliation checkpoint dimensions
- no retained PostgreSQL concurrency/restart/cancellation/recovery evidence

The current runner replays authoritative current-state mutations, but it is not yet complete drift repair. The canonical M6 reconciliation and drift-repair item therefore remains open.

## Compatibility

- no migration or table-shape change
- no source, cursor, mutation, checkpoint, event identity, or schema change
- no Product, Channel, or other source-domain dependency added to Index core
- no root `lib.rs` re-export while PR #2642 owns that file
- the capability is available through `rustok_index::infrastructure::reconciliation`
- no changed-file overlap with open Index PRs #2636, #2639, #2642, #2644, #2648, #2649, or #2652

## Validation

Not run per maintainer instruction:

- Cargo formatting/checks/tests/Clippy
- JavaScript verifier
- PostgreSQL reconciliation execution
- CI workflows

Suggested maintainer commands:

```bash
cargo test -p rustok-index infrastructure::reconciliation::tests -- --nocapture
cargo check -p rustok-index --all-targets
node scripts/verify/verify-index-reconciliation-runtime.mjs
```

## Branch state

Merge base: `main` at `733359d7102013fa91e5fc7df0dbd2ac8f919e06`
Branch: `agent/index-m6-reconciliation-runtime-20260731`

`main` subsequently advanced through unrelated Tax diagnostic and Blog projection-concurrency harness commits. The connector produced four sequential commits; squash merge is recommended after maintainer validation.