### PR TITLE
fix(commerce): sanitize order-change client diagnostics

### DIFF
--- a/crates/rustok-commerce/admin/src/transport/order_change_client_error_safety.rs
+++ b/crates/rustok-commerce/admin/src/transport/order_change_client_error_safety.rs
@@ -9,6 +9,12 @@ const COMMERCE_ADMIN_ORDER_CHANGE_CLIENT_BOUNDARY: &str =
 const COMMERCE_ADMIN_ORDER_CHANGE_CLIENT_PUBLIC_MESSAGE: &str =
     "Commerce admin order-change request could not be completed";
 
+struct OrderChangeClientErrorFacts {
+    error_variant: &'static str,
+    message_present: bool,
+    message_length: usize,
+}
+
 pub(super) struct OrderChangeClientErrorContext {
     operation: &'static str,
     correlation_id: String,
@@ -93,8 +99,11 @@ impl OrderChangeClientErrorContext {
     }
 
     pub(super) fn map_error(&self, error: ApiError) -> ApiError {
+        let error_facts = order_change_client_error_facts(&error);
         tracing::error!(
-            raw_error = ?error,
+            error_variant = error_facts.error_variant,
+            error_message_present = error_facts.message_present,
+            error_message_length = error_facts.message_length,
             owner = COMMERCE_ADMIN_ORDER_CHANGE_CLIENT_OWNER,
             owner_operation = self.operation,
             correlation_id = %self.correlation_id,
@@ -116,6 +125,19 @@ impl OrderChangeClientErrorContext {
         );
 
         ApiError::ServerFn(COMMERCE_ADMIN_ORDER_CHANGE_CLIENT_PUBLIC_MESSAGE.to_string())
+    }
+}
+
+fn order_change_client_error_facts(error: &ApiError) -> OrderChangeClientErrorFacts {
+    let (error_variant, message) = match error {
+        ApiError::Graphql(message) => ("graphql", message),
+        ApiError::ServerFn(message) => ("server_fn", message),
+    };
+
+    OrderChangeClientErrorFacts {
+        error_variant,
+        message_present: !message.trim().is_empty(),
+        message_length: message.chars().count(),
     }
 }
 

--- a/crates/rustok-commerce/contracts/evidence/admin-order-change-client-transport-error-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/admin-order-change-client-transport-error-safety-source-review.json
@@ -7,9 +7,9 @@
     "The GraphQL branches and their existing map_graphql_error calls are unchanged.",
     "Each native branch creates an operation-specific context before moving request arguments into the unchanged adapter call.",
     "Each native branch maps only the final returned ApiError to one static public message.",
-    "The original native error remains available only to structured tracing diagnostics.",
-    "Diagnostics retain only token presence and bounded string presence or character-length shape.",
-    "No token, tenant, order, status, or action-draft value is logged by the new client boundary.",
+    "The complete ApiError and its message text are not written to structured tracing diagnostics.",
+    "Diagnostics retain only the ApiError variant, message presence or character length, token presence, and bounded request string presence or character-length shape.",
+    "No token, tenant, order, status, action-draft, or native error message value is logged by the client boundary.",
     "Default and SSR native adapters, mounted endpoints, permissions, owner calls, and response mapping are outside the diff.",
     "Promotion transport is outside the diff.",
     "The broad ecommerce mapper cleanup remains open."
@@ -22,5 +22,5 @@
     "workflow_checks_run": false,
     "ci_run": false
   },
-  "review_note": "Source review corrected a generic iterator-count expression to explicit closures; no execution evidence is claimed."
+  "review_note": "Source review confirms variant and message-shape diagnostics only; no execution evidence is claimed."
 }

--- a/crates/rustok-commerce/contracts/evidence/admin-order-change-client-transport-error-safety-source.json
+++ b/crates/rustok-commerce/contracts/evidence/admin-order-change-client-transport-error-safety-source.json
@@ -20,7 +20,11 @@
     "context_created_before_native_call": true,
     "raw_native_error_public": false,
     "static_public_message": true,
-    "original_error_logged_privately": true,
+    "original_error_logged_privately": false,
+    "original_error_shape_logged": true,
+    "error_variant_logged": true,
+    "error_message_length_only": true,
+    "raw_native_error_logged": false,
     "per_call_correlation_logging": true,
     "safe_request_shape_only": true,
     "token_values_logged": false,
@@ -44,6 +48,7 @@
   "notes": [
     "The GraphQL branches retain their existing correlation-aware map_graphql_error policy.",
     "Only final native ApiError results are remapped at the public order-change facade.",
+    "Private client diagnostics retain only ApiError variant and message presence or character length.",
     "The shared default and SSR native adapters remain unchanged.",
     "No FFA or FBA status is promoted from source inspection."
   ]

