### PR TITLE
fix(search): index Forum ingest-sequence lookups

### DIFF
--- a/crates/rustok-forum/contracts/forum-search-ingest-sequence-index.json
+++ b/crates/rustok-forum/contracts/forum-search-ingest-sequence-index.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-23B2G1A",
+  "status": "source_complete_execution_pending",
+  "scope": "Add an upgrade-safe PostgreSQL lookup index for Forum Search inbox ingest-sequence claim and due-tenant ordering without rewriting the already delivered ingest-sequence migration",
+  "canonical_forum_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "canonical_search_plan": "crates/rustok-search/docs/implementation-plan.md",
+  "predecessor_contract": "crates/rustok-forum/contracts/forum-search-durable-ingest-sequence.json",
+  "predecessor_migration": "crates/rustok-search/src/migrations/m20260731_000010_add_forum_projection_ingest_sequence.rs",
+  "additive_migration": "crates/rustok-search/src/migrations/m20260731_000011_add_forum_projection_ingest_sequence_lookup.rs",
+  "claim_owner": "crates/rustok-search/src/forum_inbox.rs",
+  "due_tenant_owner": "crates/rustok-search/src/forum_reconciliation.rs",
+  "owner_note": "crates/rustok-forum/docs/forum-23b2g1a-search-ingest-sequence-index.md",
+  "verifier": "scripts/verify/verify-forum-search-ingest-sequence-index.mjs",
+  "index": {
+    "name": "idx_search_projection_inbox_due_ingest_sequence",
+    "table": "search_projection_inbox",
+    "columns": ["source_module", "tenant_id", "ingest_sequence"],
+    "predicate": "status IN ('pending', 'retryable_error')",
+    "claim_query_supported": true,
+    "due_tenant_query_supported": true,
+    "terminal_rows_excluded": true,
+    "unique": false
+  },
+  "upgrade_safety": {
+    "predecessor_migration_modified": false,
+    "new_migration_registered_after_predecessor": true,
+    "already_migrated_databases_receive_index": true,
+    "sqlite_schema_changed": false,
+    "down_migration_drops_only_new_index": true
+  },
+  "constraint_repair": {
+    "inbox_constraint": "ck_search_projection_inbox_ingest_sequence",
+    "watermark_constraint": "ck_search_projection_watermark_ingest_sequence",
+    "existence_check_scoped_by_conrelid": true,
+    "inbox_positive_sequence_required": true,
+    "watermark_non_negative_sequence_required": true
+  },
+  "compatibility": {
+    "claim_order_changed": false,
+    "due_tenant_order_changed": false,
+    "watermark_semantics_changed": false,
+    "event_schema_changed": false,
+    "forum_owner_write_changed": false,
+    "public_api_changed": false,
+    "dependency_added": false,
+    "cargo_lock_changed": false
+  },
+  "remaining_scope": [
+    "capture maintainer-executed PostgreSQL EXPLAIN evidence for claim and due-tenant queries",
+    "add Forum-owner-issued monotonic projection revisions to versioned invalidation events",
+    "reconcile owner revision watermarks with Search ingest-sequence watermarks",
+    "capture restart, retry and LINK-FORUM-03 runtime evidence"
+  ],
+  "non_claims": [
+    "Tests, verifiers, Cargo checks, formatting, Clippy and PostgreSQL EXPLAIN were not executed by the implementation agent",
+    "The partial index does not alter event ordering or authorization semantics",
+    "This slice does not claim the PostgreSQL planner selected the index at runtime",
+    "This slice does not replace the final Forum-owner-issued projection revision"
+  ]
+}

--- a/crates/rustok-forum/contracts/forum-search-ingest-sequence-index.json
+++ b/crates/rustok-forum/contracts/forum-search-ingest-sequence-index.json
@@ -5,6 +5,12 @@
   "scope": "Add an upgrade-safe PostgreSQL lookup index for Forum Search inbox ingest-sequence claim and due-tenant ordering without rewriting the already delivered ingest-sequence migration",
   "canonical_forum_plan": "crates/rustok-forum/docs/implementation-plan.md",
   "canonical_search_plan": "crates/rustok-search/docs/implementation-plan.md",
