### PR TITLE
test(index): retain reconciliation failed progress recovery

### DIFF
--- a/crates/rustok-index/docs/m6-reconciliation-failed-progress-recovery-postgres-harness.md
+++ b/crates/rustok-index/docs/m6-reconciliation-failed-progress-recovery-postgres-harness.md
@@ -1,0 +1,96 @@
+# M6 Reconciliation Failed Progress Recovery PostgreSQL Harness
+
+Status: executable target retained, not run.
+
+This harness retains the durable boundary where a reconciliation run has already published one safe page cursor and then fails while applying a mutation from the next page.
+
+It complements the source-failure diagnostics harness and the mutation-failure diagnostics harness by proving recovery after non-zero durable progress.
+
+## First attempt
+
+The source owns two pages with stable event UUIDs and source versions.
+
+Page one returns one valid mutation and cursor `{ "offset": 1 }`. The canonical `PostgresIndexReconciliationRunner` must:
+
+- apply the mutation;
+- persist one entity and one inbox row;
+- publish durable reconciliation cursor progress with `pages_processed = 1`;
+- retain `completed_passes = 0`;
+- heartbeat before scanning page two because `heartbeat_every_pages = 1`.
+
+Page two remains inside the exact tenant and schema scope, but its record omits the required `id` field. Source-page scope validation therefore succeeds, while `PostgresMutationStore` schema validation returns permanent `mutation_rejected`.
+
+The runner must return `IndexReconciliationRunError::MutationFailed` at position zero and terminalize attempt one as `failed`.
+
+## Durable failed state
+
+The failed row must retain the previous safe page boundary:
+
+- state `failed`;
+- attempt count 1;
+- `completed_passes = 0`;
+- `pages_processed = 1`;
+- source cursor `{ "offset": 1 }`;
+- cleared lease owner and expiry;
+- non-null completion timestamp.
+
+Its diagnostic must be exact three-field JSON:
+
+```json
+{
+  "contract": "index_reconciliation_run_failure_v1",
+  "dependency_code": "mutation_rejected",
+  "retryable": false
+}
+```
+
+The diagnostic exposes no mutation payload, tenant, actor, worker, job, database, SQL, transport, stack, or owner-detail field.
+
+The second-page invalid mutation must create no entity or inbox row. PostgreSQL must retain exactly one entity, one inbox row, and one failed reconciliation job.
+
+A later exact-tenant cancellation request must return `AlreadyTerminal(Failed)`.
+
+## Duplicate-safe recovery
+
+Terminal failed reconciliation jobs are excluded from active acquisition under the current runner. A new explicit invocation therefore creates a new job and starts from the initial source cursor.
+
+The recovery source returns:
+
+1. the same valid first-page mutation with the same event UUID and source version;
+2. a corrected valid second-page mutation using the same second-page event UUID and source version that never reached mutation storage during the failed run.
+
+The recovery invocation must:
+
+- use a different job UUID;
+- complete as attempt one;
+- process two pages and one completed pass;
+- execute one page-boundary heartbeat;
+- report one duplicate and one newly applied mutation;
+- report no stale mutation;
+- preserve exactly two entity rows and two inbox rows.
+
+The succeeded job must retain `completed_passes = 1`, `pages_processed = 2`, a null source cursor, cleared lease ownership, and no failure diagnostic.
+
+A later invocation must return `AlreadyComplete` for the succeeded recovery job without processing another page.
+
+## PostgreSQL isolation
+
+The target reads `RUSTOK_INDEX_TEST_DATABASE_URL`, with a PostgreSQL `DATABASE_URL` fallback. Without a PostgreSQL URL it reports a skip and succeeds.
+
+Each invocation creates a unique schema, creates the tenant owner fixture, applies every real `IndexModule` migration, persists one active schema, uses one-connection pools with schema-local `search_path`, reads durable evidence, and drops the schema.
+
+No sleep, polling delay, or elapsed-time race is used.
+
+## Scope boundaries
+
+This harness changes no production code, migration, reconciliation SQL/state machine, source contract, cursor shape, mutation identity, schema, diagnostic, or public API.
+
+It does not provide:
+
+- automatic retry, backoff, scheduling, or attempt exhaustion;
+- failed-scope dead-letter admission or authorized requeue;
+- cancellation, lease-loss, heartbeat-takeover, or restart races;
+- source-call timeout or pending-future preemption;
+- digest comparison, orphan cleanup, targeted/full/shadow repair, locale/partition dimensions, or complete drift repair.
+
+The canonical M6 reconciliation and drift-repair item therefore remains open.

