### PR TITLE
fix(payment): sanitize execution UUID and serde diagnostics

### DIFF
--- a/crates/rustok-payment/contracts/evidence/checkout-execution-uuid-serde-diagnostic-safety-source.json
+++ b/crates/rustok-payment/contracts/evidence/checkout-execution-uuid-serde-diagnostic-safety-source.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "status": "payment_checkout_execution_uuid_serde_diagnostic_safety_source_reviewed_unvalidated",
+  "owner": "rustok-payment",
+  "boundary": "checkout_payment_execution_port",
+  "scope": "tenant UUID parse and durable provider-result serde diagnostics",
+  "source_contract": {
+    "uuid_diagnostic_site_count": 1,
+    "serde_diagnostic_site_count": 1,
+    "complete_uuid_error_logged": false,
+    "complete_serde_error_logged": false,
+    "tenant_id_text_logged": false,
+    "provider_result_payload_logged": false,
+    "tenant_id_length_logged": true,
+    "tenant_parse_failure_fact_logged": true,
+    "provider_result_decode_failure_fact_logged": true,
+    "provider_result_kind_logged": true,
+    "provider_result_collection_length_logged": true,
+    "tenant_validation_mapping_preserved": true,
+    "persisted_provider_result_mapping_preserved": true,
+    "manual_reconciliation_routing_preserved": true,
+    "public_port_error_contract_changed": false,
+    "payment_lifecycle_changed": false,
+    "provider_execution_changed": false,
+    "manual_reconciliation_reason_changed": false,
+    "local_persistence_diagnostics_changed": false,
+    "provider_checkpoint_diagnostics_changed": false,
+    "remaining_payment_execution_diagnostics_open": true,
+    "broad_ecommerce_cleanup_closed": false
+  },
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "notes": [
+    "Malformed durable provider results still route through the same manual-reconciliation path and public PortError.",
+    "Invalid tenant IDs still return the same validation code and public message.",
+    "Serde diagnostics retain only the top-level JSON kind and array/object cardinality, never the payload or decode error text.",
+    "UUID diagnostics retain only a parse-failure fact and the existing tenant ID character length, never the tenant value or parse error.",
+    "Manual-reconciliation reason text, local persistence, and provider checkpoint diagnostics remain separate open slices.",
+    "No payment FFA or FBA status is promoted from source inspection."
+  ]
+}

--- a/crates/rustok-payment/docs/checkout-execution-uuid-serde-diagnostic-safety.md
+++ b/crates/rustok-payment/docs/checkout-execution-uuid-serde-diagnostic-safety.md
@@ -1,0 +1,73 @@
+# Checkout payment execution UUID and serde diagnostic safety
+
+Status: **source-ready / unvalidated**
+
+## Boundary
+
+Checkout payment execution has two retained parsing boundaries in
+`validation_errors.rs`:
+
+- tenant context text is parsed as a UUID before owner access;
+- a durable provider-operation JSON result is decoded into
+  `PaymentProviderOperationResult` during recovery.
+
+Both paths already returned sanitized public `PortError` values, but their private
+tracing events recorded complete parser errors. Serde error text can include payload
+fragments and structural detail, while UUID parser debug output is unnecessary for
+correlation once the rejected input shape is known.
+
+## Private diagnostics
+
+The tenant UUID path now records only:
+
+- a static parse-failure fact;
+- tenant ID character length;
+- owner operation, correlation ID, stable code, and boundary.
+
+The durable provider-result path now records only:
+
+- a static decode-failure fact;
+- top-level JSON kind (`null`, `bool`, `number`, `string`, `array`, or `object`);
+- array length or object field count when applicable;
+- operation identity shape and existing bounded context facts;
+- stable code, owner operation, correlation ID, and boundary.
+
+Neither event records parser error text, tenant ID text, or provider-result payload.
+
+## Preserved behavior
+
+This source slice does not change:
+
+- UUID parsing or accepted tenant IDs;
+- the `payment.tenant_id_invalid` validation code or public message;
+- provider-result presence and operation-status gates;
+- `serde_json::from_value` decoding behavior;
+- successful provider-result recovery;
+- malformed-result routing to `manual_reconciliation`;
+- the public manual-reconciliation `PortError` code, kind, message, or retryability;
+- payment lifecycle, provider execution, journal, or recovery ordering.
+
+## Remaining payment execution diagnostics
+
+Separate cleanup remains open for:
+
+- manual-reconciliation reason text;
+- local persistence diagnostics;
+- provider checkpoint diagnostics.
+
+The canonical ecommerce correlation-safe mapper-cleanup item remains open.
+
+## Evidence
+
+- `contracts/evidence/checkout-execution-uuid-serde-diagnostic-safety-source.json`
+- `scripts/verify/verify-payment-checkout-execution-uuid-serde-diagnostic-safety.mjs`
+
+## Validation still required
+
+Per maintainer instruction, no tests, Node verifiers, Cargo commands, formatting,
+workflows, or CI were run. Maintainer validation should include the focused verifier,
+payment owner tests, compilation, malformed durable JSON injection, and invalid tenant
+UUID injection.
+
+No payment FFA/FBA, runtime, workflow, CI, or production status is promoted from this
+source review.

