### PR TITLE
test(forum): add retained runtime evidence promotion gate

### DIFF
--- a/crates/rustok-forum/contracts/forum-search-versioned-invalidation-retained-evidence-promotion.json
+++ b/crates/rustok-forum/contracts/forum-search-versioned-invalidation-retained-evidence-promotion.json
@@ -1,0 +1,51 @@
+{
+  "contract": "forum_search_versioned_invalidation_retained_evidence_promotion_v1",
+  "task": "FORUM-23B2G2B3D12",
+  "status": "source_ready_maintainer_execution_pending",
+  "runtime_evidence_parent": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json",
+  "aggregate_artifact": "target/forum-search-versioned-invalidation-runtime-evidence.json",
+  "reviewer": "scripts/evidence/review-forum-search-versioned-invalidation-runtime-evidence.mjs",
+  "verifier": "scripts/verify/verify-forum-search-versioned-invalidation-retained-evidence-promotion.mjs",
+  "promotion_candidate": {
+    "path": "target/forum-search-versioned-invalidation-runtime-promotion-candidate.json",
+    "generation": "reviewer_only_after_retained_aggregate_validation",
+    "hand_editing_forbidden": true,
+    "source_commit_required": true,
+    "atomic_replace": true,
+    "automatic_canonical_source_mutation": false
+  },
+  "required_attestations": [
+    "RUSTOK_FORUM_EVIDENCE_REVIEWER",
+    "RUSTOK_FORUM_EVIDENCE_RETENTION_REF",
+    "RUSTOK_FORUM_EVIDENCE_RETAINED_SHA256"
+  ],
+  "fail_closed_requirements": [
+    "the D0 parent remains source_ready_maintainer_execution_pending before review",
+    "the aggregate artifact has exact D0 identity and runtime_evidence_assembled status",
+    "the aggregate source_commit is one lowercase forty-character SHA equal to git rev-parse HEAD",
+    "the aggregate parent-contract digest equals the current D0 parent bytes",
+    "all ten frozen scenarios exist exactly once in canonical order with passed results and non-empty facts",
+    "all nine D2 through D10 source artifacts exist and match the aggregate path, task, contract, source commit, byte length and SHA-256 digest",
+    "every grouped D0 required evidence field contains only source-attributed non-empty facts from the retained source-artifact set",
+    "the assembly record reports complete validation, one source commit, current-head equality, nine inputs and ten frozen scenarios",
+    "the reviewer identity and retention reference are bounded non-empty values without control characters",
+    "the maintainer-supplied retained SHA-256 equals the exact aggregate artifact digest",
+    "the promotion candidate is written only after complete validation by same-directory atomic rename",
+    "the reviewer never edits the D0 parent, canonical plan or LINK-FORUM-03 status"
+  ],
+  "proposed_transition": {
+    "from": "source_ready_maintainer_execution_pending",
+    "to": "runtime_evidence_reviewed",
+    "requires_separate_canonical_source_pull_request": true,
+    "closes_forum_23": false,
+    "closes_link_forum_03": false
+  },
+  "maintainer_command": "RUSTOK_FORUM_EVIDENCE_REVIEWER=\"<reviewer>\" RUSTOK_FORUM_EVIDENCE_RETENTION_REF=\"<immutable-retention-reference>\" RUSTOK_FORUM_EVIDENCE_RETAINED_SHA256=\"<aggregate-sha256>\" node scripts/evidence/review-forum-search-versioned-invalidation-runtime-evidence.mjs",
+  "non_claims": [
+    "this source-ready gate does not claim that D2 through D10 or the D11 assembler ran",
+    "this gate does not retrieve or independently authenticate an external retention service",
+    "this gate records an explicit retained-digest attestation but does not sign it cryptographically",
+    "this gate does not automatically edit or promote the D0 parent contract or canonical Forum plan",
+    "this gate does not close FORUM-23 or LINK-FORUM-03"
+  ]
+}

