### PR TITLE
fix(payment): sanitize local execution PortError diagnostics

### DIFF
--- a/crates/rustok-payment/contracts/evidence/checkout-execution-local-porterror-diagnostic-safety-source.json
+++ b/crates/rustok-payment/contracts/evidence/checkout-execution-local-porterror-diagnostic-safety-source.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": 1,
+  "status": "payment_checkout_execution_local_porterror_diagnostic_safety_source_reviewed_unvalidated",
+  "owner": "rustok-payment",
+  "boundary": "checkout_payment_execution_port",
+  "scope": "final local PortError mapper across prepare, authorize, capture, and read operations",
+  "source_contract": {
+    "operation_count": 4,
+    "diagnostic_helper_added": true,
+    "complete_port_error_logged": false,
+    "port_error_message_text_logged": false,
+    "stable_error_code_logged": true,
+    "static_error_kind_logged": true,
+    "retryability_logged": true,
+    "message_shape_only": true,
+    "context_shape_preserved": true,
+    "identity_shape_preserved": true,
+    "original_port_error_returned": true,
+    "public_port_error_contract_changed": false,
+    "payment_lifecycle_changed": false,
+    "provider_execution_changed": false,
+    "admission_diagnostics_changed": false,
+    "owner_payment_error_diagnostics_changed": false,
+    "provider_checkpoint_diagnostics_changed": false,
+    "remaining_payment_execution_diagnostics_open": true,
+    "broad_ecommerce_cleanup_closed": false
+  },
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "notes": [
+    "The final local mapper still classifies technical failures for error severity and other outcomes for warning severity.",
+    "The stable PortError code and retryability remain available to diagnostics.",
+    "The complete PortError and its message text are replaced by a static error-kind label plus message presence and character length.",
+    "All four port methods still return the exact mapper result, and the mapper still returns the original PortError unchanged.",
+    "Admission, owner PaymentError, serde/UUID, local persistence, and provider checkpoint diagnostics remain outside this source slice and are still open.",
+    "No FFA or FBA status is promoted from source inspection."
+  ]
+}

--- a/crates/rustok-payment/docs/checkout-execution-local-porterror-diagnostic-safety.md
+++ b/crates/rustok-payment/docs/checkout-execution-local-porterror-diagnostic-safety.md
@@ -1,0 +1,77 @@
+# Checkout payment execution local PortError diagnostic safety
+
+Status: **source-ready / unvalidated**
+
+## Boundary
+
+`CheckoutPaymentExecutionPort` exposes four operations through the in-process payment
+owner adapter:
+
+- prepare a checkout payment collection;
+- authorize the collection;
+- capture the collection;
+- read the collection for recovery.
+
+Each operation already created bounded request and `PortContext` diagnostic facts before
+calling the local implementation. The final local mapper preserved the returned
+`PortError`, but both its warning and error events also recorded the complete error and
+its message text.
+
+Although technical `PortError` messages are sanitized at construction and serde
+boundaries, the mapper also handles validation, not-found, conflict, forbidden, and
+other owner-local outcomes. A complete compatibility envelope is not required for
+operator correlation and must not become a diagnostic payload.
+
+## Private diagnostics
+
+The final local mapper now records only:
+
+- stable error code;
+- static error-kind label;
+- retryability;
+- error-message presence and character length;
+- owner operation and local operation;
+- correlation ID;
+- existing bounded context and checkout identity facts.
+
+It does not record the complete `PortError` or its message text.
+
+## Preserved behavior
+
+This source slice does not change:
+
+- the four public port methods or their signatures;
+- admission, tenant, causation, deadline, or idempotency enforcement;
+- payment collection validation or typed lifecycle policy;
+- provider selection, authorization, capture, journal, or recovery behavior;
+- stable `PortError` codes, kinds, messages, or retryability;
+- warning versus error severity selection;
+- passthrough of unrecognized local error codes;
+- return of the original `PortError` from the mapper.
+
+## Remaining payment execution diagnostics
+
+This is intentionally one bounded sub-slice. Separate cleanup remains open for:
+
+- admission rejection diagnostics;
+- complete owner `PaymentError` diagnostics;
+- UUID and serde error diagnostics;
+- local persistence and provider checkpoint diagnostics;
+- manual-reconciliation reason text.
+
+The canonical ecommerce mapper-cleanup item therefore remains open.
+
+## Evidence
+
+- `contracts/evidence/checkout-execution-local-porterror-diagnostic-safety-source.json`
+- `scripts/verify/verify-payment-checkout-execution-local-porterror-diagnostic-safety.mjs`
+
+## Validation still required
+
+Per maintainer instruction, no tests, Node verifiers, Cargo commands, formatting,
+workflows, or CI were run. Maintainer validation should include the focused verifier,
+payment owner tests, ecommerce aggregate guards, compilation, and injected failures for
+all four operations.
+
+No payment FFA/FBA, transport, runtime, workflow, CI, or production status is promoted
+from this source review.

