### PR TITLE
feat(blog): add deadline-bound Comments TCP transport

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-comments-tcp-transport.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-tcp-transport.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "module": "blog",
+  "provider": "comments",
+  "surface": "comments_tcp_json_transport",
+  "status": "source_verified_no_compile",
+  "compile_policy": "not_run_by_request",
+  "runtime_status": "not_run",
+  "generated_from": "crates/rustok-blog/docs/implementation-plan-slice-68.md",
+  "source_contract": {
+    "remote_core": "crates/rustok-comments/src/remote.rs",
+    "transport_adapter": "crates/rustok-comments/src/tcp_transport.rs",
+    "provider_export": "crates/rustok-comments/src/lib.rs",
+    "provider_manifest": "crates/rustok-comments/Cargo.toml",
+    "transport": "rustok_comments::TcpJsonCommentsTransport",
+    "request": "rustok_comments::CommentsThreadRequest",
+    "reply": "rustok_comments::CommentsThreadTransportReply",
+    "error": "rustok_api::PortError"
+  },
+  "protocol": {
+    "name": "comments_tcp_length_prefixed_json_v1",
+    "length_prefix": "u32_big_endian",
+    "request_encoding": "serde_json",
+    "reply_encoding": "serde_json",
+    "connection_scope": "one_request_one_reply",
+    "default_max_frame_bytes": 8388608,
+    "endpoint_owner": "host"
+  },
+  "deadline": {
+    "source": "PortContext.deadline_ms",
+    "required_before_connect": true,
+    "scope": "connect_write_read_decode",
+    "mechanism": "tokio::time::timeout",
+    "timeout_code": "comments.tcp_timeout"
+  },
+  "fail_closed": {
+    "invalid_frame_limit_code": "comments.tcp_invalid_frame_limit",
+    "oversized_frame_code": "comments.tcp_frame_too_large",
+    "encode_code": "comments.tcp_encode",
+    "decode_code": "comments.tcp_decode",
+    "unavailable_code": "comments.tcp_unavailable",
+    "typed_provider_error_preserved": true,
+    "retry_implemented": false
+  },
+  "operations": [
+    "CreateComment",
+    "GetComment",
+    "ListCommentsForTarget",
+    "ListPublicCommentsForTarget",
+    "UpdateComment",
+    "SetCommentStatus",
+    "DeleteComment"
+  ],
+  "pending": [
+    "tcp_server_adapter",
+    "endpoint_discovery",
+    "authentication",
+    "retry_backoff",
+    "host_publication",
+    "in_process_remote_runtime_parity",
+    "runtime_execution"
+  ],
+  "explicit_non_claims": [
+    "no_compile_result",
+    "no_rust_test_result",
+    "no_javascript_verifier_result",
+    "no_tcp_runtime_result",
+    "no_database_result",
+    "no_browser_result",
+    "no_workflow_result",
+    "no_ci_result",
+    "no_production_result"
+  ]
+}

