### PR TITLE
test(forum): add reviewed LINK-FORUM-03 core evidence assembler

### DIFF
--- a/crates/rustok-forum/contracts/forum-search-link-forum-03-evidence-assembler.json
+++ b/crates/rustok-forum/contracts/forum-search-link-forum-03-evidence-assembler.json
@@ -1,0 +1,75 @@
+{
+  "contract": "forum_search_link_forum_03_evidence_assembler_v1",
+  "task": "FORUM-23B2G2B3D13",
+  "target_link": "LINK-FORUM-03",
+  "coverage": "ordering_visibility_and_search_disabled_core_only",
+  "status": "source_ready_maintainer_execution_pending",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "d0_parent": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json",
+  "d12_contract": "crates/rustok-forum/contracts/forum-search-versioned-invalidation-retained-evidence-promotion.json",
+  "assembler": "scripts/evidence/assemble-link-forum-03-forum-search-evidence.mjs",
+  "verifier": "scripts/verify/verify-link-forum-03-forum-search-evidence.mjs",
+  "required_inputs": [
+    "target/forum-search-versioned-invalidation-runtime-promotion-candidate.json",
+    "target/forum-search-versioned-invalidation-runtime-evidence.json",
+    "target/forum-search-versioned-invalidation-deletion-acl-ordering-evidence.json",
+    "target/forum-search-versioned-invalidation-search-disabled-recovery-evidence.json",
+    "target/forum-search-versioned-invalidation-normal-delivery-evidence.json"
+  ],
+  "output_artifact": {
+    "path": "target/link-forum-03-forum-index-search-ordering-visibility-evidence.json",
+    "generation": "assembler_only_after_d12_review_candidate",
+    "hand_editing_forbidden": true,
+    "source_commit_required": true,
+    "atomic_replace": true,
+    "automatic_canonical_source_mutation": false
+  },
+  "required_runtime_lineage": {
+    "normal_delivery": "FORUM-23B2G2B3D10:normal_delivery",
+    "ordering_and_visibility": "FORUM-23B2G2B3D8:deletion_acl_ordering",
+    "search_disabled_recovery": "FORUM-23B2G2B3D9:search_disabled_profile",
+    "retained_review": "FORUM-23B2G2B3D12:approved_for_canonical_status_promotion"
+  },
+  "fail_closed_requirements": [
+    "the canonical Forum plan still records FORUM-23 in_progress and LINK-FORUM-03 planned before downstream evidence assembly",
+    "the D12 promotion candidate has exact contract, task and approved status",
+    "the D12 candidate source commit equals git rev-parse HEAD and its proposed transition remains pending to runtime_evidence_reviewed",
+    "the D12 candidate parent-contract path, pending status and SHA-256 equal the current D0 parent bytes",
+    "the exact aggregate artifact bytes match the candidate SHA-256 and byte length",
+    "the aggregate retains exact D0 identity, runtime_evidence_assembled status, all ten frozen scenarios and PostgreSQL outbox_iggy profile",
+    "the D8, D9 and D10 source artifacts exist with exact task, contract, source commit, scenario identity, passed result and non-empty facts",
+    "the D8 and D9 source artifacts report broker_used false while D10 reports outbox_iggy, the canonical consumer group, topic and a non-empty stream",
+    "the D8, D9 and D10 source bytes match both the aggregate source_artifact digests and the D12 candidate retained source digests",
+    "the aggregate frozen scenario facts for normal_delivery, deletion_acl_ordering and search_disabled_profile equal the retained D10, D8 and D9 source facts",
+    "the output records the D12 reviewer and retention reference without claiming independent external-retention authentication",
+    "the output declares partial core coverage and cannot support a canonical LINK status change",
+    "the output is written only after complete validation by same-directory atomic rename",
+    "the assembler never edits D0, the canonical Forum plan, FORUM-23 or LINK-FORUM-03 status"
+  ],
+  "proves_after_maintainer_execution": [
+    "one real Forum owner transaction reaches external Iggy, durable Search ingress, production projection, delivery-covered checkpoint and exact storefront visibility",
+    "out-of-order and duplicate owner invalidations cannot restore hidden, deleted or richer-ACL-denied Forum content",
+    "current Forum owner reauthorization excludes stale denied Search rows from items, totals and facets",
+    "Forum owner writes remain available while Search storage and runtime are absent and late Search recovery rebuilds from the owner ledger",
+    "the normal, ordering/visibility and Search-disabled proofs share one reviewed source commit and retained evidence lineage"
+  ],
+  "remaining_link_forum_03_runtime_scope": [
+    "translation projection and retrieval",
+    "real moderation approval transition into Search visibility",
+    "topic move and category-scope projection update",
+    "exact private and trusted-channel exclusion runtime profile",
+    "separate review of the generated partial LINK artifact before any canonical plan change"
+  ],
+  "maintainer_commands": [
+    "node scripts/verify/verify-link-forum-03-forum-search-evidence.mjs",
+    "node scripts/evidence/assemble-link-forum-03-forum-search-evidence.mjs"
+  ],
+  "non_claims": [
+    "this source-ready slice does not claim that D8, D9, D10, D11 or D12 ran",
+    "this slice does not generate missing runtime evidence or accept static fixtures",
+    "this slice does not independently authenticate the external retention reference recorded by D12",
+    "this partial core artifact is not sufficient to mark LINK-FORUM-03 done",
+    "this slice does not promote D0, FORUM-23 or LINK-FORUM-03 in canonical source",
+    "this slice does not close arbitrary channel/group, topic-kind or attachment-presence scope"
+  ]
+}

