### PR TITLE
test(blog): bind admin native composition into Comments port gate

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-comments-storefront-native-port-injection.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-storefront-native-port-injection.json
@@ -20,7 +20,6 @@
       "host_injected_port_selection"
     ],
     "pending": [
-      "admin_native_ssr_composition",
       "remote_transport_implementation"
     ]
   },
@@ -61,7 +60,6 @@
   },
   "non_claims": [
     "no remote network transport is implemented",
-    "no admin native SSR composition is implemented",
     "no Rust or JavaScript test was run",
     "no compile, database, browser, workflow, CI, or production result is recorded"
   ]

--- a/crates/rustok-blog/docs/implementation-plan.md
+++ b/crates/rustok-blog/docs/implementation-plan.md
@@ -179,7 +179,9 @@ HTTP and GraphQL composition imports. The source marker `storefront native SSR
 Comments host selection is source-locked` is mandatory inside the existing
 first-class Comments port leaf. Blog FBA package-chain registration remains
 pending only as a dedicated parallel storefront leaf; that duplicate leaf is
-intentionally not added. The remote network transport remains pending.
+intentionally not added. The stale `admin_native_ssr_composition` pending marker
+was removed after admin native composition became source-locked. The remote
+network transport remains pending.
 
 Admin native SSR Comments composition is host-attached through the existing
 `NativeContext`. `native_context()` reads an optional
@@ -200,9 +202,15 @@ retained compile-only harness is
 `transport::native_server_adapter::tests::admin_native_runtime_exposes_comments_port_selection`,
 with suggested command
 `cargo test -p rustok-blog-admin --features ssr transport::native_server_adapter::tests::admin_native_runtime_exposes_comments_port_selection -- --exact`.
-The admin native SSR Comments host selection is source-locked. Blog FBA
-package-chain registration remains pending, and the remote network transport
-remains pending.
+The registered `verify:blog:comments-port-boundary` verifier imports the standalone
+admin native verifier, and the registered
+`test:verify:blog:comments-port-boundary` self-test imports all seventeen focused
+cases. `scripts/verify/verify-blog-fba.test.mjs` locks both imports beside the
+HTTP, GraphQL, and storefront native composition imports. The source marker
+`admin native SSR Comments host selection is source-locked` is mandatory inside
+the existing first-class Comments port leaf. Blog FBA package-chain registration
+remains pending only as a dedicated parallel admin native leaf; that duplicate
+leaf is intentionally not added. The remote network transport remains pending.
 
 Comments lifecycle projection into Blog-owned `comment_count` is a Blog consumer
 boundary. `BlogCommentProjectionHandler` accepts only `comment.created` and
@@ -765,6 +773,27 @@ verifier, seventeen focused positive/negative cases, and a compile-only selector
 harness retain the source contract. Blog FBA package-chain integration, the remote
 network transport, and all execution remain pending.
 
+The continuation audit at `f6cd8b598d2ff57e19ec50a1455bf8d8bb31a972`
+found that slice 65's admin native evidence, standalone verifier, focused fixture,
+and compile-only harness were complete, but the registered
+`comments_port_boundary` verifier and self-test still imported only HTTP, GraphQL,
+and storefront native composition sub-contracts. The audit also found storefront
+native evidence still carrying the now-stale `admin_native_ssr_composition`
+pending marker.
+
+Slice 66 imports the standalone admin native verifier from the registered Comments
+port verifier and imports all seventeen focused admin native cases from the
+registered Comments port self-test. The parent positive fixture now materializes
+the admin `NativeContext`, selector, tenant/permission admission, pagination,
+fail-closed handoffs, harness, and schema-v1 evidence under the same temporary
+repo root. The aggregate Blog FBA self-test locks both imports beside the existing
+HTTP, GraphQL, and storefront assertions. Storefront evidence and its sixteen-case
+fixture now retain only the remote transport as pending and reject reintroduction
+of the stale admin marker. Registry schema v13, package scripts, verify/test order,
+runtime source, remote transport status, and all execution claims remain
+unchanged. Admin native composition is now a mandatory sub-contract of the
+existing first-class Comments port leaf rather than a parallel duplicate leaf.
+
 ## FFA/FBA status
 
 - FFA status: `in_progress`.
@@ -778,10 +807,9 @@ network transport, and all execution remain pending.
   plus aggregate/consumer bindings for admin, storefront, Comments port boundary,
   Comments event projection, category Search reindex, GraphQL rate limiting,
   GraphQL richtext, AI richtext, offline backfill, Forum ownership, and runtime
