### PR TITLE
fix(translation): sanitize shared public errors

### DIFF
--- a/crates/rustok-translation/contracts/evidence/translation-public-error-safety-source-review.json
+++ b/crates/rustok-translation/contracts/evidence/translation-public-error-safety-source-review.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "status": "translation_public_error_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-translation/src/public_error.rs",
+    "crates/rustok-translation/src/error.rs",
+    "crates/rustok-translation/src/graphql/context.rs",
+    "crates/rustok-translation/admin/src/transport/native_server_adapter.rs",
+    "scripts/verify/verify-translation-public-error-safety.mjs",
+    "crates/rustok-translation/contracts/evidence/translation-public-error-safety-source.json"
+  ],
+  "review_findings": {
+    "public_structs_preserved": true,
+    "public_kind_classification_preserved": true,
+    "public_codes_preserved": true,
+    "public_retryability_preserved": true,
+    "correlation_envelope_preserved": true,
+    "forbidden_message_preserved": true,
+    "not_found_payload_redacted": true,
+    "bad_input_payload_redacted": true,
+    "internal_messages_preserved": true,
+    "complete_translation_error_logging_removed": true,
+    "provider_database_payload_removed": true,
+    "workflow_locale_revision_reason_payload_removed": true,
+    "static_error_class_retained": true,
+    "graphql_consumer_preserved": true,
+    "native_consumer_preserved": true,
+    "shared_export_preserved": true,
+    "broad_ecommerce_cleanup_remains_open": true,
+    "runtime_evidence_claimed": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, workflows, CI, GraphQL runtime, or native runtime validation was executed."
+}

--- a/crates/rustok-translation/contracts/evidence/translation-public-error-safety-source.json
+++ b/crates/rustok-translation/contracts/evidence/translation-public-error-safety-source.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": 1,
+  "status": "translation_public_error_safety_source_unvalidated",
+  "scope": {
+    "owner_source": "crates/rustok-translation/src/public_error.rs",
+    "owner_error": "crates/rustok-translation/src/error.rs",
+    "graphql_consumer": "crates/rustok-translation/src/graphql/context.rs",
+    "native_consumer": "crates/rustok-translation/admin/src/transport/native_server_adapter.rs",
+    "focused_verifier": "scripts/verify/verify-translation-public-error-safety.mjs",
+    "documentation": "crates/rustok-translation/docs/translation-public-error-safety.md"
+  },
+  "source_contract": {
+    "public_kind_changed": false,
+    "public_code_changed": false,
+    "public_retryability_changed": false,
+    "forbidden_message_changed": false,
+    "not_found_dynamic_payload_removed": true,
+    "bad_input_dynamic_payload_removed": true,
+    "internal_messages_changed": false,
+    "complete_translation_error_logged": false,
+    "provider_error_payload_logged": false,
+    "database_error_payload_logged": false,
+    "workflow_state_payload_logged": false,
+    "locale_revision_reason_payload_logged": false,
+    "static_error_class_logged": true,
+    "operation_logged": true,
+    "boundary_logged": true,
+    "public_code_logged": true,
+    "retryability_logged": true,
+    "correlation_logged": true,
+    "correlation_generation_changed": false,
+    "correlation_rendering_changed": false,
+    "graphql_consumer_changed": false,
+    "native_consumer_changed": false,
+    "shared_export_changed": false,
+    "broad_ecommerce_cleanup_closed": false
+  },
+  "validation": {
+    "tests_run": false,
+    "verifiers_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "graphql_runtime_proven": false,
+    "native_runtime_proven": false
+  },
+  "execution": []
+}

