### PR TITLE
feat(blog): wire HTTP Comments port injection

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-comments-http-port-injection.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-http-port-injection.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "module": "blog",
+  "surface": "comments_http_port_injection",
+  "role": "consumer",
+  "provider": "comments",
+  "status": "source_verified_no_compile",
+  "compile_policy": "not_run_by_request",
+  "runtime_status": "not_run",
+  "source_contract": {
+    "http_runtime": "crates/rustok-blog/src/controllers/mod.rs",
+    "moderation_controller": "crates/rustok-blog/src/controllers/comments.rs",
+    "consumer_service": "crates/rustok-blog/src/services/comment.rs",
+    "consumer_matrix": "crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json"
+  },
+  "profiles": {
+    "source_verified": [
+      "in_process_fallback",
+      "host_injected_port_selection"
+    ],
+    "pending": [
+      "remote_transport_implementation"
+    ]
+  },
+  "composition": {
+    "host_context": "rustok_api::HostRuntimeContext",
+    "shared_value": "Arc<dyn CommentsThreadPort>",
+    "lookup": "HostRuntimeContext::shared_get",
+    "selector": "BlogHttpRuntime::comment_service",
+    "injected_constructor": "CommentService::with_comments_thread_port",
+    "fallback_constructor": "CommentService::new",
+    "http_operation": "moderate_comment"
+  },
+  "harness": {
+    "status": "executable_no_run",
+    "runtime_status": "not_run",
+    "source": "crates/rustok-blog/src/controllers/mod.rs",
+    "test": "controllers::tests::blog_http_runtime_exposes_comments_port_selection",
+    "command": "cargo test -p rustok-blog --lib controllers::tests::blog_http_runtime_exposes_comments_port_selection -- --exact"
+  },
+  "non_claims": [
+    "no remote network transport is implemented",
+    "no Rust or JavaScript test was run",
+    "no compile, database, browser, workflow, CI, or production result is recorded",
+    "GraphQL and native SSR composition remain separate pending slices"
+  ]
+}

--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -105,6 +105,23 @@ source profile and transport-neutral injection seam are source-locked. The remot
 transport remains pending; degraded UI modes remain planned. Cached snapshot and
 comment-form fallback remain planned, and runtime evidence is pending.
 
+HTTP moderation composition is retained separately. `BlogHttpRuntime::from_host`
+reads an optional `Arc<dyn CommentsThreadPort>` through
+`HostRuntimeContext::shared_get`, and `BlogHttpRuntime::comment_service` selects
+`CommentService::with_comments_thread_port` when the host supplies one while
+preserving `CommentService::new` as the in-process fallback. The moderation
+controller delegates only to that selector. Schema-v1 evidence lives at
+`crates/rustok-blog/contracts/evidence/blog-comments-http-port-injection.json`,
+guarded by `scripts/verify/verify-blog-comments-http-port-injection.mjs` and
+focused fixture
+`scripts/verify/verify-blog-comments-http-port-injection.test.mjs`. The retained
+compile-only harness is
+`controllers::tests::blog_http_runtime_exposes_comments_port_selection`, with
+suggested command
+`cargo test -p rustok-blog --lib controllers::tests::blog_http_runtime_exposes_comments_port_selection -- --exact`.
+HTTP moderation host selection is source-locked; GraphQL and native SSR
+composition plus the remote network transport remains pending.
+
 Comments lifecycle projection into Blog-owned `comment_count` is a Blog consumer
 boundary. `BlogCommentProjectionHandler` accepts only `comment.created` and
 `comment.deleted` for `blog_post`, uses the envelope id as the durable delivery
@@ -557,6 +574,20 @@ fail-closed verifier now rejects constructor, harness, metadata, and unearned
 runtime-status drift. No remote transport implementation, Rust/JavaScript test,
 compile, database, browser, workflow, CI, or production execution is recorded.
 
