### PR TITLE
fix(payment): bound storefront GraphQL diagnostics

### DIFF
--- a/crates/rustok-payment/contracts/evidence/payment-storefront-graphql-error-safety-source-review.json
+++ b/crates/rustok-payment/contracts/evidence/payment-storefront-graphql-error-safety-source-review.json
@@ -1,43 +1,60 @@
 {
   "schema_version": 1,
-  "reviewed_at": "2026-07-30",
+  "reviewed_at": "2026-08-01",
   "status": "payment_storefront_graphql_error_safety_source_reviewed_unvalidated",
-  "base_main": "3b11116c73b93894ee5e7228ac0b119b57eedf52",
+  "base_main": "d0c554d4a7b107215f113cf00d52dfdf3b8ab3e6",
+  "scope": "payment storefront GraphQL public and diagnostic boundary",
   "reviewed_sources": [
     "crates/rustok-commerce/docs/implementation-plan.md",
     "crates/rustok-payment/storefront/Cargo.toml",
     "crates/rustok-payment/storefront/src/transport.rs",
     "crates/rustok-payment/storefront/src/transport/graphql_adapter.rs",
+    "crates/rustok-payment/storefront/src/transport/graphql_error_safety.rs",
     "crates/rustok-payment/storefront/src/transport/native_server_adapter/server_functions.rs",
+    "crates/rustok-payment/contracts/evidence/payment-storefront-graphql-error-safety-source.json",
+    "crates/rustok-payment/docs/storefront-graphql-error-safety.md",
+    "scripts/verify/verify-payment-storefront-graphql-error-safety.mjs",
     "crates/rustok-graphql/src/lib.rs",
-    "crates/rustok-ui-transport/src/lib.rs",
-    "scripts/verify/verify-payment-storefront-native-error-safety.mjs"
+    "crates/rustok-ui-transport/src/lib.rs"
   ],
-  "findings": {
-    "master_mapper_cleanup_open": true,
-    "graphql_adapter_private": true,
-    "raw_graphql_display_handoffs": 3,
-    "ui_transport_preserves_graphql_display": true,
-    "native_transport_has_static_owner_envelopes": true,
-    "graphql_http_error_variants_reviewed": [
-      "Network",
-      "Http",
-      "Unauthorized",
-      "Graphql"
-    ],
-    "graphql_http_error_display_round_trip_available": true,
-    "covered_public_operations": [
-      "create_payment_collection",
-      "fetch_payment_collection",
-      "fetch_refund_summary"
-    ],
-    "native_calls_preserved": true,
-    "transport_selection_preserved": true,
-    "graphql_queries_preserved": true,
-    "request_response_dtos_preserved": true,
-    "validation_errors_pass_through": true,
-    "raw_tenant_slug_excluded_from_diagnostics": true,
-    "graphql_variables_excluded_from_diagnostics": true
+  "findings": [
+    {
+      "id": "payment-storefront-static-public-envelope-preserved",
+      "severity": "preservation",
+      "finding": "All three public GraphQL operations already reparse the private adapter display through GraphqlHttpError and return static payment-owned messages."
+    },
+    {
+      "id": "payment-storefront-raw-diagnostic-payload",
+      "severity": "diagnostic_safety",
+      "finding": "The shared safety mapper still copied the complete private GraphQL display handoff and Debug representation of the parsed typed error into structured events."
+    },
+    {
+      "id": "payment-storefront-operation-coverage",
+      "severity": "preservation",
+      "finding": "create payment collection, read payment collection, and read order refunds all use the same GraphqlCallContext while retaining distinct owner operations."
+    },
+    {
+      "id": "payment-storefront-transport-separation",
+      "severity": "preservation",
+      "finding": "The native path, validation pass-through, private GraphQL queries, DTOs, explicit selection, and no-fallback behavior remain separate and unchanged."
+    }
+  ],
+  "implementation_review": {
+    "typed_graphql_variant_policy": true,
+    "static_public_graphql_messages": true,
+    "raw_graphql_detail_logging_removed": true,
+    "parsed_graphql_error_debug_logging_removed": true,
+    "bounded_graphql_error_shape_retained": true,
+    "all_three_public_operations_preserved": true,
+    "per_call_correlation_id": true,
+    "tenant_shape_only": true,
+    "private_graphql_adapter_changed": false,
+    "native_path_changed": false,
+    "validation_path_changed": false,
+    "graphql_queries_changed": false,
+    "transport_selection_changed": false,
+    "request_response_dto_changed": false,
+    "runtime_evidence_claimed": false
   },
   "execution": {
     "commands": [],
@@ -48,11 +65,11 @@
     "workflows": [],
     "ci": []
   },
-  "nonclaims": [
-    "No focused verifier was executed.",
-    "No Cargo command or test was executed.",
-    "No browser, GraphQL server, mounted transport, workflow, or CI behavior was proven.",
-    "The generic rustok-graphql client and rustok-ui-transport envelope were not changed.",
-    "The broad ecommerce correlation-safe mapper cleanup remains open."
+  "remaining_scope": [
+    "payment checkout execution and compensation diagnostics",
+    "remaining ecommerce storefront and admin GraphQL adapters",
+    "remaining non-PortError public and diagnostic envelopes",
+    "browser and mounted GraphQL runtime evidence",
+    "broad ecommerce correlation-safe mapper cleanup"
   ]
 }

--- a/crates/rustok-payment/contracts/evidence/payment-storefront-graphql-error-safety-source.json
+++ b/crates/rustok-payment/contracts/evidence/payment-storefront-graphql-error-safety-source.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-30",
+  "generated_at": "2026-08-01",
   "status": "payment_storefront_graphql_error_safety_source_unvalidated",
   "scope": "payment-owned storefront GraphQL transport consumer for refund summary and payment collection read/create",
   "source_contract": {
@@ -19,8 +19,25 @@
     "transport_selection_changed": false,
     "request_response_dto_changed": false,
     "graphql_query_changed": false,
+    "raw_graphql_detail_logged": false,
+    "parsed_graphql_error_debug_logged": false,
+    "raw_graphql_detail_shape_logged": true,
+    "typed_parse_validity_logged": true,
+    "closed_graphql_error_category_logged": true,
     "raw_graphql_error_public": false,
-    "raw_tenant_slug_logged": false
+    "raw_tenant_slug_logged": false,
+    "broad_ecommerce_cleanup_closed": false
+  },
+  "internal_diagnostics": {
+    "raw_graphql_error": false,
+    "parsed_graphql_error_debug": false,
+    "raw_graphql_error_present": true,
+    "raw_graphql_error_length": true,
+    "parsed_graphql_error_valid": true,
+    "closed_graphql_error_category": true,
+    "owner_operation": true,
+    "correlation_id": true,
+    "tenant_slug_configured_and_length": true
   },
   "stable_public_messages": {
     "network_unavailable": "Payment storefront is temporarily unavailable",

--- a/crates/rustok-payment/docs/storefront-graphql-error-safety.md
+++ b/crates/rustok-payment/docs/storefront-graphql-error-safety.md
@@ -4,8 +4,9 @@ Status: **source-ready / unvalidated**
 
 ## Scope
 
-This slice hardens the payment-owned storefront GraphQL transport used when
-`UiTransportPath::Graphql` is selected for:
+This slice hardens both the public and private diagnostic boundary for the
+payment-owned storefront GraphQL transport used when `UiTransportPath::Graphql`
+is selected for:
 
 - `create_payment_collection`;
 - `fetch_payment_collection`;
@@ -14,22 +15,28 @@ This slice hardens the payment-owned storefront GraphQL transport used when
 The private low-level adapter, GraphQL documents, variables, DTO mapping, native
 server functions, and explicit transport selection remain unchanged.
 
-## Problem
+## Rechecked gap
 
-`rustok_graphql::execute` returns a typed `GraphqlHttpError`, but the private
-payment GraphQL adapter converted each failure to
-`PaymentTransportError::Graphql(error.to_string())`. The public transport facade
-then passed that display string into `UiTransportError.graphql_error`.
+The public transport consumer already reparsed each private adapter display
+handoff through `GraphqlHttpError::from_str` and returned static payment-owned
+messages. GraphQL server messages and HTTP/client detail therefore did not cross
+the public storefront envelope.
 
-That made GraphQL server messages and HTTP/client details part of a public UI
-transport envelope. Native storefront calls already used stable owner-owned
-messages, so the two payment transport paths had different error-safety policy.
+The shared structured event still copied two complete private values:
+
+- `raw_error = %raw_error`;
+- `parsed_error = ?parsed_error`.
+
+Those payloads were unnecessary for correlation, exact owner-operation
+attribution, or the closed five-category transport policy. This was a remaining
+non-`PortError` diagnostic-envelope gap in the ecommerce correlation-safe mapper
+cleanup.
 
 ## Consumer safety boundary
 
-The low-level adapter remains private and unchanged. The public payment
-transport consumer now creates a `GraphqlCallContext` immediately before each
-GraphQL call and maps only a returned `PaymentTransportError::Graphql`.
+The low-level adapter remains private and unchanged. The public payment transport
+consumer creates a `GraphqlCallContext` immediately before each GraphQL call and
+maps only a returned `PaymentTransportError::Graphql`.
 
 `PaymentTransportError::Validation` and `PaymentTransportError::ServerFn` are
 returned unchanged. There is no native-to-GraphQL fallback and transport
@@ -49,10 +56,10 @@ The consumer reparses the private adapter display using
 | `Graphql(_)` | `payment.storefront_graphql_request_rejected` | `Payment storefront request could not be completed` | warning |
 | unknown display | `payment.storefront_graphql_unknown_failure` | `Payment storefront request could not be completed` | error |
 
-The original raw display and parsed typed result remain internal diagnostic
-fields. Neither is copied into the returned `PaymentTransportError`.
+The original raw display is not copied into the returned
+`PaymentTransportError`. Validation and native variants remain pass-through.
 
-## Correlation and diagnostics
+## Correlation and bounded diagnostics
 
 Every selected GraphQL operation receives a unique correlation id with the
 shape:
@@ -61,19 +68,24 @@ shape:
 payment-storefront-graphql:{owner_operation}:{uuid}
 ```
 
-Internal events include:
+Internal events retain only:
 
 - truthful owner `rustok_payment.storefront`;
 - exact owner operation;
 - correlation id;
 - tenant slug configured/not-configured fact;
 - trimmed tenant slug character length when configured;
-- typed error kind;
-- stable code;
-- boundary `payment_storefront_graphql_transport`;
-- raw and parsed error details for server diagnostics only.
+- one closed error category: `network`, `http`, `unauthorized`, `graphql`, or
+  `unknown`;
+- stable internal code;
+- raw-display presence and character length;
+- whether typed `GraphqlHttpError` parsing succeeded;
+- boundary `payment_storefront_graphql_transport`.
 
-Diagnostics deliberately exclude:
+Raw GraphQL display text is not written to the event.
+Debug output from the parsed typed error is not written to the event.
+
+Diagnostics also exclude:
 
 - the tenant slug value;
 - authentication tokens or authorization headers;
@@ -85,7 +97,7 @@ Diagnostics deliberately exclude:
 
 ## Covered operations
 
-The public facade maps the following owner operations:
+The public facade retains the following exact owner operations:
 
 - `create_storefront_payment_collection`;
 - `read_storefront_payment_collection`;
@@ -107,30 +119,33 @@ This work does not change:
 - payment collection field mapping;
 - native server-function behavior;
 - feature-based native/GraphQL transport selection;
-- no-fallback behavior.
+- no-fallback behavior;
+- static public messages, stable codes, category severity, or non-GraphQL
+  pass-through behavior.
 
 ## Static evidence
 
 `scripts/verify/verify-payment-storefront-graphql-error-safety.mjs` guards:
 
 - private adapter and safety-module visibility;
-- all three consumer mappings;
-- exact owner operations;
-- typed display parsing and all error variants;
+- all three consumer mappings and exact owner operations;
+- typed display parsing and all closed error variants;
 - stable codes and public messages;
 - correlation and tenant-shape diagnostics;
+- bounded raw-display presence/length and typed-parse validity;
+- absence of raw GraphQL display text and parsed-error Debug output;
 - absence of raw tenant, query, variable, token, endpoint, request-id, and
   metadata fields;
 - unchanged native calls and transport selection;
 - unchanged low-level GraphQL handoffs;
-- unvalidated evidence flags.
+- truthful source/review evidence and unvalidated flags.
 
 ## Remaining work
 
-The ecommerce correlation-safe mapper item remains open for other payment,
-fulfillment, order, customer, tax, promotion, ecommerce, and non-`PortError`
-public envelopes. This slice does not promote FFA, FBA, transport, browser,
-runtime, or production status.
+The ecommerce correlation-safe mapper item remains open for payment checkout
+execution and compensation, remaining storefront/admin GraphQL adapters, other
+non-`PortError` public and diagnostic envelopes, and runtime evidence. This slice
+does not promote FFA, FBA, transport, browser, runtime, or production status.
 
 ## Suggested maintainer checks
 

--- a/crates/rustok-payment/storefront/src/transport/graphql_error_safety.rs
+++ b/crates/rustok-payment/storefront/src/transport/graphql_error_safety.rs
@@ -30,7 +30,10 @@ impl GraphqlCallContext {
         let PaymentTransportError::Graphql(raw_error) = error else {
             return error;
         };
+        let raw_error_present = !raw_error.trim().is_empty();
+        let raw_error_length = raw_error.chars().count();
         let parsed_error = GraphqlHttpError::from_str(raw_error.as_str());
+        let parsed_error_valid = parsed_error.is_ok();
         let (error_kind, code, public_message, technical_failure) = match &parsed_error {
             Ok(GraphqlHttpError::Network) => (
                 "network",
@@ -66,8 +69,9 @@ impl GraphqlCallContext {
 
         if technical_failure {
             tracing::error!(
-                raw_error = %raw_error,
-                parsed_error = ?parsed_error,
+                raw_error_present,
+                raw_error_length,
+                parsed_error_valid,
                 owner = PAYMENT_STOREFRONT_GRAPHQL_OWNER,
                 owner_operation = self.owner_operation,
                 correlation_id = %self.correlation_id,
@@ -80,8 +84,9 @@ impl GraphqlCallContext {
             );
         } else {
             tracing::warn!(
-                raw_error = %raw_error,
-                parsed_error = ?parsed_error,
+                raw_error_present,
+                raw_error_length,
+                parsed_error_valid,
                 owner = PAYMENT_STOREFRONT_GRAPHQL_OWNER,
                 owner_operation = self.owner_operation,
                 correlation_id = %self.correlation_id,

--- a/scripts/verify/verify-payment-storefront-graphql-error-safety.mjs
+++ b/scripts/verify/verify-payment-storefront-graphql-error-safety.mjs
@@ -21,6 +21,12 @@ const evidence = JSON.parse(
     'crates/rustok-payment/contracts/evidence/payment-storefront-graphql-error-safety-source.json',
   ),
 );
+const review = JSON.parse(
+  read(
+    'crates/rustok-payment/contracts/evidence/payment-storefront-graphql-error-safety-source-review.json',
+  ),
+);
+const document = read('crates/rustok-payment/docs/storefront-graphql-error-safety.md');
 
 const failures = [];
 const requireText = (content, value, label) => {
@@ -124,23 +130,32 @@ for (const [value, label] of [
   ['Uuid::new_v4()', 'unique correlation generation'],
   ['let PaymentTransportError::Graphql(raw_error) = error else', 'non-GraphQL pass-through'],
   ['return error;', 'same non-GraphQL error return'],
+  ['let raw_error_present = !raw_error.trim().is_empty();', 'raw display presence fact'],
+  ['let raw_error_length = raw_error.chars().count();', 'raw display length fact'],
   ['GraphqlHttpError::from_str(raw_error.as_str())', 'typed display parsing'],
+  ['let parsed_error_valid = parsed_error.is_ok();', 'typed parse validity fact'],
   ['Ok(GraphqlHttpError::Network)', 'network policy'],
   ['Ok(GraphqlHttpError::Http(_))', 'HTTP policy'],
   ['Ok(GraphqlHttpError::Unauthorized)', 'authentication policy'],
   ['Ok(GraphqlHttpError::Graphql(_))', 'GraphQL rejection policy'],
   ['Err(_)', 'unknown failure policy'],
+  ['"network"', 'closed network category'],
+  ['"http"', 'closed HTTP category'],
+  ['"unauthorized"', 'closed unauthorized category'],
+  ['"graphql"', 'closed GraphQL category'],
+  ['"unknown"', 'closed unknown category'],
   ['tracing::error!(', 'technical diagnostics'],
   ['tracing::warn!(', 'rejection diagnostics'],
-  ['raw_error = %raw_error', 'internal raw cause'],
-  ['parsed_error = ?parsed_error', 'typed internal cause'],
+  ['raw_error_present,', 'bounded raw display presence logging'],
+  ['raw_error_length,', 'bounded raw display length logging'],
+  ['parsed_error_valid,', 'bounded typed parse logging'],
   ['owner = PAYMENT_STOREFRONT_GRAPHQL_OWNER', 'truthful owner'],
   ['owner_operation = self.owner_operation', 'exact owner operation'],
   ['correlation_id = %self.correlation_id', 'correlation diagnostics'],
   ['tenant_slug_configured = self.tenant_slug_length.is_some()', 'tenant configuration fact'],
   ['tenant_slug_length = ?self.tenant_slug_length', 'tenant length fact'],
-  ['error_kind,', 'stable error kind'],
-  ['code,', 'stable public code'],
+  ['error_kind,', 'closed error category'],
+  ['code,', 'stable internal code'],
   ['boundary = PAYMENT_STOREFRONT_GRAPHQL_BOUNDARY', 'boundary diagnostics'],
   ['PaymentTransportError::Graphql(public_message.to_string())', 'static public GraphQL envelope'],
 ]) requireText(safety, value, label);
@@ -157,6 +172,10 @@ for (const [code, message, label] of [
 }
 
 for (const value of [
+  'raw_error = %raw_error',
+  'raw_error = ?raw_error',
+  'parsed_error = ?parsed_error',
+  'parsed_error = %parsed_error',
   'tenant_slug =',
   'tenant_slug = %',
   'graphql_query',
@@ -185,8 +204,14 @@ for (const [key, expected] of Object.entries({
   transport_selection_changed: false,
   request_response_dto_changed: false,
   graphql_query_changed: false,
+  raw_graphql_detail_logged: false,
+  parsed_graphql_error_debug_logged: false,
+  raw_graphql_detail_shape_logged: true,
+  typed_parse_validity_logged: true,
+  closed_graphql_error_category_logged: true,
   raw_graphql_error_public: false,
   raw_tenant_slug_logged: false,
+  broad_ecommerce_cleanup_closed: false,
 })) {
   if (evidence.source_contract?.[key] !== expected) {
     failures.push(`evidence source_contract.${key} must be ${expected}`);
@@ -208,6 +233,40 @@ for (const key of [
   }
 }
 
+if (
+  review.status !==
+  'payment_storefront_graphql_error_safety_source_reviewed_unvalidated'
+) failures.push(`review status mismatch: ${review.status}`);
+for (const [key, expected] of Object.entries({
+  typed_graphql_variant_policy: true,
+  static_public_graphql_messages: true,
+  raw_graphql_detail_logging_removed: true,
+  parsed_graphql_error_debug_logging_removed: true,
+  bounded_graphql_error_shape_retained: true,
+  all_three_public_operations_preserved: true,
+  per_call_correlation_id: true,
+  tenant_shape_only: true,
+  private_graphql_adapter_changed: false,
+  native_path_changed: false,
+  validation_path_changed: false,
+  graphql_queries_changed: false,
+  transport_selection_changed: false,
+  request_response_dto_changed: false,
+  runtime_evidence_claimed: false,
+})) {
+  if (review.implementation_review?.[key] !== expected) {
+    failures.push(`review implementation_review.${key} must be ${expected}`);
+  }
+}
+
+for (const marker of [
+  'Status: **source-ready / unvalidated**',
+  'Raw GraphQL display text is not written to the event.',
+  'Debug output from the parsed typed error is not written to the event.',
+  'raw-display presence and character length',
+  'The ecommerce correlation-safe mapper item remains open',
+]) requireText(document, marker, 'truthful payment GraphQL documentation');
+
 if (failures.length > 0) {
   console.error('Payment storefront GraphQL error-safety verification failed:');
   for (const failure of failures) console.error(`✗ ${failure}`);
@@ -215,5 +274,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ payment storefront GraphQL failures retain internal typed diagnostics and expose only static transport messages; runtime evidence remains open',
+  '✔ payment storefront GraphQL failures retain bounded error and tenant shape while exposing only static transport messages; runtime evidence remains open',
 );


### PR DESCRIPTION
## Summary

- continue the ecommerce correlation-safe mapper cleanup for the Payment storefront non-`PortError` GraphQL boundary
- preserve all three public operations, typed `GraphqlHttpError` classification, five stable codes, static public messages, severity, exact owner-operation attribution, per-call correlation, validation/native pass-through, explicit transport selection, and no-fallback behavior
- stop writing the complete private GraphQL display handoff and Debug representation of the parsed typed error into structured events
- retain only raw-display presence/character length, typed-parse validity, a closed five-value category, stable code, tenant configuration shape, and correlation
- update the focused fail-closed verifier, source/review evidence, and Payment documentation

## Recheck

The public payment GraphQL envelopes were already static and safe, but `crates/rustok-payment/storefront/src/transport/graphql_error_safety.rs` still logged `raw_error = %raw_error` and `parsed_error = ?parsed_error`. The existing verifier and documentation explicitly required/described those complete internal payloads. This PR closes only that diagnostic-envelope gap.

## Deliberate boundary

The broad ecommerce mapper cleanup remains open, including payment checkout execution/compensation diagnostics and other storefront/admin non-`PortError` envelopes. No DTO, GraphQL query or mutation, adapter request construction, validation order, native path, public transport variant, stable message/code, category severity, fallback policy, dependency, workflow, CI configuration, FFA/FBA status, or runtime-evidence status changes.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, CI, browser execution, or mounted runtime validation was executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-payment-storefront-graphql-error-safety.mjs
node scripts/verify/verify-payment-storefront-native-error-safety.mjs
node scripts/verify/verify-payment-storefront-boundary.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-payment-storefront
cargo check -p rustok-payment-storefront --features hydrate
cargo check -p rustok-payment-storefront --features ssr
```

Branch: `agent/payment-storefront-graphql-diagnostic-safety-20260801`
Base main: `d0c554d4a7b107215f113cf00d52dfdf3b8ab3e6`