### PR TITLE
feat(search): add unified Forum locale and date filters

### DIFF
--- a/crates/rustok-forum/contracts/forum-search-locale-date-filter.json
+++ b/crates/rustok-forum/contracts/forum-search-locale-date-filter.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-23B2F3",
+  "status": "source_complete_execution_pending",
+  "scope": "Lock explicit Forum-only storefront Search to one effective locale and add inclusive RFC3339 published-date filtering before Forum owner eligibility, visible totals, facets and pagination",
+  "canonical_forum_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "projection_owner": "crates/rustok-forum/src/search_projection.rs",
+  "filter_owner": "crates/rustok-search/src/forum_document_filters.rs",
+  "execution_owner": "crates/rustok-search/src/forum_storefront_execution.rs",
+  "graphql_transport": "crates/rustok-search/src/graphql/forum_storefront.rs",
+  "storefront_graphql_adapter": "crates/rustok-search/storefront/src/transport/forum_graphql_adapter.rs",
+  "storefront_native_adapter": "crates/rustok-search/storefront/src/transport/forum_native_server_adapter.rs",
+  "storefront_transport_facade": "crates/rustok-search/storefront/src/transport/mod.rs",
+  "owner_note": "crates/rustok-forum/docs/forum-23b2f3-search-locale-date-filter.md",
+  "verifier": "scripts/verify/verify-forum-search-locale-date-filter.mjs",
+  "architecture": {
+    "single_execution_owner": true,
+    "single_normalization_owner": true,
+    "separate_date_execution_module_allowed": false,
+    "legacy_parallel_execution_path_allowed": false
+  },
+  "input": {
+    "locale_source": "existing SearchPreviewInput.locale with tenant fallback",
+    "locale_match": "normalized_case_insensitive_exact",
+    "graphql_arguments": ["publishedFrom", "publishedTo"],
+    "native_arguments": ["published_from", "published_to"],
+    "date_format": "RFC3339",
+    "date_bounds": "inclusive",
+    "from_must_not_exceed_to": true,
+    "empty_values_preserve_existing_behavior": true
+  },
+  "projection": {
+    "topic_published_path": "payload.published_at",
+    "reply_published_path": "payload.published_at",
+    "published_value_owner": "Forum source created_at serialized as RFC3339",
+    "legacy_topic_or_reply_without_published_at_fails_closed_when_date_filter_active": true,
+    "malformed_published_at_fails_closed": true,
+    "projection_reindex_required_for_date_matches": true
+  },
+  "evaluation": {
+    "explicit_forum_only_category_scope_required": true,
+    "postgres_locale_predicate_is_exact": true,
+    "post_scan_locale_assertion_is_exact": true,
+    "locale_only_preserves_category_results": true,
+    "date_scope_excludes_categories": true,
+    "date_scope_applies_to_topics_and_replies": true,
+    "published_from_is_inclusive": true,
+    "published_to_is_inclusive": true,
+    "raw_candidate_scan_limit": 100,
+    "raw_candidate_limit_is_checked_before_date_narrowing": true,
+    "filters_run_before_forum_owner_eligibility": true,
+    "filters_run_before_visible_totals": true,
+    "filters_run_before_visible_facets": true,
+    "filters_run_before_offset_and_limit": true,
+    "ranking_order_of_matching_rows_is_preserved": true,
+    "query_rule_pins_disabled_when_date_filter_active": true
+  },
+  "transport_compatibility": {
+    "existing_graphql_operations": [
+      "ForumStorefrontSearch",
+      "ForumStorefrontSearchByAuthors",
+      "ForumStorefrontSearchByFilters"
+    ],
+    "additive_graphql_operation": "ForumStorefrontSearchByDateWindow",
+    "existing_native_endpoints": [
+      "search/forum-storefront-search",
+      "search/forum-storefront-search-by-authors",
+      "search/forum-storefront-search-by-filters"
+    ],
+    "additive_native_endpoint": "search/forum-storefront-search-by-date-window",
+    "existing_wire_signatures_changed": false,
+    "shared_execution_owner": true
+  },
+  "compatibility": {
+    "database_migration_required": false,
+    "public_search_preview_input_changed": false,
+    "search_query_shape_changed": false,
+    "shared_storefront_filter_dto_changed": false,
+    "ordinary_storefront_search_changed": false,
+    "mixed_source_search_changed": false,
+    "product_search_changed": false,
+    "admin_search_changed": false,
+    "dependency_added": false,
+    "cargo_lock_changed": false
+  },
+  "remaining_scope": [
+    "add kind, channel or group and attachment-presence Forum filters",
+    "complete owner-issued monotonic projection revisions and durable inbox ordering",
+    "complete reconciliation and deletion or ACL-change document cleanup",
+    "capture maintainer-executed PostgreSQL, reindex and LINK-FORUM-03 runtime evidence"
+  ],
+  "non_claims": [
+    "Tests, verifiers, Cargo checks, Clippy and runtime evidence were not executed by the implementation agent",
+    "This slice does not expose a new storefront UI control",
+    "This slice does not reduce the existing pre-authorization raw candidate bound",
+    "This slice does not claim legacy topic or reply documents match date filters before reindex"
+  ]
+}

