### PR TITLE
refactor(blog): add Comments TCP channel seam

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-comments-tcp-channel-seam.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-tcp-channel-seam.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": 1,
+  "module": "blog",
+  "provider": "comments",
+  "surface": "comments_tcp_channel_seam",
+  "status": "source_verified_no_compile",
+  "compile_policy": "not_run_by_request",
+  "runtime_status": "not_run",
+  "generated_from": "crates/rustok-blog/docs/implementation-plan-slice-74.md",
+  "source_contract": {
+    "channel": "crates/rustok-comments/src/tcp_channel.rs",
+    "framing": "crates/rustok-comments/src/tcp_protocol.rs",
+    "client_transport": "crates/rustok-comments/src/tcp_transport.rs",
+    "server_adapter": "crates/rustok-comments/src/tcp_server.rs",
+    "provider_export": "crates/rustok-comments/src/lib.rs",
+    "provider_manifest": "crates/rustok-comments/Cargo.toml",
+    "lockfile": "Cargo.lock"
+  },
+  "channel_io": {
+    "trait": "CommentsTcpIo",
+    "async_read": true,
+    "async_write": true,
+    "unpin": true,
+    "send": true,
+    "boxed_alias": "BoxCommentsTcpIo",
+    "concrete_stream_erased_after_establishment": true
+  },
+  "protection_classification": {
+    "enum": "CommentsTcpChannelProtection",
+    "values": [
+      "PlaintextLoopback",
+      "AuthenticatedEncrypted"
+    ],
+    "classification_is_runtime_evidence": false,
+    "classification_mints_comments_authority": false
+  },
+  "client_connector": {
+    "trait": "CommentsTcpClientChannelConnector",
+    "endpoint_type": "SocketAddr",
+    "returns": "BoxCommentsTcpIo",
+    "host_injectable": true,
+    "establishment_inside_port_deadline": true,
+    "default": "PlaintextLoopbackCommentsTcpChannel"
+  },
+  "server_acceptor": {
+    "trait": "CommentsTcpServerChannelAcceptor",
+    "input_stream": "tokio::net::TcpStream",
+    "input_peer": "SocketAddr",
+    "returns": "BoxCommentsTcpIo",
+    "runs_before_first_frame_read": true,
+    "concrete_tls_acceptor_must_bound_handshake": true,
+    "pre_request_timeout_starts_after_channel_establishment": true,
+    "default": "PlaintextLoopbackCommentsTcpChannel"
+  },
+  "plaintext_profile": {
+    "client_endpoint_loopback_required": true,
+    "server_peer_loopback_required": true,
+    "non_loopback_error_code": "comments.tcp_plaintext_non_loopback",
+    "host_non_loopback_enabled": false
+  },
+  "framing": {
+    "generic_async_reader": true,
+    "generic_async_writer": true,
+    "owns_tcp_stream": false,
+    "length_prefix": "u32_big_endian",
+    "default_max_frame_bytes": 8388608,
+    "one_request_one_reply": true
+  },
+  "client_transport": {
+    "connector_storage": "Arc<dyn CommentsTcpClientChannelConnector>",
+    "existing_plaintext_constructors_retained": true,
+    "connector_only_constructor": true,
+    "connector_bearer_constructor": true,
+    "connector_bearer_delegation_constructor": true,
+    "connector_frame_limit_constructor": true,
+    "channel_protection_visible": true,
+    "bearer_redaction_retained": true,
+    "delegation_redaction_retained": true
+  },
+  "server_adapter": {
+    "existing_plaintext_methods_retained": true,
+    "acceptor_method": "handle_connection_with_acceptor",
+    "acceptor_idle_method": "handle_connection_with_acceptor_and_pre_request_timeout",
+    "protocol_validation_after_channel_establishment": true,
+    "authority_before_provider_dispatch": true,
+    "tenant_match_retained": true,
+    "principal_replacement_retained": true
+  },
+  "deadline": {
+    "client_source": "PortContext.deadline_ms",
+    "client_scope": "credential_prepare_encode_channel_connect_write_read_decode",
+    "server_channel_handshake_bound_owner": "channel_acceptor",
+    "server_pre_request_scope": "first_complete_frame_after_channel_establishment",
+    "server_provider_source": "PortContext.deadline_ms"
+  },
+  "dependency_contract": {
+    "new_direct_dependencies": [],
+    "rustok_comments_manifest_changed": false,
+    "cargo_lock_changed": false,
+    "rustls_adapter_implemented": false,
+    "tokio_rustls_adapter_implemented": false
+  },
+  "retained_authority": {
+    "bearer_reads": true,
+    "signed_user_writes": true,
+    "service_moderation": true,
+    "process_local_replay": true,
+    "channel_replaces_application_authority": false
+  },
+  "pending": [
+    "concrete_rustls_client_connector",
+    "concrete_rustls_server_acceptor",
+    "mutual_certificate_verification",
+    "server_name_validation",
+    "tls_handshake_timeout",
+    "host_mtls_configuration",
+    "encrypted_runtime_execution",
+    "non_loopback_runtime_evidence",
+    "shared_replay_store",
+    "certificate_rotation"
+  ],
+  "non_claims": {
+    "tls_implemented": false,
+    "mtls_implemented": false,
+    "encrypted_host_profile": false,
+    "non_loopback_safe": false,
+    "certificate_identity_authority": false,
+    "compile_passed": false,
+    "source_verifier_executed": false,
+    "runtime_executed": false
+  }
+}

--- a/crates/rustok-blog/docs/implementation-plan-slice-74.md
+++ b/crates/rustok-blog/docs/implementation-plan-slice-74.md
@@ -1,0 +1,174 @@
+# rustok-blog implementation plan — slice 74 continuation
+
+This document continues
+`crates/rustok-blog/docs/implementation-plan-slice-73.md`. Slices 1–66 remain in
+the original plan; slices 67–73 retain the typed Comments remote core, bounded
+TCP framing and lifecycle, bearer-authenticated reads, signed user delegation,
+and process-local replay admission.
+
+## 2026-08-01 continuation audit
+
+Slice 73 was rechecked against current `main` at
+`fd27c7665f61fdacd3e8ebfa677d0569f87e05c6`. No later main commit existed when
+this continuation branch was created.
+
+The next planned result was a TLS/mTLS transport. The current framing and
+adapter implementations, however, owned concrete `tokio::net::TcpStream`
+values. Adding certificate configuration directly there would couple typed
+Comments protocol logic to one TLS library and make later channel testing,
+rotation, or alternative protected transports unnecessarily invasive.
+
+This bounded continuation therefore introduces the transport-owned protected
+channel injection contract first. It deliberately does not claim that TLS or
+mTLS is implemented. The concrete rustls client connector, server acceptor,
+certificate loading, and host mode are deferred to the next slice.
+
+No compile, Rust or JavaScript test, TCP exchange, TLS handshake, database,
+browser, workflow, CI, production, or runtime result is promoted by this
+continuation. Execution remains maintainer-owned.
+
+## Slice 74 — protected channel injection core
+
+### Implemented source scope
+
+- `crates/rustok-comments/src/tcp_channel.rs` owns the channel abstraction.
+- `CommentsTcpIo` is the byte-stream boundary consumed by framing and typed
+  transport code. Implementations must provide asynchronous read/write, be
+  unpinned, and be sendable between tasks.
+- `BoxCommentsTcpIo` erases the concrete stream type after channel establishment.
+- `CommentsTcpChannelProtection` exposes a closed source-level classification:
+  - `PlaintextLoopback`;
+  - `AuthenticatedEncrypted`.
+- The classification is descriptive policy metadata. Selecting
+  `AuthenticatedEncrypted` does not itself prove that an implementation is
+  secure; a concrete connector/acceptor and retained runtime evidence remain
+  required.
+- `CommentsTcpClientChannelConnector` owns client channel establishment.
+  Implementations may own DNS, SNI, certificate validation, TLS handshakes, or
+  another protected-channel policy and return a stream only after that policy
+  succeeds.
+- `CommentsTcpServerChannelAcceptor` receives the host-accepted raw socket and
+  peer address. A TLS/mTLS implementation must complete and independently bound
+  its handshake before returning a protected byte channel.
+- `PlaintextLoopbackCommentsTcpChannel` preserves the compatibility profile but
+  now enforces loopback independently on both client endpoint and accepted peer.
+- A non-loopback plaintext endpoint or peer fails with
+  `comments.tcp_plaintext_non_loopback` before a typed request is exchanged.
+- `crates/rustok-comments/src/tcp_protocol.rs` no longer owns `TcpStream`.
+  Length-prefixed framing is generic over asynchronous readers and writers while
+  retaining:
+  - four-byte big-endian frame length;
+  - configured and `u32` frame limits;
+  - the existing stable frame and I/O errors.
+- `TcpJsonCommentsTransport` stores an injected
+  `Arc<dyn CommentsTcpClientChannelConnector>`.
+- Existing constructors retain the plaintext loopback compatibility connector.
+- New constructors permit a host to combine a connector with:
+  - no application credential;
+  - a bearer token;
+  - bearer plus signed user delegation;
+  - an explicit frame limit.
+- Connector establishment, typed credential preparation, envelope encoding,
+  request write, response read, and response decoding remain inside the original
+  `PortContext.deadline_ms` timeout.
+- `TcpJsonCommentsTransport::channel_protection` exposes the connector's closed
+  protection classification without exposing certificate or secret material.
+- Transport `Debug` includes the protection classification and retains redaction
+  for bearer and delegation secrets.
+- `TcpJsonCommentsServerAdapter` retains its existing plaintext methods for
+  compatibility.
+- The server adapter adds:
+  - `handle_connection_with_acceptor`;
+  - `handle_connection_with_acceptor_and_pre_request_timeout`.
+- The injected acceptor runs before the adapter reads the first typed frame.
+- The existing pre-request timeout begins after channel establishment and bounds
+  receipt of the first complete frame. A concrete TLS acceptor must apply a
+  separate handshake timeout; this slice does not silently reuse the request
+  idle timeout as a handshake bound.
+- After channel establishment, protocol-version validation, bearer/delegation
+  authority, tenant equality, trusted principal replacement, owner dispatch,
+  exact provider replies, request deadlines, and one-request/one-reply scope are
+  unchanged.
+- No direct dependency was added to `rustok-comments`, and neither its manifest
+  nor `Cargo.lock` is changed by this slice.
+- The retained slice-68 client and slice-69 server source guards are reconciled
+  with the channel abstraction while preserving their historical source-only
+  evidence.
+- Source evidence is retained at
+  `crates/rustok-blog/contracts/evidence/blog-comments-tcp-channel-seam.json`.
+- The standalone source verifier is
+  `scripts/verify/verify-blog-comments-tcp-channel-seam.mjs`.
+
+### Explicit non-claims
+
+This slice does not implement or claim:
+
+- TLS or mTLS handshakes;
+- certificate, private-key, CA, DNS name, SNI, ALPN, or revocation validation;
+- a rustls, tokio-rustls, native-tls, or OpenSSL adapter;
+- encrypted bytes in the built-in host runtime;
+- non-loopback endpoint or listener enablement;
+- channel-derived Comments authority or certificate-to-principal mapping;
+- multi-process, durable, restart-safe, or multi-replica replay prevention;
+- key or certificate rotation and secret-manager loading;
+- retry/backoff, circuit breaking, or automatic write replay;
+- listener health/readiness or successful channel negotiation evidence;
+- successful compile, Rust test, JavaScript verifier, TCP/TLS runtime, database,
+  browser, workflow, CI, or production execution.
+
+Status: `source_verified_no_compile`.
+Compile policy: `not_run_by_request`.
+Runtime status: `not_run`.
+
+## Next implementation results
+
+1. Add a concrete rustls/tokio-rustls mutual-TLS connector and acceptor using
+   host-owned trust roots, certificate chains, private keys, server-name policy,
+   TLS 1.3, and a separately bounded handshake.
+2. Add fail-closed host configuration for the mTLS client and listener profile.
+   Plaintext must remain loopback-only, and non-loopback must remain disabled
+   until retained runtime evidence exists.
+3. Decide whether verified certificate identity is an additional transport
+   gate or the source of service authority. Do not weaken bearer/delegation or
+   tenant matching implicitly.
+4. Add certificate/key rotation, overlapping trust roots, revocation policy,
+   and secret-manager loading without logging key or certificate payloads.
+5. Replace the process-local delegation nonce cache with a bounded shared replay
+   store before claiming multi-replica or restart-safe replay prevention.
+6. Add in-process/plaintext/mTLS parity fixtures for all seven operations,
+   handshake failure and timeout, unknown CA, missing client certificate, wrong
+   server name, expired certificate, malformed frames, request deadlines,
+   concurrency rejection, and shutdown.
+7. Add listener readiness and health only after retained runtime execution
+   confirms negotiation, application authentication, dispatch, and drain.
+8. Continue retry/backoff and cached comment fallback work only after the
+   protected remote path has retained runtime evidence.
+
+## Suggested verification — intentionally not run in this slice
+
+- `node scripts/verify/verify-blog-comments-tcp-channel-seam.mjs`
+- `node scripts/verify/verify-blog-comments-tcp-transport.mjs`
+- `node scripts/verify/verify-blog-comments-tcp-server-adapter.mjs`
+- `node scripts/verify/verify-blog-comments-tcp-user-delegation.mjs`
+- `cargo test -p rustok-comments --features tcp-transport --lib tcp_channel::tests`
+- `cargo test -p rustok-comments --features tcp-transport --lib tcp_transport::tests`
+- `cargo test -p rustok-comments --features tcp-transport --lib tcp_server::tests`
+- `cargo check -p rustok-server --features mod-blog --locked`
+
+## Boundaries retained
+
+- Comments owns typed request/reply envelopes, length-prefixed framing, channel
+  interfaces, application credentials, trusted principal replacement, provider
+  dispatch, and stable transport errors.
+- A concrete protected-channel implementation owns cryptographic negotiation,
+  peer verification, and handshake bounds. It must not mint Comments authority
+  merely by returning `AuthenticatedEncrypted`.
+- Blog owns consumer policy, authenticated user/moderation contexts, article
+  rendering, and degraded presentation.
+- The server host owns connector/acceptor selection, certificate and trust
+  configuration, listener policy, authority composition, provider selection,
+  concurrency, and shutdown.
+- Plaintext remains loopback-only. Non-loopback publication remains forbidden
+  until a concrete protected channel and retained runtime evidence are present.
+- Source-only evidence remains explicit until the maintainer runs and records the
+  corresponding execution targets.