--- a/crates/rustok-index/tests/reconciliation_failed_progress_recovery/connection.rs
+++ b/crates/rustok-index/tests/reconciliation_failed_progress_recovery/connection.rs
@@ -1,0 +1,33 @@
+use std::{env, error::Error};
+
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection};
+
+pub type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+pub const DATABASE_ENV: &str = "RUSTOK_INDEX_TEST_DATABASE_URL";
+
+pub fn database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+pub async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+pub async fn scoped_connection(
+    database_url: &str,
+    schema_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url).await?;
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}""#))
+        .await?;
+    Ok(db)
+}

--- a/crates/rustok-index/tests/reconciliation_failed_progress_recovery/database.rs
+++ b/crates/rustok-index/tests/reconciliation_failed_progress_recovery/database.rs
@@ -1,0 +1,74 @@
+use rustok_core::MigrationSource;
+use rustok_index::IndexModule;
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement};
+use sea_orm_migration::SchemaManager;
+use uuid::Uuid;
+
+use super::{
+    connection::{DATABASE_ENV, TestResult, connect, database_url, scoped_connection},
+    schema::persist_schema,
+};
+
+pub struct TestDatabase {
+    control: DatabaseConnection,
+    database_url: String,
+    schema_name: String,
+    pub tenant_id: Uuid,
+}
+
+impl TestDatabase {
+    pub async fn setup() -> TestResult<Option<Self>> {
+        let Some(database_url) = database_url() else {
+            eprintln!(
+                "{DATABASE_ENV} is not set to a PostgreSQL URL; skipping reconciliation failed progress recovery harness"
+            );
+            return Ok(None);
+        };
+        let control = connect(&database_url).await?;
+        let schema_name = format!(
+            "rustok_idx_rec_fail_recover_{}",
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let tenant_id = Uuid::new_v4();
+        let db = scoped_connection(&database_url, &schema_name).await?;
+        db.execute_unprepared("CREATE TABLE tenants (id UUID NOT NULL PRIMARY KEY)")
+            .await?;
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "INSERT INTO tenants (id) VALUES ($1)",
+            vec![tenant_id.into()],
+        ))
+        .await?;
+
+        let manager = SchemaManager::new(&db);
+        for migration in IndexModule.migrations() {
+            migration.up(&manager).await?;
+        }
+        persist_schema(&db, tenant_id).await?;
+
+        Ok(Some(Self {
+            control,
+            database_url,
+            schema_name,
+            tenant_id,
+        }))
+    }
+
+    pub async fn connection(&self) -> TestResult<DatabaseConnection> {
+        scoped_connection(&self.database_url, &self.schema_name).await
+    }
+
+    pub async fn cleanup(self) -> TestResult<()> {
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/rustok-index/tests/reconciliation_failed_progress_recovery/evidence.rs
+++ b/crates/rustok-index/tests/reconciliation_failed_progress_recovery/evidence.rs
@@ -1,0 +1,62 @@
+use std::io;
+
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement};
+use serde_json::Value as JsonValue;
+use uuid::Uuid;
+
+use super::connection::TestResult;
+
+#[derive(Debug)]
+pub struct JobEvidence {
+    pub job_id: Uuid,
+    pub state: String,
+    pub attempt_count: i64,
+    pub completed_passes: i64,
+    pub pages_processed: i64,
+    pub source_cursor: JsonValue,
+    pub last_error_code: Option<String>,
+    pub last_error_details: Option<JsonValue>,
+    pub lease_released: bool,
+    pub completed: bool,
+}
+
+pub async fn read_job(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    state: &str,
+) -> TestResult<JobEvidence> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT job_id, state, attempt_count::bigint AS attempt_count_value, (cursor->>'completed_passes')::bigint AS completed_passes, (cursor->>'pages_processed')::bigint AS pages_processed, cursor->'source_cursor' AS source_cursor, last_error_code, last_error_details, (lease_owner IS NULL AND lease_expires_at IS NULL) AS lease_released, (completed_at IS NOT NULL) AS completed FROM index_jobs WHERE tenant_id = $1 AND kind = 'reconcile' AND state = $2 ORDER BY created_at DESC LIMIT 1",
+            vec![tenant_id.into(), state.to_owned().into()],
+        ))
+        .await?
+        .ok_or_else(|| io::Error::other(format!("reconciliation {state} job row is missing")))?;
+    Ok(JobEvidence {
+        job_id: row.try_get("", "job_id")?,
+        state: row.try_get("", "state")?,
+        attempt_count: row.try_get("", "attempt_count_value")?,
+        completed_passes: row.try_get("", "completed_passes")?,
+        pages_processed: row.try_get("", "pages_processed")?,
+        source_cursor: row.try_get("", "source_cursor")?,
+        last_error_code: row.try_get("", "last_error_code")?,
+        last_error_details: row.try_get("", "last_error_details")?,
+        lease_released: row.try_get("", "lease_released")?,
+        completed: row.try_get("", "completed")?,
+    })
+}
+
+pub async fn count(db: &DatabaseConnection, table: &str) -> TestResult<i64> {
+    let sql = match table {
+        "index_entities" => "SELECT COUNT(*)::bigint AS value FROM index_entities",
+        "index_inbox" => "SELECT COUNT(*)::bigint AS value FROM index_inbox",
+        "index_jobs" => "SELECT COUNT(*)::bigint AS value FROM index_jobs WHERE kind = 'reconcile'",
+        _ => panic!("unsupported fixture table"),
+    };
+    Ok(db
+        .query_one(Statement::from_string(DbBackend::Postgres, sql.to_owned()))
+        .await?
+        .ok_or_else(|| io::Error::other("count query returned no row"))?
+        .try_get("", "value")?)
+}

