### PR TITLE
fix(rbac): require direct control-plane principals

### DIFF
--- a/apps/server/docs/implementation-plan.md
+++ b/apps/server/docs/implementation-plan.md
@@ -82,6 +82,34 @@ staging only. Issue #2680 remains open until same-SHA source/unit/compile
 evidence and retained live denial, admission, rotation, revocation and
 multi-replica parity evidence exist.
 
+## RBAC artifact permission control-plane composition
+
+Artifact role-permission grants and role/permission metadata are tenant RBAC
+control-plane state. Server and native adapters may authenticate and map
+transport errors, but they must not define a second principal policy or treat an
+effective permission as sufficient proof of principal eligibility.
+
+The correction staged during `core/rbac` uses the owner-provided
+`RbacControlPlanePrincipal` policy for GraphQL, REST and native RBAC Admin:
+
+- only a direct grant with a non-nil session may enter the control plane;
+- the authenticated tenant must equal the middleware-routed tenant before
+  permission admission;
+- OAuth authorization-code and client-credentials principals remain denied even
+  when their effective scoped permissions include `modules:manage` or
+  `settings:read`;
+- permission admission occurs only after principal and tenant admission;
+- the durable REST operation actor is always `AuthContext.user_id`; request
+  payloads cannot supply or replace the audit identity;
+- native RBAC Admin uses the same owner policy and no longer retains a separate
+  generic tenant-only helper;
+- adapters compose neutral authenticated facts into the owner policy, while the
+  owner crate remains independent of Axum and the `rustok-api/server` feature.
+
+Same-SHA formatting, default/all-feature owner compilation, RBAC Admin SSR
+compilation, server compilation, focused tests and live negative transport
+evidence remain required before this correction is considered verified.
+
 ## Improvements
 
 ### Architecture debt
@@ -109,6 +137,7 @@ multi-replica parity evidence exist.
 - Introduce regular security review for sensitive endpoints (auth, tenant, admin operations).
 - Expand security event audit (login, privilege changes, tenant boundary violations).
 - Retain host-global operator credential denial/admission, rotation and replica-parity evidence without moving credential ownership into tenant OAuth or RBAC.
+- Keep role/permission control-plane principal admission owner-defined and ahead of effective permission checks on every transport.
 
 ### Test coverage
 
@@ -116,16 +145,17 @@ multi-replica parity evidence exist.
 - Add contract tests for API response stability for frontends.
 - Include negative tests for RBAC/tenant isolation and failure-mode tests for event transport.
 - Add live HTTP/native host-authority tests for no header, wrong token, read/manage hierarchy, audit identity, Iggy authenticated/resolved tenant ownership, rotation/revocation and WebSocket denial.
+- Retain REST artifact-role permission and native RBAC Admin tests/verifiers for OAuth delegated/service denial, tenant mismatch, missing permission and trusted actor propagation.
 
 ## Periodic release verification handoff
 
 - Cycle: `cycle-001`
 - Status: `pending`
 - Last verified at (UTC): `2026-07-31`
-- Scope inspected: `cross-owner Tenant trust sweep only: host-global Events native, Iggy native, System GraphQL and Settings GraphQL authority; tenant OAuth administration; credential middleware and HTTP GraphQL/WebSocket composition`
-- Findings: `P0=2, P1=1, P2=1, P3=0` (the two P0 findings and one P1 raw-credential-lifetime defect belong to the cross-owner Tenant/Events interaction; the existing P2 is the earlier module-control-plane construction finding)
-- Fixed in this pass: `the earlier fail-closed host context is retained; a rejected OAuth-client allowlist design was removed before merge after proving tenant settings:manage can rotate OAuth app secrets; the replacement authenticates a dedicated host-owned opaque token by SHA-256 digest, removes the raw header before dispatch, inserts typed native authority, scopes typed authority across HTTP GraphQL, leaves WebSocket denied, moves the separate Iggy native read/write adapter from tenant SETTINGS_* to host Read/Manage, uses the host audit actor, and retains authenticated/resolved tenant equality for Iggy secret ownership; PR #2735 merged the result as 1ce83819b077ef6e0df009fd5675f556315ef63a`
-- Remaining risks or blockers: `the complete apps/server Wave 2 inspection has not started; host-authority formatting, source guard, server/API unit tests, server/events/Iggy-admin compile checks and live denial/admission/rotation/revocation/replica evidence are pending; issue #2680 remains open`
-- Evidence: `source files, unit regressions, the boundary verifier and runbook are merged at 1ce83819b077ef6e0df009fd5675f556315ef63a; PR #2735 exact-head jobs were queued at merge and are not claimed as passed; Rust-host smoke remained in its pre-build migration phase; no pull-request workflow runs are currently returned for the merge commit; local execution remains unavailable because github.com DNS resolution fails; superseded PR #2726 is not merge-SHA evidence`
-- Next action: `finish the current core/tenant item; collect any completed PR #2735 exact-head evidence without upgrading queued jobs, run the host-authority source/unit/compile gates on one reconciled revision, then resume the full server composition audit in Wave 2`
-- Resume command: `node scripts/verify/verify-host-global-authority-boundary.mjs && cargo test -p rustok-api host_authority -- --nocapture && cargo test -p rustok-server host_authority --lib -- --nocapture && cargo check -p rustok-events-module && cargo check -p rustok-iggy-connector-admin --features ssr && cargo check -p rustok-server --lib`
+- Scope inspected: `cross-owner Tenant trust sweep for host-global Events/Iggy/System/Settings authority, followed by the active core/rbac review of authoritative request scope, artifact role-permission REST adapter and native RBAC Admin bootstrap`
+- Findings: `P0=3, P1=2, P2=1, P3=0` (two host-global P0 findings and one raw-credential-lifetime P1 belong to the Tenant/Events interaction; the third P0 is the RBAC REST invalid principal grant; the second P1 is native role-metadata admission inconsistency; the existing P2 is the earlier module-control-plane construction finding)
+- Fixed in this pass: `PR #2735 merged the host-owned operator credential boundary as 1ce83819b077ef6e0df009fd5675f556315ef63a. PR #2747 now stages one owner host-neutral direct-session policy for REST, GraphQL and native RBAC Admin, authenticated/routed tenant equality before modules:manage or settings:read, trusted AuthContext actor propagation and removal of the obsolete native tenant-only helper.`
+- Remaining risks or blockers: `the complete apps/server Wave 2 inspection has not started; the RBAC P0/P1 corrections still lack same-SHA format, owner/admin/server compile, focused unit/architecture/verifier tests and live transport evidence; host-authority source/unit/compile and live denial/admission/rotation/revocation/replica evidence also remain pending; issues #2680 and #2740 remain open`
+- Evidence: `source audit confirms middleware builds AuthContext and request scope from authoritative DB permissions, with OAuth scopes only narrowing authority. PR #2747 contains the owner principal policy, REST/GraphQL/native composition, unit regressions, rbac_artifact_permission_control_plane_guard and the updated native verifier. No successful branch execution result is claimed yet. Host-authority source is merged at 1ce83819b077ef6e0df009fd5675f556315ef63a; its exact-head Rust-host path is blocked before server build by issue #2740.`
+- Next action: `collect exact-head format/check/Clippy and focused evidence for PR #2747, continue the core/rbac P0/P1 sweep, and leave the full server composition audit for its Wave 2 cursor visit`
+- Resume command: `cargo fmt --all -- --check && cargo check -p rustok-rbac && cargo check -p rustok-rbac --all-features && cargo check -p rustok-rbac-admin --features ssr && cargo check -p rustok-server --lib && cargo test -p rustok-rbac --all-features && cargo test -p rustok-rbac-admin --features ssr && cargo test -p rustok-server --test rbac_artifact_permission_control_plane_guard && node scripts/verify/verify-rbac-admin-tenant-scope.mjs`

