### PR TITLE
fix(pricing): bound admin GraphQL diagnostics

### DIFF
--- a/crates/rustok-pricing/admin/src/transport/graphql_error_safety.rs
+++ b/crates/rustok-pricing/admin/src/transport/graphql_error_safety.rs
@@ -106,7 +106,10 @@ impl GraphqlCallContext {
             return error;
         };
 
+        let raw_error_present = !raw_error.trim().is_empty();
+        let raw_error_length = raw_error.chars().count();
         let parsed_error = GraphqlHttpError::from_str(raw_error.as_str());
+        let parsed_error_valid = parsed_error.is_ok();
         let (error_kind, code, public_message, technical_failure) = match &parsed_error {
             Ok(GraphqlHttpError::Network) => (
                 "network",
@@ -142,8 +145,9 @@ impl GraphqlCallContext {
 
         if technical_failure {
             tracing::error!(
-                raw_error = %raw_error,
-                parsed_error = ?parsed_error,
+                raw_error_present,
+                raw_error_length,
+                parsed_error_valid,
                 owner = PRICING_ADMIN_GRAPHQL_OWNER,
                 owner_operation = self.operation,
                 correlation_id = %self.correlation_id,
@@ -177,8 +181,9 @@ impl GraphqlCallContext {
             );
         } else {
             tracing::warn!(
-                raw_error = %raw_error,
-                parsed_error = ?parsed_error,
+                raw_error_present,
+                raw_error_length,
+                parsed_error_valid,
                 owner = PRICING_ADMIN_GRAPHQL_OWNER,
                 owner_operation = self.operation,
                 correlation_id = %self.correlation_id,

--- a/crates/rustok-pricing/contracts/evidence/admin-graphql-error-safety-source-review.json
+++ b/crates/rustok-pricing/contracts/evidence/admin-graphql-error-safety-source-review.json
@@ -1,57 +1,72 @@
 {
   "schema_version": 1,
-  "reviewed_at_utc": "2026-07-30T18:45:00Z",
+  "reviewed_at_utc": "2026-08-01T08:30:00Z",
+  "review_base": "f8cf7098c390d78e958cc0a6310a23ecc617539f",
   "status": "pricing_admin_graphql_error_safety_source_reviewed_unvalidated",
-  "scope": "Pricing admin GraphQL public error boundary",
+  "scope": "Pricing admin GraphQL public and diagnostic error boundary",
   "reviewed_sources": [
     "crates/rustok-commerce/docs/implementation-plan.md",
     "crates/rustok-pricing/docs/implementation-plan.md",
     "crates/rustok-pricing/admin/Cargo.toml",
     "crates/rustok-pricing/admin/src/transport.rs",
     "crates/rustok-pricing/admin/src/transport/graphql_adapter.rs",
+    "crates/rustok-pricing/admin/src/transport/graphql_error_safety.rs",
     "crates/rustok-pricing/admin/src/transport/native_server_adapter.rs",
-    "crates/rustok-pricing/storefront/src/transport/graphql_error_safety.rs",
-    "crates/rustok-commerce/admin/src/transport/graphql_error_safety.rs",
+    "crates/rustok-pricing/contracts/evidence/admin-graphql-error-safety-source.json",
+    "crates/rustok-pricing/docs/admin-graphql-error-safety.md",
     "crates/rustok-graphql/src/lib.rs",
-    "scripts/verify/verify-pricing-admin-boundary.mjs"
+    "scripts/verify/verify-pricing-admin-graphql-error-safety.mjs"
   ],
   "findings": [
     {
-      "id": "pricing-admin-graphql-display-public",
-      "severity": "confirmed",
-      "finding": "All four Pricing admin GraphQL reads converted GraphqlHttpError through ApiError::Graphql(value.to_string()) and returned that display directly from the selected transport facade. GraphQL server messages and HTTP status text could therefore reach the admin UI error envelope."
+      "id": "pricing-admin-static-public-envelope-preserved",
+      "severity": "preservation",
+      "finding": "All four Pricing admin GraphQL reads already reparse the private adapter display through GraphqlHttpError and return stable Pricing-owned public messages."
     },
     {
-      "id": "pricing-admin-final-facade-boundary",
-      "severity": "selected",
-      "finding": "The smallest compatible fix is a Pricing-owned per-call context in transport.rs. It sanitizes only ApiError::Graphql after the adapter call while preserving request validation and native behavior."
+      "id": "pricing-admin-raw-diagnostic-payload",
+      "severity": "diagnostic_safety",
+      "finding": "The shared mapper still copied the complete private GraphQL display and Debug representation of the parsed typed error into both technical and rejection tracing events."
     },
     {
-      "id": "pricing-admin-safe-shape",
-      "severity": "confirmed",
-      "finding": "The new diagnostics retain a unique correlation id and only request-field presence or character lengths. Identifier, locale, search, status, money-context, channel, and quantity values are not recorded as structured fields."
+      "id": "pricing-admin-request-shape-preservation",
+      "severity": "preservation",
+      "finding": "Correlation and optional request-field presence or length facts can be retained without recording raw identifiers, search text, status, pricing context, channel values, or backend error payloads."
     },
     {
-      "id": "pricing-admin-mutations-native-only",
-      "severity": "preserved",
-      "finding": "Variant price, discount, rule, and price-list scope mutations remain native-only and are outside this GraphQL read slice."
+      "id": "pricing-admin-transport-separation",
+      "severity": "preservation",
+      "finding": "The four GraphQL documents, request validation, native reads, native-only mutations, selected transport, and no-fallback behavior remain unchanged."
     }
   ],
+  "implementation_review": {
+    "typed_graphql_variant_policy": true,
+    "static_public_graphql_messages": true,
+    "raw_graphql_detail_logging_removed": true,
+    "parsed_graphql_error_debug_logging_removed": true,
+    "bounded_graphql_error_shape_retained": true,
+    "all_four_read_operations_preserved": true,
+    "per_call_correlation_id": true,
+    "safe_request_shape_only": true,
+    "private_graphql_adapter_changed": false,
+    "native_reads_changed": false,
+    "native_only_mutations_changed": false,
+    "graphql_documents_changed": false,
+    "transport_selection_changed": false,
+    "runtime_evidence_claimed": false
+  },
   "changed_files_expected": [
-    "crates/rustok-pricing/admin/Cargo.toml",
-    "crates/rustok-pricing/admin/src/transport.rs",
     "crates/rustok-pricing/admin/src/transport/graphql_error_safety.rs",
     "crates/rustok-pricing/contracts/evidence/admin-graphql-error-safety-source.json",
     "crates/rustok-pricing/contracts/evidence/admin-graphql-error-safety-source-review.json",
     "crates/rustok-pricing/docs/admin-graphql-error-safety.md",
-    "crates/rustok-pricing/docs/implementation-plan.md",
-    "scripts/verify/verify-pricing-admin-boundary.mjs",
     "scripts/verify/verify-pricing-admin-graphql-error-safety.mjs"
   ],
   "remaining_scope": [
-    "remaining ecommerce adapters and non-PortError public envelopes",
+    "remaining ecommerce adapters and non-PortError public or diagnostic envelopes",
     "Pricing admin verifier and Cargo execution",
-    "GraphQL/browser runtime and mounted parity evidence"
+    "GraphQL/browser runtime and mounted parity evidence",
+    "broad ecommerce correlation-safe mapper cleanup"
   ],
   "validation": {
     "tests_run": false,

--- a/crates/rustok-pricing/contracts/evidence/admin-graphql-error-safety-source.json
+++ b/crates/rustok-pricing/contracts/evidence/admin-graphql-error-safety-source.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
-  "generated_at_utc": "2026-07-30T18:45:00Z",
+  "generated_at_utc": "2026-08-01T08:30:00Z",
   "status": "pricing_admin_graphql_error_safety_source_unvalidated",
-  "scope": "Pricing-owned admin GraphQL public transport envelope",
+  "scope": "Pricing-owned admin GraphQL public and diagnostic transport envelope",
   "operations": [
     "fetch_bootstrap",
     "fetch_active_price_lists",
@@ -24,13 +24,18 @@
     "graphql_rejection_static_public_envelope": true,
     "raw_graphql_http_display_public": false,
     "raw_request_values_logged": false,
-    "private_graphql_error_diagnostics": true,
+    "raw_graphql_detail_logged": false,
+    "parsed_graphql_error_debug_logged": false,
+    "raw_graphql_detail_shape_logged": true,
+    "typed_parse_validity_logged": true,
+    "closed_graphql_error_category_logged": true,
     "request_validation_messages_preserved": true,
     "native_adapter_changed": false,
     "graphql_documents_changed": false,
     "transport_selection_changed": false,
     "fallback_added": false,
-    "native_only_mutations_changed": false
+    "native_only_mutations_changed": false,
+    "broad_ecommerce_cleanup_closed": false
   },
   "safe_diagnostics": [
     "owner",
@@ -48,10 +53,12 @@
     "channel_id presence and length",
     "channel_slug presence and length",
     "quantity presence",
-    "error_kind",
+    "raw GraphQL display presence",
+    "raw GraphQL display character length",
+    "typed GraphQL parse validity",
+    "closed GraphQL error category",
     "stable code",
-    "boundary",
-    "private raw and parsed GraphQL error"
+    "boundary"
   ],
   "forbidden_public_or_structured_values": [
     "tenant_slug",
@@ -66,7 +73,8 @@
     "channel_id",
     "channel_slug",
     "quantity",
-    "GraphqlHttpError display",
+    "raw GraphqlHttpError display",
+    "parsed GraphqlHttpError Debug output",
     "GraphQL server error message",
     "HTTP status text"
   ],
@@ -77,13 +85,15 @@
     "native server-function read behavior",
     "native-only Pricing admin mutations",
     "native versus GraphQL selected transport",
-    "absence of fallback"
+    "absence of fallback",
+    "stable public messages, codes, and severity"
   ],
   "remaining_scope": [
-    "remaining ecommerce adapters and non-PortError public envelopes",
+    "remaining ecommerce adapters and non-PortError public or diagnostic envelopes",
     "Pricing admin focused verifier execution",
     "Pricing admin Cargo compilation across default, hydrate, and SSR profiles",
-    "GraphQL/browser runtime and mounted parity evidence"
+    "GraphQL/browser runtime and mounted parity evidence",
+    "broad ecommerce correlation-safe mapper cleanup"
   ],
   "suggested_execution": [
     "node scripts/verify/verify-pricing-admin-graphql-error-safety.mjs",

--- a/crates/rustok-pricing/docs/admin-graphql-error-safety.md
+++ b/crates/rustok-pricing/docs/admin-graphql-error-safety.md
@@ -4,7 +4,8 @@ Status: **source-ready / unvalidated**
 
 ## Scope
 
-This slice hardens the four Pricing admin GraphQL read operations selected by
+This slice hardens the public and diagnostic boundary for the four Pricing admin
+GraphQL read operations selected by
 `crates/rustok-pricing/admin/src/transport.rs`:
 
 - `fetch_bootstrap`;
@@ -12,30 +13,41 @@ This slice hardens the four Pricing admin GraphQL read operations selected by
 - `fetch_products`;
 - `fetch_product`.
 
-The GraphQL documents, variables, request normalization, result mapping, native server
-functions, and native-only Pricing mutations remain unchanged.
+The GraphQL documents, variables, request normalization, result mapping, native
+server functions, and native-only Pricing mutations remain unchanged.
 
-## Confirmed gap
+## Rechecked gap
 
-The Pricing admin GraphQL adapter captures `GraphqlHttpError` as
-`ApiError::Graphql(value.to_string())`. Before this slice, the selected transport facade
-returned that display directly. GraphQL server messages, HTTP status text, and transport
-classification details could therefore cross the final admin UI boundary.
+The Pricing admin transport already creates a `GraphqlCallContext` before each
+adapter call, reparses the private adapter display through
+`GraphqlHttpError::from_str`, and returns only stable Pricing-owned messages.
+GraphQL server messages and HTTP status text therefore do not cross the final
+admin UI envelope.
+
+The shared tracing event still copied two complete private values:
+
+- `raw_error = %raw_error`;
+- `parsed_error = ?parsed_error`.
+
+Those payloads were not required for correlation, exact operation attribution,
+the closed five-category policy, or request-shape diagnosis. They were a
+remaining non-`PortError` diagnostic-envelope gap in the ecommerce
+correlation-safe mapper cleanup.
 
 ## Boundary placement
 
-Each GraphQL branch now creates a `GraphqlCallContext` before calling the adapter. The
-context receives the final `ApiError` after the adapter returns and before the admin UI can
-render it.
+Each GraphQL branch retains a `GraphqlCallContext` created before the private
+adapter call. The context maps only `ApiError::Graphql` after the adapter returns
+and before the admin UI can render the selected transport error.
 
-Only `ApiError::Graphql` is reclassified. Existing `ApiError::ServerFn` request-validation
-results pass through unchanged.
-
-Every call receives a unique correlation id in the namespace:
+Existing `ApiError::ServerFn` request-validation results pass through unchanged.
+Every call retains a unique correlation id in the namespace:
 
 ```text
 pricing-admin-graphql:<operation>:<uuid>
 ```
+
+No fallback is introduced, and the selected transport path remains unchanged.
 
 ## Public policy
 
@@ -47,34 +59,41 @@ pricing-admin-graphql:<operation>:<uuid>
 | GraphQL response rejection | `Pricing admin request could not be completed` |
 | Unrecognized captured display | `Pricing admin request could not be completed` |
 
-No fallback is introduced, and the selected transport path remains unchanged.
+Technical network, HTTP, and unknown failures retain error severity.
+Unauthorized and ordinary GraphQL rejection retain warning severity.
 
-## Internal diagnostics
+## Bounded internal diagnostics
 
-The original captured GraphQL display and parsed `GraphqlHttpError` remain private tracing
-fields. Structured diagnostics record only:
+Structured events retain only:
 
-- owner, operation, boundary, stable code, error kind, and correlation id;
+- owner, exact operation, boundary, stable code, closed error category, and
+  correlation id;
 - tenant slug presence and character length;
 - tenant id and requested resource id presence and character length;
-- locale, search, status, currency, region, price-list, channel id, and channel slug
-  presence and character length;
-- quantity presence.
+- locale, search, status, currency, region, price-list, channel id, and channel
+  slug presence and character length;
+- quantity presence;
+- raw-display presence and character length;
+- whether typed `GraphqlHttpError` parsing succeeded.
 
-The actual tenant, identifier, locale, search, status, pricing-context, channel, or
-quantity values are not recorded as structured fields.
+Raw GraphQL display text is not written to the event.
+Debug output from the parsed typed error is not written to the event.
+
+The actual tenant, identifier, locale, search, status, pricing-context, channel,
+or quantity values are also not recorded as structured fields.
 
 ## Preserved behavior
 
-This slice does not change:
+This work does not change:
 
 - Pricing admin GraphQL queries or variables;
 - bootstrap, active-price-list, product-list, or product-detail response mapping;
 - UUID, channel, resolution-context, locale, search, or status normalization;
+- request-validation messages or non-GraphQL pass-through;
 - native server-function reads;
 - variant price, discount, price-list rule, or price-list scope mutations;
 - native versus GraphQL selection;
-- fallback behavior;
+- stable public messages, codes, category severity, or fallback behavior;
 - FFA, FBA, browser, runtime, workflow, CI, or production status.
 
 ## Static evidence
@@ -83,15 +102,24 @@ This slice does not change:
 - `crates/rustok-pricing/contracts/evidence/admin-graphql-error-safety-source-review.json`;
 - `scripts/verify/verify-pricing-admin-graphql-error-safety.mjs`.
 
-The focused verifier is imported by `scripts/verify/verify-pricing-admin-boundary.mjs`.
-All execution flags remain `false`; source review alone does not prove compilation,
-GraphQL/browser runtime, or mounted parity.
+The focused verifier is imported by
+`scripts/verify/verify-pricing-admin-boundary.mjs`. It requires bounded error
+facts, forbids complete raw and parsed payload fields, preserves all four read
+operations and native-only mutations, and checks truthful source/review evidence.
+
+All execution flags remain `false`; source review alone does not prove
+compilation, GraphQL/browser runtime, mounted parity, workflow, CI, or production
+behavior.
 
 ## Remaining work
 
-The ecommerce correlation-safe mapper cleanup remains open for other storefront/admin
-adapters and non-`PortError` public envelopes, including inventory, customer, tax,
-promotion, and remaining owner-specific paths.
+The ecommerce correlation-safe mapper cleanup remains open for other
+storefront/admin adapters, payment and fulfillment execution diagnostics,
+remaining non-`PortError` public or diagnostic envelopes, and runtime or
+mounted-parity evidence.
+
+No tests, verifiers, Cargo commands, formatting, workflows, or CI were run per
+maintainer instruction.
 
 ## Suggested maintainer checks
 

--- a/scripts/verify/verify-pricing-admin-graphql-error-safety.mjs
+++ b/scripts/verify/verify-pricing-admin-graphql-error-safety.mjs
@@ -31,6 +31,7 @@ const reviewPath =
   "crates/rustok-pricing/contracts/evidence/admin-graphql-error-safety-source-review.json";
 const docPath = "crates/rustok-pricing/docs/admin-graphql-error-safety.md";
 const planPath = "crates/rustok-pricing/docs/implementation-plan.md";
+const masterPlanPath = "crates/rustok-commerce/docs/implementation-plan.md";
 
 const cargo = read(cargoPath);
 const transport = read(transportPath);
@@ -41,6 +42,7 @@ const evidence = JSON.parse(read(evidencePath));
 const review = JSON.parse(read(reviewPath));
 const doc = read(docPath);
 const plan = read(planPath);
+const masterPlan = read(masterPlanPath);
 
 requireText(cargo, "tracing.workspace = true", `${cargoPath}: all-profile tracing`);
 requireText(cargo, "uuid.workspace = true", `${cargoPath}: correlation UUID`);
@@ -87,11 +89,21 @@ for (const marker of [
   "pub(super) struct GraphqlCallContext",
   "pricing-admin-graphql:{operation}:{}",
   "Uuid::new_v4()",
+  "let ApiError::Graphql(raw_error) = error else",
+  "return error;",
+  "let raw_error_present = !raw_error.trim().is_empty();",
+  "let raw_error_length = raw_error.chars().count();",
   "GraphqlHttpError::from_str(raw_error.as_str())",
+  "let parsed_error_valid = parsed_error.is_ok();",
   "Ok(GraphqlHttpError::Network)",
   "Ok(GraphqlHttpError::Http(_))",
   "Ok(GraphqlHttpError::Unauthorized)",
   "Ok(GraphqlHttpError::Graphql(_))",
+  '"network"',
+  '"http"',
+  '"unauthorized"',
+  '"graphql"',
+  '"unknown"',
   "Pricing admin service is temporarily unavailable",
   "Pricing admin authentication is required",
   "Pricing admin request could not be completed",
@@ -100,16 +112,26 @@ for (const marker of [
   "pricing.admin_graphql_authentication_required",
   "pricing.admin_graphql_request_rejected",
   "pricing.admin_graphql_unknown_failure",
-  "raw_error = %raw_error",
-  "parsed_error = ?parsed_error",
+  "raw_error_present,",
+  "raw_error_length,",
+  "parsed_error_valid,",
+  "owner = PRICING_ADMIN_GRAPHQL_OWNER",
+  "owner_operation = self.operation",
+  "correlation_id = %self.correlation_id",
   "tenant_id_length = ?self.tenant_id_length",
   "resource_id_length = ?self.resource_id_length",
   "search_length = ?self.search_length",
   "quantity_present = self.quantity_present",
+  "error_kind,",
+  "code,",
   "ApiError::Graphql(public_message.to_string())",
 ]) requireText(safety, marker, `${safetyPath}: bounded GraphQL policy`);
 
 for (const marker of [
+  "raw_error = %raw_error",
+  "raw_error = ?raw_error",
+  "parsed_error = ?parsed_error",
+  "parsed_error = %parsed_error",
   "tenant_slug = %",
   "tenant_slug = ?",
   "tenant_id = %",
@@ -134,7 +156,7 @@ for (const marker of [
   "channel_slug = ?",
   "quantity = %",
   "quantity = ?",
-]) forbidText(safety, marker, `${safetyPath}: raw request value diagnostics`);
+]) forbidText(safety, marker, `${safetyPath}: raw diagnostic or request payload`);
 
 requireText(native, "pub enum ApiError", `${nativePath}: shared error envelope`);
 requireText(native, "pricing_admin_bootstrap_native", `${nativePath}: native read preserved`);
@@ -147,15 +169,24 @@ if (evidence.status !== "pricing_admin_graphql_error_safety_source_unvalidated")
 for (const [key, expected] of Object.entries({
   context_before_each_graphql_call: true,
   unique_correlation_id_per_call: true,
+  network_static_public_envelope: true,
+  http_static_public_envelope: true,
+  authentication_static_public_envelope: true,
+  graphql_rejection_static_public_envelope: true,
   raw_graphql_http_display_public: false,
   raw_request_values_logged: false,
-  private_graphql_error_diagnostics: true,
+  raw_graphql_detail_logged: false,
+  parsed_graphql_error_debug_logged: false,
+  raw_graphql_detail_shape_logged: true,
+  typed_parse_validity_logged: true,
+  closed_graphql_error_category_logged: true,
   request_validation_messages_preserved: true,
   native_adapter_changed: false,
   graphql_documents_changed: false,
   transport_selection_changed: false,
   fallback_added: false,
   native_only_mutations_changed: false,
+  broad_ecommerce_cleanup_closed: false,
 })) {
   if (evidence.source_contract?.[key] !== expected) {
     failures.push(`${evidencePath}: source_contract.${key} must be ${expected}`);
@@ -184,8 +215,40 @@ if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
 if (review.status !== "pricing_admin_graphql_error_safety_source_reviewed_unvalidated") {
   failures.push(`${reviewPath}: status mismatch`);
 }
-requireText(doc, "Status: **source-ready / unvalidated**", `${docPath}: source status`);
+for (const [key, expected] of Object.entries({
+  typed_graphql_variant_policy: true,
+  static_public_graphql_messages: true,
+  raw_graphql_detail_logging_removed: true,
+  parsed_graphql_error_debug_logging_removed: true,
+  bounded_graphql_error_shape_retained: true,
+  all_four_read_operations_preserved: true,
+  per_call_correlation_id: true,
+  safe_request_shape_only: true,
+  private_graphql_adapter_changed: false,
+  native_reads_changed: false,
+  native_only_mutations_changed: false,
+  graphql_documents_changed: false,
+  transport_selection_changed: false,
+  runtime_evidence_claimed: false,
+})) {
+  if (review.implementation_review?.[key] !== expected) {
+    failures.push(`${reviewPath}: implementation_review.${key} must be ${expected}`);
+  }
+}
+for (const marker of [
+  "Status: **source-ready / unvalidated**",
+  "Raw GraphQL display text is not written to the event.",
+  "Debug output from the parsed typed error is not written to the event.",
+  "raw-display presence and character length",
+  "The ecommerce correlation-safe mapper cleanup remains open",
+  "No tests, verifiers, Cargo commands, formatting, workflows, or CI were run",
+]) requireText(doc, marker, `${docPath}: truthful documentation`);
 requireText(plan, "admin GraphQL public errors", `${planPath}: local plan record`);
+requireText(
+  masterPlan,
+  "Finish correlation-safe mapper cleanup",
+  `${masterPlanPath}: broad mapper cleanup remains open`,
+);
 
 if (failures.length > 0) {
   console.error("Pricing admin GraphQL error-safety verification failed:");
@@ -194,5 +257,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "✔ Pricing admin GraphQL reads use correlation-safe static public envelopes; execution evidence remains maintainer-owned",
+  "✔ Pricing admin GraphQL reads retain bounded error/request shape and static public envelopes; execution evidence remains maintainer-owned",
 );


### PR DESCRIPTION
## Summary

- continue the ecommerce correlation-safe mapper cleanup for the Pricing admin non-`PortError` GraphQL boundary
- preserve all four read operations, typed `GraphqlHttpError` classification, five stable codes, static public messages, severity, per-call correlation, request-validation pass-through, bounded request shape, private GraphQL documents, explicit transport selection, and no-fallback behavior
- stop writing the complete private GraphQL display handoff and Debug representation of the parsed typed error into structured events
- retain only raw-display presence/character length, typed-parse validity, a closed five-value category, stable code, correlation, and the existing bounded request shape
- update the focused fail-closed verifier, source/review evidence, and Pricing admin documentation

## Recheck

The public Pricing admin GraphQL envelopes were already static and safe, but `crates/rustok-pricing/admin/src/transport/graphql_error_safety.rs` still logged `raw_error = %raw_error` and `parsed_error = ?parsed_error`. The existing verifier, evidence, and documentation explicitly retained those complete internal payloads. This PR closes only that diagnostic-envelope gap.

## Deliberate boundary

The broad ecommerce mapper cleanup remains open. No Cargo dependency, request DTO, GraphQL document, adapter request construction, normalization, result mapping, native read, native-only mutation, public transport variant, stable message/code, category severity, fallback policy, workflow, CI configuration, FFA/FBA status, or runtime-evidence status changes.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, CI, browser execution, or mounted runtime validation was executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-pricing-admin-graphql-error-safety.mjs
node scripts/verify/verify-pricing-admin-boundary.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-pricing-admin
cargo check -p rustok-pricing-admin --features hydrate
cargo check -p rustok-pricing-admin --features ssr
```

Branch: `agent/pricing-admin-graphql-diagnostic-safety-20260801`
Base main: `f8cf7098c390d78e958cc0a6310a23ecc617539f`