### PR TITLE
test(index): retain reconciliation event-id contracts

### DIFF
--- a/crates/rustok-index/docs/m6-reconciliation-event-id-contract-postgres-harness.md
+++ b/crates/rustok-index/docs/m6-reconciliation-event-id-contract-postgres-harness.md
@@ -1,0 +1,131 @@
+# M6 reconciliation event-ID contract PostgreSQL harness
+
+Status: executable target retained, not run.
+
+## Purpose
+
+This harness retains PostgreSQL evidence for the page-wide event identity preflight in
+`PostgresIndexReconciliationRunner`.
+
+The runner validates every mutation event UUID before it starts the mutation persistence
+loop. A later invalid event UUID must therefore reject the complete page without allowing
+an earlier valid mutation to create an entity or inbox row.
+
+## Cases
+
+The source page contains two schema-valid upsert mutations in the exact requested tenant
+and schema scope. Both records contain the required `id` field and use distinct entity
+UUIDs.
+
+### Nil second event UUID
+
+The first mutation has a non-nil event UUID. The second mutation has `Uuid::nil()`.
+
+The run must return:
+
+- `IndexReconciliationRunError::NilEventId`;
+- position `1`;
+- no mutation persistence.
+
+### Duplicate second event UUID
+
+The first and second mutations have distinct entity UUIDs but share the same non-nil
+event UUID.
+
+The run must return:
+
+- `IndexReconciliationRunError::DuplicateEventId`;
+- position `1`;
+- the exact repeated event UUID;
+- no mutation persistence.
+
+## Durable failure evidence
+
+Each case creates one attempt-1 reconciliation job and terminalizes it as `failed`.
+The durable cursor remains at the initial safe boundary:
+
+- `completed_passes = 0`;
+- `pages_processed = 0`.
+
+The job must retain:
+
+- `last_error_code = index.reconciliation_page_failed`;
+- cleared lease owner and expiry;
+- non-null completion timestamp.
+
+The diagnostic must equal this exact three-field JSON object:
+
+```json
+{
+  "contract": "index_reconciliation_run_failure_v1",
+  "dependency_code": "reconciliation_contract_invalid",
+  "retryable": false
+}
+```
+
+No event UUID, entity UUID, tenant UUID, worker ID, request, source payload, database
+error, SQL, transport detail, or stack text is persisted in the diagnostic.
+
+PostgreSQL must contain exactly:
+
+- one reconciliation job;
+- zero `index_entities` rows;
+- zero `index_inbox` rows.
+
+The zero-write requirement is material because the invalid identity is on the second
+mutation. The first mutation is otherwise valid and would be persistable if the runner
+applied mutations before completing page-wide event-ID validation.
+
+A cancellation request from another tenant must return `NotFound`. A later exact-tenant
+request must return `AlreadyTerminal(Failed)`.
+
+## PostgreSQL isolation
+
+The target reads `RUSTOK_INDEX_TEST_DATABASE_URL`, with PostgreSQL `DATABASE_URL` as a
+fallback. Without a PostgreSQL URL it reports a skip and succeeds.
+
+Each case:
+
+1. creates a unique PostgreSQL schema;
+2. creates the tenant owner fixture;
+3. applies every real `IndexModule` migration;
+4. persists one active schema contract;
+5. materializes canonical source and schema registries;
+6. runs the canonical reconciliation runner;
+7. reads durable job/entity/inbox evidence;
+8. drops the isolated schema.
+
+No sleep, polling delay, elapsed-time expiry, or concurrent race is used.
+
+## Scope boundaries
+
+This harness adds no production code, migration, reconciliation SQL/state-machine,
+source/cursor contract, mutation identity, schema, diagnostic, or public API change.
+
+It does not add or claim:
+
+- automatic retry, backoff, scheduling, or attempt exhaustion;
+- failed-scope dead-letter admission or authorized requeue;
+- cancellation, heartbeat, lease-loss, takeover, or restart races;
+- source-call timeout or pending-future preemption;
+- cross-page event-ID uniqueness;
+- source/index digest comparison;
+- orphan cleanup;
+- targeted, full, or shadow repair;
+- locale or partition checkpoint dimensions;
+- complete drift repair.
+
+The canonical M6 reconciliation and drift-repair item therefore remains open.
+
+## Suggested validation
+
+```bash
+RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
+  cargo test -p rustok-index \
+  --test source_reconciliation_event_id_contract_postgres_test \
+  -- --nocapture
+
+cargo check -p rustok-index --all-targets
+
+node scripts/verify/verify-index-reconciliation-event-id-contract-harness.mjs
+```