--- a/crates/rustok-payment/src/checkout_execution/validation_errors.rs
+++ b/crates/rustok-payment/src/checkout_execution/validation_errors.rs
@@ -21,11 +21,21 @@ fn persisted_provider_result(
             "payment provider operation has no normalized durable result",
         )
     })?;
-    serde_json::from_value(value).map(Some).map_err(|error| {
+    let (provider_result_kind, provider_result_collection_length) = match &value {
+        Value::Null => ("null", None),
+        Value::Bool(_) => ("bool", None),
+        Value::Number(_) => ("number", None),
+        Value::String(_) => ("string", None),
+        Value::Array(items) => ("array", Some(items.len())),
+        Value::Object(fields) => ("object", Some(fields.len())),
+    };
+    serde_json::from_value(value).map(Some).map_err(|_| {
         let context_facts = checkout_payment_execution_context_facts(context);
         tracing::error!(
             operation_id_non_nil = !operation.id.is_nil(),
-            error = ?error,
+            provider_result_decode_failed = true,
+            provider_result_kind,
+            provider_result_collection_length = ?provider_result_collection_length,
             correlation_id = %context.correlation_id,
             tenant_id_length = context_facts.tenant_id_length,
             actor_kind = context_facts.actor_kind,
@@ -237,10 +247,10 @@ fn parse_tenant_id(
     context: &PortContext,
     owner_operation: &'static str,
 ) -> Result<Uuid, PortError> {
-    Uuid::parse_str(&context.tenant_id).map_err(|error| {
+    Uuid::parse_str(&context.tenant_id).map_err(|_| {
         let context_facts = checkout_payment_execution_context_facts(context);
         tracing::warn!(
-            error = ?error,
+            tenant_id_parse_failed = true,
             tenant_id_length = context_facts.tenant_id_length,
             correlation_id = %context.correlation_id,
             operation = owner_operation,

--- a/scripts/verify/verify-payment-checkout-execution-uuid-serde-diagnostic-safety.mjs
+++ b/scripts/verify/verify-payment-checkout-execution-uuid-serde-diagnostic-safety.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+function functionBody(source, functionName) {
+  const signature = new RegExp(
+    `(?:pub(?:\\([^)]*\\))?\\s+)?(?:async\\s+)?fn\\s+${functionName}(?:<[^>]*>)?\\s*\\(`,
+  );
+  const match = signature.exec(source);
+  if (!match) {
+    failures.push(`missing function ${functionName}`);
+    return "";
+  }
+  const openBrace = source.indexOf("{", match.index);
+  if (openBrace < 0) {
+    failures.push(`missing body for ${functionName}`);
+    return "";
+  }
+  let depth = 0;
+  for (let index = openBrace; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(openBrace, index + 1);
+    }
+  }
+  failures.push(`unterminated body for ${functionName}`);
+  return "";
+}
+
+const paths = {
+  source: "crates/rustok-payment/src/checkout_execution/validation_errors.rs",
+  evidence:
+    "crates/rustok-payment/contracts/evidence/checkout-execution-uuid-serde-diagnostic-safety-source.json",
+  doc:
+    "crates/rustok-payment/docs/checkout-execution-uuid-serde-diagnostic-safety.md",
+  plan: "crates/rustok-commerce/docs/implementation-plan.md",
+};
+
+const source = read(paths.source);
+const evidence = JSON.parse(read(paths.evidence));
+const doc = read(paths.doc);
+const plan = read(paths.plan);
+
+const persisted = functionBody(source, "persisted_provider_result");
+for (const marker of [
+  "operation.status == PROVIDER_OPERATION_EXECUTING",
+  "PROVIDER_OPERATION_COMMITTED",
+  "PROVIDER_OPERATION_SUCCEEDED",
+  "PROVIDER_OPERATION_RECONCILIATION_REQUIRED",
+  "operation.provider_result.clone().ok_or_else(||",
+  '"payment provider operation has no normalized durable result"',
+  'Value::Null => ("null", None)',
+  'Value::Bool(_) => ("bool", None)',
+  'Value::Number(_) => ("number", None)',
+  'Value::String(_) => ("string", None)',
+  'Value::Array(items) => ("array", Some(items.len()))',
+  'Value::Object(fields) => ("object", Some(fields.len()))',
+  "serde_json::from_value(value).map(Some).map_err(|_|",
+  "provider_result_decode_failed = true",
+  "provider_result_kind",
+  "provider_result_collection_length = ?provider_result_collection_length",
+  'code = "payment.provider_invalid_response"',
+  '"payment provider operation result is malformed"',
+  "manual_reconciliation(",
+]) {
+  requireText(persisted, marker, `${paths.source}: persisted provider result`);
+}
+for (const forbidden of [
+  "error = ?error",
+  "error = %error",
+  "error.to_string()",
+  "provider_result = ?value",
+  "provider_result = %value",
+  "value = ?value",
+  "value = %value",
+]) {
+  forbidText(persisted, forbidden, `${paths.source}: serde payload diagnostics`);
+}
+
+const tenant = functionBody(source, "parse_tenant_id");
+for (const marker of [
+  "Uuid::parse_str(&context.tenant_id).map_err(|_|",
+  "tenant_id_parse_failed = true",
+  "tenant_id_length = context_facts.tenant_id_length",
+  "correlation_id = %context.correlation_id",
+  "operation = owner_operation",
+  'code = "payment.tenant_id_invalid"',
+  '"payment checkout execution tenant context is invalid"',
+  "PortError::validation(",
+  '"payment.tenant_id_invalid"',
+  '"payment request context is invalid"',
+]) {
+  requireText(tenant, marker, `${paths.source}: tenant UUID parsing`);
+}
+for (const forbidden of [
+  "error = ?error",
+  "error = %error",
+  "error.to_string()",
+  "tenant_id = %context.tenant_id",
+  "tenant_id = ?context.tenant_id",
+]) {
+  forbidText(tenant, forbidden, `${paths.source}: UUID payload diagnostics`);
+}
+
+const reconciliation = functionBody(source, "manual_reconciliation");
+for (const marker of [
+  'code = "payment.checkout_execution_manual_reconciliation"',
+  "PortError::new(",
+  "PortErrorKind::Conflict",
+  '"payment checkout execution requires manual reconciliation"',
+  "false,",
+]) {
+  requireText(reconciliation, marker, `${paths.source}: preserved reconciliation envelope`);
+}
+
+if (
+  evidence.status !==
+  "payment_checkout_execution_uuid_serde_diagnostic_safety_source_reviewed_unvalidated"
+) {
+  failures.push(`${paths.evidence}: unexpected status ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  uuid_diagnostic_site_count: 1,
+  serde_diagnostic_site_count: 1,
+  complete_uuid_error_logged: false,
+  complete_serde_error_logged: false,
+  tenant_id_text_logged: false,
+  provider_result_payload_logged: false,
+  tenant_id_length_logged: true,
+  tenant_parse_failure_fact_logged: true,
+  provider_result_decode_failure_fact_logged: true,
+  provider_result_kind_logged: true,
+  provider_result_collection_length_logged: true,
+  tenant_validation_mapping_preserved: true,
+  persisted_provider_result_mapping_preserved: true,
+  manual_reconciliation_routing_preserved: true,
+  public_port_error_contract_changed: false,
+  payment_lifecycle_changed: false,
+  provider_execution_changed: false,
+  manual_reconciliation_reason_changed: false,
+  local_persistence_diagnostics_changed: false,
+  provider_checkpoint_diagnostics_changed: false,
+  remaining_payment_execution_diagnostics_open: true,
+  broad_ecommerce_cleanup_closed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "compile_proven",
+  "runtime_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+
+requireText(doc, "Status: **source-ready / unvalidated**", `${paths.doc}: status`);
+requireText(
+  doc,
+  "Neither event records parser error text, tenant ID text, or provider-result payload.",
+  `${paths.doc}: diagnostic policy`,
+);
+requireText(
+  doc,
+  "Remaining payment execution diagnostics",
+  `${paths.doc}: remaining work`,
+);
+requireText(
+  plan,
+  "Finish correlation-safe mapper cleanup",
+  `${paths.plan}: broad ecommerce cleanup remains open`,
+);
+
+if (failures.length > 0) {
+  console.error(
+    "Payment checkout execution UUID/serde diagnostic-safety verification failed:",
+  );
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "Payment checkout execution UUID and serde diagnostics retain only parser failure and input-shape facts; execution evidence remains open",
+);


### PR DESCRIPTION
## Summary

- continue the open ecommerce correlation-safe mapper cleanup at checkout payment execution parsing boundaries
- remove complete UUID parse and serde decode errors from private tracing
- retain tenant input length, static parse/decode failure facts, top-level JSON kind, collection cardinality, correlation, stable codes, and bounded context shape
- preserve tenant validation behavior, durable provider-result decoding, and malformed-result manual-reconciliation routing
- add a focused source verifier, documentation, and reviewed-unvalidated evidence

## Confirmed gap

`parse_tenant_id` logged the complete UUID parser error, and `persisted_provider_result` logged the complete serde error. These payloads were unnecessary for correlation and could disclose parser detail or provider-result fragments.

## Scope boundary

Exactly four files change: the existing parsing/validation source plus a focused verifier, document, and evidence file. Manual-reconciliation reason text, local persistence, provider checkpoint diagnostics, lifecycle policy, provider execution, and public `PortError` behavior remain outside this PR and explicitly open.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-payment-checkout-execution-uuid-serde-diagnostic-safety.mjs
cargo check -p rustok-payment --all-targets
```

## Branch state

The branch is based on current `main` at `a14c8e13f019532735f69054107e9d074ea0982a`, is one commit ahead and zero behind, and changes exactly four files. Head commit: `fc1df3b84ecd9f6cea5d54fe096bc69ed69201da`. Squash merge is intended.