### PR TITLE
fix(inventory): bound reservation owner diagnostics

### DIFF
--- a/crates/rustok-inventory/contracts/evidence/inventory-reservation-owner-diagnostic-safety-source-review.json
+++ b/crates/rustok-inventory/contracts/evidence/inventory-reservation-owner-diagnostic-safety-source-review.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 1,
+  "status": "inventory_reservation_owner_diagnostic_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-inventory/src/reservation_owner_context.rs",
+    "crates/rustok-inventory/src/ports.rs",
+    "crates/rustok-inventory/src/lib.rs",
+    "scripts/verify/verify-inventory-reservation-owner-context.mjs",
+    "scripts/verify/verify-inventory-reservation-local-context.mjs",
+    "crates/rustok-inventory/contracts/evidence/inventory-reservation-owner-diagnostic-safety-source.json",
+    "crates/rustok-inventory/docs/reservation-owner-context.md",
+    "crates/rustok-inventory/docs/reservation-local-context.md",
+    "crates/rustok-inventory/docs/implementation-plan.md"
+  ],
+  "review_findings": {
+    "public_facade_preserved": true,
+    "both_operations_preserved": true,
+    "admission_order_preserved": true,
+    "persistent_owner_rechecks_preserved": true,
+    "exact_local_classification_preserved": true,
+    "unknown_error_pass_through_preserved": true,
+    "complete_admission_error_removed": true,
+    "complete_local_error_removed": true,
+    "raw_admission_context_removed": true,
+    "raw_request_identifiers_removed": true,
+    "exact_quantity_removed": true,
+    "tenant_parse_cause_removed": true,
+    "bounded_admission_context_retained": true,
+    "bounded_tenant_context_retained": true,
+    "bounded_request_shape_retained": true,
+    "same_admission_error_returned": true,
+    "same_tenant_error_returned": true,
+    "same_delegated_error_returned": true,
+    "persistent_owner_behavior_preserved": true,
+    "inventory_status_not_promoted": true,
+    "broad_ecommerce_cleanup_remains_open": true,
+    "runtime_evidence_claimed": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, workflows, CI, or mounted runtime validation were executed."
+}

--- a/crates/rustok-inventory/contracts/evidence/inventory-reservation-owner-diagnostic-safety-source.json
+++ b/crates/rustok-inventory/contracts/evidence/inventory-reservation-owner-diagnostic-safety-source.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": 1,
+  "status": "inventory_reservation_owner_diagnostic_safety_source_unvalidated",
+  "scope": {
+    "owner_wrapper": "crates/rustok-inventory/src/reservation_owner_context.rs",
+    "persistent_owner": "crates/rustok-inventory/src/ports.rs",
+    "owner_verifier": "scripts/verify/verify-inventory-reservation-owner-context.mjs",
+    "local_verifier": "scripts/verify/verify-inventory-reservation-local-context.mjs",
+    "owner_documentation": "crates/rustok-inventory/docs/reservation-owner-context.md",
+    "local_documentation": "crates/rustok-inventory/docs/reservation-local-context.md"
+  },
+  "source_contract": {
+    "admission_diagnostic_cleanup_closed": true,
+    "tenant_parser_diagnostic_cleanup_closed": true,
+    "local_outcome_diagnostic_cleanup_closed": true,
+    "complete_port_error_logged": false,
+    "raw_context_logged": false,
+    "uuid_parse_cause_logged": false,
+    "raw_request_uuid_logged": false,
+    "exact_request_quantity_logged": false,
+    "raw_external_id_logged": false,
+    "bounded_context_shape_logged": true,
+    "bounded_request_shape_logged": true,
+    "stable_code_logged": true,
+    "error_message_shape_logged": true,
+    "closed_error_kind_logged": true,
+    "admission_error_return_changed": false,
+    "tenant_error_return_changed": false,
+    "delegated_error_return_changed": false,
+    "exact_code_message_classification_changed": false,
+    "public_contract_changed": false,
+    "owner_delegation_changed": false,
+    "sql_or_state_machine_changed": false,
+    "inventory_ffa_fba_status_promoted": false,
+    "broad_ecommerce_cleanup_closed": false
+  },
+  "validation": {
+    "tests_run": false,
+    "verifiers_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "mounted_runtime_proven": false
+  },
+  "execution": []
+}

--- a/crates/rustok-inventory/docs/implementation-plan.md
+++ b/crates/rustok-inventory/docs/implementation-plan.md
@@ -30,6 +30,17 @@ presence/length shape facts. This source contract is guarded by
 `scripts/verify/verify-inventory-admin-client-transport-error-safety.mjs` and
 remains unvalidated.
 
+The canonical durable reservation wrapper now retains correlation, closed
+operation labels, bounded context shape, bounded reservation/request shape,
+stable code, retryability, closed error-kind labels, and error-message
+presence/length. It no longer records complete `PortError` values, raw context,
+raw UUIDs, exact quantities, raw external IDs, or tenant UUID parse causes.
+Admission, tenant-validation, and exact stable local-outcome mappings return the
+same errors unchanged. This source contract is guarded by
+`scripts/verify/verify-inventory-reservation-owner-context.mjs` and
+`scripts/verify/verify-inventory-reservation-local-context.mjs`; execution
+evidence remains open.
+
 `BootstrapService` owns default-location creation, initial item/level creation,
 variant-record cleanup, and batched available-quantity reads when product
 creates or deletes variants. This is a native transaction-sharing bootstrap
@@ -43,12 +54,17 @@ and reservation contracts remain inventory-owned.
 - Structural shape: `core_transport_ui`
 - Admin native error safety: `source_ready_unvalidated`
 - Admin client transport error safety: `source_ready_unvalidated`
+- Durable reservation owner diagnostic safety: `source_ready_unvalidated`
 - FBA provider contract: `InventoryReservationPort` /
   `inventory.reservation.v1` in
   `crates/rustok-inventory/contracts/inventory-fba-registry.json`.
 - Static and no-compile runtime evidence:
   `crates/rustok-inventory/contracts/evidence/inventory-contract-test-static-matrix.json`
   and `crates/rustok-inventory/contracts/evidence/inventory-runtime-contract-smoke.json`.
+- Durable reservation diagnostic evidence:
+  `crates/rustok-inventory/contracts/evidence/inventory-reservation-owner-diagnostic-safety-source.json`
+  and
+  `crates/rustok-inventory/contracts/evidence/inventory-reservation-owner-diagnostic-safety-source-review.json`.
 - `scripts/verify/verify-inventory-admin-boundary.mjs` locks the native
   core/transport/UI split and absence of pre-FFA/GraphQL admin paths.
 - `scripts/verify/verify-inventory-admin-native-error-safety.mjs` locks mounted
@@ -58,6 +74,10 @@ and reservation contracts remain inventory-owned.
   the final facade mapping, per-operation correlation context, safe request-shape
   diagnostics, and static `InventoryTransportError` text without claiming a
   runtime pass.
+- `scripts/verify/verify-inventory-reservation-owner-context.mjs` and
+  `scripts/verify/verify-inventory-reservation-local-context.mjs` lock bounded
+  durable reservation admission, tenant-validation, request-shape, and local
+  outcome diagnostics while preserving the exact owner calls and error returns.
 
 ## Open results
 
@@ -76,24 +96,29 @@ and reservation contracts remain inventory-owned.
    **Done when:** integration tests prove that cart, checkout, and storefront
    read models cannot diverge from `InventoryService` policy.
 
-3. **Run the verification/CI evidence slice for `InventoryReservationPort` and
-   admin native/client error safety.** Execute the remote-adapter contract and
-   fallback profiles before a `boundary_ready` promotion; retain native-only
-   admin transport unless a public parity contract is introduced. Execute both
-   focused admin error-safety guards, compile the default/hydrate/SSR package,
-   and retain mounted browser plus server-function failure evidence before
-   promoting either source-only status.
+3. **Run the verification/CI evidence slice for `InventoryReservationPort`,
+   durable reservation owner diagnostics, and admin native/client error
+   safety.** Execute the remote-adapter contract and fallback profiles before a
+   `boundary_ready` promotion; retain native-only admin transport unless a
+   public parity contract is introduced. Execute the focused error-safety
+   guards, compile the default/hydrate/SSR package, and retain mounted browser
+   plus server-function failure evidence before promoting any source-only
+   status.
    **Depends on:** a runtime-composed commerce consumer and remote adapter
    environment.
    **Done when:** deadline, idempotency, typed-error, degraded-mode, owner
-   invocation, client-facade sanitization, and mounted public-envelope evidence
-   covers every published port operation and native admin endpoint.
+   invocation, durable reservation diagnostic sanitization, client-facade
+   sanitization, and mounted public-envelope evidence covers every published
+   port operation and native admin endpoint.
 
 ## Verification
 
 - `npm run verify:inventory:admin-boundary`
 - `node scripts/verify/verify-inventory-admin-native-error-safety.mjs`
 - `node scripts/verify/verify-inventory-admin-client-transport-error-safety.mjs`
+- `node scripts/verify/verify-inventory-reservation-owner-context.mjs`
+- `node scripts/verify/verify-inventory-reservation-local-context.mjs`
+- `node scripts/verify/verify-inventory-port-diagnostic-safety.mjs`
 - `npm run verify:ecommerce:fba`
 - `cargo xtask module validate inventory`
 - `cargo xtask module test inventory`
@@ -107,3 +132,6 @@ and reservation contracts remain inventory-owned.
    with any inventory/checkout/channel contract change.
 3. Update this status block and `docs/modules/registry.md` with an FFA/FBA
    boundary change.
+4. Keep durable reservation diagnostics correlation-aware and shape-only; do
+   not log complete port errors, raw context, reservation identities, external
+   identities, exact quantities, or parser causes.

--- a/crates/rustok-inventory/docs/reservation-local-context.md
+++ b/crates/rustok-inventory/docs/reservation-local-context.md
@@ -1,171 +1,76 @@
-# Inventory durable reservation local outcome context
+# Inventory durable reservation local diagnostic safety
 
 Status: **source-ready / unvalidated**
 
 ## Scope
 
-This slice extends the canonical `PersistentInventoryReservationIdentityPort` wrapper with
-post-delegation local outcome diagnostics for:
+The canonical durable reservation wrapper classifies covered owner failures
+using exact stable `code + message` pairs and returns the same delegated
+`PortError` unchanged.
 
-- `InventoryReservationIdentityPort::reserve_inventory_by_identity`;
-- `InventoryReservationIdentityPort::release_inventory_by_identity`.
+The covered operations remain reserve and release by durable reservation
+identity. Unknown owner envelopes pass through without an additional local
+event.
 
-Admission and tenant-validation diagnostics remain owned by the preceding durable reservation context
-slice. This work covers stable errors returned after the unchanged persistent owner accepts the
-original delegated context and request.
+## Bounded request shape
 
-## Delegation order
+Reserve diagnostics retain only:
 
-Both operations now follow the same source order:
+- reservation-ID presence and non-nil status;
+- variant-ID presence and non-nil status;
+- quantity presence, non-zero status, and negative status;
+- line-item-ID presence and non-nil status;
+- external-ID character length.
 
-1. require write policy;
-2. require write semantics;
-3. parse the trimmed tenant UUID;
-4. retain the accepted `PortContext` and safe request facts;
-5. delegate the original context and request to the unchanged persistent owner;
-6. inspect only a returned `PortError`;
-7. emit a local diagnostic when its exact stable code and message identify a covered outcome;
-8. return the same `PortError` unchanged.
+Release diagnostics retain reservation-ID shape and external-ID length while
+marking variant, quantity, and line-item facts absent.
 
-Successful reserve, replay-adoption, already-released, and release snapshots do not emit a local
-failure event.
+Raw UUIDs, exact quantity, and external-ID text are not recorded.
 
-## Retained request facts
+## Local classification
 
