### PR TITLE
feat(blog): add PostgreSQL Comments schedule persistence

### DIFF
--- a/apps/server/src/services/comments_provider_runtime.rs
+++ b/apps/server/src/services/comments_provider_runtime.rs
@@ -30,6 +30,10 @@ mod keyring_schedule_persistence {
     include!("comments_provider_runtime_keyring_schedule_persistence.rs");
 }
 
+mod keyring_schedule_persistence_postgres {
+    include!("comments_provider_runtime_keyring_schedule_persistence_postgres.rs");
+}
+
 mod keyring_schedule_persisted_trigger {
     include!("comments_provider_runtime_keyring_schedule_persisted_trigger.rs");
 }
@@ -92,6 +96,11 @@ pub use keyring_schedule_persistence::{
     CommentsTcpDelegationSchedulePersistenceStore,
     CommentsTcpDelegationSchedulePersistenceStoreError,
     SharedCommentsTcpDelegationSchedulePersistenceStore,
+};
+pub use keyring_schedule_persistence_postgres::{
+    COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_STATE_KEY,
+    COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_TABLE,
+    PostgresCommentsTcpDelegationSchedulePersistenceStore,
 };
 pub use keyring_schedule_persisted_trigger::{
     CommentsTcpDelegationPersistedScheduleAuditOutcome,

--- a/apps/server/src/services/comments_provider_runtime_keyring_schedule_persistence_postgres.rs
+++ b/apps/server/src/services/comments_provider_runtime_keyring_schedule_persistence_postgres.rs
@@ -1,0 +1,416 @@
+use std::{
+    fmt,
+    sync::{
+        Arc,
+        mpsc::{self, Receiver, SyncSender},
+    },
+    thread,
+    time::Duration,
+};
+
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DbBackend, Statement, TransactionTrait,
+};
+use tokio::runtime::{Builder, Runtime};
+
+use super::{
+    keyring,
+    keyring_schedule_persistence as persistence,
+};
+
+pub const COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_STATE_KEY: &str =
+    "comments_tcp_delegation_schedule";
+pub const COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_TABLE: &str =
+    "blog_comments_tcp_delegation_schedule_state";
+
+const POSTGRES_STORE_QUEUE_CAPACITY: usize = 1;
+const COMMIT_RECONCILIATION_ATTEMPTS: usize = 20;
+const COMMIT_RECONCILIATION_DELAY_MS: u64 = 100;
+
+type StoreResult = std::result::Result<
+    (),
+    persistence::CommentsTcpDelegationSchedulePersistenceStoreError,
+>;
+
+#[derive(Clone)]
+pub struct PostgresCommentsTcpDelegationSchedulePersistenceStore {
+    commands: SyncSender<PostgresStoreCommand>,
+}
+
+enum PostgresStoreCommand {
+    VerifyCurrent {
+        expected: persistence::CommentsTcpDelegationSchedulePersistenceRecord,
+        response: SyncSender<StoreResult>,
+    },
+    CompareAndStore {
+        expected: Option<persistence::CommentsTcpDelegationSchedulePersistenceRecord>,
+        candidate: persistence::CommentsTcpDelegationSchedulePersistenceRecord,
+        response: SyncSender<StoreResult>,
+    },
+}
+
+enum PostgresWorkerStartup {
+    Ready,
+    Failed,
+}
+
+#[derive(Clone, Eq, PartialEq)]
+struct StoredScheduleRecord {
+    schema_version: i16,
+    source: keyring::CommentsTcpDelegationKeyringSource,
+    generation: i64,
+    schedule_digest_hex: String,
+}
+
+impl StoredScheduleRecord {
+    fn from_public(
+        record: &persistence::CommentsTcpDelegationSchedulePersistenceRecord,
+    ) -> StoreResultWith<Self> {
+        let schema_version = i16::try_from(record.schema_version()).map_err(|_| {
+            persistence::CommentsTcpDelegationSchedulePersistenceStoreError::Unavailable
+        })?;
+        let generation = i64::try_from(record.generation()).map_err(|_| {
+            persistence::CommentsTcpDelegationSchedulePersistenceStoreError::Unavailable
+        })?;
+        Ok(Self {
+            schema_version,
+            source: record.source(),
+            generation,
+            schedule_digest_hex: record.schedule_digest().to_hex(),
+        })
+    }
+}
+
+type StoreResultWith<T> = std::result::Result<
+    T,
+    persistence::CommentsTcpDelegationSchedulePersistenceStoreError,
+>;
+
+impl PostgresCommentsTcpDelegationSchedulePersistenceStore {
+    pub fn new(database: DatabaseConnection) -> std::result::Result<Self, String> {
+        if database.get_database_backend() != DbBackend::Postgres {
+            return Err(
+                "Comments TCP delegation schedule PostgreSQL persistence requires a PostgreSQL database"
+                    .to_string(),
+            );
+        }
+
+        let (commands, receiver) =
+            mpsc::sync_channel(POSTGRES_STORE_QUEUE_CAPACITY);
+        let (startup_sender, startup_receiver) = mpsc::sync_channel(1);
+        thread::Builder::new()
+            .name("comments-delegation-schedule-postgres".to_string())
+            .spawn(move || {
+                let runtime = match Builder::new_current_thread().enable_all().build() {
+                    Ok(runtime) => runtime,
+                    Err(_) => {
+                        let _ = startup_sender.send(PostgresWorkerStartup::Failed);
+                        return;
+                    }
+                };
+                if startup_sender.send(PostgresWorkerStartup::Ready).is_err() {
+                    return;
+                }
+                run_postgres_store_worker(runtime, database, receiver);
+            })
+            .map_err(|_| {
+                "Comments TCP delegation schedule PostgreSQL persistence worker could not start"
+                    .to_string()
+            })?;
+
+        match startup_receiver.recv() {
+            Ok(PostgresWorkerStartup::Ready) => Ok(Self { commands }),
+            Ok(PostgresWorkerStartup::Failed) | Err(_) => Err(
+                "Comments TCP delegation schedule PostgreSQL persistence worker is unavailable"
+                    .to_string(),
+            ),
+        }
+    }
+
+    pub fn into_shared(
+        self,
+    ) -> persistence::SharedCommentsTcpDelegationSchedulePersistenceStore {
+        Arc::new(self)
+    }
+
+    fn request(
+        &self,
+        build: impl FnOnce(SyncSender<StoreResult>) -> PostgresStoreCommand,
+    ) -> StoreResult {
+        let (response_sender, response_receiver) = mpsc::sync_channel(1);
+        self.commands
+            .send(build(response_sender))
+            .map_err(|_| {
+                persistence::CommentsTcpDelegationSchedulePersistenceStoreError::Unavailable
+            })?;
+        response_receiver.recv().unwrap_or(Err(
+            persistence::CommentsTcpDelegationSchedulePersistenceStoreError::Unavailable,
+        ))
+    }
+}
+
+impl persistence::CommentsTcpDelegationSchedulePersistenceStore
+    for PostgresCommentsTcpDelegationSchedulePersistenceStore
+{
+    fn verify_current(
+        &self,
+        expected: &persistence::CommentsTcpDelegationSchedulePersistenceRecord,
+    ) -> StoreResult {
+        self.request(|response| PostgresStoreCommand::VerifyCurrent {
+            expected: *expected,
+            response,
+        })
+    }
+
+    fn compare_and_store(
+        &self,
+        expected: Option<&persistence::CommentsTcpDelegationSchedulePersistenceRecord>,
+        candidate: &persistence::CommentsTcpDelegationSchedulePersistenceRecord,
+    ) -> StoreResult {
+        self.request(|response| PostgresStoreCommand::CompareAndStore {
+            expected: expected.copied(),
+            candidate: *candidate,
+            response,
+        })
+    }
+}
+
+impl fmt::Debug for PostgresCommentsTcpDelegationSchedulePersistenceStore {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct(
+                "PostgresCommentsTcpDelegationSchedulePersistenceStore",
+            )
+            .field("database", &"[CONFIGURED]")
+            .field("state_key", &COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_STATE_KEY)
+            .finish()
+    }
+}
+
+fn run_postgres_store_worker(
+    runtime: Runtime,
+    database: DatabaseConnection,
+    receiver: Receiver<PostgresStoreCommand>,
+) {
+    while let Ok(command) = receiver.recv() {
+        match command {
+            PostgresStoreCommand::VerifyCurrent { expected, response } => {
+                let result =
+                    runtime.block_on(verify_current_on_postgres(&database, &expected));
+                let _ = response.send(result);
+            }
+            PostgresStoreCommand::CompareAndStore {
+                expected,
+                candidate,
+                response,
+            } => {
+                let result = runtime.block_on(compare_and_store_on_postgres(
+                    &database,
+                    expected.as_ref(),
+                    &candidate,
+                ));
+                let _ = response.send(result);
+            }
+        }
+    }
+}
+
+async fn verify_current_on_postgres(
+    database: &DatabaseConnection,
+    expected: &persistence::CommentsTcpDelegationSchedulePersistenceRecord,
+) -> StoreResult {
+    let expected = StoredScheduleRecord::from_public(expected)?;
+    match read_current_record(database).await {
+        Ok(Some(current)) if current == expected => Ok(()),
+        Ok(_) => Err(
+            persistence::CommentsTcpDelegationSchedulePersistenceStoreError::Conflict,
+        ),
+        Err(sea_orm::DbErr::Type(_)) => Err(
+            persistence::CommentsTcpDelegationSchedulePersistenceStoreError::Conflict,
+        ),
+        Err(_) => Err(
+            persistence::CommentsTcpDelegationSchedulePersistenceStoreError::Unavailable,
+        ),
+    }
+}
+
+async fn compare_and_store_on_postgres(
+    database: &DatabaseConnection,
+    expected: Option<&persistence::CommentsTcpDelegationSchedulePersistenceRecord>,
+    candidate: &persistence::CommentsTcpDelegationSchedulePersistenceRecord,
+) -> StoreResult {
+    let expected = expected
+        .map(StoredScheduleRecord::from_public)
+        .transpose()?;
+    let candidate = StoredScheduleRecord::from_public(candidate)?;
+
+    let transaction = database.begin().await.map_err(|_| {
+        persistence::CommentsTcpDelegationSchedulePersistenceStoreError::Unavailable
+    })?;
+    let execution = match expected.as_ref() {
+        Some(expected) => {
+            transaction
+                .execute(update_statement(expected, &candidate))
+                .await
+        }
+        None => transaction.execute(insert_statement(&candidate)).await,
+    };
+
+    let rows_affected = match execution {
+        Ok(result) => result.rows_affected(),
+        Err(_) => {
+            let _ = transaction.rollback().await;
+            return Err(
+                persistence::CommentsTcpDelegationSchedulePersistenceStoreError::Unavailable,
+            );
+        }
+    };
+    if rows_affected != 1 {
+        let _ = transaction.rollback().await;
+        return Err(
+            persistence::CommentsTcpDelegationSchedulePersistenceStoreError::Conflict,
+        );
+    }
+
+    match transaction.commit().await {
+        Ok(()) => Ok(()),
+        Err(_) => {
+            reconcile_ambiguous_commit(database, expected.as_ref(), &candidate).await
+        }
+    }
+}
+
+async fn reconcile_ambiguous_commit(
+    database: &DatabaseConnection,
+    expected: Option<&StoredScheduleRecord>,
+    candidate: &StoredScheduleRecord,
+) -> StoreResult {
+    for attempt in 0..COMMIT_RECONCILIATION_ATTEMPTS {
+        match read_current_record(database).await {
+            Ok(Some(current)) if &current == candidate => return Ok(()),
+            Ok(current) if current.as_ref() == expected => {
+                return Err(
+                    persistence::CommentsTcpDelegationSchedulePersistenceStoreError::Unavailable,
+                );
+            }
+            Ok(_) => abort_on_indeterminate_postgres_commit(),
+            Err(_) if attempt + 1 < COMMIT_RECONCILIATION_ATTEMPTS => {
+                tokio::time::sleep(Duration::from_millis(
+                    COMMIT_RECONCILIATION_DELAY_MS,
+                ))
+                .await;
+            }
+            Err(_) => abort_on_indeterminate_postgres_commit(),
+        }
+    }
+    abort_on_indeterminate_postgres_commit()
+}
+
+async fn read_current_record(
+    database: &DatabaseConnection,
+) -> std::result::Result<Option<StoredScheduleRecord>, sea_orm::DbErr> {
+    let row = database
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            format!(
+                "SELECT schema_version, source, generation, schedule_digest_hex \
+                 FROM {COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_TABLE} \
+                 WHERE state_key = $1"
+            ),
+            vec![COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_STATE_KEY.into()],
+        ))
+        .await?;
+    let Some(row) = row else {
+        return Ok(None);
+    };
+
+    let schema_version: i16 = row.try_get("", "schema_version")?;
+    let source: String = row.try_get("", "source")?;
+    let generation: i64 = row.try_get("", "generation")?;
+    let schedule_digest_hex: String =
+        row.try_get("", "schedule_digest_hex")?;
+    let source = match source.as_str() {
+        "host_provided" => keyring::CommentsTcpDelegationKeyringSource::HostProvided,
+        "file" => keyring::CommentsTcpDelegationKeyringSource::File,
+        _ => {
+            return Err(sea_orm::DbErr::Type(
+                "invalid Comments delegation schedule persistence source".to_string(),
+            ));
+        }
+    };
+    if generation <= 0
+        || schedule_digest_hex.len() != 64
+        || hex::decode(&schedule_digest_hex).is_err()
+    {
+        return Err(sea_orm::DbErr::Type(
+            "invalid Comments delegation schedule persistence record".to_string(),
+        ));
+    }
+
+    Ok(Some(StoredScheduleRecord {
+        schema_version,
+        source,
+        generation,
+        schedule_digest_hex,
+    }))
+}
+
+fn insert_statement(candidate: &StoredScheduleRecord) -> Statement {
+    Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        format!(
+            "INSERT INTO {COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_TABLE} \
+             (state_key, schema_version, source, generation, schedule_digest_hex, updated_at) \
+             VALUES ($1, $2, $3, $4, $5, NOW()) \
+             ON CONFLICT (state_key) DO NOTHING"
+        ),
+        vec![
+            COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_STATE_KEY.into(),
+            candidate.schema_version.into(),
+            source_text(candidate.source).into(),
+            candidate.generation.into(),
+            candidate.schedule_digest_hex.clone().into(),
+        ],
+    )
+}
+
+fn update_statement(
+    expected: &StoredScheduleRecord,
+    candidate: &StoredScheduleRecord,
+) -> Statement {
+    Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        format!(
+            "UPDATE {COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_TABLE} \
+             SET schema_version = $2, source = $3, generation = $4, \
+                 schedule_digest_hex = $5, updated_at = NOW() \
+             WHERE state_key = $1 \
+               AND schema_version = $6 \
+               AND source = $7 \
+               AND generation = $8 \
+               AND schedule_digest_hex = $9"
+        ),
+        vec![
+            COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_STATE_KEY.into(),
+            candidate.schema_version.into(),
+            source_text(candidate.source).into(),
+            candidate.generation.into(),
+            candidate.schedule_digest_hex.clone().into(),
+            expected.schema_version.into(),
+            source_text(expected.source).into(),
+            expected.generation.into(),
+            expected.schedule_digest_hex.clone().into(),
+        ],
+    )
+}
+
+fn source_text(source: keyring::CommentsTcpDelegationKeyringSource) -> &'static str {
+    match source {
+        keyring::CommentsTcpDelegationKeyringSource::HostProvided => "host_provided",
+        keyring::CommentsTcpDelegationKeyringSource::File => "file",
+    }
+}
+
+fn abort_on_indeterminate_postgres_commit() -> ! {
+    std::process::abort()
+}

