### PR TITLE
test(index): retain reconciliation failure diagnostics

### DIFF
--- a/crates/rustok-index/docs/m6-reconciliation-failure-diagnostics-postgres-harness.md
+++ b/crates/rustok-index/docs/m6-reconciliation-failure-diagnostics-postgres-harness.md
@@ -1,0 +1,94 @@
+# M6 reconciliation failure diagnostics PostgreSQL harness
+
+Status: executable target retained, not run.
+
+## Purpose
+
+`source_reconciliation_failure_diagnostics_postgres_test` retains PostgreSQL evidence for the existing reconciliation page-failure terminal transition. It verifies both source-failure classifications without changing production code:
+
+- a permanent owner-source failure;
+- a retryable owner-source failure.
+
+Both cases use the canonical `PostgresIndexReconciliationRunner`, immutable source/schema registries, the real `IndexModule` migration sequence, and one persisted active schema.
+
+## Durable transition
+
+Each source fails on the first scan after the runner has acquired attempt 1. The call returns the typed `IndexReconciliationRunError::Source(IndexSourceError::SourceFailure { .. })` to its caller.
+
+PostgreSQL must retain exactly one reconciliation job with:
+
+- state `failed`;
+- attempt count 1;
+- cursor `completed_passes = 0`;
+- cursor `pages_processed = 0`;
+- cleared lease owner and lease expiry;
+- non-null completion timestamp;
+- `last_error_code = index.reconciliation_page_failed`.
+
+No mutation was returned, so `index_entities` and `index_inbox` must both remain empty.
+
+A later exact-tenant cancellation request must observe `AlreadyTerminal(Failed)`.
+
+## Bounded diagnostic contract
+
+`last_error_details` must equal exactly:
+
+```json
+{
+  "contract": "index_reconciliation_run_failure_v1",
+  "dependency_code": "<bounded source code>",
+  "retryable": true
+}
+```
+
+The permanent case stores `retryable: false`; the retryable case stores `retryable: true`.
+
+The object must contain exactly those three fields. It does not retain:
+
+- tenant or actor identity;
+- worker or job identity;
+- source name;
+- schema or request payload;
+- database, transport, stack, or arbitrary owner details.
+
+The source failure itself already accepts only a validated machine-readable code. The harness therefore proves the persisted shape is bounded; it does not claim redaction of an unbounded source-detail field because no such field exists in the source contract.
+
+## PostgreSQL isolation
+
+The target reads `RUSTOK_INDEX_TEST_DATABASE_URL`, with PostgreSQL `DATABASE_URL` as a fallback. Without a PostgreSQL URL it reports a skip and succeeds.
+
+Every case creates a unique schema, creates the tenant owner fixture, applies all real Index migrations, persists one active schema, uses one-connection pools with schema-local `search_path`, reads durable evidence, and drops the isolated schema.
+
+## Scope boundaries
+
+This harness does not add or prove:
+
+- automatic retry, backoff, jitter, scheduling, or polling;
+- retryable failure returning to `pending`;
+- failed-scope dead-letter admission or operator requeue;
+- attempt-budget exhaustion;
+- cancellation or lease-loss races;
+- process, host, container, or PostgreSQL restart;
+- source-call timeout or source future preemption;
+- digest comparison, orphan cleanup, targeted repair, or complete drift repair;
+- locale or partition reconciliation checkpoint dimensions;
+- server authorization, transport, task ownership, or graceful shutdown.
+
+The existing reconciliation runner terminalizes retryable and permanent page failures identically as `failed`; only the bounded diagnostic `retryable` marker differs. Automatic retry ownership remains open.
+
+The canonical M6 reconciliation and drift-repair item therefore remains open.
+
+## Suggested maintainer commands
+
+```bash
+RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
+  cargo test -p rustok-index \
+  --test source_reconciliation_failure_diagnostics_postgres_test \
+  -- --nocapture
+
+cargo check -p rustok-index --all-targets
+
+node scripts/verify/verify-index-reconciliation-failure-diagnostics-harness.mjs
+```
+
+No Cargo, PostgreSQL, JavaScript verifier, Clippy, or CI result is recorded by this slice.

