### PR TITLE
test(blog): bind HTTP composition into Comments port gate

### DIFF
--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -114,8 +114,12 @@ controller delegates only to that selector. Schema-v1 evidence lives at
 `crates/rustok-blog/contracts/evidence/blog-comments-http-port-injection.json`,
 guarded by `scripts/verify/verify-blog-comments-http-port-injection.mjs` and
 focused fixture
-`scripts/verify/verify-blog-comments-http-port-injection.test.mjs`. The retained
-compile-only harness is
+`scripts/verify/verify-blog-comments-http-port-injection.test.mjs`. The registered
+`verify:blog:comments-port-boundary` verifier imports the standalone HTTP verifier,
+and the registered `test:verify:blog:comments-port-boundary` self-test imports its
+focused fixture. `scripts/verify/verify-blog-fba.test.mjs` locks both imports, so
+the existing first-class Comments port leaf cannot silently drop HTTP composition
+coverage. The retained compile-only harness is
 `controllers::tests::blog_http_runtime_exposes_comments_port_selection`, with
 suggested command
 `cargo test -p rustok-blog --lib controllers::tests::blog_http_runtime_exposes_comments_port_selection -- --exact`.
@@ -588,6 +592,21 @@ negative fixtures, and a compile-only selector harness retain the HTTP compositi
 contract. GraphQL/native SSR wiring, package-chain registration, the remote
 network transport, and all execution remain pending.
 
+The continuation audit at `c1870d5473f0cecc2d95fa19fcd9377118a9a2d2`
+found that the HTTP composition evidence, standalone verifier, focused fixture,
+and compile-only selector harness were complete, but the registered
+`comments_port_boundary` leaf did not execute either standalone JavaScript asset.
+The HTTP contract could therefore drift while both Blog FBA package chains still
+passed their existing source order.
+
+Slice 60 imports the standalone HTTP verifier from the registered Comments port
+verifier and imports its focused fixture from the registered Comments port
+self-test. The aggregate Blog FBA self-test locks both import statements. Registry
+schema v13, package scripts, and verify/test order remain unchanged because HTTP
+composition is now a required sub-contract of the existing first-class Comments
+port leaf rather than a parallel duplicate leaf. Runtime source, evidence, remote
+transport status, and all execution claims remain unchanged.
+
 ## FFA/FBA status
 
 - FFA status: `in_progress`.
@@ -601,17 +620,19 @@ network transport, and all execution remain pending.
   plus aggregate/consumer bindings for admin, storefront, Comments port boundary,
   Comments event projection, category Search reindex, GraphQL rate limiting,
   GraphQL richtext, AI richtext, offline backfill, Forum ownership, and runtime
-  order. The standalone HTTP Comments composition guard remains outside registry
-  package order in Slice 59.
+  order. The existing Comments port leaf now requires the HTTP composition
+  verifier and focused fixture through aggregate-locked imports; package order is
+  unchanged.
 - Comments consumer port boundary: Blog-owned `source_verified_no_compile` for
   the in-process profile; evidence schema v3, all seven operations, approved public
   read, typed richtext projection, two-second deadlines, write idempotency, active
   typed `PortErrorKind` mapping, public transport-neutral injection constructor,
   compile-only exact-signature harness, exact npm leaf commands, focused fixture,
-  and Blog FBA ordering are locked. HTTP moderation now selects an optional
+  and Blog FBA ordering are locked. HTTP moderation selects an optional
   host-provided port through `BlogHttpRuntime::comment_service` with an in-process
-  fallback; schema-v1 standalone evidence and focused negatives retain that source
-  contract. Typed storefront comments availability is retained across
+  fallback; schema-v1 evidence, standalone verification, all focused HTTP
+  negatives, and both parent imports are retained inside the registered Comments
+  port gate. Typed storefront comments availability is retained across
   GraphQL/native DTOs and Leptos UI; only external-service and timeout errors
   degrade, while other errors propagate. GraphQL and native SSR composition, the
   remote network transport, remote adapter runtime parity, cached snapshot,
@@ -888,6 +909,10 @@ network transport, and all execution remain pending.
     plus a standalone verifier, focused negative fixture, and compile-only harness,
     and kept GraphQL/native SSR composition, package registration, remote transport,
     and all execution pending.
+60. Bound the standalone HTTP composition verifier and focused fixture into the
+    already registered `comments-port-boundary` verify/test leaf, added aggregate
+    regressions for both required imports, preserved registry schema v13 and exact
+    package order, and changed no runtime source or execution status.
 
 ## Next results
 
@@ -904,11 +929,12 @@ network transport, and all execution remain pending.
 4. **Execute mounted rate-limit evidence.** Run policy, memory adapter,
    controller handoff, focused verifier, then Redis-backed host requests with a
    real HTTP `Retry-After` matching GraphQL `retryAfter`.
