### PR TITLE
test(blog): retain projection retry-limit rollback harness

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json
@@ -68,6 +68,19 @@
       "concurrent_created_events_converge_without_lost_updates"
     ]
   },
+  "retry_limit_harness": {
+    "status": "executable_no_run",
+    "runtime_status": "not_run",
+    "path": "crates/rustok-blog/tests/comment_projection_postgres_test.rs",
+    "environment": "RUSTOK_BLOG_TEST_DATABASE_URL",
+    "command": "RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears -- --exact",
+    "isolation": "unique_schema_one_connection_pool_before_update_skip_trigger_nontransactional_attempt_sequence",
+    "scope": "real_handler_eight_zero_row_updates_terminal_error_atomic_rollback_and_same_envelope_replay",
+    "non_claim": "does_not_measure_natural_postgresql_contention_frequency_or_record_execution",
+    "cases": [
+      "optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears"
+    ]
+  },
   "postgres_harness": {
     "status": "executable_no_run",
     "runtime_status": "not_run",
@@ -77,6 +90,7 @@
     "isolation": "unique_schema_one_connection_pool",
     "cases": [
       "duplicate_delivery_updates_counter_and_outbox_once",
+      "optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears",
       "delete_before_create_stays_non_negative_and_replays_in_order",
       "missing_post_replay_commits_only_after_source_appears",
       "outbox_failure_rolls_back_counter_and_delivery_before_retry"
@@ -138,6 +152,10 @@
       "expected": "the production loop uses one decision helper, applies after one updated row, retries seven zero-row results, and reaches its limit on the eighth"
     },
     {
+      "name": "postgres_retry_limit_rollback_and_replay",
+      "expected": "a PostgreSQL trigger skips eight real handler updates while a sequence counts each attempt; the terminal error leaves post, delivery, and outbox unchanged, and the same envelope succeeds after the trigger is removed"
+    },
+    {
       "name": "missing_post_retry",
       "expected": "a missing tenant post returns an error before the delivery marker is committed so the event runtime can retry"
     },
@@ -191,13 +209,14 @@
     "execute cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing",
     "execute the env-gated PostgreSQL dispatcher case and retain EventBus/EventDispatcher delivery output",
     "execute the env-gated PostgreSQL concurrency case and retain four-connection convergence output",
+    "execute the env-gated PostgreSQL retry-limit case and retain its eight-attempt, rollback, and same-envelope recovery output",
     "execute the env-gated PostgreSQL comment_projection_postgres_test target and retain its output",
     "execute the env-gated same-process restart case and retain its output",
     "execute the env-gated process-restart case and retain both child-process exits plus final durable assertions",
     "retain proof that duplicate and out-of-order comment.created/comment.deleted deliveries match the source harness assertions",
     "retain proof that the counter, delivery ledger, and BlogPostUpdated outbox row commit or roll back together",
     "retain missing-post retry and later recovery evidence",
-    "retain PostgreSQL-observed retry count and limit evidence separately from the deterministic source policy",
+    "retain naturally contended PostgreSQL retry-frequency evidence separately from the deterministic zero-row retry-limit harness",
     "retain full server-host restart recovery evidence separately from the test-process harness"
   ]
 }

--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -119,7 +119,19 @@ reaches `LimitReached`. The retained Rust cases are
 `optimistic_retry_policy_applies_success_without_retry` and
 `optimistic_retry_policy_allows_seven_retries_then_stops_on_eighth_conflict`.
 They are `executable_no_run` source-policy evidence and do not measure PostgreSQL
-contention, observed retry frequency, or runtime terminal-limit behavior.
+contention or observed natural retry frequency.
+
+The retained deterministic PostgreSQL retry-limit target is
+`optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears` in
+`crates/rustok-blog/tests/comment_projection_postgres_test.rs`. It installs a
+schema-local `BEFORE UPDATE` trigger that returns `NULL`, so the real handler
+observes eight zero-row update results. A PostgreSQL sequence records all eight
+attempts outside transaction rollback. The written assertions require the
+terminal error, unchanged post state, no delivery or outbox row, removal of the
+probe, and successful replay of the same envelope. Its suggested command is
+`RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears -- --exact`.
+The target is `executable_no_run`; it does not record execution or measure natural
+contention frequency.
 
 The retained host registration target is the `tests` module in
 `crates/rustok-blog/src/lib.rs`. It creates the real module listener context,
