### PR TITLE
fix(outbox-admin): bind logs authority to routed tenant

### DIFF
--- a/crates/rustok-outbox/admin/src/transport/native_server_adapter.rs
+++ b/crates/rustok-outbox/admin/src/transport/native_server_adapter.rs
@@ -8,6 +8,25 @@ pub async fn fetch_bootstrap_native() -> Result<OutboxAdminBootstrap, ServerFnEr
     outbox_bootstrap_native().await
 }
 
+#[cfg(feature = "ssr")]
+fn require_outbox_admin_tenant_scope(
+    auth_tenant_id: uuid::Uuid,
+    resolved_tenant_id: uuid::Uuid,
+) -> Result<(), ServerFnError> {
+    if auth_tenant_id == resolved_tenant_id {
+        return Ok(());
+    }
+
+    tracing::warn!(
+        auth_tenant_id = %auth_tenant_id,
+        resolved_tenant_id = %resolved_tenant_id,
+        code = "outbox.admin_tenant_scope_mismatch",
+        boundary = "outbox_admin_native_transport",
+        "outbox admin permissions cannot cross the resolved tenant boundary"
+    );
+    Err(ServerFnError::new("Outbox admin access is denied"))
+}
+
 #[server(prefix = "/api/fn", endpoint = "outbox/bootstrap")]
 async fn outbox_bootstrap_native() -> Result<OutboxAdminBootstrap, ServerFnError> {
     #[cfg(feature = "ssr")]
@@ -27,6 +46,7 @@ async fn outbox_bootstrap_native() -> Result<OutboxAdminBootstrap, ServerFnError
             .map_err(ServerFnError::new)?
             .0
             .ok_or_else(|| ServerFnError::new("tenant context is required for outbox inspection"))?;
+        require_outbox_admin_tenant_scope(auth.tenant_id, tenant.id)?;
 
         if !has_effective_permission(&auth.permissions, &Permission::LOGS_READ) {
             return Err(ServerFnError::new(

--- a/crates/rustok-outbox/admin/tests/tenant_scope_contract.rs
+++ b/crates/rustok-outbox/admin/tests/tenant_scope_contract.rs
@@ -1,0 +1,34 @@
+const SOURCE: &str = include_str!("../src/transport/native_server_adapter.rs");
+
+#[test]
+fn outbox_admin_binds_logs_authority_to_the_resolved_tenant() {
+    let tenant_guard = SOURCE
+        .find("require_outbox_admin_tenant_scope(auth.tenant_id, tenant.id)?;")
+        .expect("Outbox Admin must bind authenticated and resolved tenants");
+    let permission_check = SOURCE
+        .find("has_effective_permission(&auth.permissions, &Permission::LOGS_READ)")
+        .expect("Outbox Admin must retain LOGS_READ admission");
+
+    assert!(
+        tenant_guard < permission_check,
+        "tenant equality must be enforced before permission admission"
+    );
+    assert_eq!(
+        SOURCE
+            .matches("leptos_axum::extract::<AuthContext>()")
+            .count(),
+        1
+    );
+    assert_eq!(
+        SOURCE
+            .matches("leptos_axum::extract::<OptionalTenant>()")
+            .count(),
+        1
+    );
+    assert!(SOURCE.contains("if auth_tenant_id == resolved_tenant_id"));
+    assert!(SOURCE.contains("Outbox admin access is denied"));
+    assert!(SOURCE.contains("outbox.admin_tenant_scope_mismatch"));
+    assert!(SOURCE.contains("auth_tenant_id = %auth_tenant_id"));
+    assert!(SOURCE.contains("resolved_tenant_id = %resolved_tenant_id"));
+    assert!(SOURCE.contains("boundary = \"outbox_admin_native_transport\""));
+}


### PR DESCRIPTION
## Summary

Outbox Admin admitted `LOGS_READ` from authenticated `AuthContext`, then returned operational counters for a separately resolved `OptionalTenant` without requiring tenant equality.

Authority issued for tenant A could therefore inspect pending, dispatched, failed, and retry state for routed tenant B.

## P0 fix

- require `AuthContext.tenant_id == resolved tenant.id` before permission admission;
- fail closed with static `Outbox admin access is denied`;
- retain both tenant ids only in structured diagnostics with code `outbox.admin_tenant_scope_mismatch`;
- preserve the existing tenant-scoped PostgreSQL/SQLite counter queries and read-only UI behavior.

## Regression evidence

`crates/rustok-outbox/admin/tests/tenant_scope_contract.rs` locks the Auth/OptionalTenant extractor pair, tenant equality before `LOGS_READ`, static public denial, and private diagnostic markers.

No workflow, relay, event schema, retry, SQL, or public response-shape changes.