### PR TITLE
fix(region): sanitize owner read port diagnostics

### DIFF
--- a/crates/rustok-region/contracts/evidence/region-owner-port-error-safety-source-review.json
+++ b/crates/rustok-region/contracts/evidence/region-owner-port-error-safety-source-review.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "status": "region_owner_port_error_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-region/src/ports.rs",
+    "crates/rustok-region/src/error.rs",
+    "scripts/verify/verify-region-owner-port-error-safety.mjs",
+    "crates/rustok-region/contracts/evidence/region-owner-port-error-safety-source.json",
+    "crates/rustok-region/docs/region-owner-port-error-safety.md",
+    "crates/rustok-region/docs/implementation-plan.md"
+  ],
+  "review_findings": {
+    "both_read_operations_preserved": true,
+    "owner_delegation_preserved": true,
+    "request_response_contract_preserved": true,
+    "public_error_kind_code_retryability_preserved": true,
+    "dynamic_validation_payload_removed_from_public_message": true,
+    "database_payload_removed_from_diagnostics": true,
+    "admission_payload_removed_from_diagnostics": true,
+    "context_payload_removed_from_diagnostics": true,
+    "request_identity_payload_removed_from_diagnostics": true,
+    "bounded_context_and_request_shape_retained": true,
+    "closed_owner_error_variant_retained": true,
+    "region_ffa_fba_status_unchanged": true,
+    "broad_ecommerce_cleanup_remains_open": true,
+    "runtime_evidence_claimed": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, workflows, CI, or mounted runtime validation was executed."
+}

--- a/crates/rustok-region/contracts/evidence/region-owner-port-error-safety-source.json
+++ b/crates/rustok-region/contracts/evidence/region-owner-port-error-safety-source.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": 1,
+  "status": "region_owner_port_error_safety_source_unvalidated",
+  "scope": {
+    "owner_source": "crates/rustok-region/src/ports.rs",
+    "owner_error": "crates/rustok-region/src/error.rs",
+    "focused_verifier": "scripts/verify/verify-region-owner-port-error-safety.mjs",
+    "documentation": "crates/rustok-region/docs/region-owner-port-error-safety.md",
+    "local_plan": "crates/rustok-region/docs/implementation-plan.md"
+  },
+  "source_contract": {
+    "owner_operation_count": 2,
+    "owner_delegation_changed": false,
+    "request_response_contract_changed": false,
+    "public_error_kind_code_retryability_changed": false,
+    "dynamic_owner_validation_message_public": false,
+    "database_error_payload_logged": false,
+    "complete_port_error_logged_by_admission": false,
+    "port_error_message_text_logged_by_admission": false,
+    "raw_context_logged": false,
+    "raw_region_uuid_logged": false,
+    "raw_country_code_logged": false,
+    "static_owner_messages": true,
+    "closed_error_variant_logged": true,
+    "aggregate_text_shape_logged": true,
+    "aggregate_uuid_shape_logged": true,
+    "opaque_payload_presence_logged": true,
+    "bounded_context_shape_logged": true,
+    "bounded_request_shape_logged": true,
+    "region_ffa_status_changed": false,
+    "region_fba_status_changed": false,
+    "broad_ecommerce_cleanup_closed": false,
+    "runtime_evidence_claimed": false
+  },
+  "validation": {
+    "tests_run": false,
+    "verifiers_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "mounted_runtime_proven": false
+  },
+  "execution": []
+}

--- a/crates/rustok-region/docs/implementation-plan.md
+++ b/crates/rustok-region/docs/implementation-plan.md
@@ -25,6 +25,11 @@ adapters bind and render prepared state.
 - Structural shape: `core_transport_ui`
 - FBA provider contract: `RegionReadPort` / `region.read_projection.v1` in
   `crates/rustok-region/contracts/region-fba-registry.json`.
+- Owner read-port error safety: `source_closed_unvalidated`; public validation
+  messages and owner diagnostics are bounded by
+  `crates/rustok-region/docs/region-owner-port-error-safety.md` and
+  `scripts/verify/verify-region-owner-port-error-safety.mjs` without promoting
+  FFA/FBA status.
 - Static and runtime-order evidence:
   `crates/rustok-region/contracts/evidence/region-contract-test-static-matrix.json`
   and `crates/rustok-region/contracts/evidence/region-provider-runtime-order-smoke.json`.
@@ -62,8 +67,16 @@ adapters bind and render prepared state.
    **Done when:** route ownership, fallback behavior, and tax-provider policy
    describe the same module boundary everywhere.
 
+4. **Validate the Region owner-port error-safety source contract.** Execute the
+   focused verifier, compile the Region and Commerce consumers, and retain
+   mounted failure-envelope evidence without exposing raw owner payloads.
+   **Depends on:** repository checkout and composed Region consumers.
+   **Done when:** source guard, compile, and mounted runtime evidence are retained
+   without changing the current FFA/FBA status prematurely.
+
 ## Verification
 
+- `node scripts/verify/verify-region-owner-port-error-safety.mjs`
 - `npm run verify:region:admin-boundary`
 - `npm run verify:region:storefront-boundary`
 - `npm run verify:region:fba`

