### PR TITLE
feat(blog): wire storefront native Comments port injection

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-comments-storefront-native-port-injection.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-storefront-native-port-injection.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": 1,
+  "module": "blog",
+  "surface": "comments_storefront_native_port_injection",
+  "role": "consumer",
+  "provider": "comments",
+  "status": "source_verified_no_compile",
+  "compile_policy": "not_run_by_request",
+  "runtime_status": "not_run",
+  "source_contract": {
+    "blog_facade": "crates/rustok-blog/src/lib.rs",
+    "native_adapter": "crates/rustok-blog/storefront/src/transport/native_server_adapter.rs",
+    "consumer_service": "crates/rustok-blog/src/services/comment.rs",
+    "consumer_matrix": "crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json",
+    "fallback_evidence": "crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json"
+  },
+  "profiles": {
+    "source_verified": [
+      "in_process_fallback",
+      "host_injected_port_selection"
+    ],
+    "pending": [
+      "admin_native_ssr_composition",
+      "remote_transport_implementation"
+    ]
+  },
+  "composition": {
+    "host_context": "rustok_api::HostRuntimeContext",
+    "shared_value": "Arc<dyn rustok_blog::CommentsThreadPort>",
+    "facade_reexport": "pub use rustok_comments::CommentsThreadPort;",
+    "lookup": "HostRuntimeContext::shared_get",
+    "selector": "comment_service",
+    "injected_constructor": "CommentService::with_comments_thread_port",
+    "fallback_constructor": "CommentService::new",
+    "native_endpoint": "blog/storefront-data",
+    "operation": "list_public_comments_for_target"
+  },
+  "availability": {
+    "states": [
+      "AVAILABLE",
+      "UNAVAILABLE",
+      "TIMEOUT"
+    ],
+    "degraded_error_kinds": [
+      "ExternalService",
+      "Timeout"
+    ],
+    "propagated_error_policy": "all_other_blog_errors"
+  },
+  "harness": {
+    "status": "executable_no_run",
+    "runtime_status": "not_run",
+    "source": "crates/rustok-blog/storefront/src/transport/native_server_adapter.rs",
+    "test": "transport::native_server_adapter::tests::storefront_native_runtime_exposes_comments_port_selection",
+    "command": "cargo test -p rustok-blog-storefront --features ssr transport::native_server_adapter::tests::storefront_native_runtime_exposes_comments_port_selection -- --exact"
+  },
+  "registration": {
+    "standalone_verifier": "scripts/verify/verify-blog-comments-storefront-native-port-injection.mjs",
+    "focused_fixture": "scripts/verify/verify-blog-comments-storefront-native-port-injection.test.mjs",
+    "blog_fba_package_chain": "pending"
+  },
+  "non_claims": [
+    "no remote network transport is implemented",
+    "no admin native SSR composition is implemented",
+    "no Rust or JavaScript test was run",
+    "no compile, database, browser, workflow, CI, or production result is recorded"
+  ]
+}

--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -25,7 +25,7 @@ both transports. It renders server-rendered `RichTextView` HTML with exactly one
 `content.html` sink and uses server-derived plain text as fallback. The public
 comments projection is Comments-owned and approved-only, and storefront comment
 pagination is route-owned and bounded consistently across GraphQL and native
-SSR. Public comment reads now carry typed `AVAILABLE`, `UNAVAILABLE`, or `TIMEOUT`
+SSR. Public comment reads carry typed `AVAILABLE`, `UNAVAILABLE`, or `TIMEOUT`
 availability across both transports, while the article remains renderable for the
 two degraded states. The active DTO/UI path has no legacy body or format field.
 
@@ -73,7 +73,7 @@ first-thread conflict, and typed propagation of unrelated insert storage errors.
 Blog consumes the owner result and does not duplicate thread locking, counter
 policy, or error classification.
 
-The Comments consumer call surface is now a first-class Blog source boundary.
+The Comments consumer call surface is a first-class Blog source boundary.
 `CommentService` depends on `Arc<dyn CommentsThreadPort>`, uses the in-process
 provider only through `in_process_comments_thread_port`, and routes all seven
 operations through typed `PortContext` / `PortError` contracts. Reads and writes
@@ -82,7 +82,9 @@ lists use the dedicated approved-only operation and service actor; richtext inpu
 view, and plain-text projections remain typed. `CommentService::new` remains the
 in-process convenience constructor, while public
 `CommentService::with_comments_thread_port` accepts a host-owned
-`Arc<dyn CommentsThreadPort>` without changing the owner service API. The retained
+`Arc<dyn CommentsThreadPort>` without changing the owner service API. The Blog
+facade re-exports `CommentsThreadPort` so UI packages can name the already-public
+injection contract without depending directly on the provider crate. The retained
 compile-only harness is
 `services::comment::port_injection_tests::comment_service_accepts_an_injected_comments_thread_port`
 in `crates/rustok-blog/src/services/comment.rs`, with suggested command
@@ -123,8 +125,8 @@ coverage. The retained compile-only harness is
 `controllers::tests::blog_http_runtime_exposes_comments_port_selection`, with
 suggested command
 `cargo test -p rustok-blog --lib controllers::tests::blog_http_runtime_exposes_comments_port_selection -- --exact`.
-HTTP moderation host selection is source-locked; native SSR composition plus the
-remote network transport remains pending.
+HTTP moderation host selection is source-locked; admin native SSR composition plus
+the remote network transport remains pending.
 
 GraphQL Comments composition is manifest-attached. The Blog package declares
 `runtime_data_factory = "graphql::attach_schema_data"`; generated server code
@@ -144,15 +146,34 @@ compile-only harness is
 `graphql::runtime_data::tests::graphql_runtime_data_exposes_comments_port_selection`,
 with suggested command
 `cargo test -p rustok-blog --lib graphql::runtime_data::tests::graphql_runtime_data_exposes_comments_port_selection -- --exact`.