--- a/crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json
+++ b/crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json
@@ -7,13 +7,7 @@
   "rollout_decision": "DECISIONS/2026-07-31-forum-search-versioned-invalidation-rollout.md",
   "baseline": {
     "main_commit": "bd25ea3577b164225359beba86f973e907b74bef",
-    "merged_pull_requests": [
-      2731,
-      2738,
-      2741,
-      2749,
-      2753
-    ],
+    "merged_pull_requests": [2731, 2738, 2741, 2749, 2753],
     "owner_revision_checkpoint": "FORUM-23B2G2B2",
     "wire_contract": "FORUM-23B2G2B3A",
     "caused_publication_api": "FORUM-23B2G2B3B1",
@@ -28,200 +22,88 @@
       "contract": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-postgres-ingress-proof.json",
       "test": "crates/rustok-search/tests/forum_versioned_invalidation_postgres.rs",
       "evidence_artifact": "target/forum-search-versioned-invalidation-postgres-ingress-evidence.json",
-      "covers": [
-        "typed_ingress_admission",
-        "legacy_first_duplicate",
-        "typed_first_duplicate",
-        "semantic_identity_conflict_classification"
-      ],
-      "does_not_cover": [
-        "broker_acknowledgement_or_restart",
-        "poison_receipt_or_dlq_publication",
-        "projector_or_owner_checkpoint",
-        "multi_process_or_visibility_end_to_end"
-      ]
+      "covers": ["typed_ingress_admission", "legacy_first_duplicate", "typed_first_duplicate", "semantic_identity_conflict_classification"],
+      "does_not_cover": ["broker_acknowledgement_or_restart", "poison_receipt_or_dlq_publication", "projector_or_owner_checkpoint", "multi_process_or_visibility_end_to_end"]
     },
     {
       "task": "FORUM-23B2G2B3D3",
       "contract": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-ack-restart-proof.json",
       "test": "apps/server/tests/forum_versioned_invalidation_ack_restart_iggy.rs",
       "evidence_artifact": "target/forum-search-versioned-invalidation-ack-restart-evidence.json",
-      "covers": [
-        "durable_ingress_before_acknowledgement",
-        "injected_acknowledgement_token_failure",
-        "same_offset_redelivery_after_consumer_restart",
-        "one_inbox_row_and_stable_ingest_sequence_after_redelivery",
-        "successful_restart_acknowledgement_advances_to_next_event"
-      ],
-      "does_not_cover": [
-        "server_worker_retry_backoff",
-        "poison_receipt_or_dlq_publication",
-        "projector_or_owner_checkpoint",
-        "multi_process_or_visibility_end_to_end"
-      ]
+      "covers": ["durable_ingress_before_acknowledgement", "injected_acknowledgement_token_failure", "same_offset_redelivery_after_consumer_restart", "one_inbox_row_and_stable_ingest_sequence_after_redelivery", "successful_restart_acknowledgement_advances_to_next_event"],
+      "does_not_cover": ["server_worker_retry_backoff", "poison_receipt_or_dlq_publication", "projector_or_owner_checkpoint", "multi_process_or_visibility_end_to_end"]
     },
     {
       "task": "FORUM-23B2G2B3D4",
       "contract": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-raw-poison-proof.json",
       "test": "apps/server/tests/forum_versioned_invalidation_raw_poison_iggy.rs",
       "evidence_artifact": "target/forum-search-versioned-invalidation-raw-poison-evidence.json",
-      "covers": [
-        "stable_connector_delivery_identity",
-        "durable_publishing_and_published_before_source_acknowledgement",
-        "deterministic_dlq_broker_message_identity",
-        "same_offset_poison_redelivery_after_consumer_restart",
-        "already_published_suppresses_duplicate_dlq_publication",
-        "source_acknowledgement_then_acknowledged_state_and_group_advancement"
-      ],
-      "does_not_cover": [
-        "server_worker_retry_backoff",
-        "dlq_publish_failure_or_publish_mark_ambiguity",
-        "semantic_identity_conflict_poison",
-        "projector_or_owner_checkpoint",
-        "multi_process_or_visibility_end_to_end"
-      ]
+      "covers": ["stable_connector_delivery_identity", "durable_publishing_and_published_before_source_acknowledgement", "deterministic_dlq_broker_message_identity", "same_offset_poison_redelivery_after_consumer_restart", "already_published_suppresses_duplicate_dlq_publication", "source_acknowledgement_then_acknowledged_state_and_group_advancement"],
+      "does_not_cover": ["server_worker_retry_backoff", "dlq_publish_failure_or_publish_mark_ambiguity", "semantic_identity_conflict_poison", "projector_or_owner_checkpoint", "multi_process_or_visibility_end_to_end"]
     },
     {
       "task": "FORUM-23B2G2B3D5",
       "contract": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-semantic-poison-proof.json",
       "test": "apps/server/tests/forum_versioned_invalidation_semantic_poison_iggy.rs",
       "evidence_artifact": "target/forum-search-versioned-invalidation-semantic-poison-evidence.json",
-      "covers": [
-        "non_retryable_semantic_identity_conflict",
-        "durable_conflict_row_preserved_and_unique",
-        "stable_connector_and_deterministic_dlq_identity_for_typed_bytes",
-        "published_receipt_before_source_acknowledgement",
-        "same_offset_redelivery_and_already_published_duplicate_suppression",
-        "acknowledged_receipt_and_group_advancement_to_valid_event"
-      ],
-      "does_not_cover": [
-        "server_worker_retry_backoff",
-        "dlq_publish_failure_or_publish_mark_ambiguity",
-        "projector_or_owner_checkpoint",
-        "missing_delivery_repair",
-        "multi_process_or_visibility_end_to_end"
-      ]
+      "covers": ["non_retryable_semantic_identity_conflict", "durable_conflict_row_preserved_and_unique", "stable_connector_and_deterministic_dlq_identity_for_typed_bytes", "published_receipt_before_source_acknowledgement", "same_offset_redelivery_and_already_published_duplicate_suppression", "acknowledged_receipt_and_group_advancement_to_valid_event"],
+      "does_not_cover": ["server_worker_retry_backoff", "dlq_publish_failure_or_publish_mark_ambiguity", "projector_or_owner_checkpoint", "missing_delivery_repair", "multi_process_or_visibility_end_to_end"]
     },
     {
       "task": "FORUM-23B2G2B3D6",
       "contract": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-missing-delivery-repair-proof.json",
       "test": "crates/rustok-search/tests/forum_versioned_invalidation_missing_delivery_repair.rs",
       "evidence_artifact": "target/forum-search-versioned-invalidation-missing-delivery-repair-evidence.json",
-      "covers": [
-        "bounded_owner_tenant_and_revision_scan",
-        "missing_delivery_detected_by_owner_event_identity",
-        "failed_rebuild_leaves_projection_and_checkpoint_unchanged",
-        "one_successful_current_state_rebuild_repairs_projection",
-        "checkpoint_audit_advances_exactly_1_2_3_after_rebuild",
-        "caught_up_repeat_suppresses_duplicate_rebuild"
-      ],
-      "does_not_cover": [
-        "host_worker_polling_loop",
-        "iggy_delivery_acknowledgement_or_poison",
-        "multi_process_lock_or_scan_cursor_contention",
-        "deletion_acl_or_storefront_visibility",
-        "search_disabled_profile_or_link_forum_03"
-      ]
+      "covers": ["bounded_owner_tenant_and_revision_scan", "missing_delivery_detected_by_owner_event_identity", "failed_rebuild_leaves_projection_and_checkpoint_unchanged", "one_successful_current_state_rebuild_repairs_projection", "checkpoint_audit_advances_exactly_1_2_3_after_rebuild", "caught_up_repeat_suppresses_duplicate_rebuild"],
+      "does_not_cover": ["host_worker_polling_loop", "iggy_delivery_acknowledgement_or_poison", "multi_process_lock_or_scan_cursor_contention", "deletion_acl_or_storefront_visibility", "search_disabled_profile_or_link_forum_03"]
     },
     {
       "task": "FORUM-23B2G2B3D7",
       "contract": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-multi-process-proof.json",
       "test": "apps/server/tests/forum_versioned_invalidation_multi_process_serialization.rs",
       "evidence_artifact": "target/forum-search-versioned-invalidation-multi-process-evidence.json",
-      "covers": [
-        "independent_host_os_process_contention",
-        "postgresql_tenant_advisory_lock_exclusion",
-        "blocked_contender_never_enters_projection",
-        "stale_scan_cursor_compare_and_set_suppressed",
-        "first_tenant_exact_checkpoint_order_1_2",
-        "next_tenant_discovered_without_cursor_skip_or_regression",
-        "second_tenant_checkpoint_revision_1"
-      ],
-      "does_not_cover": [
-        "long_running_host_polling_or_restart_timing",
-        "iggy_delivery_acknowledgement_or_poison",
-        "deletion_acl_or_storefront_visibility",
-        "search_disabled_profile_or_link_forum_03"
-      ]
+      "covers": ["independent_host_os_process_contention", "postgresql_tenant_advisory_lock_exclusion", "blocked_contender_never_enters_projection", "stale_scan_cursor_compare_and_set_suppressed", "first_tenant_exact_checkpoint_order_1_2", "next_tenant_discovered_without_cursor_skip_or_regression", "second_tenant_checkpoint_revision_1"],
+      "does_not_cover": ["long_running_host_polling_or_restart_timing", "iggy_delivery_acknowledgement_or_poison", "deletion_acl_or_storefront_visibility", "search_disabled_profile_or_link_forum_03"]
     },
     {
       "task": "FORUM-23B2G2B3D8",
       "contract": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-deletion-acl-ordering-proof.json",
       "test": "apps/server/tests/forum_versioned_invalidation_deletion_acl_ordering.rs",
       "evidence_artifact": "target/forum-search-versioned-invalidation-deletion-acl-ordering-evidence.json",
-      "covers": [
-        "owner_hide_delete_and_richer_acl_revisions",
-        "legacy_and_typed_dual_path_out_of_order_admission",
-        "durable_duplicate_root_suppression",
-        "current_state_rebuild_and_stale_category_refresh_non_restoration",
-        "search_projection_denied_objects_absent",
-        "storefront_owner_reauthorization_rejects_stale_rows",
-        "visible_totals_items_and_facets_exclude_denied_content"
-      ],
-      "does_not_cover": [
-        "long_running_host_polling_or_restart_timing",
-        "iggy_acknowledgement_poison_or_dlq",
-        "search_disabled_profile_or_link_forum_03"
-      ]
+      "covers": ["owner_hide_delete_and_richer_acl_revisions", "legacy_and_typed_dual_path_out_of_order_admission", "durable_duplicate_root_suppression", "current_state_rebuild_and_stale_category_refresh_non_restoration", "search_projection_denied_objects_absent", "storefront_owner_reauthorization_rejects_stale_rows", "visible_totals_items_and_facets_exclude_denied_content"],
+      "does_not_cover": ["long_running_host_polling_or_restart_timing", "iggy_acknowledgement_poison_or_dlq", "search_disabled_profile_or_link_forum_03"]
     },
     {
       "task": "FORUM-23B2G2B3D9",
       "contract": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-search-disabled-recovery-proof.json",
       "test": "apps/server/tests/forum_versioned_invalidation_search_disabled_recovery.rs",
       "evidence_artifact": "target/forum-search-versioned-invalidation-search-disabled-recovery-evidence.json",
-      "covers": [
-        "forum_owner_commands_commit_without_search_storage",
-        "legacy_and_typed_owner_events_persist_without_search_runtime",
-        "contiguous_owner_revisions_survive_disabled_period",
-        "late_search_enable_starts_without_inbox_or_checkpoint_state",
-        "bounded_real_owner_ledger_scan_repairs_projection_once",
-        "checkpoint_advances_exactly_1_2_3_after_rebuild",
-        "forum_owner_state_and_event_history_remain_unchanged",
-        "caught_up_repeat_suppresses_duplicate_recovery"
-      ],
-      "does_not_cover": [
-        "long_running_host_process_restart_or_polling_cadence",
-        "iggy_acknowledgement_poison_or_dlq",
-        "deployment_orchestration_or_link_forum_03"
-      ]
+      "covers": ["forum_owner_commands_commit_without_search_storage", "legacy_and_typed_owner_events_persist_without_search_runtime", "contiguous_owner_revisions_survive_disabled_period", "late_search_enable_starts_without_inbox_or_checkpoint_state", "bounded_real_owner_ledger_scan_repairs_projection_once", "checkpoint_advances_exactly_1_2_3_after_rebuild", "forum_owner_state_and_event_history_remain_unchanged", "caught_up_repeat_suppresses_duplicate_recovery"],
+      "does_not_cover": ["long_running_host_process_restart_or_polling_cadence", "iggy_acknowledgement_poison_or_dlq", "deployment_orchestration_or_link_forum_03"]
     },
     {
       "task": "FORUM-23B2G2B3D10",
       "contract": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-normal-delivery-proof.json",
       "test": "apps/server/tests/forum_versioned_invalidation_normal_delivery_iggy.rs",
       "evidence_artifact": "target/forum-search-versioned-invalidation-normal-delivery-evidence.json",
-      "covers": [
-        "one_correlated_normal_owner_delivery_trace",
-        "real_forum_owner_transaction_and_dual_outbox_publication",
-        "external_iggy_persistent_group_delivery",
-        "durable_ingress_before_source_acknowledgement",
-        "production_projection_completion",
-        "delivery_covered_checkpoint_order_1_2",
-        "storefront_exact_topic_visibility",
-        "caught_up_repeat_suppression"
-      ],
-      "does_not_cover": [
-        "acknowledgement_failure_restart_or_poison_dlq",
-        "multi_process_deletion_acl_or_search_disabled_profiles",
-        "aggregate_d0_artifact_assembly_or_link_forum_03"
-      ]
+      "covers": ["one_correlated_normal_owner_delivery_trace", "real_forum_owner_transaction_and_dual_outbox_publication", "external_iggy_persistent_group_delivery", "durable_ingress_before_source_acknowledgement", "production_projection_completion", "delivery_covered_checkpoint_order_1_2", "storefront_exact_topic_visibility", "caught_up_repeat_suppression"],
+      "does_not_cover": ["acknowledgement_failure_restart_or_poison_dlq", "multi_process_deletion_acl_or_search_disabled_profiles", "aggregate_d0_artifact_assembly_or_link_forum_03"]
     },
     {
       "task": "FORUM-23B2G2B3D11",
       "contract": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-aggregate-evidence-assembler.json",
       "assembler": "scripts/evidence/assemble-forum-search-versioned-invalidation-runtime-evidence.mjs",
       "evidence_artifact": "target/forum-search-versioned-invalidation-runtime-evidence.json",
-      "covers": [
-        "all_nine_runtime_subproof_artifacts_required",
-        "same_source_commit_aggregate_assembly",
-        "exact_ten_scenario_mapping",
-        "input_sha256_and_parent_digest_retention",
-        "atomic_output_after_complete_validation"
-      ],
-      "does_not_cover": [
-        "runtime_execution_or_d0_status_promotion",
-        "link_forum_03_or_release_completion"
-      ]
+      "covers": ["all_nine_runtime_subproof_artifacts_required", "same_source_commit_aggregate_assembly", "exact_ten_scenario_mapping", "input_sha256_and_parent_digest_retention", "atomic_output_after_complete_validation"],
+      "does_not_cover": ["runtime_execution_or_d0_status_promotion", "link_forum_03_or_release_completion"]
+    },
+    {
+      "task": "FORUM-23B2G2B3D12",
+      "contract": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-retained-evidence-promotion.json",
+      "reviewer": "scripts/evidence/review-forum-search-versioned-invalidation-runtime-evidence.mjs",
+      "promotion_candidate": "target/forum-search-versioned-invalidation-runtime-promotion-candidate.json",
+      "covers": ["retained_aggregate_digest_attestation", "all_nine_source_artifact_digest_revalidation", "exact_ten_scenario_review", "promotion_candidate_without_source_mutation"],
+      "does_not_cover": ["runtime_execution", "canonical_d0_status_promotion", "forum_23_completion", "link_forum_03"]
     }
   ],
   "required_runtime": {
@@ -240,110 +122,22 @@
     "Forum owner_revision is never compared numerically with Search ingest_sequence"
   ],
   "required_scenarios": [
-    {
-      "id": "normal_delivery",
-      "requires": [
-        "one owner transaction commits owner state, legacy root, caused typed event and ledger row",
-        "the typed consumer durably admits exactly one matching Search inbox row",
-        "the existing projector completes and the owner checkpoint advances only after projection success"
-      ]
-    },
-    {
-      "id": "legacy_first_duplicate",
-      "requires": [
-        "legacy delivery creates the shared inbox row before typed delivery",
-        "typed delivery recognizes the exact durable duplicate",
-        "one projection identity and one projector execution lane remain"
-      ]
-    },
-    {
-      "id": "typed_first_duplicate",
-      "requires": [
-        "typed delivery creates the shared inbox row before legacy delivery",
-        "legacy delivery collapses on the same root event identity",
-        "one ingest sequence is allocated for the shared inbox row"
-      ]
-    },
-    {
-      "id": "acknowledgement_failure_restart",
-      "requires": [
-        "durable inbox admission completes before the injected acknowledgement failure",
-        "the exact broker offset remains uncommitted",
-        "a restarted consumer recognizes the same durable root row and acknowledges without a second projection row"
-      ]
-    },
-    {
-      "id": "raw_poison_dlq_redelivery",
-      "requires": [
-        "decode or schema poison creates one durable connector-owned poison receipt",
-        "DLQ publication uses the deterministic message identity",
-        "redelivery reuses the durable receipt and does not duplicate DLQ publication",
-        "source acknowledgement occurs only after the durable terminal result"
-      ]
-    },
-    {
-      "id": "semantic_poison_identity_conflict",
-      "requires": [
-        "a conflicting pre-existing root event UUID fails with forum.search_projection.contract_inbox_identity_conflict",
-        "the conflicting row never enters the projector",
-        "the semantic poison uses the same durable receipt and DLQ protocol as raw poison"
-      ]
-    },
-    {
-      "id": "missing_delivery_owner_repair",
-      "requires": [
-        "an owner ledger revision exists without a Search inbox delivery",
-        "the bounded owner scan discovers the tenant",
-        "one current-state rebuild repairs projection state",
-        "the owner checkpoint advances in exact contiguous revision order only after rebuild success"
-      ]
-    },
-    {
-      "id": "multi_process_serialization",
-      "requires": [
-        "at least two server processes contend for the same tenant",
-        "the shared advisory lock prevents concurrent tenant projection and checkpoint advancement",
-        "cursor compare-and-set and exact +1 checkpoint guards prevent regression or skips"
-      ]
-    },
-    {
-      "id": "deletion_acl_ordering",
-      "requires": [
-        "published content is searchable before the owner change",
-        "hide, delete and richer ACL changes each issue owner revisions",
-        "out-of-order and duplicate deliveries cannot restore denied content",
-        "the final storefront Search result excludes the content for the denied viewer"
-      ]
-    },
-    {
-      "id": "search_disabled_profile",
-      "requires": [
-        "Forum owner commands and transactional events still commit with Search disabled",
-        "no synchronous Search dependency is introduced",
-        "reenabling Search permits bounded owner-ledger reconciliation without owner-state loss"
-      ]
-    }
+    {"id": "normal_delivery", "requires": ["one owner transaction commits owner state, legacy root, caused typed event and ledger row", "the typed consumer durably admits exactly one matching Search inbox row", "the existing projector completes and the owner checkpoint advances only after projection success"]},
+    {"id": "legacy_first_duplicate", "requires": ["legacy delivery creates the shared inbox row before typed delivery", "typed delivery recognizes the exact durable duplicate", "one projection identity and one projector execution lane remain"]},
+    {"id": "typed_first_duplicate", "requires": ["typed delivery creates the shared inbox row before legacy delivery", "legacy delivery collapses on the same root event identity", "one ingest sequence is allocated for the shared inbox row"]},
+    {"id": "acknowledgement_failure_restart", "requires": ["durable inbox admission completes before the injected acknowledgement failure", "the exact broker offset remains uncommitted", "a restarted consumer recognizes the same durable root row and acknowledges without a second projection row"]},
+    {"id": "raw_poison_dlq_redelivery", "requires": ["decode or schema poison creates one durable connector-owned poison receipt", "DLQ publication uses the deterministic message identity", "redelivery reuses the durable receipt and does not duplicate DLQ publication", "source acknowledgement occurs only after the durable terminal result"]},
+    {"id": "semantic_poison_identity_conflict", "requires": ["a conflicting pre-existing root event UUID fails with forum.search_projection.contract_inbox_identity_conflict", "the conflicting row never enters the projector", "the semantic poison uses the same durable receipt and DLQ protocol as raw poison"]},
+    {"id": "missing_delivery_owner_repair", "requires": ["an owner ledger revision exists without a Search inbox delivery", "the bounded owner scan discovers the tenant", "one current-state rebuild repairs projection state", "the owner checkpoint advances in exact contiguous revision order only after rebuild success"]},
+    {"id": "multi_process_serialization", "requires": ["at least two server processes contend for the same tenant", "the shared advisory lock prevents concurrent tenant projection and checkpoint advancement", "cursor compare-and-set and exact +1 checkpoint guards prevent regression or skips"]},
+    {"id": "deletion_acl_ordering", "requires": ["published content is searchable before the owner change", "hide, delete and richer ACL changes each issue owner revisions", "out-of-order and duplicate deliveries cannot restore denied content", "the final storefront Search result excludes the content for the denied viewer"]},
+    {"id": "search_disabled_profile", "requires": ["Forum owner commands and transactional events still commit with Search disabled", "no synchronous Search dependency is introduced", "reenabling Search permits bounded owner-ledger reconciliation without owner-state loss"]}
   ],
   "evidence_artifact": {
     "path": "target/forum-search-versioned-invalidation-runtime-evidence.json",
     "generation": "executable_runtime_only",
     "hand_editing_forbidden": true,
-    "required_fields": [
-      "contract",
-      "source_commit",
-      "database_backend",
-      "delivery_profile",
-      "consumer_group",
-      "scenario_results",
-      "owner_revision_rows",
-      "typed_and_root_event_ids",
-      "search_inbox_rows",
-      "ingest_sequences",
-      "owner_checkpoints",
-      "poison_receipts",
-      "dlq_receipts",
-      "storefront_visibility_assertions"
-    ]
+    "required_fields": ["contract", "source_commit", "database_backend", "delivery_profile", "consumer_group", "scenario_results", "owner_revision_rows", "typed_and_root_event_ids", "search_inbox_rows", "ingest_sequences", "owner_checkpoints", "poison_receipts", "dlq_receipts", "storefront_visibility_assertions"]
   },
   "maintainer_commands": [
     "node scripts/verify/verify-forum-search-versioned-invalidation-runtime-evidence.mjs",
@@ -367,6 +161,8 @@
     "RUSTOK_SEARCH_TEST_DATABASE_URL=\"$DATABASE_URL\" RUSTOK_IGGY_EXTERNAL_TEST_ADDRESS=\"127.0.0.1:8090\" cargo test -p rustok-server --test forum_versioned_invalidation_normal_delivery_iggy -- --nocapture --test-threads=1",
     "node scripts/verify/verify-forum-search-versioned-invalidation-aggregate-evidence-assembler.mjs",
     "node scripts/evidence/assemble-forum-search-versioned-invalidation-runtime-evidence.mjs",
+    "node scripts/verify/verify-forum-search-versioned-invalidation-retained-evidence-promotion.mjs",
+    "RUSTOK_FORUM_EVIDENCE_REVIEWER=\"<reviewer>\" RUSTOK_FORUM_EVIDENCE_RETENTION_REF=\"<immutable-retention-reference>\" RUSTOK_FORUM_EVIDENCE_RETAINED_SHA256=\"<aggregate-sha256>\" node scripts/evidence/review-forum-search-versioned-invalidation-runtime-evidence.mjs",
     "cargo run -p rustok-events --example event_contract_digests",
     "cargo test -p rustok-events",
     "cargo test -p rustok-search forum_contract_ingress -- --nocapture",

--- a/crates/rustok-forum/docs/forum-23b2g2b3d12-retained-evidence-promotion.md
+++ b/crates/rustok-forum/docs/forum-23b2g2b3d12-retained-evidence-promotion.md
@@ -1,0 +1,147 @@
+# FORUM-23B2G2B3D12 retained evidence review and promotion candidate
+
+## Status
+
+`source_ready_maintainer_execution_pending`
+
+This slice adds the review boundary after the D11 aggregate assembler. It does
+not execute D2 through D10, run D11, create runtime evidence during source
+implementation, promote the canonical D0 contract or close `FORUM-23` or
+`LINK-FORUM-03`.
+
+The machine contract is:
+
+```text
+crates/rustok-forum/contracts/forum-search-versioned-invalidation-retained-evidence-promotion.json
+```
+
+The reviewer is:
+
+```text
+scripts/evidence/review-forum-search-versioned-invalidation-runtime-evidence.mjs
+```
+
+The source-only verifier is:
+
+```text
+scripts/verify/verify-forum-search-versioned-invalidation-retained-evidence-promotion.mjs
+```
+
+The reviewed promotion candidate is written to:
+
+```text
+target/forum-search-versioned-invalidation-runtime-promotion-candidate.json
+```
+
+## Why review is separate from assembly
+
+D11 proves that one aggregate file can be assembled only from nine successful
+runtime artifacts generated from the same source commit. It does not establish
+that a maintainer inspected and retained the exact aggregate bytes.
+
+D12 requires an explicit reviewer identity, an immutable retention reference and
+an independently supplied SHA-256 attestation. The reviewer recomputes the
+aggregate digest, requires the supplied retained digest to match it, and records
+both values in a promotion candidate.
+
+The script does not contact or authenticate the external retention service. The
+maintainer is responsible for placing the exact bytes at the stated retention
+reference before invoking D12. That limitation is explicit in the promotion
+candidate rather than hidden behind a successful local check.
+
+## Complete revalidation
+
+Before writing a candidate, the reviewer requires:
+
+1. the D0 parent contract to retain exact identity, pending status, aggregate
+   path and the ten frozen scenarios;
+2. D12 to be registered in the D0 source-ready subproof list;
+3. the aggregate artifact to report `runtime_evidence_assembled`, PostgreSQL,
+   `outbox_iggy`, consumer group `rustok-search-forum-projection-v1`, topic
+   `domain` and the current Git commit;
+4. all ten frozen scenarios to appear exactly once, in canonical order, with
+   `passed`, non-empty facts and the exact D2 through D10 source mapping;
+5. all nine source artifacts to exist and retain exact contract, task, scenario,
+   PostgreSQL and source-commit identity;
+6. every aggregate source-artifact SHA-256 and byte length to match the bytes
+   still present under `target/`;
+7. the aggregate parent-contract digest to match the current D0 source bytes;
+8. every grouped owner-revision, identity, inbox, ingest-sequence, checkpoint,
+   poison, DLQ and storefront fact to equal the attributed source scenario;
+9. the assembly record to retain nine validated inputs, ten frozen scenarios,
+   one source commit, current-HEAD equality and write-after-validation;
+10. the maintainer-supplied retained SHA-256 to equal the exact aggregate digest.
+
+Any failure occurs before promotion-candidate creation or replacement. There is
+no skip, stale-source, mixed-commit, partial-review or canonical-source mutation
+mode.
+
+## Required maintainer attestations
+
+The reviewer accepts no command-line arguments. It requires three bounded
+environment variables:
+
+```text
+RUSTOK_FORUM_EVIDENCE_REVIEWER
+RUSTOK_FORUM_EVIDENCE_RETENTION_REF
+RUSTOK_FORUM_EVIDENCE_RETAINED_SHA256
+```
+
+`RUSTOK_FORUM_EVIDENCE_REVIEWER` identifies the accountable reviewer.
+`RUSTOK_FORUM_EVIDENCE_RETENTION_REF` identifies the immutable retained object.
+`RUSTOK_FORUM_EVIDENCE_RETAINED_SHA256` must be the lowercase SHA-256 digest of
+the exact aggregate JSON bytes.
+
+The reviewer and retention reference reject surrounding whitespace, control
+characters and unbounded lengths. The retained digest must be exactly 64
+lowercase hexadecimal characters.
+
+## Promotion candidate
+
+After complete validation, D12 writes one atomic JSON candidate containing:
+
+- reviewer, review time and exact source commit;
+- retention reference and attested aggregate SHA-256;
+- aggregate path, digest, byte length, generation time and frozen scenarios;
+- current D0 parent path, digest and pending status;
+- all nine source artifact identities and digests;
+- explicit successful validation assertions;
+- the proposed transition from
+  `source_ready_maintainer_execution_pending` to `runtime_evidence_reviewed`;
+- explicit statements that a separate canonical-source pull request is required
+  and that neither `FORUM-23` nor `LINK-FORUM-03` is closed.
+
+The reviewer never edits the D0 contract or the implementation plan. This keeps
+runtime review evidence outside source control until a maintainer deliberately
+opens the separate promotion PR with the candidate and retained artifact
+available for review.
+
+## Maintainer order
+
+On one checked-out commit:
+
+1. run all D2 through D10 verifiers and executable runtime proofs;
+2. run the D11 verifier and aggregate assembler;
+3. retain the exact aggregate bytes in the chosen immutable evidence store;
+4. compute the retained object's SHA-256 independently;
+5. run:
+
+```bash
+node scripts/verify/verify-forum-search-versioned-invalidation-retained-evidence-promotion.mjs
+RUSTOK_FORUM_EVIDENCE_REVIEWER="<reviewer>" \
+RUSTOK_FORUM_EVIDENCE_RETENTION_REF="<immutable-retention-reference>" \
+RUSTOK_FORUM_EVIDENCE_RETAINED_SHA256="<aggregate-sha256>" \
+node scripts/evidence/review-forum-search-versioned-invalidation-runtime-evidence.mjs
+```
+
+Only after the promotion candidate is reviewed should a separate source PR
+update canonical D0 and plan status. That later PR must not claim
+`LINK-FORUM-03` completion unless its separate runtime proof also exists.
+
+## Compatibility
+
+D12 adds scripts, documentation and machine contracts only. It changes no Rust
+production path, migration, event schema or digest, DTO, runtime flag,
+dependency, `Cargo.toml` or `Cargo.lock` entry.
+
+No command above was run by the implementation agent, per maintainer request.

--- a/scripts/evidence/review-forum-search-versioned-invalidation-runtime-evidence.mjs
+++ b/scripts/evidence/review-forum-search-versioned-invalidation-runtime-evidence.mjs
@@ -1,0 +1,533 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const root = process.cwd();
+const parentPath =
+  "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json";
+const contractPath =
+  "crates/rustok-forum/contracts/forum-search-versioned-invalidation-retained-evidence-promotion.json";
+const aggregatePath =
+  "target/forum-search-versioned-invalidation-runtime-evidence.json";
+const candidatePath =
+  "target/forum-search-versioned-invalidation-runtime-promotion-candidate.json";
+const reviewerEnv = "RUSTOK_FORUM_EVIDENCE_REVIEWER";
+const retentionRefEnv = "RUSTOK_FORUM_EVIDENCE_RETENTION_REF";
+const retainedShaEnv = "RUSTOK_FORUM_EVIDENCE_RETAINED_SHA256";
+const canonicalConsumerGroup = "rustok-search-forum-projection-v1";
+const canonicalTopic = "domain";
+
+const frozenScenarios = [
+  "normal_delivery",
+  "legacy_first_duplicate",
+  "typed_first_duplicate",
+  "acknowledgement_failure_restart",
+  "raw_poison_dlq_redelivery",
+  "semantic_poison_identity_conflict",
+  "missing_delivery_owner_repair",
+  "multi_process_serialization",
+  "deletion_acl_ordering",
+  "search_disabled_profile",
+];
+
+const frozenScenarioSources = new Map([
+  ["normal_delivery", ["FORUM-23B2G2B3D10", "normal_delivery"]],
+  ["legacy_first_duplicate", ["FORUM-23B2G2B3D2", "legacy_first_duplicate"]],
+  ["typed_first_duplicate", ["FORUM-23B2G2B3D2", "typed_first_duplicate"]],
+  [
+    "acknowledgement_failure_restart",
+    ["FORUM-23B2G2B3D3", "acknowledgement_failure_restart"],
+  ],
+  ["raw_poison_dlq_redelivery", ["FORUM-23B2G2B3D4", "raw_poison_dlq_redelivery"]],
+  [
+    "semantic_poison_identity_conflict",
+    ["FORUM-23B2G2B3D5", "semantic_poison_identity_conflict"],
+  ],
+  [
+    "missing_delivery_owner_repair",
+    ["FORUM-23B2G2B3D6", "missing_delivery_owner_repair"],
+  ],
+  [
+    "multi_process_serialization",
+    ["FORUM-23B2G2B3D7", "multi_process_serialization"],
+  ],
+  ["deletion_acl_ordering", ["FORUM-23B2G2B3D8", "deletion_acl_ordering"]],
+  ["search_disabled_profile", ["FORUM-23B2G2B3D9", "search_disabled_profile"]],
+]);
+
+const manifest = [
+  {
+    task: "FORUM-23B2G2B3D2",
+    contract: "forum_search_versioned_invalidation_postgres_ingress_evidence_v1",
+    path: "target/forum-search-versioned-invalidation-postgres-ingress-evidence.json",
+    scenarios: [
+      "typed_ingress_admission",
+      "legacy_first_duplicate",
+      "typed_first_duplicate",
+      "semantic_identity_conflict",
+    ],
+  },
+  {
+    task: "FORUM-23B2G2B3D3",
+    contract: "forum_search_versioned_invalidation_ack_restart_evidence_v1",
+    path: "target/forum-search-versioned-invalidation-ack-restart-evidence.json",
+    scenarios: ["acknowledgement_failure_restart"],
+  },
+  {
+    task: "FORUM-23B2G2B3D4",
+    contract: "forum_search_versioned_invalidation_raw_poison_evidence_v1",
+    path: "target/forum-search-versioned-invalidation-raw-poison-evidence.json",
+    scenarios: ["raw_poison_dlq_redelivery"],
+  },
+  {
+    task: "FORUM-23B2G2B3D5",
+    contract: "forum_search_versioned_invalidation_semantic_poison_evidence_v1",
+    path: "target/forum-search-versioned-invalidation-semantic-poison-evidence.json",
+    scenarios: ["semantic_poison_identity_conflict"],
+  },
+  {
+    task: "FORUM-23B2G2B3D6",
+    contract: "forum_search_versioned_invalidation_missing_delivery_repair_evidence_v1",
+    path: "target/forum-search-versioned-invalidation-missing-delivery-repair-evidence.json",
+    scenarios: ["missing_delivery_owner_repair"],
+  },
+  {
+    task: "FORUM-23B2G2B3D7",
+    contract: "forum_search_versioned_invalidation_multi_process_evidence_v1",
+    path: "target/forum-search-versioned-invalidation-multi-process-evidence.json",
+    scenarios: ["multi_process_serialization"],
+  },
+  {
+    task: "FORUM-23B2G2B3D8",
+    contract: "forum_search_versioned_invalidation_deletion_acl_ordering_evidence_v1",
+    path: "target/forum-search-versioned-invalidation-deletion-acl-ordering-evidence.json",
+    scenarios: ["deletion_acl_ordering"],
+  },
+  {
+    task: "FORUM-23B2G2B3D9",
+    contract: "forum_search_versioned_invalidation_search_disabled_recovery_evidence_v1",
+    path: "target/forum-search-versioned-invalidation-search-disabled-recovery-evidence.json",
+    scenarios: ["search_disabled_profile"],
+  },
+  {
+    task: "FORUM-23B2G2B3D10",
+    contract: "forum_search_versioned_invalidation_normal_delivery_evidence_v1",
+    path: "target/forum-search-versioned-invalidation-normal-delivery-evidence.json",
+    scenarios: ["normal_delivery"],
+  },
+];
+
+const groupedFields = [
+  "owner_revision_rows",
+  "typed_and_root_event_ids",
+  "search_inbox_rows",
+  "ingest_sequences",
+  "owner_checkpoints",
+  "poison_receipts",
+  "dlq_receipts",
+  "storefront_visibility_assertions",
+];
+
+function fail(message) {
+  throw new Error(`Forum Search retained evidence review failed: ${message}`);
+}
+
+function readBytes(path) {
+  try {
+    return readFileSync(resolve(root, path));
+  } catch (error) {
+    fail(`cannot read ${path}: ${error.message}`);
+  }
+}
+
+function parseJson(path, bytes) {
+  try {
+    return JSON.parse(bytes.toString("utf8"));
+  } catch (error) {
+    fail(`${path} is not valid JSON: ${error.message}`);
+  }
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+}
+
+function requireFacts(value, label) {
+  requireObject(value, label);
+  if (Object.keys(value).length === 0) {
+    fail(`${label} must not be empty`);
+  }
+}
+
+function requireCommit(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{40}$/.test(value)) {
+    fail(`${label} must be one lowercase forty-character Git commit SHA`);
+  }
+}
+
+function requireTimestamp(value, label) {
+  if (typeof value !== "string" || !Number.isFinite(Date.parse(value))) {
+    fail(`${label} must be an ISO timestamp`);
+  }
+}
+
+function boundedEnv(name, minimum, maximum) {
+  const value = process.env[name];
+  if (typeof value !== "string") {
+    fail(`${name} must be set`);
+  }
+  if (value.trim() !== value || value.length < minimum || value.length > maximum) {
+    fail(`${name} must contain ${minimum}..${maximum} characters without surrounding whitespace`);
+  }
+  if (value.split("").some((character) => /[\u0000-\u001f\u007f]/.test(character))) {
+    fail(`${name} must not contain control characters`);
+  }
+  return value;
+}
+
+function currentHead() {
+  let value;
+  try {
+    value = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (error) {
+    fail(`git rev-parse HEAD failed: ${error.message}`);
+  }
+  requireCommit(value, "git rev-parse HEAD");
+  return value;
+}
+
+function exactArray(actual, expected, label) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    fail(`${label} order or membership drifted`);
+  }
+}
+
+function validateParent(parent, aggregatePathValue) {
+  requireObject(parent, "D0 parent contract");
+  if (parent.contract !== "forum_search_versioned_invalidation_runtime_evidence_v1") {
+    fail("D0 parent contract identity drifted");
+  }
+  if (parent.task !== "FORUM-23B2G2B3D0") {
+    fail("D0 parent task identity drifted");
+  }
+  if (parent.status !== "source_ready_maintainer_execution_pending") {
+    fail("D0 parent must remain pending before a promotion candidate is created");
+  }
+  exactArray(
+    parent.required_scenarios?.map(({ id }) => id),
+    frozenScenarios,
+    "D0 frozen scenarios",
+  );
+  if (parent.evidence_artifact?.path !== aggregatePathValue) {
+    fail("D0 aggregate evidence path drifted");
+  }
+  const d12 = (parent.source_ready_subproofs ?? []).find(
+    ({ task }) => task === "FORUM-23B2G2B3D12",
+  );
+  if (!d12 || d12.contract !== contractPath || d12.reviewer !== import.meta.filename?.replace(`${root}/`, "")) {
+    fail("D0 does not register the exact D12 retained-evidence reviewer");
+  }
+}
+
+function validateSourceArtifact(entry, head) {
+  const bytes = readBytes(entry.path);
+  const artifact = parseJson(entry.path, bytes);
+  requireObject(artifact, entry.path);
+  if (artifact.contract !== entry.contract || artifact.task !== entry.task) {
+    fail(`${entry.path} contract or task identity drifted`);
+  }
+  if (artifact.source_commit !== head) {
+    fail(`${entry.path} source_commit does not equal current HEAD`);
+  }
+  requireTimestamp(artifact.generated_at, `${entry.path}.generated_at`);
+  if (artifact.database_backend !== "postgresql") {
+    fail(`${entry.path} must report PostgreSQL`);
+  }
+  if (!Array.isArray(artifact.scenario_results)) {
+    fail(`${entry.path}.scenario_results must be an array`);
+  }
+  exactArray(
+    artifact.scenario_results.map(({ id }) => id),
+    entry.scenarios,
+    `${entry.path} scenarios`,
+  );
+  const scenarios = new Map();
+  for (const scenario of artifact.scenario_results) {
+    requireObject(scenario, `${entry.path} scenario`);
+    if (scenario.result !== "passed") {
+      fail(`${entry.path} scenario ${scenario.id} did not pass`);
+    }
+    requireFacts(scenario.facts, `${entry.path} scenario ${scenario.id} facts`);
+    if (scenarios.has(scenario.id)) {
+      fail(`${entry.path} repeats scenario ${scenario.id}`);
+    }
+    scenarios.set(scenario.id, scenario);
+  }
+  return {
+    entry,
+    artifact,
+    scenarios,
+    bytes,
+    digest: sha256(bytes),
+  };
+}
+
+function validateGroupedEvidence(aggregate, sourceByTask) {
+  const allowed = new Set(manifest.map(({ task, path }) => `${task}\u0000${path}`));
+  for (const field of groupedFields) {
+    const values = aggregate[field];
+    if (!Array.isArray(values) || values.length === 0) {
+      fail(`aggregate ${field} must be a non-empty array`);
+    }
+    for (const value of values) {
+      requireObject(value, `aggregate ${field} entry`);
+      const source = sourceByTask.get(value.source_task);
+      if (!source || !allowed.has(`${value.source_task}\u0000${value.source_artifact}`)) {
+        fail(`aggregate ${field} contains an unregistered source artifact`);
+      }
+      if (value.source_contract !== source.entry.contract) {
+        fail(`aggregate ${field} source contract drifted`);
+      }
+      const scenario = source.scenarios.get(value.source_scenario_id);
+      if (!scenario) {
+        fail(`aggregate ${field} references an absent source scenario`);
+      }
+      requireFacts(value.facts, `aggregate ${field} retained facts`);
+      if (JSON.stringify(value.facts) !== JSON.stringify(scenario.facts)) {
+        fail(`aggregate ${field} facts differ from the retained source artifact`);
+      }
+    }
+  }
+}
+
+function validateAggregate(aggregate, aggregateBytes, parentBytes, head, sources) {
+  requireObject(aggregate, "aggregate D0 artifact");
+  if (
+    aggregate.contract !== "forum_search_versioned_invalidation_runtime_evidence_v1" ||
+    aggregate.task !== "FORUM-23B2G2B3D0" ||
+    aggregate.status !== "runtime_evidence_assembled"
+  ) {
+    fail("aggregate D0 identity or assembled status drifted");
+  }
+  if (aggregate.source_commit !== head) {
+    fail("aggregate source_commit does not equal current HEAD");
+  }
+  requireTimestamp(aggregate.generated_at, "aggregate.generated_at");
+  if (
+    aggregate.database_backend !== "postgresql" ||
+    aggregate.delivery_profile !== "outbox_iggy" ||
+    aggregate.consumer_group !== canonicalConsumerGroup ||
+    aggregate.topic !== canonicalTopic
+  ) {
+    fail("aggregate runtime profile drifted");
+  }
+  if (!Array.isArray(aggregate.scenario_results)) {
+    fail("aggregate scenario_results must be an array");
+  }
+  exactArray(
+    aggregate.scenario_results.map(({ id }) => id),
+    frozenScenarios,
+    "aggregate frozen scenarios",
+  );
+  for (const scenario of aggregate.scenario_results) {
+    requireObject(scenario, `aggregate scenario ${scenario.id}`);
+    if (scenario.result !== "passed") {
+      fail(`aggregate scenario ${scenario.id} did not pass`);
+    }
+    const expectedSource = frozenScenarioSources.get(scenario.id);
+    if (
+      !expectedSource ||
+      scenario.source_task !== expectedSource[0] ||
+      scenario.source_scenario_id !== expectedSource[1]
+    ) {
+      fail(`aggregate scenario ${scenario.id} source attribution drifted`);
+    }
+    requireFacts(scenario.facts, `aggregate scenario ${scenario.id} facts`);
+  }
+
+  requireObject(aggregate.assembly, "aggregate assembly record");
+  if (
+    aggregate.assembly.parent_contract !== parentPath ||
+    aggregate.assembly.parent_contract_sha256 !== sha256(parentBytes) ||
+    aggregate.assembly.input_artifact_count !== manifest.length ||
+    aggregate.assembly.frozen_scenario_count !== frozenScenarios.length ||
+    aggregate.assembly.all_inputs_same_source_commit !== true ||
+    aggregate.assembly.source_commit_matches_current_head !== true ||
+    aggregate.assembly.output_written_after_complete_validation !== true
+  ) {
+    fail("aggregate assembly record is incomplete or stale");
+  }
+
+  if (!Array.isArray(aggregate.source_artifacts)) {
+    fail("aggregate source_artifacts must be an array");
+  }
+  exactArray(
+    aggregate.source_artifacts.map(({ task }) => task),
+    manifest.map(({ task }) => task),
+    "aggregate source artifacts",
+  );
+  const sourceByTask = new Map(sources.map((source) => [source.entry.task, source]));
+  for (const retained of aggregate.source_artifacts) {
+    const source = sourceByTask.get(retained.task);
+    if (!source) {
+      fail(`aggregate retains unknown source task ${retained.task}`);
+    }
+    if (
+      retained.contract !== source.entry.contract ||
+      retained.path !== source.entry.path ||
+      retained.source_commit !== head ||
+      retained.generated_at !== source.artifact.generated_at ||
+      retained.sha256 !== source.digest ||
+      retained.byte_length !== source.bytes.length
+    ) {
+      fail(`aggregate retained metadata drifted for ${retained.task}`);
+    }
+    exactArray(retained.scenario_ids, source.entry.scenarios, `${retained.task} retained scenarios`);
+  }
+
+  for (const scenario of aggregate.scenario_results) {
+    const source = sourceByTask.get(scenario.source_task);
+    const retainedScenario = source?.scenarios.get(scenario.source_scenario_id);
+    if (!retainedScenario || JSON.stringify(scenario.facts) !== JSON.stringify(retainedScenario.facts)) {
+      fail(`aggregate scenario ${scenario.id} facts differ from retained source evidence`);
+    }
+  }
+  validateGroupedEvidence(aggregate, sourceByTask);
+
+  if (!Array.isArray(aggregate.supporting_scenario_results) || aggregate.supporting_scenario_results.length === 0) {
+    fail("aggregate supporting_scenario_results must retain D2 supporting facts");
+  }
+  validateGroupedEvidence(
+    { ...aggregate, ...Object.fromEntries(groupedFields.map((field) => [field, aggregate[field]])) },
+    sourceByTask,
+  );
+  return sha256(aggregateBytes);
+}
+
+if (process.argv.length !== 2) {
+  fail("this reviewer accepts no command-line arguments");
+}
+
+const reviewer = boundedEnv(reviewerEnv, 3, 128);
+const retentionReference = boundedEnv(retentionRefEnv, 8, 2048);
+const retainedSha = boundedEnv(retainedShaEnv, 64, 64);
+if (!/^[0-9a-f]{64}$/.test(retainedSha)) {
+  fail(`${retainedShaEnv} must be one lowercase SHA-256 digest`);
+}
+
+const head = currentHead();
+const contractBytes = readBytes(contractPath);
+const contract = parseJson(contractPath, contractBytes);
+if (
+  contract.contract !== "forum_search_versioned_invalidation_retained_evidence_promotion_v1" ||
+  contract.task !== "FORUM-23B2G2B3D12" ||
+  contract.status !== "source_ready_maintainer_execution_pending"
+) {
+  fail("D12 machine contract identity or status drifted");
+}
+
+const parentBytes = readBytes(parentPath);
+const parent = parseJson(parentPath, parentBytes);
+validateParent(parent, aggregatePath);
+
+const sources = manifest.map((entry) => validateSourceArtifact(entry, head));
+const aggregateBytes = readBytes(aggregatePath);
+const aggregate = parseJson(aggregatePath, aggregateBytes);
+const aggregateDigest = validateAggregate(
+  aggregate,
+  aggregateBytes,
+  parentBytes,
+  head,
+  sources,
+);
+if (retainedSha !== aggregateDigest) {
+  fail(`${retainedShaEnv} does not equal the exact aggregate artifact digest`);
+}
+
+const candidate = {
+  contract: "forum_search_versioned_invalidation_runtime_promotion_candidate_v1",
+  task: "FORUM-23B2G2B3D12",
+  status: "approved_for_canonical_status_promotion",
+  source_commit: head,
+  reviewed_at: new Date().toISOString(),
+  reviewer,
+  retention: {
+    reference: retentionReference,
+    attested_sha256: retainedSha,
+    matches_reviewed_aggregate: true,
+    external_service_authentication_performed_by_script: false,
+  },
+  aggregate_artifact: {
+    path: aggregatePath,
+    sha256: aggregateDigest,
+    byte_length: aggregateBytes.length,
+    generated_at: aggregate.generated_at,
+    scenario_ids: frozenScenarios,
+  },
+  parent_contract: {
+    path: parentPath,
+    sha256: sha256(parentBytes),
+    status_at_review: parent.status,
+  },
+  source_artifacts: sources.map(({ entry, artifact, digest, bytes }) => ({
+    task: entry.task,
+    contract: entry.contract,
+    path: entry.path,
+    source_commit: artifact.source_commit,
+    generated_at: artifact.generated_at,
+    sha256: digest,
+    byte_length: bytes.length,
+    scenario_ids: entry.scenarios,
+  })),
+  validation: {
+    all_ten_frozen_scenarios_passed: true,
+    all_nine_source_artifacts_revalidated: true,
+    all_source_digests_match_aggregate: true,
+    aggregate_parent_digest_matches_current_d0: true,
+    aggregate_source_commit_matches_current_head: true,
+    retained_digest_attested_by_maintainer: true,
+  },
+  proposed_transition: {
+    from: "source_ready_maintainer_execution_pending",
+    to: "runtime_evidence_reviewed",
+    separate_canonical_source_pull_request_required: true,
+    canonical_source_mutated_by_reviewer: false,
+    closes_forum_23: false,
+    closes_link_forum_03: false,
+  },
+};
+
+const absoluteCandidate = resolve(root, candidatePath);
+mkdirSync(dirname(absoluteCandidate), { recursive: true });
+const temporaryCandidate = `${absoluteCandidate}.${process.pid}.${Date.now()}.tmp`;
+try {
+  writeFileSync(temporaryCandidate, `${JSON.stringify(candidate, null, 2)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+  });
+  renameSync(temporaryCandidate, absoluteCandidate);
+} catch (error) {
+  rmSync(temporaryCandidate, { force: true });
+  fail(`atomic promotion-candidate write failed: ${error.message}`);
+}
+
+console.log(`wrote reviewed Forum Search promotion candidate to ${candidatePath}`);

--- a/scripts/verify/verify-forum-search-versioned-invalidation-retained-evidence-promotion.mjs
+++ b/scripts/verify/verify-forum-search-versioned-invalidation-retained-evidence-promotion.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = process.cwd();
+const read = (path) => readFileSync(resolve(root, path), "utf8");
+const requireAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(text.includes(marker), `${label} is missing required marker: ${marker}`);
+  }
+};
+const forbidAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(!text.includes(marker), `${label} contains forbidden marker: ${marker}`);
+  }
+};
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-search-versioned-invalidation-retained-evidence-promotion.json";
+const parentPath =
+  "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json";
+const reviewerPath =
+  "scripts/evidence/review-forum-search-versioned-invalidation-runtime-evidence.mjs";
+const verifierPath =
+  "scripts/verify/verify-forum-search-versioned-invalidation-retained-evidence-promotion.mjs";
+const docPath =
+  "crates/rustok-forum/docs/forum-23b2g2b3d12-retained-evidence-promotion.md";
+const d11DocPath =
+  "crates/rustok-forum/docs/forum-23b2g2b3d11-aggregate-evidence-assembler.md";
+const planPath = "crates/rustok-forum/docs/implementation-plan.md";
+const aggregatePath =
+  "target/forum-search-versioned-invalidation-runtime-evidence.json";
+const candidatePath =
+  "target/forum-search-versioned-invalidation-runtime-promotion-candidate.json";
+
+const frozenScenarios = [
+  "normal_delivery",
+  "legacy_first_duplicate",
+  "typed_first_duplicate",
+  "acknowledgement_failure_restart",
+  "raw_poison_dlq_redelivery",
+  "semantic_poison_identity_conflict",
+  "missing_delivery_owner_repair",
+  "multi_process_serialization",
+  "deletion_acl_ordering",
+  "search_disabled_profile",
+];
+const sourceTasks = [
+  "FORUM-23B2G2B3D2",
+  "FORUM-23B2G2B3D3",
+  "FORUM-23B2G2B3D4",
+  "FORUM-23B2G2B3D5",
+  "FORUM-23B2G2B3D6",
+  "FORUM-23B2G2B3D7",
+  "FORUM-23B2G2B3D8",
+  "FORUM-23B2G2B3D9",
+  "FORUM-23B2G2B3D10",
+];
+const sourceArtifacts = [
+  "target/forum-search-versioned-invalidation-postgres-ingress-evidence.json",
+  "target/forum-search-versioned-invalidation-ack-restart-evidence.json",
+  "target/forum-search-versioned-invalidation-raw-poison-evidence.json",
+  "target/forum-search-versioned-invalidation-semantic-poison-evidence.json",
+  "target/forum-search-versioned-invalidation-missing-delivery-repair-evidence.json",
+  "target/forum-search-versioned-invalidation-multi-process-evidence.json",
+  "target/forum-search-versioned-invalidation-deletion-acl-ordering-evidence.json",
+  "target/forum-search-versioned-invalidation-search-disabled-recovery-evidence.json",
+  "target/forum-search-versioned-invalidation-normal-delivery-evidence.json",
+];
+
+const contract = JSON.parse(read(contractPath));
+assert.equal(
+  contract.contract,
+  "forum_search_versioned_invalidation_retained_evidence_promotion_v1",
+);
+assert.equal(contract.task, "FORUM-23B2G2B3D12");
+assert.equal(contract.status, "source_ready_maintainer_execution_pending");
+assert.equal(contract.runtime_evidence_parent, parentPath);
+assert.equal(contract.aggregate_artifact, aggregatePath);
+assert.equal(contract.reviewer, reviewerPath);
+assert.equal(contract.verifier, verifierPath);
+assert.equal(contract.promotion_candidate.path, candidatePath);
+assert.equal(
+  contract.promotion_candidate.generation,
+  "reviewer_only_after_retained_aggregate_validation",
+);
+assert.equal(contract.promotion_candidate.hand_editing_forbidden, true);
+assert.equal(contract.promotion_candidate.source_commit_required, true);
+assert.equal(contract.promotion_candidate.atomic_replace, true);
+assert.equal(contract.promotion_candidate.automatic_canonical_source_mutation, false);
+assert.deepEqual(contract.required_attestations, [
+  "RUSTOK_FORUM_EVIDENCE_REVIEWER",
+  "RUSTOK_FORUM_EVIDENCE_RETENTION_REF",
+  "RUSTOK_FORUM_EVIDENCE_RETAINED_SHA256",
+]);
+assert.ok(contract.fail_closed_requirements.length >= 11);
+assert.deepEqual(contract.proposed_transition, {
+  from: "source_ready_maintainer_execution_pending",
+  to: "runtime_evidence_reviewed",
+  requires_separate_canonical_source_pull_request: true,
+  closes_forum_23: false,
+  closes_link_forum_03: false,
+});
+assert.ok(contract.maintainer_command.includes(reviewerPath));
+assert.ok(contract.non_claims.some((claim) => claim.includes("does not automatically edit")));
+
+const parent = JSON.parse(read(parentPath));
+assert.equal(parent.contract, "forum_search_versioned_invalidation_runtime_evidence_v1");
+assert.equal(parent.task, "FORUM-23B2G2B3D0");
+assert.equal(parent.status, "source_ready_maintainer_execution_pending");
+assert.deepEqual(
+  parent.required_scenarios.map(({ id }) => id),
+  frozenScenarios,
+);
+const d12 = parent.source_ready_subproofs.find(
+  ({ task }) => task === "FORUM-23B2G2B3D12",
+);
+assert.ok(d12, "D0 must register FORUM-23B2G2B3D12");
+assert.equal(d12.contract, contractPath);
+assert.equal(d12.reviewer, reviewerPath);
+assert.equal(d12.promotion_candidate, candidatePath);
+assert.ok(d12.covers.includes("retained_aggregate_digest_attestation"));
+assert.ok(d12.covers.includes("promotion_candidate_without_source_mutation"));
+assert.ok(d12.does_not_cover.includes("canonical_d0_status_promotion"));
+assert.ok(d12.does_not_cover.includes("link_forum_03"));
+for (const command of [`node ${verifierPath}`, contract.maintainer_command]) {
+  assert.ok(parent.maintainer_commands.includes(command));
+}
+
+const reviewer = read(reviewerPath);
+requireAll(
+  reviewer,
+  [
+    "execFileSync(\"git\", [\"rev-parse\", \"HEAD\"]",
+    "createHash(\"sha256\")",
+    "RUSTOK_FORUM_EVIDENCE_REVIEWER",
+    "RUSTOK_FORUM_EVIDENCE_RETENTION_REF",
+    "RUSTOK_FORUM_EVIDENCE_RETAINED_SHA256",
+    "source_ready_maintainer_execution_pending",
+    "runtime_evidence_assembled",
+    "approved_for_canonical_status_promotion",
+    "runtime_evidence_reviewed",
+    "aggregate.assembly.parent_contract_sha256 !== sha256(parentBytes)",
+    "aggregate.assembly.input_artifact_count !== manifest.length",
+    "aggregate.assembly.frozen_scenario_count !== frozenScenarios.length",
+    "aggregate.assembly.all_inputs_same_source_commit !== true",
+    "aggregate.assembly.source_commit_matches_current_head !== true",
+    "aggregate.assembly.output_written_after_complete_validation !== true",
+    "retained.sha256 !== source.digest",
+    "retained.byte_length !== source.bytes.length",
+    "JSON.stringify(scenario.facts) !== JSON.stringify(retainedScenario.facts)",
+    "JSON.stringify(value.facts) !== JSON.stringify(scenario.facts)",
+    "retainedSha !== aggregateDigest",
+    "all_ten_frozen_scenarios_passed: true",
+    "all_nine_source_artifacts_revalidated: true",
+    "all_source_digests_match_aggregate: true",
+    "aggregate_parent_digest_matches_current_d0: true",
+    "retained_digest_attested_by_maintainer: true",
+    "separate_canonical_source_pull_request_required: true",
+    "canonical_source_mutated_by_reviewer: false",
+    "external_service_authentication_performed_by_script: false",
+    "writeFileSync(temporaryCandidate",
+    "renameSync(temporaryCandidate, absoluteCandidate)",
+    "rmSync(temporaryCandidate, { force: true })",
+    "if (process.argv.length !== 2)",
+    candidatePath,
+  ],
+  "retained evidence reviewer",
+);
+for (const scenario of frozenScenarios) {
+  assert.ok(reviewer.includes(`\"${scenario}\"`), `reviewer is missing ${scenario}`);
+}
+for (const task of sourceTasks) {
+  assert.ok(reviewer.includes(`\"${task}\"`), `reviewer is missing ${task}`);
+}
+for (const path of sourceArtifacts) {
+  assert.ok(reviewer.includes(path), `reviewer is missing ${path}`);
+}
+for (const field of [
+  "owner_revision_rows",
+  "typed_and_root_event_ids",
+  "search_inbox_rows",
+  "ingest_sequences",
+  "owner_checkpoints",
+  "poison_receipts",
+  "dlq_receipts",
+  "storefront_visibility_assertions",
+]) {
+  assert.ok(reviewer.includes(`\"${field}\"`), `reviewer is missing grouped field ${field}`);
+}
+forbidAll(
+  reviewer,
+  [
+    "fetch(",
+    "axios",
+    "node:http",
+    "node:https",
+    "process.argv[2]",
+    "--source-commit",
+    "allowMissing",
+    "bestEffort",
+    "continueOnError",
+    "result: \"skipped\"",
+    "writeFileSync(parentPath",
+    "writeFileSync(planPath",
+    "renameSync(temporaryCandidate, resolve(root, parentPath))",
+    "canonical_source_mutated_by_reviewer: true",
+    "closes_forum_23: true",
+    "closes_link_forum_03: true",
+  ],
+  "retained evidence reviewer",
+);
+
+const doc = read(docPath);
+requireAll(
+  doc,
+  [
+    "`source_ready_maintainer_execution_pending`",
+    "FORUM-23B2G2B3D12",
+    contractPath,
+    reviewerPath,
+    verifierPath,
+    aggregatePath,
+    candidatePath,
+    "all nine source artifacts",
+    "all ten frozen scenarios",
+    "immutable retention reference",
+    "independently supplied SHA-256",
+    "does not contact or authenticate the external retention service",
+    "separate source PR",
+    "No command above was run by the implementation agent",
+  ],
+  "retained evidence promotion handoff",
+);
+
+const d11Doc = read(d11DocPath);
+requireAll(
+  d11Doc,
+  [
+    "A later retention/review step may inspect the generated aggregate artifact",
+    "only then decide whether the canonical D0 status can be promoted",
+  ],
+  "D11 handoff to retained review",
+);
+
+const plan = read(planPath);
+const forum23Start = plan.indexOf("## `FORUM-23` — search/index integration");
+const forum24Start = plan.indexOf("## `FORUM-24` — localized routes", forum23Start);
+assert.ok(forum23Start >= 0 && forum24Start > forum23Start);
+const forum23 = plan.slice(forum23Start, forum24Start);
+requireAll(
+  forum23,
+  [
+    "**Status:** `in_progress`",
+    "FORUM-23B2G2B3D0",
+    "source_ready_maintainer_execution_pending",
+    "`LINK-FORUM-03` cross-module runtime proof",
+  ],
+  "FORUM-23 canonical pending boundary",
+);
+forbidAll(
+  forum23,
+  [
+    "runtime_evidence_reviewed",
+    "FORUM-23 is complete",
+    "LINK-FORUM-03 is complete",
+  ],
+  "FORUM-23 canonical pending boundary",
+);
+
+console.log(
+  "Forum Search retained aggregate review and promotion-candidate gate is fail-closed and source-ready.",
+);


### PR DESCRIPTION
## What changed

- add `FORUM-23B2G2B3D12`, the retained aggregate review and promotion-candidate gate after D11;
- require exact D0 identity, pending status, parent digest and ten frozen scenario order;
- re-read all nine D2-D10 runtime artifacts and require exact task, contract, source commit, PostgreSQL profile, scenario membership, passed results and non-empty facts;
- require aggregate source-artifact SHA-256 and byte lengths to equal the bytes still present under `target/`;
- require frozen scenario and grouped D0 facts to equal their attributed source scenarios;
- require the aggregate assembly record to retain nine inputs, ten scenarios, one source commit, current-HEAD equality and write-after-validation;
- require explicit bounded reviewer, immutable retention reference and retained SHA-256 attestations;
- require the supplied retained digest to equal the exact aggregate JSON digest;
- write only an atomic `runtime_promotion_candidate_v1` record proposing `source_ready_maintainer_execution_pending -> runtime_evidence_reviewed`;
- require a separate canonical-source PR and explicitly leave `FORUM-23` and `LINK-FORUM-03` open;
- register D12 and its two maintainer commands in D0.

## Deliberate boundary

This PR does not execute D2-D10 or D11, authenticate an external retention service, generate runtime evidence, promote canonical D0 source, or close `FORUM-23`/`LINK-FORUM-03`.

## Compatibility

No production Rust path, migration, event schema/digest, DTO, runtime flag, dependency, `Cargo.toml`, or `Cargo.lock` changes. The D0 JSON is semantically extended only by D12 registration and commands; its textual diff is larger because existing arrays were compacted.

## Validation

Tests, Node verifiers, reviewer execution, formatting, Cargo checks, workflows, CI, PostgreSQL and Iggy execution were intentionally not run, per maintainer request.