@@ -158,10 +170,10 @@ an observed retry count or optimistic-exhaustion result.
 The retained PostgreSQL target is
 `crates/rustok-blog/tests/comment_projection_postgres_test.rs`. It uses
 `RUSTOK_BLOG_TEST_DATABASE_URL` (or PostgreSQL `DATABASE_URL`), a unique schema,
-and a one-connection pool for each direct handler. Its four direct-handler cases
-cover duplicate-envelope idempotency, delete-before-create ordering, missing-post
-replay after source creation, and rollback/retry when the outbox table is
-unavailable. The suggested command is
+and a one-connection pool for each direct handler. Its five direct-handler cases
+cover duplicate-envelope idempotency, deterministic retry-limit rollback/replay,
+delete-before-create ordering, missing-post replay after source creation, and
+rollback/retry when the outbox table is unavailable. The suggested command is
 `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test`.
 The target is registered as `executable_no_run`; no PostgreSQL result is recorded.
 
@@ -191,10 +203,9 @@ full application server-host restart, and no execution result is recorded.
 Exact commands `verify:blog:comments-event-projection` and
 `test:verify:blog:comments-event-projection` run after the Comments port gate in
 the Blog FBA chains. Overall status remains `source_verified_no_compile`;
-the deterministic eight-attempt retry policy is source-locked, while PostgreSQL-
-observed retry frequency/terminal-limit behavior, dispatcher/PostgreSQL/process-
-target execution, full server-host restart recovery, and all other runtime
-evidence remain pending.
+the deterministic retry policy and retry-limit PostgreSQL harness are source-
+locked, while all target execution, naturally contended retry-frequency evidence,
+full server-host restart recovery, and all other runtime evidence remain pending.
 
 Blog categories use the exclusive `blog_categories:*` permission resource.
 `CategoryService::new(db, event_bus)` is the only owner constructor. Category
@@ -213,7 +224,7 @@ backend failure is fail-closed. The retained no-compile harness is
 `blog-graphql-rate-limit-runtime-harness.json`, guarded by
 `verify-blog-graphql-rate-limit.mjs` and its focused fixture
 `scripts/verify/verify-blog-graphql-rate-limit.test.mjs`. Both are registered as the
-`graphql_rate_limit` leaf gate in the Blog FBA verify/test chain; mounted Redis
+`graphql_rate_limit` leaf gate in the Blog FBA test chain; mounted Redis
 execution remains maintainer-owned.
 
 ### AI Blog owner boundary
@@ -385,6 +396,25 @@ immediate success plus seven retry decisions followed by the eighth-attempt
 limit. Evidence schema v4 and Blog registry schema v13 remain compatible; no Rust
 test, verifier, compile, PostgreSQL, browser, workflow, or CI result is recorded.
 
+The source re-audit at current `main` commit
+`763bd8ab2912af00b3c4034b5af13da3afbbfb46` rechecked all 52 recorded slices
+against their source paths, evidence, focused verifiers, registry bindings, and
+explicit non-claims. The recorded source artifacts remain present. No compile,
+Rust/JavaScript test, PostgreSQL, Redis, browser, workflow, CI, or production
+result was promoted. The remaining concrete projection gap was that the pure
+retry decision proved the policy but no PostgreSQL target forced the real handler
+to reach the eighth zero-row result and then demonstrated transaction rollback
+plus same-envelope recovery.
+
+Slice 53 adds the env-gated
+`optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears` target. A
+schema-local trigger skips each update, a nontransactional sequence counts exactly
+eight attempts, and the written assertions retain terminal failure, unchanged
+post state, zero delivery/outbox rows, probe removal, and successful replay of the
+same envelope. Evidence schema v4 and Blog registry schema v13 remain compatible;
+focused source verification is updated, while execution and naturally contended
+retry-frequency evidence remain pending.
+
 ## FFA/FBA status
 
 - FFA status: `in_progress`.
@@ -392,11 +422,12 @@ test, verifier, compile, PostgreSQL, browser, workflow, or CI result is recorded
 - Blog FBA source-gate chain: `source_verified_no_compile`; registry schema v13
   locks exact verify/test order, source-gate paths, leaf npm commands, evidence,
   self-tests, the Comments projection classifier, deterministic retry policy,
