### PR TITLE
test(forum): retain invalidation restart evidence

### DIFF
--- a/crates/rustok-forum/contracts/evidence/forum-search-versioned-invalidation-d2-source-harness.json
+++ b/crates/rustok-forum/contracts/evidence/forum-search-versioned-invalidation-d2-source-harness.json
@@ -1,0 +1,66 @@
+{
+  "format_version": 1,
+  "task": "FORUM-23B2G2B3D2",
+  "status": "source_ready_maintainer_execution_pending",
+  "predecessors": [
+    "FORUM-23B2G2B3D0",
+    "FORUM-23B2G2B3D1"
+  ],
+  "postgresql_ingress": {
+    "test_target": "crates/rustok-search/tests/forum_contract_ingress_postgres_test.rs",
+    "environment": "RUSTOK_SEARCH_TEST_DATABASE_URL",
+    "database_url_fallback": "DATABASE_URL",
+    "isolated_schema_per_case": true,
+    "real_search_module_migrations": true,
+    "legacy_first_then_typed": true,
+    "typed_first_then_legacy": true,
+    "new_ingress_instance_redelivery": true,
+    "single_root_row": true,
+    "first_ingest_sequence_retained": true,
+    "owner_revision_is_not_ingest_sequence": true,
+    "identity_conflict_is_non_retryable_semantic_poison": true
+  },
+  "persistent_cursor_restart": {
+    "source_target": "crates/rustok-iggy/src/contract_consumer_restart_tests.rs",
+    "event_ack_failure_leaves_offset_uncommitted": true,
+    "event_redelivery_after_group_reconstruction": true,
+    "event_exact_bytes_offset_and_identity_retained": true,
+    "decode_failure_ack_failure_leaves_offset_uncommitted": true,
+    "decode_failure_redelivery_after_group_reconstruction": true,
+    "decode_failure_exact_bytes_offset_and_delivery_id_retained": true,
+    "successful_restarted_ack_commits_exact_offset": true
+  },
+  "single_execution_path": {
+    "search_inbox": "search_projection_inbox",
+    "projection_identity": "legacy root envelope id / typed causation_id",
+    "second_inbox": false,
+    "second_projector": false,
+    "second_reconciler": false,
+    "second_ordering_clock": false
+  },
+  "compatibility": {
+    "production_migration_changed": false,
+    "event_schema_or_digest_changed": false,
+    "runtime_flag_changed": false,
+    "broker_topic_or_consumer_group_changed": false,
+    "public_api_changed": false,
+    "cargo_lock_changed": false
+  },
+  "not_claimed": {
+    "tests_executed": false,
+    "postgresql_output_captured": false,
+    "external_iggy_restart_executed": false,
+    "server_worker_restart_executed": false,
+    "raw_poison_receipt_or_dlq_executed": false,
+    "semantic_poison_receipt_or_dlq_executed": false,
+    "dlq_duplicate_suppression_executed": false,
+    "owner_checkpoint_repair_executed": false,
+    "multi_process_serialization_executed": false,
+    "deletion_acl_search_disabled_evidence_executed": false,
+    "link_forum_03_closed": false
+  },
+  "follow_up": {
+    "task": "FORUM-23B2G2B3D3",
+    "scope": "Durable connector-owned poison receipt, deterministic DLQ publication, acknowledgement failure and redelivery evidence before the remaining D0 runtime scenarios"
+  }
+}

