### PR TITLE
test(rbac): add PostgreSQL concurrency harness

### DIFF
--- a/apps/server/tests/rbac_postgres_concurrency.rs
+++ b/apps/server/tests/rbac_postgres_concurrency.rs
@@ -1,0 +1,320 @@
+use std::collections::HashSet;
+use std::future::Future;
+
+use chrono::Utc;
+use rustok_core::{UserRole, UserStatus};
+use rustok_migrations::Migrator;
+use rustok_rbac::RbacRoleAssignmentDbWriter;
+use rustok_server::models::_entities::{roles, user_roles};
+use rustok_server::models::{tenants, users};
+use rustok_server::services::rbac_service::RbacService;
+use rustok_test_utils::{
+    assert_postgres_url, connect_postgres, create_postgres_database,
+    drop_postgres_database_if_exists, postgres_database_url, unique_postgres_database_name,
+};
+use sea_orm::{
+    ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, Set, TransactionTrait,
+};
+use sea_orm_migration::MigratorTrait;
+use uuid::Uuid;
+
+type TestResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+const RBAC_POSTGRES_ADMIN_URL_ENV: &str = "RUSTOK_MIGRATION_SMOKE_ADMIN_URL";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires PostgreSQL admin access"]
+async fn concurrent_role_replacement_serializes_one_target_and_advances_two_generations() {
+    with_rbac_postgres_database("rustok_rbac_role_replace", |db_a, db_b| async move {
+        let tenant_id = insert_tenant(&db_a, "role-replacement").await?;
+        let target_user_id = insert_user(&db_a, tenant_id, "role-target@example.com").await?;
+        RbacRoleAssignmentDbWriter::new(db_a.clone())
+            .assign_role_permissions(tenant_id, target_user_id, UserRole::Customer)
+            .await?;
+
+        let generation_before = rustok_rbac::read_permission_invalidation_generation(&db_a).await?;
+        let task_a = tokio::spawn(async move {
+            RbacService::replace_user_role_committed(
+                &db_a,
+                &target_user_id,
+                &tenant_id,
+                UserRole::Admin,
+            )
+            .await
+        });
+        let task_b = tokio::spawn(async move {
+            RbacService::replace_user_role_committed(
+                &db_b,
+                &target_user_id,
+                &tenant_id,
+                UserRole::Manager,
+            )
+            .await
+        });
+
+        task_a.await??;
+        task_b.await??;
+
+        let assignments = user_roles::Entity::find()
+            .filter(user_roles::Column::UserId.eq(target_user_id))
+            .all(&connect_for_assertions().await?)
+            .await?;
+        if assignments.len() != 1 {
+            return Err(format!(
+                "concurrent replacement left {} role assignments, expected exactly one",
+                assignments.len()
+            )
+            .into());
+        }
+
+        let assertion_db = connect_for_assertions().await?;
+        let final_role = roles::Entity::find_by_id(assignments[0].role_id)
+            .filter(roles::Column::TenantId.eq(tenant_id))
+            .one(&assertion_db)
+            .await?
+            .ok_or("final role assignment points to a missing tenant role")?;
+        let accepted_roles = HashSet::from([
+            UserRole::Admin.to_string(),
+            UserRole::Manager.to_string(),
+        ]);
+        if !accepted_roles.contains(&final_role.slug) {
+            return Err(format!(
+                "concurrent replacement produced unexpected role {}",
+                final_role.slug
+            )
+            .into());
+        }
+
+        let generation_after =
+            rustok_rbac::read_permission_invalidation_generation(&assertion_db).await?;
+        if generation_after != generation_before + 2 {
+            return Err(format!(
+                "two serialized role changes advanced generation from {generation_before} to \
+                 {generation_after}, expected {}",
+                generation_before + 2
+            )
+            .into());
+        }
+        assertion_db.close().await?;
+        Ok(())
+    })
+    .await
+    .unwrap_or_else(|error| panic!("RBAC concurrent role replacement evidence failed: {error}"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires PostgreSQL admin access"]
+async fn concurrent_super_admin_demotions_preserve_one_active_super_admin() {
+    with_rbac_postgres_database("rustok_rbac_super_admin", |db_a, db_b| async move {
+        let tenant_id = insert_tenant(&db_a, "super-admin-continuity").await?;
+        let first_user_id = insert_user(&db_a, tenant_id, "super-a@example.com").await?;
+        let second_user_id = insert_user(&db_a, tenant_id, "super-b@example.com").await?;
+        let writer = RbacRoleAssignmentDbWriter::new(db_a.clone());
+        writer
+            .assign_role_permissions(tenant_id, first_user_id, UserRole::SuperAdmin)
+            .await?;
+        writer
+            .assign_role_permissions(tenant_id, second_user_id, UserRole::SuperAdmin)
+            .await?;
+
+        let generation_before = rustok_rbac::read_permission_invalidation_generation(&db_a).await?;
+        let first = tokio::spawn(async move {
+            RbacService::replace_user_role_committed(
+                &db_a,
+                &first_user_id,
+                &tenant_id,
+                UserRole::Admin,
+            )
+            .await
+        });
+        let second = tokio::spawn(async move {
+            RbacService::replace_user_role_committed(
+                &db_b,
+                &second_user_id,
+                &tenant_id,
+                UserRole::Admin,
+            )
+            .await
+        });
+
+        let outcomes = [first.await?, second.await?];
+        let success_count = outcomes.iter().filter(|outcome| outcome.is_ok()).count();
+        if success_count != 1 {
+            return Err(format!(
+                "concurrent super-admin demotions produced {success_count} successes, expected one"
+            )
+            .into());
+        }
+        let rejection = outcomes
+            .iter()
+            .find_map(|outcome| outcome.as_ref().err())
+            .ok_or("one concurrent super-admin demotion must be rejected")?;
+        if !rejection
+            .to_string()
+            .contains("cannot demote the last active super administrator")
+        {
+            return Err(format!("unexpected continuity rejection: {rejection}").into());
+        }
+
+        let assertion_db = connect_for_assertions().await?;
+        let super_admin_role = roles::Entity::find()
+            .filter(roles::Column::TenantId.eq(tenant_id))
+            .filter(roles::Column::Slug.eq(UserRole::SuperAdmin.to_string()))
+            .one(&assertion_db)
+            .await?
+            .ok_or("canonical super-admin role is missing")?;
+        let remaining_super_admins = user_roles::Entity::find()
+            .filter(user_roles::Column::RoleId.eq(super_admin_role.id))
+            .all(&assertion_db)
+            .await?;
+        if remaining_super_admins.len() != 1 {
+            return Err(format!(
+                "continuity guard retained {} super-admin assignments, expected one",
+                remaining_super_admins.len()
+            )
+            .into());
+        }
+
+        let generation_after =
+            rustok_rbac::read_permission_invalidation_generation(&assertion_db).await?;
+        if generation_after != generation_before + 1 {
+            return Err(format!(
+                "one committed demotion advanced generation from {generation_before} to \
+                 {generation_after}, expected {}",
+                generation_before + 1
+            )
+            .into());
+        }
+        assertion_db.close().await?;
+        Ok(())
+    })
+    .await
+    .unwrap_or_else(|error| panic!("RBAC super-admin serialization evidence failed: {error}"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires PostgreSQL admin access"]
+async fn concurrent_generation_reservations_are_unique_contiguous_and_committed() {
+    with_rbac_postgres_database("rustok_rbac_generation", |db_a, db_b| async move {
+        let generation_before = rustok_rbac::read_permission_invalidation_generation(&db_a).await?;
+        let mut tasks = Vec::new();
+        for index in 0..8 {
+            let db = if index % 2 == 0 {
+                db_a.clone()
+            } else {
+                db_b.clone()
+            };
+            tasks.push(tokio::spawn(async move {
+                let transaction = db.begin().await?;
+                let generation =
+                    rustok_rbac::reserve_permission_invalidation_generation(&transaction).await?;
+                transaction.commit().await?;
+                Ok::<u64, Box<dyn std::error::Error + Send + Sync>>(generation)
+            }));
+        }
+
+        let mut generations = Vec::with_capacity(tasks.len());
+        for task in tasks {
+            generations.push(task.await??);
+        }
+        generations.sort_unstable();
+        let expected = (generation_before + 1..=generation_before + 8).collect::<Vec<_>>();
+        if generations != expected {
+            return Err(format!(
+                "concurrent generation reservations returned {generations:?}, expected {expected:?}"
+            )
+            .into());
+        }
+
+        let generation_after = rustok_rbac::read_permission_invalidation_generation(&db_a).await?;
+        if generation_after != generation_before + 8 {
+            return Err(format!(
+                "committed generation ended at {generation_after}, expected {}",
+                generation_before + 8
+            )
+            .into());
+        }
+        Ok(())
+    })
+    .await
+    .unwrap_or_else(|error| panic!("RBAC generation allocation evidence failed: {error}"));
+}
+
+async fn with_rbac_postgres_database<T, F, Fut>(prefix: &str, test: F) -> TestResult<T>
+where
+    F: FnOnce(DatabaseConnection, DatabaseConnection) -> Fut,
+    Fut: Future<Output = TestResult<T>>,
+{
+    let admin_url = std::env::var(RBAC_POSTGRES_ADMIN_URL_ENV)
+        .unwrap_or_else(|_| "postgres://postgres:postgres@localhost:5432/postgres".to_string());
+    assert_postgres_url(&admin_url);
+
+    let database_name = unique_postgres_database_name(prefix);
+    let target_url = postgres_database_url(&admin_url, &database_name);
+    let admin = connect_postgres(&admin_url)
+        .await
+        .map_err(|error| format!("PostgreSQL admin database must be reachable: {error}"))?;
+    drop_postgres_database_if_exists(&admin, &database_name).await?;
+    create_postgres_database(&admin, &database_name).await?;
+
+    let test_result = async {
+        let db_a = connect_postgres(&target_url).await?;
+        Migrator::up(&db_a, None).await?;
+        let db_b = connect_postgres(&target_url).await?;
+        let result = test(db_a.clone(), db_b.clone()).await;
+        db_a.close().await?;
+        db_b.close().await?;
+        result
+    }
+    .await;
+
+    drop_postgres_database_if_exists(&admin, &database_name).await?;
+    admin.close().await?;
+    test_result
+}
+
+async fn connect_for_assertions() -> TestResult<DatabaseConnection> {
+    let admin_url = std::env::var(RBAC_POSTGRES_ADMIN_URL_ENV)
+        .unwrap_or_else(|_| "postgres://postgres:postgres@localhost:5432/postgres".to_string());
+    let database_name = std::env::var("RUSTOK_RBAC_ACTIVE_TEST_DATABASE")?;
+    let target_url = postgres_database_url(&admin_url, &database_name);
+    Ok(connect_postgres(&target_url).await?)
+}
+
+async fn insert_tenant(db: &DatabaseConnection, suffix: &str) -> TestResult<Uuid> {
+    let tenant_id = Uuid::new_v4();
+    tenants::Entity::insert(tenants::ActiveModel {
+        id: Set(tenant_id),
+        name: Set(format!("RBAC PostgreSQL {suffix}")),
+        slug: Set(format!("rbac-postgres-{suffix}-{tenant_id}")),
+        domain: Set(None),
+        settings: Set(serde_json::json!({})),
+        default_locale: Set("en".to_string()),
+        is_active: Set(true),
+        created_at: Set(Utc::now().into()),
+        updated_at: Set(Utc::now().into()),
+    })
+    .exec(db)
+    .await?;
+    Ok(tenant_id)
+}
+
+async fn insert_user(db: &DatabaseConnection, tenant_id: Uuid, email: &str) -> TestResult<Uuid> {
+    let user_id = Uuid::new_v4();
+    users::Entity::insert(users::ActiveModel {
+        id: Set(user_id),
+        tenant_id: Set(tenant_id),
+        email: Set(email.to_string()),
+        password_hash: Set("hash".to_string()),
+        name: Set(None),
+        status: Set(UserStatus::Active),
+        email_verified_at: Set(None),
+        last_login_at: Set(None),
+        metadata: Set(serde_json::json!({})),
+        created_at: Set(Utc::now().into()),
+        updated_at: Set(Utc::now().into()),
+    })
+    .exec(db)
+    .await?;
+    Ok(user_id)
+}

--- a/apps/server/tests/rbac_postgres_concurrency.rs
+++ b/apps/server/tests/rbac_postgres_concurrency.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::future::Future;
+use std::sync::Arc;
 
 use chrono::Utc;
 use rustok_core::{UserRole, UserStatus};
@@ -16,6 +17,7 @@ use sea_orm::{
     ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, Set, TransactionTrait,
 };
 use sea_orm_migration::MigratorTrait;
+use tokio::sync::Barrier;
 use uuid::Uuid;
 
 type TestResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
@@ -36,7 +38,11 @@ async fn concurrent_role_replacement_serializes_one_target_and_advances_two_gene
         let assertion_db = db_a.clone();
         let task_db_a = db_a.clone();
         let task_db_b = db_b.clone();
+        let barrier = Arc::new(Barrier::new(2));
+        let barrier_a = Arc::clone(&barrier);
+        let barrier_b = Arc::clone(&barrier);
         let task_a = tokio::spawn(async move {
+            barrier_a.wait().await;
             RbacService::replace_user_role_committed(
                 &task_db_a,
                 &target_user_id,
@@ -46,6 +52,7 @@ async fn concurrent_role_replacement_serializes_one_target_and_advances_two_gene
             .await
         });
         let task_b = tokio::spawn(async move {
+            barrier_b.wait().await;
             RbacService::replace_user_role_committed(
                 &task_db_b,
                 &target_user_id,
@@ -122,7 +129,11 @@ async fn concurrent_super_admin_demotions_preserve_one_active_super_admin() {
         let assertion_db = db_a.clone();
         let task_db_a = db_a.clone();
         let task_db_b = db_b.clone();
+        let barrier = Arc::new(Barrier::new(2));
+        let barrier_a = Arc::clone(&barrier);
+        let barrier_b = Arc::clone(&barrier);
         let first = tokio::spawn(async move {
+            barrier_a.wait().await;
             RbacService::replace_user_role_committed(
                 &task_db_a,
                 &first_user_id,
@@ -132,6 +143,7 @@ async fn concurrent_super_admin_demotions_preserve_one_active_super_admin() {
             .await
         });
         let second = tokio::spawn(async move {
+            barrier_b.wait().await;
             RbacService::replace_user_role_committed(
                 &task_db_b,
                 &second_user_id,
@@ -199,6 +211,7 @@ async fn concurrent_super_admin_demotions_preserve_one_active_super_admin() {
 async fn concurrent_generation_reservations_are_unique_contiguous_and_committed() {
     with_rbac_postgres_database("rustok_rbac_generation", |db_a, db_b| async move {
         let generation_before = rustok_rbac::read_permission_invalidation_generation(&db_a).await?;
+        let barrier = Arc::new(Barrier::new(8));
         let mut tasks = Vec::new();
         for index in 0..8 {
             let db = if index % 2 == 0 {
@@ -206,7 +219,9 @@ async fn concurrent_generation_reservations_are_unique_contiguous_and_committed(
             } else {
                 db_b.clone()
             };
+            let barrier = Arc::clone(&barrier);
             tasks.push(tokio::spawn(async move {
+                barrier.wait().await;
                 let transaction = db.begin().await?;
                 let generation =
                     rustok_rbac::reserve_permission_invalidation_generation(&transaction).await?;

--- a/apps/server/tests/rbac_postgres_concurrency.rs
+++ b/apps/server/tests/rbac_postgres_concurrency.rs
@@ -33,9 +33,12 @@ async fn concurrent_role_replacement_serializes_one_target_and_advances_two_gene
             .await?;
 
         let generation_before = rustok_rbac::read_permission_invalidation_generation(&db_a).await?;
+        let assertion_db = db_a.clone();
+        let task_db_a = db_a.clone();
+        let task_db_b = db_b.clone();
         let task_a = tokio::spawn(async move {
             RbacService::replace_user_role_committed(
-                &db_a,
+                &task_db_a,
                 &target_user_id,
                 &tenant_id,
                 UserRole::Admin,
@@ -44,7 +47,7 @@ async fn concurrent_role_replacement_serializes_one_target_and_advances_two_gene
         });
         let task_b = tokio::spawn(async move {
             RbacService::replace_user_role_committed(
-                &db_b,
+                &task_db_b,
                 &target_user_id,
                 &tenant_id,
                 UserRole::Manager,
@@ -57,7 +60,7 @@ async fn concurrent_role_replacement_serializes_one_target_and_advances_two_gene
 
         let assignments = user_roles::Entity::find()
             .filter(user_roles::Column::UserId.eq(target_user_id))
-            .all(&connect_for_assertions().await?)
+            .all(&assertion_db)
             .await?;
         if assignments.len() != 1 {
             return Err(format!(
@@ -67,7 +70,6 @@ async fn concurrent_role_replacement_serializes_one_target_and_advances_two_gene
             .into());
         }
 
-        let assertion_db = connect_for_assertions().await?;
         let final_role = roles::Entity::find_by_id(assignments[0].role_id)
             .filter(roles::Column::TenantId.eq(tenant_id))
             .one(&assertion_db)
@@ -95,7 +97,6 @@ async fn concurrent_role_replacement_serializes_one_target_and_advances_two_gene
             )
             .into());
         }
-        assertion_db.close().await?;
         Ok(())
     })
     .await
@@ -118,9 +119,12 @@ async fn concurrent_super_admin_demotions_preserve_one_active_super_admin() {
             .await?;
 
         let generation_before = rustok_rbac::read_permission_invalidation_generation(&db_a).await?;
+        let assertion_db = db_a.clone();
+        let task_db_a = db_a.clone();
+        let task_db_b = db_b.clone();
         let first = tokio::spawn(async move {
             RbacService::replace_user_role_committed(
-                &db_a,
+                &task_db_a,
                 &first_user_id,
                 &tenant_id,
                 UserRole::Admin,
@@ -129,7 +133,7 @@ async fn concurrent_super_admin_demotions_preserve_one_active_super_admin() {
         });
         let second = tokio::spawn(async move {
             RbacService::replace_user_role_committed(
-                &db_b,
+                &task_db_b,
                 &second_user_id,
                 &tenant_id,
                 UserRole::Admin,
@@ -156,7 +160,6 @@ async fn concurrent_super_admin_demotions_preserve_one_active_super_admin() {
             return Err(format!("unexpected continuity rejection: {rejection}").into());
         }
 
-        let assertion_db = connect_for_assertions().await?;
         let super_admin_role = roles::Entity::find()
             .filter(roles::Column::TenantId.eq(tenant_id))
             .filter(roles::Column::Slug.eq(UserRole::SuperAdmin.to_string()))
@@ -185,7 +188,6 @@ async fn concurrent_super_admin_demotions_preserve_one_active_super_admin() {
             )
             .into());
         }
-        assertion_db.close().await?;
         Ok(())
     })
     .await
@@ -271,14 +273,6 @@ where
     drop_postgres_database_if_exists(&admin, &database_name).await?;
     admin.close().await?;
     test_result
-}
-
-async fn connect_for_assertions() -> TestResult<DatabaseConnection> {
-    let admin_url = std::env::var(RBAC_POSTGRES_ADMIN_URL_ENV)
-        .unwrap_or_else(|_| "postgres://postgres:postgres@localhost:5432/postgres".to_string());
-    let database_name = std::env::var("RUSTOK_RBAC_ACTIVE_TEST_DATABASE")?;
-    let target_url = postgres_database_url(&admin_url, &database_name);
-    Ok(connect_postgres(&target_url).await?)
 }
 
 async fn insert_tenant(db: &DatabaseConnection, suffix: &str) -> TestResult<Uuid> {

--- a/crates/rustok-rbac/contracts/evidence/rbac-postgres-concurrency-source.json
+++ b/crates/rustok-rbac/contracts/evidence/rbac-postgres-concurrency-source.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "evidence_id": "RBAC-POSTGRES-CONCURRENCY-SOURCE-20260801",
+  "generated_at": "2026-08-01T14:35:00Z",
+  "status": "source_ready_unvalidated",
+  "cycle": "cycle-001",
+  "component": "core/rbac",
+  "base_revision": "1aa051a04471f06863cce592f79c2c739443f808",
+  "test_source": "apps/server/tests/rbac_postgres_concurrency.rs",
+  "fixture": {
+    "backend": "postgresql",
+    "isolated_database_per_test": true,
+    "admin_url_env": "RUSTOK_MIGRATION_SMOKE_ADMIN_URL",
+    "full_workspace_migrator": true,
+    "two_independent_database_connections": true,
+    "ignored_by_default": true
+  },
+  "scenarios": {
+    "same_target_role_replacement": {
+      "production_entrypoint": "RbacService::replace_user_role_committed",
+      "concurrent_writers": 2,
+      "expected_final_assignments": 1,
+      "expected_generation_delta": 2,
+      "accepted_final_roles": [
+        "admin",
+        "manager"
+      ]
+    },
+    "last_active_super_admin": {
+      "production_entrypoint": "RbacService::replace_user_role_committed",
+      "concurrent_demotions": 2,
+      "expected_successes": 1,
+      "expected_rejections": 1,
+      "expected_remaining_super_admin_assignments": 1,
+      "expected_generation_delta": 1
+    },
+    "generation_allocation": {
+      "production_entrypoint": "reserve_permission_invalidation_generation",
+      "concurrent_transactions": 8,
+      "expected_unique": true,
+      "expected_contiguous": true,
+      "expected_committed_generation_delta": 8
+    }
+  },
+  "shortcuts_forbidden": {
+    "sqlite_fixture": true,
+    "mock_database": true,
+    "manual_generation_update_sql": true,
+    "manual_role_lock_sql": true,
+    "test_only_role_replacement_implementation": true
+  },
+  "validation": {
+    "rust_test_executed": false,
+    "source_verifier_executed": false,
+    "formatting_executed": false,
+    "cargo_check_executed": false,
+    "postgresql_runtime_executed": false,
+    "workflow_or_ci_executed": false
+  },
+  "multi_replica_evidence": false,
+  "redis_transport_evidence": false,
+  "cli_repair_live_replica_evidence": false,
+  "broad_rbac_verification_complete": false,
+  "cursor_advanced": false
+}

--- a/crates/rustok-rbac/contracts/evidence/rbac-postgres-concurrency-source.json
+++ b/crates/rustok-rbac/contracts/evidence/rbac-postgres-concurrency-source.json
@@ -13,6 +13,7 @@
     "admin_url_env": "RUSTOK_MIGRATION_SMOKE_ADMIN_URL",
     "full_workspace_migrator": true,
     "two_independent_database_connections": true,
+    "barrier_synchronized_starts": true,
     "ignored_by_default": true
   },
   "scenarios": {

--- a/crates/rustok-rbac/docs/postgres-concurrency-evidence.md
+++ b/crates/rustok-rbac/docs/postgres-concurrency-evidence.md
@@ -1,0 +1,88 @@
+# RBAC PostgreSQL concurrency evidence harness
+
+## Purpose
+
+`apps/server/tests/rbac_postgres_concurrency.rs` is the dedicated source-ready
+PostgreSQL harness for the remaining `core/rbac` database-concurrency gate. It
+uses the real workspace migrations, relation tables, committed role mutation
+entry point and durable invalidation-generation allocator. It does not create a
+parallel role writer, a test-only lock, or a second generation authority.
+
+The harness is ignored by default because it creates and drops isolated
+PostgreSQL databases through an administrative connection. Source presence does
+not count as retained runtime evidence.
+
+## Scenarios
+
+### Concurrent replacement of one user role
+
+Two independent PostgreSQL connections call
+`RbacService::replace_user_role_committed` concurrently for the same tenant user,
+one requesting `admin` and the other `manager`.
+
+The retained execution must prove:
+
+- both committed mutations complete through the production entry point;
+- the target-user row lock serializes the writes;
+- exactly one tenant role assignment remains;
+- the final role is one of the two requested roles;
+- the durable generation advances exactly twice.
+
+### Last-active-super-admin serialization
+
+Two active super administrators are demoted concurrently on independent
+connections through the same committed production entry point.
+
+The retained execution must prove:
+
+- exactly one demotion commits;
+- exactly one demotion is rejected with the canonical last-active-super-admin
+  continuity error;
+- exactly one super-admin assignment remains;
+- the durable generation advances only for the successful mutation.
+
+### Unique monotonic generation allocation
+
+Eight independent transactions reserve and commit RBAC invalidation generations
+concurrently through
+`rustok_rbac::reserve_permission_invalidation_generation`.
+
+The retained execution must prove that the returned values are unique,
+contiguous and equal to the durable committed range immediately following the
+starting generation.
+
+## Fixture ownership
+
+Each test:
+
+1. reads `RUSTOK_MIGRATION_SMOKE_ADMIN_URL`, falling back to the repository's
+   conventional local PostgreSQL admin URL;
+2. creates a process-unique database with `rustok-test-utils`;
+3. applies `rustok_migrations::Migrator`;
+4. opens two independent target connections;
+5. exercises only production RBAC mutation/generation APIs;
+6. closes the target connections and drops the isolated database.
+
+There is no SQLite fallback. The tests do not update the generation row with raw
+SQL and do not issue manual role-lock SQL.
+
+## Execution
+
+Run the ignored PostgreSQL harness explicitly:
+
+```bash
+cargo test -p rustok-server --test rbac_postgres_concurrency -- --ignored --nocapture
+```
+
+Run the focused source guard separately:
+
+```bash
+node scripts/verify/verify-rbac-postgres-concurrency-source.mjs
+```
+
+Retain the test output and exact commit SHA before marking PostgreSQL concurrency
+verified. Until then, the evidence remains `source_ready_unvalidated`.
+
+This harness does not prove Redis delivery, two-replica recovery, missed PubSub
+catch-up, CLI repair propagation, formatting, compilation, Clippy, or broader
+RBAC runtime behavior. Those gates remain open.

--- a/scripts/verify/verify-rbac-postgres-concurrency-source.mjs
+++ b/scripts/verify/verify-rbac-postgres-concurrency-source.mjs
@@ -79,7 +79,9 @@ for (const marker of [
   "pub async fn reserve_permission_invalidation_generation(",
   "db: &DatabaseTransaction",
   "UPDATE rbac_invalidation_state",
-  "RETURNING generation",
+  "SET generation = generation + 1",
+  "if update.rows_affected() != 1",
+  "read_permission_invalidation_generation(db).await",
 ]) requireText(sources.generation, marker, `${files.generation}: generation authority`);
 
 for (const marker of [

--- a/scripts/verify/verify-rbac-postgres-concurrency-source.mjs
+++ b/scripts/verify/verify-rbac-postgres-concurrency-source.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+const files = {
+  harness: "apps/server/tests/rbac_postgres_concurrency.rs",
+  committed: "apps/server/src/services/rbac_committed_mutations.rs",
+  generation: "crates/rustok-rbac/src/invalidation_generation.rs",
+  testDb: "crates/rustok-test-utils/src/db.rs",
+  evidence:
+    "crates/rustok-rbac/contracts/evidence/rbac-postgres-concurrency-source.json",
+  docs: "crates/rustok-rbac/docs/postgres-concurrency-evidence.md",
+  plan: "crates/rustok-rbac/docs/implementation-plan.md",
+  master: "docs/verification/PLATFORM_VERIFICATION_PLAN.md",
+};
+const sources = Object.fromEntries(
+  Object.entries(files).map(([name, relativePath]) => [name, read(relativePath)]),
+);
+
+for (const marker of [
+  '#[ignore = "requires PostgreSQL admin access"]',
+  "concurrent_role_replacement_serializes_one_target_and_advances_two_generations",
+  "concurrent_super_admin_demotions_preserve_one_active_super_admin",
+  "concurrent_generation_reservations_are_unique_contiguous_and_committed",
+  'const RBAC_POSTGRES_ADMIN_URL_ENV: &str = "RUSTOK_MIGRATION_SMOKE_ADMIN_URL"',
+  "unique_postgres_database_name(prefix)",
+  "create_postgres_database(&admin, &database_name)",
+  "drop_postgres_database_if_exists(&admin, &database_name)",
+  "Migrator::up(&db_a, None).await?",
+  "let db_b = connect_postgres(&target_url).await?",
+  "RbacService::replace_user_role_committed",
+  "RbacRoleAssignmentDbWriter::new(db_a.clone())",
+  "assignments.len() != 1",
+  "generation_before + 2",
+  "cannot demote the last active super administrator",
+  "remaining_super_admins.len() != 1",
+  "generation_before + 1",
+  "reserve_permission_invalidation_generation(&transaction)",
+  "generations.sort_unstable()",
+  "generation_before + 1..=generation_before + 8",
+  "generation_before + 8",
+]) requireText(sources.harness, marker, `${files.harness}: PostgreSQL evidence harness`);
+
+for (const forbidden of [
+  "sqlite:",
+  "setup_test_db_with_migrations",
+  "UPDATE rbac_invalidation_state",
+  "SELECT FOR UPDATE",
+  "lock_exclusive()",
+  "connect_for_assertions",
+  "RUSTOK_RBAC_ACTIVE_TEST_DATABASE",
+  "tokio::time::sleep",
+]) forbidText(sources.harness, forbidden, `${files.harness}: shortcut`);
+
+for (const marker of [
+  "lock_target_user_for_role_mutation",
+  "lock_exclusive().one(db).await?",
+  "ensure_active_super_admin_continuity",
+  "reserve_rbac_invalidation_generation(&tx)",
+  "tx.commit().await?",
+]) requireText(sources.committed, marker, `${files.committed}: production mutation path`);
+
+for (const marker of [
+  "pub async fn reserve_permission_invalidation_generation(",
+  "db: &DatabaseTransaction",
+  "UPDATE rbac_invalidation_state",
+  "RETURNING generation",
+]) requireText(sources.generation, marker, `${files.generation}: generation authority`);
+
+for (const marker of [
+  "pub async fn connect_postgres",
+  "pub async fn create_postgres_database",
+  "pub async fn drop_postgres_database_if_exists",
+  "pub fn postgres_database_url",
+  "pub fn unique_postgres_database_name",
+]) requireText(sources.testDb, marker, `${files.testDb}: isolated database helper`);
+
+const evidence = JSON.parse(sources.evidence);
+const evidenceChecks = [
+  [evidence.status === "source_ready_unvalidated", "status must remain source_ready_unvalidated"],
+  [evidence.cycle === "cycle-001", "cycle must remain cycle-001"],
+  [evidence.component === "core/rbac", "component must remain core/rbac"],
+  [evidence.fixture?.backend === "postgresql", "fixture backend must be PostgreSQL"],
+  [evidence.fixture?.isolated_database_per_test === true, "isolated databases must remain required"],
+  [evidence.fixture?.two_independent_database_connections === true, "two connections must remain required"],
+  [evidence.fixture?.ignored_by_default === true, "tests must remain ignored by default"],
+  [evidence.scenarios?.same_target_role_replacement?.expected_generation_delta === 2, "role replacement generation delta must remain two"],
+  [evidence.scenarios?.last_active_super_admin?.expected_successes === 1, "exactly one super-admin demotion must succeed"],
+  [evidence.scenarios?.last_active_super_admin?.expected_rejections === 1, "exactly one super-admin demotion must be rejected"],
+  [evidence.scenarios?.generation_allocation?.concurrent_transactions === 8, "generation allocation must retain eight transactions"],
+  [evidence.scenarios?.generation_allocation?.expected_unique === true, "unique generation requirement must remain true"],
+  [evidence.scenarios?.generation_allocation?.expected_contiguous === true, "contiguous generation requirement must remain true"],
+  [evidence.validation?.rust_test_executed === false, "Rust execution must not be claimed"],
+  [evidence.validation?.source_verifier_executed === false, "source verifier execution must not be claimed"],
+  [evidence.validation?.postgresql_runtime_executed === false, "PostgreSQL execution must not be claimed"],
+  [evidence.multi_replica_evidence === false, "multi-replica evidence must remain open"],
+  [evidence.redis_transport_evidence === false, "Redis evidence must remain open"],
+  [evidence.cli_repair_live_replica_evidence === false, "CLI repair live-replica evidence must remain open"],
+  [evidence.broad_rbac_verification_complete === false, "broad RBAC verification must remain open"],
+  [evidence.cursor_advanced === false, "cursor must not advance"],
+];
+for (const [passed, message] of evidenceChecks) {
+  if (!passed) failures.push(`${files.evidence}: ${message}`);
+}
+
+for (const marker of [
+  "dedicated source-ready PostgreSQL harness",
+  "Concurrent replacement of one user role",
+  "Last-active-super-admin serialization",
+  "Unique monotonic generation allocation",
+  "There is no SQLite fallback.",
+  "source_ready_unvalidated",
+  "does not prove Redis delivery",
+]) requireText(sources.docs, marker, `${files.docs}: evidence contract`);
+
+for (const marker of [
+  "### P0. Database concurrency and multi-replica recovery evidence",
+  "PostgreSQL integration evidence",
+  "multi-replica",
+  "Status: `in_progress`",
+]) requireText(sources.plan, marker, `${files.plan}: owner gate`);
+
+for (const marker of [
+  "Current item: `core/rbac`",
+  "Next item: `core/rbac`",
+  "PostgreSQL concurrency",
+]) requireText(sources.master, marker, `${files.master}: active cursor`);
+
+if (failures.length > 0) {
+  console.error("RBAC PostgreSQL concurrency source verification failed:");
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "✔ source-ready PostgreSQL RBAC concurrency harness covers serialized role replacement, last-super-admin continuity and unique contiguous generation allocation without claiming execution or multi-replica evidence",
+);

--- a/scripts/verify/verify-rbac-postgres-concurrency-source.mjs
+++ b/scripts/verify/verify-rbac-postgres-concurrency-source.mjs
@@ -43,6 +43,11 @@ for (const marker of [
   "drop_postgres_database_if_exists(&admin, &database_name)",
   "Migrator::up(&db_a, None).await?",
   "let db_b = connect_postgres(&target_url).await?",
+  "Barrier::new(2)",
+  "Barrier::new(8)",
+  "barrier_a.wait().await",
+  "barrier_b.wait().await",
+  "barrier.wait().await",
   "RbacService::replace_user_role_committed",
   "RbacRoleAssignmentDbWriter::new(db_a.clone())",
   "assignments.len() != 1",
@@ -100,6 +105,7 @@ const evidenceChecks = [
   [evidence.fixture?.backend === "postgresql", "fixture backend must be PostgreSQL"],
   [evidence.fixture?.isolated_database_per_test === true, "isolated databases must remain required"],
   [evidence.fixture?.two_independent_database_connections === true, "two connections must remain required"],
+  [evidence.fixture?.barrier_synchronized_starts === true, "barrier-synchronized starts must remain required"],
   [evidence.fixture?.ignored_by_default === true, "tests must remain ignored by default"],
   [evidence.scenarios?.same_target_role_replacement?.expected_generation_delta === 2, "role replacement generation delta must remain two"],
   [evidence.scenarios?.last_active_super_admin?.expected_successes === 1, "exactly one super-admin demotion must succeed"],
@@ -150,5 +156,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "✔ source-ready PostgreSQL RBAC concurrency harness covers serialized role replacement, last-super-admin continuity and unique contiguous generation allocation without claiming execution or multi-replica evidence",
+  "✔ source-ready PostgreSQL RBAC concurrency harness covers synchronized role replacement, last-super-admin continuity and unique contiguous generation allocation without claiming execution or multi-replica evidence",
 );


### PR DESCRIPTION
## Cycle scope

Continue `cycle-001` at the active `core/rbac` cursor without advancing or completing the component.

## Summary

- add three ignored PostgreSQL integration tests in isolated databases
- synchronize concurrent starts with Tokio barriers
- exercise the production committed role replacement entry point for one-target serialization
- exercise concurrent demotions of two active super administrators and require exactly one continuity rejection
- exercise eight concurrent transaction-owned durable generation reservations and require a unique contiguous committed range
- add machine-readable source evidence, operator documentation and a focused source guard

## Evidence boundary

This change is `source_ready_unvalidated`. The harness uses real PostgreSQL database creation, the full workspace migrator, two independent target connections, production RBAC mutation APIs and the canonical generation allocator. It has no SQLite fallback, raw generation update SQL, manual role-lock SQL or test-only role writer.

The canonical plan remains open because the PostgreSQL tests and source verifier were not executed. Multi-replica Redis recovery, missed PubSub catch-up and live CLI repair propagation also remain open.

## Validation

No Rust tests, Node verifiers, formatting, Cargo checks, PostgreSQL execution, Redis, workflows or CI were run by request.

Targeted maintainer commands:

```bash
cargo test -p rustok-server --test rbac_postgres_concurrency -- --ignored --nocapture
node scripts/verify/verify-rbac-postgres-concurrency-source.mjs
```

Branch: `agent/rbac-postgres-concurrency-evidence-20260801`
Original branch base: `1aa051a04471f06863cce592f79c2c739443f808`
Current `main` contains one later non-overlapping Forum evidence commit.