### PR TITLE
docs(forum): synchronize FORUM-23B2F3 plans

### DIFF
--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -229,7 +229,7 @@ at the end of this file remain authoritative.
 | `FORUM-20` | `in_progress` | FORUM-20A-AZ provide inherited and richer category/topic visibility, recipient-aware Forum notification authorization, the Notifications inbox/group owner plane, authenticated storefront ports, native and GraphQL read/open/write transport parity, grouped UI and navigation, exact topic/reply create authorization, topic-local reply narrowing, inherited moderation audiences, and existing solution-route transport composition. FORUM-20BA synchronizes the canonical ledger and owner notes after FORUM-20AV-AZ. Remaining read/search/index/SEO/deep-link migration, visibility-scoped bulk read commands, future moderation transport reuse, scheduled reconciliation/redaction, delivery transports and PostgreSQL cross-consumer evidence remain. |
 | `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |
 | `FORUM-22` | `planned` | Topic kinds, wiki/announcement/Q&A policies and scheduled lifecycle. |
-| `FORUM-23` | `in_progress` | FORUM-23A through FORUM-23A11 harden public-author Search projections and durable privacy invalidation; FORUM-23B1 adds exact Forum category filtering; FORUM-23B2A publishes a bounded Forum-owned public/authenticated category-subtree scope; FORUM-23B2B applies the complete delivered richer category audience decision before subtree IDs leave Forum; FORUM-23B2C composes that scope into explicit GraphQL and native Forum-only storefront Search execution; FORUM-23B2D applies exact topic-local and approved-reply result eligibility before visible Search totals, facets and pagination; FORUM-23B2E1 binds storefront channel selection to trusted `RequestContext`; FORUM-23B2E2 projects canonical Product channel allowlists and applies one fail-closed storefront predicate to Product-bearing Search paths; FORUM-23B2F1 adds an exact bounded Forum author filter; FORUM-23B2F2 adds exact bounded Forum tag and solved filters before owner eligibility, visible totals, facets and pagination. Remaining locale, date, kind, channel/group and attachment-presence filters, owner revision ordering/reconciliation and maintainer runtime evidence remain. |
+| `FORUM-23` | `in_progress` | FORUM-23A through FORUM-23A11 harden public-author Search projections and durable privacy invalidation; FORUM-23B1 adds exact Forum category filtering; FORUM-23B2A publishes a bounded Forum-owned public/authenticated category-subtree scope; FORUM-23B2B applies the complete delivered richer category audience decision before subtree IDs leave Forum; FORUM-23B2C composes that scope into explicit GraphQL and native Forum-only storefront Search execution; FORUM-23B2D applies exact topic-local and approved-reply result eligibility before visible Search totals, facets and pagination; FORUM-23B2E1 binds storefront channel selection to trusted `RequestContext`; FORUM-23B2E2 projects canonical Product channel allowlists and applies one fail-closed storefront predicate to Product-bearing Search paths; FORUM-23B2F1 adds an exact bounded Forum author filter; FORUM-23B2F2 adds exact bounded Forum tag and solved filters; FORUM-23B2F3 locks exact requested/fallback locale and adds inclusive published date-window filters before owner eligibility, visible totals, facets and pagination. Remaining kind, channel/group and attachment-presence filters, owner revision ordering/reconciliation and maintainer runtime evidence remain. |
 | `FORUM-24` | `planned` | Localized routes, canonical URLs and aliases. |
 | `FORUM-25` | `planned` | Full content/UI multilingual contract and RTL support. |
 | `FORUM-26` | `in_progress` | FORUM-26A-J provide authoritative Forum trust state/facts, posting-policy contracts, evaluation/composition, account-age, topics-read, approved-post and topic/reply create-window facts, plus pre-enforcement author/query-plan hardening. Active flags/moderation history, reputation, edit windows, bump age, policy persistence, owner enforcement, shared rate-limit execution, duplicate hashing, optional scoring, transports, UI and maintainer runtime evidence remain. |
@@ -1840,13 +1840,39 @@ attachment presence.
   semantics, ordering, compatibility and degraded-mode contract while recording
   execution and reindex evidence as pending.
 
+### Delivered in `FORUM-23B2F3`
+
+- every explicit Forum-only GraphQL/native wire operation delegates to one shared
+  execution owner that normalizes the requested locale or tenant fallback and uses
+  it for PostgreSQL FTS/typo scope, category scope, owner eligibility and a
+  post-scan exact result assertion; missing or mismatched locale fails closed;
+- locale-only execution retains category, topic and reply results and query-rule
+  pins; no multi-locale candidate union is introduced;
+- topics and approved replies project Forum-owned creation time as UTC RFC3339
+  `payload.published_at`; legacy rows without it fail closed for date windows until
+  reindexed;
+- optional inclusive `published_from` / `published_to` bounds accept RFC3339, may
+  be one-sided, reject reversed ranges, exclude categories and fail closed on
+  malformed projected timestamps;
+- date narrowing intersects author/tag/solved after the stable bounded raw snapshot
+  and before exact Forum owner eligibility, visible totals, facets, offset and limit;
+- existing legacy, author-only and B2F2 GraphQL/native wire signatures remain
+  unchanged; date windows use additive `ForumStorefrontSearchByDateWindow` and
+  `search/forum-storefront-search-by-date-window` transports;
+- `forum-search-locale-date-filter.json`,
+  `forum-23b2f3-search-locale-date-filter.md`, and
+  `verify-forum-search-locale-date-filter.mjs` lock locale, projection, range,
+  ordering, compatibility and degraded-mode behavior while execution/reindex
+  evidence remains pending.
+
 ### Compatibility and degraded mode
 
 No database migration, manual backfill, Search query shape, dependency, public
 DTO or `Cargo.lock` change is required by
-`FORUM-23B2A/B2B/B2C/B2D/B2E1/B2E2/B2F1/B2F2`. `FORUM-23B2F2` extends the
-Forum reply projection payload with parent-topic `topic_tags`; legacy reply rows
-require reindex before positive tag matches and fail closed until repaired. The
+`FORUM-23B2A/B2B/B2C/B2D/B2E1/B2E2/B2F1/B2F2/B2F3`. `FORUM-23B2F2` extends
+the Forum reply projection payload with parent-topic `topic_tags`; `FORUM-23B2F3`
+extends topic and reply payloads with Forum-owned `published_at`. Legacy rows
+require reindex before positive tag/date matches and fail closed until repaired. The
 Search-owned Product payload gains the
 channel allowlist projection, and missing legacy projections are repaired by a
 bounded PostgreSQL background worker started during server bootstrap.
@@ -1872,13 +1898,15 @@ malformed explicit owner values remain hidden until Product is corrected. An act
 Forum author scope uses only the public projected author identity, excludes categories and
 missing/redacted authors, and suppresses query-rule pins. Tag/solved scopes use only
 Forum-projected state, exclude categories, intersect with author scope, and suppress pins.
-Legacy replies without `topic_tags` fail closed for tag queries until reindexed; existing
-legacy and author-only GraphQL/native operations remain unchanged. Admin/global Search
-behavior remains unchanged.
+Legacy replies without `topic_tags` fail closed for tag queries until reindexed. Exact
+requested/fallback locale scopes every explicit Forum transport and post-scan result; date
+windows use Forum-projected timestamps and legacy topic/reply rows fail closed until
+reindexed. Existing legacy, author-only and B2F2 GraphQL/native wire signatures remain
+unchanged. Admin/global Search behavior remains unchanged.
 
 ### Remaining scope
 
-- add locale, date, kind, channel/group and attachment-presence query filters;
+- add kind, channel/group and attachment-presence query filters;
 - complete owner-issued monotonic projection revisions, durable inbox ordering,
   reconciliation and deletion or ACL-change document cleanup;
 - capture maintainer-executed PostgreSQL query/result evidence and the
@@ -1916,6 +1944,7 @@ node scripts/verify/verify-forum-search-trusted-channel-authority.mjs
 node scripts/verify/verify-forum-search-product-channel-visibility.mjs
 node scripts/verify/verify-forum-search-author-filter.mjs
 node scripts/verify/verify-forum-search-tag-solved-filter.mjs
+node scripts/verify/verify-forum-search-locale-date-filter.mjs
 cargo check -p rustok-search --features graphql --all-targets
 cargo check -p rustok-search-storefront --features ssr --all-targets
 cargo check -p rustok-server --features mod-forum --all-targets
@@ -1923,7 +1952,7 @@ cargo xtask module validate forum
 cargo xtask module validate search
 ```
 
