### PR TITLE
fix(customer): sanitize owner error diagnostics

### DIFF
--- a/crates/rustok-customer/contracts/evidence/customer-owner-error-diagnostic-safety-source-review.json
+++ b/crates/rustok-customer/contracts/evidence/customer-owner-error-diagnostic-safety-source-review.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "status": "customer_owner_error_diagnostic_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-customer/src/ports.rs",
+    "crates/rustok-customer/src/error.rs",
+    "scripts/verify/verify-customer-owner-error-diagnostic-safety.mjs",
+    "crates/rustok-customer/contracts/evidence/customer-owner-error-diagnostic-safety-source.json",
+    "crates/rustok-customer/docs/customer-owner-error-diagnostic-safety.md",
+    "scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs"
+  ],
+  "review_findings": {
+    "all_four_read_operations_preserved": true,
+    "public_request_response_contracts_preserved": true,
+    "owner_delegation_preserved": true,
+    "all_seven_public_mappings_preserved": true,
+    "database_profile_severity_preserved": true,
+    "ordinary_warning_severity_preserved": true,
+    "complete_customer_error_logging_removed_from_owner_mapper": true,
+    "database_profile_payload_removed": true,
+    "validation_email_text_removed": true,
+    "customer_user_uuid_removed": true,
+    "raw_context_removed_from_owner_mapper": true,
+    "bounded_context_shape_retained": true,
+    "bounded_owner_error_shape_retained": true,
+    "admission_parser_list_validation_diagnostics_remain_open": true,
+    "broad_ecommerce_cleanup_remains_open": true,
+    "runtime_evidence_claimed": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, workflows, CI, or mounted runtime validation was executed."
+}

--- a/crates/rustok-customer/contracts/evidence/customer-owner-error-diagnostic-safety-source.json
+++ b/crates/rustok-customer/contracts/evidence/customer-owner-error-diagnostic-safety-source.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": 1,
+  "status": "customer_owner_error_diagnostic_safety_source_unvalidated",
+  "scope": {
+    "owner_source": "crates/rustok-customer/src/ports.rs",
+    "owner_error": "crates/rustok-customer/src/error.rs",
+    "mapper": "customer_error_to_port_error",
+    "focused_verifier": "scripts/verify/verify-customer-owner-error-diagnostic-safety.mjs",
+    "documentation": "crates/rustok-customer/docs/customer-owner-error-diagnostic-safety.md"
+  },
+  "source_contract": {
+    "owner_error_variant_count": 7,
+    "complete_customer_error_logged": false,
+    "database_error_payload_logged": false,
+    "profile_error_payload_logged": false,
+    "validation_email_text_logged": false,
+    "customer_user_uuid_logged": false,
+    "raw_context_logged_by_owner_mapper": false,
+    "static_error_variant_logged": true,
+    "aggregate_text_shape_logged": true,
+    "aggregate_uuid_shape_logged": true,
+    "opaque_payload_presence_logged": true,
+    "bounded_context_shape_logged": true,
+    "database_profile_error_severity_changed": false,
+    "ordinary_warning_severity_changed": false,
+    "public_code_changed": false,
+    "public_message_changed": false,
+    "public_kind_changed": false,
+    "public_retryability_changed": false,
+    "owner_delegation_changed": false,
+    "read_operations_changed": false,
+    "admission_diagnostic_cleanup_closed": false,
+    "tenant_parser_diagnostic_cleanup_closed": false,
+    "list_validation_diagnostic_cleanup_closed": false,
+    "broad_ecommerce_cleanup_closed": false
+  },
+  "validation": {
+    "tests_run": false,
+    "verifiers_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "mounted_runtime_proven": false
+  },
+  "execution": []
+}