--- a/crates/rustok-forum/docs/forum-23b2g2b3d13-link-forum-03-evidence-assembler.md
+++ b/crates/rustok-forum/docs/forum-23b2g2b3d13-link-forum-03-evidence-assembler.md
@@ -1,0 +1,161 @@
+# FORUM-23B2G2B3D13 LINK-FORUM-03 core evidence assembler
+
+## Status
+
+`source_ready_maintainer_execution_pending`
+
+This slice adds a fail-closed downstream evidence boundary for the already
+delivered ordering, visibility and Search-disabled core of canonical
+`LINK-FORUM-03`. It does not run PostgreSQL, Iggy, Forum, Search or storefront
+code and does not change the canonical `LINK-FORUM-03` status from `planned`.
+
+The machine contract is:
+
+```text
+crates/rustok-forum/contracts/forum-search-link-forum-03-evidence-assembler.json
+```
+
+The assembler is:
+
+```text
+scripts/evidence/assemble-link-forum-03-forum-search-evidence.mjs
+```
+
+The partial output path is:
+
+```text
+target/link-forum-03-forum-index-search-ordering-visibility-evidence.json
+```
+
+## Why this is downstream of D12
+
+The D0 evidence chain deliberately separates executable runtime proofs from
+review and retention:
+
+- D8 proves deletion, richer ACL, reverse/stale delivery and storefront
+  fail-closed visibility;
+- D9 proves Forum owner writes while Search storage/runtime are absent and one
+  late owner-ledger recovery after Search is enabled;
+- D10 proves one correlated real Forum owner transaction through external Iggy,
+  durable Search ingress, production projection, delivery-covered checkpoint and
+  exact storefront visibility;
+- D11 assembles all D2-D10 runtime artifacts from one exact source commit;
+- D12 re-reads the aggregate and every retained source artifact, requires an
+  explicit reviewer and retained SHA-256 attestation, and writes a promotion
+  candidate without mutating canonical source.
+
+D13 does not replace those gates. It requires their retained outputs and derives
+only the partial cross-module evidence already supported by D8, D9 and D10.
+
+## Required artifacts
+
+All five files must exist on the same checked-out commit:
+
+```text
+target/forum-search-versioned-invalidation-runtime-promotion-candidate.json
+target/forum-search-versioned-invalidation-runtime-evidence.json
+target/forum-search-versioned-invalidation-deletion-acl-ordering-evidence.json
+target/forum-search-versioned-invalidation-search-disabled-recovery-evidence.json
+target/forum-search-versioned-invalidation-normal-delivery-evidence.json
+```
+
+Skipped tests do not create acceptable evidence. Static fixtures, copied JSON,
+manually edited facts and mixed-commit artifacts are rejected.
+
+## Fail-closed lineage validation
+
+Before writing the partial LINK artifact, the assembler requires:
+
+1. exact D13 and D12 machine-contract identities and pending source statuses;
+2. the canonical Forum plan to still record `FORUM-23` as `in_progress` and
+   `LINK-FORUM-03` as `planned`;
+3. the D0 parent to retain its exact identity, pending status, output path and
+   frozen ten-scenario order;
+4. the D12 candidate to be
+   `approved_for_canonical_status_promotion` for the current `HEAD`;
+5. the candidate transition to remain
+   `source_ready_maintainer_execution_pending -> runtime_evidence_reviewed` and
+   require a separate canonical-source pull request;
+6. the candidate parent-contract path, status and SHA-256 to match the exact
+   current D0 bytes;
+7. the aggregate bytes, byte length, generated time, scenario list and SHA-256
+   to match both the D12 candidate and the maintainer retention attestation;
+8. the aggregate to retain the exact ten frozen scenarios, all nine D2-D10
+   source tasks and the completed D11 assembly invariants;
+9. exact D8, D9 and D10 contracts, tasks, scenario IDs, `passed` results,
+   PostgreSQL backend and non-empty facts;
+10. D8 and D9 to report `broker_used = false`, and D10 to report `outbox_iggy`,
+    the canonical consumer group, topic `domain` and a non-empty external stream;
+11. D8, D9 and D10 source bytes to match the digest, length, generated time and
+    source commit retained in both the D11 aggregate and D12 candidate;
+12. aggregate `normal_delivery`, `deletion_acl_ordering` and
+    `search_disabled_profile` facts to equal the original D10, D8 and D9 facts;
+13. same-directory atomic output after all validation succeeds.
+
+There is no missing-artifact mode, best-effort mode, source-commit override,
+skipped-result acceptance or static fallback.
+
+## Evidence represented by the output
+
+After maintainer execution, the generated partial LINK artifact records:
+
+- the correlated Forum owner -> external Iggy -> durable Search inbox ->
+  production projector -> delivery-covered checkpoint -> storefront path from
+  D10;
+- the D8 reverse/stale and duplicate delivery proof showing that hidden, deleted
+  and richer-ACL-denied owner content is not restored;
+- current-owner reauthorization excluding deliberately stale denied Search rows
+  before visible items, totals and facets;
+- D9 Search-disabled Forum owner continuity and late owner-ledger recovery;
+- exact canonical-plan, D0 parent, D8, D9, D10, D11 aggregate and D12
+  promotion-candidate digests;
+- the D12 reviewer identity, review time and immutable retention reference;
+- the single reviewed source commit shared by the complete retained lineage.
+
+The assembler records that it did not independently authenticate the external
+retention service. It validates the explicit D12 retention attestation and exact
+retained bytes only.
+
+## Remaining LINK-FORUM-03 runtime scope
+
+This partial artifact cannot mark `LINK-FORUM-03` done. Separate executable
+runtime evidence is still required for:
+
+- translation projection and retrieval;
+- a real moderation approval transition into Search visibility;
+- topic move and category-scope projection update;
+- an exact private and trusted-channel exclusion profile;
+- review of the final combined LINK artifact before any canonical plan change.
+
+The assembler therefore writes:
+
+```text
+status = partial_runtime_evidence_assembled
+coverage = ordering_visibility_and_search_disabled_core_only
+status_change_allowed_from_this_artifact = false
+```
+
+## Maintainer order
+
+On one exact commit, execute the D2-D10 commands, D11 assembler and D12 reviewer
+from their contracts. Retain every generated artifact, then run:
+
+```bash
+node scripts/verify/verify-link-forum-03-forum-search-evidence.mjs
+node scripts/evidence/assemble-link-forum-03-forum-search-evidence.mjs
+```
+
+A later bounded slice must add the remaining executable LINK scenarios and
+assemble a final reviewed artifact. Only that later complete artifact may support
+another canonical-source pull request.
+
+## Deliberate boundary
+
+D13 adds scripts, documentation and a machine contract only. It changes no Rust
+production path, migration, event schema or digest, DTO, runtime flag,
+dependency, `Cargo.toml` or `Cargo.lock` entry.
+
+It does not close arbitrary channel/group filtering, topic kinds or attachment
+presence. Those remain blocked on their named owner contracts.
+
+No command above was run by the implementation agent, per maintainer request.

