### PR TITLE
feat(index): add cooperative replay page interruption

### DIFF
--- a/crates/rustok-index/docs/m6-cooperative-page-interruption.md
+++ b/crates/rustok-index/docs/m6-cooperative-page-interruption.md
@@ -1,0 +1,71 @@
+# M6 cooperative replay-page interruption
+
+Status: `source_complete_runner_probe_pending`
+
+## Purpose
+
+`IndexReplayWorker` now exposes an interruptible one-page execution path without
+changing the existing replay API. The ordinary `run_next_page` method delegates to
+the same implementation with a no-op probe, while hosts that own a cancellation or
+shutdown signal can call `run_next_page_interruptible`.
+
+The probe returns a bounded result:
+
+- `Ok(false)` continues execution;
+- `Ok(true)` returns `IndexReplayError::Interrupted`;
+- `Err(IndexReplayFailure)` returns
+  `IndexReplayError::InterruptionCheckFailed` without accepting a raw database,
+  transport, request, tenant, or stack payload.
+
+## Safe interruption boundaries
+
+The worker checks the probe exactly at these durable boundaries:
+
+1. after checkpoint readiness and immediately before the source scan;
+2. before every mutation is passed to `IndexReplayMutationSink`;
+3. after the page checkpoint is constructed and immediately before checkpoint
+   commit.
+
+An interruption never commits the page checkpoint. If interruption occurs after one
+or more mutations were already persisted, the next run scans the same page again.
+That replay is intentionally safe only because mutation persistence already owns
+inbox deduplication and monotonic source-version guards.
+
+A completed null-cursor checkpoint remains authoritative and returns
+`AlreadyComplete` without consulting the probe or source.
+
+## Ownership boundaries
+
+This slice is database and runtime neutral. It does not:
+
+- read `index_jobs` or interpret `cancel_requested`;
+- terminalize a replay job as cancelled;
+- create a PostgreSQL cancellation probe;
+- interrupt an owner future while one source scan or mutation call is currently
+  pending;
+- add a deadline, timer, polling loop, scheduler, task, or shutdown owner;
+- change source, mutation, checkpoint, cursor, event identity, or storage schemas.
+
+The PostgreSQL runner must later bind the probe to the exact active
+`(tenant_id, job_id, worker_id, attempt_count)` lease and terminalize a committed
+cancel request using its existing fenced cancellation path. That integration must
+also classify probe storage failure without exposing raw causes.
+
+The separate production source-call timeout slice bounds selected owner source
+futures. Cooperative boundaries and call deadlines are complementary: this worker
+contract alone cannot preempt one indefinitely pending source or mutation future.
+The combined implementation-plan item for in-page interruption/timeouts therefore
+remains open.
+
+## Source evidence
+
+Focused unit scenarios retain:
+
+- interruption before source scan with no source, mutation, or checkpoint write;
+- interruption before checkpoint commit after one durable mutation, followed by a
+  replay of the same event and duplicate-safe checkpoint completion;
+- bounded retryable interruption-probe failure before source access.
+
+Cargo checks, tests, the JavaScript verifier, PostgreSQL execution, cancellation
+races, and restart evidence remain maintainer-run and were not executed by the
+implementation agent.

--- a/crates/rustok-index/src/application/source_replay.rs
+++ b/crates/rustok-index/src/application/source_replay.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::BTreeSet,
     fmt,
+    future::Future,
     sync::Arc,
 };
 