--- a/crates/rustok-translation/docs/translation-public-error-safety.md
+++ b/crates/rustok-translation/docs/translation-public-error-safety.md
@@ -1,0 +1,56 @@
+# Translation shared public-error safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice closes the public and diagnostic payload gap in Translation-owned `map_translation_public_error`, the shared mapper used by GraphQL and native admin consumers.
+
+The public structs, error kinds, stable codes, retryability, generated correlation id, display reference, shared export, and consumer composition remain unchanged.
+
+## Public envelopes
+
+The mapper keeps four public kinds:
+
+- forbidden;
+- not found;
+- bad input;
+- internal.
+
+Forbidden, retryable-internal, and ordinary-internal messages are unchanged. Not-found errors now use `Translation resource was not found`. Bad-input errors now use `Translation request is invalid`.
+
+The previous `error.to_string()` messages could contain owner workflow state, locale, revision, reason, provider, or validation payload. Those details are no longer returned through GraphQL or native server-function errors.
+
+## Private diagnostics
+
+The structured event retains only:
+
+- a closed static error class;
+- owner operation;
+- boundary;
+- public code;
+- retryability;
+- correlation id.
+
+The complete `TranslationError`, provider code/message, database error, workflow state, locale, revision, cancellation/recovery reason, and validation payload are not recorded.
+
+## Preserved behavior
+
+- GraphQL still maps the four public kinds to permission-denied, not-found, bad-user-input, and internal GraphQL errors;
+- native admin still renders the same `TranslationPublicError` through `ServerFnError`;
+- all existing error variants remain in their previous kind/code/retryability groups;
+- `Uuid::new_v4()` still generates one correlation id per mapped failure;
+- `Display` still renders message, code, and reference;
+- dispatch, permissions, requests, responses, and transport selection are unchanged.
+
+## Evidence
+
+- `crates/rustok-translation/contracts/evidence/translation-public-error-safety-source.json`
+- `crates/rustok-translation/contracts/evidence/translation-public-error-safety-source-review.json`
+- `scripts/verify/verify-translation-public-error-safety.mjs`
+
+## Remaining gaps
+
+Compile, focused-verifier execution, GraphQL runtime evidence, and native runtime evidence remain open. The broader ecommerce mapper cleanup remains open.
+
+No test, verifier, formatter, Cargo, workflow, or CI command was executed for this source slice.

