### PR TITLE
feat(blog): wire GraphQL Comments port injection

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-comments-graphql-port-injection.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-graphql-port-injection.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "module": "blog",
+  "surface": "comments_graphql_port_injection",
+  "role": "consumer",
+  "provider": "comments",
+  "status": "source_verified_no_compile",
+  "compile_policy": "not_run_by_request",
+  "runtime_status": "not_run",
+  "source_contract": {
+    "module_manifest": "crates/rustok-blog/rustok-module.toml",
+    "graphql_module": "crates/rustok-blog/src/graphql/mod.rs",
+    "runtime_data": "crates/rustok-blog/src/graphql/runtime_data.rs",
+    "comment_reads": "crates/rustok-blog/src/graphql/types.rs",
+    "comment_mutation": "crates/rustok-blog/src/graphql/mutation.rs",
+    "consumer_service": "crates/rustok-blog/src/services/comment.rs",
+    "consumer_matrix": "crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json"
+  },
+  "profiles": {
+    "source_verified": [
+      "in_process_fallback",
+      "host_injected_port_selection"
+    ],
+    "pending": [
+      "remote_transport_implementation"
+    ]
+  },
+  "composition": {
+    "host_inputs": "rustok_api::graphql::GraphqlRuntimeInputs",
+    "manifest_factory": "graphql::attach_schema_data",
+    "schema_data": "BlogGraphqlRuntimeData",
+    "shared_value": "Arc<dyn CommentsThreadPort>",
+    "lookup": "GraphqlRuntimeInputs::shared_get",
+    "selector": "BlogGraphqlRuntimeData::comment_service",
+    "injected_constructor": "CommentService::with_comments_thread_port",
+    "fallback_constructor": "CommentService::new",
+    "graphql_operations": [
+      "public_comments",
+      "moderation_comments",
+      "moderate_comment"
+    ]
+  },
+  "harness": {
+    "status": "executable_no_run",
+    "runtime_status": "not_run",
+    "source": "crates/rustok-blog/src/graphql/runtime_data.rs",
+    "test": "graphql::runtime_data::tests::graphql_runtime_data_exposes_comments_port_selection",
+    "command": "cargo test -p rustok-blog --lib graphql::runtime_data::tests::graphql_runtime_data_exposes_comments_port_selection -- --exact"
+  },
+  "registration": {
+    "standalone_verifier": "scripts/verify/verify-blog-comments-graphql-port-injection.mjs",
+    "focused_fixture": "scripts/verify/verify-blog-comments-graphql-port-injection.test.mjs",
+    "blog_fba_package_chain": "pending"
+  },
+  "non_claims": [
+    "no remote network transport is implemented",
+    "no Rust or JavaScript test was run",
+    "no compile, database, browser, workflow, CI, or production result is recorded",
+    "storefront native SSR and admin native SSR composition remain separate pending slices"
+  ]
+}

--- a/crates/rustok-blog/contracts/evidence/blog-comments-graphql-port-injection.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-graphql-port-injection.json
@@ -14,7 +14,9 @@
     "comment_reads": "crates/rustok-blog/src/graphql/types.rs",
     "comment_mutation": "crates/rustok-blog/src/graphql/mutation.rs",
     "consumer_service": "crates/rustok-blog/src/services/comment.rs",
