### PR TITLE
feat(index): replay SalesChannel tombstones

### DIFF
--- a/crates/rustok-channel/README.md
+++ b/crates/rustok-channel/README.md
@@ -16,9 +16,9 @@
 - Back the shared request-level `ChannelContext` used by host transport layers.
 - Own the domain resolution pipeline (`RequestFacts -> ResolutionDecision`) that host middleware applies.
 - Own the durable database generation used to recover channel-resolution caches across serving replicas.
-- Own a positive monotonic `channels.index_revision` storage column. Every Channel update advances it exactly once; the value remains storage-internal and is not exposed through Channel DTOs or the SeaORM write model.
+- Own a positive monotonic `channels.index_revision` storage column and retained `channel_index_tombstones`. Every Channel update advances the live revision exactly once; hard deletion retains an exact source version strictly above the final live row. These values remain storage-internal and are not exposed through Channel DTOs or the SeaORM write model.
 - Publish only a neutral `ChannelRuntimeSelected` marker for selected cross-module composition. The Channel crate does not depend on `rustok-index` and does not construct generic Index mutations.
-- The selected `rustok-distribution` bridge publishes the non-localized `rustok-channel::sales_channel@1` schema and a bounded current-state source. Replay enumeration uses stable `channel_id` ordering, while `index_revision` is used only as generic mutation `source_version`. Hard-delete tombstones, versioned Product links, and authoritative consumer cutover remain later slices.
+- The selected `rustok-distribution` bridge publishes the non-localized `rustok-channel::sales_channel@1` schema and one bounded source. Replay enumeration uses stable `channel_id` ordering and returns live upserts or retained hard-delete mutations from the same source identity; `index_revision` is used only as generic mutation `source_version`. Incremental acknowledgement, versioned Product links, and authoritative consumer cutover remain later slices.
 - Ship the module-owned Leptos admin UI package for channel management.
 - Expose `ChannelReadPort` / `channel.read_projection.v1` as the FBA provider boundary for channel/default/host-target read projections, with deadline-aware read semantics and no-compile executable fallback smoke evidence until executable runtime smoke is available.
 
@@ -27,6 +27,7 @@
 This crate intentionally ships a minimal v0 model:
 
 - `channels`
+- `channel_index_tombstones` as storage-internal replay identity state
 - `channel_targets`
 - `channel_module_bindings`
 - `channel_oauth_apps`
@@ -57,7 +58,7 @@ Previously validated baseline:
 - `npm run verify:channel:resolution-contract` (no-compile resolution order and built-in host fast-path decision gate)
 - `npm run verify:channel:proof-points` (no-compile pages/blog/commerce/forum proof-point source/docs sync gate)
 
-The new durable-generation path remains source-complete until the current permanent cache workflow and multi-replica failure-recovery scenarios pass on the same revision.
+The new durable-generation path remains source-complete until the current permanent cache workflow and multi-replica failure-recovery scenarios pass on the same revision. The Index tombstone path likewise remains source-complete until the owner executes delete/recreate and replay evidence.
 
 It does not yet provide:
 
@@ -73,7 +74,7 @@ It does not yet provide:
 - `rustok-cache` supplies bounded invalidation transport; Redis PubSub is an acceleration path rather than the durable source of truth.
 - `rustok-api` hosts the shared `ChannelContext` and request-level contracts.
 - `rustok-auth` remains the source of truth for OAuth applications and tokens.
-- `rustok-distribution` consumes the neutral selection marker and Channel-owned table contract to publish generic SalesChannel Index schema/source capabilities; Index core and server remain Channel-agnostic.
+- `rustok-distribution` consumes the neutral selection marker and Channel-owned live/tombstone table contract to publish generic SalesChannel Index schema/source capabilities; Index core and server remain Channel-agnostic.
 - Domain modules may gradually become channel-aware by reading channel context or channel bindings.
 - The Leptos admin UI lives in `crates/rustok-channel/admin` and is mounted by `apps/admin` through manifest-driven wiring.
 
@@ -89,6 +90,7 @@ It does not yet provide:
 ## Next Steps
 
 - Execute the permanent cache workflow and multi-replica durable-generation recovery scenarios.
+- Execute SalesChannel hard-delete, identity-reuse, replay, reconciliation, and restart evidence before admitting an authoritative Index consumer.
 - Keep the current `channel_module_bindings + metadata` model for v0 while `pages` and `blog` continue to serve as proof points.
 - Revisit a dedicated relation model only if future domains need stronger DB-level querying, authoring UX, or semantics that request-time filtering can no longer cover cleanly.
 - Decide later whether `target`, `connector`, and publishable credentials should become separate concepts.

--- a/crates/rustok-channel/src/migrations/m20260731_000011_add_channel_index_tombstones.rs
+++ b/crates/rustok-channel/src/migrations/m20260731_000011_add_channel_index_tombstones.rs
@@ -1,0 +1,220 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::DatabaseBackend;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() != DatabaseBackend::Postgres {
+            return Err(DbErr::Custom(
+                "rustok-channel migrations require PostgreSQL".to_owned(),
+            ));
+        }
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+CREATE TABLE channel_index_tombstones (
+    tenant_id UUID NOT NULL,
+    channel_id UUID NOT NULL,
+    source_version BIGINT NOT NULL,
+    deleted_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (tenant_id, channel_id),
+    CONSTRAINT chk_channel_index_tombstones_source_version_positive CHECK (source_version > 0)
+);
+
+CREATE OR REPLACE FUNCTION rustok_channel_store_index_tombstone(
+    target_tenant_id UUID,
+    target_channel_id UUID,
+    target_source_version BIGINT
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    INSERT INTO channel_index_tombstones (
+        tenant_id,
+        channel_id,
+        source_version,
+        deleted_at
+    ) VALUES (
+        target_tenant_id,
+        target_channel_id,
+        target_source_version,
+        CURRENT_TIMESTAMP
+    )
+    ON CONFLICT (tenant_id, channel_id) DO UPDATE
+    SET source_version = GREATEST(
+            channel_index_tombstones.source_version,
+            EXCLUDED.source_version
+        ),
+        deleted_at = CURRENT_TIMESTAMP;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION rustok_channel_clear_superseded_index_tombstone(
+    target_tenant_id UUID,
+    target_channel_id UUID,
+    live_source_version BIGINT
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM channel_index_tombstones tombstone
+        WHERE tombstone.tenant_id = target_tenant_id
+          AND tombstone.channel_id = target_channel_id
+          AND tombstone.source_version >= live_source_version
+    ) THEN
+        RAISE EXCEPTION
+            'channel live index revision does not supersede retained tombstone for channel %',
+            target_channel_id;
+    END IF;
+
+    DELETE FROM channel_index_tombstones
+    WHERE tenant_id = target_tenant_id
+      AND channel_id = target_channel_id
+      AND source_version < live_source_version;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION rustok_channel_seed_index_revision_from_tombstone()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    retained_source_version BIGINT;
+BEGIN
+    SELECT source_version
+      INTO retained_source_version
+      FROM channel_index_tombstones
+     WHERE tenant_id = NEW.tenant_id
+       AND channel_id = NEW.id;
+
+    IF retained_source_version IS NOT NULL THEN
+        IF retained_source_version = 9223372036854775807 THEN
+            RAISE EXCEPTION 'channel index revision exhausted for reused channel %', NEW.id;
+        END IF;
+        NEW.index_revision := GREATEST(NEW.index_revision, retained_source_version + 1);
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_channels_seed_index_revision
+BEFORE INSERT ON channels
+FOR EACH ROW
+EXECUTE FUNCTION rustok_channel_seed_index_revision_from_tombstone();
+
+CREATE OR REPLACE FUNCTION rustok_channel_capture_index_tombstone()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.index_revision = 9223372036854775807 THEN
+        RAISE EXCEPTION 'channel index revision exhausted for deleted channel %', OLD.id;
+    END IF;
+
+    PERFORM rustok_channel_store_index_tombstone(
+        OLD.tenant_id,
+        OLD.id,
+        OLD.index_revision + 1
+    );
+    RETURN OLD;
+END;
+$$;
+
+CREATE TRIGGER trg_channels_capture_index_tombstone
+BEFORE DELETE ON channels
+FOR EACH ROW
+EXECUTE FUNCTION rustok_channel_capture_index_tombstone();
+
+CREATE OR REPLACE FUNCTION rustok_channel_clear_inserted_index_tombstone()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM rustok_channel_clear_superseded_index_tombstone(
+        NEW.tenant_id,
+        NEW.id,
+        NEW.index_revision
+    );
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_channels_clear_index_tombstone
+AFTER INSERT ON channels
+FOR EACH ROW
+EXECUTE FUNCTION rustok_channel_clear_inserted_index_tombstone();
+
+CREATE OR REPLACE FUNCTION rustok_channel_move_index_tombstone()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.tenant_id IS NOT DISTINCT FROM NEW.tenant_id
+       AND OLD.id IS NOT DISTINCT FROM NEW.id THEN
+        RETURN NEW;
+    END IF;
+
+    PERFORM rustok_channel_store_index_tombstone(
+        OLD.tenant_id,
+        OLD.id,
+        NEW.index_revision
+    );
+    PERFORM rustok_channel_clear_superseded_index_tombstone(
+        NEW.tenant_id,
+        NEW.id,
+        NEW.index_revision
+    );
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_channels_move_index_tombstone
+AFTER UPDATE OF id, tenant_id ON channels
+FOR EACH ROW
+EXECUTE FUNCTION rustok_channel_move_index_tombstone();
+"#,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() != DatabaseBackend::Postgres {
+            return Err(DbErr::Custom(
+                "rustok-channel migrations require PostgreSQL".to_owned(),
+            ));
+        }
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+DROP TRIGGER IF EXISTS trg_channels_move_index_tombstone ON channels;
+DROP TRIGGER IF EXISTS trg_channels_clear_index_tombstone ON channels;
+DROP TRIGGER IF EXISTS trg_channels_capture_index_tombstone ON channels;
+DROP TRIGGER IF EXISTS trg_channels_seed_index_revision ON channels;
+DROP FUNCTION IF EXISTS rustok_channel_move_index_tombstone();
+DROP FUNCTION IF EXISTS rustok_channel_clear_inserted_index_tombstone();
+DROP FUNCTION IF EXISTS rustok_channel_capture_index_tombstone();
+DROP FUNCTION IF EXISTS rustok_channel_seed_index_revision_from_tombstone();
+DROP FUNCTION IF EXISTS rustok_channel_clear_superseded_index_tombstone(UUID, UUID, BIGINT);
+DROP FUNCTION IF EXISTS rustok_channel_store_index_tombstone(UUID, UUID, BIGINT);
+DROP TABLE IF EXISTS channel_index_tombstones;
+"#,
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/crates/rustok-channel/src/migrations/mod.rs
+++ b/crates/rustok-channel/src/migrations/mod.rs
@@ -10,6 +10,7 @@ mod m20260327_000007_create_channel_resolution_policy_sets;
 mod m20260327_000008_create_channel_resolution_policy_rules;
 mod m20260716_000009_create_channel_resolution_invalidation_state;
 mod m20260730_000010_add_channel_index_revision;
+mod m20260731_000011_add_channel_index_tombstones;
 
 use rustok_core::MigrationDependencyDescriptor;
 use sea_orm_migration::MigrationTrait;
@@ -26,6 +27,7 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260327_000008_create_channel_resolution_policy_rules::Migration),
         Box::new(m20260716_000009_create_channel_resolution_invalidation_state::Migration),
         Box::new(m20260730_000010_add_channel_index_revision::Migration),
+        Box::new(m20260731_000011_add_channel_index_tombstones::Migration),
     ]
 }
 

--- a/crates/rustok-distribution/src/channel_index.rs
+++ b/crates/rustok-distribution/src/channel_index.rs
@@ -19,17 +19,59 @@ pub(crate) const SALES_CHANNEL_INDEX_SOURCE: &str = "sales-channel-postgres-prim
 const SALES_CHANNEL_INDEX_FACTORY: &str = "sales-channel-postgres-primary";
 const SALES_CHANNEL_EVENT_DOMAIN: &str = "rustok-channel.sales-channel-replay-v1";
 