--- a/crates/rustok-index/tests/reconciliation_event_id_contract/connection.rs
+++ b/crates/rustok-index/tests/reconciliation_event_id_contract/connection.rs
@@ -1,0 +1,33 @@
+use std::{env, error::Error};
+
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection};
+
+pub type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+pub const DATABASE_ENV: &str = "RUSTOK_INDEX_TEST_DATABASE_URL";
+
+pub fn database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+pub async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+pub async fn scoped_connection(
+    database_url: &str,
+    schema_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url).await?;
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}""#))
+        .await?;
+    Ok(db)
+}

--- a/crates/rustok-index/tests/reconciliation_event_id_contract/database.rs
+++ b/crates/rustok-index/tests/reconciliation_event_id_contract/database.rs
@@ -1,0 +1,75 @@
+use rustok_core::MigrationSource;
+use rustok_index::IndexModule;
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement};
+use sea_orm_migration::SchemaManager;
+use uuid::Uuid;
+
+use super::{
+    connection::{DATABASE_ENV, TestResult, connect, database_url, scoped_connection},
+    schema::persist_schema,
+};
+
+pub struct TestDatabase {
+    control: DatabaseConnection,
+    database_url: String,
+    schema_name: String,
+    pub tenant_id: Uuid,
+}
+
+impl TestDatabase {
+    pub async fn setup(case_name: &str) -> TestResult<Option<Self>> {
+        let Some(database_url) = database_url() else {
+            eprintln!(
+                "{DATABASE_ENV} is not set to a PostgreSQL URL; skipping reconciliation event-id contract harness"
+            );
+            return Ok(None);
+        };
+        let control = connect(&database_url).await?;
+        let schema_name = format!(
+            "rustok_idx_evt_id_{}_{}",
+            case_name,
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let tenant_id = Uuid::new_v4();
+        let db = scoped_connection(&database_url, &schema_name).await?;
+        db.execute_unprepared("CREATE TABLE tenants (id UUID NOT NULL PRIMARY KEY)")
+            .await?;
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "INSERT INTO tenants (id) VALUES ($1)",
+            vec![tenant_id.into()],
+        ))
+        .await?;
+
+        let manager = SchemaManager::new(&db);
+        for migration in IndexModule.migrations() {
+            migration.up(&manager).await?;
+        }
+        persist_schema(&db, tenant_id).await?;
+
+        Ok(Some(Self {
+            control,
+            database_url,
+            schema_name,
+            tenant_id,
+        }))
+    }
+
+    pub async fn connection(&self) -> TestResult<DatabaseConnection> {
+        scoped_connection(&self.database_url, &self.schema_name).await
+    }
+
+    pub async fn cleanup(self) -> TestResult<()> {
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/rustok-index/tests/reconciliation_event_id_contract/evidence.rs
+++ b/crates/rustok-index/tests/reconciliation_event_id_contract/evidence.rs
@@ -1,0 +1,61 @@
+use std::io;
+
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement};
+use serde_json::Value as JsonValue;
+use uuid::Uuid;
+
+use super::connection::TestResult;
+
+#[derive(Debug)]
+pub struct FailureEvidence {
+    pub job_id: Uuid,
+    pub state: String,
+    pub attempt_count: i64,
+    pub completed_passes: i64,
+    pub pages_processed: i64,
+    pub last_error_code: String,
+    pub last_error_details: JsonValue,
+    pub lease_released: bool,
+    pub completed: bool,
+}
+
+pub async fn read_failure(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+) -> TestResult<FailureEvidence> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT job_id, state, attempt_count::bigint AS attempt_count_value, (cursor->>'completed_passes')::bigint AS completed_passes, (cursor->>'pages_processed')::bigint AS pages_processed, last_error_code, last_error_details, (lease_owner IS NULL AND lease_expires_at IS NULL) AS lease_released, (completed_at IS NOT NULL) AS completed FROM index_jobs WHERE tenant_id = $1 AND kind = 'reconcile' AND state = 'failed'",
+            vec![tenant_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| io::Error::other("failed reconciliation event-id contract job is missing"))?;
+    Ok(FailureEvidence {
+        job_id: row.try_get("", "job_id")?,
+        state: row.try_get("", "state")?,
+        attempt_count: row.try_get("", "attempt_count_value")?,
+        completed_passes: row.try_get("", "completed_passes")?,
+        pages_processed: row.try_get("", "pages_processed")?,
+        last_error_code: row.try_get("", "last_error_code")?,
+        last_error_details: row.try_get("", "last_error_details")?,
+        lease_released: row.try_get("", "lease_released")?,
+        completed: row.try_get("", "completed")?,
+    })
+}
+
+pub async fn count(db: &DatabaseConnection, table: &str) -> TestResult<i64> {
+    let sql = match table {
+        "index_entities" => "SELECT COUNT(*)::bigint AS value FROM index_entities",
+        "index_inbox" => "SELECT COUNT(*)::bigint AS value FROM index_inbox",
+        "index_jobs" => {
+            "SELECT COUNT(*)::bigint AS value FROM index_jobs WHERE kind = 'reconcile'"
+        }
+        _ => panic!("unsupported fixture table"),
+    };
+    Ok(db
+        .query_one(Statement::from_string(DbBackend::Postgres, sql.to_owned()))
+        .await?
+        .ok_or_else(|| io::Error::other("count query returned no row"))?
+        .try_get("", "value")?)
+}