--- a/crates/rustok-forum/docs/forum-23b2g2b3d2-versioned-invalidation-source-evidence.md
+++ b/crates/rustok-forum/docs/forum-23b2g2b3d2-versioned-invalidation-source-evidence.md
@@ -1,0 +1,82 @@
+# FORUM-23B2G2B3D2 versioned invalidation source evidence
+
+Status: `source_ready_maintainer_execution_pending`
+
+## Purpose
+
+This slice continues the accepted `FORUM-23B2G2B3D0` executable evidence protocol after the canonical `FORUM-23` plan reconciliation in D1. It supplies two bounded source-ready proofs without claiming that PostgreSQL, an external Iggy broker, the server worker, DLQ publication or the final cross-module scenarios were executed.
+
+D2 contains:
+
+1. a clean PostgreSQL one-inbox ingress harness; and
+2. a transport-level persistent cursor acknowledgement-failure and reconstruction proof.
+
+## PostgreSQL ingress proof
+
+`crates/rustok-search/tests/forum_contract_ingress_postgres_test.rs` uses every real `SearchModule` migration inside a unique PostgreSQL schema per case. It covers:
+
+- legacy-root delivery before the caused typed invalidation;
+- caused typed invalidation before legacy-root delivery;
+- one durable `search_projection_inbox` row in both orders;
+- retention of the first positive Search-owned `ingest_sequence`;
+- typed redelivery through a newly constructed `ForumSearchContractIngress`;
+- independence of Forum `owner_revision` from Search `ingest_sequence`;
+- exact tenant, scope and root-envelope duplicate recognition;
+- a conflicting retained root UUID as stable non-retryable semantic poison without rewriting the durable row.
+
+The target reads `RUSTOK_SEARCH_TEST_DATABASE_URL`, with PostgreSQL `DATABASE_URL` as fallback. Without a PostgreSQL URL it reports a skip and succeeds. It uses no sleep, polling, lease expiry or second projection path.
+
+## Persistent cursor restart proof
+
+`crates/rustok-iggy/src/contract_consumer_restart_tests.rs` is a crate-local test module so it can construct the same production `PersistentContractConsumerGroup` around a deterministic connector cursor.
+
+The cursor state is shared across two separately constructed consumer-group instances. The first acknowledgement is injected to fail. The proof requires:
+
+- the exact offset to remain uncommitted after acknowledgement failure;
+- a reconstructed group to receive the same bytes, partition, offset and event identity;
+- a second acknowledgement to commit that exact position;
+- no delivery after the successful commit;
+- the same behavior for undecodable raw bytes, retaining the deterministic poison delivery ID and stable decode classification across reconstruction.
+
+This is a transport ownership proof. It does not simulate durable server poison receipts or claim an external broker restart.
+
+## Single execution path
+
+D2 changes no Forum or Search production execution policy. Typed and legacy deliveries still converge on the existing root event identity and one `search_projection_inbox` row. The existing Forum Search reconciler and projector remain the only projection lane.
+
+No second inbox, projector, reconciler, watermark or ordering clock is introduced.
+
+## Remaining runtime evidence
+
+`FORUM-23B2G2B3D` remains open for maintainer-executed evidence covering:
+
+- successful PostgreSQL D2 output capture;
+- external persistent Iggy cursor and server-worker restart;
+- connector-owned raw and semantic poison receipts;
+- deterministic DLQ publication, acknowledgement failure and redelivery;
+- DLQ duplicate suppression;
+- missing-delivery owner-checkpoint repair;
+- multi-process serialization;
+- deletion, ACL and Search-disabled correlation;
+- complete `LINK-FORUM-03` closure.
+
+The next source slice is `FORUM-23B2G2B3D3`, focused only on durable poison receipt and DLQ redelivery evidence.
+
+## Maintainer validation
+
+```bash
+RUSTOK_SEARCH_TEST_DATABASE_URL=postgresql://... \
+  cargo test -p rustok-search \
+  --test forum_contract_ingress_postgres_test \
+  -- --nocapture --test-threads=1
+
+cargo test -p rustok-iggy contract_consumer::restart_tests -- --nocapture
+cargo check -p rustok-search --all-targets
+cargo check -p rustok-iggy --all-targets
+node scripts/verify/verify-forum-search-versioned-invalidation-d2-source-harness.mjs
+node scripts/verify/verify-forum-search-versioned-invalidation-runtime-evidence.mjs
+cargo xtask module validate forum
+cargo xtask module validate search
+```
+
+These commands were not run by the implementation agent.

--- a/crates/rustok-iggy/src/contract_consumer.rs
+++ b/crates/rustok-iggy/src/contract_consumer.rs
@@ -250,3 +250,7 @@ impl ConsumedContractEvent {
         .with_connector_metadata(self.connector_metadata)
     }
 }
+
+#[cfg(test)]
+#[path = "contract_consumer_restart_tests.rs"]
+mod restart_tests;