-The `FORUM-23B2A/B2B/B2C/B2D/B2E1/B2E2/B2F1/B2F2` source and contract records do not
+The `FORUM-23B2A/B2B/B2C/B2D/B2E1/B2E2/B2F1/B2F2/B2F3` source and contract records do not
 claim successful runtime verification until the maintainer runs the commands above.
 
 ## `FORUM-24` — localized routes, canonical URLs and aliases
@@ -2710,6 +2739,7 @@ node scripts/verify/verify-forum-search-storefront-scope.mjs
 node scripts/verify/verify-forum-search-result-eligibility.mjs
 node scripts/verify/verify-forum-search-author-filter.mjs
 node scripts/verify/verify-forum-search-tag-solved-filter.mjs
+node scripts/verify/verify-forum-search-locale-date-filter.mjs
 cargo check -p rustok-search --features graphql --all-targets
 cargo check -p rustok-search-storefront --features ssr --all-targets
 cargo check -p rustok-server --features mod-forum --all-targets
@@ -2769,9 +2799,9 @@ Recommended next slices:
     transports through the delivered context-aware owner boundary;
 13. continue `FORUM-26` with authoritative active-flag and moderation-history
     fact adapters, keeping every missing owner capability explicitly unavailable;
-14. continue `FORUM-23` with locale, date, kind, channel/group and
-    attachment-presence filters before owner revision ordering and reconciliation;
-    execute B2D/F1/F2 evidence with `LINK-FORUM-03` only after ordering is stable;
+14. continue `FORUM-23` with kind, channel/group and attachment-presence
+    filters before owner revision ordering and reconciliation; execute B2D/F1/F2/F3
+    evidence with `LINK-FORUM-03` only after ordering is stable;
 15. `LINK-FORUM-01` and `LINK-FORUM-03` only after their owner contracts are
     stable.
 

