### PR TITLE
fix(payment): sanitize owner execution error diagnostics

### DIFF
--- a/crates/rustok-payment/contracts/evidence/checkout-execution-owner-error-diagnostic-safety-source.json
+++ b/crates/rustok-payment/contracts/evidence/checkout-execution-owner-error-diagnostic-safety-source.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": 1,
+  "status": "payment_checkout_execution_owner_error_diagnostic_safety_source_reviewed_unvalidated",
+  "owner": "rustok-payment",
+  "boundary": "checkout_payment_execution_port",
+  "scope": "PaymentError to PortError owner mapper diagnostics",
+  "source_contract": {
+    "payment_error_variant_count": 11,
+    "complete_payment_error_logged": false,
+    "database_error_text_logged": false,
+    "validation_text_logged": false,
+    "uuid_value_logged": false,
+    "provider_id_text_logged": false,
+    "provider_operation_text_logged": false,
+    "transition_text_logged": false,
+    "static_error_variant_logged": true,
+    "text_field_shape_logged": true,
+    "uuid_field_shape_logged": true,
+    "opaque_database_payload_presence_logged": true,
+    "stable_owner_code_logged": true,
+    "context_shape_preserved": true,
+    "public_port_error_mapping_preserved": true,
+    "manual_reconciliation_routing_preserved": true,
+    "provider_reconciliation_policy_changed": false,
+    "payment_lifecycle_changed": false,
+    "provider_execution_changed": false,
+    "uuid_serde_diagnostics_changed": false,
+    "provider_checkpoint_diagnostics_changed": false,
+    "remaining_payment_execution_diagnostics_open": true,
+    "broad_ecommerce_cleanup_closed": false
+  },
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "notes": [
+    "The owner mapper retains the same stable code selection before converting PaymentError to PortError.",
+    "Diagnostics retain only a static variant, aggregate text-field count and length, UUID-field count and non-nil count, and opaque database-payload presence.",
+    "The complete database, validation, transition, provider, and identity payloads are not logged.",
+    "All eleven PaymentError match arms and their public PortError codes, kinds, messages, and retryability remain unchanged.",
+    "Provider invalid-response and outcome-unknown variants still route through manual reconciliation.",
+    "UUID/serde, manual-reconciliation reason, local persistence, and provider checkpoint diagnostics remain separate open slices.",
+    "No payment FFA or FBA status is promoted from source inspection."
+  ]
+}

--- a/crates/rustok-payment/docs/checkout-execution-owner-error-diagnostic-safety.md
+++ b/crates/rustok-payment/docs/checkout-execution-owner-error-diagnostic-safety.md
@@ -1,0 +1,69 @@
+# Checkout payment execution owner error diagnostic safety
+
+Status: **source-ready / unvalidated**
+
+## Boundary
+
+`payment_error_to_port_error` is the payment owner mapper used by checkout execution
+storage, collection, lifecycle, and provider paths. It selects a stable internal code,
+records a private diagnostic event, and then converts one of eleven `PaymentError`
+variants to the existing public `PortError` contract.
+
+The mapper previously recorded the complete `PaymentError`. Depending on the variant,
+that debug payload could contain database details, validation text, collection/payment/
+refund UUIDs, transition values, provider IDs, or provider operation text.
+
+## Private diagnostics
+
+The owner mapper now records only:
+
+- stable owner error code;
+- static `PaymentError` variant;
+- count and aggregate character length of text fields;
+- count and non-nil count of UUID fields;
+- whether an opaque database payload is present;
+- owner operation, correlation ID, and existing bounded context facts.
+
+It does not record the complete `PaymentError`, database text, validation text, UUID
+values, transition values, provider IDs, or provider operation text.
+
+## Preserved behavior
+
+This source slice does not change:
+
+- `PaymentError` or `PortError` public types;
+- stable owner code selection;
+- any of the eleven conversion match arms;
+- public error codes, kinds, messages, or retryability;
+- database-unavailable and validation mapping;
+- not-found mapping for collections, payments, and refunds;
+- invalid-transition conflict mapping;
+- provider unavailable/rejected/configuration mapping;
+- manual-reconciliation routing for invalid responses and unknown outcomes;
+- provider retry/reconciliation policy, journal behavior, or payment lifecycle.
+
+## Remaining payment execution diagnostics
+
+Separate cleanup remains open for:
+
+- UUID and serde error diagnostics;
+- manual-reconciliation reason text;
+- local persistence diagnostics;
+- provider checkpoint diagnostics.
+
+The canonical ecommerce correlation-safe mapper-cleanup item remains open.
+
+## Evidence
+
+- `contracts/evidence/checkout-execution-owner-error-diagnostic-safety-source.json`
+- `scripts/verify/verify-payment-checkout-execution-owner-error-diagnostic-safety.mjs`
+
+## Validation still required
+
+Per maintainer instruction, no tests, Node verifiers, Cargo commands, formatting,
+workflows, or CI were run. Maintainer validation should include the focused verifier,
+payment owner tests, ecommerce aggregate guards, compilation, and injected failures for
+all eleven owner error variants.
+
+No payment FFA/FBA, runtime, workflow, CI, or production status is promoted from this
+source review.

