### PR TITLE
fix(commerce): sanitize promotion client diagnostics

### DIFF
--- a/crates/rustok-commerce/admin/src/transport/promotion_client_error_safety.rs
+++ b/crates/rustok-commerce/admin/src/transport/promotion_client_error_safety.rs
@@ -9,6 +9,12 @@ const COMMERCE_ADMIN_PROMOTION_CLIENT_BOUNDARY: &str =
 const COMMERCE_ADMIN_PROMOTION_CLIENT_PUBLIC_MESSAGE: &str =
     "Commerce admin promotion request could not be completed";
 
+struct PromotionClientErrorFacts {
+    error_variant: &'static str,
+    message_present: bool,
+    message_length: usize,
+}
+
 pub(super) struct PromotionClientErrorContext {
     operation: &'static str,
     correlation_id: String,
@@ -35,8 +41,11 @@ impl PromotionClientErrorContext {
     }
 
     pub(super) fn map_error(&self, error: ApiError) -> ApiError {
+        let error_facts = promotion_client_error_facts(&error);
         tracing::error!(
-            raw_error = ?error,
+            error_variant = error_facts.error_variant,
+            error_message_present = error_facts.message_present,
+            error_message_length = error_facts.message_length,
             owner = COMMERCE_ADMIN_PROMOTION_CLIENT_OWNER,
             owner_operation = self.operation,
             correlation_id = %self.correlation_id,
@@ -49,6 +58,19 @@ impl PromotionClientErrorContext {
         );
 
         ApiError::ServerFn(COMMERCE_ADMIN_PROMOTION_CLIENT_PUBLIC_MESSAGE.to_string())
+    }
+}
+
+fn promotion_client_error_facts(error: &ApiError) -> PromotionClientErrorFacts {
+    let (error_variant, message) = match error {
+        ApiError::Graphql(message) => ("graphql", message),
+        ApiError::ServerFn(message) => ("server_fn", message),
+    };
+
+    PromotionClientErrorFacts {
+        error_variant,
+        message_present: !message.trim().is_empty(),
+        message_length: message.chars().count(),
     }
 }
 

--- a/crates/rustok-commerce/contracts/evidence/admin-promotion-client-transport-error-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/admin-promotion-client-transport-error-safety-source-review.json
@@ -1,12 +1,13 @@
 {
   "status": "commerce_admin_promotion_client_transport_error_safety_source_reviewed_unvalidated",
-  "reviewed_at": "2026-07-30",
+  "reviewed_at": "2026-07-31",
   "review_scope": [
     "crates/rustok-commerce/admin/src/transport/mod.rs",
     "crates/rustok-commerce/admin/src/transport/promotion.rs",
     "crates/rustok-commerce/admin/src/transport/promotion_client_error_safety.rs",
     "crates/rustok-commerce/admin/src/transport/native_server_adapter.rs",
-    "crates/rustok-commerce/admin/src/transport/native_server_adapter_ssr.rs"
+    "crates/rustok-commerce/admin/src/transport/native_server_adapter_ssr.rs",
+    "scripts/verify/verify-commerce-admin-promotion-client-transport-error-safety.mjs"
   ],
   "findings": {
     "two_promotion_facade_operations_mapped": true,
@@ -17,14 +18,19 @@
     "order_change_transport_unchanged": true,
     "request_response_dtos_preserved": true,
     "static_public_message_after_native_return": true,
-    "original_native_error_private_to_structured_diagnostics": true,
+    "complete_native_error_not_logged": true,
+    "native_error_message_not_logged": true,
+    "native_error_variant_logged": true,
+    "native_error_message_presence_and_length_logged": true,
     "safe_request_shape_logging_only": true,
+    "ssr_promotion_consumer_diagnostic_cleanup_remains_open": true,
     "broad_ecommerce_mapper_cleanup_remains_open": true
   },
   "non_claims": [
     "No test or verifier was executed",
     "No Cargo compilation or formatting was executed",
     "No hydrate, SSR, browser, or mounted promotion failure was exercised",
+    "No server-side promotion diagnostic hardening is claimed by this client-only slice",
     "No Commerce FFA or FBA status was promoted"
   ]
 }

--- a/crates/rustok-commerce/contracts/evidence/admin-promotion-client-transport-error-safety-source.json
+++ b/crates/rustok-commerce/contracts/evidence/admin-promotion-client-transport-error-safety-source.json
@@ -1,6 +1,6 @@
 {
   "status": "commerce_admin_promotion_client_transport_error_safety_source_unvalidated",
-  "reviewed_at": "2026-07-30",
+  "reviewed_at": "2026-07-31",
   "boundary": "commerce_admin_promotion_client_transport",
   "public_error_type": "ApiError",
   "public_message": "Commerce admin promotion request could not be completed",
@@ -9,9 +9,12 @@
     "apply_cart_promotion"
   ],
   "confirmed_gap": {
-    "native_api_error_returned_directly": true,
-    "native_error_payload_type": "ApiError::ServerFn(String)",
-    "facade_mapping_before_slice": false
+    "native_api_error_returned_directly_before_original_slice": true,
+    "native_error_payload_types": [
+      "ApiError::Graphql(String)",
+      "ApiError::ServerFn(String)"
+    ],
+    "complete_native_error_logged_before_this_slice": true
   },
   "source_contract": {
     "native_adapters_changed": false,
@@ -23,7 +26,11 @@
     "context_created_before_native_call": true,
     "raw_native_error_public": false,
     "static_public_message": true,
-    "original_error_logged_privately": true,
+    "original_error_logged_privately": false,
+    "original_error_shape_logged": true,
+    "error_variant_logged": true,
+    "error_message_length_only": true,
+    "raw_native_error_logged": false,
     "per_call_correlation_logging": true,
     "safe_request_shape_only": true,
     "cart_id_values_logged": false,
@@ -45,6 +52,7 @@
     "Run the existing promotion native error-safety verifier",
     "Compile the Commerce admin package for hydrate and ssr profiles",
     "Retain mounted preview and apply failure evidence",
+    "Remove raw framework and owner error values from the SSR promotion consumer diagnostics in a separate source slice",
     "Continue the broad ecommerce mapper cleanup in other owner and transport boundaries"
   ]
 }