-Reserve diagnostics retain:
+The existing exact classifications remain unchanged for external-ID and
+quantity validation, variant/state lookup, replay identity conflicts,
+insufficient inventory, release lookup, missing inventory item, locked identity
+revalidation, ledger consistency, available-quantity overflow, and storage
+unavailability.
 
-- reservation id;
-- variant id;
-- requested quantity;
-- optional line-item id;
-- external-id character length.
+Technical unavailable, timeout, and invariant outcomes retain error severity.
+Ordinary validation, not-found, and conflict outcomes retain warning severity.
 
-Release diagnostics retain:
+## Bounded delegated error shape
 
-- reservation id;
-- external-id character length.
+Covered events retain stable code, retryability, a closed error-kind label, and
+error-message presence/length. The complete delegated `PortError` is not logged,
+raw message text is not copied into the event, and debug-formatted kind output is
+not retained.
 
-The caller-provided external-id text is deliberately not recorded. Validation can receive an empty or
-oversized value before the persistent owner normalizes it, so logging only its character length retains
-useful request evidence without publishing the raw identity string.
-
-## Covered stable outcomes
-
-The mapper requires exact `code + message` pairs. Code-only matching is intentionally forbidden.
-
-| Public operation | Stable envelope | Local operation | Severity |
-| --- | --- | --- | --- |
-| both | `inventory.reservation_external_id_invalid` / `reservation external_id must contain 1 to 191 characters` | `normalize_external_id` | warning |
-| reserve | `inventory.reservation_quantity_invalid` / `reservation quantity must be positive` | `validate_reservation_quantity` | warning |
-| both | `inventory.variant_not_found` / `inventory variant was not found` | `load_variant` | warning |
-| reserve | `inventory.state_not_found` / `variant has no configured inventory state` | `load_inventory_state` | warning |
-| reserve | `inventory.reservation_identity_conflict` / `reservation identity is already bound to different reservation data` | `validate_existing_reservation_identity` | warning |
-| reserve | `inventory.insufficient_inventory` / `insufficient inventory for reservation` | `reserve_available_stock` | warning |
-| release | `inventory.reservation_not_found` / `inventory reservation was not found` | `load_reservation` | warning |
-| release | `inventory.reservation_identity_conflict` / `reservation id is bound to another external identity` | `validate_release_external_identity` | warning |
-| release | `inventory.reservation_item_missing` / `reservation inventory item is missing` | `load_reservation_inventory_item` | error |
-| release | `inventory.reservation_identity_conflict` / `reservation identity changed while acquiring the owner lock` | `revalidate_release_identity` | warning |
-| release | `inventory.reservation_ledger_inconsistent` / `inventory reservation ledger is inconsistent` | `release_reserved_quantity` | error |
-| both | `inventory.available_quantity_overflow` / `inventory available quantity is outside the supported range` | `calculate_available_quantity` | error |
-| both | `inventory.database_unavailable` / `inventory storage is temporarily unavailable` | `owner_storage` | error |
-
-Unavailable, timeout, and invariant kinds use error severity. Validation, not-found, conflict, and other
-ordinary caller or state rejection use warning severity.
-
-## Retained diagnostic context
-
-Covered outcomes record:
-
-- truthful owner `rustok_inventory`;
-- exact public operation and local operation;
-- boundary `inventory_reservation_identity_port`;
-- correlation id and tenant id;
-- typed actor, channel, and locale;
-- causation id and traceparent when available;
-- idempotency key and deadline when available;
-- the safe request facts described above;
-- stable code and message;
-- typed error kind and retryability;
-- the complete delegated `PortError` value.
-
-## Pass-through behavior
-
-The local mapper does not handle:
-
-- write-policy rejection;
-- missing write semantics;
-- malformed tenant context;
-- any unrecognized owner code or message;
-- successful initial reserve;
-- successful reserve replay adoption by reservation id or external id;
-- successful insert-race adoption;
-- successful first release;
-- successful already-released replay.
-
-Admission and tenant validation continue to be recorded before delegation by the existing wrapper
-helpers. Unknown owner envelopes pass through without another event.
+The same delegated error is returned unchanged.
 
 ## Preserved owner behavior
 
-This work does not change:
+The persistent implementation in `ports.rs` is unchanged, including:
 
-- request or response DTOs;
-- public codes, messages, kinds, or retryability;
-- external-id trimming and length limits;
+- external-ID normalization;
 - positive quantity validation;
-- tenant-scoped variant loading;
-- inventory-state and row-lock behavior;
-- active-location selection and backorder policy;
-- reservation id and external-id replay adoption;
-- insert-race rollback and adoption;
-- metadata construction;
-- exact release identity checks;
-- already-released idempotency;
-- reservation ledger mutation and consistency checks;
+- reservation and external-ID replay adoption;
+- row locking and transaction ordering;
+- stock and backorder policy;
+- release identity checks and idempotency;
+- reservation-ledger mutation;
 - available-quantity calculation;
-- database mapping;
-- factory names or checkout composition.
+- storage mapping.
 
-The persistent owner implementation in `ports.rs` remains unchanged.
+## Evidence
 
-## Static evidence
+- `crates/rustok-inventory/contracts/evidence/inventory-reservation-owner-diagnostic-safety-source.json`
+- `crates/rustok-inventory/contracts/evidence/inventory-reservation-owner-diagnostic-safety-source-review.json`
+- `scripts/verify/verify-inventory-reservation-local-context.mjs`
+- `scripts/verify/verify-inventory-reservation-owner-context.mjs`
 
-`scripts/verify/verify-inventory-reservation-local-context.mjs` guards:
+No tests, verifiers, formatting, Cargo commands, workflows, CI, or mounted
+runtime validation were run.
 
-- admission → tenant validation → context retention → owner delegation → local mapping ordering;
-- retained safe request facts for reserve and release;
-- unchanged delegated method calls;
-- exact stable code-and-message classification;
-- operation-specific reserve and release local labels;
-- technical versus ordinary severity;
-- complete context and error fields;
-- absence of raw external-id diagnostics;
-- same delegated `PortError` return;
-- pass-through of unknown, admission, and context errors;
-- unchanged persistent owner validation, lookup, replay, stock, not-found, storage, and invariant branches.
-
-## Remaining gaps
-
-The ecommerce correlation-safe mapper task remains open for:
-
-- direct callers that bypass the canonical inventory factories where a bypass remains possible;
-- remaining payment execution and compensation consumers;
-- GraphQL customer reads and shared storefront customer lookup;
-- remaining customer, tax, promotion, ecommerce, and non-`PortError` envelopes;
-- compile, runtime, replay, restart, remote-port, and cross-transport evidence.
-
-No FBA or FFA status is promoted from source inspection alone.
-
-## Suggested maintainer checks
-
-These commands were intentionally not run by the implementation agent:
-
-```bash
-node scripts/verify/verify-inventory-reservation-local-context.mjs
-node scripts/verify/verify-inventory-reservation-owner-context.mjs
-node scripts/verify/verify-inventory-availability-quantity-local-context.mjs
-node scripts/verify/verify-commerce-checkout-inventory-boundary-context.mjs
-node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
-cargo check -p rustok-inventory --lib
-cargo check -p rustok-commerce --lib
-```
+The ecommerce correlation-safe mapper task remains open for the remaining
+payment, fulfillment, customer, promotion, ecommerce adapter, and non-`PortError`
+surfaces.

--- a/crates/rustok-inventory/docs/reservation-owner-context.md
+++ b/crates/rustok-inventory/docs/reservation-owner-context.md
@@ -1,187 +1,112 @@
-# Inventory reservation owner context
+# Inventory reservation owner diagnostic safety
 
 Status: **source-ready / unvalidated**
 
 ## Scope
 
-This work closes write-admission, tenant-context, and stable local-outcome diagnostic gaps at the
-durable inventory reservation owner boundary.
+This slice closes the remaining payload-diagnostic gaps in the canonical durable
+inventory reservation wrapper:
 
-The covered public operations are:
+- write-policy admission;
+- write-semantics admission;
+- tenant UUID validation;
+- stable post-delegation local outcomes.
+
+The covered public operations remain:
 
 - `InventoryReservationIdentityPort::reserve_inventory_by_identity`;
 - `InventoryReservationIdentityPort::release_inventory_by_identity`.
 
-These operations are used by the durable checkout inventory reservation and compensation paths.
-Deprecated quantity-only reserve/release and availability diagnostics are documented in their separate
-availability/quantity context notes.
+The public facade, factory names, request/response DTOs, operation ordering,
+persistent-owner delegation, and returned `PortError` values are unchanged.
 
-## Public API compatibility
+## Preserved ordering
 
-The crate-root API retains the existing names:
+Both operations still perform:
 
-- `InventoryReservationIdentityPort`;
-- `InventoryIdentityReservationRequest`;
-- `InventoryIdentityReservationReleaseRequest`;
-- `InventoryIdentityReservationSnapshot`;
-- `InventoryIdentityReservationReleaseSnapshot`;
-- `PersistentInventoryReservationIdentityPort`;
-- `PersistentInventoryReservationIdentityPort::new`;
-- `in_process_inventory_reservation_identity_port`.
+1. write-policy admission;
+2. write-semantics admission;
+3. trimmed tenant UUID validation;
+4. safe diagnostic-fact capture;
+5. delegation of the original context and request;
+6. exact stable local-outcome classification;
+7. return of the same delegated error.
 
-The public `rustok_inventory::ports` module path also retains the same contracts, struct, and factory.
+The persistent owner in `ports.rs` still repeats its existing admission and
+tenant checks before storage work.
 
-The original `ports.rs` source is compiled as the private `ports_impl` module. A public compatibility
-facade selectively re-exports all existing inventory port contracts while exporting the durable
-reservation wrapper under the original struct and factory names. External callers therefore cannot
-construct or select the direct durable reservation implementation through either the crate root or
-the public `ports` path.
+## Bounded context shape
 
-## Ordering
+Admission, tenant-validation, and covered local-outcome events retain:
 
-Each durable reservation write now flows through these layers:
+- truthful owner and exact public operation;
+- admission, validation, or local-operation label;
+- correlation ID and stable boundary;
+- tenant and actor-ID character lengths;
+- closed actor-kind label;
+- claim and role counts;
+- channel, causation, traceparent, and idempotency presence plus lengths;
+- locale length and deadline;
+- stable error code, retryability, closed error-kind label, and error-message
+  presence/length.
 
-1. require write policy;
-2. require write semantics;
-3. parse the trimmed tenant UUID;
-4. retain the accepted diagnostic context and safe request facts;
-5. delegate the original `PortContext` and request to the unchanged persistent owner;
-6. allow the persistent owner to repeat its existing admission and tenant checks before storage work;
-7. classify only covered stable local errors and return the same `PortError` unchanged.
+They do not record raw tenant, actor, channel, locale, causation, traceparent,
+or idempotency values. The complete `PortError` is not written through Debug or
+Display formatting, and raw error-message text is not copied into events.
 
-The repeated checks are deterministic. The wrapper uses the same `PortCallPolicy::write()` contract,
-the same write-semantics requirements, and the same trimmed tenant UUID parsing rule as the existing
-owner implementation.
+Unavailable, timeout, and invariant outcomes retain error severity. Ordinary
+validation, not-found, conflict, forbidden, and policy rejections retain warning
+severity.
 
-No actor validation was added because the persistent durable reservation owner did not reject malformed
-actor identity. Adding that check would change request acceptance rather than retain diagnostics.
+## Tenant validation
 
-## Admission diagnostics
+Tenant parsing still trims the delegated tenant string and returns:
 
-Write-policy and write-semantics failures record:
+- code `inventory.context_invalid`;
+- message `inventory request context is invalid`;
+- validation kind and unchanged retryability.
 
-- truthful owner `rustok_inventory`;
-- exact operation;
-- admission phase `policy` or `write_semantics`;
-- boundary `inventory_reservation_identity_port`;
-- correlation id and tenant id;
-- typed actor, channel, and locale;
-- causation id and traceparent when available;
-- idempotency key and deadline when available;
-- stable code and message;
-- typed error kind and retryability;
-- the original `PortError`.
+The UUID parse cause is not recorded. The event retains only
+`tenant_id_parse_failed = true`, bounded context shape, and bounded error shape.
 
