### PR TITLE
test(blog): bind GraphQL composition into Comments port gate

### DIFF
--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -144,9 +144,15 @@ compile-only harness is
 `graphql::runtime_data::tests::graphql_runtime_data_exposes_comments_port_selection`,
 with suggested command
 `cargo test -p rustok-blog --lib graphql::runtime_data::tests::graphql_runtime_data_exposes_comments_port_selection -- --exact`.
-GraphQL Comments host selection is source-locked. Blog FBA package-chain
-registration remains pending, storefront/admin native SSR composition remains
-pending, and the remote network transport remains pending.
+The registered `verify:blog:comments-port-boundary` verifier now imports the
+standalone GraphQL verifier, and the registered
+`test:verify:blog:comments-port-boundary` self-test imports all twelve focused
+cases. `scripts/verify/verify-blog-fba.test.mjs` locks both imports alongside the
+HTTP composition imports. GraphQL Comments host selection is source-locked and
+mandatory inside the existing first-class Comments port leaf. Blog FBA
+package-chain registration remains pending only as a dedicated parallel leaf;
+that duplicate leaf is intentionally not added. Storefront/admin native SSR
+composition and the remote network transport remain pending.
 
 Comments lifecycle projection into Blog-owned `comment_count` is a Blog consumer
 boundary. `BlogCommentProjectionHandler` accepts only `comment.created` and
@@ -645,6 +651,21 @@ factory/selector harness retain the complete host→generated-schema→resolver 
 Blog FBA package-chain integration, native SSR wiring, the remote network
 transport, and all execution remain pending.
 
+The continuation audit at `f0a342a8713fd9a29ce485e6e1481a7099810b77`
+found that slice 61's GraphQL composition evidence, standalone verifier, focused
+fixture, and compile-only harness were complete, but the registered
+`comments_port_boundary` verifier and self-test still executed only their HTTP
+composition sub-contracts. Both aggregate package chains could therefore omit the
+GraphQL host→schema→resolver guard while retaining the same registry order.
+
+Slice 62 imports the standalone GraphQL verifier from the registered Comments port
+verifier and imports all twelve focused GraphQL cases from the registered Comments
+port self-test. The aggregate Blog FBA self-test locks both imports beside the
+existing HTTP assertions. Registry schema v13, package scripts, verify/test order,
+runtime source, evidence statuses, remote transport status, and all execution
+claims remain unchanged. GraphQL composition is now a mandatory sub-contract of
+the existing first-class Comments port leaf rather than a parallel duplicate leaf.
+
 ## FFA/FBA status
 
 - FFA status: `in_progress`.
@@ -658,9 +679,9 @@ transport, and all execution remain pending.
   plus aggregate/consumer bindings for admin, storefront, Comments port boundary,
   Comments event projection, category Search reindex, GraphQL rate limiting,
   GraphQL richtext, AI richtext, offline backfill, Forum ownership, and runtime
-  order. The existing Comments port leaf requires the HTTP composition verifier
-  and focused fixture through aggregate-locked imports. The standalone GraphQL
-  Comments composition guard remains outside registry package order in Slice 61.
+  order. The existing Comments port leaf requires both HTTP and GraphQL
+  composition verifiers and focused fixtures through aggregate-locked imports;
+  package order remains unchanged.
 - Comments consumer port boundary: Blog-owned `source_verified_no_compile` for
   the in-process profile; evidence schema v3, all seven operations, approved public
   read, typed richtext projection, two-second deadlines, write idempotency, active
@@ -670,16 +691,18 @@ transport, and all execution remain pending.
   host-provided port through `BlogHttpRuntime::comment_service` with an in-process
   fallback; schema-v1 evidence, standalone verification, all focused HTTP
   negatives, and both parent imports are retained inside the registered Comments