--- a/crates/rustok-index/tests/reconciliation_failure_diagnostics/connection.rs
+++ b/crates/rustok-index/tests/reconciliation_failure_diagnostics/connection.rs
@@ -1,0 +1,33 @@
+use std::{env, error::Error};
+
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection};
+
+pub type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+pub const DATABASE_ENV: &str = "RUSTOK_INDEX_TEST_DATABASE_URL";
+
+pub fn database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+pub async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+pub async fn scoped_connection(
+    database_url: &str,
+    schema_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url).await?;
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}""#))
+        .await?;
+    Ok(db)
+}

--- a/crates/rustok-index/tests/reconciliation_failure_diagnostics/database.rs
+++ b/crates/rustok-index/tests/reconciliation_failure_diagnostics/database.rs
@@ -1,0 +1,75 @@
+use rustok_core::MigrationSource;
+use rustok_index::IndexModule;
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement};
+use sea_orm_migration::SchemaManager;
+use uuid::Uuid;
+
+use super::{
+    connection::{DATABASE_ENV, TestResult, connect, database_url, scoped_connection},
+    schema::persist_schema,
+};
+
+pub struct TestDatabase {
+    control: DatabaseConnection,
+    database_url: String,
+    schema_name: String,
+    pub tenant_id: Uuid,
+}
+
+impl TestDatabase {
+    pub async fn setup(case: &str) -> TestResult<Option<Self>> {
+        let Some(database_url) = database_url() else {
+            eprintln!(
+                "{DATABASE_ENV} is not set to a PostgreSQL URL; skipping reconciliation failure diagnostics harness"
+            );
+            return Ok(None);
+        };
+        let control = connect(&database_url).await?;
+        let schema_name = format!(
+            "rustok_index_reconciliation_failure_{}_{}",
+            case,
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let tenant_id = Uuid::new_v4();
+        let db = scoped_connection(&database_url, &schema_name).await?;
+        db.execute_unprepared("CREATE TABLE tenants (id UUID NOT NULL PRIMARY KEY)")
+            .await?;
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "INSERT INTO tenants (id) VALUES ($1)",
+            vec![tenant_id.into()],
+        ))
+        .await?;
+
+        let manager = SchemaManager::new(&db);
+        for migration in IndexModule.migrations() {
+            migration.up(&manager).await?;
+        }
+        persist_schema(&db, tenant_id).await?;
+
+        Ok(Some(Self {
+            control,
+            database_url,
+            schema_name,
+            tenant_id,
+        }))
+    }
+
+    pub async fn connection(&self) -> TestResult<DatabaseConnection> {
+        scoped_connection(&self.database_url, &self.schema_name).await
+    }
+
+    pub async fn cleanup(self) -> TestResult<()> {
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/rustok-index/tests/reconciliation_failure_diagnostics/evidence.rs
+++ b/crates/rustok-index/tests/reconciliation_failure_diagnostics/evidence.rs
@@ -1,0 +1,61 @@
+use std::io;
+
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement};
+use serde_json::Value as JsonValue;
+use uuid::Uuid;
+
+use super::connection::TestResult;
+
+#[derive(Debug)]
+pub struct FailureEvidence {
+    pub job_id: Uuid,
+    pub state: String,
+    pub attempt_count: i64,
+    pub completed_passes: i64,
+    pub pages_processed: i64,
+    pub last_error_code: String,
+    pub last_error_details: JsonValue,
+    pub lease_released: bool,
+    pub completed: bool,
+}
+
+pub async fn read_failure(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+) -> TestResult<FailureEvidence> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT job_id, state, attempt_count::bigint AS attempt_count_value, (cursor->>'completed_passes')::bigint AS completed_passes, (cursor->>'pages_processed')::bigint AS pages_processed, last_error_code, last_error_details, (lease_owner IS NULL AND lease_expires_at IS NULL) AS lease_released, (completed_at IS NOT NULL) AS completed FROM index_jobs WHERE tenant_id = $1 AND kind = 'reconcile'",
+            vec![tenant_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| io::Error::other("reconciliation failure job row is missing"))?;
+    Ok(FailureEvidence {
+        job_id: row.try_get("", "job_id")?,
+        state: row.try_get("", "state")?,
+        attempt_count: row.try_get("", "attempt_count_value")?,
+        completed_passes: row.try_get("", "completed_passes")?,
+        pages_processed: row.try_get("", "pages_processed")?,
+        last_error_code: row.try_get("", "last_error_code")?,
+        last_error_details: row.try_get("", "last_error_details")?,
+        lease_released: row.try_get("", "lease_released")?,
+        completed: row.try_get("", "completed")?,
+    })
+}
+
+pub async fn count(db: &DatabaseConnection, table: &str) -> TestResult<i64> {
+    let sql = match table {
+        "index_entities" => "SELECT COUNT(*)::bigint AS value FROM index_entities",
+        "index_inbox" => "SELECT COUNT(*)::bigint AS value FROM index_inbox",
+        "index_jobs" => {
+            "SELECT COUNT(*)::bigint AS value FROM index_jobs WHERE kind = 'reconcile'"
+        }
+        _ => panic!("unsupported fixture table"),
+    };
+    Ok(db
+        .query_one(Statement::from_string(DbBackend::Postgres, sql.to_owned()))
+        .await?
+        .ok_or_else(|| io::Error::other("count query returned no row"))?
+        .try_get("", "value")?)
+}