--- a/crates/rustok-payment/src/checkout_execution/diagnostic_safety.rs
+++ b/crates/rustok-payment/src/checkout_execution/diagnostic_safety.rs
@@ -56,6 +56,32 @@ fn checkout_payment_execution_context_facts(
 }
 
 #[derive(Debug)]
+struct CheckoutPaymentExecutionPortErrorFacts {
+    error_kind: &'static str,
+    message_present: bool,
+    message_length: usize,
+}
+
+fn checkout_payment_execution_port_error_facts(
+    error: &PortError,
+) -> CheckoutPaymentExecutionPortErrorFacts {
+    let error_kind = match &error.kind {
+        PortErrorKind::Validation => "validation",
+        PortErrorKind::NotFound => "not_found",
+        PortErrorKind::Conflict => "conflict",
+        PortErrorKind::Forbidden => "forbidden",
+        PortErrorKind::Unavailable => "unavailable",
+        PortErrorKind::Timeout => "timeout",
+        PortErrorKind::InvariantViolation => "invariant_violation",
+    };
+    CheckoutPaymentExecutionPortErrorFacts {
+        error_kind,
+        message_present: !error.message.trim().is_empty(),
+        message_length: error.message.chars().count(),
+    }
+}
+
+#[derive(Debug)]
 struct CheckoutPaymentExecutionDiagnosticFacts {
     checkout_operation_id_non_nil: bool,
     cart_id_non_nil: bool,

--- a/crates/rustok-payment/src/checkout_execution/port_impl.rs
+++ b/crates/rustok-payment/src/checkout_execution/port_impl.rs
@@ -173,9 +173,9 @@ fn map_checkout_payment_execution_local_port_error(
             PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation
         );
     let context_facts = checkout_payment_execution_context_facts(context);
+    let error_facts = checkout_payment_execution_port_error_facts(&error);
     if technical_failure {
         tracing::error!(
-            error = ?error,
             owner = "rustok_payment",
             operation,
             local_operation,
@@ -210,15 +210,15 @@ fn map_checkout_payment_execution_local_port_error(
             provider_payment_id_present = facts.provider_payment_id_present,
             provider_payment_id_length = ?facts.provider_payment_id_length,
             internal_code = %error.code,
-            internal_message = %error.message,
-            error_kind = ?error.kind,
+            error_message_present = error_facts.message_present,
+            error_message_length = error_facts.message_length,
+            error_kind = error_facts.error_kind,
             retryable = error.retryable,
             boundary = PAYMENT_EXECUTION_BOUNDARY,
             "payment checkout execution local technical outcome retained safe context"
         );
     } else {
         tracing::warn!(
-            error = ?error,
             owner = "rustok_payment",
             operation,
             local_operation,
@@ -253,8 +253,9 @@ fn map_checkout_payment_execution_local_port_error(
             provider_payment_id_present = facts.provider_payment_id_present,
             provider_payment_id_length = ?facts.provider_payment_id_length,
             internal_code = %error.code,
-            internal_message = %error.message,
-            error_kind = ?error.kind,
+            error_message_present = error_facts.message_present,
+            error_message_length = error_facts.message_length,
+            error_kind = error_facts.error_kind,
             retryable = error.retryable,
             boundary = PAYMENT_EXECUTION_BOUNDARY,
             "payment checkout execution local outcome retained safe context"

--- a/scripts/verify/verify-payment-checkout-execution-local-porterror-diagnostic-safety.mjs
+++ b/scripts/verify/verify-payment-checkout-execution-local-porterror-diagnostic-safety.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const requireCount = (source, value, expected, label) => {
+  const count = source.split(value).length - 1;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+};
+
+function functionBody(source, functionName) {
+  const signature = new RegExp(
+    `(?:pub(?:\\([^)]*\\))?\\s+)?(?:async\\s+)?fn\\s+${functionName}(?:<[^>]*>)?\\s*\\(`,
+  );
+  const match = signature.exec(source);
+  if (!match) {
+    failures.push(`missing function ${functionName}`);
+    return "";
+  }
+  const openBrace = source.indexOf("{", match.index);
+  if (openBrace < 0) {
+    failures.push(`missing body for ${functionName}`);
+    return "";
+  }
+  let depth = 0;
+  for (let index = openBrace; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(openBrace, index + 1);
+    }
+  }
+  failures.push(`unterminated body for ${functionName}`);
+  return "";
+}
+
+const paths = {
+  root: "crates/rustok-payment/src/checkout_execution.rs",
+  diagnostics:
+    "crates/rustok-payment/src/checkout_execution/diagnostic_safety.rs",
+  portImpl: "crates/rustok-payment/src/checkout_execution/port_impl.rs",
+  evidence:
+    "crates/rustok-payment/contracts/evidence/checkout-execution-local-porterror-diagnostic-safety-source.json",
+  doc:
+    "crates/rustok-payment/docs/checkout-execution-local-porterror-diagnostic-safety.md",
+  plan: "crates/rustok-commerce/docs/implementation-plan.md",
+};
+
+const rootSource = read(paths.root);
+const diagnostics = read(paths.diagnostics);
+const portImpl = read(paths.portImpl);
+const evidence = JSON.parse(read(paths.evidence));
+const doc = read(paths.doc);
+const plan = read(paths.plan);
+
+for (const marker of [
+  'include!("checkout_execution/diagnostic_safety.rs");',
+  'include!("checkout_execution/port_impl.rs");',
+  'const PREPARE_CHECKOUT_COLLECTION_OPERATION: &str = "prepare_checkout_collection"',
+  'const AUTHORIZE_CHECKOUT_COLLECTION_OPERATION: &str = "authorize_checkout_collection"',
+  'const CAPTURE_CHECKOUT_COLLECTION_OPERATION: &str = "capture_checkout_collection"',
+  'const READ_CHECKOUT_COLLECTION_OPERATION: &str = "read_checkout_collection"',
+]) {
+  requireText(rootSource, marker, `${paths.root}: preserved execution composition`);
+}
+
+for (const marker of [
+  "struct CheckoutPaymentExecutionPortErrorFacts",
+  "error_kind: &'static str",
+  "message_present: bool",
+  "message_length: usize",
+  "fn checkout_payment_execution_port_error_facts(",
+  'PortErrorKind::Validation => "validation"',
+  'PortErrorKind::NotFound => "not_found"',
+  'PortErrorKind::Conflict => "conflict"',
+  'PortErrorKind::Forbidden => "forbidden"',
+  'PortErrorKind::Unavailable => "unavailable"',
+  'PortErrorKind::Timeout => "timeout"',
+  'PortErrorKind::InvariantViolation => "invariant_violation"',
+  "message_present: !error.message.trim().is_empty()",
+  "message_length: error.message.chars().count()",
+]) {
+  requireText(diagnostics, marker, `${paths.diagnostics}: PortError shape policy`);
+}
+
+const mapper = functionBody(
+  portImpl,
+  "map_checkout_payment_execution_local_port_error",
+);
+for (const marker of [
+  "checkout_payment_execution_local_operation(operation, error.code.as_str())",
+  "let error_facts = checkout_payment_execution_port_error_facts(&error);",
+  "internal_code = %error.code",
+  "error_message_present = error_facts.message_present",
+  "error_message_length = error_facts.message_length",
+  "error_kind = error_facts.error_kind",
+  "retryable = error.retryable",
+  "boundary = PAYMENT_EXECUTION_BOUNDARY",
+  '"payment checkout execution local technical outcome retained safe context"',
+  '"payment checkout execution local outcome retained safe context"',
+]) {
+  requireText(mapper, marker, `${paths.portImpl}: safe final local mapper`);
+}
+for (const forbidden of [
+  "error = ?error",
+  "error = %error",
+  "internal_message = %error.message",
+  "internal_message = ?error.message",
+  "message = %error.message",
+  "message = ?error.message",
+  "error_kind = ?error.kind",
+  "error_kind = %error.kind",
+  "error.to_string()",
+]) {
+  forbidText(mapper, forbidden, `${paths.portImpl}: complete PortError diagnostics`);
+}
+requireCount(
+  mapper,
+  "error_message_present = error_facts.message_present",
+  2,
+  `${paths.portImpl}: warning and error message-presence facts`,
+);
+requireCount(
+  mapper,
+  "error_message_length = error_facts.message_length",
+  2,
+  `${paths.portImpl}: warning and error message-length facts`,
+);
+requireCount(
+  mapper,
+  "error_kind = error_facts.error_kind",
+  2,
+  `${paths.portImpl}: warning and error static kind facts`,
+);
+requireCount(
+  mapper,
+  "internal_code = %error.code",
+  2,
+  `${paths.portImpl}: stable code diagnostics`,
+);
+requireCount(
+  mapper,
+  "retryable = error.retryable",
+  2,
+  `${paths.portImpl}: retry policy diagnostics`,
+);
+requireText(mapper, "return error;", `${paths.portImpl}: unknown-code passthrough`);
+if (!mapper.trimEnd().endsWith("error\n}")) {
+  failures.push(`${paths.portImpl}: mapper must return the original PortError`);
+}
+
+requireCount(
+  portImpl,
+  "map_checkout_payment_execution_local_port_error(",
+  5,
+  `${paths.portImpl}: four callsites plus mapper definition`,
+);
+requireCount(
+  portImpl,
+  "result.map_err(|error|",
+  4,
+  `${paths.portImpl}: all four final mappings`,
+);
+for (const operation of [
+  "prepare_checkout_collection",
+  "authorize_checkout_collection",
+  "capture_checkout_collection",
+  "read_checkout_collection",
+]) {
+  requireText(portImpl, `async fn ${operation}(`, `${paths.portImpl}: ${operation}`);
+}
+
+if (
+  evidence.status !==
+  "payment_checkout_execution_local_porterror_diagnostic_safety_source_reviewed_unvalidated"
+) {
+  failures.push(`${paths.evidence}: unexpected status ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  operation_count: 4,
+  diagnostic_helper_added: true,
+  complete_port_error_logged: false,
+  port_error_message_text_logged: false,
+  stable_error_code_logged: true,
+  static_error_kind_logged: true,
+  retryability_logged: true,
+  message_shape_only: true,
+  context_shape_preserved: true,
+  identity_shape_preserved: true,
+  original_port_error_returned: true,
+  public_port_error_contract_changed: false,
+  payment_lifecycle_changed: false,
+  provider_execution_changed: false,
+  admission_diagnostics_changed: false,
+  owner_payment_error_diagnostics_changed: false,
+  provider_checkpoint_diagnostics_changed: false,
+  remaining_payment_execution_diagnostics_open: true,
+  broad_ecommerce_cleanup_closed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "compile_proven",
+  "runtime_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+
+requireText(doc, "Status: **source-ready / unvalidated**", `${paths.doc}: status`);
+requireText(
+  doc,
+  "It does not record the complete `PortError` or its message text.",
+  `${paths.doc}: diagnostic policy`,
+);
+requireText(
+  doc,
+  "Remaining payment execution diagnostics",
+  `${paths.doc}: remaining bounded work`,
+);
+requireText(
+  plan,
+  "Finish correlation-safe mapper cleanup",
+  `${paths.plan}: broad ecommerce cleanup remains open`,
+);
+
+if (failures.length > 0) {
+  console.error(
+    "Payment checkout execution local PortError diagnostic-safety verification failed:",
+  );
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "Payment checkout execution final local PortError diagnostics retain only stable code, static kind, retryability, and message shape; execution evidence remains open",
+);


### PR DESCRIPTION
## Summary

- continue the open ecommerce correlation-safe mapper cleanup with the first bounded payment execution sub-slice
- replace complete final local `PortError` logging and message text with stable error code, static kind, retryability, and message presence/length
- preserve all existing bounded `PortContext` and checkout identity facts
- preserve prepare/authorize/capture/read signatures, final mapper call order, severity selection, unrecognized-code passthrough, and return of the original `PortError`
- add a focused source verifier, documentation, and reviewed-unvalidated evidence

## Confirmed gap

`map_checkout_payment_execution_local_port_error` used `error = ?error`, `internal_message = %error.message`, and `error_kind = ?error.kind` in both warning and error events. The complete compatibility envelope and actionable domain message were therefore copied into diagnostics even though only stable classification and shape are required for correlation.

## Scope boundary

Exactly five files change: two payment execution source files plus a new verifier, document, and evidence file. Admission rejection diagnostics, owner `PaymentError` mapping, UUID/serde diagnostics, local persistence/provider checkpoint diagnostics, provider execution, lifecycle policy, and public `PortError` behavior remain outside this PR and explicitly open.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-payment-checkout-execution-local-porterror-diagnostic-safety.mjs
cargo check -p rustok-payment --all-targets
```

## Branch state

The branch is based on current `main` at `73a8ce9338841be66146bfc45eab5881348cc7b0`, is one commit ahead and zero behind, and changes exactly five files. Head commit: `f615477267d0a6645047f64ab96ed966c17db1ae`. Squash merge is intended.