### PR TITLE
fix(email-admin): bind read authority to routed tenant

### DIFF
--- a/apps/admin/src/features/email/transport/native_server_adapter.rs
+++ b/apps/admin/src/features/email/transport/native_server_adapter.rs
@@ -9,6 +9,25 @@ fn server_error(message: impl Into<String>) -> ServerFnError {
     ServerFnError::ServerError(message.into())
 }
 
+#[cfg(feature = "ssr")]
+fn require_email_admin_tenant_scope(
+    auth_tenant_id: uuid::Uuid,
+    resolved_tenant_id: uuid::Uuid,
+) -> Result<(), ServerFnError> {
+    if auth_tenant_id == resolved_tenant_id {
+        return Ok(());
+    }
+
+    tracing::warn!(
+        auth_tenant_id = %auth_tenant_id,
+        resolved_tenant_id = %resolved_tenant_id,
+        code = "email.admin_tenant_scope_mismatch",
+        boundary = "email_admin_native_transport",
+        "email admin permissions cannot cross the resolved tenant boundary"
+    );
+    Err(ServerFnError::new("Email admin access is denied"))
+}
+
 #[server(prefix = "/api/fn", endpoint = "admin/email-settings")]
 pub(super) async fn email_settings_native() -> Result<PlatformSettingsResponse, ServerFnError> {
     #[cfg(feature = "ssr")]
@@ -25,6 +44,7 @@ pub(super) async fn email_settings_native() -> Result<PlatformSettingsResponse, 
         let tenant = leptos_axum::extract::<TenantContext>()
             .await
             .map_err(|err| server_error(err.to_string()))?;
+        require_email_admin_tenant_scope(auth.tenant_id, tenant.id)?;
         if !has_effective_permission(&auth.permissions, &Permission::SETTINGS_READ) {
             return Err(ServerFnError::new("settings:read required"));
         }

--- a/scripts/verify/verify-email-admin-tenant-scope.mjs
+++ b/scripts/verify/verify-email-admin-tenant-scope.mjs
@@ -17,9 +17,6 @@ const failures = [];
 const requireText = (value, label) => {
   if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
 };
-const forbidText = (value, label) => {
-  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
-};
 
 for (const [value, label] of [
   ['fn require_email_admin_tenant_scope(', 'tenant scope helper'],
@@ -34,11 +31,6 @@ for (const [value, label] of [
 ]) {
   requireText(value, label);
 }
-
-forbidText(
-  'if !has_effective_permission(&auth.permissions, &Permission::SETTINGS_READ) {\n            return Err',
-  'permission-only admission before tenant binding',
-);
 
 const guardCall = source.indexOf(
   'require_email_admin_tenant_scope(auth.tenant_id, tenant.id)?;',

--- a/scripts/verify/verify-email-admin-tenant-scope.mjs
+++ b/scripts/verify/verify-email-admin-tenant-scope.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const source = readFileSync(
+  new URL('apps/admin/src/features/email/transport/native_server_adapter.rs', root),
+  'utf8',
+);
+const failures = [];
+
+const requireText = (value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [value, label] of [
+  ['fn require_email_admin_tenant_scope(', 'tenant scope helper'],
+  ['if auth_tenant_id == resolved_tenant_id', 'tenant equality'],
+  ['require_email_admin_tenant_scope(auth.tenant_id, tenant.id)?;', 'scoped endpoint call'],
+  ['has_effective_permission(&auth.permissions, &Permission::SETTINGS_READ)', 'permission admission'],
+  ['Email admin access is denied', 'static public denial'],
+  ['email.admin_tenant_scope_mismatch', 'stable diagnostic code'],
+  ['auth_tenant_id = %auth_tenant_id', 'authenticated tenant diagnostic'],
+  ['resolved_tenant_id = %resolved_tenant_id', 'resolved tenant diagnostic'],
+  ['boundary = "email_admin_native_transport"', 'transport boundary diagnostic'],
+]) {
+  requireText(value, label);
+}
+
+forbidText(
+  'if !has_effective_permission(&auth.permissions, &Permission::SETTINGS_READ) {\n            return Err',
+  'permission-only admission before tenant binding',
+);
+
+const guardCall = source.indexOf(
+  'require_email_admin_tenant_scope(auth.tenant_id, tenant.id)?;',
+);
+const permissionCheck = source.indexOf(
+  'has_effective_permission(&auth.permissions, &Permission::SETTINGS_READ)',
+);
+if (guardCall < 0 || permissionCheck < 0 || guardCall >= permissionCheck) {
+  failures.push('tenant equality must precede SETTINGS_READ admission');
+}
+
+const authExtracts = source.match(/leptos_axum::extract::<AuthContext>\(\)/g) ?? [];
+const tenantExtracts = source.match(/leptos_axum::extract::<TenantContext>\(\)/g) ?? [];
+const guardCalls = source.match(
+  /require_email_admin_tenant_scope\(auth\.tenant_id, tenant\.id\)\?;/g,
+) ?? [];
+if (authExtracts.length !== 1 || tenantExtracts.length !== 1 || guardCalls.length !== 1) {
+  failures.push(
+    `expected one AuthContext, one TenantContext and one scoped guard call; found ${authExtracts.length}/${tenantExtracts.length}/${guardCalls.length}`,
+  );
+}
+
+if (failures.length > 0) {
+  console.error('Email Admin tenant-scope verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log('✔ Email Admin binds SETTINGS_READ authority to the resolved tenant');


### PR DESCRIPTION
## Summary

Email Admin checked `SETTINGS_READ` from authenticated `AuthContext`, then read `platform_settings` for a separately resolved `TenantContext` without requiring tenant equality.

Authority issued for tenant A could therefore inspect Email settings for routed tenant B.

## P0 fix

- require `AuthContext.tenant_id == TenantContext.id` before permission admission;
- fail closed with static `Email admin access is denied`;
- retain both tenant ids only in structured diagnostics with code `email.admin_tenant_scope_mismatch`;
- preserve the existing SQL, settings fallback, permission identifier, and response shape.

## Regression evidence

`scripts/verify/verify-email-admin-tenant-scope.mjs` requires the scoped call, tenant equality, static public denial, private diagnostic fields, exact Auth/Tenant extractor counts, and guard-before-`SETTINGS_READ` ordering.

The separate raw-error and Email secret/delivery architecture findings remain outside this focused P0 fix. No workflow changes.