--- a/crates/rustok-index/tests/reconciliation_failure_diagnostics/runner.rs
+++ b/crates/rustok-index/tests/reconciliation_failure_diagnostics/runner.rs
@@ -1,0 +1,60 @@
+use std::{sync::Arc, time::Duration};
+
+use rustok_index::{
+    IndexReconciliationRunRequest, IndexSchemaSourceCatalog, IndexSourceCatalog,
+    PostgresIndexReconciliationRunner, SchemaRegistry,
+};
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use super::{
+    schema::{schema, schema_ref},
+    source::FailingSource,
+};
+
+pub const SOURCE_NAME: &str = "failure-diagnostics-primary";
+
+pub fn runner(
+    db: DatabaseConnection,
+    source: FailingSource,
+) -> PostgresIndexReconciliationRunner {
+    let schema = schema();
+    let mut schema_catalog = IndexSchemaSourceCatalog::new();
+    schema_catalog
+        .register("failure-diagnostics-harness", schema.clone())
+        .expect("fixture schema source must register");
+
+    let mut source_catalog = IndexSourceCatalog::new();
+    source_catalog
+        .register(
+            "failure-diagnostics-harness",
+            SOURCE_NAME,
+            [schema.reference.clone()],
+            source,
+        )
+        .expect("fixture source must register");
+    let sources = source_catalog
+        .materialize(&schema_catalog)
+        .expect("fixture source registry must materialize");
+
+    let mut registry = SchemaRegistry::new();
+    registry
+        .register(schema)
+        .expect("fixture schema registry must materialize");
+
+    PostgresIndexReconciliationRunner::new(db, sources, Arc::new(registry))
+}
+
+pub fn request(tenant_id: Uuid, worker_id: &str) -> IndexReconciliationRunRequest {
+    IndexReconciliationRunRequest::new(
+        tenant_id,
+        schema_ref(),
+        worker_id,
+        1,
+        1,
+        1,
+        1,
+        Duration::from_secs(60),
+    )
+    .expect("fixture reconciliation request must be valid")
+}

