### PR TITLE
test(blog): add projection process restart harness

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json
@@ -87,8 +87,23 @@
     "environment": "RUSTOK_BLOG_TEST_DATABASE_URL",
     "command": "RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test",
     "isolation": "unique_schema_new_connection",
+    "scope": "same_process_new_connection_and_handler",
     "cases": [
       "restarted_handler_reuses_delivery_ledger_without_reapplying_counter"
+    ]
+  },
+  "process_restart_harness": {
+    "status": "executable_no_run",
+    "runtime_status": "not_run",
+    "path": "crates/rustok-blog/tests/comment_projection_restart_postgres_test.rs",
+    "environment": "RUSTOK_BLOG_TEST_DATABASE_URL",
+    "command": "RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test restarted_process_reuses_delivery_ledger_without_reapplying_counter -- --exact",
+    "isolation": "unique_schema_two_sequential_test_processes_same_envelope",
+    "scope": "os_process_reinstantiation_durable_delivery_replay",
+    "non_claim": "does_not_prove_full_server_host_restart_or_record_execution",
+    "cases": [
+      "restarted_process_reuses_delivery_ledger_without_reapplying_counter",
+      "process_restart_worker_applies_envelope_from_env"
     ]
   },
   "cases": [
@@ -157,6 +172,10 @@
       "expected": "the retained restart target opens a new database connection and handler over the same schema, replays the same envelope, and expects one durable application"
     },
     {
+      "name": "postgres_process_restart_replay",
+      "expected": "the retained process target launches the integration-test executable twice in sequence, reconstructs the same envelope id in each child process, and expects one counter transition, one delivery row, and one outbox row"
+    },
+    {
       "name": "module_listener_registration",
       "expected": "Blog registers BlogCommentProjectionHandler through the module event-listener registry"
     }
@@ -167,12 +186,12 @@
     "execute the env-gated PostgreSQL dispatcher case and retain EventBus/EventDispatcher delivery output",
     "execute the env-gated PostgreSQL concurrency case and retain four-connection convergence output",
     "execute the env-gated PostgreSQL comment_projection_postgres_test target and retain its output",
-    "execute the env-gated PostgreSQL comment_projection_restart_postgres_test target and retain its output",
+    "execute the env-gated same-process restart case and retain its output",
+    "execute the env-gated process-restart case and retain both child-process exits plus final durable assertions",
     "retain proof that duplicate and out-of-order comment.created/comment.deleted deliveries match the source harness assertions",
     "retain proof that the counter, delivery ledger, and BlogPostUpdated outbox row commit or roll back together",
     "retain missing-post retry and later recovery evidence",
-    "retain restarted-handler replay evidence across a new database connection",
     "retain explicit optimistic retry-count and exhaustion evidence",
-    "retain process restart recovery evidence"
+    "retain full server-host restart recovery evidence separately from the test-process harness"
   ]
 }

--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -156,21 +156,35 @@ unavailable. The suggested command is
 `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test`.
 The target is registered as `executable_no_run`; no PostgreSQL result is recorded.
 
-The retained restart target is
+The retained same-process restart target is
 `crates/rustok-blog/tests/comment_projection_restart_postgres_test.rs`. It applies
 one envelope, drops the first handler, opens a new PostgreSQL connection against
 the same isolated schema, creates a new handler, and replays the same envelope.
 The written assertions require one counter transition, one durable delivery row,
 and one outbox row. Its suggested command is
 `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test`.
-This target is also `executable_no_run`; it represents handler/connection
-re-instantiation, not retained proof of a process or host restart.
+This target is `executable_no_run`; it represents handler/connection
+re-instantiation inside one test process.
+
+The filtered process restart target is
+`restarted_process_reuses_delivery_ledger_without_reapplying_counter` in the same
+integration-test file. Its parent creates one isolated schema and envelope, then
+launches the integration-test executable as two sequential OS test processes.
+Each child runs only `process_restart_worker_applies_envelope_from_env`, rebuilds
+the same envelope ID from private test environment variables, creates a fresh
+PostgreSQL connection and handler, and exits before the next child starts. Final
+assertions require one counter transition, one delivery row, and one outbox row.
+Its suggested command is
+`RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test restarted_process_reuses_delivery_ledger_without_reapplying_counter -- --exact`.
+The target is `executable_no_run`; it proves a written OS process boundary, not a
+full application server-host restart, and no execution result is recorded.
 
 Exact commands `verify:blog:comments-event-projection` and
 `test:verify:blog:comments-event-projection` run after the Comments port gate in
 the Blog FBA chains. Overall status remains `source_verified_no_compile`;
