### PR TITLE
fix(forum): harden projection revision counters

### DIFF
--- a/crates/rustok-forum/contracts/forum-search-owner-revision-counter-hardening.json
+++ b/crates/rustok-forum/contracts/forum-search-owner-revision-counter-hardening.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "task": "FORUM-23B2G2A1",
   "status": "source_complete_execution_pending",
-  "scope": "Harden the merged Forum projection revision counter and ledger against direct non-monotonic row mutation, uncovered committed revisions and table truncation without editing the delivered G2A baseline migration",
+  "scope": "Harden the merged Forum projection revision counter and ledger against inconsistent preexisting state, direct non-monotonic row mutation, uncovered committed revisions and table truncation without editing the delivered G2A baseline migration",
   "predecessor_task": "FORUM-23B2G2A",
   "predecessor_contract": "crates/rustok-forum/contracts/forum-search-owner-revision-ledger.json",
   "baseline_migration": "crates/rustok-forum/src/migrations/m20260731_000007_add_forum_projection_revision_ledger.rs",
@@ -10,6 +10,15 @@
   "migration_registry": "crates/rustok-forum/src/migrations/mod.rs",
   "owner_note": "crates/rustok-forum/docs/forum-23b2g2a1-search-owner-revision-counter-hardening.md",
   "verifier": "scripts/verify/verify-forum-search-owner-revision-counter-hardening.mjs",
+  "upgrade_preflight": {
+    "existing_counter_requires_contiguous_ledger_from_one": true,
+    "existing_ledger_without_counter_rejected": true,
+    "minimum_revision_must_equal": 1,
+    "maximum_revision_must_equal_counter": true,
+    "ledger_row_count_must_equal_counter": true,
+    "inconsistent_upgrade_fails_closed": true,
+    "existing_rows_rewritten": false
+  },
   "counter_invariants": {
     "table": "forum_projection_revision_counters",
     "first_revision_must_equal": 1,
@@ -58,6 +67,6 @@
     "publish and consume a versioned Forum projection invalidation carrying owner revision",
     "store owner revision independently from Search ingest_sequence",
     "reconcile pending retryable missing and stale delivery without advancing early",
-    "capture concurrent writer direct SQL rollback deferred-constraint truncate and LINK-FORUM-03 PostgreSQL evidence"
+    "capture inconsistent-upgrade concurrent-writer direct-SQL rollback deferred-constraint truncate and LINK-FORUM-03 PostgreSQL evidence"
   ]
 }

--- a/crates/rustok-forum/contracts/forum-search-owner-revision-counter-hardening.json
+++ b/crates/rustok-forum/contracts/forum-search-owner-revision-counter-hardening.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "task": "FORUM-23B2G2A1",
   "status": "source_complete_execution_pending",
-  "scope": "Harden the merged Forum projection revision counter and ledger against direct non-monotonic row mutation and table truncation without editing the delivered G2A baseline migration",
+  "scope": "Harden the merged Forum projection revision counter and ledger against direct non-monotonic row mutation, uncovered committed revisions and table truncation without editing the delivered G2A baseline migration",
   "predecessor_task": "FORUM-23B2G2A",
   "predecessor_contract": "crates/rustok-forum/contracts/forum-search-owner-revision-ledger.json",
   "baseline_migration": "crates/rustok-forum/src/migrations/m20260731_000007_add_forum_projection_revision_ledger.rs",
@@ -17,6 +17,8 @@
     "tenant_key_immutable": true,
     "row_delete_forbidden": true,
     "table_truncate_forbidden": true,
+    "committed_revision_requires_matching_ledger_row": true,
+    "ledger_coverage_check": "deferred constraint trigger at transaction commit",
     "positive_check_from_baseline_retained": true,
     "allocator_insert_or_increment_compatible": true
   },
@@ -48,6 +50,7 @@
   "non_claims": [
     "This slice does not add the G2B versioned wire event or Search owner-revision consumer",
     "This slice does not validate the sys_events JSON envelope from a Forum migration",
+    "This slice does not add a cross-module foreign key from the Forum ledger to sys_events",
     "This slice does not add PostgreSQL runtime evidence",
     "Tests, verifiers, formatting, Cargo checks and Clippy were not run by the implementation agent"
   ],
@@ -55,6 +58,6 @@
     "publish and consume a versioned Forum projection invalidation carrying owner revision",
     "store owner revision independently from Search ingest_sequence",
     "reconcile pending retryable missing and stale delivery without advancing early",
-    "capture concurrent writer direct SQL rollback truncate and LINK-FORUM-03 PostgreSQL evidence"
+    "capture concurrent writer direct SQL rollback deferred-constraint truncate and LINK-FORUM-03 PostgreSQL evidence"
   ]
 }

