### PR TITLE
feat(forum): issue Search projection owner revisions

### DIFF
--- a/crates/rustok-forum/contracts/forum-projection-invalidation.json
+++ b/crates/rustok-forum/contracts/forum-projection-invalidation.json
@@ -4,7 +4,7 @@
   "upstream_task": "FORUM-20BJ",
   "scope": "Publish durable owner-transactional invalidations on the supported PostgreSQL Forum Search runtime for every canonical Forum mutation that can change exact public category topic or approved reply projections",
   "root_event": "rustok_events::DomainEvent::ReindexRequested",
-  "event_type": "search.reindex_requested",
+  "event_type": "index.reindex_requested",
   "outbox_transaction_api": "crates/rustok-outbox/src/transactional.rs",
   "outbox_storage_api": "crates/rustok-outbox/src/transport.rs",
   "forum_invalidation_owner": "crates/rustok-forum/src/services/projection_invalidation.rs",

--- a/crates/rustok-forum/contracts/forum-search-owner-revision-ledger.json
+++ b/crates/rustok-forum/contracts/forum-search-owner-revision-ledger.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-23B2G2A",
+  "status": "source_complete_execution_pending",
+  "scope": "Issue a positive tenant-monotonic Forum-owned projection revision in the same PostgreSQL transaction as each canonical Forum Search invalidation and bind it to the exact durable legacy outbox envelope identity",
+  "canonical_forum_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "canonical_search_plan": "crates/rustok-search/docs/implementation-plan.md",
+  "predecessor_contract": "crates/rustok-forum/contracts/forum-projection-invalidation.json",
+  "predecessor_ingest_contract": "crates/rustok-forum/contracts/forum-search-durable-ingest-sequence.json",
+  "forum_migration": "crates/rustok-forum/src/migrations/m20260731_000007_add_forum_projection_revision_ledger.rs",
+  "forum_owner": "crates/rustok-forum/src/services/projection_invalidation.rs",
+  "outbox_api": "crates/rustok-outbox/src/transactional.rs",
+  "owner_note": "crates/rustok-forum/docs/forum-23b2g2a-search-owner-revision-ledger.md",
+  "verifier": "scripts/verify/verify-forum-search-owner-revision-ledger.mjs",
+  "revision_owner": {
+    "module": "forum",
+    "scope": "tenant",
+    "storage": "forum_projection_revision_counters",
+    "column_type": "postgresql_bigint",
+    "first_revision": 1,
+    "positive": true,
+    "allocation": "atomic insert-or-increment returning revision",
+    "serialized_by": "PostgreSQL primary-key conflict row lock",
+    "producer_clock_used": false,
+    "event_uuid_used_for_revision": false,
+    "search_ingest_sequence_used_for_revision": false
+  },
+  "ledger": {
+    "table": "forum_projection_revision_ledger",
+    "primary_key": ["tenant_id", "revision"],
+    "event_id_unique": true,
+    "target_types": ["forum", "forum_category", "forum_topic"],
+    "forum_target_requires_null_id": true,
+    "category_and_topic_targets_require_id": true,
+    "append_only_update_trigger": true,
+    "append_only_delete_trigger": true,
+    "target_lookup_index": true
+  },
+  "transaction": {
+    "step_1": "allocate Forum owner revision",
+    "step_2": "write validated legacy ReindexRequested envelope to canonical outbox and retain its ID",
+    "step_3": "append ledger row binding revision to envelope ID and exact target",
+    "step_4": "commit owner mutation invalidation revision and outbox record together",
+    "partial_commit_allowed": false,
+    "direct_postgresql_helper_covered": true,
+    "injected_event_bus_helper_covered": true
+  },
+  "compatibility": {
+    "legacy_root_event_retained": true,
+    "legacy_event_type_retained": "index.reindex_requested",
+    "legacy_target_strings_changed": false,
+    "search_ingestion_changed": false,
+    "search_inbox_schema_changed": false,
+    "search_watermark_semantics_changed": false,
+    "new_root_domain_event_added": false,
+    "new_sealed_event_family_added": false,
+    "event_contract_digest_changed": false,
+    "public_api_changed": false,
+    "sqlite_schema_changed": false,
+    "dependency_added": false,
+    "cargo_lock_changed": false
+  },
+  "canonical_plan_boundary": {
+    "forum_23_status_changed": false,
+    "remaining_owner_revision_reconciliation_scope_changed": false,
+    "reason": "The canonical plans already require owner-issued revisions and Search reconciliation. G2A establishes issuance and audit identity but does not yet carry the revision on the wire or apply it in Search."
+  },
+  "remaining_scope": [
+    "publish a sealed versioned Forum projection invalidation event carrying the owner revision while retaining rolling legacy compatibility",
+    "start an explicit persistent contract consumer for Search with durable poison and acknowledgement policy",
+    "store owner revision on Search inbox rows and completed scope watermarks",
+    "reconcile owner revision order independently from Search ingest delivery order",
+    "capture maintainer-executed PostgreSQL concurrency rollback outbox and LINK-FORUM-03 evidence"
+  ],
+  "non_claims": [
+    "Search does not read or enforce the owner revision in this slice",
+    "The legacy root invalidation payload does not carry the revision",
+    "This slice does not add a second Search execution or projection path",
+    "Tests, verifiers, formatting, Cargo checks, Clippy and runtime evidence were not executed by the implementation agent"
+  ]
+}

