### PR TITLE
test(blog): retain projection retry policy

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json
@@ -28,7 +28,9 @@
     "cases": [
       "shared_created_deleted_classifier",
       "non_blog_target_rejection",
-      "non_negative_saturating_counter_transition"
+      "non_negative_saturating_counter_transition",
+      "optimistic_retry_policy_applies_success_without_retry",
+      "optimistic_retry_policy_allows_seven_retries_then_stops_on_eighth_conflict"
     ]
   },
   "host_registration_harness": {
@@ -132,6 +134,10 @@
       "expected": "the post lookup and update require tenant identity and the observed post version, with a bounded retry loop"
     },
     {
+      "name": "bounded_optimistic_retry_policy",
+      "expected": "the production loop uses one decision helper, applies after one updated row, retries seven zero-row results, and reaches its limit on the eighth"
+    },
+    {
       "name": "missing_post_retry",
       "expected": "a missing tenant post returns an error before the delivery marker is committed so the event runtime can retry"
     },
@@ -181,7 +187,7 @@
     }
   ],
   "runtime_promotion_requirements": [
-    "execute cargo test -p rustok-blog --lib services::comment_projection::tests",
+    "execute cargo test -p rustok-blog --lib services::comment_projection::tests and retain classifier, counter, and deterministic retry-policy output",
     "execute cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing",
     "execute the env-gated PostgreSQL dispatcher case and retain EventBus/EventDispatcher delivery output",
     "execute the env-gated PostgreSQL concurrency case and retain four-connection convergence output",
@@ -191,7 +197,7 @@
     "retain proof that duplicate and out-of-order comment.created/comment.deleted deliveries match the source harness assertions",
     "retain proof that the counter, delivery ledger, and BlogPostUpdated outbox row commit or roll back together",
     "retain missing-post retry and later recovery evidence",
-    "retain explicit optimistic retry-count and exhaustion evidence",
+    "retain PostgreSQL-observed retry count and limit evidence separately from the deterministic source policy",
     "retain full server-host restart recovery evidence separately from the test-process harness"
   ]
 }

--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -112,6 +112,15 @@ source harness is the `services::comment_projection::tests` module in
 `executable_no_run` and suggested command
 `cargo test -p rustok-blog --lib services::comment_projection::tests`.
 
+The production optimistic-update loop now delegates every zero-row/success result
+to the shared pure `ProjectionUpdateDecision` helper. One updated row is applied
+immediately; zero rows produce seven retry decisions before the eighth attempt
+reaches `LimitReached`. The retained Rust cases are
+`optimistic_retry_policy_applies_success_without_retry` and
+`optimistic_retry_policy_allows_seven_retries_then_stops_on_eighth_conflict`.
+They are `executable_no_run` source-policy evidence and do not measure PostgreSQL
+contention, observed retry frequency, or runtime terminal-limit behavior.
+
 The retained host registration target is the `tests` module in
 `crates/rustok-blog/src/lib.rs`. It creates the real module listener context,
 invokes `BlogModule::register_event_listeners`, extracts the single registered
@@ -182,9 +191,10 @@ full application server-host restart, and no execution result is recorded.
 Exact commands `verify:blog:comments-event-projection` and
 `test:verify:blog:comments-event-projection` run after the Comments port gate in
 the Blog FBA chains. Overall status remains `source_verified_no_compile`;
-measured optimistic retry-count/exhaustion, dispatcher/PostgreSQL/process-target
-execution, full server-host restart recovery, and all other runtime evidence
-remain pending.
+the deterministic eight-attempt retry policy is source-locked, while PostgreSQL-
+observed retry frequency/terminal-limit behavior, dispatcher/PostgreSQL/process-
+target execution, full server-host restart recovery, and all other runtime
+evidence remain pending.
 
 Blog categories use the exclusive `blog_categories:*` permission resource.
 `CategoryService::new(db, event_bus)` is the only owner constructor. Category
