### PR TITLE
test(blog): retain dispatcher duplicate delivery replay

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-comments-dispatcher-duplicate-delivery.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-dispatcher-duplicate-delivery.json
@@ -24,15 +24,15 @@
     },
     {
       "name": "two_completed_dispatch_calls",
-      "expected": "an observing EventHandler wrapper records exactly two completed calls to the real module-registered projection handler"
+      "expected": "an observing EventHandler wrapper records exactly two completed calls and zero errors from the real module-registered projection handler"
     },
     {
       "name": "single_transactional_application",
-      "expected": "after both dispatches complete the post is count one/version two with one delivery-ledger row and one outbox row"
+      "expected": "after both successful dispatches complete the post is count one/version two with one delivery-ledger row and one outbox row"
     }
   ],
   "runtime_promotion_requirements": [
-    "execute the exact env-gated PostgreSQL command and retain two completed dispatcher calls plus final counter, delivery, and outbox assertions",
+    "execute the exact env-gated PostgreSQL command and retain two completed dispatcher calls, zero handler errors, and final counter, delivery, and outbox assertions",
     "retain concurrent same-envelope handler-race execution separately from this dispatcher replay target"
   ]
 }

--- a/crates/rustok-blog/contracts/evidence/blog-comments-dispatcher-duplicate-delivery.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-dispatcher-duplicate-delivery.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "module": "blog",
+  "surface": "comments_dispatcher_duplicate_delivery",
+  "status": "source_verified_no_compile",
+  "compile_policy": "not_run_by_request",
+  "runtime_status": "pending",
+  "owner": "rustok-blog",
+  "provider": "rustok-comments",
+  "harness": {
+    "status": "executable_no_run",
+    "runtime_status": "not_run",
+    "path": "crates/rustok-blog/tests/comment_projection_dispatcher_duplicate_postgres_test.rs",
+    "environment": "RUSTOK_BLOG_TEST_DATABASE_URL",
+    "command": "RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_dispatcher_duplicate_postgres_test event_dispatcher_replays_duplicate_envelope_without_double_commit -- --exact",
+    "isolation": "unique_schema_one_connection_pool_module_registered_handler_observed_two_dispatches",
+    "scope": "same_envelope_published_twice_through_event_bus_dispatcher_single_projection_commit",
+    "non_claim": "does_not_record_postgresql_execution_or_concurrent_duplicate_race"
+  },
+  "cases": [
+    {
+      "name": "module_registered_handler_routed_twice",
+      "expected": "BlogModule registers one blog_comment_projection handler and the same envelope is published twice through EventBus and EventDispatcher"
+    },
+    {
+      "name": "two_completed_dispatch_calls",
+      "expected": "an observing EventHandler wrapper records exactly two completed calls to the real module-registered projection handler"
+    },
+    {
+      "name": "single_transactional_application",
+      "expected": "after both dispatches complete the post is count one/version two with one delivery-ledger row and one outbox row"
+    }
+  ],
+  "runtime_promotion_requirements": [
+    "execute the exact env-gated PostgreSQL command and retain two completed dispatcher calls plus final counter, delivery, and outbox assertions",
+    "retain concurrent same-envelope handler-race execution separately from this dispatcher replay target"
+  ]
+}

--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -194,8 +194,9 @@ The retained dispatcher duplicate-delivery target is
 `crates/rustok-blog/tests/comment_projection_dispatcher_duplicate_postgres_test.rs`.
 It registers the real projection handler through
 `BlogModule::register_event_listeners`, wraps that handler only to count completed
-calls, publishes the same envelope twice through `EventBus` and `EventDispatcher`,
-and waits for both handler calls to finish. The written assertions require final
+calls and errors, publishes the same envelope twice through `EventBus` and
+`EventDispatcher`, and waits for both handler calls to finish. The written
+assertions require two completed calls, zero handler errors, final
 `comment_count = 1` and `version = 2`, one delivery row, and one outbox row.
 Evidence schema v1 is retained at
 `crates/rustok-blog/contracts/evidence/blog-comments-dispatcher-duplicate-delivery.json`,
@@ -206,9 +207,10 @@ fixture
 suggested command is
 `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_dispatcher_duplicate_postgres_test event_dispatcher_replays_duplicate_envelope_without_double_commit -- --exact`.
 This closes the source-only dispatcher-level duplicate delivery gap without
-claiming PostgreSQL execution or the separate concurrent handler race. The target
-and standalone guard are `source_verified_no_compile` / `executable_no_run` and
-are not added to registry-owned package order in Slice 56.
+claiming PostgreSQL execution or the separate concurrent handler race. The
+retained evidence remains `source_verified_no_compile`, the target is
+`executable_no_run`, and the standalone guard is not added to registry-owned
+package order in Slice 56.
 
 The retained PostgreSQL target is
 `crates/rustok-blog/tests/comment_projection_postgres_test.rs`. It uses
@@ -506,13 +508,14 @@ module-registered handler calls completed before final cardinality assertions.
 
 Slice 56 adds the env-gated
 `event_dispatcher_replays_duplicate_envelope_without_double_commit` target. It
-wraps the real module-registered handler only with a completed-call counter,
+wraps the real module-registered handler with completed-call and error counters,
 publishes one envelope identity twice through the dispatcher, waits for exactly
-two completed calls, and requires one post transition, one delivery row, and one
-outbox row. New schema-v1 evidence, a standalone fail-closed verifier, and focused
-negative fixtures retain the dispatcher-level duplicate delivery contract. Blog
-registry schema v13 and package order remain unchanged; no Rust, JavaScript,
-PostgreSQL, browser, workflow, CI, or production execution is recorded.
+two completed calls with zero errors, and requires one post transition, one
+delivery row, and one outbox row. New schema-v1 evidence, a standalone fail-closed
+verifier, and focused negative fixtures retain the dispatcher-level duplicate
+delivery contract. Blog registry schema v13 and package order remain unchanged;
+no Rust, JavaScript, PostgreSQL, browser, workflow, CI, or production execution is
+recorded.
 
 ## FFA/FBA status
 
@@ -550,10 +553,10 @@ PostgreSQL, browser, workflow, CI, or production execution is recorded.
   loser rolls back before clean replay. Its exact npm leaf commands and position
   immediately after the main projection gate are locked. Separate schema-v1
   evidence and a standalone fail-closed guard retain dispatcher replay of the same
-  envelope twice with two completed handler calls and one database application.
-  None of these targets has been run. Naturally contended PostgreSQL retry
-  frequency, full server-host restart recovery, and all execution evidence remain
-  pending.
+  envelope twice with two completed handler calls, zero errors, and one database
+  application. None of these targets has been run. Naturally contended PostgreSQL
+  retry frequency, full server-host restart recovery, and all execution evidence
+  remain pending.
 - Load protection: `implementation_ready`; mounted Redis evidence is pending.
 - Rate-limit harness: `executable_no_compile`; evidence, verifier, self-test,
   npm leaf commands, and aggregate FBA registration are locked; execution is
@@ -782,10 +785,11 @@ PostgreSQL, browser, workflow, CI, or production execution is recorded.
     PostgreSQL target in registry schema v13, and locked aggregate verify/test
     order without changing runtime code or recording execution.
 56. Added an env-gated dispatcher duplicate-delivery target that routes the same
