### PR TITLE
test(forum): add deletion ACL ordering proof

### DIFF
--- a/apps/server/tests/forum_versioned_invalidation_deletion_acl_ordering.rs
+++ b/apps/server/tests/forum_versioned_invalidation_deletion_acl_ordering.rs
@@ -1,0 +1,1293 @@
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::io::{Error as IoError, ErrorKind};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use rustok_api::{PortError, RequestContext};
+use rustok_core::{MigrationSource, SecurityContext, UserRole};
+use rustok_events::{
+    ContractEventEnvelope, DomainEvent, EventEnvelope, ForumSearchProjectionEvent,
+};
+use rustok_forum::{
+    CategoryService, CreateCategoryInput, CreateReplyInput, CreateTopicInput,
+    ForumAudienceConstraints, ForumModule, ForumSearchProjectionSourceFactory,
+    ForumSearchResultCandidate, ForumSearchResultCandidateKind,
+    ForumSearchResultEligibilityService, ForumTopicAudiencePolicyService, ModerationService,
+    ReplyService, SetForumTopicAudiencePolicyInput, TopicService,
+};
+use rustok_outbox::{OutboxModule, OutboxTransport, TransactionalEventBus};
+use rustok_search::{
+    ForumProjectionReconciler, ForumSearchContractIngress,
+    ForumSearchContractIngressOutcome, ForumStorefrontSearchAttributeFilter,
+    ForumStorefrontSearchRequest, SearchModule, SearchProjectionSourceFactory,
+    SharedStorefrontSearchCategoryScopePort, SharedStorefrontSearchResultEligibilityPort,
+    StorefrontSearchCategoryScopePort, StorefrontSearchCategoryScopeRequest,
+    StorefrontSearchResultCandidate, StorefrontSearchResultCandidateKind,
+    StorefrontSearchResultEligibilityPort, StorefrontSearchResultEligibilityRequest,
+    StorefrontSearchTransport, execute_forum_storefront_search,
+};
+use rustok_taxonomy::TaxonomyModule;
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
+    Value as SqlValue,
+};
+use sea_orm_migration::SchemaManager;
+use serde::Serialize;
+use serde_json::{Value as JsonValue, json};
+use uuid::Uuid;
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+const SEARCH_TEST_DATABASE_ENV: &str = "RUSTOK_SEARCH_TEST_DATABASE_URL";
+const FORUM_TEST_DATABASE_ENV: &str = "RUSTOK_FORUM_TEST_DATABASE_URL";
+const EVIDENCE_CONTRACT: &str =
+    "forum_search_versioned_invalidation_deletion_acl_ordering_evidence_v1";
+const EVIDENCE_PATH: &str =
+    "target/forum-search-versioned-invalidation-deletion-acl-ordering-evidence.json";
+const HIDDEN_REPLY_MARKER: &str = "d8hiddenreplymarker";
+const DELETED_TOPIC_MARKER: &str = "d8deletedtopicmarker";
+const ACL_TOPIC_MARKER: &str = "d8acltopicmarker";
+
+struct PostgresDeletionAclEvidence {
+    control: DatabaseConnection,
+    db: DatabaseConnection,
+    schema_name: String,
+}
+
+impl PostgresDeletionAclEvidence {
+    async fn setup(scope: &str) -> TestResult<Option<Self>> {
+        let Some(database_url) = postgres_database_url() else {
+            eprintln!(
+                "{SEARCH_TEST_DATABASE_ENV} is not set to a PostgreSQL URL; skipping Forum deletion/ACL ordering proof"
+            );
+            return Ok(None);
+        };
+
+        let control = connect(&database_url, 1).await?;
+        let schema_name = format!(
+            "rustok_forum_deletion_acl_{}_{}",
+            sanitize_identifier(scope),
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let db = connect_in_schema(&database_url, &schema_name, 10).await?;
+        let setup_result = async {
+            db.execute_unprepared(
+                r#"
+                CREATE TABLE users (
+                    id UUID NOT NULL PRIMARY KEY,
+                    tenant_id UUID NOT NULL
+                )
+                "#,
+            )
+            .await?;
+            let manager = SchemaManager::new(&db);
+            for migration in OutboxModule.migrations() {
+                migration.up(&manager).await?;
+            }
+            for migration in TaxonomyModule.migrations() {
+                migration.up(&manager).await?;
+            }
+            for migration in ForumModule.migrations() {
+                migration.up(&manager).await?;
+            }
+            for migration in SearchModule.migrations() {
+                migration.up(&manager).await?;
+            }
+            Ok::<(), sea_orm::DbErr>(())
+        }
+        .await;
+        if let Err(error) = setup_result {
+            let _ = control
+                .execute_unprepared(&format!(r#"DROP SCHEMA IF EXISTS "{schema_name}" CASCADE"#))
+                .await;
+            return Err(error.into());
+        }
+
+        Ok(Some(Self {
+            control,
+            db,
+            schema_name,
+        }))
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ForumFixture {
+    tenant_id: Uuid,
+    category_id: Uuid,
+    hidden_reply_topic_id: Uuid,
+    hidden_reply_id: Uuid,
+    deleted_topic_id: Uuid,
+    acl_topic_id: Uuid,
+    admin_id: Uuid,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct OwnerRevisionRow {
+    revision: i64,
+    event_id: Uuid,
+    target_type: String,
+    target_id: Option<Uuid>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct InboxOrderRow {
+    ingest_sequence: i64,
+    event_id: Uuid,
+    scope_key: String,
+    event_type: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ScenarioEvidence {
+    id: &'static str,
+    result: &'static str,
+    facts: JsonValue,
+}
+
+#[derive(Debug, Serialize)]
+struct DeletionAclEvidenceArtifact {
+    contract: &'static str,
+    task: &'static str,
+    source_commit: String,
+    generated_at: String,
+    database_backend: &'static str,
+    broker_used: bool,
+    scenario_results: Vec<ScenarioEvidence>,
+}
+
+#[derive(Clone)]
+struct ExactCategoryScopePort;
+
+#[async_trait]
+impl StorefrontSearchCategoryScopePort for ExactCategoryScopePort {
+    async fn expand_forum_category_scope(
+        &self,
+        request: StorefrontSearchCategoryScopeRequest,
+    ) -> Result<Vec<Uuid>, PortError> {
+        Ok(request.category_ids)
+    }
+}
+
+#[derive(Clone)]
+struct RealForumPublicEligibilityPort {
+    db: DatabaseConnection,
+    observed: Arc<Mutex<Vec<Vec<StorefrontSearchResultCandidate>>>>,
+}
+
+impl RealForumPublicEligibilityPort {
+    fn shared(
+        db: DatabaseConnection,
+        observed: Arc<Mutex<Vec<Vec<StorefrontSearchResultCandidate>>>>,
+    ) -> SharedStorefrontSearchResultEligibilityPort {
+        Arc::new(Self { db, observed })
+    }
+}
+
+#[async_trait]
+impl StorefrontSearchResultEligibilityPort for RealForumPublicEligibilityPort {
+    async fn filter_forum_result_candidates(
+        &self,
+        request: StorefrontSearchResultEligibilityRequest,
+    ) -> Result<Vec<StorefrontSearchResultCandidate>, PortError> {
+        self.observed
+            .lock()
+            .map_err(|_| owner_unavailable())?
+            .push(request.candidates.clone());
+        let forum_candidates = request
+            .candidates
+            .iter()
+            .copied()
+            .map(to_forum_candidate)
+            .collect::<Vec<_>>();
+        let channel_slug = request
+            .request_context
+            .as_ref()
+            .and_then(|context| context.channel_slug.as_deref());
+        let allowed = ForumSearchResultEligibilityService::new(self.db.clone())
+            .filter_public_storefront_visible(
+                request.tenant_id,
+                channel_slug,
+                &forum_candidates,
+            )
+            .await
+            .map_err(|_| owner_unavailable())?;
+        Ok(allowed.into_iter().map(from_forum_candidate).collect())
+    }
+}
+
+fn owner_unavailable() -> PortError {
+    PortError::unavailable(
+        "forum.search_projection.deletion_acl_owner_unavailable",
+        "Forum deletion/ACL eligibility owner is temporarily unavailable",
+    )
+}
+
+fn to_forum_candidate(candidate: StorefrontSearchResultCandidate) -> ForumSearchResultCandidate {
+    ForumSearchResultCandidate {
+        document_id: candidate.document_id,
+        kind: match candidate.kind {
+            StorefrontSearchResultCandidateKind::ForumTopic => {
+                ForumSearchResultCandidateKind::Topic
+            }
+            StorefrontSearchResultCandidateKind::ForumReply => {
+                ForumSearchResultCandidateKind::Reply
+            }
+        },
+    }
+}
+
+fn from_forum_candidate(candidate: ForumSearchResultCandidate) -> StorefrontSearchResultCandidate {
+    StorefrontSearchResultCandidate {
+        document_id: candidate.document_id,
+        kind: match candidate.kind {
+            ForumSearchResultCandidateKind::Topic => {
+                StorefrontSearchResultCandidateKind::ForumTopic
+            }
+            ForumSearchResultCandidateKind::Reply => {
+                StorefrontSearchResultCandidateKind::ForumReply
+            }
+        },
+    }
+}
+
+#[tokio::test]
+async fn deletion_acl_ordering_cannot_restore_denied_storefront_results() -> TestResult<()> {
+    let Some(evidence) = PostgresDeletionAclEvidence::setup("ordering").await? else {
+        return Ok(());
+    };
+
+    let proof = run_deletion_acl_ordering_proof(&evidence.db).await;
+    let cleanup = evidence.cleanup().await;
+    let scenario = proof?;
+    cleanup?;
+
+    write_evidence(DeletionAclEvidenceArtifact {
+        contract: EVIDENCE_CONTRACT,
+        task: "FORUM-23B2G2B3D8",
+        source_commit: source_commit()?,
+        generated_at: Utc::now().to_rfc3339(),
+        database_backend: "postgresql",
+        broker_used: false,
+        scenario_results: vec![scenario],
+    })?;
+    Ok(())
+}
+
+async fn run_deletion_acl_ordering_proof(
+    db: &DatabaseConnection,
+) -> TestResult<ScenarioEvidence> {
+    let fixture = create_forum_fixture(db).await?;
+    let projection_source = ForumSearchProjectionSourceFactory.build(db.clone());
+    let reconciler = ForumProjectionReconciler::new(db.clone(), projection_source);
+
+    let baseline_approved = load_reply_status_event(
+        db,
+        fixture.tenant_id,
+        fixture.hidden_reply_topic_id,
+        fixture.hidden_reply_id,
+        "pending",
+        "approved",
+    )
+    .await?;
+    insert_legacy_root(db, &baseline_approved, "forum").await?;
+    let baseline_report = reconciler.sweep_due(1, 16).await?;
+    if baseline_report.claimed_events != 1
+        || baseline_report.completed_events != 1
+        || baseline_report.failed_events != 0
+    {
+        return Err(test_error(format!(
+            "baseline approved-reply rebuild did not complete exactly once: {baseline_report:?}"
+        )));
+    }
+    let baseline_ingest_sequence = max_ingest_sequence(db).await?;
+
+    let observed = Arc::new(Mutex::new(Vec::new()));
+    let category_scope: SharedStorefrontSearchCategoryScopePort = Arc::new(ExactCategoryScopePort);
+    let eligibility = RealForumPublicEligibilityPort::shared(db.clone(), observed.clone());
+    assert_storefront_exact(
+        db,
+        category_scope.clone(),
+        eligibility.clone(),
+        fixture,
+        HIDDEN_REPLY_MARKER,
+        "forum_reply",
+        "approved",
+        fixture.hidden_reply_id,
+        1,
+    )
+    .await?;
+    assert_storefront_exact(
+        db,
+        category_scope.clone(),
+        eligibility.clone(),
+        fixture,
+        DELETED_TOPIC_MARKER,
+        "forum_topic",
+        "open",
+        fixture.deleted_topic_id,
+        1,
+    )
+    .await?;
+    assert_storefront_exact(
+        db,
+        category_scope.clone(),
+        eligibility.clone(),
+        fixture,
+        ACL_TOPIC_MARKER,
+        "forum_topic",
+        "open",
+        fixture.acl_topic_id,
+        1,
+    )
+    .await?;
+
+    let baseline_revision = max_owner_revision(db, fixture.tenant_id).await?;
+    let bus = event_bus(db.clone());
+    ModerationService::new(db.clone(), bus.clone())
+        .hide_reply(
+            fixture.tenant_id,
+            fixture.hidden_reply_id,
+            fixture.hidden_reply_topic_id,
+            admin_security(fixture.admin_id),
+        )
+        .await?;
+    let after_hide_revision = max_owner_revision(db, fixture.tenant_id).await?;
+    TopicService::new(db.clone(), bus)
+        .delete(
+            fixture.tenant_id,
+            fixture.deleted_topic_id,
+            admin_security(fixture.admin_id),
+        )
+        .await?;
+    let after_delete_revision = max_owner_revision(db, fixture.tenant_id).await?;
+    ForumTopicAudiencePolicyService::new(db.clone())
+        .set(
+            fixture.tenant_id,
+            fixture.acl_topic_id,
+            admin_security(fixture.admin_id),
+            SetForumTopicAudiencePolicyInput {
+                constraints: ForumAudienceConstraints {
+                    roles_any: vec![UserRole::Customer],
+                    ..ForumAudienceConstraints::default()
+                },
+            },
+        )
+        .await?;
+    let after_acl_revision = max_owner_revision(db, fixture.tenant_id).await?;
+
+    if after_hide_revision != baseline_revision + 1
+        || after_delete_revision != after_hide_revision + 2
+        || after_acl_revision != after_delete_revision + 1
+    {
+        return Err(test_error(format!(
+            "owner mutations emitted unexpected revision counts: baseline={baseline_revision}, hide={after_hide_revision}, delete={after_delete_revision}, acl={after_acl_revision}"
+        )));
+    }
+
+    let revisions = load_owner_revisions_after(db, fixture.tenant_id, baseline_revision).await?;
+    ensure_owner_revision_shape(&revisions, fixture)?;
+
+    let hidden_legacy = load_reply_status_event(
+        db,
+        fixture.tenant_id,
+        fixture.hidden_reply_topic_id,
+        fixture.hidden_reply_id,
+        "approved",
+        "hidden",
+    )
+    .await?;
+    let deleted_legacy = load_topic_status_event(
+        db,
+        fixture.tenant_id,
+        fixture.deleted_topic_id,
+        "open",
+        "archived",
+    )
+    .await?;
+
+    let mut expected_admission = Vec::new();
+    for revision in revisions[1..].iter().rev() {
+        ingest_typed_revision(db, fixture.tenant_id, revision).await?;
+        expected_admission.push(revision.event_id);
+    }
+    insert_legacy_root(db, &deleted_legacy, "forum").await?;
+    expected_admission.push(deleted_legacy.id);
+    insert_legacy_root(db, &hidden_legacy, "forum").await?;
+    expected_admission.push(hidden_legacy.id);
+    ingest_typed_revision(db, fixture.tenant_id, &revisions[0]).await?;
+    expected_admission.push(revisions[0].event_id);
+
+    ingest_typed_revision(db, fixture.tenant_id, &revisions[0]).await?;
+    insert_legacy_root(db, &hidden_legacy, "forum").await?;
+
+    let inbox_order = load_inbox_order_after(db, baseline_ingest_sequence).await?;
+    let actual_admission = inbox_order.iter().map(|row| row.event_id).collect::<Vec<_>>();
+    if actual_admission != expected_admission || inbox_order.len() != 6 {
+        return Err(test_error(format!(
+            "out-of-order durable admission drifted: expected={expected_admission:?}, actual={actual_admission:?}"
+        )));
+    }
+    for event_id in &expected_admission {
+        if count_inbox_rows(db, *event_id).await? != 1 {
+            return Err(test_error(format!(
+                "duplicate root identity {event_id} did not retain exactly one inbox row"
+            )));
+        }
+    }
+
+    let report = reconciler.sweep_due(1, 32).await?;
+    if report.claimed_events != 6 || report.completed_events != 6 || report.failed_events != 0 {
+        return Err(test_error(format!(
+            "out-of-order Forum reconciliation did not complete all unique roots: {report:?}"
+        )));
+    }
+
+    for document_id in [
+        fixture.hidden_reply_id,
+        fixture.deleted_topic_id,
+        fixture.acl_topic_id,
+    ] {
+        if count_forum_document(db, fixture.tenant_id, document_id).await? != 0 {
+            return Err(test_error(format!(
+                "denied owner object {document_id} remained in Search after reconciliation"
+            )));
+        }
+    }
+
+    for (marker, entity_type, status, expected_id) in [
+        (
+            HIDDEN_REPLY_MARKER,
+            "forum_reply",
+            "approved",
+            fixture.hidden_reply_id,
+        ),
+        (
+            DELETED_TOPIC_MARKER,
+            "forum_topic",
+            "open",
+            fixture.deleted_topic_id,
+        ),
+        (
+            ACL_TOPIC_MARKER,
+            "forum_topic",
+            "open",
+            fixture.acl_topic_id,
+        ),
+    ] {
+        assert_storefront_exact(
+            db,
+            category_scope.clone(),
+            eligibility.clone(),
+            fixture,
+            marker,
+            entity_type,
+            status,
+            expected_id,
+            0,
+        )
+        .await?;
+    }
+
+    insert_stale_search_documents(db, fixture).await?;
+    if count_stale_markers(db, fixture.tenant_id).await? != 3 {
+        return Err(test_error(
+            "stale Search candidate injection did not create exactly three rows",
+        ));
+    }
+    observed
+        .lock()
+        .map_err(|_| test_error("eligibility observation lock was poisoned"))?
+        .clear();
+
+    for (marker, entity_type, status, expected_id) in [
+        (
+            HIDDEN_REPLY_MARKER,
+            "forum_reply",
+            "approved",
+            fixture.hidden_reply_id,
+        ),
+        (
+            DELETED_TOPIC_MARKER,
+            "forum_topic",
+            "open",
+            fixture.deleted_topic_id,
+        ),
+        (
+            ACL_TOPIC_MARKER,
+            "forum_topic",
+            "open",
+            fixture.acl_topic_id,
+        ),
+    ] {
+        assert_storefront_exact(
+            db,
+            category_scope.clone(),
+            eligibility.clone(),
+            fixture,
+            marker,
+            entity_type,
+            status,
+            expected_id,
+            0,
+        )
+        .await?;
+    }
+
+    let owner_requests = observed
+        .lock()
+        .map_err(|_| test_error("eligibility observation lock was poisoned"))?
+        .clone();
+    let expected_candidates = [
+        StorefrontSearchResultCandidate {
+            document_id: fixture.hidden_reply_id,
+            kind: StorefrontSearchResultCandidateKind::ForumReply,
+        },
+        StorefrontSearchResultCandidate {
+            document_id: fixture.deleted_topic_id,
+            kind: StorefrontSearchResultCandidateKind::ForumTopic,
+        },
+        StorefrontSearchResultCandidate {
+            document_id: fixture.acl_topic_id,
+            kind: StorefrontSearchResultCandidateKind::ForumTopic,
+        },
+    ];
+    if owner_requests.len() != 3
+        || owner_requests
+            .iter()
+            .zip(expected_candidates)
+            .any(|(actual, expected)| actual.as_slice() != std::slice::from_ref(&expected))
+    {
+        return Err(test_error(format!(
+            "storefront owner did not reauthorize the exact stale candidates: {owner_requests:?}"
+        )));
+    }
+
+    Ok(ScenarioEvidence {
+        id: "deletion_acl_ordering",
+        result: "passed",
+        facts: json!({
+            "tenant_id": fixture.tenant_id,
+            "category_id": fixture.category_id,
+            "initially_searchable": {
+                "approved_reply_id": fixture.hidden_reply_id,
+                "future_deleted_topic_id": fixture.deleted_topic_id,
+                "future_acl_denied_topic_id": fixture.acl_topic_id
+            },
+            "baseline_owner_revision": baseline_revision,
+            "owner_revision_rows": revisions,
+            "legacy_hide_root_event_id": hidden_legacy.id,
+            "legacy_delete_root_event_id": deleted_legacy.id,
+            "durable_admission_order": inbox_order,
+            "duplicate_root_rows": 1,
+            "unique_post_mutation_inbox_rows": 6,
+            "projection_absence_after_reconciliation": true,
+            "stale_search_rows_injected": 3,
+            "storefront_owner_requests": owner_requests,
+            "final_visible_totals": {
+                "hidden_reply": 0,
+                "deleted_topic": 0,
+                "acl_denied_topic": 0
+            },
+            "final_visible_items": 0,
+            "final_visible_facet_buckets": 0,
+            "denied_content_restored": false
+        }),
+    })
+}
+
+async fn create_forum_fixture(db: &DatabaseConnection) -> TestResult<ForumFixture> {
+    let tenant_id = Uuid::new_v4();
+    let admin_id = Uuid::new_v4();
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "INSERT INTO users (id, tenant_id) VALUES ($1, $2)",
+        vec![admin_id.into(), tenant_id.into()],
+    ))
+    .await?;
+
+    let admin = admin_security(admin_id);
+    let category = CategoryService::new(db.clone())
+        .create(
+            tenant_id,
+            admin.clone(),
+            CreateCategoryInput {
+                locale: "en".to_string(),
+                name: "D8 public category".to_string(),
+                slug: "d8-public-category".to_string(),
+                description: Some("Forum deletion ACL ordering evidence".to_string()),
+                icon: None,
+                color: None,
+                parent_id: None,
+                position: Some(0),
+                moderated: true,
+            },
+        )
+        .await?;
+    let bus = event_bus(db.clone());
+    let topics = TopicService::new(db.clone(), bus.clone());
+    let hidden_reply_topic = topics
+        .create(
+            tenant_id,
+            customer_security(),
+            topic_input(category.id, "D8 reply owner topic", "d8-reply-owner-topic"),
+        )
+        .await?;
+    let deleted_topic = topics
+        .create(
+            tenant_id,
+            customer_security(),
+            topic_input(
+                category.id,
+                "D8 deleted topic d8deletedtopicmarker",
+                "d8-deleted-topic",
+            ),
+        )
+        .await?;
+    let acl_topic = topics
+        .create(
+            tenant_id,
+            customer_security(),
+            topic_input(
+                category.id,
+                "D8 ACL topic d8acltopicmarker",
+                "d8-acl-topic",
+            ),
+        )
+        .await?;
+    let reply = ReplyService::new(db.clone(), bus.clone())
+        .create(
+            tenant_id,
+            customer_security(),
+            hidden_reply_topic.id,
+            CreateReplyInput {
+                locale: "en".to_string(),
+                content: format!("D8 approved reply {HIDDEN_REPLY_MARKER}"),
+                content_format: "markdown".to_string(),
+                content_json: None,
+                parent_reply_id: None,
+            },
+        )
+        .await?;
+    if reply.status != "pending" {
+        return Err(test_error(format!(
+            "moderated D8 category produced unexpected reply status `{}`",
+            reply.status
+        )));
+    }
+    ModerationService::new(db.clone(), bus)
+        .approve_reply(
+            tenant_id,
+            reply.id,
+            hidden_reply_topic.id,
+            admin.clone(),
+        )
+        .await?;
+
+    Ok(ForumFixture {
+        tenant_id,
+        category_id: category.id,
+        hidden_reply_topic_id: hidden_reply_topic.id,
+        hidden_reply_id: reply.id,
+        deleted_topic_id: deleted_topic.id,
+        acl_topic_id: acl_topic.id,
+        admin_id,
+    })
+}
+
+fn topic_input(category_id: Uuid, title: &str, slug: &str) -> CreateTopicInput {
+    CreateTopicInput {
+        locale: "en".to_string(),
+        category_id,
+        title: title.to_string(),
+        slug: Some(slug.to_string()),
+        body: format!("{title} body"),
+        body_format: "markdown".to_string(),
+        content_json: None,
+        metadata: json!({}),
+        tags: Vec::new(),
+        channel_slugs: None,
+    }
+}
+
+fn event_bus(db: DatabaseConnection) -> TransactionalEventBus {
+    TransactionalEventBus::new(Arc::new(OutboxTransport::new(db)))
+}
+
+fn admin_security(user_id: Uuid) -> SecurityContext {
+    SecurityContext::new(UserRole::Admin, Some(user_id))
+}
+
+fn customer_security() -> SecurityContext {
+    SecurityContext::new(UserRole::Customer, None)
+}
+
+fn ensure_owner_revision_shape(
+    revisions: &[OwnerRevisionRow],
+    fixture: ForumFixture,
+) -> TestResult<()> {
+    if revisions.len() != 4 {
+        return Err(test_error(format!(
+            "D8 expected four owner revisions, received {revisions:?}"
+        )));
+    }
+    for pair in revisions.windows(2) {
+        if pair[1].revision != pair[0].revision + 1 {
+            return Err(test_error(format!(
+                "D8 owner revisions are not contiguous: {revisions:?}"
+            )));
+        }
+    }
+    let expected = [
+        ("forum_category", Some(fixture.category_id)),
+        ("forum_topic", Some(fixture.deleted_topic_id)),
+        ("forum_category", Some(fixture.category_id)),
+        ("forum_topic", Some(fixture.acl_topic_id)),
+    ];
+    if revisions
+        .iter()
+        .zip(expected)
+        .any(|(actual, (target_type, target_id))| {
+            actual.target_type != target_type || actual.target_id != target_id
+        })
+    {
+        return Err(test_error(format!(
+            "D8 owner revision targets drifted: {revisions:?}"
+        )));
+    }
+    Ok(())
+}
+
+async fn ingest_typed_revision(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    revision: &OwnerRevisionRow,
+) -> TestResult<()> {
+    let envelope = ContractEventEnvelope::new_caused_by(
+        tenant_id,
+        None,
+        revision.event_id,
+        ForumSearchProjectionEvent::InvalidationIssued {
+            owner_revision: revision.revision,
+            target_type: revision.target_type.clone(),
+            target_id: revision.target_id,
+        },
+    )?;
+    let outcome = ForumSearchContractIngress::new(db.clone())
+        .ingest(&envelope)
+        .await?;
+    match outcome {
+        ForumSearchContractIngressOutcome::DurablyAccepted {
+            root_event_id,
+            owner_revision,
+        } if root_event_id == revision.event_id && owner_revision == revision.revision => Ok(()),
+        other => Err(test_error(format!(
+            "typed D8 invalidation returned unexpected ingress outcome: {other:?}"
+        ))),
+    }
+}
+
+async fn insert_legacy_root(
+    db: &DatabaseConnection,
+    envelope: &EventEnvelope,
+    scope_key: &str,
+) -> TestResult<()> {
+    envelope.validate_registered_schema()?;
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+        INSERT INTO search_projection_inbox (
+            event_id, tenant_id, source_module, scope_key, event_type,
+            revision_at, envelope_json, status, attempt_count, created_at, updated_at
+        ) VALUES ($1, $2, 'forum', $3, $4, $5, $6, 'pending', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+        ON CONFLICT (event_id) DO NOTHING
+        "#,
+        vec![
+            envelope.id.into(),
+            envelope.tenant_id.into(),
+            scope_key.to_string().into(),
+            envelope.event_type.clone().into(),
+            envelope.timestamp.to_owned().into(),
+            SqlValue::Json(Some(Box::new(serde_json::to_value(envelope)?))),
+        ],
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn load_owner_revisions_after(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    after_revision: i64,
+) -> TestResult<Vec<OwnerRevisionRow>> {
+    db.query_all(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+        SELECT revision, event_id, target_type, target_id
+        FROM forum_projection_revision_ledger
+        WHERE tenant_id = $1 AND revision > $2
+        ORDER BY revision ASC
+        "#,
+        vec![tenant_id.into(), after_revision.into()],
+    ))
+    .await?
+    .into_iter()
+    .map(|row| {
+        Ok(OwnerRevisionRow {
+            revision: row.try_get("", "revision")?,
+            event_id: row.try_get("", "event_id")?,
+            target_type: row.try_get("", "target_type")?,
+            target_id: row.try_get("", "target_id")?,
+        })
+    })
+    .collect::<Result<Vec<_>, sea_orm::DbErr>>()
+    .map_err(Into::into)
+}
+
+async fn max_owner_revision(db: &DatabaseConnection, tenant_id: Uuid) -> TestResult<i64> {
+    scalar_i64(
+        db,
+        Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT COALESCE(MAX(revision), 0)::BIGINT AS value FROM forum_projection_revision_ledger WHERE tenant_id = $1",
+            vec![tenant_id.into()],
+        ),
+    )
+    .await
+}
+
+async fn max_ingest_sequence(db: &DatabaseConnection) -> TestResult<i64> {
+    scalar_i64(
+        db,
+        Statement::from_string(
+            DbBackend::Postgres,
+            "SELECT COALESCE(MAX(ingest_sequence), 0)::BIGINT AS value FROM search_projection_inbox"
+                .to_string(),
+        ),
+    )
+    .await
+}
+
+async fn load_inbox_order_after(
+    db: &DatabaseConnection,
+    after_sequence: i64,
+) -> TestResult<Vec<InboxOrderRow>> {
+    db.query_all(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+        SELECT ingest_sequence, event_id, scope_key, event_type
+        FROM search_projection_inbox
+        WHERE ingest_sequence > $1
+        ORDER BY ingest_sequence ASC
+        "#,
+        vec![after_sequence.into()],
+    ))
+    .await?
+    .into_iter()
+    .map(|row| {
+        Ok(InboxOrderRow {
+            ingest_sequence: row.try_get("", "ingest_sequence")?,
+            event_id: row.try_get("", "event_id")?,
+            scope_key: row.try_get("", "scope_key")?,
+            event_type: row.try_get("", "event_type")?,
+        })
+    })
+    .collect::<Result<Vec<_>, sea_orm::DbErr>>()
+    .map_err(Into::into)
+}
+
+async fn count_inbox_rows(db: &DatabaseConnection, event_id: Uuid) -> TestResult<i64> {
+    scalar_i64(
+        db,
+        Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT COUNT(*)::BIGINT AS value FROM search_projection_inbox WHERE event_id = $1",
+            vec![event_id.into()],
+        ),
+    )
+    .await
+}
+
+async fn count_forum_document(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    document_id: Uuid,
+) -> TestResult<i64> {
+    scalar_i64(
+        db,
+        Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT COUNT(*)::BIGINT AS value FROM search_documents WHERE tenant_id = $1 AND source_module = 'forum' AND document_id = $2",
+            vec![tenant_id.into(), document_id.into()],
+        ),
+    )
+    .await
+}
+
+async fn load_reply_status_event(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    topic_id: Uuid,
+    reply_id: Uuid,
+    old_status: &str,
+    new_status: &str,
+) -> TestResult<EventEnvelope> {
+    load_exact_event(db, "forum.reply.status_changed", |envelope| {
+        envelope.tenant_id == tenant_id
+            && matches!(
+                &envelope.event,
+                DomainEvent::ForumReplyStatusChanged {
+                    reply_id: actual_reply_id,
+                    topic_id: actual_topic_id,
+                    old_status: actual_old,
+                    new_status: actual_new,
+                    ..
+                } if *actual_reply_id == reply_id
+                    && *actual_topic_id == topic_id
+                    && actual_old == old_status
+                    && actual_new == new_status
+            )
+    })
+    .await
+}
+
+async fn load_topic_status_event(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    topic_id: Uuid,
+    old_status: &str,
+    new_status: &str,
+) -> TestResult<EventEnvelope> {
+    load_exact_event(db, "forum.topic.status_changed", |envelope| {
+        envelope.tenant_id == tenant_id
+            && matches!(
+                &envelope.event,
+                DomainEvent::ForumTopicStatusChanged {
+                    topic_id: actual_topic_id,
+                    old_status: actual_old,
+                    new_status: actual_new,
+                    ..
+                } if *actual_topic_id == topic_id
+                    && actual_old == old_status
+                    && actual_new == new_status
+            )
+    })
+    .await
+}
+
+async fn load_exact_event<F>(
+    db: &DatabaseConnection,
+    event_type: &str,
+    predicate: F,
+) -> TestResult<EventEnvelope>
+where
+    F: Fn(&EventEnvelope) -> bool,
+{
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT payload FROM sys_events WHERE event_type = $1 ORDER BY created_at ASC",
+            vec![event_type.to_string().into()],
+        ))
+        .await?;
+    let mut matches = Vec::new();
+    for row in rows {
+        let payload: JsonValue = row.try_get("", "payload")?;
+        let envelope: EventEnvelope = serde_json::from_value(payload)?;
+        if predicate(&envelope) {
+            matches.push(envelope);
+        }
+    }
+    if matches.len() != 1 {
+        return Err(test_error(format!(
+            "expected exactly one `{event_type}` owner event, found {}",
+            matches.len()
+        )));
+    }
+    Ok(matches.remove(0))
+}
+
+async fn assert_storefront_exact(
+    db: &DatabaseConnection,
+    category_scope: SharedStorefrontSearchCategoryScopePort,
+    eligibility: SharedStorefrontSearchResultEligibilityPort,
+    fixture: ForumFixture,
+    marker: &str,
+    entity_type: &str,
+    status: &str,
+    expected_id: Uuid,
+    expected_total: u64,
+) -> TestResult<()> {
+    let execution = execute_forum_storefront_search(
+        db,
+        Some(category_scope),
+        Some(eligibility),
+        ForumStorefrontSearchRequest {
+            tenant_id: fixture.tenant_id,
+            query: marker.to_string(),
+            locale: Some("en".to_string()),
+            fallback_locale: "en".to_string(),
+            channel_id: None,
+            current_channel_only: None,
+            limit: Some(10),
+            offset: Some(0),
+            ranking_profile: None,
+            preset_key: None,
+            entity_types: vec![entity_type.to_string()],
+            source_modules: vec!["forum".to_string()],
+            statuses: vec![status.to_string()],
+            category_ids: vec![fixture.category_id.to_string()],
+            author_ids: Vec::new(),
+            tags: Vec::new(),
+            solved: None,
+            published_from: None,
+            published_to: None,
+            attribute_filters: Vec::<ForumStorefrontSearchAttributeFilter>::new(),
+            sort_attribute_code: None,
+            sort_desc: false,
+            auth: None,
+            request_context: Some(RequestContext {
+                tenant_id: fixture.tenant_id,
+                user_id: None,
+                channel_id: None,
+                channel_slug: None,
+                channel_resolution_source: None,
+                locale: "en".to_string(),
+            }),
+            transport: StorefrontSearchTransport::Graphql,
+        },
+    )
+    .await?;
+    if execution.result.total != expected_total {
+        return Err(test_error(format!(
+            "storefront marker `{marker}` returned total {}, expected {expected_total}",
+            execution.result.total
+        )));
+    }
+    if expected_total == 1 {
+        if execution.result.items.len() != 1 || execution.result.items[0].id != expected_id {
+            return Err(test_error(format!(
+                "storefront marker `{marker}` did not return exact owner object {expected_id}: {:?}",
+                execution.result.items
+            )));
+        }
+    } else if !execution.result.items.is_empty()
+        || execution
+            .result
+            .facets
+            .iter()
+            .any(|facet| !facet.buckets.is_empty())
+    {
+        return Err(test_error(format!(
+            "denied storefront marker `{marker}` leaked items or visible facets"
+        )));
+    }
+    Ok(())
+}
+
+async fn insert_stale_search_documents(
+    db: &DatabaseConnection,
+    fixture: ForumFixture,
+) -> TestResult<()> {
+    for (document_id, entity_type, status, marker, slug, topic_id) in [
+        (
+            fixture.hidden_reply_id,
+            "forum_reply",
+            "approved",
+            HIDDEN_REPLY_MARKER,
+            None,
+            Some(fixture.hidden_reply_topic_id),
+        ),
+        (
+            fixture.deleted_topic_id,
+            "forum_topic",
+            "open",
+            DELETED_TOPIC_MARKER,
+            Some("d8-deleted-topic"),
+            None,
+        ),
+        (
+            fixture.acl_topic_id,
+            "forum_topic",
+            "open",
+            ACL_TOPIC_MARKER,
+            Some("d8-acl-topic"),
+            None,
+        ),
+    ] {
+        let document_key = format!("{entity_type}:{document_id}:en");
+        let facets = json!({
+            "kind": entity_type,
+            "category_id": fixture.category_id
+        });
+        let payload = json!({
+            "category_id": fixture.category_id,
+            "topic_id": topic_id.unwrap_or(document_id),
+            "owner_state": "intentionally_stale"
+        });
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+            INSERT INTO search_documents (
+                document_key, tenant_id, document_id, source_module, entity_type,
+                locale, status, is_public, title, subtitle, slug, handle, body,
+                keywords_text, facets, payload, published_at, created_at, updated_at, indexed_at
+            ) VALUES (
+                $1, $2, $3, 'forum', $4, 'en', $5, TRUE, $6, NULL, $7, NULL, $8,
+                $9, $10, $11, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+            )
+            "#,
+            vec![
+                document_key.into(),
+                fixture.tenant_id.into(),
+                document_id.into(),
+                entity_type.to_string().into(),
+                status.to_string().into(),
+                format!("Intentionally stale {marker}").into(),
+                slug.map(str::to_string).into(),
+                format!("Intentionally stale body {marker}").into(),
+                marker.to_string().into(),
+                facets.into(),
+                payload.into(),
+            ],
+        ))
+        .await?;
+    }
+    Ok(())
+}
+
+async fn count_stale_markers(db: &DatabaseConnection, tenant_id: Uuid) -> TestResult<i64> {
+    scalar_i64(
+        db,
+        Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+            SELECT COUNT(*)::BIGINT AS value
+            FROM search_documents
+            WHERE tenant_id = $1
+              AND source_module = 'forum'
+              AND payload ->> 'owner_state' = 'intentionally_stale'
+            "#,
+            vec![tenant_id.into()],
+        ),
+    )
+    .await
+}
+
+async fn scalar_i64(db: &DatabaseConnection, statement: Statement) -> TestResult<i64> {
+    let row = db
+        .query_one(statement)
+        .await?
+        .ok_or_else(|| test_error("scalar query returned no row"))?;
+    Ok(row.try_get("", "value")?)
+}
+
+fn postgres_database_url() -> Option<String> {
+    env::var(SEARCH_TEST_DATABASE_ENV)
+        .or_else(|_| env::var(FORUM_TEST_DATABASE_ENV))
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect_in_schema(
+    database_url: &str,
+    schema_name: &str,
+    max_connections: u32,
+) -> TestResult<DatabaseConnection> {
+    connect(
+        &database_url_in_schema(database_url, schema_name),
+        max_connections,
+    )
+    .await
+}
+
+fn database_url_in_schema(database_url: &str, schema_name: &str) -> String {
+    let separator = if database_url.contains('?') { '&' } else { '?' };
+    format!(
+        "{database_url}{separator}options=-c%20search_path%3D{schema_name}%2Cpublic"
+    )
+}
+
+async fn connect(database_url: &str, max_connections: u32) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(max_connections)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+fn sanitize_identifier(value: &str) -> String {
+    let normalized = value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    let normalized = normalized.trim_matches('_');
+    if normalized.is_empty() {
+        "test".to_string()
+    } else {
+        normalized.to_string()
+    }
+}
+
+fn write_evidence(artifact: DeletionAclEvidenceArtifact) -> TestResult<()> {
+    let path = workspace_root().join(EVIDENCE_PATH);
+    let parent = path
+        .parent()
+        .ok_or_else(|| test_error("evidence path has no parent directory"))?;
+    fs::create_dir_all(parent)?;
+    fs::write(path, serde_json::to_vec_pretty(&artifact)?)?;
+    Ok(())
+}
+
+fn source_commit() -> TestResult<String> {
+    let output = Command::new("git")
+        .current_dir(workspace_root())
+        .args(["rev-parse", "HEAD"])
+        .output()?;
+    if !output.status.success() {
+        return Err(test_error("git rev-parse HEAD failed for evidence generation"));
+    }
+    let value = String::from_utf8(output.stdout)?;
+    let value = value.trim();
+    if value.len() != 40 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(test_error(
+            "git rev-parse HEAD returned an invalid commit SHA",
+        ));
+    }
+    Ok(value.to_string())
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn test_error(message: impl Into<String>) -> Box<dyn Error + Send + Sync> {
+    Box::new(IoError::new(ErrorKind::InvalidData, message.into()))
+}

--- a/crates/rustok-forum/contracts/forum-search-versioned-invalidation-deletion-acl-ordering-proof.json
+++ b/crates/rustok-forum/contracts/forum-search-versioned-invalidation-deletion-acl-ordering-proof.json
@@ -1,0 +1,52 @@
+{
+  "contract": "forum_search_versioned_invalidation_deletion_acl_ordering_proof_v1",
+  "task": "FORUM-23B2G2B3D8",
+  "status": "source_ready_maintainer_execution_pending",
+  "runtime_evidence_parent": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json",
+  "test": "apps/server/tests/forum_versioned_invalidation_deletion_acl_ordering.rs",
+  "evidence_artifact": {
+    "path": "target/forum-search-versioned-invalidation-deletion-acl-ordering-evidence.json",
+    "generation": "executable_test_only",
+    "hand_editing_forbidden": true,
+    "source_commit_required": true
+  },
+  "required_runtime": {
+    "database": "postgresql",
+    "database_env": "RUSTOK_SEARCH_TEST_DATABASE_URL",
+    "host_package": "rustok-server",
+    "broker": "not_required_for_bounded_ordering_and_visibility_proof",
+    "storefront_viewer": "anonymous_public",
+    "owner_mutations": [
+      "approved_reply_hidden",
+      "topic_deleted",
+      "topic_richer_audience_restricted"
+    ]
+  },
+  "scenario": {
+    "id": "deletion_acl_ordering",
+    "proves": [
+      "an approved reply, a future-deleted topic and a future-ACL-denied topic are each visible through production Forum storefront Search before owner changes",
+      "real Forum owner transactions emit contiguous revision rows for reply hide category impact, topic delete topic/category impact and richer topic audience impact",
+      "typed owner invalidations and legacy status events can be admitted in reverse/stale order while repeated roots retain one durable Search inbox identity",
+      "current-state Forum rebuilds followed by the oldest category-only refresh cannot restore hidden, deleted or richer-ACL-denied content",
+      "the reconciled Search projection contains none of the three denied owner objects",
+      "deliberately reinserted stale Search rows are reauthorized against current Forum owner state before visible totals, items, facets or pagination",
+      "the anonymous storefront viewer receives zero visible results for the hidden reply, deleted topic and role-restricted topic"
+    ]
+  },
+  "identity_invariants": [
+    "each typed invalidation causation_id equals its exact Forum owner ledger event_id",
+    "legacy status event roots remain independent from typed owner invalidation roots",
+    "duplicate typed and legacy delivery never allocates a second Search inbox row for the same root event UUID",
+    "owner revision order remains independent from Search ingest_sequence",
+    "storefront owner eligibility receives only the exact raw Forum candidate IDs returned by Search"
+  ],
+  "maintainer_command": "RUSTOK_SEARCH_TEST_DATABASE_URL=\"$DATABASE_URL\" cargo test -p rustok-server --test forum_versioned_invalidation_deletion_acl_ordering -- --nocapture --test-threads=1",
+  "non_claims": [
+    "this source-ready proof does not claim that PostgreSQL execution passed",
+    "this proof does not execute the long-running host polling loop or validate restart timing",
+    "this proof does not use Iggy acknowledgement, poison or DLQ behavior",
+    "this proof does not validate the Search-disabled profile or LINK-FORUM-03 completion",
+    "this proof does not close the aggregate FORUM-23B2G2B3D runtime evidence gate"
+  ]
+}

--- a/crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json
+++ b/crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json
@@ -143,6 +143,26 @@
         "deletion_acl_or_storefront_visibility",
         "search_disabled_profile_or_link_forum_03"
       ]