-  port gate. GraphQL public reads, moderation reads, and moderation mutation now
-  select the same optional host port through manifest-attached
-  `BlogGraphqlRuntimeData`; schema-v1 evidence, the generated schema attachment,
-  twelve focused cases, and a compile-only selector harness retain that standalone
-  source contract. Typed storefront comments availability remains across
-  GraphQL/native DTOs and Leptos UI; only external-service and timeout errors
-  degrade, while other errors propagate. GraphQL package-chain integration,
-  storefront/admin native SSR composition, the remote network transport, remote
-  adapter runtime parity, cached snapshot, comment-form fallback, browser/runtime
-  evidence, and broader degraded UI modes remain planned or pending.
+  port gate. GraphQL public reads, moderation reads, and moderation mutation select
+  the same optional host port through manifest-attached `BlogGraphqlRuntimeData`;
+  schema-v1 evidence, generated schema attachment, all twelve focused cases, the
+  compile-only selector harness, both parent imports, and aggregate assertions are
+  retained inside the same registered Comments port gate. Typed storefront
+  comments availability remains across GraphQL/native DTOs and Leptos UI; only
+  external-service and timeout errors degrade, while other errors propagate.
+  Dedicated Blog FBA package-chain registration remains pending only as an
+  intentionally absent parallel leaf. Storefront/admin native SSR composition,
+  the remote network transport, remote adapter runtime parity, cached snapshot,
+  comment-form fallback, browser/runtime evidence, and broader degraded UI modes
+  remain planned or pending.
 - Comments event projection: Blog-owned `source_verified_no_compile`; evidence
   schema v4, shared classifier/counter/retry-decision helpers, `executable_no_run`
   source harness, deterministic PostgreSQL retry-limit target, module-registration,
@@ -971,6 +994,10 @@ transport, and all execution remain pending.
     standalone verification, twelve focused cases, and a compile-only harness,
     and kept package registration, native SSR wiring, remote transport, and all
     execution pending.
+62. Bound the standalone GraphQL composition verifier and all twelve focused cases
+    into the already registered `comments-port-boundary` verify/test leaf, added
+    aggregate regressions for both required imports, preserved registry schema v13
+    and exact package order, and changed no runtime source or execution status.
 
 ## Next results
 
@@ -1013,9 +1040,8 @@ transport, and all execution remain pending.
    duplicate replay, dispatcher delivery output, four-connection convergence,
    both child process exits, the written duplicate, delete-before-create,
    missing-post replay, outbox rollback/retry, and same-process/new-connection
-   assertions; then register the GraphQL source guard in the Blog FBA package chain,
-   wire storefront native SSR and admin native SSR to the host-owned Comments port,
-   implement the remote network transport through
+   assertions; then wire storefront native SSR and admin native SSR to the
+   host-owned Comments port, implement the remote network transport through
    `CommentService::with_comments_thread_port`, and retain all-seven-operation
    adapter parity, naturally contended PostgreSQL retry-frequency evidence, full
    server-host restart recovery, browser parity for typed unavailable/timeout

--- a/scripts/verify/verify-blog-comments-port-boundary.mjs
+++ b/scripts/verify/verify-blog-comments-port-boundary.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import './verify-blog-comments-http-port-injection.mjs';
+import './verify-blog-comments-graphql-port-injection.mjs';
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 

--- a/scripts/verify/verify-blog-comments-port-boundary.test.mjs
+++ b/scripts/verify/verify-blog-comments-port-boundary.test.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import './verify-blog-comments-http-port-injection.test.mjs';
+import './verify-blog-comments-graphql-port-injection.test.mjs';
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';

--- a/scripts/verify/verify-blog-comments-port-boundary.test.mjs
+++ b/scripts/verify/verify-blog-comments-port-boundary.test.mjs
@@ -27,6 +27,10 @@ const injectionCommand =
   `cargo test -p rustok-blog --lib ${injectionTest} -- --exact`;
 const httpHarnessTest = 'controllers::tests::blog_http_runtime_exposes_comments_port_selection';
 const httpHarnessCommand = `cargo test -p rustok-blog --lib ${httpHarnessTest} -- --exact`;