-Unavailable, timeout, and invariant admission failures use error severity. Ordinary validation,
-forbidden, conflict, and other caller rejection use warning severity.
+The exact admission and tenant-validation errors are returned unchanged.
 
-The wrapper returns the exact admission `PortError` unchanged.
-
-## Tenant-context validation
-
-The wrapper preserves the existing validation contract:
-
-- trim the delegated tenant string;
-- parse it as a UUID;
-- return code `inventory.context_invalid`;
-- return message `inventory request context is invalid`.
-
-For a parse failure, the structured warning retains the UUID parse cause together with the complete
-delegated `PortContext`, truthful owner, exact operation, validation phase `tenant_id`, stable public
-envelope, and boundary.
-
-The same constructed validation `PortError` is returned unchanged.
-
-## Local owner outcomes
-
-After successful admission and tenant validation, the wrapper retains the accepted context and safe
-request facts across the unchanged persistent owner delegation. Exact stable request-validation,
-variant/state lookup, replay identity, stock, reservation not-found, storage, and invariant envelopes
-now receive operation-specific local diagnostics while returning the same delegated `PortError`.
-
-The wrapper records only the character length of caller-provided `external_id`; it does not publish the
-raw identity string. The complete classification and pass-through contract is documented in
-[`reservation-local-context.md`](./reservation-local-context.md).
-
-## Preserved durable reservation behavior
+## Preserved behavior
 
 This work does not change:
 
-- reservation request or snapshot DTOs;
-- reservation and external identity semantics;
-- external-id trimming or length bounds;
+- reservation/external identity semantics;
+- external-ID normalization or limits;
 - positive quantity validation;
 - tenant-scoped variant loading;
-- inventory-item locking;
-- active-location selection;
-- backorder policy;
-- atomic reserved-quantity updates;
-- replay adoption by reservation id or external id;
-- conflicting replay classification;
-- reservation metadata;
-- insert-race adoption;
-- exact release identity checks;
-- already-released idempotency;
-- reservation ledger consistency checks;
-- available-quantity overflow classification;
+- row locking, transactions, replay adoption, or insert-race handling;
+- location selection or backorder policy;
+- metadata or release state transitions;
 - storage mappings;
 - public codes, messages, kinds, or retryability.
 
-The original persistent owner receives the original `PortContext` and request after wrapper acceptance.
+No FBA or FFA status is promoted from source inspection.
 
-## Static evidence
+## Evidence
 
-`scripts/verify/verify-inventory-reservation-owner-context.mjs` guards:
+- `crates/rustok-inventory/contracts/evidence/inventory-reservation-owner-diagnostic-safety-source.json`
+- `crates/rustok-inventory/contracts/evidence/inventory-reservation-owner-diagnostic-safety-source-review.json`
+- `scripts/verify/verify-inventory-reservation-owner-context.mjs`
+- `scripts/verify/verify-inventory-reservation-local-context.mjs`
 
-- private persistent implementation and public compatibility facade;
-- preserved crate-root and module-path contracts;
-- wrapper constructor and factory cutover;
-- exact reserve and release operations;
-- admission → tenant validation → owner delegation ordering;
-- write-policy and write-semantics interception;
-- full admission context and severity policy;
-- same admission error return;
-- trimmed tenant parsing and retained parse cause;
-- stable tenant validation envelope;
-- full tenant-validation context and same error return;
-- preserved persistent external-id, quantity, identity-conflict, and ledger-invariant behavior.
+## Validation status
 
-`scripts/verify/verify-inventory-reservation-local-context.mjs` separately guards:
+Tests, Node verifiers, Cargo commands, formatting, workflows, CI, and mounted
+runtime validation were intentionally not run.
 
-- accepted context and safe request-fact retention;
-- post-delegation exact stable local-outcome classification;
-- reserve/release operation-specific labels;
-- complete diagnostic fields without raw external-id text;
-- unknown-error pass-through;
-- same delegated error return;
-- unchanged persistent validation, lookup, replay, stock, storage, and invariant branches.
-
-The existing checkout inventory boundary verifier remains applicable because commerce continues to
-call the same root factory and owner trait. The wrapper adds owner-side diagnostics without changing
-the persistent owner call.
-
-## Remaining gaps
-
-The ecommerce correlation-safe mapper task remains open for:
-
-- direct callers that bypass canonical inventory factories where a bypass remains possible;
-- remaining payment execution and compensation consumers;
-- GraphQL query customer reads and the shared storefront customer lookup;
-- remaining customer, tax, promotion, ecommerce, and non-`PortError` envelopes;
-- compile, runtime, replay, restart, remote-port, and cross-transport evidence.
-
-No FBA or FFA status is promoted from source inspection alone.
-
-## Suggested maintainer checks
-
-These commands were intentionally not run by the implementation agent:
+Suggested maintainer checks:
 
 ```bash
-node scripts/verify/verify-inventory-reservation-local-context.mjs
 node scripts/verify/verify-inventory-reservation-owner-context.mjs
-node scripts/verify/verify-inventory-availability-quantity-local-context.mjs
-node scripts/verify/verify-commerce-checkout-inventory-boundary-context.mjs
-node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+node scripts/verify/verify-inventory-reservation-local-context.mjs
+node scripts/verify/verify-inventory-port-diagnostic-safety.mjs
 cargo check -p rustok-inventory --lib
 cargo check -p rustok-commerce --lib
 ```
+
+The broader ecommerce correlation-safe mapper cleanup remains open.

--- a/crates/rustok-inventory/src/reservation_owner_context.rs
+++ b/crates/rustok-inventory/src/reservation_owner_context.rs
@@ -16,12 +16,67 @@ const INVENTORY_RESERVATION_BOUNDARY: &str = "inventory_reservation_identity_por
 const RESERVE_OPERATION: &str = "reserve_inventory_by_identity";
 const RELEASE_OPERATION: &str = "release_inventory_by_identity";
 
+struct InventoryReservationContextFacts {
+    tenant_id_length: usize,
+    actor_kind: &'static str,
+    actor_id_length: usize,
+    claim_count: usize,
+    role_count: usize,
+    channel_present: bool,
+    channel_length: Option<usize>,
+    locale_length: usize,
+    causation_id_present: bool,
+    causation_id_length: Option<usize>,
+    traceparent_present: bool,
+    traceparent_length: Option<usize>,
+    idempotency_key_present: bool,
+    idempotency_key_length: Option<usize>,
+    deadline_ms: Option<u64>,
+}
+
 struct InventoryReservationIdentityDiagnostic {
-    reservation_id: Uuid,
-    variant_id: Option<Uuid>,
-    quantity: Option<i32>,
-    line_item_id: Option<Uuid>,
+    reservation_id_present: bool,
+    reservation_id_non_nil: bool,
+    variant_id_present: bool,
+    variant_id_non_nil: bool,
+    quantity_present: bool,
+    quantity_nonzero: bool,
+    quantity_negative: bool,
+    line_item_id_present: bool,
+    line_item_id_non_nil: bool,
     external_id_length: usize,
+}
+
+impl InventoryReservationIdentityDiagnostic {
+    fn reserve(request: &InventoryIdentityReservationRequest) -> Self {
+        Self {
+            reservation_id_present: true,
+            reservation_id_non_nil: !request.reservation_id.is_nil(),
+            variant_id_present: true,
+            variant_id_non_nil: !request.variant_id.is_nil(),
+            quantity_present: true,
+            quantity_nonzero: request.quantity != 0,
+            quantity_negative: request.quantity < 0,
+            line_item_id_present: request.line_item_id.is_some(),
+            line_item_id_non_nil: request.line_item_id.is_some_and(|value| !value.is_nil()),
+            external_id_length: request.external_id.chars().count(),
+        }
+    }
+
+    fn release(request: &InventoryIdentityReservationReleaseRequest) -> Self {
+        Self {
+            reservation_id_present: true,
+            reservation_id_non_nil: !request.reservation_id.is_nil(),
+            variant_id_present: false,
+            variant_id_non_nil: false,
+            quantity_present: false,
+            quantity_nonzero: false,
+            quantity_negative: false,
+            line_item_id_present: false,
+            line_item_id_non_nil: false,
+            external_id_length: request.external_id.chars().count(),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -53,13 +108,7 @@ impl InventoryReservationIdentityPort for PersistentInventoryReservationIdentity
         require_inventory_reservation_write_admission(&context, RESERVE_OPERATION)?;
         parse_inventory_reservation_tenant_id(&context, RESERVE_OPERATION)?;
         let diagnostic_context = context.clone();
-        let identity = InventoryReservationIdentityDiagnostic {
-            reservation_id: request.reservation_id,
-            variant_id: Some(request.variant_id),
-            quantity: Some(request.quantity),
-            line_item_id: request.line_item_id,
-            external_id_length: request.external_id.chars().count(),
-        };
+        let identity = InventoryReservationIdentityDiagnostic::reserve(&request);
         let result = self
             .inner
             .reserve_inventory_by_identity(context, request)
@@ -82,13 +131,7 @@ impl InventoryReservationIdentityPort for PersistentInventoryReservationIdentity
         require_inventory_reservation_write_admission(&context, RELEASE_OPERATION)?;
         parse_inventory_reservation_tenant_id(&context, RELEASE_OPERATION)?;
         let diagnostic_context = context.clone();
-        let identity = InventoryReservationIdentityDiagnostic {
-            reservation_id: request.reservation_id,
-            variant_id: None,
-            quantity: None,
-            line_item_id: None,
-            external_id_length: request.external_id.chars().count(),
-        };
+        let identity = InventoryReservationIdentityDiagnostic::release(&request);
         let result = self
             .inner
             .release_inventory_by_identity(context, request)
@@ -101,6 +144,54 @@ impl InventoryReservationIdentityPort for PersistentInventoryReservationIdentity
                 error,
             )
         })
+    }
+}
+
+fn inventory_reservation_context_facts(
+    context: &PortContext,
+) -> InventoryReservationContextFacts {
+    let actor_kind = match &context.actor.kind {
+        rustok_api::PortActorKind::User => "user",
+        rustok_api::PortActorKind::Service => "service",
+        rustok_api::PortActorKind::System => "system",
+    };
+    InventoryReservationContextFacts {
+        tenant_id_length: context.tenant_id.chars().count(),
+        actor_kind,
+        actor_id_length: context.actor.id.chars().count(),
+        claim_count: context.claims.len(),
+        role_count: context.roles.len(),
+        channel_present: context.channel.is_some(),
+        channel_length: context.channel.as_ref().map(|value| value.chars().count()),
+        locale_length: context.locale.chars().count(),
+        causation_id_present: context.causation_id.is_some(),
+        causation_id_length: context
+            .causation_id
+            .as_ref()
+            .map(|value| value.chars().count()),
+        traceparent_present: context.traceparent.is_some(),
+        traceparent_length: context
+            .traceparent
+            .as_ref()
+            .map(|value| value.chars().count()),
+        idempotency_key_present: context.idempotency_key.is_some(),
+        idempotency_key_length: context
+            .idempotency_key
+            .as_ref()
+            .map(|value| value.chars().count()),
+        deadline_ms: context.deadline_ms,
+    }
+}
+
+fn inventory_reservation_port_error_kind(kind: &PortErrorKind) -> &'static str {
+    match kind {
+        PortErrorKind::Validation => "validation",
+        PortErrorKind::NotFound => "not_found",
+        PortErrorKind::Conflict => "conflict",
+        PortErrorKind::Forbidden => "forbidden",
+        PortErrorKind::Unavailable => "unavailable",
+        PortErrorKind::Timeout => "timeout",
+        PortErrorKind::InvariantViolation => "invariant_violation",
     }
 }
 