--- a/crates/rustok-forum/contracts/forum-search-owner-revision-counter-hardening.json
+++ b/crates/rustok-forum/contracts/forum-search-owner-revision-counter-hardening.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-23B2G2A1",
+  "status": "source_complete_execution_pending",
+  "scope": "Harden the merged Forum projection revision counter and ledger against direct non-monotonic row mutation and table truncation without editing the delivered G2A baseline migration",
+  "predecessor_task": "FORUM-23B2G2A",
+  "predecessor_contract": "crates/rustok-forum/contracts/forum-search-owner-revision-ledger.json",
+  "baseline_migration": "crates/rustok-forum/src/migrations/m20260731_000007_add_forum_projection_revision_ledger.rs",
+  "hardening_migration": "crates/rustok-forum/src/migrations/m20260731_000008_harden_forum_projection_revision_counter.rs",
+  "migration_registry": "crates/rustok-forum/src/migrations/mod.rs",
+  "owner_note": "crates/rustok-forum/docs/forum-23b2g2a1-search-owner-revision-counter-hardening.md",
+  "verifier": "scripts/verify/verify-forum-search-owner-revision-counter-hardening.mjs",
+  "counter_invariants": {
+    "table": "forum_projection_revision_counters",
+    "first_revision_must_equal": 1,
+    "update_must_equal_previous_plus": 1,
+    "tenant_key_immutable": true,
+    "row_delete_forbidden": true,
+    "table_truncate_forbidden": true,
+    "positive_check_from_baseline_retained": true,
+    "allocator_insert_or_increment_compatible": true
+  },
+  "ledger_invariants": {
+    "table": "forum_projection_revision_ledger",
+    "baseline_update_trigger_retained": true,
+    "baseline_delete_trigger_retained": true,
+    "table_truncate_forbidden": true,
+    "existing_rows_rewritten": false
+  },
+  "migration_policy": {
+    "baseline_migration_modified": false,
+    "additive_upgrade_migration": true,
+    "postgresql_only": true,
+    "sqlite_remains_noop": true,
+    "down_removes_only_hardening_triggers_and_functions": true,
+    "tables_or_rows_dropped_on_down": false
+  },
+  "compatibility": {
+    "forum_owner_allocator_changed": false,
+    "outbox_api_changed": false,
+    "event_schema_changed": false,
+    "search_ingestion_changed": false,
+    "search_inbox_changed": false,
+    "public_api_changed": false,
+    "dependency_added": false,
+    "cargo_lock_changed": false
+  },
+  "non_claims": [
+    "This slice does not add the G2B versioned wire event or Search owner-revision consumer",
+    "This slice does not validate the sys_events JSON envelope from a Forum migration",
+    "This slice does not add PostgreSQL runtime evidence",
+    "Tests, verifiers, formatting, Cargo checks and Clippy were not run by the implementation agent"
+  ],
+  "remaining_scope": [
+    "publish and consume a versioned Forum projection invalidation carrying owner revision",
+    "store owner revision independently from Search ingest_sequence",
+    "reconcile pending retryable missing and stale delivery without advancing early",
+    "capture concurrent writer direct SQL rollback truncate and LINK-FORUM-03 PostgreSQL evidence"
+  ]
+}

--- a/crates/rustok-forum/docs/forum-23b2g2a1-search-owner-revision-counter-hardening.md
+++ b/crates/rustok-forum/docs/forum-23b2g2a1-search-owner-revision-counter-hardening.md
@@ -34,6 +34,21 @@ RETURNING revision
 The baseline positive check remains active. This migration adds no alternate
 allocator and does not change owner service code.
 
+## Commit-time ledger coverage
+
+An exact `+1` row trigger alone would still allow direct SQL to advance the
+counter without writing an invalidation ledger row. That would create a committed
+revision gap even though each individual update looked monotonic.
+
+A `DEFERRABLE INITIALLY DEFERRED` constraint trigger now verifies at transaction
+commit that every inserted or updated counter revision has a matching
+`(tenant_id, revision)` row in `forum_projection_revision_ledger`.
+
+The check is deferred because the canonical G2A protocol intentionally allocates
+the revision before writing the outbox envelope and ledger row. It therefore
+accepts the owner transaction after all three writes exist, while rejecting a
+direct counter-only commit.
+
 ## Truncation boundary
 
 The original G2A ledger rejected row updates and deletes, but PostgreSQL
@@ -54,9 +69,9 @@ triggers.
 The hardening migration is PostgreSQL-only, matching the owner ledger and Search
 Forum projection runtime. SQLite remains a no-op.
 
-Down migration removes only the new counter and truncate triggers/functions. It
-does not drop, rewrite or truncate either table, and it does not modify the
-baseline G2A migration.
+Down migration removes only the new counter, deferred-coverage and truncate
+triggers/functions. It does not drop, rewrite or truncate either table, and it
+does not modify the baseline G2A migration.
 
 No owner allocator, outbox API, event schema, Search ingestion, Search inbox,
 public API, dependency or `Cargo.lock` change is introduced.
@@ -64,10 +79,11 @@ public API, dependency or `Cargo.lock` change is introduced.
 ## Deliberate boundary
 
 This slice does not decode or validate `sys_events.payload` from a Forum
