### PR TITLE
test(forum): add LINK canonical promotion packet

### DIFF
--- a/crates/rustok-forum/contracts/forum-search-link-forum-03-canonical-promotion-packet.json
+++ b/crates/rustok-forum/contracts/forum-search-link-forum-03-canonical-promotion-packet.json
@@ -1,0 +1,72 @@
+{
+  "contract": "forum_search_link_forum_03_canonical_promotion_packet_v1",
+  "task": "FORUM-23B2G2B3D19",
+  "target_link": "LINK-FORUM-03",
+  "status": "source_ready_maintainer_execution_pending",
+  "canonical_plan": "crates/rustok-forum/docs/implementation-plan.md",
+  "review_contract": "crates/rustok-forum/contracts/forum-search-link-forum-03-complete-evidence-promotion.json",
+  "promotion_candidate": "target/link-forum-03-forum-index-search-complete-promotion-candidate.json",
+  "complete_artifact": "target/link-forum-03-forum-index-search-complete-evidence.json",
+  "packet_builder": "scripts/evidence/prepare-link-forum-03-canonical-promotion-packet.mjs",
+  "verifier": "scripts/verify/verify-link-forum-03-canonical-promotion-packet.mjs",
+  "output_packet": {
+    "path": "target/link-forum-03-canonical-promotion-packet.json",
+    "status": "ready_for_separate_canonical_source_pull_request",
+    "hand_editing_forbidden": true,
+    "source_commit_required": true,
+    "atomic_replace": true,
+    "automatic_canonical_source_mutation": false
+  },
+  "required_plan_state": {
+    "forum_21": "planned",
+    "forum_23": "in_progress",
+    "link_forum_03": "planned"
+  },
+  "required_ledger_transition": {
+    "before": "| `LINK-FORUM-03` | `planned` | Forum/index/search ordering and visibility proof. |",
+    "after": "| `LINK-FORUM-03` | `done` | D13-D18 provide reviewed and retained Forum/index/search ordering, recovery, multilingual, moderation, private/trusted exclusion and topic-move evidence. |",
+    "exact_before_occurrences": 1,
+    "exact_after_occurrences_before_promotion": 0
+  },
+  "required_completion_record": [
+    "the canonical pull request cites the retained D18 promotion candidate and complete D17 artifact paths",
+    "the canonical pull request records the D18 reviewer identity review time retention reference and exact retained digest",
+    "the canonical pull request lists all six canonical LINK-FORUM-03 scenarios",
+    "the canonical pull request states that FORUM-21 remains planned and FORUM-23 remains in_progress",
+    "the canonical pull request does not claim that the source-ready D13-D19 chain ran unless the retained candidate exists and validates"
+  ],
+  "fail_closed_requirements": [
+    "the D18 contract has exact pending identity paths and proposed LINK-only transition",
+    "the D18 promotion candidate has exact approved identity current source commit reviewer retention and transition fields",
+    "the candidate canonical-plan digest equals the exact current plan bytes and records FORUM-21 planned FORUM-23 in_progress LINK-FORUM-03 planned",
+    "the candidate complete-artifact metadata equals the exact retained complete artifact bytes",
+    "the candidate review-contract digest equals the current D18 contract bytes",
+    "all four candidate source-artifact records match the exact retained D13 D14 D15 and D16 bytes metadata and scenario identities",
+    "the current canonical plan contains the exact planned LINK-FORUM-03 ledger row once and no done row",
+    "the packet records exact candidate contract plan complete-artifact and source-artifact digests",
+    "the packet describes but never performs the canonical edit",
+    "the packet is written only after complete validation by same-directory atomic rename",
+    "the builder accepts no arguments overrides missing-artifact mode skipped results static fallback or source-commit override"
+  ],
+  "proposed_transition": {
+    "task": "LINK-FORUM-03",
+    "from": "planned",
+    "to": "done",
+    "requires_separate_canonical_source_pull_request": true,
+    "canonical_source_mutated_by_builder": false,
+    "promotes_forum_21": false,
+    "promotes_forum_23": false
+  },
+  "maintainer_commands": [
+    "node scripts/verify/verify-link-forum-03-canonical-promotion-packet.mjs",
+    "node scripts/evidence/prepare-link-forum-03-canonical-promotion-packet.mjs"
+  ],
+  "non_claims": [
+    "this source-ready slice does not claim that D13 D14 D15 D16 D17 D18 or any runtime command ran",
+    "this packet builder does not generate repair infer or accept a missing D18 promotion candidate",
+    "this packet builder does not authenticate external retention or create a cryptographic signature",
+    "this packet builder does not edit the canonical Forum plan",
+    "this packet does not promote FORUM-21 or mark FORUM-23 done",
+    "a generated packet is an input to a separate reviewed canonical-source pull request and is not itself a status change"
+  ]
+}

