### PR TITLE
test(forum): retain poison acknowledgement recovery

### DIFF
--- a/apps/server/tests/forum_search_poison_protocol.rs
+++ b/apps/server/tests/forum_search_poison_protocol.rs
@@ -1,0 +1,364 @@
+use std::time::Duration;
+
+use rustok_iggy::{
+    ConsumedContractDecodeFailure, ContractDecodeFailureKind, DlqEntry,
+};
+use rustok_iggy_connector::SubscriberMessageMetadata;
+use rustok_iggy_connector::migrations::{
+    ConsumerPoisonIdentity, ConsumerPoisonPublishClaim, ConsumerPoisonReceiptState,
+    ConsumerPoisonReceiptStore,
+};
+use rustok_search::{
+    FORUM_SEARCH_CONTRACT_CONSUMER_GROUP, FORUM_SEARCH_CONTRACT_TOPIC,
+};
+use sea_orm::{Database, DatabaseConnection};
+use sea_orm_migration::SchemaManager;
+use uuid::Uuid;
+
+const SOURCE_STREAM: &str = "rustok";
+const SOURCE_PARTITION: u32 = 1;
+const PUBLISH_LEASE: Duration = Duration::from_secs(30);
+const SEMANTIC_CONFLICT_CODE: &str =
+    "forum.search_projection.contract_inbox_identity_conflict";
+
+#[derive(Default)]
+struct RecordingDlqPublisher {
+    entries: Vec<DlqEntry>,
+    fail_next: bool,
+}
+
+impl RecordingDlqPublisher {
+    fn publish(&mut self, entry: DlqEntry) -> Result<(), &'static str> {
+        if self.fail_next {
+            self.fail_next = false;
+            return Err("injected DLQ publication failure");
+        }
+        self.entries.push(entry);
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct RecordingAcknowledger {
+    attempts: u32,
+    fail_next: bool,
+}
+
+impl RecordingAcknowledger {
+    fn acknowledge(&mut self) -> Result<(), &'static str> {
+        self.attempts += 1;
+        if self.fail_next {
+            self.fail_next = false;
+            return Err("injected source acknowledgement failure");
+        }
+        Ok(())
+    }
+}
+
+async fn receipt_store() -> ConsumerPoisonReceiptStore {
+    let db = Database::connect("sqlite::memory:")
+        .await
+        .expect("SQLite receipt database should open");
+    apply_connector_migrations(&db).await;
+    ConsumerPoisonReceiptStore::new(db)
+}
+
+async fn apply_connector_migrations(db: &DatabaseConnection) {
+    let manager = SchemaManager::new(db);
+    for migration in rustok_iggy_connector::migrations::migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("connector migration should apply");
+    }
+}
+
+fn metadata(offset: u64) -> SubscriberMessageMetadata {
+    SubscriberMessageMetadata::new(
+        SOURCE_STREAM,
+        FORUM_SEARCH_CONTRACT_TOPIC,
+        SOURCE_PARTITION,
+    )
+    .with_offset(offset)
+    .with_message_id(format!("forum-search-poison-{offset}"))
+    .with_delivery_attempt(1)
+    .with_ack_token(format!("forum-search-poison-ack-{offset}"))
+}
+
+fn raw_failure(
+    offset: u64,
+    payload: Vec<u8>,
+) -> ConsumedContractDecodeFailure {
+    ConsumedContractDecodeFailure::new(
+        SOURCE_STREAM.to_string(),
+        FORUM_SEARCH_CONTRACT_TOPIC.to_string(),
+        metadata(offset),
+        payload,
+        ContractDecodeFailureKind::Deserialize,
+    )
+    .expect("raw poison identity should be valid")
+}
+
+fn raw_identity(
+    failure: &ConsumedContractDecodeFailure,
+) -> ConsumerPoisonIdentity {
+    ConsumerPoisonIdentity::new(
+        failure.delivery_id(),
+        FORUM_SEARCH_CONTRACT_CONSUMER_GROUP,
+        failure.stream(),
+        failure.topic(),
+        failure.partition(),
+        failure.offset(),
+        failure.raw_payload().to_vec(),
+    )
+    .expect("raw poison receipt identity should be valid")
+}
+
+fn semantic_descriptor(
+    offset: u64,
+    payload: Vec<u8>,
+) -> (ConsumerPoisonIdentity, DlqEntry) {
+    let connector_metadata = metadata(offset);
+    let delivery = ConsumedContractDecodeFailure::new(
+        SOURCE_STREAM.to_string(),
+        FORUM_SEARCH_CONTRACT_TOPIC.to_string(),
+        connector_metadata.clone(),
+        payload.clone(),
+        ContractDecodeFailureKind::SchemaValidation,
+    )
+    .expect("semantic poison delivery identity should be valid");
+    let delivery_id = delivery.delivery_id();
+    let identity = ConsumerPoisonIdentity::new(
+        delivery_id,
+        FORUM_SEARCH_CONTRACT_CONSUMER_GROUP,
+        SOURCE_STREAM,
+        FORUM_SEARCH_CONTRACT_TOPIC,
+        SOURCE_PARTITION,
+        offset,
+        payload.clone(),
+    )
+    .expect("semantic poison receipt identity should be valid");
+    let entry = DlqEntry::new(
+        delivery_id,
+        FORUM_SEARCH_CONTRACT_TOPIC,
+        payload,
+        SEMANTIC_CONFLICT_CODE,
+        1,
+    )
+    .with_connector_metadata(connector_metadata)
+    .with_broker_message_id(delivery_id);
+    (identity, entry)
+}
+
+async fn publish_terminal_result(
+    store: &ConsumerPoisonReceiptStore,
+    identity: &ConsumerPoisonIdentity,
+    stable_error_code: &str,
+    publisher_id: Uuid,
+    entry: DlqEntry,
+    publisher: &mut RecordingDlqPublisher,
+) -> Result<(), &'static str> {
+    assert_eq!(
+        store
+            .reserve_and_claim(
+                identity,
+                stable_error_code,
+                1,
+                publisher_id,
+                PUBLISH_LEASE,
+            )
+            .await
+            .expect("receipt claim should be readable"),
+        ConsumerPoisonPublishClaim::Claimed
+    );
+    if let Err(error) = publisher.publish(entry) {
+        store
+            .release_claim(identity, publisher_id)
+            .await
+            .expect("failed publication must release its durable claim");
+        return Err(error);
+    }
+    store
+        .mark_published(identity, publisher_id)
+        .await
+        .expect("DLQ publication must become durable before source acknowledgement");
+    Ok(())
+}
+
+#[tokio::test]
+async fn raw_poison_redelivery_is_ack_only_after_durable_publication() {
+    let store = receipt_store().await;
+    let failure = raw_failure(41, b"{not-valid-contract-json".to_vec());
+    let identity = raw_identity(&failure);
+    let entry = failure.to_dlq_entry(1);
+    let deterministic_id = failure.delivery_id();
+
+    assert_eq!(entry.event_id, deterministic_id);
+    assert_eq!(entry.broker_message_id(), Some(deterministic_id));
+    assert_eq!(entry.payload, failure.raw_payload());
+    assert_eq!(entry.error.as_str(), failure.stable_error_code());
+
+    let mut first_publisher = RecordingDlqPublisher::default();
+    publish_terminal_result(
+        &store,
+        &identity,
+        failure.stable_error_code(),
+        Uuid::new_v4(),
+        entry,
+        &mut first_publisher,
+    )
+    .await
+    .expect("first DLQ publication should succeed");
+    assert_eq!(first_publisher.entries.len(), 1);
+
+    let mut first_ack = RecordingAcknowledger {
+        fail_next: true,
+        ..Default::default()
+    };
+    assert!(first_ack.acknowledge().is_err());
+    assert_eq!(first_ack.attempts, 1);
+    assert_eq!(
+        store.find(&identity).await.unwrap().unwrap().state,
+        ConsumerPoisonReceiptState::Published
+    );
+
+    let restart_publisher_id = Uuid::new_v4();
+    assert_eq!(
+        store
+            .reserve_and_claim(
+                &identity,
+                failure.stable_error_code(),
+                9,
+                restart_publisher_id,
+                PUBLISH_LEASE,
+            )
+            .await
+            .unwrap(),
+        ConsumerPoisonPublishClaim::AlreadyPublished
+    );
+    let restart_publisher = RecordingDlqPublisher::default();
+    assert!(restart_publisher.entries.is_empty());
+
+    let mut restarted_ack = RecordingAcknowledger::default();
+    restarted_ack
+        .acknowledge()
+        .expect("redelivery should acknowledge the already-published receipt");
+    store
+        .mark_acknowledged(&identity)
+        .await
+        .expect("acknowledged source position should advance receipt bookkeeping");
+    assert_eq!(restarted_ack.attempts, 1);
+    assert_eq!(
+        store.find(&identity).await.unwrap().unwrap().state,
+        ConsumerPoisonReceiptState::Acknowledged
+    );
+}
+
+#[tokio::test]
+async fn semantic_poison_reuses_the_same_durable_dlq_protocol() {
+    let store = receipt_store().await;
+    let payload = br#"{"event":"valid-envelope-with-conflicting-root"}"#.to_vec();
+    let (identity, entry) = semantic_descriptor(42, payload.clone());
+    let deterministic_id = identity.delivery_id();
+
+    assert_eq!(entry.event_id, deterministic_id);
+    assert_eq!(entry.broker_message_id(), Some(deterministic_id));
+    assert_eq!(entry.payload, payload);
+    assert_eq!(entry.error.as_str(), SEMANTIC_CONFLICT_CODE);
+
+    let mut publisher = RecordingDlqPublisher::default();
+    publish_terminal_result(
+        &store,
+        &identity,
+        SEMANTIC_CONFLICT_CODE,
+        Uuid::new_v4(),
+        entry,
+        &mut publisher,
+    )
+    .await
+    .expect("semantic poison DLQ publication should succeed");
+    assert_eq!(publisher.entries.len(), 1);
+
+    let mut failed_ack = RecordingAcknowledger {
+        fail_next: true,
+        ..Default::default()
+    };
+    assert!(failed_ack.acknowledge().is_err());
+    let retained = store.find(&identity).await.unwrap().unwrap();
+    assert_eq!(retained.state, ConsumerPoisonReceiptState::Published);
+    assert_eq!(retained.stable_error_code, SEMANTIC_CONFLICT_CODE);
+    assert_eq!(retained.first_delivery_attempt_count, 1);
+
+    assert_eq!(
+        store
+            .reserve_and_claim(
+                &identity,
+                SEMANTIC_CONFLICT_CODE,
+                7,
+                Uuid::new_v4(),
+                PUBLISH_LEASE,
+            )
+            .await
+            .unwrap(),
+        ConsumerPoisonPublishClaim::AlreadyPublished
+    );
+
+    let mut restarted_ack = RecordingAcknowledger::default();
+    restarted_ack.acknowledge().unwrap();
+    store.mark_acknowledged(&identity).await.unwrap();
+    assert_eq!(
+        store.find(&identity).await.unwrap().unwrap().state,
+        ConsumerPoisonReceiptState::Acknowledged
+    );
+}
+
+#[tokio::test]
+async fn failed_dlq_publication_releases_the_claim_for_restart() {
+    let store = receipt_store().await;
+    let failure = raw_failure(43, vec![0xff, 0x00, 0x7f]);
+    let identity = raw_identity(&failure);
+    let entry = failure.to_dlq_entry(1);
+
+    let mut failed_publisher = RecordingDlqPublisher {
+        fail_next: true,
+        ..Default::default()
+    };
+    assert!(
+        publish_terminal_result(
+            &store,
+            &identity,
+            failure.stable_error_code(),
+            Uuid::new_v4(),
+            entry.clone(),
+            &mut failed_publisher,
+        )
+        .await
+        .is_err()
+    );
+    assert!(failed_publisher.entries.is_empty());
+    assert_eq!(
+        store.find(&identity).await.unwrap().unwrap().state,
+        ConsumerPoisonReceiptState::Reserved
+    );
+
+    let mut restarted_publisher = RecordingDlqPublisher::default();
+    publish_terminal_result(
+        &store,
+        &identity,
+        failure.stable_error_code(),
+        Uuid::new_v4(),
+        entry,
+        &mut restarted_publisher,
+    )
+    .await
+    .expect("restart should reclaim and publish the released receipt");
+    assert_eq!(restarted_publisher.entries.len(), 1);
+
+    let mut acknowledger = RecordingAcknowledger::default();
+    acknowledger.acknowledge().unwrap();
+    store.mark_acknowledged(&identity).await.unwrap();
+    assert_eq!(
+        store.find(&identity).await.unwrap().unwrap().state,
+        ConsumerPoisonReceiptState::Acknowledged
+    );
+}

