### PR TITLE
fix(payment): sanitize execution admission diagnostics

### DIFF
--- a/crates/rustok-payment/contracts/evidence/checkout-execution-admission-diagnostic-safety-source.json
+++ b/crates/rustok-payment/contracts/evidence/checkout-execution-admission-diagnostic-safety-source.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "status": "payment_checkout_execution_admission_diagnostic_safety_source_reviewed_unvalidated",
+  "owner": "rustok-payment",
+  "boundary": "checkout_payment_execution_port",
+  "scope": "read and write admission rejection diagnostics",
+  "source_contract": {
+    "read_admission_preserved": true,
+    "write_policy_admission_preserved": true,
+    "write_semantics_admission_preserved": true,
+    "complete_port_error_logged": false,
+    "port_error_message_text_logged": false,
+    "stable_error_code_logged": true,
+    "static_error_kind_logged": true,
+    "retryability_logged": true,
+    "message_shape_only": true,
+    "context_shape_preserved": true,
+    "severity_classification_preserved": true,
+    "original_admission_error_returned": true,
+    "public_port_error_contract_changed": false,
+    "payment_lifecycle_changed": false,
+    "provider_execution_changed": false,
+    "owner_payment_error_diagnostics_changed": false,
+    "uuid_serde_diagnostics_changed": false,
+    "provider_checkpoint_diagnostics_changed": false,
+    "remaining_payment_execution_diagnostics_open": true,
+    "broad_ecommerce_cleanup_closed": false
+  },
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "notes": [
+    "Read admission still applies PortCallPolicy::read and returns its original error.",
+    "Write admission still applies PortCallPolicy::write followed by write-semantics enforcement.",
+    "The complete PortError and its message text are replaced by stable code, static kind, retryability, and message presence/length facts.",
+    "Warning versus error severity remains selected from the original PortError kind.",
+    "Owner PaymentError, UUID/serde, manual-reconciliation, local persistence, and provider checkpoint diagnostics remain outside this source slice and open.",
+    "No payment FFA or FBA status is promoted from source inspection."
+  ]
+}

--- a/crates/rustok-payment/docs/checkout-execution-admission-diagnostic-safety.md
+++ b/crates/rustok-payment/docs/checkout-execution-admission-diagnostic-safety.md
@@ -1,0 +1,71 @@
+# Checkout payment execution admission diagnostic safety
+
+Status: **source-ready / unvalidated**
+
+## Boundary
+
+`CheckoutPaymentExecutionPort` applies admission before each owner operation:
+
+- reads require `PortCallPolicy::read()`;
+- writes require `PortCallPolicy::write()`;
+- writes then retain the explicit `require_write_semantics()` check.
+
+Rejected admission returned the original `PortError`, but the shared rejection logger
+also recorded the complete error and its message text in both warning and error events.
+That duplicated a compatibility envelope into diagnostics even though the existing
+context-shape policy and stable error classification are sufficient for correlation.
+
+## Private diagnostics
+
+The admission logger now records only:
+
+- stable error code;
+- static error-kind label;
+- retryability;
+- error-message presence and character length;
+- admission phase (`policy` or `write_semantics`);
+- owner operation and correlation ID;
+- existing bounded actor, tenant, channel, locale, causation, traceparent,
+  idempotency, role, claim, and deadline facts.
+
+It does not record the complete `PortError` or its message text.
+
+## Preserved behavior
+
+This source slice does not change:
+
+- any public port signature;
+- read policy admission;
+- write policy admission;
+- the additional write-semantics check;
+- propagation of the original admission `PortError`;
+- stable error codes, kinds, messages, or retryability;
+- warning versus error severity selection;
+- tenant parsing or checkout-operation causation validation;
+- payment collection lifecycle, provider execution, journals, or recovery.
+
+## Remaining payment execution diagnostics
+
+Separate cleanup remains open for:
+
+- complete owner `PaymentError` diagnostics;
+- UUID and serde error diagnostics;
+- local persistence and provider checkpoint diagnostics;
+- manual-reconciliation reason text.
+
+The canonical ecommerce correlation-safe mapper-cleanup item remains open.
+
+## Evidence
+
+- `contracts/evidence/checkout-execution-admission-diagnostic-safety-source.json`
+- `scripts/verify/verify-payment-checkout-execution-admission-diagnostic-safety.mjs`
+
+## Validation still required
+
+Per maintainer instruction, no tests, Node verifiers, Cargo commands, formatting,
+workflows, or CI were run. Maintainer validation should include the focused verifier,
+payment owner tests, ecommerce aggregate guards, compilation, and injected read/write
+admission failures.
+
+No payment FFA/FBA, runtime, workflow, CI, or production status is promoted from this
+source review.

--- a/crates/rustok-payment/src/checkout_execution/validation_errors.rs
+++ b/crates/rustok-payment/src/checkout_execution/validation_errors.rs
@@ -140,9 +140,9 @@ fn log_checkout_payment_execution_admission_rejection(
         PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation
     );
     let context_facts = checkout_payment_execution_context_facts(context);