+  "canonical_plan": {
+    "predecessor_milestone": "FORUM-23B2G1",
+    "milestone_status_changed": false,
+    "remaining_scope_changed": false,
+    "predecessor_entry_remains_authoritative": true
+  },
   "predecessor_contract": "crates/rustok-forum/contracts/forum-search-durable-ingest-sequence.json",
   "predecessor_migration": "crates/rustok-search/src/migrations/m20260731_000010_add_forum_projection_ingest_sequence.rs",
   "additive_migration": "crates/rustok-search/src/migrations/m20260731_000011_add_forum_projection_ingest_sequence_lookup.rs",

--- a/crates/rustok-forum/docs/forum-23b2g1a-search-ingest-sequence-index.md
+++ b/crates/rustok-forum/docs/forum-23b2g1a-search-ingest-sequence-index.md
@@ -1,0 +1,72 @@
+# FORUM-23B2G1A Forum Search ingest-sequence lookup index
+
+## Status
+
+`source_complete_execution_pending`
+
+This hardening slice adds an upgrade-safe PostgreSQL access path for the durable
+Forum Search inbox ordering delivered in `FORUM-23B2G1`.
+
+The original `000010` migration is already part of the migration history and is
+left byte-for-byte unchanged. A new additive `000011` migration ensures that
+existing installations receive the lookup index instead of relying on a modified
+historical migration that would never rerun.
+
+## Query ownership
+
+Two existing owner queries require the same ordering prefix:
+
+- `ForumProjectionInbox::claim_next` filters one tenant and the Forum source,
+  keeps only pending/retryable rows and claims the lowest `ingest_sequence`;
+- `ForumProjectionReconciler::due_tenants` finds the lowest non-terminal sequence
+  per tenant, then orders the bounded tenant set by that oldest sequence.
+
+The migration creates:
+
+```sql
+CREATE INDEX idx_search_projection_inbox_due_ingest_sequence
+ON search_projection_inbox (source_module, tenant_id, ingest_sequence)
+WHERE status IN ('pending', 'retryable_error');
+```
+
+The partial predicate excludes completed, skipped and dead-letter rows. The key
+order supports the exact Forum source, per-tenant claim order and the
+`DISTINCT ON (tenant_id) ... ORDER BY tenant_id, ingest_sequence` due-tenant
+selection without changing either query or its semantics.
+
+## Constraint repair
+
+`000011` also rechecks the positive inbox-sequence and non-negative watermark
+constraints. Unlike the historical migration, each existence check includes the
+owning relation through `pg_constraint.conrelid`. A same-named constraint on an
+unrelated table therefore cannot suppress the required Search constraint.
+
+The down migration removes only the new lookup index. The sequence columns and
+constraints belong to `000010` and remain intact until that predecessor migration
+is rolled back.
+
+## Compatibility
+
+No event, Forum owner, inbox claim, retry, watermark, projection, public API,
+dependency or `Cargo.lock` behavior changes. SQLite remains unchanged and does not
+claim background Forum projection reconciliation.
+
+This is query-plan hardening for the Search-issued ingest sequence. It is not the
+final Forum-owner-issued monotonic projection revision.
+
+## Maintainer verification
+
+The implementation agent did not run these commands, as requested:
+
+```bash
+node scripts/verify/verify-forum-search-ingest-sequence-index.mjs
+cargo check -p rustok-search --all-targets
+cargo xtask module validate search
+cargo xtask module validate forum
+```
+
+PostgreSQL evidence should apply migrations through `000011`, retain the index
+DDL, and capture `EXPLAIN (ANALYZE, BUFFERS)` for both the per-tenant claim query
+and the bounded due-tenant query with enough tenants and terminal rows to show the
+partial access path. Runtime planner selection remains pending until that evidence
+is recorded.