-The registered `verify:blog:comments-port-boundary` verifier now imports the
-standalone GraphQL verifier, and the registered
-`test:verify:blog:comments-port-boundary` self-test imports all twelve focused
-cases. `scripts/verify/verify-blog-fba.test.mjs` locks both imports alongside the
-HTTP composition imports. GraphQL Comments host selection is source-locked and
-mandatory inside the existing first-class Comments port leaf. Blog FBA
-package-chain registration remains pending only as a dedicated parallel leaf;
-that duplicate leaf is intentionally not added. Storefront/admin native SSR
-composition and the remote network transport remain pending.
+The registered `verify:blog:comments-port-boundary` verifier imports the standalone
+GraphQL verifier, and the registered `test:verify:blog:comments-port-boundary`
+self-test imports all twelve focused cases. `scripts/verify/verify-blog-fba.test.mjs`
+locks both imports alongside the HTTP composition imports. GraphQL Comments host
+selection is source-locked and mandatory inside the existing first-class Comments
+port leaf. A dedicated parallel GraphQL leaf is intentionally absent. Admin native
+SSR composition and the remote network transport remain pending.
+
+Storefront native SSR Comments composition is host-attached. The selected-post
+server function reads `HostRuntimeContext`, and its single `comment_service`
+selector looks up an optional `Arc<dyn rustok_blog::CommentsThreadPort>` with
+`HostRuntimeContext::shared_get`. It chooses
+`CommentService::with_comments_thread_port` when the host supplies a port and
+preserves `CommentService::new` as the in-process fallback. The approved-only
+public read delegates through that selector without changing pagination or typed
+`AVAILABLE` / `UNAVAILABLE` / `TIMEOUT` degradation. Schema-v1 evidence lives at
+`crates/rustok-blog/contracts/evidence/blog-comments-storefront-native-port-injection.json`,
+guarded by
+`scripts/verify/verify-blog-comments-storefront-native-port-injection.mjs` and
+focused fixture
+`scripts/verify/verify-blog-comments-storefront-native-port-injection.test.mjs`.
+The retained compile-only harness is
+`transport::native_server_adapter::tests::storefront_native_runtime_exposes_comments_port_selection`,
+with suggested command
+`cargo test -p rustok-blog-storefront --features ssr transport::native_server_adapter::tests::storefront_native_runtime_exposes_comments_port_selection -- --exact`.
+Storefront native SSR Comments host selection is source-locked. Blog FBA
+package-chain registration remains pending, admin native SSR composition remains
+pending, and the remote network transport remains pending.
 
 Comments lifecycle projection into Blog-owned `comment_count` is a Blog consumer
 boundary. `BlogCommentProjectionHandler` accepts only `comment.created` and
@@ -170,8 +191,8 @@ source harness is the `services::comment_projection::tests` module in
 `executable_no_run` and suggested command
 `cargo test -p rustok-blog --lib services::comment_projection::tests`.
 
-The production optimistic-update loop now delegates every zero-row/success result
-to the shared pure `ProjectionUpdateDecision` helper. One updated row is applied
+The production optimistic-update loop delegates every zero-row/success result to
+the shared pure `ProjectionUpdateDecision` helper. One updated row is applied
 immediately; zero rows produce seven retry decisions before the eighth attempt
 reaches `LimitReached`. The retained Rust cases are
 `optimistic_retry_policy_applies_success_without_retry` and
@@ -666,6 +687,21 @@ runtime source, evidence statuses, remote transport status, and all execution
 claims remain unchanged. GraphQL composition is now a mandatory sub-contract of
 the existing first-class Comments port leaf rather than a parallel duplicate leaf.
 
+The continuation audit at `f7ffe816328f051bc00dcb3efa29f6ccbc0d8055`
+found that storefront native SSR still constructed `CommentService::new` directly
+for the selected post's approved public comments even though it already received
+`HostRuntimeContext`. The typed degradation path was complete, but a host-owned
+Comments port could not reach the native server function.
+
+Slice 63 re-exports the provider port contract through the Blog facade, adds the
+storefront native `comment_service` selector over `HostRuntimeContext::shared_get`,
+and routes the approved-only public read through injected or in-process
+construction while preserving typed availability. New schema-v1 evidence, a
+standalone verifier, focused positive/negative fixtures, and a compile-only
+selector harness retain the source contract. Blog FBA package-chain integration,
+admin native SSR composition, the remote network transport, and all execution
+remain pending.
+
 ## FFA/FBA status
 
 - FFA status: `in_progress`.
@@ -681,28 +717,25 @@ the existing first-class Comments port leaf rather than a parallel duplicate lea
   GraphQL richtext, AI richtext, offline backfill, Forum ownership, and runtime
   order. The existing Comments port leaf requires both HTTP and GraphQL
   composition verifiers and focused fixtures through aggregate-locked imports;
-  package order remains unchanged.
+  package order remains unchanged. The standalone storefront native composition
+  guard remains outside registry package order in Slice 63.
 - Comments consumer port boundary: Blog-owned `source_verified_no_compile` for
   the in-process profile; evidence schema v3, all seven operations, approved public
   read, typed richtext projection, two-second deadlines, write idempotency, active
   typed `PortErrorKind` mapping, public transport-neutral injection constructor,