-  host registration, dispatcher, concurrency, PostgreSQL, same-process restart,
-  and process-restart harnesses, and aggregate/consumer bindings for admin,
-  storefront, Comments port boundary, Comments event projection, category Search
-  reindex, GraphQL rate limiting, GraphQL richtext, AI richtext, offline backfill,
-  Forum ownership, and runtime order.
+  PostgreSQL retry-limit rollback/replay target, host registration, dispatcher,
+  concurrency, PostgreSQL, same-process restart, and process-restart harnesses,
+  and aggregate/consumer bindings for admin, storefront, Comments port boundary,
+  Comments event projection, category Search reindex, GraphQL rate limiting,
+  GraphQL richtext, AI richtext, offline backfill, Forum ownership, and runtime
+  order.
 - Comments consumer port boundary: Blog-owned `source_verified_no_compile` for
   the in-process profile; all seven operations, approved public read, typed
   richtext projection, two-second deadlines, write idempotency, active typed
@@ -408,21 +439,22 @@ test, verifier, compile, PostgreSQL, browser, workflow, or CI result is recorded
   remain planned or pending.
 - Comments event projection: Blog-owned `source_verified_no_compile`; evidence
   schema v4, shared classifier/counter/retry-decision helpers, `executable_no_run`
-  source harness, module-registration, dispatcher, concurrency, PostgreSQL
-  transaction, same-process restart, and process-restart targets, verifier,
-  focused self-test, exact npm leaf commands, delivery-ledger identity,
-  transactional outbox markers, and Blog FBA ordering are locked. The source
-  policy records immediate success, seven retry decisions, and the eighth-attempt
-  terminal limit without claiming observed PostgreSQL contention. The registration
-  target verifies identity/routing only. The dispatcher target passes one envelope
-  through `EventBus` and `EventDispatcher` into the module-registered handler and
-  waits for the durable commit. The concurrency target starts four independent
+  source harness, deterministic PostgreSQL retry-limit target, module-registration,
+  dispatcher, concurrency, PostgreSQL transaction, same-process restart, and
+  process-restart targets, verifier, focused self-test, exact npm leaf commands,
+  delivery-ledger identity, transactional outbox markers, and Blog FBA ordering
+  are locked. The source policy records immediate success, seven retry decisions,
+  and the eighth-attempt terminal limit. The retry-limit target forces eight
+  zero-row results through the real handler and requires atomic rollback followed
+  by successful replay of the same envelope. The registration target verifies
+  identity/routing only. The dispatcher target passes one envelope through
+  `EventBus` and `EventDispatcher` into the module-registered handler and waits
+  for the durable commit. The concurrency target starts four independent
   PostgreSQL connections behind one barrier and requires a four-count/five-version
   result with four delivery and outbox rows. The process target launches two
   sequential OS test processes against the same schema and envelope ID. None of
-  these targets has been run. PostgreSQL-observed retry frequency/terminal-limit
-  behavior, full server-host restart recovery, and all execution evidence remain
-  pending.
+  these targets has been run. Naturally contended PostgreSQL retry frequency,
+  full server-host restart recovery, and all execution evidence remain pending.
 - Load protection: `implementation_ready`; mounted Redis evidence is pending.
 - Rate-limit harness: `executable_no_compile`; evidence, verifier, self-test,
   npm leaf commands, and aggregate FBA registration are locked; execution is
@@ -629,6 +661,10 @@ test, verifier, compile, PostgreSQL, browser, workflow, or CI result is recorded
     evidence plus focused fail-closed fixtures, and kept PostgreSQL-observed retry
     behavior, registry schema v13, package order, and all execution unchanged or
     pending.
+53. Re-audited all recorded Blog slices on current `main`, added an env-gated
+    PostgreSQL retry-limit target that forces eight real zero-row handler updates,
+    retained atomic rollback and same-envelope recovery in evidence and the focused
+    guard, and kept natural contention frequency plus all execution pending.
 
 ## Next results
 
@@ -649,17 +685,19 @@ test, verifier, compile, PostgreSQL, browser, workflow, or CI result is recorded
    shared consumer runtime-order verifier, Blog projection classifier and
    deterministic retry-policy harness, module registration/routing harness, the
    filtered `event_dispatcher_routes_registered_handler_and_commits_projection`,