--- a/crates/rustok-index/tests/reconciliation_event_id_contract/runner.rs
+++ b/crates/rustok-index/tests/reconciliation_event_id_contract/runner.rs
@@ -1,0 +1,60 @@
+use std::{sync::Arc, time::Duration};
+
+use rustok_index::{
+    IndexReconciliationRunRequest, IndexSchemaSourceCatalog, IndexSourceCatalog,
+    PostgresIndexReconciliationRunner, SchemaRegistry,
+};
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use super::{
+    schema::{schema, schema_ref},
+    source::EventIdContractSource,
+};
+
+pub const SOURCE_NAME: &str = "event-id-contract-primary";
+
+pub fn runner(
+    db: DatabaseConnection,
+    source: EventIdContractSource,
+) -> PostgresIndexReconciliationRunner {
+    let schema = schema();
+    let mut schema_catalog = IndexSchemaSourceCatalog::new();
+    schema_catalog
+        .register("event-id-contract-harness", schema.clone())
+        .expect("fixture schema source must register");
+
+    let mut source_catalog = IndexSourceCatalog::new();
+    source_catalog
+        .register(
+            "event-id-contract-harness",
+            SOURCE_NAME,
+            [schema.reference.clone()],
+            source,
+        )
+        .expect("fixture source must register");
+    let sources = source_catalog
+        .materialize(&schema_catalog)
+        .expect("fixture source registry must materialize");
+
+    let mut registry = SchemaRegistry::new();
+    registry
+        .register(schema)
+        .expect("fixture schema registry must materialize");
+
+    PostgresIndexReconciliationRunner::new(db, sources, Arc::new(registry))
+}
+
+pub fn request(tenant_id: Uuid, worker_id: &str) -> IndexReconciliationRunRequest {
+    IndexReconciliationRunRequest::new(
+        tenant_id,
+        schema_ref(),
+        worker_id,
+        2,
+        1,
+        1,
+        1,
+        Duration::from_secs(3_600),
+    )
+    .expect("fixture reconciliation request must be valid")
+}

--- a/crates/rustok-index/tests/reconciliation_event_id_contract/schema.rs
+++ b/crates/rustok-index/tests/reconciliation_event_id_contract/schema.rs
@@ -1,0 +1,53 @@
+use rustok_index::{
+    EntityName, FieldCardinality, FieldName, IndexField, IndexSchema, IndexValueType,
+    LocaleMode, ModuleName, SchemaRef, SchemaVersion,
+};
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement, Value as SqlValue};
+use uuid::Uuid;
+
+use super::connection::TestResult;
+
+pub fn schema_ref() -> SchemaRef {
+    SchemaRef {
+        module: ModuleName::new("event-id-contract-harness").unwrap(),
+        entity: EntityName::new("item").unwrap(),
+        version: SchemaVersion::INITIAL,
+    }
+}
+
+pub fn schema() -> IndexSchema {
+    IndexSchema {
+        reference: schema_ref(),
+        locale_mode: LocaleMode::None,
+        fields: vec![IndexField {
+            name: FieldName::new("id").unwrap(),
+            value_type: IndexValueType::Uuid,
+            cardinality: FieldCardinality::One,
+            nullable: false,
+            selectable: true,
+            filterable: true,
+            sortable: true,
+        }],
+        links: Vec::new(),
+    }
+}
+
+pub async fn persist_schema(db: &DatabaseConnection, tenant_id: Uuid) -> TestResult<()> {
+    let schema = schema();
+    let fingerprint = schema.fingerprint()?.to_string();
+    let schema_json = serde_json::to_value(&schema)?;
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "INSERT INTO index_schemas (tenant_id, module_name, entity_name, schema_version, schema_fingerprint, schema_json, status) VALUES ($1, $2, $3, $4, $5, $6, 'active')",
+        vec![
+            tenant_id.into(),
+            schema.reference.module.as_str().to_owned().into(),
+            schema.reference.entity.as_str().to_owned().into(),
+            i64::from(schema.reference.version.get()).into(),
+            fingerprint.into(),
+            SqlValue::Json(Some(Box::new(schema_json))),
+        ],
+    ))
+    .await?;
+    Ok(())
+}

