### PR TITLE
fix(order): bound storefront GraphQL diagnostics

### DIFF
--- a/crates/rustok-order/contracts/evidence/storefront-graphql-error-safety-source-review.json
+++ b/crates/rustok-order/contracts/evidence/storefront-graphql-error-safety-source-review.json
@@ -1,8 +1,9 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-30",
+  "generated_at": "2026-08-01",
   "status": "order_storefront_graphql_error_safety_source_reviewed_unvalidated",
-  "base_main_sha": "5b9d49e65295819ee9e8e9c199688c0e2ac73d35",
+  "base_main_sha": "aad0416fd68cea3d41b1fedf58958eb9cf6d0dd9",
+  "scope": "order storefront checkout-completion GraphQL public and diagnostic boundary",
   "reviewed_sources": [
     "crates/rustok-commerce/docs/implementation-plan.md",
     "crates/rustok-order/storefront/Cargo.toml",
@@ -10,30 +11,55 @@
     "crates/rustok-order/storefront/src/transport/graphql_adapter.rs",
     "crates/rustok-order/storefront/src/transport/graphql_error_safety.rs",
     "crates/rustok-order/storefront/src/transport/native_server_adapter/server_functions.rs",
+    "crates/rustok-order/contracts/evidence/storefront-graphql-error-safety-source.json",
+    "crates/rustok-order/docs/storefront-graphql-error-safety.md",
+    "scripts/verify/verify-order-storefront-graphql-error-safety.mjs",
     "crates/rustok-ui-transport/src/lib.rs",
-    "crates/rustok-graphql/src/lib.rs",
-    "scripts/verify/verify-order-storefront-boundary.mjs"
+    "crates/rustok-graphql/src/lib.rs"
   ],
   "findings": [
     {
-      "id": "order-storefront-graphql-public-detail",
-      "severity": "p1",
-      "finding": "The order storefront facade delegated its selected GraphQL closure directly to the private adapter, so GraphqlHttpError display text was retained in UiTransportError.graphql_error.",
-      "resolution": "Create a per-call owner context at the public consumer boundary and map only CheckoutCompletionTransportError::Graphql to static public envelopes."
+      "id": "order-storefront-graphql-static-public-envelope-preserved",
+      "severity": "preservation",
+      "finding": "The public facade already maps network, HTTP, unauthorized, GraphQL rejection, and unknown handoff failures to static order-owned messages."
+    },
+    {
+      "id": "order-storefront-graphql-raw-diagnostic-payload",
+      "severity": "diagnostic_safety",
+      "finding": "The safety mapper still copied the complete private GraphQL display handoff and Debug representation of the parsed typed error into structured events. Those payloads were unnecessary for correlation or closed classification."
     },
     {
       "id": "order-storefront-validation-preservation",
-      "severity": "contract",
-      "finding": "Cart UUID and checkout idempotency-key validation execute inside the private adapter before the GraphQL request.",
-      "resolution": "Pass Validation and ServerFn variants through unchanged and leave the private adapter unmodified."
+      "severity": "preservation",
+      "finding": "Cart UUID and checkout idempotency-key validation remain inside the private adapter before the GraphQL request."
     },
     {
-      "id": "order-storefront-correlation-context",
-      "severity": "contract",
-      "finding": "The client-side GraphQL path had no owner correlation event for failures.",
-      "resolution": "Generate a unique per-call correlation id and retain only tenant configuration, identifier lengths, and create-fulfillment policy in internal diagnostics."
+      "id": "order-storefront-native-policy-preserved",
+      "severity": "preservation",
+      "finding": "The native server-function path remains separate and unchanged under its existing runtime error policy."
+    },
+    {
+      "id": "order-storefront-explicit-transport-selection",
+      "severity": "preservation",
+      "finding": "The facade continues to select one transport by feature profile without native-to-GraphQL fallback."
     }
   ],