-   `concurrent_created_events_converge_without_lost_updates`, and
+   `concurrent_created_events_converge_without_lost_updates`,
+   `optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears`, and
    `restarted_process_reuses_delivery_ledger_without_reapplying_counter` cases,
    the complete `comment_projection_postgres_test` and
    `comment_projection_restart_postgres_test` targets, both thread invariant
    concurrency targets, and concurrent PostgreSQL create/delete transactions.
    Retain deterministic immediate-success/seven-retry/eighth-limit output,
-   dispatcher delivery output, four-connection convergence, both child process
-   exits, the written duplicate, delete-before-create, missing-post replay,
-   outbox rollback/retry, and same-process/new-connection assertions; then retain
-   PostgreSQL-observed retry frequency/terminal-limit behavior, full server-host
-   restart recovery, remote adapter parity, browser parity for typed
+   the deterministic eight-zero-row terminal error, rollback and same-envelope
+   recovery output, dispatcher delivery output, four-connection convergence, both
+   child process exits, the written duplicate, delete-before-create, missing-post
+   replay, outbox rollback/retry, and same-process/new-connection assertions;
+   then retain naturally contended PostgreSQL retry-frequency evidence, full
+   server-host restart recovery, remote adapter parity, browser parity for typed
    unavailable/timeout article rendering, cached thread snapshots, comment-form
    fallback, approved-only reads, moderation, pagination, first-thread identity,
    and unrelated insert storage error propagation.