--- a/crates/rustok-index/tests/reconciliation_event_id_contract/source.rs
+++ b/crates/rustok-index/tests/reconciliation_event_id_contract/source.rs
@@ -1,0 +1,74 @@
+use std::collections::BTreeMap;
+
+use async_trait::async_trait;
+use rustok_index::{
+    EntityKey, FieldName, IndexMutation, IndexRecord, IndexSource, IndexSourceFailure,
+    IndexSourceLoadBatch, IndexSourceLoadRequest, IndexSourcePage, IndexSourceScanRequest,
+    IndexValue,
+};
+use uuid::Uuid;
+
+use super::schema::schema_ref;
+
+pub const DUPLICATE_EVENT_ID: Uuid = Uuid::from_u128(21_001);
+
+#[derive(Debug, Clone, Copy)]
+pub enum EventIdContractSource {
+    NilSecond,
+    DuplicateSecond,
+}
+
+#[async_trait]
+impl IndexSource for EventIdContractSource {
+    async fn scan(
+        &self,
+        request: IndexSourceScanRequest,
+    ) -> Result<IndexSourcePage, IndexSourceFailure> {
+        let second_event_id = match self {
+            Self::NilSecond => Uuid::nil(),
+            Self::DuplicateSecond => DUPLICATE_EVENT_ID,
+        };
+        IndexSourcePage::new(
+            &request,
+            vec![
+                valid_mutation(request.tenant_id(), 1_001, DUPLICATE_EVENT_ID),
+                valid_mutation(request.tenant_id(), 1_002, second_event_id),
+            ],
+            None,
+        )
+        .map_err(|_| fixture_failure())
+    }
+
+    async fn load(
+        &self,
+        request: IndexSourceLoadRequest,
+    ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+        Ok(IndexSourceLoadBatch::new(&request, Vec::new()).expect("empty targeted load"))
+    }
+}
+
+fn valid_mutation(tenant_id: Uuid, entity: u128, event_id: Uuid) -> IndexMutation {
+    let entity_id = Uuid::from_u128(entity);
+    IndexMutation::Upsert {
+        event_id,
+        record: IndexRecord {
+            key: EntityKey {
+                tenant_id,
+                schema: schema_ref(),
+                entity_id,
+                locale: None,
+            },
+            source_version: 1,
+            fields: BTreeMap::from([(
+                FieldName::new("id").unwrap(),
+                IndexValue::Uuid(entity_id),
+            )]),
+            links: Vec::new(),
+        },
+    }
+}
+
+fn fixture_failure() -> IndexSourceFailure {
+    IndexSourceFailure::permanent("event_id_contract_fixture_invalid")
+        .expect("fixture failure code must be valid")
+}

