### PR TITLE
feat(blog): add typed Comments remote adapter core

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-comments-remote-adapter-core.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-remote-adapter-core.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": 1,
+  "module": "blog",
+  "provider": "comments",
+  "surface": "comments_remote_adapter_core",
+  "status": "source_verified_no_compile",
+  "compile_policy": "not_run_by_request",
+  "runtime_status": "not_run",
+  "generated_from": "crates/rustok-blog/docs/implementation-plan-slice-67.md",
+  "source_contract": {
+    "provider_adapter": "crates/rustok-comments/src/remote.rs",
+    "provider_export": "crates/rustok-comments/src/lib.rs",
+    "port": "rustok_comments::CommentsThreadPort",
+    "transport": "rustok_comments::CommentsThreadTransport",
+    "context": "rustok_api::PortContext",
+    "error": "rustok_api::PortError"
+  },
+  "operations": [
+    {
+      "name": "create_comment",
+      "policy": "write",
+      "request": "CommentsThreadRequest::CreateComment",
+      "response": "CommentsThreadResponse::Comment"
+    },
+    {
+      "name": "get_comment",
+      "policy": "read",
+      "request": "CommentsThreadRequest::GetComment",
+      "response": "CommentsThreadResponse::Comment"
+    },
+    {
+      "name": "list_comments_for_target",
+      "policy": "read",
+      "request": "CommentsThreadRequest::ListCommentsForTarget",
+      "response": "CommentsThreadResponse::CommentsPage"
+    },
+    {
+      "name": "list_public_comments_for_target",
+      "policy": "read",
+      "request": "CommentsThreadRequest::ListPublicCommentsForTarget",
+      "response": "CommentsThreadResponse::CommentsPage"
+    },
+    {
+      "name": "update_comment",
+      "policy": "write",
+      "request": "CommentsThreadRequest::UpdateComment",
+      "response": "CommentsThreadResponse::Comment"
+    },
+    {
+      "name": "set_comment_status",
+      "policy": "write",
+      "request": "CommentsThreadRequest::SetCommentStatus",
+      "response": "CommentsThreadResponse::Comment"
+    },
+    {
+      "name": "delete_comment",
+      "policy": "write",
+      "request": "CommentsThreadRequest::DeleteComment",
+      "response": "CommentsThreadResponse::Deleted"
+    }
+  ],
+  "context_fields_preserved": [
+    "tenant_id",
+    "actor",
+    "claims",
+    "roles",
+    "channel",
+    "locale",
+    "correlation_id",
+    "causation_id",
+    "traceparent",
+    "idempotency_key",
+    "deadline_ms"
+  ],
+  "fail_closed": {
+    "response_mismatch_code": "comments.remote_response_mismatch",
+    "response_mismatch_kind": "InvariantViolation",
+    "policy_checked_before_dispatch": true
+  },
+  "pending": [
+    "concrete_network_transport",
+    "endpoint_discovery",
+    "authentication",
+    "retry_backoff",
+    "transport_cancellation",
+    "host_publication",
+    "in_process_remote_runtime_parity",
+    "runtime_execution"
+  ],
+  "explicit_non_claims": [
+    "no_compile_result",
+    "no_rust_test_result",
+    "no_javascript_verifier_result",
+    "no_database_result",
+    "no_browser_result",
+    "no_workflow_result",
+    "no_ci_result",
+    "no_production_result"
+  ]
+}