-migration. Exact outbox envelope identity remains guaranteed by the G2A owner
-transaction, unique ledger event ID and canonical outbox writer. Coupling a Forum
-schema trigger to outbox JSON serialization would create a cross-module storage
-contract and is deferred rather than hidden inside database SQL.
+migration and does not add a cross-module foreign key to outbox storage. Exact
+outbox envelope identity remains guaranteed by the G2A owner transaction, unique
+ledger event ID and canonical outbox writer. Coupling a Forum schema trigger to
+outbox JSON serialization would create a cross-module storage contract and is
+deferred rather than hidden inside database SQL.
 
 The versioned owner-revision event, persistent Search consumer, dual watermark
 commit protocol and lost-delivery reconciliation remain `FORUM-23B2G2B`.
@@ -84,7 +100,7 @@ cargo xtask module validate forum
 ```
 
 PostgreSQL evidence should attempt initial revision values other than `1`, skipped
-and repeated revisions, tenant-key mutation, row deletion, counter truncation and
-ledger truncation. It should also confirm that the canonical concurrent
-`INSERT ... ON CONFLICT` allocator continues to commit exact increasing tenant
-revisions.
+and repeated revisions, tenant-key mutation, row deletion, a counter-only commit,
+counter truncation and ledger truncation. It should also confirm that the
+canonical concurrent `INSERT ... ON CONFLICT` allocator continues to commit exact
+increasing tenant revisions with matching ledger rows.

--- a/crates/rustok-forum/docs/forum-23b2g2a1-search-owner-revision-counter-hardening.md
+++ b/crates/rustok-forum/docs/forum-23b2g2a1-search-owner-revision-counter-hardening.md
@@ -1,0 +1,90 @@
+# FORUM-23B2G2A1 Search owner-revision counter hardening
+
+## Status
+
+`source_complete_execution_pending`
+
+`FORUM-23B2G2A` introduced the Forum-owned tenant projection revision counter and
+append-only revision-to-outbox ledger. This follow-up closes direct SQL mutation
+paths that were still protected only by the owner allocator convention.
+
+The delivered baseline migration
+`m20260731_000007_add_forum_projection_revision_ledger` remains unchanged. All
+hardening is applied through additive migration
+`m20260731_000008_harden_forum_projection_revision_counter`.
+
+## Counter invariants
+
+PostgreSQL row triggers enforce:
+
+- the first row for one tenant must start at revision `1`;
+- an update must retain the same tenant key;
+- an update must advance the previous revision by exactly `1`;
+- row deletion is forbidden.
+
+The trigger remains compatible with the canonical owner allocator:
+
+```sql
+INSERT ... VALUES (tenant_id, 1)
+ON CONFLICT (tenant_id)
+DO UPDATE SET revision = revision + 1
+RETURNING revision
+```
+
+The baseline positive check remains active. This migration adds no alternate
+allocator and does not change owner service code.
+
+## Truncation boundary
+
+The original G2A ledger rejected row updates and deletes, but PostgreSQL
+`TRUNCATE` does not execute row-level delete triggers. A statement trigger now
+rejects truncation of both:
+
+```text
+forum_projection_revision_counters
+forum_projection_revision_ledger
+```
+
+Without this guard, direct maintenance SQL could reset the tenant clock or erase
+the immutable revision-to-event audit trail while satisfying all row-level
+triggers.
+
+## Migration compatibility
+
+The hardening migration is PostgreSQL-only, matching the owner ledger and Search
+Forum projection runtime. SQLite remains a no-op.
+
+Down migration removes only the new counter and truncate triggers/functions. It
+does not drop, rewrite or truncate either table, and it does not modify the
+baseline G2A migration.
+
+No owner allocator, outbox API, event schema, Search ingestion, Search inbox,
+public API, dependency or `Cargo.lock` change is introduced.
+
+## Deliberate boundary
+
+This slice does not decode or validate `sys_events.payload` from a Forum
+migration. Exact outbox envelope identity remains guaranteed by the G2A owner
+transaction, unique ledger event ID and canonical outbox writer. Coupling a Forum
+schema trigger to outbox JSON serialization would create a cross-module storage
+contract and is deferred rather than hidden inside database SQL.
+
+The versioned owner-revision event, persistent Search consumer, dual watermark
+commit protocol and lost-delivery reconciliation remain `FORUM-23B2G2B`.
+
+## Maintainer verification
+
+The implementation agent did not run these commands, as requested:
+
+```bash
+node scripts/verify/verify-forum-search-owner-revision-counter-hardening.mjs
+cargo test -p rustok-forum projection_revision -- --nocapture
+cargo check -p rustok-forum --all-targets
+cargo xtask module validate forum
+```
+
+PostgreSQL evidence should attempt initial revision values other than `1`, skipped
+and repeated revisions, tenant-key mutation, row deletion, counter truncation and
+ledger truncation. It should also confirm that the canonical concurrent
+`INSERT ... ON CONFLICT` allocator continues to commit exact increasing tenant
+revisions.

--- a/crates/rustok-forum/docs/forum-23b2g2a1-search-owner-revision-counter-hardening.md
+++ b/crates/rustok-forum/docs/forum-23b2g2a1-search-owner-revision-counter-hardening.md
@@ -13,6 +13,17 @@ The delivered baseline migration
 hardening is applied through additive migration
 `m20260731_000008_harden_forum_projection_revision_counter`.
 
+## Upgrade preflight
+
+Before installing triggers, PostgreSQL verifies the existing G2A storage. For
+each tenant, ledger revisions must form one contiguous sequence from `1` through
+the current counter value. The minimum must be `1`, the maximum and row count
+must equal the counter, and a ledger tenant cannot exist without a counter row.
+
+An inconsistent database fails the migration instead of silently accepting a
+preexisting gap or orphaned audit history. The preflight is read-only and does
+not repair, renumber or delete existing rows.
+
 ## Counter invariants
 
 PostgreSQL row triggers enforce:
@@ -99,8 +110,9 @@ cargo check -p rustok-forum --all-targets
 cargo xtask module validate forum
 ```
 
