### PR TITLE
docs(forum): freeze versioned Search invalidation wire contract

### DIFF
--- a/DECISIONS/2026-07-31-forum-search-versioned-invalidation-rollout.md
+++ b/DECISIONS/2026-07-31-forum-search-versioned-invalidation-rollout.md
@@ -1,0 +1,85 @@
+# ADR: Forum Search versioned invalidation rollout
+
+- Status: accepted
+- Date: 2026-07-31
+
+## Context
+
+Forum already publishes the legacy root event `index.reindex_requested` inside
+the owner transaction. Search persists that envelope in one durable inbox,
+orders execution with a Search-issued `ingest_sequence`, and reconciles the
+result against a Forum-issued monotonic owner revision ledger.
+
+The owner revision is not present in the legacy root payload. A versioned typed
+wire fact is required for remote consumers, but adding it must not create a
+second Search projection executor, a second owner clock, or an event identity
+that cannot be reconciled with the existing inbox and checkpoint.
+
+The current event release train accepts schema version 1 only. A new payload is
+therefore a new sealed event type rather than a mutation of
+`index.reindex_requested`.
+
+## Decision
+
+`rustok-events` will own a sealed `ForumSearchProjectionEvent` family with one
+version-1 variant:
+
+```text
+forum.search_projection.invalidation_issued
+```
+
+The payload contains only:
+
+- positive `owner_revision`;
+- `target_type` in `forum|forum_category|forum_topic`;
+- nullable `target_id`, null only for `forum` and required otherwise.
+
+Tenant and actor remain envelope metadata. The typed envelope's
+`causation_id` is mandatory and equals the exact legacy
+`index.reindex_requested` root envelope ID recorded in
+`forum_projection_revision_ledger.event_id`.
+
+During this release train Forum publishes both representations in one owner
+transaction in this order:
+
+1. allocate the next Forum owner revision;
+2. publish the legacy root envelope and retain its ID;
+3. publish the typed contract envelope caused by that root ID;
+4. append the owner ledger row using the root ID;
+5. commit all owner state and both outbox rows atomically.
+
+Any failure rolls back the complete transaction. PostgreSQL is the only runtime
+profile for this dual publication because the owner revision ledger and Search
+reconciler are PostgreSQL-only.
+
+The legacy root publication remains mandatory until a future accepted ADR names
+its retirement evidence. The typed event is an additional transport contract,
+not a replacement identity in this milestone.
+
+Search will use one projection inbox and one projector. The typed consumer maps
+`ContractEventEnvelope.causation_id` to the existing
+`search_projection_inbox.event_id`; the legacy consumer uses the root envelope
+ID, which is the same value. The existing uniqueness boundary therefore
+collapses both deliveries into one durable work item. The typed envelope's own
+ID is retained only for transport receipt, DLQ, and diagnostics.
+
+A valid typed delivery is acknowledged only after the shared inbox insert or a
+durable duplicate result. Decode/schema/semantic poison is acknowledged only
+after a durable DLQ receipt and one successful DLQ publication. Transient
+storage, projection, or acknowledgement failure leaves the exact persistent
+cursor offset uncommitted. No process-local fallback or second projector is
+permitted.
+
+## Consequences
+
+- owner revision and Search `ingest_sequence` remain independent counters;
+- the typed payload can carry causal owner order without changing the legacy
+  root schema;
+- dual delivery is at-least-once but has one Search execution identity;
+- the Forum ledger remains the complete revision-to-root-event history;
+- Search checkpoint advancement remains checkpoint-after-projection-success;
+- event registry, digest artifact, publisher, persistent consumer, DLQ receipt,
+  and runtime evidence are separate implementation slices following this
+  contract freeze;
+- `FORUM-23` and `LINK-FORUM-03` remain open until implementation and maintainer
+  runtime evidence are complete.

