### PR TITLE
fix(rbac): remove resolver mutation bypass

### DIFF
--- a/apps/server/src/services/rbac_runtime.rs
+++ b/apps/server/src/services/rbac_runtime.rs
@@ -9,29 +9,23 @@ use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
+#[cfg(test)]
 use rustok_core::UserRole;
 
 use rustok_api::{Action, Permission, Resource};
 use rustok_rbac::{
     AuthorizationDecision, DeniedReasonKind, PermissionCache, PermissionCacheLookup,
-    RelationPermissionStore, RoleAssignmentStore, RuntimePermissionResolver,
-    authorize_all_permissions, authorize_any_permission, authorize_permission,
-    invalidate_cached_permissions,
+    RelationPermissionStore, RuntimePermissionResolver, authorize_all_permissions,
+    authorize_any_permission, authorize_permission, invalidate_cached_permissions,
 };
 
 use crate::models::_entities::{permissions, role_permissions, roles, user_roles, users};
 
-use super::rbac_persistence::{
-    assign_role_permissions_via_store, remove_tenant_role_assignments_via_store,
-    remove_user_role_assignment_via_store, replace_user_role_via_store,
-};
+#[cfg(test)]
+use super::rbac_persistence::assign_role_permissions_via_store;
 
-pub(crate) type ServerRuntimePermissionResolver = RuntimePermissionResolver<
-    SeaOrmRelationPermissionStore,
-    MokaPermissionCache,
-    ServerRoleAssignmentStore,
-    Error,
->;
+pub(crate) type ServerRuntimePermissionResolver =
+    RuntimePermissionResolver<SeaOrmRelationPermissionStore, MokaPermissionCache, Error>;
 
 #[derive(Clone, Copy)]
 pub(crate) enum AuthorizationCheck<'a> {
@@ -229,7 +223,6 @@ pub(crate) fn resolver(db: &DatabaseConnection) -> ServerRuntimePermissionResolv
     RuntimePermissionResolver::new(
         SeaOrmRelationPermissionStore { db: db.clone() },
         MokaPermissionCache,
-        ServerRoleAssignmentStore { db: db.clone() },
     )
 }
 
