### PR TITLE
fix(tax): bound policy admission diagnostics

### DIFF
--- a/crates/rustok-tax/contracts/evidence/tax-calculation-diagnostic-safety-source-review.json
+++ b/crates/rustok-tax/contracts/evidence/tax-calculation-diagnostic-safety-source-review.json
@@ -18,10 +18,16 @@
     "provider_selection_and_delegation_preserved": true,
     "result_validation_preserved": true,
     "all_public_port_errors_preserved": true,
+    "policy_admission_error_return_preserved": true,
     "wrapper_uses_stable_code_only": true,
     "wrapper_context_logs_safe_shape_only": true,
     "wrapper_request_logs_safe_shape_only": true,
     "owner_policy_logs_safe_shape_only": true,
+    "owner_policy_complete_port_error_removed": true,
+    "owner_policy_message_text_removed": true,
+    "owner_policy_debug_kind_removed": true,
+    "owner_policy_closed_kind_retained": true,
+    "owner_policy_message_shape_retained": true,
     "owner_validation_details_reduced_to_presence_and_length": true,
     "owner_result_details_reduced_to_presence_and_length": true,
     "raw_context_values_removed": true,
@@ -33,5 +39,5 @@
     "broad_cleanup_remains_open": true,
     "runtime_evidence_claimed": false
   },
-  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed."
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, workflows, CI, or mounted runtime validation were executed."
 }

--- a/crates/rustok-tax/contracts/evidence/tax-calculation-diagnostic-safety-source.json
+++ b/crates/rustok-tax/contracts/evidence/tax-calculation-diagnostic-safety-source.json
@@ -4,7 +4,10 @@
     "public_operation": "calculate_tax",
     "canonical_wrapper": "crates/rustok-tax/src/calculation_context.rs",
     "canonical_owner": "crates/rustok-tax/src/ports.rs",