--- a/crates/rustok-index/tests/reconciliation_failed_progress_recovery/runner.rs
+++ b/crates/rustok-index/tests/reconciliation_failed_progress_recovery/runner.rs
@@ -1,0 +1,60 @@
+use std::{sync::Arc, time::Duration};
+
+use rustok_index::{
+    IndexReconciliationRunRequest, IndexSchemaSourceCatalog, IndexSourceCatalog,
+    PostgresIndexReconciliationRunner, SchemaRegistry,
+};
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use super::{
+    schema::{schema, schema_ref},
+    source::FailedProgressSource,
+};
+
+pub const SOURCE_NAME: &str = "failed-progress-recovery-primary";
+
+pub fn runner(
+    db: DatabaseConnection,
+    source: FailedProgressSource,
+) -> PostgresIndexReconciliationRunner {
+    let schema = schema();
+    let mut schema_catalog = IndexSchemaSourceCatalog::new();
+    schema_catalog
+        .register("failed-progress-recovery-harness", schema.clone())
+        .expect("fixture schema source must register");
+
+    let mut source_catalog = IndexSourceCatalog::new();
+    source_catalog
+        .register(
+            "failed-progress-recovery-harness",
+            SOURCE_NAME,
+            [schema.reference.clone()],
+            source,
+        )
+        .expect("fixture source must register");
+    let sources = source_catalog
+        .materialize(&schema_catalog)
+        .expect("fixture source registry must materialize");
+
+    let mut registry = SchemaRegistry::new();
+    registry
+        .register(schema)
+        .expect("fixture schema registry must materialize");
+
+    PostgresIndexReconciliationRunner::new(db, sources, Arc::new(registry))
+}
+
+pub fn request(tenant_id: Uuid, worker_id: &str) -> IndexReconciliationRunRequest {
+    IndexReconciliationRunRequest::new(
+        tenant_id,
+        schema_ref(),
+        worker_id,
+        1,
+        4,
+        1,
+        1,
+        Duration::from_secs(3_600),
+    )
+    .expect("fixture reconciliation request must be valid")
+}