@@ -336,11 +329,6 @@ pub(crate) struct SeaOrmRelationPermissionStore {
 
 #[derive(Clone)]
 pub(crate) struct MokaPermissionCache;
-
-#[derive(Clone)]
-pub(crate) struct ServerRoleAssignmentStore {
-    db: DatabaseConnection,
-}
 
 #[async_trait]
 impl PermissionCache for MokaPermissionCache {
@@ -501,46 +489,6 @@ impl RelationPermissionStore for SeaOrmRelationPermissionStore {
         }
 
         Ok(result)
-    }
-}
-
-#[async_trait]
-impl RoleAssignmentStore for ServerRoleAssignmentStore {
-    type Error = Error;
-
-    async fn assign_role_permissions(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<()> {
-        assign_role_permissions_via_store(&self.db, user_id, tenant_id, role).await
-    }
-
-    async fn replace_user_role(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<()> {
-        replace_user_role_via_store(&self.db, user_id, tenant_id, role).await
-    }
-
-    async fn remove_tenant_role_assignments(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-    ) -> Result<()> {
-        remove_tenant_role_assignments_via_store(&self.db, user_id, tenant_id).await
-    }
-
-    async fn remove_user_role_assignment(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<()> {
-        remove_user_role_assignment_via_store(&self.db, user_id, tenant_id, role).await
     }
 }
 

--- a/apps/server/src/services/rbac_service.rs
+++ b/apps/server/src/services/rbac_service.rs
@@ -342,11 +342,10 @@ impl RbacService {
         tenant_id: &uuid::Uuid,
         role: UserRole,
     ) -> Result<()> {
+        use super::rbac_persistence::assign_role_permissions_via_store;
+
         Self::record_authz_entrypoint_call("assign_role_permissions", "internal");
-        let resolver = Self::resolver(db);
-        resolver
-            .assign_role_permissions(tenant_id, user_id, role)
-            .await
+        assign_role_permissions_via_store(db, user_id, tenant_id, role).await
     }
 
     /// Transaction-only compatibility alias for legacy auth lifecycle composition.

--- a/apps/server/tests/rbac_permission_resolver_read_only_guard.rs
+++ b/apps/server/tests/rbac_permission_resolver_read_only_guard.rs
@@ -1,0 +1,106 @@
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("apps/server should live under workspace root")
+        .to_path_buf()
+}
+
+fn source(relative: &str) -> String {
+    let path = repo_root().join(relative);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}
+
+#[test]
+fn permission_resolver_is_read_only() {
+    let contract = source("crates/rustok-rbac/src/services/permission_resolver.rs");
+
+    for forbidden in [
+        "async fn assign_role_permissions(",
+        "async fn replace_user_role(",
+        "async fn remove_tenant_role_assignments(",
+        "async fn remove_user_role_assignment(",
+    ] {
+        assert!(
+            !contract.contains(forbidden),
+            "PermissionResolver must not expose mutation method {forbidden}"
+        );
+    }
+
+    assert!(contract.contains("Read-only owner contract"));
+    assert!(contract.contains("transaction-owned or committed RBAC mutation"));
+}
+
+#[test]
+fn permission_resolver_test_doubles_are_read_only() {
+    let authorizer = source("crates/rustok-rbac/src/services/permission_authorizer.rs");
+
+    for forbidden in [
+        "async fn assign_role_permissions(",
+        "async fn replace_user_role(",
+        "async fn remove_tenant_role_assignments(",
+        "async fn remove_user_role_assignment(",
+    ] {
+        assert!(
+            !authorizer.contains(forbidden),
+            "permission resolver test doubles must not retain removed mutation method {forbidden}"
+        );
+    }
+
+    assert!(
+        !authorizer.contains("use rustok_core::UserRole;"),
+        "permission resolver test doubles must not depend on role mutation payloads"
+    );
+}
+
+#[test]
+fn runtime_permission_resolver_has_no_mutation_composition_surface() {
+    let runtime = source("crates/rustok-rbac/src/services/runtime_permission_resolver.rs");
+    let impl_start = runtime
+        .find("impl<S, C, E> PermissionResolver for RuntimePermissionResolver")
+        .expect("runtime resolver PermissionResolver implementation must exist");
+    let impl_end = runtime[impl_start..]
+        .find("#[cfg(test)]")
+        .map(|offset| impl_start + offset)
+        .expect("runtime resolver implementation must end before tests");
+    let resolver_impl = &runtime[impl_start..impl_end];
+
+    assert!(resolver_impl.contains("resolve_permissions_with_cache"));
+    for forbidden in [
+        "RoleAssignmentStore",
+        "assignment_store",
+        "assign_role_permissions",
+        "replace_user_role",
+        "remove_tenant_role_assignments",
+        "remove_user_role_assignment",
+    ] {
+        assert!(
+            !runtime.contains(forbidden),
+            "runtime permission resolver must not retain mutation composition: {forbidden}"
+        );
+    }
+}
+
+#[test]
+fn server_runtime_does_not_reintroduce_assignment_store_adapter() {
+    let runtime = source("apps/server/src/services/rbac_runtime.rs");
+
+    for forbidden in [
+        "RoleAssignmentStore",
+        "ServerRoleAssignmentStore",
+        "remove_tenant_role_assignments_via_store",
+        "remove_user_role_assignment_via_store",
+        "replace_user_role_via_store",
+    ] {
+        assert!(
+            !runtime.contains(forbidden),
+            "server permission runtime must not retain obsolete mutation adapter: {forbidden}"
+        );
+    }
+
+    assert!(runtime.contains("RuntimePermissionResolver<SeaOrmRelationPermissionStore"));
+    assert!(runtime.contains("RuntimePermissionResolver::new("));
+}

--- a/crates/rustok-rbac/src/lib.rs
+++ b/crates/rustok-rbac/src/lib.rs
@@ -70,7 +70,7 @@ pub use services::relation_permission_resolver::{
     PermissionCache, PermissionCacheLookup, RelationPermissionStore, invalidate_cached_permissions,
     resolve_permissions_from_relations, resolve_permissions_with_cache,
 };
-pub use services::runtime_permission_resolver::{RoleAssignmentStore, RuntimePermissionResolver};
+pub use services::runtime_permission_resolver::RuntimePermissionResolver;
 
 /// Build a read-only canonical system-role repair plan.
 pub async fn plan_system_role_repair(

--- a/crates/rustok-rbac/src/services/permission_authorizer.rs
+++ b/crates/rustok-rbac/src/services/permission_authorizer.rs
@@ -135,7 +135,6 @@ mod tests {
     use crate::{AuthzEngine, PermissionResolution, PermissionResolver};
     use async_trait::async_trait;
     use rustok_api::Permission;
-    use rustok_core::UserRole;
 
     struct StubResolver {
         permissions: Vec<Permission>,
@@ -159,41 +158,6 @@ mod tests {
                 permissions: self.permissions.clone(),
                 cache_hit: self.cache_hit,
             })
-        }
-
-        async fn assign_role_permissions(
-            &self,
-            _tenant_id: &uuid::Uuid,
-            _user_id: &uuid::Uuid,
-            _role: UserRole,
-        ) -> Result<(), Self::Error> {
-            Ok(())
-        }
-
-        async fn replace_user_role(
-            &self,
-            _tenant_id: &uuid::Uuid,
-            _user_id: &uuid::Uuid,
-            _role: UserRole,
-        ) -> Result<(), Self::Error> {
-            Ok(())
-        }
-
-        async fn remove_tenant_role_assignments(
-            &self,
-            _tenant_id: &uuid::Uuid,
-            _user_id: &uuid::Uuid,
-        ) -> Result<(), Self::Error> {
-            Ok(())
-        }
-
-        async fn remove_user_role_assignment(
-            &self,
-            _tenant_id: &uuid::Uuid,
-            _user_id: &uuid::Uuid,
-            _role: UserRole,
-        ) -> Result<(), Self::Error> {
-            Ok(())
         }
     }
 
@@ -280,10 +244,14 @@ mod tests {
             fail_resolve: false,
         };
 
-        let decision =
-            authorize_all_permissions(&resolver, &uuid::Uuid::new_v4(), &uuid::Uuid::new_v4(), &[])
-                .await
-                .unwrap();
+        let decision = authorize_all_permissions(
+            &resolver,
+            &uuid::Uuid::new_v4(),
+            &uuid::Uuid::new_v4(),
+            &[],
+        )
+        .await
+        .unwrap();
 
         assert_eq!(decision.engine, AuthzEngine::Policy);
         assert!(decision.allowed);

--- a/crates/rustok-rbac/src/services/permission_resolver.rs
+++ b/crates/rustok-rbac/src/services/permission_resolver.rs
@@ -1,7 +1,6 @@
 use crate::{evaluate_all_permissions, evaluate_any_permission, evaluate_single_permission};
 use async_trait::async_trait;
 use rustok_api::Permission;
-use rustok_core::UserRole;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PermissionResolution {
@@ -9,6 +8,12 @@ pub struct PermissionResolution {
     pub cache_hit: bool,
 }
 
+/// Read-only owner contract for resolving effective tenant permissions.
+///
+/// Role and permission mutations intentionally do not belong to this trait.
+/// Existing-user writes must use transaction-owned or committed RBAC mutation
+/// entry points so continuity locks, durable invalidation generations and
+/// cross-replica cache recovery cannot be bypassed.
 #[async_trait]
 pub trait PermissionResolver {
     type Error;
@@ -48,33 +53,6 @@ pub trait PermissionResolver {
         let resolved = self.resolve_permissions(tenant_id, user_id).await?;
         Ok(evaluate_all_permissions(&resolved.permissions, required_permissions).allowed)
     }
-
-    async fn assign_role_permissions(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<(), Self::Error>;
-
-    async fn replace_user_role(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<(), Self::Error>;
-
-    async fn remove_tenant_role_assignments(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-    ) -> Result<(), Self::Error>;
-
-    async fn remove_user_role_assignment(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<(), Self::Error>;
 }
 
 #[cfg(test)]
@@ -82,7 +60,6 @@ mod tests {
     use super::{PermissionResolution, PermissionResolver};
     use async_trait::async_trait;
     use rustok_api::Permission;
-    use rustok_core::UserRole;
 
     struct StubResolver {
         permissions: Vec<Permission>,
@@ -101,41 +78,6 @@ mod tests {
                 permissions: self.permissions.clone(),
                 cache_hit: true,
             })
-        }
-
-        async fn assign_role_permissions(
-            &self,
-            _tenant_id: &uuid::Uuid,
-            _user_id: &uuid::Uuid,
-            _role: UserRole,
-        ) -> Result<(), Self::Error> {
-            Ok(())
-        }
-
-        async fn replace_user_role(
-            &self,
-            _tenant_id: &uuid::Uuid,
-            _user_id: &uuid::Uuid,
-            _role: UserRole,
-        ) -> Result<(), Self::Error> {
-            Ok(())
-        }
-
-        async fn remove_tenant_role_assignments(
-            &self,
-            _tenant_id: &uuid::Uuid,
-            _user_id: &uuid::Uuid,
-        ) -> Result<(), Self::Error> {
-            Ok(())
-        }
-
-        async fn remove_user_role_assignment(
-            &self,
-            _tenant_id: &uuid::Uuid,
-            _user_id: &uuid::Uuid,
-            _role: UserRole,
-        ) -> Result<(), Self::Error> {
-            Ok(())
         }
     }
 

--- a/crates/rustok-rbac/src/services/runtime_permission_resolver.rs
+++ b/crates/rustok-rbac/src/services/runtime_permission_resolver.rs
@@ -3,82 +3,42 @@ use crate::{
     resolve_permissions_with_cache,
 };
 use async_trait::async_trait;
-use rustok_core::UserRole;
 use std::marker::PhantomData;
 
+/// Runtime adapter for the read-only permission-resolution path.
 #[derive(Clone)]
-pub struct RuntimePermissionResolver<S, C, A, E>
+pub struct RuntimePermissionResolver<S, C, E>
 where
     S: RelationPermissionStore,
     C: PermissionCache,
-    A: RoleAssignmentStore,
     S::Error: Into<E>,
-    A::Error: Into<E>,
 {
     store: S,
     cache: C,
-    assignment_store: A,
     _error: PhantomData<E>,
 }
 
-impl<S, C, A, E> RuntimePermissionResolver<S, C, A, E>
+impl<S, C, E> RuntimePermissionResolver<S, C, E>
 where
     S: RelationPermissionStore,
     C: PermissionCache,
-    A: RoleAssignmentStore,
     S::Error: Into<E>,
-    A::Error: Into<E>,
 {
-    pub fn new(store: S, cache: C, assignment_store: A) -> Self {
+    pub fn new(store: S, cache: C) -> Self {
         Self {
             store,
             cache,
-            assignment_store,
             _error: PhantomData,
         }
     }
 }
 
 #[async_trait]
-pub trait RoleAssignmentStore {
-    type Error;
-
-    async fn assign_role_permissions(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<(), Self::Error>;
-
-    async fn replace_user_role(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<(), Self::Error>;
-
-    async fn remove_tenant_role_assignments(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-    ) -> Result<(), Self::Error>;
-
-    async fn remove_user_role_assignment(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<(), Self::Error>;
-}
-
-#[async_trait]
-impl<S, C, A, E> PermissionResolver for RuntimePermissionResolver<S, C, A, E>
+impl<S, C, E> PermissionResolver for RuntimePermissionResolver<S, C, E>
 where
     S: RelationPermissionStore + Send + Sync,
     C: PermissionCache + Send + Sync,
-    A: RoleAssignmentStore + Send + Sync,
     S::Error: Into<E> + Send + Sync,
-    A::Error: Into<E> + Send + Sync,
     E: Send + Sync,
 {
     type Error = E;
@@ -92,78 +52,14 @@ where
             .await
             .map_err(Into::into)
     }
-
-    async fn assign_role_permissions(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<(), Self::Error> {
-        self.assignment_store
-            .assign_role_permissions(tenant_id, user_id, role)
-            .await
-            .map_err(Into::into)?;
-
-        self.cache.invalidate(tenant_id, user_id).await;
-
-        Ok(())
-    }
-
-    async fn replace_user_role(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<(), Self::Error> {
-        self.assignment_store
-            .replace_user_role(tenant_id, user_id, role)
-            .await
-            .map_err(Into::into)?;
-
-        self.cache.invalidate(tenant_id, user_id).await;
-
-        Ok(())
-    }
-
-    async fn remove_tenant_role_assignments(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-    ) -> Result<(), Self::Error> {
-        self.assignment_store
-            .remove_tenant_role_assignments(tenant_id, user_id)
-            .await
-            .map_err(Into::into)?;
-
-        self.cache.invalidate(tenant_id, user_id).await;
-
-        Ok(())
-    }
-
-    async fn remove_user_role_assignment(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<(), Self::Error> {
-        self.assignment_store
-            .remove_user_role_assignment(tenant_id, user_id, role)
-            .await
-            .map_err(Into::into)?;
-
-        self.cache.invalidate(tenant_id, user_id).await;
-
-        Ok(())
-    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{RoleAssignmentStore, RuntimePermissionResolver};
+    use super::RuntimePermissionResolver;
     use crate::{PermissionCache, PermissionResolver, RelationPermissionStore};
     use async_trait::async_trait;
     use rustok_api::Permission;
-    use rustok_core::UserRole;
     use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::Mutex;
@@ -184,14 +80,8 @@ mod tests {
     }
 
     #[derive(Debug, Clone, PartialEq, Eq)]
-    enum StubAssignmentError {
-        Assign,
-    }
-
-    #[derive(Debug, Clone, PartialEq, Eq)]
     enum ResolverError {
         Store(StubStoreError),
-        Assignment(StubAssignmentError),
     }
 
     impl From<StubStoreError> for ResolverError {
@@ -200,24 +90,9 @@ mod tests {
         }
     }
 
-    impl From<StubAssignmentError> for ResolverError {
-        fn from(value: StubAssignmentError) -> Self {
-            Self::Assignment(value)
-        }
-    }
-
     #[derive(Default)]
     struct StubCache {
         values: Arc<Mutex<PermissionCacheMap>>,
-    }
-
-    #[derive(Default)]
-    struct StubAssignmentStore {
-        assigned: Arc<Mutex<Vec<(uuid::Uuid, uuid::Uuid, UserRole)>>>,
-        replaced: Arc<Mutex<Vec<(uuid::Uuid, uuid::Uuid, UserRole)>>>,
-        removed_tenant: Arc<Mutex<Vec<(uuid::Uuid, uuid::Uuid)>>>,
-        removed_single: Arc<Mutex<Vec<(uuid::Uuid, uuid::Uuid, UserRole)>>>,
-        fail_assign: bool,
     }
 
     #[async_trait]
@@ -282,71 +157,12 @@ mod tests {
         }
     }
 
-    #[async_trait]
-    impl RoleAssignmentStore for StubAssignmentStore {
-        type Error = StubAssignmentError;
-
-        async fn assign_role_permissions(
-            &self,
-            tenant_id: &uuid::Uuid,
-            user_id: &uuid::Uuid,
-            role: UserRole,
-        ) -> Result<(), Self::Error> {
-            if self.fail_assign {
-                return Err(StubAssignmentError::Assign);
-            }
-            self.assigned
-                .lock()
-                .await
-                .push((*tenant_id, *user_id, role));
-            Ok(())
-        }
-
-        async fn replace_user_role(
-            &self,
-            tenant_id: &uuid::Uuid,
-            user_id: &uuid::Uuid,
-            role: UserRole,
-        ) -> Result<(), Self::Error> {
-            self.replaced
-                .lock()
-                .await
-                .push((*tenant_id, *user_id, role));
-            Ok(())
-        }
-
-        async fn remove_tenant_role_assignments(
-            &self,
-            tenant_id: &uuid::Uuid,
-            user_id: &uuid::Uuid,
-        ) -> Result<(), Self::Error> {
-            self.removed_tenant
-                .lock()
-                .await
-                .push((*tenant_id, *user_id));
-            Ok(())
-        }
-
-        async fn remove_user_role_assignment(
-            &self,
-            tenant_id: &uuid::Uuid,
-            user_id: &uuid::Uuid,
-            role: UserRole,
-        ) -> Result<(), Self::Error> {
-            self.removed_single
-                .lock()
-                .await
-                .push((*tenant_id, *user_id, role));
-            Ok(())
-        }
-    }
-
     #[tokio::test]
     async fn resolve_permissions_delegates_to_relation_and_cache_layer() {
         let role_id = uuid::Uuid::new_v4();
         let tenant_id = uuid::Uuid::new_v4();
         let user_id = uuid::Uuid::new_v4();
-        let resolver: RuntimePermissionResolver<_, _, _, ResolverError> =
+        let resolver: RuntimePermissionResolver<_, _, ResolverError> =
             RuntimePermissionResolver::new(
                 StubStore {
                     role_ids: vec![role_id],
@@ -355,7 +171,6 @@ mod tests {
                     fail_load: false,
                 },
                 StubCache::default(),
-                StubAssignmentStore::default(),
             );
 
         let first = resolver
@@ -373,155 +188,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn role_assignment_operations_invalidate_cached_permissions() {
-        let cache = StubCache::default();
-        let resolver: RuntimePermissionResolver<_, _, _, ResolverError> =
-            RuntimePermissionResolver::new(
-                StubStore {
-                    role_ids: vec![uuid::Uuid::new_v4()],
-                    tenant_role_ids: vec![uuid::Uuid::new_v4()],
-                    permissions: vec![Permission::PRODUCTS_READ],
-                    fail_load: false,
-                },
-                cache,
-                StubAssignmentStore::default(),
-            );
-        let tenant_id = uuid::Uuid::new_v4();
-        let user_id = uuid::Uuid::new_v4();
-
-        let first = resolver
-            .resolve_permissions(&tenant_id, &user_id)
-            .await
-            .unwrap();
-        assert!(!first.cache_hit);
-
-        let second = resolver
-            .resolve_permissions(&tenant_id, &user_id)
-            .await
-            .unwrap();
-        assert!(second.cache_hit);
-
-        resolver
-            .replace_user_role(&tenant_id, &user_id, UserRole::Admin)
-            .await
-            .unwrap();
-
-        let after_replace = resolver
-            .resolve_permissions(&tenant_id, &user_id)
-            .await
-            .unwrap();
-        assert!(!after_replace.cache_hit);
-
-        let after_replace_cached = resolver
-            .resolve_permissions(&tenant_id, &user_id)
-            .await
-            .unwrap();
-        assert!(after_replace_cached.cache_hit);
-
-        resolver
-            .remove_tenant_role_assignments(&tenant_id, &user_id)
-            .await
-            .unwrap();
-
-        let after_remove = resolver
-            .resolve_permissions(&tenant_id, &user_id)
-            .await
-            .unwrap();
-        assert!(!after_remove.cache_hit);
-    }
-
-    #[tokio::test]
-    async fn role_assignment_use_cases_delegate_to_assignment_store() {
-        let assignment_store = StubAssignmentStore::default();
-        let resolver: RuntimePermissionResolver<_, _, _, ResolverError> =
-            RuntimePermissionResolver::new(
-                StubStore {
-                    role_ids: vec![],
-                    tenant_role_ids: vec![],
-                    permissions: vec![],
-                    fail_load: false,
-                },
-                StubCache::default(),
-                assignment_store,
-            );
-        let tenant_id = uuid::Uuid::new_v4();
-        let user_id = uuid::Uuid::new_v4();
-
-        resolver
-            .assign_role_permissions(&tenant_id, &user_id, UserRole::Manager)
-            .await
-            .unwrap();
-        resolver
-            .replace_user_role(&tenant_id, &user_id, UserRole::Admin)
-            .await
-            .unwrap();
-        resolver
-            .remove_tenant_role_assignments(&tenant_id, &user_id)
-            .await
-            .unwrap();
-        resolver
-            .remove_user_role_assignment(&tenant_id, &user_id, UserRole::Manager)
-            .await
-            .unwrap();
-
-        let assigned = resolver.assignment_store.assigned.lock().await.clone();
-        let replaced = resolver.assignment_store.replaced.lock().await.clone();
-        let removed_tenant = resolver
-            .assignment_store
-            .removed_tenant
-            .lock()
-            .await
-            .clone();
-        let removed_single = resolver
-            .assignment_store
-            .removed_single
-            .lock()
-            .await
-            .clone();
-
-        assert_eq!(assigned, vec![(tenant_id, user_id, UserRole::Manager)]);
-        assert_eq!(replaced, vec![(tenant_id, user_id, UserRole::Admin)]);
-        assert_eq!(removed_tenant, vec![(tenant_id, user_id)]);
-        assert_eq!(
-            removed_single,
-            vec![(tenant_id, user_id, UserRole::Manager)]
-        );
-    }
-
-    #[tokio::test]
-    async fn assignment_error_is_mapped_to_runtime_resolver_error_type() {
-        let resolver: RuntimePermissionResolver<_, _, _, ResolverError> =
-            RuntimePermissionResolver::new(
-                StubStore {
-                    role_ids: vec![],
-                    tenant_role_ids: vec![],
-                    permissions: vec![],
-                    fail_load: false,
-                },
-                StubCache::default(),
-                StubAssignmentStore {
-                    fail_assign: true,
-                    ..StubAssignmentStore::default()
-                },
-            );
-
-        let result = resolver
-            .assign_role_permissions(
-                &uuid::Uuid::new_v4(),
-                &uuid::Uuid::new_v4(),
-                UserRole::Admin,
-            )
-            .await;
-
-        assert_eq!(
-            result.err(),
-            Some(ResolverError::Assignment(StubAssignmentError::Assign))
-        );
-    }
-
-    #[tokio::test]
     async fn relation_store_error_is_mapped_to_runtime_resolver_error_type() {
-        let resolver: RuntimePermissionResolver<_, _, _, ResolverError> =
+        let resolver: RuntimePermissionResolver<_, _, ResolverError> =
             RuntimePermissionResolver::new(
                 StubStore {
                     role_ids: vec![],
@@ -530,7 +198,6 @@ mod tests {
                     fail_load: true,
                 },
                 StubCache::default(),
-                StubAssignmentStore::default(),
             );
 
         let result = resolver


### PR DESCRIPTION
## Summary

- make `PermissionResolver` and `RuntimePermissionResolver` strictly read-only
- remove the public `RoleAssignmentStore` mutation composition path and its local-only cache invalidation
- route server-side role permission assignment through the existing RBAC persistence owner
- add a source regression guard preventing the mutation adapter from returning

## Verification context

This is the current-main replacement for draft #2843. The seven code/test blobs are transferred exactly onto `main@db554f67d6c3a5342b53f45d9f302abb8e5cf6db`; later RBAC incident and concurrency work is preserved, and the stale documentation blobs from #2843 are intentionally not copied.

Local Rust/Node execution is unavailable in the connector-only environment. Same-SHA formatting, Cargo check, Clippy, targeted tests, source verifier and module gates must be established by this PR's workflows before it can leave draft.

## Required gates

- `cargo fmt --all -- --check`
- `cargo check -p rustok-rbac --all-features`
- `cargo check -p rustok-server --lib`
- `cargo test -p rustok-rbac --all-features`
- `cargo test -p rustok-server --test rbac_permission_resolver_read_only_guard`
- `cargo xtask module validate rbac`
- `cargo xtask module test rbac`

Supersedes #2843 after this replacement has current-head CI evidence.