### PR TITLE
fix(search): bind GraphQL manage authority to routed tenant

### DIFF
--- a/crates/rustok-search/src/graphql/mod.rs
+++ b/crates/rustok-search/src/graphql/mod.rs
@@ -12,3 +12,36 @@ pub use rate_limit::{
     SearchGraphqlRateLimiterHandle,
 };
 pub use types::*;
+
+async fn ensure_search_admin_permission(
+    ctx: &async_graphql::Context<'_>,
+    permission: &rustok_api::Permission,
+) -> async_graphql::Result<()> {
+    use rustok_api::graphql::GraphQLError;
+
+    let auth = ctx
+        .data::<rustok_api::AuthContext>()
+        .map_err(|_| <async_graphql::FieldError as GraphQLError>::unauthenticated())?;
+    let tenant = ctx.data::<rustok_api::TenantContext>()?;
+
+    if auth.tenant_id != tenant.id {
+        tracing::warn!(
+            auth_tenant_id = %auth.tenant_id,
+            resolved_tenant_id = %tenant.id,
+            code = "search.graphql_tenant_scope_mismatch",
+            boundary = "search_graphql_admin",
+            "Search GraphQL admin authority cannot cross the resolved tenant boundary"
+        );
+        return Err(<async_graphql::FieldError as GraphQLError>::permission_denied(
+            "Search administration access is denied",
+        ));
+    }
+
+    if !rustok_api::has_effective_permission(&auth.permissions, permission) {
+        return Err(<async_graphql::FieldError as GraphQLError>::permission_denied(
+            format!("{} required", permission.as_str()),
+        ));
+    }
+
+    Ok(())
+}

--- a/crates/rustok-search/src/graphql/mutation.rs
+++ b/crates/rustok-search/src/graphql/mutation.rs
@@ -7,9 +7,7 @@ use crate::{
     SearchAnalyticsService, SearchClickRecord, SearchDictionaryService, SearchEngineKind,
     SearchModule, SearchSettingsService,
 };
-use rustok_api::{
-    AuthContext, Permission, TenantContext, graphql::GraphQLError, has_effective_permission,
-};
+use rustok_api::{AuthContext, Permission, TenantContext, graphql::GraphQLError};
 use rustok_events::DomainEvent;
 use rustok_telemetry::metrics;
 
@@ -337,17 +335,7 @@ impl SearchMutationRoot {
 }
 
 async fn ensure_settings_manage_permission(ctx: &Context<'_>) -> Result<()> {
-    let auth = ctx
-        .data::<AuthContext>()
-        .map_err(|_| <FieldError as GraphQLError>::unauthenticated())?;
-
-    if !has_effective_permission(&auth.permissions, &Permission::SETTINGS_MANAGE) {
-        return Err(<FieldError as GraphQLError>::permission_denied(
-            "settings:manage required",
-        ));
-    }
-
-    Ok(())
+    super::ensure_search_admin_permission(ctx, &Permission::SETTINGS_MANAGE).await
 }
 
 fn parse_optional_uuid(value: Option<&str>) -> Result<Option<Uuid>> {

--- a/scripts/verify/verify-search-graphql-mutation-tenant-scope.mjs
+++ b/scripts/verify/verify-search-graphql-mutation-tenant-scope.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const moduleSource = read('crates/rustok-search/src/graphql/mod.rs');
+const mutationSource = read('crates/rustok-search/src/graphql/mutation.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+
+for (const [value, label] of [
+  ['async fn ensure_search_admin_permission(', 'shared admin permission helper'],
+  ['ctx.data::<rustok_api::AuthContext>()', 'authenticated context'],
+  ['ctx.data::<rustok_api::TenantContext>()?', 'resolved tenant context'],
+  ['if auth.tenant_id != tenant.id', 'tenant equality'],
+  ['Search administration access is denied', 'static public denial'],
+  ['search.graphql_tenant_scope_mismatch', 'stable diagnostic code'],
+  ['auth_tenant_id = %auth.tenant_id', 'authenticated tenant diagnostic'],
+  ['resolved_tenant_id = %tenant.id', 'resolved tenant diagnostic'],
+  ['boundary = "search_graphql_admin"', 'GraphQL boundary diagnostic'],
+]) {
+  requireText(moduleSource, value, label);
+}
+
+const tenantCheck = moduleSource.indexOf('if auth.tenant_id != tenant.id');
+const permissionCheck = moduleSource.indexOf(
+  'has_effective_permission(&auth.permissions, permission)',
+);
+if (tenantCheck < 0 || permissionCheck < 0 || tenantCheck >= permissionCheck) {
+  failures.push('tenant equality must precede Search permission admission');
+}
+
+requireText(
+  mutationSource,
+  'super::ensure_search_admin_permission(ctx, &Permission::SETTINGS_MANAGE).await',
+  'scoped manage helper delegation',
+);
+const manageCalls = mutationSource.match(/ensure_settings_manage_permission\(ctx\)\.await\?;/g) ?? [];
+if (manageCalls.length !== 8) {
+  failures.push(`expected eight authenticated Search manage mutations, found ${manageCalls.length}`);
+}
+
+for (const [value, label] of [
+  ['async fn track_search_click(', 'public click analytics endpoint'],
+  ['SearchAnalyticsService::record_click(', 'click analytics write'],
+  ['tenant_id: tenant.id', 'click tenant scope'],
+]) {
+  requireText(mutationSource, value, label);
+}
+const trackStart = mutationSource.indexOf('async fn track_search_click(');
+const firstManage = mutationSource.indexOf('async fn upsert_search_synonym(');
+const trackBlock = mutationSource.slice(trackStart, firstManage);
+if (trackBlock.includes('ensure_settings_manage_permission(')) {
+  failures.push('track_search_click must not be disguised as an admin manage endpoint');
+}
+
+if (mutationSource.includes('has_effective_permission(&auth.permissions')) {
+  failures.push('mutation-local permission-only admission must not bypass the shared scope helper');
+}
+
+if (failures.length > 0) {
+  console.error('Search GraphQL mutation tenant-scope verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ All eight Search GraphQL manage mutations bind authenticated authority to the resolved tenant',
+);


### PR DESCRIPTION
## Summary

All eight authenticated Search GraphQL manage mutations admitted `SETTINGS_MANAGE` from `AuthContext` before using a separately resolved `TenantContext` for dictionaries, settings, rebuild events and audit events.

Authority issued for tenant A could therefore mutate Search state or publish Search events for routed tenant B.

## P0 fix

- add one shared Search GraphQL admin permission helper;
- require `AuthContext.tenant_id == TenantContext.id` before permission admission;
- delegate the mutation-local `SETTINGS_MANAGE` helper to the scoped primitive;
- return static `Search administration access is denied` on mismatch;
- retain both tenant ids only in structured diagnostics with code `search.graphql_tenant_scope_mismatch`;
- preserve all eight mutation operations and requested-tenant override checks.

`track_search_click` remains outside the admin manage contract and continues to write only under the routed tenant.

## Regression evidence

`scripts/verify/verify-search-graphql-mutation-tenant-scope.mjs` locks the shared equality-before-permission order, exactly eight manage call sites, removal of mutation-local permission-only admission, and the separate click analytics contract.

The ten read queries use the same permission-only pattern and remain the next focused follow-up; this PR closes the write/event P0 without waiting on the much larger query file replacement.

No workflow, schema, event payload, ranking, dictionary or public mutation-shape changes.