### PR TITLE
fix(index): block failed reconciliation scopes

### DIFF
--- a/crates/rustok-index/docs/m6-reconciliation-dead-letter-admission.md
+++ b/crates/rustok-index/docs/m6-reconciliation-dead-letter-admission.md
@@ -1,0 +1,82 @@
+# Reconciliation dead-letter admission
+
+Status: production admission and PostgreSQL regression retained, not run.
+
+## Boundary
+
+A terminal failed reconciliation job now blocks later runs for the same tenant and schema scope.
+
+The acquisition transaction continues to take the existing reconciliation scope advisory lock and verify the persisted schema before reading jobs. Scope resolution includes `failed` rows and uses deterministic precedence:
+
+1. a retained `succeeded` row remains authoritative completion;
+2. an existing `running` or `pending` row remains authoritative active work;
+3. only when no successful or active row exists does the newest `failed` row block admission.
+
+The runner returns `IndexReconciliationRunError::DeadLettered` instead of silently inserting a new reconciliation job.
+
+## Bounded error contract
+
+`DeadLettered` exposes only:
+
+- the failed job UUID;
+- its durable attempt count;
+- its optional validated `last_error_code`.
+
+The acquisition query does not load `last_error_details`. Database, source, mutation, transport, tenant, worker, request, stack, and arbitrary diagnostic payloads are not returned through the error.
+
+Stored error codes must be non-empty, trimmed, free of control characters, and at most 128 bytes. An invalid stored code fails closed through `InvalidStoredJob` rather than being propagated.
+
+The current page-failure transition stores `index.reconciliation_page_failed` as the bounded error code. The source or mutation dependency code remains inside the separately persisted bounded diagnostic object and is not part of dead-letter admission.
+
+## PostgreSQL regression
+
+The environment-gated target creates a unique schema, creates a tenant fixture, applies every real `IndexModule` migration, persists one active schema, and constructs the canonical source and schema registries.
+
+A counted source fails its first scan with permanent owner code `owner_source_permanent_dead_letter`. The runner must create exactly one attempt-1 reconciliation job and terminalize it as failed with:
+
+- zero completed passes and zero processed pages;
+- released lease ownership;
+- non-null completion timestamp;
+- `last_error_code = index.reconciliation_page_failed`;
+- the existing three-field reconciliation failure diagnostic;
+- zero entity and inbox writes.
+
+The test then replaces only `last_error_details` with a private marker. A newly constructed runner invokes the same scope and must return `DeadLettered` with the same job UUID, attempt count `1`, and only the generic page-failure code.
+
+The second invocation must not call the source, create another job, change the failed row, or expose either the private marker or owner dependency code through Debug or Display output.
+
+## Compatibility
+
+This slice changes no migration, table shape, request or cursor wire contract, source ownership, mutation identity, schema fingerprint, failure transition, cancellation transition, lease fencing, or terminal success behavior.
+
+It mirrors the fail-closed replay dead-letter admission boundary while remaining independently owned by reconciliation.
+
+## Remaining work
+
+This is admission only. It does not add:
+
+- authorized dead-letter inspection;
+- actor/reason audit records;
+- manual requeue or retry-epoch reset;
+- automatic retry, backoff, exhaustion, or scheduling;
+- host polling or graceful task shutdown;
+- source/index digest comparison;
+- orphan cleanup;
+- targeted, full, or shadow repair;
+- locale or partition checkpoint dimensions;
+- complete drift repair.
+
+The canonical M6 reconciliation and drift-repair item therefore remains open.
+
+## Suggested validation
+
+```bash
+RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
+  cargo test -p rustok-index \
+  --test source_reconciliation_dead_letter_admission_postgres_test \
+  -- --nocapture
+
+cargo check -p rustok-index --all-targets
+
+node scripts/verify/verify-index-reconciliation-dead-letter-admission.mjs
+```