+  "implementation_review": {
+    "typed_graphql_variant_policy": true,
+    "static_public_graphql_messages": true,
+    "raw_graphql_detail_logging_removed": true,
+    "parsed_graphql_error_debug_logging_removed": true,
+    "bounded_graphql_error_shape_retained": true,
+    "per_call_correlation_id": true,
+    "safe_shape_only_request_facts": true,
+    "private_graphql_adapter_changed": false,
+    "native_path_changed": false,
+    "validation_path_changed": false,
+    "graphql_document_changed": false,
+    "transport_selection_changed": false,
+    "request_response_dto_changed": false,
+    "runtime_evidence_claimed": false
+  },
   "preserved_behavior": [
     "explicit feature-based transport selection",
     "no native-to-GraphQL fallback",
@@ -41,7 +67,8 @@
     "checkout completion request and response DTOs",
     "cart UUID and idempotency-key validation",
     "native server-function error policy",
-    "Commerce owner-facade delegation"
+    "Commerce owner-facade delegation",
+    "five stable public messages and category severity"
   ],
   "execution": {
     "commands": [],
@@ -61,5 +88,12 @@
     "ffa_promoted": false,
     "fba_promoted": false,
     "production_promoted": false
-  }
+  },
+  "remaining_scope": [
+    "remaining ecommerce storefront and admin GraphQL adapters",
+    "remaining non-PortError public and diagnostic envelopes",
+    "order owner mapper diagnostics outside this storefront transport",
+    "browser and mounted GraphQL runtime evidence",
+    "broad ecommerce correlation-safe mapper cleanup"
+  ]
 }

--- a/crates/rustok-order/contracts/evidence/storefront-graphql-error-safety-source.json
+++ b/crates/rustok-order/contracts/evidence/storefront-graphql-error-safety-source.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-30",
+  "generated_at": "2026-08-01",
   "status": "order_storefront_graphql_error_safety_source_unvalidated",
-  "scope": "order-owned storefront GraphQL checkout completion transport",
+  "scope": "order-owned storefront GraphQL checkout completion public and diagnostic transport boundary",
   "covered_operations": [
     "complete_storefront_checkout"
   ],
@@ -23,17 +23,41 @@
     "unknown_static_public_envelope": true,
     "correlation_logging": true,
     "safe_request_shape_logging": true,
+    "raw_graphql_detail_logged": false,
+    "parsed_graphql_error_debug_logged": false,
+    "raw_graphql_detail_shape_logged": true,
+    "typed_parse_validity_logged": true,
+    "closed_graphql_error_category_logged": true,
     "raw_cart_id_logged": false,
     "raw_idempotency_key_logged": false,
     "raw_tenant_slug_logged": false,
     "raw_command_metadata_logged": false,
     "raw_graphql_error_public": false,
