### PR TITLE
feat(search): expose Forum projection owner revisions

### DIFF
--- a/apps/server/src/services/forum_search_owner_revision.rs
+++ b/apps/server/src/services/forum_search_owner_revision.rs
@@ -1,0 +1,77 @@
+use async_trait::async_trait;
+use rustok_api::{PortError, PortErrorKind};
+use rustok_forum::{
+    ForumError, ForumEventService,
+    ForumProjectionOwnerRevisionImpact as ForumOwnerRevisionImpact,
+};
+use rustok_search::{
+    ForumProjectionOwnerRevisionImpact, ForumProjectionOwnerRevisionRecord,
+    ForumProjectionOwnerRevisionRequest, ForumProjectionOwnerRevisionSourcePort,
+    SharedForumProjectionOwnerRevisionSourcePort,
+};
+use sea_orm::DatabaseConnection;
+
+pub(crate) struct ServerForumProjectionOwnerRevisionSourcePort {
+    db: DatabaseConnection,
+}
+
+impl ServerForumProjectionOwnerRevisionSourcePort {
+    pub(crate) fn shared(db: DatabaseConnection) -> SharedForumProjectionOwnerRevisionSourcePort {
+        std::sync::Arc::new(Self { db })
+    }
+}
+
+#[async_trait]
+impl ForumProjectionOwnerRevisionSourcePort for ServerForumProjectionOwnerRevisionSourcePort {
+    async fn list_owner_revisions(
+        &self,
+        request: ForumProjectionOwnerRevisionRequest,
+    ) -> Result<Vec<ForumProjectionOwnerRevisionRecord>, PortError> {
+        let revisions = ForumEventService::new(self.db.clone())
+            .list_projection_owner_revisions(
+                request.tenant_id,
+                request.after_owner_revision,
+                request.limit,
+            )
+            .await
+            .map_err(map_forum_error)?;
+
+        Ok(revisions
+            .into_iter()
+            .map(|revision| ForumProjectionOwnerRevisionRecord {
+                owner_revision: revision.owner_revision,
+                event_id: revision.event_id,
+                event_type: revision.event_type,
+                impact: match revision.impact {
+                    ForumOwnerRevisionImpact::FullRebuild => {
+                        ForumProjectionOwnerRevisionImpact::FullRebuild
+                    }
+                    ForumOwnerRevisionImpact::NoProjectionChange => {
+                        ForumProjectionOwnerRevisionImpact::NoProjectionChange
+                    }
+                },
+            })
+            .collect())
+    }
+}
+
+fn map_forum_error(error: ForumError) -> PortError {
+    let stable_code = error.stable_code().to_ascii_lowercase();
+    let retryable = error.is_retryable();
+    match error {
+        ForumError::Validation(message) => PortError::validation(stable_code, message),
+        ForumError::Database(_)
+        | ForumError::CapabilityUnavailable { .. }
+        | ForumError::CapabilityFailure { .. }
+        | ForumError::Internal(_) => PortError::new(
+            PortErrorKind::Unavailable,
+            stable_code,
+            "Forum projection owner revision source is temporarily unavailable",
+            retryable,
+        ),
+        _ => PortError::invariant_violation(
+            stable_code,
+            "Forum projection owner revision source could not be resolved safely",
+        ),
+    }
+}

--- a/apps/server/src/services/mod.rs
+++ b/apps/server/src/services/mod.rs
@@ -93,6 +93,11 @@ pub mod module_event_dispatcher {
     }
 
     #[cfg(feature = "mod-forum")]
+    mod forum_search_owner_revision {
+        include!("forum_search_owner_revision.rs");
+    }
+
+    #[cfg(feature = "mod-forum")]
     mod forum_search_result_eligibility {
         include!("forum_search_result_eligibility.rs");
     }
@@ -130,12 +135,17 @@ pub mod module_event_dispatcher {
                     db.clone(),
                     audience_facts.clone(),
                 );
+            let owner_revision =
+                forum_search_owner_revision::ServerForumProjectionOwnerRevisionSourcePort::shared(
+                    db.clone(),
+                );
             let result_eligibility =
                 forum_search_result_eligibility::ServerForumSearchResultEligibilityPort::shared(
                     db.clone(),
                     audience_facts,
                 );
             extensions.insert(category_scope);
+            extensions.insert(owner_revision);
             extensions.insert(result_eligibility);
         }
 
@@ -224,6 +234,10 @@ pub mod module_event_dispatcher {
             );
             #[cfg(feature = "mod-forum")]
             assert!(
+                extensions.contains::<rustok_search::SharedForumProjectionOwnerRevisionSourcePort>()
+            );
+            #[cfg(feature = "mod-forum")]
+            assert!(
                 extensions.contains::<rustok_search::SharedStorefrontSearchResultEligibilityPort>()
             );
             #[cfg(all(feature = "mod-notifications", feature = "mod-profiles"))]
