### PR TITLE
test(forum): retain versioned invalidation ingress evidence

### DIFF
--- a/crates/rustok-forum/contracts/evidence/forum-search-versioned-invalidation-postgres-harness.json
+++ b/crates/rustok-forum/contracts/evidence/forum-search-versioned-invalidation-postgres-harness.json
@@ -1,0 +1,53 @@
+{
+  "format_version": 1,
+  "task": "FORUM-23B2G2B3D1",
+  "status": "source_ready_maintainer_execution_pending",
+  "predecessor": "FORUM-23B2G2B3D0",
+  "test_target": "crates/rustok-search/tests/forum_contract_ingress_postgres_test.rs",
+  "database": {
+    "backend": "postgresql",
+    "environment": "RUSTOK_SEARCH_TEST_DATABASE_URL",
+    "database_url_fallback": "DATABASE_URL",
+    "isolated_schema_per_test": true,
+    "real_search_module_migrations": true,
+    "sleep_or_polling": false
+  },
+  "scenarios": {
+    "legacy_first_then_typed": {
+      "single_root_row": true,
+      "exact_existing_ingest_sequence_retained": true,
+      "new_ingress_instance_redelivery": true
+    },
+    "typed_first_then_legacy": {
+      "single_root_row": true,
+      "search_ingest_sequence_remains_owner": true,
+      "owner_revision_not_used_as_ingest_sequence": true
+    },
+    "identity_conflict": {
+      "same_root_uuid_with_different_scope_or_payload": true,
+      "stable_error_code": "forum.search_projection.contract_inbox_identity_conflict",
+      "retryable": false,
+      "durable_row_not_rewritten": true
+    }
+  },
+  "single_execution_path": {
+    "table": "search_projection_inbox",
+    "existing_search_migrations": true,
+    "second_inbox": false,
+    "second_projector": false,
+    "typed_identity": "ContractEventEnvelope.causation_id",
+    "legacy_identity": "EventEnvelope.id"
+  },
+  "not_claimed": {
+    "test_executed": false,
+    "postgresql_output_captured": false,
+    "iggy_cursor_restart": false,
+    "raw_poison_dlq": false,
+    "semantic_poison_dlq": false,
+    "dlq_duplicate_suppression": false,
+    "owner_checkpoint_repair": false,
+    "link_forum_03_closed": false
+  },
+  "remaining_task": "FORUM-23B2G2B3D",
+  "remaining_scope": "Maintainer-executed PostgreSQL output plus the remaining persistent Iggy cursor, acknowledgement, poison/DLQ redelivery, owner-checkpoint repair, multi-process, deletion/ACL, Search-disabled and LINK-FORUM-03 evidence required by D0"
+}