--- a/crates/rustok-blog/contracts/evidence/blog-comments-tcp-delegation-schedule-postgres.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-tcp-delegation-schedule-postgres.json
@@ -1,0 +1,206 @@
+{
+  "schema_version": 1,
+  "module": "blog",
+  "provider": "comments",
+  "surface": "comments_tcp_delegation_schedule_postgres_persistence",
+  "status": "source_verified_no_compile",
+  "compile_policy": "not_run_by_request",
+  "runtime_status": "not_run",
+  "generated_from": "crates/rustok-blog/docs/implementation-plan-slice-82.md",
+  "source_contract": {
+    "runtime_facade": "apps/server/src/services/comments_provider_runtime.rs",
+    "postgres_adapter": "apps/server/src/services/comments_provider_runtime_keyring_schedule_persistence_postgres.rs",
+    "persistence_contract_preserved": "apps/server/src/services/comments_provider_runtime_keyring_schedule_persistence.rs",
+    "persisted_trigger_preserved": "apps/server/src/services/comments_provider_runtime_keyring_schedule_persisted_trigger.rs",
+    "persist_before_publish_bridge_preserved": "apps/server/src/services/comments_provider_runtime_keyring_schedule_persistence_bridge.rs",
+    "migration_registry": "crates/rustok-blog/src/migrations/mod.rs",
+    "migration": "crates/rustok-blog/src/migrations/m20260801_000007_create_blog_comments_delegation_schedule_state.rs"
+  },
+  "table": {
+    "name": "blog_comments_tcp_delegation_schedule_state",
+    "state_key": "comments_tcp_delegation_schedule",
+    "singleton_primary_key": true,
+    "columns": [
+      "state_key",
+      "schema_version",
+      "source",
+      "generation",
+      "schedule_digest_hex",
+      "updated_at"
+    ],
+    "schema_version": 1,
+    "source_values": [
+      "host_provided",
+      "file"
+    ],
+    "positive_generation": true,
+    "digest_hex_length": 64,
+    "key_ids": false,
+    "secret_values": false,
+    "schedule_json": false,
+    "credentials": false,
+    "nonces": false,
+    "tokens": false,
+    "actor_identity": false,
+    "request_identity": false,
+    "file_path": false,
+    "raw_backend_error": false,
+    "down_migration": "intentionally_irreversible"
+  },
+  "adapter": {
+    "type": "PostgresCommentsTcpDelegationSchedulePersistenceStore",
+    "database_backend": "postgresql_only",
+    "host_database_connection": true,
+    "accepts_connection_url": false,
+    "accepts_credentials": false,
+    "implements_slice_81_store_trait": true,
+    "shared_conversion": "into_shared",
+    "new_direct_dependencies": []
+  },
+  "sync_async_bridge": {
+    "dedicated_os_thread": true,
+    "tokio_runtime": "current_thread",
+    "bounded_command_queue": true,
+    "command_queue_capacity": 1,
+    "response_channel_per_operation": true,
+    "schedule_document_crosses_worker_boundary": false,
+    "secret_material_crosses_worker_boundary": false,
+    "complete_persistence_record_only": true
+  },
+  "verify_current": {
+    "reads_singleton": true,
+    "compares_schema_version": true,
+    "compares_source": true,
+    "compares_generation": true,
+    "compares_digest": true,
+    "missing_is_conflict": true,
+    "different_record_is_conflict": true,
+    "database_failure_is_unavailable": true
+  },
+  "bootstrap": {
+    "transaction": true,
+    "statement": "insert_on_conflict_do_nothing",
+    "exactly_one_row_required": true,
+    "existing_row_is_conflict": true
+  },
+  "replacement": {
+    "transaction": true,
+    "single_predicate_update": true,
+    "predicate_fields": [
+      "state_key",
+      "schema_version",
+      "source",
+      "generation",
+      "schedule_digest_hex"
+    ],
+    "candidate_fields": [
+      "schema_version",
+      "source",
+      "generation",
+      "schedule_digest_hex",
+      "updated_at"
+    ],
+    "exactly_one_row_required": true,
+    "zero_rows_is_conflict": true,
+    "application_read_then_write_gap": false
+  },
+  "commit": {
+    "commit_after_exactly_one_row": true,
+    "success_after_commit_acknowledgement": true,
+    "execution_error_rolls_back": true,
+    "unexpected_row_count_rolls_back": true,
+    "ambiguous_commit_reconciled": true,
+    "reconciliation_attempts": 20,
+    "reconciliation_delay_ms": 100,
+    "candidate_readback_is_success": true,
+    "expected_readback_is_unavailable": true,
+    "third_state_fail_stop": true,
+    "unreadable_after_retries_fail_stop": true,
+    "fail_stop": "std::process::abort",
+    "indeterminate_error_returned": false,
+    "stale_snapshot_continuation_after_indeterminate": false
+  },
+  "ordering": {
+    "slice_81_schedule_write_lock_preserved": true,
+    "slice_81_invariants_before_store": true,
+    "postgres_transaction_before_publish": true,
+    "postgres_commit_before_publish": true,
+    "snapshot_assignment_after_definitive_store_result": true,
+    "final_process_local_audit_after_publish": true
+  },
+  "concurrency": {
+    "postgres_row_predicate_cas": true,
+    "complete_expected_record_cas": true,
+    "multiple_processes_same_database": "source_level_supported",
+    "executed_concurrent_postgres_evidence": false,
+    "distributed_clock_coordination": false,
+    "distributed_atomic_activation": false
+  },
+  "bounds": {
+    "database_generation_type": "bigint",
+    "maximum_representable_generation": 9223372036854775807,
+    "larger_generation_write_attempt": "unavailable_without_write",
+    "digest_storage": "lowercase_sha256_hex"
+  },
+  "preserved_blobs": {
+    "slice_79_schedule_base": "7d0c48df3dcea5a77bebe99dcdd4f02292f7ef47",
+    "slice_79_schedule_guard": "af2d688d43286a8118823c31408dd5dc7e3f6202",
+    "slice_80_process_local_trigger": "f44f386c36ac81d51da89ee5568ffd9af083cda0",
+    "comments_lifecycle_schedule": "7701953d2892e1b68b4830135639d841ebdd6ed1",
+    "slice_81_persistence_contract": "85df8deb3203ff90be55a8fe114294ce3a1f3749",
+    "slice_81_persisted_trigger": "f3b37405f06e3cc4bd077cf8bd49f92d9e2cbe7a",
+    "slice_81_persistence_bridge": "a90bdd8e4787532bd39c1739dfef8b6a18eaa981"
+  },
+  "dependency_contract": {
+    "manifest_changed": false,
+    "cargo_lock_changed": false,
+    "feature_changed": false,
+    "new_direct_dependencies": [],
+    "existing_sea_orm_reused": true,
+    "existing_tokio_reused": true,
+    "existing_hex_reused": true
+  },
+  "non_claims": [
+    "executed_postgresql_migration",
+    "executed_postgresql_queries",
+    "crash_injection_evidence",
+    "network_partition_evidence",
+    "postgres_storage_configuration_durability",
+    "durable_audit",
+    "transactional_audit_outbox",
+    "automatic_state_repair",
+    "automatic_fail_stop_recovery",
+    "clock_synchronization",
+    "distributed_atomic_activation",
+    "shared_replay_store",
+    "durable_replay_store",
+    "restart_safe_replay_prevention",
+    "http_trigger",
+    "graphql_trigger",
+    "native_rpc_trigger",
+    "mcp_trigger",
+    "cli_trigger",
+    "signal_reload",
+    "automatic_file_watch",
+    "polling",
+    "cloud_secret_manager_sdk",
+    "kms_hsm",
+    "secret_zeroization",
+    "locked_memory",
+    "tls_mtls",
+    "non_loopback_publication",
+    "runtime_execution"
+  ],
+  "execution": {
+    "rust_tests_run": false,
+    "javascript_verifiers_run": false,
+    "cargo_commands_run": false,
+    "formatting_run": false,
+    "postgresql_run": false,
+    "tcp_runtime_run": false,
+    "database_run": false,
+    "browser_run": false,
+    "workflow_run": false,
+    "ci_run": false
+  }
+}