--- a/crates/rustok-index/tests/reconciliation_failed_progress_recovery/schema.rs
+++ b/crates/rustok-index/tests/reconciliation_failed_progress_recovery/schema.rs
@@ -1,0 +1,53 @@
+use rustok_index::{
+    EntityName, FieldCardinality, FieldName, IndexField, IndexSchema, IndexValueType,
+    LocaleMode, ModuleName, SchemaRef, SchemaVersion,
+};
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement, Value as SqlValue};
+use uuid::Uuid;
+
+use super::connection::TestResult;
+
+pub fn schema_ref() -> SchemaRef {
+    SchemaRef {
+        module: ModuleName::new("failed-progress-recovery-harness").unwrap(),
+        entity: EntityName::new("item").unwrap(),
+        version: SchemaVersion::INITIAL,
+    }
+}
+
+pub fn schema() -> IndexSchema {
+    IndexSchema {
+        reference: schema_ref(),
+        locale_mode: LocaleMode::None,
+        fields: vec![IndexField {
+            name: FieldName::new("id").unwrap(),
+            value_type: IndexValueType::Uuid,
+            cardinality: FieldCardinality::One,
+            nullable: false,
+            selectable: true,
+            filterable: true,
+            sortable: true,
+        }],
+        links: Vec::new(),
+    }
+}
+
+pub async fn persist_schema(db: &DatabaseConnection, tenant_id: Uuid) -> TestResult<()> {
+    let schema = schema();
+    let fingerprint = schema.fingerprint()?.to_string();
+    let schema_json = serde_json::to_value(&schema)?;
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "INSERT INTO index_schemas (tenant_id, module_name, entity_name, schema_version, schema_fingerprint, schema_json, status) VALUES ($1, $2, $3, $4, $5, $6, 'active')",
+        vec![
+            tenant_id.into(),
+            schema.reference.module.as_str().to_owned().into(),
+            schema.reference.entity.as_str().to_owned().into(),
+            i64::from(schema.reference.version.get()).into(),
+            fingerprint.into(),
+            SqlValue::Json(Some(Box::new(schema_json))),
+        ],
+    ))
+    .await?;
+    Ok(())
+}

--- a/crates/rustok-index/tests/reconciliation_failed_progress_recovery/source.rs
+++ b/crates/rustok-index/tests/reconciliation_failed_progress_recovery/source.rs
@@ -1,0 +1,104 @@
+use std::collections::BTreeMap;
+
+use async_trait::async_trait;
+use rustok_index::{
+    EntityKey, FieldName, IndexMutation, IndexRecord, IndexSource, IndexSourceCursor,
+    IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest, IndexSourcePage,
+    IndexSourceScanRequest, IndexValue,
+};
+use serde_json::json;
+use uuid::Uuid;
+
+use super::schema::schema_ref;
+
+#[derive(Clone, Copy)]
+pub enum FailedProgressSource {
+    FailSecondPage,
+    RecoverSecondPage,
+}
+
+#[async_trait]
+impl IndexSource for FailedProgressSource {
+    async fn scan(
+        &self,
+        request: IndexSourceScanRequest,
+    ) -> Result<IndexSourcePage, IndexSourceFailure> {
+        let offset = request
+            .cursor()
+            .and_then(|cursor| cursor.value().get("offset"))
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+
+        match offset {
+            0 => {
+                let cursor = IndexSourceCursor::new(json!({ "offset": 1 }))
+                    .expect("fixture cursor must be valid");
+                IndexSourcePage::new(
+                    &request,
+                    vec![valid_mutation(request.tenant_id(), 601, 13_601)],
+                    Some(cursor),
+                )
+                .map_err(|_| fixture_failure())
+            }
+            1 => {
+                let mutation = match self {
+                    Self::FailSecondPage => invalid_mutation(request.tenant_id(), 602, 13_602),
+                    Self::RecoverSecondPage => valid_mutation(request.tenant_id(), 602, 13_602),
+                };
+                IndexSourcePage::new(&request, vec![mutation], None)
+                    .map_err(|_| fixture_failure())
+            }
+            _ => Err(fixture_failure()),
+        }
+    }
+
+    async fn load(
+        &self,
+        request: IndexSourceLoadRequest,
+    ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+        Ok(IndexSourceLoadBatch::new(&request, Vec::new()).expect("empty targeted load"))
+    }
+}
+
+fn valid_mutation(tenant_id: Uuid, entity: u128, event: u128) -> IndexMutation {
+    let entity_id = Uuid::from_u128(entity);
+    IndexMutation::Upsert {
+        event_id: Uuid::from_u128(event),
+        record: IndexRecord {
+            key: EntityKey {
+                tenant_id,
+                schema: schema_ref(),
+                entity_id,
+                locale: None,
+            },
+            source_version: 1,
+            fields: BTreeMap::from([(
+                FieldName::new("id").unwrap(),
+                IndexValue::Uuid(entity_id),
+            )]),
+            links: Vec::new(),
+        },
+    }
+}
+
+fn invalid_mutation(tenant_id: Uuid, entity: u128, event: u128) -> IndexMutation {
+    IndexMutation::Upsert {
+        event_id: Uuid::from_u128(event),
+        record: IndexRecord {
+            key: EntityKey {
+                tenant_id,
+                schema: schema_ref(),
+                entity_id: Uuid::from_u128(entity),
+                locale: None,
+            },
+            source_version: 1,
+            fields: BTreeMap::new(),
+            links: Vec::new(),
+        },
+    }
+}
+
+fn fixture_failure() -> IndexSourceFailure {
+    IndexSourceFailure::permanent("failed_progress_recovery_fixture_invalid")
+        .expect("fixture failure code must be valid")
+}