@@ -166,66 +257,109 @@ fn map_inventory_reservation_identity_local_port_error(
         }
         _ => return error,
     };
+
+    log_inventory_reservation_local_outcome(
+        context,
+        operation,
+        local_operation,
+        identity,
+        &error,
+    );
+    error
+}
+
+fn log_inventory_reservation_local_outcome(
+    context: &PortContext,
+    operation: &'static str,
+    local_operation: &'static str,
+    identity: &InventoryReservationIdentityDiagnostic,
+    error: &PortError,
+) {
+    let facts = inventory_reservation_context_facts(context);
     let technical_failure = matches!(
         &error.kind,
         PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation
     );
+
     if technical_failure {
         tracing::error!(
-            error = ?error,
             owner = INVENTORY_OWNER,
             operation,
             local_operation,
             correlation_id = %context.correlation_id,
-            tenant_id = %context.tenant_id,
-            actor = ?context.actor,
-            channel = ?context.channel,
-            locale = %context.locale,
-            causation_id = ?context.causation_id,
-            traceparent = ?context.traceparent,
-            idempotency_key = ?context.idempotency_key,
-            deadline_ms = ?context.deadline_ms,
-            reservation_id = %identity.reservation_id,
-            variant_id = ?identity.variant_id,
-            request_quantity = ?identity.quantity,
-            line_item_id = ?identity.line_item_id,
+            tenant_id_length = facts.tenant_id_length,
+            actor_kind = facts.actor_kind,
+            actor_id_length = facts.actor_id_length,
+            claim_count = facts.claim_count,
+            role_count = facts.role_count,
+            channel_present = facts.channel_present,
+            channel_length = ?facts.channel_length,
+            locale_length = facts.locale_length,
+            causation_id_present = facts.causation_id_present,
+            causation_id_length = ?facts.causation_id_length,
+            traceparent_present = facts.traceparent_present,
+            traceparent_length = ?facts.traceparent_length,
+            idempotency_key_present = facts.idempotency_key_present,
+            idempotency_key_length = ?facts.idempotency_key_length,
+            deadline_ms = ?facts.deadline_ms,
+            reservation_id_present = identity.reservation_id_present,
+            reservation_id_non_nil = identity.reservation_id_non_nil,
+            variant_id_present = identity.variant_id_present,
+            variant_id_non_nil = identity.variant_id_non_nil,
+            quantity_present = identity.quantity_present,
+            quantity_nonzero = identity.quantity_nonzero,
+            quantity_negative = identity.quantity_negative,
+            line_item_id_present = identity.line_item_id_present,
+            line_item_id_non_nil = identity.line_item_id_non_nil,
             external_id_length = identity.external_id_length,
-            internal_code = %error.code,
-            internal_message = %error.message,
-            error_kind = ?error.kind,
+            code = %error.code,
+            error_message_present = !error.message.is_empty(),
+            error_message_length = error.message.chars().count(),
+            error_kind = inventory_reservation_port_error_kind(&error.kind),
             retryable = error.retryable,
             boundary = INVENTORY_RESERVATION_BOUNDARY,
-            "durable inventory reservation local technical outcome retained delegated context"
+            "durable inventory reservation local technical outcome retained bounded delegated context"
         );
     } else {
         tracing::warn!(
-            error = ?error,
             owner = INVENTORY_OWNER,
             operation,
             local_operation,
             correlation_id = %context.correlation_id,
-            tenant_id = %context.tenant_id,
-            actor = ?context.actor,
-            channel = ?context.channel,
-            locale = %context.locale,
-            causation_id = ?context.causation_id,
-            traceparent = ?context.traceparent,
-            idempotency_key = ?context.idempotency_key,
-            deadline_ms = ?context.deadline_ms,
-            reservation_id = %identity.reservation_id,
-            variant_id = ?identity.variant_id,
-            request_quantity = ?identity.quantity,
-            line_item_id = ?identity.line_item_id,
+            tenant_id_length = facts.tenant_id_length,
+            actor_kind = facts.actor_kind,
+            actor_id_length = facts.actor_id_length,
+            claim_count = facts.claim_count,
+            role_count = facts.role_count,
+            channel_present = facts.channel_present,
+            channel_length = ?facts.channel_length,
+            locale_length = facts.locale_length,
+            causation_id_present = facts.causation_id_present,
+            causation_id_length = ?facts.causation_id_length,
+            traceparent_present = facts.traceparent_present,
+            traceparent_length = ?facts.traceparent_length,
+            idempotency_key_present = facts.idempotency_key_present,
+            idempotency_key_length = ?facts.idempotency_key_length,
+            deadline_ms = ?facts.deadline_ms,
+            reservation_id_present = identity.reservation_id_present,
+            reservation_id_non_nil = identity.reservation_id_non_nil,
+            variant_id_present = identity.variant_id_present,
+            variant_id_non_nil = identity.variant_id_non_nil,
+            quantity_present = identity.quantity_present,
+            quantity_nonzero = identity.quantity_nonzero,
+            quantity_negative = identity.quantity_negative,
+            line_item_id_present = identity.line_item_id_present,
+            line_item_id_non_nil = identity.line_item_id_non_nil,
             external_id_length = identity.external_id_length,
-            internal_code = %error.code,
-            internal_message = %error.message,
-            error_kind = ?error.kind,
+            code = %error.code,
+            error_message_present = !error.message.is_empty(),
+            error_message_length = error.message.chars().count(),
+            error_kind = inventory_reservation_port_error_kind(&error.kind),
             retryable = error.retryable,
             boundary = INVENTORY_RESERVATION_BOUNDARY,
-            "durable inventory reservation local outcome retained delegated context"
+            "durable inventory reservation local outcome retained bounded delegated context"
         );
     }
-    error
 }
 
 fn require_inventory_reservation_write_admission(
@@ -238,7 +372,12 @@ fn require_inventory_reservation_write_admission(
             log_inventory_reservation_admission_rejection(context, operation, "policy", error);
         })?;
     context.require_write_semantics().inspect_err(|error| {
-        log_inventory_reservation_admission_rejection(context, operation, "write_semantics", error);
+        log_inventory_reservation_admission_rejection(
+            context,
+            operation,
+            "write_semantics",
+            error,
+        );
     })
 }
 