--- a/crates/rustok-blog/docs/implementation-plan-slice-82.md
+++ b/crates/rustok-blog/docs/implementation-plan-slice-82.md
@@ -1,0 +1,291 @@
+# rustok-blog implementation plan — slice 82 continuation
+
+This document continues
+`crates/rustok-blog/docs/implementation-plan-slice-81.md`.
+
+Slices 1–81 retain the typed Comments remote boundary, bounded TCP framing and
+listener lifecycle, authenticated service reads, signed user-write delegation,
+overlapping scheduled keyrings, one process-local replay gate, an explicitly
+authorized mutation trigger, bounded process-local audit, a canonical
+secret-inclusive schedule digest, and a host-owned persist-before-publish
+compare-and-store contract.
+
+## 2026-08-01 continuation audit
+
+Slice 81 intentionally stopped at an abstract persistence contract. A deployment
+could not claim restart rollback prevention until one concrete backend provided:
+
+- exact source/generation/digest comparison;
+- atomic bootstrap and replacement;
+- durable commit before success;
+- definitive handling of an ambiguous commit result;
+- no returned error after a possibly committed write.
+
+Slice 82 adds one concrete PostgreSQL adapter and one Blog-owned migration. The
+adapter preserves the synchronous slice-81 trigger boundary by isolating async
+SeaORM work on one dedicated current-thread Tokio runtime owned by a worker
+thread.
+
+Tests, source verifiers, formatting, Cargo commands, PostgreSQL execution,
+workflows, and CI remain intentionally unexecuted by request.
+
+## Slice 82 — PostgreSQL schedule persistence adapter
+
+### Module-owned singleton table
+
+The Blog migration
+`m20260801_000007_create_blog_comments_delegation_schedule_state` creates:
+
+```text
+blog_comments_tcp_delegation_schedule_state
+```
+
+The table contains one fixed row identified by:
+
+```text
+comments_tcp_delegation_schedule
+```
+
+Columns are:
+
+- `state_key VARCHAR(64)` primary key;
+- `schema_version SMALLINT`;
+- `source VARCHAR(16)`;
+- `generation BIGINT`;
+- `schedule_digest_hex VARCHAR(64)`;
+- `updated_at TIMESTAMPTZ`.
+
+Migration checks require schema version 1, a positive generation, a 64-character
+digest encoding, and source category `host_provided` or `file`.
+
+The table stores no key IDs, secret values, schedule JSON, credentials, nonces,
+tokens, actor identity, request identity, file path, or raw backend error.
+
+The migration is intentionally irreversible. A routine down migration must not
+silently erase the accepted generation baseline.
+
+### Concrete adapter
+
+`PostgresCommentsTcpDelegationSchedulePersistenceStore` implements the existing
+`CommentsTcpDelegationSchedulePersistenceStore`.
+
+Construction requires an existing SeaORM `DatabaseConnection` whose backend is
+PostgreSQL. SQLite and MySQL are rejected before the worker starts.
+
+The adapter exports `into_shared()` for direct use by
+`SharedCommentsTcpDelegationPersistedScheduleTrigger`.
+
+No environment variable, global database singleton, connection URL, or
+credential is accepted by this owner. Connection creation and credential
+ownership remain with the server host.
+
+### Synchronous trigger / async database bridge
+
+The slice-81 trigger and persist-before-publish callback are synchronous because
+the schedule write lock must remain held while durable CAS completes.
+
+The PostgreSQL adapter therefore owns:
+
+- one dedicated OS thread;
+- one current-thread Tokio runtime;
+- one bounded synchronous command channel with capacity 1;
+- one response channel per operation.
+
+The worker receives only complete persistence records. It never receives the
+schedule document or secret material.
+
+Trigger callers synchronously wait for a definitive database result. Schedule
+replacement is a rare control-plane operation; this adapter is not a
+high-throughput request-path store.
+
+### Exact resume verification
+
+`verify_current(expected)` reads the singleton row and compares:
+
+- schema version;
+- source category;
+- generation;
+- lowercase SHA-256 digest hex.
+
+A missing row, different source, different generation, different digest, or
+invalid stored representation returns `Conflict`. Database unavailability
+returns `Unavailable`.
+
+### Bootstrap CAS
+
+For `compare_and_store(None, candidate)`, the adapter executes inside a
+PostgreSQL transaction:
+
+```sql
+INSERT ... ON CONFLICT (state_key) DO NOTHING
+```
+
+Exactly one affected row is required. An existing singleton row returns
+`Conflict`.
+
+### Replacement CAS
+
+For `compare_and_store(Some(expected), candidate)`, the adapter performs one
+predicate update:
+
+```sql
+UPDATE ...
+SET schema_version = candidate.schema_version,
+    source = candidate.source,
+    generation = candidate.generation,
+    schedule_digest_hex = candidate.schedule_digest_hex,
+    updated_at = NOW()
+WHERE state_key = fixed_state_key
+  AND schema_version = expected.schema_version
+  AND source = expected.source
+  AND generation = expected.generation
+  AND schedule_digest_hex = expected.schedule_digest_hex
+```
+
+Exactly one affected row is required. Zero rows means another process already
+created, removed, modified, or advanced the record and returns `Conflict`.
+
+The complete expected record participates in the predicate; generation alone is
+not sufficient.
+
+### Transaction and commit ordering
+
+The adapter:
+
+1. begins a PostgreSQL transaction;
+2. executes the insert or update CAS;
+3. rolls back and returns a definitive error when execution fails or affects an
+   unexpected row count;
+4. commits only after exactly one row is affected;
+5. returns success only after commit acknowledgement or successful
+   post-error reconciliation.
+
+Because slice 81 invokes the adapter while the schedule write lock is held, the
+ordering remains:
+
+```text
+schedule invariant validation
+→ PostgreSQL transaction/CAS
+→ PostgreSQL commit or definitive reconciliation
+→ in-memory schedule snapshot assignment
+→ bounded process-local audit outcome
+```
+
+No application-level read-then-write gap exists in the PostgreSQL CAS.
+
+### Ambiguous commit reconciliation
+
+A connection can fail while PostgreSQL is committing, after the server may have
+made the transaction durable but before the client receives acknowledgement.
+
+Returning `Unavailable` immediately would violate the slice-81 contract because
+the durable state might already contain the candidate while the old keyring
+continues signing.
+
+After a commit error, the adapter repeatedly reads the singleton row:
+
+- exact candidate record: treat the operation as successful;
+- exact expected record, or no row for an empty bootstrap expectation: return
+  definitive `Unavailable`;
+- any third state: fail-stop the process;
+- persistence remaining unreadable after 20 attempts spaced by 100 ms:
+  fail-stop the process.
+
+Fail-stop uses `std::process::abort()`. This is deliberate: an unreconciled
+commit cannot safely return control to a process that still owns the previous
+signing snapshot.
+
+There is no panic recovery, permissive fallback, stale-snapshot continuation, or
+automatic baseline reset for an indeterminate commit.
+
+### Multi-process CAS scope
+
+The PostgreSQL row predicate provides a concrete database serialization point
+for multiple processes using the same database and state key. Only one process
+can successfully advance a given exact expected record.
+
+This source-level property does not establish executed multi-replica evidence,
+clock synchronization, coordinated activation, or shared replay protection.
+
+### Representation bounds
+
+The PostgreSQL adapter stores generation as signed `BIGINT`. A persistence
+record whose generation cannot be represented as `i64` returns `Unavailable`
+without issuing a database write.
+
+The canonical schedule digest remains the exact slice-81 32-byte SHA-256 value;
+the database stores its lowercase 64-character hexadecimal encoding.
+
+### Preserved owners
+
+The following slice-79 through slice-81 owners remain byte-for-byte unchanged:
+
+- schedule lifecycle base;
+- runtime-policy schedule guard;
+- process-local authorized trigger;
+- Comments lifecycle schedule;
+- persistence document/digest/store contract;
+- persist-before-publish bridge;
+- persisted trigger.
+
+The adapter is additive. It does not alter delegation signatures, key
+activation, retirement, overlap, TTL/skew policy, replay admission, TCP framing,
+listener lifecycle, channel selection, or loopback publication.
+
+### Explicit non-claims
+
+Slice 82 does not claim:
+
+- executed PostgreSQL migration or query evidence;
+- crash-injection evidence;
+- network-partition evidence;
+- proof that a particular PostgreSQL deployment acknowledges durable commits
+  according to its storage configuration;
+- durable audit or a transactional audit outbox;
+- automatic repair of a deleted or externally modified persistence row;
+- automatic schedule recovery after fail-stop;
+- coordinated activation clocks across replicas;
+- shared, durable, multi-replica, or restart-safe replay protection;
+- an HTTP, GraphQL, native RPC, MCP, CLI, signal, watcher, or polling trigger;
+- cloud secret-manager, KMS, HSM, or sidecar integration;
+- secret zeroization or locked memory;
+- TLS/mTLS or non-loopback publication;
+- successful compilation, tests, source-verifier execution, formatting,
+  PostgreSQL execution, workflows, CI, or production validation.
+
+Status: `source_verified_no_compile`.
+Compile policy: `not_run_by_request`.
+Runtime status: `not_run`.
+
+## Next implementation results
+
+1. Add a transactionally coupled durable authorization/audit outbox record to
+   the same PostgreSQL CAS transaction.
+2. Add isolated PostgreSQL execution for bootstrap, exact resume, stale CAS,
+   concurrent CAS, and commit-reconciliation paths.
+3. Define an operator recovery ceremony for fail-stop, lost state, corruption,
+   or externally advanced state.
+4. Add clock-health and maximum-drift ownership before coordinated activation
+   across replicas.
+5. Replace process-local replay admission before claiming restart-safe or
+   multi-replica replay protection.
+
+## Suggested verification — intentionally not run
+
+- `node scripts/verify/verify-blog-comments-tcp-delegation-schedule-postgres.mjs`
+- `node scripts/verify/verify-blog-comments-tcp-delegation-schedule-persistence.mjs`
+- `cargo test -p rustok-server --features mod-blog comments_provider_runtime`
+- `cargo test -p rustok-blog migrations`
+- `cargo check -p rustok-server --features mod-blog --locked`
+
+## Ownership retained
+
+- Comments owns lifecycle validation, effective keyring selection, signing,
+  verification, request binding, and process-local replay admission.
+- The server host owns the PostgreSQL adapter, canonical persistence record
+  composition, mutation authorization, process-local audit, runtime provider
+  composition, listener lifecycle, concurrency, and shutdown.
+- PostgreSQL owns transactional row serialization and commit durability
+  according to the configured deployment.
+- Blog owns the persistence table migration and remains transport-neutral for
+  authenticated rendering and degraded presentation.