@@ -316,6 +317,28 @@ where
         &self,
         request: IndexReplayPageRequest,
     ) -> Result<IndexReplayPageOutcome, IndexReplayError> {
+        self.run_next_page_interruptible(request, || async {
+            Ok::<bool, IndexReplayFailure>(false)
+        })
+        .await
+    }
+
+    /// Runs one replay page with cooperative interruption checks at durable boundaries.
+    ///
+    /// The probe is called after checkpoint readiness and before source scan, before every
+    /// mutation application, and before checkpoint commit. Returning `true` interrupts the
+    /// page without advancing its checkpoint. Mutations already committed before an
+    /// interruption may be replayed and must remain safe through inbox deduplication and
+    /// monotonic source-version guards.
+    pub async fn run_next_page_interruptible<Check, CheckFuture>(
+        &self,
+        request: IndexReplayPageRequest,
+        mut should_interrupt: Check,
+    ) -> Result<IndexReplayPageOutcome, IndexReplayError>
+    where
+        Check: FnMut() -> CheckFuture,
+        CheckFuture: Future<Output = Result<bool, IndexReplayFailure>>,
+    {
         let descriptor = self
             .sources
             .source_for_schema(request.schema())
@@ -350,6 +373,7 @@ where
             }
         }
 
+        check_replay_interruption(&mut should_interrupt).await?;
         let scan_request = IndexSourceScanRequest::new(
             request.tenant_id(),
             request.schema().clone(),
@@ -387,6 +411,7 @@ where
             .and_then(|checkpoint| checkpoint.last_delivery_id().map(str::to_owned));
 
         for (position, mutation) in page.mutations().iter().enumerate() {
+            check_replay_interruption(&mut should_interrupt).await?;
             let outcome = self
                 .mutation_sink
                 .apply_replay_mutation(
@@ -415,6 +440,7 @@ where
             max_source_version,
             last_delivery_id,
         )?;
+        check_replay_interruption(&mut should_interrupt).await?;
         self.checkpoint_store
             .commit_replay_checkpoint(&checkpoint)
             .await
@@ -432,6 +458,20 @@ where
             duplicate_count,
             stale_count,
         })
+    }
+}
+
+async fn check_replay_interruption<Check, CheckFuture>(
+    should_interrupt: &mut Check,
+) -> Result<(), IndexReplayError>
+where
+    Check: FnMut() -> CheckFuture,
+    CheckFuture: Future<Output = Result<bool, IndexReplayFailure>>,
+{
+    match should_interrupt().await {
+        Ok(false) => Ok(()),
+        Ok(true) => Err(IndexReplayError::Interrupted),
+        Err(failure) => Err(IndexReplayError::InterruptionCheckFailed(failure)),
     }
 }
 
