### PR TITLE
fix(pricing): bound storefront GraphQL diagnostics

### DIFF
--- a/crates/rustok-pricing/contracts/evidence/storefront-graphql-error-safety-source-review.json
+++ b/crates/rustok-pricing/contracts/evidence/storefront-graphql-error-safety-source-review.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
-  "reviewed_at_utc": "2026-07-30T18:30:00Z",
-  "review_base": "fc21cef64ffac3f1c724b223e7d729675b95380b",
+  "reviewed_at_utc": "2026-08-01T08:00:00Z",
+  "review_base": "830b0126607cf21912c7b97b11fc129061391ff3",
   "status": "pricing_storefront_graphql_error_safety_source_reviewed_unvalidated",
-  "scope": "Pricing storefront GraphQL public error boundary",
+  "scope": "Pricing storefront GraphQL public and diagnostic error boundary",
   "reviewed_sources": [
     "crates/rustok-commerce/docs/implementation-plan.md",
     "crates/rustok-pricing/docs/implementation-plan.md",
@@ -11,68 +11,72 @@
     "crates/rustok-pricing/storefront/src/core.rs",
     "crates/rustok-pricing/storefront/src/transport/mod.rs",
     "crates/rustok-pricing/storefront/src/transport/graphql_adapter.rs",
+    "crates/rustok-pricing/storefront/src/transport/graphql_error_safety.rs",
     "crates/rustok-pricing/storefront/src/transport/native_server_adapter.rs",
+    "crates/rustok-pricing/contracts/evidence/storefront-graphql-error-safety-source.json",
+    "crates/rustok-pricing/docs/storefront-graphql-error-safety.md",
     "crates/rustok-graphql/src/lib.rs",
-    "scripts/verify/verify-pricing-storefront-boundary.mjs",
-    "scripts/verify/verify-pricing-storefront-native-error-safety.mjs",
-    "crates/rustok-product/storefront/src/transport/graphql_error_safety.rs"
+    "scripts/verify/verify-pricing-storefront-graphql-error-safety.mjs"
   ],
   "findings": [
     {
-      "id": "pricing-graphql-display-public",
-      "severity": "confirmed",
-      "finding": "Pricing GraphQL transport converted GraphqlHttpError through ApiError::Graphql(value.to_string()), and the selected transport facade returned that display inside the public UiTransportError envelope. GraphQL server messages and HTTP status text could therefore cross the storefront boundary."
+      "id": "pricing-graphql-static-public-envelope-preserved",
+      "severity": "preservation",
+      "finding": "The selected Pricing GraphQL facade already reparses the private adapter display through GraphqlHttpError and returns stable Pricing-owned public messages."
     },
     {
-      "id": "native-policy-already-bounded",
-      "severity": "preserved",
-      "finding": "The Pricing native server-function adapter already maps runtime, tenant-context, and owner failures to bounded public messages. This slice does not alter that adapter or its query/result composition."
+      "id": "pricing-graphql-raw-diagnostic-payload",
+      "severity": "diagnostic_safety",
+      "finding": "The shared safety mapper still copied the complete private GraphQL display and Debug representation of the parsed typed error into both technical and rejection tracing events."
     },
     {
-      "id": "pricing-validation-contract",
-      "severity": "preserved",
-      "finding": "The two existing StorefrontPricingQuery validation mappings remain user-facing and unchanged. They are bounded owner validation messages rather than transport or backend causes."
+      "id": "pricing-query-shape-preservation",
+      "severity": "preservation",
+      "finding": "The mapper can retain correlation and optional query-field presence or length facts without recording raw Pricing query values or backend error payloads."
     },
     {
-      "id": "final-facade-boundary",
-      "severity": "selected",
-      "finding": "The smallest compatible fix is a Pricing-owned GraphqlCallContext in the selected transport facade. It sanitizes only ApiError::Graphql before execute_selected_transport constructs UiTransportError, while leaving ServerFn validation and native behavior unchanged."
-    },
-    {
-      "id": "correlation-safe-shape",
-      "severity": "confirmed",
-      "finding": "The new context records a unique correlation id, tenant and query field presence/length facts, error kind, stable code, and private raw/parsed GraphQL diagnostics without structured query values."
-    },
-    {
-      "id": "all-profile-tracing",
-      "severity": "selected",
-      "finding": "Pricing storefront tracing is made non-optional so the GraphQL-selected profile can compile the same diagnostics policy; the SSR feature no longer owns tracing activation."
+      "id": "pricing-transport-separation",
+      "severity": "preservation",
+      "finding": "The private GraphQL documents, list/detail composition, validation messages, native adapter, selected transport, dependency shape, and no-fallback behavior remain unchanged."
     }
   ],