--- a/apps/server/src/controllers/artifact_permissions.rs
+++ b/apps/server/src/controllers/artifact_permissions.rs
@@ -7,10 +7,11 @@ use axum::{
     response::Response,
     routing::put,
 };
-use rustok_api::{Permission, has_effective_permission};
+use rustok_api::{AuthContext, Permission, has_effective_permission};
 use rustok_rbac::{
     ArtifactPermissionAssignmentError, ArtifactRolePermissionAssignmentCommand,
-    RbacArtifactPermissionAssignmentService,
+    RbacArtifactPermissionAssignmentService, RbacControlPlanePrincipal,
+    require_direct_control_plane_user,
 };
 use rustok_web::json_response;
 use serde::{Deserialize, Serialize};
@@ -19,7 +20,7 @@ use uuid::Uuid;
 
 use crate::{
     error::{Error, Result, http_error},
-    extractors::{auth::CurrentUser, tenant::CurrentTenant},
+    extractors::tenant::CurrentTenant,
     services::server_runtime_context::ServerRuntimeContext,
 };
 
@@ -47,7 +48,7 @@ pub(crate) struct ArtifactRolePermissionAssignmentResponse {
         (status = 200, description = "Artifact permission granted", body = ArtifactRolePermissionAssignmentResponse),
         (status = 400, description = "Invalid command"),
         (status = 401, description = "Unauthorized"),
-        (status = 403, description = "modules:manage permission required"),
+        (status = 403, description = "Direct session user with modules:manage required"),
         (status = 404, description = "Role or registered artifact permission not found"),
         (status = 409, description = "Idempotency command conflict")
     )
@@ -55,12 +56,12 @@ pub(crate) struct ArtifactRolePermissionAssignmentResponse {
 async fn grant_artifact_permission(
     State(ctx): State<ServerRuntimeContext>,
     CurrentTenant(tenant): CurrentTenant,
-    current: CurrentUser,
+    auth: AuthContext,
     Path(role_id): Path<Uuid>,
     Json(input): Json<ArtifactRolePermissionAssignmentRequest>,
 ) -> Result<Response> {
-    ensure_modules_manage(&current)?;
-    assign(&ctx, tenant.id, current.user.id, role_id, input, true).await
+    ensure_artifact_permission_control_plane(&auth, tenant.id)?;
+    assign(&ctx, tenant.id, auth.user_id, role_id, input, true).await
 }
 
 #[utoipa::path(
@@ -74,7 +75,7 @@ async fn grant_artifact_permission(
         (status = 200, description = "Artifact permission revoked", body = ArtifactRolePermissionAssignmentResponse),
         (status = 400, description = "Invalid command"),
         (status = 401, description = "Unauthorized"),
-        (status = 403, description = "modules:manage permission required"),
+        (status = 403, description = "Direct session user with modules:manage required"),
         (status = 404, description = "Role or registered artifact permission not found"),
         (status = 409, description = "Idempotency command conflict")
     )
@@ -82,12 +83,12 @@ async fn grant_artifact_permission(
 async fn revoke_artifact_permission(
     State(ctx): State<ServerRuntimeContext>,
     CurrentTenant(tenant): CurrentTenant,
-    current: CurrentUser,
+    auth: AuthContext,
     Path(role_id): Path<Uuid>,
     Json(input): Json<ArtifactRolePermissionAssignmentRequest>,
 ) -> Result<Response> {
-    ensure_modules_manage(&current)?;
-    assign(&ctx, tenant.id, current.user.id, role_id, input, false).await
+    ensure_artifact_permission_control_plane(&auth, tenant.id)?;
+    assign(&ctx, tenant.id, auth.user_id, role_id, input, false).await
 }
 
 async fn assign(
@@ -116,8 +117,24 @@ async fn assign(
     }))
 }
 