-5. **Close comments runtime evidence.** Run the Comments port boundary fixture,
-   the compile-only injection-signature and HTTP selection harnesses, the
-   standalone HTTP composition verifier and focused fixture, shared consumer
-   runtime-order verifier, Blog projection classifier and deterministic
-   retry-policy harness, module registration/routing harness, the filtered
+5. **Close comments runtime evidence.** Run the registered Comments port boundary
+   verifier and self-test, which now include the standalone HTTP composition
+   verifier and all focused HTTP negatives, plus the compile-only injection-signature
+   and HTTP selection harnesses, shared consumer runtime-order verifier, Blog
+   projection classifier and deterministic retry-policy harness, module
+   registration/routing harness, the filtered
    `event_dispatcher_routes_registered_handler_and_commits_projection`,
    `event_dispatcher_replays_duplicate_envelope_without_double_commit`,
    `concurrent_created_events_converge_without_lost_updates`,

--- a/scripts/verify/verify-blog-comments-port-boundary.mjs
+++ b/scripts/verify/verify-blog-comments-port-boundary.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import './verify-blog-comments-http-port-injection.mjs';
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 

--- a/scripts/verify/verify-blog-comments-port-boundary.test.mjs
+++ b/scripts/verify/verify-blog-comments-port-boundary.test.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import './verify-blog-comments-http-port-injection.test.mjs';
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
@@ -23,6 +24,8 @@ const injectionTest =
   'services::comment::port_injection_tests::comment_service_accepts_an_injected_comments_thread_port';
 const injectionCommand =
   `cargo test -p rustok-blog --lib ${injectionTest} -- --exact`;
