### PR TITLE
feat(index): publish guarded reconciliation runtime

### DIFF
--- a/apps/server/docs/index-reconciliation-operator-runtime.md
+++ b/apps/server/docs/index-reconciliation-operator-runtime.md
@@ -1,0 +1,87 @@
+# Index reconciliation operator runtime
+
+Status: implementation retained, not run.
+
+## Purpose
+
+The server publishes one guarded `IndexReconciliationOperatorRuntime` after the existing Index replay composition has frozen the complete immutable source and schema registries.
+
+The boundary wraps the canonical `PostgresIndexReconciliationRunner` directly from current `main`. It does not depend on an unmerged Index runtime abstraction and performs no database I/O during composition.
+
+## Request-bound authority
+
+Every operation requires an `IndexReconciliationOperatorContext` containing one non-nil tenant UUID and actor UUID.
+
+Authorization is evaluated from the current request-scoped RBAC snapshot through `permissions_for(tenant_id, actor_id)`.
+
+The boundary requires `Permission::MODULES_MANAGE` to be present and rejects:
+
+- a nil tenant or actor identity;
+- a missing request-bound permission snapshot;
+- a snapshot without `modules:manage`;
+- a run request whose tenant differs from the authorized context tenant.
+
+The tenant comparison occurs before the inner reconciliation runner and therefore before database access.
+
+Cancellation does not accept a caller-supplied tenant separate from the context. It always calls the runner with the authorized context tenant and the requested job UUID.
+
+## Published surface
+
+The server capability exposes only:
+
+- bounded `run(IndexReconciliationRunRequest)`;
+- tenant-scoped `request_cancel(job_id)`.
+
+It does not expose:
+
+- the database connection;
+- source or schema registries;
+- mutable source catalogs;
+- scheduler or poller ownership;
+- task handles or worker spawning;
+- direct `index_jobs` SQL;
+- GraphQL, HTTP, CLI, MCP, or admin transport.
+
+## Composition
+
+The existing server replay composition remains the single source-freezing point.
+
+After it materializes PostgreSQL source factories and inserts the immutable `SharedIndexSourceRegistry`, it:
+
+1. materializes the existing guarded replay capability;
+2. requires the already-published `SharedIndexSchemaRegistry` when sources exist;
+3. constructs `PostgresIndexReconciliationRunner` from the host database and exact shared registries;
+4. inserts one guarded reconciliation operator into `ModuleRuntimeExtensions`.
+
+An absent source registry publishes no false reconciliation capability. A source registry without its shared schema registry fails closed. Duplicate guarded reconciliation materialization also fails closed.
+
+## Preserved engine behavior
+
+This server slice does not change the reconciliation runner, migrations, SQL, leases, cursor shape, event identity, mutations, diagnostics, or terminal state machine.
+
+The published boundary preserves existing bounded page/pass execution, heartbeat, yield, cancellation, attempt fencing, inbox deduplication, source-version monotonicity, and bounded failure diagnostics.
+
+## Scope boundaries
+
+This slice does not add:
+
+- automatic scheduling or takeover discovery;
+- retry/backoff or dead-letter requeue;
+- graceful task shutdown;
+- source/index digest comparison;
+- orphan cleanup;
+- targeted, full, or shadow repair modes;
+- locale or partition checkpoint dimensions;
+- complete drift repair.
+
+The canonical M6 reconciliation and drift-repair item therefore remains open.
+
+## Suggested maintainer validation
+
+```bash
+cargo test -p rustok-server index_reconciliation_operator -- --nocapture
+cargo check -p rustok-server --all-targets
+node scripts/verify/verify-index-server-reconciliation-guard.mjs
+```
+
+These commands were not run by the implementation agent.