-    envelope twice through the module-registered handler, observes both completed
-    calls, and retains one counter/delivery/outbox application in schema-v1
-    evidence plus a standalone verifier and focused negative fixture without
-    changing registry package order or recording execution.
+    envelope twice through the module-registered handler, observes two successful
+    completed calls with zero errors, and retains one counter/delivery/outbox
+    application in schema-v1 evidence plus a standalone verifier and focused
+    negative fixture without changing registry package order or recording
+    execution.
 
 ## Next results
 
@@ -818,17 +822,17 @@ PostgreSQL, browser, workflow, CI, or production execution is recorded.
    concurrency targets, and concurrent PostgreSQL create/delete transactions.
    Retain deterministic immediate-success/seven-retry/eighth-limit output, the
    deterministic eight-zero-row terminal error, rollback and same-envelope
-   recovery output, two completed dispatcher duplicate calls with one database
-   application, both blocked duplicate workers, the one-winner/one-loser outcome,
-   final single delivery/outbox cardinality, clean duplicate replay, dispatcher
-   delivery output, four-connection convergence, both child process exits, the
-   written duplicate, delete-before-create, missing-post replay, outbox
-   rollback/retry, and same-process/new-connection assertions; then retain
-   naturally contended PostgreSQL retry-frequency evidence, full server-host
-   restart recovery, remote adapter parity, browser parity for typed
-   unavailable/timeout article rendering, cached thread snapshots, comment-form
-   fallback, approved-only reads, moderation, pagination, first-thread identity,
-   and unrelated insert storage error propagation.
+   recovery output, two successful completed dispatcher duplicate calls with zero
+   errors and one database application, both blocked duplicate workers, the
+   one-winner/one-loser outcome, final single delivery/outbox cardinality, clean
+   duplicate replay, dispatcher delivery output, four-connection convergence,
+   both child process exits, the written duplicate, delete-before-create,
+   missing-post replay, outbox rollback/retry, and same-process/new-connection
+   assertions; then retain naturally contended PostgreSQL retry-frequency
+   evidence, full server-host restart recovery, remote adapter parity, browser
+   parity for typed unavailable/timeout article rendering, cached thread
+   snapshots, comment-form fallback, approved-only reads, moderation, pagination,
+   first-thread identity, and unrelated insert storage error propagation.
 6. **Execute and retain Blog article richtext cutover evidence.** Run the offline
    backfill in default dry-run mode, review its report, apply accepted conversion,
    execute the irreversible migration, reindex/rollback Search, and retain