@@ -236,6 +250,11 @@ pub mod module_event_dispatcher {
             #[cfg(feature = "mod-forum")]
             assert!(
                 host.shared_get::<rustok_search::SharedStorefrontSearchCategoryScopePort>()
+                    .is_some()
+            );
+            #[cfg(feature = "mod-forum")]
+            assert!(
+                host.shared_get::<rustok_search::SharedForumProjectionOwnerRevisionSourcePort>()
                     .is_some()
             );
             #[cfg(feature = "mod-forum")]

--- a/crates/rustok-forum/contracts/forum-search-owner-revision-source.json
+++ b/crates/rustok-forum/contracts/forum-search-owner-revision-source.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-23B2G2A",
+  "status": "source_complete_consumer_reconciliation_pending",
+  "scope": "Expose the immutable Forum owner journal as a bounded neutral Search projection revision source without advancing Search watermarks",
+  "owner_clock": {
+    "table": "forum_domain_events",
+    "field": "sequence_no",
+    "owner": "rustok-forum",
+    "strictly_increasing": true,
+    "append_only": true,
+    "global_sequence_tenant_scoped_reads": true,
+    "gaps_between_tenant_rows_are_valid": true,
+    "new_counter_added": false,
+    "migration_added": false
+  },
+  "forum_owner": {
+    "dto": "crates/rustok-forum/src/dto/event.rs",
+    "service": "crates/rustok-forum/src/services/event.rs",
+    "method": "ForumEventService::list_projection_owner_revisions",
+    "payload_exposed": false,
+    "actor_exposed": false,
+    "rbac_facing_journal_dto_reused": false,
+    "max_page_size": 100,
+    "ordering": "owner_revision ASC",
+    "cursor": "exclusive after_owner_revision"
+  },
+  "impact_classification": {
+    "full_rebuild_default": true,
+    "future_unknown_event_fails_safe": true,
+    "no_projection_change_event_types": [
+      "forum.topic.vote_changed",
+      "forum.reply.vote_changed",
+      "forum.category.subscription_changed",
+      "forum.topic.subscription_changed",
+      "forum.mention.user_added",
+      "forum.mention.audience_added"
+    ]
+  },
+  "search_contract": {
+    "owner": "crates/rustok-search/src/forum_reconciliation.rs",
+    "trait": "ForumProjectionOwnerRevisionSourcePort",
+    "shared_type": "SharedForumProjectionOwnerRevisionSourcePort",
+    "resolver": "resolve_forum_projection_owner_revisions",
+    "tenant_required": true,
+    "non_negative_cursor_required": true,
+    "strictly_increasing_page_required": true,
+    "non_nil_event_identity_required": true,
+    "bounded_event_type_required": true,
+    "missing_port_fails_closed": true,
+    "independent_from_search_ingest_sequence": true
+  },
+  "host_composition": {
+    "adapter": "apps/server/src/services/forum_search_owner_revision.rs",
+    "registration": "apps/server/src/services/mod.rs",
+    "direct_search_read_of_forum_domain_events": false,
+    "runtime_extension_registered": true
+  },
+  "non_claims": [
+    "The current Forum projection sweeper does not consume owner revisions in this slice",
+    "No Search owner-revision watermark is created or advanced",
+    "No lost-delivery gap is repaired automatically",
+    "No PostgreSQL, restart, retry or LINK-FORUM-03 runtime evidence was executed",
+    "Tests, verifiers, formatting, Cargo checks and Clippy were not run by the implementation agent"
+  ],
+  "remaining_scope": [
+    "persist a Search-owned per-tenant Forum owner-revision cursor separately from ingest_sequence",
+    "compare the owner journal with completed Search projection state without skipping pending inbox work",
+    "schedule a bounded tenant rebuild when a projection-impacting owner revision is not covered by durable delivery",
+    "advance owner revision only after the rebuild and Search state commit succeed",
+    "prove deletion, ACL, topic/reply parent-derived refresh, restart, retry and LINK-FORUM-03 behavior in PostgreSQL"
+  ]
+}