--- a/crates/rustok-commerce/docs/admin-order-change-client-transport-error-safety.md
+++ b/crates/rustok-commerce/docs/admin-order-change-client-transport-error-safety.md
@@ -6,12 +6,13 @@ Status: **source-ready / unvalidated**
 
 The public Commerce Admin order-change facade selects GraphQL only for the existing
 WASM non-hydrate profile. All other profiles call the shared native adapter. The
-GraphQL branches already use the correlation-aware `map_graphql_error` policy, while
-the native branches previously returned the shared `ApiError` unchanged.
+GraphQL branches retain the correlation-aware `map_graphql_error` policy.
 
-That shared compatibility error stores `ServerFn(String)`. A framework, transport,
-serialization, or unexpected server-function string could therefore become the
-operator-visible error after leaving an otherwise sanitized native server boundary.
+The shared compatibility `ApiError` stores either `Graphql(String)` or
+`ServerFn(String)`. The public native branches already replace the final error with a
+static compatibility envelope, but their client diagnostic mapper previously wrote the
+complete `ApiError` to tracing. That could retain framework, transport, serialization,
+or server-function message text after it left an otherwise sanitized server boundary.
 
 ## Covered operations
 
@@ -19,18 +20,19 @@ operator-visible error after leaving an otherwise sanitized native server bounda
 - `apply_order_change`
 - `cancel_order_change`
 
-Each native branch now creates `OrderChangeClientErrorContext` before the unchanged
-adapter call and maps only the final returned `ApiError`.
+Each native branch continues to create `OrderChangeClientErrorContext` before the
+unchanged adapter call and maps only the final returned `ApiError`.
 
-The final public message is always:
+The final public message remains:
 
 `Commerce admin order-change request could not be completed`
 
 ## Private diagnostics
 
-The mapper retains the original typed compatibility error only in structured tracing.
-It records:
+The complete `ApiError` is not logged. The mapper records only:
 
+- error variant: `graphql` or `server_fn`;
+- error-message presence and character length;
 - owner operation and a per-call correlation ID;
 - stable code and transport boundary;
 - token presence;
@@ -38,8 +40,8 @@ It records:
 - order ID, order-change ID, and status presence or character length;
 - action payload presence.
 
-It does not record token, tenant slug, tenant ID, order ID, order-change ID, status,
-or action-draft values.
+It does not record error message text, token, tenant slug, tenant ID, order ID,
+order-change ID, status, or action-draft values.
 
 ## Preserved behavior
 
@@ -60,15 +62,15 @@ This source slice does not change:
 - `contracts/evidence/admin-order-change-client-transport-error-safety-source-review.json`
 - `scripts/verify/verify-commerce-admin-order-change-client-transport-error-safety.mjs`
 
-The existing server-side source policy remains separately covered by
+The server-side source policy remains separately covered by
 `verify-commerce-admin-order-change-native-error-safety.mjs`.
 
 ## Validation still required
 
 Per maintainer instruction, no tests, Node verifiers, Cargo commands, formatting,
 workflows, or CI were run for this slice. Maintainer execution should include the
-focused client and native guards, the aggregate Commerce/ecommerce guards, hydrate
-and SSR compilation, and mounted failure injection for all three operations.
+focused client and native guards, aggregate Commerce/ecommerce guards, hydrate and SSR
+compilation, and mounted failure injection for all three operations.
 
 This source result does not promote Commerce FFA/FBA, browser, hydrate, SSR, mounted
 runtime, workflow, CI, or production status. The broad ecommerce correlation-safe