-    "consumer_matrix": "crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json"
+    "consumer_matrix": "crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json",
+    "server_codegen": "apps/server/build.rs",
+    "server_schema": "apps/server/src/graphql/schema.rs"
   },
   "profiles": {
     "source_verified": [
@@ -28,6 +30,7 @@
   "composition": {
     "host_inputs": "rustok_api::graphql::GraphqlRuntimeInputs",
     "manifest_factory": "graphql::attach_schema_data",
+    "schema_attachment": "schema_codegen::attach_module_graphql_data",
     "schema_data": "BlogGraphqlRuntimeData",
     "shared_value": "Arc<dyn CommentsThreadPort>",
     "lookup": "GraphqlRuntimeInputs::shared_get",

--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -123,8 +123,30 @@ coverage. The retained compile-only harness is
 `controllers::tests::blog_http_runtime_exposes_comments_port_selection`, with
 suggested command
 `cargo test -p rustok-blog --lib controllers::tests::blog_http_runtime_exposes_comments_port_selection -- --exact`.
-HTTP moderation host selection is source-locked; GraphQL and native SSR
-composition plus the remote network transport remains pending.
+HTTP moderation host selection is source-locked; native SSR composition plus the
+remote network transport remains pending.
+
+GraphQL Comments composition is manifest-attached. The Blog package declares
+`runtime_data_factory = "graphql::attach_schema_data"`; generated server code
+passes `GraphqlRuntimeInputs` through
+`schema_codegen::attach_module_graphql_data`, and `BlogGraphqlRuntimeData` reads an
+optional `Arc<dyn CommentsThreadPort>` with `GraphqlRuntimeInputs::shared_get`.
+Its single `BlogGraphqlRuntimeData::comment_service` selector chooses
+`CommentService::with_comments_thread_port` or the existing in-process
+`CommentService::new` fallback. Public comments, moderation comments, and the
+moderation mutation all consume that schema data rather than constructing a
+provider in resolver source. Schema-v1 evidence lives at
+`crates/rustok-blog/contracts/evidence/blog-comments-graphql-port-injection.json`,
+guarded by `scripts/verify/verify-blog-comments-graphql-port-injection.mjs` and
+focused fixture
+`scripts/verify/verify-blog-comments-graphql-port-injection.test.mjs`. The retained
+compile-only harness is
+`graphql::runtime_data::tests::graphql_runtime_data_exposes_comments_port_selection`,
+with suggested command
+`cargo test -p rustok-blog --lib graphql::runtime_data::tests::graphql_runtime_data_exposes_comments_port_selection -- --exact`.
+GraphQL Comments host selection is source-locked. Blog FBA package-chain
+registration remains pending, storefront/admin native SSR composition remains
+pending, and the remote network transport remains pending.
 
 Comments lifecycle projection into Blog-owned `comment_count` is a Blog consumer
 boundary. `BlogCommentProjectionHandler` accepts only `comment.created` and
@@ -607,6 +629,22 @@ composition is now a required sub-contract of the existing first-class Comments
 port leaf rather than a parallel duplicate leaf. Runtime source, evidence, remote
 transport status, and all execution claims remain unchanged.
 
+The continuation audit at `8853b4431536ceb86dbe1d5be2090977105878af`
+found that GraphQL public reads, moderation reads, and moderation mutation still
+constructed `CommentService::new` directly. Blog also had no manifest runtime-data
+factory, so host shared values could not enter the Blog GraphQL schema even though
+the transport-neutral service constructor and generic server attachment mechanism
+already existed.
+
+Slice 61 adds manifest-declared `graphql::attach_schema_data`, materializes
+`BlogGraphqlRuntimeData` from `GraphqlRuntimeInputs`, and centralizes injected or
+in-process selection in `BlogGraphqlRuntimeData::comment_service`. All three
+GraphQL Comments operations consume that schema data. New schema-v1 evidence, a
+standalone verifier, twelve focused positive/negative cases, and a compile-only
+factory/selector harness retain the complete host→generated-schema→resolver path.
+Blog FBA package-chain integration, native SSR wiring, the remote network
+transport, and all execution remain pending.
+
 ## FFA/FBA status
 
 - FFA status: `in_progress`.
@@ -620,9 +658,9 @@ transport status, and all execution claims remain unchanged.
   plus aggregate/consumer bindings for admin, storefront, Comments port boundary,
   Comments event projection, category Search reindex, GraphQL rate limiting,
   GraphQL richtext, AI richtext, offline backfill, Forum ownership, and runtime
-  order. The existing Comments port leaf now requires the HTTP composition
-  verifier and focused fixture through aggregate-locked imports; package order is
-  unchanged.
+  order. The existing Comments port leaf requires the HTTP composition verifier
+  and focused fixture through aggregate-locked imports. The standalone GraphQL
+  Comments composition guard remains outside registry package order in Slice 61.
 - Comments consumer port boundary: Blog-owned `source_verified_no_compile` for
   the in-process profile; evidence schema v3, all seven operations, approved public
   read, typed richtext projection, two-second deadlines, write idempotency, active
@@ -632,12 +670,16 @@ transport status, and all execution claims remain unchanged.
   host-provided port through `BlogHttpRuntime::comment_service` with an in-process
   fallback; schema-v1 evidence, standalone verification, all focused HTTP
   negatives, and both parent imports are retained inside the registered Comments
-  port gate. Typed storefront comments availability is retained across
+  port gate. GraphQL public reads, moderation reads, and moderation mutation now
+  select the same optional host port through manifest-attached
+  `BlogGraphqlRuntimeData`; schema-v1 evidence, the generated schema attachment,
+  twelve focused cases, and a compile-only selector harness retain that standalone
+  source contract. Typed storefront comments availability remains across
   GraphQL/native DTOs and Leptos UI; only external-service and timeout errors
-  degrade, while other errors propagate. GraphQL and native SSR composition, the
-  remote network transport, remote adapter runtime parity, cached snapshot,
-  comment-form fallback, browser/runtime evidence, and broader degraded UI modes
-  remain planned or pending.
+  degrade, while other errors propagate. GraphQL package-chain integration,
+  storefront/admin native SSR composition, the remote network transport, remote
+  adapter runtime parity, cached snapshot, comment-form fallback, browser/runtime
+  evidence, and broader degraded UI modes remain planned or pending.
 - Comments event projection: Blog-owned `source_verified_no_compile`; evidence
   schema v4, shared classifier/counter/retry-decision helpers, `executable_no_run`
   source harness, deterministic PostgreSQL retry-limit target, module-registration,
@@ -685,14 +727,21 @@ transport status, and all execution claims remain unchanged.
 - `crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-consumer-runtime-order-smoke.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-http-port-injection.json`
+- `crates/rustok-blog/contracts/evidence/blog-comments-graphql-port-injection.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-duplicate-delivery-race.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-dispatcher-duplicate-delivery.json`
+- `crates/rustok-blog/rustok-module.toml`
 - `crates/rustok-blog/src/lib.rs`
 - `crates/rustok-blog/src/controllers/mod.rs`
 - `crates/rustok-blog/src/controllers/comments.rs`
 - `crates/rustok-blog/src/services/comment.rs`
+- `crates/rustok-blog/src/graphql/mod.rs`
+- `crates/rustok-blog/src/graphql/runtime_data.rs`
 - `crates/rustok-blog/src/graphql/types.rs`
+- `crates/rustok-blog/src/graphql/mutation.rs`
+- `apps/server/build.rs`
+- `apps/server/src/graphql/schema.rs`
 - `crates/rustok-blog/storefront/src/model.rs`
 - `crates/rustok-blog/storefront/src/transport/graphql_adapter.rs`
 - `crates/rustok-blog/storefront/src/transport/native_server_adapter.rs`
@@ -720,6 +769,8 @@ transport status, and all execution claims remain unchanged.
 - `scripts/verify/verify-blog-comments-port-boundary.test.mjs`
 - `scripts/verify/verify-blog-comments-http-port-injection.mjs`
 - `scripts/verify/verify-blog-comments-http-port-injection.test.mjs`
+- `scripts/verify/verify-blog-comments-graphql-port-injection.mjs`
+- `scripts/verify/verify-blog-comments-graphql-port-injection.test.mjs`
 - `scripts/verify/verify-blog-comments-event-projection.mjs`
 - `scripts/verify/verify-blog-comments-event-projection.test.mjs`
 - `scripts/verify/verify-blog-comments-duplicate-delivery-race.mjs`
@@ -913,6 +964,13 @@ transport status, and all execution claims remain unchanged.
     already registered `comments-port-boundary` verify/test leaf, added aggregate
     regressions for both required imports, preserved registry schema v13 and exact
     package order, and changed no runtime source or execution status.
+61. Added manifest-attached `BlogGraphqlRuntimeData`, carried the optional
+    host-owned `CommentsThreadPort` through generated schema data, routed public
+    and moderation reads plus moderation mutation through one injected/in-process
+    selector, retained the full host attachment path in schema-v1 evidence,
+    standalone verification, twelve focused cases, and a compile-only harness,
+    and kept package registration, native SSR wiring, remote transport, and all
+    execution pending.
 
 ## Next results
 
@@ -930,9 +988,10 @@ transport status, and all execution claims remain unchanged.
    controller handoff, focused verifier, then Redis-backed host requests with a
    real HTTP `Retry-After` matching GraphQL `retryAfter`.
 5. **Close comments runtime evidence.** Run the registered Comments port boundary
-   verifier and self-test, which now include the standalone HTTP composition
-   verifier and all focused HTTP negatives, plus the compile-only injection-signature
-   and HTTP selection harnesses, shared consumer runtime-order verifier, Blog
+   verifier and self-test, which include the standalone HTTP composition verifier
+   and all focused HTTP negatives, plus the standalone GraphQL composition verifier
+   and focused fixture, the compile-only injection-signature, HTTP selection, and
+   GraphQL runtime-data harnesses, shared consumer runtime-order verifier, Blog
    projection classifier and deterministic retry-policy harness, module
    registration/routing harness, the filtered
    `event_dispatcher_routes_registered_handler_and_commits_projection`,
@@ -954,8 +1013,9 @@ transport status, and all execution claims remain unchanged.
    duplicate replay, dispatcher delivery output, four-connection convergence,
    both child process exits, the written duplicate, delete-before-create,
    missing-post replay, outbox rollback/retry, and same-process/new-connection
-   assertions; then wire GraphQL, storefront native SSR, and admin native SSR to
-   the host-owned Comments port, implement the remote network transport through
+   assertions; then register the GraphQL source guard in the Blog FBA package chain,
+   wire storefront native SSR and admin native SSR to the host-owned Comments port,
+   implement the remote network transport through
    `CommentService::with_comments_thread_port`, and retain all-seven-operation
    adapter parity, naturally contended PostgreSQL retry-frequency evidence, full
    server-host restart recovery, browser parity for typed unavailable/timeout
@@ -979,6 +1039,9 @@ should run the relevant subset, including:
 - `node scripts/verify/verify-blog-comments-http-port-injection.mjs`
 - `node --test scripts/verify/verify-blog-comments-http-port-injection.test.mjs`
 - `cargo test -p rustok-blog --lib controllers::tests::blog_http_runtime_exposes_comments_port_selection -- --exact`
+- `node scripts/verify/verify-blog-comments-graphql-port-injection.mjs`
+- `node --test scripts/verify/verify-blog-comments-graphql-port-injection.test.mjs`
+- `cargo test -p rustok-blog --lib graphql::runtime_data::tests::graphql_runtime_data_exposes_comments_port_selection -- --exact`
 - `npm run verify:blog:comments-event-projection`
 - `npm run test:verify:blog:comments-event-projection`
 - `npm run verify:blog:comments-duplicate-delivery-race`

--- a/crates/rustok-blog/rustok-module.toml
+++ b/crates/rustok-blog/rustok-module.toml
@@ -28,6 +28,7 @@ entry_type = "BlogModule"
 [provides.graphql]
 query = "graphql::BlogQuery"
 mutation = "graphql::BlogMutation"
+runtime_data_factory = "graphql::attach_schema_data"
 
 [provides.http]
 axum_router = "controllers::axum_router"

--- a/crates/rustok-blog/src/graphql/mod.rs
+++ b/crates/rustok-blog/src/graphql/mod.rs
@@ -1,6 +1,7 @@
 mod mutation;
 mod query;
 mod rate_limit;
+mod runtime_data;
 mod types;
 
 pub use mutation::BlogMutation;
@@ -9,4 +10,5 @@ pub use rate_limit::{
     BlogGraphqlRateLimitError, BlogGraphqlRateLimitExceeded, BlogGraphqlRateLimitPolicy,
     BlogGraphqlRateLimiter, BlogGraphqlRateLimiterHandle,
 };
+pub use runtime_data::{BlogGraphqlRuntimeData, attach_schema_data};
 pub use types::*;

--- a/crates/rustok-blog/src/graphql/mutation.rs
+++ b/crates/rustok-blog/src/graphql/mutation.rs
@@ -9,8 +9,9 @@ use rustok_outbox::TransactionalEventBus;
 use sea_orm::DatabaseConnection;
 use uuid::Uuid;
 
-use crate::{CommentService, ModerateCommentInput, PostService};
+use crate::{ModerateCommentInput, PostService};
 
+use super::runtime_data::BlogGraphqlRuntimeData;
 use super::types::*;
 
 const MODULE_SLUG: &str = "blog";
@@ -233,6 +234,7 @@ impl BlogMutation {
         require_module_enabled(ctx, MODULE_SLUG).await?;
         let db = ctx.data::<DatabaseConnection>()?;
         let event_bus = ctx.data::<TransactionalEventBus>()?;
+        let runtime = ctx.data::<BlogGraphqlRuntimeData>()?;
         let auth = require_blog_permission(
             ctx,
             &[Permission::BLOG_POSTS_MANAGE],
@@ -247,7 +249,8 @@ impl BlogMutation {
             .map(ToOwned::to_owned)
             .unwrap_or_else(|| tenant.default_locale.clone());
 
-        CommentService::new(db.clone(), event_bus.clone())
+        runtime
+            .comment_service(db.clone(), event_bus.clone())
             .moderate_comment(
                 tenant_id,
                 id,

--- a/crates/rustok-blog/src/graphql/runtime_data.rs
+++ b/crates/rustok-blog/src/graphql/runtime_data.rs
@@ -1,0 +1,58 @@
+use std::sync::Arc;
+
+use rustok_api::graphql::GraphqlRuntimeInputs;
+use rustok_comments::CommentsThreadPort;
+use rustok_outbox::TransactionalEventBus;
+use sea_orm::DatabaseConnection;
+
+use crate::CommentService;
+
+/// Manifest-attached Blog GraphQL runtime capabilities.
+///
+/// A host may publish a transport-neutral Comments port through
+/// `HostRuntimeContext`. Its absence preserves the existing in-process Blog
+/// compatibility profile.
+#[derive(Clone, Default)]
+pub struct BlogGraphqlRuntimeData {
+    comments_thread_port: Option<Arc<dyn CommentsThreadPort>>,
+}
+
+pub fn attach_schema_data(
+    inputs: &GraphqlRuntimeInputs,
+) -> Result<BlogGraphqlRuntimeData, String> {
+    Ok(BlogGraphqlRuntimeData {
+        comments_thread_port: inputs.shared_get::<Arc<dyn CommentsThreadPort>>(),
+    })
+}
+
+impl BlogGraphqlRuntimeData {
+    pub(crate) fn comment_service(
+        &self,
+        db: DatabaseConnection,
+        event_bus: TransactionalEventBus,
+    ) -> CommentService {
+        match self.comments_thread_port.clone() {
+            Some(comments_thread_port) => {
+                CommentService::with_comments_thread_port(db, comments_thread_port)
+            }
+            None => CommentService::new(db, event_bus),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn graphql_runtime_data_exposes_comments_port_selection() {
+        let factory: fn(&GraphqlRuntimeInputs) -> Result<BlogGraphqlRuntimeData, String> =
+            attach_schema_data;
+        let selector: fn(
+            &BlogGraphqlRuntimeData,
+            DatabaseConnection,
+            TransactionalEventBus,
+        ) -> CommentService = BlogGraphqlRuntimeData::comment_service;
+        let _ = (factory, selector);
+    }
+}

--- a/crates/rustok-blog/src/graphql/types.rs
+++ b/crates/rustok-blog/src/graphql/types.rs
@@ -10,11 +10,13 @@ use sea_orm::DatabaseConnection;
 use uuid::Uuid;
 
 use crate::{
-    BlogError, BlogPostStatus, CommentListItem as DomainCommentListItem, CommentService,
+    BlogError, BlogPostStatus, CommentListItem as DomainCommentListItem,
     CreatePostInput as DomainCreatePostInput, ListCommentsFilter,
     ModerateCommentStatus as DomainModerateCommentStatus, PostResponse, PostSummary,
     UpdatePostInput as DomainUpdatePostInput,
 };
+
+use super::runtime_data::BlogGraphqlRuntimeData;
 
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]
 #[graphql(name = "BlogPostStatus", rename_items = "SCREAMING_SNAKE_CASE")]
@@ -150,26 +152,25 @@ impl GqlPost {
     ) -> Result<GqlPublicCommentList> {
         let db = ctx.data::<DatabaseConnection>()?;
         let event_bus = ctx.data::<TransactionalEventBus>()?;
+        let runtime = ctx.data::<BlogGraphqlRuntimeData>()?;
         let request_tenant = ctx.data::<TenantContext>()?;
         let requested_locale = comment_locale(locale.as_deref(), &self.effective_locale);
         let fallback_locale = post_comment_fallback_locale(request_tenant, self);
+        let service = runtime.comment_service(db.clone(), event_bus.clone());
 
-        let (items, total, availability) = match CommentService::new(
-            db.clone(),
-            event_bus.clone(),
-        )
-        .list_for_post_with_locale_fallback(
-            self.tenant_id,
-            SecurityContext::public_read(),
-            self.id,
-            ListCommentsFilter {
-                locale: Some(requested_locale),
-                page: page.unwrap_or(1).max(1),
-                per_page: per_page.unwrap_or(20).clamp(1, 100),
-            },
-            Some(fallback_locale),
-        )
-        .await
+        let (items, total, availability) = match service
+            .list_for_post_with_locale_fallback(
+                self.tenant_id,
+                SecurityContext::public_read(),
+                self.id,
+                ListCommentsFilter {
+                    locale: Some(requested_locale),
+                    page: page.unwrap_or(1).max(1),
+                    per_page: per_page.unwrap_or(20).clamp(1, 100),
+                },
+                Some(fallback_locale),
+            )
+            .await
         {
             Ok((items, total)) => (items, total, GqlBlogCommentsAvailability::Available),
             Err(error) => {
@@ -199,11 +200,13 @@ impl GqlPost {
         let auth = require_comment_moderator(ctx)?;
         let db = ctx.data::<DatabaseConnection>()?;
         let event_bus = ctx.data::<TransactionalEventBus>()?;
+        let runtime = ctx.data::<BlogGraphqlRuntimeData>()?;
         let request_tenant = ctx.data::<TenantContext>()?;
         ensure_comment_tenant_binding(request_tenant, &auth, self.tenant_id)?;
         let requested_locale = comment_locale(locale.as_deref(), &self.effective_locale);
+        let service = runtime.comment_service(db.clone(), event_bus.clone());
 
-        let (items, total) = CommentService::new(db.clone(), event_bus.clone())
+        let (items, total) = service
             .list_for_post_with_locale_fallback(
                 self.tenant_id,
                 SecurityContext::system(),

--- a/scripts/verify/verify-blog-comments-graphql-port-injection.mjs
+++ b/scripts/verify/verify-blog-comments-graphql-port-injection.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve('.');
+const failures = [];
+
+function repoPath(relativePath) {
+  return path.join(repoRoot, relativePath);
+}
+
+function read(relativePath) {
+  const target = repoPath(relativePath);
+  if (!existsSync(target)) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return '';
+  }
+  return readFileSync(target, 'utf8');
+}
+
+function json(relativePath) {
+  try {
+    return JSON.parse(read(relativePath));
+  } catch (error) {
+    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function requireMarker(source, marker, label) {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+}
+
+function requireNoMarker(source, marker, label) {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+}
+
+function countMarker(source, marker) {
+  return source.split(marker).length - 1;
+}
+
+function sameSet(actual, expected) {
+  return [...actual].sort().join('|') === [...expected].sort().join('|');
+}
+
+const evidencePath =
+  'crates/rustok-blog/contracts/evidence/blog-comments-graphql-port-injection.json';
+const manifestPath = 'crates/rustok-blog/rustok-module.toml';
+const graphqlModulePath = 'crates/rustok-blog/src/graphql/mod.rs';
+const runtimeDataPath = 'crates/rustok-blog/src/graphql/runtime_data.rs';
+const commentReadsPath = 'crates/rustok-blog/src/graphql/types.rs';
+const commentMutationPath = 'crates/rustok-blog/src/graphql/mutation.rs';
+const servicePath = 'crates/rustok-blog/src/services/comment.rs';
+const consumerMatrixPath =
+  'crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json';
+const planPath = 'crates/rustok-blog/docs/implementation-plan.md';
+const harnessTest =
+  'graphql::runtime_data::tests::graphql_runtime_data_exposes_comments_port_selection';
+const harnessCommand = `cargo test -p rustok-blog --lib ${harnessTest} -- --exact`;
+const expectedOperations = ['public_comments', 'moderation_comments', 'moderate_comment'];
+
+const evidence = json(evidencePath);
+const manifest = read(manifestPath);
+const graphqlModule = read(graphqlModulePath);
+const runtimeData = read(runtimeDataPath);
+const commentReads = read(commentReadsPath);
+const commentMutation = read(commentMutationPath);
+const service = read(servicePath);
+const plan = read(planPath);
+
+if (evidence) {
+  if (evidence.schema_version !== 1) failures.push(`${evidencePath}: schema_version drift`);
+  if (
+    evidence.module !== 'blog' ||
+    evidence.surface !== 'comments_graphql_port_injection' ||
+    evidence.role !== 'consumer' ||
+    evidence.provider !== 'comments'
+  ) failures.push(`${evidencePath}: identity drift`);
+  if (evidence.status !== 'source_verified_no_compile') {
+    failures.push(`${evidencePath}: status drift`);
+  }
+  if (
+    evidence.compile_policy !== 'not_run_by_request' ||
+    evidence.runtime_status !== 'not_run'
+  ) failures.push(`${evidencePath}: execution policy drift`);
+
+  const expectedSources = {
+    module_manifest: manifestPath,
+    graphql_module: graphqlModulePath,
+    runtime_data: runtimeDataPath,
+    comment_reads: commentReadsPath,
+    comment_mutation: commentMutationPath,
+    consumer_service: servicePath,
+    consumer_matrix: consumerMatrixPath,
+  };
+  for (const [key, expected] of Object.entries(expectedSources)) {
+    if (evidence.source_contract?.[key] !== expected) {
+      failures.push(`${evidencePath}: ${key} source path drift`);
+    }
+  }
+
+  if (
+    !sameSet(evidence.profiles?.source_verified ?? [], [
+      'in_process_fallback',
+      'host_injected_port_selection',
+    ])
+  ) failures.push(`${evidencePath}: source-verified profile drift`);
+  if (!sameSet(evidence.profiles?.pending ?? [], ['remote_transport_implementation'])) {
+    failures.push(`${evidencePath}: pending profile drift`);
+  }
+
+  const composition = evidence.composition ?? {};
+  if (
+    composition.host_inputs !== 'rustok_api::graphql::GraphqlRuntimeInputs' ||
+    composition.manifest_factory !== 'graphql::attach_schema_data' ||
+    composition.schema_data !== 'BlogGraphqlRuntimeData' ||
+    composition.shared_value !== 'Arc<dyn CommentsThreadPort>' ||
+    composition.lookup !== 'GraphqlRuntimeInputs::shared_get' ||
+    composition.selector !== 'BlogGraphqlRuntimeData::comment_service' ||
+    composition.injected_constructor !== 'CommentService::with_comments_thread_port' ||
+    composition.fallback_constructor !== 'CommentService::new' ||
+    !sameSet(composition.graphql_operations ?? [], expectedOperations)
+  ) failures.push(`${evidencePath}: composition drift`);
+
+  if (
+    evidence.harness?.status !== 'executable_no_run' ||
+    evidence.harness?.runtime_status !== 'not_run' ||
+    evidence.harness?.source !== runtimeDataPath ||
+    evidence.harness?.test !== harnessTest ||
+    evidence.harness?.command !== harnessCommand
+  ) failures.push(`${evidencePath}: harness drift`);
+
+  if (
+    evidence.registration?.standalone_verifier !==
+      'scripts/verify/verify-blog-comments-graphql-port-injection.mjs' ||
+    evidence.registration?.focused_fixture !==
+      'scripts/verify/verify-blog-comments-graphql-port-injection.test.mjs' ||
+    evidence.registration?.blog_fba_package_chain !== 'pending'
+  ) failures.push(`${evidencePath}: registration drift`);
+}
+
+requireMarker(
+  manifest,
+  'runtime_data_factory = "graphql::attach_schema_data"',
+  manifestPath,
+);
+for (const marker of [
+  'mod runtime_data;',
+  'pub use runtime_data::{BlogGraphqlRuntimeData, attach_schema_data};',
+]) requireMarker(graphqlModule, marker, graphqlModulePath);
+
+for (const marker of [
+  'use rustok_api::graphql::GraphqlRuntimeInputs;',
+  'use rustok_comments::CommentsThreadPort;',
+  'comments_thread_port: Option<Arc<dyn CommentsThreadPort>>',
+  'pub fn attach_schema_data(',
+  'inputs.shared_get::<Arc<dyn CommentsThreadPort>>()',
+  'pub(crate) fn comment_service(',
+  'match self.comments_thread_port.clone()',
+  'Some(comments_thread_port)',
+  'CommentService::with_comments_thread_port(db, comments_thread_port)',
+  'None => CommentService::new(db, event_bus)',
+  'fn graphql_runtime_data_exposes_comments_port_selection()',
+  'let factory: fn(&GraphqlRuntimeInputs) -> Result<BlogGraphqlRuntimeData, String>',
+  'BlogGraphqlRuntimeData::comment_service;',
+]) requireMarker(runtimeData, marker, runtimeDataPath);
+
+for (const marker of [
+  'use super::runtime_data::BlogGraphqlRuntimeData;',
+  'async fn public_comments(',
+  'async fn moderation_comments(',
+  'let service = runtime.comment_service(db.clone(), event_bus.clone());',
+]) requireMarker(commentReads, marker, commentReadsPath);
+if (countMarker(commentReads, 'ctx.data::<BlogGraphqlRuntimeData>()?;') !== 2) {
+  failures.push(`${commentReadsPath}: expected two GraphQL runtime-data lookups`);
+}
+if (countMarker(commentReads, 'runtime.comment_service(db.clone(), event_bus.clone())') !== 2) {
+  failures.push(`${commentReadsPath}: expected two runtime selector calls`);
+}
+
+for (const marker of [
+  'use super::runtime_data::BlogGraphqlRuntimeData;',
+  'async fn moderate_comment(',
+  'let runtime = ctx.data::<BlogGraphqlRuntimeData>()?;',
+  '.comment_service(db.clone(), event_bus.clone())',
+]) requireMarker(commentMutation, marker, commentMutationPath);
+
+for (const source of [commentReads, commentMutation]) {
+  requireNoMarker(source, 'CommentService::new(', 'GraphQL resolver source');
+  requireNoMarker(
+    source,
+    'CommentService::with_comments_thread_port(',
+    'GraphQL resolver source',
+  );
+}
+
+requireMarker(service, 'pub fn with_comments_thread_port(', servicePath);
+requireMarker(
+  service,
+  'comments_thread_port: Arc<dyn CommentsThreadPort>,',
+  servicePath,
+);
+
+for (const marker of [
+  'blog-comments-graphql-port-injection.json',
+  'verify-blog-comments-graphql-port-injection.mjs',
+  'verify-blog-comments-graphql-port-injection.test.mjs',
+  'BlogGraphqlRuntimeData',
+  'graphql::attach_schema_data',
+  'GraphQL Comments host selection is source-locked',
+  'Blog FBA package-chain registration remains pending',
+  'remote network transport remains pending',
+  'Slice 61',
+]) requireMarker(plan, marker, planPath);
+
+if (failures.length > 0) {
+  console.error('Blog GraphQL Comments port injection verification failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log('Blog GraphQL Comments manifest runtime-data and port selection source boundary is consistent');

--- a/scripts/verify/verify-blog-comments-graphql-port-injection.mjs
+++ b/scripts/verify/verify-blog-comments-graphql-port-injection.mjs
@@ -56,6 +56,8 @@ const commentMutationPath = 'crates/rustok-blog/src/graphql/mutation.rs';
 const servicePath = 'crates/rustok-blog/src/services/comment.rs';
 const consumerMatrixPath =
   'crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json';
+const serverCodegenPath = 'apps/server/build.rs';
+const serverSchemaPath = 'apps/server/src/graphql/schema.rs';
 const planPath = 'crates/rustok-blog/docs/implementation-plan.md';
 const harnessTest =
   'graphql::runtime_data::tests::graphql_runtime_data_exposes_comments_port_selection';
@@ -69,6 +71,8 @@ const runtimeData = read(runtimeDataPath);
 const commentReads = read(commentReadsPath);
 const commentMutation = read(commentMutationPath);
 const service = read(servicePath);
+const serverCodegen = read(serverCodegenPath);
+const serverSchema = read(serverSchemaPath);
 const plan = read(planPath);
 
 if (evidence) {
@@ -95,6 +99,8 @@ if (evidence) {
     comment_mutation: commentMutationPath,
     consumer_service: servicePath,
     consumer_matrix: consumerMatrixPath,
+    server_codegen: serverCodegenPath,
+    server_schema: serverSchemaPath,
   };
   for (const [key, expected] of Object.entries(expectedSources)) {
     if (evidence.source_contract?.[key] !== expected) {
@@ -116,6 +122,7 @@ if (evidence) {
   if (
     composition.host_inputs !== 'rustok_api::graphql::GraphqlRuntimeInputs' ||
     composition.manifest_factory !== 'graphql::attach_schema_data' ||
+    composition.schema_attachment !== 'schema_codegen::attach_module_graphql_data' ||
     composition.schema_data !== 'BlogGraphqlRuntimeData' ||
     composition.shared_value !== 'Arc<dyn CommentsThreadPort>' ||
     composition.lookup !== 'GraphqlRuntimeInputs::shared_get' ||
@@ -151,6 +158,17 @@ for (const marker of [
   'mod runtime_data;',
   'pub use runtime_data::{BlogGraphqlRuntimeData, attach_schema_data};',
 ]) requireMarker(graphqlModule, marker, graphqlModulePath);
+
+for (const marker of [
+  'graphql_runtime_data_factory: Option<String>',
+  'graphql_runtime_data_factory_expr',
+  'builder = builder.data({factory}(inputs)?);',
+]) requireMarker(serverCodegen, marker, serverCodegenPath);
+requireMarker(
+  serverSchema,
+  'schema_codegen::attach_module_graphql_data(builder, &graphql_runtime_inputs)',
+  serverSchemaPath,
+);
 
 for (const marker of [
   'use rustok_api::graphql::GraphqlRuntimeInputs;',
@@ -210,6 +228,7 @@ for (const marker of [
   'verify-blog-comments-graphql-port-injection.test.mjs',
   'BlogGraphqlRuntimeData',
   'graphql::attach_schema_data',
+  'schema_codegen::attach_module_graphql_data',
   'GraphQL Comments host selection is source-locked',
   'Blog FBA package-chain registration remains pending',
   'remote network transport remains pending',

--- a/scripts/verify/verify-blog-comments-graphql-port-injection.test.mjs
+++ b/scripts/verify/verify-blog-comments-graphql-port-injection.test.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const verifier = path.resolve(
+  'scripts/verify/verify-blog-comments-graphql-port-injection.mjs',
+);
+const evidencePath =
+  'crates/rustok-blog/contracts/evidence/blog-comments-graphql-port-injection.json';
+const manifestPath = 'crates/rustok-blog/rustok-module.toml';
+const graphqlModulePath = 'crates/rustok-blog/src/graphql/mod.rs';
+const runtimeDataPath = 'crates/rustok-blog/src/graphql/runtime_data.rs';
+const commentReadsPath = 'crates/rustok-blog/src/graphql/types.rs';
+const commentMutationPath = 'crates/rustok-blog/src/graphql/mutation.rs';
+const servicePath = 'crates/rustok-blog/src/services/comment.rs';
+const consumerMatrixPath =
+  'crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json';
+const planPath = 'crates/rustok-blog/docs/implementation-plan.md';
+const harnessTest =
+  'graphql::runtime_data::tests::graphql_runtime_data_exposes_comments_port_selection';
+const harnessCommand = `cargo test -p rustok-blog --lib ${harnessTest} -- --exact`;
+
+function write(root, relativePath, content) {
+  const target = path.join(root, relativePath);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, content);
+}
+
+function fixture({
+  missingManifestFactory = false,
+  missingHostLookup = false,
+  missingInjectedBranch = false,
+  missingFallback = false,
+  directReadConstruction = false,
+  directMutationConstruction = false,
+  missingHarness = false,
+  runtimePromoted = false,
+  remotePromoted = false,
+  registrationPromoted = false,
+  planDrift = false,
+} = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-blog-graphql-comments-port-'));
+
+  write(
+    root,
+    manifestPath,
+    `[provides.graphql]\nquery = "graphql::BlogQuery"\nmutation = "graphql::BlogMutation"\n${
+      missingManifestFactory ? '' : 'runtime_data_factory = "graphql::attach_schema_data"'
+    }`,
+  );
+  write(
+    root,
+    graphqlModulePath,
+    'mod runtime_data;\npub use runtime_data::{BlogGraphqlRuntimeData, attach_schema_data};',
+  );
+
+  write(
+    root,
+    runtimeDataPath,
+    `
+use rustok_api::graphql::GraphqlRuntimeInputs;
+use rustok_comments::CommentsThreadPort;
+comments_thread_port: Option<Arc<dyn CommentsThreadPort>>
+pub fn attach_schema_data(
+${missingHostLookup ? '' : 'inputs.shared_get::<Arc<dyn CommentsThreadPort>>()'}
+pub(crate) fn comment_service(
+match self.comments_thread_port.clone()
+Some(comments_thread_port)
+${
+  missingInjectedBranch
+    ? ''
+    : 'CommentService::with_comments_thread_port(db, comments_thread_port)'
+}
+${missingFallback ? '' : 'None => CommentService::new(db, event_bus)'}
+${
+  missingHarness
+    ? ''
+    : `
+fn graphql_runtime_data_exposes_comments_port_selection()
+let factory: fn(&GraphqlRuntimeInputs) -> Result<BlogGraphqlRuntimeData, String>
+BlogGraphqlRuntimeData::comment_service;
+`
+}
+`,
+  );
+
+  write(
+    root,
+    commentReadsPath,
+    `
+use super::runtime_data::BlogGraphqlRuntimeData;
+async fn public_comments(
+let runtime = ctx.data::<BlogGraphqlRuntimeData>()?;
+let service = runtime.comment_service(db.clone(), event_bus.clone());
+async fn moderation_comments(
+let runtime = ctx.data::<BlogGraphqlRuntimeData>()?;
+let service = runtime.comment_service(db.clone(), event_bus.clone());
+${directReadConstruction ? 'CommentService::new(db.clone(), event_bus.clone())' : ''}
+`,
+  );
+  write(
+    root,
+    commentMutationPath,
+    `
+use super::runtime_data::BlogGraphqlRuntimeData;
+async fn moderate_comment(
+let runtime = ctx.data::<BlogGraphqlRuntimeData>()?;
+runtime.comment_service(db.clone(), event_bus.clone())
+${
+  directMutationConstruction
+    ? 'CommentService::with_comments_thread_port(db.clone(), comments_thread_port)'
+    : ''
+}
+`,
+  );
+  write(
+    root,
+    servicePath,
+    'pub fn with_comments_thread_port(\ncomments_thread_port: Arc<dyn CommentsThreadPort>,',
+  );
+  write(root, consumerMatrixPath, '{}');
+
+  write(
+    root,
+    evidencePath,
+    JSON.stringify({
+      schema_version: 1,
+      module: 'blog',
+      surface: 'comments_graphql_port_injection',
+      role: 'consumer',
+      provider: 'comments',
+      status: 'source_verified_no_compile',
+      compile_policy: 'not_run_by_request',
+      runtime_status: runtimePromoted ? 'passed' : 'not_run',
+      source_contract: {
+        module_manifest: manifestPath,
+        graphql_module: graphqlModulePath,
+        runtime_data: runtimeDataPath,
+        comment_reads: commentReadsPath,
+        comment_mutation: commentMutationPath,
+        consumer_service: servicePath,
+        consumer_matrix: consumerMatrixPath,
+      },
+      profiles: {
+        source_verified: remotePromoted
+          ? ['in_process_fallback', 'host_injected_port_selection', 'remote_transport']
+          : ['in_process_fallback', 'host_injected_port_selection'],
+        pending: remotePromoted ? [] : ['remote_transport_implementation'],
+      },
+      composition: {
+        host_inputs: 'rustok_api::graphql::GraphqlRuntimeInputs',
+        manifest_factory: 'graphql::attach_schema_data',
+        schema_data: 'BlogGraphqlRuntimeData',
+        shared_value: 'Arc<dyn CommentsThreadPort>',
+        lookup: 'GraphqlRuntimeInputs::shared_get',
+        selector: 'BlogGraphqlRuntimeData::comment_service',
+        injected_constructor: 'CommentService::with_comments_thread_port',
+        fallback_constructor: 'CommentService::new',
+        graphql_operations: ['public_comments', 'moderation_comments', 'moderate_comment'],
+      },
+      harness: {
+        status: 'executable_no_run',
+        runtime_status: 'not_run',
+        source: runtimeDataPath,
+        test: harnessTest,
+        command: harnessCommand,
+      },
+      registration: {
+        standalone_verifier:
+          'scripts/verify/verify-blog-comments-graphql-port-injection.mjs',
+        focused_fixture:
+          'scripts/verify/verify-blog-comments-graphql-port-injection.test.mjs',
+        blog_fba_package_chain: registrationPromoted ? 'registered' : 'pending',
+      },
+    }),
+  );
+
+  write(
+    root,
+    planPath,
+    planDrift
+      ? ''
+      : 'blog-comments-graphql-port-injection.json verify-blog-comments-graphql-port-injection.mjs verify-blog-comments-graphql-port-injection.test.mjs BlogGraphqlRuntimeData graphql::attach_schema_data GraphQL Comments host selection is source-locked Blog FBA package-chain registration remains pending remote network transport remains pending Slice 61',
+  );
+
+  return root;
+}
+
+function run(root) {
+  return spawnSync(process.execPath, [verifier], {
+    cwd: path.resolve('.'),
+    env: { ...process.env, RUSTOK_VERIFY_REPO_ROOT: root },
+    encoding: 'utf8',
+  });
+}
+
+function rejects(options) {
+  const root = fixture(options);
+  try {
+    return run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test('accepts canonical Blog GraphQL Comments port injection source', () => {
+  const root = fixture();
+  try {
+    const result = run(root);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects removal of the manifest runtime-data factory', () => {
+  assert.notEqual(rejects({ missingManifestFactory: true }).status, 0);
+});
+
+test('rejects removal of the host shared-value lookup', () => {
+  assert.notEqual(rejects({ missingHostLookup: true }).status, 0);
+});
+
+test('rejects removal of the injected selector branch', () => {
+  assert.notEqual(rejects({ missingInjectedBranch: true }).status, 0);
+});
+
+test('rejects removal of the in-process fallback branch', () => {
+  assert.notEqual(rejects({ missingFallback: true }).status, 0);
+});
+
+test('rejects direct provider construction in GraphQL comment reads', () => {
+  assert.notEqual(rejects({ directReadConstruction: true }).status, 0);
+});
+
+test('rejects direct provider construction in the GraphQL comment mutation', () => {
+  assert.notEqual(rejects({ directMutationConstruction: true }).status, 0);
+});
+
+test('rejects removal of the compile-only runtime-data harness', () => {
+  assert.notEqual(rejects({ missingHarness: true }).status, 0);
+});
+
+test('rejects runtime promotion without execution', () => {
+  assert.notEqual(rejects({ runtimePromoted: true }).status, 0);
+});
+
+test('rejects remote transport promotion without an implementation', () => {
+  assert.notEqual(rejects({ remotePromoted: true }).status, 0);
+});
+
+test('rejects unearned Blog FBA package-chain registration', () => {
+  assert.notEqual(rejects({ registrationPromoted: true }).status, 0);
+});
+
+test('rejects canonical-plan drift', () => {
+  assert.notEqual(rejects({ planDrift: true }).status, 0);
+});

--- a/scripts/verify/verify-blog-comments-graphql-port-injection.test.mjs
+++ b/scripts/verify/verify-blog-comments-graphql-port-injection.test.mjs
@@ -20,6 +20,8 @@ const commentMutationPath = 'crates/rustok-blog/src/graphql/mutation.rs';
 const servicePath = 'crates/rustok-blog/src/services/comment.rs';
 const consumerMatrixPath =
   'crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json';
+const serverCodegenPath = 'apps/server/build.rs';
+const serverSchemaPath = 'apps/server/src/graphql/schema.rs';
 const planPath = 'crates/rustok-blog/docs/implementation-plan.md';
 const harnessTest =
   'graphql::runtime_data::tests::graphql_runtime_data_exposes_comments_port_selection';
@@ -33,6 +35,7 @@ function write(root, relativePath, content) {
 
 function fixture({
   missingManifestFactory = false,
+  missingHostAttachment = false,
   missingHostLookup = false,
   missingInjectedBranch = false,
   missingFallback = false,
@@ -57,6 +60,20 @@ function fixture({
     root,
     graphqlModulePath,
     'mod runtime_data;\npub use runtime_data::{BlogGraphqlRuntimeData, attach_schema_data};',
+  );
+  write(
+    root,
+    serverCodegenPath,
+    missingHostAttachment
+      ? 'graphql_runtime_data_factory: Option<String> graphql_runtime_data_factory_expr'
+      : 'graphql_runtime_data_factory: Option<String> graphql_runtime_data_factory_expr builder = builder.data({factory}(inputs)?);',
+  );
+  write(
+    root,
+    serverSchemaPath,
+    missingHostAttachment
+      ? ''
+      : 'schema_codegen::attach_module_graphql_data(builder, &graphql_runtime_inputs)',
   );
 
   write(
@@ -145,6 +162,8 @@ ${
         comment_mutation: commentMutationPath,
         consumer_service: servicePath,
         consumer_matrix: consumerMatrixPath,
+        server_codegen: serverCodegenPath,
+        server_schema: serverSchemaPath,
       },
       profiles: {
         source_verified: remotePromoted
@@ -155,6 +174,7 @@ ${
       composition: {
         host_inputs: 'rustok_api::graphql::GraphqlRuntimeInputs',
         manifest_factory: 'graphql::attach_schema_data',
+        schema_attachment: 'schema_codegen::attach_module_graphql_data',
         schema_data: 'BlogGraphqlRuntimeData',
         shared_value: 'Arc<dyn CommentsThreadPort>',
         lookup: 'GraphqlRuntimeInputs::shared_get',
@@ -185,7 +205,7 @@ ${
     planPath,
     planDrift
       ? ''
-      : 'blog-comments-graphql-port-injection.json verify-blog-comments-graphql-port-injection.mjs verify-blog-comments-graphql-port-injection.test.mjs BlogGraphqlRuntimeData graphql::attach_schema_data GraphQL Comments host selection is source-locked Blog FBA package-chain registration remains pending remote network transport remains pending Slice 61',
+      : 'blog-comments-graphql-port-injection.json verify-blog-comments-graphql-port-injection.mjs verify-blog-comments-graphql-port-injection.test.mjs BlogGraphqlRuntimeData graphql::attach_schema_data schema_codegen::attach_module_graphql_data GraphQL Comments host selection is source-locked Blog FBA package-chain registration remains pending remote network transport remains pending Slice 61',
   );
 
   return root;
@@ -220,6 +240,10 @@ test('accepts canonical Blog GraphQL Comments port injection source', () => {
 
 test('rejects removal of the manifest runtime-data factory', () => {
   assert.notEqual(rejects({ missingManifestFactory: true }).status, 0);
+});
+
+test('rejects removal of the generated schema attachment path', () => {
+  assert.notEqual(rejects({ missingHostAttachment: true }).status, 0);
 });
 
 test('rejects removal of the host shared-value lookup', () => {

--- a/scripts/verify/verify-blog-comments-graphql-port-injection.test.mjs
+++ b/scripts/verify/verify-blog-comments-graphql-port-injection.test.mjs
@@ -258,12 +258,11 @@ test('rejects removal of the in-process fallback branch', () => {
   assert.notEqual(rejects({ missingFallback: true }).status, 0);
 });
 
-test('rejects direct provider construction in GraphQL comment reads', () => {
-  assert.notEqual(rejects({ directReadConstruction: true }).status, 0);
-});
-
-test('rejects direct provider construction in the GraphQL comment mutation', () => {
-  assert.notEqual(rejects({ directMutationConstruction: true }).status, 0);
+test('rejects direct provider construction in GraphQL comment resolvers', () => {
+  const readResult = rejects({ directReadConstruction: true });
+  const mutationResult = rejects({ directMutationConstruction: true });
+  assert.notEqual(readResult.status, 0);
+  assert.notEqual(mutationResult.status, 0);
 });
 
 test('rejects removal of the compile-only runtime-data harness', () => {


### PR DESCRIPTION
## Summary

- continue the canonical Blog implementation plan through slice 61
- declare a Blog GraphQL runtime-data factory in the module manifest
- materialize `BlogGraphqlRuntimeData` from host `GraphqlRuntimeInputs`
- select an injected `CommentsThreadPort` or preserve the in-process fallback through one runtime selector
- route public comment reads, moderation reads, and moderation mutation through the selector
- retain the complete host-to-generated-schema-to-resolver path in schema-v1 evidence, a standalone verifier, focused fixtures, and a compile-only harness

## Scope and non-claims

This is a source-only composition slice. It does not implement a remote network transport, register the new standalone guard in the Blog FBA package chain, or wire storefront/admin native SSR composition. No runtime or browser evidence is promoted.

No Rust or JavaScript test, verifier, compilation, database, browser, workflow, CI, or production command was run, per maintainer instruction.

## Suggested maintainer commands

```bash
node scripts/verify/verify-blog-comments-graphql-port-injection.mjs
node --test scripts/verify/verify-blog-comments-graphql-port-injection.test.mjs
cargo test -p rustok-blog --lib graphql::runtime_data::tests::graphql_runtime_data_exposes_comments_port_selection -- --exact
cargo check -p rustok-blog
cargo check -p rustok-server --features mod-blog
cargo xtask module validate blog
```

## Branch state

The branch starts from `8853b4431536ceb86dbe1d5be2090977105878af`. Current `main` is ahead only by unrelated Forum, Outbox, and Payment changes; the proposed diff changes exactly nine Blog source/evidence files.