### PR TITLE
fix(product): bound storefront GraphQL diagnostics

### DIFF
--- a/crates/rustok-product/contracts/evidence/storefront-graphql-error-safety-source-review.json
+++ b/crates/rustok-product/contracts/evidence/storefront-graphql-error-safety-source-review.json
@@ -1,8 +1,9 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-30",
+  "generated_at": "2026-08-01",
   "status": "product_storefront_graphql_error_safety_source_reviewed_unvalidated",
-  "base_main_sha": "aef96f57d3babc2efdc65cc0c57cfea6fb48b5ad",
+  "base_main_sha": "ba2b49ac520253f8d648123be712164abb9d7cda",
+  "scope": "product storefront GraphQL public and diagnostic boundary",
   "reviewed_sources": [
     "crates/rustok-commerce/docs/implementation-plan.md",
     "crates/rustok-product/storefront/Cargo.toml",
@@ -13,31 +14,51 @@
     "crates/rustok-product/storefront/src/transport/graphql_error_safety.rs",
     "crates/rustok-product/storefront/src/transport/catalog_list_native.rs",
     "crates/rustok-product/storefront/src/transport/native_server_adapter.rs",
+    "crates/rustok-product/contracts/evidence/storefront-graphql-error-safety-source.json",
+    "crates/rustok-product/docs/storefront-graphql-error-safety.md",
+    "scripts/verify/verify-product-storefront-graphql-error-safety.mjs",
     "crates/rustok-ui-transport/src/lib.rs",
-    "crates/rustok-graphql/src/lib.rs",
-    "scripts/verify/verify-product-storefront-boundary.mjs",
-    "scripts/verify/verify-product-storefront-catalog-native-error-safety.mjs"
+    "crates/rustok-graphql/src/lib.rs"
   ],
   "findings": [
     {
-      "id": "product-storefront-graphql-public-detail",
-      "severity": "p1",
-      "finding": "The product storefront facade delegated both selected GraphQL closures directly to the private adapter, whose GraphqlHttpError conversion retained display text in UiTransportError.graphql_error.",
-      "resolution": "Create owner-specific per-call contexts at the public consumer boundary and map only ApiError::Graphql to static public envelopes."
+      "id": "product-storefront-static-public-envelope-preserved",
+      "severity": "preservation",
+      "finding": "Both selected public GraphQL operations already reparse the private adapter display through GraphqlHttpError and return static product-owned messages."
+    },
+    {
+      "id": "product-storefront-raw-diagnostic-payload",
+      "severity": "diagnostic_safety",
+      "finding": "The shared safety mapper still copied the complete private GraphQL display handoff and Debug representation of the parsed typed error into structured events."
     },
     {
       "id": "product-storefront-multi-request-catalog",
-      "severity": "contract",
-      "finding": "fetch_products may execute catalog list, selected detail, and pricing GraphQL requests under one public operation.",
-      "resolution": "Sanitize once at the facade operation boundary without changing the four private GraphQL documents, request order, DTO mapping, or pricing-context construction."
+      "severity": "preservation",
+      "finding": "fetch_products may execute catalog list, selected detail, and pricing requests under one public operation while fetch_catalog_search_options uses its own operation context."
     },
     {
-      "id": "product-storefront-correlation-context",
-      "severity": "contract",
-      "finding": "The client-side GraphQL path had no product-owner correlation event and could expose raw query or HTTP detail.",
-      "resolution": "Generate a unique per-call correlation id and retain only optional-field presence, string lengths, and collection counts in internal diagnostics."
+      "id": "product-storefront-request-shape",
+      "severity": "preservation",
+      "finding": "Existing diagnostics already bounded optional request values to presence, character lengths, booleans, and collection counts."
     }
   ],
+  "implementation_review": {
+    "typed_graphql_variant_policy": true,
+    "static_public_graphql_messages": true,
+    "raw_graphql_detail_logging_removed": true,
+    "parsed_graphql_error_debug_logging_removed": true,
+    "bounded_graphql_error_shape_retained": true,
+    "both_public_operations_preserved": true,
+    "per_call_correlation_id": true,
+    "safe_request_shape_only": true,
+    "private_graphql_adapter_changed": false,
+    "native_paths_changed": false,
+    "graphql_documents_changed": false,
+    "pricing_context_changed": false,
+    "transport_selection_changed": false,
+    "request_response_dto_changed": false,
+    "runtime_evidence_claimed": false
+  },
   "preserved_behavior": [
     "explicit feature-based transport selection",
     "no native-to-GraphQL fallback",
@@ -47,7 +68,8 @@
     "request and response DTOs",
     "pricing-context derivation",
     "native catalog-list and search-options paths",
-    "native error-safety policy"
+    "native error-safety policy",
+    "static public messages, stable codes, category severity, and non-GraphQL pass-through"
   ],
   "execution": {
     "commands": [],
@@ -67,5 +89,12 @@
     "ffa_promoted": false,
     "fba_promoted": false,
     "production_promoted": false
-  }
+  },
+  "remaining_scope": [
+    "remaining ecommerce storefront and admin GraphQL adapters",
+    "payment and fulfillment checkout execution diagnostics",
+    "remaining non-PortError public and diagnostic envelopes",
+    "browser and mounted GraphQL runtime evidence",
+    "broad ecommerce correlation-safe mapper cleanup"
+  ]
 }