--- a/crates/rustok-index/tests/source_reconciliation_failed_progress_recovery_postgres_test.rs
+++ b/crates/rustok-index/tests/source_reconciliation_failed_progress_recovery_postgres_test.rs
@@ -1,0 +1,144 @@
+#[path = "reconciliation_failed_progress_recovery/connection.rs"]
+mod connection;
+#[path = "reconciliation_failed_progress_recovery/database.rs"]
+mod database;
+#[path = "reconciliation_failed_progress_recovery/evidence.rs"]
+mod evidence;
+#[path = "reconciliation_failed_progress_recovery/runner.rs"]
+mod runner;
+#[path = "reconciliation_failed_progress_recovery/schema.rs"]
+mod schema;
+#[path = "reconciliation_failed_progress_recovery/source.rs"]
+mod source;
+
+use rustok_index::{
+    IndexReconciliationCancelOutcome, IndexReconciliationRunError,
+    IndexReconciliationRunStatus, IndexReconciliationTerminalState, IndexReplayFailureKind,
+};
+use serde_json::json;
+
+use connection::TestResult;
+use database::TestDatabase;
+use evidence::{count, read_job};
+use runner::{request, runner};
+use source::FailedProgressSource;
+
+const PAGE_FAILURE_CODE: &str = "index.reconciliation_page_failed";
+const FAILURE_CONTRACT: &str = "index_reconciliation_run_failure_v1";
+const MUTATION_FAILURE_CODE: &str = "mutation_rejected";
+
+#[tokio::test]
+async fn failed_second_page_preserves_progress_and_recovers_by_duplicate_redelivery(
+) -> TestResult<()> {
+    let Some(database) = TestDatabase::setup().await? else {
+        return Ok(());
+    };
+    let tenant_id = database.tenant_id;
+    let failed_runner = runner(
+        database.connection().await?,
+        FailedProgressSource::FailSecondPage,
+    );
+
+    let error = failed_runner
+        .run(request(tenant_id, "failed-progress-worker-a"))
+        .await
+        .expect_err("second-page invalid mutation must fail reconciliation");
+    match error {
+        IndexReconciliationRunError::MutationFailed { position, failure } => {
+            assert_eq!(position, 0);
+            assert_eq!(failure.code(), MUTATION_FAILURE_CODE);
+            assert_eq!(failure.kind(), IndexReplayFailureKind::Permanent);
+        }
+        other => panic!("unexpected reconciliation failure: {other:?}"),
+    }
+
+    let inspection = database.connection().await?;
+    let failed = read_job(&inspection, tenant_id, "failed").await?;
+    assert_eq!(failed.state, "failed");
+    assert_eq!(failed.attempt_count, 1);
+    assert_eq!(failed.completed_passes, 0);
+    assert_eq!(failed.pages_processed, 1);
+    assert_eq!(failed.source_cursor, json!({ "offset": 1 }));
+    assert_eq!(failed.last_error_code.as_deref(), Some(PAGE_FAILURE_CODE));
+    assert_eq!(
+        failed.last_error_details,
+        Some(json!({
+            "contract": FAILURE_CONTRACT,
+            "dependency_code": MUTATION_FAILURE_CODE,
+            "retryable": false,
+        }))
+    );
+    assert_eq!(
+        failed
+            .last_error_details
+            .as_ref()
+            .and_then(serde_json::Value::as_object)
+            .expect("failure details must be an object")
+            .len(),
+        3
+    );
+    assert!(failed.lease_released);
+    assert!(failed.completed);
+    assert_eq!(count(&inspection, "index_jobs").await?, 1);
+    assert_eq!(count(&inspection, "index_entities").await?, 1);
+    assert_eq!(count(&inspection, "index_inbox").await?, 1);
+
+    assert_eq!(
+        failed_runner
+            .request_cancel(tenant_id, failed.job_id)
+            .await?,
+        IndexReconciliationCancelOutcome::AlreadyTerminal(
+            IndexReconciliationTerminalState::Failed
+        )
+    );
+
+    let recovery = runner(
+        database.connection().await?,
+        FailedProgressSource::RecoverSecondPage,
+    )
+    .run(request(tenant_id, "failed-progress-worker-b"))
+    .await?;
+    let recovery_job_id = recovery.job_id().expect("recovery job id");
+    assert_ne!(recovery_job_id, failed.job_id);
+    assert_eq!(recovery.status(), IndexReconciliationRunStatus::Complete);
+    assert_eq!(recovery.attempt_count(), Some(1));
+    assert_eq!(recovery.pages_processed(), 2);
+    assert_eq!(recovery.passes_completed(), 1);
+    assert_eq!(recovery.heartbeat_count(), 1);
+    assert_eq!(recovery.mutation_count(), 2);
+    assert_eq!(recovery.applied_count(), 1);
+    assert_eq!(recovery.duplicate_count(), 1);
+    assert_eq!(recovery.stale_count(), 0);
+
+    let succeeded = read_job(&inspection, tenant_id, "succeeded").await?;
+    assert_eq!(succeeded.job_id, recovery_job_id);
+    assert_eq!(succeeded.state, "succeeded");
+    assert_eq!(succeeded.attempt_count, 1);
+    assert_eq!(succeeded.completed_passes, 1);
+    assert_eq!(succeeded.pages_processed, 2);
+    assert_eq!(succeeded.source_cursor, json!(null));
+    assert_eq!(succeeded.last_error_code, None);
+    assert_eq!(succeeded.last_error_details, None);
+    assert!(succeeded.lease_released);
+    assert!(succeeded.completed);
+    assert_eq!(count(&inspection, "index_jobs").await?, 2);
+    assert_eq!(count(&inspection, "index_entities").await?, 2);
+    assert_eq!(count(&inspection, "index_inbox").await?, 2);
+
+    let already_complete = runner(
+        database.connection().await?,
+        FailedProgressSource::RecoverSecondPage,
+    )
+    .run(request(tenant_id, "failed-progress-worker-c"))
+    .await?;
+    assert_eq!(
+        already_complete.status(),
+        IndexReconciliationRunStatus::AlreadyComplete
+    );
+    assert_eq!(already_complete.job_id(), Some(recovery_job_id));
+    assert_eq!(already_complete.attempt_count(), None);
+    assert_eq!(already_complete.pages_processed(), 0);
+    assert_eq!(already_complete.passes_completed(), 1);
+
+    database.cleanup().await
+}