@@ -684,6 +722,7 @@ should run the relevant subset, including:
 - `cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test event_dispatcher_routes_registered_handler_and_commits_projection -- --exact`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test concurrent_created_events_converge_without_lost_updates -- --exact`
+- `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears -- --exact`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test restarted_process_reuses_delivery_ledger_without_reapplying_counter -- --exact`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test`

--- a/crates/rustok-blog/tests/comment_projection_postgres_test.rs
+++ b/crates/rustok-blog/tests/comment_projection_postgres_test.rs
@@ -16,6 +16,7 @@ type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
 
 const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";
 const CONCURRENT_PROJECTION_DELIVERIES: usize = 4;
+const EXPECTED_RETRY_LIMIT_ATTEMPTS: i64 = 8;
 
 struct PostgresBlogProjectionTestDb {
     control: DatabaseConnection,
@@ -200,6 +201,49 @@ async fn concurrent_created_events_converge_without_lost_updates() -> TestResult
         count_outbox_events(&test_db.db).await?,
         CONCURRENT_PROJECTION_DELIVERIES as i64
     );
+
+    test_db.cleanup().await
+}
+
+#[tokio::test]
+async fn optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears() -> TestResult<()> {
+    let Some(test_db) = PostgresBlogProjectionTestDb::setup("retry_limit").await? else {
+        return Ok(());
+    };
+
+    let tenant_id = Uuid::new_v4();
+    let post_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    insert_post(&test_db.db, tenant_id, post_id, actor_id, 0, 1).await?;
+    install_retry_limit_probe(&test_db.db).await?;
+
+    let envelope = comment_created_envelope(
+        tenant_id,
+        actor_id,
+        Uuid::new_v4(),
+        post_id,
+    );
+    let handler = BlogCommentProjectionHandler::new(test_db.db.clone());
+
+    let error = handler
+        .handle(&envelope)
+        .await
+        .expect_err("eight zero-row updates must reach the optimistic retry limit");
+    assert!(error.to_string().contains("after 8 concurrent attempts"));
+    assert_eq!(
+        load_retry_attempt_count(&test_db.db).await?,
+        EXPECTED_RETRY_LIMIT_ATTEMPTS
+    );
+    assert_eq!(load_post_state(&test_db.db, tenant_id, post_id).await?, (0, 1));
+    assert_eq!(count_delivery(&test_db.db, envelope.id).await?, 0);
+    assert_eq!(count_outbox_events(&test_db.db).await?, 0);
+
+    remove_retry_limit_probe(&test_db.db).await?;
+    handler.handle(&envelope).await?;
+
+    assert_eq!(load_post_state(&test_db.db, tenant_id, post_id).await?, (1, 2));
+    assert_eq!(count_delivery(&test_db.db, envelope.id).await?, 1);
+    assert_eq!(count_outbox_events(&test_db.db).await?, 1);
 
     test_db.cleanup().await
 }
@@ -411,6 +455,53 @@ async fn create_outbox_table(db: &DatabaseConnection) -> Result<(), sea_orm::DbE
     )
     .await?;
     Ok(())
+}
+
+async fn install_retry_limit_probe(db: &DatabaseConnection) -> Result<(), sea_orm::DbErr> {
+    db.execute_unprepared(
+        r#"
+        CREATE SEQUENCE blog_projection_retry_attempts START WITH 1;
+
+        CREATE FUNCTION force_blog_projection_retry_limit()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+            PERFORM nextval('blog_projection_retry_attempts');
+            RETURN NULL;
+        END;
+        $$;
+
+        CREATE TRIGGER force_blog_projection_retry_limit
+        BEFORE UPDATE OF comment_count, version ON blog_posts
+        FOR EACH ROW
+        EXECUTE FUNCTION force_blog_projection_retry_limit();
+        "#,
+    )
+    .await?;
+    Ok(())
+}
+
+async fn remove_retry_limit_probe(db: &DatabaseConnection) -> Result<(), sea_orm::DbErr> {
+    db.execute_unprepared(
+        r#"
+        DROP TRIGGER force_blog_projection_retry_limit ON blog_posts;
+        DROP FUNCTION force_blog_projection_retry_limit();
+        "#,
+    )
+    .await?;
+    Ok(())
+}
+
+async fn load_retry_attempt_count(db: &DatabaseConnection) -> Result<i64, sea_orm::DbErr> {
+    let row = db
+        .query_one(Statement::from_string(
+            DbBackend::Postgres,
+            "SELECT last_value::bigint AS count FROM blog_projection_retry_attempts".to_string(),
+        ))
+        .await?
+        .expect("retry-attempt sequence should return one row");
+    row.try_get("", "count")
 }
 
 async fn insert_post(

--- a/scripts/verify/verify-blog-comments-event-projection.mjs
+++ b/scripts/verify/verify-blog-comments-event-projection.mjs
@@ -51,6 +51,7 @@ const harnessCommand = 'cargo test -p rustok-blog --lib services::comment_projec
 const hostRegistrationHarnessCommand = 'cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing';
 const dispatcherHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test event_dispatcher_routes_registered_handler_and_commits_projection -- --exact';
 const concurrencyHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test concurrent_created_events_converge_without_lost_updates -- --exact';
+const retryLimitHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears -- --exact';
 const postgresHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test';
 const restartHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test';
 const processRestartHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test restarted_process_reuses_delivery_ledger_without_reapplying_counter -- --exact';
@@ -163,6 +164,7 @@ if (retryLoopStart === -1 || retryLoopEnd === -1) {
 for (const marker of [
   'const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";',
   'const CONCURRENT_PROJECTION_DELIVERIES: usize = 4;',
+  'const EXPECTED_RETRY_LIMIT_ATTEMPTS: i64 = 8;',
   'struct PostgresBlogProjectionTestDb',
   'database_url: String',
   'async fn isolated_connection(&self)',
@@ -197,6 +199,22 @@ for (const marker of [
   'barrier.wait().await;',
   'CONCURRENT_PROJECTION_DELIVERIES as i32',
   'count_all_deliveries(&test_db.db).await?',
+  'async fn optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears()',
+  'install_retry_limit_probe(&test_db.db).await?;',
+  'eight zero-row updates must reach the optimistic retry limit',
+  'after 8 concurrent attempts',
+  'load_retry_attempt_count(&test_db.db).await?',
+  'EXPECTED_RETRY_LIMIT_ATTEMPTS',
+  'remove_retry_limit_probe(&test_db.db).await?;',
+  'CREATE SEQUENCE blog_projection_retry_attempts START WITH 1;',
+  'CREATE FUNCTION force_blog_projection_retry_limit()',
+  "PERFORM nextval('blog_projection_retry_attempts');",
+  'RETURN NULL;',
+  'CREATE TRIGGER force_blog_projection_retry_limit',
+  'BEFORE UPDATE OF comment_count, version ON blog_posts',
+  'DROP TRIGGER force_blog_projection_retry_limit ON blog_posts;',
+  'DROP FUNCTION force_blog_projection_retry_limit();',
+  'SELECT last_value::bigint AS count FROM blog_projection_retry_attempts',
   'async fn delete_before_create_stays_non_negative_and_replays_in_order()',
   'DomainEvent::CommentDeleted',
   'async fn missing_post_replay_commits_only_after_source_appears()',
@@ -419,6 +437,25 @@ if (evidence) {
   ) {
     failures.push(`${evidencePath}: concurrency harness case drift`);
   }
+  const retryLimit = evidence.retry_limit_harness ?? {};
+  if (
+    retryLimit.status !== 'executable_no_run' ||
+    retryLimit.runtime_status !== 'not_run' ||
+    retryLimit.path !== postgresHarnessPath ||
+    retryLimit.environment !== postgresHarnessEnvironment ||
+    retryLimit.command !== retryLimitHarnessCommand ||
+    retryLimit.isolation !== 'unique_schema_one_connection_pool_before_update_skip_trigger_nontransactional_attempt_sequence' ||
+    retryLimit.scope !== 'real_handler_eight_zero_row_updates_terminal_error_atomic_rollback_and_same_envelope_replay' ||
+    retryLimit.non_claim !== 'does_not_measure_natural_postgresql_contention_frequency_or_record_execution'
+  ) {
+    failures.push(`${evidencePath}: retry-limit harness drift`);
+  }
+  if (
+    [...(retryLimit.cases ?? [])].join('|') !==
+    'optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears'
+  ) {
+    failures.push(`${evidencePath}: retry-limit harness case drift`);
+  }
   const postgres = evidence.postgres_harness ?? {};
   if (
     postgres.status !== 'executable_no_run' ||
@@ -434,6 +471,7 @@ if (evidence) {
   if (
     postgresCases !== [
       'duplicate_delivery_updates_counter_and_outbox_once',
+      'optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears',
       'delete_before_create_stays_non_negative_and_replays_in_order',
       'missing_post_replay_commits_only_after_source_appears',
       'outbox_failure_rolls_back_counter_and_delivery_before_retry',
@@ -494,6 +532,7 @@ if (evidence) {
     'atomic_counter_delivery_outbox',
     'tenant_scoped_optimistic_update',
     'bounded_optimistic_retry_policy',
+    'postgres_retry_limit_rollback_and_replay',
     'missing_post_retry',
     'non_negative_count',
     'host_registration_routing_harness',
@@ -574,6 +613,8 @@ for (const marker of [
   'tests::module_registers_comment_projection_handler_with_host_routing',
   'event_dispatcher_routes_registered_handler_and_commits_projection',
   'concurrent_created_events_converge_without_lost_updates',
+  'optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears',
+  'eight zero-row',
   'restarted_process_reuses_delivery_ledger_without_reapplying_counter',
   'comment_projection_postgres_test',
   'comment_projection_restart_postgres_test',
@@ -581,6 +622,7 @@ for (const marker of [
   'EventBus',
   'EventDispatcher',
   'independent PostgreSQL connections',
+  'same envelope',
   'two sequential OS test processes',
   'server-host restart',
 ]) {
@@ -593,4 +635,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log('Blog comments event projection classifier, retry policy, registration, dispatcher, concurrency, PostgreSQL, connection restart, and process restart harnesses are consistent');
+console.log('Blog comments event projection classifier, retry policy, registration, dispatcher, concurrency, PostgreSQL retry-limit, connection restart, and process restart harnesses are consistent');

--- a/scripts/verify/verify-blog-comments-event-projection.test.mjs
+++ b/scripts/verify/verify-blog-comments-event-projection.test.mjs
@@ -25,6 +25,9 @@ function fixture({
   missingDispatcherWait = false,
   missingConcurrencyCase = false,
   missingConcurrencyBarrier = false,
+  missingRetryLimitCase = false,
+  missingRetryLimitProbe = false,
+  missingRetryLimitEvidence = false,
   missingSharedClassifier = false,
   directHandlesClassifier = false,
   missingCounterHarness = false,
@@ -46,6 +49,7 @@ function fixture({
   hostHarnessStatusDrift = false,
   dispatcherStatusDrift = false,
   concurrencyStatusDrift = false,
+  retryLimitStatusDrift = false,
   postgresStatusDrift = false,
   restartStatusDrift = false,
   processRestartStatusDrift = false,
@@ -65,6 +69,7 @@ function fixture({
   const hostRegistrationHarnessCommand = 'cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing';
   const dispatcherHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test event_dispatcher_routes_registered_handler_and_commits_projection -- --exact';
   const concurrencyHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test concurrent_created_events_converge_without_lost_updates -- --exact';
+  const retryLimitHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears -- --exact';
   const postgresHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test';
   const restartHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test';
   const processRestartHarnessCommand = 'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test restarted_process_reuses_delivery_ledger_without_reapplying_counter -- --exact';
@@ -175,11 +180,32 @@ barrier.wait().await;
 CONCURRENT_PROJECTION_DELIVERIES as i32
 count_all_deliveries(&test_db.db).await?
 `;