--- a/crates/rustok-blog/src/migrations/m20260801_000007_create_blog_comments_delegation_schedule_state.rs
+++ b/crates/rustok-blog/src/migrations/m20260801_000007_create_blog_comments_delegation_schedule_state.rs
@@ -1,0 +1,77 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(BlogCommentsDelegationScheduleState::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(BlogCommentsDelegationScheduleState::StateKey)
+                            .string_len(64)
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(BlogCommentsDelegationScheduleState::SchemaVersion)
+                            .small_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(BlogCommentsDelegationScheduleState::Source)
+                            .string_len(16)
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(BlogCommentsDelegationScheduleState::Generation)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(
+                            BlogCommentsDelegationScheduleState::ScheduleDigestHex,
+                        )
+                        .string_len(64)
+                        .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(BlogCommentsDelegationScheduleState::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .check(Expr::cust("schema_version = 1"))
+                    .check(Expr::cust(
+                        "source IN ('host_provided', 'file')",
+                    ))
+                    .check(Expr::cust("generation > 0"))
+                    .check(Expr::cust("length(schedule_digest_hex) = 64"))
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        Err(DbErr::Migration(
+            "Comments delegation schedule persistence state is security-sensitive and intentionally irreversible"
+                .to_string(),
+        ))
+    }
+}
+
+#[derive(DeriveIden)]
+enum BlogCommentsDelegationScheduleState {
+    #[sea_orm(iden = "blog_comments_tcp_delegation_schedule_state")]
+    Table,
+    StateKey,
+    SchemaVersion,
+    Source,
+    Generation,
+    ScheduleDigestHex,
+    UpdatedAt,
+}

