### PR TITLE
fix(commerce): sanitize promotion SSR diagnostics

### DIFF
--- a/crates/rustok-commerce/admin/src/transport/native_server_adapter_ssr.rs
+++ b/crates/rustok-commerce/admin/src/transport/native_server_adapter_ssr.rs
@@ -170,6 +170,46 @@ fn parse_optional_uuid(
 // Cart-promotion native boundary
 // -----------------------------------------------------------------------------
 
+struct PromotionRequestContextFacts {
+    request_context_present: bool,
+    request_tenant_id_non_nil: Option<bool>,
+    request_user_id_present: bool,
+    request_user_id_non_nil: Option<bool>,
+    channel_id_present: bool,
+    channel_id_non_nil: Option<bool>,
+    channel_slug_present: bool,
+    channel_slug_length: Option<usize>,
+    locale_present: bool,
+    locale_length: Option<usize>,
+}
+
+fn promotion_request_context_facts(
+    request_context: Option<&rustok_api::RequestContext>,
+) -> PromotionRequestContextFacts {
+    PromotionRequestContextFacts {
+        request_context_present: request_context.is_some(),
+        request_tenant_id_non_nil: request_context.map(|context| !context.tenant_id.is_nil()),
+        request_user_id_present: request_context.and_then(|context| context.user_id).is_some(),
+        request_user_id_non_nil: request_context
+            .and_then(|context| context.user_id)
+            .map(|value| !value.is_nil()),
+        channel_id_present: request_context
+            .and_then(|context| context.channel_id)
+            .is_some(),
+        channel_id_non_nil: request_context
+            .and_then(|context| context.channel_id)
+            .map(|value| !value.is_nil()),
+        channel_slug_present: request_context
+            .and_then(|context| context.channel_slug.as_ref())
+            .is_some(),
+        channel_slug_length: request_context
+            .and_then(|context| context.channel_slug.as_ref())
+            .map(|value| value.chars().count()),
+        locale_present: request_context.is_some(),
+        locale_length: request_context.map(|context| context.locale.chars().count()),
+    }
+}
+
 fn parse_cart_id(value: &str) -> Result<uuid::Uuid, ServerFnError> {
     uuid::Uuid::parse_str(value.trim()).map_err(|_| ServerFnError::new("Invalid cart_id"))
 }
@@ -246,15 +286,16 @@ fn promotion_correlation_id(operation: &'static str) -> String {
 }
 
 fn promotion_context_error<E: std::fmt::Debug>(
-    error: E,
+    _error: E,
     operation: &'static str,
     context_kind: &'static str,
     correlation_id: &str,
     code: &'static str,
     public_message: &'static str,
 ) -> ServerFnError {
+    let error_type = std::any::type_name::<E>();
     tracing::error!(
-        error = ?error,
+        error_type,
         consumer = COMMERCE_ADMIN_PROMOTION_CONSUMER,
         operation,
         context_kind,
@@ -303,8 +344,9 @@ async fn optional_promotion_request_context(
     match leptos_axum::extract::<rustok_api::RequestContext>().await {
         Ok(context) => Some(context),
         Err(error) => {
+            let error_type = std::any::type_name_of_val(&error);
             tracing::warn!(
-                error = ?error,
+                error_type,
                 consumer = COMMERCE_ADMIN_PROMOTION_CONSUMER,
                 operation,
                 context_kind = "request",
@@ -363,28 +405,52 @@ fn promotion_port_error(
     request_context: Option<&rustok_api::RequestContext>,
     cart_id: uuid::Uuid,
 ) -> ServerFnError {
-    let (request_tenant_id, request_user_id, channel_id, channel_slug, locale) =
-        request_context_fields(request_context);
+    let request_facts = promotion_request_context_facts(request_context);
+    let public_message_present = !error.message.trim().is_empty();
+    let public_message_length = error.message.chars().count();
+    let effective_locale_length = request_context
+        .map(|context| context.locale.as_str())
+        .unwrap_or(tenant.default_locale.as_str())
+        .chars()
+        .count();
+    let effective_channel_present = request_context
+        .and_then(|context| {
+            context
+                .channel_slug
+                .as_ref()
+                .map(|_| ())
+                .or_else(|| context.channel_id.map(|_| ()))
+        })
+        .is_some();
+
     match &error.kind {
         rustok_api::PortErrorKind::Unavailable
         | rustok_api::PortErrorKind::Timeout
         | rustok_api::PortErrorKind::InvariantViolation => {
             tracing::error!(
-                error = ?error,
                 owner = "rustok_cart.promotion",
                 consumer = COMMERCE_ADMIN_PROMOTION_CONSUMER,
                 consumer_operation,
                 owner_operation,
                 correlation_id,
-                tenant_id = %tenant.id,
-                actor_id = %auth.user_id,
-                cart_id = %cart_id,
-                request_tenant_id = ?request_tenant_id,
-                request_user_id = ?request_user_id,
-                channel_id = ?channel_id,
-                channel_slug = ?channel_slug,
-                locale = ?locale,
+                tenant_id_non_nil = !tenant.id.is_nil(),
+                actor_id_non_nil = !auth.user_id.is_nil(),
+                cart_id_non_nil = !cart_id.is_nil(),
+                request_context_present = request_facts.request_context_present,
+                request_tenant_id_non_nil = ?request_facts.request_tenant_id_non_nil,
+                request_user_id_present = request_facts.request_user_id_present,
+                request_user_id_non_nil = ?request_facts.request_user_id_non_nil,
+                channel_id_present = request_facts.channel_id_present,
+                channel_id_non_nil = ?request_facts.channel_id_non_nil,
+                channel_slug_present = request_facts.channel_slug_present,
+                channel_slug_length = ?request_facts.channel_slug_length,
+                locale_present = request_facts.locale_present,
+                locale_length = ?request_facts.locale_length,
+                effective_locale_length,
+                effective_channel_present,
                 public_code = %error.code,
+                public_message_present,
+                public_message_length,
                 error_kind = ?error.kind,
                 retryable = error.retryable,
                 boundary = COMMERCE_ADMIN_PROMOTION_BOUNDARY,
@@ -393,21 +459,29 @@ fn promotion_port_error(
         }
         _ => {
             tracing::warn!(
-                error = ?error,
                 owner = "rustok_cart.promotion",
                 consumer = COMMERCE_ADMIN_PROMOTION_CONSUMER,
                 consumer_operation,
                 owner_operation,
                 correlation_id,
-                tenant_id = %tenant.id,
-                actor_id = %auth.user_id,
-                cart_id = %cart_id,
-                request_tenant_id = ?request_tenant_id,
-                request_user_id = ?request_user_id,
-                channel_id = ?channel_id,
-                channel_slug = ?channel_slug,
-                locale = ?locale,
+                tenant_id_non_nil = !tenant.id.is_nil(),
+                actor_id_non_nil = !auth.user_id.is_nil(),
+                cart_id_non_nil = !cart_id.is_nil(),
+                request_context_present = request_facts.request_context_present,
+                request_tenant_id_non_nil = ?request_facts.request_tenant_id_non_nil,
+                request_user_id_present = request_facts.request_user_id_present,
+                request_user_id_non_nil = ?request_facts.request_user_id_non_nil,
+                channel_id_present = request_facts.channel_id_present,
+                channel_id_non_nil = ?request_facts.channel_id_non_nil,
+                channel_slug_present = request_facts.channel_slug_present,
+                channel_slug_length = ?request_facts.channel_slug_length,
+                locale_present = request_facts.locale_present,
+                locale_length = ?request_facts.locale_length,
+                effective_locale_length,
+                effective_channel_present,
                 public_code = %error.code,
+                public_message_present,
+                public_message_length,
                 error_kind = ?error.kind,
                 retryable = error.retryable,
                 boundary = COMMERCE_ADMIN_PROMOTION_BOUNDARY,

--- a/crates/rustok-commerce/contracts/evidence/admin-promotion-native-error-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/admin-promotion-native-error-safety-source-review.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "status": "commerce_admin_promotion_native_error_safety_source_reviewed_unvalidated",
-  "captured_at": "2026-07-30",
-  "base_main_sha": "94a037124840cd906a1f979cbb7eb90421c22ce4",
+  "captured_at": "2026-07-31",
+  "base_main_sha": "c4149652fa9c5835336daa29156b1d3e7ba68ac9",
   "review": {
     "mounted_endpoint_names_preserved": true,
     "public_function_signatures_preserved": true,
@@ -11,14 +11,13 @@
     "promotion_input_validation_preserved": true,
     "cart_promotion_owner_guard_reviewed": true,
     "port_error_public_sanitization_reviewed": true,
-    "request_context_fields_reviewed": [
-      "tenant_id",
-      "user_id",
-      "channel_id",
-      "channel_slug",
-      "channel_resolution_source",
-      "locale"
-    ],
+    "framework_error_text_removed": true,
+    "owner_port_error_text_removed": true,
+    "identity_values_removed": true,
+    "safe_shape_diagnostics_reviewed": true,
+    "public_envelopes_preserved": true,
+    "request_locale_and_channel_forwarding_preserved": true,
+    "write_idempotency_preserved": true,
     "client_hydrate_contract_remains_on_canonical_adapter": true,
     "ssr_routes_to_safe_adapter": true,
     "order_change_source_explicitly_not_claimed_safe": true
@@ -32,9 +31,9 @@
     "workflow_or_ci_run": false
   },
   "limitations": [
-    "No compiler evidence has been retained.",
-    "No runtime request or owner-failure trace has been retained.",
-    "The focused source guard has been added but not executed.",
-    "Commerce admin order-change failures remain a separate open mapper-cleanup slice."
+    "Compiler evidence is not retained.",
+    "Runtime request and owner-failure traces are not retained.",
+    "The focused source guard is updated but not executed.",
+    "Commerce admin order-change failures remain a separate mapper-cleanup slice."
   ]
 }

--- a/crates/rustok-commerce/contracts/evidence/admin-promotion-native-error-safety-source.json
+++ b/crates/rustok-commerce/contracts/evidence/admin-promotion-native-error-safety-source.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0.0",
   "status": "commerce_admin_promotion_native_error_safety_source_unvalidated",
-  "captured_at": "2026-07-30",
+  "captured_at": "2026-07-31",
   "scope": {
     "package": "rustok-commerce-admin",
     "boundary": "commerce_admin_promotion_native_transport",
@@ -18,12 +18,21 @@
   "source_claims": {
     "ssr_routes_through_safe_adapter": true,
     "framework_extraction_errors_use_static_public_envelopes": true,
+    "framework_error_type_only": true,
+    "complete_framework_error_logged": false,
     "request_context_is_diagnostic_and_attribution_only": true,
     "request_locale_and_channel_cross_port_context_when_available": true,
     "correlation_is_unique_per_transport_call": true,
     "write_port_context_has_non_empty_idempotency_semantics": true,
-    "typed_owner_errors_are_logged_at_consumer_boundary": true,
-    "only_sanitized_port_error_message_crosses_public_boundary": true,
+    "typed_owner_errors_are_mapped_at_consumer_boundary": true,
+    "owner_port_error_shape_only": true,
+    "complete_owner_port_error_logged": false,
+    "raw_tenant_actor_cart_logged": false,
+    "raw_request_context_values_logged": false,
+    "uuid_non_nil_presence_length_and_type_facts_only": true,
+    "stable_public_code_kind_and_retryability_logged": true,
+    "public_message_presence_and_length_only": true,
+    "public_port_error_message_preserved": true,
     "permission_and_input_validation_messages_are_preserved": true,
     "order_change_cleanup_is_out_of_scope": true
   },
@@ -44,6 +53,5 @@
     "crates/rustok-cart/src/promotion_guard.rs",
     "scripts/verify/verify-commerce-admin-boundary.mjs",
     "scripts/verify/verify-commerce-admin-promotion-native-error-safety.mjs"
-  ],
-  "promotion_gate": "No FFA, FBA, transport, runtime, or production status is promoted from this source inspection."
+  ]
 }

--- a/crates/rustok-commerce/docs/admin-promotion-native-error-safety.md
+++ b/crates/rustok-commerce/docs/admin-promotion-native-error-safety.md
@@ -3,8 +3,8 @@
 Status: `source-complete / unvalidated`
 
 This slice hardens the mounted Commerce admin cart-promotion native server
-functions without changing their request/response contracts, permission policy,
-or cart promotion owner behavior.
+functions without changing request/response contracts, permission policy, owner
+calls, or cart-promotion behavior.
 
 ## Covered endpoints
 
@@ -12,76 +12,83 @@ or cart promotion owner behavior.
 - `commerce/admin/apply-cart-promotion`
 
 The client/hydrate server-function contract remains in
-`admin/src/transport/native_server_adapter.rs`. SSR routes through
-`admin/src/transport/native_server_adapter_ssr.rs`, where the promotion
-boundary is hardened. The order-change endpoints are retained in the SSR
-adapter for contract parity, but their remaining error cleanup is not claimed by
-this slice.
+`admin/src/transport/native_server_adapter.rs`. SSR continues to route through
+`admin/src/transport/native_server_adapter_ssr.rs`.
 
 ## Public boundary
 
-Auth and tenant extraction failures no longer serialize framework rejection
-text. They return static operation-independent availability envelopes:
+Auth and tenant extraction failures continue to return static availability
+envelopes:
 
 - `Commerce admin authentication context is temporarily unavailable`
 - `Commerce admin tenant context is temporarily unavailable`
 
-Transport-owned permission and promotion-input validation messages are
-unchanged. The cart owner already maps `CartError` into a sanitized typed
-`PortError`; the Commerce admin consumer forwards only that safe public
-`PortError.message`.
+Transport-owned permission and promotion-input validation messages are unchanged.
+The Cart owner still maps `CartError` into a sanitized typed `PortError`, and the
+Commerce admin consumer still returns only `PortError.message` through
+`ServerFnError`.
 
-## Port context
+## Framework diagnostics
 
-Each mounted promotion call creates a unique transport correlation id and keeps
-the two-second owner-port deadline. The write call also carries a non-empty
+Context-extraction diagnostics retain consumer operation, context kind,
+correlation id, stable code, boundary, and the Rust error type. The complete
+framework extraction errors are not logged, including their debug or display
+text.
+
+Optional `RequestContext` extraction remains attribution-only. Failure still
+falls back without changing permission or operation admission, but only the error
+type is retained in diagnostics.
+
+## Owner diagnostics
+
+Typed owner failures retain:
+
+- Cart promotion owner and Commerce admin consumer;
+- consumer and owner operation;
+- correlation id and transport boundary;
+- public error code, typed kind, retryability, and public-message presence/length;
+- tenant, actor, cart, request tenant/user/channel UUID non-nil facts;
+- request-context, channel, and locale presence/length facts;
+- effective channel presence and locale length.
+
+The complete `PortError` and identity values are not logged. Tenant, user, cart,
+request tenant/user/channel UUIDs, channel slug, locale, and public error message
+are not written as full structured values.
+
+Unavailable, timeout, and invariant failures retain error severity. Ordinary
+validation, not-found, conflict, and forbidden outcomes retain warning severity.
+
+## Preserved port context
+
+Each mounted promotion call still creates a unique transport correlation id and
+keeps the two-second owner-port deadline. Apply still carries a non-empty
 idempotency key.
 
 When `RequestContext` is available, its effective locale and resolved channel
-are propagated into `PortContext`. Tenant default locale remains the fallback.
-Request-context extraction is attribution-only: failure is logged and does not
-change permission or operation admission.
-
-## Diagnostics
-
-Framework extraction failures retain their original cause only in SSR logs with
-consumer operation, context kind, correlation id, stable code, and boundary.
-
-Typed owner failures are additionally logged at the Commerce admin consumer
-boundary with:
-
-- cart promotion owner and Commerce admin consumer;
-- consumer and owner operation;
-- correlation id, tenant, actor, and cart;
-- request tenant/user/channel/locale when available;
-- public error code, error kind, retryability, and boundary.
-
-Unavailable, timeout, and invariant failures use error severity. Ordinary
-validation, not-found, conflict, and forbidden outcomes use warning severity.
-Promotion source ids, metadata payloads, and raw owner/database causes are not
-added as structured fields.
+continue to cross the owner `PortContext`; tenant default locale remains the
+fallback.
 
 ## Source guard and evidence
 
-The focused guard is:
+Focused guard:
 
 ```text
 scripts/verify/verify-commerce-admin-promotion-native-error-safety.mjs
 ```
 
-Retained source evidence is:
+Retained source evidence:
 
 ```text
 crates/rustok-commerce/contracts/evidence/admin-promotion-native-error-safety-source.json
 crates/rustok-commerce/contracts/evidence/admin-promotion-native-error-safety-source-review.json
 ```
 
-The evidence remains explicitly unvalidated. No focused or aggregate verifier,
-Cargo command, test, formatting command, workflow, CI job, or runtime trace was
-executed for this slice.
+No test, verifier, Cargo command, formatting command, workflow, CI job, or runtime
+trace was executed for this source slice.
 
 ## Remaining work
 
-The ecommerce master mapper-cleanup item stays open. Commerce admin order-change
-errors, tax, and other remaining ecommerce adapters require separate source and
-runtime evidence before the broad invariant can be completed.
+Commerce admin order-change diagnostics in the same SSR adapter remain explicitly
+outside this slice. The broad ecommerce mapper-cleanup item stays open for that
+boundary and the remaining order, payment, fulfillment, inventory, customer, tax,
+promotion, adapter, and non-`PortError` envelopes.

--- a/scripts/verify/verify-commerce-admin-promotion-native-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-promotion-native-error-safety.mjs
@@ -30,7 +30,9 @@ function assertNotContains(text, pattern, description) {
 }
 
 function functionBody(text, functionName) {
-  const signature = new RegExp(`(?:pub(?:\\([^)]*\\))?\\s+)?(?:async\\s+)?fn\\s+${functionName}\\s*\\(`);
+  const signature = new RegExp(
+    `(?:pub(?:\\([^)]*\\))?\\s+)?(?:async\\s+)?fn\\s+${functionName}(?:<[^>]*>)?\\s*\\(`,
+  );
   const match = signature.exec(text);
   if (!match) {
     fail(`missing function ${functionName}`);
@@ -61,10 +63,16 @@ const safeAdapterPath =
   "crates/rustok-commerce/admin/src/transport/native_server_adapter_ssr.rs";
 const evidencePath =
   "crates/rustok-commerce/contracts/evidence/admin-promotion-native-error-safety-source.json";
+const reviewPath =
+  "crates/rustok-commerce/contracts/evidence/admin-promotion-native-error-safety-source-review.json";
+const docPath =
+  "crates/rustok-commerce/docs/admin-promotion-native-error-safety.md";
 
 const routing = readRepo(routingPath);
 const safeAdapter = readRepo(safeAdapterPath);
 const evidence = JSON.parse(readRepo(evidencePath));
+const review = JSON.parse(readRepo(reviewPath));
+const doc = readRepo(docPath);
 
 assertContains(
   routing,
@@ -84,51 +92,112 @@ for (const endpoint of [
   assertContains(safeAdapter, endpoint, `${safeAdapterPath}: missing mounted endpoint ${endpoint}`);
 }
 
-assertContains(
-  safeAdapter,
-  'uuid::Uuid::new_v4()',
-  `${safeAdapterPath}: promotion calls need a unique transport correlation id`,
-);
-assertContains(
-  safeAdapter,
-  'optional_promotion_request_context',
-  `${safeAdapterPath}: request context must be captured for attribution without changing admission`,
-);
-assertContains(
-  safeAdapter,
-  '.map(|context| context.locale.as_str())',
-  `${safeAdapterPath}: effective request locale must cross the promotion port`,
-);
-assertContains(
-  safeAdapter,
-  'context.with_channel(channel)',
-  `${safeAdapterPath}: resolved request channel must cross the promotion port`,
-);
-assertContains(
-  safeAdapter,
-  '.with_idempotency_key(correlation_id.to_string())',
-  `${safeAdapterPath}: promotion write must carry non-empty idempotency semantics`,
-);
-assertContains(
-  safeAdapter,
-  'fn promotion_port_error(',
-  `${safeAdapterPath}: owner PortError must have a consumer-side diagnostic boundary`,
-);
-assertContains(
-  safeAdapter,
-  'ServerFnError::new(error.message)',
-  `${safeAdapterPath}: only the already-sanitized PortError public message may cross the boundary`,
-);
+for (const marker of [
+  "uuid::Uuid::new_v4()",
+  "struct PromotionRequestContextFacts",
+  "fn promotion_request_context_facts(",
+  "optional_promotion_request_context",
+  ".map(|context| context.locale.as_str())",
+  "context.with_channel(channel)",
+  ".with_idempotency_key(correlation_id.to_string())",
+  "fn promotion_port_error(",
+  'owner = "rustok_cart.promotion"',
+  "ServerFnError::new(error.message)",
+]) {
+  assertContains(safeAdapter, marker, `${safeAdapterPath}: missing preserved or safe promotion marker ${marker}`);
+}
 
-for (const [functionName, contextMapper] of [
-  ["commerce_admin_preview_cart_promotion_native", "promotion_auth_context_error"],
-  ["commerce_admin_apply_cart_promotion_native", "promotion_auth_context_error"],
+const contextErrorBody = functionBody(safeAdapter, "promotion_context_error");
+assertContains(
+  contextErrorBody,
+  "let error_type = std::any::type_name::<E>();",
+  `${safeAdapterPath}: framework extraction diagnostics must retain type only`,
+);
+assertContains(contextErrorBody, "error_type", `${safeAdapterPath}: framework error type must be logged`);
+for (const forbidden of ["error = ?error", "error = %error", "error = ?_error", "error = %_error"]) {
+  assertNotContains(
+    contextErrorBody,
+    forbidden,
+    `${safeAdapterPath}: framework extraction diagnostics must not log the complete error`,
+  );
+}
+
+const optionalContextBody = functionBody(safeAdapter, "optional_promotion_request_context");
+assertContains(
+  optionalContextBody,
+  "let error_type = std::any::type_name_of_val(&error);",
+  `${safeAdapterPath}: optional request-context failure must retain type only`,
+);
+for (const forbidden of ["error = ?error", "error = %error"]) {
+  assertNotContains(
+    optionalContextBody,
+    forbidden,
+    `${safeAdapterPath}: optional request-context diagnostics must not log framework text`,
+  );
+}
+
+const portErrorBody = functionBody(safeAdapter, "promotion_port_error");
+for (const marker of [
+  "promotion_request_context_facts(request_context)",
+  "public_message_present",
+  "public_message_length",
+  "tenant_id_non_nil = !tenant.id.is_nil()",
+  "actor_id_non_nil = !auth.user_id.is_nil()",
+  "cart_id_non_nil = !cart_id.is_nil()",
+  "request_context_present = request_facts.request_context_present",
+  "request_tenant_id_non_nil = ?request_facts.request_tenant_id_non_nil",
+  "request_user_id_present = request_facts.request_user_id_present",
+  "request_user_id_non_nil = ?request_facts.request_user_id_non_nil",
+  "channel_id_present = request_facts.channel_id_present",
+  "channel_id_non_nil = ?request_facts.channel_id_non_nil",
+  "channel_slug_present = request_facts.channel_slug_present",
+  "channel_slug_length = ?request_facts.channel_slug_length",
+  "locale_present = request_facts.locale_present",
+  "locale_length = ?request_facts.locale_length",
+  "effective_locale_length",
+  "effective_channel_present",
+  "public_code = %error.code",
+  "error_kind = ?error.kind",
+  "retryable = error.retryable",
+  "PortErrorKind::Unavailable",
+  "PortErrorKind::Timeout",
+  "PortErrorKind::InvariantViolation",
+  "tracing::error!",
+  "tracing::warn!",
+  "ServerFnError::new(error.message)",
+]) {
+  assertContains(portErrorBody, marker, `${safeAdapterPath}: promotion owner mapper missing ${marker}`);
+}
+
+for (const forbidden of [
+  "error = ?error",
+  "error = %error",
+  "tenant_id = %tenant.id",
+  "actor_id = %auth.user_id",
+  "cart_id = %cart_id",
+  "request_tenant_id = ?request_tenant_id",
+  "request_user_id = ?request_user_id",
+  "channel_id = ?channel_id",
+  "channel_slug = ?channel_slug",
+  "locale = ?locale",
+  "public_message = %error.message",
+]) {
+  assertNotContains(
+    portErrorBody,
+    forbidden,
+    `${safeAdapterPath}: promotion owner diagnostics contain raw error or identity field ${forbidden}`,
+  );
+}
+
+for (const functionName of [
+  "commerce_admin_preview_cart_promotion_native",
+  "commerce_admin_apply_cart_promotion_native",
 ]) {
   const body = functionBody(safeAdapter, functionName);
-  assertContains(body, contextMapper, `${safeAdapterPath}: ${functionName} must sanitize auth extraction`);
+  assertContains(body, "promotion_auth_context_error", `${safeAdapterPath}: ${functionName} must sanitize auth extraction`);
   assertContains(body, "promotion_tenant_context_error", `${safeAdapterPath}: ${functionName} must sanitize tenant extraction`);
-  assertContains(body, "optional_promotion_request_context", `${safeAdapterPath}: ${functionName} must capture request attribution`);
-  assertNotContains(body, ".map_err(ServerFnError::new)", `${safeAdapterPath}: ${functionName} must not publish raw framework extraction errors`);
+  assertContains(body, "optional_promotion_request_context", `${safeAdapterPath}: ${functionName} must capture optional request context`);
+  assertNotContains(body, ".map_err(ServerFnError::new)", `${safeAdapterPath}: ${functionName} must not publish raw extraction errors`);
 }
 
 for (const functionName of [
@@ -136,42 +205,33 @@ for (const functionName of [
   "apply_cart_promotion_native_with_context",
 ]) {
   const body = functionBody(safeAdapter, functionName);
-  assertContains(body, "promotion_port_error", `${safeAdapterPath}: ${functionName} must log typed owner failures at the consumer boundary`);
+  assertContains(body, "promotion_port_error", `${safeAdapterPath}: ${functionName} must use the safe owner mapper`);
   assertNotContains(body, "ServerFnError::new(error.to_string())", `${safeAdapterPath}: ${functionName} must not serialize raw owner errors`);
   assertNotContains(body, "ServerFnError::new(err.to_string())", `${safeAdapterPath}: ${functionName} must not serialize raw owner errors`);
 }
 
-assertNotContains(
-  functionBody(safeAdapter, "cart_promotion_port_context"),
-  'format!("commerce-admin-cart-promotion:{operation}:{cart_id}")',
-  `${safeAdapterPath}: promotion correlation must not be deterministic only by operation and cart`,
-);
-
 assertContains(
   safeAdapter,
-  'owner = "rustok_cart.promotion"',
-  `${safeAdapterPath}: diagnostics must identify the cart promotion owner`,
+  "fn order_change_context_error<E: std::fmt::Debug>(",
+  `${safeAdapterPath}: order-change source must remain present and explicitly out of scope`,
 );
-for (const marker of [
-  "consumer_operation",
-  "owner_operation",
-  "correlation_id",
-  "tenant_id",
-  "actor_id",
-  "cart_id",
-  "channel_id",
-  "channel_slug",
-  "locale",
-  "public_code",
-  "error_kind",
-  "retryable",
-  "boundary",
-]) {
-  assertContains(safeAdapter, marker, `${safeAdapterPath}: missing structured diagnostic field ${marker}`);
-}
 
 if (evidence.status !== "commerce_admin_promotion_native_error_safety_source_unvalidated") {
   fail(`${evidencePath}: source evidence must remain explicitly unvalidated`);
+}
+for (const [field, expected] of Object.entries({
+  framework_error_type_only: true,
+  complete_framework_error_logged: false,
+  owner_port_error_shape_only: true,
+  complete_owner_port_error_logged: false,
+  raw_tenant_actor_cart_logged: false,
+  raw_request_context_values_logged: false,
+  public_port_error_message_preserved: true,
+  order_change_cleanup_is_out_of_scope: true,
+})) {
+  if (evidence.source_claims?.[field] !== expected) {
+    fail(`${evidencePath}: source_claims.${field} must be ${expected}`);
+  }
 }
 for (const field of [
   "focused_verifier_executed",
@@ -186,10 +246,30 @@ for (const field of [
   }
 }
 
+if (review.status !== "commerce_admin_promotion_native_error_safety_source_reviewed_unvalidated") {
+  fail(`${reviewPath}: source review must remain explicitly unvalidated`);
+}
+for (const field of [
+  "framework_error_text_removed",
+  "owner_port_error_text_removed",
+  "identity_values_removed",
+  "safe_shape_diagnostics_reviewed",
+  "public_envelopes_preserved",
+  "order_change_source_explicitly_not_claimed_safe",
+]) {
+  if (review.review?.[field] !== true) {
+    fail(`${reviewPath}: review.${field} must be true`);
+  }
+}
+
+assertContains(doc, "Status: `source-complete / unvalidated`", `${docPath}: status must remain unvalidated`);
+assertContains(doc, "complete framework extraction errors are not logged", `${docPath}: framework diagnostic policy`);
+assertContains(doc, "complete `PortError` and identity values are not logged", `${docPath}: owner diagnostic policy`);
+
 if (failures.length > 0) {
   console.error("Commerce admin promotion native error-safety check failed:");
   failures.forEach((failure) => console.error(`✗ ${failure}`));
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log("✔ Commerce admin promotion native error-safety source invariants passed");
+console.log("✔ Commerce admin promotion native diagnostics use correlation-safe shape only; execution evidence remains open");


### PR DESCRIPTION
## Summary

- continue the open ecommerce correlation-safe mapper cleanup with the Commerce Admin promotion SSR consumer
- replace complete auth, tenant, and optional request-context extraction error logging with Rust error-type attribution only
- replace complete owner `PortError` plus tenant/user/cart/request-context identity values with UUID non-nil, presence, length, effective-channel, effective-locale, stable public-code, typed-kind, retryability, and public-message shape facts
- preserve the mounted preview/apply endpoints, permissions, parsing, DTOs, owner operations, severity policy, unique correlation ids, two-second deadline, locale/channel forwarding, write idempotency, and the already-sanitized `ServerFnError::new(error.message)` public path
- update the focused verifier, native diagnostic documentation, source evidence, and source-review evidence

## Confirmed gap

The SSR promotion boundary returned bounded public envelopes but still copied complete framework extraction errors and complete owner `PortError` values into structured events together with tenant, actor, cart, request tenant/user/channel UUIDs, channel slug, and locale. Those values are not required for correlation or classification.

## Scope boundary

Commerce Admin order-change diagnostics share this source file but remain unchanged and explicitly outside this PR. The broad ecommerce mapper-cleanup item remains open.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-commerce-admin-promotion-native-error-safety.mjs
node scripts/verify/verify-commerce-admin-promotion-client-transport-error-safety.mjs
cargo check -p rustok-commerce-admin --all-features
```

## Branch state

The branch is based on `main` at `c4149652fa9c5835336daa29156b1d3e7ba68ac9`, is five commits ahead and zero behind, and changes exactly five Commerce Admin promotion SSR source/docs/evidence/verifier files. Squash merge is intended.