+  "implementation_review": {
+    "typed_graphql_variant_policy": true,
+    "static_public_graphql_messages": true,
+    "raw_graphql_detail_logging_removed": true,
+    "parsed_graphql_error_debug_logging_removed": true,
+    "bounded_graphql_error_shape_retained": true,
+    "pricing_operation_preserved": true,
+    "per_call_correlation_id": true,
+    "safe_query_shape_only": true,
+    "private_graphql_adapter_changed": false,
+    "native_path_changed": false,
+    "query_contract_changed": false,
+    "transport_selection_changed": false,
+    "runtime_evidence_claimed": false
+  },
   "changed_files_expected": [
     "crates/rustok-pricing/contracts/evidence/storefront-graphql-error-safety-source-review.json",
     "crates/rustok-pricing/contracts/evidence/storefront-graphql-error-safety-source.json",
     "crates/rustok-pricing/docs/storefront-graphql-error-safety.md",
-    "crates/rustok-pricing/storefront/Cargo.toml",
     "crates/rustok-pricing/storefront/src/transport/graphql_error_safety.rs",
-    "crates/rustok-pricing/storefront/src/transport/mod.rs",
-    "scripts/verify/verify-pricing-storefront-boundary.mjs",
-    "scripts/verify/verify-pricing-storefront-graphql-error-safety.mjs",
-    "scripts/verify/verify-pricing-storefront-native-error-safety.mjs"
+    "scripts/verify/verify-pricing-storefront-graphql-error-safety.mjs"
   ],
   "preserved": [
     "Pricing GraphQL adapter query documents, variables, list/detail fetches, and result mappers",
     "StorefrontPricingQuery fields and validation messages",
     "Pricing native server-function endpoint and owner operations",
+    "all-profile tracing dependency shape",
     "selected native versus GraphQL transport policy",
     "absence of broad fallback",
     "Pricing FFA/FBA and production status"
   ],
   "remaining_scope": [
-    "remaining ecommerce adapters and non-PortError public envelopes",
+    "remaining ecommerce adapters and non-PortError public or diagnostic envelopes",
     "Pricing storefront focused verifier execution",
     "Pricing storefront Cargo compilation across default, hydrate, and SSR profiles",
-    "GraphQL/browser runtime and mounted parity evidence"
+    "GraphQL/browser runtime and mounted parity evidence",
+    "broad ecommerce correlation-safe mapper cleanup"
   ],
   "execution": [],
   "validation": {

--- a/crates/rustok-pricing/contracts/evidence/storefront-graphql-error-safety-source.json
+++ b/crates/rustok-pricing/contracts/evidence/storefront-graphql-error-safety-source.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
-  "generated_at_utc": "2026-07-30T18:30:00Z",
+  "generated_at_utc": "2026-08-01T08:00:00Z",
   "status": "pricing_storefront_graphql_error_safety_source_unvalidated",
-  "scope": "Pricing-owned storefront GraphQL public transport envelope",
+  "scope": "Pricing-owned storefront GraphQL public and diagnostic transport envelope",
   "operation": "fetch_storefront_pricing",
   "boundary": "pricing_storefront_graphql_transport",
   "public_messages": {
@@ -19,12 +19,17 @@
     "graphql_rejection_static_public_envelope": true,
     "raw_graphql_http_display_public": false,
     "raw_query_values_logged": false,
-    "private_graphql_error_diagnostics": true,
+    "raw_graphql_detail_logged": false,
+    "parsed_graphql_error_debug_logged": false,
+    "raw_graphql_detail_shape_logged": true,
+    "typed_parse_validity_logged": true,
+    "closed_graphql_error_category_logged": true,
     "transport_validation_messages_preserved": true,
     "native_adapter_changed": false,
     "query_contract_changed": false,
     "transport_selection_changed": false,
-    "fallback_added": false
+    "fallback_added": false,
+    "broad_ecommerce_cleanup_closed": false
   },
   "safe_diagnostics": [
     "owner",
@@ -47,10 +52,12 @@
     "channel_slug_present",
     "channel_slug_length",
     "quantity_present",
-    "error_kind",
+    "raw_graphql_error_present",
+    "raw_graphql_error_length",
+    "parsed_graphql_error_valid",
+    "closed_graphql_error_category",
     "stable_code",
-    "boundary",
-    "private_graphql_http_error"
+    "boundary"
   ],
   "forbidden_public_or_structured_values": [
     "tenant_slug",
@@ -62,7 +69,8 @@
     "channel_id",
     "channel_slug",
     "quantity",
-    "GraphqlHttpError display",
+    "raw GraphqlHttpError display",
+    "parsed GraphqlHttpError Debug output",
     "GraphQL server error message",
     "HTTP status text"
   ],
@@ -73,12 +81,14 @@
     "Pricing transport validation messages",
     "native server-function adapter and public policy",
     "native versus GraphQL selected transport",
-    "absence of native-to-GraphQL fallback"
+    "absence of native-to-GraphQL fallback",
+    "stable public messages, codes, and severity"
   ],
   "remaining_scope": [
-    "remaining ecommerce adapters and non-PortError public envelopes",
+    "remaining ecommerce adapters and non-PortError public or diagnostic envelopes",
     "Pricing storefront GraphQL runtime and browser evidence",
-    "Pricing native and GraphQL mounted parity"
+    "Pricing native and GraphQL mounted parity",
+    "broad ecommerce correlation-safe mapper cleanup"
   ],
   "suggested_execution": [
     "node scripts/verify/verify-pricing-storefront-graphql-error-safety.mjs",

--- a/crates/rustok-pricing/docs/storefront-graphql-error-safety.md
+++ b/crates/rustok-pricing/docs/storefront-graphql-error-safety.md
@@ -4,42 +4,40 @@ Status: **source-ready / unvalidated**
 
 ## Scope
 
-This slice hardens only the Pricing storefront GraphQL public error boundary:
+This slice hardens the Pricing storefront GraphQL public and diagnostic error
+boundary for the final GraphQL branch of `fetch_storefront_pricing`.
 
-- `crates/rustok-pricing/storefront/src/transport/mod.rs`;
-- `crates/rustok-pricing/storefront/src/transport/graphql_error_safety.rs`;
-- the final GraphQL branch of `fetch_storefront_pricing`.
+The GraphQL adapter query documents, variables, list/detail composition, result
+mapping, Pricing query validation, native server-function adapter, transport
+selection, and all-profile tracing dependency shape remain unchanged.
 
-The GraphQL adapter query documents, variables, list/detail composition, result mapping,
-Pricing query validation, and the native server-function adapter remain unchanged.
+## Rechecked gap
 
-## Confirmed gap
+The selected Pricing GraphQL facade already creates `GraphqlCallContext`, reparses
+the private adapter display through `GraphqlHttpError::from_str`, and returns only
+stable Pricing-owned public messages. GraphQL server messages and HTTP detail
+therefore do not cross the public `UiTransportError` envelope.
 
-The Pricing GraphQL adapter intentionally captured `GraphqlHttpError` as
-`ApiError::Graphql(value.to_string())`. Before this slice, the selected transport facade
-returned that adapter error directly. `execute_selected_transport` then stored the string
-inside the public `UiTransportError` envelope.
+The shared structured event still copied two complete private values:
 
-That display can contain:
+- `raw_error = %raw_error`;
+- `parsed_error = ?parsed_error`.
 
-- a GraphQL server error message;
-- an HTTP status string;
-- transport classification text.
-
-Those values remain useful for private diagnostics but are not suitable as the final
-Pricing storefront public contract.
+Those payloads were not required for correlation, the closed five-category policy,
+or query-shape diagnosis. They were a remaining non-`PortError` diagnostic-envelope
+gap in the ecommerce correlation-safe mapper cleanup.
 
 ## Boundary placement
 
-`GraphqlCallContext` is created inside the selected GraphQL closure before
-`graphql_adapter::fetch_storefront_pricing` is called. It receives the final adapter
-`ApiError` before `execute_selected_transport` can construct a public `UiTransportError`.
+`GraphqlCallContext` remains inside the selected GraphQL closure and is created
+before `graphql_adapter::fetch_storefront_pricing` is called. It maps only
+`ApiError::Graphql` before `execute_selected_transport` constructs the public
+transport envelope.
 
-Only `ApiError::Graphql` is reclassified. Existing `ApiError::ServerFn` query-validation
-results pass through unchanged, so this slice does not change the Pricing validation
-contract.
+Existing `ApiError::ServerFn` query-validation results pass through unchanged.
+No native-to-GraphQL fallback is introduced.
 
-Each GraphQL fetch receives a unique correlation id in the namespace:
+Each GraphQL fetch retains a unique correlation id in the namespace:
 
 ```text
 pricing-storefront-graphql:fetch_storefront_pricing:<uuid>
@@ -55,54 +53,51 @@ pricing-storefront-graphql:fetch_storefront_pricing:<uuid>
 | GraphQL response rejection | `Pricing storefront request could not be completed` |
 | Unrecognized captured display | `Pricing storefront request could not be completed` |
 
-The selected path remains GraphQL, so `execute_selected_transport` preserves the outer
-`UiTransportPath::Graphql` evidence. No fallback is introduced.
+Technical network, HTTP, and unknown failures retain error severity. Unauthorized
+and ordinary GraphQL rejection retain warning severity.
 
-## Internal diagnostics
+## Bounded internal diagnostics
 
-The original captured GraphQL display and parsed `GraphqlHttpError` remain private tracing
-fields. The event also records:
+The event retains only:
 
 - owner and owner operation;
 - unique correlation id;
 - whether a tenant slug is configured and its character length;
-- selected handle presence and character length;
-- locale presence and character length;
-- currency-code presence and character length;
-- region-id presence and character length;
-- price-list-id presence and character length;
-- channel-id presence and character length;
-- channel-slug presence and character length;
+- selected-handle, locale, currency-code, region-id, price-list-id, channel-id,
+  and channel-slug presence and character lengths;
 - whether quantity was supplied;
-- error kind;
+- one closed category: `network`, `http`, `unauthorized`, `graphql`, or `unknown`;
 - stable internal code;
+- raw-display presence and character length;
+- whether typed `GraphqlHttpError` parsing succeeded;
 - boundary name.
 
-The structured fields do not contain tenant slug, selected handle, locale, currency code,
-region id, price-list id, channel id, channel slug, or quantity values.
+Raw GraphQL display text is not written to the event.
+Debug output from the parsed typed error is not written to the event.
+
+The structured fields also do not contain tenant slug, selected handle, locale,
+currency code, region id, price-list id, channel id, channel slug, or quantity
+values.
 
 ## Tracing dependency
 
-The Pricing storefront package previously activated `tracing` only through the `ssr`
-feature. The GraphQL-selected default profile also compiles the new diagnostics policy, so
-`tracing` is now a normal workspace dependency and is no longer listed as `dep:tracing` in
-the SSR feature.
-
-This dependency-shape change does not alter native transport behavior. The native focused
-guard is updated only to require the all-profile dependency form.
+The earlier Pricing storefront safety slice made `tracing` a normal workspace
+dependency because the GraphQL-selected default profile compiles the same policy.
+This diagnostic-only follow-up does not change `Cargo.toml`, SSR features, or native
+transport behavior.
 
 ## Preserved behavior
 
-This slice does not change:
+This work does not change:
 
 - `StorefrontPricingQuery` fields or normalization;
 - currency, UUID, resolution-context, or quantity validation messages;
-- Pricing GraphQL query documents;
-- GraphQL variables or tenant-header construction;
-- list, detail, selected-handle, price-list, channel, or effective-price composition;
-- Pricing native server-function endpoint;
-- native runtime/context/owner error policy;
+- Pricing GraphQL query documents, variables, or tenant-header construction;
+- list, detail, selected-handle, price-list, channel, or effective-price
+  composition;
+- Pricing native server-function endpoint and public policy;
 - native versus GraphQL selected transport;
+- public error variants, stable messages, stable codes, or severity;
 - fallback behavior;
 - FFA, FBA, browser, runtime, workflow, CI, or production status.
 
@@ -114,25 +109,25 @@ Focused source evidence:
 - `crates/rustok-pricing/contracts/evidence/storefront-graphql-error-safety-source-review.json`;
 - `scripts/verify/verify-pricing-storefront-graphql-error-safety.mjs`.
 
-The focused verifier is imported by:
+The focused verifier now requires bounded error facts, forbids the complete raw and
+parsed payload fields, preserves the Pricing query and transport contracts, and
+checks truthful source/review evidence.
 
-- `scripts/verify/verify-pricing-storefront-boundary.mjs`.
-
-All execution and runtime validation flags remain `false`. Source review alone does not
-prove default, hydrate, SSR, browser, GraphQL runtime, mounted parity, workflow, CI, or
-production behavior.
+All execution and runtime validation flags remain `false`. Source review alone does
+not prove default, hydrate, SSR, browser, GraphQL runtime, mounted parity, workflow,
+CI, or production behavior.
 
 ## Remaining work
 
-The master ecommerce correlation-safe mapper cleanup remains open for:
+The master ecommerce correlation-safe mapper cleanup remains open for other
+storefront/admin adapters, payment and fulfillment execution diagnostics, remaining
+non-`PortError` public or diagnostic envelopes, and runtime or mounted-parity
+evidence.
 
-- other remaining ecommerce storefront/admin adapters;
-- inventory, customer, tax, promotion, and other non-`PortError` envelopes;
-- runtime and mounted-parity evidence for Pricing storefront native and GraphQL paths.
+No tests, verifiers, Cargo commands, formatting, workflows, or CI were run per
+maintainer instruction.
 
 ## Suggested maintainer checks
-
-These commands were intentionally not run by the implementation agent:
 
 ```bash
 node scripts/verify/verify-pricing-storefront-graphql-error-safety.mjs

--- a/crates/rustok-pricing/storefront/src/transport/graphql_error_safety.rs
+++ b/crates/rustok-pricing/storefront/src/transport/graphql_error_safety.rs
@@ -47,7 +47,10 @@ impl GraphqlCallContext {
         let ApiError::Graphql(raw_error) = error else {
             return error;
         };
+        let raw_error_present = !raw_error.trim().is_empty();
+        let raw_error_length = raw_error.chars().count();
         let parsed_error = GraphqlHttpError::from_str(raw_error.as_str());
+        let parsed_error_valid = parsed_error.is_ok();
         let (error_kind, code, public_message, technical_failure) = match &parsed_error {
             Ok(GraphqlHttpError::Network) => (
                 "network",
@@ -83,8 +86,9 @@ impl GraphqlCallContext {
 
         if technical_failure {
             tracing::error!(
-                raw_error = %raw_error,
-                parsed_error = ?parsed_error,
+                raw_error_present,
+                raw_error_length,
+                parsed_error_valid,
                 owner = PRICING_STOREFRONT_GRAPHQL_OWNER,
                 owner_operation = PRICING_STOREFRONT_GRAPHQL_OPERATION,
                 correlation_id = %self.correlation_id,
@@ -112,8 +116,9 @@ impl GraphqlCallContext {
             );
         } else {
             tracing::warn!(
-                raw_error = %raw_error,
-                parsed_error = ?parsed_error,
+                raw_error_present,
+                raw_error_length,
+                parsed_error_valid,
                 owner = PRICING_STOREFRONT_GRAPHQL_OWNER,
                 owner_operation = PRICING_STOREFRONT_GRAPHQL_OPERATION,
                 correlation_id = %self.correlation_id,

--- a/scripts/verify/verify-pricing-storefront-graphql-error-safety.mjs
+++ b/scripts/verify/verify-pricing-storefront-graphql-error-safety.mjs
@@ -106,11 +106,21 @@ for (const [marker, label] of [
     "correlation namespace",
   ],
   ["pub(super) fn map_error(&self, error: ApiError)", "final adapter error mapper"],
+  ["let ApiError::Graphql(raw_error) = error else", "GraphQL-only remap"],
+  ["return error;", "non-GraphQL pass-through"],
+  ["let raw_error_present = !raw_error.trim().is_empty();", "raw display presence fact"],
+  ["let raw_error_length = raw_error.chars().count();", "raw display length fact"],
   ["GraphqlHttpError::from_str(raw_error.as_str())", "known GraphQL HTTP classifier"],
+  ["let parsed_error_valid = parsed_error.is_ok();", "typed parse validity fact"],
   ["Ok(GraphqlHttpError::Network)", "network classification"],
   ["Ok(GraphqlHttpError::Http(_))", "HTTP classification"],
   ["Ok(GraphqlHttpError::Unauthorized)", "authentication classification"],
   ["Ok(GraphqlHttpError::Graphql(_))", "GraphQL rejection classification"],
+  ['"network"', "closed network category"],
+  ['"http"', "closed HTTP category"],
+  ['"unauthorized"', "closed authentication category"],
+  ['"graphql"', "closed GraphQL category"],
+  ['"unknown"', "closed unknown category"],
   ['"Storefront pricing is temporarily unavailable"', "unavailable public envelope"],
   ['"Pricing storefront authentication is required"', "authentication public envelope"],
   ['"Pricing storefront request could not be completed"', "request-rejected public envelope"],
@@ -119,8 +129,9 @@ for (const [marker, label] of [
   ['"pricing.storefront_graphql_authentication_required"', "authentication stable code"],
   ['"pricing.storefront_graphql_request_rejected"', "request-rejected stable code"],
   ['"pricing.storefront_graphql_unknown_failure"', "unknown stable code"],
-  ["raw_error = %raw_error", "private raw GraphQL diagnostics"],
-  ["parsed_error = ?parsed_error", "private parsed diagnostics"],
+  ["raw_error_present,", "bounded raw display presence diagnostics"],
+  ["raw_error_length,", "bounded raw display length diagnostics"],
+  ["parsed_error_valid,", "bounded typed parse diagnostics"],
   ["correlation_id = %self.correlation_id", "correlation diagnostics"],
   ["tenant_slug_length = ?self.tenant_slug_length", "tenant shape diagnostics"],
   ["selected_handle_length = ?self.selected_handle_length", "handle shape diagnostics"],
@@ -131,10 +142,16 @@ for (const [marker, label] of [
   ["channel_id_length = ?self.channel_id_length", "channel-id shape diagnostics"],
   ["channel_slug_length = ?self.channel_slug_length", "channel-slug shape diagnostics"],
   ["quantity_present = self.quantity_present", "quantity presence diagnostics"],
+  ["error_kind,", "closed error category diagnostics"],
+  ["code,", "stable code diagnostics"],
   ["ApiError::Graphql(public_message.to_string())", "static public mapping"],
 ]) requireText(safety, marker, `${safetyPath}: ${label}`);
 
 for (const marker of [
+  "raw_error = %raw_error",
+  "raw_error = ?raw_error",
+  "parsed_error = ?parsed_error",
+  "parsed_error = %parsed_error",
   "selected_handle = %",
   "selected_handle = ?",
   "locale = %",
@@ -154,7 +171,7 @@ for (const marker of [
   "tenant_slug = %",
   "tenant_slug = ?",
   "query = ?query",
-]) forbidText(safety, marker, `${safetyPath}: raw query or public cause mapping`);
+]) forbidText(safety, marker, `${safetyPath}: raw diagnostic or query payload`);
 
 for (const marker of [
   "pub(crate) struct StorefrontPricingQuery",
@@ -193,12 +210,17 @@ for (const [key, expected] of Object.entries({
   graphql_rejection_static_public_envelope: true,
   raw_graphql_http_display_public: false,
   raw_query_values_logged: false,
-  private_graphql_error_diagnostics: true,
+  raw_graphql_detail_logged: false,
+  parsed_graphql_error_debug_logged: false,
+  raw_graphql_detail_shape_logged: true,
+  typed_parse_validity_logged: true,
+  closed_graphql_error_category_logged: true,
   transport_validation_messages_preserved: true,
   native_adapter_changed: false,
   query_contract_changed: false,
   transport_selection_changed: false,
   fallback_added: false,
+  broad_ecommerce_cleanup_closed: false,
 })) {
   if (evidence.source_contract?.[key] !== expected) {
     failures.push(`${evidencePath}: source_contract.${key} must be ${expected}`);
@@ -227,7 +249,33 @@ if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
 if (review.status !== "pricing_storefront_graphql_error_safety_source_reviewed_unvalidated") {
   failures.push(`${reviewPath}: status mismatch`);
 }
-requireText(doc, "Status: **source-ready / unvalidated**", `${docPath}: source status`);
+for (const [key, expected] of Object.entries({
+  typed_graphql_variant_policy: true,
+  static_public_graphql_messages: true,
+  raw_graphql_detail_logging_removed: true,
+  parsed_graphql_error_debug_logging_removed: true,
+  bounded_graphql_error_shape_retained: true,
+  pricing_operation_preserved: true,
+  per_call_correlation_id: true,
+  safe_query_shape_only: true,
+  private_graphql_adapter_changed: false,
+  native_path_changed: false,
+  query_contract_changed: false,
+  transport_selection_changed: false,
+  runtime_evidence_claimed: false,
+})) {
+  if (review.implementation_review?.[key] !== expected) {
+    failures.push(`${reviewPath}: implementation_review.${key} must be ${expected}`);
+  }
+}
+for (const marker of [
+  "Status: **source-ready / unvalidated**",
+  "Raw GraphQL display text is not written to the event.",
+  "Debug output from the parsed typed error is not written to the event.",
+  "raw-display presence and character length",
+  "The master ecommerce correlation-safe mapper cleanup remains open",
+  "No tests, verifiers, Cargo commands, formatting, workflows, or CI were run",
+]) requireText(doc, marker, `${docPath}: truthful documentation`);
 requireText(
   masterPlan,
   "Finish correlation-safe mapper cleanup",
@@ -241,5 +289,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "✔ Pricing storefront GraphQL failures use correlation-safe static public envelopes; validation and runtime evidence remain unchanged",
+  "✔ Pricing storefront GraphQL failures retain bounded error/query shape and static public envelopes; validation and runtime evidence remain unchanged",
 );


### PR DESCRIPTION
## Summary

- continue the ecommerce correlation-safe mapper cleanup for the Pricing storefront non-`PortError` GraphQL boundary
- preserve `fetch_storefront_pricing`, typed `GraphqlHttpError` classification, five stable codes, static public messages, severity, per-call correlation, validation pass-through, bounded query shape, private GraphQL composition, explicit transport selection, and no-fallback behavior
- stop writing the complete private GraphQL display handoff and Debug representation of the parsed typed error into structured events
- retain only raw-display presence/character length, typed-parse validity, a closed five-value category, stable code, correlation, and the existing bounded query shape
- update the focused fail-closed verifier, source/review evidence, and Pricing documentation

## Recheck

The public Pricing GraphQL envelope was already static and safe, but `crates/rustok-pricing/storefront/src/transport/graphql_error_safety.rs` still logged `raw_error = %raw_error` and `parsed_error = ?parsed_error`. The existing verifier, evidence, and documentation explicitly retained those complete internal payloads. This PR closes only that diagnostic-envelope gap.

## Deliberate boundary

The broad ecommerce mapper cleanup remains open. No Cargo dependency, DTO, GraphQL document, adapter request construction, list/detail composition, validation message, native path, public transport variant, stable message/code, category severity, fallback policy, workflow, CI configuration, FFA/FBA status, or runtime-evidence status changes.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, CI, browser execution, or mounted runtime validation was executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-pricing-storefront-graphql-error-safety.mjs
node scripts/verify/verify-pricing-storefront-native-error-safety.mjs
node scripts/verify/verify-pricing-storefront-boundary.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-pricing-storefront
cargo check -p rustok-pricing-storefront --features hydrate
cargo check -p rustok-pricing-storefront --features ssr
```

Branch: `agent/pricing-storefront-graphql-diagnostic-safety-20260801`
Base main: `830b0126607cf21912c7b97b11fc129061391ff3`