-measured optimistic retry-count/exhaustion, dispatcher/PostgreSQL execution,
-process-level restart recovery, and all other execution evidence remain pending.
+measured optimistic retry-count/exhaustion, dispatcher/PostgreSQL/process-target
+execution, full server-host restart recovery, and all other runtime evidence
+remain pending.
 
 Blog categories use the exclusive `blog_categories:*` permission resource.
 `CategoryService::new(db, event_bus)` is the only owner constructor. Category
@@ -188,7 +202,7 @@ Exceeded responses expose matching GraphQL `retryAfter` and HTTP `Retry-After`;
 backend failure is fail-closed. The retained no-compile harness is
 `blog-graphql-rate-limit-runtime-harness.json`, guarded by
 `verify-blog-graphql-rate-limit.mjs` and its focused fixture
-`verify-blog-graphql-rate-limit.test.mjs`. Both are registered as the
+`scripts/verify/verify-blog-graphql-rate-limit.test.mjs`. Both are registered as the
 `graphql_rate_limit` leaf gate in the Blog FBA verify/test chain; mounted Redis
 execution remains maintainer-owned.
 
@@ -343,6 +357,15 @@ one Blog post, and retains final counter/version plus ledger/outbox cardinality 
 evidence and focused negative fixtures. It does not claim an observed retry count,
 retry exhaustion, or PostgreSQL execution.
 
+The continuation audit at `144332e78c2ba64cb64c7468a718778a0d0d9183`
+found that restart evidence still stopped at a new connection and handler inside
+one process. Slice 51 adds a filtered env-gated target that starts the integration
+test executable twice in sequence, reconstructs the same envelope ID in each
+child, and retains one durable application across the OS process boundary.
+Evidence schema v4 and Blog registry schema v13 remain compatible; focused guards
+retain the parent, worker, two child launches, exact command, and non-claim for a
+full server-host restart without recording execution.
+
 ## FFA/FBA status
 
 - FFA status: `in_progress`.
@@ -350,10 +373,11 @@ retry exhaustion, or PostgreSQL execution.
 - Blog FBA source-gate chain: `source_verified_no_compile`; registry schema v13
   locks exact verify/test order, source-gate paths, leaf npm commands, evidence,
   self-tests, the Comments projection classifier, host registration, dispatcher,
-  concurrency, PostgreSQL, and restart harnesses, and aggregate/consumer bindings
-  for admin, storefront, Comments port boundary, Comments event projection,
-  category Search reindex, GraphQL rate limiting, GraphQL richtext, AI richtext,
-  offline backfill, Forum ownership, and runtime order.
+  concurrency, PostgreSQL, same-process restart, and process-restart harnesses,
+  and aggregate/consumer bindings for admin, storefront, Comments port boundary,
+  Comments event projection, category Search reindex, GraphQL rate limiting,
+  GraphQL richtext, AI richtext, offline backfill, Forum ownership, and runtime
+  order.
 - Comments consumer port boundary: Blog-owned `source_verified_no_compile` for
   the in-process profile; all seven operations, approved public read, typed
   richtext projection, two-second deadlines, write idempotency, active typed
@@ -365,17 +389,18 @@ retry exhaustion, or PostgreSQL execution.
   remain planned or pending.
 - Comments event projection: Blog-owned `source_verified_no_compile`; evidence
   schema v4, shared classifier/counter helpers, `executable_no_run` classifier,
-  module-registration, dispatcher, concurrency, PostgreSQL transaction, and
-  restart targets, verifier, focused self-test, exact npm leaf commands,
-  delivery-ledger identity, transactional outbox markers, and Blog FBA ordering
-  are locked. The registration target verifies identity/routing only. The
-  dispatcher target passes one envelope through `EventBus` and `EventDispatcher`
-  into the module-registered handler and waits for the durable commit. The
-  concurrency target starts four independent PostgreSQL connections behind one
-  barrier and requires a four-count/five-version result with four delivery and
-  outbox rows. None of these targets has been run. Measured retry count,
-  optimistic exhaustion, process-level restart recovery, and all execution
-  evidence remain pending.
+  module-registration, dispatcher, concurrency, PostgreSQL transaction,
+  same-process restart, and process-restart targets, verifier, focused self-test,
+  exact npm leaf commands, delivery-ledger identity, transactional outbox markers,
+  and Blog FBA ordering are locked. The registration target verifies
+  identity/routing only. The dispatcher target passes one envelope through
+  `EventBus` and `EventDispatcher` into the module-registered handler and waits
+  for the durable commit. The concurrency target starts four independent
+  PostgreSQL connections behind one barrier and requires a four-count/five-version
+  result with four delivery and outbox rows. The process target launches two
+  sequential OS test processes against the same schema and envelope ID. None of
+  these targets has been run. Measured retry count, optimistic exhaustion, full
+  server-host restart recovery, and all execution evidence remain pending.
 - Load protection: `implementation_ready`; mounted Redis evidence is pending.
 - Rate-limit harness: `executable_no_compile`; evidence, verifier, self-test,
   npm leaf commands, and aggregate FBA registration are locked; execution is
