### PR TITLE
fix(channel-admin): bind permissions to routed tenant

### DIFF
--- a/crates/rustok-channel/admin/src/transport/native_server_adapter.rs
+++ b/crates/rustok-channel/admin/src/transport/native_server_adapter.rs
@@ -15,12 +15,26 @@ use crate::model::{
 };
 
 #[cfg(feature = "ssr")]
-fn ensure_manage_permission(permissions: &[rustok_api::Permission]) -> Result<(), ServerFnError> {
+fn ensure_manage_permission(
+    auth: &rustok_api::AuthContext,
+    resolved_tenant_id: uuid::Uuid,
+) -> Result<(), ServerFnError> {
     use rustok_api::Permission;
     use rustok_api::has_any_effective_permission;
 
+    if auth.tenant_id != resolved_tenant_id {
+        tracing::warn!(
+            auth_tenant_id = %auth.tenant_id,
+            resolved_tenant_id = %resolved_tenant_id,
+            code = "channel.admin_tenant_scope_mismatch",
+            boundary = "channel_admin_native_transport",
+            "channel admin permissions cannot cross the resolved tenant boundary"
+        );
+        return Err(ServerFnError::new("Channel admin access is denied"));
+    }
+
     if !has_any_effective_permission(
-        permissions,
+        &auth.permissions,
         &[Permission::SETTINGS_MANAGE, Permission::MODULES_MANAGE],
     ) {
         return Err(ServerFnError::new(
@@ -286,7 +300,7 @@ pub(super) async fn channel_bootstrap_native() -> Result<ChannelAdminBootstrap, 
             .ok()
             .and_then(|value| value.0);
 
-        ensure_manage_permission(&auth.permissions)?;
+        ensure_manage_permission(&auth, tenant.id)?;
 
         let service = ChannelService::new(db.clone());
         let channels = service
@@ -446,7 +460,7 @@ pub(super) async fn channel_create_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_manage_permission(&auth.permissions)?;
+        ensure_manage_permission(&auth, tenant.id)?;
 
         let service = ChannelService::new(db.clone());
         let channel = service
@@ -490,7 +504,7 @@ pub(super) async fn channel_set_default_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_manage_permission(&auth.permissions)?;
+        ensure_manage_permission(&auth, tenant.id)?;
 
         let service = ChannelService::new(db.clone());
         let channel_uuid = parse_uuid(&channel_id, "channel_id")?;
@@ -532,7 +546,7 @@ pub(super) async fn channel_create_target_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_manage_permission(&auth.permissions)?;
+        ensure_manage_permission(&auth, tenant.id)?;
 
         let service = ChannelService::new(db.clone());
         let channel_uuid = parse_uuid(&channel_id, "channel_id")?;
@@ -583,7 +597,7 @@ pub(super) async fn channel_update_target_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_manage_permission(&auth.permissions)?;
+        ensure_manage_permission(&auth, tenant.id)?;
 
         let service = ChannelService::new(db.clone());
         let channel_uuid = parse_uuid(&channel_id, "channel_id")?;
@@ -635,7 +649,7 @@ pub(super) async fn channel_bind_module_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_manage_permission(&auth.permissions)?;
+        ensure_manage_permission(&auth, tenant.id)?;
 
         let service = ChannelService::new(db.clone());
         let channel_uuid = parse_uuid(&channel_id, "channel_id")?;
@@ -685,7 +699,7 @@ pub(super) async fn channel_bind_oauth_app_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_manage_permission(&auth.permissions)?;
+        ensure_manage_permission(&auth, tenant.id)?;
 
         let channel_uuid = parse_uuid(&channel_id, "channel_id")?;
         let oauth_app_uuid = parse_uuid(&payload.oauth_app_id, "oauth_app_id")?;
@@ -759,7 +773,7 @@ pub(super) async fn channel_delete_target_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_manage_permission(&auth.permissions)?;
+        ensure_manage_permission(&auth, tenant.id)?;
 
         let service = ChannelService::new(db.clone());
         let channel_uuid = parse_uuid(&channel_id, "channel_id")?;
@@ -802,7 +816,7 @@ pub(super) async fn channel_delete_module_binding_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_manage_permission(&auth.permissions)?;
+        ensure_manage_permission(&auth, tenant.id)?;
 
         let service = ChannelService::new(db.clone());
         let channel_uuid = parse_uuid(&channel_id, "channel_id")?;
@@ -845,7 +859,7 @@ pub(super) async fn channel_delete_oauth_app_binding_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_manage_permission(&auth.permissions)?;
+        ensure_manage_permission(&auth, tenant.id)?;
 
         let service = ChannelService::new(db.clone());
         let channel_uuid = parse_uuid(&channel_id, "channel_id")?;
@@ -887,7 +901,7 @@ pub(super) async fn channel_create_resolution_policy_set_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_manage_permission(&auth.permissions)?;
+        ensure_manage_permission(&auth, tenant.id)?;
 
         let service = ChannelService::new(db.clone());
         let policy_set = service
@@ -934,7 +948,7 @@ pub(super) async fn channel_activate_resolution_policy_set_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_manage_permission(&auth.permissions)?;
+        ensure_manage_permission(&auth, tenant.id)?;
 
         let service = ChannelService::new(db.clone());
         let policy_set_uuid = parse_uuid(&policy_set_id, "policy_set_id")?;
@@ -976,7 +990,7 @@ pub(super) async fn channel_create_resolution_rule_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_manage_permission(&auth.permissions)?;
+        ensure_manage_permission(&auth, tenant.id)?;
 
         let policy_set_uuid = parse_uuid(&policy_set_id, "policy_set_id")?;
         let action_channel_id = parse_uuid(&payload.action_channel_id, "action_channel_id")?;
@@ -1032,7 +1046,7 @@ pub(super) async fn channel_update_resolution_rule_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_manage_permission(&auth.permissions)?;
+        ensure_manage_permission(&auth, tenant.id)?;
 
         let service = ChannelService::new(db.clone());
         let policy_set_uuid = parse_uuid(&policy_set_id, "policy_set_id")?;
@@ -1098,7 +1112,7 @@ pub(super) async fn channel_reorder_resolution_rules_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_manage_permission(&auth.permissions)?;
+        ensure_manage_permission(&auth, tenant.id)?;
 
         let service = ChannelService::new(db.clone());
         let policy_set_uuid = parse_uuid(&policy_set_id, "policy_set_id")?;
@@ -1149,7 +1163,7 @@ pub(super) async fn channel_delete_resolution_rule_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_manage_permission(&auth.permissions)?;
+        ensure_manage_permission(&auth, tenant.id)?;
 
         let service = ChannelService::new(db.clone());
         let policy_set_uuid = parse_uuid(&policy_set_id, "policy_set_id")?;

--- a/crates/rustok-channel/admin/tests/tenant_scope_contract.rs
+++ b/crates/rustok-channel/admin/tests/tenant_scope_contract.rs
@@ -12,9 +12,18 @@ fn every_channel_admin_permission_check_is_bound_to_the_resolved_tenant() {
         .matches("leptos_axum::extract::<TenantContext>()")
         .count();
 
-    assert_eq!(scoped_calls, 16, "all native channel admin endpoints must use the scoped guard");
-    assert_eq!(auth_extracts, scoped_calls, "every authenticated endpoint must apply the guard");
-    assert_eq!(tenant_extracts, scoped_calls, "every routed tenant must be bound to authenticated authority");
+    assert_eq!(
+        scoped_calls, 16,
+        "all native channel admin endpoints must use the scoped guard"
+    );
+    assert_eq!(
+        auth_extracts, scoped_calls,
+        "every authenticated endpoint must apply the guard"
+    );
+    assert_eq!(
+        tenant_extracts, scoped_calls,
+        "every routed tenant must be bound to authenticated authority"
+    );
     assert!(!SOURCE.contains("ensure_manage_permission(&auth.permissions)?;"));
 }
 
@@ -36,7 +45,10 @@ fn tenant_equality_is_checked_before_permission_admission() {
         .find("has_any_effective_permission(")
         .expect("permission admission must remain");
 
-    assert!(tenant_check < permission_check, "tenant equality must precede permission admission");
+    assert!(
+        tenant_check < permission_check,
+        "tenant equality must precede permission admission"
+    );
     assert!(helper.contains("Channel admin access is denied"));
     assert!(helper.contains("channel.admin_tenant_scope_mismatch"));
     assert!(helper.contains("auth_tenant_id = %auth.tenant_id"));

--- a/crates/rustok-channel/admin/tests/tenant_scope_contract.rs
+++ b/crates/rustok-channel/admin/tests/tenant_scope_contract.rs
@@ -1,0 +1,44 @@
+const SOURCE: &str = include_str!("../src/transport/native_server_adapter.rs");
+
+#[test]
+fn every_channel_admin_permission_check_is_bound_to_the_resolved_tenant() {
+    let scoped_calls = SOURCE
+        .matches("ensure_manage_permission(&auth, tenant.id)?;")
+        .count();
+    let auth_extracts = SOURCE
+        .matches("leptos_axum::extract::<AuthContext>()")
+        .count();
+    let tenant_extracts = SOURCE
+        .matches("leptos_axum::extract::<TenantContext>()")
+        .count();
+
+    assert_eq!(scoped_calls, 16, "all native channel admin endpoints must use the scoped guard");
+    assert_eq!(auth_extracts, scoped_calls, "every authenticated endpoint must apply the guard");
+    assert_eq!(tenant_extracts, scoped_calls, "every routed tenant must be bound to authenticated authority");
+    assert!(!SOURCE.contains("ensure_manage_permission(&auth.permissions)?;"));
+}
+
+#[test]
+fn tenant_equality_is_checked_before_permission_admission() {
+    let helper_start = SOURCE
+        .find("fn ensure_manage_permission(")
+        .expect("scoped permission helper must exist");
+    let helper_end = SOURCE[helper_start..]
+        .find("\n}\n\n#[cfg(feature = \"ssr\")]\nfn parse_uuid")
+        .map(|offset| helper_start + offset)
+        .expect("scoped permission helper must remain isolated");
+    let helper = &SOURCE[helper_start..helper_end];
+
+    let tenant_check = helper
+        .find("if auth.tenant_id != resolved_tenant_id")
+        .expect("tenant equality must be checked");
+    let permission_check = helper
+        .find("has_any_effective_permission(")
+        .expect("permission admission must remain");
+
+    assert!(tenant_check < permission_check, "tenant equality must precede permission admission");
+    assert!(helper.contains("Channel admin access is denied"));
+    assert!(helper.contains("channel.admin_tenant_scope_mismatch"));
+    assert!(helper.contains("auth_tenant_id = %auth.tenant_id"));
+    assert!(helper.contains("resolved_tenant_id = %resolved_tenant_id"));
+}


### PR DESCRIPTION
## Summary

The Channel Admin native surface extracted both authenticated `AuthContext` and middleware-resolved `TenantContext`, but admitted `settings:manage` / `modules:manage` permissions without requiring those tenant identities to match.

That allowed authority issued for tenant A to operate on channel, policy, OAuth-binding, and module-binding state selected by routed tenant B.

## P0 fix

- change the shared Channel Admin permission guard to accept the full `AuthContext` and resolved tenant id;
- reject `auth.tenant_id != resolved_tenant_id` before any RBAC admission;
- return a static `Channel admin access is denied` response;
- retain both tenant ids only in structured warning diagnostics with code `channel.admin_tenant_scope_mismatch`;
- route all 16 authenticated Channel Admin native endpoints through the scoped guard.

## Regression evidence

`crates/rustok-channel/admin/tests/tenant_scope_contract.rs`:

- requires exactly 16 scoped permission calls;
- requires matching AuthContext and TenantContext extractor counts;
- forbids the old `ensure_manage_permission(&auth.permissions)` path;
- verifies tenant equality appears before `has_any_effective_permission`;
- retains the static public response and private diagnostic markers.

## Scope

No workflow, migration, database schema, public API, permission identifier, or channel lifecycle behavior changes. The existing Channel component remains blocked on its multilingual and same-SHA migration/cache evidence; this PR closes only the confirmed cross-tenant trust failure.

## Merge

Squash merge after rechecking current `main` and GitHub mergeability.