### PR TITLE
feat(blog): wire admin native Comments port injection

### DIFF
--- a/crates/rustok-blog/admin/src/transport/native_server_adapter.rs
+++ b/crates/rustok-blog/admin/src/transport/native_server_adapter.rs
@@ -1,6 +1,9 @@
 use leptos::prelude::*;
 
 #[cfg(feature = "ssr")]
+use std::sync::Arc;
+
+#[cfg(feature = "ssr")]
 use crate::model::{BlogModerationComment, BlogPostListItem};
 use crate::model::{
     BlogModerationCommentList, BlogModerationStatus, BlogPostDetail, BlogPostDraft, BlogPostList,
@@ -74,6 +77,7 @@ pub(super) async fn moderate_comment(
 struct NativeContext {
     db: sea_orm::DatabaseConnection,
     event_bus: rustok_outbox::TransactionalEventBus,
+    comments_thread_port: Option<Arc<dyn rustok_blog::CommentsThreadPort>>,
     auth: rustok_api::AuthContext,
     tenant: rustok_api::TenantContext,
 }
@@ -101,13 +105,28 @@ async fn native_context() -> Result<NativeContext, ServerFnError> {
         .ok_or_else(|| {
             ServerFnError::new("blog/admin requires TransactionalEventBus in host runtime context")
         })?;
+    let comments_thread_port =
+        runtime.shared_get::<Arc<dyn rustok_blog::CommentsThreadPort>>();
 
     Ok(NativeContext {
         db: runtime.db_clone(),
         event_bus,
+        comments_thread_port,
         auth,
         tenant,
     })
+}
+
+#[cfg(feature = "ssr")]
+fn comment_service(context: &NativeContext) -> rustok_blog::CommentService {
+    if let Some(comments_thread_port) = context.comments_thread_port.clone() {
+        rustok_blog::CommentService::with_comments_thread_port(
+            context.db.clone(),
+            comments_thread_port,
+        )
+    } else {
+        rustok_blog::CommentService::new(context.db.clone(), context.event_bus.clone())
+    }
 }
 
 #[cfg(feature = "ssr")]
@@ -475,13 +494,13 @@ async fn blog_admin_moderation_comments_native(
 ) -> Result<BlogModerationCommentList, ServerFnError> {
     #[cfg(feature = "ssr")]
     {
-        use rustok_blog::{CommentService, ListCommentsFilter};
+        use rustok_blog::ListCommentsFilter;
 
         let context = native_context().await?;
         require_manage_permission(&context.auth)?;
         let post_id = parse_uuid(&post_id, "post_id")?;
         let locale = requested_locale(locale, context.tenant.default_locale.as_str());
-        let (items, total) = CommentService::new(context.db, context.event_bus)
+        let (items, total) = comment_service(&context)
             .list_for_post_with_locale_fallback(
                 context.tenant.id,
                 security_context(&context.auth),
@@ -518,7 +537,7 @@ async fn blog_admin_moderate_comment_native(
 ) -> Result<bool, ServerFnError> {
     #[cfg(feature = "ssr")]
     {
-        use rustok_blog::{CommentService, ModerateCommentInput, ModerateCommentStatus};
+        use rustok_blog::{ModerateCommentInput, ModerateCommentStatus};
 
         let context = native_context().await?;
         require_manage_permission(&context.auth)?;
@@ -528,7 +547,7 @@ async fn blog_admin_moderate_comment_native(
             BlogModerationStatus::Spam => ModerateCommentStatus::Spam,
             BlogModerationStatus::Trash => ModerateCommentStatus::Trash,
         };
-        CommentService::new(context.db, context.event_bus)
+        comment_service(&context)
             .moderate_comment(
                 context.tenant.id,
                 comment_id,
@@ -612,5 +631,16 @@ fn map_moderation_comment(comment: rustok_blog::CommentListItem) -> BlogModerati
         status: comment.status,
         parent_comment_id: comment.parent_comment_id.map(|value| value.to_string()),
         created_at: comment.created_at,
+    }
+}
+
+#[cfg(all(test, feature = "ssr"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn admin_native_runtime_exposes_comments_port_selection() {
+        let selector: fn(&NativeContext) -> rustok_blog::CommentService = comment_service;
+        let _ = selector;
     }
 }

--- a/crates/rustok-blog/contracts/evidence/blog-comments-admin-native-port-injection.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-admin-native-port-injection.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": 1,
+  "module": "blog",
+  "surface": "comments_admin_native_port_injection",
+  "role": "consumer",
+  "provider": "comments",
+  "status": "source_verified_no_compile",
+  "compile_policy": "not_run_by_request",
+  "runtime_status": "not_run",
+  "source_contract": {
+    "admin_adapter": "crates/rustok-blog/admin/src/transport/native_server_adapter.rs",
+    "consumer_service": "crates/rustok-blog/src/services/comment.rs",
+    "consumer_matrix": "crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json"
+  },
+  "profiles": {
+    "source_verified": [
+      "in_process_fallback",
+      "host_injected_port_selection"
+    ],
+    "pending": [
+      "remote_transport_implementation"
+    ]
+  },
+  "composition": {
+    "host_context": "rustok_api::HostRuntimeContext",
+    "native_context": "NativeContext",
+    "shared_value": "Arc<dyn rustok_blog::CommentsThreadPort>",
+    "lookup": "HostRuntimeContext::shared_get",
+    "selector": "comment_service",
+    "injected_constructor": "CommentService::with_comments_thread_port",
+    "fallback_constructor": "CommentService::new",
+    "native_endpoints": [
+      "blog/admin/moderation-comments",
+      "blog/admin/moderate-comment"
+    ],
+    "port_operations": [
+      "list_comments_for_target",
+      "get_comment",
+      "set_comment_status"
+    ]
+  },
+  "authorization": {
+    "tenant_binding": "AuthContext.tenant_id == TenantContext.id",
+    "permission": "blog_posts:manage",
+    "checked_before_port_call": true
+  },
+  "moderation_policy": {
+    "read_pagination": "page >= 1; 1 <= per_page <= 100",
+    "error_policy": "all_blog_errors_propagated",
+    "storefront_degradation_reused": false
+  },
+  "harness": {
+    "status": "executable_no_run",
+    "runtime_status": "not_run",
+    "source": "crates/rustok-blog/admin/src/transport/native_server_adapter.rs",
+    "test": "transport::native_server_adapter::tests::admin_native_runtime_exposes_comments_port_selection",
+    "command": "cargo test -p rustok-blog-admin --features ssr transport::native_server_adapter::tests::admin_native_runtime_exposes_comments_port_selection -- --exact"
+  },
+  "registration": {
+    "standalone_verifier": "scripts/verify/verify-blog-comments-admin-native-port-injection.mjs",
+    "focused_fixture": "scripts/verify/verify-blog-comments-admin-native-port-injection.test.mjs",
+    "blog_fba_package_chain": "pending"
+  },
+  "non_claims": [
+    "no remote network transport is implemented",
+    "no admin moderation error is degraded to an empty success payload",
+    "no Rust or JavaScript test was run",
+    "no compile, database, browser, workflow, CI, or production result is recorded"
+  ]
+}

--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -125,8 +125,8 @@ coverage. The retained compile-only harness is
 `controllers::tests::blog_http_runtime_exposes_comments_port_selection`, with
 suggested command
 `cargo test -p rustok-blog --lib controllers::tests::blog_http_runtime_exposes_comments_port_selection -- --exact`.
-HTTP moderation host selection is source-locked; admin native SSR composition plus
-the remote network transport remains pending.
+HTTP moderation host selection is source-locked; the remote network transport
+remains pending.
 
 GraphQL Comments composition is manifest-attached. The Blog package declares
 `runtime_data_factory = "graphql::attach_schema_data"`; generated server code
@@ -151,8 +151,8 @@ GraphQL verifier, and the registered `test:verify:blog:comments-port-boundary`
 self-test imports all twelve focused cases. `scripts/verify/verify-blog-fba.test.mjs`
 locks both imports alongside the HTTP composition imports. GraphQL Comments host
 selection is source-locked and mandatory inside the existing first-class Comments
-port leaf. A dedicated parallel GraphQL leaf is intentionally absent. Admin native
-SSR composition and the remote network transport remain pending.
+port leaf. A dedicated parallel GraphQL leaf is intentionally absent. The remote
+network transport remains pending.
 
 Storefront native SSR Comments composition is host-attached. The selected-post
 server function reads `HostRuntimeContext`, and its single `comment_service`
@@ -179,8 +179,30 @@ HTTP and GraphQL composition imports. The source marker `storefront native SSR
 Comments host selection is source-locked` is mandatory inside the existing
 first-class Comments port leaf. Blog FBA package-chain registration remains
 pending only as a dedicated parallel storefront leaf; that duplicate leaf is
-intentionally not added. Admin native SSR composition and the remote network
-transport remain pending.
+intentionally not added. The remote network transport remains pending.
+
+Admin native SSR Comments composition is host-attached through the existing
+`NativeContext`. `native_context()` reads an optional
+`Arc<dyn rustok_blog::CommentsThreadPort>` from `HostRuntimeContext`, and the
+single `comment_service(&NativeContext)` selector chooses
+`CommentService::with_comments_thread_port` or the existing in-process
+`CommentService::new` fallback. Both `blog/admin/moderation-comments` and
+`blog/admin/moderate-comment` require authenticated/routed tenant equality and
+`blog_posts:manage` before selecting the service. Moderation list pagination
+remains bounded to page at least one and `per_page` in `1..100`; all Blog errors
+remain fail-closed and no storefront empty-success degradation is reused.
+Schema-v1 evidence lives at
+`crates/rustok-blog/contracts/evidence/blog-comments-admin-native-port-injection.json`,
+guarded by `scripts/verify/verify-blog-comments-admin-native-port-injection.mjs`
+and focused fixture
+`scripts/verify/verify-blog-comments-admin-native-port-injection.test.mjs`. The
+retained compile-only harness is
+`transport::native_server_adapter::tests::admin_native_runtime_exposes_comments_port_selection`,
+with suggested command
+`cargo test -p rustok-blog-admin --features ssr transport::native_server_adapter::tests::admin_native_runtime_exposes_comments_port_selection -- --exact`.
+The admin native SSR Comments host selection is source-locked. Blog FBA
+package-chain registration remains pending, and the remote network transport
+remains pending.
 
 Comments lifecycle projection into Blog-owned `comment_count` is a Blog consumer
 boundary. `BlogCommentProjectionHandler` accepts only `comment.created` and
@@ -728,6 +750,21 @@ claims remain unchanged. Storefront native composition is now a mandatory
 sub-contract of the existing first-class Comments port leaf rather than a parallel
 duplicate leaf.
 
+The continuation audit at `ffd1c3f47335d7809856737e922b3402c68a9a5c`
+found that both Blog admin native moderation endpoints still constructed
+`CommentService::new` directly even though `native_context()` already received
+`HostRuntimeContext`. A host-owned Comments port could therefore reach HTTP,
+GraphQL, and storefront native consumers but not admin native SSR.
+
+Slice 65 adds optional `Arc<dyn rustok_blog::CommentsThreadPort>` storage to
+`NativeContext`, reads it through `HostRuntimeContext::shared_get`, and routes both
+moderation list and moderation mutation through one injected/in-process
+`comment_service` selector. Tenant binding, `blog_posts:manage`, pagination, and
+fail-closed error propagation are preserved. New schema-v1 evidence, a standalone
+verifier, seventeen focused positive/negative cases, and a compile-only selector
+harness retain the source contract. Blog FBA package-chain integration, the remote
+network transport, and all execution remain pending.
+
 ## FFA/FBA status
 
 - FFA status: `in_progress`.
@@ -743,23 +780,26 @@ duplicate leaf.
   GraphQL richtext, AI richtext, offline backfill, Forum ownership, and runtime
   order. The existing Comments port leaf requires HTTP, GraphQL, and storefront
   native composition verifiers plus focused fixtures through aggregate-locked
-  imports; package order remains unchanged.
+  imports; package order remains unchanged. The standalone admin native
+  composition guard remains outside registry package order in Slice 65.
 - Comments consumer port boundary: Blog-owned `source_verified_no_compile` for
   the in-process profile; evidence schema v3, all seven operations, approved public
   read, typed richtext projection, two-second deadlines, write idempotency, active
   typed `PortErrorKind` mapping, public transport-neutral injection constructor,
   facade port re-export, compile-only exact-signature harness, exact npm leaf
   commands, focused fixture, and Blog FBA ordering are locked. HTTP moderation
-  selects an optional host-provided port through `BlogHttpRuntime::comment_service`
-  with an in-process fallback; GraphQL public/moderation operations select the same
-  optional port through manifest-attached `BlogGraphqlRuntimeData`; storefront
-  native SSR approved public reads select it through `comment_service` while
-  preserving typed `AVAILABLE` / `UNAVAILABLE` / `TIMEOUT` degradation. All three
-  composition guards and their focused fixtures are retained inside the registered
-  Comments port gate. Dedicated parallel composition leaves remain intentionally
-  absent. Admin native SSR composition, the remote network transport, remote
-  adapter runtime parity, cached snapshot, comment-form fallback, browser/runtime
-  evidence, and broader degraded UI modes remain planned or pending.
+  selects an optional host-provided port through `BlogHttpRuntime::comment_service`;
+  GraphQL public/moderation operations use manifest-attached
+  `BlogGraphqlRuntimeData`; storefront native SSR approved public reads use
+  `comment_service` with typed `AVAILABLE` / `UNAVAILABLE` / `TIMEOUT`
+  degradation. Those three composition guards are retained inside the registered
+  Comments port gate. Admin native SSR moderation list and mutation now select the
+  same optional host port through `comment_service`, preserve tenant/permission
+  admission and fail-closed errors, and retain schema-v1 evidence plus a standalone
+  verifier, focused fixture, and compile-only harness. Admin package-chain
+  integration, the remote network transport, remote adapter runtime parity, cached
+  snapshot, comment-form fallback, browser/runtime evidence, and broader degraded
+  UI modes remain planned or pending.
 - Comments event projection: Blog-owned `source_verified_no_compile`; evidence
   schema v4, shared classifier/counter/retry-decision helpers, `executable_no_run`
   source harness, deterministic PostgreSQL retry-limit target, module-registration,
@@ -809,6 +849,7 @@ duplicate leaf.
 - `crates/rustok-blog/contracts/evidence/blog-comments-http-port-injection.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-graphql-port-injection.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-storefront-native-port-injection.json`
+- `crates/rustok-blog/contracts/evidence/blog-comments-admin-native-port-injection.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-event-projection.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-duplicate-delivery-race.json`
 - `crates/rustok-blog/contracts/evidence/blog-comments-dispatcher-duplicate-delivery.json`
@@ -827,6 +868,7 @@ duplicate leaf.
 - `crates/rustok-blog/storefront/src/transport/graphql_adapter.rs`
 - `crates/rustok-blog/storefront/src/transport/native_server_adapter.rs`
 - `crates/rustok-blog/storefront/src/ui/leptos.rs`
+- `crates/rustok-blog/admin/src/transport/native_server_adapter.rs`
 - `crates/rustok-blog/src/services/comment_projection.rs`
 - `crates/rustok-blog/tests/comment_projection_postgres_test.rs`
 - `crates/rustok-blog/tests/comment_projection_duplicate_race_postgres_test.rs`
@@ -854,6 +896,8 @@ duplicate leaf.
 - `scripts/verify/verify-blog-comments-graphql-port-injection.test.mjs`
 - `scripts/verify/verify-blog-comments-storefront-native-port-injection.mjs`
 - `scripts/verify/verify-blog-comments-storefront-native-port-injection.test.mjs`
+- `scripts/verify/verify-blog-comments-admin-native-port-injection.mjs`
+- `scripts/verify/verify-blog-comments-admin-native-port-injection.test.mjs`
 - `scripts/verify/verify-blog-comments-event-projection.mjs`
 - `scripts/verify/verify-blog-comments-event-projection.test.mjs`
 - `scripts/verify/verify-blog-comments-duplicate-delivery-race.mjs`
@@ -1069,6 +1113,13 @@ duplicate leaf.
     leaf, made the parent positive fixture self-contained, added aggregate
     regressions for both required imports, preserved registry schema v13 and exact
     package order, and changed no runtime source or execution status.
+65. Wired optional host-provided `CommentsThreadPort` selection into Blog admin
+    native SSR moderation list and mutation, centralized injected/in-process
+    construction in `comment_service(&NativeContext)`, preserved tenant binding,
+    manage permission, bounded pagination, and fail-closed errors, retained the
+    source contract in schema-v1 evidence plus a standalone verifier, seventeen
+    focused cases, and a compile-only harness, and kept package integration,
+    remote transport, and all execution pending.
 
 ## Next results
 
@@ -1087,32 +1138,16 @@ duplicate leaf.
    real HTTP `Retry-After` matching GraphQL `retryAfter`.
 5. **Close comments runtime evidence.** Run the registered Comments port boundary
    verifier and self-test, which include the standalone HTTP, GraphQL, and
-   storefront native composition verifiers plus their focused fixtures, the
-   compile-only injection-signature, HTTP selection, GraphQL runtime-data, and
-   storefront native selector harnesses, shared consumer runtime-order verifier,
-   Blog projection classifier and deterministic retry-policy harness, module
-   registration/routing harness, the filtered
-   `event_dispatcher_routes_registered_handler_and_commits_projection`,
-   `event_dispatcher_replays_duplicate_envelope_without_double_commit`,
-   `concurrent_created_events_converge_without_lost_updates`,
-   `optimistic_retry_limit_rolls_back_and_replays_after_conflict_clears`,
-   `concurrent_duplicate_envelope_commits_once_and_replays_cleanly`, and
-   `restarted_process_reuses_delivery_ledger_without_reapplying_counter` cases,
-   the complete `comment_projection_postgres_test`,
-   `comment_projection_dispatcher_duplicate_postgres_test`,
-   `comment_projection_duplicate_race_postgres_test`, and
-   `comment_projection_restart_postgres_test` targets, both thread invariant
-   concurrency targets, and concurrent PostgreSQL create/delete transactions.
-   Retain deterministic immediate-success/seven-retry/eighth-limit output, the
-   deterministic eight-zero-row terminal error, rollback and same-envelope
-   recovery output, two successful completed dispatcher duplicate calls with zero
-   errors and one database application, both blocked duplicate workers, the
-   one-winner/one-loser outcome, final single delivery/outbox cardinality, clean
-   duplicate replay, dispatcher delivery output, four-connection convergence,
-   both child process exits, the written duplicate, delete-before-create,
-   missing-post replay, outbox rollback/retry, and same-process/new-connection
-   assertions; then wire admin native SSR to the host-owned Comments port,
-   implement the remote network transport through
+   storefront native composition verifiers plus their focused fixtures, and run
+   the standalone admin native composition verifier and focused fixture. Execute
+   the compile-only injection-signature, HTTP selection, GraphQL runtime-data,
+   storefront native, and admin native selector harnesses, shared consumer
+   runtime-order verifier, Blog projection classifier and deterministic retry
+   policy, module registration/routing, dispatcher, concurrency, retry-limit,
+   duplicate-delivery, and restart targets. Retain deterministic rollback,
+   cardinality, process-boundary, authorization, moderation, pagination, and
+   fail-closed outputs; then register the admin native source guard inside the
+   existing Comments port gate, implement the remote network transport through
    `CommentService::with_comments_thread_port`, and retain all-seven-operation
    adapter parity, naturally contended PostgreSQL retry-frequency evidence, full
    server-host restart recovery, browser parity for typed unavailable/timeout
@@ -1142,6 +1177,9 @@ should run the relevant subset, including:
 - `node scripts/verify/verify-blog-comments-storefront-native-port-injection.mjs`
 - `node --test scripts/verify/verify-blog-comments-storefront-native-port-injection.test.mjs`
 - `cargo test -p rustok-blog-storefront --features ssr transport::native_server_adapter::tests::storefront_native_runtime_exposes_comments_port_selection -- --exact`
+- `node scripts/verify/verify-blog-comments-admin-native-port-injection.mjs`
+- `node --test scripts/verify/verify-blog-comments-admin-native-port-injection.test.mjs`
+- `cargo test -p rustok-blog-admin --features ssr transport::native_server_adapter::tests::admin_native_runtime_exposes_comments_port_selection -- --exact`
 - `npm run verify:blog:comments-event-projection`
 - `npm run test:verify:blog:comments-event-projection`
 - `npm run verify:blog:comments-duplicate-delivery-race`

--- a/scripts/verify/verify-blog-comments-admin-native-port-injection.mjs
+++ b/scripts/verify/verify-blog-comments-admin-native-port-injection.mjs
@@ -192,15 +192,16 @@ for (const marker of [
   'let selector: fn(&NativeContext) -> rustok_blog::CommentService = comment_service;',
 ]) requireMarker(adminAdapter, marker, adminAdapterPath);
 
-if (
-  countMarker(adminAdapter, 'rustok_blog::CommentService::with_comments_thread_port(') !== 1
-) failures.push(`${adminAdapterPath}: expected one injected constructor branch`);
-if (countMarker(adminAdapter, 'rustok_blog::CommentService::new(') !== 1) {
+if (countMarker(adminAdapter, 'CommentService::with_comments_thread_port(') !== 1) {
+  failures.push(`${adminAdapterPath}: expected one injected constructor branch`);
+}
+if (countMarker(adminAdapter, 'CommentService::new(') !== 1) {
   failures.push(`${adminAdapterPath}: expected one in-process fallback branch`);
 }
 if (countMarker(adminAdapter, 'comment_service(&context)') !== 2) {
   failures.push(`${adminAdapterPath}: expected two moderation selector handoffs`);
 }
+requireNoMarker(adminAdapter, 'use rustok_blog::CommentService;', adminAdapterPath);
 requireNoMarker(adminAdapter, 'use rustok_blog::{CommentService,', adminAdapterPath);
 requireNoMarker(adminAdapter, 'Err(_) => BlogModerationCommentList', adminAdapterPath);
 requireNoMarker(adminAdapter, 'unwrap_or_default()', adminAdapterPath);

--- a/scripts/verify/verify-blog-comments-admin-native-port-injection.mjs
+++ b/scripts/verify/verify-blog-comments-admin-native-port-injection.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve('.');
+const failures = [];
+
+function repoPath(relativePath) {
+  return path.join(repoRoot, relativePath);
+}
+
+function read(relativePath) {
+  const target = repoPath(relativePath);
+  if (!existsSync(target)) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return '';
+  }
+  return readFileSync(target, 'utf8');
+}
+
+function json(relativePath) {
+  try {
+    return JSON.parse(read(relativePath));
+  } catch (error) {
+    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function requireMarker(source, marker, label) {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+}
+
+function requireNoMarker(source, marker, label) {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+}
+
+function countMarker(source, marker) {
+  return source.split(marker).length - 1;
+}
+
+function sameSet(actual, expected) {
+  return [...actual].sort().join('|') === [...expected].sort().join('|');
+}
+
+function segment(source, startMarker, endMarker) {
+  const start = source.indexOf(startMarker);
+  if (start < 0) return '';
+  const end = endMarker ? source.indexOf(endMarker, start + startMarker.length) : -1;
+  return source.slice(start, end < 0 ? source.length : end);
+}
+
+const evidencePath =
+  'crates/rustok-blog/contracts/evidence/blog-comments-admin-native-port-injection.json';
+const adminAdapterPath =
+  'crates/rustok-blog/admin/src/transport/native_server_adapter.rs';
+const servicePath = 'crates/rustok-blog/src/services/comment.rs';
+const consumerMatrixPath =
+  'crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json';
+const planPath = 'crates/rustok-blog/docs/implementation-plan.md';
+const harnessTest =
+  'transport::native_server_adapter::tests::admin_native_runtime_exposes_comments_port_selection';
+const harnessCommand =
+  `cargo test -p rustok-blog-admin --features ssr ${harnessTest} -- --exact`;
+
+const evidence = json(evidencePath);
+const consumerMatrix = json(consumerMatrixPath);
+const adminAdapter = read(adminAdapterPath);
+const service = read(servicePath);
+const normalizedPlan = read(planPath).replace(/\s+/g, ' ');
+
+if (evidence) {
+  if (evidence.schema_version !== 1) failures.push(`${evidencePath}: schema_version drift`);
+  if (
+    evidence.module !== 'blog' ||
+    evidence.surface !== 'comments_admin_native_port_injection' ||
+    evidence.role !== 'consumer' ||
+    evidence.provider !== 'comments'
+  ) failures.push(`${evidencePath}: identity drift`);
+  if (evidence.status !== 'source_verified_no_compile') {
+    failures.push(`${evidencePath}: status drift`);
+  }
+  if (
+    evidence.compile_policy !== 'not_run_by_request' ||
+    evidence.runtime_status !== 'not_run'
+  ) failures.push(`${evidencePath}: execution policy drift`);
+
+  const expectedSources = {
+    admin_adapter: adminAdapterPath,
+    consumer_service: servicePath,
+    consumer_matrix: consumerMatrixPath,
+  };
+  for (const [key, expected] of Object.entries(expectedSources)) {
+    if (evidence.source_contract?.[key] !== expected) {
+      failures.push(`${evidencePath}: ${key} source path drift`);
+    }
+  }
+
+  if (
+    !sameSet(evidence.profiles?.source_verified ?? [], [
+      'in_process_fallback',
+      'host_injected_port_selection',
+    ])
+  ) failures.push(`${evidencePath}: source-verified profile drift`);
+  if (
+    !sameSet(evidence.profiles?.pending ?? [], ['remote_transport_implementation'])
+  ) failures.push(`${evidencePath}: pending profile drift`);
+
+  const composition = evidence.composition ?? {};
+  if (
+    composition.host_context !== 'rustok_api::HostRuntimeContext' ||
+    composition.native_context !== 'NativeContext' ||
+    composition.shared_value !== 'Arc<dyn rustok_blog::CommentsThreadPort>' ||
+    composition.lookup !== 'HostRuntimeContext::shared_get' ||
+    composition.selector !== 'comment_service' ||
+    composition.injected_constructor !== 'CommentService::with_comments_thread_port' ||
+    composition.fallback_constructor !== 'CommentService::new' ||
+    !sameSet(composition.native_endpoints ?? [], [
+      'blog/admin/moderation-comments',
+      'blog/admin/moderate-comment',
+    ]) ||
+    !sameSet(composition.port_operations ?? [], [
+      'list_comments_for_target',
+      'get_comment',
+      'set_comment_status',
+    ])
+  ) failures.push(`${evidencePath}: composition drift`);
+
+  if (
+    evidence.authorization?.tenant_binding !==
+      'AuthContext.tenant_id == TenantContext.id' ||
+    evidence.authorization?.permission !== 'blog_posts:manage' ||
+    evidence.authorization?.checked_before_port_call !== true
+  ) failures.push(`${evidencePath}: authorization drift`);
+
+  if (
+    evidence.moderation_policy?.read_pagination !==
+      'page >= 1; 1 <= per_page <= 100' ||
+    evidence.moderation_policy?.error_policy !== 'all_blog_errors_propagated' ||
+    evidence.moderation_policy?.storefront_degradation_reused !== false
+  ) failures.push(`${evidencePath}: moderation policy drift`);
+
+  if (
+    evidence.harness?.status !== 'executable_no_run' ||
+    evidence.harness?.runtime_status !== 'not_run' ||
+    evidence.harness?.source !== adminAdapterPath ||
+    evidence.harness?.test !== harnessTest ||
+    evidence.harness?.command !== harnessCommand
+  ) failures.push(`${evidencePath}: harness drift`);
+
+  if (
+    evidence.registration?.standalone_verifier !==
+      'scripts/verify/verify-blog-comments-admin-native-port-injection.mjs' ||
+    evidence.registration?.focused_fixture !==
+      'scripts/verify/verify-blog-comments-admin-native-port-injection.test.mjs' ||
+    evidence.registration?.blog_fba_package_chain !== 'pending'
+  ) failures.push(`${evidencePath}: registration drift`);
+}
+
+if (
+  consumerMatrix?.schema_version !== 3 ||
+  consumerMatrix?.status !== 'source_verified_no_compile' ||
+  !sameSet(consumerMatrix?.profiles?.source_verified ?? [], ['in_process']) ||
+  !sameSet(consumerMatrix?.profiles?.pending ?? [], ['remote_adapter_placeholder'])
+) failures.push(`${consumerMatrixPath}: base consumer status drift`);
+
+for (const marker of [
+  'use std::sync::Arc;',
+  'struct NativeContext {',
+  'comments_thread_port: Option<Arc<dyn rustok_blog::CommentsThreadPort>>',
+  'let runtime = expect_context::<HostRuntimeContext>();',
+  'if auth.tenant_id != tenant.id',
+  'runtime.shared_get::<Arc<dyn rustok_blog::CommentsThreadPort>>()',
+  'fn comment_service(context: &NativeContext) -> rustok_blog::CommentService',
+  'context.comments_thread_port.clone()',
+  'rustok_blog::CommentService::with_comments_thread_port(',
+  'rustok_blog::CommentService::new(context.db.clone(), context.event_bus.clone())',
+  '#[server(prefix = "/api/fn", endpoint = "blog/admin/moderation-comments")]',
+  '#[server(prefix = "/api/fn", endpoint = "blog/admin/moderate-comment")]',
+  'require_manage_permission(&context.auth)?;',
+  '&[rustok_api::Permission::BLOG_POSTS_MANAGE]',
+  '"Permission denied: blog_posts:manage required"',
+  'page: page.max(1)',
+  'per_page: per_page.clamp(1, 100)',
+  '.list_for_post_with_locale_fallback(',
+  '.moderate_comment(',
+  '.map_err(ServerFnError::new)?;',
+  'fn admin_native_runtime_exposes_comments_port_selection()',
+  'let selector: fn(&NativeContext) -> rustok_blog::CommentService = comment_service;',
+]) requireMarker(adminAdapter, marker, adminAdapterPath);
+
+if (
+  countMarker(adminAdapter, 'rustok_blog::CommentService::with_comments_thread_port(') !== 1
+) failures.push(`${adminAdapterPath}: expected one injected constructor branch`);
+if (countMarker(adminAdapter, 'rustok_blog::CommentService::new(') !== 1) {
+  failures.push(`${adminAdapterPath}: expected one in-process fallback branch`);
+}
+if (countMarker(adminAdapter, 'comment_service(&context)') !== 2) {
+  failures.push(`${adminAdapterPath}: expected two moderation selector handoffs`);
+}
+requireNoMarker(adminAdapter, 'use rustok_blog::{CommentService,', adminAdapterPath);
+requireNoMarker(adminAdapter, 'Err(_) => BlogModerationCommentList', adminAdapterPath);
+requireNoMarker(adminAdapter, 'unwrap_or_default()', adminAdapterPath);
+
+const listSegment = segment(
+  adminAdapter,
+  '#[server(prefix = "/api/fn", endpoint = "blog/admin/moderation-comments")]',
+  '#[server(prefix = "/api/fn", endpoint = "blog/admin/moderate-comment")]',
+);
+const mutationSegment = segment(
+  adminAdapter,
+  '#[server(prefix = "/api/fn", endpoint = "blog/admin/moderate-comment")]',
+  '#[cfg(feature = "ssr")]\nfn optional_text',
+);
+for (const [label, source] of [
+  ['moderation list', listSegment],
+  ['moderation mutation', mutationSegment],
+]) {
+  const permissionIndex = source.indexOf('require_manage_permission(&context.auth)?;');
+  const selectorIndex = source.indexOf('comment_service(&context)');
+  if (permissionIndex < 0 || selectorIndex < permissionIndex) {
+    failures.push(`${adminAdapterPath}: ${label} authorization/selector order drift`);
+  }
+  if (!source.includes('.map_err(ServerFnError::new)?;')) {
+    failures.push(`${adminAdapterPath}: ${label} error propagation drift`);
+  }
+}
+
+for (const marker of [
+  'pub fn with_comments_thread_port(',
+  '.list_comments_for_target(',
+  '.get_comment(',
+  '.set_comment_status(',
+  'comments_read_port_context(',
+  'comments_write_port_context(',
+  'PortErrorKind::Unavailable => rustok_core::error::ErrorKind::ExternalService',
+  'PortErrorKind::Timeout => rustok_core::error::ErrorKind::Timeout',
+]) requireMarker(service, marker, servicePath);
+
+for (const marker of [
+  'blog-comments-admin-native-port-injection.json',
+  'verify-blog-comments-admin-native-port-injection.mjs',
+  'verify-blog-comments-admin-native-port-injection.test.mjs',
+  'admin native SSR Comments host selection is source-locked',
+  'Blog FBA package-chain registration remains pending',
+  'remote network transport remains pending',
+  'Slice 65',
+]) requireMarker(normalizedPlan, marker, planPath);
+
+if (failures.length > 0) {
+  console.error('Blog admin native Comments port injection verification failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log('Blog admin native Comments host selection and fail-closed moderation source boundary is consistent');

--- a/scripts/verify/verify-blog-comments-admin-native-port-injection.test.mjs
+++ b/scripts/verify/verify-blog-comments-admin-native-port-injection.test.mjs
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const verifier = path.resolve(
+  'scripts/verify/verify-blog-comments-admin-native-port-injection.mjs',
+);
+const evidencePath =
+  'crates/rustok-blog/contracts/evidence/blog-comments-admin-native-port-injection.json';
+const adminAdapterPath =
+  'crates/rustok-blog/admin/src/transport/native_server_adapter.rs';
+const servicePath = 'crates/rustok-blog/src/services/comment.rs';
+const consumerMatrixPath =
+  'crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json';
+const planPath = 'crates/rustok-blog/docs/implementation-plan.md';
+const harnessTest =
+  'transport::native_server_adapter::tests::admin_native_runtime_exposes_comments_port_selection';
+const harnessCommand =
+  `cargo test -p rustok-blog-admin --features ssr ${harnessTest} -- --exact`;
+
+function write(root, relativePath, content) {
+  const target = path.join(root, relativePath);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, content);
+}
+
+function fixture({
+  missingTenantBinding = false,
+  missingLookup = false,
+  missingInjected = false,
+  missingFallback = false,
+  missingListHandoff = false,
+  missingMutationHandoff = false,
+  directConstruction = false,
+  missingPermission = false,
+  permissionAfterSelector = false,
+  broadListFallback = false,
+  swallowedMutation = false,
+  missingHarness = false,
+  runtimePromoted = false,
+  remotePromoted = false,
+  registrationPromoted = false,
+  planDrift = false,
+} = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-blog-admin-native-comments-'));
+
+  const permission = missingPermission
+    ? ''
+    : 'require_manage_permission(&context.auth)?;';
+  const listSelector = missingListHandoff ? '' : 'comment_service(&context)';
+  const mutationSelector = missingMutationHandoff ? '' : 'comment_service(&context)';
+  const listAuthorization = permissionAfterSelector ? `${listSelector}\n${permission}` : `${permission}\n${listSelector}`;
+  const mutationAuthorization = permissionAfterSelector
+    ? `${mutationSelector}\n${permission}`
+    : `${permission}\n${mutationSelector}`;
+
+  write(
+    root,
+    adminAdapterPath,
+    `
+use std::sync::Arc;
+struct NativeContext {
+comments_thread_port: Option<Arc<dyn rustok_blog::CommentsThreadPort>>
+}
+let runtime = expect_context::<HostRuntimeContext>();
+${missingTenantBinding ? '' : 'if auth.tenant_id != tenant.id'}
+${missingLookup ? '' : 'runtime.shared_get::<Arc<dyn rustok_blog::CommentsThreadPort>>()'}
+fn comment_service(context: &NativeContext) -> rustok_blog::CommentService {
+context.comments_thread_port.clone()
+${missingInjected ? '' : 'rustok_blog::CommentService::with_comments_thread_port('}
+${missingFallback ? '' : 'rustok_blog::CommentService::new(context.db.clone(), context.event_bus.clone())'}
+}
+${directConstruction ? 'rustok_blog::CommentService::new(context.db.clone(), context.event_bus.clone())' : ''}
+fn require_manage_permission(
+&[rustok_api::Permission::BLOG_POSTS_MANAGE]
+"Permission denied: blog_posts:manage required"
+#[server(prefix = "/api/fn", endpoint = "blog/admin/moderation-comments")]
+${listAuthorization}
+page: page.max(1)
+per_page: per_page.clamp(1, 100)
+.list_for_post_with_locale_fallback(
+${broadListFallback ? 'Err(_) => BlogModerationCommentList' : '.map_err(ServerFnError::new)?;'}
+#[server(prefix = "/api/fn", endpoint = "blog/admin/moderate-comment")]
+${mutationAuthorization}
+.moderate_comment(
+${swallowedMutation ? 'unwrap_or_default()' : '.map_err(ServerFnError::new)?;'}
+#[cfg(feature = "ssr")]
+fn optional_text
+${
+  missingHarness
+    ? ''
+    : `
+fn admin_native_runtime_exposes_comments_port_selection()
+let selector: fn(&NativeContext) -> rustok_blog::CommentService = comment_service;
+`
+}
+`,
+  );
+
+  write(
+    root,
+    servicePath,
+    `
+pub fn with_comments_thread_port(
+.list_comments_for_target(
+.get_comment(
+.set_comment_status(
+comments_read_port_context(
+comments_write_port_context(
+PortErrorKind::Unavailable => rustok_core::error::ErrorKind::ExternalService
+PortErrorKind::Timeout => rustok_core::error::ErrorKind::Timeout
+`,
+  );
+
+  write(
+    root,
+    consumerMatrixPath,
+    JSON.stringify({
+      schema_version: 3,
+      status: 'source_verified_no_compile',
+      profiles: {
+        source_verified: ['in_process'],
+        pending: ['remote_adapter_placeholder'],
+      },
+    }),
+  );
+
+  const sourceVerified = ['in_process_fallback', 'host_injected_port_selection'];
+  const pending = ['remote_transport_implementation'];
+  if (remotePromoted) {
+    sourceVerified.push('remote_transport_implementation');
+    pending.splice(0, 1);
+  }
+
+  write(
+    root,
+    evidencePath,
+    JSON.stringify({
+      schema_version: 1,
+      module: 'blog',
+      surface: 'comments_admin_native_port_injection',
+      role: 'consumer',
+      provider: 'comments',
+      status: 'source_verified_no_compile',
+      compile_policy: 'not_run_by_request',
+      runtime_status: runtimePromoted ? 'passed' : 'not_run',
+      source_contract: {
+        admin_adapter: adminAdapterPath,
+        consumer_service: servicePath,
+        consumer_matrix: consumerMatrixPath,
+      },
+      profiles: { source_verified: sourceVerified, pending },
+      composition: {
+        host_context: 'rustok_api::HostRuntimeContext',
+        native_context: 'NativeContext',
+        shared_value: 'Arc<dyn rustok_blog::CommentsThreadPort>',
+        lookup: 'HostRuntimeContext::shared_get',
+        selector: 'comment_service',
+        injected_constructor: 'CommentService::with_comments_thread_port',
+        fallback_constructor: 'CommentService::new',
+        native_endpoints: [
+          'blog/admin/moderation-comments',
+          'blog/admin/moderate-comment',
+        ],
+        port_operations: [
+          'list_comments_for_target',
+          'get_comment',
+          'set_comment_status',
+        ],
+      },
+      authorization: {
+        tenant_binding: 'AuthContext.tenant_id == TenantContext.id',
+        permission: 'blog_posts:manage',
+        checked_before_port_call: true,
+      },
+      moderation_policy: {
+        read_pagination: 'page >= 1; 1 <= per_page <= 100',
+        error_policy: 'all_blog_errors_propagated',
+        storefront_degradation_reused: false,
+      },
+      harness: {
+        status: 'executable_no_run',
+        runtime_status: 'not_run',
+        source: adminAdapterPath,
+        test: harnessTest,
+        command: harnessCommand,
+      },
+      registration: {
+        standalone_verifier:
+          'scripts/verify/verify-blog-comments-admin-native-port-injection.mjs',
+        focused_fixture:
+          'scripts/verify/verify-blog-comments-admin-native-port-injection.test.mjs',
+        blog_fba_package_chain: registrationPromoted ? 'registered' : 'pending',
+      },
+    }),
+  );
+
+  write(
+    root,
+    planPath,
+    planDrift
+      ? ''
+      : 'blog-comments-admin-native-port-injection.json verify-blog-comments-admin-native-port-injection.mjs verify-blog-comments-admin-native-port-injection.test.mjs admin native SSR Comments host selection is source-locked Blog FBA package-chain registration remains pending remote network transport remains pending Slice 65',
+  );
+
+  return root;
+}
+
+function run(root) {
+  return spawnSync(process.execPath, [verifier], {
+    cwd: path.resolve('.'),
+    env: { ...process.env, RUSTOK_VERIFY_REPO_ROOT: root },
+    encoding: 'utf8',
+  });
+}
+
+function rejects(options) {
+  const root = fixture(options);
+  try {
+    return run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test('accepts the canonical admin native Comments composition boundary', () => {
+  const root = fixture();
+  try {
+    const result = run(root);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects removal of tenant binding', () => {
+  assert.notEqual(rejects({ missingTenantBinding: true }).status, 0);
+});
+
+test('rejects removal of the host shared-value lookup', () => {
+  assert.notEqual(rejects({ missingLookup: true }).status, 0);
+});
+
+test('rejects removal of the injected selector branch', () => {
+  assert.notEqual(rejects({ missingInjected: true }).status, 0);
+});
+
+test('rejects removal of the in-process fallback branch', () => {
+  assert.notEqual(rejects({ missingFallback: true }).status, 0);
+});
+
+test('rejects direct provider construction outside the selector', () => {
+  assert.notEqual(rejects({ directConstruction: true }).status, 0);
+});
+
+test('rejects removal of the moderation-list selector handoff', () => {
+  assert.notEqual(rejects({ missingListHandoff: true }).status, 0);
+});
+
+test('rejects removal of the moderation-mutation selector handoff', () => {
+  assert.notEqual(rejects({ missingMutationHandoff: true }).status, 0);
+});
+
+test('rejects removal of manage permission checks', () => {
+  assert.notEqual(rejects({ missingPermission: true }).status, 0);
+});
+
+test('rejects permission checks after port selection', () => {
+  assert.notEqual(rejects({ permissionAfterSelector: true }).status, 0);
+});
+
+test('rejects broad empty-success fallback for moderation lists', () => {
+  assert.notEqual(rejects({ broadListFallback: true }).status, 0);
+});
+
+test('rejects swallowed moderation mutation errors', () => {
+  assert.notEqual(rejects({ swallowedMutation: true }).status, 0);
+});
+
+test('rejects removal of the compile-only selector harness', () => {
+  assert.notEqual(rejects({ missingHarness: true }).status, 0);
+});
+
+test('rejects runtime promotion without execution', () => {
+  assert.notEqual(rejects({ runtimePromoted: true }).status, 0);
+});
+
+test('rejects remote transport promotion without implementation', () => {
+  assert.notEqual(rejects({ remotePromoted: true }).status, 0);
+});
+
+test('rejects unearned Blog FBA package-chain registration', () => {
+  assert.notEqual(rejects({ registrationPromoted: true }).status, 0);
+});
+
+test('rejects canonical-plan drift', () => {
+  assert.notEqual(rejects({ planDrift: true }).status, 0);
+});


### PR DESCRIPTION
## Summary

- continue the canonical Blog implementation plan through slice 65
- store an optional host-provided `CommentsThreadPort` in the existing admin native `NativeContext`
- centralize injected/in-process selection in one `comment_service(&NativeContext)` helper
- route both moderation list and moderation mutation through the selector
- preserve tenant binding, `blog_posts:manage`, bounded pagination, and fail-closed error propagation
- retain the contract in schema-v1 evidence, a standalone verifier, seventeen focused cases, and a compile-only harness

## Scope and non-claims

This is a source-only admin native composition slice. It does not implement the remote network transport, register the standalone admin guard in the Blog FBA package chain, change package scripts or registry order, degrade admin errors to empty success payloads, or promote runtime/browser evidence.

No Rust or JavaScript test, verifier, formatting, compilation, database, browser, workflow, CI, or production command was run, per maintainer instruction.

## Suggested maintainer commands

```bash
node scripts/verify/verify-blog-comments-admin-native-port-injection.mjs
node --test scripts/verify/verify-blog-comments-admin-native-port-injection.test.mjs
cargo test -p rustok-blog-admin --features ssr \
  transport::native_server_adapter::tests::admin_native_runtime_exposes_comments_port_selection \
  -- --exact
cargo check -p rustok-blog-admin --features ssr
cargo check -p rustok-server --features mod-blog
cargo xtask module validate blog
```

## Branch state

The branch starts from `ffd1c3f47335d7809856737e922b3402c68a9a5c`. Current `main` is ahead only by unrelated Order changes; the proposed diff changes exactly five Blog source/evidence files.