-  order. The existing Comments port leaf requires HTTP, GraphQL, and storefront
-  native composition verifiers plus focused fixtures through aggregate-locked
-  imports; package order remains unchanged. The standalone admin native
-  composition guard remains outside registry package order in Slice 65.
+  order. The existing Comments port leaf requires HTTP, GraphQL, storefront
+  native, and admin native composition verifiers plus focused fixtures through
+  aggregate-locked imports; package order remains unchanged.
 - Comments consumer port boundary: Blog-owned `source_verified_no_compile` for
   the in-process profile; evidence schema v3, all seven operations, approved public
   read, typed richtext projection, two-second deadlines, write idempotency, active
@@ -792,14 +820,13 @@ network transport, and all execution remain pending.
   GraphQL public/moderation operations use manifest-attached
   `BlogGraphqlRuntimeData`; storefront native SSR approved public reads use
   `comment_service` with typed `AVAILABLE` / `UNAVAILABLE` / `TIMEOUT`
-  degradation. Those three composition guards are retained inside the registered
-  Comments port gate. Admin native SSR moderation list and mutation now select the
-  same optional host port through `comment_service`, preserve tenant/permission
-  admission and fail-closed errors, and retain schema-v1 evidence plus a standalone
-  verifier, focused fixture, and compile-only harness. Admin package-chain
-  integration, the remote network transport, remote adapter runtime parity, cached
-  snapshot, comment-form fallback, browser/runtime evidence, and broader degraded
-  UI modes remain planned or pending.
+  degradation; admin native SSR moderation list and mutation use
+  `comment_service` with tenant/permission admission and fail-closed errors. All
+  four composition guards and their focused fixtures are retained inside the
+  registered Comments port gate. Dedicated parallel composition leaves remain
+  intentionally absent. The remote network transport, remote adapter runtime
+  parity, cached snapshot, comment-form fallback, browser/runtime evidence, and
+  broader degraded UI modes remain planned or pending.
 - Comments event projection: Blog-owned `source_verified_no_compile`; evidence
   schema v4, shared classifier/counter/retry-decision helpers, `executable_no_run`
   source harness, deterministic PostgreSQL retry-limit target, module-registration,
@@ -1120,6 +1147,12 @@ network transport, and all execution remain pending.
     source contract in schema-v1 evidence plus a standalone verifier, seventeen
     focused cases, and a compile-only harness, and kept package integration,
     remote transport, and all execution pending.
+66. Bound the standalone admin native composition verifier and all seventeen
+    focused cases into the already registered `comments-port-boundary` verify/test
+    leaf, made the parent positive fixture self-contained, added aggregate
+    regressions for both required imports, reconciled storefront evidence to remove
+    the stale admin pending marker, preserved registry schema v13 and exact package
+    order, and changed no runtime source or execution status.
 
 ## Next results
 
@@ -1137,17 +1170,15 @@ network transport, and all execution remain pending.
    controller handoff, focused verifier, then Redis-backed host requests with a
    real HTTP `Retry-After` matching GraphQL `retryAfter`.
 5. **Close comments runtime evidence.** Run the registered Comments port boundary
-   verifier and self-test, which include the standalone HTTP, GraphQL, and
-   storefront native composition verifiers plus their focused fixtures, and run
-   the standalone admin native composition verifier and focused fixture. Execute
-   the compile-only injection-signature, HTTP selection, GraphQL runtime-data,
-   storefront native, and admin native selector harnesses, shared consumer
-   runtime-order verifier, Blog projection classifier and deterministic retry
-   policy, module registration/routing, dispatcher, concurrency, retry-limit,
+   verifier and self-test, which include the standalone HTTP, GraphQL, storefront
+   native, and admin native composition verifiers plus their focused fixtures.
+   Execute the compile-only injection-signature, HTTP selection, GraphQL
+   runtime-data, storefront native, and admin native selector harnesses, shared
+   consumer runtime-order verifier, Blog projection classifier and deterministic
+   retry policy, module registration/routing, dispatcher, concurrency, retry-limit,
    duplicate-delivery, and restart targets. Retain deterministic rollback,
    cardinality, process-boundary, authorization, moderation, pagination, and
-   fail-closed outputs; then register the admin native source guard inside the
-   existing Comments port gate, implement the remote network transport through
+   fail-closed outputs; then implement the remote network transport through
    `CommentService::with_comments_thread_port`, and retain all-seven-operation
    adapter parity, naturally contended PostgreSQL retry-frequency evidence, full
    server-host restart recovery, browser parity for typed unavailable/timeout