--- a/crates/rustok-blog/docs/implementation-plan-slice-67.md
+++ b/crates/rustok-blog/docs/implementation-plan-slice-67.md
@@ -1,0 +1,114 @@
+# rustok-blog implementation plan — slice 67 continuation
+
+This document is the current continuation of
+`crates/rustok-blog/docs/implementation-plan.md`. The original plan remains the
+immutable source-history for slices 1–66 and for the existing fail-closed source
+guards. This continuation records the re-audit and the next implementation slice
+without deleting or rewriting those retained markers.
+
+## 2026-07-31 source re-audit
+
+The recorded Blog work through slice 66 was rechecked against `main` at
+`4fa4b790998d6593d24411525b3dbfaf4901bc2c`, together with the current Comments
+port, Blog consumer service, HTTP/GraphQL/native composition seams, storefront
+availability model, retained evidence, focused verifiers, and explicit
+non-claims.
+
+The source artifacts remain present. This audit does **not** promote any compile,
+Rust or JavaScript test, PostgreSQL, Redis, browser, workflow, CI, production, or
+runtime result. Execution remains maintainer-owned.
+
+## Corrected current status
+
+The previous plan sentence that grouped all degraded UI work as planned is stale.
+Typed storefront `AVAILABLE`, `UNAVAILABLE`, and `TIMEOUT` rendering is already
+source-locked across GraphQL, native SSR, the shared DTO, and Leptos UI. Only
+Comments `ExternalService` and `Timeout` failures degrade to empty typed comment
+payloads; other Blog failures remain fail-closed.
+
+The remaining transport gap is narrower:
+
+- Blog already accepts a host-owned `Arc<dyn CommentsThreadPort>` through its
+  service and HTTP, GraphQL, storefront-native, and admin-native composition
+  seams.
+- Slice 67 adds the provider-owned typed remote adapter core.
+- A concrete HTTP, gRPC, message-bus, or sidecar client is still pending.
+- Endpoint discovery, authentication, retry/backoff, cancellation, and host
+  publication are still pending.
+- Cached thread snapshots and comment-form fallback are still pending.
+- Runtime parity and all execution evidence are still pending.
+
+## Slice 67 — typed Comments remote adapter core
+
+### Implemented source scope
+
+- `crates/rustok-comments/src/remote.rs` owns typed request and response envelopes
+  for all seven `CommentsThreadPort` operations.
+- `CommentsThreadTransport` is a transport-neutral async dispatch contract.
+- `RemoteCommentsThreadPort` implements the existing owner port without changing
+  the Blog consumer API.
+- Read operations require `PortCallPolicy::read()` before dispatch.
+- Write operations require `PortCallPolicy::write()` before dispatch, preserving
+  the existing deadline and idempotency-key requirements.
+- The complete `PortContext` is carried inside every remote request, including
+  tenant, actor, claims, roles, channel, locale, correlation, causation, trace,
+  idempotency, and deadline data.
+- Response variants are operation-checked. An incompatible response fails closed
+  as `comments.remote_response_mismatch` with `InvariantViolation` semantics.
+- `rustok-comments` exports the remote adapter through its server feature.
+- Source evidence is retained at
+  `crates/rustok-blog/contracts/evidence/blog-comments-remote-adapter-core.json`.
+- The standalone fail-closed verifier is
+  `scripts/verify/verify-blog-comments-remote-adapter-core.mjs`.
+
+### Explicit non-claims
+
+This slice does not implement or claim:
+
+- a concrete network protocol or endpoint;
+- service discovery or configuration loading;
+- authentication or credential propagation beyond the typed `PortContext`;
+- retry, backoff, circuit breaking, transport cancellation, or deadline timers;
+- host registration or production selection of the remote adapter;
+- parity between in-process and remote execution;
+- successful compile, test, verifier, database, browser, workflow, CI, or
+  production execution.
+
+Status: `source_verified_no_compile`.
+Compile policy: `not_run_by_request`.
+Runtime status: `not_run`.
+
+## Next implementation results
+
+1. Add one concrete Comments transport implementation over the typed adapter core.
+   Keep endpoint ownership and authentication in the host/transport layer rather
+   than the Blog consumer.
+2. Publish the remote adapter through the host runtime and generated GraphQL
+   attachment inputs while preserving the in-process fallback.
+3. Add bounded deadline cancellation and retry policy that cannot replay writes
+   without the existing idempotency key.
+4. Add in-process/remote parity fixtures for all seven operations and typed
+   `PortError` mapping.
+5. Run the retained Rust, JavaScript, PostgreSQL, browser, workflow, and CI targets
+   before promoting any evidence beyond source-only status.
+6. Continue the already-planned cached snapshot and comment-form fallback work
+   after the concrete transport has observed runtime evidence.
+
+## Suggested verification — intentionally not run in this slice
+
+- `node scripts/verify/verify-blog-comments-remote-adapter-core.mjs`
+- `cargo test -p rustok-comments --features server --lib remote::tests::remote_adapter_accepts_a_transport_trait_object -- --exact`
+- `cargo check -p rustok-comments --features server`
+- `npm run verify:blog:comments-port-boundary`
+- `npm run test:verify:blog:comments-port-boundary`
+
+## Boundaries retained
+
+- Comments owns comment storage, public projection, moderation lifecycle, thread
+  invariants, and the `CommentsThreadPort` provider implementation.
+- Blog owns the consumer policy, article rendering, typed degraded presentation,
+  and host-selected composition seams.
+- A remote transport must implement the provider-owned typed transport contract;
+  Blog must not reconstruct Comments storage or error classification.
+- Source-only evidence must remain explicit until the maintainer runs and records
+  the corresponding execution targets.

