### PR TITLE
test(forum): add PostgreSQL versioned ingress proof

### DIFF
--- a/crates/rustok-forum/contracts/forum-search-versioned-invalidation-postgres-ingress-proof.json
+++ b/crates/rustok-forum/contracts/forum-search-versioned-invalidation-postgres-ingress-proof.json
@@ -1,0 +1,68 @@
+{
+  "contract": "forum_search_versioned_invalidation_postgres_ingress_proof_v1",
+  "task": "FORUM-23B2G2B3D2",
+  "status": "source_ready_maintainer_execution_pending",
+  "runtime_evidence_parent": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json",
+  "test": "crates/rustok-search/tests/forum_versioned_invalidation_postgres.rs",
+  "evidence_artifact": {
+    "path": "target/forum-search-versioned-invalidation-postgres-ingress-evidence.json",
+    "generation": "executable_test_only",
+    "hand_editing_forbidden": true,
+    "source_commit_required": true
+  },
+  "required_runtime": {
+    "database": "postgresql",
+    "database_env": "RUSTOK_SEARCH_TEST_DATABASE_URL",
+    "migrations": "rustok_search::SearchModule",
+    "broker_required": false
+  },
+  "scenarios": [
+    {
+      "id": "typed_ingress_admission",
+      "proves": [
+        "a caused typed invalidation creates one durable shared Search inbox row",
+        "the inbox event identity is the exact legacy root causation id",
+        "the typed envelope id is not used as a projection identity",
+        "the allocated Search ingest sequence is positive"
+      ]
+    },
+    {
+      "id": "legacy_first_duplicate",
+      "proves": [
+        "a pre-existing exact legacy root row is recognized as the durable duplicate",
+        "typed admission does not allocate a second inbox row or ingest sequence",
+        "the original durable root envelope remains unchanged"
+      ]
+    },
+    {
+      "id": "typed_first_duplicate",
+      "proves": [
+        "typed admission may create the shared row before legacy delivery",
+        "later legacy delivery collapses through the event_id uniqueness boundary",
+        "the typed-created durable row and ingest sequence remain unchanged"
+      ]
+    },
+    {
+      "id": "semantic_identity_conflict",
+      "proves": [
+        "a UUID collision with different tenant/scope/root payload identity fails closed",
+        "the stable code is forum.search_projection.contract_inbox_identity_conflict",
+        "the conflicting durable row is not replaced or duplicated"
+      ]
+    }
+  ],
+  "identity_invariants": [
+    "ContractEventEnvelope.causation_id equals search_projection_inbox.event_id",
+    "search_projection_inbox.event_type remains index.reindex_requested",
+    "one event_id has one positive ingest_sequence",
+    "duplicate recognition validates complete durable identity rather than UUID alone"
+  ],
+  "maintainer_command": "RUSTOK_SEARCH_TEST_DATABASE_URL=\"$DATABASE_URL\" cargo test -p rustok-search --test forum_versioned_invalidation_postgres -- --nocapture --test-threads=1",
+  "non_claims": [
+    "this slice does not start Iggy or the server persistent consumer loop",
+    "this slice does not prove source acknowledgement, restart or cursor persistence",
+    "this slice does not prove poison receipts or DLQ publication",
+    "this slice does not run the projector or advance the owner checkpoint",
+    "this slice does not close FORUM-23B2G2B3D or LINK-FORUM-03"
+  ]
+}

--- a/crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json
+++ b/crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json
@@ -16,6 +16,26 @@
     "runtime_evidence_protocol": "FORUM-23B2G2B3D0",
     "canonical_plan_sync": "FORUM-23B2G2B3D1"
   },