+    let error_facts = checkout_payment_execution_port_error_facts(error);
     if technical_failure {
         tracing::error!(
-            error = ?error,
             owner = "rustok_payment",
             operation = owner_operation,
             admission,
@@ -163,15 +163,15 @@ fn log_checkout_payment_execution_admission_rejection(
             idempotency_key_length = ?context_facts.idempotency_key_length,
             deadline_ms = ?context_facts.deadline_ms,
             internal_code = %error.code,
-            internal_message = %error.message,
-            error_kind = ?error.kind,
+            error_message_present = error_facts.message_present,
+            error_message_length = error_facts.message_length,
+            error_kind = error_facts.error_kind,
             retryable = error.retryable,
             boundary = PAYMENT_EXECUTION_BOUNDARY,
             "payment checkout execution admission failed with safe context"
         );
     } else {
         tracing::warn!(
-            error = ?error,
             owner = "rustok_payment",
             operation = owner_operation,
             admission,
@@ -192,8 +192,9 @@ fn log_checkout_payment_execution_admission_rejection(
             idempotency_key_length = ?context_facts.idempotency_key_length,
             deadline_ms = ?context_facts.deadline_ms,
             internal_code = %error.code,
-            internal_message = %error.message,
-            error_kind = ?error.kind,
+            error_message_present = error_facts.message_present,
+            error_message_length = error_facts.message_length,
+            error_kind = error_facts.error_kind,
             retryable = error.retryable,
             boundary = PAYMENT_EXECUTION_BOUNDARY,
             "payment checkout execution admission was rejected with safe context"

--- a/scripts/verify/verify-payment-checkout-execution-admission-diagnostic-safety.mjs
+++ b/scripts/verify/verify-payment-checkout-execution-admission-diagnostic-safety.mjs
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const requireCount = (source, value, expected, label) => {
+  const count = source.split(value).length - 1;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+};
+
+function functionBody(source, functionName) {
+  const signature = new RegExp(
+    `(?:pub(?:\\([^)]*\\))?\\s+)?(?:async\\s+)?fn\\s+${functionName}(?:<[^>]*>)?\\s*\\(`,
+  );
+  const match = signature.exec(source);
+  if (!match) {
+    failures.push(`missing function ${functionName}`);
+    return "";
+  }
+  const openBrace = source.indexOf("{", match.index);
+  if (openBrace < 0) {
+    failures.push(`missing body for ${functionName}`);
+    return "";
+  }
+  let depth = 0;
+  for (let index = openBrace; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(openBrace, index + 1);
+    }
+  }
+  failures.push(`unterminated body for ${functionName}`);
+  return "";
+}
+
+const paths = {
+  diagnostics:
+    "crates/rustok-payment/src/checkout_execution/diagnostic_safety.rs",
+  validationErrors:
+    "crates/rustok-payment/src/checkout_execution/validation_errors.rs",
+  evidence:
+    "crates/rustok-payment/contracts/evidence/checkout-execution-admission-diagnostic-safety-source.json",
+  doc:
+    "crates/rustok-payment/docs/checkout-execution-admission-diagnostic-safety.md",
+  plan: "crates/rustok-commerce/docs/implementation-plan.md",
+};
+
+const diagnostics = read(paths.diagnostics);
+const validationErrors = read(paths.validationErrors);
+const evidence = JSON.parse(read(paths.evidence));
+const doc = read(paths.doc);
+const plan = read(paths.plan);
+
+for (const marker of [
+  "struct CheckoutPaymentExecutionPortErrorFacts",
+  "fn checkout_payment_execution_port_error_facts(",
+  'PortErrorKind::Validation => "validation"',
+  'PortErrorKind::Unavailable => "unavailable"',
+  'PortErrorKind::Timeout => "timeout"',
+  'PortErrorKind::InvariantViolation => "invariant_violation"',
+  "message_present: !error.message.trim().is_empty()",
+  "message_length: error.message.chars().count()",
+]) {
+  requireText(diagnostics, marker, `${paths.diagnostics}: shared PortError shape policy`);
+}
+
+const readAdmission = functionBody(
+  validationErrors,
+  "require_checkout_payment_read_admission",
+);
+for (const marker of [
+  "require_policy(PortCallPolicy::read())",
+  ".inspect_err(|error|",
+  '"policy"',
+  "log_checkout_payment_execution_admission_rejection(",
+]) {
+  requireText(readAdmission, marker, `${paths.validationErrors}: read admission`);
+}
+
+const writeAdmission = functionBody(
+  validationErrors,
+  "require_checkout_payment_write_admission",
+);
+for (const marker of [
+  "require_policy(PortCallPolicy::write())",
+  "context.require_write_semantics().inspect_err(|error|",
+  '"policy"',
+  '"write_semantics"',
+]) {
+  requireText(writeAdmission, marker, `${paths.validationErrors}: write admission`);
+}
+requireCount(
+  writeAdmission,
+  "log_checkout_payment_execution_admission_rejection(",
+  2,
+  `${paths.validationErrors}: write policy and semantics diagnostics`,
+);
+
+const logger = functionBody(
+  validationErrors,
+  "log_checkout_payment_execution_admission_rejection",
+);
+for (const marker of [
+  "let technical_failure = matches!(",
+  "PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation",
+  "let context_facts = checkout_payment_execution_context_facts(context);",
+  "let error_facts = checkout_payment_execution_port_error_facts(error);",
+  "tracing::error!(",
+  "tracing::warn!(",
+  'owner = "rustok_payment"',
+  "operation = owner_operation",
+  "admission",
+  "correlation_id = %context.correlation_id",
+  "internal_code = %error.code",
+  "error_message_present = error_facts.message_present",
+  "error_message_length = error_facts.message_length",
+  "error_kind = error_facts.error_kind",
+  "retryable = error.retryable",
+  "boundary = PAYMENT_EXECUTION_BOUNDARY",
+]) {
+  requireText(logger, marker, `${paths.validationErrors}: safe admission logger`);
+}
+for (const forbidden of [
+  "error = ?error",
+  "error = %error",
+  "internal_message = %error.message",
+  "internal_message = ?error.message",
+  "message = %error.message",
+  "message = ?error.message",
+  "error_kind = ?error.kind",
+  "error_kind = %error.kind",
+  "error.to_string()",
+]) {
+  forbidText(logger, forbidden, `${paths.validationErrors}: complete admission error diagnostics`);
+}
+for (const marker of [
+  "error_message_present = error_facts.message_present",
+  "error_message_length = error_facts.message_length",
+  "error_kind = error_facts.error_kind",
+  "internal_code = %error.code",
+  "retryable = error.retryable",
+]) {
+  requireCount(logger, marker, 2, `${paths.validationErrors}: warning and error ${marker}`);
+}
+
+if (
+  evidence.status !==
+  "payment_checkout_execution_admission_diagnostic_safety_source_reviewed_unvalidated"
+) {
+  failures.push(`${paths.evidence}: unexpected status ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  read_admission_preserved: true,
+  write_policy_admission_preserved: true,
+  write_semantics_admission_preserved: true,
+  complete_port_error_logged: false,
+  port_error_message_text_logged: false,
+  stable_error_code_logged: true,
+  static_error_kind_logged: true,
+  retryability_logged: true,
+  message_shape_only: true,
+  context_shape_preserved: true,
+  severity_classification_preserved: true,
+  original_admission_error_returned: true,
+  public_port_error_contract_changed: false,
+  payment_lifecycle_changed: false,
+  provider_execution_changed: false,
+  owner_payment_error_diagnostics_changed: false,
+  uuid_serde_diagnostics_changed: false,
+  provider_checkpoint_diagnostics_changed: false,
+  remaining_payment_execution_diagnostics_open: true,
+  broad_ecommerce_cleanup_closed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "compile_proven",
+  "runtime_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+
+requireText(doc, "Status: **source-ready / unvalidated**", `${paths.doc}: status`);
+requireText(
+  doc,
+  "It does not record the complete `PortError` or its message text.",
+  `${paths.doc}: diagnostic policy`,
+);
+requireText(
+  doc,
+  "Remaining payment execution diagnostics",
+  `${paths.doc}: remaining work`,
+);
+requireText(
+  plan,
+  "Finish correlation-safe mapper cleanup",
+  `${paths.plan}: broad ecommerce cleanup remains open`,
+);
+
+if (failures.length > 0) {
+  console.error(
+    "Payment checkout execution admission diagnostic-safety verification failed:",
+  );
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "Payment checkout execution admission diagnostics retain only stable code, static kind, retryability, and message shape; execution evidence remains open",
+);


### PR DESCRIPTION
## Summary

- continue the open ecommerce correlation-safe mapper cleanup at checkout payment execution admission
- remove complete admission `PortError` and message text from both warning and error tracing
- retain stable error code, static kind, retryability, message presence/length, admission phase, correlation, and existing bounded context shape
- preserve read policy, write policy, explicit write-semantics admission, severity classification, and original error propagation
- add focused source guard, documentation, and reviewed-unvalidated evidence

## Confirmed gap

`log_checkout_payment_execution_admission_rejection` logged `error = ?error`, `internal_message = %error.message`, and `error_kind = ?error.kind` for read/write admission failures. The complete compatibility envelope and actionable message were copied into private diagnostics even though stable classification and shape are sufficient.

## Scope boundary

Exactly four files change: the existing admission logger plus a focused verifier, document, and evidence file. Owner `PaymentError`, UUID/serde, manual-reconciliation, local persistence, provider checkpoint diagnostics, lifecycle policy, provider execution, and public `PortError` behavior remain outside this PR and explicitly open.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-payment-checkout-execution-admission-diagnostic-safety.mjs
cargo check -p rustok-payment --all-targets
```

## Branch state

The branch is based on current `main` at `ca47b6153d09f3665d8a355894883496ccbf0a6e`, is one commit ahead and zero behind, and changes exactly four files. Head commit: `b661ee4f371d006a09a49a9bde6a9d7e3a397ccc`. Squash merge is intended.