--- a/crates/rustok-index/tests/source_reconciliation_event_id_contract_postgres_test.rs
+++ b/crates/rustok-index/tests/source_reconciliation_event_id_contract_postgres_test.rs
@@ -1,0 +1,126 @@
+#[path = "reconciliation_event_id_contract/connection.rs"]
+mod connection;
+#[path = "reconciliation_event_id_contract/database.rs"]
+mod database;
+#[path = "reconciliation_event_id_contract/evidence.rs"]
+mod evidence;
+#[path = "reconciliation_event_id_contract/runner.rs"]
+mod runner;
+#[path = "reconciliation_event_id_contract/schema.rs"]
+mod schema;
+#[path = "reconciliation_event_id_contract/source.rs"]
+mod source;
+
+use rustok_index::{
+    IndexReconciliationCancelOutcome, IndexReconciliationRunError,
+    IndexReconciliationTerminalState,
+};
+use serde_json::json;
+use uuid::Uuid;
+
+use connection::TestResult;
+use database::TestDatabase;
+use evidence::{count, read_failure};
+use runner::{request, runner};
+use source::{DUPLICATE_EVENT_ID, EventIdContractSource};
+
+const PAGE_FAILURE_CODE: &str = "index.reconciliation_page_failed";
+const FAILURE_CONTRACT: &str = "index_reconciliation_run_failure_v1";
+const DEPENDENCY_CODE: &str = "reconciliation_contract_invalid";
+
+#[derive(Debug, Clone, Copy)]
+enum ExpectedFailure {
+    NilSecond,
+    DuplicateSecond,
+}
+
+#[tokio::test]
+async fn nil_second_event_id_rejects_whole_page_before_mutation_persistence() -> TestResult<()> {
+    assert_contract_failure("nil", EventIdContractSource::NilSecond, ExpectedFailure::NilSecond).await
+}
+
+#[tokio::test]
+async fn duplicate_second_event_id_rejects_whole_page_before_mutation_persistence() -> TestResult<()> {
+    assert_contract_failure(
+        "duplicate",
+        EventIdContractSource::DuplicateSecond,
+        ExpectedFailure::DuplicateSecond,
+    )
+    .await
+}
+
+async fn assert_contract_failure(
+    case_name: &str,
+    source: EventIdContractSource,
+    expected: ExpectedFailure,
+) -> TestResult<()> {
+    let Some(database) = TestDatabase::setup(case_name).await? else {
+        return Ok(());
+    };
+    let tenant_id = database.tenant_id;
+    let reconciliation = runner(database.connection().await?, source);
+
+    let error = reconciliation
+        .run(request(tenant_id, &format!("event-id-{case_name}-worker")))
+        .await
+        .expect_err("invalid page event identity must fail reconciliation");
+    match (expected, error) {
+        (ExpectedFailure::NilSecond, IndexReconciliationRunError::NilEventId { position }) => {
+            assert_eq!(position, 1);
+        }
+        (
+            ExpectedFailure::DuplicateSecond,
+            IndexReconciliationRunError::DuplicateEventId { position, event_id },
+        ) => {
+            assert_eq!(position, 1);
+            assert_eq!(event_id, DUPLICATE_EVENT_ID);
+        }
+        (_, other) => panic!("unexpected event-id contract error: {other:?}"),
+    }
+
+    let inspection = database.connection().await?;
+    let failure = read_failure(&inspection, tenant_id).await?;
+    assert!(!failure.job_id.is_nil());
+    assert_eq!(failure.state, "failed");
+    assert_eq!(failure.attempt_count, 1);
+    assert_eq!(failure.completed_passes, 0);
+    assert_eq!(failure.pages_processed, 0);
+    assert_eq!(failure.last_error_code, PAGE_FAILURE_CODE);
+    assert_eq!(
+        failure.last_error_details,
+        json!({
+            "contract": FAILURE_CONTRACT,
+            "dependency_code": DEPENDENCY_CODE,
+            "retryable": false,
+        })
+    );
+    assert_eq!(
+        failure
+            .last_error_details
+            .as_object()
+            .map(serde_json::Map::len),
+        Some(3)
+    );
+    assert!(failure.lease_released);
+    assert!(failure.completed);
+    assert_eq!(count(&inspection, "index_jobs").await?, 1);
+    assert_eq!(count(&inspection, "index_entities").await?, 0);
+    assert_eq!(count(&inspection, "index_inbox").await?, 0);
+
+    assert_eq!(
+        reconciliation
+            .request_cancel(Uuid::new_v4(), failure.job_id)
+            .await?,
+        IndexReconciliationCancelOutcome::NotFound
+    );
+    assert_eq!(
+        reconciliation
+            .request_cancel(tenant_id, failure.job_id)
+            .await?,
+        IndexReconciliationCancelOutcome::AlreadyTerminal(
+            IndexReconciliationTerminalState::Failed
+        )
+    );
+
+    database.cleanup().await
+}