--- a/crates/rustok-comments/src/lib.rs
+++ b/crates/rustok-comments/src/lib.rs
@@ -18,6 +18,8 @@ pub mod services;
 #[cfg(feature = "tcp-transport")]
 pub mod tcp_auth;
 #[cfg(feature = "tcp-transport")]
+pub mod tcp_channel;
+#[cfg(feature = "tcp-transport")]
 pub mod tcp_delegation;
 #[cfg(feature = "tcp-transport")]
 mod tcp_protocol;
@@ -54,6 +56,11 @@ pub use tcp_auth::{
     COMMENTS_TCP_PROTOCOL_VERSION, CommentsTcpAuthenticationConfigError,
     CommentsTcpBearerAuthorityResolver, CommentsTcpBearerToken, CommentsTcpCredential,
     CommentsTcpRequestEnvelope,
+};
+#[cfg(feature = "tcp-transport")]
+pub use tcp_channel::{
+    BoxCommentsTcpIo, CommentsTcpChannelProtection, CommentsTcpClientChannelConnector,
+    CommentsTcpIo, CommentsTcpServerChannelAcceptor, PlaintextLoopbackCommentsTcpChannel,
 };
 #[cfg(feature = "tcp-transport")]
 pub use tcp_delegation::{

--- a/crates/rustok-comments/src/tcp_channel.rs
+++ b/crates/rustok-comments/src/tcp_channel.rs
@@ -1,0 +1,135 @@
+use std::{fmt, net::SocketAddr};
+
+use async_trait::async_trait;
+use rustok_api::PortError;
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    net::TcpStream,
+};
+
+use crate::tcp_protocol::io_error;
+
+/// Async byte channel consumed by the Comments framing and typed transport layers.
+///
+/// Implementations may be a loopback `TcpStream`, a TLS stream, or another
+/// authenticated encrypted channel. Framing and Comments authorization do not
+/// depend on the concrete channel type.
+pub trait CommentsTcpIo: AsyncRead + AsyncWrite + Unpin + Send {}
+
+impl<T> CommentsTcpIo for T where T: AsyncRead + AsyncWrite + Unpin + Send {}
+
+pub type BoxCommentsTcpIo = Box<dyn CommentsTcpIo>;
+
+/// Closed transport-protection classification exposed by channel adapters.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CommentsTcpChannelProtection {
+    /// Unencrypted transport that is valid only for loopback endpoints and peers.
+    PlaintextLoopback,
+    /// Host-provided channel that authenticates both peers and encrypts bytes.
+    AuthenticatedEncrypted,
+}
+
+/// Client-side channel establishment seam.
+///
+/// A connector owns DNS/SNI, certificate verification, handshake bounds, or any
+/// equivalent protected-channel policy. It returns a byte channel only after its
+/// policy succeeds.
+#[async_trait]
+pub trait CommentsTcpClientChannelConnector: Send + Sync {
+    async fn connect(&self, endpoint: SocketAddr) -> Result<BoxCommentsTcpIo, PortError>;
+
+    fn protection(&self) -> CommentsTcpChannelProtection;
+}
+
+/// Server-side accepted-stream protection seam.
+///
+/// An acceptor receives the raw socket and peer address from the host listener.
+/// TLS/mTLS implementations must complete and bound the handshake before
+/// returning a channel. Provider dispatch remains owned by the server adapter.
+#[async_trait]
+pub trait CommentsTcpServerChannelAcceptor: Send + Sync {
+    async fn accept(
+        &self,
+        stream: TcpStream,
+        peer_addr: SocketAddr,
+    ) -> Result<BoxCommentsTcpIo, PortError>;
+
+    fn protection(&self) -> CommentsTcpChannelProtection;
+}
+
+/// Built-in compatibility channel for unencrypted loopback-only deployments.
+#[derive(Clone, Copy, Default)]
+pub struct PlaintextLoopbackCommentsTcpChannel;
+
+impl fmt::Debug for PlaintextLoopbackCommentsTcpChannel {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PlaintextLoopbackCommentsTcpChannel")
+            .field("protection", &CommentsTcpChannelProtection::PlaintextLoopback)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl CommentsTcpClientChannelConnector for PlaintextLoopbackCommentsTcpChannel {
+    async fn connect(&self, endpoint: SocketAddr) -> Result<BoxCommentsTcpIo, PortError> {
+        ensure_loopback(endpoint, "endpoint")?;
+        let stream = TcpStream::connect(endpoint)
+            .await
+            .map_err(|error| io_error("connect", error))?;
+        stream
+            .set_nodelay(true)
+            .map_err(|error| io_error("set_nodelay", error))?;
+        Ok(Box::new(stream))
+    }
+
+    fn protection(&self) -> CommentsTcpChannelProtection {
+        CommentsTcpChannelProtection::PlaintextLoopback
+    }
+}
+
+#[async_trait]
+impl CommentsTcpServerChannelAcceptor for PlaintextLoopbackCommentsTcpChannel {
+    async fn accept(
+        &self,
+        stream: TcpStream,
+        peer_addr: SocketAddr,
+    ) -> Result<BoxCommentsTcpIo, PortError> {
+        ensure_loopback(peer_addr, "peer")?;
+        stream
+            .set_nodelay(true)
+            .map_err(|error| io_error("server_set_nodelay", error))?;
+        Ok(Box::new(stream))
+    }
+
+    fn protection(&self) -> CommentsTcpChannelProtection {
+        CommentsTcpChannelProtection::PlaintextLoopback
+    }
+}
+
+fn ensure_loopback(address: SocketAddr, subject: &'static str) -> Result<(), PortError> {
+    if address.ip().is_loopback() {
+        return Ok(());
+    }
+    Err(PortError::forbidden(
+        "comments.tcp_plaintext_non_loopback",
+        format!("comments plaintext TCP {subject} must be loopback"),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plaintext_channel_is_explicitly_loopback_only() {
+        assert_eq!(
+            PlaintextLoopbackCommentsTcpChannel.protection(),
+            CommentsTcpChannelProtection::PlaintextLoopback
+        );
+        assert!(ensure_loopback("127.0.0.1:9000".parse().unwrap(), "endpoint").is_ok());
+        let error = ensure_loopback("192.0.2.10:9000".parse().unwrap(), "endpoint")
+            .unwrap_err();
+        assert_eq!(error.code, "comments.tcp_plaintext_non_loopback");
+    }
+}

--- a/crates/rustok-comments/src/tcp_channel.rs
+++ b/crates/rustok-comments/src/tcp_channel.rs
@@ -124,7 +124,9 @@ mod tests {
     #[test]
     fn plaintext_channel_is_explicitly_loopback_only() {
         assert_eq!(
-            PlaintextLoopbackCommentsTcpChannel.protection(),
+            CommentsTcpClientChannelConnector::protection(
+                &PlaintextLoopbackCommentsTcpChannel,
+            ),
             CommentsTcpChannelProtection::PlaintextLoopback
         );
         assert!(ensure_loopback("127.0.0.1:9000".parse().unwrap(), "endpoint").is_ok());

--- a/crates/rustok-comments/src/tcp_channel.rs
+++ b/crates/rustok-comments/src/tcp_channel.rs
@@ -77,8 +77,7 @@ impl CommentsTcpClientChannelConnector for PlaintextLoopbackCommentsTcpChannel {
         let stream = TcpStream::connect(endpoint)
             .await
             .map_err(|error| io_error("connect", error))?;
-        stream
-            .set_nodelay(true)
+        stream.set_nodelay(true)
             .map_err(|error| io_error("set_nodelay", error))?;
         Ok(Box::new(stream))
     }
@@ -96,8 +95,7 @@ impl CommentsTcpServerChannelAcceptor for PlaintextLoopbackCommentsTcpChannel {
         peer_addr: SocketAddr,
     ) -> Result<BoxCommentsTcpIo, PortError> {
         ensure_loopback(peer_addr, "peer")?;
-        stream
-            .set_nodelay(true)
+        stream.set_nodelay(true)
             .map_err(|error| io_error("server_set_nodelay", error))?;
         Ok(Box::new(stream))
     }

--- a/crates/rustok-comments/src/tcp_protocol.rs
+++ b/crates/rustok-comments/src/tcp_protocol.rs
@@ -1,17 +1,17 @@
 use rustok_api::PortError;
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    net::TcpStream,
-};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 /// Default upper bound for one length-prefixed Comments request or response.
 pub const DEFAULT_MAX_COMMENTS_FRAME_BYTES: usize = 8 * 1024 * 1024;
 
-pub(crate) async fn write_frame(
-    stream: &mut TcpStream,
+pub(crate) async fn write_frame<S>(
+    stream: &mut S,
     payload: &[u8],
     max_frame_bytes: usize,
-) -> Result<(), PortError> {
+) -> Result<(), PortError>
+where
+    S: AsyncWrite + Unpin + ?Sized,
+{
     ensure_frame_size(payload.len(), max_frame_bytes)?;
     let length = u32::try_from(payload.len()).map_err(|_| {
         PortError::invariant_violation(
@@ -35,10 +35,13 @@ pub(crate) async fn write_frame(
     Ok(())
 }
 
-pub(crate) async fn read_frame(
-    stream: &mut TcpStream,
+pub(crate) async fn read_frame<S>(
+    stream: &mut S,
     max_frame_bytes: usize,
-) -> Result<Vec<u8>, PortError> {
+) -> Result<Vec<u8>, PortError>
+where
+    S: AsyncRead + Unpin + ?Sized,
+{
     let mut length_bytes = [0_u8; 4];
     stream
         .read_exact(&mut length_bytes)

--- a/crates/rustok-comments/src/tcp_server.rs
+++ b/crates/rustok-comments/src/tcp_server.rs
@@ -5,11 +5,13 @@ use rustok_api::{PortActor, PortContext, PortError, PortErrorKind};
 use tokio::{net::TcpStream, time::timeout};
 
 use crate::tcp_protocol::{
-    DEFAULT_MAX_COMMENTS_FRAME_BYTES, io_error, read_frame, validate_frame_limit, write_frame,
+    DEFAULT_MAX_COMMENTS_FRAME_BYTES, read_frame, validate_frame_limit, write_frame,
 };
 use crate::{
-    COMMENTS_TCP_PROTOCOL_VERSION, CommentsTcpCredential, CommentsTcpRequestEnvelope,
-    CommentsThreadPort, CommentsThreadRequest, CommentsThreadResponse, CommentsThreadTransportReply,
+    BoxCommentsTcpIo, COMMENTS_TCP_PROTOCOL_VERSION, CommentsTcpCredential,
+    CommentsTcpIo, CommentsTcpRequestEnvelope, CommentsTcpServerChannelAcceptor,
+    CommentsThreadPort, CommentsThreadRequest, CommentsThreadResponse,
+    CommentsThreadTransportReply, PlaintextLoopbackCommentsTcpChannel,
 };
 
 /// Stable operation identity exposed to host-owned TCP authority resolvers.
@@ -125,12 +127,13 @@ pub trait CommentsTcpAuthorityResolver: Send + Sync {
     ) -> Result<TrustedCommentsTcpAuthority, PortError>;
 }
 
-/// Provider-side adapter for one length-prefixed JSON request per accepted TCP stream.
+/// Provider-side adapter for one length-prefixed JSON request per accepted channel.
 ///
-/// The host owns listener lifecycle and passes each accepted stream with its peer
-/// address. This adapter decodes one versioned envelope, requires trusted
-/// authority, invokes the host-selected Comments provider, writes one typed
-/// reply, and returns.
+/// The host owns listener lifecycle and passes each accepted raw socket through a
+/// channel acceptor. The acceptor may retain the built-in plaintext loopback
+/// profile or complete a bounded authenticated encrypted handshake. This adapter
+/// then decodes one versioned envelope, requires trusted authority, invokes the
+/// host-selected Comments provider, writes one typed reply, and returns.
 #[derive(Clone)]
 pub struct TcpJsonCommentsServerAdapter {
     provider: Arc<dyn CommentsThreadPort>,
@@ -167,24 +170,59 @@ impl TcpJsonCommentsServerAdapter {
         self.max_frame_bytes
     }
 
-    /// Handles exactly one request/reply exchange on an accepted stream.
+    /// Handles exactly one request/reply exchange using the built-in plaintext
+    /// loopback-only compatibility acceptor.
     pub async fn handle_connection(
         &self,
         stream: TcpStream,
         peer_addr: SocketAddr,
     ) -> Result<(), PortError> {
-        self.handle_connection_inner(stream, peer_addr, None).await
+        let acceptor = PlaintextLoopbackCommentsTcpChannel;
+        self.handle_connection_with_acceptor(stream, peer_addr, &acceptor)
+            .await
     }
 
-    /// Handles one exchange while bounding how long an accepted peer may remain
-    /// idle before sending the complete first request frame.
-    ///
-    /// The request's own `PortContext` deadline continues to bound trusted
-    /// authority resolution and provider dispatch after the frame is decoded.
+    /// Handles one plaintext loopback exchange while bounding how long an
+    /// accepted peer may remain idle before sending the complete first frame.
     pub async fn handle_connection_with_pre_request_timeout(
         &self,
         stream: TcpStream,
         peer_addr: SocketAddr,
+        pre_request_timeout: Duration,
+    ) -> Result<(), PortError> {
+        let acceptor = PlaintextLoopbackCommentsTcpChannel;
+        self.handle_connection_with_acceptor_and_pre_request_timeout(
+            stream,
+            peer_addr,
+            &acceptor,
+            pre_request_timeout,
+        )
+        .await
+    }
+
+    /// Handles one request/reply exchange through a host-provided channel
+    /// acceptor. A TLS/mTLS acceptor owns and bounds its handshake before this
+    /// method starts reading the typed request frame.
+    pub async fn handle_connection_with_acceptor(
+        &self,
+        stream: TcpStream,
+        peer_addr: SocketAddr,
+        acceptor: &dyn CommentsTcpServerChannelAcceptor,
+    ) -> Result<(), PortError> {
+        self.accept_and_handle(stream, peer_addr, acceptor, None)
+            .await
+    }
+
+    /// Handles one exchange through a host-provided channel acceptor and bounds
+    /// receipt of the first complete request frame after channel establishment.
+    ///
+    /// The request's own `PortContext` deadline continues to bound trusted
+    /// authority resolution and provider dispatch after the frame is decoded.
+    pub async fn handle_connection_with_acceptor_and_pre_request_timeout(
+        &self,
+        stream: TcpStream,
+        peer_addr: SocketAddr,
+        acceptor: &dyn CommentsTcpServerChannelAcceptor,
         pre_request_timeout: Duration,
     ) -> Result<(), PortError> {
         if pre_request_timeout.is_zero() {
@@ -193,22 +231,35 @@ impl TcpJsonCommentsServerAdapter {
                 "comments TCP pre-request timeout must be greater than zero",
             ));
         }
-        self.handle_connection_inner(stream, peer_addr, Some(pre_request_timeout))
+        self.accept_and_handle(
+            stream,
+            peer_addr,
+            acceptor,
+            Some(pre_request_timeout),
+        )
+        .await
+    }
+
+    async fn accept_and_handle(
+        &self,
+        stream: TcpStream,
+        peer_addr: SocketAddr,
+        acceptor: &dyn CommentsTcpServerChannelAcceptor,
+        pre_request_timeout: Option<Duration>,
+    ) -> Result<(), PortError> {
+        let channel = acceptor.accept(stream, peer_addr).await?;
+        self.handle_channel_inner(channel, peer_addr, pre_request_timeout)
             .await
     }
 
-    async fn handle_connection_inner(
+    async fn handle_channel_inner(
         &self,
-        mut stream: TcpStream,
+        mut channel: BoxCommentsTcpIo,
         peer_addr: SocketAddr,
         pre_request_timeout: Option<Duration>,
     ) -> Result<(), PortError> {
-        stream
-            .set_nodelay(true)
-            .map_err(|error| io_error("server_set_nodelay", error))?;
-
         let reply = match self
-            .read_authorize_and_dispatch(&mut stream, peer_addr, pre_request_timeout)
+            .read_authorize_and_dispatch(&mut *channel, peer_addr, pre_request_timeout)
             .await
         {
             Ok(response) => CommentsThreadTransportReply::Success(response),
@@ -220,17 +271,17 @@ impl TcpJsonCommentsServerAdapter {
                 "comments TCP server reply could not be encoded",
             )
         })?;
-        write_frame(&mut stream, &reply_payload, self.max_frame_bytes).await
+        write_frame(&mut *channel, &reply_payload, self.max_frame_bytes).await
     }
 
     async fn read_authorize_and_dispatch(
         &self,
-        stream: &mut TcpStream,
+        channel: &mut dyn CommentsTcpIo,
         peer_addr: SocketAddr,
         pre_request_timeout: Option<Duration>,
     ) -> Result<CommentsThreadResponse, PortError> {
         let request_payload = match pre_request_timeout {
-            Some(duration) => timeout(duration, read_frame(stream, self.max_frame_bytes))
+            Some(duration) => timeout(duration, read_frame(channel, self.max_frame_bytes))
                 .await
                 .map_err(|_| {
                     PortError::timeout(
@@ -238,7 +289,7 @@ impl TcpJsonCommentsServerAdapter {
                         "comments TCP peer did not send a complete request frame before the idle timeout",
                     )
                 })??,
-            None => read_frame(stream, self.max_frame_bytes).await?,
+            None => read_frame(channel, self.max_frame_bytes).await?,
         };
         let envelope = serde_json::from_slice::<CommentsTcpRequestEnvelope>(&request_payload)
             .map_err(|_| {
@@ -459,8 +510,9 @@ mod tests {
     }
 
     #[test]
-    fn pre_request_timeout_api_is_source_visible() {
-        let handler = TcpJsonCommentsServerAdapter::handle_connection_with_pre_request_timeout;
+    fn channel_acceptor_api_is_source_visible() {
+        let handler =
+            TcpJsonCommentsServerAdapter::handle_connection_with_acceptor_and_pre_request_timeout;
         let _ = handler;
     }
 }

--- a/crates/rustok-comments/src/tcp_transport.rs
+++ b/crates/rustok-comments/src/tcp_transport.rs
@@ -1,32 +1,39 @@
-use std::{net::SocketAddr, time::Duration};
+use std::{fmt, net::SocketAddr, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use rustok_api::{PortActorKind, PortError};
-use tokio::{net::TcpStream, time::timeout};
+use tokio::time::timeout;
 
 use crate::{
     CommentsTcpAuthenticationConfigError, CommentsTcpBearerToken,
+    CommentsTcpChannelProtection, CommentsTcpClientChannelConnector,
     CommentsTcpDelegationConfigError, CommentsTcpDelegationSecret, CommentsTcpDelegationSigner,
     CommentsTcpOperation, CommentsTcpRequestEnvelope, CommentsThreadRequest,
     CommentsThreadResponse, CommentsThreadTransport, CommentsThreadTransportReply,
+    PlaintextLoopbackCommentsTcpChannel,
 };
 
 use crate::tcp_protocol::{
-    ensure_frame_size, io_error, read_frame, validate_frame_limit, write_frame,
+    ensure_frame_size, read_frame, validate_frame_limit, write_frame,
 };
 
 pub use crate::tcp_protocol::DEFAULT_MAX_COMMENTS_FRAME_BYTES;
 
-/// Concrete sidecar transport using length-prefixed JSON over TCP.
+/// Concrete sidecar transport using length-prefixed JSON over an injected byte channel.
 ///
-/// Each operation opens one connection, wraps the typed request in a versioned
+/// Each operation opens one channel, wraps the typed request in a versioned
 /// credential envelope, applies the port deadline to preparation and the complete
-/// exchange, and closes the connection after one typed reply. Reads and the
+/// exchange, and closes the channel after one typed reply. Reads and the
 /// host-owned system moderation path use the configured service bearer. User-
 /// owned writes use a short-lived signed delegation when a signer is configured.
-#[derive(Clone, Debug)]
+///
+/// The default connector is the built-in plaintext loopback-only compatibility
+/// channel. A host may inject an authenticated encrypted connector without
+/// changing framing, typed requests, bearer authentication, or user delegation.
+#[derive(Clone)]
 pub struct TcpJsonCommentsTransport {
     endpoint: SocketAddr,
+    channel_connector: Arc<dyn CommentsTcpClientChannelConnector>,
     bearer_token: Option<CommentsTcpBearerToken>,
     delegation_signer: Option<CommentsTcpDelegationSigner>,
     max_frame_bytes: usize,
@@ -34,8 +41,16 @@ pub struct TcpJsonCommentsTransport {
 
 impl TcpJsonCommentsTransport {
     pub fn new(endpoint: SocketAddr) -> Self {
+        Self::with_channel_connector(endpoint, plaintext_channel_connector())
+    }
+
+    pub fn with_channel_connector(
+        endpoint: SocketAddr,
+        channel_connector: Arc<dyn CommentsTcpClientChannelConnector>,
+    ) -> Self {
         Self {
             endpoint,
+            channel_connector,
             bearer_token: None,
             delegation_signer: None,
             max_frame_bytes: DEFAULT_MAX_COMMENTS_FRAME_BYTES,
@@ -43,8 +58,21 @@ impl TcpJsonCommentsTransport {
     }
 
     pub fn with_bearer_token(endpoint: SocketAddr, bearer_token: CommentsTcpBearerToken) -> Self {
+        Self::with_channel_connector_and_bearer_token(
+            endpoint,
+            plaintext_channel_connector(),
+            bearer_token,
+        )
+    }
+
+    pub fn with_channel_connector_and_bearer_token(
+        endpoint: SocketAddr,
+        channel_connector: Arc<dyn CommentsTcpClientChannelConnector>,
+        bearer_token: CommentsTcpBearerToken,
+    ) -> Self {
         Self {
             endpoint,
+            channel_connector,
             bearer_token: Some(bearer_token),
             delegation_signer: None,
             max_frame_bytes: DEFAULT_MAX_COMMENTS_FRAME_BYTES,
@@ -56,8 +84,23 @@ impl TcpJsonCommentsTransport {
         bearer_token: CommentsTcpBearerToken,
         delegation_signer: CommentsTcpDelegationSigner,
     ) -> Self {
+        Self::with_channel_connector_bearer_and_delegation(
+            endpoint,
+            plaintext_channel_connector(),
+            bearer_token,
+            delegation_signer,
+        )
+    }
+
+    pub fn with_channel_connector_bearer_and_delegation(
+        endpoint: SocketAddr,
+        channel_connector: Arc<dyn CommentsTcpClientChannelConnector>,
+        bearer_token: CommentsTcpBearerToken,
+        delegation_signer: CommentsTcpDelegationSigner,
+    ) -> Self {
         Self {
             endpoint,
+            channel_connector,
             bearer_token: Some(bearer_token),
             delegation_signer: Some(delegation_signer),
             max_frame_bytes: DEFAULT_MAX_COMMENTS_FRAME_BYTES,
@@ -94,9 +137,22 @@ impl TcpJsonCommentsTransport {
         endpoint: SocketAddr,
         max_frame_bytes: usize,
     ) -> Result<Self, PortError> {
+        Self::with_channel_connector_and_max_frame_bytes(
+            endpoint,
+            plaintext_channel_connector(),
+            max_frame_bytes,
+        )
+    }
+
+    pub fn with_channel_connector_and_max_frame_bytes(
+        endpoint: SocketAddr,
+        channel_connector: Arc<dyn CommentsTcpClientChannelConnector>,
+        max_frame_bytes: usize,
+    ) -> Result<Self, PortError> {
         validate_frame_limit(max_frame_bytes)?;
         Ok(Self {
             endpoint,
+            channel_connector,
             bearer_token: None,
             delegation_signer: None,
             max_frame_bytes,
@@ -111,6 +167,7 @@ impl TcpJsonCommentsTransport {
         validate_frame_limit(max_frame_bytes)?;
         Ok(Self {
             endpoint,
+            channel_connector: plaintext_channel_connector(),
             bearer_token: Some(bearer_token),
             delegation_signer: None,
             max_frame_bytes,
@@ -126,6 +183,7 @@ impl TcpJsonCommentsTransport {
         validate_frame_limit(max_frame_bytes)?;
         Ok(Self {
             endpoint,
+            channel_connector: plaintext_channel_connector(),
             bearer_token: Some(bearer_token),
             delegation_signer: Some(delegation_signer),
             max_frame_bytes,
@@ -140,6 +198,10 @@ impl TcpJsonCommentsTransport {
         self.max_frame_bytes
     }
 
+    pub fn channel_protection(&self) -> CommentsTcpChannelProtection {
+        self.channel_connector.protection()
+    }
+
     pub fn is_authenticated(&self) -> bool {
         self.bearer_token.is_some()
     }
@@ -152,15 +214,9 @@ impl TcpJsonCommentsTransport {
         &self,
         request_payload: &[u8],
     ) -> Result<CommentsThreadResponse, PortError> {
-        let mut stream = TcpStream::connect(self.endpoint)
-            .await
-            .map_err(|error| io_error("connect", error))?;
-        stream
-            .set_nodelay(true)
-            .map_err(|error| io_error("set_nodelay", error))?;
-
-        write_frame(&mut stream, request_payload, self.max_frame_bytes).await?;
-        let response_payload = read_frame(&mut stream, self.max_frame_bytes).await?;
+        let mut channel = self.channel_connector.connect(self.endpoint).await?;
+        write_frame(&mut *channel, request_payload, self.max_frame_bytes).await?;
+        let response_payload = read_frame(&mut *channel, self.max_frame_bytes).await?;
         decode_reply(&response_payload)
     }
 
@@ -197,6 +253,23 @@ impl TcpJsonCommentsTransport {
         ensure_frame_size(request_payload.len(), self.max_frame_bytes)?;
         self.exchange(&request_payload).await
     }
+}
+
+impl fmt::Debug for TcpJsonCommentsTransport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TcpJsonCommentsTransport")
+            .field("endpoint", &self.endpoint)
+            .field("channel_protection", &self.channel_connector.protection())
+            .field("bearer_token", &self.bearer_token)
+            .field("delegation_signer", &self.delegation_signer)
+            .field("max_frame_bytes", &self.max_frame_bytes)
+            .finish()
+    }
+}
+
+fn plaintext_channel_connector() -> Arc<dyn CommentsTcpClientChannelConnector> {
+    Arc::new(PlaintextLoopbackCommentsTcpChannel)
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -256,6 +329,16 @@ mod tests {
         let transport: Arc<dyn CommentsThreadTransport> =
             Arc::new(TcpJsonCommentsTransport::new(endpoint));
         let _ = transport;
+    }
+
+    #[test]
+    fn default_transport_is_plaintext_loopback() {
+        let endpoint = "127.0.0.1:1".parse().unwrap();
+        let transport = TcpJsonCommentsTransport::new(endpoint);
+        assert_eq!(
+            transport.channel_protection(),
+            CommentsTcpChannelProtection::PlaintextLoopback
+        );
     }
 
     #[test]

--- a/scripts/verify/verify-blog-comments-tcp-channel-seam.mjs
+++ b/scripts/verify/verify-blog-comments-tcp-channel-seam.mjs
@@ -1,0 +1,301 @@
+import fs from 'node:fs';
+
+const evidencePath =
+  'crates/rustok-blog/contracts/evidence/blog-comments-tcp-channel-seam.json';
+const planPath = 'crates/rustok-blog/docs/implementation-plan-slice-74.md';
+const lockPath = 'Cargo.lock';
+const manifestPath = 'crates/rustok-comments/Cargo.toml';
+const exportPath = 'crates/rustok-comments/src/lib.rs';
+const channelPath = 'crates/rustok-comments/src/tcp_channel.rs';
+const protocolPath = 'crates/rustok-comments/src/tcp_protocol.rs';
+const transportPath = 'crates/rustok-comments/src/tcp_transport.rs';
+const serverPath = 'crates/rustok-comments/src/tcp_server.rs';
+const authPath = 'crates/rustok-comments/src/tcp_auth.rs';
+const delegationPath = 'crates/rustok-comments/src/tcp_delegation.rs';
+const runtimePath = 'apps/server/src/services/comments_provider_runtime.rs';
+
+function read(path) {
+  return fs.readFileSync(path, 'utf8');
+}
+
+function fail(message) {
+  console.error(`[verify-blog-comments-tcp-channel-seam] ${message}`);
+  process.exit(1);
+}
+
+function requireCondition(condition, message) {
+  if (!condition) fail(message);
+}
+
+function requireText(source, fragment, label) {
+  requireCondition(source.includes(fragment), `${label} missing ${fragment}`);
+}
+
+function forbidText(source, fragment, label) {
+  requireCondition(!source.includes(fragment), `${label} contains forbidden ${fragment}`);
+}
+
+function sameSet(actual, expected, label) {
+  const left = [...actual].sort().join('|');
+  const right = [...expected].sort().join('|');
+  requireCondition(left === right, `${label} drift: expected ${right}, got ${left}`);
+}
+
+function packageBlock(lock, name) {
+  const marker = `[[package]]\nname = "${name}"\n`;
+  const start = lock.indexOf(marker);
+  requireCondition(start >= 0, `Cargo.lock missing package ${name}`);
+  const next = lock.indexOf('\n[[package]]', start + marker.length);
+  return lock.slice(start, next < 0 ? lock.length : next);
+}
+
+for (const path of [
+  evidencePath,
+  planPath,
+  lockPath,
+  manifestPath,
+  exportPath,
+  channelPath,
+  protocolPath,
+  transportPath,
+  serverPath,
+  authPath,
+  delegationPath,
+  runtimePath,
+]) {
+  requireCondition(fs.existsSync(path), `missing source artifact ${path}`);
+}
+
+const evidence = JSON.parse(read(evidencePath));
+const plan = read(planPath);
+const lock = read(lockPath);
+const manifest = read(manifestPath);
+const exports = read(exportPath);
+const channel = read(channelPath);
+const protocol = read(protocolPath);
+const transport = read(transportPath);
+const server = read(serverPath);
+const auth = read(authPath);
+const delegation = read(delegationPath);
+const runtime = read(runtimePath);
+
+requireCondition(evidence.schema_version === 1, 'evidence schema drift');
+requireCondition(
+  evidence.module === 'blog'
+    && evidence.provider === 'comments'
+    && evidence.surface === 'comments_tcp_channel_seam',
+  'evidence identity drift',
+);
+requireCondition(
+  evidence.status === 'source_verified_no_compile'
+    && evidence.compile_policy === 'not_run_by_request'
+    && evidence.runtime_status === 'not_run',
+  'evidence execution status drift',
+);
+requireCondition(evidence.generated_from === planPath, 'evidence plan path drift');
+requireCondition(
+  evidence.source_contract?.channel === channelPath
+    && evidence.source_contract?.framing === protocolPath
+    && evidence.source_contract?.client_transport === transportPath
+    && evidence.source_contract?.server_adapter === serverPath
+    && evidence.source_contract?.provider_export === exportPath
+    && evidence.source_contract?.provider_manifest === manifestPath
+    && evidence.source_contract?.lockfile === lockPath,
+  'evidence source path drift',
+);
+
+requireCondition(
+  evidence.channel_io?.trait === 'CommentsTcpIo'
+    && evidence.channel_io?.async_read === true
+    && evidence.channel_io?.async_write === true
+    && evidence.channel_io?.unpin === true
+    && evidence.channel_io?.send === true
+    && evidence.channel_io?.boxed_alias === 'BoxCommentsTcpIo'
+    && evidence.channel_io?.concrete_stream_erased_after_establishment === true,
+  'channel I/O evidence drift',
+);
+sameSet(
+  evidence.protection_classification?.values ?? [],
+  ['PlaintextLoopback', 'AuthenticatedEncrypted'],
+  'protection classification',
+);
+requireCondition(
+  evidence.protection_classification?.classification_is_runtime_evidence === false
+    && evidence.protection_classification?.classification_mints_comments_authority === false,
+  'classification non-claim drift',
+);
+
+requireCondition(
+  evidence.client_connector?.trait === 'CommentsTcpClientChannelConnector'
+    && evidence.client_connector?.host_injectable === true
+    && evidence.client_connector?.establishment_inside_port_deadline === true
+    && evidence.client_connector?.default === 'PlaintextLoopbackCommentsTcpChannel',
+  'client connector evidence drift',
+);
+requireCondition(
+  evidence.server_acceptor?.trait === 'CommentsTcpServerChannelAcceptor'
+    && evidence.server_acceptor?.runs_before_first_frame_read === true
+    && evidence.server_acceptor?.concrete_tls_acceptor_must_bound_handshake === true
+    && evidence.server_acceptor?.pre_request_timeout_starts_after_channel_establishment === true
+    && evidence.server_acceptor?.default === 'PlaintextLoopbackCommentsTcpChannel',
+  'server acceptor evidence drift',
+);
+requireCondition(
+  evidence.plaintext_profile?.client_endpoint_loopback_required === true
+    && evidence.plaintext_profile?.server_peer_loopback_required === true
+    && evidence.plaintext_profile?.non_loopback_error_code
+      === 'comments.tcp_plaintext_non_loopback'
+    && evidence.plaintext_profile?.host_non_loopback_enabled === false,
+  'plaintext profile evidence drift',
+);
+requireCondition(
+  evidence.framing?.generic_async_reader === true
+    && evidence.framing?.generic_async_writer === true
+    && evidence.framing?.owns_tcp_stream === false
+    && evidence.framing?.length_prefix === 'u32_big_endian'
+    && evidence.framing?.default_max_frame_bytes === 8388608
+    && evidence.framing?.one_request_one_reply === true,
+  'framing evidence drift',
+);
+requireCondition(
+  evidence.dependency_contract?.new_direct_dependencies?.length === 0
+    && evidence.dependency_contract?.rustok_comments_manifest_changed === false
+    && evidence.dependency_contract?.cargo_lock_changed === false
+    && evidence.dependency_contract?.rustls_adapter_implemented === false
+    && evidence.dependency_contract?.tokio_rustls_adapter_implemented === false,
+  'dependency evidence drift',
+);
+requireCondition(
+  evidence.non_claims?.tls_implemented === false
+    && evidence.non_claims?.mtls_implemented === false
+    && evidence.non_claims?.encrypted_host_profile === false
+    && evidence.non_claims?.non_loopback_safe === false
+    && evidence.non_claims?.compile_passed === false
+    && evidence.non_claims?.source_verifier_executed === false
+    && evidence.non_claims?.runtime_executed === false,
+  'non-claim evidence drift',
+);
+
+for (const fragment of [
+  'tcp-transport = ["server", "dep:tokio"]',
+  'tokio = { workspace = true, optional = true }',
+]) requireText(manifest, fragment, 'comments manifest');
+for (const fragment of [
+  'dep:rustls',
+  'dep:tokio-rustls',
+  'rustls =',
+  'tokio-rustls =',
+  'rustls-pemfile =',
+]) forbidText(manifest, fragment, 'comments manifest');
+const commentsLock = packageBlock(lock, 'rustok-comments');
+for (const fragment of ['"rustls"', '"tokio-rustls"', '"rustls-pemfile"']) {
+  forbidText(commentsLock, fragment, 'rustok-comments Cargo.lock entry');
+}
+
+for (const fragment of [
+  'pub mod tcp_channel;',
+  'BoxCommentsTcpIo',
+  'CommentsTcpChannelProtection',
+  'CommentsTcpClientChannelConnector',
+  'CommentsTcpIo',
+  'CommentsTcpServerChannelAcceptor',
+  'PlaintextLoopbackCommentsTcpChannel',
+]) requireText(exports, fragment, 'Comments channel exports');
+
+for (const fragment of [
+  'pub trait CommentsTcpIo: AsyncRead + AsyncWrite + Unpin + Send',
+  'impl<T> CommentsTcpIo for T where T: AsyncRead + AsyncWrite + Unpin + Send',
+  'pub type BoxCommentsTcpIo = Box<dyn CommentsTcpIo>;',
+  'pub enum CommentsTcpChannelProtection',
+  'PlaintextLoopback',
+  'AuthenticatedEncrypted',
+  'pub trait CommentsTcpClientChannelConnector: Send + Sync',
+  'async fn connect(&self, endpoint: SocketAddr)',
+  'pub trait CommentsTcpServerChannelAcceptor: Send + Sync',
+  'stream: TcpStream',
+  'peer_addr: SocketAddr',
+  'pub struct PlaintextLoopbackCommentsTcpChannel;',
+  'ensure_loopback(endpoint, "endpoint")?;',
+  'ensure_loopback(peer_addr, "peer")?;',
+  'comments.tcp_plaintext_non_loopback',
+  'stream.set_nodelay(true)',
+]) requireText(channel, fragment, 'channel source contract');
+for (const fragment of ['rustls::', 'tokio_rustls::', 'native_tls::', 'openssl::']) {
+  forbidText(channel, fragment, 'channel concrete crypto non-claim');
+}
+
+for (const fragment of [
+  'pub(crate) async fn write_frame<S>',
+  'S: AsyncWrite + Unpin + ?Sized',
+  'pub(crate) async fn read_frame<S>',
+  'S: AsyncRead + Unpin + ?Sized',
+  'length.to_be_bytes()',
+  'u32::from_be_bytes(length_bytes)',
+  'comments.tcp_invalid_frame_limit',
+  'comments.tcp_frame_too_large',
+]) requireText(protocol, fragment, 'generic framing');
+forbidText(protocol, 'net::TcpStream', 'generic framing');
+
+for (const fragment of [
+  'channel_connector: Arc<dyn CommentsTcpClientChannelConnector>',
+  'pub fn with_channel_connector(',
+  'pub fn with_channel_connector_and_bearer_token(',
+  'pub fn with_channel_connector_bearer_and_delegation(',
+  'pub fn with_channel_connector_and_max_frame_bytes(',
+  'pub fn channel_protection(&self) -> CommentsTcpChannelProtection',
+  'self.channel_connector.connect(self.endpoint).await?',
+  'write_frame(&mut *channel, request_payload, self.max_frame_bytes).await?;',
+  'read_frame(&mut *channel, self.max_frame_bytes).await?;',
+  'request.context().require_deadline_semantics()?;',
+  'self.prepare_and_exchange(request)',
+  'PlaintextLoopbackCommentsTcpChannel',
+  '.field("channel_protection", &self.channel_connector.protection())',
+]) requireText(transport, fragment, 'client channel injection');
+forbidText(transport, 'TcpStream::connect(self.endpoint)', 'client transport');
+
+for (const fragment of [
+  'pub async fn handle_connection(',
+  'pub async fn handle_connection_with_pre_request_timeout(',
+  'pub async fn handle_connection_with_acceptor(',
+  'pub async fn handle_connection_with_acceptor_and_pre_request_timeout(',
+  'acceptor: &dyn CommentsTcpServerChannelAcceptor',
+  'let channel = acceptor.accept(stream, peer_addr).await?;',
+  'mut channel: BoxCommentsTcpIo',
+  'channel: &mut dyn CommentsTcpIo',
+  'timeout(duration, read_frame(channel, self.max_frame_bytes))',
+  '.authorize(peer_addr, operation, credential.as_ref(), &request)',
+  'replace_request_context(&mut request, trusted_context);',
+  'dispatch_request(self.provider.as_ref(), request).await',
+]) requireText(server, fragment, 'server channel injection');
+
+for (const fragment of [
+  'CommentsTcpRequestEnvelope::with_bearer(request, token)',
+  '[REDACTED]',
+]) requireText(auth, fragment, 'retained bearer envelope');
+for (const fragment of [
+  'CommentsTcpDelegationSigner',
+  'comments.tcp_delegation_replayed',
+  'PortActor::user(claims.actor_id)',
+]) requireText(delegation, fragment, 'retained delegation authority');
+
+for (const fragment of [
+  'endpoint.ip().is_loopback()',
+  'bind_addr.ip().is_loopback()',
+  'RUSTOK_COMMENTS_TCP_BEARER_TOKEN',
+  'RUSTOK_COMMENTS_TCP_DELEGATION_SECRET',
+]) requireText(runtime, fragment, 'retained host restrictions');
+for (const fragment of ['CommentsTcpChannelProtection::AuthenticatedEncrypted', 'tokio_rustls']) {
+  forbidText(runtime, fragment, 'host encrypted-profile non-claim');
+}
+
+for (const fragment of [
+  '## Slice 74 — protected channel injection core',
+  'It deliberately does not claim that TLS or',
+  '`comments.tcp_plaintext_non_loopback`',
+  'The concrete rustls client connector, server acceptor,',
+  'Status: `source_verified_no_compile`.',
+  'Compile policy: `not_run_by_request`.',
+  'Runtime status: `not_run`.',
+]) requireText(plan, fragment, 'slice-74 plan');
+
+console.log('[verify-blog-comments-tcp-channel-seam] source contract verified');

--- a/scripts/verify/verify-blog-comments-tcp-server-adapter.mjs
+++ b/scripts/verify/verify-blog-comments-tcp-server-adapter.mjs
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 const evidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-tcp-server-adapter.json';
 const exportPath = 'crates/rustok-comments/src/lib.rs';
 const authPath = 'crates/rustok-comments/src/tcp_auth.rs';
+const channelPath = 'crates/rustok-comments/src/tcp_channel.rs';
 const protocolPath = 'crates/rustok-comments/src/tcp_protocol.rs';
 const remotePath = 'crates/rustok-comments/src/remote.rs';
 const serverPath = 'crates/rustok-comments/src/tcp_server.rs';
@@ -18,58 +19,58 @@ function fail(message) {
   process.exit(1);
 }
 
-function hasAll(text, snippets, label) {
-  for (const snippet of snippets) {
-    if (!text.includes(snippet)) fail(`${label} missing ${snippet}`);
-  }
+function requireCondition(condition, message) {
+  if (!condition) fail(message);
 }
 
-function hasNone(text, snippets, label) {
-  for (const snippet of snippets) {
-    if (text.includes(snippet)) fail(`${label} contains forbidden ${snippet}`);
-  }
+function requireText(source, fragment, label) {
+  requireCondition(source.includes(fragment), `${label} missing ${fragment}`);
 }
 
 function sameSet(actual, expected, label) {
   const left = [...actual].sort().join('|');
   const right = [...expected].sort().join('|');
-  if (left !== right) fail(`${label} drift: expected ${right}, got ${left}`);
+  requireCondition(left === right, `${label} drift: expected ${right}, got ${left}`);
 }
 
 for (const path of [
   evidencePath,
   exportPath,
   authPath,
+  channelPath,
   protocolPath,
   remotePath,
   serverPath,
   transportPath,
   planPath,
 ]) {
-  if (!fs.existsSync(path)) fail(`missing source artifact ${path}`);
+  requireCondition(fs.existsSync(path), `missing source artifact ${path}`);
 }
 
 const evidence = JSON.parse(read(evidencePath));
 const exports = read(exportPath);
 const auth = read(authPath);
+const channel = read(channelPath);
 const protocol = read(protocolPath);
 const remote = read(remotePath);
 const server = read(serverPath);
 const transport = read(transportPath);
 const plan = read(planPath);
 
-if (evidence.schema_version !== 1) fail('evidence schema_version drift');
-if (
-  evidence.module !== 'blog'
-  || evidence.provider !== 'comments'
-  || evidence.surface !== 'comments_tcp_server_adapter'
-) fail('evidence identity drift');
-if (
-  evidence.status !== 'source_verified_no_compile'
-  || evidence.compile_policy !== 'not_run_by_request'
-  || evidence.runtime_status !== 'not_run'
-) fail('evidence execution status drift');
-if (evidence.generated_from !== planPath) fail('evidence plan path drift');
+requireCondition(evidence.schema_version === 1, 'evidence schema drift');
+requireCondition(
+  evidence.module === 'blog'
+    && evidence.provider === 'comments'
+    && evidence.surface === 'comments_tcp_server_adapter',
+  'evidence identity drift',
+);
+requireCondition(
+  evidence.status === 'source_verified_no_compile'
+    && evidence.compile_policy === 'not_run_by_request'
+    && evidence.runtime_status === 'not_run',
+  'evidence execution status drift',
+);
+requireCondition(evidence.generated_from === planPath, 'historical plan path drift');
 
 sameSet(
   evidence.operations ?? [],
@@ -84,81 +85,68 @@ sameSet(
   ],
   'server operations',
 );
-
-if (
-  evidence.source_contract?.server_adapter !== serverPath
-  || evidence.source_contract?.shared_protocol !== protocolPath
-  || evidence.source_contract?.client_transport !== transportPath
-  || evidence.source_contract?.provider_export !== exportPath
-) fail('source contract path drift');
-
-if (
-  evidence.protocol?.identity !== 'comments_tcp_length_prefixed_json_v1'
-  || evidence.protocol?.length_prefix !== 'u32_big_endian'
-  || evidence.protocol?.default_max_frame_bytes !== 8388608
-  || evidence.protocol?.shared_client_server_framing !== true
-) fail('protocol evidence drift');
-
-if (
-  evidence.authority?.required !== true
-  || evidence.authority?.allow_all_fallback !== false
-  || evidence.authority?.tenant_match_required !== true
-) fail('authority evidence drift');
-
-hasAll(
-  protocol,
-  [
-    'pub const DEFAULT_MAX_COMMENTS_FRAME_BYTES: usize = 8 * 1024 * 1024;',
-    'length.to_be_bytes()',
-    'u32::from_be_bytes(length_bytes)',
-    'comments.tcp_invalid_frame_limit',
-    'comments.tcp_frame_too_large',
-  ],
-  'shared TCP protocol',
+requireCondition(
+  evidence.protocol?.length_prefix === 'u32_big_endian'
+    && evidence.protocol?.default_max_frame_bytes === 8388608
+    && evidence.protocol?.shared_client_server_framing === true,
+  'historical protocol drift',
+);
+requireCondition(
+  evidence.authority?.required === true
+    && evidence.authority?.allow_all_fallback === false
+    && evidence.authority?.tenant_match_required === true,
+  'authority evidence drift',
 );
 
-hasAll(
-  auth,
-  [
-    'pub const COMMENTS_TCP_PROTOCOL_VERSION: u16 = 1;',
-    'pub struct CommentsTcpCredential',
-    'pub struct CommentsTcpRequestEnvelope',
-    'pub struct CommentsTcpBearerAuthorityResolver',
-    'comments.tcp_authentication_failed',
-    'comments.tcp_operation_forbidden',
-  ],
-  'TCP authentication contract',
-);
+for (const fragment of [
+  'pub trait CommentsTcpServerChannelAcceptor: Send + Sync',
+  'async fn accept(',
+  'PlaintextLoopbackCommentsTcpChannel',
+  'comments.tcp_plaintext_non_loopback',
+]) requireText(channel, fragment, 'server channel seam');
 
-hasAll(
-  server,
-  [
-    'pub enum CommentsTcpOperation',
-    'pub const ALL: [Self; 7]',
-    'pub struct TrustedCommentsTcpAuthority',
-    'pub trait CommentsTcpAuthorityResolver: Send + Sync',
-    'credential: Option<&CommentsTcpCredential>',
-    'pub struct TcpJsonCommentsServerAdapter',
-    'authority: Arc<dyn CommentsTcpAuthorityResolver>',
-    'pub async fn handle_connection(',
-    'CommentsThreadTransportReply::Success(response)',
-    'CommentsThreadTransportReply::Error(error)',
-    'serde_json::from_slice::<CommentsTcpRequestEnvelope>',
-    'envelope.into_parts()',
-    'protocol_version != COMMENTS_TCP_PROTOCOL_VERSION',
-    'comments.tcp_server_unsupported_protocol',
-    'request.context().require_deadline_semantics()?;',
-    'credential.as_ref()',
-    'comments.tcp_authority_tenant_mismatch',
-    'trusted.actor = authority.actor;',
-    'trusted.claims = authority.claims;',
-    'trusted.roles = authority.roles;',
-    'dispatch_request(self.provider.as_ref(), request).await',
-    'comments.tcp_server_timeout',
-    'comments.tcp_server_invalid_request',
-  ],
-  'TCP server adapter',
-);
+for (const fragment of [
+  'pub(crate) async fn write_frame<S>',
+  'S: AsyncWrite + Unpin + ?Sized',
+  'pub(crate) async fn read_frame<S>',
+  'S: AsyncRead + Unpin + ?Sized',
+  'length.to_be_bytes()',
+  'u32::from_be_bytes(length_bytes)',
+]) requireText(protocol, fragment, 'generic framing');
+requireCondition(!protocol.includes('net::TcpStream'), 'framing must not own TcpStream');
+
+for (const fragment of [
+  'pub const COMMENTS_TCP_PROTOCOL_VERSION: u16 = 1;',
+  'pub struct CommentsTcpCredential',
+  'pub struct CommentsTcpRequestEnvelope',
+  'comments.tcp_authentication_failed',
+  'comments.tcp_operation_forbidden',
+]) requireText(auth, fragment, 'authentication contract');
+
+for (const fragment of [
+  'pub enum CommentsTcpOperation',
+  'pub const ALL: [Self; 7]',
+  'pub struct TrustedCommentsTcpAuthority',
+  'pub trait CommentsTcpAuthorityResolver: Send + Sync',
+  'pub struct TcpJsonCommentsServerAdapter',
+  'authority: Arc<dyn CommentsTcpAuthorityResolver>',
+  'pub async fn handle_connection(',
+  'pub async fn handle_connection_with_acceptor(',
+  'pub async fn handle_connection_with_acceptor_and_pre_request_timeout(',
+  'let channel = acceptor.accept(stream, peer_addr).await?;',
+  'mut channel: BoxCommentsTcpIo',
+  'channel: &mut dyn CommentsTcpIo',
+  'serde_json::from_slice::<CommentsTcpRequestEnvelope>',
+  'protocol_version != COMMENTS_TCP_PROTOCOL_VERSION',
+  'request.context().require_deadline_semantics()?;',
+  '.authorize(peer_addr, operation, credential.as_ref(), &request)',
+  'apply_authority(request.context(), authority)?',
+  'replace_request_context(&mut request, trusted_context);',
+  'dispatch_request(self.provider.as_ref(), request).await',
+  'comments.tcp_authority_tenant_mismatch',
+  'comments.tcp_server_timeout',
+  'comments.tcp_server_invalid_request',
+]) requireText(server, fragment, 'TCP server adapter');
 
 for (const variant of [
   'CreateComment',
@@ -169,70 +157,41 @@ for (const variant of [
   'SetCommentStatus',
   'DeleteComment',
 ]) {
-  if (!server.includes(`CommentsThreadRequest::${variant}`)) {
-    fail(`server dispatch missing ${variant}`);
-  }
+  requireCondition(
+    server.includes(`CommentsThreadRequest::${variant}`),
+    `server dispatch missing ${variant}`,
+  );
+}
+for (const forbidden of ['TcpListener', '.accept().await', 'AllowAll', 'retry(']) {
+  requireCondition(!server.includes(forbidden), `server contains forbidden ${forbidden}`);
 }
 
-hasNone(
-  server,
-  [
-    'TcpListener',
-    '.accept().await',
-    'loop {',
-    'AllowAll',
-    'retry(',
-  ],
-  'server adapter non-claims',
-);
+for (const fragment of [
+  'pub mod tcp_channel;',
+  'pub mod tcp_server;',
+  'CommentsTcpServerChannelAcceptor',
+  'PlaintextLoopbackCommentsTcpChannel',
+  'TcpJsonCommentsServerAdapter',
+]) requireText(exports, fragment, 'Comments exports');
 
-hasAll(
-  exports,
-  [
-    'pub mod tcp_auth;',
-    'mod tcp_protocol;',
-    'pub mod tcp_server;',
-    'pub mod tcp_transport;',
-    'CommentsTcpBearerAuthorityResolver',
-    'CommentsTcpRequestEnvelope',
-    'CommentsTcpAuthorityResolver, CommentsTcpOperation, TcpJsonCommentsServerAdapter,',
-    'TrustedCommentsTcpAuthority,',
-  ],
-  'Comments exports',
-);
+for (const fragment of [
+  'pub enum CommentsThreadRequest',
+  'pub enum CommentsThreadResponse',
+  'pub enum CommentsThreadTransportReply',
+]) requireText(remote, fragment, 'remote envelopes');
 
-hasAll(
-  remote,
-  [
-    'pub enum CommentsThreadRequest',
-    'pub enum CommentsThreadResponse',
-    'pub enum CommentsThreadTransportReply',
-  ],
-  'remote envelopes',
-);
+for (const fragment of [
+  'channel_connector: Arc<dyn CommentsTcpClientChannelConnector>',
+  'write_frame(&mut *channel, request_payload, self.max_frame_bytes).await?;',
+  'read_frame(&mut *channel, self.max_frame_bytes).await?;',
+]) requireText(transport, fragment, 'client shared framing');
 
-hasAll(
-  transport,
-  [
-    'use crate::tcp_protocol::{',
-    'pub use crate::tcp_protocol::DEFAULT_MAX_COMMENTS_FRAME_BYTES;',
-    'CommentsTcpRequestEnvelope::with_bearer(request, token)',
-    'write_frame(&mut stream, request_payload, self.max_frame_bytes).await?;',
-    'read_frame(&mut stream, self.max_frame_bytes).await?;',
-  ],
-  'TCP client shared framing',
-);
+for (const fragment of [
+  '# rustok-blog implementation plan — slice 69 continuation',
+  'CommentsTcpAuthorityResolver',
+  'source_verified_no_compile',
+  'host runtime configuration',
+  'not_run_by_request',
+]) requireText(plan, fragment, 'slice 69 plan');
 
-hasAll(
-  plan,
-  [
-    '# rustok-blog implementation plan — slice 69 continuation',
-    'CommentsTcpAuthorityResolver',
-    'source_verified_no_compile',
-    'host runtime configuration',
-    'not_run_by_request',
-  ],
-  'slice 69 plan',
-);
-
-console.log('[verify-blog-comments-tcp-server-adapter] source contract verified');
+console.log('[verify-blog-comments-tcp-server-adapter] retained server contract verified');

--- a/scripts/verify/verify-blog-comments-tcp-transport.mjs
+++ b/scripts/verify/verify-blog-comments-tcp-transport.mjs
@@ -3,8 +3,8 @@ import fs from 'node:fs';
 const evidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-tcp-transport.json';
 const manifestPath = 'crates/rustok-comments/Cargo.toml';
 const exportPath = 'crates/rustok-comments/src/lib.rs';
-const digestPath = 'crates/rustok-api/src/digest.rs';
 const authPath = 'crates/rustok-comments/src/tcp_auth.rs';
+const channelPath = 'crates/rustok-comments/src/tcp_channel.rs';
 const protocolPath = 'crates/rustok-comments/src/tcp_protocol.rs';
 const remotePath = 'crates/rustok-comments/src/remote.rs';
 const transportPath = 'crates/rustok-comments/src/tcp_transport.rs';
@@ -14,259 +14,175 @@ function read(path) {
   return fs.readFileSync(path, 'utf8');
 }
 
-function json(path) {
-  return JSON.parse(read(path));
-}
-
 function fail(message) {
   console.error(`[verify-blog-comments-tcp-transport] ${message}`);
   process.exit(1);
 }
 
-function hasAll(text, snippets, label) {
-  for (const snippet of snippets) {
-    if (!text.includes(snippet)) fail(`${label} missing ${snippet}`);
-  }
+function requireCondition(condition, message) {
+  if (!condition) fail(message);
 }
 
-function hasNone(text, snippets, label) {
-  for (const snippet of snippets) {
-    if (text.includes(snippet)) fail(`${label} contains forbidden ${snippet}`);
-  }
+function requireText(source, fragment, label) {
+  requireCondition(source.includes(fragment), `${label} missing ${fragment}`);
 }
 
 function sameSet(actual, expected, label) {
   const left = [...actual].sort().join('|');
   const right = [...expected].sort().join('|');
-  if (left !== right) fail(`${label} drift: expected ${right}, got ${left}`);
+  requireCondition(left === right, `${label} drift: expected ${right}, got ${left}`);
 }
 
 for (const path of [
   evidencePath,
   manifestPath,
   exportPath,
-  digestPath,
   authPath,
+  channelPath,
   protocolPath,
   remotePath,
   transportPath,
   planPath,
 ]) {
-  if (!fs.existsSync(path)) fail(`missing source artifact ${path}`);
+  requireCondition(fs.existsSync(path), `missing source artifact ${path}`);
 }
 
-const evidence = json(evidencePath);
+const evidence = JSON.parse(read(evidencePath));
 const manifest = read(manifestPath);
 const exports = read(exportPath);
-const digest = read(digestPath);
 const auth = read(authPath);
+const channel = read(channelPath);
 const protocol = read(protocolPath);
 const remote = read(remotePath);
 const transport = read(transportPath);
 const plan = read(planPath);
 
-if (evidence.schema_version !== 1) fail('evidence schema_version drift');
-if (
-  evidence.module !== 'blog'
-  || evidence.provider !== 'comments'
-  || evidence.surface !== 'comments_tcp_json_transport'
-) fail('evidence identity drift');
-if (
-  evidence.status !== 'source_verified_no_compile'
-  || evidence.compile_policy !== 'not_run_by_request'
-  || evidence.runtime_status !== 'not_run'
-) fail('evidence execution status drift');
-if (evidence.generated_from !== planPath) fail('evidence plan path drift');
-
-const expectedOperations = [
-  'CreateComment',
-  'GetComment',
-  'ListCommentsForTarget',
-  'ListPublicCommentsForTarget',
-  'UpdateComment',
-  'SetCommentStatus',
-  'DeleteComment',
-];
-sameSet(evidence.operations ?? [], expectedOperations, 'transport operations');
-
-if (
-  evidence.source_contract?.remote_core !== remotePath
-  || evidence.source_contract?.transport_adapter !== transportPath
-  || evidence.source_contract?.provider_export !== exportPath
-  || evidence.source_contract?.provider_manifest !== manifestPath
-) fail('source contract path drift');
-
-if (
-  evidence.protocol?.name !== 'comments_tcp_length_prefixed_json_v1'
-  || evidence.protocol?.length_prefix !== 'u32_big_endian'
-  || evidence.protocol?.request_encoding !== 'serde_json'
-  || evidence.protocol?.reply_encoding !== 'serde_json'
-  || evidence.protocol?.connection_scope !== 'one_request_one_reply'
-  || evidence.protocol?.default_max_frame_bytes !== 8388608
-  || evidence.protocol?.endpoint_owner !== 'host'
-) fail('protocol contract drift');
-
-if (
-  evidence.deadline?.source !== 'PortContext.deadline_ms'
-  || evidence.deadline?.required_before_connect !== true
-  || evidence.deadline?.scope !== 'connect_write_read_decode'
-  || evidence.deadline?.mechanism !== 'tokio::time::timeout'
-  || evidence.deadline?.timeout_code !== 'comments.tcp_timeout'
-) fail('deadline contract drift');
-
-if (evidence.fail_closed?.retry_implemented !== false) fail('retry status drift');
+requireCondition(evidence.schema_version === 1, 'evidence schema drift');
+requireCondition(
+  evidence.module === 'blog'
+    && evidence.provider === 'comments'
+    && evidence.surface === 'comments_tcp_json_transport',
+  'evidence identity drift',
+);
+requireCondition(
+  evidence.status === 'source_verified_no_compile'
+    && evidence.compile_policy === 'not_run_by_request'
+    && evidence.runtime_status === 'not_run',
+  'evidence execution status drift',
+);
+requireCondition(evidence.generated_from === planPath, 'historical plan path drift');
 
 sameSet(
-  evidence.pending ?? [],
+  evidence.operations ?? [],
   [
-    'tcp_server_adapter',
-    'endpoint_discovery',
-    'authentication',
-    'retry_backoff',
-    'host_publication',
-    'in_process_remote_runtime_parity',
-    'runtime_execution',
+    'CreateComment',
+    'GetComment',
+    'ListCommentsForTarget',
+    'ListPublicCommentsForTarget',
+    'UpdateComment',
+    'SetCommentStatus',
+    'DeleteComment',
   ],
-  'historical slice 68 pending scope',
+  'transport operations',
 );
+requireCondition(
+  evidence.protocol?.length_prefix === 'u32_big_endian'
+    && evidence.protocol?.request_encoding === 'serde_json'
+    && evidence.protocol?.reply_encoding === 'serde_json'
+    && evidence.protocol?.connection_scope === 'one_request_one_reply'
+    && evidence.protocol?.default_max_frame_bytes === 8388608,
+  'historical protocol drift',
+);
+requireCondition(
+  evidence.deadline?.source === 'PortContext.deadline_ms'
+    && evidence.deadline?.required_before_connect === true
+    && evidence.deadline?.mechanism === 'tokio::time::timeout'
+    && evidence.deadline?.timeout_code === 'comments.tcp_timeout',
+  'historical deadline drift',
+);
+requireCondition(evidence.fail_closed?.retry_implemented === false, 'retry status drift');
 
-hasAll(
-  manifest,
-  [
-    'tcp-transport = ["server", "dep:tokio"]',
-    'tokio = { workspace = true, optional = true }',
-  ],
-  'comments manifest',
-);
-hasNone(
-  manifest,
-  [
-    'dep:sha2',
-    'dep:subtle',
-    'sha2 = { workspace = true, optional = true }',
-    'subtle = { version = "2", optional = true }',
-  ],
-  'comments manifest lock compatibility',
-);
-
-hasAll(
-  exports,
-  [
-    '#[cfg(feature = "tcp-transport")]',
-    'pub mod tcp_auth;',
-    'mod tcp_protocol;',
-    'pub mod tcp_transport;',
-    'CommentsTcpBearerToken',
-    'CommentsTcpRequestEnvelope',
-    'pub use tcp_transport::TcpJsonCommentsTransport;',
-  ],
-  'comments exports',
-);
-
-hasAll(
-  digest,
-  [
-    'pub const SHA256_DIGEST_BYTES: usize = 32;',
-    'pub fn sha256_digest(',
-    'pub fn fixed_work_sha256_eq(',
-    'difference |= expected[index] ^ candidate[index];',
-    'does not claim',
-  ],
-  'shared digest helper',
-);
-
-hasAll(
-  auth,
-  [
-    'pub const COMMENTS_TCP_PROTOCOL_VERSION: u16 = 1;',
-    'pub struct CommentsTcpBearerToken',
-    'pub struct CommentsTcpCredential',
-    'pub struct CommentsTcpRequestEnvelope',
-    'fixed_work_sha256_eq',
-    'sha256_digest(&[BEARER_PREFIX, secret])',
-    '[REDACTED]',
-  ],
-  'TCP authentication envelope',
-);
-hasNone(auth, ['ConstantTimeEq', 'use sha2::', 'use subtle::'], 'TCP auth dependency boundary');
-
-hasAll(
-  remote,
-  [
-    'pub fn context(&self) -> &PortContext',
-    'pub enum CommentsThreadTransportReply',
-    'Success(CommentsThreadResponse)',
-    'Error(PortError)',
-  ],
-  'remote core',
-);
-for (const operation of expectedOperations) {
-  if (!remote.includes(`Self::${operation} { context, .. }`)) {
-    fail(`remote request context coverage missing ${operation}`);
-  }
+for (const fragment of [
+  'tcp-transport = ["server", "dep:tokio"]',
+  'tokio = { workspace = true, optional = true }',
+]) requireText(manifest, fragment, 'comments manifest');
+for (const forbidden of ['dep:rustls', 'dep:tokio-rustls', 'rustls =', 'tokio-rustls =']) {
+  requireCondition(!manifest.includes(forbidden), `comments manifest contains ${forbidden}`);
 }
 
-hasAll(
-  protocol,
-  [
-    'pub const DEFAULT_MAX_COMMENTS_FRAME_BYTES: usize = 8 * 1024 * 1024;',
-    'length.to_be_bytes()',
-    'u32::from_be_bytes(length_bytes)',
-    'comments.tcp_invalid_frame_limit',
-    'comments.tcp_frame_too_large',
-    'comments.tcp_unavailable',
-    'comments.tcp_timeout',
-  ],
-  'shared TCP protocol',
-);
+for (const fragment of [
+  'pub mod tcp_auth;',
+  'pub mod tcp_channel;',
+  'mod tcp_protocol;',
+  'pub mod tcp_transport;',
+  'CommentsTcpClientChannelConnector',
+  'PlaintextLoopbackCommentsTcpChannel',
+  'TcpJsonCommentsTransport',
+]) requireText(exports, fragment, 'comments exports');
 
-hasAll(
-  transport,
-  [
-    'pub struct TcpJsonCommentsTransport',
-    'impl CommentsThreadTransport for TcpJsonCommentsTransport',
-    'TcpStream::connect(self.endpoint)',
-    'request.context().require_deadline_semantics()?;',
-    'Duration::from_millis(deadline_ms)',
-    'self.exchange(&request_payload)',
-    'write_frame(&mut stream, request_payload, self.max_frame_bytes).await?;',
-    'read_frame(&mut stream, self.max_frame_bytes).await?;',
-    'CommentsTcpRequestEnvelope::with_bearer(request, token)',
-    'CommentsTcpRequestEnvelope::unauthenticated(request)',
-    'CommentsThreadTransportReply::Success(response)',
-    'CommentsThreadTransportReply::Error(error)',
-    'comments.tcp_encode',
-    'comments.tcp_decode',
-    'provider_error_reply_is_preserved',
-    'tcp_transport_is_injectable_without_connecting',
-    'bearer_transport_debug_is_redacted',
-  ],
-  'TCP transport',
-);
+for (const fragment of [
+  'pub const COMMENTS_TCP_PROTOCOL_VERSION: u16 = 1;',
+  'pub struct CommentsTcpRequestEnvelope',
+  'CommentsTcpRequestEnvelope',
+  '[REDACTED]',
+]) requireText(auth, fragment, 'authentication envelope');
 
-hasNone(
-  transport,
-  [
-    'loop {',
-    'retry(',
-    'println!(',
-    'tracing::info!',
-  ],
-  'TCP transport non-claims',
-);
+for (const fragment of [
+  'pub trait CommentsTcpIo: AsyncRead + AsyncWrite + Unpin + Send',
+  'pub trait CommentsTcpClientChannelConnector: Send + Sync',
+  'async fn connect(&self, endpoint: SocketAddr)',
+  'PlaintextLoopback',
+  'AuthenticatedEncrypted',
+  'ensure_loopback(endpoint, "endpoint")?;',
+  'comments.tcp_plaintext_non_loopback',
+]) requireText(channel, fragment, 'channel connector');
 
-hasAll(
-  plan,
-  [
-    '# rustok-blog implementation plan — slice 68 continuation',
-    'comments_tcp_length_prefixed_json_v1',
-    'source_verified_no_compile',
-    'tcp_server_adapter',
-    'host_publication',
-    'retry_backoff',
-    'not_run_by_request',
-  ],
-  'slice 68 plan',
-);
+for (const fragment of [
+  'pub(crate) async fn write_frame<S>',
+  'S: AsyncWrite + Unpin + ?Sized',
+  'pub(crate) async fn read_frame<S>',
+  'S: AsyncRead + Unpin + ?Sized',
+  'length.to_be_bytes()',
+  'u32::from_be_bytes(length_bytes)',
+  'comments.tcp_invalid_frame_limit',
+  'comments.tcp_frame_too_large',
+]) requireText(protocol, fragment, 'generic framing');
+requireCondition(!protocol.includes('net::TcpStream'), 'framing must not own TcpStream');
 
-console.log('[verify-blog-comments-tcp-transport] source contract verified');
+for (const fragment of [
+  'pub enum CommentsThreadRequest',
+  'pub enum CommentsThreadTransportReply',
+  'Success(CommentsThreadResponse)',
+  'Error(PortError)',
+]) requireText(remote, fragment, 'remote typed core');
+
+for (const fragment of [
+  'channel_connector: Arc<dyn CommentsTcpClientChannelConnector>',
+  'pub fn with_channel_connector(',
+  'pub fn with_channel_connector_and_bearer_token(',
+  'pub fn with_channel_connector_bearer_and_delegation(',
+  'self.channel_connector.connect(self.endpoint).await?',
+  'write_frame(&mut *channel, request_payload, self.max_frame_bytes).await?;',
+  'read_frame(&mut *channel, self.max_frame_bytes).await?;',
+  'request.context().require_deadline_semantics()?;',
+  'Duration::from_millis(deadline_ms)',
+  'self.prepare_and_exchange(request)',
+  'CommentsTcpRequestEnvelope::with_bearer(request, token)',
+  'CommentsThreadTransportReply::Success(response)',
+  'CommentsThreadTransportReply::Error(error)',
+  'pub fn channel_protection(&self) -> CommentsTcpChannelProtection',
+  'default_transport_is_plaintext_loopback',
+]) requireText(transport, fragment, 'TCP transport');
+for (const forbidden of ['TcpStream::connect(self.endpoint)', 'retry(', 'println!(', 'tracing::info!']) {
+  requireCondition(!transport.includes(forbidden), `transport contains forbidden ${forbidden}`);
+}
+
+for (const fragment of [
+  '# rustok-blog implementation plan — slice 68 continuation',
+  'comments_tcp_length_prefixed_json_v1',
+  'source_verified_no_compile',
+  'retry_backoff',
+  'not_run_by_request',
+]) requireText(plan, fragment, 'slice 68 plan');
+
+console.log('[verify-blog-comments-tcp-transport] retained transport contract verified');


### PR DESCRIPTION
## Summary

- continue the Blog improvement plan with slice 74
- add a transport-owned async byte-channel abstraction for Comments framing and typed transport
- add client connector and server acceptor traits for future authenticated encrypted channels
- preserve a built-in plaintext compatibility channel that independently rejects non-loopback client endpoints and server peers
- make length-prefixed framing generic over `AsyncRead` and `AsyncWrite` instead of owning `TcpStream`
- inject `Arc<dyn CommentsTcpClientChannelConnector>` into `TcpJsonCommentsTransport`
- keep connector establishment, credential preparation, encoding, write, read, and decode inside the original port deadline
- add server adapter methods that establish an injected channel before reading the first typed frame
- keep the request idle timeout scoped to the first complete frame after channel establishment; a future TLS acceptor must own a separate handshake timeout
- preserve protocol versioning, bearer reads, signed user writes, service moderation, tenant equality, principal replacement, owner policy, exact provider errors, and one-request/one-reply scope
- retain the existing host runtime and its explicit loopback endpoint/listener restrictions
- add slice-74 plan, machine-readable source evidence, and a standalone source guard
- reconcile the retained slice-68 client and slice-69 server source guards
- add no direct dependency and make no `Cargo.lock` change

## Explicit non-claims

- this PR does not implement TLS or mTLS
- no certificate, key, CA, DNS/SNI, ALPN, revocation, or handshake configuration is added
- `AuthenticatedEncrypted` is a source-level classification contract, not runtime security evidence
- no encrypted built-in host profile or non-loopback publication is enabled
- no channel-derived Comments authority is introduced
- no retry/backoff, shared replay store, readiness, or runtime evidence is added

## Verification

Tests, source verifiers, formatting, Cargo checks, TCP/TLS runtime targets, database targets, browser targets, workflows, and CI were intentionally not run by request. Suggested maintainer commands are recorded in `crates/rustok-blog/docs/implementation-plan-slice-74.md`.