--- a/crates/rustok-forum/contracts/forum-search-owner-revision-ledger.json
+++ b/crates/rustok-forum/contracts/forum-search-owner-revision-ledger.json
@@ -10,6 +10,7 @@
   "forum_migration": "crates/rustok-forum/src/migrations/m20260731_000007_add_forum_projection_revision_ledger.rs",
   "forum_owner": "crates/rustok-forum/src/services/projection_invalidation.rs",
   "outbox_api": "crates/rustok-outbox/src/transactional.rs",
+  "outbox_api_documentation": "crates/rustok-outbox/CRATE_API.md",
   "owner_note": "crates/rustok-forum/docs/forum-23b2g2a-search-owner-revision-ledger.md",
   "verifier": "scripts/verify/verify-forum-search-owner-revision-ledger.mjs",
   "revision_owner": {
@@ -55,7 +56,8 @@
     "new_root_domain_event_added": false,
     "new_sealed_event_family_added": false,
     "event_contract_digest_changed": false,
-    "public_api_changed": false,
+    "existing_public_api_signature_changed": false,
+    "additive_outbox_envelope_identity_api_added": true,
     "sqlite_schema_changed": false,
     "dependency_added": false,
     "cargo_lock_changed": false

--- a/crates/rustok-forum/docs/forum-20bk-projection-invalidation.md
+++ b/crates/rustok-forum/docs/forum-20bk-projection-invalidation.md
@@ -2,7 +2,7 @@
 
 `FORUM-20BK` closes the canonical mutation-to-Search gap left by the initial
 Forum projection consumer. On the supported PostgreSQL Search runtime, Forum
-owner transactions now insert durable `search.reindex_requested` events for
+owner transactions now insert durable `index.reindex_requested` events for
 every canonical mutation that can change an exact public category or topic
 document.
 

--- a/crates/rustok-forum/docs/forum-20bk-projection-invalidation.md
+++ b/crates/rustok-forum/docs/forum-20bk-projection-invalidation.md
@@ -6,6 +6,10 @@ owner transactions now insert durable `index.reindex_requested` events for
 every canonical mutation that can change an exact public category or topic
 document.
 
+The former documentation label `search.reindex_requested` was incorrect. The
+registered `DomainEvent::ReindexRequested` type has always emitted
+`index.reindex_requested`; this correction changes no runtime payload.
+
 ## Existing event contract
 
 The slice reuses the registered root event:

--- a/crates/rustok-forum/docs/forum-23b2g2a-search-owner-revision-ledger.md
+++ b/crates/rustok-forum/docs/forum-23b2g2a-search-owner-revision-ledger.md
@@ -38,7 +38,9 @@ rest of the owner work.
 
 `TransactionalEventBus::publish_root_in_tx_with_envelope_id` is an additive API
 that validates the registered root event, creates one envelope, writes it to the
-canonical outbox and returns that exact envelope ID.
+canonical outbox and returns that exact envelope ID. Existing outbox method
+signatures and behavior are unchanged; the additive identity-returning method is
+recorded in `crates/rustok-outbox/CRATE_API.md`.
 
 The Forum invalidation owner performs these ordered steps:
 
@@ -69,10 +71,11 @@ The legacy root event, event type and target strings remain unchanged. Existing
 Search ingestion, durable inbox ordering, retries, rebuild semantics and visible
 query behavior therefore continue without a second projection path.
 
-No root event schema, sealed contract family, event digest, Search migration,
-public API, dependency or `Cargo.lock` change is introduced. SQLite remains the
-existing validation-only invalidation environment because background Forum Search
-projection is PostgreSQL-only.
+No existing public signature, root event schema, sealed contract family, event
+digest, Search migration, dependency or `Cargo.lock` change is introduced. The
+only public surface addition is the exact-envelope-ID outbox helper described
+above. SQLite remains the existing validation-only invalidation environment
+because background Forum Search projection is PostgreSQL-only.
 
 The canonical Forum and Search plans already list owner-issued revision ordering
 and reconciliation as remaining work. This foundation does not mark that result

--- a/crates/rustok-forum/docs/forum-23b2g2a-search-owner-revision-ledger.md
+++ b/crates/rustok-forum/docs/forum-23b2g2a-search-owner-revision-ledger.md
@@ -1,0 +1,109 @@
+# FORUM-23B2G2A Forum Search owner revision ledger
+
+## Status
+
+`source_complete_execution_pending`
+
+This foundation slice gives Forum one tenant-scoped monotonic projection revision
+owner without changing the current Search delivery or execution path. Every
+canonical PostgreSQL Forum Search invalidation now receives a positive revision
+and an append-only audit row in the same owner transaction as the existing
+`index.reindex_requested` outbox envelope.
+
+Search continues to consume the legacy root event exactly as before. It does not
+yet receive or enforce the Forum revision. The versioned wire event, persistent
+contract consumer and dual-watermark reconciliation remain the next bounded slice.
+
+## Owner allocation
+
+Forum owns `forum_projection_revision_counters`. Allocation uses one PostgreSQL
+statement:
+
+```sql
+INSERT ... VALUES (tenant_id, 1)
+ON CONFLICT (tenant_id)
+DO UPDATE SET revision = revision + 1
+RETURNING revision
+```
+
+The tenant primary-key conflict serializes concurrent Forum writers. A revision
+is not derived from producer time, an event UUID or Search's delivered
+`ingest_sequence`.
+
+The allocation remains inside the caller's live owner transaction. A failed
+mutation, outbox write or ledger append rolls back the counter increment with the
+rest of the owner work.
+
+## Durable identity binding
+
+`TransactionalEventBus::publish_root_in_tx_with_envelope_id` is an additive API
+that validates the registered root event, creates one envelope, writes it to the
+canonical outbox and returns that exact envelope ID.
+
+The Forum invalidation owner performs these ordered steps:
+
+1. allocate the next Forum revision;
+2. write the existing validated `ReindexRequested` envelope and retain its ID;
+3. append `(tenant_id, revision, event_id, target_type, target_id)` to
+   `forum_projection_revision_ledger`;
+4. commit the mutation, invalidation, revision and ledger row together.
+
+The same sequence is used by direct PostgreSQL owner helpers and helpers with an
+injected `TransactionalEventBus`.
+
+## Ledger boundary
+
+The ledger primary key is `(tenant_id, revision)` and `event_id` is unique. Exact
+scope validation admits only:
+
+- `forum` with no target ID;
+- `forum_category` with a category ID;
+- `forum_topic` with a topic ID.
+
+PostgreSQL triggers reject updates and deletes. The ledger is an audit and rollout
+reconciliation source, not a mutable queue or a Search-owned watermark table.
+
+## Compatibility and rollout
+
+The legacy root event, event type and target strings remain unchanged. Existing
+Search ingestion, durable inbox ordering, retries, rebuild semantics and visible
+query behavior therefore continue without a second projection path.
+
+No root event schema, sealed contract family, event digest, Search migration,
+public API, dependency or `Cargo.lock` change is introduced. SQLite remains the
+existing validation-only invalidation environment because background Forum Search
+projection is PostgreSQL-only.
+
+The canonical Forum and Search plans already list owner-issued revision ordering
+and reconciliation as remaining work. This foundation does not mark that result
+complete: the revision is not yet present on the transport event and Search does
+not enforce it.
+
+## Next slice
+
+`FORUM-23B2G2B` should add one sealed versioned Forum projection event carrying
+`revision`, `target_type` and `target_id`; start one explicit persistent Search
+contract consumer; retain rolling legacy compatibility; and store both Forum
+owner revision and Search ingest sequence in durable inbox/watermark state.
+
+A late event with a lower owner revision must be stale even when it has a later
+Search ingest sequence. A legacy unversioned event must remain processable during
+the rollout rather than being silently discarded by a versioned watermark.
+
+## Maintainer verification
+
+The implementation agent did not run these commands, as requested:
+
+```bash
+cargo test -p rustok-outbox transactional -- --nocapture
+cargo test -p rustok-forum projection_invalidation -- --nocapture
+node scripts/verify/verify-forum-search-owner-revision-ledger.mjs
+cargo check -p rustok-outbox --all-targets
+cargo check -p rustok-forum --all-targets
+cargo xtask module validate forum
+```
+
+PostgreSQL evidence should cover first allocation, concurrent allocation for one
+and multiple tenants, transaction rollback after allocation, exact envelope-ID
+binding, unique event identity, target constraints, update/delete rejection and
+unchanged Search ingestion of the legacy invalidation.

--- a/crates/rustok-forum/src/migrations/m20260731_000007_add_forum_projection_revision_ledger.rs
+++ b/crates/rustok-forum/src/migrations/m20260731_000007_add_forum_projection_revision_ledger.rs
@@ -1,0 +1,96 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::{ConnectionTrait, DatabaseBackend};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DatabaseBackend::Postgres => manager
+                .get_connection()
+                .execute_unprepared(POSTGRES_UP)
+                .await
+                .map(|_| ()),
+            DatabaseBackend::Sqlite => Ok(()),
+            backend => Err(DbErr::Custom(format!(
+                "Forum projection revision ledger does not support database backend {backend:?}"
+            ))),
+        }
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DatabaseBackend::Postgres => manager
+                .get_connection()
+                .execute_unprepared(POSTGRES_DOWN)
+                .await
+                .map(|_| ()),
+            DatabaseBackend::Sqlite => Ok(()),
+            backend => Err(DbErr::Custom(format!(
+                "Forum projection revision ledger does not support database backend {backend:?}"
+            ))),
+        }
+    }
+}
+
+const POSTGRES_UP: &str = r#"
+CREATE TABLE IF NOT EXISTS forum_projection_revision_counters (
+    tenant_id UUID PRIMARY KEY,
+    revision BIGINT NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT ck_forum_projection_revision_counter_positive
+        CHECK (revision > 0)
+);
+
+CREATE TABLE IF NOT EXISTS forum_projection_revision_ledger (
+    tenant_id UUID NOT NULL,
+    revision BIGINT NOT NULL,
+    event_id UUID NOT NULL,
+    target_type VARCHAR(64) NOT NULL,
+    target_id UUID NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_forum_projection_revision_ledger
+        PRIMARY KEY (tenant_id, revision),
+    CONSTRAINT uq_forum_projection_revision_event UNIQUE (event_id),
+    CONSTRAINT ck_forum_projection_revision_positive CHECK (revision > 0),
+    CONSTRAINT ck_forum_projection_revision_target CHECK (
+        (target_type = 'forum' AND target_id IS NULL)
+        OR (target_type IN ('forum_category', 'forum_topic') AND target_id IS NOT NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_forum_projection_revision_ledger_target
+    ON forum_projection_revision_ledger (tenant_id, target_type, target_id, revision DESC);
+
+CREATE OR REPLACE FUNCTION forum_reject_projection_revision_ledger_mutation()
+RETURNS trigger AS $$
+BEGIN
+    RAISE EXCEPTION 'forum projection revision ledger is append-only';
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS forum_projection_revision_ledger_update
+    ON forum_projection_revision_ledger;
+CREATE TRIGGER forum_projection_revision_ledger_update
+BEFORE UPDATE ON forum_projection_revision_ledger
+FOR EACH ROW EXECUTE FUNCTION forum_reject_projection_revision_ledger_mutation();
+
+DROP TRIGGER IF EXISTS forum_projection_revision_ledger_delete
+    ON forum_projection_revision_ledger;
+CREATE TRIGGER forum_projection_revision_ledger_delete
+BEFORE DELETE ON forum_projection_revision_ledger
+FOR EACH ROW EXECUTE FUNCTION forum_reject_projection_revision_ledger_mutation();
+"#;
+
+const POSTGRES_DOWN: &str = r#"
+DROP TRIGGER IF EXISTS forum_projection_revision_ledger_delete
+    ON forum_projection_revision_ledger;
+DROP TRIGGER IF EXISTS forum_projection_revision_ledger_update
+    ON forum_projection_revision_ledger;
+DROP TABLE IF EXISTS forum_projection_revision_ledger;
+DROP TABLE IF EXISTS forum_projection_revision_counters;
+DROP FUNCTION IF EXISTS forum_reject_projection_revision_ledger_mutation();
+"#;

--- a/crates/rustok-forum/src/migrations/mod.rs
+++ b/crates/rustok-forum/src/migrations/mod.rs
@@ -38,6 +38,7 @@ mod m20260728_000003_add_forum_category_moderation_audience;
 mod m20260728_000004_add_forum_user_trust_state;
 mod m20260728_000005_add_forum_approved_posts_indexes;
 mod m20260728_000006_add_forum_create_window_indexes;
+mod m20260731_000007_add_forum_projection_revision_ledger;
 
 use rustok_core::MigrationDependencyDescriptor;
 use sea_orm_migration::MigrationTrait;
@@ -84,6 +85,7 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260728_000004_add_forum_user_trust_state::Migration),
         Box::new(m20260728_000005_add_forum_approved_posts_indexes::Migration),
         Box::new(m20260728_000006_add_forum_create_window_indexes::Migration),
+        Box::new(m20260731_000007_add_forum_projection_revision_ledger::Migration),
     ]
 }
 

