### PR TITLE
test(forum): retain poison publish ambiguity

### DIFF
--- a/crates/rustok-forum/contracts/forum-search-versioned-invalidation-poison-ambiguity-source-proof.json
+++ b/crates/rustok-forum/contracts/forum-search-versioned-invalidation-poison-ambiguity-source-proof.json
@@ -1,0 +1,94 @@
+{
+  "contract": "forum_search_versioned_invalidation_poison_ambiguity_source_proof_v1",
+  "task": "FORUM-23B2G2B3D6",
+  "status": "source_ready_maintainer_execution_pending",
+  "runtime_evidence_parent": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json",
+  "predecessor": {
+    "task": "FORUM-23B2G2B3D5",
+    "pull_request": 2777,
+    "state_at_authorship": "merged",
+    "merge_commit": "1d2654785047efde1d29a9682732990acc56f9b5",
+    "parent_registration": "D5_registered_D6_deferred_until_D6_merge"
+  },
+  "test": "crates/rustok-search/tests/forum_versioned_invalidation_poison_ambiguity_iggy.rs",
+  "production_reference": "apps/server/src/services/forum_search_contract_consumer.rs",
+  "evidence_artifact": {
+    "path": "target/forum-search-versioned-invalidation-poison-ambiguity-evidence.json",
+    "generation": "executable_test_only",
+    "hand_editing_forbidden": true,
+    "source_commit_required": true,
+    "written_only_after_all_modes_pass": true
+  },
+  "required_runtime": {
+    "database": "postgresql",
+    "database_env": "RUSTOK_SEARCH_TEST_DATABASE_URL",
+    "delivery_profile": "outbox_iggy",
+    "consumer_group": "rustok-search-forum-projection-v1",
+    "source_topic": "domain",
+    "dlq_topic": "dlq",
+    "iggy_instances": [
+      {
+        "mode": "dedup_enabled",
+        "address_env": "RUSTOK_FORUM_SEARCH_POISON_DEDUP_ENABLED_IGGY_ADDRESS",
+        "expected_physical_dlq_messages_after_retry": 1
+      },
+      {
+        "mode": "dedup_disabled",
+        "address_env": "RUSTOK_FORUM_SEARCH_POISON_DEDUP_DISABLED_IGGY_ADDRESS",
+        "expected_physical_dlq_messages_after_retry": 2
+      }
+    ],
+    "distinct_iggy_addresses_required": true,
+    "shared_credentials": [
+      "RUSTOK_IGGY_EXTERNAL_TEST_USERNAME",
+      "RUSTOK_IGGY_EXTERNAL_TEST_PASSWORD"
+    ]
+  },
+  "scenarios": [
+    {
+      "id": "raw_poison_publish_mark_ambiguity_dedup_enabled",
+      "proves": [
+        "malformed source bytes create one deterministic connector delivery identity",
+        "the first publisher emits the DLQ message before durable mark_published",
+        "the source offset remains unacknowledged while the receipt remains publishing",
+        "the live unexpired claim returns Busy to a second publisher",
+        "the expired publish claim is reclaimed after transport and consumer-group reconstruction",
+        "the stale publisher is fenced with ClaimLost",
+        "retry publication reuses the exact deterministic broker message identity",
+        "server-side message deduplication retains one physical DLQ message",
+        "source acknowledgement occurs only after durable published state"
+      ]
+    },
+    {
+      "id": "raw_poison_publish_mark_ambiguity_dedup_disabled",
+      "proves": [
+        "the same receipt, lease and deterministic identity protocol is used without broker deduplication",
+        "publish success before mark_published remains an unavoidable cross-system ambiguity window",
+        "retry publication produces two physical DLQ messages when server deduplication is disabled",
+        "the stale publisher is still fenced after lease takeover",
+        "the durable receipt reaches published then acknowledged",
+        "the source group advances only after terminalization"
+      ]
+    }
+  ],
+  "identity_invariants": [
+    "ConsumerPoisonIdentity.delivery_id equals DlqEntry.broker_message_id",
+    "consumer_group remains rustok-search-forum-projection-v1",
+    "source stream, topic, partition, offset and exact payload bytes remain unchanged after restart",
+    "the stale publisher cannot mark the receipt published after lease takeover",
+    "dedup mode changes only physical broker multiplicity and not durable receipt identity or terminal ordering",
+    "the next malformed delivery has a strictly later source offset"
+  ],
+  "maintainer_command": "RUSTOK_SEARCH_TEST_DATABASE_URL=\"$DATABASE_URL\" RUSTOK_FORUM_SEARCH_POISON_DEDUP_ENABLED_IGGY_ADDRESS=\"127.0.0.1:8090\" RUSTOK_FORUM_SEARCH_POISON_DEDUP_DISABLED_IGGY_ADDRESS=\"127.0.0.1:8091\" cargo test -p rustok-search --test forum_versioned_invalidation_poison_ambiguity_iggy -- --nocapture --test-threads=1",
+  "non_claims": [
+    "this source slice does not claim successful PostgreSQL or external Iggy execution",
+    "this source slice does not run the server-owned Forum Search worker loop or prove its retry backoff",
+    "semantic identity-conflict poison is owned by merged FORUM-23B2G2B3D5 and is not duplicated here",
+    "this source slice does not prove arbitrary multi-process claim contention beyond one expired-lease takeover",
+    "this source slice does not prove active production deduplication configuration, TLS, replication, multiple partitions or broker failover",
+    "this source slice does not execute the Search projector or advance an owner checkpoint",
+    "this source slice does not establish missing-delivery repair, deletion or ACL visibility ordering, or Search-disabled recovery",
+    "this source slice does not register D6 in the parent D0 contract before D6 itself merges",
+    "this source slice does not complete FORUM-23B2G2B3D or close LINK-FORUM-03"
+  ]
+}

