### PR TITLE
test(rbac): add policy incident trace packet

### DIFF
--- a/apps/server/tests/rbac_policy_incident_trace.rs
+++ b/apps/server/tests/rbac_policy_incident_trace.rs
@@ -8,7 +8,9 @@ use rustok_rbac::RbacRoleAssignmentDbWriter;
 use rustok_server::common::settings::RustokSettings;
 use rustok_server::models::_entities::user_roles;
 use rustok_server::models::{tenants, users};
-use rustok_server::services::rbac_invalidation_generation::start_rbac_invalidation_generation_watchdog;
+use rustok_server::services::rbac_invalidation_generation::{
+    start_rbac_invalidation_generation_watchdog,
+};
 use rustok_server::services::rbac_service::RbacService;
 use rustok_server::services::server_runtime_context::ServerRuntimeContext;
 use rustok_telemetry::rbac_invalidation_metrics::{
@@ -132,9 +134,10 @@ async fn missed_publication_incident_connects_decision_relations_cache_generatio
         .exec(&transaction)
         .await
         .expect("remove role relation inside owner transaction");
-    let durable_generation = rustok_rbac::reserve_permission_invalidation_generation(&transaction)
-        .await
-        .expect("reserve durable invalidation generation");
+    let durable_generation =
+        rustok_rbac::reserve_permission_invalidation_generation(&transaction)
+            .await
+            .expect("reserve durable invalidation generation");
     transaction
         .commit()
         .await

--- a/apps/server/tests/rbac_policy_incident_trace.rs
+++ b/apps/server/tests/rbac_policy_incident_trace.rs
@@ -101,14 +101,19 @@ async fn missed_publication_incident_connects_decision_relations_cache_generatio
 
     let writer = RbacRoleAssignmentDbWriter::new(db.clone());
     writer
-        .assign_role_permissions(tenant_id, user_id, UserRole::Admin)
+        .assign_role_permissions(tenant_id, user_id, UserRole::Customer)
         .await
-        .expect("assign incident admin role");
+        .expect("seed canonical tenant roles");
+    RbacService::replace_user_role_committed(&db, &user_id, &tenant_id, UserRole::Admin)
+        .await
+        .expect("commit initial admin role and durable generation");
 
-    let context = ServerRuntimeContext::new(db.clone(), RustokSettings::default());
     let initial_generation = rustok_rbac::read_permission_invalidation_generation(&db)
         .await
         .expect("read initial durable generation");
+    assert!(initial_generation > 0);
+
+    let context = ServerRuntimeContext::new(db.clone(), RustokSettings::default());
     start_rbac_invalidation_generation_watchdog(&context)
         .await
         .expect("start durable generation watchdog");
@@ -227,6 +232,7 @@ async fn missed_publication_incident_connects_decision_relations_cache_generatio
         evaluator_allowed_after_recovery = packet.evaluator_allowed_after_recovery,
         "rbac policy incident packet"
     );
+    println!("rbac policy incident packet: {packet:?}");
 
     assert_eq!(packet.relation_assigned_role_count, 0);
     assert!(!packet.relation_grants_required_permission);