--- a/crates/rustok-forum/docs/forum-23b2g1a-search-ingest-sequence-index.md
+++ b/crates/rustok-forum/docs/forum-23b2g1a-search-ingest-sequence-index.md
@@ -17,8 +17,8 @@ historical migration that would never rerun.
 The canonical Forum and Search plans already record `FORUM-23B2G1` as
 `source_complete_execution_pending`, with owner-issued revisions and maintainer
 runtime evidence still pending. This access-path correction does not change that
-milestone status or remaining scope. `G1A` is therefore retained as a focused
-machine contract and owner note rather than a duplicate roadmap milestone.
+milestone status or remaining scope. `G1A` is therefore retained as a focused machine contract and owner note
+rather than a duplicate roadmap milestone.
 
 ## Query ownership
 

--- a/crates/rustok-forum/docs/forum-23b2g1a-search-ingest-sequence-index.md
+++ b/crates/rustok-forum/docs/forum-23b2g1a-search-ingest-sequence-index.md
@@ -12,6 +12,14 @@ left byte-for-byte unchanged. A new additive `000011` migration ensures that
 existing installations receive the lookup index instead of relying on a modified
 historical migration that would never rerun.
 
+## Canonical plan boundary
+
+The canonical Forum and Search plans already record `FORUM-23B2G1` as
+`source_complete_execution_pending`, with owner-issued revisions and maintainer
+runtime evidence still pending. This access-path correction does not change that
+milestone status or remaining scope. `G1A` is therefore retained as a focused
+machine contract and owner note rather than a duplicate roadmap milestone.
+
 ## Query ownership
 
 Two existing owner queries require the same ordering prefix:

--- a/crates/rustok-search/src/migrations/m20260731_000011_add_forum_projection_ingest_sequence_lookup.rs
+++ b/crates/rustok-search/src/migrations/m20260731_000011_add_forum_projection_ingest_sequence_lookup.rs
@@ -1,0 +1,76 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::{ConnectionTrait, DatabaseBackend};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DatabaseBackend::Postgres => manager
+                .get_connection()
+                .execute_unprepared(POSTGRES_UP)
+                .await
+                .map(|_| ()),
+            DatabaseBackend::Sqlite => Ok(()),
+            backend => Err(DbErr::Custom(format!(
+                "Forum projection ingest sequence lookup does not support database backend {backend:?}"
+            ))),
+        }
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DatabaseBackend::Postgres => manager
+                .get_connection()
+                .execute_unprepared(POSTGRES_DOWN)
+                .await
+                .map(|_| ()),
+            DatabaseBackend::Sqlite => Ok(()),
+            backend => Err(DbErr::Custom(format!(
+                "Forum projection ingest sequence lookup does not support database backend {backend:?}"
+            ))),
+        }
+    }
+}
+
+const POSTGRES_UP: &str = r#"
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'ck_search_projection_inbox_ingest_sequence'
+          AND conrelid = 'search_projection_inbox'::regclass
+    ) THEN
+        ALTER TABLE search_projection_inbox
+            ADD CONSTRAINT ck_search_projection_inbox_ingest_sequence
+            CHECK (ingest_sequence > 0);
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'ck_search_projection_watermark_ingest_sequence'
+          AND conrelid = 'search_projection_watermarks'::regclass
+    ) THEN
+        ALTER TABLE search_projection_watermarks
+            ADD CONSTRAINT ck_search_projection_watermark_ingest_sequence
+            CHECK (ingest_sequence >= 0);
+    END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_search_projection_inbox_due_ingest_sequence
+    ON search_projection_inbox (source_module, tenant_id, ingest_sequence)
+    WHERE status IN ('pending', 'retryable_error');
+"#;
+
+const POSTGRES_DOWN: &str = r#"
+DROP INDEX IF EXISTS idx_search_projection_inbox_due_ingest_sequence;
+"#;