--- a/crates/rustok-search/docs/implementation-plan.md
+++ b/crates/rustok-search/docs/implementation-plan.md
@@ -99,6 +99,21 @@ a Forum Search reindex. Existing GraphQL/native legacy and author-only operation
 neutral DTOs, mixed/Product/admin Search and unfiltered behavior remain unchanged.
 Runtime and reindex evidence remain pending.
 
+`FORUM-23B2F3` adds a shared Forum-only locale/date execution owner while
+preserving the legacy, author-only and B2F2 GraphQL/native wire operations. The requested
+locale or tenant fallback is normalized once and becomes the exact PostgreSQL
+FTS/typo locale, category-scope locale, owner-eligibility locale and post-scan
+result assertion. Optional inclusive RFC3339 `published_from` / `published_to`
+bounds use Forum-projected `payload.published_at` on topics and approved replies.
+The stable raw 100-candidate cap remains before date narrowing; exact locale and
+active author/tag/solved/date predicates intersect before owner eligibility and
+visible totals/facets/pagination. Locale-only execution retains categories and
+query-rule pins, while an active date window excludes categories and suppresses
+pins. Legacy topic/reply documents without the new timestamp fail closed until a
+Forum Search reindex. Neutral DTOs, `SearchQuery`, mixed/Product/admin Search and
+existing wire signatures remain unchanged. Runtime and reindex evidence remain
+pending.
+
 Search settings have one owner boundary. Tenant-effective settings are read and
 written through `SearchSettingsService` and the `search_settings` table. The
 server-wide generic `platform_settings` service no longer admits a `search`
@@ -201,6 +216,11 @@ projection can remain stale after recovery.
 - Exact Forum tag and solved contract and guardrail:
   `crates/rustok-forum/contracts/forum-search-tag-solved-filter.json` and
   `scripts/verify/verify-forum-search-tag-solved-filter.mjs`.