--- a/crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner.rs
@@ -29,6 +29,7 @@ const MAX_PAGES_PER_RUN: usize = 1_024;
 const MAX_PASSES: u32 = 8;
 const MAX_SOURCE_NAME_BYTES: usize = 128;
 const MAX_WORKER_ID_BYTES: usize = 191;
+const MAX_ERROR_CODE_BYTES: usize = 128;
 const MAX_LEASE_SECONDS: u64 = 86_400;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -529,6 +530,7 @@ struct StoredReconciliationJob {
     cursor: ReconciliationCursor,
     attempt_count: u32,
     claimable: bool,
+    last_error_code: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -596,6 +598,13 @@ async fn acquire_in_transaction(
             "running" | "pending" => {
                 claimable = Some(stored);
                 break;
+            }
+            "failed" => {
+                return Err(IndexReconciliationRunError::DeadLettered {
+                    job_id: stored.job_id,
+                    attempt_count: stored.attempt_count,
+                    error_code: stored.last_error_code,
+                });
             }
             state => {
                 return Err(IndexReconciliationRunError::InvalidStoredJob(format!(
@@ -715,6 +724,16 @@ fn stored_job(
             "attempt count is outside the u32 range".to_owned(),
         )
     })?;
+    let last_error_code: Option<String> = row
+        .try_get("", "last_error_code")
+        .map_err(storage_error)?;
+    if let Some(code) = &last_error_code {
+        validate_storage_text(code, MAX_ERROR_CODE_BYTES).map_err(|_| {
+            IndexReconciliationRunError::InvalidStoredJob(
+                "last_error_code is outside the reconciliation error contract".to_owned(),
+            )
+        })?;
+    }
     Ok(StoredReconciliationJob {
         job_id: stored_uuid(row, "job_id", backend)?,
         state: row.try_get("", "state").map_err(storage_error)?,
@@ -722,6 +741,7 @@ fn stored_job(
         cursor,
         attempt_count,
         claimable: row.try_get("", "claimable").map_err(storage_error)?,
+        last_error_code,
     })
 }
 
@@ -1178,7 +1198,7 @@ fn select_jobs_sql(backend: DbBackend) -> String {
         _ => unreachable!("unsupported database backend was validated"),
     };
     format!(
-        "SELECT job_id, state, request, cursor, {attempt_count} AS attempt_count_value, {claimable} AS claimable FROM index_jobs WHERE tenant_id = {prefix}1 AND module_name = {prefix}2 AND entity_name = {prefix}3 AND schema_version = {prefix}4 AND kind = 'reconcile' AND scope_kind = 'schema' AND state IN ('pending', 'running', 'succeeded') ORDER BY CASE state WHEN 'succeeded' THEN 0 WHEN 'running' THEN 1 ELSE 2 END, created_at DESC"
+        "SELECT job_id, state, request, cursor, last_error_code, {attempt_count} AS attempt_count_value, {claimable} AS claimable FROM index_jobs WHERE tenant_id = {prefix}1 AND module_name = {prefix}2 AND entity_name = {prefix}3 AND schema_version = {prefix}4 AND kind = 'reconcile' AND scope_kind = 'schema' AND state IN ('pending', 'running', 'succeeded', 'failed') ORDER BY CASE state WHEN 'succeeded' THEN 0 WHEN 'running' THEN 1 WHEN 'pending' THEN 2 ELSE 3 END, created_at DESC"
     )
 }
 
@@ -1302,6 +1322,14 @@ pub enum IndexReconciliationRunError {
     SchemaNotRegistered(SchemaRef),
     #[error("Index reconciliation schema is retired: {0}")]
     SchemaRetired(SchemaRef),
+    #[error(
+        "Index reconciliation scope is blocked by failed job {job_id} after attempt {attempt_count}"
+    )]
+    DeadLettered {
+        job_id: Uuid,
+        attempt_count: u32,
+        error_code: Option<String>,
+    },
     #[error("stored Index reconciliation job is invalid: {0}")]
     InvalidStoredJob(String),
     #[error("stored Index reconciliation job has unsupported state {0}")]

--- a/crates/rustok-index/tests/source_reconciliation_dead_letter_admission_postgres_test.rs
+++ b/crates/rustok-index/tests/source_reconciliation_dead_letter_admission_postgres_test.rs
@@ -1,0 +1,404 @@
+use std::{
+    env,
+    error::Error,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use rustok_core::MigrationSource;
+use rustok_index::{
+    EntityName, FieldCardinality, FieldName, IndexField, IndexModule,
+    IndexReconciliationRunError, IndexReconciliationRunRequest, IndexSchema,
+    IndexSchemaSourceCatalog, IndexSource, IndexSourceCatalog, IndexSourceError,
+    IndexSourceFailure, IndexSourceFailureKind, IndexSourceLoadBatch, IndexSourceLoadRequest,
+    IndexSourcePage, IndexSourceScanRequest, IndexValueType, LocaleMode, ModuleName,
+    PostgresIndexReconciliationRunner, SchemaRef, SchemaRegistry, SchemaVersion,
+};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, QueryResult,
+    Statement, Value as SqlValue,
+};
+use sea_orm_migration::SchemaManager;
+use serde_json::{Value as JsonValue, json};
+use uuid::Uuid;
+
+const DATABASE_ENV: &str = "RUSTOK_INDEX_TEST_DATABASE_URL";
+const SOURCE_NAME: &str = "reconciliation-dead-letter-primary";
+const MODULE_NAME: &str = "reconciliation-dead-letter-harness";
+const DEPENDENCY_CODE: &str = "owner_source_permanent_dead_letter";
+const PAGE_FAILURE_CODE: &str = "index.reconciliation_page_failed";
+const PRIVATE_MARKER: &str = "private-reconciliation-failure-detail";
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+#[derive(Clone)]
+struct CountedFailingSource {
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl IndexSource for CountedFailingSource {
+    async fn scan(
+        &self,
+        _request: IndexSourceScanRequest,
+    ) -> Result<IndexSourcePage, IndexSourceFailure> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Err(
+            IndexSourceFailure::permanent(DEPENDENCY_CODE)
+                .expect("fixture dependency code must be valid"),
+        )
+    }
+
+    async fn load(
+        &self,
+        request: IndexSourceLoadRequest,
+    ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+        Ok(IndexSourceLoadBatch::new(&request, Vec::new()).expect("empty targeted load"))
+    }
+}
+
+struct TestDatabase {
+    control: DatabaseConnection,
+    database_url: String,
+    schema_name: String,
+    tenant_id: Uuid,
+}
+
+impl TestDatabase {
+    async fn setup() -> TestResult<Option<Self>> {
+        let Some(database_url) = database_url() else {
+            eprintln!(
+                "{DATABASE_ENV} is not set to a PostgreSQL URL; skipping reconciliation dead-letter admission harness"
+            );
+            return Ok(None);
+        };
+        let control = connect(&database_url).await?;
+        let schema_name = format!(
+            "rustok_index_reconciliation_dead_letter_{}",
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let tenant_id = Uuid::new_v4();
+        let db = scoped_connection(&database_url, &schema_name).await?;
+        db.execute_unprepared("CREATE TABLE tenants (id UUID NOT NULL PRIMARY KEY)")
+            .await?;
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "INSERT INTO tenants (id) VALUES ($1)",
+            vec![tenant_id.into()],
+        ))
+        .await?;
+
+        let manager = SchemaManager::new(&db);
+        for migration in IndexModule.migrations() {
+            migration.up(&manager).await?;
+        }
+        persist_schema(&db, tenant_id).await?;
+
+        Ok(Some(Self {
+            control,
+            database_url,
+            schema_name,
+            tenant_id,
+        }))
+    }
+
+    async fn connection(&self) -> TestResult<DatabaseConnection> {
+        scoped_connection(&self.database_url, &self.schema_name).await
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct FailedJobEvidence {
+    job_id: Uuid,
+    state: String,
+    attempt_count: i64,
+    completed_passes: i64,
+    pages_processed: i64,
+    last_error_code: String,
+    last_error_details: JsonValue,
+    lease_released: bool,
+    completed: bool,
+}
+
+#[tokio::test]
+async fn failed_reconciliation_scope_blocks_new_jobs_without_exposing_details() -> TestResult<()> {
+    let Some(database) = TestDatabase::setup().await? else {
+        return Ok(());
+    };
+    let calls = Arc::new(AtomicUsize::new(0));
+    let first_runner = runner(database.connection().await?, calls.clone());
+
+    let first_error = first_runner
+        .run(request(database.tenant_id, "dead-letter-worker-a"))
+        .await
+        .expect_err("fixture source failure must terminalize the first job");
+    match first_error {
+        IndexReconciliationRunError::Source(IndexSourceError::SourceFailure {
+            source_name,
+            failure,
+        }) => {
+            assert_eq!(source_name, SOURCE_NAME);
+            assert_eq!(failure.code(), DEPENDENCY_CODE);
+            assert_eq!(failure.kind(), IndexSourceFailureKind::Permanent);
+        }
+        other => panic!("unexpected first reconciliation error: {other:?}"),
+    }
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    let evidence_db = database.connection().await?;
+    let failed = read_failed_job(&evidence_db, database.tenant_id).await?;
+    assert_eq!(failed.state, "failed");
+    assert_eq!(failed.attempt_count, 1);
+    assert_eq!(failed.completed_passes, 0);
+    assert_eq!(failed.pages_processed, 0);
+    assert_eq!(failed.last_error_code, PAGE_FAILURE_CODE);
+    assert_eq!(
+        failed.last_error_details,
+        json!({
+            "contract": "index_reconciliation_run_failure_v1",
+            "dependency_code": DEPENDENCY_CODE,
+            "retryable": false,
+        })
+    );
+    assert!(failed.lease_released);
+    assert!(failed.completed);
+    assert_eq!(count(&evidence_db, "index_jobs").await?, 1);
+    assert_eq!(count(&evidence_db, "index_entities").await?, 0);
+    assert_eq!(count(&evidence_db, "index_inbox").await?, 0);
+
+    replace_private_failure_details(&evidence_db, database.tenant_id, failed.job_id).await?;
+
+    let second_runner = runner(database.connection().await?, calls.clone());
+    let blocked = second_runner
+        .run(request(database.tenant_id, "dead-letter-worker-b"))
+        .await
+        .expect_err("failed reconciliation scope must remain blocked");
+    let debug = format!("{blocked:?}");
+    let display = blocked.to_string();
+    match blocked {
+        IndexReconciliationRunError::DeadLettered {
+            job_id,
+            attempt_count,
+            error_code,
+        } => {
+            assert_eq!(job_id, failed.job_id);
+            assert_eq!(attempt_count, 1);
+            assert_eq!(error_code.as_deref(), Some(PAGE_FAILURE_CODE));
+        }
+        other => panic!("unexpected blocked reconciliation error: {other:?}"),
+    }
+    assert!(!debug.contains(PRIVATE_MARKER));
+    assert!(!debug.contains(DEPENDENCY_CODE));
+    assert!(!display.contains(PRIVATE_MARKER));
+    assert!(!display.contains(DEPENDENCY_CODE));
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    let retained = read_failed_job(&evidence_db, database.tenant_id).await?;
+    assert_eq!(retained.job_id, failed.job_id);
+    assert_eq!(retained.state, "failed");
+    assert_eq!(retained.attempt_count, 1);
+    assert_eq!(retained.last_error_code, PAGE_FAILURE_CODE);
+    assert_eq!(retained.last_error_details, json!({ "private": PRIVATE_MARKER }));
+    assert!(retained.lease_released);
+    assert!(retained.completed);
+    assert_eq!(count(&evidence_db, "index_jobs").await?, 1);
+    assert_eq!(count(&evidence_db, "index_entities").await?, 0);
+    assert_eq!(count(&evidence_db, "index_inbox").await?, 0);
+
+    database.cleanup().await
+}
+
+fn runner(
+    db: DatabaseConnection,
+    calls: Arc<AtomicUsize>,
+) -> PostgresIndexReconciliationRunner {
+    let schema = schema();
+    let mut schema_catalog = IndexSchemaSourceCatalog::new();
+    schema_catalog
+        .register(MODULE_NAME, schema.clone())
+        .expect("fixture schema source must register");
+
+    let mut source_catalog = IndexSourceCatalog::new();
+    source_catalog
+        .register(
+            MODULE_NAME,
+            SOURCE_NAME,
+            [schema.reference.clone()],
+            CountedFailingSource { calls },
+        )
+        .expect("fixture source must register");
+    let sources = source_catalog
+        .materialize(&schema_catalog)
+        .expect("fixture source registry must materialize");
+
+    let mut registry = SchemaRegistry::new();
+    registry
+        .register(schema)
+        .expect("fixture schema registry must materialize");
+
+    PostgresIndexReconciliationRunner::new(db, sources, Arc::new(registry))
+}
+
+fn request(tenant_id: Uuid, worker_id: &str) -> IndexReconciliationRunRequest {
+    IndexReconciliationRunRequest::new(
+        tenant_id,
+        schema_ref(),
+        worker_id,
+        1,
+        1,
+        1,
+        1,
+        Duration::from_secs(60),
+    )
+    .expect("fixture reconciliation request must be valid")
+}
+
+fn schema_ref() -> SchemaRef {
+    SchemaRef {
+        module: ModuleName::new(MODULE_NAME).unwrap(),
+        entity: EntityName::new("item").unwrap(),
+        version: SchemaVersion::INITIAL,
+    }
+}
+
+fn schema() -> IndexSchema {
+    IndexSchema {
+        reference: schema_ref(),
+        locale_mode: LocaleMode::None,
+        fields: vec![IndexField {
+            name: FieldName::new("id").unwrap(),
+            value_type: IndexValueType::Uuid,
+            cardinality: FieldCardinality::One,
+            nullable: false,
+            selectable: true,
+            filterable: true,
+            sortable: true,
+        }],
+        links: Vec::new(),
+    }
+}
+
+async fn persist_schema(db: &DatabaseConnection, tenant_id: Uuid) -> TestResult<()> {
+    let schema = schema();
+    let fingerprint = schema.fingerprint()?.to_string();
+    let schema_json = serde_json::to_value(&schema)?;
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "INSERT INTO index_schemas (tenant_id, module_name, entity_name, schema_version, schema_fingerprint, schema_json, status) VALUES ($1, $2, $3, $4, $5, $6, 'active')",
+        vec![
+            tenant_id.into(),
+            schema.reference.module.as_str().to_owned().into(),
+            schema.reference.entity.as_str().to_owned().into(),
+            i64::from(schema.reference.version.get()).into(),
+            fingerprint.into(),
+            SqlValue::Json(Some(Box::new(schema_json))),
+        ],
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn read_failed_job(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+) -> TestResult<FailedJobEvidence> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT job_id, state, attempt_count::bigint AS attempt_count_value, (cursor->>'completed_passes')::bigint AS completed_passes, (cursor->>'pages_processed')::bigint AS pages_processed, last_error_code, last_error_details, (lease_owner IS NULL AND lease_expires_at IS NULL) AS lease_released, (completed_at IS NOT NULL) AS completed FROM index_jobs WHERE tenant_id = $1 AND kind = 'reconcile' AND state = 'failed' ORDER BY created_at DESC LIMIT 1",
+            vec![tenant_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("failed reconciliation job is missing"))?;
+    Ok(FailedJobEvidence {
+        job_id: row.try_get("", "job_id")?,
+        state: row.try_get("", "state")?,
+        attempt_count: row.try_get("", "attempt_count_value")?,
+        completed_passes: row.try_get("", "completed_passes")?,
+        pages_processed: row.try_get("", "pages_processed")?,
+        last_error_code: row.try_get("", "last_error_code")?,
+        last_error_details: row.try_get("", "last_error_details")?,
+        lease_released: row.try_get("", "lease_released")?,
+        completed: row.try_get("", "completed")?,
+    })
+}
+
+async fn replace_private_failure_details(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    job_id: Uuid,
+) -> TestResult<()> {
+    let updated = db
+        .execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "UPDATE index_jobs SET last_error_details = $3 WHERE tenant_id = $1 AND job_id = $2 AND kind = 'reconcile' AND state = 'failed'",
+            vec![
+                tenant_id.into(),
+                job_id.into(),
+                SqlValue::Json(Some(Box::new(json!({ "private": PRIVATE_MARKER })))),
+            ],
+        ))
+        .await?;
+    if updated.rows_affected() != 1 {
+        return Err(std::io::Error::other("failed reconciliation details update lost scope").into());
+    }
+    Ok(())
+}
+
+async fn count(db: &DatabaseConnection, table: &str) -> TestResult<i64> {
+    let sql = match table {
+        "index_jobs" => "SELECT COUNT(*)::bigint AS value FROM index_jobs WHERE kind = 'reconcile'",
+        "index_entities" => "SELECT COUNT(*)::bigint AS value FROM index_entities",
+        "index_inbox" => "SELECT COUNT(*)::bigint AS value FROM index_inbox",
+        _ => panic!("unsupported fixture table"),
+    };
+    let row: QueryResult = db
+        .query_one(Statement::from_string(DbBackend::Postgres, sql.to_owned()))
+        .await?
+        .ok_or_else(|| std::io::Error::other("count query returned no row"))?;
+    Ok(row.try_get("", "value")?)
+}
+
+fn database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn scoped_connection(
+    database_url: &str,
+    schema_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url).await?;
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}""#))
+        .await?;
+    Ok(db)
+}

