### PR TITLE
fix(fulfillment): sanitize lifecycle read diagnostics

### DIFF
--- a/crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-diagnostic-safety-source-review.json
+++ b/crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-diagnostic-safety-source-review.json
@@ -1,0 +1,35 @@
+{
+  "status": "fulfillment_lifecycle_read_diagnostic_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-fulfillment/src/fulfillment_read.rs",
+    "crates/rustok-fulfillment/src/error.rs",
+    "scripts/verify/verify-fulfillment-lifecycle-read-diagnostic-safety.mjs",
+    "crates/rustok-fulfillment/docs/fulfillment-lifecycle-read-diagnostic-safety.md",
+    "crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-diagnostic-safety-source.json"
+  ],
+  "review_findings": {
+    "public_trait_preserved": true,
+    "request_response_dtos_preserved": true,
+    "canonical_factory_preserved": true,
+    "read_admission_order_preserved": true,
+    "owner_delegation_preserved": true,
+    "pagination_filter_semantics_preserved": true,
+    "optional_latest_semantics_preserved": true,
+    "all_public_port_errors_preserved": true,
+    "database_severity_preserved": true,
+    "ordinary_severity_preserved": true,
+    "complete_fulfillment_error_logging_removed": true,
+    "database_error_payload_removed": true,
+    "uuid_parser_payload_removed": true,
+    "raw_context_values_removed": true,
+    "resource_uuid_removed": true,
+    "validation_transition_text_removed": true,
+    "bounded_request_shape_retained": true,
+    "bounded_owner_error_shape_retained": true,
+    "shipping_selection_cleanup_already_closed": true,
+    "shipping_option_read_cleanup_already_closed": true,
+    "broad_ecommerce_cleanup_remains_open": true,
+    "runtime_evidence_claimed": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed."
+}

--- a/crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-diagnostic-safety-source.json
+++ b/crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-diagnostic-safety-source.json
@@ -1,0 +1,58 @@
+{
+  "status": "fulfillment_lifecycle_read_diagnostic_safety_source_unvalidated",
+  "scope": {
+    "owner_source": "crates/rustok-fulfillment/src/fulfillment_read.rs",
+    "trait": "FulfillmentReadPort",
+    "operations": [
+      "read_fulfillment_projection",
+      "list_fulfillment_projections",
+      "find_latest_fulfillment_by_order_projection"
+    ],
+    "focused_verifier": "scripts/verify/verify-fulfillment-lifecycle-read-diagnostic-safety.mjs",
+    "documentation": "crates/rustok-fulfillment/docs/fulfillment-lifecycle-read-diagnostic-safety.md"
+  },
+  "source_contract": {
+    "owner_error_variant_count": 5,
+    "complete_fulfillment_error_logged": false,
+    "database_error_payload_logged": false,
+    "uuid_parser_payload_logged": false,
+    "validation_text_logged": false,
+    "transition_text_logged": false,
+    "resource_uuid_logged": false,
+    "raw_context_values_logged": false,
+    "static_error_variant_logged": true,
+    "aggregate_error_shape_logged": true,
+    "safe_context_shape_logged": true,
+    "request_identity_shape_logged": true,
+    "status_shape_logged": true,
+    "tenant_parse_failure_logged": true,
+    "database_severity_changed": false,
+    "ordinary_severity_changed": false,
+    "read_policy_order_changed": false,
+    "tenant_parse_order_changed": false,
+    "owner_delegation_changed": false,
+    "public_trait_changed": false,
+    "request_response_dtos_changed": false,
+    "pagination_filter_semantics_changed": false,
+    "optional_latest_semantics_changed": false,
+    "public_code_changed": false,
+    "public_message_changed": false,
+    "public_kind_changed": false,
+    "public_retryability_changed": false,
+    "shipping_selection_diagnostic_cleanup_closed": true,
+    "shipping_option_read_diagnostic_cleanup_closed": true,
+    "broad_ecommerce_cleanup_closed": false
+  },
+  "validation": {
+    "tests_run": false,
+    "verifiers_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "mounted_runtime_proven": false,
+    "restart_proven": false,
+    "remote_adapter_proven": false
+  }
+}

--- a/crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json
+++ b/crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-port-source.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-28",
+  "generated_at": "2026-07-31",
   "status": "source_cutover_unvalidated",
