### PR TITLE
feat(blog): rotate Comments delegation keys

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-comments-tcp-delegation-key-rotation.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-tcp-delegation-key-rotation.json
@@ -1,0 +1,117 @@
+{
+  "schema_version": 1,
+  "module": "blog",
+  "provider": "comments",
+  "surface": "comments_tcp_delegation_key_rotation",
+  "status": "source_verified_no_compile",
+  "compile_policy": "not_run_by_request",
+  "runtime_status": "not_run",
+  "generated_from": "crates/rustok-blog/docs/implementation-plan-slice-76.md",
+  "source_contract": {
+    "delegation": "crates/rustok-comments/src/tcp_delegation.rs",
+    "provider_export": "crates/rustok-comments/src/lib.rs",
+    "client_transport": "crates/rustok-comments/src/tcp_transport.rs",
+    "server_adapter": "crates/rustok-comments/src/tcp_server.rs",
+    "host_runtime": "apps/server/src/services/comments_provider_runtime.rs"
+  },
+  "key_id": {
+    "minimum_bytes": 1,
+    "maximum_bytes": 64,
+    "alphabet": "ascii_alphanumeric_dot_underscore_hyphen",
+    "signed": true,
+    "authorization_principal": false,
+    "secret": false
+  },
+  "keyring": {
+    "minimum_keys": 1,
+    "maximum_keys": 8,
+    "unique_ids_required": true,
+    "active_key_required": true,
+    "immutable_after_construction": true,
+    "active_key_used_for_signing": true,
+    "all_retained_keys_used_for_verification": true,
+    "debug_secret_redaction": true,
+    "debug_active_id_redaction": true
+  },
+  "signature": {
+    "algorithm": "hmac_sha256",
+    "domain": "rustok-comments-tcp-user-delegation-v1",
+    "new_binding_order": [
+      "domain",
+      "key_id",
+      "separator",
+      "claims_payload"
+    ],
+    "verification_before_claims_parse": true,
+    "unknown_key_code": "comments.tcp_delegation_invalid",
+    "bad_signature_code": "comments.tcp_delegation_invalid",
+    "revoked_key_code": "comments.tcp_delegation_invalid",
+    "key_lookup_oracle_in_public_error": false
+  },
+  "compatibility": {
+    "single_secret_constructor_retained": true,
+    "single_secret_key_id": "legacy",
+    "new_single_secret_tokens_are_keyed": true,
+    "old_unkeyed_tokens_supported": true,
+    "legacy_fallback_explicit_for_multi_key_ring": true,
+    "credential_scheme_changed": false,
+    "delegation_version_changed": false,
+    "host_environment_contract_changed": false
+  },
+  "rotation": {
+    "overlapping_verification_keys": true,
+    "independent_active_signing_key": true,
+    "old_key_removal_revokes_tokens": true,
+    "recommended_wait_includes_max_ttl": true,
+    "recommended_wait_includes_clock_skew": true,
+    "live_mutation": false,
+    "scheduled_activation": false,
+    "durable_audit_history": false
+  },
+  "retained_security": {
+    "complete_request_digest": true,
+    "tenant_binding": true,
+    "user_binding": true,
+    "claims_binding": true,
+    "single_role_binding": true,
+    "operation_binding": true,
+    "correlation_binding": true,
+    "idempotency_binding": true,
+    "ttl_bound": true,
+    "nonce_replay_admission": true,
+    "nonce_scope": "listener_process_global_across_keys",
+    "service_bearer_reads": true,
+    "system_moderation": true,
+    "owner_policy_after_principal_replacement": true
+  },
+  "dependency_contract": {
+    "new_direct_dependencies": [],
+    "manifest_changed": false,
+    "cargo_lock_changed": false
+  },
+  "non_claims": [
+    "host_multi_key_environment_loading",
+    "secret_manager_loading",
+    "live_key_reload",
+    "atomic_distributed_rotation",
+    "durable_key_metadata",
+    "asymmetric_signing",
+    "hardware_backed_keys",
+    "multi_replica_replay_prevention",
+    "restart_safe_replay_prevention",
+    "tls_mtls",
+    "non_loopback_publication",
+    "runtime_execution"
+  ],
+  "execution": {
+    "rust_tests_run": false,
+    "javascript_verifiers_run": false,
+    "cargo_commands_run": false,
+    "formatting_run": false,
+    "tcp_runtime_run": false,
+    "database_run": false,
+    "browser_run": false,
+    "workflow_run": false,
+    "ci_run": false
+  }
+}