--- a/apps/server/tests/rbac_policy_incident_trace.rs
+++ b/apps/server/tests/rbac_policy_incident_trace.rs
@@ -1,0 +1,239 @@
+use std::time::Duration;
+
+use chrono::Utc;
+use rustok_api::Permission;
+use rustok_core::{UserRole, UserStatus};
+use rustok_migrations::Migrator;
+use rustok_rbac::RbacRoleAssignmentDbWriter;
+use rustok_server::common::settings::RustokSettings;
+use rustok_server::models::_entities::user_roles;
+use rustok_server::models::{tenants, users};
+use rustok_server::services::rbac_invalidation_generation::start_rbac_invalidation_generation_watchdog;
+use rustok_server::services::rbac_service::RbacService;
+use rustok_server::services::server_runtime_context::ServerRuntimeContext;
+use rustok_telemetry::rbac_invalidation_metrics::{
+    RBAC_INVALIDATION_APPLIED_GENERATION, RBAC_INVALIDATION_FULL_CLEARS_TOTAL,
+    RBAC_INVALIDATION_RECOVERIES_TOTAL,
+};
+use rustok_test_utils::db::setup_test_db_with_migrations;
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, Set, TransactionTrait};
+use serial_test::serial;
+use uuid::Uuid;
+
+#[derive(Debug)]
+struct RbacPolicyIncidentPacket {
+    incident_id: Uuid,
+    tenant_id: Uuid,
+    user_id: Uuid,
+    evaluator_allowed_before_recovery: bool,
+    relation_assigned_role_count: usize,
+    relation_permission_count: usize,
+    relation_grants_required_permission: bool,
+    cache_hit: bool,
+    cache_permissions_count: usize,
+    durable_generation: u64,
+    applied_generation_before: u64,
+    recovery_action: &'static str,
+    recovery_count_delta: u64,
+    full_clear_count_delta: u64,
+    applied_generation_after: u64,
+    evaluator_allowed_after_recovery: bool,
+}
+
+async fn insert_tenant_and_user(db: &sea_orm::DatabaseConnection) -> (Uuid, Uuid) {
+    let tenant_id = rustok_core::generate_id();
+    let user_id = rustok_core::generate_id();
+
+    tenants::Entity::insert(tenants::ActiveModel {
+        id: Set(tenant_id),
+        name: Set("RBAC policy incident tenant".to_string()),
+        slug: Set(format!("rbac-policy-incident-{tenant_id}")),
+        domain: Set(None),
+        settings: Set(serde_json::json!({})),
+        default_locale: Set("en".to_string()),
+        is_active: Set(true),
+        created_at: Set(Utc::now().into()),
+        updated_at: Set(Utc::now().into()),
+    })
+    .exec(db)
+    .await
+    .expect("insert incident tenant");
+
+    users::Entity::insert(users::ActiveModel {
+        id: Set(user_id),
+        tenant_id: Set(tenant_id),
+        email: Set(format!("rbac-policy-incident-{user_id}@example.com")),
+        password_hash: Set("hash".to_string()),
+        name: Set(None),
+        status: Set(UserStatus::Active),
+        email_verified_at: Set(None),
+        last_login_at: Set(None),
+        metadata: Set(serde_json::json!({})),
+        created_at: Set(Utc::now().into()),
+        updated_at: Set(Utc::now().into()),
+    })
+    .exec(db)
+    .await
+    .expect("insert incident user");
+
+    (tenant_id, user_id)
+}
+
+async fn wait_for_applied_generation(expected: u64) {
+    tokio::time::timeout(Duration::from_secs(7), async {
+        loop {
+            if RBAC_INVALIDATION_APPLIED_GENERATION.get() == expected as i64 {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("durable RBAC generation was not applied before timeout");
+}
+
+#[tokio::test]
+#[serial]
+async fn missed_publication_incident_connects_decision_relations_cache_generation_and_recovery() {
+    let db = setup_test_db_with_migrations::<Migrator>().await;
+    let (tenant_id, user_id) = insert_tenant_and_user(&db).await;
+    let required_permission = Permission::SETTINGS_MANAGE;
+
+    let writer = RbacRoleAssignmentDbWriter::new(db.clone());
+    writer
+        .assign_role_permissions(tenant_id, user_id, UserRole::Admin)
+        .await
+        .expect("assign incident admin role");
+
+    let context = ServerRuntimeContext::new(db.clone(), RustokSettings::default());
+    let initial_generation = rustok_rbac::read_permission_invalidation_generation(&db)
+        .await
+        .expect("read initial durable generation");
+    start_rbac_invalidation_generation_watchdog(&context)
+        .await
+        .expect("start durable generation watchdog");
+    wait_for_applied_generation(initial_generation).await;
+
+    RbacService::invalidate_user_rbac_caches(&tenant_id, &user_id).await;
+    assert!(
+        RbacService::has_permission(&db, &tenant_id, &user_id, &required_permission)
+            .await
+            .expect("warm authoritative permission snapshot")
+    );
+
+    let transaction = db.begin().await.expect("begin missed-publication mutation");
+    user_roles::Entity::delete_many()
+        .filter(user_roles::Column::UserId.eq(user_id))
+        .exec(&transaction)
+        .await
+        .expect("remove role relation inside owner transaction");
+    let durable_generation = rustok_rbac::reserve_permission_invalidation_generation(&transaction)
+        .await
+        .expect("reserve durable invalidation generation");
+    transaction
+        .commit()
+        .await
+        .expect("commit relation mutation and durable generation");
+
+    let metrics_before_stale_decision = RbacService::metrics_snapshot();
+    let evaluator_allowed_before_recovery =
+        RbacService::has_permission(&db, &tenant_id, &user_id, &required_permission)
+            .await
+            .expect("evaluate stale cached permission before watchdog recovery");
+    let metrics_after_stale_decision = RbacService::metrics_snapshot();
+    let cached_permissions = RbacService::get_user_permissions(&db, &tenant_id, &user_id)
+        .await
+        .expect("read stale cached permission snapshot");
+    let assigned_roles = user_roles::Entity::find()
+        .filter(user_roles::Column::UserId.eq(user_id))
+        .all(&db)
+        .await
+        .expect("read incident relation state");
+    let authoritative_permissions =
+        RbacService::get_user_permissions_authoritative(&db, &tenant_id, &user_id)
+            .await
+            .expect("read authoritative incident relation permissions");
+
+    let recovery_before = RBAC_INVALIDATION_RECOVERIES_TOTAL
+        .with_label_values(&["generation_advanced"])
+        .get();
+    let full_clear_before = RBAC_INVALIDATION_FULL_CLEARS_TOTAL
+        .with_label_values(&["generation_advanced"])
+        .get();
+    let applied_generation_before = RBAC_INVALIDATION_APPLIED_GENERATION.get() as u64;
+
+    assert!(evaluator_allowed_before_recovery);
+    assert!(assigned_roles.is_empty());
+    assert!(!authoritative_permissions.contains(&required_permission));
+    assert!(cached_permissions.contains(&required_permission));
+    assert_eq!(
+        metrics_after_stale_decision.permission_cache_hits,
+        metrics_before_stale_decision.permission_cache_hits + 1
+    );
+    assert!(durable_generation > applied_generation_before);
+
+    wait_for_applied_generation(durable_generation).await;
+
+    let evaluator_allowed_after_recovery =
+        RbacService::has_permission(&db, &tenant_id, &user_id, &required_permission)
+            .await
+            .expect("evaluate permission after durable watchdog recovery");
+    let recovery_after = RBAC_INVALIDATION_RECOVERIES_TOTAL
+        .with_label_values(&["generation_advanced"])
+        .get();
+    let full_clear_after = RBAC_INVALIDATION_FULL_CLEARS_TOTAL
+        .with_label_values(&["generation_advanced"])
+        .get();
+    let applied_generation_after = RBAC_INVALIDATION_APPLIED_GENERATION.get() as u64;
+
+    let packet = RbacPolicyIncidentPacket {
+        incident_id: Uuid::new_v4(),
+        tenant_id,
+        user_id,
+        evaluator_allowed_before_recovery,
+        relation_assigned_role_count: assigned_roles.len(),
+        relation_permission_count: authoritative_permissions.len(),
+        relation_grants_required_permission: authoritative_permissions
+            .contains(&required_permission),
+        cache_hit: metrics_after_stale_decision.permission_cache_hits
+            == metrics_before_stale_decision.permission_cache_hits + 1,
+        cache_permissions_count: cached_permissions.len(),
+        durable_generation,
+        applied_generation_before,
+        recovery_action: "generation_advanced_full_clear",
+        recovery_count_delta: recovery_after.saturating_sub(recovery_before),
+        full_clear_count_delta: full_clear_after.saturating_sub(full_clear_before),
+        applied_generation_after,
+        evaluator_allowed_after_recovery,
+    };
+
+    tracing::info!(
+        incident_id = %packet.incident_id,
+        tenant_id = %packet.tenant_id,
+        user_id = %packet.user_id,
+        required_permission = %required_permission,
+        evaluator_allowed_before_recovery = packet.evaluator_allowed_before_recovery,
+        relation_assigned_role_count = packet.relation_assigned_role_count,
+        relation_permission_count = packet.relation_permission_count,
+        relation_grants_required_permission = packet.relation_grants_required_permission,
+        cache_hit = packet.cache_hit,
+        cache_permissions_count = packet.cache_permissions_count,
+        durable_generation = packet.durable_generation,
+        applied_generation_before = packet.applied_generation_before,
+        recovery_action = packet.recovery_action,
+        recovery_count_delta = packet.recovery_count_delta,
+        full_clear_count_delta = packet.full_clear_count_delta,
+        applied_generation_after = packet.applied_generation_after,
+        evaluator_allowed_after_recovery = packet.evaluator_allowed_after_recovery,
+        "rbac policy incident packet"
+    );
+
+    assert_eq!(packet.relation_assigned_role_count, 0);
+    assert!(!packet.relation_grants_required_permission);
+    assert!(packet.cache_hit);
+    assert!(packet.cache_permissions_count > packet.relation_permission_count);
+    assert_eq!(packet.recovery_count_delta, 1);
+    assert_eq!(packet.full_clear_count_delta, 1);
+    assert_eq!(packet.applied_generation_after, packet.durable_generation);
+    assert!(!packet.evaluator_allowed_after_recovery);
+}

--- a/crates/rustok-rbac/contracts/evidence/rbac-policy-incident-trace-source.json
+++ b/crates/rustok-rbac/contracts/evidence/rbac-policy-incident-trace-source.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "evidence_id": "RBAC-POLICY-INCIDENT-TRACE-SOURCE-20260801",
-  "generated_at": "2026-08-01T11:40:00Z",
+  "generated_at": "2026-08-01T11:27:00Z",
   "status": "source_ready_unvalidated",
   "cycle": "cycle-001",
   "component": "core/rbac",

--- a/crates/rustok-rbac/contracts/evidence/rbac-policy-incident-trace-source.json
+++ b/crates/rustok-rbac/contracts/evidence/rbac-policy-incident-trace-source.json
@@ -7,6 +7,9 @@
   "component": "core/rbac",
   "base_revision": "3a9304aead372b22a5d9069143922d23934e4d7c",
   "scenario": "missed committed role-relation invalidation publication recovered by the durable generation watchdog",
+  "fixture_backend": "sqlite_in_memory",
+  "postgresql_evidence": false,
+  "multi_replica_evidence": false,
   "production_paths": {
     "evaluator": "apps/server/src/services/rbac_service.rs",
     "relation_store": "apps/server/src/services/rbac_authoritative.rs",
@@ -47,6 +50,7 @@
     "formatting_executed": false,
     "cargo_check_executed": false,
     "workflow_or_ci_executed": false,
+    "sqlite_runtime_executed": false,
     "postgresql_runtime_executed": false
   },
   "broad_rbac_verification_complete": false,

--- a/crates/rustok-rbac/contracts/evidence/rbac-policy-incident-trace-source.json
+++ b/crates/rustok-rbac/contracts/evidence/rbac-policy-incident-trace-source.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": 1,
+  "evidence_id": "RBAC-POLICY-INCIDENT-TRACE-SOURCE-20260801",
+  "generated_at": "2026-08-01T11:40:00Z",
+  "status": "source_ready_unvalidated",
+  "cycle": "cycle-001",
+  "component": "core/rbac",
+  "base_revision": "3a9304aead372b22a5d9069143922d23934e4d7c",
+  "scenario": "missed committed role-relation invalidation publication recovered by the durable generation watchdog",
+  "production_paths": {
+    "evaluator": "apps/server/src/services/rbac_service.rs",
+    "relation_store": "apps/server/src/services/rbac_authoritative.rs",
+    "permission_cache": "apps/server/src/services/rbac_runtime.rs",
+    "durable_generation": "apps/server/src/services/rbac_invalidation_generation.rs",
+    "recovery_metrics": "crates/rustok-telemetry/src/rbac_invalidation_metrics.rs"
+  },
+  "incident_packet_source": "apps/server/tests/rbac_policy_incident_trace.rs",
+  "packet_contract": {
+    "evaluator_decision_before_recovery": true,
+    "authoritative_relation_state": true,
+    "cache_hit_and_snapshot_size": true,
+    "durable_and_applied_generation": true,
+    "bounded_recovery_action": "generation_advanced_full_clear",
+    "recovery_and_full_clear_counter_deltas": true,
+    "evaluator_decision_after_recovery": true,
+    "raw_permission_list_logged": false,
+    "password_or_token_logged": false
+  },
+  "failure_injection": {
+    "relation_mutation_and_generation_share_transaction": true,
+    "publisher_intentionally_not_called": true,
+    "stale_cache_is_observed_before_watchdog_recovery": true,
+    "watchdog_is_the_recovery_actor": true,
+    "manual_test_only_cache_clear": false
+  },
+  "expected_outcome": {
+    "decision_before_recovery": "allowed_from_stale_cache",
+    "authoritative_relation_grants_required_permission": false,
+    "durable_generation_ahead_of_applied": true,
+    "recovery_count_delta": 1,
+    "full_clear_count_delta": 1,
+    "decision_after_recovery": "denied_from_authoritative_relations"
+  },
+  "validation": {
+    "rust_test_executed": false,
+    "source_verifier_executed": false,
+    "formatting_executed": false,
+    "cargo_check_executed": false,
+    "workflow_or_ci_executed": false,
+    "postgresql_runtime_executed": false
+  },
+  "broad_rbac_verification_complete": false,
+  "cursor_advanced": false
+}

--- a/crates/rustok-rbac/docs/policy-incident-trace.md
+++ b/crates/rustok-rbac/docs/policy-incident-trace.md
@@ -8,6 +8,11 @@ permission cache, durable invalidation generation, watchdog recovery action, and
 post-recovery evaluator decision without introducing a second authorization or cache
 implementation.
 
+The fixture uses the existing `setup_test_db_with_migrations` helper and therefore runs
+against a fresh single-connection in-memory SQLite database. It is not PostgreSQL
+concurrency evidence, multi-replica evidence, or Redis transport evidence. Those P0
+gates remain open.
+
 ## Incident scenario
 
 The source-ready test is
@@ -56,6 +61,8 @@ permission or relation lists are not written to the packet.
 - The test does not call the invalidation publisher, manually clear the cache, create a
   second evaluator, or normalize the durable/applied generation gap.
 - The only recovery actor is the existing durable-generation watchdog.
+- The SQLite packet does not replace retained real-PostgreSQL concurrency or
+  two-replica Redis outage/restart/missed-publication evidence.
 
 ## Source evidence
 
@@ -74,7 +81,7 @@ node scripts/verify/verify-rbac-policy-incident-trace.mjs
 ```
 
 The test should be retained with its `rbac policy incident packet` log output on the
-same revision. The source file and evidence JSON do not claim that PostgreSQL, Rust,
-Node, formatting, workflows, or CI have run. The broader `core/rbac` cursor remains
-`in_progress` until its compile, concurrency, multi-replica Redis, management-flow,
-and FFA/FBA gates are satisfied.
+same revision. The source file and evidence JSON do not claim that SQLite, PostgreSQL,
+Rust, Node, formatting, workflows, or CI have run. The broader `core/rbac` cursor
+remains `in_progress` until its compile, PostgreSQL concurrency, multi-replica Redis,
+management-flow, and FFA/FBA gates are satisfied.

--- a/crates/rustok-rbac/docs/policy-incident-trace.md
+++ b/crates/rustok-rbac/docs/policy-incident-trace.md
@@ -1,0 +1,80 @@
+# RBAC policy incident trace packet
+
+## Purpose
+
+This packet is a dedicated integration scenario for one stale authorization incident.
+It connects the evaluator decision, authoritative relation state, process-local
+permission cache, durable invalidation generation, watchdog recovery action, and the
+post-recovery evaluator decision without introducing a second authorization or cache
+implementation.
+
+## Incident scenario
+
+The source-ready test is
+`apps/server/tests/rbac_policy_incident_trace.rs`.
+
+1. A tenant user receives the canonical Admin role and the normal RBAC resolver warms
+   a permission snapshot for `settings:manage`.
+2. One transaction deletes the user's role relation and reserves the next durable RBAC
+   invalidation generation.
+3. The transaction commits, but the normal local/Redis publisher is intentionally not
+   called. This represents a missed post-commit publication rather than a rollback or
+   an invalid relation write.
+4. Before the five-second durable-generation watchdog poll, the canonical evaluator
+   observes the stale cache hit and still allows `settings:manage`.
+5. The test reads the authoritative relation-backed permission set and records that it
+   no longer grants the required permission.
+6. The durable generation remains ahead of the process-applied generation.
+7. The existing watchdog observes `generation_advanced`, performs the existing
+   process-wide permission snapshot clear, advances the applied checkpoint, and
+   increments the bounded recovery and full-clear counters.
+8. The canonical evaluator resolves again and denies the permission from authoritative
+   relations.
+
+## Packet fields
+
+The emitted `rbac policy incident packet` event contains only bounded diagnostic facts:
+
+- a per-run incident UUID;
+- tenant and user identifiers already used by RBAC decision diagnostics;
+- required permission identifier;
+- evaluator result before and after recovery;
+- authoritative assigned-role and permission counts plus a required-permission boolean;
+- cache-hit boolean and cached permission count, never the complete permission list;
+- durable and applied generation values;
+- the closed recovery action `generation_advanced_full_clear`;
+- recovery and full-clear counter deltas.
+
+Passwords, bearer tokens, OAuth secrets, session identifiers, raw cache keys, and full
+permission or relation lists are not written to the packet.
+
+## Ownership and boundaries
+
+- `rustok-rbac` remains the relation and generation-store owner.
+- `apps/server` continues to compose the canonical resolver, Moka cache, and watchdog.
+- `rustok-telemetry` continues to own the bounded generation/recovery metrics.
+- The test does not call the invalidation publisher, manually clear the cache, create a
+  second evaluator, or normalize the durable/applied generation gap.
+- The only recovery actor is the existing durable-generation watchdog.
+
+## Source evidence
+
+Machine-readable source evidence is recorded at
+`crates/rustok-rbac/contracts/evidence/rbac-policy-incident-trace-source.json`.
+The focused source guard is
+`scripts/verify/verify-rbac-policy-incident-trace.mjs`.
+
+## Execution
+
+Targeted maintainer commands:
+
+```bash
+cargo test -p rustok-server --test rbac_policy_incident_trace -- --nocapture
+node scripts/verify/verify-rbac-policy-incident-trace.mjs
+```
+
+The test should be retained with its `rbac policy incident packet` log output on the
+same revision. The source file and evidence JSON do not claim that PostgreSQL, Rust,
+Node, formatting, workflows, or CI have run. The broader `core/rbac` cursor remains
+`in_progress` until its compile, concurrency, multi-replica Redis, management-flow,
+and FFA/FBA gates are satisfied.

--- a/scripts/verify/verify-rbac-policy-incident-trace.mjs
+++ b/scripts/verify/verify-rbac-policy-incident-trace.mjs
@@ -24,6 +24,7 @@ const files = {
   runtime: "apps/server/src/services/rbac_runtime.rs",
   generation: "apps/server/src/services/rbac_invalidation_generation.rs",
   metrics: "crates/rustok-telemetry/src/rbac_invalidation_metrics.rs",
+  testDb: "crates/rustok-test-utils/src/db.rs",
   evidence:
     "crates/rustok-rbac/contracts/evidence/rbac-policy-incident-trace-source.json",
   docs: "crates/rustok-rbac/docs/policy-incident-trace.md",
@@ -38,6 +39,7 @@ const sources = Object.fromEntries(
 for (const marker of [
   "struct RbacPolicyIncidentPacket",
   "missed_publication_incident_connects_decision_relations_cache_generation_and_recovery",
+  "setup_test_db_with_migrations::<Migrator>()",
   "RbacRoleAssignmentDbWriter::new(db.clone())",
   "replace_user_role_committed",
   "assert!(initial_generation > 0)",
@@ -102,17 +104,28 @@ for (const marker of [
   "RBAC_INVALIDATION_FULL_CLEARS_TOTAL",
 ]) requireText(sources.metrics, marker, `${files.metrics}: bounded metrics`);
 
+for (const marker of [
+  "Sets up a test database with specific migrations.",
+  '"sqlite:file:rustok_test_{}?mode=memory&cache=shared"',
+  "opts.max_connections(1)",
+]) requireText(sources.testDb, marker, `${files.testDb}: SQLite fixture`);
+
 const evidence = JSON.parse(sources.evidence);
 const evidenceChecks = [
   [evidence.status === "source_ready_unvalidated", "status must remain source_ready_unvalidated"],
   [evidence.cycle === "cycle-001", "cycle must remain cycle-001"],
   [evidence.component === "core/rbac", "component must remain core/rbac"],
+  [evidence.fixture_backend === "sqlite_in_memory", "fixture backend must remain in-memory SQLite"],
+  [evidence.postgresql_evidence === false, "PostgreSQL evidence must not be claimed"],
+  [evidence.multi_replica_evidence === false, "multi-replica evidence must not be claimed"],
   [evidence.failure_injection?.publisher_intentionally_not_called === true, "publisher omission must be explicit"],
   [evidence.failure_injection?.watchdog_is_the_recovery_actor === true, "watchdog must remain the recovery actor"],
   [evidence.failure_injection?.manual_test_only_cache_clear === false, "manual cache clear must remain forbidden"],
   [evidence.packet_contract?.raw_permission_list_logged === false, "raw permission lists must not be logged"],
   [evidence.validation?.rust_test_executed === false, "Rust execution must not be claimed"],
   [evidence.validation?.source_verifier_executed === false, "source verifier execution must not be claimed"],
+  [evidence.validation?.sqlite_runtime_executed === false, "SQLite execution must not be claimed"],
+  [evidence.validation?.postgresql_runtime_executed === false, "PostgreSQL execution must not be claimed"],
   [evidence.broad_rbac_verification_complete === false, "broad RBAC verification must remain open"],
   [evidence.cursor_advanced === false, "cursor must not advance"],
 ];
@@ -122,11 +135,14 @@ for (const [passed, message] of evidenceChecks) {
 
 for (const marker of [
   "dedicated integration scenario",
+  "single-connection in-memory SQLite database",
+  "It is not PostgreSQL",
   "missed post-commit publication",
   "generation_advanced_full_clear",
   "The only recovery actor is the existing durable-generation watchdog.",
+  "does not replace retained real-PostgreSQL concurrency",
   "The source file and evidence JSON do not claim",
-  "core/rbac` cursor remains",
+  "core/rbac` cursor",
 ]) requireText(sources.docs, marker, `${files.docs}: incident contract`);
 
 for (const marker of [
@@ -149,5 +165,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "✔ one source-ready RBAC policy incident packet connects evaluator, relation truth, stale cache, durable generation, watchdog recovery, and final denial",
+  "✔ one source-ready SQLite RBAC policy incident packet connects evaluator, relation truth, stale cache, durable generation, watchdog recovery, and final denial without claiming PostgreSQL or multi-replica evidence",
 );

--- a/scripts/verify/verify-rbac-policy-incident-trace.mjs
+++ b/scripts/verify/verify-rbac-policy-incident-trace.mjs
@@ -39,6 +39,8 @@ for (const marker of [
   "struct RbacPolicyIncidentPacket",
   "missed_publication_incident_connects_decision_relations_cache_generation_and_recovery",
   "RbacRoleAssignmentDbWriter::new(db.clone())",
+  "replace_user_role_committed",
+  "assert!(initial_generation > 0)",
   "RbacService::has_permission",
   "RbacService::get_user_permissions_authoritative",
   "RbacService::get_user_permissions",
@@ -50,6 +52,7 @@ for (const marker of [
   "RBAC_INVALIDATION_FULL_CLEARS_TOTAL",
   'recovery_action: "generation_advanced_full_clear"',
   '"rbac policy incident packet"',
+  'println!("rbac policy incident packet: {packet:?}")',
   "assert!(!packet.evaluator_allowed_after_recovery)",
 ]) requireText(sources.packet, marker, `${files.packet}: packet scenario`);
 
@@ -122,17 +125,16 @@ for (const marker of [
   "missed post-commit publication",
   "generation_advanced_full_clear",
   "The only recovery actor is the existing durable-generation watchdog.",
-  "do not claim that PostgreSQL, Rust, Node, formatting, workflows, or CI have run",
+  "The source file and evidence JSON do not claim",
   "core/rbac` cursor remains",
 ]) requireText(sources.docs, marker, `${files.docs}: incident contract`);
 
 for (const marker of [
   "### P1. Invalidation observability and incident operations",
-  "policy incident",
-  "rbac_policy_incident_trace",
-  "source_ready_unvalidated",
+  "Make one policy incident traceable",
+  "Retain one real or dedicated integration incident packet",
   "Status: `in_progress`",
-]) requireText(sources.plan, marker, `${files.plan}: owner handoff`);
+]) requireText(sources.plan, marker, `${files.plan}: open owner gate`);
 
 for (const marker of [
   "Current item: `core/rbac`",

--- a/scripts/verify/verify-rbac-policy-incident-trace.mjs
+++ b/scripts/verify/verify-rbac-policy-incident-trace.mjs
@@ -45,7 +45,7 @@ for (const marker of [
   "RbacService::get_user_permissions_authoritative",
   "RbacService::get_user_permissions",
   "reserve_permission_invalidation_generation(&transaction)",
-  "transaction.commit()",
+  "commit relation mutation and durable generation",
   "durable_generation > applied_generation_before",
   "permission_cache_hits + 1",
   "RBAC_INVALIDATION_RECOVERIES_TOTAL",

--- a/scripts/verify/verify-rbac-policy-incident-trace.mjs
+++ b/scripts/verify/verify-rbac-policy-incident-trace.mjs
@@ -137,7 +137,7 @@ for (const marker of [
 for (const marker of [
   "Current item: `core/rbac`",
   "Next item: `core/rbac`",
-  "policy incident",
+  "one complete incident trace",
 ]) requireText(sources.master, marker, `${files.master}: active cursor`);
 
 if (failures.length > 0) {

--- a/scripts/verify/verify-rbac-policy-incident-trace.mjs
+++ b/scripts/verify/verify-rbac-policy-incident-trace.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+const files = {
+  packet: "apps/server/tests/rbac_policy_incident_trace.rs",
+  service: "apps/server/src/services/rbac_service.rs",
+  authoritative: "apps/server/src/services/rbac_authoritative.rs",
+  runtime: "apps/server/src/services/rbac_runtime.rs",
+  generation: "apps/server/src/services/rbac_invalidation_generation.rs",
+  metrics: "crates/rustok-telemetry/src/rbac_invalidation_metrics.rs",
+  evidence:
+    "crates/rustok-rbac/contracts/evidence/rbac-policy-incident-trace-source.json",
+  docs: "crates/rustok-rbac/docs/policy-incident-trace.md",
+  plan: "crates/rustok-rbac/docs/implementation-plan.md",
+  master: "docs/verification/PLATFORM_VERIFICATION_PLAN.md",
+};
+
+const sources = Object.fromEntries(
+  Object.entries(files).map(([name, relativePath]) => [name, read(relativePath)]),
+);
+
+for (const marker of [
+  "struct RbacPolicyIncidentPacket",
+  "missed_publication_incident_connects_decision_relations_cache_generation_and_recovery",
+  "RbacRoleAssignmentDbWriter::new(db.clone())",
+  "RbacService::has_permission",
+  "RbacService::get_user_permissions_authoritative",
+  "RbacService::get_user_permissions",
+  "reserve_permission_invalidation_generation(&transaction)",
+  "transaction.commit()",
+  "durable_generation > applied_generation_before",
+  "permission_cache_hits + 1",
+  "RBAC_INVALIDATION_RECOVERIES_TOTAL",
+  "RBAC_INVALIDATION_FULL_CLEARS_TOTAL",
+  'recovery_action: "generation_advanced_full_clear"',
+  '"rbac policy incident packet"',
+  "assert!(!packet.evaluator_allowed_after_recovery)",
+]) requireText(sources.packet, marker, `${files.packet}: packet scenario`);
+
+for (const forbidden of [
+  "publish_user_rbac_invalidation(",
+  "publish_all_rbac_invalidation(",
+  "invalidate_all_user_permissions_cache(",
+  "invalidate_user_permissions_cache(",
+  "password_hash =",
+  "access_token =",
+  "bearer =",
+]) forbidText(sources.packet, forbidden, `${files.packet}: injected shortcut or secret`);
+
+for (const marker of [
+  "rbac resolver decision (single permission check)",
+  "permissions_count",
+  "cache_hit",
+  "allowed",
+]) requireText(sources.service, marker, `${files.service}: canonical evaluator`);
+
+for (const marker of [
+  "get_user_permissions_authoritative",
+  "user_belongs_to_tenant",
+  "user_roles::Entity::find()",
+  "role_permissions::Entity::find()",
+  "permissions::Entity::find()",
+]) requireText(sources.authoritative, marker, `${files.authoritative}: relation truth`);
+
+for (const marker of [
+  "CachedPermissionSnapshot",
+  "PermissionCacheLookup",
+  "permission_cache_hits",
+  "invalidate_all_user_permissions_cache",
+]) requireText(sources.runtime, marker, `${files.runtime}: cache snapshot`);
+
+for (const marker of [
+  "read_rbac_invalidation_generation",
+  '"generation_advanced"',
+  "invalidate_all_user_permissions_cache().await",
+  "state.observe_applied(generation)",
+]) requireText(sources.generation, marker, `${files.generation}: durable recovery`);
+
+for (const marker of [
+  "RBAC_INVALIDATION_DURABLE_GENERATION",
+  "RBAC_INVALIDATION_APPLIED_GENERATION",
+  "RBAC_INVALIDATION_RECOVERIES_TOTAL",
+  "RBAC_INVALIDATION_FULL_CLEARS_TOTAL",
+]) requireText(sources.metrics, marker, `${files.metrics}: bounded metrics`);
+
+const evidence = JSON.parse(sources.evidence);
+const evidenceChecks = [
+  [evidence.status === "source_ready_unvalidated", "status must remain source_ready_unvalidated"],
+  [evidence.cycle === "cycle-001", "cycle must remain cycle-001"],
+  [evidence.component === "core/rbac", "component must remain core/rbac"],
+  [evidence.failure_injection?.publisher_intentionally_not_called === true, "publisher omission must be explicit"],
+  [evidence.failure_injection?.watchdog_is_the_recovery_actor === true, "watchdog must remain the recovery actor"],
+  [evidence.failure_injection?.manual_test_only_cache_clear === false, "manual cache clear must remain forbidden"],
+  [evidence.packet_contract?.raw_permission_list_logged === false, "raw permission lists must not be logged"],
+  [evidence.validation?.rust_test_executed === false, "Rust execution must not be claimed"],
+  [evidence.validation?.source_verifier_executed === false, "source verifier execution must not be claimed"],
+  [evidence.broad_rbac_verification_complete === false, "broad RBAC verification must remain open"],
+  [evidence.cursor_advanced === false, "cursor must not advance"],
+];
+for (const [passed, message] of evidenceChecks) {
+  if (!passed) failures.push(`${files.evidence}: ${message}`);
+}
+
+for (const marker of [
+  "dedicated integration scenario",
+  "missed post-commit publication",
+  "generation_advanced_full_clear",
+  "The only recovery actor is the existing durable-generation watchdog.",
+  "do not claim that PostgreSQL, Rust, Node, formatting, workflows, or CI have run",
+  "core/rbac` cursor remains",
+]) requireText(sources.docs, marker, `${files.docs}: incident contract`);
+
+for (const marker of [
+  "### P1. Invalidation observability and incident operations",
+  "policy incident",
+  "rbac_policy_incident_trace",
+  "source_ready_unvalidated",
+  "Status: `in_progress`",
+]) requireText(sources.plan, marker, `${files.plan}: owner handoff`);
+
+for (const marker of [
+  "Current item: `core/rbac`",
+  "Next item: `core/rbac`",
+  "policy incident",
+]) requireText(sources.master, marker, `${files.master}: active cursor`);
+
+if (failures.length > 0) {
+  console.error("RBAC policy incident trace verification failed:");
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "✔ one source-ready RBAC policy incident packet connects evaluator, relation truth, stale cache, durable generation, watchdog recovery, and final denial",
+);


### PR DESCRIPTION
## Cycle scope

Continue `cycle-001` at the active `core/rbac` cursor without advancing or completing the component.

## Summary

- add one source-ready integration packet for a missed committed RBAC invalidation publication
- warm the canonical evaluator/cache, commit relation deletion plus the next durable generation, and intentionally omit the publisher
- capture the stale allow decision, authoritative relation counts, cache-hit facts, durable/applied generation gap, existing watchdog recovery/full-clear counters, and final deny decision
- use only the production `RbacService`, relation resolver, permission cache, durable generation store, watchdog, and telemetry primitives
- emit bounded packet facts without raw permission/relation lists, credentials, tokens, sessions, or cache keys
- add machine-readable source evidence, operator-facing documentation, and a focused fail-closed source guard

## Evidence boundary

The fixture uses `setup_test_db_with_migrations` and is therefore single-connection in-memory SQLite. It is **not** PostgreSQL concurrency evidence, multi-replica evidence, or Redis transport evidence. The evidence remains `source_ready_unvalidated`; all runtime and execution flags remain false.

The canonical RBAC plan and master cursor remain open: `Current item` and `Next item` stay `core/rbac`, and the retained incident trace, PostgreSQL concurrency, multi-replica Redis recovery, compile/test, management-flow, and FFA/FBA gates remain outstanding.

## Validation

No Rust tests, Node verifiers, formatting, Cargo checks, PostgreSQL, SQLite runtime execution, Redis, workflows, or CI were run in this connector-only work unit.

Targeted maintainer commands:

```bash
cargo test -p rustok-server --test rbac_policy_incident_trace -- --nocapture
node scripts/verify/verify-rbac-policy-incident-trace.mjs
```

Branch: `agent/rbac-policy-incident-trace-cycle-001-20260801`
Original branch base: `3a9304aead372b22a5d9069143922d23934e4d7c`
Current `main` contains two later non-overlapping Blog/Forum commits.