### PR TITLE
fix(fulfillment): bound storefront GraphQL diagnostics

### DIFF
--- a/crates/rustok-fulfillment/contracts/evidence/storefront-graphql-error-safety-source-review.json
+++ b/crates/rustok-fulfillment/contracts/evidence/storefront-graphql-error-safety-source-review.json
@@ -1,45 +1,55 @@
 {
   "schema_version": 1,
-  "reviewed_at": "2026-07-30",
+  "reviewed_at": "2026-08-01",
   "status": "fulfillment_storefront_graphql_error_safety_source_reviewed_unvalidated",
-  "base_main_sha": "83e3f7254bc30d46142c09259f80dc23d6aad0c4",
-  "scope": "fulfillment storefront shipping-selection GraphQL error boundary",
+  "base_main_sha": "2e24ce69682b2c303267994df948c5049145fa45",
+  "scope": "fulfillment storefront shipping-selection GraphQL public and diagnostic boundary",
   "reviewed_files": [
     "crates/rustok-commerce/docs/implementation-plan.md",
     "crates/rustok-fulfillment/storefront/Cargo.toml",
     "crates/rustok-fulfillment/storefront/src/transport.rs",
     "crates/rustok-fulfillment/storefront/src/transport/graphql_adapter.rs",
+    "crates/rustok-fulfillment/storefront/src/transport/graphql_error_safety.rs",
     "crates/rustok-fulfillment/storefront/src/transport/native_server_adapter/server_functions.rs",
+    "crates/rustok-fulfillment/contracts/evidence/storefront-graphql-error-safety-source.json",
+    "crates/rustok-fulfillment/docs/storefront-graphql-error-safety.md",
+    "scripts/verify/verify-fulfillment-storefront-graphql-error-safety.mjs",
     "crates/rustok-graphql/src/lib.rs",
-    "crates/rustok-ui-transport/src/lib.rs",
-    "scripts/verify/verify-fulfillment-storefront-boundary.mjs"
+    "crates/rustok-ui-transport/src/lib.rs"
   ],
   "findings": [
     {
-      "id": "fulfillment-storefront-graphql-raw-public-envelope",
-      "severity": "public_error_safety",
-      "finding": "The private GraphQL adapter converted GraphqlHttpError into ShippingSelectionTransportError::Graphql(error.to_string()), and the public facade passed that value directly into UiTransportError.graphql_error. GraphQL resolver text and HTTP detail could therefore reach the storefront caller."
+      "id": "fulfillment-storefront-graphql-static-public-envelope-preserved",
+      "severity": "preservation",
+      "finding": "The public facade already maps network, HTTP, unauthorized, GraphQL rejection, and unknown handoff failures to static transport-owned messages."
+    },
+    {
+      "id": "fulfillment-storefront-graphql-raw-diagnostic-payload",
+      "severity": "diagnostic_safety",
+      "finding": "The safety mapper still copied the complete private GraphQL display handoff and Debug representation of the parsed typed error into structured events. Those payloads were unnecessary for correlation or closed classification."
     },
     {
       "id": "fulfillment-storefront-native-already-sanitized",
       "severity": "context",
-      "finding": "The native server-function path already retains internal diagnostics and static public messages under fulfillment_storefront_native_transport, so this slice is limited to the GraphQL path."
+      "finding": "The native server-function path remains separate and unchanged under fulfillment_storefront_native_transport."
     },
     {
       "id": "fulfillment-storefront-explicit-transport-selection",
       "severity": "preservation",
-      "finding": "The facade intentionally selects one transport by feature profile and does not perform native-to-GraphQL fallback; that behavior must remain unchanged."
+      "finding": "The facade intentionally selects one transport by feature profile and does not perform native-to-GraphQL fallback; that behavior remains unchanged."
     },
     {
       "id": "fulfillment-storefront-validation-pass-through",
       "severity": "preservation",
-      "finding": "Local shipping-selection validation errors are user-actionable and are not GraphqlHttpError envelopes, so they remain unchanged."
+      "finding": "Local shipping-selection validation errors remain user-actionable non-GraphQL failures and pass through unchanged."
     }
   ],
   "implementation_review": {
     "typed_graphql_variant_policy": true,
     "static_public_graphql_messages": true,
-    "raw_graphql_detail_internal_only": true,
+    "raw_graphql_detail_logging_removed": true,
+    "parsed_graphql_error_debug_logging_removed": true,
+    "bounded_graphql_error_shape_retained": true,
     "per_call_correlation_id": true,
     "safe_shape_only_request_facts": true,
     "native_path_changed": false,
@@ -47,7 +57,8 @@
     "graphql_adapter_changed": false,
     "graphql_document_changed": false,
     "transport_selection_changed": false,
-    "request_response_dto_changed": false
+    "request_response_dto_changed": false,
+    "runtime_evidence_claimed": false
   },
   "execution": {
     "commands_run": [],
@@ -58,7 +69,8 @@
   },
   "remaining_scope": [
     "remaining ecommerce storefront and admin GraphQL adapters",
-    "remaining customer and non-PortError public envelopes",
+    "remaining non-PortError public and diagnostic envelopes",
+    "fulfillment checkout execution owner diagnostics",
     "browser and mounted GraphQL runtime evidence",
     "broad ecommerce correlation-safe mapper cleanup"
   ]

--- a/crates/rustok-fulfillment/contracts/evidence/storefront-graphql-error-safety-source.json
+++ b/crates/rustok-fulfillment/contracts/evidence/storefront-graphql-error-safety-source.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-30",
+  "generated_at": "2026-08-01",
   "status": "fulfillment_storefront_graphql_error_safety_source_unvalidated",
   "scope": "fulfillment-owned storefront GraphQL shipping-selection transport",
   "owner": "rustok_fulfillment.storefront",
@@ -13,14 +13,19 @@
     "typed_graphql_error_policy": true,
     "per_call_correlation_id": true,
     "safe_request_shape_logging": true,
-    "raw_graphql_detail_internal_only": true,
+    "raw_graphql_detail_logged": false,
+    "parsed_graphql_error_debug_logged": false,
+    "raw_graphql_detail_shape_logged": true,
+    "typed_parse_validity_logged": true,
+    "closed_graphql_error_category_logged": true,
     "validation_variant_changed": false,
     "native_variant_changed": false,
     "transport_selection_changed": false,
     "graphql_document_changed": false,
     "request_response_dto_changed": false,
     "native_server_functions_changed": false,
-    "raw_graphql_detail_public": false
+    "raw_graphql_detail_public": false,
+    "broad_ecommerce_cleanup_closed": false
   },
   "stable_public_messages": {
     "network_or_http": "Shipping selection is temporarily unavailable",
@@ -28,8 +33,12 @@
     "graphql_rejection_or_unknown": "Shipping selection request could not be completed"
   },
   "internal_diagnostics": {
-    "raw_graphql_error": true,
-    "parsed_graphql_error": true,
+    "raw_graphql_error": false,
+    "parsed_graphql_error_debug": false,
+    "raw_graphql_error_present": true,
+    "raw_graphql_error_length": true,
+    "parsed_graphql_error_valid": true,
+    "closed_graphql_error_category": true,
     "owner_operation": true,
     "correlation_id": true,
     "tenant_slug_value": false,

--- a/crates/rustok-fulfillment/docs/storefront-graphql-error-safety.md
+++ b/crates/rustok-fulfillment/docs/storefront-graphql-error-safety.md
@@ -73,8 +73,8 @@ Internal events retain only:
 - seller-id presence;
 - shipping-option-id presence.
 
-Raw GraphQL display text is not written to the event. Debug output from the parsed typed
-error is not written to the event.
+Raw GraphQL display text is not written to the event.
+Debug output from the parsed typed error is not written to the event.
 
 The events also do not retain:
 

--- a/crates/rustok-fulfillment/docs/storefront-graphql-error-safety.md
+++ b/crates/rustok-fulfillment/docs/storefront-graphql-error-safety.md
@@ -4,30 +4,38 @@ Status: **source-ready / unvalidated**
 
 ## Scope
 
-This slice closes the public GraphQL error boundary for the fulfillment-owned storefront shipping-selection operation:
+This slice closes both the public and private diagnostic GraphQL error boundary for
+the fulfillment-owned storefront shipping-selection operation:
 
 - `select_storefront_shipping_option`;
 - public facade `rustok_fulfillment_storefront::transport::select_shipping_option`;
 - selected GraphQL transport path;
 - boundary `fulfillment_storefront_graphql_transport`.
 
-The private GraphQL adapter, native server functions, shipping-selection DTOs, selection planning, GraphQL document, feature-based transport selection, and Commerce compatibility delegation remain unchanged.
+The private GraphQL adapter, native server functions, shipping-selection DTOs,
+selection planning, GraphQL document, feature-based transport selection, and Commerce
+compatibility delegation remain unchanged.
 
-## Problem
+## Rechecked gap
 
-The private GraphQL adapter intentionally converted `GraphqlHttpError` into the transport-owned variant:
+The public transport facade already reparsed the private GraphQL display handoff through
+`GraphqlHttpError` and returned static transport-owned messages. The source therefore
+prevented resolver and HTTP detail from reaching the storefront caller.
 
-```text
-ShippingSelectionTransportError::Graphql(error.to_string())
-```
+The structured event still copied two complete private values:
 
-Before this slice, the public transport facade delegated that variant directly to `execute_selected_transport`. `UiTransportError::graphql` stores the delegated display string in its public `graphql_error` field, so resolver messages and HTTP detail could reach the storefront caller.
+- `raw_error = %raw_error`;
+- `parsed_error = ?parsed_error`.
 
-This is a non-`PortError` public-envelope gap in the ecommerce correlation-safe mapper cleanup.
+That display text and Debug representation were not required to correlate the call or
+distinguish the five closed transport categories. This was a remaining non-`PortError`
+diagnostic-envelope gap in the ecommerce correlation-safe mapper cleanup.
 
 ## Boundary policy
 
-The public facade now creates a `GraphqlCallContext` before invoking the private adapter. Only `ShippingSelectionTransportError::Graphql` is classified. Other variants are returned unchanged.
+The public facade creates a `GraphqlCallContext` before invoking the private adapter.
+Only `ShippingSelectionTransportError::Graphql` is classified. Other variants are
+returned unchanged.
 
 The adapter display handoff is reparsed through the typed `GraphqlHttpError` contract:
 
@@ -39,21 +47,25 @@ The adapter display handoff is reparsed through the typed `GraphqlHttpError` con
 | GraphQL rejection | `fulfillment.storefront_graphql_request_rejected` | `Shipping selection request could not be completed` | warning |
 | unknown display handoff | `fulfillment.storefront_graphql_unknown_failure` | `Shipping selection request could not be completed` | error |
 
-The raw GraphQL detail is never copied into the returned `ShippingSelectionTransportError::Graphql`.
+The raw GraphQL detail is never copied into the returned
+`ShippingSelectionTransportError::Graphql`.
 
-## Correlation and diagnostics
+## Correlation and bounded diagnostics
 
-Each selected GraphQL invocation receives a generated correlation id with the fulfillment owner operation embedded in its prefix.
+Each selected GraphQL invocation receives a generated correlation id with the
+fulfillment owner operation embedded in its prefix.
 
-Internal events retain:
+Internal events retain only:
 
 - owner `rustok_fulfillment.storefront`;
 - owner operation `select_storefront_shipping_option`;
 - boundary `fulfillment_storefront_graphql_transport`;
 - per-call correlation id;
-- parsed GraphQL error category;
+- one closed error category: `network`, `http`, `unauthorized`, `graphql`, or
+  `unknown`;
 - stable internal code;
-- raw GraphQL display detail for operator diagnostics;
+- raw-display presence and character length;
+- whether typed `GraphqlHttpError` parsing succeeded;
 - whether a tenant slug is configured and its character length;
 - cart-id character length;
 - delivery-group count;
@@ -61,7 +73,10 @@ Internal events retain:
 - seller-id presence;
 - shipping-option-id presence.
 
-The events deliberately do not retain:
+Raw GraphQL display text is not written to the event. Debug output from the parsed typed
+error is not written to the event.
+
+The events also do not retain:
 
 - tenant slug value;
 - cart id value;
@@ -90,9 +105,11 @@ This work does not change:
 - native server-function endpoint or native safety policy;
 - feature-based `NativeServer` versus `Graphql` selection;
 - the no-fallback transport contract;
-- Commerce delegation to the fulfillment-owned facade.
+- Commerce delegation to the fulfillment-owned facade;
+- static public messages, category severity, or non-GraphQL pass-through behavior.
 
-Validation errors remain pass-through because they are local, user-actionable failures and are not GraphQL runtime envelopes.
+Validation errors remain pass-through because they are local, user-actionable failures
+and are not GraphQL runtime envelopes.
 
 ## Static evidence
 
@@ -104,13 +121,17 @@ Validation errors remain pass-through because they are local, user-actionable fa
 - static public messages for every typed category;
 - error versus warning severity;
 - correlation and safe request-shape diagnostics;
+- bounded raw-display presence/length and typed-parse validity;
+- absence of raw GraphQL display text and parsed-error Debug output;
 - absence of raw request identity fields in diagnostics;
 - unchanged private GraphQL adapter handoff and GraphQL document;
 - unchanged native path and transport variant;
 - unchanged explicit transport selection;
 - unvalidated evidence flags.
 
-The focused guard is imported by `verify-fulfillment-storefront-boundary.mjs` so the ordinary fulfillment storefront boundary check also rejects restoration of the raw public GraphQL mapping.
+The focused guard is imported by `verify-fulfillment-storefront-boundary.mjs`, so the
+ordinary fulfillment storefront boundary check also rejects restoration of raw public
+or diagnostic GraphQL payloads.
 
 Evidence files:
 
@@ -119,7 +140,8 @@ Evidence files:
 
 ## Evidence boundary
 
-The source status is `fulfillment_storefront_graphql_error_safety_source_unvalidated`.
+The source status is
+`fulfillment_storefront_graphql_error_safety_source_unvalidated`.
 
 Source inspection does not prove:
 
@@ -132,7 +154,9 @@ Source inspection does not prove:
 - FFA or FBA promotion;
 - production readiness.
 
-The broad ecommerce correlation-safe mapper task remains open for remaining storefront/admin GraphQL adapters, customer and other non-`PortError` envelopes, and runtime evidence.
+The broad ecommerce correlation-safe mapper task remains open for fulfillment checkout
+execution diagnostics, remaining storefront/admin GraphQL adapters, other non-`PortError`
+envelopes, and runtime evidence.
 
 ## Suggested maintainer checks
 

--- a/crates/rustok-fulfillment/storefront/src/transport/graphql_error_safety.rs
+++ b/crates/rustok-fulfillment/storefront/src/transport/graphql_error_safety.rs
@@ -44,7 +44,10 @@ impl GraphqlCallContext {
         let ShippingSelectionTransportError::Graphql(raw_error) = error else {
             return error;
         };
+        let raw_error_present = !raw_error.trim().is_empty();
+        let raw_error_length = raw_error.chars().count();
         let parsed_error = GraphqlHttpError::from_str(raw_error.as_str());
+        let parsed_error_valid = parsed_error.is_ok();
         let (error_kind, code, public_message, technical_failure) = match &parsed_error {
             Ok(GraphqlHttpError::Network) => (
                 "network",
@@ -80,8 +83,9 @@ impl GraphqlCallContext {
 
         if technical_failure {
             tracing::error!(
-                raw_error = %raw_error,
-                parsed_error = ?parsed_error,
+                raw_error_present,
+                raw_error_length,
+                parsed_error_valid,
                 owner = FULFILLMENT_STOREFRONT_GRAPHQL_OWNER,
                 owner_operation = FULFILLMENT_STOREFRONT_GRAPHQL_OPERATION,
                 correlation_id = %self.correlation_id,
@@ -99,8 +103,9 @@ impl GraphqlCallContext {
             );
         } else {
             tracing::warn!(
-                raw_error = %raw_error,
-                parsed_error = ?parsed_error,
+                raw_error_present,
+                raw_error_length,
+                parsed_error_valid,
                 owner = FULFILLMENT_STOREFRONT_GRAPHQL_OWNER,
                 owner_operation = FULFILLMENT_STOREFRONT_GRAPHQL_OPERATION,
                 correlation_id = %self.correlation_id,

--- a/scripts/verify/verify-fulfillment-storefront-graphql-error-safety.mjs
+++ b/scripts/verify/verify-fulfillment-storefront-graphql-error-safety.mjs
@@ -26,6 +26,12 @@ const evidence = JSON.parse(
     'crates/rustok-fulfillment/contracts/evidence/storefront-graphql-error-safety-source.json',
   ),
 );
+const review = JSON.parse(
+  read(
+    'crates/rustok-fulfillment/contracts/evidence/storefront-graphql-error-safety-source-review.json',
+  ),
+);
+const document = read('crates/rustok-fulfillment/docs/storefront-graphql-error-safety.md');
 
 const failures = [];
 const requireText = (content, value, label) => {
@@ -68,10 +74,18 @@ for (const [value, label] of [
   ['Uuid::new_v4()', 'per-call correlation id'],
   ['let ShippingSelectionTransportError::Graphql(raw_error) = error else {', 'GraphQL-only mapping'],
   ['return error;', 'non-GraphQL pass-through'],
+  ['let raw_error_present = !raw_error.trim().is_empty();', 'raw display presence fact'],
+  ['let raw_error_length = raw_error.chars().count();', 'raw display length fact'],
+  ['let parsed_error_valid = parsed_error.is_ok();', 'typed parse validity fact'],
   ['GraphqlHttpError::Network', 'network policy'],
   ['GraphqlHttpError::Http(_)', 'HTTP policy'],
   ['GraphqlHttpError::Unauthorized', 'authentication policy'],
   ['GraphqlHttpError::Graphql(_)', 'GraphQL rejection policy'],
+  ['"network"', 'closed network category'],
+  ['"http"', 'closed HTTP category'],
+  ['"unauthorized"', 'closed unauthorized category'],
+  ['"graphql"', 'closed GraphQL category'],
+  ['"unknown"', 'closed unknown category'],
   ['"fulfillment.storefront_graphql_network_unavailable"', 'network stable code'],
   ['"fulfillment.storefront_graphql_http_unavailable"', 'HTTP stable code'],
   ['"fulfillment.storefront_graphql_authentication_required"', 'auth stable code'],
@@ -82,8 +96,9 @@ for (const [value, label] of [
   ['"Shipping selection request could not be completed"', 'request public envelope'],
   ['tracing::error!(', 'technical event severity'],
   ['tracing::warn!(', 'ordinary event severity'],
-  ['raw_error = %raw_error', 'internal raw detail'],
-  ['parsed_error = ?parsed_error', 'typed internal error'],
+  ['raw_error_present,', 'bounded raw display presence logging'],
+  ['raw_error_length,', 'bounded raw display length logging'],
+  ['parsed_error_valid,', 'bounded typed parse logging'],
   ['owner = FULFILLMENT_STOREFRONT_GRAPHQL_OWNER', 'truthful owner'],
   ['owner_operation = FULFILLMENT_STOREFRONT_GRAPHQL_OPERATION', 'exact operation'],
   ['correlation_id = %self.correlation_id', 'correlation diagnostics'],
@@ -94,11 +109,17 @@ for (const [value, label] of [
   ['shipping_profile_slug_length = self.shipping_profile_slug_length', 'profile length fact'],
   ['seller_id_present = self.seller_id_present', 'seller presence fact'],
   ['shipping_option_id_present = self.shipping_option_id_present', 'option presence fact'],
+  ['error_kind,', 'closed error category logging'],
+  ['code,', 'stable code logging'],
   ['boundary = FULFILLMENT_STOREFRONT_GRAPHQL_BOUNDARY', 'GraphQL boundary diagnostics'],
   ['ShippingSelectionTransportError::Graphql(public_message.to_string())', 'static GraphQL envelope'],
 ]) requireText(safety, value, label);
 
 for (const value of [
+  'raw_error = %raw_error',
+  'raw_error = ?raw_error',
+  'parsed_error = ?parsed_error',
+  'parsed_error = %parsed_error',
   'tenant_slug =',
   'cart_id =',
   'shipping_profile_slug =',
@@ -109,7 +130,7 @@ for (const value of [
   'variables =',
   'endpoint =',
   'token =',
-]) forbidText(safety, value, 'raw GraphQL request diagnostics');
+]) forbidText(safety, value, 'raw GraphQL diagnostic payload');
 
 for (const [value, label] of [
   ['SELECT_STOREFRONT_SHIPPING_OPTION_MUTATION', 'unchanged GraphQL document'],
@@ -139,7 +160,11 @@ for (const [key, expected] of Object.entries({
   typed_graphql_error_policy: true,
   per_call_correlation_id: true,
   safe_request_shape_logging: true,
-  raw_graphql_detail_internal_only: true,
+  raw_graphql_detail_logged: false,
+  parsed_graphql_error_debug_logged: false,
+  raw_graphql_detail_shape_logged: true,
+  typed_parse_validity_logged: true,
+  closed_graphql_error_category_logged: true,
   validation_variant_changed: false,
   native_variant_changed: false,
   transport_selection_changed: false,
@@ -147,6 +172,7 @@ for (const [key, expected] of Object.entries({
   request_response_dto_changed: false,
   native_server_functions_changed: false,
   raw_graphql_detail_public: false,
+  broad_ecommerce_cleanup_closed: false,
 })) {
   if (evidence.source_contract?.[key] !== expected) {
     failures.push(`evidence source_contract.${key} must be ${expected}`);
@@ -168,6 +194,39 @@ for (const key of [
   }
 }
 
+if (
+  review.status !==
+  'fulfillment_storefront_graphql_error_safety_source_reviewed_unvalidated'
+) failures.push(`review status mismatch: ${review.status}`);
+for (const [key, expected] of Object.entries({
+  typed_graphql_variant_policy: true,
+  static_public_graphql_messages: true,
+  raw_graphql_detail_logging_removed: true,
+  parsed_graphql_error_debug_logging_removed: true,
+  bounded_graphql_error_shape_retained: true,
+  per_call_correlation_id: true,
+  safe_shape_only_request_facts: true,
+  native_path_changed: false,
+  validation_path_changed: false,
+  graphql_adapter_changed: false,
+  graphql_document_changed: false,
+  transport_selection_changed: false,
+  request_response_dto_changed: false,
+  runtime_evidence_claimed: false,
+})) {
+  if (review.implementation_review?.[key] !== expected) {
+    failures.push(`review implementation_review.${key} must be ${expected}`);
+  }
+}
+
+for (const marker of [
+  'Status: **source-ready / unvalidated**',
+  'Raw GraphQL display text is not written to the event.',
+  'Debug output from the parsed typed error is not written to the event.',
+  'raw-display presence and character length',
+  'The broad ecommerce correlation-safe mapper task remains open',
+]) requireText(document, marker, 'truthful fulfillment GraphQL documentation');
+
 if (failures.length > 0) {
   console.error('Fulfillment storefront GraphQL error-safety verification failed:');
   for (const failure of failures) console.error(`✗ ${failure}`);
@@ -175,5 +234,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ fulfillment storefront GraphQL failures retain typed internal diagnostics and static public envelopes; runtime evidence remains open',
+  '✔ fulfillment storefront GraphQL failures retain bounded error/request shape and static public envelopes; runtime evidence remains open',
 );


### PR DESCRIPTION
## Summary

- continue the ecommerce correlation-safe mapper cleanup for a non-`PortError` Fulfillment storefront transport boundary
- preserve typed `GraphqlHttpError` classification, all five stable internal codes, static public messages, severity, non-GraphQL pass-through, explicit transport selection, and per-call correlation
- stop writing the complete private GraphQL display handoff and Debug representation of the parsed typed error into structured events
- retain only raw-display presence/character length, typed-parse validity, a closed five-value error category, stable code, and the existing bounded request shape
- update the focused fail-closed verifier, retained source/review evidence, and fulfillment documentation

## Recheck

The public GraphQL envelope was already static and safe, but `crates/rustok-fulfillment/storefront/src/transport/graphql_error_safety.rs` still logged `raw_error = %raw_error` and `parsed_error = ?parsed_error`. The existing verifier and retained evidence explicitly required that payload retention. This PR closes only that diagnostic-envelope gap.

## Deliberate boundary

Fulfillment FFA remains `in_progress` and FBA remains `boundary_ready`. The broader ecommerce mapper cleanup remains open, including fulfillment checkout execution diagnostics and other storefront/admin non-`PortError` envelopes. No DTO, GraphQL document, adapter request construction, native path, public transport variant, stable message/code, severity, fallback policy, dependency, workflow, CI configuration, or runtime-evidence status changes.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, CI, browser execution, or mounted runtime validation was executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-fulfillment-storefront-graphql-error-safety.mjs
node scripts/verify/verify-fulfillment-storefront-native-error-safety.mjs
node scripts/verify/verify-fulfillment-storefront-boundary.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-fulfillment-storefront
cargo check -p rustok-fulfillment-storefront --features hydrate
cargo check -p rustok-fulfillment-storefront --features ssr
```

Branch: `agent/fulfillment-storefront-graphql-diagnostic-safety-20260801`
Base source tree: `2e24ce69682b2c303267994df948c5049145fa45`
Current `main` has one unrelated Forum commit after that base.