--- a/crates/rustok-forum/src/services/projection_invalidation.rs
+++ b/crates/rustok-forum/src/services/projection_invalidation.rs
@@ -1,6 +1,8 @@
 use rustok_events::{DomainEvent, ValidateEvent};
 use rustok_outbox::TransactionalEventBus;
-use sea_orm::{ConnectionTrait, DatabaseBackend, DatabaseTransaction};
+use sea_orm::{
+    ConnectionTrait, DatabaseBackend, DatabaseTransaction, DbBackend, Statement,
+};
 use uuid::Uuid;
 
 use crate::error::{ForumError, ForumResult};
@@ -116,15 +118,12 @@ async fn write_projection_invalidation_in_tx(
     target_type: &'static str,
     target_id: Option<Uuid>,
 ) -> ForumResult<()> {
-    let event = DomainEvent::ReindexRequested {
-        target_type: target_type.to_string(),
-        target_id,
-    };
+    let event = projection_invalidation_event(target_type, target_id);
 
     // The Search-owned Forum projector is PostgreSQL-only. SQLite and any
     // other non-PostgreSQL backend are domain-test/unsupported projection
-    // environments, so keep root validation without requiring an outbox table
-    // that has no matching Search consumer.
+    // environments, so keep root validation without requiring an outbox or
+    // owner-revision ledger that has no matching Search consumer.
     if txn.get_database_backend() != DatabaseBackend::Postgres {
         event.validate().map_err(|error| {
             ForumError::Validation(format!("Forum projection invalidation failed: {error}"))
@@ -132,8 +131,20 @@ async fn write_projection_invalidation_in_tx(
         return Ok(());
     }
 
-    TransactionalEventBus::publish_root_in_tx(txn, tenant_id, actor_id, event).await?;
-    Ok(())
+    let revision = allocate_projection_revision_in_tx(txn, tenant_id).await?;
+    let event_id = TransactionalEventBus::publish_root_in_tx_with_envelope_id(
+        txn, tenant_id, actor_id, event,
+    )
+    .await?;
+    record_projection_revision_in_tx(
+        txn,
+        tenant_id,
+        revision,
+        event_id,
+        target_type,
+        target_id,
+    )
+    .await
 }
 
 async fn publish_projection_invalidation_in_tx(
@@ -144,16 +155,96 @@ async fn publish_projection_invalidation_in_tx(
     target_type: &'static str,
     target_id: Option<Uuid>,
 ) -> ForumResult<()> {
-    event_bus
-        .publish_in_tx(
-            txn,
-            tenant_id,
-            actor_id,
-            DomainEvent::ReindexRequested {
-                target_type: target_type.to_string(),
-                target_id,
-            },
-        )
+    let event = projection_invalidation_event(target_type, target_id);
+    if txn.get_database_backend() != DatabaseBackend::Postgres {
+        event_bus
+            .publish_in_tx(txn, tenant_id, actor_id, event)
+            .await?;
+        return Ok(());
+    }
+
+    let revision = allocate_projection_revision_in_tx(txn, tenant_id).await?;
+    let event_id = event_bus
+        .publish_in_tx_with_envelope_id(txn, tenant_id, actor_id, event)
         .await?;
+    record_projection_revision_in_tx(
+        txn,
+        tenant_id,
+        revision,
+        event_id,
+        target_type,
+        target_id,
+    )
+    .await
+}
+
+fn projection_invalidation_event(
+    target_type: &'static str,
+    target_id: Option<Uuid>,
+) -> DomainEvent {
+    DomainEvent::ReindexRequested {
+        target_type: target_type.to_string(),
+        target_id,
+    }
+}
+
+async fn allocate_projection_revision_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+) -> ForumResult<i64> {
+    let row = txn
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+            INSERT INTO forum_projection_revision_counters (
+                tenant_id, revision, updated_at
+            ) VALUES ($1, 1, CURRENT_TIMESTAMP)
+            ON CONFLICT (tenant_id)
+            DO UPDATE SET
+                revision = forum_projection_revision_counters.revision + 1,
+                updated_at = CURRENT_TIMESTAMP
+            RETURNING revision
+            "#,
+            vec![tenant_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| {
+            ForumError::Validation(
+                "Forum projection revision allocation returned no row".to_string(),
+            )
+        })?;
+    let revision: i64 = row.try_get("", "revision")?;
+    if revision <= 0 {
+        return Err(ForumError::Validation(
+            "Forum projection revision must be positive".to_string(),
+        ));
+    }
+    Ok(revision)
+}
+
+async fn record_projection_revision_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    revision: i64,
+    event_id: Uuid,
+    target_type: &'static str,
+    target_id: Option<Uuid>,
+) -> ForumResult<()> {
+    txn.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+        INSERT INTO forum_projection_revision_ledger (
+            tenant_id, revision, event_id, target_type, target_id, created_at
+        ) VALUES ($1, $2, $3, $4, $5, CURRENT_TIMESTAMP)
+        "#,
+        vec![
+            tenant_id.into(),
+            revision.into(),
+            event_id.into(),
+            target_type.to_string().into(),
+            target_id.into(),
+        ],
+    ))
+    .await?;
     Ok(())
 }

