### PR TITLE
fix(admin): bind global search authority to routed tenant

### DIFF
--- a/apps/admin/src/widgets/app_shell/native_server_adapter.rs
+++ b/apps/admin/src/widgets/app_shell/native_server_adapter.rs
@@ -7,6 +7,25 @@ use super::header::AdminGlobalSearchPayload;
 #[cfg(feature = "ssr")]
 const MAX_ADMIN_SEARCH_QUERY_LEN: usize = 256;
 
+#[cfg(feature = "ssr")]
+fn require_admin_global_search_tenant_scope(
+    auth_tenant_id: uuid::Uuid,
+    resolved_tenant_id: uuid::Uuid,
+) -> Result<(), ServerFnError> {
+    if auth_tenant_id == resolved_tenant_id {
+        return Ok(());
+    }
+
+    tracing::warn!(
+        auth_tenant_id = %auth_tenant_id,
+        resolved_tenant_id = %resolved_tenant_id,
+        code = "admin.global_search_tenant_scope_mismatch",
+        boundary = "admin_global_search_native_transport",
+        "admin global search authority cannot cross the resolved tenant boundary"
+    );
+    Err(ServerFnError::new("Admin search access is denied"))
+}
+
 #[server(prefix = "/api/fn", endpoint = "admin/global-search")]
 pub(crate) async fn admin_global_search_native(
     query: String,
@@ -27,6 +46,7 @@ pub(crate) async fn admin_global_search_native(
         let tenant = leptos_axum::extract::<TenantContext>()
             .await
             .map_err(ServerFnError::new)?;
+        require_admin_global_search_tenant_scope(auth.tenant_id, tenant.id)?;
 
         if !has_effective_permission(&auth.permissions, &Permission::SETTINGS_READ) {
             return Err(ServerFnError::new("settings:read required"));

--- a/scripts/verify/verify-admin-global-search-tenant-scope.mjs
+++ b/scripts/verify/verify-admin-global-search-tenant-scope.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const source = readFileSync(
+  new URL('apps/admin/src/widgets/app_shell/native_server_adapter.rs', root),
+  'utf8',
+);
+const failures = [];
+
+const requireText = (value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+
+for (const [value, label] of [
+  ['fn require_admin_global_search_tenant_scope(', 'tenant scope helper'],
+  ['if auth_tenant_id == resolved_tenant_id', 'tenant equality'],
+  [
+    'require_admin_global_search_tenant_scope(auth.tenant_id, tenant.id)?;',
+    'scoped endpoint call',
+  ],
+  [
+    'has_effective_permission(&auth.permissions, &Permission::SETTINGS_READ)',
+    'settings read admission',
+  ],
+  ['Admin search access is denied', 'static public denial'],
+  ['admin.global_search_tenant_scope_mismatch', 'stable diagnostic code'],
+  ['auth_tenant_id = %auth_tenant_id', 'authenticated tenant diagnostic'],
+  ['resolved_tenant_id = %resolved_tenant_id', 'resolved tenant diagnostic'],
+  ['boundary = "admin_global_search_native_transport"', 'transport boundary diagnostic'],
+  ['SearchDictionaryService::transform_query(', 'tenant dictionary read'],
+  ['SearchSettingsService::load_effective(', 'tenant settings read'],
+  ['tenant_id: Some(tenant.id)', 'tenant-scoped query'],
+  ['record_admin_search_query_log(', 'tenant analytics write'],
+]) {
+  requireText(value, label);
+}
+
+const guardCall = source.indexOf(
+  'require_admin_global_search_tenant_scope(auth.tenant_id, tenant.id)?;',
+);
+const permissionCheck = source.indexOf(
+  'has_effective_permission(&auth.permissions, &Permission::SETTINGS_READ)',
+);
+const dictionaryRead = source.indexOf('SearchDictionaryService::transform_query(');
+const analyticsWrite = source.indexOf('record_admin_search_query_log(');
+if (
+  guardCall < 0 ||
+  permissionCheck < 0 ||
+  dictionaryRead < 0 ||
+  analyticsWrite < 0 ||
+  !(guardCall < permissionCheck && permissionCheck < dictionaryRead && dictionaryRead < analyticsWrite)
+) {
+  failures.push(
+    'tenant equality and SETTINGS_READ must precede tenant Search reads and analytics writes',
+  );
+}
+
+const authExtracts = source.match(/leptos_axum::extract::<AuthContext>\(\)/g) ?? [];
+const tenantExtracts = source.match(/leptos_axum::extract::<TenantContext>\(\)/g) ?? [];
+const guardCalls = source.match(
+  /require_admin_global_search_tenant_scope\(auth\.tenant_id, tenant\.id\)\?;/g,
+) ?? [];
+if (authExtracts.length !== 1 || tenantExtracts.length !== 1 || guardCalls.length !== 1) {
+  failures.push(
+    `expected one AuthContext, one TenantContext and one scoped guard call; found ${authExtracts.length}/${tenantExtracts.length}/${guardCalls.length}`,
+  );
+}
+
+if (failures.length > 0) {
+  console.error('Admin global search tenant-scope verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Admin global search binds authenticated authority to the resolved tenant before Search reads and analytics writes',
+);


### PR DESCRIPTION
## Summary

Admin global search admitted `SETTINGS_READ` from authenticated `AuthContext`, then used a separately resolved `TenantContext` for Search dictionary transformation, tenant settings, the query itself and analytics logging.

Authority issued for tenant A could therefore search and write query analytics for routed tenant B.

## P0 fix

- require `AuthContext.tenant_id == TenantContext.id` before permission admission;
- fail closed with static `Admin search access is denied`;
- retain both tenant ids only in structured diagnostics with code `admin.global_search_tenant_scope_mismatch`;
- preserve the existing `SETTINGS_READ` gate and per-result domain permission filtering;
- place the guard before dictionary/settings/Search reads and the analytics write.

## Regression evidence

`scripts/verify/verify-admin-global-search-tenant-scope.mjs` locks extractor counts, equality-before-permission/read/write ordering, static public denial and private diagnostic markers.

No workflow, Search query shape, ranking, result filtering, analytics schema or public response changes.