+  "source_ready_subproofs": [
+    {
+      "task": "FORUM-23B2G2B3D2",
+      "contract": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-postgres-ingress-proof.json",
+      "test": "crates/rustok-search/tests/forum_versioned_invalidation_postgres.rs",
+      "evidence_artifact": "target/forum-search-versioned-invalidation-postgres-ingress-evidence.json",
+      "covers": [
+        "typed_ingress_admission",
+        "legacy_first_duplicate",
+        "typed_first_duplicate",
+        "semantic_identity_conflict_classification"
+      ],
+      "does_not_cover": [
+        "broker_acknowledgement_or_restart",
+        "poison_receipt_or_dlq_publication",
+        "projector_or_owner_checkpoint",
+        "multi_process_or_visibility_end_to_end"
+      ]
+    }
+  ],
   "required_runtime": {
     "database": "postgresql",
     "delivery_profile": "outbox_iggy",
@@ -139,6 +159,8 @@
   },
   "maintainer_commands": [
     "node scripts/verify/verify-forum-search-versioned-invalidation-runtime-evidence.mjs",
+    "node scripts/verify/verify-forum-search-versioned-invalidation-postgres-ingress-proof.mjs",
+    "RUSTOK_SEARCH_TEST_DATABASE_URL=\"$DATABASE_URL\" cargo test -p rustok-search --test forum_versioned_invalidation_postgres -- --nocapture --test-threads=1",
     "cargo run -p rustok-events --example event_contract_digests",
     "cargo test -p rustok-events",
     "cargo test -p rustok-search forum_contract_ingress -- --nocapture",

--- a/crates/rustok-forum/docs/forum-23b2g2b3d2-postgres-ingress-proof.md
+++ b/crates/rustok-forum/docs/forum-23b2g2b3d2-postgres-ingress-proof.md
@@ -1,0 +1,94 @@
+# FORUM-23B2G2B3D2 PostgreSQL shared-inbox proof
+
+## Status
+
+`source_ready_maintainer_execution_pending`
+
+This slice adds the first executable subset of the
+`FORUM-23B2G2B3D` runtime-evidence matrix. It exercises the Search-owned
+PostgreSQL ingress boundary directly and generates a retained JSON evidence
+artifact after all covered scenarios pass.
+
+The machine-readable proof contract is:
+
+```text
+crates/rustok-forum/contracts/forum-search-versioned-invalidation-postgres-ingress-proof.json
+```
+
+The executable test is:
+
+```text
+crates/rustok-search/tests/forum_versioned_invalidation_postgres.rs
+```
+
+## Covered scenarios
+
+The test creates an isolated PostgreSQL schema, applies the real `SearchModule`
+migrations and covers four durable-admission cases:
+
+1. a causation-bound typed invalidation creates one shared inbox row keyed by the
+   exact legacy root ID and receives one positive Search `ingest_sequence`;
+2. legacy-first delivery is recognized as an exact durable duplicate without
+   replacing the root envelope or allocating a second sequence;
+3. typed-first delivery remains the one durable row when the legacy root arrives
+   later through the same `ON CONFLICT (event_id) DO NOTHING` boundary;
+4. a colliding root ID with different tenant, scope and payload identity fails
+   with `forum.search_projection.contract_inbox_identity_conflict` and leaves the
+   conflicting row unchanged.
+
+The proof compares complete stored root-envelope identity, not UUID alone. The
+typed transport envelope ID is recorded separately and must differ from the
+shared projection identity.
+
+## Generated evidence
+
+After all scenarios pass and the isolated schema is cleaned up, the test writes:
+
+```text
+target/forum-search-versioned-invalidation-postgres-ingress-evidence.json
+```
+
+The artifact records the exact `git rev-parse HEAD` source commit, generation
+time, PostgreSQL backend, scenario results, tenant/root/typed IDs, scope keys,
+positive ingest sequences, row counts and the stable conflict code. It is test
+output and must not be hand-edited or committed as a static fixture.
+
+If no PostgreSQL URL is configured, the test follows the repository's existing
+PostgreSQL test convention and skips without generating evidence.
+
+## Deliberate boundary
+
+D2 proves Search durable ingress and duplicate identity only. It does not start
+Iggy or the server worker and therefore does not claim:
+
+- source acknowledgement or persistent cursor restart;
+- connector-owned poison receipts or deterministic DLQ publication;
+- projection execution or owner-checkpoint advancement;
+- missing-delivery repair, multi-process advisory-lock serialization,
+  deletion/ACL ordering or Search-disabled recovery;
+- completion of `FORUM-23B2G2B3D` or `LINK-FORUM-03`.
+
+Those scenarios remain separate executable follow-up slices. This separation
+prevents a PostgreSQL adapter test from being presented as broker or end-to-end
+evidence.
+
+## Compatibility and degraded mode
+
+No production Rust path, migration, event schema, digest, public DTO, Search
+query, broker configuration, dependency or `Cargo.lock` entry changes. The
+legacy root remains mandatory, the typed consumer remains default-off and
+SQLite remains validation-only for this persistent ingress boundary.
+
+## Maintainer verification
+
+```bash
+RUSTOK_SEARCH_TEST_DATABASE_URL="$DATABASE_URL" \
+  cargo test -p rustok-search --test forum_versioned_invalidation_postgres \
+  -- --nocapture --test-threads=1
+node scripts/verify/verify-forum-search-versioned-invalidation-postgres-ingress-proof.mjs
+cargo xtask module validate forum
+cargo xtask module validate search
+git diff --check
+```
+
+No command above was run by the implementation agent, per maintainer request.

--- a/crates/rustok-search/tests/forum_versioned_invalidation_postgres.rs
+++ b/crates/rustok-search/tests/forum_versioned_invalidation_postgres.rs
@@ -1,0 +1,634 @@
+use std::error::Error;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use chrono::Utc;
+use rustok_core::MigrationSource;
+use rustok_events::{
+    ContractEventEnvelope, DomainEvent, EventEnvelope, ForumSearchProjectionEvent,
+};
+use rustok_search::{
+    ForumSearchContractIngress, ForumSearchContractIngressError,
+    ForumSearchContractIngressOutcome, SearchModule,
+};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
+    Value as SqlValue,
+};
+use sea_orm_migration::SchemaManager;
+use serde::Serialize;
+use serde_json::{Value as JsonValue, json};
+use uuid::Uuid;
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+const SEARCH_TEST_DATABASE_ENV: &str = "RUSTOK_SEARCH_TEST_DATABASE_URL";
+const ROOT_EVENT_TYPE: &str = "index.reindex_requested";
+const EVIDENCE_CONTRACT: &str =
+    "forum_search_versioned_invalidation_postgres_ingress_evidence_v1";
+const EVIDENCE_PATH: &str =
+    "target/forum-search-versioned-invalidation-postgres-ingress-evidence.json";
+
+struct PostgresSearchTestDb {
+    control: DatabaseConnection,
+    db: DatabaseConnection,
+    schema_name: String,
+}
+
+impl PostgresSearchTestDb {
+    async fn setup(prefix: &str) -> TestResult<Option<Self>> {
+        let Some(database_url) = postgres_database_url() else {
+            eprintln!(
+                "{SEARCH_TEST_DATABASE_ENV} is not set to a PostgreSQL URL; skipping Forum versioned invalidation ingress proof"
+            );
+            return Ok(None);
+        };
+
+        let control = connect(&database_url).await?;
+        let schema_name = format!(
+            "rustok_search_{}_{}",
+            sanitize_identifier(prefix),
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let db = connect(&database_url).await?;
+        set_search_path(&db, &schema_name).await?;
+        let setup_result = async {
+            let manager = SchemaManager::new(&db);
+            for migration in SearchModule.migrations() {
+                migration.up(&manager).await?;
+            }
+            Ok::<(), sea_orm::DbErr>(())
+        }
+        .await;
+
+        if let Err(error) = setup_result {
+            let _ = control
+                .execute_unprepared(&format!(r#"DROP SCHEMA IF EXISTS "{schema_name}" CASCADE"#))
+                .await;
+            return Err(error.into());
+        }
+
+        Ok(Some(Self {
+            control,
+            db,
+            schema_name,
+        }))
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+struct InboxSnapshot {
+    event_id: Uuid,
+    tenant_id: Uuid,
+    source_module: String,
+    scope_key: String,
+    event_type: String,
+    ingest_sequence: i64,
+    envelope_json: JsonValue,
+}
+
+#[derive(Debug, Serialize)]
+struct ScenarioEvidence {
+    id: &'static str,
+    result: &'static str,
+    facts: JsonValue,
+}
+
+#[derive(Debug, Serialize)]
+struct IngressEvidenceArtifact {
+    contract: &'static str,
+    task: &'static str,
+    source_commit: String,
+    generated_at: String,
+    database_backend: &'static str,
+    broker_used: bool,
+    scenario_results: Vec<ScenarioEvidence>,
+}
+
+#[tokio::test]
+async fn versioned_forum_invalidation_converges_on_one_postgres_inbox_identity() -> TestResult<()> {
+    let Some(test_db) = PostgresSearchTestDb::setup("forum_versioned_ingress").await? else {
+        return Ok(());
+    };
+
+    let proof = run_ingress_proof(&test_db.db).await;
+    let cleanup = test_db.cleanup().await;
+    let scenarios = proof?;
+    cleanup?;
+
+    write_evidence(IngressEvidenceArtifact {
+        contract: EVIDENCE_CONTRACT,
+        task: "FORUM-23B2G2B3D2",
+        source_commit: source_commit()?,
+        generated_at: Utc::now().to_rfc3339(),
+        database_backend: "postgresql",
+        broker_used: false,
+        scenario_results: scenarios,
+    })?;
+
+    Ok(())
+}
+
+async fn run_ingress_proof(db: &DatabaseConnection) -> TestResult<Vec<ScenarioEvidence>> {
+    let mut scenarios = Vec::new();
+
+    let typed_tenant_id = Uuid::new_v4();
+    let typed_root_id = Uuid::new_v4();
+    let typed_category_id = Uuid::new_v4();
+    let typed = typed_invalidation(
+        typed_tenant_id,
+        typed_root_id,
+        1,
+        "forum_category",
+        Some(typed_category_id),
+    )?;
+    let typed_envelope_id = typed.id();
+    if typed.causation_id() != Some(typed_root_id) {
+        return Err(test_error(
+            "typed invalidation must retain the exact legacy root causation ID",
+        ));
+    }
+    let outcome = ForumSearchContractIngress::new(db.clone())
+        .ingest(&typed)
+        .await?;
+    ensure_durable_outcome(outcome, typed_root_id, 1)?;
+    let typed_snapshot = load_snapshot(db, typed_root_id).await?;
+    ensure_snapshot(
+        &typed_snapshot,
+        typed_tenant_id,
+        typed_root_id,
+        &format!("forum_category:{typed_category_id}"),
+        "forum_category",
+        Some(typed_category_id),
+    )?;
+    if typed_envelope_id == typed_root_id {
+        return Err(test_error(
+            "typed transport envelope ID must differ from the root projection identity",
+        ));
+    }
+    if count_event_rows(db, typed_root_id).await? != 1 {
+        return Err(test_error(
+            "typed ingress must create exactly one durable inbox row",
+        ));
+    }
+    scenarios.push(ScenarioEvidence {
+        id: "typed_ingress_admission",
+        result: "passed",
+        facts: json!({
+            "tenant_id": typed_tenant_id,
+            "root_event_id": typed_root_id,
+            "typed_envelope_id": typed_envelope_id,
+            "owner_revision": 1,
+            "scope_key": typed_snapshot.scope_key,
+            "ingest_sequence": typed_snapshot.ingest_sequence,
+            "inbox_rows": 1
+        }),
+    });
+
+    let legacy_first_tenant_id = Uuid::new_v4();
+    let legacy_first_root_id = Uuid::new_v4();
+    let legacy_first_category_id = Uuid::new_v4();
+    let legacy_first_root = root_envelope(
+        legacy_first_tenant_id,
+        legacy_first_root_id,
+        "forum_category",
+        Some(legacy_first_category_id),
+    );
+    insert_legacy_root(
+        db,
+        &legacy_first_root,
+        &format!("forum_category:{legacy_first_category_id}"),
+    )
+    .await?;
+    let legacy_first_before = load_snapshot(db, legacy_first_root_id).await?;
+    ensure_snapshot(
+        &legacy_first_before,
+        legacy_first_tenant_id,
+        legacy_first_root_id,
+        &format!("forum_category:{legacy_first_category_id}"),
+        "forum_category",
+        Some(legacy_first_category_id),
+    )?;
+    let legacy_first_typed = typed_invalidation(
+        legacy_first_tenant_id,
+        legacy_first_root_id,
+        2,
+        "forum_category",
+        Some(legacy_first_category_id),
+    )?;
+    let outcome = ForumSearchContractIngress::new(db.clone())
+        .ingest(&legacy_first_typed)
+        .await?;
+    ensure_durable_outcome(outcome, legacy_first_root_id, 2)?;
+    let legacy_first_after = load_snapshot(db, legacy_first_root_id).await?;
+    if legacy_first_after != legacy_first_before {
+        return Err(test_error(
+            "typed duplicate must not replace the exact legacy-first durable row",
+        ));
+    }
+    if count_event_rows(db, legacy_first_root_id).await? != 1 {
+        return Err(test_error(
+            "legacy-first duplicate must retain exactly one inbox row",
+        ));
+    }
+    scenarios.push(ScenarioEvidence {
+        id: "legacy_first_duplicate",
+        result: "passed",
+        facts: json!({
+            "tenant_id": legacy_first_tenant_id,
+            "root_event_id": legacy_first_root_id,
+            "typed_envelope_id": legacy_first_typed.id(),
+            "owner_revision": 2,
+            "scope_key": legacy_first_after.scope_key,
+            "ingest_sequence_before": legacy_first_before.ingest_sequence,
+            "ingest_sequence_after": legacy_first_after.ingest_sequence,
+            "inbox_rows": 1,
+            "durable_root_preserved": true
+        }),
+    });
+
+    let typed_first_tenant_id = Uuid::new_v4();
+    let typed_first_root_id = Uuid::new_v4();
+    let typed_first_category_id = Uuid::new_v4();
+    let typed_first_typed = typed_invalidation(
+        typed_first_tenant_id,
+        typed_first_root_id,
+        3,
+        "forum_category",
+        Some(typed_first_category_id),
+    )?;
+    let outcome = ForumSearchContractIngress::new(db.clone())
+        .ingest(&typed_first_typed)
+        .await?;
+    ensure_durable_outcome(outcome, typed_first_root_id, 3)?;
+    let typed_first_before = load_snapshot(db, typed_first_root_id).await?;
+    ensure_snapshot(
+        &typed_first_before,
+        typed_first_tenant_id,
+        typed_first_root_id,
+        &format!("forum_category:{typed_first_category_id}"),
+        "forum_category",
+        Some(typed_first_category_id),
+    )?;
+    let typed_first_root = root_envelope(
+        typed_first_tenant_id,
+        typed_first_root_id,
+        "forum_category",
+        Some(typed_first_category_id),
+    );
+    insert_legacy_root(
+        db,
+        &typed_first_root,
+        &format!("forum_category:{typed_first_category_id}"),
+    )
+    .await?;
+    let typed_first_after = load_snapshot(db, typed_first_root_id).await?;
+    if typed_first_after != typed_first_before {
+        return Err(test_error(
+            "legacy duplicate must not replace the typed-first durable row",
+        ));
+    }
+    if count_event_rows(db, typed_first_root_id).await? != 1 {
+        return Err(test_error(
+            "typed-first duplicate must retain exactly one inbox row",
+        ));
+    }
+    scenarios.push(ScenarioEvidence {
+        id: "typed_first_duplicate",
+        result: "passed",
+        facts: json!({
+            "tenant_id": typed_first_tenant_id,
+            "root_event_id": typed_first_root_id,
+            "typed_envelope_id": typed_first_typed.id(),
+            "owner_revision": 3,
+            "scope_key": typed_first_after.scope_key,
+            "ingest_sequence_before": typed_first_before.ingest_sequence,
+            "ingest_sequence_after": typed_first_after.ingest_sequence,
+            "inbox_rows": 1,
+            "typed_created_row_preserved": true
+        }),
+    });
+
+    let expected_tenant_id = Uuid::new_v4();
+    let conflicting_tenant_id = Uuid::new_v4();
+    let conflict_root_id = Uuid::new_v4();
+    let conflict_category_id = Uuid::new_v4();
+    let conflicting_root = root_envelope(
+        conflicting_tenant_id,
+        conflict_root_id,
+        "forum",
+        None,
+    );
+    insert_legacy_root(db, &conflicting_root, "forum").await?;
+    let conflict_before = load_snapshot(db, conflict_root_id).await?;
+    ensure_snapshot(
+        &conflict_before,
+        conflicting_tenant_id,
+        conflict_root_id,
+        "forum",
+        "forum",
+        None,
+    )?;
+    let conflict_typed = typed_invalidation(
+        expected_tenant_id,
+        conflict_root_id,
+        4,
+        "forum_category",
+        Some(conflict_category_id),
+    )?;
+    let error = ForumSearchContractIngress::new(db.clone())
+        .ingest(&conflict_typed)
+        .await
+        .expect_err("mismatched durable identity must fail closed");
+    let stable_error_code = error.stable_code();
+    if !matches!(error, ForumSearchContractIngressError::InboxIdentityConflict)
+        || stable_error_code != "forum.search_projection.contract_inbox_identity_conflict"
+    {
+        return Err(test_error(format!(
+            "unexpected identity conflict classification: {stable_error_code}"
+        )));
+    }
+    let conflict_after = load_snapshot(db, conflict_root_id).await?;
+    if conflict_after != conflict_before || count_event_rows(db, conflict_root_id).await? != 1 {
+        return Err(test_error(
+            "semantic identity conflict must not replace or duplicate the durable row",
+        ));
+    }
+    scenarios.push(ScenarioEvidence {
+        id: "semantic_identity_conflict",
+        result: "passed",
+        facts: json!({
+            "expected_tenant_id": expected_tenant_id,
+            "durable_tenant_id": conflicting_tenant_id,
+            "root_event_id": conflict_root_id,
+            "typed_envelope_id": conflict_typed.id(),
+            "owner_revision": 4,
+            "durable_scope_key": conflict_after.scope_key,
+            "requested_scope_key": format!("forum_category:{conflict_category_id}"),
+            "ingest_sequence": conflict_after.ingest_sequence,
+            "inbox_rows": 1,
+            "stable_error_code": stable_error_code,
+            "durable_row_preserved": true
+        }),
+    });
+
+    Ok(scenarios)
+}
+
+fn typed_invalidation(
+    tenant_id: Uuid,
+    root_event_id: Uuid,
+    owner_revision: i64,
+    target_type: &str,
+    target_id: Option<Uuid>,
+) -> TestResult<ContractEventEnvelope> {
+    Ok(ContractEventEnvelope::new_caused_by(
+        tenant_id,
+        None,
+        root_event_id,
+        ForumSearchProjectionEvent::InvalidationIssued {
+            owner_revision,
+            target_type: target_type.to_string(),
+            target_id,
+        },
+    )?)
+}
+
+fn root_envelope(
+    tenant_id: Uuid,
+    root_event_id: Uuid,
+    target_type: &str,
+    target_id: Option<Uuid>,
+) -> EventEnvelope {
+    EventEnvelope {
+        id: root_event_id,
+        event_type: ROOT_EVENT_TYPE.to_string(),
+        schema_version: 1,
+        correlation_id: root_event_id,
+        causation_id: None,
+        tenant_id,
+        trace_id: None,
+        timestamp: Utc::now(),
+        actor_id: None,
+        event: DomainEvent::ReindexRequested {
+            target_type: target_type.to_string(),
+            target_id,
+        },
+        retry_count: 0,
+    }
+}
+
+async fn insert_legacy_root(
+    db: &DatabaseConnection,
+    envelope: &EventEnvelope,
+    scope_key: &str,
+) -> TestResult<()> {
+    envelope.validate_registered_schema()?;
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+        INSERT INTO search_projection_inbox (
+            event_id, tenant_id, source_module, scope_key, event_type,
+            revision_at, envelope_json, status, attempt_count, created_at, updated_at
+        ) VALUES ($1, $2, 'forum', $3, $4, $5, $6, 'pending', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+        ON CONFLICT (event_id) DO NOTHING
+        "#,
+        vec![
+            envelope.id.into(),
+            envelope.tenant_id.into(),
+            scope_key.to_string().into(),
+            envelope.event_type.clone().into(),
+            envelope.timestamp.to_owned().into(),
+            SqlValue::Json(Some(Box::new(serde_json::to_value(envelope)?))),
+        ],
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn load_snapshot(db: &DatabaseConnection, event_id: Uuid) -> TestResult<InboxSnapshot> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+            SELECT event_id, tenant_id, source_module, scope_key, event_type,
+                   ingest_sequence, envelope_json
+            FROM search_projection_inbox
+            WHERE event_id = $1
+            "#,
+            vec![event_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| test_error(format!("inbox row {event_id} was not found")))?;
+
+    Ok(InboxSnapshot {
+        event_id: row.try_get("", "event_id")?,
+        tenant_id: row.try_get("", "tenant_id")?,
+        source_module: row.try_get("", "source_module")?,
+        scope_key: row.try_get("", "scope_key")?,
+        event_type: row.try_get("", "event_type")?,
+        ingest_sequence: row.try_get("", "ingest_sequence")?,
+        envelope_json: row.try_get("", "envelope_json")?,
+    })
+}
+
+async fn count_event_rows(db: &DatabaseConnection, event_id: Uuid) -> TestResult<i64> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT COUNT(*)::BIGINT AS value FROM search_projection_inbox WHERE event_id = $1",
+            vec![event_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| test_error("inbox count query returned no row"))?;
+    Ok(row.try_get("", "value")?)
+}
+
+fn ensure_durable_outcome(
+    outcome: ForumSearchContractIngressOutcome,
+    expected_root_event_id: Uuid,
+    expected_owner_revision: i64,
+) -> TestResult<()> {
+    match outcome {
+        ForumSearchContractIngressOutcome::DurablyAccepted {
+            root_event_id,
+            owner_revision,
+        } if root_event_id == expected_root_event_id
+            && owner_revision == expected_owner_revision => Ok(()),
+        other => Err(test_error(format!(
+            "unexpected durable ingress outcome: {other:?}"
+        ))),
+    }
+}
+
+fn ensure_snapshot(
+    snapshot: &InboxSnapshot,
+    expected_tenant_id: Uuid,
+    expected_root_event_id: Uuid,
+    expected_scope_key: &str,
+    expected_target_type: &str,
+    expected_target_id: Option<Uuid>,
+) -> TestResult<()> {
+    let stored_envelope: EventEnvelope = serde_json::from_value(snapshot.envelope_json.clone())?;
+    let expected_event = DomainEvent::ReindexRequested {
+        target_type: expected_target_type.to_string(),
+        target_id: expected_target_id,
+    };
+    if snapshot.event_id != expected_root_event_id
+        || snapshot.tenant_id != expected_tenant_id
+        || snapshot.source_module != "forum"
+        || snapshot.scope_key != expected_scope_key
+        || snapshot.event_type != ROOT_EVENT_TYPE
+        || snapshot.ingest_sequence <= 0
+        || stored_envelope.id != expected_root_event_id
+        || stored_envelope.tenant_id != expected_tenant_id
+        || stored_envelope.event_type != ROOT_EVENT_TYPE
+        || stored_envelope.schema_version != 1
+        || stored_envelope.correlation_id != expected_root_event_id
+        || stored_envelope.causation_id.is_some()
+        || stored_envelope.event != expected_event
+        || stored_envelope.validate_registered_schema().is_err()
+    {
+        return Err(test_error(format!(
+            "unexpected durable inbox snapshot: {snapshot:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn write_evidence(artifact: IngressEvidenceArtifact) -> TestResult<()> {
+    let path = workspace_root().join(EVIDENCE_PATH);
+    let parent = path
+        .parent()
+        .ok_or_else(|| test_error("evidence path has no parent directory"))?;
+    fs::create_dir_all(parent)?;
+    let mut bytes = serde_json::to_vec_pretty(&artifact)?;
+    bytes.push(b'\n');
+    fs::write(&path, bytes)?;
+    eprintln!("wrote Forum Search PostgreSQL ingress evidence to {}", path.display());
+    Ok(())
+}
+
+fn source_commit() -> TestResult<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(workspace_root())
+        .output()?;
+    if !output.status.success() {
+        return Err(test_error(format!(
+            "git rev-parse HEAD failed with status {}",
+            output.status
+        )));
+    }
+    let commit = String::from_utf8(output.stdout)?.trim().to_string();
+    if commit.len() != 40 || !commit.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(test_error(format!(
+            "git rev-parse HEAD returned an invalid source commit: {commit}"
+        )));
+    }
+    Ok(commit)
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn postgres_database_url() -> Option<String> {
+    std::env::var(SEARCH_TEST_DATABASE_ENV)
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn set_search_path(db: &DatabaseConnection, schema_name: &str) -> TestResult<()> {
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}""#))
+        .await?;
+    Ok(())
+}
+
+fn sanitize_identifier(value: &str) -> String {
+    let normalized = value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    let normalized = normalized.trim_matches('_');
+    if normalized.is_empty() {
+        "test".to_string()
+    } else {
+        normalized.to_string()
+    }
+}
+
+fn test_error(message: impl Into<String>) -> Box<dyn Error + Send + Sync> {
+    std::io::Error::other(message.into()).into()
+}

--- a/scripts/verify/verify-forum-search-versioned-invalidation-postgres-ingress-proof.mjs
+++ b/scripts/verify/verify-forum-search-versioned-invalidation-postgres-ingress-proof.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = process.cwd();
+const read = (path) => readFileSync(resolve(root, path), "utf8");
+const requireAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(text.includes(marker), `${label} is missing required marker: ${marker}`);
+  }
+};
+const forbidAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(!text.includes(marker), `${label} contains forbidden marker: ${marker}`);
+  }
+};
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-search-versioned-invalidation-postgres-ingress-proof.json";
+const parentContractPath =
+  "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json";
+const docPath =
+  "crates/rustok-forum/docs/forum-23b2g2b3d2-postgres-ingress-proof.md";
+const testPath =
+  "crates/rustok-search/tests/forum_versioned_invalidation_postgres.rs";
+const evidencePath =
+  "target/forum-search-versioned-invalidation-postgres-ingress-evidence.json";
+
+const contract = JSON.parse(read(contractPath));
+assert.equal(
+  contract.contract,
+  "forum_search_versioned_invalidation_postgres_ingress_proof_v1",
+);
+assert.equal(contract.task, "FORUM-23B2G2B3D2");
+assert.equal(contract.status, "source_ready_maintainer_execution_pending");
+assert.equal(contract.runtime_evidence_parent, parentContractPath);
+assert.equal(contract.test, testPath);
+assert.equal(contract.evidence_artifact.path, evidencePath);
+assert.equal(contract.evidence_artifact.generation, "executable_test_only");
+assert.equal(contract.evidence_artifact.hand_editing_forbidden, true);
+assert.equal(contract.evidence_artifact.source_commit_required, true);
+assert.equal(contract.required_runtime.database, "postgresql");
+assert.equal(
+  contract.required_runtime.database_env,
+  "RUSTOK_SEARCH_TEST_DATABASE_URL",
+);
+assert.equal(contract.required_runtime.migrations, "rustok_search::SearchModule");
+assert.equal(contract.required_runtime.broker_required, false);
+assert.deepEqual(
+  contract.scenarios.map(({ id }) => id),
+  [
+    "typed_ingress_admission",
+    "legacy_first_duplicate",
+    "typed_first_duplicate",
+    "semantic_identity_conflict",
+  ],
+);
+for (const scenario of contract.scenarios) {
+  assert.ok(Array.isArray(scenario.proves) && scenario.proves.length >= 3);
+  for (const fact of scenario.proves) {
+    assert.equal(typeof fact, "string");
+    assert.ok(fact.length > 20);
+  }
+}
+assert.ok(
+  contract.maintainer_command.includes(
+    "cargo test -p rustok-search --test forum_versioned_invalidation_postgres",
+  ),
+);
+
+const test = read(testPath);
+requireAll(
+  test,
+  [
+    "RUSTOK_SEARCH_TEST_DATABASE_URL",
+    "SearchModule.migrations()",
+    "ForumSearchContractIngress::new",
+    "ContractEventEnvelope::new_caused_by",
+    "ForumSearchProjectionEvent::InvalidationIssued",
+    "ON CONFLICT (event_id) DO NOTHING",
+    "typed_ingress_admission",
+    "legacy_first_duplicate",
+    "typed_first_duplicate",
+    "semantic_identity_conflict",
+    "forum.search_projection.contract_inbox_identity_conflict",
+    "typed transport envelope ID must differ from the root projection identity",
+    "typed invalidation must retain the exact legacy root causation ID",
+    "validate_registered_schema",
+    "ingest_sequence <= 0",
+    evidencePath,
+    ".args([\"rev-parse\", \"HEAD\"])",
+    "broker_used: false",
+  ],
+  "PostgreSQL ingress executable proof",
+);
+forbidAll(
+  test,
+  [
+    "#[ignore]",
+    "RUSTOK_FORUM_SEARCH_CONTRACT_CONSUMER_ENABLED",
+    "IggyTransport",
+    "PersistentContractConsumerGroup",
+    "ConsumerPoisonReceiptStore",
+  ],
+  "PostgreSQL ingress executable proof",
+);
+
+const doc = read(docPath);
+requireAll(
+  doc,
+  [
+    "`source_ready_maintainer_execution_pending`",
+    "FORUM-23B2G2B3D2",
+    contractPath,
+    testPath,
+    evidencePath,
+    "forum.search_projection.contract_inbox_identity_conflict",
+    "No command above was run by the implementation agent",
+  ],
+  "PostgreSQL ingress proof handoff",
+);
+
+const parent = JSON.parse(read(parentContractPath));
+assert.equal(parent.task, "FORUM-23B2G2B3D0");
+assert.equal(parent.status, "source_ready_maintainer_execution_pending");
+assert.deepEqual(
+  parent.required_scenarios.map(({ id }) => id),
+  [
+    "normal_delivery",
+    "legacy_first_duplicate",
+    "typed_first_duplicate",
+    "acknowledgement_failure_restart",
+    "raw_poison_dlq_redelivery",
+    "semantic_poison_identity_conflict",
+    "missing_delivery_owner_repair",
+    "multi_process_serialization",
+    "deletion_acl_ordering",
+    "search_disabled_profile",
+  ],
+);
+assert.ok(Array.isArray(parent.source_ready_subproofs));
+const subproof = parent.source_ready_subproofs.find(
+  ({ task }) => task === "FORUM-23B2G2B3D2",
+);
+assert.ok(subproof, "D0 runtime contract does not register the D2 subproof");
+assert.equal(subproof.contract, contractPath);
+assert.equal(subproof.test, testPath);
+assert.equal(subproof.evidence_artifact, evidencePath);
+assert.deepEqual(subproof.covers, [
+  "typed_ingress_admission",
+  "legacy_first_duplicate",
+  "typed_first_duplicate",
+  "semantic_identity_conflict_classification",
+]);
+assert.deepEqual(subproof.does_not_cover, [
+  "broker_acknowledgement_or_restart",
+  "poison_receipt_or_dlq_publication",
+  "projector_or_owner_checkpoint",
+  "multi_process_or_visibility_end_to_end",
+]);
+assert.ok(parent.maintainer_commands.includes(
+  "node scripts/verify/verify-forum-search-versioned-invalidation-postgres-ingress-proof.mjs",
+));
+assert.ok(parent.maintainer_commands.some((command) =>
+  command.includes("--test forum_versioned_invalidation_postgres"),
+));
+
+console.log(
+  "Forum Search versioned invalidation PostgreSQL shared-inbox proof is source-synchronized.",
+);


### PR DESCRIPTION
## What changed

- add `FORUM-23B2G2B3D2`, the first executable subproof of the frozen Forum Search versioned-invalidation runtime matrix;
- apply the real `SearchModule` migrations in an isolated PostgreSQL schema and prove typed admission uses the exact legacy root causation ID as the one durable Search inbox identity;
- prove legacy-first and typed-first delivery orders retain one row and one positive `ingest_sequence` without replacing the durable root envelope;
- prove a colliding UUID with different tenant/scope/payload identity fails closed with `forum.search_projection.contract_inbox_identity_conflict` and leaves the durable row unchanged;
- generate `target/forum-search-versioned-invalidation-postgres-ingress-evidence.json` only after all covered scenarios pass and cleanup completes, including the exact source commit;
- register the bounded D2 coverage and explicit non-coverage in the parent D0 runtime-evidence contract and add a focused static guard.

## Deliberate boundary

This PR does not start Iggy or the server persistent consumer loop. It does not claim source acknowledgement, cursor restart, poison receipts, DLQ publication, projector execution, owner-checkpoint advancement, multi-process serialization, deletion/ACL ordering, Search-disabled recovery, completion of `FORUM-23B2G2B3D`, or closure of `LINK-FORUM-03`.

## Compatibility

No production Rust path, migration, event schema, digest, public DTO, Search query, broker configuration, dependency, or `Cargo.lock` entry changes. The legacy root remains mandatory and the typed consumer remains default-off.

## Validation

Tests, Node verifiers, formatting, Cargo checks, workflows, CI and PostgreSQL execution were intentionally not run, per maintainer request.