--- a/crates/rustok-comments/src/lib.rs
+++ b/crates/rustok-comments/src/lib.rs
@@ -10,6 +10,8 @@ pub mod ports;
 #[cfg(feature = "server")]
 mod public_read;
 #[cfg(feature = "server")]
+pub mod remote;
+#[cfg(feature = "server")]
 mod richtext;
 #[cfg(feature = "server")]
 pub mod services;
@@ -33,6 +35,8 @@ pub use entities::*;
 pub use error::{CommentsError, CommentsResult};
 #[cfg(feature = "server")]
 pub use ports::*;
+#[cfg(feature = "server")]
+pub use remote::*;
 #[cfg(feature = "server")]
 pub use services::CommentsService;
 

--- a/crates/rustok-comments/src/remote.rs
+++ b/crates/rustok-comments/src/remote.rs
@@ -1,0 +1,285 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{PortCallPolicy, PortContext, PortError};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    CommentListItem, CommentRecord, CommentsThreadPort, CreateCommentInput, ListCommentsFilter,
+    SetCommentStatusRequest, UpdateCommentInput,
+};
+
+/// Transport-neutral wire request for a remote `CommentsThreadPort` provider.
+///
+/// Concrete HTTP, gRPC, message-bus, or sidecar clients implement
+/// [`CommentsThreadTransport`] and remain responsible for authentication,
+/// endpoint discovery, cancellation, and converting transport failures into the
+/// stable `PortError` envelope.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+pub enum CommentsThreadRequest {
+    CreateComment {
+        context: PortContext,
+        request: CreateCommentInput,
+    },
+    GetComment {
+        context: PortContext,
+        comment_id: Uuid,
+        fallback_locale: Option<String>,
+    },
+    ListCommentsForTarget {
+        context: PortContext,
+        target_type: String,
+        target_id: Uuid,
+        filter: ListCommentsFilter,
+        fallback_locale: Option<String>,
+    },
+    ListPublicCommentsForTarget {
+        context: PortContext,
+        target_type: String,
+        target_id: Uuid,
+        filter: ListCommentsFilter,
+        fallback_locale: Option<String>,
+    },
+    UpdateComment {
+        context: PortContext,
+        comment_id: Uuid,
+        request: UpdateCommentInput,
+    },
+    SetCommentStatus {
+        context: PortContext,
+        comment_id: Uuid,
+        request: SetCommentStatusRequest,
+    },
+    DeleteComment {
+        context: PortContext,
+        comment_id: Uuid,
+    },
+}
+
+/// Transport-neutral wire response for a remote `CommentsThreadPort` provider.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "result", content = "payload", rename_all = "snake_case")]
+pub enum CommentsThreadResponse {
+    Comment(CommentRecord),
+    CommentsPage {
+        items: Vec<CommentListItem>,
+        total: u64,
+    },
+    Deleted,
+}
+
+/// Executes one typed Comments request over a concrete remote transport.
+///
+/// Implementations must preserve the complete `PortContext`, including deadline,
+/// correlation, causation, trace, claims, roles, channel, and idempotency data.
+#[async_trait]
+pub trait CommentsThreadTransport: Send + Sync {
+    async fn execute(
+        &self,
+        request: CommentsThreadRequest,
+    ) -> Result<CommentsThreadResponse, PortError>;
+}
+
+/// `CommentsThreadPort` adapter backed by a typed remote transport.
+#[derive(Clone)]
+pub struct RemoteCommentsThreadPort {
+    transport: Arc<dyn CommentsThreadTransport>,
+}
+
+impl RemoteCommentsThreadPort {
+    pub fn new(transport: Arc<dyn CommentsThreadTransport>) -> Self {
+        Self { transport }
+    }
+}
+
+/// Builds a remote Comments provider that can be injected into Blog or another
+/// consumer through its existing `Arc<dyn CommentsThreadPort>` composition seam.
+pub fn remote_comments_thread_port(
+    transport: Arc<dyn CommentsThreadTransport>,
+) -> Arc<dyn CommentsThreadPort> {
+    Arc::new(RemoteCommentsThreadPort::new(transport))
+}
+
+#[async_trait]
+impl CommentsThreadPort for RemoteCommentsThreadPort {
+    async fn create_comment(
+        &self,
+        context: PortContext,
+        request: CreateCommentInput,
+    ) -> Result<CommentRecord, PortError> {
+        context.require_policy(PortCallPolicy::write())?;
+        expect_comment(
+            "create_comment",
+            self.transport
+                .execute(CommentsThreadRequest::CreateComment { context, request })
+                .await?,
+        )
+    }
+
+    async fn get_comment(
+        &self,
+        context: PortContext,
+        comment_id: Uuid,
+        fallback_locale: Option<String>,
+    ) -> Result<CommentRecord, PortError> {
+        context.require_policy(PortCallPolicy::read())?;
+        expect_comment(
+            "get_comment",
+            self.transport
+                .execute(CommentsThreadRequest::GetComment {
+                    context,
+                    comment_id,
+                    fallback_locale,
+                })
+                .await?,
+        )
+    }
+
+    async fn list_comments_for_target(
+        &self,
+        context: PortContext,
+        target_type: String,
+        target_id: Uuid,
+        filter: ListCommentsFilter,
+        fallback_locale: Option<String>,
+    ) -> Result<(Vec<CommentListItem>, u64), PortError> {
+        context.require_policy(PortCallPolicy::read())?;
+        expect_comments_page(
+            "list_comments_for_target",
+            self.transport
+                .execute(CommentsThreadRequest::ListCommentsForTarget {
+                    context,
+                    target_type,
+                    target_id,
+                    filter,
+                    fallback_locale,
+                })
+                .await?,
+        )
+    }
+
+    async fn list_public_comments_for_target(
+        &self,
+        context: PortContext,
+        target_type: String,
+        target_id: Uuid,
+        filter: ListCommentsFilter,
+        fallback_locale: Option<String>,
+    ) -> Result<(Vec<CommentListItem>, u64), PortError> {
+        context.require_policy(PortCallPolicy::read())?;
+        expect_comments_page(
+            "list_public_comments_for_target",
+            self.transport
+                .execute(CommentsThreadRequest::ListPublicCommentsForTarget {
+                    context,
+                    target_type,
+                    target_id,
+                    filter,
+                    fallback_locale,
+                })
+                .await?,
+        )
+    }
+
+    async fn update_comment(
+        &self,
+        context: PortContext,
+        comment_id: Uuid,
+        request: UpdateCommentInput,
+    ) -> Result<CommentRecord, PortError> {
+        context.require_policy(PortCallPolicy::write())?;
+        expect_comment(
+            "update_comment",
+            self.transport
+                .execute(CommentsThreadRequest::UpdateComment {
+                    context,
+                    comment_id,
+                    request,
+                })
+                .await?,
+        )
+    }
+
+    async fn set_comment_status(
+        &self,
+        context: PortContext,
+        comment_id: Uuid,
+        request: SetCommentStatusRequest,
+    ) -> Result<CommentRecord, PortError> {
+        context.require_policy(PortCallPolicy::write())?;
+        expect_comment(
+            "set_comment_status",
+            self.transport
+                .execute(CommentsThreadRequest::SetCommentStatus {
+                    context,
+                    comment_id,
+                    request,
+                })
+                .await?,
+        )
+    }
+
+    async fn delete_comment(
+        &self,
+        context: PortContext,
+        comment_id: Uuid,
+    ) -> Result<(), PortError> {
+        context.require_policy(PortCallPolicy::write())?;
+        match self
+            .transport
+            .execute(CommentsThreadRequest::DeleteComment {
+                context,
+                comment_id,
+            })
+            .await?
+        {
+            CommentsThreadResponse::Deleted => Ok(()),
+            response => Err(response_mismatch("delete_comment", &response)),
+        }
+    }
+}
+
+fn expect_comment(
+    operation: &'static str,
+    response: CommentsThreadResponse,
+) -> Result<CommentRecord, PortError> {
+    match response {
+        CommentsThreadResponse::Comment(comment) => Ok(comment),
+        response => Err(response_mismatch(operation, &response)),
+    }
+}
+
+fn expect_comments_page(
+    operation: &'static str,
+    response: CommentsThreadResponse,
+) -> Result<(Vec<CommentListItem>, u64), PortError> {
+    match response {
+        CommentsThreadResponse::CommentsPage { items, total } => Ok((items, total)),
+        response => Err(response_mismatch(operation, &response)),
+    }
+}
+
+fn response_mismatch(
+    operation: &'static str,
+    _response: &CommentsThreadResponse,
+) -> PortError {
+    PortError::invariant_violation(
+        "comments.remote_response_mismatch",
+        format!("comments remote transport returned an incompatible response for {operation}"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remote_adapter_accepts_a_transport_trait_object() {
+        let constructor: fn(
+            Arc<dyn CommentsThreadTransport>,
+        ) -> Arc<dyn CommentsThreadPort> = remote_comments_thread_port;
+        let _ = constructor;
+    }
+}

--- a/scripts/verify/verify-blog-comments-remote-adapter-core.mjs
+++ b/scripts/verify/verify-blog-comments-remote-adapter-core.mjs
@@ -1,0 +1,189 @@
+import fs from 'node:fs';
+
+const evidencePath =
+  'crates/rustok-blog/contracts/evidence/blog-comments-remote-adapter-core.json';
+const adapterPath = 'crates/rustok-comments/src/remote.rs';
+const providerExportPath = 'crates/rustok-comments/src/lib.rs';
+const planPath = 'crates/rustok-blog/docs/implementation-plan-slice-67.md';
+
+function read(path) {
+  return fs.readFileSync(path, 'utf8');
+}
+
+function json(path) {
+  return JSON.parse(read(path));
+}
+
+function fail(message) {
+  console.error(`[verify-blog-comments-remote-adapter-core] ${message}`);
+  process.exit(1);
+}
+
+function hasAll(text, markers, label) {
+  for (const marker of markers) {
+    if (!text.includes(marker)) fail(`${label} missing ${marker}`);
+  }
+}
+
+function sameSet(actual, expected, label) {
+  const left = [...actual].sort().join('|');
+  const right = [...expected].sort().join('|');
+  if (left !== right) fail(`${label} drift: expected ${right}, got ${left}`);
+}
+
+const evidence = json(evidencePath);
+const adapter = read(adapterPath);
+const providerExport = read(providerExportPath);
+const plan = read(planPath);
+
+if (evidence.schema_version !== 1) fail('evidence schema_version drift');
+if (
+  evidence.module !== 'blog'
+  || evidence.provider !== 'comments'
+  || evidence.surface !== 'comments_remote_adapter_core'
+) fail('evidence identity drift');
+if (
+  evidence.status !== 'source_verified_no_compile'
+  || evidence.compile_policy !== 'not_run_by_request'
+  || evidence.runtime_status !== 'not_run'
+) fail('evidence execution status drift');
+if (evidence.generated_from !== planPath) fail('evidence plan path drift');
+if (evidence.source_contract?.provider_adapter !== adapterPath) {
+  fail('provider adapter path drift');
+}
+if (evidence.source_contract?.provider_export !== providerExportPath) {
+  fail('provider export path drift');
+}
+
+const operations = [
+  'create_comment',
+  'get_comment',
+  'list_comments_for_target',
+  'list_public_comments_for_target',
+  'update_comment',
+  'set_comment_status',
+  'delete_comment',
+];
+sameSet(
+  (evidence.operations ?? []).map((operation) => operation.name),
+  operations,
+  'remote operation set',
+);
+
+const readOperations = new Set([
+  'get_comment',
+  'list_comments_for_target',
+  'list_public_comments_for_target',
+]);
+for (const operation of evidence.operations ?? []) {
+  const expectedPolicy = readOperations.has(operation.name) ? 'read' : 'write';
+  if (operation.policy !== expectedPolicy) {
+    fail(`${operation.name} policy drift`);
+  }
+  hasAll(
+    adapter,
+    [operation.request, operation.response],
+    `${operation.name} wire mapping`,
+  );
+}
+
+sameSet(
+  evidence.context_fields_preserved ?? [],
+  [
+    'tenant_id',
+    'actor',
+    'claims',
+    'roles',
+    'channel',
+    'locale',
+    'correlation_id',
+    'causation_id',
+    'traceparent',
+    'idempotency_key',
+    'deadline_ms',
+  ],
+  'PortContext preservation fields',
+);
+
+hasAll(
+  adapter,
+  [
+    'pub enum CommentsThreadRequest',
+    'pub enum CommentsThreadResponse',
+    'pub trait CommentsThreadTransport: Send + Sync',
+    'pub struct RemoteCommentsThreadPort',
+    'pub fn remote_comments_thread_port',
+    'impl CommentsThreadPort for RemoteCommentsThreadPort',
+    'context.require_policy(PortCallPolicy::read())?',
+    'context.require_policy(PortCallPolicy::write())?',
+    'comments.remote_response_mismatch',
+    'PortError::invariant_violation',
+    'remote_adapter_accepts_a_transport_trait_object',
+  ],
+  'remote adapter source',
+);
+
+hasAll(
+  providerExport,
+  [
+    '#[cfg(feature = "server")]\npub mod remote;',
+    '#[cfg(feature = "server")]\npub use remote::*;',
+  ],
+  'provider exports',
+);
+
+hasAll(
+  plan,
+  [
+    '# rustok-blog implementation plan — slice 67 continuation',
+    'Typed storefront `AVAILABLE`, `UNAVAILABLE`, and `TIMEOUT` rendering is already',
+    'Slice 67 adds the provider-owned typed remote adapter core.',
+    'A concrete HTTP, gRPC, message-bus, or sidecar client is still pending.',
+    'Status: `source_verified_no_compile`.',
+    'Compile policy: `not_run_by_request`.',
+    'Runtime status: `not_run`.',
+    evidencePath,
+    adapterPath,
+    'scripts/verify/verify-blog-comments-remote-adapter-core.mjs',
+  ],
+  'slice 67 plan',
+);
+
+if (evidence.fail_closed?.response_mismatch_code !== 'comments.remote_response_mismatch') {
+  fail('response mismatch code drift');
+}
+if (evidence.fail_closed?.response_mismatch_kind !== 'InvariantViolation') {
+  fail('response mismatch kind drift');
+}
+if (evidence.fail_closed?.policy_checked_before_dispatch !== true) {
+  fail('policy-before-dispatch marker drift');
+}
+
+sameSet(
+  evidence.pending ?? [],
+  [
+    'concrete_network_transport',
+    'endpoint_discovery',
+    'authentication',
+    'retry_backoff',
+    'transport_cancellation',
+    'host_publication',
+    'in_process_remote_runtime_parity',
+    'runtime_execution',
+  ],
+  'pending scope',
+);
+
+for (const forbidden of [
+  'status": "compiled"',
+  'runtime_status": "passed"',
+  'tests passed',
+  'CI passed',
+  'production verified',
+]) {
+  if (read(evidencePath).includes(forbidden) || plan.includes(forbidden)) {
+    fail(`false execution claim detected: ${forbidden}`);
+  }
+}
+
+console.log('[verify-blog-comments-remote-adapter-core] source contract verified');


### PR DESCRIPTION
## Summary

- re-audit the Blog implementation plan through slice 66 against current `main`
- add the slice 67 continuation plan and correct the stale degraded-UI status
- add a provider-owned, transport-neutral remote adapter core for all seven `CommentsThreadPort` operations
- preserve the complete `PortContext` and enforce existing read/write policy before dispatch
- reject incompatible typed responses with fail-closed `comments.remote_response_mismatch`
- retain schema-v1 source evidence and a standalone fail-closed verifier

## Scope intentionally left pending

- concrete HTTP/gRPC/message-bus/sidecar transport
- endpoint discovery and authentication
- retry/backoff and cancellation
- host publication and in-process/remote runtime parity
- cached thread snapshots and comment-form fallback
- all runtime execution evidence

## Verification

Tests, verifiers, formatting, Cargo checks, database targets, browser targets, workflows, and CI were intentionally not run by request. Suggested maintainer commands are recorded in `crates/rustok-blog/docs/implementation-plan-slice-67.md`.