--- a/crates/rustok-forum/docs/forum-23b2g2b3d1-versioned-invalidation-postgres-evidence.md
+++ b/crates/rustok-forum/docs/forum-23b2g2b3d1-versioned-invalidation-postgres-evidence.md
@@ -1,0 +1,66 @@
+# FORUM-23B2G2B3D1 versioned Search invalidation PostgreSQL evidence harness
+
+Status: `source_ready_maintainer_execution_pending`
+
+## Purpose
+
+This slice turns the PostgreSQL ingress subset of the accepted `FORUM-23B2G2B3D0` protocol into one reproducible, environment-gated integration target. It does not claim that the target was executed and does not replace the remaining persistent-Iggy evidence.
+
+The harness uses the real `SearchModule` migration list inside a unique PostgreSQL schema for every case. It constructs a new `ForumSearchContractIngress` after durable admission to model process-local runtime reconstruction without relying on sleep, polling, lease expiry, wall-clock ordering or broker mocks.
+
+## Covered evidence
+
+The target proves the source path for:
+
+- legacy-root delivery before the caused typed invalidation;
+- caused typed invalidation before legacy-root delivery;
+- one durable `search_projection_inbox` row in both orders;
+- retention of the first Search-owned positive `ingest_sequence`;
+- typed redelivery through a newly constructed ingress instance;
+- exact tenant, scope and root-envelope duplicate recognition;
+- fail-closed UUID collision handling when the retained root row has different scope or payload identity;
+- stable non-retryable semantic-poison code `forum.search_projection.contract_inbox_identity_conflict`;
+- independence of Forum `owner_revision` from Search `ingest_sequence`.
+
+The harness inserts the legacy root only through the same physical `ON CONFLICT (event_id) DO NOTHING` collapse contract used by the existing inbox. The production adapter remains responsible for the post-conflict exact identity verification.
+
+## Isolation and cleanup
+
+The test reads `RUSTOK_SEARCH_TEST_DATABASE_URL`, with PostgreSQL `DATABASE_URL` as fallback. Without a PostgreSQL URL it reports a skip and succeeds.
+
+Each case:
+
+1. creates a uniquely named schema;
+2. sets `search_path` to that schema plus `public`;
+3. applies every real `SearchModule` migration;
+4. runs one deterministic delivery-order or identity-conflict scenario;
+5. reads the durable inbox row directly;
+6. drops the isolated schema.
+
+No production migration, runtime flag, consumer group, public API or projection behavior changes in this slice.
+
+## Remaining FORUM-23B2G2B3D evidence
+
+`FORUM-23B2G2B3D` remains open for maintainer-executed evidence covering:
+
+- successful PostgreSQL harness output capture;
+- persistent Iggy cursor restart before and after acknowledgement;
+- acknowledgement failure after durable inbox admission;
+- raw and semantic poison receipt, DLQ publication and redelivery;
+- deterministic DLQ duplicate suppression;
+- owner-checkpoint repair after missed delivery;
+- the complete `LINK-FORUM-03` publish/moderate/delete/ACL ordering proof.
+
+## Maintainer validation
+
+```bash
+RUSTOK_SEARCH_TEST_DATABASE_URL=postgresql://... \
+  cargo test -p rustok-search \
+  --test forum_contract_ingress_postgres_test \
+  -- --nocapture --test-threads=1
+
+cargo check -p rustok-search --all-targets
+node scripts/verify/verify-forum-search-versioned-invalidation-postgres-harness.mjs
+```
+
+These commands were not run by the implementation agent.

