### PR TITLE
feat(blog): add trusted Comments TCP server adapter

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-comments-tcp-server-adapter.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-tcp-server-adapter.json
@@ -1,0 +1,102 @@
+{
+  "schema_version": 1,
+  "module": "blog",
+  "provider": "comments",
+  "surface": "comments_tcp_server_adapter",
+  "status": "source_verified_no_compile",
+  "compile_policy": "not_run_by_request",
+  "runtime_status": "not_run",
+  "generated_from": "crates/rustok-blog/docs/implementation-plan-slice-69.md",
+  "source_contract": {
+    "server_adapter": "crates/rustok-comments/src/tcp_server.rs",
+    "shared_protocol": "crates/rustok-comments/src/tcp_protocol.rs",
+    "client_transport": "crates/rustok-comments/src/tcp_transport.rs",
+    "provider_export": "crates/rustok-comments/src/lib.rs",
+    "port": "rustok_comments::CommentsThreadPort",
+    "request": "rustok_comments::CommentsThreadRequest",
+    "response": "rustok_comments::CommentsThreadResponse",
+    "reply": "rustok_comments::CommentsThreadTransportReply"
+  },
+  "protocol": {
+    "identity": "comments_tcp_length_prefixed_json_v1",
+    "length_prefix": "u32_big_endian",
+    "one_request_per_connection": true,
+    "one_reply_per_connection": true,
+    "default_max_frame_bytes": 8388608,
+    "shared_client_server_framing": true
+  },
+  "operations": [
+    "create_comment",
+    "get_comment",
+    "list_comments_for_target",
+    "list_public_comments_for_target",
+    "update_comment",
+    "set_comment_status",
+    "delete_comment"
+  ],
+  "authority": {
+    "resolver": "rustok_comments::CommentsTcpAuthorityResolver",
+    "required": true,
+    "allow_all_fallback": false,
+    "inputs": [
+      "peer_addr",
+      "operation",
+      "claimed_context"
+    ],
+    "trusted_output": "rustok_comments::TrustedCommentsTcpAuthority",
+    "tenant_match_required": true,
+    "replaced_fields": [
+      "actor",
+      "claims",
+      "roles"
+    ],
+    "preserved_request_metadata": [
+      "channel",
+      "locale",
+      "correlation_id",
+      "causation_id",
+      "traceparent",
+      "idempotency_key",
+      "deadline_ms"
+    ]
+  },
+  "deadline": {
+    "required_before_dispatch": true,
+    "server_scope": "authority_resolution_and_provider_dispatch",
+    "client_scope": "complete_exchange"
+  },
+  "fail_closed": {
+    "typed_error_reply": true,
+    "exact_provider_error_preserved": true,
+    "malformed_request_code": "comments.tcp_server_invalid_request",
+    "tenant_mismatch_code": "comments.tcp_authority_tenant_mismatch",
+    "processing_timeout_code": "comments.tcp_server_timeout",
+    "invalid_frame_limit_code": "comments.tcp_invalid_frame_limit",
+    "oversized_frame_code": "comments.tcp_frame_too_large"
+  },
+  "pending": [
+    "listener_bind_and_accept_loop",
+    "concrete_authority_resolver",
+    "credentials_or_mtls_identity",
+    "transport_encryption",
+    "endpoint_discovery_and_configuration",
+    "host_publication",
+    "automatic_in_process_remote_selection",
+    "connection_idle_timeout",
+    "bounded_concurrency_and_shutdown",
+    "retry_backoff",
+    "in_process_tcp_runtime_parity",
+    "runtime_execution"
+  ],
+  "explicit_non_claims": [
+    "no_compile_result",
+    "no_rust_test_result",
+    "no_javascript_verifier_result",
+    "no_tcp_runtime_result",
+    "no_database_result",
+    "no_browser_result",
+    "no_workflow_result",
+    "no_ci_result",
+    "no_production_result"
+  ]
+}

