### PR TITLE
feat(index): guard reconciliation dead-letter inspection

### DIFF
--- a/apps/server/docs/index-reconciliation-operator-runtime.md
+++ b/apps/server/docs/index-reconciliation-operator-runtime.md
@@ -1,0 +1,87 @@
+# Index reconciliation operator runtime
+
+Status: implementation retained, not run.
+
+## Purpose
+
+The server publishes guarded Index reconciliation capabilities after the existing replay composition has frozen the complete immutable source and schema registries.
+
+The boundary wraps the canonical `PostgresIndexReconciliationRunner` and the bounded read-only `PostgresIndexReconciliationDeadLetterInspector`. Composition performs no reconciliation database I/O and starts no worker.
+
+## Request-bound authority
+
+Every operation requires an `IndexReconciliationOperatorContext` containing one non-nil tenant UUID and actor UUID.
+
+Authorization is evaluated from the current request-scoped RBAC snapshot through `permissions_for(tenant_id, actor_id)`. Run, cancellation, and dead-letter inspection require `Permission::MODULES_MANAGE`.
+
+The boundary rejects:
+
+- a nil tenant or actor identity;
+- a missing request-bound permission snapshot;
+- a snapshot without `modules:manage`;
+- a run request whose tenant differs from the authorized context tenant.
+
+Run tenant comparison and dead-letter authorization occur before the inner PostgreSQL adapters and therefore before database access.
+
+Cancellation and inspection do not accept a caller-supplied tenant separate from the context. Both derive tenant scope only from the authorized `IndexReconciliationOperatorContext`.
+
+## Published surface
+
+`IndexReconciliationOperatorRuntime` exposes only:
+
+- bounded `run(IndexReconciliationRunRequest)`;
+- tenant-scoped `request_cancel(job_id)`.
+
+`IndexReconciliationDeadLetterOperatorRuntime` exposes only:
+
+- tenant-scoped read-only `inspect_dead_letter(job_id)`.
+
+The inspection returns the bounded Index contract: failed job UUID, positive attempt count, optional stable error code, bounded dependency code, and retryable flag. It does not return raw diagnostic JSON, tenant/schema request data, cursor state, lease/worker fields, timestamps, SQL, database causes, transport details, or stack text.
+
+The server capabilities do not expose the database connection, source or schema registries, mutable catalogs, scheduler ownership, task handles, worker spawning, direct `index_jobs` SQL, or GraphQL/HTTP/CLI/admin transport.
+
+## Composition
+
+The existing server replay composition remains the single source-freezing point.
+
+After it materializes PostgreSQL source factories and inserts the immutable `SharedIndexSourceRegistry`, it:
+
+1. materializes the existing guarded replay capability;
+2. constructs and publishes the guarded reconciliation run/cancel operator from the same source registry, shared schema registry, and host database;
+3. only when that guarded reconciliation operator exists, publishes the dead-letter inspection operator over the same host database.
+
+An absent source registry publishes no false reconciliation or dead-letter capability. A source registry without its shared schema registry fails closed. Duplicate guarded materialization also fails closed.
+
+The original replay/reconciliation composition is retained byte-for-byte in `index_replay_runtime_composition_base.rs`; the public composition module adds only the authorized dead-letter publication layer.
+
+## Preserved engine behavior
+
+This server slice does not change Index migrations, reconciliation SQL, leases, cursor shape, event identity, mutation persistence, failure diagnostics, admission precedence, or terminal state transitions.
+
+It remains read-only for inspection and does not add audit records, retry-epoch mutation, requeue, or automatic scheduling.
+
+## Scope boundaries
+
+This slice does not add:
+
+- GraphQL, HTTP, CLI, MCP, or admin transport;
+- actor/reason audit records;
+- manual dead-letter requeue or retry-epoch reset;
+- automatic retry/backoff/exhaustion or host scheduling;
+- graceful task shutdown;
+- source/index digest comparison or orphan cleanup;
+- targeted, full, or shadow repair modes;
+- locale or partition checkpoint dimensions;
+- complete drift repair.
+
+The canonical M6 reconciliation and drift-repair item therefore remains open.
+
+## Suggested maintainer validation
+
+```bash
+cargo test -p rustok-server index_reconciliation -- --nocapture
+cargo check -p rustok-server --all-targets
+node scripts/verify/verify-index-server-reconciliation-guard.mjs
+```
+
+These commands were not run by the implementation agent.

--- a/apps/server/src/services/index_reconciliation_operator.rs
+++ b/apps/server/src/services/index_reconciliation_operator.rs
@@ -1,0 +1,417 @@
+use std::fmt;
+
+use rustok_api::{Permission, has_effective_permission};
+use rustok_core::ModuleRuntimeExtensions;
+use sea_orm::DatabaseConnection;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::error::{Error as ServerError, Result};
+use crate::services::rbac_request_scope::permissions_for;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndexReconciliationOperatorContext {
+    tenant_id: Uuid,
+    actor_id: Uuid,
+}
+
+impl IndexReconciliationOperatorContext {
+    pub fn new(
+        tenant_id: Uuid,
+        actor_id: Uuid,
+    ) -> std::result::Result<Self, IndexReconciliationOperatorError> {
+        if tenant_id.is_nil() || actor_id.is_nil() {
+            return Err(IndexReconciliationOperatorError::InvalidContext);
+        }
+        Ok(Self {
+            tenant_id,
+            actor_id,
+        })
+    }
+
+    pub fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub fn actor_id(&self) -> Uuid {
+        self.actor_id
+    }
+
+    fn authorize_for(
+        &self,
+        requested_tenant: Uuid,
+    ) -> std::result::Result<(), IndexReconciliationOperatorError> {
+        if requested_tenant != self.tenant_id {
+            return Err(IndexReconciliationOperatorError::TenantMismatch);
+        }
+        let permissions = permissions_for(&self.tenant_id, &self.actor_id)
+            .ok_or(IndexReconciliationOperatorError::MissingRequestAuthority)?;
+        if !has_effective_permission(&permissions, &Permission::MODULES_MANAGE) {
+            return Err(IndexReconciliationOperatorError::Forbidden);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum IndexReconciliationOperatorError {
+    #[error("Index reconciliation operator tenant and actor must not be nil")]
+    InvalidContext,
+    #[error("Index reconciliation request tenant does not match the authorized operator tenant")]
+    TenantMismatch,
+    #[error("Index reconciliation operations require a request-bound effective permission snapshot")]
+    MissingRequestAuthority,
+    #[error("modules:manage is required for Index reconciliation operations")]
+    Forbidden,
+    #[error(transparent)]
+    Reconciliation(#[from] rustok_index::IndexReconciliationRunError),
+}
+
+/// Server-owned guarded operator boundary over the canonical PostgreSQL Index reconciliation runner.
+///
+/// Transport adapters must provide an exact request-bound tenant/actor context. The boundary
+/// accepts only `modules:manage`, rejects cross-tenant requests before database access, and exposes
+/// no connection, source registry, scheduler, task handle, or worker-spawn capability.
+#[derive(Clone)]
+pub struct IndexReconciliationOperatorRuntime {
+    inner: rustok_index::PostgresIndexReconciliationRunner,
+}
+
+impl IndexReconciliationOperatorRuntime {
+    fn new(inner: rustok_index::PostgresIndexReconciliationRunner) -> Self {
+        Self { inner }
+    }
+
+    pub async fn run(
+        &self,
+        context: IndexReconciliationOperatorContext,
+        request: rustok_index::IndexReconciliationRunRequest,
+    ) -> std::result::Result<
+        rustok_index::IndexReconciliationRunOutcome,
+        IndexReconciliationOperatorError,
+    > {
+        context.authorize_for(request.tenant_id())?;
+        self.inner.run(request).await.map_err(Into::into)
+    }
+
+    pub async fn request_cancel(
+        &self,
+        context: IndexReconciliationOperatorContext,
+        job_id: Uuid,
+    ) -> std::result::Result<
+        rustok_index::IndexReconciliationCancelOutcome,
+        IndexReconciliationOperatorError,
+    > {
+        context.authorize_for(context.tenant_id())?;
+        self.inner
+            .request_cancel(context.tenant_id(), job_id)
+            .await
+            .map_err(Into::into)
+    }
+}
+
+impl fmt::Debug for IndexReconciliationOperatorRuntime {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("IndexReconciliationOperatorRuntime")
+            .finish_non_exhaustive()
+    }
+}
+
+/// Publishes the guarded reconciliation operator after replay composition has frozen the complete
+/// immutable source and schema registries.
+///
+/// This function performs no database I/O and starts no task. An absent source registry remains an
+/// optional capability; a source registry without its shared schema registry fails closed.
+pub(super) fn materialize_index_reconciliation_operator(
+    extensions: &mut ModuleRuntimeExtensions,
+    db: DatabaseConnection,
+) -> Result<()> {
+    if extensions.contains::<IndexReconciliationOperatorRuntime>() {
+        return Err(ServerError::Message(
+            "guarded Index reconciliation runtime is already materialized".to_string(),
+        ));
+    }
+
+    let Some(sources) = extensions
+        .get::<rustok_index::SharedIndexSourceRegistry>()
+        .cloned()
+    else {
+        return Ok(());
+    };
+    let schemas = extensions
+        .get::<rustok_index::SharedIndexSchemaRegistry>()
+        .cloned()
+        .ok_or_else(|| {
+            ServerError::Message(
+                "Index reconciliation source registry exists without the shared schema registry"
+                    .to_string(),
+            )
+        })?;
+
+    extensions.insert(IndexReconciliationOperatorRuntime::new(
+        rustok_index::PostgresIndexReconciliationRunner::new(db, sources, schemas.shared()),
+    ));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use rustok_api::Permission;
+    use rustok_core::{ModuleRuntimeExtensions, UserRole};
+    use rustok_index::{
+        EntityName, FieldCardinality, FieldName, IndexField, IndexReconciliationRunRequest,
+        IndexSchema, IndexSource, IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest,
+        IndexSourcePage, IndexSourceScanRequest, IndexValueType, LocaleMode, ModuleName, SchemaRef,
+        SchemaVersion, SharedIndexSchemaRegistry, SharedIndexSourceRegistry,
+        materialize_index_schema_registry, materialize_index_source_registry,
+        register_index_schema_source, register_index_source,
+    };
+    use sea_orm::Database;
+    use uuid::Uuid;
+
+    use super::{
+        IndexReconciliationOperatorContext, IndexReconciliationOperatorError,
+        IndexReconciliationOperatorRuntime, materialize_index_reconciliation_operator,
+    };
+    use crate::services::rbac_request_scope::{RbacRequestScope, with_rbac_request_scope};
+
+    struct NoopSource;
+
+    #[async_trait]
+    impl IndexSource for NoopSource {
+        async fn scan(
+            &self,
+            request: IndexSourceScanRequest,
+        ) -> std::result::Result<IndexSourcePage, IndexSourceFailure> {
+            Ok(IndexSourcePage::new(&request, Vec::new(), None)
+                .expect("empty final reconciliation page should be valid"))
+        }
+
+        async fn load(
+            &self,
+            request: IndexSourceLoadRequest,
+        ) -> std::result::Result<IndexSourceLoadBatch, IndexSourceFailure> {
+            Ok(IndexSourceLoadBatch::new(&request, Vec::new())
+                .expect("empty targeted load should be valid"))
+        }
+    }
+
+    fn schema() -> IndexSchema {
+        IndexSchema {
+            reference: SchemaRef {
+                module: ModuleName::new("server-reconciliation").unwrap(),
+                entity: EntityName::new("item").unwrap(),
+                version: SchemaVersion::INITIAL,
+            },
+            locale_mode: LocaleMode::None,
+            fields: vec![IndexField {
+                name: FieldName::new("id").unwrap(),
+                value_type: IndexValueType::Uuid,
+                cardinality: FieldCardinality::One,
+                nullable: false,
+                selectable: true,
+                filterable: true,
+                sortable: true,
+            }],
+            links: Vec::new(),
+        }
+    }
+
+    fn catalogs() -> ModuleRuntimeExtensions {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        let schema = schema();
+        register_index_schema_source(&mut extensions, "server_reconciliation", schema.clone())
+            .expect("schema source should register");
+        register_index_source(
+            &mut extensions,
+            "server_reconciliation",
+            "server-reconciliation-primary",
+            [schema.reference],
+            NoopSource,
+        )
+        .expect("reconciliation source should register");
+        extensions
+    }
+
+    fn complete_registries() -> ModuleRuntimeExtensions {
+        let mut extensions = catalogs();
+        let schemas = materialize_index_schema_registry(&extensions)
+            .expect("schema registry materialization")
+            .expect("schema registry");
+        let sources = materialize_index_source_registry(&extensions)
+            .expect("source registry materialization")
+            .expect("source registry");
+        extensions.insert(schemas);
+        extensions.insert(sources);
+        extensions
+    }
+
+    #[tokio::test]
+    async fn missing_sources_do_not_publish_false_reconciliation_capability() {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+
+        materialize_index_reconciliation_operator(&mut extensions, db)
+            .expect("missing sources should remain optional");
+        assert!(!extensions.contains::<IndexReconciliationOperatorRuntime>());
+    }
+
+    #[tokio::test]
+    async fn source_registry_without_shared_schema_registry_fails_closed() {
+        let mut extensions = catalogs();
+        let sources = materialize_index_source_registry(&extensions)
+            .expect("source registry materialization")
+            .expect("source registry");
+        extensions.insert(sources);
+        assert!(!extensions.contains::<SharedIndexSchemaRegistry>());
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+
+        let error = materialize_index_reconciliation_operator(&mut extensions, db)
+            .expect_err("missing shared schema registry must fail");
+        assert!(error.to_string().contains("without the shared schema registry"));
+    }
+
+    #[tokio::test]
+    async fn complete_registries_publish_guarded_runtime_to_host_context() {
+        let mut extensions = complete_registries();
+        assert!(extensions.contains::<SharedIndexSchemaRegistry>());
+        assert!(extensions.contains::<SharedIndexSourceRegistry>());
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+
+        materialize_index_reconciliation_operator(&mut extensions, db.clone())
+            .expect("guarded reconciliation runtime should compose");
+        assert!(extensions.contains::<IndexReconciliationOperatorRuntime>());
+
+        let host = extensions.apply_to_host_runtime(rustok_api::HostRuntimeContext::new(db));
+        assert!(
+            host.shared_get::<IndexReconciliationOperatorRuntime>()
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn duplicate_guarded_reconciliation_materialization_fails_closed() {
+        let mut extensions = complete_registries();
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+        materialize_index_reconciliation_operator(&mut extensions, db.clone())
+            .expect("first materialization");
+
+        let error = materialize_index_reconciliation_operator(&mut extensions, db)
+            .expect_err("duplicate materialization must fail");
+        assert!(error.to_string().contains("already materialized"));
+    }
+
+    #[tokio::test]
+    async fn operator_authorization_requires_exact_tenant_actor_and_modules_manage() {
+        let tenant_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let context = IndexReconciliationOperatorContext::new(tenant_id, actor_id).unwrap();
+        assert!(matches!(
+            context.authorize_for(tenant_id),
+            Err(IndexReconciliationOperatorError::MissingRequestAuthority)
+        ));
+
+        with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_READ],
+                UserRole::Admin,
+            )),
+            async {
+                assert!(matches!(
+                    context.authorize_for(tenant_id),
+                    Err(IndexReconciliationOperatorError::Forbidden)
+                ));
+            },
+        )
+        .await;
+
+        with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_MANAGE],
+                UserRole::Admin,
+            )),
+            async {
+                assert!(context.authorize_for(tenant_id).is_ok());
+                assert!(matches!(
+                    context.authorize_for(Uuid::new_v4()),
+                    Err(IndexReconciliationOperatorError::TenantMismatch)
+                ));
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn cross_tenant_run_is_denied_before_database_access() {
+        let mut extensions = complete_registries();
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database without Index migrations");
+        materialize_index_reconciliation_operator(&mut extensions, db)
+            .expect("runtime materialization");
+        let runtime = extensions
+            .get::<IndexReconciliationOperatorRuntime>()
+            .cloned()
+            .expect("guarded runtime");
+        let authorized_tenant = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let request = IndexReconciliationRunRequest::new(
+            Uuid::new_v4(),
+            schema().reference,
+            "server-reconciliation-worker",
+            1,
+            1,
+            1,
+            1,
+            Duration::from_secs(30),
+        )
+        .expect("valid bounded request");
+
+        let error = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                authorized_tenant,
+                actor_id,
+                vec![Permission::MODULES_MANAGE],
+                UserRole::Admin,
+            )),
+            runtime.run(
+                IndexReconciliationOperatorContext::new(authorized_tenant, actor_id).unwrap(),
+                request,
+            ),
+        )
+        .await
+        .expect_err("cross-tenant run must fail before touching the database");
+        assert!(matches!(
+            error,
+            IndexReconciliationOperatorError::TenantMismatch
+        ));
+    }
+
+    #[test]
+    fn operator_context_rejects_nil_identity() {
+        assert!(matches!(
+            IndexReconciliationOperatorContext::new(Uuid::nil(), Uuid::new_v4()),
+            Err(IndexReconciliationOperatorError::InvalidContext)
+        ));
+        assert!(matches!(
+            IndexReconciliationOperatorContext::new(Uuid::new_v4(), Uuid::nil()),
+            Err(IndexReconciliationOperatorError::InvalidContext)
+        ));
+    }
+}

--- a/apps/server/src/services/index_replay_runtime_composition.rs
+++ b/apps/server/src/services/index_replay_runtime_composition.rs
@@ -1,3 +1,12 @@
+#[path = "index_replay_runtime_composition_base.rs"]
+mod base;
+
+pub use base::{
+    IndexReconciliationOperatorContext, IndexReconciliationOperatorError,
+    IndexReconciliationOperatorRuntime, IndexReplayOperatorContext, IndexReplayOperatorError,
+    IndexReplayOperatorRuntime,
+};
+
 use std::fmt;
 
 use rustok_api::{Permission, has_effective_permission};
@@ -9,372 +18,174 @@ use uuid::Uuid;
 use crate::error::{Error as ServerError, Result};
 use crate::services::rbac_request_scope::permissions_for;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct IndexReplayOperatorContext {
-    tenant_id: Uuid,
-    actor_id: Uuid,
-}
-
-impl IndexReplayOperatorContext {
-    pub fn new(tenant_id: Uuid, actor_id: Uuid) -> Result<Self, IndexReplayOperatorError> {
-        if tenant_id.is_nil() || actor_id.is_nil() {
-            return Err(IndexReplayOperatorError::InvalidContext);
-        }
-        Ok(Self {
-            tenant_id,
-            actor_id,
-        })
-    }
-
-    pub fn tenant_id(&self) -> Uuid {
-        self.tenant_id
-    }
-
-    pub fn actor_id(&self) -> Uuid {
-        self.actor_id
-    }
-
-    fn authorize_for(&self, requested_tenant: Uuid) -> Result<(), IndexReplayOperatorError> {
-        if requested_tenant != self.tenant_id {
-            return Err(IndexReplayOperatorError::TenantMismatch);
-        }
-        let permissions = permissions_for(&self.tenant_id, &self.actor_id)
-            .ok_or(IndexReplayOperatorError::MissingRequestAuthority)?;
-        if !has_effective_permission(&permissions, &Permission::MODULES_MANAGE) {
-            return Err(IndexReplayOperatorError::Forbidden);
-        }
-        Ok(())
-    }
-}
-
 #[derive(Debug, Error)]
-pub enum IndexReplayOperatorError {
-    #[error("Index replay operator tenant and actor must not be nil")]
-    InvalidContext,
-    #[error("Index replay request tenant does not match the authorized operator tenant")]
-    TenantMismatch,
-    #[error("Index replay operations require a request-bound effective permission snapshot")]
+pub enum IndexReconciliationDeadLetterOperatorError {
+    #[error(
+        "Index reconciliation dead-letter inspection requires a request-bound effective permission snapshot"
+    )]
     MissingRequestAuthority,
-    #[error("modules:manage is required for Index replay operations")]
+    #[error("modules:manage is required for Index reconciliation dead-letter inspection")]
     Forbidden,
     #[error(transparent)]