--- a/crates/rustok-forum/docs/forum-23b2g2b3d6-versioned-invalidation-poison-ambiguity.md
+++ b/crates/rustok-forum/docs/forum-23b2g2b3d6-versioned-invalidation-poison-ambiguity.md
@@ -1,0 +1,146 @@
+# FORUM-23B2G2B3D6 external-Iggy poison publish/mark ambiguity proof
+
+## Status
+
+`source_ready_maintainer_execution_pending`
+
+This slice continues the frozen Forum Search runtime-evidence matrix after merged
+D5 semantic-poison proof #2777. It isolates the remaining raw-poison ambiguity
+window where the broker accepts a deterministic DLQ publication but the process
+stops before PostgreSQL records `published`.
+
+The machine-readable contract is:
+
+```text
+crates/rustok-forum/contracts/forum-search-versioned-invalidation-poison-ambiguity-source-proof.json
+```
+
+The executable target is:
+
+```text
+crates/rustok-search/tests/forum_versioned_invalidation_poison_ambiguity_iggy.rs
+```
+
+The production ordering reference is:
+
+```text
+apps/server/src/services/forum_search_contract_consumer.rs
+```
+
+## Runtime topology
+
+The harness requires one PostgreSQL database and two distinct external Iggy
+instances:
+
+- `RUSTOK_FORUM_SEARCH_POISON_DEDUP_ENABLED_IGGY_ADDRESS` points to an instance
+  whose server-side deterministic message-ID duplicate suppression is enabled;
+- `RUSTOK_FORUM_SEARCH_POISON_DEDUP_DISABLED_IGGY_ADDRESS` points to a distinct
+  instance whose duplicate suppression is disabled.
+
+Both addresses must use bounded `host:port` form and must differ. Optional shared
+credentials use `RUSTOK_IGGY_EXTERNAL_TEST_USERNAME` and
+`RUSTOK_IGGY_EXTERNAL_TEST_PASSWORD` and must be supplied together.
+
+Each mode creates a unique one-partition evidence stream and an isolated
+PostgreSQL schema. The real connector migration list creates the durable receipt
+store. Source deliveries use the exact production consumer group
+`rustok-search-forum-projection-v1` and topic `domain`; DLQ publications use the
+production `IggyTransport::move_to_dlq` path.
+
+## Covered sequence
+
+For each broker mode, two malformed source payloads are published. The first
+payload follows this exact sequence:
+
+```text
+receive exact raw poison delivery
+  -> reserve_and_claim durable receipt
+  -> receipt state is publishing
+  -> publish deterministic DLQ entry
+  -> do not call mark_published
+  -> retain the exact source offset unacknowledged
+  -> second publisher observes Busy before lease expiry
+  -> stop the first transport and consumer group
+  -> wait for the bounded one-second publish lease to expire
+  -> reconstruct transport and production consumer group
+  -> redeliver the same bytes, offset and delivery UUID
+  -> reclaim the expired receipt with a new publisher
+  -> stale publisher fails mark_published with ClaimLost
+  -> republish with the same deterministic broker message ID
+  -> inspect physical DLQ multiplicity
+  -> mark_published
+  -> acknowledge the exact source delivery
+  -> mark_acknowledged
+  -> advance to the second malformed source payload
+```
+
+The dedup-enabled instance must contain exactly one physical DLQ message after the
+retry. The dedup-disabled instance must contain exactly two. This is a deliberate
+positive/negative capability proof: PostgreSQL receipt leasing fences concurrent
+live publishers, but cannot create physical exactly-once semantics across a
+successful broker write and a missing database mark without broker deduplication.
+
+## Generated evidence
+
+Only after both modes pass, the target writes:
+
+```text
+target/forum-search-versioned-invalidation-poison-ambiguity-evidence.json
+```
+
+The artifact records the exact source commit, consumer group, source positions,
+deterministic delivery and DLQ identities, claim takeover, stale-publisher
+fencing, expected and observed physical message counts, receipt terminal state,
+and advancement to the next source delivery. It is executable output and must not
+be hand-edited or committed as a static result.
+
+## Relationship to merged D5
+
+`FORUM-23B2G2B3D5` merged through PR #2777 at
+`1d2654785047efde1d29a9682732990acc56f9b5`. D5 owns valid typed semantic
+identity-conflict poison, deterministic semantic DLQ publication and
+`AlreadyPublished` restart recovery. D6 does not duplicate that scenario; it
+uses malformed raw bytes solely to expose the publish-before-`mark_published`
+ambiguity under two reviewed broker modes.
+
+The parent D0 contract already registers D5. D6 intentionally defers its own
+registration until D6 is merged, so canonical `main` never lists an unmerged
+subproof.
+
+## Deliberate limits
+
+This slice does not claim:
+
+- successful PostgreSQL or external-Iggy execution;
+- server-owned background worker-loop or retry/backoff execution;
+- active production Iggy deduplication configuration readback;
+- semantic identity-conflict poison, which is already owned by merged D5;
+- arbitrary multi-process contention beyond one lease-expiry takeover;
+- TLS, replication, multiple partitions or broker failover;
+- Search projector execution, owner-checkpoint advancement, missing-delivery
+  repair, deletion/ACL visibility ordering, Search-disabled recovery, completion
+  of `FORUM-23B2G2B3D`, or closure of `LINK-FORUM-03`.
+
+No production Rust path, migration, event schema, digest, runtime flag, consumer
+group, broker topic, Search query, public API or `Cargo.lock` entry changes. The
+only manifest change is the direct test-only `iggy` dependency already present in
+the workspace lock graph.
+
+## Maintainer verification
+
+```bash
+RUSTOK_SEARCH_TEST_DATABASE_URL="$DATABASE_URL" \
+RUSTOK_FORUM_SEARCH_POISON_DEDUP_ENABLED_IGGY_ADDRESS="127.0.0.1:8090" \
+RUSTOK_FORUM_SEARCH_POISON_DEDUP_DISABLED_IGGY_ADDRESS="127.0.0.1:8091" \
+  cargo test -p rustok-search \
+  --test forum_versioned_invalidation_poison_ambiguity_iggy \
+  -- --nocapture --test-threads=1
+
+node scripts/verify/verify-forum-search-versioned-invalidation-d6-poison-ambiguity.mjs
+cargo check -p rustok-search --all-targets
+cargo xtask module validate forum
+cargo xtask module validate search
+git diff --check
+```
+
+No command above was run by the implementation agent, per maintainer request.