--- a/scripts/verify/verify-index-reconciliation-dead-letter-admission.mjs
+++ b/scripts/verify/verify-index-reconciliation-dead-letter-admission.mjs
@@ -1,0 +1,117 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const files = {
+  runner:
+    "crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner.rs",
+  target:
+    "crates/rustok-index/tests/source_reconciliation_dead_letter_admission_postgres_test.rs",
+  docs: "crates/rustok-index/docs/m6-reconciliation-dead-letter-admission.md",
+};
+
+const read = (name) => {
+  const relative = files[name];
+  const absolute = path.join(root, relative);
+  if (!fs.existsSync(absolute)) {
+    throw new Error(`missing reconciliation dead-letter admission file: ${relative}`);
+  }
+  return fs.readFileSync(absolute, "utf8");
+};
+
+const requireMarkers = (name, markers) => {
+  const content = read(name);
+  for (const marker of markers) {
+    if (!content.includes(marker)) {
+      throw new Error(`${files[name]} is missing required marker: ${marker}`);
+    }
+  }
+};
+
+const forbidMarkers = (name, markers) => {
+  const content = read(name);
+  for (const marker of markers) {
+    if (content.includes(marker)) {
+      throw new Error(`${files[name]} contains forbidden marker: ${marker}`);
+    }
+  }
+};
+
+requireMarkers("runner", [
+  "const MAX_ERROR_CODE_BYTES: usize = 128;",
+  "DeadLettered {",
+  "job_id: Uuid,",
+  "attempt_count: u32,",
+  "error_code: Option<String>,",
+  '"failed" => {',
+  "error_code: stored.last_error_code,",
+  "last_error_code: Option<String>,",
+  '.try_get("", "last_error_code")',
+  "last_error_code is outside the reconciliation error contract",
+  "state IN ('pending', 'running', 'succeeded', 'failed')",
+  "CASE state WHEN 'succeeded' THEN 0 WHEN 'running' THEN 1 WHEN 'pending' THEN 2 ELSE 3 END",
+]);
+
+const runner = read("runner");
+const selectStart = runner.indexOf("fn select_jobs_sql");
+const selectEnd = runner.indexOf("fn insert_job_sql", selectStart);
+if (selectStart < 0 || selectEnd < 0) {
+  throw new Error("could not isolate reconciliation job selection SQL");
+}
+const selectJobs = runner.slice(selectStart, selectEnd);
+if (!selectJobs.includes("last_error_code")) {
+  throw new Error("reconciliation job selection must load the bounded error code");
+}
+if (selectJobs.includes("last_error_details")) {
+  throw new Error("reconciliation dead-letter admission must not load error details");
+}
+
+const succeededBranch = runner.indexOf('"succeeded" => {');
+const activeBranch = runner.indexOf('"running" | "pending" if !stored.claimable');
+const failedBranch = runner.indexOf('"failed" => {');
+if (!(succeededBranch >= 0 && activeBranch > succeededBranch && failedBranch > activeBranch)) {
+  throw new Error("reconciliation scope precedence must remain succeeded, active, then failed");
+}
+
+requireMarkers("target", [
+  "failed_reconciliation_scope_blocks_new_jobs_without_exposing_details",
+  "RUSTOK_INDEX_TEST_DATABASE_URL",
+  "IndexModule.migrations()",
+  "owner_source_permanent_dead_letter",
+  "IndexReconciliationRunError::Source",
+  "IndexReconciliationRunError::DeadLettered",
+  "private-reconciliation-failure-detail",
+  "assert!(!debug.contains(PRIVATE_MARKER))",
+  "assert!(!debug.contains(DEPENDENCY_CODE))",
+  "assert!(!display.contains(PRIVATE_MARKER))",
+  "assert!(!display.contains(DEPENDENCY_CODE))",
+  "assert_eq!(calls.load(Ordering::SeqCst), 1)",
+  'count(&evidence_db, "index_jobs")',
+  'count(&evidence_db, "index_entities")',
+  'count(&evidence_db, "index_inbox")',
+  "DROP SCHEMA IF EXISTS",
+]);
+
+requireMarkers("docs", [
+  "Status: production admission and PostgreSQL regression retained, not run.",
+  "deterministic precedence",
+  "The acquisition query does not load `last_error_details`.",
+  "must not call the source, create another job, change the failed row",
+  "authorized dead-letter inspection",
+  "The canonical M6 reconciliation and drift-repair item therefore remains open.",
+]);
+
+forbidMarkers("target", [
+  "tokio::time::sleep",
+  "std::thread::sleep",
+  "DELETE FROM index_jobs",
+  "INSERT INTO index_jobs",
+]);
+forbidMarkers("docs", [
+  "implementation-plan.md",
+  "automatic requeue is implemented",
+  "complete drift repair is implemented",
+]);
+
+console.log("Index reconciliation dead-letter admission markers verified.");