-  compile-only exact-signature harness, exact npm leaf commands, focused fixture,
-  and Blog FBA ordering are locked. HTTP moderation selects an optional
-  host-provided port through `BlogHttpRuntime::comment_service` with an in-process
-  fallback; schema-v1 evidence, standalone verification, all focused HTTP
-  negatives, and both parent imports are retained inside the registered Comments
-  port gate. GraphQL public reads, moderation reads, and moderation mutation select
-  the same optional host port through manifest-attached `BlogGraphqlRuntimeData`;
-  schema-v1 evidence, generated schema attachment, all twelve focused cases, the
-  compile-only selector harness, both parent imports, and aggregate assertions are
-  retained inside the same registered Comments port gate. Typed storefront
-  comments availability remains across GraphQL/native DTOs and Leptos UI; only
-  external-service and timeout errors degrade, while other errors propagate.
-  Dedicated Blog FBA package-chain registration remains pending only as an
-  intentionally absent parallel leaf. Storefront/admin native SSR composition,
-  the remote network transport, remote adapter runtime parity, cached snapshot,
-  comment-form fallback, browser/runtime evidence, and broader degraded UI modes
-  remain planned or pending.
+  facade port re-export, compile-only exact-signature harness, exact npm leaf
+  commands, focused fixture, and Blog FBA ordering are locked. HTTP moderation
+  selects an optional host-provided port through `BlogHttpRuntime::comment_service`
+  with an in-process fallback; GraphQL public/moderation operations select the same
+  optional port through manifest-attached `BlogGraphqlRuntimeData`; both
+  composition guards are retained inside the registered Comments port gate.
+  Storefront native SSR approved public reads select the optional host port through
+  `comment_service`, preserve typed `AVAILABLE` / `UNAVAILABLE` / `TIMEOUT`
+  degradation, and retain schema-v1 evidence plus a standalone verifier, focused
+  fixture, and compile-only harness. Storefront package-chain integration, admin
+  native SSR composition, the remote network transport, remote adapter runtime
+  parity, cached snapshot, comment-form fallback, browser/runtime evidence, and
+  broader degraded UI modes remain planned or pending.
 - Comments event projection: Blog-owned `source_verified_no_compile`; evidence
   schema v4, shared classifier/counter/retry-decision helpers, `executable_no_run`
   source harness, deterministic PostgreSQL retry-limit target, module-registration,
@@ -751,6 +784,7 @@ the existing first-class Comments port leaf rather than a parallel duplicate lea
 - `crates/rustok-blog/contracts/evidence/blog-comments-consumer-runtime-order-smoke.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-http-port-injection.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-graphql-port-injection.json`
+- `crates/rustok-blog/contracts/evidence/blog-comments-storefront-native-port-injection.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-duplicate-delivery-race.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-dispatcher-duplicate-delivery.json`
@@ -794,6 +828,8 @@ the existing first-class Comments port leaf rather than a parallel duplicate lea
 - `scripts/verify/verify-blog-comments-http-port-injection.test.mjs`
 - `scripts/verify/verify-blog-comments-graphql-port-injection.mjs`
 - `scripts/verify/verify-blog-comments-graphql-port-injection.test.mjs`
+- `scripts/verify/verify-blog-comments-storefront-native-port-injection.mjs`
+- `scripts/verify/verify-blog-comments-storefront-native-port-injection.test.mjs`
 - `scripts/verify/verify-blog-comments-event-projection.mjs`
 - `scripts/verify/verify-blog-comments-event-projection.test.mjs`
 - `scripts/verify/verify-blog-comments-duplicate-delivery-race.mjs`
@@ -998,6 +1034,12 @@ the existing first-class Comments port leaf rather than a parallel duplicate lea
     into the already registered `comments-port-boundary` verify/test leaf, added
     aggregate regressions for both required imports, preserved registry schema v13
     and exact package order, and changed no runtime source or execution status.
+63. Re-exported the Comments port contract through the Blog facade, wired optional
+    host-provided port selection into storefront native SSR approved public reads,
+    preserved typed availability/error propagation, retained the selector in
+    schema-v1 evidence plus a standalone verifier, focused fixtures, and a
+    compile-only harness, and kept package integration, admin SSR, remote transport,
+    and all execution pending.
 
 ## Next results
 
@@ -1015,12 +1057,13 @@ the existing first-class Comments port leaf rather than a parallel duplicate lea
    controller handoff, focused verifier, then Redis-backed host requests with a
    real HTTP `Retry-After` matching GraphQL `retryAfter`.
 5. **Close comments runtime evidence.** Run the registered Comments port boundary
-   verifier and self-test, which include the standalone HTTP composition verifier
-   and all focused HTTP negatives, plus the standalone GraphQL composition verifier
-   and focused fixture, the compile-only injection-signature, HTTP selection, and
-   GraphQL runtime-data harnesses, shared consumer runtime-order verifier, Blog
-   projection classifier and deterministic retry-policy harness, module
-   registration/routing harness, the filtered
+   verifier and self-test, which include the standalone HTTP and GraphQL
+   composition verifiers and focused fixtures, plus the standalone storefront
+   native composition verifier and focused fixture, the compile-only
+   injection-signature, HTTP selection, GraphQL runtime-data, and storefront native
+   selector harnesses, shared consumer runtime-order verifier, Blog projection
+   classifier and deterministic retry-policy harness, module registration/routing
+   harness, the filtered
    `event_dispatcher_routes_registered_handler_and_commits_projection`,
    `event_dispatcher_replays_duplicate_envelope_without_double_commit`,
    `concurrent_created_events_converge_without_lost_updates`,
@@ -1040,8 +1083,9 @@ the existing first-class Comments port leaf rather than a parallel duplicate lea
    duplicate replay, dispatcher delivery output, four-connection convergence,
    both child process exits, the written duplicate, delete-before-create,
    missing-post replay, outbox rollback/retry, and same-process/new-connection
-   assertions; then wire storefront native SSR and admin native SSR to the
-   host-owned Comments port, implement the remote network transport through
+   assertions; then register the storefront native source guard inside the existing
+   Comments port gate, wire admin native SSR to the host-owned Comments port,
+   implement the remote network transport through
    `CommentService::with_comments_thread_port`, and retain all-seven-operation
    adapter parity, naturally contended PostgreSQL retry-frequency evidence, full
    server-host restart recovery, browser parity for typed unavailable/timeout
@@ -1068,6 +1112,9 @@ should run the relevant subset, including:
 - `node scripts/verify/verify-blog-comments-graphql-port-injection.mjs`
 - `node --test scripts/verify/verify-blog-comments-graphql-port-injection.test.mjs`
 - `cargo test -p rustok-blog --lib graphql::runtime_data::tests::graphql_runtime_data_exposes_comments_port_selection -- --exact`
+- `node scripts/verify/verify-blog-comments-storefront-native-port-injection.mjs`
+- `node --test scripts/verify/verify-blog-comments-storefront-native-port-injection.test.mjs`
+- `cargo test -p rustok-blog-storefront --features ssr transport::native_server_adapter::tests::storefront_native_runtime_exposes_comments_port_selection -- --exact`
 - `npm run verify:blog:comments-event-projection`
 - `npm run test:verify:blog:comments-event-projection`
 - `npm run verify:blog:comments-duplicate-delivery-race`