--- a/crates/rustok-forum/docs/forum-23b2g2b3d19-link-forum-03-canonical-promotion-packet.md
+++ b/crates/rustok-forum/docs/forum-23b2g2b3d19-link-forum-03-canonical-promotion-packet.md
@@ -1,0 +1,166 @@
+# FORUM-23B2G2B3D19 LINK-FORUM-03 canonical promotion packet
+
+## Status
+
+`source_ready_maintainer_execution_pending`
+
+D19 adds the final source-ready handoff boundary between a retained D18 promotion
+candidate and a separate human-reviewed canonical-source pull request. It does
+not execute Forum, Search, PostgreSQL, Iggy or storefront code and does not edit
+the canonical Forum plan.
+
+The machine contract is:
+
+```text
+crates/rustok-forum/contracts/forum-search-link-forum-03-canonical-promotion-packet.json
+```
+
+The packet builder is:
+
+```text
+scripts/evidence/prepare-link-forum-03-canonical-promotion-packet.mjs
+```
+
+The generated packet is:
+
+```text
+target/link-forum-03-canonical-promotion-packet.json
+```
+
+## Why D19 remains separate
+
+D18 can generate an approved promotion candidate only after an independent
+reviewer supplies an identity, immutable retention reference and the exact
+retained SHA-256 of the complete D17 artifact. That candidate deliberately does
+not edit canonical source.
+
+D19 converts the validated candidate into a bounded canonical-PR packet. The
+packet records the exact current plan digest, the exact planned ledger row, the
+proposed done row, all retained evidence identities and the required completion
+record. It still does not apply the edit.
+
+This separation prevents a reviewer script from both approving its own evidence
+and changing the canonical roadmap.
+
+## Required retained inputs
+
+All inputs must exist on the exact checked-out commit:
+
+```text
+target/link-forum-03-forum-index-search-complete-promotion-candidate.json
+target/link-forum-03-forum-index-search-complete-evidence.json
+target/link-forum-03-forum-index-search-ordering-visibility-evidence.json
+target/forum-search-link-forum-03-translation-moderation-evidence.json
+target/forum-search-link-forum-03-private-trusted-exclusion-evidence.json
+target/forum-search-link-forum-03-topic-move-evidence.json
+```
+
+The D18 and D19 contracts and canonical Forum plan must also be the exact current
+repository bytes.
+
+Missing files, mixed commits, copied fixtures, hand-edited evidence and skipped
+runtime results are rejected.
+
+## Fail-closed validation
+
+Before writing the packet, the builder checks:
+
+1. D19 has the exact pending machine-contract identity, paths, output boundary
+   and LINK-only proposed transition;
+2. D18 has the exact pending review-contract identity and still requires a
+   separate canonical-source pull request;
+3. the D18 candidate is approved, targets only `LINK-FORUM-03`, belongs to the
+   current `HEAD` and contains bounded reviewer and retention fields;
+4. the candidate retained digest equals the exact complete D17 artifact bytes;
+5. the complete artifact retains its exact review-pending status, canonical
+   runtime coverage, six scenarios and current source commit;
+6. the D18 review-contract digest in the candidate equals the current D18
+   contract bytes;
+7. the candidate canonical-plan digest equals the exact current plan bytes and
+   records `FORUM-21` as `planned`, `FORUM-23` as `in_progress` and
+   `LINK-FORUM-03` as `planned`;
+8. all four D13-D16 source records match the exact retained artifact path, task,
+   contract, source commit, generation time, SHA-256, byte length and scenario
+   identity;
+9. all D18 validation assertions remain true;
+10. the current plan contains the exact planned `LINK-FORUM-03` row once and the
+    proposed done row zero times;
+11. the packet is written only after validation by same-directory atomic rename.
+
+The builder accepts no command-line arguments, source-commit override,
+missing-artifact mode, skipped-result acceptance or static fallback.
+
+## Proposed ledger transition
+
+The exact current row is:
+
+```text
+| `LINK-FORUM-03` | `planned` | Forum/index/search ordering and visibility proof. |
+```
+
+The packet proposes:
+
+```text
+| `LINK-FORUM-03` | `done` | D13-D18 provide reviewed and retained Forum/index/search ordering, recovery, multilingual, moderation, private/trusted exclusion and topic-move evidence. |
+```
+
+D19 does not perform this replacement.
+
+## Required completion record
+
+The separate canonical-source pull request must update the ledger and completion
+evidence together. It must record:
+
+- the retained D18 promotion-candidate path and digest;
+- the complete D17 artifact path and digest;
+- the four retained D13-D16 source artifacts;
+- all six canonical scenario identities;
+- reviewer identity and review time;
+- immutable retention reference and retained complete-artifact SHA-256;
+- that `FORUM-21` remains `planned`;
+- that `FORUM-23` remains `in_progress`;
+- that `LINK-FORUM-03` is the only proposed status change.
+
+The canonical pull request must revalidate the packet against its exact `HEAD`.
+A stale packet cannot authorize a plan change after unrelated plan edits.
+
+## Maintainer order
+
+After executing and retaining the full D13-D18 chain, run:
+
+```bash
+node scripts/verify/verify-link-forum-03-canonical-promotion-packet.mjs
+node scripts/evidence/prepare-link-forum-03-canonical-promotion-packet.mjs
+```
+
+Then open a separate canonical-source pull request using the generated packet as
+review input. Do not copy the proposed row without also carrying the retained
+candidate and completion evidence.
+
+## Canonical boundary
+
+The packet may support only:
+
+```text
+LINK-FORUM-03: planned -> done
+```
+
+It explicitly records:
+
+```text
+canonical_source_mutated_by_builder = false
+promotes_forum_21 = false
+promotes_forum_23 = false
+```
+
+`FORUM-21` remains an independent move/merge/split/fork owner-workflow task.
+`FORUM-23` retains broader unfinished Search product scope.
+
+## Deliberate boundary
+
+D19 adds a contract, packet builder, verifier and handoff only. It changes no
+Rust production code, migration, event schema, transport, runtime flag,
+dependency, `Cargo.toml`, `Cargo.lock`, D0-D18 artifact schema or canonical task
+status.
+
+No command above was run by the implementation agent, per maintainer request.

