### PR TITLE
test(forum): add complete LINK evidence review gate

### DIFF
--- a/crates/rustok-forum/contracts/forum-search-link-forum-03-complete-evidence-promotion.json
+++ b/crates/rustok-forum/contracts/forum-search-link-forum-03-complete-evidence-promotion.json
@@ -1,0 +1,73 @@
+{
+  "contract": "forum_search_link_forum_03_complete_evidence_promotion_v1",
+  "task": "FORUM-23B2G2B3D18",
+  "target_link": "LINK-FORUM-03",
+  "status": "source_ready_maintainer_execution_pending",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "complete_assembler_contract": "crates/rustok-forum/contracts/forum-search-link-forum-03-complete-evidence-assembler.json",
+  "complete_artifact": "target/link-forum-03-forum-index-search-complete-evidence.json",
+  "reviewer": "scripts/evidence/review-link-forum-03-complete-forum-search-evidence.mjs",
+  "verifier": "scripts/verify/verify-link-forum-03-complete-forum-search-evidence-promotion.mjs",
+  "promotion_candidate": {
+    "path": "target/link-forum-03-forum-index-search-complete-promotion-candidate.json",
+    "generation": "reviewer_only_after_complete_artifact_and_source_revalidation",
+    "hand_editing_forbidden": true,
+    "source_commit_required": true,
+    "atomic_replace": true,
+    "automatic_canonical_source_mutation": false
+  },
+  "required_attestations": [
+    "RUSTOK_LINK_FORUM_03_EVIDENCE_REVIEWER",
+    "RUSTOK_LINK_FORUM_03_EVIDENCE_RETENTION_REF",
+    "RUSTOK_LINK_FORUM_03_EVIDENCE_RETAINED_SHA256"
+  ],
+  "required_scenarios": [
+    "normal_delivery",
+    "deletion_acl_ordering",
+    "search_disabled_profile",
+    "translation_and_moderation_approval",
+    "private_and_trusted_channel_exclusion",
+    "topic_move_category_scope"
+  ],
+  "required_source_artifacts": [
+    "target/link-forum-03-forum-index-search-ordering-visibility-evidence.json",
+    "target/forum-search-link-forum-03-translation-moderation-evidence.json",
+    "target/forum-search-link-forum-03-private-trusted-exclusion-evidence.json",
+    "target/forum-search-link-forum-03-topic-move-evidence.json"
+  ],
+  "fail_closed_requirements": [
+    "the canonical Forum plan still records FORUM-21 planned FORUM-23 in_progress and LINK-FORUM-03 planned before review",
+    "the D17 contract remains source_ready_maintainer_execution_pending and points to the exact complete artifact reviewer verifier and scenario order",
+    "the complete artifact has exact contract task source slice status coverage source commit and six canonical scenarios",
+    "the complete artifact source commit equals git rev-parse HEAD and every retained source artifact reports the same commit",
+    "the reviewed D13 core lineage remains present and D18 does not claim to authenticate the inherited external retention service",
+    "the exact D13 D14 D15 and D16 source artifact bytes match the complete artifact SHA-256 byte length generated time source commit and scenario metadata",
+    "the complete scenario facts equal the exact retained source scenario facts and remain non-empty",
+    "the complete artifact records independent review and retention as false before D18 review",
+    "the reviewer identity and retention reference are bounded non-empty values without control characters",
+    "the maintainer-supplied retained SHA-256 equals the exact complete artifact digest",
+    "the promotion candidate records exact D17 contract complete artifact canonical plan and source artifact digests",
+    "the promotion candidate is written only after complete validation by same-directory atomic rename",
+    "the reviewer accepts no arguments overrides missing-artifact mode skipped results or static fallback",
+    "the reviewer never edits the canonical plan D17 artifact FORUM-21 FORUM-23 or LINK-FORUM-03 status"
+  ],
+  "proposed_transition": {
+    "task": "LINK-FORUM-03",
+    "from": "planned",
+    "to": "done",
+    "requires_separate_canonical_source_pull_request": true,
+    "canonical_source_mutated_by_reviewer": false,
+    "promotes_forum_21": false,
+    "promotes_forum_23": false
+  },
+  "maintainer_command": "RUSTOK_LINK_FORUM_03_EVIDENCE_REVIEWER=\"<reviewer>\" RUSTOK_LINK_FORUM_03_EVIDENCE_RETENTION_REF=\"<immutable-retention-reference>\" RUSTOK_LINK_FORUM_03_EVIDENCE_RETAINED_SHA256=\"<complete-artifact-sha256>\" node scripts/evidence/review-link-forum-03-complete-forum-search-evidence.mjs",
+  "non_claims": [
+    "this source-ready gate does not claim that D13 D14 D15 D16 D17 or any runtime command ran",
+    "this gate does not retrieve or independently authenticate an external retention service",
+    "this gate records an explicit retained-digest attestation but does not sign it cryptographically",
+    "this gate does not automatically edit or promote the canonical Forum plan",
+    "this gate does not promote the independent FORUM-21 owner task",
+    "this gate does not mark FORUM-23 done",
+    "a generated promotion candidate supports but does not itself perform the LINK-FORUM-03 canonical transition"
+  ]
+}