@@ -366,18 +376,27 @@ Evidence schema v4 and Blog registry schema v13 remain compatible; focused guard
 retain the parent, worker, two child launches, exact command, and non-claim for a
 full server-host restart without recording execution.
 
+The continuation audit at `c4149652fa9c5835336daa29156b1d3e7ba68ac9`
+found that the eight-attempt optimistic loop exposed a constant and final error but
+had no shared source decision boundary tying success, retry, and terminal-limit
+behavior to executable cases. Slice 52 introduces `ProjectionUpdateDecision`,
+routes the production loop through it, and retains deterministic Rust cases for
+immediate success plus seven retry decisions followed by the eighth-attempt
+limit. Evidence schema v4 and Blog registry schema v13 remain compatible; no Rust
+test, verifier, compile, PostgreSQL, browser, workflow, or CI result is recorded.
+
 ## FFA/FBA status
 
 - FFA status: `in_progress`.
 - FBA status: `boundary_ready` (`core_transport_ui`).
 - Blog FBA source-gate chain: `source_verified_no_compile`; registry schema v13
   locks exact verify/test order, source-gate paths, leaf npm commands, evidence,
-  self-tests, the Comments projection classifier, host registration, dispatcher,
-  concurrency, PostgreSQL, same-process restart, and process-restart harnesses,
-  and aggregate/consumer bindings for admin, storefront, Comments port boundary,
-  Comments event projection, category Search reindex, GraphQL rate limiting,
-  GraphQL richtext, AI richtext, offline backfill, Forum ownership, and runtime
-  order.
+  self-tests, the Comments projection classifier, deterministic retry policy,
+  host registration, dispatcher, concurrency, PostgreSQL, same-process restart,
+  and process-restart harnesses, and aggregate/consumer bindings for admin,
+  storefront, Comments port boundary, Comments event projection, category Search
+  reindex, GraphQL rate limiting, GraphQL richtext, AI richtext, offline backfill,
+  Forum ownership, and runtime order.
 - Comments consumer port boundary: Blog-owned `source_verified_no_compile` for
   the in-process profile; all seven operations, approved public read, typed
   richtext projection, two-second deadlines, write idempotency, active typed
@@ -388,19 +407,22 @@ full server-host restart without recording execution.
   comment-form fallback, browser/runtime evidence, and broader degraded UI modes
   remain planned or pending.
 - Comments event projection: Blog-owned `source_verified_no_compile`; evidence
-  schema v4, shared classifier/counter helpers, `executable_no_run` classifier,
-  module-registration, dispatcher, concurrency, PostgreSQL transaction,
-  same-process restart, and process-restart targets, verifier, focused self-test,
-  exact npm leaf commands, delivery-ledger identity, transactional outbox markers,
-  and Blog FBA ordering are locked. The registration target verifies
-  identity/routing only. The dispatcher target passes one envelope through
-  `EventBus` and `EventDispatcher` into the module-registered handler and waits
-  for the durable commit. The concurrency target starts four independent
+  schema v4, shared classifier/counter/retry-decision helpers, `executable_no_run`
+  source harness, module-registration, dispatcher, concurrency, PostgreSQL
+  transaction, same-process restart, and process-restart targets, verifier,
+  focused self-test, exact npm leaf commands, delivery-ledger identity,
+  transactional outbox markers, and Blog FBA ordering are locked. The source
+  policy records immediate success, seven retry decisions, and the eighth-attempt
+  terminal limit without claiming observed PostgreSQL contention. The registration
+  target verifies identity/routing only. The dispatcher target passes one envelope
+  through `EventBus` and `EventDispatcher` into the module-registered handler and
+  waits for the durable commit. The concurrency target starts four independent
   PostgreSQL connections behind one barrier and requires a four-count/five-version
   result with four delivery and outbox rows. The process target launches two
   sequential OS test processes against the same schema and envelope ID. None of