+    },
+    {
+      "task": "FORUM-23B2G2B3D8",
+      "contract": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-deletion-acl-ordering-proof.json",
+      "test": "apps/server/tests/forum_versioned_invalidation_deletion_acl_ordering.rs",
+      "evidence_artifact": "target/forum-search-versioned-invalidation-deletion-acl-ordering-evidence.json",
+      "covers": [
+        "owner_hide_delete_and_richer_acl_revisions",
+        "legacy_and_typed_dual_path_out_of_order_admission",
+        "durable_duplicate_root_suppression",
+        "current_state_rebuild_and_stale_category_refresh_non_restoration",
+        "search_projection_denied_objects_absent",
+        "storefront_owner_reauthorization_rejects_stale_rows",
+        "visible_totals_items_and_facets_exclude_denied_content"
+      ],
+      "does_not_cover": [
+        "long_running_host_polling_or_restart_timing",
+        "iggy_acknowledgement_poison_or_dlq",
+        "search_disabled_profile_or_link_forum_03"
+      ]
     }
   ],
   "required_runtime": {
@@ -280,6 +300,8 @@
     "RUSTOK_SEARCH_TEST_DATABASE_URL=\"$DATABASE_URL\" cargo test -p rustok-search --test forum_versioned_invalidation_missing_delivery_repair -- --nocapture --test-threads=1",
     "node scripts/verify/verify-forum-search-versioned-invalidation-multi-process-proof.mjs",
     "RUSTOK_SEARCH_TEST_DATABASE_URL=\"$DATABASE_URL\" cargo test -p rustok-server --test forum_versioned_invalidation_multi_process_serialization -- --nocapture --test-threads=1",
+    "node scripts/verify/verify-forum-search-versioned-invalidation-deletion-acl-ordering-proof.mjs",
+    "RUSTOK_SEARCH_TEST_DATABASE_URL=\"$DATABASE_URL\" cargo test -p rustok-server --test forum_versioned_invalidation_deletion_acl_ordering -- --nocapture --test-threads=1",
     "cargo run -p rustok-events --example event_contract_digests",
     "cargo test -p rustok-events",
     "cargo test -p rustok-search forum_contract_ingress -- --nocapture",

--- a/crates/rustok-forum/docs/forum-23b2g2b3d8-deletion-acl-ordering-proof.md
+++ b/crates/rustok-forum/docs/forum-23b2g2b3d8-deletion-acl-ordering-proof.md
@@ -1,0 +1,175 @@
+# FORUM-23B2G2B3D8 deletion and ACL ordering proof
+
+## Status
+
+`source_ready_maintainer_execution_pending`
+
+This slice adds the `deletion_acl_ordering` subset of the frozen
+`FORUM-23B2G2B3D` runtime-evidence matrix. It combines real Forum owner
+transactions, the versioned typed invalidation ingress, legacy Forum status
+roots, the production Search reconciler, the production Forum projection
+source, PostgreSQL Search execution and current Forum storefront eligibility.
+
+The machine-readable proof contract is:
+
+```text
+crates/rustok-forum/contracts/forum-search-versioned-invalidation-deletion-acl-ordering-proof.json
+```
+
+The executable test is:
+
+```text
+apps/server/tests/forum_versioned_invalidation_deletion_acl_ordering.rs
+```
+
+Successful execution writes:
+
+```text
+target/forum-search-versioned-invalidation-deletion-acl-ordering-evidence.json
+```
+
+The artifact is generated only after the proof and isolated PostgreSQL schema
+cleanup succeed. It records the exact Git source commit and must not be
+hand-edited.
+
+## Initial visible owner state
+
+The test applies real Outbox, Taxonomy, Forum and Search migrations in one
+isolated PostgreSQL schema. Real Forum services create one moderated public
+category and three independent public targets:
+
+1. an approved reply that contains `d8hiddenreplymarker`;
+2. a topic that contains `d8deletedtopicmarker`;
+3. a topic that contains `d8acltopicmarker`.
+
+A real approved-reply legacy root drives the first production Forum rebuild.
+Each marker is then queried through `execute_forum_storefront_search`. The
+production PostgreSQL engine, exact category scope and real Forum public result
+eligibility must return exactly the corresponding owner object before the
+negative mutations.
+
+## Real owner mutations and revisions
+
+The test records the owner revision head and then performs three real commands:
+
+- `ModerationService::hide_reply` for the approved reply;
+- `TopicService::delete` for the second topic;
+- `ForumTopicAudiencePolicyService::set` with `roles_any = [Customer]` for the
+  third topic.
+
+The expected contiguous post-baseline ledger shape is:
+
+```text
+revision N+1: forum_category / category ID       (reply stopped being public)
+revision N+2: forum_topic / deleted topic ID     (topic lifecycle)
+revision N+3: forum_category / category ID       (category counters)
+revision N+4: forum_topic / ACL topic ID         (richer audience policy)
+```
+
+The reply-hide path deliberately has two compatible event channels. Its legacy
+`forum.reply.status_changed` event requires a full tenant Forum rebuild, while
+its versioned owner revision targets the affected category counter. D8 retains
+and delivers both; it does not falsely claim that a category-only refresh can
+remove a reply document by itself.
+
+Topic delete likewise retains the legacy `forum.topic.status_changed` root plus
+its versioned topic and category owner revisions.
+
+## Out-of-order and duplicate delivery
+
+The test admits the post-mutation roots in this deliberate order:
+
+```text
+owner revision N+4
+owner revision N+3
+owner revision N+2
+legacy topic-delete status root
+legacy reply-hide status root
+owner revision N+1
+```
+
+The typed owner revisions are therefore reverse ordered, and the oldest
+category-only revision is processed last, after current-state full rebuilds.
+The oldest typed root and the legacy hide root are each admitted a second time.
+
+The durable Search inbox must contain exactly six new rows in the stated ingest
+order and exactly one row for every repeated root event UUID. Forum owner
+revision numbers are not compared with Search `ingest_sequence`.
+
+## Current-state convergence
+
+All owner mutations commit before delivery begins. Consequently every full
+Forum rebuild reads current owner state rather than replaying historical state.
+The production projection source excludes:
+
+- the hidden reply because its current status is not `approved`;
+- the deleted topic because its current owner lifecycle is archived/deleted;
+- the richer-policy topic because anonymous public discovery does not satisfy
+  the required Customer role.
+
+After the full rebuilds, the final stale category refresh may update the public
+category but cannot restore any topic or reply. The retained Search projection
+must contain none of the three denied document IDs.
+
+## Storefront owner reauthorization
+
+The test then inserts three intentionally stale `search_documents` rows with
+apparently visible Search status:
+
+```text
+hidden reply:     forum_reply / approved
+deleted topic:    forum_topic / open
+ACL-denied topic: forum_topic / open
+```
+
+Each row contains its unique marker and the correct category facet, so it is a
+real raw PostgreSQL Search candidate. This injection models projection lag or a
+stale external writer; it is not presented as a supported owner mutation.
+
+The same production storefront execution path must send each exact candidate
+to `ForumSearchResultEligibilityService`. Current Forum owner state rejects all
+three before visible totals, items, facets, offset or limit are finalized. Each
+marker query must return:
+
+```text
+total: 0
+items: []
+visible facet buckets: 0
+```
+
+This is the second barrier: even deliberately stale Search rows cannot become a
+storefront visibility oracle or restore denied content.
+
+## Runtime placement
+
+D8 lives in the `rustok-server` integration-test package because it composes
+Outbox, Taxonomy, Forum and Search. It uses the dependencies already owned by
+the host package and adds no `Cargo.toml` or `Cargo.lock` edge.
+
+Every pooled PostgreSQL connection receives the isolated schema through the
+connection URL `search_path` option. This is required because the Search
+projector opens nested transactions while Forum projection reads and storefront
+queries may use separate pool sessions.
+
+No broker is needed for this bounded delivery-order proof. Typed envelopes are
+passed through the production `ForumSearchContractIngress`; legacy roots use
+the same durable Search inbox schema and root identity contract.
+
+## Deliberate boundary
+
+D8 does not run the long-lived host worker loop, restart scheduling or Iggy
+acknowledgement/poison/DLQ behavior. It does not prove the Search-disabled
+profile, aggregate `FORUM-23B2G2B3D` completion or `LINK-FORUM-03` closure.
+Those remain separate gates under D0.
+
+## Maintainer verification
+
+```bash
+node scripts/verify/verify-forum-search-versioned-invalidation-deletion-acl-ordering-proof.mjs
+RUSTOK_SEARCH_TEST_DATABASE_URL="$DATABASE_URL" \
+  cargo test -p rustok-server \
+  --test forum_versioned_invalidation_deletion_acl_ordering \
+  -- --nocapture --test-threads=1
+```
+
+No command above was run by the implementation agent.

--- a/scripts/verify/verify-forum-search-versioned-invalidation-deletion-acl-ordering-proof.mjs
+++ b/scripts/verify/verify-forum-search-versioned-invalidation-deletion-acl-ordering-proof.mjs
@@ -1,0 +1,452 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = process.cwd();
+const read = (path) => readFileSync(resolve(root, path), "utf8");
+const requireAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(text.includes(marker), `${label} is missing required marker: ${marker}`);
+  }
+};
+const forbidAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(!text.includes(marker), `${label} contains forbidden marker: ${marker}`);
+  }
+};
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-search-versioned-invalidation-deletion-acl-ordering-proof.json";
+const parentContractPath =
+  "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json";
+const docPath =
+  "crates/rustok-forum/docs/forum-23b2g2b3d8-deletion-acl-ordering-proof.md";
+const testPath =
+  "apps/server/tests/forum_versioned_invalidation_deletion_acl_ordering.rs";
+const serverCargoPath = "apps/server/Cargo.toml";
+const moderationOwnerPath =
+  "crates/rustok-forum/src/services/moderation_owner.rs";
+const topicOwnerPath = "crates/rustok-forum/src/services/topic_owner.rs";
+const topicAudienceOwnerPath =
+  "crates/rustok-forum/src/services/topic_audience_owner.rs";
+const projectionSourcePath = "crates/rustok-forum/src/search_projection.rs";
+const publicDiscoveryPath =
+  "crates/rustok-forum/src/services/public_discovery.rs";
+const forumEligibilityPath =
+  "crates/rustok-forum/src/services/search_result_eligibility.rs";
+const serverEligibilityPath =
+  "apps/server/src/services/forum_search_result_eligibility.rs";
+const contractIngressPath =
+  "crates/rustok-search/src/forum_contract_ingress.rs";
+const inboxPath = "crates/rustok-search/src/forum_inbox.rs";
+const reconciliationPath =
+  "crates/rustok-search/src/forum_reconciliation.rs";
+const projectorPath = "crates/rustok-search/src/forum_projector.rs";
+const storefrontExecutionPath =
+  "crates/rustok-search/src/forum_storefront_execution.rs";
+const planPath = "crates/rustok-forum/docs/implementation-plan.md";
+const evidencePath =
+  "target/forum-search-versioned-invalidation-deletion-acl-ordering-evidence.json";
+
+const contract = JSON.parse(read(contractPath));
+assert.equal(
+  contract.contract,
+  "forum_search_versioned_invalidation_deletion_acl_ordering_proof_v1",
+);
+assert.equal(contract.task, "FORUM-23B2G2B3D8");
+assert.equal(contract.status, "source_ready_maintainer_execution_pending");
+assert.equal(contract.runtime_evidence_parent, parentContractPath);
+assert.equal(contract.test, testPath);
+assert.equal(contract.evidence_artifact.path, evidencePath);
+assert.equal(contract.evidence_artifact.generation, "executable_test_only");
+assert.equal(contract.evidence_artifact.hand_editing_forbidden, true);
+assert.equal(contract.evidence_artifact.source_commit_required, true);
+assert.equal(contract.required_runtime.database, "postgresql");
+assert.equal(
+  contract.required_runtime.database_env,
+  "RUSTOK_SEARCH_TEST_DATABASE_URL",
+);
+assert.equal(contract.required_runtime.host_package, "rustok-server");
+assert.equal(
+  contract.required_runtime.broker,
+  "not_required_for_bounded_ordering_and_visibility_proof",
+);
+assert.equal(contract.required_runtime.storefront_viewer, "anonymous_public");
+assert.deepEqual(contract.required_runtime.owner_mutations, [
+  "approved_reply_hidden",
+  "topic_deleted",
+  "topic_richer_audience_restricted",
+]);
+assert.equal(contract.scenario.id, "deletion_acl_ordering");
+assert.equal(contract.scenario.proves.length, 7);
+assert.ok(
+  contract.maintainer_command.includes(
+    "--test forum_versioned_invalidation_deletion_acl_ordering",
+  ),
+);
+
+const test = read(testPath);
+requireAll(
+  test,
+  [
+    "RUSTOK_SEARCH_TEST_DATABASE_URL",
+    "OutboxModule.migrations()",
+    "TaxonomyModule.migrations()",
+    "ForumModule.migrations()",
+    "SearchModule.migrations()",
+    "database_url_in_schema",
+    "ForumSearchProjectionSourceFactory.build",
+    "ForumProjectionReconciler::new",
+    "ForumSearchContractIngress::new",
+    "execute_forum_storefront_search",
+    "ForumSearchResultEligibilityService::new",
+    "ModerationService::new",
+    ".hide_reply(",
+    "TopicService::new",
+    ".delete(",
+    "ForumTopicAudiencePolicyService::new",
+    "roles_any: vec![UserRole::Customer]",
+    "after_hide_revision != baseline_revision + 1",
+    "after_delete_revision != after_hide_revision + 2",
+    "after_acl_revision != after_delete_revision + 1",
+    "revisions[1..].iter().rev()",
+    "insert_legacy_root(db, &deleted_legacy, \"forum\")",
+    "insert_legacy_root(db, &hidden_legacy, \"forum\")",
+    "ingest_typed_revision(db, fixture.tenant_id, &revisions[0])",
+    "duplicate root identity",
+    "inbox_order.len() != 6",
+    "report.claimed_events != 6",
+    "report.completed_events != 6",
+    "count_forum_document",
+    "insert_stale_search_documents",
+    "count_stale_markers",
+    "storefront owner did not reauthorize the exact stale candidates",
+    "d8hiddenreplymarker",
+    "d8deletedtopicmarker",
+    "d8acltopicmarker",
+    "visible facet",
+    evidencePath,
+    ".args([\"rev-parse\", \"HEAD\"])",
+  ],
+  "Forum Search deletion/ACL executable proof",
+);
+forbidAll(
+  test,
+  [
+    "#[ignore]",
+    "rustok_iggy",
+    "RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS",
+    "PersistentContractConsumerGroup",
+    "RUSTOK_FORUM_SEARCH_CONTRACT_CONSUMER_ENABLED",
+    "owner_revision == ingest_sequence",
+  ],
+  "Forum Search deletion/ACL executable proof",
+);
+
+const moderationOwner = read(moderationOwnerPath);
+requireAll(
+  moderationOwner,
+  [
+    "DomainEvent::ForumReplyStatusChanged",
+    "current == ReplyStatus::Approved && target != ReplyStatus::Approved",
+    "changed_category_id",
+    "publish_forum_category_projection_in_tx",
+  ],
+  "Forum reply hide owner path",
+);
+
+const topicOwner = read(topicOwnerPath);
+requireAll(
+  topicOwner,
+  [
+    "DomainEvent::ForumTopicStatusChanged",
+    "new_status: TopicStatus::Archived.to_string()",
+    "publish_forum_topic_projection_in_tx",
+    "publish_forum_category_projection_in_tx",
+    "mark_topic_thread_deleted_in_tx",
+  ],
+  "Forum topic delete owner path",
+);
+
+const topicAudienceOwner = read(topicAudienceOwnerPath);
+requireAll(
+  topicAudienceOwner,
+  [
+    "ForumTopicAudiencePolicyOwnerService",
+    "input.constraints.normalize()?",
+    "publish_forum_topic_projection_direct_in_tx",
+    "txn.commit().await?",
+  ],
+  "Forum richer topic audience owner path",
+);
+
+const projectionSource = read(projectionSourcePath);
+requireAll(
+  projectionSource,
+  [
+    "ForumPublicDiscoveryService::new",
+    "get_public_topic_with_locale_fallback",
+    "get_public_reply_with_locale_fallback",
+    "Some(&[ReplyStatus::Approved])",
+    "projected_reply",
+  ],
+  "Forum current-state projection source",
+);
+
+const publicDiscovery = read(publicDiscoveryPath);
+requireAll(
+  publicDiscovery,
+  [
+    "Canonical public discovery owner",
+    "requiring authentication, trust, Groups, explicit users, roles",
+    "get_public_topic_with_locale_fallback",
+    "get_public_reply_with_locale_fallback",
+  ],
+  "Forum public discovery fail-closed source",
+);
+
+const forumEligibility = read(forumEligibilityPath);
+requireAll(
+  forumEligibility,
+  [
+    "filter_public_storefront_visible",
+    "ForumTopicAudienceVisibilityService::new",
+    "ReplyStatus::Approved",
+    "visible_topics",
+    "allowed.push(*candidate)",
+  ],
+  "Forum Search result owner eligibility",
+);
+
+const serverEligibility = read(serverEligibilityPath);
+requireAll(
+  serverEligibility,
+  [
+    "ServerForumSearchResultEligibilityPort",
+    "ForumSearchResultEligibilityService::new",
+    "filter_public_storefront_visible",
+    "StorefrontSearchResultEligibilityPort",
+    "ensure_forum_enabled",
+  ],
+  "server Forum result eligibility adapter",
+);
+
+const contractIngress = read(contractIngressPath);
+requireAll(
+  contractIngress,
+  [
+    "ForumSearchContractIngress",
+    "causation_id()",
+    "root_event_id",
+    "self.inbox",
+    "verify_durable_root",
+    "InboxIdentityConflict",
+  ],
+  "typed Forum invalidation ingress",
+);
+const inbox = read(inboxPath);
+requireAll(
+  inbox,
+  [
+    "INSERT INTO search_projection_inbox",
+    "ON CONFLICT (event_id) DO NOTHING",
+    "ORDER BY ingest_sequence ASC",
+    "ForumReplyStatusChanged",
+    "ForumTopicStatusChanged",
+  ],
+  "durable Forum Search inbox",
+);
+
+const reconciliation = read(reconciliationPath);
+requireAll(
+  reconciliation,
+  [
+    "DomainEvent::ForumReplyStatusChanged",
+    "DomainEvent::ForumTopicStatusChanged",
+    "self.forum_projector",
+    "rebuild_tenant(envelope.tenant_id)",
+    '("forum_topic", Some(_))',
+    '("forum_category", Some(category_id))',
+    "refresh_entity",
+  ],
+  "production Forum Search reconciliation",
+);
+
+const projector = read(projectorPath);
+requireAll(
+  projector,
+  [
+    "self.source",
+    ".list_public_documents(",
+    "delete_forum_scope(&tx, tenant_id)",
+    "INSERT INTO search_documents",
+    "if entity_type == FORUM_TOPIC_ENTITY_TYPE",
+    "return self.rebuild_tenant(tenant_id).await",
+    "delete_forum_entity",
+  ],
+  "production Forum current-state projector",
+);
+
+const storefrontExecution = read(storefrontExecutionPath);
+requireAll(
+  storefrontExecution,
+  [
+    "resolve_storefront_search_result_candidates",
+    "let total = visible_items.len() as u64",
+    "build_forum_result_facets(&visible_items)",
+    ".skip(query.offset)",
+    ".take(query.limit)",
+    "Forum storefront Search requires an explicit Forum-only resolved source scope",
+  ],
+  "production storefront eligibility ordering",
+);
+const eligibilityIndex = storefrontExecution.indexOf(
+  "resolve_storefront_search_result_candidates",
+);
+const totalIndex = storefrontExecution.indexOf(
+  "let total = visible_items.len() as u64",
+);
+const facetsIndex = storefrontExecution.indexOf(
+  "build_forum_result_facets(&visible_items)",
+);
+const offsetIndex = storefrontExecution.indexOf(".skip(query.offset)");
+assert.ok(eligibilityIndex >= 0 && eligibilityIndex < totalIndex);
+assert.ok(totalIndex >= 0 && totalIndex < facetsIndex);
+assert.ok(facetsIndex >= 0 && facetsIndex < offsetIndex);
+
+const serverCargo = read(serverCargoPath);
+requireAll(
+  serverCargo,
+  [
+    "rustok-core = { workspace = true, features = [\"redis-cache\", \"server\"] }",
+    "rustok-api = { workspace = true, features = [\"server\"] }",
+    "rustok-events.workspace = true",
+    "rustok-forum     = { workspace = true, optional = true }",
+    "rustok-search = { workspace = true, features = [\"graphql\"] }",
+    "rustok-outbox.workspace = true",
+    "rustok-taxonomy  = { workspace = true, optional = true }",
+    "sea-orm.workspace = true",
+    "sea-orm-migration.workspace = true",
+    "tokio.workspace = true",
+    "serde.workspace = true",
+    "serde_json.workspace = true",
+    "uuid.workspace = true",
+    "chrono.workspace = true",
+    "async-trait.workspace = true",
+  ],
+  "rustok-server existing host dependencies",
+);
+
+const doc = read(docPath);
+requireAll(
+  doc,
+  [
+    "`source_ready_maintainer_execution_pending`",
+    "FORUM-23B2G2B3D8",
+    contractPath,
+    testPath,
+    evidencePath,
+    "revision N+1: forum_category",
+    "owner revision N+4",
+    "legacy reply-hide status root",
+    "deliberately stale `search_documents` rows",
+    "total: 0",
+    "No command above was run by the implementation agent",
+  ],
+  "Forum Search deletion/ACL handoff",
+);
+
+const parent = JSON.parse(read(parentContractPath));
+assert.equal(parent.task, "FORUM-23B2G2B3D0");
+assert.equal(parent.status, "source_ready_maintainer_execution_pending");
+assert.deepEqual(
+  parent.required_scenarios.map(({ id }) => id),
+  [
+    "normal_delivery",
+    "legacy_first_duplicate",
+    "typed_first_duplicate",
+    "acknowledgement_failure_restart",
+    "raw_poison_dlq_redelivery",
+    "semantic_poison_identity_conflict",
+    "missing_delivery_owner_repair",
+    "multi_process_serialization",
+    "deletion_acl_ordering",
+    "search_disabled_profile",
+  ],
+);
+for (const task of [
+  "FORUM-23B2G2B3D2",
+  "FORUM-23B2G2B3D3",
+  "FORUM-23B2G2B3D4",
+  "FORUM-23B2G2B3D5",
+  "FORUM-23B2G2B3D6",
+  "FORUM-23B2G2B3D7",
+  "FORUM-23B2G2B3D8",
+]) {
+  assert.ok(
+    parent.source_ready_subproofs.some((subproof) => subproof.task === task),
+    `${task} disappeared from the D0 source-ready subproof list`,
+  );
+}
+const subproof = parent.source_ready_subproofs.find(
+  ({ task }) => task === "FORUM-23B2G2B3D8",
+);
+assert.equal(subproof.contract, contractPath);
+assert.equal(subproof.test, testPath);
+assert.equal(subproof.evidence_artifact, evidencePath);
+assert.deepEqual(subproof.covers, [
+  "owner_hide_delete_and_richer_acl_revisions",
+  "legacy_and_typed_dual_path_out_of_order_admission",
+  "durable_duplicate_root_suppression",
+  "current_state_rebuild_and_stale_category_refresh_non_restoration",
+  "search_projection_denied_objects_absent",
+  "storefront_owner_reauthorization_rejects_stale_rows",
+  "visible_totals_items_and_facets_exclude_denied_content",
+]);
+assert.deepEqual(subproof.does_not_cover, [
+  "long_running_host_polling_or_restart_timing",
+  "iggy_acknowledgement_poison_or_dlq",
+  "search_disabled_profile_or_link_forum_03",
+]);
+assert.ok(
+  parent.maintainer_commands.includes(
+    "node scripts/verify/verify-forum-search-versioned-invalidation-deletion-acl-ordering-proof.mjs",
+  ),
+);
+assert.ok(
+  parent.maintainer_commands.some((command) =>
+    command.includes("--test forum_versioned_invalidation_deletion_acl_ordering"),
+  ),
+);
+
+const plan = read(planPath);
+const forum23Start = plan.indexOf("## `FORUM-23` — search/index integration");
+const forum24Start = plan.indexOf("## `FORUM-24` — localized routes", forum23Start);
+assert.ok(forum23Start >= 0 && forum24Start > forum23Start);
+const forum23 = plan.slice(forum23Start, forum24Start);
+requireAll(
+  forum23,
+  [
+    "**Status:** `in_progress`",
+    "FORUM-23B2G2B3D0",
+    "source_ready_maintainer_execution_pending",
+    "execute and retain every D0 PostgreSQL/Iggy scenario",
+    "`LINK-FORUM-03` cross-module runtime proof",
+  ],
+  "FORUM-23 canonical aggregate boundary",
+);
+forbidAll(
+  forum23,
+  [
+    "D8 closes FORUM-23",
+    "deletion/ACL runtime evidence passed",
+    "LINK-FORUM-03 is complete",
+  ],
+  "FORUM-23 canonical aggregate boundary",
+);
+
+console.log(
+  "Forum Search deletion/ACL ordering proof is source-synchronized.",
+);