--- a/crates/rustok-index/tests/reconciliation_failure_diagnostics/schema.rs
+++ b/crates/rustok-index/tests/reconciliation_failure_diagnostics/schema.rs
@@ -1,0 +1,53 @@
+use rustok_index::{
+    EntityName, FieldCardinality, FieldName, IndexField, IndexSchema, IndexValueType,
+    LocaleMode, ModuleName, SchemaRef, SchemaVersion,
+};
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement, Value as SqlValue};
+use uuid::Uuid;
+
+use super::connection::TestResult;
+
+pub fn schema_ref() -> SchemaRef {
+    SchemaRef {
+        module: ModuleName::new("failure-diagnostics-harness").unwrap(),
+        entity: EntityName::new("item").unwrap(),
+        version: SchemaVersion::INITIAL,
+    }
+}
+
+pub fn schema() -> IndexSchema {
+    IndexSchema {
+        reference: schema_ref(),
+        locale_mode: LocaleMode::None,
+        fields: vec![IndexField {
+            name: FieldName::new("id").unwrap(),
+            value_type: IndexValueType::Uuid,
+            cardinality: FieldCardinality::One,
+            nullable: false,
+            selectable: true,
+            filterable: true,
+            sortable: true,
+        }],
+        links: Vec::new(),
+    }
+}
+
+pub async fn persist_schema(db: &DatabaseConnection, tenant_id: Uuid) -> TestResult<()> {
+    let schema = schema();
+    let fingerprint = schema.fingerprint()?.to_string();
+    let schema_json = serde_json::to_value(&schema)?;
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "INSERT INTO index_schemas (tenant_id, module_name, entity_name, schema_version, schema_fingerprint, schema_json, status) VALUES ($1, $2, $3, $4, $5, $6, 'active')",
+        vec![
+            tenant_id.into(),
+            schema.reference.module.as_str().to_owned().into(),
+            schema.reference.entity.as_str().to_owned().into(),
+            i64::from(schema.reference.version.get()).into(),
+            fingerprint.into(),
+            SqlValue::Json(Some(Box::new(schema_json))),
+        ],
+    ))
+    .await?;
+    Ok(())
+}

--- a/crates/rustok-index/tests/reconciliation_failure_diagnostics/source.rs
+++ b/crates/rustok-index/tests/reconciliation_failure_diagnostics/source.rs
@@ -1,0 +1,52 @@
+use async_trait::async_trait;
+use rustok_index::{
+    IndexSource, IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest,
+    IndexSourcePage, IndexSourceScanRequest,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailureMode {
+    Permanent,
+    Retryable,
+}
+
+#[derive(Clone)]
+pub struct FailingSource {
+    code: &'static str,
+    mode: FailureMode,
+}
+
+impl FailingSource {
+    pub fn new(code: &'static str, mode: FailureMode) -> Self {
+        Self { code, mode }
+    }
+
+    pub fn code(&self) -> &'static str {
+        self.code
+    }
+
+    fn failure(&self) -> IndexSourceFailure {
+        match self.mode {
+            FailureMode::Permanent => IndexSourceFailure::permanent(self.code),
+            FailureMode::Retryable => IndexSourceFailure::retryable(self.code),
+        }
+        .expect("fixture failure code must be valid")
+    }
+}
+
+#[async_trait]
+impl IndexSource for FailingSource {
+    async fn scan(
+        &self,
+        _request: IndexSourceScanRequest,
+    ) -> Result<IndexSourcePage, IndexSourceFailure> {
+        Err(self.failure())
+    }
+
+    async fn load(
+        &self,
+        request: IndexSourceLoadRequest,
+    ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+        Ok(IndexSourceLoadBatch::new(&request, Vec::new()).expect("empty targeted load"))
+    }
+}

