### PR TITLE
test(forum): add aggregate runtime evidence assembler

### DIFF
--- a/crates/rustok-forum/contracts/forum-search-versioned-invalidation-aggregate-evidence-assembler.json
+++ b/crates/rustok-forum/contracts/forum-search-versioned-invalidation-aggregate-evidence-assembler.json
@@ -1,0 +1,57 @@
+{
+  "contract": "forum_search_versioned_invalidation_aggregate_evidence_assembler_v1",
+  "task": "FORUM-23B2G2B3D11",
+  "status": "source_ready_maintainer_execution_pending",
+  "runtime_evidence_parent": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json",
+  "assembler": "scripts/evidence/assemble-forum-search-versioned-invalidation-runtime-evidence.mjs",
+  "verifier": "scripts/verify/verify-forum-search-versioned-invalidation-aggregate-evidence-assembler.mjs",
+  "input_artifacts": [
+    "target/forum-search-versioned-invalidation-postgres-ingress-evidence.json",
+    "target/forum-search-versioned-invalidation-ack-restart-evidence.json",
+    "target/forum-search-versioned-invalidation-raw-poison-evidence.json",
+    "target/forum-search-versioned-invalidation-semantic-poison-evidence.json",
+    "target/forum-search-versioned-invalidation-missing-delivery-repair-evidence.json",
+    "target/forum-search-versioned-invalidation-multi-process-evidence.json",
+    "target/forum-search-versioned-invalidation-deletion-acl-ordering-evidence.json",
+    "target/forum-search-versioned-invalidation-search-disabled-recovery-evidence.json",
+    "target/forum-search-versioned-invalidation-normal-delivery-evidence.json"
+  ],
+  "output_artifact": {
+    "path": "target/forum-search-versioned-invalidation-runtime-evidence.json",
+    "generation": "assembler_only_after_all_runtime_subproofs_pass",
+    "hand_editing_forbidden": true,
+    "source_commit_required": true,
+    "atomic_replace": true
+  },
+  "fail_closed_requirements": [
+    "all nine D2 through D10 evidence files must exist and parse as JSON",
+    "every input contract and task must match its exact registered subproof",
+    "every required input scenario must be present exactly once with result passed and non-empty facts",
+    "all input artifacts must report PostgreSQL and one identical forty-character source commit",
+    "the shared source commit must equal git rev-parse HEAD at assembly time",
+    "all Iggy-backed artifacts must report outbox_iggy, the canonical consumer group and topic domain",
+    "the parent D0 contract must retain the exact ten frozen required scenarios",
+    "the assembler must derive the output from input bytes and record a SHA-256 digest for every source artifact",
+    "the output must contain every D0 required field and may be written only after all validation succeeds"
+  ],
+  "frozen_scenario_sources": {
+    "normal_delivery": "FORUM-23B2G2B3D10:normal_delivery",
+    "legacy_first_duplicate": "FORUM-23B2G2B3D2:legacy_first_duplicate",
+    "typed_first_duplicate": "FORUM-23B2G2B3D2:typed_first_duplicate",
+    "acknowledgement_failure_restart": "FORUM-23B2G2B3D3:acknowledgement_failure_restart",
+    "raw_poison_dlq_redelivery": "FORUM-23B2G2B3D4:raw_poison_dlq_redelivery",
+    "semantic_poison_identity_conflict": "FORUM-23B2G2B3D5:semantic_poison_identity_conflict",
+    "missing_delivery_owner_repair": "FORUM-23B2G2B3D6:missing_delivery_owner_repair",
+    "multi_process_serialization": "FORUM-23B2G2B3D7:multi_process_serialization",
+    "deletion_acl_ordering": "FORUM-23B2G2B3D8:deletion_acl_ordering",
+    "search_disabled_profile": "FORUM-23B2G2B3D9:search_disabled_profile"
+  },
+  "maintainer_command": "node scripts/evidence/assemble-forum-search-versioned-invalidation-runtime-evidence.mjs",
+  "non_claims": [
+    "this source-ready assembler does not claim that any PostgreSQL, Iggy, restart, poison, DLQ or multi-process command passed",
+    "the assembler does not execute D2 through D10 tests or create missing subproof evidence",
+    "the assembler does not accept mixed commits, skipped scenarios, static fixtures or manually edited aggregate output",
+    "this slice does not promote the D0 contract, FORUM-23 or LINK-FORUM-03 to complete",
+    "runtime completion still requires maintainer execution and retention of the generated aggregate artifact"
+  ]
+}

--- a/crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json
+++ b/crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json
@@ -205,6 +205,23 @@
         "multi_process_deletion_acl_or_search_disabled_profiles",
         "aggregate_d0_artifact_assembly_or_link_forum_03"
       ]
