### PR TITLE
test(forum): host poison publish ambiguity proof

### DIFF
--- a/apps/server/tests/forum_versioned_invalidation_poison_ambiguity_iggy.rs
+++ b/apps/server/tests/forum_versioned_invalidation_poison_ambiguity_iggy.rs
@@ -1,0 +1,701 @@
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::io::{Error as IoError, ErrorKind};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use chrono::Utc;
+use rustok_iggy::{
+    ConsumedContractDecodeFailure, ContractDecodeFailureKind, ExternalConfig, IggyConfig,
+    IggyMode, IggyTransport, PersistentContractConsumerGroup, PersistentContractDelivery,
+    SerializationFormat, TopologyConfig,
+};
+use rustok_iggy_connector::migrations::{
+    ConsumerPoisonIdentity, ConsumerPoisonPublishClaim, ConsumerPoisonReceipt,
+    ConsumerPoisonReceiptError, ConsumerPoisonReceiptState, ConsumerPoisonReceiptStore,
+};
+use rustok_iggy_connector::{
+    ConnectorConfig, ConsumerCursor, ExternalConnector, IggyConnector, PublishRequest,
+    SubscriberMessage,
+};
+use rustok_search::{FORUM_SEARCH_CONTRACT_CONSUMER_GROUP, FORUM_SEARCH_CONTRACT_TOPIC};
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection};
+use sea_orm_migration::SchemaManager;
+use serde::Serialize;
+use serde_json::{Value as JsonValue, json};
+use tokio::time::timeout;
+use uuid::Uuid;
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+const DATABASE_ENV: &str = "RUSTOK_SEARCH_TEST_DATABASE_URL";
+const DEDUP_ENABLED_ADDRESS_ENV: &str =
+    "RUSTOK_FORUM_SEARCH_POISON_DEDUP_ENABLED_IGGY_ADDRESS";
+const DEDUP_DISABLED_ADDRESS_ENV: &str =
+    "RUSTOK_FORUM_SEARCH_POISON_DEDUP_DISABLED_IGGY_ADDRESS";
+const USERNAME_ENV: &str = "RUSTOK_IGGY_EXTERNAL_TEST_USERNAME";
+const PASSWORD_ENV: &str = "RUSTOK_IGGY_EXTERNAL_TEST_PASSWORD";
+const RECEIVE_TIMEOUT: Duration = Duration::from_secs(20);
+const NO_ADDITIONAL_DLQ_TIMEOUT: Duration = Duration::from_millis(750);
+const PUBLISH_LEASE: Duration = Duration::from_secs(1);
+const LEASE_RECLAIM_WAIT: Duration = Duration::from_millis(1_500);
+const EVIDENCE_CONTRACT: &str =
+    "forum_search_versioned_invalidation_poison_ambiguity_evidence_v1";
+const EVIDENCE_PATH: &str =
+    "target/forum-search-versioned-invalidation-poison-ambiguity-evidence.json";
+
+struct EvidenceRuntime {
+    control: DatabaseConnection,
+    db: DatabaseConnection,
+    schema_name: String,
+    config: IggyConfig,
+    fixture: ExternalConnector,
+}
+
+impl EvidenceRuntime {
+    async fn setup(database_url: &str, config: IggyConfig, scope: &str) -> TestResult<Self> {
+        let control = connect(database_url).await?;
+        let schema_name = format!(
+            "rustok_forum_poison_ambiguity_{}_{}",
+            sanitize_identifier(scope),
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let db = connect(database_url).await?;
+        set_search_path(&db, &schema_name).await?;
+        let migration_result = async {
+            let manager = SchemaManager::new(&db);
+            for migration in rustok_iggy_connector::migrations::migrations() {
+                migration.up(&manager).await?;
+            }
+            Ok::<(), sea_orm::DbErr>(())
+        }
+        .await;
+        if let Err(error) = migration_result {
+            let _ = control
+                .execute_unprepared(&format!(r#"DROP SCHEMA IF EXISTS "{schema_name}" CASCADE"#))
+                .await;
+            return Err(error.into());
+        }
+
+        let fixture = ExternalConnector::new();
+        if let Err(error) = fixture.connect(&ConnectorConfig::from(&config)).await {
+            let _ = control
+                .execute_unprepared(&format!(r#"DROP SCHEMA IF EXISTS "{schema_name}" CASCADE"#))
+                .await;
+            return Err(error.into());
+        }
+
+        Ok(Self {
+            control,
+            db,
+            schema_name,
+            config,
+            fixture,
+        })
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.fixture.shutdown().await?;
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ScenarioEvidence {
+    id: String,
+    result: &'static str,
+    facts: JsonValue,
+}
+
+#[derive(Debug, Serialize)]
+struct EvidenceArtifact {
+    contract: &'static str,
+    task: &'static str,
+    source_commit: String,
+    generated_at: String,
+    database_backend: &'static str,
+    broker_backend: &'static str,
+    delivery_profile: &'static str,
+    consumer_group: &'static str,
+    topic: &'static str,
+    scenario_results: Vec<ScenarioEvidence>,
+}
+
+#[tokio::test]
+async fn raw_poison_publish_mark_ambiguity_obeys_configured_dedup_modes() -> TestResult<()> {
+    ensure_distinct_mode_addresses()?;
+    let Some(database_url) = postgres_database_url() else {
+        eprintln!(
+            "{DATABASE_ENV} or PostgreSQL DATABASE_URL is not set; skipping Forum Search poison ambiguity proof"
+        );
+        return Ok(());
+    };
+    let Some(dedup_enabled) = external_iggy_config(DEDUP_ENABLED_ADDRESS_ENV, "dedup-enabled")?
+    else {
+        eprintln!("{DEDUP_ENABLED_ADDRESS_ENV} is not set; skipping poison ambiguity proof");
+        return Ok(());
+    };
+    let Some(dedup_disabled) =
+        external_iggy_config(DEDUP_DISABLED_ADDRESS_ENV, "dedup-disabled")?
+    else {
+        eprintln!("{DEDUP_DISABLED_ADDRESS_ENV} is not set; skipping poison ambiguity proof");
+        return Ok(());
+    };
+
+    let enabled = exercise_mode(&database_url, dedup_enabled, "dedup_enabled", 1).await?;
+    let disabled = exercise_mode(&database_url, dedup_disabled, "dedup_disabled", 2).await?;
+
+    write_evidence(EvidenceArtifact {
+        contract: EVIDENCE_CONTRACT,
+        task: "FORUM-23B2G2B3D6",
+        source_commit: source_commit()?,
+        generated_at: Utc::now().to_rfc3339(),
+        database_backend: "postgresql",
+        broker_backend: "external_iggy",
+        delivery_profile: "outbox_iggy",
+        consumer_group: FORUM_SEARCH_CONTRACT_CONSUMER_GROUP,
+        topic: FORUM_SEARCH_CONTRACT_TOPIC,
+        scenario_results: vec![enabled, disabled],
+    })?;
+    Ok(())
+}
+
+async fn exercise_mode(
+    database_url: &str,
+    config: IggyConfig,
+    scope: &str,
+    expected_physical_dlq_messages: u32,
+) -> TestResult<ScenarioEvidence> {
+    let evidence = EvidenceRuntime::setup(database_url, config, scope).await?;
+    let stream = evidence.config.topology.stream_name.clone();
+    let dlq_group = unique_name(&format!("{scope}-dlq-observer"));
+    let marker = if expected_physical_dlq_messages == 1 {
+        0x61
+    } else {
+        0x62
+    };
+    let first_payload = vec![0xff, 0x00, marker, 0x01];
+    let second_payload = vec![0xff, 0x00, marker, 0x02];
+
+    let first_transport = IggyTransport::new(evidence.config.clone()).await?;
+    let first_group = first_transport
+        .open_persistent_contract_consumer_group(
+            FORUM_SEARCH_CONTRACT_CONSUMER_GROUP,
+            FORUM_SEARCH_CONTRACT_TOPIC,
+        )
+        .await?;
+    let mut dlq_cursor = evidence
+        .fixture
+        .open_consumer_group(&stream, "dlq", &dlq_group)
+        .await?;
+    assert_no_additional_dlq_message(&mut dlq_cursor).await?;
+
+    publish_fixture(&evidence.fixture, &stream, first_payload.clone()).await?;
+    publish_fixture(&evidence.fixture, &stream, second_payload.clone()).await?;
+
+    let first_failure = receive_decode_failure(&first_group).await?;
+    ensure_decode_failure(&first_failure, &first_payload)?;
+    let first_offset = first_failure.offset();
+    let first_delivery_id = first_failure.delivery_id();
+    let identity = poison_identity(&first_failure)?;
+    let store = ConsumerPoisonReceiptStore::new(evidence.db.clone());
+    let first_publisher = Uuid::new_v4();
+    let recovery_publisher = Uuid::new_v4();
+
+    let first_claim = store
+        .reserve_and_claim(
+            &identity,
+            first_failure.stable_error_code(),
+            1,
+            first_publisher,
+            PUBLISH_LEASE,
+        )
+        .await?;
+    if first_claim != ConsumerPoisonPublishClaim::Claimed {
+        return Err(invalid_data(format!(
+            "first poison publisher did not acquire the durable claim: {first_claim:?}"
+        ))
+        .into());
+    }
+    ensure_receipt(
+        &require_receipt(&store, &identity).await?,
+        ConsumerPoisonReceiptState::Publishing,
+        first_failure.stable_error_code(),
+        1,
+    )?;
+
+    let first_entry = first_failure.to_dlq_entry(1);
+    let deterministic_message_id = first_entry
+        .broker_message_id()
+        .ok_or_else(|| invalid_data("raw poison DLQ entry has no deterministic broker message ID"))?;
+    if deterministic_message_id != first_delivery_id || first_entry.payload != first_payload {
+        return Err(invalid_data(
+            "first DLQ entry did not retain the deterministic delivery identity and exact bytes",
+        )
+        .into());
+    }
+    first_transport.move_to_dlq(first_entry).await?;
+    let first_physical_dlq = receive_cursor_message(&mut dlq_cursor).await?;
+    ensure_dlq_payload(&first_physical_dlq, &first_payload)?;
+    acknowledge_cursor_message(&mut dlq_cursor, &first_physical_dlq).await?;
+    ensure_receipt(
+        &require_receipt(&store, &identity).await?,
+        ConsumerPoisonReceiptState::Publishing,
+        first_failure.stable_error_code(),
+        1,
+    )?;
+
+    let busy_claim = store
+        .reserve_and_claim(
+            &identity,
+            first_failure.stable_error_code(),
+            2,
+            recovery_publisher,
+            PUBLISH_LEASE,
+        )
+        .await?;
+    if busy_claim != ConsumerPoisonPublishClaim::Busy {
+        return Err(invalid_data(format!(
+            "unexpired poison claim did not remain busy: {busy_claim:?}"
+        ))
+        .into());
+    }
+
+    drop(first_group);
+    first_transport.shutdown().await?;
+    drop(first_transport);
+    tokio::time::sleep(LEASE_RECLAIM_WAIT).await;
+
+    let recovery_transport = IggyTransport::new(evidence.config.clone()).await?;
+    let recovery_group = recovery_transport
+        .open_persistent_contract_consumer_group(
+            FORUM_SEARCH_CONTRACT_CONSUMER_GROUP,
+            FORUM_SEARCH_CONTRACT_TOPIC,
+        )
+        .await?;
+    let redelivered = receive_decode_failure(&recovery_group).await?;
+    ensure_decode_failure(&redelivered, &first_payload)?;
+    if redelivered.offset() != first_offset || redelivered.delivery_id() != first_delivery_id {
+        return Err(invalid_data("restart changed the unacknowledged poison identity").into());
+    }
+
+    let recovery_claim = store
+        .reserve_and_claim(
+            &poison_identity(&redelivered)?,
+            redelivered.stable_error_code(),
+            2,
+            recovery_publisher,
+            PUBLISH_LEASE,
+        )
+        .await?;
+    if recovery_claim != ConsumerPoisonPublishClaim::Claimed {
+        return Err(invalid_data(format!(
+            "recovery publisher did not reclaim the expired receipt: {recovery_claim:?}"
+        ))
+        .into());
+    }
+    if !matches!(
+        store.mark_published(&identity, first_publisher).await,
+        Err(ConsumerPoisonReceiptError::ClaimLost)
+    ) {
+        return Err(invalid_data("stale publisher retained authority after lease takeover").into());
+    }
+
+    let retry_entry = redelivered.to_dlq_entry(2);
+    if retry_entry.broker_message_id() != Some(deterministic_message_id)
+        || retry_entry.payload != first_payload
+    {
+        return Err(invalid_data("redelivery changed the deterministic DLQ identity or bytes").into());
+    }
+    recovery_transport.move_to_dlq(retry_entry).await?;
+
+    let observed_physical_dlq_messages = if expected_physical_dlq_messages == 1 {
+        assert_no_additional_dlq_message(&mut dlq_cursor).await?;
+        1
+    } else {
+        let duplicate = receive_cursor_message(&mut dlq_cursor).await?;
+        ensure_dlq_payload(&duplicate, &first_payload)?;
+        acknowledge_cursor_message(&mut dlq_cursor, &duplicate).await?;
+        assert_no_additional_dlq_message(&mut dlq_cursor).await?;
+        2
+    };
+    if observed_physical_dlq_messages != expected_physical_dlq_messages {
+        return Err(invalid_data(format!(
+            "{scope} expected {expected_physical_dlq_messages} physical DLQ messages but observed {observed_physical_dlq_messages}"
+        ))
+        .into());
+    }
+
+    store.mark_published(&identity, recovery_publisher).await?;
+    ensure_receipt(
+        &require_receipt(&store, &identity).await?,
+        ConsumerPoisonReceiptState::Published,
+        redelivered.stable_error_code(),
+        1,
+    )?;
+    recovery_group
+        .acknowledge_decode_failure(&redelivered)
+        .await?;
+    store.mark_acknowledged(&identity).await?;
+    ensure_receipt(
+        &require_receipt(&store, &identity).await?,
+        ConsumerPoisonReceiptState::Acknowledged,
+        redelivered.stable_error_code(),
+        1,
+    )?;
+
+    let next_failure = receive_decode_failure(&recovery_group).await?;
+    ensure_decode_failure(&next_failure, &second_payload)?;
+    if next_failure.offset() <= first_offset || next_failure.delivery_id() == first_delivery_id {
+        return Err(invalid_data("terminalization did not advance to the next source delivery").into());
+    }
+    let next_offset = next_failure.offset();
+
+    drop(recovery_group);
+    recovery_transport.shutdown().await?;
+    evidence.cleanup().await?;
+
+    Ok(ScenarioEvidence {
+        id: format!("raw_poison_publish_mark_ambiguity_{scope}"),
+        result: "passed",
+        facts: json!({
+            "dedup_mode": scope,
+            "stream": stream,
+            "consumer_group": FORUM_SEARCH_CONTRACT_CONSUMER_GROUP,
+            "topic": FORUM_SEARCH_CONTRACT_TOPIC,
+            "first_offset": first_offset,
+            "first_delivery_id": first_delivery_id,
+            "deterministic_dlq_message_id": deterministic_message_id,
+            "publish_succeeded_before_mark_published": true,
+            "unexpired_claim_was_busy": true,
+            "expired_claim_reclaimed_after_restart": true,
+            "stale_publisher_fenced": true,
+            "expected_physical_dlq_messages": expected_physical_dlq_messages,
+            "observed_physical_dlq_messages": observed_physical_dlq_messages,
+            "source_acknowledged_after_durable_published": true,
+            "receipt_state_after_acknowledgement": "acknowledged",
+            "next_offset": next_offset
+        }),
+    })
+}
+
+async fn publish_fixture(
+    connector: &ExternalConnector,
+    stream: &str,
+    payload: Vec<u8>,
+) -> TestResult<()> {
+    connector
+        .publish(PublishRequest::new(
+            stream,
+            FORUM_SEARCH_CONTRACT_TOPIC,
+            "forum-search-raw-poison-ambiguity-fixture",
+            payload,
+            Uuid::new_v4().to_string(),
+        ))
+        .await?;
+    Ok(())
+}
+
+async fn receive_decode_failure(
+    group: &PersistentContractConsumerGroup,
+) -> TestResult<ConsumedContractDecodeFailure> {
+    let delivery = timeout(RECEIVE_TIMEOUT, group.receive_delivery())
+        .await
+        .map_err(|_| invalid_data("timed out waiting for Forum Search raw poison delivery"))??
+        .ok_or_else(|| invalid_data("Forum Search source cursor ended before poison delivery"))?;
+    match delivery {
+        PersistentContractDelivery::DecodeFailure(failure) => Ok(failure),
+        PersistentContractDelivery::Event(_) => Err(invalid_data(
+            "malformed ambiguity fixture unexpectedly decoded as a registered contract event",
+        )
+        .into()),
+    }
+}
+
+fn ensure_decode_failure(
+    failure: &ConsumedContractDecodeFailure,
+    expected_payload: &[u8],
+) -> TestResult<()> {
+    if failure.kind() != ContractDecodeFailureKind::Deserialize
+        || failure.stable_error_code() != "iggy.contract.decode_invalid"
+        || failure.stream().is_empty()
+        || failure.topic() != FORUM_SEARCH_CONTRACT_TOPIC
+        || failure.partition() == 0
+        || failure.ack_token().is_none()
+        || failure.raw_payload() != expected_payload
+    {
+        return Err(invalid_data(format!(
+            "unexpected Forum Search raw poison delivery: {failure:?}"
+        ))
+        .into());
+    }
+    failure.validate_connector_metadata()?;
+    Ok(())
+}
+
+fn poison_identity(
+    failure: &ConsumedContractDecodeFailure,
+) -> Result<ConsumerPoisonIdentity, ConsumerPoisonReceiptError> {
+    ConsumerPoisonIdentity::new(
+        failure.delivery_id(),
+        FORUM_SEARCH_CONTRACT_CONSUMER_GROUP,
+        failure.stream(),
+        failure.topic(),
+        failure.partition(),
+        failure.offset(),
+        failure.raw_payload().to_vec(),
+    )
+}
+
+async fn require_receipt(
+    store: &ConsumerPoisonReceiptStore,
+    identity: &ConsumerPoisonIdentity,
+) -> TestResult<ConsumerPoisonReceipt> {
+    store
+        .find(identity)
+        .await?
+        .ok_or_else(|| invalid_data("expected Forum Search poison receipt was not found").into())
+}
+
+fn ensure_receipt(
+    receipt: &ConsumerPoisonReceipt,
+    expected_state: ConsumerPoisonReceiptState,
+    expected_error_code: &str,
+    expected_first_attempt_count: u32,
+) -> TestResult<()> {
+    if receipt.state != expected_state
+        || receipt.stable_error_code != expected_error_code
+        || receipt.first_delivery_attempt_count != expected_first_attempt_count
+    {
+        return Err(invalid_data(format!(
+            "unexpected Forum Search poison receipt: {receipt:?}"
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+async fn receive_cursor_message(
+    cursor: &mut Box<dyn ConsumerCursor>,
+) -> TestResult<SubscriberMessage> {
+    timeout(RECEIVE_TIMEOUT, cursor.receive())
+        .await
+        .map_err(|_| invalid_data("timed out waiting for Forum Search DLQ delivery"))??
+        .ok_or_else(|| invalid_data("Forum Search DLQ cursor ended before a message").into())
+}
+
+fn ensure_dlq_payload(message: &SubscriberMessage, expected_payload: &[u8]) -> TestResult<()> {
+    if message.payload != expected_payload {
+        return Err(invalid_data("physical Iggy DLQ delivery changed the poison bytes").into());
+    }
+    Ok(())
+}
+
+async fn acknowledge_cursor_message(
+    cursor: &mut Box<dyn ConsumerCursor>,
+    message: &SubscriberMessage,
+) -> TestResult<()> {
+    let ack_token = message
+        .metadata
+        .ack_token
+        .as_deref()
+        .ok_or_else(|| invalid_data("Forum Search DLQ delivery has no acknowledgement token"))?;
+    cursor.acknowledge(ack_token).await?;
+    Ok(())
+}
+
+async fn assert_no_additional_dlq_message(
+    cursor: &mut Box<dyn ConsumerCursor>,
+) -> TestResult<()> {
+    match timeout(NO_ADDITIONAL_DLQ_TIMEOUT, cursor.receive()).await {
+        Err(_) | Ok(Ok(None)) => Ok(()),
+        Ok(Ok(Some(_))) => Err(invalid_data(
+            "Forum Search poison ambiguity observed an unexpected additional DLQ message",
+        )
+        .into()),
+        Ok(Err(error)) => Err(error.into()),
+    }
+}
+
+fn postgres_database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+fn external_iggy_config(address_env: &'static str, scope: &str) -> TestResult<Option<IggyConfig>> {
+    let address = match env::var(address_env) {
+        Ok(value) => bounded_env(address_env, value, 255)?,
+        Err(env::VarError::NotPresent) => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    validate_address(address_env, &address)?;
+    let username = optional_bounded_env(USERNAME_ENV, 191)?;
+    let password = optional_bounded_env(PASSWORD_ENV, 191)?;
+    if username.is_empty() != password.is_empty() {
+        return Err(invalid_data("Iggy username and password must both be set or both be empty").into());
+    }
+
+    Ok(Some(IggyConfig {
+        mode: IggyMode::External,
+        serialization: SerializationFormat::Json,
+        external: ExternalConfig {
+            addresses: vec![address],
+            protocol: "tcp".to_string(),
+            username,
+            password,
+            tls_enabled: false,
+            tls_domain: None,
+            tls_ca_file: None,
+        },
+        topology: TopologyConfig {
+            stream_name: unique_name(scope),
+            domain_partitions: 1,
+            replication_factor: 1,
+        },
+        ..IggyConfig::default()
+    }))
+}
+
+fn ensure_distinct_mode_addresses() -> TestResult<()> {
+    let enabled = env::var(DEDUP_ENABLED_ADDRESS_ENV).ok();
+    let disabled = env::var(DEDUP_DISABLED_ADDRESS_ENV).ok();
+    if let (Some(enabled), Some(disabled)) = (enabled, disabled) {
+        let enabled = bounded_env(DEDUP_ENABLED_ADDRESS_ENV, enabled, 255)?;
+        let disabled = bounded_env(DEDUP_DISABLED_ADDRESS_ENV, disabled, 255)?;
+        validate_address(DEDUP_ENABLED_ADDRESS_ENV, &enabled)?;
+        validate_address(DEDUP_DISABLED_ADDRESS_ENV, &disabled)?;
+        if enabled == disabled {
+            return Err(invalid_data(
+                "dedup-enabled and dedup-disabled evidence require distinct Iggy addresses",
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn validate_address(name: &'static str, address: &str) -> Result<(), IoError> {
+    if address.contains("://")
+        || address.contains('@')
+        || address.contains('?')
+        || address.contains('#')
+    {
+        return Err(invalid_data(format!(
+            "{name} must be host:port without credentials or URL delimiters"
+        )));
+    }
+    Ok(())
+}
+
+fn optional_bounded_env(name: &'static str, max_len: usize) -> TestResult<String> {
+    match env::var(name) {
+        Ok(value) => Ok(bounded_env(name, value, max_len)?),
+        Err(env::VarError::NotPresent) => Ok(String::new()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn bounded_env(name: &'static str, value: String, max_len: usize) -> Result<String, IoError> {
+    if value.trim() != value || value.is_empty() {
+        return Err(invalid_data(format!(
+            "{name} must be non-empty and have no surrounding whitespace"
+        )));
+    }
+    if value.len() > max_len {
+        return Err(invalid_data(format!("{name} exceeds the evidence limit")));
+    }
+    if value.chars().any(char::is_control) {
+        return Err(invalid_data(format!(
+            "{name} must not contain control characters"
+        )));
+    }
+    Ok(value)
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn set_search_path(db: &DatabaseConnection, schema_name: &str) -> TestResult<()> {
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}""#))
+        .await?;
+    Ok(())
+}
+
+fn sanitize_identifier(value: &str) -> String {
+    let normalized = value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    let normalized = normalized.trim_matches('_');
+    if normalized.is_empty() {
+        "test".to_string()
+    } else {
+        normalized.to_string()
+    }
+}
+
+fn unique_name(scope: &str) -> String {
+    format!("rustok-forum-search-{scope}-{}", Uuid::new_v4().simple())
+}
+
+fn write_evidence(artifact: EvidenceArtifact) -> TestResult<()> {
+    let path = workspace_root().join(EVIDENCE_PATH);
+    let parent = path
+        .parent()
+        .ok_or_else(|| invalid_data("evidence path has no parent directory"))?;
+    fs::create_dir_all(parent)?;
+    let mut bytes = serde_json::to_vec_pretty(&artifact)?;
+    bytes.push(b'\n');
+    fs::write(path, bytes)?;
+    Ok(())
+}
+
+fn source_commit() -> TestResult<String> {
+    let output = Command::new("git")
+        .current_dir(workspace_root())
+        .args(["rev-parse", "HEAD"])
+        .output()?;
+    if !output.status.success() {
+        return Err(invalid_data("git rev-parse HEAD failed for evidence generation").into());
+    }
+    let value = String::from_utf8(output.stdout)?;
+    let value = value.trim();
+    if value.len() != 40 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(invalid_data("git rev-parse HEAD returned an invalid commit SHA").into());
+    }
+    Ok(value.to_string())
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn invalid_data(message: impl Into<String>) -> IoError {
+    IoError::new(ErrorKind::InvalidData, message.into())
+}

--- a/crates/rustok-forum/contracts/forum-search-versioned-invalidation-poison-ambiguity-source-proof.json
+++ b/crates/rustok-forum/contracts/forum-search-versioned-invalidation-poison-ambiguity-source-proof.json
@@ -1,0 +1,105 @@
+{
+  "contract": "forum_search_versioned_invalidation_poison_ambiguity_source_proof_v1",
+  "task": "FORUM-23B2G2B3D6",
+  "status": "source_ready_maintainer_execution_pending",
+  "runtime_evidence_parent": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json",
+  "predecessor": {
+    "task": "FORUM-23B2G2B3D5",
+    "pull_request": 2777,
+    "state_at_authorship": "merged",
+    "merge_commit": "1d2654785047efde1d29a9682732990acc56f9b5",
+    "parent_registration": "D5_registered_D6_deferred_until_D6_merge"
+  },
+  "host_boundary": {
+    "package": "rustok-server",
+    "test": "apps/server/tests/forum_versioned_invalidation_poison_ambiguity_iggy.rs",
+    "reason": "the server host already owns direct Search, Iggy transport and connector dependencies without changing Cargo.lock",
+    "search_manifest_edges_forbidden": [
+      "iggy",
+      "rustok-iggy",
+      "rustok-iggy-connector"
+    ]
+  },
+  "production_reference": "apps/server/src/services/forum_search_contract_consumer.rs",
+  "evidence_artifact": {
+    "path": "target/forum-search-versioned-invalidation-poison-ambiguity-evidence.json",
+    "generation": "executable_test_only",
+    "hand_editing_forbidden": true,
+    "source_commit_required": true,
+    "written_only_after_all_modes_pass": true
+  },
+  "required_runtime": {
+    "database": "postgresql",
+    "database_env": "RUSTOK_SEARCH_TEST_DATABASE_URL",
+    "delivery_profile": "outbox_iggy",
+    "consumer_group": "rustok-search-forum-projection-v1",
+    "source_topic": "domain",
+    "dlq_topic": "dlq",
+    "dlq_observer": "rustok_iggy_connector::ConsumerCursor",
+    "iggy_instances": [
+      {
+        "mode": "dedup_enabled",
+        "address_env": "RUSTOK_FORUM_SEARCH_POISON_DEDUP_ENABLED_IGGY_ADDRESS",
+        "expected_physical_dlq_messages_after_retry": 1
+      },
+      {
+        "mode": "dedup_disabled",
+        "address_env": "RUSTOK_FORUM_SEARCH_POISON_DEDUP_DISABLED_IGGY_ADDRESS",
+        "expected_physical_dlq_messages_after_retry": 2
+      }
+    ],
+    "distinct_iggy_addresses_required": true,
+    "shared_credentials": [
+      "RUSTOK_IGGY_EXTERNAL_TEST_USERNAME",
+      "RUSTOK_IGGY_EXTERNAL_TEST_PASSWORD"
+    ]
+  },
+  "scenarios": [
+    {
+      "id": "raw_poison_publish_mark_ambiguity_dedup_enabled",
+      "proves": [
+        "malformed source bytes create one deterministic connector delivery identity",
+        "the first publisher emits the DLQ message before durable mark_published",
+        "the source offset remains unacknowledged while the receipt remains publishing",
+        "the live unexpired claim returns Busy to a second publisher",
+        "the expired publish claim is reclaimed after transport and consumer-group reconstruction",
+        "the stale publisher is fenced with ClaimLost",
+        "retry publication reuses the exact deterministic broker message identity",
+        "the connector DLQ cursor observes no second physical message when server-side deduplication is enabled",
+        "source acknowledgement occurs only after durable published state"
+      ]
+    },
+    {
+      "id": "raw_poison_publish_mark_ambiguity_dedup_disabled",
+      "proves": [
+        "the same receipt, lease and deterministic identity protocol is used without broker deduplication",
+        "publish success before mark_published remains an unavoidable cross-system ambiguity window",
+        "the connector DLQ cursor observes a second physical message when server-side deduplication is disabled",
+        "the stale publisher is still fenced after lease takeover",
+        "the durable receipt reaches published then acknowledged",
+        "the source group advances only after terminalization"
+      ]
+    }
+  ],
+  "identity_invariants": [
+    "ConsumerPoisonIdentity.delivery_id equals DlqEntry.broker_message_id",
+    "consumer_group remains rustok-search-forum-projection-v1",
+    "source stream, topic, partition, offset and exact payload bytes remain unchanged after restart",
+    "the stale publisher cannot mark the receipt published after lease takeover",
+    "dedup mode changes only physical broker multiplicity and not durable receipt identity or terminal ordering",
+    "the next malformed delivery has a strictly later source offset"
+  ],
+  "maintainer_command": "RUSTOK_SEARCH_TEST_DATABASE_URL=\"$DATABASE_URL\" RUSTOK_FORUM_SEARCH_POISON_DEDUP_ENABLED_IGGY_ADDRESS=\"127.0.0.1:8090\" RUSTOK_FORUM_SEARCH_POISON_DEDUP_DISABLED_IGGY_ADDRESS=\"127.0.0.1:8091\" cargo test --locked -p rustok-server --test forum_versioned_invalidation_poison_ambiguity_iggy -- --nocapture --test-threads=1",
+  "non_claims": [
+    "this source slice does not claim successful PostgreSQL or external Iggy execution",
+    "this source slice does not run the server-owned Forum Search worker loop or prove its retry backoff",
+    "semantic identity-conflict poison is owned by merged FORUM-23B2G2B3D5 and is not duplicated here",
+    "this source slice does not prove arbitrary multi-process claim contention beyond one expired-lease takeover",
+    "this source slice does not read active production deduplication configuration or prove TLS, replication, multiple partitions or broker failover",
+    "this source slice does not execute the Search projector or advance an owner checkpoint",
+    "this source slice does not establish missing-delivery repair, deletion or ACL visibility ordering, or Search-disabled recovery",
+    "this source slice does not modify Cargo.lock or add cross-module Iggy dependencies to rustok-search",
+    "this source slice does not register D6 in the parent D0 contract before D6 itself merges",
+    "this source slice does not complete FORUM-23B2G2B3D or close LINK-FORUM-03"
+  ]
+}

--- a/crates/rustok-forum/docs/forum-23b2g2b3d6-versioned-invalidation-poison-ambiguity.md
+++ b/crates/rustok-forum/docs/forum-23b2g2b3d6-versioned-invalidation-poison-ambiguity.md
@@ -1,0 +1,160 @@
+# FORUM-23B2G2B3D6 external-Iggy poison publish/mark ambiguity proof
+
+## Status
+
+`source_ready_maintainer_execution_pending`
+
+This slice continues the frozen Forum Search runtime-evidence matrix after merged
+D5 semantic-poison proof #2777. It isolates the raw-poison ambiguity window where
+Iggy accepts a deterministic DLQ publication but the process stops before
+PostgreSQL records `published`.
+
+The machine-readable contract is:
+
+```text
+crates/rustok-forum/contracts/forum-search-versioned-invalidation-poison-ambiguity-source-proof.json
+```
+
+The executable target is hosted by the server package:
+
+```text
+apps/server/tests/forum_versioned_invalidation_poison_ambiguity_iggy.rs
+```
+
+The production ordering reference is:
+
+```text
+apps/server/src/services/forum_search_contract_consumer.rs
+```
+
+## Host boundary
+
+PR #2781 moved the existing D3-D5 cross-module Iggy/PostgreSQL evidence targets
+to `apps/server/tests`. The server package already owns direct Search, Iggy
+transport and connector dependencies, so D6 follows the same lockfile-neutral
+boundary.
+
+D6 does not add `iggy`, `rustok-iggy` or `rustok-iggy-connector` development
+edges to `crates/rustok-search/Cargo.toml`, and it does not change `Cargo.lock`.
+The physical DLQ observer uses the public
+`rustok_iggy_connector::ConsumerCursor` instead of a direct Iggy SDK dependency.
+
+## Runtime topology
+
+The harness requires one PostgreSQL database and two distinct external Iggy
+instances:
+
+- `RUSTOK_FORUM_SEARCH_POISON_DEDUP_ENABLED_IGGY_ADDRESS` points to an instance
+  whose deterministic message-ID duplicate suppression is enabled;
+- `RUSTOK_FORUM_SEARCH_POISON_DEDUP_DISABLED_IGGY_ADDRESS` points to a distinct
+  instance whose duplicate suppression is disabled.
+
+Both addresses must use bounded `host:port` form and must differ. Optional shared
+credentials use `RUSTOK_IGGY_EXTERNAL_TEST_USERNAME` and
+`RUSTOK_IGGY_EXTERNAL_TEST_PASSWORD` and must be supplied together.
+
+Each mode creates a unique one-partition evidence stream and isolated PostgreSQL
+schema. The real connector migration list creates the durable receipt store.
+Source deliveries use production consumer group
+`rustok-search-forum-projection-v1` and topic `domain`; DLQ publications use
+`IggyTransport::move_to_dlq`, while a separately named connector cursor observes
+physical deliveries from topic `dlq`.
+
+## Covered sequence
+
+For each broker mode, two malformed source payloads are published. The first
+payload follows this exact sequence:
+
+```text
+receive exact raw poison delivery
+  -> reserve_and_claim durable receipt
+  -> receipt state is publishing
+  -> publish deterministic DLQ entry
+  -> observe and acknowledge first physical DLQ delivery
+  -> do not call mark_published
+  -> retain the exact source offset unacknowledged
+  -> second publisher observes Busy before lease expiry
+  -> stop the first transport and consumer group
+  -> wait for the bounded one-second publish lease to expire
+  -> reconstruct transport and production consumer group
+  -> redeliver the same bytes, offset and delivery UUID
+  -> reclaim the expired receipt with a new publisher
+  -> stale publisher fails mark_published with ClaimLost
+  -> republish with the same deterministic broker message ID
+  -> observe physical DLQ multiplicity through the connector cursor
+  -> mark_published
+  -> acknowledge the exact source delivery
+  -> mark_acknowledged
+  -> advance to the second malformed source payload
+```
+
+The dedup-enabled instance must expose no second physical DLQ delivery after the
+retry, for a total of one. The dedup-disabled instance must expose one additional
+physical delivery, for a total of two. This positive/negative capability proof
+shows that PostgreSQL receipt leasing fences concurrent live publishers but
+cannot create physical exactly-once semantics across a successful broker write
+and missing database mark without broker deduplication.
+
+## Generated evidence
+
+Only after both modes pass, the target writes:
+
+```text
+target/forum-search-versioned-invalidation-poison-ambiguity-evidence.json
+```
+
+The artifact records the exact source commit, consumer group, source positions,
+deterministic delivery and DLQ identities, claim takeover, stale-publisher
+fencing, expected and observed physical message counts, receipt terminal state,
+and advancement to the next source delivery. It is executable output and must not
+be hand-edited or committed as a static result.
+
+## Relationship to merged D5
+
+`FORUM-23B2G2B3D5` merged through PR #2777 at
+`1d2654785047efde1d29a9682732990acc56f9b5`. D5 owns valid typed semantic
+identity-conflict poison, deterministic semantic DLQ publication and
+`AlreadyPublished` restart recovery. D6 does not duplicate that scenario; it
+uses malformed raw bytes solely to expose the publish-before-`mark_published`
+ambiguity under two externally reviewed broker modes.
+
+The parent D0 contract already registers D5. D6 intentionally defers its own
+registration until D6 is merged, so canonical `main` never lists an unmerged
+subproof.
+
+## Deliberate limits
+
+This slice does not claim:
+
+- successful PostgreSQL or external-Iggy execution;
+- server-owned background worker-loop or retry/backoff execution;
+- active production Iggy deduplication configuration readback;
+- semantic identity-conflict poison, already owned by merged D5;
+- arbitrary multi-process contention beyond one lease-expiry takeover;
+- TLS, replication, multiple partitions or broker failover;
+- Search projector execution, owner-checkpoint advancement, missing-delivery
+  repair, deletion/ACL visibility ordering, Search-disabled recovery, completion
+  of `FORUM-23B2G2B3D`, or closure of `LINK-FORUM-03`.
+
+No production Rust path, dependency manifest, migration, event schema, digest,
+runtime flag, consumer group, broker topic, Search query, public API or
+`Cargo.lock` entry changes.
+
+## Maintainer verification
+
+```bash
+RUSTOK_SEARCH_TEST_DATABASE_URL="$DATABASE_URL" \
+RUSTOK_FORUM_SEARCH_POISON_DEDUP_ENABLED_IGGY_ADDRESS="127.0.0.1:8090" \
+RUSTOK_FORUM_SEARCH_POISON_DEDUP_DISABLED_IGGY_ADDRESS="127.0.0.1:8091" \
+  cargo test --locked -p rustok-server \
+  --test forum_versioned_invalidation_poison_ambiguity_iggy \
+  -- --nocapture --test-threads=1
+
+node scripts/verify/verify-forum-search-versioned-invalidation-d6-poison-ambiguity.mjs
+cargo check --locked -p rustok-server --features mod-forum --all-targets
+cargo xtask module validate forum
+cargo xtask module validate search
+git diff --check
+```
+
+No command above was run by the implementation agent, per maintainer request.

--- a/scripts/verify/verify-forum-search-versioned-invalidation-d6-poison-ambiguity.mjs
+++ b/scripts/verify/verify-forum-search-versioned-invalidation-d6-poison-ambiguity.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = process.cwd();
+const read = (path) => readFileSync(resolve(root, path), "utf8");
+const requireAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(text.includes(marker), `${label} is missing required marker: ${marker}`);
+  }
+};
+const forbidAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(!text.includes(marker), `${label} contains forbidden marker: ${marker}`);
+  }
+};
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-search-versioned-invalidation-poison-ambiguity-source-proof.json";
+const documentPath =
+  "crates/rustok-forum/docs/forum-23b2g2b3d6-versioned-invalidation-poison-ambiguity.md";
+const testPath =
+  "apps/server/tests/forum_versioned_invalidation_poison_ambiguity_iggy.rs";
+const serverManifestPath = "apps/server/Cargo.toml";
+const searchManifestPath = "crates/rustok-search/Cargo.toml";
+const workerPath = "apps/server/src/services/forum_search_contract_consumer.rs";
+const parentPath =
+  "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json";
+
+const contract = JSON.parse(read(contractPath));
+assert.equal(
+  contract.contract,
+  "forum_search_versioned_invalidation_poison_ambiguity_source_proof_v1",
+);
+assert.equal(contract.task, "FORUM-23B2G2B3D6");
+assert.equal(contract.status, "source_ready_maintainer_execution_pending");
+assert.equal(contract.runtime_evidence_parent, parentPath);
+assert.equal(contract.predecessor.task, "FORUM-23B2G2B3D5");
+assert.equal(contract.predecessor.pull_request, 2777);
+assert.equal(contract.predecessor.state_at_authorship, "merged");
+assert.equal(
+  contract.predecessor.merge_commit,
+  "1d2654785047efde1d29a9682732990acc56f9b5",
+);
+assert.equal(
+  contract.predecessor.parent_registration,
+  "D5_registered_D6_deferred_until_D6_merge",
+);
+assert.equal(contract.host_boundary.package, "rustok-server");
+assert.equal(contract.host_boundary.test, testPath);
+assert.deepEqual(contract.host_boundary.search_manifest_edges_forbidden, [
+  "iggy",
+  "rustok-iggy",
+  "rustok-iggy-connector",
+]);
+assert.equal(contract.production_reference, workerPath);
+assert.equal(
+  contract.evidence_artifact.path,
+  "target/forum-search-versioned-invalidation-poison-ambiguity-evidence.json",
+);
+assert.equal(contract.evidence_artifact.generation, "executable_test_only");
+assert.equal(contract.evidence_artifact.hand_editing_forbidden, true);
+assert.equal(contract.evidence_artifact.source_commit_required, true);
+assert.equal(contract.evidence_artifact.written_only_after_all_modes_pass, true);
+assert.equal(contract.required_runtime.database, "postgresql");
+assert.equal(contract.required_runtime.delivery_profile, "outbox_iggy");
+assert.equal(
+  contract.required_runtime.consumer_group,
+  "rustok-search-forum-projection-v1",
+);
+assert.equal(contract.required_runtime.source_topic, "domain");
+assert.equal(contract.required_runtime.dlq_topic, "dlq");
+assert.equal(
+  contract.required_runtime.dlq_observer,
+  "rustok_iggy_connector::ConsumerCursor",
+);
+assert.equal(contract.required_runtime.distinct_iggy_addresses_required, true);
+assert.deepEqual(
+  contract.required_runtime.iggy_instances.map(({ mode }) => mode),
+  ["dedup_enabled", "dedup_disabled"],
+);
+assert.deepEqual(
+  contract.required_runtime.iggy_instances.map(
+    ({ expected_physical_dlq_messages_after_retry }) =>
+      expected_physical_dlq_messages_after_retry,
+  ),
+  [1, 2],
+);
+assert.deepEqual(
+  contract.scenarios.map(({ id }) => id),
+  [
+    "raw_poison_publish_mark_ambiguity_dedup_enabled",
+    "raw_poison_publish_mark_ambiguity_dedup_disabled",
+  ],
+);
+assert.ok(contract.identity_invariants.length >= 6);
+assert.ok(contract.non_claims.length >= 10);
+assert.ok(contract.maintainer_command.includes("cargo test --locked -p rustok-server"));
+
+const test = read(testPath);
+requireAll(
+  test,
+  [
+    "raw_poison_publish_mark_ambiguity_obeys_configured_dedup_modes",
+    "RUSTOK_FORUM_SEARCH_POISON_DEDUP_ENABLED_IGGY_ADDRESS",
+    "RUSTOK_FORUM_SEARCH_POISON_DEDUP_DISABLED_IGGY_ADDRESS",
+    "ensure_distinct_mode_addresses",
+    "FORUM_SEARCH_CONTRACT_CONSUMER_GROUP",
+    "FORUM_SEARCH_CONTRACT_TOPIC",
+    "rustok_iggy_connector::migrations::migrations()",
+    "PersistentContractDelivery::DecodeFailure",
+    "ConsumerPoisonIdentity::new",
+    "ConsumerPoisonPublishClaim::Claimed",
+    "ConsumerPoisonPublishClaim::Busy",
+    "ConsumerPoisonReceiptError::ClaimLost",
+    "ConsumerPoisonReceiptState::Publishing",
+    "ConsumerPoisonReceiptState::Published",
+    "ConsumerPoisonReceiptState::Acknowledged",
+    "ConsumerCursor",
+    "SubscriberMessage",
+    ".open_consumer_group(&stream, \"dlq\", &dlq_group)",
+    "receive_cursor_message",
+    "acknowledge_cursor_message",
+    "assert_no_additional_dlq_message",
+    "broker_message_id()",
+    "move_to_dlq",
+    "mark_published",
+    "acknowledge_decode_failure",
+    "mark_acknowledged",
+    "tokio::time::sleep(LEASE_RECLAIM_WAIT)",
+    "expected_physical_dlq_messages",
+    "observed_physical_dlq_messages",
+    "target/forum-search-versioned-invalidation-poison-ambiguity-evidence.json",
+    "FORUM-23B2G2B3D6",
+    "source_commit()",
+  ],
+  "D6 server-hosted external-Iggy poison ambiguity test",
+);
+forbidAll(
+  test,
+  [
+    "iggy::prelude",
+    "IggyClient",
+    "TopicClient",
+    "ForumSearchContractIngress",
+    "SearchModule.migrations()",
+    "forum.search_projection.contract_inbox_identity_conflict",
+    "search_projection_inbox",
+    "FORUM-23B2G2B3D5",
+  ],
+  "D6 server-hosted external-Iggy poison ambiguity test",
+);
+
+const serverManifest = read(serverManifestPath);
+requireAll(
+  serverManifest,
+  [
+    "rustok-search = { workspace = true, features = [\"graphql\"] }",
+    "rustok-iggy.workspace = true",
+    'rustok-iggy-connector = { workspace = true, features = ["migrations"] }',
+    "sea-orm-migration.workspace = true",
+  ],
+  "server host dependencies",
+);
+
+const searchManifest = read(searchManifestPath);
+forbidAll(
+  searchManifest,
+  [
+    "iggy.workspace = true",
+    "rustok-iggy.workspace = true",
+    "rustok-iggy-connector",
+  ],
+  "Search owner manifest cross-module evidence dependencies",
+);
+
+const worker = read(workerPath);
+requireAll(
+  worker,
+  [
+    "POISON_PUBLISH_LEASE",
+    "establish_poison_result",
+    ".reserve_and_claim(",
+    "ConsumerPoisonPublishClaim::AlreadyPublished",
+    "ConsumerPoisonPublishClaim::AlreadyAcknowledged",
+    "ConsumerPoisonPublishClaim::Busy",
+    "ConsumerPoisonPublishClaim::Claimed",
+    "transport.move_to_dlq(entry.clone())",
+    ".release_claim(identity, poison_publisher_id)",
+    "mark_poison_published",
+    "acknowledge_decode_failure_with_receipt",
+    "mark_acknowledged",
+  ],
+  "production Forum Search poison worker ordering",
+);
+
+const document = read(documentPath);
+requireAll(
+  document,
+  [
+    "FORUM-23B2G2B3D6",
+    "source_ready_maintainer_execution_pending",
+    contractPath,
+    testPath,
+    workerPath,
+    "PR #2781 moved",
+    "rustok_iggy_connector::ConsumerCursor",
+    "second publisher observes Busy before lease expiry",
+    "stale publisher fails mark_published with ClaimLost",
+    "no second physical DLQ delivery",
+    "one additional physical delivery",
+    "merged through PR #2777",
+    "D6 intentionally defers its own registration",
+    "cargo test --locked -p rustok-server",
+    "No command above was run by the implementation agent",
+  ],
+  "D6 poison ambiguity handoff",
+);
+forbidAll(
+  document,
+  [
+    "crates/rustok-search/tests/forum_versioned_invalidation_poison_ambiguity_iggy.rs",
+    "cargo test -p rustok-search",
+    "only manifest change",
+    "open PR #2774",
+    "pending PR #2772",
+  ],
+  "D6 poison ambiguity handoff",
+);
+
+const parent = JSON.parse(read(parentPath));
+assert.equal(parent.task, "FORUM-23B2G2B3D0");
+assert.equal(parent.status, "source_ready_maintainer_execution_pending");
+assert.ok(
+  parent.source_ready_subproofs.some(
+    ({ task, test: registeredTest }) =>
+      task === "FORUM-23B2G2B3D5" &&
+      registeredTest ===
+        "apps/server/tests/forum_versioned_invalidation_semantic_poison_iggy.rs",
+  ),
+  "D0 parent must retain merged server-hosted D5 semantic-poison proof",
+);
+assert.ok(
+  !parent.source_ready_subproofs.some(
+    ({ task }) => task === "FORUM-23B2G2B3D6",
+  ),
+  "D0 parent must not register unmerged D6",
+);
+assert.ok(
+  parent.required_scenarios.some(
+    ({ id }) => id === "raw_poison_dlq_redelivery",
+  ),
+  "D0 parent must retain raw poison/DLQ runtime scenario",
+);
+assert.equal(parent.evidence_artifact.generation, "executable_runtime_only");
+assert.equal(parent.evidence_artifact.hand_editing_forbidden, true);
+
+console.log(
+  "Forum Search D6 server-hosted external-Iggy poison publish/mark ambiguity source proof is internally consistent.",
+);


### PR DESCRIPTION
## Summary

- continue the frozen Forum Search runtime-evidence matrix with `FORUM-23B2G2B3D6`
- supersede closed draft #2779 after merged #2781 established `apps/server/tests` as the lockfile-neutral owner for cross-module Forum Search/Iggy/PostgreSQL evidence
- add one server-hosted executable target for the raw-poison publish-success-before-`mark_published` ambiguity window
- execute the same deterministic receipt and DLQ protocol against two distinct external Iggy instances: message-ID dedup enabled and disabled
- observe physical DLQ deliveries through the existing public `rustok_iggy_connector::ConsumerCursor`, without a direct Iggy SDK dependency
- require an unexpired receipt claim to return `Busy`, an expired claim to be reclaimed after restart, and the stale publisher to be fenced with `ClaimLost`
- require retry publication to reuse the exact deterministic DLQ broker message ID
- require one total physical DLQ delivery with dedup enabled and two with dedup disabled
- persist `published` before source acknowledgement, then persist `acknowledged` and advance to the next malformed source delivery
- write retained JSON evidence only after both modes pass
- add a machine-readable contract, handoff and fail-closed verifier

## Rechecked baseline

Current `main` contains:

- D0 runtime-evidence protocol and D1 canonical-plan reconciliation
- D2 PostgreSQL shared-inbox proof from #2767
- D3 external-Iggy acknowledgement/restart proof from #2770
- D4 external-Iggy/PostgreSQL raw-poison restart proof from #2775
- D5 external-Iggy/PostgreSQL semantic identity-conflict poison proof from #2777
- the D3-D5 server-host migration and lockfile repair from #2781

The parent D0 contract already registers D5. This PR intentionally defers D6 registration until D6 itself merges.

## Host boundary

The executable target is:

```text
apps/server/tests/forum_versioned_invalidation_poison_ambiguity_iggy.rs
```

The server package already owns direct Search, Iggy transport, connector migration and PostgreSQL dependencies. Consequently this PR changes neither `apps/server/Cargo.toml`, `crates/rustok-search/Cargo.toml`, nor `Cargo.lock`.

The verifier requires the server-owned dependency boundary and forbids reintroducing `iggy`, `rustok-iggy`, or `rustok-iggy-connector` edges into the Search owner manifest.

## Executable proof

The target requires:

- PostgreSQL through `RUSTOK_SEARCH_TEST_DATABASE_URL` or PostgreSQL `DATABASE_URL`
- a dedup-enabled Iggy instance through `RUSTOK_FORUM_SEARCH_POISON_DEDUP_ENABLED_IGGY_ADDRESS`
- a distinct dedup-disabled instance through `RUSTOK_FORUM_SEARCH_POISON_DEDUP_DISABLED_IGGY_ADDRESS`
- optional paired credentials through the existing external-Iggy username/password variables

For each mode the harness:

1. creates an isolated PostgreSQL schema and applies the real connector receipt migrations;
2. creates a unique one-partition Iggy stream and separate DLQ observer group;
3. publishes two malformed payloads to `domain`;
4. receives the first payload through production group `rustok-search-forum-projection-v1`;
5. claims a durable receipt and publishes one deterministic DLQ entry without calling `mark_published`;
6. observes and acknowledges the first physical DLQ delivery through the connector cursor;
7. requires a second live publisher to observe `Busy`;
8. reconstructs transport and source consumer group after the one-second lease expires;
9. receives the exact same source delivery and reclaims the receipt;
10. requires the stale publisher to fail with `ClaimLost`;
11. republishes with the same deterministic message ID;
12. observes no additional DLQ delivery in the dedup-enabled mode or one additional delivery in the dedup-disabled mode;
13. persists `published`, acknowledges the exact source delivery, persists `acknowledged`, and advances to the second payload.

Successful execution writes:

```text
target/forum-search-versioned-invalidation-poison-ambiguity-evidence.json
```

## Deliberate limits

This PR does not claim:

- successful PostgreSQL or external-Iggy execution
- server-owned Forum Search background worker-loop or retry/backoff execution
- active production deduplication configuration readback
- semantic identity-conflict poison, already covered by merged D5
- arbitrary multi-process contention beyond one expired-lease takeover
- TLS, replication, multiple partitions or broker failover
- projector/checkpoint execution, missing-delivery repair, deletion/ACL visibility ordering, Search-disabled recovery, completion of `FORUM-23B2G2B3D`, or closure of `LINK-FORUM-03`

## Compatibility

- no production Rust path changed
- no dependency manifest or `Cargo.lock` change
- no migration, event schema, digest, runtime flag, consumer group, broker topic, Search query or public API change
- no second inbox, projector, reconciler or ordering clock

## Validation

Not run per maintainer instruction:

```bash
RUSTOK_SEARCH_TEST_DATABASE_URL="$DATABASE_URL" \
RUSTOK_FORUM_SEARCH_POISON_DEDUP_ENABLED_IGGY_ADDRESS="127.0.0.1:8090" \
RUSTOK_FORUM_SEARCH_POISON_DEDUP_DISABLED_IGGY_ADDRESS="127.0.0.1:8091" \
  cargo test --locked -p rustok-server \
  --test forum_versioned_invalidation_poison_ambiguity_iggy \
  -- --nocapture --test-threads=1

node scripts/verify/verify-forum-search-versioned-invalidation-d6-poison-ambiguity.mjs
cargo check --locked -p rustok-server --features mod-forum --all-targets
cargo xtask module validate forum
cargo xtask module validate search
git diff --check
```

No executable evidence artifact was generated. Squash merge is recommended after maintainer validation.