--- a/crates/rustok-search/Cargo.toml
+++ b/crates/rustok-search/Cargo.toml
@@ -24,6 +24,7 @@ chrono.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+iggy.workspace = true
 rustok-iggy.workspace = true
 rustok-iggy-connector = { workspace = true, features = ["migrations"] }
 tokio.workspace = true

--- a/crates/rustok-search/tests/forum_versioned_invalidation_poison_ambiguity_iggy.rs
+++ b/crates/rustok-search/tests/forum_versioned_invalidation_poison_ambiguity_iggy.rs
@@ -1,0 +1,595 @@
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::io::{Error as IoError, ErrorKind};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use chrono::Utc;
+use iggy::prelude::{Client, Identifier, IggyClient, TopicClient};
+use rustok_iggy::{
+    ConsumedContractDecodeFailure, ExternalConfig, IggyConfig, IggyMode, IggyTransport,
+    PersistentContractConsumerGroup, PersistentContractDelivery, SerializationFormat,
+    TopologyConfig,
+};
+use rustok_iggy_connector::migrations::{
+    ConsumerPoisonIdentity, ConsumerPoisonPublishClaim, ConsumerPoisonReceiptError,
+    ConsumerPoisonReceiptState, ConsumerPoisonReceiptStore,
+};
+use rustok_iggy_connector::{ConnectorConfig, ExternalConnector, IggyConnector, PublishRequest};
+use rustok_search::{FORUM_SEARCH_CONTRACT_CONSUMER_GROUP, FORUM_SEARCH_CONTRACT_TOPIC};
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection};
+use sea_orm_migration::SchemaManager;
+use serde::Serialize;
+use serde_json::{Value as JsonValue, json};
+use tokio::time::timeout;
+use uuid::Uuid;
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+const DATABASE_ENV: &str = "RUSTOK_SEARCH_TEST_DATABASE_URL";
+const DEDUP_ENABLED_ADDRESS_ENV: &str =
+    "RUSTOK_FORUM_SEARCH_POISON_DEDUP_ENABLED_IGGY_ADDRESS";
+const DEDUP_DISABLED_ADDRESS_ENV: &str =
+    "RUSTOK_FORUM_SEARCH_POISON_DEDUP_DISABLED_IGGY_ADDRESS";
+const USERNAME_ENV: &str = "RUSTOK_IGGY_EXTERNAL_TEST_USERNAME";
+const PASSWORD_ENV: &str = "RUSTOK_IGGY_EXTERNAL_TEST_PASSWORD";
+const RECEIVE_TIMEOUT: Duration = Duration::from_secs(20);
+const PUBLISH_LEASE: Duration = Duration::from_secs(1);
+const LEASE_RECLAIM_WAIT: Duration = Duration::from_millis(1_500);
+const EVIDENCE_CONTRACT: &str =
+    "forum_search_versioned_invalidation_poison_ambiguity_evidence_v1";
+const EVIDENCE_PATH: &str =
+    "target/forum-search-versioned-invalidation-poison-ambiguity-evidence.json";
+
+#[derive(Debug, Serialize)]
+struct ScenarioEvidence {
+    id: String,
+    result: &'static str,
+    facts: JsonValue,
+}
+
+#[derive(Debug, Serialize)]
+struct EvidenceArtifact {
+    contract: &'static str,
+    task: &'static str,
+    source_commit: String,
+    generated_at: String,
+    database_backend: &'static str,
+    delivery_profile: &'static str,
+    consumer_group: &'static str,
+    topic: &'static str,
+    scenario_results: Vec<ScenarioEvidence>,
+}
+
+struct EvidenceRuntime {
+    control: DatabaseConnection,
+    db: DatabaseConnection,
+    schema_name: String,
+    config: IggyConfig,
+    fixture: ExternalConnector,
+}
+
+impl EvidenceRuntime {
+    async fn setup(database_url: &str, config: IggyConfig, scope: &str) -> TestResult<Self> {
+        let control = connect(database_url).await?;
+        let schema_name = format!(
+            "rustok_forum_poison_ambiguity_{}_{}",
+            sanitize_identifier(scope),
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let db = connect_in_schema(database_url, &schema_name).await?;
+        let migration_result = async {
+            let manager = SchemaManager::new(&db);
+            for migration in rustok_iggy_connector::migrations::migrations() {
+                migration.up(&manager).await?;
+            }
+            Ok::<(), sea_orm::DbErr>(())
+        }
+        .await;
+        if let Err(error) = migration_result {
+            let _ = control
+                .execute_unprepared(&format!(r#"DROP SCHEMA IF EXISTS "{schema_name}" CASCADE"#))
+                .await;
+            return Err(error.into());
+        }
+
+        let fixture = ExternalConnector::new();
+        if let Err(error) = fixture.connect(&ConnectorConfig::from(&config)).await {
+            let _ = control
+                .execute_unprepared(&format!(r#"DROP SCHEMA IF EXISTS "{schema_name}" CASCADE"#))
+                .await;
+            return Err(error.into());
+        }
+
+        Ok(Self {
+            control,
+            db,
+            schema_name,
+            config,
+            fixture,
+        })
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.fixture.shutdown().await?;
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn raw_poison_publish_mark_ambiguity_obeys_configured_dedup_modes() -> TestResult<()> {
+    ensure_distinct_mode_addresses()?;
+    let Some(database_url) = postgres_database_url() else {
+        eprintln!(
+            "{DATABASE_ENV} or PostgreSQL DATABASE_URL is not set; skipping Forum Search poison ambiguity proof"
+        );
+        return Ok(());
+    };
+    let Some(dedup_enabled) = external_iggy_config(DEDUP_ENABLED_ADDRESS_ENV, "dedup-enabled")?
+    else {
+        eprintln!("{DEDUP_ENABLED_ADDRESS_ENV} is not set; skipping poison ambiguity proof");
+        return Ok(());
+    };
+    let Some(dedup_disabled) =
+        external_iggy_config(DEDUP_DISABLED_ADDRESS_ENV, "dedup-disabled")?
+    else {
+        eprintln!("{DEDUP_DISABLED_ADDRESS_ENV} is not set; skipping poison ambiguity proof");
+        return Ok(());
+    };
+
+    let enabled = exercise_mode(&database_url, dedup_enabled, "dedup_enabled", 1).await?;
+    let disabled = exercise_mode(&database_url, dedup_disabled, "dedup_disabled", 2).await?;
+
+    write_evidence(EvidenceArtifact {
+        contract: EVIDENCE_CONTRACT,
+        task: "FORUM-23B2G2B3D6",
+        source_commit: source_commit()?,
+        generated_at: Utc::now().to_rfc3339(),
+        database_backend: "postgresql",
+        delivery_profile: "outbox_iggy",
+        consumer_group: FORUM_SEARCH_CONTRACT_CONSUMER_GROUP,
+        topic: FORUM_SEARCH_CONTRACT_TOPIC,
+        scenario_results: vec![enabled, disabled],
+    })?;
+    Ok(())
+}
+
+async fn exercise_mode(
+    database_url: &str,
+    config: IggyConfig,
+    scope: &str,
+    expected_physical_dlq_messages: u64,
+) -> TestResult<ScenarioEvidence> {
+    let evidence = EvidenceRuntime::setup(database_url, config, scope).await?;
+    let stream = evidence.config.topology.stream_name.clone();
+    let first_transport = IggyTransport::new(evidence.config.clone()).await?;
+    let first_group = first_transport
+        .open_persistent_contract_consumer_group(
+            FORUM_SEARCH_CONTRACT_CONSUMER_GROUP,
+            FORUM_SEARCH_CONTRACT_TOPIC,
+        )
+        .await?;
+    let observer = connect_observer(&evidence.config).await?;
+
+    let marker = if expected_physical_dlq_messages == 1 { 0x61 } else { 0x62 };
+    let first_payload = vec![0xff, 0x00, marker, 0x01];
+    let second_payload = vec![0xff, 0x00, marker, 0x02];
+    publish_fixture(&evidence.fixture, &stream, first_payload.clone()).await?;
+    publish_fixture(&evidence.fixture, &stream, second_payload.clone()).await?;
+
+    let first_failure = receive_decode_failure(&first_group).await?;
+    ensure_failure(&first_failure, &first_payload)?;
+    let first_offset = first_failure.offset();
+    let first_delivery_id = first_failure.delivery_id();
+    let identity = poison_identity(&first_failure)?;
+    let store = ConsumerPoisonReceiptStore::new(evidence.db.clone());
+    let first_publisher = Uuid::new_v4();
+    let recovery_publisher = Uuid::new_v4();
+
+    assert_eq!(
+        store
+            .reserve_and_claim(
+                &identity,
+                first_failure.stable_error_code(),
+                1,
+                first_publisher,
+                PUBLISH_LEASE,
+            )
+            .await?,
+        ConsumerPoisonPublishClaim::Claimed
+    );
+    assert_receipt_state(&store, &identity, ConsumerPoisonReceiptState::Publishing).await?;
+    assert_message_count(&observer, &stream, 0).await?;
+
+    let first_entry = first_failure.to_dlq_entry(1);
+    let deterministic_message_id = first_entry
+        .broker_message_id()
+        .ok_or_else(|| invalid_data("raw poison DLQ entry has no deterministic message ID"))?;
+    if deterministic_message_id != first_delivery_id {
+        return Err(invalid_data("DLQ message ID differs from deterministic delivery ID").into());
+    }
+    first_transport.move_to_dlq(first_entry).await?;
+    assert_message_count(&observer, &stream, 1).await?;
+    assert_receipt_state(&store, &identity, ConsumerPoisonReceiptState::Publishing).await?;
+
+    assert_eq!(
+        store
+            .reserve_and_claim(
+                &identity,
+                first_failure.stable_error_code(),
+                2,
+                recovery_publisher,
+                PUBLISH_LEASE,
+            )
+            .await?,
+        ConsumerPoisonPublishClaim::Busy
+    );
+
+    drop(first_group);
+    first_transport.shutdown().await?;
+    drop(first_transport);
+    tokio::time::sleep(LEASE_RECLAIM_WAIT).await;
+
+    let recovery_transport = IggyTransport::new(evidence.config.clone()).await?;
+    let recovery_group = recovery_transport
+        .open_persistent_contract_consumer_group(
+            FORUM_SEARCH_CONTRACT_CONSUMER_GROUP,
+            FORUM_SEARCH_CONTRACT_TOPIC,
+        )
+        .await?;
+    let redelivered = receive_decode_failure(&recovery_group).await?;
+    ensure_failure(&redelivered, &first_payload)?;
+    if redelivered.offset() != first_offset || redelivered.delivery_id() != first_delivery_id {
+        return Err(invalid_data("restart changed the unacknowledged raw poison identity").into());
+    }
+
+    assert_eq!(
+        store
+            .reserve_and_claim(
+                &poison_identity(&redelivered)?,
+                redelivered.stable_error_code(),
+                2,
+                recovery_publisher,
+                PUBLISH_LEASE,
+            )
+            .await?,
+        ConsumerPoisonPublishClaim::Claimed
+    );
+    if !matches!(
+        store.mark_published(&identity, first_publisher).await,
+        Err(ConsumerPoisonReceiptError::ClaimLost)
+    ) {
+        return Err(invalid_data("stale publisher retained authority after lease takeover").into());
+    }
+
+    let retry_entry = redelivered.to_dlq_entry(2);
+    if retry_entry.broker_message_id() != Some(deterministic_message_id) {
+        return Err(invalid_data("redelivery changed the deterministic DLQ message ID").into());
+    }
+    recovery_transport.move_to_dlq(retry_entry).await?;
+    let observed_physical_dlq_messages = message_count(&observer, &stream).await?;
+    if observed_physical_dlq_messages != expected_physical_dlq_messages {
+        return Err(invalid_data(format!(
+            "{scope} expected {expected_physical_dlq_messages} physical DLQ messages but observed {observed_physical_dlq_messages}"
+        ))
+        .into());
+    }
+
+    store.mark_published(&identity, recovery_publisher).await?;
+    assert_receipt_state(&store, &identity, ConsumerPoisonReceiptState::Published).await?;
+    recovery_group.acknowledge_decode_failure(&redelivered).await?;
+    store.mark_acknowledged(&identity).await?;
+    assert_receipt_state(&store, &identity, ConsumerPoisonReceiptState::Acknowledged).await?;
+
+    let next_failure = receive_decode_failure(&recovery_group).await?;
+    ensure_failure(&next_failure, &second_payload)?;
+    if next_failure.offset() <= first_offset {
+        return Err(invalid_data("terminalization did not advance to the next source delivery").into());
+    }
+    let next_offset = next_failure.offset();
+
+    drop(recovery_group);
+    observer.shutdown().await?;
+    recovery_transport.shutdown().await?;
+    evidence.cleanup().await?;
+
+    Ok(ScenarioEvidence {
+        id: format!("raw_poison_publish_mark_ambiguity_{scope}"),
+        result: "passed",
+        facts: json!({
+            "dedup_mode": scope,
+            "stream": stream,
+            "first_offset": first_offset,
+            "first_delivery_id": first_delivery_id,
+            "deterministic_dlq_message_id": deterministic_message_id,
+            "publish_succeeded_before_mark_published": true,
+            "expired_claim_reclaimed_after_restart": true,
+            "stale_publisher_fenced": true,
+            "expected_physical_dlq_messages": expected_physical_dlq_messages,
+            "observed_physical_dlq_messages": observed_physical_dlq_messages,
+            "source_acknowledged_after_durable_published": true,
+            "receipt_state_after_acknowledgement": "acknowledged",
+            "next_offset": next_offset
+        }),
+    })
+}
+
+async fn publish_fixture(
+    connector: &ExternalConnector,
+    stream: &str,
+    payload: Vec<u8>,
+) -> TestResult<()> {
+    connector
+        .publish(PublishRequest::new(
+            stream,
+            FORUM_SEARCH_CONTRACT_TOPIC,
+            "forum-search-raw-poison-ambiguity-fixture",
+            payload,
+            Uuid::new_v4().to_string(),
+        ))
+        .await?;
+    Ok(())
+}
+
+async fn receive_decode_failure(
+    group: &PersistentContractConsumerGroup,
+) -> TestResult<ConsumedContractDecodeFailure> {
+    let delivery = timeout(RECEIVE_TIMEOUT, group.receive_delivery())
+        .await
+        .map_err(|_| invalid_data("timed out waiting for Forum Search raw poison delivery"))??
+        .ok_or_else(|| invalid_data("Forum Search source cursor ended before poison delivery"))?;
+    match delivery {
+        PersistentContractDelivery::DecodeFailure(failure) => Ok(failure),
+        PersistentContractDelivery::Event(_) => Err(invalid_data(
+            "malformed ambiguity fixture unexpectedly decoded as a contract event",
+        )
+        .into()),
+    }
+}
+
+fn ensure_failure(failure: &ConsumedContractDecodeFailure, expected_payload: &[u8]) -> TestResult<()> {
+    if failure.topic() != FORUM_SEARCH_CONTRACT_TOPIC
+        || failure.partition() == 0
+        || failure.ack_token().is_none()
+        || failure.raw_payload() != expected_payload
+    {
+        return Err(invalid_data(format!("unexpected raw poison delivery: {failure:?}")).into());
+    }
+    failure.validate_connector_metadata()?;
+    Ok(())
+}
+
+fn poison_identity(
+    failure: &ConsumedContractDecodeFailure,
+) -> Result<ConsumerPoisonIdentity, ConsumerPoisonReceiptError> {
+    ConsumerPoisonIdentity::new(
+        failure.delivery_id(),
+        FORUM_SEARCH_CONTRACT_CONSUMER_GROUP,
+        failure.stream(),
+        failure.topic(),
+        failure.partition(),
+        failure.offset(),
+        failure.raw_payload().to_vec(),
+    )
+}
+
+async fn assert_receipt_state(
+    store: &ConsumerPoisonReceiptStore,
+    identity: &ConsumerPoisonIdentity,
+    expected: ConsumerPoisonReceiptState,
+) -> TestResult<()> {
+    let receipt = store
+        .find(identity)
+        .await?
+        .ok_or_else(|| invalid_data("expected poison receipt was not found"))?;
+    if receipt.state != expected {
+        return Err(invalid_data(format!(
+            "expected poison receipt state {expected:?}, observed {:?}",
+            receipt.state
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+async fn connect_observer(config: &IggyConfig) -> TestResult<IggyClient> {
+    let client = IggyClient::from_connection_string(&connection_string(&config.external)?)?;
+    client.connect().await?;
+    Ok(client)
+}
+
+async fn message_count(client: &IggyClient, stream: &str) -> TestResult<u64> {
+    let stream_id: Identifier = stream.to_string().try_into()?;
+    let topic_id: Identifier = "dlq".to_string().try_into()?;
+    let topic = client
+        .get_topic(&stream_id, &topic_id)
+        .await?
+        .ok_or_else(|| invalid_data("poison ambiguity DLQ topic is missing"))?;
+    let partition = topic
+        .partitions
+        .iter()
+        .find(|partition| partition.id == 1)
+        .ok_or_else(|| invalid_data("poison ambiguity DLQ partition 1 is missing"))?;
+    Ok(partition.messages_count)
+}
+
+async fn assert_message_count(client: &IggyClient, stream: &str, expected: u64) -> TestResult<()> {
+    let observed = message_count(client, stream).await?;
+    if observed != expected {
+        return Err(invalid_data(format!(
+            "expected {expected} physical DLQ messages but observed {observed}"
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+fn postgres_database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+fn external_iggy_config(address_env: &'static str, scope: &str) -> TestResult<Option<IggyConfig>> {
+    let address = match env::var(address_env) {
+        Ok(value) => bounded_env(address_env, value, 255)?,
+        Err(env::VarError::NotPresent) => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    validate_address(address_env, &address)?;
+    let username = optional_bounded_env(USERNAME_ENV, 191)?;
+    let password = optional_bounded_env(PASSWORD_ENV, 191)?;
+    if username.is_empty() != password.is_empty() {
+        return Err(invalid_data("Iggy username and password must both be set or both be empty").into());
+    }
+
+    Ok(Some(IggyConfig {
+        mode: IggyMode::External,
+        serialization: SerializationFormat::Json,
+        external: ExternalConfig {
+            addresses: vec![address],
+            protocol: "tcp".to_string(),
+            username,
+            password,
+            tls_enabled: false,
+            tls_domain: None,
+            tls_ca_file: None,
+        },
+        topology: TopologyConfig {
+            stream_name: unique_name(scope),
+            domain_partitions: 1,
+            replication_factor: 1,
+        },
+        ..IggyConfig::default()
+    }))
+}
+
+fn ensure_distinct_mode_addresses() -> TestResult<()> {
+    let enabled = env::var(DEDUP_ENABLED_ADDRESS_ENV).ok();
+    let disabled = env::var(DEDUP_DISABLED_ADDRESS_ENV).ok();
+    if let (Some(enabled), Some(disabled)) = (enabled, disabled) {
+        let enabled = bounded_env(DEDUP_ENABLED_ADDRESS_ENV, enabled, 255)?;
+        let disabled = bounded_env(DEDUP_DISABLED_ADDRESS_ENV, disabled, 255)?;
+        validate_address(DEDUP_ENABLED_ADDRESS_ENV, &enabled)?;
+        validate_address(DEDUP_DISABLED_ADDRESS_ENV, &disabled)?;
+        if enabled == disabled {
+            return Err(invalid_data(
+                "dedup-enabled and dedup-disabled evidence require distinct Iggy addresses",
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn validate_address(name: &'static str, address: &str) -> Result<(), IoError> {
+    if address.contains("://") || address.contains('@') || address.contains('?') || address.contains('#') {
+        return Err(invalid_data(format!(
+            "{name} must be host:port without credentials or URL delimiters"
+        )));
+    }
+    Ok(())
+}
+
+fn connection_string(config: &ExternalConfig) -> Result<String, IoError> {
+    let address = config
+        .addresses
+        .first()
+        .ok_or_else(|| invalid_data("Iggy address is missing"))?;
+    validate_address("Iggy address", address)?;
+    if config.username.is_empty() {
+        Ok(format!("iggy://{address}"))
+    } else {
+        Ok(format!("iggy://{}:{}@{address}", config.username, config.password))
+    }
+}
+
+fn optional_bounded_env(name: &'static str, max_len: usize) -> TestResult<String> {
+    match env::var(name) {
+        Ok(value) => Ok(bounded_env(name, value, max_len)?),
+        Err(env::VarError::NotPresent) => Ok(String::new()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn bounded_env(name: &'static str, value: String, max_len: usize) -> Result<String, IoError> {
+    if value.trim() != value || value.is_empty() || value.len() > max_len || value.chars().any(char::is_control) {
+        return Err(invalid_data(format!("{name} is invalid for retained evidence")));
+    }
+    Ok(value)
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options.max_connections(1).min_connections(1).sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn connect_in_schema(
+    database_url: &str,
+    schema_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url).await?;
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}", public"#))
+        .await?;
+    Ok(db)
+}
+
+fn sanitize_identifier(value: &str) -> String {
+    let normalized = value
+        .chars()
+        .map(|character| if character.is_ascii_alphanumeric() { character.to_ascii_lowercase() } else { '_' })
+        .collect::<String>();
+    let normalized = normalized.trim_matches('_');
+    if normalized.is_empty() { "test".to_string() } else { normalized.to_string() }
+}
+
+fn unique_name(scope: &str) -> String {
+    format!("rustok-forum-search-poison-{scope}-{}", Uuid::new_v4().simple())
+}
+
+fn write_evidence(artifact: EvidenceArtifact) -> TestResult<()> {
+    let path = workspace_root().join(EVIDENCE_PATH);
+    let parent = path.parent().ok_or_else(|| invalid_data("evidence path has no parent"))?;
+    fs::create_dir_all(parent)?;
+    let mut bytes = serde_json::to_vec_pretty(&artifact)?;
+    bytes.push(b'\n');
+    fs::write(path, bytes)?;
+    Ok(())
+}
+
+fn source_commit() -> TestResult<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(workspace_root())
+        .output()?;
+    if !output.status.success() {
+        return Err(invalid_data("git rev-parse HEAD failed").into());
+    }
+    let commit = String::from_utf8(output.stdout)?.trim().to_string();
+    if commit.len() != 40 || !commit.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(invalid_data("git rev-parse HEAD returned an invalid source commit").into());
+    }
+    Ok(commit)
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn invalid_data(message: impl Into<String>) -> IoError {
+    IoError::new(ErrorKind::InvalidData, message.into())
+}

--- a/scripts/verify/verify-forum-search-versioned-invalidation-d6-poison-ambiguity.mjs
+++ b/scripts/verify/verify-forum-search-versioned-invalidation-d6-poison-ambiguity.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = process.cwd();
+const read = (path) => readFileSync(resolve(root, path), "utf8");
+const requireAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(text.includes(marker), `${label} is missing required marker: ${marker}`);
+  }
+};
+const forbidAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(!text.includes(marker), `${label} contains forbidden marker: ${marker}`);
+  }
+};
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-search-versioned-invalidation-poison-ambiguity-source-proof.json";
+const documentPath =
+  "crates/rustok-forum/docs/forum-23b2g2b3d6-versioned-invalidation-poison-ambiguity.md";
+const testPath =
+  "crates/rustok-search/tests/forum_versioned_invalidation_poison_ambiguity_iggy.rs";
+const manifestPath = "crates/rustok-search/Cargo.toml";
+const workerPath = "apps/server/src/services/forum_search_contract_consumer.rs";
+const parentPath =
+  "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json";
+
+const contract = JSON.parse(read(contractPath));
+assert.equal(
+  contract.contract,
+  "forum_search_versioned_invalidation_poison_ambiguity_source_proof_v1",
+);
+assert.equal(contract.task, "FORUM-23B2G2B3D6");
+assert.equal(contract.status, "source_ready_maintainer_execution_pending");
+assert.equal(contract.runtime_evidence_parent, parentPath);
+assert.equal(contract.predecessor.task, "FORUM-23B2G2B3D5");
+assert.equal(contract.predecessor.pull_request, 2777);
+assert.equal(contract.predecessor.state_at_authorship, "merged");
+assert.equal(
+  contract.predecessor.merge_commit,
+  "1d2654785047efde1d29a9682732990acc56f9b5",
+);
+assert.equal(
+  contract.predecessor.parent_registration,
+  "D5_registered_D6_deferred_until_D6_merge",
+);
+assert.equal(contract.test, testPath);
+assert.equal(contract.production_reference, workerPath);
+assert.equal(
+  contract.evidence_artifact.path,
+  "target/forum-search-versioned-invalidation-poison-ambiguity-evidence.json",
+);
+assert.equal(contract.evidence_artifact.generation, "executable_test_only");
+assert.equal(contract.evidence_artifact.hand_editing_forbidden, true);
+assert.equal(contract.evidence_artifact.source_commit_required, true);
+assert.equal(contract.evidence_artifact.written_only_after_all_modes_pass, true);
+assert.equal(contract.required_runtime.database, "postgresql");
+assert.equal(contract.required_runtime.delivery_profile, "outbox_iggy");
+assert.equal(
+  contract.required_runtime.consumer_group,
+  "rustok-search-forum-projection-v1",
+);
+assert.equal(contract.required_runtime.source_topic, "domain");
+assert.equal(contract.required_runtime.dlq_topic, "dlq");
+assert.equal(contract.required_runtime.distinct_iggy_addresses_required, true);
+assert.deepEqual(
+  contract.required_runtime.iggy_instances.map(({ mode }) => mode),
+  ["dedup_enabled", "dedup_disabled"],
+);
+assert.deepEqual(
+  contract.required_runtime.iggy_instances.map(
+    ({ expected_physical_dlq_messages_after_retry }) =>
+      expected_physical_dlq_messages_after_retry,
+  ),
+  [1, 2],
+);
+assert.deepEqual(
+  contract.scenarios.map(({ id }) => id),
+  [
+    "raw_poison_publish_mark_ambiguity_dedup_enabled",
+    "raw_poison_publish_mark_ambiguity_dedup_disabled",
+  ],
+);
+assert.ok(contract.identity_invariants.length >= 6);
+assert.ok(contract.non_claims.length >= 9);
+
+const test = read(testPath);
+requireAll(
+  test,
+  [
+    "raw_poison_publish_mark_ambiguity_obeys_configured_dedup_modes",
+    "RUSTOK_FORUM_SEARCH_POISON_DEDUP_ENABLED_IGGY_ADDRESS",
+    "RUSTOK_FORUM_SEARCH_POISON_DEDUP_DISABLED_IGGY_ADDRESS",
+    "ensure_distinct_mode_addresses",
+    "FORUM_SEARCH_CONTRACT_CONSUMER_GROUP",
+    "FORUM_SEARCH_CONTRACT_TOPIC",
+    "rustok_iggy_connector::migrations::migrations()",
+    "PersistentContractDelivery::DecodeFailure",
+    "ConsumerPoisonIdentity::new",
+    "ConsumerPoisonPublishClaim::Claimed",
+    "ConsumerPoisonPublishClaim::Busy",
+    "ConsumerPoisonReceiptError::ClaimLost",
+    "ConsumerPoisonReceiptState::Publishing",
+    "ConsumerPoisonReceiptState::Published",
+    "ConsumerPoisonReceiptState::Acknowledged",
+    "broker_message_id()",
+    "move_to_dlq",
+    "mark_published",
+    "acknowledge_decode_failure",
+    "mark_acknowledged",
+    "tokio::time::sleep(LEASE_RECLAIM_WAIT)",
+    "expected_physical_dlq_messages",
+    "observed_physical_dlq_messages",
+    "message_count",
+    "target/forum-search-versioned-invalidation-poison-ambiguity-evidence.json",
+    "FORUM-23B2G2B3D6",
+    "source_commit()",
+  ],
+  "D6 external-Iggy poison ambiguity test",
+);
+forbidAll(
+  test,
+  [
+    "ForumSearchContractIngress",
+    "SearchModule.migrations()",
+    "forum.search_projection.contract_inbox_identity_conflict",
+    "search_projection_inbox",
+    "FORUM-23B2G2B3D5",
+  ],
+  "D6 external-Iggy poison ambiguity test",
+);
+
+const manifest = read(manifestPath);
+requireAll(
+  manifest,
+  [
+    "[dev-dependencies]",
+    "iggy.workspace = true",
+    "rustok-iggy.workspace = true",
+    'rustok-iggy-connector = { workspace = true, features = ["migrations"] }',
+  ],
+  "rustok-search test dependencies",
+);
+
+const worker = read(workerPath);
+requireAll(
+  worker,
+  [
+    "POISON_PUBLISH_LEASE",
+    "establish_poison_result",
+    ".reserve_and_claim(",
+    "ConsumerPoisonPublishClaim::AlreadyPublished",
+    "ConsumerPoisonPublishClaim::AlreadyAcknowledged",
+    "ConsumerPoisonPublishClaim::Busy",
+    "ConsumerPoisonPublishClaim::Claimed",
+    "transport.move_to_dlq(entry.clone())",
+    ".release_claim(identity, poison_publisher_id)",
+    "mark_poison_published",
+    "acknowledge_decode_failure_with_receipt",
+    "mark_acknowledged",
+  ],
+  "production Forum Search poison worker ordering",
+);
+
+const document = read(documentPath);
+requireAll(
+  document,
+  [
+    "FORUM-23B2G2B3D6",
+    "source_ready_maintainer_execution_pending",
+    contractPath,
+    testPath,
+    workerPath,
+    "second publisher observes Busy before lease expiry",
+    "stale publisher fails mark_published with ClaimLost",
+    "exactly one physical DLQ message",
+    "exactly two",
+    "merged through PR #2777",
+    "D6 intentionally defers its own registration",
+    "No command above was run by the implementation agent",
+  ],
+  "D6 poison ambiguity handoff",
+);
+forbidAll(
+  document,
+  ["open PR #2774", "pending PR #2772", "FORUM-23B2G2B3D5 external-Iggy poison ambiguity"],
+  "D6 poison ambiguity handoff",
+);
+
+const parent = JSON.parse(read(parentPath));
+assert.equal(parent.task, "FORUM-23B2G2B3D0");
+assert.equal(parent.status, "source_ready_maintainer_execution_pending");
+assert.ok(
+  parent.source_ready_subproofs.some(
+    ({ task }) => task === "FORUM-23B2G2B3D5",
+  ),
+  "D0 parent must retain merged D5 semantic-poison proof",
+);
+assert.ok(
+  !parent.source_ready_subproofs.some(
+    ({ task }) => task === "FORUM-23B2G2B3D6",
+  ),
+  "D0 parent must not register unmerged D6",
+);
+assert.ok(
+  parent.required_scenarios.some(
+    ({ id }) => id === "raw_poison_dlq_redelivery",
+  ),
+  "D0 parent must retain raw poison/DLQ runtime scenario",
+);
+assert.equal(parent.evidence_artifact.generation, "executable_runtime_only");
+assert.equal(parent.evidence_artifact.hand_editing_forbidden, true);
+
+console.log(
+  "Forum Search D6 external-Iggy poison publish/mark ambiguity source proof is internally consistent.",
+);


### PR DESCRIPTION
## Summary

- continue the frozen Forum Search runtime-evidence matrix with `FORUM-23B2G2B3D6`
- build on merged D5 semantic-poison restart proof #2777 without duplicating its typed identity-conflict scenario
- add one external-Iggy/PostgreSQL executable target for the raw-poison publish-success-before-`mark_published` ambiguity window
- execute the same deterministic receipt and DLQ protocol against two distinct Iggy instances: server-side message-ID dedup enabled and disabled
- retain exact source bytes, partition, offset and deterministic delivery identity through transport and consumer-group reconstruction
- require an unexpired claim to return `Busy`, an expired claim to be reclaimed, and the stale publisher to be fenced with `ClaimLost`
- republish with the exact deterministic DLQ broker message ID
- require one physical DLQ message with dedup enabled and two with dedup disabled
- acknowledge the source only after durable `published`, mark the receipt `acknowledged`, and advance to the next malformed delivery
- write retained JSON evidence only after both modes pass
- add a machine-readable contract, handoff and fail-closed verifier

## Rechecked baseline

Current `main` contains:

- D0 runtime-evidence protocol and D1 canonical-plan reconciliation
- D2 PostgreSQL shared-inbox proof from #2767
- D3 external-Iggy acknowledgement/restart proof from #2770
- D4 external-Iggy/PostgreSQL raw-poison restart proof from #2775
- D5 external-Iggy/PostgreSQL semantic identity-conflict poison proof from #2777

The parent D0 contract already registers D5. This PR intentionally defers D6 registration until D6 itself merges, so canonical `main` never lists an unmerged subproof.

## Executable proof

`crates/rustok-search/tests/forum_versioned_invalidation_poison_ambiguity_iggy.rs` requires:

- PostgreSQL through `RUSTOK_SEARCH_TEST_DATABASE_URL` or PostgreSQL `DATABASE_URL`
- a dedup-enabled Iggy instance through `RUSTOK_FORUM_SEARCH_POISON_DEDUP_ENABLED_IGGY_ADDRESS`
- a distinct dedup-disabled instance through `RUSTOK_FORUM_SEARCH_POISON_DEDUP_DISABLED_IGGY_ADDRESS`
- optional paired credentials through the existing external-Iggy username/password variables

For each mode the harness:

1. creates an isolated PostgreSQL schema and applies the real connector poison-receipt migrations;
2. creates a unique one-partition Iggy evidence stream;
3. publishes two malformed payloads to `domain`;
4. receives the first payload through production group `rustok-search-forum-projection-v1`;
5. claims a durable receipt and publishes one deterministic DLQ entry without calling `mark_published`;
6. requires another live publisher to observe `Busy`;
7. reconstructs transport and consumer group after the one-second lease expires;
8. receives the exact same delivery and reclaims the receipt;
9. requires the stale publisher to fail with `ClaimLost`;
10. republishes with the same deterministic message ID;
11. observes one physical message with dedup enabled or two with dedup disabled;
12. persists `published`, acknowledges the exact source delivery, persists `acknowledged`, and advances to the second payload.

Successful execution writes:

```text
target/forum-search-versioned-invalidation-poison-ambiguity-evidence.json
```

The artifact records the exact source commit and is generated only after both broker modes pass.

## Deliberate limits

This PR does not claim:

- successful PostgreSQL or external-Iggy execution
- server-owned Forum Search worker-loop or retry/backoff execution
- active production deduplication configuration readback
- semantic identity-conflict poison, already covered by merged D5
- arbitrary multi-process contention beyond one expired-lease takeover
- TLS, replication, multiple partitions or broker failover
- projector/checkpoint execution, missing-delivery repair, deletion/ACL visibility ordering, Search-disabled recovery, completion of `FORUM-23B2G2B3D`, or closure of `LINK-FORUM-03`

## Compatibility

- no production Rust path changed
- no migration, event schema, digest, runtime flag, consumer group, broker topic, Search query or public API changed
- no `Cargo.lock` change
- the only manifest addition is direct test-only `iggy.workspace = true`, already present in the workspace lock graph
- no second inbox, projector, reconciler or ordering clock

## Validation

Not run per maintainer instruction:

```bash
RUSTOK_SEARCH_TEST_DATABASE_URL="$DATABASE_URL" \
RUSTOK_FORUM_SEARCH_POISON_DEDUP_ENABLED_IGGY_ADDRESS="127.0.0.1:8090" \
RUSTOK_FORUM_SEARCH_POISON_DEDUP_DISABLED_IGGY_ADDRESS="127.0.0.1:8091" \
  cargo test -p rustok-search \
  --test forum_versioned_invalidation_poison_ambiguity_iggy \
  -- --nocapture --test-threads=1

node scripts/verify/verify-forum-search-versioned-invalidation-d6-poison-ambiguity.mjs
cargo check -p rustok-search --all-targets
cargo xtask module validate forum
cargo xtask module validate search
git diff --check
```

No executable evidence artifact was generated. Squash merge is recommended after maintainer validation.