+    const retryLimitSource = missingRetryLimitCase
+      ? ''
+      : `
+async fn optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears()
+${missingRetryLimitProbe ? '' : `install_retry_limit_probe(&test_db.db).await?;
+eight zero-row updates must reach the optimistic retry limit
+after 8 concurrent attempts
+load_retry_attempt_count(&test_db.db).await?
+EXPECTED_RETRY_LIMIT_ATTEMPTS
+remove_retry_limit_probe(&test_db.db).await?;
+CREATE SEQUENCE blog_projection_retry_attempts START WITH 1;
+CREATE FUNCTION force_blog_projection_retry_limit()
+PERFORM nextval('blog_projection_retry_attempts');
+RETURN NULL;
+CREATE TRIGGER force_blog_projection_retry_limit
+BEFORE UPDATE OF comment_count, version ON blog_posts
+DROP TRIGGER force_blog_projection_retry_limit ON blog_posts;
+DROP FUNCTION force_blog_projection_retry_limit();
+SELECT last_value::bigint AS count FROM blog_projection_retry_attempts`}
+`;
     write(
       root,
       postgresHarnessPath,
       `
 const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";
+const EXPECTED_RETRY_LIMIT_ATTEMPTS: i64 = 8;
 struct PostgresBlogProjectionTestDb
 CREATE SCHEMA
 DROP SCHEMA IF EXISTS
@@ -189,6 +215,7 @@ async fn duplicate_delivery_updates_counter_and_outbox_once()
 handler.handle(&envelope).await?;
 ${dispatcherSource}
 ${concurrencySource}
+${retryLimitSource}
 async fn delete_before_create_stays_non_negative_and_replays_in_order()
 DomainEvent::CommentDeleted
 async fn missing_post_replay_commits_only_after_source_appears()
@@ -383,6 +410,26 @@ assert!(!handler.handles(&forum_created));
         scope: 'concurrent_unique_envelopes_same_post_final_counter_delivery_outbox',
         cases: ['concurrent_created_events_converge_without_lost_updates'],
       },
+      ...(missingRetryLimitEvidence
+        ? {}
+        : {
+            retry_limit_harness: {
+              status: retryLimitStatusDrift ? 'executed' : 'executable_no_run',
+              runtime_status: retryLimitStatusDrift ? 'passed' : 'not_run',
+              path: postgresHarnessPath,
+              environment: 'RUSTOK_BLOG_TEST_DATABASE_URL',
+              command: retryLimitHarnessCommand,
+              isolation:
+                'unique_schema_one_connection_pool_before_update_skip_trigger_nontransactional_attempt_sequence',
+              scope:
+                'real_handler_eight_zero_row_updates_terminal_error_atomic_rollback_and_same_envelope_replay',
+              non_claim:
+                'does_not_measure_natural_postgresql_contention_frequency_or_record_execution',
+              cases: [
+                'optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears',
+              ],
+            },
+          }),
       postgres_harness: {
         status: postgresStatusDrift ? 'executed' : 'executable_no_run',
         runtime_status: postgresStatusDrift ? 'passed' : 'not_run',
@@ -392,6 +439,7 @@ assert!(!handler.handles(&forum_created));
         isolation: 'unique_schema_one_connection_pool',
         cases: [
           'duplicate_delivery_updates_counter_and_outbox_once',
+          'optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears',
           'delete_before_create_stays_non_negative_and_replays_in_order',
           'missing_post_replay_commits_only_after_source_appears',
           'outbox_failure_rolls_back_counter_and_delivery_before_retry',
@@ -429,6 +477,9 @@ assert!(!handler.handles(&forum_created));
         { name: 'atomic_counter_delivery_outbox' },
         { name: 'tenant_scoped_optimistic_update' },
         ...(missingRetryPolicyEvidence ? [] : [{ name: 'bounded_optimistic_retry_policy' }]),
+        ...(missingRetryLimitEvidence
+          ? []
+          : [{ name: 'postgres_retry_limit_rollback_and_replay' }]),
         { name: 'missing_post_retry' },
         { name: 'non_negative_count' },
         { name: 'host_registration_routing_harness' },
@@ -490,7 +541,7 @@ assert!(!handler.handles(&forum_created));
   write(
     root,
     'crates/rustok-blog/docs/implementation-plan.md',
-    'blog-comments-event-projection.json verify:blog:comments-event-projection test:verify:blog:comments-event-projection source_verified_no_compile services::comment_projection::tests ProjectionUpdateDecision seven retry decisions tests::module_registers_comment_projection_handler_with_host_routing event_dispatcher_routes_registered_handler_and_commits_projection concurrent_created_events_converge_without_lost_updates restarted_process_reuses_delivery_ledger_without_reapplying_counter comment_projection_postgres_test comment_projection_restart_postgres_test RUSTOK_BLOG_TEST_DATABASE_URL EventBus EventDispatcher independent PostgreSQL connections two sequential OS test processes server-host restart',
+    'blog-comments-event-projection.json verify:blog:comments-event-projection test:verify:blog:comments-event-projection source_verified_no_compile services::comment_projection::tests ProjectionUpdateDecision seven retry decisions tests::module_registers_comment_projection_handler_with_host_routing event_dispatcher_routes_registered_handler_and_commits_projection concurrent_created_events_converge_without_lost_updates optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears eight zero-row same envelope restarted_process_reuses_delivery_ledger_without_reapplying_counter comment_projection_postgres_test comment_projection_restart_postgres_test RUSTOK_BLOG_TEST_DATABASE_URL EventBus EventDispatcher independent PostgreSQL connections two sequential OS test processes server-host restart',
   );
 
   return root;
@@ -574,6 +625,24 @@ test('rejects concurrent projection coverage without a shared barrier', () => {
     { missingConcurrencyBarrier: true },
     /missing Arc::new\(Barrier::new\(envelopes.len\(\)\)\)/,
   );
+});
+
+test('rejects a missing PostgreSQL retry-limit case', () => {
+  expectRejected(
+    { missingRetryLimitCase: true },
+    /missing async fn optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears/,
+  );
+});
+
+test('rejects retry-limit coverage without the deterministic probe', () => {
+  expectRejected(
+    { missingRetryLimitProbe: true },
+    /missing install_retry_limit_probe\(&test_db.db\).await\?;/,
+  );
+});
+
+test('rejects retry-limit evidence drift', () => {
+  expectRejected({ missingRetryLimitEvidence: true }, /retry-limit harness drift/);
 });
 
 test('rejects project without the shared event classifier', () => {
@@ -685,6 +754,10 @@ test('rejects dispatcher harness execution promotion without execution', () => {
 
 test('rejects concurrency harness execution promotion without execution', () => {
   expectRejected({ concurrencyStatusDrift: true }, /concurrency harness drift/);
+});
+
+test('rejects retry-limit harness execution promotion without execution', () => {
+  expectRejected({ retryLimitStatusDrift: true }, /retry-limit harness drift/);
 });
 
 test('rejects PostgreSQL harness execution promotion without execution', () => {


### PR DESCRIPTION
## Summary

- re-audit the canonical Blog implementation plan against `main` and retain all 52 prior source-only claims without promoting execution
- add an env-gated PostgreSQL target that forces the real `BlogCommentProjectionHandler` through eight zero-row optimistic updates
- count attempts with a nontransactional sequence while a schema-local `BEFORE UPDATE` trigger skips each update
- require the terminal error to leave the post, delivery ledger, and outbox unchanged
- remove the probe and replay the same envelope successfully
- update projection evidence, the focused source verifier, its negative self-test, and the canonical plan through slice 53

## Scope and non-claims

The retry-limit target is deterministic conflict injection. It does not measure naturally contended PostgreSQL retry frequency, and no Rust test, JavaScript verifier, compile, PostgreSQL, browser, workflow, or CI command was run.

## Suggested maintainer commands

```bash
RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... \
  cargo test -p rustok-blog \
  --test comment_projection_postgres_test \
  optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears \
  -- --exact

npm run verify:blog:comments-event-projection
npm run test:verify:blog:comments-event-projection
```

## Branch state

The work started from `763bd8ab2912af00b3c4034b5af13da3afbbfb46`. `main` later received unrelated Commerce change `3c76a488d750ef312ac4ecd6e20f8a2a3460d839`; GitHub reports this PR mergeable with five Blog-only commits and five changed files. Tests are intentionally left to the maintainer.