--- a/crates/rustok-product/contracts/evidence/storefront-graphql-error-safety-source.json
+++ b/crates/rustok-product/contracts/evidence/storefront-graphql-error-safety-source.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-30",
+  "generated_at": "2026-08-01",
   "status": "product_storefront_graphql_error_safety_source_unvalidated",
   "scope": "product-owned storefront GraphQL catalog, detail, pricing, and catalog-search-options transport",
   "covered_operations": [
@@ -25,10 +25,27 @@
     "unknown_static_public_envelope": true,
     "correlation_logging": true,
     "safe_request_shape_logging": true,
+    "raw_graphql_detail_logged": false,
+    "parsed_graphql_error_debug_logged": false,
+    "raw_graphql_detail_shape_logged": true,
+    "typed_parse_validity_logged": true,
+    "closed_graphql_error_category_logged": true,
     "raw_request_values_logged": false,
     "raw_tenant_slug_logged": false,
     "raw_graphql_error_public": false,
-    "non_graphql_errors_pass_through": true
+    "non_graphql_errors_pass_through": true,
+    "broad_ecommerce_cleanup_closed": false
+  },
+  "internal_diagnostics": {
+    "raw_graphql_error": false,
+    "parsed_graphql_error_debug": false,
+    "raw_graphql_error_present": true,
+    "raw_graphql_error_length": true,
+    "parsed_graphql_error_valid": true,
+    "closed_graphql_error_category": true,
+    "owner_operation": true,
+    "correlation_id": true,
+    "safe_request_shape": true
   },
   "stable_public_messages": {
     "network_or_http": "Product storefront is temporarily unavailable",

--- a/crates/rustok-product/docs/storefront-graphql-error-safety.md
+++ b/crates/rustok-product/docs/storefront-graphql-error-safety.md
@@ -4,8 +4,8 @@ Status: source-unvalidated
 
 ## Scope
 
-This source slice hardens the product-owned storefront GraphQL transport for two
-public operations:
+This source slice hardens both the public and private diagnostic boundary for the
+product-owned storefront GraphQL transport used by two public operations:
 
 - `fetch_products`;
 - `fetch_catalog_search_options`.
@@ -15,25 +15,30 @@ GraphQL adapter remains private and continues to own the catalog-list, selected
 product, pricing-product, and catalog-search-options documents, variables,
 response decoding, request ordering, and DTO mapping.
 
-## Previous gap
+## Rechecked gap
 
-Both selected GraphQL closures delegated directly to the private adapter. The
-adapter converted `GraphqlHttpError` into `ApiError::Graphql(value.to_string())`,
-and `execute_selected_transport` retained that display string in the public
-`UiTransportError.graphql_error` field.
+The public consumer already created a `GraphqlCallContext`, reparsed each private
+adapter display handoff through `GraphqlHttpError::from_str`, and returned static
+product-owned messages. GraphQL server messages and HTTP/client detail therefore
+did not cross the public storefront envelope.
 
-Consequently, server-provided GraphQL messages and HTTP detail could cross the
-storefront UI boundary without a product-owned public-envelope policy. The
-native catalog-list and catalog-search-options paths already had their own
-owner mappings, but those mappings did not cover the GraphQL path.
+The shared structured event still copied two complete private values:
+
+- `raw_error = %raw_error`;
+- `parsed_error = ?parsed_error`.
+
+Those payloads were unnecessary for correlation, exact owner-operation
+attribution, or the closed five-category transport policy. This was a remaining
+non-`PortError` diagnostic-envelope gap in the ecommerce correlation-safe mapper
+cleanup.
 
 ## Public consumer policy
 
-`transport/mod.rs` now creates a private `GraphqlCallContext` before invoking
-each GraphQL adapter operation. The context reparses the adapter's display
-handoff through `GraphqlHttpError::from_str` and maps only `ApiError::Graphql`.
+`transport/mod.rs` creates a private `GraphqlCallContext` before invoking each
+GraphQL adapter operation. The context reparses the adapter's display handoff
+through `GraphqlHttpError::from_str` and maps only `ApiError::Graphql`.
 
-The stable public messages are:
+The stable public messages remain:
 
 | Typed failure | Public message |
 | --- | --- |
@@ -46,17 +51,20 @@ The stable public messages are:
 `ApiError::ServerFn` is returned unchanged. This preserves the independent
 native transport policy.
 
-## Correlation diagnostics
+## Correlation and bounded diagnostics
 
 Every selected GraphQL call creates a unique correlation identifier using the
-owner operation and a new UUID. Internal tracing events retain:
+owner operation and a new UUID. Internal tracing events retain only:
 
 - owner `rustok_product.storefront`;
 - operation `fetch_products` or `fetch_catalog_search_options`;
 - boundary `product_storefront_graphql_transport`;
 - correlation identifier;
-- typed error kind and stable code;
-- raw and reparsed GraphQL cause for internal diagnosis;
+- one closed error category: `network`, `http`, `unauthorized`, `graphql`, or
+  `unknown`;
+- stable internal code;
+- raw-display presence and character length;
+- whether typed `GraphqlHttpError` parsing succeeded;
 - whether a tenant slug is configured and its character length;
 - optional selected-handle, locale, currency, region, price-list, channel-id,
   channel-slug, search, and category-id presence and character lengths;
@@ -64,13 +72,25 @@ owner operation and a new UUID. Internal tracing events retain:
 - sort-field and sort-direction presence;
 - attribute-filter count.
 
-The mapper does not log raw tenant slug, selected handle, locale, currency,
+Raw GraphQL display text is not written to the event.
+Debug output from the parsed typed error is not written to the event.
+
+The mapper also does not log raw tenant slug, selected handle, locale, currency,
 region id, price-list id, channel id, channel slug, quantity, search text,
 category id, sort values, attribute-filter values, GraphQL endpoint, documents,
 variables, tokens, or returned product data.
 
-Technical network, HTTP, and unknown failures use error-level diagnostics.
-Unauthorized and ordinary GraphQL rejection use warning-level diagnostics.
+Technical network, HTTP, and unknown failures continue to use error-level
+diagnostics. Unauthorized and ordinary GraphQL rejection continue to use
+warning-level diagnostics.
+
+## Covered operations
+
+`fetch_products` retains its existing catalog-list, optional selected-product,
+and optional pricing request sequence under one owner context.
+
+`fetch_catalog_search_options` retains its independent owner context and the
+existing catalog-search-options request.
 
 ## Preserved behavior
 
@@ -90,7 +110,9 @@ This slice does not change:
 - pricing-context construction;
 - native owner catalog-list execution;
 - native catalog-search-options server function;
-- native error-safety policy.
+- native error-safety policy;
+- static public messages, stable codes, category severity, or non-GraphQL
+  pass-through behavior.
 
 The adapter still creates the exact typed GraphQL display handoff. Sanitization
 occurs once at the public consumer boundary, avoiding duplicate diagnostics and
@@ -104,10 +126,11 @@ The focused verifier is:
 node scripts/verify/verify-product-storefront-graphql-error-safety.mjs
 ```
 
-It checks the typed mapping policy, static public messages, stable codes,
-correlation and safe request-shape diagnostics, GraphQL-only remapping,
-private-adapter preservation, native-path preservation, evidence status, and
-validation nonclaims.
+It checks the typed mapping policy, all five static public categories, stable
+codes, correlation and bounded request-shape diagnostics, absence of raw GraphQL
+and parsed Debug payloads, GraphQL-only remapping, private-adapter preservation,
+native-path preservation, truthful source/review evidence, and validation
+nonclaims.
 
 The general owner boundary verifier imports the focused guard:
 

--- a/crates/rustok-product/storefront/src/transport/graphql_error_safety.rs
+++ b/crates/rustok-product/storefront/src/transport/graphql_error_safety.rs
@@ -77,7 +77,10 @@ impl GraphqlCallContext {
         let ApiError::Graphql(raw_error) = error else {
             return error;
         };
+        let raw_error_present = !raw_error.trim().is_empty();
+        let raw_error_length = raw_error.chars().count();
         let parsed_error = GraphqlHttpError::from_str(raw_error.as_str());
+        let parsed_error_valid = parsed_error.is_ok();
         let (error_kind, code, public_message, technical_failure) = match &parsed_error {
             Ok(GraphqlHttpError::Network) => (
                 "network",
@@ -113,8 +116,9 @@ impl GraphqlCallContext {
 
         if technical_failure {
             tracing::error!(
-                raw_error = %raw_error,
-                parsed_error = ?parsed_error,
+                raw_error_present,
+                raw_error_length,
+                parsed_error_valid,
                 owner = PRODUCT_STOREFRONT_GRAPHQL_OWNER,
                 owner_operation = self.owner_operation,
                 correlation_id = %self.correlation_id,
@@ -149,8 +153,9 @@ impl GraphqlCallContext {
             );
         } else {
             tracing::warn!(
-                raw_error = %raw_error,
-                parsed_error = ?parsed_error,
+                raw_error_present,
+                raw_error_length,
+                parsed_error_valid,
                 owner = PRODUCT_STOREFRONT_GRAPHQL_OWNER,
                 owner_operation = self.owner_operation,
                 correlation_id = %self.correlation_id,

--- a/scripts/verify/verify-product-storefront-graphql-error-safety.mjs
+++ b/scripts/verify/verify-product-storefront-graphql-error-safety.mjs
@@ -26,12 +26,18 @@ const nativePath =
   "crates/rustok-product/storefront/src/transport/native_server_adapter.rs";
 const evidencePath =
   "crates/rustok-product/contracts/evidence/storefront-graphql-error-safety-source.json";
+const reviewPath =
+  "crates/rustok-product/contracts/evidence/storefront-graphql-error-safety-source-review.json";
+const documentPath =
+  "crates/rustok-product/docs/storefront-graphql-error-safety.md";
 
 const transport = read(transportPath);
 const policy = read(policyPath);
 const adapter = read(adapterPath);
 const native = read(nativePath);
 const evidence = JSON.parse(read(evidencePath));
+const review = JSON.parse(read(reviewPath));
+const document = read(documentPath);
 
 for (const [value, label] of [
   ["mod graphql_error_safety;", "policy module wiring"],
@@ -53,10 +59,18 @@ for (const [value, label] of [
   ["GraphqlHttpError::from_str", "typed display reparse"],
   ["let ApiError::Graphql(raw_error) = error else", "GraphQL-only remap"],
   ["return error;", "non-GraphQL pass-through"],
+  ["let raw_error_present = !raw_error.trim().is_empty();", "raw display presence fact"],
+  ["let raw_error_length = raw_error.chars().count();", "raw display length fact"],
+  ["let parsed_error_valid = parsed_error.is_ok();", "typed parse validity fact"],
   ["GraphqlHttpError::Network", "network policy"],
   ["GraphqlHttpError::Http(_)", "HTTP policy"],
   ["GraphqlHttpError::Unauthorized", "unauthorized policy"],
   ["GraphqlHttpError::Graphql(_)", "GraphQL rejection policy"],
+  ["\"network\"", "closed network category"],
+  ["\"http\"", "closed HTTP category"],
+  ["\"unauthorized\"", "closed unauthorized category"],
+  ["\"graphql\"", "closed GraphQL category"],
+  ["\"unknown\"", "closed unknown category"],
   ["product.storefront_graphql_network_unavailable", "network code"],
   ["product.storefront_graphql_http_unavailable", "HTTP code"],
   ["product.storefront_graphql_authentication_required", "authentication code"],
@@ -70,8 +84,9 @@ for (const [value, label] of [
   ["owner = PRODUCT_STOREFRONT_GRAPHQL_OWNER", "owner diagnostics"],
   ["owner_operation = self.owner_operation", "operation diagnostics"],
   ["correlation_id = %self.correlation_id", "correlation diagnostics"],
-  ["raw_error = %raw_error", "private raw cause diagnostics"],
-  ["parsed_error = ?parsed_error", "typed cause diagnostics"],
+  ["raw_error_present,", "bounded raw display presence logging"],
+  ["raw_error_length,", "bounded raw display length logging"],
+  ["parsed_error_valid,", "bounded typed parse logging"],
   ["tenant_slug_length", "safe tenant shape"],
   ["selected_handle_length", "safe handle shape"],
   ["locale_length", "safe locale shape"],
@@ -89,6 +104,10 @@ for (const [value, label] of [
 ]) requireText(policy, value, label);
 
 for (const value of [
+  "raw_error = %raw_error",
+  "raw_error = ?raw_error",
+  "parsed_error = ?parsed_error",
+  "parsed_error = %parsed_error",
   "selected_handle =",
   "locale = %",
   "currency_code = %",
@@ -133,9 +152,15 @@ for (const [key, expected] of Object.entries({
   graphql_http_error_reparsed: true,
   correlation_logging: true,
   safe_request_shape_logging: true,
+  raw_graphql_detail_logged: false,
+  parsed_graphql_error_debug_logged: false,
+  raw_graphql_detail_shape_logged: true,
+  typed_parse_validity_logged: true,
+  closed_graphql_error_category_logged: true,
   raw_request_values_logged: false,
   raw_graphql_error_public: false,
   non_graphql_errors_pass_through: true,
+  broad_ecommerce_cleanup_closed: false,
 })) {
   if (evidence.source_contract?.[key] !== expected) {
     failures.push(`evidence source_contract.${key} must be ${expected}`);
@@ -158,6 +183,40 @@ for (const key of [
   }
 }
 
+if (review.status !== "product_storefront_graphql_error_safety_source_reviewed_unvalidated") {
+  failures.push(`review status mismatch: ${review.status}`);
+}
+for (const [key, expected] of Object.entries({
+  typed_graphql_variant_policy: true,
+  static_public_graphql_messages: true,
+  raw_graphql_detail_logging_removed: true,
+  parsed_graphql_error_debug_logging_removed: true,
+  bounded_graphql_error_shape_retained: true,
+  both_public_operations_preserved: true,
+  per_call_correlation_id: true,
+  safe_request_shape_only: true,
+  private_graphql_adapter_changed: false,
+  native_paths_changed: false,
+  graphql_documents_changed: false,
+  pricing_context_changed: false,
+  transport_selection_changed: false,
+  request_response_dto_changed: false,
+  runtime_evidence_claimed: false,
+})) {
+  if (review.implementation_review?.[key] !== expected) {
+    failures.push(`review implementation_review.${key} must be ${expected}`);
+  }
+}
+
+for (const marker of [
+  "Status: source-unvalidated",
+  "Raw GraphQL display text is not written to the event.",
+  "Debug output from the parsed typed error is not written to the event.",
+  "raw-display presence and character length",
+  "The broad ecommerce correlation-safe mapper cleanup remains open.",
+  "No tests, verifiers, Cargo commands, formatting, workflows, or CI were run",
+]) requireText(document, marker, "truthful product GraphQL documentation");
+
 if (failures.length > 0) {
   console.error("Product storefront GraphQL error-safety verification failed:");
   for (const failure of failures) console.error(`✗ ${failure}`);
@@ -165,5 +224,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "✔ product storefront GraphQL failures use static public envelopes with private correlated diagnostics; source evidence remains unvalidated",
+  "✔ product storefront GraphQL failures retain bounded error/request shape and static public envelopes; source evidence remains unvalidated",
 );


### PR DESCRIPTION
## Summary

- continue the ecommerce correlation-safe mapper cleanup for the Product storefront non-`PortError` GraphQL boundary
- preserve both public operations, typed `GraphqlHttpError` classification, five stable codes, static public messages, severity, exact owner-operation attribution, per-call correlation, non-GraphQL pass-through, explicit transport selection, and no-fallback behavior
- stop writing the complete private GraphQL display handoff and Debug representation of the parsed typed error into structured events
- retain only raw-display presence/character length, typed-parse validity, a closed five-value category, stable code, correlation, and the existing bounded request shape
- update the focused fail-closed verifier, source/review evidence, and Product documentation

## Recheck

The public Product GraphQL envelopes were already static and safe, but `crates/rustok-product/storefront/src/transport/graphql_error_safety.rs` still logged `raw_error = %raw_error` and `parsed_error = ?parsed_error`. The existing verifier and documentation explicitly required/described those complete internal payloads. This PR closes only that diagnostic-envelope gap.

## Deliberate boundary

The broad ecommerce mapper cleanup remains open. No DTO, GraphQL document, adapter request construction, catalog controls, pricing-context derivation, request order, native path, public transport variant, stable message/code, category severity, fallback policy, dependency, workflow, CI configuration, FFA/FBA status, or runtime-evidence status changes.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, CI, browser execution, or mounted runtime validation was executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-product-storefront-graphql-error-safety.mjs
node scripts/verify/verify-product-storefront-catalog-native-error-safety.mjs
node scripts/verify/verify-product-storefront-boundary.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-product-storefront
cargo check -p rustok-product-storefront --features hydrate
cargo check -p rustok-product-storefront --features ssr
```

Branch: `agent/product-storefront-graphql-diagnostic-safety-20260801`
Base main: `ba2b49ac520253f8d648123be712164abb9d7cda`