### PR TITLE
test(blog): retain concurrent duplicate delivery rollback

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-comments-duplicate-delivery-race.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-duplicate-delivery-race.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": 1,
+  "module": "blog",
+  "surface": "comments_duplicate_delivery_race",
+  "status": "source_verified_no_compile",
+  "compile_policy": "not_run_by_request",
+  "runtime_status": "pending",
+  "owner": "rustok-blog",
+  "provider": "rustok-comments",
+  "harness": {
+    "status": "executable_no_run",
+    "runtime_status": "not_run",
+    "path": "crates/rustok-blog/tests/comment_projection_duplicate_race_postgres_test.rs",
+    "environment": "RUSTOK_BLOG_TEST_DATABASE_URL",
+    "command": "RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_duplicate_race_postgres_test concurrent_duplicate_envelope_commits_once_and_replays_cleanly -- --exact",
+    "isolation": "unique_schema_three_independent_connections_two_named_workers_controlled_row_lock",
+    "scope": "same_envelope_concurrent_delivery_unique_ledger_loser_rollback_and_clean_replay",
+    "non_claim": "does_not_record_postgresql_execution_or_full_event_dispatcher_delivery"
+  },
+  "cases": [
+    {
+      "name": "both_workers_pass_initial_delivery_lookup",
+      "expected": "a control transaction holds the Blog post row until pg_stat_activity reports both named worker sessions blocked on a lock"
+    },
+    {
+      "name": "single_duplicate_commit",
+      "expected": "after the control lock is released exactly one handler succeeds and exactly one handler fails"
+    },
+    {
+      "name": "losing_transaction_rolls_back",
+      "expected": "the final post state is comment_count one and version two with one delivery row and one outbox row"
+    },
+    {
+      "name": "same_envelope_replay_is_clean",
+      "expected": "replaying the same envelope after the race returns success without changing post, delivery, or outbox cardinality"
+    }
+  ],
+  "runtime_promotion_requirements": [
+    "execute the env-gated PostgreSQL target and retain both blocked-worker observation plus both handler outcomes",
+    "retain final post, delivery-ledger, and outbox assertions",
+    "retain successful same-envelope replay output",
+    "record dispatcher-level duplicate delivery separately"
+  ]
+}

--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -167,6 +167,26 @@ suggested command is
 The target is `executable_no_run`. It records a written convergence contract, not
 an observed retry count or optimistic-exhaustion result.
 
+The retained concurrent duplicate-delivery target is
+`concurrent_duplicate_envelope_commits_once_and_replays_cleanly` in
+`crates/rustok-blog/tests/comment_projection_duplicate_race_postgres_test.rs`.
+A control transaction locks the Blog post before two named one-connection workers
+start with the same envelope. The harness waits until `pg_stat_activity` reports
+both workers blocked on a lock, proving both initial delivery-ledger lookups have
+completed before the row lock is released. The written assertions require exactly
+one successful handler, one failed losing transaction, final `comment_count = 1`
+and `version = 2`, one delivery row, one outbox row, and a clean replay of the same
+envelope. Evidence schema v1 is retained at
+`crates/rustok-blog/contracts/evidence/blog-comments-duplicate-delivery-race.json`,
+guarded by `scripts/verify/verify-blog-comments-duplicate-delivery-race.mjs` and
+focused fixture
+`scripts/verify/verify-blog-comments-duplicate-delivery-race.test.mjs`. Its
+suggested command is
+`RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_duplicate_race_postgres_test concurrent_duplicate_envelope_commits_once_and_replays_cleanly -- --exact`.
+The target and focused guard are `executable_no_run` / source-only; no PostgreSQL
+or dispatcher-level duplicate result is recorded, and the standalone guard is not
+added to registry-owned package order in this slice.
+
 The retained PostgreSQL target is
 `crates/rustok-blog/tests/comment_projection_postgres_test.rs`. It uses
 `RUSTOK_BLOG_TEST_DATABASE_URL` (or PostgreSQL `DATABASE_URL`), a unique schema,
@@ -203,9 +223,11 @@ full application server-host restart, and no execution result is recorded.
 Exact commands `verify:blog:comments-event-projection` and
 `test:verify:blog:comments-event-projection` run after the Comments port gate in
 the Blog FBA chains. Overall status remains `source_verified_no_compile`;
-the deterministic retry policy and retry-limit PostgreSQL harness are source-
-locked, while all target execution, naturally contended retry-frequency evidence,
-full server-host restart recovery, and all other runtime evidence remain pending.
+the deterministic retry policy, retry-limit target, and separately guarded
+concurrent duplicate-delivery target are source-locked, while all target
+execution, naturally contended retry-frequency evidence, dispatcher-level
+duplicate delivery, full server-host restart recovery, and all other runtime
+evidence remain pending.
 
 Blog categories use the exclusive `blog_categories:*` permission resource.
 `CategoryService::new(db, event_bus)` is the only owner constructor. Category