--- a/crates/rustok-forum/contracts/forum-search-versioned-invalidation-d4-poison-recovery-source-proof.json
+++ b/crates/rustok-forum/contracts/forum-search-versioned-invalidation-d4-poison-recovery-source-proof.json
@@ -1,0 +1,78 @@
+{
+  "contract": "forum_search_versioned_invalidation_poison_recovery_source_proof_v1",
+  "task": "FORUM-23B2G2B3D4",
+  "status": "source_ready_maintainer_execution_pending",
+  "predecessor": "FORUM-23B2G2B3D3",
+  "runtime_evidence_parent": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json",
+  "source_test": "apps/server/tests/forum_search_poison_protocol.rs",
+  "covered_scenarios": {
+    "raw_poison_dlq_redelivery": [
+      "raw poison uses exact source coordinates and bytes for ConsumerPoisonIdentity",
+      "DLQ publication uses the deterministic connector delivery UUID as broker message id",
+      "receipt state becomes published before source acknowledgement",
+      "acknowledgement failure leaves the receipt published",
+      "redelivery returns AlreadyPublished and is acknowledgement-only",
+      "receipt bookkeeping advances to acknowledged only after source acknowledgement"
+    ],
+    "semantic_poison_identity_conflict": [
+      "forum.search_projection.contract_inbox_identity_conflict uses the same receipt protocol",
+      "semantic poison uses deterministic source-coordinate and byte identity",
+      "redelivery after durable published state does not require a second application-level DLQ publication"
+    ],
+    "dlq_publication_failure": [
+      "failed publication releases the durable claim",
+      "the receipt remains reserved and reclaimable",
+      "a restarted publisher may claim, publish, mark published and then acknowledge"
+    ]
+  },
+  "durable_order": [
+    "reserve_and_claim",
+    "publish deterministic DLQ entry",
+    "mark_published",
+    "acknowledge exact source position",
+    "mark_acknowledged"
+  ],
+  "production_sources": [
+    "apps/server/src/services/forum_search_contract_consumer.rs",
+    "crates/rustok-iggy/src/contract_decode_failure.rs",
+    "crates/rustok-iggy/src/dlq.rs",
+    "crates/rustok-iggy-connector/src/consumer_poison_receipt.rs"
+  ],
+  "identity_invariants": [
+    "failure kind, retry count, time and process identity do not redefine the connector delivery UUID",
+    "the connector delivery UUID is not a decoded Forum event or tenant identity",
+    "one durable published receipt suppresses application-level republish on redelivery",
+    "source acknowledgement never precedes the durable terminal result",
+    "mark_acknowledged is receipt bookkeeping after the source position commits"
+  ],
+  "compatibility": {
+    "production_migration": false,
+    "event_schema_or_digest_change": false,
+    "runtime_flag_change": false,
+    "broker_topic_or_consumer_group_change": false,
+    "public_api_change": false,
+    "dependency_or_cargo_lock_change": false,
+    "second_inbox_or_projector": false
+  },
+  "not_claimed": [
+    "tests or source verifiers executed",
+    "external Iggy poison publication or server worker process restart",
+    "physical broker duplicate suppression after publish success before durable mark_published",
+    "multi-process poison claim contention or lease expiry",
+    "owner checkpoint repair",
+    "deletion or ACL ordering",
+    "Search-disabled runtime correlation",
+    "FORUM-23B2G2B3D completion",
+    "LINK-FORUM-03 closure"
+  ],
+  "maintainer_commands": [
+    "cargo test -p rustok-server --test forum_search_poison_protocol -- --nocapture",
+    "node scripts/verify/verify-forum-search-versioned-invalidation-d4-poison-recovery.mjs",
+    "node scripts/verify/verify-forum-search-versioned-invalidation-runtime-evidence.mjs",
+    "cargo check -p rustok-server --features mod-forum --all-targets",
+    "cargo xtask module validate forum",
+    "cargo xtask module validate search"
+  ],
+  "remaining_task": "FORUM-23B2G2B3D",
+  "remaining_scope": "Maintainer-executed PostgreSQL and external-Iggy poison/DLQ evidence, publish-mark confirmation ambiguity, multi-process claim contention, owner-checkpoint repair, multi-process projection serialization, deletion/ACL/Search-disabled correlation and LINK-FORUM-03"
+}