-PostgreSQL evidence should attempt initial revision values other than `1`, skipped
-and repeated revisions, tenant-key mutation, row deletion, a counter-only commit,
-counter truncation and ledger truncation. It should also confirm that the
-canonical concurrent `INSERT ... ON CONFLICT` allocator continues to commit exact
-increasing tenant revisions with matching ledger rows.
+PostgreSQL evidence should attempt an inconsistent pre-upgrade ledger, initial
+revision values other than `1`, skipped and repeated revisions, tenant-key
+mutation, row deletion, a counter-only commit, counter truncation and ledger
+truncation. It should also confirm that the canonical concurrent
+`INSERT ... ON CONFLICT` allocator continues to commit exact increasing tenant
+revisions with matching ledger rows.

--- a/crates/rustok-forum/src/migrations/m20260731_000008_harden_forum_projection_revision_counter.rs
+++ b/crates/rustok-forum/src/migrations/m20260731_000008_harden_forum_projection_revision_counter.rs
@@ -36,6 +36,29 @@ impl MigrationTrait for Migration {
 }
 
 const POSTGRES_UP: &str = r#"
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM forum_projection_revision_counters AS counters
+        LEFT JOIN forum_projection_revision_ledger AS ledger
+          ON ledger.tenant_id = counters.tenant_id
+        GROUP BY counters.tenant_id, counters.revision
+        HAVING COUNT(ledger.revision) <> counters.revision
+            OR MIN(ledger.revision) IS DISTINCT FROM 1
+            OR MAX(ledger.revision) IS DISTINCT FROM counters.revision
+    ) OR EXISTS (
+        SELECT 1
+        FROM forum_projection_revision_ledger AS ledger
+        LEFT JOIN forum_projection_revision_counters AS counters
+          ON counters.tenant_id = ledger.tenant_id
+        WHERE counters.tenant_id IS NULL
+    ) THEN
+        RAISE EXCEPTION 'existing forum projection revision storage is inconsistent';
+    END IF;
+END;
+$$;
+
 CREATE OR REPLACE FUNCTION forum_enforce_projection_revision_counter()
 RETURNS trigger AS $$
 BEGIN

--- a/crates/rustok-forum/src/migrations/m20260731_000008_harden_forum_projection_revision_counter.rs
+++ b/crates/rustok-forum/src/migrations/m20260731_000008_harden_forum_projection_revision_counter.rs
@@ -76,6 +76,28 @@ CREATE TRIGGER forum_projection_revision_counter_delete
 BEFORE DELETE ON forum_projection_revision_counters
 FOR EACH ROW EXECUTE FUNCTION forum_enforce_projection_revision_counter();
 
+CREATE OR REPLACE FUNCTION forum_require_projection_revision_ledger_row()
+RETURNS trigger AS $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM forum_projection_revision_ledger
+        WHERE tenant_id = NEW.tenant_id
+          AND revision = NEW.revision
+    ) THEN
+        RAISE EXCEPTION 'forum projection revision counter requires a matching ledger row';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS forum_projection_revision_counter_ledger_commit
+    ON forum_projection_revision_counters;
+CREATE CONSTRAINT TRIGGER forum_projection_revision_counter_ledger_commit
+AFTER INSERT OR UPDATE ON forum_projection_revision_counters
+DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW EXECUTE FUNCTION forum_require_projection_revision_ledger_row();
+
 CREATE OR REPLACE FUNCTION forum_reject_projection_revision_truncate()
 RETURNS trigger AS $$
 BEGIN
@@ -102,6 +124,8 @@ DROP TRIGGER IF EXISTS forum_projection_revision_ledger_truncate
     ON forum_projection_revision_ledger;
 DROP TRIGGER IF EXISTS forum_projection_revision_counter_truncate
     ON forum_projection_revision_counters;
+DROP TRIGGER IF EXISTS forum_projection_revision_counter_ledger_commit
+    ON forum_projection_revision_counters;
 DROP TRIGGER IF EXISTS forum_projection_revision_counter_delete
     ON forum_projection_revision_counters;
 DROP TRIGGER IF EXISTS forum_projection_revision_counter_update
