### PR TITLE
fix(search): unblock migration plan export

### DIFF
--- a/crates/rustok-search/src/projector_legacy.rs
+++ b/crates/rustok-search/src/projector_legacy.rs
@@ -516,6 +516,8 @@ impl SearchProjector {
             values.push(product_id.into());
         }
 
+        // `format!` emits the PostgreSQL JSON path below after brace escaping:
+        // p.metadata #> '{channel_visibility,allowed_channel_slugs}'
         let sql = format!(
             r#"
             INSERT INTO search_documents (
@@ -577,9 +579,9 @@ impl SearchProjector {
                         CASE
                             WHEN NOT (p.metadata ? 'channel_visibility') THEN '[]'::jsonb
                             WHEN jsonb_typeof(
-                                p.metadata #> '{channel_visibility,allowed_channel_slugs}'
+                                p.metadata #> '{{channel_visibility,allowed_channel_slugs}}'
                             ) = 'array' THEN
-                                p.metadata #> '{channel_visibility,allowed_channel_slugs}'
+                                p.metadata #> '{{channel_visibility,allowed_channel_slugs}}'
                             ELSE 'null'::jsonb
                         END
                     ),

--- a/crates/rustok-search/tests/projector_format_contract.rs
+++ b/crates/rustok-search/tests/projector_format_contract.rs
@@ -1,0 +1,17 @@
+#[test]
+fn product_channel_json_path_is_escaped_for_format_macro() {
+    let source = include_str!("../src/projector_legacy.rs");
+    let escaped_path = "p.metadata #> '{{channel_visibility,allowed_channel_slugs}}'";
+
+    assert_eq!(
+        source.matches(escaped_path).count(),
+        2,
+        "both executable JSON-path uses inside format! must escape literal braces"
+    );
+    assert!(
+        !source
+            .lines()
+            .any(|line| line.trim() == "p.metadata #> '{channel_visibility,allowed_channel_slugs}'"),
+        "an unescaped executable JSON path would make rustok-search fail to compile"
+    );
+}


### PR DESCRIPTION
## Summary

Migration Compatibility on Tenant PR #2665 never reached Tenant migration evidence because the base revision failed to compile `rustok-search` while exporting the migration plan.

The Product channel-visibility JSON path is embedded in a Rust `format!` raw string. Literal PostgreSQL path braces were not escaped, so rustc parsed `{channel_visibility,allowed_channel_slugs}` as a formatting placeholder and rejected the crate.

This change:

- escapes both executable JSON-path occurrences as `{{channel_visibility,allowed_channel_slugs}}` so the emitted SQL remains `{channel_visibility,allowed_channel_slugs}`;
- retains the emitted SQL contract in a source comment for existing product-channel evidence;
- adds a focused Rust source regression requiring exactly two escaped executable paths and forbidding the unescaped executable line.

## Impact

This is a P1 release-path fix in the Search owner. It unblocks migration-plan export so PostgreSQL fresh-install, N-1 upgrade, and Tenant locale-backfill evidence can proceed. It does not change the generated SQL, Search semantics, migrations, CI workflows, or public contracts.

## Evidence

Observed failure in Migration Compatibility run `30619092488`:

`crates/rustok-search/src/projector_legacy.rs:580: invalid format string`

The branch diff is limited to six lines in the projector and one 17-line regression test. The current `main` advanced only through unrelated Blog evidence after this branch was created; GitHub mergeability against the current base is the source of truth before squash merge.