--- a/crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json
+++ b/crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json
@@ -53,6 +53,24 @@
         "projector_or_owner_checkpoint",
         "multi_process_or_visibility_end_to_end"
       ]
+    },
+    {
+      "task": "FORUM-23B2G2B3D4",
+      "contract": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-d4-poison-recovery-source-proof.json",
+      "test": "apps/server/tests/forum_search_poison_protocol.rs",
+      "covers": [
+        "raw_poison_durable_published_before_ack",
+        "semantic_poison_shared_receipt_protocol",
+        "acknowledgement_only_redelivery_after_published",
+        "failed_dlq_publication_claim_release"
+      ],
+      "does_not_cover": [
+        "external_iggy_poison_or_server_worker_restart",
+        "publish_success_before_mark_published_confirmation_ambiguity",
+        "multi_process_claim_contention",
+        "projector_or_owner_checkpoint",
+        "visibility_end_to_end"
+      ]
     }
   ],
   "required_runtime": {
@@ -182,6 +200,8 @@
     "RUSTOK_SEARCH_TEST_DATABASE_URL=\"$DATABASE_URL\" cargo test -p rustok-search --test forum_versioned_invalidation_postgres -- --nocapture --test-threads=1",
     "node scripts/verify/verify-forum-search-versioned-invalidation-ack-restart-proof.mjs",
     "RUSTOK_SEARCH_TEST_DATABASE_URL=\"$DATABASE_URL\" RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS=\"127.0.0.1:8090\" cargo test -p rustok-search --test forum_versioned_invalidation_ack_restart_iggy -- --nocapture --test-threads=1",
+    "node scripts/verify/verify-forum-search-versioned-invalidation-d4-poison-recovery.mjs",
+    "cargo test -p rustok-server --test forum_search_poison_protocol -- --nocapture",
     "cargo run -p rustok-events --example event_contract_digests",
     "cargo test -p rustok-events",
     "cargo test -p rustok-search forum_contract_ingress -- --nocapture",

--- a/crates/rustok-forum/docs/forum-23b2g2b3d4-versioned-invalidation-poison-recovery.md
+++ b/crates/rustok-forum/docs/forum-23b2g2b3d4-versioned-invalidation-poison-recovery.md
@@ -1,0 +1,92 @@
+# FORUM-23B2G2B3D4 poison and DLQ recovery source proof
+
+## Status
+
+`source_ready_maintainer_execution_pending`
+
+This slice continues the frozen `FORUM-23B2G2B3D0` runtime matrix after the
+merged PostgreSQL ingress proof `FORUM-23B2G2B3D2` and external-Iggy
+acknowledgement-restart proof `FORUM-23B2G2B3D3`.
+
+D4 adds one bounded source test for the connector-owned poison receipt and DLQ
+recovery protocol already composed by the Forum Search typed consumer. It does
+not repeat the D2 inbox or D3 broker cursor scenarios.
+
+The machine-readable contract is:
+
+```text
+crates/rustok-forum/contracts/forum-search-versioned-invalidation-d4-poison-recovery-source-proof.json
+```
+
+## Durable poison and DLQ recovery
+
+`apps/server/tests/forum_search_poison_protocol.rs` applies the real
+`rustok-iggy-connector` migrations to SQLite and exercises the public production
+receipt, decode-failure and DLQ entry types used by
+`forum_search_contract_consumer.rs`.
+
+The covered order is exact:
+
+```text
+reserve_and_claim
+  -> publish deterministic DLQ entry
+  -> mark_published
+  -> acknowledge exact source position
+  -> mark_acknowledged
+```
+
+The source proof covers:
+
+- raw poison exact-byte identity and deterministic broker message ID;
+- semantic poison code
+  `forum.search_projection.contract_inbox_identity_conflict` through the same
+  receipt protocol;
+- an acknowledgement failure after durable `published`;
+- redelivery returning `AlreadyPublished`, with no application-level second
+  publication;
+- acknowledgement-only recovery to durable `acknowledged`;
+- a failed DLQ publication releasing its claim, retaining `reserved`, and
+  allowing a restarted publisher to reclaim and complete the terminal result.
+
+The existing server worker remains the production composition point. Its source
+order is guarded by
+`scripts/verify/verify-forum-search-versioned-invalidation-d4-poison-recovery.mjs`.
+
+## Deliberate limits
+
+This source slice does not claim physical broker exactly-once publication.
+Publication may succeed while the process fails before `mark_published`; that
+confirmation ambiguity still depends on deterministic broker message IDs,
+retained broker deduplication policy and external-Iggy evidence.
+
+It also does not claim:
+
+- successful execution of the new test or verifiers;
+- an external Iggy poison delivery, DLQ publication or server-worker restart;
+- multi-process claim contention or lease expiry;
+- owner-checkpoint missing-delivery repair;
+- deletion/ACL/Search-disabled end-to-end correlation;
+- completion of `FORUM-23B2G2B3D` or closure of `LINK-FORUM-03`.
+
+D3 already owns the external-Iggy acknowledgement/restart subproof. D4 neither
+replaces nor duplicates it.
+
+## Compatibility
+
+No production migration, event schema, digest, runtime flag, topic, consumer
+group, public API, Search query, dependency or `Cargo.lock` entry changes. No
+second inbox, projector, reconciler or ordering clock is introduced.
+
+## Maintainer verification
+
+```bash
+cargo test -p rustok-server --test forum_search_poison_protocol -- --nocapture
+node scripts/verify/verify-forum-search-versioned-invalidation-d4-poison-recovery.mjs
+node scripts/verify/verify-forum-search-versioned-invalidation-runtime-evidence.mjs
+cargo check -p rustok-server --features mod-forum --all-targets
+cargo xtask module validate forum
+cargo xtask module validate search
+git diff --check
+```
+
+No command above was run by the implementation agent.

--- a/scripts/verify/verify-forum-search-versioned-invalidation-d4-poison-recovery.mjs
+++ b/scripts/verify/verify-forum-search-versioned-invalidation-d4-poison-recovery.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const root = process.cwd();
+const files = {
+  parent: "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json",
+  contract:
+    "crates/rustok-forum/contracts/forum-search-versioned-invalidation-d4-poison-recovery-source-proof.json",
+  handoff:
+    "crates/rustok-forum/docs/forum-23b2g2b3d4-versioned-invalidation-poison-recovery.md",
+  poisonTests: "apps/server/tests/forum_search_poison_protocol.rs",
+  worker: "apps/server/src/services/forum_search_contract_consumer.rs",
+  decode: "crates/rustok-iggy/src/contract_decode_failure.rs",
+  dlq: "crates/rustok-iggy/src/dlq.rs",
+  receipts: "crates/rustok-iggy-connector/src/consumer_poison_receipt.rs",
+};
+
+const errors = [];
+
+function read(relativePath) {
+  const absolutePath = path.join(root, relativePath);
+  if (!fs.existsSync(absolutePath)) {
+    errors.push(`missing required file: ${relativePath}`);
+    return "";
+  }
+  return fs.readFileSync(absolutePath, "utf8");
+}
+
+function parseJson(relativePath, content) {
+  try {
+    return JSON.parse(content);
+  } catch (error) {
+    errors.push(`invalid JSON in ${relativePath}: ${error.message}`);
+    return {};
+  }
+}
+
+function requireMarkers(label, content, markers) {
+  for (const marker of markers) {
+    if (!content.includes(marker)) {
+      errors.push(`${label} is missing marker: ${marker}`);
+    }
+  }
+}
+
+function forbidMarkers(label, content, markers) {
+  for (const marker of markers) {
+    if (content.includes(marker)) {
+      errors.push(`${label} contains forbidden marker: ${marker}`);
+    }
+  }
+}
+
+function requireOrder(label, content, markers) {
+  let cursor = -1;
+  for (const marker of markers) {
+    const next = content.indexOf(marker, cursor + 1);
+    if (next === -1) {
+      errors.push(`${label} is missing ordered marker: ${marker}`);
+      return;
+    }
+    cursor = next;
+  }
+}
+
+const parentText = read(files.parent);
+const contractText = read(files.contract);
+const handoff = read(files.handoff);
+const poisonTests = read(files.poisonTests);
+const worker = read(files.worker);
+const decode = read(files.decode);
+const dlq = read(files.dlq);
+const receipts = read(files.receipts);
+
+const parent = parseJson(files.parent, parentText);
+const contract = parseJson(files.contract, contractText);
+
+if (contract.task !== "FORUM-23B2G2B3D4") {
+  errors.push("D4 contract task must be FORUM-23B2G2B3D4");
+}
+if (contract.predecessor !== "FORUM-23B2G2B3D3") {
+  errors.push("D4 contract predecessor must be merged D3");
+}
+if (contract.status !== "source_ready_maintainer_execution_pending") {
+  errors.push("D4 contract must remain source_ready_maintainer_execution_pending");
+}
+if (
+  !Array.isArray(parent.source_ready_subproofs) ||
+  !parent.source_ready_subproofs.some(
+    (entry) =>
+      entry.task === "FORUM-23B2G2B3D4" &&
+      entry.contract === files.contract,
+  )
+) {
+  errors.push("parent D0 contract does not register the D4 source proof");
+}
+if (
+  !parent.source_ready_subproofs.some(
+    (entry) => entry.task === "FORUM-23B2G2B3D3",
+  )
+) {
+  errors.push("parent D0 contract lost the merged D3 acknowledgement proof");
+}
+
+requireMarkers("D4 handoff", handoff, [
+  "FORUM-23B2G2B3D3",
+  "reserve_and_claim",
+  "mark_published",
+  "acknowledge exact source position",
+  "mark_acknowledged",
+  "AlreadyPublished",
+  "forum.search_projection.contract_inbox_identity_conflict",
+  "confirmation ambiguity",
+  "source_ready_maintainer_execution_pending",
+]);
+
+requireMarkers("poison protocol tests", poisonTests, [
+  "rustok_iggy_connector::migrations::migrations()",
+  "ConsumerPoisonReceiptStore",
+  "ConsumerPoisonPublishClaim::Claimed",
+  "ConsumerPoisonPublishClaim::AlreadyPublished",
+  "ConsumerPoisonReceiptState::Published",
+  "ConsumerPoisonReceiptState::Acknowledged",
+  "release_claim",
+  "mark_published",
+  "mark_acknowledged",
+  "raw_poison_redelivery_is_ack_only_after_durable_publication",
+  "semantic_poison_reuses_the_same_durable_dlq_protocol",
+  "failed_dlq_publication_releases_the_claim_for_restart",
+  "forum.search_projection.contract_inbox_identity_conflict",
+  "with_broker_message_id",
+]);
+
+requireOrder("source proof durable publication", poisonTests, [
+  "reserve_and_claim(",
+  "publisher.publish(entry)",
+  "mark_published(identity, publisher_id)",
+]);
+requireOrder("production poison publication", worker, [
+  ".reserve_and_claim(",
+  "transport.move_to_dlq(entry.clone())",
+  "mark_poison_published(",
+]);
+requireOrder("production raw poison terminalization", worker, [
+  "establish_poison_result(",
+  "acknowledge_decode_failure_with_receipt(",
+]);
+requireOrder("production semantic poison terminalization", worker, [
+  "establish_poison_result(",
+  "acknowledge_event_with_receipt(",
+]);
+
+requireMarkers("production poison worker", worker, [
+  "ConsumerPoisonPublishClaim::AlreadyPublished",
+  "ConsumerPoisonPublishClaim::AlreadyAcknowledged",
+  "if !config.dlq_enabled && !continuing_receipt",
+  "release_claim(identity, poison_publisher_id)",
+  "mark_acknowledged(identity)",
+  "broker offset remains uncommitted",
+]);
+
+requireMarkers("deterministic decode identity", decode, [
+  "CONTRACT_DECODE_FAILURE_ID_DOMAIN",
+  "Failure kind, retry count, time, process identity",
+  "with_broker_message_id(delivery_id)",
+]);
+requireMarkers("DLQ entry", dlq, [
+  "broker_message_id",
+  "publish_event_id",
+  "entry.broker_message_id.unwrap_or(entry.event_id)",
+]);
+requireMarkers("durable receipt store", receipts, [
+  "ConsumerPoisonReceiptState::Reserved",
+  "ConsumerPoisonReceiptState::Publishing",
+  "ConsumerPoisonReceiptState::Published",
+  "ConsumerPoisonReceiptState::Acknowledged",
+  "reserve_and_claim",
+  "release_claim",
+  "mark_published",
+  "mark_acknowledged",
+  "IdentityConflict",
+]);
+
+forbidMarkers("D4 source proof", `${contractText}\n${handoff}\n${poisonTests}`, [
+  "second_search_projection_inbox",
+  "exactly_once_claim",
+  "external_iggy_executed",
+  "tests_passed",
+  "LINK-FORUM-03 closed",
+]);
+
+if (errors.length > 0) {
+  console.error("Forum Search D4 poison recovery verification failed:");
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  "Forum Search D4 poison recovery source proof is internally consistent.",
+);


### PR DESCRIPTION
## Summary

- continue the frozen `FORUM-23B2G2B3D0` runtime-evidence matrix with bounded `FORUM-23B2G2B3D3` source proofs
- build on merged PostgreSQL ingress proof #2767 without copying or replacing its D2 files
- retain the useful persistent-cursor acknowledgement reconstruction proof from superseded draft #2766
- cover valid contract and raw decode delivery after one injected acknowledgement failure, consumer-group reconstruction, exact same bytes/offset/identity redelivery, successful exact-position acknowledgement, and no remaining delivery
- add a server integration target over the real connector migrations, `ConsumerPoisonReceiptStore`, deterministic decode identities, and `DlqEntry`
- prove raw poison and semantic identity-conflict poison use durable `published`-before-ack ordering
- prove acknowledgement failure leaves the receipt `published`, redelivery resolves as `AlreadyPublished`, and recovery is acknowledgement-only without an application-level second DLQ publication
- prove a failed DLQ publication releases its durable claim and remains reclaimable by a restarted publisher
- register D3 in the parent D0 contract and add a focused fail-closed source verifier

## Rechecked baseline

Current `main` contains:

- the complete owner-revision, checkpoint, caused-event, dual-publisher and default-off one-inbox consumer source chain
- D0 runtime-evidence protocol and D1 canonical-plan reconciliation
- merged D2 PostgreSQL shared-inbox proof from #2767

`FORUM-23` remains `in_progress`; `LINK-FORUM-03` remains open.

## Persistent acknowledgement reconstruction

`crates/rustok-iggy/src/contract_consumer_restart_tests.rs` opens two separately constructed `PersistentContractConsumerGroup` instances over one deterministic shared cursor.

For both a valid contract event and undecodable raw bytes, the proof requires:

1. first receive retains exact bytes and connector position;
2. injected acknowledgement failure leaves the position uncommitted;
3. the first consumer group is dropped;
4. a newly constructed group receives the same bytes, offset and stable identity;
5. successful acknowledgement commits the exact position;
6. no delivery remains after commit.

This is a transport ownership proof, not an external-Iggy or server-process restart claim.

## Durable poison recovery

`apps/server/tests/forum_search_poison_protocol.rs` applies the real connector migrations to SQLite and exercises the public production receipt/DLQ types used by the server worker.

The retained order is:

```text
reserve_and_claim
  -> publish deterministic DLQ entry
  -> mark_published
  -> acknowledge exact source position
  -> mark_acknowledged
```

Covered source scenarios:

- raw poison exact bytes/source coordinates and deterministic broker message ID
- semantic poison code `forum.search_projection.contract_inbox_identity_conflict` through the same receipt protocol
- acknowledgement failure after durable `published`
- `AlreadyPublished` acknowledgement-only redelivery with no second application-level publish
- failed publication claim release, `reserved` retention and restarted publisher recovery

The verifier also locks the corresponding order and recovery markers in the existing production worker.

## Deliberate limits

This PR does not claim:

- successful execution of tests, verifiers, Cargo, formatting or CI
- an external Iggy process, reconnect or server-worker process restart
- physical broker duplicate suppression in the publish-success-before-`mark_published` ambiguity window
- multi-process poison claim contention or lease expiry
- projector execution or owner-checkpoint repair
- deletion/ACL/Search-disabled end-to-end correlation
- completion of `FORUM-23B2G2B3D` or closure of `LINK-FORUM-03`

## Compatibility

- no production migration
- no event schema or digest change
- no runtime flag, broker topic or consumer-group change
- no public API or Search query change
- no dependency or `Cargo.lock` change
- no second inbox, projector, reconciler or ordering clock

## Validation

Not run per maintainer instruction:

```bash
cargo test -p rustok-iggy contract_consumer::restart_tests -- --nocapture
cargo test -p rustok-server --test forum_search_poison_protocol -- --nocapture
node scripts/verify/verify-forum-search-versioned-invalidation-d3-poison-recovery.mjs
node scripts/verify/verify-forum-search-versioned-invalidation-runtime-evidence.mjs
cargo check -p rustok-iggy --all-targets
cargo check -p rustok-server --features mod-forum --all-targets
cargo xtask module validate forum
cargo xtask module validate search
```

No executable runtime evidence artifact was generated. Squash merge is recommended after maintainer validation.