--- a/crates/rustok-region/docs/region-owner-port-error-safety.md
+++ b/crates/rustok-region/docs/region-owner-port-error-safety.md
@@ -1,0 +1,63 @@
+# Region owner port error safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This contract closes the currently identified public-message and diagnostic-payload gaps in the owner `RegionReadPort` implementation in `crates/rustok-region/src/ports.rs`.
+
+The two owner operations remain unchanged:
+
+- `RegionReadPort::read_region`;
+- `RegionReadPort::list_regions_for_tenant`.
+
+Region lookup, country-code resolution, list projection, locale fallback, DTOs, owner service delegation, and read policy remain owned by the existing Region implementation.
+
+## Public outcomes
+
+Stable public codes, `PortErrorKind` values, and retryability are preserved.
+
+- `region.not_found` remains a non-retryable not-found outcome.
+- `region.read_failed` remains a retryable unavailable outcome with the existing static storage message.
+- `region.validation` remains a non-retryable validation outcome, but owner-supplied validation and country-code payloads are no longer returned as public text. Both now use `region request is invalid`.
+- `region.tenant_id_invalid` remains a non-retryable validation outcome with a bounded request-context message.
+- Direct empty country-code validation retains its existing stable code and static message.
+
+## Bounded diagnostics
+
+Owner events retain the correlation id, exact owner operation, stable code, retryability where applicable, and the Region owner boundary label.
+
+Request context is represented only through bounded context shape:
+
+- tenant and actor-id character lengths;
+- a closed actor-kind label;
+- claim and role counts;
+- optional channel, causation, trace, and idempotency presence/length;
+- locale length and deadline.
+
+Read requests are represented only through bounded selector and locale shape:
+
+- selector kind;
+- whether a UUID selector is non-nil;
+- country-code presence and length;
+- requested and tenant-default locale presence and length.
+
+Owner failures retain a closed error-variant label plus aggregate text, UUID, and opaque-payload facts. Database errors, validation text, country codes, region UUIDs, and complete `PortError` envelopes are not recorded.
+
+## Severity
+
+Database failures remain error severity. Not-found, validation, policy-admission, tenant-parse, and direct request-validation outcomes remain warning severity.
+
+## Deliberate boundary
+
+This is a source-only Region owner-boundary change. Storefront transport behavior, GraphQL/native selection, Region policy, persistence, module manifests, Commerce topology, and FBA/FFA status are unchanged.
+
+The broader ecommerce correlation-safe mapper cleanup and runtime validation remain open.
+
+## Evidence
+
+- `crates/rustok-region/contracts/evidence/region-owner-port-error-safety-source.json`
+- `crates/rustok-region/contracts/evidence/region-owner-port-error-safety-source-review.json`
+- `scripts/verify/verify-region-owner-port-error-safety.mjs`
+
+No tests, Node verifiers, Cargo commands, formatting, workflows, CI, or mounted runtime validation was executed.

--- a/crates/rustok-region/src/ports.rs
+++ b/crates/rustok-region/src/ports.rs
@@ -1,9 +1,12 @@
 use async_trait::async_trait;
-use rustok_api::{PortCallPolicy, PortContext, PortError};
+use rustok_api::{PortCallPolicy, PortContext, PortError, PortErrorKind};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::dto::RegionResponse;
+
+const REGION_OWNER: &str = "rustok_region";
+const REGION_READ_PORT_BOUNDARY: &str = "region_read_owner_port";
 
 /// Transport-neutral selector for region read-projection consumers.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -57,9 +60,10 @@ impl RegionReadPort for crate::RegionService {
         context: PortContext,
         request: RegionReadRequest,
     ) -> Result<Option<RegionReadProjection>, PortError> {
-        context.require_policy(PortCallPolicy::read())?;
-        let tenant_id = parse_tenant_id(&context)?;
-        validate_region_read_request(&request)?;
+        let owner_operation = "read_region";
+        require_region_read_policy(&context, owner_operation)?;
+        let tenant_id = parse_tenant_id(&context, owner_operation)?;
+        validate_region_read_request(&context, owner_operation, &request)?;
 
         let result = match request.selector {
             RegionReadSelector::Id(region_id) => self
@@ -81,7 +85,7 @@ impl RegionReadPort for crate::RegionService {
                 .await
             }
         }
-        .map_err(map_region_error)?;
+        .map_err(|error| map_region_error(&context, owner_operation, error))?;
 
         Ok(result.map(|region| RegionReadProjection { region }))
     }