--- a/crates/rustok-blog/docs/implementation-plan-slice-69.md
+++ b/crates/rustok-blog/docs/implementation-plan-slice-69.md
@@ -1,0 +1,114 @@
+# rustok-blog implementation plan — slice 69 continuation
+
+This document continues
+`crates/rustok-blog/docs/implementation-plan-slice-68.md`. Slices 1–66 remain in
+the original implementation plan, slice 67 retains the transport-neutral Comments
+remote adapter, and slice 68 retains the concrete TCP JSON client transport.
+
+## 2026-07-31 continuation audit
+
+The slice 68 client transport was rechecked against current `main` at
+`2d299c82f398b4e0558e7e58bbf19a097462c3c4`. Its seven-operation typed request,
+stable success/error reply, bounded length-prefixed JSON framing, complete
+`PortContext`, client-side whole-exchange deadline, source evidence, and explicit
+runtime non-claims remain present.
+
+No compile, Rust or JavaScript test, TCP exchange, database, browser, workflow,
+CI, production, or runtime result is promoted by this continuation. Execution
+remains maintainer-owned.
+
+## Slice 69 — trusted Comments TCP server adapter
+
+### Implemented source scope
+
+- `crates/rustok-comments/src/tcp_protocol.rs` owns the shared bounded four-byte
+  unsigned big-endian length-prefix framing used by both TCP client and server.
+- `crates/rustok-comments/src/tcp_server.rs` adds
+  `TcpJsonCommentsServerAdapter` for exactly one typed request/reply exchange on
+  a host-accepted `TcpStream`.
+- The adapter decodes `CommentsThreadRequest`, dispatches all seven operations to
+  a host-selected `Arc<dyn CommentsThreadPort>`, and returns either the matching
+  `CommentsThreadResponse` or the exact provider `PortError` in
+  `CommentsThreadTransportReply`.
+- Listener ownership, accept-loop lifecycle, concurrency policy, shutdown, and
+  socket binding remain host responsibilities.
+- `CommentsTcpAuthorityResolver` is mandatory. There is no allow-all constructor
+  and no fallback that trusts tenant, actor, claims, or roles from the network
+  payload.
+- The resolver receives the peer address, stable `CommentsTcpOperation`, and
+  claimed context. It returns `TrustedCommentsTcpAuthority` or a typed error.
+- The adapter requires the trusted tenant to equal the claimed tenant and then
+  replaces actor, claims, and roles with trusted values before provider dispatch.
+- Channel, locale, correlation, causation, traceparent, idempotency key, and
+  deadline remain request metadata and are preserved when authority is applied.
+- Missing deadline semantics fail before authority/provider dispatch. The request
+  deadline bounds the combined authority resolution and provider call.
+- Malformed typed JSON, authority denial, tenant mismatch, provider errors,
+  oversized frames, disconnects, response encoding failure, and processing
+  deadline exhaustion remain typed and fail closed.
+- `crates/rustok-comments/src/lib.rs` exports the client and server adapters only
+  behind the existing opt-in `tcp-transport` feature.
+- Source evidence is retained at
+  `crates/rustok-blog/contracts/evidence/blog-comments-tcp-server-adapter.json`.
+- The standalone fail-closed verifier is
+  `scripts/verify/verify-blog-comments-tcp-server-adapter.mjs`.
+
+### Explicit non-claims
+
+This slice does not implement or claim:
+
+- a listener bind or accept loop;
+- a concrete authority resolver, credential loader, mTLS identity mapper, or
+  transport encryption;
+- endpoint discovery, DNS policy, or runtime configuration publication;
+- automatic in-process/TCP provider selection;
+- retry/backoff, circuit breaking, replay, or write retry policy;
+- connection-level pre-request idle timeout or concurrency limits;
+- in-process/TCP parity execution;
+- successful compile, Rust test, JavaScript verifier, TCP runtime, database,
+  browser, workflow, CI, or production execution.
+
+Status: `source_verified_no_compile`.
+Compile policy: `not_run_by_request`.
+Runtime status: `not_run`.
+
+## Next implementation results
+
+1. Publish the TCP client/server choice through host runtime configuration while
+   preserving the current in-process fallback.
+2. Add host-owned listener lifecycle, bounded concurrency, shutdown, pre-request
+   idle timeout, endpoint configuration, and a concrete authenticated authority
+   resolver. Production publication must use transport encryption or an
+   equivalently protected local sidecar channel.
+3. Add bounded retry/backoff only for retryable failures. Writes must never be
+   replayed without the existing idempotency key, and the original deadline must
+   bound the complete attempt set.
+4. Add in-process/TCP parity fixtures for all seven operations, authority denial,
+   tenant mismatch, exact provider errors, malformed requests, oversized frames,
+   disconnects, and timeouts.
+5. Run and record retained Rust, JavaScript, TCP, PostgreSQL, browser, workflow,
+   and CI targets before promoting evidence beyond source-only status.
+6. Continue cached thread snapshot and comment-form fallback work after the
+   remote path has observed runtime evidence.
+
+## Suggested verification — intentionally not run in this slice
+
+- `node scripts/verify/verify-blog-comments-tcp-server-adapter.mjs`
+- `cargo test -p rustok-comments --features tcp-transport --lib tcp_server::tests`
+- `cargo test -p rustok-comments --features tcp-transport --lib tcp_transport::tests`
+- `cargo check -p rustok-comments --features tcp-transport`
+- `npm run verify:blog:comments-port-boundary`
+- `npm run test:verify:blog:comments-port-boundary`
+
+## Boundaries retained
+
+- Comments owns storage, moderation lifecycle, public projection, typed remote
+  requests/replies, provider dispatch, and concrete transport adapters.
+- Blog owns consumer policy, article rendering, typed degraded presentation, and
+  host-selected `Arc<dyn CommentsThreadPort>` composition seams.
+- The host owns endpoint and listener lifecycle, authentication, trusted authority
+  resolution, transport protection, and in-process/remote selection.
+- A transport or authority failure must remain a typed `PortError`; Blog must not
+  infer Comments storage state from TCP details.
+- Source-only evidence remains explicit until the maintainer runs and records the
+  corresponding execution targets.

--- a/crates/rustok-comments/src/lib.rs
+++ b/crates/rustok-comments/src/lib.rs
@@ -16,6 +16,10 @@ mod richtext;
 #[cfg(feature = "server")]
 pub mod services;
 #[cfg(feature = "tcp-transport")]
+mod tcp_protocol;
+#[cfg(feature = "tcp-transport")]
+pub mod tcp_server;
+#[cfg(feature = "tcp-transport")]
 pub mod tcp_transport;
 
 #[cfg(feature = "server")]
@@ -41,6 +45,11 @@ pub use ports::*;
 pub use remote::*;
 #[cfg(feature = "server")]
 pub use services::CommentsService;
+#[cfg(feature = "tcp-transport")]
+pub use tcp_server::{
+    CommentsTcpAuthorityResolver, CommentsTcpOperation, TcpJsonCommentsServerAdapter,
+    TrustedCommentsTcpAuthority,
+};
 #[cfg(feature = "tcp-transport")]
 pub use tcp_transport::TcpJsonCommentsTransport;
 

