### PR TITLE
feat(forum): publish versioned Search invalidations

### DIFF
--- a/crates/rustok-events/CRATE_API.md
+++ b/crates/rustok-events/CRATE_API.md
@@ -9,6 +9,7 @@
 - `pub use crate::{EventSchema, FieldSchema, EventValidationError, ValidateEvent}`
 - `pub use crate::{EventContract, ContractEventPayload, ContractEventEnvelope, EventContractEnvelopeError}`
 - `pub use crate::{ForumMentionEvent, FORUM_MENTION_EVENT_SCHEMAS}`
+- `pub use crate::{ForumSearchProjectionEvent, FORUM_SEARCH_PROJECTION_EVENT_SCHEMAS}`
 - `pub use crate::{MarketplaceListingEvent, MARKETPLACE_LISTING_EVENT_SCHEMAS}`
 - `pub use crate::{MarketplaceSellerEvent, MARKETPLACE_SELLER_EVENT_SCHEMAS}`
 - `pub use crate::{SocialGraphRelationEvent, SOCIAL_GRAPH_RELATION_EVENT_SCHEMAS}`
@@ -32,6 +33,11 @@
 - Established root events use `DomainEvent`/`EventEnvelope`.
 - Bounded event families use sealed `EventContract` implementations and `ContractEventEnvelope`.
 - `ForumMentionEvent` defines v1 `forum.mention.user_added` and `forum.mention.audience_added` with source revision and target identity only.
+- `ForumSearchProjectionEvent` defines v1
+  `forum.search_projection.invalidation_issued` with a positive Forum owner
+  revision, one bounded projection target type, and a target identity only when
+  the scope is a category or topic. The exact legacy root envelope identity is
+  carried in typed-envelope `causation_id`, not in the payload.
 - `SocialGraphRelationEvent` defines v1 `social_graph.relation.state_changed`
   as an authoritative fact for one persisted relation revision, with relation id,
   source/target user ids, canonical kind, active state, and revision only. Tenant
@@ -56,6 +62,10 @@
 - Stores bounded-family payloads as untyped `serde_json::Value` instead of adding one typed `ContractEventPayload` family variant.
 - Copies causal identity into the event payload instead of using envelope `causation_id`.
 - Uses a nil, reconstructed, or unrelated UUID as a causal predecessor.
+- Publishes the Forum Search typed invalidation without the legacy root envelope
+  or records the typed envelope id in the Forum owner ledger.
+- Adds locale, channel, visibility, rendered content, document payload, reason,
+  claims, roles, or Search `ingest_sequence` to the Forum Search invalidation payload.
 - Adds contact data, source body or profile handle snapshots to Forum mention events instead of stable identities.
 - Adds idempotency keys, expected revisions, request context, claims, roles, locale,
   channel, or receipt snapshots to Social Graph relation events.
@@ -86,6 +96,11 @@
 - Root envelope trace identifiers must be non-empty and at most 512 bytes.
 - `payload` and `into_payload` fail closed when semantic or schema validation fails.
 - Forum mention events expose source revision and resolved user/audience identity only; contact and rendered content remain owner-private.
+- Forum Search projection invalidations require `owner_revision >= 1`, accept
+  only `forum|forum_category|forum_topic`, require `target_id = null` for
+  `forum`, and require a non-nil `target_id` for category/topic scope.
+- Forum owner revision and Search-owned `ingest_sequence` remain independent
+  counters and must never be compared numerically.
 - Social Graph relation events accept only non-nil distinct source/target ids,
   canonical `block|mute|follow` kind, and a positive monotonic revision.
 - A Social Graph consumer applies by relation id plus monotonic revision, ignores
@@ -100,6 +115,9 @@
 
 ### Events / Outbox Side Effects
 - Owner modules publish sealed contracts through `TransactionalEventBus::publish_contract_in_tx` inside the owner transaction.
+- Forum dual publication writes the legacy root first, publishes the typed
+  contract caused by that exact root id, and retains the root id as owner-ledger
+  and downstream projection identity.
 - Root and bounded-family envelopes remain distinct typed transport profiles.
 - Event payload and event-type format must remain backward-compatible for cross-module consumers.
 - The current release train permits only schema version 1. A versioned migration

--- a/crates/rustok-events/contracts/event-contract-digests.json
+++ b/crates/rustok-events/contracts/event-contract-digests.json
@@ -1,8 +1,8 @@
 {
   "format_version": 1,
-  "registry": "sha256:18fdee49d915a22ed3dd709ec6cc1826d6d47a59ddfe659fbd07ede7f6cd3d07",
+  "registry": "sha256:a4b41305240a06ad57bb10499f6699226e5fe77adff7d6efbafe83c9e84ae0aa",
   "root_event": "sha256:2bc388a237ff1fcbe327c340633815a64c84c799afef5a0012f458752d6deb87",
   "root_envelope": "sha256:cfb55b9ac1fbebdc27658e035c00a98468c947b4830f8603c4258457849db42d",
-  "contract_payload": "sha256:5f1f9577bc9429b76bbfe5420d1bd71249efd6aea702ec0a103e4a402702cd02",
-  "contract_envelope": "sha256:b29a8c7809045e14f1233db4e2f9dba9cedf96352df3ea9e87ca1e86f6a59eb8"
+  "contract_payload": "sha256:e07934a82cb82ae14ec3d8b7c1e5938a6dd4bafdd563ebdce7e890985bd8011d",
+  "contract_envelope": "sha256:e0466ed18a986885f62f08f866a882b1f2de9ed277c6e8a29d04f43aaa705d5d"
 }