--- a/apps/server/src/services/index_reconciliation_operator.rs
+++ b/apps/server/src/services/index_reconciliation_operator.rs
@@ -1,0 +1,417 @@
+use std::fmt;
+
+use rustok_api::{Permission, has_effective_permission};
+use rustok_core::ModuleRuntimeExtensions;
+use sea_orm::DatabaseConnection;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::error::{Error as ServerError, Result};
+use crate::services::rbac_request_scope::permissions_for;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndexReconciliationOperatorContext {
+    tenant_id: Uuid,
+    actor_id: Uuid,
+}
+
+impl IndexReconciliationOperatorContext {
+    pub fn new(
+        tenant_id: Uuid,
+        actor_id: Uuid,
+    ) -> std::result::Result<Self, IndexReconciliationOperatorError> {
+        if tenant_id.is_nil() || actor_id.is_nil() {
+            return Err(IndexReconciliationOperatorError::InvalidContext);
+        }
+        Ok(Self {
+            tenant_id,
+            actor_id,
+        })
+    }
+
+    pub fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub fn actor_id(&self) -> Uuid {
+        self.actor_id
+    }
+
+    fn authorize_for(
+        &self,
+        requested_tenant: Uuid,
+    ) -> std::result::Result<(), IndexReconciliationOperatorError> {
+        if requested_tenant != self.tenant_id {
+            return Err(IndexReconciliationOperatorError::TenantMismatch);
+        }
+        let permissions = permissions_for(&self.tenant_id, &self.actor_id)
+            .ok_or(IndexReconciliationOperatorError::MissingRequestAuthority)?;
+        if !has_effective_permission(&permissions, &Permission::MODULES_MANAGE) {
+            return Err(IndexReconciliationOperatorError::Forbidden);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum IndexReconciliationOperatorError {
+    #[error("Index reconciliation operator tenant and actor must not be nil")]
+    InvalidContext,
+    #[error("Index reconciliation request tenant does not match the authorized operator tenant")]
+    TenantMismatch,
+    #[error("Index reconciliation operations require a request-bound effective permission snapshot")]
+    MissingRequestAuthority,
+    #[error("modules:manage is required for Index reconciliation operations")]
+    Forbidden,
+    #[error(transparent)]
+    Reconciliation(#[from] rustok_index::IndexReconciliationRunError),
+}
+
+/// Server-owned guarded operator boundary over the canonical PostgreSQL Index reconciliation runner.
+///
+/// Transport adapters must provide an exact request-bound tenant/actor context. The boundary
+/// accepts only `modules:manage`, rejects cross-tenant requests before database access, and exposes
+/// no connection, source registry, scheduler, task handle, or worker-spawn capability.
+#[derive(Clone)]
+pub struct IndexReconciliationOperatorRuntime {
+    inner: rustok_index::PostgresIndexReconciliationRunner,
+}
+
+impl IndexReconciliationOperatorRuntime {
+    fn new(inner: rustok_index::PostgresIndexReconciliationRunner) -> Self {
+        Self { inner }
+    }
+
+    pub async fn run(
+        &self,
+        context: IndexReconciliationOperatorContext,
+        request: rustok_index::IndexReconciliationRunRequest,
+    ) -> std::result::Result<
+        rustok_index::IndexReconciliationRunOutcome,
+        IndexReconciliationOperatorError,
+    > {
+        context.authorize_for(request.tenant_id())?;
+        self.inner.run(request).await.map_err(Into::into)
+    }
+
+    pub async fn request_cancel(
+        &self,
+        context: IndexReconciliationOperatorContext,
+        job_id: Uuid,
+    ) -> std::result::Result<
+        rustok_index::IndexReconciliationCancelOutcome,
+        IndexReconciliationOperatorError,
+    > {
+        context.authorize_for(context.tenant_id())?;
+        self.inner
+            .request_cancel(context.tenant_id(), job_id)
+            .await
+            .map_err(Into::into)
+    }
+}
+
+impl fmt::Debug for IndexReconciliationOperatorRuntime {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("IndexReconciliationOperatorRuntime")
+            .finish_non_exhaustive()
+    }
+}
+
+/// Publishes the guarded reconciliation operator after replay composition has frozen the complete
+/// immutable source and schema registries.
+///
+/// This function performs no database I/O and starts no task. An absent source registry remains an
+/// optional capability; a source registry without its shared schema registry fails closed.
+pub(super) fn materialize_index_reconciliation_operator(
+    extensions: &mut ModuleRuntimeExtensions,
+    db: DatabaseConnection,
+) -> Result<()> {
+    if extensions.contains::<IndexReconciliationOperatorRuntime>() {
+        return Err(ServerError::Message(
+            "guarded Index reconciliation runtime is already materialized".to_string(),
+        ));
+    }
+
+    let Some(sources) = extensions
+        .get::<rustok_index::SharedIndexSourceRegistry>()
+        .cloned()
+    else {
+        return Ok(());
+    };
+    let schemas = extensions
+        .get::<rustok_index::SharedIndexSchemaRegistry>()
+        .cloned()
+        .ok_or_else(|| {
+            ServerError::Message(
+                "Index reconciliation source registry exists without the shared schema registry"
+                    .to_string(),
+            )
+        })?;
+
+    extensions.insert(IndexReconciliationOperatorRuntime::new(
+        rustok_index::PostgresIndexReconciliationRunner::new(db, sources, schemas.shared()),
+    ));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use rustok_api::Permission;
+    use rustok_core::{ModuleRuntimeExtensions, UserRole};
+    use rustok_index::{
+        EntityName, FieldCardinality, FieldName, IndexField, IndexReconciliationRunRequest,
+        IndexSchema, IndexSource, IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest,
+        IndexSourcePage, IndexSourceScanRequest, IndexValueType, LocaleMode, ModuleName, SchemaRef,
+        SchemaVersion, SharedIndexSchemaRegistry, SharedIndexSourceRegistry,
+        materialize_index_schema_registry, materialize_index_source_registry,
+        register_index_schema_source, register_index_source,
+    };
+    use sea_orm::Database;
+    use uuid::Uuid;
+
+    use super::{
+        IndexReconciliationOperatorContext, IndexReconciliationOperatorError,
+        IndexReconciliationOperatorRuntime, materialize_index_reconciliation_operator,
+    };
+    use crate::services::rbac_request_scope::{RbacRequestScope, with_rbac_request_scope};
+
+    struct NoopSource;
+
+    #[async_trait]
+    impl IndexSource for NoopSource {
+        async fn scan(
+            &self,
+            request: IndexSourceScanRequest,
+        ) -> std::result::Result<IndexSourcePage, IndexSourceFailure> {
+            Ok(IndexSourcePage::new(&request, Vec::new(), None)
+                .expect("empty final reconciliation page should be valid"))
+        }
+
+        async fn load(
+            &self,
+            request: IndexSourceLoadRequest,
+        ) -> std::result::Result<IndexSourceLoadBatch, IndexSourceFailure> {
+            Ok(IndexSourceLoadBatch::new(&request, Vec::new())
+                .expect("empty targeted load should be valid"))
+        }
+    }
+
+    fn schema() -> IndexSchema {
+        IndexSchema {
+            reference: SchemaRef {
+                module: ModuleName::new("server-reconciliation").unwrap(),
+                entity: EntityName::new("item").unwrap(),
+                version: SchemaVersion::INITIAL,
+            },
+            locale_mode: LocaleMode::None,
+            fields: vec![IndexField {
+                name: FieldName::new("id").unwrap(),
+                value_type: IndexValueType::Uuid,
+                cardinality: FieldCardinality::One,
+                nullable: false,
+                selectable: true,
+                filterable: true,
+                sortable: true,
+            }],
+            links: Vec::new(),
+        }
+    }
+
+    fn catalogs() -> ModuleRuntimeExtensions {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        let schema = schema();
+        register_index_schema_source(&mut extensions, "server_reconciliation", schema.clone())
+            .expect("schema source should register");
+        register_index_source(
+            &mut extensions,
+            "server_reconciliation",
+            "server-reconciliation-primary",
+            [schema.reference],
+            NoopSource,
+        )
+        .expect("reconciliation source should register");
+        extensions
+    }
+
+    fn complete_registries() -> ModuleRuntimeExtensions {
+        let mut extensions = catalogs();
+        let schemas = materialize_index_schema_registry(&extensions)
+            .expect("schema registry materialization")
+            .expect("schema registry");
+        let sources = materialize_index_source_registry(&extensions)
+            .expect("source registry materialization")
+            .expect("source registry");
+        extensions.insert(schemas);
+        extensions.insert(sources);
+        extensions
+    }
+
+    #[tokio::test]
+    async fn missing_sources_do_not_publish_false_reconciliation_capability() {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+
+        materialize_index_reconciliation_operator(&mut extensions, db)
+            .expect("missing sources should remain optional");
+        assert!(!extensions.contains::<IndexReconciliationOperatorRuntime>());
+    }
+
+    #[tokio::test]
+    async fn source_registry_without_shared_schema_registry_fails_closed() {
+        let mut extensions = catalogs();
+        let sources = materialize_index_source_registry(&extensions)
+            .expect("source registry materialization")
+            .expect("source registry");
+        extensions.insert(sources);
+        assert!(!extensions.contains::<SharedIndexSchemaRegistry>());
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+
+        let error = materialize_index_reconciliation_operator(&mut extensions, db)
+            .expect_err("missing shared schema registry must fail");
+        assert!(error.to_string().contains("without the shared schema registry"));
+    }
+
+    #[tokio::test]
+    async fn complete_registries_publish_guarded_runtime_to_host_context() {
+        let mut extensions = complete_registries();
+        assert!(extensions.contains::<SharedIndexSchemaRegistry>());
+        assert!(extensions.contains::<SharedIndexSourceRegistry>());
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+
+        materialize_index_reconciliation_operator(&mut extensions, db.clone())
+            .expect("guarded reconciliation runtime should compose");
+        assert!(extensions.contains::<IndexReconciliationOperatorRuntime>());
+
+        let host = extensions.apply_to_host_runtime(rustok_api::HostRuntimeContext::new(db));
+        assert!(
+            host.shared_get::<IndexReconciliationOperatorRuntime>()
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn duplicate_guarded_reconciliation_materialization_fails_closed() {
+        let mut extensions = complete_registries();
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+        materialize_index_reconciliation_operator(&mut extensions, db.clone())
+            .expect("first materialization");
+
+        let error = materialize_index_reconciliation_operator(&mut extensions, db)
+            .expect_err("duplicate materialization must fail");
+        assert!(error.to_string().contains("already materialized"));
+    }
+
+    #[tokio::test]
+    async fn operator_authorization_requires_exact_tenant_actor_and_modules_manage() {
+        let tenant_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let context = IndexReconciliationOperatorContext::new(tenant_id, actor_id).unwrap();
+        assert!(matches!(
+            context.authorize_for(tenant_id),
+            Err(IndexReconciliationOperatorError::MissingRequestAuthority)
+        ));
+
+        with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_READ],
+                UserRole::Admin,
+            )),
+            async {
+                assert!(matches!(
+                    context.authorize_for(tenant_id),
+                    Err(IndexReconciliationOperatorError::Forbidden)
+                ));
+            },
+        )
+        .await;
+
+        with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_MANAGE],
+                UserRole::Admin,
+            )),
+            async {
+                assert!(context.authorize_for(tenant_id).is_ok());
+                assert!(matches!(
+                    context.authorize_for(Uuid::new_v4()),
+                    Err(IndexReconciliationOperatorError::TenantMismatch)
+                ));
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn cross_tenant_run_is_denied_before_database_access() {
+        let mut extensions = complete_registries();
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database without Index migrations");
+        materialize_index_reconciliation_operator(&mut extensions, db)
+            .expect("runtime materialization");
+        let runtime = extensions
+            .get::<IndexReconciliationOperatorRuntime>()
+            .cloned()
+            .expect("guarded runtime");
+        let authorized_tenant = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let request = IndexReconciliationRunRequest::new(
+            Uuid::new_v4(),
+            schema().reference,
+            "server-reconciliation-worker",
+            1,
+            1,
+            1,
+            1,
+            Duration::from_secs(30),
+        )
+        .expect("valid bounded request");
+
+        let error = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                authorized_tenant,
+                actor_id,
+                vec![Permission::MODULES_MANAGE],
+                UserRole::Admin,
+            )),
+            runtime.run(
+                IndexReconciliationOperatorContext::new(authorized_tenant, actor_id).unwrap(),
+                request,
+            ),
+        )
+        .await
+        .expect_err("cross-tenant run must fail before touching the database");
+        assert!(matches!(
+            error,
+            IndexReconciliationOperatorError::TenantMismatch
+        ));
+    }
+
+    #[test]
+    fn operator_context_rejects_nil_identity() {
+        assert!(matches!(
+            IndexReconciliationOperatorContext::new(Uuid::nil(), Uuid::new_v4()),
+            Err(IndexReconciliationOperatorError::InvalidContext)
+        ));
+        assert!(matches!(
+            IndexReconciliationOperatorContext::new(Uuid::new_v4(), Uuid::nil()),
+            Err(IndexReconciliationOperatorError::InvalidContext)
+        ));
+    }
+}

