### PR TITLE
fix(fulfillment): sanitize shipping-option read diagnostics

### DIFF
--- a/crates/rustok-fulfillment/contracts/evidence/shipping-option-read-diagnostic-safety-source-review.json
+++ b/crates/rustok-fulfillment/contracts/evidence/shipping-option-read-diagnostic-safety-source-review.json
@@ -1,0 +1,32 @@
+{
+  "status": "fulfillment_shipping_option_read_diagnostic_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-fulfillment/src/shipping_option_read.rs",
+    "crates/rustok-fulfillment/src/error.rs",
+    "scripts/verify/verify-fulfillment-shipping-option-read-port.mjs",
+    "crates/rustok-fulfillment/docs/shipping-option-read-diagnostic-safety.md",
+    "crates/rustok-fulfillment/docs/implementation-plan.md"
+  ],
+  "review_findings": {
+    "public_traits_preserved": true,
+    "request_response_dtos_preserved": true,
+    "canonical_factories_preserved": true,
+    "read_admission_order_preserved": true,
+    "owner_delegation_preserved": true,
+    "locale_delegation_preserved": true,
+    "all_public_port_errors_preserved": true,
+    "database_severity_preserved": true,
+    "ordinary_severity_preserved": true,
+    "complete_fulfillment_error_logging_removed": true,
+    "database_error_payload_removed": true,
+    "uuid_parser_payload_removed": true,
+    "raw_context_values_removed": true,
+    "resource_uuid_removed": true,
+    "validation_transition_text_removed": true,
+    "bounded_request_shape_retained": true,
+    "bounded_owner_error_shape_retained": true,
+    "fulfillment_lifecycle_read_cleanup_remains_open": true,
+    "runtime_evidence_claimed": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed."
+}

--- a/crates/rustok-fulfillment/contracts/evidence/shipping-option-read-diagnostic-safety-source.json
+++ b/crates/rustok-fulfillment/contracts/evidence/shipping-option-read-diagnostic-safety-source.json
@@ -1,0 +1,58 @@
+{
+  "status": "fulfillment_shipping_option_read_diagnostic_safety_source_unvalidated",
+  "scope": {
+    "owner_source": "crates/rustok-fulfillment/src/shipping_option_read.rs",
+    "traits": [
+      "ShippingOptionReadPort",
+      "ShippingOptionAdminReadPort"
+    ],
+    "operations": [
+      "list_shipping_option_projections",
+      "read_shipping_option_projection",
+      "list_all_shipping_option_projections"
+    ],
+    "focused_verifier": "scripts/verify/verify-fulfillment-shipping-option-read-port.mjs",
+    "documentation": "crates/rustok-fulfillment/docs/shipping-option-read-diagnostic-safety.md"
+  },
+  "source_contract": {
+    "owner_error_variant_count": 5,
+    "complete_fulfillment_error_logged": false,
+    "database_error_payload_logged": false,
+    "uuid_parser_payload_logged": false,
+    "validation_text_logged": false,
+    "transition_text_logged": false,
+    "resource_uuid_logged": false,
+    "raw_context_values_logged": false,
+    "static_error_variant_logged": true,
+    "aggregate_error_shape_logged": true,
+    "safe_context_shape_logged": true,
+    "request_identity_shape_logged": true,
+    "locale_shape_logged": true,
+    "tenant_parse_failure_logged": true,
+    "database_severity_changed": false,
+    "ordinary_severity_changed": false,
+    "read_policy_order_changed": false,
+    "tenant_parse_order_changed": false,
+    "owner_delegation_changed": false,
+    "locale_delegation_changed": false,
+    "public_traits_changed": false,
+    "request_response_dtos_changed": false,
+    "public_code_changed": false,
+    "public_message_changed": false,
+    "public_kind_changed": false,
+    "public_retryability_changed": false,
+    "fulfillment_lifecycle_read_diagnostic_cleanup_closed": false,
+    "broad_ecommerce_cleanup_closed": false
+  },
+  "validation": {
+    "tests_run": false,
+    "verifiers_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "mounted_runtime_proven": false,
+    "remote_adapter_proven": false
+  }
+}

--- a/crates/rustok-fulfillment/docs/shipping-option-read-diagnostic-safety.md
+++ b/crates/rustok-fulfillment/docs/shipping-option-read-diagnostic-safety.md
@@ -1,0 +1,44 @@
+# Fulfillment shipping-option read diagnostic safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice closes the payload-diagnostic gap in the owner projection-read boundary implemented by `crates/rustok-fulfillment/src/shipping_option_read.rs`:
+
+- storefront active-list;
+- storefront/admin single lookup;
+- administrative list-all;
+- tenant UUID parsing;
+- all five current `FulfillmentError` variants.
+
+The public traits, request/response DTOs, canonical factories, locale arguments, owner service calls, Commerce runtime composition, filters, optional-not-found behavior, and public `PortError` envelopes remain unchanged.
+
+## Retained diagnostic shape
+
+Events retain correlation id, static owner operation, stable code, retryability, severity, and boundary. Other context is limited to actor kind, character lengths, counts, presence flags, and deadline milliseconds.
+
+The optional shipping-option identity is represented only by presence and non-nil facts. Requested and tenant-default locales are represented only by presence and character length.
+
+Owner failures retain only a closed static variant and aggregate text, UUID, and opaque-payload shape. Parser errors, raw context, resource UUIDs, validation/transition text, database errors, and complete `FulfillmentError` debug/display payloads are not recorded.
+
+## Preserved behavior
+
+- read policy remains before tenant parsing and owner delegation;
+- active list, list-all, and lookup delegate to the same owner methods;
+- requested/default locale propagation is unchanged;
+- database failures remain error severity;
+- context, validation, not-found, and transition failures remain warning severity;
+- public code, message, kind, and retryability are unchanged.
+
+## Evidence
+
+- `crates/rustok-fulfillment/contracts/evidence/shipping-option-read-diagnostic-safety-source.json`
+- `crates/rustok-fulfillment/contracts/evidence/shipping-option-read-diagnostic-safety-source-review.json`
+- `scripts/verify/verify-fulfillment-shipping-option-read-port.mjs`
+
+## Remaining gaps
+
+Fulfillment lifecycle projection-read diagnostics in `fulfillment_read.rs` remain a separate open slice. Compile, verifier execution, mounted runtime parity, restart, remote-adapter evidence, and the broader ecommerce cleanup remain open.
+
+No test, verifier, formatter, Cargo, workflow, or CI command was executed for this source slice.