@@ -415,6 +437,24 @@ same envelope. Evidence schema v4 and Blog registry schema v13 remain compatible
 focused source verification is updated, while execution and naturally contended
 retry-frequency evidence remain pending.
 
+The continuation audit at `e7224d7deecaecc8d8f0a10ca9423b2ee8b5c16c`
+found that duplicate idempotency was retained only as sequential replay, while the
+concurrency target used four different envelope identities. The production comment
+explicitly relies on the delivery-ledger unique insert to roll back a losing
+concurrent duplicate transaction, but no retained target forced two handlers past
+the initial ledger lookup with the same envelope.
+
+Slice 54 adds the env-gated
+`concurrent_duplicate_envelope_commits_once_and_replays_cleanly` target. A control
+transaction holds the Blog post row, two named workers pass the initial delivery
+lookup and block on the optimistic update, and `pg_stat_activity` is used to prove
+both are waiting before release. The written contract requires one winner, one
+failed losing transaction, one post transition, one delivery row, one outbox row,
+and a clean same-envelope replay. New schema-v1 evidence, a standalone fail-closed
+verifier, and a focused negative fixture retain the source contract. Blog registry
+schema v13 and its package order remain unchanged; no Rust, JavaScript,
+PostgreSQL, dispatcher, workflow, or CI execution is recorded.
+
 ## FFA/FBA status
 
 - FFA status: `in_progress`.
@@ -427,7 +467,8 @@ retry-frequency evidence remain pending.
   and aggregate/consumer bindings for admin, storefront, Comments port boundary,
   Comments event projection, category Search reindex, GraphQL rate limiting,
   GraphQL richtext, AI richtext, offline backfill, Forum ownership, and runtime
-  order.
+  order. The separately guarded duplicate-delivery race target is source-ready but
+  intentionally not added to the registry-owned package order in slice 54.
 - Comments consumer port boundary: Blog-owned `source_verified_no_compile` for
   the in-process profile; all seven operations, approved public read, typed
   richtext projection, two-second deadlines, write idempotency, active typed
@@ -443,18 +484,13 @@ retry-frequency evidence remain pending.
   dispatcher, concurrency, PostgreSQL transaction, same-process restart, and
   process-restart targets, verifier, focused self-test, exact npm leaf commands,
   delivery-ledger identity, transactional outbox markers, and Blog FBA ordering
-  are locked. The source policy records immediate success, seven retry decisions,
-  and the eighth-attempt terminal limit. The retry-limit target forces eight
-  zero-row results through the real handler and requires atomic rollback followed
-  by successful replay of the same envelope. The registration target verifies
-  identity/routing only. The dispatcher target passes one envelope through
-  `EventBus` and `EventDispatcher` into the module-registered handler and waits
-  for the durable commit. The concurrency target starts four independent
-  PostgreSQL connections behind one barrier and requires a four-count/five-version
-  result with four delivery and outbox rows. The process target launches two
-  sequential OS test processes against the same schema and envelope ID. None of
-  these targets has been run. Naturally contended PostgreSQL retry frequency,
-  full server-host restart recovery, and all execution evidence remain pending.
+  are locked. Separate schema-v1 evidence and a standalone fail-closed verifier
+  retain the concurrent same-envelope target: both named workers must be observed
+  blocked after their initial ledger lookups, then one transaction commits and the
+  loser rolls back before clean replay. None of these targets has been run.
+  Naturally contended PostgreSQL retry frequency, dispatcher-level duplicate
+  delivery, full server-host restart recovery, and all execution evidence remain
+  pending.
 - Load protection: `implementation_ready`; mounted Redis evidence is pending.
 - Rate-limit harness: `executable_no_compile`; evidence, verifier, self-test,
   npm leaf commands, and aggregate FBA registration are locked; execution is
@@ -487,6 +523,7 @@ retry-frequency evidence remain pending.
 - `crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-consumer-runtime-order-smoke.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json`
+- `crates/rustok-blog/contracts/evidence/blog-comments-duplicate-delivery-race.json`
 - `crates/rustok-blog/src/lib.rs`
 - `crates/rustok-blog/src/graphql/types.rs`
 - `crates/rustok-blog/storefront/src/model.rs`
@@ -495,6 +532,7 @@ retry-frequency evidence remain pending.
 - `crates/rustok-blog/storefront/src/ui/leptos.rs`
 - `crates/rustok-blog/src/services/comment_projection.rs`
 - `crates/rustok-blog/tests/comment_projection_postgres_test.rs`