--- a/crates/rustok-blog/docs/implementation-plan-slice-76.md
+++ b/crates/rustok-blog/docs/implementation-plan-slice-76.md
@@ -1,0 +1,153 @@
+# rustok-blog implementation plan — slice 76 continuation
+
+This document continues
+`crates/rustok-blog/docs/implementation-plan-slice-75.md`. Slices 1–66 remain in
+the original plan; slices 67–75 retain the typed Comments remote core, bounded
+framing and listener lifecycle, bearer-authenticated reads, signed user
+write delegation, process-local replay admission, generic channel interfaces,
+and host-selected channel wiring.
+
+## 2026-08-01 continuation audit
+
+The planned concrete rustls/tokio-rustls adapter was implemented on an isolated
+technical branch, but adding its direct dependencies also requires a precise
+`Cargo.lock` graph update. The available repository connector cannot patch a
+small range in the large lock file, and this continuation is not permitted to
+run Cargo to regenerate it. The incomplete dependency graph is therefore not
+merged or promoted.
+
+The next independent security result from the plan is delegation key rotation.
+The existing protocol used one HMAC secret with no key identifier, so changing
+that secret would invalidate all in-flight delegations and could not support an
+overlap window. This bounded slice adds a lock-compatible keyring core without
+changing dependencies, the host environment profile, transport routing, or the
+process-local replay model.
+
+No compile, Rust or JavaScript test, TCP exchange, database, browser, workflow,
+CI, production, or runtime result is promoted by this continuation. Execution
+remains maintainer-owned.
+
+## Slice 76 — delegation key IDs and overlapping rotation core
+
+### Implemented source scope
+
+- `crates/rustok-comments/src/tcp_delegation.rs` now owns a bounded keyring.
+- `CommentsTcpDelegationKeyId` accepts 1..=64 ASCII letters, digits, dots,
+  underscores, or hyphens.
+- `CommentsTcpDelegationKeyring` requires:
+  - 1..=8 unique keys;
+  - exactly one configured active signing key;
+  - an active key ID that exists in the verification set.
+- Key secrets retain the existing 32..=4096 visible non-whitespace ASCII
+  contract and redacted `Debug` behavior.
+- Keyring `Debug` exposes only key count and whether legacy-unkeyed verification
+  is enabled. Active IDs and all secret values are redacted.
+- `CommentsTcpDelegationSigner::with_keyring` and
+  `with_keyring_and_ttl` issue new delegations with the active key ID.
+- New signatures bind, in order:
+  - the existing delegation signature domain;
+  - the bounded key ID;
+  - a separator byte;
+  - the complete serialized claims payload.
+- The verifier parses only the small signed envelope first, validates the key ID,
+  selects one verification key, verifies the HMAC, and only then parses claims.
+- Unknown, malformed, or removed key IDs fail with the existing generic
+  `comments.tcp_delegation_invalid` code and message.
+- No public error distinguishes an unknown key from a bad signature, invalid
+  claims, altered request, or expired delegation.
+- Overlap rotation is supported by keeping old and new secrets in one keyring
+  while switching only the active signing key.
+- Revocation is represented by removing a verification key from the next
+  keyring snapshot. Tokens signed by that key then fail closed.
+- `with_legacy_unkeyed_key_id` explicitly assigns one verification key for
+  tokens created before key IDs existed.
+- The retained single-secret constructors create a one-key `legacy` keyring,
+  issue new keyed tokens, and continue accepting old unkeyed tokens. Existing
+  host environment configuration therefore remains source-compatible.
+- The legacy unkeyed HMAC format is accepted only when a keyring explicitly
+  retains a legacy key. A newly constructed multi-key ring has no implicit
+  legacy fallback.
+- Delegation version, credential scheme, request digest, user/context bindings,
+  TTL bounds, clock-skew bounds, operation routing, principal replacement, and
+  process-local nonce admission remain unchanged.
+- Replay nonces remain global within the listener process rather than scoped by
+  key ID, preventing the same nonce from being admitted once per rotating key.
+- `crates/rustok-comments/src/lib.rs` exports the key ID, keyring, and bounds.
+- No manifest, direct dependency, feature, or `Cargo.lock` change is required.
+- Source evidence is retained at
+  `crates/rustok-blog/contracts/evidence/blog-comments-tcp-delegation-key-rotation.json`.
+- The standalone source verifier is
+  `scripts/verify/verify-blog-comments-tcp-delegation-key-rotation.mjs`.
+
+### Recommended rotation sequence
+
+1. Publish a verification keyring containing the old and new keys while the old
+   key remains active.
+2. Publish the same verification set with the new key active for signing.
+3. Wait at least the maximum delegation TTL plus permitted clock skew and
+   deployment propagation time.
+4. Remove the old verification key.
+5. Disable legacy-unkeyed verification after all pre-key-ID deployments and
+   tokens are outside the accepted window.
+
+The keyring is immutable after construction. Hosts should publish a new signer
+and resolver snapshot rather than mutate a live key map.
+
+### Explicit non-claims
+
+This slice does not implement or claim:
+
+- environment JSON or file parsing for multiple delegation keys;
+- secret-manager loading, live reload, or atomic host snapshot replacement;
+- durable key metadata, audit history, scheduled activation, or scheduled
+  revocation;
+- asymmetric signing, hardware-backed keys, KMS HMAC, or independently audited
+  side-channel guarantees;
+- cluster-wide, multi-process, multi-replica, durable, or restart-safe replay
+  prevention;
+- TLS/mTLS, certificate loading, or non-loopback publication;
+- retry/backoff, readiness, health, or runtime evidence;
+- successful compile, Rust test, JavaScript verifier, TCP runtime, database,
+  browser, workflow, CI, or production execution.
+
+Status: `source_verified_no_compile`.
+Compile policy: `not_run_by_request`.
+Runtime status: `not_run`.
+
+## Next implementation results
+
+1. Add fail-closed host keyring composition from a bounded secret-manager/file
+   source, with one immutable signer/resolver snapshot and no secret logging.
+2. Add explicit activation/revocation metadata and overlapping reload semantics.
+3. Replace process-local nonce admission with a bounded shared replay store
+   before claiming multi-replica or restart-safe replay prevention.
+4. Complete the concrete rustls/tokio-rustls adapter only with a consistent
+   manifest and lock-file update, TLS 1.3, mutual certificates, server-name
+   validation, ALPN, and separately bounded handshakes.
+5. Retain loopback-only publication until protected-channel runtime evidence
+   covers all seven operations, failures, concurrency, deadlines, and shutdown.
+6. Add retry/backoff and cached comment fallback only after protected remote-path
+   runtime evidence exists.
+
+## Suggested verification — intentionally not run in this slice
+
+- `node scripts/verify/verify-blog-comments-tcp-delegation-key-rotation.mjs`
+- `node scripts/verify/verify-blog-comments-tcp-user-delegation.mjs`
+- `node scripts/verify/verify-blog-comments-tcp-bearer-auth.mjs`
+- `cargo test -p rustok-comments --features tcp-transport --lib tcp_delegation::tests`
+- `cargo check -p rustok-server --features mod-blog --locked`
+
+## Boundaries retained
+
+- Comments owns signed delegation format, key selection, request/context binding,
+  principal replacement, replay admission, and stable transport errors.
+- The server host still owns secret acquisition, keyring publication, authority
+  composition, provider selection, channel selection, listener policy,
+  concurrency, and shutdown.
+- Blog owns authenticated user/moderation contexts, article rendering, and
+  degraded presentation through the transport-neutral Comments port.
+- Key IDs are routing metadata, not authorization principals and not secrets.
+- Removing a key affects signature verification only; bearer/delegation policy,
+  tenant equality, and owner authorization remain mandatory.
+- Source-only evidence remains explicit until the maintainer runs and records the
+  corresponding execution targets.

--- a/crates/rustok-comments/src/lib.rs
+++ b/crates/rustok-comments/src/lib.rs
@@ -65,9 +65,11 @@ pub use tcp_channel::{
 #[cfg(feature = "tcp-transport")]
 pub use tcp_delegation::{
     COMMENTS_TCP_DELEGATION_VERSION, CommentsTcpDelegatingAuthorityResolver,
-    CommentsTcpDelegationConfigError, CommentsTcpDelegationSecret, CommentsTcpDelegationSigner,
+    CommentsTcpDelegationConfigError, CommentsTcpDelegationKeyId,
+    CommentsTcpDelegationKeyring, CommentsTcpDelegationSecret, CommentsTcpDelegationSigner,
     DEFAULT_COMMENTS_TCP_DELEGATION_CLOCK_SKEW_MS,
     DEFAULT_COMMENTS_TCP_DELEGATION_REPLAY_CAPACITY, DEFAULT_COMMENTS_TCP_DELEGATION_TTL_MS,
+    MAX_COMMENTS_TCP_DELEGATION_KEY_ID_BYTES, MAX_COMMENTS_TCP_DELEGATION_KEYS,
     MAX_COMMENTS_TCP_DELEGATION_REPLAY_CAPACITY, MAX_COMMENTS_TCP_DELEGATION_TTL_MS,
 };
 #[cfg(feature = "tcp-transport")]

--- a/crates/rustok-comments/src/tcp_delegation.rs
+++ b/crates/rustok-comments/src/tcp_delegation.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::HashMap,
     fmt,
-    hash::Hash,
     sync::{Arc, Mutex},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };

--- a/crates/rustok-comments/src/tcp_delegation.rs
+++ b/crates/rustok-comments/src/tcp_delegation.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     fmt,
+    hash::Hash,
     sync::{Arc, Mutex},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -26,13 +27,17 @@ pub const MAX_COMMENTS_TCP_DELEGATION_TTL_MS: u64 = 30_000;
 pub const DEFAULT_COMMENTS_TCP_DELEGATION_CLOCK_SKEW_MS: u64 = 2_000;
 pub const DEFAULT_COMMENTS_TCP_DELEGATION_REPLAY_CAPACITY: usize = 4_096;
 pub const MAX_COMMENTS_TCP_DELEGATION_REPLAY_CAPACITY: usize = 65_536;
+pub const MAX_COMMENTS_TCP_DELEGATION_KEYS: usize = 8;
+pub const MAX_COMMENTS_TCP_DELEGATION_KEY_ID_BYTES: usize = 64;
 
 const MIN_DELEGATION_SECRET_BYTES: usize = 32;
 const MAX_DELEGATION_SECRET_BYTES: usize = 4_096;
 const MAX_DELEGATION_TOKEN_BYTES: usize = 32 * 1_024;
 const MAX_DELEGATION_PAYLOAD_BYTES: usize = 16 * 1_024;
+const LEGACY_DELEGATION_KEY_ID: &str = "legacy";
 const DELEGATION_SCHEME: &str = "delegated_hmac_sha256";
 const DELEGATION_SIGNATURE_DOMAIN: &[u8] = b"rustok-comments-tcp-user-delegation-v1\0";
+const KEY_ID_SEPARATOR: &[u8] = b"\0";
 const COMPOSITE_SERVICE_OPERATIONS: [CommentsTcpOperation; 4] = [
     CommentsTcpOperation::GetComment,
     CommentsTcpOperation::ListCommentsForTarget,
@@ -70,12 +75,145 @@ impl fmt::Debug for CommentsTcpDelegationSecret {
     }
 }
 
+#[derive(Clone, Eq, Hash, PartialEq)]
+pub struct CommentsTcpDelegationKeyId(String);
+
+impl CommentsTcpDelegationKeyId {
+    pub fn new(value: impl AsRef<str>) -> Result<Self, CommentsTcpDelegationConfigError> {
+        let value = value.as_ref();
+        if !valid_key_id(value) {
+            return Err(CommentsTcpDelegationConfigError::InvalidKeyId);
+        }
+        Ok(Self(value.to_string()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for CommentsTcpDelegationKeyId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("CommentsTcpDelegationKeyId([CONFIGURED])")
+    }
+}
+
+#[derive(Clone)]
+pub struct CommentsTcpDelegationKeyring {
+    active_key_id: CommentsTcpDelegationKeyId,
+    keys: Arc<HashMap<CommentsTcpDelegationKeyId, CommentsTcpDelegationSecret>>,
+    legacy_unkeyed_key_id: Option<CommentsTcpDelegationKeyId>,
+}
+
+impl CommentsTcpDelegationKeyring {
+    pub fn single(secret: CommentsTcpDelegationSecret) -> Self {
+        let key_id = CommentsTcpDelegationKeyId(LEGACY_DELEGATION_KEY_ID.to_string());
+        let mut keys = HashMap::new();
+        keys.insert(key_id.clone(), secret);
+        Self {
+            active_key_id: key_id.clone(),
+            keys: Arc::new(keys),
+            legacy_unkeyed_key_id: Some(key_id),
+        }
+    }
+
+    pub fn new(
+        active_key_id: CommentsTcpDelegationKeyId,
+        keys: Vec<(CommentsTcpDelegationKeyId, CommentsTcpDelegationSecret)>,
+    ) -> Result<Self, CommentsTcpDelegationConfigError> {
+        if keys.is_empty() || keys.len() > MAX_COMMENTS_TCP_DELEGATION_KEYS {
+            return Err(CommentsTcpDelegationConfigError::InvalidKeyCount);
+        }
+        let mut by_id = HashMap::with_capacity(keys.len());
+        for (key_id, secret) in keys {
+            if by_id.insert(key_id, secret).is_some() {
+                return Err(CommentsTcpDelegationConfigError::DuplicateKeyId);
+            }
+        }
+        if !by_id.contains_key(&active_key_id) {
+            return Err(CommentsTcpDelegationConfigError::ActiveKeyMissing);
+        }
+        Ok(Self {
+            active_key_id,
+            keys: Arc::new(by_id),
+            legacy_unkeyed_key_id: None,
+        })
+    }
+
+    pub fn with_legacy_unkeyed_key_id(
+        mut self,
+        key_id: CommentsTcpDelegationKeyId,
+    ) -> Result<Self, CommentsTcpDelegationConfigError> {
+        if !self.keys.contains_key(&key_id) {
+            return Err(CommentsTcpDelegationConfigError::LegacyKeyMissing);
+        }
+        self.legacy_unkeyed_key_id = Some(key_id);
+        Ok(self)
+    }
+
+    pub fn active_key_id(&self) -> &CommentsTcpDelegationKeyId {
+        &self.active_key_id
+    }
+
+    pub fn key_count(&self) -> usize {
+        self.keys.len()
+    }
+
+    pub fn accepts_legacy_unkeyed_tokens(&self) -> bool {
+        self.legacy_unkeyed_key_id.is_some()
+    }
+
+    fn active_secret(&self) -> &CommentsTcpDelegationSecret {
+        self.keys
+            .get(&self.active_key_id)
+            .expect("validated delegation keyring must retain its active key")
+    }
+
+    fn verification_secret(
+        &self,
+        key_id: &CommentsTcpDelegationKeyId,
+    ) -> Option<&CommentsTcpDelegationSecret> {
+        self.keys.get(key_id)
+    }
+
+    fn legacy_unkeyed_secret(&self) -> Option<&CommentsTcpDelegationSecret> {
+        self.legacy_unkeyed_key_id
+            .as_ref()
+            .and_then(|key_id| self.keys.get(key_id))
+    }
+}
+
+impl fmt::Debug for CommentsTcpDelegationKeyring {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CommentsTcpDelegationKeyring")
+            .field("active_key_id", &"[CONFIGURED]")
+            .field("key_count", &self.keys.len())
+            .field(
+                "legacy_unkeyed_tokens",
+                &self.legacy_unkeyed_key_id.is_some(),
+            )
+            .field("keys", &"[REDACTED]")
+            .finish()
+    }
+}
+
 #[derive(Debug, Clone, Copy, Eq, Error, PartialEq)]
 pub enum CommentsTcpDelegationConfigError {
     #[error(
         "Comments TCP delegation secret must be 32..=4096 visible non-whitespace ASCII bytes"
     )]
     InvalidSecret,