--- a/crates/rustok-search/tests/forum_contract_ingress_postgres_test.rs
+++ b/crates/rustok-search/tests/forum_contract_ingress_postgres_test.rs
@@ -1,0 +1,300 @@
+use std::error::Error;
+
+use chrono::Utc;
+use rustok_core::MigrationSource;
+use rustok_events::{
+    ContractEventEnvelope, DomainEvent, EventEnvelope, ForumSearchProjectionEvent,
+};
+use rustok_search::{
+    ForumSearchContractIngress, ForumSearchContractIngressError,
+    ForumSearchContractIngressOutcome, SearchModule,
+};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, QueryResult,
+    Statement, Value as SqlValue,
+};
+use sea_orm_migration::SchemaManager;
+use serde_json::Value as JsonValue;
+use uuid::Uuid;
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+const SEARCH_TEST_DATABASE_ENV: &str = "RUSTOK_SEARCH_TEST_DATABASE_URL";
+const ROOT_EVENT_TYPE: &str = "index.reindex_requested";
+const FORUM_SOURCE_MODULE: &str = "forum";
+
+struct PostgresSearchTestDb {
+    control: DatabaseConnection,
+    db: DatabaseConnection,
+    schema_name: String,
+}
+
+impl PostgresSearchTestDb {
+    async fn setup(prefix: &str) -> TestResult<Option<Self>> {
+        let Some(database_url) = postgres_database_url() else {
+            eprintln!(
+                "{SEARCH_TEST_DATABASE_ENV} is not set to a PostgreSQL URL; skipping Forum versioned invalidation ingress evidence"
+            );
+            return Ok(None);
+        };
+
+        let control = connect(&database_url).await?;
+        let schema_name = format!(
+            "rustok_search_{}_{}",
+            sanitize_identifier(prefix),
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let db = connect(&database_url).await?;
+        set_search_path(&db, &schema_name).await?;
+
+        let setup_result = async {
+            let manager = SchemaManager::new(&db);
+            for migration in SearchModule.migrations() {
+                migration.up(&manager).await?;
+            }
+            Ok::<(), sea_orm::DbErr>(())
+        }
+        .await;
+
+        if let Err(error) = setup_result {
+            let _ = control
+                .execute_unprepared(&format!(r#"DROP SCHEMA IF EXISTS "{schema_name}" CASCADE"#))
+                .await;
+            return Err(error.into());
+        }
+
+        Ok(Some(Self {
+            control,
+            db,
+            schema_name,
+        }))
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InboxSnapshot {
+    tenant_id: Uuid,
+    source_module: String,
+    scope_key: String,
+    event_type: String,
+    ingest_sequence: i64,
+    envelope_json: JsonValue,
+}
+
+#[tokio::test]
+async fn legacy_first_then_typed_restart_reuses_one_exact_root_row() -> TestResult<()> {
+    let Some(test_db) = PostgresSearchTestDb::setup("forum_contract_legacy_first").await? else {
+        return Ok(());
+    };
+
+    let tenant_id = Uuid::new_v4();
+    let root_event_id = Uuid::new_v4();
+    let category_id = Uuid::new_v4();
+    let owner_revision = 9_000_001_i64;
+    let target_type = "forum_category";
+    let target_id = Some(category_id);
+    let scope_key = format!("forum_category:{category_id}");
+    let root = legacy_root_envelope(tenant_id, root_event_id, target_type, target_id)?;
+    insert_legacy_root(&test_db.db, &root, &scope_key).await?;
+    let before = load_snapshot(&test_db.db, root_event_id).await?;
+
+    let typed = typed_invalidation(
+        tenant_id,
+        root_event_id,
+        owner_revision,
+        target_type,
+        target_id,
+    )?;
+    let first = ForumSearchContractIngress::new(test_db.db.clone())
+        .ingest(&typed)
+        .await?;
+    assert_eq!(
+        first,
+        ForumSearchContractIngressOutcome::DurablyAccepted {
+            root_event_id,
+            owner_revision,
+        }
+    );
+
+    let after_first = load_snapshot(&test_db.db, root_event_id).await?;
+    assert_eq!(after_first, before);
+    assert_eq!(count_root_rows(&test_db.db, root_event_id).await?, 1);
+
+    let restarted = ForumSearchContractIngress::new(test_db.db.clone());
+    let redelivery = restarted.ingest(&typed).await?;
+    assert_eq!(redelivery, first);
+    assert_eq!(load_snapshot(&test_db.db, root_event_id).await?, before);
+    assert_eq!(count_root_rows(&test_db.db, root_event_id).await?, 1);
+
+    test_db.cleanup().await
+}
+
+#[tokio::test]
+async fn typed_first_then_legacy_delivery_keeps_search_owned_sequence() -> TestResult<()> {
+    let Some(test_db) = PostgresSearchTestDb::setup("forum_contract_typed_first").await? else {
+        return Ok(());
+    };
+
+    let tenant_id = Uuid::new_v4();
+    let root_event_id = Uuid::new_v4();
+    let owner_revision = 8_000_003_i64;
+    let target_type = "forum_topic";
+    let target_id = Some(Uuid::new_v4());
+    let typed = typed_invalidation(
+        tenant_id,
+        root_event_id,
+        owner_revision,
+        target_type,
+        target_id,
+    )?;
+
+    let accepted = ForumSearchContractIngress::new(test_db.db.clone())
+        .ingest(&typed)
+        .await?;
+    assert!(matches!(
+        accepted,
+        ForumSearchContractIngressOutcome::DurablyAccepted {
+            root_event_id: accepted_id,
+            owner_revision: accepted_revision,
+        } if accepted_id == root_event_id && accepted_revision == owner_revision
+    ));
+
+    let typed_first = load_snapshot(&test_db.db, root_event_id).await?;
+    assert_eq!(typed_first.source_module, FORUM_SOURCE_MODULE);
+    assert_eq!(typed_first.scope_key, "forum");
+    assert_eq!(typed_first.event_type, ROOT_EVENT_TYPE);
+    assert!(typed_first.ingest_sequence > 0);
+    assert_ne!(typed_first.ingest_sequence, owner_revision);
+
+    let root = legacy_root_envelope(tenant_id, root_event_id, target_type, target_id)?;
+    insert_legacy_root(&test_db.db, &root, "forum").await?;
+    assert_eq!(load_snapshot(&test_db.db, root_event_id).await?, typed_first);
+    assert_eq!(count_root_rows(&test_db.db, root_event_id).await?, 1);
+
+    let restarted = ForumSearchContractIngress::new(test_db.db.clone());
+    restarted.ingest(&typed).await?;
+    assert_eq!(load_snapshot(&test_db.db, root_event_id).await?, typed_first);
+
+    test_db.cleanup().await
+}
+
+#[tokio::test]
+async fn conflicting_legacy_identity_is_non_retryable_semantic_poison() -> TestResult<()> {
+    let Some(test_db) = PostgresSearchTestDb::setup("forum_contract_conflict").await? else {
+        return Ok(());
+    };
+
+    let tenant_id = Uuid::new_v4();
+    let root_event_id = Uuid::new_v4();
+    let requested_category_id = Uuid::new_v4();
+    let conflicting_category_id = Uuid::new_v4();
+    let conflicting_root = legacy_root_envelope(
+        tenant_id,
+        root_event_id,
+        "forum_category",
+        Some(conflicting_category_id),
+    )?;
+    insert_legacy_root(
+        &test_db.db,
+        &conflicting_root,
+        &format!("forum_category:{conflicting_category_id}"),
+    )
+    .await?;
+    let before = load_snapshot(&test_db.db, root_event_id).await?;
+
+    let typed = typed_invalidation(
+        tenant_id,
+        root_event_id,
+        42,
+        "forum_category",
+        Some(requested_category_id),
+    )?;
+    let error = ForumSearchContractIngress::new(test_db.db.clone())
+        .ingest(&typed)
+        .await
+        .expect_err("conflicting root identity must fail closed");
+    assert_eq!(error, ForumSearchContractIngressError::InboxIdentityConflict);
+    assert_eq!(
+        error.stable_code(),
+        "forum.search_projection.contract_inbox_identity_conflict"
+    );
+    assert!(!error.is_retryable());
+    assert_eq!(load_snapshot(&test_db.db, root_event_id).await?, before);
+    assert_eq!(count_root_rows(&test_db.db, root_event_id).await?, 1);
+
+    test_db.cleanup().await
+}
+
+fn typed_invalidation(
+    tenant_id: Uuid,
+    root_event_id: Uuid,
+    owner_revision: i64,
+    target_type: &str,
+    target_id: Option<Uuid>,
+) -> TestResult<ContractEventEnvelope> {
+    Ok(ContractEventEnvelope::new_caused_by(
+        tenant_id,
+        None,
+        root_event_id,
+        ForumSearchProjectionEvent::InvalidationIssued {
+            owner_revision,
+            target_type: target_type.to_string(),
+            target_id,
+        },
+    )?)
+}
+
+fn legacy_root_envelope(
+    tenant_id: Uuid,
+    root_event_id: Uuid,
+    target_type: &str,
+    target_id: Option<Uuid>,
+) -> TestResult<EventEnvelope> {
+    let envelope = EventEnvelope {
+        id: root_event_id,
+        event_type: ROOT_EVENT_TYPE.to_string(),
+        schema_version: 1,
+        correlation_id: root_event_id,
+        causation_id: None,
+        tenant_id,
+        trace_id: None,
+        timestamp: Utc::now(),
+        actor_id: None,
+        event: DomainEvent::ReindexRequested {
+            target_type: target_type.to_string(),
+            target_id,
+        },
+        retry_count: 0,
+    };
+    envelope.validate_registered_schema()?;
+    Ok(envelope)
+}
+
+async fn insert_legacy_root(
+    db: &DatabaseConnection,
+    envelope: &EventEnvelope,
+    scope_key: &str,
+) -> Result<(), sea_orm::DbErr> {
+    let envelope_json = serde_json::to_value(envelope)
+        .map_err(|error| sea_orm::DbErr::Custom(error.to_string()))?;
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+        INSERT INTO search_projection_inbox (
+            event_id, tenant_id, source_module, scope_key, event_type,
+            revision_at, envelope_json
+        ) VALUES ($1, $2, $3"ÂCBÂCRÂCbÂCr¢ôâ4ôädÄ”5B†WfVçEö–B’DòäõD„”är"À¢fV5°¢VçfVÆ÷Ræ–Bæ–çFò‚’À¢VçfVÆ÷RçFVæçEö–Bæ–çFò‚’À¢dõ%TÕõ4õU$4UôÔôETÄRæ–çFò‚’À¢66÷Uö¶W’çFõ÷7G&–ær‚’æ–çFò‚’À¢$ôõEôUdTåEõE•Ræ–çFò‚’À¢VçfVÆ÷RçF–ÖW7F×æ–çFò‚’À¢7ÅfÇVS£¤§6öâ…6öÖR„&÷ƒ£¦æWr†VçfVÆ÷Uö§6öâ’’’À¢ÒÀ¢’¢æv—Có°¢ö²‚‚’§Ğ ¦7–æ2fâÆöE÷6æ6†÷B€¢F#¢dFF&6T6öææV7F–öâÀ¢&ö÷EöWfVçEö–C¢WV–BÀ¢’Óâ&W7VÇCÄ–æ&÷…6æ6†÷BÂ6Vö÷&Ó£¤F$W'#â°¢ÆWB&÷rÒF ¢çVW'•ööæR…7FFVÖVçC£¦g&öÕ÷7ÅöæE÷fÇVW2€¢F$&6¶VæC£¥÷7Fw&W2À¢"2 ¢4TÄT5BFVæçEö–BÂ6÷W&6UöÖöGVÆRÂ66÷Uö¶W’ÂWfVçE÷G—RÀ¢–ævW7E÷6WVVæ6RÂVçfVÆ÷Uö§6öà¢e$ôÒ6V&6…÷&ö¦V7F–öåö–æ&÷€¢t„U$RWfVçEö–BÒC¢"2À¢fV6·&ö÷EöWfVçEö–Bæ–çFò‚•ÒÀ¢’¢æv—Cğ¢æW‡V7B‚&W‡V7FVBGW&&ÆRf÷'VÒ6V&6‚–æ&÷‚&÷r"“°¢6æ6†÷Eög&öÕ÷&÷r‚g&÷r§Ğ ¦fâ6æ6†÷Eög&öÕ÷&÷r‡&÷s¢eVW'•&W7VÇB’Óâ&W7VÇCÄ–æ&÷…6æ6†÷BÂ6Vö÷&Ó£¤F$W'#â°¢ö²„–æ&÷…6æ6†÷B°¢FVæçEö–C¢&÷rçG'•övWB‚""Â'FVæçEö–B"“òÀ¢6÷W&6UöÖöGVÆS¢&÷rçG'•övWB‚""Â'6÷W&6UöÖöGVÆR"“òÀ¢66÷Uö¶W“¢&÷rçG'•övWB‚""Â'66÷Uö¶W’"“òÀ¢WfVçE÷G—S¢&÷rçG'•övWB‚""Â&WfVçE÷G—R"“òÀ¢–ævW7E÷6WVVæ6S¢&÷rçG'•övWB‚""Â&–ævW7E÷6WVVæ6R"“òÀ¢VçfVÆ÷Uö§6öã¢&÷rçG'•övWB‚""Â&VçfVÆ÷Uö§6öâ"“òÀ¢Ò§Ğ ¦7–æ2fâ6÷VçE÷&ö÷E÷&÷w2€¢F#¢dFF&6T6öææV7F–öâÀ¢&ö÷EöWfVçEö–C¢WV–BÀ¢’Óâ&W7VÇCÆ“cBÂ6Vö÷&Ó£¤F$W'#â°¢ÆWB&÷rÒF ¢çVW'•ööæR…7FFVÖVçC£¦g&öÕ÷7ÅöæE÷fÇVW2€¢F$&6¶VæC£¥÷7Fw&W2À¢%4TÄT5B4õTåB‚¢“£¦&–v–çB26÷VçBe$ôÒ6V&6…÷&ö¦V7F–öåö–æ&÷‚t„U$RWfVçEö–BÒC"À¢fV5·&ö÷EöWfVçEö–Bæ–çFò‚•ÒÀ¢’¢æv—Cğ¢æW‡V7B‚&6÷VçBVW'’&WGW&ç2öæR&÷r"“°¢&÷rçG'•övWB‚""Â&6÷VçB"§Ğ ¦fâ÷7Fw&W5öFF&6U÷W&Â‚’Óâ÷F–öãÅ7G&–æsâ°¢7FC£¦Vçc£§f"…4T$4…õDU5EôDD$4UôTåb¢æ÷%öVÇ6R‡Å÷Â7FC£¦Vçc£§f"‚$DD$4UõU$Â"’¢æö²‚¢æf–ÇFW"‡ÇW&ÇÂW&Âç7F'G5÷v—F‚‚'÷7Fw&W3¢òò"’ÇÂW&Âç7F'G5÷v—F‚‚'÷7Fw&W7Ã¢òò"’§Ğ ¦7–æ2fâ6öææV7B†FF&6U÷W&Ã¢g7G"’ÓâFW7E&W7VÇCÄFF&6T6öææV7F–öãâ°¢ÆWB×WB÷F–öç2Ò6öææV7D÷F–öç3£¦æWr†FF&6U÷W&ÂçFõö÷væVB‚’“°¢÷F–öç0¢æÖ…ö6öææV7F–öç2ƒ¢æÖ–åö6öææV7F–öç2ƒ¢ç7Ç…öÆövv–ær†fÇ6R“°¢ö²„FF&6S£¦6öææV7B†÷F–öç2’æv—Cò§Ğ ¦7–æ2fâ6WE÷6V&6…÷F‚†F#¢dFF&6T6öææV7F–öâÂ66†VÖöæÖS¢g7G"’ÓâFW7E&W7VÇCÂ‚“â°¢F"æW†V7WFU÷Vç&W&VB‚ff÷&ÖB‡"2%4UB6V&6…÷F‚Dò'·66†VÖöæÖWÒ"ÂV&Æ–2"2’¢æv—Có°¢ö²‚‚’§Ğ ¦fâ6æ—F—¦Uö–FVçF–f–W"‡fÇVS¢g7G"’Óâ7G&–ær°¢ÆWBæ÷&ÖÆ—¦VBÒfÇVP¢æ6†'2‚¢æÖ‡Æ6†&7FW'Â°¢–b6†&7FW"æ—5ö66–•öÇ†çVÖW&–2‚’°¢6†&7FW"çFõö66–•öÆ÷vW&66R‚¢ÒVÇ6R°¢uòp¢Ğ¢Ò¢æ6öÆÆV7C££Å7G&–æsâ‚“°¢ÆWBæ÷&ÖÆ—¦VBÒæ÷&ÖÆ—¦VBçG&–ÕöÖF6†W2‚uòr“°¢–bæ÷&ÖÆ—¦VBæ—5öV×G’‚’°¢'FW7B"çFõ÷7G&–ær‚¢ÒVÇ6R°¢æ÷&ÖÆ—¦VBçFõ÷7G&–ær‚¢Ğ§Ğ 

--- a/scripts/verify/verify-forum-search-versioned-invalidation-postgres-harness.mjs
+++ b/scripts/verify/verify-forum-search-versioned-invalidation-postgres-harness.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const root = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : process.cwd();
+const failures = [];
+
+const paths = {
+  contract: "crates/rustok-forum/contracts/evidence/forum-search-versioned-invalidation-postgres-harness.json",
+  note: "crates/rustok-forum/docs/forum-23b2g2b3d1-versioned-invalidation-postgres-evidence.md",
+  test: "crates/rustok-search/tests/forum_contract_ingress_postgres_test.rs",
+  ingress: "crates/rustok-search/src/forum_contract_ingress.rs",
+  migrations: "crates/rustok-search/src/migrations/mod.rs",
+  protocolContract: "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json",
+  protocolNote: "crates/rustok-forum/docs/forum-23b2g2b3d-runtime-evidence.md",
+  forumPlan: "crates/rustok-forum/docs/implementation-plan.md",
+};
+
+function target(relativePath) {
+  return path.join(root, relativePath);
+}
+
+function read(relativePath) {
+  if (!fs.existsSync(target(relativePath))) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return "";
+  }
+  return fs.readFileSync(target(relativePath), "utf8");
+}
+
+function readJson(relativePath) {
+  try {
+    return JSON.parse(read(relativePath));
+  } catch (error) {
+    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function requireAll(source, markers, label) {
+  for (const marker of markers) {
+    if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+  }
+}
+
+function rejectAll(source, markers, label) {
+  for (const marker of markers) {
+    if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+  }
+}
+
+const contract = readJson(paths.contract);
+const protocolContract = readJson(paths.protocolContract);
+const protocolNote = read(paths.protocolNote);
+const note = read(paths.note);
+const test = read(paths.test);
+const ingress = read(paths.ingress);
+const migrations = read(paths.migrations);
+const forumPlan = read(paths.forumPlan);
+
+if (protocolContract?.task !== "FORUM-23B2G2B3D0"
+    || protocolContract?.status !== "source_ready_maintainer_execution_pending"
+    || protocolContract?.evidence_artifact?.generation !== "executable_runtime_only") {
+  failures.push(`${paths.protocolContract}: predecessor protocol drift`);
+}
+
+if (contract) {
+  if (contract.task !== "FORUM-23B2G2B3D1"
+      || contract.status !== "source_ready_maintainer_execution_pending"
+      || contract.predecessor !== "FORUM-23B2G2B3D0") {
+    failures.push(`${paths.contract}: task, status or predecessor drift`);
+  }
+  if (contract.database?.backend !== "postgresql"
+      || contract.database?.environment !== "RUSTOK_SEARCH_TEST_DATABASE_URL"
+      || contract.database?.isolated_schema_per_test !== true
+      || contract.database?.real_search_module_migrations !== true
+      || contract.database?.sleep_or_polling !== false) {
+    failures.push(`${paths.contract}: database evidence boundary drift`);
+  }
+  if (contract.scenarios?.legacy_first_then_typed?.single_root_row !== true
+      || contract.scenarios?.typed_first_then_legacy?.single_root_row !== true
+      || contract.scenarios?.identity_conflict?.stable_error_code
+        !== "forum.search_projection.contract_inbox_identity_conflict"
+      || contract.scenarios?.identity_conflict?.retryable !== false) {
+    failures.push(`${paths.contract}: scenario contract drift`);
+  }
+  if (contract.single_execution_path?.table !== "search_projection_inbox"
+      || contract.single_execution_path?.second_inbox !== false
+      || contract.single_execution_path?.second_projector !== false
+      || contract.single_execution_path?.typed_identity
+        !== "ContractEventEnvelope.causation_id") {
+    failures.push(`${paths.contract}: single execution path drift`);
+  }
+  if (contract.not_claimed?.test_executed !== false
+      || contract.not_claimed?.postgresql_output_captured !== false
+      || contract.not_claimed?.iggy_cursor_restart !== false
+      || contract.not_claimed?.raw_poison_dlq !== false
+      || contract.not_claimed?.semantic_poison_dlq !== false
+      || contract.not_claimed?.dlq_duplicate_suppression !== false
+      || contract.not_claimed?.owner_checkpoint_repair !== false
+      || contract.not_claimed?.link_forum_03_closed !== false) {
+    failures.push(`${paths.contract}: execution claims drift`);
+  }
+  if (contract.remaining_task !== "FORUM-23B2G2B3D") {
+    failures.push(`${paths.contract}: remaining task drift`);
+  }
+}
+
+requireAll(test, [
+  "RUSTOK_SEARCH_TEST_DATABASE_URL",
+  "for migration in SearchModule.migrations()",
+  "legacy_first_then_typed_restart_reuses_one_exact_root_row",
+  "typed_first_then_legacy_delivery_keeps_search_owned_sequence",
+  "conflicting_legacy_identity_is_non_retryable_semantic_poison",
+  "ContractEventEnvelope::new_caused_by",
+  "ForumSearchContractIngress::new",
+  "ON CONFLICT (event_id) DO NOTHING",
+  "search_projection_inbox",
+  "assert_ne!(typed_first.ingest_sequence, owner_revision)",
+  "ForumSearchContractIngressError::InboxIdentityConflict",
+  "forum.search_projection.contract_inbox_identity_conflict",
+  "DROP SCHEMA IF EXISTS",
+], paths.test);
+rejectAll(test, [
+  "tokio::time::sleep",
+  "std::thread::sleep",
+  "iggy",
+  "owner_revision > ingest_sequence",
+  "owner_revision < ingest_sequence",
+], paths.test);
+
+requireAll(ingress, [
+  "ContractEventEnvelope.causation_id",
+  "ON CONFLICT (event_id) DO NOTHING",
+  "verify_durable_root",
+  "InboxIdentityConflict",
+], paths.ingress);
+requireAll(migrations, [
+  "m20260730_000009_create_search_projection_inbox",
+  "m20260731_000010_add_forum_projection_ingest_sequence",
+], paths.migrations);
+
+requireAll(protocolNote, [
+  "# FORUM-23B2G2B3D0 versioned invalidation runtime evidence protocol",
+  "source_ready_maintainer_execution_pending",
+  "legacy-first and typed-first duplicate races",
+  "acknowledgement failure followed by restart",
+  "FORUM-23B2G2B3D",
+], paths.protocolNote);
+
+requireAll(note, [
+  "# FORUM-23B2G2B3D1 versioned Search invalidation PostgreSQL evidence harness",
+  "source_ready_maintainer_execution_pending",
+  "legacy-root delivery before the caused typed invalidation",
+  "typed invalidation before legacy-root delivery",
+  "FORUM-23B2G2B3D",
+  "These commands were not run by the implementation agent.",
+], paths.note);
+requireAll(forumPlan, [
+  "| `FORUM-23` | `in_progress` |",
+  "owner-issued revision reconciliation plus maintainer runtime evidence remain",
+  "LINK-FORUM-03",
+], paths.forumPlan);
+
+if (failures.length > 0) {
+  console.error("Forum Search versioned invalidation PostgreSQL harness verification failed:\n");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum Search versioned invalidation PostgreSQL harness source contract verified.");


### PR DESCRIPTION
## Summary

- recheck the canonical Forum implementation plan and the merged FORUM-23 Search rollout through PRs #2731, #2738, #2741, #2749, #2753, and #2757
- continue the accepted `FORUM-23B2G2B3D0` executable evidence protocol with one bounded `FORUM-23B2G2B3D1` PostgreSQL ingress harness
- add an environment-gated integration target using the real `SearchModule` migration list in an isolated PostgreSQL schema
- cover legacy-first and typed-first delivery collapse onto one existing `search_projection_inbox` row
- reconstruct `ForumSearchContractIngress` before typed redelivery to retain the process-local restart boundary
- assert that the first Search-owned positive `ingest_sequence` is retained and is not replaced by Forum `owner_revision`
- cover a conflicting root UUID with different scope/payload identity as stable non-retryable semantic poison while preserving the durable row
- add a machine-readable source-ready evidence record, focused documentation, and a fail-closed static verifier

## Rechecked baseline

The current `main` already contains:

- Forum owner revision ledger and Search checkpoint reconciliation (#2731)
- sealed versioned invalidation wire (#2738)
- causation-aware publication API (#2741)
- atomic legacy plus typed Forum publisher (#2749)
- persistent typed Search consumer and one-inbox adapter (#2753)
- the accepted D0 runtime-evidence protocol and reconciled handoff documents (#2757)

This PR does not duplicate or replace those production paths. `FORUM-23` remains `in_progress`, and `LINK-FORUM-03` remains open.

## D1 scope

The PostgreSQL target proves the source path for:

1. legacy root first, typed invalidation second, then typed redelivery through a newly constructed ingress instance;
2. typed invalidation first, legacy root second, with one retained Search-owned ingest sequence;
3. a pre-existing root UUID with a different exact target/scope identity, producing `forum.search_projection.contract_inbox_identity_conflict` as non-retryable semantic poison without rewriting the durable row.

The harness uses no sleeps, polling, broker mock, second inbox, second projector, or production migration.

## Remaining D0 evidence

This source-ready slice does not claim:

- successful PostgreSQL execution or captured output
- persistent Iggy cursor restart or acknowledgement-failure recovery
- raw/semantic poison receipt and DLQ publication/redelivery
- deterministic DLQ duplicate suppression
- multi-process advisory-lock serialization
- missing-delivery owner-checkpoint repair
- deletion/ACL/Search-disabled runtime correlation
- `LINK-FORUM-03` closure

Those remain under `FORUM-23B2G2B3D` and the executable-only D0 artifact policy.

## Compatibility

- no production Rust code changed
- no migration, event schema/digest, dependency, runtime flag, consumer group, broker topic, public API, Search query, or `Cargo.lock` change
- the typed consumer remains default-off
- the mandatory legacy root publisher remains active
- the canonical plan remains authoritative and keeps `FORUM-23` in progress

## Validation

Not run per maintainer instruction:

- Rust tests
- source verifiers
- formatting
- Cargo checks or Clippy
- PostgreSQL runtime execution
- Iggy/DLQ evidence
- CI workflows

Suggested maintainer commands:

```bash
RUSTOK_SEARCH_TEST_DATABASE_URL=postgresql://... \
  cargo test -p rustok-search \
  --test forum_contract_ingress_postgres_test \
  -- --nocapture --test-threads=1

cargo check -p rustok-search --all-targets
node scripts/verify/verify-forum-search-versioned-invalidation-runtime-evidence.mjs
node scripts/verify/verify-forum-search-versioned-invalidation-postgres-harness.mjs
cargo xtask module validate forum
cargo xtask module validate search
```

No executable evidence artifact was generated by this PR. Squash merge is recommended after maintainer validation.