--- a/crates/rustok-forum/docs/forum-23b2g2b3d18-complete-link-evidence-promotion.md
+++ b/crates/rustok-forum/docs/forum-23b2g2b3d18-complete-link-evidence-promotion.md
@@ -1,0 +1,154 @@
+# FORUM-23B2G2B3D18 complete LINK-FORUM-03 evidence promotion
+
+## Status
+
+`source_ready_maintainer_execution_pending`
+
+D18 adds the independent maintainer review and retention boundary for the complete
+runtime artifact assembled by D17. It does not execute Forum, Search, PostgreSQL,
+Iggy or storefront code and does not edit the canonical Forum plan.
+
+The machine contract is:
+
+```text
+crates/rustok-forum/contracts/forum-search-link-forum-03-complete-evidence-promotion.json
+```
+
+The reviewer is:
+
+```text
+scripts/evidence/review-link-forum-03-complete-forum-search-evidence.mjs
+```
+
+The generated promotion candidate is:
+
+```text
+target/link-forum-03-forum-index-search-complete-promotion-candidate.json
+```
+
+## Review boundary
+
+D17 can assemble complete canonical runtime coverage, but its output explicitly
+records:
+
+```text
+status = complete_runtime_evidence_assembled_review_pending
+complete_artifact_independently_reviewed = false
+complete_artifact_retention_attested = false
+status_change_allowed_from_this_artifact = false
+```
+
+D18 is the separate review gate. It requires an explicit reviewer identity, an
+immutable retention reference and the exact SHA-256 of the retained complete
+artifact. It does not retrieve the retention object, authenticate an external
+retention service or create a cryptographic signature.
+
+## Required retained artifacts
+
+All files must be generated on the same checked-out commit:
+
+```text
+target/link-forum-03-forum-index-search-complete-evidence.json
+target/link-forum-03-forum-index-search-ordering-visibility-evidence.json
+target/forum-search-link-forum-03-translation-moderation-evidence.json
+target/forum-search-link-forum-03-private-trusted-exclusion-evidence.json
+target/forum-search-link-forum-03-topic-move-evidence.json
+```
+
+Missing artifacts, skipped results, copied fixtures, hand-edited JSON and
+mixed-commit artifacts are rejected.
+
+## Fail-closed validation
+
+Before writing a promotion candidate, the reviewer checks:
+
+1. the D18 and D17 machine contracts have exact identities, pending source
+   statuses, paths and scenario order;
+2. the canonical plan still records `FORUM-21` as `planned`, `FORUM-23` as
+   `in_progress` and `LINK-FORUM-03` as `planned`;
+3. the complete D17 artifact has exact contract, source slice, review-pending
+   status, canonical runtime coverage and current `HEAD`;
+4. all six canonical scenarios exist in exact order;
+5. D13 remains the partial reviewed core with exact inherited D12 reviewer and
+   retention lineage;
+6. D13 core scenario entries preserve their original D8, D9 and D10 source
+   attribution rather than being rewritten as D13-owned runtime facts;
+7. D14, D15 and D16 have exact task, contract, current source commit,
+   PostgreSQL backend, no-broker profile, passed scenario and non-empty facts;
+8. every source artifact's exact SHA-256, byte length, generation time, source
+   commit and scenario metadata match the D17 retained records;
+9. every complete-artifact scenario fact equals its exact retained source fact;
+10. D17 still records independent review and retention as false and forbids
+    automatic canonical transition;
+11. the maintainer-supplied retained digest equals the exact complete artifact
+    bytes;
+12. the candidate is written only after validation by same-directory atomic
+    rename.
+
+The reviewer accepts no command-line arguments or source-commit overrides.
+
+## Promotion candidate
+
+A successful review writes:
+
+```text
+contract = link_forum_03_forum_index_search_complete_promotion_candidate_v1
+status = approved_for_canonical_status_promotion
+```
+
+The candidate records:
+
+- reviewer identity and review time;
+- retention reference and attested complete-artifact digest;
+- exact D17 and D18 contract digests;
+- exact complete artifact digest, length, generation time and six scenarios;
+- exact canonical plan digest and statuses at review time;
+- exact metadata for D13 through D16 retained artifacts;
+- inherited D13/D12 core-retention lineage;
+- complete revalidation assertions;
+- the proposed canonical transition.
+
+## Canonical transition boundary
+
+The proposed transition is limited to:
+
+```text
+LINK-FORUM-03: planned -> done
+```
+
+It requires a separate canonical-source pull request. The reviewer does not edit
+the plan. The candidate explicitly records:
+
+```text
+promotes_forum_21 = false
+promotes_forum_23 = false
+canonical_source_mutated_by_reviewer = false
+```
+
+`FORUM-21` remains an independent owner-workflow task and `FORUM-23` retains
+broader unfinished Search product scope.
+
+## Maintainer command
+
+After generating and immutably retaining the complete D17 artifact, run:
+
+```bash
+RUSTOK_LINK_FORUM_03_EVIDENCE_REVIEWER="<reviewer>" \
+RUSTOK_LINK_FORUM_03_EVIDENCE_RETENTION_REF="<immutable-retention-reference>" \
+RUSTOK_LINK_FORUM_03_EVIDENCE_RETAINED_SHA256="<complete-artifact-sha256>" \
+node scripts/evidence/review-link-forum-03-complete-forum-search-evidence.mjs
+```
+
+The retained SHA must be the lowercase SHA-256 of the exact bytes at:
+
+```text
+target/link-forum-03-forum-index-search-complete-evidence.json
+```
+
+## Deliberate boundary
+
+D18 adds a contract, reviewer, verifier and handoff only. It changes no Rust
+production code, migration, transport, event schema, runtime flag, dependency,
+`Cargo.toml`, `Cargo.lock`, D0-D17 artifact schema or canonical task status.
+
+No command above was run by the implementation agent, per maintainer request.