--- a/crates/rustok-payment/src/checkout_execution/validation_errors.rs
+++ b/crates/rustok-payment/src/checkout_execution/validation_errors.rs
@@ -284,6 +284,131 @@ fn manual_reconciliation(
     )
 }
 
+#[derive(Debug)]
+struct CheckoutPaymentExecutionPaymentErrorFacts {
+    error_variant: &'static str,
+    text_field_count: usize,
+    text_total_length: usize,
+    uuid_field_count: usize,
+    uuid_non_nil_count: usize,
+    opaque_payload_present: bool,
+}
+
+fn checkout_payment_execution_payment_error_facts(
+    error: &PaymentError,
+) -> CheckoutPaymentExecutionPaymentErrorFacts {
+    let (
+        error_variant,
+        text_field_count,
+        text_total_length,
+        uuid_field_count,
+        uuid_non_nil_count,
+        opaque_payload_present,
+    ) = match error {
+        PaymentError::Validation(value) => (
+            "validation",
+            1,
+            value.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        PaymentError::PaymentCollectionNotFound(id) => (
+            "payment_collection_not_found",
+            0,
+            0,
+            1,
+            if id.is_nil() { 0 } else { 1 },
+            false,
+        ),
+        PaymentError::PaymentNotFound(id) => (
+            "payment_not_found",
+            0,
+            0,
+            1,
+            if id.is_nil() { 0 } else { 1 },
+            false,
+        ),
+        PaymentError::RefundNotFound(id) => (
+            "refund_not_found",
+            0,
+            0,
+            1,
+            if id.is_nil() { 0 } else { 1 },
+            false,
+        ),
+        PaymentError::InvalidTransition { from, to } => (
+            "invalid_transition",
+            2,
+            from.chars().count() + to.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        PaymentError::ProviderUnavailable {
+            provider_id,
+            operation,
+        } => (
+            "provider_unavailable",
+            2,
+            provider_id.chars().count() + operation.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        PaymentError::ProviderRejected {
+            provider_id,
+            operation,
+        } => (
+            "provider_rejected",
+            2,
+            provider_id.chars().count() + operation.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        PaymentError::ProviderInvalidResponse {
+            provider_id,
+            operation,
+        } => (
+            "provider_invalid_response",
+            2,
+            provider_id.chars().count() + operation.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        PaymentError::ProviderOutcomeUnknown {
+            provider_id,
+            operation,
+        } => (
+            "provider_outcome_unknown",
+            2,
+            provider_id.chars().count() + operation.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        PaymentError::ProviderConfiguration { provider_id } => (
+            "provider_configuration",
+            1,
+            provider_id.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        PaymentError::Database(_) => ("database", 0, 0, 0, 0, true),
+    };
+    CheckoutPaymentExecutionPaymentErrorFacts {
+        error_variant,
+        text_field_count,
+        text_total_length,
+        uuid_field_count,
+        uuid_non_nil_count,
+        opaque_payload_present,
+    }
+}
+
 fn stable_payment_error_code(error: &PaymentError) -> &'static str {
     match error {
         PaymentError::Database(_) => "payment.database_unavailable",
@@ -307,8 +432,14 @@ fn payment_error_to_port_error(
 ) -> PortError {
     let code = stable_payment_error_code(&error);
     let context_facts = checkout_payment_execution_context_facts(context);
+    let error_facts = checkout_payment_execution_payment_error_facts(&error);
     tracing::error!(
-        error = ?error,
+        owner_error_variant = error_facts.error_variant,
+        owner_error_text_field_count = error_facts.text_field_count,
+        owner_error_text_total_length = error_facts.text_total_length,
+        owner_error_uuid_field_count = error_facts.uuid_field_count,
+        owner_error_uuid_non_nil_count = error_facts.uuid_non_nil_count,
+        owner_error_opaque_payload_present = error_facts.opaque_payload_present,
         correlation_id = %context.correlation_id,
         tenant_id_length = context_facts.tenant_id_length,
         actor_kind = context_facts.actor_kind,

--- a/scripts/verify/verify-payment-checkout-execution-owner-error-diagnostic-safety.mjs
+++ b/scripts/verify/verify-payment-checkout-execution-owner-error-diagnostic-safety.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const requireCount = (source, value, expected, label) => {
+  const count = source.split(value).length - 1;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+};
+
+function functionBody(source, functionName) {
+  const signature = new RegExp(
+    `(?:pub(?:\\([^)]*\\))?\\s+)?(?:async\\s+)?fn\\s+${functionName}(?:<[^>]*>)?\\s*\\(`,
+  );
+  const match = signature.exec(source);
+  if (!match) {
+    failures.push(`missing function ${functionName}`);
+    return "";
+  }
+  const openBrace = source.indexOf("{", match.index);
+  if (openBrace < 0) {
+    failures.push(`missing body for ${functionName}`);
+    return "";
+  }
+  let depth = 0;
+  for (let index = openBrace; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(openBrace, index + 1);
+    }
+  }
+  failures.push(`unterminated body for ${functionName}`);
+  return "";
+}
+
+const paths = {
+  error: "crates/rustok-payment/src/error.rs",
+  mapper: "crates/rustok-payment/src/checkout_execution/validation_errors.rs",
+  evidence:
+    "crates/rustok-payment/contracts/evidence/checkout-execution-owner-error-diagnostic-safety-source.json",
+  doc:
+    "crates/rustok-payment/docs/checkout-execution-owner-error-diagnostic-safety.md",
+  plan: "crates/rustok-commerce/docs/implementation-plan.md",
+};
+
+const errorSource = read(paths.error);
+const mapperSource = read(paths.mapper);
+const evidence = JSON.parse(read(paths.evidence));
+const doc = read(paths.doc);
+const plan = read(paths.plan);
+
+for (const marker of [
+  "Validation(String)",
+  "PaymentCollectionNotFound(Uuid)",
+  "PaymentNotFound(Uuid)",
+  "RefundNotFound(Uuid)",
+  "InvalidTransition { from: String, to: String }",
+  "ProviderUnavailable {",
+  "ProviderRejected {",
+  "ProviderInvalidResponse {",
+  "ProviderOutcomeUnknown {",
+  "ProviderConfiguration { provider_id: String }",
+  "Database(#[from] DbErr)",
+]) {
+  requireText(errorSource, marker, `${paths.error}: retained PaymentError variant`);
+}
+
+const facts = functionBody(
+  mapperSource,
+  "checkout_payment_execution_payment_error_facts",
+);
+for (const marker of [
+  "CheckoutPaymentExecutionPaymentErrorFacts",
+  '"validation"',
+  '"payment_collection_not_found"',
+  '"payment_not_found"',
+  '"refund_not_found"',
+  '"invalid_transition"',
+  '"provider_unavailable"',
+  '"provider_rejected"',
+  '"provider_invalid_response"',
+  '"provider_outcome_unknown"',
+  '"provider_configuration"',
+  'PaymentError::Database(_) => ("database", 0, 0, 0, 0, true)',
+  "value.chars().count()",
+  "from.chars().count() + to.chars().count()",
+  "provider_id.chars().count() + operation.chars().count()",
+  "if id.is_nil() { 0 } else { 1 }",
+]) {
+  requireText(facts, marker, `${paths.mapper}: owner error shape policy`);
+}
+for (const forbidden of [
+  "format!(",
+  ".to_string()",
+  "error.to_string()",
+  "provider_id =",
+  "provider_operation =",
+  "database_error =",
+]) {
+  forbidText(facts, forbidden, `${paths.mapper}: owner payload values`);
+}
+requireCount(
+  facts,
+  "if id.is_nil() { 0 } else { 1 }",
+  3,
+  `${paths.mapper}: three UUID-bearing variants`,
+);
+
+const stableCode = functionBody(mapperSource, "stable_payment_error_code");
+for (const marker of [
+  'PaymentError::Database(_) => "payment.database_unavailable"',
+  'PaymentError::Validation(_) => "payment.validation"',
+  'PaymentError::PaymentCollectionNotFound(_) => "payment.collection_not_found"',
+  'PaymentError::PaymentNotFound(_) => "payment.payment_not_found"',
+  'PaymentError::RefundNotFound(_) => "payment.refund_not_found"',
+  'PaymentError::InvalidTransition { .. } => "payment.invalid_transition"',
+  'PaymentError::ProviderUnavailable { .. } => "payment.provider_unavailable"',
+  'PaymentError::ProviderRejected { .. } => "payment.provider_rejected"',
+  'PaymentError::ProviderInvalidResponse { .. } => "payment.provider_invalid_response"',
+  'PaymentError::ProviderOutcomeUnknown { .. } => "payment.provider_outcome_unknown"',
+  'PaymentError::ProviderConfiguration { .. } => "payment.provider_not_configured"',
+]) {
+  requireText(stableCode, marker, `${paths.mapper}: stable owner code`);
+}
+
+const mapper = functionBody(mapperSource, "payment_error_to_port_error");
+for (const marker of [
+  "let code = stable_payment_error_code(&error);",
+  "let error_facts = checkout_payment_execution_payment_error_facts(&error);",
+  "owner_error_variant = error_facts.error_variant",
+  "owner_error_text_field_count = error_facts.text_field_count",
+  "owner_error_text_total_length = error_facts.text_total_length",
+  "owner_error_uuid_field_count = error_facts.uuid_field_count",
+  "owner_error_uuid_non_nil_count = error_facts.uuid_non_nil_count",
+  "owner_error_opaque_payload_present = error_facts.opaque_payload_present",
+  "correlation_id = %context.correlation_id",
+  "code,",
+  "boundary = PAYMENT_EXECUTION_BOUNDARY",
+  '"payment checkout execution owner operation failed"',
+]) {
+  requireText(mapper, marker, `${paths.mapper}: safe owner mapper diagnostics`);
+}
+for (const forbidden of [
+  "error = ?error",
+  "error = %error",
+  "error.to_string()",
+  "provider_id =",
+  "provider_operation =",
+  "validation_message =",
+  "database_error =",
+  "collection_id =",
+  "payment_id =",
+  "refund_id =",
+]) {
+  forbidText(mapper, forbidden, `${paths.mapper}: complete PaymentError diagnostics`);
+}
+
+for (const marker of [
+  'PortError::unavailable(\n            "payment.database_unavailable",\n            "payment storage is temporarily unavailable"',
+  'PortError::validation(\n            "payment.checkout_execution_validation",\n            "checkout payment request is invalid"',
+  'PortError::not_found(\n            "payment.collection_not_found",\n            "payment collection was not found"',
+  'PortError::not_found("payment.payment_not_found", "payment was not found")',
+  'PortError::not_found("payment.refund_not_found", "refund was not found")',
+  'PortError::conflict(\n            "payment.checkout_execution_state_conflict",\n            "payment lifecycle conflicts with checkout execution"',
+  'PortError::unavailable(\n            "payment.provider_unavailable",\n            "payment provider is temporarily unavailable"',
+  'PortError::conflict(\n            "payment.provider_rejected",\n            "payment provider rejected the requested operation"',
+  'PaymentError::ProviderInvalidResponse { .. } => manual_reconciliation(',
+  '"payment provider returned an invalid successful response"',
+  'PaymentError::ProviderOutcomeUnknown { .. } => manual_reconciliation(',
+  '"payment provider operation outcome is unknown"',
+  'PortError::invariant_violation(\n            "payment.provider_not_configured",\n            "payment provider is not configured"',
+]) {
+  requireText(mapper, marker, `${paths.mapper}: preserved public mapping`);
+}
+
+if (
+  evidence.status !==
+  "payment_checkout_execution_owner_error_diagnostic_safety_source_reviewed_unvalidated"
+) {
+  failures.push(`${paths.evidence}: unexpected status ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  payment_error_variant_count: 11,
+  complete_payment_error_logged: false,
+  database_error_text_logged: false,
+  validation_text_logged: false,
+  uuid_value_logged: false,
+  provider_id_text_logged: false,
+  provider_operation_text_logged: false,
+  transition_text_logged: false,
+  static_error_variant_logged: true,
+  text_field_shape_logged: true,
+  uuid_field_shape_logged: true,
+  opaque_database_payload_presence_logged: true,
+  stable_owner_code_logged: true,
+  context_shape_preserved: true,
+  public_port_error_mapping_preserved: true,
+  manual_reconciliation_routing_preserved: true,
+  provider_reconciliation_policy_changed: false,
+  payment_lifecycle_changed: false,
+  provider_execution_changed: false,
+  uuid_serde_diagnostics_changed: false,
+  provider_checkpoint_diagnostics_changed: false,
+  remaining_payment_execution_diagnostics_open: true,
+  broad_ecommerce_cleanup_closed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "compile_proven",
+  "runtime_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+
+requireText(doc, "Status: **source-ready / unvalidated**", `${paths.doc}: status`);
+requireText(
+  doc,
+  "It does not record the complete `PaymentError`",
+  `${paths.doc}: diagnostic policy`,
+);
+requireText(
+  doc,
+  "Remaining payment execution diagnostics",
+  `${paths.doc}: remaining work`,
+);
+requireText(
+  plan,
+  "Finish correlation-safe mapper cleanup",
+  `${paths.plan}: broad ecommerce cleanup remains open`,
+);
+
+if (failures.length > 0) {
+  console.error(
+    "Payment checkout execution owner error diagnostic-safety verification failed:",
+  );
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "Payment checkout execution owner diagnostics retain only stable variant and payload shape; public mappings and execution evidence remain unchanged",
+);


### PR DESCRIPTION
## Summary

- continue the open ecommerce correlation-safe mapper cleanup at the checkout payment execution owner mapper
- replace complete `PaymentError` debug logging with a static variant and aggregate payload-shape facts
- retain stable owner code, correlation, operation, and existing bounded context facts
- preserve all eleven `PaymentError` to `PortError` match arms, public codes/messages/retryability, and manual-reconciliation routing
- add a focused source verifier, documentation, and reviewed-unvalidated evidence

## Confirmed gap

`payment_error_to_port_error` logged `error = ?error` before conversion. Depending on the variant, the debug payload could include database details, validation text, UUIDs, transition values, provider IDs, and provider operation text.

## Scope boundary

Exactly four files change: the existing owner mapper plus a focused verifier, document, and evidence file. UUID/serde diagnostics, manual-reconciliation reason text, local persistence, provider checkpoint diagnostics, lifecycle policy, provider execution, and public `PortError` behavior remain outside this PR and explicitly open.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-payment-checkout-execution-owner-error-diagnostic-safety.mjs
cargo check -p rustok-payment --all-targets
```

## Branch state

The branch is based on current `main` at `f7573da76208546de14b19587caf0f6dc2f24407`, is one commit ahead and zero behind, and changes exactly four files. Head commit: `99171da1332b7b5d2643b4b3c9bb212b1a63a628`. Squash merge is intended.