+const httpHarnessTest = 'controllers::tests::blog_http_runtime_exposes_comments_port_selection';
+const httpHarnessCommand = `cargo test -p rustok-blog --lib ${httpHarnessTest} -- --exact`;
 
 function write(root, relativePath, content) {
   const target = path.join(root, relativePath);
@@ -48,7 +51,10 @@ function fixture({
   const root = mkdtempSync(path.join(tmpdir(), 'rustok-blog-comments-port-'));
   const evidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json';
   const fallbackEvidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json';
+  const httpEvidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-http-port-injection.json';
   const servicePath = 'crates/rustok-blog/src/services/comment.rs';
+  const httpRuntimePath = 'crates/rustok-blog/src/controllers/mod.rs';
+  const httpControllerPath = 'crates/rustok-blog/src/controllers/comments.rs';
   const graphqlOwnerPath = 'crates/rustok-blog/src/graphql/types.rs';
   const storefrontModelPath = 'crates/rustok-blog/storefront/src/model.rs';
   const storefrontGraphqlPath = 'crates/rustok-blog/storefront/src/transport/graphql_adapter.rs';
@@ -109,6 +115,28 @@ post_id
 ${directBypass ? '.comments.get_comment(' : ''}
 `,
   );
+
+  write(
+    root,
+    httpRuntimePath,
+    `
+use rustok_comments::CommentsThreadPort;
+use std::sync::Arc;
+comments_thread_port: Option<Arc<dyn CommentsThreadPort>>
+fn comment_service(&self) -> CommentService {
+if let Some(comments_thread_port) = self.comments_thread_port.clone() {
+CommentService::with_comments_thread_port(self.db_clone(), comments_thread_port)
+} else {
+CommentService::new(self.db_clone(), self.event_bus())
+}
+}
+comments_thread_port: runtime.shared_get::<Arc<dyn CommentsThreadPort>>()
+mod tests
+fn blog_http_runtime_exposes_comments_port_selection()
+let selector: fn(&BlogHttpRuntime) -> CommentService = BlogHttpRuntime::comment_service;
+`,
+  );
+  write(root, httpControllerPath, 'let service = runtime.comment_service();');
 
   write(
     root,
@@ -223,6 +251,48 @@ Comments took too long to load. The article is still available.
 
   write(
     root,
+    httpEvidencePath,
+    JSON.stringify({
+      schema_version: 1,
+      module: 'blog',
+      surface: 'comments_http_port_injection',
+      role: 'consumer',
+      provider: 'comments',
+      status: 'source_verified_no_compile',
+      compile_policy: 'not_run_by_request',
+      runtime_status: 'not_run',
+      source_contract: {
+        http_runtime: httpRuntimePath,
+        moderation_controller: httpControllerPath,
+        consumer_service: servicePath,
+        consumer_matrix: evidencePath,
+      },
+      profiles: {
+        source_verified: ['in_process_fallback', 'host_injected_port_selection'],
+        pending: ['remote_transport_implementation'],
+      },
+      composition: {
+        host_context: 'rustok_api::HostRuntimeContext',
+        shared_value: 'Arc<dyn CommentsThreadPort>',
+        lookup: 'HostRuntimeContext::shared_get',
+        selector: 'BlogHttpRuntime::comment_service',
+        injected_constructor: 'CommentService::with_comments_thread_port',
+        fallback_constructor: 'CommentService::new',
+        http_operation: 'moderate_comment',
+      },
+      harness: {
+        status: 'executable_no_run',
+        runtime_status: 'not_run',
+        source: httpRuntimePath,
+        test: httpHarnessTest,
+        command: httpHarnessCommand,
+      },
+      non_claims: [],
+    }),
+  );
+
+  write(
+    root,
     fallbackEvidencePath,
     JSON.stringify({
       schema_version: 2,
@@ -307,7 +377,7 @@ Comments took too long to load. The article is still available.
   write(
     root,
     'crates/rustok-blog/docs/implementation-plan.md',
-    'blog-comments-consumer-static-matrix.json blog-comments-runtime-fallback-smoke.json verify:blog:comments-port-boundary test:verify:blog:comments-port-boundary source_verified_no_compile typed storefront comments availability CommentService::with_comments_thread_port remote transport remains pending cached snapshot and comment-form fallback remain planned',
+    'blog-comments-consumer-static-matrix.json blog-comments-runtime-fallback-smoke.json blog-comments-http-port-injection.json verify-blog-comments-http-port-injection.mjs verify-blog-comments-http-port-injection.test.mjs verify:blog:comments-port-boundary test:verify:blog:comments-port-boundary source_verified_no_compile typed storefront comments availability CommentService::with_comments_thread_port BlogHttpRuntime::comment_service HTTP moderation remote transport remains pending remote network transport remains pending cached snapshot and comment-form fallback remain planned Slice 59 Slice 60',
   );
 
   return root;

--- a/scripts/verify/verify-blog-fba.test.mjs
+++ b/scripts/verify/verify-blog-fba.test.mjs
@@ -2,6 +2,7 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import {
   BLOG_FBA_CONSUMER_RUNTIME_SELF_TEST,
   BLOG_FBA_SELF_TEST,
@@ -10,6 +11,11 @@ import {
   BLOG_FBA_VERIFICATION_STEPS,
   collectBlogFbaVerificationChainFailures,
 } from './blog-fba-verification-chain.mjs';
+
+const commentsPortVerifier = 'scripts/verify/verify-blog-comments-port-boundary.mjs';
+const commentsPortSelfTest = 'scripts/verify/verify-blog-comments-port-boundary.test.mjs';
+const httpVerifierImport = "import './verify-blog-comments-http-port-injection.mjs';";
+const httpSelfTestImport = "import './verify-blog-comments-http-port-injection.test.mjs';";
 
 function clone(value) {
   return JSON.parse(JSON.stringify(value));
@@ -71,6 +77,16 @@ function failures({
 
 test('Blog FBA verification-chain policy accepts canonical verify and test chains', () => {
   assert.deepEqual(failures(), []);
+});
+
+test('Blog FBA policy retains HTTP composition verifier inside the registered Comments port gate', () => {
+  const source = readFileSync(commentsPortVerifier, 'utf8');
+  assert.ok(source.includes(httpVerifierImport));
+});
+
+test('Blog FBA policy retains HTTP composition focused fixture inside the registered Comments port self-test', () => {
+  const source = readFileSync(commentsPortSelfTest, 'utf8');
+  assert.ok(source.includes(httpSelfTestImport));
 });
 
 test('Blog FBA verification-chain policy rejects removal of the storefront verify step', () => {


### PR DESCRIPTION
## Summary

- continue the canonical Blog implementation plan through slice 60
- make the registered `verify:blog:comments-port-boundary` verifier execute the standalone HTTP Comments composition verifier
- make the registered Comments port self-test include all focused HTTP composition cases
- extend the aggregate Blog FBA self-test to lock both required imports
- keep Blog registry schema v13, package scripts, and verify/test order unchanged

## Scope and non-claims

This is an integration-only source-contract slice. It changes no Blog runtime source, service behavior, evidence status, provider profile, package order, or registry schema. The remote network transport, GraphQL composition, storefront native SSR composition, admin native SSR composition, runtime evidence, and browser evidence remain pending.

No Rust or JavaScript test, verifier, compilation, database, browser, workflow, CI, or production command was run, per maintainer instruction.

## Suggested maintainer commands

```bash
npm run verify:blog:comments-port-boundary
npm run test:verify:blog:comments-port-boundary
npm run verify:blog:fba
npm run test:verify:blog:fba
```

## Branch state

The branch starts from current `main` at `c1870d5473f0cecc2d95fa19fcd9377118a9a2d2`, contains four commits, and changes exactly four Blog source-contract files.