### PR TITLE
test(forum): add correlated normal delivery proof

### DIFF
--- a/apps/server/tests/forum_versioned_invalidation_normal_delivery_iggy.rs
+++ b/apps/server/tests/forum_versioned_invalidation_normal_delivery_iggy.rs
@@ -1,0 +1,1351 @@
+use std::collections::BTreeSet;
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::io::{Error as IoError, ErrorKind};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use rustok_api::{PortError, RequestContext};
+use rustok_core::{MigrationSource, SecurityContext, UserRole, events::EventTransport};
+use rustok_events::{
+    ContractEventEnvelope, ContractEventPayload, DomainEvent, EventEnvelope,
+    ForumSearchProjectionEvent,
+};
+use rustok_forum::{
+    CategoryService, CreateCategoryInput, CreateTopicInput, ForumError, ForumEventService,
+    ForumModule, ForumProjectionOwnerRevisionImpact as ForumOwnerRevisionImpact,
+    ForumSearchProjectionSourceFactory, ForumSearchResultCandidate,
+    ForumSearchResultCandidateKind, ForumSearchResultEligibilityService, TopicService,
+};
+use rustok_iggy::{
+    ConsumedContractEvent, ExternalConfig, IggyConfig, IggyMode, IggyTransport,
+    PersistentContractConsumerGroup, PersistentContractDelivery, SerializationFormat,
+    TopologyConfig,
+};
+use rustok_outbox::{OutboxModule, OutboxTransport, TransactionalEventBus};
+use rustok_search::{
+    FORUM_SEARCH_CONTRACT_CONSUMER_GROUP, FORUM_SEARCH_CONTRACT_TOPIC,
+    ForumProjectionOwnerRevisionImpact as SearchOwnerRevisionImpact,
+    ForumProjectionOwnerRevisionRecord, ForumProjectionOwnerRevisionRequest,
+    ForumProjectionOwnerRevisionSourcePort, ForumProjectionOwnerTenantHead,
+    ForumProjectionOwnerTenantPageRequest, ForumProjectionReconciler,
+    ForumSearchContractIngress, ForumSearchContractIngressOutcome,
+    ForumStorefrontSearchAttributeFilter, ForumStorefrontSearchRequest, SearchModule,
+    SearchProjectionSourceFactory, SharedStorefrontSearchCategoryScopePort,
+    SharedStorefrontSearchResultEligibilityPort, StorefrontSearchCategoryScopePort,
+    StorefrontSearchCategoryScopeRequest, StorefrontSearchResultCandidate,
+    StorefrontSearchResultCandidateKind, StorefrontSearchResultEligibilityPort,
+    StorefrontSearchResultEligibilityRequest, StorefrontSearchTransport,
+    execute_forum_storefront_search,
+};
+use rustok_taxonomy::TaxonomyModule;
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
+};
+use sea_orm_migration::SchemaManager;
+use serde::Serialize;
+use serde_json::{Value as JsonValue, json};
+use tokio::time::timeout;
+use uuid::Uuid;
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+const SEARCH_TEST_DATABASE_ENV: &str = "RUSTOK_SEARCH_TEST_DATABASE_URL";
+const FORUM_TEST_DATABASE_ENV: &str = "RUSTOK_FORUM_TEST_DATABASE_URL";
+const IGGY_ADDRESS_ENV: &str = "RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS";
+const IGGY_USERNAME_ENV: &str = "RUSTOK_IGGY_EXTERNAL_TEST_USERNAME";
+const IGGY_PASSWORD_ENV: &str = "RUSTOK_IGGY_EXTERNAL_TEST_PASSWORD";
+const RECEIVE_TIMEOUT: Duration = Duration::from_secs(20);
+const ROOT_EVENT_TYPE: &str = "index.reindex_requested";
+const TYPED_EVENT_TYPE: &str = "forum.search_projection.invalidation_issued";
+const TOPIC_MARKER: &str = "d10normaldeliverytopic";
+const EVIDENCE_CONTRACT: &str =
+    "forum_search_versioned_invalidation_normal_delivery_evidence_v1";
+const EVIDENCE_PATH: &str =
+    "target/forum-search-versioned-invalidation-normal-delivery-evidence.json";
+
+struct PostgresNormalDeliveryEvidence {
+    control: DatabaseConnection,
+    db: DatabaseConnection,
+    schema_name: String,
+}
+
+impl PostgresNormalDeliveryEvidence {
+    async fn setup(scope: &str) -> TestResult<Option<Self>> {
+        let Some(database_url) = postgres_database_url() else {
+            eprintln!(
+                "{SEARCH_TEST_DATABASE_ENV} is not set to a PostgreSQL URL; skipping Forum normal-delivery proof"
+            );
+            return Ok(None);
+        };
+
+        let control = connect(&database_url, 1).await?;
+        let schema_name = format!(
+            "rustok_forum_normal_delivery_{}_{}",
+            sanitize_identifier(scope),
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let db = connect_in_schema(&database_url, &schema_name, 10).await?;
+        let setup_result = async {
+            db.execute_unprepared(
+                r#"
+                CREATE TABLE users (
+                    id UUID NOT NULL PRIMARY KEY,
+                    tenant_id UUID NOT NULL
+                )
+                "#,
+            )
+            .await?;
+            let manager = SchemaManager::new(&db);
+            for migration in OutboxModule.migrations() {
+                migration.up(&manager).await?;
+            }
+            for migration in TaxonomyModule.migrations() {
+                migration.up(&manager).await?;
+            }
+            for migration in ForumModule.migrations() {
+                migration.up(&manager).await?;
+            }
+            for migration in SearchModule.migrations() {
+                migration.up(&manager).await?;
+            }
+            create_checkpoint_audit(&db).await?;
+            Ok::<(), sea_orm::DbErr>(())
+        }
+        .await;
+        if let Err(error) = setup_result {
+            let _ = control
+                .execute_unprepared(&format!(r#"DROP SCHEMA IF EXISTS "{schema_name}" CASCADE"#))
+                .await;
+            return Err(error.into());
+        }
+
+        Ok(Some(Self {
+            control,
+            db,
+            schema_name,
+        }))
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct RealForumOwnerRevisionSource {
+    db: DatabaseConnection,
+}
+
+#[async_trait]
+impl ForumProjectionOwnerRevisionSourcePort for RealForumOwnerRevisionSource {
+    async fn list_owner_revisions(
+        &self,
+        request: ForumProjectionOwnerRevisionRequest,
+    ) -> Result<Vec<ForumProjectionOwnerRevisionRecord>, PortError> {
+        let revisions = ForumEventService::new(self.db.clone())
+            .list_projection_owner_revisions(
+                request.tenant_id,
+                request.after_owner_revision,
+                request.limit,
+            )
+            .await
+            .map_err(map_forum_owner_error)?;
+        Ok(revisions
+            .into_iter()
+            .map(|revision| ForumProjectionOwnerRevisionRecord {
+                owner_revision: revision.owner_revision,
+                event_id: revision.event_id,
+                event_type: revision.event_type,
+                impact: match revision.impact {
+                    ForumOwnerRevisionImpact::FullRebuild => {
+                        SearchOwnerRevisionImpact::FullRebuild
+                    }
+                },
+            })
+            .collect())
+    }
+
+    async fn list_owner_revision_tenants(
+        &self,
+        request: ForumProjectionOwnerTenantPageRequest,
+    ) -> Result<Vec<ForumProjectionOwnerTenantHead>, PortError> {
+        let heads = ForumEventService::new(self.db.clone())
+            .list_projection_owner_revision_tenants(request.after_tenant_id, request.limit)
+            .await
+            .map_err(map_forum_owner_error)?;
+        Ok(heads
+            .into_iter()
+            .map(|head| ForumProjectionOwnerTenantHead {
+                tenant_id: head.tenant_id,
+                latest_owner_revision: head.latest_owner_revision,
+            })
+            .collect())
+    }
+}
+
+fn map_forum_owner_error(_error: ForumError) -> PortError {
+    PortError::unavailable(
+        "forum.search_projection_owner_revision.normal_delivery_unavailable",
+        "Forum projection owner revision source is temporarily unavailable",
+    )
+}
+
+#[derive(Clone)]
+struct ExactCategoryScopePort;
+
+#[async_trait]
+impl StorefrontSearchCategoryScopePort for ExactCategoryScopePort {
+    async fn expand_forum_category_scope(
+        &self,
+        request: StorefrontSearchCategoryScopeRequest,
+    ) -> Result<Vec<Uuid>, PortError> {
+        Ok(request.category_ids)
+    }
+}
+
+#[derive(Clone)]
+struct RealForumPublicEligibilityPort {
+    db: DatabaseConnection,
+}
+
+#[async_trait]
+impl StorefrontSearchResultEligibilityPort for RealForumPublicEligibilityPort {
+    async fn filter_forum_result_candidates(
+        &self,
+        request: StorefrontSearchResultEligibilityRequest,
+    ) -> Result<Vec<StorefrontSearchResultCandidate>, PortError> {
+        let candidates = request
+            .candidates
+            .iter()
+            .copied()
+            .map(to_forum_candidate)
+            .collect::<Vec<_>>();
+        let channel_slug = request
+            .request_context
+            .as_ref()
+            .and_then(|context| context.channel_slug.as_deref());
+        let allowed = ForumSearchResultEligibilityService::new(self.db.clone())
+            .filter_public_storefront_visible(request.tenant_id, channel_slug, &candidates)
+            .await
+            .map_err(|_| {
+                PortError::unavailable(
+                    "forum.search_projection.normal_delivery_eligibility_unavailable",
+                    "Forum Search result eligibility is temporarily unavailable",
+                )
+            })?;
+        Ok(allowed.into_iter().map(from_forum_candidate).collect())
+    }
+}
+
+fn to_forum_candidate(candidate: StorefrontSearchResultCandidate) -> ForumSearchResultCandidate {
+    ForumSearchResultCandidate {
+        document_id: candidate.document_id,
+        kind: match candidate.kind {
+            StorefrontSearchResultCandidateKind::ForumTopic => {
+                ForumSearchResultCandidateKind::Topic
+            }
+            StorefrontSearchResultCandidateKind::ForumReply => {
+                ForumSearchResultCandidateKind::Reply
+            }
+        },
+    }
+}
+
+fn from_forum_candidate(candidate: ForumSearchResultCandidate) -> StorefrontSearchResultCandidate {
+    StorefrontSearchResultCandidate {
+        document_id: candidate.document_id,
+        kind: match candidate.kind {
+            ForumSearchResultCandidateKind::Topic => {
+                StorefrontSearchResultCandidateKind::ForumTopic
+            }
+            ForumSearchResultCandidateKind::Reply => {
+                StorefrontSearchResultCandidateKind::ForumReply
+            }
+        },
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ForumFixture {
+    tenant_id: Uuid,
+    category_id: Uuid,
+    topic_id: Uuid,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+struct OwnerRevisionRow {
+    revision: i64,
+    event_id: Uuid,
+    target_type: String,
+    target_id: Option<Uuid>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct BrokerDeliveryFact {
+    owner_revision: i64,
+    root_event_id: Uuid,
+    typed_envelope_id: Uuid,
+    offset: u64,
+    ingest_sequence: i64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct InboxRow {
+    event_id: Uuid,
+    ingest_sequence: i64,
+    scope_key: String,
+    status: String,
+    attempt_count: i32,
+    envelope_json: JsonValue,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct CheckpointAuditRow {
+    sequence: i64,
+    owner_revision: i64,
+    event_id: Uuid,
+    outcome: String,
+    observed_forum_documents: i64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct CheckpointSnapshot {
+    owner_revision: i64,
+    event_id: Uuid,
+    outcome: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct SearchDocumentRow {
+    document_id: Uuid,
+    entity_type: String,
+    status: String,
+    title: String,
+    body: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ScenarioEvidence {
+    id: &'static str,
+    result: &'static str,
+    facts: JsonValue,
+}
+
+#[derive(Debug, Serialize)]
+struct NormalDeliveryEvidenceArtifact {
+    contract: &'static str,
+    task: &'static str,
+    source_commit: String,
+    generated_at: String,
+    database_backend: &'static str,
+    delivery_profile: &'static str,
+    consumer_group: &'static str,
+    stream: String,
+    topic: &'static str,
+    scenario_results: Vec<ScenarioEvidence>,
+}
+
+#[tokio::test]
+async fn normal_owner_delivery_projects_and_checkpoints_exactly_once() -> TestResult<()> {
+    let Some(config) = external_test_config()? else {
+        eprintln!(
+            "{IGGY_ADDRESS_ENV} is not set; skipping Forum normal-delivery Iggy proof"
+        );
+        return Ok(());
+    };
+    let Some(evidence) = PostgresNormalDeliveryEvidence::setup("normal").await? else {
+        return Ok(());
+    };
+
+    let stream = config.topology.stream_name.clone();
+    let proof = run_normal_delivery_proof(&evidence.db, config).await;
+    let cleanup = evidence.cleanup().await;
+    let scenario = proof?;
+    cleanup?;
+
+    write_evidence(NormalDeliveryEvidenceArtifact {
+        contract: EVIDENCE_CONTRACT,
+        task: "FORUM-23B2G2B3D10",
+        source_commit: source_commit()?,
+        generated_at: Utc::now().to_rfc3339(),
+        database_backend: "postgresql",
+        delivery_profile: "outbox_iggy",
+        consumer_group: FORUM_SEARCH_CONTRACT_CONSUMER_GROUP,
+        stream,
+        topic: FORUM_SEARCH_CONTRACT_TOPIC,
+        scenario_results: vec![scenario],
+    })?;
+    Ok(())
+}
+
+async fn run_normal_delivery_proof(
+    db: &DatabaseConnection,
+    config: IggyConfig,
+) -> TestResult<ScenarioEvidence> {
+    let fixture = create_forum_fixture(db).await?;
+    let revisions = load_owner_revisions(db, fixture.tenant_id).await?;
+    ensure_owner_revision_shape(&revisions, fixture)?;
+    let roots = load_root_envelopes(db, fixture.tenant_id).await?;
+    let typed = load_typed_envelopes(db, fixture.tenant_id).await?;
+    ensure_owner_event_identity(&revisions, &roots, &typed, fixture)?;
+
+    if count_rows(db, "search_projection_inbox").await? != 0
+        || count_rows(db, "search_projection_owner_checkpoints").await? != 0
+        || count_forum_documents(db, fixture.tenant_id).await? != 0
+    {
+        return Err(test_error(
+            "normal-delivery fixture started with unexpected Search state",
+        ));
+    }
+
+    let transport = IggyTransport::new(config).await?;
+    let transport_proof = async {
+        let group = transport
+            .open_persistent_contract_consumer_group(
+                FORUM_SEARCH_CONTRACT_CONSUMER_GROUP,
+                FORUM_SEARCH_CONTRACT_TOPIC,
+            )
+            .await?;
+        for envelope in &typed {
+            transport.publish_contract(envelope.clone()).await?;
+        }
+
+        let ingress = ForumSearchContractIngress::new(db.clone());
+        let mut deliveries = Vec::new();
+        for (revision, expected) in revisions.iter().zip(&typed) {
+            let delivery = receive_event(&group).await?;
+            ensure_delivery_identity(&delivery, expected, revision, fixture.tenant_id)?;
+            let offset = delivery
+                .offset()
+                .ok_or_else(|| test_error("normal Iggy delivery has no broker offset"))?;
+            ensure_durable_outcome(
+                ingress.ingest(&delivery.envelope).await?,
+                revision.event_id,
+                revision.revision,
+            )?;
+            let inbox = load_inbox_row(db, revision.event_id).await?;
+            ensure_pending_inbox(&inbox, revision, fixture)?;
+            group.acknowledge(&delivery).await?;
+            deliveries.push(BrokerDeliveryFact {
+                owner_revision: revision.revision,
+                root_event_id: revision.event_id,
+                typed_envelope_id: expected.id(),
+                offset,
+                ingest_sequence: inbox.ingest_sequence,
+            });
+        }
+        drop(group);
+        Ok::<Vec<BrokerDeliveryFact>, Box<dyn Error + Send + Sync>>(deliveries)
+    }
+    .await;
+    let shutdown = transport.shutdown().await;
+    let deliveries = transport_proof?;
+    shutdown?;
+
+    if deliveries.len() != 2
+        || deliveries[1].offset <= deliveries[0].offset
+        || deliveries[1].ingest_sequence <= deliveries[0].ingest_sequence
+    {
+        return Err(test_error(format!(
+            "normal delivery did not preserve independent monotonic broker and inbox order: {deliveries:?}"
+        )));
+    }
+
+    let projection_source = ForumSearchProjectionSourceFactory.build(db.clone());
+    let owner_source = Arc::new(RealForumOwnerRevisionSource { db: db.clone() });
+    let reconciler = ForumProjectionReconciler::with_owner_revision_source(
+        db.clone(),
+        projection_source,
+        owner_source,
+    );
+    let report = reconciler.sweep_due(8, 8).await?;
+    if report.due_tenants != 1
+        || report.claimed_events != 2
+        || report.completed_events != 2
+        || report.failed_events != 0
+        || report.owner_tenants_scanned != 1
+        || report.owner_tenants_reconciled != 1
+        || report.owner_tenants_blocked != 0
+        || report.owner_tenants_failed != 0
+        || report.owner_revisions_checkpointed != 2
+        || report.owner_rebuilds != 0
+    {
+        return Err(test_error(format!(
+            "normal delivery produced an unexpected reconciler report: {report:?}"
+        )));
+    }
+
+    let completed_inbox = load_inbox_rows(db, fixture.tenant_id).await?;
+    if completed_inbox.len() != 2
+        || completed_inbox
+            .iter()
+            .any(|row| row.status != "completed" || row.attempt_count != 1)
+    {
+        return Err(test_error(format!(
+            "normal delivery did not complete exactly two inbox rows once: {completed_inbox:?}"
+        )));
+    }
+
+    let checkpoint = load_checkpoint(db, fixture.tenant_id)
+        .await?
+        .ok_or_else(|| test_error("normal delivery did not create an owner checkpoint"))?;
+    if checkpoint.owner_revision != 2
+        || checkpoint.event_id != revisions[1].event_id
+        || checkpoint.outcome != "delivery_covered"
+    {
+        return Err(test_error(format!(
+            "normal delivery stored an unexpected final checkpoint: {checkpoint:?}"
+        )));
+    }
+    let audit = load_checkpoint_audit(db, fixture.tenant_id).await?;
+    if audit.iter().map(|row| row.owner_revision).collect::<Vec<_>>() != [1, 2]
+        || audit.iter().map(|row| row.event_id).collect::<Vec<_>>()
+            != revisions.iter().map(|row| row.event_id).collect::<Vec<_>>()
+        || audit.iter().any(|row| {
+            row.outcome != "delivery_covered" || row.observed_forum_documents != 2
+        })
+    {
+        return Err(test_error(format!(
+            "normal delivery checkpoint audit drifted from projection-before-checkpoint ordering: {audit:?}"
+        )));
+    }
+
+    let documents = load_forum_documents(db, fixture.tenant_id).await?;
+    ensure_projected_documents(&documents, fixture)?;
+    let storefront_total = assert_storefront_topic(db, fixture).await?;
+
+    let caught_up = reconciler.sweep_due(8, 8).await?;
+    if caught_up.due_tenants != 0
+        || caught_up.claimed_events != 0
+        || caught_up.completed_events != 0
+        || caught_up.owner_tenants_reconciled != 0
+        || caught_up.owner_revisions_checkpointed != 0
+        || caught_up.owner_rebuilds != 0
+        || load_checkpoint_audit(db, fixture.tenant_id).await?.len() != 2
+    {
+        return Err(test_error(format!(
+            "caught-up normal delivery repeated projection or checkpoint work: {caught_up:?}"
+        )));
+    }
+
+    Ok(ScenarioEvidence {
+        id: "normal_delivery",
+        result: "passed",
+        facts: json!({
+            "tenant_id": fixture.tenant_id,
+            "category_id": fixture.category_id,
+            "topic_id": fixture.topic_id,
+            "owner_revision_rows": revisions,
+            "legacy_root_event_ids": roots.iter().map(|envelope| envelope.id).collect::<Vec<_>>(),
+            "typed_envelope_ids": typed.iter().map(ContractEventEnvelope::id).collect::<Vec<_>>(),
+            "typed_causation_ids": typed.iter().map(ContractEventEnvelope::causation_id).collect::<Vec<_>>(),
+            "broker_deliveries": deliveries,
+            "completed_inbox_rows": completed_inbox,
+            "reconciler_claimed_events": report.claimed_events,
+            "reconciler_completed_events": report.completed_events,
+            "owner_revisions_checkpointed": report.owner_revisions_checkpointed,
+            "owner_repair_rebuilds": report.owner_rebuilds,
+            "checkpoint_audit_revisions": audit.iter().map(|row| row.owner_revision).collect::<Vec<_>>(),
+            "checkpoint_audit_outcomes": audit.iter().map(|row| row.outcome.clone()).collect::<Vec<_>>(),
+            "checkpoint_audit_document_counts": audit.iter().map(|row| row.observed_forum_documents).collect::<Vec<_>>(),
+            "final_checkpoint_revision": checkpoint.owner_revision,
+            "final_checkpoint_event_id": checkpoint.event_id,
+            "final_checkpoint_outcome": checkpoint.outcome,
+            "projected_documents": documents,
+            "storefront_topic_total": storefront_total,
+            "caught_up_repeat_claims": caught_up.claimed_events,
+            "caught_up_repeat_checkpoint_advances": caught_up.owner_revisions_checkpointed
+        }),
+    })
+}
+
+async fn create_forum_fixture(db: &DatabaseConnection) -> TestResult<ForumFixture> {
+    let tenant_id = Uuid::new_v4();
+    let admin_id = Uuid::new_v4();
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "INSERT INTO users (id, tenant_id) VALUES ($1, $2)",
+        vec![admin_id.into(), tenant_id.into()],
+    ))
+    .await?;
+
+    let category = CategoryService::new(db.clone())
+        .create(
+            tenant_id,
+            SecurityContext::new(UserRole::Admin, Some(admin_id)),
+            CreateCategoryInput {
+                locale: "en".to_string(),
+                name: "D10 normal delivery category".to_string(),
+                slug: "d10-normal-delivery-category".to_string(),
+                description: Some("Normal delivery owner fixture".to_string()),
+                icon: None,
+                color: None,
+                parent_id: None,
+                position: Some(0),
+                moderated: false,
+            },
+        )
+        .await?;
+
+    let topic = TopicService::new(db.clone(), event_bus(db.clone()))
+        .create(
+            tenant_id,
+            SecurityContext::new(UserRole::Customer, None),
+            CreateTopicInput {
+                locale: "en".to_string(),
+                category_id: category.id,
+                title: format!("D10 normal delivery {TOPIC_MARKER}"),
+                slug: Some("d10-normal-delivery-topic".to_string()),
+                body: format!("Current Forum owner body {TOPIC_MARKER}"),
+                body_format: "markdown".to_string(),
+                content_json: None,
+                metadata: json!({}),
+                tags: Vec::new(),
+                channel_slugs: None,
+            },
+        )
+        .await?;
+
+    Ok(ForumFixture {
+        tenant_id,
+        category_id: category.id,
+        topic_id: topic.id,
+    })
+}
+
+fn event_bus(db: DatabaseConnection) -> TransactionalEventBus {
+    TransactionalEventBus::new(Arc::new(OutboxTransport::new(db)))
+}
+
+async fn load_owner_revisions(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+) -> TestResult<Vec<OwnerRevisionRow>> {
+    db.query_all(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+        SELECT revision, event_id, target_type, target_id
+        FROM forum_projection_revision_ledger
+        WHERE tenant_id = $1
+        ORDER BY revision ASC
+        "#,
+        vec![tenant_id.into()],
+    ))
+    .await?
+    .into_iter()
+    .map(|row| {
+        Ok(OwnerRevisionRow {
+            revision: row.try_get("", "revision")?,
+            event_id: row.try_get("", "event_id")?,
+            target_type: row.try_get("", "target_type")?,
+            target_id: row.try_get("", "target_id")?,
+        })
+    })
+    .collect::<Result<Vec<_>, sea_orm::DbErr>>()
+    .map_err(Into::into)
+}
+
+fn ensure_owner_revision_shape(
+    revisions: &[OwnerRevisionRow],
+    fixture: ForumFixture,
+) -> TestResult<()> {
+    if revisions.len() != 2
+        || revisions[0].revision != 1
+        || revisions[0].target_type != "forum"
+        || revisions[0].target_id.is_some()
+        || revisions[1].revision != 2
+        || revisions[1].target_type != "forum_category"
+        || revisions[1].target_id != Some(fixture.category_id)
+    {
+        return Err(test_error(format!(
+            "normal delivery owner revisions have an unexpected shape: {revisions:?}"
+        )));
+    }
+    Ok(())
+}
+
+async fn load_root_envelopes(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+) -> TestResult<Vec<EventEnvelope>> {
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT payload FROM sys_events WHERE event_type = $1 ORDER BY created_at ASC",
+            vec![ROOT_EVENT_TYPE.to_string().into()],
+        ))
+        .await?;
+    let mut envelopes = Vec::new();
+    for row in rows {
+        let payload: JsonValue = row.try_get("", "payload")?;
+        let envelope: EventEnvelope = serde_json::from_value(payload)?;
+        if envelope.tenant_id == tenant_id {
+            envelopes.push(envelope);
+        }
+    }
+    Ok(envelopes)
+}
+
+async fn load_typed_envelopes(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+) -> TestResult<Vec<ContractEventEnvelope>> {
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT payload FROM sys_events WHERE event_type = $1 ORDER BY created_at ASC",
+            vec![TYPED_EVENT_TYPE.to_string().into()],
+        ))
+        .await?;
+    let mut envelopes = Vec::new();
+    for row in rows {
+        let payload: JsonValue = row.try_get("", "payload")?;
+        let envelope: ContractEventEnvelope = serde_json::from_value(payload)?;
+        if envelope.tenant_id() == tenant_id {
+            envelopes.push(envelope);
+        }
+    }
+    Ok(envelopes)
+}
+
+fn ensure_owner_event_identity(
+    revisions: &[OwnerRevisionRow],
+    roots: &[EventEnvelope],
+    typed: &[ContractEventEnvelope],
+    fixture: ForumFixture,
+) -> TestResult<()> {
+    if roots.len() != 2 || typed.len() != 2 {
+        return Err(test_error(format!(
+            "normal delivery expected two root and two typed events: roots={}, typed={}",
+            roots.len(),
+            typed.len()
+        )));
+    }
+    let root_ids = roots.iter().map(|envelope| envelope.id).collect::<BTreeSet<_>>();
+    let revision_ids = revisions
+        .iter()
+        .map(|revision| revision.event_id)
+        .collect::<BTreeSet<_>>();
+    if root_ids != revision_ids {
+        return Err(test_error(format!(
+            "normal delivery ledger and root event identities diverged: roots={root_ids:?}, revisions={revision_ids:?}"
+        )));
+    }
+
+    for (revision, envelope) in revisions.iter().zip(typed) {
+        envelope.validate_registered_schema()?;
+        if envelope.tenant_id() != fixture.tenant_id
+            || envelope.causation_id() != Some(revision.event_id)
+            || envelope.id() == revision.event_id
+            || envelope.event_type() != TYPED_EVENT_TYPE
+            || envelope.schema_version() != 1
+        {
+            return Err(test_error(format!(
+                "typed normal-delivery envelope lost transport/root identity: {envelope:?}"
+            )));
+        }
+        match envelope.payload()? {
+            ContractEventPayload::ForumSearchProjection(
+                ForumSearchProjectionEvent::InvalidationIssued {
+                    owner_revision,
+                    target_type,
+                    target_id,
+                },
+            ) if *owner_revision == revision.revision
+                && target_type == &revision.target_type
+                && *target_id == revision.target_id => {}
+            payload => {
+                return Err(test_error(format!(
+                    "typed normal-delivery payload does not match owner revision: {payload:?}"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn receive_event(
+    group: &PersistentContractConsumerGroup,
+) -> TestResult<ConsumedContractEvent> {
+    let delivery = timeout(RECEIVE_TIMEOUT, group.receive_delivery())
+        .await
+        .map_err(|_| test_error("timed out waiting for a normal Forum Iggy delivery"))??
+        .ok_or_else(|| test_error("Iggy consumer group ended before normal delivery"))?;
+    match delivery {
+        PersistentContractDelivery::Event(consumed) => Ok(consumed),
+        PersistentContractDelivery::DecodeFailure(failure) => Err(test_error(format!(
+            "normal Forum typed event decoded as poison: {}",
+            failure.stable_error_code()
+        ))),
+    }
+}
+
+fn ensure_delivery_identity(
+    delivery: &ConsumedContractEvent,
+    expected: &ContractEventEnvelope,
+    revision: &OwnerRevisionRow,
+    tenant_id: Uuid,
+) -> TestResult<()> {
+    if delivery.topic != FORUM_SEARCH_CONTRACT_TOPIC
+        || delivery.envelope != *expected
+        || delivery.envelope.id() != expected.id()
+        || delivery.envelope.causation_id() != Some(revision.event_id)
+        || delivery.envelope.tenant_id() != tenant_id
+        || delivery.offset().is_none()
+        || delivery.ack_token().is_none()
+        || delivery.raw_payload().is_empty()
+    {
+        return Err(test_error(format!(
+            "normal Iggy delivery identity drifted: {delivery:?}"
+        )));
+    }
+    delivery.validate_connector_metadata()?;
+    delivery.envelope.validate_registered_schema()?;
+    Ok(())
+}
+
+fn ensure_durable_outcome(
+    outcome: ForumSearchContractIngressOutcome,
+    root_event_id: Uuid,
+    owner_revision: i64,
+) -> TestResult<()> {
+    match outcome {
+        ForumSearchContractIngressOutcome::DurablyAccepted {
+            root_event_id: actual_root,
+            owner_revision: actual_revision,
+        } if actual_root == root_event_id && actual_revision == owner_revision => Ok(()),
+        other => Err(test_error(format!(
+            "normal delivery ingress returned an unexpected outcome: {other:?}"
+        ))),
+    }
+}
+
+async fn load_inbox_row(db: &DatabaseConnection, event_id: Uuid) -> TestResult<InboxRow> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+            SELECT event_id, ingest_sequence, scope_key, status, attempt_count, envelope_json
+            FROM search_projection_inbox
+            WHERE event_id = $1
+            "#,
+            vec![event_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| test_error(format!("normal Search inbox row {event_id} was not found")))?;
+    Ok(InboxRow {
+        event_id: row.try_get("", "event_id")?,
+        ingest_sequence: row.try_get("", "ingest_sequence")?,
+        scope_key: row.try_get("", "scope_key")?,
+        status: row.try_get("", "status")?,
+        attempt_count: row.try_get("", "attempt_count")?,
+        envelope_json: row.try_get("", "envelope_json")?,
+    })
+}
+
+async fn load_inbox_rows(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+) -> TestResult<Vec<InboxRow>> {
+    db.query_all(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+        SELECT event_id, ingest_sequence, scope_key, status, attempt_count, envelope_json
+        FROM search_projection_inbox
+        WHERE tenant_id = $1 AND source_module = 'forum'
+        ORDER BY ingest_sequence ASC
+        "#,
+        vec![tenant_id.into()],
+    ))
+    .await?
+    .into_iter()
+    .map(|row| {
+        Ok(InboxRow {
+            event_id: row.try_get("", "event_id")?,
+            ingest_sequence: row.try_get("", "ingest_sequence")?,
+            scope_key: row.try_get("", "scope_key")?,
+            status: row.try_get("", "status")?,
+            attempt_count: row.try_get("", "attempt_count")?,
+            envelope_json: row.try_get("", "envelope_json")?,
+        })
+    })
+    .collect::<Result<Vec<_>, sea_orm::DbErr>>()
+    .map_err(Into::into)
+}
+
+fn ensure_pending_inbox(
+    inbox: &InboxRow,
+    revision: &OwnerRevisionRow,
+    fixture: ForumFixture,
+) -> TestResult<()> {
+    let root: EventEnvelope = serde_json::from_value(inbox.envelope_json.clone())?;
+    let expected_scope = if revision.target_type == "forum" {
+        "forum".to_string()
+    } else {
+        format!("forum_category:{}", fixture.category_id)
+    };
+    if inbox.event_id != revision.event_id
+        || inbox.ingest_sequence <= 0
+        || inbox.scope_key != expected_scope
+        || inbox.status != "pending"
+        || inbox.attempt_count != 0
+        || root.id != revision.event_id
+        || root.tenant_id != fixture.tenant_id
+        || root.event_type != ROOT_EVENT_TYPE
+        || root.causation_id.is_some()
+        || !matches!(
+            root.event,
+            DomainEvent::ReindexRequested {
+                ref target_type,
+                target_id,
+            } if target_type == &revision.target_type && target_id == revision.target_id
+        )
+    {
+        return Err(test_error(format!(
+            "normal delivery created an unexpected pending inbox row: {inbox:?}"
+        )));
+    }
+    root.validate_registered_schema()?;
+    Ok(())
+}
+
+async fn create_checkpoint_audit(db: &DatabaseConnection) -> Result<(), sea_orm::DbErr> {
+    db.execute_unprepared(
+        r#"
+        CREATE TABLE forum_normal_delivery_checkpoint_audit (
+            sequence BIGSERIAL PRIMARY KEY,
+            tenant_id UUID NOT NULL,
+            owner_revision BIGINT NOT NULL,
+            event_id UUID NOT NULL,
+            outcome VARCHAR(32) NOT NULL,
+            observed_forum_documents BIGINT NOT NULL
+        );
+
+        CREATE OR REPLACE FUNCTION forum_capture_normal_delivery_checkpoint()
+        RETURNS trigger AS $$
+        BEGIN
+            INSERT INTO forum_normal_delivery_checkpoint_audit (
+                tenant_id, owner_revision, event_id, outcome,
+                observed_forum_documents
+            ) VALUES (
+                NEW.tenant_id,
+                NEW.owner_revision,
+                NEW.event_id,
+                NEW.outcome,
+                (
+                    SELECT COUNT(*)::BIGINT
+                    FROM search_documents
+                    WHERE tenant_id = NEW.tenant_id
+                      AND source_module = 'forum'
+                )
+            );
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+
+        CREATE TRIGGER forum_normal_delivery_checkpoint_audit
+        AFTER INSERT OR UPDATE ON search_projection_owner_checkpoints
+        FOR EACH ROW EXECUTE FUNCTION forum_capture_normal_delivery_checkpoint();
+        "#,
+    )
+    .await?;
+    Ok(())
+}
+
+async fn load_checkpoint(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+) -> TestResult<Option<CheckpointSnapshot>> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+            SELECT owner_revision, event_id, outcome
+            FROM search_projection_owner_checkpoints
+            WHERE tenant_id = $1 AND source_module = 'forum'
+            "#,
+            vec![tenant_id.into()],
+        ))
+        .await?;
+    row.map(|row| {
+        Ok(CheckpointSnapshot {
+            owner_revision: row.try_get("", "owner_revision")?,
+            event_id: row.try_get("", "event_id")?,
+            outcome: row.try_get("", "outcome")?,
+        })
+    })
+    .transpose()
+    .map_err(Into::into)
+}
+
+async fn load_checkpoint_audit(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+) -> TestResult<Vec<CheckpointAuditRow>> {
+    db.query_all(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+        SELECT sequence, owner_revision, event_id, outcome, observed_forum_documents
+        FROM forum_normal_delivery_checkpoint_audit
+        WHERE tenant_id = $1
+        ORDER BY sequence ASC
+        "#,
+        vec![tenant_id.into()],
+    ))
+    .await?
+    .into_iter()
+    .map(|row| {
+        Ok(CheckpointAuditRow {
+            sequence: row.try_get("", "sequence")?,
+            owner_revision: row.try_get("", "owner_revision")?,
+            event_id: row.try_get("", "event_id")?,
+            outcome: row.try_get("", "outcome")?,
+            observed_forum_documents: row.try_get("", "observed_forum_documents")?,
+        })
+    })
+    .collect::<Result<Vec<_>, sea_orm::DbErr>>()
+    .map_err(Into::into)
+}
+
+async fn load_forum_documents(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+) -> TestResult<Vec<SearchDocumentRow>> {
+    db.query_all(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+        SELECT document_id, entity_type, status, title, body
+        FROM search_documents
+        WHERE tenant_id = $1 AND source_module = 'forum'
+        ORDER BY entity_type ASC, document_id ASC
+        "#,
+        vec![tenant_id.into()],
+    ))
+    .await?
+    .into_iter()
+    .map(|row| {
+        Ok(SearchDocumentRow {
+            document_id: row.try_get("", "document_id")?,
+            entity_type: row.try_get("", "entity_type")?,
+            status: row.try_get("", "status")?,
+            title: row.try_get("", "title")?,
+            body: row.try_get("", "body")?,
+        })
+    })
+    .collect::<Result<Vec<_>, sea_orm::DbErr>>()
+    .map_err(Into::into)
+}
+
+fn ensure_projected_documents(
+    documents: &[SearchDocumentRow],
+    fixture: ForumFixture,
+) -> TestResult<()> {
+    if documents.len() != 2 {
+        return Err(test_error(format!(
+            "normal delivery projected {} Forum documents instead of two: {documents:?}",
+            documents.len()
+        )));
+    }
+    let category = documents
+        .iter()
+        .find(|document| document.document_id == fixture.category_id)
+        .ok_or_else(|| test_error("normal delivery omitted the Forum category"))?;
+    let topic = documents
+        .iter()
+        .find(|document| document.document_id == fixture.topic_id)
+        .ok_or_else(|| test_error("normal delivery omitted the Forum topic"))?;
+    if category.entity_type != "forum_category"
+        || category.status != "public"
+        || category.title != "D10 normal delivery category"
+        || topic.entity_type != "forum_topic"
+        || topic.status != "open"
+        || !topic.title.contains(TOPIC_MARKER)
+        || !topic.body.contains(TOPIC_MARKER)
+    {
+        return Err(test_error(format!(
+            "normal delivery projected unexpected current Forum documents: {documents:?}"
+        )));
+    }
+    Ok(())
+}
+
+async fn assert_storefront_topic(
+    db: &DatabaseConnection,
+    fixture: ForumFixture,
+) -> TestResult<u64> {
+    let category_scope: SharedStorefrontSearchCategoryScopePort = Arc::new(ExactCategoryScopePort);
+    let eligibility: SharedStorefrontSearchResultEligibilityPort =
+        Arc::new(RealForumPublicEligibilityPort { db: db.clone() });
+    let execution = execute_forum_storefront_search(
+        db,
+        Some(category_scope),
+        Some(eligibility),
+        ForumStorefrontSearchRequest {
+            tenant_id: fixture.tenant_id,
+            query: TOPIC_MARKER.to_string(),
+            locale: Some("en".to_string()),
+            fallback_locale: "en".to_string(),
+            channel_id: None,
+            current_channel_only: None,
+            limit: Some(10),
+            offset: Some(0),
+            ranking_profile: None,
+            preset_key: None,
+            entity_types: vec!["forum_topic".to_string()],
+            source_modules: vec!["forum".to_string()],
+            statuses: vec!["open".to_string()],
+            category_ids: vec![fixture.category_id.to_string()],
+            author_ids: Vec::new(),
+            tags: Vec::new(),
+            solved: None,
+            published_from: None,
+            published_to: None,
+            attribute_filters: Vec::<ForumStorefrontSearchAttributeFilter>::new(),
+            sort_attribute_code: None,
+            sort_desc: false,
+            auth: None,
+            request_context: Some(RequestContext {
+                tenant_id: fixture.tenant_id,
+                user_id: None,
+                channel_id: None,
+                channel_slug: None,
+                channel_resolution_source: None,
+                locale: "en".to_string(),
+            }),
+            transport: StorefrontSearchTransport::Graphql,
+        },
+    )
+    .await?;
+    if execution.result.total != 1
+        || execution.result.items.len() != 1
+        || execution.result.items[0].id != fixture.topic_id
+    {
+        return Err(test_error(format!(
+            "normal delivery storefront Search did not return the exact topic: {:?}",
+            execution.result
+        )));
+    }
+    Ok(execution.result.total)
+}
+
+async fn count_rows(db: &DatabaseConnection, table: &str) -> TestResult<i64> {
+    if !matches!(
+        table,
+        "search_projection_inbox" | "search_projection_owner_checkpoints"
+    ) {
+        return Err(test_error("count_rows received an unsupported table"));
+    }
+    scalar_i64(
+        db,
+        Statement::from_string(
+            DbBackend::Postgres,
+            format!("SELECT COUNT(*)::BIGINT AS value FROM {table}"),
+        ),
+    )
+    .await
+}
+
+async fn count_forum_documents(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+) -> TestResult<i64> {
+    scalar_i64(
+        db,
+        Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT COUNT(*)::BIGINT AS value FROM search_documents WHERE tenant_id = $1 AND source_module = 'forum'",
+            vec![tenant_id.into()],
+        ),
+    )
+    .await
+}
+
+async fn scalar_i64(db: &DatabaseConnection, statement: Statement) -> TestResult<i64> {
+    let row = db
+        .query_one(statement)
+        .await?
+        .ok_or_else(|| test_error("scalar query returned no row"))?;
+    Ok(row.try_get("", "value")?)
+}
+
+fn external_test_config() -> TestResult<Option<IggyConfig>> {
+    let address = match env::var(IGGY_ADDRESS_ENV) {
+        Ok(value) => bounded_env(IGGY_ADDRESS_ENV, value, 255)?,
+        Err(env::VarError::NotPresent) => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    if address.contains("://") || address.contains('@') || address.contains('?') {
+        return Err(test_error(
+            "RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS must be host:port without credentials or query parameters",
+        ));
+    }
+    let username = optional_bounded_env(IGGY_USERNAME_ENV, 191)?;
+    let password = optional_bounded_env(IGGY_PASSWORD_ENV, 191)?;
+    if username.is_empty() != password.is_empty() {
+        return Err(test_error(
+            "external Iggy evidence username and password must both be set or both be empty",
+        ));
+    }
+    Ok(Some(IggyConfig {
+        mode: IggyMode::External,
+        serialization: SerializationFormat::Json,
+        external: ExternalConfig {
+            addresses: vec![address],
+            protocol: "tcp".to_string(),
+            username,
+            password,
+            tls_enabled: false,
+            tls_domain: None,
+            tls_ca_file: None,
+        },
+        topology: TopologyConfig {
+            stream_name: unique_name("normal"),
+            domain_partitions: 1,
+            replication_factor: 1,
+        },
+        ..IggyConfig::default()
+    }))
+}
+
+fn optional_bounded_env(name: &'static str, max_len: usize) -> TestResult<String> {
+    match env::var(name) {
+        Ok(value) => Ok(bounded_env(name, value, max_len)?),
+        Err(env::VarError::NotPresent) => Ok(String::new()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn bounded_env(name: &'static str, value: String, max_len: usize) -> Result<String, IoError> {
+    if value.trim() != value || value.is_empty() {
+        return Err(IoError::new(
+            ErrorKind::InvalidData,
+            format!("{name} must be non-empty and have no surrounding whitespace"),
+        ));
+    }
+    if value.len() > max_len {
+        return Err(IoError::new(
+            ErrorKind::InvalidData,
+            format!("{name} exceeds the evidence limit"),
+        ));
+    }
+    if value.chars().any(char::is_control) {
+        return Err(IoError::new(
+            ErrorKind::InvalidData,
+            format!("{name} must not contain control characters"),
+        ));
+    }
+    Ok(value)
+}
+
+fn postgres_database_url() -> Option<String> {
+    env::var(SEARCH_TEST_DATABASE_ENV)
+        .or_else(|_| env::var(FORUM_TEST_DATABASE_ENV))
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect_in_schema(
+    database_url: &str,
+    schema_name: &str,
+    max_connections: u32,
+) -> TestResult<DatabaseConnection> {
+    connect(
+        &database_url_in_schema(database_url, schema_name),
+        max_connections,
+    )
+    .await
+}
+
+fn database_url_in_schema(database_url: &str, schema_name: &str) -> String {
+    let separator = if database_url.contains('?') { '&' } else { '?' };
+    format!(
+        "{database_url}{separator}options=-c%20search_path%3D{schema_name}%2Cpublic"
+    )
+}
+
+async fn connect(database_url: &str, max_connections: u32) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(max_connections)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+fn sanitize_identifier(value: &str) -> String {
+    let normalized = value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    let normalized = normalized.trim_matches('_');
+    if normalized.is_empty() {
+        "test".to_string()
+    } else {
+        normalized.to_string()
+    }
+}
+
+fn unique_name(scope: &str) -> String {
+    format!("rustok-forum-search-{scope}-{}", Uuid::new_v4().simple())
+}
+
+fn write_evidence(artifact: NormalDeliveryEvidenceArtifact) -> TestResult<()> {
+    let path = workspace_root().join(EVIDENCE_PATH);
+    let parent = path
+        .parent()
+        .ok_or_else(|| test_error("evidence path has no parent directory"))?;
+    fs::create_dir_all(parent)?;
+    let mut bytes = serde_json::to_vec_pretty(&artifact)?;
+    bytes.push(b'\n');
+    fs::write(&path, bytes)?;
+    Ok(())
+}
+
+fn source_commit() -> TestResult<String> {
+    let output = Command::new("git")
+        .current_dir(workspace_root())
+        .args(["rev-parse", "HEAD"])
+        .output()?;
+    if !output.status.success() {
+        return Err(test_error("git rev-parse HEAD failed for evidence generation"));
+    }
+    let value = String::from_utf8(output.stdout)?;
+    let value = value.trim();
+    if value.len() != 40 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(test_error(
+            "git rev-parse HEAD returned an invalid commit SHA",
+        ));
+    }
+    Ok(value.to_string())
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn test_error(message: impl Into<String>) -> Box<dyn Error + Send + Sync> {
+    Box::new(IoError::new(ErrorKind::InvalidData, message.into()))
+}

--- a/crates/rustok-forum/contracts/forum-search-versioned-invalidation-normal-delivery-proof.json
+++ b/crates/rustok-forum/contracts/forum-search-versioned-invalidation-normal-delivery-proof.json
@@ -1,0 +1,52 @@
+{
+  "contract": "forum_search_versioned_invalidation_normal_delivery_proof_v1",
+  "task": "FORUM-23B2G2B3D10",
+  "status": "source_ready_maintainer_execution_pending",
+  "runtime_evidence_parent": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json",
+  "test": "apps/server/tests/forum_versioned_invalidation_normal_delivery_iggy.rs",
+  "evidence_artifact": {
+    "path": "target/forum-search-versioned-invalidation-normal-delivery-evidence.json",
+    "generation": "executable_test_only",
+    "hand_editing_forbidden": true,
+    "source_commit_required": true
+  },
+  "required_runtime": {
+    "database": "postgresql",
+    "database_env": "RUSTOK_SEARCH_TEST_DATABASE_URL",
+    "broker": "external_iggy",
+    "broker_env": "RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS",
+    "delivery_profile": "outbox_iggy",
+    "consumer_group": "rustok-search-forum-projection-v1",
+    "topic": "domain",
+    "host_package": "rustok-server"
+  },
+  "scenario": {
+    "id": "normal_delivery",
+    "proves": [
+      "real Forum category and topic owner transactions commit owner state, legacy roots, caused typed invalidations and contiguous owner ledger revisions",
+      "the exact typed outbox envelopes are published to an external Iggy stream in owner revision order",
+      "the persistent Forum Search consumer group receives each typed envelope with its exact transport ID, causation root ID and broker offset",
+      "production Forum Search contract ingress durably admits one Search inbox row per root before source acknowledgement",
+      "successful source acknowledgement advances the persistent group without duplicate delivery or synthetic inbox identity",
+      "the production Forum projector completes both inbox rows and materializes current category and topic documents",
+      "owner checkpoint reconciliation advances exactly through revisions 1 and 2 with delivery_covered after projection success and without a repair rebuild",
+      "the production anonymous storefront Search path returns the exact topic created by the correlated owner transaction"
+    ]
+  },
+  "identity_invariants": [
+    "forum_projection_revision_ledger.event_id equals the legacy root envelope id",
+    "ContractEventEnvelope.causation_id equals the same legacy root envelope id",
+    "search_projection_inbox.event_id equals the same legacy root envelope id",
+    "typed envelope id remains transport identity and differs from the root projection identity",
+    "Iggy offsets and Search ingest_sequence are independently monotonic",
+    "Forum owner_revision is never compared numerically with Search ingest_sequence"
+  ],
+  "maintainer_command": "RUSTOK_SEARCH_TEST_DATABASE_URL=\"$DATABASE_URL\" RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS=\"127.0.0.1:8090\" cargo test -p rustok-server --test forum_versioned_invalidation_normal_delivery_iggy -- --nocapture --test-threads=1",
+  "non_claims": [
+    "this source-ready proof does not claim that PostgreSQL or Iggy execution passed",
+    "this proof does not validate acknowledgement failure, restart redelivery, poison or DLQ behavior",
+    "this proof does not validate multi-process contention, deletion ACL ordering or Search-disabled recovery",
+    "this proof does not assemble or retain the aggregate D0 runtime artifact",
+    "this proof does not close FORUM-23 or LINK-FORUM-03"
+  ]
+}

--- a/crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json
+++ b/crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json
@@ -184,6 +184,27 @@
         "iggy_acknowledgement_poison_or_dlq",
         "deployment_orchestration_or_link_forum_03"
       ]
+    },
+    {
+      "task": "FORUM-23B2G2B3D10",
+      "contract": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-normal-delivery-proof.json",
+      "test": "apps/server/tests/forum_versioned_invalidation_normal_delivery_iggy.rs",
+      "evidence_artifact": "target/forum-search-versioned-invalidation-normal-delivery-evidence.json",
+      "covers": [
+        "one_correlated_normal_owner_delivery_trace",
+        "real_forum_owner_transaction_and_dual_outbox_publication",
+        "external_iggy_persistent_group_delivery",
+        "durable_ingress_before_source_acknowledgement",
+        "production_projection_completion",
+        "delivery_covered_checkpoint_order_1_2",
+        "storefront_exact_topic_visibility",
+        "caught_up_repeat_suppression"
+      ],
+      "does_not_cover": [
+        "acknowledgement_failure_restart_or_poison_dlq",
+        "multi_process_deletion_acl_or_search_disabled_profiles",
+        "aggregate_d0_artifact_assembly_or_link_forum_03"
+      ]
     }
   ],
   "required_runtime": {
@@ -325,6 +346,8 @@
     "RUSTOK_SEARCH_TEST_DATABASE_URL=\"$DATABASE_URL\" cargo test -p rustok-server --test forum_versioned_invalidation_deletion_acl_ordering -- --nocapture --test-threads=1",
     "node scripts/verify/verify-forum-search-versioned-invalidation-search-disabled-recovery-proof.mjs",
     "RUSTOK_SEARCH_TEST_DATABASE_URL=\"$DATABASE_URL\" cargo test -p rustok-server --test forum_versioned_invalidation_search_disabled_recovery -- --nocapture --test-threads=1",
+    "node scripts/verify/verify-forum-search-versioned-invalidation-normal-delivery-proof.mjs",
+    "RUSTOK_SEARCH_TEST_DATABASE_URL=\"$DATABASE_URL\" RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS=\"127.0.0.1:8090\" cargo test -p rustok-server --test forum_versioned_invalidation_normal_delivery_iggy -- --nocapture --test-threads=1",
     "cargo run -p rustok-events --example event_contract_digests",
     "cargo test -p rustok-events",
     "cargo test -p rustok-search forum_contract_ingress -- --nocapture",

--- a/crates/rustok-forum/docs/forum-23b2g2b3d10-normal-delivery-proof.md
+++ b/crates/rustok-forum/docs/forum-23b2g2b3d10-normal-delivery-proof.md
@@ -1,0 +1,142 @@
+# FORUM-23B2G2B3D10 normal delivery proof
+
+## Status
+
+`source_ready_maintainer_execution_pending`
+
+This slice supplies the direct `normal_delivery` trace required by the frozen
+`FORUM-23B2G2B3D0` runtime-evidence matrix. Earlier subproofs independently
+covered PostgreSQL ingress, Iggy acknowledgement/restart, owner-ledger repair,
+projection ordering and storefront visibility. D10 correlates the ordinary
+success path through one shared set of Forum owner, broker, Search inbox and
+checkpoint identities.
+
+The machine-readable proof contract is:
+
+```text
+crates/rustok-forum/contracts/forum-search-versioned-invalidation-normal-delivery-proof.json
+```
+
+The executable test is:
+
+```text
+apps/server/tests/forum_versioned_invalidation_normal_delivery_iggy.rs
+```
+
+Successful execution writes:
+
+```text
+target/forum-search-versioned-invalidation-normal-delivery-evidence.json
+```
+
+The artifact is written only after the complete scenario and isolated
+PostgreSQL schema cleanup succeed. It records the exact Git source commit and
+must not be hand-edited.
+
+## One correlated owner trace
+
+The test applies real Outbox, Taxonomy, Forum and Search migrations in one
+isolated PostgreSQL schema. Real Forum services create:
+
+1. one public category;
+2. one public topic containing `d10normaldeliverytopic`.
+
+Those two owner transactions must commit this exact ledger shape:
+
+```text
+revision 1: forum          / null
+revision 2: forum_category / category ID
+```
+
+For each revision, the test reads the committed legacy root and typed contract
+envelopes from the transactional outbox and requires:
+
+```text
+forum_projection_revision_ledger.event_id
+  = legacy EventEnvelope.id
+  = typed ContractEventEnvelope.causation_id
+```
+
+The typed envelope ID must differ from the root ID and remains transport
+identity only.
+
+## External Iggy delivery
+
+The exact typed envelopes committed by Forum are published to a unique external
+Iggy stream in owner-revision order. The production persistent group
+`rustok-search-forum-projection-v1` receives both messages from topic `domain`.
+
+For each broker delivery, the test requires:
+
+- the exact typed envelope bytes decode successfully;
+- typed ID, tenant ID and causation root match the owner transaction;
+- a broker offset and acknowledgement token are present;
+- production `ForumSearchContractIngress` creates one pending Search inbox row
+  keyed by the root ID;
+- source acknowledgement happens only after durable ingress succeeds.
+
+Broker offsets and Search `ingest_sequence` values must each increase, but they
+remain independent clocks and are never compared to Forum owner revisions.
+
+## Projection and delivery-covered checkpoint
+
+After both source acknowledgements, the production Forum projection source and
+`ForumProjectionReconciler::with_owner_revision_source` process the two pending
+inbox rows. The expected report is:
+
+```text
+due tenants:                  1
+claimed inbox rows:           2
+completed inbox rows:         2
+failed inbox rows:            0
+owner tenants reconciled:     1
+owner revisions checkpointed: 2
+owner repair rebuilds:        0
+```
+
+Revision coverage comes from the completed rows carrying the exact ledger root
+IDs. No missing-delivery repair rebuild is permitted on the ordinary path.
+
+A PostgreSQL audit trigger captures every owner checkpoint mutation. It must
+observe:
+
+```text
+revision 1 / delivery_covered / 2 Forum documents
+revision 2 / delivery_covered / 2 Forum documents
+```
+
+The final checkpoint references the revision-2 root UUID. Projection therefore
+commits before either checkpoint mutation.
+
+## Storefront assertion
+
+The retained Search projection must contain exactly the current category and
+topic. The same production anonymous Forum storefront Search execution and
+current owner eligibility boundary then query `d10normaldeliverytopic` and must
+return exactly the created topic with `total = 1`.
+
+A caught-up repeat sweep must claim no inbox row, perform no owner rebuild and
+advance no checkpoint.
+
+## Deliberate boundary
+
+D10 proves the successful external-broker delivery path. It does not repeat the
+failure/restart, poison/DLQ, multi-process, deletion/ACL or Search-disabled
+scenarios owned by D3-D9. It does not assemble the aggregate D0 artifact or
+close `FORUM-23` or `LINK-FORUM-03`.
+
+No production Rust path, dependency, migration, event schema, digest, public
+DTO, runtime flag, `Cargo.toml` or `Cargo.lock` entry changes in this slice.
+
+## Maintainer verification
+
+```bash
+node scripts/verify/verify-forum-search-versioned-invalidation-normal-delivery-proof.mjs
+RUSTOK_SEARCH_TEST_DATABASE_URL="$DATABASE_URL" \
+RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS="127.0.0.1:8090" \
+  cargo test -p rustok-server \
+  --test forum_versioned_invalidation_normal_delivery_iggy \
+  -- --nocapture --test-threads=1
+```
+
+No command above was run by the implementation agent.

--- a/scripts/verify/verify-forum-search-versioned-invalidation-normal-delivery-proof.mjs
+++ b/scripts/verify/verify-forum-search-versioned-invalidation-normal-delivery-proof.mjs
@@ -1,0 +1,361 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = process.cwd();
+const read = (path) => readFileSync(resolve(root, path), "utf8");
+const requireAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(text.includes(marker), `${label} is missing required marker: ${marker}`);
+  }
+};
+const forbidAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(!text.includes(marker), `${label} contains forbidden marker: ${marker}`);
+  }
+};
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-search-versioned-invalidation-normal-delivery-proof.json";
+const parentContractPath =
+  "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json";
+const docPath =
+  "crates/rustok-forum/docs/forum-23b2g2b3d10-normal-delivery-proof.md";
+const testPath =
+  "apps/server/tests/forum_versioned_invalidation_normal_delivery_iggy.rs";
+const evidencePath =
+  "target/forum-search-versioned-invalidation-normal-delivery-evidence.json";
+const projectionInvalidationPath =
+  "crates/rustok-forum/src/services/projection_invalidation.rs";
+const ingressPath = "crates/rustok-search/src/forum_contract_ingress.rs";
+const reconciliationPath = "crates/rustok-search/src/forum_reconciliation.rs";
+const ownerCheckpointPath =
+  "crates/rustok-search/src/forum_owner_checkpoint.rs";
+const projectorPath = "crates/rustok-search/src/forum_projector.rs";
+const storefrontExecutionPath =
+  "crates/rustok-search/src/forum_storefront_execution.rs";
+const planPath = "crates/rustok-forum/docs/implementation-plan.md";
+
+const contract = JSON.parse(read(contractPath));
+assert.equal(
+  contract.contract,
+  "forum_search_versioned_invalidation_normal_delivery_proof_v1",
+);
+assert.equal(contract.task, "FORUM-23B2G2B3D10");
+assert.equal(contract.status, "source_ready_maintainer_execution_pending");
+assert.equal(contract.runtime_evidence_parent, parentContractPath);
+assert.equal(contract.test, testPath);
+assert.equal(contract.evidence_artifact.path, evidencePath);
+assert.equal(contract.evidence_artifact.generation, "executable_test_only");
+assert.equal(contract.evidence_artifact.hand_editing_forbidden, true);
+assert.equal(contract.evidence_artifact.source_commit_required, true);
+assert.equal(contract.required_runtime.database, "postgresql");
+assert.equal(contract.required_runtime.broker, "external_iggy");
+assert.equal(contract.required_runtime.delivery_profile, "outbox_iggy");
+assert.equal(
+  contract.required_runtime.consumer_group,
+  "rustok-search-forum-projection-v1",
+);
+assert.equal(contract.required_runtime.topic, "domain");
+assert.equal(contract.scenario.id, "normal_delivery");
+assert.equal(contract.scenario.proves.length, 8);
+assert.ok(
+  contract.maintainer_command.includes(
+    "--test forum_versioned_invalidation_normal_delivery_iggy",
+  ),
+);
+
+const test = read(testPath);
+requireAll(
+  test,
+  [
+    "RUSTOK_SEARCH_TEST_DATABASE_URL",
+    "RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS",
+    "OutboxModule.migrations()",
+    "TaxonomyModule.migrations()",
+    "ForumModule.migrations()",
+    "SearchModule.migrations()",
+    "CategoryService::new",
+    "TopicService::new",
+    "d10normaldeliverytopic",
+    "SELECT revision, event_id, target_type, target_id",
+    'revisions[0].target_type != "forum"',
+    'revisions[1].target_type != "forum_category"',
+    "load_root_envelopes",
+    "load_typed_envelopes",
+    "ContractEventPayload::ForumSearchProjection",
+    "ForumSearchProjectionEvent::InvalidationIssued",
+    "envelope.causation_id() != Some(revision.event_id)",
+    "IggyMode::External",
+    "SerializationFormat::Json",
+    "open_persistent_contract_consumer_group",
+    "FORUM_SEARCH_CONTRACT_CONSUMER_GROUP",
+    "FORUM_SEARCH_CONTRACT_TOPIC",
+    "transport.publish_contract(envelope.clone()).await?",
+    "receive_delivery()",
+    "ForumSearchContractIngress::new",
+    "ensure_pending_inbox(&inbox, revision, fixture)?",
+    "group.acknowledge(&delivery).await?",
+    "ForumSearchProjectionSourceFactory.build",
+    "ForumProjectionReconciler::with_owner_revision_source",
+    "report.claimed_events != 2",
+    "report.completed_events != 2",
+    "report.owner_revisions_checkpointed != 2",
+    "report.owner_rebuilds != 0",
+    "forum_normal_delivery_checkpoint_audit",
+    'row.outcome != "delivery_covered"',
+    "row.observed_forum_documents != 2",
+    "execute_forum_storefront_search",
+    "ForumSearchResultEligibilityService::new",
+    "execution.result.total != 1",
+    "caught_up.claimed_events != 0",
+    "caught_up.owner_revisions_checkpointed != 0",
+    'id: "normal_delivery"',
+    evidencePath,
+    '.args(["rev-parse", "HEAD"])',
+  ],
+  "Forum normal-delivery executable proof",
+);
+forbidAll(
+  test,
+  [
+    "#[ignore]",
+    "MemoryTransport",
+    "InMemory",
+    "FixedOwnerRevisionSource",
+    "ControlledForumSource",
+    "ContractEventEnvelope::new_caused_by",
+    "insert_legacy_root",
+    "owner_revision == ingest_sequence",
+    "owner_revision != ingest_sequence",
+  ],
+  "Forum normal-delivery executable proof",
+);
+const ingressIndex = test.indexOf("ingress.ingest(&delivery.envelope).await?");
+const pendingIndex = test.indexOf("ensure_pending_inbox(&inbox, revision, fixture)?");
+const acknowledgeIndex = test.indexOf("group.acknowledge(&delivery).await?");
+assert.ok(ingressIndex >= 0 && ingressIndex < pendingIndex);
+assert.ok(pendingIndex >= 0 && pendingIndex < acknowledgeIndex);
+const projectionIndex = test.indexOf("let report = reconciler.sweep_due(8, 8).await?");
+const checkpointIndex = test.indexOf("let checkpoint = load_checkpoint");
+const storefrontIndex = test.indexOf("let storefront_total = assert_storefront_topic");
+assert.ok(projectionIndex >= 0 && projectionIndex < checkpointIndex);
+assert.ok(checkpointIndex >= 0 && checkpointIndex < storefrontIndex);
+
+const projectionInvalidation = read(projectionInvalidationPath);
+requireAll(
+  projectionInvalidation,
+  [
+    "allocate_projection_revision_in_tx",
+    "publish_in_tx_with_envelope_id",
+    "publish_contract_in_tx_with_causation",
+    "record_projection_revision_in_tx",
+    "TransactionalEventBus::publish_root_in_tx_with_envelope_id",
+    "TransactionalEventBus::publish_contract_direct_in_tx_with_causation_and_envelope_id",
+    "forum_projection_revision_ledger",
+  ],
+  "Forum atomic owner invalidation publisher",
+);
+forbidAll(
+  projectionInvalidation,
+  [
+    "rustok_search",
+    "search_projection_inbox",
+    "search_projection_owner_checkpoints",
+  ],
+  "Forum atomic owner invalidation publisher",
+);
+
+const ingress = read(ingressPath);
+requireAll(
+  ingress,
+  [
+    "FORUM_SEARCH_CONTRACT_CONSUMER_GROUP",
+    "FORUM_SEARCH_CONTRACT_TOPIC",
+    "causation_id()",
+    "search_projection_inbox",
+    "DurablyAccepted",
+  ],
+  "production Forum Search contract ingress",
+);
+
+const reconciliation = read(reconciliationPath);
+requireAll(
+  reconciliation,
+  [
+    "ForumProjectionReconciler",
+    "with_owner_revision_source",
+    "claim.complete().await?",
+    "owner_checkpoint",
+    "owner_revisions_checkpointed",
+    "owner_rebuilds",
+  ],
+  "production Forum Search reconciliation",
+);
+
+const ownerCheckpoint = read(ownerCheckpointPath);
+requireAll(
+  ownerCheckpoint,
+  [
+    "load_delivery_coverage",
+    "DeliveryCoverage::Covered",
+    "DELIVERY_COVERED_OUTCOME",
+    "advance_checkpoint",
+    "previous_revision = revision.owner_revision",
+  ],
+  "production delivery-covered owner checkpoint",
+);
+
+const projector = read(projectorPath);
+requireAll(
+  projector,
+  [
+    ".list_public_documents(",
+    "delete_forum_scope(&tx, tenant_id)",
+    "INSERT INTO search_documents",
+    "tx.commit().await",
+  ],
+  "production current-state Forum projector",
+);
+
+const storefrontExecution = read(storefrontExecutionPath);
+requireAll(
+  storefrontExecution,
+  [
+    "resolve_storefront_search_result_candidates",
+    "let total = visible_items.len() as u64",
+    "build_forum_result_facets(&visible_items)",
+    ".skip(query.offset)",
+    ".take(query.limit)",
+  ],
+  "production Forum storefront execution",
+);
+const eligibilityIndex = storefrontExecution.indexOf(
+  "resolve_storefront_search_result_candidates",
+);
+const totalIndex = storefrontExecution.indexOf(
+  "let total = visible_items.len() as u64",
+);
+const facetsIndex = storefrontExecution.indexOf(
+  "build_forum_result_facets(&visible_items)",
+);
+const offsetIndex = storefrontExecution.indexOf(".skip(query.offset)");
+assert.ok(eligibilityIndex >= 0 && eligibilityIndex < totalIndex);
+assert.ok(totalIndex >= 0 && totalIndex < facetsIndex);
+assert.ok(facetsIndex >= 0 && facetsIndex < offsetIndex);
+
+const doc = read(docPath);
+requireAll(
+  doc,
+  [
+    "`source_ready_maintainer_execution_pending`",
+    "FORUM-23B2G2B3D10",
+    contractPath,
+    testPath,
+    evidencePath,
+    "revision 1: forum          / null",
+    "revision 2: forum_category / category ID",
+    "rustok-search-forum-projection-v1",
+    "revision 1 / delivery_covered / 2 Forum documents",
+    "owner repair rebuilds:        0",
+    "total = 1",
+    "No command above was run by the implementation agent",
+  ],
+  "Forum normal-delivery handoff",
+);
+
+const parent = JSON.parse(read(parentContractPath));
+assert.equal(parent.task, "FORUM-23B2G2B3D0");
+assert.equal(parent.status, "source_ready_maintainer_execution_pending");
+assert.deepEqual(
+  parent.required_scenarios.map(({ id }) => id),
+  [
+    "normal_delivery",
+    "legacy_first_duplicate",
+    "typed_first_duplicate",
+    "acknowledgement_failure_restart",
+    "raw_poison_dlq_redelivery",
+    "semantic_poison_identity_conflict",
+    "missing_delivery_owner_repair",
+    "multi_process_serialization",
+    "deletion_acl_ordering",
+    "search_disabled_profile",
+  ],
+);
+for (const task of [
+  "FORUM-23B2G2B3D2",
+  "FORUM-23B2G2B3D3",
+  "FORUM-23B2G2B3D4",
+  "FORUM-23B2G2B3D5",
+  "FORUM-23B2G2B3D6",
+  "FORUM-23B2G2B3D7",
+  "FORUM-23B2G2B3D8",
+  "FORUM-23B2G2B3D9",
+  "FORUM-23B2G2B3D10",
+]) {
+  assert.ok(
+    parent.source_ready_subproofs.some((subproof) => subproof.task === task),
+    `${task} disappeared from the D0 source-ready subproof list`,
+  );
+}
+const subproof = parent.source_ready_subproofs.find(
+  ({ task }) => task === "FORUM-23B2G2B3D10",
+);
+assert.equal(subproof.contract, contractPath);
+assert.equal(subproof.test, testPath);
+assert.equal(subproof.evidence_artifact, evidencePath);
+assert.deepEqual(subproof.covers, [
+  "one_correlated_normal_owner_delivery_trace",
+  "real_forum_owner_transaction_and_dual_outbox_publication",
+  "external_iggy_persistent_group_delivery",
+  "durable_ingress_before_source_acknowledgement",
+  "production_projection_completion",
+  "delivery_covered_checkpoint_order_1_2",
+  "storefront_exact_topic_visibility",
+  "caught_up_repeat_suppression",
+]);
+assert.deepEqual(subproof.does_not_cover, [
+  "acknowledgement_failure_restart_or_poison_dlq",
+  "multi_process_deletion_acl_or_search_disabled_profiles",
+  "aggregate_d0_artifact_assembly_or_link_forum_03",
+]);
+assert.ok(
+  parent.maintainer_commands.includes(
+    "node scripts/verify/verify-forum-search-versioned-invalidation-normal-delivery-proof.mjs",
+  ),
+);
+assert.ok(
+  parent.maintainer_commands.some((command) =>
+    command.includes("--test forum_versioned_invalidation_normal_delivery_iggy"),
+  ),
+);
+
+const plan = read(planPath);
+const forum23Start = plan.indexOf("## `FORUM-23` — search/index integration");
+const forum24Start = plan.indexOf("## `FORUM-24` — localized routes", forum23Start);
+assert.ok(forum23Start >= 0 && forum24Start > forum23Start);
+const forum23 = plan.slice(forum23Start, forum24Start);
+requireAll(
+  forum23,
+  [
+    "**Status:** `in_progress`",
+    "FORUM-23B2G2B3D0",
+    "source_ready_maintainer_execution_pending",
+    "execute and retain every D0 PostgreSQL/Iggy scenario",
+    "`LINK-FORUM-03` cross-module runtime proof",
+  ],
+  "FORUM-23 canonical aggregate boundary",
+);
+forbidAll(
+  forum23,
+  [
+    "D10 closes FORUM-23",
+    "normal delivery runtime evidence passed",
+    "LINK-FORUM-03 is complete",
+  ],
+  "FORUM-23 canonical aggregate boundary",
+);
+
+console.log("Forum Search normal-delivery proof is source-synchronized.");


### PR DESCRIPTION
## What changed

- add `FORUM-23B2G2B3D10`, the direct `normal_delivery` subset of the frozen Forum Search D0 runtime-evidence matrix;
- apply real Outbox, Taxonomy, Forum and Search migrations in one isolated PostgreSQL schema;
- create one real Forum category and one real public topic through owner services;
- require exact contiguous Forum owner revisions `1` and `2` with ledger event IDs equal to the committed legacy root envelope IDs;
- read the caused typed invalidation envelopes from the transactional outbox and require each `causation_id` to equal its exact root ID while retaining a distinct typed transport ID;
- publish those exact typed envelopes to a unique external Iggy stream and consume them through persistent group `rustok-search-forum-projection-v1` on topic `domain`;
- require production Search ingress to create one pending inbox row per root before source acknowledgement;
- require independent monotonic broker offsets and Search ingest sequences without comparing either to Forum owner revisions;
- run the production Forum projection source and owner-aware reconciler;
- require exactly two completed inbox rows and owner checkpoints `1`, `2` with `delivery_covered`, after two Forum documents are visible and with no repair rebuild;
- run production anonymous Forum storefront Search and require the exact created topic with `total = 1`;
- require a caught-up repeat sweep to claim no work or advance a checkpoint;
- register D10 in D0 and add a focused static guard for the complete correlated identity and ordering path.

## Deliberate boundary

This PR does not repeat acknowledgement-failure/restart, poison/DLQ, multi-process, deletion/ACL or Search-disabled scenarios. It does not assemble the aggregate D0 artifact or close `FORUM-23` or `LINK-FORUM-03`.

## Compatibility

No production Rust path, dependency, migration, event schema or digest, public DTO, runtime flag, `Cargo.toml`, or `Cargo.lock` entry changes.

## Validation

Tests, Node verifiers, formatting, Cargo checks, workflows, CI, PostgreSQL and Iggy execution were intentionally not run, per maintainer request.