-    "documentation": "crates/rustok-tax/docs/calculation-local-context.md",
+    "documentation": [
+      "crates/rustok-tax/docs/calculation-local-context.md",
+      "crates/rustok-tax/docs/calculation-port-policy-context.md"
+    ],
     "verifiers": [
       "scripts/verify/verify-tax-calculation-local-context.mjs",
       "scripts/verify/verify-tax-calculation-policy-context.mjs",
@@ -16,6 +19,12 @@
     "wrapper_safe_context_shape": true,
     "wrapper_safe_request_shape": true,
     "owner_safe_policy_context_shape": true,
+    "owner_policy_complete_port_error_logged": false,
+    "owner_policy_message_text_logged": false,
+    "owner_policy_debug_kind_logged": false,
+    "owner_policy_closed_kind_logged": true,
+    "owner_policy_message_shape_logged": true,
+    "owner_policy_error_return_changed": false,
     "owner_safe_validation_detail_shape": true,
     "owner_safe_result_detail_shape": true,
     "correlation_id_logged": true,

--- a/crates/rustok-tax/docs/calculation-port-policy-context.md
+++ b/crates/rustok-tax/docs/calculation-port-policy-context.md
@@ -8,7 +8,8 @@ The canonical `TaxCalculationPort::calculate_tax` implementation assigns the tru
 `calculate_tax` operation before applying `PortCallPolicy::read()`. Admission failures
 are inspected, diagnosed, and returned unchanged.
 
-This slice keeps that ordering while hardening the diagnostic payload.
+This slice keeps that ordering while closing the remaining policy-admission diagnostic
+payload gap.
 
 ## Safe policy diagnostics
 
@@ -18,15 +19,23 @@ Policy rejection events retain:
 - operation `calculate_tax`;
 - boundary `tax_calculation_port`;
 - correlation id;
-- stable error code, typed kind, and retryability;
+- stable error code, a closed typed-kind label, and retryability;
+- error-message presence and character length;
 - tenant and actor-id lengths;
 - actor kind, claim count, and role count;
 - channel, causation, traceparent, and idempotency presence plus lengths;
 - locale length and deadline.
 
-They do not record raw tenant, actor id, channel, locale, causation id, traceparent, or
-idempotency key values. The original typed `PortError` remains available as structured
-technical evidence and is returned unchanged.
+They do not record:
+
+- the complete `PortError` through Debug or Display formatting;
+- public/internal error-message text;
+- debug-formatted `PortErrorKind` output;
+- raw tenant, actor id, channel, locale, causation id, traceparent, or idempotency
+  key values.
+
+The original typed `PortError` is still returned to the caller unchanged. It is not
+copied into the diagnostic event.
 
 Unavailable, timeout, and invariant failures retain error severity. Ordinary policy or
 validation rejections retain warning severity.
@@ -47,10 +56,11 @@ The change does not alter:
 
 `scripts/verify/verify-tax-calculation-policy-context.mjs` requires operation assignment
 before policy admission, the unchanged read policy, safe context-shape diagnostics,
-original typed error fields, and unchanged public envelopes. It forbids raw context
-values.
+closed kind classification, message shape, and unchanged public envelopes. It forbids
+complete `PortError` formatting, raw message text, debug-kind formatting, and raw
+context values.
 
-The owner and wrapper result paths are guarded by:
+The owner and wrapper result paths remain guarded by:
 
 - `scripts/verify/verify-tax-calculation-error-context.mjs`;
 - `scripts/verify/verify-tax-calculation-local-context.mjs`.

--- a/crates/rustok-tax/docs/implementation-plan.md
+++ b/crates/rustok-tax/docs/implementation-plan.md
@@ -11,12 +11,14 @@ This module has no module-owned UI. `calculate_tax` is a read-like port with a
 required deadline and typed `PortError` mapping; it must not require write
 idempotency.
 
-The canonical root wrapper and the owner `TaxService` port implementation now retain
+The canonical root wrapper and the owner `TaxService` port implementation retain
 correlation plus safe context, request, and detail shape. Local attribution uses stable
-error codes only. Raw tenant, actor, channel, causation, provider, identifier,
-financial, and validation-detail values are not written by the hardened tax
-calculation diagnostics. Public error envelopes, provider behavior, and validation
-order remain unchanged.
+error codes only. Policy admission records a closed error-kind label, retryability, and
+message presence/length while returning the original `PortError` unchanged; it does
+not record the complete envelope, message text, or debug-kind output. Raw tenant,
+actor, channel, causation, provider, identifier, financial, and validation-detail
+values are not written by the hardened tax calculation diagnostics. Public error
+envelopes, provider behavior, and validation order remain unchanged.
 
 ## FFA/FBA boundary
 
@@ -36,7 +38,7 @@ order remain unchanged.
   port semantics, plan/registry evidence, and fallback metadata.
 - `scripts/verify/verify-tax-calculation-policy-context.mjs`,
   `scripts/verify/verify-tax-calculation-error-context.mjs`, and
-  `scripts/verify/verify-tax-calculation-local-context.mjs` lock safe owner policy,
+  `scripts/verify/verify-tax-calculation-local-context.mjs` lock bounded owner policy,
   owner mapper, and post-delegation context retention without promoting runtime
   evidence.
 
@@ -90,4 +92,5 @@ order remain unchanged.
 3. Update this status block and `docs/modules/registry.md` with an FBA boundary
    change.
 4. Keep diagnostics correlation-aware and shape-only; never route on public messages
-   or log raw tax identities, values, provider payloads, or internal validation text.
+   or log complete `PortError` envelopes, raw tax identities, values, provider payloads,
+   or internal validation text.

--- a/crates/rustok-tax/src/ports.rs
+++ b/crates/rustok-tax/src/ports.rs
@@ -109,6 +109,18 @@ fn tax_calculation_context_facts(context: &PortContext) -> TaxCalculationContext
     }
 }
 