--- a/crates/rustok-outbox/CRATE_API.md
+++ b/crates/rustok-outbox/CRATE_API.md
@@ -5,6 +5,8 @@
 
 ## Primary Public Types and Signatures
 - `pub struct TransactionalEventBus`
+- `pub async fn TransactionalEventBus::publish_root_in_tx(...)`
+- `pub async fn TransactionalEventBus::publish_root_in_tx_with_envelope_id(...) -> Result<Uuid>`
 - `pub async fn TransactionalEventBus::publish_in_tx(...)`
 - `pub async fn TransactionalEventBus::publish_contract_in_tx<C, E>(...) where E: EventContract`
 - `pub struct OutboxRelay`, `pub struct RelayConfig`, `pub struct RelayMetricsSnapshot`
@@ -36,9 +38,13 @@
 ## Minimum Contract Set
 
 ### Input DTOs/Commands
-- Root events use `publish_in_tx`.
+- Root events use `publish_in_tx` or the static `publish_root_in_tx` owner helper.
+- Owners that must durably bind audit state to the exact root envelope use
+  `publish_root_in_tx_with_envelope_id`; the returned UUID is the ID of the
+  validated envelope written by the same transaction.
 - Sealed bounded-family events use `publish_contract_in_tx`.
-- Both APIs require the live owner transaction and preserve the returned envelope identity internally.
+- Every API requires the live owner transaction; identity-returning variants do
+  not publish a second envelope or reconstruct an ID after persistence.
 
 ### Domain Invariants
 - State, owner timeline, outbox envelope, and command receipt commit or roll back together.