--- a/crates/rustok-search/src/migrations/mod.rs
+++ b/crates/rustok-search/src/migrations/mod.rs
@@ -7,6 +7,7 @@ mod m20260325_000006_add_search_typo_tolerance_indexes;
 mod m20260721_000008_expand_search_query_locale_storage;
 mod m20260730_000009_create_search_projection_inbox;
 mod m20260731_000010_add_forum_projection_ingest_sequence;
+mod m20260731_000011_add_forum_projection_ingest_sequence_lookup;
 
 use sea_orm_migration::MigrationTrait;
 
@@ -21,5 +22,6 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260721_000008_expand_search_query_locale_storage::Migration),
         Box::new(m20260730_000009_create_search_projection_inbox::Migration),
         Box::new(m20260731_000010_add_forum_projection_ingest_sequence::Migration),
+        Box::new(m20260731_000011_add_forum_projection_ingest_sequence_lookup::Migration),
     ]
 }

--- a/scripts/verify/verify-forum-search-ingest-sequence-index.mjs
+++ b/scripts/verify/verify-forum-search-ingest-sequence-index.mjs
@@ -137,6 +137,7 @@ requireAll(
   [
     "# FORUM-23B2G1A Forum Search ingest-sequence lookup index",
     "left byte-for-byte unchanged",
+    "focused machine contract and owner note",
     "idx_search_projection_inbox_due_ingest_sequence",
     "EXPLAIN (ANALYZE, BUFFERS)",
     "did not run these commands",
@@ -146,20 +147,20 @@ requireAll(
 requireAll(
   forumPlan,
   [
-    "FORUM-23B2G1A",
-    "partial ingest-sequence lookup index",
-    "verify-forum-search-ingest-sequence-index.mjs",
+    "FORUM-23B2G1",
+    "durable PostgreSQL ingest sequence",
+    "owner-issued revision reconciliation",
   ],
-  paths.forumPlan,
+  `${paths.forumPlan} predecessor milestone`,
 );
 requireAll(
   searchPlan,
   [
-    "FORUM-23B2G1A",
+    "FORUM-23B2G1",
     "source_complete_execution_pending",
-    "ingest-sequence lookup index",
+    "Durable Forum inbox ingest ordering",
   ],
-  paths.searchPlan,
+  `${paths.searchPlan} predecessor milestone`,
 );
 
 if (contract) {
@@ -184,6 +185,15 @@ if (contract) {
   }
   if (contract.compatibility?.claim_order_changed !== false) {
     failures.push(`${paths.contract}: claim order compatibility drift`);
+  }
+  if (contract.canonical_plan?.predecessor_milestone !== "FORUM-23B2G1") {
+    failures.push(`${paths.contract}: predecessor plan milestone drift`);
+  }
+  if (contract.canonical_plan?.milestone_status_changed !== false) {
+    failures.push(`${paths.contract}: hardening must not invent a new plan status`);
+  }
+  if (contract.canonical_plan?.remaining_scope_changed !== false) {
+    failures.push(`${paths.contract}: hardening must preserve remaining plan scope`);
   }
 }
 

--- a/scripts/verify/verify-forum-search-ingest-sequence-index.mjs
+++ b/scripts/verify/verify-forum-search-ingest-sequence-index.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(".");
+const failures = [];
+const paths = {
+  contract: "crates/rustok-forum/contracts/forum-search-ingest-sequence-index.json",
+  note: "crates/rustok-forum/docs/forum-23b2g1a-search-ingest-sequence-index.md",
+  forumPlan: "crates/rustok-forum/docs/implementation-plan.md",
+  searchPlan: "crates/rustok-search/docs/implementation-plan.md",
+  predecessor:
+    "crates/rustok-search/src/migrations/m20260731_000010_add_forum_projection_ingest_sequence.rs",
+  migration:
+    "crates/rustok-search/src/migrations/m20260731_000011_add_forum_projection_ingest_sequence_lookup.rs",
+  registry: "crates/rustok-search/src/migrations/mod.rs",
+  inbox: "crates/rustok-search/src/forum_inbox.rs",
+  reconciliation: "crates/rustok-search/src/forum_reconciliation.rs",
+};
+
+function read(relativePath) {
+  const target = path.join(root, relativePath);
+  if (!existsSync(target)) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return "";
+  }
+  return readFileSync(target, "utf8");
+}
+
+function requireAll(source, markers, label) {
+  for (const marker of markers) {
+    if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+  }
+}
+
+function rejectAll(source, markers, label) {
+  for (const marker of markers) {
+    if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+  }
+}
+
+function parseJson(relativePath) {
+  try {
+    return JSON.parse(read(relativePath));
+  } catch (error) {
+    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+const contract = parseJson(paths.contract);
+const note = read(paths.note);
+const forumPlan = read(paths.forumPlan);
+const searchPlan = read(paths.searchPlan);
+const predecessor = read(paths.predecessor);
+const migration = read(paths.migration);
+const registry = read(paths.registry);
+const inbox = read(paths.inbox);
+const reconciliation = read(paths.reconciliation);
+
+requireAll(
+  migration,
+  [
+    "idx_search_projection_inbox_due_ingest_sequence",
+    "ON search_projection_inbox (source_module, tenant_id, ingest_sequence)",
+    "WHERE status IN ('pending', 'retryable_error')",
+    "conrelid = 'search_projection_inbox'::regclass",
+    "conrelid = 'search_projection_watermarks'::regclass",
+    "CHECK (ingest_sequence > 0)",
+    "CHECK (ingest_sequence >= 0)",
+    "DROP INDEX IF EXISTS idx_search_projection_inbox_due_ingest_sequence",
+    "DatabaseBackend::Sqlite => Ok(())",
+  ],
+  paths.migration,
+);
+rejectAll(
+  migration,
+  [
+    "ADD COLUMN",
+    "DROP COLUMN",
+    "CREATE SEQUENCE",
+    "DROP SEQUENCE",
+    "ALTER COLUMN ingest_sequence",
+  ],
+  paths.migration,
+);
+rejectAll(
+  predecessor,
+  ["idx_search_projection_inbox_due_ingest_sequence"],
+  `${paths.predecessor} immutable history`,
+);
+
+requireAll(
+  registry,
+  [
+    "mod m20260731_000010_add_forum_projection_ingest_sequence;",
+    "mod m20260731_000011_add_forum_projection_ingest_sequence_lookup;",
+    "m20260731_000010_add_forum_projection_ingest_sequence::Migration",
+    "m20260731_000011_add_forum_projection_ingest_sequence_lookup::Migration",
+  ],
+  paths.registry,
+);
+if (
+  registry.indexOf("m20260731_000010_add_forum_projection_ingest_sequence::Migration") >
+  registry.indexOf("m20260731_000011_add_forum_projection_ingest_sequence_lookup::Migration")
+) {
+  failures.push(`${paths.registry}: 000011 must follow 000010`);
+}
+
+requireAll(
+  inbox,
+  [
+    "WHERE tenant_id = $1",
+    "AND source_module = 'forum'",
+    "AND status IN ('pending', 'retryable_error')",
+    "ORDER BY ingest_sequence ASC",
+  ],
+  `${paths.inbox} claim query`,
+);
+requireAll(
+  reconciliation,
+  [
+    "SELECT DISTINCT ON (tenant_id)",
+    "WHERE source_module = 'forum'",
+    "AND status IN ('pending', 'retryable_error')",
+    "ORDER BY tenant_id, ingest_sequence ASC",
+    "ORDER BY ingest_sequence ASC",
+  ],
+  `${paths.reconciliation} due-tenant query`,
+);
+
+requireAll(
+  note,
+  [
+    "# FORUM-23B2G1A Forum Search ingest-sequence lookup index",
+    "left byte-for-byte unchanged",
+    "idx_search_projection_inbox_due_ingest_sequence",
+    "EXPLAIN (ANALYZE, BUFFERS)",
+    "did not run these commands",
+  ],
+  paths.note,
+);
+requireAll(
+  forumPlan,
+  [
+    "FORUM-23B2G1A",
+    "partial ingest-sequence lookup index",
+    "verify-forum-search-ingest-sequence-index.mjs",
+  ],
+  paths.forumPlan,
+);
+requireAll(
+  searchPlan,
+  [
+    "FORUM-23B2G1A",
+    "source_complete_execution_pending",
+    "ingest-sequence lookup index",
+  ],
+  paths.searchPlan,
+);
+
+if (contract) {
+  if (contract.task !== "FORUM-23B2G1A") failures.push(`${paths.contract}: unexpected task`);
+  if (contract.status !== "source_complete_execution_pending") {
+    failures.push(`${paths.contract}: unexpected status`);
+  }
+  if (contract.index?.name !== "idx_search_projection_inbox_due_ingest_sequence") {
+    failures.push(`${paths.contract}: unexpected index name`);
+  }
+  if (contract.index?.predicate !== "status IN ('pending', 'retryable_error')") {
+    failures.push(`${paths.contract}: partial predicate drift`);
+  }
+  if (contract.upgrade_safety?.predecessor_migration_modified !== false) {
+    failures.push(`${paths.contract}: predecessor migration must remain immutable`);
+  }
+  if (contract.upgrade_safety?.already_migrated_databases_receive_index !== true) {
+    failures.push(`${paths.contract}: upgrade-safe delivery is not recorded`);
+  }
+  if (contract.constraint_repair?.existence_check_scoped_by_conrelid !== true) {
+    failures.push(`${paths.contract}: scoped constraint repair is not recorded`);
+  }
+  if (contract.compatibility?.claim_order_changed !== false) {
+    failures.push(`${paths.contract}: claim order compatibility drift`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("FORUM-23B2G1A ingest-sequence lookup verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("FORUM-23B2G1A ingest-sequence lookup source contract is consistent.");


### PR DESCRIPTION
## Summary

- add `FORUM-23B2G1A` as an upgrade-safe hardening of the delivered durable Forum Search inbox ordering
- keep the already delivered `000010` migration unchanged and add a new PostgreSQL-only `000011` migration
- create the partial `idx_search_projection_inbox_due_ingest_sequence` index on `(source_module, tenant_id, ingest_sequence)` for pending/retryable rows
- support both the per-tenant oldest-event claim and bounded due-tenant `DISTINCT ON` ordering without changing query semantics
- reassert the positive inbox sequence and non-negative watermark constraints with relation-scoped `pg_constraint.conrelid` checks
- add a machine contract, owner note and fail-closed source verifier

## Recheck finding

`FORUM-23B2G1` moved claim and due-tenant ordering from producer timestamps/UUIDs to `ingest_sequence`, but its migration added only a global unique index. With many tenants and terminal rows, the owner lookups could require a broad scan instead of using the exact source/tenant/order prefix.

Editing `m20260731_000010_add_forum_projection_ingest_sequence.rs` would not repair databases where that migration has already run. This PR therefore uses additive migration `000011`; the predecessor migration remains unchanged.

## Canonical plan boundary

The canonical Forum and Search plans already record `FORUM-23B2G1` as `source_complete_execution_pending`, with owner-issued revisions and maintainer runtime evidence still pending. This lookup hardening changes neither milestone status nor remaining scope, so `G1A` is retained as a focused contract and owner note rather than a duplicate roadmap milestone.

## Compatibility

- no event, Forum owner, claim order, retry, watermark or projection behavior change
- no public API, dependency or `Cargo.lock` change
- SQLite schema remains unchanged and background Forum projection reconciliation remains PostgreSQL-only
- down migration drops only the new lookup index

## Verification

Tests, verifiers, formatting, Cargo checks, Clippy and PostgreSQL `EXPLAIN` evidence were intentionally not run by request. Maintainer commands and the required claim/due-tenant query-plan evidence are recorded in `crates/rustok-forum/docs/forum-23b2g1a-search-ingest-sequence-index.md`.