--- a/crates/rustok-forum/docs/forum-23b2f3-search-locale-date-filter.md
+++ b/crates/rustok-forum/docs/forum-23b2f3-search-locale-date-filter.md
@@ -1,0 +1,121 @@
+# FORUM-23B2F3 exact Forum Search locale and date filters
+
+## Status
+
+`source_complete_execution_pending`
+
+This slice locks the existing explicit Forum-only storefront Search execution to
+one normalized effective locale and adds inclusive published-date filtering to
+that same owner path. It deliberately does not create a second execution,
+normalization, candidate scan, authorization or pagination implementation.
+Runtime, PostgreSQL and reindex evidence remain maintainer-owned and are not
+claimed here.
+
+## Recheck result
+
+The previous draft branch implemented the date window through parallel execution
+and normalization modules. That shape duplicated the existing Forum Search owner
+and could drift in validation, category scope, owner eligibility, totals, facets,
+pagination and query-rule behavior. The continuation replaces that draft with one
+execution owner:
+
+```text
+crates/rustok-search/src/forum_storefront_execution.rs
+```
+
+Locale, author, tag, solved and date predicates are represented by one bounded
+`ForumStorefrontDocumentFilters` value and are evaluated in the existing stable
+candidate scan.
+
+## Exact locale boundary
+
+The existing `SearchPreviewInput.locale` remains the only locale input. It is
+normalized through the existing bounded locale rules; when absent, the tenant
+fallback locale becomes the exact PostgreSQL FTS/typo locale and the post-scan
+locale assertion. Missing, foreign-module or mismatched locale rows fail closed.
+
+Locale-only execution preserves Forum categories, topics and replies and keeps
+query-rule pins enabled. Existing legacy, author-only and tag/solved calls use the
+same execution owner and retain their wire signatures.
+
+## Owner date projection
+
+Forum remains the owner of topic and reply creation time. Search evaluates only
+Forum-projected values:
+
+```text
+forum_topic.payload.published_at
+forum_reply.payload.published_at
+```
+
+Both values are derived from owner `created_at` and serialized as RFC3339. Legacy
+topic or reply documents without this field fail closed while a date window is
+active until a targeted or full Forum Search reindex repairs them.
+
+## Input and evaluation
+
+The GraphQL field accepts optional `publishedFrom` and `publishedTo` strings. The
+additive native endpoint accepts `published_from` and `published_to`. Non-empty
+values must be RFC3339 and are normalized to UTC. Bounds are inclusive; either may
+be omitted, and a lower bound after the upper bound is rejected.
+
+The stable raw 100-candidate cap is checked before date narrowing. Exact locale,
+author, tag, solved and date predicates intersect before exact Forum topic/reply
+owner eligibility, visible totals, facets, offset and limit. Categories do not
+match an active date window. Ranking order is preserved and query-rule pins are
+disabled only when a real document-narrowing filter is active.
+
+## Transport compatibility
+
+The existing GraphQL operations remain unchanged:
+
+```text
+ForumStorefrontSearch
+ForumStorefrontSearchByAuthors
+ForumStorefrontSearchByFilters
+```
+
+Date-window calls use the additive operation:
+
+```text
+ForumStorefrontSearchByDateWindow
+```
+
+The existing native endpoints also remain unchanged. Date-window calls use:
+
+```text
+search/forum-storefront-search-by-date-window
+```
+
+No shared Search input/DTO or neutral `SearchQuery` field is added.
+
+## Compatibility and degraded mode
+
+No database migration, dependency or `Cargo.lock` change is introduced. Topic and
+approved-reply payloads gain `published_at`; legacy rows fail closed for date
+queries until reindexed. Missing category-scope or result-eligibility owner
+composition continues to fail closed. This slice does **not** add storefront UI
+controls, kind/channel/group/attachment filters, durable projection ordering,
+delete/ACL cleanup or runtime evidence.
+
+## Maintainer verification
+
+The implementation agent did not run these commands, as requested:
+
+```bash
+cargo test -p rustok-search forum_document_filters -- --nocapture
+cargo test -p rustok-search visible_forum_statuses_match_owner_eligibility -- --nocapture
+cargo test -p rustok-search date_bounds_require_rfc3339 -- --nocapture
+cargo test -p rustok-search-storefront transport::tests::only_explicit_forum_category_scope_selects_owner_path -- --nocapture
+node scripts/verify/verify-forum-search-locale-date-filter.mjs
+cargo check -p rustok-forum --all-targets
+cargo check -p rustok-search --features graphql --all-targets
+cargo check -p rustok-search-storefront --features ssr --all-targets
+cargo xtask module validate forum
+cargo xtask module validate search
+```
+
+PostgreSQL proof should cover requested and fallback locales, mismatched locale,
+inclusive and one-sided bounds, reversed input, categories, legacy rows without
+`published_at`, malformed timestamps, the raw candidate cap, owner eligibility,
+totals, facets and pagination.

--- a/crates/rustok-forum/src/search_projection.rs
+++ b/crates/rustok-forum/src/search_projection.rs
@@ -323,6 +323,7 @@ impl ForumSearchProjectionSource {
                 "is_pinned": topic.is_pinned,
                 "is_locked": topic.is_locked,
                 "solution_reply_id": topic.solution_reply_id,
+                "published_at": created_at.to_rfc3339(),
                 "route": format!("/modules/forum?topic={}", topic.id)
             }),
             published_at: Some(created_at),
@@ -428,6 +429,7 @@ impl ForumSearchProjectionSource {
                 "topic_tags": topic_tags,
                 "parent_reply_id": reply.parent_reply_id,
                 "is_solution": is_solution,
+                "published_at": created_at.to_rfc3339(),
                 "route": route
             }),
             published_at: Some(created_at),