+fn tax_port_error_kind(kind: &PortErrorKind) -> &'static str {
+    match kind {
+        PortErrorKind::Validation => "validation",
+        PortErrorKind::NotFound => "not_found",
+        PortErrorKind::Conflict => "conflict",
+        PortErrorKind::Forbidden => "forbidden",
+        PortErrorKind::Unavailable => "unavailable",
+        PortErrorKind::Timeout => "timeout",
+        PortErrorKind::InvariantViolation => "invariant_violation",
+    }
+}
+
 fn require_tax_calculation_policy(
     context: &PortContext,
     owner_operation: &'static str,
@@ -129,7 +141,6 @@ fn log_tax_calculation_policy_rejection(
     match &error.kind {
         PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation => {
             tracing::error!(
-                error = ?error,
                 owner = "rustok_tax",
                 correlation_id = %context.correlation_id,
                 tenant_id_length = facts.tenant_id_length,
@@ -149,15 +160,16 @@ fn log_tax_calculation_policy_rejection(
                 deadline_ms = ?facts.deadline_ms,
                 operation = owner_operation,
                 code = %error.code,
-                error_kind = ?error.kind,
+                error_kind = tax_port_error_kind(&error.kind),
+                error_message_present = !error.message.is_empty(),
+                error_message_length = error.message.chars().count(),
                 retryable = error.retryable,
                 boundary = TAX_CALCULATION_PORT_BOUNDARY,
-                "tax calculation policy admission failed"
+                "tax calculation policy admission failed with bounded diagnostics"
             );
         }
         _ => {
             tracing::warn!(
-                error = ?error,
                 owner = "rustok_tax",
                 correlation_id = %context.correlation_id,
                 tenant_id_length = facts.tenant_id_length,
@@ -177,10 +189,12 @@ fn log_tax_calculation_policy_rejection(
                 deadline_ms = ?facts.deadline_ms,
                 operation = owner_operation,
                 code = %error.code,
-                error_kind = ?error.kind,
+                error_kind = tax_port_error_kind(&error.kind),
+                error_message_present = !error.message.is_empty(),
+                error_message_length = error.message.chars().count(),
                 retryable = error.retryable,
                 boundary = TAX_CALCULATION_PORT_BOUNDARY,
-                "tax calculation policy admission was rejected"
+                "tax calculation policy admission was rejected with bounded diagnostics"
             );
         }
     }

--- a/scripts/verify/verify-tax-calculation-policy-context.mjs
+++ b/scripts/verify/verify-tax-calculation-policy-context.mjs
@@ -36,9 +36,20 @@ for (const [value, label] of [
   ],
   [
     'log_tax_calculation_policy_rejection(context, owner_operation, error);',
-    'rejection diagnostics before rethrow',
+    'rejection diagnostics before unchanged return',
   ],
   ['fn tax_calculation_context_facts(', 'safe context fact helper'],
+  ['fn tax_port_error_kind(', 'closed port error kind helper'],
+  ['PortErrorKind::Validation => "validation"', 'validation kind label'],
+  ['PortErrorKind::NotFound => "not_found"', 'not-found kind label'],
+  ['PortErrorKind::Conflict => "conflict"', 'conflict kind label'],
+  ['PortErrorKind::Forbidden => "forbidden"', 'forbidden kind label'],
+  ['PortErrorKind::Unavailable => "unavailable"', 'unavailable kind label'],
+  ['PortErrorKind::Timeout => "timeout"', 'timeout kind label'],
+  [
+    'PortErrorKind::InvariantViolation => "invariant_violation"',
+    'invariant kind label',
+  ],
   ['fn log_tax_calculation_policy_rejection(', 'structured diagnostic helper'],
   ['owner = "rustok_tax"', 'truthful tax owner'],
   ['correlation_id = %context.correlation_id', 'correlation context'],
@@ -58,14 +69,28 @@ for (const [value, label] of [
   ['idempotency_key_length = ?facts.idempotency_key_length', 'idempotency length'],
   ['deadline_ms = ?facts.deadline_ms', 'deadline context'],
   ['operation = owner_operation', 'exact owner operation'],
-  ['code = %error.code', 'original port code'],
-  ['error_kind = ?error.kind', 'original port kind'],
+  ['code = %error.code', 'stable port code'],
+  [
+    'error_kind = tax_port_error_kind(&error.kind)',
+    'closed port error kind label',
+  ],
+  [
+    'error_message_present = !error.message.is_empty()',
+    'port error message presence',
+  ],
+  [
+    'error_message_length = error.message.chars().count()',
+    'port error message length',
+  ],
   ['retryable = error.retryable', 'original retryability'],
   ['boundary = TAX_CALCULATION_PORT_BOUNDARY', 'boundary identity'],
-  ['"tax calculation policy admission failed"', 'error diagnostic event'],
   [
-    '"tax calculation policy admission was rejected"',
-    'warning diagnostic event',
+    '"tax calculation policy admission failed with bounded diagnostics"',
+    'technical diagnostic event',
+  ],
+  [
+    '"tax calculation policy admission was rejected with bounded diagnostics"',
+    'ordinary diagnostic event',
   ],
   [
     'PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation',
@@ -101,6 +126,11 @@ for (const [value, label] of [
 }
 
 for (const [value, label] of [
+  ['error = ?error', 'complete PortError debug payload'],
+  ['error = %error', 'complete PortError display payload'],
+  ['error_kind = ?error.kind', 'debug-formatted PortError kind'],
+  ['error_message = %error.message', 'raw PortError message'],
+  ['message = %error.message', 'raw PortError message alias'],
   ['tenant_id = %context.tenant_id', 'raw tenant context'],
   ['actor = ?context.actor', 'raw actor context'],
   ['channel = ?context.channel', 'raw channel context'],
@@ -124,5 +154,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Tax calculation policy rejections retain correlation plus safe context shape and the original PortError',
+  '✔ Tax calculation policy rejections retain correlation and bounded PortError shape without logging the complete envelope',
 );


### PR DESCRIPTION
## Summary

- continue the ecommerce correlation-safe mapper cleanup in `crates/rustok-tax/src/ports.rs`
- preserve `TaxCalculationPort::calculate_tax`, read/deadline admission, request/result validation order, provider delegation, DTOs, and every returned `PortError`
- stop recording the complete policy-admission `PortError` through Debug formatting
- replace debug-formatted `PortErrorKind` with a closed seven-value label
- retain stable code, retryability, message presence/length, correlation, and bounded context shape
- keep technical admission failures at error severity and ordinary rejections at warning severity
- harden the focused verifier so complete envelopes, raw message text, debug-kind output, and raw context values fail closed
- correct the Tax policy document, implementation plan, and retained source/review evidence

## Recheck

The ecommerce source-of-truth plan still keeps Tax inside the broad correlation-safe mapper cleanup. Tax request, result, and owner-validation diagnostics were already shape-only, but policy admission still emitted `error = ?error` and `error_kind = ?error.kind`. Existing Tax evidence incorrectly described that surface as safe. This PR closes that policy-admission slice and corrects the retained claims.

## Deliberate boundary

Tax FFA remains `not_started` and Tax FBA remains `boundary_ready`. No tax policy, calculation, provider selection, persistence, cart/order integration, manifests, dependencies, workflows, CI configuration, or runtime-evidence status changes. The broader ecommerce cleanup remains open.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, CI, or mounted runtime validation was executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-tax-calculation-policy-context.mjs
node scripts/verify/verify-tax-calculation-error-context.mjs
node scripts/verify/verify-tax-calculation-local-context.mjs
cargo check -p rustok-tax --lib
cargo check -p rustok-cart --lib
```

Branch: `agent/tax-policy-admission-diagnostic-safety-20260801`
Base at source review: `e2c69b022b5380ba27eb3583688d154cb7a20d39`