@@ -856,7 +860,7 @@ should run the relevant subset, including:
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_dispatcher_duplicate_postgres_test event_dispatcher_replays_duplicate_envelope_without_double_commit -- --exact`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test concurrent_created_events_converge_without_lost_updates -- --exact`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears -- --exact`
-- `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_duplicate_race_postgres_test concurrent_duplicate_envelope_commits_once_and_replays_after_conflict_clears -- --exact`
+- `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_duplicate_race_postgres_test concurrent_duplicate_envelope_commits_once_and_replays_cleanly -- --exact`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test restarted_process_reuses_delivery_ledger_without_reapplying_counter -- --exact`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test`

--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -189,6 +189,27 @@ after the main Comments event-projection leaf in both Blog FBA chains. The targe
 and focused guard remain `executable_no_run` / source-only; no PostgreSQL or
 dispatcher-level duplicate result is recorded.
 
+The retained dispatcher duplicate-delivery target is
+`event_dispatcher_replays_duplicate_envelope_without_double_commit` in
+`crates/rustok-blog/tests/comment_projection_dispatcher_duplicate_postgres_test.rs`.
+It registers the real projection handler through
+`BlogModule::register_event_listeners`, wraps that handler only to count completed
+calls, publishes the same envelope twice through `EventBus` and `EventDispatcher`,
+and waits for both handler calls to finish. The written assertions require final
+`comment_count = 1` and `version = 2`, one delivery row, and one outbox row.
+Evidence schema v1 is retained at
+`crates/rustok-blog/contracts/evidence/blog-comments-dispatcher-duplicate-delivery.json`,
+guarded by
+`scripts/verify/verify-blog-comments-dispatcher-duplicate-delivery.mjs` and focused
+fixture
+`scripts/verify/verify-blog-comments-dispatcher-duplicate-delivery.test.mjs`. Its
+suggested command is
+`RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_dispatcher_duplicate_postgres_test event_dispatcher_replays_duplicate_envelope_without_double_commit -- --exact`.
+This closes the source-only dispatcher-level duplicate delivery gap without
+claiming PostgreSQL execution or the separate concurrent handler race. The target
+and standalone guard are `source_verified_no_compile` / `executable_no_run` and
+are not added to registry-owned package order in Slice 56.
+
 The retained PostgreSQL target is
 `crates/rustok-blog/tests/comment_projection_postgres_test.rs`. It uses
 `RUSTOK_BLOG_TEST_DATABASE_URL` (or PostgreSQL `DATABASE_URL`), a unique schema,
@@ -226,12 +247,14 @@ Exact commands `verify:blog:comments-event-projection` /
 `test:verify:blog:comments-event-projection` and
 `verify:blog:comments-duplicate-delivery-race` /
 `test:verify:blog:comments-duplicate-delivery-race` run after the Comments port
-gate, with the duplicate-delivery leaf immediately after the main event-projection
-leaf. Overall status remains `source_verified_no_compile`; the deterministic retry
-policy, retry-limit target, and concurrent duplicate-delivery target are
-source-locked, while all target execution, naturally contended retry-frequency
-evidence, dispatcher-level duplicate delivery, full server-host restart recovery,
-and all other runtime evidence remain pending.
+gate, with the duplicate-delivery race leaf immediately after the main
+event-projection leaf. The dispatcher duplicate-delivery target is separately
+guarded and intentionally remains outside registry-owned package order in Slice
+56. Overall status remains `source_verified_no_compile`; the deterministic retry
+policy, retry-limit target, concurrent duplicate race, and dispatcher duplicate
+replay are source-locked, while all target execution, naturally contended
+retry-frequency evidence, full server-host restart recovery, and all other
+runtime evidence remain pending.
 
 Blog categories use the exclusive `blog_categories:*` permission resource.
 `CategoryService::new(db, event_bus)` is the only owner constructor. Category
@@ -474,6 +497,23 @@ policy and existing aggregate self-test fixture. Runtime code and the standalone
 verifier are unchanged. No Rust test, JavaScript verifier, compile, PostgreSQL,
 browser, workflow, CI, or production result is recorded.
 
+The continuation audit at `ee8ec47cc151b4215d96d467880a238752dde3f5`
+found that the real dispatcher path retained only one-envelope delivery, while
+duplicate replay was proven either directly against the handler or through the
+separate controlled race target. No retained source target published the same
+envelope twice through `EventBus` and `EventDispatcher` and also proved that both
+module-registered handler calls completed before final cardinality assertions.
+
+Slice 56 adds the env-gated
+`event_dispatcher_replays_duplicate_envelope_without_double_commit` target. It
+wraps the real module-registered handler only with a completed-call counter,
+publishes one envelope identity twice through the dispatcher, waits for exactly
+two completed calls, and requires one post transition, one delivery row, and one
+outbox row. New schema-v1 evidence, a standalone fail-closed verifier, and focused
+negative fixtures retain the dispatcher-level duplicate delivery contract. Blog
+registry schema v13 and package order remain unchanged; no Rust, JavaScript,
+PostgreSQL, browser, workflow, CI, or production execution is recorded.
+
 ## FFA/FBA status
 
 - FFA status: `in_progress`.
@@ -486,7 +526,9 @@ browser, workflow, CI, or production result is recorded.
   and process-restart harnesses, plus aggregate/consumer bindings for admin,
   storefront, Comments port boundary, Comments event projection, category Search
   reindex, GraphQL rate limiting, GraphQL richtext, AI richtext, offline backfill,
-  Forum ownership, and runtime order.
+  Forum ownership, and runtime order. The separately guarded dispatcher duplicate
+  target is source-ready but intentionally outside registry package order in
+  Slice 56.
 - Comments consumer port boundary: Blog-owned `source_verified_no_compile` for
   the in-process profile; all seven operations, approved public read, typed
   richtext projection, two-second deadlines, write idempotency, active typed
@@ -506,10 +548,12 @@ browser, workflow, CI, or production result is recorded.
   retain the concurrent same-envelope target: both named workers must be observed
   blocked after their initial ledger lookups, then one transaction commits and the
   loser rolls back before clean replay. Its exact npm leaf commands and position
-  immediately after the main projection gate are locked. None of these targets has
-  been run. Naturally contended PostgreSQL retry frequency, dispatcher-level
-  duplicate delivery, full server-host restart recovery, and all execution
-  evidence remain pending.
+  immediately after the main projection gate are locked. Separate schema-v1
+  evidence and a standalone fail-closed guard retain dispatcher replay of the same
+  envelope twice with two completed handler calls and one database application.
+  None of these targets has been run. Naturally contended PostgreSQL retry
+  frequency, full server-host restart recovery, and all execution evidence remain
+  pending.
 - Load protection: `implementation_ready`; mounted Redis evidence is pending.
 - Rate-limit harness: `executable_no_compile`; evidence, verifier, self-test,
   npm leaf commands, and aggregate FBA registration are locked; execution is
@@ -543,6 +587,7 @@ browser, workflow, CI, or production result is recorded.
 - `crates/rustok-blog/contracts/evidence/blog-comments-consumer-runtime-order-smoke.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-duplicate-delivery-race.json`
+- `crates/rustok-blog/contracts/evidence/blog-comments-dispatcher-duplicate-delivery.json`
 - `crates/rustok-blog/src/lib.rs`
 - `crates/rustok-blog/src/graphql/types.rs`
 - `crates/rustok-blog/storefront/src/model.rs`
@@ -552,6 +597,7 @@ browser, workflow, CI, or production result is recorded.
 - `crates/rustok-blog/src/services/comment_projection.rs`
 - `crates/rustok-blog/tests/comment_projection_postgres_test.rs`
 - `crates/rustok-blog/tests/comment_projection_duplicate_race_postgres_test.rs`
+- `crates/rustok-blog/tests/comment_projection_dispatcher_duplicate_postgres_test.rs`
 - `crates/rustok-blog/tests/comment_projection_restart_postgres_test.rs`
 - `crates/rustok-comments/contracts/comments-fba-registry.json`
 - `crates/rustok-comments/contracts/evidence/comments-thread-write-invariants.json`
@@ -573,6 +619,8 @@ browser, workflow, CI, or production result is recorded.
 - `scripts/verify/verify-blog-comments-event-projection.test.mjs`
 - `scripts/verify/verify-blog-comments-duplicate-delivery-race.mjs`
 - `scripts/verify/verify-blog-comments-duplicate-delivery-race.test.mjs`
+- `scripts/verify/verify-blog-comments-dispatcher-duplicate-delivery.mjs`
+- `scripts/verify/verify-blog-comments-dispatcher-duplicate-delivery.test.mjs`
 - `scripts/verify/verify-blog-graphql-rate-limit.mjs`
 - `scripts/verify/verify-blog-graphql-rate-limit.test.mjs`
 - `scripts/verify/verify-blog-category-search-reindex.mjs`
@@ -733,6 +781,11 @@ browser, workflow, CI, or production result is recorded.
     source gate, added exact verify/test npm leaf commands, bound its evidence and
     PostgreSQL target in registry schema v13, and locked aggregate verify/test
     order without changing runtime code or recording execution.
+56. Added an env-gated dispatcher duplicate-delivery target that routes the same
+    envelope twice through the module-registered handler, observes both completed
+    calls, and retains one counter/delivery/outbox application in schema-v1
+    evidence plus a standalone verifier and focused negative fixture without
+    changing registry package order or recording execution.
 
 ## Next results
 
@@ -753,27 +806,29 @@ browser, workflow, CI, or production result is recorded.
    shared consumer runtime-order verifier, Blog projection classifier and
    deterministic retry-policy harness, module registration/routing harness, the
    filtered `event_dispatcher_routes_registered_handler_and_commits_projection`,
+   `event_dispatcher_replays_duplicate_envelope_without_double_commit`,
    `concurrent_created_events_converge_without_lost_updates`,
    `optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears`,
    `concurrent_duplicate_envelope_commits_once_and_replays_cleanly`, and
    `restarted_process_reuses_delivery_ledger_without_reapplying_counter` cases,
    the complete `comment_projection_postgres_test`,
+   `comment_projection_dispatcher_duplicate_postgres_test`,
    `comment_projection_duplicate_race_postgres_test`, and
    `comment_projection_restart_postgres_test` targets, both thread invariant
    concurrency targets, and concurrent PostgreSQL create/delete transactions.
    Retain deterministic immediate-success/seven-retry/eighth-limit output, the
    deterministic eight-zero-row terminal error, rollback and same-envelope
-   recovery output, both blocked duplicate workers, the one-winner/one-loser
-   outcome, final single delivery/outbox cardinality, clean duplicate replay,
-   dispatcher delivery output, four-connection convergence, both child process
-   exits, the written duplicate, delete-before-create, missing-post replay,
-   outbox rollback/retry, and same-process/new-connection assertions; then retain
-   dispatcher-level duplicate delivery, naturally contended PostgreSQL
-   retry-frequency evidence, full server-host restart recovery, remote adapter
-   parity, browser parity for typed unavailable/timeout article rendering, cached
-   thread snapshots, comment-form fallback, approved-only reads, moderation,
-   pagination, first-thread identity, and unrelated insert storage error
-   propagation.
+   recovery output, two completed dispatcher duplicate calls with one database
+   application, both blocked duplicate workers, the one-winner/one-loser outcome,
+   final single delivery/outbox cardinality, clean duplicate replay, dispatcher
+   delivery output, four-connection convergence, both child process exits, the
+   written duplicate, delete-before-create, missing-post replay, outbox
+   rollback/retry, and same-process/new-connection assertions; then retain
+   naturally contended PostgreSQL retry-frequency evidence, full server-host
+   restart recovery, remote adapter parity, browser parity for typed
+   unavailable/timeout article rendering, cached thread snapshots, comment-form
+   fallback, approved-only reads, moderation, pagination, first-thread identity,
+   and unrelated insert storage error propagation.
 6. **Execute and retain Blog article richtext cutover evidence.** Run the offline
    backfill in default dry-run mode, review its report, apply accepted conversion,
    execute the irreversible migration, reindex/rollback Search, and retain
@@ -791,14 +846,17 @@ should run the relevant subset, including:
 - `npm run test:verify:blog:comments-event-projection`
 - `npm run verify:blog:comments-duplicate-delivery-race`
 - `npm run test:verify:blog:comments-duplicate-delivery-race`
+- `node scripts/verify/verify-blog-comments-dispatcher-duplicate-delivery.mjs`
+- `node --test scripts/verify/verify-blog-comments-dispatcher-duplicate-delivery.test.mjs`
 - `cargo test -p rustok-blog --lib services::comment_projection::tests`
 - `cargo test -p rustok-blog --lib services::comment_projection::tests::optimistic_retry_policy_applies_success_without_retry -- --exact`
 - `cargo test -p rustok-blog --lib services::comment_projection::tests::optimistic_retry_policy_allows_seven_retries_then_stops_on_eighth_conflict -- --exact`
 - `cargo test -p rustok-blog --lib tests::module_registers_comment_projection_handler_with_host_routing`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test event_dispatcher_routes_registered_handler_and_commits_projection -- --exact`