--- a/crates/rustok-forum/contracts/forum-search-versioned-invalidation-wire.json
+++ b/crates/rustok-forum/contracts/forum-search-versioned-invalidation-wire.json
@@ -1,0 +1,153 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-23B2G2B3A",
+  "status": "contract_frozen_implementation_pending",
+  "scope": "Freeze the version-1 Forum Search owner-revision invalidation wire shape and rolling dual-delivery protocol before changing the sealed event registry or Search consumer runtime",
+  "decision": "DECISIONS/2026-07-31-forum-search-versioned-invalidation-rollout.md",
+  "canonical_forum_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "canonical_search_plan": "crates/rustok-search/docs/implementation-plan.md",
+  "predecessors": [
+    "crates/rustok-forum/contracts/forum-search-owner-revision-ledger.json",
+    "crates/rustok-forum/contracts/forum-search-owner-revision-counter-hardening.json",
+    "crates/rustok-forum/contracts/forum-search-owner-revision-source.json",
+    "crates/rustok-forum/contracts/forum-search-owner-revision-checkpoint.json",
+    "crates/rustok-forum/contracts/forum-search-durable-ingest-sequence.json"
+  ],
+  "event_contract": {
+    "registry_owner": "rustok-events",
+    "publisher_owner": "rustok-forum",
+    "consumer_owner": "rustok-search",
+    "rust_family": "ForumSearchProjectionEvent",
+    "transport_family": "forum_search_projection",
+    "variant": "InvalidationIssued",
+    "event_type": "forum.search_projection.invalidation_issued",
+    "schema_version": 1,
+    "payload": {
+      "owner_revision": {
+        "type": "int64",
+        "minimum": 1
+      },
+      "target_type": {
+        "type": "string",
+        "allowed": [
+          "forum",
+          "forum_category",
+          "forum_topic"
+        ]
+      },
+      "target_id": {
+        "type": "uuid",
+        "nullable": true,
+        "null_only_when_target_type": "forum",
+        "required_when_target_type": [
+          "forum_category",
+          "forum_topic"
+        ]
+      }
+    },
+    "forbidden_payload": [
+      "tenant_id",
+      "actor_id",
+      "ingest_sequence",
+      "locale",
+      "channel",
+      "visibility_snapshot",
+      "document_payload",
+      "reason",
+      "claims",
+      "roles"
+    ],
+    "envelope": {
+      "tenant_id_from_metadata": true,
+      "actor_id_from_metadata": true,
+      "causation_id_required": true,
+      "causation_id_equals_legacy_root_envelope_id": true,
+      "legacy_root_event_type": "index.reindex_requested",
+      "typed_envelope_id_is_projection_identity": false
+    }
+  },
+  "owner_transaction_protocol": {
+    "postgresql_only": true,
+    "order": [
+      "allocate_owner_revision",
+      "publish_legacy_root_and_retain_envelope_id",
+      "publish_typed_contract_caused_by_legacy_root",
+      "append_owner_ledger_with_legacy_root_envelope_id",
+      "commit_owner_transaction"
+    ],
+    "legacy_root_publication_required": true,
+    "typed_publication_required_after_rollout_enablement": true,
+    "failure_rolls_back_owner_state_root_typed_and_ledger": true,
+    "sqlite_dual_publication": false
+  },
+  "single_projection_path": {
+    "inbox_table": "search_projection_inbox",
+    "legacy_ingress_identity": "EventEnvelope.id",
+    "typed_ingress_identity": "ContractEventEnvelope.causation_id",
+    "shared_identity": "legacy root envelope ID",
+    "typed_envelope_id_usage": [
+      "transport_receipt",
+      "dead_letter_receipt",
+      "diagnostics"
+    ],
+    "typed_ingress_adapts_to_existing_root_inbox_shape": true,
+    "existing_inbox_unique_boundary_collapses_dual_delivery": true,
+    "existing_forum_projector_reused": true,
+    "second_inbox_forbidden": true,
+    "second_projector_forbidden": true
+  },
+  "consumer_cursor_protocol": {
+    "transport": "persistent contract consumer cursor",
+    "valid_event_terminal_result": "shared inbox inserted or durable duplicate recognized",
+    "valid_event_ack_after_terminal_result": true,
+    "decode_schema_or_semantic_poison_terminal_result": "durable DLQ receipt and one successful DLQ publication",
+    "poison_ack_after_terminal_result": true,
+    "transient_failure_acknowledged": false,
+    "ack_failure_acknowledged": false,
+    "process_local_fallback": false,
+    "exact_cursor_receive_and_ack": true
+  },
+  "ordering": {
+    "owner_revision_source": "forum_projection_revision_ledger.revision",
+    "delivery_order_source": "search_projection_inbox.ingest_sequence",
+    "owner_revision_compared_numerically_with_ingest_sequence": false,
+    "checkpoint_advances_only_after_projection_success": true,
+    "legacy_root_event_id_remains_ledger_identity": true
+  },
+  "rollout_slices": [
+    {
+      "task": "FORUM-23B2G2B3A",
+      "result": "freeze contract and rollout decision"
+    },
+    {
+      "task": "FORUM-23B2G2B3B",
+      "result": "add sealed v1 family, registry, schema digest, causation-aware outbox publication and Forum dual publisher"
+    },
+    {
+      "task": "FORUM-23B2G2B3C",
+      "result": "add Search persistent contract consumer, durable poison receipt and one-inbox dedupe adapter"
+    },
+    {
+      "task": "FORUM-23B2G2B3D",
+      "result": "capture PostgreSQL, persistent cursor, restart, poison, dual-delivery and LINK-FORUM-03 evidence"
+    }
+  ],
+  "current_slice_changes": {
+    "sealed_event_family_added": false,
+    "event_registry_changed": false,
+    "event_digest_changed": false,
+    "forum_publisher_changed": false,
+    "search_consumer_changed": false,
+    "search_inbox_changed": false,
+    "projection_execution_changed": false,
+    "canonical_task_closed": false
+  },
+  "non_claims": [
+    "This slice does not publish the typed event",
+    "This slice does not add a persistent Search contract consumer",
+    "This slice does not change the legacy root event payload or event type",
+    "This slice does not retire legacy root publication",
+    "This slice does not claim PostgreSQL, Iggy, restart, poison, DLQ, ACL or LINK-FORUM-03 runtime evidence",
+    "Tests, verifiers, formatting, Cargo checks, Clippy and runtime evidence were not executed by the implementation agent"
+  ]
+}