--- a/scripts/evidence/prepare-link-forum-03-canonical-promotion-packet.mjs
+++ b/scripts/evidence/prepare-link-forum-03-canonical-promotion-packet.mjs
@@ -1,0 +1,525 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const root = process.cwd();
+const contractPath =
+  "crates/rustok-forum/contracts/forum-search-link-forum-03-canonical-promotion-packet.json";
+const reviewContractPath =
+  "crates/rustok-forum/contracts/forum-search-link-forum-03-complete-evidence-promotion.json";
+const planPath = "crates/rustok-forum/docs/implementation-plan.md";
+const candidatePath =
+  "target/link-forum-03-forum-index-search-complete-promotion-candidate.json";
+const completePath =
+  "target/link-forum-03-forum-index-search-complete-evidence.json";
+const outputPath = "target/link-forum-03-canonical-promotion-packet.json";
+
+const plannedRow =
+  "| `LINK-FORUM-03` | `planned` | Forum/index/search ordering and visibility proof. |";
+const doneRow =
+  "| `LINK-FORUM-03` | `done` | D13-D18 provide reviewed and retained Forum/index/search ordering, recovery, multilingual, moderation, private/trusted exclusion and topic-move evidence. |";
+const forum21Row =
+  "| `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |";
+const forum23Marker = "| `FORUM-23` | `in_progress` |";
+
+const scenarioIds = [
+  "normal_delivery",
+  "deletion_acl_ordering",
+  "search_disabled_profile",
+  "translation_and_moderation_approval",
+  "private_and_trusted_channel_exclusion",
+  "topic_move_category_scope",
+];
+
+const sourceSpecs = [
+  {
+    path: "target/link-forum-03-forum-index-search-ordering-visibility-evidence.json",
+    task: "LINK-FORUM-03",
+    contract: "link_forum_03_forum_index_search_ordering_visibility_evidence_v1",
+    scenarios: scenarioIds.slice(0, 3),
+  },
+  {
+    path: "target/forum-search-link-forum-03-translation-moderation-evidence.json",
+    task: "FORUM-23B2G2B3D14",
+    contract: "forum_search_link_forum_03_translation_moderation_evidence_v1",
+    scenarios: ["translation_and_moderation_approval"],
+  },
+  {
+    path: "target/forum-search-link-forum-03-private-trusted-exclusion-evidence.json",
+    task: "FORUM-23B2G2B3D15",
+    contract: "forum_search_link_forum_03_private_trusted_exclusion_proof_v1",
+    scenarios: ["private_and_trusted_channel_exclusion"],
+  },
+  {
+    path: "target/forum-search-link-forum-03-topic-move-evidence.json",
+    task: "FORUM-23B2G2B3D16",
+    contract: "forum_search_link_forum_03_topic_move_evidence_v1",
+    scenarios: ["topic_move_category_scope"],
+  },
+];
+
+function fail(message) {
+  throw new Error(`LINK-FORUM-03 canonical promotion packet failed: ${message}`);
+}
+
+function readBytes(path) {
+  try {
+    return readFileSync(resolve(root, path));
+  } catch (error) {
+    fail(`cannot read ${path}: ${error.message}`);
+  }
+}
+
+function parseJson(path, bytes = readBytes(path)) {
+  try {
+    return JSON.parse(bytes.toString("utf8"));
+  } catch (error) {
+    fail(`${path} is not valid JSON: ${error.message}`);
+  }
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+}
+
+function requireString(value, label) {
+  if (typeof value !== "string" || value.trim() === "") {
+    fail(`${label} must be a non-empty string`);
+  }
+}
+
+function requireTimestamp(value, label) {
+  requireString(value, label);
+  if (!Number.isFinite(Date.parse(value))) {
+    fail(`${label} must be an ISO timestamp`);
+  }
+}
+
+function requireDigest(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/.test(value)) {
+    fail(`${label} must be a lowercase SHA-256 digest`);
+  }
+}
+
+function requireCommit(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{40}$/.test(value)) {
+    fail(`${label} must be a lowercase forty-character Git commit SHA`);
+  }
+}
+
+function exactArray(actual, expected, label) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    fail(`${label} order or membership drifted`);
+  }
+}
+
+function exactJson(actual, expected, label) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    fail(`${label} drifted`);
+  }
+}
+
+function countOccurrences(text, marker) {
+  return text.split(marker).length - 1;
+}
+
+function currentHead() {
+  let head;
+  try {
+    head = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (error) {
+    fail(`git rev-parse HEAD failed: ${error.message}`);
+  }
+  requireCommit(head, "git rev-parse HEAD");
+  return head;
+}
+
+function validatePacketContract(contract) {
+  requireObject(contract, "D19 contract");
+  if (
+    contract.contract !==
+      "forum_search_link_forum_03_canonical_promotion_packet_v1" ||
+    contract.task !== "FORUM-23B2G2B3D19" ||
+    contract.target_link !== "LINK-FORUM-03" ||
+    contract.status !== "source_ready_maintainer_execution_pending" ||
+    contract.canonical_plan !== planPath ||
+    contract.review_contract !== reviewContractPath ||
+    contract.promotion_candidate !== candidatePath ||
+    contract.complete_artifact !== completePath ||
+    contract.packet_builder !==
+      "scripts/evidence/prepare-link-forum-03-canonical-promotion-packet.mjs" ||
+    contract.verifier !==
+      "scripts/verify/verify-link-forum-03-canonical-promotion-packet.mjs"
+  ) {
+    fail("D19 contract identity or paths drifted");
+  }
+  if (
+    contract.output_packet?.path !== outputPath ||
+    contract.output_packet?.status !==
+      "ready_for_separate_canonical_source_pull_request" ||
+    contract.output_packet?.hand_editing_forbidden !== true ||
+    contract.output_packet?.source_commit_required !== true ||
+    contract.output_packet?.atomic_replace !== true ||
+    contract.output_packet?.automatic_canonical_source_mutation !== false
+  ) {
+    fail("D19 output packet boundary drifted");
+  }
+  if (
+    contract.required_ledger_transition?.before !== plannedRow ||
+    contract.required_ledger_transition?.after !== doneRow ||
+    contract.required_ledger_transition?.exact_before_occurrences !== 1 ||
+    contract.required_ledger_transition?.exact_after_occurrences_before_promotion !== 0
+  ) {
+    fail("D19 required ledger transition drifted");
+  }
+  if (
+    contract.proposed_transition?.task !== "LINK-FORUM-03" ||
+    contract.proposed_transition?.from !== "planned" ||
+    contract.proposed_transition?.to !== "done" ||
+    contract.proposed_transition?.requires_separate_canonical_source_pull_request !== true ||
+    contract.proposed_transition?.canonical_source_mutated_by_builder !== false ||
+    contract.proposed_transition?.promotes_forum_21 !== false ||
+    contract.proposed_transition?.promotes_forum_23 !== false
+  ) {
+    fail("D19 proposed transition drifted");
+  }
+}
+
+function validateReviewContract(contract) {
+  requireObject(contract, "D18 review contract");
+  if (
+    contract.contract !==
+      "forum_search_link_forum_03_complete_evidence_promotion_v1" ||
+    contract.task !== "FORUM-23B2G2B3D18" ||
+    contract.target_link !== "LINK-FORUM-03" ||
+    contract.status !== "source_ready_maintainer_execution_pending" ||
+    contract.canonical_plan !== planPath ||
+    contract.promotion_candidate?.path !== candidatePath ||
+    contract.complete_artifact !== completePath
+  ) {
+    fail("D18 review contract identity or paths drifted");
+  }
+  exactArray(contract.required_scenarios, scenarioIds, "D18 required scenarios");
+  if (
+    contract.proposed_transition?.task !== "LINK-FORUM-03" ||
+    contract.proposed_transition?.from !== "planned" ||
+    contract.proposed_transition?.to !== "done" ||
+    contract.proposed_transition?.requires_separate_canonical_source_pull_request !== true ||
+    contract.proposed_transition?.canonical_source_mutated_by_reviewer !== false ||
+    contract.proposed_transition?.promotes_forum_21 !== false ||
+    contract.proposed_transition?.promotes_forum_23 !== false
+  ) {
+    fail("D18 transition boundary drifted");
+  }
+}
+
+function validatePlan(plan, planDigest) {
+  if (countOccurrences(plan, plannedRow) !== 1) {
+    fail("canonical plan must contain the exact planned LINK-FORUM-03 row once");
+  }
+  if (countOccurrences(plan, doneRow) !== 0) {
+    fail("canonical plan already contains the D19 done row");
+  }
+  if (!plan.includes(forum21Row) || !plan.includes(forum23Marker)) {
+    fail("canonical plan no longer preserves FORUM-21 planned and FORUM-23 in_progress");
+  }
+  return {
+    path: planPath,
+    sha256_before: planDigest,
+    statuses_before: {
+      forum_21: "planned",
+      forum_23: "in_progress",
+      link_forum_03: "planned",
+    },
+  };
+}
+
+function validateCompleteArtifact(candidate, head) {
+  const bytes = readBytes(completePath);
+  const artifact = parseJson(completePath, bytes);
+  requireObject(artifact, "D17 complete artifact");
+  if (
+    artifact.contract !== "link_forum_03_forum_index_search_complete_evidence_v1" ||
+    artifact.task !== "LINK-FORUM-03" ||
+    artifact.source_slice !== "FORUM-23B2G2B3D17" ||
+    artifact.status !== "complete_runtime_evidence_assembled_review_pending" ||
+    artifact.coverage !== "canonical_link_forum_03_runtime_scope" ||
+    artifact.source_commit !== head
+  ) {
+    fail("D17 complete artifact identity status coverage or source commit drifted");
+  }
+  requireTimestamp(artifact.generated_at, "D17 complete artifact generated_at");
+  exactArray(artifact.assembled_scenario_ids, scenarioIds, "D17 complete scenarios");
+  const digest = sha256(bytes);
+  if (
+    candidate.complete_artifact?.path !== completePath ||
+    candidate.complete_artifact?.sha256 !== digest ||
+    candidate.complete_artifact?.byte_length !== bytes.length ||
+    candidate.complete_artifact?.generated_at !== artifact.generated_at ||
+    candidate.complete_artifact?.status_at_review !== artifact.status ||
+    candidate.complete_artifact?.coverage !== artifact.coverage
+  ) {
+    fail("D18 candidate complete-artifact metadata drifted");
+  }
+  exactArray(candidate.complete_artifact.scenario_ids, scenarioIds, "candidate scenarios");
+  return {
+    path: completePath,
+    sha256: digest,
+    byte_length: bytes.length,
+    generated_at: artifact.generated_at,
+    status: artifact.status,
+    coverage: artifact.coverage,
+    scenario_ids: scenarioIds,
+  };
+}
+
+function validateSources(candidate, head) {
+  if (!Array.isArray(candidate.source_artifacts)) {
+    fail("D18 candidate source_artifacts must be an array");
+  }
+  exactArray(
+    candidate.source_artifacts.map(({ path }) => path),
+    sourceSpecs.map(({ path }) => path),
+    "D18 candidate source-artifact paths",
+  );
+  return sourceSpecs.map((spec, index) => {
+    const bytes = readBytes(spec.path);
+    const artifact = parseJson(spec.path, bytes);
+    const retained = candidate.source_artifacts[index];
+    requireObject(artifact, spec.path);
+    if (
+      artifact.contract !== spec.contract ||
+      artifact.task !== spec.task ||
+      artifact.source_commit !== head
+    ) {
+      fail(`${spec.path} identity or source commit drifted`);
+    }
+    requireTimestamp(artifact.generated_at, `${spec.path}.generated_at`);
+    const digest = sha256(bytes);
+    if (
+      retained.path !== spec.path ||
+      retained.task !== spec.task ||
+      retained.contract !== spec.contract ||
+      retained.source_commit !== head ||
+      retained.generated_at !== artifact.generated_at ||
+      retained.sha256 !== digest ||
+      retained.byte_length !== bytes.length
+    ) {
+      fail(`D18 retained metadata drifted for ${spec.path}`);
+    }
+    exactArray(retained.scenario_ids, spec.scenarios, `${spec.path} scenarios`);
+    return {
+      path: spec.path,
+      task: spec.task,
+      contract: spec.contract,
+      source_commit: head,
+      generated_at: artifact.generated_at,
+      sha256: digest,
+      byte_length: bytes.length,
+      scenario_ids: spec.scenarios,
+    };
+  });
+}
+
+function validateCandidate(candidate, candidateBytes, reviewContractBytes, planBytes, head) {
+  requireObject(candidate, "D18 promotion candidate");
+  if (
+    candidate.contract !==
+      "link_forum_03_forum_index_search_complete_promotion_candidate_v1" ||
+    candidate.task !== "FORUM-23B2G2B3D18" ||
+    candidate.target_link !== "LINK-FORUM-03" ||
+    candidate.status !== "approved_for_canonical_status_promotion" ||
+    candidate.source_commit !== head
+  ) {
+    fail("D18 promotion candidate identity status or source commit drifted");
+  }
+  requireTimestamp(candidate.reviewed_at, "candidate.reviewed_at");
+  requireString(candidate.reviewer, "candidate.reviewer");
+  requireObject(candidate.retention, "candidate.retention");
+  requireString(candidate.retention.reference, "candidate.retention.reference");
+  requireDigest(candidate.retention.attested_sha256, "candidate retained digest");
+  if (
+    candidate.retention.matches_reviewed_complete_artifact !== true ||
+    candidate.retention.external_service_authentication_performed_by_script !== false ||
+    candidate.retention.cryptographic_signature_created_by_script !== false
+  ) {
+    fail("D18 candidate retention boundary drifted");
+  }
+  const planDigest = sha256(planBytes);
+  if (
+    candidate.canonical_plan?.path !== planPath ||
+    candidate.canonical_plan?.sha256 !== planDigest ||
+    candidate.canonical_plan?.forum_21_status_at_review !== "planned" ||
+    candidate.canonical_plan?.forum_23_status_at_review !== "in_progress" ||
+    candidate.canonical_plan?.link_forum_03_status_at_review !== "planned"
+  ) {
+    fail("D18 candidate canonical-plan identity status or digest drifted");
+  }
+  if (
+    candidate.review_contract?.path !== reviewContractPath ||
+    candidate.review_contract?.sha256 !== sha256(reviewContractBytes) ||
+    candidate.review_contract?.status_at_review !==
+      "source_ready_maintainer_execution_pending"
+  ) {
+    fail("D18 candidate review-contract metadata drifted");
+  }
+  if (
+    candidate.proposed_transition?.task !== "LINK-FORUM-03" ||
+    candidate.proposed_transition?.from !== "planned" ||
+    candidate.proposed_transition?.to !== "done" ||
+    candidate.proposed_transition?.separate_canonical_source_pull_request_required !== true ||
+    candidate.proposed_transition?.canonical_source_mutated_by_reviewer !== false ||
+    candidate.proposed_transition?.promotes_forum_21 !== false ||
+    candidate.proposed_transition?.promotes_forum_23 !== false
+  ) {
+    fail("D18 candidate transition boundary drifted");
+  }
+  for (const field of [
+    "all_six_canonical_scenarios_revalidated",
+    "all_four_source_artifacts_revalidated",
+    "all_source_digests_match_complete_artifact",
+    "all_scenario_facts_match_retained_sources",
+    "complete_artifact_source_commit_matches_current_head",
+    "complete_artifact_was_review_pending_before_review",
+    "retained_digest_attested_by_maintainer",
+    "canonical_plan_remained_unmodified",
+  ]) {
+    if (candidate.validation?.[field] !== true) {
+      fail(`D18 candidate validation.${field} must be true`);
+    }
+  }
+  const complete = validateCompleteArtifact(candidate, head);
+  if (candidate.retention.attested_sha256 !== complete.sha256) {
+    fail("D18 retained digest does not equal the exact complete artifact digest");
+  }
+  const sources = validateSources(candidate, head);
+  return {
+    candidate: {
+      path: candidatePath,
+      sha256: sha256(candidateBytes),
+      byte_length: candidateBytes.length,
+      source_commit: candidate.source_commit,
+      reviewed_at: candidate.reviewed_at,
+      reviewer: candidate.reviewer,
+      retention: candidate.retention,
+    },
+    complete,
+    sources,
+  };
+}
+
+if (process.argv.length !== 2) {
+  fail("this packet builder accepts no command-line arguments");
+}
+
+const head = currentHead();
+const contractBytes = readBytes(contractPath);
+validatePacketContract(parseJson(contractPath, contractBytes));
+const reviewContractBytes = readBytes(reviewContractPath);
+validateReviewContract(parseJson(reviewContractPath, reviewContractBytes));
+const planBytes = readBytes(planPath);
+const planText = planBytes.toString("utf8");
+const plan = validatePlan(planText, sha256(planBytes));
+const candidateBytes = readBytes(candidatePath);
+const validated = validateCandidate(
+  parseJson(candidatePath, candidateBytes),
+  candidateBytes,
+  reviewContractBytes,
+  planBytes,
+  head,
+);
+
+const output = {
+  contract: "link_forum_03_canonical_promotion_packet_v1",
+  task: "FORUM-23B2G2B3D19",
+  target_link: "LINK-FORUM-03",
+  status: "ready_for_separate_canonical_source_pull_request",
+  source_commit: head,
+  generated_at: new Date().toISOString(),
+  promotion_candidate: validated.candidate,
+  complete_artifact: validated.complete,
+  source_artifacts: validated.sources,
+  review_contract: {
+    path: reviewContractPath,
+    sha256: sha256(reviewContractBytes),
+  },
+  packet_contract: {
+    path: contractPath,
+    sha256: sha256(contractBytes),
+  },
+  canonical_plan: plan,
+  required_ledger_edit: {
+    before: plannedRow,
+    after: doneRow,
+    exact_before_occurrences: 1,
+    exact_after_occurrences_before_promotion: 0,
+    automatic_application_performed: false,
+  },
+  required_completion_record: {
+    evidence_paths: [candidatePath, completePath, ...sourceSpecs.map(({ path }) => path)],
+    scenario_ids: scenarioIds,
+    reviewer: validated.candidate.reviewer,
+    reviewed_at: validated.candidate.reviewed_at,
+    retention_reference: validated.candidate.retention.reference,
+    retained_complete_artifact_sha256:
+      validated.candidate.retention.attested_sha256,
+    explicit_boundaries: {
+      forum_21_remains_planned: true,
+      forum_23_remains_in_progress: true,
+      link_forum_03_is_the_only_proposed_status_change: true,
+    },
+  },
+  canonical_pull_request_requirements: {
+    revalidate_packet_against_exact_head: true,
+    update_ledger_and_completion_evidence_together: true,
+    preserve_forum_21_status: "planned",
+    preserve_forum_23_status: "in_progress",
+    cite_reviewer_and_retention_attestation: true,
+    claim_runtime_execution_only_from_retained_candidate: true,
+  },
+  assertions: {
+    d18_candidate_approved_and_revalidated: true,
+    complete_and_source_artifact_bytes_match_candidate: true,
+    candidate_plan_digest_matches_current_plan: true,
+    exact_planned_ledger_row_present_once: true,
+    exact_done_ledger_row_absent: true,
+    canonical_source_mutated_by_builder: false,
+    promotes_forum_21: false,
+    promotes_forum_23: false,
+  },
+};
+
+const absoluteOutput = resolve(root, outputPath);
+mkdirSync(dirname(absoluteOutput), { recursive: true });
+const temporaryOutput = `${absoluteOutput}.${process.pid}.${Date.now()}.tmp`;
+try {
+  writeFileSync(temporaryOutput, `${JSON.stringify(output, null, 2)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+  });
+  renameSync(temporaryOutput, absoluteOutput);
+} catch (error) {
+  rmSync(temporaryOutput, { force: true });
+  fail(`atomic promotion-packet write failed: ${error.message}`);
+}
+
+console.log(`wrote LINK-FORUM-03 canonical promotion packet to ${outputPath}`);

--- a/scripts/verify/verify-link-forum-03-canonical-promotion-packet.mjs
+++ b/scripts/verify/verify-link-forum-03-canonical-promotion-packet.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const contractPath =
+  "crates/rustok-forum/contracts/forum-search-link-forum-03-canonical-promotion-packet.json";
+const reviewContractPath =
+  "crates/rustok-forum/contracts/forum-search-link-forum-03-complete-evidence-promotion.json";
+const docsPath =
+  "crates/rustok-forum/docs/forum-23b2g2b3d19-link-forum-03-canonical-promotion-packet.md";
+const builderPath =
+  "scripts/evidence/prepare-link-forum-03-canonical-promotion-packet.mjs";
+const verifierPath =
+  "scripts/verify/verify-link-forum-03-canonical-promotion-packet.mjs";
+const planPath = "crates/rustok-forum/docs/implementation-plan.md";
+const candidatePath =
+  "target/link-forum-03-forum-index-search-complete-promotion-candidate.json";
+const completePath =
+  "target/link-forum-03-forum-index-search-complete-evidence.json";
+const outputPath = "target/link-forum-03-canonical-promotion-packet.json";
+const plannedRow =
+  "| `LINK-FORUM-03` | `planned` | Forum/index/search ordering and visibility proof. |";
+const doneRow =
+  "| `LINK-FORUM-03` | `done` | D13-D18 provide reviewed and retained Forum/index/search ordering, recovery, multilingual, moderation, private/trusted exclusion and topic-move evidence. |";
+const scenarios = [
+  "normal_delivery",
+  "deletion_acl_ordering",
+  "search_disabled_profile",
+  "translation_and_moderation_approval",
+  "private_and_trusted_channel_exclusion",
+  "topic_move_category_scope",
+];
+const sourcePaths = [
+  "target/link-forum-03-forum-index-search-ordering-visibility-evidence.json",
+  "target/forum-search-link-forum-03-translation-moderation-evidence.json",
+  "target/forum-search-link-forum-03-private-trusted-exclusion-evidence.json",
+  "target/forum-search-link-forum-03-topic-move-evidence.json",
+];
+
+function read(path) {
+  return readFileSync(path, "utf8");
+}
+
+function count(text, marker) {
+  return text.split(marker).length - 1;
+}
+
+function includesAll(text, markers, label) {
+  for (const marker of markers) {
+    assert.ok(text.includes(marker), `${label} is missing marker: ${marker}`);
+  }
+}
+
+const contract = JSON.parse(read(contractPath));
+const reviewContract = JSON.parse(read(reviewContractPath));
+const docs = read(docsPath);
+const builder = read(builderPath);
+const verifier = read(verifierPath);
+const plan = read(planPath);
+
+assert.equal(
+  contract.contract,
+  "forum_search_link_forum_03_canonical_promotion_packet_v1",
+);
+assert.equal(contract.task, "FORUM-23B2G2B3D19");
+assert.equal(contract.target_link, "LINK-FORUM-03");
+assert.equal(contract.status, "source_ready_maintainer_execution_pending");
+assert.equal(contract.canonical_plan, planPath);
+assert.equal(contract.review_contract, reviewContractPath);
+assert.equal(contract.promotion_candidate, candidatePath);
+assert.equal(contract.complete_artifact, completePath);
+assert.equal(contract.packet_builder, builderPath);
+assert.equal(contract.verifier, verifierPath);
+assert.deepEqual(contract.output_packet, {
+  path: outputPath,
+  status: "ready_for_separate_canonical_source_pull_request",
+  hand_editing_forbidden: true,
+  source_commit_required: true,
+  atomic_replace: true,
+  automatic_canonical_source_mutation: false,
+});
+assert.deepEqual(contract.required_plan_state, {
+  forum_21: "planned",
+  forum_23: "in_progress",
+  link_forum_03: "planned",
+});
+assert.deepEqual(contract.required_ledger_transition, {
+  before: plannedRow,
+  after: doneRow,
+  exact_before_occurrences: 1,
+  exact_after_occurrences_before_promotion: 0,
+});
+assert.deepEqual(contract.proposed_transition, {
+  task: "LINK-FORUM-03",
+  from: "planned",
+  to: "done",
+  requires_separate_canonical_source_pull_request: true,
+  canonical_source_mutated_by_builder: false,
+  promotes_forum_21: false,
+  promotes_forum_23: false,
+});
+assert.equal(contract.fail_closed_requirements.length, 11);
+assert.equal(contract.required_completion_record.length, 5);
+assert.deepEqual(contract.maintainer_commands, [
+  `node ${verifierPath}`,
+  `node ${builderPath}`,
+]);
+
+assert.equal(
+  reviewContract.contract,
+  "forum_search_link_forum_03_complete_evidence_promotion_v1",
+);
+assert.equal(reviewContract.task, "FORUM-23B2G2B3D18");
+assert.equal(reviewContract.target_link, "LINK-FORUM-03");
+assert.equal(reviewContract.status, "source_ready_maintainer_execution_pending");
+assert.equal(reviewContract.canonical_plan, planPath);
+assert.equal(reviewContract.complete_artifact, completePath);
+assert.equal(reviewContract.promotion_candidate.path, candidatePath);
+assert.deepEqual(reviewContract.required_scenarios, scenarios);
+assert.deepEqual(reviewContract.required_source_artifacts, sourcePaths);
+assert.deepEqual(reviewContract.proposed_transition, {
+  task: "LINK-FORUM-03",
+  from: "planned",
+  to: "done",
+  requires_separate_canonical_source_pull_request: true,
+  canonical_source_mutated_by_reviewer: false,
+  promotes_forum_21: false,
+  promotes_forum_23: false,
+});
+
+assert.equal(count(plan, plannedRow), 1);
+assert.equal(count(plan, doneRow), 0);
+assert.ok(
+  plan.includes(
+    "| `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |",
+  ),
+);
+assert.ok(plan.includes("| `FORUM-23` | `in_progress` |"));
+assert.ok(!plan.includes("| `LINK-FORUM-03` | `done` |"));
+
+includesAll(
+  builder,
+  [
+    `const contractPath =\n  "${contractPath}";`,
+    `const reviewContractPath =\n  "${reviewContractPath}";`,
+    `const planPath = "${planPath}";`,
+    `const candidatePath =\n  "${candidatePath}";`,
+    `const completePath =\n  "${completePath}";`,
+    `const outputPath = "${outputPath}";`,
+    "git\", [\"rev-parse\", \"HEAD\"]",
+    "this packet builder accepts no command-line arguments",
+    "candidate.retention.attested_sha256 !== complete.sha256",
+    "candidate.canonical_plan?.sha256 !== planDigest",
+    "candidate.review_contract?.sha256 !== sha256(reviewContractBytes)",
+    "candidate.proposed_transition?.separate_canonical_source_pull_request_required !== true",
+    "contract.proposed_transition?.promotes_forum_21 !== false",
+    "contract.proposed_transition?.promotes_forum_23 !== false",
+    "exact_before_occurrences: 1",
+    "exact_after_occurrences_before_promotion: 0",
+    "automatic_application_performed: false",
+    "canonical_source_mutated_by_builder: false",
+    "writeFileSync(temporaryOutput",
+    "renameSync(temporaryOutput, absoluteOutput)",
+    "flag: \"wx\"",
+  ],
+  "packet builder",
+);
+for (const scenario of scenarios) {
+  assert.ok(builder.includes(`"${scenario}"`), `builder is missing ${scenario}`);
+}
+for (const path of sourcePaths) {
+  assert.ok(builder.includes(path), `builder is missing source path ${path}`);
+}
+for (const marker of [
+  "approved_for_canonical_status_promotion",
+  "complete_runtime_evidence_assembled_review_pending",
+  "canonical_link_forum_03_runtime_scope",
+  "all_six_canonical_scenarios_revalidated",
+  "all_four_source_artifacts_revalidated",
+  "all_source_digests_match_complete_artifact",
+  "all_scenario_facts_match_retained_sources",
+  "retained_digest_attested_by_maintainer",
+  "canonical_plan_remained_unmodified",
+]) {
+  assert.ok(builder.includes(marker), `builder is missing candidate marker ${marker}`);
+}
+
+for (const forbidden of [
+  "writeFileSync(planPath",
+  "writeFileSync(resolve(root, planPath)",
+  "renameSync(temporaryOutput, resolve(root, planPath))",
+  "process.argv[2]",
+  "ALLOW_MISSING",
+  "SKIP_VALIDATION",
+  "sourceCommitOverride",
+  "bestEffort",
+]) {
+  assert.ok(!builder.includes(forbidden), `builder contains forbidden marker: ${forbidden}`);
+}
+
+includesAll(
+  docs,
+  [
+    "# FORUM-23B2G2B3D19 LINK-FORUM-03 canonical promotion packet",
+    "`source_ready_maintainer_execution_pending`",
+    contractPath,
+    builderPath,
+    outputPath,
+    candidatePath,
+    completePath,
+    plannedRow,
+    doneRow,
+    "LINK-FORUM-03: planned -> done",
+    "canonical_source_mutated_by_builder = false",
+    "promotes_forum_21 = false",
+    "promotes_forum_23 = false",
+    "No command above was run by the implementation agent",
+  ],
+  "D19 handoff",
+);
+for (const scenario of scenarios) {
+  assert.ok(
+    contract.required_completion_record.some((value) =>
+      value.includes("six canonical LINK-FORUM-03 scenarios"),
+    ),
+    `contract completion record does not cover ${scenario}`,
+  );
+}
+
+assert.ok(verifier.includes("automatic_canonical_source_mutation: false"));
+assert.ok(verifier.includes("canonical_source_mutated_by_builder: false"));
+assert.ok(verifier.includes("promotes_forum_21: false"));
+assert.ok(verifier.includes("promotes_forum_23: false"));
+
+console.log(
+  "LINK-FORUM-03 canonical promotion packet source is ready and canonical status remains unchanged.",
+);


### PR DESCRIPTION
## What changed

- add source-ready `FORUM-23B2G2B3D19`, a fail-closed canonical promotion packet for `LINK-FORUM-03`;
- require an exact retained D18 promotion candidate on the current source commit;
- revalidate the current Forum plan digest, the complete D17 artifact and all retained D13-D16 artifact bytes and metadata;
- require the exact current planned ledger row and ensure the proposed done row is still absent;
- record the exact `LINK-FORUM-03: planned -> done` ledger replacement and the required completion-evidence checklist;
- carry reviewer identity, review time, immutable retention reference, retained digest, all six scenario IDs and exact evidence paths into the packet;
- write the packet only after complete validation through same-directory atomic rename;
- add the machine contract, maintainer handoff and fail-closed source verifier.

## Deliberate boundary

D19 does not run or regenerate evidence, accept missing or mixed-commit artifacts, authenticate external retention, edit `implementation-plan.md`, promote `FORUM-21`, or mark `FORUM-23` done. A generated packet is only input to a separate human-reviewed canonical-source pull request.

## Validation

Tests, Node verifiers, packet builders, reviewers, assemblers, formatting, Cargo checks, workflows, CI, PostgreSQL, Iggy and storefront execution were intentionally not run, per maintainer request.