--- a/scripts/verify/verify-index-reconciliation-failed-progress-recovery-harness.mjs
+++ b/scripts/verify/verify-index-reconciliation-failed-progress-recovery-harness.mjs
@@ -1,0 +1,118 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const files = {
+  target:
+    "crates/rustok-index/tests/source_reconciliation_failed_progress_recovery_postgres_test.rs",
+  source:
+    "crates/rustok-index/tests/reconciliation_failed_progress_recovery/source.rs",
+  runner:
+    "crates/rustok-index/tests/reconciliation_failed_progress_recovery/runner.rs",
+  evidence:
+    "crates/rustok-index/tests/reconciliation_failed_progress_recovery/evidence.rs",
+  database:
+    "crates/rustok-index/tests/reconciliation_failed_progress_recovery/database.rs",
+  docs:
+    "crates/rustok-index/docs/m6-reconciliation-failed-progress-recovery-postgres-harness.md",
+};
+
+const read = (name) => {
+  const relative = files[name];
+  const absolute = path.join(root, relative);
+  if (!fs.existsSync(absolute)) {
+    throw new Error(`missing reconciliation failed progress recovery file: ${relative}`);
+  }
+  return fs.readFileSync(absolute, "utf8");
+};
+
+const requireMarkers = (name, markers) => {
+  const content = read(name);
+  for (const marker of markers) {
+    if (!content.includes(marker)) {
+      throw new Error(`${files[name]} is missing required marker: ${marker}`);
+    }
+  }
+};
+
+const forbidMarkers = (name, markers) => {
+  const content = read(name);
+  for (const marker of markers) {
+    if (content.includes(marker)) {
+      throw new Error(`${files[name]} contains forbidden marker: ${marker}`);
+    }
+  }
+};
+
+requireMarkers("target", [
+  "failed_second_page_preserves_progress_and_recovers_by_duplicate_redelivery",
+  "IndexReconciliationRunError::MutationFailed",
+  "IndexReplayFailureKind::Permanent",
+  'const MUTATION_FAILURE_CODE: &str = "mutation_rejected"',
+  'const PAGE_FAILURE_CODE: &str = "index.reconciliation_page_failed"',
+  'const FAILURE_CONTRACT: &str = "index_reconciliation_run_failure_v1"',
+  "failed.pages_processed, 1",
+  'failed.source_cursor, json!({ "offset": 1 })',
+  "IndexReconciliationTerminalState::Failed",
+  "assert_ne!(recovery_job_id, failed.job_id)",
+  "recovery.heartbeat_count(), 1",
+  "recovery.applied_count(), 1",
+  "recovery.duplicate_count(), 1",
+  "recovery.stale_count(), 0",
+  "IndexReconciliationRunStatus::AlreadyComplete",
+  'count(&inspection, "index_jobs")',
+  'count(&inspection, "index_entities")',
+  'count(&inspection, "index_inbox")',
+]);
+
+requireMarkers("source", [
+  "FailSecondPage",
+  "RecoverSecondPage",
+  'IndexSourceCursor::new(json!({ "offset": 1 }))',
+  "valid_mutation(request.tenant_id(), 601, 13_601)",
+  "invalid_mutation(request.tenant_id(), 602, 13_602)",
+  "valid_mutation(request.tenant_id(), 602, 13_602)",
+  "fields: BTreeMap::new()",
+  'FieldName::new("id")',
+  "source_version: 1",
+]);
+
+requireMarkers("runner", [
+  "failed-progress-recovery-primary",
+  "PostgresIndexReconciliationRunner::new",
+  "Duration::from_secs(3_600)",
+  "        4,",
+  "        1,",
+]);
+
+requireMarkers("evidence", [
+  "cursor->'source_cursor' AS source_cursor",
+  "last_error_code",
+  "last_error_details",
+  "lease_released",
+  "completed_at IS NOT NULL",
+  "ORDER BY created_at DESC LIMIT 1",
+]);
+
+requireMarkers("database", [
+  "RUSTOK_INDEX_TEST_DATABASE_URL",
+  "CREATE SCHEMA",
+  "IndexModule.migrations()",
+  "persist_schema",
+  "DROP SCHEMA IF EXISTS",
+]);
+
+requireMarkers("docs", [
+  "Status: executable target retained, not run.",
+  "previous safe page boundary",
+  "exact three-field JSON",
+  "one duplicate and one newly applied mutation",
+  "No sleep, polling delay, or elapsed-time race is used.",
+  "The canonical M6 reconciliation and drift-repair item therefore remains open.",
+]);
+
+forbidMarkers("target", ["tokio::time::sleep", "std::thread::sleep"]);
+forbidMarkers("source", ["tokio::time::sleep", "std::thread::sleep"]);
+
+console.log("Index reconciliation failed progress recovery harness markers verified.");