@@ -248,53 +387,70 @@ fn log_inventory_reservation_admission_rejection(
     admission_phase: &'static str,
     error: &PortError,
 ) {
-    match &error.kind {
-        PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation => {
-            tracing::error!(
-                error = ?error,
-                owner = INVENTORY_OWNER,
-                operation,
-                admission_phase,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                actor = ?context.actor,
-                channel = ?context.channel,
-                locale = %context.locale,
-                causation_id = ?context.causation_id,
-                traceparent = ?context.traceparent,
-                idempotency_key = ?context.idempotency_key,
-                deadline_ms = ?context.deadline_ms,
-                internal_code = %error.code,
-                internal_message = %error.message,
-                error_kind = ?error.kind,
-                retryable = error.retryable,
-                boundary = INVENTORY_RESERVATION_BOUNDARY,
-                "inventory reservation owner admission failed"
-            );
-        }
-        _ => {
-            tracing::warn!(
-                error = ?error,
-                owner = INVENTORY_OWNER,
-                operation,
-                admission_phase,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                actor = ?context.actor,
-                channel = ?context.channel,
-                locale = %context.locale,
-                causation_id = ?context.causation_id,
-                traceparent = ?context.traceparent,
-                idempotency_key = ?context.idempotency_key,
-                deadline_ms = ?context.deadline_ms,
-                internal_code = %error.code,
-                internal_message = %error.message,
-                error_kind = ?error.kind,
-                retryable = error.retryable,
-                boundary = INVENTORY_RESERVATION_BOUNDARY,
-                "inventory reservation owner admission was rejected"
-            );
-        }
+    let facts = inventory_reservation_context_facts(context);
+    let technical_failure = matches!(
+        &error.kind,
+        PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation
+    );
+
+    if technical_failure {
+        tracing::error!(
+            owner = INVENTORY_OWNER,
+            operation,
+            admission_phase,
+            correlation_id = %context.correlation_id,
+            tenant_id_length = facts.tenant_id_length,
+            actor_kind = facts.actor_kind,
+            actor_id_length = facts.actor_id_length,
+            claim_count = facts.claim_count,
+            role_count = facts.role_count,
+            channel_present = facts.channel_present,
+            channel_length = ?facts.channel_length,
+            locale_length = facts.locale_length,
+            causation_id_present = facts.causation_id_present,
+            causation_id_length = ?facts.causation_id_length,
+            traceparent_present = facts.traceparent_present,
+            traceparent_length = ?facts.traceparent_length,
+            idempotency_key_present = facts.idempotency_key_present,
+            idempotency_key_length = ?facts.idempotency_key_length,
+            deadline_ms = ?facts.deadline_ms,
+            code = %error.code,
+            error_message_present = !error.message.is_empty(),
+            error_message_length = error.message.chars().count(),
+            error_kind = inventory_reservation_port_error_kind(&error.kind),
+            retryable = error.retryable,
+            boundary = INVENTORY_RESERVATION_BOUNDARY,
+            "inventory reservation owner admission failed with bounded diagnostics"
+        );
+    } else {
+        tracing::warn!(
+            owner = INVENTORY_OWNER,
+            operation,
+            admission_phase,
+            correlation_id = %context.correlation_id,
+            tenant_id_length = facts.tenant_id_length,
+            actor_kind = facts.actor_kind,
+            actor_id_length = facts.actor_id_length,
+            claim_count = facts.claim_count,
+            role_count = facts.role_count,
+            channel_present = facts.channel_present,
+            channel_length = ?facts.channel_length,
+            locale_length = facts.locale_length,
+            causation_id_present = facts.causation_id_present,
+            causation_id_length = ?facts.causation_id_length,
+            traceparent_present = facts.traceparent_present,
+            traceparent_length = ?facts.traceparent_length,
+            idempotency_key_present = facts.idempotency_key_present,
+            idempotency_key_length = ?facts.idempotency_key_length,
+            deadline_ms = ?facts.deadline_ms,
+            code = %error.code,
+            error_message_present = !error.message.is_empty(),
+            error_message_length = error.message.chars().count(),
+            error_kind = inventory_reservation_port_error_kind(&error.kind),
+            retryable = error.retryable,
+            boundary = INVENTORY_RESERVATION_BOUNDARY,
+            "inventory reservation owner admission was rejected with bounded diagnostics"
+        );
     }
 }
 
@@ -302,33 +458,49 @@ fn parse_inventory_reservation_tenant_id(
     context: &PortContext,
     operation: &'static str,
 ) -> Result<Uuid, PortError> {
-    Uuid::parse_str(context.tenant_id.trim()).map_err(|cause| {
+    Uuid::parse_str(context.tenant_id.trim()).map_err(|_| {
         let error = PortError::validation(
             "inventory.context_invalid",
             "inventory request context is invalid",
         );
-        tracing::warn!(
-            parse_cause = ?cause,
-            error = ?error,
-            owner = INVENTORY_OWNER,
-            operation,
-            validation_phase = "tenant_id",
-            correlation_id = %context.correlation_id,
-            tenant_id = %context.tenant_id,
-            actor = ?context.actor,
-            channel = ?context.channel,
-            locale = %context.locale,
-            causation_id = ?context.causation_id,
-            traceparent = ?context.traceparent,
-            idempotency_key = ?context.idempotency_key,
-            deadline_ms = ?context.deadline_ms,
-            internal_code = %error.code,
-            internal_message = %error.message,
-            error_kind = ?error.kind,
-            retryable = error.retryable,
-            boundary = INVENTORY_RESERVATION_BOUNDARY,
-            "inventory reservation owner context validation was rejected"
-        );
+        log_inventory_reservation_tenant_rejection(context, operation, &error);
         error
     })
+}
+
+fn log_inventory_reservation_tenant_rejection(
+    context: &PortContext,
+    operation: &'static str,
+    error: &PortError,
+) {
+    let facts = inventory_reservation_context_facts(context);
+    tracing::warn!(
+        owner = INVENTORY_OWNER,
+        operation,
+        validation_phase = "tenant_id",
+        correlation_id = %context.correlation_id,
+        tenant_id_length = facts.tenant_id_length,
+        actor_kind = facts.actor_kind,
+        actor_id_length = facts.actor_id_length,
+        claim_count = facts.claim_count,
+        role_count = facts.role_count,
+        channel_present = facts.channel_present,
+        channel_length = ?facts.channel_length,
+        locale_length = facts.locale_length,
+        causation_id_present = facts.causation_id_present,
+        causation_id_length = ?facts.causation_id_length,
+        traceparent_present = facts.traceparent_present,
+        traceparent_length = ?facts.traceparent_length,
+        idempotency_key_present = facts.idempotency_key_present,
+        idempotency_key_length = ?facts.idempotency_key_length,
+        deadline_ms = ?facts.deadline_ms,
+        tenant_id_parse_failed = true,
+        code = %error.code,
+        error_message_present = !error.message.is_empty(),
+        error_message_length = error.message.chars().count(),
+        error_kind = inventory_reservation_port_error_kind(&error.kind),
+        retryable = error.retryable,
+        boundary = INVENTORY_RESERVATION_BOUNDARY,
+        "inventory reservation owner context validation was rejected with bounded diagnostics"
+    );
 }

--- a/scripts/verify/verify-inventory-reservation-local-context.mjs
+++ b/scripts/verify/verify-inventory-reservation-local-context.mjs
@@ -9,10 +9,22 @@ const root = configuredRoot
   ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
   : new URL('../../', import.meta.url);
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
-
-const wrapper = read('crates/rustok-inventory/src/reservation_owner_context.rs');
-const legacy = read('crates/rustok-inventory/src/ports.rs');
 const failures = [];
+
+const paths = {
+  wrapper: 'crates/rustok-inventory/src/reservation_owner_context.rs',
+  legacy: 'crates/rustok-inventory/src/ports.rs',
+  evidence:
+    'crates/rustok-inventory/contracts/evidence/inventory-reservation-owner-diagnostic-safety-source.json',
+  review:
+    'crates/rustok-inventory/contracts/evidence/inventory-reservation-owner-diagnostic-safety-source-review.json',
+  document: 'crates/rustok-inventory/docs/reservation-local-context.md',
+};
+const wrapper = read(paths.wrapper);
+const legacy = read(paths.legacy);
+const evidence = JSON.parse(read(paths.evidence));
+const review = JSON.parse(read(paths.review));
+const document = read(paths.document);
 
 const requireText = (content, value, label) => {
   if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
@@ -20,201 +32,209 @@ const requireText = (content, value, label) => {
 const forbidText = (content, value, label) => {
   if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
 };
-const between = (content, start, end, label) => {
-  const startIndex = content.indexOf(start);
-  const endIndex = content.indexOf(end, startIndex + start.length);
-  if (startIndex < 0 || endIndex < 0) {
-    failures.push(`${label}: unable to isolate source block`);
+function functionBody(content, name) {
+  const signature = new RegExp(
+    `(?:pub(?:\\([^)]*\\))?\\s+)?(?:async\\s+)?fn\\s+${name}(?:<[^>]*>)?\\s*\\(`,
+  );
+  const match = signature.exec(content);
+  if (!match) {
+    failures.push(`missing function ${name}`);
     return '';
   }
-  return content.slice(startIndex, endIndex);
-};
+  const open = content.indexOf('{', match.index);
+  let depth = 0;
+  for (let index = open; index < content.length; index += 1) {
+    if (content[index] === '{') depth += 1;
+    if (content[index] === '}') {
+      depth -= 1;
+      if (depth === 0) return content.slice(open, index + 1);
+    }
+  }
+  failures.push(`unterminated function ${name}`);
+  return '';
+}
 
-const wrapperImpl = between(
+const mapper = functionBody(
   wrapper,
-  'impl InventoryReservationIdentityPort for PersistentInventoryReservationIdentityPort {',
-  'fn map_inventory_reservation_identity_local_port_error(',
-  'durable reservation wrapper implementation',
+  'map_inventory_reservation_identity_local_port_error',
 );
-const reserve = between(
-  wrapperImpl,
-  'async fn reserve_inventory_by_identity(',
-  'async fn release_inventory_by_identity(',
-  'durable reserve operation',
-);
-const release = wrapperImpl.slice(
-  wrapperImpl.indexOf('async fn release_inventory_by_identity('),
-);
-const mapper = between(
-  wrapper,
-  'fn map_inventory_reservation_identity_local_port_error(',
-  'fn require_inventory_reservation_write_admission(',
-  'durable reservation local mapper',
-);
-const legacyIdentityImpl = between(
-  legacy,
-  'impl InventoryReservationIdentityPort for PersistentInventoryReservationIdentityPort {',
-  'async fn load_tenant_variant<C>(',
-  'legacy durable reservation implementation',
-);
-const legacyHelpers = legacy.slice(legacy.indexOf('async fn load_tenant_variant<C>('));
+const logger = functionBody(wrapper, 'log_inventory_reservation_local_outcome');
+const reserveFacts = functionBody(wrapper, 'reserve');
+const releaseFacts = functionBody(wrapper, 'release');
+const diagnosticScope = [logger, reserveFacts, releaseFacts].join('\n');
 
-for (const [block, config] of [
+for (const [value, label] of [
+  ['let diagnostic_context = context.clone();', 'delegated context retention'],
   [
-    reserve,
-    {
-      operation: 'RESERVE_OPERATION',
-      delegation: '.reserve_inventory_by_identity(context, request)',
-      facts: [
-        'let variant_id = Some(request.variant_id);',
-        'let quantity = Some(request.quantity);',
-        'let line_item_id = request.line_item_id;',
-        'variant_id,\n                quantity,\n                line_item_id,',
-      ],
-      label: 'durable reserve local routing',
-    },
+    'let identity = InventoryReservationIdentityDiagnostic::reserve(&request);',
+    'reserve request shape',
   ],
   [
-    release,
-    {
-      operation: 'RELEASE_OPERATION',
-      delegation: '.release_inventory_by_identity(context, request)',
-      facts: [
-        'None,\n                None,\n                None,',
-      ],
-      label: 'durable release local routing',
-    },
+    'let identity = InventoryReservationIdentityDiagnostic::release(&request);',
+    'release request shape',
   ],
-]) {
-  for (const [value, detail] of [
-    [`require_inventory_reservation_write_admission(&context, ${config.operation})?;`, 'admission'],
-    [`parse_inventory_reservation_tenant_id(&context, ${config.operation})?;`, 'tenant validation'],
-    ['let diagnostic_context = context.clone();', 'delegated context retention'],
-    ['let reservation_id = request.reservation_id;', 'reservation identity retention'],
-    ['let external_id_length = request.external_id.chars().count();', 'external identity length retention'],
-    ['let result = self', 'owner result retention'],
-    [config.delegation, 'unchanged owner delegation'],
-    ['result.map_err(|error| {', 'post-delegation mapping'],
-    ['map_inventory_reservation_identity_local_port_error(', 'local mapper call'],
-    ['&diagnostic_context,', 'retained context mapper argument'],
-    [config.operation, 'exact operation mapper argument'],
-    ['reservation_id,', 'reservation identity mapper argument'],
-    ['external_id_length,', 'external identity length mapper argument'],
-  ]) requireText(block, value, `${config.label} ${detail}`);
-  for (const value of config.facts) requireText(block, value, `${config.label} request facts`);
+  ['.reserve_inventory_by_identity(context, request)', 'reserve delegation'],
+  ['.release_inventory_by_identity(context, request)', 'release delegation'],
+  ['result.map_err(|error| {', 'post-delegation mapping'],
+  ['&diagnostic_context,', 'retained context argument'],
+  ['&identity,', 'request-shape argument'],
+]) requireText(wrapper, value, label);
 
-  const indexes = [
-    block.indexOf('require_inventory_reservation_write_admission('),
-    block.indexOf('parse_inventory_reservation_tenant_id('),
-    block.indexOf('let diagnostic_context = context.clone();'),
-    block.indexOf(config.delegation),
-    block.indexOf('map_inventory_reservation_identity_local_port_error('),
-  ];
-  if (!indexes.every((value, index) => index === 0 || indexes[index - 1] < value)) {
-    failures.push(
-      `${config.label}: expected admission -> tenant validation -> context retention -> delegation -> local mapping ordering`,
-    );
+for (const [value, label] of [
+  ['reservation_id_present: true', 'reservation-id presence'],
+  ['reservation_id_non_nil: !request.reservation_id.is_nil()', 'reservation-id shape'],
+  ['variant_id_present: true', 'variant-id presence'],
+  ['variant_id_non_nil: !request.variant_id.is_nil()', 'variant-id shape'],
+  ['quantity_present: true', 'quantity presence'],
+  ['quantity_nonzero: request.quantity != 0', 'quantity non-zero shape'],
+  ['quantity_negative: request.quantity < 0', 'quantity sign shape'],
+  ['line_item_id_present: request.line_item_id.is_some()', 'line-item presence'],
+  ['external_id_length: request.external_id.chars().count()', 'external-id length'],
+]) requireText(reserveFacts, value, label);
+for (const [value, label] of [
+  ['reservation_id_present: true', 'release reservation-id presence'],
+  ['reservation_id_non_nil: !request.reservation_id.is_nil()', 'release reservation-id shape'],
+  ['variant_id_present: false', 'release variant absence'],
+  ['quantity_present: false', 'release quantity absence'],
+  ['line_item_id_present: false', 'release line-item absence'],
+  ['external_id_length: request.external_id.chars().count()', 'release external-id length'],
+]) requireText(releaseFacts, value, label);
+
+for (const [value, label] of [
+  ['"inventory.reservation_external_id_invalid"', 'external-id validation code'],
+  ['"reservation external_id must contain 1 to 191 characters"', 'external-id exact classification'],
+  ['"normalize_external_id"', 'external-id local operation'],
+  ['"inventory.reservation_quantity_invalid"', 'quantity validation code'],
+  ['"validate_reservation_quantity"', 'quantity local operation'],
+  ['"inventory.variant_not_found"', 'variant code'],
+  ['"load_variant"', 'variant local operation'],
+  ['"inventory.state_not_found"', 'state code'],
+  ['"load_inventory_state"', 'state local operation'],
+  ['"validate_existing_reservation_identity"', 'reserve replay local operation'],
+  ['"reserve_available_stock"', 'stock local operation'],
+  ['"load_reservation"', 'release lookup local operation'],
+  ['"validate_release_external_identity"', 'release identity local operation'],
+  ['"load_reservation_inventory_item"', 'missing item local operation'],
+  ['"revalidate_release_identity"', 'locked identity local operation'],
+  ['"release_reserved_quantity"', 'ledger local operation'],
+  ['"calculate_available_quantity"', 'availability local operation'],
+  ['"owner_storage"', 'storage local operation'],
+  ['_ => return error,', 'unknown pass-through'],
+  ['log_inventory_reservation_local_outcome(', 'bounded logger call'],
+  ['error\n}', 'same delegated error return'],
+]) requireText(mapper, value, label);
+
+for (const [value, label] of [
+  ['tracing::error!(', 'technical event'],
+  ['tracing::warn!(', 'ordinary event'],
+  ['owner = INVENTORY_OWNER', 'truthful owner'],
+  ['operation,', 'public operation'],
+  ['local_operation,', 'local operation'],
+  ['correlation_id = %context.correlation_id', 'correlation id'],
+  ['tenant_id_length = facts.tenant_id_length', 'tenant shape'],
+  ['actor_kind = facts.actor_kind', 'actor kind'],
+  ['reservation_id_present = identity.reservation_id_present', 'reservation presence'],
+  ['reservation_id_non_nil = identity.reservation_id_non_nil', 'reservation shape'],
+  ['variant_id_present = identity.variant_id_present', 'variant presence'],
+  ['variant_id_non_nil = identity.variant_id_non_nil', 'variant shape'],
+  ['quantity_present = identity.quantity_present', 'quantity presence'],
+  ['quantity_nonzero = identity.quantity_nonzero', 'quantity non-zero'],
+  ['quantity_negative = identity.quantity_negative', 'quantity sign'],
+  ['line_item_id_present = identity.line_item_id_present', 'line-item presence'],
+  ['line_item_id_non_nil = identity.line_item_id_non_nil', 'line-item shape'],
+  ['external_id_length = identity.external_id_length', 'external-id length'],
+  ['code = %error.code', 'stable code'],
+  ['error_message_present = !error.message.is_empty()', 'message presence'],
+  ['error_message_length = error.message.chars().count()', 'message length'],
+  [
+    'error_kind = inventory_reservation_port_error_kind(&error.kind)',
+    'closed error kind',
+  ],
+  ['retryable = error.retryable', 'retryability'],
+  ['boundary = INVENTORY_RESERVATION_BOUNDARY', 'boundary'],
+  [
+    'PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation',
+    'severity classification',
+  ],
+]) requireText(logger, value, label);
+
+for (const [value, label] of [
+  ['error = ?error', 'complete delegated error'],
+  ['error = %error', 'display delegated error'],
+  ['internal_message = %error.message', 'raw message'],
+  ['error_kind = ?error.kind', 'debug error kind'],
+  ['tenant_id = %context.tenant_id', 'raw tenant'],
+  ['actor = ?context.actor', 'raw actor'],
+  ['channel = ?context.channel', 'raw channel'],
+  ['locale = %context.locale', 'raw locale'],
+  ['reservation_id = %', 'raw reservation id'],
+  ['variant_id = ?', 'raw variant id'],
+  ['request_quantity = ?', 'exact quantity'],
+  ['line_item_id = ?', 'raw line-item id'],
+  ['external_id =', 'raw external id'],
+]) forbidText(diagnosticScope, value, label);
+
+for (const marker of [
+  'request.external_id = normalize_external_id(request.external_id)?;',
+  '"inventory.reservation_quantity_invalid"',
+  '"inventory.state_not_found"',
+  '"inventory.insufficient_inventory"',
+  '"inventory.reservation_not_found"',
+  '"inventory.reservation_item_missing"',
+  '"inventory.reservation_ledger_inconsistent"',
+]) requireText(legacy, marker, 'unchanged persistent reservation behavior');
+
+for (const [key, expected] of Object.entries({
+  local_outcome_diagnostic_cleanup_closed: true,
+  complete_port_error_logged: false,
+  raw_request_uuid_logged: false,
+  exact_request_quantity_logged: false,
+  raw_external_id_logged: false,
+  bounded_request_shape_logged: true,
+  stable_code_logged: true,
+  error_message_shape_logged: true,
+  closed_error_kind_logged: true,
+  delegated_error_return_changed: false,
+  exact_code_message_classification_changed: false,
+  broad_ecommerce_cleanup_closed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
   }
 }
 
-for (const [value, label] of [
-  ['"inventory.reservation_external_id_invalid"', 'external identity validation code'],
-  ['"reservation external_id must contain 1 to 191 characters"', 'external identity validation message'],
-  [') => "normalize_external_id"', 'external identity local operation'],
-  ['"inventory.reservation_quantity_invalid"', 'quantity validation code'],
-  ['"reservation quantity must be positive"', 'quantity validation message'],
-  [') if operation == RESERVE_OPERATION => "validate_reservation_quantity"', 'reserve quantity local operation'],
-  ['("inventory.variant_not_found", "inventory variant was not found") => "load_variant"', 'variant lookup outcome for both operations'],
-  ['"inventory.state_not_found"', 'inventory state code'],
-  ['"variant has no configured inventory state"', 'inventory state message'],
-  ['"load_inventory_state"', 'inventory state local operation'],
-  ['"reservation identity is already bound to different reservation data"', 'reserve replay conflict message'],
-  ['"validate_existing_reservation_identity"', 'reserve replay conflict local operation'],
-  ['"inventory.insufficient_inventory"', 'reserve stock code'],
-  ['"insufficient inventory for reservation"', 'reserve stock message'],
-  ['"reserve_available_stock"', 'reserve stock local operation'],
-  ['"inventory.reservation_not_found"', 'release not-found code'],
-  ['"inventory reservation was not found"', 'release not-found message'],
-  ['"load_reservation"', 'release not-found local operation'],
-  ['"reservation id is bound to another external identity"', 'release identity conflict message'],
-  ['"validate_release_external_identity"', 'release identity local operation'],
-  ['"inventory.reservation_item_missing"', 'missing reservation item code'],
-  ['"reservation inventory item is missing"', 'missing reservation item message'],
-  ['"load_reservation_inventory_item"', 'missing reservation item local operation'],
-  ['"reservation identity changed while acquiring the owner lock"', 'locked identity conflict message'],
-  ['"revalidate_release_identity"', 'locked identity local operation'],
-  ['"inventory.reservation_ledger_inconsistent"', 'ledger invariant code'],
-  ['"inventory reservation ledger is inconsistent"', 'ledger invariant message'],
-  ['"release_reserved_quantity"', 'ledger invariant local operation'],
-  ['"inventory.available_quantity_overflow"', 'available quantity invariant code'],
-  ['"inventory available quantity is outside the supported range"', 'available quantity invariant message'],
-  ['"calculate_available_quantity"', 'available quantity local operation'],
-  ['"inventory.database_unavailable"', 'storage code'],
-  ['"inventory storage is temporarily unavailable"', 'storage message'],
-  ['"owner_storage"', 'storage local operation'],
-  ['PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation', 'technical severity classification'],
-  ['tracing::error!(', 'technical local event'],
-  ['tracing::warn!(', 'ordinary local event'],
-  ['error = ?error', 'original delegated error evidence'],
-  ['owner = INVENTORY_OWNER', 'truthful local owner'],
-  ['operation,', 'exact public operation'],
-  ['local_operation,', 'exact local operation'],
-  ['correlation_id = %context.correlation_id', 'correlation context'],
-  ['tenant_id = %context.tenant_id', 'tenant context'],
-  ['actor = ?context.actor', 'actor context'],
-  ['channel = ?context.channel', 'channel context'],
-  ['locale = %context.locale', 'locale context'],
-  ['causation_id = ?context.causation_id', 'causation context'],
-  ['traceparent = ?context.traceparent', 'trace context'],
-  ['idempotency_key = ?context.idempotency_key', 'idempotency context'],
-  ['deadline_ms = ?context.deadline_ms', 'deadline context'],
-  ['reservation_id = %reservation_id', 'reservation identity context'],
-  ['variant_id = ?variant_id', 'variant context'],
-  ['request_quantity = ?quantity', 'quantity context'],
-  ['line_item_id = ?line_item_id', 'line-item context'],
-  ['external_id_length,', 'external identity length context'],
-  ['internal_code = %error.code', 'stable local code'],
-  ['internal_message = %error.message', 'stable local message'],
-  ['error_kind = ?error.kind', 'typed local kind'],
-  ['retryable = error.retryable', 'local retryability'],
-  ['boundary = INVENTORY_RESERVATION_BOUNDARY', 'local boundary'],
-  ['\n    error\n}', 'same delegated error return'],
-]) requireText(mapper, value, label);
-
-const unknownReturns = mapper.match(/_ => return error,/g)?.length ?? 0;
-if (unknownReturns !== 1) {
-  failures.push(`unknown local outcome pass-through count: expected 1, found ${unknownReturns}`);
+for (const [key, expected] of Object.entries({
+  exact_local_classification_preserved: true,
+  unknown_error_pass_through_preserved: true,
+  complete_local_error_removed: true,
+  raw_request_identifiers_removed: true,
+  exact_quantity_removed: true,
+  bounded_request_shape_retained: true,
+  same_delegated_error_returned: true,
+  persistent_owner_behavior_preserved: true,
+  runtime_evidence_claimed: false,
+})) {
+  if (review.review_findings?.[key] !== expected) {
+    failures.push(`${paths.review}: review_findings.${key} must be ${expected}`);
+  }
 }
-forbidText(mapper, 'external_id =', 'raw external identity diagnostics');
-forbidText(mapper, '%request.external_id', 'raw request external identity diagnostics');
-forbidText(mapper, 'inventory.context_invalid', 'admission and context errors must not be remapped locally');
 
-for (const [value, label] of [
-  ['request.external_id = normalize_external_id(request.external_id)?;', 'legacy external identity normalization'],
-  ['"inventory.reservation_quantity_invalid"', 'legacy quantity validation'],
-  ['"inventory.state_not_found"', 'legacy inventory state conflict'],
-  ['"inventory.insufficient_inventory"', 'legacy reserve stock conflict'],
-  ['"reservation identity is already bound to different reservation data"', 'legacy reserve replay conflict'],
-  ['"inventory.reservation_not_found"', 'legacy release not-found'],
-  ['"reservation id is bound to another external identity"', 'legacy release external identity conflict'],
-  ['"inventory.reservation_item_missing"', 'legacy missing inventory item invariant'],
-  ['"reservation identity changed while acquiring the owner lock"', 'legacy locked identity conflict'],
-  ['"inventory.reservation_ledger_inconsistent"', 'legacy ledger invariant'],
-]) requireText(legacyIdentityImpl, value, label);
-
-for (const [value, label] of [
-  ['"inventory.variant_not_found",\n                "inventory variant was not found",', 'legacy variant envelope'],
-  ['"inventory.available_quantity_overflow",\n                "inventory available quantity is outside the supported range",', 'legacy available quantity invariant'],
-  ['"inventory.reservation_external_id_invalid"', 'legacy external identity envelope'],
-  ['"inventory.database_unavailable",\n        "inventory storage is temporarily unavailable",', 'legacy storage envelope'],
-]) requireText(legacyHelpers, value, label);
+for (const marker of [
+  '# Inventory durable reservation local diagnostic safety',
+  'Status: **source-ready / unvalidated**',
+  'exact stable `code + message` pairs',
+  'bounded request shape',
+  'complete delegated `PortError` is not logged',
+  'The same delegated error is returned unchanged.',
+  'The ecommerce correlation-safe mapper task remains open',
+]) requireText(document, marker, 'truthful local diagnostic document');
 
 if (failures.length > 0) {
-  console.error('Durable inventory reservation local-context verification failed:');
+  console.error('Inventory durable reservation local diagnostic-safety verification failed:');
   for (const failure of failures) console.error(`✗ ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
 
 console.log(
-  '✔ Durable inventory reservation operations retain delegated context for stable local owner outcomes without logging raw external identity or changing PortError results',
+  '✔ Durable inventory reservation local outcomes retain exact classification and bounded request/context shape without logging complete delegated errors',
 );

--- a/scripts/verify/verify-inventory-reservation-owner-context.mjs
+++ b/scripts/verify/verify-inventory-reservation-owner-context.mjs
@@ -9,11 +9,24 @@ const root = configuredRoot
   ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
   : new URL('../../', import.meta.url);
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
-
-const wrapper = read('crates/rustok-inventory/src/reservation_owner_context.rs');
-const legacy = read('crates/rustok-inventory/src/ports.rs');
-const lib = read('crates/rustok-inventory/src/lib.rs');
 const failures = [];
+
+const paths = {
+  wrapper: 'crates/rustok-inventory/src/reservation_owner_context.rs',
+  legacy: 'crates/rustok-inventory/src/ports.rs',
+  lib: 'crates/rustok-inventory/src/lib.rs',
+  evidence:
+    'crates/rustok-inventory/contracts/evidence/inventory-reservation-owner-diagnostic-safety-source.json',
+  review:
+    'crates/rustok-inventory/contracts/evidence/inventory-reservation-owner-diagnostic-safety-source-review.json',
+  document: 'crates/rustok-inventory/docs/reservation-owner-context.md',
+};
+const wrapper = read(paths.wrapper);
+const legacy = read(paths.legacy);
+const lib = read(paths.lib);
+const evidence = JSON.parse(read(paths.evidence));
+const review = JSON.parse(read(paths.review));
+const document = read(paths.document);
 
 const requireText = (content, value, label) => {
   if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
@@ -21,189 +34,270 @@ const requireText = (content, value, label) => {
 const forbidText = (content, value, label) => {
   if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
 };
-const between = (content, start, end, label) => {
-  const startIndex = content.indexOf(start);
-  const endIndex = content.indexOf(end, startIndex + start.length);
-  if (startIndex < 0 || endIndex < 0) {
-    failures.push(`${label}: unable to isolate source block`);
+function functionBody(content, name) {
+  const signature = new RegExp(
+    `(?:pub(?:\\([^)]*\\))?\\s+)?(?:async\\s+)?fn\\s+${name}(?:<[^>]*>)?\\s*\\(`,
+  );
+  const match = signature.exec(content);
+  if (!match) {
+    failures.push(`missing function ${name}`);
     return '';
   }
-  return content.slice(startIndex, endIndex);
-};
-
-const wrapperImpl = between(
-  wrapper,
-  'impl InventoryReservationIdentityPort for PersistentInventoryReservationIdentityPort {',
-  'fn require_inventory_reservation_write_admission(',
-  'durable reservation wrapper implementation',
-);
-const reserve = between(
-  wrapperImpl,
-  'async fn reserve_inventory_by_identity(',
-  'async fn release_inventory_by_identity(',
-  'reserve wrapper operation',
-);
-const release = wrapperImpl.slice(
-  wrapperImpl.indexOf('async fn release_inventory_by_identity('),
-);
-const admission = between(
-  wrapper,
-  'fn require_inventory_reservation_write_admission(',
-  'fn parse_inventory_reservation_tenant_id(',
-  'reservation admission helpers',
-);
-const tenant = wrapper.slice(
-  wrapper.indexOf('fn parse_inventory_reservation_tenant_id('),
-);
-const legacyIdentityImpl = between(
-  legacy,
-  'impl InventoryReservationIdentityPort for PersistentInventoryReservationIdentityPort {',
-  'async fn load_tenant_variant<C>(',
-  'legacy identity reservation implementation',
-);
+  const open = content.indexOf('{', match.index);
+  let depth = 0;
+  for (let index = open; index < content.length; index += 1) {
+    if (content[index] === '{') depth += 1;
+    if (content[index] === '}') {
+      depth -= 1;
+      if (depth === 0) return content.slice(open, index + 1);
+    }
+  }
+  failures.push(`unterminated function ${name}`);
+  return '';
+}
 
 for (const [value, label] of [
   ['#[path = "ports.rs"]', 'private legacy implementation path'],
   ['mod ports_impl;', 'private legacy implementation module'],
-  ['mod reservation_owner_context;', 'private context wrapper module'],
+  ['mod reservation_owner_context;', 'private wrapper module'],
   ['pub mod ports {', 'public compatibility facade'],
-  ['pub use crate::ports_impl::{', 'public contract facade'],
+  ['pub use crate::ports_impl::{', 'public owner contract facade'],
   ['pub use crate::reservation_owner_context::{', 'public wrapper facade'],
   ['pub use ports::*;', 'crate-root compatibility export'],
-  ['InventoryReservationIdentityPort, InventoryReservationPort,', 'trait compatibility export'],
-  ['PersistentInventoryReservationIdentityPort,', 'wrapper struct compatibility export'],
-  ['in_process_inventory_reservation_identity_port,', 'factory compatibility export'],
 ]) requireText(lib, value, label);
 
-for (const value of [
-  'pub mod ports;',
-  'pub use ports_impl::*;',
-  'pub use reservation_owner_context::*;',
-]) forbidText(lib, value, 'public legacy bypass');
+for (const value of ['pub mod ports;', 'pub use ports_impl::*;', 'pub use reservation_owner_context::*;']) {
+  forbidText(lib, value, 'public legacy bypass');
+}
 
 for (const [value, label] of [
   ['const INVENTORY_OWNER: &str = "rustok_inventory";', 'truthful owner'],
-  ['const INVENTORY_RESERVATION_BOUNDARY: &str = "inventory_reservation_identity_port";', 'stable boundary'],
+  [
+    'const INVENTORY_RESERVATION_BOUNDARY: &str = "inventory_reservation_identity_port";',
+    'stable boundary',
+  ],
   ['const RESERVE_OPERATION: &str = "reserve_inventory_by_identity";', 'reserve operation'],
   ['const RELEASE_OPERATION: &str = "release_inventory_by_identity";', 'release operation'],
-  ['pub struct PersistentInventoryReservationIdentityPort {', 'public wrapper struct'],
-  ['inner: Arc<dyn InventoryReservationIdentityPort>', 'inner owner port'],
-  ['crate::ports_impl::PersistentInventoryReservationIdentityPort::new(db)', 'legacy constructor delegation'],
-  ['pub fn in_process_inventory_reservation_identity_port(', 'public wrapper factory'],
+  ['pub struct PersistentInventoryReservationIdentityPort {', 'wrapper struct'],
+  ['inner: Arc<dyn InventoryReservationIdentityPort>', 'delegated owner port'],
+  [
+    'crate::ports_impl::PersistentInventoryReservationIdentityPort::new(db)',
+    'legacy owner construction',
+  ],
+  ['pub fn in_process_inventory_reservation_identity_port(', 'canonical factory'],
+  ['async fn reserve_inventory_by_identity(', 'reserve operation implementation'],
+  ['async fn release_inventory_by_identity(', 'release operation implementation'],
+  [
+    'require_inventory_reservation_write_admission(&context, RESERVE_OPERATION)?;',
+    'reserve admission',
+  ],
+  [
+    'parse_inventory_reservation_tenant_id(&context, RESERVE_OPERATION)?;',
+    'reserve tenant validation',
+  ],
+  [
+    'require_inventory_reservation_write_admission(&context, RELEASE_OPERATION)?;',
+    'release admission',
+  ],
+  [
+    'parse_inventory_reservation_tenant_id(&context, RELEASE_OPERATION)?;',
+    'release tenant validation',
+  ],
+  ['.reserve_inventory_by_identity(context, request)', 'reserve delegation'],
+  ['.release_inventory_by_identity(context, request)', 'release delegation'],
 ]) requireText(wrapper, value, label);
 
-for (const [block, operation, delegation, label] of [
-  [
-    reserve,
-    'RESERVE_OPERATION',
-    '.reserve_inventory_by_identity(context, request)',
-    'reserve owner routing',
-  ],
-  [
-    release,
-    'RELEASE_OPERATION',
-    '.release_inventory_by_identity(context, request)',
-    'release owner routing',
-  ],
-]) {
-  for (const value of [
-    `require_inventory_reservation_write_admission(&context, ${operation})?;`,
-    `parse_inventory_reservation_tenant_id(&context, ${operation})?;`,
-    delegation,
-  ]) requireText(block, value, label);
-
-  const admissionIndex = block.indexOf('require_inventory_reservation_write_admission(');
-  const tenantIndex = block.indexOf('parse_inventory_reservation_tenant_id(');
-  const delegationIndex = block.indexOf(delegation);
-  if (!(admissionIndex >= 0 && admissionIndex < tenantIndex && tenantIndex < delegationIndex)) {
-    failures.push(`${label}: expected admission -> tenant validation -> owner delegation ordering`);
-  }
-}
+const contextFacts = functionBody(wrapper, 'inventory_reservation_context_facts');
+const kindLabel = functionBody(wrapper, 'inventory_reservation_port_error_kind');
+const admission = functionBody(wrapper, 'require_inventory_reservation_write_admission');
+const admissionLogger = functionBody(wrapper, 'log_inventory_reservation_admission_rejection');
+const tenantParser = functionBody(wrapper, 'parse_inventory_reservation_tenant_id');
+const tenantLogger = functionBody(wrapper, 'log_inventory_reservation_tenant_rejection');
+const diagnosticScope = [contextFacts, kindLabel, admissionLogger, tenantLogger].join('\n');
 
 for (const [value, label] of [
-  ['context.require_policy(PortCallPolicy::write()).map_err(|error| {', 'write-policy interception'],
-  ['context.require_write_semantics().map_err(|error| {', 'write-semantics interception'],
+  ['tenant_id_length: context.tenant_id.chars().count()', 'tenant shape'],
+  ['actor_kind', 'closed actor kind'],
+  ['actor_id_length: context.actor.id.chars().count()', 'actor-id shape'],
+  ['claim_count: context.claims.len()', 'claim count'],
+  ['role_count: context.roles.len()', 'role count'],
+  ['channel_present: context.channel.is_some()', 'channel presence'],
+  ['channel_length: context.channel.as_ref().map(', 'channel length'],
+  ['locale_length: context.locale.chars().count()', 'locale length'],
+  ['causation_id_present: context.causation_id.is_some()', 'causation presence'],
+  ['traceparent_present: context.traceparent.is_some()', 'trace presence'],
+  ['idempotency_key_present: context.idempotency_key.is_some()', 'idempotency presence'],
+  ['deadline_ms: context.deadline_ms', 'deadline shape'],
+]) requireText(contextFacts, value, label);
+
+for (const [value, label] of [
+  ['PortErrorKind::Validation => "validation"', 'validation label'],
+  ['PortErrorKind::NotFound => "not_found"', 'not-found label'],
+  ['PortErrorKind::Conflict => "conflict"', 'conflict label'],
+  ['PortErrorKind::Forbidden => "forbidden"', 'forbidden label'],
+  ['PortErrorKind::Unavailable => "unavailable"', 'unavailable label'],
+  ['PortErrorKind::Timeout => "timeout"', 'timeout label'],
+  ['PortErrorKind::InvariantViolation => "invariant_violation"', 'invariant label'],
+]) requireText(kindLabel, value, label);
+
+for (const [value, label] of [
+  ['.require_policy(PortCallPolicy::write())', 'write policy preserved'],
+  ['.inspect_err(|error| {', 'write policy interception'],
   ['"policy"', 'policy phase'],
-  ['"write_semantics"', 'write-semantics phase'],
-  ['PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation', 'technical severity classification'],
-  ['tracing::error!(', 'technical admission event'],
-  ['tracing::warn!(', 'ordinary admission event'],
-  ['error = ?error', 'original admission error evidence'],
-  ['owner = INVENTORY_OWNER', 'truthful admission owner'],
-  ['operation,', 'exact admission operation'],
-  ['admission_phase,', 'admission phase evidence'],
-  ['correlation_id = %context.correlation_id', 'correlation context'],
-  ['tenant_id = %context.tenant_id', 'tenant context'],
-  ['actor = ?context.actor', 'actor context'],
-  ['channel = ?context.channel', 'channel context'],
-  ['locale = %context.locale', 'locale context'],
-  ['causation_id = ?context.causation_id', 'causation context'],
-  ['traceparent = ?context.traceparent', 'trace context'],
-  ['idempotency_key = ?context.idempotency_key', 'idempotency context'],
-  ['deadline_ms = ?context.deadline_ms', 'deadline context'],
-  ['internal_code = %error.code', 'stable admission code'],
-  ['internal_message = %error.message', 'stable admission message'],
-  ['error_kind = ?error.kind', 'typed admission kind'],
-  ['retryable = error.retryable', 'admission retryability'],
-  ['boundary = INVENTORY_RESERVATION_BOUNDARY', 'admission boundary'],
-  ['error\n    })', 'same admission error return'],
+  ['context.require_write_semantics().inspect_err(|error| {', 'write semantics interception'],
+  ['"write_semantics"', 'write semantics phase'],
+  ['log_inventory_reservation_admission_rejection(', 'bounded admission logger call'],
 ]) requireText(admission, value, label);
 
 for (const [value, label] of [
-  ['Uuid::parse_str(context.tenant_id.trim()).map_err(|cause| {', 'preserved trimmed tenant parsing'],
-  ['let error = PortError::validation(', 'stable context error construction'],
-  ['"inventory.context_invalid"', 'stable context code'],
-  ['"inventory request context is invalid"', 'stable context message'],
-  ['parse_cause = ?cause', 'tenant parse cause'],
-  ['error = ?error', 'mapped context error'],
-  ['owner = INVENTORY_OWNER', 'truthful context owner'],
-  ['operation,', 'exact context operation'],
-  ['validation_phase = "tenant_id"', 'tenant validation phase'],
-  ['correlation_id = %context.correlation_id', 'tenant correlation context'],
-  ['tenant_id = %context.tenant_id', 'raw delegated tenant context'],
-  ['actor = ?context.actor', 'tenant actor context'],
-  ['channel = ?context.channel', 'tenant channel context'],
-  ['locale = %context.locale', 'tenant locale context'],
-  ['causation_id = ?context.causation_id', 'tenant causation context'],
-  ['traceparent = ?context.traceparent', 'tenant trace context'],
-  ['idempotency_key = ?context.idempotency_key', 'tenant idempotency context'],
-  ['deadline_ms = ?context.deadline_ms', 'tenant deadline context'],
-  ['internal_code = %error.code', 'tenant mapped code'],
-  ['internal_message = %error.message', 'tenant mapped message'],
-  ['error_kind = ?error.kind', 'tenant mapped kind'],
-  ['retryable = error.retryable', 'tenant mapped retryability'],
-  ['boundary = INVENTORY_RESERVATION_BOUNDARY', 'tenant boundary'],
-  ['error\n    })', 'same tenant validation error return'],
-]) requireText(tenant, value, label);
+  ['tracing::error!(', 'technical event'],
+  ['tracing::warn!(', 'ordinary event'],
+  ['owner = INVENTORY_OWNER', 'truthful owner'],
+  ['operation,', 'exact operation'],
+  ['admission_phase,', 'admission phase'],
+  ['correlation_id = %context.correlation_id', 'correlation id'],
+  ['tenant_id_length = facts.tenant_id_length', 'tenant shape'],
+  ['actor_kind = facts.actor_kind', 'actor kind'],
+  ['actor_id_length = facts.actor_id_length', 'actor shape'],
+  ['claim_count = facts.claim_count', 'claim count'],
+  ['role_count = facts.role_count', 'role count'],
+  ['channel_present = facts.channel_present', 'channel presence'],
+  ['locale_length = facts.locale_length', 'locale length'],
+  ['code = %error.code', 'stable code'],
+  ['error_message_present = !error.message.is_empty()', 'message presence'],
+  ['error_message_length = error.message.chars().count()', 'message length'],
+  [
+    'error_kind = inventory_reservation_port_error_kind(&error.kind)',
+    'closed error kind',
+  ],
+  ['retryable = error.retryable', 'retryability'],
+  ['boundary = INVENTORY_RESERVATION_BOUNDARY', 'boundary'],
+  [
+    'PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation',
+    'severity classification',
+  ],
+]) requireText(admissionLogger, value, label);
 
 for (const [value, label] of [
-  ['let owner_operation = "reserve_inventory_by_identity";', 'legacy reserve operation'],
-  ['let owner_operation = "release_inventory_by_identity";', 'legacy release operation'],
-  ['context.require_policy(PortCallPolicy::write())?;', 'legacy write policy'],
-  ['context.require_write_semantics()?;', 'legacy write semantics'],
-  ['let tenant_id = parse_port_tenant_id(&context, owner_operation)?;', 'legacy tenant validation'],
-  ['request.external_id = normalize_external_id(request.external_id)?;', 'legacy external identity validation'],
-  ['"inventory.reservation_quantity_invalid"', 'legacy quantity validation'],
-  ['"inventory.reservation_identity_conflict"', 'legacy identity conflict'],
-  ['"inventory.reservation_ledger_inconsistent"', 'legacy ledger invariant'],
-]) requireText(legacyIdentityImpl, value, label);
+  ['Uuid::parse_str(context.tenant_id.trim()).map_err(|_| {', 'trimmed UUID parsing'],
+  ['let error = PortError::validation(', 'stable validation construction'],
+  ['"inventory.context_invalid"', 'stable code'],
+  ['"inventory request context is invalid"', 'stable message'],
+  ['log_inventory_reservation_tenant_rejection(context, operation, &error);', 'bounded tenant logger'],
+  ['error\n    })', 'same validation error return'],
+]) requireText(tenantParser, value, label);
 
-for (const [pattern, expected, label] of [
-  [/impl InventoryReservationIdentityPort for PersistentInventoryReservationIdentityPort/g, 1, 'wrapper trait impl count'],
-  [/require_inventory_reservation_write_admission\(/g, 3, 'admission definition/use count'],
-  [/parse_inventory_reservation_tenant_id\(/g, 3, 'tenant validation definition/use count'],
-  [/crate::ports_impl::PersistentInventoryReservationIdentityPort::new\(db\)/g, 1, 'legacy constructor delegation count'],
+for (const [value, label] of [
+  ['tracing::warn!(', 'warning event'],
+  ['validation_phase = "tenant_id"', 'validation phase'],
+  ['tenant_id_parse_failed = true', 'parse failure fact'],
+  ['tenant_id_length = facts.tenant_id_length', 'tenant shape'],
+  ['code = %error.code', 'stable code'],
+  ['error_message_present = !error.message.is_empty()', 'message presence'],
+  ['error_message_length = error.message.chars().count()', 'message length'],
+  [
+    'error_kind = inventory_reservation_port_error_kind(&error.kind)',
+    'closed error kind',
+  ],
+  ['boundary = INVENTORY_RESERVATION_BOUNDARY', 'boundary'],
+]) requireText(tenantLogger, value, label);
+
+for (const [value, label] of [
+  ['error = ?error', 'complete PortError debug payload'],
+  ['error = %error', 'complete PortError display payload'],
+  ['internal_message = %error.message', 'raw PortError message'],
+  ['error_kind = ?error.kind', 'debug-formatted kind'],
+  ['tenant_id = %context.tenant_id', 'raw tenant'],
+  ['actor = ?context.actor', 'raw actor'],
+  ['channel = ?context.channel', 'raw channel'],
+  ['locale = %context.locale', 'raw locale'],
+  ['causation_id = ?context.causation_id', 'raw causation'],
+  ['traceparent = ?context.traceparent', 'raw trace'],
+  ['idempotency_key = ?context.idempotency_key', 'raw idempotency'],
+  ['parse_cause =', 'UUID parse cause'],
+]) forbidText(diagnosticScope, value, label);
+
+for (const marker of [
+  'let owner_operation = "reserve_inventory_by_identity";',
+  'let owner_operation = "release_inventory_by_identity";',
+  'context.require_policy(PortCallPolicy::write())?;',
+  'context.require_write_semantics()?;',
+  'let tenant_id = parse_port_tenant_id(&context, owner_operation)?;',
+]) requireText(legacy, marker, 'unchanged persistent owner');
+
+for (const [key, expected] of Object.entries({
+  admission_diagnostic_cleanup_closed: true,
+  tenant_parser_diagnostic_cleanup_closed: true,
+  complete_port_error_logged: false,
+  raw_context_logged: false,
+  uuid_parse_cause_logged: false,
+  closed_error_kind_logged: true,
+  error_message_shape_logged: true,
+  admission_error_return_changed: false,
+  tenant_error_return_changed: false,
+  public_contract_changed: false,
+  owner_delegation_changed: false,
+  sql_or_state_machine_changed: false,
+  inventory_ffa_fba_status_promoted: false,
+  broad_ecommerce_cleanup_closed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  'tests_run',
+  'verifiers_run',
+  'cargo_run',
+  'format_run',
+  'workflow_checks_run',
+  'ci_run',
+  'compile_proven',
+  'mounted_runtime_proven',
 ]) {
-  const count = wrapper.match(pattern)?.length ?? 0;
-  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push(`${paths.evidence}: execution must remain empty`);
 }
 
+for (const [key, expected] of Object.entries({
+  public_facade_preserved: true,
+  both_operations_preserved: true,
+  admission_order_preserved: true,
+  persistent_owner_rechecks_preserved: true,
+  complete_admission_error_removed: true,
+  raw_admission_context_removed: true,
+  tenant_parse_cause_removed: true,
+  bounded_admission_context_retained: true,
+  bounded_tenant_context_retained: true,
+  same_admission_error_returned: true,
+  same_tenant_error_returned: true,
+  runtime_evidence_claimed: false,
+})) {
+  if (review.review_findings?.[key] !== expected) {
+    failures.push(`${paths.review}: review_findings.${key} must be ${expected}`);
+  }
+}
+
+for (const marker of [
+  '# Inventory reservation owner diagnostic safety',
+  'Status: **source-ready / unvalidated**',
+  'complete `PortError`',
+  'bounded context shape',
+  'UUID parse cause is not recorded',
+  'The exact admission and tenant-validation errors are returned unchanged.',
+  'No FBA or FFA status is promoted',
+]) requireText(document, marker, 'truthful owner diagnostic document');
+
 if (failures.length > 0) {
-  console.error('Inventory reservation owner context verification failed:');
+  console.error('Inventory reservation owner diagnostic-safety verification failed:');
   for (const failure of failures) console.error(`✗ ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
 
 console.log(
-  '✔ Durable inventory reservation factories retain complete write-admission and tenant-validation context before preserving the existing owner implementation',
+  '✔ Durable inventory reservation admission and tenant-validation diagnostics are bounded while public routing and exact PortError returns remain unchanged',
 );


### PR DESCRIPTION
## Summary

- continue the ecommerce correlation-safe mapper cleanup at the canonical durable Inventory reservation wrapper
- preserve both `InventoryReservationIdentityPort` operations, public facade/factory names, admission and tenant-validation ordering, persistent-owner delegation, exact stable `code + message` local classification, severity, and every returned `PortError`
- remove complete `PortError` Debug/Display payloads from admission, tenant-validation, and post-delegation local events
- replace raw tenant/actor/channel/locale/causation/trace/idempotency values with bounded context shape
- replace raw reservation/variant/line-item UUIDs and exact quantity with presence, non-nil, sign, and non-zero facts
- retain external-ID length without recording external-ID text
- remove UUID parse-cause diagnostics while preserving the same trimmed tenant validation envelope
- replace debug-formatted error kinds with a closed seven-value label and retain stable code, retryability, and message presence/length
- update both focused fail-closed verifiers, add retained source/review evidence, and reconcile the local documentation and Inventory implementation plan

## Recheck

The ecommerce plan still keeps Inventory inside the broad correlation-safe mapper cleanup. The persistent owner in `ports.rs` was already bounded, but the canonical durable reservation wrapper in `reservation_owner_context.rs` still logged complete errors, raw delegated context, raw request identifiers, exact quantities, and tenant UUID parse causes. This PR closes that wrapper slice without changing owner behavior.

## Deliberate boundary

Inventory FFA remains `in_progress` and Inventory FBA remains `boundary_ready`. No request/response DTO, public API, policy, write-semantics rule, tenant acceptance rule, SQL, transaction, locking, replay, reservation state machine, backorder policy, persistence, dependency, workflow, CI configuration, or runtime-evidence status changes. The broader ecommerce cleanup remains open.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, CI, or mounted runtime validation was executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-inventory-reservation-owner-context.mjs
node scripts/verify/verify-inventory-reservation-local-context.mjs
node scripts/verify/verify-inventory-port-diagnostic-safety.mjs
cargo check -p rustok-inventory --lib
cargo check -p rustok-commerce --lib
```

Branch: `agent/inventory-policy-admission-diagnostics-20260801`
Base at source review: `fd27c7665f61fdacd3e8ebfa677d0569f87e05c6`