--- a/crates/rustok-iggy/src/contract_consumer_restart_tests.rs
+++ b/crates/rustok-iggy/src/contract_consumer_restart_tests.rs
@@ -1,0 +1,232 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_events::{ContractEventEnvelope, ForumSearchProjectionEvent};
+use rustok_iggy_connector::{
+    ConnectorError, ConsumerCursor, SubscriberMessage, SubscriberMessageMetadata,
+};
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+use super::{PersistentContractConsumerGroup, PersistentContractDelivery};
+use crate::serialization::{EventSerializer, JsonSerializer};
+
+const STREAM: &str = "rustok";
+const TOPIC: &str = "domain";
+const PARTITION: u32 = 1;
+const OFFSET: u64 = 41;
+const ACK_TOKEN: &str = "restart-proof-ack-41";
+
+#[derive(Clone)]
+struct SharedCursorState {
+    inner: Arc<Mutex<CursorState>>,
+}
+
+struct CursorState {
+    message: SubscriberMessage,
+    committed: bool,
+    ack_failures_remaining: u32,
+    receive_count: u32,
+    acknowledge_count: u32,
+}
+
+impl SharedCursorState {
+    fn new(payload: Vec<u8>, ack_failures_remaining: u32) -> Self {
+        let metadata = SubscriberMessageMetadata::new(STREAM, TOPIC, PARTITION)
+            .with_offset(OFFSET)
+            .with_message_id("restart-proof-message")
+            .with_delivery_attempt(1)
+            .with_ack_token(ACK_TOKEN);
+        Self {
+            inner: Arc::new(Mutex::new(CursorState {
+                message: SubscriberMessage { payload, metadata },
+                committed: false,
+                ack_failures_remaining,
+                receive_count: 0,
+                acknowledge_count: 0,
+            })),
+        }
+    }
+
+    async fn snapshot(&self) -> (bool, u32, u32) {
+        let state = self.inner.lock().await;
+        (
+            state.committed,
+            state.receive_count,
+            state.acknowledge_count,
+        )
+    }
+}
+
+struct RestartableCursor {
+    state: SharedCursorState,
+}
+
+#[async_trait]
+impl ConsumerCursor for RestartableCursor {
+    async fn receive(&mut self) -> Result<Option<SubscriberMessage>, ConnectorError> {
+        let mut state = self.state.inner.lock().await;
+        if state.committed {
+            return Ok(None);
+        }
+        state.receive_count += 1;
+        Ok(Some(state.message.clone()))
+    }
+
+    async fn acknowledge(&mut self, ack_token: &str) -> Result<(), ConnectorError> {
+        let mut state = self.state.inner.lock().await;
+        state.acknowledge_count += 1;
+        if state.message.metadata.ack_token.as_deref() != Some(ack_token) {
+            return Err(ConnectorError::Connection(
+                "ack token does not match the delivered cursor position".to_string(),
+            ));
+        }
+        if state.ack_failures_remaining > 0 {
+            state.ack_failures_remaining -= 1;
+            return Err(ConnectorError::Connection(
+                "injected acknowledgement failure".to_string(),
+            ));
+        }
+        state.committed = true;
+        Ok(())
+    }
+}
+
+fn group(state: SharedCursorState) -> PersistentContractConsumerGroup {
+    PersistentContractConsumerGroup::new(
+        STREAM.to_string(),
+        TOPIC.to_string(),
+        Arc::new(JsonSerializer),
+        Box::new(RestartableCursor { state }),
+    )
+}
+
+fn valid_payload() -> (ContractEventEnvelope, Vec<u8>) {
+    let envelope = ContractEventEnvelope::new_caused_by(
+        Uuid::new_v4(),
+        None,
+        Uuid::new_v4(),
+        ForumSearchProjectionEvent::InvalidationIssued {
+            owner_revision: 7,
+            target_type: "forum_category".to_string(),
+            target_id: Some(Uuid::new_v4()),
+        },
+    )
+    .expect("valid Forum Search contract envelope");
+    let payload = JsonSerializer
+        .serialize_contract(&envelope)
+        .expect("contract JSON should serialize");
+    (envelope, payload)
+}
+
+#[tokio::test]
+async fn event_ack_failure_is_redelivered_after_consumer_reconstruction() {
+    let (envelope, payload) = valid_payload();
+    let state = SharedCursorState::new(payload.clone(), 1);
+
+    let first_group = group(state.clone());
+    let first = match first_group
+        .receive_delivery()
+        .await
+        .expect("first receive should succeed")
+        .expect("delivery should exist")
+    {
+        PersistentContractDelivery::Event(consumed) => consumed,
+        PersistentContractDelivery::DecodeFailure(_) => {
+            panic!("valid contract bytes must not become decode poison")
+        }
+    };
+    assert_eq!(first.envelope.id(), envelope.id());
+    assert_eq!(first.offset(), Some(OFFSET));
+    assert_eq!(first.raw_payload(), payload.as_slice());
+    assert_eq!(first.ack_token(), Some(ACK_TOKEN));
+    assert!(first_group.acknowledge(&first).await.is_err());
+    assert_eq!(state.snapshot().await, (false, 1, 1));
+    drop(first_group);
+
+    let restarted_group = group(state.clone());
+    let redelivery = match restarted_group
+        .receive_delivery()
+        .await
+        .expect("restart receive should succeed")
+        .expect("uncommitted delivery should be redelivered")
+    {
+        PersistentContractDelivery::Event(consumed) => consumed,
+        PersistentContractDelivery::DecodeFailure(_) => {
+            panic!("redelivered valid bytes must remain a contract event")
+        }
+    };
+    assert_eq!(redelivery.envelope.id(), envelope.id());
+    assert_eq!(redelivery.offset(), Some(OFFSET));
+    assert_eq!(redelivery.raw_payload(), payload.as_slice());
+    restarted_group
+        .acknowledge(&redelivery)
+        .await
+        .expect("restarted consumer should commit the exact offset");
+    assert_eq!(state.snapshot().await, (true, 2, 2));
+    assert!(
+        restarted_group
+            .receive_delivery()
+            .await
+            .expect("post-ack receive should succeed")
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn decode_failure_ack_failure_is_redelivered_after_consumer_reconstruction() {
+    let payload = b"{not-valid-contract-json".to_vec();
+    let state = SharedCursorState::new(payload.clone(), 1);
+
+    let first_group = group(state.clone());
+    let first = match first_group
+        .receive_delivery()
+        .await
+        .expect("first raw receive should succeed")
+        .expect("raw delivery should exist")
+    {
+        PersistentContractDelivery::DecodeFailure(failure) => failure,
+        PersistentContractDelivery::Event(_) => panic!("invalid bytes must be decode poison"),
+    };
+    let delivery_id = first.delivery_id();
+    let stable_error_code = first.stable_error_code();
+    assert_eq!(first.offset(), OFFSET);
+    assert_eq!(first.raw_payload(), payload.as_slice());
+    assert!(
+        first_group
+            .acknowledge_decode_failure(&first)
+            .await
+            .is_err()
+    );
+    assert_eq!(state.snapshot().await, (false, 1, 1));
+    drop(first_group);
+
+    let restarted_group = group(state.clone());
+    let redelivery = match restarted_group
+        .receive_delivery()
+        .await
+        .expect("restart raw receive should succeed")
+        .expect("uncommitted raw delivery should be redelivered")
+    {
+        PersistentContractDelivery::DecodeFailure(failure) => failure,
+        PersistentContractDelivery::Event(_) => {
+            panic!("redelivered invalid bytes must remain decode poison")
+        }
+    };
+    assert_eq!(redelivery.delivery_id(), delivery_id);
+    assert_eq!(redelivery.stable_error_code(), stable_error_code);
+    assert_eq!(redelivery.offset(), OFFSET);
+    assert_eq!(redelivery.raw_payload(), payload.as_slice());
+    restarted_group
+        .acknowledge_decode_failure(&redelivery)
+        .await
+        .expect("restarted consumer should commit the poison offset");
+    assert_eq!(state.snapshot().await, (true, 2, 2));
+    assert!(
+        restarted_group
+            .receive_delivery()
+            .await
+            .expect("post-poison-ack receive should succeed")
+            .is_none()
+    );
+}

--- a/crates/rustok-search/tests/forum_contract_ingress_postgres_test.rs
+++ b/crates/rustok-search/tests/forum_contract_ingress_postgres_test.rs
@@ -1,0 +1,398 @@
+use std::error::Error;
+
+use chrono::Utc;
+use rustok_core::MigrationSource;
+use rustok_events::{
+    ContractEventEnvelope, DomainEvent, EventEnvelope, ForumSearchProjectionEvent,
+};
+use rustok_search::{
+    ForumSearchContractIngress, ForumSearchContractIngressError,
+    ForumSearchContractIngressOutcome, SearchModule,
+};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
+    Value as SqlValue,
+};
+use sea_orm_migration::SchemaManager;
+use serde_json::Value as JsonValue;
+use uuid::Uuid;
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+const SEARCH_TEST_DATABASE_ENV: &str = "RUSTOK_SEARCH_TEST_DATABASE_URL";
+const ROOT_EVENT_TYPE: &str = "index.reindex_requested";
+const FORUM_SOURCE_MODULE: &str = "forum";
+
+struct PostgresSearchTestDb {
+    control: DatabaseConnection,
+    db: DatabaseConnection,
+    schema_name: String,
+}
+
+impl PostgresSearchTestDb {
+    async fn setup(prefix: &str) -> TestResult<Option<Self>> {
+        let Some(database_url) = postgres_database_url() else {
+            eprintln!(
+                "{SEARCH_TEST_DATABASE_ENV} is not set to a PostgreSQL URL; skipping Forum versioned invalidation ingress evidence"
+            );
+            return Ok(None);
+        };
+
+        let control = connect(&database_url).await?;
+        let schema_name = format!(
+            "rustok_search_{}_{}",
+            sanitize_identifier(prefix),
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let db = connect(&database_url).await?;
+        set_search_path(&db, &schema_name).await?;
+
+        let setup_result = async {
+            let manager = SchemaManager::new(&db);
+            for migration in SearchModule.migrations() {
+                migration.up(&manager).await?;
+            }
+            Ok::<(), sea_orm::DbErr>(())
+        }
+        .await;
+
+        if let Err(error) = setup_result {
+            let _ = control
+                .execute_unprepared(&format!(r#"DROP SCHEMA IF EXISTS "{schema_name}" CASCADE"#))
+                .await;
+            return Err(error.into());
+        }
+
+        Ok(Some(Self {
+            control,
+            db,
+            schema_name,
+        }))
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InboxSnapshot {
+    tenant_id: Uuid,
+    source_module: String,
+    scope_key: String,
+    event_type: String,
+    ingest_sequence: i64,
+    envelope_json: JsonValue,
+}
+
+#[tokio::test]
+async fn legacy_first_then_typed_restart_reuses_one_exact_root_row() -> TestResult<()> {
+    let Some(test_db) = PostgresSearchTestDb::setup("forum_contract_legacy_first").await? else {
+        return Ok(());
+    };
+
+    let tenant_id = Uuid::new_v4();
+    let root_event_id = Uuid::new_v4();
+    let category_id = Uuid::new_v4();
+    let owner_revision = 9_000_001_i64;
+    let target_type = "forum_category";
+    let target_id = Some(category_id);
+    let scope_key = format!("forum_category:{category_id}");
+    let root = legacy_root_envelope(tenant_id, root_event_id, target_type, target_id)?;
+    insert_legacy_root(&test_db.db, &root, &scope_key).await?;
+    let before = load_snapshot(&test_db.db, root_event_id).await?;
+
+    let typed = typed_invalidation(
+        tenant_id,
+        root_event_id,
+        owner_revision,
+        target_type,
+        target_id,
+    )?;
+    let first = ForumSearchContractIngress::new(test_db.db.clone())
+        .ingest(&typed)
+        .await?;
+    assert_eq!(
+        first,
+        ForumSearchContractIngressOutcome::DurablyAccepted {
+            root_event_id,
+            owner_revision,
+        }
+    );
+
+    let after_first = load_snapshot(&test_db.db, root_event_id).await?;
+    assert_eq!(after_first, before);
+    assert_eq!(count_root_rows(&test_db.db, root_event_id).await?, 1);
+
+    let restarted = ForumSearchContractIngress::new(test_db.db.clone());
+    let redelivery = restarted.ingest(&typed).await?;
+    assert_eq!(redelivery, first);
+    assert_eq!(load_snapshot(&test_db.db, root_event_id).await?, before);
+    assert_eq!(count_root_rows(&test_db.db, root_event_id).await?, 1);
+
+    test_db.cleanup().await
+}
+
+#[tokio::test]
+async fn typed_first_then_legacy_delivery_keeps_search_owned_sequence() -> TestResult<()> {
+    let Some(test_db) = PostgresSearchTestDb::setup("forum_contract_typed_first").await? else {
+        return Ok(());
+    };
+
+    let tenant_id = Uuid::new_v4();
+    let root_event_id = Uuid::new_v4();
+    let owner_revision = 8_000_003_i64;
+    let target_type = "forum_topic";
+    let target_id = Some(Uuid::new_v4());
+    let typed = typed_invalidation(
+        tenant_id,
+        root_event_id,
+        owner_revision,
+        target_type,
+        target_id,
+    )?;
+
+    let accepted = ForumSearchContractIngress::new(test_db.db.clone())
+        .ingest(&typed)
+        .await?;
+    assert!(matches!(
+        accepted,
+        ForumSearchContractIngressOutcome::DurablyAccepted {
+            root_event_id: accepted_id,
+            owner_revision: accepted_revision,
+        } if accepted_id == root_event_id && accepted_revision == owner_revision
+    ));
+
+    let typed_first = load_snapshot(&test_db.db, root_event_id).await?;
+    assert_eq!(typed_first.source_module, FORUM_SOURCE_MODULE);
+    assert_eq!(typed_first.scope_key, "forum");
+    assert_eq!(typed_first.event_type, ROOT_EVENT_TYPE);
+    assert!(typed_first.ingest_sequence > 0);
+    assert_ne!(typed_first.ingest_sequence, owner_revision);
+
+    let root = legacy_root_envelope(tenant_id, root_event_id, target_type, target_id)?;
+    insert_legacy_root(&test_db.db, &root, "forum").await?;
+    assert_eq!(load_snapshot(&test_db.db, root_event_id).await?, typed_first);
+    assert_eq!(count_root_rows(&test_db.db, root_event_id).await?, 1);
+
+    let restarted = ForumSearchContractIngress::new(test_db.db.clone());
+    restarted.ingest(&typed).await?;
+    assert_eq!(load_snapshot(&test_db.db, root_event_id).await?, typed_first);
+
+    test_db.cleanup().await
+}
+
+#[tokio::test]
+async fn conflicting_legacy_identity_is_non_retryable_semantic_poison() -> TestResult<()> {
+    let Some(test_db) = PostgresSearchTestDb::setup("forum_contract_conflict").await? else {
+        return Ok(());
+    };
+
+    let tenant_id = Uuid::new_v4();
+    let root_event_id = Uuid::new_v4();
+    let requested_category_id = Uuid::new_v4();
+    let conflicting_category_id = Uuid::new_v4();
+    let conflicting_root = legacy_root_envelope(
+        tenant_id,
+        root_event_id,
+        "forum_category",
+        Some(conflicting_category_id),
+    )?;
+    insert_legacy_root(
+        &test_db.db,
+        &conflicting_root,
+        &format!("forum_category:{conflicting_category_id}"),
+    )
+    .await?;
+    let before = load_snapshot(&test_db.db, root_event_id).await?;
+
+    let typed = typed_invalidation(
+        tenant_id,
+        root_event_id,
+        42,
+        "forum_category",
+        Some(requested_category_id),
+    )?;
+    let error = ForumSearchContractIngress::new(test_db.db.clone())
+        .ingest(&typed)
+        .await
+        .expect_err("conflicting root identity must fail closed");
+    assert_eq!(error, ForumSearchContractIngressError::InboxIdentityConflict);
+    assert_eq!(
+        error.stable_code(),
+        "forum.search_projection.contract_inbox_identity_conflict"
+    );
+    assert!(!error.is_retryable());
+    assert_eq!(load_snapshot(&test_db.db, root_event_id).await?, before);
+    assert_eq!(count_root_rows(&test_db.db, root_event_id).await?, 1);
+
+    test_db.cleanup().await
+}
+
+fn typed_invalidation(
+    tenant_id: Uuid,
+    root_event_id: Uuid,
+    owner_revision: i64,
+    target_type: &str,
+    target_id: Option<Uuid>,
+) -> TestResult<ContractEventEnvelope> {
+    Ok(ContractEventEnvelope::new_caused_by(
+        tenant_id,
+        None,
+        root_event_id,
+        ForumSearchProjectionEvent::InvalidationIssued {
+            owner_revision,
+            target_type: target_type.to_string(),
+            target_id,
+        },
+    )?)
+}
+
+fn legacy_root_envelope(
+    tenant_id: Uuid,
+    root_event_id: Uuid,
+    target_type: &str,
+    target_id: Option<Uuid>,
+) -> TestResult<EventEnvelope> {
+    let envelope = EventEnvelope {
+        id: root_event_id,
+        event_type: ROOT_EVENT_TYPE.to_string(),
+        schema_version: 1,
+        correlation_id: root_event_id,
+        causation_id: None,
+        tenant_id,
+        trace_id: None,
+        timestamp: Utc::now(),
+        actor_id: None,
+        event: DomainEvent::ReindexRequested {
+            target_type: target_type.to_string(),
+            target_id,
+        },
+        retry_count: 0,
+    };
+    envelope.validate_registered_schema()?;
+    Ok(envelope)
+}
+
+async fn insert_legacy_root(
+    db: &DatabaseConnection,
+    envelope: &EventEnvelope,
+    scope_key: &str,
+) -> Result<(), sea_orm::DbErr> {
+    let envelope_json = serde_json::to_value(envelope)
+        .map_err(|error| sea_orm::DbErr::Custom(error.to_string()))?;
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+        INSERT INTO search_projection_inbox (
+            event_id, tenant_id, source_module, scope_key, event_type,
+            revision_at, envelope_json
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+        ON CONFLICT (event_id) DO NOTHING
+        "#,
+        vec![
+            envelope.id.into(),
+            envelope.tenant_id.into(),
+            FORUM_SOURCE_MODULE.to_string().into(),
+            scope_key.to_string().into(),
+            ROOT_EVENT_TYPE.to_string().into(),
+            envelope.timestamp.to_owned().into(),
+            SqlValue::Json(Some(Box::new(envelope_json))),
+        ],
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn load_snapshot(
+    db: &DatabaseConnection,
+    event_id: Uuid,
+) -> Result<InboxSnapshot, sea_orm::DbErr> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+            SELECT tenant_id, source_module, scope_key, event_type,
+                   ingest_sequence, envelope_json
+            FROM search_projection_inbox
+            WHERE event_id = $1
+            "#,
+            vec![event_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| sea_orm::DbErr::Custom("expected inbox row is missing".to_string()))?;
+    Ok(InboxSnapshot {
+        tenant_id: row.try_get("", "tenant_id")?,
+        source_module: row.try_get("", "source_module")?,
+        scope_key: row.try_get("", "scope_key")?,
+        event_type: row.try_get("", "event_type")?,
+        ingest_sequence: row.try_get("", "ingest_sequence")?,
+        envelope_json: row.try_get("", "envelope_json")?,
+    })
+}
+
+async fn count_root_rows(
+    db: &DatabaseConnection,
+    event_id: Uuid,
+) -> Result<i64, sea_orm::DbErr> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT COUNT(*)::bigint AS count FROM search_projection_inbox WHERE event_id = $1",
+            vec![event_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| sea_orm::DbErr::Custom("count query returned no row".to_string()))?;
+    row.try_get("", "count")
+}
+
+fn postgres_database_url() -> Option<String> {
+    std::env::var(SEARCH_TEST_DATABASE_ENV)
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn set_search_path(db: &DatabaseConnection, schema_name: &str) -> TestResult<()> {
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}", public"#))
+        .await?;
+    Ok(())
+}
+
+fn sanitize_identifier(value: &str) -> String {
+    let normalized = value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    let normalized = normalized.trim_matches('_');
+    if normalized.is_empty() {
+        "test".to_string()
+    } else {
+        normalized.to_string()
+    }
+}

--- a/scripts/verify/verify-forum-search-versioned-invalidation-d2-source-harness.mjs
+++ b/scripts/verify/verify-forum-search-versioned-invalidation-d2-source-harness.mjs
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const root = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : process.cwd();
+const failures = [];
+
+const paths = {
+  contract:
+    "crates/rustok-forum/contracts/evidence/forum-search-versioned-invalidation-d2-source-harness.json",
+  note:
+    "crates/rustok-forum/docs/forum-23b2g2b3d2-versioned-invalidation-source-evidence.md",
+  postgres:
+    "crates/rustok-search/tests/forum_contract_ingress_postgres_test.rs",
+  consumer: "crates/rustok-iggy/src/contract_consumer.rs",
+  restart: "crates/rustok-iggy/src/contract_consumer_restart_tests.rs",
+  worker: "apps/server/src/services/forum_search_contract_consumer.rs",
+  plan: "crates/rustok-forum/docs/implementation-plan.md",
+  d0:
+    "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json",
+};
+
+function target(relativePath) {
+  return path.join(root, relativePath);
+}
+
+function read(relativePath) {
+  if (!fs.existsSync(target(relativePath))) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return "";
+  }
+  return fs.readFileSync(target(relativePath), "utf8");
+}
+
+function readJson(relativePath) {
+  try {
+    return JSON.parse(read(relativePath));
+  } catch (error) {
+    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function requireAll(source, markers, label) {
+  for (const marker of markers) {
+    if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+  }
+}
+
+function rejectAll(source, markers, label) {
+  for (const marker of markers) {
+    if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+  }
+}
+
+const contract = readJson(paths.contract);
+const d0 = readJson(paths.d0);
+const note = read(paths.note);
+const postgres = read(paths.postgres);
+const consumer = read(paths.consumer);
+const restart = read(paths.restart);
+const worker = read(paths.worker);
+const plan = read(paths.plan);
+
+if (contract) {
+  if (
+    contract.task !== "FORUM-23B2G2B3D2" ||
+    contract.status !== "source_ready_maintainer_execution_pending"
+  ) {
+    failures.push(`${paths.contract}: task or status drift`);
+  }
+  if (
+    contract.postgresql_ingress?.test_target !== paths.postgres ||
+    contract.postgresql_ingress?.real_search_module_migrations !== true ||
+    contract.postgresql_ingress?.single_root_row !== true ||
+    contract.postgresql_ingress?.first_ingest_sequence_retained !== true ||
+    contract.postgresql_ingress?.owner_revision_is_not_ingest_sequence !== true ||
+    contract.postgresql_ingress
+      ?.identity_conflict_is_non_retryable_semantic_poison !== true
+  ) {
+    failures.push(`${paths.contract}: PostgreSQL evidence boundary drift`);
+  }
+  if (
+    contract.persistent_cursor_restart?.source_target !== paths.restart ||
+    contract.persistent_cursor_restart
+      ?.event_ack_failure_leaves_offset_uncommitted !== true ||
+    contract.persistent_cursor_restart
+      ?.event_redelivery_after_group_reconstruction !== true ||
+    contract.persistent_cursor_restart
+      ?.decode_failure_ack_failure_leaves_offset_uncommitted !== true ||
+    contract.persistent_cursor_restart
+      ?.decode_failure_redelivery_after_group_reconstruction !== true ||
+    contract.persistent_cursor_restart
+      ?.successful_restarted_ack_commits_exact_offset !== true
+  ) {
+    failures.push(`${paths.contract}: persistent cursor restart boundary drift`);
+  }
+  if (
+    contract.single_execution_path?.search_inbox !==
+      "search_projection_inbox" ||
+    contract.single_execution_path?.second_inbox !== false ||
+    contract.single_execution_path?.second_projector !== false ||
+    contract.single_execution_path?.second_reconciler !== false ||
+    contract.single_execution_path?.second_ordering_clock !== false
+  ) {
+    failures.push(`${paths.contract}: single execution path drift`);
+  }
+  if (contract.follow_up?.task !== "FORUM-23B2G2B3D3") {
+    failures.push(`${paths.contract}: bounded follow-up drift`);
+  }
+}
+
+if (
+  d0?.task !== "FORUM-23B2G2B3D0" ||
+  d0?.status !== "source_ready_maintainer_execution_pending"
+) {
+  failures.push(`${paths.d0}: accepted runtime protocol drift`);
+}
+
+requireAll(
+  note,
+  [
+    "# FORUM-23B2G2B3D2 versioned invalidation source evidence",
+    "source_ready_maintainer_execution_pending",
+    "forum_contract_ingress_postgres_test.rs",
+    "contract_consumer_restart_tests.rs",
+    "exact offset to remain uncommitted",
+    "FORUM-23B2G2B3D3",
+    "These commands were not run",
+  ],
+  paths.note,
+);
+
+requireAll(
+  postgres,
+  [
+    "RUSTOK_SEARCH_TEST_DATABASE_URL",
+    "for migration in SearchModule.migrations()",
+    "legacy_first_then_typed_restart_reuses_one_exact_root_row",
+    "typed_first_then_legacy_delivery_keeps_search_owned_sequence",
+    "conflicting_legacy_identity_is_non_retryable_semantic_poison",
+    "ForumSearchContractIngress::new",
+    "ON CONFLICT (event_id) DO NOTHING",
+    "assert_ne!(typed_first.ingest_sequence, owner_revision)",
+    "forum.search_projection.contract_inbox_identity_conflict",
+    "DROP SCHEMA IF EXISTS",
+  ],
+  paths.postgres,
+);
+rejectAll(
+  postgres,
+  ["tokio::time::sleep", "std::thread::sleep", "loop {"],
+  `${paths.postgres} deterministic boundary`,
+);
+
+requireAll(
+  consumer,
+  [
+    "pub struct PersistentContractConsumerGroup",
+    "pub async fn acknowledge(",
+    "pub async fn acknowledge_decode_failure(",
+    "#[path = \"contract_consumer_restart_tests.rs\"]",
+    "mod restart_tests;",
+  ],
+  paths.consumer,
+);
+
+requireAll(
+  restart,
+  [
+    "struct RestartableCursor",
+    "impl ConsumerCursor for RestartableCursor",
+    "injected acknowledgement failure",
+    "event_ack_failure_is_redelivered_after_consumer_reconstruction",
+    "decode_failure_ack_failure_is_redelivered_after_consumer_reconstruction",
+    "assert_eq!(state.snapshot().await, (false, 1, 1))",
+    "assert_eq!(state.snapshot().await, (true, 2, 2))",
+    "redelivery.raw_payload()",
+    "redelivery.delivery_id()",
+  ],
+  paths.restart,
+);
+rejectAll(
+  restart,
+  ["tokio::time::sleep", "std::thread::sleep"],
+  `${paths.restart} deterministic boundary`,
+);
+
+requireAll(
+  worker,
+  [
+    "ForumSearchContractIngressOutcome::DurablyAccepted",
+    "if !acknowledge_event(group, config, stop_rx, &consumed).await",
+    "broker acknowledgement failed; redelivery will recognize the durable inbox row",
+    "raw poison acknowledgement failed; redelivery will recognize the durable receipt",
+  ],
+  `${paths.worker} production acknowledgement order`,
+);
+
+requireAll(
+  plan,
+  [
+    "| `FORUM-23` | `in_progress` |",
+    "FORUM-23B2G2B3D0 freezes executable runtime evidence",
+    "FORUM-23B2G2B3D1 reconciles this canonical plan",
+    "maintainer PostgreSQL/Iggy plus LINK-FORUM-03 runtime evidence remain",
+  ],
+  paths.plan,
+);
+
+for (const source of [contract ? JSON.stringify(contract) : "", note, postgres, restart]) {
+  rejectAll(
+    source,
+    [
+      "create_forum_search_contract_inbox",
+      "second Search inbox",
+      "second Forum Search projector",
+      "LINK-FORUM-03 closed",
+      "runtime_evidence_complete",
+    ],
+    "D2 non-claim boundary",
+  );
+}
+
+if (failures.length > 0) {
+  console.error("Forum Search D2 source evidence verification failed:\n");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Forum Search D2 source evidence contract verified.");


### PR DESCRIPTION
## Summary

- continue the canonical Forum Search evidence chain after merged `FORUM-23B2G2B3D0` and plan reconciliation `FORUM-23B2G2B3D1`
- supersede draft #2759, whose PostgreSQL test blob contains invalid UTF-8 after its first valid section and whose D1 task number is now owned by merged PR #2761
- reconstruct the PostgreSQL ingress harness as clean UTF-8 under `FORUM-23B2G2B3D2`
- retain legacy-first and typed-first one-inbox admission, Search-owned ingest-sequence retention, reconstructed ingress redelivery, and exact non-retryable identity-conflict evidence
- add a crate-local `PersistentContractConsumerGroup` reconstruction proof for valid contract events and raw decode failures
- inject one acknowledgement failure, require the offset to remain uncommitted, reconstruct the consumer group, receive the same bytes/offset/identity, commit the exact position, and require no later delivery
- add a D2 machine-readable source record, focused handoff and fail-closed source verifier

## Rechecked baseline

Current `main` already contains:

- owner revision ledger and hardening
- bounded owner source plus Search checkpoint/repair protocol
- caused sealed invalidation event and atomic legacy/typed publisher
- default-off persistent one-inbox consumer
- D0 executable runtime-evidence protocol
- D1 canonical plan reconciliation through PR #2761

`FORUM-23` remains `in_progress`, and `LINK-FORUM-03` remains open until maintainer-executed PostgreSQL/Iggy and cross-module runtime evidence exists.

## PostgreSQL source evidence

`crates/rustok-search/tests/forum_contract_ingress_postgres_test.rs`:

- uses every real `SearchModule` migration in a unique PostgreSQL schema per case
- covers legacy-first then typed delivery and typed-first then legacy delivery
- reconstructs `ForumSearchContractIngress` before redelivery
- requires exactly one retained root inbox row
- requires the first positive Search-owned `ingest_sequence` to remain unchanged
- proves Forum `owner_revision` is not used as Search `ingest_sequence`
- treats a conflicting retained root UUID as stable non-retryable semantic poison without rewriting the row
- uses no sleep, polling, broker mock or production migration

## Persistent cursor reconstruction evidence

The production contract-consumer implementation now includes a crate-local test module. A deterministic shared cursor is opened through two separately constructed `PersistentContractConsumerGroup` instances.

For both a valid contract event and undecodable raw bytes, the source proof requires:

1. first receive returns exact bytes and connector position;
2. injected acknowledgement failure leaves the position uncommitted;
3. the first group is dropped;
4. a new group receives the same bytes, offset and stable identity;
5. successful acknowledgement commits that exact position;
6. no delivery remains after commit.

This is a transport ownership proof. It does not claim an external Iggy process or server-worker restart.

## Remaining D0 evidence

The next bounded source slice is `FORUM-23B2G2B3D3`, covering connector-owned durable poison receipts, deterministic DLQ publication, acknowledgement failure and redelivery.

Still unclaimed:

- successful PostgreSQL or external Iggy execution
- server-worker restart
- raw/semantic poison receipt and DLQ runtime evidence
- DLQ duplicate suppression
- owner-checkpoint missing-delivery repair
- multi-process serialization
- deletion/ACL/Search-disabled correlation
- `LINK-FORUM-03` closure

## Compatibility

- no production migration
- no event schema or digest change
- no runtime flag, broker topic or consumer-group change
- no public API or Search query change
- no second inbox, projector, reconciler or ordering clock
- no dependency or `Cargo.lock` change

## Validation

Not run per maintainer instruction:

- Rust tests
- source verifiers
- formatting
- Cargo checks or Clippy
- PostgreSQL or Iggy runtime execution
- CI workflows

Suggested maintainer commands:

```bash
RUSTOK_SEARCH_TEST_DATABASE_URL=postgresql://... \
  cargo test -p rustok-search \
  --test forum_contract_ingress_postgres_test \
  -- --nocapture --test-threads=1

cargo test -p rustok-iggy contract_consumer::restart_tests -- --nocapture
cargo check -p rustok-search --all-targets
cargo check -p rustok-iggy --all-targets
node scripts/verify/verify-forum-search-versioned-invalidation-d2-source-harness.mjs
node scripts/verify/verify-forum-search-versioned-invalidation-runtime-evidence.mjs
cargo xtask module validate forum
cargo xtask module validate search
```

No executable runtime evidence artifact was generated. Squash merge is recommended after maintainer validation.