+- `crates/rustok-blog/tests/comment_projection_duplicate_race_postgres_test.rs`
 - `crates/rustok-blog/tests/comment_projection_restart_postgres_test.rs`
 - `crates/rustok-comments/contracts/comments-fba-registry.json`
 - `crates/rustok-comments/contracts/evidence/comments-thread-write-invariants.json`
@@ -514,6 +552,8 @@ retry-frequency evidence remain pending.
 - `scripts/verify/verify-blog-comments-port-boundary.test.mjs`
 - `scripts/verify/verify-blog-comments-event-projection.mjs`
 - `scripts/verify/verify-blog-comments-event-projection.test.mjs`
+- `scripts/verify/verify-blog-comments-duplicate-delivery-race.mjs`
+- `scripts/verify/verify-blog-comments-duplicate-delivery-race.test.mjs`
 - `scripts/verify/verify-blog-graphql-rate-limit.mjs`
 - `scripts/verify/verify-blog-graphql-rate-limit.test.mjs`
 - `scripts/verify/verify-blog-category-search-reindex.mjs`
@@ -665,6 +705,11 @@ retry-frequency evidence remain pending.
     PostgreSQL retry-limit target that forces eight real zero-row handler updates,
     retained atomic rollback and same-envelope recovery in evidence and the focused
     guard, and kept natural contention frequency plus all execution pending.
+54. Added an env-gated same-envelope concurrent delivery target with a controlled
+    row lock and two named workers, retained one winner, losing-transaction
+    rollback, final ledger/outbox cardinality, and clean replay in schema-v1
+    evidence plus a standalone verifier and focused negative fixture, and kept
+    registry package order plus all execution unchanged or pending.
 
 ## Next results
 
@@ -686,21 +731,26 @@ retry-frequency evidence remain pending.
    deterministic retry-policy harness, module registration/routing harness, the
    filtered `event_dispatcher_routes_registered_handler_and_commits_projection`,
    `concurrent_created_events_converge_without_lost_updates`,
-   `optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears`, and
+   `optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears`,
+   `concurrent_duplicate_envelope_commits_once_and_replays_cleanly`, and
    `restarted_process_reuses_delivery_ledger_without_reapplying_counter` cases,
-   the complete `comment_projection_postgres_test` and
+   the complete `comment_projection_postgres_test`,
+   `comment_projection_duplicate_race_postgres_test`, and
    `comment_projection_restart_postgres_test` targets, both thread invariant
    concurrency targets, and concurrent PostgreSQL create/delete transactions.
-   Retain deterministic immediate-success/seven-retry/eighth-limit output,
-   the deterministic eight-zero-row terminal error, rollback and same-envelope
-   recovery output, dispatcher delivery output, four-connection convergence, both
-   child process exits, the written duplicate, delete-before-create, missing-post
-   replay, outbox rollback/retry, and same-process/new-connection assertions;
-   then retain naturally contended PostgreSQL retry-frequency evidence, full
-   server-host restart recovery, remote adapter parity, browser parity for typed
-   unavailable/timeout article rendering, cached thread snapshots, comment-form
-   fallback, approved-only reads, moderation, pagination, first-thread identity,
-   and unrelated insert storage error propagation.
+   Retain deterministic immediate-success/seven-retry/eighth-limit output, the
+   deterministic eight-zero-row terminal error, rollback and same-envelope
+   recovery output, both blocked duplicate workers, the one-winner/one-loser
+   outcome, final single delivery/outbox cardinality, clean duplicate replay,
+   dispatcher delivery output, four-connection convergence, both child process
+   exits, the written duplicate, delete-before-create, missing-post replay,
+   outbox rollback/retry, and same-process/new-connection assertions; then retain
+   dispatcher-level duplicate delivery, naturally contended PostgreSQL
+   retry-frequency evidence, full server-host restart recovery, remote adapter
+   parity, browser parity for typed unavailable/timeout article rendering, cached
+   thread snapshots, comment-form fallback, approved-only reads, moderation,
+   pagination, first-thread identity, and unrelated insert storage error
+   propagation.
 6. **Execute and retain Blog article richtext cutover evidence.** Run the offline
    backfill in default dry-run mode, review its report, apply accepted conversion,
    execute the irreversible migration, reindex/rollback Search, and retain
@@ -716,6 +766,8 @@ should run the relevant subset, including:
 - `npm run test:verify:blog:comments-port-boundary`
 - `npm run verify:blog:comments-event-projection`
 - `npm run test:verify:blog:comments-event-projection`
+- `node scripts/verify/verify-blog-comments-duplicate-delivery-race.mjs`
+- `node --test scripts/verify/verify-blog-comments-duplicate-delivery-race.test.mjs`
 - `cargo test -p rustok-blog --lib services::comment_projection::tests`
 - `cargo test -p rustok-blog --lib services::comment_projection::tests::optimistic_retry_policy_applies_success_without_retry -- --exact`
 - `cargo test -p rustok-blog --lib services::comment_projection::tests::optimistic_retry_policy_allows_seven_retries_then_stops_on_eighth_conflict -- --exact`