--- a/crates/rustok-index/tests/source_reconciliation_failure_diagnostics_postgres_test.rs
+++ b/crates/rustok-index/tests/source_reconciliation_failure_diagnostics_postgres_test.rs
@@ -1,0 +1,130 @@
+#[path = "reconciliation_failure_diagnostics/connection.rs"]
+mod connection;
+#[path = "reconciliation_failure_diagnostics/database.rs"]
+mod database;
+#[path = "reconciliation_failure_diagnostics/evidence.rs"]
+mod evidence;
+#[path = "reconciliation_failure_diagnostics/runner.rs"]
+mod runner;
+#[path = "reconciliation_failure_diagnostics/schema.rs"]
+mod schema;
+#[path = "reconciliation_failure_diagnostics/source.rs"]
+mod source;
+
+use rustok_index::{
+    IndexReconciliationCancelOutcome, IndexReconciliationRunError,
+    IndexReconciliationTerminalState, IndexSourceError, IndexSourceFailureKind,
+};
+use serde_json::json;
+
+use connection::TestResult;
+use database::TestDatabase;
+use evidence::{count, read_failure};
+use runner::{SOURCE_NAME, request, runner};
+use source::{FailingSource, FailureMode};
+
+const PAGE_FAILURE_CODE: &str = "index.reconciliation_page_failed";
+const FAILURE_CONTRACT: &str = "index_reconciliation_run_failure_v1";
+
+async fn assert_failure_case(
+    case: &str,
+    worker_id: &str,
+    dependency_code: &'static str,
+    mode: FailureMode,
+    expected_retryable: bool,
+) -> TestResult<()> {
+    let Some(database) = TestDatabase::setup(case).await? else {
+        return Ok(());
+    };
+    let tenant_id = database.tenant_id;
+    let source = FailingSource::new(dependency_code, mode);
+    assert_eq!(source.code(), dependency_code);
+    let reconciliation = runner(database.connection().await?, source);
+
+    let error = reconciliation
+        .run(request(tenant_id, worker_id))
+        .await
+        .expect_err("fixture source failure must escape the run");
+    match error {
+        IndexReconciliationRunError::Source(IndexSourceError::SourceFailure {
+            source_name,
+            failure,
+        }) => {
+            assert_eq!(source_name, SOURCE_NAME);
+            assert_eq!(failure.code(), dependency_code);
+            assert_eq!(
+                failure.kind(),
+                if expected_retryable {
+                    IndexSourceFailureKind::Retryable
+                } else {
+                    IndexSourceFailureKind::Permanent
+                }
+            );
+        }
+        other => panic!("unexpected reconciliation failure: {other:?}"),
+    }
+
+    let evidence_db = database.connection().await?;
+    let failure = read_failure(&evidence_db, tenant_id).await?;
+    assert_eq!(failure.state, "failed");
+    assert_eq!(failure.attempt_count, 1);
+    assert_eq!(failure.completed_passes, 0);
+    assert_eq!(failure.pages_processed, 0);
+    assert_eq!(failure.last_error_code, PAGE_FAILURE_CODE);
+    assert_eq!(
+        failure.last_error_details,
+        json!({
+            "contract": FAILURE_CONTRACT,
+            "dependency_code": dependency_code,
+            "retryable": expected_retryable,
+        })
+    );
+    assert_eq!(
+        failure
+            .last_error_details
+            .as_object()
+            .expect("failure details must be an object")
+            .len(),
+        3
+    );
+    assert!(failure.lease_released);
+    assert!(failure.completed);
+    assert_eq!(count(&evidence_db, "index_jobs").await?, 1);
+    assert_eq!(count(&evidence_db, "index_entities").await?, 0);
+    assert_eq!(count(&evidence_db, "index_inbox").await?, 0);
+
+    assert_eq!(
+        reconciliation
+            .request_cancel(tenant_id, failure.job_id)
+            .await?,
+        IndexReconciliationCancelOutcome::AlreadyTerminal(
+            IndexReconciliationTerminalState::Failed
+        )
+    );
+
+    database.cleanup().await
+}
+
+#[tokio::test]
+async fn permanent_source_failure_terminalizes_with_bounded_diagnostics() -> TestResult<()> {
+    assert_failure_case(
+        "permanent",
+        "failure-worker-permanent",
+        "owner_source_permanent",
+        FailureMode::Permanent,
+        false,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn retryable_source_failure_terminalizes_with_retryable_diagnostic() -> TestResult<()> {
+    assert_failure_case(
+        "retryable",
+        "failure-worker-retryable",
+        "owner_source_retryable",
+        FailureMode::Retryable,
+        true,
+    )
+    .await
+}

--- a/scripts/verify/verify-index-reconciliation-failure-diagnostics-harness.mjs
+++ b/scripts/verify/verify-index-reconciliation-failure-diagnostics-harness.mjs
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const files = {
+  target: "crates/rustok-index/tests/source_reconciliation_failure_diagnostics_postgres_test.rs",
+  source: "crates/rustok-index/tests/reconciliation_failure_diagnostics/source.rs",
+  evidence: "crates/rustok-index/tests/reconciliation_failure_diagnostics/evidence.rs",
+  database: "crates/rustok-index/tests/reconciliation_failure_diagnostics/database.rs",
+  docs: "crates/rustok-index/docs/m6-reconciliation-failure-diagnostics-postgres-harness.md",
+};
+
+const read = (name) => {
+  const relative = files[name];
+  const absolute = path.join(root, relative);
+  if (!fs.existsSync(absolute)) {
+    throw new Error(`missing reconciliation failure diagnostics file: ${relative}`);
+  }
+  return fs.readFileSync(absolute, "utf8");
+};
+
+const requireMarkers = (name, markers) => {
+  const content = read(name);
+  for (const marker of markers) {
+    if (!content.includes(marker)) {
+      throw new Error(`${files[name]} is missing required marker: ${marker}`);
+    }
+  }
+};
+
+const forbidMarkers = (name, markers) => {
+  const content = read(name);
+  for (const marker of markers) {
+    if (content.includes(marker)) {
+      throw new Error(`${files[name]} contains forbidden marker: ${marker}`);
+    }
+  }
+};
+
+requireMarkers("target", [
+  "permanent_source_failure_terminalizes_with_bounded_diagnostics",
+  "retryable_source_failure_terminalizes_with_retryable_diagnostic",
+  "IndexReconciliationRunError::Source(IndexSourceError::SourceFailure",
+  "IndexSourceFailureKind::Permanent",
+  "IndexSourceFailureKind::Retryable",
+  "index.reconciliation_page_failed",
+  "index_reconciliation_run_failure_v1",
+  "failure.last_error_details",
+  ".len(),\n        3",
+  "IndexReconciliationCancelOutcome::AlreadyTerminal",
+  "IndexReconciliationTerminalState::Failed",
+  "count(&evidence_db, \"index_jobs\")",
+  "count(&evidence_db, \"index_entities\")",
+  "count(&evidence_db, \"index_inbox\")",
+]);
+
+requireMarkers("source", [
+  "FailureMode::Permanent",
+  "FailureMode::Retryable",
+  "IndexSourceFailure::permanent",
+  "IndexSourceFailure::retryable",
+  "Err(self.failure())",
+]);
+
+requireMarkers("evidence", [
+  "cursor->>'completed_passes'",
+  "cursor->>'pages_processed'",
+  "last_error_code",
+  "last_error_details",
+  "lease_owner IS NULL AND lease_expires_at IS NULL",
+  "completed_at IS NOT NULL",
+]);
+
+requireMarkers("database", [
+  "RUSTOK_INDEX_TEST_DATABASE_URL",
+  "CREATE SCHEMA",
+  "IndexModule.migrations()",
+  "persist_schema",
+  "DROP SCHEMA IF EXISTS",
+]);
+
+requireMarkers("docs", [
+  "Status: executable target retained, not run.",
+  "The object must contain exactly those three fields.",
+  "does not claim redaction of an unbounded source-detail field",
+  "terminalizes retryable and permanent page failures identically as `failed`",
+  "The canonical M6 reconciliation and drift-repair item therefore remains open.",
+]);
+
+forbidMarkers("target", ["tokio::time::sleep", "std::thread::sleep"]);
+forbidMarkers("source", ["tokio::time::sleep", "std::thread::sleep"]);
+
+console.log("Index reconciliation failure diagnostics harness markers verified.");


### PR DESCRIPTION
Superseded by #2934, merged as `a10b6f7ad1029b975aabda692ed09a837841d644`.

The canonical reconciliation runner now classifies source, mutation, and page-contract failures through the bounded retry transition store and returns typed scheduled, permanent, and exhausted outcomes. This draft encodes the replaced unconditional first-run `Err`/`failed` contract and must not merge.