--- a/apps/server/src/services/index_replay_runtime_composition.rs
+++ b/apps/server/src/services/index_replay_runtime_composition.rs
@@ -1,3 +1,11 @@
+#[path = "index_reconciliation_operator.rs"]
+mod reconciliation_operator;
+
+pub use reconciliation_operator::{
+    IndexReconciliationOperatorContext, IndexReconciliationOperatorError,
+    IndexReconciliationOperatorRuntime,
+};
+
 use std::fmt;
 
 use rustok_api::{Permission, has_effective_permission};
@@ -110,8 +118,8 @@ impl fmt::Debug for IndexReplayOperatorRuntime {
 ///
 /// This function performs no database I/O and starts no worker. It invokes selected source
 /// factories only to construct adapters, freezes the complete source catalog, binds the immutable
-/// schema/source registries to the host database, and publishes the guarded bounded operator
-/// capability through `ModuleRuntimeExtensions`.
+/// schema/source registries to the host database, and publishes the guarded bounded replay and
+/// reconciliation operator capabilities through `ModuleRuntimeExtensions`.
 pub(crate) fn materialize_index_replay_runtime(
     extensions: &mut ModuleRuntimeExtensions,
     db: DatabaseConnection,
@@ -138,12 +146,14 @@ pub(crate) fn materialize_index_replay_runtime(
         extensions.insert(sources);
     }
 
-    let runtime = rustok_index::materialize_postgres_index_replay_runtime(extensions, db).map_err(
-        |error| ServerError::Message(format!("Index replay runtime composition failed: {error}")),
-    )?;
+    let runtime = rustok_index::materialize_postgres_index_replay_runtime(extensions, db.clone())
+        .map_err(|error| {
+            ServerError::Message(format!("Index replay runtime composition failed: {error}"))
+        })?;
     if let Some(runtime) = runtime {
         extensions.insert(IndexReplayOperatorRuntime::new(runtime));
     }
+    reconciliation_operator::materialize_index_reconciliation_operator(extensions, db)?;
     Ok(())
 }
 

--- a/scripts/verify/verify-index-server-reconciliation-guard.mjs
+++ b/scripts/verify/verify-index-server-reconciliation-guard.mjs
@@ -1,0 +1,83 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const files = {
+  composition: "apps/server/src/services/index_replay_runtime_composition.rs",
+  operator: "apps/server/src/services/index_reconciliation_operator.rs",
+  docs: "apps/server/docs/index-reconciliation-operator-runtime.md",
+};
+
+const read = (name) => {
+  const relative = files[name];
+  const absolute = path.join(root, relative);
+  if (!fs.existsSync(absolute)) {
+    throw new Error(`missing Index server reconciliation guard file: ${relative}`);
+  }
+  return fs.readFileSync(absolute, "utf8");
+};
+
+const requireMarkers = (name, markers) => {
+  const content = read(name);
+  for (const marker of markers) {
+    if (!content.includes(marker)) {
+      throw new Error(`${files[name]} is missing required marker: ${marker}`);
+    }
+  }
+};
+
+const forbidMarkers = (name, markers) => {
+  const content = read(name);
+  for (const marker of markers) {
+    if (content.includes(marker)) {
+      throw new Error(`${files[name]} contains forbidden marker: ${marker}`);
+    }
+  }
+};
+
+requireMarkers("composition", [
+  "#[path = \"index_reconciliation_operator.rs\"]",
+  "IndexReconciliationOperatorRuntime",
+  "materialize_postgres_index_replay_runtime(extensions, db.clone())",
+  "materialize_index_reconciliation_operator(extensions, db)?",
+]);
+
+requireMarkers("operator", [
+  "pub struct IndexReconciliationOperatorContext",
+  "tenant_id.is_nil() || actor_id.is_nil()",
+  "permissions_for(&self.tenant_id, &self.actor_id)",
+  "Permission::MODULES_MANAGE",
+  "IndexReconciliationOperatorError::TenantMismatch",
+  "context.authorize_for(request.tenant_id())?",
+  "request_cancel(context.tenant_id(), job_id)",
+  "PostgresIndexReconciliationRunner::new(db, sources, schemas.shared())",
+  "missing_sources_do_not_publish_false_reconciliation_capability",
+  "source_registry_without_shared_schema_registry_fails_closed",
+  "complete_registries_publish_guarded_runtime_to_host_context",
+  "duplicate_guarded_reconciliation_materialization_fails_closed",
+  "cross_tenant_run_is_denied_before_database_access",
+]);
+
+requireMarkers("docs", [
+  "Status: implementation retained, not run.",
+  "requires `Permission::MODULES_MANAGE` to be present",
+  "tenant comparison occurs before the inner reconciliation runner",
+  "does not accept a caller-supplied tenant separate from the context",
+  "performs no database I/O during composition",
+  "The canonical M6 reconciliation and drift-repair item therefore remains open.",
+]);
+
+forbidMarkers("operator", [
+  "tokio::spawn",
+  "spawn_blocking",
+  "SELECT ",
+  "INSERT ",
+  "UPDATE ",
+  "DELETE ",
+  "Router::new",
+  "route(",
+  "async_graphql",
+]);
+
+console.log("Index server reconciliation guard markers verified.");


### PR DESCRIPTION
## Superseded

Closed without merge. Rebuilt directly on current `main`, rechecked against the merged replay retry/dead-letter contracts and current reconciliation runner/export surface, and merged as #2900.

Merged behavior:

- server-owned `IndexReconciliationOperatorRuntime` is published only after replay composition freezes the immutable source/schema registries;
- exact non-nil tenant/actor request context and effective `modules:manage` are required;
- cross-tenant run requests fail before inner runner or database delegation;
- cancellation accepts only a job UUID and derives tenant scope from the authorized context;
- missing sources publish no false capability;
- source/schema inconsistency and duplicate materialization fail closed;
- the guarded surface exposes only bounded run and cancellation;
- no direct SQL, transport, scheduler, task spawning, failed-scope admission, dead-letter inspection, requeue, retry reset, or retained PostgreSQL evidence was added.

The canonical M6 drift-diagnosis and targeted-repair roadmap item remains open.

Validation remained unrun per maintainer instruction.