--- a/crates/rustok-blog/docs/implementation-plan-slice-68.md
+++ b/crates/rustok-blog/docs/implementation-plan-slice-68.md
@@ -1,0 +1,106 @@
+# rustok-blog implementation plan — slice 68 continuation
+
+This document continues
+`crates/rustok-blog/docs/implementation-plan-slice-67.md`. Slices 1–66 remain in
+the original implementation plan, and slice 67 remains the retained typed remote
+adapter-core record.
+
+## 2026-07-31 continuation audit
+
+The slice 67 remote adapter core was rechecked against current `main` at
+`d5b79c98cbd5d7f00e88e0587dacfe3c91cea06e`. The seven-operation request and
+response model, complete `PortContext`, read/write policy enforcement, Blog host
+injection seams, typed storefront degradation, source evidence, and explicit
+runtime non-claims remain present.
+
+No compile, Rust or JavaScript test, TCP exchange, database, browser, workflow,
+CI, production, or runtime result is promoted by this continuation. Execution
+remains maintainer-owned.
+
+## Slice 68 — concrete TCP JSON Comments transport
+
+### Implemented source scope
+
+- `crates/rustok-comments/src/tcp_transport.rs` adds
+  `TcpJsonCommentsTransport`, a concrete implementation of
+  `CommentsThreadTransport`.
+- The transport uses the source-owned protocol identity
+  `comments_tcp_length_prefixed_json_v1`: a four-byte unsigned big-endian length
+  followed by one JSON request, then one length-prefixed JSON reply.
+- Each connection carries exactly one `CommentsThreadRequest` and one
+  `CommentsThreadTransportReply`, then closes.
+- `CommentsThreadTransportReply` preserves either a typed
+  `CommentsThreadResponse` or the exact provider `PortError`.
+- Every request exposes its complete context through
+  `CommentsThreadRequest::context()` without reconstructing or dropping tenant,
+  actor, claims, roles, channel, locale, correlation, causation, trace,
+  idempotency, or deadline fields.
+- The transport requires deadline semantics before connecting and wraps connect,
+  write, read, and decode in one `tokio::time::timeout` using
+  `PortContext.deadline_ms`.
+- Request and response frames are bounded by an eight-MiB default, configurable
+  only inside `1..=u32::MAX`.
+- Invalid limits, oversized frames, encode failures, decode failures, transport
+  unavailability, and deadline exhaustion remain typed and fail closed.
+- The `tcp-transport` feature keeps Tokio transport dependencies outside the
+  default Comments provider build.
+- Source evidence is retained at
+  `crates/rustok-blog/contracts/evidence/blog-comments-tcp-transport.json`.
+- The standalone fail-closed verifier is
+  `scripts/verify/verify-blog-comments-tcp-transport.mjs`.
+
+### Explicit non-claims
+
+This slice does not implement or claim:
+
+- a TCP server adapter or listener;
+- endpoint discovery, DNS policy, or configuration loading;
+- authentication, credentials, or transport encryption;
+- retry_backoff, circuit breaking, or replay policy;
+- host_publication or automatic in-process/remote selection;
+- in-process/remote parity execution;
+- successful compile, Rust test, JavaScript verifier, TCP runtime, database,
+  browser, workflow, CI, or production execution.
+
+Status: `source_verified_no_compile`.
+Compile policy: `not_run_by_request`.
+Runtime status: `not_run`.
+
+## Next implementation results
+
+1. Add a `tcp_server_adapter` that decodes the same bounded request frame,
+   dispatches to a host-owned `Arc<dyn CommentsThreadPort>`, and returns the
+   stable typed reply envelope.
+2. Publish the client and server adapters through host runtime configuration,
+   preserving the current in-process fallback and keeping endpoint/auth ownership
+   outside Blog.
+3. Add bounded retry_backoff only for retryable failures. Writes must never be
+   replayed without the existing idempotency key, and the original deadline must
+   bound the complete attempt set.
+4. Add in-process/TCP parity fixtures for all seven operations, provider errors,
+   mismatched response variants, oversized frames, disconnects, and timeout.
+5. Run and record retained Rust, JavaScript, TCP, PostgreSQL, browser, workflow,
+   and CI targets before promoting evidence beyond source-only status.
+6. Continue cached thread snapshot and comment-form fallback work after the
+   remote path has observed runtime evidence.
+
+## Suggested verification — intentionally not run in this slice
+
+- `node scripts/verify/verify-blog-comments-tcp-transport.mjs`
+- `cargo test -p rustok-comments --features tcp-transport --lib tcp_transport::tests`
+- `cargo check -p rustok-comments --features tcp-transport`
+- `npm run verify:blog:comments-port-boundary`
+- `npm run test:verify:blog:comments-port-boundary`
+
+## Boundaries retained
+
+- Comments owns storage, moderation lifecycle, public projection, typed remote
+  requests/replies, and concrete provider-side transport adapters.
+- Blog owns consumer policy, article rendering, typed degraded presentation, and
+  host-selected `Arc<dyn CommentsThreadPort>` composition seams.
+- The host owns endpoint selection, authentication, service lifecycle, and the
+  decision to publish an in-process or remote provider.
+- A transport failure must remain a typed `PortError`; Blog must not infer
+  Comments storage state from TCP details.
+- Source-only evidence remains explicit until the maintainer runs and records the
+  corresponding execution targets.