+The continuation audit at `99418b0ea424dbb56835ee61105de4294cb75337`
+found that the new public injection seam was not yet consumed by the Blog HTTP
+moderation runtime. `BlogHttpRuntime` retained only database and event-bus handles,
+and the controller still constructed the in-process service directly, so a
+host-provided Comments port could not reach the HTTP moderation surface.
+
+Slice 59 adds optional `Arc<dyn CommentsThreadPort>` lookup from
+`HostRuntimeContext`, centralizes injected/in-process selection in
+`BlogHttpRuntime::comment_service`, and removes direct provider construction from
+the moderation controller. New schema-v1 evidence, a standalone verifier, focused
+negative fixtures, and a compile-only selector harness retain the HTTP composition
+contract. GraphQL/native SSR wiring, package-chain registration, the remote
+network transport, and all execution remain pending.
+
 ## FFA/FBA status
 
 - FFA status: `in_progress`.
@@ -570,18 +601,22 @@ compile, database, browser, workflow, CI, or production execution is recorded.
   plus aggregate/consumer bindings for admin, storefront, Comments port boundary,
   Comments event projection, category Search reindex, GraphQL rate limiting,
   GraphQL richtext, AI richtext, offline backfill, Forum ownership, and runtime
-  order.
+  order. The standalone HTTP Comments composition guard remains outside registry
+  package order in Slice 59.
 - Comments consumer port boundary: Blog-owned `source_verified_no_compile` for
   the in-process profile; evidence schema v3, all seven operations, approved public
   read, typed richtext projection, two-second deadlines, write idempotency, active
   typed `PortErrorKind` mapping, public transport-neutral injection constructor,
   compile-only exact-signature harness, exact npm leaf commands, focused fixture,
-  and Blog FBA ordering are locked. Typed storefront comments availability is
-  retained across GraphQL/native DTOs and Leptos UI; only external-service and
-  timeout errors degrade, while other errors propagate. The remote transport,
-  remote adapter runtime parity, cached snapshot, comment-form fallback,
-  browser/runtime evidence, and broader degraded UI modes remain planned or
-  pending.
+  and Blog FBA ordering are locked. HTTP moderation now selects an optional
+  host-provided port through `BlogHttpRuntime::comment_service` with an in-process
+  fallback; schema-v1 standalone evidence and focused negatives retain that source
+  contract. Typed storefront comments availability is retained across
+  GraphQL/native DTOs and Leptos UI; only external-service and timeout errors
+  degrade, while other errors propagate. GraphQL and native SSR composition, the
+  remote network transport, remote adapter runtime parity, cached snapshot,
+  comment-form fallback, browser/runtime evidence, and broader degraded UI modes
+  remain planned or pending.
 - Comments event projection: Blog-owned `source_verified_no_compile`; evidence
   schema v4, shared classifier/counter/retry-decision helpers, `executable_no_run`
   source harness, deterministic PostgreSQL retry-limit target, module-registration,
@@ -628,10 +663,13 @@ compile, database, browser, workflow, CI, or production execution is recorded.
 - `crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-consumer-runtime-order-smoke.json`
+- `crates/rustok-blog/contracts/evidence/blog-comments-http-port-injection.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-duplicate-delivery-race.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-dispatcher-duplicate-delivery.json`
 - `crates/rustok-blog/src/lib.rs`
+- `crates/rustok-blog/src/controllers/mod.rs`
+- `crates/rustok-blog/src/controllers/comments.rs`
 - `crates/rustok-blog/src/services/comment.rs`
 - `crates/rustok-blog/src/graphql/types.rs`
 - `crates/rustok-blog/storefront/src/model.rs`
@@ -659,6 +697,8 @@ compile, database, browser, workflow, CI, or production execution is recorded.
 - `crates/rustok-search/contracts/evidence/search-canonical-url-contract.json`
 - `scripts/verify/verify-blog-comments-port-boundary.mjs`
 - `scripts/verify/verify-blog-comments-port-boundary.test.mjs`
+- `scripts/verify/verify-blog-comments-http-port-injection.mjs`
+- `scripts/verify/verify-blog-comments-http-port-injection.test.mjs`
 - `scripts/verify/verify-blog-comments-event-projection.mjs`
 - `scripts/verify/verify-blog-comments-event-projection.test.mjs`
 - `scripts/verify/verify-blog-comments-duplicate-delivery-race.mjs`
