### PR TITLE
fix(index-admin): bind read authority to routed tenant

### DIFF
--- a/crates/rustok-index/admin/src/transport/native_server_adapter.rs
+++ b/crates/rustok-index/admin/src/transport/native_server_adapter.rs
@@ -4,6 +4,25 @@ use crate::model::IndexAdminBootstrap;
 #[cfg(feature = "ssr")]
 use crate::model::{IndexModuleSnapshot, IndexTenantSnapshot};
 
+#[cfg(feature = "ssr")]
+fn require_index_admin_tenant_scope(
+    auth_tenant_id: uuid::Uuid,
+    resolved_tenant_id: uuid::Uuid,
+) -> Result<(), ServerFnError> {
+    if auth_tenant_id == resolved_tenant_id {
+        return Ok(());
+    }
+
+    tracing::warn!(
+        auth_tenant_id = %auth_tenant_id,
+        resolved_tenant_id = %resolved_tenant_id,
+        code = "index.admin_tenant_scope_mismatch",
+        boundary = "index_admin_native_transport",
+        "index admin permissions cannot cross the resolved tenant boundary"
+    );
+    Err(ServerFnError::new("Index admin access is denied"))
+}
+
 #[server(prefix = "/api/fn", endpoint = "index/bootstrap")]
 pub async fn fetch_bootstrap_native() -> Result<IndexAdminBootstrap, ServerFnError> {
     #[cfg(feature = "ssr")]
@@ -17,6 +36,7 @@ pub async fn fetch_bootstrap_native() -> Result<IndexAdminBootstrap, ServerFnErr
         let tenant = leptos_axum::extract::<TenantContext>()
             .await
             .map_err(ServerFnError::new)?;
+        require_index_admin_tenant_scope(auth.tenant_id, tenant.id)?;
 
         if !has_effective_permission(&auth.permissions, &Permission::SETTINGS_READ) {
             return Err(ServerFnError::new(

--- a/crates/rustok-index/admin/tests/tenant_scope_contract.rs
+++ b/crates/rustok-index/admin/tests/tenant_scope_contract.rs
@@ -1,0 +1,33 @@
+const SOURCE: &str = include_str!("../src/transport/native_server_adapter.rs");
+
+#[test]
+fn index_admin_binds_authenticated_authority_to_the_resolved_tenant() {
+    let tenant_guard = SOURCE
+        .find("require_index_admin_tenant_scope(auth.tenant_id, tenant.id)?;")
+        .expect("index admin must bind authenticated and resolved tenants");
+    let permission_check = SOURCE
+        .find("has_effective_permission(&auth.permissions, &Permission::SETTINGS_READ)")
+        .expect("index admin must retain SETTINGS_READ admission");
+
+    assert!(
+        tenant_guard < permission_check,
+        "tenant equality must be enforced before permission admission"
+    );
+    assert_eq!(
+        SOURCE
+            .matches("leptos_axum::extract::<AuthContext>()")
+            .count(),
+        1
+    );
+    assert_eq!(
+        SOURCE
+            .matches("leptos_axum::extract::<TenantContext>()")
+            .count(),
+        1
+    );
+    assert!(SOURCE.contains("if auth_tenant_id == resolved_tenant_id"));
+    assert!(SOURCE.contains("Index admin access is denied"));
+    assert!(SOURCE.contains("index.admin_tenant_scope_mismatch"));
+    assert!(SOURCE.contains("auth_tenant_id = %auth_tenant_id"));
+    assert!(SOURCE.contains("resolved_tenant_id = %resolved_tenant_id"));
+}


### PR DESCRIPTION
## Summary

Index Admin bootstrap admitted `settings:read` from `AuthContext` and returned state for a separately resolved `TenantContext` without first requiring tenant equality.

That allowed authority issued for tenant A to inspect Index administration state for routed tenant B.

## P0 fix

- require `AuthContext.tenant_id == TenantContext.id` before `SETTINGS_READ` admission;
- fail closed with static `Index admin access is denied`;
- retain both tenant ids only in structured diagnostics with code `index.admin_tenant_scope_mismatch`;
- preserve the existing permission identifier and bootstrap response shape.

## Regression evidence

`crates/rustok-index/admin/tests/tenant_scope_contract.rs` requires the tenant guard to precede permission admission, retains the single Auth/Tenant extractor pair, and locks the static public/private diagnostic contract.

No workflow, migration, storage, replay, or public API changes.