### PR TITLE
test(forum): add translation moderation Search proof

### DIFF
--- a/apps/server/tests/forum_versioned_invalidation_translation_moderation.rs
+++ b/apps/server/tests/forum_versioned_invalidation_translation_moderation.rs
@@ -1,0 +1,1396 @@
+use std::collections::BTreeSet;
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::io::{Error as IoError, ErrorKind};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use rustok_api::{PortError, RequestContext};
+use rustok_core::{MigrationSource, SecurityContext, UserRole};
+use rustok_events::{
+    ContractEventEnvelope, ContractEventPayload, DomainEvent, EventEnvelope,
+    ForumSearchProjectionEvent,
+};
+use rustok_forum::{
+    CategoryService, CreateCategoryInput, CreateReplyInput, CreateTopicInput, ForumModule,
+    ForumSearchProjectionSourceFactory, ForumSearchResultCandidate,
+    ForumSearchResultCandidateKind, ForumSearchResultEligibilityService, ModerationService,
+    ReplyService, TopicService, UpdateCategoryInput, UpdateTopicInput,
+};
+use rustok_outbox::{OutboxModule, OutboxTransport, TransactionalEventBus};
+use rustok_search::{
+    ForumProjectionReconciler, ForumSearchContractIngress,
+    ForumSearchContractIngressOutcome, ForumStorefrontSearchAttributeFilter,
+    ForumStorefrontSearchRequest, SearchModule, SearchProjectionSourceFactory,
+    SharedStorefrontSearchCategoryScopePort, SharedStorefrontSearchResultEligibilityPort,
+    StorefrontSearchCategoryScopePort, StorefrontSearchCategoryScopeRequest,
+    StorefrontSearchResultCandidate, StorefrontSearchResultCandidateKind,
+    StorefrontSearchResultEligibilityPort, StorefrontSearchResultEligibilityRequest,
+    StorefrontSearchTransport, execute_forum_storefront_search,
+};
+use rustok_taxonomy::TaxonomyModule;
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
+    Value as SqlValue,
+};
+use sea_orm_migration::SchemaManager;
+use serde::Serialize;
+use serde_json::{Value as JsonValue, json};
+use uuid::Uuid;
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+const SEARCH_TEST_DATABASE_ENV: &str = "RUSTOK_SEARCH_TEST_DATABASE_URL";
+const FORUM_TEST_DATABASE_ENV: &str = "RUSTOK_FORUM_TEST_DATABASE_URL";
+const ROOT_EVENT_TYPE: &str = "index.reindex_requested";
+const TYPED_EVENT_TYPE: &str = "forum.search_projection.invalidation_issued";
+const ENGLISH_TOPIC_MARKER: &str = "d14englishtopicmarker";
+const FRENCH_CATEGORY_MARKER: &str = "d14frenchcategorymarker";
+const FRENCH_TOPIC_MARKER: &str = "d14frenchtopicmarker";
+const APPROVED_REPLY_MARKER: &str = "d14approvedreplymarker";
+const EVIDENCE_CONTRACT: &str =
+    "forum_search_link_forum_03_translation_moderation_evidence_v1";
+const EVIDENCE_PATH: &str =
+    "target/forum-search-link-forum-03-translation-moderation-evidence.json";
+
+struct PostgresTranslationModerationEvidence {
+    control: DatabaseConnection,
+    db: DatabaseConnection,
+    schema_name: String,
+}
+
+impl PostgresTranslationModerationEvidence {
+    async fn setup(scope: &str) -> TestResult<Option<Self>> {
+        let Some(database_url) = postgres_database_url() else {
+            eprintln!(
+                "{SEARCH_TEST_DATABASE_ENV} is not set to a PostgreSQL URL; skipping Forum translation/moderation proof"
+            );
+            return Ok(None);
+        };
+
+        let control = connect(&database_url, 1).await?;
+        let schema_name = format!(
+            "rustok_forum_translation_moderation_{}_{}",
+            sanitize_identifier(scope),
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let db = connect_in_schema(&database_url, &schema_name, 10).await?;
+        let setup_result = async {
+            db.execute_unprepared(
+                r#"
+                CREATE TABLE users (
+                    id UUID NOT NULL PRIMARY KEY,
+                    tenant_id UUID NOT NULL
+                )
+                "#,
+            )
+            .await?;
+            let manager = SchemaManager::new(&db);
+            for migration in OutboxModule.migrations() {
+                migration.up(&manager).await?;
+            }
+            for migration in TaxonomyModule.migrations() {
+                migration.up(&manager).await?;
+            }
+            for migration in ForumModule.migrations() {
+                migration.up(&manager).await?;
+            }
+            for migration in SearchModule.migrations() {
+                migration.up(&manager).await?;
+            }
+            Ok::<(), sea_orm::DbErr>(())
+        }
+        .await;
+        if let Err(error) = setup_result {
+            let _ = control
+                .execute_unprepared(&format!(r#"DROP SCHEMA IF EXISTS "{schema_name}" CASCADE"#))
+                .await;
+            return Err(error.into());
+        }
+
+        Ok(Some(Self {
+            control,
+            db,
+            schema_name,
+        }))
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ForumFixture {
+    tenant_id: Uuid,
+    category_id: Uuid,
+    topic_id: Uuid,
+    reply_id: Uuid,
+    admin_id: Uuid,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct OwnerRevisionRow {
+    revision: i64,
+    event_id: Uuid,
+    target_type: String,
+    target_id: Option<Uuid>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct DeliveryIdentityFact {
+    owner_revision: i64,
+    root_event_id: Uuid,
+    typed_envelope_id: Uuid,
+    ingest_sequence: i64,
+    scope_key: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct InboxOrderRow {
+    ingest_sequence: i64,
+    event_id: Uuid,
+    scope_key: String,
+    event_type: String,
+    status: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct SearchDocumentRow {
+    document_id: Uuid,
+    entity_type: String,
+    locale: String,
+    status: String,
+    title: String,
+    body: String,
+    facets: JsonValue,
+    payload: JsonValue,
+}
+
+#[derive(Debug, Serialize)]
+struct ScenarioEvidence {
+    id: &'static str,
+    result: &'static str,
+    facts: JsonValue,
+}
+
+#[derive(Debug, Serialize)]
+struct TranslationModerationEvidenceArtifact {
+    contract: &'static str,
+    task: &'static str,
+    source_commit: String,
+    generated_at: String,
+    database_backend: &'static str,
+    broker_used: bool,
+    scenario_results: Vec<ScenarioEvidence>,
+}
+
+#[derive(Clone)]
+struct ExactCategoryScopePort;
+
+#[async_trait]
+impl StorefrontSearchCategoryScopePort for ExactCategoryScopePort {
+    async fn expand_forum_category_scope(
+        &self,
+        request: StorefrontSearchCategoryScopeRequest,
+    ) -> Result<Vec<Uuid>, PortError> {
+        Ok(request.category_ids)
+    }
+}
+
+#[derive(Clone)]
+struct RealForumPublicEligibilityPort {
+    db: DatabaseConnection,
+}
+
+#[async_trait]
+impl StorefrontSearchResultEligibilityPort for RealForumPublicEligibilityPort {
+    async fn filter_forum_result_candidates(
+        &self,
+        request: StorefrontSearchResultEligibilityRequest,
+    ) -> Result<Vec<StorefrontSearchResultCandidate>, PortError> {
+        let candidates = request
+            .candidates
+            .iter()
+            .copied()
+            .map(to_forum_candidate)
+            .collect::<Vec<_>>();
+        let channel_slug = request
+            .request_context
+            .as_ref()
+            .and_then(|context| context.channel_slug.as_deref());
+        let allowed = ForumSearchResultEligibilityService::new(self.db.clone())
+            .filter_public_storefront_visible(request.tenant_id, channel_slug, &candidates)
+            .await
+            .map_err(|_| {
+                PortError::unavailable(
+                    "forum.search_projection.translation_moderation_owner_unavailable",
+                    "Forum Search result eligibility is temporarily unavailable",
+                )
+            })?;
+        Ok(allowed.into_iter().map(from_forum_candidate).collect())
+    }
+}
+
+fn to_forum_candidate(candidate: StorefrontSearchResultCandidate) -> ForumSearchResultCandidate {
+    ForumSearchResultCandidate {
+        document_id: candidate.document_id,
+        kind: match candidate.kind {
+            StorefrontSearchResultCandidateKind::ForumTopic => {
+                ForumSearchResultCandidateKind::Topic
+            }
+            StorefrontSearchResultCandidateKind::ForumReply => {
+                ForumSearchResultCandidateKind::Reply
+            }
+        },
+    }
+}
+
+fn from_forum_candidate(candidate: ForumSearchResultCandidate) -> StorefrontSearchResultCandidate {
+    StorefrontSearchResultCandidate {
+        document_id: candidate.document_id,
+        kind: match candidate.kind {
+            ForumSearchResultCandidateKind::Topic => {
+                StorefrontSearchResultCandidateKind::ForumTopic
+            }
+            ForumSearchResultCandidateKind::Reply => {
+                StorefrontSearchResultCandidateKind::ForumReply
+            }
+        },
+    }
+}
+
+#[tokio::test]
+async fn translation_and_moderation_approval_reach_storefront_search() -> TestResult<()> {
+    let Some(evidence) = PostgresTranslationModerationEvidence::setup("link").await? else {
+        return Ok(());
+    };
+
+    let proof = run_translation_moderation_proof(&evidence.db).await;
+    let cleanup = evidence.cleanup().await;
+    let scenario = proof?;
+    cleanup?;
+
+    write_evidence(TranslationModerationEvidenceArtifact {
+        contract: EVIDENCE_CONTRACT,
+        task: "FORUM-23B2G2B3D14",
+        source_commit: source_commit()?,
+        generated_at: Utc::now().to_rfc3339(),
+        database_backend: "postgresql",
+        broker_used: false,
+        scenario_results: vec![scenario],
+    })?;
+    Ok(())
+}
+
+async fn run_translation_moderation_proof(
+    db: &DatabaseConnection,
+) -> TestResult<ScenarioEvidence> {
+    let fixture = create_forum_fixture(db).await?;
+    let projection_source = ForumSearchProjectionSourceFactory.build(db.clone());
+    let reconciler = ForumProjectionReconciler::new(db.clone(), projection_source);
+
+    let baseline_revisions = load_owner_revisions_after(db, fixture.tenant_id, 0).await?;
+    ensure_revision_shape(
+        &baseline_revisions,
+        1,
+        &[
+            ("forum", None),
+            ("forum_category", Some(fixture.category_id)),
+        ],
+        "baseline",
+    )?;
+    let baseline_deliveries = ingest_exact_typed_revisions(db, fixture, &baseline_revisions).await?;
+    let baseline_report = reconciler.sweep_due(1, 16).await?;
+    if baseline_report.claimed_events != 2
+        || baseline_report.completed_events != 2
+        || baseline_report.failed_events != 0
+    {
+        return Err(test_error(format!(
+            "baseline Forum projection did not complete exactly two events: {baseline_report:?}"
+        )));
+    }
+    let baseline_documents = load_forum_documents(db, fixture.tenant_id).await?;
+    ensure_baseline_documents(&baseline_documents, fixture)?;
+    assert_storefront_exact(
+        db,
+        fixture,
+        "en",
+        ENGLISH_TOPIC_MARKER,
+        "forum_topic",
+        "open",
+        fixture.topic_id,
+        1,
+    )
+    .await?;
+    assert_storefront_exact(
+        db,
+        fixture,
+        "en",
+        APPROVED_REPLY_MARKER,
+        "forum_reply",
+        "approved",
+        fixture.reply_id,
+        0,
+    )
+    .await?;
+
+    let category_service = CategoryService::new(db.clone());
+    category_service
+        .update(
+            fixture.tenant_id,
+            fixture.category_id,
+            admin_security(fixture.admin_id),
+            UpdateCategoryInput {
+                locale: "fr".to_string(),
+                name: Some(format!("Catégorie D14 {FRENCH_CATEGORY_MARKER}")),
+                slug: Some("d14-categorie-francaise".to_string()),
+                description: Some(format!("Description {FRENCH_CATEGORY_MARKER}")),
+                icon: None,
+                color: None,
+                position: None,
+                moderated: None,
+            },
+        )
+        .await?;
+    let bus = event_bus(db.clone());
+    TopicService::new(db.clone(), bus.clone())
+        .update(
+            fixture.tenant_id,
+            fixture.topic_id,
+            admin_security(fixture.admin_id),
+            UpdateTopicInput {
+                locale: "fr".to_string(),
+                title: Some(format!("Sujet D14 {FRENCH_TOPIC_MARKER}")),
+                body: Some(format!("Corps français D14 {FRENCH_TOPIC_MARKER}")),
+                body_format: Some("markdown".to_string()),
+                content_json: None,
+                metadata: None,
+                tags: None,
+                channel_slugs: None,
+            },
+        )
+        .await?;
+
+    let translation_revisions = load_owner_revisions_after(db, fixture.tenant_id, 2).await?;
+    ensure_revision_shape(
+        &translation_revisions,
+        3,
+        &[
+            ("forum", None),
+            ("forum_topic", Some(fixture.topic_id)),
+        ],
+        "translation",
+    )?;
+    let translation_deliveries =
+        ingest_exact_typed_revisions(db, fixture, &translation_revisions).await?;
+    let translation_report = reconciler.sweep_due(1, 16).await?;
+    if translation_report.claimed_events != 2
+        || translation_report.completed_events != 2
+        || translation_report.failed_events != 0
+    {
+        return Err(test_error(format!(
+            "translation projection did not complete exactly two events: {translation_report:?}"
+        )));
+    }
+    let translated_documents = load_forum_documents(db, fixture.tenant_id).await?;
+    ensure_translated_documents(&translated_documents, fixture)?;
+    assert_storefront_exact(
+        db,
+        fixture,
+        "fr",
+        FRENCH_TOPIC_MARKER,
+        "forum_topic",
+        "open",
+        fixture.topic_id,
+        1,
+    )
+    .await?;
+    assert_storefront_exact(
+        db,
+        fixture,
+        "en",
+        ENGLISH_TOPIC_MARKER,
+        "forum_topic",
+        "open",
+        fixture.topic_id,
+        1,
+    )
+    .await?;
+    assert_storefront_exact(
+        db,
+        fixture,
+        "en",
+        APPROVED_REPLY_MARKER,
+        "forum_reply",
+        "approved",
+        fixture.reply_id,
+        0,
+    )
+    .await?;
+
+    let before_approval_sequence = max_ingest_sequence(db).await?;
+    ModerationService::new(db.clone(), bus)
+        .approve_reply(
+            fixture.tenant_id,
+            fixture.reply_id,
+            fixture.topic_id,
+            admin_security(fixture.admin_id),
+        )
+        .await?;
+    let approval_revisions = load_owner_revisions_after(db, fixture.tenant_id, 4).await?;
+    ensure_revision_shape(
+        &approval_revisions,
+        5,
+        &[("forum_category", Some(fixture.category_id))],
+        "approval",
+    )?;
+    let approval_status_event = load_reply_status_event(
+        db,
+        fixture.tenant_id,
+        fixture.topic_id,
+        fixture.reply_id,
+        "pending",
+        "approved",
+    )
+    .await?;
+    insert_legacy_root(db, &approval_status_event, "forum").await?;
+    let approval_deliveries = ingest_exact_typed_revisions(db, fixture, &approval_revisions).await?;
+    let approval_inbox_order =
+        load_inbox_order_after(db, fixture.tenant_id, before_approval_sequence).await?;
+    if approval_inbox_order.len() != 2
+        || approval_inbox_order[0].event_id != approval_status_event.id
+        || approval_inbox_order[1].event_id != approval_revisions[0].event_id
+        || approval_inbox_order[0].ingest_sequence >= approval_inbox_order[1].ingest_sequence
+    {
+        return Err(test_error(format!(
+            "approval legacy/typed inbox order drifted: {approval_inbox_order:?}"
+        )));
+    }
+    let approval_report = reconciler.sweep_due(1, 16).await?;
+    if approval_report.claimed_events != 2
+        || approval_report.completed_events != 2
+        || approval_report.failed_events != 0
+    {
+        return Err(test_error(format!(
+            "approval projection did not complete legacy and typed events: {approval_report:?}"
+        )));
+    }
+
+    let approved_documents = load_forum_documents(db, fixture.tenant_id).await?;
+    ensure_approved_documents(&approved_documents, fixture)?;
+    assert_storefront_exact(
+        db,
+        fixture,
+        "en",
+        APPROVED_REPLY_MARKER,
+        "forum_reply",
+        "approved",
+        fixture.reply_id,
+        1,
+    )
+    .await?;
+    assert_storefront_exact(
+        db,
+        fixture,
+        "fr",
+        FRENCH_TOPIC_MARKER,
+        "forum_topic",
+        "open",
+        fixture.topic_id,
+        1,
+    )
+    .await?;
+
+    let all_revisions = load_owner_revisions_after(db, fixture.tenant_id, 0).await?;
+    if all_revisions.len() != 5
+        || all_revisions
+            .windows(2)
+            .any(|pair| pair[1].revision != pair[0].revision + 1)
+    {
+        return Err(test_error(format!(
+            "D14 owner revisions are not exactly contiguous 1 through 5: {all_revisions:?}"
+        )));
+    }
+    let root_ids = load_root_event_ids(db, fixture.tenant_id).await?;
+    let revision_ids = all_revisions
+        .iter()
+        .map(|revision| revision.event_id)
+        .collect::<BTreeSet<_>>();
+    if root_ids != revision_ids {
+        return Err(test_error(format!(
+            "D14 ledger/root identities diverged: revisions={revision_ids:?}, roots={root_ids:?}"
+        )));
+    }
+    for revision in &all_revisions {
+        if count_inbox_rows(db, revision.event_id).await? != 1 {
+            return Err(test_error(format!(
+                "D14 root {} did not retain exactly one Search inbox row",
+                revision.event_id
+            )));
+        }
+    }
+    if count_inbox_rows(db, approval_status_event.id).await? != 1 {
+        return Err(test_error(
+            "D14 approval status event did not retain exactly one Search inbox row",
+        ));
+    }
+
+    let caught_up = reconciler.sweep_due(1, 16).await?;
+    if caught_up.claimed_events != 0
+        || caught_up.completed_events != 0
+        || caught_up.failed_events != 0
+    {
+        return Err(test_error(format!(
+            "caught-up D14 repeat performed duplicate work: {caught_up:?}"
+        )));
+    }
+
+    Ok(ScenarioEvidence {
+        id: "translation_and_moderation_approval",
+        result: "passed",
+        facts: json!({
+            "tenant_id": fixture.tenant_id,
+            "category_id": fixture.category_id,
+            "topic_id": fixture.topic_id,
+            "reply_id": fixture.reply_id,
+            "owner_revision_rows": all_revisions,
+            "baseline_deliveries": baseline_deliveries,
+            "translation_deliveries": translation_deliveries,
+            "approval_deliveries": approval_deliveries,
+            "approval_status_root_event_id": approval_status_event.id,
+            "approval_inbox_order": approval_inbox_order,
+            "baseline_documents": baseline_documents,
+            "translated_documents": translated_documents,
+            "approved_documents": approved_documents,
+            "english_topic_remained_visible": true,
+            "french_topic_became_visible": true,
+            "pending_reply_visible_before_approval": false,
+            "approved_reply_visible_after_approval": true,
+            "owner_revision_compared_to_ingest_sequence": false,
+            "caught_up_repeat_performed_work": false,
+            "topic_move_executed": false,
+            "topic_move_blocked_on": "FORUM-21"
+        }),
+    })
+}
+
+async fn create_forum_fixture(db: &DatabaseConnection) -> TestResult<ForumFixture> {
+    let tenant_id = Uuid::new_v4();
+    let admin_id = Uuid::new_v4();
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "INSERT INTO users (id, tenant_id) VALUES ($1, $2)",
+        vec![admin_id.into(), tenant_id.into()],
+    ))
+    .await?;
+
+    let admin = admin_security(admin_id);
+    let category = CategoryService::new(db.clone())
+        .create(
+            tenant_id,
+            admin.clone(),
+            CreateCategoryInput {
+                locale: "en".to_string(),
+                name: "D14 moderated category".to_string(),
+                slug: "d14-moderated-category".to_string(),
+                description: Some("D14 translation moderation evidence".to_string()),
+                icon: None,
+                color: None,
+                parent_id: None,
+                position: Some(0),
+                moderated: true,
+            },
+        )
+        .await?;
+    let bus = event_bus(db.clone());
+    let topic = TopicService::new(db.clone(), bus.clone())
+        .create(
+            tenant_id,
+            customer_security(),
+            CreateTopicInput {
+                locale: "en".to_string(),
+                category_id: category.id,
+                title: format!("D14 English topic {ENGLISH_TOPIC_MARKER}"),
+                slug: Some("d14-english-topic".to_string()),
+                body: format!("D14 English body {ENGLISH_TOPIC_MARKER}"),
+                body_format: "markdown".to_string(),
+                content_json: None,
+                metadata: json!({}),
+                tags: Vec::new(),
+                channel_slugs: None,
+            },
+        )
+        .await?;
+    let reply = ReplyService::new(db.clone(), bus)
+        .create(
+            tenant_id,
+            customer_security(),
+            topic.id,
+            CreateReplyInput {
+                locale: "en".to_string(),
+                content: format!("D14 pending reply {APPROVED_REPLY_MARKER}"),
+                content_format: "markdown".to_string(),
+                content_json: None,
+                parent_reply_id: None,
+            },
+        )
+        .await?;
+    if reply.status != "pending" {
+        return Err(test_error(format!(
+            "D14 moderated category produced reply status `{}` instead of pending",
+            reply.status
+        )));
+    }
+
+    Ok(ForumFixture {
+        tenant_id,
+        category_id: category.id,
+        topic_id: topic.id,
+        reply_id: reply.id,
+        admin_id,
+    })
+}
+
+async fn ingest_exact_typed_revisions(
+    db: &DatabaseConnection,
+    fixture: ForumFixture,
+    revisions: &[OwnerRevisionRow],
+) -> TestResult<Vec<DeliveryIdentityFact>> {
+    let mut facts = Vec::with_capacity(revisions.len());
+    for revision in revisions {
+        let root = load_root_envelope(db, fixture.tenant_id, revision.event_id).await?;
+        root.validate_registered_schema()?;
+        if root.causation_id.is_some()
+            || !matches!(
+                &root.event,
+                DomainEvent::ReindexRequested {
+                    target_type,
+                    target_id,
+                } if target_type == &revision.target_type && *target_id == revision.target_id
+            )
+        {
+            return Err(test_error(format!(
+                "D14 root envelope does not match owner revision: root={root:?}, revision={revision:?}"
+            )));
+        }
+        let typed = load_typed_envelope(db, fixture.tenant_id, revision.event_id).await?;
+        typed.validate_registered_schema()?;
+        if typed.id() == revision.event_id
+            || typed.causation_id() != Some(revision.event_id)
+            || typed.event_type() != TYPED_EVENT_TYPE
+            || typed.schema_version() != 1
+        {
+            return Err(test_error(format!(
+                "D14 typed envelope lost transport/root identity: {typed:?}"
+            )));
+        }
+        match typed.payload()? {
+            ContractEventPayload::ForumSearchProjection(
+                ForumSearchProjectionEvent::InvalidationIssued {
+                    owner_revision,
+                    target_type,
+                    target_id,
+                },
+            ) if *owner_revision == revision.revision
+                && target_type == &revision.target_type
+                && *target_id == revision.target_id => {}
+            payload => {
+                return Err(test_error(format!(
+                    "D14 typed payload does not match owner revision: {payload:?}"
+                )));
+            }
+        }
+        match ForumSearchContractIngress::new(db.clone())
+            .ingest(&typed)
+            .await?
+        {
+            ForumSearchContractIngressOutcome::DurablyAccepted {
+                root_event_id,
+                owner_revision,
+            } if root_event_id == revision.event_id && owner_revision == revision.revision => {}
+            outcome => {
+                return Err(test_error(format!(
+                    "D14 typed ingress returned unexpected outcome: {outcome:?}"
+                )));
+            }
+        }
+        let inbox = load_inbox_row(db, revision.event_id).await?;
+        if inbox.status != "pending" || inbox.ingest_sequence <= 0 {
+            return Err(test_error(format!(
+                "D14 typed ingress did not create a pending durable inbox row: {inbox:?}"
+            )));
+        }
+        facts.push(DeliveryIdentityFact {
+            owner_revision: revision.revision,
+            root_event_id: revision.event_id,
+            typed_envelope_id: typed.id(),
+            ingest_sequence: inbox.ingest_sequence,
+            scope_key: inbox.scope_key,
+        });
+    }
+    if facts
+        .windows(2)
+        .any(|pair| pair[1].ingest_sequence <= pair[0].ingest_sequence)
+    {
+        return Err(test_error(format!(
+            "D14 typed inbox sequences did not increase within phase: {facts:?}"
+        )));
+    }
+    Ok(facts)
+}
+
+fn ensure_revision_shape(
+    revisions: &[OwnerRevisionRow],
+    first_revision: i64,
+    expected: &[(&str, Option<Uuid>)],
+    phase: &str,
+) -> TestResult<()> {
+    if revisions.len() != expected.len() {
+        return Err(test_error(format!(
+            "D14 {phase} expected {} owner revisions, received {revisions:?}",
+            expected.len()
+        )));
+    }
+    for (index, (actual, (target_type, target_id))) in
+        revisions.iter().zip(expected.iter()).enumerate()
+    {
+        if actual.revision != first_revision + index as i64
+            || actual.target_type != *target_type
+            || actual.target_id != *target_id
+        {
+            return Err(test_error(format!(
+                "D14 {phase} owner revision shape drifted: {revisions:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+async fn load_owner_revisions_after(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    after_revision: i64,
+) -> TestResult<Vec<OwnerRevisionRow>> {
+    db.query_all(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+        SELECT revision, event_id, target_type, target_id
+        FROM forum_projection_revision_ledger
+        WHERE tenant_id = $1 AND revision > $2
+        ORDER BY revision ASC
+        "#,
+        vec![tenant_id.into(), after_revision.into()],
+    ))
+    .await?
+    .into_iter()
+    .map(|row| {
+        Ok(OwnerRevisionRow {
+            revision: row.try_get("", "revision")?,
+            event_id: row.try_get("", "event_id")?,
+            target_type: row.try_get("", "target_type")?,
+            target_id: row.try_get("", "target_id")?,
+        })
+    })
+    .collect::<Result<Vec<_>, sea_orm::DbErr>>()
+    .map_err(Into::into)
+}
+
+async fn load_root_envelope(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    event_id: Uuid,
+) -> TestResult<EventEnvelope> {
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT payload FROM sys_events WHERE event_type = $1 ORDER BY created_at ASC",
+            vec![ROOT_EVENT_TYPE.to_string().into()],
+        ))
+        .await?;
+    let mut matches = Vec::new();
+    for row in rows {
+        let payload: JsonValue = row.try_get("", "payload")?;
+        let envelope: EventEnvelope = serde_json::from_value(payload)?;
+        if envelope.tenant_id == tenant_id && envelope.id == event_id {
+            matches.push(envelope);
+        }
+    }
+    if matches.len() != 1 {
+        return Err(test_error(format!(
+            "expected one D14 root envelope {event_id}, found {}",
+            matches.len()
+        )));
+    }
+    Ok(matches.remove(0))
+}
+
+async fn load_typed_envelope(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    root_event_id: Uuid,
+) -> TestResult<ContractEventEnvelope> {
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT payload FROM sys_events WHERE event_type = $1 ORDER BY created_at ASC",
+            vec![TYPED_EVENT_TYPE.to_string().into()],
+        ))
+        .await?;
+    let mut matches = Vec::new();
+    for row in rows {
+        let payload: JsonValue = row.try_get("", "payload")?;
+        let envelope: ContractEventEnvelope = serde_json::from_value(payload)?;
+        if envelope.tenant_id() == tenant_id && envelope.causation_id() == Some(root_event_id) {
+            matches.push(envelope);
+        }
+    }
+    if matches.len() != 1 {
+        return Err(test_error(format!(
+            "expected one D14 typed envelope caused by {root_event_id}, found {}",
+            matches.len()
+        )));
+    }
+    Ok(matches.remove(0))
+}
+
+async fn load_root_event_ids(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+) -> TestResult<BTreeSet<Uuid>> {
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT payload FROM sys_events WHERE event_type = $1 ORDER BY created_at ASC",
+            vec![ROOT_EVENT_TYPE.to_string().into()],
+        ))
+        .await?;
+    let mut ids = BTreeSet::new();
+    for row in rows {
+        let payload: JsonValue = row.try_get("", "payload")?;
+        let envelope: EventEnvelope = serde_json::from_value(payload)?;
+        if envelope.tenant_id == tenant_id {
+            ids.insert(envelope.id);
+        }
+    }
+    Ok(ids)
+}
+
+async fn load_reply_status_event(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    topic_id: Uuid,
+    reply_id: Uuid,
+    old_status: &str,
+    new_status: &str,
+) -> TestResult<EventEnvelope> {
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT payload FROM sys_events WHERE event_type = 'forum.reply.status_changed' ORDER BY created_at ASC",
+            Vec::new(),
+        ))
+        .await?;
+    let mut matches = Vec::new();
+    for row in rows {
+        let payload: JsonValue = row.try_get("", "payload")?;
+        let envelope: EventEnvelope = serde_json::from_value(payload)?;
+        if envelope.tenant_id == tenant_id
+            && matches!(
+                &envelope.event,
+                DomainEvent::ForumReplyStatusChanged {
+                    reply_id: actual_reply,
+                    topic_id: actual_topic,
+                    old_status: actual_old,
+                    new_status: actual_new,
+                    ..
+                } if *actual_reply == reply_id
+                    && *actual_topic == topic_id
+                    && actual_old == old_status
+                    && actual_new == new_status
+            )
+        {
+            matches.push(envelope);
+        }
+    }
+    if matches.len() != 1 {
+        return Err(test_error(format!(
+            "expected one D14 approval status event, found {}",
+            matches.len()
+        )));
+    }
+    Ok(matches.remove(0))
+}
+
+async fn insert_legacy_root(
+    db: &DatabaseConnection,
+    envelope: &EventEnvelope,
+    scope_key: &str,
+) -> TestResult<()> {
+    envelope.validate_registered_schema()?;
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+        INSERT INTO search_projection_inbox (
+            event_id, tenant_id, source_module, scope_key, event_type,
+            revision_at, envelope_json, status, attempt_count, created_at, updated_at
+        ) VALUES ($1, $2, 'forum', $3, $4, $5, $6, 'pending', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+        ON CONFLICT (event_id) DO NOTHING
+        "#,
+        vec![
+            envelope.id.into(),
+            envelope.tenant_id.into(),
+            scope_key.to_string().into(),
+            envelope.event_type.clone().into(),
+            envelope.timestamp.to_owned().into(),
+            SqlValue::Json(Some(Box::new(serde_json::to_value(envelope)?))),
+        ],
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn load_inbox_row(
+    db: &DatabaseConnection,
+    event_id: Uuid,
+) -> TestResult<InboxOrderRow> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+            SELECT ingest_sequence, event_id, scope_key, event_type, status
+            FROM search_projection_inbox
+            WHERE event_id = $1
+            "#,
+            vec![event_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| test_error(format!("D14 Search inbox row {event_id} was not found")))?;
+    Ok(InboxOrderRow {
+        ingest_sequence: row.try_get("", "ingest_sequence")?,
+        event_id: row.try_get("", "event_id")?,
+        scope_key: row.try_get("", "scope_key")?,
+        event_type: row.try_get("", "event_type")?,
+        status: row.try_get("", "status")?,
+    })
+}
+
+async fn load_inbox_order_after(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    after_sequence: i64,
+) -> TestResult<Vec<InboxOrderRow>> {
+    db.query_all(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+        SELECT ingest_sequence, event_id, scope_key, event_type, status
+        FROM search_projection_inbox
+        WHERE tenant_id = $1 AND source_module = 'forum' AND ingest_sequence > $2
+        ORDER BY ingest_sequence ASC
+        "#,
+        vec![tenant_id.into(), after_sequence.into()],
+    ))
+    .await?
+    .into_iter()
+    .map(|row| {
+        Ok(InboxOrderRow {
+            ingest_sequence: row.try_get("", "ingest_sequence")?,
+            event_id: row.try_get("", "event_id")?,
+            scope_key: row.try_get("", "scope_key")?,
+            event_type: row.try_get("", "event_type")?,
+            status: row.try_get("", "status")?,
+        })
+    })
+    .collect::<Result<Vec<_>, sea_orm::DbErr>>()
+    .map_err(Into::into)
+}
+
+async fn max_ingest_sequence(db: &DatabaseConnection) -> TestResult<i64> {
+    scalar_i64(
+        db,
+        Statement::from_string(
+            DbBackend::Postgres,
+            "SELECT COALESCE(MAX(ingest_sequence), 0)::BIGINT AS value FROM search_projection_inbox"
+                .to_string(),
+        ),
+    )
+    .await
+}
+
+async fn count_inbox_rows(db: &DatabaseConnection, event_id: Uuid) -> TestResult<i64> {
+    scalar_i64(
+        db,
+        Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT COUNT(*)::BIGINT AS value FROM search_projection_inbox WHERE event_id = $1",
+            vec![event_id.into()],
+        ),
+    )
+    .await
+}
+
+async fn load_forum_documents(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+) -> TestResult<Vec<SearchDocumentRow>> {
+    db.query_all(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+        SELECT document_id, entity_type, locale, status, title, body, facets, payload
+        FROM search_documents
+        WHERE tenant_id = $1 AND source_module = 'forum'
+        ORDER BY entity_type ASC, document_id ASC, locale ASC
+        "#,
+        vec![tenant_id.into()],
+    ))
+    .await?
+    .into_iter()
+    .map(|row| {
+        Ok(SearchDocumentRow {
+            document_id: row.try_get("", "document_id")?,
+            entity_type: row.try_get("", "entity_type")?,
+            locale: row.try_get("", "locale")?,
+            status: row.try_get("", "status")?,
+            title: row.try_get("", "title")?,
+            body: row.try_get("", "body")?,
+            facets: row.try_get("", "facets")?,
+            payload: row.try_get("", "payload")?,
+        })
+    })
+    .collect::<Result<Vec<_>, sea_orm::DbErr>>()
+    .map_err(Into::into)
+}
+
+fn ensure_baseline_documents(
+    documents: &[SearchDocumentRow],
+    fixture: ForumFixture,
+) -> TestResult<()> {
+    if documents.len() != 2 {
+        return Err(test_error(format!(
+            "D14 baseline projected {} documents instead of two: {documents:?}",
+            documents.len()
+        )));
+    }
+    let category = find_document(documents, fixture.category_id, "forum_category", "en")?;
+    let topic = find_document(documents, fixture.topic_id, "forum_topic", "en")?;
+    if category.status != "public"
+        || topic.status != "open"
+        || !topic.title.contains(ENGLISH_TOPIC_MARKER)
+        || !topic.body.contains(ENGLISH_TOPIC_MARKER)
+        || documents.iter().any(|document| document.document_id == fixture.reply_id)
+    {
+        return Err(test_error(format!(
+            "D14 baseline documents drifted: {documents:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn ensure_translated_documents(
+    documents: &[SearchDocumentRow],
+    fixture: ForumFixture,
+) -> TestResult<()> {
+    if documents.len() != 4 {
+        return Err(test_error(format!(
+            "D14 translation projected {} documents instead of four: {documents:?}",
+            documents.len()
+        )));
+    }
+    let category_en = find_document(documents, fixture.category_id, "forum_category", "en")?;
+    let category_fr = find_document(documents, fixture.category_id, "forum_category", "fr")?;
+    let topic_en = find_document(documents, fixture.topic_id, "forum_topic", "en")?;
+    let topic_fr = find_document(documents, fixture.topic_id, "forum_topic", "fr")?;
+    if category_en.status != "public"
+        || !category_fr.title.contains(FRENCH_CATEGORY_MARKER)
+        || !category_fr.body.contains(FRENCH_CATEGORY_MARKER)
+        || !topic_en.title.contains(ENGLISH_TOPIC_MARKER)
+        || !topic_fr.title.contains(FRENCH_TOPIC_MARKER)
+        || !topic_fr.body.contains(FRENCH_TOPIC_MARKER)
+        || documents.iter().any(|document| document.document_id == fixture.reply_id)
+    {
+        return Err(test_error(format!(
+            "D14 translated documents drifted: {documents:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn ensure_approved_documents(
+    documents: &[SearchDocumentRow],
+    fixture: ForumFixture,
+) -> TestResult<()> {
+    if documents.len() != 5 {
+        return Err(test_error(format!(
+            "D14 approval projected {} documents instead of five: {documents:?}",
+            documents.len()
+        )));
+    }
+    ensure_translated_documents_without_reply_count(documents, fixture)?;
+    let reply = find_document(documents, fixture.reply_id, "forum_reply", "en")?;
+    let category_id = reply
+        .facets
+        .get("category_id")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| test_error("D14 approved reply facet has no category_id"))?;
+    let topic_id = reply
+        .facets
+        .get("topic_id")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| test_error("D14 approved reply facet has no topic_id"))?;
+    if reply.status != "approved"
+        || !reply.body.contains(APPROVED_REPLY_MARKER)
+        || category_id != fixture.category_id.to_string()
+        || topic_id != fixture.topic_id.to_string()
+    {
+        return Err(test_error(format!(
+            "D14 approved reply document drifted: {reply:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn ensure_translated_documents_without_reply_count(
+    documents: &[SearchDocumentRow],
+    fixture: ForumFixture,
+) -> TestResult<()> {
+    let category_fr = find_document(documents, fixture.category_id, "forum_category", "fr")?;
+    let topic_en = find_document(documents, fixture.topic_id, "forum_topic", "en")?;
+    let topic_fr = find_document(documents, fixture.topic_id, "forum_topic", "fr")?;
+    if !category_fr.title.contains(FRENCH_CATEGORY_MARKER)
+        || !topic_en.title.contains(ENGLISH_TOPIC_MARKER)
+        || !topic_fr.title.contains(FRENCH_TOPIC_MARKER)
+    {
+        return Err(test_error(format!(
+            "D14 translated documents were not retained after approval: {documents:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn find_document<'a>(
+    documents: &'a [SearchDocumentRow],
+    document_id: Uuid,
+    entity_type: &str,
+    locale: &str,
+) -> TestResult<&'a SearchDocumentRow> {
+    let matches = documents
+        .iter()
+        .filter(|document| {
+            document.document_id == document_id
+                && document.entity_type == entity_type
+                && document.locale == locale
+        })
+        .collect::<Vec<_>>();
+    if matches.len() != 1 {
+        return Err(test_error(format!(
+            "D14 expected one {entity_type}:{document_id}:{locale}, found {}",
+            matches.len()
+        )));
+    }
+    Ok(matches[0])
+}
+
+async fn assert_storefront_exact(
+    db: &DatabaseConnection,
+    fixture: ForumFixture,
+    locale: &str,
+    marker: &str,
+    entity_type: &str,
+    status: &str,
+    expected_id: Uuid,
+    expected_total: u64,
+) -> TestResult<()> {
+    let category_scope: SharedStorefrontSearchCategoryScopePort = Arc::new(ExactCategoryScopePort);
+    let eligibility: SharedStorefrontSearchResultEligibilityPort =
+        Arc::new(RealForumPublicEligibilityPort { db: db.clone() });
+    let execution = execute_forum_storefront_search(
+        db,
+        Some(category_scope),
+        Some(eligibility),
+        ForumStorefrontSearchRequest {
+            tenant_id: fixture.tenant_id,
+            query: marker.to_string(),
+            locale: Some(locale.to_string()),
+            fallback_locale: "en".to_string(),
+            channel_id: None,
+            current_channel_only: None,
+            limit: Some(10),
+            offset: Some(0),
+            ranking_profile: None,
+            preset_key: None,
+            entity_types: vec![entity_type.to_string()],
+            source_modules: vec!["forum".to_string()],
+            statuses: vec![status.to_string()],
+            category_ids: vec![fixture.category_id.to_string()],
+            author_ids: Vec::new(),
+            tags: Vec::new(),
+            solved: None,
+            published_from: None,
+            published_to: None,
+            attribute_filters: Vec::<ForumStorefrontSearchAttributeFilter>::new(),
+            sort_attribute_code: None,
+            sort_desc: false,
+            auth: None,
+            request_context: Some(RequestContext {
+                tenant_id: fixture.tenant_id,
+                user_id: None,
+                channel_id: None,
+                channel_slug: None,
+                channel_resolution_source: None,
+                locale: locale.to_string(),
+            }),
+            transport: StorefrontSearchTransport::Graphql,
+        },
+    )
+    .await?;
+    if execution.result.total != expected_total {
+        return Err(test_error(format!(
+            "D14 storefront marker `{marker}` in `{locale}` returned total {}, expected {expected_total}",
+            execution.result.total
+        )));
+    }
+    if expected_total == 1 {
+        if execution.result.items.len() != 1 || execution.result.items[0].id != expected_id {
+            return Err(test_error(format!(
+                "D14 storefront marker `{marker}` did not return exact owner object {expected_id}: {:?}",
+                execution.result.items
+            )));
+        }
+    } else if !execution.result.items.is_empty()
+        || execution
+            .result
+            .facets
+            .iter()
+            .any(|facet| !facet.buckets.is_empty())
+    {
+        return Err(test_error(format!(
+            "D14 storefront marker `{marker}` leaked items or visible facets"
+        )));
+    }
+    Ok(())
+}
+
+fn event_bus(db: DatabaseConnection) -> TransactionalEventBus {
+    TransactionalEventBus::new(Arc::new(OutboxTransport::new(db)))
+}
+
+fn admin_security(user_id: Uuid) -> SecurityContext {
+    SecurityContext::new(UserRole::Admin, Some(user_id))
+}
+
+fn customer_security() -> SecurityContext {
+    SecurityContext::new(UserRole::Customer, None)
+}
+
+async fn scalar_i64(db: &DatabaseConnection, statement: Statement) -> TestResult<i64> {
+    let row = db
+        .query_one(statement)
+        .await?
+        .ok_or_else(|| test_error("D14 scalar query returned no row"))?;
+    Ok(row.try_get("", "value")?)
+}
+
+fn postgres_database_url() -> Option<String> {
+    env::var(SEARCH_TEST_DATABASE_ENV)
+        .or_else(|_| env::var(FORUM_TEST_DATABASE_ENV))
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect_in_schema(
+    database_url: &str,
+    schema_name: &str,
+    max_connections: u32,
+) -> TestResult<DatabaseConnection> {
+    connect(
+        &database_url_in_schema(database_url, schema_name),
+        max_connections,
+    )
+    .await
+}
+
+fn database_url_in_schema(database_url: &str, schema_name: &str) -> String {
+    let separator = if database_url.contains('?') { '&' } else { '?' };
+    format!(
+        "{database_url}{separator}options=-c%20search_path%3D{schema_name}%2Cpublic"
+    )
+}
+
+async fn connect(database_url: &str, max_connections: u32) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(max_connections)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+fn sanitize_identifier(value: &str) -> String {
+    let normalized = value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    let normalized = normalized.trim_matches('_');
+    if normalized.is_empty() {
+        "test".to_string()
+    } else {
+        normalized.to_string()
+    }
+}
+
+fn write_evidence(artifact: TranslationModerationEvidenceArtifact) -> TestResult<()> {
+    let path = workspace_root().join(EVIDENCE_PATH);
+    let parent = path
+        .parent()
+        .ok_or_else(|| test_error("D14 evidence path has no parent directory"))?;
+    fs::create_dir_all(parent)?;
+    fs::write(path, serde_json::to_vec_pretty(&artifact)?)?;
+    Ok(())
+}
+
+fn source_commit() -> TestResult<String> {
+    let output = Command::new("git")
+        .current_dir(workspace_root())
+        .args(["rev-parse", "HEAD"])
+        .output()?;
+    if !output.status.success() {
+        return Err(test_error("git rev-parse HEAD failed for D14 evidence generation"));
+    }
+    let value = String::from_utf8(output.stdout)?;
+    let value = value.trim();
+    if value.len() != 40 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(test_error(
+            "git rev-parse HEAD returned an invalid D14 commit SHA",
+        ));
+    }
+    Ok(value.to_string())
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn test_error(message: impl Into<String>) -> Box<dyn Error + Send + Sync> {
+    Box::new(IoError::new(ErrorKind::InvalidData, message.into()))
+}

--- a/crates/rustok-forum/contracts/forum-search-link-forum-03-translation-moderation-proof.json
+++ b/crates/rustok-forum/contracts/forum-search-link-forum-03-translation-moderation-proof.json
@@ -1,0 +1,58 @@
+{
+  "contract": "forum_search_link_forum_03_translation_moderation_proof_v1",
+  "task": "FORUM-23B2G2B3D14",
+  "target_link": "LINK-FORUM-03",
+  "coverage": "translation_and_moderation_approval_only",
+  "status": "source_ready_maintainer_execution_pending",
+  "test": "apps/server/tests/forum_versioned_invalidation_translation_moderation.rs",
+  "verifier": "scripts/verify/verify-forum-search-link-forum-03-translation-moderation-proof.mjs",
+  "evidence_artifact": "target/forum-search-link-forum-03-translation-moderation-evidence.json",
+  "required_runtime": {
+    "database": "postgresql",
+    "broker_used": false,
+    "host_package": "rustok-server",
+    "search_inbox": "search_projection_inbox",
+    "projector": "ForumProjectionReconciler",
+    "storefront_execution": "execute_forum_storefront_search"
+  },
+  "required_owner_trace": [
+    "revision 1 is the real category-create forum-scope invalidation",
+    "revision 2 is the real topic-create forum-category invalidation",
+    "a pending reply in the moderated category creates no public projection revision",
+    "revision 3 is the real French category-translation forum-scope invalidation",
+    "revision 4 is the real French topic-translation forum-topic invalidation",
+    "revision 5 is the real pending-to-approved moderation forum-category invalidation"
+  ],
+  "fail_closed_requirements": [
+    "the test creates one isolated PostgreSQL schema and applies real Outbox Taxonomy Forum and Search migrations",
+    "all category topic reply translation and moderation mutations use exported Forum owner services",
+    "the five owner revisions are contiguous and have exact target types and target identifiers",
+    "every owner revision retains one legacy root envelope and one distinct caused typed envelope from sys_events",
+    "the exact typed envelopes enter Search through ForumSearchContractIngress rather than manual inbox insertion",
+    "the approval legacy ForumReplyStatusChanged envelope enters the existing Search inbox before the caused typed invalidation",
+    "Search ingest_sequence ordering increases independently and is never compared numerically with Forum owner_revision",
+    "the production Forum projection source and ForumProjectionReconciler project English and French current state",
+    "the pending reply is absent before approval and the exact approved reply becomes visible only after the real moderation command",
+    "the production storefront execution and Forum eligibility owner return exact English French and approved-reply results",
+    "each root event retains exactly one Search inbox row and a caught-up repeat performs no duplicate work",
+    "the evidence artifact is written only after every assertion succeeds and the isolated schema is removed"
+  ],
+  "proves_after_maintainer_execution": [
+    "English Forum topic projection remains visible after adding French category and topic translations",
+    "French category and topic owner translations become exact locale-specific Search documents and storefront results",
+    "a moderated pending reply is excluded from Search before approval",
+    "real ModerationService approval publishes durable owner state and makes the exact approved reply visible",
+    "translation and moderation invalidations converge on the existing one-inbox one-projector path"
+  ],
+  "maintainer_commands": [
+    "node scripts/verify/verify-forum-search-link-forum-03-translation-moderation-proof.mjs",
+    "RUSTOK_SEARCH_TEST_DATABASE_URL=\"$DATABASE_URL\" cargo test -p rustok-server --test forum_versioned_invalidation_translation_moderation -- --nocapture --test-threads=1"
+  ],
+  "non_claims": [
+    "this source-ready slice does not claim that the verifier PostgreSQL test or storefront execution ran",
+    "this proof does not execute or simulate topic move because the owner command remains planned under FORUM-21",
+    "this proof does not cover exact private or trusted-channel exclusion runtime behavior",
+    "this proof does not use external Iggy or replace the reviewed D0 D12 or D13 artifacts",
+    "this proof is not sufficient to mark LINK-FORUM-03 done or promote FORUM-23"
+  ]
+}

--- a/crates/rustok-forum/docs/forum-23b2g2b3d14-translation-moderation-proof.md
+++ b/crates/rustok-forum/docs/forum-23b2g2b3d14-translation-moderation-proof.md
@@ -1,0 +1,161 @@
+# FORUM-23B2G2B3D14 translation and moderation Search proof
+
+## Status
+
+`source_ready_maintainer_execution_pending`
+
+This slice adds an executable PostgreSQL proof for two remaining
+`LINK-FORUM-03` behaviors that already have real Forum owner commands:
+
+- locale-specific category and topic translation projection;
+- pending reply approval into public Search visibility.
+
+It does not execute or simulate topic move. Topic move remains a planned owner
+workflow under `FORUM-21`, so direct SQL mutation would not be valid cross-module
+evidence.
+
+The machine contract is:
+
+```text
+crates/rustok-forum/contracts/forum-search-link-forum-03-translation-moderation-proof.json
+```
+
+The executable test is:
+
+```text
+apps/server/tests/forum_versioned_invalidation_translation_moderation.rs
+```
+
+Successful execution writes:
+
+```text
+target/forum-search-link-forum-03-translation-moderation-evidence.json
+```
+
+## Runtime topology
+
+The test creates one isolated PostgreSQL schema, creates only the minimal
+`users` owner table required by Forum foreign keys, and applies the real
+migrations from:
+
+- `OutboxModule`;
+- `TaxonomyModule`;
+- `ForumModule`;
+- `SearchModule`.
+
+It uses production Forum owner services, the production
+`ForumSearchContractIngress`, the production Forum projection source, the
+production `ForumProjectionReconciler`, the shared Forum storefront Search
+execution, and the real Forum result-eligibility owner.
+
+No fake projection source, direct Search document write, manual typed-event
+construction or alternate inbox is used.
+
+## Exact owner revision trace
+
+The fixture contains one moderated category, one public English topic and one
+pending English reply.
+
+The proof requires the following contiguous Forum owner revisions:
+
+1. category creation: target `forum`, null target ID;
+2. topic creation: target `forum_category`, exact category ID;
+3. French category translation update: target `forum`, null target ID;
+4. French topic translation update: target `forum_topic`, exact topic ID;
+5. pending-to-approved reply moderation: target `forum_category`, exact category
+   ID.
+
+Creating the pending reply must not allocate a public projection revision. That
+is part of the proof: pending content remains owner state but does not enter the
+public Search projection until the real moderation command changes it to
+`approved`.
+
+For every revision the test reads the exact legacy root and caused typed envelope
+from `sys_events`. It requires:
+
+- ledger event ID equals legacy root envelope ID;
+- typed envelope ID is distinct;
+- typed `causation_id` equals the root/ledger ID;
+- typed owner revision, target type and target ID equal the ledger row;
+- registered event schemas remain valid.
+
+The exact typed envelopes enter the existing Search inbox through
+`ForumSearchContractIngress`.
+
+## Translation phase
+
+The test first projects the English category and topic and verifies that the
+pending reply is absent from Search and storefront results.
+
+It then calls:
+
+- `CategoryService::update` with locale `fr`;
+- `TopicService::update` with locale `fr`.
+
+The category translation is created first because a public French topic document
+requires a public French category translation. After the two exact typed
+invalidations are durably admitted and reconciled, the proof requires:
+
+- English category and topic documents remain present;
+- French category and topic documents exist with exact marker text;
+- the French topic is returned through the production storefront path for locale
+  `fr`;
+- the English topic remains returned for locale `en`;
+- the pending reply remains absent.
+
+## Moderation phase
+
+The test calls real `ModerationService::approve_reply` for the pending reply. The
+owner transaction must persist:
+
+- the pending-to-approved reply state transition;
+- the legacy `forum.reply.status_changed` event;
+- the category projection owner revision and its root/typed invalidation;
+- public counters maintained by the owner workflow.
+
+The exact legacy moderation event is inserted into the existing
+`search_projection_inbox`, followed by the exact caused typed invalidation through
+`ForumSearchContractIngress`. Their `ingest_sequence` values must increase in
+that delivery order. Forum `owner_revision` is an independent causal clock and is
+never compared numerically with Search `ingest_sequence`.
+
+After the production reconciler processes both events, the proof requires one
+approved reply document with the exact body, topic and category identities and
+one exact storefront result. English and French topic documents must remain
+visible.
+
+## Idempotence and retention
+
+Every owner root ID and the moderation status-event ID must retain exactly one
+Search inbox row. A caught-up second reconciler sweep must claim and complete no
+work.
+
+The JSON evidence is written only after:
+
+1. all owner, envelope, inbox, projection and storefront assertions pass;
+2. the isolated PostgreSQL schema is removed;
+3. `git rev-parse HEAD` returns one valid 40-character source commit.
+
+Skipped tests do not write acceptable evidence.
+
+## Maintainer execution
+
+```bash
+node scripts/verify/verify-forum-search-link-forum-03-translation-moderation-proof.mjs
+RUSTOK_SEARCH_TEST_DATABASE_URL="$DATABASE_URL" cargo test -p rustok-server --test forum_versioned_invalidation_translation_moderation -- --nocapture --test-threads=1
+```
+
+## Remaining LINK-FORUM-03 scope
+
+This proof does not close `LINK-FORUM-03`. The remaining executable scope still
+includes:
+
+- a real topic move and category-scope projection update after `FORUM-21`
+  delivers the owner command;
+- exact private and trusted-channel exclusion runtime evidence;
+- final retained assembly and review with the D13 core artifact.
+
+D14 changes no production Rust path, migration, event schema or digest, DTO,
+runtime flag, dependency, `Cargo.toml` or `Cargo.lock` entry.
+
+No command above was run by the implementation agent, per maintainer request.

--- a/scripts/verify/verify-forum-search-link-forum-03-translation-moderation-proof.mjs
+++ b/scripts/verify/verify-forum-search-link-forum-03-translation-moderation-proof.mjs
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = process.cwd();
+const read = (path) => readFileSync(resolve(root, path), "utf8");
+const requireAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(text.includes(marker), `${label} is missing required marker: ${marker}`);
+  }
+};
+const forbidAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(!text.includes(marker), `${label} contains forbidden marker: ${marker}`);
+  }
+};
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-search-link-forum-03-translation-moderation-proof.json";
+const docPath =
+  "crates/rustok-forum/docs/forum-23b2g2b3d14-translation-moderation-proof.md";
+const testPath =
+  "apps/server/tests/forum_versioned_invalidation_translation_moderation.rs";
+const verifierPath =
+  "scripts/verify/verify-forum-search-link-forum-03-translation-moderation-proof.mjs";
+const evidencePath =
+  "target/forum-search-link-forum-03-translation-moderation-evidence.json";
+const planPath = "crates/rustok-forum/docs/implementation-plan.md";
+const topicInlinePath = "crates/rustok-forum/src/services/topic_inline.rs";
+const categoryOwnerPath =
+  "crates/rustok-forum/src/services/category_projection_owner.rs";
+const moderationOwnerPath =
+  "crates/rustok-forum/src/services/moderation_owner.rs";
+const replyOwnerPath = "crates/rustok-forum/src/services/reply_owner.rs";
+const projectionSourcePath = "crates/rustok-forum/src/search_projection.rs";
+const invalidationContractPath =
+  "crates/rustok-forum/contracts/forum-projection-invalidation.json";
+
+const contract = JSON.parse(read(contractPath));
+assert.equal(
+  contract.contract,
+  "forum_search_link_forum_03_translation_moderation_proof_v1",
+);
+assert.equal(contract.task, "FORUM-23B2G2B3D14");
+assert.equal(contract.target_link, "LINK-FORUM-03");
+assert.equal(contract.coverage, "translation_and_moderation_approval_only");
+assert.equal(contract.status, "source_ready_maintainer_execution_pending");
+assert.equal(contract.test, testPath);
+assert.equal(contract.verifier, verifierPath);
+assert.equal(contract.evidence_artifact, evidencePath);
+assert.equal(contract.required_runtime.database, "postgresql");
+assert.equal(contract.required_runtime.broker_used, false);
+assert.equal(contract.required_runtime.host_package, "rustok-server");
+assert.equal(contract.required_runtime.search_inbox, "search_projection_inbox");
+assert.equal(contract.required_runtime.projector, "ForumProjectionReconciler");
+assert.equal(
+  contract.required_runtime.storefront_execution,
+  "execute_forum_storefront_search",
+);
+assert.equal(contract.required_owner_trace.length, 6);
+assert.ok(contract.fail_closed_requirements.length >= 12);
+assert.ok(contract.proves_after_maintainer_execution.length >= 5);
+assert.deepEqual(contract.maintainer_commands, [
+  `node ${verifierPath}`,
+  'RUSTOK_SEARCH_TEST_DATABASE_URL="$DATABASE_URL" cargo test -p rustok-server --test forum_versioned_invalidation_translation_moderation -- --nocapture --test-threads=1',
+]);
+assert.ok(
+  contract.non_claims.some((claim) => claim.includes("FORUM-21")),
+  "D14 must retain the topic-move owner dependency",
+);
+assert.ok(
+  contract.non_claims.some((claim) => claim.includes("not sufficient")),
+  "D14 must not claim LINK-FORUM-03 completion",
+);
+
+const test = read(testPath);
+requireAll(
+  test,
+  [
+    "forum_search_link_forum_03_translation_moderation_evidence_v1",
+    'task: "FORUM-23B2G2B3D14"',
+    evidencePath,
+    "PostgresTranslationModerationEvidence::setup",
+    "OutboxModule.migrations()",
+    "TaxonomyModule.migrations()",
+    "ForumModule.migrations()",
+    "SearchModule.migrations()",
+    "CategoryService::new",
+    "TopicService::new",
+    "ReplyService::new",
+    "ModerationService::new",
+    "UpdateCategoryInput",
+    "UpdateTopicInput",
+    'locale: "fr".to_string()',
+    "FRENCH_CATEGORY_MARKER",
+    "FRENCH_TOPIC_MARKER",
+    "APPROVED_REPLY_MARKER",
+    "reply.status != \"pending\"",
+    ".approve_reply(",
+    '"pending",\n        "approved"',
+    "forum_projection_revision_ledger",
+    "load_root_envelope",
+    "load_typed_envelope",
+    "ContractEventPayload::ForumSearchProjection",
+    "ForumSearchProjectionEvent::InvalidationIssued",
+    "typed.causation_id() != Some(revision.event_id)",
+    "ForumSearchContractIngress::new",
+    "ForumSearchContractIngressOutcome::DurablyAccepted",
+    "insert_legacy_root(db, &approval_status_event, \"forum\")",
+    "search_projection_inbox",
+    "approval_inbox_order[0].event_id != approval_status_event.id",
+    "approval_inbox_order[1].event_id != approval_revisions[0].event_id",
+    "ForumSearchProjectionSourceFactory.build",
+    "ForumProjectionReconciler::new",
+    "execute_forum_storefront_search",
+    "ForumSearchResultEligibilityService::new",
+    "ensure_baseline_documents",
+    "ensure_translated_documents",
+    "ensure_approved_documents",
+    "pending_reply_visible_before_approval",
+    "approved_reply_visible_after_approval",
+    "owner_revision_compared_to_ingest_sequence",
+    "caught_up_repeat_performed_work",
+    '"topic_move_executed": false',
+    '"topic_move_blocked_on": "FORUM-21"',
+    'id: "translation_and_moderation_approval"',
+    'result: "passed"',
+    '.args(["rev-parse", "HEAD"])',
+    "evidence.cleanup().await",
+  ],
+  "D14 executable proof",
+);
+forbidAll(
+  test,
+  [
+    "#[ignore]",
+    "result: \"skipped\"",
+    "static_fixture",
+    "MockForum",
+    "FakeForum",
+    "InMemory",
+    "INSERT INTO search_documents",
+    "UPDATE forum_topics SET category_id",
+    "UPDATE forum_topics\nSET category_id",
+    "ForumSearchProjectionEvent::InvalidationIssued {\n            owner_revision: revision.revision",
+    "owner_revision == inbox.ingest_sequence",
+    "owner_revision as i64 ==",
+  ],
+  "D14 executable proof",
+);
+
+const topicInline = read(topicInlinePath);
+requireAll(
+  topicInline,
+  [
+    "update_with_inline_relations",
+    "upsert_translation_in_tx",
+    "publish_forum_topic_projection_in_tx",
+    "txn.commit().await?",
+  ],
+  "topic translation owner",
+);
+
+const categoryOwner = read(categoryOwnerPath);
+requireAll(
+  categoryOwner,
+  [
+    "CategoryProjectionOwnerService",
+    "pub(super) async fn update",
+    "forum_category_translation::ActiveModel",
+    "publish_forum_projection_scope_direct_in_tx",
+    "txn.commit().await?",
+  ],
+  "category translation owner",
+);
+
+const moderationOwner = read(moderationOwnerPath);
+requireAll(
+  moderationOwner,
+  [
+    "pub async fn approve_reply",
+    "current.validate_transition(&target)?",
+    "ReplyService::set_status_in_tx",
+    "DomainEvent::ForumReplyStatusChanged",
+    "DomainEvent::ForumTopicReplied",
+    "publish_forum_category_projection_in_tx",
+    "txn.commit().await?",
+  ],
+  "moderation approval owner",
+);
+
+const replyOwner = read(replyOwnerPath);
+requireAll(
+  replyOwner,
+  [
+    "let status = if category.moderated",
+    "ReplyStatus::Pending",
+    "if status == ReplyStatus::Approved",
+    "publish_forum_category_projection_in_tx",
+  ],
+  "pending reply owner",
+);
+
+const projectionSource = read(projectionSourcePath);
+requireAll(
+  projectionSource,
+  [
+    "forum_category_translation::Entity::find()",
+    "forum_topic_translation::Entity::find()",
+    "forum_reply_body::Entity::find()",
+    "ReplyStatus::Approved",
+    'document_key: format!("forum_topic:{}:{locale}"',
+    'document_key: format!("forum_reply:{reply_id}:{locale}")',
+    '"category_id": topic.category_id',
+    '"topic_id": topic.id',
+  ],
+  "Forum Search projection source",
+);
+
+const invalidationContract = JSON.parse(read(invalidationContractPath));
+assert.equal(
+  invalidationContract.forum_scope_invalidation.category_content_or_translation_update,
+  true,
+);
+assert.equal(
+  invalidationContract.topic_target_invalidation
+    .topic_content_translation_metadata_tags_or_channel_update,
+  true,
+);
+assert.equal(
+  invalidationContract.category_target_invalidation
+    .reply_moderation_public_state_transition_updates_reply_count,
+  true,
+);
+
+const plan = read(planPath);
+requireAll(
+  plan,
+  [
+    "| `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |",
+    "| `FORUM-23` | `in_progress` |",
+    "| `LINK-FORUM-03` | `planned` | Forum/index/search ordering and visibility proof. |",
+    "## `LINK-FORUM-03` — index and search",
+    "Prove publish, translation, moderation approval, move, hide/delete, ACL change,",
+  ],
+  "Forum canonical plan",
+);
+forbidAll(
+  plan,
+  [
+    "| `LINK-FORUM-03` | `done` |",
+    "| `FORUM-21` | `done` | Move, merge, split and fork topic workflows. |",
+    "FORUM-23B2G2B3D14 closes LINK-FORUM-03",
+  ],
+  "Forum canonical plan",
+);
+
+const doc = read(docPath);
+requireAll(
+  doc,
+  [
+    "`source_ready_maintainer_execution_pending`",
+    "FORUM-23B2G2B3D14",
+    "LINK-FORUM-03",
+    contractPath,
+    testPath,
+    evidencePath,
+    "CategoryService::update",
+    "TopicService::update",
+    "ModerationService::approve_reply",
+    "pending content remains owner state",
+    "Forum `owner_revision` is an independent causal clock",
+    "Topic move remains a planned owner workflow under `FORUM-21`",
+    "No command above was run by the implementation agent",
+  ],
+  "D14 handoff",
+);
+
+console.log(
+  "Forum Search LINK-FORUM-03 translation and moderation proof is source-ready and fail-closed.",
+);


### PR DESCRIPTION
## What changed

- add `FORUM-23B2G2B3D14`, an executable PostgreSQL proof for locale-specific Forum translation projection and real pending-to-approved moderation visibility;
- create one moderated category, one English topic and one pending reply through exported Forum owner services;
- require exact contiguous owner revisions 1-5 for category create, topic create, French category translation, French topic translation and reply approval;
- read exact legacy roots and caused typed envelopes from `sys_events` and require exact ledger/causation/payload identity;
- admit typed invalidations through production `ForumSearchContractIngress` and use the existing Search inbox and production `ForumProjectionReconciler`;
- verify English visibility remains, French category/topic documents and storefront results appear, pending reply stays absent, and the exact reply appears only after real `ModerationService::approve_reply`;
- require one inbox row per root and a caught-up repeat with no duplicate work;
- add machine contract, handoff and fail-closed source verifier.

## Deliberate boundary

Topic move is not simulated: the owner command remains planned under `FORUM-21`. This slice also does not cover exact private/trusted-channel exclusion, external Iggy, final LINK assembly, or canonical status promotion.

## Compatibility

No production Rust path, migration, event schema/digest, DTO, runtime flag, dependency, `Cargo.toml`, `Cargo.lock` or canonical plan status changes.

## Validation

Tests, Node verifiers, formatting, Cargo checks, workflows, CI and PostgreSQL execution were intentionally not run, per maintainer request.