### PR TITLE
fix(settings): bind platform settings to routed tenant

### DIFF
--- a/apps/server/src/graphql/settings/mod.rs
+++ b/apps/server/src/graphql/settings/mod.rs
@@ -5,3 +5,25 @@ pub mod types;
 pub use mutation::SettingsMutation;
 pub use query::SettingsQuery;
 pub use types::*;
+
+pub(super) fn require_tenant_settings_scope(
+    auth: &crate::context::AuthContext,
+    resolved_tenant_id: uuid::Uuid,
+) -> async_graphql::Result<()> {
+    use rustok_api::graphql::GraphQLError;
+
+    if auth.tenant_id == resolved_tenant_id {
+        return Ok(());
+    }
+
+    tracing::warn!(
+        auth_tenant_id = %auth.tenant_id,
+        resolved_tenant_id = %resolved_tenant_id,
+        code = "settings.tenant_scope_mismatch",
+        boundary = "server_settings_graphql",
+        "tenant settings authority cannot cross the resolved tenant boundary"
+    );
+    Err(<async_graphql::FieldError as GraphQLError>::permission_denied(
+        "Settings access is denied",
+    ))
+}

--- a/apps/server/src/graphql/settings/mutation.rs
+++ b/apps/server/src/graphql/settings/mutation.rs
@@ -7,6 +7,7 @@ use crate::services::server_runtime_context::ServerRuntimeContext;
 use crate::services::settings_service::{SettingsService, ValidatorRegistry};
 use rustok_api::{Permission, graphql::GraphQLError, has_effective_permission};
 