@@ -91,15 +95,16 @@ impl RegionReadPort for crate::RegionService {
         context: PortContext,
         request: RegionListRequest,
     ) -> Result<Vec<RegionReadProjection>, PortError> {
-        context.require_policy(PortCallPolicy::read())?;
-        let tenant_id = parse_tenant_id(&context)?;
+        let owner_operation = "list_regions_for_tenant";
+        require_region_read_policy(&context, owner_operation)?;
+        let tenant_id = parse_tenant_id(&context, owner_operation)?;
         self.list_regions(
             tenant_id,
             request.requested_locale.as_deref(),
             request.tenant_default_locale.as_deref(),
         )
         .await
-        .map_err(map_region_error)
+        .map_err(|error| map_region_error(&context, owner_operation, error))
         .map(|regions| {
             regions
                 .into_iter()
@@ -109,19 +114,220 @@ impl RegionReadPort for crate::RegionService {
     }
 }
 
-fn parse_tenant_id(context: &PortContext) -> Result<Uuid, PortError> {
+struct RegionReadContextFacts {
+    tenant_id_length: usize,
+    actor_kind: &'static str,
+    actor_id_length: usize,
+    claim_count: usize,
+    role_count: usize,
+    channel_present: bool,
+    channel_length: Option<usize>,
+    locale_length: usize,
+    causation_id_present: bool,
+    causation_id_length: Option<usize>,
+    traceparent_present: bool,
+    traceparent_length: Option<usize>,
+    idempotency_key_present: bool,
+    idempotency_key_length: Option<usize>,
+    deadline_ms: Option<u64>,
+}
+
+struct RegionReadRequestFacts {
+    selector_kind: &'static str,
+    selector_uuid_non_nil: Option<bool>,
+    country_code_present: bool,
+    country_code_length: Option<usize>,
+    requested_locale_present: bool,
+    requested_locale_length: Option<usize>,
+    tenant_default_locale_present: bool,
+    tenant_default_locale_length: Option<usize>,
+}
+
+struct RegionOwnerErrorFacts {
+    error_variant: &'static str,
+    text_field_count: usize,
+    text_total_length: usize,
+    uuid_field_count: usize,
+    uuid_non_nil_count: usize,
+    opaque_payload_present: bool,
+}
+
+fn region_read_context_facts(context: &PortContext) -> RegionReadContextFacts {
+    let actor_kind = match &context.actor.kind {
+        rustok_api::PortActorKind::User => "user",
+        rustok_api::PortActorKind::Service => "service",
+        rustok_api::PortActorKind::System => "system",
+    };
+    RegionReadContextFacts {
+        tenant_id_length: context.tenant_id.chars().count(),
+        actor_kind,
+        actor_id_length: context.actor.id.chars().count(),
+        claim_count: context.claims.len(),
+        role_count: context.roles.len(),
+        channel_present: context.channel.is_some(),
+        channel_length: context.channel.as_ref().map(|value| value.chars().count()),
+        locale_length: context.locale.chars().count(),
+        causation_id_present: context.causation_id.is_some(),
+        causation_id_length: context
+            .causation_id
+            .as_ref()
+            .map(|value| value.chars().count()),
+        traceparent_present: context.traceparent.is_some(),
+        traceparent_length: context
+            .traceparent
+            .as_ref()
+            .map(|value| value.chars().count()),
+        idempotency_key_present: context.idempotency_key.is_some(),
+        idempotency_key_length: context
+            .idempotency_key
+            .as_ref()
+            .map(|value| value.chars().count()),
+        deadline_ms: context.deadline_ms,
+    }
+}
+
+fn region_read_request_facts(request: &RegionReadRequest) -> RegionReadRequestFacts {
+    let (
+        selector_kind,
+        selector_uuid_non_nil,
+        country_code_present,
+        country_code_length,
+    ) = match &request.selector {
+        RegionReadSelector::Id(region_id) => ("id", Some(!region_id.is_nil()), false, None),
+        RegionReadSelector::CountryCode(country_code) => (
+            "country_code",
+            None,
+            true,
+            Some(country_code.chars().count()),
+        ),
+    };
+    RegionReadRequestFacts {
+        selector_kind,
+        selector_uuid_non_nil,
+        country_code_present,
+        country_code_length,
+        requested_locale_present: request.requested_locale.is_some(),
+        requested_locale_length: request
+            .requested_locale
+            .as_ref()
+            .map(|value| value.chars().count()),
+        tenant_default_locale_present: request.tenant_default_locale.is_some(),
+        tenant_default_locale_length: request
+            .tenant_default_locale
+            .as_ref()
+            .map(|value| value.chars().count()),
+    }
+}
+
+fn region_port_error_kind(kind: &PortErrorKind) -> &'static str {
+    match kind {
+        PortErrorKind::Validation => "validation",
+        PortErrorKind::NotFound => "not_found",
+        PortErrorKind::Conflict => "conflict",
+        PortErrorKind::Forbidden => "forbidden",
+        PortErrorKind::Unavailable => "unavailable",
+        PortErrorKind::Timeout => "timeout",
+        PortErrorKind::InvariantViolation => "invariant_violation",
+    }
+}
+
+fn require_region_read_policy(
+    context: &PortContext,
+    owner_operation: &'static str,
+) -> Result<(), PortError> {
+    context
+        .require_policy(PortCallPolicy::read())
+        .map_err(|error| {
+            log_region_read_admission_rejection(context, owner_operation, &error);
+            error
+        })
+}
+
+fn log_region_read_admission_rejection(
+    context: &PortContext,
+    owner_operation: &'static str,
+    error: &PortError,
+) {
+    let context_facts = region_read_context_facts(context);
+    tracing::warn!(
+        owner = REGION_OWNER,
+        correlation_id = %context.correlation_id,
+        tenant_id_length = context_facts.tenant_id_length,
+        actor_kind = context_facts.actor_kind,
+        actor_id_length = context_facts.actor_id_length,
+        claim_count = context_facts.claim_count,
+        role_count = context_facts.role_count,
+        channel_present = context_facts.channel_present,
+        channel_length = ?context_facts.channel_length,
+        locale_length = context_facts.locale_length,
+        causation_id_present = context_facts.causation_id_present,
+        causation_id_length = ?context_facts.causation_id_length,
+        traceparent_present = context_facts.traceparent_present,
+        traceparent_length = ?context_facts.traceparent_length,
+        idempotency_key_present = context_facts.idempotency_key_present,
+        idempotency_key_length = ?context_facts.idempotency_key_length,
+        deadline_ms = ?context_facts.deadline_ms,
+        operation = owner_operation,
+        code = %error.code,
+        error_kind = region_port_error_kind(&error.kind),
+        error_message_present = !error.message.is_empty(),
+        error_message_length = error.message.chars().count(),
+        retryable = error.retryable,
+        boundary = REGION_READ_PORT_BOUNDARY,
+        "region read admission was rejected with bounded diagnostics"
+    );
+}
+
+fn parse_tenant_id(
+    context: &PortContext,
+    owner_operation: &'static str,
+) -> Result<Uuid, PortError> {
     context.tenant_id.parse::<Uuid>().map_err(|_| {
+        log_region_tenant_parse_rejection(context, owner_operation);
         PortError::validation(
             "region.tenant_id_invalid",
-            "region read port requires a UUID tenant_id in context",
+            "region request context is invalid",
         )
     })
 }
 
-fn validate_region_read_request(request: &RegionReadRequest) -> Result<(), PortError> {
+fn log_region_tenant_parse_rejection(context: &PortContext, owner_operation: &'static str) {
+    let context_facts = region_read_context_facts(context);
+    tracing::warn!(
+        owner = REGION_OWNER,
+        correlation_id = %context.correlation_id,
+        tenant_id_length = context_facts.tenant_id_length,
+        actor_kind = context_facts.actor_kind,
+        actor_id_length = context_facts.actor_id_length,
+        claim_count = context_facts.claim_count,
+        role_count = context_facts.role_count,
+        channel_present = context_facts.channel_present,
+        channel_length = ?context_facts.channel_length,
+        locale_length = context_facts.locale_length,
+        causation_id_present = context_facts.causation_id_present,
+        causation_id_length = ?context_facts.causation_id_length,
+        traceparent_present = context_facts.traceparent_present,
+        traceparent_length = ?context_facts.traceparent_length,
+        idempotency_key_present = context_facts.idempotency_key_present,
+        idempotency_key_length = ?context_facts.idempotency_key_length,
+        deadline_ms = ?context_facts.deadline_ms,
+        operation = owner_operation,
+        code = "region.tenant_id_invalid",
+        tenant_id_parse_failed = true,
+        boundary = REGION_READ_PORT_BOUNDARY,
+        "region read tenant context was rejected with bounded diagnostics"
+    );
+}
+
+fn validate_region_read_request(
+    context: &PortContext,
+    owner_operation: &'static str,
+    request: &RegionReadRequest,
+) -> Result<(), PortError> {
     if let RegionReadSelector::CountryCode(country_code) = &request.selector
         && country_code.trim().is_empty()
     {
+        log_region_request_validation_rejection(context, owner_operation, request);
         return Err(PortError::validation(
             "region.country_code_empty",
             "region read port requires a non-empty country code selector",
@@ -130,17 +336,189 @@ fn validate_region_read_request(request: &RegionReadRequest) -> Result<(), PortE
     Ok(())
 }
 
-fn map_region_error(error: crate::RegionError) -> PortError {
+fn log_region_request_validation_rejection(
+    context: &PortContext,
+    owner_operation: &'static str,
+    request: &RegionReadRequest,
+) {
+    let context_facts = region_read_context_facts(context);
+    let request_facts = region_read_request_facts(request);
+    tracing::warn!(
+        owner = REGION_OWNER,
+        correlation_id = %context.correlation_id,
+        tenant_id_length = context_facts.tenant_id_length,
+        actor_kind = context_facts.actor_kind,
+        actor_id_length = context_facts.actor_id_length,
+        claim_count = context_facts.claim_count,
+        role_count = context_facts.role_count,
+        channel_present = context_facts.channel_present,
+        channel_length = ?context_facts.channel_length,
+        locale_length = context_facts.locale_length,
+        causation_id_present = context_facts.causation_id_present,
+        causation_id_length = ?context_facts.causation_id_length,
+        traceparent_present = context_facts.traceparent_present,
+        traceparent_length = ?context_facts.traceparent_length,
+        idempotency_key_present = context_facts.idempotency_key_present,
+        idempotency_key_length = ?context_facts.idempotency_key_length,
+        deadline_ms = ?context_facts.deadline_ms,
+        operation = owner_operation,
+        code = "region.country_code_empty",
+        selector_kind = request_facts.selector_kind,
+        selector_uuid_non_nil = ?request_facts.selector_uuid_non_nil,
+        country_code_present = request_facts.country_code_present,
+        country_code_length = ?request_facts.country_code_length,
+        requested_locale_present = request_facts.requested_locale_present,
+        requested_locale_length = ?request_facts.requested_locale_length,
+        tenant_default_locale_present = request_facts.tenant_default_locale_present,
+        tenant_default_locale_length = ?request_facts.tenant_default_locale_length,
+        boundary = REGION_READ_PORT_BOUNDARY,
+        "region read request was rejected with bounded diagnostics"
+    );
+}
+
+fn region_owner_error_facts(error: &crate::RegionError) -> RegionOwnerErrorFacts {
+    match error {
+        crate::RegionError::Validation(message) => RegionOwnerErrorFacts {
+            error_variant: "validation",
+            text_field_count: 1,
+            text_total_length: message.chars().count(),
+            uuid_field_count: 0,
+            uuid_non_nil_count: 0,
+            opaque_payload_present: false,
+        },
+        crate::RegionError::RegionNotFound(region_id) => RegionOwnerErrorFacts {
+            error_variant: "region_not_found",
+            text_field_count: 0,
+            text_total_length: 0,
+            uuid_field_count: 1,
+            uuid_non_nil_count: if region_id.is_nil() { 0 } else { 1 },
+            opaque_payload_present: false,
+        },
+        crate::RegionError::InvalidCountryCode(country_code) => RegionOwnerErrorFacts {
+            error_variant: "invalid_country_code",
+            text_field_count: 1,
+            text_total_length: country_code.chars().count(),
+            uuid_field_count: 0,
+            uuid_non_nil_count: 0,
+            opaque_payload_present: false,
+        },
+        crate::RegionError::Database(_) => RegionOwnerErrorFacts {
+            error_variant: "database",
+            text_field_count: 0,
+            text_total_length: 0,
+            uuid_field_count: 0,
+            uuid_non_nil_count: 0,
+            opaque_payload_present: true,
+        },
+    }
+}
+
+fn log_region_owner_failure(
+    context: &PortContext,
+    owner_operation: &'static str,
+    code: &'static str,
+    error_facts: &RegionOwnerErrorFacts,
+    technical_failure: bool,
+) {
+    let context_facts = region_read_context_facts(context);
+    if technical_failure {
+        tracing::error!(
+            owner = REGION_OWNER,
+            correlation_id = %context.correlation_id,
+            tenant_id_length = context_facts.tenant_id_length,
+            actor_kind = context_facts.actor_kind,
+            actor_id_length = context_facts.actor_id_length,
+            claim_count = context_facts.claim_count,
+            role_count = context_facts.role_count,
+            channel_present = context_facts.channel_present,
+            channel_length = ?context_facts.channel_length,
+            locale_length = context_facts.locale_length,
+            causation_id_present = context_facts.causation_id_present,
+            causation_id_length = ?context_facts.causation_id_length,
+            traceparent_present = context_facts.traceparent_present,
+            traceparent_length = ?context_facts.traceparent_length,
+            idempotency_key_present = context_facts.idempotency_key_present,
+            idempotency_key_length = ?context_facts.idempotency_key_length,
+            deadline_ms = ?context_facts.deadline_ms,
+            operation = owner_operation,
+            code,
+            error_variant = error_facts.error_variant,
+            text_field_count = error_facts.text_field_count,
+            text_total_length = error_facts.text_total_length,
+            uuid_field_count = error_facts.uuid_field_count,
+            uuid_non_nil_count = error_facts.uuid_non_nil_count,
+            opaque_payload_present = error_facts.opaque_payload_present,
+            boundary = REGION_READ_PORT_BOUNDARY,
+            "region owner read failed with bounded diagnostics"
+        );
+    } else {
+        tracing::warn!(
+            owner = REGION_OWNER,
+            correlation_id = %context.correlation_id,
+            tenant_id_length = context_facts.tenant_id_length,
+            actor_kind = context_facts.actor_kind,
+            actor_id_length = context_facts.actor_id_length,
+            claim_count = context_facts.claim_count,
+            role_count = context_facts.role_count,
+            channel_present = context_facts.channel_present,
+            channel_length = ?context_facts.channel_length,
+            locale_length = context_facts.locale_length,
+            causation_id_present = context_facts.causation_id_present,
+            causation_id_length = ?context_facts.causation_id_length,
+            traceparent_present = context_facts.traceparent_present,
+            traceparent_length = ?context_facts.traceparent_length,
+            idempotency_key_present = context_facts.idempotency_key_present,
+            idempotency_key_length = ?context_facts.idempotency_key_length,
+            deadline_ms = ?context_facts.deadline_ms,
+            operation = owner_operation,
+            code,
+            error_variant = error_facts.error_variant,
+            text_field_count = error_facts.text_field_count,
+            text_total_length = error_facts.text_total_length,
+            uuid_field_count = error_facts.uuid_field_count,
+            uuid_non_nil_count = error_facts.uuid_non_nil_count,
+            opaque_payload_present = error_facts.opaque_payload_present,
+            boundary = REGION_READ_PORT_BOUNDARY,
+            "region owner read was rejected with bounded diagnostics"
+        );
+    }
+}
+
+fn map_region_error(
+    context: &PortContext,
+    owner_operation: &'static str,
+    error: crate::RegionError,
+) -> PortError {
+    let error_facts = region_owner_error_facts(&error);
     match error {
         crate::RegionError::RegionNotFound(_) => {
+            log_region_owner_failure(
+                context,
+                owner_operation,
+                "region.not_found",
+                &error_facts,
+                false,
+            );
             PortError::not_found("region.not_found", "region read projection was not found")
         }
-        crate::RegionError::Validation(message)
-        | crate::RegionError::InvalidCountryCode(message) => {
-            PortError::validation("region.validation", message)
+        crate::RegionError::Validation(_) | crate::RegionError::InvalidCountryCode(_) => {
+            log_region_owner_failure(
+                context,
+                owner_operation,
+                "region.validation",
+                &error_facts,
+                false,
+            );
+            PortError::validation("region.validation", "region request is invalid")
         }
-        crate::RegionError::Database(error) => {
-            tracing::error!(error = ?error, "region port storage operation failed");
+        crate::RegionError::Database(_) => {
+            log_region_owner_failure(
+                context,
+                owner_operation,
+                "region.read_failed",
+                &error_facts,
+                true,
+            );
             PortError::unavailable(
                 "region.read_failed",
                 "region storage is temporarily unavailable",

--- a/scripts/verify/verify-region-owner-port-error-safety.mjs
+++ b/scripts/verify/verify-region-owner-port-error-safety.mjs
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const failures = [];
+
+const paths = {
+  ports: 'crates/rustok-region/src/ports.rs',
+  error: 'crates/rustok-region/src/error.rs',
+  evidence:
+    'crates/rustok-region/contracts/evidence/region-owner-port-error-safety-source.json',
+  review:
+    'crates/rustok-region/contracts/evidence/region-owner-port-error-safety-source-review.json',
+  document: 'crates/rustok-region/docs/region-owner-port-error-safety.md',
+  plan: 'crates/rustok-region/docs/implementation-plan.md',
+};
+
+const ports = read(paths.ports);
+const errorSource = read(paths.error);
+const evidence = JSON.parse(read(paths.evidence));
+const review = JSON.parse(read(paths.review));
+const document = read(paths.document);
+const plan = read(paths.plan);
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+function functionBody(source, functionName) {
+  const signature = new RegExp(
+    `(?:pub(?:\\([^)]*\\))?\\s+)?(?:async\\s+)?fn\\s+${functionName}(?:<[^>]*>)?\\s*\\(`,
+  );
+  const match = signature.exec(source);
+  if (!match) {
+    failures.push(`missing function ${functionName}`);
+    return '';
+  }
+  const openBrace = source.indexOf('{', match.index);
+  let depth = 0;
+  for (let index = openBrace; index >= 0 && index < source.length; index += 1) {
+    if (source[index] === '{') depth += 1;
+    if (source[index] === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(openBrace, index + 1);
+    }
+  }
+  failures.push(`unterminated function ${functionName}`);
+  return '';
+}
+
+for (const marker of [
+  'pub trait RegionReadPort: Send + Sync',
+  'async fn read_region(',
+  'async fn list_regions_for_tenant(',
+  'impl RegionReadPort for crate::RegionService',
+  'self.get_region(',
+  'self.resolve_region_for_country(',
+  'self.list_regions(',
+  'require_region_read_policy(&context, owner_operation)?;',
+  'parse_tenant_id(&context, owner_operation)?;',
+  'map_region_error(&context, owner_operation, error)',
+]) requireText(ports, marker, `${paths.ports}: preserved owner boundary`);
+
+for (const marker of [
+  'Validation(String)',
+  'RegionNotFound(Uuid)',
+  'InvalidCountryCode(String)',
+  'Database(#[from] DbErr)',
+]) requireText(errorSource, marker, `${paths.error}: owner error shape`);
+
+const contextFacts = functionBody(ports, 'region_read_context_facts');
+const requestFacts = functionBody(ports, 'region_read_request_facts');
+const kindMapper = functionBody(ports, 'region_port_error_kind');
+const admission = functionBody(ports, 'require_region_read_policy');
+const admissionLogger = functionBody(ports, 'log_region_read_admission_rejection');
+const tenantParser = functionBody(ports, 'parse_tenant_id');
+const tenantLogger = functionBody(ports, 'log_region_tenant_parse_rejection');
+const validation = functionBody(ports, 'validate_region_read_request');
+const validationLogger = functionBody(ports, 'log_region_request_validation_rejection');
+const ownerFacts = functionBody(ports, 'region_owner_error_facts');
+const ownerLogger = functionBody(ports, 'log_region_owner_failure');
+const mapper = functionBody(ports, 'map_region_error');
+const diagnosticScope = [
+  contextFacts,
+  requestFacts,
+  kindMapper,
+  admission,
+  admissionLogger,
+  tenantParser,
+  tenantLogger,
+  validation,
+  validationLogger,
+  ownerFacts,
+  ownerLogger,
+  mapper,
+].join('\n');
+
+for (const marker of [
+  'tenant_id_length: context.tenant_id.chars().count()',
+  'actor_kind',
+  'actor_id_length: context.actor.id.chars().count()',
+  'claim_count: context.claims.len()',
+  'role_count: context.roles.len()',
+  'channel_present: context.channel.is_some()',
+  'locale_length: context.locale.chars().count()',
+  'causation_id_present: context.causation_id.is_some()',
+  'traceparent_present: context.traceparent.is_some()',
+  'idempotency_key_present: context.idempotency_key.is_some()',
+  'deadline_ms: context.deadline_ms',
+]) requireText(contextFacts, marker, `${paths.ports}: bounded context facts`);
+
+for (const marker of [
+  'selector_kind',
+  'selector_uuid_non_nil',
+  'country_code_length',
+  'requested_locale_length',
+  'tenant_default_locale_length',
+]) requireText(requestFacts, marker, `${paths.ports}: bounded request facts`);
+
+for (const marker of [
+  'PortErrorKind::Validation => "validation"',
+  'PortErrorKind::NotFound => "not_found"',
+  'PortErrorKind::Conflict => "conflict"',
+  'PortErrorKind::Forbidden => "forbidden"',
+  'PortErrorKind::Unavailable => "unavailable"',
+  'PortErrorKind::Timeout => "timeout"',
+  'PortErrorKind::InvariantViolation => "invariant_violation"',
+]) requireText(kindMapper, marker, `${paths.ports}: closed PortError kind`);
+
+for (const marker of [
+  '.require_policy(PortCallPolicy::read())',
+  'log_region_read_admission_rejection(context, owner_operation, &error);',
+  'error',
+]) requireText(admission, marker, `${paths.ports}: preserved admission return`);
+
+for (const marker of [
+  'correlation_id = %context.correlation_id',
+  'tenant_id_length = context_facts.tenant_id_length',
+  'operation = owner_operation',
+  'code = %error.code',
+  'error_kind = region_port_error_kind(&error.kind)',
+  'error_message_present = !error.message.is_empty()',
+  'error_message_length = error.message.chars().count()',
+  'retryable = error.retryable',
+  'boundary = REGION_READ_PORT_BOUNDARY',
+]) requireText(admissionLogger, marker, `${paths.ports}: bounded admission logger`);
+
+for (const marker of [
+  'context.tenant_id.parse::<Uuid>().map_err(|_|',
+  'log_region_tenant_parse_rejection(context, owner_operation);',
+  '"region.tenant_id_invalid"',
+  '"region request context is invalid"',
+]) requireText(tenantParser, marker, `${paths.ports}: stable tenant parser`);
+
+for (const marker of [
+  'tenant_id_parse_failed = true',
+  'tenant_id_length = context_facts.tenant_id_length',
+  'boundary = REGION_READ_PORT_BOUNDARY',
+]) requireText(tenantLogger, marker, `${paths.ports}: bounded tenant parser logger`);
+
+for (const marker of [
+  'country_code.trim().is_empty()',
+  'log_region_request_validation_rejection(context, owner_operation, request);',
+  '"region.country_code_empty"',
+  '"region read port requires a non-empty country code selector"',
+]) requireText(validation, marker, `${paths.ports}: preserved direct validation`);
+
+for (const marker of [
+  'selector_kind = request_facts.selector_kind',
+  'selector_uuid_non_nil = ?request_facts.selector_uuid_non_nil',
+  'country_code_length = ?request_facts.country_code_length',
+  'requested_locale_length = ?request_facts.requested_locale_length',
+  'tenant_default_locale_length = ?request_facts.tenant_default_locale_length',
+]) requireText(validationLogger, marker, `${paths.ports}: bounded validation logger`);
+
+for (const marker of [
+  'crate::RegionError::Validation(message)',
+  'error_variant: "validation"',
+  'text_total_length: message.chars().count()',
+  'crate::RegionError::RegionNotFound(region_id)',
+  'error_variant: "region_not_found"',
+  'uuid_field_count: 1',
+  'crate::RegionError::InvalidCountryCode(country_code)',
+  'error_variant: "invalid_country_code"',
+  'text_total_length: country_code.chars().count()',
+  'crate::RegionError::Database(_)',
+  'error_variant: "database"',
+  'opaque_payload_present: true',
+]) requireText(ownerFacts, marker, `${paths.ports}: bounded owner error facts`);
+
+for (const marker of [
+  'tracing::error!(',
+  'tracing::warn!(',
+  'owner = REGION_OWNER',
+  'correlation_id = %context.correlation_id',
+  'operation = owner_operation',
+  'error_variant = error_facts.error_variant',
+  'text_field_count = error_facts.text_field_count',
+  'text_total_length = error_facts.text_total_length',
+  'uuid_field_count = error_facts.uuid_field_count',
+  'uuid_non_nil_count = error_facts.uuid_non_nil_count',
+  'opaque_payload_present = error_facts.opaque_payload_present',
+  'boundary = REGION_READ_PORT_BOUNDARY',
+]) requireText(ownerLogger, marker, `${paths.ports}: bounded owner logger`);
+
+for (const [variant, code, message, constructor, technical] of [
+  [
+    'crate::RegionError::RegionNotFound(_)',
+    'region.not_found',
+    'region read projection was not found',
+    'PortError::not_found',
+    'false',
+  ],
+  [
+    'crate::RegionError::Validation(_) | crate::RegionError::InvalidCountryCode(_)',
+    'region.validation',
+    'region request is invalid',
+    'PortError::validation',
+    'false',
+  ],
+  [
+    'crate::RegionError::Database(_)',
+    'region.read_failed',
+    'region storage is temporarily unavailable',
+    'PortError::unavailable',
+    'true',
+  ],
+]) {
+  for (const marker of [variant, `"${code}"`, `"${message}"`, constructor]) {
+    requireText(mapper, marker, `${paths.ports}: stable ${code} mapping`);
+  }
+  const severity = new RegExp(
+    `"${code.replaceAll('.', '\\.')}\\",[\\s\\S]*?&error_facts,[\\s\\S]*?${technical},`,
+  );
+  if (!severity.test(mapper)) {
+    failures.push(`${paths.ports}: ${code} severity classification drift`);
+  }
+}
+
+for (const forbidden of [
+  'error = ?error',
+  'error = %error',
+  'internal_message = %error.message',
+  'tenant_id = %context.tenant_id',
+  'actor = ?context.actor',
+  'channel = ?context.channel',
+  'locale = %context.locale',
+  'causation_id = ?context.causation_id',
+  'traceparent = ?context.traceparent',
+  'idempotency_key = ?context.idempotency_key',
+  'region_id = %',
+  'country_code = %',
+  'requested_locale = %',
+  'tenant_default_locale = %',
+]) forbidText(diagnosticScope, forbidden, `${paths.ports}: payload diagnostics`);
+
+for (const [key, expected] of Object.entries({
+  owner_operation_count: 2,
+  dynamic_owner_validation_message_public: false,
+  database_error_payload_logged: false,
+  complete_port_error_logged_by_admission: false,
+  port_error_message_text_logged_by_admission: false,
+  raw_context_logged: false,
+  raw_region_uuid_logged: false,
+  raw_country_code_logged: false,
+  static_owner_messages: true,
+  closed_error_variant_logged: true,
+  aggregate_text_shape_logged: true,
+  aggregate_uuid_shape_logged: true,
+  opaque_payload_presence_logged: true,
+  bounded_context_shape_logged: true,
+  bounded_request_shape_logged: true,
+  runtime_evidence_claimed: false,
+})) {
+  if (evidence.source_contract[key] !== expected) {
+    failures.push(`${paths.evidence}: ${key} expected ${expected}`);
+  }
+}
+
+for (const [key, expected] of Object.entries({
+  both_read_operations_preserved: true,
+  owner_delegation_preserved: true,
+  public_error_kind_code_retryability_preserved: true,
+  dynamic_validation_payload_removed_from_public_message: true,
+  database_payload_removed_from_diagnostics: true,
+  admission_payload_removed_from_diagnostics: true,
+  context_payload_removed_from_diagnostics: true,
+  request_identity_payload_removed_from_diagnostics: true,
+  broad_ecommerce_cleanup_remains_open: true,
+  runtime_evidence_claimed: false,
+})) {
+  if (review.review_findings[key] !== expected) {
+    failures.push(`${paths.review}: ${key} expected ${expected}`);
+  }
+}
+
+for (const marker of [
+  'Status: **source-ready / unvalidated**',
+  '`RegionReadPort`',
+  '`region request is invalid`',
+  'bounded context',
+  'No tests, Node verifiers, Cargo commands, formatting, workflows, CI, or mounted runtime validation',
+]) requireText(document, marker, `${paths.document}: documentation contract`);
+
+for (const marker of [
+  'Owner read-port error safety: `source_closed_unvalidated`',
+  'verify-region-owner-port-error-safety.mjs',
+]) requireText(plan, marker, `${paths.plan}: plan registration`);
+
+if (failures.length > 0) {
+  console.error('region owner port error safety verification failed');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log('region owner port error safety verification passed');


### PR DESCRIPTION
## Summary

- continue the ecommerce correlation-safe mapper cleanup in `crates/rustok-region/src/ports.rs`
- preserve both `RegionReadPort` operations, read-policy admission, locale fallback, DTOs, and existing Region service delegation
- replace owner-supplied validation and country-code text in public `region.validation` envelopes with a static message
- replace raw database-error diagnostics with a closed owner-error variant and opaque-payload presence
- add bounded context, selector, locale, UUID, and message-shape diagnostics for admission, parser, request-validation, and owner failures
- preserve public codes, error kinds, retryability, and technical-versus-ordinary severity
- add focused source/review evidence, documentation, a fail-closed verifier, and register the source-only boundary in the Region implementation plan

## Recheck

The ecommerce source-of-truth plan still keeps the broad correlation-safe mapper cleanup open. Pricing owner/read/write diagnostics are already source-closed by the latest merged Pricing PRs. Region storefront native errors were hardened separately, but the owner `RegionReadPort` still returned dynamic owner validation text and logged complete `DbErr` payloads. This PR closes that Region owner slice only.

## Deliberate boundary

Region FFA remains `in_progress` and Region FBA remains `boundary_ready`. This PR does not change Region policy, persistence, GraphQL/native selection, Commerce topology, manifests, dependencies, workflows, CI configuration, or runtime-evidence status. The broader ecommerce cleanup remains open.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, CI, or mounted runtime validation was executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-region-owner-port-error-safety.mjs
cargo check -p rustok-region --lib
cargo check -p rustok-commerce --lib
```

Branch: `agent/region-owner-port-error-safety-20260801`
Base at source review: `1cc032d6ceba0e55b5f3a1dfa2a64b066dc73f71`