@@ -456,6 +496,10 @@ pub enum IndexReplayError {
     UnknownSchemaSource(SchemaRef),
     #[error(transparent)]
     SourceContract(IndexSourceError),
+    #[error("Index replay page was cooperatively interrupted")]
+    Interrupted,
+    #[error("Index replay interruption check failed")]
+    InterruptionCheckFailed(#[source] IndexReplayFailure),
     #[error("Index replay checkpoint identity does not match the requested replay scope")]
     CheckpointIdentityMismatch {
         expected: IndexReplayCheckpointKey,

--- a/crates/rustok-index/src/application/source_replay_tests.rs
+++ b/crates/rustok-index/src/application/source_replay_tests.rs
@@ -344,3 +344,116 @@ async fn nil_replay_event_is_rejected_before_persistence() {
     assert_eq!(mutation_calls.load(Ordering::SeqCst), 0);
     assert!(checkpoint.lock().unwrap().is_none());
 }
+
+#[tokio::test]
+async fn interruption_before_source_scan_skips_source_and_checkpoint() {
+    let tenant_id = Uuid::from_u128(6);
+    let source_calls = Arc::new(AtomicUsize::new(0));
+    let mutation_calls = Arc::new(AtomicUsize::new(0));
+    let checkpoint = Arc::new(Mutex::new(None));
+    let worker = worker(
+        tenant_id,
+        Uuid::from_u128(10),
+        source_calls.clone(),
+        mutation_calls.clone(),
+        Arc::new(Mutex::new(Vec::new())),
+        checkpoint.clone(),
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(Mutex::new(Vec::new())),
+    );
+
+    assert!(matches!(
+        worker
+            .run_next_page_interruptible(
+                IndexReplayPageRequest::new(tenant_id, schema_ref(), 10).unwrap(),
+                || async { Ok::<bool, IndexReplayFailure>(true) },
+            )
+            .await,
+        Err(IndexReplayError::Interrupted)
+    ));
+    assert_eq!(source_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(mutation_calls.load(Ordering::SeqCst), 0);
+    assert!(checkpoint.lock().unwrap().is_none());
+}
+
+#[tokio::test]
+async fn interruption_before_checkpoint_replays_applied_mutation_without_advancing_cursor() {
+    let tenant_id = Uuid::from_u128(7);
+    let event_id = Uuid::from_u128(10);
+    let source_calls = Arc::new(AtomicUsize::new(0));
+    let mutation_calls = Arc::new(AtomicUsize::new(0));
+    let event_ids = Arc::new(Mutex::new(Vec::new()));
+    let checkpoint = Arc::new(Mutex::new(None));
+    let interruption_checks = Arc::new(AtomicUsize::new(0));
+    let worker = worker(
+        tenant_id,
+        event_id,
+        source_calls.clone(),
+        mutation_calls.clone(),
+        event_ids.clone(),
+        checkpoint.clone(),
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(Mutex::new(Vec::new())),
+    );
+    let checks = interruption_checks.clone();
+    let request = IndexReplayPageRequest::new(tenant_id, schema_ref(), 10).unwrap();
+
+    assert!(matches!(
+        worker
+            .run_next_page_interruptible(request.clone(), move || {
+                let check = checks.fetch_add(1, Ordering::SeqCst);
+                async move { Ok::<bool, IndexReplayFailure>(check == 2) }
+            })
+            .await,
+        Err(IndexReplayError::Interrupted)
+    ));
+    assert_eq!(interruption_checks.load(Ordering::SeqCst), 3);
+    assert_eq!(source_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(mutation_calls.load(Ordering::SeqCst), 1);
+    assert!(checkpoint.lock().unwrap().is_none());
+
+    let outcome = worker.run_next_page(request).await.unwrap();
+    assert_eq!(outcome.duplicate_count(), 1);
+    assert_eq!(source_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(mutation_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(*event_ids.lock().unwrap(), vec![event_id, event_id]);
+    assert!(checkpoint.lock().unwrap().as_ref().unwrap().is_complete());
+}
+
+#[tokio::test]
+async fn interruption_probe_failure_stays_bounded_and_skips_source() {
+    let tenant_id = Uuid::from_u128(8);
+    let source_calls = Arc::new(AtomicUsize::new(0));
+    let mutation_calls = Arc::new(AtomicUsize::new(0));
+    let checkpoint = Arc::new(Mutex::new(None));
+    let worker = worker(
+        tenant_id,
+        Uuid::from_u128(10),
+        source_calls.clone(),
+        mutation_calls.clone(),
+        Arc::new(Mutex::new(Vec::new())),
+        checkpoint.clone(),
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(Mutex::new(Vec::new())),
+    );
+
+    let error = worker
+        .run_next_page_interruptible(
+            IndexReplayPageRequest::new(tenant_id, schema_ref(), 10).unwrap(),
+            || async {
+                Err::<bool, IndexReplayFailure>(
+                    IndexReplayFailure::retryable("interruption_probe_unavailable").unwrap(),
+                )
+            },
+        )
+        .await
+        .unwrap_err();
+    let IndexReplayError::InterruptionCheckFailed(failure) = error else {
+        panic!("unexpected replay interruption failure: {error:?}");
+    };
+    assert_eq!(failure.kind(), IndexReplayFailureKind::Retryable);
+    assert_eq!(failure.code(), "interruption_probe_unavailable");
+    assert_eq!(source_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(mutation_calls.load(Ordering::SeqCst), 0);
+    assert!(checkpoint.lock().unwrap().is_none());
+}

--- a/scripts/verify/verify-index-replay-page-interruption.mjs
+++ b/scripts/verify/verify-index-replay-page-interruption.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-replay-page-interruption] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const replayPath = 'crates/rustok-index/src/application/source_replay.rs';
+const replay = requireMarkers(replayPath, [
+  'future::Future',
+  'pub async fn run_next_page_interruptible<Check, CheckFuture>',
+  'Check: FnMut() -> CheckFuture',
+  'CheckFuture: Future<Output = Result<bool, IndexReplayFailure>>',
+  'Ok::<bool, IndexReplayFailure>(false)',
+  'Ok(true) => Err(IndexReplayError::Interrupted)',
+  'Err(failure) => Err(IndexReplayError::InterruptionCheckFailed(failure))',
+  'Index replay page was cooperatively interrupted',
+  'Index replay interruption check failed',
+]);
+const interruptionChecks = replay.match(
+  /check_replay_interruption\(&mut should_interrupt\)\.await\?;/g,
+)?.length ?? 0;
+if (interruptionChecks !== 3) {
+  fail(`${replayPath} must retain exactly three cooperative interruption boundaries`);
+}
+for (const forbidden of [
+  'DatabaseConnection',
+  'index_jobs',
+  'cancel_requested',
+  'tokio::spawn',
+  'tokio::time::sleep',
+  'loop {',
+  'last_error_details',
+  'backtrace',
+  'stack_trace',
+]) {
+  if (replay.includes(forbidden)) {
+    fail(`${replayPath} contains forbidden host/storage/scheduler marker ${forbidden}`);
+  }
+}
+
+requireMarkers('crates/rustok-index/src/application/source_replay_tests.rs', [
+  'interruption_before_source_scan_skips_source_and_checkpoint',
+  'interruption_before_checkpoint_replays_applied_mutation_without_advancing_cursor',
+  'interruption_probe_failure_stays_bounded_and_skips_source',
+  'Err(IndexReplayError::Interrupted)',
+  'Err::<bool, IndexReplayFailure>',
+  'assert!(checkpoint.lock().unwrap().is_none());',
+  'assert_eq!(outcome.duplicate_count(), 1);',
+]);
+
+requireMarkers('crates/rustok-index/docs/m6-cooperative-page-interruption.md', [
+  'Status: `source_complete_runner_probe_pending`',
+  '`run_next_page_interruptible`',
+  '`IndexReplayError::Interrupted`',
+  '`IndexReplayError::InterruptionCheckFailed`',
+  'before every mutation',
+  'never commits the page checkpoint',
+  '`(tenant_id, job_id, worker_id, attempt_count)`',
+  'cannot preempt one indefinitely pending source or mutation future',
+  'combined implementation-plan item for in-page interruption/timeouts therefore\nremains open',
+  'maintainer-run',
+]);
+
+console.log('[verify-index-replay-page-interruption] OK');


### PR DESCRIPTION
## Superseded

Closed without merge. Rebuilt directly on current `main`, rechecked after the production source-call timeout and bounded replay dry-run slices, and merged as #2892.

The replacement preserves the reviewed database-neutral worker safe points while actualizing documentation and repository verification:

- `run_next_page` remains source-compatible through a no-op probe;
- interruption is checked before source scan, before every mutation, and before checkpoint commit;
- interruption never advances the page checkpoint;
- durable mutations before interruption remain duplicate-safe on replay;
- probe failures remain bounded to the existing retryable/permanent machine-code contract;
- the worker does not time-bound the probe itself or preempt already-pending source/mutation/checkpoint futures;
- the PostgreSQL runner still does not derive the probe from the active lease or cancellation row.

The canonical combined roadmap item remains open because runner binding, pending-future handling, targeted/full/shadow rebuild modes, and retained PostgreSQL evidence are still absent.

Validation remained unrun per maintainer instruction.