--- a/crates/rustok-fulfillment/src/shipping_option_read.rs
+++ b/crates/rustok-fulfillment/src/shipping_option_read.rs
@@ -7,6 +7,9 @@ use uuid::Uuid;
 
 use crate::{FulfillmentError, FulfillmentService, ShippingOptionResponse};
 
+const FULFILLMENT_OWNER: &str = "rustok_fulfillment";
+const SHIPPING_OPTION_READ_BOUNDARY: &str = "fulfillment_shipping_option_read_port";
+
 /// Transport-neutral owner boundary for storefront-complete shipping-option reads.
 #[async_trait]
 pub trait ShippingOptionReadPort: Send + Sync {
@@ -94,6 +97,42 @@ pub fn in_process_shipping_option_admin_read_port(
     db: sea_orm::DatabaseConnection,
 ) -> Arc<dyn ShippingOptionAdminReadPort> {
     Arc::new(InProcessShippingOptionAdminReadPort::new(db))
+}
+
+struct ShippingOptionReadContextFacts {
+    tenant_id_length: usize,
+    actor_kind: &'static str,
+    actor_id_length: usize,
+    claim_count: usize,
+    role_count: usize,
+    channel_present: bool,
+    channel_length: Option<usize>,
+    locale_length: usize,
+    causation_id_present: bool,
+    causation_id_length: Option<usize>,
+    traceparent_present: bool,
+    traceparent_length: Option<usize>,
+    idempotency_key_present: bool,
+    idempotency_key_length: Option<usize>,
+    deadline_ms: Option<u64>,
+}
+
+struct ShippingOptionOwnerErrorFacts {
+    error_variant: &'static str,
+    text_field_count: usize,
+    text_total_length: usize,
+    uuid_field_count: usize,
+    uuid_non_nil_count: usize,
+    opaque_payload_present: bool,
+}
+
+struct ShippingOptionReadRequestFacts {
+    shipping_option_id_present: bool,
+    shipping_option_id_non_nil: bool,
+    requested_locale_present: bool,
+    requested_locale_length: Option<usize>,
+    tenant_default_locale_present: bool,
+    tenant_default_locale_length: Option<usize>,
 }
 
 #[async_trait]
@@ -190,22 +229,135 @@ impl ShippingOptionAdminReadPort for InProcessShippingOptionAdminReadPort {
     }
 }
 
