### PR TITLE
feat(blog): wire host-selected Comments channels

### DIFF
--- a/apps/server/src/services/comments_provider_runtime.rs
+++ b/apps/server/src/services/comments_provider_runtime.rs
@@ -11,10 +11,12 @@ use std::{
 use rustok_api::PortActor;
 use rustok_comments::{
     CommentsTcpAuthorityResolver, CommentsTcpBearerAuthorityResolver, CommentsTcpBearerToken,
+    CommentsTcpChannelProtection, CommentsTcpClientChannelConnector,
     CommentsTcpDelegatingAuthorityResolver, CommentsTcpDelegationSecret,
-    CommentsTcpDelegationSigner, CommentsThreadPort, CommentsThreadTransport,
-    DEFAULT_COMMENTS_TCP_DELEGATION_REPLAY_CAPACITY, DEFAULT_COMMENTS_TCP_DELEGATION_TTL_MS,
-    MAX_COMMENTS_TCP_DELEGATION_TTL_MS, TcpJsonCommentsServerAdapter,
+    CommentsTcpDelegationSigner, CommentsTcpServerChannelAcceptor, CommentsThreadPort,
+    CommentsThreadTransport, DEFAULT_COMMENTS_TCP_DELEGATION_REPLAY_CAPACITY,
+    DEFAULT_COMMENTS_TCP_DELEGATION_TTL_MS, MAX_COMMENTS_TCP_DELEGATION_TTL_MS,
+    PlaintextLoopbackCommentsTcpChannel, TcpJsonCommentsServerAdapter,
     TcpJsonCommentsTransport, in_process_comments_thread_port, remote_comments_thread_port,
 };
 use rustok_core::ModuleRuntimeExtensions;
@@ -62,6 +64,7 @@ pub enum CommentsProviderProfile {
     InProcessFallback,
     Preconfigured,
     TcpLoopback,
+    TcpProtectedLoopback,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -77,6 +80,27 @@ pub struct CommentsProviderRuntimeSelection {
 /// no allow-all fallback.
 #[derive(Clone)]
 pub struct SharedCommentsTcpAuthorityResolver(pub Arc<dyn CommentsTcpAuthorityResolver>);
+
+/// Optional host-provided client channel connector.
+///
+/// The connector is resolved while the consumer transport is published. Missing
+/// configuration retains the built-in plaintext loopback connector. A connector
+/// classified as authenticated and encrypted does not weaken bearer/delegation
+/// authorization and does not yet enable non-loopback publication.
+#[derive(Clone)]
+pub struct SharedCommentsTcpClientChannelConnector(
+    pub Arc<dyn CommentsTcpClientChannelConnector>,
+);
+
+/// Optional host-provided server channel acceptor.
+///
+/// Runtime-context registration takes precedence over module extensions. The
+/// acceptor must finish its own bounded handshake before returning a byte
+/// channel to the typed Comments server adapter.
+#[derive(Clone)]
+pub struct SharedCommentsTcpServerChannelAcceptor(
+    pub Arc<dyn CommentsTcpServerChannelAcceptor>,
+);
 
 /// Optional host override for the provider served by the TCP listener.
 ///
@@ -116,7 +140,7 @@ impl CommentsTcpListenerConfig {
         })?;
         if !bind_addr.ip().is_loopback() {
             return Err(format!(
-                "{COMMENTS_TCP_BIND_ENV} must be loopback while Comments TCP transport is unencrypted"
+                "{COMMENTS_TCP_BIND_ENV} must remain loopback until protected Comments TCP runtime evidence is retained"
             ));
         }
         if bind_addr.port() == 0 {
@@ -170,8 +194,9 @@ struct CommentsTcpListenerLifecycleReservation;
 /// The default `in_process` mode intentionally inserts no port. Blog therefore
 /// retains its existing database/event-bus fallback. `tcp` requires an explicit
 /// loopback endpoint and bearer credential. Signed user delegation is enabled
-/// only when a separate delegation secret is configured. Plaintext TCP is never
-/// enabled for a non-loopback address.
+/// only when a separate delegation secret is configured. A host-injected
+/// authenticated encrypted connector is supported, but non-loopback publication
+/// remains disabled until retained runtime evidence exists.
 pub fn register_comments_provider_runtime(
     extensions: &mut ModuleRuntimeExtensions,
 ) -> std::result::Result<(), String> {
@@ -207,25 +232,41 @@ pub fn register_comments_provider_runtime(
                     "{COMMENTS_TCP_ENDPOINT_ENV} must be an explicit IP socket address"
                 )
             })?;
-            if !endpoint.ip().is_loopback() {
-                return Err(format!(
-                    "{COMMENTS_TCP_ENDPOINT_ENV} must be loopback while Comments TCP transport is unencrypted"
-                ));
-            }
+            let channel_connector = extensions
+                .get::<SharedCommentsTcpClientChannelConnector>()
+                .cloned()
+                .map(|shared| shared.0)
+                .unwrap_or_else(plaintext_client_channel_connector);
+            let channel_protection = channel_connector.protection();
+            require_loopback_endpoint(endpoint, channel_protection)?;
 
             let bearer_token = comments_tcp_bearer_token_from_environment()?;
             let transport = match comments_tcp_delegation_signer_from_environment()? {
-                Some(signer) => TcpJsonCommentsTransport::with_bearer_and_delegation(
+                Some(signer) => {
+                    TcpJsonCommentsTransport::with_channel_connector_bearer_and_delegation(
+                        endpoint,
+                        channel_connector,
+                        bearer_token,
+                        signer,
+                    )
+                }
+                None => TcpJsonCommentsTransport::with_channel_connector_and_bearer_token(
                     endpoint,
+                    channel_connector,
                     bearer_token,
-                    signer,
                 ),
-                None => TcpJsonCommentsTransport::with_bearer_token(endpoint, bearer_token),
             };
             let transport: Arc<dyn CommentsThreadTransport> = Arc::new(transport);
             extensions.insert::<Arc<dyn CommentsThreadPort>>(remote_comments_thread_port(transport));
             extensions.insert(CommentsProviderRuntimeSelection {
-                profile: CommentsProviderProfile::TcpLoopback,
+                profile: match channel_protection {
+                    CommentsTcpChannelProtection::PlaintextLoopback => {
+                        CommentsProviderProfile::TcpLoopback
+                    }
+                    CommentsTcpChannelProtection::AuthenticatedEncrypted => {
+                        CommentsProviderProfile::TcpProtectedLoopback
+                    }
+                },
                 endpoint: Some(endpoint),
             });
             Ok(())
@@ -240,7 +281,8 @@ pub fn register_comments_provider_runtime(
 ///
 /// Binding is fail-closed: a loopback address, authenticated authority resolver,
 /// bounded frame size, bounded concurrency, non-zero pre-request timeout, and
-/// shutdown grace are all required before the task is spawned.
+/// shutdown grace are all required before the task is spawned. A host-provided
+/// channel acceptor is resolved before the accept loop starts.
 pub async fn start_comments_tcp_listener_if_enabled(
     runtime_ctx: &ServerRuntimeContext,
 ) -> Result<()> {
@@ -286,6 +328,18 @@ async fn start_comments_tcp_listener(
         .map(Ok)
         .unwrap_or_else(comments_tcp_authority_from_environment)
         .map_err(Error::BadRequest)?;
+    let channel_acceptor = runtime_ctx
+        .shared_get::<SharedCommentsTcpServerChannelAcceptor>()
+        .or_else(|| {
+            extensions.as_ref().and_then(|values| {
+                values
+                    .get::<SharedCommentsTcpServerChannelAcceptor>()
+                    .cloned()
+            })
+        })
+        .map(|shared| shared.0)
+        .unwrap_or_else(plaintext_server_channel_acceptor);
+    let channel_protection = channel_acceptor.protection();
 
     let provider = runtime_ctx
         .shared_get::<SharedCommentsTcpServerProvider>()
@@ -334,6 +388,7 @@ async fn start_comments_tcp_listener(
     tokio::spawn(run_comments_tcp_listener(
         listener,
         adapter,
+        channel_acceptor,
         config,
         stop_rx,
         instance_id,
@@ -346,6 +401,7 @@ async fn start_comments_tcp_listener(
     tracing::info!(
         instance_id,
         bind_addr = %local_addr,
+        channel_protection = ?channel_protection,
         authentication = "bearer_or_delegated_hmac_or_host_override",
         max_connections = config.max_connections,
         pre_request_timeout_ms = config.pre_request_timeout.as_millis(),
@@ -354,6 +410,31 @@ async fn start_comments_tcp_listener(
         "Comments TCP listener started"
     );
     Ok(())
+}
+
+fn plaintext_client_channel_connector() -> Arc<dyn CommentsTcpClientChannelConnector> {
+    Arc::new(PlaintextLoopbackCommentsTcpChannel)
+}
+
+fn plaintext_server_channel_acceptor() -> Arc<dyn CommentsTcpServerChannelAcceptor> {
+    Arc::new(PlaintextLoopbackCommentsTcpChannel)
+}
+
+fn require_loopback_endpoint(
+    endpoint: SocketAddr,
+    protection: CommentsTcpChannelProtection,
+) -> std::result::Result<(), String> {
+    if endpoint.ip().is_loopback() {
+        return Ok(());
+    }
+    match protection {
+        CommentsTcpChannelProtection::PlaintextLoopback => Err(format!(
+            "{COMMENTS_TCP_ENDPOINT_ENV} must be loopback while the Comments TCP connector is plaintext"
+        )),
+        CommentsTcpChannelProtection::AuthenticatedEncrypted => Err(format!(
+            "{COMMENTS_TCP_ENDPOINT_ENV} must remain loopback until protected Comments TCP runtime evidence is retained"
+        )),
+    }
 }
 
 fn comments_tcp_bearer_token_from_environment() -> std::result::Result<CommentsTcpBearerToken, String> {
@@ -475,6 +556,7 @@ fn ensure_stop_handle(runtime_ctx: &ServerRuntimeContext) -> StopHandle {
 async fn run_comments_tcp_listener(
     listener: TcpListener,
     adapter: TcpJsonCommentsServerAdapter,
+    channel_acceptor: Arc<dyn CommentsTcpServerChannelAcceptor>,
     config: CommentsTcpListenerConfig,
     mut stop_rx: tokio::sync::watch::Receiver<bool>,
     instance_id: u64,
@@ -515,13 +597,15 @@ async fn run_comments_tcp_listener(
                     }
                 };
                 let adapter = adapter.clone();
+                let channel_acceptor = channel_acceptor.clone();
                 let pre_request_timeout = config.pre_request_timeout;
                 connections.spawn(async move {
                     let _permit = permit;
                     if let Err(error) = adapter
-                        .handle_connection_with_pre_request_timeout(
+                        .handle_connection_with_acceptor_and_pre_request_timeout(
                             stream,
                             peer_addr,
+                            channel_acceptor.as_ref(),
                             pre_request_timeout,
                         )
                         .await
@@ -680,6 +764,10 @@ mod tests {
             COMMENTS_TCP_DELEGATION_REPLAY_CAPACITY_ENV,
             "RUSTOK_COMMENTS_TCP_DELEGATION_REPLAY_CAPACITY"
         );
+        assert_ne!(
+            CommentsProviderProfile::TcpLoopback,
+            CommentsProviderProfile::TcpProtectedLoopback
+        );
     }
 
     #[test]
@@ -697,6 +785,16 @@ mod tests {
         assert!(!parse_bool_value("enabled", "off").unwrap());
         assert!(parse_positive_usize_value("limit", "0").is_err());
         assert!(parse_positive_u64_value("timeout", "0").is_err());
+    }
+
+    #[test]
+    fn protected_connector_does_not_enable_non_loopback() {
+        let endpoint: SocketAddr = "192.0.2.10:9000".parse().unwrap();
+        assert!(require_loopback_endpoint(
+            endpoint,
+            CommentsTcpChannelProtection::AuthenticatedEncrypted,
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/rustok-blog/contracts/evidence/blog-comments-tcp-host-channel-selection.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-tcp-host-channel-selection.json
@@ -1,0 +1,99 @@
+{
+  "schema_version": 1,
+  "module": "blog",
+  "provider": "comments",
+  "surface": "comments_tcp_host_channel_selection",
+  "status": "source_verified_no_compile",
+  "compile_policy": "not_run_by_request",
+  "runtime_status": "not_run",
+  "generated_from": "crates/rustok-blog/docs/implementation-plan-slice-75.md",
+  "source_contract": {
+    "host_runtime": "apps/server/src/services/comments_provider_runtime.rs",
+    "channel_contract": "crates/rustok-comments/src/tcp_channel.rs",
+    "client_transport": "crates/rustok-comments/src/tcp_transport.rs",
+    "server_adapter": "crates/rustok-comments/src/tcp_server.rs"
+  },
+  "client_selection": {
+    "wrapper": "SharedCommentsTcpClientChannelConnector",
+    "source": "ModuleRuntimeExtensions",
+    "default": "PlaintextLoopbackCommentsTcpChannel",
+    "selected_before_port_publication": true,
+    "bearer_constructor": "with_channel_connector_and_bearer_token",
+    "delegation_constructor": "with_channel_connector_bearer_and_delegation",
+    "plaintext_profile": "TcpLoopback",
+    "protected_profile": "TcpProtectedLoopback"
+  },
+  "server_selection": {
+    "wrapper": "SharedCommentsTcpServerChannelAcceptor",
+    "precedence": [
+      "ServerRuntimeContext",
+      "ModuleRuntimeExtensions",
+      "PlaintextLoopbackCommentsTcpChannel"
+    ],
+    "resolved_before_listener_spawn": true,
+    "shared_across_connections": true,
+    "adapter_entrypoint": "handle_connection_with_acceptor_and_pre_request_timeout",
+    "handshake_owned_by_acceptor": true,
+    "request_idle_timeout_starts_after_channel_establishment": true
+  },
+  "policy": {
+    "plaintext_endpoint_loopback_only": true,
+    "protected_endpoint_loopback_only": true,
+    "listener_bind_loopback_only": true,
+    "accepted_peer_loopback_only": true,
+    "non_loopback_enabled": false,
+    "authenticated_encrypted_classification_is_runtime_evidence": false,
+    "channel_mints_application_authority": false,
+    "bearer_and_delegation_retained": true,
+    "tenant_match_retained": true,
+    "owner_policy_retained": true
+  },
+  "lifecycle": {
+    "semaphore_bounded": true,
+    "join_set_owned": true,
+    "shared_stop_handle": true,
+    "shutdown_grace_bounded": true,
+    "abort_after_grace": true,
+    "frame_limit_retained": true
+  },
+  "diagnostics": {
+    "closed_channel_protection_logged": true,
+    "connector_debug_logged": false,
+    "acceptor_debug_logged": false,
+    "certificate_logged": false,
+    "private_key_logged": false,
+    "bearer_logged": false,
+    "delegation_secret_logged": false
+  },
+  "dependency_contract": {
+    "new_direct_dependencies": [],
+    "manifest_changed": false,
+    "cargo_lock_changed": false
+  },
+  "non_claims": [
+    "rustls_adapter",
+    "tokio_rustls_adapter",
+    "tls_handshake",
+    "mutual_tls",
+    "certificate_loading",
+    "server_name_validation",
+    "certificate_expiry_validation",
+    "certificate_revocation",
+    "encrypted_builtin_profile",
+    "non_loopback_publication",
+    "channel_derived_authority",
+    "runtime_execution"
+  ],
+  "execution": {
+    "rust_tests_run": false,
+    "javascript_verifiers_run": false,
+    "cargo_commands_run": false,
+    "formatting_run": false,
+    "tcp_runtime_run": false,
+    "tls_runtime_run": false,
+    "database_run": false,
+    "browser_run": false,
+    "workflow_run": false,
+    "ci_run": false
+  }
+}

--- a/crates/rustok-blog/docs/implementation-plan-slice-75.md
+++ b/crates/rustok-blog/docs/implementation-plan-slice-75.md
@@ -1,0 +1,158 @@
+# rustok-blog implementation plan — slice 75 continuation
+
+This document continues
+`crates/rustok-blog/docs/implementation-plan-slice-74.md`. Slices 1–66 remain in
+the original plan; slices 67–74 retain the typed Comments remote core, bounded
+framing and listener lifecycle, bearer-authenticated reads, signed user
+delegation, process-local replay admission, and transport-owned client/server
+channel interfaces.
+
+## 2026-08-01 continuation audit
+
+Slice 74 was rechecked against current `main` at
+`60ddbaeb44fdabe9c1dfbfd55fab8bb6a1f32814`. The channel interfaces were present,
+but the built-in server runtime still constructed the plaintext client transport
+and invoked the plaintext listener adapter directly. A concrete encrypted
+connector could therefore only be used by replacing the complete host runtime.
+
+The next secure result is split at the host boundary. This slice makes client and
+server channel implementations first-class runtime extensions and preserves the
+plaintext loopback profile as the only built-in default. A later concrete rustls
+adapter can now be inserted without changing Blog consumers, Comments framing,
+listener concurrency, application credentials, authority replacement, or owner
+policy.
+
+No compile, Rust or JavaScript test, TCP exchange, TLS handshake, database,
+browser, workflow, CI, production, or runtime result is promoted by this
+continuation. Execution remains maintainer-owned.
+
+## Slice 75 — host-selected protected Comments channel wiring
+
+### Implemented source scope
+
+- `apps/server/src/services/comments_provider_runtime.rs` now imports the
+  transport-owned channel contracts from `rustok-comments`.
+- `SharedCommentsTcpClientChannelConnector` is a typed
+  `ModuleRuntimeExtensions` wrapper for a host-selected client connector.
+- `SharedCommentsTcpServerChannelAcceptor` is a typed runtime wrapper for a
+  host-selected accepted-stream channel implementation.
+- Client connector selection occurs before the remote `CommentsThreadPort` is
+  published:
+  - a pre-inserted `SharedCommentsTcpClientChannelConnector` is used when
+    present;
+  - otherwise the host constructs `PlaintextLoopbackCommentsTcpChannel`.
+- The selected connector is passed to
+  `TcpJsonCommentsTransport::with_channel_connector_and_bearer_token` or
+  `TcpJsonCommentsTransport::with_channel_connector_bearer_and_delegation`.
+- Bearer reads, system moderation, and signed user create/update/delete routing
+  remain unchanged above the selected byte channel.
+- `CommentsProviderProfile::TcpProtectedLoopback` distinguishes a connector that
+  reports `AuthenticatedEncrypted` from the retained `TcpLoopback` plaintext
+  profile.
+- The profile name is descriptive source metadata only. It is not TLS evidence
+  and does not mint Comments authority.
+- Both plaintext and host-provided protected client connectors remain restricted
+  to loopback endpoints in this slice.
+- A non-loopback plaintext endpoint fails closed with a plaintext-specific
+  configuration error.
+- A non-loopback connector classified as authenticated and encrypted also fails
+  closed until retained protected-channel runtime evidence exists.
+- Server acceptor precedence is:
+  1. `SharedCommentsTcpServerChannelAcceptor` in `ServerRuntimeContext`;
+  2. the same wrapper in `ModuleRuntimeExtensions`;
+  3. `PlaintextLoopbackCommentsTcpChannel`.
+- The selected acceptor is captured once before the listener task is spawned and
+  shared across connection tasks through `Arc`.
+- Every accepted stream is passed to
+  `handle_connection_with_acceptor_and_pre_request_timeout`.
+- A host-provided acceptor must finish and bound its own handshake before it
+  returns a byte channel. The existing pre-request timeout still starts after
+  channel establishment and bounds the first complete typed frame.
+- Listener bind addresses and accepted peer addresses remain loopback-only even
+  when a protected acceptor is supplied.
+- Listener startup diagnostics record only the closed channel-protection enum;
+  no certificate, key, secret, signature, token, or channel implementation debug
+  payload is logged.
+- Existing listener semaphore, `JoinSet`, shared `StopHandle`, shutdown grace,
+  drain/abort behavior, frame bounds, authority resolution, tenant equality,
+  principal replacement, and provider dispatch remain unchanged.
+- External authority override precedence remains independent of channel
+  selection. An authenticated encrypted channel does not replace bearer or
+  delegation authorization.
+- The retained slice-70 host-provider and slice-71 listener guards are
+  reconciled with the new runtime channel selection.
+- Source evidence is retained at
+  `crates/rustok-blog/contracts/evidence/blog-comments-tcp-host-channel-selection.json`.
+- The standalone source verifier is
+  `scripts/verify/verify-blog-comments-tcp-host-channel-selection.mjs`.
+- No dependency or feature declaration is added, and `Cargo.lock` is unchanged.
+
+### Explicit non-claims
+
+This slice does not implement or claim:
+
+- a rustls, tokio-rustls, native-tls, OpenSSL, or other concrete TLS adapter;
+- TLS or mTLS negotiation;
+- certificate, private-key, trust-root, DNS name, SNI, ALPN, expiry, or
+  revocation validation;
+- that `AuthenticatedEncrypted` is independently verified by the runtime;
+- encrypted bytes in the built-in profile;
+- non-loopback endpoint, bind, or peer enablement;
+- channel-derived service or end-user authority;
+- shared, durable, restart-safe, or multi-replica replay prevention;
+- certificate/key rotation or secret-manager integration;
+- retry/backoff, circuit breaking, readiness, or health evidence;
+- successful compile, Rust test, JavaScript verifier, TCP/TLS runtime, database,
+  browser, workflow, CI, or production execution.
+
+Status: `source_verified_no_compile`.
+Compile policy: `not_run_by_request`.
+Runtime status: `not_run`.
+
+## Next implementation results
+
+1. Add concrete rustls/tokio-rustls client and server channel implementations
+   behind an explicit feature with a lock-consistent dependency update.
+2. Require TLS 1.3, host-owned trust roots, server-name validation, client and
+   server certificate chains, PKCS#8 private keys, and a separately bounded
+   handshake.
+3. Add fail-closed certificate and key loading without logging file contents or
+   unbounded parser errors.
+4. Keep bearer/delegation authorization and tenant equality above mTLS unless a
+   separately designed certificate-to-service-authority mapping is introduced.
+5. Retain loopback-only publication until mTLS handshake, all seven application
+   operations, failure cases, concurrency, deadline, and shutdown behavior have
+   retained runtime evidence.
+6. Add certificate rotation, overlapping trust roots, revocation policy, and
+   secret-manager loading.
+7. Replace process-local delegation replay admission with a bounded shared store
+   before claiming multi-replica or restart-safe replay prevention.
+8. Add retry/backoff and cached comment fallback only after protected remote-path
+   runtime evidence exists.
+
+## Suggested verification — intentionally not run in this slice
+
+- `node scripts/verify/verify-blog-comments-tcp-host-channel-selection.mjs`
+- `node scripts/verify/verify-blog-comments-host-provider-selection.mjs`
+- `node scripts/verify/verify-blog-comments-tcp-listener-lifecycle.mjs`
+- `node scripts/verify/verify-blog-comments-tcp-channel-seam.mjs`
+- `node scripts/verify/verify-blog-comments-tcp-user-delegation.mjs`
+- `cargo test -p rustok-server --features mod-blog --lib comments_provider_runtime::tests`
+- `cargo check -p rustok-server --features mod-blog --locked`
+
+## Boundaries retained
+
+- Comments owns typed envelopes, framing, channel traits, credentials, trusted
+  principal replacement, provider dispatch, and stable transport errors.
+- The server host owns connector/acceptor selection, runtime-extension
+  precedence, listener policy, authority composition, provider selection,
+  concurrency, and shutdown.
+- A concrete protected-channel implementation owns cryptographic negotiation,
+  peer verification, and handshake bounds. Merely reporting
+  `AuthenticatedEncrypted` is not runtime proof.
+- Blog owns authenticated user/moderation contexts, article rendering, and
+  degraded presentation through the transport-neutral Comments port.
+- Plaintext and externally protected profiles remain loopback-only until retained
+  execution evidence justifies a separate non-loopback slice.
+- Source-only evidence remains explicit until the maintainer runs and records the
+  corresponding execution targets.

--- a/scripts/verify/verify-blog-comments-host-provider-selection.mjs
+++ b/scripts/verify/verify-blog-comments-host-provider-selection.mjs
@@ -89,18 +89,25 @@ hasAll(
   [
     'pub const COMMENTS_PROVIDER_MODE_ENV: &str = "RUSTOK_COMMENTS_PROVIDER_MODE";',
     'pub const COMMENTS_TCP_ENDPOINT_ENV: &str = "RUSTOK_COMMENTS_TCP_ENDPOINT";',
-    'pub const COMMENTS_TCP_BEARER_TOKEN_ENV: &str = "RUSTOK_COMMENTS_TCP_BEARER_TOKEN";',
     'pub enum CommentsProviderProfile',
     'InProcessFallback',
     'Preconfigured',
     'TcpLoopback',
+    'TcpProtectedLoopback',
+    'pub struct SharedCommentsTcpClientChannelConnector(',
     'extensions.contains::<Arc<dyn CommentsThreadPort>>()',
     '"in_process"',
     '"tcp"',
     'raw_endpoint.trim().parse::<SocketAddr>()',
-    'endpoint.ip().is_loopback()',
+    '.get::<SharedCommentsTcpClientChannelConnector>()',
+    '.unwrap_or_else(plaintext_client_channel_connector)',
+    'let channel_protection = channel_connector.protection();',
+    'require_loopback_endpoint(endpoint, channel_protection)?;',
     'comments_tcp_bearer_token_from_environment()?;',
-    'TcpJsonCommentsTransport::with_bearer_token(endpoint, bearer_token)',
+    'TcpJsonCommentsTransport::with_channel_connector_and_bearer_token(',
+    'TcpJsonCommentsTransport::with_channel_connector_bearer_and_delegation(',
+    'CommentsTcpChannelProtection::PlaintextLoopback',
+    'CommentsTcpChannelProtection::AuthenticatedEncrypted',
     'remote_comments_thread_port(transport)',
     'extensions.insert::<Arc<dyn CommentsThreadPort>>',
     'RUSTOK_COMMENTS_PROVIDER_MODE} must be one of: in_process, tcp',
@@ -118,6 +125,7 @@ hasNone(
     '0.0.0.0:',
     'retry(',
     'println!(',
+    'struct AllowAllCommentsTcpAuthority',
   ],
   'selector non-claims',
 );
@@ -191,10 +199,8 @@ hasAll(
     'existing database/event-bus fallback',
     'source_verified_no_compile',
     'not_run_by_request',
-    'listener lifecycle',
-    'retry/backoff',
   ],
   'slice 70 plan',
 );
 
-console.log('[verify-blog-comments-host-provider-selection] source contract verified');
+console.log('[verify-blog-comments-host-provider-selection] retained source contract verified');

--- a/scripts/verify/verify-blog-comments-tcp-host-channel-selection.mjs
+++ b/scripts/verify/verify-blog-comments-tcp-host-channel-selection.mjs
@@ -1,0 +1,239 @@
+import fs from 'node:fs';
+
+const evidencePath =
+  'crates/rustok-blog/contracts/evidence/blog-comments-tcp-host-channel-selection.json';
+const planPath = 'crates/rustok-blog/docs/implementation-plan-slice-75.md';
+const runtimePath = 'apps/server/src/services/comments_provider_runtime.rs';
+const channelPath = 'crates/rustok-comments/src/tcp_channel.rs';
+const transportPath = 'crates/rustok-comments/src/tcp_transport.rs';
+const serverPath = 'crates/rustok-comments/src/tcp_server.rs';
+const commentsManifestPath = 'crates/rustok-comments/Cargo.toml';
+const lockPath = 'Cargo.lock';
+
+function read(path) {
+  return fs.readFileSync(path, 'utf8');
+}
+
+function fail(message) {
+  console.error(`[verify-blog-comments-tcp-host-channel-selection] ${message}`);
+  process.exit(1);
+}
+
+function requireCondition(condition, message) {
+  if (!condition) fail(message);
+}
+
+function hasAll(source, fragments, label) {
+  for (const fragment of fragments) {
+    requireCondition(source.includes(fragment), `${label} missing ${fragment}`);
+  }
+}
+
+function hasNone(source, fragments, label) {
+  for (const fragment of fragments) {
+    requireCondition(!source.includes(fragment), `${label} contains forbidden ${fragment}`);
+  }
+}
+
+function packageBlock(lock, name) {
+  const marker = `[[package]]\nname = "${name}"\n`;
+  const start = lock.indexOf(marker);
+  requireCondition(start >= 0, `Cargo.lock missing package ${name}`);
+  const next = lock.indexOf('\n[[package]]', start + marker.length);
+  return lock.slice(start, next < 0 ? lock.length : next);
+}
+
+for (const path of [
+  evidencePath,
+  planPath,
+  runtimePath,
+  channelPath,
+  transportPath,
+  serverPath,
+  commentsManifestPath,
+  lockPath,
+]) {
+  requireCondition(fs.existsSync(path), `missing source artifact ${path}`);
+}
+
+const evidence = JSON.parse(read(evidencePath));
+const plan = read(planPath);
+const runtime = read(runtimePath);
+const channel = read(channelPath);
+const transport = read(transportPath);
+const server = read(serverPath);
+const commentsManifest = read(commentsManifestPath);
+const lock = read(lockPath);
+
+requireCondition(evidence.schema_version === 1, 'evidence schema drift');
+requireCondition(
+  evidence.module === 'blog'
+    && evidence.provider === 'comments'
+    && evidence.surface === 'comments_tcp_host_channel_selection',
+  'evidence identity drift',
+);
+requireCondition(
+  evidence.status === 'source_verified_no_compile'
+    && evidence.compile_policy === 'not_run_by_request'
+    && evidence.runtime_status === 'not_run',
+  'evidence execution status drift',
+);
+requireCondition(evidence.generated_from === planPath, 'plan path drift');
+
+requireCondition(
+  evidence.client_selection?.wrapper === 'SharedCommentsTcpClientChannelConnector'
+    && evidence.client_selection?.source === 'ModuleRuntimeExtensions'
+    && evidence.client_selection?.default === 'PlaintextLoopbackCommentsTcpChannel'
+    && evidence.client_selection?.selected_before_port_publication === true
+    && evidence.client_selection?.plaintext_profile === 'TcpLoopback'
+    && evidence.client_selection?.protected_profile === 'TcpProtectedLoopback',
+  'client selection evidence drift',
+);
+requireCondition(
+  evidence.server_selection?.wrapper === 'SharedCommentsTcpServerChannelAcceptor'
+    && JSON.stringify(evidence.server_selection?.precedence) === JSON.stringify([
+      'ServerRuntimeContext',
+      'ModuleRuntimeExtensions',
+      'PlaintextLoopbackCommentsTcpChannel',
+    ])
+    && evidence.server_selection?.resolved_before_listener_spawn === true
+    && evidence.server_selection?.shared_across_connections === true
+    && evidence.server_selection?.handshake_owned_by_acceptor === true
+    && evidence.server_selection?.request_idle_timeout_starts_after_channel_establishment === true,
+  'server selection evidence drift',
+);
+requireCondition(
+  evidence.policy?.plaintext_endpoint_loopback_only === true
+    && evidence.policy?.protected_endpoint_loopback_only === true
+    && evidence.policy?.listener_bind_loopback_only === true
+    && evidence.policy?.accepted_peer_loopback_only === true
+    && evidence.policy?.non_loopback_enabled === false
+    && evidence.policy?.authenticated_encrypted_classification_is_runtime_evidence === false
+    && evidence.policy?.channel_mints_application_authority === false
+    && evidence.policy?.bearer_and_delegation_retained === true
+    && evidence.policy?.tenant_match_retained === true
+    && evidence.policy?.owner_policy_retained === true,
+  'channel policy evidence drift',
+);
+requireCondition(
+  Array.isArray(evidence.dependency_contract?.new_direct_dependencies)
+    && evidence.dependency_contract.new_direct_dependencies.length === 0
+    && evidence.dependency_contract?.manifest_changed === false
+    && evidence.dependency_contract?.cargo_lock_changed === false,
+  'dependency evidence drift',
+);
+
+hasAll(
+  runtime,
+  [
+    'CommentsTcpChannelProtection, CommentsTcpClientChannelConnector,',
+    'CommentsTcpServerChannelAcceptor, CommentsThreadPort,',
+    'PlaintextLoopbackCommentsTcpChannel',
+    'TcpProtectedLoopback',
+    'pub struct SharedCommentsTcpClientChannelConnector(',
+    'pub struct SharedCommentsTcpServerChannelAcceptor(',
+    '.get::<SharedCommentsTcpClientChannelConnector>()',
+    '.unwrap_or_else(plaintext_client_channel_connector)',
+    'let channel_protection = channel_connector.protection();',
+    'require_loopback_endpoint(endpoint, channel_protection)?;',
+    'TcpJsonCommentsTransport::with_channel_connector_and_bearer_token(',
+    'TcpJsonCommentsTransport::with_channel_connector_bearer_and_delegation(',
+    '.shared_get::<SharedCommentsTcpServerChannelAcceptor>()',
+    '.get::<SharedCommentsTcpServerChannelAcceptor>()',
+    '.unwrap_or_else(plaintext_server_channel_acceptor)',
+    'channel_acceptor: Arc<dyn CommentsTcpServerChannelAcceptor>',
+    'let channel_acceptor = channel_acceptor.clone();',
+    'handle_connection_with_acceptor_and_pre_request_timeout(',
+    'channel_acceptor.as_ref()',
+    'channel_protection = ?channel_protection',
+    'peer_addr.ip().is_loopback()',
+    'must remain loopback until protected Comments TCP runtime evidence is retained',
+    'CommentsTcpBearerAuthorityResolver::from_token(token, actor)',
+    'CommentsTcpDelegatingAuthorityResolver::new(token, actor, delegation_secret)',
+  ],
+  'host runtime',
+);
+hasNone(
+  runtime,
+  [
+    'rustls::',
+    'tokio_rustls::',
+    'native_tls::',
+    'openssl::',
+    'struct AllowAllCommentsTcpAuthority',
+    'TrustedCommentsTcpAuthority::new(',
+    '0.0.0.0:',
+    'retry(',
+    'println!(',
+  ],
+  'host runtime non-claims',
+);
+
+hasAll(
+  channel,
+  [
+    'pub enum CommentsTcpChannelProtection',
+    'PlaintextLoopback',
+    'AuthenticatedEncrypted',
+    'pub trait CommentsTcpClientChannelConnector: Send + Sync',
+    'pub trait CommentsTcpServerChannelAcceptor: Send + Sync',
+    'pub struct PlaintextLoopbackCommentsTcpChannel;',
+    'comments.tcp_plaintext_non_loopback',
+  ],
+  'channel seam',
+);
+
+hasAll(
+  transport,
+  [
+    'channel_connector: Arc<dyn CommentsTcpClientChannelConnector>',
+    'pub fn with_channel_connector_and_bearer_token(',
+    'pub fn with_channel_connector_bearer_and_delegation(',
+    'self.channel_connector.connect(self.endpoint).await?',
+    'request.context().require_deadline_semantics()?;',
+  ],
+  'client transport',
+);
+
+hasAll(
+  server,
+  [
+    'pub async fn handle_connection_with_acceptor_and_pre_request_timeout(',
+    'acceptor: &dyn CommentsTcpServerChannelAcceptor',
+    'let channel = acceptor.accept(stream, peer_addr).await?;',
+    'timeout(duration, read_frame(channel, self.max_frame_bytes))',
+    '.authorize(peer_addr, operation, credential.as_ref(), &request)',
+    'replace_request_context(&mut request, trusted_context);',
+  ],
+  'server adapter',
+);
+
+hasNone(
+  commentsManifest,
+  ['rustls =', 'tokio-rustls =', 'native-tls =', 'openssl ='],
+  'comments manifest',
+);
+const commentsLockBlock = packageBlock(lock, 'rustok-comments');
+hasNone(
+  commentsLockBlock,
+  ['"rustls"', '"tokio-rustls"', '"native-tls"', '"openssl"'],
+  'comments lock entry',
+);
+
+hasAll(
+  plan,
+  [
+    '# rustok-blog implementation plan — slice 75 continuation',
+    '## Slice 75 — host-selected protected Comments channel wiring',
+    'SharedCommentsTcpClientChannelConnector',
+    'SharedCommentsTcpServerChannelAcceptor',
+    'does not implement or claim',
+    'rustls/tokio-rustls',
+    'Status: `source_verified_no_compile`.',
+    'Compile policy: `not_run_by_request`.',
+    'Runtime status: `not_run`.',
+  ],
+  'slice-75 plan',
+);
+
+console.log('[verify-blog-comments-tcp-host-channel-selection] source contract verified');

--- a/scripts/verify/verify-blog-comments-tcp-listener-lifecycle.mjs
+++ b/scripts/verify/verify-blog-comments-tcp-listener-lifecycle.mjs
@@ -14,9 +14,7 @@ function read(path) {
 }
 
 function requireCondition(condition, message) {
-  if (!condition) {
-    throw new Error(message);
-  }
+  if (!condition) throw new Error(message);
 }
 
 function requireText(source, fragment, path) {
@@ -40,69 +38,29 @@ requireCondition(
   'evidence surface must identify the Comments TCP listener lifecycle',
 );
 requireCondition(
-  evidence.status === 'source_verified_no_compile',
-  'evidence must remain source-only',
+  evidence.status === 'source_verified_no_compile'
+    && evidence.compile_policy === 'not_run_by_request'
+    && evidence.runtime_status === 'not_run',
+  'listener evidence execution status must remain source-only',
 );
-requireCondition(
-  evidence.compile_policy === 'not_run_by_request',
-  'compile policy must record that execution was not requested',
-);
-requireCondition(
-  evidence.runtime_status === 'not_run',
-  'runtime status must remain not_run',
-);
-requireCondition(
-  evidence.configuration.default_enabled === false,
-  'listener must remain disabled by default',
-);
-requireCondition(
-  evidence.configuration.loopback_required === true,
-  'plaintext listener must remain loopback-only',
-);
-requireCondition(
-  evidence.configuration.default_max_connections === 64,
-  'default connection bound must remain 64',
-);
-requireCondition(
-  evidence.configuration.default_pre_request_timeout_ms === 2000,
-  'default pre-request timeout must remain 2000 ms',
-);
-requireCondition(
-  evidence.configuration.default_shutdown_grace_ms === 5000,
-  'default shutdown grace must remain 5000 ms',
-);
-requireCondition(
-  evidence.configuration.default_max_frame_bytes === 8388608,
-  'default frame bound must remain 8 MiB',
-);
-requireCondition(
-  evidence.authority.allow_all_fallback === false,
-  'authority must not gain an allow-all fallback',
-);
-requireCondition(
-  evidence.authority.listener_start_without_authority === false,
-  'listener must not start without authenticated authority',
-);
+requireCondition(evidence.configuration.default_enabled === false, 'listener must remain opt-in');
+requireCondition(evidence.configuration.loopback_required === true, 'listener must remain loopback-only');
+requireCondition(evidence.configuration.default_max_connections === 64, 'connection bound drift');
+requireCondition(evidence.configuration.default_pre_request_timeout_ms === 2000, 'idle timeout drift');
+requireCondition(evidence.configuration.default_shutdown_grace_ms === 5000, 'shutdown grace drift');
+requireCondition(evidence.configuration.default_max_frame_bytes === 8388608, 'frame bound drift');
+requireCondition(evidence.authority.allow_all_fallback === false, 'authority widened');
+requireCondition(evidence.authority.listener_start_without_authority === false, 'authority became optional');
 requireCondition(
   evidence.provider.consumer_port_reused_as_server_provider === false,
-  'consumer-selected TCP port must remain separate from server provider selection',
+  'consumer port/server provider separation drift',
 );
+requireCondition(evidence.lifecycle.bounded_concurrency === 'tokio::sync::Semaphore', 'semaphore drift');
+requireCondition(evidence.lifecycle.shared_shutdown_signal === 'StopHandle', 'shutdown signal drift');
+requireCondition(evidence.lifecycle.abort_after_grace === true, 'bounded shutdown drift');
 requireCondition(
-  evidence.lifecycle.bounded_concurrency === 'tokio::sync::Semaphore',
-  'listener concurrency must remain semaphore bounded',
-);
-requireCondition(
-  evidence.lifecycle.shared_shutdown_signal === 'StopHandle',
-  'listener must remain attached to the shared StopHandle',
-);
-requireCondition(
-  evidence.lifecycle.abort_after_grace === true,
-  'shutdown must remain bounded by a grace period',
-);
-requireCondition(
-  evidence.connection.pre_request_timeout_code ===
-    'comments.tcp_server_idle_timeout',
-  'pre-request timeout code must remain stable',
+  evidence.connection.pre_request_timeout_code === 'comments.tcp_server_idle_timeout',
+  'pre-request timeout code drift',
 );
 
 for (const fragment of [
@@ -119,17 +77,20 @@ for (const fragment of [
   'DEFAULT_COMMENTS_TCP_SHUTDOWN_GRACE_MS: u64 = 5_000',
   'DEFAULT_COMMENTS_TCP_MAX_FRAME_BYTES: usize = 8 * 1024 * 1024',
   'pub struct SharedCommentsTcpAuthorityResolver',
+  'pub struct SharedCommentsTcpServerChannelAcceptor(',
   'pub struct SharedCommentsTcpServerProvider',
   'pub struct CommentsTcpListenerConfig',
   'pub struct CommentsTcpListenerHandle',
   'CommentsTcpListenerLifecycleReservation',
   'bind_addr.ip().is_loopback()',
   'bind_addr.port() == 0',
-  'max_frame_bytes > u32::MAX as usize',
   'runtime.is_registry_only()',
   'runtime.is_worker_only()',
-  'SharedCommentsTcpAuthorityResolver',
-  'comments_tcp_bearer_authority_from_environment',
+  '.shared_get::<SharedCommentsTcpServerChannelAcceptor>()',
+  '.get::<SharedCommentsTcpServerChannelAcceptor>()',
+  '.unwrap_or_else(plaintext_server_channel_acceptor)',
+  'let channel_protection = channel_acceptor.protection();',
+  'comments_tcp_authority_from_environment',
   'CommentsTcpBearerAuthorityResolver::from_token(token, actor)',
   '.with_claim(COMMENTS_TCP_SERVICE_PERMISSION)',
   '.with_role(COMMENTS_TCP_SERVICE_ROLE)',
@@ -140,79 +101,58 @@ for (const fragment of [
   'try_acquire_owned()',
   'JoinSet::new()',
   'peer_addr.ip().is_loopback()',
-  'handle_connection_with_pre_request_timeout(',
+  'handle_connection_with_acceptor_and_pre_request_timeout(',
+  'channel_acceptor.as_ref()',
   'StopHandle::new()',
   'stop_handle.subscribe()',
   'timeout(config.shutdown_grace',
   'connections.abort_all()',
+  'channel_protection = ?channel_protection',
   'code = %error.code',
   'kind = ?error.kind',
   'retryable = error.retryable',
-]) {
-  requireText(runtime, fragment, runtimePath);
-}
+]) requireText(runtime, fragment, runtimePath);
 
 requireCondition(
   !runtime.includes('struct AllowAllCommentsTcpAuthority'),
-  'runtime must not introduce an allow-all Comments authority resolver',
+  'runtime must not introduce allow-all authority',
 );
 requireCondition(
   !runtime.includes('TrustedCommentsTcpAuthority::new('),
-  'host listener runtime must not manufacture trusted authority from the payload',
+  'listener runtime must not mint authority from payload data',
 );
 requireCondition(
-  !runtime.includes('COMMENTS_TCP_BEARER_TOKEN_ENV, %'),
-  'runtime must not log the bearer token value',
+  !runtime.includes('0.0.0.0:'),
+  'listener must not publish a wildcard endpoint',
 );
 
 for (const fragment of [
   'pub const SHA256_DIGEST_BYTES: usize = 32;',
   'pub fn sha256_digest(',
   'pub fn fixed_work_sha256_eq(',
-  'difference |= expected[index] ^ candidate[index];',
-]) {
-  requireText(digest, fragment, digestPath);
-}
+]) requireText(digest, fragment, digestPath);
 
 for (const fragment of [
   'pub struct CommentsTcpBearerAuthorityResolver',
   'fixed_work_sha256_eq',
-  'sha256_digest(&[BEARER_PREFIX, secret])',
   'comments.tcp_authentication_failed',
   '[REDACTED]',
-]) {
-  requireText(auth, fragment, authPath);
-}
-requireCondition(
-  !auth.includes('ConstantTimeEq') && !auth.includes('use subtle::'),
-  'Comments auth must use the shared lock-compatible digest helper',
-);
+]) requireText(auth, fragment, authPath);
 
 for (const fragment of [
-  'handle_connection_with_pre_request_timeout',
+  'pub async fn handle_connection_with_acceptor_and_pre_request_timeout(',
+  'acceptor: &dyn CommentsTcpServerChannelAcceptor',
+  'let channel = acceptor.accept(stream, peer_addr).await?;',
   'comments.tcp_server_invalid_idle_timeout',
   'comments.tcp_server_idle_timeout',
-  'timeout(duration, read_frame(stream, self.max_frame_bytes))',
+  'timeout(duration, read_frame(channel, self.max_frame_bytes))',
   'serde_json::from_slice::<CommentsTcpRequestEnvelope>',
   'request.context().require_deadline_semantics()',
   'credential.as_ref()',
-]) {
-  requireText(adapter, fragment, adapterPath);
-}
+]) requireText(adapter, fragment, adapterPath);
 
-requireText(
-  bootstrap,
-  'start_comments_tcp_listener_if_enabled(',
-  bootstrapPath,
-);
-requireText(
-  bootstrap,
-  'bootstrap_app_runtime(runtime_ctx.clone(), auth_config.clone(), &rustok_settings).await?',
-  bootstrapPath,
-);
+requireText(bootstrap, 'start_comments_tcp_listener_if_enabled(', bootstrapPath);
 requireText(plan, '## Slice 71 — host-owned Comments TCP listener lifecycle', planPath);
 requireText(plan, 'Status: `source_verified_no_compile`.', planPath);
-requireText(plan, 'concrete authenticated authority resolver', planPath);
-requireText(plan, 'intentionally not run in this slice', planPath);
 
 console.log('Blog Comments TCP listener lifecycle source contract is retained.');


### PR DESCRIPTION
## Summary

- continue the Blog improvement plan with slice 75
- make client and server Comments channel implementations first-class host runtime extensions
- add `SharedCommentsTcpClientChannelConnector` for consumer-side channel selection
- add `SharedCommentsTcpServerChannelAcceptor` with runtime-context, module-extension, then plaintext-default precedence
- publish the remote Comments port through the selected client connector
- route every listener connection through the selected server acceptor before typed framing
- distinguish plaintext and host-protected loopback profiles through `TcpLoopback` and `TcpProtectedLoopback`
- keep plaintext as the only built-in connector and acceptor
- keep both plaintext and host-protected profiles loopback-only until retained runtime evidence exists
- preserve bearer reads, signed user writes, service moderation, tenant equality, trusted principal replacement, owner policy, frame bounds, concurrency, deadlines, and bounded shutdown
- log only the closed channel-protection classification, never connector/acceptor internals or credentials
- add slice-75 plan, machine-readable source evidence, and a focused source guard
- reconcile the retained slice-70 host-provider and slice-71 listener lifecycle guards
- add no dependency or feature declaration and make no `Cargo.lock` change

## Explicit non-claims

- no concrete rustls, tokio-rustls, TLS, or mTLS adapter is implemented
- no certificate, private-key, trust-root, server-name, ALPN, expiry, or revocation handling is added
- `AuthenticatedEncrypted` remains host-provided classification metadata, not independently verified runtime evidence
- no non-loopback endpoint, bind address, or peer is enabled
- no channel-derived Comments authority is introduced
- no retry/backoff, shared replay store, readiness, health, or runtime evidence is added

## Verification

Tests, source verifiers, formatting, Cargo checks, TCP/TLS runtime targets, database targets, browser targets, workflows, and CI were intentionally not run by request. Suggested maintainer commands are recorded in `crates/rustok-blog/docs/implementation-plan-slice-75.md`.