@@ -572,6 +597,11 @@ retry exhaustion, or PostgreSQL execution.
     shared barrier, and retained final counter/version plus ledger/outbox
     cardinality in evidence and focused fail-closed fixtures without claiming
     measured retries, exhaustion, or execution.
+51. Added an executable-no-run process restart target that launches the integration
+    test executable twice with one durable envelope identity, retained the parent,
+    private worker, exact two-launch boundary, final counter/ledger/outbox
+    assertions, evidence metadata, and focused negative fixtures without claiming
+    a full server-host restart or recording execution.
 
 ## Next results
 
@@ -591,19 +621,20 @@ retry exhaustion, or PostgreSQL execution.
 5. **Close comments runtime evidence.** Run the Comments port boundary fixture,
    shared consumer runtime-order verifier, Blog projection classifier harness,
    module registration/routing harness, the filtered
-   `event_dispatcher_routes_registered_handler_and_commits_projection` and
-   `concurrent_created_events_converge_without_lost_updates` cases, the complete
-   `comment_projection_postgres_test` and
+   `event_dispatcher_routes_registered_handler_and_commits_projection`,
+   `concurrent_created_events_converge_without_lost_updates`, and
+   `restarted_process_reuses_delivery_ledger_without_reapplying_counter` cases,
+   the complete `comment_projection_postgres_test` and
    `comment_projection_restart_postgres_test` targets, both thread invariant
    concurrency targets, and concurrent PostgreSQL create/delete transactions.
-   Retain dispatcher delivery output, four-connection convergence, the written
-   duplicate, delete-before-create, missing-post replay, outbox rollback/retry,
-   and new-connection handler replay assertions; then cover measured optimistic
-   retry count and exhaustion, process-level restart recovery, remote adapter
-   parity, browser parity for typed unavailable/timeout article rendering, cached
-   thread snapshots, comment-form fallback, approved-only reads, moderation,
-   pagination, first-thread identity, and unrelated insert storage error
-   propagation.
+   Retain dispatcher delivery output, four-connection convergence, both child
+   process exits, the written duplicate, delete-before-create, missing-post
+   replay, outbox rollback/retry, and same-process/new-connection assertions;
+   then cover measured optimistic retry count and exhaustion, full server-host
+   restart recovery, remote adapter parity, browser parity for typed
+   unavailable/timeout article rendering, cached thread snapshots, comment-form
+   fallback, approved-only reads, moderation, pagination, first-thread identity,
+   and unrelated insert storage error propagation.
 6. **Execute and retain Blog article richtext cutover evidence.** Run the offline
    backfill in default dry-run mode, review its report, apply accepted conversion,
    execute the irreversible migration, reindex/rollback Search, and retain
@@ -624,6 +655,7 @@ should run the relevant subset, including:
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test event_dispatcher_routes_registered_handler_and_commits_projection -- --exact`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test concurrent_created_events_converge_without_lost_updates -- --exact`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test`
+- `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test restarted_process_reuses_delivery_ledger_without_reapplying_counter -- --exact`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test`
 - `npm run verify:blog:category-search-reindex`
 - `npm run test:verify:blog:category-search-reindex`

--- a/crates/rustok-blog/tests/comment_projection_restart_postgres_test.rs
+++ b/crates/rustok-blog/tests/comment_projection_restart_postgres_test.rs
@@ -1,4 +1,4 @@
-use std::error::Error;
+use std::{env, error::Error, io, process::Command};
 
 use rustok_blog::services::BlogCommentProjectionHandler;
 use rustok_core::events::EventHandler;
@@ -11,6 +11,14 @@ use uuid::Uuid;
 type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
 
 const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";