-    "non_graphql_errors_pass_through": true
+    "non_graphql_errors_pass_through": true,
+    "broad_ecommerce_cleanup_closed": false
   },
   "stable_public_messages": {
     "network_or_http": "Checkout completion is temporarily unavailable",
     "unauthorized": "Checkout authentication is required",
     "graphql_rejection_or_unknown": "Checkout request could not be completed"
+  },
+  "internal_diagnostics": {
+    "raw_graphql_error": false,
+    "parsed_graphql_error_debug": false,
+    "raw_graphql_error_present": true,
+    "raw_graphql_error_length": true,
+    "parsed_graphql_error_valid": true,
+    "closed_graphql_error_category": true,
+    "owner_operation": true,
+    "correlation_id": true,
+    "tenant_slug_value": false,
+    "tenant_slug_configured_and_length": true,
+    "cart_id_value": false,
+    "cart_id_length": true,
+    "idempotency_key_value": false,
+    "idempotency_key_length": true,
+    "command_metadata": false,
+    "create_fulfillment_policy": true
   },
   "suggested_execution": [
     "node scripts/verify/verify-order-storefront-graphql-error-safety.mjs",

--- a/crates/rustok-order/docs/storefront-graphql-error-safety.md
+++ b/crates/rustok-order/docs/storefront-graphql-error-safety.md
@@ -4,36 +4,39 @@ Status: source-unvalidated
 
 ## Scope
 
-This source slice hardens the order-owned storefront GraphQL transport for the
-single public checkout-completion operation:
+This source slice hardens both the public and private diagnostic boundary of the
+order-owned storefront GraphQL transport for the single public checkout-completion
+operation:
 
 - `complete_storefront_checkout`.
 
-The storefront facade remains the public transport consumer. The low-level
-GraphQL adapter remains private and continues to own the mutation document,
-variables, response decoding, cart UUID validation, checkout idempotency-key
-validation, and DTO mapping.
+The storefront facade remains the public transport consumer. The low-level GraphQL
+adapter remains private and continues to own the mutation document, variables,
+response decoding, cart UUID validation, checkout idempotency-key validation, and
+DTO mapping.
 
-## Previous gap
+## Rechecked gap
 
-The selected GraphQL closure delegated directly to the private adapter. The
-adapter converted `GraphqlHttpError` into
-`CheckoutCompletionTransportError::Graphql(error.to_string())`, and
-`execute_selected_transport` retained that display string in the public
-`UiTransportError.graphql_error` field.
+The public consumer boundary already reparsed the private adapter display handoff
+through `GraphqlHttpError` and returned static order-owned messages. Server-provided
+GraphQL messages and HTTP details therefore did not reach the storefront caller.
 
-Consequently, server-provided GraphQL messages and HTTP status details could
-cross the storefront UI boundary without an order-owned public-envelope policy.
-The native server-function path already had a separate sanitized runtime policy,
-but that policy did not cover the GraphQL path.
+The structured event still copied two complete private values:
+
+- `raw_error = %raw_error`;
+- `parsed_error = ?parsed_error`.
+
+The display text and Debug representation were unnecessary for correlation or the
+closed five-category transport policy. This was a remaining non-`PortError`
+diagnostic-envelope gap in the ecommerce correlation-safe mapper cleanup.
 
 ## Public consumer policy
 
-`transport.rs` now creates a private `GraphqlCallContext` before invoking the
-GraphQL adapter. The context reparses the adapter's display handoff through
+`transport.rs` creates a private `GraphqlCallContext` before invoking the GraphQL
+adapter. The context reparses the adapter display handoff through
 `GraphqlHttpError::from_str` and maps only the `Graphql` transport variant.
 
-The stable public messages are:
+The stable public messages remain:
 
 | Typed failure | Public message |
 | --- | --- |
@@ -46,28 +49,34 @@ The stable public messages are:
 `Validation` and `ServerFn` variants are returned unchanged. This preserves the
 existing validation order and the independent native transport policy.
 
-## Correlation diagnostics
+## Correlation and bounded diagnostics
 
-Every selected GraphQL call creates a unique correlation identifier using the
-owner operation and a new UUID. Internal tracing events retain:
+Every selected GraphQL call creates a unique correlation identifier using the owner
+operation and a new UUID. Internal tracing events retain only:
 
 - owner `rustok_order.storefront`;
 - owner operation `complete_storefront_checkout`;
 - boundary `order_storefront_graphql_transport`;
 - correlation identifier;
-- typed error kind and stable code;
-- raw and reparsed GraphQL cause for internal diagnosis;
+- one closed category: `network`, `http`, `unauthorized`, `graphql`, or `unknown`;
+- stable internal code;
+- raw-display presence and character length;
+- whether typed `GraphqlHttpError` parsing succeeded;
 - whether a tenant slug is configured and its character length;
 - cart-id character length;
 - idempotency-key character length;
 - the `create_fulfillment` policy flag.
 
-The mapper does not log the raw tenant slug, cart id, idempotency key, command
+Raw GraphQL display text is not written to the event.
+Debug output from the parsed typed error is not written to the event.
+
+The mapper also does not log the raw tenant slug, cart id, idempotency key, command
 metadata, GraphQL endpoint, mutation, variables, tokens, or returned checkout
 objects.
 
-Technical network, HTTP, and unknown failures use error-level diagnostics.
-Unauthorized and ordinary GraphQL rejection use warning-level diagnostics.
+Technical network, HTTP, and unknown failures continue to use error-level
+diagnostics. Unauthorized and ordinary GraphQL rejection continue to use
+warning-level diagnostics.
 
 ## Preserved behavior
 
@@ -82,11 +91,13 @@ This slice does not change:
 - the 1-to-191-byte checkout idempotency-key rule;
 - checkout command metadata;
 - native server functions or native runtime mapping;
-- Commerce delegation to the order-owned storefront facade.
+- Commerce delegation to the order-owned storefront facade;
+- static public messages, stable codes, category severity, or non-GraphQL
+  pass-through behavior.
 
-The adapter still creates the exact typed GraphQL display handoff. Sanitization
-occurs once at the public consumer boundary, avoiding duplicate diagnostics and
-preserving adapter ownership.
+The adapter still creates the exact typed GraphQL display handoff. Sanitization and
+bounded diagnostics occur once at the public consumer boundary, preserving adapter
+ownership.
 
 ## Source guard
 
@@ -96,10 +107,11 @@ The focused verifier is:
 node scripts/verify/verify-order-storefront-graphql-error-safety.mjs
 ```
 
-It checks the typed mapping policy, static public messages, stable codes,
-correlation and safe request-shape diagnostics, GraphQL-only remapping,
-private-adapter preservation, native-path preservation, evidence status, and
-validation nonclaims.
+It checks typed mapping, static public messages and stable codes, correlation and safe
+request-shape diagnostics, bounded raw-display presence/length and typed-parse
+validity, absence of complete raw/debug payloads, GraphQL-only remapping,
+private-adapter preservation, native-path preservation, truthful evidence status,
+and validation nonclaims.
 
 The general owner boundary verifier imports the focused guard:
 
@@ -114,10 +126,9 @@ Retained source evidence:
 - `crates/rustok-order/contracts/evidence/storefront-graphql-error-safety-source.json`;
 - `crates/rustok-order/contracts/evidence/storefront-graphql-error-safety-source-review.json`.
 
-The evidence establishes only that the source and guardrail are present and
-have been reviewed. It does not establish compilation, browser execution,
-GraphQL runtime behavior, mounted Commerce parity, workflow success, CI success,
-or production behavior.
+The evidence establishes only that the source and guardrail are present and reviewed.
+It does not establish compilation, browser execution, GraphQL runtime behavior,
+mounted Commerce parity, workflow success, CI success, or production behavior.
 
 The broad ecommerce correlation-safe mapper cleanup remains open.
 
@@ -136,6 +147,5 @@ cargo check -p rustok-order-storefront --features hydrate
 cargo check -p rustok-order-storefront --features ssr
 ```
 
-Source readiness must remain separate from runtime or promotion claims until
-those commands and the required mounted failure evidence are retained on the
-same revision.
+Source readiness must remain separate from runtime or promotion claims until those
+commands and the required mounted failure evidence are retained on the same revision.

--- a/crates/rustok-order/storefront/src/transport/graphql_error_safety.rs
+++ b/crates/rustok-order/storefront/src/transport/graphql_error_safety.rs
@@ -39,7 +39,10 @@ impl GraphqlCallContext {
         let CheckoutCompletionTransportError::Graphql(raw_error) = error else {
             return error;
         };
+        let raw_error_present = !raw_error.trim().is_empty();
+        let raw_error_length = raw_error.chars().count();
         let parsed_error = GraphqlHttpError::from_str(raw_error.as_str());
+        let parsed_error_valid = parsed_error.is_ok();
         let (error_kind, code, public_message, technical_failure) = match &parsed_error {
             Ok(GraphqlHttpError::Network) => (
                 "network",
@@ -75,8 +78,9 @@ impl GraphqlCallContext {
 
         if technical_failure {
             tracing::error!(
-                raw_error = %raw_error,
-                parsed_error = ?parsed_error,
+                raw_error_present,
+                raw_error_length,
+                parsed_error_valid,
                 owner = ORDER_STOREFRONT_GRAPHQL_OWNER,
                 owner_operation = ORDER_STOREFRONT_GRAPHQL_OPERATION,
                 correlation_id = %self.correlation_id,
@@ -92,8 +96,9 @@ impl GraphqlCallContext {
             );
         } else {
             tracing::warn!(
-                raw_error = %raw_error,
-                parsed_error = ?parsed_error,
+                raw_error_present,
+                raw_error_length,
+                parsed_error_valid,
                 owner = ORDER_STOREFRONT_GRAPHQL_OWNER,
                 owner_operation = ORDER_STOREFRONT_GRAPHQL_OPERATION,
                 correlation_id = %self.correlation_id,

--- a/scripts/verify/verify-order-storefront-graphql-error-safety.mjs
+++ b/scripts/verify/verify-order-storefront-graphql-error-safety.mjs
@@ -21,6 +21,11 @@ const docs = read('crates/rustok-order/docs/storefront-graphql-error-safety.md')
 const evidence = JSON.parse(
   read('crates/rustok-order/contracts/evidence/storefront-graphql-error-safety-source.json'),
 );
+const review = JSON.parse(
+  read(
+    'crates/rustok-order/contracts/evidence/storefront-graphql-error-safety-source-review.json',
+  ),
+);
 
 const failures = [];
 const requireText = (content, value, label) => {
@@ -55,18 +60,33 @@ for (const [value, label] of [
   ['let CheckoutCompletionTransportError::Graphql(raw_error) = error else', 'GraphQL-only mapping'],
   ['return error;', 'non-GraphQL pass-through'],
   ['Uuid::new_v4()', 'unique correlation id'],
+  ['let raw_error_present = !raw_error.trim().is_empty();', 'raw display presence fact'],
+  ['let raw_error_length = raw_error.chars().count();', 'raw display length fact'],
+  ['let parsed_error_valid = parsed_error.is_ok();', 'typed parse validity fact'],
   ['correlation_id = %self.correlation_id', 'correlation diagnostics'],
   ['tenant_slug_configured = self.tenant_slug_length.is_some()', 'tenant configured fact'],
   ['tenant_slug_length = ?self.tenant_slug_length', 'tenant length fact'],
   ['cart_id_length = self.cart_id_length', 'cart id length fact'],
   ['idempotency_key_length = self.idempotency_key_length', 'idempotency length fact'],
   ['create_fulfillment = self.create_fulfillment', 'fulfillment policy fact'],
-  ['raw_error = %raw_error', 'internal raw cause diagnostics'],
-  ['parsed_error = ?parsed_error', 'typed cause diagnostics'],
+  ['raw_error_present,', 'bounded raw display presence logging'],
+  ['raw_error_length,', 'bounded raw display length logging'],
+  ['parsed_error_valid,', 'bounded typed parse logging'],
+  ['error_kind,', 'closed error category logging'],
+  ['code,', 'stable code logging'],
   ['boundary = ORDER_STOREFRONT_GRAPHQL_BOUNDARY', 'boundary diagnostics'],
 ]) requireText(safety, value, label);
 
 for (const [value, label] of [
+  ['GraphqlHttpError::Network', 'network policy'],
+  ['GraphqlHttpError::Http(_)', 'HTTP policy'],
+  ['GraphqlHttpError::Unauthorized', 'authentication policy'],
+  ['GraphqlHttpError::Graphql(_)', 'GraphQL rejection policy'],
+  ['"network"', 'closed network category'],
+  ['"http"', 'closed HTTP category'],
+  ['"unauthorized"', 'closed unauthorized category'],
+  ['"graphql"', 'closed GraphQL category'],
+  ['"unknown"', 'closed unknown category'],
   ['order.storefront_graphql_network_unavailable', 'network stable code'],
   ['order.storefront_graphql_http_unavailable', 'HTTP stable code'],
   ['order.storefront_graphql_authentication_required', 'authentication stable code'],
@@ -77,6 +97,21 @@ for (const [value, label] of [
   ['Checkout request could not be completed', 'rejection public message'],
   ['CheckoutCompletionTransportError::Graphql(public_message.to_string())', 'static public envelope'],
 ]) requireText(safety, value, label);
+
+for (const value of [
+  'raw_error = %raw_error',
+  'raw_error = ?raw_error',
+  'parsed_error = ?parsed_error',
+  'parsed_error = %parsed_error',
+  'tenant_slug = %',
+  'cart_id = %',
+  'idempotency_key = %',
+  'metadata = ?',
+  'source_module = %',
+  'source_surface = %',
+  'command = %',
+  'owner_module = %',
+]) forbidText(safety, value, 'raw diagnostic payload');
 
 for (const [value, label] of [
   ['COMPLETE_STOREFRONT_CHECKOUT_MUTATION', 'checkout mutation'],
@@ -98,17 +133,6 @@ for (const value of [
   'UiTransportError::graphql("order", error)',
 ]) forbidText(transport, value, 'unsanitized public GraphQL delegation');
 
-for (const value of [
-  'tenant_slug = %',
-  'cart_id = %',
-  'idempotency_key = %',
-  'metadata = ?',
-  'source_module = %',
-  'source_surface = %',
-  'command = %',
-  'owner_module = %',
-]) forbidText(safety, value, 'raw request diagnostics');
-
 for (const [value, label] of [
   ['CheckoutCompletionTransportError::ServerFn(', 'native outer transport variant'],
   ['Checkout transport is temporarily unavailable', 'native outer public message'],
@@ -118,6 +142,9 @@ for (const [value, label] of [
 
 for (const [value, label] of [
   ['Status: source-unvalidated', 'documentation source status'],
+  ['Raw GraphQL display text is not written to the event.', 'raw diagnostic removal'],
+  ['Debug output from the parsed typed error is not written to the event.', 'typed debug removal'],
+  ['raw-display presence and character length', 'bounded display shape'],
   ['The broad ecommerce correlation-safe mapper cleanup remains open.', 'broad-plan nonclaim'],
   ['No tests, verifiers, Cargo commands, formatting, workflows, or CI were run', 'execution nonclaim'],
 ]) requireText(docs, value, label);
@@ -135,12 +162,18 @@ for (const [key, expected] of Object.entries({
   transport_selection_changed: false,
   native_to_graphql_fallback_added: false,
   graphql_http_error_reparsed: true,
+  raw_graphql_detail_logged: false,
+  parsed_graphql_error_debug_logged: false,
+  raw_graphql_detail_shape_logged: true,
+  typed_parse_validity_logged: true,
+  closed_graphql_error_category_logged: true,
   raw_cart_id_logged: false,
   raw_idempotency_key_logged: false,
   raw_tenant_slug_logged: false,
   raw_command_metadata_logged: false,
   raw_graphql_error_public: false,
   non_graphql_errors_pass_through: true,
+  broad_ecommerce_cleanup_closed: false,
 })) {
   if (evidence.source_contract?.[key] !== expected) {
     failures.push(`evidence source_contract.${key} must be ${expected}`);
@@ -163,6 +196,31 @@ for (const key of [
   }
 }
 
+if (
+  review.status !==
+  'order_storefront_graphql_error_safety_source_reviewed_unvalidated'
+) failures.push(`review status mismatch: ${review.status}`);
+for (const [key, expected] of Object.entries({
+  typed_graphql_variant_policy: true,
+  static_public_graphql_messages: true,
+  raw_graphql_detail_logging_removed: true,
+  parsed_graphql_error_debug_logging_removed: true,
+  bounded_graphql_error_shape_retained: true,
+  per_call_correlation_id: true,
+  safe_shape_only_request_facts: true,
+  private_graphql_adapter_changed: false,
+  native_path_changed: false,
+  validation_path_changed: false,
+  graphql_document_changed: false,
+  transport_selection_changed: false,
+  request_response_dto_changed: false,
+  runtime_evidence_claimed: false,
+})) {
+  if (review.implementation_review?.[key] !== expected) {
+    failures.push(`review implementation_review.${key} must be ${expected}`);
+  }
+}
+
 if (failures.length > 0) {
   console.error('Order storefront GraphQL error-safety verification failed:');
   for (const failure of failures) console.error(`✗ ${failure}`);
@@ -170,5 +228,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ order storefront GraphQL failures retain correlation diagnostics and static public envelopes; runtime evidence remains open',
+  '✔ order storefront GraphQL failures retain bounded error/request shape and static public envelopes; runtime evidence remains open',
 );


### PR DESCRIPTION
## Summary

- continue the ecommerce correlation-safe mapper cleanup for the Order storefront non-`PortError` GraphQL boundary
- preserve typed `GraphqlHttpError` classification, all five stable codes, static public messages, severity, correlation, validation/native pass-through, explicit transport selection, and no-fallback policy
- stop writing the complete private GraphQL display handoff and Debug representation of the parsed typed error into structured events
- retain only raw-display presence/character length, typed-parse validity, a closed five-value category, stable code, and the existing bounded request shape
- update the focused fail-closed verifier, source/review evidence, and Order documentation

## Recheck

The public checkout-completion GraphQL envelope was already static and safe, but `crates/rustok-order/storefront/src/transport/graphql_error_safety.rs` still logged `raw_error = %raw_error` and `parsed_error = ?parsed_error`. The existing verifier and documentation explicitly required/described those complete internal payloads. This PR closes only that diagnostic-envelope gap.

## Deliberate boundary

The broad ecommerce mapper cleanup remains open. No DTO, GraphQL mutation, adapter request construction, validation order, native path, public transport variant, stable message/code, category severity, fallback policy, dependency, workflow, CI configuration, FFA/FBA status, or runtime-evidence status changes.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, CI, browser execution, or mounted runtime validation was executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-order-storefront-graphql-error-safety.mjs
node scripts/verify/verify-order-storefront-runtime-error-diagnostics.mjs
node scripts/verify/verify-order-storefront-boundary.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-order-storefront
cargo check -p rustok-order-storefront --features hydrate
cargo check -p rustok-order-storefront --features ssr
```

Branch: `agent/order-storefront-graphql-diagnostic-safety-20260801`
Base main: `aad0416fd68cea3d41b1fedf58958eb9cf6d0dd9`