--- a/crates/rustok-forum/docs/forum-23b2g2b3a-versioned-invalidation-wire-contract.md
+++ b/crates/rustok-forum/docs/forum-23b2g2b3a-versioned-invalidation-wire-contract.md
@@ -1,0 +1,202 @@
+# FORUM-23B2G2B3A versioned Search invalidation wire contract
+
+## Status
+
+`contract_frozen_implementation_pending`
+
+This slice freezes the version-1 typed wire contract and rollout sequence for
+Forum Search projection invalidations. It deliberately does not modify the
+sealed event registry, digest artifact, Forum publisher, Search inbox, Search
+worker, Iggy consumer, or projection execution.
+
+The accepted cross-module decision is:
+
+```text
+DECISIONS/2026-07-31-forum-search-versioned-invalidation-rollout.md
+```
+
+The machine-readable contract is:
+
+```text
+crates/rustok-forum/contracts/forum-search-versioned-invalidation-wire.json
+```
+
+## Why a new event type
+
+The current release train permits schema version 1 only. The legacy root event
+`index.reindex_requested` cannot gain an owner revision without changing its
+payload contract. The rollout therefore introduces a new sealed event type
+rather than mutating the established root shape:
+
+```text
+family: forum_search_projection
+Rust family: ForumSearchProjectionEvent
+variant: InvalidationIssued
+event type: forum.search_projection.invalidation_issued
+schema version: 1
+```
+
+The v1 payload contains exactly the causal facts required by a downstream
+projection owner:
+
+```text
+owner_revision: positive int64
+target_type: forum | forum_category | forum_topic
+target_id: null for forum; non-nil UUID for forum_category/forum_topic
+```
+
+Tenant and actor remain typed-envelope metadata. Locale, channel, visibility,
+rendered content, document payload, reason, claims, roles and Search
+`ingest_sequence` do not belong in the event.
+
+## One owner transaction
+
+After implementation is enabled on PostgreSQL, Forum must perform one atomic
+sequence:
+
+1. allocate the next tenant-scoped owner revision;
+2. publish the existing `index.reindex_requested` root envelope and retain its
+   exact envelope ID;
+3. publish `forum.search_projection.invalidation_issued` with
+   `causation_id` equal to that root envelope ID;
+4. append `forum_projection_revision_ledger` using the same root envelope ID;
+5. commit owner state, both outbox rows, the counter and the ledger row together.
+
+Failure at any point rolls back the complete owner transaction. The typed event
+must not be emitted separately after commit, and the ledger must not switch to
+the typed envelope ID.
+
+SQLite remains validation-only for this projection boundary. It has no matching
+owner revision ledger or PostgreSQL Search background reconciler and therefore
+does not dual-publish the typed invalidation.
+
+## Why legacy publication remains
+
+The legacy root envelope ID is already the canonical identity in:
+
+```text
+forum_projection_revision_ledger.event_id
+search_projection_inbox.event_id
+```
+
+This release train keeps legacy publication mandatory. The typed event adds an
+explicit remote-consumer contract but does not replace the root identity. Any
+future retirement requires a separate accepted ADR and evidence proving a new
+stable projection identity, replay behavior and checkpoint migration.
+
+## One Search inbox and one projector
+
+The future typed consumer must not create a parallel Search execution lane.
+Instead it adapts the validated typed event into the existing root-compatible
+Forum inbox representation:
+
+```text
+legacy ingress inbox identity = EventEnvelope.id
+typed ingress inbox identity  = ContractEventEnvelope.causation_id
+shared identity               = legacy root envelope ID
+```
+
+`search_projection_inbox` already uses `ON CONFLICT (event_id) DO NOTHING`.
+Whichever representation arrives first creates the one durable work item; the
+other is a duplicate of the same owner invalidation. Both therefore converge on
+the existing `ForumProjectionInbox`, `ForumProjectionReconciler` and
+`ForumSearchProjector` path.
+
+The typed envelope's own ID is retained only for the persistent transport
+receipt, poison/DLQ receipt and diagnostics. It is never used as a second
+projection identity or a second owner revision.
+
+## Persistent cursor and poison policy
+
+The future Search consumer must use the existing persistent typed-contract
+consumer cursor contract. Receive and acknowledgement use the same cursor.
+
+A valid Forum Search invalidation can be acknowledged only after:
+
+- the shared inbox row is durably inserted; or
+- the existing durable row for the shared event identity is recognized.
+
+A decode, schema or semantic poison delivery can be acknowledged only after:
+
+- a durable poison/DLQ receipt is stored for the exact broker message identity;
+- the DLQ payload is published once or a previous successful publication is
+  durably recognized.
+
+Transient database, transport, projection or acknowledgement failure leaves the
+exact source offset uncommitted. The owner process must fail or retry under its
+supervisor rather than silently falling back to an in-memory consumer.
+
+Unrelated sealed event families may be ignored by this dedicated consumer only
+through the normal validated persistent-cursor path; they must not be decoded as
+Forum events.
+
+## Independent clocks
+
+The typed payload carries Forum causal order:
+
+```text
+forum_projection_revision_ledger.revision
+```
+
+Search delivery execution continues to use:
+
+```text
+search_projection_inbox.ingest_sequence
+```
+
+These values remain independent and are never compared numerically. The owner
+revision checkpoint still advances only after the projection state commits or a
+missing/dead-lettered delivery is repaired successfully.
+
+## Planned implementation slices
+
+### `FORUM-23B2G2B3B`
+
+Add `ForumSearchProjectionEvent` to `rustok-events`, register its v1 schema,
+update the committed registry and wire-schema digest artifact, add an additive
+causation-aware typed-envelope publication API, and dual-publish from the Forum
+owner transaction while retaining legacy root and ledger identity.
+
+### `FORUM-23B2G2B3C`
+
+Add the Search-owned persistent typed-contract consumer, durable poison/DLQ
+receipt and one-inbox adapter keyed by the legacy root causation ID. It must
+reuse the existing inbox claimant and projector.
+
+### `FORUM-23B2G2B3D`
+
+Capture maintainer-executed PostgreSQL and persistent-cursor evidence for normal
+delivery, root-first and typed-first duplicate races, restart, poison, DLQ
+publication, acknowledgement failure, missing delivery repair, multi-process
+serialization, deletion/ACL ordering and `LINK-FORUM-03`.
+
+## Current-slice boundary
+
+G2B3A does not:
+
+- add `ForumSearchProjectionEvent` or a `ContractEventPayload` variant;
+- change `event-contract-digests.json`;
+- change `projection_invalidation.rs`;
+- publish a typed outbox row;
+- add a Search persistent contract consumer;
+- change the Search inbox schema or projection executor;
+- close `FORUM-23` or `LINK-FORUM-03`.
+
+The canonical tasks remain `in_progress` because implementation and runtime
+evidence are still pending.
+
+## Maintainer verification
+
+The implementation agent did not run these commands:
+
+```bash
+node scripts/verify/verify-forum-search-versioned-invalidation-wire.mjs
+cargo run -p rustok-events --example event_contract_digests
+cargo test -p rustok-events
+cargo check -p rustok-forum -p rustok-search -p rustok-outbox
+cargo clippy -p rustok-events -p rustok-forum -p rustok-search -p rustok-outbox --all-targets -- -D warnings
+```
+
+The event digest generator is intentionally deferred to the executable registry
+slice; G2B3A changes no Rust event schema and therefore must leave the committed
+digest artifact unchanged.