-  these targets has been run. Measured retry count, optimistic exhaustion, full
-  server-host restart recovery, and all execution evidence remain pending.
+  these targets has been run. PostgreSQL-observed retry frequency/terminal-limit
+  behavior, full server-host restart recovery, and all execution evidence remain
+  pending.
 - Load protection: `implementation_ready`; mounted Redis evidence is pending.
 - Rate-limit harness: `executable_no_compile`; evidence, verifier, self-test,
   npm leaf commands, and aggregate FBA registration are locked; execution is
@@ -602,6 +624,11 @@ full server-host restart without recording execution.
     private worker, exact two-launch boundary, final counter/ledger/outbox
     assertions, evidence metadata, and focused negative fixtures without claiming
     a full server-host restart or recording execution.
+52. Added a shared pure optimistic retry decision used by the production projection
+    loop, retained immediate-success and seven-retry/eighth-limit Rust cases in
+    evidence plus focused fail-closed fixtures, and kept PostgreSQL-observed retry
+    behavior, registry schema v13, package order, and all execution unchanged or
+    pending.
 
 ## Next results
 
@@ -619,18 +646,19 @@ full server-host restart without recording execution.
    controller handoff, focused verifier, then Redis-backed host requests with a
    real HTTP `Retry-After` matching GraphQL `retryAfter`.
 5. **Close comments runtime evidence.** Run the Comments port boundary fixture,
-   shared consumer runtime-order verifier, Blog projection classifier harness,
-   module registration/routing harness, the filtered
-   `event_dispatcher_routes_registered_handler_and_commits_projection`,
+   shared consumer runtime-order verifier, Blog projection classifier and
+   deterministic retry-policy harness, module registration/routing harness, the
+   filtered `event_dispatcher_routes_registered_handler_and_commits_projection`,
    `concurrent_created_events_converge_without_lost_updates`, and
    `restarted_process_reuses_delivery_ledger_without_reapplying_counter` cases,
    the complete `comment_projection_postgres_test` and
    `comment_projection_restart_postgres_test` targets, both thread invariant
    concurrency targets, and concurrent PostgreSQL create/delete transactions.
-   Retain dispatcher delivery output, four-connection convergence, both child
-   process exits, the written duplicate, delete-before-create, missing-post
-   replay, outbox rollback/retry, and same-process/new-connection assertions;
-   then cover measured optimistic retry count and exhaustion, full server-host
+   Retain deterministic immediate-success/seven-retry/eighth-limit output,
+   dispatcher delivery output, four-connection convergence, both child process
+   exits, the written duplicate, delete-before-create, missing-post replay,
+   outbox rollback/retry, and same-process/new-connection assertions; then retain
+   PostgreSQL-observed retry frequency/terminal-limit behavior, full server-host
    restart recovery, remote adapter parity, browser parity for typed
    unavailable/timeout article rendering, cached thread snapshots, comment-form
    fallback, approved-only reads, moderation, pagination, first-thread identity,
@@ -651,6 +679,8 @@ should run the relevant subset, including:
 - `npm run verify:blog:comments-event-projection`
 - `npm run test:verify:blog:comments-event-projection`
 - `cargo test -p rustok-blog --lib services::comment_projection::tests`