### PR DESCRIPTION
## Summary

- add an environment-gated PostgreSQL integration target for recovery after reconciliation fails on page two with page-one progress already durable
- apply one valid first-page mutation and persist cursor `{ "offset": 1 }`
- fail the second page through the canonical `IndexReconciliationRunError::MutationFailed` path with permanent `mutation_rejected`
- require the failed attempt to retain the previous safe cursor boundary, one entity, and one inbox row
- require exact bounded `index_reconciliation_run_failure_v1` diagnostics and terminal cancellation semantics
- start a new recovery job from the initial source cursor
- redeliver the stable first-page event as a duplicate and apply a corrected second-page mutation
- require final `AlreadyComplete` behavior without additional processing
- add focused documentation and a standalone fail-closed verifier

## Failed attempt

The fixture source owns two pages with page size one.

Page one returns one valid mutation and cursor `{ "offset": 1 }`. The canonical reconciliation runner must apply the mutation, persist one entity and one inbox row, and publish durable progress with:

- `completed_passes = 0`
- `pages_processed = 1`
- source cursor `{ "offset": 1 }`

With `heartbeat_every_pages = 1`, the runner heartbeats before requesting page two.

Page two remains inside the exact tenant/schema scope but omits the required `id` field. Source-page validation succeeds; full mutation validation in `PostgresMutationStore` must return:

