### PR TITLE
feat(blog): add Comments TCP listener lifecycle

### DIFF
--- a/apps/server/src/services/comments_provider_runtime.rs
+++ b/apps/server/src/services/comments_provider_runtime.rs
@@ -1,13 +1,48 @@
-use std::{env, net::SocketAddr, sync::Arc};
+use std::{
+    env,
+    net::SocketAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
 
 use rustok_comments::{
-    CommentsThreadPort, CommentsThreadTransport, TcpJsonCommentsTransport,
+    CommentsTcpAuthorityResolver, CommentsThreadPort, CommentsThreadTransport,
+    TcpJsonCommentsServerAdapter, TcpJsonCommentsTransport, in_process_comments_thread_port,
     remote_comments_thread_port,
 };
 use rustok_core::ModuleRuntimeExtensions;
+use tokio::{
+    net::TcpListener,
+    sync::Semaphore,
+    task::{JoinError, JoinSet},
+    time::timeout,
+};
+
+use crate::error::{Error, Result};
+use crate::services::app_lifecycle::StopHandle;
+use crate::services::event_bus::transactional_event_bus_from_context;
+use crate::services::server_runtime_context::ServerRuntimeContext;
 
 pub const COMMENTS_PROVIDER_MODE_ENV: &str = "RUSTOK_COMMENTS_PROVIDER_MODE";
 pub const COMMENTS_TCP_ENDPOINT_ENV: &str = "RUSTOK_COMMENTS_TCP_ENDPOINT";
+pub const COMMENTS_TCP_LISTENER_ENABLED_ENV: &str = "RUSTOK_COMMENTS_TCP_LISTENER_ENABLED";
+pub const COMMENTS_TCP_BIND_ENV: &str = "RUSTOK_COMMENTS_TCP_BIND";
+pub const COMMENTS_TCP_MAX_CONNECTIONS_ENV: &str = "RUSTOK_COMMENTS_TCP_MAX_CONNECTIONS";
+pub const COMMENTS_TCP_PRE_REQUEST_TIMEOUT_MS_ENV: &str =
+    "RUSTOK_COMMENTS_TCP_PRE_REQUEST_TIMEOUT_MS";
+pub const COMMENTS_TCP_SHUTDOWN_GRACE_MS_ENV: &str =
+    "RUSTOK_COMMENTS_TCP_SHUTDOWN_GRACE_MS";
+pub const COMMENTS_TCP_MAX_FRAME_BYTES_ENV: &str = "RUSTOK_COMMENTS_TCP_MAX_FRAME_BYTES";
+
+const DEFAULT_COMMENTS_TCP_MAX_CONNECTIONS: usize = 64;
+const DEFAULT_COMMENTS_TCP_PRE_REQUEST_TIMEOUT_MS: u64 = 2_000;
+const DEFAULT_COMMENTS_TCP_SHUTDOWN_GRACE_MS: u64 = 5_000;
+const DEFAULT_COMMENTS_TCP_MAX_FRAME_BYTES: usize = 8 * 1024 * 1024;
+
+static COMMENTS_TCP_LISTENER_INSTANCE_IDS: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CommentsProviderProfile {
@@ -22,6 +57,98 @@ pub struct CommentsProviderRuntimeSelection {
     pub endpoint: Option<SocketAddr>,
 }
 
+/// Host-provided authority implementation required before a Comments TCP
+/// listener may bind. There is deliberately no allow-all fallback.
+#[derive(Clone)]
+pub struct SharedCommentsTcpAuthorityResolver(pub Arc<dyn CommentsTcpAuthorityResolver>);
+
+/// Optional host override for the provider served by the TCP listener.
+///
+/// This wrapper is intentionally distinct from the consumer-selected
+/// `Arc<dyn CommentsThreadPort>` so a TCP client cannot accidentally be served
+/// back through itself. When absent, the listener uses the owner-managed
+/// in-process Comments provider.
+#[derive(Clone)]
+pub struct SharedCommentsTcpServerProvider(pub Arc<dyn CommentsThreadPort>);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CommentsTcpListenerConfig {
+    pub bind_addr: SocketAddr,
+    pub max_connections: usize,
+    pub pre_request_timeout: Duration,
+    pub shutdown_grace: Duration,
+    pub max_frame_bytes: usize,
+}
+
+impl CommentsTcpListenerConfig {
+    pub fn from_environment() -> Result<Option<Self>, String> {
+        let enabled = match read_optional_environment(COMMENTS_TCP_LISTENER_ENABLED_ENV)? {
+            Some(value) => parse_bool_value(COMMENTS_TCP_LISTENER_ENABLED_ENV, &value)?,
+            None => false,
+        };
+        if !enabled {
+            return Ok(None);
+        }
+
+        let raw_bind = read_optional_environment(COMMENTS_TCP_BIND_ENV)?.ok_or_else(|| {
+            format!(
+                "{COMMENTS_TCP_BIND_ENV} is required when {COMMENTS_TCP_LISTENER_ENABLED_ENV}=true"
+            )
+        })?;
+        let bind_addr = raw_bind.trim().parse::<SocketAddr>().map_err(|_| {
+            format!("{COMMENTS_TCP_BIND_ENV} must be an explicit IP socket address")
+        })?;
+        if !bind_addr.ip().is_loopback() {
+            return Err(format!(
+                "{COMMENTS_TCP_BIND_ENV} must be loopback while Comments TCP transport is unencrypted"
+            ));
+        }
+        if bind_addr.port() == 0 {
+            return Err(format!(
+                "{COMMENTS_TCP_BIND_ENV} must use an explicit non-zero port"
+            ));
+        }
+
+        let max_connections = parse_optional_positive_usize(
+            COMMENTS_TCP_MAX_CONNECTIONS_ENV,
+            DEFAULT_COMMENTS_TCP_MAX_CONNECTIONS,
+        )?;
+        let pre_request_timeout_ms = parse_optional_positive_u64(
+            COMMENTS_TCP_PRE_REQUEST_TIMEOUT_MS_ENV,
+            DEFAULT_COMMENTS_TCP_PRE_REQUEST_TIMEOUT_MS,
+        )?;
+        let shutdown_grace_ms = parse_optional_positive_u64(
+            COMMENTS_TCP_SHUTDOWN_GRACE_MS_ENV,
+            DEFAULT_COMMENTS_TCP_SHUTDOWN_GRACE_MS,
+        )?;
+        let max_frame_bytes = parse_optional_positive_usize(
+            COMMENTS_TCP_MAX_FRAME_BYTES_ENV,
+            DEFAULT_COMMENTS_TCP_MAX_FRAME_BYTES,
+        )?;
+        if max_frame_bytes > u32::MAX as usize {
+            return Err(format!(
+                "{COMMENTS_TCP_MAX_FRAME_BYTES_ENV} must be within 1..=u32::MAX"
+            ));
+        }
+
+        Ok(Some(Self {
+            bind_addr,
+            max_connections,
+            pre_request_timeout: Duration::from_millis(pre_request_timeout_ms),
+            shutdown_grace: Duration::from_millis(shutdown_grace_ms),
+            max_frame_bytes,
+        }))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CommentsTcpListenerHandle {
+    pub instance_id: u64,
+    pub local_addr: SocketAddr,
+}
+
+struct CommentsTcpListenerLifecycleReservation;
+
 /// Publishes the host-selected Comments provider through `ModuleRuntimeExtensions`.
 ///
 /// The default `in_process` mode intentionally inserts no port. Blog therefore
@@ -30,7 +157,7 @@ pub struct CommentsProviderRuntimeSelection {
 /// is never enabled for a non-loopback address.
 pub fn register_comments_provider_runtime(
     extensions: &mut ModuleRuntimeExtensions,
-) -> Result<(), String> {
+) -> std::result::Result<(), String> {
     if extensions.contains::<Arc<dyn CommentsThreadPort>>() {
         extensions.insert(CommentsProviderRuntimeSelection {
             profile: CommentsProviderProfile::Preconfigured,
@@ -84,16 +211,341 @@ pub fn register_comments_provider_runtime(
     }
 }
 
+/// Starts the opt-in host-owned Comments TCP listener exactly once.
+///
+/// Binding is fail-closed: a loopback address, explicit authority resolver,
+/// bounded frame size, bounded concurrency, non-zero pre-request timeout, and
+/// shutdown grace are all required before the task is spawned.
+pub async fn start_comments_tcp_listener_if_enabled(
+    runtime_ctx: &ServerRuntimeContext,
+) -> Result<()> {
+    let Some(config) = CommentsTcpListenerConfig::from_environment().map_err(Error::BadRequest)?
+    else {
+        return Ok(());
+    };
+
+    if runtime_ctx.settings().runtime.is_registry_only()
+        || runtime_ctx.settings().runtime.is_worker_only()
+    {
+        return Err(Error::BadRequest(
+            "Comments TCP listener requires an HTTP-serving runtime host mode".to_string(),
+        ));
+    }
+
+    if !runtime_ctx.shared_insert_if_absent(CommentsTcpListenerLifecycleReservation) {
+        return Ok(());
+    }
+
+    let result = start_comments_tcp_listener(runtime_ctx, config).await;
+    if result.is_err() {
+        let _ = runtime_ctx.shared_take::<CommentsTcpListenerLifecycleReservation>();
+    }
+    result
+}
+
+async fn start_comments_tcp_listener(
+    runtime_ctx: &ServerRuntimeContext,
+    config: CommentsTcpListenerConfig,
+) -> Result<()> {
+    let extensions = runtime_ctx.shared_get::<Arc<ModuleRuntimeExtensions>>();
+    let authority = runtime_ctx
+        .shared_get::<SharedCommentsTcpAuthorityResolver>()
+        .or_else(|| {
+            extensions.as_ref().and_then(|values| {
+                values
+                    .get::<SharedCommentsTcpAuthorityResolver>()
+                    .cloned()
+            })
+        })
+        .ok_or_else(|| {
+            Error::BadRequest(
+                "Comments TCP listener requires a host-provided SharedCommentsTcpAuthorityResolver"
+                    .to_string(),
+            )
+        })?
+        .0;
+
+    let provider = runtime_ctx
+        .shared_get::<SharedCommentsTcpServerProvider>()
+        .or_else(|| {
+            extensions.as_ref().and_then(|values| {
+                values
+                    .get::<SharedCommentsTcpServerProvider>()
+                    .cloned()
+            })
+        })
+        .map(|shared| shared.0)
+        .unwrap_or_else(|| {
+            in_process_comments_thread_port(
+                runtime_ctx.db_clone(),
+                transactional_event_bus_from_context(runtime_ctx),
+            )
+        });
+
+    let adapter = TcpJsonCommentsServerAdapter::with_max_frame_bytes(
+        provider,
+        authority,
+        config.max_frame_bytes,
+    )
+    .map_err(|error| {
+        Error::BadRequest(format!(
+            "Comments TCP server adapter configuration failed with {} ({:?})",
+            error.code, error.kind
+        ))
+    })?;
+
+    let listener = TcpListener::bind(config.bind_addr).await.map_err(|error| {
+        Error::Message(format!(
+            "failed to bind Comments TCP listener at {}: {error}",
+            config.bind_addr
+        ))
+    })?;
+    let local_addr = listener.local_addr().map_err(|error| {
+        Error::Message(format!(
+            "failed to read Comments TCP listener address after bind: {error}"
+        ))
+    })?;
+
+    let stop_handle = ensure_stop_handle(runtime_ctx);
+    let stop_rx = stop_handle.subscribe();
+    let instance_id = COMMENTS_TCP_LISTENER_INSTANCE_IDS.fetch_add(1, Ordering::Relaxed);
+    tokio::spawn(run_comments_tcp_listener(
+        listener,
+        adapter,
+        config,
+        stop_rx,
+        instance_id,
+    ));
+    runtime_ctx.shared_insert(CommentsTcpListenerHandle {
+        instance_id,
+        local_addr,
+    });
+
+    tracing::info!(
+        instance_id,
+        bind_addr = %local_addr,
+        max_connections = config.max_connections,
+        pre_request_timeout_ms = config.pre_request_timeout.as_millis(),
+        shutdown_grace_ms = config.shutdown_grace.as_millis(),
+        max_frame_bytes = config.max_frame_bytes,
+        "Comments TCP listener started"
+    );
+    Ok(())
+}
+
+fn ensure_stop_handle(runtime_ctx: &ServerRuntimeContext) -> StopHandle {
+    if let Some(handle) = runtime_ctx.shared_get::<StopHandle>() {
+        return handle;
+    }
+
+    let (candidate, _receiver) = StopHandle::new();
+    let _ = runtime_ctx.shared_insert_if_absent(candidate.clone());
+    runtime_ctx
+        .shared_get::<StopHandle>()
+        .expect("StopHandle must exist after Comments TCP listener initialization")
+}
+
+async fn run_comments_tcp_listener(
+    listener: TcpListener,
+    adapter: TcpJsonCommentsServerAdapter,
+    config: CommentsTcpListenerConfig,
+    mut stop_rx: tokio::sync::watch::Receiver<bool>,
+    instance_id: u64,
+) {
+    let permits = Arc::new(Semaphore::new(config.max_connections));
+    let mut connections = JoinSet::new();
+
+    loop {
+        if *stop_rx.borrow() {
+            break;
+        }
+
+        tokio::select! {
+            changed = stop_rx.changed() => {
+                if changed.is_err() || *stop_rx.borrow() {
+                    break;
+                }
+            }
+            accepted = listener.accept() => {
+                let (stream, peer_addr) = match accepted {
+                    Ok(value) => value,
+                    Err(error) => {
+                        tracing::warn!(instance_id, error = %error, "Comments TCP accept failed");
+                        continue;
+                    }
+                };
+                if !peer_addr.ip().is_loopback() {
+                    tracing::warn!(instance_id, peer_addr = %peer_addr, "Rejected non-loopback Comments TCP peer");
+                    drop(stream);
+                    continue;
+                }
+                let permit = match permits.clone().try_acquire_owned() {
+                    Ok(permit) => permit,
+                    Err(_) => {
+                        tracing::warn!(instance_id, peer_addr = %peer_addr, max_connections = config.max_connections, "Rejected Comments TCP connection at concurrency limit");
+                        drop(stream);
+                        continue;
+                    }
+                };
+                let adapter = adapter.clone();
+                let pre_request_timeout = config.pre_request_timeout;
+                connections.spawn(async move {
+                    let _permit = permit;
+                    if let Err(error) = adapter
+                        .handle_connection_with_pre_request_timeout(
+                            stream,
+                            peer_addr,
+                            pre_request_timeout,
+                        )
+                        .await
+                    {
+                        tracing::warn!(
+                            peer_addr = %peer_addr,
+                            code = %error.code,
+                            kind = ?error.kind,
+                            retryable = error.retryable,
+                            "Comments TCP connection failed closed"
+                        );
+                    }
+                });
+            }
+            Some(result) = connections.join_next(), if !connections.is_empty() => {
+                log_connection_join(instance_id, result);
+            }
+        }
+    }
+
+    drop(listener);
+    tracing::info!(
+        instance_id,
+        active_connections = connections.len(),
+        "Comments TCP listener stopped accepting connections"
+    );
+
+    let drain_result = timeout(config.shutdown_grace, async {
+        while let Some(result) = connections.join_next().await {
+            log_connection_join(instance_id, result);
+        }
+    })
+    .await;
+
+    if drain_result.is_err() {
+        let aborted_connections = connections.len();
+        connections.abort_all();
+        while let Some(result) = connections.join_next().await {
+            log_connection_join(instance_id, result);
+        }
+        tracing::warn!(
+            instance_id,
+            aborted_connections,
+            "Comments TCP listener shutdown grace elapsed; remaining connections were aborted"
+        );
+    } else {
+        tracing::info!(instance_id, "Comments TCP listener drained all connections");
+    }
+}
+
+fn log_connection_join(instance_id: u64, result: std::result::Result<(), JoinError>) {
+    if let Err(error) = result {
+        tracing::warn!(
+            instance_id,
+            cancelled = error.is_cancelled(),
+            panicked = error.is_panic(),
+            "Comments TCP connection task ended unexpectedly"
+        );
+    }
+}
+
+fn read_optional_environment(key: &'static str) -> std::result::Result<Option<String>, String> {
+    match env::var(key) {
+        Ok(value) => Ok(Some(value)),
+        Err(env::VarError::NotPresent) => Ok(None),
+        Err(env::VarError::NotUnicode(_)) => Err(format!("{key} must contain valid UTF-8")),
+    }
+}
+
+fn parse_bool_value(key: &'static str, value: &str) -> std::result::Result<bool, String> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        _ => Err(format!(
+            "{key} must be one of: true, false, 1, 0, yes, no, on, off"
+        )),
+    }
+}
+
+fn parse_optional_positive_usize(
+    key: &'static str,
+    default: usize,
+) -> std::result::Result<usize, String> {
+    match read_optional_environment(key)? {
+        Some(value) => parse_positive_usize_value(key, &value),
+        None => Ok(default),
+    }
+}
+
+fn parse_optional_positive_u64(
+    key: &'static str,
+    default: u64,
+) -> std::result::Result<u64, String> {
+    match read_optional_environment(key)? {
+        Some(value) => parse_positive_u64_value(key, &value),
+        None => Ok(default),
+    }
+}
+
+fn parse_positive_usize_value(
+    key: &'static str,
+    value: &str,
+) -> std::result::Result<usize, String> {
+    let parsed = value
+        .trim()
+        .parse::<usize>()
+        .map_err(|_| format!("{key} must be a positive integer"))?;
+    if parsed == 0 {
+        return Err(format!("{key} must be greater than zero"));
+    }
+    Ok(parsed)
+}
+
+fn parse_positive_u64_value(
+    key: &'static str,
+    value: &str,
+) -> std::result::Result<u64, String> {
+    let parsed = value
+        .trim()
+        .parse::<u64>()
+        .map_err(|_| format!("{key} must be a positive integer"))?;
+    if parsed == 0 {
+        return Err(format!("{key} must be greater than zero"));
+    }
+    Ok(parsed)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn selector_contract_exposes_profiles_and_environment_keys() {
-        let selector: fn(&mut ModuleRuntimeExtensions) -> Result<(), String> =
+        let selector: fn(&mut ModuleRuntimeExtensions) -> std::result::Result<(), String> =
             register_comments_provider_runtime;
         let _ = selector;
         assert_eq!(COMMENTS_PROVIDER_MODE_ENV, "RUSTOK_COMMENTS_PROVIDER_MODE");
         assert_eq!(COMMENTS_TCP_ENDPOINT_ENV, "RUSTOK_COMMENTS_TCP_ENDPOINT");
+    }
+
+    #[test]
+    fn listener_contract_exposes_bounded_defaults() {
+        let starter = start_comments_tcp_listener_if_enabled;
+        let _ = starter;
+        assert_eq!(DEFAULT_COMMENTS_TCP_MAX_CONNECTIONS, 64);
+        assert_eq!(DEFAULT_COMMENTS_TCP_PRE_REQUEST_TIMEOUT_MS, 2_000);
+        assert_eq!(DEFAULT_COMMENTS_TCP_SHUTDOWN_GRACE_MS, 5_000);
+        assert_eq!(DEFAULT_COMMENTS_TCP_MAX_FRAME_BYTES, 8 * 1024 * 1024);
+        assert!(parse_bool_value("enabled", "true").unwrap());
+        assert!(!parse_bool_value("enabled", "off").unwrap());
+        assert!(parse_positive_usize_value("limit", "0").is_err());
+        assert!(parse_positive_u64_value("timeout", "0").is_err());
     }
 }

--- a/apps/server/src/services/comments_provider_runtime.rs
+++ b/apps/server/src/services/comments_provider_runtime.rs
@@ -81,7 +81,7 @@ pub struct CommentsTcpListenerConfig {
 }
 
 impl CommentsTcpListenerConfig {
-    pub fn from_environment() -> Result<Option<Self>, String> {
+    pub fn from_environment() -> std::result::Result<Option<Self>, String> {
         let enabled = match read_optional_environment(COMMENTS_TCP_LISTENER_ENABLED_ENV)? {
             Some(value) => parse_bool_value(COMMENTS_TCP_LISTENER_ENABLED_ENV, &value)?,
             None => false,

--- a/apps/server/src/services/server_bootstrap.rs
+++ b/apps/server/src/services/server_bootstrap.rs
@@ -130,6 +130,12 @@ pub async fn bootstrap_application_router(
         bootstrap_app_runtime(runtime_ctx.clone(), auth_config.clone(), &rustok_settings).await?;
     tracing::info!("RusTok app runtime bootstrap completed");
 
+    #[cfg(feature = "mod-comments")]
+    crate::services::comments_provider_runtime::start_comments_tcp_listener_if_enabled(
+        &runtime_ctx,
+    )
+    .await?;
+
     crate::services::event_dlq_duplicate_alert_observer::start_event_dlq_duplicate_alert_observer(
         &runtime_ctx,
     )

--- a/crates/rustok-blog/contracts/evidence/blog-comments-tcp-listener-lifecycle.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-tcp-listener-lifecycle.json
@@ -1,0 +1,122 @@
+{
+  "schema_version": 1,
+  "module": "blog",
+  "provider": "comments",
+  "surface": "comments_tcp_listener_lifecycle",
+  "status": "source_verified_no_compile",
+  "compile_policy": "not_run_by_request",
+  "runtime_status": "not_run",
+  "generated_from": "crates/rustok-blog/docs/implementation-plan-slice-71.md",
+  "source_contract": {
+    "host_runtime": "apps/server/src/services/comments_provider_runtime.rs",
+    "bootstrap": "apps/server/src/services/server_bootstrap.rs",
+    "server_adapter": "crates/rustok-comments/src/tcp_server.rs",
+    "provider_factory": "rustok_comments::in_process_comments_thread_port",
+    "authority_trait": "rustok_comments::CommentsTcpAuthorityResolver",
+    "stop_handle": "apps/server/src/services/app_lifecycle.rs"
+  },
+  "configuration": {
+    "enabled_environment": "RUSTOK_COMMENTS_TCP_LISTENER_ENABLED",
+    "default_enabled": false,
+    "bind_environment": "RUSTOK_COMMENTS_TCP_BIND",
+    "bind_format": "explicit_ip_socket_address",
+    "loopback_required": true,
+    "non_zero_port_required": true,
+    "max_connections_environment": "RUSTOK_COMMENTS_TCP_MAX_CONNECTIONS",
+    "default_max_connections": 64,
+    "pre_request_timeout_environment": "RUSTOK_COMMENTS_TCP_PRE_REQUEST_TIMEOUT_MS",
+    "default_pre_request_timeout_ms": 2000,
+    "shutdown_grace_environment": "RUSTOK_COMMENTS_TCP_SHUTDOWN_GRACE_MS",
+    "default_shutdown_grace_ms": 5000,
+    "max_frame_environment": "RUSTOK_COMMENTS_TCP_MAX_FRAME_BYTES",
+    "default_max_frame_bytes": 8388608,
+    "max_frame_wire_limit": "u32_max",
+    "positive_numeric_values_required": true,
+    "non_utf8_values_rejected": true
+  },
+  "authority": {
+    "required_wrapper": "SharedCommentsTcpAuthorityResolver",
+    "runtime_context_supported": true,
+    "module_runtime_extensions_supported": true,
+    "allow_all_fallback": false,
+    "payload_principal_trusted": false,
+    "built_in_credentials": false,
+    "built_in_mtls": false,
+    "listener_start_without_authority": false
+  },
+  "provider": {
+    "override_wrapper": "SharedCommentsTcpServerProvider",
+    "consumer_port_reused_as_server_provider": false,
+    "default_provider": "owner_managed_in_process",
+    "default_provider_inputs": [
+      "server_database",
+      "transactional_event_bus"
+    ]
+  },
+  "lifecycle": {
+    "opt_in": true,
+    "startup_hook": "bootstrap_application_router",
+    "startup_after_app_runtime": true,
+    "startup_before_remaining_workers": true,
+    "idempotent_reservation": true,
+    "reservation_released_on_startup_failure": true,
+    "listener": "tokio::net::TcpListener",
+    "accepted_peer_loopback_recheck": true,
+    "bounded_concurrency": "tokio::sync::Semaphore",
+    "over_capacity_behavior": "reject_and_close",
+    "connection_tasks": "tokio::task::JoinSet",
+    "shared_shutdown_signal": "StopHandle",
+    "stop_accepting_before_drain": true,
+    "bounded_drain": true,
+    "abort_after_grace": true
+  },
+  "connection": {
+    "one_request_per_connection": true,
+    "pre_request_timeout_method": "TcpJsonCommentsServerAdapter::handle_connection_with_pre_request_timeout",
+    "pre_request_timeout_code": "comments.tcp_server_idle_timeout",
+    "invalid_pre_request_timeout_code": "comments.tcp_server_invalid_idle_timeout",
+    "request_deadline_retained_after_decode": true,
+    "provider_error_message_logged": false,
+    "provider_error_shape_logged": [
+      "code",
+      "kind",
+      "retryable"
+    ]
+  },
+  "fail_closed": {
+    "missing_bind_rejected": true,
+    "invalid_bind_rejected": true,
+    "non_loopback_bind_rejected": true,
+    "zero_port_rejected": true,
+    "invalid_boolean_rejected": true,
+    "zero_limits_rejected": true,
+    "oversized_frame_limit_rejected": true,
+    "missing_authority_rejected": true,
+    "non_serving_host_mode_rejected": true,
+    "non_loopback_peer_rejected": true,
+    "over_capacity_connection_rejected": true
+  },
+  "pending": [
+    "credential_envelope_or_mtls_identity",
+    "concrete_authenticated_authority_resolver",
+    "transport_encryption",
+    "non_loopback_remote_publication",
+    "service_discovery",
+    "startup_connection_probe",
+    "listener_readiness_and_health",
+    "retry_backoff",
+    "in_process_tcp_runtime_parity",
+    "runtime_execution"
+  ],
+  "explicit_non_claims": [
+    "no_compile_result",
+    "no_rust_test_result",
+    "no_javascript_verifier_result",
+    "no_tcp_runtime_result",
+    "no_database_result",
+    "no_browser_result",
+    "no_workflow_result",
+    "no_ci_result",
+    "no_production_result"
+  ]
+}

--- a/crates/rustok-blog/docs/implementation-plan-slice-71.md
+++ b/crates/rustok-blog/docs/implementation-plan-slice-71.md
@@ -1,0 +1,137 @@
+# rustok-blog implementation plan — slice 71 continuation
+
+This document continues
+`crates/rustok-blog/docs/implementation-plan-slice-70.md`. Slices 1–66 remain in
+the original plan; slices 67–70 retain the typed remote core, TCP client,
+trusted accepted-stream adapter, and host-selected consumer publication.
+
+## 2026-08-01 continuation audit
+
+Slice 70 was rechecked against current `main` at
+`0eb3b47eef939b93ebbe753a0be1ea8eeff6dcc2`. Default in-process fallback,
+explicit loopback-only TCP selection, preservation of preconfigured consumer
+ports, shared host publication, source evidence, and runtime non-claims remain
+present.
+
+No compile, Rust or JavaScript test, TCP exchange, database, browser, workflow,
+CI, production, or runtime result is promoted by this continuation. Execution
+remains maintainer-owned.
+
+## Slice 71 — host-owned Comments TCP listener lifecycle
+
+### Implemented source scope
+
+- `apps/server/src/services/comments_provider_runtime.rs` now owns the opt-in
+  provider-side listener lifecycle in addition to the consumer selector.
+- `RUSTOK_COMMENTS_TCP_LISTENER_ENABLED` defaults to false. Disabled listener
+  configuration performs no bind and preserves the existing process behavior.
+- An enabled listener requires `RUSTOK_COMMENTS_TCP_BIND` as an explicit,
+  non-zero, loopback IP socket address. Plaintext non-loopback bind fails startup
+  configuration closed.
+- Bounded listener settings are published through:
+  - `RUSTOK_COMMENTS_TCP_MAX_CONNECTIONS` (default 64);
+  - `RUSTOK_COMMENTS_TCP_PRE_REQUEST_TIMEOUT_MS` (default 2000);
+  - `RUSTOK_COMMENTS_TCP_SHUTDOWN_GRACE_MS` (default 5000);
+  - `RUSTOK_COMMENTS_TCP_MAX_FRAME_BYTES` (default 8 MiB and bounded by the
+    `u32` wire limit).
+- Zero, malformed, non-UTF-8, oversized, missing-required, or unsupported host
+  configuration fails startup rather than silently changing mode.
+- `SharedCommentsTcpAuthorityResolver` is mandatory when the listener is enabled.
+  It may be supplied through `ServerRuntimeContext` or `ModuleRuntimeExtensions`.
+  There is no loopback-only allow-all resolver and no fallback that trusts actor,
+  claims, roles, or tenant authority from the request payload.
+- `SharedCommentsTcpServerProvider` is a distinct provider-side override. It is
+  intentionally separate from the consumer-selected `Arc<dyn CommentsThreadPort>`
+  so a TCP client cannot be served recursively through itself.
+- Without a provider-side override, the host composes the owner-managed in-process
+  Comments provider from the server database and transactional event bus.
+- The listener uses `TcpJsonCommentsServerAdapter` with the configured frame bound.
+- A semaphore rejects connections beyond the configured active-connection limit;
+  rejected sockets are closed without provider dispatch.
+- Accepted peers are rechecked as loopback before a connection task is spawned.
+- `TcpJsonCommentsServerAdapter::handle_connection_with_pre_request_timeout`
+  bounds receipt of the complete first request frame and returns
+  `comments.tcp_server_idle_timeout` when the peer remains idle.
+- After request decode, the request-owned `PortContext` deadline still bounds
+  authority resolution and provider dispatch.
+- The listener subscribes to the shared server `StopHandle`. Shutdown stops new
+  accepts, drains active connection tasks within the configured grace period,
+  then aborts only the tasks that remain.
+- A lifecycle reservation makes repeated startup calls idempotent and is released
+  when configuration, authority resolution, adapter construction, or bind fails.
+- `apps/server/src/services/server_bootstrap.rs` starts the listener after app
+  runtime composition and before the remaining worker startup path.
+- Source evidence is retained at
+  `crates/rustok-blog/contracts/evidence/blog-comments-tcp-listener-lifecycle.json`.
+- The standalone fail-closed verifier is
+  `scripts/verify/verify-blog-comments-tcp-listener-lifecycle.mjs`.
+
+### Explicit non-claims
+
+This slice does not implement or claim:
+
+- a built-in credential, shared-token, certificate, or mTLS authority resolver;
+- a wire credential envelope or encrypted transport;
+- non-loopback bind, endpoint discovery, or multi-host publication;
+- startup connection probing, listener readiness integration, or provider health
+  reporting;
+- retry/backoff, circuit breaking, or replay policy;
+- in-process/TCP parity execution;
+- successful compile, Rust test, JavaScript verifier, TCP runtime, database,
+  browser, workflow, CI, or production execution.
+
+The listener cannot start successfully until the host supplies a concrete
+`SharedCommentsTcpAuthorityResolver`. This is deliberate: the current wire
+protocol carries no credential, so manufacturing a permissive resolver would
+create a false authentication claim.
+
+Status: `source_verified_no_compile`.
+Compile policy: `not_run_by_request`.
+Runtime status: `not_run`.
+
+## Next implementation results
+
+1. Add an authenticated credential envelope or mTLS identity integration and a
+   concrete authority resolver. Preserve exact tenant matching and principal-field
+   replacement before provider dispatch.
+2. Replace loopback-only plaintext constraints with authenticated encryption
+   before allowing non-loopback endpoints.
+3. Add bounded retry/backoff only for retryable client failures. Writes must never
+   be replayed without the existing idempotency key, and the original deadline
+   must bound the complete attempt set.
+4. Add in-process/TCP parity fixtures for all seven operations, selection and
+   listener modes, authority denial, tenant mismatch, malformed requests,
+   oversized frames, concurrency rejection, idle peers, disconnects, shutdown,
+   and exact provider errors.
+5. Add listener health/readiness state only after runtime execution establishes
+   bind, drain, and provider behavior.
+6. Run and record retained Rust, JavaScript, TCP, PostgreSQL, browser, workflow,
+   and CI targets before promoting evidence beyond source-only status.
+7. Continue cached thread snapshot and comment-form fallback work after the
+   remote path has observed runtime evidence.
+
+## Suggested verification — intentionally not run in this slice
+
+- `node scripts/verify/verify-blog-comments-tcp-listener-lifecycle.mjs`
+- `node scripts/verify/verify-blog-comments-host-provider-selection.mjs`
+- `node scripts/verify/verify-blog-comments-tcp-server-adapter.mjs`
+- `cargo test -p rustok-comments --features tcp-transport --lib tcp_server::tests`
+- `cargo test -p rustok-server --features mod-blog --lib comments_provider_runtime::tests`
+- `cargo check -p rustok-server --features mod-blog`
+- `npm run verify:blog:comments-port-boundary`
+- `npm run test:verify:blog:comments-port-boundary`
+
+## Boundaries retained
+
+- Comments owns storage, moderation lifecycle, public projection, typed remote
+  requests/replies, provider dispatch, framing, and connection adapter behavior.
+- Blog owns consumer policy, article rendering, degraded presentation, and
+  transport-neutral `Arc<dyn CommentsThreadPort>` consumption.
+- The server host owns listener configuration and lifecycle, provider-side
+  composition, trusted authority supply, endpoint policy, transport protection,
+  concurrency, and shutdown.
+- Disabled listener configuration must preserve existing behavior. Invalid or
+  incomplete explicit listener configuration must fail startup rather than fall
+  back to unauthenticated service.
+- Source-only evidence remains explicit until the maintainer runs and records the
+  corresponding execution targets.

--- a/crates/rustok-comments/src/tcp_server.rs
+++ b/crates/rustok-comments/src/tcp_server.rs
@@ -116,14 +116,47 @@ impl TcpJsonCommentsServerAdapter {
     /// Handles exactly one request/reply exchange on an accepted stream.
     pub async fn handle_connection(
         &self,
+        stream: TcpStream,
+        peer_addr: SocketAddr,
+    ) -> Result<(), PortError> {
+        self.handle_connection_inner(stream, peer_addr, None).await
+    }
+
+    /// Handles one exchange while bounding how long an accepted peer may remain
+    /// idle before sending the complete first request frame.
+    ///
+    /// The request's own `PortContext` deadline continues to bound trusted
+    /// authority resolution and provider dispatch after the frame is decoded.
+    pub async fn handle_connection_with_pre_request_timeout(
+        &self,
+        stream: TcpStream,
+        peer_addr: SocketAddr,
+        pre_request_timeout: Duration,
+    ) -> Result<(), PortError> {
+        if pre_request_timeout.is_zero() {
+            return Err(PortError::validation(
+                "comments.tcp_server_invalid_idle_timeout",
+                "comments TCP pre-request timeout must be greater than zero",
+            ));
+        }
+        self.handle_connection_inner(stream, peer_addr, Some(pre_request_timeout))
+            .await
+    }
+
+    async fn handle_connection_inner(
+        &self,
         mut stream: TcpStream,
         peer_addr: SocketAddr,
+        pre_request_timeout: Option<Duration>,
     ) -> Result<(), PortError> {
         stream
             .set_nodelay(true)
             .map_err(|error| io_error("server_set_nodelay", error))?;
 
-        let reply = match self.read_authorize_and_dispatch(&mut stream, peer_addr).await {
+        let reply = match self
+            .read_authorize_and_dispatch(&mut stream, peer_addr, pre_request_timeout)
+            .await
+        {
             Ok(response) => CommentsThreadTransportReply::Success(response),
             Err(error) => CommentsThreadTransportReply::Error(error),
         };
@@ -140,8 +173,19 @@ impl TcpJsonCommentsServerAdapter {
         &self,
         stream: &mut TcpStream,
         peer_addr: SocketAddr,
+        pre_request_timeout: Option<Duration>,
     ) -> Result<CommentsThreadResponse, PortError> {
-        let request_payload = read_frame(stream, self.max_frame_bytes).await?;
+        let request_payload = match pre_request_timeout {
+            Some(duration) => timeout(duration, read_frame(stream, self.max_frame_bytes))
+                .await
+                .map_err(|_| {
+                    PortError::timeout(
+                        "comments.tcp_server_idle_timeout",
+                        "comments TCP peer did not send a complete request frame before the idle timeout",
+                    )
+                })??,
+            None => read_frame(stream, self.max_frame_bytes).await?,
+        };
         let mut request = serde_json::from_slice::<CommentsThreadRequest>(&request_payload)
             .map_err(|_| {
                 PortError::validation(
@@ -356,5 +400,11 @@ mod tests {
 
         assert_eq!(error.kind, PortErrorKind::Forbidden);
         assert_eq!(error.code, "comments.tcp_authority_tenant_mismatch");
+    }
+
+    #[test]
+    fn pre_request_timeout_api_is_source_visible() {
+        let handler = TcpJsonCommentsServerAdapter::handle_connection_with_pre_request_timeout;
+        let _ = handler;
     }
 }

--- a/scripts/verify/verify-blog-comments-tcp-listener-lifecycle.mjs
+++ b/scripts/verify/verify-blog-comments-tcp-listener-lifecycle.mjs
@@ -157,7 +157,7 @@ for (const fragment of [
   'comments.tcp_server_idle_timeout',
   'timeout(duration, read_frame(stream, self.max_frame_bytes))',
   'request.context().require_deadline_semantics()',
-  '.authority\n                .authorize(peer_addr, operation, request.context())',
+  '.authorize(peer_addr, operation, request.context())',
 ]) {
   requireText(adapter, fragment, adapterPath);
 }

--- a/scripts/verify/verify-blog-comments-tcp-listener-lifecycle.mjs
+++ b/scripts/verify/verify-blog-comments-tcp-listener-lifecycle.mjs
@@ -1,0 +1,180 @@
+import fs from 'node:fs';
+
+const evidencePath =
+  'crates/rustok-blog/contracts/evidence/blog-comments-tcp-listener-lifecycle.json';
+const planPath = 'crates/rustok-blog/docs/implementation-plan-slice-71.md';
+const runtimePath = 'apps/server/src/services/comments_provider_runtime.rs';
+const bootstrapPath = 'apps/server/src/services/server_bootstrap.rs';
+const adapterPath = 'crates/rustok-comments/src/tcp_server.rs';
+
+function read(path) {
+  return fs.readFileSync(path, 'utf8');
+}
+
+function requireCondition(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function requireText(source, fragment, path) {
+  requireCondition(
+    source.includes(fragment),
+    `${path} must retain source fragment: ${fragment}`,
+  );
+}
+
+const evidence = JSON.parse(read(evidencePath));
+const plan = read(planPath);
+const runtime = read(runtimePath);
+const bootstrap = read(bootstrapPath);
+const adapter = read(adapterPath);
+
+requireCondition(evidence.schema_version === 1, 'evidence schema must remain version 1');
+requireCondition(
+  evidence.surface === 'comments_tcp_listener_lifecycle',
+  'evidence surface must identify the Comments TCP listener lifecycle',
+);
+requireCondition(
+  evidence.status === 'source_verified_no_compile',
+  'evidence must remain source-only',
+);
+requireCondition(
+  evidence.compile_policy === 'not_run_by_request',
+  'compile policy must record that execution was not requested',
+);
+requireCondition(
+  evidence.runtime_status === 'not_run',
+  'runtime status must remain not_run',
+);
+requireCondition(
+  evidence.configuration.default_enabled === false,
+  'listener must remain disabled by default',
+);
+requireCondition(
+  evidence.configuration.loopback_required === true,
+  'plaintext listener must remain loopback-only',
+);
+requireCondition(
+  evidence.configuration.default_max_connections === 64,
+  'default connection bound must remain 64',
+);
+requireCondition(
+  evidence.configuration.default_pre_request_timeout_ms === 2000,
+  'default pre-request timeout must remain 2000 ms',
+);
+requireCondition(
+  evidence.configuration.default_shutdown_grace_ms === 5000,
+  'default shutdown grace must remain 5000 ms',
+);
+requireCondition(
+  evidence.configuration.default_max_frame_bytes === 8388608,
+  'default frame bound must remain 8 MiB',
+);
+requireCondition(
+  evidence.authority.allow_all_fallback === false,
+  'authority must not gain an allow-all fallback',
+);
+requireCondition(
+  evidence.authority.listener_start_without_authority === false,
+  'listener must not start without host authority',
+);
+requireCondition(
+  evidence.provider.consumer_port_reused_as_server_provider === false,
+  'consumer-selected TCP port must remain separate from server provider selection',
+);
+requireCondition(
+  evidence.lifecycle.bounded_concurrency === 'tokio::sync::Semaphore',
+  'listener concurrency must remain semaphore bounded',
+);
+requireCondition(
+  evidence.lifecycle.shared_shutdown_signal === 'StopHandle',
+  'listener must remain attached to the shared StopHandle',
+);
+requireCondition(
+  evidence.lifecycle.abort_after_grace === true,
+  'shutdown must remain bounded by a grace period',
+);
+requireCondition(
+  evidence.connection.pre_request_timeout_code ===
+    'comments.tcp_server_idle_timeout',
+  'pre-request timeout code must remain stable',
+);
+
+for (const fragment of [
+  'RUSTOK_COMMENTS_TCP_LISTENER_ENABLED',
+  'RUSTOK_COMMENTS_TCP_BIND',
+  'RUSTOK_COMMENTS_TCP_MAX_CONNECTIONS',
+  'RUSTOK_COMMENTS_TCP_PRE_REQUEST_TIMEOUT_MS',
+  'RUSTOK_COMMENTS_TCP_SHUTDOWN_GRACE_MS',
+  'RUSTOK_COMMENTS_TCP_MAX_FRAME_BYTES',
+  'DEFAULT_COMMENTS_TCP_MAX_CONNECTIONS: usize = 64',
+  'DEFAULT_COMMENTS_TCP_PRE_REQUEST_TIMEOUT_MS: u64 = 2_000',
+  'DEFAULT_COMMENTS_TCP_SHUTDOWN_GRACE_MS: u64 = 5_000',
+  'DEFAULT_COMMENTS_TCP_MAX_FRAME_BYTES: usize = 8 * 1024 * 1024',
+  'pub struct SharedCommentsTcpAuthorityResolver',
+  'pub struct SharedCommentsTcpServerProvider',
+  'pub struct CommentsTcpListenerConfig',
+  'pub struct CommentsTcpListenerHandle',
+  'CommentsTcpListenerLifecycleReservation',
+  'bind_addr.ip().is_loopback()',
+  'bind_addr.port() == 0',
+  'max_frame_bytes > u32::MAX as usize',
+  'runtime.is_registry_only()',
+  'runtime.is_worker_only()',
+  'SharedCommentsTcpAuthorityResolver',
+  'in_process_comments_thread_port(',
+  'TcpJsonCommentsServerAdapter::with_max_frame_bytes(',
+  'TcpListener::bind(config.bind_addr)',
+  'Semaphore::new(config.max_connections)',
+  'try_acquire_owned()',
+  'JoinSet::new()',
+  'peer_addr.ip().is_loopback()',
+  'handle_connection_with_pre_request_timeout(',
+  'StopHandle::new()',
+  'stop_handle.subscribe()',
+  'timeout(config.shutdown_grace',
+  'connections.abort_all()',
+  'code = %error.code',
+  'kind = ?error.kind',
+  'retryable = error.retryable',
+]) {
+  requireText(runtime, fragment, runtimePath);
+}
+
+requireCondition(
+  !runtime.includes('struct AllowAllCommentsTcpAuthority'),
+  'runtime must not introduce an allow-all Comments authority resolver',
+);
+requireCondition(
+  !runtime.includes('TrustedCommentsTcpAuthority::new('),
+  'host listener runtime must not manufacture trusted authority from the payload',
+);
+
+for (const fragment of [
+  'handle_connection_with_pre_request_timeout',
+  'comments.tcp_server_invalid_idle_timeout',
+  'comments.tcp_server_idle_timeout',
+  'timeout(duration, read_frame(stream, self.max_frame_bytes))',
+  'request.context().require_deadline_semantics()',
+  '.authority\n                .authorize(peer_addr, operation, request.context())',
+]) {
+  requireText(adapter, fragment, adapterPath);
+}
+
+requireText(
+  bootstrap,
+  'start_comments_tcp_listener_if_enabled(',
+  bootstrapPath,
+);
+requireText(
+  bootstrap,
+  'bootstrap_app_runtime(runtime_ctx.clone(), auth_config.clone(), &rustok_settings).await?',
+  bootstrapPath,
+);
+requireText(plan, '## Slice 71 — host-owned Comments TCP listener lifecycle', planPath);
+requireText(plan, 'Status: `source_verified_no_compile`.', planPath);
+requireText(plan, 'concrete authenticated authority resolver', planPath);
+requireText(plan, 'intentionally not run in this slice', planPath);
+
+console.log('Blog Comments TCP listener lifecycle source contract is retained.');


### PR DESCRIPTION
## Summary

- continue the Blog improvement plan with slice 71
- add an opt-in host-owned Comments TCP listener lifecycle
- require an explicit non-zero loopback bind while the transport remains plaintext
- keep the listener disabled by default
- require a host-provided `SharedCommentsTcpAuthorityResolver`; there is no allow-all fallback
- keep provider-side selection separate from the consumer-selected Comments port to prevent recursive TCP composition
- default the server side to the owner-managed in-process Comments provider
- bound active connections with a semaphore and reject overload before provider dispatch
- add a pre-request idle timeout for receiving the complete first request frame
- reuse the request-owned deadline for authority resolution and provider dispatch
- attach listener shutdown to the shared `StopHandle`
- stop accepting before draining connections, then abort only after the configured shutdown grace
- wire listener startup into the canonical server bootstrap
- add slice-71 source evidence and a standalone fail-closed verifier

## Configuration

- `RUSTOK_COMMENTS_TCP_LISTENER_ENABLED` — default `false`
- `RUSTOK_COMMENTS_TCP_BIND` — required explicit loopback socket address when enabled
- `RUSTOK_COMMENTS_TCP_MAX_CONNECTIONS` — default `64`
- `RUSTOK_COMMENTS_TCP_PRE_REQUEST_TIMEOUT_MS` — default `2000`
- `RUSTOK_COMMENTS_TCP_SHUTDOWN_GRACE_MS` — default `5000`
- `RUSTOK_COMMENTS_TCP_MAX_FRAME_BYTES` — default `8388608`

## Scope intentionally left pending

- a credential envelope, shared-token protocol, certificate identity, or mTLS resolver
- transport encryption and non-loopback publication
- service discovery
- startup connection probing and listener readiness/health integration
- retry/backoff and circuit breaking
- in-process/TCP runtime parity
- cached thread snapshot and comment-form fallback

The listener cannot start successfully until the host supplies a concrete authority resolver. This is deliberate because the current wire protocol carries no credential and a permissive built-in resolver would create a false authentication claim.

## Verification

Tests, source verifiers, formatting, Cargo checks, TCP runtime targets, database targets, browser targets, workflows, and CI were intentionally not run by request. Suggested maintainer commands are recorded in `crates/rustok-blog/docs/implementation-plan-slice-71.md`.