### PR TITLE
fix(payment): sanitize compensation wrapper diagnostics

### DIFF
--- a/crates/rustok-payment/contracts/evidence/checkout-compensation-wrapper-diagnostic-safety-source-review.json
+++ b/crates/rustok-payment/contracts/evidence/checkout-compensation-wrapper-diagnostic-safety-source-review.json
@@ -6,10 +6,9 @@
     "crates/rustok-payment/src/checkout_compensation_api.rs",
     "crates/rustok-payment/src/lib.rs",
     "crates/rustok-payment/docs/checkout-compensation-local-context.md",
-    "crates/rustok-payment/docs/checkout-execution-local-context.md",
     "crates/rustok-payment/docs/implementation-plan.md",
-    "scripts/verify/verify-payment-checkout-compensation-local-context.mjs",
-    "scripts/verify/verify-payment-checkout-execution-local-context.mjs"
+    "scripts/verify/verify-payment-checkout-compensation-wrapper-error-diagnostic-safety.mjs",
+    "scripts/verify/verify-payment-checkout-compensation-local-context.mjs"
   ],
   "review_findings": {
     "public_wrapper_construction_preserved": true,
@@ -17,13 +16,19 @@
     "stable_code_only_classifier_present": true,
     "message_pair_classifier_removed_from_wrapper": true,
     "same_port_error_returned": true,
+    "complete_port_error_logging_removed": true,
+    "port_error_message_text_logging_removed": true,
+    "static_error_kind_logged": true,
+    "error_message_shape_logged": true,
     "safe_context_shape_only": true,
     "safe_request_shape_only": true,
     "raw_identifier_logging_removed_from_wrapper": true,
+    "severity_classification_preserved": true,
+    "local_operation_mapping_preserved": true,
     "provider_cancel_and_replay_policy_preserved": true,
     "persistent_owner_source_unchanged": true,
     "persistent_owner_diagnostic_cleanup_complete": false,
-    "execution_guard_aligned_with_current_wrapper": true,
+    "focused_wrapper_guard_added": true,
     "broad_commerce_cleanup_remains_open": true,
     "runtime_evidence_claimed": false
   },

--- a/crates/rustok-payment/contracts/evidence/checkout-compensation-wrapper-diagnostic-safety-source.json
+++ b/crates/rustok-payment/contracts/evidence/checkout-compensation-wrapper-diagnostic-safety-source.json
@@ -9,11 +9,20 @@
   "source_contract": {
     "stable_code_only_local_classification": true,
     "human_message_control_flow": false,
+    "complete_port_error_logged_by_wrapper": false,
+    "port_error_message_text_logged_by_wrapper": false,
+    "static_error_kind_logged_by_wrapper": true,
+    "error_message_presence_logged_by_wrapper": true,
+    "error_message_length_logged_by_wrapper": true,
+    "retryability_logged_by_wrapper": true,
     "delegated_port_error_changed": false,
+    "same_port_error_returned": true,
     "public_code_changed": false,
     "public_message_changed": false,
     "public_kind_changed": false,
     "public_retryability_changed": false,
+    "severity_classification_changed": false,
+    "local_operation_mapping_changed": false,
     "owner_delegation_changed": false,
     "request_response_dto_changed": false,
     "persistent_owner_source_changed": false,
@@ -33,7 +42,6 @@
     "safe_context_shape_logged": true,
     "safe_request_shape_logged": true,
     "correlation_id_logged": true,
-    "original_port_error_private": true,
     "persistent_owner_diagnostic_cleanup_complete": false,
     "broad_ecommerce_cleanup_closed": false
   },
@@ -49,5 +57,12 @@
     "restart_proven": false,
     "remote_port_proven": false,
     "mounted_runtime_proven": false
-  }
+  },
+  "notes": [
+    "Known local outcomes are still classified only by stable PortError code.",
+    "Both error and warning events retain a static PortError kind plus message presence and character length.",
+    "Complete PortError debug payloads and PortError message text are not logged by the wrapper.",
+    "The original PortError is returned unchanged after diagnostics.",
+    "Persistent compensation owner payload diagnostics remain a separate open source slice."
+  ]
 }

--- a/crates/rustok-payment/docs/checkout-compensation-local-context.md
+++ b/crates/rustok-payment/docs/checkout-compensation-local-context.md
@@ -17,7 +17,7 @@ provider cancellation, provider-journal replay/checkpointing, local cancellation
 
 ## Public wrapper
 