### PR DESCRIPTION
## Summary

- include terminal `failed` reconciliation jobs in tenant/schema scope resolution
- preserve deterministic precedence: `succeeded`, then active `running`/`pending`, then the newest `failed` row
- return typed `IndexReconciliationRunError::DeadLettered` instead of silently inserting a new reconciliation job
- expose only the failed job UUID, durable attempt count, and optional validated `last_error_code`
- never load or expose `last_error_details` during dead-letter admission
- add an environment-gated PostgreSQL regression, focused documentation, and a standalone fail-closed verifier

## Admission semantics

The existing acquisition transaction still:

1. takes the reconciliation scope advisory lock;
2. verifies the persisted tenant schema is active;
3. resolves retained jobs for the exact schema scope.

Selection now includes `failed` rows and orders them so:

1. a retained `succeeded` row remains authoritative completion;
2. an existing `running` or `pending` row remains authoritative active work and retains current busy/reclaim behavior;
3. only when there is no successful or active work does the newest `failed` row block admission.

A blocked run returns:

```rust
IndexReconciliationRunError::DeadLettered {
    job_id,
    attempt_count,
    error_code,
}
```

No new job row is inserted and the source is not scanned.

## Privacy boundary

The acquisition query selects `last_error_code` but deliberately does not select `last_error_details`.

