### PR TITLE
fix(cart): bound storefront GraphQL diagnostics

### DIFF
--- a/crates/rustok-cart/contracts/evidence/storefront-graphql-error-safety-source-review.json
+++ b/crates/rustok-cart/contracts/evidence/storefront-graphql-error-safety-source-review.json
@@ -1,8 +1,9 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-30",
+  "generated_at": "2026-08-01",
   "status": "cart_storefront_graphql_error_safety_source_reviewed_unvalidated",
-  "base_main_sha": "57ad4a48b8d27ecf168d67a4bba98015be627e9a",
+  "base_main_sha": "1bd2286cef47fe79f9f53c5788ff0ba008124dfe",
+  "scope": "Cart storefront GraphQL public and diagnostic error boundary",
   "reviewed_sources": [
     "crates/rustok-commerce/docs/implementation-plan.md",
     "crates/rustok-cart/storefront/Cargo.toml",
@@ -12,29 +13,54 @@
     "crates/rustok-cart/storefront/src/transport/graphql_adapter.rs",
     "crates/rustok-cart/storefront/src/transport/graphql_error_safety.rs",
     "crates/rustok-cart/storefront/src/transport/native_server_adapter_ssr.rs",
+    "crates/rustok-cart/contracts/evidence/storefront-graphql-error-safety-source.json",
+    "crates/rustok-cart/docs/storefront-graphql-error-safety.md",
     "crates/rustok-graphql/src/lib.rs",
-    "crates/rustok-ui-transport/src/lib.rs",
-    "scripts/verify/verify-cart-storefront-boundary.mjs"
+    "scripts/verify/verify-cart-storefront-graphql-error-safety.mjs"
   ],
   "findings": [
     {
-      "id": "cart-storefront-graphql-public-detail",
-      "severity": "p1",
-      "finding": "The cart storefront GraphQL adapter converted GraphqlHttpError to ApiError::Graphql using the full display string, and all three public facade closures delegated to that adapter without an owner sanitizer.",
-      "resolution": "Create an operation-specific per-call context at the public consumer boundary and map only ApiError::Graphql to static public envelopes."
+      "id": "cart-storefront-static-public-envelope-preserved",
+      "severity": "preservation",
+      "finding": "All three Cart storefront GraphQL operations already reparse the private adapter display through GraphqlHttpError and return stable Cart-owned public messages."
     },
     {
-      "id": "cart-storefront-validation-preservation",
-      "severity": "contract",
-      "finding": "Cart UUID, line-item UUID, and quantity-command validation execute before the GraphQL request and return ApiError::Validation.",
-      "resolution": "Pass Validation and ServerFn variants through unchanged and leave the private adapter and core policy unmodified."
+      "id": "cart-storefront-raw-diagnostic-payload",
+      "severity": "diagnostic_safety",
+      "finding": "The shared mapper still copied the complete private GraphQL display and Debug representation of the parsed typed error into both technical and rejection tracing events."
     },
     {
-      "id": "cart-storefront-correlation-context",
-      "severity": "contract",
-      "finding": "The selected GraphQL paths had no cart-owner correlation event retaining operation and safe request-shape context.",
-      "resolution": "Generate a unique per-call correlation id and retain only configuration facts, identifier lengths, optional-field presence, and command kind in internal diagnostics."
+      "id": "cart-storefront-request-shape-preservation",
+      "severity": "preservation",
+      "finding": "Correlation, exact operation attribution, identifier lengths, optional-field presence, and bounded command kind can be retained without recording raw request identifiers or backend error payloads."
+    },
+    {
+      "id": "cart-storefront-transport-separation",
+      "severity": "preservation",
+      "finding": "The private GraphQL documents, validation, DTO mapping, native SSR path, selected transport, and no-fallback behavior remain unchanged."
     }
+  ],
+  "implementation_review": {
+    "typed_graphql_variant_policy": true,
+    "static_public_graphql_messages": true,
+    "raw_graphql_detail_logging_removed": true,
+    "parsed_graphql_error_debug_logging_removed": true,
+    "bounded_graphql_error_shape_retained": true,
+    "all_three_operations_preserved": true,
+    "per_call_correlation_id": true,
+    "safe_request_shape_only": true,
+    "private_graphql_adapter_changed": false,
+    "native_path_changed": false,
+    "graphql_documents_changed": false,
+    "transport_selection_changed": false,
+    "runtime_evidence_claimed": false
+  },
+  "changed_files_expected": [
+    "crates/rustok-cart/storefront/src/transport/graphql_error_safety.rs",
+    "crates/rustok-cart/contracts/evidence/storefront-graphql-error-safety-source.json",
+    "crates/rustok-cart/contracts/evidence/storefront-graphql-error-safety-source-review.json",
+    "crates/rustok-cart/docs/storefront-graphql-error-safety.md",
+    "scripts/verify/verify-cart-storefront-graphql-error-safety.mjs"
   ],
   "preserved_behavior": [
     "explicit feature-based transport selection",
@@ -45,6 +71,12 @@
     "decrement quantity command policy",
     "native SSR error-safety policy",
     "Commerce aggregate cart and payment composition"
+  ],
+  "remaining_scope": [
+    "remaining ecommerce adapters and non-PortError public or diagnostic envelopes",
+    "Cart storefront verifier and Cargo execution",
+    "GraphQL/browser runtime and mounted parity evidence",
+    "broad ecommerce correlation-safe mapper cleanup"
   ],
   "execution": {
     "commands": [],

--- a/crates/rustok-cart/contracts/evidence/storefront-graphql-error-safety-source.json
+++ b/crates/rustok-cart/contracts/evidence/storefront-graphql-error-safety-source.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-30",
+  "generated_at": "2026-08-01",
   "status": "cart_storefront_graphql_error_safety_source_unvalidated",
-  "scope": "cart-owned storefront GraphQL read and line-item mutation transport",
+  "scope": "cart-owned storefront GraphQL public and diagnostic read and line-item mutation transport",
   "covered_operations": [
     "fetch_cart",
     "decrement_line_item",
@@ -28,13 +28,67 @@
     "raw_request_identifiers_logged": false,
     "raw_tenant_slug_logged": false,
     "raw_graphql_error_public": false,
-    "non_graphql_errors_pass_through": true
+    "raw_graphql_detail_logged": false,
+    "parsed_graphql_error_debug_logged": false,
+    "raw_graphql_detail_shape_logged": true,
+    "typed_parse_validity_logged": true,
+    "closed_graphql_error_category_logged": true,
+    "non_graphql_errors_pass_through": true,
+    "broad_ecommerce_cleanup_closed": false
   },
   "stable_public_messages": {
     "network_or_http": "Cart storefront is temporarily unavailable",
     "unauthorized": "Cart authentication is required",
     "graphql_rejection_or_unknown": "Cart request could not be completed"
   },
+  "safe_diagnostics": [
+    "owner",
+    "owner operation",
+    "correlation id",
+    "tenant slug configured and character length",
+    "selected cart id presence and character length",
+    "locale presence and character length",
+    "cart id character length",
+    "line item id character length",
+    "bounded command kind",
+    "raw GraphQL display presence",
+    "raw GraphQL display character length",
+    "typed GraphQL parse validity",
+    "closed GraphQL error category",
+    "stable code",
+    "boundary"
+  ],
+  "forbidden_public_or_structured_values": [
+    "raw GraphqlHttpError display",
+    "parsed GraphqlHttpError Debug output",
+    "tenant slug",
+    "selected cart id",
+    "locale",
+    "cart id",
+    "line item id",
+    "quantity",
+    "GraphQL endpoint",
+    "GraphQL document",
+    "GraphQL variables",
+    "authentication token",
+    "response payload"
+  ],
+  "preserved": [
+    "private GraphQL query and mutation documents",
+    "cart storefront request and response DTOs",
+    "cart and line-item identifier validation",
+    "decrement quantity command policy",
+    "native SSR error-safety policy",
+    "explicit feature-based transport selection",
+    "absence of native-to-GraphQL fallback",
+    "stable public messages, codes, and severity"
+  ],
+  "remaining_scope": [
+    "remaining ecommerce adapters and non-PortError public or diagnostic envelopes",
+    "Cart storefront verifier and Cargo execution",
+    "GraphQL/browser runtime and mounted parity evidence",
+    "broad ecommerce correlation-safe mapper cleanup"
+  ],
   "suggested_execution": [
     "node scripts/verify/verify-cart-storefront-graphql-error-safety.mjs",
     "node scripts/verify/verify-cart-storefront-native-error-safety.mjs",

--- a/crates/rustok-cart/docs/storefront-graphql-error-safety.md
+++ b/crates/rustok-cart/docs/storefront-graphql-error-safety.md
@@ -4,8 +4,8 @@ Status: source-unvalidated
 
 ## Scope
 
-This source slice hardens the cart-owned storefront GraphQL transport for the
-three public operations:
+This source slice hardens the public and diagnostic boundary for the three
+cart-owned storefront GraphQL operations:
 
 - `fetch_cart`;
 - `decrement_line_item`;
@@ -16,25 +16,32 @@ GraphQL adapter remains private and continues to own the query and mutation
 documents, variables, response decoding, cart and line-item UUID validation,
 quantity-command behavior, and DTO mapping.
 
-## Previous gap
+## Rechecked gap
 
-The private adapter converted `GraphqlHttpError` into
-`ApiError::Graphql(value.to_string())`. Each selected GraphQL closure delegated
-directly to that adapter, and `execute_selected_transport` retained the display
-string in the public `UiTransportError.graphql_error` field.
+The Cart storefront facade already creates an operation-specific
+`GraphqlCallContext`, reparses the private adapter display through
+`GraphqlHttpError::from_str`, and returns only stable Cart-owned public messages.
+GraphQL server messages and HTTP details therefore do not cross the public
+`UiTransportError` envelope.
 
-Consequently, server-provided GraphQL messages and HTTP details could cross the
-cart storefront UI boundary without a cart-owned public-envelope policy. The
-native SSR path already had a separate static-envelope policy, but that policy
-did not cover the GraphQL transport.
+The shared tracing event still copied two complete private values:
+
+- `raw_error = %raw_error`;
+- `parsed_error = ?parsed_error`.
+
+Those payloads were not required for correlation, exact operation attribution,
+the closed five-category policy, or request-shape diagnosis. They were a
+remaining non-`PortError` diagnostic-envelope gap in the ecommerce
+correlation-safe mapper cleanup.
 
 ## Public consumer policy
 
-`transport/mod.rs` now creates a private `GraphqlCallContext` before invoking
-each GraphQL operation. The context reparses the adapter's display handoff
-through `GraphqlHttpError::from_str` and maps only `ApiError::Graphql`.
+`transport/mod.rs` continues to create a private `GraphqlCallContext` before
+invoking each GraphQL operation. The context maps only `ApiError::Graphql` after
+the adapter returns and before the selected transport creates the public error
+envelope.
 
-The stable public messages are:
+The stable public messages remain:
 
 | Typed failure | Public message |
 | --- | --- |
@@ -47,32 +54,38 @@ The stable public messages are:
 `Validation` and `ServerFn` variants are returned unchanged. This preserves the
 existing identifier-validation behavior and independent native SSR policy.
 
-## Correlation diagnostics
+Technical network, HTTP, and unknown failures retain error-level diagnostics.
+Unauthorized and ordinary GraphQL rejection retain warning-level diagnostics.
 
-Every selected GraphQL call creates a unique correlation identifier from the
-owner operation and a new UUID. Internal tracing events retain:
+## Bounded correlation diagnostics
+
+Every selected GraphQL call retains a unique correlation identifier from the
+owner operation and a new UUID. Structured events retain only:
 
 - owner `rustok_cart.storefront`;
 - owner operation `fetch_cart`, `decrement_line_item`, or `remove_line_item`;
 - boundary `cart_storefront_graphql_transport`;
 - correlation identifier;
-- typed error kind and stable code;
-- raw and reparsed GraphQL cause for internal diagnosis;
+- one closed error category: `network`, `http`, `unauthorized`, `graphql`, or
+  `unknown`;
+- stable internal code;
+- raw-display presence and character length;
+- whether typed `GraphqlHttpError` parsing succeeded;
 - whether a tenant slug is configured and its character length;
 - selected-cart and locale presence plus character lengths for reads;
 - cart-id and line-item-id character lengths for writes;
 - decrement command kind, without quantity or identifier values.
 
-The mapper does not log the raw tenant slug, selected cart id, locale, cart id,
-line-item id, GraphQL endpoint, documents, variables, tokens, response payloads,
-or cart/customer data.
+Raw GraphQL display text is not written to the event.
+Debug output from the parsed typed error is not written to the event.
 
-Technical network, HTTP, and unknown failures use error-level diagnostics.
-Unauthorized and ordinary GraphQL rejection use warning-level diagnostics.
+The mapper also does not log the raw tenant slug, selected cart id, locale, cart
+id, line-item id, GraphQL endpoint, documents, variables, tokens, response
+payloads, or cart/customer data.
 
 ## Preserved behavior
 
-This slice does not change:
+This work does not change:
 
 - feature-based `NativeServer` versus `Graphql` selection;
 - the no-fallback transport policy;
@@ -84,11 +97,13 @@ This slice does not change:
 - cart and line-item identifier validation;
 - decrement quantity-command policy;
 - native server functions or native SSR error mapping;
-- Commerce aggregate use of the cart storefront facade.
+- stable public messages, codes, or severity;
+- Commerce aggregate use of the cart storefront facade;
+- FFA, FBA, browser, runtime, workflow, CI, or production status.
 
 The adapter still creates the same typed GraphQL display handoff. Sanitization
-occurs once at the public consumer boundary, avoiding duplicate diagnostics and
-preserving adapter ownership.
+continues to occur once at the public consumer boundary, avoiding duplicate
+diagnostics and preserving adapter ownership.
 
 ## Source guard
 
@@ -98,10 +113,9 @@ The focused verifier is:
 node scripts/verify/verify-cart-storefront-graphql-error-safety.mjs
 ```
 
-It checks all three operation contexts, typed mapping policy, static public
-messages and codes, correlation and safe request-shape diagnostics, GraphQL-only
-remapping, private-adapter preservation, native-path preservation, evidence
-status, and validation nonclaims.
+It now requires bounded error facts, forbids the complete raw and parsed payload
+fields, checks all three operation contexts and static public envelopes, and
+reconciles the retained source/review evidence and this documentation.
 
 The general owner boundary verifier imports both native and GraphQL guards:
 

--- a/crates/rustok-cart/storefront/src/transport/graphql_error_safety.rs
+++ b/crates/rustok-cart/storefront/src/transport/graphql_error_safety.rs
@@ -92,7 +92,10 @@ impl GraphqlCallContext {
         let ApiError::Graphql(raw_error) = error else {
             return error;
         };
+        let raw_error_present = !raw_error.trim().is_empty();
+        let raw_error_length = raw_error.chars().count();
         let parsed_error = GraphqlHttpError::from_str(raw_error.as_str());
+        let parsed_error_valid = parsed_error.is_ok();
         let (error_kind, code, public_message, technical_failure) = match &parsed_error {
             Ok(GraphqlHttpError::Network) => (
                 "network",
@@ -128,8 +131,9 @@ impl GraphqlCallContext {
 
         if technical_failure {
             tracing::error!(
-                raw_error = %raw_error,
-                parsed_error = ?parsed_error,
+                raw_error_present,
+                raw_error_length,
+                parsed_error_valid,
                 owner = CART_STOREFRONT_GRAPHQL_OWNER,
                 owner_operation = self.owner_operation,
                 correlation_id = %self.correlation_id,
@@ -149,8 +153,9 @@ impl GraphqlCallContext {
             );
         } else {
             tracing::warn!(
-                raw_error = %raw_error,
-                parsed_error = ?parsed_error,
+                raw_error_present,
+                raw_error_length,
+                parsed_error_valid,
                 owner = CART_STOREFRONT_GRAPHQL_OWNER,
                 owner_operation = self.owner_operation,
                 correlation_id = %self.correlation_id,

--- a/scripts/verify/verify-cart-storefront-graphql-error-safety.mjs
+++ b/scripts/verify/verify-cart-storefront-graphql-error-safety.mjs
@@ -24,6 +24,8 @@ const files = {
   nativeSafety: "crates/rustok-cart/storefront/src/transport/native_server_adapter_ssr.rs",
   evidence: "crates/rustok-cart/contracts/evidence/storefront-graphql-error-safety-source.json",
   review: "crates/rustok-cart/contracts/evidence/storefront-graphql-error-safety-source-review.json",
+  doc: "crates/rustok-cart/docs/storefront-graphql-error-safety.md",
+  masterPlan: "crates/rustok-commerce/docs/implementation-plan.md",
 };
 
 for (const filePath of Object.values(files)) {
@@ -38,6 +40,8 @@ const safety = read(files.safety);
 const nativeSafety = read(files.nativeSafety);
 const evidence = JSON.parse(read(files.evidence));
 const review = JSON.parse(read(files.review));
+const doc = read(files.doc);
+const masterPlan = read(files.masterPlan);
 
 for (const [value, label] of [
   ["mod graphql_error_safety;", "safety module wiring"],
@@ -50,14 +54,8 @@ for (const [value, label] of [
   [".map_err(|error| context.map_error(error))", "consumer-boundary mapping"],
   ["NativeClientErrorContext::fetch_cart(&native_request)", "native fetch context preservation"],
   ["native_server_adapter::fetch_cart(native_request)", "native fetch preservation"],
-  [
-    "NativeClientErrorContext::decrement_line_item(",
-    "native decrement context preservation",
-  ],
-  [
-    "native_server_adapter::decrement_line_item(native_request)",
-    "native decrement preservation",
-  ],
+  ["NativeClientErrorContext::decrement_line_item(", "native decrement context preservation"],
+  ["native_server_adapter::decrement_line_item(native_request)", "native decrement preservation"],
   ["NativeClientErrorContext::remove_line_item(", "native remove context preservation"],
   ["native_server_adapter::remove_line_item(native_request)", "native remove preservation"],
 ]) requireText(transport, value, label);
@@ -73,13 +71,22 @@ for (const [value, label] of [
 ]) requireText(adapter, value, label);
 
 for (const [value, label] of [
-  ["GraphqlHttpError::from_str", "typed GraphQL display reparse"],
+  ["pub(super) struct GraphqlCallContext", "private call context"],
   ["let ApiError::Graphql(raw_error) = error else", "GraphQL-only mapping"],
   ["return error;", "non-GraphQL pass-through"],
+  ["let raw_error_present = !raw_error.trim().is_empty();", "raw display presence fact"],
+  ["let raw_error_length = raw_error.chars().count();", "raw display length fact"],
+  ["GraphqlHttpError::from_str(raw_error.as_str())", "typed GraphQL display reparse"],
+  ["let parsed_error_valid = parsed_error.is_ok();", "typed parse validity fact"],
   ["GraphqlHttpError::Network", "network policy"],
   ["GraphqlHttpError::Http(_)", "HTTP policy"],
   ["GraphqlHttpError::Unauthorized", "unauthorized policy"],
   ["GraphqlHttpError::Graphql(_)", "GraphQL rejection policy"],
+  ['"network"', "closed network category"],
+  ['"http"', "closed HTTP category"],
+  ['"unauthorized"', "closed authentication category"],
+  ['"graphql"', "closed GraphQL category"],
+  ['"unknown"', "closed unknown category"],
   ["cart.storefront_graphql_network_unavailable", "network code"],
   ["cart.storefront_graphql_http_unavailable", "HTTP code"],
   ["cart.storefront_graphql_authentication_required", "authentication code"],
@@ -89,6 +96,9 @@ for (const [value, label] of [
   ["Cart authentication is required", "authentication public envelope"],
   ["Cart request could not be completed", "request public envelope"],
   ["Uuid::new_v4()", "unique correlation id"],
+  ["raw_error_present,", "bounded raw display presence diagnostics"],
+  ["raw_error_length,", "bounded raw display length diagnostics"],
+  ["parsed_error_valid,", "bounded typed parse diagnostics"],
   ["owner_operation = self.owner_operation", "owner operation diagnostics"],
   ["correlation_id = %self.correlation_id", "correlation diagnostics"],
   ["tenant_slug_length", "safe tenant fact"],
@@ -97,18 +107,29 @@ for (const [value, label] of [
   ["cart_id_length", "safe cart fact"],
   ["line_item_id_length", "safe line-item fact"],
   ["command_kind", "safe command fact"],
-  ["raw_error = %raw_error", "private raw cause diagnostics"],
+  ["error_kind,", "closed error category diagnostics"],
+  ["code,", "stable code diagnostics"],
   ["ApiError::Graphql(public_message.to_string())", "static public remap"],
 ]) requireText(safety, value, label);
 
 for (const forbidden of [
+  "raw_error = %raw_error",
+  "raw_error = ?raw_error",
+  "parsed_error = ?parsed_error",
+  "parsed_error = %parsed_error",
   "tenant_slug = %",
+  "tenant_slug = ?",
   "selected_cart_id = %",
+  "selected_cart_id = ?",
   "locale = %",
+  "locale = ?",
   "cart_id = %",
+  "cart_id = ?",
   "line_item_id = %",
+  "line_item_id = ?",
   "graphql_url =",
   "query = %",
+  "query = ?",
   "variables =",
   "token =",
 ]) forbidText(safety, forbidden, "safe GraphQL diagnostics");
@@ -140,10 +161,35 @@ for (const [key, expected] of Object.entries({
   raw_request_identifiers_logged: false,
   raw_tenant_slug_logged: false,
   raw_graphql_error_public: false,
+  raw_graphql_detail_logged: false,
+  parsed_graphql_error_debug_logged: false,
+  raw_graphql_detail_shape_logged: true,
+  typed_parse_validity_logged: true,
+  closed_graphql_error_category_logged: true,
   non_graphql_errors_pass_through: true,
+  broad_ecommerce_cleanup_closed: false,
 })) {
   if (evidence.source_contract?.[key] !== expected) {
     failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+for (const [key, expected] of Object.entries({
+  typed_graphql_variant_policy: true,
+  static_public_graphql_messages: true,
+  raw_graphql_detail_logging_removed: true,
+  parsed_graphql_error_debug_logging_removed: true,
+  bounded_graphql_error_shape_retained: true,
+  all_three_operations_preserved: true,
+  per_call_correlation_id: true,
+  safe_request_shape_only: true,
+  private_graphql_adapter_changed: false,
+  native_path_changed: false,
+  graphql_documents_changed: false,
+  transport_selection_changed: false,
+  runtime_evidence_claimed: false,
+})) {
+  if (review.implementation_review?.[key] !== expected) {
+    failures.push(`review implementation_review.${key} must be ${expected}`);
   }
 }
 for (const key of [
@@ -162,6 +208,19 @@ for (const key of [
     failures.push(`evidence validation.${key} must remain false`);
   }
 }
+for (const marker of [
+  "Status: source-unvalidated",
+  "Raw GraphQL display text is not written to the event.",
+  "Debug output from the parsed typed error is not written to the event.",
+  "raw-display presence and character length",
+  "The broad ecommerce correlation-safe mapper cleanup remains open.",
+  "No tests, verifiers, Cargo commands, formatting, workflows, or CI were run",
+]) requireText(doc, marker, `${files.doc}: truthful documentation`);
+requireText(
+  masterPlan,
+  "Finish correlation-safe mapper cleanup",
+  `${files.masterPlan}: broad mapper cleanup remains open`,
+);
 
 if (failures.length > 0) {
   console.error("Cart storefront GraphQL error-safety verification failed:");
@@ -170,5 +229,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "✔ cart storefront GraphQL failures use static public envelopes with correlation-aware private diagnostics; source evidence remains unvalidated",
+  "✔ cart storefront GraphQL failures retain bounded error/request shape and static public envelopes; source evidence remains unvalidated",
 );


### PR DESCRIPTION
## Summary

- continue the ecommerce correlation-safe mapper cleanup for the Cart storefront non-`PortError` GraphQL boundary
- preserve all three public operations, typed `GraphqlHttpError` classification, five stable codes, static public messages, severity, exact owner-operation attribution, per-call correlation, validation/non-GraphQL pass-through, bounded request shape, private GraphQL documents, native SSR policy, explicit transport selection, and no-fallback behavior
- stop writing the complete private GraphQL display handoff and Debug representation of the parsed typed error into structured events
- retain only raw-display presence/character length, typed-parse validity, a closed five-value category, stable code, correlation, and the existing bounded request shape
- update the focused fail-closed verifier, source/review evidence, and Cart documentation

## Recheck

The public Cart GraphQL envelopes were already static and safe, but `crates/rustok-cart/storefront/src/transport/graphql_error_safety.rs` still logged `raw_error = %raw_error` and `parsed_error = ?parsed_error`. The existing verifier and documentation explicitly required/described those complete internal payloads. This PR closes only that diagnostic-envelope gap.

## Deliberate boundary

The broad ecommerce mapper cleanup remains open. No Cargo dependency, request/response DTO, GraphQL document, adapter request construction, validation, quantity-command policy, native path, public transport variant, stable message/code, category severity, fallback policy, workflow, CI configuration, FFA/FBA status, or runtime-evidence status changes.

## Validation

Not run by request. No tests, Node verifiers, Cargo commands, formatting, workflows, CI, browser execution, or mounted runtime validation was executed.

Suggested maintainer commands:

```bash
node scripts/verify/verify-cart-storefront-graphql-error-safety.mjs
node scripts/verify/verify-cart-storefront-native-error-safety.mjs
node scripts/verify/verify-cart-storefront-boundary.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-cart-storefront
cargo check -p rustok-cart-storefront --features hydrate
cargo check -p rustok-cart-storefront --features ssr
```

Branch: `agent/cart-storefront-graphql-diagnostic-safety-20260801`
Base main: `1bd2286cef47fe79f9f53c5788ff0ba008124dfe`