--- a/crates/rustok-translation/src/public_error.rs
+++ b/crates/rustok-translation/src/public_error.rs
@@ -34,12 +34,13 @@ pub fn map_translation_public_error(
     operation: &'static str,
     boundary: &'static str,
 ) -> TranslationPublicError {
-    let (kind, message, code, retryable) = match error {
+    let (kind, message, code, retryable, error_class) = match error {
         TranslationError::Forbidden => (
             TranslationPublicErrorKind::Forbidden,
             "Translation permission denied".to_string(),
             "TRANSLATION_PERMISSION_DENIED",
             false,
+            "forbidden",
         ),
         TranslationError::JobNotFound
         | TranslationError::ItemNotFound
@@ -49,9 +50,10 @@ pub fn map_translation_public_error(
         | TranslationError::MemoryEntryNotFound
         | TranslationError::MachineOperationNotFound => (
             TranslationPublicErrorKind::NotFound,
-            error.to_string(),
+            "Translation resource was not found".to_string(),
             "TRANSLATION_RESOURCE_NOT_FOUND",
             false,
+            "not_found",
         ),
         TranslationError::InvalidRequest(_)
         | TranslationError::IdempotencyConflict
@@ -95,9 +97,10 @@ pub fn map_translation_public_error(
         | TranslationError::MachineRecoveryAlreadyRequested
         | TranslationError::MemoryRetentionConflict(_) => (
             TranslationPublicErrorKind::BadInput,
-            error.to_string(),
+            "Translation request is invalid".to_string(),
             "TRANSLATION_REQUEST_INVALID",
             false,
+            "bad_input",
         ),
         TranslationError::Provider {
             retryable: true, ..
@@ -108,23 +111,25 @@ pub fn map_translation_public_error(
             "Translation service is temporarily unavailable".to_string(),
             "TRANSLATION_TEMPORARILY_UNAVAILABLE",
             true,
+            "temporarily_unavailable",
         ),
         _ => (
             TranslationPublicErrorKind::Internal,
             "Translation operation could not be completed".to_string(),
             "TRANSLATION_OPERATION_FAILED",
             false,
+            "internal",
         ),
     };
     let correlation_id = Uuid::new_v4();
     tracing::error!(
-        error = ?error,
+        error_class,
         operation,
         boundary,
         public_code = code,
         retryable,
         %correlation_id,
-        "Translation service operation failed"
+        "Translation service operation failed with bounded diagnostics"
     );
     TranslationPublicError {
         kind,
@@ -151,5 +156,18 @@ mod tests {
         assert!(public.retryable);
         assert!(!rendered.contains("password=private"));
         assert!(!rendered.contains("host=internal"));
+    }
+
+    #[test]
+    fn bad_input_details_are_redacted() {
+        let error = TranslationError::InvalidRequest("owner-payload=private".to_string());
+        let public = map_translation_public_error(&error, "test", "translation_test");
+        let rendered = public.to_string();
+
+        assert_eq!(public.kind, TranslationPublicErrorKind::BadInput);
+        assert_eq!(public.message, "Translation request is invalid");
+        assert_eq!(public.code, "TRANSLATION_REQUEST_INVALID");
+        assert!(!public.retryable);
+        assert!(!rendered.contains("owner-payload=private"));
     }
 }

--- a/scripts/verify/verify-translation-public-error-safety.mjs
+++ b/scripts/verify/verify-translation-public-error-safety.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const failures = [];
+
+const paths = {
+  mapper: 'crates/rustok-translation/src/public_error.rs',
+  error: 'crates/rustok-translation/src/error.rs',
+  root: 'crates/rustok-translation/src/lib.rs',
+  graphql: 'crates/rustok-translation/src/graphql/context.rs',
+  native:
+    'crates/rustok-translation/admin/src/transport/native_server_adapter.rs',
+  evidence:
+    'crates/rustok-translation/contracts/evidence/translation-public-error-safety-source.json',
+  review:
+    'crates/rustok-translation/contracts/evidence/translation-public-error-safety-source-review.json',
+  document: 'crates/rustok-translation/docs/translation-public-error-safety.md',
+};
+
+const mapper = read(paths.mapper);
+const errorSource = read(paths.error);
+const rootSource = read(paths.root);
+const graphql = read(paths.graphql);
+const native = read(paths.native);
+const evidence = JSON.parse(read(paths.evidence));
+const review = JSON.parse(read(paths.review));
+const document = read(paths.document);
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const countText = (source, value) => source.split(value).length - 1;
+
+for (const marker of [
+  'pub enum TranslationPublicErrorKind {',
+  'Forbidden,',
+  'NotFound,',
+  'BadInput,',
+  'Internal,',
+  'pub struct TranslationPublicError {',
+  'pub kind: TranslationPublicErrorKind',
+  'pub message: String',
+  "pub code: &'static str",
+  'pub retryable: bool',
+  'pub correlation_id: Uuid',
+  'impl std::fmt::Display for TranslationPublicError',
+  '"{} (code: {}; reference: {})"',
+  'pub fn map_translation_public_error(',
+]) requireText(mapper, marker, `${paths.mapper}: public contract`);
+
+requireText(
+  rootSource,
+  'TranslationPublicError, TranslationPublicErrorKind, map_translation_public_error,',
+  `${paths.root}: shared export`,
+);
+
+const ownerVariantCount = (
+  errorSource.match(/^\s{4}[A-Z][A-Za-z0-9_]*(?:\s*\{|\s*\(|,)/gm) ?? []
+).length;
+if (ownerVariantCount !== 83) {
+  failures.push(`${paths.error}: expected 83 TranslationError variants, found ${ownerVariantCount}`);
+}
+
+for (const marker of [
+  'let (kind, message, code, retryable, error_class) = match error {',
+  'TranslationError::Forbidden =>',
+  'TranslationPublicErrorKind::Forbidden',
+  '"Translation permission denied".to_string()',
+  '"TRANSLATION_PERMISSION_DENIED"',
+  '"forbidden"',
+  'TranslationError::JobNotFound',
+  '| TranslationError::ItemNotFound',
+  '| TranslationError::ProposalNotFound',
+  '| TranslationError::JobProgressNotFound',
+  '| TranslationError::GlossaryNotFound',
+  '| TranslationError::MemoryEntryNotFound',
+  '| TranslationError::MachineOperationNotFound',
+  'TranslationPublicErrorKind::NotFound',
+  '"Translation resource was not found".to_string()',
+  '"TRANSLATION_RESOURCE_NOT_FOUND"',
+  '"not_found"',
+  'TranslationError::InvalidRequest(_)',
+  '| TranslationError::WorkflowRevisionConflict',
+  '| TranslationError::JobNotWritable(_)',
+  '| TranslationError::TranslationPolicyConflict { .. }',
+  '| TranslationError::RequiredTargetLocaleDisabled(_)',
+  '| TranslationError::DisabledJobLocale { .. }',
+  '| TranslationError::GlossaryRevisionConflict { .. }',
+  '| TranslationError::GlossaryRevisionUnavailable { .. }',
+  '| TranslationError::MemoryRevisionConflict { .. }',
+  '| TranslationError::MachineOperationTerminal(_)',
+  '| TranslationError::MemoryRetentionConflict(_)',
+  'TranslationPublicErrorKind::BadInput',
+  '"Translation request is invalid".to_string()',
+  '"TRANSLATION_REQUEST_INVALID"',
+  '"bad_input"',
+  'TranslationError::Provider {',
+  'retryable: true, ..',
+  '| TranslationError::MachineRecoveryResultUnavailable',
+  '| TranslationError::Database(_)',
+  '"Translation service is temporarily unavailable".to_string()',
+  '"TRANSLATION_TEMPORARILY_UNAVAILABLE"',
+  '"temporarily_unavailable"',
+  '"Translation operation could not be completed".to_string()',
+  '"TRANSLATION_OPERATION_FAILED"',
+  '"internal"',
+  'let correlation_id = Uuid::new_v4();',
+  'tracing::error!(',
+  'error_class,',
+  'operation,',
+  'boundary,',
+  'public_code = code',
+  'retryable,',
+  '%correlation_id',
+  'TranslationPublicError {',
+  'kind,',
+  'message,',
+  'code,',
+  'correlation_id,',
+]) requireText(mapper, marker, `${paths.mapper}: stable shared mapping`);
+
+for (const forbidden of [
+  'error.to_string()',
+  'error = ?error',
+  'error = %error',
+  'provider_code =',
+  'provider_message =',
+  'locale = %',
+  'locale = ?',
+  'revision =',
+  'reason = %',
+  'reason = ?',
+  'state = %',
+  'state = ?',
+]) forbidText(mapper, forbidden, `${paths.mapper}: owner payload exposure`);
+
+if (countText(mapper, '"Translation resource was not found".to_string()') !== 1) {
+  failures.push(`${paths.mapper}: not-found envelope must be unique`);
+}
+if (countText(mapper, '"Translation request is invalid".to_string()') !== 1) {
+  failures.push(`${paths.mapper}: bad-input envelope must be unique`);
+}
+
+for (const marker of [
+  'pub(crate) fn translation_error(error: crate::TranslationError) -> Error',
+  'crate::map_translation_public_error(',
+  '"graphql_operation"',
+  '"translation_graphql"',
+  'crate::TranslationPublicErrorKind::Forbidden =>',
+  'crate::TranslationPublicErrorKind::NotFound =>',
+  'crate::TranslationPublicErrorKind::BadInput =>',
+  'crate::TranslationPublicErrorKind::Internal =>',
+]) requireText(graphql, marker, `${paths.graphql}: preserved shared consumer`);
+
+for (const marker of [
+  'fn public_error(error: rustok_translation::TranslationError) -> ServerFnError',
+  'rustok_translation::map_translation_public_error(',
+  '"native_operation"',
+  '"translation_admin_native"',
+  '.to_string()',
+]) requireText(native, marker, `${paths.native}: preserved shared consumer`);
+
+for (const [key, expected] of Object.entries({
+  public_kind_changed: false,
+  public_code_changed: false,
+  public_retryability_changed: false,
+  forbidden_message_changed: false,
+  not_found_dynamic_payload_removed: true,
+  bad_input_dynamic_payload_removed: true,
+  internal_messages_changed: false,
+  complete_translation_error_logged: false,
+  provider_error_payload_logged: false,
+  database_error_payload_logged: false,
+  workflow_state_payload_logged: false,
+  locale_revision_reason_payload_logged: false,
+  static_error_class_logged: true,
+  operation_logged: true,
+  boundary_logged: true,
+  public_code_logged: true,
+  retryability_logged: true,
+  correlation_logged: true,
+  correlation_generation_changed: false,
+  correlation_rendering_changed: false,
+  graphql_consumer_changed: false,
+  native_consumer_changed: false,
+  shared_export_changed: false,
+  broad_ecommerce_cleanup_closed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+
+for (const key of [
+  'tests_run',
+  'verifiers_run',
+  'cargo_run',
+  'format_run',
+  'workflow_checks_run',
+  'ci_run',
+  'compile_proven',
+  'graphql_runtime_proven',
+  'native_runtime_proven',
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push(`${paths.evidence}: execution must remain empty`);
+}
+
+for (const [key, expected] of Object.entries({
+  public_structs_preserved: true,
+  public_kind_classification_preserved: true,
+  public_codes_preserved: true,
+  public_retryability_preserved: true,
+  correlation_envelope_preserved: true,
+  forbidden_message_preserved: true,
+  not_found_payload_redacted: true,
+  bad_input_payload_redacted: true,
+  internal_messages_preserved: true,
+  complete_translation_error_logging_removed: true,
+  provider_database_payload_removed: true,
+  workflow_locale_revision_reason_payload_removed: true,
+  static_error_class_retained: true,
+  graphql_consumer_preserved: true,
+  native_consumer_preserved: true,
+  shared_export_preserved: true,
+  broad_ecommerce_cleanup_remains_open: true,
+  runtime_evidence_claimed: false,
+})) {
+  if (review.review_findings?.[key] !== expected) {
+    failures.push(`${paths.review}: review_findings.${key} must be ${expected}`);
+  }
+}
+
+for (const marker of [
+  'Status: **source-ready / unvalidated**',
+  '`map_translation_public_error`',
+  'GraphQL and native admin consumers',
+  '`Translation resource was not found`',
+  '`Translation request is invalid`',
+  'The broader ecommerce mapper cleanup remains open.',
+]) requireText(document, marker, `${paths.document}: truthful source scope`);
+
+if (failures.length > 0) {
+  console.error('Translation shared public-error safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Translation shared public errors use static public envelopes and bounded diagnostics; execution evidence remains open',
+);


### PR DESCRIPTION
## Summary

- continue the ecommerce mapper cleanup at Translation-owned `map_translation_public_error`
- replace dynamic `error.to_string()` not-found and bad-input envelopes with stable public messages
- replace complete `TranslationError` debug logging with a closed static error class
- preserve public kind, stable code, retryability, correlation generation/rendering, and shared exports
- keep GraphQL and native admin consumers unchanged
- add focused source evidence/review, documentation, and a fail-closed verifier

## Public behavior

- forbidden remains `TRANSLATION_PERMISSION_DENIED` with the existing message
- not-found remains `TranslationPublicErrorKind::NotFound` / `TRANSLATION_RESOURCE_NOT_FOUND`, now with `Translation resource was not found`
- bad-input remains `TranslationPublicErrorKind::BadInput` / `TRANSLATION_REQUEST_INVALID`, now with `Translation request is invalid`
- retryable and non-retryable internal mappings are unchanged
- each failure still receives a fresh correlation ID and the display string still includes message, code, and reference

## Scope

Exactly five files change:

- `crates/rustok-translation/src/public_error.rs`
- one focused verifier
- two diagnostic evidence files
- one focused document

`TranslationError`, GraphQL/native consumer files, dispatch, permissions, DTOs, Cargo manifests, migrations, dependencies, workflows, and CI configuration are unchanged.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, CI, GraphQL runtime, or native runtime validation was executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-translation-public-error-safety.mjs
cargo check -p rustok-translation --lib
```

Branch: `agent/translation-public-error-safety-20260731`
Base at creation: `7a36e37075f7e825fc9a4ad2174a3ab3bec99d83`