+const PROCESS_WORKER_ENV: &str = "RUSTOK_BLOG_PROCESS_RESTART_WORKER";
+const PROCESS_DATABASE_ENV: &str = "RUSTOK_BLOG_PROCESS_RESTART_DATABASE_URL";
+const PROCESS_SCHEMA_ENV: &str = "RUSTOK_BLOG_PROCESS_RESTART_SCHEMA";
+const PROCESS_TENANT_ENV: &str = "RUSTOK_BLOG_PROCESS_RESTART_TENANT_ID";
+const PROCESS_POST_ENV: &str = "RUSTOK_BLOG_PROCESS_RESTART_POST_ID";
+const PROCESS_ACTOR_ENV: &str = "RUSTOK_BLOG_PROCESS_RESTART_ACTOR_ID";
+const PROCESS_COMMENT_ENV: &str = "RUSTOK_BLOG_PROCESS_RESTART_COMMENT_ID";
+const PROCESS_EVENT_ENV: &str = "RUSTOK_BLOG_PROCESS_RESTART_EVENT_ID";
 
 struct PostgresBlogProjectionRestartTestDb {
     control: DatabaseConnection,
@@ -108,6 +116,140 @@ async fn restarted_handler_reuses_delivery_ledger_without_reapplying_counter() -
     drop(restarted_handler);
     drop(restarted_db);
     test_db.cleanup().await
+}
+
+#[tokio::test]
+async fn restarted_process_reuses_delivery_ledger_without_reapplying_counter() -> TestResult<()> {
+    let Some(test_db) = PostgresBlogProjectionRestartTestDb::setup().await? else {
+        return Ok(());
+    };
+
+    let tenant_id = Uuid::new_v4();
+    let post_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    let comment_id = Uuid::new_v4();
+    let envelope = EventEnvelope::new(
+        tenant_id,
+        Some(actor_id),
+        DomainEvent::CommentCreated {
+            comment_id,
+            target_type: "blog_post".to_string(),
+            target_id: post_id,
+            author_id: actor_id,
+        },
+    );
+    insert_post(&test_db.db, tenant_id, post_id, actor_id).await?;
+
+    run_projection_worker(
+        &test_db,
+        tenant_id,
+        post_id,
+        actor_id,
+        comment_id,
+        envelope.id,
+    )?;
+    run_projection_worker(
+        &test_db,
+        tenant_id,
+        post_id,
+        actor_id,
+        comment_id,
+        envelope.id,
+    )?;
+
+    assert_eq!(load_post_state(&test_db.db, tenant_id, post_id).await?, (1, 2));
+    assert_eq!(count_delivery(&test_db.db, envelope.id).await?, 1);
+    assert_eq!(count_outbox_events(&test_db.db).await?, 1);
+
+    test_db.cleanup().await
+}
+
+#[tokio::test]
+async fn process_restart_worker_applies_envelope_from_env() -> TestResult<()> {
+    if env::var_os(PROCESS_WORKER_ENV).is_none() {
+        return Ok(());
+    }
+
+    let database_url = required_env(PROCESS_DATABASE_ENV)?;
+    let schema_name = required_env(PROCESS_SCHEMA_ENV)?;
+    let tenant_id = required_uuid(PROCESS_TENANT_ENV)?;
+    let post_id = required_uuid(PROCESS_POST_ENV)?;
+    let actor_id = required_uuid(PROCESS_ACTOR_ENV)?;
+    let comment_id = required_uuid(PROCESS_COMMENT_ENV)?;
+    let event_id = required_uuid(PROCESS_EVENT_ENV)?;
+
+    let db = connect(&database_url).await?;
+    set_search_path(&db, &schema_name).await?;
+    let mut envelope = EventEnvelope::new(
+        tenant_id,
+        Some(actor_id),
+        DomainEvent::CommentCreated {
+            comment_id,
+            target_type: "blog_post".to_string(),
+            target_id: post_id,
+            author_id: actor_id,
+        },
+    );
+    envelope.id = event_id;
+    envelope.correlation_id = event_id;
+
+    let handler = BlogCommentProjectionHandler::new(db);
+    handler.handle(&envelope).await?;
+    Ok(())
+}
+
+fn run_projection_worker(
+    test_db: &PostgresBlogProjectionRestartTestDb,
+    tenant_id: Uuid,
+    post_id: Uuid,
+    actor_id: Uuid,
+    comment_id: Uuid,
+    event_id: Uuid,
+) -> TestResult<()> {
+    let status = Command::new(env::current_exe()?)
+        .arg("--exact")
+        .arg("process_restart_worker_applies_envelope_from_env")
+        .arg("--nocapture")
+        .env(PROCESS_WORKER_ENV, "1")
+        .env(PROCESS_DATABASE_ENV, &test_db.database_url)
+        .env(PROCESS_SCHEMA_ENV, &test_db.schema_name)
+        .env(PROCESS_TENANT_ENV, tenant_id.to_string())
+        .env(PROCESS_POST_ENV, post_id.to_string())
+        .env(PROCESS_ACTOR_ENV, actor_id.to_string())
+        .env(PROCESS_COMMENT_ENV, comment_id.to_string())
+        .env(PROCESS_EVENT_ENV, event_id.to_string())
+        .status()?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("Blog projection restart worker exited with status {status}"),
+        )
+        .into())
+    }
+}
+
+fn required_env(name: &str) -> TestResult<String> {
+    env::var(name).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("missing or invalid {name}: {error}"),
+        )
+        .into()
+    })
+}
+
+fn required_uuid(name: &str) -> TestResult<Uuid> {
+    let value = required_env(name)?;
+    Uuid::parse_str(&value).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid UUID in {name}: {error}"),
+        )
+        .into()
+    })
 }
 
 async fn create_projection_tables(db: &DatabaseConnection) -> Result<(), sea_orm::DbErr> {
@@ -230,8 +372,8 @@ async fn count_outbox_events(db: &DatabaseConnection) -> Result<i64, sea_orm::Db
 }
 
 fn postgres_database_url() -> Option<String> {
-    std::env::var(BLOG_TEST_DATABASE_ENV)
-        .or_else(|_| std::env::var("DATABASE_URL"))
+    env::var(BLOG_TEST_DATABASE_ENV)
+        .or_else(|_| env::var("DATABASE_URL"))
         .ok()
         .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
 }