-The wrapper retains its previously established contract:
+The wrapper retains its established contract:
 
 1. capture safe context and request shape;
 2. delegate the original context and request;
@@ -31,6 +31,17 @@ Wrapper diagnostics retain correlation plus lengths, counts, presence flags, act
 UUID non-nil facts, reason length, metadata kind, and metadata entry count. They do not record raw
 tenant, actor, channel, locale, causation, traceparent, idempotency, checkout-operation, collection,
 reason, or metadata values.
+
+The wrapper error and warning events now also retain only:
+
+- stable `PortError.code`;
+- a closed static `PortErrorKind` label;
+- message presence and character length;
+- retryability.
+
+They no longer record the complete `PortError`, debug representation, or human-readable message text.
+The same original `PortError` is returned after the private event, so public code, message, kind, and
+retryability are unchanged.
 
 ## Persistent owner diagnostics
 
@@ -59,11 +70,18 @@ The owner no longer writes raw tenant, actor, channel, locale, causation, tracep
 checkout-operation, collection, provider-journal operation, reason, metadata, provider identity, or
 financial values into these diagnostic fields.
 
-## Preserved owner behavior
+This wrapper-only slice does not change the persistent owner. Stricter payload-shape replacement for
+complete owner, checkpoint, serialization, and reconciliation error payloads remains a separate open
+source slice.
+
+## Preserved behavior
 
 This slice does not change:
 
 - public trait, request, response, wrapper, factory, or module exports;
+- stable-code local-operation mapping;
+- technical/integrity severity classification;
+- unknown-code passthrough;
 - write policy, deadline, idempotency, tenant, or causation admission order;
 - optional missing-collection no-op behavior;
 - captured-payment refund-policy reconciliation;
@@ -87,26 +105,30 @@ This slice does not change:
 - `crates/rustok-payment/contracts/evidence/checkout-compensation-wrapper-diagnostic-safety-source-review.json`
 - `crates/rustok-payment/contracts/evidence/checkout-compensation-owner-diagnostic-safety-source.json`
 - `crates/rustok-payment/contracts/evidence/checkout-compensation-owner-diagnostic-safety-source-review.json`
+- `scripts/verify/verify-payment-checkout-compensation-wrapper-error-diagnostic-safety.mjs`
 - `scripts/verify/verify-payment-checkout-compensation-local-context.mjs`
 
-The focused verifier guards facade wiring, stable-code-only wrapper attribution, safe wrapper and
-owner context shape, absence of raw diagnostic values, unchanged provider/journal/lifecycle markers,
-unchanged public envelopes, and source-only validation flags.
+The focused wrapper verifier guards stable-code attribution, closed error-kind labels, message-shape
+facts, absence of complete `PortError` and message text, unchanged severity routing, same-error return,
+and source-only validation flags. The broader compensation verifier continues to guard facade wiring,
+owner context shape, provider/journal/lifecycle markers, and public envelopes.
 
 ## Remaining gaps
 
-Compile, provider replay, process-exit, restart, contention, mounted transport, remote-profile,
-workflow, CI, and production evidence remain unexecuted.
+Persistent owner payload-shape cleanup remains open. Compile, provider replay, process-exit, restart,
+contention, mounted transport, remote-profile, workflow, CI, and production evidence remain
+unexecuted.
 