+- `cargo test -p rustok-blog --lib services::comment_projection::tests::optimistic_retry_policy_applies_success_without_retry -- --exact`
+- `cargo test -p rustok-blog --lib services::comment_projection::tests::optimistic_retry_policy_allows_seven_retries_then_stops_on_eighth_conflict -- --exact`
 - `cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test event_dispatcher_routes_registered_handler_and_commits_projection -- --exact`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test concurrent_created_events_converge_without_lost_updates -- --exact`

--- a/crates/rustok-blog/src/services/comment_projection.rs
+++ b/crates/rustok-blog/src/services/comment_projection.rs
@@ -24,6 +24,13 @@ struct CommentProjectionChange {
     delta: i32,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProjectionUpdateDecision {
+    Applied,
+    Retry,
+    Exhausted,
+}
+
 fn comment_projection_change(event: &DomainEvent) -> Option<CommentProjectionChange> {
     match event {
         DomainEvent::CommentCreated {
@@ -55,6 +62,19 @@ fn next_comment_projection_state(comment_count: i32, version: i32, delta: i32) -
         comment_count.saturating_add(delta).max(0),
         version.saturating_add(1),
     )
+}
+
+fn projection_update_decision(
+    attempt_index: usize,
+    rows_affected: u64,
+) -> ProjectionUpdateDecision {
+    if rows_affected == 1 {
+        ProjectionUpdateDecision::Applied
+    } else if attempt_index + 1 < MAX_PROJECTION_UPDATE_ATTEMPTS {
+        ProjectionUpdateDecision::Retry
+    } else {
+        ProjectionUpdateDecision::Exhausted
+    }
 }
 
 /// Projects Comments lifecycle events into Blog-owned reply-count state.
@@ -132,7 +152,7 @@ async fn update_comment_count_in_tx(
     post_id: Uuid,
     delta: i32,
 ) -> HandlerResult {
-    for _ in 0..MAX_PROJECTION_UPDATE_ATTEMPTS {
+    for attempt_index in 0..MAX_PROJECTION_UPDATE_ATTEMPTS {
         let Some(post) = blog_post::Entity::find_by_id(post_id)
             .filter(blog_post::Column::TenantId.eq(tenant_id))
             .one(txn)
@@ -161,8 +181,10 @@ async fn update_comment_count_in_tx(
             .exec(txn)
             .await?;
 
-        if result.rows_affected == 1 {
-            return Ok(());
+        match projection_update_decision(attempt_index, result.rows_affected) {
+            ProjectionUpdateDecision::Applied => return Ok(()),
+            ProjectionUpdateDecision::Retry => continue,
+            ProjectionUpdateDecision::Exhausted => break,
         }
     }
 
@@ -251,6 +273,37 @@ mod tests {
         assert_eq!(
             next_comment_projection_state(i32::MAX, i32::MAX, 1),
             (i32::MAX, i32::MAX)
+        );
+    }
+
+    #[test]
+    fn optimistic_retry_policy_applies_success_without_retry() {
+        assert_eq!(
+            projection_update_decision(0, 1),
+            ProjectionUpdateDecision::Applied
+        );
+        assert_eq!(
+            projection_update_decision(MAX_PROJECTION_UPDATE_ATTEMPTS - 1, 1),
+            ProjectionUpdateDecision::Applied
+        );
+    }
+
+    #[test]
+    fn optimistic_retry_policy_retries_seven_times_then_exhausts_on_eighth_conflict() {
+        let decisions = (0..MAX_PROJECTION_UPDATE_ATTEMPTS)
+            .map(|attempt_index| projection_update_decision(attempt_index, 0))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            decisions
+                .iter()
+                .filter(|decision| **decision == ProjectionUpdateDecision::Retry)
+                .count(),
+            MAX_PROJECTION_UPDATE_ATTEMPTS - 1
+        );
+        assert_eq!(
+            decisions.last(),
+            Some(&ProjectionUpdateDecision::Exhausted)
         );
     }
 }

--- a/crates/rustok-blog/src/services/comment_projection.rs
+++ b/crates/rustok-blog/src/services/comment_projection.rs
@@ -28,7 +28,7 @@ struct CommentProjectionChange {
 enum ProjectionUpdateDecision {
     Applied,
     Retry,
-    Exhausted,
+    LimitReached,
 }
 
 fn comment_projection_change(event: &DomainEvent) -> Option<CommentProjectionChange> {
@@ -73,7 +73,7 @@ fn projection_update_decision(
     } else if attempt_index + 1 < MAX_PROJECTION_UPDATE_ATTEMPTS {
         ProjectionUpdateDecision::Retry
     } else {
-        ProjectionUpdateDecision::Exhausted
+        ProjectionUpdateDecision::LimitReached
     }
 }
 
@@ -184,7 +184,7 @@ async fn update_comment_count_in_tx(
         match projection_update_decision(attempt_index, result.rows_affected) {
             ProjectionUpdateDecision::Applied => return Ok(()),
             ProjectionUpdateDecision::Retry => continue,
-            ProjectionUpdateDecision::Exhausted => break,
+            ProjectionUpdateDecision::LimitReached => break,
         }
     }
 
@@ -289,7 +289,7 @@ mod tests {
     }
 
     #[test]
-    fn optimistic_retry_policy_retries_seven_times_then_exhausts_on_eighth_conflict() {
+    fn optimistic_retry_policy_allows_seven_retries_then_stops_on_eighth_conflict() {
         let decisions = (0..MAX_PROJECTION_UPDATE_ATTEMPTS)
             .map(|attempt_index| projection_update_decision(attempt_index, 0))
             .collect::<Vec<_>>();
@@ -303,7 +303,7 @@ mod tests {
         );
         assert_eq!(
             decisions.last(),
-            Some(&ProjectionUpdateDecision::Exhausted)
+            Some(&ProjectionUpdateDecision::LimitReached)
         );
     }
 }

--- a/scripts/verify/verify-blog-comments-event-projection.mjs
+++ b/scripts/verify/verify-blog-comments-event-projection.mjs
@@ -82,6 +82,10 @@ for (const marker of [
   'const BLOG_POST_TARGET_TYPE: &str = "blog_post";',
   'const MAX_PROJECTION_UPDATE_ATTEMPTS: usize = 8;',
   'struct CommentProjectionChange',
+  'enum ProjectionUpdateDecision',
+  'ProjectionUpdateDecision::Applied',
+  'ProjectionUpdateDecision::Retry',
+  'ProjectionUpdateDecision::LimitReached',
   'fn comment_projection_change(event: &DomainEvent) -> Option<CommentProjectionChange>',
   'DomainEvent::CommentCreated',
   'delta: 1',
@@ -90,6 +94,10 @@ for (const marker of [
   'fn next_comment_projection_state(comment_count: i32, version: i32, delta: i32)',
   'comment_count.saturating_add(delta).max(0)',
   'version.saturating_add(1)',
+  'fn projection_update_decision(',
+  'attempt_index: usize',
+  'rows_affected: u64',
+  'else if attempt_index + 1 < MAX_PROJECTION_UPDATE_ATTEMPTS',
   'let Some(change) = comment_projection_change(&envelope.event) else',
   'let txn = self.db.begin().await?;',
   'blog_comment_projection_delivery::Entity::find_by_id(envelope.id)',
@@ -104,7 +112,8 @@ for (const marker of [
   'Column::TenantId.eq(tenant_id)',
   'Column::Version.eq(post.version)',
   'next_comment_projection_state(post.comment_count, post.version, delta)',
-  'if result.rows_affected == 1',
+  'for attempt_index in 0..MAX_PROJECTION_UPDATE_ATTEMPTS',
+  'match projection_update_decision(attempt_index, result.rows_affected)',
   'Error::NotFound',
   'impl EventHandler for BlogCommentProjectionHandler',
   'comment_projection_change(event).is_some()',
@@ -112,6 +121,10 @@ for (const marker of [
   'fn classifies_blog_comment_lifecycle_events()',
   'fn ignores_non_blog_targets_and_unrelated_events()',
   'fn counter_transition_is_non_negative_and_saturating()',
+  'fn optimistic_retry_policy_applies_success_without_retry()',
+  'fn optimistic_retry_policy_allows_seven_retries_then_stops_on_eighth_conflict()',
+  'MAX_PROJECTION_UPDATE_ATTEMPTS - 1',
+  'Some(&ProjectionUpdateDecision::LimitReached)',
 ]) {
   requireMarker(handler, marker, handlerPath);
 }
@@ -125,6 +138,26 @@ if (handlesStart === -1 || handleStart === -1) {
   const handlesBody = handler.slice(handlesStart, handleStart);
   requireMarker(handlesBody, 'comment_projection_change(event).is_some()', `${handlerPath}: handles`);
   requireNoMarker(handlesBody, 'matches!(', `${handlerPath}: handles`);
+}
+
+const retryLoopStart = handler.indexOf(
+  'for attempt_index in 0..MAX_PROJECTION_UPDATE_ATTEMPTS',
+);
+const retryLoopEnd = handler.indexOf('Err(Error::External(format!(', retryLoopStart);
+if (retryLoopStart === -1 || retryLoopEnd === -1) {
+  failures.push(`${handlerPath}: missing bounded optimistic retry loop boundary`);
+} else {
+  const retryLoopBody = handler.slice(retryLoopStart, retryLoopEnd);
+  requireMarker(
+    retryLoopBody,
+    'match projection_update_decision(attempt_index, result.rows_affected)',
+    `${handlerPath}: retry loop`,
+  );
+  requireNoMarker(
+    retryLoopBody,
+    'if result.rows_affected == 1',
+    `${handlerPath}: retry loop`,
+  );
 }
 
 for (const marker of [
@@ -327,6 +360,8 @@ if (evidence) {
       'shared_created_deleted_classifier',
       'non_blog_target_rejection',
       'non_negative_saturating_counter_transition',
+      'optimistic_retry_policy_applies_success_without_retry',
+      'optimistic_retry_policy_allows_seven_retries_then_stops_on_eighth_conflict',
     ].sort().join('|')
   ) {
     failures.push(`${evidencePath}: source harness case drift`);
@@ -458,6 +493,7 @@ if (evidence) {
     'envelope_idempotency',
     'atomic_counter_delivery_outbox',
     'tenant_scoped_optimistic_update',
+    'bounded_optimistic_retry_policy',
     'missing_post_retry',
     'non_negative_count',
     'host_registration_routing_harness',
@@ -533,6 +569,8 @@ for (const marker of [
   'test:verify:blog:comments-event-projection',
   'source_verified_no_compile',
   'services::comment_projection::tests',
+  'ProjectionUpdateDecision',
+  'seven retry decisions',
   'tests::module_registers_comment_projection_handler_with_host_routing',
   'event_dispatcher_routes_registered_handler_and_commits_projection',
   'concurrent_created_events_converge_without_lost_updates',
@@ -555,4 +593,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log('Blog comments event projection classifier, registration, dispatcher, concurrency, PostgreSQL, connection restart, and process restart harnesses are consistent');
+console.log('Blog comments event projection classifier, retry policy, registration, dispatcher, concurrency, PostgreSQL, connection restart, and process restart harnesses are consistent');

--- a/scripts/verify/verify-blog-comments-event-projection.test.mjs
+++ b/scripts/verify/verify-blog-comments-event-projection.test.mjs
@@ -28,6 +28,10 @@ function fixture({
   missingSharedClassifier = false,
   directHandlesClassifier = false,
   missingCounterHarness = false,
+  missingRetryDecisionHelper = false,
+  bypassRetryDecisionHelper = false,
+  missingRetryPolicyHarness = false,
+  missingRetryPolicyEvidence = false,
   missingPostgresHarness = false,
   missingRollbackCase = false,
   missingPostgresRegistration = false,
@@ -65,6 +69,26 @@ function fixture({
   const restartHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test';
   const processRestartHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test restarted_process_reuses_delivery_ledger_without_reapplying_counter -- --exact';
 
+  const retryHelperSource = missingRetryDecisionHelper
+    ? ''
+    : `
+fn projection_update_decision(
+attempt_index: usize
+rows_affected: u64
+else if attempt_index + 1 < MAX_PROJECTION_UPDATE_ATTEMPTS
+`;
+  const retryLoopSource = bypassRetryDecisionHelper
+    ? 'if result.rows_affected == 1'
+    : 'match projection_update_decision(attempt_index, result.rows_affected)';
+  const retryHarnessSource = missingRetryPolicyHarness
+    ? ''
+    : `
+fn optimistic_retry_policy_applies_success_without_retry()
+fn optimistic_retry_policy_allows_seven_retries_then_stops_on_eighth_conflict()
+MAX_PROJECTION_UPDATE_ATTEMPTS - 1
+Some(&ProjectionUpdateDecision::LimitReached)
+`;
+
   write(
     root,
     handlerPath,
@@ -72,6 +96,10 @@ function fixture({
 const BLOG_POST_TARGET_TYPE: &str = "blog_post";
 const MAX_PROJECTION_UPDATE_ATTEMPTS: usize = 8;
 struct CommentProjectionChange
+enum ProjectionUpdateDecision
+ProjectionUpdateDecision::Applied
+ProjectionUpdateDecision::Retry
+ProjectionUpdateDecision::LimitReached
 ${missingSharedClassifier ? '' : 'fn comment_projection_change(event: &DomainEvent) -> Option<CommentProjectionChange>'}
 DomainEvent::CommentCreated
 delta: 1
@@ -80,6 +108,7 @@ delta: -1
 fn next_comment_projection_state(comment_count: i32, version: i32, delta: i32)
 comment_count.saturating_add(delta).max(0)
 version.saturating_add(1)
+${retryHelperSource}
 ${missingSharedClassifier ? '' : 'let Some(change) = comment_projection_change(&envelope.event) else'}
 let txn = self.db.begin().await?;
 ${missingDeliveryLookup ? '' : 'blog_comment_projection_delivery::Entity::find_by_id(envelope.id)'}
@@ -92,7 +121,9 @@ txn.commit().await?;
 ${missingTenantScope ? '' : 'Column::TenantId.eq(tenant_id)'}
 Column::Version.eq(post.version)
 next_comment_projection_state(post.comment_count, post.version, delta)
-if result.rows_affected == 1
+for attempt_index in 0..MAX_PROJECTION_UPDATE_ATTEMPTS
+${retryLoopSource}
+Err(Error::External(format!(
 Error::NotFound
 impl EventHandler for BlogCommentProjectionHandler
 fn handles(&self, event: &DomainEvent) -> bool {
@@ -103,6 +134,7 @@ async fn handle(&self, envelope: &EventEnvelope)
 fn classifies_blog_comment_lifecycle_events()
 fn ignores_non_blog_targets_and_unrelated_events()
 ${missingCounterHarness ? '' : 'fn counter_transition_is_non_negative_and_saturating()'}
+${retryHarnessSource}
 `,
   );
 