--- a/scripts/verify/verify-commerce-admin-order-change-client-transport-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-order-change-client-transport-error-safety.mjs
@@ -23,7 +23,10 @@ const requireCount = (source, value, expected, label) => {
 };
 
 function functionBody(source, functionName) {
-  const match = new RegExp(`pub\\s+async\\s+fn\\s+${functionName}\\s*\\(`).exec(source);
+  const signature = new RegExp(
+    `(?:pub(?:\\([^)]*\\))?\\s+)?(?:async\\s+)?fn\\s+${functionName}(?:<[^>]*>)?\\s*\\(`,
+  );
+  const match = signature.exec(source);
   if (!match) {
     failures.push(`missing function ${functionName}`);
     return "";
@@ -153,11 +156,18 @@ for (const marker of [
   'const COMMERCE_ADMIN_ORDER_CHANGE_CLIENT_BOUNDARY: &str =',
   '"commerce_admin_order_change_client_transport"',
   '"Commerce admin order-change request could not be completed"',
+  "struct OrderChangeClientErrorFacts",
+  "error_variant: &'static str",
+  "message_present: bool",
+  "message_length: usize",
   "pub(super) struct OrderChangeClientErrorContext",
   'operation: "fetch_order_changes"',
   'Self::for_write(\n            "apply_order_change"',
   'Self::for_write(\n            "cancel_order_change"',
-  "raw_error = ?error",
+  "let error_facts = order_change_client_error_facts(&error);",
+  "error_variant = error_facts.error_variant",
+  "error_message_present = error_facts.message_present",
+  "error_message_length = error_facts.message_length",
   "owner_operation = self.operation",
   "correlation_id = %self.correlation_id",
   "token_present = self.token_present",
@@ -170,8 +180,26 @@ for (const marker of [
   'code = "commerce.admin_order_change_client_transport_failed"',
   "boundary = COMMERCE_ADMIN_ORDER_CHANGE_CLIENT_BOUNDARY",
   "ApiError::ServerFn(COMMERCE_ADMIN_ORDER_CHANGE_CLIENT_PUBLIC_MESSAGE.to_string())",
+  "fn order_change_client_error_facts(error: &ApiError)",
+  'ApiError::Graphql(message) => ("graphql", message)',
+  'ApiError::ServerFn(message) => ("server_fn", message)',
+  "message_present: !message.trim().is_empty()",
+  "message_length: message.chars().count()",
 ]) {
   requireText(safety, marker, `${paths.safety}: safe final mapping`);
+}
+
+const mapperBody = functionBody(safety, "map_error");
+for (const forbidden of [
+  "raw_error = ?error",
+  "raw_error = %error",
+  "error = ?error",
+  "error = %error",
+  "message = %error",
+  "message = ?error",
+  "error.to_string()",
+]) {
+  forbidText(mapperBody, forbidden, `${paths.safety}: complete error diagnostics`);
 }
 
 for (const forbidden of [
@@ -189,9 +217,8 @@ for (const forbidden of [
   "status = ?",
   "draft = ?",
   "payload = ?",
-  "error.to_string()",
 ]) {
-  forbidText(safety, forbidden, `${paths.safety}: raw request or error text`);
+  forbidText(safety, forbidden, `${paths.safety}: raw request value`);
 }
 
 for (const source of [native, nativeSsr]) {
@@ -224,7 +251,7 @@ for (const endpoint of [
 }
 requireText(
   nativeGuard,
-  "Commerce admin order-change native error-safety source invariants passed",
+  "Commerce admin order-change native diagnostics use correlation-safe shape only",
   `${paths.nativeGuard}: prior server-side guard remains registered`,
 );
 
@@ -252,7 +279,11 @@ for (const [key, expected] of Object.entries({
   context_created_before_native_call: true,
   raw_native_error_public: false,
   static_public_message: true,
-  original_error_logged_privately: true,
+  original_error_logged_privately: false,
+  original_error_shape_logged: true,
+  error_variant_logged: true,
+  error_message_length_only: true,
+  raw_native_error_logged: false,
   per_call_correlation_logging: true,
   safe_request_shape_only: true,
   token_values_logged: false,
@@ -290,6 +321,11 @@ requireText(
   `${paths.doc}: static public message`,
 );
 requireText(
+  doc,
+  "complete `ApiError` is not logged",
+  `${paths.doc}: private diagnostic policy`,
+);
+requireText(
   commercePlan,
   "Finish correlation-safe mapper cleanup",
   `${paths.commercePlan}: broad ecommerce cleanup remains open`,
@@ -302,5 +338,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Commerce Admin order-change native failures use a correlation-safe static final envelope across three operations; execution evidence remains open",
+  "Commerce Admin order-change client diagnostics retain only ApiError variant and message shape; execution evidence remains open",
 );


### PR DESCRIPTION
## Summary

- continue the open ecommerce correlation-safe mapper cleanup with the Commerce Admin order-change client transport
- replace complete `ApiError::Graphql(String)` and `ApiError::ServerFn(String)` logging with bounded error variant, message-presence, and message-length facts
- preserve the static public `ApiError` envelope: `Commerce admin order-change request could not be completed`
- preserve all three fetch/apply/cancel facade operations, GraphQL selection and `map_graphql_error`, native adapter call order, request/response DTOs, mounted endpoints, and previously hardened SSR diagnostics
- update the focused verifier, documentation, source evidence, and source-review evidence

## Confirmed gap

The client mapper already returned a static public envelope but still wrote the complete compatibility `ApiError` to tracing through `raw_error = ?error`. Both compatibility variants carry arbitrary strings, so framework, transport, serialization, GraphQL, or server-function text could remain in diagnostics.

## Scope boundary

This PR changes exactly five existing Commerce Admin order-change client source/docs/evidence/verifier files. The facade, GraphQL transport, native adapters, mounted server functions, promotion transport, DTOs, permissions, and owner operations remain unchanged. The broad ecommerce mapper-cleanup item remains open.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-commerce-admin-order-change-client-transport-error-safety.mjs
node scripts/verify/verify-commerce-admin-order-change-native-error-safety.mjs
cargo check -p rustok-commerce-admin --all-features
```

## Branch state

The branch is based on current `main` at `f920841718500fec6966cd42564e94b73499566a`, is one commit ahead and zero behind, and changes exactly five files. Head commit: `d056139d9a6f8fbd7025223ee6379309110e2fe4`. Squash merge is intended.