-const SALES_CHANNEL_SELECT: &str = r#"
+const SALES_CHANNEL_ROWS_CTE: &str = r#"
+sales_channel_index_union AS (
+    SELECT
+        FALSE AS is_deleted,
+        c.tenant_id,
+        c.id AS channel_id,
+        c.index_revision,
+        c.slug,
+        c.name,
+        c.is_active,
+        c.is_default,
+        c.status
+    FROM channels c
+    WHERE c.tenant_id = $1
+
+    UNION ALL
+
+    SELECT
+        TRUE AS is_deleted,
+        tombstone.tenant_id,
+        tombstone.channel_id,
+        tombstone.source_version AS index_revision,
+        NULL::text AS slug,
+        NULL::text AS name,
+        NULL::boolean AS is_active,
+        NULL::boolean AS is_default,
+        NULL::text AS status
+    FROM channel_index_tombstones tombstone
+    WHERE tombstone.tenant_id = $1
+),
+sales_channel_index_rows AS (
+    SELECT
+        row.*,
+        COUNT(*) OVER (
+            PARTITION BY row.tenant_id, row.channel_id
+        ) AS identity_count
+    FROM sales_channel_index_union row
+)
+"#;
+
+const SALES_CHANNEL_ROW_SELECT: &str = r#"
 SELECT
-    c.tenant_id,
-    c.id AS channel_id,
-    c.index_revision,
-    c.slug,
-    c.name,
-    c.is_active,
-    c.is_default,
-    c.status
-FROM channels c
+    row.is_deleted,
+    row.identity_count,
+    row.tenant_id,
+    row.channel_id,
+    row.index_revision,
+    row.slug,
+    row.name,
+    row.is_active,
+    row.is_default,
+    row.status
+FROM sales_channel_index_rows row
 "#;
 
 #[derive(Debug, Error)]