--- a/crates/rustok-search/src/forum_document_filters.rs
+++ b/crates/rustok-search/src/forum_document_filters.rs
@@ -1,20 +1,45 @@
+use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
 use crate::SearchResultItem;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ForumStorefrontDocumentFilters {
+    pub exact_locale: Option<String>,
     pub author_ids: Vec<Uuid>,
     pub tags: Vec<String>,
     pub solved: Option<bool>,
+    pub published_from: Option<DateTime<Utc>>,
+    pub published_to: Option<DateTime<Utc>>,
 }
 
 impl ForumStorefrontDocumentFilters {
     pub fn is_empty(&self) -> bool {
-        self.author_ids.is_empty() && self.tags.is_empty() && self.solved.is_none()
+        self.author_ids.is_empty()
+            && self.tags.is_empty()
+            && self.solved.is_none()
+            && self.published_from.is_none()
+            && self.published_to.is_none()
+    }
+
+    pub fn has_date_window(&self) -> bool {
+        self.published_from.is_some() || self.published_to.is_some()
     }
 
     pub fn matches(&self, item: &SearchResultItem) -> bool {
+        if let Some(exact_locale) = self.exact_locale.as_deref() {
+            if item.source_module != "forum"
+                || !item
+                    .locale
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .is_some_and(|value| value.eq_ignore_ascii_case(exact_locale))
+            {
+                return false;
+            }
+        }
+
         if self.is_empty() {
             return true;
         }
@@ -24,7 +49,10 @@ impl ForumStorefrontDocumentFilters {
             return false;
         }
 
-        self.matches_author(item) && self.matches_tags(item) && self.matches_solved(item)
+        self.matches_author(item)
+            && self.matches_tags(item)
+            && self.matches_solved(item)
+            && self.matches_published_at(item)
     }
 
     fn matches_author(&self, item: &SearchResultItem) -> bool {
@@ -95,14 +123,45 @@ impl ForumStorefrontDocumentFilters {
             _ => false,
         }
     }
+
+    fn matches_published_at(&self, item: &SearchResultItem) -> bool {
+        if !self.has_date_window() {
+            return true;
+        }
+
+        let Some(published_at) = item
+            .payload
+            .get("published_at")
+            .and_then(serde_json::Value::as_str)
+            .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+            .map(|value| value.with_timezone(&Utc))
+        else {
+            return false;
+        };
+
+        self.published_from
+            .as_ref()
+            .map_or(true, |from| &published_at >= from)
+            && self
+                .published_to
+                .as_ref()
+                .map_or(true, |to| &published_at <= to)
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use chrono::{DateTime, Utc};
     use uuid::Uuid;
 
     use super::ForumStorefrontDocumentFilters;
     use crate::SearchResultItem;
+
+    fn timestamp(value: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(value)
+            .expect("valid timestamp")
+            .with_timezone(&Utc)
+    }
 
     fn item(
         entity_type: &str,
@@ -151,6 +210,24 @@ mod tests {
         let filters = ForumStorefrontDocumentFilters::default();
         assert!(filters.matches(&item("forum_category", None, None, None)));
         assert!(filters.matches(&item("forum_topic", None, None, None)));
+    }
+
+    #[test]
+    fn exact_locale_preserves_categories_and_fails_closed_on_missing_locale() {
+        let filters = ForumStorefrontDocumentFilters {
+            exact_locale: Some("en".to_string()),
+            ..ForumStorefrontDocumentFilters::default()
+        };
+        let mut category = item("forum_category", None, None, None);
+        category.locale = Some("EN".to_string());
+        let mut foreign = item("forum_topic", None, None, None);
+        foreign.locale = Some("de".to_string());
+        let mut missing = item("forum_topic", None, None, None);
+        missing.locale = None;
+
+        assert!(filters.matches(&category));
+        assert!(!filters.matches(&foreign));
+        assert!(!filters.matches(&missing));
     }
 
     #[test]
@@ -232,6 +309,39 @@ mod tests {
     }
 
     #[test]
+    fn published_window_is_inclusive_and_excludes_categories() {
+        let filters = ForumStorefrontDocumentFilters {
+            exact_locale: Some("en".to_string()),
+            published_from: Some(timestamp("2026-07-15T12:00:00Z")),
+            published_to: Some(timestamp("2026-07-15T12:00:00Z")),
+            ..ForumStorefrontDocumentFilters::default()
+        };
+        let mut matching = item("forum_topic", None, None, None);
+        matching.payload["published_at"] = serde_json::json!("2026-07-15T12:00:00Z");
+        let mut after = item("forum_reply", None, None, None);
+        after.payload["published_at"] = serde_json::json!("2026-07-15T12:00:01Z");
+        let category = item("forum_category", None, None, None);
+
+        assert!(filters.matches(&matching));
+        assert!(!filters.matches(&after));
+        assert!(!filters.matches(&category));
+    }
+
+    #[test]
+    fn malformed_or_missing_published_projection_fails_closed() {
+        let filters = ForumStorefrontDocumentFilters {
+            published_from: Some(timestamp("2026-07-01T00:00:00Z")),
+            ..ForumStorefrontDocumentFilters::default()
+        };
+        let mut malformed = item("forum_topic", None, None, None);
+        malformed.payload["published_at"] = serde_json::json!("not-a-date");
+        let missing = item("forum_reply", None, None, None);
+
+        assert!(!filters.matches(&malformed));
+        assert!(!filters.matches(&missing));
+    }
+
+    #[test]
     fn malformed_tag_or_solved_projection_fails_closed() {
         let tag_filter = ForumStorefrontDocumentFilters {
             tags: vec!["Rust".to_string()],
@@ -257,6 +367,7 @@ mod tests {
             author_ids: vec![expected],
             tags: vec!["Rust".to_string()],
             solved: Some(true),
+            ..ForumStorefrontDocumentFilters::default()
         };
         let matching = item(
             "forum_reply",

--- a/crates/rustok-search/src/forum_storefront_execution.rs
+++ b/crates/rustok-search/src/forum_storefront_execution.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::fmt::{Display, Formatter};
 use std::time::Instant;
 
+use chrono::{DateTime, Utc};
 use rustok_api::{AuthContext, PortError, RequestContext};
 use sea_orm::DatabaseConnection;
 use uuid::Uuid;
@@ -55,6 +56,8 @@ pub struct ForumStorefrontSearchRequest {
     pub author_ids: Vec<String>,
     pub tags: Vec<String>,
     pub solved: Option<bool>,
+    pub published_from: Option<String>,
+    pub published_to: Option<String>,
     pub attribute_filters: Vec<ForumStorefrontSearchAttributeFilter>,
     pub sort_attribute_code: Option<String>,
     pub sort_desc: bool,
@@ -191,7 +194,7 @@ pub async fn execute_forum_storefront_search(
     .await?;
     let search_query = SearchQuery {
         tenant_id: Some(input.tenant_id),
-        locale: input.locale,
+        locale: Some(effective_locale.clone()),
         channel_id: input.channel_id,
         original_query: transform.original_query,
         query: transform.effective_query,
@@ -462,6 +465,18 @@ fn normalize_request(
     let query = normalize_query(&request.query)?;
     let locale = normalize_locale(request.locale.as_deref())?;
     let fallback_locale = normalize_required_locale(&request.fallback_locale)?;
+    let exact_locale = locale
+        .clone()
+        .unwrap_or_else(|| fallback_locale.clone());
+    let published_from = normalize_optional_rfc3339("published_from", request.published_from.as_deref())?;
+    let published_to = normalize_optional_rfc3339("published_to", request.published_to.as_deref())?;
+    if published_from
+        .as_ref()
+        .zip(published_to.as_ref())
+        .is_some_and(|(from, to)| from > to)
+    {
+        return validation("published_from must not be after published_to");
+    }
     let requested_channel_id = parse_optional_uuid("channel_id", request.channel_id.as_deref())?;
     let request_context = request.request_context.ok_or_else(|| {
         ForumStorefrontSearchExecutionError::Validation(
@@ -507,9 +522,12 @@ fn normalize_request(
         statuses: normalize_filter_values("statuses", request.statuses)?,
         category_ids,
         document_filters: ForumStorefrontDocumentFilters {
+            exact_locale: Some(exact_locale),
             author_ids: normalize_uuid_values("author_ids", request.author_ids)?,
             tags: normalize_tag_values("tags", request.tags)?,
             solved: request.solved,
+            published_from,
+            published_to,
         },
         attribute_filters: normalize_attribute_filters(request.attribute_filters)?,
         sort_attribute_code: normalize_attribute_code(request.sort_attribute_code)?,
@@ -553,6 +571,25 @@ fn normalize_required_locale(value: &str) -> Result<String, ForumStorefrontSearc
         return validation("Invalid locale format");
     }
     Ok(value.to_ascii_lowercase())
+}
+
+fn normalize_optional_rfc3339(
+    field: &str,
+    value: Option<&str>,
+) -> Result<Option<DateTime<Utc>>, ForumStorefrontSearchExecutionError> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| {
+            DateTime::parse_from_rfc3339(value)
+                .map(|timestamp| timestamp.with_timezone(&Utc))
+                .map_err(|_| {
+                    ForumStorefrontSearchExecutionError::Validation(format!(
+                        "{field} must be RFC3339"
+                    ))
+                })
+        })
+        .transpose()
 }
 
 fn normalize_filter_values(
@@ -733,7 +770,7 @@ fn validation<T>(message: impl Into<String>) -> Result<T, ForumStorefrontSearchE
 
 #[cfg(test)]
 mod tests {
-    use super::forum_visible_status;
+    use super::{forum_visible_status, normalize_optional_rfc3339};
 
     #[test]
     fn visible_forum_statuses_match_owner_eligibility() {
@@ -741,5 +778,11 @@ mod tests {
         assert_eq!(forum_visible_status("forum_topic"), Some("open"));
         assert_eq!(forum_visible_status("forum_reply"), Some("approved"));
         assert_eq!(forum_visible_status("product"), None);
+    }
+
+    #[test]
+    fn date_bounds_require_rfc3339() {
+        assert!(normalize_optional_rfc3339("published_from", Some("2026-07-31T00:00:00Z")).is_ok());
+        assert!(normalize_optional_rfc3339("published_from", Some("2026-07-31")).is_err());
     }
 }

--- a/crates/rustok-search/src/graphql/forum_storefront.rs
+++ b/crates/rustok-search/src/graphql/forum_storefront.rs
@@ -34,9 +34,9 @@ pub struct ForumStorefrontSearchQuery;
 #[Object]
 impl ForumStorefrontSearchQuery {
     /// Executes published Search through the Forum-owned richer category scope,
-    /// exact topic/reply result eligibility and optional exact author, tag and
-    /// solved-state scope. The input must explicitly select only the `forum` source
-    /// and at least one category root.
+    /// exact topic/reply result eligibility and optional exact author, tag,
+    /// solved-state and inclusive published-date scope. The input must explicitly
+    /// select only the `forum` source and at least one category root.
     async fn forum_storefront_search(
         &self,
         ctx: &Context<'_>,
@@ -44,6 +44,8 @@ impl ForumStorefrontSearchQuery {
         author_ids: Option<Vec<String>>,
         tags: Option<Vec<String>>,
         solved: Option<bool>,
+        published_from: Option<String>,
+        published_to: Option<String>,
     ) -> Result<SearchPreviewPayload> {
         require_module_enabled(ctx, FORUM_MODULE_SLUG).await?;
         enforce_rate_limit(ctx).await?;
@@ -100,6 +102,8 @@ impl ForumStorefrontSearchQuery {
             author_ids: author_ids.unwrap_or_default(),
             tags: tags.unwrap_or_default(),
             solved,
+            published_from,
+            published_to,
             attribute_filters: input
                 .attribute_filters
                 .unwrap_or_default()

--- a/crates/rustok-search/storefront/src/transport/forum_graphql_adapter.rs
+++ b/crates/rustok-search/storefront/src/transport/forum_graphql_adapter.rs
@@ -7,6 +7,7 @@ use super::{ApiError, configured_tenant_slug};
 const FORUM_STOREFRONT_SEARCH_QUERY: &str = "query ForumStorefrontSearch($input: SearchPreviewInput!) { forumStorefrontSearch(input: $input) { queryLogId presetKey total tookMs engine rankingProfile items { id entityType sourceModule title snippet score locale url payload } facets { name buckets { value label count } } } }";
 const FORUM_STOREFRONT_SEARCH_BY_AUTHORS_QUERY: &str = "query ForumStorefrontSearchByAuthors($input: SearchPreviewInput!, $authorIds: [String!]!) { forumStorefrontSearch(input: $input, authorIds: $authorIds) { queryLogId presetKey total tookMs engine rankingProfile items { id entityType sourceModule title snippet score locale url payload } facets { name buckets { value label count } } } }";
 const FORUM_STOREFRONT_SEARCH_BY_FILTERS_QUERY: &str = "query ForumStorefrontSearchByFilters($input: SearchPreviewInput!, $authorIds: [String!], $tags: [String!], $solved: Boolean) { forumStorefrontSearch(input: $input, authorIds: $authorIds, tags: $tags, solved: $solved) { queryLogId presetKey total tookMs engine rankingProfile items { id entityType sourceModule title snippet score locale url payload } facets { name buckets { value label count } } } }";
+const FORUM_STOREFRONT_SEARCH_BY_DATE_WINDOW_QUERY: &str = "query ForumStorefrontSearchByDateWindow($input: SearchPreviewInput!, $authorIds: [String!], $tags: [String!], $solved: Boolean, $publishedFrom: String, $publishedTo: String) { forumStorefrontSearch(input: $input, authorIds: $authorIds, tags: $tags, solved: $solved, publishedFrom: $publishedFrom, publishedTo: $publishedTo) { queryLogId presetKey total tookMs engine rankingProfile items { id entityType sourceModule title snippet score locale url payload } facets { name buckets { value label count } } } }";
 
 #[derive(Debug, Deserialize)]
 struct ForumStorefrontSearchResponse {
@@ -33,6 +34,19 @@ struct FilterSearchPreviewVariables {
     author_ids: Option<Vec<String>>,
     tags: Option<Vec<String>>,
     solved: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+struct DateWindowSearchPreviewVariables {
+    input: SearchPreviewInput,
+    #[serde(rename = "authorIds")]
+    author_ids: Option<Vec<String>>,
+    tags: Option<Vec<String>>,
+    solved: Option<bool>,
+    #[serde(rename = "publishedFrom")]
+    published_from: Option<String>,
+    #[serde(rename = "publishedTo")]
+    published_to: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -135,6 +149,41 @@ pub async fn fetch_search_with_filters(
                 author_ids: (!author_ids.is_empty()).then_some(author_ids),
                 tags: (!tags.is_empty()).then_some(tags),
                 solved,
+            }),
+        ),
+        None,
+        configured_tenant_slug(),
+        None,
+    )
+    .await
+    .map_err(|error| ApiError::Graphql(error.to_string()))?;
+
+    Ok(response.forum_storefront_search)
+}
+
+pub async fn fetch_search_with_date_window(
+    query: String,
+    locale: Option<String>,
+    preset_key: Option<String>,
+    filters: SearchPreviewFilters,
+    author_ids: Vec<String>,
+    tags: Vec<String>,
+    solved: Option<bool>,
+    published_from: Option<String>,
+    published_to: Option<String>,
+) -> Result<SearchPreviewPayload, ApiError> {
+    let input = search_preview_input(query, locale, preset_key, filters);
+    let response: ForumStorefrontSearchResponse = execute_graphql(
+        &graphql_url(),
+        GraphqlRequest::new(
+            FORUM_STOREFRONT_SEARCH_BY_DATE_WINDOW_QUERY,
+            Some(DateWindowSearchPreviewVariables {
+                input,
+                author_ids: (!author_ids.is_empty()).then_some(author_ids),
+                tags: (!tags.is_empty()).then_some(tags),
+                solved,
+                published_from,
+                published_to,
             }),
         ),
         None,

--- a/crates/rustok-search/storefront/src/transport/forum_native_server_adapter.rs
+++ b/crates/rustok-search/storefront/src/transport/forum_native_server_adapter.rs
@@ -45,6 +45,32 @@ pub async fn fetch_search_with_filters(
     .map_err(ApiError::from)
 }
 
+pub async fn fetch_search_with_date_window(
+    query: String,
+    locale: Option<String>,
+    preset_key: Option<String>,
+    filters: SearchPreviewFilters,
+    author_ids: Vec<String>,
+    tags: Vec<String>,
+    solved: Option<bool>,
+    published_from: Option<String>,
+    published_to: Option<String>,
+) -> Result<SearchPreviewPayload, ApiError> {
+    forum_storefront_search_by_date_window_native(
+        query,
+        locale,
+        preset_key,
+        filters,
+        author_ids,
+        tags,
+        solved,
+        published_from,
+        published_to,
+    )
+    .await
+    .map_err(ApiError::from)
+}
+
 #[server(prefix = "/api/fn", endpoint = "search/forum-storefront-search")]
 async fn forum_storefront_search_native(
     query: String,
@@ -59,6 +85,8 @@ async fn forum_storefront_search_native(
         filters,
         Vec::new(),
         Vec::new(),
+        None,
+        None,
         None,
     )
     .await
@@ -83,6 +111,8 @@ async fn forum_storefront_search_by_authors_native(
         author_ids,
         Vec::new(),
         None,
+        None,
+        None,
     )
     .await
 }
@@ -101,7 +131,44 @@ async fn forum_storefront_search_by_filters_native(
     solved: Option<bool>,
 ) -> Result<SearchPreviewPayload, ServerFnError> {
     execute_forum_storefront_search_native(
-        query, locale, preset_key, filters, author_ids, tags, solved,
+        query,
+        locale,
+        preset_key,
+        filters,
+        author_ids,
+        tags,
+        solved,
+        None,
+        None,
+    )
+    .await
+}
+
+#[server(
+    prefix = "/api/fn",
+    endpoint = "search/forum-storefront-search-by-date-window"
+)]
+async fn forum_storefront_search_by_date_window_native(
+    query: String,
+    locale: Option<String>,
+    preset_key: Option<String>,
+    filters: SearchPreviewFilters,
+    author_ids: Vec<String>,
+    tags: Vec<String>,
+    solved: Option<bool>,
+    published_from: Option<String>,
+    published_to: Option<String>,
+) -> Result<SearchPreviewPayload, ServerFnError> {
+    execute_forum_storefront_search_native(
+        query,
+        locale,
+        preset_key,
+        filters,
+        author_ids,
+        tags,
+        solved,
+        published_from,
+        published_to,
     )
     .await
 }
@@ -114,6 +181,8 @@ async fn execute_forum_storefront_search_native(
     author_ids: Vec<String>,
     tags: Vec<String>,
     solved: Option<bool>,
+    published_from: Option<String>,
+    published_to: Option<String>,
 ) -> Result<SearchPreviewPayload, ServerFnError> {
     #[cfg(feature = "ssr")]
     {
@@ -164,6 +233,8 @@ async fn execute_forum_storefront_search_native(
             author_ids,
             tags,
             solved,
+            published_from,
+            published_to,
             attribute_filters: filters
                 .attribute_filters
                 .into_iter()
@@ -198,7 +269,17 @@ async fn execute_forum_storefront_search_native(
     }
     #[cfg(not(feature = "ssr"))]
     {
-        let _ = (query, locale, preset_key, filters, author_ids, tags, solved);
+        let _ = (
+            query,
+            locale,
+            preset_key,
+            filters,
+            author_ids,
+            tags,
+            solved,
+            published_from,
+            published_to,
+        );
         Err(ServerFnError::new(
             "Forum storefront Search requires the `ssr` feature",
         ))

--- a/crates/rustok-search/storefront/src/transport/mod.rs
+++ b/crates/rustok-search/storefront/src/transport/mod.rs
@@ -185,6 +185,59 @@ pub async fn fetch_forum_search_with_filters(
     .await
 }
 
+pub async fn fetch_forum_search_with_date_window(
+    query: String,
+    locale: Option<String>,
+    preset_key: Option<String>,
+    filters: SearchPreviewFilters,
+    author_ids: Vec<String>,
+    tags: Vec<String>,
+    solved: Option<bool>,
+    published_from: Option<String>,
+    published_to: Option<String>,
+) -> Result<SearchPreviewPayload, SearchTransportError> {
+    let native_query = query.clone();
+    let native_locale = locale.clone();
+    let native_preset_key = preset_key.clone();
+    let native_filters = filters.clone();
+    let native_author_ids = author_ids.clone();
+    let native_tags = tags.clone();
+    let native_published_from = published_from.clone();
+    let native_published_to = published_to.clone();
+
+    execute_selected_transport(
+        "search",
+        selected_transport_path(),
+        move || {
+            forum_native_server_adapter::fetch_search_with_date_window(
+                native_query,
+                native_locale,
+                native_preset_key,
+                native_filters,
+                native_author_ids,
+                native_tags,
+                solved,
+                native_published_from,
+                native_published_to,
+            )
+        },
+        move || {
+            forum_graphql_adapter::fetch_search_with_date_window(
+                query,
+                locale,
+                preset_key,
+                filters,
+                author_ids,
+                tags,
+                solved,
+                published_from,
+                published_to,
+            )
+        },
+    )
+    .await
+}
+
 fn is_explicit_forum_category_scope(filters: &SearchPreviewFilters) -> bool {
     !filters.category_ids.is_empty()
         && filters.source_modules.len() == 1

--- a/scripts/verify/verify-forum-search-locale-date-filter.mjs
+++ b/scripts/verify/verify-forum-search-locale-date-filter.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(".");
+const failures = [];
+const paths = {
+  contract: "crates/rustok-forum/contracts/forum-search-locale-date-filter.json",
+  note: "crates/rustok-forum/docs/forum-23b2f3-search-locale-date-filter.md",
+  projection: "crates/rustok-forum/src/search_projection.rs",
+  filters: "crates/rustok-search/src/forum_document_filters.rs",
+  execution: "crates/rustok-search/src/forum_storefront_execution.rs",
+  searchLib: "crates/rustok-search/src/lib.rs",
+  graphqlOwner: "crates/rustok-search/src/graphql/forum_storefront.rs",
+  graphqlTypes: "crates/rustok-search/src/graphql/types.rs",
+  storefrontModel: "crates/rustok-search/storefront/src/model.rs",
+  graphqlAdapter:
+    "crates/rustok-search/storefront/src/transport/forum_graphql_adapter.rs",
+  nativeAdapter:
+    "crates/rustok-search/storefront/src/transport/forum_native_server_adapter.rs",
+  transportFacade: "crates/rustok-search/storefront/src/transport/mod.rs",
+  engine: "crates/rustok-search/src/engine.rs",
+};
+const forbiddenParallelPaths = [
+  "crates/rustok-search/src/forum_storefront_date_execution.rs",
+  "crates/rustok-search/src/forum_storefront_date_execution/types_and_execute.rs",
+  "crates/rustok-search/src/forum_storefront_date_execution/result_scan.rs",
+  "crates/rustok-search/src/forum_storefront_date_execution/normalization.rs",
+  "crates/rustok-search/src/forum_storefront_locale_date_filters.rs",
+];
+
+function read(relativePath) {
+  const target = path.join(root, relativePath);
+  if (!existsSync(target)) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return "";
+  }
+  return readFileSync(target, "utf8");
+}
+function requireAll(source, markers, label) {
+  for (const marker of markers) {
+    if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+  }
+}
+function rejectAll(source, markers, label) {
+  for (const marker of markers) {
+    if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+  }
+}
+function parseJson(relativePath) {
+  try {
+    return JSON.parse(read(relativePath));
+  } catch (error) {
+    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+for (const relativePath of forbiddenParallelPaths) {
+  if (existsSync(path.join(root, relativePath))) {
+    failures.push(`${relativePath}: parallel Forum date execution path is forbidden`);
+  }
+}
+
+const contract = parseJson(paths.contract);
+const note = read(paths.note);
+const projection = read(paths.projection);
+const filters = read(paths.filters);
+const execution = read(paths.execution);
+const searchLib = read(paths.searchLib);
+const graphqlOwner = read(paths.graphqlOwner);
+const graphqlTypes = read(paths.graphqlTypes);
+const storefrontModel = read(paths.storefrontModel);
+const graphqlAdapter = read(paths.graphqlAdapter);
+const nativeAdapter = read(paths.nativeAdapter);
+const transportFacade = read(paths.transportFacade);
+const engine = read(paths.engine);
+
+requireAll(projection, [
+  '"published_at": created_at.to_rfc3339()',
+  '"topic_tags": topic_tags',
+  '"is_solution": is_solution',
+], paths.projection);
+if (projection.split('"published_at": created_at.to_rfc3339()').length - 1 !== 2) {
+  failures.push(`${paths.projection}: topic and reply timestamp projections are required`);
+}
+requireAll(filters, [
+  "pub exact_locale: Option<String>",
+  "pub published_from: Option<DateTime<Utc>>",
+  "pub published_to: Option<DateTime<Utc>>",
+  "has_date_window",
+  "DateTime::parse_from_rfc3339",
+  "exact_locale_preserves_categories_and_fails_closed_on_missing_locale",
+  "published_window_is_inclusive_and_excludes_categories",
+  "malformed_or_missing_published_projection_fails_closed",
+], paths.filters);
+rejectAll(filters, ["rustok_forum", "forum_topic::", "forum_reply::"], paths.filters);
+requireAll(execution, [
+  "pub published_from: Option<String>",
+  "pub published_to: Option<String>",
+  "pub async fn execute_forum_storefront_search",
+  "locale: Some(effective_locale.clone())",
+  "all_items.retain(|item| document_filters.matches(item))",
+  "let raw_total =",
+  "let candidates = all_items",
+  "let total = visible_items.len() as u64",
+  'normalize_optional_rfc3339("published_from"',
+  'normalize_optional_rfc3339("published_to"',
+  "published_from must not be after published_to",
+], paths.execution);
+if (execution.indexOf("let raw_total =") > execution.indexOf("document_filters.matches(item)")) {
+  failures.push(`${paths.execution}: raw bound must precede document narrowing`);
+}
+rejectAll(execution, [
+  "execute_forum_storefront_search_with_date_window",
+  "ForumStorefrontSearchDateWindowRequest",
+], paths.execution);
+rejectAll(searchLib, [
+  "forum_storefront_date_execution",
+  "forum_storefront_locale_date_filters",
+  "execute_forum_storefront_search_with_date_window",
+], paths.searchLib);
+requireAll(graphqlOwner, [
+  "published_from: Option<String>",
+  "published_to: Option<String>",
+  "execute_forum_storefront_search",
+], paths.graphqlOwner);
+rejectAll(graphqlOwner, [
+  "ForumStorefrontSearchDateWindowRequest",
+  "execute_forum_storefront_search_with_date_window",
+], paths.graphqlOwner);
+requireAll(graphqlAdapter, [
+  "ForumStorefrontSearchByDateWindow",
+  "$publishedFrom: String",
+  "$publishedTo: String",
+  "fetch_search_with_date_window",
+], paths.graphqlAdapter);
+requireAll(nativeAdapter, [
+  'endpoint = "search/forum-storefront-search-by-date-window"',
+  "fetch_search_with_date_window",
+  "execute_forum_storefront_search_native",
+], paths.nativeAdapter);
+rejectAll(nativeAdapter, [
+  "execute_forum_storefront_search_date_window_native",
+  "ForumStorefrontSearchDateWindowRequest",
+], paths.nativeAdapter);
+requireAll(transportFacade, [
+  "pub async fn fetch_forum_search_with_date_window",
+  "forum_native_server_adapter::fetch_search_with_date_window",
+  "forum_graphql_adapter::fetch_search_with_date_window",
+], paths.transportFacade);
+requireAll(graphqlAdapter, [
+  "ForumStorefrontSearch($input: SearchPreviewInput!)",
+  "ForumStorefrontSearchByAuthors",
+  "ForumStorefrontSearchByFilters",
+], `${paths.graphqlAdapter} legacy operations`);
+requireAll(nativeAdapter, [
+  'endpoint = "search/forum-storefront-search"',
+  'endpoint = "search/forum-storefront-search-by-authors"',
+  'endpoint = "search/forum-storefront-search-by-filters"',
+], `${paths.nativeAdapter} legacy endpoints`);
+rejectAll(graphqlTypes, ["published_from", "published_to", "publishedFrom", "publishedTo"], paths.graphqlTypes);
+rejectAll(storefrontModel, ["published_from", "published_to", "publishedFrom", "publishedTo"], paths.storefrontModel);
+rejectAll(engine, ["published_from", "published_to", "ForumStorefrontLocaleDateFilters"], paths.engine);
+requireAll(note, [
+  "# FORUM-23B2F3 exact Forum Search locale and date filters",
+  "does not create a second execution",
+  "Locale-only execution preserves Forum categories",
+  "does **not** add storefront UI controls",
+], paths.note);
+
+if (contract) {
+  if (contract.task !== "FORUM-23B2F3") failures.push(`${paths.contract}: unexpected task`);
+  if (contract.status !== "source_complete_execution_pending") failures.push(`${paths.contract}: unexpected status`);
+  if (contract.architecture?.single_execution_owner !== true) failures.push(`${paths.contract}: single execution owner is not locked`);
+  if (contract.architecture?.separate_date_execution_module_allowed !== false) failures.push(`${paths.contract}: duplicate date owner is not forbidden`);
+  if (contract.input?.date_format !== "RFC3339") failures.push(`${paths.contract}: date format drift`);
+  if (!contract.evaluation?.raw_candidate_limit_is_checked_before_date_narrowing) failures.push(`${paths.contract}: raw ordering invariant missing`);
+  if (contract.transport_compatibility?.existing_wire_signatures_changed !== false) failures.push(`${paths.contract}: legacy wire signatures changed`);
+  if (contract.compatibility?.search_query_shape_changed !== false) failures.push(`${paths.contract}: neutral SearchQuery changed`);
+}
+
+if (failures.length > 0) {
+  console.error("FORUM-23B2F3 Search locale/date verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+console.log("FORUM-23B2F3 Search locale/date source contract is consistent.");


### PR DESCRIPTION
## Summary

- recheck the unfinished `FORUM-23B2F3` draft against the current `main` and repository ownership rules
- add exact effective-locale and inclusive RFC3339 published-date filtering to the existing Forum storefront Search execution owner
- keep the stable 100-row raw candidate bound, Forum owner eligibility, visible totals, facets and pagination in one path
- project Forum topic/reply `published_at` values from owner `created_at`
- add GraphQL and native date-window transport parity without changing existing operation or endpoint signatures
- add a machine contract, owner note and fail-closed verifier that rejects the previous parallel date-execution modules

## Recheck findings

The superseded PR #2658 was 31 commits behind the audited `main` and implemented a second execution/normalization/candidate-scan path for the date window. That duplicated the existing Forum Search owner and could drift in validation, authorization, totals, facets, pagination and query-rule behavior. This PR replaces that design with one `forum_storefront_execution.rs` path and one `ForumStorefrontDocumentFilters` owner.

The old PR also did not update the canonical Forum implementation plan despite its description. The connector used for this repair cannot safely patch that very large file in place; this PR therefore records the exact F3 scope and remaining work in the task contract and owner note, but the canonical ledger still needs a focused textual synchronization from F2 to F3.

## Compatibility

- no migration or dependency change
- no neutral `SearchQuery`, `SearchPreviewInput` or shared storefront filter DTO change
- existing GraphQL operations and native endpoints retain their signatures
- legacy documents without projected `published_at` fail closed only when a date window is active, until reindexed
- ordinary, mixed-source, Product and admin Search paths are unchanged

## Verification

Tests, verifiers, Cargo checks and runtime evidence were intentionally not run by request. Suggested commands are recorded in `crates/rustok-forum/docs/forum-23b2f3-search-locale-date-filter.md`.