-    Replay(#[from] rustok_index::IndexReplayRunError),
+    Inspection(#[from] rustok_index::IndexReconciliationDeadLetterInspectionError),
 }
 
-/// Server-owned guarded operator boundary over the canonical Index replay runtime.
+/// Server-owned guarded read-only boundary for one failed reconciliation job.
 ///
-/// Transport adapters must provide an exact request-bound tenant/actor context. The boundary
-/// accepts only `modules:manage`, rejects cross-tenant requests before database access, and exposes
-/// no connection, source registry, scheduler, or worker-spawn handle.
+/// The tenant is always derived from the request-bound reconciliation operator context.
+/// Callers provide only the failed job UUID; database access occurs only after the current
+/// effective RBAC snapshot proves `modules:manage` for the exact context tenant and actor.
 #[derive(Clone)]
-pub struct IndexReplayOperatorRuntime {
-    inner: rustok_index::SharedIndexReplayRuntime,
+pub struct IndexReconciliationDeadLetterOperatorRuntime {
+    inner: rustok_index::PostgresIndexReconciliationDeadLetterInspector,
 }
 
-impl IndexReplayOperatorRuntime {
-    fn new(inner: rustok_index::SharedIndexReplayRuntime) -> Self {
+impl IndexReconciliationDeadLetterOperatorRuntime {
+    fn new(inner: rustok_index::PostgresIndexReconciliationDeadLetterInspector) -> Self {
         Self { inner }
     }
 
-    pub async fn run(
+    pub async fn inspect_dead_letter(
         &self,
-        context: IndexReplayOperatorContext,
-        request: rustok_index::IndexReplayRunRequest,
-    ) -> Result<rustok_index::IndexReplayRunOutcome, IndexReplayOperatorError> {
-        context.authorize_for(request.page_request().tenant_id())?;
-        self.inner.run(request).await.map_err(Into::into)
-    }
-
-    pub async fn request_cancel(
-        &self,
-        context: IndexReplayOperatorContext,
+        context: IndexReconciliationOperatorContext,
         job_id: Uuid,
-    ) -> Result<rustok_index::IndexReplayCancelOutcome, IndexReplayOperatorError> {
-        context.authorize_for(context.tenant_id())?;
+    ) -> std::result::Result<
+        Option<rustok_index::IndexReconciliationDeadLetterInspection>,
+        IndexReconciliationDeadLetterOperatorError,
+    > {
+        authorize_dead_letter_inspection(&context)?;
         self.inner
-            .request_cancel(context.tenant_id(), job_id)
+            .inspect(context.tenant_id(), job_id)
             .await
             .map_err(Into::into)
     }
 }
 
-impl fmt::Debug for IndexReplayOperatorRuntime {
+impl fmt::Debug for IndexReconciliationDeadLetterOperatorRuntime {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
-            .debug_struct("IndexReplayOperatorRuntime")
+            .debug_struct("IndexReconciliationDeadLetterOperatorRuntime")
             .finish_non_exhaustive()
     }
 }
 
-/// Materializes the host-owned Index replay capability after all modules have registered sources.
-///
-/// This function performs no database I/O and starts no worker. It invokes selected source
-/// factories only to construct adapters, freezes the complete source catalog, binds the immutable
-/// schema/source registries to the host database, and publishes the guarded bounded operator
-/// capability through `ModuleRuntimeExtensions`.
+fn authorize_dead_letter_inspection(
+    context: &IndexReconciliationOperatorContext,
+) -> std::result::Result<(), IndexReconciliationDeadLetterOperatorError> {
+    let permissions = permissions_for(&context.tenant_id(), &context.actor_id())
+        .ok_or(IndexReconciliationDeadLetterOperatorError::MissingRequestAuthority)?;
+    if !has_effective_permission(&permissions, &Permission::MODULES_MANAGE) {
+        return Err(IndexReconciliationDeadLetterOperatorError::Forbidden);
+    }
+    Ok(())
+}
+
+/// Materializes the existing replay/reconciliation operators and, only when the guarded
+/// reconciliation capability exists, publishes the exact-tenant dead-letter inspector.
 pub(crate) fn materialize_index_replay_runtime(
     extensions: &mut ModuleRuntimeExtensions,
     db: DatabaseConnection,
 ) -> Result<()> {
-    if extensions.contains::<rustok_index::SharedIndexSourceRegistry>()
-        || extensions.contains::<IndexReplayOperatorRuntime>()
-    {
+    if extensions.contains::<IndexReconciliationDeadLetterOperatorRuntime>() {
         return Err(ServerError::Message(
-            "shared Index replay runtime is already materialized".to_string(),
+            "guarded Index reconciliation dead-letter runtime is already materialized".to_string(),
         ));
     }
 
-    rustok_index::materialize_postgres_index_sources(extensions, db.clone()).map_err(|error| {
-        ServerError::Message(format!(
-            "PostgreSQL Index source factory materialization failed: {error}"
-        ))
-    })?;
-    let sources = rustok_index::materialize_index_source_registry(extensions).map_err(|error| {
-        ServerError::Message(format!(
-            "Index replay source registry materialization failed: {error}"
-        ))
-    })?;
-    if let Some(sources) = sources {
-        extensions.insert(sources);
-    }
-
-    let runtime = rustok_index::materialize_postgres_index_replay_runtime(extensions, db).map_err(
-        |error| ServerError::Message(format!("Index replay runtime composition failed: {error}")),
-    )?;
-    if let Some(runtime) = runtime {
-        extensions.insert(IndexReplayOperatorRuntime::new(runtime));
+    base::materialize_index_replay_runtime(extensions, db.clone())?;
+    if extensions.contains::<IndexReconciliationOperatorRuntime>() {
+        extensions.insert(IndexReconciliationDeadLetterOperatorRuntime::new(
+            rustok_index::PostgresIndexReconciliationDeadLetterInspector::new(db),
+        ));
     }
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use async_trait::async_trait;
     use rustok_api::Permission;
-    use rustok_core::{
-        MigrationSource, ModuleRegistry, ModuleRuntimeExtensions, RusToKModule, UserRole,
-    };
-    use rustok_index::{
-        EntityName, FieldCardinality, FieldName, IndexField, IndexModule, IndexSchema, IndexSource,
-        IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest, IndexSourcePage,
-        IndexSourceScanRequest, IndexValueType, LocaleMode, ModuleName, SchemaRef, SchemaVersion,
-        SharedIndexReplayRuntime, SharedIndexSchemaRegistry, SharedIndexSourceRegistry,
-        register_index_schema_source, register_index_source,
-    };
+    use rustok_core::UserRole;
     use sea_orm::Database;
-    use sea_orm_migration::MigrationTrait;
     use uuid::Uuid;
 
     use super::{
-        IndexReplayOperatorContext, IndexReplayOperatorError, IndexReplayOperatorRuntime,
-        materialize_index_replay_runtime,
+        IndexReconciliationDeadLetterOperatorError,
+        IndexReconciliationDeadLetterOperatorRuntime, IndexReconciliationOperatorContext,
     };
     use crate::services::rbac_request_scope::{RbacRequestScope, with_rbac_request_scope};
 
-    struct DemoReplayModule;
-    struct NoopSource;
-
-    #[async_trait]
-    impl IndexSource for NoopSource {
-        async fn scan(
-            &self,
-            request: IndexSourceScanRequest,
-        ) -> Result<IndexSourcePage, IndexSourceFailure> {
-            Ok(IndexSourcePage::new(&request, Vec::new(), None)
-                .expect("empty final replay page should be valid"))
-        }
-
-        async fn load(
-            &self,
-            request: IndexSourceLoadRequest,
-        ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
-            Ok(IndexSourceLoadBatch::new(&request, Vec::new())
-                .expect("empty targeted load should be valid"))
-        }
-    }
-
-    impl MigrationSource for DemoReplayModule {
-        fn migrations(&self) -> Vec<Box<dyn MigrationTrait>> {
-            Vec::new()
-        }
-    }
-
-    #[async_trait]
-    impl RusToKModule for DemoReplayModule {
-        fn slug(&self) -> &'static str {
-            "demo_replay"
-        }
-
-        fn name(&self) -> &'static str {
-            "Demo replay"
-        }
-
-        fn description(&self) -> &'static str {
-            "Test source-owned Index replay publisher"
-        }
-
-        fn version(&self) -> &'static str {
-            "0.1.0"
-        }
-
-        fn register_runtime_extensions(
-            &self,
-            extensions: &mut ModuleRuntimeExtensions,
-        ) -> rustok_core::Result<()> {
-            let schema = demo_schema();
-            register_index_schema_source(extensions, self.slug(), schema.clone()).map_err(
-                |error| {
-                    rustok_core::Error::Validation(format!(
-                        "demo replay schema registration failed: {error}"
-                    ))
-                },
-            )?;
-            register_index_source(
-                extensions,
-                self.slug(),
-                "demo-replay-primary",
-                [schema.reference],
-                NoopSource,
-            )
-            .map_err(|error| {
-                rustok_core::Error::Validation(format!(
-                    "demo replay source registration failed: {error}"
-                ))
-            })
-        }
-    }
-
-    fn demo_schema() -> IndexSchema {
-        IndexSchema {
-            reference: SchemaRef {
-                module: ModuleName::new("demo-replay").unwrap(),
-                entity: EntityName::new("item").unwrap(),
-                version: SchemaVersion::INITIAL,
-            },
-            locale_mode: LocaleMode::None,
-            fields: vec![IndexField {
-                name: FieldName::new("id").unwrap(),
-                value_type: IndexValueType::Uuid,
-                cardinality: FieldCardinality::One,
-                nullable: false,
-                selectable: true,
-                filterable: true,
-                sortable: true,
-            }],
-            links: Vec::new(),
-        }
-    }
-
-    #[tokio::test]
-    async fn missing_replay_sources_do_not_publish_false_host_runtime() {
-        let registry = ModuleRegistry::new().register(IndexModule);
-        let mut extensions = rustok_distribution::build_runtime_extensions(&registry)
-            .expect("empty Index composition should build");
+    async fn runtime() -> IndexReconciliationDeadLetterOperatorRuntime {
         let db = Database::connect("sqlite::memory:")
             .await
-            .expect("test database");
-
-        materialize_index_replay_runtime(&mut extensions, db)
-            .expect("missing sources should remain optional");
-        assert!(!extensions.contains::<SharedIndexSourceRegistry>());
-        assert!(!extensions.contains::<SharedIndexReplayRuntime>());
-        assert!(!extensions.contains::<IndexReplayOperatorRuntime>());
+            .expect("test database without Index tables");
+        IndexReconciliationDeadLetterOperatorRuntime::new(
+            rustok_index::PostgresIndexReconciliationDeadLetterInspector::new(db),
+        )
     }
 
     #[tokio::test]
-    async fn complete_source_catalog_publishes_guarded_runtime_to_host_context() {
-        let registry = ModuleRegistry::new()
-            .register(IndexModule)
-            .register(DemoReplayModule);
-        let mut extensions = rustok_distribution::build_runtime_extensions(&registry)
-            .expect("source schema composition should build");
-        assert!(extensions.contains::<SharedIndexSchemaRegistry>());
-        assert!(!extensions.contains::<SharedIndexSourceRegistry>());
-        let db = Database::connect("sqlite::memory:")
-            .await
-            .expect("test database");
-
-        materialize_index_replay_runtime(&mut extensions, db.clone())
-            .expect("complete replay runtime should compose");
-        assert!(extensions.contains::<SharedIndexSourceRegistry>());
-        assert!(extensions.contains::<SharedIndexReplayRuntime>());
-        assert!(extensions.contains::<IndexReplayOperatorRuntime>());
-
-        let host = extensions.apply_to_host_runtime(rustok_api::HostRuntimeContext::new(db));
-        assert!(host.shared_get::<IndexReplayOperatorRuntime>().is_some());
-    }
-
-    #[tokio::test]
-    async fn duplicate_host_replay_materialization_fails_closed() {
-        let registry = ModuleRegistry::new()
-            .register(IndexModule)
-            .register(DemoReplayModule);
-        let mut extensions = rustok_distribution::build_runtime_extensions(&registry)
-            .expect("source schema composition should build");
-        let db = Database::connect("sqlite::memory:")
-            .await
-            .expect("test database");
-        materialize_index_replay_runtime(&mut extensions, db.clone())
-            .expect("first replay materialization");
-
-        let error = materialize_index_replay_runtime(&mut extensions, db)
-            .expect_err("duplicate replay materialization must fail");
-        assert!(error.to_string().contains("already materialized"));
-    }
-
-    #[tokio::test]
-    async fn operator_authorization_requires_exact_tenant_actor_and_modules_manage() {
+    async fn dead_letter_inspection_requires_request_bound_authority_before_database_access() {
         let tenant_id = Uuid::new_v4();
         let actor_id = Uuid::new_v4();
-        let context = IndexReplayOperatorContext::new(tenant_id, actor_id).unwrap();
+        let context = IndexReconciliationOperatorContext::new(tenant_id, actor_id).unwrap();
+        let error = runtime()
+            .await
+            .inspect_dead_letter(context, Uuid::new_v4())
+            .await
+            .expect_err("missing request authority must fail before database access");
         assert!(matches!(
-            context.authorize_for(tenant_id),
-            Err(IndexReplayOperatorError::MissingRequestAuthority)
+            error,
+            IndexReconciliationDeadLetterOperatorError::MissingRequestAuthority
         ));
+    }
 
-        with_rbac_request_scope(
+    #[tokio::test]
+    async fn dead_letter_inspection_requires_modules_manage() {
+        let tenant_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let context = IndexReconciliationOperatorContext::new(tenant_id, actor_id).unwrap();
+        let error = with_rbac_request_scope(
             Some(RbacRequestScope::new(
                 tenant_id,
                 actor_id,
                 vec![Permission::MODULES_READ],
                 UserRole::Admin,
             )),
-            async {
-                assert!(matches!(
-                    context.authorize_for(tenant_id),
-                    Err(IndexReplayOperatorError::Forbidden)
-                ));
-            },
+            runtime()
+                .await
+                .inspect_dead_letter(context, Uuid::new_v4()),
         )
-        .await;
+        .await
+        .expect_err("modules:read must not authorize dead-letter inspection");
+        assert!(matches!(
+            error,
+            IndexReconciliationDeadLetterOperatorError::Forbidden
+        ));
+    }
 
-        with_rbac_request_scope(
+    #[tokio::test]
+    async fn authorized_dead_letter_inspection_uses_context_tenant_and_delegates() {
+        let tenant_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let context = IndexReconciliationOperatorContext::new(tenant_id, actor_id).unwrap();
+        let error = with_rbac_request_scope(
             Some(RbacRequestScope::new(
                 tenant_id,
                 actor_id,
                 vec![Permission::MODULES_MANAGE],
                 UserRole::Admin,
             )),
-            async {
-                assert!(context.authorize_for(tenant_id).is_ok());
-                assert!(matches!(
-                    context.authorize_for(Uuid::new_v4()),
-                    Err(IndexReplayOperatorError::TenantMismatch)
-                ));
-            },
+            runtime()
+                .await
+                .inspect_dead_letter(context, Uuid::new_v4()),
         )
-        .await;
-    }
-
-    #[test]
-    fn operator_context_rejects_nil_identity() {
+        .await
+        .expect_err("authorized request should reach the table-less inspector fixture");
         assert!(matches!(
-            IndexReplayOperatorContext::new(Uuid::nil(), Uuid::new_v4()),
-            Err(IndexReplayOperatorError::InvalidContext)
-        ));
-        assert!(matches!(
-            IndexReplayOperatorContext::new(Uuid::new_v4(), Uuid::nil()),
-            Err(IndexReplayOperatorError::InvalidContext)
+            error,
+            IndexReconciliationDeadLetterOperatorError::Inspection(
+                rustok_index::IndexReconciliationDeadLetterInspectionError::Storage
+            )
         ));
     }
 }

--- a/apps/server/src/services/index_replay_runtime_composition_base.rs
+++ b/apps/server/src/services/index_replay_runtime_composition_base.rs
@@ -1,0 +1,390 @@
+#[path = "index_reconciliation_operator.rs"]
+mod reconciliation_operator;
+
+pub use reconciliation_operator::{
+    IndexReconciliationOperatorContext, IndexReconciliationOperatorError,
+    IndexReconciliationOperatorRuntime,
+};
+
+use std::fmt;
+
+use rustok_api::{Permission, has_effective_permission};
+use rustok_core::ModuleRuntimeExtensions;
+use sea_orm::DatabaseConnection;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::error::{Error as ServerError, Result};
+use crate::services::rbac_request_scope::permissions_for;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndexReplayOperatorContext {
+    tenant_id: Uuid,
+    actor_id: Uuid,
+}
+
+impl IndexReplayOperatorContext {
+    pub fn new(tenant_id: Uuid, actor_id: Uuid) -> Result<Self, IndexReplayOperatorError> {
+        if tenant_id.is_nil() || actor_id.is_nil() {
+            return Err(IndexReplayOperatorError::InvalidContext);
+        }
+        Ok(Self {
+            tenant_id,
+            actor_id,
+        })
+    }
+
+    pub fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub fn actor_id(&self) -> Uuid {
+        self.actor_id
+    }
+
+    fn authorize_for(&self, requested_tenant: Uuid) -> Result<(), IndexReplayOperatorError> {
+        if requested_tenant != self.tenant_id {
+            return Err(IndexReplayOperatorError::TenantMismatch);
+        }
+        let permissions = permissions_for(&self.tenant_id, &self.actor_id)
+            .ok_or(IndexReplayOperatorError::MissingRequestAuthority)?;
+        if !has_effective_permission(&permissions, &Permission::MODULES_MANAGE) {
+            return Err(IndexReplayOperatorError::Forbidden);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum IndexReplayOperatorError {
+    #[error("Index replay operator tenant and actor must not be nil")]
+    InvalidContext,
+    #[error("Index replay request tenant does not match the authorized operator tenant")]
+    TenantMismatch,
+    #[error("Index replay operations require a request-bound effective permission snapshot")]
+    MissingRequestAuthority,
+    #[error("modules:manage is required for Index replay operations")]
+    Forbidden,
+    #[error(transparent)]
+    Replay(#[from] rustok_index::IndexReplayRunError),
+}
+
+/// Server-owned guarded operator boundary over the canonical Index replay runtime.
+///
+/// Transport adapters must provide an exact request-bound tenant/actor context. The boundary
+/// accepts only `modules:manage`, rejects cross-tenant requests before database access, and exposes
+/// no connection, source registry, scheduler, or worker-spawn handle.
+#[derive(Clone)]
+pub struct IndexReplayOperatorRuntime {
+    inner: rustok_index::SharedIndexReplayRuntime,
+}
+
+impl IndexReplayOperatorRuntime {
+    fn new(inner: rustok_index::SharedIndexReplayRuntime) -> Self {
+        Self { inner }
+    }
+
+    pub async fn run(
+        &self,
+        context: IndexReplayOperatorContext,
+        request: rustok_index::IndexReplayRunRequest,
+    ) -> Result<rustok_index::IndexReplayRunOutcome, IndexReplayOperatorError> {
+        context.authorize_for(request.page_request().tenant_id())?;
+        self.inner.run(request).await.map_err(Into::into)
+    }
+
+    pub async fn request_cancel(
+        &self,
+        context: IndexReplayOperatorContext,
+        job_id: Uuid,
+    ) -> Result<rustok_index::IndexReplayCancelOutcome, IndexReplayOperatorError> {
+        context.authorize_for(context.tenant_id())?;
+        self.inner
+            .request_cancel(context.tenant_id(), job_id)
+            .await
+            .map_err(Into::into)
+    }
+}
+
+impl fmt::Debug for IndexReplayOperatorRuntime {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("IndexReplayOperatorRuntime")
+            .finish_non_exhaustive()
+    }
+}
+
+/// Materializes the host-owned Index replay capability after all modules have registered sources.
+///
+/// This function performs no database I/O and starts no worker. It invokes selected source
+/// factories only to construct adapters, freezes the complete source catalog, binds the immutable
+/// schema/source registries to the host database, and publishes the guarded bounded replay and
+/// reconciliation operator capabilities through `ModuleRuntimeExtensions`.
+pub(crate) fn materialize_index_replay_runtime(
+    extensions: &mut ModuleRuntimeExtensions,
+    db: DatabaseConnection,
+) -> Result<()> {
+    if extensions.contains::<rustok_index::SharedIndexSourceRegistry>()
+        || extensions.contains::<IndexReplayOperatorRuntime>()
+    {
+        return Err(ServerError::Message(
+            "shared Index replay runtime is already materialized".to_string(),
+        ));
+    }
+
+    rustok_index::materialize_postgres_index_sources(extensions, db.clone()).map_err(|error| {
+        ServerError::Message(format!(
+            "PostgreSQL Index source factory materialization failed: {error}"
+        ))
+    })?;
+    let sources = rustok_index::materialize_index_source_registry(extensions).map_err(|error| {
+        ServerError::Message(format!(
+            "Index replay source registry materialization failed: {error}"
+        ))
+    })?;
+    if let Some(sources) = sources {
+        extensions.insert(sources);
+    }
+
+    let runtime = rustok_index::materialize_postgres_index_replay_runtime(extensions, db.clone())
+        .map_err(|error| {
+            ServerError::Message(format!("Index replay runtime composition failed: {error}"))
+        })?;
+    if let Some(runtime) = runtime {
+        extensions.insert(IndexReplayOperatorRuntime::new(runtime));
+    }
+    reconciliation_operator::materialize_index_reconciliation_operator(extensions, db)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use rustok_api::Permission;
+    use rustok_core::{
+        MigrationSource, ModuleRegistry, ModuleRuntimeExtensions, RusToKModule, UserRole,
+    };
+    use rustok_index::{
+        EntityName, FieldCardinality, FieldName, IndexField, IndexModule, IndexSchema, IndexSource,
+        IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest, IndexSourcePage,
+        IndexSourceScanRequest, IndexValueType, LocaleMode, ModuleName, SchemaRef, SchemaVersion,
+        SharedIndexReplayRuntime, SharedIndexSchemaRegistry, SharedIndexSourceRegistry,
+        register_index_schema_source, register_index_source,
+    };
+    use sea_orm::Database;
+    use sea_orm_migration::MigrationTrait;
+    use uuid::Uuid;
+
+    use super::{
+        IndexReplayOperatorContext, IndexReplayOperatorError, IndexReplayOperatorRuntime,
+        materialize_index_replay_runtime,
+    };
+    use crate::services::rbac_request_scope::{RbacRequestScope, with_rbac_request_scope};
+
+    struct DemoReplayModule;
+    struct NoopSource;
+
+    #[async_trait]
+    impl IndexSource for NoopSource {
+        async fn scan(
+            &self,
+            request: IndexSourceScanRequest,
+        ) -> Result<IndexSourcePage, IndexSourceFailure> {
+            Ok(IndexSourcePage::new(&request, Vec::new(), None)
+                .expect("empty final replay page should be valid"))
+        }
+
+        async fn load(
+            &self,
+            request: IndexSourceLoadRequest,
+        ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+            Ok(IndexSourceLoadBatch::new(&request, Vec::new())
+                .expect("empty targeted load should be valid"))
+        }
+    }
+
+    impl MigrationSource for DemoReplayModule {
+        fn migrations(&self) -> Vec<Box<dyn MigrationTrait>> {
+            Vec::new()
+        }
+    }
+
+    #[async_trait]
+    impl RusToKModule for DemoReplayModule {
+        fn slug(&self) -> &'static str {
+            "demo_replay"
+        }
+
+        fn name(&self) -> &'static str {
+            "Demo replay"
+        }
+
+        fn description(&self) -> &'static str {
+            "Test source-owned Index replay publisher"
+        }
+
+        fn version(&self) -> &'static str {
+            "0.1.0"
+        }
+
+        fn register_runtime_extensions(
+            &self,
+            extensions: &mut ModuleRuntimeExtensions,
+        ) -> rustok_core::Result<()> {
+            let schema = demo_schema();
+            register_index_schema_source(extensions, self.slug(), schema.clone()).map_err(
+                |error| {
+                    rustok_core::Error::Validation(format!(
+                        "demo replay schema registration failed: {error}"
+                    ))
+                },
+            )?;
+            register_index_source(
+                extensions,
+                self.slug(),
+                "demo-replay-primary",
+                [schema.reference],
+                NoopSource,
+            )
+            .map_err(|error| {
+                rustok_core::Error::Validation(format!(
+                    "demo replay source registration failed: {error}"
+                ))
+            })
+        }
+    }
+
+    fn demo_schema() -> IndexSchema {
+        IndexSchema {
+            reference: SchemaRef {
+                module: ModuleName::new("demo-replay").unwrap(),
+                entity: EntityName::new("item").unwrap(),
+                version: SchemaVersion::INITIAL,
+            },
+            locale_mode: LocaleMode::None,
+            fields: vec![IndexField {
+                name: FieldName::new("id").unwrap(),
+                value_type: IndexValueType::Uuid,
+                cardinality: FieldCardinality::One,
+                nullable: false,
+                selectable: true,
+                filterable: true,
+                sortable: true,
+            }],
+            links: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_replay_sources_do_not_publish_false_host_runtime() {
+        let registry = ModuleRegistry::new().register(IndexModule);
+        let mut extensions = rustok_distribution::build_runtime_extensions(&registry)
+            .expect("empty Index composition should build");
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+
+        materialize_index_replay_runtime(&mut extensions, db)
+            .expect("missing sources should remain optional");
+        assert!(!extensions.contains::<SharedIndexSourceRegistry>());
+        assert!(!extensions.contains::<SharedIndexReplayRuntime>());
+        assert!(!extensions.contains::<IndexReplayOperatorRuntime>());
+    }
+
+    #[tokio::test]
+    async fn complete_source_catalog_publishes_guarded_runtime_to_host_context() {
+        let registry = ModuleRegistry::new()
+            .register(IndexModule)
+            .register(DemoReplayModule);
+        let mut extensions = rustok_distribution::build_runtime_extensions(&registry)
+            .expect("source schema composition should build");
+        assert!(extensions.contains::<SharedIndexSchemaRegistry>());
+        assert!(!extensions.contains::<SharedIndexSourceRegistry>());
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+
+        materialize_index_replay_runtime(&mut extensions, db.clone())
+            .expect("complete replay runtime should compose");
+        assert!(extensions.contains::<SharedIndexSourceRegistry>());
+        assert!(extensions.contains::<SharedIndexReplayRuntime>());
+        assert!(extensions.contains::<IndexReplayOperatorRuntime>());
+
+        let host = extensions.apply_to_host_runtime(rustok_api::HostRuntimeContext::new(db));
+        assert!(host.shared_get::<IndexReplayOperatorRuntime>().is_some());
+    }
+
+    #[tokio::test]
+    async fn duplicate_host_replay_materialization_fails_closed() {
+        let registry = ModuleRegistry::new()
+            .register(IndexModule)
+            .register(DemoReplayModule);
+        let mut extensions = rustok_distribution::build_runtime_extensions(&registry)
+            .expect("source schema composition should build");
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+        materialize_index_replay_runtime(&mut extensions, db.clone())
+            .expect("first replay materialization");
+
+        let error = materialize_index_replay_runtime(&mut extensions, db)
+            .expect_err("duplicate replay materialization must fail");
+        assert!(error.to_string().contains("already materialized"));
+    }
+
+    #[tokio::test]
+    async fn operator_authorization_requires_exact_tenant_actor_and_modules_manage() {
+        let tenant_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let context = IndexReplayOperatorContext::new(tenant_id, actor_id).unwrap();
+        assert!(matches!(
+            context.authorize_for(tenant_id),
+            Err(IndexReplayOperatorError::MissingRequestAuthority)
+        ));
+
+        with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_READ],
+                UserRole::Admin,
+            )),
+            async {
+                assert!(matches!(
+                    context.authorize_for(tenant_id),
+                    Err(IndexReplayOperatorError::Forbidden)
+                ));
+            },
+        )
+        .await;
+
+        with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_MANAGE],
+                UserRole::Admin,
+            )),
+            async {
+                assert!(context.authorize_for(tenant_id).is_ok());
+                assert!(matches!(
+                    context.authorize_for(Uuid::new_v4()),
+                    Err(IndexReplayOperatorError::TenantMismatch)
+                ));
+            },
+        )
+        .await;
+    }
+
+    #[test]
+    fn operator_context_rejects_nil_identity() {
+        assert!(matches!(
+            IndexReplayOperatorContext::new(Uuid::nil(), Uuid::new_v4()),
+            Err(IndexReplayOperatorError::InvalidContext)
+        ));
+        assert!(matches!(
+            IndexReplayOperatorContext::new(Uuid::new_v4(), Uuid::nil()),
+            Err(IndexReplayOperatorError::InvalidContext)
+        ));
+    }
+}