--- a/crates/rustok-comments/Cargo.toml
+++ b/crates/rustok-comments/Cargo.toml
@@ -20,6 +20,7 @@ server = [
   "dep:thiserror",
   "dep:tracing",
 ]
+tcp-transport = ["server", "dep:tokio"]
 
 [dependencies]
 async-trait = { workspace = true, optional = true }
@@ -35,6 +36,7 @@ sea-orm-migration = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 thiserror = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 uuid.workspace = true
 

--- a/crates/rustok-comments/src/lib.rs
+++ b/crates/rustok-comments/src/lib.rs
@@ -15,6 +15,8 @@ pub mod remote;
 mod richtext;
 #[cfg(feature = "server")]
 pub mod services;
+#[cfg(feature = "tcp-transport")]
+pub mod tcp_transport;
 
 #[cfg(feature = "server")]
 use async_trait::async_trait;
@@ -39,6 +41,8 @@ pub use ports::*;
 pub use remote::*;
 #[cfg(feature = "server")]
 pub use services::CommentsService;
+#[cfg(feature = "tcp-transport")]
+pub use tcp_transport::TcpJsonCommentsTransport;
 
 #[cfg(feature = "server")]
 pub struct CommentsModule;

--- a/crates/rustok-comments/src/remote.rs
+++ b/crates/rustok-comments/src/remote.rs
@@ -58,6 +58,21 @@ pub enum CommentsThreadRequest {
     },
 }
 
+impl CommentsThreadRequest {
+    /// Returns the complete port context carried by this operation.
+    pub fn context(&self) -> &PortContext {
+        match self {
+            Self::CreateComment { context, .. }
+            | Self::GetComment { context, .. }
+            | Self::ListCommentsForTarget { context, .. }
+            | Self::ListPublicCommentsForTarget { context, .. }
+            | Self::UpdateComment { context, .. }
+            | Self::SetCommentStatus { context, .. }
+            | Self::DeleteComment { context, .. } => context,
+        }
+    }
+}
+
 /// Transport-neutral wire response for a remote `CommentsThreadPort` provider.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "result", content = "payload", rename_all = "snake_case")]
@@ -68,6 +83,14 @@ pub enum CommentsThreadResponse {
         total: u64,
     },
     Deleted,
+}
+
+/// Stable provider reply envelope used by concrete remote transports.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "status", content = "payload", rename_all = "snake_case")]
+pub enum CommentsThreadTransportReply {
+    Success(CommentsThreadResponse),
+    Error(PortError),
 }
 
 /// Executes one typed Comments request over a concrete remote transport.