@@ -109,5 +133,6 @@ DROP TRIGGER IF EXISTS forum_projection_revision_counter_update
 DROP TRIGGER IF EXISTS forum_projection_revision_counter_insert
     ON forum_projection_revision_counters;
 DROP FUNCTION IF EXISTS forum_reject_projection_revision_truncate();
+DROP FUNCTION IF EXISTS forum_require_projection_revision_ledger_row();
 DROP FUNCTION IF EXISTS forum_enforce_projection_revision_counter();
 "#;

--- a/crates/rustok-forum/src/migrations/m20260731_000008_harden_forum_projection_revision_counter.rs
+++ b/crates/rustok-forum/src/migrations/m20260731_000008_harden_forum_projection_revision_counter.rs
@@ -1,0 +1,113 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::{ConnectionTrait, DatabaseBackend};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DatabaseBackend::Postgres => manager
+                .get_connection()
+                .execute_unprepared(POSTGRES_UP)
+                .await
+                .map(|_| ()),
+            DatabaseBackend::Sqlite => Ok(()),
+            backend => Err(DbErr::Custom(format!(
+                "Forum projection revision counter hardening does not support database backend {backend:?}"
+            ))),
+        }
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DatabaseBackend::Postgres => manager
+                .get_connection()
+                .execute_unprepared(POSTGRES_DOWN)
+                .await
+                .map(|_| ()),
+            DatabaseBackend::Sqlite => Ok(()),
+            backend => Err(DbErr::Custom(format!(
+                "Forum projection revision counter hardening does not support database backend {backend:?}"
+            ))),
+        }
+    }
+}
+
+const POSTGRES_UP: &str = r#"
+CREATE OR REPLACE FUNCTION forum_enforce_projection_revision_counter()
+RETURNS trigger AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        IF NEW.revision <> 1 THEN
+            RAISE EXCEPTION 'forum projection revision counter must start at 1';
+        END IF;
+        RETURN NEW;
+    END IF;
+
+    IF TG_OP = 'UPDATE' THEN
+        IF NEW.tenant_id <> OLD.tenant_id OR NEW.revision <> OLD.revision + 1 THEN
+            RAISE EXCEPTION 'forum projection revision counter must advance by exactly 1';
+        END IF;
+        RETURN NEW;
+    END IF;
+
+    RAISE EXCEPTION 'forum projection revision counter cannot be deleted';
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS forum_projection_revision_counter_insert
+    ON forum_projection_revision_counters;
+CREATE TRIGGER forum_projection_revision_counter_insert
+BEFORE INSERT ON forum_projection_revision_counters
+FOR EACH ROW EXECUTE FUNCTION forum_enforce_projection_revision_counter();
+
+DROP TRIGGER IF EXISTS forum_projection_revision_counter_update
+    ON forum_projection_revision_counters;
+CREATE TRIGGER forum_projection_revision_counter_update
+BEFORE UPDATE ON forum_projection_revision_counters
+FOR EACH ROW EXECUTE FUNCTION forum_enforce_projection_revision_counter();
+
+DROP TRIGGER IF EXISTS forum_projection_revision_counter_delete
+    ON forum_projection_revision_counters;
+CREATE TRIGGER forum_projection_revision_counter_delete
+BEFORE DELETE ON forum_projection_revision_counters
+FOR EACH ROW EXECUTE FUNCTION forum_enforce_projection_revision_counter();
+
+CREATE OR REPLACE FUNCTION forum_reject_projection_revision_truncate()
+RETURNS trigger AS $$
+BEGIN
+    RAISE EXCEPTION 'forum projection revision storage cannot be truncated';
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS forum_projection_revision_counter_truncate
+    ON forum_projection_revision_counters;
+CREATE TRIGGER forum_projection_revision_counter_truncate
+BEFORE TRUNCATE ON forum_projection_revision_counters
+FOR EACH STATEMENT EXECUTE FUNCTION forum_reject_projection_revision_truncate();
+
+DROP TRIGGER IF EXISTS forum_projection_revision_ledger_truncate
+    ON forum_projection_revision_ledger;
+CREATE TRIGGER forum_projection_revision_ledger_truncate
+BEFORE TRUNCATE ON forum_projection_revision_ledger
+FOR EACH STATEMENT EXECUTE FUNCTION forum_reject_projection_revision_truncate();
+"#;
+
+const POSTGRES_DOWN: &str = r#"
+DROP TRIGGER IF EXISTS forum_projection_revision_ledger_truncate
+    ON forum_projection_revision_ledger;
+DROP TRIGGER IF EXISTS forum_projection_revision_counter_truncate
+    ON forum_projection_revision_counters;
+DROP TRIGGER IF EXISTS forum_projection_revision_counter_delete
+    ON forum_projection_revision_counters;
+DROP TRIGGER IF EXISTS forum_projection_revision_counter_update
+    ON forum_projection_revision_counters;
+DROP TRIGGER IF EXISTS forum_projection_revision_counter_insert
+    ON forum_projection_revision_counters;
+DROP FUNCTION IF EXISTS forum_reject_projection_revision_truncate();
+DROP FUNCTION IF EXISTS forum_enforce_projection_revision_counter();
+"#;