--- a/scripts/verify/verify-blog-comments-event-projection.mjs
+++ b/scripts/verify/verify-blog-comments-event-projection.mjs
@@ -29,6 +29,13 @@ function requireNoMarker(source, marker, label) {
   if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
 }
 
+function requireCount(source, marker, expected, label) {
+  const count = source.split(marker).length - 1;
+  if (count !== expected) {
+    failures.push(`${label}: expected ${expected} occurrences of ${marker}, found ${count}`);
+  }
+}
+
 const evidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json';
 const handlerPath = 'crates/rustok-blog/src/services/comment_projection.rs';
 const postgresHarnessPath = 'crates/rustok-blog/tests/comment_projection_postgres_test.rs';
@@ -46,6 +53,7 @@ const dispatcherHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://...
 const concurrencyHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test concurrent_created_events_converge_without_lost_updates -- --exact';
 const postgresHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test';
 const restartHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test';
+const processRestartHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test restarted_process_reuses_delivery_ledger_without_reapplying_counter -- --exact';
 const postgresHarnessEnvironment = 'RUSTOK_BLOG_TEST_DATABASE_URL';
 
 const handler = read(handlerPath);
@@ -176,6 +184,8 @@ requireNoMarker(postgresHarness, 'runtime_verified', postgresHarnessPath);
 
 for (const marker of [
   'const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";',
+  'const PROCESS_WORKER_ENV: &str = "RUSTOK_BLOG_PROCESS_RESTART_WORKER";',
+  'const PROCESS_EVENT_ENV: &str = "RUSTOK_BLOG_PROCESS_RESTART_EVENT_ID";',
   'struct PostgresBlogProjectionRestartTestDb',
   'database_url: String',
   'async fn restarted_connection(&self)',
@@ -190,10 +200,42 @@ for (const marker of [
   'load_post_state(&restarted_db, tenant_id, post_id).await?, (1, 2)',
   'count_delivery(&restarted_db, envelope.id).await?, 1',
   'count_outbox_events(&restarted_db).await?, 1',
+  'async fn restarted_process_reuses_delivery_ledger_without_reapplying_counter()',
+  'async fn process_restart_worker_applies_envelope_from_env()',
+  'if env::var_os(PROCESS_WORKER_ENV).is_none()',
+  'let event_id = required_uuid(PROCESS_EVENT_ENV)?;',
+  'envelope.id = event_id;',
+  'envelope.correlation_id = event_id;',
+  'fn run_projection_worker(',
+  'Command::new(env::current_exe()?)',
+  '.arg("--exact")',
+  '.arg("process_restart_worker_applies_envelope_from_env")',
+  '.env(PROCESS_WORKER_ENV, "1")',
+  'Blog projection restart worker exited with status',
+  'load_post_state(&test_db.db, tenant_id, post_id).await?, (1, 2)',
+  'count_delivery(&test_db.db, envelope.id).await?, 1',
+  'count_outbox_events(&test_db.db).await?, 1',
   'CREATE TABLE blog_comment_projection_deliveries',
   'CREATE TABLE sys_events',
 ]) {
   requireMarker(restartHarness, marker, restartHarnessPath);
+}
+const processParentStart = restartHarness.indexOf(
+  'async fn restarted_process_reuses_delivery_ledger_without_reapplying_counter()',
+);
+const processWorkerStart = restartHarness.indexOf(
+  'async fn process_restart_worker_applies_envelope_from_env()',
+  processParentStart,
+);
+if (processParentStart === -1 || processWorkerStart === -1) {
+  failures.push(`${restartHarnessPath}: missing process restart parent/worker boundary`);
+} else {
+  requireCount(
+    restartHarness.slice(processParentStart, processWorkerStart),
+    'run_projection_worker(',
+    2,
+    `${restartHarnessPath}: process restart parent`,
+  );
 }
 requireNoMarker(restartHarness, '#[ignore]', restartHarnessPath);
 requireNoMarker(restartHarness, 'runtime_verified', restartHarnessPath);
@@ -371,7 +413,8 @@ if (evidence) {
     restart.path !== restartHarnessPath ||
     restart.environment !== postgresHarnessEnvironment ||
     restart.command !== restartHarnessCommand ||
-    restart.isolation !== 'unique_schema_new_connection'
+    restart.isolation !== 'unique_schema_new_connection' ||
+    restart.scope !== 'same_process_new_connection_and_handler'
   ) {
     failures.push(`${evidencePath}: restart harness drift`);
   }
@@ -380,6 +423,28 @@ if (evidence) {
     'restarted_handler_reuses_delivery_ledger_without_reapplying_counter'
   ) {
     failures.push(`${evidencePath}: restart harness case drift`);
+  }
+  const processRestart = evidence.process_restart_harness ?? {};
+  if (
+    processRestart.status !== 'executable_no_run' ||
+    processRestart.runtime_status !== 'not_run' ||
+    processRestart.path !== restartHarnessPath ||
+    processRestart.environment !== postgresHarnessEnvironment ||
+    processRestart.command !== processRestartHarnessCommand ||
+    processRestart.isolation !== 'unique_schema_two_sequential_test_processes_same_envelope' ||
+    processRestart.scope !== 'os_process_reinstantiation_durable_delivery_replay' ||
+    processRestart.non_claim !== 'does_not_prove_full_server_host_restart_or_record_execution'
+  ) {
+    failures.push(`${evidencePath}: process restart harness drift`);
+  }
+  const processRestartCases = [...(processRestart.cases ?? [])].sort().join('|');
+  if (
+    processRestartCases !== [
+      'restarted_process_reuses_delivery_ledger_without_reapplying_counter',
+      'process_restart_worker_applies_envelope_from_env',
+    ].sort().join('|')
+  ) {
+    failures.push(`${evidencePath}: process restart harness case drift`);
   }
   const events = [...(evidence.events ?? [])].sort().join('|');
   if (events !== ['comment.created', 'comment.deleted'].sort().join('|')) {
@@ -403,6 +468,7 @@ if (evidence) {
     'postgres_missing_post_recovery',
     'postgres_outbox_rollback_recovery',
     'postgres_restart_replay',
+    'postgres_process_restart_replay',
     'module_listener_registration',
   ]) {
     if (!cases.has(requiredCase)) failures.push(`${evidencePath}: missing case ${requiredCase}`);
@@ -470,13 +536,15 @@ for (const marker of [
   'tests::module_registers_comment_projection_handler_with_host_routing',
   'event_dispatcher_routes_registered_handler_and_commits_projection',
   'concurrent_created_events_converge_without_lost_updates',
+  'restarted_process_reuses_delivery_ledger_without_reapplying_counter',
   'comment_projection_postgres_test',
   'comment_projection_restart_postgres_test',
   'RUSTOK_BLOG_TEST_DATABASE_URL',
   'EventBus',
   'EventDispatcher',
   'independent PostgreSQL connections',
-  'process-level restart recovery',
+  'two sequential OS test processes',
+  'server-host restart',
 ]) {
   requireMarker(plan, marker, planPath);
 }
@@ -487,4 +555,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log('Blog comments event projection classifier, registration, dispatcher, concurrency, PostgreSQL, and restart harnesses are consistent');
+console.log('Blog comments event projection classifier, registration, dispatcher, concurrency, PostgreSQL, connection restart, and process restart harnesses are consistent');

--- a/scripts/verify/verify-blog-comments-event-projection.test.mjs
+++ b/scripts/verify/verify-blog-comments-event-projection.test.mjs
@@ -34,6 +34,9 @@ function fixture({
   missingRestartHarness = false,
   missingRestartConnection = false,
   missingRestartRegistration = false,
+  missingProcessRestartCase = false,
+  missingProcessWorker = false,
+  singleProcessWorkerInvocation = false,
   statusDrift = false,
   harnessStatusDrift = false,
   hostHarnessStatusDrift = false,
@@ -41,6 +44,7 @@ function fixture({
   concurrencyStatusDrift = false,
   postgresStatusDrift = false,
   restartStatusDrift = false,
+  processRestartStatusDrift = false,
 } = {}) {
   const root = mkdtempSync(path.join(tmpdir(), 'rustok-blog-comments-projection-'));
   const evidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json';
@@ -59,6 +63,7 @@ function fixture({
   const concurrencyHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test concurrent_created_events_converge_without_lost_updates -- --exact';
   const postgresHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test';
   const restartHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test';
+  const processRestartHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test restarted_process_reuses_delivery_ledger_without_reapplying_counter -- --exact';
 
   write(
     root,
@@ -169,11 +174,32 @@ count_outbox_events(&test_db.db)
   }
 
   if (!missingRestartHarness) {
+    const processParentSource = missingProcessRestartCase
+      ? ''
+      : `
+async fn restarted_process_reuses_delivery_ledger_without_reapplying_counter()
+run_projection_worker(
+${singleProcessWorkerInvocation ? '' : 'run_projection_worker('}
+load_post_state(&test_db.db, tenant_id, post_id).await?, (1, 2)
+count_delivery(&test_db.db, envelope.id).await?, 1
+count_outbox_events(&test_db.db).await?, 1
+`;
+    const processWorkerSource = missingProcessWorker
+      ? ''
+      : `
+async fn process_restart_worker_applies_envelope_from_env()
+if env::var_os(PROCESS_WORKER_ENV).is_none()
+let event_id = required_uuid(PROCESS_EVENT_ENV)?;
+envelope.id = event_id;
+envelope.correlation_id = event_id;
+`;
     write(
       root,
       restartHarnessPath,
       `
 const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";
+const PROCESS_WORKER_ENV: &str = "RUSTOK_BLOG_PROCESS_RESTART_WORKER";
+const PROCESS_EVENT_ENV: &str = "RUSTOK_BLOG_PROCESS_RESTART_EVENT_ID";
 struct PostgresBlogProjectionRestartTestDb
 database_url: String
 async fn restarted_connection(&self)
@@ -188,6 +214,14 @@ restarted_handler.handle(&envelope).await?;
 load_post_state(&restarted_db, tenant_id, post_id).await?, (1, 2)
 count_delivery(&restarted_db, envelope.id).await?, 1
 count_outbox_events(&restarted_db).await?, 1
+${processParentSource}
+${processWorkerSource}
+fn run_projection_worker(
+Command::new(env::current_exe()?)
+.arg("--exact")
+.arg("process_restart_worker_applies_envelope_from_env")
+.env(PROCESS_WORKER_ENV, "1")
+Blog projection restart worker exited with status
 CREATE TABLE blog_comment_projection_deliveries
 CREATE TABLE sys_events
 `,
@@ -330,7 +364,22 @@ assert!(!handler.handles(&forum_created));
         environment: 'RUSTOK_BLOG_TEST_DATABASE_URL',
         command: restartHarnessCommand,
         isolation: 'unique_schema_new_connection',
+        scope: 'same_process_new_connection_and_handler',
         cases: ['restarted_handler_reuses_delivery_ledger_without_reapplying_counter'],
+      },
+      process_restart_harness: {
+        status: processRestartStatusDrift ? 'executed' : 'executable_no_run',
+        runtime_status: processRestartStatusDrift ? 'passed' : 'not_run',
+        path: restartHarnessPath,
+        environment: 'RUSTOK_BLOG_TEST_DATABASE_URL',
+        command: processRestartHarnessCommand,
+        isolation: 'unique_schema_two_sequential_test_processes_same_envelope',
+        scope: 'os_process_reinstantiation_durable_delivery_replay',
+        non_claim: 'does_not_prove_full_server_host_restart_or_record_execution',
+        cases: [
+          'restarted_process_reuses_delivery_ledger_without_reapplying_counter',
+          'process_restart_worker_applies_envelope_from_env',
+        ],
       },
       cases: [
         { name: 'shared_event_classifier' },
@@ -349,6 +398,7 @@ assert!(!handler.handles(&forum_created));
         { name: 'postgres_missing_post_recovery' },
         { name: 'postgres_outbox_rollback_recovery' },
         { name: 'postgres_restart_replay' },
+        { name: 'postgres_process_restart_replay' },
         { name: 'module_listener_registration' },
       ],
     }),
@@ -399,7 +449,7 @@ assert!(!handler.handles(&forum_created));
   write(
     root,
     'crates/rustok-blog/docs/implementation-plan.md',
-    'blog-comments-event-projection.json verify:blog:comments-event-projection test:verify:blog:comments-event-projection source_verified_no_compile services::comment_projection::tests tests::module_registers_comment_projection_handler_with_host_routing event_dispatcher_routes_registered_handler_and_commits_projection concurrent_created_events_converge_without_lost_updates comment_projection_postgres_test comment_projection_restart_postgres_test RUSTOK_BLOG_TEST_DATABASE_URL EventBus EventDispatcher independent PostgreSQL connections process-level restart recovery',
+    'blog-comments-event-projection.json verify:blog:comments-event-projection test:verify:blog:comments-event-projection source_verified_no_compile services::comment_projection::tests tests::module_registers_comment_projection_handler_with_host_routing event_dispatcher_routes_registered_handler_and_commits_projection concurrent_created_events_converge_without_lost_updates restarted_process_reuses_delivery_ledger_without_reapplying_counter comment_projection_postgres_test comment_projection_restart_postgres_test RUSTOK_BLOG_TEST_DATABASE_URL EventBus EventDispatcher independent PostgreSQL connections two sequential OS test processes server-host restart',
   );
 
   return root;
@@ -526,6 +576,27 @@ test('rejects restart coverage that reuses the original connection', () => {
   );
 });
 
+test('rejects a missing process restart parent case', () => {
+  expectRejected(
+    { missingProcessRestartCase: true },
+    /missing async fn restarted_process_reuses_delivery_ledger_without_reapplying_counter/,
+  );
+});
+
+test('rejects a missing process restart worker', () => {
+  expectRejected(
+    { missingProcessWorker: true },
+    /missing async fn process_restart_worker_applies_envelope_from_env/,
+  );
+});
+
+test('rejects process restart coverage with only one child process', () => {
+  expectRejected(
+    { singleProcessWorkerInvocation: true },
+    /expected 2 occurrences of run_projection_worker\(/,
+  );
+});
+
 test('rejects a registry without the restart target', () => {
   expectRejected({ missingRestartRegistration: true }, /restart test path drift/);
 });
@@ -556,4 +627,8 @@ test('rejects PostgreSQL harness execution promotion without execution', () => {
 
 test('rejects restart harness execution promotion without execution', () => {
   expectRejected({ restartStatusDrift: true }, /restart harness drift/);
+});
+
+test('rejects process restart harness execution promotion without execution', () => {
+  expectRejected({ processRestartStatusDrift: true }, /process restart harness drift/);
 });


### PR DESCRIPTION
## Summary

- add an env-gated PostgreSQL restart case that launches the integration-test executable twice in sequence
- pass the same isolated schema and `EventEnvelope` identity to a private worker test in both child processes
- retain one counter transition, one delivery-ledger row, and one outbox row after both process exits
- keep the existing same-process new-connection target separate
- record a `process_restart_harness` in Comments event-projection evidence schema v4
- extend the focused verifier and negative fixture for the parent, worker, exact two-launch boundary, envelope-ID reuse, and false execution promotion
- keep Blog registry schema v13 and package command order unchanged
- keep full server-host restart, measured optimistic retries/exhaustion, and all execution pending

## Validation

Not run by request. No verifier, Rust test, compile, PostgreSQL, browser, workflow, or CI command was executed.

Suggested maintainer commands:

```bash
RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test restarted_process_reuses_delivery_ledger_without_reapplying_counter -- --exact
npm run verify:blog:comments-event-projection
npm run test:verify:blog:comments-event-projection
npm run verify:blog:fba
npm run test:verify:blog:fba
cargo check -p rustok-server --features mod-blog
```