--- a/crates/rustok-commerce/docs/admin-promotion-client-transport-error-safety.md
+++ b/crates/rustok-commerce/docs/admin-promotion-client-transport-error-safety.md
@@ -5,7 +5,9 @@ Status: **source-ready / unvalidated**
 ## Scope
 
 This source slice covers the final Commerce Admin promotion facade in
-`crates/rustok-commerce/admin/src/transport/promotion.rs`.
+`crates/rustok-commerce/admin/src/transport/promotion.rs` and its client error
+policy in
+`crates/rustok-commerce/admin/src/transport/promotion_client_error_safety.rs`.
 
 Covered operations:
 
@@ -14,31 +16,36 @@ Covered operations:
 
 ## Confirmed gap
 
-The mounted SSR promotion adapter already owns correlation-aware context and cart
-promotion `PortError` mapping. The public facade nevertheless returned the shared
-native `ApiError` directly. That type stores `ServerFn(String)`, so framework,
-serialization, transport, or unexpected server-function text could still become
-the displayed Admin error after leaving the native adapter.
+The mounted SSR promotion adapter owns context and cart-promotion `PortError`
+mapping. The public facade then converts a final returned `ApiError` to one static
+Admin message. Before this follow-up, that final mapping also wrote the complete
+`ApiError` into structured diagnostics.
+
+Both `ApiError::Graphql(String)` and `ApiError::ServerFn(String)` can contain
+framework, serialization, transport, GraphQL, or unexpected server-function text.
+That text is not required to correlate or classify the facade failure.
 
 ## Source policy
 