@@ -1126,6 +1173,7 @@ should run the relevant subset, including:
 - `RUSTOK_SEARCH_TEST_DATABASE_URL=postgresql://... cargo test -p rustok-search --test blog_projection_postgres_test`
 - `cargo check -p rustok-ai --features server`
 - `cargo check -p rustok-server --features mod-blog`
+- `cargo check -p rustok-blog-storefront --features ssr`
 - `cargo check -p rustok-blog-admin --features ssr`
 - `cargo check -p rustok-blog-admin --target wasm32-unknown-unknown --features hydrate`
 - `npm run verify --prefix packages/richtext`

--- a/crates/rustok-blog/src/lib.rs
+++ b/crates/rustok-blog/src/lib.rs
@@ -74,6 +74,7 @@ pub use dto::{
 pub use entities::*;
 pub use error::{BlogError, BlogResult};
 pub use graphql::{BlogMutation, BlogQuery};
+pub use rustok_comments::CommentsThreadPort;
 pub use services::{CategoryService, CommentService, PostService, TagService};
 pub use state_machine::{
     Archived, BlogPost, BlogPostStatus, CommentStatus, Draft, Published, ToBlogPostStatus,

--- a/crates/rustok-blog/storefront/Cargo.toml
+++ b/crates/rustok-blog/storefront/Cargo.toml
@@ -16,7 +16,6 @@ ssr = [
   "dep:rustok-outbox",
   "dep:rustok-tenant",
   "rustok-api/server",
-  "rustok-comments/server",
 ]
 
 [dependencies]
@@ -30,7 +29,6 @@ serde = { workspace = true, features = ["derive"] }
 rustok-core = { workspace = true, optional = true }
 rustok-blog = { workspace = true, optional = true }
 rustok-api = { workspace = true, default-features = false }
-rustok-comments = { workspace = true, default-features = false, optional = true }
 rustok-ui-i18n-leptos.workspace = true
 rustok-channel = { workspace = true, optional = true }
 rustok-outbox = { workspace = true, optional = true }

--- a/crates/rustok-blog/storefront/Cargo.toml
+++ b/crates/rustok-blog/storefront/Cargo.toml
@@ -16,6 +16,7 @@ ssr = [
   "dep:rustok-outbox",
   "dep:rustok-tenant",
   "rustok-api/server",
+  "rustok-comments/server",
 ]
 
 [dependencies]
@@ -29,6 +30,7 @@ serde = { workspace = true, features = ["derive"] }
 rustok-core = { workspace = true, optional = true }
 rustok-blog = { workspace = true, optional = true }
 rustok-api = { workspace = true, default-features = false }
+rustok-comments = { workspace = true, default-features = false, optional = true }
 rustok-ui-i18n-leptos.workspace = true
 rustok-channel = { workspace = true, optional = true }
 rustok-outbox = { workspace = true, optional = true }

--- a/crates/rustok-blog/storefront/src/transport/native_server_adapter.rs
+++ b/crates/rustok-blog/storefront/src/transport/native_server_adapter.rs
@@ -220,7 +220,7 @@ fn comment_service(
     event_bus: rustok_outbox::TransactionalEventBus,
 ) -> rustok_blog::CommentService {
     if let Some(comments_thread_port) =
-        runtime_ctx.shared_get::<Arc<dyn rustok_comments::CommentsThreadPort>>()
+        runtime_ctx.shared_get::<Arc<dyn rustok_blog::CommentsThreadPort>>()
     {
         rustok_blog::CommentService::with_comments_thread_port(
             runtime_ctx.db_clone(),

--- a/crates/rustok-blog/storefront/src/transport/native_server_adapter.rs
+++ b/crates/rustok-blog/storefront/src/transport/native_server_adapter.rs
@@ -8,6 +8,8 @@ use crate::model::{
     BlogCommentList, BlogCommentListItem, BlogCommentsAvailability, BlogPostDetail, BlogPostList,
 };
 use leptos::prelude::*;
+#[cfg(feature = "ssr")]
+use std::sync::Arc;
 
 use super::{ApiError, configured_tenant_slug};
 
@@ -51,9 +53,7 @@ async fn storefront_blog_native(
     {
         use leptos::prelude::expect_context;
         use rustok_api::HostRuntimeContext;
-        use rustok_blog::{
-            BlogPostStatus, CommentService, ListCommentsFilter, PostListQuery, PostService,
-        };
+        use rustok_blog::{BlogPostStatus, ListCommentsFilter, PostListQuery, PostService};
         use rustok_channel::ChannelService;
         use rustok_core::SecurityContext;
         use rustok_outbox::TransactionalEventBus;
@@ -141,22 +141,19 @@ async fn storefront_blog_native(
             });
 
         let selected_post = if let Some(post) = selected_post {
-            let public_comments = match CommentService::new(
-                runtime_ctx.db_clone(),
-                event_bus.clone(),
-            )
-            .list_for_post_with_locale_fallback(
-                tenant_id,
-                SecurityContext::public_read(),
-                post.id,
-                ListCommentsFilter {
-                    locale: Some(requested_locale.clone()),
-                    page: comments_page.max(1),
-                    per_page: COMMENTS_PAGE_SIZE,
-                },
-                Some(fallback_locale.as_str()),
-            )
-            .await
+            let public_comments = match comment_service(&runtime_ctx, event_bus.clone())
+                .list_for_post_with_locale_fallback(
+                    tenant_id,
+                    SecurityContext::public_read(),
+                    post.id,
+                    ListCommentsFilter {
+                        locale: Some(requested_locale.clone()),
+                        page: comments_page.max(1),
+                        per_page: COMMENTS_PAGE_SIZE,
+                    },
+                    Some(fallback_locale.as_str()),
+                )
+                .await
             {
                 Ok((comments, total)) => BlogCommentList {
                     availability: BlogCommentsAvailability::Available,
@@ -214,6 +211,23 @@ async fn storefront_blog_native(
         Err(ServerFnError::new(
             "blog/storefront-data requires the `ssr` feature",
         ))
+    }
+}
+
+#[cfg(feature = "ssr")]
+fn comment_service(
+    runtime_ctx: &rustok_api::HostRuntimeContext,
+    event_bus: rustok_outbox::TransactionalEventBus,
+) -> rustok_blog::CommentService {
+    if let Some(comments_thread_port) =
+        runtime_ctx.shared_get::<Arc<dyn rustok_comments::CommentsThreadPort>>()
+    {
+        rustok_blog::CommentService::with_comments_thread_port(
+            runtime_ctx.db_clone(),
+            comments_thread_port,
+        )
+    } else {
+        rustok_blog::CommentService::new(runtime_ctx.db_clone(), event_bus)
     }
 }
 
@@ -312,5 +326,19 @@ fn map_post_list_item(post: rustok_blog::PostSummary) -> BlogPostListItem {
         }
         .to_string(),
         published_at: post.published_at.map(|value| value.to_string()),
+    }
+}
+
+#[cfg(all(test, feature = "ssr"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn storefront_native_runtime_exposes_comments_port_selection() {
+        let selector: fn(
+            &rustok_api::HostRuntimeContext,
+            rustok_outbox::TransactionalEventBus,
+        ) -> rustok_blog::CommentService = comment_service;
+        let _ = selector;
     }
 }

--- a/scripts/verify/verify-blog-comments-storefront-native-port-injection.mjs
+++ b/scripts/verify/verify-blog-comments-storefront-native-port-injection.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve('.');
+const failures = [];
+
+function repoPath(relativePath) {
+  return path.join(repoRoot, relativePath);
+}
+
+function read(relativePath) {
+  const target = repoPath(relativePath);
+  if (!existsSync(target)) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return '';
+  }
+  return readFileSync(target, 'utf8');
+}
+
+function json(relativePath) {
+  try {
+    return JSON.parse(read(relativePath));
+  } catch (error) {
+    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function requireMarker(source, marker, label) {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+}
+
+function requireNoMarker(source, marker, label) {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+}
+
+function countMarker(source, marker) {
+  return source.split(marker).length - 1;
+}
+
+function sameSet(actual, expected) {
+  return [...actual].sort().join('|') === [...expected].sort().join('|');
+}
+
+const evidencePath =
+  'crates/rustok-blog/contracts/evidence/blog-comments-storefront-native-port-injection.json';
+const facadePath = 'crates/rustok-blog/src/lib.rs';
+const nativeAdapterPath =
+  'crates/rustok-blog/storefront/src/transport/native_server_adapter.rs';
+const servicePath = 'crates/rustok-blog/src/services/comment.rs';
+const consumerMatrixPath =
+  'crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json';
+const fallbackEvidencePath =
+  'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json';
+const planPath = 'crates/rustok-blog/docs/implementation-plan.md';
+const harnessTest =
+  'transport::native_server_adapter::tests::storefront_native_runtime_exposes_comments_port_selection';
+const harnessCommand =
+  `cargo test -p rustok-blog-storefront --features ssr ${harnessTest} -- --exact`;
+
+const evidence = json(evidencePath);
+const consumerMatrix = json(consumerMatrixPath);
+const fallbackEvidence = json(fallbackEvidencePath);
+const facade = read(facadePath);
+const nativeAdapter = read(nativeAdapterPath);
+const service = read(servicePath);
+const plan = read(planPath);
+
+if (evidence) {
+  if (evidence.schema_version !== 1) failures.push(`${evidencePath}: schema_version drift`);
+  if (
+    evidence.module !== 'blog' ||
+    evidence.surface !== 'comments_storefront_native_port_injection' ||
+    evidence.role !== 'consumer' ||
+    evidence.provider !== 'comments'
+  ) failures.push(`${evidencePath}: identity drift`);
+  if (evidence.status !== 'source_verified_no_compile') {
+    failures.push(`${evidencePath}: status drift`);
+  }
+  if (
+    evidence.compile_policy !== 'not_run_by_request' ||
+    evidence.runtime_status !== 'not_run'
+  ) failures.push(`${evidencePath}: execution policy drift`);
+
+  const expectedSources = {
+    blog_facade: facadePath,
+    native_adapter: nativeAdapterPath,
+    consumer_service: servicePath,
+    consumer_matrix: consumerMatrixPath,
+    fallback_evidence: fallbackEvidencePath,
+  };
+  for (const [key, expected] of Object.entries(expectedSources)) {
+    if (evidence.source_contract?.[key] !== expected) {
+      failures.push(`${evidencePath}: ${key} source path drift`);
+    }
+  }
+
+  if (
+    !sameSet(evidence.profiles?.source_verified ?? [], [
+      'in_process_fallback',
+      'host_injected_port_selection',
+    ])
+  ) failures.push(`${evidencePath}: source-verified profile drift`);
+  if (
+    !sameSet(evidence.profiles?.pending ?? [], [
+      'admin_native_ssr_composition',
+      'remote_transport_implementation',
+    ])
+  ) failures.push(`${evidencePath}: pending profile drift`);
+
+  const composition = evidence.composition ?? {};
+  if (
+    composition.host_context !== 'rustok_api::HostRuntimeContext' ||
+    composition.shared_value !== 'Arc<dyn rustok_blog::CommentsThreadPort>' ||
+    composition.facade_reexport !== 'pub use rustok_comments::CommentsThreadPort;' ||
+    composition.lookup !== 'HostRuntimeContext::shared_get' ||
+    composition.selector !== 'comment_service' ||
+    composition.injected_constructor !== 'CommentService::with_comments_thread_port' ||
+    composition.fallback_constructor !== 'CommentService::new' ||
+    composition.native_endpoint !== 'blog/storefront-data' ||
+    composition.operation !== 'list_public_comments_for_target'
+  ) failures.push(`${evidencePath}: composition drift`);
+
+  if (
+    !sameSet(evidence.availability?.states ?? [], ['AVAILABLE', 'UNAVAILABLE', 'TIMEOUT']) ||
+    !sameSet(evidence.availability?.degraded_error_kinds ?? [], [
+      'ExternalService',
+      'Timeout',
+    ]) ||
+    evidence.availability?.propagated_error_policy !== 'all_other_blog_errors'
+  ) failures.push(`${evidencePath}: availability drift`);
+
+  if (
+    evidence.harness?.status !== 'executable_no_run' ||
+    evidence.harness?.runtime_status !== 'not_run' ||
+    evidence.harness?.source !== nativeAdapterPath ||
+    evidence.harness?.test !== harnessTest ||
+    evidence.harness?.command !== harnessCommand
+  ) failures.push(`${evidencePath}: harness drift`);
+
+  if (
+    evidence.registration?.standalone_verifier !==
+      'scripts/verify/verify-blog-comments-storefront-native-port-injection.mjs' ||
+    evidence.registration?.focused_fixture !==
+      'scripts/verify/verify-blog-comments-storefront-native-port-injection.test.mjs' ||
+    evidence.registration?.blog_fba_package_chain !== 'pending'
+  ) failures.push(`${evidencePath}: registration drift`);
+}
+
+if (
+  consumerMatrix?.schema_version !== 3 ||
+  consumerMatrix?.status !== 'source_verified_no_compile' ||
+  !sameSet(consumerMatrix?.profiles?.source_verified ?? [], ['in_process']) ||
+  !sameSet(consumerMatrix?.profiles?.pending ?? [], ['remote_adapter_placeholder'])
+) failures.push(`${consumerMatrixPath}: base consumer status drift`);
+
+if (
+  fallbackEvidence?.schema_version !== 2 ||
+  fallbackEvidence?.status !== 'source_verified_no_compile' ||
+  fallbackEvidence?.runtime_status !== 'not_run' ||
+  !sameSet(
+    fallbackEvidence?.storefront_read_degradation?.availability_states ?? [],
+    ['AVAILABLE', 'UNAVAILABLE', 'TIMEOUT'],
+  ) ||
+  !sameSet(
+    fallbackEvidence?.storefront_read_degradation?.degraded_error_kinds ?? [],
+    ['ExternalService', 'Timeout'],
+  ) ||
+  fallbackEvidence?.storefront_read_degradation?.propagated_error_policy !==
+    'all_other_blog_errors'
+) failures.push(`${fallbackEvidencePath}: fallback evidence drift`);
+
+requireMarker(facade, 'pub use rustok_comments::CommentsThreadPort;', facadePath);
+
+for (const marker of [
+  'use std::sync::Arc;',
+  '#[server(prefix = "/api/fn", endpoint = "blog/storefront-data")]',
+  'let runtime_ctx = expect_context::<HostRuntimeContext>();',
+  'fn comment_service(',
+  'runtime_ctx: &rustok_api::HostRuntimeContext,',
+  'runtime_ctx.shared_get::<Arc<dyn rustok_blog::CommentsThreadPort>>()',
+  'rustok_blog::CommentService::with_comments_thread_port(',
+  'rustok_blog::CommentService::new(runtime_ctx.db_clone(), event_bus)',
+  'comment_service(&runtime_ctx, event_bus.clone())',
+  '.list_for_post_with_locale_fallback(',
+  'SecurityContext::public_read()',
+  'fn comments_read_availability(',
+  'ErrorKind::ExternalService',
+  'BlogCommentsAvailability::Unavailable',
+  'ErrorKind::Timeout',
+  'BlogCommentsAvailability::Timeout',
+  'let Some(availability) = comments_read_availability(&error) else',
+  'return Err(ServerFnError::new(error));',
+  'fn storefront_native_runtime_exposes_comments_port_selection()',
+  ') -> rustok_blog::CommentService = comment_service;',
+]) requireMarker(nativeAdapter, marker, nativeAdapterPath);
+
+if (countMarker(nativeAdapter, 'rustok_blog::CommentService::with_comments_thread_port(') !== 1) {
+  failures.push(`${nativeAdapterPath}: expected one injected constructor branch`);
+}
+if (countMarker(nativeAdapter, 'rustok_blog::CommentService::new(') !== 1) {
+  failures.push(`${nativeAdapterPath}: expected one in-process fallback branch`);
+}
+if (countMarker(nativeAdapter, 'comment_service(&runtime_ctx, event_bus.clone())') !== 1) {
+  failures.push(`${nativeAdapterPath}: expected one public-read selector handoff`);
+}
+requireNoMarker(nativeAdapter, 'rustok_comments::CommentsThreadPort', nativeAdapterPath);
+requireNoMarker(nativeAdapter, 'Err(_) => BlogCommentList', nativeAdapterPath);
+
+const lookupIndex = nativeAdapter.indexOf(
+  'runtime_ctx.shared_get::<Arc<dyn rustok_blog::CommentsThreadPort>>()',
+);
+const injectedIndex = nativeAdapter.indexOf(
+  'rustok_blog::CommentService::with_comments_thread_port(',
+);
+const fallbackIndex = nativeAdapter.indexOf('rustok_blog::CommentService::new(');
+if (
+  lookupIndex < 0 ||
+  injectedIndex < lookupIndex ||
+  fallbackIndex < injectedIndex
+) failures.push(`${nativeAdapterPath}: selector branch order drift`);
+
+for (const marker of [
+  'pub fn with_comments_thread_port(',
+  '.list_public_comments_for_target(',
+  'comments_public_read_port_context(',
+  'PortActor::service(PUBLIC_COMMENTS_PORT_ACTOR)',
+]) requireMarker(service, marker, servicePath);
+
+for (const marker of [
+  'blog-comments-storefront-native-port-injection.json',
+  'verify-blog-comments-storefront-native-port-injection.mjs',
+  'verify-blog-comments-storefront-native-port-injection.test.mjs',
+  'storefront native SSR Comments host selection is source-locked',
+  'admin native SSR composition remains pending',
+  'Blog FBA package-chain registration remains pending',
+  'remote network transport remains pending',
+  'Slice 63',
+]) requireMarker(plan, marker, planPath);
+
+if (failures.length > 0) {
+  console.error('Blog storefront native Comments port injection verification failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log('Blog storefront native Comments host selection and typed degradation source boundary is consistent');

--- a/scripts/verify/verify-blog-comments-storefront-native-port-injection.test.mjs
+++ b/scripts/verify/verify-blog-comments-storefront-native-port-injection.test.mjs
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const verifier = path.resolve(
+  'scripts/verify/verify-blog-comments-storefront-native-port-injection.mjs',
+);
+const evidencePath =
+  'crates/rustok-blog/contracts/evidence/blog-comments-storefront-native-port-injection.json';
+const facadePath = 'crates/rustok-blog/src/lib.rs';
+const nativeAdapterPath =
+  'crates/rustok-blog/storefront/src/transport/native_server_adapter.rs';
+const servicePath = 'crates/rustok-blog/src/services/comment.rs';
+const consumerMatrixPath =
+  'crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json';
+const fallbackEvidencePath =
+  'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json';
+const planPath = 'crates/rustok-blog/docs/implementation-plan.md';
+const harnessTest =
+  'transport::native_server_adapter::tests::storefront_native_runtime_exposes_comments_port_selection';
+const harnessCommand =
+  `cargo test -p rustok-blog-storefront --features ssr ${harnessTest} -- --exact`;
+
+function write(root, relativePath, content) {
+  const target = path.join(root, relativePath);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, content);
+}
+
+function fixture({
+  missingFacade = false,
+  missingLookup = false,
+  missingInjected = false,
+  missingFallback = false,
+  directReadConstruction = false,
+  missingSelectorHandoff = false,
+  missingPublicRead = false,
+  broadFallback = false,
+  missingAvailability = false,
+  missingHarness = false,
+  runtimePromoted = false,
+  adminPromoted = false,
+  remotePromoted = false,
+  registrationPromoted = false,
+  planDrift = false,
+} = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-blog-storefront-native-comments-'));
+
+  write(
+    root,
+    facadePath,
+    missingFacade ? '' : 'pub use rustok_comments::CommentsThreadPort;',
+  );
+
+  write(
+    root,
+    nativeAdapterPath,
+    `
+use std::sync::Arc;
+#[server(prefix = "/api/fn", endpoint = "blog/storefront-data")]
+let runtime_ctx = expect_context::<HostRuntimeContext>();
+fn comment_service(
+runtime_ctx: &rustok_api::HostRuntimeContext,
+${missingLookup ? '' : 'runtime_ctx.shared_get::<Arc<dyn rustok_blog::CommentsThreadPort>>()'}
+${missingInjected ? '' : 'rustok_blog::CommentService::with_comments_thread_port('}
+${missingFallback ? '' : 'rustok_blog::CommentService::new(runtime_ctx.db_clone(), event_bus)'}
+${
+  missingSelectorHandoff
+    ? ''
+    : 'comment_service(&runtime_ctx, event_bus.clone())'
+}
+${directReadConstruction ? 'rustok_blog::CommentService::new(runtime_ctx.db_clone(), event_bus.clone())' : ''}
+.list_for_post_with_locale_fallback(
+SecurityContext::public_read()
+fn comments_read_availability(
+ErrorKind::ExternalService
+${missingAvailability ? '' : 'BlogCommentsAvailability::Unavailable'}
+ErrorKind::Timeout
+${missingAvailability ? '' : 'BlogCommentsAvailability::Timeout'}
+let Some(availability) = comments_read_availability(&error) else
+return Err(ServerFnError::new(error));
+${broadFallback ? 'Err(_) => BlogCommentList' : ''}
+${
+  missingHarness
+    ? ''
+    : `
+fn storefront_native_runtime_exposes_comments_port_selection()
+) -> rustok_blog::CommentService = comment_service;
+`
+}
+`,
+  );
+
+  write(
+    root,
+    servicePath,
+    `
+pub fn with_comments_thread_port(
+${missingPublicRead ? '' : '.list_public_comments_for_target('}
+comments_public_read_port_context(
+PortActor::service(PUBLIC_COMMENTS_PORT_ACTOR)
+`,
+  );
+
+  write(
+    root,
+    consumerMatrixPath,
+    JSON.stringify({
+      schema_version: 3,
+      status: 'source_verified_no_compile',
+      profiles: {
+        source_verified: ['in_process'],
+        pending: ['remote_adapter_placeholder'],
+      },
+    }),
+  );
+
+  write(
+    root,
+    fallbackEvidencePath,
+    JSON.stringify({
+      schema_version: 2,
+      status: 'source_verified_no_compile',
+      runtime_status: 'not_run',
+      storefront_read_degradation: {
+        availability_states: ['AVAILABLE', 'UNAVAILABLE', 'TIMEOUT'],
+        degraded_error_kinds: ['ExternalService', 'Timeout'],
+        propagated_error_policy: 'all_other_blog_errors',
+      },
+    }),
+  );
+
+  const sourceVerified = ['in_process_fallback', 'host_injected_port_selection'];
+  const pending = ['admin_native_ssr_composition', 'remote_transport_implementation'];
+  if (adminPromoted) {
+    sourceVerified.push('admin_native_ssr_composition');
+    pending.splice(pending.indexOf('admin_native_ssr_composition'), 1);
+  }
+  if (remotePromoted) {
+    sourceVerified.push('remote_transport_implementation');
+    pending.splice(pending.indexOf('remote_transport_implementation'), 1);
+  }
+
+  write(
+    root,
+    evidencePath,
+    JSON.stringify({
+      schema_version: 1,
+      module: 'blog',
+      surface: 'comments_storefront_native_port_injection',
+      role: 'consumer',
+      provider: 'comments',
+      status: 'source_verified_no_compile',
+      compile_policy: 'not_run_by_request',
+      runtime_status: runtimePromoted ? 'passed' : 'not_run',
+      source_contract: {
+        blog_facade: facadePath,
+        native_adapter: nativeAdapterPath,
+        consumer_service: servicePath,
+        consumer_matrix: consumerMatrixPath,
+        fallback_evidence: fallbackEvidencePath,
+      },
+      profiles: {
+        source_verified: sourceVerified,
+        pending,
+      },
+      composition: {
+        host_context: 'rustok_api::HostRuntimeContext',
+        shared_value: 'Arc<dyn rustok_blog::CommentsThreadPort>',
+        facade_reexport: 'pub use rustok_comments::CommentsThreadPort;',
+        lookup: 'HostRuntimeContext::shared_get',
+        selector: 'comment_service',
+        injected_constructor: 'CommentService::with_comments_thread_port',
+        fallback_constructor: 'CommentService::new',
+        native_endpoint: 'blog/storefront-data',
+        operation: 'list_public_comments_for_target',
+      },
+      availability: {
+        states: ['AVAILABLE', 'UNAVAILABLE', 'TIMEOUT'],
+        degraded_error_kinds: ['ExternalService', 'Timeout'],
+        propagated_error_policy: 'all_other_blog_errors',
+      },
+      harness: {
+        status: 'executable_no_run',
+        runtime_status: 'not_run',
+        source: nativeAdapterPath,
+        test: harnessTest,
+        command: harnessCommand,
+      },
+      registration: {
+        standalone_verifier:
+          'scripts/verify/verify-blog-comments-storefront-native-port-injection.mjs',
+        focused_fixture:
+          'scripts/verify/verify-blog-comments-storefront-native-port-injection.test.mjs',
+        blog_fba_package_chain: registrationPromoted ? 'registered' : 'pending',
+      },
+    }),
+  );
+
+  write(
+    root,
+    planPath,
+    planDrift
+      ? ''
+      : 'blog-comments-storefront-native-port-injection.json verify-blog-comments-storefront-native-port-injection.mjs verify-blog-comments-storefront-native-port-injection.test.mjs storefront native SSR Comments host selection is source-locked admin native SSR composition remains pending Blog FBA package-chain registration remains pending remote network transport remains pending Slice 63',
+  );
+
+  return root;
+}
+
+function run(root) {
+  return spawnSync(process.execPath, [verifier], {
+    cwd: path.resolve('.'),
+    env: { ...process.env, RUSTOK_VERIFY_REPO_ROOT: root },
+    encoding: 'utf8',
+  });
+}
+
+function rejects(options) {
+  const root = fixture(options);
+  try {
+    return run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test('accepts the canonical storefront native Comments composition boundary', () => {
+  const root = fixture();
+  try {
+    const result = run(root);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects removal of the Blog facade port re-export', () => {
+  assert.notEqual(rejects({ missingFacade: true }).status, 0);
+});
+
+test('rejects removal of the host shared-value lookup', () => {
+  assert.notEqual(rejects({ missingLookup: true }).status, 0);
+});
+
+test('rejects removal of the injected selector branch', () => {
+  assert.notEqual(rejects({ missingInjected: true }).status, 0);
+});
+
+test('rejects removal of the in-process fallback branch', () => {
+  assert.notEqual(rejects({ missingFallback: true }).status, 0);
+});
+
+test('rejects direct provider construction in the storefront public read', () => {
+  assert.notEqual(rejects({ directReadConstruction: true }).status, 0);
+});
+
+test('rejects removal of the storefront selector handoff', () => {
+  assert.notEqual(rejects({ missingSelectorHandoff: true }).status, 0);
+});
+
+test('rejects removal of the approved-only public port operation', () => {
+  assert.notEqual(rejects({ missingPublicRead: true }).status, 0);
+});
+
+test('rejects broad storefront degradation for every error', () => {
+  assert.notEqual(rejects({ broadFallback: true }).status, 0);
+});
+
+test('rejects removal of typed unavailable and timeout states', () => {
+  assert.notEqual(rejects({ missingAvailability: true }).status, 0);
+});
+
+test('rejects removal of the compile-only selector harness', () => {
+  assert.notEqual(rejects({ missingHarness: true }).status, 0);
+});
+
+test('rejects runtime promotion without execution', () => {
+  assert.notEqual(rejects({ runtimePromoted: true }).status, 0);
+});
+
+test('rejects admin native SSR promotion without implementation', () => {
+  assert.notEqual(rejects({ adminPromoted: true }).status, 0);
+});
+
+test('rejects remote transport promotion without implementation', () => {
+  assert.notEqual(rejects({ remotePromoted: true }).status, 0);
+});
+
+test('rejects unearned Blog FBA package-chain registration', () => {
+  assert.notEqual(rejects({ registrationPromoted: true }).status, 0);
+});
+
+test('rejects canonical-plan drift', () => {
+  assert.notEqual(rejects({ planDrift: true }).status, 0);
+});


### PR DESCRIPTION
## Summary

- continue the canonical Blog implementation plan through slice 63
- re-export the transport-neutral `CommentsThreadPort` through the Blog facade
- select an optional host-provided Comments port in the storefront native SSR adapter
- preserve the existing in-process fallback, approved-only public read, pagination, and typed availability policy
- retain the selector through schema-v1 evidence, a standalone verifier, focused fixtures, and a compile-only harness

## Scope and non-claims

This is a source-only storefront native composition slice. It does not wire admin native SSR, implement a remote network transport, register the new standalone guard in the Blog FBA package chain, or promote runtime/browser evidence.

No Rust or JavaScript test, verifier, formatting, compilation, database, browser, workflow, CI, or production command was run, per maintainer instruction.

## Suggested maintainer commands

```bash
node scripts/verify/verify-blog-comments-storefront-native-port-injection.mjs
node --test scripts/verify/verify-blog-comments-storefront-native-port-injection.test.mjs
cargo test -p rustok-blog-storefront --features ssr \
  transport::native_server_adapter::tests::storefront_native_runtime_exposes_comments_port_selection \
  -- --exact
cargo check -p rustok-blog-storefront --features ssr
cargo check -p rustok-server --features mod-blog
cargo xtask module validate blog
```

## Branch state

The branch starts from `f7ffe816328f051bc00dcb3efa29f6ccbc0d8055`. Current `main` is ahead by unrelated Forum/Search and Order changes plus a net-zero accidental-file create/delete pair. The proposed diff changes exactly six Blog source/evidence files.