-The broad ecommerce correlation-safe mapper item remains open for remaining order, fulfillment,
-inventory, customer, tax, promotion, ecommerce adapter, and non-`PortError` public envelopes. No FBA
-or FFA status is promoted from source inspection.
+The broad ecommerce correlation-safe mapper item remains open for remaining payment compensation,
+order, fulfillment, inventory, customer, tax, promotion, ecommerce adapter, and non-`PortError`
+public envelopes. No FBA or FFA status is promoted from source inspection.
 
 ## Suggested maintainer checks
 
 These commands were intentionally not run by the implementation agent:
 
 ```bash
+node scripts/verify/verify-payment-checkout-compensation-wrapper-error-diagnostic-safety.mjs
 node scripts/verify/verify-payment-checkout-compensation-local-context.mjs
 node scripts/verify/verify-payment-checkout-execution-local-context.mjs
 node scripts/verify/verify-commerce-checkout-compensation-owner-boundary.mjs

--- a/crates/rustok-payment/src/checkout_compensation_context.rs
+++ b/crates/rustok-payment/src/checkout_compensation_context.rs
@@ -44,6 +44,12 @@ struct CheckoutPaymentCompensationDiagnosticFacts {
     metadata_entry_count: Option<usize>,
 }
 
+struct CheckoutPaymentCompensationPortErrorFacts {
+    error_kind: &'static str,
+    message_present: bool,
+    message_length: usize,
+}
+
 pub struct InProcessCheckoutPaymentCompensationPort {
     inner: PersistentCheckoutPaymentCompensationPort,
 }
@@ -162,6 +168,25 @@ fn payment_metadata_kind(metadata: &Value) -> &'static str {
     }
 }
 
+fn checkout_payment_compensation_port_error_facts(
+    error: &PortError,
+) -> CheckoutPaymentCompensationPortErrorFacts {
+    let error_kind = match &error.kind {
+        PortErrorKind::Validation => "validation",
+        PortErrorKind::NotFound => "not_found",
+        PortErrorKind::Conflict => "conflict",
+        PortErrorKind::Forbidden => "forbidden",
+        PortErrorKind::Unavailable => "unavailable",
+        PortErrorKind::Timeout => "timeout",
+        PortErrorKind::InvariantViolation => "invariant_violation",
+    };
+    CheckoutPaymentCompensationPortErrorFacts {
+        error_kind,
+        message_present: !error.message.trim().is_empty(),
+        message_length: error.message.chars().count(),
+    }
+}
+
 fn checkout_payment_compensation_local_operation(code: &str) -> Option<&'static str> {
     match code {
         "port.idempotency_key_required" => Some("admit_write_idempotency"),
@@ -217,9 +242,9 @@ fn map_checkout_payment_compensation_local_port_error(
             PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation
         );
     let context_facts = checkout_payment_compensation_context_facts(context);
+    let error_facts = checkout_payment_compensation_port_error_facts(&error);
     if technical_failure {
         tracing::error!(
-            error = ?error,
             owner = PAYMENT_OWNER,
             operation = COMPENSATE_CHECKOUT_PAYMENT_OPERATION,
             local_operation,
@@ -247,15 +272,15 @@ fn map_checkout_payment_compensation_local_port_error(
             metadata_kind = facts.metadata_kind,
             metadata_entry_count = ?facts.metadata_entry_count,
             internal_code = %error.code,
-            internal_message = %error.message,
-            error_kind = ?error.kind,
+            error_message_present = error_facts.message_present,
+            error_message_length = error_facts.message_length,
+            error_kind = error_facts.error_kind,
             retryable = error.retryable,
             boundary = PAYMENT_COMPENSATION_BOUNDARY,
             "payment checkout compensation local technical outcome retained safe context"
         );
     } else {
         tracing::warn!(
-            error = ?error,
             owner = PAYMENT_OWNER,
             operation = COMPENSATE_CHECKOUT_PAYMENT_OPERATION,
             local_operation,
@@ -283,8 +308,9 @@ fn map_checkout_payment_compensation_local_port_error(
             metadata_kind = facts.metadata_kind,
             metadata_entry_count = ?facts.metadata_entry_count,
             internal_code = %error.code,
-            internal_message = %error.message,
-            error_kind = ?error.kind,
+            error_message_present = error_facts.message_present,
+            error_message_length = error_facts.message_length,
+            error_kind = error_facts.error_kind,
             retryable = error.retryable,
             boundary = PAYMENT_COMPENSATION_BOUNDARY,
             "payment checkout compensation local outcome retained safe context"

--- a/scripts/verify/verify-payment-checkout-compensation-wrapper-error-diagnostic-safety.mjs
+++ b/scripts/verify/verify-payment-checkout-compensation-wrapper-error-diagnostic-safety.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const requireCount = (source, value, expected, label) => {
+  const count = source.split(value).length - 1;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+};
+
+function functionBody(source, functionName) {
+  const signature = new RegExp(
+    `(?:pub(?:\\([^)]*\\))?\\s+)?(?:async\\s+)?fn\\s+${functionName}(?:<[^>]*>)?\\s*\\(`,
+  );
+  const match = signature.exec(source);
+  if (!match) {
+    failures.push(`missing function ${functionName}`);
+    return "";
+  }
+  const openBrace = source.indexOf("{", match.index);
+  if (openBrace < 0) {
+    failures.push(`missing body for ${functionName}`);
+    return "";
+  }
+  let depth = 0;
+  for (let index = openBrace; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(openBrace, index + 1);
+    }
+  }
+  failures.push(`unterminated body for ${functionName}`);
+  return "";
+}
+
+const paths = {
+  source: "crates/rustok-payment/src/checkout_compensation_context.rs",
+  evidence:
+    "crates/rustok-payment/contracts/evidence/checkout-compensation-wrapper-diagnostic-safety-source.json",
+  review:
+    "crates/rustok-payment/contracts/evidence/checkout-compensation-wrapper-diagnostic-safety-source-review.json",
+  doc: "crates/rustok-payment/docs/checkout-compensation-local-context.md",
+  plan: "crates/rustok-commerce/docs/implementation-plan.md",
+};
+
+const source = read(paths.source);
+const evidence = JSON.parse(read(paths.evidence));
+const review = JSON.parse(read(paths.review));
+const doc = read(paths.doc);
+const plan = read(paths.plan);
+const helper = functionBody(source, "checkout_payment_compensation_port_error_facts");
+const mapper = functionBody(source, "map_checkout_payment_compensation_local_port_error");
+
+for (const marker of [
+  "struct CheckoutPaymentCompensationPortErrorFacts {",
+  "error_kind: &'static str",
+  "message_present: bool",
+  "message_length: usize",
+  "fn checkout_payment_compensation_port_error_facts(",
+]) {
+  requireText(source, marker, `${paths.source}: error fact model`);
+}
+
+for (const [variant, label] of [
+  ["Validation", "validation"],
+  ["NotFound", "not_found"],
+  ["Conflict", "conflict"],
+  ["Forbidden", "forbidden"],
+  ["Unavailable", "unavailable"],
+  ["Timeout", "timeout"],
+  ["InvariantViolation", "invariant_violation"],
+]) {
+  requireText(
+    helper,
+    `PortErrorKind::${variant} => "${label}"`,
+    `${paths.source}: static ${variant} label`,
+  );
+}
+for (const marker of [
+  "message_present: !error.message.trim().is_empty()",
+  "message_length: error.message.chars().count()",
+]) {
+  requireText(helper, marker, `${paths.source}: message shape`);
+}
+for (const forbidden of ["format!(", ".to_string()", "message_text", "debug_error"]) {
+  forbidText(helper, forbidden, `${paths.source}: fact payload values`);
+}
+
+for (const marker of [
+  "checkout_payment_compensation_local_operation(error.code.as_str())",
+  '"require_manual_reconciliation" | "validate_provider_journal_state"',
+  "PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation",
+  "let context_facts = checkout_payment_compensation_context_facts(context);",
+  "let error_facts = checkout_payment_compensation_port_error_facts(&error);",
+  "tracing::error!(",
+  "tracing::warn!(",
+  "internal_code = %error.code",
+  "error_message_present = error_facts.message_present",
+  "error_message_length = error_facts.message_length",
+  "error_kind = error_facts.error_kind",
+  "retryable = error.retryable",
+  "boundary = PAYMENT_COMPENSATION_BOUNDARY",
+  "\n    error\n}",
+]) {
+  requireText(mapper, marker, `${paths.source}: wrapper mapper`);
+}
+
+requireCount(mapper, "error_message_present = error_facts.message_present", 2, "two message presence fields");
+requireCount(mapper, "error_message_length = error_facts.message_length", 2, "two message length fields");
+requireCount(mapper, "error_kind = error_facts.error_kind", 2, "two static kind fields");
+requireCount(mapper, "internal_code = %error.code", 2, "two stable code fields");
+
+for (const forbidden of [
+  "error = ?error",
+  "error = %error",
+  "internal_message",
+  "error.message",
+  "error_kind = ?error.kind",
+  "error_kind = %error.kind",
+  "format!(\"{error",
+  "error.to_string()",
+]) {
+  forbidText(mapper, forbidden, `${paths.source}: complete PortError payload`);
+}
+
+for (const marker of [
+  "tenant_id_length = context_facts.tenant_id_length",
+  "actor_kind = context_facts.actor_kind",
+  "checkout_operation_id_non_nil = facts.checkout_operation_id_non_nil",
+  "collection_id_present = facts.collection_id_present",
+  "reason_length = ?facts.reason_length",
+  "metadata_kind = facts.metadata_kind",
+  "correlation_id = %context.correlation_id",
+]) {
+  requireText(mapper, marker, `${paths.source}: retained safe context`);
+}
+
+if (
+  evidence.status !==
+  "payment_checkout_compensation_wrapper_diagnostic_safety_source_unvalidated"
+) {
+  failures.push(`${paths.evidence}: unexpected status ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  stable_code_only_local_classification: true,
+  human_message_control_flow: false,
+  complete_port_error_logged_by_wrapper: false,
+  port_error_message_text_logged_by_wrapper: false,
+  static_error_kind_logged_by_wrapper: true,
+  error_message_presence_logged_by_wrapper: true,
+  error_message_length_logged_by_wrapper: true,
+  retryability_logged_by_wrapper: true,
+  delegated_port_error_changed: false,
+  same_port_error_returned: true,
+  public_code_changed: false,
+  public_message_changed: false,
+  public_kind_changed: false,
+  public_retryability_changed: false,
+  severity_classification_changed: false,
+  local_operation_mapping_changed: false,
+  owner_delegation_changed: false,
+  request_response_dto_changed: false,
+  persistent_owner_source_changed: false,
+  persistent_owner_diagnostic_cleanup_complete: false,
+  broad_ecommerce_cleanup_closed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "compile_proven",
+  "provider_replay_proven",
+  "restart_proven",
+  "remote_port_proven",
+  "mounted_runtime_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+
+if (
+  review.status !==
+  "payment_checkout_compensation_wrapper_diagnostic_safety_source_reviewed_unvalidated"
+) {
+  failures.push(`${paths.review}: unexpected status ${review.status}`);
+}
+for (const [key, expected] of Object.entries({
+  same_port_error_returned: true,
+  complete_port_error_logging_removed: true,
+  port_error_message_text_logging_removed: true,
+  static_error_kind_logged: true,
+  error_message_shape_logged: true,
+  severity_classification_preserved: true,
+  local_operation_mapping_preserved: true,
+  persistent_owner_source_unchanged: true,
+  persistent_owner_diagnostic_cleanup_complete: false,
+  focused_wrapper_guard_added: true,
+  runtime_evidence_claimed: false,
+})) {
+  if (review.review_findings?.[key] !== expected) {
+    failures.push(`${paths.review}: review_findings.${key} must be ${expected}`);
+  }
+}
+
+for (const marker of [
+  "Status: **source-ready / unvalidated**",
+  "They no longer record the complete `PortError`",
+  "The same original `PortError` is returned",
+  "Persistent owner payload-shape cleanup remains open.",
+  "No FBA or FFA status is promoted from source inspection.",
+]) {
+  requireText(doc, marker, `${paths.doc}: wrapper error policy`);
+}
+requireText(
+  plan,
+  "Finish correlation-safe mapper cleanup for order, payment execution/compensation,",
+  `${paths.plan}: broad ecommerce cleanup remains open`,
+);
+
+if (failures.length > 0) {
+  console.error(
+    "Payment checkout compensation wrapper error diagnostic-safety verification failed:",
+  );
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "Payment checkout compensation wrapper diagnostics retain only stable PortError kind and message shape while returning the same public error; owner payload cleanup remains open",
+);


### PR DESCRIPTION
## Summary

- continue the open ecommerce correlation-safe mapper cleanup at the checkout payment compensation public wrapper
- replace complete `PortError` debug and message-text diagnostics in both error and warning branches with a closed static kind plus message presence/length facts
- preserve stable-code local-operation routing, technical/integrity severity classification, safe request/context shape, owner delegation, and the unchanged returned `PortError`
- update wrapper source evidence/review and the compensation diagnostic-safety documentation
- add a focused fail-closed wrapper error diagnostic verifier

## Scope boundary

Exactly five files change: one compensation wrapper source file, two wrapper evidence files, one existing document, and one new focused verifier. The private persistent compensation owner is intentionally unchanged and remains the next payload-shape cleanup slice.

## Preserved behavior

- original context/request delegation
- unknown-code passthrough
- stable `PortError.code` local-operation mapping
- integrity/technical error-vs-warning classification
- public code, message, kind, retryability, and same-error return
- compensation lifecycle, provider cancel, journal, replay, reconciliation, and local cancellation behavior

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-payment-checkout-compensation-wrapper-error-diagnostic-safety.mjs
node scripts/verify/verify-payment-checkout-compensation-local-context.mjs
cargo check -p rustok-payment --lib
```

## Branch state

The branch is based on current `main` at `8fc2abb29670e663ccc1d430d83e12e478ab5eff`, is one commit ahead and zero behind, and changes exactly five files. Head commit: `e01bee7dc4becb81cb7e42e98e170d5db296f9fb`. Squash merge is intended.