### PR TITLE
feat(index): inspect reconciliation dead letters

### DIFF
--- a/crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md
+++ b/crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md
@@ -1,0 +1,53 @@
+# Reconciliation dead-letter inspection
+
+Status: `source_complete_owner_execution_pending`.
+
+## Purpose
+
+`PostgresIndexReconciliationDeadLetterInspector` provides a bounded, read-only view of one failed reconciliation job after dead-letter admission has blocked the tenant/schema scope.
+
+The adapter requires an exact non-nil tenant UUID and job UUID. Its query is restricted to `kind = 'reconcile'` and `state = 'failed'`, so cross-tenant, non-reconciliation, active, successful, cancelled, or unknown jobs return no inspection.
+
+## Returned contract
+
+The public inspection contains only:
+
+- job UUID;
+- positive durable attempt count;
+- optional bounded `last_error_code`;
+- bounded `dependency_code` from `index_reconciliation_run_failure_v1`;
+- retryable flag.
+
+Both machine codes are limited to 128 ASCII bytes and lowercase letters, digits, `.`, `_`, or `-`. Stored diagnostics must match the exact three-field failure contract; unknown fields, unsupported contract versions, invalid codes, zero/overflowing attempts, and malformed JSON fail closed.
+
+The query does not select or return tenant identifiers, schema request JSON, source cursors, worker IDs, lease fields, timestamps, mutation payloads, SQL, database causes, transport details, stack text, or arbitrary diagnostic values. Storage failures map to one stable error without embedding the database error.
+
+## Authorization boundary
+
+This Index adapter intentionally accepts no actor or permission object. It is not a public endpoint.
+
+Server, GraphQL, HTTP, CLI, and admin callers must bind the exact request tenant and actor, require a request-scoped effective `modules:manage` permission, and reject cross-tenant requests before calling the inspector. That server-owned authorization wrapper remains open and must reuse the guarded reconciliation operator boundary rather than expose the database adapter directly.
+
+## Compatibility
+
+The slice adds no migration and changes no reconciliation job state, lease, retry, cursor, source, mutation, schema, or admission behavior. It is read-only and can be deployed independently of manual requeue or retry-epoch reset.
+
+## Remaining work
+
+- server-owned authorized inspection composition and transport mapping;
+- actor/reason audit records;
+- manual requeue or retry-epoch reset under the reconciliation scope lock;
+- automatic retry/backoff/exhaustion and host scheduling;
+- digest comparison, orphan cleanup, targeted/full/shadow repair;
+- locale/partition checkpoint dimensions and complete drift-repair admission;
+- retained PostgreSQL execution evidence.
+
+## Suggested maintainer validation
+
+```bash
+cargo test -p rustok-index source_reconciliation_dead_letter_inspector -- --nocapture
+cargo check -p rustok-index --all-targets
+node scripts/verify/verify-index-reconciliation-dead-letter-inspection.mjs
+```
+
+The implementation agent did not run formatting, Cargo commands, JavaScript verifiers, PostgreSQL fixtures, or CI, per maintainer instruction.

--- a/crates/rustok-index/src/infrastructure/postgres/mod.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/mod.rs
@@ -7,6 +7,7 @@ mod schema_lease;
 mod schema_registration;
 mod secondary_index;
 mod source_factory;
+mod source_reconciliation_dead_letter_inspector;
 mod source_reconciliation_runner;
 mod source_replay;
 mod source_replay_job;