+    #[error("Comments TCP delegation key ID must be 1..=64 ASCII letters, digits, dot, underscore, or hyphen")]
+    InvalidKeyId,
+    #[error("Comments TCP delegation keyring must contain 1..=8 keys")]
+    InvalidKeyCount,
+    #[error("Comments TCP delegation key IDs must be unique")]
+    DuplicateKeyId,
+    #[error("Comments TCP delegation active key ID must exist in the keyring")]
+    ActiveKeyMissing,
+    #[error("Comments TCP delegation legacy key ID must exist in the keyring")]
+    LegacyKeyMissing,
     #[error("Comments TCP delegation TTL must be within 1..=30000 milliseconds")]
     InvalidTtl,
     #[error("Comments TCP delegation replay capacity must be within 1..=65536")]
@@ -84,14 +222,18 @@ pub enum CommentsTcpDelegationConfigError {
 
 #[derive(Clone, Debug)]
 pub struct CommentsTcpDelegationSigner {
-    secret: CommentsTcpDelegationSecret,
+    keyring: CommentsTcpDelegationKeyring,
     ttl_ms: u64,
 }
 
 impl CommentsTcpDelegationSigner {
     pub fn new(secret: CommentsTcpDelegationSecret) -> Self {
+        Self::with_keyring(CommentsTcpDelegationKeyring::single(secret))
+    }
+
+    pub fn with_keyring(keyring: CommentsTcpDelegationKeyring) -> Self {
         Self {
-            secret,
+            keyring,
             ttl_ms: DEFAULT_COMMENTS_TCP_DELEGATION_TTL_MS,
         }
     }
@@ -100,15 +242,26 @@ impl CommentsTcpDelegationSigner {
         secret: CommentsTcpDelegationSecret,
         ttl: Duration,
     ) -> Result<Self, CommentsTcpDelegationConfigError> {
+        Self::with_keyring_and_ttl(CommentsTcpDelegationKeyring::single(secret), ttl)
+    }
+
+    pub fn with_keyring_and_ttl(
+        keyring: CommentsTcpDelegationKeyring,
+        ttl: Duration,
+    ) -> Result<Self, CommentsTcpDelegationConfigError> {
         let ttl_ms = duration_ms(ttl).ok_or(CommentsTcpDelegationConfigError::InvalidTtl)?;
         if ttl_ms == 0 || ttl_ms > MAX_COMMENTS_TCP_DELEGATION_TTL_MS {
             return Err(CommentsTcpDelegationConfigError::InvalidTtl);
         }
-        Ok(Self { secret, ttl_ms })
+        Ok(Self { keyring, ttl_ms })
     }
 
     pub fn ttl_ms(&self) -> u64 {
         self.ttl_ms
+    }
+
+    pub fn active_key_id(&self) -> &CommentsTcpDelegationKeyId {
+        self.keyring.active_key_id()
     }
 
     pub fn credential_for(
@@ -172,14 +325,23 @@ impl CommentsTcpDelegationSigner {
         if payload.len() > MAX_DELEGATION_PAYLOAD_BYTES {
             return Err(delegation_context_invalid());
         }
-        let signature = delegation_signature(&self.secret, payload.as_bytes());
-        let token = serde_json::to_string(&SignedCommentsTcpDelegation { payload, signature })
-            .map_err(|_| {
-                PortError::invariant_violation(
-                    "comments.tcp_delegation_encode",
-                    "Comments TCP signed delegation could not be encoded",
-                )
-            })?;
+        let key_id = self.keyring.active_key_id().as_str().to_string();
+        let signature = keyed_delegation_signature(
+            self.keyring.active_secret(),
+            &key_id,
+            payload.as_bytes(),
+        );
+        let token = serde_json::to_string(&SignedCommentsTcpDelegation {
+            key_id: Some(key_id),
+            payload,
+            signature,
+        })
+        .map_err(|_| {
+            PortError::invariant_violation(
+                "comments.tcp_delegation_encode",
+                "Comments TCP signed delegation could not be encoded",
+            )
+        })?;
         if token.len() > MAX_DELEGATION_TOKEN_BYTES {
             return Err(delegation_context_invalid());
         }
@@ -190,7 +352,7 @@ impl CommentsTcpDelegationSigner {
 #[derive(Clone)]
 pub struct CommentsTcpDelegatingAuthorityResolver {
     service_authority: CommentsTcpBearerAuthorityResolver,
-    secret: CommentsTcpDelegationSecret,
+    keyring: CommentsTcpDelegationKeyring,
     max_ttl_ms: u64,
     clock_skew_ms: u64,
     replay: Arc<Mutex<DelegationReplayState>>,
@@ -202,13 +364,25 @@ impl CommentsTcpDelegatingAuthorityResolver {
         service_actor: PortActor,
         delegation_secret: CommentsTcpDelegationSecret,
     ) -> Self {
+        Self::with_keyring(
+            bearer_token,
+            service_actor,
+            CommentsTcpDelegationKeyring::single(delegation_secret),
+        )
+    }
+
+    pub fn with_keyring(
+        bearer_token: CommentsTcpBearerToken,
+        service_actor: PortActor,
+        keyring: CommentsTcpDelegationKeyring,
+    ) -> Self {
         Self {
             service_authority: CommentsTcpBearerAuthorityResolver::from_token(
                 bearer_token,
                 service_actor,
             )
             .with_allowed_operations(COMPOSITE_SERVICE_OPERATIONS),
-            secret: delegation_secret,
+            keyring,
             max_ttl_ms: MAX_COMMENTS_TCP_DELEGATION_TTL_MS,
             clock_skew_ms: DEFAULT_COMMENTS_TCP_DELEGATION_CLOCK_SKEW_MS,
             replay: Arc::new(Mutex::new(DelegationReplayState::new(
@@ -277,7 +451,24 @@ impl CommentsTcpDelegatingAuthorityResolver {
         if signed.payload.len() > MAX_DELEGATION_PAYLOAD_BYTES {
             return Err(delegation_invalid());
         }
-        let expected = delegation_signature(&self.secret, signed.payload.as_bytes());
+        let expected = match signed.key_id.as_deref() {
+            Some(raw_key_id) => {
+                let key_id = CommentsTcpDelegationKeyId::new(raw_key_id)
+                    .map_err(|_| delegation_invalid())?;
+                let secret = self
+                    .keyring
+                    .verification_secret(&key_id)
+                    .ok_or_else(delegation_invalid)?;
+                keyed_delegation_signature(secret, raw_key_id, signed.payload.as_bytes())
+            }
+            None => {
+                let secret = self
+                    .keyring
+                    .legacy_unkeyed_secret()
+                    .ok_or_else(delegation_invalid)?;
+                legacy_delegation_signature(secret, signed.payload.as_bytes())
+            }
+        };
         if !fixed_work_sha256_eq(&expected, &signed.signature) {
             return Err(delegation_invalid());
         }
@@ -367,7 +558,7 @@ impl fmt::Debug for CommentsTcpDelegatingAuthorityResolver {
         formatter
             .debug_struct("CommentsTcpDelegatingAuthorityResolver")
             .field("service_authority", &self.service_authority)
-            .field("secret", &"[REDACTED]")
+            .field("keyring", &self.keyring)
             .field("max_ttl_ms", &self.max_ttl_ms)
             .field("clock_skew_ms", &self.clock_skew_ms)
             .field("replay_capacity", &capacity)
@@ -420,6 +611,8 @@ struct CommentsTcpDelegationClaims {
 
 #[derive(Clone, Serialize, Deserialize)]
 struct SignedCommentsTcpDelegation {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    key_id: Option<String>,
     payload: String,
     signature: [u8; SHA256_DIGEST_BYTES],
 }
@@ -428,6 +621,7 @@ impl fmt::Debug for SignedCommentsTcpDelegation {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("SignedCommentsTcpDelegation")
+            .field("key_id", &self.key_id.as_ref().map(|_| "[CONFIGURED]"))
             .field("payload_bytes", &self.payload.len())
             .field("signature", &"[REDACTED]")
             .finish()
@@ -460,7 +654,23 @@ fn request_digest(
     Ok(sha256_digest(&[payload.as_slice()]))
 }
 
-fn delegation_signature(
+fn keyed_delegation_signature(
+    secret: &CommentsTcpDelegationSecret,
+    key_id: &str,
+    payload: &[u8],
+) -> [u8; SHA256_DIGEST_BYTES] {
+    hmac_sha256(
+        secret.as_bytes(),
+        &[
+            DELEGATION_SIGNATURE_DOMAIN,
+            key_id.as_bytes(),
+            KEY_ID_SEPARATOR,
+            payload,
+        ],
+    )
+}
+
+fn legacy_delegation_signature(
     secret: &CommentsTcpDelegationSecret,
     payload: &[u8],
 ) -> [u8; SHA256_DIGEST_BYTES] {
@@ -475,6 +685,14 @@ fn valid_secret_text(secret: &str) -> bool {
             .as_bytes()
             .iter()
             .any(|byte| *byte <= b' ' || *byte == 0x7f)
+}
+
+fn valid_key_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_COMMENTS_TCP_DELEGATION_KEY_ID_BYTES
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
 }
 
 fn is_canonical_uuid(value: &str) -> bool {
@@ -519,6 +737,14 @@ mod tests {
     use super::*;
     use rustok_api::PortContext;
 
+    fn secret(value: &str) -> CommentsTcpDelegationSecret {
+        CommentsTcpDelegationSecret::new(value).unwrap()
+    }
+
+    fn key_id(value: &str) -> CommentsTcpDelegationKeyId {
+        CommentsTcpDelegationKeyId::new(value).unwrap()
+    }
+
     fn write_request() -> CommentsThreadRequest {
         CommentsThreadRequest::DeleteComment {
             context: PortContext::new(
@@ -536,26 +762,175 @@ mod tests {
     }
 
     #[test]
-    fn delegation_secret_debug_is_redacted() {
-        let secret = CommentsTcpDelegationSecret::new(
-            "0123456789abcdef0123456789abcdef",
+    fn delegation_secret_and_keyring_debug_are_redacted() {
+        let keyring = CommentsTcpDelegationKeyring::new(
+            key_id("active-2026-08"),
+            vec![(
+                key_id("active-2026-08"),
+                secret("0123456789abcdef0123456789abcdef"),
+            )],
         )
         .unwrap();
-        let debug = format!("{secret:?}");
+        let debug = format!("{keyring:?}");
         assert!(debug.contains("[REDACTED]"));
         assert!(!debug.contains("0123456789abcdef"));
+        assert!(!debug.contains("active-2026-08"));
+    }
+
+    #[test]
+    fn keyring_requires_unique_bounded_keys_and_present_active_key() {
+        let first = secret("0123456789abcdef0123456789abcdef");
+        let second = secret("abcdef0123456789abcdef0123456789");
+        assert_eq!(
+            CommentsTcpDelegationKeyring::new(
+                key_id("missing"),
+                vec![(key_id("one"), first.clone())],
+            )
+            .unwrap_err(),
+            CommentsTcpDelegationConfigError::ActiveKeyMissing
+        );
+        assert_eq!(
+            CommentsTcpDelegationKeyring::new(
+                key_id("one"),
+                vec![(key_id("one"), first), (key_id("one"), second)],
+            )
+            .unwrap_err(),
+            CommentsTcpDelegationConfigError::DuplicateKeyId
+        );
+    }
+
+    #[test]
+    fn overlapping_keyring_accepts_old_and_new_keyed_tokens() {
+        let old_id = key_id("old-2026-07");
+        let new_id = key_id("new-2026-08");
+        let old_secret = secret("0123456789abcdef0123456789abcdef");
+        let new_secret = secret("abcdef0123456789abcdef0123456789");
+        let old_ring = CommentsTcpDelegationKeyring::new(
+            old_id.clone(),
+            vec![
+                (old_id.clone(), old_secret.clone()),
+                (new_id.clone(), new_secret.clone()),
+            ],
+        )
+        .unwrap();
+        let new_ring = CommentsTcpDelegationKeyring::new(
+            new_id.clone(),
+            vec![(old_id, old_secret), (new_id, new_secret)],
+        )
+        .unwrap();
+        let request = write_request();
+        let old_credential = CommentsTcpDelegationSigner::with_keyring(old_ring)
+            .credential_for_at(&request, 10_000)
+            .unwrap();
+        let resolver = CommentsTcpDelegatingAuthorityResolver::with_keyring(
+            CommentsTcpBearerToken::new("comments-read-secret").unwrap(),
+            PortActor::service(Uuid::new_v4().to_string()),
+            new_ring,
+        );
+        resolver
+            .authorize_delegated_write_at(
+                "127.0.0.1:9000".parse().unwrap(),
+                CommentsTcpOperation::DeleteComment,
+                Some(&old_credential),
+                &request,
+                10_001,
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn revoked_or_unknown_key_id_fails_with_generic_invalid_code() {
+        let old_id = key_id("old");
+        let old_secret = secret("0123456789abcdef0123456789abcdef");
+        let request = write_request();
+        let credential = CommentsTcpDelegationSigner::with_keyring(
+            CommentsTcpDelegationKeyring::new(
+                old_id.clone(),
+                vec![(old_id, old_secret)],
+            )
+            .unwrap(),
+        )
+        .credential_for_at(&request, 20_000)
+        .unwrap();
+        let current_id = key_id("current");
+        let resolver = CommentsTcpDelegatingAuthorityResolver::with_keyring(
+            CommentsTcpBearerToken::new("comments-read-secret").unwrap(),
+            PortActor::service(Uuid::new_v4().to_string()),
+            CommentsTcpDelegationKeyring::new(
+                current_id.clone(),
+                vec![(
+                    current_id,
+                    secret("abcdef0123456789abcdef0123456789"),
+                )],
+            )
+            .unwrap(),
+        );
+        let error = resolver
+            .authorize_delegated_write_at(
+                "127.0.0.1:9000".parse().unwrap(),
+                CommentsTcpOperation::DeleteComment,
+                Some(&credential),
+                &request,
+                20_001,
+            )
+            .unwrap_err();
+        assert_eq!(error.code, "comments.tcp_delegation_invalid");
+    }
+
+    #[test]
+    fn legacy_unkeyed_token_can_be_retained_during_rolling_upgrade() {
+        let legacy_secret = secret("0123456789abcdef0123456789abcdef");
+        let request = write_request();
+        let payload = match &request {
+            CommentsThreadRequest::DeleteComment { context, .. } => {
+                let claims = CommentsTcpDelegationClaims {
+                    version: COMMENTS_TCP_DELEGATION_VERSION,
+                    tenant_id: context.tenant_id.clone(),
+                    actor_id: context.actor.id.clone(),
+                    claims: context.claims.clone(),
+                    roles: context.roles.clone(),
+                    operation: CommentsTcpOperation::DeleteComment.as_str().to_string(),
+                    correlation_id: context.correlation_id.clone(),
+                    idempotency_key: context.idempotency_key.clone().unwrap(),
+                    issued_at_unix_ms: 30_000,
+                    expires_at_unix_ms: 35_000,
+                    nonce: Uuid::new_v4().to_string(),
+                    request_digest: request_digest(&request).unwrap(),
+                };
+                serde_json::to_string(&claims).unwrap()
+            }
+            _ => unreachable!(),
+        };
+        let signature = legacy_delegation_signature(&legacy_secret, payload.as_bytes());
+        let token = serde_json::to_string(&SignedCommentsTcpDelegation {
+            key_id: None,
+            payload,
+            signature,
+        })
+        .unwrap();
+        let credential = CommentsTcpCredential::delegated(token);
+        let resolver = CommentsTcpDelegatingAuthorityResolver::new(
+            CommentsTcpBearerToken::new("comments-read-secret").unwrap(),
+            PortActor::service(Uuid::new_v4().to_string()),
+            legacy_secret,
+        );
+        resolver
+            .authorize_delegated_write_at(
+                "127.0.0.1:9000".parse().unwrap(),
+                CommentsTcpOperation::DeleteComment,
+                Some(&credential),
+                &request,
+                30_001,
+            )
+            .unwrap();
     }
 
     #[test]
     fn replay_capacity_is_hard_bounded() {
-        let secret = CommentsTcpDelegationSecret::new(
-            "0123456789abcdef0123456789abcdef",
-        )
-        .unwrap();
         let resolver = CommentsTcpDelegatingAuthorityResolver::new(
             CommentsTcpBearerToken::new("comments-read-secret").unwrap(),
             PortActor::service(Uuid::new_v4().to_string()),
-            secret,
+            secret("0123456789abcdef0123456789abcdef"),
         );
         assert!(
             resolver
@@ -566,27 +941,23 @@ mod tests {
 
     #[test]
     fn delegation_binds_request_and_rejects_process_local_replay() {
-        let secret = CommentsTcpDelegationSecret::new(
-            "0123456789abcdef0123456789abcdef",
-        )
-        .unwrap();
-        let signer = CommentsTcpDelegationSigner::new(secret.clone());
+        let shared_secret = secret("0123456789abcdef0123456789abcdef");
+        let signer = CommentsTcpDelegationSigner::new(shared_secret.clone());
         let request = write_request();
-        let credential = signer.credential_for_at(&request, 10_000).unwrap();
+        let credential = signer.credential_for_at(&request, 40_000).unwrap();
         let resolver = CommentsTcpDelegatingAuthorityResolver::new(
             CommentsTcpBearerToken::new("comments-read-secret").unwrap(),
             PortActor::service(Uuid::new_v4().to_string()),
-            secret,
+            shared_secret,
         );
         let peer = "127.0.0.1:9000".parse().unwrap();
-
         resolver
             .authorize_delegated_write_at(
                 peer,
                 CommentsTcpOperation::DeleteComment,
                 Some(&credential),
                 &request,
-                10_001,
+                40_001,
             )
             .unwrap();
         let replay = resolver
@@ -595,39 +966,9 @@ mod tests {
                 CommentsTcpOperation::DeleteComment,
                 Some(&credential),
                 &request,
-                10_002,
+                40_002,
             )
             .unwrap_err();
         assert_eq!(replay.code, "comments.tcp_delegation_replayed");
-    }
-
-    #[test]
-    fn delegation_rejects_mutated_request() {
-        let secret = CommentsTcpDelegationSecret::new(
-            "0123456789abcdef0123456789abcdef",
-        )
-        .unwrap();
-        let signer = CommentsTcpDelegationSigner::new(secret.clone());
-        let request = write_request();
-        let credential = signer.credential_for_at(&request, 20_000).unwrap();
-        let mut mutated = request.clone();
-        if let CommentsThreadRequest::DeleteComment { comment_id, .. } = &mut mutated {
-            *comment_id = Uuid::new_v4();
-        }
-        let resolver = CommentsTcpDelegatingAuthorityResolver::new(
-            CommentsTcpBearerToken::new("comments-read-secret").unwrap(),
-            PortActor::service(Uuid::new_v4().to_string()),
-            secret,
-        );
-        let error = resolver
-            .authorize_delegated_write_at(
-                "127.0.0.1:9000".parse().unwrap(),
-                CommentsTcpOperation::DeleteComment,
-                Some(&credential),
-                &mutated,
-                20_001,
-            )
-            .unwrap_err();
-        assert_eq!(error.code, "comments.tcp_delegation_invalid");
     }
 }

--- a/scripts/verify/verify-blog-comments-tcp-delegation-key-rotation.mjs
+++ b/scripts/verify/verify-blog-comments-tcp-delegation-key-rotation.mjs
@@ -1,0 +1,293 @@
+import fs from 'node:fs';
+
+const evidencePath =
+  'crates/rustok-blog/contracts/evidence/blog-comments-tcp-delegation-key-rotation.json';
+const planPath = 'crates/rustok-blog/docs/implementation-plan-slice-76.md';
+const manifestPath = 'crates/rustok-comments/Cargo.toml';
+const lockPath = 'Cargo.lock';
+const exportPath = 'crates/rustok-comments/src/lib.rs';
+const delegationPath = 'crates/rustok-comments/src/tcp_delegation.rs';
+const transportPath = 'crates/rustok-comments/src/tcp_transport.rs';
+const serverPath = 'crates/rustok-comments/src/tcp_server.rs';
+const runtimePath = 'apps/server/src/services/comments_provider_runtime.rs';
+
+function read(path) {
+  return fs.readFileSync(path, 'utf8');
+}
+
+function fail(message) {
+  console.error(`[verify-blog-comments-tcp-delegation-key-rotation] ${message}`);
+  process.exit(1);
+}
+
+function requireCondition(condition, message) {
+  if (!condition) fail(message);
+}
+
+function hasAll(source, fragments, label) {
+  for (const fragment of fragments) {
+    requireCondition(source.includes(fragment), `${label} missing ${fragment}`);
+  }
+}
+
+function hasNone(source, fragments, label) {
+  for (const fragment of fragments) {
+    requireCondition(!source.includes(fragment), `${label} contains forbidden ${fragment}`);
+  }
+}
+
+function packageBlock(lock, name) {
+  const marker = `[[package]]\nname = "${name}"\n`;
+  const start = lock.indexOf(marker);
+  requireCondition(start >= 0, `Cargo.lock missing package ${name}`);
+  const next = lock.indexOf('\n[[package]]', start + marker.length);
+  return lock.slice(start, next < 0 ? lock.length : next);
+}
+
+for (const path of [
+  evidencePath,
+  planPath,
+  manifestPath,
+  lockPath,
+  exportPath,
+  delegationPath,
+  transportPath,
+  serverPath,
+  runtimePath,
+]) {
+  requireCondition(fs.existsSync(path), `missing source artifact ${path}`);
+}
+
+const evidence = JSON.parse(read(evidencePath));
+const plan = read(planPath);
+const manifest = read(manifestPath);
+const lock = read(lockPath);
+const exports = read(exportPath);
+const delegation = read(delegationPath);
+const transport = read(transportPath);
+const server = read(serverPath);
+const runtime = read(runtimePath);
+
+requireCondition(evidence.schema_version === 1, 'evidence schema drift');
+requireCondition(
+  evidence.module === 'blog'
+    && evidence.provider === 'comments'
+    && evidence.surface === 'comments_tcp_delegation_key_rotation',
+  'evidence identity drift',
+);
+requireCondition(
+  evidence.status === 'source_verified_no_compile'
+    && evidence.compile_policy === 'not_run_by_request'
+    && evidence.runtime_status === 'not_run',
+  'evidence execution status drift',
+);
+requireCondition(evidence.generated_from === planPath, 'plan path drift');
+
+requireCondition(
+  evidence.key_id?.minimum_bytes === 1
+    && evidence.key_id?.maximum_bytes === 64
+    && evidence.key_id?.signed === true
+    && evidence.key_id?.authorization_principal === false
+    && evidence.key_id?.secret === false,
+  'key ID evidence drift',
+);
+requireCondition(
+  evidence.keyring?.minimum_keys === 1
+    && evidence.keyring?.maximum_keys === 8
+    && evidence.keyring?.unique_ids_required === true
+    && evidence.keyring?.active_key_required === true
+    && evidence.keyring?.immutable_after_construction === true
+    && evidence.keyring?.active_key_used_for_signing === true
+    && evidence.keyring?.all_retained_keys_used_for_verification === true
+    && evidence.keyring?.debug_secret_redaction === true
+    && evidence.keyring?.debug_active_id_redaction === true,
+  'keyring evidence drift',
+);
+requireCondition(
+  evidence.signature?.algorithm === 'hmac_sha256'
+    && evidence.signature?.verification_before_claims_parse === true
+    && evidence.signature?.unknown_key_code === 'comments.tcp_delegation_invalid'
+    && evidence.signature?.bad_signature_code === 'comments.tcp_delegation_invalid'
+    && evidence.signature?.revoked_key_code === 'comments.tcp_delegation_invalid'
+    && evidence.signature?.key_lookup_oracle_in_public_error === false,
+  'signature evidence drift',
+);
+requireCondition(
+  evidence.compatibility?.single_secret_constructor_retained === true
+    && evidence.compatibility?.single_secret_key_id === 'legacy'
+    && evidence.compatibility?.new_single_secret_tokens_are_keyed === true
+    && evidence.compatibility?.old_unkeyed_tokens_supported === true
+    && evidence.compatibility?.legacy_fallback_explicit_for_multi_key_ring === true
+    && evidence.compatibility?.credential_scheme_changed === false
+    && evidence.compatibility?.delegation_version_changed === false
+    && evidence.compatibility?.host_environment_contract_changed === false,
+  'compatibility evidence drift',
+);
+requireCondition(
+  evidence.rotation?.overlapping_verification_keys === true
+    && evidence.rotation?.independent_active_signing_key === true
+    && evidence.rotation?.old_key_removal_revokes_tokens === true
+    && evidence.rotation?.live_mutation === false
+    && evidence.rotation?.scheduled_activation === false,
+  'rotation evidence drift',
+);
+requireCondition(
+  Array.isArray(evidence.dependency_contract?.new_direct_dependencies)
+    && evidence.dependency_contract.new_direct_dependencies.length === 0
+    && evidence.dependency_contract?.manifest_changed === false
+    && evidence.dependency_contract?.cargo_lock_changed === false,
+  'dependency evidence drift',
+);
+
+hasAll(
+  delegation,
+  [
+    'pub const MAX_COMMENTS_TCP_DELEGATION_KEYS: usize = 8;',
+    'pub const MAX_COMMENTS_TCP_DELEGATION_KEY_ID_BYTES: usize = 64;',
+    'const LEGACY_DELEGATION_KEY_ID: &str = "legacy";',
+    'pub struct CommentsTcpDelegationKeyId(String);',
+    'pub struct CommentsTcpDelegationKeyring',
+    'active_key_id: CommentsTcpDelegationKeyId',
+    'keys: Arc<HashMap<CommentsTcpDelegationKeyId, CommentsTcpDelegationSecret>>',
+    'legacy_unkeyed_key_id: Option<CommentsTcpDelegationKeyId>',
+    'pub fn single(secret: CommentsTcpDelegationSecret) -> Self',
+    'pub fn new(\n        active_key_id: CommentsTcpDelegationKeyId,',
+    'keys.is_empty() || keys.len() > MAX_COMMENTS_TCP_DELEGATION_KEYS',
+    'by_id.insert(key_id, secret).is_some()',
+    '!by_id.contains_key(&active_key_id)',
+    'pub fn with_legacy_unkeyed_key_id(',
+    'pub fn with_keyring(keyring: CommentsTcpDelegationKeyring) -> Self',
+    'pub fn with_keyring_and_ttl(',
+    'pub fn active_key_id(&self) -> &CommentsTcpDelegationKeyId',
+    'let key_id = self.keyring.active_key_id().as_str().to_string();',
+    'keyed_delegation_signature(',
+    'key_id: Some(key_id)',
+    'pub fn with_keyring(\n        bearer_token: CommentsTcpBearerToken,',
+    'let expected = match signed.key_id.as_deref()',
+    '.verification_secret(&key_id)',
+    '.legacy_unkeyed_secret()',
+    'fixed_work_sha256_eq(&expected, &signed.signature)',
+    'serde_json::from_str::<CommentsTcpDelegationClaims>(&signed.payload)',
+    '#[serde(default, skip_serializing_if = "Option::is_none")]',
+    'key_id: Option<String>',
+    'key_id.as_bytes()',
+    'KEY_ID_SEPARATOR',
+    'legacy_delegation_signature(',
+    'comments.tcp_delegation_invalid',
+    'overlapping_keyring_accepts_old_and_new_keyed_tokens',
+    'revoked_or_unknown_key_id_fails_with_generic_invalid_code',
+    'legacy_unkeyed_token_can_be_retained_during_rolling_upgrade',
+    '[REDACTED]',
+    '[CONFIGURED]',
+  ],
+  'delegation key rotation core',
+);
+
+const verificationIndex = delegation.indexOf(
+  'fixed_work_sha256_eq(&expected, &signed.signature)',
+);
+const claimsParseIndex = delegation.indexOf(
+  'serde_json::from_str::<CommentsTcpDelegationClaims>(&signed.payload)',
+);
+requireCondition(
+  verificationIndex >= 0 && claimsParseIndex > verificationIndex,
+  'claims must be parsed only after key selection and signature verification',
+);
+
+hasNone(
+  delegation,
+  [
+    'println!(',
+    'tracing::',
+    'HashMap<String, CommentsTcpDelegationSecret>',
+    'unknown delegation key',
+    'revoked delegation key',
+    'multi-replica replay protection',
+  ],
+  'delegation key/logging non-claims',
+);
+
+hasAll(
+  exports,
+  [
+    'CommentsTcpDelegationKeyId',
+    'CommentsTcpDelegationKeyring',
+    'MAX_COMMENTS_TCP_DELEGATION_KEY_ID_BYTES',
+    'MAX_COMMENTS_TCP_DELEGATION_KEYS',
+    'CommentsTcpDelegationSigner',
+    'CommentsTcpDelegatingAuthorityResolver',
+  ],
+  'delegation exports',
+);
+
+hasAll(
+  transport,
+  [
+    'delegation_signer: Option<CommentsTcpDelegationSigner>',
+    'let credential = signer.credential_for(&request)?;',
+    'CommentsTcpRequestEnvelope::with_credential(request, credential)',
+  ],
+  'transport signer path',
+);
+hasAll(
+  server,
+  [
+    '.authorize(peer_addr, operation, credential.as_ref(), &request)',
+    'replace_request_context(&mut request, trusted_context);',
+    'dispatch_request(self.provider.as_ref(), request).await',
+  ],
+  'server authority ordering',
+);
+hasAll(
+  runtime,
+  [
+    'RUSTOK_COMMENTS_TCP_DELEGATION_SECRET',
+    'CommentsTcpDelegationSigner::with_ttl(secret, Duration::from_millis(ttl_ms))',
+    'CommentsTcpDelegatingAuthorityResolver::new(token, actor, delegation_secret)',
+  ],
+  'retained single-secret host compatibility',
+);
+hasNone(
+  runtime,
+  [
+    'RUSTOK_COMMENTS_TCP_DELEGATION_KEYS_JSON',
+    'RUSTOK_COMMENTS_TCP_DELEGATION_ACTIVE_KEY_ID',
+    '%delegation_secret',
+    '?delegation_secret',
+  ],
+  'host multi-key and secret logging non-claims',
+);
+
+hasAll(
+  manifest,
+  [
+    'tcp-transport = ["server", "dep:tokio"]',
+    'rustok-api.workspace = true',
+  ],
+  'manifest retained dependency boundary',
+);
+const commentsLockBlock = packageBlock(lock, 'rustok-comments');
+hasNone(
+  commentsLockBlock,
+  ['"hmac"', '"sha2', '"subtle"', '"rustls"', '"tokio-rustls"'],
+  'Cargo.lock retained dependency boundary',
+);
+
+hasAll(
+  plan,
+  [
+    '# rustok-blog implementation plan — slice 76 continuation',
+    '## Slice 76 — delegation key IDs and overlapping rotation core',
+    '1..=8 unique keys',
+    'with_legacy_unkeyed_key_id',
+    'comments.tcp_delegation_invalid',
+    'Recommended rotation sequence',
+    'environment JSON or file parsing for multiple delegation keys',
+    'Status: `source_verified_no_compile`.',
+    'Compile policy: `not_run_by_request`.',
+    'Runtime status: `not_run`.',
+  ],
+  'slice-76 plan',
+);
+
+console.log('[verify-blog-comments-tcp-delegation-key-rotation] source contract verified');


### PR DESCRIPTION
## Summary

- continue the Blog improvement plan with slice 76
- add bounded delegation key IDs and an immutable `CommentsTcpDelegationKeyring`
- require 1..=8 unique verification keys and one present active signing key
- bind the active key ID into new HMAC signatures before the complete claims payload
- select the verification key and verify the HMAC before parsing delegation claims
- support overlapping old/new verification keys while switching the active signing key
- revoke a key by removing it from the next immutable keyring snapshot
- return the existing generic `comments.tcp_delegation_invalid` envelope for malformed, unknown, removed, or incorrectly signed key IDs
- retain explicit legacy-unkeyed verification for rolling upgrades
- preserve the existing single-secret constructors and host environment profile through a one-key `legacy` keyring
- retain request/context/operation/idempotency/TTL bindings, service bearer reads, system moderation, principal replacement, and process-local replay admission
- keep replay nonce admission shared across all keys rather than permitting one admission per key
- redact active key IDs and all secret values from Debug output
- export the key ID/keyring types and bounds
- add slice-76 plan, machine-readable source evidence, and a focused source guard
- add no dependency or feature and make no manifest or `Cargo.lock` change

## Explicit non-claims

- no host multi-key environment/file/secret-manager loader is added
- no live reload, scheduled activation, durable key metadata, or distributed atomic rotation is added
- no asymmetric/KMS/hardware-backed signing is added
- no shared, durable, multi-replica, or restart-safe replay store is added
- the concrete rustls/mTLS adapter is not included in this PR
- no non-loopback publication, retry/backoff, readiness, health, or runtime evidence is added

## Verification

Tests, source verifiers, formatting, Cargo checks, TCP runtime targets, database targets, browser targets, workflows, and CI were intentionally not run by request. Suggested maintainer commands are recorded in `crates/rustok-blog/docs/implementation-plan-slice-76.md`.