@@ -281,6 +313,18 @@ assert!(!handler.handles(&forum_created));
 }`;
   write(root, modulePath, `${registrationSource}\n${hostHarnessSource}`);
 
+  const sourceHarnessCases = [
+    'shared_created_deleted_classifier',
+    'non_blog_target_rejection',
+    'non_negative_saturating_counter_transition',
+    ...(missingRetryPolicyEvidence
+      ? []
+      : [
+          'optimistic_retry_policy_applies_success_without_retry',
+          'optimistic_retry_policy_allows_seven_retries_then_stops_on_eighth_conflict',
+        ]),
+  ];
+
   write(
     root,
     evidencePath,
@@ -308,11 +352,7 @@ assert!(!handler.handles(&forum_created));
         path: handlerPath,
         module: 'services::comment_projection::tests',
         command: harnessCommand,
-        cases: [
-          'shared_created_deleted_classifier',
-          'non_blog_target_rejection',
-          'non_negative_saturating_counter_transition',
-        ],
+        cases: sourceHarnessCases,
       },
       host_registration_harness: {
         status: hostHarnessStatusDrift ? 'executed' : 'executable_no_run',
@@ -388,6 +428,7 @@ assert!(!handler.handles(&forum_created));
         { name: 'envelope_idempotency' },
         { name: 'atomic_counter_delivery_outbox' },
         { name: 'tenant_scoped_optimistic_update' },
+        ...(missingRetryPolicyEvidence ? [] : [{ name: 'bounded_optimistic_retry_policy' }]),
         { name: 'missing_post_retry' },
         { name: 'non_negative_count' },
         { name: 'host_registration_routing_harness' },
@@ -449,7 +490,7 @@ assert!(!handler.handles(&forum_created));
   write(
     root,
     'crates/rustok-blog/docs/implementation-plan.md',
-    'blog-comments-event-projection.json verify:blog:comments-event-projection test:verify:blog:comments-event-projection source_verified_no_compile services::comment_projection::tests tests::module_registers_comment_projection_handler_with_host_routing event_dispatcher_routes_registered_handler_and_commits_projection concurrent_created_events_converge_without_lost_updates restarted_process_reuses_delivery_ledger_without_reapplying_counter comment_projection_postgres_test comment_projection_restart_postgres_test RUSTOK_BLOG_TEST_DATABASE_URL EventBus EventDispatcher independent PostgreSQL connections two sequential OS test processes server-host restart',
+    'blog-comments-event-projection.json verify:blog:comments-event-projection test:verify:blog:comments-event-projection source_verified_no_compile services::comment_projection::tests ProjectionUpdateDecision seven retry decisions tests::module_registers_comment_projection_handler_with_host_routing event_dispatcher_routes_registered_handler_and_commits_projection concurrent_created_events_converge_without_lost_updates restarted_process_reuses_delivery_ledger_without_reapplying_counter comment_projection_postgres_test comment_projection_restart_postgres_test RUSTOK_BLOG_TEST_DATABASE_URL EventBus EventDispatcher independent PostgreSQL connections two sequential OS test processes server-host restart',
   );
 
   return root;
@@ -548,6 +589,31 @@ test('rejects a missing counter transition harness', () => {
     { missingCounterHarness: true },
     /missing fn counter_transition_is_non_negative_and_saturating/,
   );
+});
+
+test('rejects a missing retry decision helper', () => {
+  expectRejected(
+    { missingRetryDecisionHelper: true },
+    /missing fn projection_update_decision/,
+  );
+});
+
+test('rejects a production loop that bypasses the retry decision helper', () => {
+  expectRejected(
+    { bypassRetryDecisionHelper: true },
+    /forbidden if result.rows_affected == 1/,
+  );
+});
+
+test('rejects a missing deterministic retry policy harness', () => {
+  expectRejected(
+    { missingRetryPolicyHarness: true },
+    /missing fn optimistic_retry_policy_applies_success_without_retry/,
+  );
+});
+
+test('rejects retry policy evidence drift', () => {
+  expectRejected({ missingRetryPolicyEvidence: true }, /source harness case drift/);
 });
 
 test('rejects a missing PostgreSQL harness source', () => {


### PR DESCRIPTION
## Summary

- add a pure `ProjectionUpdateDecision` used by the production optimistic update loop
- preserve the existing eight-attempt boundary and public error behavior
- add deterministic source cases for immediate success and seven retries followed by the eighth-attempt limit
- extend Comments event-projection evidence schema v4 and focused source guardrails
- update the canonical Blog implementation plan through slice 52
- keep Blog registry schema v13 and package command order unchanged
- keep PostgreSQL-observed retry behavior and all execution pending

## Validation

Not run by request. No verifier, Rust test, compile, PostgreSQL, browser, workflow, or CI command was executed.