--- a/scripts/verify/verify-blog-comments-port-boundary.mjs
+++ b/scripts/verify/verify-blog-comments-port-boundary.mjs
@@ -3,6 +3,7 @@
 import './verify-blog-comments-http-port-injection.mjs';
 import './verify-blog-comments-graphql-port-injection.mjs';
 import './verify-blog-comments-storefront-native-port-injection.mjs';
+import './verify-blog-comments-admin-native-port-injection.mjs';
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 

--- a/scripts/verify/verify-blog-comments-port-boundary.test.mjs
+++ b/scripts/verify/verify-blog-comments-port-boundary.test.mjs
@@ -3,6 +3,7 @@
 import './verify-blog-comments-http-port-injection.test.mjs';
 import './verify-blog-comments-graphql-port-injection.test.mjs';
 import './verify-blog-comments-storefront-native-port-injection.test.mjs';
+import './verify-blog-comments-admin-native-port-injection.test.mjs';
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
@@ -36,6 +37,10 @@ const storefrontHarnessTest =
   'transport::native_server_adapter::tests::storefront_native_runtime_exposes_comments_port_selection';
 const storefrontHarnessCommand =
   `cargo test -p rustok-blog-storefront --features ssr ${storefrontHarnessTest} -- --exact`;
+const adminHarnessTest =
+  'transport::native_server_adapter::tests::admin_native_runtime_exposes_comments_port_selection';
+const adminHarnessCommand =
+  `cargo test -p rustok-blog-admin --features ssr ${adminHarnessTest} -- --exact`;
 
 function write(root, relativePath, content) {
   const target = path.join(root, relativePath);
@@ -66,6 +71,8 @@ function fixture({
     'crates/rustok-blog/contracts/evidence/blog-comments-graphql-port-injection.json';
   const storefrontEvidencePath =
     'crates/rustok-blog/contracts/evidence/blog-comments-storefront-native-port-injection.json';
+  const adminEvidencePath =
+    'crates/rustok-blog/contracts/evidence/blog-comments-admin-native-port-injection.json';
   const facadePath = 'crates/rustok-blog/src/lib.rs';
   const servicePath = 'crates/rustok-blog/src/services/comment.rs';
   const httpRuntimePath = 'crates/rustok-blog/src/controllers/mod.rs';
@@ -81,6 +88,7 @@ function fixture({
   const storefrontGraphqlPath = 'crates/rustok-blog/storefront/src/transport/graphql_adapter.rs';
   const storefrontNativePath = 'crates/rustok-blog/storefront/src/transport/native_server_adapter.rs';
   const storefrontUiPath = 'crates/rustok-blog/storefront/src/ui/leptos.rs';
+  const adminNativePath = 'crates/rustok-blog/admin/src/transport/native_server_adapter.rs';
   const providerRegistryPath = 'crates/rustok-comments/contracts/comments-fba-registry.json';
   const consumerRegistryPath = 'crates/rustok-blog/contracts/blog-fba-registry.json';
 
@@ -295,6 +303,44 @@ Comments took too long to load. The article is still available.
 `,
   );
 
+  write(
+    root,
+    adminNativePath,
+    `
+use std::sync::Arc;
+struct NativeContext {
+comments_thread_port: Option<Arc<dyn rustok_blog::CommentsThreadPort>>
+}
+let runtime = expect_context::<HostRuntimeContext>();
+if auth.tenant_id != tenant.id
+runtime.shared_get::<Arc<dyn rustok_blog::CommentsThreadPort>>()
+fn comment_service(context: &NativeContext) -> rustok_blog::CommentService {
+context.comments_thread_port.clone()
+rustok_blog::CommentService::with_comments_thread_port(
+rustok_blog::CommentService::new(context.db.clone(), context.event_bus.clone())
+}
+fn require_manage_permission(
+&[rustok_api::Permission::BLOG_POSTS_MANAGE]
+"Permission denied: blog_posts:manage required"
+#[server(prefix = "/api/fn", endpoint = "blog/admin/moderation-comments")]
+require_manage_permission(&context.auth)?;
+comment_service(&context)
+page: page.max(1)
+per_page: per_page.clamp(1, 100)
+.list_for_post_with_locale_fallback(
+.map_err(ServerFnError::new)?;
+#[server(prefix = "/api/fn", endpoint = "blog/admin/moderate-comment")]
+require_manage_permission(&context.auth)?;
+comment_service(&context)
+.moderate_comment(
+.map_err(ServerFnError::new)?;
+#[cfg(feature = "ssr")]
+fn optional_text
+fn admin_native_runtime_exposes_comments_port_selection()
+let selector: fn(&NativeContext) -> rustok_blog::CommentService = comment_service;
+`,
+  );
+
   const cases = operations.map((operation) => ({
     operation,
     assertions: ['typed_port_error_mapping', 'context_deadline_preserved'],
@@ -462,7 +508,7 @@ Comments took too long to load. The article is still available.
       },
       profiles: {
         source_verified: ['in_process_fallback', 'host_injected_port_selection'],
-        pending: ['admin_native_ssr_composition', 'remote_transport_implementation'],
+        pending: ['remote_transport_implementation'],
       },
       composition: {
         host_context: 'rustok_api::HostRuntimeContext',
@@ -496,7 +542,78 @@ Comments took too long to load. The article is still available.
       },
       non_claims: [
         'no remote network transport is implemented',
-        'no admin native SSR composition is implemented',
+        'no Rust or JavaScript test was run',
+        'no compile, database, browser, workflow, CI, or production result is recorded',
+      ],
+    }),
+  );
+
+  write(
+    root,
+    adminEvidencePath,
+    JSON.stringify({
+      schema_version: 1,
+      module: 'blog',
+      surface: 'comments_admin_native_port_injection',
+      role: 'consumer',
+      provider: 'comments',
+      status: 'source_verified_no_compile',
+      compile_policy: 'not_run_by_request',
+      runtime_status: 'not_run',
+      source_contract: {
+        admin_adapter: adminNativePath,
+        consumer_service: servicePath,
+        consumer_matrix: evidencePath,
+      },
+      profiles: {
+        source_verified: ['in_process_fallback', 'host_injected_port_selection'],
+        pending: ['remote_transport_implementation'],
+      },
+      composition: {
+        host_context: 'rustok_api::HostRuntimeContext',
+        native_context: 'NativeContext',
+        shared_value: 'Arc<dyn rustok_blog::CommentsThreadPort>',
+        lookup: 'HostRuntimeContext::shared_get',
+        selector: 'comment_service',
+        injected_constructor: 'CommentService::with_comments_thread_port',
+        fallback_constructor: 'CommentService::new',
+        native_endpoints: [
+          'blog/admin/moderation-comments',
+          'blog/admin/moderate-comment',
+        ],
+        port_operations: [
+          'list_comments_for_target',
+          'get_comment',
+          'set_comment_status',
+        ],
+      },
+      authorization: {
+        tenant_binding: 'AuthContext.tenant_id == TenantContext.id',
+        permission: 'blog_posts:manage',
+        checked_before_port_call: true,
+      },
+      moderation_policy: {
+        read_pagination: 'page >= 1; 1 <= per_page <= 100',
+        error_policy: 'all_blog_errors_propagated',
+        storefront_degradation_reused: false,
+      },
+      harness: {
+        status: 'executable_no_run',
+        runtime_status: 'not_run',
+        source: adminNativePath,
+        test: adminHarnessTest,
+        command: adminHarnessCommand,
+      },
+      registration: {
+        standalone_verifier:
+          'scripts/verify/verify-blog-comments-admin-native-port-injection.mjs',
+        focused_fixture:
+          'scripts/verify/verify-blog-comments-admin-native-port-injection.test.mjs',
+        blog_fba_package_chain: 'pending',
+      },
+      non_claims: [
+        'no remote network transport is implemented',
+        'no admin moderation error is degraded to an empty success payload',
         'no Rust or JavaScript test was run',
         'no compile, database, browser, workflow, CI, or production result is recorded',
       ],
@@ -589,7 +706,7 @@ Comments took too long to load. The article is still available.
   write(
     root,
     'crates/rustok-blog/docs/implementation-plan.md',
-    'blog-comments-consumer-static-matrix.json blog-comments-runtime-fallback-smoke.json blog-comments-http-port-injection.json verify-blog-comments-http-port-injection.mjs verify-blog-comments-http-port-injection.test.mjs blog-comments-graphql-port-injection.json verify-blog-comments-graphql-port-injection.mjs verify-blog-comments-graphql-port-injection.test.mjs blog-comments-storefront-native-port-injection.json verify-blog-comments-storefront-native-port-injection.mjs verify-blog-comments-storefront-native-port-injection.test.mjs BlogGraphqlRuntimeData graphql::attach_schema_data schema_codegen::attach_module_graphql_data GraphQL Comments host selection is source-locked storefront native SSR Comments host selection is source-locked Blog FBA package-chain registration remains pending admin native SSR composition remains pending verify:blog:comments-port-boundary test:verify:blog:comments-port-boundary source_verified_no_compile typed storefront comments availability CommentService::with_comments_thread_port BlogHttpRuntime::comment_service HTTP moderation remote transport remains pending remote network transport remains pending cached snapshot and comment-form fallback remain planned Slice 59 Slice 60 Slice 61 Slice 62 Slice 63 Slice 64',
+    'blog-comments-consumer-static-matrix.json blog-comments-runtime-fallback-smoke.json blog-comments-http-port-injection.json verify-blog-comments-http-port-injection.mjs verify-blog-comments-http-port-injection.test.mjs blog-comments-graphql-port-injection.json verify-blog-comments-graphql-port-injection.mjs verify-blog-comments-graphql-port-injection.test.mjs blog-comments-storefront-native-port-injection.json verify-blog-comments-storefront-native-port-injection.mjs verify-blog-comments-storefront-native-port-injection.test.mjs blog-comments-admin-native-port-injection.json verify-blog-comments-admin-native-port-injection.mjs verify-blog-comments-admin-native-port-injection.test.mjs BlogGraphqlRuntimeData graphql::attach_schema_data schema_codegen::attach_module_graphql_data GraphQL Comments host selection is source-locked storefront native SSR Comments host selection is source-locked admin native SSR Comments host selection is source-locked Blog FBA package-chain registration remains pending verify:blog:comments-port-boundary test:verify:blog:comments-port-boundary source_verified_no_compile typed storefront comments availability CommentService::with_comments_thread_port BlogHttpRuntime::comment_service HTTP moderation remote transport remains pending remote network transport remains pending cached snapshot and comment-form fallback remain planned Slice 59 Slice 60 Slice 61 Slice 62 Slice 63 Slice 64 Slice 65 Slice 66',
   );
 
   return root;

--- a/scripts/verify/verify-blog-comments-storefront-native-port-injection.mjs
+++ b/scripts/verify/verify-blog-comments-storefront-native-port-injection.mjs
@@ -107,10 +107,7 @@ if (evidence) {
     ])
   ) failures.push(`${evidencePath}: source-verified profile drift`);
   if (
-    !sameSet(evidence.profiles?.pending ?? [], [
-      'admin_native_ssr_composition',
-      'remote_transport_implementation',
-    ])
+    !sameSet(evidence.profiles?.pending ?? [], ['remote_transport_implementation'])
   ) failures.push(`${evidencePath}: pending profile drift`);
 
   const composition = evidence.composition ?? {};
@@ -237,7 +234,6 @@ for (const marker of [
   'verify-blog-comments-storefront-native-port-injection.mjs',
   'verify-blog-comments-storefront-native-port-injection.test.mjs',
   'storefront native SSR Comments host selection is source-locked',
-  'admin native SSR composition',
   'Blog FBA package-chain registration remains pending',
   'remote network transport remains pending',
   'Slice 63',

--- a/scripts/verify/verify-blog-comments-storefront-native-port-injection.test.mjs
+++ b/scripts/verify/verify-blog-comments-storefront-native-port-injection.test.mjs
@@ -44,7 +44,7 @@ function fixture({
   missingAvailability = false,
   missingHarness = false,
   runtimePromoted = false,
-  adminPromoted = false,
+  adminStillPending = false,
   remotePromoted = false,
   registrationPromoted = false,
   planDrift = false,
@@ -136,11 +136,8 @@ PortActor::service(PUBLIC_COMMENTS_PORT_ACTOR)
   );
 
   const sourceVerified = ['in_process_fallback', 'host_injected_port_selection'];
-  const pending = ['admin_native_ssr_composition', 'remote_transport_implementation'];
-  if (adminPromoted) {
-    sourceVerified.push('admin_native_ssr_composition');
-    pending.splice(pending.indexOf('admin_native_ssr_composition'), 1);
-  }
+  const pending = ['remote_transport_implementation'];
+  if (adminStillPending) pending.unshift('admin_native_ssr_composition');
   if (remotePromoted) {
     sourceVerified.push('remote_transport_implementation');
     pending.splice(pending.indexOf('remote_transport_implementation'), 1);
@@ -207,7 +204,7 @@ PortActor::service(PUBLIC_COMMENTS_PORT_ACTOR)
     planPath,
     planDrift
       ? ''
-      : 'blog-comments-storefront-native-port-injection.json verify-blog-comments-storefront-native-port-injection.mjs verify-blog-comments-storefront-native-port-injection.test.mjs storefront native SSR Comments host selection is source-locked admin native SSR composition remains pending Blog FBA package-chain registration remains pending remote network transport remains pending Slice 63',
+      : 'blog-comments-storefront-native-port-injection.json verify-blog-comments-storefront-native-port-injection.mjs verify-blog-comments-storefront-native-port-injection.test.mjs storefront native SSR Comments host selection is source-locked Blog FBA package-chain registration remains pending remote network transport remains pending Slice 63',
   );
 
   return root;
@@ -284,8 +281,8 @@ test('rejects runtime promotion without execution', () => {
   assert.notEqual(rejects({ runtimePromoted: true }).status, 0);
 });
 
-test('rejects admin native SSR promotion without implementation', () => {
-  assert.notEqual(rejects({ adminPromoted: true }).status, 0);
+test('rejects stale admin native SSR pending status after composition', () => {
+  assert.notEqual(rejects({ adminStillPending: true }).status, 0);
 });
 
 test('rejects remote transport promotion without implementation', () => {

--- a/scripts/verify/verify-blog-fba.test.mjs
+++ b/scripts/verify/verify-blog-fba.test.mjs
@@ -22,6 +22,10 @@ const storefrontNativeVerifierImport =
   "import './verify-blog-comments-storefront-native-port-injection.mjs';";
 const storefrontNativeSelfTestImport =
   "import './verify-blog-comments-storefront-native-port-injection.test.mjs';";
+const adminNativeVerifierImport =
+  "import './verify-blog-comments-admin-native-port-injection.mjs';";
+const adminNativeSelfTestImport =
+  "import './verify-blog-comments-admin-native-port-injection.test.mjs';";
 
 function clone(value) {
   return JSON.parse(JSON.stringify(value));
@@ -113,6 +117,16 @@ test('Blog FBA policy retains storefront native composition verifier inside the 
 test('Blog FBA policy retains storefront native composition focused fixture inside the registered Comments port self-test', () => {
   const source = readFileSync(commentsPortSelfTest, 'utf8');
   assert.ok(source.includes(storefrontNativeSelfTestImport));
+});
+
+test('Blog FBA policy retains admin native composition verifier inside the registered Comments port gate', () => {
+  const source = readFileSync(commentsPortVerifier, 'utf8');
+  assert.ok(source.includes(adminNativeVerifierImport));
+});
+
+test('Blog FBA policy retains admin native composition focused fixture inside the registered Comments port self-test', () => {
+  const source = readFileSync(commentsPortSelfTest, 'utf8');
+  assert.ok(source.includes(adminNativeSelfTestImport));
 });
 
 test('Blog FBA verification-chain policy rejects removal of the storefront verify step', () => {


### PR DESCRIPTION
## Summary

- continue the canonical Blog implementation plan through slice 66
- import the standalone admin native Comments composition verifier from the already registered Comments port verifier
- import all seventeen focused admin native composition cases from the registered Comments port self-test
- make the parent positive fixture self-contained for admin `NativeContext`, selector, tenant/permission admission, pagination, fail-closed handoffs, harness, and schema-v1 evidence
- lock both required admin imports in the aggregate Blog FBA self-test
- reconcile storefront native evidence so the already implemented admin native composition is no longer listed as pending

## Scope and non-claims

This is an integration-only source-contract slice. It does not change Blog runtime Rust, `package.json`, registry schema v13, Blog FBA verify/test order, remote transport status, or any execution status. No dedicated parallel admin native leaf is added because the composition guard is now a mandatory sub-contract of the existing first-class Comments port leaf.

No Rust or JavaScript test, verifier, formatting, compilation, database, browser, workflow, CI, or production command was run, per maintainer instruction.

## Suggested maintainer commands

```bash
npm run verify:blog:comments-port-boundary
npm run test:verify:blog:comments-port-boundary
npm run verify:blog:fba
npm run test:verify:blog:fba
```

## Branch state

The branch starts from `f6cd8b598d2ff57e19ec50a1455bf8d8bb31a972`. Current `main` is ahead only by unrelated Forum/Search consumer changes; the proposed diff changes exactly seven Blog source-contract files.