--- a/scripts/verify/verify-forum-search-versioned-invalidation-wire.mjs
+++ b/scripts/verify/verify-forum-search-versioned-invalidation-wire.mjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(".");
+const failures = [];
+
+const paths = {
+  contract: "crates/rustok-forum/contracts/forum-search-versioned-invalidation-wire.json",
+  note: "crates/rustok-forum/docs/forum-23b2g2b3a-versioned-invalidation-wire-contract.md",
+  decision: "DECISIONS/2026-07-31-forum-search-versioned-invalidation-rollout.md",
+  checkpointContract: "crates/rustok-forum/contracts/forum-search-owner-revision-checkpoint.json",
+  ledgerContract: "crates/rustok-forum/contracts/forum-search-owner-revision-ledger.json",
+  hardeningContract: "crates/rustok-forum/contracts/forum-search-owner-revision-counter-hardening.json",
+  sourceContract: "crates/rustok-forum/contracts/forum-search-owner-revision-source.json",
+  ingestContract: "crates/rustok-forum/contracts/forum-search-durable-ingest-sequence.json",
+  eventLib: "crates/rustok-events/src/lib.rs",
+  eventPayload: "crates/rustok-events/src/contract.rs",
+  eventDigests: "crates/rustok-events/contracts/event-contract-digests.json",
+  outbox: "crates/rustok-outbox/src/transactional.rs",
+  forumPublisher: "crates/rustok-forum/src/services/projection_invalidation.rs",
+  searchInbox: "crates/rustok-search/src/forum_inbox.rs",
+  forumPlan: "crates/rustok-forum/docs/implementation-plan.md",
+  searchPlan: "crates/rustok-search/docs/implementation-plan.md",
+};
+
+function read(relativePath) {
+  const target = path.join(root, relativePath);
+  if (!existsSync(target)) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return "";
+  }
+  return readFileSync(target, "utf8");
+}
+
+function parseJson(relativePath) {
+  try {
+    return JSON.parse(read(relativePath));
+  } catch (error) {
+    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function requireAll(source, markers, label) {
+  for (const marker of markers) {
+    if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+  }
+}
+
+function rejectAll(source, markers, label) {
+  for (const marker of markers) {
+    if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+  }
+}
+
+const contract = parseJson(paths.contract);
+const checkpointContract = parseJson(paths.checkpointContract);
+const ledgerContract = parseJson(paths.ledgerContract);
+const hardeningContract = parseJson(paths.hardeningContract);
+const sourceContract = parseJson(paths.sourceContract);
+const ingestContract = parseJson(paths.ingestContract);
+const digests = parseJson(paths.eventDigests);
+
+const note = read(paths.note);
+const decision = read(paths.decision);
+const eventLib = read(paths.eventLib);
+const eventPayload = read(paths.eventPayload);
+const outbox = read(paths.outbox);
+const forumPublisher = read(paths.forumPublisher);
+const searchInbox = read(paths.searchInbox);
+const forumPlan = read(paths.forumPlan);
+const searchPlan = read(paths.searchPlan);
+
+requireAll(decision, [
+  "# ADR: Forum Search versioned invalidation rollout",
+  "- Status: accepted",
+  "forum.search_projection.invalidation_issued",
+  "causation_id",
+  "search_projection_inbox.event_id",
+  "The legacy root publication remains mandatory",
+  "No process-local fallback or second projector is permitted",
+], paths.decision);
+
+requireAll(note, [
+  "# FORUM-23B2G2B3A versioned Search invalidation wire contract",
+  "contract_frozen_implementation_pending",
+  "family: forum_search_projection",
+  "ForumSearchProjectionEvent",
+  "forum.search_projection.invalidation_issued",
+  "typed ingress inbox identity  = ContractEventEnvelope.causation_id",
+  "ON CONFLICT (event_id) DO NOTHING",
+  "FORUM-23B2G2B3B",
+  "FORUM-23B2G2B3C",
+  "FORUM-23B2G2B3D",
+  "The implementation agent did not run these commands",
+], paths.note);
+
+requireAll(outbox, [
+  "publish_contract_in_tx_with_envelope_id",
+  "ContractEventEnvelope::new",
+  "write_contract_to_outbox",
+], `${paths.outbox} typed publication predecessor`);
+
+requireAll(forumPublisher, [
+  "DomainEvent::ReindexRequested",
+  "publish_in_tx_with_envelope_id",
+  "forum_projection_revision_ledger",
+  "record_projection_revision_in_tx",
+], `${paths.forumPublisher} legacy identity predecessor`);
+
+requireAll(searchInbox, [
+  "ON CONFLICT (event_id) DO NOTHING",
+  "envelope.id.into()",
+  "ORDER BY ingest_sequence ASC",
+  "use rustok_events::{DomainEvent, EventEnvelope};",
+], `${paths.searchInbox} one-inbox predecessor`);
+
+// G2B3A is a contract freeze only. Executable registration and publication are
+// intentionally forbidden until G2B3B updates the schema digest in the same PR.
+for (const [source, label] of [
+  [eventLib, paths.eventLib],
+  [eventPayload, paths.eventPayload],
+  [forumPublisher, paths.forumPublisher],
+]) {
+  rejectAll(source, [
+    "ForumSearchProjectionEvent",
+    "forum_search_projection",
+    "forum.search_projection.invalidation_issued",
+  ], `${label} G2B3A implementation boundary`);
+}
+
+requireAll(forumPlan, [
+  "| `FORUM-23` | `in_progress` |",
+  "owner-issued revision reconciliation plus maintainer runtime evidence remain",
+], `${paths.forumPlan} canonical open boundary`);
+requireAll(searchPlan, [
+  "This is not the final Forum-owner-issued projection revision",
+  "owner contract and rollout reconciliation remain pending",
+], `${paths.searchPlan} canonical open boundary`);
+
+if (contract) {
+  if (contract.task !== "FORUM-23B2G2B3A") {
+    failures.push(`${paths.contract}: unexpected task`);
+  }
+  if (contract.status !== "contract_frozen_implementation_pending") {
+    failures.push(`${paths.contract}: unexpected status`);
+  }
+  const event = contract.event_contract;
+  if (event?.registry_owner !== "rustok-events"
+      || event?.publisher_owner !== "rustok-forum"
+      || event?.consumer_owner !== "rustok-search") {
+    failures.push(`${paths.contract}: event ownership drift`);
+  }
+  if (event?.rust_family !== "ForumSearchProjectionEvent"
+      || event?.transport_family !== "forum_search_projection"
+      || event?.variant !== "InvalidationIssued"
+      || event?.event_type !== "forum.search_projection.invalidation_issued"
+      || event?.schema_version !== 1) {
+    failures.push(`${paths.contract}: event identity drift`);
+  }
+  if (event?.payload?.owner_revision?.minimum !== 1) {
+    failures.push(`${paths.contract}: owner revision must be positive`);
+  }
+  const targets = event?.payload?.target_type?.allowed ?? [];
+  if (JSON.stringify(targets) !== JSON.stringify([
+    "forum",
+    "forum_category",
+    "forum_topic",
+  ])) {
+    failures.push(`${paths.contract}: target type set or order drift`);
+  }
+  if (event?.envelope?.causation_id_required !== true
+      || event?.envelope?.causation_id_equals_legacy_root_envelope_id !== true
+      || event?.envelope?.legacy_root_event_type !== "index.reindex_requested") {
+    failures.push(`${paths.contract}: legacy causation identity drift`);
+  }
+  const transaction = contract.owner_transaction_protocol;
+  if (transaction?.postgresql_only !== true
+      || transaction?.legacy_root_publication_required !== true
+      || transaction?.failure_rolls_back_owner_state_root_typed_and_ledger !== true) {
+    failures.push(`${paths.contract}: owner transaction protocol drift`);
+  }
+  const execution = contract.single_projection_path;
+  if (execution?.inbox_table !== "search_projection_inbox"
+      || execution?.typed_ingress_identity !== "ContractEventEnvelope.causation_id"
+      || execution?.shared_identity !== "legacy root envelope ID"
+      || execution?.existing_inbox_unique_boundary_collapses_dual_delivery !== true
+      || execution?.second_inbox_forbidden !== true
+      || execution?.second_projector_forbidden !== true) {
+    failures.push(`${paths.contract}: one-inbox execution contract drift`);
+  }
+  const cursor = contract.consumer_cursor_protocol;
+  if (cursor?.valid_event_ack_after_terminal_result !== true
+      || cursor?.poison_ack_after_terminal_result !== true
+      || cursor?.transient_failure_acknowledged !== false
+      || cursor?.process_local_fallback !== false
+      || cursor?.exact_cursor_receive_and_ack !== true) {
+    failures.push(`${paths.contract}: persistent cursor or poison policy drift`);
+  }
+  if (contract.ordering?.owner_revision_compared_numerically_with_ingest_sequence !== false
+      || contract.ordering?.checkpoint_advances_only_after_projection_success !== true) {
+    failures.push(`${paths.contract}: independent ordering contract drift`);
+  }
+  const slices = (contract.rollout_slices ?? []).map((slice) => slice.task);
+  if (JSON.stringify(slices) !== JSON.stringify([
+    "FORUM-23B2G2B3A",
+    "FORUM-23B2G2B3B",
+    "FORUM-23B2G2B3C",
+    "FORUM-23B2G2B3D",
+  ])) {
+    failures.push(`${paths.contract}: rollout slice order drift`);
+  }
+  const changes = contract.current_slice_changes;
+  for (const [name, value] of Object.entries(changes ?? {})) {
+    if (value !== false) failures.push(`${paths.contract}: ${name} must remain false in G2B3A`);
+  }
+}
+
+if (checkpointContract?.task !== "FORUM-23B2G2B2") {
+  failures.push(`${paths.checkpointContract}: checkpoint predecessor drift`);
+}
+if (ledgerContract?.task !== "FORUM-23B2G2A") {
+  failures.push(`${paths.ledgerContract}: ledger predecessor drift`);
+}
+if (hardeningContract?.task !== "FORUM-23B2G2A1") {
+  failures.push(`${paths.hardeningContract}: hardening predecessor drift`);
+}
+if (sourceContract?.task !== "FORUM-23B2G2B1") {
+  failures.push(`${paths.sourceContract}: source predecessor drift`);
+}
+if (ingestContract?.task !== "FORUM-23B2G1") {
+  failures.push(`${paths.ingestContract}: ingest predecessor drift`);
+}
+
+const expectedDigests = {
+  format_version: 1,
+  registry: "sha256:18fdee49d915a22ed3dd709ec6cc1826d6d47a59ddfe659fbd07ede7f6cd3d07",
+  root_event: "sha256:2bc388a237ff1fcbe327c340633815a64c84c799afef5a0012f458752d6deb87",
+  root_envelope: "sha256:cfb55b9ac1fbebdc27658e035c00a98468c947b4830f8603c4258457849db42d",
+  contract_payload: "sha256:5f1f9577bc9429b76bbfe5420d1bd71249efd6aea702ec0a103e4a402702cd02",
+  contract_envelope: "sha256:b29a8c7809045e14f1233db4e2f9dba9cedf96352df3ea9e87ca1e86f6a59eb8",
+};
+if (digests && JSON.stringify(digests) !== JSON.stringify(expectedDigests)) {
+  failures.push(`${paths.eventDigests}: G2B3A must not change the event schema digest baseline`);
+}
+
+if (failures.length > 0) {
+  console.error("FORUM-23B2G2B3A versioned invalidation wire verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("FORUM-23B2G2B3A versioned invalidation wire contract is consistent.");


### PR DESCRIPTION
## Summary

Freezes `FORUM-23B2G2B3A`, the version-1 Forum Search owner-revision invalidation wire contract and rolling dual-delivery protocol, before any executable event-registry or consumer changes.

- accept the cross-module rollout ADR for `forum.search_projection.invalidation_issued`;
- define the sealed future family `ForumSearchProjectionEvent` / `forum_search_projection` with positive `owner_revision`, bounded `target_type`, and exact nullable `target_id` semantics;
- require the typed envelope `causation_id` to equal the existing legacy `index.reindex_requested` root envelope ID recorded by the Forum owner ledger;
- freeze one PostgreSQL owner transaction: allocate revision, publish legacy root, publish caused typed contract, append ledger, then commit atomically;
- keep legacy root publication mandatory for this release train;
- require both legacy and typed ingress to collapse onto the existing `search_projection_inbox.event_id` and existing Forum projector;
- freeze the persistent cursor, durable poison/DLQ receipt, acknowledge-after-terminal-result and no-process-local-fallback policy;
- keep Forum owner revision and Search `ingest_sequence` independent;
- define follow-up slices for executable registry/publisher, persistent Search consumer, and maintainer runtime evidence;
- add a fail-closed verifier that proves this slice changes no Rust event registry, digest baseline, publisher, inbox, or projector.

## Deliberate boundary

This is a contract freeze only. It does not add `ForumSearchProjectionEvent`, change `ContractEventPayload`, update `event-contract-digests.json`, dual-publish from Forum, add a Search contract consumer, change the Search inbox, or close `FORUM-23`/`LINK-FORUM-03`.

The executable event family and causation-aware dual publisher are planned as `FORUM-23B2G2B3B`; the one-inbox persistent consumer and poison receipt are `FORUM-23B2G2B3C`.

## Verification

Tests, verifiers, formatting, Cargo checks, Clippy, digest generation, and runtime evidence were intentionally not run by request.