--- a/crates/rustok-customer/docs/customer-owner-error-diagnostic-safety.md
+++ b/crates/rustok-customer/docs/customer-owner-error-diagnostic-safety.md
@@ -1,0 +1,55 @@
+# Customer owner error diagnostic safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice closes the owner-error payload gap in `customer_error_to_port_error` inside `crates/rustok-customer/src/ports.rs`.
+
+The four `CustomerReadPort` operations, request/response DTOs, admission order, list validation, tenant parsing, owner service delegation, pagination and enrichment behavior remain unchanged.
+
+All seven current `CustomerError` variants retain their existing public `PortError` mapping:
+
+- database unavailable;
+- customer not found;
+- customer by user not found;
+- duplicate email;
+- duplicate user link;
+- validation;
+- profile unavailable.
+
+## Retained diagnostics
+
+The owner mapper records correlation id, owner operation, boundary, stable code and bounded context shape. Raw tenant, actor, channel, locale and other context values are not recorded by this mapper.
+
+Owner failures retain only:
+
+- a closed static error variant;
+- text-field count and total character length;
+- UUID-field count and non-nil count;
+- opaque-payload presence for database and profile failures.
+
+Database/Profile errors, validation messages, email values, customer IDs, user IDs and complete `CustomerError` debug/display payloads are not recorded by the owner mapper.
+
+## Preserved behavior
+
+- database and profile failures remain error severity;
+- not-found, conflict and validation failures remain warning severity;
+- all public codes are unchanged;
+- all public messages are unchanged;
+- public kinds and retryability are unchanged;
+- all four owner service calls and their arguments are unchanged.
+
+## Deliberate boundary
+
+This source slice does not close Customer read admission, list-validation or tenant-parser diagnostics. Those paths still retain raw context or parser/error payload and remain separate bounded follow-up work.
+
+The broad ecommerce mapper cleanup, compile validation, focused-verifier execution and mounted runtime evidence remain open.
+
+## Evidence
+
+- `crates/rustok-customer/contracts/evidence/customer-owner-error-diagnostic-safety-source.json`
+- `crates/rustok-customer/contracts/evidence/customer-owner-error-diagnostic-safety-source-review.json`
+- `scripts/verify/verify-customer-owner-error-diagnostic-safety.mjs`
+
+No test, verifier, formatter, Cargo, workflow or CI command was executed for this source slice.

--- a/crates/rustok-customer/src/ports.rs
+++ b/crates/rustok-customer/src/ports.rs
@@ -229,45 +229,227 @@ fn parse_port_tenant_id(
     })
 }
 
