### PR TITLE
fix(commerce): sanitize shared GraphQL diagnostics

### DIFF
--- a/crates/rustok-commerce/admin/src/transport/graphql_error_safety.rs
+++ b/crates/rustok-commerce/admin/src/transport/graphql_error_safety.rs
@@ -7,6 +7,14 @@ use super::native_server_adapter::ApiError;
 const COMMERCE_ADMIN_GRAPHQL_CONSUMER: &str = "rustok_commerce.admin_graphql_transport";
 const COMMERCE_ADMIN_GRAPHQL_BOUNDARY: &str = "commerce_admin_graphql_transport";
 
+struct CommerceAdminGraphqlErrorFacts {
+    error_payload_present: bool,
+    error_payload_length: usize,
+    parse_succeeded: bool,
+    detail_present: bool,
+    detail_length: usize,
+}
+
 pub(super) fn graphql_correlation_id(operation: &'static str) -> String {
     format!(
         "commerce-admin-graphql:{operation}:{}",
@@ -26,6 +34,9 @@ pub(super) fn map_graphql_error(
     };
 
     let parsed = GraphqlHttpError::from_str(raw_error.as_str());
+    let error_facts = commerce_admin_graphql_error_facts(raw_error.as_str(), &parsed);
+    let tenant_id_length = tenant_id.map(|value| value.chars().count());
+    let tenant_uuid = tenant_id.and_then(|value| uuid::Uuid::parse_str(value).ok());
     let (public_code, public_message, error_kind, severe) = match &parsed {
         Ok(GraphqlHttpError::Unauthorized) => (
             "commerce.admin_graphql_authentication_required",
@@ -61,12 +72,18 @@ pub(super) fn map_graphql_error(
 
     if severe {
         tracing::error!(
-            error = %raw_error,
-            parsed_error = ?parsed,
+            error_payload_present = error_facts.error_payload_present,
+            error_payload_length = error_facts.error_payload_length,
+            parse_succeeded = error_facts.parse_succeeded,
+            error_detail_present = error_facts.detail_present,
+            error_detail_length = error_facts.detail_length,
             consumer = COMMERCE_ADMIN_GRAPHQL_CONSUMER,
             operation,
             correlation_id,
-            tenant_id,
+            tenant_id_present = tenant_id_length.is_some(),
+            tenant_id_length,
+            tenant_id_uuid_valid = tenant_uuid.is_some(),
+            tenant_id_uuid_non_nil = tenant_uuid.as_ref().is_some_and(|value| !value.is_nil()),
             tenant_slug_present = tenant_slug_length.is_some(),
             tenant_slug_length,
             error_kind,
@@ -76,12 +93,18 @@ pub(super) fn map_graphql_error(
         );
     } else {
         tracing::warn!(
-            error = %raw_error,
-            parsed_error = ?parsed,
+            error_payload_present = error_facts.error_payload_present,
+            error_payload_length = error_facts.error_payload_length,
+            parse_succeeded = error_facts.parse_succeeded,
+            error_detail_present = error_facts.detail_present,
+            error_detail_length = error_facts.detail_length,
             consumer = COMMERCE_ADMIN_GRAPHQL_CONSUMER,
             operation,
             correlation_id,
-            tenant_id,
+            tenant_id_present = tenant_id_length.is_some(),
+            tenant_id_length,
+            tenant_id_uuid_valid = tenant_uuid.is_some(),
+            tenant_id_uuid_non_nil = tenant_uuid.as_ref().is_some_and(|value| !value.is_nil()),
             tenant_slug_present = tenant_slug_length.is_some(),
             tenant_slug_length,
             error_kind,
@@ -92,4 +115,24 @@ pub(super) fn map_graphql_error(
     }
 
     ApiError::Graphql(public_message.to_string())
+}
+
+fn commerce_admin_graphql_error_facts(
+    raw_error: &str,
+    parsed: &Result<GraphqlHttpError, String>,
+) -> CommerceAdminGraphqlErrorFacts {
+    let detail = match parsed {
+        Ok(GraphqlHttpError::Graphql(message)) | Ok(GraphqlHttpError::Http(message)) => {
+            Some(message.as_str())
+        }
+        Ok(GraphqlHttpError::Network) | Ok(GraphqlHttpError::Unauthorized) | Err(_) => None,
+    };
+
+    CommerceAdminGraphqlErrorFacts {
+        error_payload_present: !raw_error.trim().is_empty(),
+        error_payload_length: raw_error.chars().count(),
+        parse_succeeded: parsed.is_ok(),
+        detail_present: detail.is_some_and(|value| !value.trim().is_empty()),
+        detail_length: detail.map_or(0, |value| value.chars().count()),
+    }
 }

--- a/crates/rustok-commerce/contracts/evidence/admin-graphql-transport-error-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/admin-graphql-transport-error-safety-source-review.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "status": "commerce_admin_graphql_transport_error_safety_source_reviewed_unvalidated",
+  "reviewed_boundary": "commerce_admin_graphql_transport",
+  "review_findings": [
+    "The shared mapper still passes non-Graphql ApiError values through unchanged.",
+    "Unauthorized, network, HTTP, GraphQL rejection, and unknown parse-failure classifications retain their existing stable codes, public messages, and warning/error severity.",
+    "The complete raw GraphQL transport string is no longer written to tracing.",
+    "The parsed GraphqlHttpError and parse-error String are no longer written to tracing.",
+    "GraphQL and HTTP detail strings are represented only by presence and character length.",
+    "The tenant ID string is represented only by presence, character length, UUID validity, and non-nil facts.",
+    "Tenant slug diagnostics remain presence and character length only.",
+    "All three order-change and seven shipping-profile map_graphql_error callsites remain outside the source diff.",
+    "Commerce Admin promotion transport remains outside this shared GraphQL boundary.",
+    "The broad ecommerce correlation-safe mapper cleanup remains open."
+  ],
+  "execution": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false
+  },
+  "review_note": "Source review confirms error and tenant shape-only diagnostics; no compile, verifier, runtime, workflow, or CI evidence is claimed."
+}

--- a/crates/rustok-commerce/contracts/evidence/admin-graphql-transport-error-safety-source.json
+++ b/crates/rustok-commerce/contracts/evidence/admin-graphql-transport-error-safety-source.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "status": "commerce_admin_graphql_transport_error_safety_source_unvalidated",
+  "owner": "rustok-commerce",
+  "boundary": "commerce_admin_graphql_transport",
+  "covered_consumers": [
+    "commerce_admin_order_change_transport",
+    "commerce_admin_shipping_profile_transport"
+  ],
+  "source_contract": {
+    "shared_mapper_changed": true,
+    "order_change_facade_changed": false,
+    "shipping_profile_facade_changed": false,
+    "graphql_adapter_changed": false,
+    "promotion_transport_changed": false,
+    "api_error_contract_preserved": true,
+    "order_change_graphql_callsites": 3,
+    "shipping_profile_graphql_callsites": 7,
+    "non_graphql_passthrough_preserved": true,
+    "severity_classification_preserved": true,
+    "public_messages_preserved": true,
+    "complete_graphql_error_logged": false,
+    "parsed_error_payload_logged": false,
+    "raw_tenant_id_logged": false,
+    "error_shape_only": true,
+    "tenant_shape_only": true,
+    "broad_ecommerce_cleanup_closed": false
+  },
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "wasm_compile_proven": false,
+    "hydrate_compile_proven": false,
+    "ssr_compile_proven": false,
+    "mounted_runtime_proven": false
+  },
+  "notes": [
+    "The shared mapper continues to classify unauthorized, network, HTTP, GraphQL rejection, and unknown parse failures into the existing public codes, messages, and severity classes.",
+    "Complete GraphQL, HTTP, and parse-failure strings are not written to diagnostics.",
+    "Private diagnostics retain only error payload presence and character length, parse success, bounded parsed-detail shape, tenant string shape, and tenant UUID validity/non-nil facts.",
+    "The three order-change and seven shipping-profile GraphQL callsites remain unchanged.",
+    "Commerce Admin promotion remains on its separate native client policy.",
+    "No FFA or FBA status is promoted from source inspection."
+  ]
+}

--- a/crates/rustok-commerce/docs/admin-graphql-transport-error-safety.md
+++ b/crates/rustok-commerce/docs/admin-graphql-transport-error-safety.md
@@ -1,0 +1,74 @@
+# Commerce Admin shared GraphQL transport error safety
+
+Status: **source-ready / unvalidated**
+
+## Boundary
+
+Commerce Admin order-change and shipping-profile facades use the shared
+`map_graphql_error` policy for GraphQL transport failures. The mapper already
+returned bounded public `ApiError::Graphql` messages, but its private tracing events
+recorded the complete raw compatibility error, the complete parsed
+`GraphqlHttpError` or parse-failure string, and the tenant ID value.
+
+`GraphqlHttpError::Graphql(String)` and `GraphqlHttpError::Http(String)` carry
+arbitrary server or transport text. A parse failure also embeds the original value in
+its error string. Those values are not safe diagnostic attributes.
+
+## Covered callsites
+
+The unchanged callers are:
+
+- three order-change operations: fetch, apply, and cancel;
+- seven shipping-profile operations: bootstrap, list, detail, create, update,
+  deactivate, and reactivate.
+
+Commerce Admin promotion transport is not part of this shared GraphQL boundary and
+retains its separate native client error policy.
+
+## Private diagnostics
+
+The complete GraphQL transport error is not logged. Both warning and error events now
+retain only:
+
+- error payload presence and character length;
+- whether `GraphqlHttpError::from_str` succeeded;
+- parsed GraphQL or HTTP detail presence and character length;
+- stable error kind and public code;
+- operation and per-call correlation ID;
+- tenant ID presence, character length, UUID validity, and non-nil shape;
+- tenant slug presence and character length;
+- consumer and transport-boundary identifiers.
+
+They do not record raw GraphQL, HTTP, parse-failure, tenant ID, or tenant-slug text.
+
+## Preserved behavior
+
+This source slice preserves:
+
+- pass-through of non-`ApiError::Graphql` variants;
+- unauthorized as a warning with the authentication-required message;
+- network and HTTP failures as errors with the temporarily-unavailable message;
+- GraphQL rejections as warnings with the request-could-not-be-completed message;
+- unknown parse failures as errors with the request-could-not-be-completed message;
+- all existing public codes;
+- `ApiError::Graphql(public_message.to_string())` as the public envelope;
+- all order-change and shipping-profile facades, arguments, DTOs, and adapter calls;
+- promotion, native server, SSR, permissions, request-context, and owner behavior.
+
+## Evidence
+
+- `contracts/evidence/admin-graphql-transport-error-safety-source.json`
+- `contracts/evidence/admin-graphql-transport-error-safety-source-review.json`
+- `scripts/verify/verify-commerce-admin-graphql-transport-error-safety.mjs`
+
+## Validation still required
+
+Per maintainer instruction, no tests, Node verifiers, Cargo commands, formatting,
+workflows, or CI were run. Maintainer validation should include the focused verifier,
+aggregate Commerce/ecommerce guards, WASM/hydrate/SSR compilation, and mounted failure
+injection for representative unauthorized, network, HTTP, GraphQL rejection, and
+unknown parse-failure cases.
+
+This source result does not promote Commerce FFA/FBA, browser, hydrate, SSR, mounted
+runtime, workflow, CI, or production status. The broad ecommerce correlation-safe
+mapper cleanup remains open for other adapters and non-`PortError` envelopes.

--- a/scripts/verify/verify-commerce-admin-graphql-transport-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-graphql-transport-error-safety.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const requireCount = (source, value, expected, label) => {
+  const count = source.split(value).length - 1;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+};
+
+const paths = {
+  safety: "crates/rustok-commerce/admin/src/transport/graphql_error_safety.rs",
+  orderChange: "crates/rustok-commerce/admin/src/transport/order_change.rs",
+  shippingProfile: "crates/rustok-commerce/admin/src/transport/shipping_profile.rs",
+  promotion: "crates/rustok-commerce/admin/src/transport/promotion.rs",
+  evidence:
+    "crates/rustok-commerce/contracts/evidence/admin-graphql-transport-error-safety-source.json",
+  review:
+    "crates/rustok-commerce/contracts/evidence/admin-graphql-transport-error-safety-source-review.json",
+  doc: "crates/rustok-commerce/docs/admin-graphql-transport-error-safety.md",
+  plan: "crates/rustok-commerce/docs/implementation-plan.md",
+};
+
+const safety = read(paths.safety);
+const orderChange = read(paths.orderChange);
+const shippingProfile = read(paths.shippingProfile);
+const promotion = read(paths.promotion);
+const evidence = JSON.parse(read(paths.evidence));
+const review = JSON.parse(read(paths.review));
+const doc = read(paths.doc);
+const plan = read(paths.plan);
+
+for (const marker of [
+  'const COMMERCE_ADMIN_GRAPHQL_CONSUMER: &str = "rustok_commerce.admin_graphql_transport"',
+  'const COMMERCE_ADMIN_GRAPHQL_BOUNDARY: &str = "commerce_admin_graphql_transport"',
+  "struct CommerceAdminGraphqlErrorFacts",
+  "error_payload_present: bool",
+  "error_payload_length: usize",
+  "parse_succeeded: bool",
+  "detail_present: bool",
+  "detail_length: usize",
+  "let ApiError::Graphql(raw_error) = error else",
+  "return error;",
+  "let parsed = GraphqlHttpError::from_str(raw_error.as_str());",
+  "let error_facts = commerce_admin_graphql_error_facts(raw_error.as_str(), &parsed);",
+  "tenant_id_present = tenant_id_length.is_some()",
+  "tenant_id_length",
+  "tenant_id_uuid_valid = tenant_uuid.is_some()",
+  "tenant_id_uuid_non_nil = tenant_uuid.as_ref().is_some_and(|value| !value.is_nil())",
+  "error_payload_present = error_facts.error_payload_present",
+  "error_payload_length = error_facts.error_payload_length",
+  "parse_succeeded = error_facts.parse_succeeded",
+  "error_detail_present = error_facts.detail_present",
+  "error_detail_length = error_facts.detail_length",
+  "fn commerce_admin_graphql_error_facts(",
+  "error_payload_present: !raw_error.trim().is_empty()",
+  "error_payload_length: raw_error.chars().count()",
+  "parse_succeeded: parsed.is_ok()",
+  "detail_length: detail.map_or(0, |value| value.chars().count())",
+]) {
+  requireText(safety, marker, `${paths.safety}: safe diagnostic shape`);
+}
+
+for (const forbidden of [
+  "error = %raw_error",
+  "error = ?raw_error",
+  "raw_error = %raw_error",
+  "raw_error = ?raw_error",
+  "parsed_error = ?parsed",
+  "parsed_error = %parsed",
+  "tenant_id = %",
+  "tenant_id = ?",
+  "tenant_id,\n            tenant_slug_present",
+  "error.to_string()",
+  "raw_error.to_string()",
+]) {
+  forbidText(safety, forbidden, `${paths.safety}: complete payload or identity logging`);
+}
+
+for (const [code, message, kind] of [
+  [
+    "commerce.admin_graphql_authentication_required",
+    "Commerce admin authentication is required",
+    "unauthorized",
+  ],
+  [
+    "commerce.admin_graphql_network_unavailable",
+    "Commerce admin service is temporarily unavailable",
+    "network",
+  ],
+  [
+    "commerce.admin_graphql_http_unavailable",
+    "Commerce admin service is temporarily unavailable",
+    "http",
+  ],
+  [
+    "commerce.admin_graphql_request_rejected",
+    "Commerce admin request could not be completed",
+    "graphql",
+  ],
+  [
+    "commerce.admin_graphql_unknown_failure",
+    "Commerce admin request could not be completed",
+    "unknown",
+  ],
+]) {
+  requireText(safety, code, `${paths.safety}: preserved public code`);
+  requireText(safety, message, `${paths.safety}: preserved public message`);
+  requireText(safety, `"${kind}"`, `${paths.safety}: preserved error kind`);
+}
+requireText(
+  safety,
+  "ApiError::Graphql(public_message.to_string())",
+  `${paths.safety}: public ApiError envelope`,
+);
+requireText(safety, "tracing::error!(", `${paths.safety}: severe diagnostics`);
+requireText(safety, "tracing::warn!(", `${paths.safety}: rejection diagnostics`);
+
+requireCount(
+  orderChange,
+  "map_graphql_error(",
+  3,
+  `${paths.orderChange}: order-change GraphQL mappings`,
+);
+requireCount(
+  shippingProfile,
+  "map_graphql_error(",
+  7,
+  `${paths.shippingProfile}: shipping-profile GraphQL mappings`,
+);
+for (const operation of [
+  "fetch_order_changes",
+  "apply_order_change",
+  "cancel_order_change",
+]) {
+  requireText(orderChange, `pub async fn ${operation}(`, `${paths.orderChange}: ${operation}`);
+}
+for (const operation of [
+  "fetch_bootstrap",
+  "fetch_shipping_profiles",
+  "fetch_shipping_profile",
+  "create_shipping_profile",
+  "update_shipping_profile",
+  "deactivate_shipping_profile",
+  "reactivate_shipping_profile",
+]) {
+  requireText(
+    shippingProfile,
+    `pub async fn ${operation}(`,
+    `${paths.shippingProfile}: ${operation}`,
+  );
+}
+forbidText(
+  promotion,
+  "map_graphql_error(",
+  `${paths.promotion}: promotion remains on its native client policy`,
+);
+
+if (evidence.status !== "commerce_admin_graphql_transport_error_safety_source_unvalidated") {
+  failures.push(`${paths.evidence}: unexpected status ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  shared_mapper_changed: true,
+  order_change_facade_changed: false,
+  shipping_profile_facade_changed: false,
+  graphql_adapter_changed: false,
+  promotion_transport_changed: false,
+  api_error_contract_preserved: true,
+  order_change_graphql_callsites: 3,
+  shipping_profile_graphql_callsites: 7,
+  non_graphql_passthrough_preserved: true,
+  severity_classification_preserved: true,
+  public_messages_preserved: true,
+  complete_graphql_error_logged: false,
+  parsed_error_payload_logged: false,
+  raw_tenant_id_logged: false,
+  error_shape_only: true,
+  tenant_shape_only: true,
+  broad_ecommerce_cleanup_closed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "wasm_compile_proven",
+  "hydrate_compile_proven",
+  "ssr_compile_proven",
+  "mounted_runtime_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+
+if (
+  review.status !==
+  "commerce_admin_graphql_transport_error_safety_source_reviewed_unvalidated"
+) {
+  failures.push(`${paths.review}: unexpected status ${review.status}`);
+}
+requireText(doc, "Status: **source-ready / unvalidated**", `${paths.doc}: status`);
+requireText(doc, "complete GraphQL transport error is not logged", `${paths.doc}: policy`);
+requireText(
+  plan,
+  "Finish correlation-safe mapper cleanup",
+  `${paths.plan}: broad ecommerce cleanup remains open`,
+);
+
+if (failures.length > 0) {
+  console.error("Commerce Admin GraphQL transport error-safety verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "Commerce Admin shared GraphQL diagnostics retain only error and tenant shape; execution evidence remains open",
+);


### PR DESCRIPTION
## Summary

- continue the open ecommerce correlation-safe mapper cleanup at the shared Commerce Admin GraphQL transport boundary
- remove complete raw GraphQL/HTTP/parse-failure payloads, complete parsed errors, and raw tenant IDs from warning/error tracing
- retain only error payload presence/length, parse success, parsed detail presence/length, tenant shape, stable classification, public code, operation, and correlation ID
- preserve non-Graphql `ApiError` passthrough, all existing public messages/codes, and warning/error severity
- preserve all three order-change and seven shipping-profile GraphQL callsites without facade or adapter changes
- add focused verifier, documentation, source evidence, and source-review evidence

## Confirmed gap

`map_graphql_error` logged `error = %raw_error`, `parsed_error = ?parsed`, and the raw optional tenant ID. `GraphqlHttpError::Graphql(String)` and `GraphqlHttpError::Http(String)` carry arbitrary text, while parse failures embed the original string in their error value.

## Scope boundary

Exactly five files change: the shared mapper plus a new focused verifier, document, and two evidence files. Order-change and shipping-profile facades, GraphQL adapter execution, promotion transport, native/SSR adapters, DTOs, permissions, request context, and owner operations remain unchanged. The broad ecommerce mapper cleanup remains open.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-commerce-admin-graphql-transport-error-safety.mjs
cargo check -p rustok-commerce-admin --all-features
```

## Branch state

The branch is based on current `main` at `1ee4c6f8689e26f1a256b479ad3f83cdc2baaebe`, is one commit ahead and zero behind, and changes exactly five files. Head commit: `785ce764e67f8dea50b366692fc56ebd6f7bd8d9`. Squash merge is intended.