--- a/crates/rustok-comments/src/tcp_protocol.rs
+++ b/crates/rustok-comments/src/tcp_protocol.rs
@@ -1,0 +1,95 @@
+use rustok_api::PortError;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpStream,
+};
+
+/// Default upper bound for one length-prefixed Comments request or response.
+pub const DEFAULT_MAX_COMMENTS_FRAME_BYTES: usize = 8 * 1024 * 1024;
+
+pub(crate) async fn write_frame(
+    stream: &mut TcpStream,
+    payload: &[u8],
+    max_frame_bytes: usize,
+) -> Result<(), PortError> {
+    ensure_frame_size(payload.len(), max_frame_bytes)?;
+    let length = u32::try_from(payload.len()).map_err(|_| {
+        PortError::invariant_violation(
+            "comments.tcp_frame_too_large",
+            "comments TCP frame length exceeds the u32 wire limit",
+        )
+    })?;
+
+    stream
+        .write_all(&length.to_be_bytes())
+        .await
+        .map_err(|error| io_error("write_length", error))?;
+    stream
+        .write_all(payload)
+        .await
+        .map_err(|error| io_error("write_payload", error))?;
+    stream
+        .flush()
+        .await
+        .map_err(|error| io_error("flush", error))?;
+    Ok(())
+}
+
+pub(crate) async fn read_frame(
+    stream: &mut TcpStream,
+    max_frame_bytes: usize,
+) -> Result<Vec<u8>, PortError> {
+    let mut length_bytes = [0_u8; 4];
+    stream
+        .read_exact(&mut length_bytes)
+        .await
+        .map_err(|error| io_error("read_length", error))?;
+    let length = u32::from_be_bytes(length_bytes) as usize;
+    ensure_frame_size(length, max_frame_bytes)?;
+
+    let mut payload = vec![0_u8; length];
+    stream
+        .read_exact(&mut payload)
+        .await
+        .map_err(|error| io_error("read_payload", error))?;
+    Ok(payload)
+}
+
+pub(crate) fn validate_frame_limit(max_frame_bytes: usize) -> Result<(), PortError> {
+    if max_frame_bytes == 0 || max_frame_bytes > u32::MAX as usize {
+        return Err(PortError::validation(
+            "comments.tcp_invalid_frame_limit",
+            "comments TCP frame limit must be within 1..=u32::MAX",
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn ensure_frame_size(
+    length: usize,
+    max_frame_bytes: usize,
+) -> Result<(), PortError> {
+    validate_frame_limit(max_frame_bytes)?;
+    if length > max_frame_bytes {
+        return Err(PortError::invariant_violation(
+            "comments.tcp_frame_too_large",
+            format!(
+                "comments TCP frame length {length} exceeds configured limit {max_frame_bytes}"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn io_error(stage: &'static str, error: std::io::Error) -> PortError {
+    if error.kind() == std::io::ErrorKind::TimedOut {
+        return PortError::timeout(
+            "comments.tcp_timeout",
+            format!("comments TCP {stage} timed out"),
+        );
+    }
+    PortError::unavailable(
+        "comments.tcp_unavailable",
+        format!("comments TCP {stage} failed: {error}"),
+    )
+}

--- a/crates/rustok-comments/src/tcp_server.rs
+++ b/crates/rustok-comments/src/tcp_server.rs
@@ -127,8 +127,11 @@ impl TcpJsonCommentsServerAdapter {
             Ok(response) => CommentsThreadTransportReply::Success(response),
             Err(error) => CommentsThreadTransportReply::Error(error),
         };
-        let reply_payload = serde_json::to_vec(&reply).map_err(|error| {
-            PortError::invariant_violation("comments.tcp_server_encode", error.to_string())
+        let reply_payload = serde_json::to_vec(&reply).map_err(|_| {
+            PortError::invariant_violation(
+                "comments.tcp_server_encode",
+                "comments TCP server reply could not be encoded",
+            )
         })?;
         write_frame(&mut stream, &reply_payload, self.max_frame_bytes).await
     }
@@ -140,8 +143,11 @@ impl TcpJsonCommentsServerAdapter {
     ) -> Result<CommentsThreadResponse, PortError> {
         let request_payload = read_frame(stream, self.max_frame_bytes).await?;
         let mut request = serde_json::from_slice::<CommentsThreadRequest>(&request_payload)
-            .map_err(|error| {
-                PortError::validation("comments.tcp_server_invalid_request", error.to_string())
+            .map_err(|_| {
+                PortError::validation(
+                    "comments.tcp_server_invalid_request",
+                    "comments TCP request is not valid typed JSON",
+                )
             })?;
         request.context().require_deadline_semantics()?;
 

--- a/crates/rustok-comments/src/tcp_server.rs
+++ b/crates/rustok-comments/src/tcp_server.rs
@@ -1,0 +1,354 @@
+use std::{net::SocketAddr, sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use rustok_api::{PortActor, PortContext, PortError, PortErrorKind};
+use tokio::{net::TcpStream, time::timeout};
+
+use crate::tcp_protocol::{
+    DEFAULT_MAX_COMMENTS_FRAME_BYTES, io_error, read_frame, validate_frame_limit, write_frame,
+};
+use crate::{
+    CommentsThreadPort, CommentsThreadRequest, CommentsThreadResponse, CommentsThreadTransportReply,
+};
+
+/// Stable operation identity exposed to the host-owned TCP authority resolver.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum CommentsTcpOperation {
+    CreateComment,
+    GetComment,
+    ListCommentsForTarget,
+    ListPublicCommentsForTarget,
+    UpdateComment,
+    SetCommentStatus,
+    DeleteComment,
+}
+
+/// Principal fields established by a host-owned authentication boundary.
+///
+/// Correlation, causation, trace, locale, channel, idempotency, and deadline
+/// remain request metadata. Tenant and principal authority never come from the
+/// untrusted TCP payload alone.
+#[derive(Clone, Debug)]
+pub struct TrustedCommentsTcpAuthority {
+    pub tenant_id: String,
+    pub actor: PortActor,
+    pub claims: Vec<String>,
+    pub roles: Vec<String>,
+}
+
+impl TrustedCommentsTcpAuthority {
+    pub fn new(tenant_id: impl Into<String>, actor: PortActor) -> Self {
+        Self {
+            tenant_id: tenant_id.into(),
+            actor,
+            claims: Vec::new(),
+            roles: Vec::new(),
+        }
+    }
+
+    pub fn with_claim(mut self, claim: impl Into<String>) -> Self {
+        self.claims.push(claim.into());
+        self
+    }
+
+    pub fn with_role(mut self, role: impl Into<String>) -> Self {
+        self.roles.push(role.into());
+        self
+    }
+}
+
+/// Host-owned authentication and operation-authorization seam.
+///
+/// Implementations may resolve authority from an authenticated sidecar channel,
+/// mTLS identity, a pre-authorized local peer, or another host policy. Returning
+/// an error produces the stable typed error reply and prevents provider dispatch.
+#[async_trait]
+pub trait CommentsTcpAuthorityResolver: Send + Sync {
+    async fn authorize(
+        &self,
+        peer_addr: SocketAddr,
+        operation: CommentsTcpOperation,
+        claimed_context: &PortContext,
+    ) -> Result<TrustedCommentsTcpAuthority, PortError>;
+}
+
+/// Provider-side adapter for one length-prefixed JSON request per accepted TCP stream.
+///
+/// The host owns listener lifecycle and passes each accepted stream with its peer
+/// address. This adapter decodes one request, requires trusted authority, invokes
+/// the host-selected Comments provider, writes one typed reply, and returns.
+#[derive(Clone)]
+pub struct TcpJsonCommentsServerAdapter {
+    provider: Arc<dyn CommentsThreadPort>,
+    authority: Arc<dyn CommentsTcpAuthorityResolver>,
+    max_frame_bytes: usize,
+}
+
+impl TcpJsonCommentsServerAdapter {
+    pub fn new(
+        provider: Arc<dyn CommentsThreadPort>,
+        authority: Arc<dyn CommentsTcpAuthorityResolver>,
+    ) -> Self {
+        Self {
+            provider,
+            authority,
+            max_frame_bytes: DEFAULT_MAX_COMMENTS_FRAME_BYTES,
+        }
+    }
+
+    pub fn with_max_frame_bytes(
+        provider: Arc<dyn CommentsThreadPort>,
+        authority: Arc<dyn CommentsTcpAuthorityResolver>,
+        max_frame_bytes: usize,
+    ) -> Result<Self, PortError> {
+        validate_frame_limit(max_frame_bytes)?;
+        Ok(Self {
+            provider,
+            authority,
+            max_frame_bytes,
+        })
+    }
+
+    pub fn max_frame_bytes(&self) -> usize {
+        self.max_frame_bytes
+    }
+
+    /// Handles exactly one request/reply exchange on an accepted stream.
+    pub async fn handle_connection(
+        &self,
+        mut stream: TcpStream,
+        peer_addr: SocketAddr,
+    ) -> Result<(), PortError> {
+        stream
+            .set_nodelay(true)
+            .map_err(|error| io_error("server_set_nodelay", error))?;
+
+        let reply = match self.read_authorize_and_dispatch(&mut stream, peer_addr).await {
+            Ok(response) => CommentsThreadTransportReply::Success(response),
+            Err(error) => CommentsThreadTransportReply::Error(error),
+        };
+        let reply_payload = serde_json::to_vec(&reply).map_err(|error| {
+            PortError::invariant_violation("comments.tcp_server_encode", error.to_string())
+        })?;
+        write_frame(&mut stream, &reply_payload, self.max_frame_bytes).await
+    }
+
+    async fn read_authorize_and_dispatch(
+        &self,
+        stream: &mut TcpStream,
+        peer_addr: SocketAddr,
+    ) -> Result<CommentsThreadResponse, PortError> {
+        let request_payload = read_frame(stream, self.max_frame_bytes).await?;
+        let mut request = serde_json::from_slice::<CommentsThreadRequest>(&request_payload)
+            .map_err(|error| {
+                PortError::validation("comments.tcp_server_invalid_request", error.to_string())
+            })?;
+        request.context().require_deadline_semantics()?;
+
+        let operation = request_operation(&request);
+        let deadline_ms = request.context().deadline_ms.unwrap_or_default();
+        timeout(Duration::from_millis(deadline_ms), async {
+            let authority = self
+                .authority
+                .authorize(peer_addr, operation, request.context())
+                .await?;
+            let trusted_context = apply_authority(request.context(), authority)?;
+            replace_request_context(&mut request, trusted_context);
+            dispatch_request(self.provider.as_ref(), request).await
+        })
+        .await
+        .map_err(|_| {
+            PortError::timeout(
+                "comments.tcp_server_timeout",
+                "comments TCP authority or provider dispatch exceeded the port deadline",
+            )
+        })?
+    }
+}
+
+fn apply_authority(
+    claimed: &PortContext,
+    authority: TrustedCommentsTcpAuthority,
+) -> Result<PortContext, PortError> {
+    if claimed.tenant_id != authority.tenant_id {
+        return Err(PortError::new(
+            PortErrorKind::Forbidden,
+            "comments.tcp_authority_tenant_mismatch",
+            "comments TCP tenant does not match trusted authority",
+            false,
+        ));
+    }
+
+    let mut trusted = claimed.clone();
+    trusted.tenant_id = authority.tenant_id;
+    trusted.actor = authority.actor;
+    trusted.claims = authority.claims;
+    trusted.roles = authority.roles;
+    Ok(trusted)
+}
+
+fn request_operation(request: &CommentsThreadRequest) -> CommentsTcpOperation {
+    match request {
+        CommentsThreadRequest::CreateComment { .. } => CommentsTcpOperation::CreateComment,
+        CommentsThreadRequest::GetComment { .. } => CommentsTcpOperation::GetComment,
+        CommentsThreadRequest::ListCommentsForTarget { .. } => {
+            CommentsTcpOperation::ListCommentsForTarget
+        }
+        CommentsThreadRequest::ListPublicCommentsForTarget { .. } => {
+            CommentsTcpOperation::ListPublicCommentsForTarget
+        }
+        CommentsThreadRequest::UpdateComment { .. } => CommentsTcpOperation::UpdateComment,
+        CommentsThreadRequest::SetCommentStatus { .. } => CommentsTcpOperation::SetCommentStatus,
+        CommentsThreadRequest::DeleteComment { .. } => CommentsTcpOperation::DeleteComment,
+    }
+}
+
+fn replace_request_context(request: &mut CommentsThreadRequest, trusted: PortContext) {
+    match request {
+        CommentsThreadRequest::CreateComment { context, .. }
+        | CommentsThreadRequest::GetComment { context, .. }
+        | CommentsThreadRequest::ListCommentsForTarget { context, .. }
+        | CommentsThreadRequest::ListPublicCommentsForTarget { context, .. }
+        | CommentsThreadRequest::UpdateComment { context, .. }
+        | CommentsThreadRequest::SetCommentStatus { context, .. }
+        | CommentsThreadRequest::DeleteComment { context, .. } => *context = trusted,
+    }
+}
+
+async fn dispatch_request(
+    provider: &dyn CommentsThreadPort,
+    request: CommentsThreadRequest,
+) -> Result<CommentsThreadResponse, PortError> {
+    match request {
+        CommentsThreadRequest::CreateComment { context, request } => provider
+            .create_comment(context, request)
+            .await
+            .map(CommentsThreadResponse::Comment),
+        CommentsThreadRequest::GetComment {
+            context,
+            comment_id,
+            fallback_locale,
+        } => provider
+            .get_comment(context, comment_id, fallback_locale)
+            .await
+            .map(CommentsThreadResponse::Comment),
+        CommentsThreadRequest::ListCommentsForTarget {
+            context,
+            target_type,
+            target_id,
+            filter,
+            fallback_locale,
+        } => provider
+            .list_comments_for_target(
+                context,
+                target_type,
+                target_id,
+                filter,
+                fallback_locale,
+            )
+            .await
+            .map(|(items, total)| CommentsThreadResponse::CommentsPage { items, total }),
+        CommentsThreadRequest::ListPublicCommentsForTarget {
+            context,
+            target_type,
+            target_id,
+            filter,
+            fallback_locale,
+        } => provider
+            .list_public_comments_for_target(
+                context,
+                target_type,
+                target_id,
+                filter,
+                fallback_locale,
+            )
+            .await
+            .map(|(items, total)| CommentsThreadResponse::CommentsPage { items, total }),
+        CommentsThreadRequest::UpdateComment {
+            context,
+            comment_id,
+            request,
+        } => provider
+            .update_comment(context, comment_id, request)
+            .await
+            .map(CommentsThreadResponse::Comment),
+        CommentsThreadRequest::SetCommentStatus {
+            context,
+            comment_id,
+            request,
+        } => provider
+            .set_comment_status(context, comment_id, request)
+            .await
+            .map(CommentsThreadResponse::Comment),
+        CommentsThreadRequest::DeleteComment {
+            context,
+            comment_id,
+        } => provider
+            .delete_comment(context, comment_id)
+            .await
+            .map(|()| CommentsThreadResponse::Deleted),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trusted_authority_replaces_only_principal_fields() {
+        let claimed = PortContext::new(
+            "tenant-a",
+            PortActor::user("forged-user"),
+            "en",
+            "corr-1",
+        )
+        .with_claim("forged-claim")
+        .with_role("forged-role")
+        .with_channel("storefront")
+        .with_causation_id("cause-1")
+        .with_traceparent("trace-1")
+        .with_idempotency_key("idem-1")
+        .with_deadline(Duration::from_millis(500));
+        let trusted = apply_authority(
+            &claimed,
+            TrustedCommentsTcpAuthority::new(
+                "tenant-a",
+                PortActor::service("comments-sidecar"),
+            )
+            .with_claim("comments:read")
+            .with_role("comments-worker"),
+        )
+        .unwrap();
+
+        assert_eq!(trusted.actor.id, "comments-sidecar");
+        assert_eq!(trusted.claims, ["comments:read"]);
+        assert_eq!(trusted.roles, ["comments-worker"]);
+        assert_eq!(trusted.channel, claimed.channel);
+        assert_eq!(trusted.correlation_id, claimed.correlation_id);
+        assert_eq!(trusted.causation_id, claimed.causation_id);
+        assert_eq!(trusted.traceparent, claimed.traceparent);
+        assert_eq!(trusted.idempotency_key, claimed.idempotency_key);
+        assert_eq!(trusted.deadline_ms, claimed.deadline_ms);
+    }
+
+    #[test]
+    fn trusted_authority_rejects_tenant_mismatch() {
+        let claimed = PortContext::new(
+            "tenant-a",
+            PortActor::user("forged-user"),
+            "en",
+            "corr-1",
+        );
+        let error = apply_authority(
+            &claimed,
+            TrustedCommentsTcpAuthority::new(
+                "tenant-b",
+                PortActor::service("comments-sidecar"),
+            ),
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind, PortErrorKind::Forbidden);
+        assert_eq!(error.code, "comments.tcp_authority_tenant_mismatch");
+    }
+}

--- a/crates/rustok-comments/src/tcp_transport.rs
+++ b/crates/rustok-comments/src/tcp_transport.rs
@@ -10,8 +10,7 @@ use crate::{
 };
 
 use crate::tcp_protocol::{
-    DEFAULT_MAX_COMMENTS_FRAME_BYTES, ensure_frame_size, io_error, read_frame,
-    validate_frame_limit, write_frame,
+    ensure_frame_size, io_error, read_frame, validate_frame_limit, write_frame,
 };
 
 pub use crate::tcp_protocol::DEFAULT_MAX_COMMENTS_FRAME_BYTES;

--- a/crates/rustok-comments/src/tcp_transport.rs
+++ b/crates/rustok-comments/src/tcp_transport.rs
@@ -2,19 +2,19 @@ use std::{net::SocketAddr, time::Duration};
 
 use async_trait::async_trait;
 use rustok_api::PortError;
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    net::TcpStream,
-    time::timeout,
-};
+use tokio::{net::TcpStream, time::timeout};
 
 use crate::{
     CommentsThreadRequest, CommentsThreadResponse, CommentsThreadTransport,
     CommentsThreadTransportReply,
 };
 
-/// Default upper bound for one length-prefixed Comments request or response.
-pub const DEFAULT_MAX_COMMENTS_FRAME_BYTES: usize = 8 * 1024 * 1024;
+use crate::tcp_protocol::{
+    DEFAULT_MAX_COMMENTS_FRAME_BYTES, ensure_frame_size, io_error, read_frame,
+    validate_frame_limit, write_frame,
+};
+
+pub use crate::tcp_protocol::DEFAULT_MAX_COMMENTS_FRAME_BYTES;
 
 /// Concrete sidecar transport using length-prefixed JSON over TCP.
 ///
@@ -98,54 +98,6 @@ impl CommentsThreadTransport for TcpJsonCommentsTransport {
     }
 }
 
-async fn write_frame(
-    stream: &mut TcpStream,
-    payload: &[u8],
-    max_frame_bytes: usize,
-) -> Result<(), PortError> {
-    ensure_frame_size(payload.len(), max_frame_bytes)?;
-    let length = u32::try_from(payload.len()).map_err(|_| {
-        PortError::invariant_violation(
-            "comments.tcp_frame_too_large",
-            "comments TCP frame length exceeds the u32 wire limit",
-        )
-    })?;
-
-    stream
-        .write_all(&length.to_be_bytes())
-        .await
-        .map_err(|error| io_error("write_length", error))?;
-    stream
-        .write_all(payload)
-        .await
-        .map_err(|error| io_error("write_payload", error))?;
-    stream
-        .flush()
-        .await
-        .map_err(|error| io_error("flush", error))?;
-    Ok(())
-}
-
-async fn read_frame(
-    stream: &mut TcpStream,
-    max_frame_bytes: usize,
-) -> Result<Vec<u8>, PortError> {
-    let mut length_bytes = [0_u8; 4];
-    stream
-        .read_exact(&mut length_bytes)
-        .await
-        .map_err(|error| io_error("read_length", error))?;
-    let length = u32::from_be_bytes(length_bytes) as usize;
-    ensure_frame_size(length, max_frame_bytes)?;
-
-    let mut payload = vec![0_u8; length];
-    stream
-        .read_exact(&mut payload)
-        .await
-        .map_err(|error| io_error("read_payload", error))?;
-    Ok(payload)
-}
-
 fn decode_reply(payload: &[u8]) -> Result<CommentsThreadResponse, PortError> {
     let reply = serde_json::from_slice::<CommentsThreadTransportReply>(payload).map_err(|error| {
         PortError::invariant_violation("comments.tcp_decode", error.to_string())
@@ -154,42 +106,6 @@ fn decode_reply(payload: &[u8]) -> Result<CommentsThreadResponse, PortError> {
         CommentsThreadTransportReply::Success(response) => Ok(response),
         CommentsThreadTransportReply::Error(error) => Err(error),
     }
-}
-
-fn validate_frame_limit(max_frame_bytes: usize) -> Result<(), PortError> {
-    if max_frame_bytes == 0 || max_frame_bytes > u32::MAX as usize {
-        return Err(PortError::validation(
-            "comments.tcp_invalid_frame_limit",
-            "comments TCP frame limit must be within 1..=u32::MAX",
-        ));
-    }
-    Ok(())
-}
-
-fn ensure_frame_size(length: usize, max_frame_bytes: usize) -> Result<(), PortError> {
-    validate_frame_limit(max_frame_bytes)?;
-    if length > max_frame_bytes {
-        return Err(PortError::invariant_violation(
-            "comments.tcp_frame_too_large",
-            format!(
-                "comments TCP frame length {length} exceeds configured limit {max_frame_bytes}"
-            ),
-        ));
-    }
-    Ok(())
-}
-
-fn io_error(stage: &'static str, error: std::io::Error) -> PortError {
-    if error.kind() == std::io::ErrorKind::TimedOut {
-        return PortError::timeout(
-            "comments.tcp_timeout",
-            format!("comments TCP {stage} timed out"),
-        );
-    }
-    PortError::unavailable(
-        "comments.tcp_unavailable",
-        format!("comments TCP {stage} failed: {error}"),
-    )
 }
 
 #[cfg(test)]

--- a/scripts/verify/verify-blog-comments-tcp-server-adapter.mjs
+++ b/scripts/verify/verify-blog-comments-tcp-server-adapter.mjs
@@ -1,0 +1,212 @@
+import fs from 'node:fs';
+
+const evidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-tcp-server-adapter.json';
+const exportPath = 'crates/rustok-comments/src/lib.rs';
+const protocolPath = 'crates/rustok-comments/src/tcp_protocol.rs';
+const remotePath = 'crates/rustok-comments/src/remote.rs';
+const serverPath = 'crates/rustok-comments/src/tcp_server.rs';
+const transportPath = 'crates/rustok-comments/src/tcp_transport.rs';
+const planPath = 'crates/rustok-blog/docs/implementation-plan-slice-69.md';
+
+function read(path) {
+  return fs.readFileSync(path, 'utf8');
+}
+
+function fail(message) {
+  console.error(`[verify-blog-comments-tcp-server-adapter] ${message}`);
+  process.exit(1);
+}
+
+function hasAll(text, snippets, label) {
+  for (const snippet of snippets) {
+    if (!text.includes(snippet)) fail(`${label} missing ${snippet}`);
+  }
+}
+
+function hasNone(text, snippets, label) {
+  for (const snippet of snippets) {
+    if (text.includes(snippet)) fail(`${label} contains forbidden ${snippet}`);
+  }
+}
+
+function sameSet(actual, expected, label) {
+  const left = [...actual].sort().join('|');
+  const right = [...expected].sort().join('|');
+  if (left !== right) fail(`${label} drift: expected ${right}, got ${left}`);
+}
+
+for (const path of [
+  evidencePath,
+  exportPath,
+  protocolPath,
+  remotePath,
+  serverPath,
+  transportPath,
+  planPath,
+]) {
+  if (!fs.existsSync(path)) fail(`missing source artifact ${path}`);
+}
+
+const evidence = JSON.parse(read(evidencePath));
+const exports = read(exportPath);
+const protocol = read(protocolPath);
+const remote = read(remotePath);
+const server = read(serverPath);
+const transport = read(transportPath);
+const plan = read(planPath);
+
+if (evidence.schema_version !== 1) fail('evidence schema_version drift');
+if (
+  evidence.module !== 'blog'
+  || evidence.provider !== 'comments'
+  || evidence.surface !== 'comments_tcp_server_adapter'
+) fail('evidence identity drift');
+if (
+  evidence.status !== 'source_verified_no_compile'
+  || evidence.compile_policy !== 'not_run_by_request'
+  || evidence.runtime_status !== 'not_run'
+) fail('evidence execution status drift');
+if (evidence.generated_from !== planPath) fail('evidence plan path drift');
+
+sameSet(
+  evidence.operations ?? [],
+  [
+    'create_comment',
+    'get_comment',
+    'list_comments_for_target',
+    'list_public_comments_for_target',
+    'update_comment',
+    'set_comment_status',
+    'delete_comment',
+  ],
+  'server operations',
+);
+
+if (
+  evidence.source_contract?.server_adapter !== serverPath
+  || evidence.source_contract?.shared_protocol !== protocolPath
+  || evidence.source_contract?.client_transport !== transportPath
+  || evidence.source_contract?.provider_export !== exportPath
+) fail('source contract path drift');
+
+if (
+  evidence.protocol?.identity !== 'comments_tcp_length_prefixed_json_v1'
+  || evidence.protocol?.length_prefix !== 'u32_big_endian'
+  || evidence.protocol?.default_max_frame_bytes !== 8388608
+  || evidence.protocol?.shared_client_server_framing !== true
+) fail('protocol evidence drift');
+
+if (
+  evidence.authority?.required !== true
+  || evidence.authority?.allow_all_fallback !== false
+  || evidence.authority?.tenant_match_required !== true
+) fail('authority evidence drift');
+
+hasAll(
+  protocol,
+  [
+    'pub const DEFAULT_MAX_COMMENTS_FRAME_BYTES: usize = 8 * 1024 * 1024;',
+    'length.to_be_bytes()',
+    'u32::from_be_bytes(length_bytes)',
+    'comments.tcp_invalid_frame_limit',
+    'comments.tcp_frame_too_large',
+  ],
+  'shared TCP protocol',
+);
+
+hasAll(
+  server,
+  [
+    'pub enum CommentsTcpOperation',
+    'pub struct TrustedCommentsTcpAuthority',
+    'pub trait CommentsTcpAuthorityResolver: Send + Sync',
+    'pub struct TcpJsonCommentsServerAdapter',
+    'authority: Arc<dyn CommentsTcpAuthorityResolver>',
+    'pub async fn handle_connection(',
+    'CommentsThreadTransportReply::Success(response)',
+    'CommentsThreadTransportReply::Error(error)',
+    'request.context().require_deadline_semantics()?;',
+    '.authorize(peer_addr, operation, request.context())',
+    'comments.tcp_authority_tenant_mismatch',
+    'trusted.actor = authority.actor;',
+    'trusted.claims = authority.claims;',
+    'trusted.roles = authority.roles;',
+    'dispatch_request(self.provider.as_ref(), request).await',
+    'comments.tcp_server_timeout',
+    'comments.tcp_server_invalid_request',
+  ],
+  'TCP server adapter',
+);
+
+for (const variant of [
+  'CreateComment',
+  'GetComment',
+  'ListCommentsForTarget',
+  'ListPublicCommentsForTarget',
+  'UpdateComment',
+  'SetCommentStatus',
+  'DeleteComment',
+]) {
+  if (!server.includes(`CommentsThreadRequest::${variant}`)) {
+    fail(`server dispatch missing ${variant}`);
+  }
+}
+
+hasNone(
+  server,
+  [
+    'TcpListener',
+    '.accept().await',
+    'loop {',
+    'AllowAll',
+    'retry(',
+  ],
+  'server adapter non-claims',
+);
+
+hasAll(
+  exports,
+  [
+    'mod tcp_protocol;',
+    'pub mod tcp_server;',
+    'pub mod tcp_transport;',
+    'CommentsTcpAuthorityResolver, CommentsTcpOperation, TcpJsonCommentsServerAdapter,',
+    'TrustedCommentsTcpAuthority,',
+  ],
+  'Comments exports',
+);
+
+hasAll(
+  remote,
+  [
+    'pub enum CommentsThreadRequest',
+    'pub enum CommentsThreadResponse',
+    'pub enum CommentsThreadTransportReply',
+  ],
+  'remote envelopes',
+);
+
+hasAll(
+  transport,
+  [
+    'use crate::tcp_protocol::{',
+    'pub use crate::tcp_protocol::DEFAULT_MAX_COMMENTS_FRAME_BYTES;',
+    'write_frame(&mut stream, request_payload, self.max_frame_bytes).await?;',
+    'read_frame(&mut stream, self.max_frame_bytes).await?;',
+  ],
+  'TCP client shared framing',
+);
+
+hasAll(
+  plan,
+  [
+    '# rustok-blog implementation plan — slice 69 continuation',
+    'CommentsTcpAuthorityResolver',
+    'source_verified_no_compile',
+    'host runtime configuration',
+    'not_run_by_request',
+  ],
+  'slice 69 plan',
+);
+
+console.log('[verify-blog-comments-tcp-server-adapter] source contract verified');

--- a/scripts/verify/verify-blog-comments-tcp-transport.mjs
+++ b/scripts/verify/verify-blog-comments-tcp-transport.mjs
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 const evidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-tcp-transport.json';
 const manifestPath = 'crates/rustok-comments/Cargo.toml';
 const exportPath = 'crates/rustok-comments/src/lib.rs';
+const protocolPath = 'crates/rustok-comments/src/tcp_protocol.rs';
 const remotePath = 'crates/rustok-comments/src/remote.rs';
 const transportPath = 'crates/rustok-comments/src/tcp_transport.rs';
 const planPath = 'crates/rustok-blog/docs/implementation-plan-slice-68.md';
@@ -38,13 +39,22 @@ function sameSet(actual, expected, label) {
   if (left !== right) fail(`${label} drift: expected ${right}, got ${left}`);
 }
 
-for (const path of [evidencePath, manifestPath, exportPath, remotePath, transportPath, planPath]) {
+for (const path of [
+  evidencePath,
+  manifestPath,
+  exportPath,
+  protocolPath,
+  remotePath,
+  transportPath,
+  planPath,
+]) {
   if (!fs.existsSync(path)) fail(`missing source artifact ${path}`);
 }
 
 const evidence = json(evidencePath);
 const manifest = read(manifestPath);
 const exports = read(exportPath);
+const protocol = read(protocolPath);
 const remote = read(remotePath);
 const transport = read(transportPath);
 const plan = read(planPath);
@@ -111,7 +121,7 @@ sameSet(
     'in_process_remote_runtime_parity',
     'runtime_execution',
   ],
-  'pending transport scope',
+  'historical slice 68 pending scope',
 );
 
 hasAll(
@@ -127,6 +137,7 @@ hasAll(
   exports,
   [
     '#[cfg(feature = "tcp-transport")]',
+    'mod tcp_protocol;',
     'pub mod tcp_transport;',
     'pub use tcp_transport::TcpJsonCommentsTransport;',
   ],
@@ -150,25 +161,34 @@ for (const operation of expectedOperations) {
 }
 
 hasAll(
-  transport,
+  protocol,
   [
     'pub const DEFAULT_MAX_COMMENTS_FRAME_BYTES: usize = 8 * 1024 * 1024;',
+    'length.to_be_bytes()',
+    'u32::from_be_bytes(length_bytes)',
+    'comments.tcp_invalid_frame_limit',
+    'comments.tcp_frame_too_large',
+    'comments.tcp_unavailable',
+    'comments.tcp_timeout',
+  ],
+  'shared TCP protocol',
+);
+
+hasAll(
+  transport,
+  [
     'pub struct TcpJsonCommentsTransport',
     'impl CommentsThreadTransport for TcpJsonCommentsTransport',
     'TcpStream::connect(self.endpoint)',
     'request.context().require_deadline_semantics()?;',
     'Duration::from_millis(deadline_ms)',
     'self.exchange(&request_payload)',
-    'length.to_be_bytes()',
-    'u32::from_be_bytes(length_bytes)',
+    'write_frame(&mut stream, request_payload, self.max_frame_bytes).await?;',
+    'read_frame(&mut stream, self.max_frame_bytes).await?;',
     'CommentsThreadTransportReply::Success(response)',
     'CommentsThreadTransportReply::Error(error)',
-    'comments.tcp_invalid_frame_limit',
-    'comments.tcp_frame_too_large',
     'comments.tcp_encode',
     'comments.tcp_decode',
-    'comments.tcp_unavailable',
-    'comments.tcp_timeout',
     'provider_error_reply_is_preserved',
     'tcp_transport_is_injectable_without_connecting',
   ],


### PR DESCRIPTION
## Summary

- continue the Blog improvement plan with slice 69
- add shared bounded TCP framing used by both Comments client and server
- add `TcpJsonCommentsServerAdapter` for one typed request/reply per accepted stream
- dispatch all seven `CommentsThreadPort` operations to a host-selected provider
- require a host-owned `CommentsTcpAuthorityResolver` with no allow-all fallback
- reject tenant mismatch and replace untrusted actor, claims, and roles before dispatch
- preserve channel, locale, correlation, causation, trace, idempotency, and deadline metadata
- bound authority resolution plus provider dispatch by the request deadline
- preserve exact provider `PortError` values in the stable reply envelope
- keep the existing TCP client verifier aligned with the shared framing refactor
- add slice-69 source evidence and a standalone fail-closed verifier

## Scope intentionally left pending

- listener bind and accept loop
- concrete authority resolver, credentials, mTLS identity, and transport encryption
- endpoint discovery and runtime configuration publication
- automatic in-process/TCP provider selection
- pre-request idle timeout, bounded concurrency, and shutdown policy
- retry/backoff and circuit breaking
- in-process/TCP parity execution
- cached snapshot and comment-form fallback

## Verification

Tests, verifiers, formatting, Cargo checks, TCP runtime targets, database targets, browser targets, workflows, and CI were intentionally not run by request. Suggested maintainer commands are recorded in `crates/rustok-blog/docs/implementation-plan-slice-69.md`.