### PR TITLE
fix(commerce): sanitize order-change SSR diagnostics

### DIFF
--- a/crates/rustok-commerce/admin/src/transport/native_server_adapter_ssr.rs
+++ b/crates/rustok-commerce/admin/src/transport/native_server_adapter_ssr.rs
@@ -635,20 +635,135 @@ async fn apply_cart_promotion_native_with_context(
 // Order-change native boundary
 // -----------------------------------------------------------------------------
 
+struct OrderChangeRequestContextFacts {
+    request_context_present: bool,
+    request_tenant_id_non_nil: Option<bool>,
+    request_user_id_present: bool,
+    request_user_id_non_nil: Option<bool>,
+    channel_id_present: bool,
+    channel_id_non_nil: Option<bool>,
+    channel_slug_present: bool,
+    channel_slug_length: Option<usize>,
+    locale_present: bool,
+    locale_length: Option<usize>,
+}
+
+fn order_change_request_context_facts(
+    request_context: Option<&rustok_api::RequestContext>,
+) -> OrderChangeRequestContextFacts {
+    OrderChangeRequestContextFacts {
+        request_context_present: request_context.is_some(),
+        request_tenant_id_non_nil: request_context.map(|context| !context.tenant_id.is_nil()),
+        request_user_id_present: request_context.and_then(|context| context.user_id).is_some(),
+        request_user_id_non_nil: request_context
+            .and_then(|context| context.user_id)
+            .map(|value| !value.is_nil()),
+        channel_id_present: request_context
+            .and_then(|context| context.channel_id)
+            .is_some(),
+        channel_id_non_nil: request_context
+            .and_then(|context| context.channel_id)
+            .map(|value| !value.is_nil()),
+        channel_slug_present: request_context
+            .and_then(|context| context.channel_slug.as_ref())
+            .is_some(),
+        channel_slug_length: request_context
+            .and_then(|context| context.channel_slug.as_ref())
+            .map(|value| value.chars().count()),
+        locale_present: request_context.is_some(),
+        locale_length: request_context.map(|context| context.locale.chars().count()),
+    }
+}
+
+struct OrderChangeOwnerErrorFacts {
+    validation_detail_present: bool,
+    validation_detail_length: Option<usize>,
+    resource_id_present: bool,
+    resource_id_non_nil: Option<bool>,
+    transition_from_length: Option<usize>,
+    transition_to_length: Option<usize>,
+    database_cause_present: bool,
+    core_cause_present: bool,
+}
+
+fn order_change_owner_error_facts(
+    error: &rustok_order::error::OrderError,
+) -> OrderChangeOwnerErrorFacts {
+    match error {
+        rustok_order::error::OrderError::Validation(detail) => OrderChangeOwnerErrorFacts {
+            validation_detail_present: !detail.trim().is_empty(),
+            validation_detail_length: Some(detail.chars().count()),
+            resource_id_present: false,
+            resource_id_non_nil: None,
+            transition_from_length: None,
+            transition_to_length: None,
+            database_cause_present: false,
+            core_cause_present: false,
+        },
+        rustok_order::error::OrderError::OrderNotFound(id)
+        | rustok_order::error::OrderError::OrderReturnNotFound(id)
+        | rustok_order::error::OrderError::OrderChangeNotFound(id) => {
+            OrderChangeOwnerErrorFacts {
+                validation_detail_present: false,
+                validation_detail_length: None,
+                resource_id_present: true,
+                resource_id_non_nil: Some(!id.is_nil()),
+                transition_from_length: None,
+                transition_to_length: None,
+                database_cause_present: false,
+                core_cause_present: false,
+            }
+        }
+        rustok_order::error::OrderError::InvalidTransition { from, to } => {
+            OrderChangeOwnerErrorFacts {
+                validation_detail_present: false,
+                validation_detail_length: None,
+                resource_id_present: false,
+                resource_id_non_nil: None,
+                transition_from_length: Some(from.chars().count()),
+                transition_to_length: Some(to.chars().count()),
+                database_cause_present: false,
+                core_cause_present: false,
+            }
+        }
+        rustok_order::error::OrderError::Database(_) => OrderChangeOwnerErrorFacts {
+            validation_detail_present: false,
+            validation_detail_length: None,
+            resource_id_present: false,
+            resource_id_non_nil: None,
+            transition_from_length: None,
+            transition_to_length: None,
+            database_cause_present: true,
+            core_cause_present: false,
+        },
+        rustok_order::error::OrderError::Core(_) => OrderChangeOwnerErrorFacts {
+            validation_detail_present: false,
+            validation_detail_length: None,
+            resource_id_present: false,
+            resource_id_non_nil: None,
+            transition_from_length: None,
+            transition_to_length: None,
+            database_cause_present: false,
+            core_cause_present: true,
+        },
+    }
+}
+
 fn order_change_correlation_id(operation: &'static str) -> String {
     transport_correlation_id("commerce-admin-order-change", operation)
 }
 
 fn order_change_context_error<E: std::fmt::Debug>(
-    error: E,
+    _error: E,
     operation: &'static str,
     context_kind: &'static str,
     correlation_id: &str,
     code: &'static str,
     public_message: &'static str,
 ) -> ServerFnError {
+    let error_type = std::any::type_name::<E>();
     tracing::error!(
-        error = ?error,
+        error_type,
         consumer = COMMERCE_ADMIN_ORDER_CHANGE_CONSUMER,
         operation,
         context_kind,
@@ -697,8 +812,9 @@ async fn optional_order_change_request_context(
     match leptos_axum::extract::<rustok_api::RequestContext>().await {
         Ok(context) => Some(context),
         Err(error) => {
+            let error_type = std::any::type_name_of_val(&error);
             tracing::warn!(
-                error = ?error,
+                error_type,
                 consumer = COMMERCE_ADMIN_ORDER_CHANGE_CONSUMER,
                 operation,
                 context_kind = "request",
@@ -723,20 +839,24 @@ fn order_service_from_context(
     let event_bus = runtime_ctx
         .shared_get::<rustok_outbox::TransactionalEventBus>()
         .ok_or_else(|| {
-            let (request_tenant_id, request_user_id, channel_id, channel_slug, locale) =
-                request_context_fields(request_context);
+            let request_facts = order_change_request_context_facts(request_context);
             tracing::error!(
                 owner = "rustok_order",
                 consumer = COMMERCE_ADMIN_ORDER_CHANGE_CONSUMER,
                 operation,
                 correlation_id,
-                tenant_id = %tenant.id,
-                actor_id = %auth.user_id,
-                request_tenant_id = ?request_tenant_id,
-                request_user_id = ?request_user_id,
-                channel_id = ?channel_id,
-                channel_slug = ?channel_slug,
-                locale = ?locale,
+                tenant_id_non_nil = !tenant.id.is_nil(),
+                actor_id_non_nil = !auth.user_id.is_nil(),
+                request_context_present = request_facts.request_context_present,
+                request_tenant_id_non_nil = ?request_facts.request_tenant_id_non_nil,
+                request_user_id_present = request_facts.request_user_id_present,
+                request_user_id_non_nil = ?request_facts.request_user_id_non_nil,
+                channel_id_present = request_facts.channel_id_present,
+                channel_id_non_nil = ?request_facts.channel_id_non_nil,
+                channel_slug_present = request_facts.channel_slug_present,
+                channel_slug_length = ?request_facts.channel_slug_length,
+                locale_present = request_facts.locale_present,
+                locale_length = ?request_facts.locale_length,
                 code = "commerce.admin_order_change_runtime_unavailable",
                 boundary = COMMERCE_ADMIN_ORDER_CHANGE_BOUNDARY,
                 "commerce admin order-change runtime composition is unavailable"
@@ -806,24 +926,43 @@ fn order_change_owner_error(
         ),
     };
 
-    let (request_tenant_id, request_user_id, channel_id, channel_slug, locale) =
-        request_context_fields(context.request_context);
+    let request_facts = order_change_request_context_facts(context.request_context);
+    let error_facts = order_change_owner_error_facts(&error);
+    let order_id_present = context.order_id.is_some();
+    let order_id_non_nil = context.order_id.map(|value| !value.is_nil());
+    let order_change_id_present = context.order_change_id.is_some();
+    let order_change_id_non_nil = context.order_change_id.map(|value| !value.is_nil());
+
     if severe {
         tracing::error!(
-            error = ?error,
             owner = "rustok_order",
             consumer = COMMERCE_ADMIN_ORDER_CHANGE_CONSUMER,
             operation = context.operation,
             correlation_id = context.correlation_id,
-            tenant_id = %context.tenant.id,
-            actor_id = %context.auth.user_id,
-            order_id = ?context.order_id,
-            order_change_id = ?context.order_change_id,
-            request_tenant_id = ?request_tenant_id,
-            request_user_id = ?request_user_id,
-            channel_id = ?channel_id,
-            channel_slug = ?channel_slug,
-            locale = ?locale,
+            tenant_id_non_nil = !context.tenant.id.is_nil(),
+            actor_id_non_nil = !context.auth.user_id.is_nil(),
+            order_id_present,
+            order_id_non_nil = ?order_id_non_nil,
+            order_change_id_present,
+            order_change_id_non_nil = ?order_change_id_non_nil,
+            request_context_present = request_facts.request_context_present,
+            request_tenant_id_non_nil = ?request_facts.request_tenant_id_non_nil,
+            request_user_id_present = request_facts.request_user_id_present,
+            request_user_id_non_nil = ?request_facts.request_user_id_non_nil,
+            channel_id_present = request_facts.channel_id_present,
+            channel_id_non_nil = ?request_facts.channel_id_non_nil,
+            channel_slug_present = request_facts.channel_slug_present,
+            channel_slug_length = ?request_facts.channel_slug_length,
+            locale_present = request_facts.locale_present,
+            locale_length = ?request_facts.locale_length,
+            validation_detail_present = error_facts.validation_detail_present,
+            validation_detail_length = ?error_facts.validation_detail_length,
+            resource_id_present = error_facts.resource_id_present,
+            resource_id_non_nil = ?error_facts.resource_id_non_nil,
+            transition_from_length = ?error_facts.transition_from_length,
+            transition_to_length = ?error_facts.transition_to_length,
+            database_cause_present = error_facts.database_cause_present,
+            core_cause_present = error_facts.core_cause_present,
             error_kind,
             public_code,
             boundary = COMMERCE_ADMIN_ORDER_CHANGE_BOUNDARY,
@@ -831,20 +970,34 @@ fn order_change_owner_error(
         );
     } else {
         tracing::warn!(
-            error = ?error,
             owner = "rustok_order",
             consumer = COMMERCE_ADMIN_ORDER_CHANGE_CONSUMER,
             operation = context.operation,
             correlation_id = context.correlation_id,
-            tenant_id = %context.tenant.id,
-            actor_id = %context.auth.user_id,
-            order_id = ?context.order_id,
-            order_change_id = ?context.order_change_id,
-            request_tenant_id = ?request_tenant_id,
-            request_user_id = ?request_user_id,
-            channel_id = ?channel_id,
-            channel_slug = ?channel_slug,
-            locale = ?locale,
+            tenant_id_non_nil = !context.tenant.id.is_nil(),
+            actor_id_non_nil = !context.auth.user_id.is_nil(),
+            order_id_present,
+            order_id_non_nil = ?order_id_non_nil,
+            order_change_id_present,
+            order_change_id_non_nil = ?order_change_id_non_nil,
+            request_context_present = request_facts.request_context_present,
+            request_tenant_id_non_nil = ?request_facts.request_tenant_id_non_nil,
+            request_user_id_present = request_facts.request_user_id_present,
+            request_user_id_non_nil = ?request_facts.request_user_id_non_nil,
+            channel_id_present = request_facts.channel_id_present,
+            channel_id_non_nil = ?request_facts.channel_id_non_nil,
+            channel_slug_present = request_facts.channel_slug_present,
+            channel_slug_length = ?request_facts.channel_slug_length,
+            locale_present = request_facts.locale_present,
+            locale_length = ?request_facts.locale_length,
+            validation_detail_present = error_facts.validation_detail_present,
+            validation_detail_length = ?error_facts.validation_detail_length,
+            resource_id_present = error_facts.resource_id_present,
+            resource_id_non_nil = ?error_facts.resource_id_non_nil,
+            transition_from_length = ?error_facts.transition_from_length,
+            transition_to_length = ?error_facts.transition_to_length,
+            database_cause_present = error_facts.database_cause_present,
+            core_cause_present = error_facts.core_cause_present,
             error_kind,
             public_code,
             boundary = COMMERCE_ADMIN_ORDER_CHANGE_BOUNDARY,

--- a/crates/rustok-commerce/contracts/evidence/admin-order-change-native-error-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/admin-order-change-native-error-safety-source-review.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "status": "commerce_admin_order_change_native_error_safety_source_reviewed_unvalidated",
-  "captured_at": "2026-07-30",
-  "base_main_sha": "d5817939405f5577ef0f68c3e5583c1a2726ccbc",
+  "captured_at": "2026-07-31",
+  "base_main_sha": "b4889de03d881c08e39dd1f933291bfd87d44b3d",
   "review": {
     "mounted_endpoint_names_preserved": true,
     "public_function_signatures_preserved": true,
@@ -18,17 +18,16 @@
       "Database",
       "Core"
     ],
-    "request_context_fields_reviewed": [
-      "tenant_id",
-      "user_id",
-      "channel_id",
-      "channel_slug",
-      "locale"
-    ],
+    "framework_error_text_removed": true,
+    "runtime_identity_values_removed": true,
+    "owner_error_text_removed": true,
+    "owner_identity_values_removed": true,
+    "owner_error_shape_reviewed": true,
+    "public_envelopes_preserved": true,
+    "severity_policy_preserved": true,
     "transactional_event_bus_composition_reviewed": true,
     "existing_http_order_change_error_policy_reviewed": true,
     "promotion_native_safety_markers_preserved": true,
-    "intervening_main_commits_have_no_commerce_admin_overlap": true,
     "feature_diff_is_commerce_only": true
   },
   "execution": {
@@ -40,9 +39,9 @@
     "workflow_or_ci_run": false
   },
   "limitations": [
-    "No compiler evidence has been retained.",
-    "No mounted request or owner-failure trace has been retained.",
-    "The focused source guard has been added but not executed.",
+    "Compiler evidence is not retained.",
+    "Mounted request and owner-failure traces are not retained.",
+    "The focused source guard is updated but not executed.",
     "Direct OrderService composition and native/REST orchestration parity remain separate source debt.",
     "Other ecommerce mapper cleanup and non-PortError public envelopes remain open."
   ]

--- a/crates/rustok-commerce/contracts/evidence/admin-order-change-native-error-safety-source.json
+++ b/crates/rustok-commerce/contracts/evidence/admin-order-change-native-error-safety-source.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0.0",
   "status": "commerce_admin_order_change_native_error_safety_source_unvalidated",
-  "captured_at": "2026-07-30",
+  "captured_at": "2026-07-31",
   "scope": {
     "package": "rustok-commerce-admin",
     "boundary": "commerce_admin_order_change_native_transport",
@@ -24,11 +24,18 @@
     "permissions_preserved": true,
     "tenant_match_and_input_validation_preserved": true,
     "framework_extraction_errors_use_static_public_envelopes": true,
+    "framework_error_type_only": true,
+    "complete_framework_error_logged": false,
     "request_context_is_diagnostic_only": true,
     "correlation_is_unique_per_transport_call": true,
     "missing_transactional_event_bus_detail_is_internal_only": true,
+    "runtime_identity_shape_only": true,
     "typed_order_errors_use_static_public_envelopes": true,
-    "typed_order_errors_retain_internal_route_context": true,
+    "owner_error_shape_only": true,
+    "complete_order_error_logged": false,
+    "raw_identity_values_logged": false,
+    "order_error_detail_presence_length_non_nil_only": true,
+    "severity_policy_preserved": true,
     "promotion_safety_contract_is_preserved": true
   },
   "validation": {
@@ -60,6 +67,5 @@
     "This slice does not replace direct OrderService composition with a host-selected owner port.",
     "This slice does not change order-change orchestration policy or persisted state.",
     "Remaining ecommerce mapper cleanup and non-PortError envelopes stay open."
-  ],
-  "promotion_gate": "No FFA, FBA, transport, runtime, or production status is promoted from source inspection."
+  ]
 }

--- a/crates/rustok-commerce/docs/admin-order-change-native-error-safety.md
+++ b/crates/rustok-commerce/docs/admin-order-change-native-error-safety.md
@@ -1,115 +1,125 @@
-# Commerce admin order-change native error safety
+# Commerce admin order-change native diagnostic safety
 
-Date: 2026-07-30
+Date: 2026-07-31
 
-Status: `commerce_admin_order_change_native_error_safety_source_unvalidated`
+Status: `source-complete / unvalidated`
 
-This source slice hardens the mounted Commerce admin native order-change endpoints:
+This source slice hardens the mounted Commerce admin native order-change diagnostics for:
 
 - `commerce/admin/order-changes`
 - `commerce/admin/apply-order-change`
 - `commerce/admin/cancel-order-change`
 
-The ecommerce master mapper-cleanup item remains open for other owners, adapters, and
-non-`PortError` envelopes. This document records only the bounded native order-change
-source change and does not promote FFA, FBA, transport, runtime, or production status.
+The endpoint names, wrapper signatures, permissions, tenant matching, parsing, DTO mapping,
+owner calls, pagination, filtering, apply/cancel inputs, and persisted behavior remain
+unchanged.
 
-## Problem
+## Public envelopes
 
-The mounted SSR adapter previously converted framework and owner failures directly into
-`ServerFnError` values:
+Auth and tenant extraction failures retain the existing static messages:
 
-- `AuthContext` and `TenantContext` extraction failures were serialized with
-  `.map_err(ServerFnError::new)`;
-- missing `TransactionalEventBus` exposed the host-composition implementation detail;
-- `OrderService` list/apply/cancel failures were converted with
-  `.map_err(ServerFnError::new)` and could carry database, core, identity, or transition
-  details into the public server-function envelope;
-- native order-change failures had no per-call transport correlation identifier or
-  request-attributed structured diagnostics.
+- `Commerce admin authentication context is temporarily unavailable`
+- `Commerce admin tenant context is temporarily unavailable`
 
-## Source boundary
+Missing host event-bus composition retains:
 
-The mounted endpoint names, public wrapper signatures, DTO mapping, permissions, tenant
-matching, UUID/JSON validation, pagination, status filtering, and owner service calls are
-preserved.
+- `Commerce order-change runtime is temporarily unavailable`
 
-Each endpoint now creates a unique correlation identifier:
+Typed `rustok_order::error::OrderError` variants retain the same public mapping:
+
+| Owner error | Public message | Severity |
+| --- | --- | --- |
+| `Validation` | `Order change request is invalid` | warning |
+| `OrderNotFound`, `OrderReturnNotFound`, `OrderChangeNotFound` | `Order resource was not found` | warning |
+| `InvalidTransition` | `Order change conflicts with the current order state` | warning |
+| `Database` | `Order storage is temporarily unavailable` | error |
+| `Core` | `Order change could not be completed safely` | error |
+
+No public message or error-classification behavior is changed by this slice.
+
+## Framework diagnostics
+
+Auth, tenant, and optional `RequestContext` extraction diagnostics keep the consumer,
+operation, context kind, correlation ID, stable code, boundary, and Rust error type. The
+complete framework extraction errors are not logged; neither debug nor display text is
+retained.
+
+Optional `RequestContext` extraction remains diagnostic-only. Failure still falls back
+without changing authentication, authorization, tenant matching, validation, or owner-call
+admission.
+
+## Runtime composition diagnostics
+
+Missing `TransactionalEventBus` still produces the static runtime envelope and stable
+runtime diagnostic code. The event now records only:
+
+- tenant and actor UUID non-nil facts;
+- request-context presence;
+- request tenant/user/channel UUID presence and non-nil facts;
+- channel-slug and locale presence/length facts;
+- owner, consumer, operation, correlation ID, code, and boundary.
+
+Tenant, actor, request tenant/user/channel UUIDs, channel slug, and locale are not logged as
+full values.
+
+## Owner diagnostics
+
+The owner mapper still covers all seven `OrderError` variants and preserves the original
+warning/error split. Diagnostics now retain only:
+
+- owner, consumer, operation, correlation ID, typed error kind, stable public code, and
+  boundary;
+- effective tenant and actor UUID non-nil facts;
+- order and order-change ID presence/non-nil facts;
+- request-context identity presence/non-nil/length facts;
+- validation-detail presence and length;
+- not-found resource UUID presence/non-nil facts;
+- transition source/target string lengths;
+- database/core cause presence flags.
+
+The complete `OrderError` and identity values are not logged. Validation detail, transition
+state text, database/core causes, tenant/user/order UUIDs, channel slug, and locale remain
+absent from structured values.
+
+## Preserved correlation and orchestration
+
+Each mounted call still creates a unique correlation identifier:
 
 ```text
 commerce-admin-order-change:{operation}:{uuid}
 ```
 
-`RequestContext` extraction is optional and diagnostic-only. Its absence does not change
-authentication, authorization, tenant matching, validation, or owner-call admission.
-
-## Public envelopes
-
-Framework context failures use static public messages:
-
-- `Commerce admin authentication context is temporarily unavailable`
-- `Commerce admin tenant context is temporarily unavailable`
-
-Missing host event-bus composition returns:
-
-- `Commerce order-change runtime is temporarily unavailable`
-
-Typed `rustok_order::error::OrderError` variants use stable public messages:
-
-| Owner error | Public message |
-| --- | --- |
-| `Validation` | `Order change request is invalid` |
-| `OrderNotFound`, `OrderReturnNotFound`, `OrderChangeNotFound` | `Order resource was not found` |
-| `InvalidTransition` | `Order change conflicts with the current order state` |
-| `Database` | `Order storage is temporarily unavailable` |
-| `Core` | `Order change could not be completed safely` |
-
-The original typed cause remains internal.
-
-## Internal diagnostics
-
-Structured diagnostics identify:
-
-- owner and consumer;
-- consumer operation;
-- correlation ID;
-- effective tenant and authenticated actor;
-- order and order-change identity when known;
-- request tenant, user, channel ID, channel slug, and locale when available;
-- typed error kind;
-- stable public code;
-- native transport boundary.
-
-Database/core failures are logged as errors. Validation, not-found, and state-conflict
-failures are logged as warnings. Raw request metadata is not logged.
+Direct `OrderService` construction, `TransactionalEventBus` lookup, list/apply/cancel call
+order, operation constants, and result mapping are unchanged. This slice does not claim a
+host-selected typed owner port or native/REST orchestration parity.
 
 ## Promotion compatibility
 
-The same mounted SSR source still contains the previously hardened cart-promotion
-endpoints. Their endpoint names, permission policy, request parsing, unique correlation,
-request locale/channel propagation, write idempotency semantics, consumer diagnostics,
-and sanitized `PortError.message` boundary are preserved.
+The same SSR file contains the previously hardened cart-promotion boundary. Its safe
+framework type-only diagnostics, promotion request-context facts, safe `PortError` shape,
+endpoints, permissions, channel/locale forwarding, deadline, idempotency, public message,
+and owner calls remain unchanged.
 
-## Explicit non-claims
+## Evidence boundary
 
-This source slice does not:
+Focused guard:
 
-- replace direct `OrderService` construction with a host-selected typed owner port;
-- change apply/cancel orchestration policy;
-- prove parity with the REST order-change orchestration surface;
-- run Cargo, tests, static verifiers, formatting, workflows, or CI;
-- retain mounted failure-injection or remote-profile evidence;
-- close the broad ecommerce mapper-cleanup task.
-
-## Owner validation
-
-Not run by the implementation agent, per maintainer instruction.
-
-Suggested commands:
-
-```bash
-node scripts/verify/verify-commerce-admin-order-change-native-error-safety.mjs
-node scripts/verify/verify-commerce-admin-promotion-native-error-safety.mjs
-node scripts/verify/verify-commerce-admin-boundary.mjs
-cargo check -p rustok-commerce-admin --features ssr
+```text
+scripts/verify/verify-commerce-admin-order-change-native-error-safety.mjs
 ```
+
+Retained evidence:
+
+```text
+crates/rustok-commerce/contracts/evidence/admin-order-change-native-error-safety-source.json
+crates/rustok-commerce/contracts/evidence/admin-order-change-native-error-safety-source-review.json
+```
+
+No test, verifier, Cargo command, formatting command, workflow, CI job, mounted request, or
+runtime failure-injection trace was executed for this source slice.
+
+## Remaining work
+
+The broad ecommerce mapper-cleanup item remains open for direct owner-port composition,
+native/REST parity, remaining order, payment, fulfillment, inventory, customer, tax,
+promotion and adapter boundaries, and non-`PortError` public envelopes.

--- a/scripts/verify/verify-commerce-admin-order-change-native-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-order-change-native-error-safety.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Commerce admin order-change native transport error-safety source guard.
+// Commerce admin order-change native transport diagnostic-safety source guard.
 
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -30,7 +30,9 @@ function assertNotContains(text, pattern, description) {
 }
 
 function functionBody(text, functionName) {
-  const signature = new RegExp(`(?:pub(?:\\([^)]*\\))?\\s+)?(?:async\\s+)?fn\\s+${functionName}\\s*\\(`);
+  const signature = new RegExp(
+    `(?:pub(?:\\([^)]*\\))?\\s+)?(?:async\\s+)?fn\\s+${functionName}(?:<[^>]*>)?\\s*\\(`,
+  );
   const match = signature.exec(text);
   if (!match) {
     fail(`missing function ${functionName}`);
@@ -60,9 +62,15 @@ const adapterPath =
   "crates/rustok-commerce/admin/src/transport/native_server_adapter_ssr.rs";
 const evidencePath =
   "crates/rustok-commerce/contracts/evidence/admin-order-change-native-error-safety-source.json";
+const reviewPath =
+  "crates/rustok-commerce/contracts/evidence/admin-order-change-native-error-safety-source-review.json";
+const docPath =
+  "crates/rustok-commerce/docs/admin-order-change-native-error-safety.md";
 
 const adapter = readRepo(adapterPath);
 const evidence = JSON.parse(readRepo(evidencePath));
+const review = JSON.parse(readRepo(reviewPath));
+const doc = readRepo(docPath);
 
 for (const endpoint of [
   'endpoint = "commerce/admin/order-changes"',
@@ -73,18 +81,22 @@ for (const endpoint of [
 }
 
 for (const marker of [
-  'const COMMERCE_ADMIN_ORDER_CHANGE_CONSUMER',
-  'const COMMERCE_ADMIN_ORDER_CHANGE_BOUNDARY',
-  'fn order_change_correlation_id(',
-  'uuid::Uuid::new_v4()',
-  'fn order_change_context_error',
-  'fn order_change_auth_context_error',
-  'fn order_change_tenant_context_error',
-  'optional_order_change_request_context',
-  'struct OrderChangeOwnerErrorContext',
-  'fn order_change_owner_error(',
-  'error: rustok_order::error::OrderError',
-  'Commerce order-change runtime is temporarily unavailable',
+  "const COMMERCE_ADMIN_ORDER_CHANGE_CONSUMER",
+  "const COMMERCE_ADMIN_ORDER_CHANGE_BOUNDARY",
+  "fn order_change_correlation_id(",
+  "uuid::Uuid::new_v4()",
+  "struct OrderChangeRequestContextFacts",
+  "fn order_change_request_context_facts(",
+  "struct OrderChangeOwnerErrorFacts",
+  "fn order_change_owner_error_facts(",
+  "fn order_change_context_error",
+  "fn order_change_auth_context_error",
+  "fn order_change_tenant_context_error",
+  "optional_order_change_request_context",
+  "struct OrderChangeOwnerErrorContext",
+  "fn order_change_owner_error(",
+  "error: rustok_order::error::OrderError",
+  "Commerce order-change runtime is temporarily unavailable",
 ]) {
   assertContains(adapter, marker, `${adapterPath}: missing order-change safety marker ${marker}`);
 }
@@ -100,6 +112,137 @@ for (const [variant, publicMessage] of [
 ]) {
   assertContains(adapter, variant, `${adapterPath}: typed owner mapping must cover ${variant}`);
   assertContains(adapter, publicMessage, `${adapterPath}: missing static public message ${publicMessage}`);
+}
+
+const contextErrorBody = functionBody(adapter, "order_change_context_error");
+assertContains(
+  contextErrorBody,
+  "let error_type = std::any::type_name::<E>();",
+  `${adapterPath}: framework context diagnostics must retain type only`,
+);
+assertContains(contextErrorBody, "error_type", `${adapterPath}: framework error type must be logged`);
+for (const forbidden of ["error = ?error", "error = %error", "error = ?_error", "error = %_error"]) {
+  assertNotContains(
+    contextErrorBody,
+    forbidden,
+    `${adapterPath}: framework context diagnostics must not log complete errors`,
+  );
+}
+
+const optionalContextBody = functionBody(adapter, "optional_order_change_request_context");
+assertContains(
+  optionalContextBody,
+  "let error_type = std::any::type_name_of_val(&error);",
+  `${adapterPath}: optional request-context failure must retain type only`,
+);
+for (const forbidden of ["error = ?error", "error = %error"]) {
+  assertNotContains(
+    optionalContextBody,
+    forbidden,
+    `${adapterPath}: optional request-context diagnostics must not log framework text`,
+  );
+}
+
+const runtimeBody = functionBody(adapter, "order_service_from_context");
+for (const marker of [
+  "order_change_request_context_facts(request_context)",
+  'code = "commerce.admin_order_change_runtime_unavailable"',
+  'ServerFnError::new("Commerce order-change runtime is temporarily unavailable")',
+  "tenant_id_non_nil = !tenant.id.is_nil()",
+  "actor_id_non_nil = !auth.user_id.is_nil()",
+  "request_context_present = request_facts.request_context_present",
+  "request_tenant_id_non_nil = ?request_facts.request_tenant_id_non_nil",
+  "request_user_id_present = request_facts.request_user_id_present",
+  "request_user_id_non_nil = ?request_facts.request_user_id_non_nil",
+  "channel_id_present = request_facts.channel_id_present",
+  "channel_id_non_nil = ?request_facts.channel_id_non_nil",
+  "channel_slug_present = request_facts.channel_slug_present",
+  "channel_slug_length = ?request_facts.channel_slug_length",
+  "locale_present = request_facts.locale_present",
+  "locale_length = ?request_facts.locale_length",
+]) {
+  assertContains(runtimeBody, marker, `${adapterPath}: runtime mapper missing ${marker}`);
+}
+for (const forbidden of [
+  "tenant_id = %tenant.id",
+  "actor_id = %auth.user_id",
+  "request_tenant_id = ?request_tenant_id",
+  "request_user_id = ?request_user_id",
+  "channel_id = ?channel_id",
+  "channel_slug = ?channel_slug",
+  "locale = ?locale",
+  "Commerce admin requires TransactionalEventBus in host runtime context",
+]) {
+  assertNotContains(runtimeBody, forbidden, `${adapterPath}: runtime diagnostics contain ${forbidden}`);
+}
+
+const factsBody = functionBody(adapter, "order_change_owner_error_facts");
+for (const marker of [
+  "OrderError::Validation(detail)",
+  "validation_detail_length: Some(detail.chars().count())",
+  "OrderError::OrderNotFound(id)",
+  "OrderError::OrderReturnNotFound(id)",
+  "OrderError::OrderChangeNotFound(id)",
+  "resource_id_non_nil: Some(!id.is_nil())",
+  "OrderError::InvalidTransition { from, to }",
+  "transition_from_length: Some(from.chars().count())",
+  "transition_to_length: Some(to.chars().count())",
+  "OrderError::Database(_)",
+  "database_cause_present: true",
+  "OrderError::Core(_)",
+  "core_cause_present: true",
+]) {
+  assertContains(factsBody, marker, `${adapterPath}: owner error facts missing ${marker}`);
+}
+
+const ownerBody = functionBody(adapter, "order_change_owner_error");
+for (const marker of [
+  "order_change_request_context_facts(context.request_context)",
+  "order_change_owner_error_facts(&error)",
+  "order_id_present",
+  "order_id_non_nil",
+  "order_change_id_present",
+  "order_change_id_non_nil",
+  "tenant_id_non_nil = !context.tenant.id.is_nil()",
+  "actor_id_non_nil = !context.auth.user_id.is_nil()",
+  "request_context_present = request_facts.request_context_present",
+  "request_tenant_id_non_nil = ?request_facts.request_tenant_id_non_nil",
+  "request_user_id_present = request_facts.request_user_id_present",
+  "request_user_id_non_nil = ?request_facts.request_user_id_non_nil",
+  "channel_id_present = request_facts.channel_id_present",
+  "channel_id_non_nil = ?request_facts.channel_id_non_nil",
+  "channel_slug_present = request_facts.channel_slug_present",
+  "channel_slug_length = ?request_facts.channel_slug_length",
+  "locale_present = request_facts.locale_present",
+  "locale_length = ?request_facts.locale_length",
+  "validation_detail_present = error_facts.validation_detail_present",
+  "validation_detail_length = ?error_facts.validation_detail_length",
+  "resource_id_present = error_facts.resource_id_present",
+  "resource_id_non_nil = ?error_facts.resource_id_non_nil",
+  "transition_from_length = ?error_facts.transition_from_length",
+  "transition_to_length = ?error_facts.transition_to_length",
+  "database_cause_present = error_facts.database_cause_present",
+  "core_cause_present = error_facts.core_cause_present",
+  "tracing::error!",
+  "tracing::warn!",
+  "ServerFnError::new(public_message)",
+]) {
+  assertContains(ownerBody, marker, `${adapterPath}: owner mapper missing ${marker}`);
+}
+for (const forbidden of [
+  "error = ?error",
+  "error = %error",
+  "tenant_id = %context.tenant.id",
+  "actor_id = %context.auth.user_id",
+  "order_id = ?context.order_id",
+  "order_change_id = ?context.order_change_id",
+  "request_tenant_id = ?request_tenant_id",
+  "request_user_id = ?request_user_id",
+  "channel_id = ?channel_id",
+  "channel_slug = ?channel_slug",
+  "locale = ?locale",
+]) {
+  assertNotContains(ownerBody, forbidden, `${adapterPath}: owner diagnostics contain ${forbidden}`);
 }
 
 for (const functionName of [
@@ -132,42 +275,14 @@ if (ownerMapperUses.length !== 3) {
   fail(`${adapterPath}: expected three typed order-change owner mapper callsites, found ${ownerMapperUses.length}`);
 }
 
-const runtimeBody = functionBody(adapter, "order_service_from_context");
-assertContains(
-  runtimeBody,
-  'code = "commerce.admin_order_change_runtime_unavailable"',
-  `${adapterPath}: runtime composition failure needs a stable diagnostic code`,
-);
-assertContains(
-  runtimeBody,
-  'ServerFnError::new("Commerce order-change runtime is temporarily unavailable")',
-  `${adapterPath}: runtime composition detail must stay internal`,
-);
-assertNotContains(
-  runtimeBody,
-  "Commerce admin requires TransactionalEventBus in host runtime context",
-  `${adapterPath}: host composition detail must not cross the public boundary`,
-);
-
 for (const marker of [
-  'owner = "rustok_order"',
-  "consumer",
-  "operation",
-  "correlation_id",
-  "tenant_id",
-  "actor_id",
-  "order_id",
-  "order_change_id",
-  "request_tenant_id",
-  "request_user_id",
-  "channel_id",
-  "channel_slug",
-  "locale",
-  "error_kind",
-  "public_code",
-  "boundary",
+  "struct PromotionRequestContextFacts",
+  "fn promotion_request_context_facts(",
+  "fn promotion_context_error",
+  "fn promotion_port_error(",
+  "ServerFnError::new(error.message)",
 ]) {
-  assertContains(adapter, marker, `${adapterPath}: missing structured diagnostic field ${marker}`);
+  assertContains(adapter, marker, `${adapterPath}: prior promotion safety marker must remain ${marker}`);
 }
 
 for (const forbidden of [
@@ -186,6 +301,20 @@ for (const forbidden of [
 if (evidence.status !== "commerce_admin_order_change_native_error_safety_source_unvalidated") {
   fail(`${evidencePath}: source evidence must remain explicitly unvalidated`);
 }
+for (const [field, expected] of Object.entries({
+  framework_error_type_only: true,
+  complete_framework_error_logged: false,
+  runtime_identity_shape_only: true,
+  owner_error_shape_only: true,
+  complete_order_error_logged: false,
+  raw_identity_values_logged: false,
+  typed_order_errors_use_static_public_envelopes: true,
+  promotion_safety_contract_is_preserved: true,
+})) {
+  if (evidence.source_claims?.[field] !== expected) {
+    fail(`${evidencePath}: source_claims.${field} must be ${expected}`);
+  }
+}
 for (const field of [
   "focused_verifier_executed",
   "aggregate_verifier_executed",
@@ -200,10 +329,31 @@ for (const field of [
   }
 }
 
+if (review.status !== "commerce_admin_order_change_native_error_safety_source_reviewed_unvalidated") {
+  fail(`${reviewPath}: source review must remain explicitly unvalidated`);
+}
+for (const field of [
+  "framework_error_text_removed",
+  "runtime_identity_values_removed",
+  "owner_error_text_removed",
+  "owner_identity_values_removed",
+  "owner_error_shape_reviewed",
+  "public_envelopes_preserved",
+  "promotion_native_safety_markers_preserved",
+]) {
+  if (review.review?.[field] !== true) {
+    fail(`${reviewPath}: review.${field} must be true`);
+  }
+}
+
+assertContains(doc, "Status: `source-complete / unvalidated`", `${docPath}: status must remain unvalidated`);
+assertContains(doc, "complete framework extraction errors are not logged", `${docPath}: framework diagnostic policy`);
+assertContains(doc, "complete `OrderError` and identity values are not logged", `${docPath}: owner diagnostic policy`);
+
 if (failures.length > 0) {
-  console.error("Commerce admin order-change native error-safety check failed:");
+  console.error("Commerce admin order-change native diagnostic-safety check failed:");
   failures.forEach((failure) => console.error(`✗ ${failure}`));
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log("✔ Commerce admin order-change native error-safety source invariants passed");
+console.log("✔ Commerce admin order-change native diagnostics use correlation-safe shape only; execution evidence remains open");


### PR DESCRIPTION
## Summary

- continue the open ecommerce correlation-safe mapper cleanup with the Commerce Admin order-change SSR consumer
- replace complete auth, tenant, and optional request-context extraction error logging with Rust error-type attribution only
- replace raw runtime tenant/actor/request-context identity values with UUID non-nil, presence, and length facts
- replace complete `OrderError` plus tenant/actor/order/order-change/request-context identities with typed error kind, stable public code, presence, length, non-nil, and cause-presence facts
- preserve all three mounted endpoints, permissions, tenant matching, parsing, DTOs, pagination/filtering, owner calls, operation constants, public messages, and warning/error severity
- preserve the previously hardened promotion SSR boundary
- update the focused verifier, documentation, source evidence, and source-review evidence

## Confirmed gap

The order-change SSR boundary already returned static public envelopes, but diagnostics still stored complete framework errors, complete `OrderError` values, tenant and actor UUIDs, order and order-change UUIDs, request tenant/user/channel UUIDs, channel slug, locale, validation detail, transition state text, and database/core causes.

## Scope boundary

This PR changes only the five existing Commerce Admin order-change source/docs/evidence/verifier files. Direct `OrderService` composition, native/REST orchestration parity, other ecommerce boundaries, and the broad mapper-cleanup item remain open.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-commerce-admin-order-change-native-error-safety.mjs
node scripts/verify/verify-commerce-admin-promotion-native-error-safety.mjs
cargo check -p rustok-commerce-admin --features ssr
```

## Branch state

The branch is based on current `main` at `b4889de03d881c08e39dd1f933291bfd87d44b3d`, is one commit ahead and zero behind, and changes exactly five files. Squash merge is intended.