-fn ensure_modules_manage(current: &CurrentUser) -> Result<()> {
-    if has_effective_permission(&current.permissions, &Permission::MODULES_MANAGE) {
+fn ensure_artifact_permission_control_plane(auth: &AuthContext, tenant_id: Uuid) -> Result<()> {
+    let principal = RbacControlPlanePrincipal {
+        tenant_id: auth.tenant_id,
+        session_id: auth.session_id,
+        client_id: auth.client_id,
+        grant_type: &auth.grant_type,
+    };
+    require_direct_control_plane_user(principal, tenant_id).map_err(|error| {
+        http_error(rustok_web::HttpError::forbidden(
+            "forbidden",
+            error.to_string(),
+        ))
+    })?;
+    ensure_modules_manage(&auth.permissions)
+}
+
+fn ensure_modules_manage(permissions: &[Permission]) -> Result<()> {
+    if has_effective_permission(permissions, &Permission::MODULES_MANAGE) {
         return Ok(());
     }
     Err(http_error(rustok_web::HttpError::forbidden(
@@ -152,4 +169,86 @@ pub fn router() -> crate::routes::ServerRouter {
         "/api/rbac/artifact-permissions/roles/{role_id}",
         put(grant_artifact_permission).delete(revoke_artifact_permission),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_artifact_permission_control_plane;
+    use rustok_api::{AuthContext, Permission};
+    use uuid::Uuid;
+
+    fn auth_context(
+        tenant_id: Uuid,
+        session_id: Uuid,
+        client_id: Option<Uuid>,
+        grant_type: &str,
+        permissions: Vec<Permission>,
+    ) -> AuthContext {
+        AuthContext {
+            user_id: Uuid::new_v4(),
+            session_id,
+            tenant_id,
+            permissions,
+            client_id,
+            scopes: Vec::new(),
+            grant_type: grant_type.to_string(),
+        }
+    }
+
+    #[test]
+    fn direct_session_manager_is_admitted() {
+        let tenant_id = Uuid::new_v4();
+        let auth = auth_context(
+            tenant_id,
+            Uuid::new_v4(),
+            None,
+            "direct",
+            vec![Permission::MODULES_MANAGE],
+        );
+
+        assert!(ensure_artifact_permission_control_plane(&auth, tenant_id).is_ok());
+    }
+
+    #[test]
+    fn oauth_principals_are_denied_even_with_modules_manage() {
+        for grant_type in ["authorization_code", "client_credentials"] {
+            let tenant_id = Uuid::new_v4();
+            let auth = auth_context(
+                tenant_id,
+                Uuid::nil(),
+                Some(Uuid::new_v4()),
+                grant_type,
+                vec![Permission::MODULES_MANAGE],
+            );
+
+            assert!(ensure_artifact_permission_control_plane(&auth, tenant_id).is_err());
+        }
+    }
+
+    #[test]
+    fn direct_user_from_another_tenant_is_denied() {
+        let auth = auth_context(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            None,
+            "direct",
+            vec![Permission::MODULES_MANAGE],
+        );
+
+        assert!(ensure_artifact_permission_control_plane(&auth, Uuid::new_v4()).is_err());
+    }
+
+    #[test]
+    fn direct_user_without_modules_manage_is_denied() {
+        let tenant_id = Uuid::new_v4();
+        let auth = auth_context(
+            tenant_id,
+            Uuid::new_v4(),
+            None,
+            "direct",
+            vec![Permission::MODULES_READ],
+        );
+
+        assert!(ensure_artifact_permission_control_plane(&auth, tenant_id).is_err());
+    }
 }

--- a/apps/server/tests/rbac_artifact_permission_control_plane_guard.rs
+++ b/apps/server/tests/rbac_artifact_permission_control_plane_guard.rs
@@ -1,0 +1,105 @@
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("apps/server should live under workspace root")
+        .to_path_buf()
+}
+
+fn source(relative: &str) -> String {
+    let path = repo_root().join(relative);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}
+
+#[test]
+fn artifact_role_permission_routes_require_owner_direct_session_admission_first() {
+    let controller = source("apps/server/src/controllers/artifact_permissions.rs");
+
+    assert!(controller.contains("use rustok_api::{AuthContext, Permission"));
+    assert!(!controller.contains("extractors::{auth::CurrentUser"));
+    assert_eq!(controller.matches("auth: AuthContext,").count(), 2);
+    assert_eq!(
+        controller
+            .matches("ensure_artifact_permission_control_plane(&auth, tenant.id)?;")
+            .count(),
+        2
+    );
+    assert_eq!(
+        controller
+            .matches("assign(&ctx, tenant.id, auth.user_id")
+            .count(),
+        2
+    );
+
+    let helper_start = controller
+        .find("fn ensure_artifact_permission_control_plane")
+        .expect("artifact control-plane helper must exist");
+    let permission_start = controller[helper_start..]
+        .find("fn ensure_modules_manage")
+        .map(|offset| helper_start + offset)
+        .expect("permission helper must follow control-plane helper");
+    let helper = &controller[helper_start..permission_start];
+    assert!(helper.contains("RbacControlPlanePrincipal"));
+    let principal_guard = helper
+        .find("require_direct_control_plane_user(principal, tenant_id)")
+        .expect("owner direct-session admission must be applied");
+    let permission_guard = helper
+        .find("ensure_modules_manage(&auth.permissions)")
+        .expect("modules:manage must be checked after principal admission");
+    assert!(principal_guard < permission_guard);
+}
+
+#[test]
+fn native_admin_bootstrap_uses_the_same_owner_principal_policy() {
+    let native = source("crates/rustok-rbac/admin/src/transport/native_server_adapter.rs");
+
+    for required in [
+        "RbacControlPlanePrincipal",
+        "tenant_id: auth.tenant_id",
+        "session_id: auth.session_id",
+        "client_id: auth.client_id",
+        "grant_type: &auth.grant_type",
+        "require_direct_control_plane_user(principal, tenant.id)",
+        "code = \"rbac.admin_control_plane_denied\"",
+        "ServerFnError::new(\"RBAC admin access is denied\")",
+    ] {
+        assert!(native.contains(required), "native adapter must retain {required}");
+    }
+
+    let principal_guard = native
+        .find("require_direct_control_plane_user(principal, tenant.id)")
+        .expect("native admin must use owner principal admission");
+    let permission_guard = native
+        .find("Permission::SETTINGS_READ")
+        .expect("native admin must retain settings:read admission");
+    assert!(principal_guard < permission_guard);
+    assert!(!native.contains("fn require_rbac_admin_tenant_scope<T>("));
+    assert!(!native.contains("fn rbac_admin_scope_matches<T: PartialEq>("));
+}
+
+#[test]
+fn module_owned_control_plane_guard_denies_oauth_and_cross_tenant_principals() {
+    let owner = source("crates/rustok-rbac/src/control_plane.rs");
+    let exports = source("crates/rustok-rbac/src/lib.rs");
+    let graphql = source("crates/rustok-rbac/src/graphql/control_plane.rs");
+
+    for required in [
+        "pub struct RbacControlPlanePrincipal",
+        "principal.client_id.is_some()",
+        "principal.grant_type != \"direct\"",
+        "principal.session_id.is_nil()",
+        "principal.tenant_id != tenant_id",
+        "oauth_principals_are_denied_even_with_management_permission",
+        "cross_tenant_context_is_denied",
+    ] {
+        assert!(owner.contains(required), "owner guard must retain {required}");
+    }
+
+    assert!(exports.contains("RbacControlPlanePrincipal"));
+    assert!(exports.contains("require_direct_control_plane_user"));
+    assert!(graphql.contains("crate::RbacControlPlanePrincipal"));
+    assert!(graphql.contains("crate::require_direct_control_plane_user(principal, tenant_id)"));
+}

--- a/crates/rustok-rbac/admin/src/transport/native_server_adapter.rs
+++ b/crates/rustok-rbac/admin/src/transport/native_server_adapter.rs
@@ -8,33 +8,6 @@ use crate::model::{RbacModulePermissionGroup, RbacRoleInfo};
 const RBAC_ADMIN_BOUNDARY: &str = "rbac_admin_native_transport";
 
 #[cfg(feature = "ssr")]
-fn rbac_admin_scope_matches<T: PartialEq>(auth_tenant_id: &T, resolved_tenant_id: &T) -> bool {
-    auth_tenant_id == resolved_tenant_id
-}
-
-#[cfg(feature = "ssr")]
-fn require_rbac_admin_tenant_scope<T>(
-    auth_tenant_id: &T,
-    resolved_tenant_id: &T,
-) -> Result<(), ServerFnError>
-where
-    T: PartialEq + std::fmt::Display,
-{
-    if rbac_admin_scope_matches(auth_tenant_id, resolved_tenant_id) {
-        return Ok(());
-    }
-
-    tracing::warn!(
-        auth_tenant_id = %auth_tenant_id,
-        resolved_tenant_id = %resolved_tenant_id,
-        code = "rbac.admin_tenant_scope_mismatch",
-        boundary = RBAC_ADMIN_BOUNDARY,
-        "RBAC admin permissions cannot cross the resolved tenant boundary"
-    );
-    Err(ServerFnError::new("RBAC admin access is denied"))
-}
-
-#[cfg(feature = "ssr")]
 fn rbac_admin_context_error<E: std::fmt::Debug>(
     error: E,
     context_kind: &'static str,
@@ -56,6 +29,9 @@ pub async fn fetch_bootstrap_native() -> Result<RbacAdminBootstrap, ServerFnErro
     {
         use rustok_api::{AuthContext, Permission, TenantContext, has_effective_permission};
         use rustok_core::{ModuleRegistry, Rbac, UserRole, infer_user_role_from_permissions};
+        use rustok_rbac::{
+            RbacControlPlanePrincipal, require_direct_control_plane_user,
+        };
 
         let registry = expect_context::<ModuleRegistry>();
         let auth = leptos_axum::extract::<AuthContext>()
@@ -76,7 +52,23 @@ pub async fn fetch_bootstrap_native() -> Result<RbacAdminBootstrap, ServerFnErro
                     "RBAC tenant context is temporarily unavailable",
                 )
             })?;
-        require_rbac_admin_tenant_scope(&auth.tenant_id, &tenant.id)?;
+        let principal = RbacControlPlanePrincipal {
+            tenant_id: auth.tenant_id,
+            session_id: auth.session_id,
+            client_id: auth.client_id,
+            grant_type: &auth.grant_type,
+        };
+        require_direct_control_plane_user(principal, tenant.id).map_err(|error| {
+            tracing::warn!(
+                reason = ?error,
+                auth_tenant_id = %auth.tenant_id,
+                resolved_tenant_id = %tenant.id,
+                code = "rbac.admin_control_plane_denied",
+                boundary = RBAC_ADMIN_BOUNDARY,
+                "RBAC admin bootstrap principal is not eligible for control-plane access"
+            );
+            ServerFnError::new("RBAC admin access is denied")
+        })?;
 
         if !has_effective_permission(&auth.permissions, &Permission::SETTINGS_READ) {
             return Err(ServerFnError::new(
@@ -156,18 +148,5 @@ pub async fn fetch_bootstrap_native() -> Result<RbacAdminBootstrap, ServerFnErro
         Err(ServerFnError::new(
             "rustok-rbac-admin requires the `ssr` feature for native bootstrap",
         ))
-    }
-}
-
-#[cfg(all(test, feature = "ssr"))]
-mod tests {
-    use super::{rbac_admin_scope_matches, require_rbac_admin_tenant_scope};
-
-    #[test]
-    fn rbac_admin_scope_requires_matching_tenant() {
-        assert!(rbac_admin_scope_matches(&"tenant-a", &"tenant-a"));
-        assert!(!rbac_admin_scope_matches(&"tenant-a", &"tenant-b"));
-        assert!(require_rbac_admin_tenant_scope(&"tenant-a", &"tenant-a").is_ok());
-        assert!(require_rbac_admin_tenant_scope(&"tenant-a", &"tenant-b").is_err());
     }
 }

--- a/crates/rustok-rbac/docs/implementation-plan.md
+++ b/crates/rustok-rbac/docs/implementation-plan.md
@@ -75,7 +75,7 @@ The ownership boundary is:
 - [x] Prevent service principals and OAuth delegated users from entering direct
   role-assignment or role-metadata control-plane operations.
 - [x] Require a direct grant, a valid session and matching tenant context for
-  GraphQL RBAC control-plane access.
+  GraphQL, REST and native RBAC control-plane access.
 - [x] Keep authorization decisions on typed permissions rather than inferred
   presentation roles.
 
@@ -157,6 +157,11 @@ The ownership boundary is:
   durable watchdog and invalidation listeners.
 - [x] Keep the FFA/FBA provider registry and native-only admin boundary guarded
   by existing static verification scripts.
+- [x] Guard artifact-role permission REST admission so the owner direct-session
+  policy precedes `modules:manage`, tenant equality is mandatory and the audit
+  actor comes from the authenticated context.
+- [x] Guard native RBAC Admin metadata bootstrap with the same owner principal
+  policy before `settings:read`; remove the obsolete tenant-only helper.
 - [ ] Execute the added Rust tests and architecture guards in a toolchain-enabled
   environment and fix any compile, formatting or lint failures.
 
@@ -248,22 +253,55 @@ The ownership boundary is:
 - This correction was delivered during the `core/tenant` cross-module work unit
   and is carried evidence for the now-active `core/rbac` verification item.
 
+## Artifact permission and role-metadata control-plane correction (2026-07-31)
+
+- Status: `source_ready_unvalidated`.
+- Severity: `P0` invalid authorization grant for REST mutation; `P1` cross-surface
+  admission inconsistency for native role/permission metadata.
+- Root cause: the REST PUT/DELETE artifact-role permission adapter admitted any
+  authenticated principal with effective `modules:manage`, while native RBAC
+  Admin bootstrap admitted any principal with `settings:read`. GraphQL correctly
+  required a direct session-bound user. Tenant OAuth authorization-code and
+  client-credentials principals could therefore mutate artifact grants or read
+  control-plane role metadata when their narrowed authority retained those
+  permissions.
+- [x] Add one host-neutral owner policy over
+  `RbacControlPlanePrincipal`; `rustok-rbac` remains compilable without the
+  `rustok-api/server` feature or Axum context types.
+- [x] Reuse that owner policy from GraphQL, REST and native RBAC Admin rather than
+  maintaining transport-specific principal classifiers.
+- [x] Require direct grant, non-nil session and authenticated/routed tenant
+  equality before `modules:manage` or `settings:read` admission.
+- [x] Bind the durable REST operation actor only from trusted
+  `AuthContext.user_id`; request payloads cannot supply or replace it.
+- [x] Remove the obsolete native generic tenant-only helper and retain static
+  public denials plus structured, non-secret diagnostics.
+- [x] Add owner unit tests, REST helper tests,
+  `rbac_artifact_permission_control_plane_guard` and the updated
+  `verify-rbac-admin-tenant-scope.mjs` source verifier for OAuth denial, tenant
+  mismatch, permission denial, shared-policy composition and admission order.
+- [ ] Same-SHA formatting, default/all-feature RBAC compile, RBAC Admin SSR
+  compile, server compile, focused unit/architecture/verifier execution and
+  transport-level negative requests are still required.
+
 ## Verification commands
 
 - Contract tests cover every public use case.
 
 ```bash
 cargo fmt --all -- --check
+cargo check -p rustok-rbac
 cargo check -p rustok-rbac --all-features
 cargo check -p rustok-rbac-admin --features ssr
 cargo check -p rustok-rbac-cli
 cargo check -p rustok-server --lib
 cargo test -p rustok-rbac --all-features
-cargo test -p rustok-rbac-admin --features ssr rbac_admin_scope_requires_matching_tenant -- --nocapture
+cargo test -p rustok-rbac-admin --features ssr
 cargo test -p rustok-migrations --lib rbac_system_role_repair_tests
 cargo test -p rustok-rbac-cli
 cargo test -p rustok-server --lib rbac
 cargo test -p rustok-server \
+  --test rbac_artifact_permission_control_plane_guard \
   --test rbac_cache_invalidation_architecture_guard \
   --test rbac_mutation_api_architecture_guard \
   --test rbac_migration_registration_guard \
@@ -316,10 +354,10 @@ harness owns them.
 - Cycle: `cycle-001`
 - Status: `in_progress`
 - Last verified at (UTC): `2026-07-31`
-- Scope inspected: `verification handoff initialized after the blocked Tenant visit; RBAC owner docs, source-complete phase claims, tenant trust-boundary carryover and required execution matrix were reconciled before code inspection`
-- Findings: `P0=0, P1=0, P2=0, P3=0` (initial handoff only; no new RBAC finding is claimed yet)
-- Fixed in this pass: `none; this handoff only establishes the active cursor and preserves the previously merged RBAC Admin tenant-boundary correction as unvalidated evidence`
-- Remaining risks or blockers: `all source-complete phases still require same-SHA format, compile, Clippy, targeted test and module validation evidence; PostgreSQL mutation concurrency, durable generation allocation, Redis outage/restart/missed-publication recovery, operator repair propagation, explicit actor-kind design and module-owned management flows remain open`
-- Evidence: `AGENTS.md, docs/index.md, the crate README, local documentation index and this implementation plan were read at main bd8188db80ebc9b9d7771a7da40483f31bc718bf; no execution result is claimed`
-- Next action: `inspect relation writes, principal classification, tenant-composite integrity, durable invalidation generation, cache recovery, repair tooling and every native/GraphQL/server adapter for P0/P1 defects; add regression coverage before any correction is merged`
-- Resume command: `cargo check -p rustok-rbac --all-features && cargo test -p rustok-rbac --all-features && cargo test -p rustok-server --lib rbac && cargo xtask module validate rbac && cargo xtask module test rbac`
+- Scope inspected: `principal classification and authoritative request-scope construction; tenant-filtered relation resolution; generation-aware cache fill; committed role replacement; canonical repair; installer bootstrap boundary; artifact permission catalog, durable assignment owner, REST/GraphQL adapters and native RBAC Admin bootstrap`
+- Findings: `P0=1, P1=1, P2=0, P3=0`
+- Fixed in this pass: `one host-neutral rustok-rbac policy now requires a direct non-nil session and authenticated/routed tenant equality before GraphQL, REST and native RBAC control-plane permission admission; REST no longer treats modules:manage as sufficient principal authority, native bootstrap no longer treats settings:read as sufficient, the obsolete native tenant-only helper is removed and the durable actor remains derived from trusted AuthContext`
+- Remaining risks or blockers: `the P0/P1 corrections are source-ready but same-SHA format, default/all-feature RBAC compile, RBAC Admin SSR compile, server compile, focused unit/architecture/verifier tests and live negative transport requests have not run; all previously open PostgreSQL concurrency, durable generation allocation, Redis outage/restart/missed-publication recovery, operator repair propagation, explicit actor-kind design, module-owned management flow and FFA/FBA evidence remain open`
+- Evidence: `source review confirms middleware builds request scope from authoritative DB permissions and OAuth only narrows authority; relation resolution tenant-filters role ids and generation-aware fills fail closed; role replacement and repair reserve durable generation in their owner transaction. PR #2747 adds owner, GraphQL, REST, native and architecture/source regressions. No successful execution result is claimed yet.`
+- Next action: `collect exact-head format/check/Clippy and focused evidence for PR #2747, fix branch-related failures, then continue the RBAC sweep across remaining CLI/event/worker surfaces and live recovery gates`
+- Resume command: `cargo fmt --all -- --check && cargo check -p rustok-rbac && cargo check -p rustok-rbac --all-features && cargo check -p rustok-rbac-admin --features ssr && cargo check -p rustok-server --lib && cargo test -p rustok-rbac --all-features && cargo test -p rustok-rbac-admin --features ssr && cargo test -p rustok-server --test rbac_artifact_permission_control_plane_guard && node scripts/verify/verify-rbac-admin-tenant-scope.mjs && cargo xtask module validate rbac && cargo xtask module test rbac`

--- a/crates/rustok-rbac/src/control_plane.rs
+++ b/crates/rustok-rbac/src/control_plane.rs
@@ -1,0 +1,113 @@
+use thiserror::Error;
+use uuid::Uuid;
+
+/// Host-neutral authenticated facts required by the RBAC control-plane policy.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RbacControlPlanePrincipal<'a> {
+    pub tenant_id: Uuid,
+    pub session_id: Uuid,
+    pub client_id: Option<Uuid>,
+    pub grant_type: &'a str,
+}
+
+/// Fail-closed admission errors for tenant-scoped RBAC control-plane operations.
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+pub enum RbacControlPlaneAdmissionError {
+    #[error("RBAC control plane requires a direct, session-bound user principal")]
+    DirectSessionRequired,
+    #[error("authenticated principal belongs to another tenant")]
+    TenantMismatch,
+}
+
+/// Require a direct, session-bound user whose authenticated tenant matches the
+/// routed tenant before any RBAC role or permission control-plane admission.
+///
+/// OAuth authorization-code and client-credentials principals remain valid for
+/// data-plane operations admitted by their effective permissions, but they are
+/// not allowed to mutate RBAC control-plane state.
+pub fn require_direct_control_plane_user(
+    principal: RbacControlPlanePrincipal<'_>,
+    tenant_id: Uuid,
+) -> Result<(), RbacControlPlaneAdmissionError> {
+    if principal.client_id.is_some()
+        || principal.grant_type != "direct"
+        || principal.session_id.is_nil()
+    {
+        return Err(RbacControlPlaneAdmissionError::DirectSessionRequired);
+    }
+
+    if principal.tenant_id != tenant_id {
+        return Err(RbacControlPlaneAdmissionError::TenantMismatch);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn principal(
+        tenant_id: Uuid,
+        session_id: Uuid,
+        client_id: Option<Uuid>,
+        grant_type: &str,
+    ) -> RbacControlPlanePrincipal<'_> {
+        RbacControlPlanePrincipal {
+            tenant_id,
+            session_id,
+            client_id,
+            grant_type,
+        }
+    }
+
+    #[test]
+    fn direct_session_bound_user_is_allowed_for_matching_tenant() {
+        let tenant_id = Uuid::new_v4();
+        let principal = principal(tenant_id, Uuid::new_v4(), None, "direct");
+
+        assert_eq!(
+            require_direct_control_plane_user(principal, tenant_id),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn oauth_principals_are_denied_even_with_management_permission() {
+        for grant_type in ["authorization_code", "client_credentials"] {
+            let tenant_id = Uuid::new_v4();
+            let principal = principal(
+                tenant_id,
+                Uuid::nil(),
+                Some(Uuid::new_v4()),
+                grant_type,
+            );
+
+            assert_eq!(
+                require_direct_control_plane_user(principal, tenant_id),
+                Err(RbacControlPlaneAdmissionError::DirectSessionRequired)
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_direct_principal_without_session_is_denied() {
+        let tenant_id = Uuid::new_v4();
+        let principal = principal(tenant_id, Uuid::nil(), None, "direct");
+
+        assert_eq!(
+            require_direct_control_plane_user(principal, tenant_id),
+            Err(RbacControlPlaneAdmissionError::DirectSessionRequired)
+        );
+    }
+
+    #[test]
+    fn cross_tenant_context_is_denied() {
+        let principal = principal(Uuid::new_v4(), Uuid::new_v4(), None, "direct");
+
+        assert_eq!(
+            require_direct_control_plane_user(principal, Uuid::new_v4()),
+            Err(RbacControlPlaneAdmissionError::TenantMismatch)
+        );
+    }
+}

--- a/crates/rustok-rbac/src/graphql/control_plane.rs
+++ b/crates/rustok-rbac/src/graphql/control_plane.rs
@@ -3,19 +3,16 @@ use rustok_api::{AuthContext, graphql::GraphQLError};
 use uuid::Uuid;
 
 pub(super) fn require_direct_control_plane_user(auth: &AuthContext, tenant_id: Uuid) -> Result<()> {
-    if auth.client_id.is_some() || auth.grant_type != "direct" || auth.session_id.is_nil() {
-        return Err(<FieldError as GraphQLError>::permission_denied(
-            "RBAC control plane requires a direct, session-bound user principal",
-        ));
-    }
-
-    if auth.tenant_id != tenant_id {
-        return Err(<FieldError as GraphQLError>::permission_denied(
-            "authenticated principal belongs to another tenant",
-        ));
-    }
-
-    Ok(())
+    let principal = crate::RbacControlPlanePrincipal {
+        tenant_id: auth.tenant_id,
+        session_id: auth.session_id,
+        client_id: auth.client_id,
+        grant_type: &auth.grant_type,
+    };
+    crate::require_direct_control_plane_user(principal, tenant_id).map_err(|error| {
+        let message = error.to_string();
+        <FieldError as GraphQLError>::permission_denied(&message)
+    })
 }
 
 #[cfg(test)]

--- a/crates/rustok-rbac/src/lib.rs
+++ b/crates/rustok-rbac/src/lib.rs
@@ -2,6 +2,7 @@ mod artifact_permission_assignment;
 mod artifact_permission_catalog;
 pub mod bootstrap;
 pub mod catalog;
+mod control_plane;
 pub mod dto;
 pub mod entities;
 pub mod error;
@@ -26,6 +27,10 @@ pub use artifact_permission_catalog::RbacArtifactPermissionCatalog;
 pub use bootstrap::{RbacRoleAssignmentDbWriter, RbacRoleAssignmentError};
 pub use catalog::BuiltinTenantRbacCatalog;
 pub use consistency::{RbacConsistencyStats, load_consistency_stats};
+pub use control_plane::{
+    RbacControlPlaneAdmissionError, RbacControlPlanePrincipal,
+    require_direct_control_plane_user,
+};
 pub use error::RbacError;
 pub use integration::{
     RBAC_EVENT_ROLE_PERMISSIONS_ASSIGNED, RBAC_EVENT_TENANT_ROLE_ASSIGNMENTS_REMOVED,

--- a/scripts/verify/verify-rbac-admin-tenant-scope.mjs
+++ b/scripts/verify/verify-rbac-admin-tenant-scope.mjs
@@ -7,6 +7,10 @@ const source = readFileSync(
   new URL('crates/rustok-rbac/admin/src/transport/native_server_adapter.rs', root),
   'utf8',
 );
+const owner = readFileSync(
+  new URL('crates/rustok-rbac/src/control_plane.rs', root),
+  'utf8',
+);
 const cargo = readFileSync(
   new URL('crates/rustok-rbac/admin/Cargo.toml', root),
   'utf8',
@@ -17,37 +21,54 @@ const fail = (message) => {
 };
 
 for (const marker of [
-  'fn require_rbac_admin_tenant_scope<T>(',
-  'rbac_admin_scope_matches(auth_tenant_id, resolved_tenant_id)',
-  'code = "rbac.admin_tenant_scope_mismatch"',
+  'RbacControlPlanePrincipal',
+  'require_direct_control_plane_user(principal, tenant.id)',
+  'tenant_id: auth.tenant_id',
+  'session_id: auth.session_id',
+  'client_id: auth.client_id',
+  'grant_type: &auth.grant_type',
+  'code = "rbac.admin_control_plane_denied"',
   'boundary = RBAC_ADMIN_BOUNDARY',
-  'Err(ServerFnError::new("RBAC admin access is denied"))',
-  'require_rbac_admin_tenant_scope(&auth.tenant_id, &tenant.id)?;',
-  'fn rbac_admin_scope_requires_matching_tenant()',
+  'ServerFnError::new("RBAC admin access is denied")',
   'RBAC authentication context is temporarily unavailable',
   'RBAC tenant context is temporarily unavailable',
   'fn rbac_admin_context_error<E: std::fmt::Debug>(',
 ]) {
-  if (!source.includes(marker)) fail(`RBAC Admin tenant/error guard missing ${marker}`);
+  if (!source.includes(marker)) fail(`RBAC Admin principal/error guard missing ${marker}`);
 }
 
-const scopeIndex = source.indexOf('require_rbac_admin_tenant_scope(&auth.tenant_id, &tenant.id)?;');
+const principalIndex = source.indexOf('require_direct_control_plane_user(principal, tenant.id)');
 const permissionIndex = source.indexOf('Permission::SETTINGS_READ');
-if (scopeIndex < 0 || permissionIndex < 0 || scopeIndex >= permissionIndex) {
-  fail('RBAC Admin must bind authenticated and resolved tenants before SETTINGS_READ admission');
+if (principalIndex < 0 || permissionIndex < 0 || principalIndex >= permissionIndex) {
+  fail('RBAC Admin must admit a direct matching principal before SETTINGS_READ');
 }
 
 for (const forbidden of [
+  'fn require_rbac_admin_tenant_scope<T>(',
+  'fn rbac_admin_scope_matches<T: PartialEq>(',
   '.map_err(ServerFnError::new)?',
   '.map_err(|error| ServerFnError::new(error))?',
 ]) {
-  if (source.includes(forbidden)) fail(`RBAC Admin exposes raw context errors through ${forbidden}`);
+  if (source.includes(forbidden)) fail(`RBAC Admin retains obsolete or unsafe path ${forbidden}`);
+}
+
+for (const marker of [
+  'pub struct RbacControlPlanePrincipal',
+  'principal.client_id.is_some()',
+  'principal.grant_type != "direct"',
+  'principal.session_id.is_nil()',
+  'principal.tenant_id != tenant_id',
+]) {
+  if (!owner.includes(marker)) fail(`RBAC owner control-plane policy missing ${marker}`);
 }
 
 if (!cargo.includes('tracing.workspace = true')) {
-  fail('RBAC Admin structured tenant-scope diagnostics require direct tracing dependency');
+  fail('RBAC Admin structured control-plane diagnostics require direct tracing dependency');
+}
+if (!cargo.includes('"dep:rustok-rbac"')) {
+  fail('RBAC Admin SSR feature must activate the RBAC owner policy dependency');
 }
 
 console.log(
-  '[verify-rbac-admin-tenant-scope] RBAC Admin binds authenticated permissions to the resolved tenant and keeps context failures static publicly',
+  '[verify-rbac-admin-tenant-scope] RBAC Admin requires a direct matching principal before permission admission and keeps context failures static publicly',
 );


### PR DESCRIPTION
## Summary

- close the REST artifact role-permission mutation bypass (`P0`)
- close native RBAC Admin role/permission metadata admission inconsistency (`P1`)
- add one host-neutral `rustok-rbac` principal policy shared by GraphQL, REST and native admin
- require a direct grant, a non-nil session and authenticated/routed tenant equality before effective permission admission
- derive durable mutation audit identity only from trusted `AuthContext.user_id`
- remove the obsolete native tenant-only helper
- add owner unit tests, server helper tests, an architecture guard and an updated native source verifier
- update the RBAC owner and server host implementation plans without advancing the cycle cursor

## Root causes

1. `PUT` and `DELETE /api/rbac/artifact-permissions/roles/{role_id}` treated effective `modules:manage` as sufficient authority. OAuth authorization-code users and client-credentials service principals could mutate tenant role-to-artifact grants when their narrowed authority retained that permission.
2. Native RBAC Admin bootstrap treated effective `settings:read` as sufficient authority, while GraphQL role metadata already required a direct session user. OAuth principals could read role and module-permission control-plane metadata through the native surface.

## Security boundary

Admission order is now:

1. build a host-neutral `RbacControlPlanePrincipal` from trusted `AuthContext`
2. require direct grant and non-nil session
3. require authenticated tenant equal to middleware-routed tenant
4. require the surface permission (`modules:manage` or `settings:read`)
5. for REST mutation, call the RBAC owner with `AuthContext.user_id` as actor

OAuth principals remain valid for admitted data-plane operations but cannot enter RBAC role/permission control-plane surfaces.

## Regression coverage

- owner policy: direct user allowed; authorization-code/client-credentials denied; nil session denied; tenant mismatch denied
- REST helper: OAuth denied even with `modules:manage`; missing permission denied; tenant mismatch denied
- native verifier: owner principal composition precedes `settings:read`; obsolete tenant-only helper is forbidden; public failures remain static
- architecture guard: GraphQL, REST and native admin share the owner policy; mutation actor comes from trusted context

## Validation status

On exact head `3cf4b3a44980ca257f7f53849e905673141db289`, Rust-host workflow run `30650883159` compiled the default `rustok-rbac` crate successfully in its migration dependency graph. The workflow then reproduced issue #2740 before building `rustok-server`: its nominally successful bounded-role step targeted the wrong PostgreSQL container, and the service instance reported that role `rustok_browser` does not exist. Standard CI and Hardening runs remain pending without jobs; RBAC Admin SSR compile, server compile, formatting, Clippy, focused tests, verifier execution, module validation and live negative HTTP/native requests are not claimed as passed. Browser E2E retained the known unrelated four Next Admin `sessionStorage` failures while Next Frontend passed. Local execution remains unavailable because GitHub DNS resolution fails in the checkout environment. No CI workflow files are changed.