### PR TITLE
test(index): retain reconciliation mutation storage recovery

### DIFF
--- a/crates/rustok-index/docs/m6-reconciliation-mutation-storage-failed-progress-recovery-postgres-harness.md
+++ b/crates/rustok-index/docs/m6-reconciliation-mutation-storage-failed-progress-recovery-postgres-harness.md
@@ -1,0 +1,107 @@
+# M6 reconciliation mutation-storage failed-progress recovery PostgreSQL harness
+
+Status: executable target retained, not run.
+
+This harness retains the current reconciliation behavior when mutation storage becomes temporarily unavailable on page two after page one has already crossed a durable progress boundary.
+
+## Failed run
+
+The fixture source owns two pages with a scan limit of one.
+
+Page one returns one valid upsert and continuation cursor `{ "offset": 1 }`. The canonical PostgreSQL reconciliation runner must:
+
+- apply the mutation;
+- persist one entity and one inbox row;
+- persist `pages_processed = 1` and `completed_passes = 0`;
+- persist source cursor `{ "offset": 1 }`;
+- execute the configured page-boundary heartbeat.
+
+The page-two source call blocks behind two async barriers. Once the test observes the running job at the page-one boundary, a separate schema-scoped connection temporarily renames only `index_entities`. The source is then released and returns a fully valid second-page mutation.
+
+Mutation persistence inserts its inbox candidate inside a transaction and then fails while reading the temporarily unavailable entity table. The whole page-two mutation transaction must roll back. The runner must return:
+
+- `IndexReconciliationRunError::MutationFailed`;
+- mutation position `0`;
+- dependency code `mutation_storage_retryable`;
+- `IndexReplayFailureKind::Retryable`.
+
+The table is restored before final evidence is read.
+
+## Durable failure evidence
+
+The failed job must retain the previous safe boundary:
+
+- state `failed`;
+- attempt count `1`;
+- `completed_passes = 0`;
+- `pages_processed = 1`;
+- source cursor `{ "offset": 1 }`;
+- cleared lease owner and expiry;
+- non-null completion timestamp;
+- exactly one entity and one inbox row.
+
+The exact failure diagnostic is:
+
+```json
+{
+  "contract": "index_reconciliation_run_failure_v1",
+  "dependency_code": "mutation_storage_retryable",
+  "retryable": true
+}
+```
+
+The object contains exactly three fields. It contains no database error text, SQL, table name, tenant, worker, job, source payload, mutation payload, transport detail or stack text.
+
+Retaining exactly one inbox row proves the page-two inbox candidate rolled back with the unavailable entity read. A later exact-tenant cancellation request must return `AlreadyTerminal(Failed)`.
+
+## Duplicate-safe recovery
+
+Failed reconciliation jobs are terminal and excluded from active acquisition under the current runner. Recovery therefore creates a new job from the initial source cursor.
+
+The recovery source returns:
+
+1. page one with the exact same event UUID, entity UUID and source version already committed by the failed job;
+2. the same valid page-two mutation that failed before durable persistence.
+
+The recovery job must:
+
+- use a different job UUID;
+- complete on attempt `1`;
+- process two pages and one pass;
+- execute one page-boundary heartbeat;
+- report two mutations;
+- report one duplicate, one applied and zero stale mutations;
+- persist a terminal null source cursor.
+
+Final PostgreSQL evidence requires one failed job plus one succeeded job, exactly two entities and exactly two inbox rows. A later invocation must return `AlreadyComplete` for the succeeded recovery job without another page scan.
+
+## Isolation
+
+The target reads `RUSTOK_INDEX_TEST_DATABASE_URL`, with PostgreSQL `DATABASE_URL` as a fallback. Without a PostgreSQL URL it reports a skip and succeeds.
+
+The fixture creates a unique PostgreSQL schema, creates the tenant owner row, applies every real `IndexModule` migration, persists one active schema, materializes canonical source and schema registries, reads durable evidence and drops the isolated schema.
+
+No sleep, polling delay, elapsed-time expiry or concurrent worker race is used. The only coordination is the deterministic page-two source barrier around the schema-local DDL transition.
+
+## Scope boundaries
+
+This harness does not change production code, migrations, reconciliation SQL or state machines, source or cursor contracts, mutation identity, schemas, diagnostics or public APIs.
+
+It does not add automatic retry, backoff, scheduling, attempt exhaustion, failed-scope dead-letter admission, authorized requeue, lease takeover, restart handling, source timeout, pending-future preemption, digest comparison, orphan cleanup, targeted/full/shadow repair, locale or partition dimensions, or complete drift repair.
+
+The canonical M6 reconciliation and drift-repair item therefore remains open.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
+  cargo test -p rustok-index \
+  --test source_reconciliation_mutation_storage_failed_progress_recovery_postgres_test \
+  -- --nocapture
+
+cargo check -p rustok-index --all-targets
+
+node scripts/verify/verify-index-reconciliation-mutation-storage-failed-progress-recovery-harness.mjs
+```

--- a/crates/rustok-index/tests/reconciliation_mutation_storage_failed_progress_recovery/connection.rs
+++ b/crates/rustok-index/tests/reconciliation_mutation_storage_failed_progress_recovery/connection.rs
@@ -1,0 +1,33 @@
+use std::{env, error::Error};
+
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection};
+
+pub type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+pub const DATABASE_ENV: &str = "RUSTOK_INDEX_TEST_DATABASE_URL";
+
+pub fn database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+pub async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+pub async fn scoped_connection(
+    database_url: &str,
+    schema_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url).await?;
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}""#))
+        .await?;
+    Ok(db)
+}

--- a/crates/rustok-index/tests/reconciliation_mutation_storage_failed_progress_recovery/database.rs
+++ b/crates/rustok-index/tests/reconciliation_mutation_storage_failed_progress_recovery/database.rs
@@ -1,0 +1,94 @@
+use rustok_core::MigrationSource;
+use rustok_index::IndexModule;
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement};
+use sea_orm_migration::SchemaManager;
+use uuid::Uuid;
+
+use super::{
+    connection::{DATABASE_ENV, TestResult, connect, database_url, scoped_connection},
+    schema::persist_schema,
+};
+
+pub struct TestDatabase {
+    control: DatabaseConnection,
+    database_url: String,
+    schema_name: String,
+    pub tenant_id: Uuid,
+}
+
+impl TestDatabase {
+    pub async fn setup() -> TestResult<Option<Self>> {
+        let Some(database_url) = database_url() else {
+            eprintln!(
+                "{DATABASE_ENV} is not set to a PostgreSQL URL; skipping reconciliation mutation storage failed progress recovery harness"
+            );
+            return Ok(None);
+        };
+        let control = connect(&database_url).await?;
+        let schema_name = format!(
+            "rustok_idx_mutstore_recover_{}",
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let tenant_id = Uuid::new_v4();
+        let db = scoped_connection(&database_url, &schema_name).await?;
+        db.execute_unprepared("CREATE TABLE tenants (id UUID NOT NULL PRIMARY KEY)")
+            .await?;
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "INSERT INTO tenants (id) VALUES ($1)",
+            vec![tenant_id.into()],
+        ))
+        .await?;
+
+        let manager = SchemaManager::new(&db);
+        for migration in IndexModule.migrations() {
+            migration.up(&manager).await?;
+        }
+        persist_schema(&db, tenant_id).await?;
+
+        Ok(Some(Self {
+            control,
+            database_url,
+            schema_name,
+            tenant_id,
+        }))
+    }
+
+    pub async fn connection(&self) -> TestResult<DatabaseConnection> {
+        scoped_connection(&self.database_url, &self.schema_name).await
+    }
+
+    pub async fn hide_entities_table(&self) -> TestResult<()> {
+        self.connection()
+            .await?
+            .execute_unprepared(
+                "ALTER TABLE index_entities RENAME TO index_entities_temporarily_unavailable",
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub async fn restore_entities_table(&self) -> TestResult<()> {
+        self.connection()
+            .await?
+            .execute_unprepared(
+                "ALTER TABLE index_entities_temporarily_unavailable RENAME TO index_entities",
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub async fn cleanup(self) -> TestResult<()> {
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/rustok-index/tests/reconciliation_mutation_storage_failed_progress_recovery/evidence.rs
+++ b/crates/rustok-index/tests/reconciliation_mutation_storage_failed_progress_recovery/evidence.rs
@@ -1,0 +1,62 @@
+use std::io;
+
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement};
+use serde_json::Value as JsonValue;
+use uuid::Uuid;
+
+use super::connection::TestResult;
+
+#[derive(Debug)]
+pub struct JobEvidence {
+    pub job_id: Uuid,
+    pub state: String,
+    pub attempt_count: i64,
+    pub completed_passes: i64,
+    pub pages_processed: i64,
+    pub source_cursor: JsonValue,
+    pub last_error_code: Option<String>,
+    pub last_error_details: Option<JsonValue>,
+    pub lease_released: bool,
+    pub completed: bool,
+}
+
+pub async fn read_job(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    state: &str,
+) -> TestResult<JobEvidence> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT job_id, state, attempt_count::bigint AS attempt_count_value, (cursor->>'completed_passes')::bigint AS completed_passes, (cursor->>'pages_processed')::bigint AS pages_processed, cursor->'source_cursor' AS source_cursor, last_error_code, last_error_details, (lease_owner IS NULL AND lease_expires_at IS NULL) AS lease_released, (completed_at IS NOT NULL) AS completed FROM index_jobs WHERE tenant_id = $1 AND kind = 'reconcile' AND state = $2 ORDER BY created_at DESC LIMIT 1",
+            vec![tenant_id.into(), state.to_owned().into()],
+        ))
+        .await?
+        .ok_or_else(|| io::Error::other(format!("reconciliation {state} job row is missing")))?;
+    Ok(JobEvidence {
+        job_id: row.try_get("", "job_id")?,
+        state: row.try_get("", "state")?,
+        attempt_count: row.try_get("", "attempt_count_value")?,
+        completed_passes: row.try_get("", "completed_passes")?,
+        pages_processed: row.try_get("", "pages_processed")?,
+        source_cursor: row.try_get("", "source_cursor")?,
+        last_error_code: row.try_get("", "last_error_code")?,
+        last_error_details: row.try_get("", "last_error_details")?,
+        lease_released: row.try_get("", "lease_released")?,
+        completed: row.try_get("", "completed")?,
+    })
+}
+
+pub async fn count(db: &DatabaseConnection, table: &str) -> TestResult<i64> {
+    let sql = match table {
+        "index_entities" => "SELECT COUNT(*)::bigint AS value FROM index_entities",
+        "index_inbox" => "SELECT COUNT(*)::bigint AS value FROM index_inbox",
+        "index_jobs" => "SELECT COUNT(*)::bigint AS value FROM index_jobs WHERE kind = 'reconcile'",
+        _ => panic!("unsupported fixture table"),
+    };
+    Ok(db
+        .query_one(Statement::from_string(DbBackend::Postgres, sql.to_owned()))
+        .await?
+        .ok_or_else(|| io::Error::other("count query returned no row"))?
+        .try_get("", "value")?)
+}

--- a/crates/rustok-index/tests/reconciliation_mutation_storage_failed_progress_recovery/runner.rs
+++ b/crates/rustok-index/tests/reconciliation_mutation_storage_failed_progress_recovery/runner.rs
@@ -1,0 +1,63 @@
+use std::{sync::Arc, time::Duration};
+
+use rustok_index::{
+    IndexReconciliationRunRequest, IndexSchemaSourceCatalog, IndexSourceCatalog,
+    PostgresIndexReconciliationRunner, SchemaRegistry,
+};
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use super::{
+    schema::{schema, schema_ref},
+    source::MutationStorageFailedProgressSource,
+};
+
+pub const SOURCE_NAME: &str = "mutation-storage-failed-progress-recovery-primary";
+
+pub fn runner(
+    db: DatabaseConnection,
+    source: MutationStorageFailedProgressSource,
+) -> PostgresIndexReconciliationRunner {
+    let schema = schema();
+    let mut schema_catalog = IndexSchemaSourceCatalog::new();
+    schema_catalog
+        .register(
+            "mutation-storage-failed-progress-recovery-harness",
+            schema.clone(),
+        )
+        .expect("fixture schema source must register");
+
+    let mut source_catalog = IndexSourceCatalog::new();
+    source_catalog
+        .register(
+            "mutation-storage-failed-progress-recovery-harness",
+            SOURCE_NAME,
+            [schema.reference.clone()],
+            source,
+        )
+        .expect("fixture source must register");
+    let sources = source_catalog
+        .materialize(&schema_catalog)
+        .expect("fixture source registry must materialize");
+
+    let mut registry = SchemaRegistry::new();
+    registry
+        .register(schema)
+        .expect("fixture schema registry must materialize");
+
+    PostgresIndexReconciliationRunner::new(db, sources, Arc::new(registry))
+}
+
+pub fn request(tenant_id: Uuid, worker_id: &str) -> IndexReconciliationRunRequest {
+    IndexReconciliationRunRequest::new(
+        tenant_id,
+        schema_ref(),
+        worker_id,
+        1,
+        4,
+        1,
+        1,
+        Duration::from_secs(3_600),
+    )
+    .expect("fixture reconciliation request must be valid")
+}

--- a/crates/rustok-index/tests/reconciliation_mutation_storage_failed_progress_recovery/schema.rs
+++ b/crates/rustok-index/tests/reconciliation_mutation_storage_failed_progress_recovery/schema.rs
@@ -1,0 +1,53 @@
+use rustok_index::{
+    EntityName, FieldCardinality, FieldName, IndexField, IndexSchema, IndexValueType,
+    LocaleMode, ModuleName, SchemaRef, SchemaVersion,
+};
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement, Value as SqlValue};
+use uuid::Uuid;
+
+use super::connection::TestResult;
+
+pub fn schema_ref() -> SchemaRef {
+    SchemaRef {
+        module: ModuleName::new("mutation-storage-failed-progress-recovery-harness").unwrap(),
+        entity: EntityName::new("item").unwrap(),
+        version: SchemaVersion::INITIAL,
+    }
+}
+
+pub fn schema() -> IndexSchema {
+    IndexSchema {
+        reference: schema_ref(),
+        locale_mode: LocaleMode::None,
+        fields: vec![IndexField {
+            name: FieldName::new("id").unwrap(),
+            value_type: IndexValueType::Uuid,
+            cardinality: FieldCardinality::One,
+            nullable: false,
+            selectable: true,
+            filterable: true,
+            sortable: true,
+        }],
+        links: Vec::new(),
+    }
+}
+
+pub async fn persist_schema(db: &DatabaseConnection, tenant_id: Uuid) -> TestResult<()> {
+    let schema = schema();
+    let fingerprint = schema.fingerprint()?.to_string();
+    let schema_json = serde_json::to_value(&schema)?;
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "INSERT INTO index_schemas (tenant_id, module_name, entity_name, schema_version, schema_fingerprint, schema_json, status) VALUES ($1, $2, $3, $4, $5, $6, 'active')",
+        vec![
+            tenant_id.into(),
+            schema.reference.module.as_str().to_owned().into(),
+            schema.reference.entity.as_str().to_owned().into(),
+            i64::from(schema.reference.version.get()).into(),
+            fingerprint.into(),
+            SqlValue::Json(Some(Box::new(schema_json))),
+        ],
+    ))
+    .await?;
+    Ok(())
+}

--- a/crates/rustok-index/tests/reconciliation_mutation_storage_failed_progress_recovery/source.rs
+++ b/crates/rustok-index/tests/reconciliation_mutation_storage_failed_progress_recovery/source.rs
@@ -1,0 +1,95 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use async_trait::async_trait;
+use rustok_index::{
+    EntityKey, FieldName, IndexMutation, IndexRecord, IndexSource, IndexSourceCursor,
+    IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest, IndexSourcePage,
+    IndexSourceScanRequest, IndexValue,
+};
+use serde_json::json;
+use tokio::sync::Barrier;
+use uuid::Uuid;
+
+use super::schema::schema_ref;
+
+#[derive(Clone)]
+pub enum MutationStorageFailedProgressSource {
+    BlockSecondPage {
+        entered: Arc<Barrier>,
+        release: Arc<Barrier>,
+    },
+    RecoverSecondPage,
+}
+
+#[async_trait]
+impl IndexSource for MutationStorageFailedProgressSource {
+    async fn scan(
+        &self,
+        request: IndexSourceScanRequest,
+    ) -> Result<IndexSourcePage, IndexSourceFailure> {
+        let offset = request
+            .cursor()
+            .and_then(|cursor| cursor.value().get("offset"))
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+
+        match offset {
+            0 => {
+                let cursor = IndexSourceCursor::new(json!({ "offset": 1 }))
+                    .expect("fixture cursor must be valid");
+                IndexSourcePage::new(
+                    &request,
+                    vec![valid_mutation(request.tenant_id(), 901, 15_901)],
+                    Some(cursor),
+                )
+                .map_err(|_| fixture_failure())
+            }
+            1 => {
+                if let Self::BlockSecondPage { entered, release } = self {
+                    entered.wait().await;
+                    release.wait().await;
+                }
+                IndexSourcePage::new(
+                    &request,
+                    vec![valid_mutation(request.tenant_id(), 902, 15_902)],
+                    None,
+                )
+                .map_err(|_| fixture_failure())
+            }
+            _ => Err(fixture_failure()),
+        }
+    }
+
+    async fn load(
+        &self,
+        request: IndexSourceLoadRequest,
+    ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+        Ok(IndexSourceLoadBatch::new(&request, Vec::new()).expect("empty targeted load"))
+    }
+}
+
+fn valid_mutation(tenant_id: Uuid, entity: u128, event: u128) -> IndexMutation {
+    let entity_id = Uuid::from_u128(entity);
+    IndexMutation::Upsert {
+        event_id: Uuid::from_u128(event),
+        record: IndexRecord {
+            key: EntityKey {
+                tenant_id,
+                schema: schema_ref(),
+                entity_id,
+                locale: None,
+            },
+            source_version: 1,
+            fields: BTreeMap::from([(
+                FieldName::new("id").unwrap(),
+                IndexValue::Uuid(entity_id),
+            )]),
+            links: Vec::new(),
+        },
+    }
+}
+
+fn fixture_failure() -> IndexSourceFailure {
+    IndexSourceFailure::permanent("mutation_storage_failed_progress_fixture_invalid")
+        .expect("fixture failure code must be valid")
+}

--- a/crates/rustok-index/tests/source_reconciliation_mutation_storage_failed_progress_recovery_postgres_test.rs
+++ b/crates/rustok-index/tests/source_reconciliation_mutation_storage_failed_progress_recovery_postgres_test.rs
@@ -1,0 +1,176 @@
+#[path = "reconciliation_mutation_storage_failed_progress_recovery/connection.rs"]
+mod connection;
+#[path = "reconciliation_mutation_storage_failed_progress_recovery/database.rs"]
+mod database;
+#[path = "reconciliation_mutation_storage_failed_progress_recovery/evidence.rs"]
+mod evidence;
+#[path = "reconciliation_mutation_storage_failed_progress_recovery/runner.rs"]
+mod runner;
+#[path = "reconciliation_mutation_storage_failed_progress_recovery/schema.rs"]
+mod schema;
+#[path = "reconciliation_mutation_storage_failed_progress_recovery/source.rs"]
+mod source;
+
+use std::sync::Arc;
+
+use rustok_index::{
+    IndexReconciliationCancelOutcome, IndexReconciliationRunError, IndexReconciliationRunStatus,
+    IndexReconciliationTerminalState, IndexReplayFailureKind,
+};
+use serde_json::json;
+use tokio::sync::Barrier;
+
+use connection::TestResult;
+use database::TestDatabase;
+use evidence::{count, read_job};
+use runner::{request, runner};
+use source::MutationStorageFailedProgressSource;
+
+const PAGE_FAILURE_CODE: &str = "index.reconciliation_page_failed";
+const FAILURE_CONTRACT: &str = "index_reconciliation_run_failure_v1";
+const STORAGE_FAILURE_CODE: &str = "mutation_storage_retryable";
+
+#[tokio::test]
+async fn retryable_second_page_storage_failure_preserves_progress_and_recovers_by_duplicate_redelivery(
+) -> TestResult<()> {
+    let Some(database) = TestDatabase::setup().await? else {
+        return Ok(());
+    };
+    let tenant_id = database.tenant_id;
+    let entered = Arc::new(Barrier::new(2));
+    let release = Arc::new(Barrier::new(2));
+    let failed_runner = runner(
+        database.connection().await?,
+        MutationStorageFailedProgressSource::BlockSecondPage {
+            entered: entered.clone(),
+            release: release.clone(),
+        },
+    );
+    let active_task = tokio::spawn(async move {
+        failed_runner
+            .run(request(tenant_id, "mutation-storage-progress-worker-a"))
+            .await
+    });
+
+    entered.wait().await;
+    let inspection = database.connection().await?;
+    let running = read_job(&inspection, tenant_id, "running").await?;
+    assert_eq!(running.state, "running");
+    assert_eq!(running.attempt_count, 1);
+    assert_eq!(running.completed_passes, 0);
+    assert_eq!(running.pages_processed, 1);
+    assert_eq!(running.source_cursor, json!({ "offset": 1 }));
+    assert_eq!(running.last_error_code, None);
+    assert_eq!(running.last_error_details, None);
+    assert!(!running.lease_released);
+    assert!(!running.completed);
+    assert_eq!(count(&inspection, "index_jobs").await?, 1);
+    assert_eq!(count(&inspection, "index_entities").await?, 1);
+    assert_eq!(count(&inspection, "index_inbox").await?, 1);
+
+    database.hide_entities_table().await?;
+    release.wait().await;
+    let task_result = active_task.await;
+    database.restore_entities_table().await?;
+    let error = task_result?
+        .expect_err("temporarily unavailable second-page entity storage must fail reconciliation");
+    match error {
+        IndexReconciliationRunError::MutationFailed { position, failure } => {
+            assert_eq!(position, 0);
+            assert_eq!(failure.code(), STORAGE_FAILURE_CODE);
+            assert_eq!(failure.kind(), IndexReplayFailureKind::Retryable);
+        }
+        other => panic!("unexpected reconciliation storage failure: {other:?}"),
+    }
+
+    let failed = read_job(&inspection, tenant_id, "failed").await?;
+    assert_eq!(failed.job_id, running.job_id);
+    assert_eq!(failed.state, "failed");
+    assert_eq!(failed.attempt_count, 1);
+    assert_eq!(failed.completed_passes, 0);
+    assert_eq!(failed.pages_processed, 1);
+    assert_eq!(failed.source_cursor, json!({ "offset": 1 }));
+    assert_eq!(failed.last_error_code.as_deref(), Some(PAGE_FAILURE_CODE));
+    assert_eq!(
+        failed.last_error_details,
+        Some(json!({
+            "contract": FAILURE_CONTRACT,
+            "dependency_code": STORAGE_FAILURE_CODE,
+            "retryable": true,
+        }))
+    );
+    assert_eq!(
+        failed
+            .last_error_details
+            .as_ref()
+            .and_then(serde_json::Value::as_object)
+            .expect("failure details must be an object")
+            .len(),
+        3
+    );
+    assert!(failed.lease_released);
+    assert!(failed.completed);
+    assert_eq!(count(&inspection, "index_jobs").await?, 1);
+    assert_eq!(count(&inspection, "index_entities").await?, 1);
+    assert_eq!(count(&inspection, "index_inbox").await?, 1);
+
+    let recovery_runner = runner(
+        database.connection().await?,
+        MutationStorageFailedProgressSource::RecoverSecondPage,
+    );
+    assert_eq!(
+        recovery_runner
+            .request_cancel(tenant_id, failed.job_id)
+            .await?,
+        IndexReconciliationCancelOutcome::AlreadyTerminal(
+            IndexReconciliationTerminalState::Failed
+        )
+    );
+
+    let recovery = recovery_runner
+        .run(request(tenant_id, "mutation-storage-progress-worker-b"))
+        .await?;
+    let recovery_job_id = recovery.job_id().expect("recovery job id");
+    assert_ne!(recovery_job_id, failed.job_id);
+    assert_eq!(recovery.status(), IndexReconciliationRunStatus::Complete);
+    assert_eq!(recovery.attempt_count(), Some(1));
+    assert_eq!(recovery.pages_processed(), 2);
+    assert_eq!(recovery.passes_completed(), 1);
+    assert_eq!(recovery.heartbeat_count(), 1);
+    assert_eq!(recovery.mutation_count(), 2);
+    assert_eq!(recovery.applied_count(), 1);
+    assert_eq!(recovery.duplicate_count(), 1);
+    assert_eq!(recovery.stale_count(), 0);
+
+    let succeeded = read_job(&inspection, tenant_id, "succeeded").await?;
+    assert_eq!(succeeded.job_id, recovery_job_id);
+    assert_eq!(succeeded.state, "succeeded");
+    assert_eq!(succeeded.attempt_count, 1);
+    assert_eq!(succeeded.completed_passes, 1);
+    assert_eq!(succeeded.pages_processed, 2);
+    assert_eq!(succeeded.source_cursor, json!(null));
+    assert_eq!(succeeded.last_error_code, None);
+    assert_eq!(succeeded.last_error_details, None);
+    assert!(succeeded.lease_released);
+    assert!(succeeded.completed);
+    assert_eq!(count(&inspection, "index_jobs").await?, 2);
+    assert_eq!(count(&inspection, "index_entities").await?, 2);
+    assert_eq!(count(&inspection, "index_inbox").await?, 2);
+
+    let already_complete = runner(
+        database.connection().await?,
+        MutationStorageFailedProgressSource::RecoverSecondPage,
+    )
+    .run(request(tenant_id, "mutation-storage-progress-worker-c"))
+    .await?;
+    assert_eq!(
+        already_complete.status(),
+        IndexReconciliationRunStatus::AlreadyComplete
+    );
+    assert_eq!(already_complete.job_id(), Some(recovery_job_id));
+    assert_eq!(already_complete.attempt_count(), None);
+    assert_eq!(already_complete.pages_processed(), 0);
+    assert_eq!(already_complete.passes_completed(), 1);
+
+    database.cleanup().await
+}

--- a/scripts/verify/verify-index-reconciliation-mutation-storage-failed-progress-recovery-harness.mjs
+++ b/scripts/verify/verify-index-reconciliation-mutation-storage-failed-progress-recovery-harness.mjs
@@ -1,0 +1,126 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const files = {
+  target:
+    "crates/rustok-index/tests/source_reconciliation_mutation_storage_failed_progress_recovery_postgres_test.rs",
+  source:
+    "crates/rustok-index/tests/reconciliation_mutation_storage_failed_progress_recovery/source.rs",
+  runner:
+    "crates/rustok-index/tests/reconciliation_mutation_storage_failed_progress_recovery/runner.rs",
+  evidence:
+    "crates/rustok-index/tests/reconciliation_mutation_storage_failed_progress_recovery/evidence.rs",
+  database:
+    "crates/rustok-index/tests/reconciliation_mutation_storage_failed_progress_recovery/database.rs",
+  docs:
+    "crates/rustok-index/docs/m6-reconciliation-mutation-storage-failed-progress-recovery-postgres-harness.md",
+};
+
+const read = (name) => {
+  const relative = files[name];
+  const absolute = path.join(root, relative);
+  if (!fs.existsSync(absolute)) {
+    throw new Error(`missing reconciliation mutation storage recovery file: ${relative}`);
+  }
+  return fs.readFileSync(absolute, "utf8");
+};
+
+const requireMarkers = (name, markers) => {
+  const content = read(name);
+  for (const marker of markers) {
+    if (!content.includes(marker)) {
+      throw new Error(`${files[name]} is missing required marker: ${marker}`);
+    }
+  }
+};
+
+const forbidMarkers = (name, markers) => {
+  const content = read(name);
+  for (const marker of markers) {
+    if (content.includes(marker)) {
+      throw new Error(`${files[name]} contains forbidden marker: ${marker}`);
+    }
+  }
+};
+
+requireMarkers("target", [
+  "retryable_second_page_storage_failure_preserves_progress_and_recovers_by_duplicate_redelivery",
+  "MutationStorageFailedProgressSource::BlockSecondPage",
+  "entered.wait().await",
+  "running.pages_processed, 1",
+  'running.source_cursor, json!({ "offset": 1 })',
+  'count(&inspection, "index_entities").await?, 1',
+  'count(&inspection, "index_inbox").await?, 1',
+  "database.hide_entities_table().await?",
+  "database.restore_entities_table().await?",
+  "IndexReconciliationRunError::MutationFailed",
+  "IndexReplayFailureKind::Retryable",
+  'const STORAGE_FAILURE_CODE: &str = "mutation_storage_retryable"',
+  'failed.source_cursor, json!({ "offset": 1 })',
+  '"retryable": true',
+  "IndexReconciliationTerminalState::Failed",
+  "assert_ne!(recovery_job_id, failed.job_id)",
+  "recovery.heartbeat_count(), 1",
+  "recovery.applied_count(), 1",
+  "recovery.duplicate_count(), 1",
+  "recovery.stale_count(), 0",
+  "IndexReconciliationRunStatus::AlreadyComplete",
+]);
+
+requireMarkers("source", [
+  "BlockSecondPage",
+  "RecoverSecondPage",
+  "entered.wait().await",
+  "release.wait().await",
+  'IndexSourceCursor::new(json!({ "offset": 1 }))',
+  "valid_mutation(request.tenant_id(), 901, 15_901)",
+  "valid_mutation(request.tenant_id(), 902, 15_902)",
+  'FieldName::new("id")',
+  "source_version: 1",
+]);
+
+requireMarkers("runner", [
+  "mutation-storage-failed-progress-recovery-primary",
+  "PostgresIndexReconciliationRunner::new",
+  "Duration::from_secs(3_600)",
+  "        4,",
+  "        1,",
+]);
+
+requireMarkers("evidence", [
+  "cursor->'source_cursor' AS source_cursor",
+  "last_error_code",
+  "last_error_details",
+  "lease_released",
+  "completed_at IS NOT NULL",
+  "ORDER BY created_at DESC LIMIT 1",
+]);
+
+requireMarkers("database", [
+  "RUSTOK_INDEX_TEST_DATABASE_URL",
+  "CREATE SCHEMA",
+  "IndexModule.migrations()",
+  "persist_schema",
+  "ALTER TABLE index_entities RENAME TO index_entities_temporarily_unavailable",
+  "ALTER TABLE index_entities_temporarily_unavailable RENAME TO index_entities",
+  "DROP SCHEMA IF EXISTS",
+]);
+
+requireMarkers("docs", [
+  "Status: executable target retained, not run.",
+  "temporarily unavailable on page two",
+  "The whole page-two mutation transaction must roll back.",
+  "exactly one entity and one inbox row",
+  "one duplicate, one applied and zero stale mutations",
+  "No sleep, polling delay, elapsed-time expiry or concurrent worker race is used.",
+  "The canonical M6 reconciliation and drift-repair item therefore remains open.",
+]);
+
+forbidMarkers("target", ["tokio::time::sleep", "std::thread::sleep"]);
+forbidMarkers("source", ["tokio::time::sleep", "std::thread::sleep"]);
+
+console.log(
+  "Index reconciliation mutation storage failed progress recovery harness markers verified.",
+);


### PR DESCRIPTION
## Summary

- add an environment-gated PostgreSQL integration target for a retryable mutation-storage failure on page two after page-one reconciliation progress is durable
- block the second source page behind deterministic async barriers
- temporarily rename only the isolated `index_entities` table after observing cursor `{ "offset": 1 }`
- require `IndexReconciliationRunError::MutationFailed` with retryable `mutation_storage_retryable`
- require the page-two mutation transaction to roll back its inbox candidate while preserving page-one entity, inbox and cursor progress
- restore storage and recover with a new job from the initial cursor
- duplicate-redeliver page one and apply page two exactly once
- add focused documentation and a standalone fail-closed verifier

## Failed run

The source owns two pages with scan limit one and stable event/entity identities.

Page one returns one valid upsert plus cursor `{ "offset": 1 }`. The canonical runner must apply it, persist one entity and one inbox row, publish `pages_processed = 1`, retain `completed_passes = 0`, and execute the configured page-boundary heartbeat.

The second source scan then blocks. A separate schema-scoped connection observes the running attempt at the page-one boundary and temporarily renames only `index_entities`. The source is released and returns a fully valid second-page mutation.

Mutation persistence inserts the page-two inbox candidate inside its transaction and then fails when it reads the unavailable entity table. The runner must return:

- `IndexReconciliationRunError::MutationFailed`
- mutation position `0`
- dependency code `mutation_storage_retryable`
- `IndexReplayFailureKind::Retryable`

The table is restored before final evidence reads.

## Durable rollback evidence

The failed job must retain:

- the original job UUID
- state `failed`
- attempt count `1`
- `completed_passes = 0`
- `pages_processed = 1`
- source cursor `{ "offset": 1 }`
- cleared lease owner and expiry
- non-null completion timestamp
- exactly one entity and exactly one inbox row

The exact diagnostic is:

```json
{
  "contract": "index_reconciliation_run_failure_v1",
  "dependency_code": "mutation_storage_retryable",
  "retryable": true
}
```

The object contains exactly three fields and no database error text, SQL, table name, tenant, worker, job, source payload, mutation payload, transport detail or stack text.

Retaining one inbox row proves the page-two inbox candidate rolled back with the failed entity read. A later exact-tenant cancellation request must return `AlreadyTerminal(Failed)`.

## Duplicate-safe recovery

Failed reconciliation rows are terminal and excluded from the current acquisition query, so recovery creates a new job from the initial source cursor.

The recovery source redelivers page one with the same event UUID, entity UUID and source version, then returns the same valid page-two mutation that failed before durable persistence.

Recovery must:

- use a different job UUID
- complete on attempt `1`
- process two pages and one pass
- execute one heartbeat
- report two mutations
- report one duplicate, one applied and zero stale mutations
- persist a terminal null source cursor
- leave exactly two jobs, two entities and two inbox rows

A later invocation must return `AlreadyComplete` for the succeeded recovery job.

## PostgreSQL isolation

The target reads `RUSTOK_INDEX_TEST_DATABASE_URL`, with PostgreSQL `DATABASE_URL` as a fallback. Without a PostgreSQL URL it reports a skip and succeeds.

The fixture creates a unique schema, creates the tenant owner row, applies every real `IndexModule` migration, persists one active schema, materializes canonical source/schema registries, reads durable evidence and drops the schema.

No sleep, polling delay, elapsed-time expiry or concurrent worker race is used. Coordination is limited to the deterministic page-two source barrier around the schema-local DDL transition.

## Scope boundaries

- no production code, migration, reconciliation SQL/state-machine, source/cursor contract, mutation identity, schema, diagnostic or public API change
- no automatic retry, backoff, scheduling or attempt exhaustion
- no failed-scope dead-letter admission or authorized requeue
- no lease takeover, restart, source timeout or pending-future preemption
- no digest comparison, orphan cleanup, targeted/full/shadow repair, locale/partition dimensions or complete drift repair

The canonical M6 reconciliation and drift-repair item remains open.

## Compatibility

- nine new test, documentation and verifier files; final diff is add-only
- no changed-file overlap with open Index PRs #2636, #2639, #2642, #2644, #2648, #2649, #2652, #2656, #2660, #2663, #2667, #2679, #2684, #2689, #2693, #2698, #2703, #2719, #2724, #2725 or #2727
- no implementation-plan edit while PR #2636 owns the canonical plan
- merge base: `a6ac8e05056b8ce899cf744da9fcde0848f919a2`
- current `main` advanced through unrelated Blog composition work to `b70845f9e970a7730a83773f86ff43bdf0a22527`

## Validation

Not run per maintainer instruction:

- Cargo formatting/checks/tests/Clippy
- JavaScript verifier
- PostgreSQL integration target
- CI workflows

Suggested maintainer commands:

```bash
RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
  cargo test -p rustok-index \
  --test source_reconciliation_mutation_storage_failed_progress_recovery_postgres_test \
  -- --nocapture

cargo check -p rustok-index --all-targets

node scripts/verify/verify-index-reconciliation-mutation-storage-failed-progress-recovery-harness.mjs
```

## Branch state

Branch: `agent/index-m6-reconciliation-mutation-storage-failed-progress-recovery-harness-20260731`

The connector produced nine sequential commits, one per new file. Squash merge is recommended after maintainer validation.