### PR TITLE
fix(order-storefront): generate native error correlation id

### DIFF
--- a/crates/rustok-order/contracts/evidence/storefront-runtime-error-diagnostics-source.json
+++ b/crates/rustok-order/contracts/evidence/storefront-runtime-error-diagnostics-source.json
@@ -1,12 +1,15 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-30",
+  "generated_at": "2026-07-31",
   "status": "order_storefront_runtime_error_diagnostics_source_unvalidated",
   "scope": "order storefront native checkout runtime error mapper",
   "source_contract": {
     "runtime_cause_logged_server_side": true,
     "owner_operation_logged": true,
     "correlation_logged": true,
+    "correlation_generated_server_side": true,
+    "request_context_correlation_required": false,
+    "idempotency_key_logged": false,
     "tenant_logged": true,
     "channel_logged": true,
     "locale_logged": true,

--- a/crates/rustok-order/storefront/src/transport/native_server_adapter/server_functions.rs
+++ b/crates/rustok-order/storefront/src/transport/native_server_adapter/server_functions.rs
@@ -86,6 +86,7 @@ async fn storefront_order_complete_checkout_native(
             return Err(ServerFnError::new("Checkout request is invalid"));
         }
         let metadata = request.metadata;
+        let correlation_id = Uuid::new_v4();
 
         let completion = storefront_staged_checkout_runtime::complete_storefront_checkout_with_product_port(
             &runtime,
@@ -108,7 +109,9 @@ async fn storefront_order_complete_checkout_native(
             },
         )
         .await
-        .map_err(|error| native_checkout_runtime_error(&request_context, tenant.id, error))?;
+        .map_err(|error| {
+            native_checkout_runtime_error(&request_context, tenant.id, correlation_id, error)
+        })?;
 
         Ok(map_checkout_completion(completion))
     }
@@ -133,6 +136,7 @@ fn native_context_error(operation: &'static str, error: impl std::fmt::Display) 
 fn native_checkout_runtime_error(
     request_context: &rustok_api::RequestContext,
     tenant_id: Uuid,
+    correlation_id: Uuid,
     error: rustok_commerce::services::storefront_staged_checkout_runtime::StorefrontStagedCheckoutRuntimeError,
 ) -> ServerFnError {
     let public_code = error.public_code();
@@ -141,7 +145,7 @@ fn native_checkout_runtime_error(
         error = ?error,
         owner = ORDER_STOREFRONT_NATIVE_OWNER,
         owner_operation = "complete_storefront_checkout",
-        correlation_id = %request_context.correlation_id,
+        correlation_id = %correlation_id,
         tenant_id = %tenant_id,
         channel_id = ?request_context.channel_id,
         channel_slug = ?request_context.channel_slug,

--- a/scripts/verify/verify-order-storefront-runtime-error-diagnostics.mjs
+++ b/scripts/verify/verify-order-storefront-runtime-error-diagnostics.mjs
@@ -34,9 +34,11 @@ for (const [value, label] of [
   ["fn native_checkout_runtime_error(", "runtime error mapper"],
   ["request_context: &rustok_api::RequestContext", "request context mapper input"],
   ["tenant_id: Uuid", "tenant mapper input"],
+  ["correlation_id: Uuid", "correlation mapper input"],
+  ["let correlation_id = Uuid::new_v4();", "server-generated correlation id"],
   ["owner = ORDER_STOREFRONT_NATIVE_OWNER", "owner diagnostics"],
   ['owner_operation = "complete_storefront_checkout"', "operation diagnostics"],
-  ["correlation_id = %request_context.correlation_id", "correlation diagnostics"],
+  ["correlation_id = %correlation_id", "correlation diagnostics"],
   ["tenant_id = %tenant_id", "tenant diagnostics"],
   ["channel_id = ?request_context.channel_id", "channel id diagnostics"],
   ["channel_slug = ?request_context.channel_slug", "channel slug diagnostics"],
@@ -70,8 +72,8 @@ for (const [value, label] of [
 
 requireText(
   source,
-  ".map_err(|error| native_checkout_runtime_error(&request_context, tenant.id, error))?;",
-  "correlation-aware runtime mapper call",
+  "native_checkout_runtime_error(&request_context, tenant.id, correlation_id, error)",
+  "server-correlation-aware runtime mapper call",
 );
 requireText(source, "let public_code = error.public_code();", "public code source");
 requireText(source, "let public_message = error.public_message();", "public message source");
@@ -89,6 +91,16 @@ if (countText(source, 'ServerFnError::new("Checkout service is temporarily unava
 }
 forbidText(
   source,
+  "request_context.correlation_id",
+  "nonexistent RequestContext correlation field",
+);
+forbidText(
+  source,
+  "correlation_id = %idempotency_key",
+  "idempotency key in diagnostics",
+);
+forbidText(
+  source,
   ".map_err(native_checkout_runtime_error)?;",
   "runtime mapper without request diagnostics",
 );
@@ -100,6 +112,9 @@ for (const [key, expected] of Object.entries({
   runtime_cause_logged_server_side: true,
   owner_operation_logged: true,
   correlation_logged: true,
+  correlation_generated_server_side: true,
+  request_context_correlation_required: false,
+  idempotency_key_logged: false,
   tenant_logged: true,
   channel_logged: true,
   locale_logged: true,
@@ -139,5 +154,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "✔ Order storefront checkout runtime failures retain the public envelope and add correlation-safe SSR diagnostics; runtime evidence remains open",
+  "✔ Order storefront checkout runtime failures retain the public envelope and use a server-generated correlation id; runtime evidence remains open",
 );


### PR DESCRIPTION
## Summary

Ecommerce Hardening on the Tenant/Commerce follow-up compiled `rustok-commerce` successfully, then stopped in `rustok-order-storefront` because `native_checkout_runtime_error` referenced `RequestContext.correlation_id`, a field that does not exist.

## Fix

- generate a fresh server-side `Uuid::new_v4()` for each native checkout operation;
- pass it only to the private runtime-error mapper;
- log that correlation id alongside tenant/channel/locale and typed owner failure;
- do not log the idempotency key, cart payload, or invent a correlation field on shared `RequestContext`;
- preserve the endpoint, dependency composition, context extraction, checkout command, public code/message envelope, and outer client-safe transport envelope.

## Regression evidence

The focused verifier now requires the server-generated correlation id, forbids `request_context.correlation_id`, forbids idempotency-key correlation logging, and checks the refreshed source evidence contract.

The evidence remains `source_unvalidated` until the focused verifier and `cargo check -p rustok-order-storefront --all-features` pass on this SHA.

No workflow changes.