### PR TITLE
test(forum): add topic move Search proof

### DIFF
--- a/apps/server/tests/forum_versioned_invalidation_topic_move.rs
+++ b/apps/server/tests/forum_versioned_invalidation_topic_move.rs
@@ -1,0 +1,1394 @@
+use std::collections::BTreeSet;
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::io::{Error as IoError, ErrorKind};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use rustok_api::{PortError, RequestContext};
+use rustok_core::{MigrationSource, SecurityContext, UserRole};
+use rustok_events::{
+    ContractEventEnvelope, ContractEventPayload, DomainEvent, EventEnvelope,
+    ForumSearchProjectionEvent,
+};
+use rustok_forum::{
+    CategoryService, CreateCategoryInput, CreateReplyInput, CreateTopicInput, ForumModule,
+    ForumSearchProjectionSourceFactory, ForumSearchResultCandidate,
+    ForumSearchResultCandidateKind, ForumSearchResultEligibilityService, ForumTopicMoveResult,
+    ForumTopicMoveService, MoveForumTopicInput, ReplyService, TopicService,
+};
+use rustok_outbox::{OutboxModule, OutboxTransport, TransactionalEventBus};
+use rustok_search::{
+    ForumProjectionReconciler, ForumSearchContractIngress,
+    ForumSearchContractIngressOutcome, ForumStorefrontSearchAttributeFilter,
+    ForumStorefrontSearchRequest, SearchModule, SearchProjectionSourceFactory,
+    SharedStorefrontSearchCategoryScopePort, SharedStorefrontSearchResultEligibilityPort,
+    StorefrontSearchCategoryScopePort, StorefrontSearchCategoryScopeRequest,
+    StorefrontSearchResultCandidate, StorefrontSearchResultCandidateKind,
+    StorefrontSearchResultEligibilityPort, StorefrontSearchResultEligibilityRequest,
+    StorefrontSearchTransport, execute_forum_storefront_search,
+};
+use rustok_taxonomy::TaxonomyModule;
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, QueryResult,
+    Statement,
+};
+use sea_orm_migration::SchemaManager;
+use serde::Serialize;
+use serde_json::{Value as JsonValue, json};
+use uuid::Uuid;
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+const SEARCH_TEST_DATABASE_ENV: &str = "RUSTOK_SEARCH_TEST_DATABASE_URL";
+const FORUM_TEST_DATABASE_ENV: &str = "RUSTOK_FORUM_TEST_DATABASE_URL";
+const ROOT_EVENT_TYPE: &str = "index.reindex_requested";
+const TYPED_EVENT_TYPE: &str = "forum.search_projection.invalidation_issued";
+const TOPIC_MARKER: &str = "d16topicmovemarker";
+const REPLY_MARKER: &str = "d16replymovemarker";
+const MOVE_REASON: &str = "Move the discussion to its canonical category";
+const EVIDENCE_CONTRACT: &str = "forum_search_link_forum_03_topic_move_evidence_v1";
+const EVIDENCE_PATH: &str = "target/forum-search-link-forum-03-topic-move-evidence.json";
+
+struct PostgresTopicMoveEvidence {
+    control: DatabaseConnection,
+    db: DatabaseConnection,
+    schema_name: String,
+}
+
+impl PostgresTopicMoveEvidence {
+    async fn setup(scope: &str) -> TestResult<Option<Self>> {
+        let Some(database_url) = postgres_database_url() else {
+            eprintln!(
+                "{SEARCH_TEST_DATABASE_ENV} is not set to a PostgreSQL URL; skipping Forum topic-move proof"
+            );
+            return Ok(None);
+        };
+
+        let control = connect(&database_url, 1).await?;
+        let schema_name = format!(
+            "rustok_forum_topic_move_{}_{}",
+            sanitize_identifier(scope),
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let db = connect_in_schema(&database_url, &schema_name, 10).await?;
+        let setup_result = async {
+            db.execute_unprepared(
+                r#"
+                CREATE TABLE users (
+                    id UUID NOT NULL PRIMARY KEY,
+                    tenant_id UUID NOT NULL
+                )
+                "#,
+            )
+            .await?;
+            let manager = SchemaManager::new(&db);
+            for migration in OutboxModule.migrations() {
+                migration.up(&manager).await?;
+            }
+            for migration in TaxonomyModule.migrations() {
+                migration.up(&manager).await?;
+            }
+            for migration in ForumModule.migrations() {
+                migration.up(&manager).await?;
+            }
+            for migration in SearchModule.migrations() {
+                migration.up(&manager).await?;
+            }
+            Ok::<(), sea_orm::DbErr>(())
+        }
+        .await;
+        if let Err(error) = setup_result {
+            let _ = control
+                .execute_unprepared(&format!(r#"DROP SCHEMA IF EXISTS "{schema_name}" CASCADE"#))
+                .await;
+            return Err(error.into());
+        }
+
+        Ok(Some(Self {
+            control,
+            db,
+            schema_name,
+        }))
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ForumFixture {
+    tenant_id: Uuid,
+    source_category_id: Uuid,
+    target_category_id: Uuid,
+    topic_id: Uuid,
+    reply_id: Uuid,
+    admin_id: Uuid,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct OwnerRevisionRow {
+    revision: i64,
+    event_id: Uuid,
+    target_type: String,
+    target_id: Option<Uuid>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct DeliveryIdentityFact {
+    owner_revision: i64,
+    root_event_id: Uuid,
+    typed_envelope_id: Uuid,
+    ingest_sequence: i64,
+    scope_key: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct InboxRow {
+    ingest_sequence: i64,
+    event_id: Uuid,
+    scope_key: String,
+    status: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct SearchDocumentRow {
+    document_id: Uuid,
+    entity_type: String,
+    locale: String,
+    status: String,
+    title: String,
+    body: String,
+    facets: JsonValue,
+    payload: JsonValue,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct MoveOwnerFact {
+    operation_id: Uuid,
+    topic_id: Uuid,
+    source_category_id: Uuid,
+    target_category_id: Uuid,
+    actor_id: Uuid,
+    reason: String,
+    published_reply_count: i32,
+    event_id: Uuid,
+    event_payload: JsonValue,
+}
+
+#[derive(Debug, Serialize)]
+struct ScenarioEvidence {
+    id: &'static str,
+    result: &'static str,
+    facts: JsonValue,
+}
+
+#[derive(Debug, Serialize)]
+struct TopicMoveEvidenceArtifact {
+    contract: &'static str,
+    task: &'static str,
+    source_commit: String,
+    generated_at: String,
+    database_backend: &'static str,
+    broker_used: bool,
+    scenario_results: Vec<ScenarioEvidence>,
+}
+
+#[derive(Clone)]
+struct ExactCategoryScopePort;
+
+#[async_trait]
+impl StorefrontSearchCategoryScopePort for ExactCategoryScopePort {
+    async fn expand_forum_category_scope(
+        &self,
+        request: StorefrontSearchCategoryScopeRequest,
+    ) -> Result<Vec<Uuid>, PortError> {
+        Ok(request.category_ids)
+    }
+}
+
+#[derive(Clone)]
+struct RealForumPublicEligibilityPort {
+    db: DatabaseConnection,
+}
+
+#[async_trait]
+impl StorefrontSearchResultEligibilityPort for RealForumPublicEligibilityPort {
+    async fn filter_forum_result_candidates(
+        &self,
+        request: StorefrontSearchResultEligibilityRequest,
+    ) -> Result<Vec<StorefrontSearchResultCandidate>, PortError> {
+        let candidates = request
+            .candidates
+            .iter()
+            .copied()
+            .map(to_forum_candidate)
+            .collect::<Vec<_>>();
+        let channel_slug = request
+            .request_context
+            .as_ref()
+            .and_then(|context| context.channel_slug.as_deref());
+        let allowed = ForumSearchResultEligibilityService::new(self.db.clone())
+            .filter_public_storefront_visible(request.tenant_id, channel_slug, &candidates)
+            .await
+            .map_err(|_| {
+                PortError::unavailable(
+                    "forum.search_projection.topic_move_owner_unavailable",
+                    "Forum Search result eligibility is temporarily unavailable",
+                )
+            })?;
+        Ok(allowed.into_iter().map(from_forum_candidate).collect())
+    }
+}
+
+fn to_forum_candidate(candidate: StorefrontSearchResultCandidate) -> ForumSearchResultCandidate {
+    ForumSearchResultCandidate {
+        document_id: candidate.document_id,
+        kind: match candidate.kind {
+            StorefrontSearchResultCandidateKind::ForumTopic => {
+                ForumSearchResultCandidateKind::Topic
+            }
+            StorefrontSearchResultCandidateKind::ForumReply => {
+                ForumSearchResultCandidateKind::Reply
+            }
+        },
+    }
+}
+
+fn from_forum_candidate(candidate: ForumSearchResultCandidate) -> StorefrontSearchResultCandidate {
+    StorefrontSearchResultCandidate {
+        document_id: candidate.document_id,
+        kind: match candidate.kind {
+            ForumSearchResultCandidateKind::Topic => {
+                StorefrontSearchResultCandidateKind::ForumTopic
+            }
+            ForumSearchResultCandidateKind::Reply => {
+                StorefrontSearchResultCandidateKind::ForumReply
+            }
+        },
+    }
+}
+
+#[tokio::test]
+async fn topic_move_reassigns_search_category_scope_without_identity_drift() -> TestResult<()> {
+    let Some(evidence) = PostgresTopicMoveEvidence::setup("link").await? else {
+        return Ok(());
+    };
+
+    let proof = run_topic_move_proof(&evidence.db).await;
+    let cleanup = evidence.cleanup().await;
+    let scenario = proof?;
+    cleanup?;
+
+    write_evidence(TopicMoveEvidenceArtifact {
+        contract: EVIDENCE_CONTRACT,
+        task: "FORUM-23B2G2B3D16",
+        source_commit: source_commit()?,
+        generated_at: Utc::now().to_rfc3339(),
+        database_backend: "postgresql",
+        broker_used: false,
+        scenario_results: vec![scenario],
+    })?;
+    Ok(())
+}
+
+async fn run_topic_move_proof(db: &DatabaseConnection) -> TestResult<ScenarioEvidence> {
+    let fixture = create_forum_fixture(db).await?;
+    let projection_source = ForumSearchProjectionSourceFactory.build(db.clone());
+    let reconciler = ForumProjectionReconciler::new(db.clone(), projection_source);
+
+    let baseline_revisions = load_owner_revisions_after(db, fixture.tenant_id, 0).await?;
+    ensure_revision_shape(
+        &baseline_revisions,
+        1,
+        &[
+            ("forum", None),
+            ("forum", None),
+            ("forum_category", Some(fixture.source_category_id)),
+            ("forum_category", Some(fixture.source_category_id)),
+        ],
+        "baseline",
+    )?;
+    let baseline_deliveries = ingest_exact_typed_revisions(db, fixture, &baseline_revisions).await?;
+    let baseline_report = reconciler.sweep_due(1, 16).await?;
+    if baseline_report.claimed_events != 4
+        || baseline_report.completed_events != 4
+        || baseline_report.failed_events != 0
+    {
+        return Err(test_error(format!(
+            "D16 baseline Forum projection did not complete exactly four events: {baseline_report:?}"
+        )));
+    }
+
+    let baseline_documents = load_forum_documents(db, fixture.tenant_id).await?;
+    ensure_document_scope(&baseline_documents, fixture, fixture.source_category_id, 1, 1)?;
+    assert_storefront_exact(
+        db,
+        fixture,
+        fixture.source_category_id,
+        TOPIC_MARKER,
+        "forum_topic",
+        "open",
+        fixture.topic_id,
+        1,
+    )
+    .await?;
+    assert_storefront_exact(
+        db,
+        fixture,
+        fixture.target_category_id,
+        TOPIC_MARKER,
+        "forum_topic",
+        "open",
+        fixture.topic_id,
+        0,
+    )
+    .await?;
+    assert_storefront_exact(
+        db,
+        fixture,
+        fixture.source_category_id,
+        REPLY_MARKER,
+        "forum_reply",
+        "approved",
+        fixture.reply_id,
+        1,
+    )
+    .await?;
+    assert_storefront_exact(
+        db,
+        fixture,
+        fixture.target_category_id,
+        REPLY_MARKER,
+        "forum_reply",
+        "approved",
+        fixture.reply_id,
+        0,
+    )
+    .await?;
+
+    let operation_id = Uuid::new_v4();
+    let input = MoveForumTopicInput {
+        operation_id,
+        target_category_id: fixture.target_category_id,
+        reason: MOVE_REASON.to_string(),
+    };
+    let bus = event_bus(db.clone());
+    let move_service = ForumTopicMoveService::new(db.clone(), bus);
+    let moved = move_service
+        .move_topic(
+            fixture.tenant_id,
+            fixture.topic_id,
+            admin_security(fixture.admin_id),
+            input.clone(),
+        )
+        .await?;
+    ensure_move_result(moved.clone(), fixture, operation_id)?;
+    let move_owner_fact = load_move_owner_fact(db, fixture, operation_id).await?;
+
+    let move_revisions = load_owner_revisions_after(db, fixture.tenant_id, 4).await?;
+    ensure_revision_shape(
+        &move_revisions,
+        5,
+        &[
+            ("forum_topic", Some(fixture.topic_id)),
+            ("forum_category", Some(fixture.source_category_id)),
+            ("forum_category", Some(fixture.target_category_id)),
+        ],
+        "move",
+    )?;
+    let move_deliveries = ingest_exact_typed_revisions(db, fixture, &move_revisions).await?;
+    let move_report = reconciler.sweep_due(1, 16).await?;
+    if move_report.claimed_events != 3
+        || move_report.completed_events != 3
+        || move_report.failed_events != 0
+    {
+        return Err(test_error(format!(
+            "D16 move projection did not complete exactly three events: {move_report:?}"
+        )));
+    }
+
+    let moved_documents = load_forum_documents(db, fixture.tenant_id).await?;
+    ensure_document_scope(&moved_documents, fixture, fixture.target_category_id, 0, 0)?;
+    assert_storefront_exact(
+        db,
+        fixture,
+        fixture.source_category_id,
+        TOPIC_MARKER,
+        "forum_topic",
+        "open",
+        fixture.topic_id,
+        0,
+    )
+    .await?;
+    assert_storefront_exact(
+        db,
+        fixture,
+        fixture.target_category_id,
+        TOPIC_MARKER,
+        "forum_topic",
+        "open",
+        fixture.topic_id,
+        1,
+    )
+    .await?;
+    assert_storefront_exact(
+        db,
+        fixture,
+        fixture.source_category_id,
+        REPLY_MARKER,
+        "forum_reply",
+        "approved",
+        fixture.reply_id,
+        0,
+    )
+    .await?;
+    assert_storefront_exact(
+        db,
+        fixture,
+        fixture.target_category_id,
+        REPLY_MARKER,
+        "forum_reply",
+        "approved",
+        fixture.reply_id,
+        1,
+    )
+    .await?;
+
+    let roots_before_replay = load_root_event_ids(db, fixture.tenant_id).await?;
+    let typed_before_replay = load_typed_event_ids(db, fixture.tenant_id).await?;
+    let max_ingest_before_replay = max_ingest_sequence(db).await?;
+    let replay = move_service
+        .move_topic(
+            fixture.tenant_id,
+            fixture.topic_id,
+            admin_security(fixture.admin_id),
+            input,
+        )
+        .await?;
+    if replay != moved {
+        return Err(test_error(format!(
+            "D16 exact replay did not return the original move result: first={moved:?}, replay={replay:?}"
+        )));
+    }
+    if !load_owner_revisions_after(db, fixture.tenant_id, 7)
+        .await?
+        .is_empty()
+        || load_root_event_ids(db, fixture.tenant_id).await? != roots_before_replay
+        || load_typed_event_ids(db, fixture.tenant_id).await? != typed_before_replay
+        || max_ingest_sequence(db).await? != max_ingest_before_replay
+        || count_move_receipts(db, fixture.tenant_id, operation_id).await? != 1
+        || count_move_semantic_events(db, fixture.tenant_id, operation_id).await? != 1
+    {
+        return Err(test_error(
+            "D16 exact replay created duplicate owner, transport, inbox or semantic state",
+        ));
+    }
+
+    let all_revisions = load_owner_revisions_after(db, fixture.tenant_id, 0).await?;
+    if all_revisions.len() != 7
+        || all_revisions
+            .windows(2)
+            .any(|pair| pair[1].revision != pair[0].revision + 1)
+    {
+        return Err(test_error(format!(
+            "D16 owner revisions are not exactly contiguous 1 through 7: {all_revisions:?}"
+        )));
+    }
+    let revision_ids = all_revisions
+        .iter()
+        .map(|revision| revision.event_id)
+        .collect::<BTreeSet<_>>();
+    if roots_before_replay != revision_ids {
+        return Err(test_error(format!(
+            "D16 ledger/root identities diverged: revisions={revision_ids:?}, roots={roots_before_replay:?}"
+        )));
+    }
+    for revision in &all_revisions {
+        if count_inbox_rows(db, revision.event_id).await? != 1 {
+            return Err(test_error(format!(
+                "D16 root {} did not retain exactly one Search inbox row",
+                revision.event_id
+            )));
+        }
+    }
+
+    let caught_up = reconciler.sweep_due(1, 16).await?;
+    if caught_up.claimed_events != 0
+        || caught_up.completed_events != 0
+        || caught_up.failed_events != 0
+    {
+        return Err(test_error(format!(
+            "caught-up D16 repeat performed duplicate work: {caught_up:?}"
+        )));
+    }
+
+    Ok(ScenarioEvidence {
+        id: "topic_move_category_scope",
+        result: "passed",
+        facts: json!({
+            "tenant_id": fixture.tenant_id,
+            "source_category_id": fixture.source_category_id,
+            "target_category_id": fixture.target_category_id,
+            "topic_id": fixture.topic_id,
+            "reply_id": fixture.reply_id,
+            "move_owner_fact": move_owner_fact,
+            "owner_revision_rows": all_revisions,
+            "baseline_deliveries": baseline_deliveries,
+            "move_deliveries": move_deliveries,
+            "baseline_documents": baseline_documents,
+            "moved_documents": moved_documents,
+            "topic_identity_retained": true,
+            "reply_identity_retained": true,
+            "source_category_scope_empty_after_move": true,
+            "target_category_scope_contains_topic_and_reply_after_move": true,
+            "exact_replay_created_new_owner_revision": false,
+            "exact_replay_created_new_transport_event": false,
+            "exact_replay_created_new_inbox_row": false,
+            "owner_revision_compared_to_ingest_sequence": false,
+            "caught_up_repeat_performed_work": false
+        }),
+    })
+}
+
+async fn create_forum_fixture(db: &DatabaseConnection) -> TestResult<ForumFixture> {
+    let tenant_id = Uuid::new_v4();
+    let admin_id = Uuid::new_v4();
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "INSERT INTO users (id, tenant_id) VALUES ($1, $2)",
+        vec![admin_id.into(), tenant_id.into()],
+    ))
+    .await?;
+
+    let admin = admin_security(admin_id);
+    let source = CategoryService::new(db.clone())
+        .create(
+            tenant_id,
+            admin.clone(),
+            CreateCategoryInput {
+                locale: "en".to_string(),
+                name: "D16 source category".to_string(),
+                slug: "d16-source-category".to_string(),
+                description: Some("D16 topic move source".to_string()),
+                icon: None,
+                color: None,
+                parent_id: None,
+                position: Some(0),
+                moderated: false,
+            },
+        )
+        .await?;
+    let target = CategoryService::new(db.clone())
+        .create(
+            tenant_id,
+            admin.clone(),
+            CreateCategoryInput {
+                locale: "en".to_string(),
+                name: "D16 target category".to_string(),
+                slug: "d16-target-category".to_string(),
+                description: Some("D16 topic move target".to_string()),
+                icon: None,
+                color: None,
+                parent_id: None,
+                position: Some(1),
+                moderated: false,
+            },
+        )
+        .await?;
+    let bus = event_bus(db.clone());
+    let topic = TopicService::new(db.clone(), bus.clone())
+        .create(
+            tenant_id,
+            admin.clone(),
+            CreateTopicInput {
+                locale: "en".to_string(),
+                category_id: source.id,
+                title: format!("D16 topic {TOPIC_MARKER}"),
+                slug: Some("d16-topic-move".to_string()),
+                body: format!("D16 topic body {TOPIC_MARKER}"),
+                body_format: "markdown".to_string(),
+                content_json: None,
+                metadata: json!({}),
+                tags: Vec::new(),
+                channel_slugs: None,
+            },
+        )
+        .await?;
+    let reply = ReplyService::new(db.clone(), bus)
+        .create(
+            tenant_id,
+            admin,
+            topic.id,
+            CreateReplyInput {
+                locale: "en".to_string(),
+                content: format!("D16 approved reply {REPLY_MARKER}"),
+                content_format: "markdown".to_string(),
+                content_json: None,
+                parent_reply_id: None,
+            },
+        )
+        .await?;
+    if reply.status != "approved" {
+        return Err(test_error(format!(
+            "D16 unmoderated category produced reply status `{}` instead of approved",
+            reply.status
+        )));
+    }
+
+    Ok(ForumFixture {
+        tenant_id,
+        source_category_id: source.id,
+        target_category_id: target.id,
+        topic_id: topic.id,
+        reply_id: reply.id,
+        admin_id,
+    })
+}
+
+fn ensure_move_result(
+    moved: ForumTopicMoveResult,
+    fixture: ForumFixture,
+    operation_id: Uuid,
+) -> TestResult<()> {
+    if moved.operation_id != operation_id
+        || moved.event_id != operation_id
+        || moved.topic_id != fixture.topic_id
+        || moved.source_category_id != fixture.source_category_id
+        || moved.target_category_id != fixture.target_category_id
+        || moved.actor_id != fixture.admin_id
+        || moved.reason != MOVE_REASON
+        || moved.published_reply_count != 1
+    {
+        return Err(test_error(format!(
+            "D16 owner move result drifted: {moved:?}"
+        )));
+    }
+    Ok(())
+}
+
+async fn load_move_owner_fact(
+    db: &DatabaseConnection,
+    fixture: ForumFixture,
+    operation_id: Uuid,
+) -> TestResult<MoveOwnerFact> {
+    let receipt = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+            SELECT operation_id, topic_id, source_category_id, target_category_id,
+                   actor_id, reason, published_reply_count, event_id
+            FROM forum_topic_move_operations
+            WHERE tenant_id = $1 AND operation_id = $2
+            "#,
+            vec![fixture.tenant_id.into(), operation_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| test_error("D16 topic move receipt was not found"))?;
+    let journal = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+            SELECT event_id, aggregate_type, aggregate_id, event_type,
+                   schema_version, actor_id, payload
+            FROM forum_domain_events
+            WHERE tenant_id = $1 AND event_id = $2
+            "#,
+            vec![fixture.tenant_id.into(), operation_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| test_error("D16 topic move semantic event was not found"))?;
+
+    let event_id: Uuid = journal.try_get("", "event_id")?;
+    let aggregate_type: String = journal.try_get("", "aggregate_type")?;
+    let aggregate_id: Uuid = journal.try_get("", "aggregate_id")?;
+    let event_type: String = journal.try_get("", "event_type")?;
+    let schema_version: i16 = journal.try_get("", "schema_version")?;
+    let event_actor_id: Option<Uuid> = journal.try_get("", "actor_id")?;
+    let event_payload: JsonValue = journal.try_get("", "payload")?;
+    if event_id != operation_id
+        || aggregate_type != "forum_topic"
+        || aggregate_id != fixture.topic_id
+        || event_type != "forum.topic.moved"
+        || schema_version != 1
+        || event_actor_id != Some(fixture.admin_id)
+        || event_payload["operation_id"] != operation_id.to_string()
+        || event_payload["topic_id"] != fixture.topic_id.to_string()
+        || event_payload["source_category_id"] != fixture.source_category_id.to_string()
+        || event_payload["target_category_id"] != fixture.target_category_id.to_string()
+        || event_payload["published_reply_count"] != 1
+        || event_payload["reason"] != MOVE_REASON
+    {
+        return Err(test_error(format!(
+            "D16 topic move semantic event drifted: {event_payload:?}"
+        )));
+    }
+
+    let fact = MoveOwnerFact {
+        operation_id: receipt.try_get("", "operation_id")?,
+        topic_id: receipt.try_get("", "topic_id")?,
+        source_category_id: receipt.try_get("", "source_category_id")?,
+        target_category_id: receipt.try_get("", "target_category_id")?,
+        actor_id: receipt.try_get("", "actor_id")?,
+        reason: receipt.try_get("", "reason")?,
+        published_reply_count: receipt.try_get("", "published_reply_count")?,
+        event_id: receipt.try_get("", "event_id")?,
+        event_payload,
+    };
+    if fact.operation_id != operation_id
+        || fact.event_id != operation_id
+        || fact.topic_id != fixture.topic_id
+        || fact.source_category_id != fixture.source_category_id
+        || fact.target_category_id != fixture.target_category_id
+        || fact.actor_id != fixture.admin_id
+        || fact.reason != MOVE_REASON
+        || fact.published_reply_count != 1
+    {
+        return Err(test_error(format!(
+            "D16 immutable topic move receipt drifted: {fact:?}"
+        )));
+    }
+    Ok(fact)
+}
+
+async fn ingest_exact_typed_revisions(
+    db: &DatabaseConnection,
+    fixture: ForumFixture,
+    revisions: &[OwnerRevisionRow],
+) -> TestResult<Vec<DeliveryIdentityFact>> {
+    let mut facts = Vec::with_capacity(revisions.len());
+    for revision in revisions {
+        let root = load_root_envelope(db, fixture.tenant_id, revision.event_id).await?;
+        root.validate_registered_schema()?;
+        if root.causation_id.is_some()
+            || !matches!(
+                &root.event,
+                DomainEvent::ReindexRequested {
+                    target_type,
+                    target_id,
+                } if target_type == &revision.target_type && *target_id == revision.target_id
+            )
+        {
+            return Err(test_error(format!(
+                "D16 root envelope does not match owner revision: root={root:?}, revision={revision:?}"
+            )));
+        }
+        let typed = load_typed_envelope(db, fixture.tenant_id, revision.event_id).await?;
+        typed.validate_registered_schema()?;
+        if typed.id() == revision.event_id
+            || typed.causation_id() != Some(revision.event_id)
+            || typed.event_type() != TYPED_EVENT_TYPE
+            || typed.schema_version() != 1
+        {
+            return Err(test_error(format!(
+                "D16 typed envelope lost transport/root identity: {typed:?}"
+            )));
+        }
+        match typed.payload()? {
+            ContractEventPayload::ForumSearchProjection(
+                ForumSearchProjectionEvent::InvalidationIssued {
+                    owner_revision,
+                    target_type,
+                    target_id,
+                },
+            ) if *owner_revision == revision.revision
+                && target_type == &revision.target_type
+                && *target_id == revision.target_id => {}
+            payload => {
+                return Err(test_error(format!(
+                    "D16 typed payload does not match owner revision: {payload:?}"
+                )));
+            }
+        }
+        match ForumSearchContractIngress::new(db.clone())
+            .ingest(&typed)
+            .await?
+        {
+            ForumSearchContractIngressOutcome::DurablyAccepted {
+                root_event_id,
+                owner_revision,
+            } if root_event_id == revision.event_id && owner_revision == revision.revision => {}
+            outcome => {
+                return Err(test_error(format!(
+                    "D16 typed ingress returned unexpected outcome: {outcome:?}"
+                )));
+            }
+        }
+        let inbox = load_inbox_row(db, revision.event_id).await?;
+        if inbox.status != "pending" || inbox.ingest_sequence <= 0 {
+            return Err(test_error(format!(
+                "D16 typed ingress did not create a pending durable inbox row: {inbox:?}"
+            )));
+        }
+        facts.push(DeliveryIdentityFact {
+            owner_revision: revision.revision,
+            root_event_id: revision.event_id,
+            typed_envelope_id: typed.id(),
+            ingest_sequence: inbox.ingest_sequence,
+            scope_key: inbox.scope_key,
+        });
+    }
+    if facts
+        .windows(2)
+        .any(|pair| pair[1].ingest_sequence <= pair[0].ingest_sequence)
+    {
+        return Err(test_error(format!(
+            "D16 typed inbox sequences did not increase within phase: {facts:?}"
+        )));
+    }
+    Ok(facts)
+}
+
+fn ensure_revision_shape(
+    revisions: &[OwnerRevisionRow],
+    first_revision: i64,
+    expected: &[(&str, Option<Uuid>)],
+    phase: &str,
+) -> TestResult<()> {
+    if revisions.len() != expected.len() {
+        return Err(test_error(format!(
+            "D16 {phase} expected {} owner revisions, received {revisions:?}",
+            expected.len()
+        )));
+    }
+    for (index, (actual, (target_type, target_id))) in
+        revisions.iter().zip(expected.iter()).enumerate()
+    {
+        if actual.revision != first_revision + index as i64
+            || actual.target_type != *target_type
+            || actual.target_id != *target_id
+        {
+            return Err(test_error(format!(
+                "D16 {phase} owner revision shape drifted: {revisions:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+async fn load_owner_revisions_after(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    after_revision: i64,
+) -> TestResult<Vec<OwnerRevisionRow>> {
+    db.query_all(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+        SELECT revision, event_id, target_type, target_id
+        FROM forum_projection_revision_ledger
+        WHERE tenant_id = $1 AND revision > $2
+        ORDER BY revision ASC
+        "#,
+        vec![tenant_id.into(), after_revision.into()],
+    ))
+    .await?
+    .into_iter()
+    .map(|row| {
+        Ok(OwnerRevisionRow {
+            revision: row.try_get("", "revision")?,
+            event_id: row.try_get("", "event_id")?,
+            target_type: row.try_get("", "target_type")?,
+            target_id: row.try_get("", "target_id")?,
+        })
+    })
+    .collect::<Result<Vec<_>, sea_orm::DbErr>>()
+    .map_err(Into::into)
+}
+
+async fn load_root_envelope(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    event_id: Uuid,
+) -> TestResult<EventEnvelope> {
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT payload FROM sys_events WHERE event_type = $1 ORDER BY created_at ASC",
+            vec![ROOT_EVENT_TYPE.to_string().into()],
+        ))
+        .await?;
+    let mut matches = Vec::new();
+    for row in rows {
+        let payload: JsonValue = row.try_get("", "payload")?;
+        let envelope: EventEnvelope = serde_json::from_value(payload)?;
+        if envelope.tenant_id == tenant_id && envelope.id == event_id {
+            matches.push(envelope);
+        }
+    }
+    if matches.len() != 1 {
+        return Err(test_error(format!(
+            "expected one D16 root envelope {event_id}, found {}",
+            matches.len()
+        )));
+    }
+    Ok(matches.remove(0))
+}
+
+async fn load_typed_envelope(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    root_event_id: Uuid,
+) -> TestResult<ContractEventEnvelope> {
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT payload FROM sys_events WHERE event_type = $1 ORDER BY created_at ASC",
+            vec![TYPED_EVENT_TYPE.to_string().into()],
+        ))
+        .await?;
+    let mut matches = Vec::new();
+    for row in rows {
+        let payload: JsonValue = row.try_get("", "payload")?;
+        let envelope: ContractEventEnvelope = serde_json::from_value(payload)?;
+        if envelope.tenant_id() == tenant_id && envelope.causation_id() == Some(root_event_id) {
+            matches.push(envelope);
+        }
+    }
+    if matches.len() != 1 {
+        return Err(test_error(format!(
+            "expected one D16 typed envelope caused by {root_event_id}, found {}",
+            matches.len()
+        )));
+    }
+    Ok(matches.remove(0))
+}
+
+async fn load_root_event_ids(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+) -> TestResult<BTreeSet<Uuid>> {
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT payload FROM sys_events WHERE event_type = $1 ORDER BY created_at ASC",
+            vec![ROOT_EVENT_TYPE.to_string().into()],
+        ))
+        .await?;
+    let mut ids = BTreeSet::new();
+    for row in rows {
+        let payload: JsonValue = row.try_get("", "payload")?;
+        let envelope: EventEnvelope = serde_json::from_value(payload)?;
+        if envelope.tenant_id == tenant_id {
+            ids.insert(envelope.id);
+        }
+    }
+    Ok(ids)
+}
+
+async fn load_typed_event_ids(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+) -> TestResult<BTreeSet<Uuid>> {
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT payload FROM sys_events WHERE event_type = $1 ORDER BY created_at ASC",
+            vec![TYPED_EVENT_TYPE.to_string().into()],
+        ))
+        .await?;
+    let mut ids = BTreeSet::new();
+    for row in rows {
+        let payload: JsonValue = row.try_get("", "payload")?;
+        let envelope: ContractEventEnvelope = serde_json::from_value(payload)?;
+        if envelope.tenant_id() == tenant_id {
+            ids.insert(envelope.id());
+        }
+    }
+    Ok(ids)
+}
+
+async fn load_inbox_row(db: &DatabaseConnection, event_id: Uuid) -> TestResult<InboxRow> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+            SELECT ingest_sequence, event_id, scope_key, status
+            FROM search_projection_inbox
+            WHERE event_id = $1
+            "#,
+            vec![event_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| test_error(format!("D16 Search inbox row {event_id} was not found")))?;
+    Ok(InboxRow {
+        ingest_sequence: row.try_get("", "ingest_sequence")?,
+        event_id: row.try_get("", "event_id")?,
+        scope_key: row.try_get("", "scope_key")?,
+        status: row.try_get("", "status")?,
+    })
+}
+
+async fn load_forum_documents(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+) -> TestResult<Vec<SearchDocumentRow>> {
+    db.query_all(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+        SELECT document_id, entity_type, locale, status, title, body, facets, payload
+        FROM search_documents
+        WHERE tenant_id = $1 AND source_module = 'forum'
+        ORDER BY entity_type ASC, document_id ASC, locale ASC
+        "#,
+        vec![tenant_id.into()],
+    ))
+    .await?
+    .into_iter()
+    .map(|row| {
+        Ok(SearchDocumentRow {
+            document_id: row.try_get("", "document_id")?,
+            entity_type: row.try_get("", "entity_type")?,
+            locale: row.try_get("", "locale")?,
+            status: row.try_get("", "status")?,
+            title: row.try_get("", "title")?,
+            body: row.try_get("", "body")?,
+            facets: row.try_get("", "facets")?,
+            payload: row.try_get("", "payload")?,
+        })
+    })
+    .collect::<Result<Vec<_>, sea_orm::DbErr>>()
+    .map_err(Into::into)
+}
+
+fn ensure_document_scope(
+    documents: &[SearchDocumentRow],
+    fixture: ForumFixture,
+    expected_category_id: Uuid,
+    expected_source_topics: i64,
+    expected_source_replies: i64,
+) -> TestResult<()> {
+    if documents.len() != 4 {
+        return Err(test_error(format!(
+            "D16 projected {} documents instead of four: {documents:?}",
+            documents.len()
+        )));
+    }
+    let source = find_document(
+        documents,
+        fixture.source_category_id,
+        "forum_category",
+        "en",
+    )?;
+    let target = find_document(
+        documents,
+        fixture.target_category_id,
+        "forum_category",
+        "en",
+    )?;
+    let topic = find_document(documents, fixture.topic_id, "forum_topic", "en")?;
+    let reply = find_document(documents, fixture.reply_id, "forum_reply", "en")?;
+
+    let expected_target_topics = 1 - expected_source_topics;
+    let expected_target_replies = 1 - expected_source_replies;
+    if source.payload["topic_count"].as_i64() != Some(expected_source_topics)
+        || source.payload["reply_count"].as_i64() != Some(expected_source_replies)
+        || target.payload["topic_count"].as_i64() != Some(expected_target_topics)
+        || target.payload["reply_count"].as_i64() != Some(expected_target_replies)
+        || topic.status != "open"
+        || reply.status != "approved"
+        || !topic.title.contains(TOPIC_MARKER)
+        || !topic.body.contains(TOPIC_MARKER)
+        || !reply.body.contains(REPLY_MARKER)
+        || document_category_id(topic)? != expected_category_id
+        || document_category_id(reply)? != expected_category_id
+        || topic.payload["category_id"] != expected_category_id.to_string()
+        || reply.payload["category_id"] != expected_category_id.to_string()
+        || reply.payload["topic_id"] != fixture.topic_id.to_string()
+    {
+        return Err(test_error(format!(
+            "D16 Search document category scope drifted: {documents:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn document_category_id(document: &SearchDocumentRow) -> TestResult<Uuid> {
+    document
+        .facets
+        .get("category_id")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| test_error("D16 Forum document facet has no category_id"))?
+        .parse()
+        .map_err(Into::into)
+}
+
+fn find_document<'a>(
+    documents: &'a [SearchDocumentRow],
+    document_id: Uuid,
+    entity_type: &str,
+    locale: &str,
+) -> TestResult<&'a SearchDocumentRow> {
+    let matches = documents
+        .iter()
+        .filter(|document| {
+            document.document_id == document_id
+                && document.entity_type == entity_type
+                && document.locale == locale
+        })
+        .collect::<Vec<_>>();
+    if matches.len() != 1 {
+        return Err(test_error(format!(
+            "D16 expected one {entity_type}:{document_id}:{locale}, found {}",
+            matches.len()
+        )));
+    }
+    Ok(matches[0])
+}
+
+async fn assert_storefront_exact(
+    db: &DatabaseConnection,
+    fixture: ForumFixture,
+    category_id: Uuid,
+    marker: &str,
+    entity_type: &str,
+    status: &str,
+    expected_id: Uuid,
+    expected_total: u64,
+) -> TestResult<()> {
+    let category_scope: SharedStorefrontSearchCategoryScopePort = Arc::new(ExactCategoryScopePort);
+    let eligibility: SharedStorefrontSearchResultEligibilityPort =
+        Arc::new(RealForumPublicEligibilityPort { db: db.clone() });
+    let execution = execute_forum_storefront_search(
+        db,
+        Some(category_scope),
+        Some(eligibility),
+        ForumStorefrontSearchRequest {
+            tenant_id: fixture.tenant_id,
+            query: marker.to_string(),
+            locale: Some("en".to_string()),
+            fallback_locale: "en".to_string(),
+            channel_id: None,
+            current_channel_only: None,
+            limit: Some(10),
+            offset: Some(0),
+            ranking_profile: None,
+            preset_key: None,
+            entity_types: vec![entity_type.to_string()],
+            source_modules: vec!["forum".to_string()],
+            statuses: vec![status.to_string()],
+            category_ids: vec![category_id.to_string()],
+            author_ids: Vec::new(),
+            tags: Vec::new(),
+            solved: None,
+            published_from: None,
+            published_to: None,
+            attribute_filters: Vec::<ForumStorefrontSearchAttributeFilter>::new(),
+            sort_attribute_code: None,
+            sort_desc: false,
+            auth: None,
+            request_context: Some(RequestContext {
+                tenant_id: fixture.tenant_id,
+                user_id: None,
+                channel_id: None,
+                channel_slug: None,
+                channel_resolution_source: None,
+                locale: "en".to_string(),
+            }),
+            transport: StorefrontSearchTransport::Graphql,
+        },
+    )
+    .await?;
+    if execution.result.total != expected_total {
+        return Err(test_error(format!(
+            "D16 storefront marker `{marker}` in category {category_id} returned total {}, expected {expected_total}",
+            execution.result.total
+        )));
+    }
+    if expected_total == 1 {
+        if execution.result.items.len() != 1 || execution.result.items[0].id != expected_id {
+            return Err(test_error(format!(
+                "D16 storefront marker `{marker}` did not return exact owner object {expected_id}: {:?}",
+                execution.result.items
+            )));
+        }
+    } else if !execution.result.items.is_empty()
+        || execution
+            .result
+            .facets
+            .iter()
+            .any(|facet| !facet.buckets.is_empty())
+    {
+        return Err(test_error(format!(
+            "D16 storefront marker `{marker}` leaked items or visible facets"
+        )));
+    }
+    Ok(())
+}
+
+async fn count_move_receipts(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    operation_id: Uuid,
+) -> TestResult<i64> {
+    scalar_i64(
+        db,
+        Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT COUNT(*)::BIGINT AS value FROM forum_topic_move_operations WHERE tenant_id = $1 AND operation_id = $2",
+            vec![tenant_id.into(), operation_id.into()],
+        ),
+    )
+    .await
+}
+
+async fn count_move_semantic_events(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    operation_id: Uuid,
+) -> TestResult<i64> {
+    scalar_i64(
+        db,
+        Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT COUNT(*)::BIGINT AS value FROM forum_domain_events WHERE tenant_id = $1 AND event_id = $2 AND event_type = 'forum.topic.moved'",
+            vec![tenant_id.into(), operation_id.into()],
+        ),
+    )
+    .await
+}
+
+async fn count_inbox_rows(db: &DatabaseConnection, event_id: Uuid) -> TestResult<i64> {
+    scalar_i64(
+        db,
+        Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT COUNT(*)::BIGINT AS value FROM search_projection_inbox WHERE event_id = $1",
+            vec![event_id.into()],
+        ),
+    )
+    .await
+}
+
+async fn max_ingest_sequence(db: &DatabaseConnection) -> TestResult<i64> {
+    scalar_i64(
+        db,
+        Statement::from_string(
+            DbBackend::Postgres,
+            "SELECT COALESCE(MAX(ingest_sequence), 0)::BIGINT AS value FROM search_projection_inbox"
+                .to_string(),
+        ),
+    )
+    .await
+}
+
+async fn scalar_i64(db: &DatabaseConnection, statement: Statement) -> TestResult<i64> {
+    let row: QueryResult = db
+        .query_one(statement)
+        .await?
+        .ok_or_else(|| test_error("D16 scalar query returned no row"))?;
+    Ok(row.try_get("", "value")?)
+}
+
+fn event_bus(db: DatabaseConnection) -> TransactionalEventBus {
+    TransactionalEventBus::new(Arc::new(OutboxTransport::new(db)))
+}
+
+fn admin_security(user_id: Uuid) -> SecurityContext {
+    SecurityContext::new(UserRole::Admin, Some(user_id))
+}
+
+fn postgres_database_url() -> Option<String> {
+    env::var(SEARCH_TEST_DATABASE_ENV)
+        .or_else(|_| env::var(FORUM_TEST_DATABASE_ENV))
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect_in_schema(
+    database_url: &str,
+    schema_name: &str,
+    max_connections: u32,
+) -> TestResult<DatabaseConnection> {
+    connect(
+        &database_url_in_schema(database_url, schema_name),
+        max_connections,
+    )
+    .await
+}
+
+fn database_url_in_schema(database_url: &str, schema_name: &str) -> String {
+    let separator = if database_url.contains('?') { '&' } else { '?' };
+    format!(
+        "{database_url}{separator}options=-c%20search_path%3D{schema_name}%2Cpublic"
+    )
+}
+
+async fn connect(database_url: &str, max_connections: u32) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(max_connections)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+fn sanitize_identifier(value: &str) -> String {
+    let normalized = value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    let normalized = normalized.trim_matches('_');
+    if normalized.is_empty() {
+        "test".to_string()
+    } else {
+        normalized.to_string()
+    }
+}
+
+fn write_evidence(artifact: TopicMoveEvidenceArtifact) -> TestResult<()> {
+    let path = workspace_root().join(EVIDENCE_PATH);
+    let parent = path
+        .parent()
+        .ok_or_else(|| test_error("D16 evidence path has no parent directory"))?;
+    fs::create_dir_all(parent)?;
+    fs::write(path, serde_json::to_vec_pretty(&artifact)?)?;
+    Ok(())
+}
+
+fn source_commit() -> TestResult<String> {
+    let output = Command::new("git")
+        .current_dir(workspace_root())
+        .args(["rev-parse", "HEAD"])
+        .output()?;
+    if !output.status.success() {
+        return Err(test_error("git rev-parse HEAD failed for D16 evidence generation"));
+    }
+    let value = String::from_utf8(output.stdout)?;
+    let value = value.trim();
+    if value.len() != 40 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(test_error(
+            "git rev-parse HEAD returned an invalid D16 commit SHA",
+        ));
+    }
+    Ok(value.to_string())
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn test_error(message: impl Into<String>) -> Box<dyn Error + Send + Sync> {
+    Box::new(IoError::new(ErrorKind::InvalidData, message.into()))
+}

--- a/crates/rustok-forum/contracts/forum-search-link-forum-03-topic-move-proof.json
+++ b/crates/rustok-forum/contracts/forum-search-link-forum-03-topic-move-proof.json
@@ -1,0 +1,71 @@
+{
+  "contract": "forum_search_link_forum_03_topic_move_proof_v1",
+  "task": "FORUM-23B2G2B3D16",
+  "target_link": "LINK-FORUM-03",
+  "coverage": "topic_move_category_scope_only",
+  "status": "source_ready_maintainer_execution_pending",
+  "owner_dependency": {
+    "task": "FORUM-21A",
+    "contract": "crates/rustok-forum/contracts/forum-topic-move-owner.json",
+    "service": "ForumTopicMoveService",
+    "operation_receipt": "forum_topic_move_operations",
+    "semantic_event": "forum.topic.moved"
+  },
+  "test": "apps/server/tests/forum_versioned_invalidation_topic_move.rs",
+  "verifier": "scripts/verify/verify-forum-search-link-forum-03-topic-move-proof.mjs",
+  "evidence_artifact": "target/forum-search-link-forum-03-topic-move-evidence.json",
+  "required_runtime": {
+    "database": "postgresql",
+    "broker_used": false,
+    "host_package": "rustok-server",
+    "search_inbox": "search_projection_inbox",
+    "projector": "ForumProjectionReconciler",
+    "storefront_execution": "execute_forum_storefront_search"
+  },
+  "required_owner_trace": [
+    "revisions 1 and 2 are the real source and target category-create forum-scope invalidations",
+    "revision 3 is the real topic-create source-category invalidation",
+    "revision 4 is the real approved-reply source-category invalidation",
+    "the move operation identifier equals the immutable receipt and Forum-local semantic event identifiers",
+    "revision 5 is the real moved-topic invalidation",
+    "revision 6 is the real source-category counter invalidation",
+    "revision 7 is the real target-category counter invalidation",
+    "an exact owner replay returns the original result without creating revision 8"
+  ],
+  "fail_closed_requirements": [
+    "the test creates one isolated PostgreSQL schema and applies real Outbox Taxonomy Forum and Search migrations",
+    "both categories the topic the approved reply and the move use exported Forum owner services",
+    "the seven owner revisions are contiguous and have exact target types target identifiers and order",
+    "every owner revision retains one legacy root envelope and one distinct caused typed envelope from sys_events",
+    "the exact typed envelopes enter Search through ForumSearchContractIngress rather than manual inbox insertion",
+    "Search ingest_sequence increases independently and is never compared numerically with Forum owner_revision",
+    "the production Forum projection source and ForumProjectionReconciler project the current topic reply and category counters",
+    "before the move only the source category storefront scope contains the exact topic and reply",
+    "after the move only the target category storefront scope contains the same topic and reply identities",
+    "topic and reply Search facets and payload category identifiers both change to the target category",
+    "source category counters become zero and target category counters become one topic and one approved reply",
+    "the operation receipt and forum.topic.moved journal payload exactly match the owner result",
+    "exact replay creates no new owner revision root typed event inbox row receipt semantic event or projection work",
+    "each root event retains exactly one Search inbox row and a caught-up repeat performs no duplicate work",
+    "the evidence artifact is written only after every assertion succeeds and the isolated schema is removed"
+  ],
+  "proves_after_maintainer_execution": [
+    "the real idempotent Forum topic-move owner command reaches the existing typed Search ingress and one durable inbox",
+    "topic and approved reply identities remain stable while their exact category scope changes",
+    "old category filtering no longer returns the moved discussion or visible facet buckets",
+    "new category filtering returns the exact moved topic and reply through production storefront execution and Forum owner eligibility",
+    "category counters Search documents and owner revision lineage converge after the move",
+    "exact owner replay is observationally idempotent across Forum Search and storefront state"
+  ],
+  "maintainer_commands": [
+    "node scripts/verify/verify-forum-search-link-forum-03-topic-move-proof.mjs",
+    "RUSTOK_SEARCH_TEST_DATABASE_URL=\"$DATABASE_URL\" cargo test -p rustok-server --test forum_versioned_invalidation_topic_move -- --nocapture --test-threads=1"
+  ],
+  "non_claims": [
+    "this source-ready slice does not claim that the verifier PostgreSQL test or storefront execution ran",
+    "this proof does not provide the separate FORUM-21A SQLite or PostgreSQL concurrency promotion evidence",
+    "this proof does not use external Iggy or replace the reviewed D0 D12 D13 D14 or D15 artifacts",
+    "this proof does not cover merge split fork reply-range moves aliases redirects or topic-move transports",
+    "this proof is not sufficient to mark LINK-FORUM-03 done promote FORUM-23 or change canonical FORUM-21 status"
+  ]
+}

--- a/crates/rustok-forum/docs/forum-23b2g2b3d16-topic-move-proof.md
+++ b/crates/rustok-forum/docs/forum-23b2g2b3d16-topic-move-proof.md
@@ -1,0 +1,204 @@
+# FORUM-23B2G2B3D16 topic-move Search proof
+
+## Status
+
+`source_ready_maintainer_execution_pending`
+
+FORUM-23B2G2B3D16 adds the remaining source-ready `LINK-FORUM-03` lifecycle
+proof that was blocked on a real Forum owner command: move one existing active
+topic from its current category to another active category, retain topic and
+reply identity, and converge Search category scope through the existing typed
+invalidation, one-inbox, production reconciler and storefront path.
+
+The machine contract is:
+
+```text
+crates/rustok-forum/contracts/forum-search-link-forum-03-topic-move-proof.json
+```
+
+The executable proof is:
+
+```text
+apps/server/tests/forum_versioned_invalidation_topic_move.rs
+```
+
+Successful maintainer execution writes:
+
+```text
+target/forum-search-link-forum-03-topic-move-evidence.json
+```
+
+The artifact is generated only after every assertion succeeds and the isolated
+PostgreSQL schema is removed.
+
+## Owner dependency
+
+The proof calls the exported FORUM-21A owner API directly:
+
+```rust
+ForumTopicMoveService::move_topic(
+    tenant_id,
+    topic_id,
+    admin_security,
+    MoveForumTopicInput {
+        operation_id,
+        target_category_id,
+        reason,
+    },
+)
+```
+
+It does not update `forum_topics.category_id`, category counters, move receipts,
+Forum journal rows, outbox rows or Search tables through direct SQL. Direct SQL
+is used only for evidence reads and the isolated test user fixture.
+
+The move result must correlate with:
+
+- one immutable `forum_topic_move_operations` receipt;
+- one Forum-local `forum.topic.moved` journal row;
+- `event_id = operation_id` in both owner records;
+- the same topic, source category, target category, actor, bounded reason and
+  published-reply count;
+- exactly three new projection revisions in owner order: topic, source category,
+  target category.
+
+## PostgreSQL profile
+
+The test creates a unique PostgreSQL schema and applies the real migrations for:
+
+1. `rustok-outbox`;
+2. `rustok-taxonomy`;
+3. `rustok-forum`;
+4. `rustok-search`.
+
+It uses `RUSTOK_SEARCH_TEST_DATABASE_URL`, then
+`RUSTOK_FORUM_TEST_DATABASE_URL`, then `DATABASE_URL`. A non-PostgreSQL or absent
+URL skips the runtime profile and cannot create an evidence artifact.
+
+External Iggy is not used in this bounded proof. D3-D5 and D10 retain the broker
+profiles; D16 focuses on the owner command, typed contract ingress, durable
+Search inbox, production projection source, reconciler and storefront category
+scope.
+
+## Baseline phase
+
+The fixture creates two public categories, one public topic in the source
+category and one approved reply. These real owner commands must produce exactly
+four contiguous projection revisions:
+
+1. source category create: `forum` scope;
+2. target category create: `forum` scope;
+3. topic create: source `forum_category` scope;
+4. approved reply create: source `forum_category` scope.
+
+For every revision the proof resolves the real legacy root envelope and the
+distinct caused typed envelope from `sys_events`. The typed envelope enters
+Search only through `ForumSearchContractIngress`.
+
+After `ForumProjectionReconciler` catches up, the source category storefront
+filter must return the exact topic and reply, while the target category filter
+must return neither item nor visible facet buckets. Search documents must expose
+source category identifiers in both `facets.category_id` and
+`payload.category_id`; source category counters are `1/1`, target counters are
+`0/0`.
+
+## Move phase
+
+The test invokes one real `ForumTopicMoveService` command with a fresh operation
+ID. It verifies the immutable receipt and semantic journal identity before
+accepting the projection trace.
+
+The move must append exactly these owner revisions:
+
+5. `forum_topic:<topic_id>`;
+6. `forum_category:<source_category_id>`;
+7. `forum_category:<target_category_id>`.
+
+Every revision must retain one root envelope, one distinct caused typed
+envelope and one Search inbox row. Search-owned `ingest_sequence` must increase
+within each delivery phase, but it is never compared numerically with the
+Forum-owned revision clock.
+
+The topic invalidation rebuilds the Forum tenant projection, so the approved
+reply document must move with the topic rather than retaining a stale source
+category facet. Source and target category invalidations then refresh their
+counter documents.
+
+After reconciliation:
+
+- the exact topic ID remains unchanged;
+- the exact reply ID remains unchanged;
+- both documents expose the target category in facets and payload;
+- source category counters are `0/0`;
+- target category counters are `1/1`;
+- source category storefront searches return zero items and zero visible facet
+  buckets;
+- target category storefront searches return the exact topic and reply through
+  production execution and Forum owner reauthorization.
+
+## Exact replay phase
+
+The proof calls the owner command again with the same operation ID, topic,
+target, actor and normalized reason. Replay must return the original
+`ForumTopicMoveResult` and create none of the following:
+
+- owner revision 8;
+- another root invalidation;
+- another typed envelope;
+- another Search inbox row;
+- another move receipt;
+- another `forum.topic.moved` journal row;
+- additional reconciler work.
+
+The final owner ledger must be exactly contiguous revisions 1 through 7, and its
+root event identities must equal the retained root event set.
+
+## Evidence shape
+
+The generated artifact records one passed scenario:
+
+```text
+topic_move_category_scope
+```
+
+Its facts include:
+
+- tenant, source category, target category, topic and reply identities;
+- immutable move owner receipt and semantic event payload;
+- all seven owner revision rows;
+- baseline and move root/typed/inbox correlations;
+- baseline and moved Search documents;
+- explicit retained-identity, old-scope exclusion, new-scope inclusion and
+  replay-idempotency booleans.
+
+`source_commit` is read from `git rev-parse HEAD`; hand-edited or stale evidence
+is not accepted as current source proof.
+
+## Deliberate boundaries
+
+This slice does not:
+
+- run the FORUM-21A SQLite owner regression or provide its PostgreSQL concurrency
+  promotion evidence;
+- add REST, GraphQL, native, admin or storefront topic-move mutations;
+- add canonical URL aliases, redirects or tombstones;
+- implement merge, split, fork or reply-range operations;
+- use external Iggy;
+- mutate the reviewed D0, D12, D13, D14 or D15 evidence contracts;
+- mark `FORUM-21`, `FORUM-23` or `LINK-FORUM-03` complete.
+
+A later reviewed assembler may consume D13-D16 only after the required runtime
+artifacts are generated on the same exact source commit and independently
+reviewed.
+
+## Maintainer verification
+
+```bash
+node scripts/verify/verify-forum-search-link-forum-03-topic-move-proof.mjs
+RUSTOK_SEARCH_TEST_DATABASE_URL="$DATABASE_URL" \
+  cargo test -p rustok-server \
+  --test forum_versioned_invalidation_topic_move \
+  -- --nocapture --test-threads=1
+```
+
+No command above was run by the implementation agent, per maintainer request.

--- a/scripts/verify/verify-forum-search-link-forum-03-topic-move-proof.mjs
+++ b/scripts/verify/verify-forum-search-link-forum-03-topic-move-proof.mjs
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = process.cwd();
+const read = (path) => readFileSync(resolve(root, path), "utf8");
+const requireAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(text.includes(marker), `${label} is missing required marker: ${marker}`);
+  }
+};
+const forbidAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(!text.includes(marker), `${label} contains forbidden marker: ${marker}`);
+  }
+};
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-search-link-forum-03-topic-move-proof.json";
+const ownerContractPath =
+  "crates/rustok-forum/contracts/forum-topic-move-owner.json";
+const docPath =
+  "crates/rustok-forum/docs/forum-23b2g2b3d16-topic-move-proof.md";
+const testPath =
+  "apps/server/tests/forum_versioned_invalidation_topic_move.rs";
+const verifierPath =
+  "scripts/verify/verify-forum-search-link-forum-03-topic-move-proof.mjs";
+const evidencePath =
+  "target/forum-search-link-forum-03-topic-move-evidence.json";
+const planPath = "crates/rustok-forum/docs/implementation-plan.md";
+const moveServicePath = "crates/rustok-forum/src/services/topic_move.rs";
+const projectionSourcePath = "crates/rustok-forum/src/search_projection.rs";
+const reconcilerPath = "crates/rustok-search/src/forum_reconciliation.rs";
+const categoryOwnerPath =
+  "crates/rustok-forum/src/services/category_projection_owner.rs";
+const topicOwnerPath = "crates/rustok-forum/src/services/topic_inline.rs";
+const replyOwnerPath = "crates/rustok-forum/src/services/reply_owner.rs";
+
+const contract = JSON.parse(read(contractPath));
+assert.equal(
+  contract.contract,
+  "forum_search_link_forum_03_topic_move_proof_v1",
+);
+assert.equal(contract.task, "FORUM-23B2G2B3D16");
+assert.equal(contract.target_link, "LINK-FORUM-03");
+assert.equal(contract.coverage, "topic_move_category_scope_only");
+assert.equal(contract.status, "source_ready_maintainer_execution_pending");
+assert.deepEqual(contract.owner_dependency, {
+  task: "FORUM-21A",
+  contract: ownerContractPath,
+  service: "ForumTopicMoveService",
+  operation_receipt: "forum_topic_move_operations",
+  semantic_event: "forum.topic.moved",
+});
+assert.equal(contract.test, testPath);
+assert.equal(contract.verifier, verifierPath);
+assert.equal(contract.evidence_artifact, evidencePath);
+assert.equal(contract.required_runtime.database, "postgresql");
+assert.equal(contract.required_runtime.broker_used, false);
+assert.equal(contract.required_runtime.host_package, "rustok-server");
+assert.equal(contract.required_runtime.search_inbox, "search_projection_inbox");
+assert.equal(contract.required_runtime.projector, "ForumProjectionReconciler");
+assert.equal(
+  contract.required_runtime.storefront_execution,
+  "execute_forum_storefront_search",
+);
+assert.equal(contract.required_owner_trace.length, 8);
+assert.ok(contract.fail_closed_requirements.length >= 15);
+assert.ok(contract.proves_after_maintainer_execution.length >= 6);
+assert.deepEqual(contract.maintainer_commands, [
+  `node ${verifierPath}`,
+  'RUSTOK_SEARCH_TEST_DATABASE_URL="$DATABASE_URL" cargo test -p rustok-server --test forum_versioned_invalidation_topic_move -- --nocapture --test-threads=1',
+]);
+assert.ok(
+  contract.non_claims.some((claim) => claim.includes("FORUM-21A")),
+  "D16 must retain the separate owner promotion gate",
+);
+assert.ok(
+  contract.non_claims.some((claim) => claim.includes("not sufficient")),
+  "D16 must not claim canonical completion",
+);
+
+const ownerContract = JSON.parse(read(ownerContractPath));
+assert.equal(ownerContract.contract, "forum_topic_move_owner_v1");
+assert.equal(ownerContract.task, "FORUM-21A");
+assert.equal(ownerContract.parent_task, "FORUM-21");
+assert.equal(ownerContract.status, "source_ready_maintainer_execution_pending");
+assert.equal(ownerContract.canonical_plan_status, "planned");
+assert.equal(ownerContract.owner_service, "ForumTopicMoveService");
+assert.equal(ownerContract.receipt_table, "forum_topic_move_operations");
+assert.deepEqual(ownerContract.semantic_event, {
+  journal: "forum_domain_events",
+  event_type: "forum.topic.moved",
+  schema_version: 1,
+  event_id_equals_operation_id: true,
+  shared_rustok_events_contract_changed: false,
+});
+
+const test = read(testPath);
+requireAll(
+  test,
+  [
+    "forum_search_link_forum_03_topic_move_evidence_v1",
+    'task: "FORUM-23B2G2B3D16"',
+    evidencePath,
+    "PostgresTopicMoveEvidence::setup",
+    "OutboxModule.migrations()",
+    "TaxonomyModule.migrations()",
+    "ForumModule.migrations()",
+    "SearchModule.migrations()",
+    "CategoryService::new",
+    "TopicService::new",
+    "ReplyService::new",
+    "ForumTopicMoveService::new",
+    "MoveForumTopicInput",
+    "MOVE_REASON",
+    "forum_topic_move_operations",
+    "forum.topic.moved",
+    "event_id != operation_id",
+    "forum_projection_revision_ledger",
+    '("forum", None)',
+    '("forum_topic", Some(fixture.topic_id))',
+    '("forum_category", Some(fixture.source_category_id))',
+    '("forum_category", Some(fixture.target_category_id))',
+    "load_root_envelope",
+    "load_typed_envelope",
+    "ContractEventPayload::ForumSearchProjection",
+    "ForumSearchProjectionEvent::InvalidationIssued",
+    "typed.causation_id() != Some(revision.event_id)",
+    "ForumSearchContractIngress::new",
+    "ForumSearchContractIngressOutcome::DurablyAccepted",
+    "search_projection_inbox",
+    "ForumSearchProjectionSourceFactory.build",
+    "ForumProjectionReconciler::new",
+    "execute_forum_storefront_search",
+    "ForumSearchResultEligibilityService::new",
+    "ensure_document_scope",
+    "document_category_id(topic)? != expected_category_id",
+    "document_category_id(reply)? != expected_category_id",
+    'source.payload["topic_count"]',
+    'target.payload["reply_count"]',
+    "roots_before_replay",
+    "typed_before_replay",
+    "max_ingest_before_replay",
+    "load_owner_revisions_after(db, fixture.tenant_id, 7)",
+    "count_move_receipts",
+    "count_move_semantic_events",
+    'id: "topic_move_category_scope"',
+    'result: "passed"',
+    '"topic_identity_retained": true',
+    '"reply_identity_retained": true',
+    '"source_category_scope_empty_after_move": true',
+    '"target_category_scope_contains_topic_and_reply_after_move": true',
+    '"exact_replay_created_new_owner_revision": false',
+    '"owner_revision_compared_to_ingest_sequence": false',
+    '"caught_up_repeat_performed_work": false',
+    '.args(["rev-parse", "HEAD"])',
+    "evidence.cleanup().await",
+  ],
+  "D16 executable proof",
+);
+forbidAll(
+  test,
+  [
+    "#[ignore]",
+    'result: "skipped"',
+    "static_fixture",
+    "MockForum",
+    "FakeForum",
+    "InMemory",
+    "INSERT INTO search_documents",
+    "UPDATE search_documents",
+    "UPDATE forum_topics SET category_id",
+    "UPDATE forum_topics\nSET category_id",
+    "INSERT INTO forum_topic_move_operations",
+    "INSERT INTO forum_domain_events",
+    "owner_revision == inbox.ingest_sequence",
+    "owner_revision as i64 ==",
+  ],
+  "D16 executable proof",
+);
+
+const moveService = read(moveServicePath);
+requireAll(
+  moveService,
+  [
+    "pub struct ForumTopicMoveService",
+    "pub async fn move_topic",
+    "lock_topic_move_tenant_in_tx(&txn, tenant_id).await?",
+    "forum_topic_move_operation::Entity::find_by_id",
+    "validate_existing_semantic_event_in_tx",
+    "ForumError::TopicMoveOperationConflict",
+    "transfer_category_counters_in_tx",
+    "active.category_id = Set(input.target_category_id)",
+    'const FORUM_TOPIC_MOVED_EVENT_TYPE: &str = "forum.topic.moved";',
+    "event_id: Set(input.operation_id)",
+    "publish_forum_topic_projection_in_tx",
+    "publish_forum_category_projection_in_tx",
+    "txn.commit().await?",
+  ],
+  "FORUM-21A topic move owner",
+);
+assert.ok(
+  (moveService.match(/publish_forum_category_projection_in_tx\(/g) ?? []).length >= 2,
+  "topic move owner must invalidate source and target categories",
+);
+assert.ok(
+  moveService.indexOf("publish_forum_topic_projection_in_tx(") <
+    moveService.indexOf("publish_forum_category_projection_in_tx("),
+  "topic invalidation must precede category invalidations",
+);
+forbidAll(
+  moveService,
+  [".max(0)", "saturating_", "DomainEvent::ForumTopicMoved"],
+  "FORUM-21A topic move owner",
+);
+
+const categoryOwner = read(categoryOwnerPath);
+requireAll(
+  categoryOwner,
+  [
+    "CategoryProjectionOwnerService",
+    "pub(super) async fn create",
+    "publish_forum_projection_scope_direct_in_tx",
+    "txn.commit().await?",
+  ],
+  "category owner",
+);
+const topicOwner = read(topicOwnerPath);
+requireAll(
+  topicOwner,
+  [
+    "create_with_inline_relations",
+    "publish_forum_category_projection_in_tx",
+    "txn.commit().await?",
+  ],
+  "topic owner",
+);
+const replyOwner = read(replyOwnerPath);
+requireAll(
+  replyOwner,
+  [
+    "if status == ReplyStatus::Approved",
+    "TopicService::adjust_reply_count_in_tx",
+    "CategoryService::adjust_counters_in_tx",
+    "publish_forum_category_projection_in_tx",
+    "txn.commit().await?",
+  ],
+  "approved reply owner",
+);
+
+const projectionSource = read(projectionSourcePath);
+requireAll(
+  projectionSource,
+  [
+    'document_key: format!("forum_topic:{}:{locale}"',
+    'document_key: format!("forum_reply:{reply_id}:{locale}")',
+    '"category_id": topic.category_id',
+    '"topic_id": topic.id',
+    '"topic_count": category.topic_count',
+    '"reply_count": category.reply_count',
+    "ReplyStatus::Approved",
+  ],
+  "Forum Search projection source",
+);
+
+const reconciler = read(reconcilerPath);
+requireAll(
+  reconciler,
+  [
+    "pub struct ForumProjectionReconciler",
+    "pub async fn sweep_due",
+    '("forum", _) | ("forum_topic", Some(_))',
+    ".rebuild_tenant(envelope.tenant_id)",
+    '("forum_category", Some(category_id))',
+    '.refresh_entity(envelope.tenant_id, "forum_category", *category_id)',
+  ],
+  "Forum production reconciler",
+);
+
+const plan = read(planPath);
+requireAll(
+  plan,
+  [
+    "| `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |",
+    "| `FORUM-23` | `in_progress` |",
+    "| `LINK-FORUM-03` | `planned` | Forum/index/search ordering and visibility proof. |",
+    "## `LINK-FORUM-03` — index and search",
+    "Prove publish, translation, moderation approval, move, hide/delete, ACL change,",
+  ],
+  "Forum canonical plan",
+);
+forbidAll(
+  plan,
+  [
+    "| `LINK-FORUM-03` | `done` |",
+    "| `FORUM-21` | `done` | Move, merge, split and fork topic workflows. |",
+    "FORUM-23B2G2B3D16 closes LINK-FORUM-03",
+  ],
+  "Forum canonical plan",
+);
+
+const doc = read(docPath);
+requireAll(
+  doc,
+  [
+    "`source_ready_maintainer_execution_pending`",
+    "FORUM-23B2G2B3D16",
+    "LINK-FORUM-03",
+    contractPath,
+    testPath,
+    evidencePath,
+    "ForumTopicMoveService::move_topic",
+    "revisions 1 through 7",
+    "source category storefront searches return zero items",
+    "target category storefront searches return the exact topic and reply",
+    "No command above was run by the implementation agent",
+  ],
+  "D16 handoff",
+);
+
+console.log(
+  "Forum Search LINK-FORUM-03 topic-move proof is source-ready and fail-closed.",
+);


### PR DESCRIPTION
## What changed

- add source-ready `FORUM-23B2G2B3D16` PostgreSQL evidence for the real `FORUM-21A` idempotent topic-move owner command;
- create two categories, one public topic and one approved reply through exported Forum owner services;
- correlate seven contiguous Forum owner revisions with their legacy root envelopes, distinct caused typed envelopes and one durable Search inbox row each;
- run the production Forum projection source and `ForumProjectionReconciler` through baseline and move phases;
- prove topic and reply identities remain stable while both Search facets and payload category identifiers move from source to target;
- prove source category counters become `0/0`, target counters become `1/1`, and exact storefront category filters change from source-only to target-only visibility;
- correlate the move result with one immutable `forum_topic_move_operations` receipt and one Forum-local `forum.topic.moved` journal event using `event_id = operation_id`;
- prove exact owner replay creates no revision 8, root event, typed event, inbox row, receipt, semantic event or reconciler work;
- add a fail-closed contract, handoff and source verifier.

## Deliberate boundary

This slice does not run or promote the separate FORUM-21A owner verification gate, use external Iggy, add topic-move transports or aliases, implement merge/split/fork/reply-range workflows, mutate reviewed D0/D12/D13/D14/D15 artifacts, or change canonical `FORUM-21`, `FORUM-23` or `LINK-FORUM-03` status.

## Validation

Tests, Node verifiers, formatting, Cargo checks, workflows, CI and PostgreSQL execution were intentionally not run, per maintainer request.