@@ -64,6 +65,10 @@ pub use source_factory::{
     PostgresIndexSourceFactory, PostgresIndexSourceFactoryCatalog,
     PostgresIndexSourceFactoryDescriptor, PostgresIndexSourceFactoryError,
     materialize_postgres_index_sources, register_postgres_index_source_factory,
+};
+pub use source_reconciliation_dead_letter_inspector::{
+    IndexReconciliationDeadLetterInspection, IndexReconciliationDeadLetterInspectionError,
+    PostgresIndexReconciliationDeadLetterInspector,
 };
 pub use source_reconciliation_runner::{
     IndexReconciliationCancelOutcome, IndexReconciliationRunError,

--- a/crates/rustok-index/src/infrastructure/postgres/source_reconciliation_dead_letter_inspector.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_reconciliation_dead_letter_inspector.rs
@@ -1,0 +1,323 @@
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DbBackend, QueryResult, Statement, Value as SqlValue,
+};
+use serde::Deserialize;
+use serde_json::Value as JsonValue;
+use thiserror::Error;
+use uuid::Uuid;
+
+const RECONCILIATION_FAILURE_CONTRACT: &str = "index_reconciliation_run_failure_v1";
+const MAX_ERROR_CODE_BYTES: usize = 128;
+
+/// A bounded, read-only view of one failed reconciliation job.
+///
+/// The inspection intentionally excludes the tenant, schema request, cursor, worker,
+/// lease, timestamps, and raw diagnostic JSON. Callers receive only stable machine
+/// fields that are safe to expose behind an operator authorization boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexReconciliationDeadLetterInspection {
+    job_id: Uuid,
+    attempt_count: u32,
+    error_code: Option<String>,
+    dependency_code: String,
+    retryable: bool,
+}
+
+impl IndexReconciliationDeadLetterInspection {
+    pub fn job_id(&self) -> Uuid {
+        self.job_id
+    }
+
+    pub fn attempt_count(&self) -> u32 {
+        self.attempt_count
+    }
+
+    pub fn error_code(&self) -> Option<&str> {
+        self.error_code.as_deref()
+    }
+
+    pub fn dependency_code(&self) -> &str {
+        &self.dependency_code
+    }
+
+    pub fn retryable(&self) -> bool {
+        self.retryable
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StoredReconciliationFailure {
+    contract: String,
+    dependency_code: String,
+    retryable: bool,
+}
+
+/// PostgreSQL-backed read-only dead-letter inspector.
+///
+/// Authorization is deliberately not accepted as data by this adapter. Server,
+/// GraphQL, HTTP, CLI, and admin callers must authorize the exact tenant and actor
+/// before invoking `inspect`.
+#[derive(Clone)]
+pub struct PostgresIndexReconciliationDeadLetterInspector {
+    db: DatabaseConnection,
+}
+
+impl PostgresIndexReconciliationDeadLetterInspector {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    pub async fn inspect(
+        &self,
+        tenant_id: Uuid,
+        job_id: Uuid,
+    ) -> Result<Option<IndexReconciliationDeadLetterInspection>, IndexReconciliationDeadLetterInspectionError>
+    {
+        if tenant_id.is_nil() {
+            return Err(IndexReconciliationDeadLetterInspectionError::NilTenantId);
+        }
+        if job_id.is_nil() {
+            return Err(IndexReconciliationDeadLetterInspectionError::NilJobId);
+        }
+
+        let backend = self.db.get_database_backend();
+        ensure_supported_backend(backend)?;
+        let row = self
+            .db
+            .query_one(Statement::from_sql_and_values(
+                backend,
+                select_failed_job_sql(backend),
+                vec![uuid_value(tenant_id, backend), uuid_value(job_id, backend)],
+            ))
+            .await
+            .map_err(|_| IndexReconciliationDeadLetterInspectionError::Storage)?;
+        row.map(|row| decode_failed_job(&row, job_id))
+            .transpose()
+    }
+}
+
+fn decode_failed_job(
+    row: &QueryResult,
+    job_id: Uuid,
+) -> Result<IndexReconciliationDeadLetterInspection, IndexReconciliationDeadLetterInspectionError> {
+    let attempt_count: i64 = row
+        .try_get("", "attempt_count_value")
+        .map_err(|_| IndexReconciliationDeadLetterInspectionError::Storage)?;
+    let attempt_count = u32::try_from(attempt_count).map_err(|_| {
+        IndexReconciliationDeadLetterInspectionError::InvalidStoredJob(
+            "attempt count is outside the u32 range",
+        )
+    })?;
+    if attempt_count == 0 {
+        return Err(IndexReconciliationDeadLetterInspectionError::InvalidStoredJob(
+            "attempt count must be positive",
+        ));
+    }
+
+    let error_code: Option<String> = row
+        .try_get("", "last_error_code")
+        .map_err(|_| IndexReconciliationDeadLetterInspectionError::Storage)?;
+    if let Some(code) = &error_code {
+        validate_machine_code(code).map_err(|_| {
+            IndexReconciliationDeadLetterInspectionError::InvalidStoredJob(
+                "last_error_code is outside the bounded machine-code contract",
+            )
+        })?;
+    }
+
+    let details: JsonValue = row
+        .try_get("", "last_error_details")
+        .map_err(|_| IndexReconciliationDeadLetterInspectionError::Storage)?;
+    let details: StoredReconciliationFailure = serde_json::from_value(details).map_err(|_| {
+        IndexReconciliationDeadLetterInspectionError::InvalidStoredJob(
+            "last_error_details does not match the reconciliation failure contract",
+        )
+    })?;
+    if details.contract != RECONCILIATION_FAILURE_CONTRACT {
+        return Err(IndexReconciliationDeadLetterInspectionError::InvalidStoredJob(
+            "last_error_details contract is unsupported",
+        ));
+    }
+    validate_machine_code(&details.dependency_code).map_err(|_| {
+        IndexReconciliationDeadLetterInspectionError::InvalidStoredJob(
+            "dependency_code is outside the bounded machine-code contract",
+        )
+    })?;
+
+    Ok(IndexReconciliationDeadLetterInspection {
+        job_id,
+        attempt_count,
+        error_code,
+        dependency_code: details.dependency_code,
+        retryable: details.retryable,
+    })
+}
+
+fn validate_machine_code(value: &str) -> Result<(), ()> {
+    if value.is_empty()
+        || value.len() > MAX_ERROR_CODE_BYTES
+        || value.trim() != value
+        || !value.bytes().all(|byte| {
+            byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || matches!(byte, b'.' | b'_' | b'-')
+        })
+    {
+        return Err(());
+    }
+    Ok(())
+}
+
+fn ensure_supported_backend(
+    backend: DbBackend,
+) -> Result<(), IndexReconciliationDeadLetterInspectionError> {
+    match backend {
+        DbBackend::Postgres => Ok(()),
+        DbBackend::Sqlite if cfg!(test) => Ok(()),
+        _ => Err(IndexReconciliationDeadLetterInspectionError::UnsupportedBackend),
+    }
+}
+
+fn placeholder_prefix(backend: DbBackend) -> &'static str {
+    match backend {
+        DbBackend::Postgres => "$",
+        DbBackend::Sqlite => "?",
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+fn uuid_value(value: Uuid, backend: DbBackend) -> SqlValue {
+    match backend {
+        DbBackend::Postgres => value.into(),
+        DbBackend::Sqlite => value.to_string().into(),
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+fn select_failed_job_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    let attempt_count = match backend {
+        DbBackend::Postgres => "CAST(attempt_count AS BIGINT)",
+        DbBackend::Sqlite => "CAST(attempt_count AS INTEGER)",
+        _ => unreachable!("unsupported database backend was validated"),
+    };
+    format!(
+        "SELECT {attempt_count} AS attempt_count_value, last_error_code, last_error_details FROM index_jobs WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'reconcile' AND state = 'failed' LIMIT 1"
+    )
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum IndexReconciliationDeadLetterInspectionError {
+    #[error("Index reconciliation dead-letter inspection tenant id must not be nil")]
+    NilTenantId,
+    #[error("Index reconciliation dead-letter inspection job id must not be nil")]
+    NilJobId,
+    #[error("stored Index reconciliation dead letter is invalid: {0}")]
+    InvalidStoredJob(&'static str),
+    #[error("Index reconciliation dead-letter inspection does not support this database backend")]
+    UnsupportedBackend,
+    #[error("Index reconciliation dead-letter inspection storage operation failed")]
+    Storage,
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{Database, DbBackend, Statement};
+    use serde_json::json;
+
+    use super::*;
+
+    async fn database() -> DatabaseConnection {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+        db.execute(Statement::from_string(
+            DbBackend::Sqlite,
+            "CREATE TABLE index_jobs (tenant_id TEXT NOT NULL, job_id TEXT NOT NULL, kind TEXT NOT NULL, state TEXT NOT NULL, attempt_count INTEGER NOT NULL, last_error_code TEXT NULL, last_error_details JSON NOT NULL)"
+                .to_owned(),
+        ))
+        .await
+        .expect("index_jobs fixture");
+        db
+    }
+
+    async fn insert_failed(
+        db: &DatabaseConnection,
+        tenant_id: Uuid,
+        job_id: Uuid,
+        details: JsonValue,
+    ) {
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO index_jobs (tenant_id, job_id, kind, state, attempt_count, last_error_code, last_error_details) VALUES (?1, ?2, 'reconcile', 'failed', 3, ?3, ?4)",
+            vec![
+                tenant_id.to_string().into(),
+                job_id.to_string().into(),
+                "index.reconciliation_page_failed".into(),
+                SqlValue::Json(Some(Box::new(details))),
+            ],
+        ))
+        .await
+        .expect("failed job fixture");
+    }
+
+    #[tokio::test]
+    async fn inspection_is_tenant_scoped_and_bounded() {
+        let db = database().await;
+        let tenant_id = Uuid::new_v4();
+        let job_id = Uuid::new_v4();
+        insert_failed(
+            &db,
+            tenant_id,
+            job_id,
+            json!({
+                "contract": RECONCILIATION_FAILURE_CONTRACT,
+                "dependency_code": "owner_source_retryable",
+                "retryable": true
+            }),
+        )
+        .await;
+        let inspector = PostgresIndexReconciliationDeadLetterInspector::new(db);
+
+        assert!(inspector.inspect(Uuid::new_v4(), job_id).await.unwrap().is_none());
+        let inspection = inspector
+            .inspect(tenant_id, job_id)
+            .await
+            .unwrap()
+            .expect("exact tenant failed job");
+        assert_eq!(inspection.job_id(), job_id);
+        assert_eq!(inspection.attempt_count(), 3);
+        assert_eq!(
+            inspection.error_code(),
+            Some("index.reconciliation_page_failed")
+        );
+        assert_eq!(inspection.dependency_code(), "owner_source_retryable");
+        assert!(inspection.retryable());
+    }
+
+    #[tokio::test]
+    async fn inspection_fails_closed_on_unbounded_diagnostic_shape() {
+        let db = database().await;
+        let tenant_id = Uuid::new_v4();
+        let job_id = Uuid::new_v4();
+        insert_failed(
+            &db,
+            tenant_id,
+            job_id,
+            json!({
+                "contract": RECONCILIATION_FAILURE_CONTRACT,
+                "dependency_code": "owner_source_permanent",
+                "retryable": false,
+                "private_detail": "must-not-pass"
+            }),
+        )
+        .await;
+        let inspector = PostgresIndexReconciliationDeadLetterInspector::new(db);
+
+        assert!(matches!(
+            inspector.inspect(tenant_id, job_id).await,
+            Err(IndexReconciliationDeadLetterInspectionError::InvalidStoredJob(_))
+        ));
+    }
+}

--- a/scripts/verify/verify-index-reconciliation-dead-letter-inspection.mjs
+++ b/scripts/verify/verify-index-reconciliation-dead-letter-inspection.mjs
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const files = {
+  inspector:
+    "crates/rustok-index/src/infrastructure/postgres/source_reconciliation_dead_letter_inspector.rs",
+  docs: "crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md",
+  postgres: "crates/rustok-index/src/infrastructure/postgres/mod.rs",
+};
+
+const read = (name) => {
+  const relative = files[name];
+  const absolute = path.join(root, relative);
+  if (!fs.existsSync(absolute)) {
+    throw new Error(`missing reconciliation dead-letter inspection file: ${relative}`);
+  }
+  return fs.readFileSync(absolute, "utf8");
+};
+
+const requireMarkers = (name, markers) => {
+  const content = read(name);
+  for (const marker of markers) {
+    if (!content.includes(marker)) {
+      throw new Error(`${files[name]} is missing required marker: ${marker}`);
+    }
+  }
+  return content;
+};
+
+const inspector = requireMarkers("inspector", [
+  "pub struct IndexReconciliationDeadLetterInspection",
+  "pub struct PostgresIndexReconciliationDeadLetterInspector",
+  "pub async fn inspect(",
+  "kind = 'reconcile' AND state = 'failed'",
+  "index_reconciliation_run_failure_v1",
+  "#[serde(deny_unknown_fields)]",
+  "validate_machine_code",
+  "IndexReconciliationDeadLetterInspectionError::Storage",
+  "inspection_is_tenant_scoped_and_bounded",
+  "inspection_fails_closed_on_unbounded_diagnostic_shape",
+]);
+
+for (const forbidden of [
+  "SELECT *",
+  "request, cursor",
+  "lease_owner",
+  "worker_id",
+  "completed_at",
+  "format!(\"Index reconciliation dead-letter inspection storage operation failed:",
+  "tokio::spawn",
+  "UPDATE index_jobs",
+  "DELETE FROM index_jobs",
+]) {
+  if (inspector.includes(forbidden)) {
+    throw new Error(`${files.inspector} contains forbidden marker: ${forbidden}`);
+  }
+}
+
+requireMarkers("docs", [
+  "Status: `source_complete_owner_execution_pending`",
+  "modules:manage",
+  "actor/reason audit records",
+  "manual requeue or retry-epoch reset",
+  "did not run",
+]);
+requireMarkers("postgres", [
+  "mod source_reconciliation_dead_letter_inspector;",
+  "IndexReconciliationDeadLetterInspection",
+  "IndexReconciliationDeadLetterInspectionError",
+  "PostgresIndexReconciliationDeadLetterInspector",
+]);
+
+console.log("Index reconciliation dead-letter inspection contract verified.");


### PR DESCRIPTION
## Superseded

Closed without merge. Rebuilt directly on fresh `main`, rechecked against merged replay retry/dead-letter storage, reconciliation failed-scope admission, and the guarded server reconciliation runtime, then merged as #2907.

Merged behavior:

- exact non-nil tenant/job inspection is restricted to `kind = 'reconcile'` and `state = 'failed'`;
- the read-only result exposes only job UUID, positive attempt count, optional bounded `last_error_code`, bounded dependency code, and retryability;
- raw `last_error_details` is strictly decoded through the exact deny-unknown-fields contract but never returned;
- malformed diagnostics, unknown fields, unsupported contracts, invalid codes, and invalid attempts fail closed;
- database failures map to one stable detail-free storage error;
- no insert, update, delete, retry, requeue, reset, polling, scheduling, task, or transport was added;
- PostgreSQL registration was rebuilt additively beside the merged reconciliation runner and replay retry store;
- the guarded server operator remains run/cancel only; authorized inspection composition is still open;
- documentation indexing and aggregate fail-closed verification were added.

The canonical M6 drift-diagnosis and targeted-repair roadmap item remains open.

Validation remained unrun per maintainer instruction.