--- a/crates/rustok-channel/README.md
+++ b/crates/rustok-channel/README.md
@@ -16,9 +16,9 @@
 - Back the shared request-level `ChannelContext` used by host transport layers.
 - Own the domain resolution pipeline (`RequestFacts -> ResolutionDecision`) that host middleware applies.
 - Own the durable database generation used to recover channel-resolution caches across serving replicas.
-- Own a positive monotonic `channels.index_revision` storage column. Every Channel update advances it exactly once; the value remains storage-internal and is not exposed through Channel DTOs or the SeaORM write model.
+- Own a positive monotonic `channels.index_revision` storage column and retained `channel_index_tombstones`. Every Channel update advances the live revision exactly once; hard deletion retains an exact source version strictly above the final live row. These values remain storage-internal and are not exposed through Channel DTOs or the SeaORM write model.
 - Publish only a neutral `ChannelRuntimeSelected` marker for selected cross-module composition. The Channel crate does not depend on `rustok-index` and does not construct generic Index mutations.
-- The selected `rustok-distribution` bridge publishes the non-localized `rustok-channel::sales_channel@1` schema and a bounded current-state source. Replay enumeration uses stable `channel_id` ordering, while `index_revision` is used only as generic mutation `source_version`. Hard-delete tombstones, versioned Product links, and authoritative consumer cutover remain later slices.
+- The selected `rustok-distribution` bridge publishes the non-localized `rustok-channel::sales_channel@1` schema and one bounded source. Replay enumeration uses stable `channel_id` ordering and returns live upserts or retained hard-delete mutations from the same source identity; `index_revision` is used only as generic mutation `source_version`. Incremental acknowledgement, versioned Product links, and authoritative consumer cutover remain later slices.
 - Ship the module-owned Leptos admin UI package for channel management.
 - Expose `ChannelReadPort` / `channel.read_projection.v1` as the FBA provider boundary for channel/default/host-target read projections, with deadline-aware read semantics and no-compile executable fallback smoke evidence until executable runtime smoke is available.
 
@@ -27,6 +27,7 @@
 This crate intentionally ships a minimal v0 model:
 
 - `channels`
+- `channel_index_tombstones` as storage-internal replay identity state
 - `channel_targets`
 - `channel_module_bindings`
 - `channel_oauth_apps`
@@ -57,7 +58,7 @@ Previously validated baseline:
 - `npm run verify:channel:resolution-contract` (no-compile resolution order and built-in host fast-path decision gate)
 - `npm run verify:channel:proof-points` (no-compile pages/blog/commerce/forum proof-point source/docs sync gate)
 
-The new durable-generation path remains source-complete until the current permanent cache workflow and multi-replica failure-recovery scenarios pass on the same revision.
+The new durable-generation path remains source-complete until the current permanent cache workflow and multi-replica failure-recovery scenarios pass on the same revision. The Index tombstone path likewise remains source-complete until the owner executes delete/recreate and replay evidence.
 
 It does not yet provide:
 
@@ -73,7 +74,7 @@ It does not yet provide:
 - `rustok-cache` supplies bounded invalidation transport; Redis PubSub is an acceleration path rather than the durable source of truth.
 - `rustok-api` hosts the shared `ChannelContext` and request-level contracts.
 - `rustok-auth` remains the source of truth for OAuth applications and tokens.
-- `rustok-distribution` consumes the neutral selection marker and Channel-owned table contract to publish generic SalesChannel Index schema/source capabilities; Index core and server remain Channel-agnostic.
+- `rustok-distribution` consumes the neutral selection marker and Channel-owned live/tombstone table contract to publish generic SalesChannel Index schema/source capabilities; Index core and server remain Channel-agnostic.
 - Domain modules may gradually become channel-aware by reading channel context or channel bindings.
 - The Leptos admin UI lives in `crates/rustok-channel/admin` and is mounted by `apps/admin` through manifest-driven wiring.
 
@@ -89,6 +90,7 @@ It does not yet provide:
 ## Next Steps
 
 - Execute the permanent cache workflow and multi-replica durable-generation recovery scenarios.
+- Execute SalesChannel hard-delete, identity-reuse, replay, reconciliation, and restart evidence before admitting an authoritative Index consumer.
 - Keep the current `channel_module_bindings + metadata` model for v0 while `pages` and `blog` continue to serve as proof points.
 - Revisit a dedicated relation model only if future domains need stronger DB-level querying, authoring UX, or semantics that request-time filtering can no longer cover cleanly.
 - Decide later whether `target`, `connector`, and publishable credentials should become separate concepts.

--- a/crates/rustok-channel/src/migrations/m20260731_000011_add_channel_index_tombstones.rs
+++ b/crates/rustok-channel/src/migrations/m20260731_000011_add_channel_index_tombstones.rs
@@ -1,0 +1,220 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::DatabaseBackend;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() != DatabaseBackend::Postgres {
+            return Err(DbErr::Custom(
+                "rustok-channel migrations require PostgreSQL".to_owned(),
+            ));
+        }
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+CREATE TABLE channel_index_tombstones (
+    tenant_id UUID NOT NULL,
+    channel_id UUID NOT NULL,
+    source_version BIGINT NOT NULL,
+    deleted_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (tenant_id, channel_id),
+    CONSTRAINT chk_channel_index_tombstones_source_version_positive CHECK (source_version > 0)
+);
+
+CREATE OR REPLACE FUNCTION rustok_channel_store_index_tombstone(
+    target_tenant_id UUID,
+    target_channel_id UUID,
+    target_source_version BIGINT
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    INSERT INTO channel_index_tombstones (
+        tenant_id,
+        channel_id,
+        source_version,
+        deleted_at
+    ) VALUES (
+        target_tenant_id,
+        target_channel_id,
+        target_source_version,
+        CURRENT_TIMESTAMP
+    )
+    ON CONFLICT (tenant_id, channel_id) DO UPDATE
+    SET source_version = GREATEST(
+            channel_index_tombstones.source_version,
+            EXCLUDED.source_version
+        ),
+        deleted_at = CURRENT_TIMESTAMP;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION rustok_channel_clear_superseded_index_tombstone(
+    target_tenant_id UUID,
+    target_channel_id UUID,
+    live_source_version BIGINT
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM channel_index_tombstones tombstone
+        WHERE tombstone.tenant_id = target_tenant_id
+          AND tombstone.channel_id = target_channel_id
+          AND tombstone.source_version >= live_source_version
+    ) THEN
+        RAISE EXCEPTION
+            'channel live index revision does not supersede retained tombstone for channel %',
+            target_channel_id;
+    END IF;
+
+    DELETE FROM channel_index_tombstones
+    WHERE tenant_id = target_tenant_id
+      AND channel_id = target_channel_id
+      AND source_version < live_source_version;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION rustok_channel_seed_index_revision_from_tombstone()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    retained_source_version BIGINT;
+BEGIN
+    SELECT source_version
+      INTO retained_source_version
+      FROM channel_index_tombstones
+     WHERE tenant_id = NEW.tenant_id
+       AND channel_id = NEW.id;
+
+    IF retained_source_version IS NOT NULL THEN
+        IF retained_source_version = 9223372036854775807 THEN
+            RAISE EXCEPTION 'channel index revision exhausted for reused channel %', NEW.id;
+        END IF;
+        NEW.index_revision := GREATEST(NEW.index_revision, retained_source_version + 1);
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_channels_seed_index_revision
+BEFORE INSERT ON channels
+FOR EACH ROW
+EXECUTE FUNCTION rustok_channel_seed_index_revision_from_tombstone();
+
+CREATE OR REPLACE FUNCTION rustok_channel_capture_index_tombstone()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.index_revision = 9223372036854775807 THEN
+        RAISE EXCEPTION 'channel index revision exhausted for deleted channel %', OLD.id;
+    END IF;
+
+    PERFORM rustok_channel_store_index_tombstone(
+        OLD.tenant_id,
+        OLD.id,
+        OLD.index_revision + 1
+    );
+    RETURN OLD;
+END;
+$$;
+
+CREATE TRIGGER trg_channels_capture_index_tombstone
+BEFORE DELETE ON channels
+FOR EACH ROW
+EXECUTE FUNCTION rustok_channel_capture_index_tombstone();
+
+CREATE OR REPLACE FUNCTION rustok_channel_clear_inserted_index_tombstone()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM rustok_channel_clear_superseded_index_tombstone(
+        NEW.tenant_id,
+        NEW.id,
+        NEW.index_revision
+    );
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_channels_clear_index_tombstone
+AFTER INSERT ON channels
+FOR EACH ROW
+EXECUTE FUNCTION rustok_channel_clear_inserted_index_tombstone();
+
+CREATE OR REPLACE FUNCTION rustok_channel_move_index_tombstone()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.tenant_id IS NOT DISTINCT FROM NEW.tenant_id
+       AND OLD.id IS NOT DISTINCT FROM NEW.id THEN
+        RETURN NEW;
+    END IF;
+
+    PERFORM rustok_channel_store_index_tombstone(
+        OLD.tenant_id,
+        OLD.id,
+        NEW.index_revision
+    );
+    PERFORM rustok_channel_clear_superseded_index_tombstone(
+        NEW.tenant_id,
+        NEW.id,
+        NEW.index_revision
+    );
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_channels_move_index_tombstone
+AFTER UPDATE OF id, tenant_id ON channels
+FOR EACH ROW
+EXECUTE FUNCTION rustok_channel_move_index_tombstone();
+"#,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() != DatabaseBackend::Postgres {
+            return Err(DbErr::Custom(
+                "rustok-channel migrations require PostgreSQL".to_owned(),
+            ));
+        }
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+DROP TRIGGER IF EXISTS trg_channels_move_index_tombstone ON channels;
+DROP TRIGGER IF EXISTS trg_channels_clear_index_tombstone ON channels;
+DROP TRIGGER IF EXISTS trg_channels_capture_index_tombstone ON channels;
+DROP TRIGGER IF EXISTS trg_channels_seed_index_revision ON channels;
+DROP FUNCTION IF EXISTS rustok_channel_move_index_tombstone();
+DROP FUNCTION IF EXISTS rustok_channel_clear_inserted_index_tombstone();
+DROP FUNCTION IF EXISTS rustok_channel_capture_index_tombstone();
+DROP FUNCTION IF EXISTS rustok_channel_seed_index_revision_from_tombstone();
+DROP FUNCTION IF EXISTS rustok_channel_clear_superseded_index_tombstone(UUID, UUID, BIGINT);
+DROP FUNCTION IF EXISTS rustok_channel_store_index_tombstone(UUID, UUID, BIGINT);
+DROP TABLE IF EXISTS channel_index_tombstones;
+"#,
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/crates/rustok-channel/src/migrations/mod.rs
+++ b/crates/rustok-channel/src/migrations/mod.rs
@@ -10,6 +10,7 @@ mod m20260327_000007_create_channel_resolution_policy_sets;
 mod m20260327_000008_create_channel_resolution_policy_rules;
 mod m20260716_000009_create_channel_resolution_invalidation_state;
 mod m20260730_000010_add_channel_index_revision;
+mod m20260731_000011_add_channel_index_tombstones;
 
 use rustok_core::MigrationDependencyDescriptor;
 use sea_orm_migration::MigrationTrait;
@@ -26,6 +27,7 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260327_000008_create_channel_resolution_policy_rules::Migration),
         Box::new(m20260716_000009_create_channel_resolution_invalidation_state::Migration),
         Box::new(m20260730_000010_add_channel_index_revision::Migration),
+        Box::new(m20260731_000011_add_channel_index_tombstones::Migration),
     ]
 }
 

--- a/crates/rustok-distribution/src/channel_index.rs
+++ b/crates/rustok-distribution/src/channel_index.rs
@@ -19,17 +19,59 @@ pub(crate) const SALES_CHANNEL_INDEX_SOURCE: &str = "sales-channel-postgres-prim
 const SALES_CHANNEL_INDEX_FACTORY: &str = "sales-channel-postgres-primary";
 const SALES_CHANNEL_EVENT_DOMAIN: &str = "rustok-channel.sales-channel-replay-v1";
 
-const SALES_CHANNEL_SELECT: &str = r#"
+const SALES_CHANNEL_ROWS_CTE: &str = r#"
+sales_channel_index_union AS (
+    SELECT
+        FALSE AS is_deleted,
+        c.tenant_id,
+        c.id AS channel_id,
+        c.index_revision,
+        c.slug,
+        c.name,
+        c.is_active,
+        c.is_default,
+        c.status
+    FROM channels c
+    WHERE c.tenant_id = $1
+
+    UNION ALL
+
+    SELECT
+        TRUE AS is_deleted,
+        tombstone.tenant_id,
+        tombstone.channel_id,
+        tombstone.source_version AS index_revision,
+        NULL::text AS slug,
+        NULL::text AS name,
+        NULL::boolean AS is_active,
+        NULL::boolean AS is_default,
+        NULL::text AS status
+    FROM channel_index_tombstones tombstone
+    WHERE tombstone.tenant_id = $1
+),
+sales_channel_index_rows AS (
+    SELECT
+        row.*,
+        COUNT(*) OVER (
+            PARTITION BY row.tenant_id, row.channel_id
+        ) AS identity_count
+    FROM sales_channel_index_union row
+)
+"#;
+
+const SALES_CHANNEL_ROW_SELECT: &str = r#"
 SELECT