--- a/scripts/evidence/review-link-forum-03-complete-forum-search-evidence.mjs
+++ b/scripts/evidence/review-link-forum-03-complete-forum-search-evidence.mjs
@@ -1,0 +1,520 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const root = process.cwd();
+const contractPath =
+  "crates/rustok-forum/contracts/forum-search-link-forum-03-complete-evidence-promotion.json";
+const d17ContractPath =
+  "crates/rustok-forum/contracts/forum-search-link-forum-03-complete-evidence-assembler.json";
+const planPath = "crates/rustok-forum/docs/implementation-plan.md";
+const completePath =
+  "target/link-forum-03-forum-index-search-complete-evidence.json";
+const candidatePath =
+  "target/link-forum-03-forum-index-search-complete-promotion-candidate.json";
+const reviewerEnv = "RUSTOK_LINK_FORUM_03_EVIDENCE_REVIEWER";
+const retentionRefEnv = "RUSTOK_LINK_FORUM_03_EVIDENCE_RETENTION_REF";
+const retainedShaEnv = "RUSTOK_LINK_FORUM_03_EVIDENCE_RETAINED_SHA256";
+
+const scenarioIds = [
+  "normal_delivery",
+  "deletion_acl_ordering",
+  "search_disabled_profile",
+  "translation_and_moderation_approval",
+  "private_and_trusted_channel_exclusion",
+  "topic_move_category_scope",
+];
+const d13StoredScenarioIds = [
+  "deletion_acl_ordering",
+  "search_disabled_profile",
+  "normal_delivery",
+];
+const sourceSpecs = [
+  {
+    kind: "core",
+    path: "target/link-forum-03-forum-index-search-ordering-visibility-evidence.json",
+    contract: "link_forum_03_forum_index_search_ordering_visibility_evidence_v1",
+    task: "LINK-FORUM-03",
+    sourceSlice: "FORUM-23B2G2B3D13",
+    scenarios: scenarioIds.slice(0, 3),
+    retainedScenarios: d13StoredScenarioIds,
+  },
+  {
+    kind: "extension",
+    path: "target/forum-search-link-forum-03-translation-moderation-evidence.json",
+    contract: "forum_search_link_forum_03_translation_moderation_evidence_v1",
+    task: "FORUM-23B2G2B3D14",
+    scenarios: ["translation_and_moderation_approval"],
+  },
+  {
+    kind: "extension",
+    path: "target/forum-search-link-forum-03-private-trusted-exclusion-evidence.json",
+    contract: "forum_search_link_forum_03_private_trusted_exclusion_proof_v1",
+    task: "FORUM-23B2G2B3D15",
+    scenarios: ["private_and_trusted_channel_exclusion"],
+  },
+  {
+    kind: "extension",
+    path: "target/forum-search-link-forum-03-topic-move-evidence.json",
+    contract: "forum_search_link_forum_03_topic_move_evidence_v1",
+    task: "FORUM-23B2G2B3D16",
+    scenarios: ["topic_move_category_scope"],
+  },
+];
+
+function fail(message) {
+  throw new Error(`LINK-FORUM-03 complete evidence review failed: ${message}`);
+}
+function readBytes(path) {
+  try {
+    return readFileSync(resolve(root, path));
+  } catch (error) {
+    fail(`cannot read ${path}: ${error.message}`);
+  }
+}
+function parseJson(path, bytes = readBytes(path)) {
+  try {
+    return JSON.parse(bytes.toString("utf8"));
+  } catch (error) {
+    fail(`${path} is not valid JSON: ${error.message}`);
+  }
+}
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+function requireObject(value, label) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+}
+function requireString(value, label) {
+  if (typeof value !== "string" || value.trim() === "") {
+    fail(`${label} must be a non-empty string`);
+  }
+}
+function requireFacts(value, label) {
+  requireObject(value, label);
+  if (Object.keys(value).length === 0) fail(`${label} must not be empty`);
+}
+function requireCommit(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{40}$/.test(value)) {
+    fail(`${label} must be one lowercase forty-character Git commit SHA`);
+  }
+}
+function requireDigest(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/.test(value)) {
+    fail(`${label} must be one lowercase SHA-256 digest`);
+  }
+}
+function requireTimestamp(value, label) {
+  requireString(value, label);
+  if (!Number.isFinite(Date.parse(value))) fail(`${label} must be an ISO timestamp`);
+}
+function exactArray(actual, expected, label) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    fail(`${label} order or membership drifted`);
+  }
+}
+function exactJson(actual, expected, label) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) fail(`${label} drifted`);
+}
+function boundedEnv(name, minimum, maximum) {
+  const value = process.env[name];
+  if (typeof value !== "string") fail(`${name} must be set`);
+  if (value.trim() !== value || value.length < minimum || value.length > maximum) {
+    fail(`${name} must contain ${minimum}..${maximum} characters without surrounding whitespace`);
+  }
+  if (value.split("").some((character) => /[\u0000-\u001f\u007f]/.test(character))) {
+    fail(`${name} must not contain control characters`);
+  }
+  return value;
+}
+function currentHead() {
+  let value;
+  try {
+    value = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (error) {
+    fail(`git rev-parse HEAD failed: ${error.message}`);
+  }
+  requireCommit(value, "git rev-parse HEAD");
+  return value;
+}
+
+function validateReviewContract(contract) {
+  requireObject(contract, "D18 machine contract");
+  if (
+    contract.contract !== "forum_search_link_forum_03_complete_evidence_promotion_v1" ||
+    contract.task !== "FORUM-23B2G2B3D18" ||
+    contract.target_link !== "LINK-FORUM-03" ||
+    contract.status !== "source_ready_maintainer_execution_pending" ||
+    contract.complete_assembler_contract !== d17ContractPath ||
+    contract.complete_artifact !== completePath ||
+    contract.reviewer !== "scripts/evidence/review-link-forum-03-complete-forum-search-evidence.mjs" ||
+    contract.promotion_candidate?.path !== candidatePath
+  ) {
+    fail("D18 machine contract identity or path drifted");
+  }
+  exactArray(contract.required_scenarios, scenarioIds, "D18 required scenarios");
+  exactArray(
+    contract.required_source_artifacts,
+    sourceSpecs.map(({ path }) => path),
+    "D18 source artifacts",
+  );
+  exactArray(
+    contract.required_attestations,
+    [reviewerEnv, retentionRefEnv, retainedShaEnv],
+    "D18 attestations",
+  );
+  if (
+    contract.proposed_transition?.task !== "LINK-FORUM-03" ||
+    contract.proposed_transition?.from !== "planned" ||
+    contract.proposed_transition?.to !== "done" ||
+    contract.proposed_transition?.requires_separate_canonical_source_pull_request !== true ||
+    contract.proposed_transition?.canonical_source_mutated_by_reviewer !== false ||
+    contract.proposed_transition?.promotes_forum_21 !== false ||
+    contract.proposed_transition?.promotes_forum_23 !== false
+  ) {
+    fail("D18 proposed transition boundary drifted");
+  }
+}
+
+function validateD17Contract(contract) {
+  requireObject(contract, "D17 machine contract");
+  if (
+    contract.contract !== "forum_search_link_forum_03_complete_evidence_assembler_v1" ||
+    contract.task !== "FORUM-23B2G2B3D17" ||
+    contract.status !== "source_ready_maintainer_execution_pending" ||
+    contract.coverage !== "complete_canonical_runtime_scope_review_pending" ||
+    contract.output_artifact?.path !== completePath ||
+    contract.output_artifact?.status !== "complete_runtime_evidence_assembled_review_pending" ||
+    contract.output_artifact?.automatic_canonical_source_mutation !== false
+  ) {
+    fail("D17 machine contract identity or boundary drifted");
+  }
+  exactArray(contract.required_scenarios, scenarioIds, "D17 required scenarios");
+  exactArray(
+    contract.required_inputs,
+    sourceSpecs.map(({ path }) => path),
+    "D17 required inputs",
+  );
+}
+
+function validatePlan(plan) {
+  for (const marker of [
+    "| `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |",
+    "| `FORUM-23` | `in_progress` |",
+    "| `LINK-FORUM-03` | `planned` | Forum/index/search ordering and visibility proof. |",
+  ]) {
+    if (!plan.includes(marker)) fail(`canonical plan is missing marker: ${marker}`);
+  }
+  if (plan.includes("| `LINK-FORUM-03` | `done` | Forum/index/search ordering and visibility proof. |")) {
+    fail("LINK-FORUM-03 was promoted before D18 review");
+  }
+}
+
+function validateSource(spec, head) {
+  const bytes = readBytes(spec.path);
+  const artifact = parseJson(spec.path, bytes);
+  requireObject(artifact, spec.path);
+  if (spec.kind === "core") {
+    if (
+      artifact.contract !== spec.contract ||
+      artifact.task !== spec.task ||
+      artifact.source_slice !== spec.sourceSlice ||
+      artifact.status !== "partial_runtime_evidence_assembled" ||
+      artifact.coverage !== "ordering_visibility_and_search_disabled_core_only" ||
+      artifact.source_commit !== head
+    ) {
+      fail(`${spec.path} identity status or source commit drifted`);
+    }
+    requireTimestamp(artifact.generated_at, `${spec.path}.generated_at`);
+    requireObject(artifact.selected_scenario_evidence, `${spec.path}.selected_scenario_evidence`);
+    exactArray(
+      Object.keys(artifact.selected_scenario_evidence),
+      spec.retainedScenarios,
+      `${spec.path} stored scenario order`,
+    );
+    for (const scenarioId of spec.retainedScenarios) {
+      const evidence = artifact.selected_scenario_evidence[scenarioId];
+      requireObject(evidence, `${spec.path}.${scenarioId}`);
+      requireString(evidence.source_task, `${spec.path}.${scenarioId}.source_task`);
+      requireString(evidence.source_contract, `${spec.path}.${scenarioId}.source_contract`);
+      requireString(evidence.source_artifact, `${spec.path}.${scenarioId}.source_artifact`);
+      requireDigest(evidence.source_sha256, `${spec.path}.${scenarioId}.source_sha256`);
+      requireFacts(evidence.facts, `${spec.path}.${scenarioId}.facts`);
+    }
+    requireObject(artifact.retained_lineage, `${spec.path}.retained_lineage`);
+    requireString(artifact.retained_lineage.reviewer, `${spec.path}.retained_lineage.reviewer`);
+    requireTimestamp(artifact.retained_lineage.reviewed_at, `${spec.path}.retained_lineage.reviewed_at`);
+    requireString(
+      artifact.retained_lineage.retention_reference,
+      `${spec.path}.retained_lineage.retention_reference`,
+    );
+    requireDigest(
+      artifact.retained_lineage.retained_aggregate_sha256,
+      `${spec.path}.retained_lineage.retained_aggregate_sha256`,
+    );
+    if (
+      artifact.retained_lineage.external_retention_authentication_performed_by_assembler !== false ||
+      artifact.canonical_transition?.status_change_allowed_from_this_artifact !== false
+    ) {
+      fail(`${spec.path} retention or canonical boundary drifted`);
+    }
+  } else {
+    if (
+      artifact.contract !== spec.contract ||
+      artifact.task !== spec.task ||
+      artifact.source_commit !== head ||
+      artifact.database_backend !== "postgresql" ||
+      artifact.broker_used !== false
+    ) {
+      fail(`${spec.path} identity runtime profile or source commit drifted`);
+    }
+    requireTimestamp(artifact.generated_at, `${spec.path}.generated_at`);
+    if (!Array.isArray(artifact.scenario_results)) {
+      fail(`${spec.path}.scenario_results must be an array`);
+    }
+    exactArray(
+      artifact.scenario_results.map(({ id }) => id),
+      spec.scenarios,
+      `${spec.path} scenarios`,
+    );
+    const scenario = artifact.scenario_results[0];
+    if (scenario.result !== "passed") fail(`${spec.path} scenario did not pass`);
+    requireFacts(scenario.facts, `${spec.path}.${scenario.id}.facts`);
+  }
+  return { spec, bytes, artifact, digest: sha256(bytes) };
+}
+
+function validateComplete(artifact, bytes, head, sources) {
+  requireObject(artifact, "D17 complete artifact");
+  if (
+    artifact.contract !== "link_forum_03_forum_index_search_complete_evidence_v1" ||
+    artifact.task !== "LINK-FORUM-03" ||
+    artifact.source_slice !== "FORUM-23B2G2B3D17" ||
+    artifact.status !== "complete_runtime_evidence_assembled_review_pending" ||
+    artifact.coverage !== "canonical_link_forum_03_runtime_scope" ||
+    artifact.source_commit !== head
+  ) {
+    fail("D17 complete artifact identity status or source commit drifted");
+  }
+  requireTimestamp(artifact.generated_at, "D17 complete artifact generated_at");
+  exactArray(artifact.assembled_scenario_ids, scenarioIds, "D17 assembled scenarios");
+  requireObject(artifact.scenario_evidence, "D17 scenario_evidence");
+  exactArray(Object.keys(artifact.scenario_evidence), scenarioIds, "D17 scenario order");
+  if (!Array.isArray(artifact.source_artifacts)) fail("D17 source_artifacts must be an array");
+  exactArray(
+    artifact.source_artifacts.map(({ path }) => path),
+    sourceSpecs.map(({ path }) => path),
+    "D17 source artifact order",
+  );
+
+  const sourceByPath = new Map(sources.map((source) => [source.spec.path, source]));
+  for (const retained of artifact.source_artifacts) {
+    const source = sourceByPath.get(retained.path);
+    if (!source) fail(`D17 retains unknown source ${retained.path}`);
+    if (
+      retained.sha256 !== source.digest ||
+      retained.byte_length !== source.bytes.length ||
+      retained.generated_at !== source.artifact.generated_at ||
+      retained.source_commit !== head
+    ) {
+      fail(`D17 source metadata drifted for ${retained.path}`);
+    }
+    if (source.spec.kind === "core") {
+      exactArray(
+        retained.scenario_ids,
+        source.spec.retainedScenarios,
+        `${retained.path} retained scenario_ids`,
+      );
+    } else if (
+      retained.task !== source.spec.task ||
+      retained.contract !== source.spec.contract ||
+      retained.database_backend !== "postgresql" ||
+      retained.broker_used !== false ||
+      retained.scenario_id !== source.spec.scenarios[0]
+    ) {
+      fail(`D17 extension metadata drifted for ${retained.path}`);
+    }
+  }
+
+  const core = sources[0];
+  for (const scenarioId of core.spec.scenarios) {
+    exactJson(
+      artifact.scenario_evidence[scenarioId],
+      core.artifact.selected_scenario_evidence[scenarioId],
+      `D17 core scenario ${scenarioId}`,
+    );
+  }
+  for (const source of sources.slice(1)) {
+    const scenarioId = source.spec.scenarios[0];
+    const sourceScenario = source.artifact.scenario_results[0];
+    const evidence = artifact.scenario_evidence[scenarioId];
+    requireObject(evidence, `D17 scenario ${scenarioId}`);
+    if (
+      evidence.source_task !== source.spec.task ||
+      evidence.source_contract !== source.spec.contract ||
+      evidence.source_artifact !== source.spec.path ||
+      evidence.source_sha256 !== source.digest
+    ) {
+      fail(`D17 extension attribution drifted for ${scenarioId}`);
+    }
+    exactJson(evidence.facts, sourceScenario.facts, `D17 extension facts ${scenarioId}`);
+  }
+
+  requireObject(artifact.reviewed_core_lineage, "D17 reviewed_core_lineage");
+  if (
+    artifact.reviewed_core_lineage.source_artifact !== core.spec.path ||
+    artifact.reviewed_core_lineage.source_sha256 !== core.digest ||
+    artifact.reviewed_core_lineage.external_retention_authentication_performed_by_d17 !== false
+  ) {
+    fail("D17 reviewed core lineage drifted");
+  }
+  exactJson(
+    artifact.reviewed_core_lineage.inherited_retained_lineage,
+    core.artifact.retained_lineage,
+    "D17 inherited retained lineage",
+  );
+  if (
+    artifact.assertions?.canonical_link_runtime_scope_assembled !== true ||
+    artifact.assertions?.complete_artifact_independently_reviewed !== false ||
+    artifact.assertions?.complete_artifact_retention_attested !== false ||
+    artifact.assertions?.canonical_source_mutated_by_assembler !== false ||
+    artifact.canonical_transition?.status_change_allowed_from_this_artifact !== false ||
+    artifact.canonical_transition?.separate_review_gate_required !== true ||
+    artifact.canonical_transition?.separate_canonical_source_pull_request_required !== true ||
+    artifact.canonical_transition?.closes_forum_21_automatically !== false ||
+    artifact.canonical_transition?.closes_forum_23_automatically !== false ||
+    artifact.canonical_transition?.closes_link_forum_03_automatically !== false
+  ) {
+    fail("D17 review or canonical boundary drifted");
+  }
+  return sha256(bytes);
+}
+
+if (process.argv.length !== 2) fail("this reviewer accepts no command-line arguments");
+const reviewer = boundedEnv(reviewerEnv, 3, 128);
+const retentionReference = boundedEnv(retentionRefEnv, 8, 2048);
+const retainedSha = boundedEnv(retainedShaEnv, 64, 64);
+requireDigest(retainedSha, retainedShaEnv);
+
+const head = currentHead();
+const contractBytes = readBytes(contractPath);
+validateReviewContract(parseJson(contractPath, contractBytes));
+const d17ContractBytes = readBytes(d17ContractPath);
+validateD17Contract(parseJson(d17ContractPath, d17ContractBytes));
+const planBytes = readBytes(planPath);
+validatePlan(planBytes.toString("utf8"));
+const sources = sourceSpecs.map((spec) => validateSource(spec, head));
+const completeBytes = readBytes(completePath);
+const completeArtifact = parseJson(completePath, completeBytes);
+const completeDigest = validateComplete(completeArtifact, completeBytes, head, sources);
+if (retainedSha !== completeDigest) {
+  fail(`${retainedShaEnv} does not equal the exact complete artifact digest`);
+}
+
+const candidate = {
+  contract: "link_forum_03_forum_index_search_complete_promotion_candidate_v1",
+  task: "FORUM-23B2G2B3D18",
+  target_link: "LINK-FORUM-03",
+  status: "approved_for_canonical_status_promotion",
+  source_commit: head,
+  reviewed_at: new Date().toISOString(),
+  reviewer,
+  retention: {
+    reference: retentionReference,
+    attested_sha256: retainedSha,
+    matches_reviewed_complete_artifact: true,
+    external_service_authentication_performed_by_script: false,
+    cryptographic_signature_created_by_script: false,
+  },
+  complete_artifact: {
+    path: completePath,
+    sha256: completeDigest,
+    byte_length: completeBytes.length,
+    generated_at: completeArtifact.generated_at,
+    status_at_review: completeArtifact.status,
+    coverage: completeArtifact.coverage,
+    scenario_ids: scenarioIds,
+  },
+  assembler_contract: {
+    path: d17ContractPath,
+    sha256: sha256(d17ContractBytes),
+    status_at_review: "source_ready_maintainer_execution_pending",
+  },
+  review_contract: {
+    path: contractPath,
+    sha256: sha256(contractBytes),
+    status_at_review: "source_ready_maintainer_execution_pending",
+  },
+  canonical_plan: {
+    path: planPath,
+    sha256: sha256(planBytes),
+    forum_21_status_at_review: "planned",
+    forum_23_status_at_review: "in_progress",
+    link_forum_03_status_at_review: "planned",
+  },
+  source_artifacts: sources.map(({ spec, artifact, bytes, digest }) => ({
+    path: spec.path,
+    task: spec.task,
+    contract: spec.contract,
+    source_commit: artifact.source_commit,
+    generated_at: artifact.generated_at,
+    sha256: digest,
+    byte_length: bytes.length,
+    scenario_ids: spec.scenarios,
+  })),
+  inherited_core_retention: {
+    source_artifact: sources[0].spec.path,
+    source_sha256: sources[0].digest,
+    lineage: sources[0].artifact.retained_lineage,
+    external_retention_authentication_performed_by_d18: false,
+  },
+  validation: {
+    all_six_canonical_scenarios_revalidated: true,
+    all_four_source_artifacts_revalidated: true,
+    all_source_digests_match_complete_artifact: true,
+    all_scenario_facts_match_retained_sources: true,
+    complete_artifact_source_commit_matches_current_head: true,
+    complete_artifact_was_review_pending_before_review: true,
+    retained_digest_attested_by_maintainer: true,
+    canonical_plan_remained_unmodified: true,
+  },
+  proposed_transition: {
+    task: "LINK-FORUM-03",
+    from: "planned",
+    to: "done",
+    separate_canonical_source_pull_request_required: true,
+    canonical_source_mutated_by_reviewer: false,
+    promotes_forum_21: false,
+    promotes_forum_23: false,
+  },
+};
+
+const absoluteCandidate = resolve(root, candidatePath);
+mkdirSync(dirname(absoluteCandidate), { recursive: true });
+const temporaryCandidate = `${absoluteCandidate}.${process.pid}.${Date.now()}.tmp`;
+try {
+  writeFileSync(temporaryCandidate, `${JSON.stringify(candidate, null, 2)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+  });
+  renameSync(temporaryCandidate, absoluteCandidate);
+} catch (error) {
+  rmSync(temporaryCandidate, { force: true });
+  fail(`atomic promotion-candidate write failed: ${error.message}`);
+}
+console.log(`wrote reviewed LINK-FORUM-03 promotion candidate to ${candidatePath}`);

--- a/scripts/verify/verify-link-forum-03-complete-forum-search-evidence-promotion.mjs
+++ b/scripts/verify/verify-link-forum-03-complete-forum-search-evidence-promotion.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = process.cwd();
+const read = (path) => readFileSync(resolve(root, path), "utf8");
+const requireAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(text.includes(marker), `${label} is missing required marker: ${marker}`);
+  }
+};
+const forbidAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(!text.includes(marker), `${label} contains forbidden marker: ${marker}`);
+  }
+};
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-search-link-forum-03-complete-evidence-promotion.json";
+const d17ContractPath =
+  "crates/rustok-forum/contracts/forum-search-link-forum-03-complete-evidence-assembler.json";
+const reviewerPath =
+  "scripts/evidence/review-link-forum-03-complete-forum-search-evidence.mjs";
+const verifierPath =
+  "scripts/verify/verify-link-forum-03-complete-forum-search-evidence-promotion.mjs";
+const docPath =
+  "crates/rustok-forum/docs/forum-23b2g2b3d18-complete-link-evidence-promotion.md";
+const planPath = "crates/rustok-forum/docs/implementation-plan.md";
+const completePath =
+  "target/link-forum-03-forum-index-search-complete-evidence.json";
+const candidatePath =
+  "target/link-forum-03-forum-index-search-complete-promotion-candidate.json";
+const sourcePaths = [
+  "target/link-forum-03-forum-index-search-ordering-visibility-evidence.json",
+  "target/forum-search-link-forum-03-translation-moderation-evidence.json",
+  "target/forum-search-link-forum-03-private-trusted-exclusion-evidence.json",
+  "target/forum-search-link-forum-03-topic-move-evidence.json",
+];
+const scenarioIds = [
+  "normal_delivery",
+  "deletion_acl_ordering",
+  "search_disabled_profile",
+  "translation_and_moderation_approval",
+  "private_and_trusted_channel_exclusion",
+  "topic_move_category_scope",
+];
+
+const contract = JSON.parse(read(contractPath));
+assert.equal(
+  contract.contract,
+  "forum_search_link_forum_03_complete_evidence_promotion_v1",
+);
+assert.equal(contract.task, "FORUM-23B2G2B3D18");
+assert.equal(contract.target_link, "LINK-FORUM-03");
+assert.equal(contract.status, "source_ready_maintainer_execution_pending");
+assert.equal(contract.canonical_plan, planPath);
+assert.equal(contract.complete_assembler_contract, d17ContractPath);
+assert.equal(contract.complete_artifact, completePath);
+assert.equal(contract.reviewer, reviewerPath);
+assert.equal(contract.verifier, verifierPath);
+assert.equal(contract.promotion_candidate.path, candidatePath);
+assert.equal(
+  contract.promotion_candidate.generation,
+  "reviewer_only_after_complete_artifact_and_source_revalidation",
+);
+assert.equal(contract.promotion_candidate.hand_editing_forbidden, true);
+assert.equal(contract.promotion_candidate.source_commit_required, true);
+assert.equal(contract.promotion_candidate.atomic_replace, true);
+assert.equal(contract.promotion_candidate.automatic_canonical_source_mutation, false);
+assert.deepEqual(contract.required_scenarios, scenarioIds);
+assert.deepEqual(contract.required_source_artifacts, sourcePaths);
+assert.deepEqual(contract.required_attestations, [
+  "RUSTOK_LINK_FORUM_03_EVIDENCE_REVIEWER",
+  "RUSTOK_LINK_FORUM_03_EVIDENCE_RETENTION_REF",
+  "RUSTOK_LINK_FORUM_03_EVIDENCE_RETAINED_SHA256",
+]);
+assert.ok(contract.fail_closed_requirements.length >= 14);
+assert.equal(contract.proposed_transition.task, "LINK-FORUM-03");
+assert.equal(contract.proposed_transition.from, "planned");
+assert.equal(contract.proposed_transition.to, "done");
+assert.equal(
+  contract.proposed_transition.requires_separate_canonical_source_pull_request,
+  true,
+);
+assert.equal(contract.proposed_transition.canonical_source_mutated_by_reviewer, false);
+assert.equal(contract.proposed_transition.promotes_forum_21, false);
+assert.equal(contract.proposed_transition.promotes_forum_23, false);
+assert.ok(contract.maintainer_command.includes(reviewerPath));
+assert.ok(
+  contract.non_claims.some((claim) => claim.includes("does not automatically edit")),
+);
+assert.ok(contract.non_claims.some((claim) => claim.includes("FORUM-21")));
+assert.ok(contract.non_claims.some((claim) => claim.includes("FORUM-23")));
+
+const d17Contract = JSON.parse(read(d17ContractPath));
+assert.equal(
+  d17Contract.contract,
+  "forum_search_link_forum_03_complete_evidence_assembler_v1",
+);
+assert.equal(d17Contract.task, "FORUM-23B2G2B3D17");
+assert.equal(d17Contract.status, "source_ready_maintainer_execution_pending");
+assert.equal(d17Contract.coverage, "complete_canonical_runtime_scope_review_pending");
+assert.deepEqual(d17Contract.required_scenarios, scenarioIds);
+assert.deepEqual(d17Contract.required_inputs, sourcePaths);
+assert.equal(d17Contract.output_artifact.path, completePath);
+assert.equal(
+  d17Contract.output_artifact.status,
+  "complete_runtime_evidence_assembled_review_pending",
+);
+assert.equal(d17Contract.output_artifact.automatic_canonical_source_mutation, false);
+
+const reviewer = read(reviewerPath);
+requireAll(
+  reviewer,
+  [
+    "FORUM-23B2G2B3D18",
+    "forum_search_link_forum_03_complete_evidence_promotion_v1",
+    "link_forum_03_forum_index_search_complete_promotion_candidate_v1",
+    "approved_for_canonical_status_promotion",
+    completePath,
+    candidatePath,
+    ...sourcePaths,
+    ...scenarioIds,
+    "RUSTOK_LINK_FORUM_03_EVIDENCE_REVIEWER",
+    "RUSTOK_LINK_FORUM_03_EVIDENCE_RETENTION_REF",
+    "RUSTOK_LINK_FORUM_03_EVIDENCE_RETAINED_SHA256",
+    'execFileSync("git", ["rev-parse", "HEAD"]',
+    "requireDigest(retainedSha, retainedShaEnv)",
+    "retainedSha !== completeDigest",
+    "complete_runtime_evidence_assembled_review_pending",
+    "partial_runtime_evidence_assembled",
+    "ordering_visibility_and_search_disabled_core_only",
+    "selected_scenario_evidence",
+    "artifact.scenario_evidence[scenarioId]",
+    "core.artifact.selected_scenario_evidence[scenarioId]",
+    "D17 core scenario ${scenarioId}",
+    "source.artifact.scenario_results[0]",
+    "D17 extension attribution drifted",
+    "reviewed_core_lineage",
+    "inherited_retained_lineage",
+    "external_retention_authentication_performed_by_d17",
+    "complete_artifact_independently_reviewed",
+    "complete_artifact_retention_attested",
+    "status_change_allowed_from_this_artifact",
+    "separate_review_gate_required",
+    "separate_canonical_source_pull_request_required",
+    "promotes_forum_21: false",
+    "promotes_forum_23: false",
+    "canonical_source_mutated_by_reviewer: false",
+    "external_service_authentication_performed_by_script: false",
+    "cryptographic_signature_created_by_script: false",
+    "all_six_canonical_scenarios_revalidated: true",
+    "all_four_source_artifacts_revalidated: true",
+    "all_source_digests_match_complete_artifact: true",
+    "all_scenario_facts_match_retained_sources: true",
+    "canonical_plan_remained_unmodified: true",
+    "writeFileSync(temporaryCandidate",
+    "renameSync(temporaryCandidate, absoluteCandidate)",
+    "flag: \"wx\"",
+    "this reviewer accepts no command-line arguments",
+  ],
+  "D18 reviewer",
+);
+forbidAll(
+  reviewer,
+  [
+    "process.argv[2]",
+    "--force",
+    "--allow-missing",
+    "static_fixture",
+    "result === \"skipped\"",
+    "result: \"skipped\"",
+    "writeFileSync(resolve(root, planPath)",
+    "updateFile(planPath",
+    "status_change_allowed_from_this_artifact: true",
+    "promotes_forum_21: true",
+    "promotes_forum_23: true",
+    "canonical_source_mutated_by_reviewer: true",
+    "external_service_authentication_performed_by_script: true",
+    "cryptographic_signature_created_by_script: true",
+  ],
+  "D18 reviewer",
+);
+
+const plan = read(planPath);
+requireAll(
+  plan,
+  [
+    "| `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |",
+    "| `FORUM-23` | `in_progress` |",
+    "| `LINK-FORUM-03` | `planned` | Forum/index/search ordering and visibility proof. |",
+  ],
+  "Forum canonical plan",
+);
+forbidAll(
+  plan,
+  [
+    "| `LINK-FORUM-03` | `done` | Forum/index/search ordering and visibility proof. |",
+    "FORUM-23B2G2B3D18 closes LINK-FORUM-03",
+    "FORUM-23B2G2B3D18 marks FORUM-23 done",
+    "FORUM-23B2G2B3D18 marks FORUM-21 done",
+  ],
+  "Forum canonical plan",
+);
+
+const doc = read(docPath);
+requireAll(
+  doc,
+  [
+    "`source_ready_maintainer_execution_pending`",
+    "FORUM-23B2G2B3D18",
+    "complete_runtime_evidence_assembled_review_pending",
+    "complete_artifact_independently_reviewed = false",
+    "complete_artifact_retention_attested = false",
+    "status_change_allowed_from_this_artifact = false",
+    contractPath,
+    reviewerPath,
+    candidatePath,
+    ...sourcePaths,
+    "D13 core scenario entries preserve their original D8, D9 and D10 source",
+    "LINK-FORUM-03: planned -> done",
+    "promotes_forum_21 = false",
+    "promotes_forum_23 = false",
+    "canonical_source_mutated_by_reviewer = false",
+    "does not retrieve the retention object",
+    "does not create a cryptographic signature",
+    "No command above was run by the implementation agent",
+  ],
+  "D18 handoff",
+);
+
+console.log(
+  "LINK-FORUM-03 complete evidence promotion gate is source-ready and preserves canonical status until separate review and plan PRs.",
+);


### PR DESCRIPTION
## What changed

- add source-ready `FORUM-23B2G2B3D18`, the independent reviewer and retention gate for the complete D17 `LINK-FORUM-03` artifact;
- require explicit reviewer identity, immutable retention reference and exact retained SHA-256 through bounded environment variables;
- revalidate the D17 and D18 contracts, canonical pending statuses, the complete artifact, the reviewed D13 core and the D14-D16 runtime extensions on one exact source commit;
- preserve D13 core scenario attribution to D8/D9/D10 and validate D17's exact retained metadata forms (`scenario_ids` for D13, `scenario_id` for D14-D16);
- re-read every source artifact and require exact digest, byte length, generation time, source commit and source facts;
- require the complete artifact to remain review-pending before review and reject automatic canonical transition;
- write a promotion candidate only after full validation by same-directory atomic rename;
- propose only `LINK-FORUM-03: planned -> done` in a separate canonical-source PR, while keeping `FORUM-21` planned and `FORUM-23` in progress;
- add a machine contract, maintainer handoff and fail-closed source verifier.

## Deliberate boundary

D18 does not run or regenerate any evidence, retrieve or authenticate an external retention service, create a cryptographic signature, modify the D17 artifact or canonical plan, promote FORUM-21, or mark FORUM-23 done. A generated candidate supports but does not perform the LINK-FORUM-03 status change.

## Validation

Tests, Node verifiers, reviewers, assemblers, formatting, Cargo checks, workflows, CI, PostgreSQL, Iggy and storefront execution were intentionally not run, per maintainer request.