--- a/crates/rustok-forum/src/migrations/mod.rs
+++ b/crates/rustok-forum/src/migrations/mod.rs
@@ -39,6 +39,7 @@ mod m20260728_000004_add_forum_user_trust_state;
 mod m20260728_000005_add_forum_approved_posts_indexes;
 mod m20260728_000006_add_forum_create_window_indexes;
 mod m20260731_000007_add_forum_projection_revision_ledger;
+mod m20260731_000008_harden_forum_projection_revision_counter;
 
 use rustok_core::MigrationDependencyDescriptor;
 use sea_orm_migration::MigrationTrait;
@@ -86,6 +87,7 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260728_000005_add_forum_approved_posts_indexes::Migration),
         Box::new(m20260728_000006_add_forum_create_window_indexes::Migration),
         Box::new(m20260731_000007_add_forum_projection_revision_ledger::Migration),
+        Box::new(m20260731_000008_harden_forum_projection_revision_counter::Migration),
     ]
 }
 

--- a/scripts/verify/verify-forum-search-owner-revision-counter-hardening.mjs
+++ b/scripts/verify/verify-forum-search-owner-revision-counter-hardening.mjs
@@ -64,6 +64,7 @@ requireAll(baseline, [
 ], `${paths.baseline} retained baseline`);
 rejectAll(baseline, [
   "forum_enforce_projection_revision_counter",
+  "forum_require_projection_revision_ledger_row",
   "forum_reject_projection_revision_truncate",
 ], `${paths.baseline} immutable baseline boundary`);
 
