### PR TITLE
fix(search-admin): bind permissions to routed tenant

### DIFF
--- a/crates/rustok-search/admin/src/transport/native_server_adapter/read_analytics.rs
+++ b/crates/rustok-search/admin/src/transport/native_server_adapter/read_analytics.rs
@@ -16,7 +16,7 @@ async fn search_admin_analytics_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_settings_read_permission(&auth.permissions)?;
+        ensure_settings_read_permission(&auth, tenant.id)?;
 
         let snapshot = rustok_search::SearchAnalyticsService::snapshot(
             &app_ctx.db,
@@ -54,7 +54,7 @@ async fn search_admin_dictionary_snapshot_native()
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_settings_read_permission(&auth.permissions)?;
+        ensure_settings_read_permission(&auth, tenant.id)?;
 
         let snapshot = rustok_search::SearchDictionaryService::snapshot(&app_ctx.db, tenant.id)
             .await

--- a/crates/rustok-search/admin/src/transport/native_server_adapter/read_bootstrap.rs
+++ b/crates/rustok-search/admin/src/transport/native_server_adapter/read_bootstrap.rs
@@ -13,7 +13,7 @@ async fn search_admin_bootstrap_native() -> Result<SearchAdminBootstrap, ServerF
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_settings_read_permission(&auth.permissions)?;
+        ensure_settings_read_permission(&auth, tenant.id)?;
 
         let module = rustok_search::SearchModule;
         let settings =
@@ -64,7 +64,7 @@ async fn search_admin_preview_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_settings_read_permission(&auth.permissions)?;
+        ensure_settings_read_permission(&auth, tenant.id)?;
 
         let input = normalize_search_preview_input(SearchPreviewInput {
             query,

--- a/crates/rustok-search/admin/src/transport/native_server_adapter/read_diagnostics.rs
+++ b/crates/rustok-search/admin/src/transport/native_server_adapter/read_diagnostics.rs
@@ -15,7 +15,7 @@ async fn search_admin_filter_presets_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_settings_read_permission(&auth.permissions)?;
+        ensure_settings_read_permission(&auth, tenant.id)?;
 
         let surface = normalize_surface(&surface)?;
         let settings =
@@ -65,7 +65,7 @@ async fn search_admin_lagging_documents_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_settings_read_permission(&auth.permissions)?;
+        ensure_settings_read_permission(&auth, tenant.id)?;
 
         let rows = rustok_search::SearchDiagnosticsService::lagging_documents(
             &app_ctx.db,
@@ -103,7 +103,7 @@ async fn search_admin_consistency_issues_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_settings_read_permission(&auth.permissions)?;
+        ensure_settings_read_permission(&auth, tenant.id)?;
 
         let rows = rustok_search::SearchDiagnosticsService::consistency_issues(
             &app_ctx.db,

--- a/crates/rustok-search/admin/src/transport/native_server_adapter/support.rs
+++ b/crates/rustok-search/admin/src/transport/native_server_adapter/support.rs
@@ -19,10 +19,34 @@ fn normalize_limit(value: Option<i32>, default: i32, max: i32) -> usize {
 }
 
 #[cfg(feature = "ssr")]
-fn ensure_settings_read_permission(
-    permissions: &[rustok_api::Permission],
+fn ensure_search_admin_tenant_scope(
+    auth: &rustok_api::AuthContext,
+    resolved_tenant_id: uuid::Uuid,
 ) -> Result<(), ServerFnError> {
-    if !rustok_api::has_effective_permission(permissions, &rustok_api::Permission::SETTINGS_READ) {
+    if auth.tenant_id == resolved_tenant_id {
+        return Ok(());
+    }
+
+    tracing::warn!(
+        auth_tenant_id = %auth.tenant_id,
+        resolved_tenant_id = %resolved_tenant_id,
+        code = "search.admin_tenant_scope_mismatch",
+        boundary = "search_admin_native_transport",
+        "search admin permissions cannot cross the resolved tenant boundary"
+    );
+    Err(ServerFnError::new("Search admin access is denied"))
+}
+
+#[cfg(feature = "ssr")]
+fn ensure_settings_read_permission(
+    auth: &rustok_api::AuthContext,
+    resolved_tenant_id: uuid::Uuid,
+) -> Result<(), ServerFnError> {
+    ensure_search_admin_tenant_scope(auth, resolved_tenant_id)?;
+    if !rustok_api::has_effective_permission(
+        &auth.permissions,
+        &rustok_api::Permission::SETTINGS_READ,
+    ) {
         return Err(ServerFnError::new("settings:read required"));
     }
     Ok(())
@@ -30,10 +54,14 @@ fn ensure_settings_read_permission(
 
 #[cfg(feature = "ssr")]
 fn ensure_settings_manage_permission(
-    permissions: &[rustok_api::Permission],
+    auth: &rustok_api::AuthContext,
+    resolved_tenant_id: uuid::Uuid,
 ) -> Result<(), ServerFnError> {
-    if !rustok_api::has_effective_permission(permissions, &rustok_api::Permission::SETTINGS_MANAGE)
-    {
+    ensure_search_admin_tenant_scope(auth, resolved_tenant_id)?;
+    if !rustok_api::has_effective_permission(
+        &auth.permissions,
+        &rustok_api::Permission::SETTINGS_MANAGE,
+    ) {
         return Err(ServerFnError::new("settings:manage required"));
     }
     Ok(())

--- a/crates/rustok-search/admin/src/transport/native_server_adapter/write_dictionary.rs
+++ b/crates/rustok-search/admin/src/transport/native_server_adapter/write_dictionary.rs
@@ -16,7 +16,7 @@ async fn upsert_search_synonym_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_settings_manage_permission(&auth.permissions)?;
+        ensure_settings_manage_permission(&auth, tenant.id)?;
 
         rustok_search::SearchDictionaryService::upsert_synonym(
             &app_ctx.db,
@@ -55,7 +55,7 @@ async fn delete_search_synonym_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_settings_manage_permission(&auth.permissions)?;
+        ensure_settings_manage_permission(&auth, tenant.id)?;
 
         rustok_search::SearchDictionaryService::delete_synonym(
             &app_ctx.db,
@@ -93,7 +93,7 @@ async fn add_search_stop_word_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_settings_manage_permission(&auth.permissions)?;
+        ensure_settings_manage_permission(&auth, tenant.id)?;
 
         rustok_search::SearchDictionaryService::add_stop_word(&app_ctx.db, tenant.id, &value)
             .await
@@ -127,7 +127,7 @@ async fn delete_search_stop_word_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_settings_manage_permission(&auth.permissions)?;
+        ensure_settings_manage_permission(&auth, tenant.id)?;
 
         rustok_search::SearchDictionaryService::delete_stop_word(
             &app_ctx.db,
@@ -167,7 +167,7 @@ async fn upsert_search_pin_rule_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_settings_manage_permission(&auth.permissions)?;
+        ensure_settings_manage_permission(&auth, tenant.id)?;
 
         rustok_search::SearchDictionaryService::upsert_pin_rule(
             &app_ctx.db,
@@ -207,7 +207,7 @@ async fn delete_search_query_rule_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_settings_manage_permission(&auth.permissions)?;
+        ensure_settings_manage_permission(&auth, tenant.id)?;
 
         rustok_search::SearchDictionaryService::delete_query_rule(
             &app_ctx.db,

--- a/crates/rustok-search/admin/src/transport/native_server_adapter/write_runtime.rs
+++ b/crates/rustok-search/admin/src/transport/native_server_adapter/write_runtime.rs
@@ -18,7 +18,7 @@ async fn update_search_settings_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_settings_manage_permission(&auth.permissions)?;
+        ensure_settings_manage_permission(&auth, tenant.id)?;
 
         let active_engine = parse_engine(&active_engine, "active_engine")?;
         let fallback_engine = fallback_engine
@@ -84,7 +84,7 @@ async fn trigger_search_rebuild_native(
             .await
             .map_err(ServerFnError::new)?;
 
-        ensure_settings_manage_permission(&auth.permissions)?;
+        ensure_settings_manage_permission(&auth, tenant.id)?;
 
         let target_type = target_type
             .unwrap_or_else(|| "search".to_string())

--- a/crates/rustok-search/admin/tests/tenant_scope_contract.rs
+++ b/crates/rustok-search/admin/tests/tenant_scope_contract.rs
@@ -1,0 +1,96 @@
+const SUPPORT: &str = include_str!("../src/transport/native_server_adapter/support.rs");
+const READ_BOOTSTRAP: &str =
+    include_str!("../src/transport/native_server_adapter/read_bootstrap.rs");
+const READ_DIAGNOSTICS: &str =
+    include_str!("../src/transport/native_server_adapter/read_diagnostics.rs");
+const READ_ANALYTICS: &str =
+    include_str!("../src/transport/native_server_adapter/read_analytics.rs");
+const WRITE_RUNTIME: &str =
+    include_str!("../src/transport/native_server_adapter/write_runtime.rs");
+const WRITE_DICTIONARY: &str =
+    include_str!("../src/transport/native_server_adapter/write_dictionary.rs");
+
+fn endpoint_source() -> String {
+    [
+        READ_BOOTSTRAP,
+        READ_DIAGNOSTICS,
+        READ_ANALYTICS,
+        WRITE_RUNTIME,
+        WRITE_DICTIONARY,
+    ]
+    .join("\n")
+}
+
+#[test]
+fn every_authenticated_search_admin_endpoint_uses_the_scoped_permission_helpers() {
+    let source = endpoint_source();
+    let read_calls = source
+        .matches("ensure_settings_read_permission(&auth, tenant.id)?;")
+        .count();
+    let manage_calls = source
+        .matches("ensure_settings_manage_permission(&auth, tenant.id)?;")
+        .count();
+    let auth_extracts = source
+        .matches("leptos_axum::extract::<AuthContext>()")
+        .count();
+    let tenant_extracts = source
+        .matches("leptos_axum::extract::<TenantContext>()")
+        .count();
+
+    assert_eq!(read_calls, 7, "all Search Admin read endpoints must be scoped");
+    assert_eq!(
+        manage_calls, 8,
+        "all Search Admin manage endpoints must be scoped"
+    );
+    assert_eq!(
+        auth_extracts,
+        read_calls + manage_calls,
+        "every authenticated endpoint must apply exactly one scoped permission helper"
+    );
+    assert_eq!(
+        tenant_extracts,
+        auth_extracts + 1,
+        "track-click is the single tenant-scoped endpoint without AuthContext"
+    );
+    assert!(!source.contains("ensure_settings_read_permission(&auth.permissions)?;"));
+    assert!(!source.contains("ensure_settings_manage_permission(&auth.permissions)?;"));
+}
+
+#[test]
+fn tenant_equality_precedes_read_and_manage_permission_admission() {
+    let tenant_scope = SUPPORT
+        .find("fn ensure_search_admin_tenant_scope(")
+        .expect("shared Search Admin tenant guard must exist");
+    let read_helper = SUPPORT
+        .find("fn ensure_settings_read_permission(")
+        .expect("read permission helper must exist");
+    let manage_helper = SUPPORT
+        .find("fn ensure_settings_manage_permission(")
+        .expect("manage permission helper must exist");
+    let parse_helper = SUPPORT
+        .find("fn parse_required_uuid(")
+        .expect("permission helper section must remain bounded");
+
+    let tenant_scope_source = &SUPPORT[tenant_scope..read_helper];
+    let read_source = &SUPPORT[read_helper..manage_helper];
+    let manage_source = &SUPPORT[manage_helper..parse_helper];
+
+    assert!(tenant_scope_source.contains("if auth.tenant_id == resolved_tenant_id"));
+    assert!(tenant_scope_source.contains("Search admin access is denied"));
+    assert!(tenant_scope_source.contains("search.admin_tenant_scope_mismatch"));
+    assert!(tenant_scope_source.contains("auth_tenant_id = %auth.tenant_id"));
+    assert!(tenant_scope_source.contains("resolved_tenant_id = %resolved_tenant_id"));
+
+    for helper in [read_source, manage_source] {
+        let scope_check = helper
+            .find("ensure_search_admin_tenant_scope(auth, resolved_tenant_id)?;")
+            .expect("tenant scope must be enforced");
+        let permission_check = helper
+            .find("has_effective_permission(")
+            .expect("permission admission must remain");
+        assert!(
+            scope_check < permission_check,
+            "tenant equality must precede permission admission"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Search Admin had the same cross-tenant trust failure across its authenticated native surface: permissions from `AuthContext` were admitted while reads, settings writes, dictionary writes, diagnostics, analytics, preview, and rebuild events used a separately resolved `TenantContext`.

Authority issued for tenant A could therefore read or mutate Search state for routed tenant B.

## P0 fix

- add one shared `ensure_search_admin_tenant_scope` guard;
- require tenant equality before both `SETTINGS_READ` and `SETTINGS_MANAGE` admission;
- return static `Search admin access is denied` on mismatch;
- retain both tenant ids only in structured diagnostics with code `search.admin_tenant_scope_mismatch`;
- route all 15 authenticated endpoints through the scoped helpers: 7 read and 8 manage;
- leave `track-click` unchanged because it intentionally has no AuthContext/admin permission contract.

## Regression evidence

`crates/rustok-search/admin/tests/tenant_scope_contract.rs` locks:

- 7 scoped read calls and 8 scoped manage calls;
- one scoped helper per AuthContext extractor;
- the single extra TenantContext extractor for unauthenticated `track-click`;
- removal of both old unscoped helper calls;
- tenant equality before read and manage permission admission;
- static public denial and private structured diagnostic markers.

No workflow, schema, projection, ranking, event payload, permission identifier, or Search API shape changes.