+fn shipping_option_read_context_facts(context: &PortContext) -> ShippingOptionReadContextFacts {
+    let actor_kind = match &context.actor.kind {
+        rustok_api::PortActorKind::User => "user",
+        rustok_api::PortActorKind::Service => "service",
+        rustok_api::PortActorKind::System => "system",
+    };
+    ShippingOptionReadContextFacts {
+        tenant_id_length: context.tenant_id.chars().count(),
+        actor_kind,
+        actor_id_length: context.actor.id.chars().count(),
+        claim_count: context.claims.len(),
+        role_count: context.roles.len(),
+        channel_present: context.channel.is_some(),
+        channel_length: context.channel.as_ref().map(|value| value.chars().count()),
+        locale_length: context.locale.chars().count(),
+        causation_id_present: context.causation_id.is_some(),
+        causation_id_length: context
+            .causation_id
+            .as_ref()
+            .map(|value| value.chars().count()),
+        traceparent_present: context.traceparent.is_some(),
+        traceparent_length: context
+            .traceparent
+            .as_ref()
+            .map(|value| value.chars().count()),
+        idempotency_key_present: context.idempotency_key.is_some(),
+        idempotency_key_length: context
+            .idempotency_key
+            .as_ref()
+            .map(|value| value.chars().count()),
+        deadline_ms: context.deadline_ms,
+    }
+}
+
+fn shipping_option_owner_error_facts(error: &FulfillmentError) -> ShippingOptionOwnerErrorFacts {
+    let (
+        error_variant,
+        text_field_count,
+        text_total_length,
+        uuid_field_count,
+        uuid_non_nil_count,
+        opaque_payload_present,
+    ) = match error {
+        FulfillmentError::Validation(value) => (
+            "validation",
+            1,
+            value.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        FulfillmentError::ShippingOptionNotFound(id) => (
+            "shipping_option_not_found",
+            0,
+            0,
+            1,
+            if id.is_nil() { 0 } else { 1 },
+            false,
+        ),
+        FulfillmentError::FulfillmentNotFound(id) => (
+            "fulfillment_not_found",
+            0,
+            0,
+            1,
+            if id.is_nil() { 0 } else { 1 },
+            false,
+        ),
+        FulfillmentError::InvalidTransition { from, to } => (
+            "invalid_transition",
+            2,
+            from.chars().count() + to.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        FulfillmentError::Database(_) => ("database", 0, 0, 0, 0, true),
+    };
+    ShippingOptionOwnerErrorFacts {
+        error_variant,
+        text_field_count,
+        text_total_length,
+        uuid_field_count,
+        uuid_non_nil_count,
+        opaque_payload_present,
+    }
+}
+
+fn shipping_option_read_request_facts(
+    shipping_option_id: Option<Uuid>,
+    requested_locale_length: Option<usize>,
+    tenant_default_locale_length: Option<usize>,
+) -> ShippingOptionReadRequestFacts {
+    ShippingOptionReadRequestFacts {
+        shipping_option_id_present: shipping_option_id.is_some(),
+        shipping_option_id_non_nil: shipping_option_id
+            .map(|value| !value.is_nil())
+            .unwrap_or(false),
+        requested_locale_present: requested_locale_length.is_some(),
+        requested_locale_length,
+        tenant_default_locale_present: tenant_default_locale_length.is_some(),
+        tenant_default_locale_length,
+    }
+}
+
 fn parse_tenant_id(context: &PortContext, operation: &'static str) -> Result<Uuid, PortError> {
-    Uuid::parse_str(&context.tenant_id).map_err(|error| {
+    Uuid::parse_str(&context.tenant_id).map_err(|_| {
+        let context_facts = shipping_option_read_context_facts(context);
         tracing::warn!(
-            error = ?error,
-            owner = "rustok_fulfillment",
+            owner = FULFILLMENT_OWNER,
             operation,
             correlation_id = %context.correlation_id,
-            tenant_id = %context.tenant_id,
-            actor = ?context.actor,
-            channel_length = context.channel.as_deref().map(str::len),
-            locale_length = context.locale.len(),
-            causation_id_present = context.causation_id.is_some(),
-            traceparent_present = context.traceparent.is_some(),
-            deadline_ms = ?context.deadline_ms,
+            tenant_id_parse_failed = true,
+            tenant_id_length = context_facts.tenant_id_length,
+            actor_kind = context_facts.actor_kind,
+            actor_id_length = context_facts.actor_id_length,
+            claim_count = context_facts.claim_count,
+            role_count = context_facts.role_count,
+            channel_present = context_facts.channel_present,
+            channel_length = ?context_facts.channel_length,
+            locale_length = context_facts.locale_length,
+            causation_id_present = context_facts.causation_id_present,
+            causation_id_length = ?context_facts.causation_id_length,
+            traceparent_present = context_facts.traceparent_present,
+            traceparent_length = ?context_facts.traceparent_length,
+            idempotency_key_present = context_facts.idempotency_key_present,
+            idempotency_key_length = ?context_facts.idempotency_key_length,
+            deadline_ms = ?context_facts.deadline_ms,
             code = "fulfillment.context_invalid",
-            boundary = "fulfillment_shipping_option_read_port",
+            boundary = SHIPPING_OPTION_READ_BOUNDARY,
             "fulfillment shipping-option read context is invalid"
         );
         PortError::validation(
@@ -224,86 +376,124 @@ fn map_owner_error(
     tenant_default_locale_length: Option<usize>,
     error: FulfillmentError,
 ) -> PortError {
-    let (kind, code, message, retryable, error_kind) = match &error {
+    let error_facts = shipping_option_owner_error_facts(&error);
+    let request_facts = shipping_option_read_request_facts(
+        shipping_option_id,
+        requested_locale_length,
+        tenant_default_locale_length,
+    );
+    let (kind, code, message, retryable, technical_failure) = match &error {
         FulfillmentError::Validation(_) => (
             PortErrorKind::Validation,
             "fulfillment.validation",
             "fulfillment request is invalid",
             false,
-            "validation",
+            false,
         ),
         FulfillmentError::ShippingOptionNotFound(_) => (
             PortErrorKind::NotFound,
             "fulfillment.shipping_option_not_found",
             "shipping option was not found",
             false,
-            "shipping_option_not_found",
+            false,
         ),
         FulfillmentError::FulfillmentNotFound(_) => (
             PortErrorKind::NotFound,
             "fulfillment.fulfillment_not_found",
             "fulfillment was not found",
             false,
-            "fulfillment_not_found",
+            false,
         ),
         FulfillmentError::InvalidTransition { .. } => (
             PortErrorKind::Conflict,
             "fulfillment.invalid_transition",
             "fulfillment lifecycle transition conflicts with the current state",
             false,
-            "invalid_transition",
+            false,
         ),
         FulfillmentError::Database(_) => (
             PortErrorKind::Unavailable,
             "fulfillment.database_unavailable",
             "fulfillment storage is temporarily unavailable",
             true,
-            "database",
+            true,
         ),
     };
+    let context_facts = shipping_option_read_context_facts(context);
 
-    if matches!(&error, FulfillmentError::Database(_)) {
+    if technical_failure {
         tracing::error!(
-            error = ?error,
-            owner = "rustok_fulfillment",
+            owner = FULFILLMENT_OWNER,
             operation,
             correlation_id = %context.correlation_id,
-            tenant_id = %context.tenant_id,
-            actor = ?context.actor,
-            channel_length = context.channel.as_deref().map(str::len),
-            locale_length = context.locale.len(),
-            causation_id_present = context.causation_id.is_some(),
-            traceparent_present = context.traceparent.is_some(),
-            deadline_ms = ?context.deadline_ms,
-            shipping_option_id = ?shipping_option_id,
-            requested_locale_length = ?requested_locale_length,
-            tenant_default_locale_length = ?tenant_default_locale_length,
-            error_kind,
+            tenant_id_length = context_facts.tenant_id_length,
+            actor_kind = context_facts.actor_kind,
+            actor_id_length = context_facts.actor_id_length,
+            claim_count = context_facts.claim_count,
+            role_count = context_facts.role_count,
+            channel_present = context_facts.channel_present,
+            channel_length = ?context_facts.channel_length,
+            locale_length = context_facts.locale_length,
+            causation_id_present = context_facts.causation_id_present,
+            causation_id_length = ?context_facts.causation_id_length,
+            traceparent_present = context_facts.traceparent_present,
+            traceparent_length = ?context_facts.traceparent_length,
+            idempotency_key_present = context_facts.idempotency_key_present,
+            idempotency_key_length = ?context_facts.idempotency_key_length,
+            deadline_ms = ?context_facts.deadline_ms,
+            shipping_option_id_present = request_facts.shipping_option_id_present,
+            shipping_option_id_non_nil = request_facts.shipping_option_id_non_nil,
+            requested_locale_present = request_facts.requested_locale_present,
+            requested_locale_length = ?request_facts.requested_locale_length,
+            tenant_default_locale_present = request_facts.tenant_default_locale_present,
+            tenant_default_locale_length = ?request_facts.tenant_default_locale_length,
+            error_variant = error_facts.error_variant,
+            text_field_count = error_facts.text_field_count,
+            text_total_length = error_facts.text_total_length,
+            uuid_field_count = error_facts.uuid_field_count,
+            uuid_non_nil_count = error_facts.uuid_non_nil_count,
+            opaque_payload_present = error_facts.opaque_payload_present,
             code,
             retryable,
-            boundary = "fulfillment_shipping_option_read_port",
-            "fulfillment shipping-option read failed"
+            boundary = SHIPPING_OPTION_READ_BOUNDARY,
+            "fulfillment shipping-option read failed with bounded diagnostics"
         );
     } else {
         tracing::warn!(
-            owner = "rustok_fulfillment",
+            owner = FULFILLMENT_OWNER,
             operation,
             correlation_id = %context.correlation_id,
-            tenant_id = %context.tenant_id,
-            actor = ?context.actor,
-            channel_length = context.channel.as_deref().map(str::len),
-            locale_length = context.locale.len(),
-            causation_id_present = context.causation_id.is_some(),
-            traceparent_present = context.traceparent.is_some(),
-            deadline_ms = ?context.deadline_ms,
-            shipping_option_id = ?shipping_option_id,
-            requested_locale_length = ?requested_locale_length,
-            tenant_default_locale_length = ?tenant_default_locale_length,
-            error_kind,
+            tenant_id_length = context_facts.tenant_id_length,
+            actor_kind = context_facts.actor_kind,
+            actor_id_length = context_facts.actor_id_length,
+            claim_count = context_facts.claim_count,
+            role_count = context_facts.role_count,
+            channel_present = context_facts.channel_present,
+            channel_length = ?context_facts.channel_length,
+            locale_length = context_facts.locale_length,
+            causation_id_present = context_facts.causation_id_present,
+            causation_id_length = ?context_facts.causation_id_length,
+            traceparent_present = context_facts.traceparent_present,
+            traceparent_length = ?context_facts.traceparent_length,
+            idempotency_key_present = context_facts.idempotency_key_present,
+            idempotency_key_length = ?context_facts.idempotency_key_length,
+            deadline_ms = ?context_facts.deadline_ms,
+            shipping_option_id_present = request_facts.shipping_option_id_present,
+            shipping_option_id_non_nil = request_facts.shipping_option_id_non_nil,
+            requested_locale_present = request_facts.requested_locale_present,
+            requested_locale_length = ?request_facts.requested_locale_length,
+            tenant_default_locale_present = request_facts.tenant_default_locale_present,
+            tenant_default_locale_length = ?request_facts.tenant_default_locale_length,
+            error_variant = error_facts.error_variant,
+            text_field_count = error_facts.text_field_count,
+            text_total_length = error_facts.text_total_length,
+            uuid_field_count = error_facts.uuid_field_count,
+            uuid_non_nil_count = error_facts.uuid_non_nil_count,
+            opaque_payload_present = error_facts.opaque_payload_present,
             code,
             retryable,
-            boundary = "fulfillment_shipping_option_read_port",
-            "fulfillment shipping-option read was rejected"
+            boundary = SHIPPING_OPTION_READ_BOUNDARY,
+            "fulfillment shipping-option read was rejected with bounded diagnostics"
         );
     }
 

--- a/scripts/verify/verify-fulfillment-shipping-option-read-port.mjs
+++ b/scripts/verify/verify-fulfillment-shipping-option-read-port.mjs
@@ -10,20 +10,24 @@ const root = configuredRoot
   : new URL('../../', import.meta.url);
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
 const failures = [];
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
 
 const ownerRoot = read('crates/rustok-fulfillment/src/lib.rs');
-const ownerSource = read('crates/rustok-fulfillment/src/shipping_option_read.rs');
-const errorSource = read('crates/rustok-fulfillment/src/error.rs');
-const contextSource = read(
+const owner = read('crates/rustok-fulfillment/src/shipping_option_read.rs');
+const context = read(
   'crates/rustok-commerce/src/graphql/mutations/shipping_option_read_context.rs',
 );
-const optionSource = read(
+const optionConsumer = read(
   'crates/rustok-commerce/src/graphql/mutations/typed_shipping_option_helper.rs',
 );
-const enrichmentSource = read(
+const listConsumer = read(
   'crates/rustok-commerce/src/graphql/mutations/typed_shipping_enrichment_helper.rs',
 );
-const projectionSource = read('crates/rustok-commerce/src/storefront_shipping.rs');
 const evidence = JSON.parse(
   read(
     'crates/rustok-fulfillment/contracts/evidence/shipping-option-read-diagnostic-safety-source.json',
@@ -34,59 +38,67 @@ const review = JSON.parse(
     'crates/rustok-fulfillment/contracts/evidence/shipping-option-read-diagnostic-safety-source-review.json',
   ),
 );
-const diagnosticDoc = read(
+const doc = read(
   'crates/rustok-fulfillment/docs/shipping-option-read-diagnostic-safety.md',
 );
-const plan = read('crates/rustok-fulfillment/docs/implementation-plan.md');
 
-const requireText = (source, value, label) => {
-  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
-};
-const forbidText = (source, value, label) => {
-  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
-};
+for (const marker of [
+  'mod shipping_option_read;',
+  'ShippingOptionReadPort,',
+  'ShippingOptionAdminReadPort,',
+  'in_process_shipping_option_read_port,',
+  'in_process_shipping_option_admin_read_port,',
+]) requireText(ownerRoot, marker, 'owner export');
 
-for (const [source, value, label] of [
-  [ownerRoot, 'mod shipping_option_read;', 'private owner module'],
-  [ownerRoot, 'ShippingOptionReadPort,', 'storefront trait export'],
-  [ownerRoot, 'ShippingOptionAdminReadPort,', 'admin trait export'],
-  [ownerRoot, 'in_process_shipping_option_read_port,', 'storefront factory export'],
-  [ownerRoot, 'in_process_shipping_option_admin_read_port,', 'admin factory export'],
-  [ownerSource, 'pub trait ShippingOptionReadPort: Send + Sync {', 'storefront read trait'],
-  [ownerSource, 'pub trait ShippingOptionAdminReadPort: Send + Sync {', 'admin read trait'],
-  [ownerSource, 'impl ShippingOptionReadPort for InProcessShippingOptionReadPort', 'storefront implementation'],
-  [ownerSource, 'impl ShippingOptionAdminReadPort for InProcessShippingOptionAdminReadPort', 'admin implementation'],
-]) requireText(source, value, label);
+for (const marker of [
+  'pub trait ShippingOptionReadPort: Send + Sync {',
+  'pub trait ShippingOptionAdminReadPort: Send + Sync {',
+  'impl ShippingOptionReadPort for InProcessShippingOptionReadPort',
+  'impl ShippingOptionAdminReadPort for InProcessShippingOptionAdminReadPort',
+  'context.require_policy(PortCallPolicy::read())?',
+  'parse_tenant_id(&context, "list_shipping_option_projections")?',
+  'parse_tenant_id(&context, "read_shipping_option_projection")?',
+  'parse_tenant_id(&context, "list_all_shipping_option_projections")?',
+  '.list_shipping_options(',
+  '.get_shipping_option(',
+  '.list_all_shipping_options(',
+  'request.requested_locale.as_deref()',
+  'request.tenant_default_locale.as_deref()',
+]) requireText(owner, marker, 'owner topology');
 
-for (const [value, label] of [
-  ['context.require_policy(PortCallPolicy::read())?', 'read admission'],
-  ['parse_tenant_id(&context, "list_shipping_option_projections")?', 'active-list tenant parse'],
-  ['parse_tenant_id(&context, "read_shipping_option_projection")?', 'lookup tenant parse'],
-  ['parse_tenant_id(&context, "list_all_shipping_option_projections")?', 'list-all tenant parse'],
-  ['.list_shipping_options(', 'active-list owner delegation'],
-  ['.get_shipping_option(', 'lookup owner delegation'],
-  ['.list_all_shipping_options(', 'list-all owner delegation'],
-  ['request.requested_locale.as_deref()', 'requested locale delegation'],
-  ['request.tenant_default_locale.as_deref()', 'default locale delegation'],
-]) requireText(ownerSource, value, label);
+for (const marker of [
+  'ShippingOptionReadContextFacts',
+  'ShippingOptionOwnerErrorFacts',
+  'ShippingOptionReadRequestFacts',
+  'tenant_id_parse_failed = true',
+  'shipping_option_id_present = request_facts.shipping_option_id_present',
+  'shipping_option_id_non_nil = request_facts.shipping_option_id_non_nil',
+  'requested_locale_present = request_facts.requested_locale_present',
+  'tenant_default_locale_present = request_facts.tenant_default_locale_present',
+  'error_variant = error_facts.error_variant',
+  'text_total_length = error_facts.text_total_length',
+  'uuid_non_nil_count = error_facts.uuid_non_nil_count',
+  'opaque_payload_present = error_facts.opaque_payload_present',
+  'boundary = SHIPPING_OPTION_READ_BOUNDARY',
+  'PortError::new(kind, code, message, retryable)',
+  'tracing::error!(',
+  'tracing::warn!(',
+]) requireText(owner, marker, 'bounded diagnostics');
 
-for (const [value, label] of [
-  ['ShippingOptionReadContextFacts', 'bounded context facts'],
-  ['ShippingOptionOwnerErrorFacts', 'bounded owner-error facts'],
-  ['ShippingOptionReadRequestFacts', 'bounded request facts'],
-  ['tenant_id_parse_failed = true', 'tenant parse failure fact'],
-  ['shipping_option_id_present = request_facts.shipping_option_id_present', 'identity presence fact'],
-  ['shipping_option_id_non_nil = request_facts.shipping_option_id_non_nil', 'identity shape fact'],
-  ['requested_locale_present = request_facts.requested_locale_present', 'requested locale presence'],
-  ['tenant_default_locale_present = request_facts.tenant_default_locale_present', 'default locale presence'],
-  ['error_variant = error_facts.error_variant', 'static error variant'],
-  ['text_total_length = error_facts.text_total_length', 'text shape'],
-  ['uuid_non_nil_count = error_facts.uuid_non_nil_count', 'uuid shape'],
-  ['opaque_payload_present = error_facts.opaque_payload_present', 'opaque payload presence'],
-  ['boundary = SHIPPING_OPTION_READ_BOUNDARY', 'owner boundary'],
-  ['tracing::error!(', 'technical severity'],
-  ['tracing::warn!(', 'ordinary severity'],
-]) requireText(ownerSource, value, label);
+for (const marker of [
+  '"fulfillment.context_invalid"',
+  '"fulfillment.validation"',
+  '"fulfillment.shipping_option_not_found"',
+  '"fulfillment.fulfillment_not_found"',
+  '"fulfillment.invalid_transition"',
+  '"fulfillment.database_unavailable"',
+  '"fulfillment request context is invalid"',
+  '"fulfillment request is invalid"',
+  '"shipping option was not found"',
+  '"fulfillment was not found"',
+  '"fulfillment lifecycle transition conflicts with the current state"',
+  '"fulfillment storage is temporarily unavailable"',
+]) requireText(owner, marker, 'stable public error');
 
 for (const value of [
   'error = ?error',
@@ -101,35 +113,19 @@ for (const value of [
   'requested_locale = ?',
   'tenant_default_locale = %',
   'tenant_default_locale = ?',
-]) forbidText(ownerSource, value, 'shipping-option owner diagnostics');
+]) forbidText(owner, value, 'complete owner payload');
 
-for (const marker of [
-  'Validation(String)',
-  'ShippingOptionNotFound(Uuid)',
-  'FulfillmentNotFound(Uuid)',
-  'InvalidTransition { from: String, to: String }',
-  'Database(#[from] DbErr)',
-]) requireText(errorSource, marker, 'retained owner error shape');
-
-for (const [source, value, label] of [
-  [contextSource, 'PortActor::service("rustok-commerce.storefront-shipping")', 'commerce service actor'],
-  [contextSource, 'format!("storefront-shipping:{operation}:{cart_id}")', 'commerce correlation'],
-  [contextSource, '.with_deadline(std::time::Duration::from_secs(2))', 'commerce deadline'],
-  [contextSource, 'context.clone().with_channel(channel)', 'commerce channel propagation'],
-  [contextSource, 'rustok_fulfillment::in_process_shipping_option_read_port(db)', 'commerce root factory'],
-  [optionSource, '.read_shipping_option_projection(', 'mounted lookup'],
-  [enrichmentSource, '.list_shipping_option_projections(', 'mounted active-list'],
-  [projectionSource, 'pub fn enrich_cart_delivery_groups_from_options(', 'pure projection'],
-]) requireText(source, value, label);
-
-for (const source of [optionSource, enrichmentSource]) {
-  for (const value of [
-    'FulfillmentService::new(',
-    '.get_shipping_option(',
-    '.list_shipping_options(',
-    'FulfillmentError',
-    'error.message',
-  ]) forbidText(source, value, 'mounted shipping-option topology');
+for (const [source, marker, label] of [
+  [context, 'PortActor::service("rustok-commerce.storefront-shipping")', 'commerce actor'],
+  [context, '.with_deadline(std::time::Duration::from_secs(2))', 'commerce deadline'],
+  [context, 'rustok_fulfillment::in_process_shipping_option_read_port(db)', 'root factory'],
+  [optionConsumer, '.read_shipping_option_projection(', 'mounted lookup'],
+  [listConsumer, '.list_shipping_option_projections(', 'mounted list'],
+]) requireText(source, marker, label);
+for (const source of [optionConsumer, listConsumer]) {
+  for (const value of ['FulfillmentService::new(', 'FulfillmentError', 'error.message']) {
+    forbidText(source, value, 'mounted consumer boundary');
+  }
 }
 
 for (const [key, expected] of Object.entries({
@@ -153,9 +149,6 @@ for (const [key, expected] of Object.entries({
     failures.push(`diagnostic evidence ${key} must be ${expected}`);
   }
 }
-if (evidence.validation?.compile_proven !== false) {
-  failures.push('diagnostic evidence must not claim compilation');
-}
 for (const [key, expected] of Object.entries({
   public_traits_preserved: true,
   read_admission_order_preserved: true,
@@ -171,22 +164,14 @@ for (const [key, expected] of Object.entries({
     failures.push(`source review ${key} must be ${expected}`);
   }
 }
-
-for (const marker of [
-  'Status: **source-ready / unvalidated**',
-  'Fulfillment lifecycle projection-read diagnostics',
-]) requireText(diagnosticDoc, marker, 'diagnostic documentation');
-for (const marker of [
-  'Shipping-option projection-read owner payload diagnostics are source-closed / unvalidated.',
-  'verify-fulfillment-shipping-option-read-port.mjs',
-]) requireText(plan, marker, 'implementation plan');
+requireText(doc, 'Status: **source-ready / unvalidated**', 'diagnostic document');
+requireText(doc, 'Fulfillment lifecycle projection-read diagnostics', 'remaining gap');
 
 if (failures.length > 0) {
   console.error('Fulfillment shipping-option read port verification failed:');
   for (const failure of failures) console.error(`✗ ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
-
 console.log(
   '✔ fulfillment shipping-option projection reads retain owner topology, bounded diagnostics, and stable public PortError behavior',
 );

--- a/scripts/verify/verify-fulfillment-shipping-option-read-port.mjs
+++ b/scripts/verify/verify-fulfillment-shipping-option-read-port.mjs
@@ -13,6 +13,7 @@ const failures = [];
 
 const ownerRoot = read('crates/rustok-fulfillment/src/lib.rs');
 const ownerSource = read('crates/rustok-fulfillment/src/shipping_option_read.rs');
+const errorSource = read('crates/rustok-fulfillment/src/error.rs');
 const contextSource = read(
   'crates/rustok-commerce/src/graphql/mutations/shipping_option_read_context.rs',
 );
@@ -23,6 +24,20 @@ const enrichmentSource = read(
   'crates/rustok-commerce/src/graphql/mutations/typed_shipping_enrichment_helper.rs',
 );
 const projectionSource = read('crates/rustok-commerce/src/storefront_shipping.rs');
+const evidence = JSON.parse(
+  read(
+    'crates/rustok-fulfillment/contracts/evidence/shipping-option-read-diagnostic-safety-source.json',
+  ),
+);
+const review = JSON.parse(
+  read(
+    'crates/rustok-fulfillment/contracts/evidence/shipping-option-read-diagnostic-safety-source-review.json',
+  ),
+);
+const diagnosticDoc = read(
+  'crates/rustok-fulfillment/docs/shipping-option-read-diagnostic-safety.md',
+);
+const plan = read('crates/rustok-fulfillment/docs/implementation-plan.md');
 
 const requireText = (source, value, label) => {
   if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
@@ -33,152 +48,79 @@ const forbidText = (source, value, label) => {
 
 for (const [source, value, label] of [
   [ownerRoot, 'mod shipping_option_read;', 'private owner module'],
-  [ownerRoot, 'InProcessShippingOptionReadPort,', 'storefront wrapper export'],
-  [ownerRoot, 'InProcessShippingOptionAdminReadPort,', 'admin wrapper export'],
-  [
-    ownerRoot,
-    'ListAllShippingOptionProjectionsRequest,',
-    'administrative list request export',
-  ],
   [ownerRoot, 'ShippingOptionReadPort,', 'storefront trait export'],
   [ownerRoot, 'ShippingOptionAdminReadPort,', 'admin trait export'],
   [ownerRoot, 'in_process_shipping_option_read_port,', 'storefront factory export'],
-  [
-    ownerRoot,
-    'in_process_shipping_option_admin_read_port,',
-    'admin factory export',
-  ],
-  [ownerSource, 'pub trait ShippingOptionReadPort: Send + Sync {', 'storefront read port trait'],
-  [ownerSource, 'pub trait ShippingOptionAdminReadPort: Send + Sync {', 'admin read port trait'],
-  [ownerSource, 'pub struct InProcessShippingOptionReadPort {', 'storefront wrapper'],
-  [ownerSource, 'pub struct InProcessShippingOptionAdminReadPort {', 'admin wrapper'],
-  [ownerSource, 'impl ShippingOptionReadPort for InProcessShippingOptionReadPort', 'storefront wrapper implementation'],
-  [ownerSource, 'impl ShippingOptionAdminReadPort for InProcessShippingOptionAdminReadPort', 'admin wrapper implementation'],
-  [
-    ownerSource,
-    'pub fn in_process_shipping_option_read_port(',
-    'storefront canonical factory',
-  ],
-  [
-    ownerSource,
-    'pub fn in_process_shipping_option_admin_read_port(',
-    'admin canonical factory',
-  ],
-]) {
-  requireText(source, value, label);
-}
+  [ownerRoot, 'in_process_shipping_option_admin_read_port,', 'admin factory export'],
+  [ownerSource, 'pub trait ShippingOptionReadPort: Send + Sync {', 'storefront read trait'],
+  [ownerSource, 'pub trait ShippingOptionAdminReadPort: Send + Sync {', 'admin read trait'],
+  [ownerSource, 'impl ShippingOptionReadPort for InProcessShippingOptionReadPort', 'storefront implementation'],
+  [ownerSource, 'impl ShippingOptionAdminReadPort for InProcessShippingOptionAdminReadPort', 'admin implementation'],
+]) requireText(source, value, label);
 
 for (const [value, label] of [
-  ['async fn list_shipping_option_projections(', 'active list operation'],
-  ['async fn list_all_shipping_option_projections(', 'administrative list operation'],
-  ['async fn read_shipping_option_projection(', 'read operation'],
-  ['ListShippingOptionProjectionsRequest', 'active list request'],
-  ['ListAllShippingOptionProjectionsRequest', 'administrative list request'],
-  ['ReadShippingOptionProjectionRequest', 'read request'],
-  ['pub requested_locale: Option<String>', 'requested locale'],
-  ['pub tenant_default_locale: Option<String>', 'default locale'],
-  ['pub shipping_option_id: Uuid', 'option identity'],
-  ['context.require_policy(PortCallPolicy::read())?', 'read admission policy'],
-  ['parse_tenant_id(&context, "list_shipping_option_projections")?', 'active list tenant parse'],
-  [
-    'parse_tenant_id(&context, "list_all_shipping_option_projections")?',
-    'administrative list tenant parse',
-  ],
-  ['parse_tenant_id(&context, "read_shipping_option_projection")?', 'read tenant parse'],
-  ['.list_shipping_options(', 'owner active list delegation'],
-  ['.list_all_shipping_options(', 'owner administrative list delegation'],
-  ['.get_shipping_option(', 'owner read delegation'],
+  ['context.require_policy(PortCallPolicy::read())?', 'read admission'],
+  ['parse_tenant_id(&context, "list_shipping_option_projections")?', 'active-list tenant parse'],
+  ['parse_tenant_id(&context, "read_shipping_option_projection")?', 'lookup tenant parse'],
+  ['parse_tenant_id(&context, "list_all_shipping_option_projections")?', 'list-all tenant parse'],
+  ['.list_shipping_options(', 'active-list owner delegation'],
+  ['.get_shipping_option(', 'lookup owner delegation'],
+  ['.list_all_shipping_options(', 'list-all owner delegation'],
   ['request.requested_locale.as_deref()', 'requested locale delegation'],
   ['request.tenant_default_locale.as_deref()', 'default locale delegation'],
-]) {
-  requireText(ownerSource, value, label);
-}
-
-const listDelegations = ownerSource.match(/\.list_shipping_options\(/g) ?? [];
-if (listDelegations.length !== 1) {
-  failures.push(`expected one owner active list delegation, found ${listDelegations.length}`);
-}
-const listAllDelegations = ownerSource.match(/\.list_all_shipping_options\(/g) ?? [];
-if (listAllDelegations.length !== 1) {
-  failures.push(
-    `expected one owner administrative list delegation, found ${listAllDelegations.length}`,
-  );
-}
-const readDelegations = ownerSource.match(/\.get_shipping_option\(/g) ?? [];
-if (readDelegations.length !== 1) {
-  failures.push(`expected one owner option delegation, found ${readDelegations.length}`);
-}
+]) requireText(ownerSource, value, label);
 
 for (const [value, label] of [
-  ['FulfillmentError::Validation(_)', 'validation mapping'],
-  ['FulfillmentError::ShippingOptionNotFound(_)', 'shipping option mapping'],
-  ['FulfillmentError::FulfillmentNotFound(_)', 'fulfillment mapping'],
-  ['FulfillmentError::InvalidTransition { .. }', 'conflict mapping'],
-  ['FulfillmentError::Database(_)', 'database mapping'],
-  ['PortErrorKind::Validation', 'validation kind'],
-  ['PortErrorKind::NotFound', 'not-found kind'],
-  ['PortErrorKind::Conflict', 'conflict kind'],
-  ['PortErrorKind::Unavailable', 'unavailable kind'],
-  ['"fulfillment.validation"', 'validation code'],
-  ['"fulfillment.shipping_option_not_found"', 'shipping option code'],
-  ['"fulfillment.fulfillment_not_found"', 'fulfillment code'],
-  ['"fulfillment.invalid_transition"', 'conflict code'],
-  ['"fulfillment.database_unavailable"', 'database code'],
-  ['PortError::new(kind, code, message, retryable)', 'stable error construction'],
-]) {
-  requireText(ownerSource, value, label);
-}
-
-for (const [value, label] of [
-  ['correlation_id = %context.correlation_id', 'correlation fact'],
-  ['tenant_id = %context.tenant_id', 'tenant fact'],
-  ['actor = ?context.actor', 'actor fact'],
-  ['channel_length = context.channel.as_deref().map(str::len)', 'channel length'],
-  ['locale_length = context.locale.len()', 'locale length'],
-  ['causation_id_present = context.causation_id.is_some()', 'causation presence'],
-  ['traceparent_present = context.traceparent.is_some()', 'trace presence'],
-  ['deadline_ms = ?context.deadline_ms', 'deadline fact'],
-  ['shipping_option_id = ?shipping_option_id', 'option identity fact'],
-  ['requested_locale_length = ?requested_locale_length', 'requested locale length'],
-  ['tenant_default_locale_length = ?tenant_default_locale_length', 'default locale length'],
-  ['boundary = "fulfillment_shipping_option_read_port"', 'owner boundary'],
+  ['ShippingOptionReadContextFacts', 'bounded context facts'],
+  ['ShippingOptionOwnerErrorFacts', 'bounded owner-error facts'],
+  ['ShippingOptionReadRequestFacts', 'bounded request facts'],
+  ['tenant_id_parse_failed = true', 'tenant parse failure fact'],
+  ['shipping_option_id_present = request_facts.shipping_option_id_present', 'identity presence fact'],
+  ['shipping_option_id_non_nil = request_facts.shipping_option_id_non_nil', 'identity shape fact'],
+  ['requested_locale_present = request_facts.requested_locale_present', 'requested locale presence'],
+  ['tenant_default_locale_present = request_facts.tenant_default_locale_present', 'default locale presence'],
+  ['error_variant = error_facts.error_variant', 'static error variant'],
+  ['text_total_length = error_facts.text_total_length', 'text shape'],
+  ['uuid_non_nil_count = error_facts.uuid_non_nil_count', 'uuid shape'],
+  ['opaque_payload_present = error_facts.opaque_payload_present', 'opaque payload presence'],
+  ['boundary = SHIPPING_OPTION_READ_BOUNDARY', 'owner boundary'],
   ['tracing::error!(', 'technical severity'],
   ['tracing::warn!(', 'ordinary severity'],
-]) {
-  requireText(ownerSource, value, label);
-}
+]) requireText(ownerSource, value, label);
 
-for (const [value, label] of [
-  ['PortActor::service("rustok-commerce.storefront-shipping")', 'commerce service actor'],
-  ['format!("storefront-shipping:{operation}:{cart_id}")', 'commerce correlation'],
-  ['.with_deadline(std::time::Duration::from_secs(2))', 'commerce deadline'],
-  ['context.clone().with_channel(channel)', 'commerce channel propagation'],
-  [
-    'rustok_fulfillment::in_process_shipping_option_read_port(db)',
-    'commerce root factory usage',
-  ],
-]) {
-  requireText(contextSource, value, label);
-}
+for (const value of [
+  'error = ?error',
+  'tenant_id = %context.tenant_id',
+  'actor = ?context.actor',
+  'shipping_option_id = ?shipping_option_id',
+  'error = %message',
+  'resource_id = %',
+  'from = %from',
+  'to = %to',
+  'requested_locale = %',
+  'requested_locale = ?',
+  'tenant_default_locale = %',
+  'tenant_default_locale = ?',
+]) forbidText(ownerSource, value, 'shipping-option owner diagnostics');
+
+for (const marker of [
+  'Validation(String)',
+  'ShippingOptionNotFound(Uuid)',
+  'FulfillmentNotFound(Uuid)',
+  'InvalidTransition { from: String, to: String }',
+  'Database(#[from] DbErr)',
+]) requireText(errorSource, marker, 'retained owner error shape');
 
 for (const [source, value, label] of [
-  [optionSource, '.read_shipping_option_projection(', 'mounted option read'],
-  [optionSource, 'ReadShippingOptionProjectionRequest {', 'mounted option request'],
-  [enrichmentSource, '.list_shipping_option_projections(', 'mounted option list'],
-  [enrichmentSource, 'ListShippingOptionProjectionsRequest {', 'mounted list request'],
-  [
-    projectionSource,
-    'pub fn enrich_cart_delivery_groups_from_options(',
-    'pure commerce projection',
-  ],
-  [
-    enrichmentSource,
-    'enrich_cart_delivery_groups_from_options(',
-    'mounted pure projection usage',
-  ],
-]) {
-  requireText(source, value, label);
-}
+  [contextSource, 'PortActor::service("rustok-commerce.storefront-shipping")', 'commerce service actor'],
+  [contextSource, 'format!("storefront-shipping:{operation}:{cart_id}")', 'commerce correlation'],
+  [contextSource, '.with_deadline(std::time::Duration::from_secs(2))', 'commerce deadline'],
+  [contextSource, 'context.clone().with_channel(channel)', 'commerce channel propagation'],
+  [contextSource, 'rustok_fulfillment::in_process_shipping_option_read_port(db)', 'commerce root factory'],
+  [optionSource, '.read_shipping_option_projection(', 'mounted lookup'],
+  [enrichmentSource, '.list_shipping_option_projections(', 'mounted active-list'],
+  [projectionSource, 'pub fn enrich_cart_delivery_groups_from_options(', 'pure projection'],
+]) requireText(source, value, label);
 
 for (const source of [optionSource, enrichmentSource]) {
   for (const value of [
@@ -187,21 +129,57 @@ for (const source of [optionSource, enrichmentSource]) {
     '.list_shipping_options(',
     'FulfillmentError',
     'error.message',
-  ]) {
-    forbidText(source, value, 'mounted shipping-option read topology');
+  ]) forbidText(source, value, 'mounted shipping-option topology');
+}
+
+for (const [key, expected] of Object.entries({
+  complete_fulfillment_error_logged: false,
+  database_error_payload_logged: false,
+  uuid_parser_payload_logged: false,
+  resource_uuid_logged: false,
+  raw_context_values_logged: false,
+  static_error_variant_logged: true,
+  aggregate_error_shape_logged: true,
+  safe_context_shape_logged: true,
+  request_identity_shape_logged: true,
+  locale_shape_logged: true,
+  public_code_changed: false,
+  public_message_changed: false,
+  public_kind_changed: false,
+  public_retryability_changed: false,
+  fulfillment_lifecycle_read_diagnostic_cleanup_closed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`diagnostic evidence ${key} must be ${expected}`);
+  }
+}
+if (evidence.validation?.compile_proven !== false) {
+  failures.push('diagnostic evidence must not claim compilation');
+}
+for (const [key, expected] of Object.entries({
+  public_traits_preserved: true,
+  read_admission_order_preserved: true,
+  owner_delegation_preserved: true,
+  locale_delegation_preserved: true,
+  all_public_port_errors_preserved: true,
+  complete_fulfillment_error_logging_removed: true,
+  raw_context_values_removed: true,
+  resource_uuid_removed: true,
+  runtime_evidence_claimed: false,
+})) {
+  if (review.review_findings?.[key] !== expected) {
+    failures.push(`source review ${key} must be ${expected}`);
   }
 }
 
-for (const value of [
-  'error = %message',
-  'message = %',
-  'requested_locale = %',
-  'requested_locale = ?',
-  'tenant_default_locale = %',
-  'tenant_default_locale = ?',
-]) {
-  forbidText(ownerSource, value, 'shipping-option owner diagnostics');
-}
+for (const marker of [
+  'Status: **source-ready / unvalidated**',
+  'Fulfillment lifecycle projection-read diagnostics',
+]) requireText(diagnosticDoc, marker, 'diagnostic documentation');
+for (const marker of [
+  'Shipping-option projection-read owner payload diagnostics are source-closed / unvalidated.',
+  'verify-fulfillment-shipping-option-read-port.mjs',
+]) requireText(plan, marker, 'implementation plan');
 
 if (failures.length > 0) {
   console.error('Fulfillment shipping-option read port verification failed:');
@@ -210,5 +188,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ fulfillment owns storefront active/list lookup and administrative list-all projections behind separate canonical read ports while mounted storefront commerce retains owner context',
+  '✔ fulfillment shipping-option projection reads retain owner topology, bounded diagnostics, and stable public PortError behavior',
 );


### PR DESCRIPTION
## Summary

- continue the ecommerce diagnostic cleanup at the Fulfillment shipping-option projection-read owner boundary
- replace tenant UUID parser payloads with a static parse-failure fact and bounded context shape
- replace complete `FulfillmentError` diagnostics with a closed static variant plus aggregate text, UUID, and opaque-payload shape
- replace raw shipping-option UUID logging with presence/non-nil facts and retain locale presence/length only
- preserve all three read operations, canonical factories, read admission, locale delegation, owner calls, severity, and exact public `PortError` envelopes
- strengthen the existing shipping-option owner verifier and add focused source evidence/review documentation

## Scope

Exactly five files change: one runtime owner file, one existing focused verifier, two evidence files, and one focused document. `fulfillment_read.rs`, native `ShippingSelectionPort`, checkout execution, Commerce consumers/runtime composition, DTOs, contracts, migrations, dependencies, workflows, and CI configuration are unchanged.

The canonical Fulfillment plan was rechecked: this closes the shipping-option projection-read diagnostic slice identified after PR #2756. Fulfillment lifecycle projection-read diagnostics remain the next separate slice.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-fulfillment-shipping-option-read-port.mjs
cargo check -p rustok-fulfillment --lib
cargo check -p rustok-commerce --lib
```

Branch starts from `dca73ffd3076c180f6c969eec67702447704d64a`; current `main` advanced by one unrelated Forum documentation commit. GitHub mergeability will be checked before squash merge.