--- a/scripts/verify/verify-index-reconciliation-event-id-contract-harness.mjs
+++ b/scripts/verify/verify-index-reconciliation-event-id-contract-harness.mjs
@@ -1,0 +1,119 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const files = {
+  target:
+    "crates/rustok-index/tests/source_reconciliation_event_id_contract_postgres_test.rs",
+  source:
+    "crates/rustok-index/tests/reconciliation_event_id_contract/source.rs",
+  runner:
+    "crates/rustok-index/tests/reconciliation_event_id_contract/runner.rs",
+  evidence:
+    "crates/rustok-index/tests/reconciliation_event_id_contract/evidence.rs",
+  database:
+    "crates/rustok-index/tests/reconciliation_event_id_contract/database.rs",
+  docs:
+    "crates/rustok-index/docs/m6-reconciliation-event-id-contract-postgres-harness.md",
+};
+
+const read = (name) => {
+  const relative = files[name];
+  const absolute = path.join(root, relative);
+  if (!fs.existsSync(absolute)) {
+    throw new Error(`missing reconciliation event-id contract file: ${relative}`);
+  }
+  return fs.readFileSync(absolute, "utf8");
+};
+
+const requireMarkers = (name, markers) => {
+  const content = read(name);
+  for (const marker of markers) {
+    if (!content.includes(marker)) {
+      throw new Error(`${files[name]} is missing required marker: ${marker}`);
+    }
+  }
+};
+
+const forbidMarkers = (name, markers) => {
+  const content = read(name);
+  for (const marker of markers) {
+    if (content.includes(marker)) {
+      throw new Error(`${files[name]} contains forbidden marker: ${marker}`);
+    }
+  }
+};
+
+requireMarkers("target", [
+  "nil_second_event_id_rejects_whole_page_before_mutation_persistence",
+  "duplicate_second_event_id_rejects_whole_page_before_mutation_persistence",
+  "IndexReconciliationRunError::NilEventId",
+  "IndexReconciliationRunError::DuplicateEventId",
+  "assert_eq!(position, 1)",
+  "assert_eq!(event_id, DUPLICATE_EVENT_ID)",
+  'const PAGE_FAILURE_CODE: &str = "index.reconciliation_page_failed"',
+  'const FAILURE_CONTRACT: &str = "index_reconciliation_run_failure_v1"',
+  'const DEPENDENCY_CODE: &str = "reconciliation_contract_invalid"',
+  "failure.completed_passes, 0",
+  "failure.pages_processed, 0",
+  "Some(3)",
+  'count(&inspection, "index_jobs")',
+  'count(&inspection, "index_entities")',
+  'count(&inspection, "index_inbox")',
+  "IndexReconciliationCancelOutcome::NotFound",
+  "IndexReconciliationTerminalState::Failed",
+]);
+
+requireMarkers("source", [
+  "NilSecond",
+  "DuplicateSecond",
+  "Uuid::nil()",
+  "DUPLICATE_EVENT_ID",
+  "valid_mutation(request.tenant_id(), 1_001",
+  "valid_mutation(request.tenant_id(), 1_002",
+  'FieldName::new("id")',
+  "source_version: 1",
+  "IndexSourcePage::new",
+]);
+
+requireMarkers("runner", [
+  "event-id-contract-primary",
+  "PostgresIndexReconciliationRunner::new",
+  "Duration::from_secs(3_600)",
+  "        2,",
+  "        1,",
+]);
+
+requireMarkers("evidence", [
+  "cursor->>'completed_passes'",
+  "cursor->>'pages_processed'",
+  "last_error_code",
+  "last_error_details",
+  "lease_released",
+  "completed_at IS NOT NULL",
+]);
+
+requireMarkers("database", [
+  "RUSTOK_INDEX_TEST_DATABASE_URL",
+  "CREATE SCHEMA",
+  "IndexModule.migrations()",
+  "persist_schema",
+  "DROP SCHEMA IF EXISTS",
+]);
+
+requireMarkers("docs", [
+  "Status: executable target retained, not run.",
+  "page-wide event identity preflight",
+  "second mutation",
+  "exact three-field JSON object",
+  "zero `index_entities` rows",
+  "zero `index_inbox` rows",
+  "No sleep, polling delay, elapsed-time expiry, or concurrent race is used.",
+  "The canonical M6 reconciliation and drift-repair item therefore remains open.",
+]);
+
+forbidMarkers("target", ["tokio::time::sleep", "std::thread::sleep"]);
+forbidMarkers("source", ["tokio::time::sleep", "std::thread::sleep"]);
+
+console.log("Index reconciliation event-id contract harness markers verified.");


### PR DESCRIPTION
Superseded by #2934, merged as `a10b6f7ad1029b975aabda692ed09a837841d644`.

The canonical reconciliation runner now classifies source, mutation, and page-contract failures through the bounded retry transition store and returns typed scheduled, permanent, and exhausted outcomes. This draft encodes the replaced unconditional first-run `Err`/`failed` contract and must not merge.