+- `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_dispatcher_duplicate_postgres_test event_dispatcher_replays_duplicate_envelope_without_double_commit -- --exact`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test concurrent_created_events_converge_without_lost_updates -- --exact`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears -- --exact`
-- `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_duplicate_race_postgres_test concurrent_duplicate_envelope_commits_once_and_replays_cleanly -- --exact`
+- `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_duplicate_race_postgres_test concurrent_duplicate_envelope_commits_once_and_replays_after_conflict_clears -- --exact`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_postgres_test`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test restarted_process_reuses_delivery_ledger_without_reapplying_counter -- --exact`
 - `RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_restart_postgres_test`

--- a/crates/rustok-blog/tests/comment_projection_dispatcher_duplicate_postgres_test.rs
+++ b/crates/rustok-blog/tests/comment_projection_dispatcher_duplicate_postgres_test.rs
@@ -12,9 +12,7 @@ use async_trait::async_trait;
 use rustok_blog::BlogModule;
 use rustok_core::{
     ModuleEventListenerContext, ModuleEventListenerRegistry, ModuleRuntimeExtensions, RusToKModule,
-    events::{
-        DispatcherConfig, EventBus, EventDispatcher, EventHandler, HandlerResult,
-    },
+    events::{DispatcherConfig, EventBus, EventDispatcher, EventHandler, HandlerResult},
 };
 use rustok_events::{DomainEvent, EventEnvelope};
 use sea_orm::{
@@ -22,7 +20,7 @@ use sea_orm::{
 };
 use uuid::Uuid;
 
- type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
 
 const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";
 const DISPATCHER_DUPLICATE_DELIVERIES: usize = 2;

--- a/crates/rustok-blog/tests/comment_projection_dispatcher_duplicate_postgres_test.rs
+++ b/crates/rustok-blog/tests/comment_projection_dispatcher_duplicate_postgres_test.rs
@@ -1,0 +1,348 @@
+use std::{
+    error::Error,
+    io,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use rustok_blog::BlogModule;
+use rustok_core::{
+    ModuleEventListenerContext, ModuleEventListenerRegistry, ModuleRuntimeExtensions, RusToKModule,
+    events::{
+        DispatcherConfig, EventBus, EventDispatcher, EventHandler, HandlerResult,
+    },
+};
+use rustok_events::{DomainEvent, EventEnvelope};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
+};
+use uuid::Uuid;
+
+ type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";
+const DISPATCHER_DUPLICATE_DELIVERIES: usize = 2;
+
+struct PostgresBlogDispatcherDuplicateTestDb {
+    control: DatabaseConnection,
+    db: DatabaseConnection,
+    schema_name: String,
+}
+
+impl PostgresBlogDispatcherDuplicateTestDb {
+    async fn setup() -> TestResult<Option<Self>> {
+        let Some(database_url) = postgres_database_url() else {
+            eprintln!(
+                "{BLOG_TEST_DATABASE_ENV} is not set to a PostgreSQL URL; skipping Blog dispatcher duplicate delivery test"
+            );
+            return Ok(None);
+        };
+
+        let control = connect(&database_url).await?;
+        let schema_name = format!(
+            "rustok_blog_dispatcher_duplicate_{}",
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let db = connect(&database_url).await?;
+        set_search_path(&db, &schema_name).await?;
+
+        if let Err(error) = create_projection_tables(&db).await {
+            let _ = control
+                .execute_unprepared(&format!(r#"DROP SCHEMA IF EXISTS "{schema_name}" CASCADE"#))
+                .await;
+            return Err(error.into());
+        }
+
+        Ok(Some(Self {
+            control,
+            db,
+            schema_name,
+        }))
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+struct ObservedProjectionHandler {
+    inner: Arc<dyn EventHandler>,
+    completed: Arc<AtomicUsize>,
+}
+
+impl ObservedProjectionHandler {
+    fn new(inner: Arc<dyn EventHandler>, completed: Arc<AtomicUsize>) -> Self {
+        Self { inner, completed }
+    }
+}
+
+#[async_trait]
+impl EventHandler for ObservedProjectionHandler {
+    fn name(&self) -> &'static str {
+        self.inner.name()
+    }
+
+    fn handles(&self, event: &DomainEvent) -> bool {
+        self.inner.handles(event)
+    }
+
+    async fn handle(&self, envelope: &EventEnvelope) -> HandlerResult {
+        let result = self.inner.handle(envelope).await;
+        self.completed.fetch_add(1, Ordering::SeqCst);
+        result
+    }
+
+    async fn on_error(&self, envelope: &EventEnvelope, error: &rustok_core::Error) {
+        self.inner.on_error(envelope, error).await;
+    }
+}
+
+#[tokio::test]
+async fn event_dispatcher_replays_duplicate_envelope_without_double_commit() -> TestResult<()> {
+    let Some(test_db) = PostgresBlogDispatcherDuplicateTestDb::setup().await? else {
+        return Ok(());
+    };
+
+    let tenant_id = Uuid::new_v4();
+    let post_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    let comment_id = Uuid::new_v4();
+    insert_post(&test_db.db, tenant_id, post_id, actor_id).await?;
+
+    let extensions = ModuleRuntimeExtensions::default();
+    let context = ModuleEventListenerContext {
+        db: test_db.db.clone(),
+        extensions: &extensions,
+    };
+    let mut registry = ModuleEventListenerRegistry::new();
+    BlogModule.register_event_listeners(&mut registry, &context);
+
+    let mut handlers = registry.into_handlers();
+    assert_eq!(handlers.len(), 1);
+    let projection = handlers
+        .pop()
+        .expect("Blog must register the comment projection handler");
+    assert_eq!(projection.name(), "blog_comment_projection");
+
+    let completed = Arc::new(AtomicUsize::new(0));
+    let observed = ObservedProjectionHandler::new(projection, Arc::clone(&completed));
+    let bus = EventBus::new();
+    let mut dispatcher = EventDispatcher::with_config(
+        bus,
+        DispatcherConfig {
+            fail_fast: true,
+            max_concurrent: 1,
+            retry_count: 0,
+            retry_delay_ms: 0,
+            max_queue_depth: 128,
+        },
+    );
+    dispatcher.register(observed);
+    assert_eq!(dispatcher.handler_count(), 1);
+
+    let envelope = comment_created_envelope(tenant_id, actor_id, comment_id, post_id);
+    let running = dispatcher.start();
+    for _ in 0..DISPATCHER_DUPLICATE_DELIVERIES {
+        running.bus().publish_envelope(envelope.clone())?;
+    }
+    wait_for_completed_dispatches(&completed).await?;
+
+    assert_eq!(
+        completed.load(Ordering::SeqCst),
+        DISPATCHER_DUPLICATE_DELIVERIES
+    );
+    assert_eq!(load_post_state(&test_db.db, tenant_id, post_id).await?, (1, 2));
+    assert_eq!(count_delivery(&test_db.db, envelope.id).await?, 1);
+    assert_eq!(count_outbox_events(&test_db.db).await?, 1);
+
+    running.stop();
+    test_db.cleanup().await
+}
+
+fn comment_created_envelope(
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    comment_id: Uuid,
+    post_id: Uuid,
+) -> EventEnvelope {
+    EventEnvelope::new(
+        tenant_id,
+        Some(actor_id),
+        DomainEvent::CommentCreated {
+            comment_id,
+            target_type: "blog_post".to_string(),
+            target_id: post_id,
+            author_id: actor_id,
+        },
+    )
+}
+
+async fn wait_for_completed_dispatches(completed: &AtomicUsize) -> TestResult<()> {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if completed.load(Ordering::SeqCst) >= DISPATCHER_DUPLICATE_DELIVERIES {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::TimedOut,
+            "event dispatcher did not complete both duplicate deliveries",
+        )
+    })?;
+    Ok(())
+}
+
+async fn create_projection_tables(db: &DatabaseConnection) -> Result<(), sea_orm::DbErr> {
+    db.execute_unprepared(
+        r#"
+        CREATE TABLE blog_posts (
+            id UUID PRIMARY KEY,
+            tenant_id UUID NOT NULL,
+            author_id UUID NOT NULL,
+            category_id UUID NULL,
+            status TEXT NOT NULL,
+            slug TEXT NOT NULL,
+            metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+            featured_image_url TEXT NULL,
+            published_at TIMESTAMPTZ NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            archived_at TIMESTAMPTZ NULL,
+            comment_count INTEGER NOT NULL DEFAULT 0,
+            view_count INTEGER NOT NULL DEFAULT 0,
+            version INTEGER NOT NULL DEFAULT 1
+        );
+
+        CREATE TABLE blog_comment_projection_deliveries (
+            event_id UUID PRIMARY KEY,
+            tenant_id UUID NOT NULL,
+            comment_id UUID NOT NULL,
+            post_id UUID NOT NULL,
+            delta INTEGER NOT NULL,
+            processed_at TIMESTAMPTZ NOT NULL
+        );
+
+        CREATE TABLE sys_events (
+            id UUID PRIMARY KEY,
+            event_type TEXT NOT NULL,
+            schema_version SMALLINT NOT NULL,
+            payload JSONB NOT NULL,
+            status VARCHAR(32) NOT NULL,
+            retry_count INTEGER NOT NULL,
+            next_attempt_at TIMESTAMPTZ NULL,
+            last_error TEXT NULL,
+            claimed_by TEXT NULL,
+            claimed_at TIMESTAMPTZ NULL,
+            created_at TIMESTAMPTZ NOT NULL,
+            dispatched_at TIMESTAMPTZ NULL
+        );
+        "#,
+    )
+    .await?;
+    Ok(())
+}
+
+async fn insert_post(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    post_id: Uuid,
+    author_id: Uuid,
+) -> Result<(), sea_orm::DbErr> {
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+        INSERT INTO blog_posts (
+            id, tenant_id, author_id, status, slug, metadata,
+            comment_count, view_count, version
+        ) VALUES ($1, $2, $3, 'published', 'dispatcher-duplicate-test', '{}'::jsonb, 0, 0, 1)
+        "#,
+        vec![post_id.into(), tenant_id.into(), author_id.into()],
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn load_post_state(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    post_id: Uuid,
+) -> Result<(i32, i32), sea_orm::DbErr> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT comment_count, version FROM blog_posts WHERE tenant_id = $1 AND id = $2",
+            vec![tenant_id.into(), post_id.into()],
+        ))
+        .await?
+        .expect("Blog post state should exist");
+    Ok((
+        row.try_get("", "comment_count")?,
+        row.try_get("", "version")?,
+    ))
+}
+
+async fn count_delivery(
+    db: &DatabaseConnection,
+    event_id: Uuid,
+) -> Result<i64, sea_orm::DbErr> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT COUNT(*)::bigint AS count FROM blog_comment_projection_deliveries WHERE event_id = $1",
+            vec![event_id.into()],
+        ))
+        .await?
+        .expect("delivery count query should return one row");
+    row.try_get("", "count")
+}
+
+async fn count_outbox_events(db: &DatabaseConnection) -> Result<i64, sea_orm::DbErr> {
+    let row = db
+        .query_one(Statement::from_string(
+            DbBackend::Postgres,
+            "SELECT COUNT(*)::bigint AS count FROM sys_events".to_string(),
+        ))
+        .await?
+        .expect("outbox count query should return one row");
+    row.try_get("", "count")
+}
+
+fn postgres_database_url() -> Option<String> {
+    std::env::var(BLOG_TEST_DATABASE_ENV)
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn set_search_path(db: &DatabaseConnection, schema_name: &str) -> TestResult<()> {
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}", public"#))
+        .await?;
+    Ok(())
+}