@@ -163,7 +205,7 @@ impl SalesChannelPostgresIndexSource {
         let (sql, values): (String, Vec<Value>) = match cursor {
             Some(cursor) => (
                 format!(
-                    "{SALES_CHANNEL_SELECT}\nWHERE c.tenant_id = $1\n  AND c.id > $2\nORDER BY c.id ASC\nLIMIT $3"
+                    "WITH {SALES_CHANNEL_ROWS_CTE}\n{SALES_CHANNEL_ROW_SELECT}\nWHERE row.channel_id > $2\nORDER BY row.channel_id ASC\nLIMIT $3"
                 ),
                 vec![
                     request.tenant_id().into(),
@@ -173,7 +215,7 @@ impl SalesChannelPostgresIndexSource {
             ),
             None => (
                 format!(
-                    "{SALES_CHANNEL_SELECT}\nWHERE c.tenant_id = $1\nORDER BY c.id ASC\nLIMIT $2"
+                    "WITH {SALES_CHANNEL_ROWS_CTE}\n{SALES_CHANNEL_ROW_SELECT}\nORDER BY row.channel_id ASC\nLIMIT $2"
                 ),
                 vec![request.tenant_id().into(), fetch_limit.into()],
             ),
@@ -200,7 +242,7 @@ impl SalesChannelPostgresIndexSource {
             values.push(key.entity_id.into());
         }
         let sql = format!(
-            "WITH requested(channel_id) AS (VALUES {})\n{SALES_CHANNEL_SELECT}\nJOIN requested r ON r.channel_id = c.id\nWHERE c.tenant_id = $1\nORDER BY c.id ASC",
+            "WITH requested(channel_id) AS (VALUES {}),\n{SALES_CHANNEL_ROWS_CTE}\n{SALES_CHANNEL_ROW_SELECT}\nJOIN requested requested_key ON requested_key.channel_id = row.channel_id\nORDER BY row.channel_id ASC",
             rows.join(", ")
         );
         self.db
@@ -295,6 +337,17 @@ struct SalesChannelRow {
     tenant_id: Uuid,
     channel_id: Uuid,
     source_version: u64,
+    state: SalesChannelRowState,
+}
+
+#[derive(Debug)]
+enum SalesChannelRowState {
+    Live(SalesChannelLiveFields),
+    Deleted,
+}
+
+#[derive(Debug)]
+struct SalesChannelLiveFields {
     slug: String,
     name: String,
     is_active: bool,
@@ -307,6 +360,12 @@ impl SalesChannelRow {
         row: QueryResult,
         expected_tenant: Uuid,
     ) -> Result<Self, SalesChannelIndexBridgeError> {
+        let is_deleted = row
+            .try_get::<bool>("", "is_deleted")
+            .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
+        let identity_count = row
+            .try_get::<i64>("", "identity_count")
+            .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
         let tenant_id = row
             .try_get::<Uuid>("", "tenant_id")
             .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
@@ -316,27 +375,41 @@ impl SalesChannelRow {
         let revision = row
             .try_get::<i64>("", "index_revision")
             .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
-        if tenant_id != expected_tenant
+        if identity_count != 1
+            || tenant_id != expected_tenant
             || tenant_id.is_nil()
             || channel_id.is_nil()
             || revision <= 0
         {
             return Err(SalesChannelIndexBridgeError::InvalidRow);
         }
+        let source_version =
+            u64::try_from(revision).map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
+
+        if is_deleted {
+            return Ok(Self {
+                tenant_id,
+                channel_id,
+                source_version,
+                state: SalesChannelRowState::Deleted,
+            });
+        }
+
         Ok(Self {
             tenant_id,
             channel_id,
-            source_version: u64::try_from(revision)
-                .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?,
-            slug: required_string(&row, "slug")?,
-            name: required_string(&row, "name")?,
-            is_active: row
-                .try_get::<bool>("", "is_active")
-                .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?,
-            is_default: row
-                .try_get::<bool>("", "is_default")
-                .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?,
-            status: required_string(&row, "status")?,
+            source_version,
+            state: SalesChannelRowState::Live(SalesChannelLiveFields {
+                slug: required_string(&row, "slug")?,
+                name: required_string(&row, "name")?,
+                is_active: row
+                    .try_get::<bool>("", "is_active")
+                    .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?,
+                is_default: row
+                    .try_get::<bool>("", "is_default")
+                    .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?,
+                status: required_string(&row, "status")?,
+            }),
         })
     }
 
@@ -355,27 +428,40 @@ impl SalesChannelRow {
             self.source_version,
         )
         .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
+        let key = EntityKey {
+            tenant_id: self.tenant_id,
+            schema: sales_channel_schema_ref()
+                .map_err(SalesChannelIndexBridgeError::InvalidContract)?,
+            entity_id: self.channel_id,
+            locale: None,
+        };
+
+        let SalesChannelRowState::Live(live) = self.state else {
+            return Ok(IndexMutation::Delete {
+                event_id,
+                key,
+                source_version: self.source_version,
+            });
+        };
+
         let fields = BTreeMap::from([
             (field_name("id")?, IndexValue::Uuid(self.channel_id)),
-            (field_name("slug")?, IndexValue::String(self.slug)),
-            (field_name("name")?, IndexValue::String(self.name)),
-            (field_name("is_active")?, IndexValue::Boolean(self.is_active)),
+            (field_name("slug")?, IndexValue::String(live.slug)),
+            (field_name("name")?, IndexValue::String(live.name)),
+            (
+                field_name("is_active")?,
+                IndexValue::Boolean(live.is_active),
+            ),
             (
                 field_name("is_default")?,
-                IndexValue::Boolean(self.is_default),
+                IndexValue::Boolean(live.is_default),
             ),
-            (field_name("status")?, IndexValue::String(self.status)),
+            (field_name("status")?, IndexValue::String(live.status)),
         ]);
         Ok(IndexMutation::Upsert {
             event_id,
             record: IndexRecord {
-                key: EntityKey {
-                    tenant_id: self.tenant_id,
-                    schema: sales_channel_schema_ref()
-                        .map_err(SalesChannelIndexBridgeError::InvalidContract)?,
-                    entity_id: self.channel_id,
-                    locale: None,
-                },
+                key,
                 source_version: self.source_version,
                 fields,
                 links: Vec::new(),
@@ -440,6 +526,45 @@ mod tests {
         ] {
             let cursor = IndexSourceCursor::new(value).unwrap();
             assert!(SalesChannelCursor::decode(&cursor).is_err());
+        }
+    }
+
+    #[test]
+    fn selected_sales_channel_tombstone_emits_delete_with_stable_identity() {
+        let tenant_id = Uuid::from_u128(1);
+        let channel_id = Uuid::from_u128(2);
+        let mutation = SalesChannelRow {
+            tenant_id,
+            channel_id,
+            source_version: 7,
+            state: SalesChannelRowState::Deleted,
+        }
+        .into_mutation()
+        .unwrap();
+
+        match mutation {
+            IndexMutation::Delete {
+                event_id,
+                key,
+                source_version,
+            } => {
+                assert_eq!(key.tenant_id, tenant_id);
+                assert_eq!(key.entity_id, channel_id);
+                assert_eq!(key.locale, None);
+                assert_eq!(source_version, 7);
+                assert_eq!(
+                    event_id,
+                    derive_index_source_event_id(
+                        SALES_CHANNEL_EVENT_DOMAIN,
+                        tenant_id,
+                        channel_id,
+                        None,
+                        7,
+                    )
+                    .unwrap()
+                );
+            }
+            IndexMutation::Upsert { .. } => panic!("retained delete must not become an upsert"),
         }
     }
 

--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -97,7 +97,7 @@ pull requests record checks and PostgreSQL runs that were not executed.
   event acknowledgement, persisted per-tenant schema readiness, durable
   Product-to-SalesChannel relations, freshness/recovery evidence, authoritative
   consumer cutover, tombstone purge admission, and production partition lifecycle
-  remain open.
+  remain open
 
 The production crate contains the generic domain/application core, seven canonical
 M3 tables, an atomic mutation adapter, durable schema leases, secondary-index
@@ -113,10 +113,10 @@ repeatable-read page/count snapshot, source-owned schema and replay catalogs, a
 neutral bounded `IndexSource` scan/load boundary, a one-page replay executor,
 `PostgresIndexReplayJobStore` for durable fenced schema-scoped rebuild ownership,
 a lease-bound PostgreSQL rebuild-checkpoint adapter, `PostgresIndexReplayRunner` for
-bounded heartbeat/yield/cancellation execution, a bounded multi-pass reconciliation
-runner with durable pass/source cursor state, `SharedIndexReplayRuntime` for host
-capability transfer, and atomic host-database-aware source factory composition. The
-server publishes `IndexReplayOperatorRuntime` as the request-bound authorization
+bounded heartbeat/yield/cancellation execution, a bounded multi-pass source
+reconciliation runner with durable pass/source cursor state, `SharedIndexReplayRuntime`
+for host capability transfer, and atomic host-database-aware source factory composition.
+The server publishes `IndexReplayOperatorRuntime` as the request-bound authorization
 boundary. The selected distribution contributes Product, ProductVariant, and
 SalesChannel schemas/sources without adding source-domain dependencies to Index core
 or server. Owner-operated evidence tools live under `ops/benches`; they do not become
@@ -141,7 +141,7 @@ they do not move storage ownership into Index or server.
 ```text
 source modules
     -> IndexSchemaSourceCatalog / IndexSourceCatalog / IndexMutation
-    -> ingestion, rebuild, and reconciliation engines
+    -> ingestion and rebuild engines
     -> PostgreSQL index storage
     -> schema/link registry and query planner
     -> SQL compiler
@@ -169,7 +169,7 @@ crates/rustok-index/src/
     source_replay.rs
     source_replay_job.rs
     source_replay_runner.rs
-    source_reconciliation.rs
+    source_reconciliation_runner.rs
     replay_runtime.rs
     schema_lease.rs
     secondary_index.rs
@@ -312,12 +312,58 @@ relations.
 
 #### Completed M3 slices
 
-Canonical migrations, atomic mutation persistence, schema leases, secondary-index
-lifecycle, fail-closed partition admission, exact-byte retained packet tooling,
-baseline/shadow capture, query/mutation/WAL/maintenance/cutover evidence runners,
-full-capture orchestration, read-only retained review, admitted archive manifests,
-and recursive filesystem integrity checks are source complete. Real PostgreSQL
-execution and admission remain owner steps.
+1. Canonical migrations register the seven module-owned tables with complete tenant,
+   schema, entity, locale, and full-range non-negative source-version identity.
+2. `PostgresMutationStore` validates deliveries, claims the composite inbox key,
+   serializes the entity key, and applies entity/tombstone/link replacement atomically.
+3. `PostgresSchemaLeaseStore` provides durable schema-application exclusion,
+   reclaim, heartbeat, terminal completion, and attempt fencing.
+4. `SecondaryIndexPlan` and `PostgresSecondaryIndexManager` derive typed/GIN indexes,
+   coordinate concurrent ensure/reindex/retire work, and verify catalog readiness.
+5. `PartitionAdmissionPolicy` and `PartitionShadowPlan` implement measured,
+   fail-closed admission and deterministic shadow-only hash partition DDL.
+6. Immutable manifest preparation and packet validation bind commit, image, modulus,
+   repetitions, thresholds, evidence identity, raw hashes, and calculated reasons.
+7. `index_partition_capture_v1` assembly reads six unique confined raw files once,
+   calculates exact-byte hashes, validates the packet, and refuses overwrite/aliases.
+8. The snapshot runner creates evidence-bound shadow parents/children, copies one
+   repeatable-read baseline, attaches shadow integrity, records parity/size/catch-up,
+   and publishes `baseline.json` plus `shadow.json` without touching canonical DDL.
+9. The query runner validates the shadow catalog, executes exact tenant-scoped runs
+   read-only, proves semantic parity and one-child pruning, retains full EXPLAIN JSON,
+   calculates p95 and normalized plan digests, and publishes `query.json` once.
+10. The mutation/WAL runner validates the same manifest and catalog, requires count
+    parity and matching generic anchors, executes rollback-only mutation samples,
+    proves one-child shadow pruning, retains EXPLAIN JSON and WAL evidence, and
+    publishes `mutation.json` without overwrite. Real database execution remains an
+    owner step.
+11. The maintenance runner revalidates the manifest and retained shadow catalog,
+    creates isolated ordinary and tenant-hash clone pairs, applies identical committed
+    churn only to those clones, times ordinary `VACUUM (ANALYZE)`, proves production
+    and retained snapshot-shadow relations unchanged, and publishes
+    `maintenance.json` without overwrite. Real database execution remains an owner
+    step.
+12. The cutover rehearsal runner validates production and retained shadow identities,
+    creates deterministic evidence-only ordinary clones, measures `ACCESS EXCLUSIVE`
+    lock acquisition, performs rename swaps only inside rollback-only transactions,
+    proves clone OIDs/names and production relations unchanged, and publishes
+    `cutover.json` without overwrite. Real database execution remains an owner step.
+13. The full-capture orchestrator requires one explicit owner opt-in, one immutable
+    manifest, one database URL, and a fresh empty output directory. It sequentially
+    runs all five evidence commands, finalizes `capture.json` with PostgreSQL identity
+    and run provenance, assembles exact retained bytes into `partition-packet.json`,
+    validates `admission.json`, and refuses partial-output reuse or resume.
+14. The retained bundle review inspects exactly nine authoritative files, recalculates
+    exact-byte packet assembly and admission, rejects aliases or drift, and renders a
+    deterministic read-only owner report without editing the bundle.
+15. The archive tooling emits a deterministic admitted-only manifest outside the
+    immutable bundle and verifies a saved manifest into a read-only receipt with
+    `production_lifecycle_authorized: false`.
+16. Retained verification binds every authoritative file and required directory to
+    stable-descriptor bytes, filesystem identity, metadata fingerprints, canonical
+    paths, and an exact recursive inventory. It rereads the saved manifest and fails
+    closed on replacement, metadata, inventory, alias, or post-inspection byte drift
+    while keeping public manifest and receipt schemas unchanged.
 
 ### M4 - Query engine v1
 
@@ -342,25 +388,62 @@ execution and admission remain owner steps.
 The first M4 slice is database independent. `SchemaRegistry::plan_query` validates
 before planning, assigns stable `t0`, `t1`, ... aliases from sorted explicit link
 prefixes, and captures every referenced field with type, cardinality, nullability,
-path, alias, and propagated many-link traversal state. The typed plan fingerprint
-uses the versioned `rustok-index-query-plan-v4` domain.
+path, alias, and propagated many-link traversal state. It groups selected many fields
+by terminal relation path while preserving first path appearance and field order. The
+typed plan fingerprint uses the versioned `rustok-index-query-plan-v4` domain.
 
 The controlled compiler emits ordered typed binds, deterministic identity/projection/
 order columns, exact tenant/schema/locale/live-row scope, all current typed filters,
 reference-compatible null ordering, validated lexicographic keyset predicates with an
 ascending root `entity_id` tie-breaker, bounded offset pagination, and an optional
-separate exact-count statement without pagination leakage.
+separate exact-count statement without pagination leakage. Opaque continuation tokens
+must pass `SchemaRegistry::compile_postgres_query`, which validates checksum, scope,
+schema fingerprint, order arity, and order-value types before SQL emission.
 
 Each selected many path compiles as one correlated JSONB aggregate outside the outer
-rowset. Many aggregates do not alter root pagination, lookahead, or exact-count
-cardinality. Many-link filtering compiles every atomic predicate through an
-independent nested correlated `EXISTS` chain, so root pagination and exact count stay
-duplicate free.
+rowset. Aggregate items preserve the complete linked entity identity chain and aligned
+tagged field values, are ordered by stored link ordinal plus target identity/locale at
+each hop, and produce an empty array when no reachable row exists. Many aggregates do
+not alter root pagination, lookahead, or exact-count cardinality.
 
-`PostgresIndexQueryPort` requires exact persisted schema readiness and executes page
-and optional count in one read-only repeatable-read transaction. Live metrics/evidence
-execution, PostgreSQL/reference-engine equivalence admission, and authoritative
-consumer cutover remain open.
+The result handoff uses `SchemaRegistry::compile_postgres_page_query` to increase only
+the validated page-limit bind by one. `decode_postgres_query_page` rechecks the plan
+fingerprint, deterministic scalar and many-relation column contracts, page size, row
+count, tagged `IndexValue` type/cardinality/nullability, relation identities, nested
+identity/value arity, duplicate/nil nested identities, and optional count. It removes
+the lookahead row, reports `has_more`, preserves flat and nested selection order, and
+emits a query-scoped cursor from the last retained root identity plus hidden order
+values. Offset pages use the same lookahead rule but do not synthesize a cursor.
+
+Many-link filtering compiles every atomic predicate through an independent nested
+correlated `EXISTS` chain. Many paths never enter the outer rowset, so root pagination,
+lookahead, result decoding, and exact count stay duplicate free. Positive operators use
+any-match semantics; `IsNull` checks for the absence of a reachable non-null value;
+`Ne` requires at least one stored reachable value and rejects any null or equal value.
+This matches the test-only reference engine's flattened path-value semantics.
+
+`IndexQueryPort` is the transport-neutral owner boundary for executing one structured
+query. `PostgresIndexQueryPort` owns one immutable `Arc<SchemaRegistry>` and one
+PostgreSQL connection. It derives every root/source/target schema used by the plan,
+requires an exact active tenant-scoped `index_schemas` row with matching fingerprint
+and schema JSON, executes the page and optional exact count in one read-only
+repeatable-read transaction, converts every `PostgresBindValue` to a SeaORM value, and
+maps only compiler-declared UUID/JSONB/bigint aliases into `CompiledPostgresRow` before
+calling the strict decoder. Authentication and transport policy remain caller-owned.
+
+Many-link ordering is admitted only through caller-explicit `min_asc`, `min_desc`,
+`max_asc`, and `max_desc`. Integer, string, timestamp, and Decimal terminals retain
+typed PostgreSQL aggregation and ordering; Decimal encodes only the hidden aggregate
+order value through the exact tagged string wire. UUID aggregate ordering, implicit
+first-row semantics, and aggregate cursor continuation remain fail closed. Aggregate
+ordering is bounded-offset-only and does not change root cardinality or exact count.
+
+Source-owned schema publication, shared query-runtime composition, retained plan/SQL
+snapshots, and the first default-off Social Graph privacy parity shadow are source
+complete. The shadow is non-authoritative, records bounded parity observations, uses
+only the caller's remaining deadline budget, and always returns the owner result.
+Live metrics/evidence execution, PostgreSQL/reference-engine equivalence admission,
+and authoritative consumer cutover remain open.
 
 ### M5 - Incremental ingestion
 
@@ -404,29 +487,42 @@ database, or transport causes stay in owner logs.
       equivalence with retained PostgreSQL evidence.
 
 The one-page executor, replay job store, checkpoint adapter, bounded multi-page runner,
-cancellation path, reconciliation runner, and host composition are source complete.
+cancellation path, bounded reconciliation runner, and host composition are source complete.
 `PostgresIndexReplayJobStore` serializes one tenant/schema claim, validates the exact
-request and active persisted schema, reclaims expired attempts with an incremented
-fence, and rejects stale heartbeat or terminal updates.
+`index_replay_job_v1` request and active persisted schema, reclaims expired attempts with an
+incremented fence, and rejects stale heartbeat or terminal updates.
+`PostgresIndexReplayCheckpointStore` is constructed from the acquired lease; it locks and
+validates that exact attempt before every checkpoint read or write.
 
-`PostgresIndexReplayRunner` resolves the source from the materialized registry, executes
-at most 1024 pages, heartbeats between pages, completes only after a durable JSON null
-cursor, and returns unfinished work to immediately claimable `pending` state while
-preserving the same job UUID and checkpoint.
+`PostgresIndexReplayRunner` resolves the source from the materialized registry, executes at
+most 1024 pages, heartbeats between pages, completes only after a durable JSON null cursor,
+and returns unfinished work to immediately claimable `pending` state while preserving the
+same job UUID and checkpoint. `request_cancel` terminalizes pending jobs immediately and
+marks running jobs for observation before/after pages; success, failure, and yield all
+require `cancel_requested = FALSE`, so cancellation committed first cannot be overwritten.
+A running cancel request survives reclaim and is terminalized by the next fenced attempt
+before source access.
 
 The bounded reconciliation runner performs durable multi-pass source scans without
-collecting all IDs, persists pass and source cursor state, applies stable source
-mutations through the same monotonic mutation store, and can be cancelled or reclaimed
-under the existing attempt fence. It repairs replay-visible stale and missing materialized
-state but does not claim an owner snapshot/high-watermark, a proof against every
-concurrent final-pass write, or an authoritative drift-repair admission.
+collecting all IDs, persists pass and source cursor state, applies stable source mutations
+through the same monotonic mutation store, and can be cancelled or reclaimed under the
+existing attempt fence. It repairs replay-visible stale and missing materialized state but
+does not claim an owner snapshot/high-watermark, proof against every concurrent final-pass
+write, or authoritative drift-repair admission.
 
-The server materializes `SharedIndexSourceRegistry` only after selected modules register
-their source-owned schema and replay contracts. `IndexReplayOperatorRuntime` requires an
-exact request-bound tenant/actor permission snapshot and `modules:manage`. In-page
-interruption, automatic retry/backoff, dead-letter scheduling, host scheduling, graceful
-task shutdown, command/audit transports, and retained multi-instance PostgreSQL evidence
-remain open.
+The server materializes `SharedIndexSourceRegistry` only after all selected modules have
+registered their source-owned schema and replay contracts. The Index-owned
+`materialize_postgres_index_replay_runtime` requires both immutable registries, performs no
+SQL, starts no task, and publishes only bounded `run` and `request_cancel` through
+`SharedIndexReplayRuntime`.
+
+`IndexReplayOperatorRuntime` requires an exact request-bound tenant/actor permission snapshot,
+requires `modules:manage`, rejects cross-tenant run requests before delegation, and derives
+cancel tenant scope only from the authorized context. GraphQL, HTTP, CLI, and admin transports
+must not call the raw replay runtime directly. In-page interruption, automatic retry/backoff,
+dead-letter scheduling, host scheduling, graceful task shutdown, command/audit transports,
+additional production source adapters, and retained multi-instance PostgreSQL evidence remain
+open.
 
 ### M7 - First vertical slice
 
@@ -511,7 +607,7 @@ cargo test -p rustok-index source_event_id --lib -- --nocapture
 cargo test -p rustok-index source_replay --lib -- --nocapture
 cargo test -p rustok-index source_replay_job --lib -- --nocapture
 cargo test -p rustok-index source_replay_runner --lib -- --nocapture
-cargo test -p rustok-index source_reconciliation --lib -- --nocapture
+cargo test -p rustok-index source_reconciliation_runner --lib -- --nocapture
 cargo test -p rustok-index source_factory --lib -- --nocapture
 cargo test -p rustok-index replay_runtime --lib -- --nocapture
 cargo test -p rustok-distribution --all-targets --features mod-product -- --nocapture
@@ -580,16 +676,53 @@ node scripts/verify/verify-index-sales-channel-source.mjs
   capture, rollback-only mutation/WAL evidence capture, and isolated ordinary-VACUUM
   maintenance evidence capture.
 - 2026-07-28: completed rollback-only cutover rehearsal evidence, full retained packet
-  owner orchestration, read-only retained bundle review, admitted archive manifest
-  generation, saved-manifest verification receipts, and recursive filesystem snapshot
-  enforcement.
-- 2026-07-29: completed deterministic typed M4 planning, controlled PostgreSQL query
-  compilation, many-link filtering/projection, strict result decoding, and the
-  PostgreSQL query port source boundary.
-- 2026-07-30: completed retained v4 plan/SQL snapshots, explicit many-link aggregate
-  ordering, source-owned schema publication, shared query runtime, the bounded source
-  registry, one-page replay, durable replay jobs/checkpoints, bounded multi-page
-  execution, cancellation, runtime/operator composition, and the first Product source.
+  owner orchestration with PostgreSQL identity-bound capture finalization, read-only
+  retained bundle review, admitted archive manifest generation, saved-manifest
+  verification receipts, and exact recursive filesystem snapshot enforcement.
+- 2026-07-29: rechecked the merged M3 source boundary, completed deterministic typed
+  M4 planning, controlled projection SQL, root/one-link filters, ordering, separate
+  exact count, validated lexicographic keyset continuation, bounded offset
+  compatibility, one-row page lookahead, deterministic tagged-row decoding, exact
+  count decoding, relation identity reconstruction, scoped next-cursor creation,
+  correlated many-link `EXISTS` filtering with duplicate-free root count/pagination,
+  deterministic nested many-link projection aggregation with aligned identity/value
+  decoding, and PostgreSQL `IndexQueryPort` source with exact persisted-schema
+  preflight, one repeatable-read page/count snapshot, exhaustive bind conversion, and
+  compiler-metadata-driven row adaptation.
+- 2026-07-30: completed retained v4 plan/SQL snapshots, explicit many-link MIN/MAX
+  aggregate ordering for integer, string, timestamp, and Decimal terminals, exact
+  Decimal tagged string wire, source-owned schema publication, shared query-runtime
+  composition, and the first default-off Social Graph privacy parity shadow.
+- 2026-07-30: bounded the non-authoritative Social Graph privacy shadow by the caller's
+  remaining deadline and repaired stale Index repository/evidence guards and retained
+  fixtures. No authoritative cutover or live PostgreSQL evidence is claimed.
+- 2026-07-30: added the neutral bounded replay source registry, opaque JSON cursor and
+  scan/load contracts, exact schema-owner materialization, tenant/schema/result bounds,
+  continuation-progress checks, and retryable/permanent source failure classification.
+- 2026-07-30: added the one-page replay executor, stable replay event checks,
+  `PostgresMutationStore` sink composition, durable rebuild-checkpoint read/write
+  adapter, post-mutation checkpoint ordering, completion no-op, and replay-after-
+  checkpoint-failure contracts.
+- 2026-07-30: added schema-scoped durable rebuild job claims, advisory-lock exclusion,
+  lease/heartbeat, expired-attempt reclaim, attempt fencing, exact request validation,
+  lease-bound checkpoint reads/writes, stale-writer rejection, and null-cursor-gated
+  terminal success.
+- 2026-07-30: added `PostgresIndexReplayRunner` with a 1024-page invocation bound,
+  registry-derived source ownership, between-page heartbeat cadence, accumulated page/
+  mutation outcomes, terminal failure classification, graceful lease-loss handling,
+  null-cursor completion, and immediate `pending` yield/resume with attempt fencing.
+- 2026-07-30: added durable pending/running cancellation requests, typed terminal and
+  not-found outcomes, cancellation observation before/after bounded pages, cancellation
+  persistence across reclaim, and cancel-first fenced success/failure/yield transitions.
+- 2026-07-30: materialized the immutable source registry in server composition, added
+  `SharedIndexReplayRuntime`, transferred it through the typed host seam, and published
+  `IndexReplayOperatorRuntime` with exact request-bound tenant/actor scope and
+  `modules:manage`. Composition performs no SQL and starts no task.
+- 2026-07-30: added atomic PostgreSQL source-factory composition, an Index-owned stable
+  source event-ID helper, a Product-owned monotonic `index_revision`, and the first
+  selected locale-required Product current-state source with stable `(product_id,
+  locale)` cursor and targeted loads. Product delete/translation tombstones,
+  incremental acknowledgement, related schemas, and live evidence remain open.
 - 2026-07-31: rechecked merged M7 work and actualized this plan. ProductVariant and
   SalesChannel sources, Product v2 graph links, retained Product/translation/
   ProductVariant hard deletes, and bounded multi-pass reconciliation were already in
@@ -598,12 +731,12 @@ node scripts/verify/verify-index-sales-channel-source.mjs
   fencing, live/tombstone conflict rejection, and generic replay deletes through the
   existing stable SalesChannel source. No schema fingerprint, source name, cursor shape,
   or event domain changed.
-- Repository test/fixture suites, verifiers, PostgreSQL execution, in-page interruption,
-  automatic retry/backoff, dead-letter and host scheduling, graceful task shutdown,
-  authorized command transports, incremental event acknowledgement, persisted schema
-  readiness, durable Product-to-SalesChannel relations, retained freshness/recovery and
-  equivalence evidence, one admitted PostgreSQL/reference equivalence bundle, and one
-  real full PostgreSQL partition packet remain for the owner to execute and admit before
+- Repository test/fixture suites, verifiers, in-page interruption, automatic retry/backoff,
+  dead-letter and host scheduling, graceful task shutdown, authorized command transports,
+  incremental event acknowledgement, persisted per-tenant schema readiness, durable
+  Product-to-SalesChannel relations, tombstone purge admission, live freshness/recovery
+  evidence, one admitted PostgreSQL/reference equivalence bundle, and one real full
+  PostgreSQL partition packet remain for the owner to execute and admit before
   authoritative consumer or production partition cutover.
 
 ## Periodic release verification handoff
@@ -611,7 +744,7 @@ node scripts/verify/verify-index-sales-channel-source.mjs
 - Cycle: `cycle-001`
 - Status: `blocked`
 - Last verified at (UTC): `2026-07-31`
-- Scope inspected: `Index ownership, migrations, mutation/version ordering, query execution, partition evidence guards, source replay ownership, replay checkpoint ordering, replay job attempt fencing, bounded multi-page replay, bounded reconciliation, cancellation ordering, host replay composition, operator authorization, Product/ProductVariant/SalesChannel source composition, Product graph links, retained delete identities, stable source identity, and source/search/server boundaries`
+- Scope inspected: `Index ownership, migrations, mutation/version ordering, query execution, partition evidence guards, Social Graph consumer authority, privacy shadow deadline behavior, source replay ownership, replay checkpoint ordering, replay job attempt fencing, bounded multi-page replay progression, bounded multi-pass reconciliation, cancellation ordering, host replay composition, operator authorization, Product/ProductVariant/SalesChannel source composition, Product graph links, retained delete identities, stable source identity, and source/search/server boundaries`
 - Findings: `P0=0, P1=2, P2=0, P3=1`
 - Fixed in this pass: `actualized stale M6/M7 plan state; preserved bounded replay and reconciliation non-claims; added Channel-owned retained hard-delete identities with monotonic reuse fencing; replayed SalesChannel deletes through the existing source with the same schema fingerprint, source name, cursor and event domain; added fail-closed live/tombstone identity checks, documentation, and a static repository guard`
 - Remaining risks or blockers: `one retained admitted real PostgreSQL partition packet is absent; live PostgreSQL/reference query equivalence remains open; in-page interruption, automatic retry/backoff, dead-letter scheduling, host scheduling, graceful task shutdown, authorized command transports, locale/partition checkpoint dimensions, mutation-source event acknowledgement, persisted per-tenant schema readiness, durable Product-to-SalesChannel relations, tombstone purge admission, and additional production source adapters remain absent; no retained per-tenant freshness/watermark, lag, negative-result safety, outage/restart/backlog catch-up, delete/recreate, cancellation, authorization, replay, reconciliation, or repair evidence exists; consumer and production partition cutover remain forbidden`

--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -26,7 +26,7 @@ pull requests record checks and PostgreSQL runs that were not executed.
 ## Current state
 
 - Rewrite status: `in_progress`
-- Current milestone: `M7 - first Product schema and bounded replay source (source complete; tombstones, incremental events, related entities, consumer cutover, and retained evidence open)`
+- Current milestone: `M7 - Product/ProductVariant/SalesChannel bounded replay graph (live sources, Product/ProductVariant/SalesChannel tombstones, and bounded reconciliation source-complete; incremental events, persisted readiness, durable Product-to-Channel relations, consumer cutover, and retained evidence open)`
 - FFA status: `in_progress`
 - FBA status: `in_progress`
 - M0 code reset: `complete`
@@ -63,12 +63,14 @@ pull requests record checks and PostgreSQL runs that were not executed.
 - M4 source-owned schema catalog and shared query runtime: `source_complete`
 - M4 first Social Graph privacy parity shadow: `source_complete_metrics_evidence_tooling_execution_pending`
 - M5 inbox deduplication and monotonic source-version persistence: `complete`
-- M5/M6 bounded source replay contract: `source_complete_worker_pending`
+- M5/M6 bounded source replay contract: `source_complete_owner_execution_pending`
 - M6 one-page replay and durable checkpoint progression: `source_complete`
 - M6 replay job leases and checkpoint attempt fencing: `source_complete_owner_execution_pending`
 - M6 bounded multi-page replay and cancellation: `source_complete_owner_execution_pending`
+- M6 bounded multi-pass source reconciliation: `source_complete_owner_execution_pending`
 - M6 replay runtime host composition and operator guard: `source_complete_owner_execution_pending`
-- M7 first Product schema and bounded source bridge: `source_complete_owner_execution_pending`
+- M7 Product/ProductVariant graph schemas and bounded sources: `source_complete_owner_execution_pending`
+- M7 SalesChannel schema, bounded source, and retained deletes: `source_complete_owner_execution_pending`
 - Production persistence: mutation writes, schema/index coordination, fail-closed
   partition admission, snapshot/query/mutation/maintenance/cutover evidence tooling,
   full-capture orchestration, exact-byte packet assembly, retained bundle review,
@@ -84,14 +86,18 @@ pull requests record checks and PostgreSQL runs that were not executed.
   rebuild checkpoint progression, schema-scoped rebuild job claims, lease/heartbeat,
   attempt fencing, fenced checkpoint writes, bounded multi-page execution, immediate
   pending resume, durable cancellation requests, fenced between-page terminal
-  cancellation, immutable source-registry host materialization, shared replay-runtime
-  publication, request-bound operator authorization, atomic PostgreSQL source-factory
-  composition, stable source event identities, and one selected Product current-state
-  replay source are implemented; one retained admitted packet, live PostgreSQL/reference
-  equivalence, in-page interruption, retry/backoff, dead-letter scheduling, host
-  scheduling, graceful task shutdown, command transport, Product tombstones and
-  incremental ingestion, additional vertical schemas, freshness/recovery evidence,
-  authoritative consumer cutover, and production partition lifecycle remain open
+  cancellation, bounded multi-pass reconciliation, immutable source-registry host
+  materialization, shared replay-runtime publication, request-bound operator
+  authorization, atomic PostgreSQL source-factory composition, stable source event
+  identities, Product/ProductVariant/SalesChannel current-state sources, versioned
+  Product-to-ProductVariant links, and retained Product/ProductVariant/SalesChannel
+  hard-delete mutations are implemented; one retained admitted packet, live
+  PostgreSQL/reference equivalence, in-page interruption, retry/backoff, dead-letter
+  scheduling, host scheduling, graceful task shutdown, command transport, incremental
+  event acknowledgement, persisted per-tenant schema readiness, durable
+  Product-to-SalesChannel relations, freshness/recovery evidence, authoritative
+  consumer cutover, tombstone purge admission, and production partition lifecycle
+  remain open.
 
 The production crate contains the generic domain/application core, seven canonical
 M3 tables, an atomic mutation adapter, durable schema leases, secondary-index
@@ -107,12 +113,14 @@ repeatable-read page/count snapshot, source-owned schema and replay catalogs, a
 neutral bounded `IndexSource` scan/load boundary, a one-page replay executor,
 `PostgresIndexReplayJobStore` for durable fenced schema-scoped rebuild ownership,
 a lease-bound PostgreSQL rebuild-checkpoint adapter, `PostgresIndexReplayRunner` for
-bounded heartbeat/yield/cancellation execution, `SharedIndexReplayRuntime` for host
+bounded heartbeat/yield/cancellation execution, a bounded multi-pass reconciliation
+runner with durable pass/source cursor state, `SharedIndexReplayRuntime` for host
 capability transfer, and atomic host-database-aware source factory composition. The
 server publishes `IndexReplayOperatorRuntime` as the request-bound authorization
-boundary. The selected distribution now contributes the first Product schema/source
-bridge without adding a Product dependency to Index core. Owner-operated evidence
-tools live under `ops/benches`; they do not become runtime storage code.
+boundary. The selected distribution contributes Product, ProductVariant, and
+SalesChannel schemas/sources without adding source-domain dependencies to Index core
+or server. Owner-operated evidence tools live under `ops/benches`; they do not become
+runtime storage code.
 
 ## Ownership
 
@@ -123,16 +131,17 @@ reconciliation, drift repair, distributed coordination, and operator diagnostics
 
 Source modules own normalized domain data, schema declarations, conversion to
 generic Index records/mutations, bounded `IndexSource::scan` and targeted `load`
-adapters, stable replay event identities, and source ordering and version information.
-Selected cross-module adapters that require both owner storage and Index contracts
-live in `rustok-distribution`; they do not move storage ownership into Index or server.
+adapters, stable replay event identities, source ordering and version information,
+and retained deletion identities needed for replay. Selected cross-module adapters
+that require both owner storage and Index contracts live in `rustok-distribution`;
+they do not move storage ownership into Index or server.
 
 ## Target architecture
 
 ```text
 source modules
     -> IndexSchemaSourceCatalog / IndexSourceCatalog / IndexMutation
-    -> ingestion and rebuild engines
+    -> ingestion, rebuild, and reconciliation engines
     -> PostgreSQL index storage
     -> schema/link registry and query planner
     -> SQL compiler
@@ -160,6 +169,7 @@ crates/rustok-index/src/
     source_replay.rs
     source_replay_job.rs
     source_replay_runner.rs
+    source_reconciliation.rs
     replay_runtime.rs
     schema_lease.rs
     secondary_index.rs
@@ -168,7 +178,8 @@ crates/rustok-index/src/
   api/
 
 crates/rustok-distribution/src/
-  product_index.rs
+  product_index/
+  channel_index.rs
 
 apps/server/src/services/
   index_replay_runtime_composition.rs
@@ -301,58 +312,12 @@ relations.
 
 #### Completed M3 slices
 
-1. Canonical migrations register the seven module-owned tables with complete tenant,
-   schema, entity, locale, and full-range non-negative source-version identity.
-2. `PostgresMutationStore` validates deliveries, claims the composite inbox key,
-   serializes the entity key, and applies entity/tombstone/link replacement atomically.
-3. `PostgresSchemaLeaseStore` provides durable schema-application exclusion,
-   reclaim, heartbeat, terminal completion, and attempt fencing.
-4. `SecondaryIndexPlan` and `PostgresSecondaryIndexManager` derive typed/GIN indexes,
-   coordinate concurrent ensure/reindex/retire work, and verify catalog readiness.
-5. `PartitionAdmissionPolicy` and `PartitionShadowPlan` implement measured,
-   fail-closed admission and deterministic shadow-only hash partition DDL.
-6. Immutable manifest preparation and packet validation bind commit, image, modulus,
-   repetitions, thresholds, evidence identity, raw hashes, and calculated reasons.
-7. `index_partition_capture_v1` assembly reads six unique confined raw files once,
-   calculates exact-byte hashes, validates the packet, and refuses overwrite/aliases.
-8. The snapshot runner creates evidence-bound shadow parents/children, copies one
-   repeatable-read baseline, attaches shadow integrity, records parity/size/catch-up,
-   and publishes `baseline.json` plus `shadow.json` without touching canonical DDL.
-9. The query runner validates the shadow catalog, executes exact tenant-scoped runs
-   read-only, proves semantic parity and one-child pruning, retains full EXPLAIN JSON,
-   calculates p95 and normalized plan digests, and publishes `query.json` once.
-10. The mutation/WAL runner validates the same manifest and catalog, requires count
-    parity and matching generic anchors, executes rollback-only mutation samples,
-    proves one-child shadow pruning, retains EXPLAIN JSON and WAL evidence, and
-    publishes `mutation.json` without overwrite. Real database execution remains an
-    owner step.
-11. The maintenance runner revalidates the manifest and retained shadow catalog,
-    creates isolated ordinary and tenant-hash clone pairs, applies identical committed
-    churn only to those clones, times ordinary `VACUUM (ANALYZE)`, proves production
-    and retained snapshot-shadow relations unchanged, and publishes
-    `maintenance.json` without overwrite. Real database execution remains an owner
-    step.
-12. The cutover rehearsal runner validates production and retained shadow identities,
-    creates deterministic evidence-only ordinary clones, measures `ACCESS EXCLUSIVE`
-    lock acquisition, performs rename swaps only inside rollback-only transactions,
-    proves clone OIDs/names and production relations unchanged, and publishes
-    `cutover.json` without overwrite. Real database execution remains an owner step.
-13. The full-capture orchestrator requires one explicit owner opt-in, one immutable
-    manifest, one database URL, and a fresh empty output directory. It sequentially
-    runs all five evidence commands, finalizes `capture.json` with PostgreSQL identity
-    and run provenance, assembles exact retained bytes into `partition-packet.json`,
-    validates `admission.json`, and refuses partial-output reuse or resume.
-14. The retained bundle review inspects exactly nine authoritative files, recalculates
-    exact-byte packet assembly and admission, rejects aliases or drift, and renders a
-    deterministic read-only owner report without editing the bundle.
-15. The archive tooling emits a deterministic admitted-only manifest outside the
-    immutable bundle and verifies a saved manifest into a read-only receipt with
-    `production_lifecycle_authorized: false`.
-16. Retained verification binds every authoritative file and required directory to
-    stable-descriptor bytes, filesystem identity, metadata fingerprints, canonical
-    paths, and an exact recursive inventory. It rereads the saved manifest and fails
-    closed on replacement, metadata, inventory, alias, or post-inspection byte drift
-    while keeping public manifest and receipt schemas unchanged.
+Canonical migrations, atomic mutation persistence, schema leases, secondary-index
+lifecycle, fail-closed partition admission, exact-byte retained packet tooling,
+baseline/shadow capture, query/mutation/WAL/maintenance/cutover evidence runners,
+full-capture orchestration, read-only retained review, admitted archive manifests,
+and recursive filesystem integrity checks are source complete. Real PostgreSQL
+execution and admission remain owner steps.
 
 ### M4 - Query engine v1
 
@@ -377,62 +342,25 @@ relations.
 The first M4 slice is database independent. `SchemaRegistry::plan_query` validates
 before planning, assigns stable `t0`, `t1`, ... aliases from sorted explicit link
 prefixes, and captures every referenced field with type, cardinality, nullability,
-path, alias, and propagated many-link traversal state. It groups selected many fields
-by terminal relation path while preserving first path appearance and field order. The
-typed plan fingerprint uses the versioned `rustok-index-query-plan-v4` domain.
+path, alias, and propagated many-link traversal state. The typed plan fingerprint
+uses the versioned `rustok-index-query-plan-v4` domain.
 
 The controlled compiler emits ordered typed binds, deterministic identity/projection/
 order columns, exact tenant/schema/locale/live-row scope, all current typed filters,
 reference-compatible null ordering, validated lexicographic keyset predicates with an
 ascending root `entity_id` tie-breaker, bounded offset pagination, and an optional
-separate exact-count statement without pagination leakage. Opaque continuation tokens
-must pass `SchemaRegistry::compile_postgres_query`, which validates checksum, scope,
-schema fingerprint, order arity, and order-value types before SQL emission.
+separate exact-count statement without pagination leakage.
 
 Each selected many path compiles as one correlated JSONB aggregate outside the outer
-rowset. Aggregate items preserve the complete linked entity identity chain and aligned
-tagged field values, are ordered by stored link ordinal plus target identity/locale at
-each hop, and produce an empty array when no reachable row exists. Many aggregates do
-not alter root pagination, lookahead, or exact-count cardinality.
+rowset. Many aggregates do not alter root pagination, lookahead, or exact-count
+cardinality. Many-link filtering compiles every atomic predicate through an
+independent nested correlated `EXISTS` chain, so root pagination and exact count stay
+duplicate free.
 
-The result handoff uses `SchemaRegistry::compile_postgres_page_query` to increase only
-the validated page-limit bind by one. `decode_postgres_query_page` rechecks the plan
-fingerprint, deterministic scalar and many-relation column contracts, page size, row
-count, tagged `IndexValue` type/cardinality/nullability, relation identities, nested
-identity/value arity, duplicate/nil nested identities, and optional count. It removes
-the lookahead row, reports `has_more`, preserves flat and nested selection order, and
-emits a query-scoped cursor from the last retained root identity plus hidden order
-values. Offset pages use the same lookahead rule but do not synthesize a cursor.
-
-Many-link filtering compiles every atomic predicate through an independent nested
-correlated `EXISTS` chain. Many paths never enter the outer rowset, so root pagination,
-lookahead, result decoding, and exact count stay duplicate free. Positive operators use
-any-match semantics; `IsNull` checks for the absence of a reachable non-null value;
-`Ne` requires at least one stored reachable value and rejects any null or equal value.
-This matches the test-only reference engine's flattened path-value semantics.
-
-`IndexQueryPort` is the transport-neutral owner boundary for executing one structured
-query. `PostgresIndexQueryPort` owns one immutable `Arc<SchemaRegistry>` and one
-PostgreSQL connection. It derives every root/source/target schema used by the plan,
-requires an exact active tenant-scoped `index_schemas` row with matching fingerprint
-and schema JSON, executes the page and optional exact count in one read-only
-repeatable-read transaction, converts every `PostgresBindValue` to a SeaORM value, and
-maps only compiler-declared UUID/JSONB/bigint aliases into `CompiledPostgresRow` before
-calling the strict decoder. Authentication and transport policy remain caller-owned.
-
-Many-link ordering is admitted only through caller-explicit `min_asc`, `min_desc`,
-`max_asc`, and `max_desc`. Integer, string, timestamp, and Decimal terminals retain
-typed PostgreSQL aggregation and ordering; Decimal encodes only the hidden aggregate
-order value through the exact tagged string wire. UUID aggregate ordering, implicit
-first-row semantics, and aggregate cursor continuation remain fail closed. Aggregate
-ordering is bounded-offset-only and does not change root cardinality or exact count.
-
-Source-owned schema publication, shared query-runtime composition, retained plan/SQL
-snapshots, and the first default-off Social Graph privacy parity shadow are source
-complete. The shadow is non-authoritative, records bounded parity observations, uses
-only the caller's remaining deadline budget, and always returns the owner result.
-Live metrics/evidence execution, PostgreSQL/reference-engine equivalence admission,
-and authoritative consumer cutover remain open.
+`PostgresIndexQueryPort` requires exact persisted schema readiness and executes page
+and optional count in one read-only repeatable-read transaction. Live metrics/evidence
+execution, PostgreSQL/reference-engine equivalence admission, and authoritative
+consumer cutover remain open.
 
 ### M5 - Incremental ingestion
 
@@ -467,43 +395,38 @@ database, or transport causes stay in owner logs.
 - [x] Add bounded multi-page execution with heartbeat cadence and immediate pending resume.
 - [x] Add durable cancellation requests and fenced between-page terminal cancellation.
 - [x] Bind job requests directly to the materialized source registry in server composition.
+- [x] Add bounded multi-pass source reconciliation with durable pass/source cursor state.
 - [ ] Add in-page interruption/timeouts, dry-run, and targeted/full/shadow rebuild modes.
 - [ ] Add bounded retry/backoff, dead-letter state, and global scheduling ownership.
 - [ ] Add locale/partition replay checkpoint dimensions.
-- [ ] Add reconciliation and drift repair.
+- [ ] Add drift diagnosis, targeted repair commands, and admitted repair evidence.
 - [ ] Cover crash, lease expiry, restart, cancellation, authorization, and incremental/full
       equivalence with retained PostgreSQL evidence.
 
 The one-page executor, replay job store, checkpoint adapter, bounded multi-page runner,
-cancellation path, and host composition are source complete. `PostgresIndexReplayJobStore`
-serializes one tenant/schema claim, validates the exact `index_replay_job_v1` request and
-active persisted schema, reclaims expired attempts with an incremented fence, and rejects
-stale heartbeat or terminal updates. `PostgresIndexReplayCheckpointStore` is constructed
-from the acquired lease; it locks and validates that exact attempt before every checkpoint
-read or write.
+cancellation path, reconciliation runner, and host composition are source complete.
+`PostgresIndexReplayJobStore` serializes one tenant/schema claim, validates the exact
+request and active persisted schema, reclaims expired attempts with an incremented
+fence, and rejects stale heartbeat or terminal updates.
 
-`PostgresIndexReplayRunner` resolves the source from the materialized registry, executes at
-most 1024 pages, heartbeats between pages, completes only after a durable JSON null cursor,
-and returns unfinished work to immediately claimable `pending` state while preserving the
-same job UUID and checkpoint. `request_cancel` terminalizes pending jobs immediately and
-marks running jobs for observation before/after pages; success, failure, and yield all
-require `cancel_requested = FALSE`, so cancellation committed first cannot be overwritten.
-A running cancel request survives reclaim and is terminalized by the next fenced attempt
-before source access.
+`PostgresIndexReplayRunner` resolves the source from the materialized registry, executes
+at most 1024 pages, heartbeats between pages, completes only after a durable JSON null
+cursor, and returns unfinished work to immediately claimable `pending` state while
+preserving the same job UUID and checkpoint.
 
-The server materializes `SharedIndexSourceRegistry` only after all selected modules have
-registered their source-owned schema and replay contracts. The Index-owned
-`materialize_postgres_index_replay_runtime` requires both immutable registries, performs no
-SQL, starts no task, and publishes only bounded `run` and `request_cancel` through
-`SharedIndexReplayRuntime`.
+The bounded reconciliation runner performs durable multi-pass source scans without
+collecting all IDs, persists pass and source cursor state, applies stable source
+mutations through the same monotonic mutation store, and can be cancelled or reclaimed
+under the existing attempt fence. It repairs replay-visible stale and missing materialized
+state but does not claim an owner snapshot/high-watermark, a proof against every
+concurrent final-pass write, or an authoritative drift-repair admission.
 
-`IndexReplayOperatorRuntime` requires an exact request-bound tenant/actor permission snapshot,
-requires `modules:manage`, rejects cross-tenant run requests before delegation, and derives
-cancel tenant scope only from the authorized context. GraphQL, HTTP, CLI, and admin transports
-must not call the raw replay runtime directly. In-page interruption, automatic retry/backoff,
-dead-letter scheduling, host scheduling, graceful task shutdown, command/audit transports,
-additional production source adapters, and retained multi-instance PostgreSQL evidence remain
-open.
+The server materializes `SharedIndexSourceRegistry` only after selected modules register
+their source-owned schema and replay contracts. `IndexReplayOperatorRuntime` requires an
+exact request-bound tenant/actor permission snapshot and `modules:manage`. In-page
+interruption, automatic retry/backoff, dead-letter scheduling, host scheduling, graceful
+task shutdown, command/audit transports, and retained multi-instance PostgreSQL evidence
+remain open.
 
 ### M7 - First vertical slice
 
@@ -513,20 +436,35 @@ Entities: Product, ProductVariant, SalesChannel.
 - [x] Add stable `(product_id, locale)` replay cursor, targeted loads, and one-row lookahead.
 - [x] Add Product-owned monotonic `index_revision` and stable Index-owned event identity.
 - [x] Compose selected Product schema/source through atomic distribution source factories.
-- [ ] Add Product and translation delete tombstones plus incremental event acknowledgement.
-- [ ] Add ProductVariant and SalesChannel schemas, links, and bounded sources.
+- [x] Add Product and translation delete tombstones.
+- [x] Add ProductVariant and SalesChannel schemas and bounded sources.
+- [x] Add Product-to-ProductVariant v2 links and bounded graph projection fields.
+- [x] Add ProductVariant and SalesChannel hard-delete tombstones.
+- [ ] Add source-versioned Product, ProductVariant, and SalesChannel incremental event acknowledgement.
+- [ ] Add durable Product/ProductVariant-to-SalesChannel relations with owner revision semantics.
 - [ ] Support tenant, locale, status, projection, link filters, sorting, and cursor
       pagination across the complete Product/Variant/Channel slice.
 - [ ] Move one Storefront query to Index.
 - [ ] Prove no source-module filtering fan-out.
 
-The first Product source is source complete for bounded current-state upserts. Product owns
-its storage and revision triggers; `rustok-distribution` owns the selected generic bridge;
-Index owns schema/source/runtime contracts and mutation persistence. The Product crate does
-not depend on Index, Index/server do not import Product, and factory composition commits the
-source catalog only after every selected factory succeeds. See
-[`m7-product-source.md`](./m7-product-source.md) for exact scope and open tombstone,
-concurrency, persisted-schema-readiness, evidence, and cutover boundaries.
+Product v1/v2, ProductVariant v1/v2, and SalesChannel v1 schemas are source complete.
+Product v2 links to ProductVariant v2; Product channel visibility remains represented by
+bounded scalar projection until the owner has a durable relational contract. Product,
+translation, ProductVariant, and SalesChannel deletion identities are retained with
+monotonic source versions and replayed through the existing stable sources as generic
+`IndexMutation::Delete` values. Recreated identities must strictly supersede retained
+deletes, and live/tombstone coexistence fails closed.
+
+Product and Channel crates own normalized storage, revisions, and tombstones without
+depending on Index. `rustok-distribution` owns the selected generic bridges. Index owns
+schema/source/runtime contracts, reconciliation, and mutation persistence. Runtime
+capability presence does not establish persisted schema readiness. Incremental event
+acknowledgement, durable Product-to-SalesChannel links, owner evidence, and consumer
+cutover remain open. See [`m7-product-source.md`](./m7-product-source.md),
+[`m7-product-variant-source.md`](./m7-product-variant-source.md),
+[`m7-product-graph-source.md`](./m7-product-graph-source.md),
+[`m7-product-tombstone-source.md`](./m7-product-tombstone-source.md), and
+[`m7-sales-channel-source.md`](./m7-sales-channel-source.md).
 
 ### M8 - Commerce scale slice
 
@@ -573,6 +511,7 @@ cargo test -p rustok-index source_event_id --lib -- --nocapture
 cargo test -p rustok-index source_replay --lib -- --nocapture
 cargo test -p rustok-index source_replay_job --lib -- --nocapture
 cargo test -p rustok-index source_replay_runner --lib -- --nocapture
+cargo test -p rustok-index source_reconciliation --lib -- --nocapture
 cargo test -p rustok-index source_factory --lib -- --nocapture
 cargo test -p rustok-index replay_runtime --lib -- --nocapture
 cargo test -p rustok-distribution --all-targets --features mod-product -- --nocapture
@@ -621,8 +560,13 @@ node scripts/verify/verify-index-many-link-filtering.mjs
 node scripts/verify/verify-index-source-replay-contract.mjs
 node scripts/verify/verify-index-replay-job-leases.mjs
 node scripts/verify/verify-index-replay-multipage-runner.mjs
+node scripts/verify/verify-index-source-reconciliation.mjs
 node scripts/verify/verify-index-replay-runtime-composition.mjs
 node scripts/verify/verify-index-product-source.mjs
+node scripts/verify/verify-index-product-variant-source.mjs
+node scripts/verify/verify-index-product-graph-source.mjs
+node scripts/verify/verify-index-product-tombstone-source.mjs
+node scripts/verify/verify-index-sales-channel-source.mjs
 ```
 
 ## Progress log
@@ -636,69 +580,41 @@ node scripts/verify/verify-index-product-source.mjs
   capture, rollback-only mutation/WAL evidence capture, and isolated ordinary-VACUUM
   maintenance evidence capture.
 - 2026-07-28: completed rollback-only cutover rehearsal evidence, full retained packet
-  owner orchestration with PostgreSQL identity-bound capture finalization, read-only
-  retained bundle review, admitted archive manifest generation, saved-manifest
-  verification receipts, and exact recursive filesystem snapshot enforcement.
-- 2026-07-29: rechecked the merged M3 source boundary, completed deterministic typed
-  M4 planning, controlled projection SQL, root/one-link filters, ordering, separate
-  exact count, validated lexicographic keyset continuation, bounded offset
-  compatibility, one-row page lookahead, deterministic tagged-row decoding, exact
-  count decoding, relation identity reconstruction, scoped next-cursor creation,
-  correlated many-link `EXISTS` filtering with duplicate-free root count/pagination,
-  deterministic nested many-link projection aggregation with aligned identity/value
-  decoding, and PostgreSQL `IndexQueryPort` source with exact persisted-schema
-  preflight, one repeatable-read page/count snapshot, exhaustive bind conversion, and
-  compiler-metadata-driven row adaptation.
-- 2026-07-30: completed retained v4 plan/SQL snapshots, explicit many-link MIN/MAX
-  aggregate ordering for integer, string, timestamp, and Decimal terminals, exact
-  Decimal tagged string wire, source-owned schema publication, shared query-runtime
-  composition, and the first default-off Social Graph privacy parity shadow.
-- 2026-07-30: bounded the non-authoritative Social Graph privacy shadow by the caller's
-  remaining deadline and repaired stale Index repository/evidence guards and retained
-  fixtures. No authoritative cutover or live PostgreSQL evidence is claimed.
-- 2026-07-30: added the neutral bounded replay source registry, opaque JSON cursor and
-  scan/load contracts, exact schema-owner materialization, tenant/schema/result bounds,
-  continuation-progress checks, and retryable/permanent source failure classification.
-- 2026-07-30: added the one-page replay executor, stable replay event checks,
-  `PostgresMutationStore` sink composition, durable rebuild-checkpoint read/write
-  adapter, post-mutation checkpoint ordering, completion no-op, and replay-after-
-  checkpoint-failure contracts.
-- 2026-07-30: added schema-scoped durable rebuild job claims, advisory-lock exclusion,
-  lease/heartbeat, expired-attempt reclaim, attempt fencing, exact request validation,
-  lease-bound checkpoint reads/writes, stale-writer rejection, and null-cursor-gated
-  terminal success.
-- 2026-07-30: added `PostgresIndexReplayRunner` with a 1024-page invocation bound,
-  registry-derived source ownership, between-page heartbeat cadence, accumulated page/
-  mutation outcomes, terminal failure classification, graceful lease-loss handling,
-  null-cursor completion, and immediate `pending` yield/resume with attempt fencing.
-- 2026-07-30: added durable pending/running cancellation requests, typed terminal and
-  not-found outcomes, cancellation observation before/after bounded pages, cancellation
-  persistence across reclaim, and cancel-first fenced success/failure/yield transitions.
-- 2026-07-30: materialized the immutable source registry in server composition, added
-  `SharedIndexReplayRuntime`, transferred it through the typed host seam, and published
-  `IndexReplayOperatorRuntime` with exact request-bound tenant/actor scope and
-  `modules:manage`. Composition performs no SQL and starts no task.
-- 2026-07-30: added atomic PostgreSQL source-factory composition, an Index-owned stable
-  source event-ID helper, a Product-owned monotonic `index_revision`, and the first
-  selected locale-required Product current-state source with stable `(product_id,
-  locale)` cursor and targeted loads. Product delete/translation tombstones,
-  incremental acknowledgement, related schemas, and live evidence remain open.
-- Repository test/fixture suites, verifiers, in-page interruption, automatic retry/backoff,
-  dead-letter and host scheduling, graceful task shutdown, authorized command transports,
-  Product tombstones and incremental ingestion, ProductVariant/SalesChannel sources,
-  live freshness/recovery evidence, one admitted PostgreSQL/reference equivalence bundle,
-  and one real full PostgreSQL partition packet remain for the owner to execute and admit
-  before authoritative consumer or production partition cutover.
+  owner orchestration, read-only retained bundle review, admitted archive manifest
+  generation, saved-manifest verification receipts, and recursive filesystem snapshot
+  enforcement.
+- 2026-07-29: completed deterministic typed M4 planning, controlled PostgreSQL query
+  compilation, many-link filtering/projection, strict result decoding, and the
+  PostgreSQL query port source boundary.
+- 2026-07-30: completed retained v4 plan/SQL snapshots, explicit many-link aggregate
+  ordering, source-owned schema publication, shared query runtime, the bounded source
+  registry, one-page replay, durable replay jobs/checkpoints, bounded multi-page
+  execution, cancellation, runtime/operator composition, and the first Product source.
+- 2026-07-31: rechecked merged M7 work and actualized this plan. ProductVariant and
+  SalesChannel sources, Product v2 graph links, retained Product/translation/
+  ProductVariant hard deletes, and bounded multi-pass reconciliation were already in
+  `main` but had stale open checklist entries.
+- 2026-07-31: added retained SalesChannel hard-delete identities, strict identity-reuse
+  fencing, live/tombstone conflict rejection, and generic replay deletes through the
+  existing stable SalesChannel source. No schema fingerprint, source name, cursor shape,
+  or event domain changed.
+- Repository test/fixture suites, verifiers, PostgreSQL execution, in-page interruption,
+  automatic retry/backoff, dead-letter and host scheduling, graceful task shutdown,
+  authorized command transports, incremental event acknowledgement, persisted schema
+  readiness, durable Product-to-SalesChannel relations, retained freshness/recovery and
+  equivalence evidence, one admitted PostgreSQL/reference equivalence bundle, and one
+  real full PostgreSQL partition packet remain for the owner to execute and admit before
+  authoritative consumer or production partition cutover.
 
 ## Periodic release verification handoff
 
 - Cycle: `cycle-001`
 - Status: `blocked`
-- Last verified at (UTC): `2026-07-30`
-- Scope inspected: `Index ownership, migrations, mutation/version ordering, query execution, partition evidence guards, Social Graph consumer authority, privacy shadow deadline behavior, source replay ownership, replay checkpoint ordering, replay job attempt fencing, bounded multi-page replay progression, cancellation ordering, host replay composition, operator authorization, selected Product source composition, stable source identity, and source/search/server boundaries`
+- Last verified at (UTC): `2026-07-31`
+- Scope inspected: `Index ownership, migrations, mutation/version ordering, query execution, partition evidence guards, source replay ownership, replay checkpoint ordering, replay job attempt fencing, bounded multi-page replay, bounded reconciliation, cancellation ordering, host replay composition, operator authorization, Product/ProductVariant/SalesChannel source composition, Product graph links, retained delete identities, stable source identity, and source/search/server boundaries`
 - Findings: `P0=0, P1=2, P2=0, P3=1`
-- Fixed in this pass: `bounded the non-authoritative Social Graph privacy comparison by the remaining caller deadline while preserving the owner result; repaired stale Index scale/FBA and retained-artifact guards; added a canonical bounded source replay/load registry; added one-page replay mutation application with stable event checks and checkpoint progression only after durable mutation outcomes; added schema-scoped rebuild job claims with lease/heartbeat, expired-attempt reclaim, attempt fencing, fenced checkpoint access, durable null-cursor-gated success, bounded multi-page execution with between-page heartbeat and immediate pending resume, durable cancel-first terminalization, immutable source-registry host materialization, one shared replay runtime, a request-bound modules:manage operator guard, atomic host source factories, stable source event identities, Product revision fencing, and the first selected Product current-state source`
-- Remaining risks or blockers: `one retained admitted real PostgreSQL partition packet is absent; live PostgreSQL/reference query equivalence remains open; in-page interruption, automatic retry/backoff, dead-letter scheduling, host scheduling, graceful task shutdown, authorized command transports, locale/partition checkpoint dimensions, Product hard-delete and translation-delete tombstones, incremental Product event acknowledgement, ProductVariant/SalesChannel sources, and additional production source adapters remain absent; no retained per-tenant freshness/watermark, lag, negative-result safety, outage/restart/backlog catch-up, cancellation, authorization, Product replay, or replay-repair evidence exists; consumer and production partition cutover remain forbidden`
-- Evidence: `PR #2544 merged as b647a5a17f27b34a07c20cd57525ed1806994c49; PR #2554 merged as 5b9d49e65295819ee9e8e9c199688c0e2ac73d35; PR #2576 merged as aef96f57d3babc2efdc65cc0c57cfea6fb48b5ad; PR #2578 merged as 9d725de7bac2039c86d5b5dffdf5d6be1b4812a8; PR #2585 merged as 1863a28fa2ebccdab39f19fce5b6971078e7e9f3; same-SHA Index Storage Scale Run Contract and full Scale Evidence contract passed JavaScript syntax, workflow contracts, repository contracts, direct validator arguments and fixture suites; source replay registry, one-page checkpoint progression, replay job fencing, bounded multi-page runner, cancellation, shared replay runtime, operator guard, source factory, stable event identity, and selected Product source are present without implementation-agent test execution; general CI/Hardening received no jobs; Rust-hosted smoke previously stopped before compilation because Cargo.lock required an Athanor update under --locked`
-- Next action: `add Product and translation tombstones plus source-versioned incremental event acknowledgement, then add ProductVariant and SalesChannel schemas/links/sources; implement scheduler/retry/shutdown ownership only after command and source contracts are fixed; execute retained PostgreSQL packet, live query equivalence, and per-tenant freshness/outage/recovery evidence before authoritative cutover`
-- Resume command: `cargo fmt --all -- --check && cargo check -p rustok-index --all-targets && cargo check -p rustok-distribution --all-targets --features mod-product && cargo check -p rustok-server --all-targets && node scripts/verify/verify-index-product-source.mjs && node scripts/verify/verify-index-query-contract.mjs && node scripts/verify/index-storage-tooling.mjs contract && node scripts/verify/index-storage-tooling.mjs fixtures`
+- Fixed in this pass: `actualized stale M6/M7 plan state; preserved bounded replay and reconciliation non-claims; added Channel-owned retained hard-delete identities with monotonic reuse fencing; replayed SalesChannel deletes through the existing source with the same schema fingerprint, source name, cursor and event domain; added fail-closed live/tombstone identity checks, documentation, and a static repository guard`
+- Remaining risks or blockers: `one retained admitted real PostgreSQL partition packet is absent; live PostgreSQL/reference query equivalence remains open; in-page interruption, automatic retry/backoff, dead-letter scheduling, host scheduling, graceful task shutdown, authorized command transports, locale/partition checkpoint dimensions, mutation-source event acknowledgement, persisted per-tenant schema readiness, durable Product-to-SalesChannel relations, tombstone purge admission, and additional production source adapters remain absent; no retained per-tenant freshness/watermark, lag, negative-result safety, outage/restart/backlog catch-up, delete/recreate, cancellation, authorization, replay, reconciliation, or repair evidence exists; consumer and production partition cutover remain forbidden`
+- Evidence: `PR #2604 added the first Product source; PR #2611 added ProductVariant; PR #2616 added SalesChannel; PR #2623 added Product graph v2 and Product-to-ProductVariant links; PR #2628 added retained Product/translation/ProductVariant deletes; PR #2632 added bounded source reconciliation. This SalesChannel tombstone slice is source-ready without implementation-agent test, verifier, Cargo, CI, or PostgreSQL execution.`
+- Next action: `define the source-versioned incremental mutation event and acknowledgement contract, then persist/apply exact per-tenant M7 schemas and add durable Product-to-SalesChannel relations; execute retained delete/recreate, replay/reconciliation, freshness/outage/recovery, live query equivalence, and partition evidence before authoritative cutover`
+- Resume command: `cargo fmt --all -- --check && cargo check -p rustok-channel --all-targets && cargo check -p rustok-index --all-targets && cargo check -p rustok-distribution --all-targets --features mod-product && cargo check -p rustok-server --all-targets && node scripts/verify/verify-index-sales-channel-source.mjs && node scripts/verify/verify-index-source-reconciliation.mjs && node scripts/verify/verify-index-product-tombstone-source.mjs && node scripts/verify/verify-index-query-contract.mjs && node scripts/verify/index-storage-tooling.mjs contract && node scripts/verify/index-storage-tooling.mjs fixtures`

--- a/crates/rustok-index/docs/implementation-recheck-2026-08-01.md
+++ b/crates/rustok-index/docs/implementation-recheck-2026-08-01.md
@@ -1,0 +1,48 @@
+# `rustok-index` implementation recheck — 2026-08-01
+
+## Audited baseline
+
+- Repository: `RusTokRs/RusTok`
+- Target branch: `main`
+- Audited commit: `1cc032d6ceba0e55b5f3a1dfa2a64b066dc73f71`
+- Validation owner: repository maintainer
+
+This recheck compares the canonical implementation plan with the source and recent Index pull-request history. Tests, verifiers, Cargo commands, CI, and PostgreSQL execution were not run, per maintainer instruction.
+
+## Confirmed on `main`
+
+- Product v1/v2 bounded replay sources and stable Product event identities.
+- ProductVariant v1/v2 bounded replay sources.
+- Product v2 to ProductVariant v2 graph links and bounded graph projection fields.
+- Product, translation, and ProductVariant retained hard-delete mutations.
+- SalesChannel v1 bounded current-state replay source.
+- Bounded multi-pass source reconciliation with durable pass/source cursor state.
+
+The pre-existing canonical plan still described several of these delivered slices as open. The plan update in this branch corrects those entries without promoting owner-executed evidence.
+
+## Confirmed missing on `main`
+
+SalesChannel hard-delete identities were not retained. A physical Channel deletion could therefore disappear from current-state replay without producing a generic Index delete, and identity reuse had no retained-delete revision fence.
+
+## Continued slice
+
+This branch adds the missing bounded SalesChannel delete path:
+
+- Channel-owned `channel_index_tombstones` storage;
+- delete, identity-move, and identity-reuse revision fencing;
+- replay of live rows and retained deletes through the existing `sales-channel-postgres-primary` source;
+- fail-closed rejection when one identity exists as both live and tombstoned;
+- synchronized Channel, Index, and verifier documentation.
+
+The following contracts remain unchanged:
+
+- `rustok-channel::sales_channel@1` schema fingerprint;
+- replay source and factory name;
+- stable `channel_id` cursor ordering;
+- targeted-load key shape;
+- replay event domain;
+- Index core ownership boundaries.
+
+## Remaining work
+
+Incremental mutation-event acknowledgement, persisted per-tenant schema readiness, durable Product-to-SalesChannel relation revisions, tombstone purge admission, authoritative Storefront cutover, and retained PostgreSQL replay/reconciliation/delete-recreate evidence remain open.

--- a/crates/rustok-index/docs/m7-sales-channel-source.md
+++ b/crates/rustok-index/docs/m7-sales-channel-source.md
@@ -1,24 +1,26 @@
-# M7 SalesChannel schema and bounded replay source
+# M7 SalesChannel schema, bounded replay source, and retained deletes
 
 Status: `source_complete_owner_execution_pending`
 
-This slice publishes the first Channel-owned current-state replay contract for
+This slice publishes the Channel-owned replay contract for
 `rustok-channel::sales_channel@1` without adding Channel semantics to Index core or the
-server.
+server. The stable source now covers both current rows and retained hard-delete
+identities.
 
 ## Ownership
 
 `rustok-channel` owns the `channels` table, the `ChannelRuntimeSelected` composition marker,
-and the positive monotonic `channels.index_revision` storage contract. The owner crate does
-not depend on `rustok-index` and does not construct generic Index mutations.
+the positive monotonic `channels.index_revision` storage contract, and the
+`channel_index_tombstones` replay-identity table. The owner crate does not depend on
+`rustok-index` and does not construct generic Index mutations.
 
 `rustok-distribution` owns the selected cross-module adapter because it already composes both
 Channel and Index. The adapter registers one schema and one host-database-aware source factory
 only when `ChannelModule` participated in runtime extension registration.
 
 `rustok-index` owns generic schema/source registration, deterministic event identity, immutable
-source registry materialization, replay jobs/checkpoints, mutation persistence, and query
-execution. The server remains Channel-agnostic.
+source registry materialization, replay jobs/checkpoints, reconciliation, mutation persistence,
+and query execution. The server remains Channel-agnostic.
 
 ## Schema
 
@@ -43,22 +45,40 @@ this schema.
 
 The selected `sales-channel-postgres-primary` source:
 
-- reads only the Channel-owned `channels` table;
+- reads only Channel-owned `channels` and `channel_index_tombstones` tables;
 - requires exact tenant and exact schema scope;
-- scans in stable `channel_id` UUID order with one-row lookahead;
+- scans live and deleted identities in stable `channel_id` UUID order with one-row lookahead;
 - persists an opaque cursor containing only `channel_id`;
 - never orders or paginates by mutable `index_revision`;
 - supports bounded targeted loads over exact non-localized entity keys;
 - rejects locale-bearing targeted keys;
-- rejects nil tenant/channel identities, non-positive revisions, and empty required strings;
-- emits generic `IndexMutation::Upsert` records with no links;
-- derives stable event UUIDs from tenant, channel, and source revision;
+- rejects nil tenant/channel identities and non-positive revisions;
+- rejects any live/tombstone coexistence for the same `(tenant_id, channel_id)` identity;
+- emits generic `IndexMutation::Upsert` records for live rows and `IndexMutation::Delete`
+  values for retained deletes;
+- derives stable event UUIDs from tenant, channel, and source revision for both mutation kinds;
 - maps storage failures to one bounded retryable code and contract/backend failures to bounded
   permanent codes.
 
 `index_revision` is the mutation `source_version`; it is not the scan cursor. A PostgreSQL
 trigger advances it exactly once for every Channel update and rejects revision exhaustion.
 The SeaORM owner model and public Channel DTOs do not expose the storage-internal column.
+
+## Retained deletion and identity reuse
+
+A `BEFORE DELETE` trigger stores the exact Channel identity at `OLD.index_revision + 1`.
+The tombstone table has no foreign key back to `channels` or `tenants`, so owner deletion and
+tenant cascade cannot erase the replay identity before Index observes it.
+
+A recreated `(tenant_id, channel_id)` is seeded strictly above the retained delete version.
+The retained row is removed only after the live revision is greater. Equal or lower live
+revisions fail the owner write instead of allowing a stale upsert to suppress a delete.
+Channel identity moves retain the old key at the newly advanced revision and clear the new key
+only after the same strict supersession check.
+
+The replay query unions current rows and retained deletes, then computes an exact identity
+count. A count other than one is a permanent source-contract failure; the adapter never chooses
+nondeterministically between live and deleted state.
 
 ## Composition
 
@@ -72,15 +92,16 @@ started by this slice.
 
 ## Explicitly open
 
-- Channel hard-delete tombstones;
 - incremental Channel event ingestion and broker acknowledgement;
+- tombstone retention and purge admission after every relevant consumer checkpoint is newer;
 - persisted per-tenant schema application;
-- repeatable-read full-scan snapshot and concurrent-insert reconciliation semantics;
-- versioned Product/ProductVariant to SalesChannel links;
+- owner snapshot/high-watermark semantics beyond bounded multi-pass reconciliation;
+- durable Product/ProductVariant to SalesChannel relations and revision semantics;
 - Channel target, binding, and resolution-policy schemas;
 - authoritative Storefront/Admin/Search consumer cutover;
 - retry/backoff/dead-letter scheduling and graceful host task ownership;
-- retained PostgreSQL replay, restart, drift, freshness, and equivalence evidence.
+- retained PostgreSQL delete/recreate, replay, restart, drift, freshness, and equivalence
+  evidence.
 
 Runtime capability presence does not establish persisted schema readiness. Consumers must not
 query this schema authoritatively until the exact tenant schema is applied and the relevant

--- a/scripts/verify/verify-index-sales-channel-source.mjs
+++ b/scripts/verify/verify-index-sales-channel-source.mjs
@@ -54,9 +54,9 @@ requireMarkers('crates/rustok-channel/tests/index_selection.rs', [
   'assert!(!cargo.contains("rustok-index"));',
 ]);
 
-const migrationPath =
+const revisionMigrationPath =
   'crates/rustok-channel/src/migrations/m20260730_000010_add_channel_index_revision.rs';
-const migration = requireMarkers(migrationPath, [
+const revisionMigration = requireMarkers(revisionMigrationPath, [
   'ALTER TABLE channels',
   'ADD COLUMN index_revision BIGINT NOT NULL DEFAULT 1',
   'chk_channels_index_revision_positive',
@@ -65,7 +65,38 @@ const migration = requireMarkers(migrationPath, [
   'trg_channels_bump_index_revision',
   'BEFORE UPDATE ON channels',
 ]);
-forbidMarkers(migrationPath, migration, [
+forbidMarkers(revisionMigrationPath, revisionMigration, [
+  'index_entities',
+  'index_links',
+  'index_jobs',
+  'index_checkpoints',
+]);
+
+const tombstoneMigrationPath =
+  'crates/rustok-channel/src/migrations/m20260731_000011_add_channel_index_tombstones.rs';
+const tombstoneMigration = requireMarkers(tombstoneMigrationPath, [
+  'CREATE TABLE channel_index_tombstones',
+  'PRIMARY KEY (tenant_id, channel_id)',
+  'chk_channel_index_tombstones_source_version_positive',
+  'rustok_channel_store_index_tombstone(',
+  'rustok_channel_clear_superseded_index_tombstone(',
+  'rustok_channel_seed_index_revision_from_tombstone()',
+  'retained_source_version + 1',
+  'trg_channels_seed_index_revision',
+  'BEFORE INSERT ON channels',
+  'rustok_channel_capture_index_tombstone()',
+  'OLD.index_revision + 1',
+  'trg_channels_capture_index_tombstone',
+  'BEFORE DELETE ON channels',
+  'trg_channels_clear_index_tombstone',
+  'AFTER INSERT ON channels',
+  'rustok_channel_move_index_tombstone()',
+  'AFTER UPDATE OF id, tenant_id ON channels',
+  'NEW.index_revision',
+]);
+forbidMarkers(tombstoneMigrationPath, tombstoneMigration, [
+  'REFERENCES channels',
+  'REFERENCES tenants',
   'index_entities',
   'index_links',
   'index_jobs',
@@ -74,6 +105,8 @@ forbidMarkers(migrationPath, migration, [
 requireMarkers('crates/rustok-channel/src/migrations/mod.rs', [
   'mod m20260730_000010_add_channel_index_revision;',
   'Box::new(m20260730_000010_add_channel_index_revision::Migration)',
+  'mod m20260731_000011_add_channel_index_tombstones;',
+  'Box::new(m20260731_000011_add_channel_index_tombstones::Migration)',
 ]);
 requireMarkers('crates/rustok-channel/src/migrations/m20260325_000001_create_channels.rs', [
   '.name("idx_channels_tenant_slug")',
@@ -104,6 +137,15 @@ const sourcePath = 'crates/rustok-distribution/src/channel_index.rs';
 const source = requireMarkers(sourcePath, [
   'SALES_CHANNEL_INDEX_SOURCE: &str = "sales-channel-postgres-primary"',
   'SALES_CHANNEL_EVENT_DOMAIN: &str = "rustok-channel.sales-channel-replay-v1"',
+  'SALES_CHANNEL_ROWS_CTE',
+  'sales_channel_index_union AS (',
+  'FALSE AS is_deleted',
+  'TRUE AS is_deleted',
+  'FROM channels c',
+  'FROM channel_index_tombstones tombstone',
+  'COUNT(*) OVER (',
+  'PARTITION BY row.tenant_id, row.channel_id',
+  'row.identity_count',
   'extensions.contains::<rustok_channel::ChannelRuntimeSelected>()',
   'register_index_schema_source(extensions, "channel", schema)',
   'register_postgres_index_source_factory(',
@@ -112,17 +154,18 @@ const source = requireMarkers(sourcePath, [
   'field("id", IndexValueType::Uuid, true, true)?',
   'field("slug", IndexValueType::String, true, true)?',
   'field("is_active", IndexValueType::Boolean, true, true)?',
-  'field_name("id")?, IndexValue::Uuid(self.channel_id)',
   'impl PostgresIndexSourceFactory for SalesChannelPostgresIndexSourceFactory',
   'impl IndexSource for SalesChannelPostgresIndexSource',
-  'FROM channels c',
-  'c.index_revision,',
-  'c.id > $2',
-  'ORDER BY c.id ASC',
+  'row.channel_id > $2',
+  'ORDER BY row.channel_id ASC',
   'request.limit() + 1',
   'WITH requested(channel_id) AS (VALUES {})',
-  'JOIN requested r ON r.channel_id = c.id',
+  'JOIN requested requested_key ON requested_key.channel_id = row.channel_id',
   'sales_channel_index_locale_forbidden',
+  'identity_count != 1',
+  'enum SalesChannelRowState',
+  'SalesChannelRowState::Deleted',
+  'IndexMutation::Delete',
   'derive_index_source_event_id(',
   'locale: None',
   'links: Vec::new()',
@@ -130,6 +173,7 @@ const source = requireMarkers(sourcePath, [
   'assert_eq!(schema.fields.len(), 6);',
   'selected_sales_channel_schema_is_nonlocalized_and_link_free',
   'selected_sales_channel_cursor_rejects_nil_and_unknown_fields',
+  'selected_sales_channel_tombstone_emits_delete_with_stable_identity',
   'selected_sales_channel_bridge_skips_partial_registry_without_channel_module',
   'selected_sales_channel_bridge_registers_schema_and_factory',
 ]);
@@ -138,8 +182,8 @@ forbidMarkers(sourcePath, source, [
   'IndexLink',
   'IndexLinkValue',
   'LocaleKey',
-  'ORDER BY c.index_revision',
-  '(c.index_revision, c.id)',
+  'ORDER BY row.index_revision',
+  '(row.index_revision, row.channel_id)',
   'SELECT *',
   'index_entities',
   'index_links',
@@ -161,9 +205,11 @@ requireMarkers('crates/rustok-distribution/tests/channel_index.rs', [
 
 requireMarkers('crates/rustok-channel/README.md', [
   '`channels.index_revision`',
+  '`channel_index_tombstones`',
   '`ChannelRuntimeSelected`',
   '`rustok-channel::sales_channel@1`',
   'stable `channel_id` ordering',
+  'retained hard-delete mutations',
   'does not depend on `rustok-index`',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-sales-channel-source.md', [
@@ -174,7 +220,9 @@ requireMarkers('crates/rustok-index/docs/m7-sales-channel-source.md', [
   'stable `channel_id` UUID order',
   '`index_revision` is the mutation `source_version`; it is not the scan cursor.',
   'The schema itself is link-free.',
-  'Channel hard-delete tombstones',
+  '`channel_index_tombstones`',
+  '`IndexMutation::Delete`',
+  'A count other than one is a permanent source-contract failure',
   'Runtime capability presence does not establish persisted schema readiness.',
   'maintainer-run',
 ]);


### PR DESCRIPTION
## Summary

- recheck the canonical `rustok-index` implementation plan against current `main` at `1cc032d6ceba0e55b5f3a1dfa2a64b066dc73f71`;
- correct stale M6/M7 plan entries for ProductVariant, SalesChannel, Product graph, Product/ProductVariant tombstones, and bounded source reconciliation already present on `main`;
- retain Channel hard-delete identities in Channel-owned `channel_index_tombstones` storage;
- fence hard delete, identity move, and identity reuse with monotonic source-version semantics;
- extend the existing `sales-channel-postgres-primary` source to replay live upserts and retained `IndexMutation::Delete` mutations;
- fail closed when a SalesChannel identity appears as both a live row and a retained tombstone;
- synchronize Channel ownership documentation, the M7 source contract, and the fail-closed verifier;
- add a dated implementation recheck recording the exact audited `main` SHA and remaining boundaries.

## Rechecked baseline

The following slices are already present on `main` and are now reflected in the canonical plan:

- Product v1/v2 bounded replay;
- ProductVariant v1/v2 bounded replay;
- Product v2 to ProductVariant v2 graph links;
- Product, translation, and ProductVariant retained hard deletes;
- SalesChannel v1 bounded current-state replay;
- bounded multi-pass source reconciliation with durable pass/source cursor state.

`channel_index_tombstones` was absent from `main`, so physical Channel deletion and identity reuse remained the next bounded M7 correctness gap.

## Preserved contracts

This slice does not change:

- `rustok-channel::sales_channel@1` schema fingerprint;
- source/factory name;
- stable `channel_id` cursor shape and ordering;
- targeted-load key shape;
- replay event domain;
- Index core or server source-domain dependency boundaries.

The existing source now returns either one live row or one retained delete for an exact identity. Coexistence is rejected instead of being resolved nondeterministically.

## Scope boundaries

This PR does not claim or add:

- incremental event ingestion or broker acknowledgement;
- persisted per-tenant Index schema readiness;
- durable Product/ProductVariant-to-SalesChannel relation revisions;
- tombstone purge admission;
- scheduler, retry/backoff, dead-letter, or graceful task ownership;
- authoritative Storefront cutover;
- retained PostgreSQL delete/recreate, replay, reconciliation, freshness, restart, or equivalence evidence.

## Validation

Not run per maintainer instruction:

- formatting;
- Cargo checks, tests, or Clippy;
- JavaScript verifiers;
- PostgreSQL migration or replay scenarios;
- CI workflows.

Suggested maintainer commands are retained in the implementation plan and M7 source document.

## History

Supersedes the closed unmerged SalesChannel tombstone PR #2636 with a new branch and a recheck against current `main`.