-    c.tenant_id,
-    c.id AS channel_id,
-    c.index_revision,
-    c.slug,
-    c.name,
-    c.is_active,
-    c.is_default,
-    c.status
-FROM channels c
+    row.is_deleted,
+    row.identity_count,
+    row.tenant_id,
+    row.channel_id,
+    row.index_revision,
+    row.slug,
+    row.name,
+    row.is_active,
+    row.is_default,
+    row.status
+FROM sales_channel_index_rows row
 "#;
 
 #[derive(Debug, Error)]
@@ -163,7 +205,7 @@ impl SalesChannelPostgresIndexSource {
         let (sql, values): (String, Vec<Value>) = match cursor {
             Some(cursor) => (
                 format!(
-                    "{SALES_CHANNEL_SELECT}\nWHERE c.tenant_id = $1\n  AND c.id > $2\nORDER BY c.id ASC\nLIMIT $3"
+                    "WITH {SALES_CHANNEL_ROWS_CTE}\n{SALES_CHANNEL_ROW_SELECT}\nWHERE row.channel_id > $2\nORDER BY row.channel_id ASC\nLIMIT $3"
                 ),
                 vec![
                     request.tenant_id().into(),
@@ -173,7 +215,7 @@ impl SalesChannelPostgresIndexSource {
             ),
             None => (
                 format!(
-                    "{SALES_CHANNEL_SELECT}\nWHERE c.tenant_id = $1\nORDER BY c.id ASC\nLIMIT $2"
+                    "WITH {SALES_CHANNEL_ROWS_CTE}\n{SALES_CHANNEL_ROW_SELECT}\nORDER BY row.channel_id ASC\nLIMIT $2"
                 ),
                 vec![request.tenant_id().into(), fetch_limit.into()],
             ),
@@ -200,7 +242,7 @@ impl SalesChannelPostgresIndexSource {
             values.push(key.entity_id.into());
         }
         let sql = format!(
-            "WITH requested(channel_id) AS (VALUES {})\n{SALES_CHANNEL_SELECT}\nJOIN requested r ON r.channel_id = c.id\nWHERE c.tenant_id = $1\nORDER BY c.id ASC",
+            "WITH requested(channel_id) AS (VALUES {}),\n{SALES_CHANNEL_ROWS_CTE}\n{SALES_CHANNEL_ROW_SELECT}\nJOIN requested requested_key ON requested_key.channel_id = row.channel_id\nORDER BY row.channel_id ASC",
             rows.join(", ")
         );
         self.db
@@ -295,6 +337,17 @@ struct SalesChannelRow {
     tenant_id: Uuid,
     channel_id: Uuid,
     source_version: u64,
+    state: SalesChannelRowState,
+}
+
+#[derive(Debug)]
+enum SalesChannelRowState {
+    Live(SalesChannelLiveFields),
+    Deleted,
+}
+
+#[derive(Debug)]
+struct SalesChannelLiveFields {
     slug: String,
     name: String,
     is_active: bool,
@@ -307,6 +360,12 @@ impl SalesChannelRow {
         row: QueryResult,
         expected_tenant: Uuid,
     ) -> Result<Self, SalesChannelIndexBridgeError> {
+        let is_deleted = row
+            .try_get::<bool>("", "is_deleted")
+            .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
+        let identity_count = row
+            .try_get::<i64>("", "identity_count")
+            .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
         let tenant_id = row
             .try_get::<Uuid>("", "tenant_id")
             .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
@@ -316,27 +375,41 @@ impl SalesChannelRow {
         let revision = row
             .try_get::<i64>("", "index_revision")
             .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
-        if tenant_id != expected_tenant
+        if identity_count != 1
+            || tenant_id != expected_tenant
             || tenant_id.is_nil()
             || channel_id.is_nil()
             || revision <= 0
         {
             return Err(SalesChannelIndexBridgeError::InvalidRow);
         }
+        let source_version =
+            u64::try_from(revision).map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
+
+        if is_deleted {
+            return Ok(Self {
+                tenant_id,
+                channel_id,
+                source_version,
+                state: SalesChannelRowState::Deleted,
+            });
+        }
+
         Ok(Self {
             tenant_id,
             channel_id,
-            source_version: u64::try_from(revision)
-                .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?,
-            slug: required_string(&row, "slug")?,
-            name: required_string(&row, "name")?,
-            is_active: row
-                .try_get::<bool>("", "is_active")
-                .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?,
-            is_default: row
-                .try_get::<bool>("", "is_default")
-                .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?,
-            status: required_string(&row, "status")?,
+            source_version,
+            state: SalesChannelRowState::Live(SalesChannelLiveFields {
+                slug: required_string(&row, "slug")?,
+                name: required_string(&row, "name")?,
+                is_active: row
+                    .try_get::<bool>("", "is_active")
+                    .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?,
+                is_default: row
+                    .try_get::<bool>("", "is_default")
+                    .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?,
+                status: required_string(&row, "status")?,
+            }),
         })
     }
 
@@ -355,27 +428,40 @@ impl SalesChannelRow {
             self.source_version,
         )
         .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
+        let key = EntityKey {
+            tenant_id: self.tenant_id,
+            schema: sales_channel_schema_ref()
+                .map_err(SalesChannelIndexBridgeError::InvalidContract)?,
+            entity_id: self.channel_id,
+            locale: None,
+        };
+
+        let SalesChannelRowState::Live(live) = self.state else {
+            return Ok(IndexMutation::Delete {
+                event_id,
+                key,
+                source_version: self.source_version,
+            });
+        };
+
         let fields = BTreeMap::from([
             (field_name("id")?, IndexValue::Uuid(self.channel_id)),
-            (field_name("slug")?, IndexValue::String(self.slug)),
-            (field_name("name")?, IndexValue::String(self.name)),
-            (field_name("is_active")?, IndexValue::Boolean(self.is_active)),
+            (field_name("slug")?, IndexValue::String(live.slug)),
+            (field_name("name")?, IndexValue::String(live.name)),
+            (
+                field_name("is_active")?,
+                IndexValue::Boolean(live.is_active),
+            ),
             (
                 field_name("is_default")?,
-                IndexValue::Boolean(self.is_default),
+                IndexValue::Boolean(live.is_default),
             ),
-            (field_name("status")?, IndexValue::String(self.status)),
+            (field_name("status")?, IndexValue::String(live.status)),
         ]);
         Ok(IndexMutation::Upsert {
             event_id,
             record: IndexRecord {
-                key: EntityKey {
-                    tenant_id: self.tenant_id,
-                    schema: sales_channel_schema_ref()
-                        .map_err(SalesChannelIndexBridgeError::InvalidContract)?,
-                    entity_id: self.channel_id,
-                    locale: None,
-                },
+                key,
                 source_version: self.source_version,
                 fields,
                 links: Vec::new(),
@@ -440,6 +526,45 @@ mod tests {
         ] {
             let cursor = IndexSourceCursor::new(value).unwrap();
             assert!(SalesChannelCursor::decode(&cursor).is_err());
+        }
+    }
+
+    #[test]
+    fn selected_sales_channel_tombstone_emits_delete_with_stable_identity() {
+        let tenant_id = Uuid::from_u128(1);
+        let channel_id = Uuid::from_u128(2);
+        let mutation = SalesChannelRow {
+            tenant_id,
+            channel_id,
+            source_version: 7,
+            state: SalesChannelRowState::Deleted,
+        }
+        .into_mutation()
+        .unwrap();
+
+        match mutation {
+            IndexMutation::Delete {
+                event_id,
+                key,
+                source_version,
+            } => {
+                assert_eq!(key.tenant_id, tenant_id);
+                assert_eq!(key.entity_id, channel_id);
+                assert_eq!(key.locale, None);
+                assert_eq!(source_version, 7);
+                assert_eq!(
+                    event_id,
+                    derive_index_source_event_id(
+                        SALES_CHANNEL_EVENT_DOMAIN,
+                        tenant_id,
+                        channel_id,
+                        None,
+                        7,
+                    )
+                    .unwrap()
+                );
+            }
+            IndexMutation::Upsert { .. } => panic!("retained delete must not become an upsert"),
         }
     }
 

--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -27,7 +27,10 @@ This directory contains the detailed technical architecture documentation for `r
 ## Reference Documents
 
 - [Live Implementation Plan](./implementation-plan.md)
+- [Implementation Status Audit — 2026-07-31](./implementation-plan-audit-2026-07-31.md)
 - [M5/M6 Source Replay Contract](./m5-m6-source-replay-contract.md)
+- [M6 Reconciliation Dead-letter Admission](./m6-reconciliation-dead-letter-admission.md)
+- [M6 Reconciliation Dead-letter Inspection](./m6-reconciliation-dead-letter-inspection.md)
 - [M6 Replay Job Leases](./m6-replay-job-leases.md)
 - [M6 Bounded Multi-page Replay Runner](./m6-bounded-multipage-runner.md)
 - [M6 Replay Runtime Host Composition](./m6-replay-runtime-composition.md)

--- a/crates/rustok-index/docs/implementation-plan-audit-2026-07-31.md
+++ b/crates/rustok-index/docs/implementation-plan-audit-2026-07-31.md
@@ -1,0 +1,44 @@
+# `rustok-index` implementation status audit — 2026-07-31
+
+This audit accompanies the canonical [implementation plan](./implementation-plan.md) and prevents source-complete draft work from being mistaken for code already merged to `main`.
+
+## Status vocabulary
+
+- `merged_main`: present on the current default branch.
+- `open_source_complete`: implemented in an open PR, with maintainer validation still pending.
+- `owner_evidence_pending`: source exists, but retained runtime/PostgreSQL/CI evidence has not been executed by the implementation agent.
+- `not_started`: no reviewed implementation was found.
+
+## Rechecked M6/M7 state
+
+| Capability | Status | Evidence |
+| --- | --- | --- |
+| bounded multi-pass reconciliation runner, durable cursor/pass progress, lease fencing and cancellation | `merged_main`; `owner_evidence_pending` | production runner exists on `main`; focused PostgreSQL harness PRs remain open |
+| failed reconciliation scope admission | `open_source_complete`; `owner_evidence_pending` | superseded PR #2743, retained in this PR |
+| bounded dead-letter inspection core adapter | `open_source_complete`; `owner_evidence_pending` | retained from superseded PR #2751 |
+| guarded reconciliation run/cancel operator | `open_source_complete`; `owner_evidence_pending` | superseded PR #2693, retained in this PR |
+| guarded request-bound dead-letter inspection | `open_source_complete`; `owner_evidence_pending` | added in this PR; exact context tenant plus `modules:manage` before database delegation |
+| source-call timeout | `open_source_complete`; `owner_evidence_pending` | PR #2639 |
+| bounded replay dry-run | `open_source_complete`; `owner_evidence_pending` | PR #2642 |
+| replay retry transition store | `open_source_complete`; `owner_evidence_pending` | PR #2644 |
+| replay dead-letter admission | `open_source_complete`; `owner_evidence_pending` | PR #2648 |
+| cooperative replay page interruption | `open_source_complete`; `owner_evidence_pending` | PR #2649 |
+| Product/ProductVariant/SalesChannel bounded schemas and sources | `open_source_complete`; `owner_evidence_pending` | canonical M7 work retained from PR #2636 and related open slices |
+| incremental event acknowledgement | `not_started` | no reviewed implementation found |
+| durable Product/ProductVariant-to-SalesChannel relation revision contract | `not_started` | channel changes can invalidate links without advancing Product revision |
+| automatic retry/backoff/exhaustion plus host scheduling | `not_started` as an integrated capability | storage substrate exists in open PRs, but runner wiring and host ownership remain open |
+| actor/reason audit and manual dead-letter requeue/reset | `not_started` | next production sequence after authorized inspection |
+| digest comparison, orphan cleanup, targeted/full/shadow repair and complete drift admission | `not_started` | remains the final M6 consistency boundary |
+
+## Updated execution order
+
+1. Merge or supersede the source-complete M7, reconciliation admission, inspection, and guarded operator work without losing the canonical plan.
+2. Add immutable actor/reason audit records for dead-letter actions.
+3. Add a scope-locked manual requeue or retry-epoch reset with exact failed-job fencing.
+4. Wire bounded retry/backoff/exhaustion and explicit host scheduling/graceful shutdown ownership.
+5. Add digest comparison, orphan detection, targeted/full/shadow repair, locale/partition dimensions, and retained admission evidence.
+6. Continue M7 with incremental acknowledgement, durable relation revision semantics, slice completeness, and consumer cutover.
+
+## Validation ownership
+
+Per maintainer instruction, the implementation agent did not run tests, formatting, Cargo checks, JavaScript verifiers, PostgreSQL fixtures, or CI. All source-complete claims in this audit mean code review/repository inspection only, not executed evidence.

--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -26,7 +26,7 @@ pull requests record checks and PostgreSQL runs that were not executed.
 ## Current state
 
 - Rewrite status: `in_progress`
-- Current milestone: `M7 - first Product schema and bounded replay source (source complete; tombstones, incremental events, related entities, consumer cutover, and retained evidence open)`
+- Current milestone: `M7 - Product/ProductVariant/SalesChannel bounded replay graph (live sources, Product/ProductVariant/SalesChannel tombstones, and bounded reconciliation source-complete; incremental events, persisted readiness, durable Product-to-Channel relations, consumer cutover, and retained evidence open)`
 - FFA status: `in_progress`
 - FBA status: `in_progress`
 - M0 code reset: `complete`
@@ -63,12 +63,14 @@ pull requests record checks and PostgreSQL runs that were not executed.
 - M4 source-owned schema catalog and shared query runtime: `source_complete`
 - M4 first Social Graph privacy parity shadow: `source_complete_metrics_evidence_tooling_execution_pending`
 - M5 inbox deduplication and monotonic source-version persistence: `complete`
-- M5/M6 bounded source replay contract: `source_complete_worker_pending`
+- M5/M6 bounded source replay contract: `source_complete_owner_execution_pending`
 - M6 one-page replay and durable checkpoint progression: `source_complete`
 - M6 replay job leases and checkpoint attempt fencing: `source_complete_owner_execution_pending`
 - M6 bounded multi-page replay and cancellation: `source_complete_owner_execution_pending`
+- M6 bounded multi-pass source reconciliation: `source_complete_owner_execution_pending`
 - M6 replay runtime host composition and operator guard: `source_complete_owner_execution_pending`
-- M7 first Product schema and bounded source bridge: `source_complete_owner_execution_pending`
+- M7 Product/ProductVariant graph schemas and bounded sources: `source_complete_owner_execution_pending`
+- M7 SalesChannel schema, bounded source, and retained deletes: `source_complete_owner_execution_pending`
 - Production persistence: mutation writes, schema/index coordination, fail-closed
   partition admission, snapshot/query/mutation/maintenance/cutover evidence tooling,
   full-capture orchestration, exact-byte packet assembly, retained bundle review,
@@ -84,14 +86,18 @@ pull requests record checks and PostgreSQL runs that were not executed.
   rebuild checkpoint progression, schema-scoped rebuild job claims, lease/heartbeat,
   attempt fencing, fenced checkpoint writes, bounded multi-page execution, immediate
   pending resume, durable cancellation requests, fenced between-page terminal
-  cancellation, immutable source-registry host materialization, shared replay-runtime
-  publication, request-bound operator authorization, atomic PostgreSQL source-factory
-  composition, stable source event identities, and one selected Product current-state
-  replay source are implemented; one retained admitted packet, live PostgreSQL/reference
-  equivalence, in-page interruption, retry/backoff, dead-letter scheduling, host
-  scheduling, graceful task shutdown, command transport, Product tombstones and
-  incremental ingestion, additional vertical schemas, freshness/recovery evidence,
-  authoritative consumer cutover, and production partition lifecycle remain open
+  cancellation, bounded multi-pass reconciliation, immutable source-registry host
+  materialization, shared replay-runtime publication, request-bound operator
+  authorization, atomic PostgreSQL source-factory composition, stable source event
+  identities, Product/ProductVariant/SalesChannel current-state sources, versioned
+  Product-to-ProductVariant links, and retained Product/ProductVariant/SalesChannel
+  hard-delete mutations are implemented; one retained admitted packet, live
+  PostgreSQL/reference equivalence, in-page interruption, retry/backoff, dead-letter
+  scheduling, host scheduling, graceful task shutdown, command transport, incremental
+  event acknowledgement, persisted per-tenant schema readiness, durable
+  Product-to-SalesChannel relations, freshness/recovery evidence, authoritative
+  consumer cutover, tombstone purge admission, and production partition lifecycle
+  remain open
 
 The production crate contains the generic domain/application core, seven canonical
 M3 tables, an atomic mutation adapter, durable schema leases, secondary-index
@@ -107,12 +113,14 @@ repeatable-read page/count snapshot, source-owned schema and replay catalogs, a
 neutral bounded `IndexSource` scan/load boundary, a one-page replay executor,
 `PostgresIndexReplayJobStore` for durable fenced schema-scoped rebuild ownership,
 a lease-bound PostgreSQL rebuild-checkpoint adapter, `PostgresIndexReplayRunner` for
-bounded heartbeat/yield/cancellation execution, `SharedIndexReplayRuntime` for host
-capability transfer, and atomic host-database-aware source factory composition. The
-server publishes `IndexReplayOperatorRuntime` as the request-bound authorization
-boundary. The selected distribution now contributes the first Product schema/source
-bridge without adding a Product dependency to Index core. Owner-operated evidence
-tools live under `ops/benches`; they do not become runtime storage code.
+bounded heartbeat/yield/cancellation execution, a bounded multi-pass source
+reconciliation runner with durable pass/source cursor state, `SharedIndexReplayRuntime`
+for host capability transfer, and atomic host-database-aware source factory composition.
+The server publishes `IndexReplayOperatorRuntime` as the request-bound authorization
+boundary. The selected distribution contributes Product, ProductVariant, and
+SalesChannel schemas/sources without adding source-domain dependencies to Index core
+or server. Owner-operated evidence tools live under `ops/benches`; they do not become
+runtime storage code.
 
 ## Ownership
 
@@ -123,9 +131,10 @@ reconciliation, drift repair, distributed coordination, and operator diagnostics
 
 Source modules own normalized domain data, schema declarations, conversion to
 generic Index records/mutations, bounded `IndexSource::scan` and targeted `load`
-adapters, stable replay event identities, and source ordering and version information.
-Selected cross-module adapters that require both owner storage and Index contracts
-live in `rustok-distribution`; they do not move storage ownership into Index or server.
+adapters, stable replay event identities, source ordering and version information,
+and retained deletion identities needed for replay. Selected cross-module adapters
+that require both owner storage and Index contracts live in `rustok-distribution`;
+they do not move storage ownership into Index or server.
 
 ## Target architecture
 
@@ -160,6 +169,7 @@ crates/rustok-index/src/
     source_replay.rs
     source_replay_job.rs
     source_replay_runner.rs
+    source_reconciliation_runner.rs
     replay_runtime.rs
     schema_lease.rs
     secondary_index.rs
@@ -168,7 +178,8 @@ crates/rustok-index/src/
   api/
 
 crates/rustok-distribution/src/
-  product_index.rs
+  product_index/
+  channel_index.rs
 
 apps/server/src/services/
   index_replay_runtime_composition.rs
@@ -467,20 +478,21 @@ database, or transport causes stay in owner logs.
 - [x] Add bounded multi-page execution with heartbeat cadence and immediate pending resume.
 - [x] Add durable cancellation requests and fenced between-page terminal cancellation.
 - [x] Bind job requests directly to the materialized source registry in server composition.
+- [x] Add bounded multi-pass source reconciliation with durable pass/source cursor state.
 - [ ] Add in-page interruption/timeouts, dry-run, and targeted/full/shadow rebuild modes.
 - [ ] Add bounded retry/backoff, dead-letter state, and global scheduling ownership.
 - [ ] Add locale/partition replay checkpoint dimensions.
-- [ ] Add reconciliation and drift repair.
+- [ ] Add drift diagnosis, targeted repair commands, and admitted repair evidence.
 - [ ] Cover crash, lease expiry, restart, cancellation, authorization, and incremental/full
       equivalence with retained PostgreSQL evidence.
 
 The one-page executor, replay job store, checkpoint adapter, bounded multi-page runner,
-cancellation path, and host composition are source complete. `PostgresIndexReplayJobStore`
-serializes one tenant/schema claim, validates the exact `index_replay_job_v1` request and
-active persisted schema, reclaims expired attempts with an incremented fence, and rejects
-stale heartbeat or terminal updates. `PostgresIndexReplayCheckpointStore` is constructed
-from the acquired lease; it locks and validates that exact attempt before every checkpoint
-read or write.
+cancellation path, bounded reconciliation runner, and host composition are source complete.
+`PostgresIndexReplayJobStore` serializes one tenant/schema claim, validates the exact
+`index_replay_job_v1` request and active persisted schema, reclaims expired attempts with an
+incremented fence, and rejects stale heartbeat or terminal updates.
+`PostgresIndexReplayCheckpointStore` is constructed from the acquired lease; it locks and
+validates that exact attempt before every checkpoint read or write.
 
 `PostgresIndexReplayRunner` resolves the source from the materialized registry, executes at
 most 1024 pages, heartbeats between pages, completes only after a durable JSON null cursor,
@@ -490,6 +502,13 @@ marks running jobs for observation before/after pages; success, failure, and yie
 require `cancel_requested = FALSE`, so cancellation committed first cannot be overwritten.
 A running cancel request survives reclaim and is terminalized by the next fenced attempt
 before source access.
+
+The bounded reconciliation runner performs durable multi-pass source scans without
+collecting all IDs, persists pass and source cursor state, applies stable source mutations
+through the same monotonic mutation store, and can be cancelled or reclaimed under the
+existing attempt fence. It repairs replay-visible stale and missing materialized state but
+does not claim an owner snapshot/high-watermark, proof against every concurrent final-pass
+write, or authoritative drift-repair admission.
 
 The server materializes `SharedIndexSourceRegistry` only after all selected modules have
 registered their source-owned schema and replay contracts. The Index-owned
@@ -513,20 +532,35 @@ Entities: Product, ProductVariant, SalesChannel.
 - [x] Add stable `(product_id, locale)` replay cursor, targeted loads, and one-row lookahead.
 - [x] Add Product-owned monotonic `index_revision` and stable Index-owned event identity.
 - [x] Compose selected Product schema/source through atomic distribution source factories.
-- [ ] Add Product and translation delete tombstones plus incremental event acknowledgement.
-- [ ] Add ProductVariant and SalesChannel schemas, links, and bounded sources.
+- [x] Add Product and translation delete tombstones.
+- [x] Add ProductVariant and SalesChannel schemas and bounded sources.
+- [x] Add Product-to-ProductVariant v2 links and bounded graph projection fields.
+- [x] Add ProductVariant and SalesChannel hard-delete tombstones.
+- [ ] Add source-versioned Product, ProductVariant, and SalesChannel incremental event acknowledgement.
+- [ ] Add durable Product/ProductVariant-to-SalesChannel relations with owner revision semantics.
 - [ ] Support tenant, locale, status, projection, link filters, sorting, and cursor
       pagination across the complete Product/Variant/Channel slice.
 - [ ] Move one Storefront query to Index.
 - [ ] Prove no source-module filtering fan-out.
 
-The first Product source is source complete for bounded current-state upserts. Product owns
-its storage and revision triggers; `rustok-distribution` owns the selected generic bridge;
-Index owns schema/source/runtime contracts and mutation persistence. The Product crate does
-not depend on Index, Index/server do not import Product, and factory composition commits the
-source catalog only after every selected factory succeeds. See
-[`m7-product-source.md`](./m7-product-source.md) for exact scope and open tombstone,
-concurrency, persisted-schema-readiness, evidence, and cutover boundaries.
+Product v1/v2, ProductVariant v1/v2, and SalesChannel v1 schemas are source complete.
+Product v2 links to ProductVariant v2; Product channel visibility remains represented by
+bounded scalar projection until the owner has a durable relational contract. Product,
+translation, ProductVariant, and SalesChannel deletion identities are retained with
+monotonic source versions and replayed through the existing stable sources as generic
+`IndexMutation::Delete` values. Recreated identities must strictly supersede retained
+deletes, and live/tombstone coexistence fails closed.
+
+Product and Channel crates own normalized storage, revisions, and tombstones without
+depending on Index. `rustok-distribution` owns the selected generic bridges. Index owns
+schema/source/runtime contracts, reconciliation, and mutation persistence. Runtime
+capability presence does not establish persisted schema readiness. Incremental event
+acknowledgement, durable Product-to-SalesChannel links, owner evidence, and consumer
+cutover remain open. See [`m7-product-source.md`](./m7-product-source.md),
+[`m7-product-variant-source.md`](./m7-product-variant-source.md),
+[`m7-product-graph-source.md`](./m7-product-graph-source.md),
+[`m7-product-tombstone-source.md`](./m7-product-tombstone-source.md), and
+[`m7-sales-channel-source.md`](./m7-sales-channel-source.md).
 
 ### M8 - Commerce scale slice
 
@@ -573,6 +607,7 @@ cargo test -p rustok-index source_event_id --lib -- --nocapture
 cargo test -p rustok-index source_replay --lib -- --nocapture
 cargo test -p rustok-index source_replay_job --lib -- --nocapture
 cargo test -p rustok-index source_replay_runner --lib -- --nocapture
+cargo test -p rustok-index source_reconciliation_runner --lib -- --nocapture
 cargo test -p rustok-index source_factory --lib -- --nocapture
 cargo test -p rustok-index replay_runtime --lib -- --nocapture
 cargo test -p rustok-distribution --all-targets --features mod-product -- --nocapture
@@ -621,8 +656,13 @@ node scripts/verify/verify-index-many-link-filtering.mjs
 node scripts/verify/verify-index-source-replay-contract.mjs
 node scripts/verify/verify-index-replay-job-leases.mjs
 node scripts/verify/verify-index-replay-multipage-runner.mjs
+node scripts/verify/verify-index-source-reconciliation.mjs
 node scripts/verify/verify-index-replay-runtime-composition.mjs
 node scripts/verify/verify-index-product-source.mjs
+node scripts/verify/verify-index-product-variant-source.mjs
+node scripts/verify/verify-index-product-graph-source.mjs
+node scripts/verify/verify-index-product-tombstone-source.mjs
+node scripts/verify/verify-index-sales-channel-source.mjs
 ```
 
 ## Progress log
@@ -683,22 +723,31 @@ node scripts/verify/verify-index-product-source.mjs
   selected locale-required Product current-state source with stable `(product_id,
   locale)` cursor and targeted loads. Product delete/translation tombstones,
   incremental acknowledgement, related schemas, and live evidence remain open.
+- 2026-07-31: rechecked merged M7 work and actualized this plan. ProductVariant and
+  SalesChannel sources, Product v2 graph links, retained Product/translation/
+  ProductVariant hard deletes, and bounded multi-pass reconciliation were already in
+  `main` but had stale open checklist entries.
+- 2026-07-31: added retained SalesChannel hard-delete identities, strict identity-reuse
+  fencing, live/tombstone conflict rejection, and generic replay deletes through the
+  existing stable SalesChannel source. No schema fingerprint, source name, cursor shape,
+  or event domain changed.
 - Repository test/fixture suites, verifiers, in-page interruption, automatic retry/backoff,
   dead-letter and host scheduling, graceful task shutdown, authorized command transports,
-  Product tombstones and incremental ingestion, ProductVariant/SalesChannel sources,
-  live freshness/recovery evidence, one admitted PostgreSQL/reference equivalence bundle,
-  and one real full PostgreSQL partition packet remain for the owner to execute and admit
-  before authoritative consumer or production partition cutover.
+  incremental event acknowledgement, persisted per-tenant schema readiness, durable
+  Product-to-SalesChannel relations, tombstone purge admission, live freshness/recovery
+  evidence, one admitted PostgreSQL/reference equivalence bundle, and one real full
+  PostgreSQL partition packet remain for the owner to execute and admit before
+  authoritative consumer or production partition cutover.
 
 ## Periodic release verification handoff
 
 - Cycle: `cycle-001`
 - Status: `blocked`
-- Last verified at (UTC): `2026-07-30`
-- Scope inspected: `Index ownership, migrations, mutation/version ordering, query execution, partition evidence guards, Social Graph consumer authority, privacy shadow deadline behavior, source replay ownership, replay checkpoint ordering, replay job attempt fencing, bounded multi-page replay progression, cancellation ordering, host replay composition, operator authorization, selected Product source composition, stable source identity, and source/search/server boundaries`
+- Last verified at (UTC): `2026-07-31`
+- Scope inspected: `Index ownership, migrations, mutation/version ordering, query execution, partition evidence guards, Social Graph consumer authority, privacy shadow deadline behavior, source replay ownership, replay checkpoint ordering, replay job attempt fencing, bounded multi-page replay progression, bounded multi-pass reconciliation, cancellation ordering, host replay composition, operator authorization, Product/ProductVariant/SalesChannel source composition, Product graph links, retained delete identities, stable source identity, and source/search/server boundaries`
 - Findings: `P0=0, P1=2, P2=0, P3=1`
-- Fixed in this pass: `bounded the non-authoritative Social Graph privacy comparison by the remaining caller deadline while preserving the owner result; repaired stale Index scale/FBA and retained-artifact guards; added a canonical bounded source replay/load registry; added one-page replay mutation application with stable event checks and checkpoint progression only after durable mutation outcomes; added schema-scoped rebuild job claims with lease/heartbeat, expired-attempt reclaim, attempt fencing, fenced checkpoint access, durable null-cursor-gated success, bounded multi-page execution with between-page heartbeat and immediate pending resume, durable cancel-first terminalization, immutable source-registry host materialization, one shared replay runtime, a request-bound modules:manage operator guard, atomic host source factories, stable source event identities, Product revision fencing, and the first selected Product current-state source`
-- Remaining risks or blockers: `one retained admitted real PostgreSQL partition packet is absent; live PostgreSQL/reference query equivalence remains open; in-page interruption, automatic retry/backoff, dead-letter scheduling, host scheduling, graceful task shutdown, authorized command transports, locale/partition checkpoint dimensions, Product hard-delete and translation-delete tombstones, incremental Product event acknowledgement, ProductVariant/SalesChannel sources, and additional production source adapters remain absent; no retained per-tenant freshness/watermark, lag, negative-result safety, outage/restart/backlog catch-up, cancellation, authorization, Product replay, or replay-repair evidence exists; consumer and production partition cutover remain forbidden`
-- Evidence: `PR #2544 merged as b647a5a17f27b34a07c20cd57525ed1806994c49; PR #2554 merged as 5b9d49e65295819ee9e8e9c199688c0e2ac73d35; PR #2576 merged as aef96f57d3babc2efdc65cc0c57cfea6fb48b5ad; PR #2578 merged as 9d725de7bac2039c86d5b5dffdf5d6be1b4812a8; PR #2585 merged as 1863a28fa2ebccdab39f19fce5b6971078e7e9f3; same-SHA Index Storage Scale Run Contract and full Scale Evidence contract passed JavaScript syntax, workflow contracts, repository contracts, direct validator arguments and fixture suites; source replay registry, one-page checkpoint progression, replay job fencing, bounded multi-page runner, cancellation, shared replay runtime, operator guard, source factory, stable event identity, and selected Product source are present without implementation-agent test execution; general CI/Hardening received no jobs; Rust-hosted smoke previously stopped before compilation because Cargo.lock required an Athanor update under --locked`
-- Next action: `add Product and translation tombstones plus source-versioned incremental event acknowledgement, then add ProductVariant and SalesChannel schemas/links/sources; implement scheduler/retry/shutdown ownership only after command and source contracts are fixed; execute retained PostgreSQL packet, live query equivalence, and per-tenant freshness/outage/recovery evidence before authoritative cutover`
-- Resume command: `cargo fmt --all -- --check && cargo check -p rustok-index --all-targets && cargo check -p rustok-distribution --all-targets --features mod-product && cargo check -p rustok-server --all-targets && node scripts/verify/verify-index-product-source.mjs && node scripts/verify/verify-index-query-contract.mjs && node scripts/verify/index-storage-tooling.mjs contract && node scripts/verify/index-storage-tooling.mjs fixtures`
+- Fixed in this pass: `actualized stale M6/M7 plan state; preserved bounded replay and reconciliation non-claims; added Channel-owned retained hard-delete identities with monotonic reuse fencing; replayed SalesChannel deletes through the existing source with the same schema fingerprint, source name, cursor and event domain; added fail-closed live/tombstone identity checks, documentation, and a static repository guard`
+- Remaining risks or blockers: `one retained admitted real PostgreSQL partition packet is absent; live PostgreSQL/reference query equivalence remains open; in-page interruption, automatic retry/backoff, dead-letter scheduling, host scheduling, graceful task shutdown, authorized command transports, locale/partition checkpoint dimensions, mutation-source event acknowledgement, persisted per-tenant schema readiness, durable Product-to-SalesChannel relations, tombstone purge admission, and additional production source adapters remain absent; no retained per-tenant freshness/watermark, lag, negative-result safety, outage/restart/backlog catch-up, delete/recreate, cancellation, authorization, replay, reconciliation, or repair evidence exists; consumer and production partition cutover remain forbidden`
+- Evidence: `PR #2604 added the first Product source; PR #2611 added ProductVariant; PR #2616 added SalesChannel; PR #2623 added Product graph v2 and Product-to-ProductVariant links; PR #2628 added retained Product/translation/ProductVariant deletes; PR #2632 added bounded source reconciliation. This SalesChannel tombstone slice is source-ready without implementation-agent test, verifier, Cargo, CI, or PostgreSQL execution.`
+- Next action: `define the source-versioned incremental mutation event and acknowledgement contract, then persist/apply exact per-tenant M7 schemas and add durable Product-to-SalesChannel relations; execute retained delete/recreate, replay/reconciliation, freshness/outage/recovery, live query equivalence, and partition evidence before authoritative cutover`
+- Resume command: `cargo fmt --all -- --check && cargo check -p rustok-channel --all-targets && cargo check -p rustok-index --all-targets && cargo check -p rustok-distribution --all-targets --features mod-product && cargo check -p rustok-server --all-targets && node scripts/verify/verify-index-sales-channel-source.mjs && node scripts/verify/verify-index-source-reconciliation.mjs && node scripts/verify/verify-index-product-tombstone-source.mjs && node scripts/verify/verify-index-query-contract.mjs && node scripts/verify/index-storage-tooling.mjs contract && node scripts/verify/index-storage-tooling.mjs fixtures`

--- a/crates/rustok-index/docs/m6-reconciliation-dead-letter-admission.md
+++ b/crates/rustok-index/docs/m6-reconciliation-dead-letter-admission.md
@@ -1,0 +1,82 @@
+# Reconciliation dead-letter admission
+
+Status: production admission and PostgreSQL regression retained, not run.
+
+## Boundary
+
+A terminal failed reconciliation job now blocks later runs for the same tenant and schema scope.
+
+The acquisition transaction continues to take the existing reconciliation scope advisory lock and verify the persisted schema before reading jobs. Scope resolution includes `failed` rows and uses deterministic precedence:
+
+1. a retained `succeeded` row remains authoritative completion;
+2. an existing `running` or `pending` row remains authoritative active work;
+3. only when no successful or active row exists does the newest `failed` row block admission.
+
+The runner returns `IndexReconciliationRunError::DeadLettered` instead of silently inserting a new reconciliation job.
+
+## Bounded error contract
+
+`DeadLettered` exposes only:
+
+- the failed job UUID;
+- its durable attempt count;
+- its optional validated `last_error_code`.
+
+The acquisition query does not load `last_error_details`. Database, source, mutation, transport, tenant, worker, request, stack, and arbitrary diagnostic payloads are not returned through the error.
+
+Stored error codes must be non-empty, trimmed, free of control characters, and at most 128 bytes. An invalid stored code fails closed through `InvalidStoredJob` rather than being propagated.
+
+The current page-failure transition stores `index.reconciliation_page_failed` as the bounded error code. The source or mutation dependency code remains inside the separately persisted bounded diagnostic object and is not part of dead-letter admission.
+
+## PostgreSQL regression
+
+The environment-gated target creates a unique schema, creates a tenant fixture, applies every real `IndexModule` migration, persists one active schema, and constructs the canonical source and schema registries.
+
+A counted source fails its first scan with permanent owner code `owner_source_permanent_dead_letter`. The runner must create exactly one attempt-1 reconciliation job and terminalize it as failed with:
+
+- zero completed passes and zero processed pages;
+- released lease ownership;
+- non-null completion timestamp;
+- `last_error_code = index.reconciliation_page_failed`;
+- the existing three-field reconciliation failure diagnostic;
+- zero entity and inbox writes.
+
+The test then replaces only `last_error_details` with a private marker. A newly constructed runner invokes the same scope and must return `DeadLettered` with the same job UUID, attempt count `1`, and only the generic page-failure code.
+
+The second invocation must not call the source, create another job, change the failed row, or expose either the private marker or owner dependency code through Debug or Display output.
+
+## Compatibility
+
+This slice changes no migration, table shape, request or cursor wire contract, source ownership, mutation identity, schema fingerprint, failure transition, cancellation transition, lease fencing, or terminal success behavior.
+
+It mirrors the fail-closed replay dead-letter admission boundary while remaining independently owned by reconciliation.
+
+## Remaining work
+
+This is admission only. It does not add:
+
+- authorized dead-letter inspection;
+- actor/reason audit records;
+- manual requeue or retry-epoch reset;
+- automatic retry, backoff, exhaustion, or scheduling;
+- host polling or graceful task shutdown;
+- source/index digest comparison;
+- orphan cleanup;
+- targeted, full, or shadow repair;
+- locale or partition checkpoint dimensions;
+- complete drift repair.
+
+The canonical M6 reconciliation and drift-repair item therefore remains open.
+
+## Suggested validation
+
+```bash
+RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
+  cargo test -p rustok-index \
+  --test source_reconciliation_dead_letter_admission_postgres_test \
+  -- --nocapture
+
+cargo check -p rustok-index --all-targets
+
+node scripts/verify/verify-index-reconciliation-dead-letter-admission.mjs
+```

--- a/crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md
+++ b/crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md
@@ -1,0 +1,64 @@
+# Reconciliation dead-letter inspection
+
+Status: `source_complete_owner_execution_pending`.
+
+## Purpose
+
+`PostgresIndexReconciliationDeadLetterInspector` provides a bounded, read-only view of one failed reconciliation job after dead-letter admission has blocked the tenant/schema scope.
+
+The adapter requires an exact non-nil tenant UUID and job UUID. Its query is restricted to `kind = 'reconcile'` and `state = 'failed'`, so cross-tenant, non-reconciliation, active, successful, cancelled, or unknown jobs return no inspection.
+
+## Returned contract
+
+The public inspection contains only:
+
+- job UUID;
+- positive durable attempt count;
+- optional bounded `last_error_code`;
+- bounded `dependency_code` from `index_reconciliation_run_failure_v1`;
+- retryable flag.
+
+Both machine codes are limited to 128 ASCII bytes and lowercase letters, digits, `.`, `_`, or `-`. Stored diagnostics must match the exact three-field failure contract; unknown fields, unsupported contract versions, invalid codes, zero/overflowing attempts, and malformed JSON fail closed.
+
+The query does not select or return tenant identifiers, schema request JSON, source cursors, worker IDs, lease fields, timestamps, mutation payloads, SQL, database causes, transport details, stack text, or arbitrary diagnostic values. Storage failures map to one stable error without embedding the database error.
+
+## Authorization boundary
+
+The Index adapter intentionally accepts no actor or permission object and remains transport-neutral.
+
+The server now composes `IndexReconciliationDeadLetterOperatorRuntime` only when the guarded reconciliation operator exists. Its `inspect_dead_letter(context, job_id)` method:
+
+- derives tenant scope only from the non-nil `IndexReconciliationOperatorContext`;
+- reads the current request-bound effective RBAC snapshot for that exact tenant and actor;
+- requires `modules:manage` before invoking the inspector;
+- accepts no independent caller-supplied tenant;
+- returns the same bounded read-only inspection contract.
+
+GraphQL, HTTP, CLI, MCP, and admin transport mapping remain open and must consume the guarded server capability rather than the PostgreSQL adapter directly.
+
+## Compatibility
+
+The slice adds no migration and changes no reconciliation job state, lease, retry, cursor, source, mutation, schema, or admission behavior. Inspection is read-only and can be deployed independently of manual requeue or retry-epoch reset.
+
+## Remaining work
+
+- transport mapping over the guarded server capability;
+- actor/reason audit records;
+- manual requeue or retry-epoch reset under the reconciliation scope lock;
+- automatic retry/backoff/exhaustion and host scheduling;
+- digest comparison, orphan cleanup, targeted/full/shadow repair;
+- locale/partition checkpoint dimensions and complete drift-repair admission;
+- retained PostgreSQL/server execution evidence.
+
+## Suggested maintainer validation
+
+```bash
+cargo test -p rustok-index source_reconciliation_dead_letter_inspector -- --nocapture
+cargo test -p rustok-server index_reconciliation -- --nocapture
+cargo check -p rustok-index --all-targets
+cargo check -p rustok-server --all-targets
+node scripts/verify/verify-index-reconciliation-dead-letter-inspection.mjs
+node scripts/verify/verify-index-server-reconciliation-guard.mjs
+```
+
+The implementation agent did not run formatting, Cargo commands, JavaScript verifiers, PostgreSQL fixtures, or CI, per maintainer instruction.

--- a/crates/rustok-index/docs/m7-sales-channel-source.md
+++ b/crates/rustok-index/docs/m7-sales-channel-source.md
@@ -1,24 +1,26 @@
-# M7 SalesChannel schema and bounded replay source
+# M7 SalesChannel schema, bounded replay source, and retained deletes
 
 Status: `source_complete_owner_execution_pending`
 
-This slice publishes the first Channel-owned current-state replay contract for
+This slice publishes the Channel-owned replay contract for
 `rustok-channel::sales_channel@1` without adding Channel semantics to Index core or the
-server.
+server. The stable source now covers both current rows and retained hard-delete
+identities.
 
 ## Ownership
 
 `rustok-channel` owns the `channels` table, the `ChannelRuntimeSelected` composition marker,
-and the positive monotonic `channels.index_revision` storage contract. The owner crate does
-not depend on `rustok-index` and does not construct generic Index mutations.
+the positive monotonic `channels.index_revision` storage contract, and the
+`channel_index_tombstones` replay-identity table. The owner crate does not depend on
+`rustok-index` and does not construct generic Index mutations.
 
 `rustok-distribution` owns the selected cross-module adapter because it already composes both
 Channel and Index. The adapter registers one schema and one host-database-aware source factory
 only when `ChannelModule` participated in runtime extension registration.
 
 `rustok-index` owns generic schema/source registration, deterministic event identity, immutable
-source registry materialization, replay jobs/checkpoints, mutation persistence, and query
-execution. The server remains Channel-agnostic.
+source registry materialization, replay jobs/checkpoints, reconciliation, mutation persistence,
+and query execution. The server remains Channel-agnostic.
 
 ## Schema
 
@@ -43,22 +45,40 @@ this schema.
 
 The selected `sales-channel-postgres-primary` source:
 
-- reads only the Channel-owned `channels` table;
+- reads only Channel-owned `channels` and `channel_index_tombstones` tables;
 - requires exact tenant and exact schema scope;
-- scans in stable `channel_id` UUID order with one-row lookahead;
+- scans live and deleted identities in stable `channel_id` UUID order with one-row lookahead;
 - persists an opaque cursor containing only `channel_id`;
 - never orders or paginates by mutable `index_revision`;
 - supports bounded targeted loads over exact non-localized entity keys;
 - rejects locale-bearing targeted keys;
-- rejects nil tenant/channel identities, non-positive revisions, and empty required strings;
-- emits generic `IndexMutation::Upsert` records with no links;
-- derives stable event UUIDs from tenant, channel, and source revision;
+- rejects nil tenant/channel identities and non-positive revisions;
+- rejects any live/tombstone coexistence for the same `(tenant_id, channel_id)` identity;
+- emits generic `IndexMutation::Upsert` records for live rows and `IndexMutation::Delete`
+  values for retained deletes;
+- derives stable event UUIDs from tenant, channel, and source revision for both mutation kinds;
 - maps storage failures to one bounded retryable code and contract/backend failures to bounded
   permanent codes.
 
 `index_revision` is the mutation `source_version`; it is not the scan cursor. A PostgreSQL
 trigger advances it exactly once for every Channel update and rejects revision exhaustion.
 The SeaORM owner model and public Channel DTOs do not expose the storage-internal column.
+
+## Retained deletion and identity reuse
+
+A `BEFORE DELETE` trigger stores the exact Channel identity at `OLD.index_revision + 1`.
+The tombstone table has no foreign key back to `channels` or `tenants`, so owner deletion and
+tenant cascade cannot erase the replay identity before Index observes it.
+
+A recreated `(tenant_id, channel_id)` is seeded strictly above the retained delete version.
+The retained row is removed only after the live revision is greater. Equal or lower live
+revisions fail the owner write instead of allowing a stale upsert to suppress a delete.
+Channel identity moves retain the old key at the newly advanced revision and clear the new key
+only after the same strict supersession check.
+
+The replay query unions current rows and retained deletes, then computes an exact identity
+count. A count other than one is a permanent source-contract failure; the adapter never chooses
+nondeterministically between live and deleted state.
 
 ## Composition
 
@@ -72,15 +92,16 @@ started by this slice.
 
 ## Explicitly open
 
-- Channel hard-delete tombstones;
 - incremental Channel event ingestion and broker acknowledgement;
+- tombstone retention and purge admission after every relevant consumer checkpoint is newer;
 - persisted per-tenant schema application;
-- repeatable-read full-scan snapshot and concurrent-insert reconciliation semantics;
-- versioned Product/ProductVariant to SalesChannel links;
+- owner snapshot/high-watermark semantics beyond bounded multi-pass reconciliation;
+- durable Product/ProductVariant to SalesChannel relations and revision semantics;
 - Channel target, binding, and resolution-policy schemas;
 - authoritative Storefront/Admin/Search consumer cutover;
 - retry/backoff/dead-letter scheduling and graceful host task ownership;
-- retained PostgreSQL replay, restart, drift, freshness, and equivalence evidence.
+- retained PostgreSQL delete/recreate, replay, restart, drift, freshness, and equivalence
+  evidence.
 
 Runtime capability presence does not establish persisted schema readiness. Consumers must not
 query this schema authoritatively until the exact tenant schema is applied and the relevant

--- a/crates/rustok-index/src/infrastructure/postgres/mod.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/mod.rs
@@ -7,6 +7,7 @@ mod schema_lease;
 mod schema_registration;
 mod secondary_index;
 mod source_factory;
+mod source_reconciliation_dead_letter_inspector;
 mod source_reconciliation_runner;
 mod source_replay;
 mod source_replay_job;
@@ -64,6 +65,10 @@ pub use source_factory::{
     PostgresIndexSourceFactory, PostgresIndexSourceFactoryCatalog,
     PostgresIndexSourceFactoryDescriptor, PostgresIndexSourceFactoryError,
     materialize_postgres_index_sources, register_postgres_index_source_factory,
+};
+pub use source_reconciliation_dead_letter_inspector::{
+    IndexReconciliationDeadLetterInspection, IndexReconciliationDeadLetterInspectionError,
+    PostgresIndexReconciliationDeadLetterInspector,
 };
 pub use source_reconciliation_runner::{
     IndexReconciliationCancelOutcome, IndexReconciliationRunError,

--- a/crates/rustok-index/src/infrastructure/postgres/source_reconciliation_dead_letter_inspector.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_reconciliation_dead_letter_inspector.rs
@@ -1,0 +1,323 @@
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DbBackend, QueryResult, Statement, Value as SqlValue,
+};
+use serde::Deserialize;
+use serde_json::Value as JsonValue;
+use thiserror::Error;
+use uuid::Uuid;
+
+const RECONCILIATION_FAILURE_CONTRACT: &str = "index_reconciliation_run_failure_v1";
+const MAX_ERROR_CODE_BYTES: usize = 128;
+
+/// A bounded, read-only view of one failed reconciliation job.
+///
+/// The inspection intentionally excludes the tenant, schema request, cursor, worker,
+/// lease, timestamps, and raw diagnostic JSON. Callers receive only stable machine
+/// fields that are safe to expose behind an operator authorization boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexReconciliationDeadLetterInspection {
+    job_id: Uuid,
+    attempt_count: u32,
+    error_code: Option<String>,
+    dependency_code: String,
+    retryable: bool,
+}
+
+impl IndexReconciliationDeadLetterInspection {
+    pub fn job_id(&self) -> Uuid {
+        self.job_id
+    }
+
+    pub fn attempt_count(&self) -> u32 {
+        self.attempt_count
+    }
+
+    pub fn error_code(&self) -> Option<&str> {
+        self.error_code.as_deref()
+    }
+
+    pub fn dependency_code(&self) -> &str {
+        &self.dependency_code
+    }
+
+    pub fn retryable(&self) -> bool {
+        self.retryable
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StoredReconciliationFailure {
+    contract: String,
+    dependency_code: String,
+    retryable: bool,
+}
+
+/// PostgreSQL-backed read-only dead-letter inspector.
+///
+/// Authorization is deliberately not accepted as data by this adapter. Server,
+/// GraphQL, HTTP, CLI, and admin callers must authorize the exact tenant and actor
+/// before invoking `inspect`.
+#[derive(Clone)]
+pub struct PostgresIndexReconciliationDeadLetterInspector {
+    db: DatabaseConnection,
+}
+
+impl PostgresIndexReconciliationDeadLetterInspector {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    pub async fn inspect(
+        &self,
+        tenant_id: Uuid,
+        job_id: Uuid,
+    ) -> Result<Option<IndexReconciliationDeadLetterInspection>, IndexReconciliationDeadLetterInspectionError>
+    {
+        if tenant_id.is_nil() {
+            return Err(IndexReconciliationDeadLetterInspectionError::NilTenantId);
+        }
+        if job_id.is_nil() {
+            return Err(IndexReconciliationDeadLetterInspectionError::NilJobId);
+        }
+
+        let backend = self.db.get_database_backend();
+        ensure_supported_backend(backend)?;
+        let row = self
+            .db
+            .query_one(Statement::from_sql_and_values(
+                backend,
+                select_failed_job_sql(backend),
+                vec![uuid_value(tenant_id, backend), uuid_value(job_id, backend)],
+            ))
+            .await
+            .map_err(|_| IndexReconciliationDeadLetterInspectionError::Storage)?;
+        row.map(|row| decode_failed_job(&row, job_id))
+            .transpose()
+    }
+}
+
+fn decode_failed_job(
+    row: &QueryResult,
+    job_id: Uuid,
+) -> Result<IndexReconciliationDeadLetterInspection, IndexReconciliationDeadLetterInspectionError> {
+    let attempt_count: i64 = row
+        .try_get("", "attempt_count_value")
+        .map_err(|_| IndexReconciliationDeadLetterInspectionError::Storage)?;
+    let attempt_count = u32::try_from(attempt_count).map_err(|_| {
+        IndexReconciliationDeadLetterInspectionError::InvalidStoredJob(
+            "attempt count is outside the u32 range",
+        )
+    })?;
+    if attempt_count == 0 {
+        return Err(IndexReconciliationDeadLetterInspectionError::InvalidStoredJob(
+            "attempt count must be positive",
+        ));
+    }
+
+    let error_code: Option<String> = row
+        .try_get("", "last_error_code")
+        .map_err(|_| IndexReconciliationDeadLetterInspectionError::Storage)?;
+    if let Some(code) = &error_code {
+        validate_machine_code(code).map_err(|_| {
+            IndexReconciliationDeadLetterInspectionError::InvalidStoredJob(
+                "last_error_code is outside the bounded machine-code contract",
+            )
+        })?;
+    }
+
+    let details: JsonValue = row
+        .try_get("", "last_error_details")
+        .map_err(|_| IndexReconciliationDeadLetterInspectionError::Storage)?;
+    let details: StoredReconciliationFailure = serde_json::from_value(details).map_err(|_| {
+        IndexReconciliationDeadLetterInspectionError::InvalidStoredJob(
+            "last_error_details does not match the reconciliation failure contract",
+        )
+    })?;
+    if details.contract != RECONCILIATION_FAILURE_CONTRACT {
+        return Err(IndexReconciliationDeadLetterInspectionError::InvalidStoredJob(
+            "last_error_details contract is unsupported",
+        ));
+    }
+    validate_machine_code(&details.dependency_code).map_err(|_| {
+        IndexReconciliationDeadLetterInspectionError::InvalidStoredJob(
+            "dependency_code is outside the bounded machine-code contract",
+        )
+    })?;
+
+    Ok(IndexReconciliationDeadLetterInspection {
+        job_id,
+        attempt_count,
+        error_code,
+        dependency_code: details.dependency_code,
+        retryable: details.retryable,
+    })
+}
+
+fn validate_machine_code(value: &str) -> Result<(), ()> {
+    if value.is_empty()
+        || value.len() > MAX_ERROR_CODE_BYTES
+        || value.trim() != value
+        || !value.bytes().all(|byte| {
+            byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || matches!(byte, b'.' | b'_' | b'-')
+        })
+    {
+        return Err(());
+    }
+    Ok(())
+}
+
+fn ensure_supported_backend(
+    backend: DbBackend,
+) -> Result<(), IndexReconciliationDeadLetterInspectionError> {
+    match backend {
+        DbBackend::Postgres => Ok(()),
+        DbBackend::Sqlite if cfg!(test) => Ok(()),
+        _ => Err(IndexReconciliationDeadLetterInspectionError::UnsupportedBackend),
+    }
+}
+
+fn placeholder_prefix(backend: DbBackend) -> &'static str {
+    match backend {
+        DbBackend::Postgres => "$",
+        DbBackend::Sqlite => "?",
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+fn uuid_value(value: Uuid, backend: DbBackend) -> SqlValue {
+    match backend {
+        DbBackend::Postgres => value.into(),
+        DbBackend::Sqlite => value.to_string().into(),
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+fn select_failed_job_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    let attempt_count = match backend {
+        DbBackend::Postgres => "CAST(attempt_count AS BIGINT)",
+        DbBackend::Sqlite => "CAST(attempt_count AS INTEGER)",
+        _ => unreachable!("unsupported database backend was validated"),
+    };
+    format!(
+        "SELECT {attempt_count} AS attempt_count_value, last_error_code, last_error_details FROM index_jobs WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'reconcile' AND state = 'failed' LIMIT 1"
+    )
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum IndexReconciliationDeadLetterInspectionError {
+    #[error("Index reconciliation dead-letter inspection tenant id must not be nil")]
+    NilTenantId,
+    #[error("Index reconciliation dead-letter inspection job id must not be nil")]
+    NilJobId,
+    #[error("stored Index reconciliation dead letter is invalid: {0}")]
+    InvalidStoredJob(&'static str),
+    #[error("Index reconciliation dead-letter inspection does not support this database backend")]
+    UnsupportedBackend,
+    #[error("Index reconciliation dead-letter inspection storage operation failed")]
+    Storage,
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{Database, DbBackend, Statement};
+    use serde_json::json;
+
+    use super::*;
+
+    async fn database() -> DatabaseConnection {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+        db.execute(Statement::from_string(
+            DbBackend::Sqlite,
+            "CREATE TABLE index_jobs (tenant_id TEXT NOT NULL, job_id TEXT NOT NULL, kind TEXT NOT NULL, state TEXT NOT NULL, attempt_count INTEGER NOT NULL, last_error_code TEXT NULL, last_error_details JSON NOT NULL)"
+                .to_owned(),
+        ))
+        .await
+        .expect("index_jobs fixture");
+        db
+    }
+
+    async fn insert_failed(
+        db: &DatabaseConnection,
+        tenant_id: Uuid,
+        job_id: Uuid,
+        details: JsonValue,
+    ) {
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO index_jobs (tenant_id, job_id, kind, state, attempt_count, last_error_code, last_error_details) VALUES (?1, ?2, 'reconcile', 'failed', 3, ?3, ?4)",
+            vec![
+                tenant_id.to_string().into(),
+                job_id.to_string().into(),
+                "index.reconciliation_page_failed".into(),
+                SqlValue::Json(Some(Box::new(details))),
+            ],
+        ))
+        .await
+        .expect("failed job fixture");
+    }
+
+    #[tokio::test]
+    async fn inspection_is_tenant_scoped_and_bounded() {
+        let db = database().await;
+        let tenant_id = Uuid::new_v4();
+        let job_id = Uuid::new_v4();
+        insert_failed(
+            &db,
+            tenant_id,
+            job_id,
+            json!({
+                "contract": RECONCILIATION_FAILURE_CONTRACT,
+                "dependency_code": "owner_source_retryable",
+                "retryable": true
+            }),
+        )
+        .await;
+        let inspector = PostgresIndexReconciliationDeadLetterInspector::new(db);
+
+        assert!(inspector.inspect(Uuid::new_v4(), job_id).await.unwrap().is_none());
+        let inspection = inspector
+            .inspect(tenant_id, job_id)
+            .await
+            .unwrap()
+            .expect("exact tenant failed job");
+        assert_eq!(inspection.job_id(), job_id);
+        assert_eq!(inspection.attempt_count(), 3);
+        assert_eq!(
+            inspection.error_code(),
+            Some("index.reconciliation_page_failed")
+        );
+        assert_eq!(inspection.dependency_code(), "owner_source_retryable");
+        assert!(inspection.retryable());
+    }
+
+    #[tokio::test]
+    async fn inspection_fails_closed_on_unbounded_diagnostic_shape() {
+        let db = database().await;
+        let tenant_id = Uuid::new_v4();
+        let job_id = Uuid::new_v4();
+        insert_failed(
+            &db,
+            tenant_id,
+            job_id,
+            json!({
+                "contract": RECONCILIATION_FAILURE_CONTRACT,
+                "dependency_code": "owner_source_permanent",
+                "retryable": false,
+                "private_detail": "must-not-pass"
+            }),
+        )
+        .await;
+        let inspector = PostgresIndexReconciliationDeadLetterInspector::new(db);
+
+        assert!(matches!(
+            inspector.inspect(tenant_id, job_id).await,
+            Err(IndexReconciliationDeadLetterInspectionError::InvalidStoredJob(_))
+        ));
+    }
+}

--- a/crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner.rs
@@ -29,6 +29,7 @@ const MAX_PAGES_PER_RUN: usize = 1_024;
 const MAX_PASSES: u32 = 8;
 const MAX_SOURCE_NAME_BYTES: usize = 128;
 const MAX_WORKER_ID_BYTES: usize = 191;
+const MAX_ERROR_CODE_BYTES: usize = 128;
 const MAX_LEASE_SECONDS: u64 = 86_400;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -529,6 +530,7 @@ struct StoredReconciliationJob {
     cursor: ReconciliationCursor,
     attempt_count: u32,
     claimable: bool,
+    last_error_code: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -596,6 +598,13 @@ async fn acquire_in_transaction(
             "running" | "pending" => {
                 claimable = Some(stored);
                 break;
+            }
+            "failed" => {
+                return Err(IndexReconciliationRunError::DeadLettered {
+                    job_id: stored.job_id,
+                    attempt_count: stored.attempt_count,
+                    error_code: stored.last_error_code,
+                });
             }
             state => {
                 return Err(IndexReconciliationRunError::InvalidStoredJob(format!(
@@ -715,6 +724,16 @@ fn stored_job(
             "attempt count is outside the u32 range".to_owned(),
         )
     })?;
+    let last_error_code: Option<String> = row
+        .try_get("", "last_error_code")
+        .map_err(storage_error)?;
+    if let Some(code) = &last_error_code {
+        validate_storage_text(code, MAX_ERROR_CODE_BYTES).map_err(|_| {
+            IndexReconciliationRunError::InvalidStoredJob(
+                "last_error_code is outside the reconciliation error contract".to_owned(),
+            )
+        })?;
+    }
     Ok(StoredReconciliationJob {
         job_id: stored_uuid(row, "job_id", backend)?,
         state: row.try_get("", "state").map_err(storage_error)?,
@@ -722,6 +741,7 @@ fn stored_job(
         cursor,
         attempt_count,
         claimable: row.try_get("", "claimable").map_err(storage_error)?,
+        last_error_code,
     })
 }
 
@@ -1178,7 +1198,7 @@ fn select_jobs_sql(backend: DbBackend) -> String {
         _ => unreachable!("unsupported database backend was validated"),
     };
     format!(
-        "SELECT job_id, state, request, cursor, {attempt_count} AS attempt_count_value, {claimable} AS claimable FROM index_jobs WHERE tenant_id = {prefix}1 AND module_name = {prefix}2 AND entity_name = {prefix}3 AND schema_version = {prefix}4 AND kind = 'reconcile' AND scope_kind = 'schema' AND state IN ('pending', 'running', 'succeeded') ORDER BY CASE state WHEN 'succeeded' THEN 0 WHEN 'running' THEN 1 ELSE 2 END, created_at DESC"
+        "SELECT job_id, state, request, cursor, last_error_code, {attempt_count} AS attempt_count_value, {claimable} AS claimable FROM index_jobs WHERE tenant_id = {prefix}1 AND module_name = {prefix}2 AND entity_name = {prefix}3 AND schema_version = {prefix}4 AND kind = 'reconcile' AND scope_kind = 'schema' AND state IN ('pending', 'running', 'succeeded', 'failed') ORDER BY CASE state WHEN 'succeeded' THEN 0 WHEN 'running' THEN 1 WHEN 'pending' THEN 2 ELSE 3 END, created_at DESC"
     )
 }
 
@@ -1302,6 +1322,14 @@ pub enum IndexReconciliationRunError {
     SchemaNotRegistered(SchemaRef),
     #[error("Index reconciliation schema is retired: {0}")]
     SchemaRetired(SchemaRef),
+    #[error(
+        "Index reconciliation scope is blocked by failed job {job_id} after attempt {attempt_count}"
+    )]
+    DeadLettered {
+        job_id: Uuid,
+        attempt_count: u32,
+        error_code: Option<String>,
+    },
     #[error("stored Index reconciliation job is invalid: {0}")]
     InvalidStoredJob(String),
     #[error("stored Index reconciliation job has unsupported state {0}")]

--- a/crates/rustok-index/src/lib.rs
+++ b/crates/rustok-index/src/lib.rs
@@ -6,11 +6,12 @@
 //! schema registration, bounded source replay/load contracts, one-page replay
 //! orchestration with durable fenced checkpoint progression, bounded multi-page
 //! replay coordination with heartbeat/yield/cancellation semantics, bounded
-//! multi-pass source reconciliation with durable pass/cursor progression,
-//! host-published replay and query capabilities, host-database-aware source factory
-//! composition, durable replay-job and schema-application leases, schema-derived
-//! secondary-index lifecycle, fail-closed measured partition admission, and the
-//! PostgreSQL execution adapter for structured Index queries.
+//! multi-pass source reconciliation with durable pass/cursor progression and
+//! bounded read-only dead-letter inspection, host-published replay and query
+//! capabilities, host-database-aware source factory composition, durable replay-job
+//! and schema-application leases, schema-derived secondary-index lifecycle,
+//! fail-closed measured partition admission, and the PostgreSQL execution adapter
+//! for structured Index queries.
 
 use async_trait::async_trait;
 use rustok_core::{
@@ -30,7 +31,8 @@ pub use infrastructure::postgres::{
     evaluate_partition_admission, materialize_postgres_index_query_runtime,
     materialize_postgres_index_replay_runtime, materialize_postgres_index_sources,
     register_postgres_index_source_factory, IndexQueryRuntimeCompositionError,
-    IndexReconciliationCancelOutcome, IndexReconciliationRunError,
+    IndexReconciliationCancelOutcome, IndexReconciliationDeadLetterInspection,
+    IndexReconciliationDeadLetterInspectionError, IndexReconciliationRunError,
     IndexReconciliationRunOutcome, IndexReconciliationRunRequest, IndexReconciliationRunStatus,
     IndexReconciliationTerminalState, IndexReplayCancelOutcome, IndexReplayJobAcquireOutcome,
     IndexReplayJobError, IndexReplayJobLease, IndexReplayJobLeaseRequest, IndexReplayRunError,
@@ -41,16 +43,16 @@ pub use infrastructure::postgres::{
     PartitionEvidence, PartitionMeasurementCoverage, PartitionRelationPlan,
     PartitionShadowEvidence, PartitionShadowPlan, PartitionStrategy,
     PersistedSchemaRegistrationOutcome, PostgresIndexQueryPort,
-    PostgresIndexReconciliationRunner, PostgresIndexReplayCheckpointStore,
-    PostgresIndexReplayJobStore, PostgresIndexReplayRunner, PostgresIndexSourceFactory,
-    PostgresIndexSourceFactoryCatalog, PostgresIndexSourceFactoryDescriptor,
-    PostgresIndexSourceFactoryError, PostgresMutationStore, PostgresSchemaLeaseStore,
-    PostgresSchemaRegistrationStore, PostgresSecondaryIndexManager, SchemaApplicationLease,
-    SchemaApplicationLeaseRequest, SchemaLeaseAcquireOutcome, SchemaLeaseError,
-    SchemaRegistrationError, SecondaryIndexClaimOutcome, SecondaryIndexError,
-    SecondaryIndexExecutionOutcome, SecondaryIndexKind, SecondaryIndexLease,
-    SecondaryIndexOperation, SecondaryIndexPlan, SecondaryIndexRequest, SecondaryIndexSpec,
-    SharedIndexReplayRuntime,
+    PostgresIndexReconciliationDeadLetterInspector, PostgresIndexReconciliationRunner,
+    PostgresIndexReplayCheckpointStore, PostgresIndexReplayJobStore, PostgresIndexReplayRunner,
+    PostgresIndexSourceFactory, PostgresIndexSourceFactoryCatalog,
+    PostgresIndexSourceFactoryDescriptor, PostgresIndexSourceFactoryError,
+    PostgresMutationStore, PostgresSchemaLeaseStore, PostgresSchemaRegistrationStore,
+    PostgresSecondaryIndexManager, SchemaApplicationLease, SchemaApplicationLeaseRequest,
+    SchemaLeaseAcquireOutcome, SchemaLeaseError, SchemaRegistrationError,
+    SecondaryIndexClaimOutcome, SecondaryIndexError, SecondaryIndexExecutionOutcome,
+    SecondaryIndexKind, SecondaryIndexLease, SecondaryIndexOperation, SecondaryIndexPlan,
+    SecondaryIndexRequest, SecondaryIndexSpec, SharedIndexReplayRuntime,
 };
 
 pub struct IndexModule;

--- a/crates/rustok-index/tests/source_reconciliation_dead_letter_admission_postgres_test.rs
+++ b/crates/rustok-index/tests/source_reconciliation_dead_letter_admission_postgres_test.rs
@@ -1,0 +1,404 @@
+use std::{
+    env,
+    error::Error,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use rustok_core::MigrationSource;
+use rustok_index::{
+    EntityName, FieldCardinality, FieldName, IndexField, IndexModule,
+    IndexReconciliationRunError, IndexReconciliationRunRequest, IndexSchema,
+    IndexSchemaSourceCatalog, IndexSource, IndexSourceCatalog, IndexSourceError,
+    IndexSourceFailure, IndexSourceFailureKind, IndexSourceLoadBatch, IndexSourceLoadRequest,
+    IndexSourcePage, IndexSourceScanRequest, IndexValueType, LocaleMode, ModuleName,
+    PostgresIndexReconciliationRunner, SchemaRef, SchemaRegistry, SchemaVersion,
+};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, QueryResult,
+    Statement, Value as SqlValue,
+};
+use sea_orm_migration::SchemaManager;
+use serde_json::{Value as JsonValue, json};
+use uuid::Uuid;
+
+const DATABASE_ENV: &str = "RUSTOK_INDEX_TEST_DATABASE_URL";
+const SOURCE_NAME: &str = "reconciliation-dead-letter-primary";
+const MODULE_NAME: &str = "reconciliation-dead-letter-harness";
+const DEPENDENCY_CODE: &str = "owner_source_permanent_dead_letter";
+const PAGE_FAILURE_CODE: &str = "index.reconciliation_page_failed";
+const PRIVATE_MARKER: &str = "private-reconciliation-failure-detail";
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+#[derive(Clone)]
+struct CountedFailingSource {
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl IndexSource for CountedFailingSource {
+    async fn scan(
+        &self,
+        _request: IndexSourceScanRequest,
+    ) -> Result<IndexSourcePage, IndexSourceFailure> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Err(
+            IndexSourceFailure::permanent(DEPENDENCY_CODE)
+                .expect("fixture dependency code must be valid"),
+        )
+    }
+
+    async fn load(
+        &self,
+        request: IndexSourceLoadRequest,
+    ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+        Ok(IndexSourceLoadBatch::new(&request, Vec::new()).expect("empty targeted load"))
+    }
+}
+
+struct TestDatabase {
+    control: DatabaseConnection,
+    database_url: String,
+    schema_name: String,
+    tenant_id: Uuid,
+}
+
+impl TestDatabase {
+    async fn setup() -> TestResult<Option<Self>> {
+        let Some(database_url) = database_url() else {
+            eprintln!(
+                "{DATABASE_ENV} is not set to a PostgreSQL URL; skipping reconciliation dead-letter admission harness"
+            );
+            return Ok(None);
+        };
+        let control = connect(&database_url).await?;
+        let schema_name = format!(
+            "rustok_index_reconciliation_dead_letter_{}",
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let tenant_id = Uuid::new_v4();
+        let db = scoped_connection(&database_url, &schema_name).await?;
+        db.execute_unprepared("CREATE TABLE tenants (id UUID NOT NULL PRIMARY KEY)")
+            .await?;
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "INSERT INTO tenants (id) VALUES ($1)",
+            vec![tenant_id.into()],
+        ))
+        .await?;
+
+        let manager = SchemaManager::new(&db);
+        for migration in IndexModule.migrations() {
+            migration.up(&manager).await?;
+        }
+        persist_schema(&db, tenant_id).await?;
+
+        Ok(Some(Self {
+            control,
+            database_url,
+            schema_name,
+            tenant_id,
+        }))
+    }
+
+    async fn connection(&self) -> TestResult<DatabaseConnection> {
+        scoped_connection(&self.database_url, &self.schema_name).await
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct FailedJobEvidence {
+    job_id: Uuid,
+    state: String,
+    attempt_count: i64,
+    completed_passes: i64,
+    pages_processed: i64,
+    last_error_code: String,
+    last_error_details: JsonValue,
+    lease_released: bool,
+    completed: bool,
+}
+
+#[tokio::test]
+async fn failed_reconciliation_scope_blocks_new_jobs_without_exposing_details() -> TestResult<()> {
+    let Some(database) = TestDatabase::setup().await? else {
+        return Ok(());
+    };
+    let calls = Arc::new(AtomicUsize::new(0));
+    let first_runner = runner(database.connection().await?, calls.clone());
+
+    let first_error = first_runner
+        .run(request(database.tenant_id, "dead-letter-worker-a"))
+        .await
+        .expect_err("fixture source failure must terminalize the first job");
+    match first_error {
+        IndexReconciliationRunError::Source(IndexSourceError::SourceFailure {
+            source_name,
+            failure,
+        }) => {
+            assert_eq!(source_name, SOURCE_NAME);
+            assert_eq!(failure.code(), DEPENDENCY_CODE);
+            assert_eq!(failure.kind(), IndexSourceFailureKind::Permanent);
+        }
+        other => panic!("unexpected first reconciliation error: {other:?}"),
+    }
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    let evidence_db = database.connection().await?;
+    let failed = read_failed_job(&evidence_db, database.tenant_id).await?;
+    assert_eq!(failed.state, "failed");
+    assert_eq!(failed.attempt_count, 1);
+    assert_eq!(failed.completed_passes, 0);
+    assert_eq!(failed.pages_processed, 0);
+    assert_eq!(failed.last_error_code, PAGE_FAILURE_CODE);
+    assert_eq!(
+        failed.last_error_details,
+        json!({
+            "contract": "index_reconciliation_run_failure_v1",
+            "dependency_code": DEPENDENCY_CODE,
+            "retryable": false,
+        })
+    );
+    assert!(failed.lease_released);
+    assert!(failed.completed);
+    assert_eq!(count(&evidence_db, "index_jobs").await?, 1);
+    assert_eq!(count(&evidence_db, "index_entities").await?, 0);
+    assert_eq!(count(&evidence_db, "index_inbox").await?, 0);
+
+    replace_private_failure_details(&evidence_db, database.tenant_id, failed.job_id).await?;
+
+    let second_runner = runner(database.connection().await?, calls.clone());
+    let blocked = second_runner
+        .run(request(database.tenant_id, "dead-letter-worker-b"))
+        .await
+        .expect_err("failed reconciliation scope must remain blocked");
+    let debug = format!("{blocked:?}");
+    let display = blocked.to_string();
+    match blocked {
+        IndexReconciliationRunError::DeadLettered {
+            job_id,
+            attempt_count,
+            error_code,
+        } => {
+            assert_eq!(job_id, failed.job_id);
+            assert_eq!(attempt_count, 1);
+            assert_eq!(error_code.as_deref(), Some(PAGE_FAILURE_CODE));
+        }
+        other => panic!("unexpected blocked reconciliation error: {other:?}"),
+    }
+    assert!(!debug.contains(PRIVATE_MARKER));
+    assert!(!debug.contains(DEPENDENCY_CODE));
+    assert!(!display.contains(PRIVATE_MARKER));
+    assert!(!display.contains(DEPENDENCY_CODE));
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    let retained = read_failed_job(&evidence_db, database.tenant_id).await?;
+    assert_eq!(retained.job_id, failed.job_id);
+    assert_eq!(retained.state, "failed");
+    assert_eq!(retained.attempt_count, 1);
+    assert_eq!(retained.last_error_code, PAGE_FAILURE_CODE);
+    assert_eq!(retained.last_error_details, json!({ "private": PRIVATE_MARKER }));
+    assert!(retained.lease_released);
+    assert!(retained.completed);
+    assert_eq!(count(&evidence_db, "index_jobs").await?, 1);
+    assert_eq!(count(&evidence_db, "index_entities").await?, 0);
+    assert_eq!(count(&evidence_db, "index_inbox").await?, 0);
+
+    database.cleanup().await
+}
+
+fn runner(
+    db: DatabaseConnection,
+    calls: Arc<AtomicUsize>,
+) -> PostgresIndexReconciliationRunner {
+    let schema = schema();
+    let mut schema_catalog = IndexSchemaSourceCatalog::new();
+    schema_catalog
+        .register(MODULE_NAME, schema.clone())
+        .expect("fixture schema source must register");
+
+    let mut source_catalog = IndexSourceCatalog::new();
+    source_catalog
+        .register(
+            MODULE_NAME,
+            SOURCE_NAME,
+            [schema.reference.clone()],
+            CountedFailingSource { calls },
+        )
+        .expect("fixture source must register");
+    let sources = source_catalog
+        .materialize(&schema_catalog)
+        .expect("fixture source registry must materialize");
+
+    let mut registry = SchemaRegistry::new();
+    registry
+        .register(schema)
+        .expect("fixture schema registry must materialize");
+
+    PostgresIndexReconciliationRunner::new(db, sources, Arc::new(registry))
+}
+
+fn request(tenant_id: Uuid, worker_id: &str) -> IndexReconciliationRunRequest {
+    IndexReconciliationRunRequest::new(
+        tenant_id,
+        schema_ref(),
+        worker_id,
+        1,
+        1,
+        1,
+        1,
+        Duration::from_secs(60),
+    )
+    .expect("fixture reconciliation request must be valid")
+}
+
+fn schema_ref() -> SchemaRef {
+    SchemaRef {
+        module: ModuleName::new(MODULE_NAME).unwrap(),
+        entity: EntityName::new("item").unwrap(),
+        version: SchemaVersion::INITIAL,
+    }
+}
+
+fn schema() -> IndexSchema {
+    IndexSchema {
+        reference: schema_ref(),
+        locale_mode: LocaleMode::None,
+        fields: vec![IndexField {
+            name: FieldName::new("id").unwrap(),
+            value_type: IndexValueType::Uuid,
+            cardinality: FieldCardinality::One,
+            nullable: false,
+            selectable: true,
+            filterable: true,
+            sortable: true,
+        }],
+        links: Vec::new(),
+    }
+}
+
+async fn persist_schema(db: &DatabaseConnection, tenant_id: Uuid) -> TestResult<()> {
+    let schema = schema();
+    let fingerprint = schema.fingerprint()?.to_string();
+    let schema_json = serde_json::to_value(&schema)?;
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "INSERT INTO index_schemas (tenant_id, module_name, entity_name, schema_version, schema_fingerprint, schema_json, status) VALUES ($1, $2, $3, $4, $5, $6, 'active')",
+        vec![
+            tenant_id.into(),
+            schema.reference.module.as_str().to_owned().into(),
+            schema.reference.entity.as_str().to_owned().into(),
+            i64::from(schema.reference.version.get()).into(),
+            fingerprint.into(),
+            SqlValue::Json(Some(Box::new(schema_json))),
+        ],
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn read_failed_job(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+) -> TestResult<FailedJobEvidence> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT job_id, state, attempt_count::bigint AS attempt_count_value, (cursor->>'completed_passes')::bigint AS completed_passes, (cursor->>'pages_processed')::bigint AS pages_processed, last_error_code, last_error_details, (lease_owner IS NULL AND lease_expires_at IS NULL) AS lease_released, (completed_at IS NOT NULL) AS completed FROM index_jobs WHERE tenant_id = $1 AND kind = 'reconcile' AND state = 'failed' ORDER BY created_at DESC LIMIT 1",
+            vec![tenant_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("failed reconciliation job is missing"))?;
+    Ok(FailedJobEvidence {
+        job_id: row.try_get("", "job_id")?,
+        state: row.try_get("", "state")?,
+        attempt_count: row.try_get("", "attempt_count_value")?,
+        completed_passes: row.try_get("", "completed_passes")?,
+        pages_processed: row.try_get("", "pages_processed")?,
+        last_error_code: row.try_get("", "last_error_code")?,
+        last_error_details: row.try_get("", "last_error_details")?,
+        lease_released: row.try_get("", "lease_released")?,
+        completed: row.try_get("", "completed")?,
+    })
+}
+
+async fn replace_private_failure_details(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    job_id: Uuid,
+) -> TestResult<()> {
+    let updated = db
+        .execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "UPDATE index_jobs SET last_error_details = $3 WHERE tenant_id = $1 AND job_id = $2 AND kind = 'reconcile' AND state = 'failed'",
+            vec![
+                tenant_id.into(),
+                job_id.into(),
+                SqlValue::Json(Some(Box::new(json!({ "private": PRIVATE_MARKER })))),
+            ],
+        ))
+        .await?;
+    if updated.rows_affected() != 1 {
+        return Err(std::io::Error::other("failed reconciliation details update lost scope").into());
+    }
+    Ok(())
+}
+
+async fn count(db: &DatabaseConnection, table: &str) -> TestResult<i64> {
+    let sql = match table {
+        "index_jobs" => "SELECT COUNT(*)::bigint AS value FROM index_jobs WHERE kind = 'reconcile'",
+        "index_entities" => "SELECT COUNT(*)::bigint AS value FROM index_entities",
+        "index_inbox" => "SELECT COUNT(*)::bigint AS value FROM index_inbox",
+        _ => panic!("unsupported fixture table"),
+    };
+    let row: QueryResult = db
+        .query_one(Statement::from_string(DbBackend::Postgres, sql.to_owned()))
+        .await?
+        .ok_or_else(|| std::io::Error::other("count query returned no row"))?;
+    Ok(row.try_get("", "value")?)
+}
+
+fn database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn scoped_connection(
+    database_url: &str,
+    schema_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url).await?;
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}""#))
+        .await?;
+    Ok(db)
+}

--- a/scripts/verify/verify-index-reconciliation-dead-letter-admission.mjs
+++ b/scripts/verify/verify-index-reconciliation-dead-letter-admission.mjs
@@ -1,0 +1,117 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const files = {
+  runner:
+    "crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner.rs",
+  target:
+    "crates/rustok-index/tests/source_reconciliation_dead_letter_admission_postgres_test.rs",
+  docs: "crates/rustok-index/docs/m6-reconciliation-dead-letter-admission.md",
+};
+
+const read = (name) => {
+  const relative = files[name];
+  const absolute = path.join(root, relative);
+  if (!fs.existsSync(absolute)) {
+    throw new Error(`missing reconciliation dead-letter admission file: ${relative}`);
+  }
+  return fs.readFileSync(absolute, "utf8");
+};
+
+const requireMarkers = (name, markers) => {
+  const content = read(name);
+  for (const marker of markers) {
+    if (!content.includes(marker)) {
+      throw new Error(`${files[name]} is missing required marker: ${marker}`);
+    }
+  }
+};
+
+const forbidMarkers = (name, markers) => {
+  const content = read(name);
+  for (const marker of markers) {
+    if (content.includes(marker)) {
+      throw new Error(`${files[name]} contains forbidden marker: ${marker}`);
+    }
+  }
+};
+
+requireMarkers("runner", [
+  "const MAX_ERROR_CODE_BYTES: usize = 128;",
+  "DeadLettered {",
+  "job_id: Uuid,",
+  "attempt_count: u32,",
+  "error_code: Option<String>,",
+  '"failed" => {',
+  "error_code: stored.last_error_code,",
+  "last_error_code: Option<String>,",
+  '.try_get("", "last_error_code")',
+  "last_error_code is outside the reconciliation error contract",
+  "state IN ('pending', 'running', 'succeeded', 'failed')",
+  "CASE state WHEN 'succeeded' THEN 0 WHEN 'running' THEN 1 WHEN 'pending' THEN 2 ELSE 3 END",
+]);
+
+const runner = read("runner");
+const selectStart = runner.indexOf("fn select_jobs_sql");
+const selectEnd = runner.indexOf("fn insert_job_sql", selectStart);
+if (selectStart < 0 || selectEnd < 0) {
+  throw new Error("could not isolate reconciliation job selection SQL");
+}
+const selectJobs = runner.slice(selectStart, selectEnd);
+if (!selectJobs.includes("last_error_code")) {
+  throw new Error("reconciliation job selection must load the bounded error code");
+}
+if (selectJobs.includes("last_error_details")) {
+  throw new Error("reconciliation dead-letter admission must not load error details");
+}
+
+const succeededBranch = runner.indexOf('"succeeded" => {');
+const activeBranch = runner.indexOf('"running" | "pending" if !stored.claimable');
+const failedBranch = runner.indexOf('"failed" => {');
+if (!(succeededBranch >= 0 && activeBranch > succeededBranch && failedBranch > activeBranch)) {
+  throw new Error("reconciliation scope precedence must remain succeeded, active, then failed");
+}
+
+requireMarkers("target", [
+  "failed_reconciliation_scope_blocks_new_jobs_without_exposing_details",
+  "RUSTOK_INDEX_TEST_DATABASE_URL",
+  "IndexModule.migrations()",
+  "owner_source_permanent_dead_letter",
+  "IndexReconciliationRunError::Source",
+  "IndexReconciliationRunError::DeadLettered",
+  "private-reconciliation-failure-detail",
+  "assert!(!debug.contains(PRIVATE_MARKER))",
+  "assert!(!debug.contains(DEPENDENCY_CODE))",
+  "assert!(!display.contains(PRIVATE_MARKER))",
+  "assert!(!display.contains(DEPENDENCY_CODE))",
+  "assert_eq!(calls.load(Ordering::SeqCst), 1)",
+  'count(&evidence_db, "index_jobs")',
+  'count(&evidence_db, "index_entities")',
+  'count(&evidence_db, "index_inbox")',
+  "DROP SCHEMA IF EXISTS",
+]);
+
+requireMarkers("docs", [
+  "Status: production admission and PostgreSQL regression retained, not run.",
+  "deterministic precedence",
+  "The acquisition query does not load `last_error_details`.",
+  "must not call the source, create another job, change the failed row",
+  "authorized dead-letter inspection",
+  "The canonical M6 reconciliation and drift-repair item therefore remains open.",
+]);
+
+forbidMarkers("target", [
+  "tokio::time::sleep",
+  "std::thread::sleep",
+  "DELETE FROM index_jobs",
+  "INSERT INTO index_jobs",
+]);
+forbidMarkers("docs", [
+  "implementation-plan.md",
+  "automatic requeue is implemented",
+  "complete drift repair is implemented",
+]);
+
+console.log("Index reconciliation dead-letter admission markers verified.");

--- a/scripts/verify/verify-index-reconciliation-dead-letter-inspection.mjs
+++ b/scripts/verify/verify-index-reconciliation-dead-letter-inspection.mjs
@@ -1,0 +1,89 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const files = {
+  inspector:
+    "crates/rustok-index/src/infrastructure/postgres/source_reconciliation_dead_letter_inspector.rs",
+  docs: "crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md",
+  audit: "crates/rustok-index/docs/implementation-plan-audit-2026-07-31.md",
+  postgres: "crates/rustok-index/src/infrastructure/postgres/mod.rs",
+  lib: "crates/rustok-index/src/lib.rs",
+};
+
+const read = (name) => {
+  const relative = files[name];
+  const absolute = path.join(root, relative);
+  if (!fs.existsSync(absolute)) {
+    throw new Error(`missing reconciliation dead-letter inspection file: ${relative}`);
+  }
+  return fs.readFileSync(absolute, "utf8");
+};
+
+const requireMarkers = (name, markers) => {
+  const content = read(name);
+  for (const marker of markers) {
+    if (!content.includes(marker)) {
+      throw new Error(`${files[name]} is missing required marker: ${marker}`);
+    }
+  }
+  return content;
+};
+
+const inspector = requireMarkers("inspector", [
+  "pub struct IndexReconciliationDeadLetterInspection",
+  "pub struct PostgresIndexReconciliationDeadLetterInspector",
+  "pub async fn inspect(",
+  "kind = 'reconcile' AND state = 'failed'",
+  "index_reconciliation_run_failure_v1",
+  "#[serde(deny_unknown_fields)]",
+  "validate_machine_code",
+  "IndexReconciliationDeadLetterInspectionError::Storage",
+  "inspection_is_tenant_scoped_and_bounded",
+  "inspection_fails_closed_on_unbounded_diagnostic_shape",
+]);
+
+for (const forbidden of [
+  "SELECT *",
+  "request, cursor",
+  "lease_owner",
+  "worker_id",
+  "completed_at",
+  "format!(\"Index reconciliation dead-letter inspection storage operation failed:",
+  "tokio::spawn",
+  "UPDATE index_jobs",
+  "DELETE FROM index_jobs",
+]) {
+  if (inspector.includes(forbidden)) {
+    throw new Error(`${files.inspector} contains forbidden marker: ${forbidden}`);
+  }
+}
+
+requireMarkers("docs", [
+  "Status: `source_complete_owner_execution_pending`",
+  "modules:manage",
+  "actor/reason audit records",
+  "manual requeue or retry-epoch reset",
+  "did not run",
+]);
+requireMarkers("audit", [
+  "merged_main",
+  "open_source_complete",
+  "owner_evidence_pending",
+  "PR #2743",
+  "PR #2639",
+  "PR #2642",
+  "PR #2644",
+  "PR #2693",
+]);
+requireMarkers("postgres", [
+  "mod source_reconciliation_dead_letter_inspector;",
+  "PostgresIndexReconciliationDeadLetterInspector",
+]);
+requireMarkers("lib", [
+  "IndexReconciliationDeadLetterInspection",
+  "PostgresIndexReconciliationDeadLetterInspector",
+]);
+
+console.log("Index reconciliation dead-letter inspection contract verified.");

--- a/scripts/verify/verify-index-sales-channel-source.mjs
+++ b/scripts/verify/verify-index-sales-channel-source.mjs
@@ -54,9 +54,9 @@ requireMarkers('crates/rustok-channel/tests/index_selection.rs', [
   'assert!(!cargo.contains("rustok-index"));',
 ]);
 
-const migrationPath =
+const revisionMigrationPath =
   'crates/rustok-channel/src/migrations/m20260730_000010_add_channel_index_revision.rs';
-const migration = requireMarkers(migrationPath, [
+const revisionMigration = requireMarkers(revisionMigrationPath, [
   'ALTER TABLE channels',
   'ADD COLUMN index_revision BIGINT NOT NULL DEFAULT 1',
   'chk_channels_index_revision_positive',
@@ -65,7 +65,38 @@ const migration = requireMarkers(migrationPath, [
   'trg_channels_bump_index_revision',
   'BEFORE UPDATE ON channels',
 ]);
-forbidMarkers(migrationPath, migration, [
+forbidMarkers(revisionMigrationPath, revisionMigration, [
+  'index_entities',
+  'index_links',
+  'index_jobs',
+  'index_checkpoints',
+]);
+
+const tombstoneMigrationPath =
+  'crates/rustok-channel/src/migrations/m20260731_000011_add_channel_index_tombstones.rs';
+const tombstoneMigration = requireMarkers(tombstoneMigrationPath, [
+  'CREATE TABLE channel_index_tombstones',
+  'PRIMARY KEY (tenant_id, channel_id)',
+  'chk_channel_index_tombstones_source_version_positive',
+  'rustok_channel_store_index_tombstone(',
+  'rustok_channel_clear_superseded_index_tombstone(',
+  'rustok_channel_seed_index_revision_from_tombstone()',
+  'retained_source_version + 1',
+  'trg_channels_seed_index_revision',
+  'BEFORE INSERT ON channels',
+  'rustok_channel_capture_index_tombstone()',
+  'OLD.index_revision + 1',
+  'trg_channels_capture_index_tombstone',
+  'BEFORE DELETE ON channels',
+  'trg_channels_clear_index_tombstone',
+  'AFTER INSERT ON channels',
+  'rustok_channel_move_index_tombstone()',
+  'AFTER UPDATE OF id, tenant_id ON channels',
+  'NEW.index_revision',
+]);
+forbidMarkers(tombstoneMigrationPath, tombstoneMigration, [
+  'REFERENCES channels',
+  'REFERENCES tenants',
   'index_entities',
   'index_links',
   'index_jobs',
@@ -74,6 +105,8 @@ forbidMarkers(migrationPath, migration, [
 requireMarkers('crates/rustok-channel/src/migrations/mod.rs', [
   'mod m20260730_000010_add_channel_index_revision;',
   'Box::new(m20260730_000010_add_channel_index_revision::Migration)',
+  'mod m20260731_000011_add_channel_index_tombstones;',
+  'Box::new(m20260731_000011_add_channel_index_tombstones::Migration)',
 ]);
 requireMarkers('crates/rustok-channel/src/migrations/m20260325_000001_create_channels.rs', [
   '.name("idx_channels_tenant_slug")',
@@ -104,6 +137,15 @@ const sourcePath = 'crates/rustok-distribution/src/channel_index.rs';
 const source = requireMarkers(sourcePath, [
   'SALES_CHANNEL_INDEX_SOURCE: &str = "sales-channel-postgres-primary"',
   'SALES_CHANNEL_EVENT_DOMAIN: &str = "rustok-channel.sales-channel-replay-v1"',
+  'SALES_CHANNEL_ROWS_CTE',
+  'sales_channel_index_union AS (',
+  'FALSE AS is_deleted',
+  'TRUE AS is_deleted',
+  'FROM channels c',
+  'FROM channel_index_tombstones tombstone',
+  'COUNT(*) OVER (',
+  'PARTITION BY row.tenant_id, row.channel_id',
+  'row.identity_count',
   'extensions.contains::<rustok_channel::ChannelRuntimeSelected>()',
   'register_index_schema_source(extensions, "channel", schema)',
   'register_postgres_index_source_factory(',
@@ -112,17 +154,18 @@ const source = requireMarkers(sourcePath, [
   'field("id", IndexValueType::Uuid, true, true)?',
   'field("slug", IndexValueType::String, true, true)?',
   'field("is_active", IndexValueType::Boolean, true, true)?',
-  'field_name("id")?, IndexValue::Uuid(self.channel_id)',
   'impl PostgresIndexSourceFactory for SalesChannelPostgresIndexSourceFactory',
   'impl IndexSource for SalesChannelPostgresIndexSource',
-  'FROM channels c',
-  'c.index_revision,',
-  'c.id > $2',
-  'ORDER BY c.id ASC',
+  'row.channel_id > $2',
+  'ORDER BY row.channel_id ASC',
   'request.limit() + 1',
   'WITH requested(channel_id) AS (VALUES {})',
-  'JOIN requested r ON r.channel_id = c.id',
+  'JOIN requested requested_key ON requested_key.channel_id = row.channel_id',
   'sales_channel_index_locale_forbidden',
+  'identity_count != 1',
+  'enum SalesChannelRowState',
+  'SalesChannelRowState::Deleted',
+  'IndexMutation::Delete',
   'derive_index_source_event_id(',
   'locale: None',
   'links: Vec::new()',
@@ -130,6 +173,7 @@ const source = requireMarkers(sourcePath, [
   'assert_eq!(schema.fields.len(), 6);',
   'selected_sales_channel_schema_is_nonlocalized_and_link_free',
   'selected_sales_channel_cursor_rejects_nil_and_unknown_fields',
+  'selected_sales_channel_tombstone_emits_delete_with_stable_identity',
   'selected_sales_channel_bridge_skips_partial_registry_without_channel_module',
   'selected_sales_channel_bridge_registers_schema_and_factory',
 ]);
@@ -138,8 +182,8 @@ forbidMarkers(sourcePath, source, [
   'IndexLink',
   'IndexLinkValue',
   'LocaleKey',
-  'ORDER BY c.index_revision',
-  '(c.index_revision, c.id)',
+  'ORDER BY row.index_revision',
+  '(row.index_revision, row.channel_id)',
   'SELECT *',
   'index_entities',
   'index_links',
@@ -161,9 +205,11 @@ requireMarkers('crates/rustok-distribution/tests/channel_index.rs', [
 
 requireMarkers('crates/rustok-channel/README.md', [
   '`channels.index_revision`',
+  '`channel_index_tombstones`',
   '`ChannelRuntimeSelected`',
   '`rustok-channel::sales_channel@1`',
   'stable `channel_id` ordering',
+  'retained hard-delete mutations',
   'does not depend on `rustok-index`',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-sales-channel-source.md', [
@@ -174,7 +220,9 @@ requireMarkers('crates/rustok-index/docs/m7-sales-channel-source.md', [
   'stable `channel_id` UUID order',
   '`index_revision` is the mutation `source_version`; it is not the scan cursor.',
   'The schema itself is link-free.',
-  'Channel hard-delete tombstones',
+  '`channel_index_tombstones`',
+  '`IndexMutation::Delete`',
+  'A count other than one is a permanent source-contract failure',
   'Runtime capability presence does not establish persisted schema readiness.',
   'maintainer-run',
 ]);

--- a/scripts/verify/verify-index-server-reconciliation-guard.mjs
+++ b/scripts/verify/verify-index-server-reconciliation-guard.mjs
@@ -1,0 +1,105 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const files = {
+  composition: "apps/server/src/services/index_replay_runtime_composition.rs",
+  base: "apps/server/src/services/index_replay_runtime_composition_base.rs",
+  operator: "apps/server/src/services/index_reconciliation_operator.rs",
+  docs: "apps/server/docs/index-reconciliation-operator-runtime.md",
+};
+
+const read = (name) => {
+  const relative = files[name];
+  const absolute = path.join(root, relative);
+  if (!fs.existsSync(absolute)) {
+    throw new Error(`missing Index server reconciliation guard file: ${relative}`);
+  }
+  return fs.readFileSync(absolute, "utf8");
+};
+
+const requireMarkers = (name, markers) => {
+  const content = read(name);
+  for (const marker of markers) {
+    if (!content.includes(marker)) {
+      throw new Error(`${files[name]} is missing required marker: ${marker}`);
+    }
+  }
+};
+
+const forbidMarkers = (name, markers) => {
+  const content = read(name);
+  for (const marker of markers) {
+    if (content.includes(marker)) {
+      throw new Error(`${files[name]} contains forbidden marker: ${marker}`);
+    }
+  }
+};
+
+requireMarkers("composition", [
+  "#[path = \"index_replay_runtime_composition_base.rs\"]",
+  "pub struct IndexReconciliationDeadLetterOperatorRuntime",
+  "permissions_for(&context.tenant_id(), &context.actor_id())",
+  "Permission::MODULES_MANAGE",
+  "inspect_dead_letter(",
+  ".inspect(context.tenant_id(), job_id)",
+  "base::materialize_index_replay_runtime(extensions, db.clone())?",
+  "extensions.contains::<IndexReconciliationOperatorRuntime>()",
+  "PostgresIndexReconciliationDeadLetterInspector::new(db)",
+  "dead_letter_inspection_requires_request_bound_authority_before_database_access",
+  "dead_letter_inspection_requires_modules_manage",
+  "authorized_dead_letter_inspection_uses_context_tenant_and_delegates",
+]);
+
+requireMarkers("base", [
+  "#[path = \"index_reconciliation_operator.rs\"]",
+  "IndexReconciliationOperatorRuntime",
+  "materialize_postgres_index_replay_runtime(extensions, db.clone())",
+  "materialize_index_reconciliation_operator(extensions, db)?",
+]);
+
+requireMarkers("operator", [
+  "pub struct IndexReconciliationOperatorContext",
+  "tenant_id.is_nil() || actor_id.is_nil()",
+  "permissions_for(&self.tenant_id, &self.actor_id)",
+  "Permission::MODULES_MANAGE",
+  "context.authorize_for(request.tenant_id())?",
+  "request_cancel(context.tenant_id(), job_id)",
+  "PostgresIndexReconciliationRunner::new(db, sources, schemas.shared())",
+]);
+
+requireMarkers("docs", [
+  "Status: implementation retained, not run.",
+  "Run, cancellation, and dead-letter inspection require `Permission::MODULES_MANAGE`.",
+  "derive tenant scope only from the authorized `IndexReconciliationOperatorContext`",
+  "publishes the dead-letter inspection operator",
+  "does not add audit records",
+  "The canonical M6 reconciliation and drift-repair item therefore remains open.",
+]);
+
+forbidMarkers("composition", [
+  "tokio::spawn",
+  "spawn_blocking",
+  "SELECT ",
+  "INSERT ",
+  "UPDATE ",
+  "DELETE ",
+  "Router::new",
+  "route(",
+  "async_graphql",
+]);
+
+forbidMarkers("operator", [
+  "tokio::spawn",
+  "spawn_blocking",
+  "SELECT ",
+  "INSERT ",
+  "UPDATE ",
+  "DELETE ",
+  "Router::new",
+  "route(",
+  "async_graphql",
+]);
+
+console.log("Index server reconciliation run/cancel/dead-letter guards verified.");


### PR DESCRIPTION
## Summary

- supersede draft PRs #2751 and #2693 with one fresh branch built directly on current `main`
- retain the canonical `rustok-index` plan/M7 SalesChannel tombstone work, reconciliation failed-scope admission, and bounded core dead-letter inspector from #2751
- retain the server-owned guarded reconciliation run/cancel operator from #2693
- add `IndexReconciliationDeadLetterOperatorRuntime` as a request-bound read-only server capability
- derive tenant scope only from `IndexReconciliationOperatorContext`; callers provide only the failed job UUID
- require the current effective `modules:manage` permission before any inspector/database delegation
- preserve bounded inspection output and stable typed errors without exposing raw diagnostic JSON, SQL, database causes, request/schema/cursor data, worker/lease fields, timestamps, transport details, or stack text
- update the dated implementation audit and operator/inspection docs
- extend the fail-closed server verifier with authorization, composition, and no-transport/no-SQL markers

## Fresh-base reconstruction

The final branch is one commit directly on current `main` (`bd25ea3577b164225359beba86f973e907b74bef`). The branch was assembled through exact Git blob/tree objects so concurrent Forum/Search work on `main` is preserved.

Final relationship before PR creation:

- ahead of `main`: 1 commit
- behind `main`: 0 commits
- changed files: 23

The existing PR #2693 composition is retained byte-for-byte in `apps/server/src/services/index_replay_runtime_composition_base.rs`. The public composition module is a small wrapper that delegates to that base and conditionally publishes the new dead-letter operator only when the guarded reconciliation run/cancel capability exists.

## Authorization boundary

`inspect_dead_letter(context, job_id)`:

1. reads tenant and actor only from the non-nil `IndexReconciliationOperatorContext`;
2. reads the current request-scoped effective RBAC snapshot for that exact pair;
3. requires `Permission::MODULES_MANAGE`;
4. delegates to `PostgresIndexReconciliationDeadLetterInspector::inspect(context.tenant_id(), job_id)`.

There is no separate caller-supplied tenant, so transport adapters cannot select another tenant after authorization. Missing authority and insufficient permission fail before database access.

## Read-only bounded result

The guarded runtime returns only the core inspection contract:

- failed job UUID
- positive attempt count
- optional stable error code
- bounded dependency code
- retryable flag

The operation performs no state transition and adds no audit, requeue, retry-epoch reset, scheduler, task, or transport surface.

## Plan status

The updated audit distinguishes `merged_main`, `open_source_complete`, `owner_evidence_pending`, and `not_started`.

After this slice, the next production sequence is:

1. immutable actor/reason audit records
2. scope-locked manual requeue or retry-epoch reset
3. bounded retry/backoff/exhaustion plus explicit host scheduling ownership
4. digest/orphan/targeted/full/shadow drift-repair admission

## Compatibility

- no additional Index migration for inspection or authorization
- no change to reconciliation request/cursor wire contracts, source identity, mutation identity, schema fingerprints, leases, cancellation, failure transition, admission precedence, or success behavior
- no GraphQL, HTTP, CLI, MCP, or admin transport
- no direct SQL in the server authorization wrapper

## Validation

Not run per maintainer instruction:

- formatting
- Cargo checks/tests/Clippy
- JavaScript verifiers
- PostgreSQL fixtures
- CI workflows

Suggested maintainer commands:

```bash
cargo test -p rustok-index source_reconciliation_dead_letter_inspector -- --nocapture
cargo test -p rustok-server index_reconciliation -- --nocapture
cargo check -p rustok-index --all-targets
cargo check -p rustok-server --all-targets
node scripts/verify/verify-index-reconciliation-dead-letter-admission.mjs
node scripts/verify/verify-index-reconciliation-dead-letter-inspection.mjs
node scripts/verify/verify-index-server-reconciliation-guard.mjs
node scripts/verify/verify-index-sales-channel-source.mjs
```

## Supersedes

- #2751
- #2693
- previously superseded #2636 and #2743 remain represented in this consolidated diff

Squash merge is recommended after maintainer validation.