@@ -842,6 +882,12 @@ compile, database, browser, workflow, CI, or production execution is recorded.
     schema v3, registered the harness in Blog registry schema v13, and extended the
     existing fail-closed verifier and focused fixture without implementing or
     claiming a remote transport.
+59. Wired optional host-provided `CommentsThreadPort` selection into Blog HTTP
+    moderation, centralized injected/in-process construction in
+    `BlogHttpRuntime::comment_service`, retained the selector in schema-v1 evidence
+    plus a standalone verifier, focused negative fixture, and compile-only harness,
+    and kept GraphQL/native SSR composition, package registration, remote transport,
+    and all execution pending.
 
 ## Next results
 
@@ -859,9 +905,10 @@ compile, database, browser, workflow, CI, or production execution is recorded.
    controller handoff, focused verifier, then Redis-backed host requests with a
    real HTTP `Retry-After` matching GraphQL `retryAfter`.
 5. **Close comments runtime evidence.** Run the Comments port boundary fixture,
-   the compile-only injection-signature harness, shared consumer runtime-order
-   verifier, Blog projection classifier and deterministic retry-policy harness,
-   module registration/routing harness, the filtered
+   the compile-only injection-signature and HTTP selection harnesses, the
+   standalone HTTP composition verifier and focused fixture, shared consumer
+   runtime-order verifier, Blog projection classifier and deterministic
+   retry-policy harness, module registration/routing harness, the filtered
    `event_dispatcher_routes_registered_handler_and_commits_projection`,
    `event_dispatcher_replays_duplicate_envelope_without_double_commit`,
    `concurrent_created_events_converge_without_lost_updates`,
@@ -881,8 +928,9 @@ compile, database, browser, workflow, CI, or production execution is recorded.
    duplicate replay, dispatcher delivery output, four-connection convergence,
    both child process exits, the written duplicate, delete-before-create,
    missing-post replay, outbox rollback/retry, and same-process/new-connection
-   assertions; then implement the host-owned remote Comments transport through
-   `CommentService::with_comments_thread_port` and retain all-seven-operation
+   assertions; then wire GraphQL, storefront native SSR, and admin native SSR to
+   the host-owned Comments port, implement the remote network transport through
+   `CommentService::with_comments_thread_port`, and retain all-seven-operation
    adapter parity, naturally contended PostgreSQL retry-frequency evidence, full
    server-host restart recovery, browser parity for typed unavailable/timeout
    article rendering, cached thread snapshots, comment-form fallback,
@@ -902,6 +950,9 @@ should run the relevant subset, including:
 - `npm run verify:blog:comments-port-boundary`
 - `npm run test:verify:blog:comments-port-boundary`
 - `cargo test -p rustok-blog --lib services::comment::port_injection_tests::comment_service_accepts_an_injected_comments_thread_port -- --exact`
+- `node scripts/verify/verify-blog-comments-http-port-injection.mjs`
+- `node --test scripts/verify/verify-blog-comments-http-port-injection.test.mjs`
+- `cargo test -p rustok-blog --lib controllers::tests::blog_http_runtime_exposes_comments_port_selection -- --exact`
 - `npm run verify:blog:comments-event-projection`
 - `npm run test:verify:blog:comments-event-projection`
 - `npm run verify:blog:comments-duplicate-delivery-race`

--- a/crates/rustok-blog/src/controllers/comments.rs
+++ b/crates/rustok-blog/src/controllers/comments.rs
@@ -8,7 +8,7 @@ use rustok_web::{HttpError, HttpResult};
 use uuid::Uuid;
 
 use super::{BlogHttpRuntime, posts::ensure_blog_permission};
-use crate::{CommentResponse, CommentService, ModerateCommentInput};
+use crate::{CommentResponse, ModerateCommentInput};
 
 #[utoipa::path(
     post,
