### PR TITLE
fix(rbac): publish artifact permission changes transactionally

### DIFF
--- a/apps/server/src/controllers/artifact_permissions.rs
+++ b/apps/server/src/controllers/artifact_permissions.rs
@@ -1,5 +1,8 @@
 //! Host transport for RBAC-owned artifact permission grants.
 
+use std::sync::Arc;
+
+use async_trait::async_trait;
 use axum::{
     Json,
     extract::{Path, State},
@@ -8,12 +11,15 @@ use axum::{
     routing::put,
 };
 use rustok_api::{AuthContext, Permission, has_effective_permission};
+use rustok_events::RbacArtifactPermissionEvent;
+use rustok_outbox::TransactionalEventBus;
 use rustok_rbac::{
-    ArtifactPermissionAssignmentError, ArtifactRolePermissionAssignmentCommand,
-    RbacArtifactPermissionAssignmentService, RbacControlPlanePrincipal,
-    require_direct_control_plane_user,
+    ArtifactPermissionAssignmentError, ArtifactPermissionEventPublisher,
+    ArtifactRolePermissionAssignmentCommand, RbacArtifactPermissionAssignmentService,
+    RbacControlPlanePrincipal, require_direct_control_plane_user,
 };
 use rustok_web::json_response;
+use sea_orm::DatabaseTransaction;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -21,8 +27,38 @@ use uuid::Uuid;
 use crate::{
     error::{Error, Result, http_error},
     extractors::tenant::CurrentTenant,
-    services::server_runtime_context::ServerRuntimeContext,
+    services::{
+        event_bus::transactional_event_bus_from_context,
+        server_runtime_context::ServerRuntimeContext,
+    },
 };
+
+#[derive(Clone)]
+struct TransactionalOutboxArtifactPermissionEventPublisher {
+    event_bus: TransactionalEventBus,
+}
+
+impl TransactionalOutboxArtifactPermissionEventPublisher {
+    fn new(event_bus: TransactionalEventBus) -> Self {
+        Self { event_bus }
+    }
+}
+
+#[async_trait]
+impl ArtifactPermissionEventPublisher for TransactionalOutboxArtifactPermissionEventPublisher {
+    async fn publish_assignment_changed(
+        &self,
+        transaction: &DatabaseTransaction,
+        tenant_id: Uuid,
+        actor_id: Uuid,
+        event: RbacArtifactPermissionEvent,
+    ) -> std::result::Result<(), ArtifactPermissionAssignmentError> {
+        self.event_bus
+            .publish_contract_in_tx(transaction, tenant_id, Some(actor_id), event)
+            .await
+            .map_err(|error| ArtifactPermissionAssignmentError::Database(error.to_string()))
+    }
+}
 
 /// The transport input for one exact role-to-artifact-permission operation.
 #[derive(Debug, Deserialize, ToSchema)]
@@ -99,7 +135,10 @@ async fn assign(
     input: ArtifactRolePermissionAssignmentRequest,
     granted: bool,
 ) -> Result<Response> {
-    let service = RbacArtifactPermissionAssignmentService::new(ctx.db_clone());
+    let event_publisher = Arc::new(TransactionalOutboxArtifactPermissionEventPublisher::new(
+        transactional_event_bus_from_context(ctx),
+    ));
+    let service = RbacArtifactPermissionAssignmentService::new(ctx.db_clone(), event_publisher);
     let result = service
         .assign(ArtifactRolePermissionAssignmentCommand {
             tenant_id,
@@ -173,8 +212,17 @@ pub fn router() -> crate::routes::ServerRouter {
 
 #[cfg(test)]
 mod tests {
-    use super::ensure_artifact_permission_control_plane;
+    use super::{
+        TransactionalOutboxArtifactPermissionEventPublisher,
+        ensure_artifact_permission_control_plane,
+    };
     use rustok_api::{AuthContext, Permission};
+    use rustok_events::RbacArtifactPermissionEvent;
+    use rustok_outbox::{OutboxTransport, SysEvents, SysEventsMigration, TransactionalEventBus};
+    use rustok_rbac::ArtifactPermissionEventPublisher;
+    use sea_orm::{Database, EntityTrait, TransactionTrait};
+    use sea_orm_migration::{MigrationTrait, SchemaManager};
+    use std::sync::Arc;
     use uuid::Uuid;
 
     fn auth_context(
@@ -250,5 +298,49 @@ mod tests {
         );
 
         assert!(ensure_artifact_permission_control_plane(&auth, tenant_id).is_err());
+    }
+
+    #[tokio::test]
+    async fn transactional_outbox_adapter_writes_typed_event() {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("connect sqlite");
+        SysEventsMigration
+            .up(&SchemaManager::new(&db))
+            .await
+            .expect("create outbox table");
+
+        let adapter = TransactionalOutboxArtifactPermissionEventPublisher::new(
+            TransactionalEventBus::new(Arc::new(OutboxTransport::new(db.clone()))),
+        );
+        let tenant_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let transaction = db.begin().await.expect("begin owner transaction");
+        adapter
+            .publish_assignment_changed(
+                &transaction,
+                tenant_id,
+                actor_id,
+                RbacArtifactPermissionEvent::AssignmentChanged {
+                    operation_id: Uuid::new_v4(),
+                    role_id: Uuid::new_v4(),
+                    installation_id: Uuid::new_v4(),
+                    permission_key: "sample.events.handle".to_string(),
+                    granted: true,
+                },
+            )
+            .await
+            .expect("publish typed event");
+        transaction.commit().await.expect("commit owner transaction");
+
+        let events = SysEvents::find().all(&db).await.expect("load outbox");
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].event_type,
+            "rbac.artifact_role_permission.assignment_changed"
+        );
+        assert_eq!(events[0].schema_version, 1);
+        assert_eq!(events[0].payload["tenant_id"], serde_json::json!(tenant_id));
+        assert_eq!(events[0].payload["actor_id"], serde_json::json!(actor_id));
     }
 }

--- a/crates/rustok-events/src/contract.rs
+++ b/crates/rustok-events/src/contract.rs
@@ -8,7 +8,8 @@ use uuid::Uuid;
 use crate::{
     DomainEvent, EventEnvelope, EventValidationError, ForumMentionEvent,
     ForumSearchProjectionEvent, MarketplaceListingEvent, MarketplaceSellerEvent,
-    SocialGraphRelationEvent, TranslationWorkflowEvent, ValidateEvent,
+    RbacArtifactPermissionEvent, SocialGraphRelationEvent, TranslationWorkflowEvent,
+    ValidateEvent,
 };
 
 pub(crate) mod sealed {
@@ -45,6 +46,8 @@ pub enum ContractEventPayload {
     MarketplaceListing(MarketplaceListingEvent),
     #[serde(rename = "marketplace_seller")]
     MarketplaceSeller(MarketplaceSellerEvent),
+    #[serde(rename = "rbac_artifact_permission")]
+    RbacArtifactPermission(RbacArtifactPermissionEvent),
     #[serde(rename = "social_graph_relation")]
     SocialGraphRelation(SocialGraphRelationEvent),
     #[serde(rename = "translation_workflow")]
@@ -59,6 +62,7 @@ impl ContractEventPayload {
             Self::ForumSearchProjection(event) => event.event_type(),
             Self::MarketplaceListing(event) => event.event_type(),
             Self::MarketplaceSeller(event) => event.event_type(),
+            Self::RbacArtifactPermission(event) => event.event_type(),
             Self::SocialGraphRelation(event) => event.event_type(),
             Self::TranslationWorkflow(event) => event.event_type(),
         }
@@ -71,6 +75,7 @@ impl ContractEventPayload {
             Self::ForumSearchProjection(event) => event.schema_version(),
             Self::MarketplaceListing(event) => event.schema_version(),
             Self::MarketplaceSeller(event) => event.schema_version(),
+            Self::RbacArtifactPermission(event) => event.schema_version(),
             Self::SocialGraphRelation(event) => event.schema_version(),
             Self::TranslationWorkflow(event) => event.schema_version(),
         }
@@ -85,6 +90,7 @@ impl ValidateEvent for ContractEventPayload {
             Self::ForumSearchProjection(event) => event.validate(),
             Self::MarketplaceListing(event) => event.validate(),
             Self::MarketplaceSeller(event) => event.validate(),
+            Self::RbacArtifactPermission(event) => event.validate(),
             Self::SocialGraphRelation(event) => event.validate(),
             Self::TranslationWorkflow(event) => event.validate(),
         }

--- a/crates/rustok-events/src/lib.rs
+++ b/crates/rustok-events/src/lib.rs
@@ -5,6 +5,7 @@ mod forum_mention;
 mod forum_search_projection;
 mod marketplace_listing;
 mod marketplace_seller;
+mod rbac_artifact_permission;
 mod schema;
 mod social_graph;
 mod translation_workflow;
@@ -27,6 +28,10 @@ pub use marketplace_listing::{
 pub use marketplace_seller::{
     MARKETPLACE_SELLER_EVENT_SCHEMAS, MarketplaceSellerEvent, marketplace_seller_event_schema,
 };
+pub use rbac_artifact_permission::{
+    RBAC_ARTIFACT_PERMISSION_EVENT_SCHEMAS, RbacArtifactPermissionEvent,
+    rbac_artifact_permission_event_schema,
+};
 pub use schema::{
     EVENT_SCHEMAS, EventContractDigests, EventSchema, FieldSchema,
     contract_event_envelope_json_schema, contract_event_payload_json_schema,
@@ -37,7 +42,8 @@ pub use social_graph::{
     social_graph_relation_event_schema,
 };
 pub use translation_workflow::{
-    TRANSLATION_WORKFLOW_EVENT_SCHEMAS, TranslationWorkflowEvent, translation_workflow_event_schema,
+    TRANSLATION_WORKFLOW_EVENT_SCHEMAS, TranslationWorkflowEvent,
+    translation_workflow_event_schema,
 };
 pub use types::{DomainEvent, EventEnvelope, EventEnvelopeError};
 pub use validation::{EventValidationError, ValidateEvent};
@@ -51,6 +57,7 @@ pub fn event_schema(event_type: &str) -> Option<&'static EventSchema> {
         .or_else(|| forum_search_projection_event_schema(event_type))
         .or_else(|| marketplace_listing_event_schema(event_type))
         .or_else(|| marketplace_seller_event_schema(event_type))
+        .or_else(|| rbac_artifact_permission_event_schema(event_type))
         .or_else(|| social_graph_relation_event_schema(event_type))
         .or_else(|| translation_workflow_event_schema(event_type))
 }
@@ -62,6 +69,7 @@ pub fn event_schemas() -> impl Iterator<Item = &'static EventSchema> {
         .chain(FORUM_SEARCH_PROJECTION_EVENT_SCHEMAS.iter())
         .chain(MARKETPLACE_LISTING_EVENT_SCHEMAS.iter())
         .chain(MARKETPLACE_SELLER_EVENT_SCHEMAS.iter())
+        .chain(RBAC_ARTIFACT_PERMISSION_EVENT_SCHEMAS.iter())
         .chain(SOCIAL_GRAPH_RELATION_EVENT_SCHEMAS.iter())
         .chain(TRANSLATION_WORKFLOW_EVENT_SCHEMAS.iter())
 }

--- a/crates/rustok-events/src/rbac_artifact_permission.rs
+++ b/crates/rustok-events/src/rbac_artifact_permission.rs
@@ -1,0 +1,189 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::contract::{ContractEventPayload, EventContract, sealed};
+use crate::validation::{EventValidationError, ValidateEvent, validators};
+use crate::{EventSchema, FieldSchema};
+
+const MAX_PERMISSION_KEY_LENGTH: usize = 256;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(tag = "type", content = "data")]
+pub enum RbacArtifactPermissionEvent {
+    AssignmentChanged {
+        operation_id: Uuid,
+        role_id: Uuid,
+        installation_id: Uuid,
+        permission_key: String,
+        granted: bool,
+    },
+}
+
+impl RbacArtifactPermissionEvent {
+    pub fn event_type(&self) -> &'static str {
+        match self {
+            Self::AssignmentChanged { .. } => {
+                "rbac.artifact_role_permission.assignment_changed"
+            }
+        }
+    }
+
+    pub const fn schema_version(&self) -> u16 {
+        1
+    }
+}
+
+const ASSIGNMENT_CHANGED_FIELDS: &[FieldSchema] = &[
+    FieldSchema {
+        name: "operation_id",
+        data_type: "uuid",
+        optional: false,
+    },
+    FieldSchema {
+        name: "role_id",
+        data_type: "uuid",
+        optional: false,
+    },
+    FieldSchema {
+        name: "installation_id",
+        data_type: "uuid",
+        optional: false,
+    },
+    FieldSchema {
+        name: "permission_key",
+        data_type: "string",
+        optional: false,
+    },
+    FieldSchema {
+        name: "granted",
+        data_type: "bool",
+        optional: false,
+    },
+];
+
+pub const RBAC_ARTIFACT_PERMISSION_EVENT_SCHEMAS: &[EventSchema] = &[EventSchema {
+    event_type: "rbac.artifact_role_permission.assignment_changed",
+    version: 1,
+    description: "RBAC atomically changed one tenant role grant for an admitted artifact permission.",
+    fields: ASSIGNMENT_CHANGED_FIELDS,
+}];
+
+impl sealed::Sealed for RbacArtifactPermissionEvent {}
+
+impl EventContract for RbacArtifactPermissionEvent {
+    fn event_type(&self) -> &'static str {
+        RbacArtifactPermissionEvent::event_type(self)
+    }
+
+    fn schema_version(&self) -> u16 {
+        RbacArtifactPermissionEvent::schema_version(self)
+    }
+
+    fn into_contract_payload(self) -> ContractEventPayload {
+        ContractEventPayload::RbacArtifactPermission(self)
+    }
+}
+
+impl ValidateEvent for RbacArtifactPermissionEvent {
+    fn validate(&self) -> Result<(), EventValidationError> {
+        let Self::AssignmentChanged {
+            operation_id,
+            role_id,
+            installation_id,
+            permission_key,
+            ..
+        } = self;
+
+        validators::validate_not_nil_uuid("operation_id", operation_id)?;
+        validators::validate_not_nil_uuid("role_id", role_id)?;
+        validators::validate_not_nil_uuid("installation_id", installation_id)?;
+        validators::validate_not_empty("permission_key", permission_key)?;
+        validators::validate_max_length(
+            "permission_key",
+            permission_key,
+            MAX_PERMISSION_KEY_LENGTH,
+        )?;
+        if permission_key.trim() != permission_key
+            || permission_key.chars().any(char::is_control)
+        {
+            return Err(EventValidationError::InvalidCharacters("permission_key"));
+        }
+        Ok(())
+    }
+}
+
+pub fn rbac_artifact_permission_event_schema(
+    event_type: &str,
+) -> Option<&'static EventSchema> {
+    RBAC_ARTIFACT_PERMISSION_EVENT_SCHEMAS
+        .iter()
+        .find(|schema| schema.event_type == event_type)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event() -> RbacArtifactPermissionEvent {
+        RbacArtifactPermissionEvent::AssignmentChanged {
+            operation_id: Uuid::new_v4(),
+            role_id: Uuid::new_v4(),
+            installation_id: Uuid::new_v4(),
+            permission_key: "sample.events.handle".to_string(),
+            granted: true,
+        }
+    }
+
+    #[test]
+    fn validates_registered_assignment_change() {
+        let event = event();
+        assert!(event.validate().is_ok());
+        assert_eq!(
+            event.event_type(),
+            "rbac.artifact_role_permission.assignment_changed"
+        );
+        assert_eq!(event.schema_version(), 1);
+    }
+
+    #[test]
+    fn rejects_nil_identity_and_unbounded_permission_key() {
+        let RbacArtifactPermissionEvent::AssignmentChanged {
+            role_id,
+            installation_id,
+            permission_key,
+            granted,
+            ..
+        } = event();
+        assert!(
+            RbacArtifactPermissionEvent::AssignmentChanged {
+                operation_id: Uuid::nil(),
+                role_id,
+                installation_id,
+                permission_key,
+                granted,
+            }
+            .validate()
+            .is_err()
+        );
+
+        let RbacArtifactPermissionEvent::AssignmentChanged {
+            operation_id,
+            role_id,
+            installation_id,
+            granted,
+            ..
+        } = event();
+        assert!(
+            RbacArtifactPermissionEvent::AssignmentChanged {
+                operation_id,
+                role_id,
+                installation_id,
+                permission_key: "x".repeat(MAX_PERMISSION_KEY_LENGTH + 1),
+                granted,
+            }
+            .validate()
+            .is_err()
+        );
+    }
+}

--- a/crates/rustok-events/tests/rbac_artifact_permission_contracts.rs
+++ b/crates/rustok-events/tests/rbac_artifact_permission_contracts.rs
@@ -1,0 +1,71 @@
+use rustok_events::{
+    ContractEventEnvelope, ContractEventPayload, RBAC_ARTIFACT_PERMISSION_EVENT_SCHEMAS,
+    RbacArtifactPermissionEvent, ValidateEvent, event_schema,
+};
+use uuid::Uuid;
+
+fn event() -> RbacArtifactPermissionEvent {
+    RbacArtifactPermissionEvent::AssignmentChanged {
+        operation_id: Uuid::new_v4(),
+        role_id: Uuid::new_v4(),
+        installation_id: Uuid::new_v4(),
+        permission_key: "sample.events.handle".to_string(),
+        granted: true,
+    }
+}
+
+#[test]
+fn rbac_artifact_permission_family_has_one_registered_contract() {
+    assert_eq!(RBAC_ARTIFACT_PERMISSION_EVENT_SCHEMAS.len(), 1);
+    let schema = event_schema("rbac.artifact_role_permission.assignment_changed")
+        .expect("registered RBAC artifact permission schema");
+    assert_eq!(schema.version, 1);
+    assert_eq!(schema.fields.len(), 5);
+}
+
+#[test]
+fn rbac_artifact_permission_contract_is_typed_validated_and_enveloped() {
+    let tenant_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    let event = event();
+    event.validate().expect("valid event");
+
+    let envelope = ContractEventEnvelope::new(tenant_id, Some(actor_id), event.clone())
+        .expect("valid typed envelope");
+    assert_eq!(
+        envelope.event_type(),
+        "rbac.artifact_role_permission.assignment_changed"
+    );
+    assert_eq!(envelope.schema_version(), 1);
+    assert_eq!(envelope.tenant_id(), tenant_id);
+    assert_eq!(
+        envelope.payload().expect("registered payload"),
+        &ContractEventPayload::RbacArtifactPermission(event)
+    );
+}
+
+#[test]
+fn rbac_artifact_permission_contract_rejects_invalid_identity_and_key() {
+    assert!(
+        RbacArtifactPermissionEvent::AssignmentChanged {
+            operation_id: Uuid::nil(),
+            role_id: Uuid::new_v4(),
+            installation_id: Uuid::new_v4(),
+            permission_key: "sample.events.handle".to_string(),
+            granted: true,
+        }
+        .validate()
+        .is_err()
+    );
+    assert!(
+        RbacArtifactPermissionEvent::AssignmentChanged {
+            operation_id: Uuid::new_v4(),
+            role_id: Uuid::new_v4(),
+            installation_id: Uuid::new_v4(),
+            permission_key: " sample.events.handle".to_string(),
+            granted: true,
+        }
+        .validate()
+        .is_err()
+    );
+}

--- a/crates/rustok-rbac/rustok-module.toml
+++ b/crates/rustok-rbac/rustok-module.toml
@@ -8,6 +8,9 @@ trust_level = "core"
 ui_classification = "admin_only"
 recommended_admin_surfaces = ["leptos-admin"]
 
+[dependencies]
+outbox = { version_req = ">=0.1.0" }
+
 [crate]
 entry_type = "RbacModule"
 

--- a/crates/rustok-rbac/src/artifact_permission_assignment.rs
+++ b/crates/rustok-rbac/src/artifact_permission_assignment.rs
@@ -1,5 +1,9 @@
 //! RBAC-owned grants and checks for immutable artifact permission vocabulary.
 
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_events::RbacArtifactPermissionEvent;
 use sea_orm::{
     ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, Statement,
     TransactionTrait,
@@ -47,18 +51,44 @@ pub enum ArtifactPermissionAssignmentError {
     Database(String),
 }
 
+/// Host-neutral publisher used by the RBAC owner while its transaction is live.
+///
+/// Implementations must persist the typed event through the configured durable
+/// transport using the supplied owner transaction. Returning an error causes
+/// RBAC to roll back both the mutation and its idempotency receipt.
+#[async_trait]
+pub trait ArtifactPermissionEventPublisher: Send + Sync {
+    async fn publish_assignment_changed(
+        &self,
+        transaction: &DatabaseTransaction,
+        tenant_id: Uuid,
+        actor_id: Uuid,
+        event: RbacArtifactPermissionEvent,
+    ) -> Result<(), ArtifactPermissionAssignmentError>;
+}
+
 /// Durable RBAC owner service for explicit dynamic artifact permission grants.
 ///
 /// This service never writes the static `role_permissions` relation. Dynamic
 /// permissions remain bound to the admitted installation that declared them.
+/// The idempotency receipt, grant/revocation, and typed integration event are
+/// committed by one owner transaction. State no-ops commit their receipt but
+/// do not publish a false change event.
 #[derive(Clone)]
 pub struct RbacArtifactPermissionAssignmentService {
     db: DatabaseConnection,
+    event_publisher: Arc<dyn ArtifactPermissionEventPublisher>,
 }
 
 impl RbacArtifactPermissionAssignmentService {
-    pub fn new(db: DatabaseConnection) -> Self {
-        Self { db }
+    pub fn new(
+        db: DatabaseConnection,
+        event_publisher: Arc<dyn ArtifactPermissionEventPublisher>,
+    ) -> Self {
+        Self {
+            db,
+            event_publisher,
+        }
     }
 
     pub async fn assign(
@@ -73,30 +103,48 @@ impl RbacArtifactPermissionAssignmentService {
             return match_operation(existing, &command);
         }
 
-        let inserted_operation = insert_operation(&transaction, &command).await?;
-        if !inserted_operation {
-            let existing = find_operation(&transaction, &command)
-                .await?
-                .ok_or_else(|| {
-                    ArtifactPermissionAssignmentError::Database(
-                        "artifact permission operation disappeared after an idempotency conflict"
-                            .to_string(),
-                    )
-                })?;
-            return match_operation(existing, &command);
-        }
+        let operation_id = match insert_operation(&transaction, &command).await? {
+            Some(operation_id) => operation_id,
+            None => {
+                let existing = find_operation(&transaction, &command)
+                    .await?
+                    .ok_or_else(|| {
+                        ArtifactPermissionAssignmentError::Database(
+                            "artifact permission operation disappeared after an idempotency conflict"
+                                .to_string(),
+                        )
+                    })?;
+                return match_operation(existing, &command);
+            }
+        };
 
         if !role_exists(&transaction, &command).await? {
+            transaction.rollback().await.map_err(database_error)?;
             return Err(ArtifactPermissionAssignmentError::RoleNotFound);
         }
         if !permission_is_registered(&transaction, &command).await? {
+            transaction.rollback().await.map_err(database_error)?;
             return Err(ArtifactPermissionAssignmentError::PermissionNotRegistered);
         }
 
-        if command.granted {
-            grant_permission(&transaction, &command).await?;
+        let changed = if command.granted {
+            grant_permission(&transaction, &command).await?
         } else {
-            revoke_permission(&transaction, &command).await?;
+            revoke_permission(&transaction, &command).await?
+        };
+        if changed
+            && let Err(error) = self
+                .event_publisher
+                .publish_assignment_changed(
+                    &transaction,
+                    command.tenant_id,
+                    command.actor_id,
+                    assignment_event(operation_id, &command),
+                )
+                .await
+        {
+            transaction.rollback().await.map_err(database_error)?;
+            return Err(error);
         }
         transaction.commit().await.map_err(database_error)?;
 
@@ -259,8 +307,9 @@ fn match_operation(
 async fn insert_operation(
     transaction: &DatabaseTransaction,
     command: &ArtifactRolePermissionAssignmentCommand,
-) -> Result<bool, ArtifactPermissionAssignmentError> {
+) -> Result<Option<Uuid>, ArtifactPermissionAssignmentError> {
     let backend = transaction.get_database_backend();
+    let operation_id = rustok_core::generate_id();
     let sql = placeholders(
         backend,
         "INSERT INTO rbac_artifact_role_permission_operations (id, tenant_id, idempotency_key, role_id, installation_id, permission_key, actor_id, granted) VALUES ({id}, {tenant_id}, {idempotency_key}, {role_id}, {installation_id}, {permission_key}, {actor_id}, {granted}) ON CONFLICT (tenant_id, idempotency_key) DO NOTHING",
@@ -270,7 +319,7 @@ async fn insert_operation(
             backend,
             sql,
             vec![
-                rustok_core::generate_id().into(),
+                operation_id.into(),
                 command.tenant_id.into(),
                 command.idempotency_key.clone().into(),
                 command.role_id.into(),
@@ -282,7 +331,7 @@ async fn insert_operation(
         ))
         .await
         .map_err(database_error)?;
-    Ok(result.rows_affected() == 1)
+    Ok((result.rows_affected() == 1).then_some(operation_id))
 }
 
 async fn role_exists(
@@ -333,13 +382,13 @@ async fn permission_is_registered(
 async fn grant_permission(
     transaction: &DatabaseTransaction,
     command: &ArtifactRolePermissionAssignmentCommand,
-) -> Result<(), ArtifactPermissionAssignmentError> {
+) -> Result<bool, ArtifactPermissionAssignmentError> {
     let backend = transaction.get_database_backend();
     let sql = placeholders(
         backend,
         "INSERT INTO rbac_artifact_role_permissions (id, tenant_id, role_id, installation_id, permission_key, granted_by_actor_id) VALUES ({id}, {tenant_id}, {role_id}, {installation_id}, {permission_key}, {actor_id}) ON CONFLICT (tenant_id, role_id, installation_id, permission_key) DO NOTHING",
     );
-    transaction
+    let result = transaction
         .execute(Statement::from_sql_and_values(
             backend,
             sql,
@@ -354,19 +403,19 @@ async fn grant_permission(
         ))
         .await
         .map_err(database_error)?;
-    Ok(())
+    Ok(result.rows_affected() == 1)
 }
 
 async fn revoke_permission(
     transaction: &DatabaseTransaction,
     command: &ArtifactRolePermissionAssignmentCommand,
-) -> Result<(), ArtifactPermissionAssignmentError> {
+) -> Result<bool, ArtifactPermissionAssignmentError> {
     let backend = transaction.get_database_backend();
     let sql = placeholders(
         backend,
         "DELETE FROM rbac_artifact_role_permissions WHERE tenant_id = {tenant_id} AND role_id = {role_id} AND installation_id = {installation_id} AND permission_key = {permission_key}",
     );
-    transaction
+    let result = transaction
         .execute(Statement::from_sql_and_values(
             backend,
             sql,
@@ -379,7 +428,20 @@ async fn revoke_permission(
         ))
         .await
         .map_err(database_error)?;
-    Ok(())
+    Ok(result.rows_affected() == 1)
+}
+
+fn assignment_event(
+    operation_id: Uuid,
+    command: &ArtifactRolePermissionAssignmentCommand,
+) -> RbacArtifactPermissionEvent {
+    RbacArtifactPermissionEvent::AssignmentChanged {
+        operation_id,
+        role_id: command.role_id,
+        installation_id: command.installation_id,
+        permission_key: command.permission_key.clone(),
+        granted: command.granted,
+    }
 }
 
 fn placeholders(backend: DbBackend, template: &str) -> String {
@@ -416,9 +478,8 @@ fn database_error(error: impl std::fmt::Display) -> ArtifactPermissionAssignment
 mod tests {
     use super::*;
 
-    #[test]
-    fn assignment_validation_rejects_empty_or_control_text_tokens() {
-        let mut command = ArtifactRolePermissionAssignmentCommand {
+    fn command() -> ArtifactRolePermissionAssignmentCommand {
+        ArtifactRolePermissionAssignmentCommand {
             tenant_id: Uuid::new_v4(),
             role_id: Uuid::new_v4(),
             installation_id: Uuid::new_v4(),
@@ -426,7 +487,12 @@ mod tests {
             actor_id: Uuid::new_v4(),
             granted: true,
             idempotency_key: "grant-1".to_string(),
-        };
+        }
+    }
+
+    #[test]
+    fn assignment_validation_rejects_empty_or_control_text_tokens() {
+        let mut command = command();
         command.permission_key = " sample.events.handle".to_string();
         assert!(matches!(
             validate_command(&command),
@@ -445,15 +511,7 @@ mod tests {
 
     #[test]
     fn exact_operation_retry_is_not_applied_twice() {
-        let command = ArtifactRolePermissionAssignmentCommand {
-            tenant_id: Uuid::new_v4(),
-            role_id: Uuid::new_v4(),
-            installation_id: Uuid::new_v4(),
-            permission_key: "sample.events.handle".to_string(),
-            actor_id: Uuid::new_v4(),
-            granted: true,
-            idempotency_key: "grant-1".to_string(),
-        };
+        let command = command();
         let result = match_operation(
             StoredOperation {
                 role_id: command.role_id,
@@ -466,5 +524,21 @@ mod tests {
         )
         .expect("exact retry");
         assert!(!result.applied);
+    }
+
+    #[test]
+    fn assignment_event_retains_operation_and_scope() {
+        let command = command();
+        let operation_id = Uuid::new_v4();
+        assert_eq!(
+            assignment_event(operation_id, &command),
+            RbacArtifactPermissionEvent::AssignmentChanged {
+                operation_id,
+                role_id: command.role_id,
+                installation_id: command.installation_id,
+                permission_key: command.permission_key,
+                granted: command.granted,
+            }
+        );
     }
 }

--- a/crates/rustok-rbac/src/lib.rs
+++ b/crates/rustok-rbac/src/lib.rs
@@ -19,9 +19,9 @@ mod repair;
 pub mod services;
 
 pub use artifact_permission_assignment::{
-    ArtifactPermissionAssignmentError, ArtifactRolePermissionAssignmentCommand,
-    ArtifactRolePermissionAssignmentResult, RbacArtifactPermissionAssignmentService,
-    SeaOrmArtifactPermissionAuthorizer,
+    ArtifactPermissionAssignmentError, ArtifactPermissionEventPublisher,
+    ArtifactRolePermissionAssignmentCommand, ArtifactRolePermissionAssignmentResult,
+    RbacArtifactPermissionAssignmentService, SeaOrmArtifactPermissionAuthorizer,
 };
 pub use artifact_permission_catalog::RbacArtifactPermissionCatalog;
 pub use bootstrap::{RbacRoleAssignmentDbWriter, RbacRoleAssignmentError};
@@ -142,6 +142,10 @@ impl RusToKModule for RbacModule {
 
     fn version(&self) -> &'static str {
         env!("CARGO_PKG_VERSION")
+    }
+
+    fn dependencies(&self) -> &[&'static str] {
+        &["outbox"]
     }
 
     fn kind(&self) -> ModuleKind {

--- a/crates/rustok-rbac/tests/artifact_permission_outbox_sqlite.rs
+++ b/crates/rustok-rbac/tests/artifact_permission_outbox_sqlite.rs
@@ -1,0 +1,273 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_events::RbacArtifactPermissionEvent;
+use rustok_rbac::{
+    ArtifactPermissionAssignmentError, ArtifactPermissionEventPublisher,
+    ArtifactRolePermissionAssignmentCommand, RbacArtifactPermissionAssignmentService,
+};
+use sea_orm::{
+    ConnectionTrait, Database, DatabaseConnection, DatabaseTransaction, Statement,
+};
+use uuid::Uuid;
+
+#[derive(Clone)]
+struct SqliteArtifactPermissionEventPublisher {
+    fail: bool,
+}
+
+#[async_trait]
+impl ArtifactPermissionEventPublisher for SqliteArtifactPermissionEventPublisher {
+    async fn publish_assignment_changed(
+        &self,
+        transaction: &DatabaseTransaction,
+        tenant_id: Uuid,
+        actor_id: Uuid,
+        event: RbacArtifactPermissionEvent,
+    ) -> Result<(), ArtifactPermissionAssignmentError> {
+        if self.fail {
+            return Err(ArtifactPermissionAssignmentError::Database(
+                "test publisher rejected the event".to_string(),
+            ));
+        }
+
+        let event_type = event.event_type();
+        let schema_version = event.schema_version();
+        let RbacArtifactPermissionEvent::AssignmentChanged {
+            operation_id,
+            role_id,
+            installation_id,
+            permission_key,
+            granted,
+        } = event;
+        transaction
+            .execute(Statement::from_sql_and_values(
+                transaction.get_database_backend(),
+                "INSERT INTO rbac_artifact_permission_events (operation_id, tenant_id, actor_id, role_id, installation_id, permission_key, granted, event_type, schema_version) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                vec![
+                    operation_id.into(),
+                    tenant_id.into(),
+                    actor_id.into(),
+                    role_id.into(),
+                    installation_id.into(),
+                    permission_key.into(),
+                    granted.into(),
+                    event_type.into(),
+                    i32::from(schema_version).into(),
+                ],
+            ))
+            .await
+            .map_err(|error| ArtifactPermissionAssignmentError::Database(error.to_string()))?;
+        Ok(())
+    }
+}
+
+async fn setup_database() -> DatabaseConnection {
+    let db = Database::connect("sqlite::memory:")
+        .await
+        .expect("connect sqlite");
+    for statement in [
+        "CREATE TABLE roles (id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL)",
+        "CREATE TABLE rbac_artifact_permission_catalog (id TEXT PRIMARY KEY, scope_key TEXT NOT NULL, installation_id TEXT NOT NULL, module_slug TEXT NOT NULL, release_digest TEXT NOT NULL, permission_key TEXT NOT NULL, locale TEXT NOT NULL, label TEXT NOT NULL, description TEXT NOT NULL, registered_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, UNIQUE (scope_key, installation_id, permission_key, locale))",
+        "CREATE TABLE rbac_artifact_role_permissions (id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, role_id TEXT NOT NULL, installation_id TEXT NOT NULL, permission_key TEXT NOT NULL, granted_by_actor_id TEXT NOT NULL, granted_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, UNIQUE (tenant_id, role_id, installation_id, permission_key))",
+        "CREATE TABLE rbac_artifact_role_permission_operations (id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, idempotency_key TEXT NOT NULL, role_id TEXT NOT NULL, installation_id TEXT NOT NULL, permission_key TEXT NOT NULL, actor_id TEXT NOT NULL, granted BOOLEAN NOT NULL, applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, UNIQUE (tenant_id, idempotency_key))",
+        "CREATE TABLE rbac_artifact_permission_events (operation_id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, actor_id TEXT NOT NULL, role_id TEXT NOT NULL, installation_id TEXT NOT NULL, permission_key TEXT NOT NULL, granted BOOLEAN NOT NULL, event_type TEXT NOT NULL, schema_version INTEGER NOT NULL)",
+    ] {
+        db.execute_unprepared(statement)
+            .await
+            .expect("create RBAC fixture table");
+    }
+    db
+}
+
+async fn insert_scope(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    role_id: Uuid,
+    installation_id: Uuid,
+    permission_key: &str,
+) {
+    db.execute(Statement::from_sql_and_values(
+        db.get_database_backend(),
+        "INSERT INTO roles (id, tenant_id) VALUES (?1, ?2)",
+        vec![role_id.into(), tenant_id.into()],
+    ))
+    .await
+    .expect("insert role");
+    db.execute(Statement::from_sql_and_values(
+        db.get_database_backend(),
+        "INSERT INTO rbac_artifact_permission_catalog (id, scope_key, installation_id, module_slug, release_digest, permission_key, locale, label, description) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        vec![
+            Uuid::new_v4().into(),
+            format!("tenant:{tenant_id}").into(),
+            installation_id.into(),
+            "sample".into(),
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+            permission_key.into(),
+            "en".into(),
+            "Handle events".into(),
+            "Allows the role to handle sample events".into(),
+        ],
+    ))
+    .await
+    .expect("insert artifact permission catalog row");
+}
+
+fn command(
+    tenant_id: Uuid,
+    role_id: Uuid,
+    installation_id: Uuid,
+    actor_id: Uuid,
+    permission_key: &str,
+    granted: bool,
+    idempotency_key: &str,
+) -> ArtifactRolePermissionAssignmentCommand {
+    ArtifactRolePermissionAssignmentCommand {
+        tenant_id,
+        role_id,
+        installation_id,
+        permission_key: permission_key.to_string(),
+        actor_id,
+        granted,
+        idempotency_key: idempotency_key.to_string(),
+    }
+}
+
+async fn table_count(db: &DatabaseConnection, table: &str) -> i64 {
+    db.query_one(Statement::from_string(
+        db.get_database_backend(),
+        format!("SELECT COUNT(*) AS count FROM {table}"),
+    ))
+    .await
+    .expect("count table")
+    .expect("count row")
+    .try_get("", "count")
+    .expect("decode count")
+}
+
+async fn event_grants(db: &DatabaseConnection) -> Vec<bool> {
+    db.query_all(Statement::from_string(
+        db.get_database_backend(),
+        "SELECT granted FROM rbac_artifact_permission_events ORDER BY rowid".to_string(),
+    ))
+    .await
+    .expect("load published events")
+    .into_iter()
+    .map(|row| row.try_get("", "granted").expect("decode granted"))
+    .collect()
+}
+
+#[tokio::test]
+async fn only_state_changes_publish_artifact_permission_events() {
+    let db = setup_database().await;
+    let tenant_id = Uuid::new_v4();
+    let role_id = Uuid::new_v4();
+    let installation_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    let permission_key = "sample.events.handle";
+    insert_scope(&db, tenant_id, role_id, installation_id, permission_key).await;
+
+    let service = RbacArtifactPermissionAssignmentService::new(
+        db.clone(),
+        Arc::new(SqliteArtifactPermissionEventPublisher { fail: false }),
+    );
+    let grant = command(
+        tenant_id,
+        role_id,
+        installation_id,
+        actor_id,
+        permission_key,
+        true,
+        "grant-1",
+    );
+
+    assert!(service.assign(grant.clone()).await.expect("grant").applied);
+    assert!(!service.assign(grant).await.expect("exact retry").applied);
+    assert!(
+        service
+            .assign(command(
+                tenant_id,
+                role_id,
+                installation_id,
+                actor_id,
+                permission_key,
+                true,
+                "grant-confirmation",
+            ))
+            .await
+            .expect("grant state confirmation")
+            .applied
+    );
+    assert_eq!(event_grants(&db).await, vec![true]);
+
+    assert!(
+        service
+            .assign(command(
+                tenant_id,
+                role_id,
+                installation_id,
+                actor_id,
+                permission_key,
+                false,
+                "revoke-1",
+            ))
+            .await
+            .expect("revoke")
+            .applied
+    );
+    assert!(
+        service
+            .assign(command(
+                tenant_id,
+                role_id,
+                installation_id,
+                actor_id,
+                permission_key,
+                false,
+                "revoke-confirmation",
+            ))
+            .await
+            .expect("revoke state confirmation")
+            .applied
+    );
+    assert_eq!(event_grants(&db).await, vec![true, false]);
+}
+
+#[tokio::test]
+async fn publication_failure_rolls_back_grant_and_idempotency_receipt() {
+    let db = setup_database().await;
+    let tenant_id = Uuid::new_v4();
+    let role_id = Uuid::new_v4();
+    let installation_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    let permission_key = "sample.events.handle";
+    insert_scope(&db, tenant_id, role_id, installation_id, permission_key).await;
+
+    let service = RbacArtifactPermissionAssignmentService::new(
+        db.clone(),
+        Arc::new(SqliteArtifactPermissionEventPublisher { fail: true }),
+    );
+    let error = service
+        .assign(command(
+            tenant_id,
+            role_id,
+            installation_id,
+            actor_id,
+            permission_key,
+            true,
+            "grant-without-publication",
+        ))
+        .await
+        .expect_err("publisher failure must fail closed");
+
+    assert!(matches!(
+        error,
+        ArtifactPermissionAssignmentError::Database(_)
+    ));
+    assert_eq!(table_count(&db, "rbac_artifact_role_permissions").await, 0);
+    assert_eq!(
+        table_count(&db, "rbac_artifact_role_permission_operations").await,
+        0
+    );
+    assert_eq!(table_count(&db, "rbac_artifact_permission_events").await, 0);
+}

--- a/modules.toml
+++ b/modules.toml
@@ -42,7 +42,7 @@ search = { crate = "rustok-search", source = "path", path = "crates/rustok-searc
 outbox = { crate = "rustok-outbox", source = "path", path = "crates/rustok-outbox", required = true }
 events = { crate = "rustok-events-module", source = "path", path = "crates/rustok-events-module", required = true, depends_on = ["outbox"] }
 tenant = { crate = "rustok-tenant", source = "path", path = "crates/rustok-tenant", required = true }
-rbac = { crate = "rustok-rbac", source = "path", path = "crates/rustok-rbac", required = true }
+rbac = { crate = "rustok-rbac", source = "path", path = "crates/rustok-rbac", required = true, depends_on = ["outbox"] }
 
 # Domain modules (optional)
 content = { crate = "rustok-content", source = "path", path = "crates/rustok-content" }

--- a/modules.toml.example
+++ b/modules.toml.example
@@ -36,7 +36,7 @@ search = { crate = "rustok-search", source = "path", path = "crates/rustok-searc
 outbox = { crate = "rustok-outbox", source = "path", path = "crates/rustok-outbox", required = true }
 events = { crate = "rustok-events-module", source = "path", path = "crates/rustok-events-module", required = true, depends_on = ["outbox"] }
 tenant = { crate = "rustok-tenant", source = "path", path = "crates/rustok-tenant", required = true }
-rbac = { crate = "rustok-rbac", source = "path", path = "crates/rustok-rbac", required = true }
+rbac = { crate = "rustok-rbac", source = "path", path = "crates/rustok-rbac", required = true, depends_on = ["outbox"] }
 
 # Domain modules (optional)
 content = { crate = "rustok-content", source = "path", path = "crates/rustok-content" }

--- a/scripts/verify/verify-rbac-artifact-permission-outbox.mjs
+++ b/scripts/verify/verify-rbac-artifact-permission-outbox.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+// RBAC artifact permission owner-event and transactional-outbox guardrails.
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  if (!existsSync(absolutePath)) {
+    failures.push(`${relativePath}: expected file`);
+    return "";
+  }
+  return readFileSync(absolutePath, "utf8");
+}
+
+function requireMarker(text, marker, description) {
+  const found = typeof marker === "string" ? text.includes(marker) : marker.test(text);
+  if (!found) failures.push(description);
+}
+
+function forbidMarker(text, marker, description) {
+  const found = typeof marker === "string" ? text.includes(marker) : marker.test(text);
+  if (found) failures.push(description);
+}
+
+const paths = {
+  modules: "modules.toml",
+  modulesExample: "modules.toml.example",
+  moduleManifest: "crates/rustok-rbac/rustok-module.toml",
+  cargo: "crates/rustok-rbac/Cargo.toml",
+  event: "crates/rustok-events/src/rbac_artifact_permission.rs",
+  eventLib: "crates/rustok-events/src/lib.rs",
+  contract: "crates/rustok-events/src/contract.rs",
+  rbacLib: "crates/rustok-rbac/src/lib.rs",
+  owner: "crates/rustok-rbac/src/artifact_permission_assignment.rs",
+  host: "apps/server/src/controllers/artifact_permissions.rs",
+  integrationTest: "crates/rustok-rbac/tests/artifact_permission_outbox_sqlite.rs",
+};
+
+const content = Object.fromEntries(
+  Object.entries(paths).map(([name, relativePath]) => [name, read(relativePath)]),
+);
+
+const manifestMarker =
+  'rbac = { crate = "rustok-rbac", source = "path", path = "crates/rustok-rbac", required = true, depends_on = ["outbox"] }';
+requireMarker(
+  content.modules,
+  manifestMarker,
+  `${paths.modules}: RBAC Core module must declare Outbox dependency`,
+);
+requireMarker(
+  content.modulesExample,
+  manifestMarker,
+  `${paths.modulesExample}: example topology must mirror the RBAC Outbox dependency`,
+);
+requireMarker(
+  content.moduleManifest,
+  'outbox = { version_req = ">=0.1.0" }',
+  `${paths.moduleManifest}: Outbox module dependency missing`,
+);
+forbidMarker(
+  content.cargo,
+  "rustok-outbox.workspace = true",
+  `${paths.cargo}: RBAC owner must depend on its publisher port, not the concrete Outbox crate`,
+);
+
+for (const marker of [
+  "pub enum RbacArtifactPermissionEvent",
+  "AssignmentChanged",
+  'event_type: "rbac.artifact_role_permission.assignment_changed"',
+  "impl sealed::Sealed for RbacArtifactPermissionEvent",
+  "impl EventContract for RbacArtifactPermissionEvent",
+  "impl ValidateEvent for RbacArtifactPermissionEvent",
+  'validate_not_nil_uuid("operation_id", operation_id)',
+  "validate_max_length(",
+]) {
+  requireMarker(content.event, marker, `${paths.event}: event contract missing ${marker}`);
+}
+for (const marker of [
+  "mod rbac_artifact_permission;",
+  "RBAC_ARTIFACT_PERMISSION_EVENT_SCHEMAS",
+  "rbac_artifact_permission_event_schema",
+  ".chain(RBAC_ARTIFACT_PERMISSION_EVENT_SCHEMAS.iter())",
+]) {
+  requireMarker(content.eventLib, marker, `${paths.eventLib}: registry missing ${marker}`);
+}
+for (const marker of [
+  "RbacArtifactPermission(RbacArtifactPermissionEvent)",
+  "Self::RbacArtifactPermission(event) => event.event_type()",
+  "Self::RbacArtifactPermission(event) => event.schema_version()",
+  "Self::RbacArtifactPermission(event) => event.validate()",
+]) {
+  requireMarker(content.contract, marker, `${paths.contract}: sealed payload missing ${marker}`);
+}
+for (const marker of [
+  "ArtifactPermissionEventPublisher",
+  "fn dependencies(&self) -> &[&'static str]",
+  '&["outbox"]',
+]) {
+  requireMarker(content.rbacLib, marker, `${paths.rbacLib}: runtime contract missing ${marker}`);
+}
+
+for (const marker of [
+  "pub trait ArtifactPermissionEventPublisher",
+  "transaction: &DatabaseTransaction",
+  "event_publisher: Arc<dyn ArtifactPermissionEventPublisher>",
+  "let operation_id = match insert_operation",
+  "let changed = if command.granted",
+  "if changed",
+  ".publish_assignment_changed(",
+  "assignment_event(operation_id, &command)",
+  "transaction.rollback().await.map_err(database_error)?",
+  "transaction.commit().await.map_err(database_error)?",
+  "then_some(operation_id)",
+  "Ok(result.rows_affected() == 1)",
+]) {
+  requireMarker(content.owner, marker, `${paths.owner}: transactional owner path missing ${marker}`);
+}
+forbidMarker(
+  content.owner,
+  "rustok_outbox",
+  `${paths.owner}: owner must not import concrete Outbox types`,
+);
+const changedIndex = content.owner.indexOf("if changed");
+const publishIndex = content.owner.indexOf(".publish_assignment_changed(", changedIndex);
+const rollbackIndex = content.owner.indexOf(
+  "transaction.rollback().await.map_err(database_error)?",
+  publishIndex,
+);
+const commitIndex = content.owner.indexOf(
+  "transaction.commit().await.map_err(database_error)?",
+  publishIndex,
+);
+if (
+  !(
+    changedIndex >= 0 &&
+    publishIndex > changedIndex &&
+    rollbackIndex > publishIndex &&
+    commitIndex > rollbackIndex
+  )
+) {
+  failures.push(
+    `${paths.owner}: expected state change -> publisher port -> failure rollback -> commit order`,
+  );
+}
+const existingIndex = content.owner.indexOf("if let Some(existing) = find_operation");
+if (!(existingIndex >= 0 && existingIndex < publishIndex)) {
+  failures.push(`${paths.owner}: exact retry lookup must precede event publication`);
+}
+
+for (const marker of [
+  "TransactionalOutboxArtifactPermissionEventPublisher",
+  "impl ArtifactPermissionEventPublisher",
+  ".publish_contract_in_tx(",
+  "transactional_event_bus_from_context",
+  "Arc::new(TransactionalOutboxArtifactPermissionEventPublisher::new(",
+  "RbacArtifactPermissionAssignmentService::new(ctx.db_clone(), event_publisher)",
+  "transactional_outbox_adapter_writes_typed_event",
+  '"rbac.artifact_role_permission.assignment_changed"',
+]) {
+  requireMarker(content.host, marker, `${paths.host}: host Outbox adapter missing ${marker}`);
+}
+
+for (const marker of [
+  "impl ArtifactPermissionEventPublisher for SqliteArtifactPermissionEventPublisher",
+  "only_state_changes_publish_artifact_permission_events",
+  "assert_eq!(event_grants(&db).await, vec![true])",
+  "assert_eq!(event_grants(&db).await, vec![true, false])",
+  "publication_failure_rolls_back_grant_and_idempotency_receipt",
+  "publisher failure must fail closed",
+  'table_count(&db, "rbac_artifact_role_permissions")',
+  'table_count(&db, "rbac_artifact_role_permission_operations")',
+  'table_count(&db, "rbac_artifact_permission_events")',
+]) {
+  requireMarker(
+    content.integrationTest,
+    marker,
+    `${paths.integrationTest}: executable owner regression missing ${marker}`,
+  );
+}
+forbidMarker(
+  content.integrationTest,
+  "rustok_outbox",
+  `${paths.integrationTest}: owner regression must remain transport-neutral`,
+);
+
+if (failures.length > 0) {
+  console.error("RBAC artifact permission outbox verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("RBAC artifact permission outbox verification passed");


### PR DESCRIPTION
## Summary

- close the RBAC artifact role-permission integration-event gap (`P1`);
- add sealed typed event `rbac.artifact_role_permission.assignment_changed`;
- let RBAC own the command, live database transaction, state-change decision, and publication timing through the host-neutral `ArtifactPermissionEventPublisher` port;
- adapt that port in `apps/server` to the canonical `TransactionalEventBus::publish_contract_in_tx` / `sys_events` path;
- preserve exact retry semantics: an idempotent replay returns `applied=false` and emits no duplicate event;
- preserve state semantics: a new idempotency key that only confirms an existing grant or absent revoke commits its receipt but emits no false change event;
- roll back mutation and idempotency receipt when required publication fails;
- bind tenant and actor to typed envelope metadata and keep only bounded operation, role, installation, permission, and grant state in the payload;
- declare the runtime RBAC -> Outbox dependency consistently in `modules.toml`, `rustok-module.toml`, `RbacModule::dependencies()`, and the example topology without coupling `rustok-rbac` to the concrete Outbox crate;
- add sealed-contract tests, a transport-neutral SQLite owner transaction proof, a server canonical-Outbox adapter test, and a fail-closed source verifier.

## P1 root cause

The durable artifact role-permission mutation committed its idempotency receipt and grant or revocation, but no production publisher emitted an observable owner event through the canonical transactional outbox.

Downstream authorization caches, audit consumers, or module integrations could therefore miss a committed permission-state change.

## Transaction order

1. validate the owner command;
2. begin the RBAC owner transaction;
3. resolve or reserve the tenant-scoped idempotency operation;
4. validate the tenant role and admitted artifact permission;
5. apply or confirm grant/revocation state;
6. when `rows_affected == 1`, invoke the publisher port with the same live transaction;
7. the server adapter writes the sealed contract envelope to `sys_events` through `publish_contract_in_tx`;
8. roll back explicitly on publication failure, otherwise commit once.

Exact retries return before mutation. State confirmations commit their receipt without publishing a false change event.

## Fresh-main reconstruction

The previous clean branch was based on `main@0eb3b47eef939b93ebbe753a0be1ea8eeff6dcc2`. The 37 intervening commits did not change any of this PR's twelve paths.

All twelve final blobs were preserved exactly and rebuilt as one clean commit on current `main@2ac132f401f5f10243a508f882569495a79e243c`.

Current head: `0bb5a4f53fdd53a560e7b00af16f321b7facff72`.

The branch is one commit ahead and zero behind `main`, with 972 additions and 52 deletions across twelve files.

## Compatibility and ownership

- no direct `rustok-rbac` -> `rustok-outbox` crate dependency;
- no compatibility wrapper or parallel legacy publication path;
- no migration or table-shape change;
- no workflow change;
- existing REST authorization and direct-session control-plane admission remain unchanged;
- #2799 separately removes the resolver mutation bypass and shares only `crates/rustok-rbac/src/lib.rs`; whichever PR lands second requires a routine additive rebase preserving both exports.

## Draft and validation status

This PR is intentionally **draft**. Source and architecture review are present, but the new event contract digest has not been generated and exact-head execution evidence is absent.

The digest must be generated by the repository-owned command rather than guessed:

```bash
cargo run -p rustok-events --example event_contract_digests -- --write
```

Required exact-head gates include:

```bash
cargo fmt --all -- --check
cargo check -p rustok-events --all-targets
cargo check -p rustok-rbac --all-features
cargo check -p rustok-server --lib
cargo test -p rustok-events --test rbac_artifact_permission_contracts
cargo test -p rustok-rbac --test artifact_permission_outbox_sqlite
cargo test -p rustok-server --lib artifact_permission
node scripts/verify/verify-rbac-artifact-permission-outbox.mjs
cargo xtask module validate rbac
cargo xtask module test rbac
```

No local checkout is available in the current execution environment and `github.com` DNS resolution fails, so these commands were not run. This is an environment limitation, not product pass evidence or a product defect.

Known issue #2740 may independently stop Rust-host before the server build because the PostgreSQL service fixture lacks the expected `rustok_browser` role.

## Cycle status

`cycle-001 / core/rbac` remains `in_progress`. This PR fixes one P1 transactional event/outbox gap but does not complete RBAC verification: digest generation, exact-head checks, PostgreSQL concurrency, multi-replica invalidation recovery, explicit actor-kind work, and live FFA/FBA evidence remain open.