@@ -723,6 +775,7 @@ should run the relevant subset, including:
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test event_dispatcher_routes_registered_handler_and_commits_projection -- --exact`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test concurrent_created_events_converge_without_lost_updates -- --exact`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears -- --exact`
+- `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_duplicate_race_postgres_test concurrent_duplicate_envelope_commits_once_and_replays_cleanly -- --exact`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test restarted_process_reuses_delivery_ledger_without_reapplying_counter -- --exact`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test`

--- a/crates/rustok-blog/tests/comment_projection_duplicate_race_postgres_test.rs
+++ b/crates/rustok-blog/tests/comment_projection_duplicate_race_postgres_test.rs
@@ -1,0 +1,349 @@
+use std::{error::Error, io, sync::Arc, time::Duration};
+
+use rustok_blog::services::BlogCommentProjectionHandler;
+use rustok_core::events::{EventEnvelope, EventHandler};
+use rustok_events::DomainEvent;
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
+    TransactionTrait,
+};
+use tokio::sync::Barrier;
+use uuid::Uuid;
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";
+const WORKER_A_APPLICATION_NAME: &str = "rustok_blog_duplicate_race_a";
+const WORKER_B_APPLICATION_NAME: &str = "rustok_blog_duplicate_race_b";
+
+struct PostgresBlogProjectionDuplicateRaceTestDb {
+    control: DatabaseConnection,
+    db: DatabaseConnection,
+    database_url: String,
+    schema_name: String,
+}
+
+impl PostgresBlogProjectionDuplicateRaceTestDb {
+    async fn setup() -> TestResult<Option<Self>> {
+        let Some(database_url) = postgres_database_url() else {
+            eprintln!(
+                "{BLOG_TEST_DATABASE_ENV} is not set to a PostgreSQL URL; skipping Blog duplicate projection race test"
+            );
+            return Ok(None);
+        };
+
+        let control = connect(&database_url, "rustok_blog_duplicate_race_control").await?;
+        let schema_name = format!(
+            "rustok_blog_duplicate_race_{}",
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let db = connect(&database_url, "rustok_blog_duplicate_race_assertions").await?;
+        set_search_path(&db, &schema_name).await?;
+
+        if let Err(error) = create_projection_tables(&db).await {
+            let _ = control
+                .execute_unprepared(&format!(r#"DROP SCHEMA IF EXISTS "{schema_name}" CASCADE"#))
+                .await;
+            return Err(error.into());
+        }
+
+        Ok(Some(Self {
+            control,
+            db,
+            database_url,
+            schema_name,
+        }))
+    }
+
+    async fn isolated_connection(
+        &self,
+        application_name: &str,
+    ) -> TestResult<DatabaseConnection> {
+        let db = connect(&self.database_url, application_name).await?;
+        set_search_path(&db, &self.schema_name).await?;
+        Ok(db)
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn concurrent_duplicate_envelope_commits_once_and_replays_cleanly() -> TestResult<()> {
+    let Some(test_db) = PostgresBlogProjectionDuplicateRaceTestDb::setup().await? else {
+        return Ok(());
+    };
+
+    let tenant_id = Uuid::new_v4();
+    let post_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    insert_post(&test_db.db, tenant_id, post_id, actor_id).await?;
+
+    let envelope = EventEnvelope::new(
+        tenant_id,
+        Some(actor_id),
+        DomainEvent::CommentCreated {
+            comment_id: Uuid::new_v4(),
+            target_type: "blog_post".to_string(),
+            target_id: post_id,
+            author_id: actor_id,
+        },
+    );
+
+    // Hold the post row before starting either handler. Both workers can finish
+    // their delivery-ledger lookup, then block on the same optimistic UPDATE.
+    let lock_db = test_db
+        .isolated_connection("rustok_blog_duplicate_race_lock_holder")
+        .await?;
+    let lock_txn = lock_db.begin().await?;
+    let locked = lock_txn
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT id FROM blog_posts WHERE tenant_id = $1 AND id = $2 FOR UPDATE",
+            vec![tenant_id.into(), post_id.into()],
+        ))
+        .await?;
+    assert!(locked.is_some(), "the Blog post row must be locked");
+
+    let worker_a = test_db
+        .isolated_connection(WORKER_A_APPLICATION_NAME)
+        .await?;
+    let worker_b = test_db
+        .isolated_connection(WORKER_B_APPLICATION_NAME)
+        .await?;
+    let start = Arc::new(Barrier::new(2));
+
+    let task_a = spawn_projection(worker_a, Arc::clone(&start), envelope.clone());
+    let task_b = spawn_projection(worker_b, Arc::clone(&start), envelope.clone());
+
+    wait_for_both_workers_to_block(&test_db.control).await?;
+    lock_txn.commit().await?;
+
+    let outcomes = [task_a.await?, task_b.await?];
+    let success_count = outcomes.iter().filter(|outcome| outcome.is_ok()).count();
+    let failure_count = outcomes.iter().filter(|outcome| outcome.is_err()).count();
+    assert_eq!(success_count, 1, "exactly one duplicate delivery must commit");
+    assert_eq!(
+        failure_count, 1,
+        "the losing duplicate transaction must fail and roll back"
+    );
+
+    assert_eq!(load_post_state(&test_db.db, tenant_id, post_id).await?, (1, 2));
+    assert_eq!(count_delivery(&test_db.db, envelope.id).await?, 1);
+    assert_eq!(count_outbox_events(&test_db.db).await?, 1);
+
+    let replay_db = test_db
+        .isolated_connection("rustok_blog_duplicate_race_replay")
+        .await?;
+    BlogCommentProjectionHandler::new(replay_db)
+        .handle(&envelope)
+        .await?;
+
+    assert_eq!(load_post_state(&test_db.db, tenant_id, post_id).await?, (1, 2));
+    assert_eq!(count_delivery(&test_db.db, envelope.id).await?, 1);
+    assert_eq!(count_outbox_events(&test_db.db).await?, 1);
+
+    test_db.cleanup().await
+}
+
+fn spawn_projection(
+    db: DatabaseConnection,
+    start: Arc<Barrier>,
+    envelope: EventEnvelope,
+) -> tokio::task::JoinHandle<rustok_core::Result<()>> {
+    tokio::spawn(async move {
+        let handler = BlogCommentProjectionHandler::new(db);
+        start.wait().await;
+        handler.handle(&envelope).await
+    })
+}
+
+async fn wait_for_both_workers_to_block(control: &DatabaseConnection) -> TestResult<()> {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let row = control
+                .query_one(Statement::from_string(
+                    DbBackend::Postgres,
+                    format!(
+                        "SELECT COUNT(*)::bigint AS count \
+                         FROM pg_stat_activity \
+                         WHERE application_name IN ('{WORKER_A_APPLICATION_NAME}', '{WORKER_B_APPLICATION_NAME}') \
+                           AND wait_event_type = 'Lock'"
+                    ),
+                ))
+                .await?
+                .expect("pg_stat_activity count query should return one row");
+            let blocked: i64 = row.try_get("", "count")?;
+            if blocked == 2 {
+                return Ok::<(), sea_orm::DbErr>(());
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::TimedOut,
+            "both duplicate projection workers did not block on the post row",
+        )
+    })??;
+    Ok(())
+}
+
+async fn create_projection_tables(db: &DatabaseConnection) -> Result<(), sea_orm::DbErr> {
+    db.execute_unprepared(
+        r#"
+        CREATE TABLE blog_posts (
+            id UUID PRIMARY KEY,
+            tenant_id UUID NOT NULL,
+            author_id UUID NOT NULL,
+            category_id UUID NULL,
+            status TEXT NOT NULL,
+            slug TEXT NOT NULL,
+            metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+            featured_image_url TEXT NULL,
+            published_at TIMESTAMPTZ NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            archived_at TIMESTAMPTZ NULL,
+            comment_count INTEGER NOT NULL DEFAULT 0,
+            view_count INTEGER NOT NULL DEFAULT 0,
+            version INTEGER NOT NULL DEFAULT 1
+        );
+
+        CREATE TABLE blog_comment_projection_deliveries (
+            event_id UUID PRIMARY KEY,
+            tenant_id UUID NOT NULL,
+            comment_id UUID NOT NULL,
+            post_id UUID NOT NULL,
+            delta INTEGER NOT NULL,
+            processed_at TIMESTAMPTZ NOT NULL
+        );
+
+        CREATE TABLE sys_events (
+            id UUID PRIMARY KEY,
+            event_type TEXT NOT NULL,
+            schema_version SMALLINT NOT NULL,
+            payload JSONB NOT NULL,
+            status VARCHAR(32) NOT NULL,
+            retry_count INTEGER NOT NULL,
+            next_attempt_at TIMESTAMPTZ NULL,
+            last_error TEXT NULL,
+            claimed_by TEXT NULL,
+            claimed_at TIMESTAMPTZ NULL,
+            created_at TIMESTAMPTZ NOT NULL,
+            dispatched_at TIMESTAMPTZ NULL
+        );
+        "#,
+    )
+    .await?;
+    Ok(())
+}
+
+async fn insert_post(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    post_id: Uuid,
+    author_id: Uuid,
+) -> Result<(), sea_orm::DbErr> {
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+        INSERT INTO blog_posts (
+            id, tenant_id, author_id, status, slug, metadata,
+            comment_count, view_count, version
+        ) VALUES ($1, $2, $3, 'published', 'duplicate-race-test', '{}'::jsonb, 0, 0, 1)
+        "#,
+        vec![post_id.into(), tenant_id.into(), author_id.into()],
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn load_post_state(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    post_id: Uuid,
+) -> Result<(i32, i32), sea_orm::DbErr> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT comment_count, version FROM blog_posts WHERE tenant_id = $1 AND id = $2",
+            vec![tenant_id.into(), post_id.into()],
+        ))
+        .await?
+        .expect("Blog post state should exist");
+    Ok((
+        row.try_get("", "comment_count")?,
+        row.try_get("", "version")?,
+    ))
+}
+
+async fn count_delivery(
+    db: &DatabaseConnection,
+    event_id: Uuid,
+) -> Result<i64, sea_orm::DbErr> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT COUNT(*)::bigint AS count FROM blog_comment_projection_deliveries WHERE event_id = $1",
+            vec![event_id.into()],
+        ))
+        .await?
+        .expect("delivery count query should return one row");
+    row.try_get("", "count")
+}
+
+async fn count_outbox_events(db: &DatabaseConnection) -> Result<i64, sea_orm::DbErr> {
+    let row = db
+        .query_one(Statement::from_string(
+            DbBackend::Postgres,
+            "SELECT COUNT(*)::bigint AS count FROM sys_events".to_string(),
+        ))
+        .await?
+        .expect("outbox count query should return one row");
+    row.try_get("", "count")
+}
+
+fn postgres_database_url() -> Option<String> {
+    std::env::var(BLOG_TEST_DATABASE_ENV)
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(
+    database_url: &str,
+    application_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    let db = Database::connect(options).await?;
+    db.query_one(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "SELECT set_config('application_name', $1, false)",
+        vec![application_name.into()],
+    ))
+    .await?;
+    Ok(db)
+}
+
+async fn set_search_path(db: &DatabaseConnection, schema_name: &str) -> TestResult<()> {
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}", public"#))
+        .await?;
+    Ok(())
+}

--- a/scripts/verify/verify-blog-comments-duplicate-delivery-race.mjs
+++ b/scripts/verify/verify-blog-comments-duplicate-delivery-race.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve('.');
+const failures = [];
+
+const evidencePath =
+  'crates/rustok-blog/contracts/evidence/blog-comments-duplicate-delivery-race.json';
+const harnessPath =
+  'crates/rustok-blog/tests/comment_projection_duplicate_race_postgres_test.rs';
+const harnessCommand =
+  'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_duplicate_race_postgres_test concurrent_duplicate_envelope_commits_once_and_replays_cleanly -- --exact';
+
+function read(relativePath) {
+  const target = path.join(repoRoot, relativePath);
+  if (!existsSync(target)) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return '';
+  }
+  return readFileSync(target, 'utf8');
+}
+
+function requireMarker(source, marker, label) {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+}
+
+function requireNoMarker(source, marker, label) {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+}
+
+const harness = read(harnessPath);
+let evidence = null;
+try {
+  evidence = JSON.parse(read(evidencePath));
+} catch (error) {
+  failures.push(`${evidencePath}: invalid JSON: ${error.message}`);
+}
+
+for (const marker of [
+  'const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";',
+  'const WORKER_A_APPLICATION_NAME: &str = "rustok_blog_duplicate_race_a";',
+  'const WORKER_B_APPLICATION_NAME: &str = "rustok_blog_duplicate_race_b";',
+  'async fn concurrent_duplicate_envelope_commits_once_and_replays_cleanly()',
+  'SELECT id FROM blog_posts WHERE tenant_id = $1 AND id = $2 FOR UPDATE',
+  'let task_a = spawn_projection(worker_a, Arc::clone(&start), envelope.clone());',
+  'let task_b = spawn_projection(worker_b, Arc::clone(&start), envelope.clone());',
+  'wait_for_both_workers_to_block(&test_db.control).await?;',
+  'lock_txn.commit().await?;',
+  'assert_eq!(success_count, 1',
+  'assert_eq!(\n        failure_count, 1',
+  'load_post_state(&test_db.db, tenant_id, post_id).await?, (1, 2)',
+  'count_delivery(&test_db.db, envelope.id).await?, 1',
+  'count_outbox_events(&test_db.db).await?, 1',
+  'BlogCommentProjectionHandler::new(replay_db)',
+  '.handle(&envelope)',
+  'FROM pg_stat_activity',
+  "application_name IN ('{WORKER_A_APPLICATION_NAME}', '{WORKER_B_APPLICATION_NAME}')",
+  "wait_event_type = 'Lock'",
+  'if blocked == 2',
+  'SELECT set_config(\'application_name\', $1, false)',
+  'CREATE TABLE blog_comment_projection_deliveries',
+  'CREATE TABLE sys_events',
+  '.max_connections(1)',
+  'SET search_path TO',
+]) {
+  requireMarker(harness, marker, harnessPath);
+}
+requireNoMarker(harness, '#[ignore]', harnessPath);
+requireNoMarker(harness, 'runtime_verified', harnessPath);
+requireNoMarker(harness, 'tokio::time::sleep(Duration::from_secs(', harnessPath);
+
+if (evidence) {
+  if (evidence.schema_version !== 1) failures.push(`${evidencePath}: schema_version drift`);
+  if (
+    evidence.module !== 'blog' ||
+    evidence.surface !== 'comments_duplicate_delivery_race' ||
+    evidence.owner !== 'rustok-blog' ||
+    evidence.provider !== 'rustok-comments'
+  ) {
+    failures.push(`${evidencePath}: identity drift`);
+  }
+  if (evidence.status !== 'source_verified_no_compile') {
+    failures.push(`${evidencePath}: status drift`);
+  }
+  if (evidence.compile_policy !== 'not_run_by_request') {
+    failures.push(`${evidencePath}: compile policy drift`);
+  }
+  if (evidence.runtime_status !== 'pending') {
+    failures.push(`${evidencePath}: runtime status drift`);
+  }
+
+  const retained = evidence.harness ?? {};
+  if (
+    retained.status !== 'executable_no_run' ||
+    retained.runtime_status !== 'not_run' ||
+    retained.path !== harnessPath ||
+    retained.environment !== 'RUSTOK_BLOG_TEST_DATABASE_URL' ||
+    retained.command !== harnessCommand ||
+    retained.isolation !==
+      'unique_schema_three_independent_connections_two_named_workers_controlled_row_lock' ||
+    retained.scope !==
+      'same_envelope_concurrent_delivery_unique_ledger_loser_rollback_and_clean_replay' ||
+    retained.non_claim !==
+      'does_not_record_postgresql_execution_or_full_event_dispatcher_delivery'
+  ) {
+    failures.push(`${evidencePath}: harness metadata drift`);
+  }
+
+  const cases = new Set((evidence.cases ?? []).map((entry) => entry.name));
+  for (const requiredCase of [
+    'both_workers_pass_initial_delivery_lookup',
+    'single_duplicate_commit',
+    'losing_transaction_rolls_back',
+    'same_envelope_replay_is_clean',
+  ]) {
+    if (!cases.has(requiredCase)) failures.push(`${evidencePath}: missing case ${requiredCase}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Blog duplicate delivery race verification failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  'Blog concurrent duplicate delivery lock, rollback, cardinality, and replay source contract is consistent',
+);