+use super::require_tenant_settings_scope;
 use super::types::{
     UpdateEventDeliveryConfigurationInput, UpdateEventDeliveryConfigurationPayload,
     UpdateIggyConnectorConfigurationInput, UpdateIggyConnectorConfigurationPayload,
@@ -102,6 +103,7 @@ impl SettingsMutation {
             .data::<AuthContext>()
             .map_err(|_| <FieldError as GraphQLError>::unauthenticated())?;
         let tenant = ctx.data::<TenantContext>()?;
+        require_tenant_settings_scope(auth, tenant.id)?;
 
         if !has_effective_permission(&auth.permissions, &Permission::SETTINGS_MANAGE) {
             return Err(<FieldError as GraphQLError>::permission_denied(

--- a/apps/server/src/graphql/settings/query.rs
+++ b/apps/server/src/graphql/settings/query.rs
@@ -5,6 +5,7 @@ use crate::services::server_runtime_context::ServerRuntimeContext;
 use crate::services::settings_service::SettingsService;
 use rustok_api::{Permission, graphql::GraphQLError, has_effective_permission};
 
+use super::require_tenant_settings_scope;
 use super::types::{
     EventDeliveryConfigurationPayload, IggyConnectorConfigurationPayload, PlatformSettingsPayload,
 };
@@ -82,6 +83,7 @@ impl SettingsQuery {
             .data::<AuthContext>()
             .map_err(|_| <FieldError as GraphQLError>::unauthenticated())?;
         let tenant = ctx.data::<TenantContext>()?;
+        require_tenant_settings_scope(auth, tenant.id)?;
 
         if !has_effective_permission(&auth.permissions, &Permission::SETTINGS_READ) {
             return Err(<FieldError as GraphQLError>::permission_denied(
@@ -110,6 +112,7 @@ impl SettingsQuery {
             .data::<AuthContext>()
             .map_err(|_| <FieldError as GraphQLError>::unauthenticated())?;
         let tenant = ctx.data::<TenantContext>()?;
+        require_tenant_settings_scope(auth, tenant.id)?;
 
         if !has_effective_permission(&auth.permissions, &Permission::SETTINGS_READ) {
             return Err(<FieldError as GraphQLError>::permission_denied(

--- a/scripts/verify/verify-server-platform-settings-tenant-scope.mjs
+++ b/scripts/verify/verify-server-platform-settings-tenant-scope.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const moduleSource = read('apps/server/src/graphql/settings/mod.rs');
+const querySource = read('apps/server/src/graphql/settings/query.rs');
+const mutationSource = read('apps/server/src/graphql/settings/mutation.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = end ? content.indexOf(end, startIndex + start.length) : content.length;
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+const requireOrder = (content, values, label) => {
+  let cursor = -1;
+  for (const value of values) {
+    const next = content.indexOf(value, cursor + 1);
+    if (next < 0 || next <= cursor) {
+      failures.push(`${label}: expected ordered marker ${value}`);
+      return;
+    }
+    cursor = next;
+  }
+};
+
+for (const [value, label] of [
+  ['fn require_tenant_settings_scope(', 'shared tenant scope helper'],
+  ['if auth.tenant_id == resolved_tenant_id', 'tenant equality'],
+  ['Settings access is denied', 'static public denial'],
+  ['settings.tenant_scope_mismatch', 'stable diagnostic code'],
+  ['auth_tenant_id = %auth.tenant_id', 'authenticated tenant diagnostic'],
+  ['resolved_tenant_id = %resolved_tenant_id', 'resolved tenant diagnostic'],
+  ['boundary = "server_settings_graphql"', 'GraphQL boundary diagnostic'],
+]) {
+  requireText(moduleSource, value, label);
+}
+
+const platformSettings = between(
+  querySource,
+  'async fn platform_settings(',
+  'async fn all_platform_settings(',
+  'platform settings query',
+);
+const allPlatformSettings = between(
+  querySource,
+  'async fn all_platform_settings(',
+  null,
+  'all platform settings query',
+);
+const updatePlatformSettings = between(
+  mutationSource,
+  'async fn update_platform_settings(',
+  null,
+  'update platform settings mutation',
+);
+
+requireOrder(
+  platformSettings,
+  [
+    'ctx.data::<TenantContext>()?',
+    'require_tenant_settings_scope(auth, tenant.id)?;',
+    'has_effective_permission(&auth.permissions, &Permission::SETTINGS_READ)',
+    'SettingsService::get(runtime_ctx, tenant.id, &category)',
+  ],
+  'single-category settings read',
+);
+requireOrder(
+  allPlatformSettings,
+  [
+    'ctx.data::<TenantContext>()?',
+    'require_tenant_settings_scope(auth, tenant.id)?;',
+    'has_effective_permission(&auth.permissions, &Permission::SETTINGS_READ)',
+    'SettingsService::get_all(runtime_ctx, tenant.id)',
+  ],
+  'all settings read',
+);
+requireOrder(
+  updatePlatformSettings,
+  [
+    'ctx.data::<TenantContext>()?',
+    'require_tenant_settings_scope(auth, tenant.id)?;',
+    'has_effective_permission(&auth.permissions, &Permission::SETTINGS_MANAGE)',
+    'SettingsService::update(',
+    'event_bus',
+    '.publish(',
+  ],
+  'settings write and event publication',
+);
+
+const queryCalls = querySource.match(/require_tenant_settings_scope\(auth, tenant\.id\)\?;/g) ?? [];
+const mutationCalls = mutationSource.match(/require_tenant_settings_scope\(auth, tenant\.id\)\?;/g) ?? [];
+if (queryCalls.length !== 2 || mutationCalls.length !== 1) {
+  failures.push(
+    `expected two scoped tenant settings queries and one scoped mutation; found ${queryCalls.length}/${mutationCalls.length}`,
+  );
+}
+
+for (const [content, name] of [
+  [between(querySource, 'async fn iggy_connector_configuration(', 'async fn event_delivery_configuration(', 'Iggy query'), 'Iggy connector query'],
+  [between(querySource, 'async fn event_delivery_configuration(', 'async fn platform_settings(', 'event query'), 'event delivery query'],
+  [between(mutationSource, 'async fn update_iggy_connector_configuration(', 'async fn update_event_delivery_configuration(', 'Iggy mutation'), 'Iggy connector mutation'],
+  [between(mutationSource, 'async fn update_event_delivery_configuration(', 'async fn update_platform_settings(', 'event mutation'), 'event delivery mutation'],
+]) {
+  if (content.includes('require_tenant_settings_scope(')) {
+    failures.push(`${name}: host-global resource must not be disguised as tenant-owned`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Server platform settings tenant-scope verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Tenant platform-settings GraphQL reads/writes bind authority before storage and events; host-global controls remain separate',
+);


### PR DESCRIPTION
## Summary

Tenant-owned platform settings GraphQL used authenticated permissions from `AuthContext` with a separately resolved `TenantContext` but did not require the tenant identities to match.

This affected:

- `platform_settings`;
- `all_platform_settings`;
- `update_platform_settings`, including its `PlatformSettingsChanged` publication.

Authority issued for tenant A could read or mutate settings and publish a settings event for routed tenant B.

## P0 fix

- add one shared `require_tenant_settings_scope` GraphQL guard;
- require tenant equality before `SETTINGS_READ` / `SETTINGS_MANAGE`;
- place the guard before storage reads, storage writes and event publication;
- return static `Settings access is denied` on mismatch;
- retain both tenant ids only in structured diagnostics with code `settings.tenant_scope_mismatch`.

## Host-global separation

Iggy connector and event-delivery configuration are singleton/process-global resources. They intentionally do not receive this tenant guard; their missing typed host-global authority is tracked in P0 issue #2680, including the newly confirmed settings GraphQL query/mutation surfaces.

## Regression evidence

`scripts/verify/verify-server-platform-settings-tenant-scope.mjs` locks three scoped endpoints, equality-before-permission/storage/event ordering, and forbids disguising the four host-global controls as tenant-owned.

No workflow, settings schema, validation, event payload or public settings response changes.