### PR TITLE
feat(blog): add Comments port injection seam

### DIFF
--- a/crates/rustok-blog/contracts/blog-fba-registry.json
+++ b/crates/rustok-blog/contracts/blog-fba-registry.json
@@ -244,6 +244,16 @@
     "pending_profiles": [
       "remote_adapter_placeholder"
     ],
+    "adapter_injection": {
+      "status": "executable_no_run",
+      "runtime_status": "not_run",
+      "source": "crates/rustok-blog/src/services/comment.rs",
+      "constructor": "CommentService::with_comments_thread_port",
+      "signature": "fn(DatabaseConnection, Arc<dyn CommentsThreadPort>) -> CommentService",
+      "test": "services::comment::port_injection_tests::comment_service_accepts_an_injected_comments_thread_port",
+      "command": "cargo test -p rustok-blog --lib services::comment::port_injection_tests::comment_service_accepts_an_injected_comments_thread_port -- --exact",
+      "remote_transport_implementation": "pending"
+    },
     "cases": [
       {
         "provider": "comments",

--- a/crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "module": "blog",
   "surface": "comments_port_boundary",
   "role": "consumer",
@@ -10,11 +10,23 @@
   "source_contract": {
     "consumer_service": "crates/rustok-blog/src/services/comment.rs",
     "provider_registry": "crates/rustok-comments/contracts/comments-fba-registry.json",
-    "consumer_registry": "crates/rustok-blog/contracts/blog-fba-registry.json"
+    "consumer_registry": "crates/rustok-blog/contracts/blog-fba-registry.json",
+    "injection_constructor": "CommentService::with_comments_thread_port"
   },
   "profiles": {
     "source_verified": ["in_process"],
     "pending": ["remote_adapter_placeholder"]
+  },
+  "adapter_injection": {
+    "status": "executable_no_run",
+    "runtime_status": "not_run",
+    "source": "crates/rustok-blog/src/services/comment.rs",
+    "constructor": "CommentService::with_comments_thread_port",
+    "signature": "fn(DatabaseConnection, Arc<dyn CommentsThreadPort>) -> CommentService",
+    "test": "services::comment::port_injection_tests::comment_service_accepts_an_injected_comments_thread_port",
+    "command": "cargo test -p rustok-blog --lib services::comment::port_injection_tests::comment_service_accepts_an_injected_comments_thread_port -- --exact",
+    "default_profile": "in_process",
+    "remote_transport_implementation": "pending"
   },
   "cases": [
     {

--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -79,7 +79,15 @@ provider only through `in_process_comments_thread_port`, and routes all seven
 operations through typed `PortContext` / `PortError` contracts. Reads and writes
 carry a two-second deadline; writes add command-scoped idempotency keys; public
 lists use the dedicated approved-only operation and service actor; richtext input,
-view, and plain-text projections remain typed. Evidence schema v2 lives at
+view, and plain-text projections remain typed. `CommentService::new` remains the
+in-process convenience constructor, while public
+`CommentService::with_comments_thread_port` accepts a host-owned
+`Arc<dyn CommentsThreadPort>` without changing the owner service API. The retained
+compile-only harness is
+`services::comment::port_injection_tests::comment_service_accepts_an_injected_comments_thread_port`
+in `crates/rustok-blog/src/services/comment.rs`, with suggested command
+`cargo test -p rustok-blog --lib services::comment::port_injection_tests::comment_service_accepts_an_injected_comments_thread_port -- --exact`.
+Evidence schema v3 lives at
 `crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json`.
 The active fallback/error source evidence is
 `crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json`,
@@ -93,8 +101,9 @@ projection. Typed storefront comments availability is source-verified across the
 owner GraphQL resolver, GraphQL client, native SSR adapter, shared DTO, and Leptos
 UI. Only `ExternalService` and `Timeout` become empty `UNAVAILABLE` or `TIMEOUT`
 comment payloads; every other `BlogError` remains fail-closed. The in-process
-source profile is verified. The remote adapter and degraded UI modes remain planned.
-Cached snapshot and comment-form fallback remain planned, and runtime evidence is pending.
+source profile and transport-neutral injection seam are source-locked. The remote
+transport remains pending; degraded UI modes remain planned. Cached snapshot and
+comment-form fallback remain planned, and runtime evidence is pending.
 
 Comments lifecycle projection into Blog-owned `comment_count` is a Blog consumer
 boundary. `BlogCommentProjectionHandler` accepts only `comment.created` and
@@ -534,6 +543,20 @@ code, the dispatcher target, and its standalone verifier are unchanged. No Rust
 test, JavaScript verifier, compile, PostgreSQL, browser, workflow, CI, or
 production execution is recorded.
 
+The continuation audit at `bef0ffcce06551914175c00fa5e540aa4ceed720`
+found that `CommentService` stored a transport-neutral `Arc<dyn CommentsThreadPort>`
+but exposed only `new(db, event_bus)`, which always constructed the in-process
+provider. A future host-owned remote adapter therefore had no public composition
+seam even though all seven calls already routed through the trait boundary.
+
+Slice 58 adds public `CommentService::with_comments_thread_port`, keeps `new` as
+the in-process convenience path, and adds a compile-only exact-signature harness.
+Comments consumer evidence advances to schema v3 and Blog registry schema v13
+retains the harness under `contract_tests.adapter_injection`. The existing
+fail-closed verifier now rejects constructor, harness, metadata, and unearned
+runtime-status drift. No remote transport implementation, Rust/JavaScript test,
+compile, database, browser, workflow, CI, or production execution is recorded.
+
 ## FFA/FBA status
 
 - FFA status: `in_progress`.
@@ -549,14 +572,16 @@ production execution is recorded.
   GraphQL richtext, AI richtext, offline backfill, Forum ownership, and runtime
   order.
 - Comments consumer port boundary: Blog-owned `source_verified_no_compile` for
-  the in-process profile; all seven operations, approved public read, typed
-  richtext projection, two-second deadlines, write idempotency, active typed
-  `PortErrorKind` mapping, exact npm leaf commands, focused fixture, and Blog FBA
-  ordering are locked. Typed storefront comments availability is retained across
-  GraphQL/native DTOs and Leptos UI; only external-service and timeout errors
-  degrade, while other errors propagate. The remote adapter, cached snapshot,
-  comment-form fallback, browser/runtime evidence, and broader degraded UI modes
-  remain planned or pending.
+  the in-process profile; evidence schema v3, all seven operations, approved public
+  read, typed richtext projection, two-second deadlines, write idempotency, active
+  typed `PortErrorKind` mapping, public transport-neutral injection constructor,
+  compile-only exact-signature harness, exact npm leaf commands, focused fixture,
+  and Blog FBA ordering are locked. Typed storefront comments availability is
+  retained across GraphQL/native DTOs and Leptos UI; only external-service and
+  timeout errors degrade, while other errors propagate. The remote transport,
+  remote adapter runtime parity, cached snapshot, comment-form fallback,
+  browser/runtime evidence, and broader degraded UI modes remain planned or
+  pending.
 - Comments event projection: Blog-owned `source_verified_no_compile`; evidence
   schema v4, shared classifier/counter/retry-decision helpers, `executable_no_run`
   source harness, deterministic PostgreSQL retry-limit target, module-registration,
@@ -607,6 +632,7 @@ production execution is recorded.
 - `crates/rustok-blog/contracts/evidence/blog-comments-duplicate-delivery-race.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-dispatcher-duplicate-delivery.json`
 - `crates/rustok-blog/src/lib.rs`
+- `crates/rustok-blog/src/services/comment.rs`
 - `crates/rustok-blog/src/graphql/types.rs`
 - `crates/rustok-blog/storefront/src/model.rs`
 - `crates/rustok-blog/storefront/src/transport/graphql_adapter.rs`
@@ -810,6 +836,12 @@ production execution is recorded.
     duplicate-delivery race gate, bound its evidence and PostgreSQL target in
     registry schema v13, and locked aggregate verify/test order without changing
     runtime code or recording execution.
+58. Added a public transport-neutral Comments port injection constructor while
+    preserving the in-process convenience path, retained its exact trait-object
+    signature in an executable-no-run Rust harness, advanced consumer evidence to
+    schema v3, registered the harness in Blog registry schema v13, and extended the
+    existing fail-closed verifier and focused fixture without implementing or
+    claiming a remote transport.
 
 ## Next results
 
@@ -827,9 +859,10 @@ production execution is recorded.
    controller handoff, focused verifier, then Redis-backed host requests with a
    real HTTP `Retry-After` matching GraphQL `retryAfter`.
 5. **Close comments runtime evidence.** Run the Comments port boundary fixture,
-   shared consumer runtime-order verifier, Blog projection classifier and
-   deterministic retry-policy harness, module registration/routing harness, the
-   filtered `event_dispatcher_routes_registered_handler_and_commits_projection`,
+   the compile-only injection-signature harness, shared consumer runtime-order
+   verifier, Blog projection classifier and deterministic retry-policy harness,
+   module registration/routing harness, the filtered
+   `event_dispatcher_routes_registered_handler_and_commits_projection`,
    `event_dispatcher_replays_duplicate_envelope_without_double_commit`,
    `concurrent_created_events_converge_without_lost_updates`,
    `optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears`,
@@ -848,11 +881,13 @@ production execution is recorded.
    duplicate replay, dispatcher delivery output, four-connection convergence,
    both child process exits, the written duplicate, delete-before-create,
    missing-post replay, outbox rollback/retry, and same-process/new-connection
-   assertions; then retain naturally contended PostgreSQL retry-frequency
-   evidence, full server-host restart recovery, remote adapter parity, browser
-   parity for typed unavailable/timeout article rendering, cached thread
-   snapshots, comment-form fallback, approved-only reads, moderation, pagination,
-   first-thread identity, and unrelated insert storage error propagation.
+   assertions; then implement the host-owned remote Comments transport through
+   `CommentService::with_comments_thread_port` and retain all-seven-operation
+   adapter parity, naturally contended PostgreSQL retry-frequency evidence, full
+   server-host restart recovery, browser parity for typed unavailable/timeout
+   article rendering, cached thread snapshots, comment-form fallback,
+   approved-only reads, moderation, pagination, first-thread identity, and
+   unrelated insert storage error propagation.
 6. **Execute and retain Blog article richtext cutover evidence.** Run the offline
    backfill in default dry-run mode, review its report, apply accepted conversion,
    execute the irreversible migration, reindex/rollback Search, and retain
@@ -866,6 +901,7 @@ should run the relevant subset, including:
 
 - `npm run verify:blog:comments-port-boundary`
 - `npm run test:verify:blog:comments-port-boundary`
+- `cargo test -p rustok-blog --lib services::comment::port_injection_tests::comment_service_accepts_an_injected_comments_thread_port -- --exact`
 - `npm run verify:blog:comments-event-projection`
 - `npm run test:verify:blog:comments-event-projection`
 - `npm run verify:blog:comments-duplicate-delivery-race`

--- a/crates/rustok-blog/src/services/comment.rs
+++ b/crates/rustok-blog/src/services/comment.rs
@@ -33,9 +33,17 @@ pub struct CommentService {
 
 impl CommentService {
     pub fn new(db: DatabaseConnection, event_bus: TransactionalEventBus) -> Self {
+        let comments_thread_port = in_process_comments_thread_port(db.clone(), event_bus);
+        Self::with_comments_thread_port(db, comments_thread_port)
+    }
+
+    pub fn with_comments_thread_port(
+        db: DatabaseConnection,
+        comments_thread_port: Arc<dyn CommentsThreadPort>,
+    ) -> Self {
         Self {
-            comments_thread_port: in_process_comments_thread_port(db.clone(), event_bus),
             db,
+            comments_thread_port,
         }
     }
 
@@ -474,6 +482,20 @@ fn comments_port_error_to_blog_error(error: PortError) -> BlogError {
     BlogError::Rich(Box::new(
         rustok_core::error::RichError::new(kind, error.message).with_error_code(error.code),
     ))
+}
+
+#[cfg(test)]
+mod port_injection_tests {
+    use super::*;
+
+    #[test]
+    fn comment_service_accepts_an_injected_comments_thread_port() {
+        let constructor: fn(
+            DatabaseConnection,
+            Arc<dyn CommentsThreadPort>,
+        ) -> CommentService = CommentService::with_comments_thread_port;
+        let _ = constructor;
+    }
 }
 
 #[cfg(test)]

--- a/scripts/verify/verify-blog-comments-port-boundary.mjs
+++ b/scripts/verify/verify-blog-comments-port-boundary.mjs
@@ -53,6 +53,12 @@ const storefrontUiPath = 'crates/rustok-blog/storefront/src/ui/leptos.rs';
 const providerRegistryPath = 'crates/rustok-comments/contracts/comments-fba-registry.json';
 const consumerRegistryPath = 'crates/rustok-blog/contracts/blog-fba-registry.json';
 const planPath = 'crates/rustok-blog/docs/implementation-plan.md';
+const injectionConstructor = 'CommentService::with_comments_thread_port';
+const injectionSignature = 'fn(DatabaseConnection, Arc<dyn CommentsThreadPort>) -> CommentService';
+const injectionTest =
+  'services::comment::port_injection_tests::comment_service_accepts_an_injected_comments_thread_port';
+const injectionCommand =
+  `cargo test -p rustok-blog --lib ${injectionTest} -- --exact`;
 const expectedOperations = [
   'create_comment',
   'get_comment',
@@ -76,7 +82,7 @@ const storefrontUi = read(storefrontUiPath);
 const plan = read(planPath);
 
 if (evidence) {
-  if (evidence.schema_version !== 2) failures.push(`${evidencePath}: schema_version drift`);
+  if (evidence.schema_version !== 3) failures.push(`${evidencePath}: schema_version drift`);
   if (
     evidence.module !== 'blog' ||
     evidence.surface !== 'comments_port_boundary' ||
@@ -88,7 +94,8 @@ if (evidence) {
   if (
     evidence.source_contract?.consumer_service !== servicePath ||
     evidence.source_contract?.provider_registry !== providerRegistryPath ||
-    evidence.source_contract?.consumer_registry !== consumerRegistryPath
+    evidence.source_contract?.consumer_registry !== consumerRegistryPath ||
+    evidence.source_contract?.injection_constructor !== injectionConstructor
   ) failures.push(`${evidencePath}: source contract path drift`);
   if (!sameSet(evidence.profiles?.source_verified ?? [], ['in_process'])) {
     failures.push(`${evidencePath}: source-verified profile drift`);
@@ -96,6 +103,18 @@ if (evidence) {
   if (!sameSet(evidence.profiles?.pending ?? [], ['remote_adapter_placeholder'])) {
     failures.push(`${evidencePath}: pending profile drift`);
   }
+  const injection = evidence.adapter_injection ?? {};
+  if (
+    injection.status !== 'executable_no_run' ||
+    injection.runtime_status !== 'not_run' ||
+    injection.source !== servicePath ||
+    injection.constructor !== injectionConstructor ||
+    injection.signature !== injectionSignature ||
+    injection.test !== injectionTest ||
+    injection.command !== injectionCommand ||
+    injection.default_profile !== 'in_process' ||
+    injection.remote_transport_implementation !== 'pending'
+  ) failures.push(`${evidencePath}: adapter injection drift`);
   if (!sameSet((evidence.cases ?? []).map((entry) => entry.operation), expectedOperations)) {
     failures.push(`${evidencePath}: operation set drift`);
   }
@@ -177,6 +196,17 @@ if (!sameSet(dependency?.operations ?? [], expectedOperations)) failures.push(`$
 if (!sameSet((consumerRegistry?.contract_tests?.cases ?? []).map((entry) => entry.operation), expectedOperations)) {
   failures.push(`${consumerRegistryPath}: contract-test operation drift`);
 }
+const registryInjection = consumerRegistry?.contract_tests?.adapter_injection ?? {};
+if (
+  registryInjection.status !== 'executable_no_run' ||
+  registryInjection.runtime_status !== 'not_run' ||
+  registryInjection.source !== servicePath ||
+  registryInjection.constructor !== injectionConstructor ||
+  registryInjection.signature !== injectionSignature ||
+  registryInjection.test !== injectionTest ||
+  registryInjection.command !== injectionCommand ||
+  registryInjection.remote_transport_implementation !== 'pending'
+) failures.push(`${consumerRegistryPath}: adapter injection drift`);
 if (
   consumerRegistry?.contract_tests?.status !== 'source_verified_no_compile' ||
   consumerRegistry?.contract_tests?.runtime_status !== 'pending' ||
@@ -185,7 +215,14 @@ if (
 
 for (const marker of [
   'comments_thread_port: Arc<dyn CommentsThreadPort>',
-  'comments_thread_port: in_process_comments_thread_port(db.clone(), event_bus)',
+  'let comments_thread_port = in_process_comments_thread_port(db.clone(), event_bus);',
+  'Self::with_comments_thread_port(db, comments_thread_port)',
+  'pub fn with_comments_thread_port(',
+  'comments_thread_port: Arc<dyn CommentsThreadPort>,',
+  'Self {\n            db,\n            comments_thread_port,\n        }',
+  'mod port_injection_tests',
+  'fn comment_service_accepts_an_injected_comments_thread_port()',
+  ') -> CommentService = CommentService::with_comments_thread_port;',
   '.comments_thread_port',
   '.create_comment(',
   '.get_comment(',
@@ -280,6 +317,8 @@ for (const marker of [
   'test:verify:blog:comments-port-boundary',
   'source_verified_no_compile',
   'typed storefront comments availability',
+  'CommentService::with_comments_thread_port',
+  'remote transport remains pending',
   'cached snapshot and comment-form fallback remain planned',
 ]) requireMarker(plan, marker, planPath);
 
@@ -289,4 +328,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log('Blog Comments consumer port and storefront read-degradation source boundary is consistent');
+console.log('Blog Comments consumer port, injection seam, and storefront read-degradation source boundary is consistent');

--- a/scripts/verify/verify-blog-comments-port-boundary.test.mjs
+++ b/scripts/verify/verify-blog-comments-port-boundary.test.mjs
@@ -17,6 +17,12 @@ const operations = [
   'set_comment_status',
   'delete_comment',
 ];
+const injectionConstructor = 'CommentService::with_comments_thread_port';
+const injectionSignature = 'fn(DatabaseConnection, Arc<dyn CommentsThreadPort>) -> CommentService';
+const injectionTest =
+  'services::comment::port_injection_tests::comment_service_accepts_an_injected_comments_thread_port';
+const injectionCommand =
+  `cargo test -p rustok-blog --lib ${injectionTest} -- --exact`;
 
 function write(root, relativePath, content) {
   const target = path.join(root, relativePath);
@@ -33,6 +39,9 @@ function fixture({
   broadNativeFallback = false,
   missingGraphqlAvailability = false,
   missingUiState = false,
+  missingInjectionConstructor = false,
+  missingInjectionHarness = false,
+  injectionRuntimePromoted = false,
   statusDrift = false,
   fallbackPromoted = false,
 } = {}) {
@@ -53,7 +62,21 @@ function fixture({
     servicePath,
     `
 comments_thread_port: Arc<dyn CommentsThreadPort>
-comments_thread_port: in_process_comments_thread_port(db.clone(), event_bus)
+${missingInjectionConstructor ? '' : `
+let comments_thread_port = in_process_comments_thread_port(db.clone(), event_bus);
+Self::with_comments_thread_port(db, comments_thread_port)
+pub fn with_comments_thread_port(
+comments_thread_port: Arc<dyn CommentsThreadPort>,
+Self {
+            db,
+            comments_thread_port,
+        }
+`}
+${missingInjectionHarness ? '' : `
+mod port_injection_tests
+fn comment_service_accepts_an_injected_comments_thread_port()
+) -> CommentService = CommentService::with_comments_thread_port;
+`}
 .comments_thread_port
 .create_comment(
 .get_comment(
@@ -159,7 +182,7 @@ Comments took too long to load. The article is still available.
     root,
     evidencePath,
     JSON.stringify({
-      schema_version: 2,
+      schema_version: 3,
       module: 'blog',
       surface: 'comments_port_boundary',
       role: 'consumer',
@@ -171,10 +194,22 @@ Comments took too long to load. The article is still available.
         consumer_service: servicePath,
         provider_registry: providerRegistryPath,
         consumer_registry: consumerRegistryPath,
+        injection_constructor: injectionConstructor,
       },
       profiles: {
         source_verified: ['in_process'],
         pending: ['remote_adapter_placeholder'],
+      },
+      adapter_injection: {
+        status: 'executable_no_run',
+        runtime_status: injectionRuntimePromoted ? 'passed' : 'not_run',
+        source: servicePath,
+        constructor: injectionConstructor,
+        signature: injectionSignature,
+        test: injectionTest,
+        command: injectionCommand,
+        default_profile: 'in_process',
+        remote_transport_implementation: 'pending',
       },
       cases,
       fallback_smoke: {
@@ -254,6 +289,16 @@ Comments took too long to load. The article is still available.
       contract_tests: {
         status: 'source_verified_no_compile',
         runtime_status: 'pending',
+        adapter_injection: {
+          status: 'executable_no_run',
+          runtime_status: injectionRuntimePromoted ? 'passed' : 'not_run',
+          source: servicePath,
+          constructor: injectionConstructor,
+          signature: injectionSignature,
+          test: injectionTest,
+          command: injectionCommand,
+          remote_transport_implementation: 'pending',
+        },
         cases: operations.map((operation) => ({ operation })),
         fallback_smoke: { status: fallbackPromoted ? 'source_verified_no_compile' : 'planned' },
       },
@@ -262,7 +307,7 @@ Comments took too long to load. The article is still available.
   write(
     root,
     'crates/rustok-blog/docs/implementation-plan.md',
-    'blog-comments-consumer-static-matrix.json blog-comments-runtime-fallback-smoke.json verify:blog:comments-port-boundary test:verify:blog:comments-port-boundary source_verified_no_compile typed storefront comments availability cached snapshot and comment-form fallback remain planned',
+    'blog-comments-consumer-static-matrix.json blog-comments-runtime-fallback-smoke.json verify:blog:comments-port-boundary test:verify:blog:comments-port-boundary source_verified_no_compile typed storefront comments availability CommentService::with_comments_thread_port remote transport remains pending cached snapshot and comment-form fallback remain planned',
   );
 
   return root;
@@ -309,6 +354,24 @@ test('rejects writes without idempotency keys', () => {
 
 test('rejects removal of the approved public-read port operation', () => {
   assert.notEqual(rejects({ missingPublicRead: true }).status, 0);
+});
+
+test('rejects removal of the Comments port injection constructor', () => {
+  const result = rejects({ missingInjectionConstructor: true });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /with_comments_thread_port/);
+});
+
+test('rejects removal of the compile-only injection harness', () => {
+  const result = rejects({ missingInjectionHarness: true });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /port_injection_tests|injected_comments_thread_port/);
+});
+
+test('rejects runtime promotion of the unexecuted injection harness', () => {
+  const result = rejects({ injectionRuntimePromoted: true });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /adapter injection drift/);
 });
 
 test('rejects a storefront model without typed availability', () => {


### PR DESCRIPTION
## Summary

- continue the canonical Blog implementation plan through slice 58
- add public `CommentService::with_comments_thread_port(DatabaseConnection, Arc<dyn CommentsThreadPort>)`
- preserve `CommentService::new` as the in-process convenience constructor and delegate it through the new seam
- add an executable-no-run exact-signature Rust harness
- advance Blog Comments consumer evidence to schema v3
- register the injection harness under Blog registry schema v13 without changing FBA package order
- extend the existing fail-closed verifier and focused fixture for constructor, harness, metadata, and unearned runtime-status drift

## Scope and non-claims

This PR creates the composition seam required for a future host-owned remote Comments adapter. It does not implement a network transport, promote `remote_adapter_placeholder`, add cached thread snapshots or comment-form fallback, or record runtime parity.

No Rust or JavaScript test, verifier, compilation, database, browser, workflow, CI, or production command was run, per maintainer instruction.

## Suggested maintainer commands

```bash
npm run verify:blog:comments-port-boundary
npm run test:verify:blog:comments-port-boundary
cargo test -p rustok-blog --lib services::comment::port_injection_tests::comment_service_accepts_an_injected_comments_thread_port -- --exact
npm run verify:blog:fba
npm run test:verify:blog:fba
```

## Branch state

The work started from `main` at `bef0ffcce06551914175c00fa5e540aa4ceed720`. Current `main` is ahead through an unrelated Payment diagnostic commit. The branch contains six commits and changes exactly six Blog consumer-boundary files.