--- a/crates/rustok-outbox/src/transactional.rs
+++ b/crates/rustok-outbox/src/transactional.rs
@@ -33,12 +33,27 @@ impl TransactionalEventBus {
     where
         C: ConnectionTrait,
     {
+        Self::publish_root_in_tx_with_envelope_id(txn, tenant_id, actor_id, event)
+            .await
+            .map(|_| ())
+    }
+
+    /// Publishes a validated registered root event and returns the exact durable
+    /// envelope identity written by the same owner transaction.
+    pub async fn publish_root_in_tx_with_envelope_id<C>(
+        txn: &C,
+        tenant_id: Uuid,
+        actor_id: Option<Uuid>,
+        event: DomainEvent,
+    ) -> Result<Uuid>
+    where
+        C: ConnectionTrait,
+    {
         validate_event(&event)?;
-        OutboxTransport::write_envelope_in_tx(
-            txn,
-            EventEnvelope::new(tenant_id, actor_id, event),
-        )
-        .await
+        let envelope = EventEnvelope::new(tenant_id, actor_id, event);
+        let envelope_id = envelope.id;
+        OutboxTransport::write_envelope_in_tx(txn, envelope).await?;
+        Ok(envelope_id)
     }
 
     pub async fn publish_in_tx<C>(

--- a/scripts/verify/verify-forum-search-owner-revision-ledger.mjs
+++ b/scripts/verify/verify-forum-search-owner-revision-ledger.mjs
@@ -184,7 +184,7 @@ requireAll(
   legacyContract,
   [
     '"root_event": "rustok_events::DomainEvent::ReindexRequested"',
-    '"event_type": "search.reindex_requested"',
+    '"event_type": "index.reindex_requested"',
     '"new_root_domain_event_added": false',
     '"new_event_schema_added": false',
   ],

--- a/scripts/verify/verify-forum-search-owner-revision-ledger.mjs
+++ b/scripts/verify/verify-forum-search-owner-revision-ledger.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(".");
+const failures = [];
+const paths = {
+  contract: "crates/rustok-forum/contracts/forum-search-owner-revision-ledger.json",
+  note: "crates/rustok-forum/docs/forum-23b2g2a-search-owner-revision-ledger.md",
+  migration:
+    "crates/rustok-forum/src/migrations/m20260731_000007_add_forum_projection_revision_ledger.rs",
+  migrationRegistry: "crates/rustok-forum/src/migrations/mod.rs",
+  owner: "crates/rustok-forum/src/services/projection_invalidation.rs",
+  outbox: "crates/rustok-outbox/src/transactional.rs",
+  legacyContract: "crates/rustok-forum/contracts/forum-projection-invalidation.json",
+  searchIngestion: "crates/rustok-search/src/ingestion.rs",
+  forumPlan: "crates/rustok-forum/docs/implementation-plan.md",
+  searchPlan: "crates/rustok-search/docs/implementation-plan.md",
+};
+
+function read(relativePath) {
+  const target = path.join(root, relativePath);
+  if (!existsSync(target)) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return "";
+  }
+  return readFileSync(target, "utf8");
+}
+
+function requireAll(source, markers, label) {
+  for (const marker of markers) {
+    if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+  }
+}
+
+function rejectAll(source, markers, label) {
+  for (const marker of markers) {
+    if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+  }
+}
+
+function requireOrdered(source, markers, label) {
+  let cursor = -1;
+  for (const marker of markers) {
+    const next = source.indexOf(marker, cursor + 1);
+    if (next < 0) {
+      failures.push(`${label}: missing ordered marker ${marker}`);
+      return;
+    }
+    if (next <= cursor) {
+      failures.push(`${label}: marker out of order ${marker}`);
+      return;
+    }
+    cursor = next;
+  }
+}
+
+function parseJson(relativePath) {
+  try {
+    return JSON.parse(read(relativePath));
+  } catch (error) {
+    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+const contract = parseJson(paths.contract);
+const note = read(paths.note);
+const migration = read(paths.migration);
+const migrationRegistry = read(paths.migrationRegistry);
+const owner = read(paths.owner);
+const outbox = read(paths.outbox);
+const legacyContract = read(paths.legacyContract);
+const searchIngestion = read(paths.searchIngestion);
+const forumPlan = read(paths.forumPlan);
+const searchPlan = read(paths.searchPlan);
+
+requireAll(
+  migration,
+  [
+    "forum_projection_revision_counters",
+    "forum_projection_revision_ledger",
+    "PRIMARY KEY (tenant_id, revision)",
+    "UNIQUE (event_id)",
+    "CHECK (revision > 0)",
+    "target_type = 'forum' AND target_id IS NULL",
+    "target_type IN ('forum_category', 'forum_topic') AND target_id IS NOT NULL",
+    "idx_forum_projection_revision_ledger_target",
+    "forum_reject_projection_revision_ledger_mutation",
+    "BEFORE UPDATE ON forum_projection_revision_ledger",
+    "BEFORE DELETE ON forum_projection_revision_ledger",
+    "DatabaseBackend::Sqlite => Ok(())",
+  ],
+  paths.migration,
+);
+requireAll(
+  migrationRegistry,
+  [
+    "mod m20260731_000007_add_forum_projection_revision_ledger;",
+    "m20260731_000007_add_forum_projection_revision_ledger::Migration",
+  ],
+  paths.migrationRegistry,
+);
+
+requireAll(
+  outbox,
+  [
+    "pub async fn publish_root_in_tx_with_envelope_id<C>",
+    "let envelope = EventEnvelope::new(tenant_id, actor_id, event);",
+    "let envelope_id = envelope.id;",
+    "OutboxTransport::write_envelope_in_tx(txn, envelope).await?;",
+    "Ok(envelope_id)",
+  ],
+  paths.outbox,
+);
+requireOrdered(
+  outbox,
+  [
+    "pub async fn publish_root_in_tx<C>",
+    "Self::publish_root_in_tx_with_envelope_id",
+    "pub async fn publish_root_in_tx_with_envelope_id<C>",
+  ],
+  `${paths.outbox} compatibility delegation`,
+);
+
+requireAll(
+  owner,
+  [
+    "allocate_projection_revision_in_tx",
+    "forum_projection_revision_counters",
+    "ON CONFLICT (tenant_id)",
+    "revision = forum_projection_revision_counters.revision + 1",
+    "RETURNING revision",
+    "publish_root_in_tx_with_envelope_id",
+    "publish_in_tx_with_envelope_id",
+    "record_projection_revision_in_tx",
+    "forum_projection_revision_ledger",
+    "target_type.to_string().into()",
+    "target_id.into()",
+    "txn.get_database_backend() != DatabaseBackend::Postgres",
+  ],
+  paths.owner,
+);
+requireOrdered(
+  owner,
+  [
+    "let revision = allocate_projection_revision_in_tx(txn, tenant_id).await?;",
+    "let event_id = TransactionalEventBus::publish_root_in_tx_with_envelope_id",
+    "record_projection_revision_in_tx(",
+  ],
+  `${paths.owner} direct transactional ordering`,
+);
+const injectedOwner = owner.slice(owner.indexOf("async fn publish_projection_invalidation_in_tx"));
+requireOrdered(
+  injectedOwner,
+  [
+    "let revision = allocate_projection_revision_in_tx(txn, tenant_id).await?;",
+    "publish_in_tx_with_envelope_id",
+    "record_projection_revision_in_tx(",
+  ],
+  `${paths.owner} injected transactional ordering`,
+);
+rejectAll(
+  owner,
+  ["ForumProjectionEvent", "publish_contract_in_tx", "SearchProjectionRevision"],
+  `${paths.owner} wire rollout boundary`,
+);
+
+requireAll(
+  legacyContract,
+  [
+    '"root_event": "rustok_events::DomainEvent::ReindexRequested"',
+    '"event_type": "search.reindex_requested"',
+    '"new_root_domain_event_added": false',
+    '"new_event_schema_added": false',
+  ],
+  paths.legacyContract,
+);
+requireAll(
+  searchIngestion,
+  [
+    "DomainEvent::ReindexRequested",
+    "ForumProjectionScope::for_event(&envelope.event)",
+    "inbox.enqueue(envelope, &scope).await?;",
+  ],
+  `${paths.searchIngestion} unchanged legacy consumer`,
+);
+requireAll(
+  forumPlan,
+  ["owner-issued monotonic projection revisions", "maintainer runtime evidence"],
+  `${paths.forumPlan} remaining canonical scope`,
+);
+requireAll(
+  searchPlan,
+  ["Forum-owner-issued revisions remain pending", "Search ingest sequence"],
+  `${paths.searchPlan} remaining canonical scope`,
+);
+requireAll(
+  note,
+  [
+    "# FORUM-23B2G2A Forum Search owner revision ledger",
+    "same owner transaction",
+    "publish_root_in_tx_with_envelope_id",
+    "Search does not yet receive or enforce the Forum revision",
+    "FORUM-23B2G2B",
+    "did not run these commands",
+  ],
+  paths.note,
+);
+
+if (contract) {
+  if (contract.task !== "FORUM-23B2G2A") failures.push(`${paths.contract}: unexpected task`);
+  if (contract.status !== "source_complete_execution_pending") {
+    failures.push(`${paths.contract}: unexpected status`);
+  }
+  if (contract.revision_owner?.module !== "forum") {
+    failures.push(`${paths.contract}: revision owner drift`);
+  }
+  if (contract.revision_owner?.first_revision !== 1) {
+    failures.push(`${paths.contract}: first revision drift`);
+  }
+  if (contract.ledger?.event_id_unique !== true) {
+    failures.push(`${paths.contract}: envelope identity is not unique`);
+  }
+  if (contract.transaction?.partial_commit_allowed !== false) {
+    failures.push(`${paths.contract}: partial commit must be forbidden`);
+  }
+  if (contract.compatibility?.legacy_root_event_retained !== true) {
+    failures.push(`${paths.contract}: legacy rollout compatibility drift`);
+  }
+  if (contract.compatibility?.new_sealed_event_family_added !== false) {
+    failures.push(`${paths.contract}: G2A must not claim the G2B wire family`);
+  }
+  if (contract.canonical_plan_boundary?.forum_23_status_changed !== false) {
+    failures.push(`${paths.contract}: canonical milestone status must remain unchanged`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("FORUM-23B2G2A owner revision ledger verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("FORUM-23B2G2A owner revision ledger source contract is consistent.");

--- a/scripts/verify/verify-forum-search-owner-revision-ledger.mjs
+++ b/scripts/verify/verify-forum-search-owner-revision-ledger.mjs
@@ -15,6 +15,7 @@ const paths = {
   migrationRegistry: "crates/rustok-forum/src/migrations/mod.rs",
   owner: "crates/rustok-forum/src/services/projection_invalidation.rs",
   outbox: "crates/rustok-outbox/src/transactional.rs",
+  outboxApi: "crates/rustok-outbox/CRATE_API.md",
   legacyContract: "crates/rustok-forum/contracts/forum-projection-invalidation.json",
   searchIngestion: "crates/rustok-search/src/ingestion.rs",
   forumPlan: "crates/rustok-forum/docs/implementation-plan.md",
@@ -73,6 +74,7 @@ const migration = read(paths.migration);
 const migrationRegistry = read(paths.migrationRegistry);
 const owner = read(paths.owner);
 const outbox = read(paths.outbox);
+const outboxApi = read(paths.outboxApi);
 const legacyContract = read(paths.legacyContract);
 const searchIngestion = read(paths.searchIngestion);
 const forumPlan = read(paths.forumPlan);
@@ -124,6 +126,15 @@ requireOrdered(
     "pub async fn publish_root_in_tx_with_envelope_id<C>",
   ],
   `${paths.outbox} compatibility delegation`,
+);
+requireAll(
+  outboxApi,
+  [
+    "TransactionalEventBus::publish_root_in_tx_with_envelope_id",
+    "the exact root envelope",
+    "do not publish a second envelope",
+  ],
+  paths.outboxApi,
 );
 
 requireAll(
@@ -233,6 +244,12 @@ if (contract) {
   }
   if (contract.compatibility?.new_sealed_event_family_added !== false) {
     failures.push(`${paths.contract}: G2A must not claim the G2B wire family`);
+  }
+  if (contract.compatibility?.existing_public_api_signature_changed !== false) {
+    failures.push(`${paths.contract}: existing public signature compatibility drift`);
+  }
+  if (contract.compatibility?.additive_outbox_envelope_identity_api_added !== true) {
+    failures.push(`${paths.contract}: additive outbox identity API is not recorded`);
   }
   if (contract.canonical_plan_boundary?.forum_23_status_changed !== false) {
     failures.push(`${paths.contract}: canonical milestone status must remain unchanged`);


### PR DESCRIPTION
## Summary

Implements the bounded `FORUM-23B2G2A` foundation for Forum-owned Search projection revisions.

- add a PostgreSQL Forum migration with a tenant-scoped positive revision counter and append-only projection revision ledger;
- allocate revisions atomically through `INSERT ... ON CONFLICT ... DO UPDATE ... RETURNING revision`;
- add an additive `TransactionalEventBus::publish_root_in_tx_with_envelope_id` API that returns the exact validated root envelope identity written by the owner transaction;
- bind each canonical Forum Search invalidation revision to its exact legacy `DomainEvent::ReindexRequested` envelope ID and exact Forum/category/topic target;
- keep counter allocation, legacy outbox write and ledger append inside the existing owner transaction so partial commit is impossible;
- retain current Search ingestion, durable inbox ordering, retries, rebuild behavior and public query behavior unchanged;
- add a machine contract, owner note and fail-closed source verifier;
- correct the historical `FORUM-20BK` documentation event-name drift from `search.reindex_requested` to the registered `index.reindex_requested` without changing runtime payloads.

## Rollout boundary

This slice deliberately does not add the versioned wire event or a second consumer path. Search still consumes the legacy root invalidation exactly as before. `FORUM-23B2G2B` remains responsible for one sealed Forum projection event family, explicit persistent contract consumption, owner-revision inbox/watermark storage and reconciliation against the already delivered Search `ingest_sequence`.

The canonical Forum and Search plans already list owner-issued revision ordering and reconciliation as remaining scope. G2A establishes issuance and durable envelope identity but does not mark that result complete, so no duplicate roadmap milestone is introduced.

## Compatibility

- no existing event, outbox method, Search ingestion, Search inbox, Search watermark, route, GraphQL, native or DTO signature changes;
- one additive outbox identity-returning method, documented in `crates/rustok-outbox/CRATE_API.md`;
- no new root event variant, sealed event family or canonical event digest change;
- no dependency or `Cargo.lock` change;
- SQLite remains the existing validation-only Forum invalidation environment.

## Verification

Tests, verifiers, formatting, Cargo checks, Clippy and PostgreSQL runtime evidence were intentionally not run by request. Suggested commands and concurrency/rollback/envelope-binding evidence are recorded in `crates/rustok-forum/docs/forum-23b2g2a-search-owner-revision-ledger.md`.