### PR DESCRIPTION
## What changed

- add `FORUM-23B2G2B3D8`, the deletion/ACL ordering subset of the frozen Forum Search D0 runtime-evidence matrix;
- apply real Outbox, Taxonomy, Forum and Search migrations in one isolated PostgreSQL schema;
- create an initially searchable approved reply, future-deleted topic and future richer-ACL-denied topic through real Forum services;
- execute real reply hide, topic delete and topic audience-policy owner transactions and assert the exact contiguous revision shape;
- admit typed owner invalidations in reverse order, interleave legacy delete/hide roots, and process the oldest category revision last;
- redeliver one typed and one legacy root and require exactly one durable Search inbox identity per root UUID;
- run the production Forum projection source and Search reconciler and require that no denied document remains after all six unique roots complete;
- deliberately reinsert stale apparently-visible Search rows for all three denied objects;
- run production Forum storefront Search with current owner eligibility and require zero totals, items and visible facet buckets for the anonymous viewer;
- generate `target/forum-search-versioned-invalidation-deletion-acl-ordering-evidence.json` only after the scenario and PostgreSQL cleanup succeed;
- register D8 in D0 and add a focused static guard for owner invalidation, durable ordering, current-state projection and eligibility-before-total behavior.

## Deliberate boundary

This PR does not execute the long-running host polling loop or restart scheduling. It does not use Iggy acknowledgement, poison or DLQ behavior. It does not validate the Search-disabled profile, aggregate `FORUM-23B2G2B3D` completion, or closure of `LINK-FORUM-03`.

## Compatibility

No production Rust path, dependency, migration, event schema or digest, public DTO, Search query, runtime flag, `Cargo.toml`, or `Cargo.lock` entry changes.

## Validation

Tests, Node verifiers, formatting, Cargo checks, workflows, CI and PostgreSQL execution were intentionally not run, per maintainer request.