+- Exact Forum locale and date filter status:
+  `source_complete_execution_pending` under `FORUM-23B2F3`.
+- Exact Forum locale/date contract and guardrail:
+  `crates/rustok-forum/contracts/forum-search-locale-date-filter.json` and
+  `scripts/verify/verify-forum-search-locale-date-filter.mjs`.
 - GraphQL and all native/admin mappings use the same Search-owned URL function.
 - The removed storefront `transport/navigation.rs` path is forbidden by the
   canonical URL guardrail.
@@ -220,6 +240,8 @@ projection can remain stale after recovery.
   `FORUM-23B2F1`.
 - Exact Forum tag and solved filtering is `source_complete_execution_pending` under
   `FORUM-23B2F2`.
+- Exact Forum locale and date filtering is `source_complete_execution_pending` under
+  `FORUM-23B2F3`.
 - Durable non-Forum projection replay/recovery remains `blocked`.
 
 ## Deployment and connector boundary
@@ -296,10 +318,14 @@ rebuild behavior through replayable event transport.
     projection for approved replies, additive GraphQL/native filter operations,
     pre-eligibility intersection, post-authorization totals/facets/pagination, and
     fail-closed legacy reply behavior under `FORUM-23B2F2`.
+22. Added exact requested/fallback locale enforcement and inclusive RFC3339
+    published date-window filtering through an additive Forum-only execution owner,
+    Forum-owned topic/reply timestamp projection, post-scan locale assertion and
+    fail-closed legacy projection behavior under `FORUM-23B2F3`.
 
 ## Next results
 
-1. **Complete remaining Forum storefront query filters.** Add locale, date, kind,
+1. **Complete remaining Forum storefront query filters.** Add kind,
    channel/group and attachment-presence filters without moving owner
    authorization into Search. **Done when:** GraphQL/native Forum-only Search expose
    the same bounded filter contract and every owner-sensitive result still passes
@@ -341,6 +367,7 @@ should run the relevant subset, including:
 - `cargo test -p rustok-search storefront_category_scope -- --nocapture`
 - `cargo test -p rustok-search storefront_result_eligibility -- --nocapture`
 - `cargo test -p rustok-search forum_document_filters -- --nocapture`
+- `cargo test -p rustok-search forum_storefront_locale_date_filters -- --nocapture`
 - `cargo test -p rustok-search storefront_product_channel_visibility -- --nocapture`
 - `cargo test -p rustok-search product_channel_visibility_legacy_projection_is_detected -- --nocapture`
 - `cargo test -p rustok-search product_channel_reconciliation -- --nocapture`
@@ -353,6 +380,8 @@ should run the relevant subset, including:
 - `node scripts/verify/verify-forum-search-result-eligibility.mjs`
 - `node scripts/verify/verify-forum-search-product-channel-visibility.mjs`
 - `node scripts/verify/verify-forum-search-author-filter.mjs`
+- `node scripts/verify/verify-forum-search-tag-solved-filter.mjs`
+- `node scripts/verify/verify-forum-search-locale-date-filter.mjs`
 - `npm run verify:search:canonical-url`
 - `npm run test:verify:search:canonical-url`
 - `npm run verify:search:blog-projection`
@@ -372,3 +401,5 @@ should run the relevant subset, including:
 - [Forum exact-category contract](../../rustok-forum/contracts/forum-search-exact-category-filter.json)
 - [Forum result-eligibility contract](../../rustok-forum/contracts/forum-search-result-eligibility.json)
 - [Forum author-filter contract](../../rustok-forum/contracts/forum-search-author-filter.json)
+- [Forum tag/solved contract](../../rustok-forum/contracts/forum-search-tag-solved-filter.json)
+- [Forum locale/date contract](../../rustok-forum/contracts/forum-search-locale-date-filter.json)


### PR DESCRIPTION
## Summary

- synchronize the canonical Forum implementation plan with the already merged `FORUM-23B2F3` locale/date Search slice
- synchronize the Search implementation plan and FFA/FBA status entry
- remove locale/date from the remaining filter list while retaining kind, channel/group and attachment-presence filters
- record runtime, PostgreSQL and reindex evidence as still pending

## Safety

The two plan blobs were taken from the superseded F3 branch only after verifying that their F3 text describes the unified shared execution owner now present on `main`. No code, dependency, migration or runtime contract changes are included.

## Verification

Tests and verifiers were intentionally not run by request. This PR changes documentation only.