--- a/crates/rustok-forum/docs/forum-23b2g2a-search-owner-revision-source.md
+++ b/crates/rustok-forum/docs/forum-23b2g2a-search-owner-revision-source.md
@@ -1,0 +1,103 @@
+# FORUM-23B2G2A Search owner-revision source
+
+## Status
+
+`source_complete_consumer_reconciliation_pending`
+
+This slice exposes the existing immutable Forum event journal as a bounded,
+transport-neutral owner-revision source for Search. It does not add another
+revision counter and it does not change the already delivered Search inbox
+`ingest_sequence` ordering.
+
+## Owner clock
+
+The authoritative revision is:
+
+```text
+forum_domain_events.sequence_no
+```
+
+`FORUM-09` already owns this append-only BIGINT sequence. It is globally
+monotonic across the Forum journal. Search reads remain tenant-scoped, so gaps
+between successive rows for one tenant are expected and valid.
+
+No migration, sequence, timestamp ordering rule, UUID ordering rule or new
+`DomainEvent` field is introduced.
+
+## Forum owner boundary
+
+`ForumEventService::list_projection_owner_revisions` reads at most 100 journal
+rows after an exclusive `after_owner_revision` cursor and orders them by
+`sequence_no ASC`.
+
+The owner-facing result contains only:
+
+- owner revision;
+- event identity;
+- bounded event type;
+- projection impact.
+
+Journal payload, actor identity and the RBAC-facing event response are not
+exported through the Search capability.
+
+The owner explicitly marks vote, subscription and mention records as
+`NoProjectionChange`. Every other current or future admitted Forum journal event
+fails safe to `FullRebuild` until the owner classifies it more narrowly.
+
+## Neutral Search contract
+
+Search owns `ForumProjectionOwnerRevisionSourcePort` and validates every page
+before it can be consumed:
+
+- tenant UUID must be non-nil;
+- cursor must be non-negative;
+- page size must be between 1 and 100;
+- returned rows must not exceed the requested page size;
+- owner revisions must be strictly increasing after the cursor;
+- event IDs must be non-nil;
+- event types must remain inside the published 96-character journal bound.
+
+Missing host composition and malformed owner pages fail closed through typed
+`PortError` values.
+
+The host adapter is the only composition point between Search and Forum. Search
+does not query `forum_domain_events` directly.
+
+## Deliberate boundary with G1
+
+Search `ingest_sequence` remains a delivery-order cursor owned by the durable
+Search inbox. Forum `sequence_no` is source-of-truth owner order. They are
+separate monotonic domains and must not be compared numerically.
+
+This source slice registers the owner port but does not yet connect it to the
+background sweeper. In particular, it does not:
+
+- create or advance an owner-revision watermark;
+- infer that a missing inbox row is safe to skip;
+- rebuild a tenant automatically;
+- mark owner state covered by a pending or failed delivery;
+- claim PostgreSQL runtime reconciliation evidence.
+
+Those actions require a separate `FORUM-23B2G2B` commit protocol that preserves
+pending inbox ordering and advances the owner cursor only after projection state
+commits successfully.
+
+## Maintainer verification
+
+The implementation agent did not run these commands, as requested:
+
+```bash
+cargo test -p rustok-forum services::event::tests -- --nocapture
+cargo test -p rustok-search owner_revision_tests -- --nocapture
+cargo test -p rustok-server --features mod-forum host_materializes_index_query_runtime_after_source_registry -- --nocapture
+node scripts/verify/verify-forum-search-owner-revision-source.mjs
+cargo check -p rustok-forum --all-targets
+cargo check -p rustok-search --all-targets
+cargo check -p rustok-server --features mod-forum --all-targets
+cargo xtask module validate forum
+cargo xtask module validate search
+```
+
+Future PostgreSQL evidence should prove tenant isolation, legal global-sequence
+gaps, exact page boundaries, unknown-event fail-safe classification and lossless
+paging before G2B is allowed to mutate reconciliation state.