--- a/crates/rustok-blog/src/migrations/mod.rs
+++ b/crates/rustok-blog/src/migrations/mod.rs
@@ -4,6 +4,7 @@ mod m20260329_000001_create_blog_post_channel_visibility_table;
 mod m20260716_000001_create_blog_comment_projection_deliveries;
 mod m20260721_000005_expand_blog_locale_storage_columns;
 mod m20260730_000006_cutover_blog_article_richtext;
+mod m20260801_000007_create_blog_comments_delegation_schedule_state;
 
 use rustok_core::MigrationDependencyDescriptor;
 use sea_orm_migration::MigrationTrait;
@@ -16,6 +17,9 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260716_000001_create_blog_comment_projection_deliveries::Migration),
         Box::new(m20260721_000005_expand_blog_locale_storage_columns::Migration),
         Box::new(m20260730_000006_cutover_blog_article_richtext::Migration),
+        Box::new(
+            m20260801_000007_create_blog_comments_delegation_schedule_state::Migration,
+        ),
     ]
 }
 

--- a/scripts/verify/verify-blog-comments-tcp-delegation-schedule-postgres.mjs
+++ b/scripts/verify/verify-blog-comments-tcp-delegation-schedule-postgres.mjs
@@ -1,0 +1,260 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const read = (relativePath) => readFileSync(path.join(root, relativePath), 'utf8');
+const readBuffer = (relativePath) => readFileSync(path.join(root, relativePath));
+
+const runtimePath = 'apps/server/src/services/comments_provider_runtime.rs';
+const adapterPath =
+  'apps/server/src/services/comments_provider_runtime_keyring_schedule_persistence_postgres.rs';
+const persistencePath =
+  'apps/server/src/services/comments_provider_runtime_keyring_schedule_persistence.rs';
+const persistedTriggerPath =
+  'apps/server/src/services/comments_provider_runtime_keyring_schedule_persisted_trigger.rs';
+const bridgePath =
+  'apps/server/src/services/comments_provider_runtime_keyring_schedule_persistence_bridge.rs';
+const scheduleBasePath =
+  'apps/server/src/services/comments_provider_runtime_keyring_schedule_base.rs';
+const scheduleGuardPath =
+  'apps/server/src/services/comments_provider_runtime_keyring_schedule_guard.rs';
+const processTriggerPath =
+  'apps/server/src/services/comments_provider_runtime_keyring_schedule_trigger.rs';
+const commentsSchedulePath = 'crates/rustok-comments/src/tcp_delegation_schedule.rs';
+const migrationModPath = 'crates/rustok-blog/src/migrations/mod.rs';
+const migrationPath =
+  'crates/rustok-blog/src/migrations/m20260801_000007_create_blog_comments_delegation_schedule_state.rs';
+const planPath = 'crates/rustok-blog/docs/implementation-plan-slice-82.md';
+const evidencePath =
+  'crates/rustok-blog/contracts/evidence/blog-comments-tcp-delegation-schedule-postgres.json';
+const serverManifestPath = 'apps/server/Cargo.toml';
+const blogManifestPath = 'crates/rustok-blog/Cargo.toml';
+const lockPath = 'Cargo.lock';
+
+const runtime = read(runtimePath);
+const adapter = read(adapterPath);
+const migrationMod = read(migrationModPath);
+const migration = read(migrationPath);
+const plan = read(planPath);
+const evidence = JSON.parse(read(evidencePath));
+
+function requireCondition(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function hasAll(source, markers, label) {
+  for (const marker of markers) {
+    requireCondition(source.includes(marker), `${label} missing marker: ${marker}`);
+  }
+}
+
+function hasNone(source, markers, label) {
+  for (const marker of markers) {
+    requireCondition(!source.includes(marker), `${label} forbidden marker: ${marker}`);
+  }
+}
+
+function gitBlobSha(relativePath) {
+  const content = readBuffer(relativePath);
+  return createHash('sha1')
+    .update(`blob ${content.length}\0`)
+    .update(content)
+    .digest('hex');
+}
+
+const preserved = {
+  [scheduleBasePath]: '7d0c48df3dcea5a77bebe99dcdd4f02292f7ef47',
+  [scheduleGuardPath]: 'af2d688d43286a8118823c31408dd5dc7e3f6202',
+  [processTriggerPath]: 'f44f386c36ac81d51da89ee5568ffd9af083cda0',
+  [commentsSchedulePath]: '7701953d2892e1b68b4830135639d841ebdd6ed1',
+  [persistencePath]: '85df8deb3203ff90be55a8fe114294ce3a1f3749',
+  [persistedTriggerPath]: 'f3b37405f06e3cc4bd077cf8bd49f92d9e2cbe7a',
+  [bridgePath]: 'a90bdd8e4787532bd39c1739dfef8b6a18eaa981',
+  [serverManifestPath]: 'd6a77ff30fd67c3d4fee16afbadc584c2bcce9e7',
+  [blogManifestPath]: 'd71db5d5f7e43ed969485ea9ab508f11b9554902',
+  [lockPath]: 'c862fa6acc5f77642c1ce860e8810ca4cfc1a3c2',
+};
+for (const [relativePath, expected] of Object.entries(preserved)) {
+  requireCondition(
+    gitBlobSha(relativePath) === expected,
+    `preserved source drift: ${relativePath}`,
+  );
+}
+
+hasAll(
+  runtime,
+  [
+    'include!("comments_provider_runtime_keyring_schedule_persistence_postgres.rs");',
+    'COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_STATE_KEY',
+    'COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_TABLE',
+    'PostgresCommentsTcpDelegationSchedulePersistenceStore',
+  ],
+  'runtime PostgreSQL persistence export',
+);
+
+hasAll(
+  adapter,
+  [
+    'pub const COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_STATE_KEY: &str',
+    '"comments_tcp_delegation_schedule"',
+    'pub const COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_TABLE: &str',
+    '"blog_comments_tcp_delegation_schedule_state"',
+    'pub struct PostgresCommentsTcpDelegationSchedulePersistenceStore',
+    'database.get_database_backend() != DbBackend::Postgres',
+    'mpsc::sync_channel(POSTGRES_STORE_QUEUE_CAPACITY)',
+    'Builder::new_current_thread().enable_all().build()',
+    'impl persistence::CommentsTcpDelegationSchedulePersistenceStore',
+    'pub fn into_shared(',
+    'database.begin().await',
+    'ON CONFLICT (state_key) DO NOTHING',
+    'AND schema_version = $6',
+    'AND source = $7',
+    'AND generation = $8',
+    'AND schedule_digest_hex = $9',
+    'transaction.commit().await',
+    'reconcile_ambiguous_commit(',
+    'COMMIT_RECONCILIATION_ATTEMPTS: usize = 20',
+    'COMMIT_RECONCILIATION_DELAY_MS: u64 = 100',
+    'std::process::abort()',
+  ],
+  'PostgreSQL persistence adapter',
+);
+
+const beginIndex = adapter.indexOf('let transaction = database.begin().await');
+const executeIndex = adapter.indexOf('let execution = match expected.as_ref()');
+const rowsIndex = adapter.indexOf('let rows_affected = match execution');
+const commitIndex = adapter.indexOf('match transaction.commit().await');
+const reconcileIndex = adapter.indexOf('reconcile_ambiguous_commit(', commitIndex);
+requireCondition(
+  beginIndex >= 0
+    && beginIndex < executeIndex
+    && executeIndex < rowsIndex
+    && rowsIndex < commitIndex
+    && commitIndex < reconcileIndex,
+  'PostgreSQL transaction / CAS / commit ordering drift',
+);
+
+const candidateReadIndex = adapter.indexOf('if &current == candidate');
+const expectedReadIndex = adapter.indexOf('if current.as_ref() == expected');
+const abortIndex = adapter.indexOf('abort_on_indeterminate_postgres_commit()', expectedReadIndex);
+requireCondition(
+  candidateReadIndex >= 0
+    && candidateReadIndex < expectedReadIndex
+    && expectedReadIndex < abortIndex,
+  'ambiguous commit reconciliation ordering drift',
+);
+
+hasNone(
+  adapter,
+  [
+    'println!(',
+    'eprintln!(',
+    'tracing::',
+    'secret',
+    'key_id',
+    'file_path',
+    'DATABASE_URL',
+    'std::env::',
+    'tokio::spawn',
+  ],
+  'PostgreSQL adapter secret and ambient configuration boundary',
+);
+
+hasAll(
+  migrationMod,
+  [
+    'mod m20260801_000007_create_blog_comments_delegation_schedule_state;',
+    'm20260801_000007_create_blog_comments_delegation_schedule_state::Migration',
+  ],
+  'Blog migration registry',
+);
+
+hasAll(
+  migration,
+  [
+    'blog_comments_tcp_delegation_schedule_state',
+    '.string_len(64)',
+    '.small_integer()',
+    '.string_len(16)',
+    '.big_integer()',
+    'ScheduleDigestHex',
+    '.timestamp_with_time_zone()',
+    'schema_version = 1',
+    "source IN ('host_provided', 'file')",
+    'generation > 0',
+    'length(schedule_digest_hex) = 64',
+  ],
+  'Blog PostgreSQL persistence migration',
+);
+
+hasNone(
+  migration,
+  ['Secret', 'KeyId', 'Credential', 'Nonce', 'Token', 'FilePath', 'ActorId', 'RequestId'],
+  'persistence table secret and identity columns',
+);
+
+requireCondition(
+  evidence.status === 'source_verified_no_compile'
+    && evidence.compile_policy === 'not_run_by_request'
+    && evidence.runtime_status === 'not_run',
+  'evidence status drift',
+);
+requireCondition(
+  evidence.table?.name === 'blog_comments_tcp_delegation_schedule_state'
+    && evidence.table?.state_key === 'comments_tcp_delegation_schedule'
+    && evidence.table?.singleton_primary_key === true
+    && evidence.table?.secret_values === false
+    && evidence.table?.key_ids === false,
+  'table evidence drift',
+);
+requireCondition(
+  evidence.adapter?.database_backend === 'postgresql_only'
+    && evidence.adapter?.implements_slice_81_store_trait === true
+    && evidence.adapter?.accepts_connection_url === false
+    && evidence.adapter?.new_direct_dependencies?.length === 0,
+  'adapter evidence drift',
+);
+requireCondition(
+  evidence.commit?.ambiguous_commit_reconciled === true
+    && evidence.commit?.candidate_readback_is_success === true
+    && evidence.commit?.expected_readback_is_unavailable === true
+    && evidence.commit?.third_state_fail_stop === true
+    && evidence.commit?.unreadable_after_retries_fail_stop === true
+    && evidence.commit?.indeterminate_error_returned === false,
+  'commit reconciliation evidence drift',
+);
+requireCondition(
+  evidence.execution?.rust_tests_run === false
+    && evidence.execution?.javascript_verifiers_run === false
+    && evidence.execution?.cargo_commands_run === false
+    && evidence.execution?.formatting_run === false
+    && evidence.execution?.postgresql_run === false
+    && evidence.execution?.workflow_run === false
+    && evidence.execution?.ci_run === false,
+  'execution evidence drift',
+);
+
+hasAll(
+  plan,
+  [
+    '## Slice 82 — PostgreSQL schedule persistence adapter',
+    '`PostgresCommentsTcpDelegationSchedulePersistenceStore`',
+    '`INSERT ... ON CONFLICT (state_key) DO NOTHING`',
+    'The complete expected record participates in the predicate',
+    'Ambiguous commit reconciliation',
+    'fail-stop the process',
+    '`std::process::abort()`',
+    'Status: `source_verified_no_compile`.',
+    'Compile policy: `not_run_by_request`.',
+    'Runtime status: `not_run`.',
+  ],
+  'slice-82 plan',
+);
+
+console.log(
+  'Blog Comments TCP delegation schedule PostgreSQL persistence source verification passed',
+);


### PR DESCRIPTION
## Summary

- continue the Blog implementation plan with slice 82
- add a concrete PostgreSQL implementation of the slice-81 Comments delegation schedule persistence-store contract
- add the Blog-owned singleton `blog_comments_tcp_delegation_schedule_state` migration
- retain one fixed `comments_tcp_delegation_schedule` state key
- store only schema version, source category, accepted generation, lowercase SHA-256 digest hex, and update time
- make the security-state migration intentionally irreversible
- require an existing host-owned SeaORM PostgreSQL connection; accept no URL, credential, environment variable, or global database singleton
- bridge the synchronous persist-before-publish trigger to async SeaORM through one dedicated OS thread, one current-thread Tokio runtime, and a bounded command queue of one
- implement exact startup verification over source, generation, and digest
- implement empty bootstrap with transactional `INSERT ... ON CONFLICT DO NOTHING`
- implement replacement with one transactional predicate `UPDATE` comparing the complete expected record
- require exactly one affected row for CAS success
- commit PostgreSQL before returning store success and therefore before slice-81 snapshot publication
- reconcile a commit error by reading the singleton row: exact candidate is success, exact expected is definitive unavailable
- fail-stop with `std::process::abort()` when a possibly committed transaction cannot be reconciled or a third state is observed
- reject invalid stored representations as conflicts
- preserve slice-79 lifecycle owners, slice-80 process-local trigger, and all slice-81 persistence/trigger/bridge owners byte-for-byte
- add slice-82 plan, evidence, and a focused source guard
- reuse existing SeaORM, Tokio, and hex dependencies without manifest, feature, or `Cargo.lock` changes

## Explicit non-claims

- no executed PostgreSQL migration or query evidence
- no crash-injection or network-partition evidence
- no proof of a particular PostgreSQL deployment's physical durability configuration
- no durable authorization/audit outbox
- no automatic repair or fail-stop recovery ceremony
- no clock synchronization or distributed atomic activation
- no shared, durable, multi-replica, or restart-safe replay store
- no HTTP, GraphQL, native RPC, MCP, CLI, signal, watcher, or polling trigger
- no cloud secret-manager, KMS, HSM, or sidecar integration
- no secret zeroization, locked memory, TLS/mTLS, or non-loopback publication
- no runtime, workflow, CI, or production evidence

## Verification

Tests, source verifiers, formatting, Cargo checks, PostgreSQL targets, TCP runtime targets, database targets, browser targets, workflows, and CI were intentionally not run by request. Suggested maintainer commands are recorded in `crates/rustok-blog/docs/implementation-plan-slice-82.md`.