--- a/scripts/evidence/assemble-link-forum-03-forum-search-evidence.mjs
+++ b/scripts/evidence/assemble-link-forum-03-forum-search-evidence.mjs
@@ -1,0 +1,647 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const root = process.cwd();
+const contractPath =
+  "crates/rustok-forum/contracts/forum-search-link-forum-03-evidence-assembler.json";
+const forumPlanPath = "crates/rustok-forum/docs/implementation-plan.md";
+const d0Path =
+  "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json";
+const d12ContractPath =
+  "crates/rustok-forum/contracts/forum-search-versioned-invalidation-retained-evidence-promotion.json";
+const candidatePath =
+  "target/forum-search-versioned-invalidation-runtime-promotion-candidate.json";
+const aggregatePath =
+  "target/forum-search-versioned-invalidation-runtime-evidence.json";
+const d8Path =
+  "target/forum-search-versioned-invalidation-deletion-acl-ordering-evidence.json";
+const d9Path =
+  "target/forum-search-versioned-invalidation-search-disabled-recovery-evidence.json";
+const d10Path =
+  "target/forum-search-versioned-invalidation-normal-delivery-evidence.json";
+const outputPath =
+  "target/link-forum-03-forum-index-search-ordering-visibility-evidence.json";
+
+const frozenScenarioIds = [
+  "normal_delivery",
+  "legacy_first_duplicate",
+  "typed_first_duplicate",
+  "acknowledgement_failure_restart",
+  "raw_poison_dlq_redelivery",
+  "semantic_poison_identity_conflict",
+  "missing_delivery_owner_repair",
+  "multi_process_serialization",
+  "deletion_acl_ordering",
+  "search_disabled_profile",
+];
+const sourceTaskOrder = [
+  "FORUM-23B2G2B3D2",
+  "FORUM-23B2G2B3D3",
+  "FORUM-23B2G2B3D4",
+  "FORUM-23B2G2B3D5",
+  "FORUM-23B2G2B3D6",
+  "FORUM-23B2G2B3D7",
+  "FORUM-23B2G2B3D8",
+  "FORUM-23B2G2B3D9",
+  "FORUM-23B2G2B3D10",
+];
+const selectedSources = [
+  {
+    task: "FORUM-23B2G2B3D8",
+    contract:
+      "forum_search_versioned_invalidation_deletion_acl_ordering_evidence_v1",
+    path: d8Path,
+    scenario: "deletion_acl_ordering",
+    profile: "no_broker",
+  },
+  {
+    task: "FORUM-23B2G2B3D9",
+    contract:
+      "forum_search_versioned_invalidation_search_disabled_recovery_evidence_v1",
+    path: d9Path,
+    scenario: "search_disabled_profile",
+    profile: "no_broker",
+  },
+  {
+    task: "FORUM-23B2G2B3D10",
+    contract: "forum_search_versioned_invalidation_normal_delivery_evidence_v1",
+    path: d10Path,
+    scenario: "normal_delivery",
+    profile: "external_iggy",
+  },
+];
+const remainingScope = [
+  "translation projection and retrieval",
+  "real moderation approval transition into Search visibility",
+  "topic move and category-scope projection update",
+  "exact private and trusted-channel exclusion runtime profile",
+  "separate review of this partial artifact before any canonical plan change",
+];
+
+function fail(message) {
+  throw new Error(`LINK-FORUM-03 core evidence assembly failed: ${message}`);
+}
+
+function readBytes(path) {
+  try {
+    return readFileSync(resolve(root, path));
+  } catch (error) {
+    fail(`cannot read ${path}: ${error.message}`);
+  }
+}
+
+function parseJson(path, bytes) {
+  try {
+    return JSON.parse(bytes.toString("utf8"));
+  } catch (error) {
+    fail(`${path} is not valid JSON: ${error.message}`);
+  }
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+}
+
+function requireExactArray(actual, expected, label) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    fail(`${label} order or membership drifted`);
+  }
+}
+
+function requireNonEmptyString(value, label) {
+  if (typeof value !== "string" || value.trim() !== value || value.length === 0) {
+    fail(`${label} must be a non-empty trimmed string`);
+  }
+}
+
+function requireCommit(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{40}$/.test(value)) {
+    fail(`${label} must be one lowercase forty-character Git SHA`);
+  }
+}
+
+function requireDigest(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/.test(value)) {
+    fail(`${label} must be one lowercase SHA-256 digest`);
+  }
+}
+
+function requireTimestamp(value, label) {
+  if (typeof value !== "string" || !Number.isFinite(Date.parse(value))) {
+    fail(`${label} must be an ISO timestamp`);
+  }
+}
+
+function requireFacts(value, label) {
+  requireObject(value, label);
+  if (Object.keys(value).length === 0) {
+    fail(`${label} must not be empty`);
+  }
+}
+
+function currentHead() {
+  let head;
+  try {
+    head = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (error) {
+    fail(`git rev-parse HEAD failed: ${error.message}`);
+  }
+  requireCommit(head, "git rev-parse HEAD");
+  return head;
+}
+
+function validateMachineContract(contract) {
+  requireObject(contract, "D13 machine contract");
+  if (
+    contract.contract !== "forum_search_link_forum_03_evidence_assembler_v1" ||
+    contract.task !== "FORUM-23B2G2B3D13" ||
+    contract.target_link !== "LINK-FORUM-03" ||
+    contract.coverage !== "ordering_visibility_and_search_disabled_core_only" ||
+    contract.status !== "source_ready_maintainer_execution_pending" ||
+    contract.canonical_plan !== forumPlanPath ||
+    contract.d0_parent !== d0Path ||
+    contract.d12_contract !== d12ContractPath ||
+    contract.assembler !==
+      "scripts/evidence/assemble-link-forum-03-forum-search-evidence.mjs" ||
+    contract.output_artifact?.path !== outputPath ||
+    contract.output_artifact?.hand_editing_forbidden !== true ||
+    contract.output_artifact?.source_commit_required !== true ||
+    contract.output_artifact?.atomic_replace !== true ||
+    contract.output_artifact?.automatic_canonical_source_mutation !== false
+  ) {
+    fail("D13 machine contract identity or output policy drifted");
+  }
+  requireExactArray(
+    contract.required_inputs,
+    [candidatePath, aggregatePath, d8Path, d9Path, d10Path],
+    "D13 required inputs",
+  );
+  requireExactArray(
+    contract.remaining_link_forum_03_runtime_scope,
+    remainingScope,
+    "D13 remaining LINK scope",
+  );
+}
+
+function validateCanonicalPlan(plan) {
+  for (const marker of [
+    "| `FORUM-23` | `in_progress` |",
+    "maintainer PostgreSQL/Iggy plus LINK-FORUM-03 runtime evidence remain",
+    "| `LINK-FORUM-03` | `planned` | Forum/index/search ordering and visibility proof. |",
+    "## `LINK-FORUM-03` — index and search",
+    "**Status:** `planned`",
+    "**Dependencies:** FORUM-20/23",
+    "Prove publish, translation, moderation approval, move, hide/delete, ACL change,",
+    "out-of-order events and search-disabled behavior",
+  ]) {
+    if (!plan.includes(marker)) {
+      fail(`canonical Forum plan is missing pending marker: ${marker}`);
+    }
+  }
+  if (
+    plan.includes("| `LINK-FORUM-03` | `done` |") ||
+    plan.includes("LINK-FORUM-03 runtime evidence passed")
+  ) {
+    fail("canonical Forum plan already claims LINK-FORUM-03 completion");
+  }
+}
+
+function validateD0(d0) {
+  requireObject(d0, "D0 parent contract");
+  if (
+    d0.contract !== "forum_search_versioned_invalidation_runtime_evidence_v1" ||
+    d0.task !== "FORUM-23B2G2B3D0" ||
+    d0.status !== "source_ready_maintainer_execution_pending" ||
+    d0.evidence_artifact?.path !== aggregatePath
+  ) {
+    fail("D0 parent identity, status or output path drifted");
+  }
+  requireExactArray(
+    d0.required_scenarios?.map(({ id }) => id),
+    frozenScenarioIds,
+    "D0 frozen scenarios",
+  );
+}
+
+function validateD12Contract(contract) {
+  requireObject(contract, "D12 machine contract");
+  if (
+    contract.contract !==
+      "forum_search_versioned_invalidation_retained_evidence_promotion_v1" ||
+    contract.task !== "FORUM-23B2G2B3D12" ||
+    contract.status !== "source_ready_maintainer_execution_pending" ||
+    contract.aggregate_artifact !== aggregatePath ||
+    contract.promotion_candidate?.path !== candidatePath ||
+    contract.proposed_transition?.from !==
+      "source_ready_maintainer_execution_pending" ||
+    contract.proposed_transition?.to !== "runtime_evidence_reviewed" ||
+    contract.proposed_transition?.requires_separate_canonical_source_pull_request !==
+      true ||
+    contract.proposed_transition?.closes_forum_23 !== false ||
+    contract.proposed_transition?.closes_link_forum_03 !== false
+  ) {
+    fail("D12 contract identity or transition boundary drifted");
+  }
+}
+
+function validateSource(entry, head) {
+  const bytes = readBytes(entry.path);
+  const artifact = parseJson(entry.path, bytes);
+  requireObject(artifact, entry.path);
+  if (
+    artifact.task !== entry.task ||
+    artifact.contract !== entry.contract ||
+    artifact.source_commit !== head ||
+    artifact.database_backend !== "postgresql"
+  ) {
+    fail(`${entry.path} identity, commit or database profile drifted`);
+  }
+  requireTimestamp(artifact.generated_at, `${entry.path}.generated_at`);
+  if (entry.profile === "no_broker") {
+    if (artifact.broker_used !== false) {
+      fail(`${entry.path} must report broker_used false`);
+    }
+  } else if (
+    artifact.delivery_profile !== "outbox_iggy" ||
+    artifact.consumer_group !== "rustok-search-forum-projection-v1" ||
+    artifact.topic !== "domain" ||
+    typeof artifact.stream !== "string" ||
+    artifact.stream.trim().length === 0
+  ) {
+    fail(`${entry.path} external Iggy profile drifted`);
+  }
+  if (!Array.isArray(artifact.scenario_results)) {
+    fail(`${entry.path}.scenario_results must be an array`);
+  }
+  requireExactArray(
+    artifact.scenario_results.map(({ id }) => id),
+    [entry.scenario],
+    `${entry.path} scenarios`,
+  );
+  const scenario = artifact.scenario_results[0];
+  if (scenario.result !== "passed") {
+    fail(`${entry.path} scenario did not pass`);
+  }
+  requireFacts(scenario.facts, `${entry.path} scenario facts`);
+  return {
+    entry,
+    artifact,
+    scenario,
+    bytes,
+    digest: sha256(bytes),
+  };
+}
+
+function findRetained(records, task, label) {
+  if (!Array.isArray(records)) {
+    fail(`${label} must be an array`);
+  }
+  const matches = records.filter((record) => record.task === task);
+  if (matches.length !== 1) {
+    fail(`${label} must retain ${task} exactly once`);
+  }
+  return matches[0];
+}
+
+function validateRetainedRecord(record, source, head, label) {
+  if (
+    record.task !== source.entry.task ||
+    record.contract !== source.entry.contract ||
+    record.path !== source.entry.path ||
+    record.source_commit !== head ||
+    record.generated_at !== source.artifact.generated_at ||
+    record.sha256 !== source.digest ||
+    record.byte_length !== source.bytes.length
+  ) {
+    fail(`${label} metadata or digest drifted`);
+  }
+  requireExactArray(
+    record.scenario_ids,
+    [source.entry.scenario],
+    `${label} scenarios`,
+  );
+}
+
+function validateAggregate(aggregate, aggregateBytes, d0Bytes, head, sources) {
+  requireObject(aggregate, "D0 aggregate artifact");
+  if (
+    aggregate.contract !== "forum_search_versioned_invalidation_runtime_evidence_v1" ||
+    aggregate.task !== "FORUM-23B2G2B3D0" ||
+    aggregate.status !== "runtime_evidence_assembled" ||
+    aggregate.source_commit !== head ||
+    aggregate.database_backend !== "postgresql" ||
+    aggregate.delivery_profile !== "outbox_iggy" ||
+    aggregate.consumer_group !== "rustok-search-forum-projection-v1" ||
+    aggregate.topic !== "domain"
+  ) {
+    fail("aggregate identity, commit or runtime profile drifted");
+  }
+  requireTimestamp(aggregate.generated_at, "aggregate.generated_at");
+  if (!Array.isArray(aggregate.scenario_results)) {
+    fail("aggregate scenario_results must be an array");
+  }
+  requireExactArray(
+    aggregate.scenario_results.map(({ id }) => id),
+    frozenScenarioIds,
+    "aggregate frozen scenarios",
+  );
+  for (const scenario of aggregate.scenario_results) {
+    if (scenario.result !== "passed") {
+      fail(`aggregate scenario ${scenario.id} did not pass`);
+    }
+    requireFacts(scenario.facts, `aggregate scenario ${scenario.id} facts`);
+  }
+  if (!Array.isArray(aggregate.source_artifacts)) {
+    fail("aggregate source_artifacts must be an array");
+  }
+  requireExactArray(
+    aggregate.source_artifacts.map(({ task }) => task),
+    sourceTaskOrder,
+    "aggregate source tasks",
+  );
+  requireObject(aggregate.assembly, "aggregate assembly record");
+  if (
+    aggregate.assembly.parent_contract !== d0Path ||
+    aggregate.assembly.parent_contract_sha256 !== sha256(d0Bytes) ||
+    aggregate.assembly.input_artifact_count !== 9 ||
+    aggregate.assembly.frozen_scenario_count !== 10 ||
+    aggregate.assembly.all_inputs_same_source_commit !== true ||
+    aggregate.assembly.source_commit_matches_current_head !== true ||
+    aggregate.assembly.output_written_after_complete_validation !== true
+  ) {
+    fail("aggregate assembly record is incomplete or stale");
+  }
+
+  const selected = {};
+  for (const source of sources) {
+    const retained = findRetained(
+      aggregate.source_artifacts,
+      source.entry.task,
+      "aggregate source_artifacts",
+    );
+    validateRetainedRecord(retained, source, head, `aggregate ${source.entry.task}`);
+    const matches = aggregate.scenario_results.filter(
+      ({ id }) => id === source.entry.scenario,
+    );
+    if (matches.length !== 1) {
+      fail(`aggregate must retain ${source.entry.scenario} exactly once`);
+    }
+    const scenario = matches[0];
+    if (
+      scenario.source_task !== source.entry.task ||
+      scenario.source_contract !== source.entry.contract ||
+      scenario.source_artifact !== source.entry.path ||
+      scenario.source_scenario_id !== source.entry.scenario ||
+      JSON.stringify(scenario.facts) !== JSON.stringify(source.scenario.facts)
+    ) {
+      fail(`aggregate ${source.entry.scenario} attribution or facts drifted`);
+    }
+    selected[source.entry.scenario] = scenario;
+  }
+  return {
+    digest: sha256(aggregateBytes),
+    generatedAt: aggregate.generated_at,
+    selected,
+  };
+}
+
+function validateCandidate(
+  candidate,
+  candidateBytes,
+  aggregateBytes,
+  aggregateReview,
+  d0,
+  d0Bytes,
+  head,
+  sources,
+) {
+  requireObject(candidate, "D12 promotion candidate");
+  if (
+    candidate.contract !==
+      "forum_search_versioned_invalidation_runtime_promotion_candidate_v1" ||
+    candidate.task !== "FORUM-23B2G2B3D12" ||
+    candidate.status !== "approved_for_canonical_status_promotion" ||
+    candidate.source_commit !== head
+  ) {
+    fail("D12 candidate identity, status or source commit drifted");
+  }
+  requireTimestamp(candidate.reviewed_at, "candidate.reviewed_at");
+  requireNonEmptyString(candidate.reviewer, "candidate.reviewer");
+  requireObject(candidate.retention, "candidate.retention");
+  requireNonEmptyString(candidate.retention.reference, "candidate.retention.reference");
+  requireDigest(candidate.retention.attested_sha256, "candidate retained digest");
+  if (
+    candidate.retention.matches_reviewed_aggregate !== true ||
+    candidate.retention.external_service_authentication_performed_by_script !== false
+  ) {
+    fail("candidate retention boundary drifted");
+  }
+  requireObject(candidate.parent_contract, "candidate.parent_contract");
+  if (
+    candidate.parent_contract.path !== d0Path ||
+    candidate.parent_contract.sha256 !== sha256(d0Bytes) ||
+    candidate.parent_contract.status_at_review !== d0.status
+  ) {
+    fail("candidate parent-contract identity or digest drifted");
+  }
+  requireObject(candidate.aggregate_artifact, "candidate.aggregate_artifact");
+  if (
+    candidate.aggregate_artifact.path !== aggregatePath ||
+    candidate.aggregate_artifact.sha256 !== aggregateReview.digest ||
+    candidate.aggregate_artifact.byte_length !== aggregateBytes.length ||
+    candidate.aggregate_artifact.generated_at !== aggregateReview.generatedAt ||
+    candidate.retention.attested_sha256 !== aggregateReview.digest
+  ) {
+    fail("candidate aggregate metadata or retained digest drifted");
+  }
+  requireExactArray(
+    candidate.aggregate_artifact.scenario_ids,
+    frozenScenarioIds,
+    "candidate aggregate scenarios",
+  );
+  if (!Array.isArray(candidate.source_artifacts)) {
+    fail("candidate source_artifacts must be an array");
+  }
+  requireExactArray(
+    candidate.source_artifacts.map(({ task }) => task),
+    sourceTaskOrder,
+    "candidate source tasks",
+  );
+  for (const source of sources) {
+    const retained = findRetained(
+      candidate.source_artifacts,
+      source.entry.task,
+      "candidate source_artifacts",
+    );
+    validateRetainedRecord(retained, source, head, `candidate ${source.entry.task}`);
+  }
+  requireObject(candidate.validation, "candidate.validation");
+  for (const field of [
+    "all_ten_frozen_scenarios_passed",
+    "all_nine_source_artifacts_revalidated",
+    "all_source_digests_match_aggregate",
+    "aggregate_parent_digest_matches_current_d0",
+    "aggregate_source_commit_matches_current_head",
+    "retained_digest_attested_by_maintainer",
+  ]) {
+    if (candidate.validation[field] !== true) {
+      fail(`candidate validation.${field} must be true`);
+    }
+  }
+  if (
+    candidate.proposed_transition?.from !==
+      "source_ready_maintainer_execution_pending" ||
+    candidate.proposed_transition?.to !== "runtime_evidence_reviewed" ||
+    candidate.proposed_transition?.separate_canonical_source_pull_request_required !==
+      true ||
+    candidate.proposed_transition?.canonical_source_mutated_by_reviewer !== false ||
+    candidate.proposed_transition?.closes_forum_23 !== false ||
+    candidate.proposed_transition?.closes_link_forum_03 !== false
+  ) {
+    fail("candidate proposed transition boundary drifted");
+  }
+  return {
+    digest: sha256(candidateBytes),
+    reviewedAt: candidate.reviewed_at,
+    reviewer: candidate.reviewer,
+    retentionReference: candidate.retention.reference,
+    retainedAggregateDigest: candidate.retention.attested_sha256,
+  };
+}
+
+if (process.argv.length !== 2) {
+  fail("this assembler accepts no command-line arguments");
+}
+
+const head = currentHead();
+const contractBytes = readBytes(contractPath);
+validateMachineContract(parseJson(contractPath, contractBytes));
+const forumPlanBytes = readBytes(forumPlanPath);
+validateCanonicalPlan(forumPlanBytes.toString("utf8"));
+const d0Bytes = readBytes(d0Path);
+const d0 = parseJson(d0Path, d0Bytes);
+validateD0(d0);
+const d12ContractBytes = readBytes(d12ContractPath);
+validateD12Contract(parseJson(d12ContractPath, d12ContractBytes));
+
+const sources = selectedSources.map((entry) => validateSource(entry, head));
+const aggregateBytes = readBytes(aggregatePath);
+const aggregate = parseJson(aggregatePath, aggregateBytes);
+const aggregateReview = validateAggregate(
+  aggregate,
+  aggregateBytes,
+  d0Bytes,
+  head,
+  sources,
+);
+const candidateBytes = readBytes(candidatePath);
+const candidate = parseJson(candidatePath, candidateBytes);
+const candidateReview = validateCandidate(
+  candidate,
+  candidateBytes,
+  aggregateBytes,
+  aggregateReview,
+  d0,
+  d0Bytes,
+  head,
+  sources,
+);
+
+const evidenceByScenario = Object.fromEntries(
+  sources.map((source) => [
+    source.entry.scenario,
+    {
+      source_task: source.entry.task,
+      source_contract: source.entry.contract,
+      source_artifact: source.entry.path,
+      source_sha256: source.digest,
+      facts: aggregateReview.selected[source.entry.scenario].facts,
+    },
+  ]),
+);
+const output = {
+  contract: "link_forum_03_forum_index_search_ordering_visibility_evidence_v1",
+  task: "LINK-FORUM-03",
+  source_slice: "FORUM-23B2G2B3D13",
+  status: "partial_runtime_evidence_assembled",
+  coverage: "ordering_visibility_and_search_disabled_core_only",
+  source_commit: head,
+  generated_at: new Date().toISOString(),
+  runtime_profile: {
+    database_backend: "postgresql",
+    delivery_profile: "outbox_iggy",
+    consumer_group: "rustok-search-forum-projection-v1",
+    topic: "domain",
+  },
+  selected_scenario_evidence: evidenceByScenario,
+  retained_lineage: {
+    canonical_plan_path: forumPlanPath,
+    canonical_plan_sha256: sha256(forumPlanBytes),
+    d0_parent_path: d0Path,
+    d0_parent_sha256: sha256(d0Bytes),
+    aggregate_path: aggregatePath,
+    aggregate_sha256: aggregateReview.digest,
+    promotion_candidate_path: candidatePath,
+    promotion_candidate_sha256: candidateReview.digest,
+    reviewed_at: candidateReview.reviewedAt,
+    reviewer: candidateReview.reviewer,
+    retention_reference: candidateReview.retentionReference,
+    retained_aggregate_sha256: candidateReview.retainedAggregateDigest,
+    external_retention_authentication_performed_by_assembler: false,
+  },
+  assertions: {
+    real_forum_owner_to_iggy_to_search_to_storefront_trace_passed: true,
+    projection_completed_before_delivery_covered_checkpoint: true,
+    out_of_order_and_duplicate_delivery_did_not_restore_denied_content: true,
+    stale_denied_rows_were_reauthorized_before_items_totals_and_facets: true,
+    forum_owner_writes_survived_search_disabled_profile: true,
+    late_search_recovery_rebuilt_from_owner_revision_ledger: true,
+    selected_proofs_share_one_reviewed_source_commit: true,
+    canonical_source_mutated_by_assembler: false,
+  },
+  remaining_link_forum_03_runtime_scope: remainingScope,
+  canonical_transition: {
+    link_status_before_review: "planned",
+    status_change_allowed_from_this_artifact: false,
+    reason: "partial ordering, visibility and Search-disabled core evidence only",
+    separate_follow_up_runtime_evidence_required: true,
+    closes_forum_23_automatically: false,
+    closes_link_forum_03_automatically: false,
+  },
+};
+
+const absoluteOutput = resolve(root, outputPath);
+mkdirSync(dirname(absoluteOutput), { recursive: true });
+const temporaryOutput = `${absoluteOutput}.${process.pid}.${Date.now()}.tmp`;
+try {
+  writeFileSync(temporaryOutput, `${JSON.stringify(output, null, 2)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+  });
+  renameSync(temporaryOutput, absoluteOutput);
+} catch (error) {
+  rmSync(temporaryOutput, { force: true });
+  fail(`atomic LINK-FORUM-03 output write failed: ${error.message}`);
+}
+
+console.log(`wrote validated partial LINK-FORUM-03 evidence to ${outputPath}`);

--- a/scripts/verify/verify-link-forum-03-forum-search-evidence.mjs
+++ b/scripts/verify/verify-link-forum-03-forum-search-evidence.mjs
@@ -1,0 +1,362 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = process.cwd();
+const read = (path) => readFileSync(resolve(root, path), "utf8");
+const requireAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(text.includes(marker), `${label} is missing marker: ${marker}`);
+  }
+};
+const forbidAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(!text.includes(marker), `${label} contains forbidden marker: ${marker}`);
+  }
+};
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-search-link-forum-03-evidence-assembler.json";
+const docPath =
+  "crates/rustok-forum/docs/forum-23b2g2b3d13-link-forum-03-evidence-assembler.md";
+const assemblerPath =
+  "scripts/evidence/assemble-link-forum-03-forum-search-evidence.mjs";
+const verifierPath =
+  "scripts/verify/verify-link-forum-03-forum-search-evidence.mjs";
+const forumPlanPath = "crates/rustok-forum/docs/implementation-plan.md";
+const searchPlanPath = "crates/rustok-search/docs/implementation-plan.md";
+const d0Path =
+  "crates/rustok-forum/contracts/forum-search-versioned-invalidation-runtime-evidence.json";
+const d12Path =
+  "crates/rustok-forum/contracts/forum-search-versioned-invalidation-retained-evidence-promotion.json";
+const d12ReviewerPath =
+  "scripts/evidence/review-forum-search-versioned-invalidation-runtime-evidence.mjs";
+const d8TestPath =
+  "apps/server/tests/forum_versioned_invalidation_deletion_acl_ordering.rs";
+const d9TestPath =
+  "apps/server/tests/forum_versioned_invalidation_search_disabled_recovery.rs";
+const d10TestPath =
+  "apps/server/tests/forum_versioned_invalidation_normal_delivery_iggy.rs";
+const candidatePath =
+  "target/forum-search-versioned-invalidation-runtime-promotion-candidate.json";
+const aggregatePath =
+  "target/forum-search-versioned-invalidation-runtime-evidence.json";
+const d8Path =
+  "target/forum-search-versioned-invalidation-deletion-acl-ordering-evidence.json";
+const d9Path =
+  "target/forum-search-versioned-invalidation-search-disabled-recovery-evidence.json";
+const d10Path =
+  "target/forum-search-versioned-invalidation-normal-delivery-evidence.json";
+const outputPath =
+  "target/link-forum-03-forum-index-search-ordering-visibility-evidence.json";
+const remainingScope = [
+  "translation projection and retrieval",
+  "real moderation approval transition into Search visibility",
+  "topic move and category-scope projection update",
+  "exact private and trusted-channel exclusion runtime profile",
+  "separate review of the generated partial LINK artifact before any canonical plan change",
+];
+
+const contract = JSON.parse(read(contractPath));
+assert.equal(contract.contract, "forum_search_link_forum_03_evidence_assembler_v1");
+assert.equal(contract.task, "FORUM-23B2G2B3D13");
+assert.equal(contract.target_link, "LINK-FORUM-03");
+assert.equal(contract.coverage, "ordering_visibility_and_search_disabled_core_only");
+assert.equal(contract.status, "source_ready_maintainer_execution_pending");
+assert.equal(contract.canonical_plan, forumPlanPath);
+assert.equal(contract.d0_parent, d0Path);
+assert.equal(contract.d12_contract, d12Path);
+assert.equal(contract.assembler, assemblerPath);
+assert.equal(contract.verifier, verifierPath);
+assert.deepEqual(contract.required_inputs, [
+  candidatePath,
+  aggregatePath,
+  d8Path,
+  d9Path,
+  d10Path,
+]);
+assert.equal(contract.output_artifact.path, outputPath);
+assert.equal(
+  contract.output_artifact.generation,
+  "assembler_only_after_d12_review_candidate",
+);
+assert.equal(contract.output_artifact.hand_editing_forbidden, true);
+assert.equal(contract.output_artifact.source_commit_required, true);
+assert.equal(contract.output_artifact.atomic_replace, true);
+assert.equal(contract.output_artifact.automatic_canonical_source_mutation, false);
+assert.equal(
+  contract.required_runtime_lineage.ordering_and_visibility,
+  "FORUM-23B2G2B3D8:deletion_acl_ordering",
+);
+assert.equal(
+  contract.required_runtime_lineage.search_disabled_recovery,
+  "FORUM-23B2G2B3D9:search_disabled_profile",
+);
+assert.equal(
+  contract.required_runtime_lineage.normal_delivery,
+  "FORUM-23B2G2B3D10:normal_delivery",
+);
+assert.equal(
+  contract.required_runtime_lineage.retained_review,
+  "FORUM-23B2G2B3D12:approved_for_canonical_status_promotion",
+);
+assert.deepEqual(contract.remaining_link_forum_03_runtime_scope, remainingScope);
+assert.deepEqual(contract.maintainer_commands, [
+  `node ${verifierPath}`,
+  `node ${assemblerPath}`,
+]);
+assert.ok(contract.fail_closed_requirements.length >= 14);
+assert.ok(contract.non_claims.includes("this partial core artifact is not sufficient to mark LINK-FORUM-03 done"));
+
+const d0 = JSON.parse(read(d0Path));
+assert.equal(d0.contract, "forum_search_versioned_invalidation_runtime_evidence_v1");
+assert.equal(d0.task, "FORUM-23B2G2B3D0");
+assert.equal(d0.status, "source_ready_maintainer_execution_pending");
+assert.equal(d0.evidence_artifact.path, aggregatePath);
+assert.deepEqual(
+  d0.required_scenarios.map(({ id }) => id),
+  [
+    "normal_delivery",
+    "legacy_first_duplicate",
+    "typed_first_duplicate",
+    "acknowledgement_failure_restart",
+    "raw_poison_dlq_redelivery",
+    "semantic_poison_identity_conflict",
+    "missing_delivery_owner_repair",
+    "multi_process_serialization",
+    "deletion_acl_ordering",
+    "search_disabled_profile",
+  ],
+);
+for (const task of [
+  "FORUM-23B2G2B3D8",
+  "FORUM-23B2G2B3D9",
+  "FORUM-23B2G2B3D10",
+  "FORUM-23B2G2B3D11",
+  "FORUM-23B2G2B3D12",
+]) {
+  assert.ok(
+    d0.source_ready_subproofs.some((subproof) => subproof.task === task),
+    `${task} disappeared from D0 lineage`,
+  );
+}
+
+const d12 = JSON.parse(read(d12Path));
+assert.equal(
+  d12.contract,
+  "forum_search_versioned_invalidation_retained_evidence_promotion_v1",
+);
+assert.equal(d12.task, "FORUM-23B2G2B3D12");
+assert.equal(d12.status, "source_ready_maintainer_execution_pending");
+assert.equal(d12.aggregate_artifact, aggregatePath);
+assert.equal(d12.promotion_candidate.path, candidatePath);
+assert.equal(d12.proposed_transition.from, "source_ready_maintainer_execution_pending");
+assert.equal(d12.proposed_transition.to, "runtime_evidence_reviewed");
+assert.equal(d12.proposed_transition.requires_separate_canonical_source_pull_request, true);
+assert.equal(d12.proposed_transition.closes_forum_23, false);
+assert.equal(d12.proposed_transition.closes_link_forum_03, false);
+
+const d12Reviewer = read(d12ReviewerPath);
+requireAll(
+  d12Reviewer,
+  [
+    'contract: "forum_search_versioned_invalidation_runtime_promotion_candidate_v1"',
+    'status: "approved_for_canonical_status_promotion"',
+    "all_ten_frozen_scenarios_passed: true",
+    "all_nine_source_artifacts_revalidated: true",
+    "all_source_digests_match_aggregate: true",
+    "aggregate_parent_digest_matches_current_d0: true",
+    "retained_digest_attested_by_maintainer: true",
+    "separate_canonical_source_pull_request_required: true",
+    "canonical_source_mutated_by_reviewer: false",
+    "closes_link_forum_03: false",
+    candidatePath,
+  ],
+  "D12 reviewer",
+);
+
+const d8Test = read(d8TestPath);
+requireAll(
+  d8Test,
+  [
+    "forum_search_versioned_invalidation_deletion_acl_ordering_evidence_v1",
+    d8Path,
+    'id: "deletion_acl_ordering"',
+    'result: "passed"',
+    "broker_used: false",
+    "ForumProjectionReconciler",
+    "execute_forum_storefront_search",
+    "assert_storefront_exact",
+    "search_projection_inbox",
+    "forum_projection_revision_ledger",
+    '.args(["rev-parse", "HEAD"])',
+  ],
+  "D8 proof",
+);
+
+const d9Test = read(d9TestPath);
+requireAll(
+  d9Test,
+  [
+    "forum_search_versioned_invalidation_search_disabled_recovery_evidence_v1",
+    d9Path,
+    'id: "search_disabled_profile"',
+    'result: "passed"',
+    "broker_used: false",
+    "assert_search_storage_absent",
+    "enable_search",
+    "ForumProjectionReconciler::with_owner_revision_source",
+    "owner_rebuilds != 1",
+    "owner_revisions_checkpointed != 3",
+    '.args(["rev-parse", "HEAD"])',
+  ],
+  "D9 proof",
+);
+
+const d10Test = read(d10TestPath);
+requireAll(
+  d10Test,
+  [
+    "forum_search_versioned_invalidation_normal_delivery_evidence_v1",
+    d10Path,
+    'id: "normal_delivery"',
+    'result: "passed"',
+    'delivery_profile: "outbox_iggy"',
+    "open_persistent_contract_consumer_group",
+    "ForumSearchContractIngress::new",
+    "ForumProjectionReconciler::with_owner_revision_source",
+    "execute_forum_storefront_search",
+    'row.outcome != "delivery_covered"',
+    '.args(["rev-parse", "HEAD"])',
+  ],
+  "D10 proof",
+);
+
+const assembler = read(assemblerPath);
+requireAll(
+  assembler,
+  [
+    'execFileSync("git", ["rev-parse", "HEAD"]',
+    'createHash("sha256")',
+    contractPath,
+    forumPlanPath,
+    d0Path,
+    d12Path,
+    candidatePath,
+    aggregatePath,
+    d8Path,
+    d9Path,
+    d10Path,
+    outputPath,
+    "forum_search_link_forum_03_evidence_assembler_v1",
+    "ordering_visibility_and_search_disabled_core_only",
+    "forum_search_versioned_invalidation_runtime_promotion_candidate_v1",
+    "approved_for_canonical_status_promotion",
+    "runtime_evidence_assembled",
+    "forum_search_versioned_invalidation_deletion_acl_ordering_evidence_v1",
+    "forum_search_versioned_invalidation_search_disabled_recovery_evidence_v1",
+    "forum_search_versioned_invalidation_normal_delivery_evidence_v1",
+    "candidate.parent_contract.sha256 !== sha256(d0Bytes)",
+    "candidate.aggregate_artifact.sha256 !== aggregateReview.digest",
+    "record.sha256 !== source.digest",
+    "JSON.stringify(scenario.facts) !== JSON.stringify(source.scenario.facts)",
+    'status: "partial_runtime_evidence_assembled"',
+    'coverage: "ordering_visibility_and_search_disabled_core_only"',
+    "status_change_allowed_from_this_artifact: false",
+    "separate_follow_up_runtime_evidence_required: true",
+    "closes_link_forum_03_automatically: false",
+    "external_retention_authentication_performed_by_assembler: false",
+    "writeFileSync(temporaryOutput",
+    "renameSync(temporaryOutput, absoluteOutput)",
+    "rmSync(temporaryOutput, { force: true })",
+    "if (process.argv.length !== 2)",
+  ],
+  "D13 assembler",
+);
+forbidAll(
+  assembler,
+  [
+    'status: "runtime_evidence_complete"',
+    "status_change_allowed_from_this_artifact: true",
+    'proposed_link_status_after_separate_canonical_review: "done"',
+    "result: \"skipped\"",
+    "allowMissing",
+    "bestEffort",
+    "continueOnError",
+    "process.env.SOURCE_COMMIT",
+    "--source-commit",
+    "writeFileSync(resolve(root, d0Path)",
+    "writeFileSync(resolve(root, forumPlanPath)",
+  ],
+  "D13 assembler",
+);
+
+const forumPlan = read(forumPlanPath);
+requireAll(
+  forumPlan,
+  [
+    "| `FORUM-23` | `in_progress` |",
+    "maintainer PostgreSQL/Iggy plus LINK-FORUM-03 runtime evidence remain",
+    "| `LINK-FORUM-03` | `planned` | Forum/index/search ordering and visibility proof. |",
+    "## `LINK-FORUM-03` — index and search",
+    "**Status:** `planned`",
+    "**Dependencies:** FORUM-20/23",
+    "Prove publish, translation, moderation approval, move, hide/delete, ACL change,",
+    "out-of-order events and search-disabled behavior",
+  ],
+  "Forum canonical plan",
+);
+forbidAll(
+  forumPlan,
+  [
+    "| `LINK-FORUM-03` | `done` |",
+    "LINK-FORUM-03 runtime evidence passed",
+    "FORUM-23B2G2B3D13 closes LINK-FORUM-03",
+  ],
+  "Forum canonical plan",
+);
+
+const searchPlan = read(searchPlanPath);
+requireAll(
+  searchPlan,
+  [
+    "The source-ready Forum-only storefront Search path composes two neutral optional",
+    "owner ports without importing Forum into Search",
+    "Runtime evidence remains pending",
+    "Durable Forum inbox ingest ordering is `source_complete_execution_pending`",
+  ],
+  "Search canonical plan",
+);
+
+const doc = read(docPath);
+requireAll(
+  doc,
+  [
+    "FORUM-23B2G2B3D13",
+    "`source_ready_maintainer_execution_pending`",
+    contractPath,
+    assemblerPath,
+    verifierPath,
+    outputPath,
+    "D8 proves deletion",
+    "D9 proves Forum owner writes",
+    "D10 proves one correlated real Forum owner transaction",
+    "D11 assembles all D2-D10 runtime artifacts",
+    "D12 re-reads the aggregate",
+    "partial_runtime_evidence_assembled",
+    "ordering_visibility_and_search_disabled_core_only",
+    "status_change_allowed_from_this_artifact = false",
+    "translation projection and retrieval",
+    "real moderation approval transition",
+    "topic move and category-scope projection update",
+    "exact private and trusted-channel exclusion profile",
+    "No command above was run by the implementation agent",
+  ],
+  "D13 handoff",
+);
+
+console.log(
+  "LINK-FORUM-03 ordering, visibility and Search-disabled core evidence assembler is source-ready and remains partial.",
+);


### PR DESCRIPTION
## What changed

- add `FORUM-23B2G2B3D13`, a fail-closed downstream assembler for the reviewed core of `LINK-FORUM-03`;
- require the D12 promotion candidate, D11 aggregate, D8 deletion/ACL ordering artifact, D9 Search-disabled recovery artifact and D10 correlated normal-delivery artifact;
- require one current `HEAD`, exact D0 parent digest, exact ten-scenario aggregate order and all nine D2-D10 retained source tasks;
- re-read D8/D9/D10 bytes and require their SHA-256, length, generated time, source commit and scenario identities to match both D11 and D12 retention records;
- require D8/D9 no-broker profiles and the D10 external `outbox_iggy` profile with canonical group/topic;
- write only an atomic `partial_runtime_evidence_assembled` artifact with coverage `ordering_visibility_and_search_disabled_core_only`;
- explicitly forbid a canonical status change from this artifact.

## Remaining LINK-FORUM-03 scope

This PR does not cover translation projection/retrieval, a real moderation approval transition, topic move/category-scope update, or an exact private/trusted-channel exclusion runtime profile. A later complete reviewed artifact is required before `LINK-FORUM-03` can move from `planned`.

## Deliberate boundary

The PR does not execute D8-D12, generate missing runtime artifacts, authenticate an external retention service, promote D0/FORUM-23/LINK-FORUM-03, or change production Rust, migrations, schemas, dependencies, `Cargo.toml` or `Cargo.lock`.

## Validation

Tests, Node verifiers, assembler execution, formatting, Cargo checks, workflows, CI, PostgreSQL and Iggy execution were intentionally not run, per maintainer request.