-Each promotion facade operation now creates a `PromotionClientErrorContext` before
-the unchanged native adapter call and maps only a final returned `ApiError`.
+Each promotion facade operation creates a `PromotionClientErrorContext` before the
+unchanged native adapter call and maps only a final returned `ApiError`.
 
-The original typed native error is retained only in structured diagnostics with:
+The client diagnostic now records only:
 
 - the Commerce Admin promotion consumer and exact operation;
 - a per-call correlation id;
-- the client transport boundary and a stable error code;
+- the client transport boundary and stable error code;
 - cart-id presence and character length;
-- promotion-payload presence.
+- promotion-payload presence;
+- the typed native error variant (`graphql` or `server_fn`);
+- native error-message presence and character length.
 
-The cart id and promotion draft values, including scope, kind, source id, line item,
-discount, amount, metadata, and any other payload fields, are not logged by this
-client boundary.
+The complete native error and its message are not logged. Cart-id and promotion
+draft values, including scope, kind, source id, line item, discount, amount,
+metadata, and any other payload fields, are also not logged by this boundary.
 
-The existing public error contract remains `ApiError`, but preview and apply now
-return the same static final message:
+The existing public error contract remains `ApiError`, and preview/apply continue
+to return the same static final message:
 
 `Commerce admin promotion request could not be completed`
 
@@ -62,6 +69,11 @@ formatting, workflows, CI, hydrate compilation, SSR compilation, browser behavio
 and mounted preview/apply failure behavior were not executed by this implementation
 agent.
 
-The broad ecommerce mapper-cleanup item remains open for tax, payment,
-fulfillment, order, remaining promotion paths, and other non-`PortError` public
-envelopes.
+The SSR promotion consumer still records raw framework extraction and owner
+`PortError` values together with full tenant, user, cart, channel, and locale
+identities. That server-side diagnostic cleanup is explicitly outside this
+client-only slice and remains open.
+
+The broad ecommerce mapper-cleanup item remains open for the SSR promotion
+consumer, payment, fulfillment, order, inventory, customer, remaining tax and
+promotion paths, and other non-`PortError` public envelopes.