--- a/crates/rustok-forum/docs/forum-23b2g2a-search-owner-revision-source.md
+++ b/crates/rustok-forum/docs/forum-23b2g2a-search-owner-revision-source.md
@@ -17,9 +17,9 @@ The authoritative revision is:
 forum_domain_events.sequence_no
 ```
 
-`FORUM-09` already owns this append-only BIGINT sequence. It is globally
-monotonic across the Forum journal. Search reads remain tenant-scoped, so gaps
-between successive rows for one tenant are expected and valid.
+`FORUM-09` already owns this append-only BIGINT sequence. The sequence is global
+while reads are tenant-scoped, so gaps between successive rows for one tenant
+are expected and valid.
 
 No migration, sequence, timestamp ordering rule, UUID ordering rule or new
 `DomainEvent` field is introduced.

--- a/crates/rustok-forum/src/dto/event.rs
+++ b/crates/rustok-forum/src/dto/event.rs
@@ -25,3 +25,17 @@ pub struct ForumDomainEventResponse {
     pub payload: Value,
     pub created_at: String,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForumProjectionOwnerRevisionImpact {
+    FullRebuild,
+    NoProjectionChange,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForumProjectionOwnerRevisionResponse {
+    pub owner_revision: i64,
+    pub event_id: Uuid,
+    pub event_type: String,
+    pub impact: ForumProjectionOwnerRevisionImpact,
+}

--- a/crates/rustok-forum/src/services/event.rs
+++ b/crates/rustok-forum/src/services/event.rs
@@ -3,13 +3,17 @@ use rustok_core::SecurityContext;
 use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder, QuerySelect};
 use uuid::Uuid;
 
-use crate::dto::{ForumDomainEventQuery, ForumDomainEventResponse};
+use crate::dto::{
+    ForumDomainEventQuery, ForumDomainEventResponse, ForumProjectionOwnerRevisionImpact,
+    ForumProjectionOwnerRevisionResponse,
+};
 use crate::entities::forum_domain_event;
 use crate::error::{ForumError, ForumResult};
 use crate::services::rbac::enforce_scope;
 
 const DEFAULT_EVENT_LIMIT: u64 = 50;
 const MAX_EVENT_LIMIT: u64 = 100;
+pub const MAX_FORUM_PROJECTION_OWNER_REVISION_PAGE: usize = 100;
 
 #[derive(Clone)]
 pub struct ForumEventService {
@@ -77,6 +81,67 @@ impl ForumEventService {
             })
             .collect())
     }
+
+    /// Reads the immutable Forum owner journal as a bounded projection-revision
+    /// source. This internal owner boundary deliberately omits journal payload,
+    /// actor and user-facing authorization state.
+    pub async fn list_projection_owner_revisions(
+        &self,
+        tenant_id: Uuid,
+        after_owner_revision: i64,
+        limit: usize,
+    ) -> ForumResult<Vec<ForumProjectionOwnerRevisionResponse>> {
+        if tenant_id.is_nil() {
+            return Err(ForumError::Validation(
+                "projection owner revision tenant must not be nil".to_string(),
+            ));
+        }
+        if after_owner_revision < 0 {
+            return Err(ForumError::Validation(
+                "after_owner_revision must not be negative".to_string(),
+            ));
+        }
+        if !(1..=MAX_FORUM_PROJECTION_OWNER_REVISION_PAGE).contains(&limit) {
+            return Err(ForumError::Validation(format!(
+                "projection owner revision limit must be between 1 and {MAX_FORUM_PROJECTION_OWNER_REVISION_PAGE}"
+            )));
+        }
+
+        let events = forum_domain_event::Entity::find()
+            .filter(forum_domain_event::Column::TenantId.eq(tenant_id))
+            .filter(forum_domain_event::Column::SequenceNo.gt(after_owner_revision))
+            .order_by_asc(forum_domain_event::Column::SequenceNo)
+            .limit(limit as u64)
+            .all(&self.db)
+            .await?;
+
+        Ok(events
+            .into_iter()
+            .map(|event| ForumProjectionOwnerRevisionResponse {
+                owner_revision: event.sequence_no,
+                event_id: event.event_id,
+                impact: projection_revision_impact(&event.event_type),
+                event_type: event.event_type,
+            })
+            .collect())
+    }
+}
+
+fn projection_revision_impact(event_type: &str) -> ForumProjectionOwnerRevisionImpact {
+    match event_type {
+        "forum.topic.vote_changed"
+        | "forum.reply.vote_changed"
+        | "forum.category.subscription_changed"
+        | "forum.topic.subscription_changed"
+        | "forum.mention.user_added"
+        | "forum.mention.audience_added" => {
+            ForumProjectionOwnerRevisionImpact::NoProjectionChange
+        }
+        // Unknown future Forum journal types fail safe. Until the owner contract
+        // explicitly classifies them, Search reconciliation must assume that the
+        // public projection may have changed.
+        _ => ForumProjectionOwnerRevisionImpact::FullRebuild,
+    }
 }
 
 fn normalize_filter(value: Option<String>, field: &str) -> ForumResult<Option<String>> {
@@ -94,4 +159,44 @@ fn normalize_filter(value: Option<String>, field: &str) -> ForumResult<Option<St
             Ok(normalized)
         })
         .transpose()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::projection_revision_impact;
+    use crate::ForumProjectionOwnerRevisionImpact;
+
+    #[test]
+    fn non_projection_events_are_explicitly_classified() {
+        for event_type in [
+            "forum.topic.vote_changed",
+            "forum.reply.vote_changed",
+            "forum.category.subscription_changed",
+            "forum.topic.subscription_changed",
+            "forum.mention.user_added",
+            "forum.mention.audience_added",
+        ] {
+            assert_eq!(
+                projection_revision_impact(event_type),
+                ForumProjectionOwnerRevisionImpact::NoProjectionChange
+            );
+        }
+    }
+
+    #[test]
+    fn projection_and_unknown_events_fail_safe_to_full_rebuild() {
+        for event_type in [
+            "forum.category.updated",
+            "forum.topic.updated",
+            "forum.reply.status_changed",
+            "forum.solution.marked",
+            "forum.topic.tags_changed",
+            "forum.future_projection_event",
+        ] {
+            assert_eq!(
+                projection_revision_impact(event_type),
+                ForumProjectionOwnerRevisionImpact::FullRebuild
+            );
+        }
+    }
 }

--- a/crates/rustok-search/src/forum_reconciliation.rs
+++ b/crates/rustok-search/src/forum_reconciliation.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use async_trait::async_trait;
+use rustok_api::PortError;
 use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement};
 use uuid::Uuid;
 
@@ -14,8 +16,129 @@ use crate::projector::SearchProjector;
 
 pub const DEFAULT_FORUM_SWEEP_TENANT_LIMIT: usize = 32;
 pub const DEFAULT_FORUM_SWEEP_EVENT_LIMIT: usize = 64;
+pub const DEFAULT_FORUM_OWNER_REVISION_PAGE_LIMIT: usize = 64;
+pub const MAX_FORUM_OWNER_REVISION_PAGE_LIMIT: usize = 100;
 const MAX_FORUM_SWEEP_TENANT_LIMIT: usize = 256;
 const MAX_FORUM_SWEEP_EVENT_LIMIT: usize = 256;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ForumProjectionOwnerRevisionImpact {
+    FullRebuild,
+    NoProjectionChange,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ForumProjectionOwnerRevisionRecord {
+    pub owner_revision: i64,
+    pub event_id: Uuid,
+    pub event_type: String,
+    pub impact: ForumProjectionOwnerRevisionImpact,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ForumProjectionOwnerRevisionRequest {
+    pub tenant_id: Uuid,
+    pub after_owner_revision: i64,
+    pub limit: usize,
+}
+
+#[async_trait]
+pub trait ForumProjectionOwnerRevisionSourcePort: Send + Sync {
+    async fn list_owner_revisions(
+        &self,
+        request: ForumProjectionOwnerRevisionRequest,
+    ) -> std::result::Result<Vec<ForumProjectionOwnerRevisionRecord>, PortError>;
+}
+
+pub type SharedForumProjectionOwnerRevisionSourcePort =
+    Arc<dyn ForumProjectionOwnerRevisionSourcePort>;
+
+/// Resolves a bounded page from the Forum owner journal and verifies the neutral
+/// revision contract before any reconciliation logic can consume it. Owner
+/// revisions are independent from Search-owned inbox ingest sequences; gaps are
+/// valid because the Forum journal sequence is global while reads are tenant
+/// scoped.
+pub async fn resolve_forum_projection_owner_revisions(
+    port: Option<SharedForumProjectionOwnerRevisionSourcePort>,
+    request: ForumProjectionOwnerRevisionRequest,
+) -> std::result::Result<Vec<ForumProjectionOwnerRevisionRecord>, PortError> {
+    validate_owner_revision_request(request)?;
+    let port = port.ok_or_else(|| {
+        PortError::unavailable(
+            "forum.search_projection_owner_revision.owner_unavailable",
+            "Forum projection owner revision source is temporarily unavailable",
+        )
+    })?;
+    let revisions = port.list_owner_revisions(request).await?;
+    validate_owner_revision_page(request, &revisions)?;
+    Ok(revisions)
+}
+
+fn validate_owner_revision_request(
+    request: ForumProjectionOwnerRevisionRequest,
+) -> std::result::Result<(), PortError> {
+    if request.tenant_id.is_nil() {
+        return Err(PortError::validation(
+            "forum.search_projection_owner_revision.tenant_required",
+            "Forum projection owner revision source requires a tenant",
+        ));
+    }
+    if request.after_owner_revision < 0 {
+        return Err(PortError::validation(
+            "forum.search_projection_owner_revision.cursor_invalid",
+            "Forum projection owner revision cursor must not be negative",
+        ));
+    }
+    if !(1..=MAX_FORUM_OWNER_REVISION_PAGE_LIMIT).contains(&request.limit) {
+        return Err(PortError::validation(
+            "forum.search_projection_owner_revision.limit_invalid",
+            format!(
+                "Forum projection owner revision limit must be between 1 and {MAX_FORUM_OWNER_REVISION_PAGE_LIMIT}"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_owner_revision_page(
+    request: ForumProjectionOwnerRevisionRequest,
+    revisions: &[ForumProjectionOwnerRevisionRecord],
+) -> std::result::Result<(), PortError> {
+    if revisions.len() > request.limit {
+        return Err(owner_revision_invariant(
+            "owner returned more revisions than requested",
+        ));
+    }
+
+    let mut previous_revision = request.after_owner_revision;
+    for revision in revisions {
+        if revision.owner_revision <= previous_revision {
+            return Err(owner_revision_invariant(
+                "owner revisions must be strictly increasing after the requested cursor",
+            ));
+        }
+        if revision.event_id.is_nil() {
+            return Err(owner_revision_invariant(
+                "owner revision event identity must not be nil",
+            ));
+        }
+        let event_type = revision.event_type.trim();
+        if event_type.is_empty() || event_type.len() > 96 {
+            return Err(owner_revision_invariant(
+                "owner revision event type is outside the published Forum journal bounds",
+            ));
+        }
+        previous_revision = revision.owner_revision;
+    }
+    Ok(())
+}
+
+fn owner_revision_invariant(message: &'static str) -> PortError {
+    PortError::invariant_violation(
+        "forum.search_projection_owner_revision.contract_invalid",
+        message,
+    )
+}
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ForumProjectionSweepReport {
@@ -215,4 +338,84 @@ fn validate_limit(label: &str, value: usize, maximum: usize) -> Result<()> {
         )));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod owner_revision_tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use rustok_api::{PortError, PortErrorKind};
+    use uuid::Uuid;
+
+    use super::{
+        ForumProjectionOwnerRevisionImpact, ForumProjectionOwnerRevisionRecord,
+        ForumProjectionOwnerRevisionRequest, ForumProjectionOwnerRevisionSourcePort,
+        SharedForumProjectionOwnerRevisionSourcePort,
+        resolve_forum_projection_owner_revisions,
+    };
+
+    struct FixedRevisionSource {
+        revisions: Vec<ForumProjectionOwnerRevisionRecord>,
+    }
+
+    #[async_trait]
+    impl ForumProjectionOwnerRevisionSourcePort for FixedRevisionSource {
+        async fn list_owner_revisions(
+            &self,
+            _request: ForumProjectionOwnerRevisionRequest,
+        ) -> Result<Vec<ForumProjectionOwnerRevisionRecord>, PortError> {
+            Ok(self.revisions.clone())
+        }
+    }
+
+    fn request(after_owner_revision: i64) -> ForumProjectionOwnerRevisionRequest {
+        ForumProjectionOwnerRevisionRequest {
+            tenant_id: Uuid::new_v4(),
+            after_owner_revision,
+            limit: 10,
+        }
+    }
+
+    fn record(owner_revision: i64) -> ForumProjectionOwnerRevisionRecord {
+        ForumProjectionOwnerRevisionRecord {
+            owner_revision,
+            event_id: Uuid::new_v4(),
+            event_type: "forum.topic.updated".to_string(),
+            impact: ForumProjectionOwnerRevisionImpact::FullRebuild,
+        }
+    }
+
+    #[tokio::test]
+    async fn owner_revision_port_requires_host_composition() {
+        let error = resolve_forum_projection_owner_revisions(None, request(0))
+            .await
+            .expect_err("missing owner source must fail closed");
+        assert_eq!(error.kind, PortErrorKind::Unavailable);
+    }
+
+    #[tokio::test]
+    async fn owner_revision_page_accepts_strictly_increasing_global_sequence() {
+        let port: SharedForumProjectionOwnerRevisionSourcePort =
+            Arc::new(FixedRevisionSource {
+                revisions: vec![record(4), record(9)],
+            });
+        let revisions = resolve_forum_projection_owner_revisions(Some(port), request(3))
+            .await
+            .expect("valid owner revisions should resolve");
+        assert_eq!(revisions.len(), 2);
+        assert_eq!(revisions[1].owner_revision, 9);
+    }
+
+    #[tokio::test]
+    async fn owner_revision_page_rejects_reordered_or_replayed_rows() {
+        let port: SharedForumProjectionOwnerRevisionSourcePort =
+            Arc::new(FixedRevisionSource {
+                revisions: vec![record(8), record(8)],
+            });
+        let error = resolve_forum_projection_owner_revisions(Some(port), request(7))
+            .await
+            .expect_err("duplicate owner revisions must fail closed");
+        assert_eq!(error.kind, PortErrorKind::InvariantViolation);
+    }
 }

--- a/crates/rustok-search/src/lib.rs
+++ b/crates/rustok-search/src/lib.rs
@@ -59,8 +59,12 @@ pub use engine::{
 pub use engine::{SearchResult, SearchResultItem};
 pub use forum_document_filters::ForumStorefrontDocumentFilters;
 pub use forum_reconciliation::{
-    DEFAULT_FORUM_SWEEP_EVENT_LIMIT, DEFAULT_FORUM_SWEEP_TENANT_LIMIT, ForumProjectionReconciler,
-    ForumProjectionSweepReport,
+    DEFAULT_FORUM_OWNER_REVISION_PAGE_LIMIT, DEFAULT_FORUM_SWEEP_EVENT_LIMIT,
+    DEFAULT_FORUM_SWEEP_TENANT_LIMIT, ForumProjectionOwnerRevisionImpact,
+    ForumProjectionOwnerRevisionRecord, ForumProjectionOwnerRevisionRequest,
+    ForumProjectionOwnerRevisionSourcePort, ForumProjectionReconciler,
+    ForumProjectionSweepReport, MAX_FORUM_OWNER_REVISION_PAGE_LIMIT,
+    SharedForumProjectionOwnerRevisionSourcePort, resolve_forum_projection_owner_revisions,
 };
 pub use forum_storefront_execution::{
     ForumStorefrontSearchAttributeFilter, ForumStorefrontSearchExecution,

--- a/scripts/verify/verify-forum-search-owner-revision-source.mjs
+++ b/scripts/verify/verify-forum-search-owner-revision-source.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(".");
+const failures = [];
+const paths = {
+  contract: "crates/rustok-forum/contracts/forum-search-owner-revision-source.json",
+  note: "crates/rustok-forum/docs/forum-23b2g2a-search-owner-revision-source.md",
+  forumDto: "crates/rustok-forum/src/dto/event.rs",
+  forumOwner: "crates/rustok-forum/src/services/event.rs",
+  forumJournal: "crates/rustok-forum/src/entities/forum_domain_event.rs",
+  forumMigrations: "crates/rustok-forum/src/migrations/mod.rs",
+  searchOwner: "crates/rustok-search/src/forum_reconciliation.rs",
+  searchLib: "crates/rustok-search/src/lib.rs",
+  searchInbox: "crates/rustok-search/src/forum_inbox.rs",
+  searchMigrations: "crates/rustok-search/src/migrations/mod.rs",
+  hostAdapter: "apps/server/src/services/forum_search_owner_revision.rs",
+  hostComposition: "apps/server/src/services/mod.rs",
+  rootEvents: "crates/rustok-events/src/types.rs",
+};
+
+function read(relativePath) {
+  const target = path.join(root, relativePath);
+  if (!existsSync(target)) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return "";
+  }
+  return readFileSync(target, "utf8");
+}
+
+function parseJson(relativePath) {
+  try {
+    return JSON.parse(read(relativePath));
+  } catch (error) {
+    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function requireAll(source, markers, label) {
+  for (const marker of markers) {
+    if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+  }
+}
+
+function rejectAll(source, markers, label) {
+  for (const marker of markers) {
+    if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+  }
+}
+
+const contract = parseJson(paths.contract);
+const note = read(paths.note);
+const forumDto = read(paths.forumDto);
+const forumOwner = read(paths.forumOwner);
+const forumJournal = read(paths.forumJournal);
+const forumMigrations = read(paths.forumMigrations);
+const searchOwner = read(paths.searchOwner);
+const searchLib = read(paths.searchLib);
+const searchInbox = read(paths.searchInbox);
+const searchMigrations = read(paths.searchMigrations);
+const hostAdapter = read(paths.hostAdapter);
+const hostComposition = read(paths.hostComposition);
+const rootEvents = read(paths.rootEvents);
+
+requireAll(forumJournal, [
+  'table_name = "forum_domain_events"',
+  "pub sequence_no: i64",
+  "pub event_id: Uuid",
+], paths.forumJournal);
+
+requireAll(forumDto, [
+  "pub enum ForumProjectionOwnerRevisionImpact",
+  "FullRebuild",
+  "NoProjectionChange",
+  "pub struct ForumProjectionOwnerRevisionResponse",
+  "pub owner_revision: i64",
+], paths.forumDto);
+
+requireAll(forumOwner, [
+  "MAX_FORUM_PROJECTION_OWNER_REVISION_PAGE: usize = 100",
+  "pub async fn list_projection_owner_revisions",
+  "after_owner_revision",
+  "SequenceNo.gt(after_owner_revision)",
+  "order_by_asc(forum_domain_event::Column::SequenceNo)",
+  "projection_revision_impact",
+  '"forum.topic.vote_changed"',
+  '"forum.mention.audience_added"',
+  "Unknown future Forum journal types fail safe",
+], paths.forumOwner);
+rejectAll(forumOwner, [
+  "SearchProjection",
+  "search_projection_inbox",
+  "search_projection_watermarks",
+], paths.forumOwner);
+
+requireAll(searchOwner, [
+  "pub trait ForumProjectionOwnerRevisionSourcePort",
+  "pub type SharedForumProjectionOwnerRevisionSourcePort",
+  "pub async fn resolve_forum_projection_owner_revisions",
+  "DEFAULT_FORUM_OWNER_REVISION_PAGE_LIMIT: usize = 64",
+  "MAX_FORUM_OWNER_REVISION_PAGE_LIMIT: usize = 100",
+  "owner revisions must be strictly increasing",
+  "gaps are valid",
+  "owner_revision_port_requires_host_composition",
+  "owner_revision_page_rejects_reordered_or_replayed_rows",
+], paths.searchOwner);
+requireAll(searchLib, [
+  "ForumProjectionOwnerRevisionSourcePort",
+  "SharedForumProjectionOwnerRevisionSourcePort",
+  "resolve_forum_projection_owner_revisions",
+], paths.searchLib);
+rejectAll(searchOwner, [
+  "forum_domain_event::",
+  "forum_domain_events",
+  "rustok_forum",
+  "UPDATE search_projection_watermarks",
+  "INSERT INTO search_projection_watermarks",
+], paths.searchOwner);
+
+requireAll(hostAdapter, [
+  "ServerForumProjectionOwnerRevisionSourcePort",
+  "ForumEventService::new",
+  "list_projection_owner_revisions",
+  "ForumOwnerRevisionImpact::FullRebuild",
+  "ForumProjectionOwnerRevisionImpact::NoProjectionChange",
+], paths.hostAdapter);
+rejectAll(hostAdapter, [
+  "forum_domain_event::",
+  "forum_domain_events",
+  "search_projection_watermarks",
+], paths.hostAdapter);
+requireAll(hostComposition, [
+  'mod forum_search_owner_revision {',
+  "ServerForumProjectionOwnerRevisionSourcePort::shared",
+  "extensions.insert(owner_revision);",
+  "SharedForumProjectionOwnerRevisionSourcePort",
+], paths.hostComposition);
+
+requireAll(searchInbox, [
+  "ingest_sequence",
+  "ORDER BY ingest_sequence ASC",
+], `${paths.searchInbox} G1 boundary`);
+rejectAll(searchInbox, [
+  "owner_revision",
+  "forum_domain_events",
+], `${paths.searchInbox} G2A non-consumer boundary`);
+rejectAll(rootEvents, [
+  "ForumProjectionOwnerRevision",
+  "forum_projection_owner_revision",
+], `${paths.rootEvents} root event boundary`);
+rejectAll([forumMigrations, searchMigrations].join("\n"), [
+  "owner_revision_source",
+  "projection_owner_revision",
+], "migration boundary");
+
+requireAll(note, [
+  "# FORUM-23B2G2A Search owner-revision source",
+  "forum_domain_events.sequence_no",
+  "global while reads are tenant-scoped",
+  "does not yet connect it to the background sweeper",
+  "did not run these commands",
+], paths.note);
+
+if (contract) {
+  if (contract.task !== "FORUM-23B2G2A") {
+    failures.push(`${paths.contract}: unexpected task`);
+  }
+  if (contract.status !== "source_complete_consumer_reconciliation_pending") {
+    failures.push(`${paths.contract}: unexpected status`);
+  }
+  if (contract.owner_clock?.field !== "sequence_no") {
+    failures.push(`${paths.contract}: owner clock must reuse sequence_no`);
+  }
+  if (contract.owner_clock?.new_counter_added !== false) {
+    failures.push(`${paths.contract}: a second owner counter is forbidden`);
+  }
+  if (contract.owner_clock?.migration_added !== false) {
+    failures.push(`${paths.contract}: G2A must not add a migration`);
+  }
+  if (contract.forum_owner?.payload_exposed !== false) {
+    failures.push(`${paths.contract}: owner journal payload must remain private`);
+  }
+  if (contract.search_contract?.independent_from_search_ingest_sequence !== true) {
+    failures.push(`${paths.contract}: owner and ingest sequences must remain independent`);
+  }
+  if (contract.host_composition?.direct_search_read_of_forum_domain_events !== false) {
+    failures.push(`${paths.contract}: Search must not read the Forum journal directly`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("FORUM-23B2G2A owner revision source verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("FORUM-23B2G2A owner revision source contract is consistent.");


### PR DESCRIPTION
## Summary

- deliver `FORUM-23B2G2A` as a bounded neutral owner-revision source for Forum Search projection reconciliation
- reuse immutable `forum_domain_events.sequence_no` instead of adding a second owner clock
- expose only revision identity, bounded event type and projection impact; journal payload, actor and RBAC-facing DTO remain Forum-private
- classify vote, subscription and mention records as `NoProjectionChange`; all other and future Forum journal records fail safe to `FullRebuild`
- add a Search-owned port with strict tenant, cursor, page-size, identity and monotonic-page validation
- compose the Forum adapter through host runtime extensions without direct Search access to `forum_domain_events`
- add a machine contract, owner note and fail-closed source verifier

## Boundary with G1 and G2B

Search inbox `ingest_sequence` remains the durable delivery-order cursor. Forum `sequence_no` is an independent source-of-truth owner clock; the values are never compared numerically.

This PR registers the source port but intentionally does not connect it to the sweeper, create an owner watermark, repair a lost delivery, rebuild a tenant, or advance reconciliation state. Those commit-ordering behaviors remain `FORUM-23B2G2B`.

## Compatibility

- no migration, dependency, Cargo.lock or root DomainEvent change
- no Search query, storefront transport or projection payload change
- no direct Search query of Forum owner tables
- existing G1 ingest-sequence claim/watermark ordering remains unchanged

## Plan synchronization

The focused contract and owner note record G2A precisely. Canonical Forum/Search ledger synchronization will be added only after final diff review against the latest main, to avoid replacing unrelated concurrent plan edits.

## Verification

Tests, verifiers, formatting, Cargo checks, Clippy and PostgreSQL evidence were intentionally not run by request.