+struct CustomerReadContextFacts {
+    tenant_id_length: usize,
+    actor_kind: &'static str,
+    actor_id_length: usize,
+    claim_count: usize,
+    role_count: usize,
+    channel_present: bool,
+    channel_length: Option<usize>,
+    locale_length: usize,
+    causation_id_present: bool,
+    causation_id_length: Option<usize>,
+    traceparent_present: bool,
+    traceparent_length: Option<usize>,
+    idempotency_key_present: bool,
+    idempotency_key_length: Option<usize>,
+    deadline_ms: Option<u64>,
+}
+
+struct CustomerOwnerErrorFacts {
+    error_variant: &'static str,
+    text_field_count: usize,
+    text_total_length: usize,
+    uuid_field_count: usize,
+    uuid_non_nil_count: usize,
+    opaque_payload_present: bool,
+}
+
+fn customer_read_context_facts(context: &PortContext) -> CustomerReadContextFacts {
+    let actor_kind = match &context.actor.kind {
+        rustok_api::PortActorKind::User => "user",
+        rustok_api::PortActorKind::Service => "service",
+        rustok_api::PortActorKind::System => "system",
+    };
+    CustomerReadContextFacts {
+        tenant_id_length: context.tenant_id.chars().count(),
+        actor_kind,
+        actor_id_length: context.actor.id.chars().count(),
+        claim_count: context.claims.len(),
+        role_count: context.roles.len(),
+        channel_present: context.channel.is_some(),
+        channel_length: context.channel.as_ref().map(|value| value.chars().count()),
+        locale_length: context.locale.chars().count(),
+        causation_id_present: context.causation_id.is_some(),
+        causation_id_length: context
+            .causation_id
+            .as_ref()
+            .map(|value| value.chars().count()),
+        traceparent_present: context.traceparent.is_some(),
+        traceparent_length: context
+            .traceparent
+            .as_ref()
+            .map(|value| value.chars().count()),
+        idempotency_key_present: context.idempotency_key.is_some(),
+        idempotency_key_length: context
+            .idempotency_key
+            .as_ref()
+            .map(|value| value.chars().count()),
+        deadline_ms: context.deadline_ms,
+    }
+}
+
+fn customer_owner_error_facts(error: &CustomerError) -> CustomerOwnerErrorFacts {
+    let (
+        error_variant,
+        text_field_count,
+        text_total_length,
+        uuid_field_count,
+        uuid_non_nil_count,
+        opaque_payload_present,
+    ) = match error {
+        CustomerError::Validation(message) => {
+            ("validation", 1, message.chars().count(), 0, 0, false)
+        }
+        CustomerError::CustomerNotFound(customer_id) => (
+            "customer_not_found",
+            0,
+            0,
+            1,
+            if customer_id.is_nil() { 0 } else { 1 },
+            false,
+        ),
+        CustomerError::CustomerByUserNotFound(user_id) => (
+            "customer_by_user_not_found",
+            0,
+            0,
+            1,
+            if user_id.is_nil() { 0 } else { 1 },
+            false,
+        ),
+        CustomerError::DuplicateEmail(email) => {
+            ("duplicate_email", 1, email.chars().count(), 0, 0, false)
+        }
+        CustomerError::DuplicateUserLink(user_id) => (
+            "duplicate_user_link",
+            0,
+            0,
+            1,
+            if user_id.is_nil() { 0 } else { 1 },
+            false,
+        ),
+        CustomerError::Profile(_) => ("profile", 0, 0, 0, 0, true),
+        CustomerError::Database(_) => ("database", 0, 0, 0, 0, true),
+    };
+    CustomerOwnerErrorFacts {
+        error_variant,
+        text_field_count,
+        text_total_length,
+        uuid_field_count,
+        uuid_non_nil_count,
+        opaque_payload_present,
+    }
+}
+
+fn log_customer_owner_failure(
+    context: &PortContext,
+    owner_operation: &'static str,
+    code: &'static str,
+    error_facts: &CustomerOwnerErrorFacts,
+    technical_failure: bool,
+) {
+    let context_facts = customer_read_context_facts(context);
+    if technical_failure {
+        tracing::error!(
+            owner = "rustok_customer",
+            correlation_id = %context.correlation_id,
+            tenant_id_length = context_facts.tenant_id_length,
+            actor_kind = context_facts.actor_kind,
+            actor_id_length = context_facts.actor_id_length,
+            claim_count = context_facts.claim_count,
+            role_count = context_facts.role_count,
+            channel_present = context_facts.channel_present,
+            channel_length = ?context_facts.channel_length,
+            locale_length = context_facts.locale_length,
+            causation_id_present = context_facts.causation_id_present,
+            causation_id_length = ?context_facts.causation_id_length,
+            traceparent_present = context_facts.traceparent_present,
+            traceparent_length = ?context_facts.traceparent_length,
+            idempotency_key_present = context_facts.idempotency_key_present,
+            idempotency_key_length = ?context_facts.idempotency_key_length,
+            deadline_ms = ?context_facts.deadline_ms,
+            operation = owner_operation,
+            code,
+            error_variant = error_facts.error_variant,
+            text_field_count = error_facts.text_field_count,
+            text_total_length = error_facts.text_total_length,
+            uuid_field_count = error_facts.uuid_field_count,
+            uuid_non_nil_count = error_facts.uuid_non_nil_count,
+            opaque_payload_present = error_facts.opaque_payload_present,
+            boundary = CUSTOMER_READ_PORT_BOUNDARY,
+            "customer owner operation failed with bounded diagnostics"
+        );
+    } else {
+        tracing::warn!(
+            owner = "rustok_customer",
+            correlation_id = %context.correlation_id,
+            tenant_id_length = context_facts.tenant_id_length,
+            actor_kind = context_facts.actor_kind,
+            actor_id_length = context_facts.actor_id_length,
+            claim_count = context_facts.claim_count,
+            role_count = context_facts.role_count,
+            channel_present = context_facts.channel_present,
+            channel_length = ?context_facts.channel_length,
+            locale_length = context_facts.locale_length,
+            causation_id_present = context_facts.causation_id_present,
+            causation_id_length = ?context_facts.causation_id_length,
+            traceparent_present = context_facts.traceparent_present,
+            traceparent_length = ?context_facts.traceparent_length,
+            idempotency_key_present = context_facts.idempotency_key_present,
+            idempotency_key_length = ?context_facts.idempotency_key_length,
+            deadline_ms = ?context_facts.deadline_ms,
+            operation = owner_operation,
+            code,
+            error_variant = error_facts.error_variant,
+            text_field_count = error_facts.text_field_count,
+            text_total_length = error_facts.text_total_length,
+            uuid_field_count = error_facts.uuid_field_count,
+            uuid_non_nil_count = error_facts.uuid_non_nil_count,
+            opaque_payload_present = error_facts.opaque_payload_present,
+            boundary = CUSTOMER_READ_PORT_BOUNDARY,
+            "customer owner operation was rejected with bounded diagnostics"
+        );
+    }
+}
+
 fn customer_error_to_port_error(
     context: &PortContext,
     owner_operation: &'static str,
     error: CustomerError,
 ) -> PortError {
+    let error_facts = customer_owner_error_facts(&error);
     match error {
-        CustomerError::Database(error) => {
-            tracing::error!(
-                error = ?error,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                operation = owner_operation,
-                code = "customer.database_unavailable",
-                "customer owner storage operation failed"
+        CustomerError::Database(_) => {
+            log_customer_owner_failure(
+                context,
+                owner_operation,
+                "customer.database_unavailable",
+                &error_facts,
+                true,
             );
             PortError::unavailable(
                 "customer.database_unavailable",
                 "customer storage is temporarily unavailable",
             )
         }
-        CustomerError::CustomerNotFound(customer_id) => {
-            tracing::warn!(
-                customer_id = %customer_id,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                operation = owner_operation,
-                code = "customer.customer_not_found",
-                "customer projection was not found"
+        CustomerError::CustomerNotFound(_) => {
+            log_customer_owner_failure(
+                context,
+                owner_operation,
+                "customer.customer_not_found",
+                &error_facts,
+                false,
             );
             PortError::not_found("customer.customer_not_found", "customer was not found")
         }
-        CustomerError::CustomerByUserNotFound(user_id) => {
-            tracing::warn!(
-                user_id = %user_id,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                operation = owner_operation,
-                code = "customer.customer_by_user_not_found",
-                "customer projection was not found for user"
+        CustomerError::CustomerByUserNotFound(_) => {
+            log_customer_owner_failure(
+                context,
+                owner_operation,
+                "customer.customer_by_user_not_found",
+                &error_facts,
+                false,
             );
             PortError::not_found(
                 "customer.customer_by_user_not_found",
@@ -275,51 +457,48 @@ fn customer_error_to_port_error(
             )
         }
         CustomerError::DuplicateEmail(_) => {
-            tracing::warn!(
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                operation = owner_operation,
-                code = "customer.duplicate_email",
-                "customer email conflict"
+            log_customer_owner_failure(
+                context,
+                owner_operation,
+                "customer.duplicate_email",
+                &error_facts,
+                false,
             );
             PortError::conflict(
                 "customer.duplicate_email",
                 "customer email is already in use",
             )
         }
-        CustomerError::DuplicateUserLink(user_id) => {
-            tracing::warn!(
-                user_id = %user_id,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                operation = owner_operation,
-                code = "customer.duplicate_user_link",
-                "customer user link conflict"
+        CustomerError::DuplicateUserLink(_) => {
+            log_customer_owner_failure(
+                context,
+                owner_operation,
+                "customer.duplicate_user_link",
+                &error_facts,
+                false,
             );
             PortError::conflict(
                 "customer.duplicate_user_link",
                 "customer user link already exists",
             )
         }
-        CustomerError::Validation(message) => {
-            tracing::warn!(
-                error = %message,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                operation = owner_operation,
-                code = "customer.validation",
-                "customer owner validation failed"
+        CustomerError::Validation(_) => {
+            log_customer_owner_failure(
+                context,
+                owner_operation,
+                "customer.validation",
+                &error_facts,
+                false,
             );
             PortError::validation("customer.validation", "customer request is invalid")
         }
-        CustomerError::Profile(error) => {
-            tracing::error!(
-                error = ?error,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                operation = owner_operation,
-                code = "customer.profile_unavailable",
-                "customer profile projection failed"
+        CustomerError::Profile(_) => {
+            log_customer_owner_failure(
+                context,
+                owner_operation,
+                "customer.profile_unavailable",
+                &error_facts,
+                true,
             );
             PortError::unavailable(
                 "customer.profile_unavailable",

--- a/scripts/verify/verify-customer-owner-error-diagnostic-safety.mjs
+++ b/scripts/verify/verify-customer-owner-error-diagnostic-safety.mjs
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const failures = [];
+
+const paths = {
+  ports: 'crates/rustok-customer/src/ports.rs',
+  error: 'crates/rustok-customer/src/error.rs',
+  evidence:
+    'crates/rustok-customer/contracts/evidence/customer-owner-error-diagnostic-safety-source.json',
+  review:
+    'crates/rustok-customer/contracts/evidence/customer-owner-error-diagnostic-safety-source-review.json',
+  document: 'crates/rustok-customer/docs/customer-owner-error-diagnostic-safety.md',
+  broad: 'scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs',
+};
+
+const ports = read(paths.ports);
+const errorSource = read(paths.error);
+const evidence = JSON.parse(read(paths.evidence));
+const review = JSON.parse(read(paths.review));
+const document = read(paths.document);
+const broad = read(paths.broad);
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+function functionBody(source, functionName) {
+  const signature = new RegExp(
+    `(?:pub(?:\\([^)]*\\))?\\s+)?(?:async\\s+)?fn\\s+${functionName}(?:<[^>]*>)?\\s*\\(`,
+  );
+  const match = signature.exec(source);
+  if (!match) {
+    failures.push(`missing function ${functionName}`);
+    return '';
+  }
+  const openBrace = source.indexOf('{', match.index);
+  let depth = 0;
+  for (let index = openBrace; index >= 0 && index < source.length; index += 1) {
+    if (source[index] === '{') depth += 1;
+    if (source[index] === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(openBrace, index + 1);
+    }
+  }
+  failures.push(`unterminated function ${functionName}`);
+  return '';
+}
+
+for (const marker of [
+  'pub trait CustomerReadPort: Send + Sync',
+  'async fn read_customer_projection(',
+  'async fn read_customer_projection_by_user(',
+  'async fn list_customer_projections(',
+  'async fn list_profile_enrichment(',
+  'pub fn in_process_customer_read_port(',
+  'self.get_customer(tenant_id, request.customer_id)',
+  'self.get_customer_by_user(tenant_id, request.user_id)',
+  'self.list_customers(',
+  'crate::CustomerService::list_profile_enrichment(self, tenant_id, &request.user_ids)',
+  'require_customer_read_policy(&context, owner_operation)?;',
+  'validate_customer_list_projection_request(&context, owner_operation, &request)?;',
+  'let tenant_id = parse_port_tenant_id(&context, owner_operation)?;',
+  'customer_error_to_port_error(&context, owner_operation, error)',
+]) requireText(ports, marker, `${paths.ports}: preserved read contract`);
+
+for (const marker of [
+  'Validation(String)',
+  'CustomerNotFound(Uuid)',
+  'CustomerByUserNotFound(Uuid)',
+  'DuplicateEmail(String)',
+  'DuplicateUserLink(Uuid)',
+  'Profile(#[from] rustok_profiles::ProfileError)',
+  'Database(#[from] DbErr)',
+]) requireText(errorSource, marker, `${paths.error}: owner error shape`);
+
+const contextFacts = functionBody(ports, 'customer_read_context_facts');
+const errorFacts = functionBody(ports, 'customer_owner_error_facts');
+const logger = functionBody(ports, 'log_customer_owner_failure');
+const mapper = functionBody(ports, 'customer_error_to_port_error');
+const diagnosticScope = [contextFacts, errorFacts, logger, mapper].join('\n');
+
+for (const marker of [
+  'struct CustomerReadContextFacts',
+  'tenant_id_length: context.tenant_id.chars().count()',
+  'actor_kind',
+  'actor_id_length: context.actor.id.chars().count()',
+  'claim_count: context.claims.len()',
+  'role_count: context.roles.len()',
+  'channel_present: context.channel.is_some()',
+  'locale_length: context.locale.chars().count()',
+  'causation_id_present: context.causation_id.is_some()',
+  'traceparent_present: context.traceparent.is_some()',
+  'idempotency_key_present: context.idempotency_key.is_some()',
+  'deadline_ms: context.deadline_ms',
+  'struct CustomerOwnerErrorFacts',
+  'CustomerError::Validation(message)',
+  '("validation", 1, message.chars().count(), 0, 0, false)',
+  'CustomerError::CustomerNotFound(customer_id)',
+  '"customer_not_found"',
+  'CustomerError::CustomerByUserNotFound(user_id)',
+  '"customer_by_user_not_found"',
+  'CustomerError::DuplicateEmail(email)',
+  '("duplicate_email", 1, email.chars().count(), 0, 0, false)',
+  'CustomerError::DuplicateUserLink(user_id)',
+  '"duplicate_user_link"',
+  'CustomerError::Profile(_) => ("profile", 0, 0, 0, 0, true)',
+  'CustomerError::Database(_) => ("database", 0, 0, 0, 0, true)',
+]) requireText(ports, marker, `${paths.ports}: bounded diagnostic facts`);
+
+for (const marker of [
+  'tracing::error!(',
+  'tracing::warn!(',
+  'owner = "rustok_customer"',
+  'correlation_id = %context.correlation_id',
+  'tenant_id_length = context_facts.tenant_id_length',
+  'actor_kind = context_facts.actor_kind',
+  'claim_count = context_facts.claim_count',
+  'role_count = context_facts.role_count',
+  'operation = owner_operation',
+  'error_variant = error_facts.error_variant',
+  'text_field_count = error_facts.text_field_count',
+  'text_total_length = error_facts.text_total_length',
+  'uuid_field_count = error_facts.uuid_field_count',
+  'uuid_non_nil_count = error_facts.uuid_non_nil_count',
+  'opaque_payload_present = error_facts.opaque_payload_present',
+  'boundary = CUSTOMER_READ_PORT_BOUNDARY',
+]) requireText(logger, marker, `${paths.ports}: bounded owner logger`);
+
+for (const [variant, code, message, constructor, technical] of [
+  [
+    'CustomerError::Database(_)',
+    'customer.database_unavailable',
+    'customer storage is temporarily unavailable',
+    'PortError::unavailable',
+    'true',
+  ],
+  [
+    'CustomerError::CustomerNotFound(_)',
+    'customer.customer_not_found',
+    'customer was not found',
+    'PortError::not_found',
+    'false',
+  ],
+  [
+    'CustomerError::CustomerByUserNotFound(_)',
+    'customer.customer_by_user_not_found',
+    'customer was not found for the requested user',
+    'PortError::not_found',
+    'false',
+  ],
+  [
+    'CustomerError::DuplicateEmail(_)',
+    'customer.duplicate_email',
+    'customer email is already in use',
+    'PortError::conflict',
+    'false',
+  ],
+  [
+    'CustomerError::DuplicateUserLink(_)',
+    'customer.duplicate_user_link',
+    'customer user link already exists',
+    'PortError::conflict',
+    'false',
+  ],
+  [
+    'CustomerError::Validation(_)',
+    'customer.validation',
+    'customer request is invalid',
+    'PortError::validation',
+    'false',
+  ],
+  [
+    'CustomerError::Profile(_)',
+    'customer.profile_unavailable',
+    'customer profile projection is temporarily unavailable',
+    'PortError::unavailable',
+    'true',
+  ],
+]) {
+  for (const marker of [variant, `"${code}"`, `"${message}"`, constructor]) {
+    requireText(mapper, marker, `${paths.ports}: stable ${code} mapping`);
+  }
+  const call = new RegExp(
+    `"${code.replaceAll('.', '\\.')}",[\\s\\S]*?&error_facts,[\\s\\S]*?${technical},`,
+  );
+  if (!call.test(mapper)) {
+    failures.push(`${paths.ports}: ${code} severity classification drift`);
+  }
+}
+
+for (const forbidden of [
+  'error = ?error',
+  'error = %error',
+  'error = %message',
+  'tenant_id = %context.tenant_id',
+  'actor = ?context.actor',
+  'channel = ?context.channel',
+  'locale = %context.locale',
+  'causation_id = ?context.causation_id',
+  'traceparent = ?context.traceparent',
+  'customer_id = %',
+  'user_id = %',
+  'email = %',
+]) forbidText(diagnosticScope, forbidden, `${paths.ports}: owner mapper payload diagnostics`);
+
+requireText(
+  broad,
+  "[customer, 'customer_error_to_port_error(&context, owner_operation, error)', 'customer context-aware mapping']",
+  `${paths.broad}: aggregate owner mapper coverage`,
+);
+
+for (const [key, expected] of Object.entries({
+  owner_error_variant_count: 7,
+  complete_customer_error_logged: false,
+  database_error_payload_logged: false,
+  profile_error_payload_logged: false,
+  validation_email_text_logged: false,
+  customer_user_uuid_logged: false,
+  raw_context_logged_by_owner_mapper: false,
+  static_error_variant_logged: true,
+  aggregate_text_shape_logged: true,
+  aggregate_uuid_shape_logged: true,
+  opaque_payload_presence_logged: true,
+  bounded_context_shape_logged: true,
+  database_profile_error_severity_changed: false,
+  ordinary_warning_severity_changed: false,
+  public_code_changed: false,
+  public_message_changed: false,
+  public_kind_changed: false,
+  public_retryability_changed: false,
+  owner_delegation_changed: false,
+  read_operations_changed: false,
+  admission_diagnostic_cleanup_closed: false,
+  tenant_parser_diagnostic_cleanup_closed: false,
+  list_validation_diagnostic_cleanup_closed: false,
+  broad_ecommerce_cleanup_closed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+
+for (const key of [
+  'tests_run',
+  'verifiers_run',
+  'cargo_run',
+  'format_run',
+  'workflow_checks_run',
+  'ci_run',
+  'compile_proven',
+  'mounted_runtime_proven',
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push(`${paths.evidence}: execution must remain empty`);
+}
+
+for (const [key, expected] of Object.entries({
+  all_four_read_operations_preserved: true,
+  public_request_response_contracts_preserved: true,
+  owner_delegation_preserved: true,
+  all_seven_public_mappings_preserved: true,
+  database_profile_severity_preserved: true,
+  ordinary_warning_severity_preserved: true,
+  complete_customer_error_logging_removed_from_owner_mapper: true,
+  database_profile_payload_removed: true,
+  validation_email_text_removed: true,
+  customer_user_uuid_removed: true,
+  raw_context_removed_from_owner_mapper: true,
+  bounded_context_shape_retained: true,
+  bounded_owner_error_shape_retained: true,
+  admission_parser_list_validation_diagnostics_remain_open: true,
+  broad_ecommerce_cleanup_remains_open: true,
+  runtime_evidence_claimed: false,
+})) {
+  if (review.review_findings?.[key] !== expected) {
+    failures.push(`${paths.review}: review_findings.${key} must be ${expected}`);
+  }
+}
+
+for (const marker of [
+  'Status: **source-ready / unvalidated**',
+  '`customer_error_to_port_error`',
+  'All seven current `CustomerError` variants',
+  'database and profile failures remain error severity',
+  'admission, list-validation or tenant-parser diagnostics',
+  'The broad ecommerce mapper cleanup',
+]) requireText(document, marker, `${paths.document}: truthful source scope`);
+
+if (failures.length > 0) {
+  console.error('Customer owner error diagnostic-safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Customer owner errors preserve public mappings and severity while retaining only bounded context and error shape; admission/parser execution evidence remains open',
+);


### PR DESCRIPTION
## Summary

- continue the ecommerce correlation-safe mapper cleanup at Customer-owned `customer_error_to_port_error`
- replace database/profile, validation/email, customer/user UUID and complete `CustomerError` payload logging with bounded context and owner-error shape
- preserve all seven public `PortError` codes, messages, kinds and retryability
- preserve database/profile error severity and ordinary warning severity
- keep all four `CustomerReadPort` operations, DTOs, admission order, list validation, tenant parsing and owner service delegation unchanged
- add focused source evidence/review, documentation and a fail-closed verifier

## Deliberate boundary

This slice closes only the post-delegation owner mapper. Customer read admission, list-validation and tenant-parser diagnostics remain open and still retain raw context/parser payload. The broad ecommerce cleanup therefore remains open.

## Scope

Exactly five files change:

- `crates/rustok-customer/src/ports.rs`
- one focused verifier
- two evidence files
- one focused document

Customer adapters, DTOs, service methods, error enum, Cargo manifests, migrations, dependencies, workflows and CI configuration are unchanged.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, CI or mounted runtime validation was executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-customer-owner-error-diagnostic-safety.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-customer --lib
```

Branch: `agent/customer-owner-error-diagnostic-safety-20260731`
Base at creation: `d5b79c98cbd5d7f00e88e0587dacfe3c91cea06e`