@@ -49,7 +49,7 @@ pub async fn moderate_comment(
         .unwrap_or_else(|| request_context.locale.clone());
     input.locale = Some(locale);
 
-    let service = CommentService::new(runtime.db_clone(), runtime.event_bus());
+    let service = runtime.comment_service();
     let comment = service
         .moderate_comment(
             tenant.id,

--- a/crates/rustok-blog/src/controllers/mod.rs
+++ b/crates/rustok-blog/src/controllers/mod.rs
@@ -2,8 +2,12 @@ use anyhow::Context;
 use axum::Router;
 use axum::routing::{get, post};
 use rustok_api::HostRuntimeContext;
+use rustok_comments::CommentsThreadPort;
 use rustok_outbox::TransactionalEventBus;
 use sea_orm::DatabaseConnection;
+use std::sync::Arc;
+
+use crate::CommentService;
 
 pub mod categories;
 pub mod comments;
@@ -13,6 +17,7 @@ pub mod posts;
 pub struct BlogHttpRuntime {
     db: DatabaseConnection,
     event_bus: TransactionalEventBus,
+    comments_thread_port: Option<Arc<dyn CommentsThreadPort>>,
 }
 
 impl BlogHttpRuntime {
@@ -22,6 +27,14 @@ impl BlogHttpRuntime {
 
     fn event_bus(&self) -> TransactionalEventBus {
         self.event_bus.clone()
+    }
+
+    fn comment_service(&self) -> CommentService {
+        if let Some(comments_thread_port) = self.comments_thread_port.clone() {
+            CommentService::with_comments_thread_port(self.db_clone(), comments_thread_port)
+        } else {
+            CommentService::new(self.db_clone(), self.event_bus())
+        }
     }
 }
 
@@ -33,6 +46,7 @@ impl BlogHttpRuntime {
         Ok(Self {
             db: runtime.db_clone(),
             event_bus,
+            comments_thread_port: runtime.shared_get::<Arc<dyn CommentsThreadPort>>(),
         })
     }
 }
@@ -70,4 +84,15 @@ pub fn axum_router(runtime: &HostRuntimeContext) -> anyhow::Result<Router> {
             post(comments::moderate_comment),
         )
         .with_state(state))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blog_http_runtime_exposes_comments_port_selection() {
+        let selector: fn(&BlogHttpRuntime) -> CommentService = BlogHttpRuntime::comment_service;
+        let _ = selector;
+    }
 }