Stored error codes are validated as non-empty, trimmed, control-character-free text bounded to 128 bytes. An invalid code fails closed through `InvalidStoredJob`.

The error exposes no source or mutation dependency code, diagnostic JSON, database error, SQL, tenant, worker, request, transport detail, or stack text.

## PostgreSQL regression

The environment-gated target creates a unique PostgreSQL schema, creates the tenant fixture, applies every real `IndexModule` migration, persists one active schema, and constructs canonical source/schema registries.

A counted source fails the first scan permanently. Attempt 1 must create exactly one failed reconciliation job with:

- zero completed passes and zero processed pages
- released lease ownership
- non-null completion timestamp
- `last_error_code = index.reconciliation_page_failed`
- the existing bounded three-field failure diagnostic
- zero entity and inbox writes

The fixture then replaces only `last_error_details` with a private marker. A newly constructed runner invokes the same scope and must return `DeadLettered` with the same job UUID, attempt count `1`, and only the generic page-failure code.

The second invocation must not call the source, create another job, mutate the failed row, or expose the private marker or owner dependency code through Debug or Display output.

## Compatibility and open PR interaction

Changed files do not overlap open Index PRs #2636, #2639, #2642, #2644, #2648, #2649, #2652, #2656, #2660, #2663, #2667, #2679, #2684, #2689, #2693, #2698, #2703, #2719, #2724, #2725, #2727, #2730, #2733, or #2737.