--- a/crates/rustok-comments/src/tcp_transport.rs
+++ b/crates/rustok-comments/src/tcp_transport.rs
@@ -1,0 +1,228 @@
+use std::{net::SocketAddr, time::Duration};
+
+use async_trait::async_trait;
+use rustok_api::PortError;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpStream,
+    time::timeout,
+};
+
+use crate::{
+    CommentsThreadRequest, CommentsThreadResponse, CommentsThreadTransport,
+    CommentsThreadTransportReply,
+};
+
+/// Default upper bound for one length-prefixed Comments request or response.
+pub const DEFAULT_MAX_COMMENTS_FRAME_BYTES: usize = 8 * 1024 * 1024;
+
+/// Concrete sidecar transport using length-prefixed JSON over TCP.
+///
+/// Endpoint resolution and authentication remain host-owned. Each operation opens
+/// one connection, carries the typed request unchanged, applies the port deadline
+/// to the complete exchange, and closes the connection after one typed reply.
+#[derive(Clone, Debug)]
+pub struct TcpJsonCommentsTransport {
+    endpoint: SocketAddr,
+    max_frame_bytes: usize,
+}
+
+impl TcpJsonCommentsTransport {
+    pub fn new(endpoint: SocketAddr) -> Self {
+        Self {
+            endpoint,
+            max_frame_bytes: DEFAULT_MAX_COMMENTS_FRAME_BYTES,
+        }
+    }
+
+    pub fn with_max_frame_bytes(
+        endpoint: SocketAddr,
+        max_frame_bytes: usize,
+    ) -> Result<Self, PortError> {
+        validate_frame_limit(max_frame_bytes)?;
+        Ok(Self {
+            endpoint,
+            max_frame_bytes,
+        })
+    }
+
+    pub fn endpoint(&self) -> SocketAddr {
+        self.endpoint
+    }
+
+    pub fn max_frame_bytes(&self) -> usize {
+        self.max_frame_bytes
+    }
+
+    async fn exchange(
+        &self,
+        request_payload: &[u8],
+    ) -> Result<CommentsThreadResponse, PortError> {
+        let mut stream = TcpStream::connect(self.endpoint)
+            .await
+            .map_err(|error| io_error("connect", error))?;
+        stream
+            .set_nodelay(true)
+            .map_err(|error| io_error("set_nodelay", error))?;
+
+        write_frame(&mut stream, request_payload, self.max_frame_bytes).await?;
+        let response_payload = read_frame(&mut stream, self.max_frame_bytes).await?;
+        decode_reply(&response_payload)
+    }
+}
+
+#[async_trait]
+impl CommentsThreadTransport for TcpJsonCommentsTransport {
+    async fn execute(
+        &self,
+        request: CommentsThreadRequest,
+    ) -> Result<CommentsThreadResponse, PortError> {
+        request.context().require_deadline_semantics()?;
+        let deadline_ms = request.context().deadline_ms.unwrap_or_default();
+        let request_payload = serde_json::to_vec(&request).map_err(|error| {
+            PortError::invariant_violation("comments.tcp_encode", error.to_string())
+        })?;
+        ensure_frame_size(request_payload.len(), self.max_frame_bytes)?;
+
+        timeout(
+            Duration::from_millis(deadline_ms),
+            self.exchange(&request_payload),
+        )
+        .await
+        .map_err(|_| {
+            PortError::timeout(
+                "comments.tcp_timeout",
+                "comments sidecar call exceeded the port deadline",
+            )
+        })?
+    }
+}
+
+async fn write_frame(
+    stream: &mut TcpStream,
+    payload: &[u8],
+    max_frame_bytes: usize,
+) -> Result<(), PortError> {
+    ensure_frame_size(payload.len(), max_frame_bytes)?;
+    let length = u32::try_from(payload.len()).map_err(|_| {
+        PortError::invariant_violation(
+            "comments.tcp_frame_too_large",
+            "comments TCP frame length exceeds the u32 wire limit",
+        )
+    })?;
+
+    stream
+        .write_all(&length.to_be_bytes())
+        .await
+        .map_err(|error| io_error("write_length", error))?;
+    stream
+        .write_all(payload)
+        .await
+        .map_err(|error| io_error("write_payload", error))?;
+    stream
+        .flush()
+        .await
+        .map_err(|error| io_error("flush", error))?;
+    Ok(())
+}
+
+async fn read_frame(
+    stream: &mut TcpStream,
+    max_frame_bytes: usize,
+) -> Result<Vec<u8>, PortError> {
+    let mut length_bytes = [0_u8; 4];
+    stream
+        .read_exact(&mut length_bytes)
+        .await
+        .map_err(|error| io_error("read_length", error))?;
+    let length = u32::from_be_bytes(length_bytes) as usize;
+    ensure_frame_size(length, max_frame_bytes)?;
+
+    let mut payload = vec![0_u8; length];
+    stream
+        .read_exact(&mut payload)
+        .await
+        .map_err(|error| io_error("read_payload", error))?;
+    Ok(payload)
+}
+
+fn decode_reply(payload: &[u8]) -> Result<CommentsThreadResponse, PortError> {
+    let reply = serde_json::from_slice::<CommentsThreadTransportReply>(payload).map_err(|error| {
+        PortError::invariant_violation("comments.tcp_decode", error.to_string())
+    })?;
+    match reply {
+        CommentsThreadTransportReply::Success(response) => Ok(response),
+        CommentsThreadTransportReply::Error(error) => Err(error),
+    }
+}
+
+fn validate_frame_limit(max_frame_bytes: usize) -> Result<(), PortError> {
+    if max_frame_bytes == 0 || max_frame_bytes > u32::MAX as usize {
+        return Err(PortError::validation(
+            "comments.tcp_invalid_frame_limit",
+            "comments TCP frame limit must be within 1..=u32::MAX",
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_frame_size(length: usize, max_frame_bytes: usize) -> Result<(), PortError> {
+    validate_frame_limit(max_frame_bytes)?;
+    if length > max_frame_bytes {
+        return Err(PortError::invariant_violation(
+            "comments.tcp_frame_too_large",
+            format!(
+                "comments TCP frame length {length} exceeds configured limit {max_frame_bytes}"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn io_error(stage: &'static str, error: std::io::Error) -> PortError {
+    if error.kind() == std::io::ErrorKind::TimedOut {
+        return PortError::timeout(
+            "comments.tcp_timeout",
+            format!("comments TCP {stage} timed out"),
+        );
+    }
+    PortError::unavailable(
+        "comments.tcp_unavailable",
+        format!("comments TCP {stage} failed: {error}"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rustok_api::PortErrorKind;
+
+    use super::*;
+
+    #[test]
+    fn tcp_transport_is_injectable_without_connecting() {
+        let endpoint = "127.0.0.1:1".parse().unwrap();
+        let transport: Arc<dyn CommentsThreadTransport> =
+            Arc::new(TcpJsonCommentsTransport::new(endpoint));
+        let _ = transport;
+    }
+
+    #[test]
+    fn provider_error_reply_is_preserved() {
+        let expected = PortError::validation("comments.exact", "exact provider error");
+        let payload = serde_json::to_vec(&CommentsThreadTransportReply::Error(expected.clone()))
+            .unwrap();
+
+        assert_eq!(decode_reply(&payload).unwrap_err(), expected);
+    }
+
+    #[test]
+    fn invalid_frame_limit_fails_closed() {
+        let endpoint = "127.0.0.1:1".parse().unwrap();
+        let error = TcpJsonCommentsTransport::with_max_frame_bytes(endpoint, 0).unwrap_err();
+
+        assert_eq!(error.kind, PortErrorKind::Validation);
+        assert_eq!(error.code, "comments.tcp_invalid_frame_limit");
+    }
+}

--- a/scripts/verify/verify-blog-comments-tcp-transport.mjs
+++ b/scripts/verify/verify-blog-comments-tcp-transport.mjs
@@ -1,0 +1,203 @@
+import fs from 'node:fs';
+
+const evidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-tcp-transport.json';
+const manifestPath = 'crates/rustok-comments/Cargo.toml';
+const exportPath = 'crates/rustok-comments/src/lib.rs';
+const remotePath = 'crates/rustok-comments/src/remote.rs';
+const transportPath = 'crates/rustok-comments/src/tcp_transport.rs';
+const planPath = 'crates/rustok-blog/docs/implementation-plan-slice-68.md';
+
+function read(path) {
+  return fs.readFileSync(path, 'utf8');
+}
+
+function json(path) {
+  return JSON.parse(read(path));
+}
+
+function fail(message) {
+  console.error(`[verify-blog-comments-tcp-transport] ${message}`);
+  process.exit(1);
+}
+
+function hasAll(text, snippets, label) {
+  for (const snippet of snippets) {
+    if (!text.includes(snippet)) fail(`${label} missing ${snippet}`);
+  }
+}
+
+function hasNone(text, snippets, label) {
+  for (const snippet of snippets) {
+    if (text.includes(snippet)) fail(`${label} contains forbidden ${snippet}`);
+  }
+}
+
+function sameSet(actual, expected, label) {
+  const left = [...actual].sort().join('|');
+  const right = [...expected].sort().join('|');
+  if (left !== right) fail(`${label} drift: expected ${right}, got ${left}`);
+}
+
+for (const path of [evidencePath, manifestPath, exportPath, remotePath, transportPath, planPath]) {
+  if (!fs.existsSync(path)) fail(`missing source artifact ${path}`);
+}
+
+const evidence = json(evidencePath);
+const manifest = read(manifestPath);
+const exports = read(exportPath);
+const remote = read(remotePath);
+const transport = read(transportPath);
+const plan = read(planPath);
+
+if (evidence.schema_version !== 1) fail('evidence schema_version drift');
+if (
+  evidence.module !== 'blog'
+  || evidence.provider !== 'comments'
+  || evidence.surface !== 'comments_tcp_json_transport'
+) fail('evidence identity drift');
+if (
+  evidence.status !== 'source_verified_no_compile'
+  || evidence.compile_policy !== 'not_run_by_request'
+  || evidence.runtime_status !== 'not_run'
+) fail('evidence execution status drift');
+if (evidence.generated_from !== planPath) fail('evidence plan path drift');
+
+const expectedOperations = [
+  'CreateComment',
+  'GetComment',
+  'ListCommentsForTarget',
+  'ListPublicCommentsForTarget',
+  'UpdateComment',
+  'SetCommentStatus',
+  'DeleteComment',
+];
+sameSet(evidence.operations ?? [], expectedOperations, 'transport operations');
+
+if (
+  evidence.source_contract?.remote_core !== remotePath
+  || evidence.source_contract?.transport_adapter !== transportPath
+  || evidence.source_contract?.provider_export !== exportPath
+  || evidence.source_contract?.provider_manifest !== manifestPath
+) fail('source contract path drift');
+
+if (
+  evidence.protocol?.name !== 'comments_tcp_length_prefixed_json_v1'
+  || evidence.protocol?.length_prefix !== 'u32_big_endian'
+  || evidence.protocol?.request_encoding !== 'serde_json'
+  || evidence.protocol?.reply_encoding !== 'serde_json'
+  || evidence.protocol?.connection_scope !== 'one_request_one_reply'
+  || evidence.protocol?.default_max_frame_bytes !== 8388608
+  || evidence.protocol?.endpoint_owner !== 'host'
+) fail('protocol contract drift');
+
+if (
+  evidence.deadline?.source !== 'PortContext.deadline_ms'
+  || evidence.deadline?.required_before_connect !== true
+  || evidence.deadline?.scope !== 'connect_write_read_decode'
+  || evidence.deadline?.mechanism !== 'tokio::time::timeout'
+  || evidence.deadline?.timeout_code !== 'comments.tcp_timeout'
+) fail('deadline contract drift');
+
+if (evidence.fail_closed?.retry_implemented !== false) fail('retry status drift');
+
+sameSet(
+  evidence.pending ?? [],
+  [
+    'tcp_server_adapter',
+    'endpoint_discovery',
+    'authentication',
+    'retry_backoff',
+    'host_publication',
+    'in_process_remote_runtime_parity',
+    'runtime_execution',
+  ],
+  'pending transport scope',
+);
+
+hasAll(
+  manifest,
+  [
+    'tcp-transport = ["server", "dep:tokio"]',
+    'tokio = { workspace = true, optional = true }',
+  ],
+  'comments manifest',
+);
+
+hasAll(
+  exports,
+  [
+    '#[cfg(feature = "tcp-transport")]',
+    'pub mod tcp_transport;',
+    'pub use tcp_transport::TcpJsonCommentsTransport;',
+  ],
+  'comments exports',
+);
+
+hasAll(
+  remote,
+  [
+    'pub fn context(&self) -> &PortContext',
+    'pub enum CommentsThreadTransportReply',
+    'Success(CommentsThreadResponse)',
+    'Error(PortError)',
+  ],
+  'remote core',
+);
+for (const operation of expectedOperations) {
+  if (!remote.includes(`Self::${operation} { context, .. }`)) {
+    fail(`remote request context coverage missing ${operation}`);
+  }
+}
+
+hasAll(
+  transport,
+  [
+    'pub const DEFAULT_MAX_COMMENTS_FRAME_BYTES: usize = 8 * 1024 * 1024;',
+    'pub struct TcpJsonCommentsTransport',
+    'impl CommentsThreadTransport for TcpJsonCommentsTransport',
+    'TcpStream::connect(self.endpoint)',
+    'request.context().require_deadline_semantics()?;',
+    'Duration::from_millis(deadline_ms)',
+    'self.exchange(&request_payload)',
+    'length.to_be_bytes()',
+    'u32::from_be_bytes(length_bytes)',
+    'CommentsThreadTransportReply::Success(response)',
+    'CommentsThreadTransportReply::Error(error)',
+    'comments.tcp_invalid_frame_limit',
+    'comments.tcp_frame_too_large',
+    'comments.tcp_encode',
+    'comments.tcp_decode',
+    'comments.tcp_unavailable',
+    'comments.tcp_timeout',
+    'provider_error_reply_is_preserved',
+    'tcp_transport_is_injectable_without_connecting',
+  ],
+  'TCP transport',
+);
+
+hasNone(
+  transport,
+  [
+    'loop {',
+    'retry(',
+    'Authorization',
+    'Bearer ',
+  ],
+  'TCP transport non-claims',
+);
+
+hasAll(
+  plan,
+  [
+    '# rustok-blog implementation plan — slice 68 continuation',
+    'comments_tcp_length_prefixed_json_v1',
+    'source_verified_no_compile',
+    'tcp_server_adapter',
+    'host_publication',
+    'retry_backoff',
+    'not_run_by_request',
+  ],
+  'slice 68 plan',
+);
+
+console.log('[verify-blog-comments-tcp-transport] source contract verified');


### PR DESCRIPTION
## Summary

- continue the Blog improvement plan with slice 68
- add `TcpJsonCommentsTransport` as a concrete `CommentsThreadTransport`
- use bounded u32 big-endian length-prefixed JSON request/reply framing
- preserve the complete typed `CommentsThreadRequest` and provider `PortError`
- apply `PortContext.deadline_ms` to connect, write, read, and decode as one bounded exchange
- reject invalid frame limits, oversized frames, encode/decode failures, disconnects, and deadline exhaustion fail closed
- keep Tokio behind the opt-in `tcp-transport` feature
- retain schema-v1 source evidence and a standalone fail-closed verifier

## Scope intentionally left pending

- TCP server adapter/listener
- endpoint discovery and configuration loading
- authentication and transport encryption
- retry/backoff and circuit breaking
- host publication and automatic in-process/remote selection
- in-process/TCP parity execution
- cached snapshot and comment-form fallback

## Verification

Tests, verifiers, formatting, Cargo checks, TCP runtime targets, database targets, browser targets, workflows, and CI were intentionally not run by request. Suggested maintainer commands are recorded in `crates/rustok-blog/docs/implementation-plan-slice-68.md`.