--- a/crates/rustok-blog/tests/comment_projection_dispatcher_duplicate_postgres_test.rs
+++ b/crates/rustok-blog/tests/comment_projection_dispatcher_duplicate_postgres_test.rs
@@ -80,11 +80,20 @@ impl PostgresBlogDispatcherDuplicateTestDb {
 struct ObservedProjectionHandler {
     inner: Arc<dyn EventHandler>,
     completed: Arc<AtomicUsize>,
+    failed: Arc<AtomicUsize>,
 }
 
 impl ObservedProjectionHandler {
-    fn new(inner: Arc<dyn EventHandler>, completed: Arc<AtomicUsize>) -> Self {
-        Self { inner, completed }
+    fn new(
+        inner: Arc<dyn EventHandler>,
+        completed: Arc<AtomicUsize>,
+        failed: Arc<AtomicUsize>,
+    ) -> Self {
+        Self {
+            inner,
+            completed,
+            failed,
+        }
     }
 }
 
@@ -100,6 +109,9 @@ impl EventHandler for ObservedProjectionHandler {
 
     async fn handle(&self, envelope: &EventEnvelope) -> HandlerResult {
         let result = self.inner.handle(envelope).await;
+        if result.is_err() {
+            self.failed.fetch_add(1, Ordering::SeqCst);
+        }
         self.completed.fetch_add(1, Ordering::SeqCst);
         result
     }
@@ -137,7 +149,12 @@ async fn event_dispatcher_replays_duplicate_envelope_without_double_commit() -> 
     assert_eq!(projection.name(), "blog_comment_projection");
 
     let completed = Arc::new(AtomicUsize::new(0));
-    let observed = ObservedProjectionHandler::new(projection, Arc::clone(&completed));
+    let failed = Arc::new(AtomicUsize::new(0));
+    let observed = ObservedProjectionHandler::new(
+        projection,
+        Arc::clone(&completed),
+        Arc::clone(&failed),
+    );
     let bus = EventBus::new();
     let mut dispatcher = EventDispatcher::with_config(
         bus,
@@ -163,6 +180,7 @@ async fn event_dispatcher_replays_duplicate_envelope_without_double_commit() -> 
         completed.load(Ordering::SeqCst),
         DISPATCHER_DUPLICATE_DELIVERIES
     );
+    assert_eq!(failed.load(Ordering::SeqCst), 0);
     assert_eq!(load_post_state(&test_db.db, tenant_id, post_id).await?, (1, 2));
     assert_eq!(count_delivery(&test_db.db, envelope.id).await?, 1);
     assert_eq!(count_outbox_events(&test_db.db).await?, 1);

--- a/scripts/verify/verify-blog-comments-dispatcher-duplicate-delivery.mjs
+++ b/scripts/verify/verify-blog-comments-dispatcher-duplicate-delivery.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve('.');
+const failures = [];
+
+const evidencePath =
+  'crates/rustok-blog/contracts/evidence/blog-comments-dispatcher-duplicate-delivery.json';
+const harnessPath =
+  'crates/rustok-blog/tests/comment_projection_dispatcher_duplicate_postgres_test.rs';
+const planPath = 'crates/rustok-blog/docs/implementation-plan.md';
+const harnessCommand =
+  'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_dispatcher_duplicate_postgres_test event_dispatcher_replays_duplicate_envelope_without_double_commit -- --exact';
+
+function read(relativePath) {
+  const target = path.join(repoRoot, relativePath);
+  if (!existsSync(target)) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return '';
+  }
+  return readFileSync(target, 'utf8');
+}
+
+function requireMarker(source, marker, label) {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+}
+
+function requireNoMarker(source, marker, label) {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+}
+
+const harness = read(harnessPath);
+const plan = read(planPath);
+let evidence = null;
+try {
+  evidence = JSON.parse(read(evidencePath));
+} catch (error) {
+  failures.push(`${evidencePath}: invalid JSON: ${error.message}`);
+}
+
+for (const marker of [
+  'use async_trait::async_trait;',
+  'const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";',
+  'const DISPATCHER_DUPLICATE_DELIVERIES: usize = 2;',
+  'struct ObservedProjectionHandler',
+  'inner: Arc<dyn EventHandler>',
+  'completed: Arc<AtomicUsize>',
+  'impl EventHandler for ObservedProjectionHandler',
+  'self.inner.handles(event)',
+  'let result = self.inner.handle(envelope).await;',
+  'self.completed.fetch_add(1, Ordering::SeqCst);',
+  'async fn event_dispatcher_replays_duplicate_envelope_without_double_commit()',
+  'BlogModule.register_event_listeners(&mut registry, &context);',
+  'let mut handlers = registry.into_handlers();',
+  'assert_eq!(handlers.len(), 1);',
+  'assert_eq!(projection.name(), "blog_comment_projection");',
+  'let mut dispatcher = EventDispatcher::with_config(',
+  'fail_fast: true',
+  'max_concurrent: 1',
+  'retry_count: 0',
+  'dispatcher.register(observed);',
+  'for _ in 0..DISPATCHER_DUPLICATE_DELIVERIES',
+  'running.bus().publish_envelope(envelope.clone())?;',
+  'wait_for_completed_dispatches(&completed).await?;',
+  'completed.load(Ordering::SeqCst)',
+  'DISPATCHER_DUPLICATE_DELIVERIES',
+  'load_post_state(&test_db.db, tenant_id, post_id).await?, (1, 2)',
+  'count_delivery(&test_db.db, envelope.id).await?, 1',
+  'count_outbox_events(&test_db.db).await?, 1',
+  'async fn wait_for_completed_dispatches(completed: &AtomicUsize)',
+  'event dispatcher did not complete both duplicate deliveries',
+  'CREATE TABLE blog_comment_projection_deliveries',
+  'CREATE TABLE sys_events',
+  '.max_connections(1)',
+  'SET search_path TO',
+]) {
+  requireMarker(harness, marker, harnessPath);
+}
+requireNoMarker(harness, '#[ignore]', harnessPath);
+requireNoMarker(harness, 'runtime_verified', harnessPath);
+
+if (evidence) {
+  if (evidence.schema_version !== 1) failures.push(`${evidencePath}: schema_version drift`);
+  if (
+    evidence.module !== 'blog' ||
+    evidence.surface !== 'comments_dispatcher_duplicate_delivery' ||
+    evidence.owner !== 'rustok-blog' ||
+    evidence.provider !== 'rustok-comments'
+  ) {
+    failures.push(`${evidencePath}: identity drift`);
+  }
+  if (evidence.status !== 'source_verified_no_compile') {
+    failures.push(`${evidencePath}: status drift`);
+  }
+  if (evidence.compile_policy !== 'not_run_by_request') {
+    failures.push(`${evidencePath}: compile policy drift`);
+  }
+  if (evidence.runtime_status !== 'pending') {
+    failures.push(`${evidencePath}: runtime status drift`);
+  }
+
+  const retained = evidence.harness ?? {};
+  if (
+    retained.status !== 'executable_no_run' ||
+    retained.runtime_status !== 'not_run' ||
+    retained.path !== harnessPath ||
+    retained.environment !== 'RUSTOK_BLOG_TEST_DATABASE_URL' ||
+    retained.command !== harnessCommand ||
+    retained.isolation !==
+      'unique_schema_one_connection_pool_module_registered_handler_observed_two_dispatches' ||
+    retained.scope !==
+      'same_envelope_published_twice_through_event_bus_dispatcher_single_projection_commit' ||
+    retained.non_claim !==
+      'does_not_record_postgresql_execution_or_concurrent_duplicate_race'
+  ) {
+    failures.push(`${evidencePath}: harness metadata drift`);
+  }
+
+  const cases = new Set((evidence.cases ?? []).map((entry) => entry.name));
+  for (const requiredCase of [
+    'module_registered_handler_routed_twice',
+    'two_completed_dispatch_calls',
+    'single_transactional_application',
+  ]) {
+    if (!cases.has(requiredCase)) failures.push(`${evidencePath}: missing case ${requiredCase}`);
+  }
+}
+
+for (const marker of [
+  'blog-comments-dispatcher-duplicate-delivery.json',
+  'comment_projection_dispatcher_duplicate_postgres_test',
+  'event_dispatcher_replays_duplicate_envelope_without_double_commit',
+  harnessCommand,
+  'dispatcher-level duplicate delivery',
+  'source_verified_no_compile',
+  'Slice 56',
+]) {
+  requireMarker(plan, marker, planPath);
+}
+
+if (failures.length > 0) {
+  console.error('Blog dispatcher duplicate delivery verification failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  'Blog dispatcher duplicate delivery routing, observation, and single-commit source contract is consistent',
+);

--- a/scripts/verify/verify-blog-comments-dispatcher-duplicate-delivery.mjs
+++ b/scripts/verify/verify-blog-comments-dispatcher-duplicate-delivery.mjs
@@ -49,15 +49,20 @@ for (const marker of [
   'struct ObservedProjectionHandler',
   'inner: Arc<dyn EventHandler>',
   'completed: Arc<AtomicUsize>',
+  'failed: Arc<AtomicUsize>',
   'impl EventHandler for ObservedProjectionHandler',
   'self.inner.handles(event)',
   'let result = self.inner.handle(envelope).await;',
+  'if result.is_err()',
+  'self.failed.fetch_add(1, Ordering::SeqCst);',
   'self.completed.fetch_add(1, Ordering::SeqCst);',
   'async fn event_dispatcher_replays_duplicate_envelope_without_double_commit()',
   'BlogModule.register_event_listeners(&mut registry, &context);',
   'let mut handlers = registry.into_handlers();',
   'assert_eq!(handlers.len(), 1);',
   'assert_eq!(projection.name(), "blog_comment_projection");',
+  'let failed = Arc::new(AtomicUsize::new(0));',
+  'Arc::clone(&failed)',
   'let mut dispatcher = EventDispatcher::with_config(',
   'fail_fast: true',
   'max_concurrent: 1',
@@ -68,6 +73,7 @@ for (const marker of [
   'wait_for_completed_dispatches(&completed).await?;',
   'completed.load(Ordering::SeqCst)',
   'DISPATCHER_DUPLICATE_DELIVERIES',
+  'assert_eq!(failed.load(Ordering::SeqCst), 0);',
   'load_post_state(&test_db.db, tenant_id, post_id).await?, (1, 2)',
   'count_delivery(&test_db.db, envelope.id).await?, 1',
   'count_outbox_events(&test_db.db).await?, 1',
@@ -149,5 +155,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  'Blog dispatcher duplicate delivery routing, observation, and single-commit source contract is consistent',
+  'Blog dispatcher duplicate delivery routing, successful acknowledgement, observation, and single-commit source contract is consistent',
 );

--- a/scripts/verify/verify-blog-comments-dispatcher-duplicate-delivery.test.mjs
+++ b/scripts/verify/verify-blog-comments-dispatcher-duplicate-delivery.test.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const verifier = path.resolve(
+  'scripts/verify/verify-blog-comments-dispatcher-duplicate-delivery.mjs',
+);
+
+function write(root, relativePath, content) {
+  const target = path.join(root, relativePath);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, content);
+}
+
+function runFixture({
+  missingSecondPublish = false,
+  missingObservationCounter = false,
+  missingSingleCommit = false,
+  missingEvidenceCase = false,
+  statusDrift = false,
+  runtimeStatusDrift = false,
+} = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-blog-dispatcher-duplicate-'));
+  const evidencePath =
+    'crates/rustok-blog/contracts/evidence/blog-comments-dispatcher-duplicate-delivery.json';
+  const harnessPath =
+    'crates/rustok-blog/tests/comment_projection_dispatcher_duplicate_postgres_test.rs';
+  const planPath = 'crates/rustok-blog/docs/implementation-plan.md';
+  const harnessCommand =
+    'RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-blog --test comment_projection_dispatcher_duplicate_postgres_test event_dispatcher_replays_duplicate_envelope_without_double_commit -- --exact';
+
+  write(
+    root,
+    harnessPath,
+    `
+use async_trait::async_trait;
+const BLOG_TEST_DATABASE_ENV: &str = "RUSTOK_BLOG_TEST_DATABASE_URL";
+const DISPATCHER_DUPLICATE_DELIVERIES: usize = 2;
+struct ObservedProjectionHandler
+inner: Arc<dyn EventHandler>
+completed: Arc<AtomicUsize>
+impl EventHandler for ObservedProjectionHandler
+self.inner.handles(event)
+let result = self.inner.handle(envelope).await;
+${missingObservationCounter ? '' : 'self.completed.fetch_add(1, Ordering::SeqCst);'}
+async fn event_dispatcher_replays_duplicate_envelope_without_double_commit()
+BlogModule.register_event_listeners(&mut registry, &context);
+let mut handlers = registry.into_handlers();
+assert_eq!(handlers.len(), 1);
+assert_eq!(projection.name(), "blog_comment_projection");
+let mut dispatcher = EventDispatcher::with_config(
+fail_fast: true
+max_concurrent: 1
+retry_count: 0
+dispatcher.register(observed);
+${missingSecondPublish ? '' : 'for _ in 0..DISPATCHER_DUPLICATE_DELIVERIES'}
+running.bus().publish_envelope(envelope.clone())?;
+wait_for_completed_dispatches(&completed).await?;
+completed.load(Ordering::SeqCst)
+DISPATCHER_DUPLICATE_DELIVERIES
+load_post_state(&test_db.db, tenant_id, post_id).await?, (1, 2)
+count_delivery(&test_db.db, envelope.id).await?, 1
+${missingSingleCommit ? '' : 'count_outbox_events(&test_db.db).await?, 1'}
+async fn wait_for_completed_dispatches(completed: &AtomicUsize)
+event dispatcher did not complete both duplicate deliveries
+CREATE TABLE blog_comment_projection_deliveries
+CREATE TABLE sys_events
+.max_connections(1)
+SET search_path TO
+`,
+  );
+
+  const cases = [
+    {
+      name: 'module_registered_handler_routed_twice',
+      expected: 'same envelope reaches the module-registered handler twice',
+    },
+    {
+      name: 'two_completed_dispatch_calls',
+      expected: 'two handler calls complete',
+    },
+    ...(
+      missingEvidenceCase
+        ? []
+        : [
+            {
+              name: 'single_transactional_application',
+              expected: 'one counter, delivery, and outbox application remains',
+            },
+          ]
+    ),
+  ];
+
+  write(
+    root,
+    evidencePath,
+    JSON.stringify({
+      schema_version: 1,
+      module: 'blog',
+      surface: 'comments_dispatcher_duplicate_delivery',
+      status: statusDrift ? 'runtime_verified' : 'source_verified_no_compile',
+      compile_policy: 'not_run_by_request',
+      runtime_status: runtimeStatusDrift ? 'verified' : 'pending',
+      owner: 'rustok-blog',
+      provider: 'rustok-comments',
+      harness: {
+        status: 'executable_no_run',
+        runtime_status: 'not_run',
+        path: harnessPath,
+        environment: 'RUSTOK_BLOG_TEST_DATABASE_URL',
+        command: harnessCommand,
+        isolation:
+          'unique_schema_one_connection_pool_module_registered_handler_observed_two_dispatches',
+        scope:
+          'same_envelope_published_twice_through_event_bus_dispatcher_single_projection_commit',
+        non_claim: 'does_not_record_postgresql_execution_or_concurrent_duplicate_race',
+      },
+      cases,
+    }),
+  );
+
+  write(
+    root,
+    planPath,
+    `
+blog-comments-dispatcher-duplicate-delivery.json
+comment_projection_dispatcher_duplicate_postgres_test
+event_dispatcher_replays_duplicate_envelope_without_double_commit
+${harnessCommand}
+dispatcher-level duplicate delivery
+source_verified_no_compile
+Slice 56
+`,
+  );
+
+  const result = spawnSync(process.execPath, [verifier], {
+    cwd: root,
+    env: { ...process.env, RUSTOK_VERIFY_REPO_ROOT: root },
+    encoding: 'utf8',
+  });
+  rmSync(root, { recursive: true, force: true });
+  return result;
+}
+
+test('Blog dispatcher duplicate verifier accepts the canonical source contract', () => {
+  const result = runFixture();
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test('Blog dispatcher duplicate verifier rejects removal of the two-delivery loop', () => {
+  const result = runFixture({ missingSecondPublish: true });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /for _ in 0\.\.DISPATCHER_DUPLICATE_DELIVERIES/);
+});
+
+test('Blog dispatcher duplicate verifier rejects removal of completed-call observation', () => {
+  const result = runFixture({ missingObservationCounter: true });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /self\.completed\.fetch_add/);
+});
+
+test('Blog dispatcher duplicate verifier rejects removal of the single-commit assertion', () => {
+  const result = runFixture({ missingSingleCommit: true });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /count_outbox_events/);
+});
+
+test('Blog dispatcher duplicate verifier rejects missing evidence coverage', () => {
+  const result = runFixture({ missingEvidenceCase: true });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /missing case single_transactional_application/);
+});
+
+test('Blog dispatcher duplicate verifier rejects false runtime promotion', () => {
+  const result = runFixture({ statusDrift: true });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /status drift/);
+});
+
+test('Blog dispatcher duplicate verifier rejects runtime-status promotion', () => {
+  const result = runFixture({ runtimeStatusDrift: true });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /runtime status drift/);
+});

--- a/scripts/verify/verify-blog-comments-dispatcher-duplicate-delivery.test.mjs
+++ b/scripts/verify/verify-blog-comments-dispatcher-duplicate-delivery.test.mjs
@@ -20,6 +20,7 @@ function write(root, relativePath, content) {
 function runFixture({
   missingSecondPublish = false,
   missingObservationCounter = false,
+  missingFailureObservation = false,
   missingSingleCommit = false,
   missingEvidenceCase = false,
   statusDrift = false,
@@ -44,15 +45,20 @@ const DISPATCHER_DUPLICATE_DELIVERIES: usize = 2;
 struct ObservedProjectionHandler
 inner: Arc<dyn EventHandler>
 completed: Arc<AtomicUsize>
+failed: Arc<AtomicUsize>
 impl EventHandler for ObservedProjectionHandler
 self.inner.handles(event)
 let result = self.inner.handle(envelope).await;
+if result.is_err()
+${missingFailureObservation ? '' : 'self.failed.fetch_add(1, Ordering::SeqCst);'}
 ${missingObservationCounter ? '' : 'self.completed.fetch_add(1, Ordering::SeqCst);'}
 async fn event_dispatcher_replays_duplicate_envelope_without_double_commit()
 BlogModule.register_event_listeners(&mut registry, &context);
 let mut handlers = registry.into_handlers();
 assert_eq!(handlers.len(), 1);
 assert_eq!(projection.name(), "blog_comment_projection");
+let failed = Arc::new(AtomicUsize::new(0));
+Arc::clone(&failed)
 let mut dispatcher = EventDispatcher::with_config(
 fail_fast: true
 max_concurrent: 1
@@ -63,6 +69,7 @@ running.bus().publish_envelope(envelope.clone())?;
 wait_for_completed_dispatches(&completed).await?;
 completed.load(Ordering::SeqCst)
 DISPATCHER_DUPLICATE_DELIVERIES
+assert_eq!(failed.load(Ordering::SeqCst), 0);
 load_post_state(&test_db.db, tenant_id, post_id).await?, (1, 2)
 count_delivery(&test_db.db, envelope.id).await?, 1
 ${missingSingleCommit ? '' : 'count_outbox_events(&test_db.db).await?, 1'}
@@ -82,7 +89,7 @@ SET search_path TO
     },
     {
       name: 'two_completed_dispatch_calls',
-      expected: 'two handler calls complete',
+      expected: 'two handler calls complete with zero errors',
     },
     ...(
       missingEvidenceCase
@@ -162,6 +169,12 @@ test('Blog dispatcher duplicate verifier rejects removal of completed-call obser
   const result = runFixture({ missingObservationCounter: true });
   assert.equal(result.status, 1);
   assert.match(result.stderr, /self\.completed\.fetch_add/);
+});
+
+test('Blog dispatcher duplicate verifier rejects removal of handler-error observation', () => {
+  const result = runFixture({ missingFailureObservation: true });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /self\.failed\.fetch_add/);
 });
 
 test('Blog dispatcher duplicate verifier rejects removal of the single-commit assertion', () => {


### PR DESCRIPTION
## Summary

- continue the canonical Blog improvement plan through slice 56
- add an env-gated PostgreSQL target that publishes the same Comments envelope twice through `EventBus` and `EventDispatcher`
- obtain the real `blog_comment_projection` handler through `BlogModule::register_event_listeners`
- wrap the real handler only to observe completed calls and handler errors
- require exactly two completed dispatcher calls, zero handler errors, and one transactional projection application
- require final `comment_count = 1`, `version = 2`, one delivery-ledger row, and one outbox row
- add schema-v1 machine evidence, a standalone fail-closed verifier, focused negative fixtures, and update the canonical plan

## Scope and non-claims

This target proves source-ready dispatcher duplicate replay. It is separate from the controlled concurrent same-envelope handler race retained in slices 54–55. It does not record PostgreSQL execution, naturally contended retry frequency, full server-host restart, browser evidence, workflow results, or CI results. The standalone guard is not added to registry-owned package order in this slice.

No Rust test, JavaScript verifier, compile, PostgreSQL, browser, workflow, or CI command was run, per maintainer instruction.

## Suggested maintainer commands

```bash
node scripts/verify/verify-blog-comments-dispatcher-duplicate-delivery.mjs
node --test scripts/verify/verify-blog-comments-dispatcher-duplicate-delivery.test.mjs

RUSTOK_BLOG_TEST_DATABASE_URL=postgresql://... \
  cargo test -p rustok-blog \
  --test comment_projection_dispatcher_duplicate_postgres_test \
  event_dispatcher_replays_duplicate_envelope_without_double_commit \
  -- --exact
```

## Branch state

The work started from `main` at `ee8ec47cc151b4215d96d467880a238752dde3f5`. Current `main` is ahead through unrelated Admin, Settings, Search, and Payment changes. The branch changes exactly five Blog source-target/evidence/guard/plan files.