--- a/scripts/verify/verify-blog-comments-duplicate-delivery-race.test.mjs
+++ b/scripts/verify/verify-blog-comments-duplicate-delivery-race.test.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const verifier = path.resolve(
+  'scripts/verify/verify-blog-comments-duplicate-delivery-race.mjs',
+);
+
+function write(root, relativePath, content) {
+  const target = path.join(root, relativePath);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, content);
+}
+
+function fixture({
+  missingBlockedWorkerObservation = false,
+  missingReplay = false,
+  statusDrift = false,
+} = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-blog-duplicate-race-'));
+  const evidencePath =
+    'crates/rustok-blog/contracts/evidence/blog-comments-duplicate-delivery-race.json';
+  const harnessPath =
+    'crates/rustok-blog/tests/comment_projection_duplicate_race_postgres_test.rs';
+  const command =
+    'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_duplicate_race_postgres_test concurrent_duplicate_envelope_commits_once_and_replays_cleanly -- --exact';
+
+  write(
+    root,
+    harnessPath,
+    `
+const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";
+const WORKER_A_APPLICATION_NAME: &str = "rustok_blog_duplicate_race_a";
+const WORKER_B_APPLICATION_NAME: &str = "rustok_blog_duplicate_race_b";
+async fn concurrent_duplicate_envelope_commits_once_and_replays_cleanly()
+SELECT id FROM blog_posts WHERE tenant_id = $1 AND id = $2 FOR UPDATE
+let task_a = spawn_projection(worker_a, Arc::clone(&start), envelope.clone());
+let task_b = spawn_projection(worker_b, Arc::clone(&start), envelope.clone());
+${missingBlockedWorkerObservation ? '' : 'wait_for_both_workers_to_block(&test_db.control).await?;'}
+lock_txn.commit().await?;
+assert_eq!(success_count, 1
+assert_eq!(
+        failure_count, 1
+load_post_state(&test_db.db, tenant_id, post_id).await?, (1, 2)
+count_delivery(&test_db.db, envelope.id).await?, 1
+count_outbox_events(&test_db.db).await?, 1
+${missingReplay ? '' : `BlogCommentProjectionHandler::new(replay_db)
+.handle(&envelope)`}
+FROM pg_stat_activity
+application_name IN ('{WORKER_A_APPLICATION_NAME}', '{WORKER_B_APPLICATION_NAME}')
+wait_event_type = 'Lock'
+if blocked == 2
+SELECT set_config('application_name', $1, false)
+CREATE TABLE blog_comment_projection_deliveries
+CREATE TABLE sys_events
+.max_connections(1)
+SET search_path TO
+`,
+  );
+
+  write(
+    root,
+    evidencePath,
+    JSON.stringify({
+      schema_version: 1,
+      module: 'blog',
+      surface: 'comments_duplicate_delivery_race',
+      status: statusDrift ? 'runtime_verified' : 'source_verified_no_compile',
+      compile_policy: 'not_run_by_request',
+      runtime_status: 'pending',
+      owner: 'rustok-blog',
+      provider: 'rustok-comments',
+      harness: {
+        status: 'executable_no_run',
+        runtime_status: 'not_run',
+        path: harnessPath,
+        environment: 'RUSTOK_BLOG_TEST_DATABASE_URL',
+        command,
+        isolation:
+          'unique_schema_three_independent_connections_two_named_workers_controlled_row_lock',
+        scope:
+          'same_envelope_concurrent_delivery_unique_ledger_loser_rollback_and_clean_replay',
+        non_claim:
+          'does_not_record_postgresql_execution_or_full_event_dispatcher_delivery',
+      },
+      cases: [
+        { name: 'both_workers_pass_initial_delivery_lookup' },
+        { name: 'single_duplicate_commit' },
+        { name: 'losing_transaction_rolls_back' },
+        { name: 'same_envelope_replay_is_clean' },
+      ],
+    }),
+  );
+
+  return root;
+}
+
+function run(root) {
+  return spawnSync(process.execPath, [verifier], {
+    cwd: path.resolve('.'),
+    env: { ...process.env, RUSTOK_VERIFY_REPO_ROOT: root },
+    encoding: 'utf8',
+  });
+}
+
+function expectRejected(options, pattern) {
+  const root = fixture(options);
+  try {
+    const result = run(root);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, pattern);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test('accepts the canonical duplicate delivery race contract', () => {
+  const root = fixture();
+  try {
+    const result = run(root);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects a race without blocked-worker observation', () => {
+  expectRejected(
+    { missingBlockedWorkerObservation: true },
+    /missing wait_for_both_workers_to_block/,
+  );
+});
+
+test('rejects a race without clean same-envelope replay', () => {
+  expectRejected({ missingReplay: true }, /missing BlogCommentProjectionHandler::new/);
+});
+
+test('rejects runtime promotion without execution', () => {
+  expectRejected({ statusDrift: true }, /status drift/);
+});


### PR DESCRIPTION
## Summary

- continue the canonical Blog improvement plan through slice 54
- add an env-gated PostgreSQL target for two `BlogCommentProjectionHandler` instances processing the same envelope concurrently
- hold the Blog post row with a control transaction and use named one-connection workers
- wait for `pg_stat_activity` to report both workers blocked after their initial delivery-ledger lookup
- release the lock and require exactly one successful transaction plus one failed losing transaction
- require final `comment_count = 1`, `version = 2`, one delivery row, and one outbox row
- replay the same envelope and require no additional mutation
- add schema-v1 machine evidence, a standalone fail-closed verifier, its focused negative fixture, and update the canonical plan

## Scope and non-claims

This target exercises the direct handler against PostgreSQL. It does not record PostgreSQL execution, dispatcher-level duplicate delivery, naturally contended retry frequency, full server-host restart, or CI results. The standalone guard is not added to registry-owned package order in this slice.

No Rust test, JavaScript verifier, compile, PostgreSQL, browser, workflow, or CI command was run, per maintainer instruction.

## Suggested maintainer commands

```bash
node scripts/verify/verify-blog-comments-duplicate-delivery-race.mjs
node --test scripts/verify/verify-blog-comments-duplicate-delivery-race.test.mjs

RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... \
  cargo test -p rustok-blog \
  --test comment_projection_duplicate_race_postgres_test \
  concurrent_duplicate_envelope_commits_once_and_replays_cleanly \
  -- --exact
```

## Branch state

The work started from `main` at `e7224d7deecaecc8d8f0a10ca9423b2ee8b5c16c`. Current `main` is ahead through unrelated Search Admin, Commerce, Email Admin, and Outbox Admin changes. The branch contains five Blog-only commits and changes exactly five files.