@@ -75,6 +76,10 @@ requireAll(migration, [
   "forum_projection_revision_counter_insert",
   "forum_projection_revision_counter_update",
   "forum_projection_revision_counter_delete",
+  "forum_require_projection_revision_ledger_row",
+  "forum projection revision counter requires a matching ledger row",
+  "CREATE CONSTRAINT TRIGGER forum_projection_revision_counter_ledger_commit",
+  "DEFERRABLE INITIALLY DEFERRED",
   "forum_reject_projection_revision_truncate",
   "forum_projection_revision_counter_truncate",
   "forum_projection_revision_ledger_truncate",
@@ -108,9 +113,11 @@ requireAll(allocator, [
   "VALUES ($1, 1, CURRENT_TIMESTAMP)",
   "revision = forum_projection_revision_counters.revision + 1",
   "RETURNING revision",
+  "INSERT INTO forum_projection_revision_ledger",
 ], `${paths.allocator} compatibility`);
 rejectAll(allocator, [
   "forum_enforce_projection_revision_counter",
+  "forum_require_projection_revision_ledger_row",
   "forum_reject_projection_revision_truncate",
 ], `${paths.allocator} no duplicate hardening`);
 
@@ -118,6 +125,8 @@ requireAll(note, [
   "# FORUM-23B2G2A1 Search owner-revision counter hardening",
   "baseline migration",
   "advance the previous revision by exactly `1`",
+  "DEFERRABLE INITIALLY DEFERRED",
+  "direct counter-only commit",
   "rejects truncation of both",
   "does not decode or validate `sys_events.payload`",
   "did not run these commands",
@@ -138,8 +147,13 @@ if (contract) {
   }
   if (contract.counter_invariants?.tenant_key_immutable !== true
       || contract.counter_invariants?.row_delete_forbidden !== true
-      || contract.counter_invariants?.table_truncate_forbidden !== true) {
-    failures.push(`${paths.contract}: counter lifecycle invariants are incomplete`);
+      || contract.counter_invariants?.table_truncate_forbidden !== true
+      || contract.counter_invariants?.committed_revision_requires_matching_ledger_row !== true) {
+    failures.push(`${paths.contract}: counter lifecycle and commit invariants are incomplete`);
+  }
+  if (contract.counter_invariants?.ledger_coverage_check
+      !== "deferred constraint trigger at transaction commit") {
+    failures.push(`${paths.contract}: deferred ledger coverage contract is missing`);
   }
   if (contract.ledger_invariants?.table_truncate_forbidden !== true) {
     failures.push(`${paths.contract}: ledger truncate guard is missing`);

--- a/scripts/verify/verify-forum-search-owner-revision-counter-hardening.mjs
+++ b/scripts/verify/verify-forum-search-owner-revision-counter-hardening.mjs
@@ -69,6 +69,11 @@ rejectAll(baseline, [
 ], `${paths.baseline} immutable baseline boundary`);
 
 requireAll(migration, [
+  "existing forum projection revision storage is inconsistent",
+  "COUNT(ledger.revision) <> counters.revision",
+  "MIN(ledger.revision) IS DISTINCT FROM 1",
+  "MAX(ledger.revision) IS DISTINCT FROM counters.revision",
+  "WHERE counters.tenant_id IS NULL",
   "forum_enforce_projection_revision_counter",
   "NEW.revision <> 1",
   "NEW.tenant_id <> OLD.tenant_id OR NEW.revision <> OLD.revision + 1",
@@ -124,6 +129,8 @@ rejectAll(allocator, [
 requireAll(note, [
   "# FORUM-23B2G2A1 Search owner-revision counter hardening",
   "baseline migration",
+  "ledger revisions must form one contiguous sequence",
+  "fails the migration",
   "advance the previous revision by exactly `1`",
   "DEFERRABLE INITIALLY DEFERRED",
   "direct counter-only commit",
@@ -138,6 +145,12 @@ if (contract) {
   }
   if (contract.status !== "source_complete_execution_pending") {
     failures.push(`${paths.contract}: unexpected status`);
+  }
+  if (contract.upgrade_preflight?.existing_counter_requires_contiguous_ledger_from_one !== true
+      || contract.upgrade_preflight?.existing_ledger_without_counter_rejected !== true
+      || contract.upgrade_preflight?.inconsistent_upgrade_fails_closed !== true
+      || contract.upgrade_preflight?.existing_rows_rewritten !== false) {
+    failures.push(`${paths.contract}: upgrade preflight contract is incomplete`);
   }
   if (contract.counter_invariants?.first_revision_must_equal !== 1) {
     failures.push(`${paths.contract}: first revision invariant must equal 1`);

--- a/scripts/verify/verify-forum-search-owner-revision-counter-hardening.mjs
+++ b/scripts/verify/verify-forum-search-owner-revision-counter-hardening.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(".");
+const failures = [];
+const paths = {
+  contract:
+    "crates/rustok-forum/contracts/forum-search-owner-revision-counter-hardening.json",
+  note:
+    "crates/rustok-forum/docs/forum-23b2g2a1-search-owner-revision-counter-hardening.md",
+  baseline:
+    "crates/rustok-forum/src/migrations/m20260731_000007_add_forum_projection_revision_ledger.rs",
+  migration:
+    "crates/rustok-forum/src/migrations/m20260731_000008_harden_forum_projection_revision_counter.rs",
+  registry: "crates/rustok-forum/src/migrations/mod.rs",
+  allocator: "crates/rustok-forum/src/services/projection_invalidation.rs",
+};
+
+function read(relativePath) {
+  const target = path.join(root, relativePath);
+  if (!existsSync(target)) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return "";
+  }
+  return readFileSync(target, "utf8");
+}
+
+function parseJson(relativePath) {
+  try {
+    return JSON.parse(read(relativePath));
+  } catch (error) {
+    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function requireAll(source, markers, label) {
+  for (const marker of markers) {
+    if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+  }
+}
+
+function rejectAll(source, markers, label) {
+  for (const marker of markers) {
+    if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+  }
+}
+
+const contract = parseJson(paths.contract);
+const note = read(paths.note);
+const baseline = read(paths.baseline);
+const migration = read(paths.migration);
+const registry = read(paths.registry);
+const allocator = read(paths.allocator);
+
+requireAll(baseline, [
+  "CREATE TABLE IF NOT EXISTS forum_projection_revision_counters",
+  "CREATE TABLE IF NOT EXISTS forum_projection_revision_ledger",
+  "forum_reject_projection_revision_ledger_mutation",
+], `${paths.baseline} retained baseline`);
+rejectAll(baseline, [
+  "forum_enforce_projection_revision_counter",
+  "forum_reject_projection_revision_truncate",
+], `${paths.baseline} immutable baseline boundary`);
+
+requireAll(migration, [
+  "forum_enforce_projection_revision_counter",
+  "NEW.revision <> 1",
+  "NEW.tenant_id <> OLD.tenant_id OR NEW.revision <> OLD.revision + 1",
+  "forum projection revision counter cannot be deleted",
+  "forum_projection_revision_counter_insert",
+  "forum_projection_revision_counter_update",
+  "forum_projection_revision_counter_delete",
+  "forum_reject_projection_revision_truncate",
+  "forum_projection_revision_counter_truncate",
+  "forum_projection_revision_ledger_truncate",
+  "BEFORE TRUNCATE ON forum_projection_revision_counters",
+  "BEFORE TRUNCATE ON forum_projection_revision_ledger",
+  "DatabaseBackend::Sqlite => Ok(())",
+], paths.migration);
+rejectAll(migration, [
+  "DROP TABLE",
+  "DELETE FROM forum_projection_revision",
+  "TRUNCATE forum_projection_revision",
+  "sys_events",
+  "serde_json",
+], `${paths.migration} additive boundary`);
+
+requireAll(registry, [
+  "mod m20260731_000007_add_forum_projection_revision_ledger;",
+  "mod m20260731_000008_harden_forum_projection_revision_counter;",
+  "Box::new(m20260731_000007_add_forum_projection_revision_ledger::Migration)",
+  "Box::new(m20260731_000008_harden_forum_projection_revision_counter::Migration)",
+], paths.registry);
+if (
+  registry.indexOf("m20260731_000007_add_forum_projection_revision_ledger::Migration")
+  > registry.indexOf("m20260731_000008_harden_forum_projection_revision_counter::Migration")
+) {
+  failures.push(`${paths.registry}: hardening migration must follow the baseline ledger migration`);
+}
+
+requireAll(allocator, [
+  "INSERT INTO forum_projection_revision_counters",
+  "VALUES ($1, 1, CURRENT_TIMESTAMP)",
+  "revision = forum_projection_revision_counters.revision + 1",
+  "RETURNING revision",
+], `${paths.allocator} compatibility`);
+rejectAll(allocator, [
+  "forum_enforce_projection_revision_counter",
+  "forum_reject_projection_revision_truncate",
+], `${paths.allocator} no duplicate hardening`);
+
+requireAll(note, [
+  "# FORUM-23B2G2A1 Search owner-revision counter hardening",
+  "baseline migration",
+  "advance the previous revision by exactly `1`",
+  "rejects truncation of both",
+  "does not decode or validate `sys_events.payload`",
+  "did not run these commands",
+], paths.note);
+
+if (contract) {
+  if (contract.task !== "FORUM-23B2G2A1") {
+    failures.push(`${paths.contract}: unexpected task`);
+  }
+  if (contract.status !== "source_complete_execution_pending") {
+    failures.push(`${paths.contract}: unexpected status`);
+  }
+  if (contract.counter_invariants?.first_revision_must_equal !== 1) {
+    failures.push(`${paths.contract}: first revision invariant must equal 1`);
+  }
+  if (contract.counter_invariants?.update_must_equal_previous_plus !== 1) {
+    failures.push(`${paths.contract}: update increment invariant must equal 1`);
+  }
+  if (contract.counter_invariants?.tenant_key_immutable !== true
+      || contract.counter_invariants?.row_delete_forbidden !== true
+      || contract.counter_invariants?.table_truncate_forbidden !== true) {
+    failures.push(`${paths.contract}: counter lifecycle invariants are incomplete`);
+  }
+  if (contract.ledger_invariants?.table_truncate_forbidden !== true) {
+    failures.push(`${paths.contract}: ledger truncate guard is missing`);
+  }
+  if (contract.migration_policy?.baseline_migration_modified !== false
+      || contract.migration_policy?.additive_upgrade_migration !== true) {
+    failures.push(`${paths.contract}: migration immutability policy is incorrect`);
+  }
+  if (contract.compatibility?.forum_owner_allocator_changed !== false
+      || contract.compatibility?.outbox_api_changed !== false
+      || contract.compatibility?.search_inbox_changed !== false) {
+    failures.push(`${paths.contract}: runtime compatibility boundary changed`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("FORUM-23B2G2A1 counter hardening verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("FORUM-23B2G2A1 counter hardening source contract is consistent.");


### PR DESCRIPTION
## Summary

- deliver `FORUM-23B2G2A1` as an additive PostgreSQL hardening migration after merged owner revision ledger PR #2716
- keep baseline migration `000007` unchanged and register new migration `000008`
- fail the upgrade when existing per-tenant ledger history is not one contiguous `1..counter` sequence or when ledger rows have no counter
- require a tenant counter to start at revision `1`, retain its tenant key and advance by exactly `+1`
- use a deferred constraint trigger so every committed counter revision has a matching `(tenant_id, revision)` ledger row
- reject direct counter-row deletion
- reject `TRUNCATE` for both the counter and append-only ledger tables, closing the statement-level bypass around row triggers
- add a focused machine contract, owner note and fail-closed source verifier

## Recheck findings

PR #2716 correctly serializes normal owner allocation with `INSERT ... ON CONFLICT DO UPDATE`, but the database accepted direct non-monotonic counter writes and `TRUNCATE`. An exact-step trigger alone would also allow a direct `+1` counter-only commit with no ledger row.

This PR makes those invariants database-enforced without changing the owner allocator, outbox API, event schema, Search ingestion or inbox ordering.

## Commit and upgrade protocol

- a read-only migration preflight rejects inconsistent existing counter/ledger state instead of renumbering or repairing it silently
- row triggers enforce initial `1`, immutable tenant identity, exact `+1`, and no delete
- a `DEFERRABLE INITIALLY DEFERRED` constraint trigger checks ledger coverage at commit, after the canonical owner path has allocated the revision and written its outbox/ledger records
- statement triggers reject truncation of both revision tables

## Migration compatibility

- merged migration `m20260731_000007_add_forum_projection_revision_ledger` is byte-for-byte untouched
- new `m20260731_000008_harden_forum_projection_revision_counter` is upgrade-safe and PostgreSQL-only
- SQLite remains a no-op, matching the Forum Search projection runtime boundary
- down migration removes only the new triggers/functions and never drops or rewrites revision tables
- no dependency or `Cargo.lock` change

## Deliberate boundary

The migration does not decode `sys_events.payload` or add a cross-module foreign key from Forum to outbox storage. Exact event-ID binding remains owned by the transactional G2A write path. Versioned wire delivery and Search owner-revision reconciliation remain G2B.

## Plan synchronization

The focused G2A1 contract and owner note record this hardening. The canonical Forum/Search plans already retain G2 owner-revision reconciliation as incomplete; no completion status is advanced by this storage-only follow-up.

## Verification

Tests, verifiers, formatting, Cargo checks, Clippy and PostgreSQL runtime evidence were intentionally not run by request.