This production contract intentionally supersedes the post-failure recovery expectations in test-only PRs #2719, #2727, and #2730. Those harnesses currently expect a later explicit invocation to create a new job after `failed`; they must be updated or not merged unchanged after this PR.

No migration, table shape, request/cursor wire contract, source ownership, mutation identity, failure transition, cancellation transition, lease fencing, or success behavior changes.

No implementation-plan edit while PR #2636 owns the canonical plan.

Merge base: `bd8188db80ebc9b9d7771a7da40483f31bc718bf`. Current `main` advanced through unrelated Events/Outbox work to `d1c1391d640bad3973894e86460b0633a7136d3e`.

## Remaining work

- authorized dead-letter inspection
- actor/reason audit records
- manual requeue or retry-epoch reset
- automatic retry/backoff/exhaustion and host scheduling
- digest comparison, orphan cleanup, targeted/full/shadow repair
- locale/partition checkpoint dimensions
- complete drift repair

The canonical M6 reconciliation and drift-repair item remains open.

## Validation

Not run per maintainer instruction:

- Cargo formatting/checks/tests/Clippy
- JavaScript verifier
- PostgreSQL integration target
- CI workflows

Suggested maintainer commands:

```bash
RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
  cargo test -p rustok-index \
  --test source_reconciliation_dead_letter_admission_postgres_test \
  -- --nocapture

cargo check -p rustok-index --all-targets

node scripts/verify/verify-index-reconciliation-dead-letter-admission.mjs
```

## Branch state

Branch: `agent/index-m6-reconciliation-dead-letter-admission-20260731`

The connector produced four sequential commits. Squash merge is recommended after maintainer validation.