--- a/scripts/verify/verify-blog-comments-http-port-injection.mjs
+++ b/scripts/verify/verify-blog-comments-http-port-injection.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve('.');
+const failures = [];
+
+function repoPath(relativePath) {
+  return path.join(repoRoot, relativePath);
+}
+
+function read(relativePath) {
+  const target = repoPath(relativePath);
+  if (!existsSync(target)) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return '';
+  }
+  return readFileSync(target, 'utf8');
+}
+
+function json(relativePath) {
+  try {
+    return JSON.parse(read(relativePath));
+  } catch (error) {
+    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function requireMarker(source, marker, label) {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+}
+
+function requireNoMarker(source, marker, label) {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+}
+
+function sameSet(actual, expected) {
+  return [...actual].sort().join('|') === [...expected].sort().join('|');
+}
+
+const evidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-http-port-injection.json';
+const runtimePath = 'crates/rustok-blog/src/controllers/mod.rs';
+const controllerPath = 'crates/rustok-blog/src/controllers/comments.rs';
+const servicePath = 'crates/rustok-blog/src/services/comment.rs';
+const matrixPath = 'crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json';
+const planPath = 'crates/rustok-blog/docs/implementation-plan.md';
+const harnessTest = 'controllers::tests::blog_http_runtime_exposes_comments_port_selection';
+const harnessCommand = `cargo test -p rustok-blog --lib ${harnessTest} -- --exact`;
+
+const evidence = json(evidencePath);
+const runtime = read(runtimePath);
+const controller = read(controllerPath);
+const service = read(servicePath);
+const matrix = json(matrixPath);
+const plan = read(planPath);
+
+if (evidence) {
+  if (evidence.schema_version !== 1) failures.push(`${evidencePath}: schema_version drift`);
+  if (
+    evidence.module !== 'blog' ||
+    evidence.surface !== 'comments_http_port_injection' ||
+    evidence.role !== 'consumer' ||
+    evidence.provider !== 'comments'
+  ) failures.push(`${evidencePath}: identity drift`);
+  if (
+    evidence.status !== 'source_verified_no_compile' ||
+    evidence.compile_policy !== 'not_run_by_request' ||
+    evidence.runtime_status !== 'not_run'
+  ) failures.push(`${evidencePath}: execution status drift`);
+  if (
+    evidence.source_contract?.http_runtime !== runtimePath ||
+    evidence.source_contract?.moderation_controller !== controllerPath ||
+    evidence.source_contract?.consumer_service !== servicePath ||
+    evidence.source_contract?.consumer_matrix !== matrixPath
+  ) failures.push(`${evidencePath}: source path drift`);
+  if (!sameSet(evidence.profiles?.source_verified ?? [], [
+    'in_process_fallback',
+    'host_injected_port_selection',
+  ])) failures.push(`${evidencePath}: source-verified profile drift`);
+  if (!sameSet(evidence.profiles?.pending ?? [], ['remote_transport_implementation'])) {
+    failures.push(`${evidencePath}: pending profile drift`);
+  }
+  const composition = evidence.composition ?? {};
+  if (
+    composition.host_context !== 'rustok_api::HostRuntimeContext' ||
+    composition.shared_value !== 'Arc<dyn CommentsThreadPort>' ||
+    composition.lookup !== 'HostRuntimeContext::shared_get' ||
+    composition.selector !== 'BlogHttpRuntime::comment_service' ||
+    composition.injected_constructor !== 'CommentService::with_comments_thread_port' ||
+    composition.fallback_constructor !== 'CommentService::new' ||
+    composition.http_operation !== 'moderate_comment'
+  ) failures.push(`${evidencePath}: composition drift`);
+  const harness = evidence.harness ?? {};
+  if (
+    harness.status !== 'executable_no_run' ||
+    harness.runtime_status !== 'not_run' ||
+    harness.source !== runtimePath ||
+    harness.test !== harnessTest ||
+    harness.command !== harnessCommand
+  ) failures.push(`${evidencePath}: harness drift`);
+}
+
+if (
+  matrix?.schema_version !== 3 ||
+  matrix?.adapter_injection?.constructor !== 'CommentService::with_comments_thread_port' ||
+  matrix?.adapter_injection?.runtime_status !== 'not_run' ||
+  matrix?.adapter_injection?.remote_transport_implementation !== 'pending'
+) failures.push(`${matrixPath}: base injection seam drift`);
+
+for (const marker of [
+  'use rustok_comments::CommentsThreadPort;',
+  'use std::sync::Arc;',
+  'comments_thread_port: Option<Arc<dyn CommentsThreadPort>>',
+  'fn comment_service(&self) -> CommentService',
+  'if let Some(comments_thread_port) = self.comments_thread_port.clone()',
+  'CommentService::with_comments_thread_port(self.db_clone(), comments_thread_port)',
+  'CommentService::new(self.db_clone(), self.event_bus())',
+  'comments_thread_port: runtime.shared_get::<Arc<dyn CommentsThreadPort>>()',
+  'mod tests',
+  'fn blog_http_runtime_exposes_comments_port_selection()',
+  'let selector: fn(&BlogHttpRuntime) -> CommentService = BlogHttpRuntime::comment_service;',
+]) requireMarker(runtime, marker, runtimePath);
+
+requireMarker(controller, 'let service = runtime.comment_service();', controllerPath);
+requireNoMarker(controller, 'CommentService::new(', controllerPath);
+requireNoMarker(controller, 'CommentService::with_comments_thread_port(', controllerPath);
+
+for (const marker of [
+  'pub fn with_comments_thread_port(',
+  'comments_thread_port: Arc<dyn CommentsThreadPort>',
+]) requireMarker(service, marker, servicePath);
+
+for (const marker of [
+  'blog-comments-http-port-injection.json',
+  'verify-blog-comments-http-port-injection.mjs',
+  'verify-blog-comments-http-port-injection.test.mjs',
+  'BlogHttpRuntime::comment_service',
+  'HTTP moderation',
+  'remote network transport remains pending',
+  'Slice 59',
+]) requireMarker(plan, marker, planPath);
+
+if (failures.length > 0) {
+  console.error('Blog Comments HTTP port injection verification failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log('Blog Comments HTTP host-injected port composition is source-consistent');

--- a/scripts/verify/verify-blog-comments-http-port-injection.test.mjs
+++ b/scripts/verify/verify-blog-comments-http-port-injection.test.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const verifier = path.resolve('scripts/verify/verify-blog-comments-http-port-injection.mjs');
+const evidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-http-port-injection.json';
+const runtimePath = 'crates/rustok-blog/src/controllers/mod.rs';
+const controllerPath = 'crates/rustok-blog/src/controllers/comments.rs';
+const servicePath = 'crates/rustok-blog/src/services/comment.rs';
+const matrixPath = 'crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json';
+const planPath = 'crates/rustok-blog/docs/implementation-plan.md';
+const harnessTest = 'controllers::tests::blog_http_runtime_exposes_comments_port_selection';
+const harnessCommand = `cargo test -p rustok-blog --lib ${harnessTest} -- --exact`;
+
+function write(root, relativePath, content) {
+  const target = path.join(root, relativePath);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, content);
+}
+
+function fixture({
+  missingSharedLookup = false,
+  missingInjectedBranch = false,
+  missingFallback = false,
+  directControllerConstruction = false,
+  missingHarness = false,
+  runtimePromoted = false,
+  remotePromoted = false,
+  missingPlanMarker = false,
+} = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-blog-comments-http-port-'));
+
+  write(
+    root,
+    runtimePath,
+    `
+use rustok_comments::CommentsThreadPort;
+use std::sync::Arc;
+comments_thread_port: Option<Arc<dyn CommentsThreadPort>>
+fn comment_service(&self) -> CommentService {
+${missingInjectedBranch ? '' : `
+if let Some(comments_thread_port) = self.comments_thread_port.clone() {
+CommentService::with_comments_thread_port(self.db_clone(), comments_thread_port)
+}
+`}
+${missingFallback ? '' : 'CommentService::new(self.db_clone(), self.event_bus())'}
+}
+${missingSharedLookup ? '' : 'comments_thread_port: runtime.shared_get::<Arc<dyn CommentsThreadPort>>()'}
+${missingHarness ? '' : `
+mod tests
+fn blog_http_runtime_exposes_comments_port_selection()
+let selector: fn(&BlogHttpRuntime) -> CommentService = BlogHttpRuntime::comment_service;
+`}
+`,
+  );
+
+  write(
+    root,
+    controllerPath,
+    directControllerConstruction
+      ? 'let service = CommentService::new(runtime.db_clone(), runtime.event_bus());'
+      : 'let service = runtime.comment_service();',
+  );
+
+  write(
+    root,
+    servicePath,
+    `
+pub fn with_comments_thread_port(
+comments_thread_port: Arc<dyn CommentsThreadPort>
+`,
+  );
+
+  write(
+    root,
+    matrixPath,
+    JSON.stringify({
+      schema_version: 3,
+      adapter_injection: {
+        constructor: 'CommentService::with_comments_thread_port',
+        runtime_status: 'not_run',
+        remote_transport_implementation: 'pending',
+      },
+    }),
+  );
+
+  write(
+    root,
+    evidencePath,
+    JSON.stringify({
+      schema_version: 1,
+      module: 'blog',
+      surface: 'comments_http_port_injection',
+      role: 'consumer',
+      provider: 'comments',
+      status: 'source_verified_no_compile',
+      compile_policy: 'not_run_by_request',
+      runtime_status: runtimePromoted ? 'passed' : 'not_run',
+      source_contract: {
+        http_runtime: runtimePath,
+        moderation_controller: controllerPath,
+        consumer_service: servicePath,
+        consumer_matrix: matrixPath,
+      },
+      profiles: {
+        source_verified: [
+          'in_process_fallback',
+          'host_injected_port_selection',
+          ...(remotePromoted ? ['remote_transport_implementation'] : []),
+        ],
+        pending: remotePromoted ? [] : ['remote_transport_implementation'],
+      },
+      composition: {
+        host_context: 'rustok_api::HostRuntimeContext',
+        shared_value: 'Arc<dyn CommentsThreadPort>',
+        lookup: 'HostRuntimeContext::shared_get',
+        selector: 'BlogHttpRuntime::comment_service',
+        injected_constructor: 'CommentService::with_comments_thread_port',
+        fallback_constructor: 'CommentService::new',
+        http_operation: 'moderate_comment',
+      },
+      harness: {
+        status: 'executable_no_run',
+        runtime_status: runtimePromoted ? 'passed' : 'not_run',
+        source: runtimePath,
+        test: harnessTest,
+        command: harnessCommand,
+      },
+      non_claims: [],
+    }),
+  );
+
+  write(
+    root,
+    planPath,
+    missingPlanMarker
+      ? 'Slice 59 remote network transport remains pending'
+      : 'blog-comments-http-port-injection.json verify-blog-comments-http-port-injection.mjs verify-blog-comments-http-port-injection.test.mjs BlogHttpRuntime::comment_service HTTP moderation remote network transport remains pending Slice 59',
+  );
+
+  return root;
+}
+
+function run(root) {
+  return spawnSync(process.execPath, [verifier], {
+    cwd: path.resolve('.'),
+    env: { ...process.env, RUSTOK_VERIFY_REPO_ROOT: root },
+    encoding: 'utf8',
+  });
+}
+
+function rejects(options) {
+  const root = fixture(options);
+  try {
+    return run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test('accepts the canonical Blog Comments HTTP port injection boundary', () => {
+  const root = fixture();
+  try {
+    const result = run(root);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects removal of the HostRuntimeContext shared port lookup', () => {
+  assert.notEqual(rejects({ missingSharedLookup: true }).status, 0);
+});
+
+test('rejects removal of the injected Comments port branch', () => {
+  assert.notEqual(rejects({ missingInjectedBranch: true }).status, 0);
+});
+
+test('rejects removal of the in-process fallback', () => {
+  assert.notEqual(rejects({ missingFallback: true }).status, 0);
+});
+
+test('rejects controller-level Comments service construction', () => {
+  const result = rejects({ directControllerConstruction: true });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /forbidden CommentService::new/);
+});
+
+test('rejects removal of the compile-only HTTP selection harness', () => {
+  assert.notEqual(rejects({ missingHarness: true }).status, 0);
+});
+
+test('rejects runtime promotion without execution', () => {
+  const result = rejects({ runtimePromoted: true });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /execution status drift|harness drift/);
+});
+
+test('rejects promotion of the unimplemented remote transport', () => {
+  const result = rejects({ remotePromoted: true });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /profile drift/);
+});
+
+test('rejects removal of canonical plan bindings', () => {
+  assert.notEqual(rejects({ missingPlanMarker: true }).status, 0);
+});


### PR DESCRIPTION
## Summary

- continue the canonical Blog implementation plan through slice 59
- let `BlogHttpRuntime` read an optional host-provided `Arc<dyn CommentsThreadPort>` from `HostRuntimeContext`
- centralize injected/in-process service selection in `BlogHttpRuntime::comment_service`
- route HTTP comment moderation through that selector instead of constructing the in-process provider directly
- retain the composition contract in schema-v1 evidence
- add a standalone fail-closed verifier, focused negative fixture, and compile-only selector harness

## Scope and non-claims

This PR wires the existing transport-neutral injection seam into the Blog HTTP moderation surface only. GraphQL, storefront native SSR, and admin native SSR composition remain separate pending slices. No remote network transport is implemented, the remote profile is not promoted, and this standalone guard is not yet registered in the Blog FBA package chain.

No Rust or JavaScript test, verifier, compilation, database, browser, workflow, CI, or production command was run, per maintainer instruction.

## Suggested maintainer commands

```bash
node scripts/verify/verify-blog-comments-http-port-injection.mjs
node --test scripts/verify/verify-blog-comments-http-port-injection.test.mjs
cargo test -p rustok-blog --lib controllers::tests::blog_http_runtime_exposes_comments_port_selection -- --exact
```

## Branch state

The work started from `main` at `6eef1ce55f09b2c46e0f578c56c1bef3031759f8`. Current `main` is ahead through one unrelated Forum/Search commit. The branch contains six commits and changes exactly six Blog HTTP composition/source-contract files.