--- a/crates/rustok-events/src/contract.rs
+++ b/crates/rustok-events/src/contract.rs
@@ -6,8 +6,9 @@ use ulid::Ulid;
 use uuid::Uuid;
 
 use crate::{
-    DomainEvent, EventEnvelope, EventValidationError, ForumMentionEvent, MarketplaceListingEvent,
-    MarketplaceSellerEvent, SocialGraphRelationEvent, TranslationWorkflowEvent, ValidateEvent,
+    DomainEvent, EventEnvelope, EventValidationError, ForumMentionEvent,
+    ForumSearchProjectionEvent, MarketplaceListingEvent, MarketplaceSellerEvent,
+    SocialGraphRelationEvent, TranslationWorkflowEvent, ValidateEvent,
 };
 
 pub(crate) mod sealed {
@@ -38,6 +39,8 @@ pub enum ContractEventPayload {
     Root(DomainEvent),
     #[serde(rename = "forum_mention")]
     ForumMention(ForumMentionEvent),
+    #[serde(rename = "forum_search_projection")]
+    ForumSearchProjection(ForumSearchProjectionEvent),
     #[serde(rename = "marketplace_listing")]
     MarketplaceListing(MarketplaceListingEvent),
     #[serde(rename = "marketplace_seller")]
@@ -53,6 +56,7 @@ impl ContractEventPayload {
         match self {
             Self::Root(event) => event.event_type(),
             Self::ForumMention(event) => event.event_type(),
+            Self::ForumSearchProjection(event) => event.event_type(),
             Self::MarketplaceListing(event) => event.event_type(),
             Self::MarketplaceSeller(event) => event.event_type(),
             Self::SocialGraphRelation(event) => event.event_type(),
@@ -64,6 +68,7 @@ impl ContractEventPayload {
         match self {
             Self::Root(event) => event.schema_version(),
             Self::ForumMention(event) => event.schema_version(),
+            Self::ForumSearchProjection(event) => event.schema_version(),
             Self::MarketplaceListing(event) => event.schema_version(),
             Self::MarketplaceSeller(event) => event.schema_version(),
             Self::SocialGraphRelation(event) => event.schema_version(),
@@ -77,6 +82,7 @@ impl ValidateEvent for ContractEventPayload {
         match self {
             Self::Root(event) => event.validate(),
             Self::ForumMention(event) => event.validate(),
+            Self::ForumSearchProjection(event) => event.validate(),
             Self::MarketplaceListing(event) => event.validate(),
             Self::MarketplaceSeller(event) => event.validate(),
             Self::SocialGraphRelation(event) => event.validate(),

--- a/crates/rustok-events/src/forum_search_projection.rs
+++ b/crates/rustok-events/src/forum_search_projection.rs
@@ -1,0 +1,172 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::contract::{ContractEventPayload, EventContract, sealed};
+use crate::validation::{EventValidationError, ValidateEvent, validators};
+use crate::{EventSchema, FieldSchema};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, JsonSchema)]
+#[serde(tag = "type", content = "data")]
+pub enum ForumSearchProjectionEvent {
+    InvalidationIssued {
+        owner_revision: i64,
+        target_type: String,
+        target_id: Option<Uuid>,
+    },
+}
+
+impl ForumSearchProjectionEvent {
+    pub fn event_type(&self) -> &'static str {
+        match self {
+            Self::InvalidationIssued { .. } => {
+                "forum.search_projection.invalidation_issued"
+            }
+        }
+    }
+
+    pub const fn schema_version(&self) -> u16 {
+        1
+    }
+}
+
+const INVALIDATION_ISSUED_FIELDS: &[FieldSchema] = &[
+    FieldSchema {
+        name: "owner_revision",
+        data_type: "int64",
+        optional: false,
+    },
+    FieldSchema {
+        name: "target_type",
+        data_type: "string",
+        optional: false,
+    },
+    FieldSchema {
+        name: "target_id",
+        data_type: "uuid",
+        optional: true,
+    },
+];
+
+pub const FORUM_SEARCH_PROJECTION_EVENT_SCHEMAS: &[EventSchema] = &[EventSchema {
+    event_type: "forum.search_projection.invalidation_issued",
+    version: 1,
+    description: "Forum issued one monotonic owner revision that invalidates a Search projection scope.",
+    fields: INVALIDATION_ISSUED_FIELDS,
+}];
+
+impl sealed::Sealed for ForumSearchProjectionEvent {}
+
+impl EventContract for ForumSearchProjectionEvent {
+    fn event_type(&self) -> &'static str {
+        ForumSearchProjectionEvent::event_type(self)
+    }
+
+    fn schema_version(&self) -> u16 {
+        ForumSearchProjectionEvent::schema_version(self)
+    }
+
+    fn into_contract_payload(self) -> ContractEventPayload {
+        ContractEventPayload::ForumSearchProjection(self)
+    }
+}
+
+impl ValidateEvent for ForumSearchProjectionEvent {
+    fn validate(&self) -> Result<(), EventValidationError> {
+        let Self::InvalidationIssued {
+            owner_revision,
+            target_type,
+            target_id,
+        } = self;
+
+        validators::validate_range("owner_revision", *owner_revision, 1, i64::MAX)?;
+        match (target_type.as_str(), target_id) {
+            ("forum", None) => Ok(()),
+            ("forum_category" | "forum_topic", Some(target_id)) => {
+                validators::validate_not_nil_uuid("target_id", target_id)
+            }
+            ("forum", Some(_)) => Err(EventValidationError::InvalidValue(
+                "target_id",
+                "must be absent for a full Forum projection invalidation".to_string(),
+            )),
+            ("forum_category" | "forum_topic", None) => {
+                Err(EventValidationError::MissingField("target_id"))
+            }
+            _ => Err(EventValidationError::InvalidValue(
+                "target_type",
+                "must be forum, forum_category, or forum_topic".to_string(),
+            )),
+        }
+    }
+}
+
+pub fn forum_search_projection_event_schema(
+    event_type: &str,
+) -> Option<&'static EventSchema> {
+    FORUM_SEARCH_PROJECTION_EVENT_SCHEMAS
+        .iter()
+        .find(|schema| schema.event_type == event_type)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_each_supported_projection_scope() {
+        assert!(
+            ForumSearchProjectionEvent::InvalidationIssued {
+                owner_revision: 1,
+                target_type: "forum".to_string(),
+                target_id: None,
+            }
+            .validate()
+            .is_ok()
+        );
+
+        for target_type in ["forum_category", "forum_topic"] {
+            assert!(
+                ForumSearchProjectionEvent::InvalidationIssued {
+                    owner_revision: 2,
+                    target_type: target_type.to_string(),
+                    target_id: Some(Uuid::new_v4()),
+                }
+                .validate()
+                .is_ok()
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_revision_and_scope_identity() {
+        for event in [
+            ForumSearchProjectionEvent::InvalidationIssued {
+                owner_revision: 0,
+                target_type: "forum".to_string(),
+                target_id: None,
+            },
+            ForumSearchProjectionEvent::InvalidationIssued {
+                owner_revision: 1,
+                target_type: "forum".to_string(),
+                target_id: Some(Uuid::new_v4()),
+            },
+            ForumSearchProjectionEvent::InvalidationIssued {
+                owner_revision: 1,
+                target_type: "forum_topic".to_string(),
+                target_id: None,
+            },
+            ForumSearchProjectionEvent::InvalidationIssued {
+                owner_revision: 1,
+                target_type: "forum_category".to_string(),
+                target_id: Some(Uuid::nil()),
+            },
+            ForumSearchProjectionEvent::InvalidationIssued {
+                owner_revision: 1,
+                target_type: "post".to_string(),
+                target_id: Some(Uuid::new_v4()),
+            },
+        ] {
+            assert!(event.validate().is_err());
+        }
+    }
+}

--- a/crates/rustok-events/src/lib.rs
+++ b/crates/rustok-events/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod contract;
 mod forum_mention;
+mod forum_search_projection;
 mod marketplace_listing;
 mod marketplace_seller;
 mod schema;
@@ -15,6 +16,10 @@ pub use contract::{
 };
 pub use forum_mention::{
     FORUM_MENTION_EVENT_SCHEMAS, ForumMentionEvent, forum_mention_event_schema,
+};
+pub use forum_search_projection::{
+    FORUM_SEARCH_PROJECTION_EVENT_SCHEMAS, ForumSearchProjectionEvent,
+    forum_search_projection_event_schema,
 };
 pub use marketplace_listing::{
     MARKETPLACE_LISTING_EVENT_SCHEMAS, MarketplaceListingEvent, marketplace_listing_event_schema,
@@ -43,6 +48,7 @@ pub use EventEnvelope as RootEventEnvelope;
 pub fn event_schema(event_type: &str) -> Option<&'static EventSchema> {
     schema::event_schema(event_type)
         .or_else(|| forum_mention_event_schema(event_type))
+        .or_else(|| forum_search_projection_event_schema(event_type))
         .or_else(|| marketplace_listing_event_schema(event_type))
         .or_else(|| marketplace_seller_event_schema(event_type))
         .or_else(|| social_graph_relation_event_schema(event_type))
@@ -53,6 +59,7 @@ pub fn event_schemas() -> impl Iterator<Item = &'static EventSchema> {
     EVENT_SCHEMAS
         .iter()
         .chain(FORUM_MENTION_EVENT_SCHEMAS.iter())
+        .chain(FORUM_SEARCH_PROJECTION_EVENT_SCHEMAS.iter())
         .chain(MARKETPLACE_LISTING_EVENT_SCHEMAS.iter())
         .chain(MARKETPLACE_SELLER_EVENT_SCHEMAS.iter())
         .chain(SOCIAL_GRAPH_RELATION_EVENT_SCHEMAS.iter())

--- a/crates/rustok-events/tests/forum_search_projection_contracts.rs
+++ b/crates/rustok-events/tests/forum_search_projection_contracts.rs
@@ -1,0 +1,90 @@
+use rustok_events::{
+    ContractEventEnvelope, ContractEventPayload, ForumSearchProjectionEvent, ValidateEvent,
+    event_schema,
+};
+use uuid::Uuid;
+
+#[test]
+fn forum_search_projection_contract_roundtrips_with_root_causation() {
+    let tenant_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    let root_event_id = Uuid::new_v4();
+    let target_id = Uuid::new_v4();
+    let event = ForumSearchProjectionEvent::InvalidationIssued {
+        owner_revision: 7,
+        target_type: "forum_topic".to_string(),
+        target_id: Some(target_id),
+    };
+    event.validate().expect("valid Forum Search invalidation");
+
+    let envelope = ContractEventEnvelope::new_caused_by(
+        tenant_id,
+        Some(actor_id),
+        root_event_id,
+        event,
+    )
+    .expect("registered caused contract envelope");
+    assert_eq!(
+        envelope.event_type(),
+        "forum.search_projection.invalidation_issued"
+    );
+    assert_eq!(envelope.schema_version(), 1);
+    assert_eq!(envelope.tenant_id(), tenant_id);
+    assert_eq!(envelope.causation_id(), Some(root_event_id));
+
+    let encoded = serde_json::to_vec(&envelope).expect("serialize envelope");
+    let decoded: ContractEventEnvelope =
+        serde_json::from_slice(&encoded).expect("deserialize envelope");
+    decoded
+        .validate_registered_schema()
+        .expect("decoded envelope remains registered");
+    assert_eq!(decoded.causation_id(), Some(root_event_id));
+    assert!(matches!(
+        decoded.payload().expect("validated payload"),
+        ContractEventPayload::ForumSearchProjection(
+            ForumSearchProjectionEvent::InvalidationIssued {
+                owner_revision: 7,
+                target_type,
+                target_id: Some(decoded_target_id),
+            }
+        ) if target_type == "forum_topic" && *decoded_target_id == target_id
+    ));
+}
+
+#[test]
+fn forum_search_projection_registry_and_scope_validation_are_fail_closed() {
+    let schema = event_schema("forum.search_projection.invalidation_issued")
+        .expect("Forum Search event must be registered");
+    assert_eq!(schema.version, 1);
+    assert_eq!(schema.fields.len(), 3);
+
+    for invalid in [
+        ForumSearchProjectionEvent::InvalidationIssued {
+            owner_revision: 0,
+            target_type: "forum".to_string(),
+            target_id: None,
+        },
+        ForumSearchProjectionEvent::InvalidationIssued {
+            owner_revision: 1,
+            target_type: "forum".to_string(),
+            target_id: Some(Uuid::new_v4()),
+        },
+        ForumSearchProjectionEvent::InvalidationIssued {
+            owner_revision: 1,
+            target_type: "forum_category".to_string(),
+            target_id: None,
+        },
+        ForumSearchProjectionEvent::InvalidationIssued {
+            owner_revision: 1,
+            target_type: "forum_topic".to_string(),
+            target_id: Some(Uuid::nil()),
+        },
+        ForumSearchProjectionEvent::InvalidationIssued {
+            owner_revision: 1,
+            target_type: "reply".to_string(),
+            target_id: Some(Uuid::new_v4()),
+        },
+    ] {
+        assert!(invalid.validate().is_err());
+    }
+}

--- a/crates/rustok-forum/contracts/forum-search-versioned-invalidation-publisher.json
+++ b/crates/rustok-forum/contracts/forum-search-versioned-invalidation-publisher.json
@@ -1,0 +1,116 @@
+{
+  "schema_version": 1,
+  "task": "FORUM-23B2G2B3B2",
+  "status": "source_complete_consumer_pending",
+  "scope": "Publish the sealed version-1 Forum Search owner-revision invalidation contract atomically beside the legacy root invalidation while retaining the root envelope id as the owner-ledger and Search projection identity",
+  "decision": "DECISIONS/2026-07-31-forum-search-versioned-invalidation-rollout.md",
+  "wire_contract": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-wire.json",
+  "causation_api_contract": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-causation-api.json",
+  "events_owner": "crates/rustok-events/src/forum_search_projection.rs",
+  "events_registry": "crates/rustok-events/src/lib.rs",
+  "typed_payload_registry": "crates/rustok-events/src/contract.rs",
+  "digest_artifact": "crates/rustok-events/contracts/event-contract-digests.json",
+  "forum_publisher": "crates/rustok-forum/src/services/projection_invalidation.rs",
+  "owner_note": "crates/rustok-forum/docs/forum-23b2g2b3b2-versioned-invalidation-publisher.md",
+  "verifier": "scripts/verify/verify-forum-search-versioned-invalidation-publisher.mjs",
+  "event_contract": {
+    "rust_family": "ForumSearchProjectionEvent",
+    "transport_family": "forum_search_projection",
+    "variant": "InvalidationIssued",
+    "event_type": "forum.search_projection.invalidation_issued",
+    "schema_version": 1,
+    "owner_revision_minimum": 1,
+    "target_types": [
+      "forum",
+      "forum_category",
+      "forum_topic"
+    ],
+    "forum_target_id": "null",
+    "category_and_topic_target_id": "required non-nil UUID",
+    "tenant_from_envelope": true,
+    "actor_from_envelope": true,
+    "legacy_root_id_from_causation": true,
+    "forbidden_payload": [
+      "tenant_id",
+      "actor_id",
+      "ingest_sequence",
+      "locale",
+      "channel",
+      "visibility_snapshot",
+      "document_payload",
+      "reason",
+      "claims",
+      "roles"
+    ]
+  },
+  "postgresql_owner_transaction": {
+    "order": [
+      "allocate_owner_revision",
+      "publish_legacy_index_reindex_requested_and_retain_root_envelope_id",
+      "publish_forum_search_projection_invalidation_issued_caused_by_root_envelope_id",
+      "append_forum_projection_revision_ledger_with_root_envelope_id",
+      "commit_owner_transaction"
+    ],
+    "legacy_root_required": true,
+    "typed_contract_required": true,
+    "typed_publish_failure_rolls_back_revision_root_and_owner_state": true,
+    "ledger_event_id": "legacy root envelope id",
+    "typed_envelope_id_is_ledger_identity": false,
+    "second_outbox_or_broker_path_added": false
+  },
+  "non_postgresql_behavior": {
+    "typed_contract_published": false,
+    "owner_revision_allocated": false,
+    "owner_ledger_appended": false,
+    "composed_legacy_root_behavior_retained": true,
+    "direct_helper_validates_legacy_root_only": true
+  },
+  "digest_generation": {
+    "algorithm": "repository event_contract_digests registry and schemars 1.2.1 canonical JSON SHA-256 algorithm",
+    "pre_change_artifact_matched_exactly": true,
+    "pre_change_registry_matched": true,
+    "pre_change_root_event_matched": true,
+    "pre_change_root_envelope_matched": true,
+    "pre_change_contract_payload_matched": true,
+    "pre_change_contract_envelope_matched": true,
+    "cargo_generator_executed": false,
+    "tests_or_verifiers_executed": false,
+    "new_values": {
+      "registry": "sha256:a4b41305240a06ad57bb10499f6699226e5fe77adff7d6efbafe83c9e84ae0aa",
+      "root_event": "sha256:2bc388a237ff1fcbe327c340633815a64c84c799afef5a0012f458752d6deb87",
+      "root_envelope": "sha256:cfb55b9ac1fbebdc27658e035c00a98468c947b4830f8603c4258457849db42d",
+      "contract_payload": "sha256:e07934a82cb82ae14ec3d8b7c1e5938a6dd4bafdd563ebdce7e890985bd8011d",
+      "contract_envelope": "sha256:e0466ed18a986885f62f08f866a882b1f2de9ed277c6e8a29d04f43aaa705d5d"
+    }
+  },
+  "ordering": {
+    "forum_owner_revision_source": "forum_projection_revision_ledger.revision",
+    "search_delivery_order_source": "search_projection_inbox.ingest_sequence",
+    "owner_revision_compared_numerically_with_ingest_sequence": false,
+    "root_event_id_remains_reconciliation_identity": true
+  },
+  "compatibility": {
+    "legacy_root_payload_changed": false,
+    "legacy_root_event_type_changed": false,
+    "legacy_root_publication_removed": false,
+    "outbox_table_changed": false,
+    "relay_changed": false,
+    "iggy_changed": false,
+    "search_inbox_changed": false,
+    "search_projector_changed": false,
+    "search_checkpoint_changed": false,
+    "dependency_added": false,
+    "cargo_lock_changed": false
+  },
+  "follow_up": {
+    "task": "FORUM-23B2G2B3C",
+    "scope": "Consume the typed contract through one persistent Search cursor, durably record poison and transport receipts, and collapse typed and legacy delivery onto the existing root-id inbox identity without adding a second projector"
+  },
+  "non_claims": [
+    "This slice does not add the Search persistent typed consumer",
+    "This slice does not add the durable Search poison or transport receipt",
+    "This slice does not retire legacy index.reindex_requested publication",
+    "This slice does not claim PostgreSQL, relay, Iggy, restart, poison, DLQ, ACL or LINK-FORUM-03 runtime evidence",
+    "Tests, source verifiers, formatting, Cargo checks, Clippy, CI and runtime evidence were not executed by the implementation agent"
+  ]
+}

--- a/crates/rustok-forum/docs/forum-23b2g2b3b2-versioned-invalidation-publisher.md
+++ b/crates/rustok-forum/docs/forum-23b2g2b3b2-versioned-invalidation-publisher.md
@@ -1,0 +1,183 @@
+# FORUM-23B2G2B3B2 versioned invalidation publisher
+
+## Status
+
+`source_complete_consumer_pending`
+
+This slice completes the owner-publisher half of the accepted Forum Search
+versioned invalidation rollout. Forum now publishes one sealed version-1 typed
+contract beside the existing root invalidation inside the same PostgreSQL owner
+transaction.
+
+The accepted rollout remains defined by:
+
+```text
+DECISIONS/2026-07-31-forum-search-versioned-invalidation-rollout.md
+crates/rustok-forum/contracts/forum-search-versioned-invalidation-wire.json
+```
+
+The machine-readable implementation result is:
+
+```text
+crates/rustok-forum/contracts/forum-search-versioned-invalidation-publisher.json
+```
+
+## Sealed event family
+
+`rustok-events` now owns:
+
+```text
+Rust family: ForumSearchProjectionEvent
+transport family: forum_search_projection
+variant: InvalidationIssued
+event type: forum.search_projection.invalidation_issued
+schema version: 1
+```
+
+The payload contains only:
+
+```text
+owner_revision: positive int64
+target_type: forum | forum_category | forum_topic
+target_id: null for forum; non-nil UUID for forum_category/forum_topic
+```
+
+Tenant and optional actor remain envelope metadata. The exact predecessor root
+envelope id remains typed-envelope `causation_id`. Search `ingest_sequence`,
+locale, channel, visibility snapshots, rendered content, document payload,
+reasons, claims and roles are not part of the typed payload.
+
+The family is sealed through `EventContract`, registered through
+`event_schema`/`event_schemas`, and represented by one explicit
+`ContractEventPayload::ForumSearchProjection` variant. External modules cannot
+invent an arbitrary event name or untyped JSON payload.
+
+## PostgreSQL owner transaction
+
+Both active Forum invalidation publisher styles now perform the same ordered
+sequence:
+
+1. allocate the next tenant-scoped Forum owner revision;
+2. publish the mandatory legacy `index.reindex_requested` root envelope and
+   retain its exact envelope id;
+3. publish `forum.search_projection.invalidation_issued` with
+   `causation_id` equal to that root id;
+4. append `forum_projection_revision_ledger` with the same root id;
+5. commit owner state, revision counter, both outbox rows and ledger row
+   together.
+
+The direct transaction-only helper uses:
+
+```text
+TransactionalEventBus::publish_root_in_tx_with_envelope_id
+TransactionalEventBus::publish_contract_direct_in_tx_with_causation_and_envelope_id
+```
+
+The composed bus path uses:
+
+```text
+TransactionalEventBus::publish_in_tx_with_envelope_id
+TransactionalEventBus::publish_contract_in_tx_with_causation
+```
+
+Both paths use the canonical `sys_events` outbox writer. No direct broker,
+process-local fallback, second outbox table or second owner clock is introduced.
+
+A typed publication failure occurs before the owner-ledger append and fails the
+same database transaction. It therefore cannot leave a committed owner revision,
+legacy root or owner mutation without the required typed counterpart.
+
+## Identity and ordering
+
+The legacy root envelope id remains the canonical identity in:
+
+```text
+forum_projection_revision_ledger.event_id
+search_projection_inbox.event_id
+```
+
+The typed envelope has its own transport id, but that id is not written to the
+Forum owner ledger and is not a second Search projection identity. The future
+Search consumer must adapt the typed delivery through its mandatory
+`causation_id`, so legacy and typed delivery converge on the existing root-id
+inbox uniqueness boundary.
+
+Forum owner revision and Search-owned `ingest_sequence` remain independent:
+
+```text
+Forum revision: causal owner order and gap detection
+Search ingest_sequence: durable delivery claim order
+```
+
+The values are never compared numerically.
+
+## Non-PostgreSQL behavior
+
+The owner revision ledger and background Search reconciler are PostgreSQL-only.
+This slice therefore does not emit the typed contract on SQLite or other
+non-PostgreSQL profiles.
+
+The composed non-PostgreSQL path retains its historical legacy root publication.
+The transaction-only validation path retains root payload validation without
+inventing an owner revision, ledger row or typed event that has no matching
+runtime consumer.
+
+## Digest release gate
+
+Adding the family changes three release digests and deliberately leaves the two
+root-wire digests unchanged:
+
+```text
+registry:          sha256:a4b41305240a06ad57bb10499f6699226e5fe77adff7d6efbafe83c9e84ae0aa
+root event:        sha256:2bc388a237ff1fcbe327c340633815a64c84c799afef5a0012f458752d6deb87
+root envelope:     sha256:cfb55b9ac1fbebdc27658e035c00a98468c947b4830f8603c4258457849db42d
+contract payload:  sha256:e07934a82cb82ae14ec3d8b7c1e5938a6dd4bafdd563ebdce7e890985bd8011d
+contract envelope: sha256:e0466ed18a986885f62f08f866a882b1f2de9ed277c6e8a29d04f43aaa705d5d
+```
+
+The implementation environment did not have the repository Rust toolchain and
+did not execute the Cargo example. The exact repository algorithm was reproduced
+from `schema.rs`, `schemars 1.2.1` derive/generator behavior, sorted registry
+serialization and SHA-256 canonical JSON. Before computing the new values, that
+model reproduced all five committed pre-change digests exactly. The committed
+artifact therefore contains deliberate release values rather than placeholders
+or guessed hashes.
+
+Maintainers may independently regenerate the artifact with:
+
+```bash
+cargo run -p rustok-events --example event_contract_digests -- --write
+```
+
+## Compatibility boundary
+
+This slice does not:
+
+- change or remove the legacy root event;
+- change the root event or root envelope JSON schema;
+- change the outbox table or relay;
+- add a second Forum publisher path;
+- add a Search inbox or projector;
+- advance a Search owner checkpoint on enqueue;
+- add dependencies or change `Cargo.lock`;
+- claim remote transport or PostgreSQL runtime evidence.
+
+`FORUM-23` and `LINK-FORUM-03` remain open.
+
+## Next slice
+
+`FORUM-23B2G2B3C` must add one persistent Search typed-contract consumer that:
+
+1. receives and acknowledges with the exact persistent cursor;
+2. validates the sealed event and mandatory root causation id;
+3. maps that root id into the existing `search_projection_inbox.event_id`;
+4. treats an existing row as a durable duplicate;
+5. records decode/schema/semantic poison durably before DLQ acknowledgement;
+6. reuses the existing Forum reconciler and projector;
+7. never creates a second projection lane or compares owner revision with
+   `ingest_sequence`.
+
+## Verification status
+
+Tests, source verifiers, formatting, Cargo checks, Clippy, CI and runtime
+evidence were intentionally not executed by the implementation agent.

--- a/crates/rustok-forum/src/services/projection_invalidation.rs
+++ b/crates/rustok-forum/src/services/projection_invalidation.rs
@@ -1,4 +1,4 @@
-use rustok_events::{DomainEvent, ValidateEvent};
+use rustok_events::{DomainEvent, ForumSearchProjectionEvent, ValidateEvent};
 use rustok_outbox::TransactionalEventBus;
 use sea_orm::{
     ConnectionTrait, DatabaseBackend, DatabaseTransaction, DbBackend, Statement,
@@ -118,29 +118,40 @@ async fn write_projection_invalidation_in_tx(
     target_type: &'static str,
     target_id: Option<Uuid>,
 ) -> ForumResult<()> {
-    let event = projection_invalidation_event(target_type, target_id);
+    let root_event = projection_invalidation_event(target_type, target_id);
 
     // The Search-owned Forum projector is PostgreSQL-only. SQLite and any
     // other non-PostgreSQL backend are domain-test/unsupported projection
     // environments, so keep root validation without requiring an outbox or
     // owner-revision ledger that has no matching Search consumer.
     if txn.get_database_backend() != DatabaseBackend::Postgres {
-        event.validate().map_err(|error| {
+        root_event.validate().map_err(|error| {
             ForumError::Validation(format!("Forum projection invalidation failed: {error}"))
         })?;
         return Ok(());
     }
 
     let revision = allocate_projection_revision_in_tx(txn, tenant_id).await?;
-    let event_id = TransactionalEventBus::publish_root_in_tx_with_envelope_id(
-        txn, tenant_id, actor_id, event,
+    let root_event_id = TransactionalEventBus::publish_root_in_tx_with_envelope_id(
+        txn,
+        tenant_id,
+        actor_id,
+        root_event,
+    )
+    .await?;
+    TransactionalEventBus::publish_contract_direct_in_tx_with_causation_and_envelope_id(
+        txn,
+        tenant_id,
+        actor_id,
+        root_event_id,
+        projection_invalidation_contract(revision, target_type, target_id),
     )
     .await?;
     record_projection_revision_in_tx(
         txn,
         tenant_id,
         revision,
-        event_id,
+        root_event_id,
         target_type,
         target_id,
     )
@@ -155,23 +166,32 @@ async fn publish_projection_invalidation_in_tx(
     target_type: &'static str,
     target_id: Option<Uuid>,
 ) -> ForumResult<()> {
-    let event = projection_invalidation_event(target_type, target_id);
+    let root_event = projection_invalidation_event(target_type, target_id);
     if txn.get_database_backend() != DatabaseBackend::Postgres {
         event_bus
-            .publish_in_tx(txn, tenant_id, actor_id, event)
+            .publish_in_tx(txn, tenant_id, actor_id, root_event)
             .await?;
         return Ok(());
     }
 
     let revision = allocate_projection_revision_in_tx(txn, tenant_id).await?;
-    let event_id = event_bus
-        .publish_in_tx_with_envelope_id(txn, tenant_id, actor_id, event)
+    let root_event_id = event_bus
+        .publish_in_tx_with_envelope_id(txn, tenant_id, actor_id, root_event)
+        .await?;
+    event_bus
+        .publish_contract_in_tx_with_causation(
+            txn,
+            tenant_id,
+            actor_id,
+            root_event_id,
+            projection_invalidation_contract(revision, target_type, target_id),
+        )
         .await?;
     record_projection_revision_in_tx(
         txn,
         tenant_id,
         revision,
-        event_id,
+        root_event_id,
         target_type,
         target_id,
     )
@@ -183,6 +203,18 @@ fn projection_invalidation_event(
     target_id: Option<Uuid>,
 ) -> DomainEvent {
     DomainEvent::ReindexRequested {
+        target_type: target_type.to_string(),
+        target_id,
+    }
+}
+
+fn projection_invalidation_contract(
+    owner_revision: i64,
+    target_type: &'static str,
+    target_id: Option<Uuid>,
+) -> ForumSearchProjectionEvent {
+    ForumSearchProjectionEvent::InvalidationIssued {
+        owner_revision,
         target_type: target_type.to_string(),
         target_id,
     }

--- a/scripts/verify/verify-forum-search-versioned-invalidation-causation-api.mjs
+++ b/scripts/verify/verify-forum-search-versioned-invalidation-causation-api.mjs
@@ -6,8 +6,16 @@ import process from "node:process";
 
 const root = process.cwd();
 
+function filePath(relativePath) {
+  return path.join(root, relativePath);
+}
+
 function read(relativePath) {
-  return fs.readFileSync(path.join(root, relativePath), "utf8");
+  return fs.readFileSync(filePath(relativePath), "utf8");
+}
+
+function readJson(relativePath) {
+  return JSON.parse(read(relativePath));
 }
 
 function requireMarker(source, marker, label) {
@@ -32,6 +40,8 @@ const outboxApiPath = "crates/rustok-outbox/CRATE_API.md";
 const forumPublisherPath = "crates/rustok-forum/src/services/projection_invalidation.rs";
 const machineContractPath =
   "crates/rustok-forum/contracts/forum-search-versioned-invalidation-causation-api.json";
+const publisherContractPath =
+  "crates/rustok-forum/contracts/forum-search-versioned-invalidation-publisher.json";
 const ownerNotePath =
   "crates/rustok-forum/docs/forum-23b2g2b3b1-causation-publication-api.md";
 
@@ -45,8 +55,10 @@ const sources = new Map([
   [forumPublisherPath, read(forumPublisherPath)],
   [ownerNotePath, read(ownerNotePath)],
 ]);
-const digest = JSON.parse(read(digestPath));
-const contract = JSON.parse(read(machineContractPath));
+const digest = readJson(digestPath);
+const contract = readJson(machineContractPath);
+const publisherDelivered = fs.existsSync(filePath(publisherContractPath));
+const publisherContract = publisherDelivered ? readJson(publisherContractPath) : null;
 
 for (const [marker, sourcePath] of [
   ["pub fn new_caused_by<E>(", eventsContractPath],
@@ -61,7 +73,6 @@ for (const [marker, sourcePath] of [
   ["publish_contract_in_tx_with_causation_and_envelope_id<C, E>", outboxTransactionalPath],
   ["ContractEventEnvelope::new_caused_by", outboxTransactionalPath],
   ["OutboxTransport::write_contract_envelope_in_tx(txn, envelope)", outboxTransactionalPath],
-  ["async fn write_contract_envelope_in_tx<C>", outboxTransactionalPath],
   ["pub(crate) async fn write_contract_envelope_in_tx<C>", outboxTransportPath],
   ["publish_contract_in_tx_with_causation", outboxApiPath],
   ["FORUM-23B2G2B3B1", ownerNotePath],
@@ -70,18 +81,35 @@ for (const [marker, sourcePath] of [
   requireMarker(sources.get(sourcePath), marker, sourcePath);
 }
 
-for (const [marker, sourcePath] of [
-  ["ForumSearchProjectionEvent", eventsContractPath],
-  ["ForumSearchProjectionEvent", eventsLibPath],
-  ["forum_search_projection", eventsContractPath],
-  ["forum.search_projection.invalidation_issued", eventsLibPath],
-  ["ForumSearchProjectionEvent", forumPublisherPath],
-  ["forum.search_projection.invalidation_issued", forumPublisherPath],
-]) {
-  forbidMarker(sources.get(sourcePath), marker, sourcePath);
+if (contract.task !== "FORUM-23B2G2B3B1") {
+  throw new Error(`${machineContractPath} has the wrong task`);
+}
+if (contract.status !== "source_complete_family_publisher_pending") {
+  throw new Error(`${machineContractPath} has the wrong historical status`);
+}
+if (contract.envelope_api?.constructor !== "ContractEventEnvelope::new_caused_by"
+    || contract.envelope_api?.getter !== "ContractEventEnvelope::causation_id"
+    || contract.envelope_api?.wire_fields_added !== false
+    || contract.envelope_api?.json_schema_changed !== false
+    || contract.envelope_api?.event_digest_changed !== false) {
+  throw new Error(`${machineContractPath} causation API boundary drift`);
+}
+if (
+  contract.publication_api?.canonical_writer !==
+  "OutboxTransport::write_contract_envelope_in_tx"
+  || contract.publication_api?.requires_live_owner_transaction !== true
+  || contract.publication_api?.creates_second_transport_path !== false
+) {
+  throw new Error(`${machineContractPath} outbox publication boundary drift`);
+}
+if (contract.compatibility?.["ContractEventEnvelope::new_retained"] !== true
+    || contract.compatibility?.sealed_event_family_added !== false
+    || contract.compatibility?.event_digest_artifact_changed !== false
+    || contract.follow_up?.task !== "FORUM-23B2G2B3B2") {
+  throw new Error(`${machineContractPath} historical slice facts drift`);
 }
 
-const expectedDigest = {
+const prePublisherDigest = {
   format_version: 1,
   registry: "sha256:18fdee49d915a22ed3dd709ec6cc1826d6d47a59ddfe659fbd07ede7f6cd3d07",
   root_event: "sha256:2bc388a237ff1fcbe327c340633815a64c84c799afef5a0012f458752d6deb87",
@@ -90,58 +118,39 @@ const expectedDigest = {
   contract_envelope: "sha256:b29a8c7809045e14f1233db4e2f9dba9cedf96352df3ea9e87ca1e86f6a59eb8",
 };
 
-if (JSON.stringify(digest) !== JSON.stringify(expectedDigest)) {
-  throw new Error(
-    `${digestPath} changed even though FORUM-23B2G2B3B1 is schema-neutral`,
-  );
-}
-
-if (contract.task !== "FORUM-23B2G2B3B1") {
-  throw new Error(`${machineContractPath} has the wrong task`);
-}
-if (contract.status !== "source_complete_family_publisher_pending") {
-  throw new Error(`${machineContractPath} has the wrong status`);
-}
-if (contract.envelope_api?.constructor !== "ContractEventEnvelope::new_caused_by") {
-  throw new Error(`${machineContractPath} does not bind the caused constructor`);
-}
-if (contract.envelope_api?.getter !== "ContractEventEnvelope::causation_id") {
-  throw new Error(`${machineContractPath} does not bind the causation getter`);
-}
-if (contract.envelope_api?.wire_fields_added !== false) {
-  throw new Error(`${machineContractPath} must reject a wire-field addition claim`);
-}
-if (contract.envelope_api?.json_schema_changed !== false) {
-  throw new Error(`${machineContractPath} must reject a JSON-schema change claim`);
-}
-if (contract.envelope_api?.event_digest_changed !== false) {
-  throw new Error(`${machineContractPath} must reject an event-digest change claim`);
-}
-if (
-  contract.publication_api?.canonical_writer !==
-  "OutboxTransport::write_contract_envelope_in_tx"
-) {
-  throw new Error(`${machineContractPath} does not bind the canonical outbox writer`);
-}
-if (contract.publication_api?.requires_live_owner_transaction !== true) {
-  throw new Error(`${machineContractPath} must require the live owner transaction`);
-}
-if (contract.publication_api?.creates_second_transport_path !== false) {
-  throw new Error(`${machineContractPath} must forbid a second transport path`);
-}
-if (
-  contract.compatibility?.["ContractEventEnvelope::new_retained"] !== true
-) {
-  throw new Error(`${machineContractPath} must retain the existing constructor`);
-}
-if (contract.compatibility?.sealed_event_family_added !== false) {
-  throw new Error(`${machineContractPath} must not claim the Forum family exists`);
-}
-if (contract.compatibility?.event_digest_artifact_changed !== false) {
-  throw new Error(`${machineContractPath} must not claim a digest update`);
-}
-if (contract.follow_up?.task !== "FORUM-23B2G2B3B2") {
-  throw new Error(`${machineContractPath} does not name the next publisher slice`);
+if (!publisherDelivered) {
+  for (const [marker, sourcePath] of [
+    ["ForumSearchProjectionEvent", eventsContractPath],
+    ["ForumSearchProjectionEvent", eventsLibPath],
+    ["forum_search_projection", eventsContractPath],
+    ["ForumSearchProjectionEvent", forumPublisherPath],
+  ]) {
+    forbidMarker(sources.get(sourcePath), marker, sourcePath);
+  }
+  if (JSON.stringify(digest) !== JSON.stringify(prePublisherDigest)) {
+    throw new Error(`${digestPath} changed before the named publisher slice`);
+  }
+} else {
+  if (publisherContract.task !== "FORUM-23B2G2B3B2"
+      || publisherContract.status !== "source_complete_consumer_pending") {
+    throw new Error(`${publisherContractPath} does not prove the downstream publisher slice`);
+  }
+  for (const [marker, sourcePath] of [
+    ["ForumSearchProjectionEvent", eventsContractPath],
+    ["ForumSearchProjectionEvent", eventsLibPath],
+    ["forum_search_projection", eventsContractPath],
+    ["ForumSearchProjectionEvent", forumPublisherPath],
+    ["publish_contract_in_tx_with_causation", forumPublisherPath],
+  ]) {
+    requireMarker(sources.get(sourcePath), marker, sourcePath);
+  }
+  const expected = {
+    format_version: 1,
+    ...publisherContract.digest_generation.new_values,
+  };
+  if (JSON.stringify(digest) !== JSON.stringify(expected)) {
+    throw new Error(`${digestPath} does not match the delivered publisher contract`);
+  }
 }
 
 console.log(

--- a/scripts/verify/verify-forum-search-versioned-invalidation-publisher.mjs
+++ b/scripts/verify/verify-forum-search-versioned-invalidation-publisher.mjs
@@ -11,6 +11,7 @@ const failures = [];
 
 const paths = {
   event: "crates/rustok-events/src/forum_search_projection.rs",
+  eventTest: "crates/rustok-events/tests/forum_search_projection_contracts.rs",
   eventLib: "crates/rustok-events/src/lib.rs",
   eventPayload: "crates/rustok-events/src/contract.rs",
   eventApi: "crates/rustok-events/CRATE_API.md",
@@ -83,6 +84,7 @@ function requireOrder(source, markers, label) {
 }
 
 const event = read(paths.event);
+const eventTest = read(paths.eventTest);
 const eventLib = read(paths.eventLib);
 const eventPayload = read(paths.eventPayload);
 const eventApi = read(paths.eventApi);
@@ -119,6 +121,13 @@ rejectAll(event, [
   "claims",
   "roles",
 ], `${paths.event} bounded payload`);
+requireAll(eventTest, [
+  "forum_search_projection_contract_roundtrips_with_root_causation",
+  "ContractEventEnvelope::new_caused_by",
+  "ContractEventPayload::ForumSearchProjection",
+  "forum_search_projection_registry_and_scope_validation_are_fail_closed",
+  "event_schema(\"forum.search_projection.invalidation_issued\")",
+], paths.eventTest);
 
 requireAll(eventLib, [
   "mod forum_search_projection;",
@@ -262,7 +271,7 @@ requireAll(note, [
   "# FORUM-23B2G2B3B2 versioned invalidation publisher",
   "source_complete_consumer_pending",
   "forum.search_projection.invalidation_issued",
-  "legacy root envelope id remains the canonical identity",
+  "The legacy root envelope id remains the canonical identity",
   "FORUM-23B2G2B3C",
   "did not execute the Cargo example",
 ], paths.note);

--- a/scripts/verify/verify-forum-search-versioned-invalidation-publisher.mjs
+++ b/scripts/verify/verify-forum-search-versioned-invalidation-publisher.mjs
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const root = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : process.cwd();
+const failures = [];
+
+const paths = {
+  event: "crates/rustok-events/src/forum_search_projection.rs",
+  eventLib: "crates/rustok-events/src/lib.rs",
+  eventPayload: "crates/rustok-events/src/contract.rs",
+  eventApi: "crates/rustok-events/CRATE_API.md",
+  digests: "crates/rustok-events/contracts/event-contract-digests.json",
+  outbox: "crates/rustok-outbox/src/transactional.rs",
+  publisher: "crates/rustok-forum/src/services/projection_invalidation.rs",
+  contract: "crates/rustok-forum/contracts/forum-search-versioned-invalidation-publisher.json",
+  note: "crates/rustok-forum/docs/forum-23b2g2b3b2-versioned-invalidation-publisher.md",
+  wireContract: "crates/rustok-forum/contracts/forum-search-versioned-invalidation-wire.json",
+  causationContract: "crates/rustok-forum/contracts/forum-search-versioned-invalidation-causation-api.json",
+};
+
+function target(relativePath) {
+  return path.join(root, relativePath);
+}
+
+function read(relativePath) {
+  if (!fs.existsSync(target(relativePath))) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return "";
+  }
+  return fs.readFileSync(target(relativePath), "utf8");
+}
+
+function readJson(relativePath) {
+  try {
+    return JSON.parse(read(relativePath));
+  } catch (error) {
+    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function requireAll(source, markers, label) {
+  for (const marker of markers) {
+    if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+  }
+}
+
+function rejectAll(source, markers, label) {
+  for (const marker of markers) {
+    if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+  }
+}
+
+function functionBlock(source, startMarker, endMarker, label) {
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker, start + startMarker.length);
+  if (start < 0 || end < 0 || end <= start) {
+    failures.push(`${label}: function boundary not found`);
+    return "";
+  }
+  return source.slice(start, end);
+}
+
+function requireOrder(source, markers, label) {
+  let previous = -1;
+  for (const marker of markers) {
+    const index = source.indexOf(marker, previous + 1);
+    if (index < 0) {
+      failures.push(`${label}: missing ordered marker ${marker}`);
+      return;
+    }
+    if (index <= previous) {
+      failures.push(`${label}: marker order drift at ${marker}`);
+      return;
+    }
+    previous = index;
+  }
+}
+
+const event = read(paths.event);
+const eventLib = read(paths.eventLib);
+const eventPayload = read(paths.eventPayload);
+const eventApi = read(paths.eventApi);
+const outbox = read(paths.outbox);
+const publisher = read(paths.publisher);
+const note = read(paths.note);
+const contract = readJson(paths.contract);
+const wireContract = readJson(paths.wireContract);
+const causationContract = readJson(paths.causationContract);
+const digests = readJson(paths.digests);
+
+requireAll(event, [
+  "pub enum ForumSearchProjectionEvent",
+  "InvalidationIssued",
+  "owner_revision: i64",
+  "target_type: String",
+  "target_id: Option<Uuid>",
+  "forum.search_projection.invalidation_issued",
+  "FORUM_SEARCH_PROJECTION_EVENT_SCHEMAS",
+  "impl sealed::Sealed for ForumSearchProjectionEvent",
+  "impl EventContract for ForumSearchProjectionEvent",
+  "ContractEventPayload::ForumSearchProjection(self)",
+  "validators::validate_range(\"owner_revision\", *owner_revision, 1, i64::MAX)",
+  "(\"forum\", None) => Ok(())",
+  "(\"forum_category\" | \"forum_topic\", Some(target_id))",
+  "EventValidationError::MissingField(\"target_id\")",
+  "must be forum, forum_category, or forum_topic",
+], paths.event);
+rejectAll(event, [
+  "ingest_sequence",
+  "locale",
+  "visibility_snapshot",
+  "document_payload",
+  "claims",
+  "roles",
+], `${paths.event} bounded payload`);
+
+requireAll(eventLib, [
+  "mod forum_search_projection;",
+  "FORUM_SEARCH_PROJECTION_EVENT_SCHEMAS",
+  "ForumSearchProjectionEvent",
+  "forum_search_projection_event_schema(event_type)",
+  ".chain(FORUM_SEARCH_PROJECTION_EVENT_SCHEMAS.iter())",
+], paths.eventLib);
+requireAll(eventPayload, [
+  "ForumSearchProjectionEvent",
+  "#[serde(rename = \"forum_search_projection\")]",
+  "ForumSearchProjection(ForumSearchProjectionEvent)",
+  "Self::ForumSearchProjection(event) => event.event_type()",
+  "Self::ForumSearchProjection(event) => event.schema_version()",
+  "Self::ForumSearchProjection(event) => event.validate()",
+], paths.eventPayload);
+requireAll(eventApi, [
+  "ForumSearchProjectionEvent",
+  "forum.search_projection.invalidation_issued",
+  "Forum owner revision and Search-owned `ingest_sequence` remain independent",
+], paths.eventApi);
+
+requireAll(outbox, [
+  "publish_contract_direct_in_tx_with_causation_and_envelope_id",
+  "publish_contract_in_tx_with_causation",
+  "ContractEventEnvelope::new_caused_by",
+  "OutboxTransport::write_contract_envelope_in_tx",
+], paths.outbox);
+requireAll(publisher, [
+  "DomainEvent::ReindexRequested",
+  "ForumSearchProjectionEvent::InvalidationIssued",
+  "allocate_projection_revision_in_tx",
+  "publish_root_in_tx_with_envelope_id",
+  "publish_contract_direct_in_tx_with_causation_and_envelope_id",
+  "publish_in_tx_with_envelope_id",
+  "publish_contract_in_tx_with_causation",
+  "record_projection_revision_in_tx",
+  "forum_projection_revision_ledger",
+], paths.publisher);
+rejectAll(publisher, [
+  "typed_envelope_id",
+  "ingest_sequence",
+], `${paths.publisher} identity and ordering boundary`);
+
+const direct = functionBlock(
+  publisher,
+  "async fn write_projection_invalidation_in_tx(",
+  "async fn publish_projection_invalidation_in_tx(",
+  "direct publisher",
+);
+const composed = functionBlock(
+  publisher,
+  "async fn publish_projection_invalidation_in_tx(",
+  "fn projection_invalidation_event(",
+  "composed publisher",
+);
+requireOrder(direct, [
+  "allocate_projection_revision_in_tx",
+  "publish_root_in_tx_with_envelope_id",
+  "publish_contract_direct_in_tx_with_causation_and_envelope_id",
+  "record_projection_revision_in_tx",
+], "direct PostgreSQL publication order");
+requireOrder(composed, [
+  "allocate_projection_revision_in_tx",
+  "publish_in_tx_with_envelope_id",
+  "publish_contract_in_tx_with_causation",
+  "record_projection_revision_in_tx",
+], "composed PostgreSQL publication order");
+requireAll(direct, [
+  "txn.get_database_backend() != DatabaseBackend::Postgres",
+  "root_event.validate()",
+  "root_event_id",
+  "record_projection_revision_in_tx(",
+], "direct PostgreSQL boundary");
+requireAll(composed, [
+  "txn.get_database_backend() != DatabaseBackend::Postgres",
+  ".publish_in_tx(txn, tenant_id, actor_id, root_event)",
+  "root_event_id",
+  "record_projection_revision_in_tx(",
+], "composed PostgreSQL boundary");
+
+const expectedDigests = {
+  format_version: 1,
+  registry: "sha256:a4b41305240a06ad57bb10499f6699226e5fe77adff7d6efbafe83c9e84ae0aa",
+  root_event: "sha256:2bc388a237ff1fcbe327c340633815a64c84c799afef5a0012f458752d6deb87",
+  root_envelope: "sha256:cfb55b9ac1fbebdc27658e035c00a98468c947b4830f8603c4258457849db42d",
+  contract_payload: "sha256:e07934a82cb82ae14ec3d8b7c1e5938a6dd4bafdd563ebdce7e890985bd8011d",
+  contract_envelope: "sha256:e0466ed18a986885f62f08f866a882b1f2de9ed277c6e8a29d04f43aaa705d5d",
+};
+if (digests && JSON.stringify(digests) !== JSON.stringify(expectedDigests)) {
+  failures.push(`${paths.digests}: released digest values drift`);
+}
+
+if (contract) {
+  if (contract.task !== "FORUM-23B2G2B3B2"
+      || contract.status !== "source_complete_consumer_pending") {
+    failures.push(`${paths.contract}: task or status drift`);
+  }
+  if (contract.event_contract?.rust_family !== "ForumSearchProjectionEvent"
+      || contract.event_contract?.transport_family !== "forum_search_projection"
+      || contract.event_contract?.event_type !== "forum.search_projection.invalidation_issued"
+      || contract.event_contract?.schema_version !== 1
+      || contract.event_contract?.owner_revision_minimum !== 1) {
+    failures.push(`${paths.contract}: event identity drift`);
+  }
+  if (JSON.stringify(contract.event_contract?.target_types ?? []) !== JSON.stringify([
+    "forum",
+    "forum_category",
+    "forum_topic",
+  ])) {
+    failures.push(`${paths.contract}: target type drift`);
+  }
+  if (contract.postgresql_owner_transaction?.ledger_event_id !== "legacy root envelope id"
+      || contract.postgresql_owner_transaction?.typed_envelope_id_is_ledger_identity !== false
+      || contract.postgresql_owner_transaction?.legacy_root_required !== true
+      || contract.postgresql_owner_transaction?.typed_contract_required !== true) {
+    failures.push(`${paths.contract}: owner identity or transaction drift`);
+  }
+  if (contract.non_postgresql_behavior?.typed_contract_published !== false
+      || contract.non_postgresql_behavior?.owner_revision_allocated !== false) {
+    failures.push(`${paths.contract}: non-PostgreSQL behavior drift`);
+  }
+  if (contract.ordering?.owner_revision_compared_numerically_with_ingest_sequence !== false
+      || contract.follow_up?.task !== "FORUM-23B2G2B3C") {
+    failures.push(`${paths.contract}: ordering or follow-up drift`);
+  }
+  const expectedFromContract = {
+    format_version: 1,
+    ...contract.digest_generation?.new_values,
+  };
+  if (digests && JSON.stringify(digests) !== JSON.stringify(expectedFromContract)) {
+    failures.push(`${paths.contract}: machine digest evidence drift`);
+  }
+}
+
+if (wireContract?.task !== "FORUM-23B2G2B3A"
+    || causationContract?.task !== "FORUM-23B2G2B3B1") {
+  failures.push("publisher predecessor contract drift");
+}
+requireAll(note, [
+  "# FORUM-23B2G2B3B2 versioned invalidation publisher",
+  "source_complete_consumer_pending",
+  "forum.search_projection.invalidation_issued",
+  "legacy root envelope id remains the canonical identity",
+  "FORUM-23B2G2B3C",
+  "did not execute the Cargo example",
+], paths.note);
+
+if (failures.length > 0) {
+  console.error("FORUM-23B2G2B3B2 versioned invalidation publisher verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("FORUM-23B2G2B3B2 versioned invalidation publisher is consistent.");

--- a/scripts/verify/verify-forum-search-versioned-invalidation-wire.mjs
+++ b/scripts/verify/verify-forum-search-versioned-invalidation-wire.mjs
@@ -10,11 +10,11 @@ const failures = [];
 
 const paths = {
   contract: "crates/rustok-forum/contracts/forum-search-versioned-invalidation-wire.json",
+  publisherContract: "crates/rustok-forum/contracts/forum-search-versioned-invalidation-publisher.json",
   note: "crates/rustok-forum/docs/forum-23b2g2b3a-versioned-invalidation-wire-contract.md",
   decision: "DECISIONS/2026-07-31-forum-search-versioned-invalidation-rollout.md",
   checkpointContract: "crates/rustok-forum/contracts/forum-search-owner-revision-checkpoint.json",
   ledgerContract: "crates/rustok-forum/contracts/forum-search-owner-revision-ledger.json",
-  hardeningContract: "crates/rustok-forum/contracts/forum-search-owner-revision-counter-hardening.json",
   sourceContract: "crates/rustok-forum/contracts/forum-search-owner-revision-source.json",
   ingestContract: "crates/rustok-forum/contracts/forum-search-durable-ingest-sequence.json",
   eventLib: "crates/rustok-events/src/lib.rs",
@@ -27,13 +27,16 @@ const paths = {
   searchPlan: "crates/rustok-search/docs/implementation-plan.md",
 };
 
+function target(relativePath) {
+  return path.join(root, relativePath);
+}
+
 function read(relativePath) {
-  const target = path.join(root, relativePath);
-  if (!existsSync(target)) {
+  if (!existsSync(target(relativePath))) {
     failures.push(`${relativePath}: expected file is missing`);
     return "";
   }
-  return readFileSync(target, "utf8");
+  return readFileSync(target(relativePath), "utf8");
 }
 
 function parseJson(relativePath) {
@@ -58,9 +61,10 @@ function rejectAll(source, markers, label) {
 }
 
 const contract = parseJson(paths.contract);
+const publisherDelivered = existsSync(target(paths.publisherContract));
+const publisherContract = publisherDelivered ? parseJson(paths.publisherContract) : null;
 const checkpointContract = parseJson(paths.checkpointContract);
 const ledgerContract = parseJson(paths.ledgerContract);
-const hardeningContract = parseJson(paths.hardeningContract);
 const sourceContract = parseJson(paths.sourceContract);
 const ingestContract = parseJson(paths.ingestContract);
 const digests = parseJson(paths.eventDigests);
@@ -84,7 +88,6 @@ requireAll(decision, [
   "The legacy root publication remains mandatory",
   "No process-local fallback or second projector is permitted",
 ], paths.decision);
-
 requireAll(note, [
   "# FORUM-23B2G2B3A versioned Search invalidation wire contract",
   "contract_frozen_implementation_pending",
@@ -93,80 +96,34 @@ requireAll(note, [
   "forum.search_projection.invalidation_issued",
   "typed ingress inbox identity  = ContractEventEnvelope.causation_id",
   "ON CONFLICT (event_id) DO NOTHING",
-  "FORUM-23B2G2B3B",
   "FORUM-23B2G2B3C",
-  "FORUM-23B2G2B3D",
-  "The implementation agent did not run these commands",
 ], paths.note);
-
 requireAll(outbox, [
-  "publish_contract_in_tx_with_envelope_id",
-  "ContractEventEnvelope::new",
+  "publish_contract_in_tx_with_causation",
+  "ContractEventEnvelope::new_caused_by",
   "write_contract_to_outbox",
-], `${paths.outbox} typed publication predecessor`);
-
-requireAll(forumPublisher, [
-  "DomainEvent::ReindexRequested",
-  "publish_in_tx_with_envelope_id",
-  "forum_projection_revision_ledger",
-  "record_projection_revision_in_tx",
-], `${paths.forumPublisher} legacy identity predecessor`);
-
+], `${paths.outbox} typed publication boundary`);
 requireAll(searchInbox, [
   "ON CONFLICT (event_id) DO NOTHING",
   "envelope.id.into()",
   "ORDER BY ingest_sequence ASC",
-  "use rustok_events::{DomainEvent, EventEnvelope};",
 ], `${paths.searchInbox} one-inbox predecessor`);
 
-// G2B3A is a contract freeze only. Executable registration and publication are
-// intentionally forbidden until G2B3B updates the schema digest in the same PR.
-for (const [source, label] of [
-  [eventLib, paths.eventLib],
-  [eventPayload, paths.eventPayload],
-  [forumPublisher, paths.forumPublisher],
-]) {
-  rejectAll(source, [
-    "ForumSearchProjectionEvent",
-    "forum_search_projection",
-    "forum.search_projection.invalidation_issued",
-  ], `${label} G2B3A implementation boundary`);
-}
-
-requireAll(forumPlan, [
-  "| `FORUM-23` | `in_progress` |",
-  "owner-issued revision reconciliation plus maintainer runtime evidence remain",
-], `${paths.forumPlan} canonical open boundary`);
-requireAll(searchPlan, [
-  "This is not the final Forum-owner-issued projection revision",
-  "owner contract and rollout reconciliation remain pending",
-], `${paths.searchPlan} canonical open boundary`);
-
 if (contract) {
-  if (contract.task !== "FORUM-23B2G2B3A") {
-    failures.push(`${paths.contract}: unexpected task`);
-  }
-  if (contract.status !== "contract_frozen_implementation_pending") {
-    failures.push(`${paths.contract}: unexpected status`);
+  if (contract.task !== "FORUM-23B2G2B3A"
+      || contract.status !== "contract_frozen_implementation_pending") {
+    failures.push(`${paths.contract}: historical freeze identity drift`);
   }
   const event = contract.event_contract;
-  if (event?.registry_owner !== "rustok-events"
-      || event?.publisher_owner !== "rustok-forum"
-      || event?.consumer_owner !== "rustok-search") {
-    failures.push(`${paths.contract}: event ownership drift`);
-  }
   if (event?.rust_family !== "ForumSearchProjectionEvent"
       || event?.transport_family !== "forum_search_projection"
       || event?.variant !== "InvalidationIssued"
       || event?.event_type !== "forum.search_projection.invalidation_issued"
-      || event?.schema_version !== 1) {
-    failures.push(`${paths.contract}: event identity drift`);
+      || event?.schema_version !== 1
+      || event?.payload?.owner_revision?.minimum !== 1) {
+    failures.push(`${paths.contract}: event contract drift`);
   }
-  if (event?.payload?.owner_revision?.minimum !== 1) {
-    failures.push(`${paths.contract}: owner revision must be positive`);
-  }
-  const targets = event?.payload?.target_type?.allowed ?? [];
-  if (JSON.stringify(targets) !== JSON.stringify([
+  if (JSON.stringify(event?.payload?.target_type?.allowed ?? []) !== JSON.stringify([
     "forum",
     "forum_category",
     "forum_topic",
@@ -178,65 +135,34 @@ if (contract) {
       || event?.envelope?.legacy_root_event_type !== "index.reindex_requested") {
     failures.push(`${paths.contract}: legacy causation identity drift`);
   }
-  const transaction = contract.owner_transaction_protocol;
-  if (transaction?.postgresql_only !== true
-      || transaction?.legacy_root_publication_required !== true
-      || transaction?.failure_rolls_back_owner_state_root_typed_and_ledger !== true) {
+  if (contract.owner_transaction_protocol?.postgresql_only !== true
+      || contract.owner_transaction_protocol?.legacy_root_publication_required !== true
+      || contract.owner_transaction_protocol?.failure_rolls_back_owner_state_root_typed_and_ledger !== true) {
     failures.push(`${paths.contract}: owner transaction protocol drift`);
   }
-  const execution = contract.single_projection_path;
-  if (execution?.inbox_table !== "search_projection_inbox"
-      || execution?.typed_ingress_identity !== "ContractEventEnvelope.causation_id"
-      || execution?.shared_identity !== "legacy root envelope ID"
-      || execution?.existing_inbox_unique_boundary_collapses_dual_delivery !== true
-      || execution?.second_inbox_forbidden !== true
-      || execution?.second_projector_forbidden !== true) {
+  if (contract.single_projection_path?.inbox_table !== "search_projection_inbox"
+      || contract.single_projection_path?.typed_ingress_identity !== "ContractEventEnvelope.causation_id"
+      || contract.single_projection_path?.second_inbox_forbidden !== true
+      || contract.single_projection_path?.second_projector_forbidden !== true) {
     failures.push(`${paths.contract}: one-inbox execution contract drift`);
-  }
-  const cursor = contract.consumer_cursor_protocol;
-  if (cursor?.valid_event_ack_after_terminal_result !== true
-      || cursor?.poison_ack_after_terminal_result !== true
-      || cursor?.transient_failure_acknowledged !== false
-      || cursor?.process_local_fallback !== false
-      || cursor?.exact_cursor_receive_and_ack !== true) {
-    failures.push(`${paths.contract}: persistent cursor or poison policy drift`);
   }
   if (contract.ordering?.owner_revision_compared_numerically_with_ingest_sequence !== false
       || contract.ordering?.checkpoint_advances_only_after_projection_success !== true) {
     failures.push(`${paths.contract}: independent ordering contract drift`);
   }
-  const slices = (contract.rollout_slices ?? []).map((slice) => slice.task);
-  if (JSON.stringify(slices) !== JSON.stringify([
-    "FORUM-23B2G2B3A",
-    "FORUM-23B2G2B3B",
-    "FORUM-23B2G2B3C",
-    "FORUM-23B2G2B3D",
-  ])) {
-    failures.push(`${paths.contract}: rollout slice order drift`);
-  }
-  const changes = contract.current_slice_changes;
-  for (const [name, value] of Object.entries(changes ?? {})) {
-    if (value !== false) failures.push(`${paths.contract}: ${name} must remain false in G2B3A`);
+  for (const [name, value] of Object.entries(contract.current_slice_changes ?? {})) {
+    if (value !== false) failures.push(`${paths.contract}: historical ${name} must remain false`);
   }
 }
 
-if (checkpointContract?.task !== "FORUM-23B2G2B2") {
-  failures.push(`${paths.checkpointContract}: checkpoint predecessor drift`);
-}
-if (ledgerContract?.task !== "FORUM-23B2G2A") {
-  failures.push(`${paths.ledgerContract}: ledger predecessor drift`);
-}
-if (hardeningContract?.task !== "FORUM-23B2G2A1") {
-  failures.push(`${paths.hardeningContract}: hardening predecessor drift`);
-}
-if (sourceContract?.task !== "FORUM-23B2G2B1") {
-  failures.push(`${paths.sourceContract}: source predecessor drift`);
-}
-if (ingestContract?.task !== "FORUM-23B2G1") {
-  failures.push(`${paths.ingestContract}: ingest predecessor drift`);
+if (checkpointContract?.task !== "FORUM-23B2G2B2"
+    || ledgerContract?.task !== "FORUM-23B2G2A"
+    || sourceContract?.task !== "FORUM-23B2G2B1"
+    || ingestContract?.task !== "FORUM-23B2G1") {
+  failures.push("versioned wire predecessor contract drift");
 }
 
-const expectedDigests = {
+const prePublisherDigest = {
   format_version: 1,
   registry: "sha256:18fdee49d915a22ed3dd709ec6cc1826d6d47a59ddfe659fbd07ede7f6cd3d07",
   root_event: "sha256:2bc388a237ff1fcbe327c340633815a64c84c799afef5a0012f458752d6deb87",
@@ -244,9 +170,59 @@ const expectedDigests = {
   contract_payload: "sha256:5f1f9577bc9429b76bbfe5420d1bd71249efd6aea702ec0a103e4a402702cd02",
   contract_envelope: "sha256:b29a8c7809045e14f1233db4e2f9dba9cedf96352df3ea9e87ca1e86f6a59eb8",
 };
-if (digests && JSON.stringify(digests) !== JSON.stringify(expectedDigests)) {
-  failures.push(`${paths.eventDigests}: G2B3A must not change the event schema digest baseline`);
+
+if (!publisherDelivered) {
+  for (const [source, label] of [
+    [eventLib, paths.eventLib],
+    [eventPayload, paths.eventPayload],
+    [forumPublisher, paths.forumPublisher],
+  ]) {
+    rejectAll(source, [
+      "ForumSearchProjectionEvent",
+      "forum_search_projection",
+      "forum.search_projection.invalidation_issued",
+    ], `${label} pre-publisher boundary`);
+  }
+  if (digests && JSON.stringify(digests) !== JSON.stringify(prePublisherDigest)) {
+    failures.push(`${paths.eventDigests}: digest changed before publisher delivery`);
+  }
+} else {
+  if (publisherContract?.task !== "FORUM-23B2G2B3B2"
+      || publisherContract?.status !== "source_complete_consumer_pending") {
+    failures.push(`${paths.publisherContract}: downstream publisher identity drift`);
+  }
+  requireAll(eventLib, [
+    "ForumSearchProjectionEvent",
+    "FORUM_SEARCH_PROJECTION_EVENT_SCHEMAS",
+    "forum_search_projection_event_schema",
+  ], paths.eventLib);
+  requireAll(eventPayload, [
+    "ForumSearchProjection(ForumSearchProjectionEvent)",
+    "#[serde(rename = \"forum_search_projection\")]",
+  ], paths.eventPayload);
+  requireAll(forumPublisher, [
+    "ForumSearchProjectionEvent::InvalidationIssued",
+    "publish_contract_in_tx_with_causation",
+    "publish_contract_direct_in_tx_with_causation_and_envelope_id",
+    "record_projection_revision_in_tx",
+  ], paths.forumPublisher);
+  const expected = {
+    format_version: 1,
+    ...publisherContract.digest_generation.new_values,
+  };
+  if (digests && JSON.stringify(digests) !== JSON.stringify(expected)) {
+    failures.push(`${paths.eventDigests}: downstream publisher digest drift`);
+  }
 }
+
+requireAll(forumPlan, [
+  "| `FORUM-23` | `in_progress` |",
+  "owner-issued revision reconciliation plus maintainer runtime evidence remain",
+], `${paths.forumPlan} canonical open boundary`);
+requireAll(searchPlan, [
+  "This is not the final Forum-owner-issued projection revision",
+  "owner contract and rollout reconciliation remain pending",
+], `${paths.searchPlan} canonical open boundary`);
 
 if (failures.length > 0) {
   console.error("FORUM-23B2G2B3A versioned invalidation wire verification failed:");


### PR DESCRIPTION
## Summary

Implements `FORUM-23B2G2B3B2`, completing the Forum owner-publisher half of the versioned Search projection invalidation rollout.

- add sealed v1 `ForumSearchProjectionEvent::InvalidationIssued`;
- register transport family `forum_search_projection` and event type `forum.search_projection.invalidation_issued`;
- expose only positive `owner_revision`, bounded `target_type`, and conditional `target_id`;
- reject revision zero, unknown target types, full-Forum target IDs, missing category/topic IDs, and nil target IDs;
- add the explicit `ContractEventPayload::ForumSearchProjection` family variant;
- retain tenant and actor in envelope metadata and the exact legacy root envelope ID in `causation_id`;
- update the committed event-contract digest release artifact;
- dual-publish from both active Forum invalidation helpers inside one PostgreSQL owner transaction;
- preserve the exact order: allocate revision, publish legacy root and retain ID, publish caused typed contract, append ledger with the root ID, commit;
- keep legacy `index.reindex_requested` publication mandatory;
- keep non-PostgreSQL profiles legacy-only without inventing an owner revision or typed event;
- add contract roundtrip/scope source tests, machine contract, owner note, current source verifier, and downstream-aware historical guards.

## Digest release gate

The implementation environment did not provide the repository Rust toolchain, so the Cargo digest example was not executed. The exact repository algorithm was reproduced from `schema.rs`, `schemars 1.2.1` derive/generator behavior, sorted registry serialization, canonical `serde_json` ordering, and SHA-256.

Before computing the new values, the reproduction matched all five committed pre-change hashes exactly. The release artifact now records:

- registry: `sha256:a4b41305240a06ad57bb10499f6699226e5fe77adff7d6efbafe83c9e84ae0aa`
- root event: unchanged
- root envelope: unchanged
- contract payload: `sha256:e07934a82cb82ae14ec3d8b7c1e5938a6dd4bafdd563ebdce7e890985bd8011d`
- contract envelope: `sha256:e0466ed18a986885f62f08f866a882b1f2de9ed277c6e8a29d04f43aaa705d5d`

Maintainers can independently regenerate with `cargo run -p rustok-events --example event_contract_digests -- --write`.

## Deliberate boundary

This PR does not add the persistent Search typed consumer, a Search poison/transport receipt, a second inbox, or a second projector. Typed and legacy delivery will converge on the existing root-event inbox identity in `FORUM-23B2G2B3C`.

It also does not retire the legacy root event, change Search checkpoint semantics, compare Forum owner revision with Search `ingest_sequence`, change the outbox table/relay/Iggy paths, add dependencies, or change `Cargo.lock`.

## Verification

Tests, source verifiers, formatting, Cargo checks, Clippy, CI, and PostgreSQL/relay/Iggy/runtime evidence were intentionally not run by request.