- `IndexReconciliationRunError::MutationFailed`
- position 0
- dependency code `mutation_rejected`
- `IndexReplayFailureKind::Permanent`

## Durable failure evidence

Attempt one must terminalize as one failed job while retaining the previous safe page boundary:

- state `failed`
- attempt count 1
- `completed_passes = 0`
- `pages_processed = 1`
- source cursor `{ "offset": 1 }`
- cleared lease owner and expiry
- non-null completion timestamp

The exact diagnostic is:

```json
{
  "contract": "index_reconciliation_run_failure_v1",
  "dependency_code": "mutation_rejected",
  "retryable": false
}
```

The object must contain exactly three fields. PostgreSQL must retain one job, one entity, and one inbox row. The rejected second-page mutation must produce no partial entity or inbox write.

A later exact-tenant cancellation request must return `AlreadyTerminal(Failed)`.

## Duplicate-safe recovery

Failed reconciliation jobs are terminal and excluded from active acquisition under the current runner. A new explicit invocation therefore creates another job and starts from the initial source cursor.

The recovery source returns:

1. the same first-page event UUID and source version;
2. a corrected valid second-page mutation using the same second-page event UUID that never reached mutation storage during the failed run.

Recovery must:

- use a different job UUID
- complete as attempt 1
- process two pages and one pass
- execute one page-boundary heartbeat
- report two mutations
- report one duplicate and one newly applied mutation
- report zero stale mutations

Final durable evidence requires one failed job plus one succeeded job, exactly two entities, and exactly two inbox rows. The succeeded cursor must contain one completed pass, two processed pages, and a null source cursor, with no failure diagnostic.

A later invocation must return `AlreadyComplete` for the succeeded recovery job without processing another page.

## PostgreSQL isolation

The target reads `RUSTOK_INDEX_TEST_DATABASE_URL`, with PostgreSQL `DATABASE_URL` as a fallback. Without a PostgreSQL URL it reports a skip and succeeds.

Each invocation creates a unique schema, creates the tenant owner fixture, applies every real `IndexModule` migration, persists one active schema, uses one-connection pools with schema-local `search_path`, reads durable evidence, and drops the schema.

No sleep, polling, or elapsed-time race is used.

## Scope boundaries

- no production code, migration, reconciliation SQL/state-machine, source/cursor contract, mutation identity, schema, diagnostic, or public API change
- no automatic retry, backoff, scheduling, or attempt exhaustion
- no failed-scope dead-letter admission or authorized requeue
- no cancellation, lease-loss, heartbeat-takeover, or restart race
- no source-call timeout or pending-future preemption
- no digest comparison, orphan cleanup, targeted/full/shadow repair, locale/partition dimensions, or complete drift repair

The canonical M6 reconciliation and drift-repair item remains open.

## Compatibility

- nine new test, documentation, and verifier files; final diff is add-only
- no changed-file overlap with open Index PRs #2636, #2639, #2642, #2644, #2648, #2649, #2652, #2656, #2660, #2663, #2667, #2679, #2684, #2689, #2693, #2698, or #2703
- no implementation-plan edit while PR #2636 owns the canonical plan
- merge base and current `main`: `ee474ca21f42fff394f8b1346fa2cdd3f4c13965`

## Validation

Not run per maintainer instruction:

- Cargo formatting/checks/tests/Clippy
- JavaScript verifier
- PostgreSQL integration target
- CI workflows

Suggested maintainer commands:

```bash
RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
  cargo test -p rustok-index \
  --test source_reconciliation_failed_progress_recovery_postgres_test \
  -- --nocapture

cargo check -p rustok-index --all-targets

node scripts/verify/verify-index-reconciliation-failed-progress-recovery-harness.mjs
```

## Branch state

Branch: `agent/index-m6-reconciliation-failed-progress-recovery-harness-20260731`

The connector produced nine sequential commits, one per new file. Squash merge is recommended after maintainer validation.