+    },
+    {
+      "task": "FORUM-23B2G2B3D11",
+      "contract": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-aggregate-evidence-assembler.json",
+      "assembler": "scripts/evidence/assemble-forum-search-versioned-invalidation-runtime-evidence.mjs",
+      "evidence_artifact": "target/forum-search-versioned-invalidation-runtime-evidence.json",
+      "covers": [
+        "all_nine_runtime_subproof_artifacts_required",
+        "same_source_commit_aggregate_assembly",
+        "exact_ten_scenario_mapping",
+        "input_sha256_and_parent_digest_retention",
+        "atomic_output_after_complete_validation"
+      ],
+      "does_not_cover": [
+        "runtime_execution_or_d0_status_promotion",
+        "link_forum_03_or_release_completion"
+      ]
     }
   ],
   "required_runtime": {
@@ -348,6 +365,8 @@
     "RUSTOK_SEARCH_TEST_DATABASE_URL=\"$DATABASE_URL\" cargo test -p rustok-server --test forum_versioned_invalidation_search_disabled_recovery -- --nocapture --test-threads=1",
     "node scripts/verify/verify-forum-search-versioned-invalidation-normal-delivery-proof.mjs",
     "RUSTOK_SEARCH_TEST_DATABASE_URL=\"$DATABASE_URL\" RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS=\"127.0.0.1:8090\" cargo test -p rustok-server --test forum_versioned_invalidation_normal_delivery_iggy -- --nocapture --test-threads=1",
+    "node scripts/verify/verify-forum-search-versioned-invalidation-aggregate-evidence-assembler.mjs",
+    "node scripts/evidence/assemble-forum-search-versioned-invalidation-runtime-evidence.mjs",
     "cargo run -p rustok-events --example event_contract_digests",
     "cargo test -p rustok-events",
     "cargo test -p rustok-search forum_contract_ingress -- --nocapture",

--- a/crates/rustok-forum/docs/forum-23b2g2b3d11-aggregate-evidence-assembler.md
+++ b/crates/rustok-forum/docs/forum-23b2g2b3d11-aggregate-evidence-assembler.md
@@ -1,0 +1,121 @@
+# FORUM-23B2G2B3D11 aggregate evidence assembler
+
+## Status
+
+`source_ready_maintainer_execution_pending`
+
+This slice adds the fail-closed assembly boundary for the aggregate
+`FORUM-23B2G2B3D0` runtime artifact. It does not execute any Forum, Search,
+PostgreSQL, Iggy, restart, poison, DLQ or multi-process scenario and does not
+promote D0 to runtime-complete.
+
+The machine contract is:
+
+```text
+crates/rustok-forum/contracts/forum-search-versioned-invalidation-aggregate-evidence-assembler.json
+```
+
+The assembler is:
+
+```text
+scripts/evidence/assemble-forum-search-versioned-invalidation-runtime-evidence.mjs
+```
+
+The retained output path remains:
+
+```text
+target/forum-search-versioned-invalidation-runtime-evidence.json
+```
+
+## Why assembly is a separate gate
+
+D2 through D10 deliberately generate separate executable artifacts. A maintainer
+may run one proof, change source, and later run another proof. Merely finding nine
+JSON files under `target/` therefore cannot establish one reviewed runtime
+baseline.
+
+D11 requires every subproof to be regenerated from one exact source commit and
+refuses to combine mixed or stale evidence. This preserves the D0 requirement
+that all ten frozen scenarios describe one source tree rather than a collection
+of unrelated successful runs.
+
+## Required input set
+
+The assembler requires all nine executable artifacts:
+
+- D2 PostgreSQL ingress and legacy/typed duplicate evidence;
+- D3 acknowledgement failure and consumer restart evidence;
+- D4 raw poison, durable receipt and deterministic DLQ evidence;
+- D5 semantic inbox-identity poison evidence;
+- D6 missing-delivery owner-ledger repair evidence;
+- D7 multi-process lock, checkpoint and scan-cursor evidence;
+- D8 deletion, richer ACL and storefront fail-closed evidence;
+- D9 Search-disabled owner continuity and late recovery evidence;
+- D10 correlated normal owner delivery through Iggy, projection, checkpoint and
+  storefront visibility.
+
+D2 supplies both frozen duplicate scenarios. D10 supplies the frozen successful
+`normal_delivery` scenario. The remaining artifacts supply one frozen scenario
+each.
+
+## Fail-closed validation
+
+Before any output file is written, the assembler requires:
+
+1. every input path to exist and contain valid JSON;
+2. exact contract and task identities for D2 through D10;
+3. exact scenario order and membership for each input artifact;
+4. every scenario result to equal `passed` and contain non-empty facts;
+5. `database_backend` to equal `postgresql` for every input;
+6. all nine `source_commit` values to be one lowercase forty-character SHA;
+7. that shared SHA to equal `git rev-parse HEAD` at assembly time;
+8. every Iggy-backed artifact to report `outbox_iggy`, consumer group
+   `rustok-search-forum-projection-v1`, topic `domain` and a non-empty stream;
+9. the D0 parent contract to retain the exact ten frozen scenarios and every
+   required aggregate field;
+10. every D2 through D10 artifact path to remain registered in D0.
+
+Failure at any step throws before output creation or replacement. There is no
+skip mode, partial mode, best-effort mode, alternate source-commit argument or
+static fixture fallback.
+
+## Aggregate artifact
+
+After complete validation, the assembler writes one JSON document by atomic
+rename. It records:
+
+- the exact source commit and assembly time;
+- PostgreSQL, `outbox_iggy`, canonical consumer-group and topic identity;
+- all ten frozen scenario results, preserving each source artifact's facts;
+- grouped owner-revision, root/typed identity, inbox, ingest-sequence,
+  checkpoint, poison, DLQ and storefront evidence;
+- D2 supporting typed-ingress and semantic-collision facts;
+- every source artifact's task, contract, path, generated time, byte length and
+  SHA-256 digest;
+- the D0 parent-contract SHA-256 digest and assembly invariants.
+
+The grouped fields retain source attribution rather than inventing a normalized
+fact that an individual executable proof did not emit.
+
+## Maintainer order
+
+Run the D2 through D10 static verifiers and executable commands from the D0
+contract on the same checked-out commit. Confirm that each expected artifact was
+created; skipped tests do not create acceptable evidence. Then run:
+
+```bash
+node scripts/verify/verify-forum-search-versioned-invalidation-aggregate-evidence-assembler.mjs
+node scripts/evidence/assemble-forum-search-versioned-invalidation-runtime-evidence.mjs
+```
+
+A later retention/review step may inspect the generated aggregate artifact and
+only then decide whether the canonical D0 status can be promoted. The assembler
+itself does not edit the D0 contract, the Forum plan or `LINK-FORUM-03`.
+
+## Compatibility
+
+D11 adds scripts, documentation and machine contracts only. It changes no Rust
+production path, migration, event schema or digest, DTO, runtime flag,
+dependency, `Cargo.toml` or `Cargo.lock` entry.
+
+No command above was run by the implementation agent, per maintainer request.

--- a/scripts/evidence/assemble-forum-search-versioned-invalidation-runtime-evidence.mjs
+++ b/scripts/evidence/assemble-forum-search-versioned-invalidation-runtime-evidence.mjs
@@ -1,0 +1,466 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const root = process.cwd();
+const parentContractPath =
+  "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json";
+const outputPath =
+  "target/forum-search-versioned-invalidation-runtime-evidence.json";
+const canonicalConsumerGroup = "rustok-search-forum-projection-v1";
+const canonicalTopic = "domain";
+const frozenScenarioIds = [
+  "normal_delivery",
+  "legacy_first_duplicate",
+  "typed_first_duplicate",
+  "acknowledgement_failure_restart",
+  "raw_poison_dlq_redelivery",
+  "semantic_poison_identity_conflict",
+  "missing_delivery_owner_repair",
+  "multi_process_serialization",
+  "deletion_acl_ordering",
+  "search_disabled_profile",
+];
+
+const manifest = [
+  {
+    task: "FORUM-23B2G2B3D2",
+    contract: "forum_search_versioned_invalidation_postgres_ingress_evidence_v1",
+    path: "target/forum-search-versioned-invalidation-postgres-ingress-evidence.json",
+    scenarios: [
+      "typed_ingress_admission",
+      "legacy_first_duplicate",
+      "typed_first_duplicate",
+      "semantic_identity_conflict",
+    ],
+    iggy: false,
+  },
+  {
+    task: "FORUM-23B2G2B3D3",
+    contract: "forum_search_versioned_invalidation_ack_restart_evidence_v1",
+    path: "target/forum-search-versioned-invalidation-ack-restart-evidence.json",
+    scenarios: ["acknowledgement_failure_restart"],
+    iggy: true,
+  },
+  {
+    task: "FORUM-23B2G2B3D4",
+    contract: "forum_search_versioned_invalidation_raw_poison_evidence_v1",
+    path: "target/forum-search-versioned-invalidation-raw-poison-evidence.json",
+    scenarios: ["raw_poison_dlq_redelivery"],
+    iggy: true,
+  },
+  {
+    task: "FORUM-23B2G2B3D5",
+    contract: "forum_search_versioned_invalidation_semantic_poison_evidence_v1",
+    path: "target/forum-search-versioned-invalidation-semantic-poison-evidence.json",
+    scenarios: ["semantic_poison_identity_conflict"],
+    iggy: true,
+  },
+  {
+    task: "FORUM-23B2G2B3D6",
+    contract: "forum_search_versioned_invalidation_missing_delivery_repair_evidence_v1",
+    path: "target/forum-search-versioned-invalidation-missing-delivery-repair-evidence.json",
+    scenarios: ["missing_delivery_owner_repair"],
+    iggy: false,
+  },
+  {
+    task: "FORUM-23B2G2B3D7",
+    contract: "forum_search_versioned_invalidation_multi_process_evidence_v1",
+    path: "target/forum-search-versioned-invalidation-multi-process-evidence.json",
+    scenarios: ["multi_process_serialization"],
+    iggy: false,
+  },
+  {
+    task: "FORUM-23B2G2B3D8",
+    contract: "forum_search_versioned_invalidation_deletion_acl_ordering_evidence_v1",
+    path: "target/forum-search-versioned-invalidation-deletion-acl-ordering-evidence.json",
+    scenarios: ["deletion_acl_ordering"],
+    iggy: false,
+  },
+  {
+    task: "FORUM-23B2G2B3D9",
+    contract: "forum_search_versioned_invalidation_search_disabled_recovery_evidence_v1",
+    path: "target/forum-search-versioned-invalidation-search-disabled-recovery-evidence.json",
+    scenarios: ["search_disabled_profile"],
+    iggy: false,
+  },
+  {
+    task: "FORUM-23B2G2B3D10",
+    contract: "forum_search_versioned_invalidation_normal_delivery_evidence_v1",
+    path: "target/forum-search-versioned-invalidation-normal-delivery-evidence.json",
+    scenarios: ["normal_delivery"],
+    iggy: true,
+  },
+];
+
+const frozenScenarioSources = new Map([
+  ["normal_delivery", ["FORUM-23B2G2B3D10", "normal_delivery"]],
+  ["legacy_first_duplicate", ["FORUM-23B2G2B3D2", "legacy_first_duplicate"]],
+  ["typed_first_duplicate", ["FORUM-23B2G2B3D2", "typed_first_duplicate"]],
+  [
+    "acknowledgement_failure_restart",
+    ["FORUM-23B2G2B3D3", "acknowledgement_failure_restart"],
+  ],
+  ["raw_poison_dlq_redelivery", ["FORUM-23B2G2B3D4", "raw_poison_dlq_redelivery"]],
+  [
+    "semantic_poison_identity_conflict",
+    ["FORUM-23B2G2B3D5", "semantic_poison_identity_conflict"],
+  ],
+  [
+    "missing_delivery_owner_repair",
+    ["FORUM-23B2G2B3D6", "missing_delivery_owner_repair"],
+  ],
+  ["multi_process_serialization", ["FORUM-23B2G2B3D7", "multi_process_serialization"]],
+  ["deletion_acl_ordering", ["FORUM-23B2G2B3D8", "deletion_acl_ordering"]],
+  ["search_disabled_profile", ["FORUM-23B2G2B3D9", "search_disabled_profile"]],
+]);
+
+function fail(message) {
+  throw new Error(`Forum Search aggregate evidence assembly failed: ${message}`);
+}
+
+function readBytes(path) {
+  try {
+    return readFileSync(resolve(root, path));
+  } catch (error) {
+    fail(`required artifact ${path} is unavailable: ${error.message}`);
+  }
+}
+
+function parseJson(path, bytes) {
+  try {
+    return JSON.parse(bytes.toString("utf8"));
+  } catch (error) {
+    fail(`required artifact ${path} is not valid JSON: ${error.message}`);
+  }
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+}
+
+function requireNonEmptyFacts(value, label) {
+  requireObject(value, label);
+  if (Object.keys(value).length === 0) {
+    fail(`${label} must not be empty`);
+  }
+}
+
+function requireSourceCommit(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{40}$/.test(value)) {
+    fail(`${label} must be one lowercase forty-character Git commit SHA`);
+  }
+}
+
+function requireGeneratedAt(value, label) {
+  if (typeof value !== "string" || !Number.isFinite(Date.parse(value))) {
+    fail(`${label} must be an ISO timestamp`);
+  }
+}
+
+function currentHead() {
+  let value;
+  try {
+    value = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (error) {
+    fail(`git rev-parse HEAD failed: ${error.message}`);
+  }
+  requireSourceCommit(value, "git rev-parse HEAD");
+  return value;
+}
+
+function validateParentContract(parent) {
+  requireObject(parent, "D0 parent contract");
+  if (parent.contract !== "forum_search_versioned_invalidation_runtime_evidence_v1") {
+    fail("D0 parent contract identity drifted");
+  }
+  if (parent.task !== "FORUM-23B2G2B3D0") {
+    fail("D0 parent task identity drifted");
+  }
+  if (parent.status !== "source_ready_maintainer_execution_pending") {
+    fail("D0 parent must remain source_ready_maintainer_execution_pending before assembly");
+  }
+  const parentScenarios = parent.required_scenarios?.map(({ id }) => id);
+  if (JSON.stringify(parentScenarios) !== JSON.stringify(frozenScenarioIds)) {
+    fail("D0 frozen required scenario order or membership drifted");
+  }
+  if (parent.evidence_artifact?.path !== outputPath) {
+    fail("D0 aggregate evidence output path drifted");
+  }
+  const requiredFields = new Set(parent.evidence_artifact?.required_fields ?? []);
+  for (const field of [
+    "contract",
+    "source_commit",
+    "database_backend",
+    "delivery_profile",
+    "consumer_group",
+    "scenario_results",
+    "owner_revision_rows",
+    "typed_and_root_event_ids",
+    "search_inbox_rows",
+    "ingest_sequences",
+    "owner_checkpoints",
+    "poison_receipts",
+    "dlq_receipts",
+    "storefront_visibility_assertions",
+  ]) {
+    if (!requiredFields.has(field)) {
+      fail(`D0 aggregate required field ${field} is missing`);
+    }
+  }
+  const registered = new Map(
+    (parent.source_ready_subproofs ?? []).map((entry) => [entry.task, entry]),
+  );
+  for (const entry of manifest) {
+    const registration = registered.get(entry.task);
+    if (!registration || registration.evidence_artifact !== entry.path) {
+      fail(`${entry.task} is not registered with its exact evidence artifact in D0`);
+    }
+  }
+}
+
+function validateArtifact(entry, bytes, artifact, head) {
+  requireObject(artifact, entry.path);
+  if (artifact.contract !== entry.contract) {
+    fail(`${entry.path} contract must be ${entry.contract}`);
+  }
+  if (artifact.task !== entry.task) {
+    fail(`${entry.path} task must be ${entry.task}`);
+  }
+  requireSourceCommit(artifact.source_commit, `${entry.path}.source_commit`);
+  if (artifact.source_commit !== head) {
+    fail(`${entry.path} was generated from ${artifact.source_commit}, not current HEAD ${head}`);
+  }
+  requireGeneratedAt(artifact.generated_at, `${entry.path}.generated_at`);
+  if (artifact.database_backend !== "postgresql") {
+    fail(`${entry.path} must report database_backend postgresql`);
+  }
+  if (entry.iggy) {
+    if (artifact.delivery_profile !== "outbox_iggy") {
+      fail(`${entry.path} must report delivery_profile outbox_iggy`);
+    }
+    if (artifact.consumer_group !== canonicalConsumerGroup) {
+      fail(`${entry.path} must report consumer group ${canonicalConsumerGroup}`);
+    }
+    if (artifact.topic !== canonicalTopic) {
+      fail(`${entry.path} must report topic ${canonicalTopic}`);
+    }
+    if (typeof artifact.stream !== "string" || artifact.stream.trim().length === 0) {
+      fail(`${entry.path} must report a non-empty external Iggy stream`);
+    }
+  }
+  if (!Array.isArray(artifact.scenario_results)) {
+    fail(`${entry.path}.scenario_results must be an array`);
+  }
+  const actualIds = artifact.scenario_results.map(({ id }) => id);
+  if (JSON.stringify(actualIds) !== JSON.stringify(entry.scenarios)) {
+    fail(`${entry.path} scenario order or membership drifted`);
+  }
+  const scenarioMap = new Map();
+  for (const scenario of artifact.scenario_results) {
+    requireObject(scenario, `${entry.path} scenario`);
+    if (scenarioMap.has(scenario.id)) {
+      fail(`${entry.path} repeats scenario ${scenario.id}`);
+    }
+    if (scenario.result !== "passed") {
+      fail(`${entry.path} scenario ${scenario.id} did not pass`);
+    }
+    requireNonEmptyFacts(scenario.facts, `${entry.path} scenario ${scenario.id} facts`);
+    scenarioMap.set(scenario.id, scenario);
+  }
+  return {
+    entry,
+    artifact,
+    scenarioMap,
+    digest: sha256(bytes),
+    byteLength: bytes.length,
+  };
+}
+
+function evidenceBundle(validatedByTask, sources) {
+  return sources.map(([task, scenarioId]) => {
+    const validated = validatedByTask.get(task);
+    const scenario = validated?.scenarioMap.get(scenarioId);
+    if (!validated || !scenario) {
+      fail(`aggregate evidence bundle cannot resolve ${task}:${scenarioId}`);
+    }
+    return {
+      source_task: task,
+      source_contract: validated.entry.contract,
+      source_artifact: validated.entry.path,
+      source_scenario_id: scenarioId,
+      facts: scenario.facts,
+    };
+  });
+}
+
+if (process.argv.length !== 2) {
+  fail("this assembler accepts no command-line arguments");
+}
+
+const head = currentHead();
+const parentBytes = readBytes(parentContractPath);
+const parent = parseJson(parentContractPath, parentBytes);
+validateParentContract(parent);
+
+const validated = manifest.map((entry) => {
+  const bytes = readBytes(entry.path);
+  return validateArtifact(entry, bytes, parseJson(entry.path, bytes), head);
+});
+const validatedByTask = new Map(validated.map((item) => [item.entry.task, item]));
+if (validatedByTask.size !== manifest.length) {
+  fail("aggregate manifest contains duplicate task identities");
+}
+
+const scenarioResults = frozenScenarioIds.map((id) => {
+  const source = frozenScenarioSources.get(id);
+  if (!source) {
+    fail(`frozen scenario ${id} has no registered source`);
+  }
+  const [task, sourceScenarioId] = source;
+  const validatedSource = validatedByTask.get(task);
+  const scenario = validatedSource?.scenarioMap.get(sourceScenarioId);
+  if (!validatedSource || !scenario) {
+    fail(`frozen scenario ${id} cannot resolve ${task}:${sourceScenarioId}`);
+  }
+  return {
+    id,
+    result: "passed",
+    source_task: task,
+    source_contract: validatedSource.entry.contract,
+    source_artifact: validatedSource.entry.path,
+    source_scenario_id: sourceScenarioId,
+    facts: scenario.facts,
+  };
+});
+
+const sourceArtifacts = validated.map(({ entry, artifact, digest, byteLength }) => ({
+  task: entry.task,
+  contract: entry.contract,
+  path: entry.path,
+  source_commit: artifact.source_commit,
+  generated_at: artifact.generated_at,
+  sha256: digest,
+  byte_length: byteLength,
+  scenario_ids: entry.scenarios,
+}));
+
+const aggregate = {
+  contract: "forum_search_versioned_invalidation_runtime_evidence_v1",
+  task: "FORUM-23B2G2B3D0",
+  status: "runtime_evidence_assembled",
+  source_commit: head,
+  generated_at: new Date().toISOString(),
+  database_backend: "postgresql",
+  delivery_profile: "outbox_iggy",
+  consumer_group: canonicalConsumerGroup,
+  topic: canonicalTopic,
+  scenario_results: scenarioResults,
+  owner_revision_rows: evidenceBundle(validatedByTask, [
+    ["FORUM-23B2G2B3D6", "missing_delivery_owner_repair"],
+    ["FORUM-23B2G2B3D7", "multi_process_serialization"],
+    ["FORUM-23B2G2B3D8", "deletion_acl_ordering"],
+    ["FORUM-23B2G2B3D9", "search_disabled_profile"],
+    ["FORUM-23B2G2B3D10", "normal_delivery"],
+  ]),
+  typed_and_root_event_ids: evidenceBundle(validatedByTask, [
+    ["FORUM-23B2G2B3D2", "typed_ingress_admission"],
+    ["FORUM-23B2G2B3D3", "acknowledgement_failure_restart"],
+    ["FORUM-23B2G2B3D5", "semantic_poison_identity_conflict"],
+    ["FORUM-23B2G2B3D8", "deletion_acl_ordering"],
+    ["FORUM-23B2G2B3D9", "search_disabled_profile"],
+    ["FORUM-23B2G2B3D10", "normal_delivery"],
+  ]),
+  search_inbox_rows: evidenceBundle(validatedByTask, [
+    ["FORUM-23B2G2B3D2", "typed_ingress_admission"],
+    ["FORUM-23B2G2B3D2", "legacy_first_duplicate"],
+    ["FORUM-23B2G2B3D2", "typed_first_duplicate"],
+    ["FORUM-23B2G2B3D3", "acknowledgement_failure_restart"],
+    ["FORUM-23B2G2B3D5", "semantic_poison_identity_conflict"],
+    ["FORUM-23B2G2B3D8", "deletion_acl_ordering"],
+    ["FORUM-23B2G2B3D10", "normal_delivery"],
+  ]),
+  ingest_sequences: evidenceBundle(validatedByTask, [
+    ["FORUM-23B2G2B3D2", "typed_ingress_admission"],
+    ["FORUM-23B2G2B3D2", "legacy_first_duplicate"],
+    ["FORUM-23B2G2B3D2", "typed_first_duplicate"],
+    ["FORUM-23B2G2B3D3", "acknowledgement_failure_restart"],
+    ["FORUM-23B2G2B3D8", "deletion_acl_ordering"],
+    ["FORUM-23B2G2B3D10", "normal_delivery"],
+  ]),
+  owner_checkpoints: evidenceBundle(validatedByTask, [
+    ["FORUM-23B2G2B3D6", "missing_delivery_owner_repair"],
+    ["FORUM-23B2G2B3D7", "multi_process_serialization"],
+    ["FORUM-23B2G2B3D9", "search_disabled_profile"],
+    ["FORUM-23B2G2B3D10", "normal_delivery"],
+  ]),
+  poison_receipts: evidenceBundle(validatedByTask, [
+    ["FORUM-23B2G2B3D4", "raw_poison_dlq_redelivery"],
+    ["FORUM-23B2G2B3D5", "semantic_poison_identity_conflict"],
+  ]),
+  dlq_receipts: evidenceBundle(validatedByTask, [
+    ["FORUM-23B2G2B3D4", "raw_poison_dlq_redelivery"],
+    ["FORUM-23B2G2B3D5", "semantic_poison_identity_conflict"],
+  ]),
+  storefront_visibility_assertions: evidenceBundle(validatedByTask, [
+    ["FORUM-23B2G2B3D8", "deletion_acl_ordering"],
+    ["FORUM-23B2G2B3D10", "normal_delivery"],
+  ]),
+  supporting_scenario_results: evidenceBundle(validatedByTask, [
+    ["FORUM-23B2G2B3D2", "typed_ingress_admission"],
+    ["FORUM-23B2G2B3D2", "semantic_identity_conflict"],
+  ]),
+  source_artifacts: sourceArtifacts,
+  assembly: {
+    assembler:
+      "scripts/evidence/assemble-forum-search-versioned-invalidation-runtime-evidence.mjs",
+    parent_contract: parentContractPath,
+    parent_contract_sha256: sha256(parentBytes),
+    input_artifact_count: sourceArtifacts.length,
+    frozen_scenario_count: scenarioResults.length,
+    all_inputs_same_source_commit: true,
+    source_commit_matches_current_head: true,
+    output_written_after_complete_validation: true,
+  },
+};
+
+for (const field of parent.evidence_artifact.required_fields) {
+  if (!(field in aggregate)) {
+    fail(`assembled output is missing D0 required field ${field}`);
+  }
+}
+
+const absoluteOutput = resolve(root, outputPath);
+mkdirSync(dirname(absoluteOutput), { recursive: true });
+const temporaryOutput = `${absoluteOutput}.${process.pid}.${Date.now()}.tmp`;
+try {
+  writeFileSync(temporaryOutput, `${JSON.stringify(aggregate, null, 2)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+  });
+  renameSync(temporaryOutput, absoluteOutput);
+} catch (error) {
+  rmSync(temporaryOutput, { force: true });
+  fail(`atomic aggregate output write failed: ${error.message}`);
+}
+
+console.log(`wrote validated Forum Search aggregate runtime evidence to ${outputPath}`);

--- a/scripts/verify/verify-forum-search-versioned-invalidation-aggregate-evidence-assembler.mjs
+++ b/scripts/verify/verify-forum-search-versioned-invalidation-aggregate-evidence-assembler.mjs
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = process.cwd();
+const read = (path) => readFileSync(resolve(root, path), "utf8");
+const requireAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(text.includes(marker), `${label} is missing required marker: ${marker}`);
+  }
+};
+const forbidAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(!text.includes(marker), `${label} contains forbidden marker: ${marker}`);
+  }
+};
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-search-versioned-invalidation-aggregate-evidence-assembler.json";
+const parentPath =
+  "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json";
+const assemblerPath =
+  "scripts/evidence/assemble-forum-search-versioned-invalidation-runtime-evidence.mjs";
+const verifierPath =
+  "scripts/verify/verify-forum-search-versioned-invalidation-aggregate-evidence-assembler.mjs";
+const docPath =
+  "crates/rustok-forum/docs/forum-23b2g2b3d11-aggregate-evidence-assembler.md";
+const outputPath =
+  "target/forum-search-versioned-invalidation-runtime-evidence.json";
+
+const expectedInputs = [
+  "target/forum-search-versioned-invalidation-postgres-ingress-evidence.json",
+  "target/forum-search-versioned-invalidation-ack-restart-evidence.json",
+  "target/forum-search-versioned-invalidation-raw-poison-evidence.json",
+  "target/forum-search-versioned-invalidation-semantic-poison-evidence.json",
+  "target/forum-search-versioned-invalidation-missing-delivery-repair-evidence.json",
+  "target/forum-search-versioned-invalidation-multi-process-evidence.json",
+  "target/forum-search-versioned-invalidation-deletion-acl-ordering-evidence.json",
+  "target/forum-search-versioned-invalidation-search-disabled-recovery-evidence.json",
+  "target/forum-search-versioned-invalidation-normal-delivery-evidence.json",
+];
+const frozenScenarios = [
+  "normal_delivery",
+  "legacy_first_duplicate",
+  "typed_first_duplicate",
+  "acknowledgement_failure_restart",
+  "raw_poison_dlq_redelivery",
+  "semantic_poison_identity_conflict",
+  "missing_delivery_owner_repair",
+  "multi_process_serialization",
+  "deletion_acl_ordering",
+  "search_disabled_profile",
+];
+
+const contract = JSON.parse(read(contractPath));
+assert.equal(
+  contract.contract,
+  "forum_search_versioned_invalidation_aggregate_evidence_assembler_v1",
+);
+assert.equal(contract.task, "FORUM-23B2G2B3D11");
+assert.equal(contract.status, "source_ready_maintainer_execution_pending");
+assert.equal(contract.runtime_evidence_parent, parentPath);
+assert.equal(contract.assembler, assemblerPath);
+assert.equal(contract.verifier, verifierPath);
+assert.deepEqual(contract.input_artifacts, expectedInputs);
+assert.equal(contract.output_artifact.path, outputPath);
+assert.equal(
+  contract.output_artifact.generation,
+  "assembler_only_after_all_runtime_subproofs_pass",
+);
+assert.equal(contract.output_artifact.hand_editing_forbidden, true);
+assert.equal(contract.output_artifact.source_commit_required, true);
+assert.equal(contract.output_artifact.atomic_replace, true);
+assert.ok(contract.fail_closed_requirements.length >= 9);
+assert.deepEqual(Object.keys(contract.frozen_scenario_sources), frozenScenarios);
+assert.equal(
+  contract.maintainer_command,
+  "node scripts/evidence/assemble-forum-search-versioned-invalidation-runtime-evidence.mjs",
+);
+
+const parent = JSON.parse(read(parentPath));
+assert.equal(parent.contract, "forum_search_versioned_invalidation_runtime_evidence_v1");
+assert.equal(parent.task, "FORUM-23B2G2B3D0");
+assert.equal(parent.status, "source_ready_maintainer_execution_pending");
+assert.deepEqual(
+  parent.required_scenarios.map(({ id }) => id),
+  frozenScenarios,
+);
+assert.equal(parent.evidence_artifact.path, outputPath);
+const d11 = parent.source_ready_subproofs.find(
+  ({ task }) => task === "FORUM-23B2G2B3D11",
+);
+assert.ok(d11, "D0 must register FORUM-23B2G2B3D11");
+assert.equal(d11.contract, contractPath);
+assert.equal(d11.assembler, assemblerPath);
+assert.equal(d11.evidence_artifact, outputPath);
+assert.ok(d11.covers.includes("same_source_commit_aggregate_assembly"));
+assert.ok(d11.does_not_cover.includes("runtime_execution_or_d0_status_promotion"));
+for (const command of [
+  `node ${verifierPath}`,
+  `node ${assemblerPath}`,
+]) {
+  assert.ok(parent.maintainer_commands.includes(command));
+}
+
+const assembler = read(assemblerPath);
+requireAll(
+  assembler,
+  [
+    "execFileSync(\"git\", [\"rev-parse\", \"HEAD\"]",
+    "createHash(\"sha256\")",
+    "source_ready_maintainer_execution_pending",
+    "runtime_evidence_assembled",
+    "database_backend: \"postgresql\"",
+    "delivery_profile: \"outbox_iggy\"",
+    "rustok-search-forum-projection-v1",
+    "const canonicalTopic = \"domain\"",
+    "artifact.source_commit !== head",
+    "artifact.database_backend !== \"postgresql\"",
+    "artifact.delivery_profile !== \"outbox_iggy\"",
+    "artifact.consumer_group !== canonicalConsumerGroup",
+    "artifact.topic !== canonicalTopic",
+    "scenario.result !== \"passed\"",
+    "Object.keys(value).length === 0",
+    "JSON.stringify(parentScenarios) !== JSON.stringify(frozenScenarioIds)",
+    "parent.evidence_artifact.required_fields",
+    "registration.evidence_artifact !== entry.path",
+    "source_artifacts: sourceArtifacts",
+    "parent_contract_sha256: sha256(parentBytes)",
+    "all_inputs_same_source_commit: true",
+    "source_commit_matches_current_head: true",
+    "output_written_after_complete_validation: true",
+    "writeFileSync(temporaryOutput",
+    "renameSync(temporaryOutput, absoluteOutput)",
+    "rmSync(temporaryOutput, { force: true })",
+    "if (process.argv.length !== 2)",
+    "supporting_scenario_results",
+    "owner_revision_rows",
+    "typed_and_root_event_ids",
+    "search_inbox_rows",
+    "ingest_sequences",
+    "owner_checkpoints",
+    "poison_receipts",
+    "dlq_receipts",
+    "storefront_visibility_assertions",
+  ],
+  "aggregate evidence assembler",
+);
+for (const path of expectedInputs) {
+  assert.ok(assembler.includes(path), `assembler manifest is missing ${path}`);
+}
+for (const scenario of frozenScenarios) {
+  assert.ok(assembler.includes(`\"${scenario}\"`), `assembler is missing ${scenario}`);
+}
+forbidAll(
+  assembler,
+  [
+    "process.env.FORUM_SEARCH_SOURCE_COMMIT",
+    "process.env.SOURCE_COMMIT",
+    "--source-commit",
+    "allowMissing",
+    "bestEffort",
+    "continueOnError",
+    "writeFileSync(absoluteOutput",
+    "generation: \"static_fixture\"",
+    "result: \"skipped\"",
+  ],
+  "aggregate evidence assembler",
+);
+
+const inputSources = [
+  [
+    "crates/rustok-search/tests/forum_versioned_invalidation_postgres.rs",
+    "forum_search_versioned_invalidation_postgres_ingress_evidence_v1",
+  ],
+  [
+    "apps/server/tests/forum_versioned_invalidation_ack_restart_iggy.rs",
+    "forum_search_versioned_invalidation_ack_restart_evidence_v1",
+  ],
+  [
+    "apps/server/tests/forum_versioned_invalidation_raw_poison_iggy.rs",
+    "forum_search_versioned_invalidation_raw_poison_evidence_v1",
+  ],
+  [
+    "apps/server/tests/forum_versioned_invalidation_semantic_poison_iggy.rs",
+    "forum_search_versioned_invalidation_semantic_poison_evidence_v1",
+  ],
+  [
+    "crates/rustok-search/tests/forum_versioned_invalidation_missing_delivery_repair.rs",
+    "forum_search_versioned_invalidation_missing_delivery_repair_evidence_v1",
+  ],
+  [
+    "apps/server/tests/forum_versioned_invalidation_multi_process_serialization.rs",
+    "forum_search_versioned_invalidation_multi_process_evidence_v1",
+  ],
+  [
+    "apps/server/tests/forum_versioned_invalidation_deletion_acl_ordering.rs",
+    "forum_search_versioned_invalidation_deletion_acl_ordering_evidence_v1",
+  ],
+  [
+    "apps/server/tests/forum_versioned_invalidation_search_disabled_recovery.rs",
+    "forum_search_versioned_invalidation_search_disabled_recovery_evidence_v1",
+  ],
+  [
+    "apps/server/tests/forum_versioned_invalidation_normal_delivery_iggy.rs",
+    "forum_search_versioned_invalidation_normal_delivery_evidence_v1",
+  ],
+];
+for (const [path, evidenceContract] of inputSources) {
+  const source = read(path);
+  requireAll(
+    source,
+    [
+      evidenceContract,
+      "source_commit: String",
+      "generated_at: String",
+      "database_backend: &'static str",
+      "scenario_results: Vec<ScenarioEvidence>",
+      "source_commit()?",
+      'database_backend: "postgresql"',
+    ],
+    path,
+  );
+}
+
+const doc = read(docPath);
+requireAll(
+  doc,
+  [
+    "`source_ready_maintainer_execution_pending`",
+    "FORUM-23B2G2B3D11",
+    contractPath,
+    assemblerPath,
+    verifierPath,
+    outputPath,
+    "all nine `source_commit` values",
+    "`git rev-parse HEAD`",
+    "SHA-256 digest",
+    "atomic rename",
+    "There is no",
+    "No command above was run by the implementation agent",
+  ],
+  "aggregate evidence assembler handoff",
+);
+
+console.log(
+  "Forum Search aggregate runtime evidence assembler is fail-closed and source-ready.",
+);


### PR DESCRIPTION
## What changed

- add `FORUM-23B2G2B3D11`, the fail-closed aggregate assembly gate for the frozen Forum Search D0 runtime-evidence matrix;
- require all nine executable D2-D10 artifacts to exist, parse and match their exact contract/task/scenario identities;
- reject missing, skipped, duplicate, empty-facts or non-PostgreSQL evidence;
- require every input artifact to carry the same lowercase 40-character `source_commit` and require that SHA to equal `git rev-parse HEAD`;
- require all Iggy-backed artifacts to report `outbox_iggy`, consumer group `rustok-search-forum-projection-v1`, topic `domain` and a non-empty stream;
- preserve the exact ten frozen D0 scenarios and map each to its registered source artifact;
- retain D2 supporting typed-ingress and semantic-collision evidence separately from the ten frozen scenario results;
- record SHA-256, byte length, generated time and source identity for every input artifact plus a digest of the D0 parent contract;
- populate every D0 aggregate required field with source-attributed evidence bundles rather than inferred normalized facts;
- write `target/forum-search-versioned-invalidation-runtime-evidence.json` only after complete validation, using a same-directory temporary file and atomic rename;
- register D11 in D0 and add the focused verifier and assembler maintainer commands.

## Deliberate boundary

This PR does not execute D2-D10, generate any runtime artifact, promote D0 to complete, or close `FORUM-23` or `LINK-FORUM-03`.

## Compatibility

No production Rust path, migration, event schema or digest, DTO, runtime flag, dependency, `Cargo.toml`, or `Cargo.lock` entry changes.

## Validation

Tests, Node verifiers, the assembler, formatting, Cargo checks, workflows, CI, PostgreSQL and Iggy execution were intentionally not run, per maintainer request.