+const graphqlHarnessTest =
+  'graphql::runtime_data::tests::graphql_runtime_data_exposes_comments_port_selection';
+const graphqlHarnessCommand =
+  `cargo test -p rustok-blog --lib ${graphqlHarnessTest} -- --exact`;
 
 function write(root, relativePath, content) {
   const target = path.join(root, relativePath);
@@ -53,10 +57,18 @@ function fixture({
   const evidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json';
   const fallbackEvidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json';
   const httpEvidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-http-port-injection.json';
+  const graphqlEvidencePath =
+    'crates/rustok-blog/contracts/evidence/blog-comments-graphql-port-injection.json';
   const servicePath = 'crates/rustok-blog/src/services/comment.rs';
   const httpRuntimePath = 'crates/rustok-blog/src/controllers/mod.rs';
   const httpControllerPath = 'crates/rustok-blog/src/controllers/comments.rs';
+  const manifestPath = 'crates/rustok-blog/rustok-module.toml';
+  const graphqlModulePath = 'crates/rustok-blog/src/graphql/mod.rs';
+  const graphqlRuntimeDataPath = 'crates/rustok-blog/src/graphql/runtime_data.rs';
   const graphqlOwnerPath = 'crates/rustok-blog/src/graphql/types.rs';
+  const graphqlMutationPath = 'crates/rustok-blog/src/graphql/mutation.rs';
+  const serverCodegenPath = 'apps/server/build.rs';
+  const serverSchemaPath = 'apps/server/src/graphql/schema.rs';
   const storefrontModelPath = 'crates/rustok-blog/storefront/src/model.rs';
   const storefrontGraphqlPath = 'crates/rustok-blog/storefront/src/transport/graphql_adapter.rs';
   const storefrontNativePath = 'crates/rustok-blog/storefront/src/transport/native_server_adapter.rs';
@@ -141,6 +153,46 @@ let selector: fn(&BlogHttpRuntime) -> CommentService = BlogHttpRuntime::comment_
 
   write(
     root,
+    manifestPath,
+    '[provides.graphql]\nquery = "graphql::BlogQuery"\nmutation = "graphql::BlogMutation"\nruntime_data_factory = "graphql::attach_schema_data"',
+  );
+  write(
+    root,
+    graphqlModulePath,
+    'mod runtime_data;\npub use runtime_data::{BlogGraphqlRuntimeData, attach_schema_data};',
+  );
+  write(
+    root,
+    serverCodegenPath,
+    'graphql_runtime_data_factory: Option<String> graphql_runtime_data_factory_expr builder = builder.data({factory}(inputs)?);',
+  );
+  write(
+    root,
+    serverSchemaPath,
+    'schema_codegen::attach_module_graphql_data(builder, &graphql_runtime_inputs)',
+  );
+  write(
+    root,
+    graphqlRuntimeDataPath,
+    `
+use rustok_api::graphql::GraphqlRuntimeInputs;
+use rustok_comments::CommentsThreadPort;
+comments_thread_port: Option<Arc<dyn CommentsThreadPort>>
+pub fn attach_schema_data(
+inputs.shared_get::<Arc<dyn CommentsThreadPort>>()
+pub(crate) fn comment_service(
+match self.comments_thread_port.clone()
+Some(comments_thread_port)
+CommentService::with_comments_thread_port(db, comments_thread_port)
+None => CommentService::new(db, event_bus)
+fn graphql_runtime_data_exposes_comments_port_selection()
+let factory: fn(&GraphqlRuntimeInputs) -> Result<BlogGraphqlRuntimeData, String>
+BlogGraphqlRuntimeData::comment_service;
+`,
+  );
+
+  write(
+    root,
     storefrontModelPath,
     `
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -173,6 +225,13 @@ ${broadNativeFallback ? 'Err(_) => BlogCommentList' : ''}
     root,
     graphqlOwnerPath,
     `
+use super::runtime_data::BlogGraphqlRuntimeData;
+async fn public_comments(
+let runtime = ctx.data::<BlogGraphqlRuntimeData>()?;
+let service = runtime.comment_service(db.clone(), event_bus.clone());
+async fn moderation_comments(
+let runtime = ctx.data::<BlogGraphqlRuntimeData>()?;
+let service = runtime.comment_service(db.clone(), event_bus.clone());
 pub enum GqlBlogCommentsAvailability
 pub availability: GqlBlogCommentsAvailability
 fn graphql_comments_read_availability(error: &BlogError)
@@ -181,6 +240,17 @@ ErrorKind::Timeout => Some(GqlBlogCommentsAvailability::Timeout)
 ${missingGraphqlAvailability ? '' : 'let Some(availability) = graphql_comments_read_availability(&error) else'}
 return Err(async_graphql::Error::new(error.to_string()));
 GqlBlogCommentsAvailability::Available
+`,
+  );
+  write(
+    root,
+    graphqlMutationPath,
+    `
+use super::runtime_data::BlogGraphqlRuntimeData;
+async fn moderate_comment(
+let runtime = ctx.data::<BlogGraphqlRuntimeData>()?;
+runtime
+.comment_service(db.clone(), event_bus.clone())
 `,
   );
   write(
@@ -294,6 +364,62 @@ Comments took too long to load. The article is still available.
 
   write(
     root,
+    graphqlEvidencePath,
+    JSON.stringify({
+      schema_version: 1,
+      module: 'blog',
+      surface: 'comments_graphql_port_injection',
+      role: 'consumer',
+      provider: 'comments',
+      status: 'source_verified_no_compile',
+      compile_policy: 'not_run_by_request',
+      runtime_status: 'not_run',
+      source_contract: {
+        module_manifest: manifestPath,
+        graphql_module: graphqlModulePath,
+        runtime_data: graphqlRuntimeDataPath,
+        comment_reads: graphqlOwnerPath,
+        comment_mutation: graphqlMutationPath,
+        consumer_service: servicePath,
+        consumer_matrix: evidencePath,
+        server_codegen: serverCodegenPath,
+        server_schema: serverSchemaPath,
+      },
+      profiles: {
+        source_verified: ['in_process_fallback', 'host_injected_port_selection'],
+        pending: ['remote_transport_implementation'],
+      },
+      composition: {
+        host_inputs: 'rustok_api::graphql::GraphqlRuntimeInputs',
+        manifest_factory: 'graphql::attach_schema_data',
+        schema_attachment: 'schema_codegen::attach_module_graphql_data',
+        schema_data: 'BlogGraphqlRuntimeData',
+        shared_value: 'Arc<dyn CommentsThreadPort>',
+        lookup: 'GraphqlRuntimeInputs::shared_get',
+        selector: 'BlogGraphqlRuntimeData::comment_service',
+        injected_constructor: 'CommentService::with_comments_thread_port',
+        fallback_constructor: 'CommentService::new',
+        graphql_operations: ['public_comments', 'moderation_comments', 'moderate_comment'],
+      },
+      harness: {
+        status: 'executable_no_run',
+        runtime_status: 'not_run',
+        source: graphqlRuntimeDataPath,
+        test: graphqlHarnessTest,
+        command: graphqlHarnessCommand,
+      },
+      registration: {
+        standalone_verifier:
+          'scripts/verify/verify-blog-comments-graphql-port-injection.mjs',
+        focused_fixture:
+          'scripts/verify/verify-blog-comments-graphql-port-injection.test.mjs',
+        blog_fba_package_chain: 'pending',
+      },
+    }),
+  );
+
+  write(
+    root,
     fallbackEvidencePath,
     JSON.stringify({
       schema_version: 2,
@@ -378,7 +504,7 @@ Comments took too long to load. The article is still available.
   write(
     root,
     'crates/rustok-blog/docs/implementation-plan.md',
-    'blog-comments-consumer-static-matrix.json blog-comments-runtime-fallback-smoke.json blog-comments-http-port-injection.json verify-blog-comments-http-port-injection.mjs verify-blog-comments-http-port-injection.test.mjs verify:blog:comments-port-boundary test:verify:blog:comments-port-boundary source_verified_no_compile typed storefront comments availability CommentService::with_comments_thread_port BlogHttpRuntime::comment_service HTTP moderation remote transport remains pending remote network transport remains pending cached snapshot and comment-form fallback remain planned Slice 59 Slice 60',
+    'blog-comments-consumer-static-matrix.json blog-comments-runtime-fallback-smoke.json blog-comments-http-port-injection.json verify-blog-comments-http-port-injection.mjs verify-blog-comments-http-port-injection.test.mjs blog-comments-graphql-port-injection.json verify-blog-comments-graphql-port-injection.mjs verify-blog-comments-graphql-port-injection.test.mjs BlogGraphqlRuntimeData graphql::attach_schema_data schema_codegen::attach_module_graphql_data GraphQL Comments host selection is source-locked Blog FBA package-chain registration remains pending verify:blog:comments-port-boundary test:verify:blog:comments-port-boundary source_verified_no_compile typed storefront comments availability CommentService::with_comments_thread_port BlogHttpRuntime::comment_service HTTP moderation remote transport remains pending remote network transport remains pending cached snapshot and comment-form fallback remain planned Slice 59 Slice 60 Slice 61 Slice 62',
   );
 
   return root;

--- a/scripts/verify/verify-blog-fba.test.mjs
+++ b/scripts/verify/verify-blog-fba.test.mjs
@@ -16,6 +16,8 @@ const commentsPortVerifier = 'scripts/verify/verify-blog-comments-port-boundary.
 const commentsPortSelfTest = 'scripts/verify/verify-blog-comments-port-boundary.test.mjs';
 const httpVerifierImport = "import './verify-blog-comments-http-port-injection.mjs';";
 const httpSelfTestImport = "import './verify-blog-comments-http-port-injection.test.mjs';";
+const graphqlVerifierImport = "import './verify-blog-comments-graphql-port-injection.mjs';";
+const graphqlSelfTestImport = "import './verify-blog-comments-graphql-port-injection.test.mjs';";
 
 function clone(value) {
   return JSON.parse(JSON.stringify(value));
@@ -87,6 +89,16 @@ test('Blog FBA policy retains HTTP composition verifier inside the registered Co
 test('Blog FBA policy retains HTTP composition focused fixture inside the registered Comments port self-test', () => {
   const source = readFileSync(commentsPortSelfTest, 'utf8');
   assert.ok(source.includes(httpSelfTestImport));
+});
+
+test('Blog FBA policy retains GraphQL composition verifier inside the registered Comments port gate', () => {
+  const source = readFileSync(commentsPortVerifier, 'utf8');
+  assert.ok(source.includes(graphqlVerifierImport));
+});
+
+test('Blog FBA policy retains GraphQL composition focused fixture inside the registered Comments port self-test', () => {
+  const source = readFileSync(commentsPortSelfTest, 'utf8');
+  assert.ok(source.includes(graphqlSelfTestImport));
 });
 
 test('Blog FBA verification-chain policy rejects removal of the storefront verify step', () => {


### PR DESCRIPTION
## Summary

- continue the canonical Blog implementation plan through slice 62
- import the standalone GraphQL Comments composition verifier from the already registered Comments port verifier
- import all twelve focused GraphQL composition cases from the registered Comments port self-test
- materialize the complete GraphQL manifest/runtime/codegen/schema/evidence fixture inside the parent self-test repo root
- lock both required imports in the aggregate Blog FBA self-test

## Scope and non-claims

This is an integration-only source-contract slice. It does not change Blog runtime code, `package.json`, registry schema v13, Blog FBA verify/test order, evidence execution statuses, native SSR composition, or the remote Comments transport. A dedicated parallel GraphQL leaf is intentionally not added because GraphQL composition is now a mandatory sub-contract of the existing first-class Comments port leaf.

No Rust or JavaScript test, verifier, formatting, compilation, database, browser, workflow, CI, or production command was run, per maintainer instruction.

## Suggested maintainer commands

```bash
npm run verify:blog:comments-port-boundary
npm run test:verify:blog:comments-port-boundary
npm run verify:blog:fba
npm run test:verify:blog:fba
```

## Branch state

The branch starts from `f0a342a8713fd9a29ce485e6e1481a7099810b77`. Current `main` is ahead only by unrelated Forum/Search/Distribution and Payment changes; the proposed diff changes exactly four Blog source-contract files.