-  "source_base_revision": "606408363aceae770ffeb2af63a5c4644ee1e31e",
+  "source_base_revision": "2e7e14a04a885f4ed6b88c1a687729c0bc94f601",
   "scope": "fulfillment lifecycle projection reads for mounted Commerce queries",
   "owner": {
     "crate": "rustok-fulfillment",
@@ -41,13 +41,30 @@
     "read_policy_required": true,
     "tenant_parsed_from_port_context": true,
     "deadline_required_by_policy": true,
-    "diagnostics_retain_actor_channel_locale_correlation": true
+    "diagnostics_retain_actor_channel_locale_correlation": false,
+    "diagnostics_retain_correlation_id": true,
+    "diagnostics_retain_bounded_context_shape": true,
+    "raw_tenant_actor_channel_locale_logged": false,
+    "tenant_parser_payload_logged": false
   },
   "errors": {
     "type": "PortError",
     "owner_message_control_flow": false,
     "database_retryable": true,
-    "all_current_fulfillment_error_variants_mapped": true
+    "all_current_fulfillment_error_variants_mapped": true,
+    "complete_owner_error_logged": false,
+    "database_error_payload_logged": false,
+    "resource_uuid_logged": false,
+    "validation_transition_text_logged": false,
+    "bounded_owner_error_shape_logged": true,
+    "bounded_request_identity_shape_logged": true
+  },
+  "diagnostic_safety": {
+    "status": "source_closed_unvalidated",
+    "evidence": "crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-diagnostic-safety-source.json",
+    "review": "crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-diagnostic-safety-source-review.json",
+    "verifier": "scripts/verify/verify-fulfillment-lifecycle-read-diagnostic-safety.mjs",
+    "runbook": "crates/rustok-fulfillment/docs/fulfillment-lifecycle-read-diagnostic-safety.md"
   },
   "runtime_publication": {
     "runtime": "CommerceFulfillmentLifecycleReadRuntime",

--- a/crates/rustok-fulfillment/docs/fulfillment-lifecycle-read-diagnostic-safety.md
+++ b/crates/rustok-fulfillment/docs/fulfillment-lifecycle-read-diagnostic-safety.md
@@ -1,0 +1,45 @@
+# Fulfillment lifecycle read diagnostic safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice closes the payload-diagnostic gap in the owner lifecycle projection-read boundary implemented by `crates/rustok-fulfillment/src/fulfillment_read.rs`:
+
+- single fulfillment lookup;
+- filtered and paginated fulfillment list;
+- optional latest fulfillment by order;
+- tenant UUID parsing;
+- all five current `FulfillmentError` variants.
+
+The public trait, request/response DTOs, canonical factory, owner service calls, pagination/filter semantics, GraphQL/admin REST composition, optional-not-found behavior, and public `PortError` envelopes remain unchanged.
+
+## Retained diagnostic shape
+
+Events retain correlation id, static owner operation, stable code, retryability, severity, and boundary. Other context is limited to actor kind, character lengths, counts, presence flags, and deadline milliseconds.
+
+Fulfillment, order, and customer identities are represented only by presence and non-nil facts. Status is represented only by presence and character length.
+
+Owner failures retain only a closed static variant and aggregate text, UUID, and opaque-payload shape. Parser errors, raw context, resource UUIDs, validation/transition text, database errors, and complete `FulfillmentError` debug/display payloads are not recorded.
+
+## Preserved behavior
+
+- read policy remains before tenant parsing and owner delegation;
+- lookup still delegates to `get_fulfillment`;
+- list still delegates to `list_fulfillments` with unchanged page, per-page, status, order, and customer filters;
+- latest-by-order still delegates to `find_by_order` and keeps its optional result;
+- database failures remain error severity;
+- context, validation, not-found, and transition failures remain warning severity;
+- public code, message, kind, and retryability are unchanged.
+
+## Evidence
+
+- `crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-diagnostic-safety-source.json`
+- `crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-diagnostic-safety-source-review.json`
+- `scripts/verify/verify-fulfillment-lifecycle-read-diagnostic-safety.mjs`
+
+## Remaining gaps
+
+The three currently identified Fulfillment owner diagnostic slices—native shipping selection, shipping-option projection reads, and lifecycle projection reads—are source-closed but unvalidated. Compile, verifier execution, mounted transport parity, restart, remote-adapter evidence, checkout identity persistence, and the broader ecommerce cleanup remain open.
+
+No test, verifier, formatter, Cargo, workflow, or CI command was executed for this source slice.

--- a/crates/rustok-fulfillment/src/fulfillment_read.rs
+++ b/crates/rustok-fulfillment/src/fulfillment_read.rs
@@ -7,6 +7,9 @@ use uuid::Uuid;
 
 use crate::{FulfillmentError, FulfillmentResponse, FulfillmentService, ListFulfillmentsInput};
 
+const FULFILLMENT_OWNER: &str = "rustok_fulfillment";
+const FULFILLMENT_LIFECYCLE_READ_BOUNDARY: &str = "fulfillment_lifecycle_read_port";
+
 /// Transport-neutral owner boundary for fulfillment lifecycle projection reads.
 #[async_trait]
 pub trait FulfillmentReadPort: Send + Sync {
@@ -74,6 +77,44 @@ pub fn in_process_fulfillment_read_port(
     db: sea_orm::DatabaseConnection,
 ) -> Arc<dyn FulfillmentReadPort> {
     Arc::new(InProcessFulfillmentReadPort::new(db))
+}
+
+struct FulfillmentLifecycleReadContextFacts {
+    tenant_id_length: usize,
+    actor_kind: &'static str,
+    actor_id_length: usize,
+    claim_count: usize,
+    role_count: usize,
+    channel_present: bool,
+    channel_length: Option<usize>,
+    locale_length: usize,
+    causation_id_present: bool,
+    causation_id_length: Option<usize>,
+    traceparent_present: bool,
+    traceparent_length: Option<usize>,
+    idempotency_key_present: bool,
+    idempotency_key_length: Option<usize>,
+    deadline_ms: Option<u64>,
+}
+
+struct FulfillmentLifecycleOwnerErrorFacts {
+    error_variant: &'static str,
+    text_field_count: usize,
+    text_total_length: usize,
+    uuid_field_count: usize,
+    uuid_non_nil_count: usize,
+    opaque_payload_present: bool,
+}
+
+struct FulfillmentLifecycleReadRequestFacts {
+    fulfillment_id_present: bool,
+    fulfillment_id_non_nil: bool,
+    order_id_present: bool,
+    order_id_non_nil: bool,
+    customer_id_present: bool,
+    customer_id_non_nil: bool,
+    status_present: bool,
+    status_length: Option<usize>,
 }
 
 #[async_trait]
@@ -165,22 +206,144 @@ impl FulfillmentReadPort for InProcessFulfillmentReadPort {
     }
 }
 
+fn fulfillment_lifecycle_read_context_facts(
+    context: &PortContext,
+) -> FulfillmentLifecycleReadContextFacts {
+    let actor_kind = match &context.actor.kind {
+        rustok_api::PortActorKind::User => "user",
+        rustok_api::PortActorKind::Service => "service",
+        rustok_api::PortActorKind::System => "system",
+    };
+    FulfillmentLifecycleReadContextFacts {
+        tenant_id_length: context.tenant_id.chars().count(),
+        actor_kind,
+        actor_id_length: context.actor.id.chars().count(),
+        claim_count: context.claims.len(),
+        role_count: context.roles.len(),
+        channel_present: context.channel.is_some(),
+        channel_length: context.channel.as_ref().map(|value| value.chars().count()),
+        locale_length: context.locale.chars().count(),
+        causation_id_present: context.causation_id.is_some(),
+        causation_id_length: context
+            .causation_id
+            .as_ref()
+            .map(|value| value.chars().count()),
+        traceparent_present: context.traceparent.is_some(),
+        traceparent_length: context
+            .traceparent
+            .as_ref()
+            .map(|value| value.chars().count()),
+        idempotency_key_present: context.idempotency_key.is_some(),
+        idempotency_key_length: context
+            .idempotency_key
+            .as_ref()
+            .map(|value| value.chars().count()),
+        deadline_ms: context.deadline_ms,
+    }
+}
+
+fn fulfillment_lifecycle_owner_error_facts(
+    error: &FulfillmentError,
+) -> FulfillmentLifecycleOwnerErrorFacts {
+    let (
+        error_variant,
+        text_field_count,
+        text_total_length,
+        uuid_field_count,
+        uuid_non_nil_count,
+        opaque_payload_present,
+    ) = match error {
+        FulfillmentError::Validation(value) => (
+            "validation",
+            1,
+            value.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        FulfillmentError::ShippingOptionNotFound(id) => (
+            "shipping_option_not_found",
+            0,
+            0,
+            1,
+            if id.is_nil() { 0 } else { 1 },
+            false,
+        ),
+        FulfillmentError::FulfillmentNotFound(id) => (
+            "fulfillment_not_found",
+            0,
+            0,
+            1,
+            if id.is_nil() { 0 } else { 1 },
+            false,
+        ),
+        FulfillmentError::InvalidTransition { from, to } => (
+            "invalid_transition",
+            2,
+            from.chars().count() + to.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        FulfillmentError::Database(_) => ("database", 0, 0, 0, 0, true),
+    };
+    FulfillmentLifecycleOwnerErrorFacts {
+        error_variant,
+        text_field_count,
+        text_total_length,
+        uuid_field_count,
+        uuid_non_nil_count,
+        opaque_payload_present,
+    }
+}
+
+fn fulfillment_lifecycle_read_request_facts(
+    fulfillment_id: Option<Uuid>,
+    order_id: Option<Uuid>,
+    status_length: Option<usize>,
+    customer_id: Option<Uuid>,
+) -> FulfillmentLifecycleReadRequestFacts {
+    FulfillmentLifecycleReadRequestFacts {
+        fulfillment_id_present: fulfillment_id.is_some(),
+        fulfillment_id_non_nil: fulfillment_id
+            .map(|value| !value.is_nil())
+            .unwrap_or(false),
+        order_id_present: order_id.is_some(),
+        order_id_non_nil: order_id.map(|value| !value.is_nil()).unwrap_or(false),
+        customer_id_present: customer_id.is_some(),
+        customer_id_non_nil: customer_id
+            .map(|value| !value.is_nil())
+            .unwrap_or(false),
+        status_present: status_length.is_some(),
+        status_length,
+    }
+}
+
 fn parse_tenant_id(context: &PortContext, operation: &'static str) -> Result<Uuid, PortError> {
-    Uuid::parse_str(&context.tenant_id).map_err(|error| {
+    Uuid::parse_str(&context.tenant_id).map_err(|_| {
+        let context_facts = fulfillment_lifecycle_read_context_facts(context);
         tracing::warn!(
-            error = ?error,
-            owner = "rustok_fulfillment",
+            owner = FULFILLMENT_OWNER,
             operation,
             correlation_id = %context.correlation_id,
-            tenant_id = %context.tenant_id,
-            actor = ?context.actor,
-            channel_length = context.channel.as_deref().map(str::len),
-            locale_length = context.locale.len(),
-            causation_id_present = context.causation_id.is_some(),
-            traceparent_present = context.traceparent.is_some(),
-            deadline_ms = ?context.deadline_ms,
+            tenant_id_parse_failed = true,
+            tenant_id_length = context_facts.tenant_id_length,
+            actor_kind = context_facts.actor_kind,
+            actor_id_length = context_facts.actor_id_length,
+            claim_count = context_facts.claim_count,
+            role_count = context_facts.role_count,
+            channel_present = context_facts.channel_present,
+            channel_length = ?context_facts.channel_length,
+            locale_length = context_facts.locale_length,
+            causation_id_present = context_facts.causation_id_present,
+            causation_id_length = ?context_facts.causation_id_length,
+            traceparent_present = context_facts.traceparent_present,
+            traceparent_length = ?context_facts.traceparent_length,
+            idempotency_key_present = context_facts.idempotency_key_present,
+            idempotency_key_length = ?context_facts.idempotency_key_length,
+            deadline_ms = ?context_facts.deadline_ms,
             code = "fulfillment.context_invalid",
-            boundary = "fulfillment_lifecycle_read_port",
+            boundary = FULFILLMENT_LIFECYCLE_READ_BOUNDARY,
             "fulfillment lifecycle read context is invalid"
         );
         PortError::validation(
@@ -200,88 +363,129 @@ fn map_owner_error(
     customer_id: Option<Uuid>,
     error: FulfillmentError,
 ) -> PortError {
-    let (kind, code, message, retryable, error_kind) = match &error {
+    let error_facts = fulfillment_lifecycle_owner_error_facts(&error);
+    let request_facts = fulfillment_lifecycle_read_request_facts(
+        fulfillment_id,
+        order_id,
+        status_length,
+        customer_id,
+    );
+    let (kind, code, message, retryable, technical_failure) = match &error {
         FulfillmentError::Validation(_) => (
             PortErrorKind::Validation,
             "fulfillment.validation",
             "fulfillment request is invalid",
             false,
-            "validation",
+            false,
         ),
         FulfillmentError::ShippingOptionNotFound(_) => (
             PortErrorKind::NotFound,
             "fulfillment.shipping_option_not_found",
             "shipping option was not found",
             false,
-            "shipping_option_not_found",
+            false,
         ),
         FulfillmentError::FulfillmentNotFound(_) => (
             PortErrorKind::NotFound,
             "fulfillment.fulfillment_not_found",
             "fulfillment was not found",
             false,
-            "fulfillment_not_found",
+            false,
         ),
         FulfillmentError::InvalidTransition { .. } => (
             PortErrorKind::Conflict,
             "fulfillment.invalid_transition",
             "fulfillment lifecycle transition conflicts with the current state",
             false,
-            "invalid_transition",
+            false,
         ),
         FulfillmentError::Database(_) => (
             PortErrorKind::Unavailable,
             "fulfillment.database_unavailable",
             "fulfillment storage is temporarily unavailable",
             true,
-            "database",
+            true,
         ),
     };
+    let context_facts = fulfillment_lifecycle_read_context_facts(context);
 
-    if matches!(&error, FulfillmentError::Database(_)) {
+    if technical_failure {
         tracing::error!(
-            error = ?error,
-            owner = "rustok_fulfillment",
+            owner = FULFILLMENT_OWNER,
             operation,
             correlation_id = %context.correlation_id,
-            tenant_id = %context.tenant_id,
-            actor = ?context.actor,
-            channel_length = context.channel.as_deref().map(str::len),
-            locale_length = context.locale.len(),
-            causation_id_present = context.causation_id.is_some(),
-            traceparent_present = context.traceparent.is_some(),
-            deadline_ms = ?context.deadline_ms,
-            fulfillment_id = ?fulfillment_id,
-            order_id = ?order_id,
-            customer_id = ?customer_id,
-            status_length = ?status_length,
-            error_kind,
+            tenant_id_length = context_facts.tenant_id_length,
+            actor_kind = context_facts.actor_kind,
+            actor_id_length = context_facts.actor_id_length,
+            claim_count = context_facts.claim_count,
+            role_count = context_facts.role_count,
+            channel_present = context_facts.channel_present,
+            channel_length = ?context_facts.channel_length,
+            locale_length = context_facts.locale_length,
+            causation_id_present = context_facts.causation_id_present,
+            causation_id_length = ?context_facts.causation_id_length,
+            traceparent_present = context_facts.traceparent_present,
+            traceparent_length = ?context_facts.traceparent_length,
+            idempotency_key_present = context_facts.idempotency_key_present,
+            idempotency_key_length = ?context_facts.idempotency_key_length,
+            deadline_ms = ?context_facts.deadline_ms,
+            fulfillment_id_present = request_facts.fulfillment_id_present,
+            fulfillment_id_non_nil = request_facts.fulfillment_id_non_nil,
+            order_id_present = request_facts.order_id_present,
+            order_id_non_nil = request_facts.order_id_non_nil,
+            customer_id_present = request_facts.customer_id_present,
+            customer_id_non_nil = request_facts.customer_id_non_nil,
+            status_present = request_facts.status_present,
+            status_length = ?request_facts.status_length,
+            error_variant = error_facts.error_variant,
+            text_field_count = error_facts.text_field_count,
+            text_total_length = error_facts.text_total_length,
+            uuid_field_count = error_facts.uuid_field_count,
+            uuid_non_nil_count = error_facts.uuid_non_nil_count,
+            opaque_payload_present = error_facts.opaque_payload_present,
             code,
             retryable,
-            boundary = "fulfillment_lifecycle_read_port",
-            "fulfillment lifecycle read failed"
+            boundary = FULFILLMENT_LIFECYCLE_READ_BOUNDARY,
+            "fulfillment lifecycle read failed with bounded diagnostics"
         );
     } else {
         tracing::warn!(
-            owner = "rustok_fulfillment",
+            owner = FULFILLMENT_OWNER,
             operation,
             correlation_id = %context.correlation_id,
-            tenant_id = %context.tenant_id,
-            actor = ?context.actor,
-            channel_length = context.channel.as_deref().map(str::len),
-            locale_length = context.locale.len(),
-            causation_id_present = context.causation_id.is_some(),
-            traceparent_present = context.traceparent.is_some(),
-            deadline_ms = ?context.deadline_ms,
-            fulfillment_id = ?fulfillment_id,
-            order_id = ?order_id,
-            customer_id = ?customer_id,
-            status_length = ?status_length,
-            error_kind,
+            tenant_id_length = context_facts.tenant_id_length,
+            actor_kind = context_facts.actor_kind,
+            actor_id_length = context_facts.actor_id_length,
+            claim_count = context_facts.claim_count,
+            role_count = context_facts.role_count,
+            channel_present = context_facts.channel_present,
+            channel_length = ?context_facts.channel_length,
+            locale_length = context_facts.locale_length,
+            causation_id_present = context_facts.causation_id_present,
+            causation_id_length = ?context_facts.causation_id_length,
+            traceparent_present = context_facts.traceparent_present,
+            traceparent_length = ?context_facts.traceparent_length,
+            idempotency_key_present = context_facts.idempotency_key_present,
+            idempotency_key_length = ?context_facts.idempotency_key_length,
+            deadline_ms = ?context_facts.deadline_ms,
+            fulfillment_id_present = request_facts.fulfillment_id_present,
+            fulfillment_id_non_nil = request_facts.fulfillment_id_non_nil,
+            order_id_present = request_facts.order_id_present,
+            order_id_non_nil = request_facts.order_id_non_nil,
+            customer_id_present = request_facts.customer_id_present,
+            customer_id_non_nil = request_facts.customer_id_non_nil,
+            status_present = request_facts.status_present,
+            status_length = ?request_facts.status_length,
+            error_variant = error_facts.error_variant,
+            text_field_count = error_facts.text_field_count,
+            text_total_length = error_facts.text_total_length,
+            uuid_field_count = error_facts.uuid_field_count,
+            uuid_non_nil_count = error_facts.uuid_non_nil_count,
+            opaque_payload_present = error_facts.opaque_payload_present,
             code,
             retryable,
-            boundary = "fulfillment_lifecycle_read_port",
-            "fulfillment lifecycle read was rejected"
+            boundary = FULFILLMENT_LIFECYCLE_READ_BOUNDARY,
+            "fulfillment lifecycle read was rejected with bounded diagnostics"
         );
     }
 

--- a/scripts/verify/verify-fulfillment-lifecycle-read-diagnostic-safety.mjs
+++ b/scripts/verify/verify-fulfillment-lifecycle-read-diagnostic-safety.mjs
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const failures = [];
+
+const paths = {
+  owner: 'crates/rustok-fulfillment/src/fulfillment_read.rs',
+  error: 'crates/rustok-fulfillment/src/error.rs',
+  document:
+    'crates/rustok-fulfillment/docs/fulfillment-lifecycle-read-diagnostic-safety.md',
+  evidence:
+    'crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-diagnostic-safety-source.json',
+  review:
+    'crates/rustok-fulfillment/contracts/evidence/fulfillment-lifecycle-read-diagnostic-safety-source-review.json',
+};
+
+const owner = read(paths.owner);
+const errorSource = read(paths.error);
+const document = read(paths.document);
+const evidence = JSON.parse(read(paths.evidence));
+const review = JSON.parse(read(paths.review));
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+function functionBody(source, functionName) {
+  const signature = new RegExp(
+    `(?:pub(?:\\([^)]*\\))?\\s+)?(?:async\\s+)?fn\\s+${functionName}(?:<[^>]*>)?\\s*\\(`,
+  );
+  const match = signature.exec(source);
+  if (!match) {
+    failures.push(`missing function ${functionName}`);
+    return '';
+  }
+  const openBrace = source.indexOf('{', match.index);
+  let depth = 0;
+  for (let index = openBrace; index >= 0 && index < source.length; index += 1) {
+    if (source[index] === '{') depth += 1;
+    if (source[index] === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(openBrace, index + 1);
+    }
+  }
+  failures.push(`unterminated function ${functionName}`);
+  return '';
+}
+
+function functionBodyAfter(source, anchor, functionName) {
+  const anchorIndex = source.indexOf(anchor);
+  if (anchorIndex < 0) {
+    failures.push(`missing anchor ${anchor}`);
+    return '';
+  }
+  return functionBody(source.slice(anchorIndex), functionName);
+}
+
+for (const marker of [
+  'pub trait FulfillmentReadPort: Send + Sync',
+  'ReadFulfillmentProjectionRequest',
+  'ListFulfillmentProjectionsRequest',
+  'FulfillmentProjectionPage',
+  'FindLatestFulfillmentByOrderProjectionRequest',
+  'pub fn in_process_fulfillment_read_port(',
+  'impl FulfillmentReadPort for InProcessFulfillmentReadPort',
+]) requireText(owner, marker, `${paths.owner}: public surface`);
+
+const implementationAnchor =
+  'impl FulfillmentReadPort for InProcessFulfillmentReadPort';
+const readBody = functionBodyAfter(
+  owner,
+  implementationAnchor,
+  'read_fulfillment_projection',
+);
+const listBody = functionBodyAfter(
+  owner,
+  implementationAnchor,
+  'list_fulfillment_projections',
+);
+const latestBody = functionBodyAfter(
+  owner,
+  implementationAnchor,
+  'find_latest_fulfillment_by_order_projection',
+);
+
+for (const marker of [
+  'context.require_policy(PortCallPolicy::read())?',
+  'parse_tenant_id(&context, "read_fulfillment_projection")?',
+  '.get_fulfillment(tenant_id, request.fulfillment_id)',
+  'Some(request.fulfillment_id)',
+]) requireText(readBody, marker, `${paths.owner}: lookup flow`);
+for (const marker of [
+  'context.require_policy(PortCallPolicy::read())?',
+  'parse_tenant_id(&context, "list_fulfillment_projections")?',
+  'let status_length = request.status.as_deref().map(str::len);',
+  'ListFulfillmentsInput {',
+  'page: request.page',
+  'per_page: request.per_page',
+  'status: request.status',
+  'order_id,',
+  'customer_id,',
+  'Ok(FulfillmentProjectionPage { items, total })',
+]) requireText(listBody, marker, `${paths.owner}: list flow`);
+for (const marker of [
+  'context.require_policy(PortCallPolicy::read())?',
+  'parse_tenant_id(&context, "find_latest_fulfillment_by_order_projection")?',
+  '.find_by_order(tenant_id, request.order_id)',
+  'Some(request.order_id)',
+]) requireText(latestBody, marker, `${paths.owner}: latest flow`);
+
+for (const [body, delegation, label] of [
+  [readBody, '.get_fulfillment(', 'lookup'],
+  [listBody, '.list_fulfillments(', 'list'],
+  [latestBody, '.find_by_order(', 'latest'],
+]) {
+  const policy = body.indexOf('context.require_policy(PortCallPolicy::read())?');
+  const parse = body.indexOf('parse_tenant_id(');
+  const ownerCall = body.indexOf(delegation);
+  if (!(policy >= 0 && policy < parse && parse < ownerCall)) {
+    failures.push(`${paths.owner}: ${label} admission/delegation order changed`);
+  }
+}
+
+for (const marker of [
+  'struct FulfillmentLifecycleReadContextFacts',
+  'struct FulfillmentLifecycleOwnerErrorFacts',
+  'struct FulfillmentLifecycleReadRequestFacts',
+  'fn fulfillment_lifecycle_read_context_facts(',
+  'fn fulfillment_lifecycle_owner_error_facts(',
+  'fn fulfillment_lifecycle_read_request_facts(',
+  'FulfillmentError::Validation(value) =>',
+  'FulfillmentError::ShippingOptionNotFound(id) =>',
+  'FulfillmentError::FulfillmentNotFound(id) =>',
+  'FulfillmentError::InvalidTransition { from, to } =>',
+  'FulfillmentError::Database(_) => ("database", 0, 0, 0, 0, true)',
+]) requireText(owner, marker, `${paths.owner}: bounded facts`);
+
+for (const marker of [
+  'Validation(String)',
+  'ShippingOptionNotFound(Uuid)',
+  'FulfillmentNotFound(Uuid)',
+  'InvalidTransition { from: String, to: String }',
+  'Database(#[from] DbErr)',
+]) requireText(errorSource, marker, `${paths.error}: retained error shape`);
+
+const parser = functionBody(owner, 'parse_tenant_id');
+for (const marker of [
+  'map_err(|_|',
+  'tenant_id_parse_failed = true',
+  'tenant_id_length = context_facts.tenant_id_length',
+  'actor_kind = context_facts.actor_kind',
+  'claim_count = context_facts.claim_count',
+  'role_count = context_facts.role_count',
+  'boundary = FULFILLMENT_LIFECYCLE_READ_BOUNDARY',
+  '"fulfillment.context_invalid"',
+]) requireText(parser, marker, `${paths.owner}: bounded tenant parser`);
+for (const forbidden of [
+  '|error|',
+  'error = ?error',
+  'tenant_id = %context.tenant_id',
+  'actor = ?context.actor',
+]) forbidText(parser, forbidden, `${paths.owner}: parser payload`);
+
+const mapper = functionBody(owner, 'map_owner_error');
+for (const marker of [
+  'let error_facts = fulfillment_lifecycle_owner_error_facts(&error);',
+  'let request_facts = fulfillment_lifecycle_read_request_facts(',
+  'let (kind, code, message, retryable, technical_failure) = match &error',
+  'tracing::error!(',
+  'tracing::warn!(',
+  'fulfillment_id_present = request_facts.fulfillment_id_present',
+  'fulfillment_id_non_nil = request_facts.fulfillment_id_non_nil',
+  'order_id_present = request_facts.order_id_present',
+  'order_id_non_nil = request_facts.order_id_non_nil',
+  'customer_id_present = request_facts.customer_id_present',
+  'customer_id_non_nil = request_facts.customer_id_non_nil',
+  'status_present = request_facts.status_present',
+  'status_length = ?request_facts.status_length',
+  'error_variant = error_facts.error_variant',
+  'text_total_length = error_facts.text_total_length',
+  'uuid_non_nil_count = error_facts.uuid_non_nil_count',
+  'opaque_payload_present = error_facts.opaque_payload_present',
+  'PortError::new(kind, code, message, retryable)',
+]) requireText(mapper, marker, `${paths.owner}: bounded owner mapper`);
+for (const forbidden of [
+  'error = ?error',
+  'error = %message',
+  'tenant_id = %context.tenant_id',
+  'actor = ?context.actor',
+  'fulfillment_id = ?fulfillment_id',
+  'order_id = ?order_id',
+  'customer_id = ?customer_id',
+  'from = %from',
+  'to = %to',
+]) forbidText(mapper, forbidden, `${paths.owner}: owner payload`);
+
+for (const marker of [
+  '"fulfillment.validation"',
+  '"fulfillment.shipping_option_not_found"',
+  '"fulfillment.fulfillment_not_found"',
+  '"fulfillment.invalid_transition"',
+  '"fulfillment.database_unavailable"',
+  '"fulfillment request is invalid"',
+  '"shipping option was not found"',
+  '"fulfillment was not found"',
+  '"fulfillment lifecycle transition conflicts with the current state"',
+  '"fulfillment storage is temporarily unavailable"',
+]) requireText(mapper, marker, `${paths.owner}: stable public envelope`);
+
+for (const [key, expected] of Object.entries({
+  complete_fulfillment_error_logged: false,
+  database_error_payload_logged: false,
+  uuid_parser_payload_logged: false,
+  validation_text_logged: false,
+  transition_text_logged: false,
+  resource_uuid_logged: false,
+  raw_context_values_logged: false,
+  static_error_variant_logged: true,
+  aggregate_error_shape_logged: true,
+  safe_context_shape_logged: true,
+  request_identity_shape_logged: true,
+  status_shape_logged: true,
+  tenant_parse_failure_logged: true,
+  database_severity_changed: false,
+  ordinary_severity_changed: false,
+  read_policy_order_changed: false,
+  tenant_parse_order_changed: false,
+  owner_delegation_changed: false,
+  pagination_filter_semantics_changed: false,
+  optional_latest_semantics_changed: false,
+  public_code_changed: false,
+  public_message_changed: false,
+  public_kind_changed: false,
+  public_retryability_changed: false,
+  broad_ecommerce_cleanup_closed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+if (evidence.validation?.compile_proven !== false) {
+  failures.push(`${paths.evidence}: compile_proven must remain false`);
+}
+for (const [key, expected] of Object.entries({
+  public_trait_preserved: true,
+  request_response_dtos_preserved: true,
+  canonical_factory_preserved: true,
+  read_admission_order_preserved: true,
+  owner_delegation_preserved: true,
+  pagination_filter_semantics_preserved: true,
+  optional_latest_semantics_preserved: true,
+  all_public_port_errors_preserved: true,
+  complete_fulfillment_error_logging_removed: true,
+  database_error_payload_removed: true,
+  uuid_parser_payload_removed: true,
+  raw_context_values_removed: true,
+  resource_uuid_removed: true,
+  runtime_evidence_claimed: false,
+})) {
+  if (review.review_findings?.[key] !== expected) {
+    failures.push(`${paths.review}: review_findings.${key} must be ${expected}`);
+  }
+}
+
+for (const marker of [
+  'Status: **source-ready / unvalidated**',
+  'single fulfillment lookup',
+  'filtered and paginated fulfillment list',
+  'optional latest fulfillment by order',
+  'three currently identified Fulfillment owner diagnostic slices',
+  'broader ecommerce cleanup remain open',
+]) requireText(document, marker, `${paths.document}: truthful status`);
+
+if (failures.length > 0) {
+  console.error('Fulfillment lifecycle read diagnostic-safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ fulfillment lifecycle reads preserve admission, pagination/filtering, owner delegation, optional latest semantics, and public PortError behavior while retaining only bounded context, request, and owner-error facts',
+);


### PR DESCRIPTION
## Summary

- continue the ecommerce diagnostic cleanup at the Fulfillment lifecycle projection-read owner boundary
- replace tenant UUID parser payloads with a static parse-failure fact and bounded `PortContext` shape
- replace complete `FulfillmentError` diagnostics with a closed static variant plus aggregate text, UUID, and opaque-payload shape
- replace raw fulfillment/order/customer UUID logging with presence/non-nil facts and retain status presence/length only
- preserve lookup, filtered/paginated list, optional latest-by-order semantics, read admission, owner delegation, severity, and exact public `PortError` envelopes
- add focused source evidence/review, a boundary document, a fail-closed diagnostic verifier, and synchronize the existing lifecycle source evidence

## Scope

Exactly six files change:

- `crates/rustok-fulfillment/src/fulfillment_read.rs`;
- one new focused verifier;
- two new diagnostic evidence files;
- the existing lifecycle read source evidence;
- one focused document.

Commerce GraphQL/REST consumers, runtime composition, public DTOs/traits, migrations, dependencies, workflows, and CI configuration are unchanged.

This closes the third currently identified Fulfillment owner diagnostic slice after native shipping selection and shipping-option projection reads. Broader ecommerce cleanup, compile, mounted transport parity, deterministic failure-harness execution, restart, and remote-adapter evidence remain open.

## Preserved behavior

- all three operations still require read policy before tenant parsing and owner delegation;
- lookup still delegates to `get_fulfillment`;
- list still delegates to `list_fulfillments` with unchanged page, per-page, status, order, and customer filters;
- latest-by-order still delegates to `find_by_order` and preserves its optional result;
- database failures remain error severity and other mapped failures remain warning severity;
- public `PortError` code, message, kind, and retryability are unchanged.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-fulfillment-lifecycle-read-diagnostic-safety.mjs
node scripts/verify/verify-fulfillment-lifecycle-read-port.mjs
cargo check -p rustok-fulfillment --lib
cargo check -p rustok-commerce --lib
```

Branch: `agent/fulfillment-lifecycle-read-diagnostic-safety-20260731`
Base at creation: `2e7e14a04a885f4ed6b88c1a687729c0bc94f601`