--- a/scripts/verify/verify-commerce-admin-promotion-client-transport-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-promotion-client-transport-error-safety.mjs
@@ -23,7 +23,7 @@ const requireCount = (source, value, expected, label) => {
 };
 
 function functionBody(source, functionName) {
-  const match = new RegExp(`pub\\s+async\\s+fn\\s+${functionName}\\s*\\(`).exec(source);
+  const match = new RegExp(`(?:pub\\(super\\)\\s+)?(?:pub\\s+)?(?:async\\s+)?fn\\s+${functionName}\\s*\\(`).exec(source);
   if (!match) {
     failures.push(`missing function ${functionName}`);
     return "";
@@ -130,10 +130,14 @@ for (const marker of [
   'const COMMERCE_ADMIN_PROMOTION_CLIENT_BOUNDARY: &str =',
   '"commerce_admin_promotion_client_transport"',
   '"Commerce admin promotion request could not be completed"',
+  "struct PromotionClientErrorFacts",
   "pub(super) struct PromotionClientErrorContext",
   'Self::new("preview_cart_promotion", cart_id)',
   'Self::new("apply_cart_promotion", cart_id)',
-  "raw_error = ?error",
+  "let error_facts = promotion_client_error_facts(&error);",
+  "error_variant = error_facts.error_variant",
+  "error_message_present = error_facts.message_present",
+  "error_message_length = error_facts.message_length",
   "owner_operation = self.operation",
   "correlation_id = %self.correlation_id",
   "cart_id_present = self.cart_id_length > 0",
@@ -142,11 +146,26 @@ for (const marker of [
   'code = "commerce.admin_promotion_client_transport_failed"',
   "boundary = COMMERCE_ADMIN_PROMOTION_CLIENT_BOUNDARY",
   "ApiError::ServerFn(COMMERCE_ADMIN_PROMOTION_CLIENT_PUBLIC_MESSAGE.to_string())",
+  "fn promotion_client_error_facts(error: &ApiError)",
+  'ApiError::Graphql(message) => ("graphql", message)',
+  'ApiError::ServerFn(message) => ("server_fn", message)',
+  "message_present: !message.trim().is_empty()",
+  "message_length: message.chars().count()",
 ]) {
   requireText(safety, marker, `${paths.safety}: safe final mapping`);
 }
 
+const mapperBody = functionBody(safety, "map_error");
+requireText(
+  mapperBody,
+  "promotion_client_error_facts(&error)",
+  `${paths.safety}: error shape must be captured before logging`,
+);
 for (const forbidden of [
+  "raw_error = ?error",
+  "error = ?error",
+  "error = %error",
+  "message = %",
   "cart_id = %",
   "cart_id = ?",
   "payload = ?",
@@ -213,7 +232,11 @@ for (const [key, expected] of Object.entries({
   context_created_before_native_call: true,
   raw_native_error_public: false,
   static_public_message: true,
-  original_error_logged_privately: true,
+  original_error_logged_privately: false,
+  original_error_shape_logged: true,
+  error_variant_logged: true,
+  error_message_length_only: true,
+  raw_native_error_logged: false,
   per_call_correlation_logging: true,
   safe_request_shape_only: true,
   cart_id_values_logged: false,
@@ -247,6 +270,11 @@ requireText(
   `${paths.doc}: static public message`,
 );
 requireText(
+  doc,
+  "The complete native error and its message are not logged",
+  `${paths.doc}: raw diagnostic removal`,
+);
+requireText(
   commercePlan,
   "Finish correlation-safe mapper cleanup",
   `${paths.commercePlan}: broad ecommerce cleanup remains open`,
@@ -259,5 +287,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Commerce Admin promotion preview/apply failures use a correlation-safe static final envelope; execution evidence remains open",
+  "Commerce Admin promotion preview/apply failures use a correlation-safe static final envelope and shape-only diagnostics; execution evidence remains open",
 );


### PR DESCRIPTION
## Summary

- continue the open ecommerce correlation-safe mapper cleanup with a focused Commerce Admin promotion client-boundary slice
- replace complete `ApiError` logging in `PromotionClientErrorContext` with typed error-variant plus message presence/length facts
- preserve per-call correlation, safe cart-id shape, payload presence, stable diagnostic code, and boundary attribution
- preserve the `ApiError` result contract and the static public message `Commerce admin promotion request could not be completed`
- leave the default/SSR native adapters, mounted endpoints, permission/input policy, owner calls, DTOs, and order-change transport unchanged
- update the focused verifier, documentation, source evidence, and source-review evidence

## Confirmed gap

The final promotion facade already replaced returned native errors with a static public envelope, but its structured event still included the complete `ApiError`. Both `ApiError::Graphql(String)` and `ApiError::ServerFn(String)` may carry framework, GraphQL, serialization, transport, or unexpected server-function text that is not required for correlation or classification.

## Scope boundary

This PR is client-only. The SSR promotion consumer still logs raw framework extraction errors and complete owner `PortError` plus full tenant, actor, cart, channel, and locale identities. That server-side cleanup remains the next separate slice, and the broad ecommerce mapper-cleanup item stays open.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-commerce-admin-promotion-client-transport-error-safety.mjs
node scripts/verify/verify-commerce-admin-promotion-native-error-safety.mjs
cargo check -p rustok-commerce-admin --all-features
```

## Branch state

The branch is based on current `main` at `9a0d9d94053069257221eb4b9e2cbc881f470e5f`, is five commits ahead and zero behind, and changes exactly five Commerce Admin promotion client source/docs/evidence/verifier files. Squash merge is intended.