### PR TITLE
fix(rbac): reconcile artifact authorization integrity

### DIFF
--- a/apps/server/src/controllers/artifact_permissions.rs
+++ b/apps/server/src/controllers/artifact_permissions.rs
@@ -1,5 +1,8 @@
 //! Host transport for RBAC-owned artifact permission grants.
 
+use std::sync::Arc;
+
+use async_trait::async_trait;
 use axum::{
     Json,
     extract::{Path, State},
@@ -10,12 +13,15 @@ use axum::{
 use rustok_api::{
     AuthContext, AuthPrincipalContext, Permission, has_effective_permission,
 };
+use rustok_events::RbacArtifactPermissionEvent;
+use rustok_outbox::TransactionalEventBus;
 use rustok_rbac::{
-    ArtifactPermissionAssignmentError, ArtifactRolePermissionAssignmentCommand,
-    RbacArtifactPermissionAssignmentService, RbacControlPlanePrincipal,
-    require_direct_control_plane_user,
+    ArtifactPermissionAssignmentError, ArtifactPermissionEventPublisher,
+    ArtifactRolePermissionAssignmentCommand, RbacArtifactPermissionAssignmentService,
+    RbacControlPlanePrincipal, require_direct_control_plane_user,
 };
 use rustok_web::json_response;
+use sea_orm::DatabaseTransaction;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -23,8 +29,38 @@ use uuid::Uuid;
 use crate::{
     error::{Error, Result, http_error},
     extractors::tenant::CurrentTenant,
-    services::server_runtime_context::ServerRuntimeContext,
+    services::{
+        event_bus::transactional_event_bus_from_context,
+        server_runtime_context::ServerRuntimeContext,
+    },
 };
+
+#[derive(Clone)]
+struct TransactionalOutboxArtifactPermissionEventPublisher {
+    event_bus: TransactionalEventBus,
+}
+
+impl TransactionalOutboxArtifactPermissionEventPublisher {
+    fn new(event_bus: TransactionalEventBus) -> Self {
+        Self { event_bus }
+    }
+}
+
+#[async_trait]
+impl ArtifactPermissionEventPublisher for TransactionalOutboxArtifactPermissionEventPublisher {
+    async fn publish_assignment_changed(
+        &self,
+        transaction: &DatabaseTransaction,
+        tenant_id: Uuid,
+        actor_id: Uuid,
+        event: RbacArtifactPermissionEvent,
+    ) -> std::result::Result<(), ArtifactPermissionAssignmentError> {
+        self.event_bus
+            .publish_contract_in_tx(transaction, tenant_id, Some(actor_id), event)
+            .await
+            .map_err(|error| ArtifactPermissionAssignmentError::Database(error.to_string()))
+    }
+}
 
 /// The transport input for one exact role-to-artifact-permission operation.
 #[derive(Debug, Deserialize, ToSchema)]
@@ -103,7 +139,10 @@ async fn assign(
     input: ArtifactRolePermissionAssignmentRequest,
     granted: bool,
 ) -> Result<Response> {
-    let service = RbacArtifactPermissionAssignmentService::new(ctx.db_clone());
+    let event_publisher = Arc::new(TransactionalOutboxArtifactPermissionEventPublisher::new(
+        transactional_event_bus_from_context(ctx),
+    ));
+    let service = RbacArtifactPermissionAssignmentService::new(ctx.db_clone(), event_publisher);
     let result = service
         .assign(ArtifactRolePermissionAssignmentCommand {
             tenant_id,
@@ -179,10 +218,19 @@ pub fn router() -> crate::routes::ServerRouter {
 
 #[cfg(test)]
 mod tests {
-    use super::ensure_artifact_permission_control_plane;
+    use super::{
+        TransactionalOutboxArtifactPermissionEventPublisher,
+        ensure_artifact_permission_control_plane,
+    };
     use rustok_api::{
         AuthContext, AuthPrincipalContext, AuthPrincipalKind, Permission,
     };
+    use rustok_events::RbacArtifactPermissionEvent;
+    use rustok_outbox::{OutboxTransport, SysEvents, SysEventsMigration, TransactionalEventBus};
+    use rustok_rbac::ArtifactPermissionEventPublisher;
+    use sea_orm::{Database, EntityTrait, TransactionTrait};
+    use sea_orm_migration::{MigrationTrait, SchemaManager};
+    use std::sync::Arc;
     use uuid::Uuid;
 
     fn auth_context(tenant_id: Uuid, permissions: Vec<Permission>) -> AuthContext {
@@ -259,5 +307,49 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[tokio::test]
+    async fn transactional_outbox_adapter_writes_typed_event() {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("connect sqlite");
+        SysEventsMigration
+            .up(&SchemaManager::new(&db))
+            .await
+            .expect("create outbox table");
+
+        let adapter = TransactionalOutboxArtifactPermissionEventPublisher::new(
+            TransactionalEventBus::new(Arc::new(OutboxTransport::new(db.clone()))),
+        );
+        let tenant_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let transaction = db.begin().await.expect("begin owner transaction");
+        adapter
+            .publish_assignment_changed(
+                &transaction,
+                tenant_id,
+                actor_id,
+                RbacArtifactPermissionEvent::AssignmentChanged {
+                    operation_id: Uuid::new_v4(),
+                    role_id: Uuid::new_v4(),
+                    installation_id: Uuid::new_v4(),
+                    permission_key: "sample.events.handle".to_string(),
+                    granted: true,
+                },
+            )
+            .await
+            .expect("publish typed event");
+        transaction.commit().await.expect("commit owner transaction");
+
+        let events = SysEvents::find().all(&db).await.expect("load outbox");
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].event_type,
+            "rbac.artifact_role_permission.assignment_changed"
+        );
+        assert_eq!(events[0].schema_version, 1);
+        assert_eq!(events[0].payload["tenant_id"], serde_json::json!(tenant_id));
+        assert_eq!(events[0].payload["actor_id"], serde_json::json!(actor_id));
     }
 }

--- a/apps/server/src/services/auth_admin_mutation_provider/user_admin.rs
+++ b/apps/server/src/services/auth_admin_mutation_provider/user_admin.rs
@@ -56,6 +56,13 @@ fn parse_user_role(value: &str) -> Result<UserRole, AuthAdminMutationError> {
         .map_err(|error| AuthAdminMutationError::Validation(error.to_string()))
 }
 
+fn status_change_requested(
+    current_status: &UserStatus,
+    requested_status: Option<&UserStatus>,
+) -> bool {
+    requested_status.is_some_and(|status| status != current_status)
+}
+
 fn map_lifecycle_error(error: AuthLifecycleError) -> AuthAdminMutationError {
     match error {
         AuthLifecycleError::EmailAlreadyExists => {
@@ -437,20 +444,20 @@ impl UserAdminMutationPort for ServerAuthAdminMutationProvider {
         .await
         .map_err(map_custom_field_error)?;
         let password_changed = command.password.is_some();
-        let status_disables_user = requested_status
-            .as_ref()
-            .is_some_and(|status| status != &UserStatus::Active);
 
         let tx = self
             .db
             .begin()
             .await
             .map_err(|error| AuthAdminMutationError::Internal(error.to_string()))?;
-        let user = lock_user_for_mutation(&tx, context.tenant_id, command.id).await?;
-        let current_role = self.user_role(&tx, context.tenant_id, user.id).await?;
-        let user_id = user.id;
-        let target_tenant_id = user.tenant_id;
-        let target_status = user.status.clone();
+        let locked_user = lock_user_for_mutation(&tx, context.tenant_id, command.id).await?;
+        let current_role = self
+            .user_role(&tx, context.tenant_id, locked_user.id)
+            .await?;
+        let user_id = locked_user.id;
+        let target_tenant_id = locked_user.tenant_id;
+        let target_status = locked_user.status.clone();
+        let status_changed = status_change_requested(&target_status, requested_status.as_ref());
 
         let role_mutation_plan: Option<RbacRoleMutationPlan> =
             if let Some(requested_role) = requested_role.as_ref() {
@@ -499,15 +506,22 @@ impl UserAdminMutationPort for ServerAuthAdminMutationProvider {
                 None
             };
 
-        let mut active: users::ActiveModel = user.into();
+        let user_row_update_requested = command.email.is_some()
+            || command.name.is_some()
+            || status_changed
+            || command.password.is_some()
+            || prepared.metadata.is_some();
+        let mut active: users::ActiveModel = locked_user.clone().into();
         if let Some(email) = command.email {
             active.email = Set(email.to_lowercase());
         }
         if let Some(name) = command.name {
             active.name = Set(Some(name));
         }
-        if let Some(status) = requested_status.as_ref() {
-            active.status = Set(status.clone());
+        if status_changed {
+            if let Some(status) = requested_status.as_ref() {
+                active.status = Set(status.clone());
+            }
         }
         if let Some(password) = command.password {
             active.password_hash = Set(hash_password(&password)
@@ -518,21 +532,30 @@ impl UserAdminMutationPort for ServerAuthAdminMutationProvider {
         }
 
         if requested_role.is_none() {
+            let effective_requested_status = if status_changed {
+                requested_status.as_ref()
+            } else {
+                None
+            };
             ensure_active_super_admin_continuity(
                 &tx,
                 context.tenant_id,
                 user_id,
                 &current_role,
                 None,
-                requested_status.as_ref(),
+                effective_requested_status,
                 false,
             )
             .await?;
         }
-        let user = active
-            .update(&tx)
-            .await
-            .map_err(|error| AuthAdminMutationError::Internal(error.to_string()))?;
+        let user = if user_row_update_requested {
+            active
+                .update(&tx)
+                .await
+                .map_err(|error| AuthAdminMutationError::Internal(error.to_string()))?
+        } else {
+            locked_user
+        };
         if let Some(plan) = role_mutation_plan.as_ref() {
             RbacService::replace_user_role_in_transaction(
                 &tx,
@@ -543,6 +566,10 @@ impl UserAdminMutationPort for ServerAuthAdminMutationProvider {
             .await
             .map_err(|error| AuthAdminMutationError::Internal(error.to_string()))?;
         }
+        let status_disables_user = status_changed
+            && requested_status
+                .as_ref()
+                .is_some_and(|status| status != &UserStatus::Active);
         if password_changed || status_disables_user {
             revoke_active_sessions(&tx, context.tenant_id, user.id).await?;
         }
@@ -561,7 +588,7 @@ impl UserAdminMutationPort for ServerAuthAdminMutationProvider {
             .await
             .map_err(map_custom_field_error)?;
         }
-        let invalidates_authorization = role_mutation_plan.is_some() || requested_status.is_some();
+        let invalidates_authorization = role_mutation_plan.is_some() || status_changed;
         let durable_generation = if invalidates_authorization {
             Some(
                 reserve_rbac_invalidation_generation(&tx)
@@ -698,7 +725,10 @@ impl UserAdminMutationPort for ServerAuthAdminMutationProvider {
 
 #[cfg(test)]
 mod tests {
-    use super::{map_role_mutation_policy_error, parse_user_role, parse_user_status};
+    use super::{
+        map_role_mutation_policy_error, parse_user_role, parse_user_status,
+        status_change_requested,
+    };
     use rustok_auth::AuthAdminMutationError;
     use rustok_core::{UserRole, UserStatus};
     use rustok_rbac::RbacRoleMutationPolicyError;
@@ -720,6 +750,19 @@ mod tests {
         assert!(matches!(
             map_role_mutation_policy_error(RbacRoleMutationPolicyError::LastActiveSuperAdmin),
             AuthAdminMutationError::Conflict(_)
+        ));
+    }
+
+    #[test]
+    fn status_effective_change_ignores_exact_replay() {
+        assert!(!status_change_requested(
+            &UserStatus::Active,
+            Some(&UserStatus::Active),
+        ));
+        assert!(!status_change_requested(&UserStatus::Active, None));
+        assert!(status_change_requested(
+            &UserStatus::Active,
+            Some(&UserStatus::Banned),
         ));
     }
 }

--- a/apps/server/src/services/rbac_runtime.rs
+++ b/apps/server/src/services/rbac_runtime.rs
@@ -9,29 +9,23 @@ use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
+#[cfg(test)]
 use rustok_core::UserRole;
 
 use rustok_api::{Action, Permission, Resource};
 use rustok_rbac::{
     AuthorizationDecision, DeniedReasonKind, PermissionCache, PermissionCacheLookup,
-    RelationPermissionStore, RoleAssignmentStore, RuntimePermissionResolver,
-    authorize_all_permissions, authorize_any_permission, authorize_permission,
-    invalidate_cached_permissions,
+    RelationPermissionStore, RuntimePermissionResolver, authorize_all_permissions,
+    authorize_any_permission, authorize_permission, invalidate_cached_permissions,
 };
 
 use crate::models::_entities::{permissions, role_permissions, roles, user_roles, users};
 
-use super::rbac_persistence::{
-    assign_role_permissions_via_store, remove_tenant_role_assignments_via_store,
-    remove_user_role_assignment_via_store, replace_user_role_via_store,
-};
+#[cfg(test)]
+use super::rbac_persistence::assign_role_permissions_via_store;
 
-pub(crate) type ServerRuntimePermissionResolver = RuntimePermissionResolver<
-    SeaOrmRelationPermissionStore,
-    MokaPermissionCache,
-    ServerRoleAssignmentStore,
-    Error,
->;
+pub(crate) type ServerRuntimePermissionResolver =
+    RuntimePermissionResolver<SeaOrmRelationPermissionStore, MokaPermissionCache, Error>;
 
 #[derive(Clone, Copy)]
 pub(crate) enum AuthorizationCheck<'a> {
@@ -229,7 +223,6 @@ pub(crate) fn resolver(db: &DatabaseConnection) -> ServerRuntimePermissionResolv
     RuntimePermissionResolver::new(
         SeaOrmRelationPermissionStore { db: db.clone() },
         MokaPermissionCache,
-        ServerRoleAssignmentStore { db: db.clone() },
     )
 }
 
@@ -336,11 +329,6 @@ pub(crate) struct SeaOrmRelationPermissionStore {
 
 #[derive(Clone)]
 pub(crate) struct MokaPermissionCache;
-
-#[derive(Clone)]
-pub(crate) struct ServerRoleAssignmentStore {
-    db: DatabaseConnection,
-}
 
 #[async_trait]
 impl PermissionCache for MokaPermissionCache {
@@ -501,46 +489,6 @@ impl RelationPermissionStore for SeaOrmRelationPermissionStore {
         }
 
         Ok(result)
-    }
-}
-
-#[async_trait]
-impl RoleAssignmentStore for ServerRoleAssignmentStore {
-    type Error = Error;
-
-    async fn assign_role_permissions(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<()> {
-        assign_role_permissions_via_store(&self.db, user_id, tenant_id, role).await
-    }
-
-    async fn replace_user_role(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<()> {
-        replace_user_role_via_store(&self.db, user_id, tenant_id, role).await
-    }
-
-    async fn remove_tenant_role_assignments(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-    ) -> Result<()> {
-        remove_tenant_role_assignments_via_store(&self.db, user_id, tenant_id).await
-    }
-
-    async fn remove_user_role_assignment(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<()> {
-        remove_user_role_assignment_via_store(&self.db, user_id, tenant_id, role).await
     }
 }
 

--- a/apps/server/src/services/rbac_service.rs
+++ b/apps/server/src/services/rbac_service.rs
@@ -342,11 +342,10 @@ impl RbacService {
         tenant_id: &uuid::Uuid,
         role: UserRole,
     ) -> Result<()> {
+        use super::rbac_persistence::assign_role_permissions_via_store;
+
         Self::record_authz_entrypoint_call("assign_role_permissions", "internal");
-        let resolver = Self::resolver(db);
-        resolver
-            .assign_role_permissions(tenant_id, user_id, role)
-            .await
+        assign_role_permissions_via_store(db, user_id, tenant_id, role).await
     }
 
     /// Transaction-only compatibility alias for legacy auth lifecycle composition.

--- a/apps/server/tests/rbac_auth_admin_effective_noop_guard.rs
+++ b/apps/server/tests/rbac_auth_admin_effective_noop_guard.rs
@@ -1,0 +1,91 @@
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("apps/server should live under workspace root")
+        .to_path_buf()
+}
+
+fn source(relative: &str) -> String {
+    let path = repo_root().join(relative);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}
+
+fn update_user_block(admin: &str) -> &str {
+    let start = admin
+        .find("    async fn update_user(")
+        .expect("Auth admin update_user must exist");
+    let end = admin[start..]
+        .find("    async fn delete_user(")
+        .map(|offset| start + offset)
+        .expect("Auth admin update_user must end before delete_user");
+    &admin[start..end]
+}
+
+#[test]
+fn owner_policy_retains_exact_noop_and_malformed_repair() {
+    let policy = source("crates/rustok-rbac/src/role_mutation.rs");
+
+    for required in [
+        "RbacRoleMutationOutcome::Noop",
+        "RbacRoleMutationChange::AssignmentRepaired",
+        "facts.assignment_is_exact && facts.target_role == facts.requested_role",
+        "exact_same_role_is_noop_but_malformed_same_role_is_repair",
+    ] {
+        assert!(policy.contains(required), "owner policy must retain {required}");
+    }
+}
+
+#[test]
+fn auth_admin_status_and_row_writes_follow_effective_change() {
+    let admin = source("apps/server/src/services/auth_admin_mutation_provider/user_admin.rs");
+    let update = update_user_block(&admin);
+
+    for required in [
+        "status_change_requested(&target_status, requested_status.as_ref())",
+        "let user_row_update_requested = command.email.is_some()",
+        "let user = if user_row_update_requested",
+        "RbacRoleMutationOutcome::Noop => None",
+        "let status_disables_user = status_changed",
+        "let invalidates_authorization = role_mutation_plan.is_some() || status_changed;",
+        "status_effective_change_ignores_exact_replay",
+    ] {
+        assert!(update.contains(required) || admin.contains(required), "effective-change path must retain {required}");
+    }
+
+    for forbidden in [
+        "let invalidates_authorization = role_mutation_plan.is_some() || requested_status.is_some();",
+        "let status_disables_user = requested_status",
+        "let user = active\n            .update(&tx)",
+    ] {
+        assert!(!update.contains(forbidden), "presence-based or unconditional mutation returned: {forbidden}");
+    }
+
+    let lock = update
+        .find("let locked_user = lock_user_for_mutation")
+        .expect("target row must be locked");
+    let status = update
+        .find("status_change_requested(&target_status, requested_status.as_ref())")
+        .expect("status must compare locked state");
+    let plan = update
+        .find("let role_mutation_plan: Option<RbacRoleMutationPlan>")
+        .expect("owner role plan must be used");
+    let row_update = update
+        .find("let user = if user_row_update_requested")
+        .expect("user row update must be conditional");
+    let invalidation = update
+        .find("let invalidates_authorization = role_mutation_plan.is_some() || status_changed;")
+        .expect("effective invalidation decision must exist");
+    let reserve = update
+        .find("reserve_rbac_invalidation_generation(&tx)")
+        .expect("effective change must reserve a generation");
+
+    assert!(lock < status);
+    assert!(status < plan);
+    assert!(plan < row_update);
+    assert!(row_update < invalidation);
+    assert!(invalidation < reserve);
+}

--- a/apps/server/tests/rbac_permission_resolver_read_only_guard.rs
+++ b/apps/server/tests/rbac_permission_resolver_read_only_guard.rs
@@ -1,0 +1,106 @@
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("apps/server should live under workspace root")
+        .to_path_buf()
+}
+
+fn source(relative: &str) -> String {
+    let path = repo_root().join(relative);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}
+
+#[test]
+fn permission_resolver_is_read_only() {
+    let contract = source("crates/rustok-rbac/src/services/permission_resolver.rs");
+
+    for forbidden in [
+        "async fn assign_role_permissions(",
+        "async fn replace_user_role(",
+        "async fn remove_tenant_role_assignments(",
+        "async fn remove_user_role_assignment(",
+    ] {
+        assert!(
+            !contract.contains(forbidden),
+            "PermissionResolver must not expose mutation method {forbidden}"
+        );
+    }
+
+    assert!(contract.contains("Read-only owner contract"));
+    assert!(contract.contains("transaction-owned or committed RBAC mutation"));
+}
+
+#[test]
+fn permission_resolver_test_doubles_are_read_only() {
+    let authorizer = source("crates/rustok-rbac/src/services/permission_authorizer.rs");
+
+    for forbidden in [
+        "async fn assign_role_permissions(",
+        "async fn replace_user_role(",
+        "async fn remove_tenant_role_assignments(",
+        "async fn remove_user_role_assignment(",
+    ] {
+        assert!(
+            !authorizer.contains(forbidden),
+            "permission resolver test doubles must not retain removed mutation method {forbidden}"
+        );
+    }
+
+    assert!(
+        !authorizer.contains("use rustok_core::UserRole;"),
+        "permission resolver test doubles must not depend on role mutation payloads"
+    );
+}
+
+#[test]
+fn runtime_permission_resolver_has_no_mutation_composition_surface() {
+    let runtime = source("crates/rustok-rbac/src/services/runtime_permission_resolver.rs");
+    let impl_start = runtime
+        .find("impl<S, C, E> PermissionResolver for RuntimePermissionResolver")
+        .expect("runtime resolver PermissionResolver implementation must exist");
+    let impl_end = runtime[impl_start..]
+        .find("#[cfg(test)]")
+        .map(|offset| impl_start + offset)
+        .expect("runtime resolver implementation must end before tests");
+    let resolver_impl = &runtime[impl_start..impl_end];
+
+    assert!(resolver_impl.contains("resolve_permissions_with_cache"));
+    for forbidden in [
+        "RoleAssignmentStore",
+        "assignment_store",
+        "assign_role_permissions",
+        "replace_user_role",
+        "remove_tenant_role_assignments",
+        "remove_user_role_assignment",
+    ] {
+        assert!(
+            !runtime.contains(forbidden),
+            "runtime permission resolver must not retain mutation composition: {forbidden}"
+        );
+    }
+}
+
+#[test]
+fn server_runtime_does_not_reintroduce_assignment_store_adapter() {
+    let runtime = source("apps/server/src/services/rbac_runtime.rs");
+
+    for forbidden in [
+        "RoleAssignmentStore",
+        "ServerRoleAssignmentStore",
+        "remove_tenant_role_assignments_via_store",
+        "remove_user_role_assignment_via_store",
+        "replace_user_role_via_store",
+    ] {
+        assert!(
+            !runtime.contains(forbidden),
+            "server permission runtime must not retain obsolete mutation adapter: {forbidden}"
+        );
+    }
+
+    assert!(runtime.contains("RuntimePermissionResolver<SeaOrmRelationPermissionStore"));
+    assert!(runtime.contains("RuntimePermissionResolver::new("));
+}

--- a/crates/rustok-events/docs/implementation-plan.md
+++ b/crates/rustok-events/docs/implementation-plan.md
@@ -2,223 +2,112 @@
 
 ## Source of truth
 
-This file is the live plan for shared event contracts and guarantees remote consumers
-may rely on. Transport execution remains owned by Outbox, Iggy, the server runtime,
-or the consuming owner module.
+This file owns shared typed event payloads, envelope validation, schema registry, and
+deterministic contract digest generation. Domain transactions and transport execution
+remain in producer owners, Outbox, broker runtimes, and consumers.
 
-Last reconciled with `main`: 2026-07-28.
+Last reconciled with `main`: 2026-08-01.
 
 ## Current state
 
-`rustok-events` is the canonical source of `DomainEvent`, `EventEnvelope`, sealed typed
-families, schema metadata, semantic validation, and versioning policy.
-`rustok-core::events` is a compatibility re-export only.
+- Root and typed contract envelopes validate at publication, transport, and decode
+  boundaries.
+- External crates cannot implement `EventContract` or publish arbitrary typed-family
+  names.
+- Tenant, actor, correlation, causation, trace, retry, and timestamp facts remain
+  envelope metadata.
+- `contracts/event-contract-digests.json` is generated only by the repository-owned
+  command after intentional schema review.
 
-The committed `contracts/event-contract-digests.json` gates the root registry and
-root/typed wire schemas. Digest generation is deterministic and never occurs as an
-implicit build/test side effect. The current release train intentionally allows only
-version-1 schemas until remote-consumer migration ownership is retained.
+Merged PR #2867 registers canonical built-in role mutation contracts:
 
-Root and typed envelopes validate at publication, outbox, relay, and JSON/MessagePack
-decode boundaries. `EventRuntime` is published before dispatcher startup and owns the
-shared Iggy transport used by outbound relay and approved inbound consumers.
+- `rbac.user_role_replaced`;
+- `rbac.user_role_assignment_repaired`.
 
-The typed-family implementation includes sealed
-`social_graph.relation.state_changed` v1. Its payload contains relation id,
-source/target user ids, canonical relation kind, active state, and revision only.
-Tenant and actor remain envelope metadata. The Social Graph owner publishes the fact
-transactionally and provides bounded service/system-only replay over authoritative
-relation state.
+Their owner policy and same-transaction publication live in `rustok-rbac` and the Auth
+admin adapter. Exact canonical role replay emits neither event.
 
-The typed-family implementation also includes
-`TranslationWorkflowEvent` v1 for job creation/cancellation/completion,
-assignment, explicit blocked-item retry, proposal, apply, and recovery
-lifecycle evidence. Translation publishes these contracts transactionally with
-its workflow state. Payloads exclude source/target copy, proposal values,
-operator reasons, claims, roles, and owner receipt data.
+Draft PR #2866 adds the remaining artifact permission family:
 
-Contract tests cover public event-contract use cases.
+- `rbac.artifact_role_permission.assignment_changed` v1;
+- mutation, idempotency receipt, relation state, and event share one owner transaction;
+- exact retry and state no-op emit no event;
+- tenant and actor remain envelope metadata;
+- required Outbox failure rolls back the mutation and receipt.
 
-## Delivered Social Graph → Index consumer contract
+## Delivered results
 
-- Index is the first approved consumer of the sealed relation family.
-- Active relations map to generic non-localized upserts, inactive relations to
-  tombstones, relation id to entity identity, and revision to monotonic
-  `source_version`.
-- `SocialGraphIndexProjector` persists or exactly recognizes the tenant schema through
-  Index-owned `PostgresSchemaRegistrationStore` before `PostgresMutationStore` apply.
-- `Applied`, `Duplicate`, and `StaleIgnored` are durable terminal outcomes.
-- Persistent group `rustok-social-graph-index` consumes the shared `domain` topic;
-  unrelated sealed families are acknowledged without projection.
-- Staged receive/project/ack retains one outstanding delivery across bounded retries.
-- Runtime execution is default-off and requires explicit enablement, a worker host,
-  and effective `outbox_iggy` delivery.
-- Relay and consumer reuse the exact `Arc<IggyTransport>` created by `EventRuntime`.
-- Shared `StopHandle` controls graceful shutdown and the worker handle participates in
-  readiness only while explicitly enabled.
-- Projection, DLQ publication, and source acknowledgement use bounded retry.
-- Migration `m20260727_000004_create_index_dlq_receipts` binds a poison decision to
-  tenant/consumer-group/event identity, exact source coordinates, exact broker bytes,
-  stable error code, and projection attempts.
-- Receipt states durably reserve and lease publication, then record `published` before
-  source ack. The consumer checks them before projection.
-- A `published`/`acknowledged` redelivery skips Index projection and DLQ publication and
-  enters acknowledgement-only recovery. An unfinished receipt remains retryable DLQ
-  work and cannot cross back into mutation apply.
-- A versioned length-framed SHA-256 construction derives one RFC 9562 UUIDv8 from the
-  immutable receipt identity and exact payload. Retry count, time, publisher identity,
-  and random state are excluded.
-- `publish_consumed_to_dlq` attaches that UUID separately from the source event ID,
-  publishes exact bytes, and returns success only after the durable `published`
-  transition. The worker records fresh and previously published outcomes separately.
-- `IggyTransport` lazily opens an SDK publisher connection to the same configured
-  endpoint and existing `dlq` topic, then maps the UUIDv8 to Iggy's `u128` message
-  header. It creates no second transport or broker process.
-- Ack failure after successful publication is replay-safe without DLQ republish.
-  Receipt acknowledgement is best-effort bookkeeping after the source broker commit.
-- Broker success followed by process/DB failure before the `published` transition is
-  still an explicit confirmation ambiguity. Republication carries the same header ID,
-  but physical suppression occurs only while deployment-owned Iggy deduplication is
-  enabled and its per-partition cache/expiry contains that ID.
-- A deterministic ID and bounded optional deduplication do not create an event-contract
-  exactly-once guarantee. The durable owner receipt remains authoritative.
-- Successfully decoded deliveries retain exact raw bytes. Undecodable bytes remain
-  unacknowledged pending a connector-level poison-message contract.
-- Missing/stopped/invalid enabled worker state reaches `runtime_guardrails`,
-  `/health/ready`, and aggregate guardrail metrics. Disabled execution is healthy.
-- Shared bounded Prometheus delivery metrics cover received/terminal outcomes,
-  projection/DLQ/ack retries, stage/error failures, DLQ publish classifications,
-  receive-to-ack duration, worker lifecycle, in-flight state/timestamp, and last
-  success.
-- A read-only Iggy observer connects to the already-running configured endpoint and
-  reads every `domain` partition plus the persistent group checkpoint. It does not
-  consume events, store offsets, publish, acknowledge, or manage a broker process.
-- Position metrics expose snapshot timestamp, partition count, completeness, and exact
-  total/max broker offset lag only when every partition has a coherent result. Empty
-  partitions contribute zero; missing/inconsistent checkpoints make the snapshot
-  incomplete and clear lag gauges.
-- Metric labels are bounded and exclude tenants, event/relation identifiers, partition,
-  offset, payloads, broker IDs, ack tokens, credentials, and raw error messages.
-- Observer failures are retried independently and do not stop projection or enter the
-  projection worker readiness contract.
-- Bounded Social Graph replay uses the same schema/inbox/source-version path for repair.
-- Profiles privacy remains on synchronous authoritative Social Graph ports and must not
-  authorize from Index, DLQ receipts, broker IDs, deduplication state, or lag.
+- [x] Seal typed contract families.
+- [x] Validate payload and envelope metadata.
+- [x] Keep explicit event type and schema version registry entries.
+- [x] Generate deterministic JSON schemas and contract digests.
+- [x] Register merged RBAC role replacement/repair contracts from #2867.
+- [x] Register artifact role-permission assignment contract in draft #2866.
+- [x] Add artifact contract validation and envelope round-trip tests.
+- [x] Add source guards for owner transaction and rollback ordering.
+- [ ] Generate and review the exact-head digest for #2866.
+- [ ] Execute Events/RBAC/server contract, transaction, verifier, and module gates.
 
-## FFA/FBA boundary
+## Open work
 
-- FFA status: `in_progress`
-- FBA status: `in_progress`
-- Structural shape: `core -> transport -> ui/leptos`, with a sibling module-owned Next
-  package.
-- `rustok-events-module` remains the cycle-free runtime/manifest adapter and owns its
-  admin delivery-profile surface.
-- The host composes routes and delivery control; it does not own event schemas or
-  module UI.
+### P0. Digest and exact-head verification
 
-## Completed source results
+- [x] Reconstruct #2866 as one commit on the latest `main`.
+- [ ] Run `event_contract_digests -- --write` on that exact head.
+- [ ] Review and commit generator output only; never guess or hand-edit hashes.
+- [ ] Run all-target Events compilation and focused RBAC event tests.
 
-- [x] Keep one canonical event/envelope/schema definition in `rustok-events`.
-- [x] Validate root and typed payloads at publication, relay, and decode boundaries.
-- [x] Keep registry, wire schemas, and committed digest artifact synchronized.
-- [x] Own and guard outbound relay lifecycle.
-- [x] Add sealed `social_graph.relation.state_changed` v1 and transactional publication.
-- [x] Add bounded authoritative Social Graph replay.
-- [x] Add generic Index conversion and Index-owned tenant schema registration.
-- [x] Add persistent result-first Index consumption with duplicate/stale recognition.
-- [x] Add default-off host startup, strict delivery gating, one shared Iggy transport,
-  shutdown, bounded projection/DLQ/ack retry, durable exact-byte DLQ receipts,
-  deterministic UUIDv8 broker headers, and acknowledgement-only recovery.
-- [x] Add enabled-worker readiness and aggregate guardrail metrics.
-- [x] Add bounded dedicated remote-consumer delivery telemetry.
-- [x] Add read-only every-partition committed/high-watermark observation and
-  completeness-gated total/max lag.
-- [x] Add source guards for ordering, transport ownership, readiness, telemetry labels,
-  broker-backed lag origin, incomplete-snapshot clearing, durable DLQ identity/state,
-  deterministic header construction, explicit Iggy `u128` publication, and
-  foreign-table isolation.
+### P1. Producer and consumer evidence
 
-## Open results
+- [ ] Execute artifact mutation success, exact retry, state no-op, publication failure,
+  and rollback cases.
+- [ ] Identify approved artifact permission event consumers.
+- [ ] Require consumers to be tenant-bound, idempotent, replay-safe, and
+  non-authoritative for access decisions.
+- [ ] Define retention and replay guidance before remote consumption.
 
-1. **Keep reviewed event-contract digests synchronized.** Regenerate only through the
-   deterministic example when a reviewed contract shape changes.
-2. **Keep event types, registry, release artifacts, and consumer imports synchronized.**
-   New families require direct `rustok-events` imports, semantic coverage, and owner
-   recovery guidance.
-3. **Prove remote cursor, receipt, header, and position recovery.** Execute real-Iggy
-   restart, redelivery, ack failure, DLQ failure, publisher reconnect, connector loss,
-   observer reconnect, shutdown, TLS/auth, rebalance, concurrent snapshot movement,
-   and multi-replica ownership.
-4. **Exercise the remaining DLQ confirmation ambiguity.** Fail after broker publication
-   but before the durable `published` mark with deduplication disabled, enabled,
-   capacity-evicted, and expired. Verify the configured window covers the maximum
-   lease/restart/recovery horizon before relying on suppression.
-5. **Choose the production confirmation mechanism.** Enforce and monitor an adequate
-   Iggy deduplication contract, or adopt a broker transaction/DB-owned DLQ outbox relay
-   before claiming stronger physical duplicate guarantees.
-6. **Prove Index repair and concurrency.** Execute PostgreSQL concurrent schema
-   registration/mutation/DLQ receipt claims, create drift, and repair through bounded
-   owner replay/rescan while privacy remains on owner ports.
-7. **Define undecodable poison handling.** Add a connector shape that preserves exact
-   raw bytes and source coordinates before envelope construction without moving owner
-   policy into the transport.
-8. **Synchronize recovery guidance.** Outbox, replay, reindex, lag, dedup configuration,
-   receipt retention, and DLQ runbooks must name exact schemas and avoid
-   transport-owned payload copies.
+### P1. Existing transport evidence
 
-## Verification
+- [ ] Execute retained Iggy restart, redelivery, acknowledgement, DLQ, reconnect,
+  rebalance, and multi-replica ownership packets.
+- [ ] Prove exact-byte durable DLQ receipts and acknowledgement-only recovery.
+- [ ] Preserve poison messages and source coordinates for undecodable payloads.
 
-- `cargo xtask module validate events`
-- `cargo xtask module test events`
-- `cargo test -p rustok-events --test social_graph_contracts -- --nocapture`
-- `cargo run -p rustok-events --example event_contract_digests`
-- `RUSTFLAGS="-Dwarnings" cargo check -p rustok-telemetry --all-targets`
-- `cargo test -p rustok-telemetry`
-- `RUSTFLAGS="-Dwarnings" cargo check -p rustok-index --all-targets`
-- `cargo test -p rustok-index schema_registration --lib -- --nocapture`
-- `RUSTFLAGS="-Dwarnings" cargo check -p rustok-iggy --all-targets`
-- `RUSTFLAGS="-Dwarnings" cargo check -p rustok-social-graph --features index-consumer --all-targets`
-- `cargo test -p rustok-social-graph --features index-consumer index_consumer::tests -- --nocapture`
-- `cargo test -p rustok-social-graph --features index-consumer index_dlq_receipt::tests -- --nocapture`
-- `cargo test -p rustok-social-graph --features index-consumer index_dlq_message_id::tests -- --nocapture`
-- `RUSTFLAGS="-Dwarnings" cargo check -p rustok-server --features mod-social_graph --all-targets`
-- `cargo test -p rustok-server social_graph_index_worker --lib -- --nocapture`
-- `cargo test -p rustok-server runtime_guardrails --lib -- --nocapture`
-- `node scripts/verify/verify-index-schema-registration.mjs`
-- `node scripts/verify/verify-iggy-consumer-position.mjs`
-- `node scripts/verify/verify-social-graph-relation-event-replay.mjs`
-- `node scripts/verify/verify-social-graph-index-consumer.mjs`
-- `node scripts/verify/verify-social-graph-index-runtime-consumer.mjs`
-- `node scripts/verify/verify-social-graph-index-worker-lifecycle.mjs`
-- `node scripts/verify/verify-social-graph-index-dlq-receipts.mjs`
-- `node scripts/verify/verify-runtime-consumer-metrics.mjs`
-- Real-broker deterministic-header/dedup disabled-enabled-expiry-capacity,
-  multi-replica restart/recovery/position/receipt, and PostgreSQL evidence.
+## Verification commands
 
-These commands and scenarios remain maintainer-run and were not executed manually in
-this slice.
+```bash
+cargo run -p rustok-events --example event_contract_digests -- --write
+cargo check -p rustok-events --all-targets
+cargo test -p rustok-events rbac_role_mutation
+cargo test -p rustok-events --test rbac_artifact_permission_contracts
+cargo test -p rustok-rbac --test artifact_permission_outbox_sqlite
+cargo test -p rustok-server --lib artifact_permission
+node scripts/verify/verify-rbac-owner-role-mutation-contract.mjs
+node scripts/verify/verify-rbac-artifact-permission-outbox.mjs
+cargo xtask module validate events
+cargo xtask module test events
+cargo xtask module validate rbac
+cargo xtask module test rbac
+```
 
-## Change rules
+No command above was executed in this connector-only source slice.
 
-1. Keep canonical event payloads and schemas in this module.
-2. Keep transport execution in its runtime owner; do not copy payload definitions.
-3. Update digest artifacts only through intentional contract review.
-4. Consumers persist or recognize tenant schema and owner result before ack.
-5. Source consumers never write another owner's schema/projection tables directly.
-6. Reuse the host-owned transport; additional SDK clients may connect only to its
-   configured endpoint and must never create another bundled process.
-7. Permitted DLQ publication and durable terminal receipt precede source ack;
-   terminal-result ack failure is acknowledgement-only recovery.
-8. A durable receipt is checked before projection and binds exact source coordinates and
-   bytes. A deterministic broker ID must bind the same immutable identity and exclude
-   attempt/time/random state.
-9. Do not claim physical broker exactly-once from a receipt, message ID, or optional
-   bounded deduplication cache without retained configuration/runtime evidence.
-10. Enabled durable workers participate in readiness and bounded telemetry; disabled
-    optional workers do not degrade the host.
-11. Publish lag only from every-partition broker checkpoints/high-watermarks with an
-    explicit completeness signal; never infer it from event age or one offset.
-12. Position observation is read-only and cannot become event execution or owner policy.
-13. Keep producer storage authoritative for bounded repair.
-14. Update module docs, event flow, and recovery guidance with every contract change.
-15. Keep the central plan registry limited to status and nearest priority.
+## Completion gates
+
+- A new event family is not reviewed until its generated digest is committed.
+- A reviewed contract is not operationally verified until producer transaction and
+  consumer replay/idempotency evidence pass.
+- Authorization consumers may react to RBAC events but cannot authorize from them.
+
+## Periodic release verification handoff
+
+- Cycle: `cycle-001`
+- Status: `in_progress`
+- Last verified at (UTC): `2026-08-01`
+- Scope inspected: `merged owner role mutation contracts; artifact permission sealed family; envelope registry; owner transaction ordering; digest synchronization`
+- Findings: `P0=1, P1=1, P2=0, P3=0`
+- Fixed in this pass: `draft PR #2866 adds sealed artifact role-permission assignment events through the canonical Outbox in the same RBAC owner transaction. Exact retry and state no-op publish nothing, while required publication failure rolls back mutation and idempotency receipt. The branch is reconstructed as one commit on the latest main.`
+- Remaining risks or blockers: `The #2866 generated contract digest is absent. Events/RBAC/server compilation, focused tests, Node/module gates, approved consumers, replay guidance, and runtime transport evidence remain absent.`
+- Evidence: `source review confirms the artifact family composes additively with merged #2867 role mutation contracts, retains typed validation and transaction-bound publication, and is one commit zero behind current main. No generator or runtime execution is claimed.`
+- Next action: `generate and review the #2866 digest, then execute exact-head Events/RBAC/server contract and transaction gates`
+- Resume command: `cargo run -p rustok-events --example event_contract_digests -- --write && cargo check -p rustok-events --all-targets && cargo test -p rustok-events --test rbac_artifact_permission_contracts && cargo test -p rustok-rbac --test artifact_permission_outbox_sqlite && node scripts/verify/verify-rbac-artifact-permission-outbox.mjs`

--- a/crates/rustok-events/src/contract.rs
+++ b/crates/rustok-events/src/contract.rs
@@ -8,7 +8,8 @@ use uuid::Uuid;
 use crate::{
     DomainEvent, EventEnvelope, EventValidationError, ForumMentionEvent,
     ForumSearchProjectionEvent, MarketplaceListingEvent, MarketplaceSellerEvent,
-    RbacRoleMutationEvent, SocialGraphRelationEvent, TranslationWorkflowEvent, ValidateEvent,
+    RbacArtifactPermissionEvent, RbacRoleMutationEvent, SocialGraphRelationEvent,
+    TranslationWorkflowEvent, ValidateEvent,
 };
 
 pub(crate) mod sealed {
@@ -16,9 +17,6 @@ pub(crate) mod sealed {
 }
 
 /// Closed platform contract for typed events accepted by durable transports.
-///
-/// Implementations live in `rustok-events`; domain modules cannot publish
-/// arbitrary string event names or unregistered payloads.
 #[allow(private_bounds)]
 pub trait EventContract:
     sealed::Sealed + Clone + Serialize + DeserializeOwned + ValidateEvent + Send + Sync + 'static
@@ -28,10 +26,6 @@ pub trait EventContract:
     fn into_contract_payload(self) -> ContractEventPayload;
 }
 
-/// Typed family wrapper used by durable and streaming transports.
-///
-/// Adding a bounded family requires one platform variant, while lifecycle
-/// evolution remains inside the family's own enum.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, JsonSchema)]
 #[serde(tag = "family", content = "event")]
 pub enum ContractEventPayload {
@@ -45,6 +39,8 @@ pub enum ContractEventPayload {
     MarketplaceListing(MarketplaceListingEvent),
     #[serde(rename = "marketplace_seller")]
     MarketplaceSeller(MarketplaceSellerEvent),
+    #[serde(rename = "rbac_artifact_permission")]
+    RbacArtifactPermission(RbacArtifactPermissionEvent),
     #[serde(rename = "rbac_role_mutation")]
     RbacRoleMutation(RbacRoleMutationEvent),
     #[serde(rename = "social_graph_relation")]
@@ -61,6 +57,7 @@ impl ContractEventPayload {
             Self::ForumSearchProjection(event) => event.event_type(),
             Self::MarketplaceListing(event) => event.event_type(),
             Self::MarketplaceSeller(event) => event.event_type(),
+            Self::RbacArtifactPermission(event) => event.event_type(),
             Self::RbacRoleMutation(event) => event.event_type(),
             Self::SocialGraphRelation(event) => event.event_type(),
             Self::TranslationWorkflow(event) => event.event_type(),
@@ -74,6 +71,7 @@ impl ContractEventPayload {
             Self::ForumSearchProjection(event) => event.schema_version(),
             Self::MarketplaceListing(event) => event.schema_version(),
             Self::MarketplaceSeller(event) => event.schema_version(),
+            Self::RbacArtifactPermission(event) => event.schema_version(),
             Self::RbacRoleMutation(event) => event.schema_version(),
             Self::SocialGraphRelation(event) => event.schema_version(),
             Self::TranslationWorkflow(event) => event.schema_version(),
@@ -89,6 +87,7 @@ impl ValidateEvent for ContractEventPayload {
             Self::ForumSearchProjection(event) => event.validate(),
             Self::MarketplaceListing(event) => event.validate(),
             Self::MarketplaceSeller(event) => event.validate(),
+            Self::RbacArtifactPermission(event) => event.validate(),
             Self::RbacRoleMutation(event) => event.validate(),
             Self::SocialGraphRelation(event) => event.validate(),
             Self::TranslationWorkflow(event) => event.validate(),
@@ -112,7 +111,6 @@ impl EventContract for DomainEvent {
     }
 }
 
-/// Transport-neutral envelope for any sealed typed platform event contract.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, JsonSchema)]
 pub struct ContractEventEnvelope {
     id: Uuid,
@@ -142,12 +140,6 @@ impl ContractEventEnvelope {
         Self::new_with_causation(tenant_id, actor_id, None, event)
     }
 
-    /// Creates a typed envelope that is causally linked to one exact durable
-    /// predecessor envelope.
-    ///
-    /// The causation identity is transport metadata, not payload data. A nil
-    /// identity is rejected by the same registered-envelope validation used for
-    /// decoded and relayed events.
     pub fn new_caused_by<E>(
         tenant_id: Uuid,
         actor_id: Option<Uuid>,

--- a/crates/rustok-events/src/lib.rs
+++ b/crates/rustok-events/src/lib.rs
@@ -5,6 +5,7 @@ mod forum_mention;
 mod forum_search_projection;
 mod marketplace_listing;
 mod marketplace_seller;
+mod rbac_artifact_permission;
 mod rbac_role_mutation;
 mod schema;
 mod social_graph;
@@ -27,6 +28,10 @@ pub use marketplace_listing::{
 };
 pub use marketplace_seller::{
     MARKETPLACE_SELLER_EVENT_SCHEMAS, MarketplaceSellerEvent, marketplace_seller_event_schema,
+};
+pub use rbac_artifact_permission::{
+    RBAC_ARTIFACT_PERMISSION_EVENT_SCHEMAS, RbacArtifactPermissionEvent,
+    rbac_artifact_permission_event_schema,
 };
 pub use rbac_role_mutation::{
     RBAC_EVENT_USER_ROLE_ASSIGNMENT_REPAIRED, RBAC_EVENT_USER_ROLE_REPLACED,
@@ -56,6 +61,7 @@ pub fn event_schema(event_type: &str) -> Option<&'static EventSchema> {
         .or_else(|| forum_search_projection_event_schema(event_type))
         .or_else(|| marketplace_listing_event_schema(event_type))
         .or_else(|| marketplace_seller_event_schema(event_type))
+        .or_else(|| rbac_artifact_permission_event_schema(event_type))
         .or_else(|| rbac_role_mutation_event_schema(event_type))
         .or_else(|| social_graph_relation_event_schema(event_type))
         .or_else(|| translation_workflow_event_schema(event_type))
@@ -68,6 +74,7 @@ pub fn event_schemas() -> impl Iterator<Item = &'static EventSchema> {
         .chain(FORUM_SEARCH_PROJECTION_EVENT_SCHEMAS.iter())
         .chain(MARKETPLACE_LISTING_EVENT_SCHEMAS.iter())
         .chain(MARKETPLACE_SELLER_EVENT_SCHEMAS.iter())
+        .chain(RBAC_ARTIFACT_PERMISSION_EVENT_SCHEMAS.iter())
         .chain(RBAC_ROLE_MUTATION_EVENT_SCHEMAS.iter())
         .chain(SOCIAL_GRAPH_RELATION_EVENT_SCHEMAS.iter())
         .chain(TRANSLATION_WORKFLOW_EVENT_SCHEMAS.iter())

--- a/crates/rustok-events/src/rbac_artifact_permission.rs
+++ b/crates/rustok-events/src/rbac_artifact_permission.rs
@@ -1,0 +1,189 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::contract::{ContractEventPayload, EventContract, sealed};
+use crate::validation::{EventValidationError, ValidateEvent, validators};
+use crate::{EventSchema, FieldSchema};
+
+const MAX_PERMISSION_KEY_LENGTH: usize = 256;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(tag = "type", content = "data")]
+pub enum RbacArtifactPermissionEvent {
+    AssignmentChanged {
+        operation_id: Uuid,
+        role_id: Uuid,
+        installation_id: Uuid,
+        permission_key: String,
+        granted: bool,
+    },
+}
+
+impl RbacArtifactPermissionEvent {
+    pub fn event_type(&self) -> &'static str {
+        match self {
+            Self::AssignmentChanged { .. } => {
+                "rbac.artifact_role_permission.assignment_changed"
+            }
+        }
+    }
+
+    pub const fn schema_version(&self) -> u16 {
+        1
+    }
+}
+
+const ASSIGNMENT_CHANGED_FIELDS: &[FieldSchema] = &[
+    FieldSchema {
+        name: "operation_id",
+        data_type: "uuid",
+        optional: false,
+    },
+    FieldSchema {
+        name: "role_id",
+        data_type: "uuid",
+        optional: false,
+    },
+    FieldSchema {
+        name: "installation_id",
+        data_type: "uuid",
+        optional: false,
+    },
+    FieldSchema {
+        name: "permission_key",
+        data_type: "string",
+        optional: false,
+    },
+    FieldSchema {
+        name: "granted",
+        data_type: "bool",
+        optional: false,
+    },
+];
+
+pub const RBAC_ARTIFACT_PERMISSION_EVENT_SCHEMAS: &[EventSchema] = &[EventSchema {
+    event_type: "rbac.artifact_role_permission.assignment_changed",
+    version: 1,
+    description: "RBAC atomically changed one tenant role grant for an admitted artifact permission.",
+    fields: ASSIGNMENT_CHANGED_FIELDS,
+}];
+
+impl sealed::Sealed for RbacArtifactPermissionEvent {}
+
+impl EventContract for RbacArtifactPermissionEvent {
+    fn event_type(&self) -> &'static str {
+        RbacArtifactPermissionEvent::event_type(self)
+    }
+
+    fn schema_version(&self) -> u16 {
+        RbacArtifactPermissionEvent::schema_version(self)
+    }
+
+    fn into_contract_payload(self) -> ContractEventPayload {
+        ContractEventPayload::RbacArtifactPermission(self)
+    }
+}
+
+impl ValidateEvent for RbacArtifactPermissionEvent {
+    fn validate(&self) -> Result<(), EventValidationError> {
+        let Self::AssignmentChanged {
+            operation_id,
+            role_id,
+            installation_id,
+            permission_key,
+            ..
+        } = self;
+
+        validators::validate_not_nil_uuid("operation_id", operation_id)?;
+        validators::validate_not_nil_uuid("role_id", role_id)?;
+        validators::validate_not_nil_uuid("installation_id", installation_id)?;
+        validators::validate_not_empty("permission_key", permission_key)?;
+        validators::validate_max_length(
+            "permission_key",
+            permission_key,
+            MAX_PERMISSION_KEY_LENGTH,
+        )?;
+        if permission_key.trim() != permission_key
+            || permission_key.chars().any(char::is_control)
+        {
+            return Err(EventValidationError::InvalidCharacters("permission_key"));
+        }
+        Ok(())
+    }
+}
+
+pub fn rbac_artifact_permission_event_schema(
+    event_type: &str,
+) -> Option<&'static EventSchema> {
+    RBAC_ARTIFACT_PERMISSION_EVENT_SCHEMAS
+        .iter()
+        .find(|schema| schema.event_type == event_type)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event() -> RbacArtifactPermissionEvent {
+        RbacArtifactPermissionEvent::AssignmentChanged {
+            operation_id: Uuid::new_v4(),
+            role_id: Uuid::new_v4(),
+            installation_id: Uuid::new_v4(),
+            permission_key: "sample.events.handle".to_string(),
+            granted: true,
+        }
+    }
+
+    #[test]
+    fn validates_registered_assignment_change() {
+        let event = event();
+        assert!(event.validate().is_ok());
+        assert_eq!(
+            event.event_type(),
+            "rbac.artifact_role_permission.assignment_changed"
+        );
+        assert_eq!(event.schema_version(), 1);
+    }
+
+    #[test]
+    fn rejects_nil_identity_and_unbounded_permission_key() {
+        let RbacArtifactPermissionEvent::AssignmentChanged {
+            role_id,
+            installation_id,
+            permission_key,
+            granted,
+            ..
+        } = event();
+        assert!(
+            RbacArtifactPermissionEvent::AssignmentChanged {
+                operation_id: Uuid::nil(),
+                role_id,
+                installation_id,
+                permission_key,
+                granted,
+            }
+            .validate()
+            .is_err()
+        );
+
+        let RbacArtifactPermissionEvent::AssignmentChanged {
+            operation_id,
+            role_id,
+            installation_id,
+            granted,
+            ..
+        } = event();
+        assert!(
+            RbacArtifactPermissionEvent::AssignmentChanged {
+                operation_id,
+                role_id,
+                installation_id,
+                permission_key: "x".repeat(MAX_PERMISSION_KEY_LENGTH + 1),
+                granted,
+            }
+            .validate()
+            .is_err()
+        );
+    }
+}

--- a/crates/rustok-events/tests/rbac_artifact_permission_contracts.rs
+++ b/crates/rustok-events/tests/rbac_artifact_permission_contracts.rs
@@ -1,0 +1,71 @@
+use rustok_events::{
+    ContractEventEnvelope, ContractEventPayload, RBAC_ARTIFACT_PERMISSION_EVENT_SCHEMAS,
+    RbacArtifactPermissionEvent, ValidateEvent, event_schema,
+};
+use uuid::Uuid;
+
+fn event() -> RbacArtifactPermissionEvent {
+    RbacArtifactPermissionEvent::AssignmentChanged {
+        operation_id: Uuid::new_v4(),
+        role_id: Uuid::new_v4(),
+        installation_id: Uuid::new_v4(),
+        permission_key: "sample.events.handle".to_string(),
+        granted: true,
+    }
+}
+
+#[test]
+fn rbac_artifact_permission_family_has_one_registered_contract() {
+    assert_eq!(RBAC_ARTIFACT_PERMISSION_EVENT_SCHEMAS.len(), 1);
+    let schema = event_schema("rbac.artifact_role_permission.assignment_changed")
+        .expect("registered RBAC artifact permission schema");
+    assert_eq!(schema.version, 1);
+    assert_eq!(schema.fields.len(), 5);
+}
+
+#[test]
+fn rbac_artifact_permission_contract_is_typed_validated_and_enveloped() {
+    let tenant_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    let event = event();
+    event.validate().expect("valid event");
+
+    let envelope = ContractEventEnvelope::new(tenant_id, Some(actor_id), event.clone())
+        .expect("valid typed envelope");
+    assert_eq!(
+        envelope.event_type(),
+        "rbac.artifact_role_permission.assignment_changed"
+    );
+    assert_eq!(envelope.schema_version(), 1);
+    assert_eq!(envelope.tenant_id(), tenant_id);
+    assert_eq!(
+        envelope.payload().expect("registered payload"),
+        &ContractEventPayload::RbacArtifactPermission(event)
+    );
+}
+
+#[test]
+fn rbac_artifact_permission_contract_rejects_invalid_identity_and_key() {
+    assert!(
+        RbacArtifactPermissionEvent::AssignmentChanged {
+            operation_id: Uuid::nil(),
+            role_id: Uuid::new_v4(),
+            installation_id: Uuid::new_v4(),
+            permission_key: "sample.events.handle".to_string(),
+            granted: true,
+        }
+        .validate()
+        .is_err()
+    );
+    assert!(
+        RbacArtifactPermissionEvent::AssignmentChanged {
+            operation_id: Uuid::new_v4(),
+            role_id: Uuid::new_v4(),
+            installation_id: Uuid::new_v4(),
+            permission_key: " sample.events.handle".to_string(),
+            granted: true,
+        }
+        .validate()
+        .is_err()
+    );
+}

--- a/crates/rustok-rbac/docs/auth-admin-effective-noop.md
+++ b/crates/rustok-rbac/docs/auth-admin-effective-noop.md
@@ -1,0 +1,48 @@
+# Auth admin effective no-op contract
+
+## Status
+
+`source_ready_unvalidated`
+
+Merged PR #2867 owns canonical built-in role policy and durable role mutation events.
+This correction narrows the host adapter to effective status and user-row changes.
+
+## Exact replay
+
+After the tenant-scoped user row is locked:
+
+- a requested status equal to the locked status is not a status change;
+- an exact canonical role request is classified by `plan_user_role_mutation` as `Noop`;
+- a request containing only exact role/status replay does not update `users`;
+- it does not reserve a durable authorization generation;
+- it does not revoke sessions;
+- it does not publish a role event or invalidation fast path.
+
+Email, name, password, metadata, real status transitions, role replacement, and malformed
+role-relation repair remain real writes according to their owned policies.
+
+## Relation repair
+
+A matching effective role among multiple or malformed tenant assignments is not an
+exact replay. The RBAC owner returns `RbacRoleMutationOutcome::Apply` with
+`AssignmentRepaired`; the server repairs the relation, reserves a generation, and
+publishes the merged `rbac.user_role_assignment_repaired` contract in the same
+transaction.
+
+## Status transitions
+
+A real transition to `inactive` or `banned` revokes active sessions. Replaying an
+already inactive or banned status does not revoke them again. Status-only transitions
+advance the durable authorization generation but do not publish a role-mutation event.
+
+## Required verification
+
+```bash
+cargo check -p rustok-server --lib
+cargo test -p rustok-server status_effective_change_ignores_exact_replay
+cargo test -p rustok-server --test rbac_auth_admin_effective_noop_guard
+cargo test -p rustok-server auth_admin_mutation_provider
+```
+
+No formatting, compile, test, database, Outbox, or runtime execution is claimed by this
+source-only correction.

--- a/crates/rustok-rbac/docs/implementation-plan.md
+++ b/crates/rustok-rbac/docs/implementation-plan.md
@@ -2,465 +2,217 @@
 
 ## Source of truth
 
-This file is the canonical live implementation plan for RBAC. It owns the
-current implementation state, completed source phases, remaining priorities and
-targeted verification.
+This file is the canonical live RBAC implementation plan. It owns current source state,
+remaining priorities, verification commands, and the periodic release handoff.
 
-- `[x]` means the capability is present in `main` and protected by source-level
-  tests or architecture guards.
-- `[ ]` means implementation or verification is still required.
-- A source-complete item is not considered compiled or operationally verified
-  until the corresponding Rust and live-service checks have passed.
-- `docs/modules/implementation-plans-registry.md` contains only the current
-  status and nearest priority; it must not duplicate this backlog.
-- `docs/verification/rbac-server-modules-verification-plan.md` remains the
-  cross-platform verification checklist, not a second RBAC implementation plan.
+- `[x]` means present in `main` or the current verification branch.
+- `[ ]` means landing or execution evidence remains required.
+- Source-ready is not compiled or operationally verified.
 
 Last reconciled with `main`: 2026-08-01.
 
+## Ownership boundary
+
+`rustok-rbac` owns permission decisions, role/permission relation semantics, canonical
+built-in role mutation policy, repair, relation integrity, durable generation storage,
+and RBAC integration contracts.
+
+`apps/server` owns authenticated adapters, database transaction orchestration, cache
+adapters, fast-path delivery, worker supervision, and process telemetry. `rustok-events`
+owns sealed payloads and schema digests; `rustok-outbox` owns transactional durable
+transport.
+
+Claims, presentation roles, caches, projections, and event consumers are never
+permission or role-assignment authority.
+
 ## Current state
 
-`rustok-rbac` is the single tenant-policy owner for permission decisions,
-role/permission relations, canonical built-in role repair and authorization
-policy. The relation store is the assignment source of truth. No shadow policy
-engine or presentation-only role inference may participate in live
-authorization.
+Merged PR #2867 owns the canonical built-in user-role mutation contract:
 
-The ownership boundary is:
+- tenant and identity validation;
+- actor assign/manage hierarchy;
+- last-active-SuperAdmin continuity;
+- exact canonical role no-op;
+- malformed same-effective-role repair;
+- typed `rbac.user_role_replaced` and `rbac.user_role_assignment_repaired` events;
+- relation, generation, and event in one caller transaction.
 
-- `rustok-rbac` owns permission evaluation, relation persistence primitives,
-  transaction-typed repair APIs, relation-integrity and durable invalidation
-  generation migrations, and integration contracts;
-- `apps/server` owns authenticated host adapters, transaction orchestration,
-  request/process cache adapters, distributed invalidation delivery, runtime
-  supervision and process-level invalidation telemetry;
-- `rustok-api` owns the host-neutral `AuthPrincipalKind` contract and the
-  server-only typed request carrier; it does not own RBAC admission policy;
-- `rustok-telemetry` owns the bounded Prometheus collectors registered in the
-  canonical process registry; it does not own RBAC recovery decisions;
-- `RbacRoleAssignmentDbWriter` is an idempotent bootstrap/test persistence
-  primitive, while existing-user mutations use explicit transaction-owned or
-  committed entry points;
-- Redis/local PubSub is a best-effort fast path; the database-backed monotonic
-  generation is the recovery source of truth;
-- the admin overview remains an intentional native-only module-owned surface.
-  A GraphQL/REST management path requires an approved remote or headless
-  operator contract.
+Draft PR #2866 is strictly additive and contains four remaining P1 corrections:
 
-PR #2747 merged as `75b67f877eb405abe4e6761a16d6b7ece98bc103` and
-made principal admission one owner-defined contract across GraphQL, REST and
-native RBAC Admin. The host-neutral `RbacControlPlanePrincipal` keeps the owner
-crate independent of Axum and `rustok-api/server`.
+1. remove mutation methods from `PermissionResolver` and
+   `RuntimePermissionResolver`, plus `RoleAssignmentStore` and the server direct-store
+   adapter;
+2. publish sealed artifact role-permission assignment events with mutation and receipt
+   in one RBAC owner transaction;
+3. compare requested status to the locked user row and skip user-row update,
+   generation, session revocation, and fan-out for exact role/status replay;
+4. add an incremental PostgreSQL/SQLite migration that cleans malformed artifact grant
+   and operation rows and enforces tenant, role, actor, catalog, parent-update, parent-
+   delete, and referenced-catalog identity integrity at the database boundary.
 
-The current cycle-001 source slice replaces transport-metadata inference inside
-that owner policy with one explicit `AuthPrincipalKind`. The access-token resolver
-classifies validated claims once and stores the typed result on `CurrentUser`.
-HTTP/native middleware and GraphQL HTTP/WebSocket composition only propagate that
-result into `AuthPrincipalContext`; repeated grant/client/session interpretation is
-forbidden. RBAC transports have no compatibility fallback.
-
-The cycle-001 invalidation observability slice adds dedicated bounded metrics to
-the canonical telemetry registry and instruments the existing database watchdog.
-It does not add a second generation counter, cache authority or recovery path.
+Historical drafts #2843, #2847, and #2863 were cross-linked and closed without merge on
+2026-08-01 after their unique corrections were reconciled into #2866. They must not be
+reopened or merged in addition to #2866.
 
 ## FFA/FBA boundary
 
-- FFA status: `in_progress`
-- FBA status: `boundary_ready`
-- Structural shape: `core_transport_ui`
-- FBA provider contract: `RbacPermissionDecisionPort` /
-  `rbac.permission_decision.v1` in
-  `crates/rustok-rbac/contracts/rbac-fba-registry.json`.
-- Static and runtime-order evidence:
-  `crates/rustok-rbac/contracts/evidence/rbac-contract-test-static-matrix.json`
-  and `crates/rustok-rbac/contracts/evidence/rbac-provider-runtime-order-smoke.json`.
-- `scripts/verify/verify-rbac-admin-boundary.mjs` and `npm run verify:rbac:fba`
-  lock the native-only boundary, provider metadata and authorization order.
-- The in-process provider is `RbacPermissionDecisionProvider`: it resolves the
-  UUID tenant and authenticated user actor from `PortContext`, then delegates
-  to the authoritative `PermissionResolver`. Request claims are not a second
-  authorization source.
-- Do not promote FBA to `transport_verified` until composed live-host and
-  degraded-path evidence is recorded.
+- FFA: `in_progress`
+- FBA: `boundary_ready`
+- Provider: `RbacPermissionDecisionPort` / `rbac.permission_decision.v1`
+- Promotion remains blocked on composed live-host, degraded-path, and native operator
+  parity evidence.
 
-## Consolidated implementation phases
+## Implementation phases
 
-### Phase 1. Principal classification and control-plane boundary — source complete
+### Principal and tenant trust — source complete, execution pending
 
-- [x] Distinguish direct sessions, OAuth authorization-code users and OAuth
-  client-credentials principals.
-- [x] Fail closed for malformed or ambiguous subject/grant combinations.
-- [x] Intersect OAuth-granted permissions with token scopes before deriving the
-  effective role used by hierarchy checks.
-- [x] Prevent service principals and OAuth delegated users from entering direct
-  role-assignment or role-metadata control-plane operations.
-- [x] Require a direct grant, a valid session and matching tenant context for
-  GraphQL, REST and native RBAC control-plane access.
-- [x] Keep authorization decisions on typed permissions rather than inferred
-  presentation roles.
+- [x] Use one typed principal classifier.
+- [x] Fail closed for malformed authenticated facts.
+- [x] Require direct, session-bound, tenant-matching principals for RBAC control-plane
+  operations.
+- [x] Keep authoritative and cached relation reads tenant-safe.
+- [x] Enforce cross-tenant base `user_roles` and `role_permissions` integrity.
+- [ ] Execute focused API/server and live negative transport gates.
 
-### Phase 2. Tenant isolation and persistence integrity — source complete
+### Canonical user-role mutation — merged source-ready in #2867
 
-- [x] Require authoritative permission resolution to confirm that the user
-  belongs to the requested tenant.
-- [x] Filter cached relation loading through the user's actual tenant before
-  resolving requested-tenant roles.
-- [x] Enforce cross-tenant `user_roles` and `role_permissions` integrity at the
-  database boundary.
-- [x] Keep authoritative and cached resolvers fail-closed when foreign or
-  malformed relations are encountered.
-- [x] Align regression fixtures with database-level rejection of cross-tenant
-  relation corruption.
+- [x] Keep canonical role policy in `rustok-rbac`.
+- [x] Lock target and continuity facts in the server transaction.
+- [x] Distinguish exact no-op, relation repair, and role replacement.
+- [x] Publish typed role mutation event with the same durable generation.
+- [x] Roll back relation, user row, generation, and event on required publication failure.
+- [x] Preserve exact role replay as no relation mutation, generation, or event.
+- [x] In draft #2866, also preserve exact status replay as no user-row update,
+  generation, session revocation, or fan-out.
+- [ ] Execute owner policy, server adapter, Outbox, and effective-status tests.
 
-### Phase 3. Transactional role and user mutation safety — source complete
+### Resolver ownership — source complete in draft #2866
 
-- [x] Separate transaction-owned role replacement from the committed public
-  mutation entry point.
-- [x] Keep the legacy low-level role alias crate-private and confined to new-user
-  creation inside a caller-owned transaction.
-- [x] Lock the target user before committed role replacement and serialize
-  concurrent changes for the same identity.
-- [x] Lock/check the built-in super-admin role and reject demotion, disabling or
-  deletion of the last active super administrator.
-- [x] Treat an exact single-system-role replacement as a no-op without advancing
-  the global invalidation generation.
-- [x] Repair multiple or malformed assignments even when one assignment already
-  matches the requested role.
-- [x] Revoke active sessions when a user is disabled, banned, deleted or has a
-  password change that requires revocation.
-- [x] Reserve invalidation generations only for mutations that can change an
-  existing authorization snapshot.
+- [x] Make `PermissionResolver` and `RuntimePermissionResolver` read-only.
+- [x] Remove `RoleAssignmentStore` and the server-owned direct persistence adapter.
+- [x] Retain no deprecated alias, compatibility mutation path, or local-only
+  invalidation bypass.
+- [ ] Land and execute #2866.
 
-### Phase 4. Durable cache invalidation and replica recovery — source complete
+### Artifact permission mutation and events — source complete in draft #2866
 
-- [x] Add the singleton `rbac_invalidation_state` migration with an idempotent
-  seed that preserves an already advanced generation.
-- [x] Reserve the next permission invalidation generation inside the same
-  database transaction as the authorization mutation.
-- [x] Publish the committed database generation directly through the local and
-  Redis invalidation fast paths; do not maintain a separate Redis counter.
-- [x] Treat post-commit PubSub/Redis delivery failures as recoverable and never
-  return a false mutation failure after a successful database commit.
-- [x] Share durable generation storage through transaction-typed
-  `rustok-rbac` APIs so server and operational tools use one implementation.
-- [x] Reconcile missed, unverified, duplicate, stale and gapped invalidation
-  events through a shared applied-generation checkpoint.
-- [x] Clear all permission snapshots when durable recovery proves a missed
-  generation or listener lag.
-- [x] Supervise the database watchdog and local/Redis/reconciliation workers;
-  replace terminal runtimes and restart workers after panic or unexpected exit.
-- [x] Allow pre-install startup before the generation table exists and activate
-  reconciliation after migrations become visible.
+- [x] Add sealed `rbac.artifact_role_permission.assignment_changed` v1.
+- [x] Keep command validation, idempotency, state-change detection, and publication in
+  the RBAC owner.
+- [x] Preserve stable typed role/catalog errors by validating before receipt insert.
+- [x] Publish mutation, receipt, relation, and event in one transaction.
+- [x] Emit no event for exact retry or state no-op.
+- [x] Roll back on required Outbox failure.
+- [x] Declare the RBAC -> Outbox module dependency consistently.
+- [x] Clean legacy malformed grant and receipt rows during incremental migration.
+- [x] Enforce role/actor tenant and admitted catalog scope on grant and receipt writes.
+- [x] Guard parent role/user tenant changes and deletes that would orphan artifact state.
+- [x] Keep referenced catalog identity immutable while allowing label/description upsert.
+- [x] Add SQLite cleanup, valid-write, cross-tenant, parent-change, and catalog guards.
+- [x] Add a fail-closed source verifier for migration registration and owner ordering.
+- [ ] Generate and review the exact-head event digest.
+- [ ] Execute contract, owner transaction, SQLite, PostgreSQL, adapter, source verifier,
+  migration rollback, and module gates.
 
-### Phase 5. Canonical role repair and operational tooling — source complete
+### Durable invalidation and recovery — source complete, execution pending
 
-- [x] Split the public repair surface into a read-only plan API and a
-  `DatabaseTransaction`-typed apply API.
-- [x] Apply system-role repair and durable generation reservation in one
-  transaction in the server host.
-- [x] Make `rbac repair-system-roles --apply` commit repair plus generation
-  atomically and roll back explicitly on failure.
-- [x] Report the committed durable generation from the CLI and remove the old
-  restart-required result for successfully applied repairs.
-- [x] Invalidate all affected local snapshots after committed repair and use the
-  database generation to recover other replicas.
+- [x] Reserve monotonic database generation in authorization mutation transactions.
+- [x] Use local/Redis publication as best-effort fast paths.
+- [x] Recover missed, stale, duplicate, and gapped generations through one checkpoint.
+- [x] Export bounded lag, generation, worker, and recovery telemetry.
+- [x] Add source packets for PostgreSQL concurrency (#2849), watchdog recovery (#2853),
+  Redis restart/outage (#2856), and full registered-CLI repair propagation (#2862).
+- [ ] Execute and retain all four packets on one reconciled revision.
+- [ ] Execute and retain the incident packet from #2846.
 
-### Phase 6. Source guardrails and regression coverage — source complete, execution pending
+## Remaining work
 
-- [x] Add unit/regression coverage for generation commit/rollback, idempotent
-  migration replay, exact role no-op, malformed multiple assignments and
-  last-super-admin rejection.
-- [x] Add architecture guards for control-plane ownership, tenant integrity,
-  transaction-only mutation APIs, split repair APIs, atomic CLI repair and
-  unified invalidation generation.
-- [x] Add worker lifecycle guards and panic/restart regression fixtures for the
-  durable watchdog and invalidation listeners.
-- [x] Keep the FFA/FBA provider registry and native-only admin boundary guarded
-  by existing static verification scripts.
-- [x] Guard artifact-role permission REST admission so the owner direct-session
-  policy precedes `modules:manage`, tenant equality is mandatory and the audit
-  actor comes from the authenticated context.
-- [x] Guard native RBAC Admin metadata bootstrap with the same owner principal
-  policy before `settings:read`; remove the obsolete tenant-only helper.
-- [x] Add bounded invalidation metric registration tests, signed lag regression
-  coverage and `verify-rbac-invalidation-observability.mjs` to lock the canonical
-  registry, watchdog transitions, operator policy and active cursor.
-- [x] Add `verify-rbac-explicit-principal-kind.mjs` and update the Rust/source
-  architecture guards so the token resolver is the single classifier, every RBAC
-  transport requires typed principal context and the owner cannot reintroduce
-  grant/client/session inference.
-- [ ] Execute the added Rust tests and architecture guards in a toolchain-enabled
-  environment and fix any compile, formatting or lint failures.
+### P0. Exact-head verification
 
-## Remaining work, in priority order
+- [x] Rebuild #2866 as one commit on the latest `main` after the migration packet.
+- [ ] Generate and review the artifact event contract digest.
+- [ ] Run formatting, Events/RBAC/Admin/server compilation, Clippy, focused Rust/Node
+  tests, and module validate/test on that exact head.
+- [ ] Run the new SQLite migration proof and a real PostgreSQL apply/integrity/rollback
+  target on the same revision.
+- [ ] Resolve every failure before claiming verification.
 
-### P0. Compile and targeted verification
+### P0. Runtime evidence
 
-- [ ] Run formatting, compilation, Clippy and targeted API/RBAC/server/CLI tests
-  on the reconciled `main` revision.
-- [ ] Record successful module validate/test evidence for `rbac`.
-- [ ] Execute the existing FFA/FBA, invalidation-observability and explicit-
-  principal-kind verification scripts against the same revision.
-- [ ] Resolve every failure before claiming the source-complete phases are
-  compiled verified.
+- [ ] Execute #2849 PostgreSQL concurrency.
+- [ ] Execute #2853 independent-process watchdog recovery.
+- [ ] Execute #2856 real Redis available/outage/restart recovery.
+- [ ] Execute #2862 full registered-CLI repair propagation.
+- [ ] Retain one same-revision result set within documented bounds.
 
-### P0. Database concurrency and multi-replica recovery evidence
+### P1. Operator parity and lifecycle
 
-- [ ] Add PostgreSQL integration evidence for concurrent role replacement,
-  last-active-super-admin serialization and unique monotonic generation
-  allocation.
-- [ ] Exercise at least two server replicas with Redis available, unavailable,
-  restarted and with intentionally missed PubSub events.
-- [ ] Prove that the mutating replica invalidates immediately and that another
-  replica catches up through the durable database generation without serving a
-  stale authorization snapshot beyond the documented reconciliation bound.
-- [ ] Exercise CLI system-role repair while live replicas are running and prove
-  they recover from the committed generation without a restart.
+- [x] Cross-link and close #2843/#2847/#2863 as superseded without merge.
+- [ ] Land #2866 without restoring the superseded branches.
+- [ ] Define cleanup ordering for hard role/user/tenant deletion before referenced
+  artifact grants or operation receipts can be removed.
+- [ ] Decide whether remote/headless role management is required.
+- [ ] Define custom-role and arbitrary permission mutation ownership.
+- [ ] Route native operator management through owner policy without host-owned relation
+  writes or a parallel `/roles` implementation.
+- [ ] Identify idempotent, non-authoritative consumers for RBAC integration events.
+- [ ] Complete incident and live negative transport evidence.
 
-### P1. Invalidation observability and incident operations
+### P2. FBA/FFA promotion evidence
 
-- [x] Export metrics for database generation, locally applied generation,
-  generation lag, worker running/restart state and recovery/full-clear counts.
-- [x] Define alert thresholds for non-zero sustained lag, repeated worker
-  restarts, generation regression and failed database reads.
-- [x] Add an operator runbook covering Redis outage, missed event, generation
-  regression, repair execution and verification of effective permissions.
-- [ ] Make one policy incident traceable to the evaluator decision, relation
-  state, cache snapshot, durable generation and recovery action.
-
-### P1. Explicit actor-kind contract
-
-- [x] Add an explicit actor/principal kind to the shared authorization context
-  and relevant ports instead of permanently inferring control-plane eligibility
-  from `client_id`, `grant_type` and `session_id` combinations.
-- [x] Preserve fail-closed compatibility during migration for direct users,
-  authorization-code users and client-credentials principals.
-- [x] Add boundary tests proving that only the explicit direct-user actor kind
-  can execute control-plane mutations.
-
-### P1. Module-owned operator role and permission flows
-
-- [ ] Define the approved role/permission mutation contract in the owner package,
-  including validation, hierarchy, tenant scope, continuity and integration
-  event requirements.
-- [ ] Route native admin management actions through the module facade without
-  adding host-owned relation writes or a parallel `/roles` implementation.
-- [ ] Publish and verify the expected integration events for committed role and
-  permission changes.
-- [ ] Decide whether a remote/headless GraphQL or REST management contract is a
-  real product requirement; do not add one speculatively.
-
-### P2. Live FBA evidence and promotion
-
-- [ ] Exercise `RbacPermissionDecisionPort` in a composed host with tenant scope,
-  representative claims, deadlines, cache hits/misses and degraded behavior.
-- [ ] Prove that the module evaluator remains the only decision engine for both
-  allowed and denied requests.
-- [ ] Record provider/consumer/fallback evidence and promote FBA only when the
-  `transport_verified` gate is satisfied.
-- [ ] Complete native operator parity evidence before considering FFA
-  `parity_verified`.
-
-## Explicit principal-kind correction (2026-08-01)
-
-- Status: `source_ready_unvalidated`.
-- Severity: `P1` because control-plane authority was reconstructed independently
-  from string grant metadata in the owner policy after authentication had already
-  validated the principal shape.
-- Root cause: `RbacControlPlanePrincipal` carried `client_id`, `grant_type` and
-  `session_id`; every adapter copied those fields and the owner repeated the
-  classification instead of consuming one typed trusted fact.
-- [x] Add host-neutral `AuthPrincipalKind::{DirectUser, DelegatedUser, Service}`
-  outside the `rustok-api/server` feature.
-- [x] Add server-only `AuthPrincipalContext` and an Axum extractor while leaving
-  existing `AuthContext` transport metadata unchanged for unrelated consumers.
-- [x] Classify validated claims once in the access-token resolver, store the typed
-  result on `CurrentUser`, and reject unknown or inconsistent combinations before
-  any request context or module policy is constructed.
-- [x] Propagate `CurrentUser.principal_kind` through HTTP/native middleware and
-  GraphQL HTTP/WebSocket composition without reinterpreting grant/client/session
-  metadata.
-- [x] Reduce `RbacControlPlanePrincipal` to tenant id plus typed kind and remove
-  all owner references to client, grant and session metadata.
-- [x] Require typed context in GraphQL role reads/writes, REST artifact-role
-  permission writes and native RBAC Admin before effective permission admission.
-- [x] Deny delegated users and services even when their effective permission set
-  contains the required management permission; admit only typed direct users with
-  authenticated/routed tenant equality.
-- [x] Update owner/unit/REST/native architecture guards and add
-  `scripts/verify/verify-rbac-explicit-principal-kind.mjs`.
-- [x] Document the contract in
-  `crates/rustok-rbac/docs/explicit-principal-kind.md`.
-- [ ] Execute API/RBAC/Admin/server compilation, focused tests, source verifiers
-  and live negative transport requests on the same revision.
-
-## Durable invalidation observability correction (2026-08-01)
-
-- Status: `source_ready_unvalidated`.
-- Severity: `P1` because stale authorization recovery lacked dedicated lag,
-  worker-health and full-clear telemetry plus a bounded incident response policy.
-- Root cause: the canonical watchdog emitted logs and generic event-error counters,
-  but operators could not directly compare the database generation with the
-  process checkpoint, distinguish lag from regression, or alert on worker/read
-  failures without reconstructing state from logs.
-- [x] Add one `rustok-telemetry` metric module registered in the existing process
-  registry; do not create a second registry or generation authority.
-- [x] Export durable generation, applied generation, signed lag and watchdog
-  running state without tenant, user, role, permission, session, client or cache-key
-  labels.
-- [x] Count bounded watchdog restart reasons, database read failures, recovery
-  reasons and process-wide permission snapshot clears.
-- [x] Instrument the existing database watchdog before and after recovery so
-  positive lag is visible during catch-up, zero after successful application and
-  negative during database regression.
-- [x] Retain the monotonic local checkpoint on database regression while clearing
-  permission snapshots; telemetry must not normalize the unsafe state to zero.
-- [x] Add unit coverage for signed lag and metric registration plus the focused
-  source verifier `scripts/verify/verify-rbac-invalidation-observability.mjs`.
-- [x] Document alert thresholds and recovery procedures for Redis outage/restart,
-  missed PubSub, generation regression and canonical role repair.
-- [ ] Execute telemetry/server tests and the source verifier on the same revision.
-- [ ] Retain one real or dedicated integration incident packet connecting evaluator
-  decision, relation state, cache snapshot, durable generation and recovery action.
-
-## Tenant trust boundary correction (2026-07-31)
-
-- Status: `source_ready_unvalidated`.
-- Severity: `P0` for authenticated/resolved tenant mismatch; `P1` for raw native
-  context-error serialization.
-- [x] RBAC Admin bootstrap now requires authenticated and middleware-resolved
-  tenant equality before `SETTINGS_READ` permission admission or tenant data use.
-- [x] Mismatches fail closed with a static public response and structured tenant
-  diagnostics.
-- [x] Auth and tenant extractor failures return fixed public messages; typed
-  causes stay in server diagnostics.
-- [x] `scripts/verify/verify-rbac-admin-tenant-scope.mjs` locks ordering, public
-  error safety, direct tracing dependency and exactly one routed bootstrap guard.
-- [x] Focused unit coverage retains matching and mismatched tenant cases.
-- [ ] Same-SHA `rustfmt`, `cargo check -p rustok-rbac-admin --features ssr`,
-  focused unit execution and composed native parity remain required.
-- This correction was delivered during the `core/tenant` cross-module work unit
-  and is carried evidence for the now-active `core/rbac` verification item.
-
-## Artifact permission and role-metadata control-plane correction (2026-07-31)
-
-- Status: `merged_partially_compiled`.
-- Merge: PR #2747, commit
-  `75b67f877eb405abe4e6761a16d6b7ece98bc103`.
-- Severity: `P0` invalid authorization grant for REST mutation; `P1` cross-surface
-  admission inconsistency for native role/permission metadata.
-- Root cause: the REST PUT/DELETE artifact-role permission adapter admitted any
-  authenticated principal with effective `modules:manage`, while native RBAC
-  Admin bootstrap admitted any principal with `settings:read`. GraphQL correctly
-  required a direct session-bound user. Tenant OAuth authorization-code and
-  client-credentials principals could therefore mutate artifact grants or read
-  control-plane role metadata when their narrowed authority retained those
-  permissions.
-- [x] Add one host-neutral owner policy over
-  `RbacControlPlanePrincipal`; `rustok-rbac` remains independent of the
-  `rustok-api/server` feature and Axum context types.
-- [x] Reuse that owner policy from GraphQL, REST and native RBAC Admin rather than
-  maintaining transport-specific principal classifiers.
-- [x] Require typed `DirectUser` principal context and authenticated/routed tenant
-  equality before `modules:manage` or `settings:read` admission.
-- [x] Bind the durable REST operation actor only from trusted
-  `AuthContext.user_id`; request payloads cannot supply or replace it.
-- [x] Remove the obsolete native generic tenant-only helper and retain static
-  public denials plus structured, non-secret diagnostics.
-- [x] Add owner unit tests, REST helper tests,
-  `rbac_artifact_permission_control_plane_guard` and the updated source verifiers
-  for delegated/service denial, tenant mismatch, permission denial, typed-policy
-  composition and admission order.
-- [x] The default `rustok-rbac` crate compiled on exact PR head
-  `3cf4b3a44980ca257f7f53849e905673141db289` inside Rust-host workflow run
-  `30650883159` before that workflow hit issue #2740.
-- [ ] Same-SHA formatting, all-feature RBAC compile, RBAC Admin SSR compile,
-  server compile, focused unit/architecture/verifier execution and transport-
-  level negative requests are still required.
+- [ ] Exercise provider/consumer/degraded paths in a composed host.
+- [ ] Prove the RBAC evaluator remains the only decision engine.
+- [ ] Complete native operator parity before FFA promotion.
 
 ## Verification commands
 
-- Contract tests cover every public use case.
-
 ```bash
 cargo fmt --all -- --check
+cargo run -p rustok-events --example event_contract_digests -- --write
 cargo check -p rustok-api
 cargo check -p rustok-api --features server
-cargo check -p rustok-telemetry
-cargo check -p rustok-rbac
+cargo check -p rustok-events --all-targets
 cargo check -p rustok-rbac --all-features
 cargo check -p rustok-rbac-admin --features ssr
-cargo check -p rustok-rbac-cli
 cargo check -p rustok-server --lib
-cargo test -p rustok-api authenticated_facts_classify_fail_closed
-cargo test -p rustok-server --lib token_claim_classifier_returns_explicit_principal_kinds
-cargo test -p rustok-telemetry rbac_invalidation_metrics
-cargo test -p rustok-rbac --all-features
-cargo test -p rustok-rbac-admin --features ssr
-cargo test -p rustok-migrations --lib rbac_system_role_repair_tests
-cargo test -p rustok-rbac-cli
-cargo test -p rustok-server --lib rbac_invalidation_generation
-cargo test -p rustok-server --lib rbac
-cargo test -p rustok-server \
-  --test rbac_artifact_permission_control_plane_guard \
-  --test rbac_cache_invalidation_architecture_guard \
-  --test rbac_mutation_api_architecture_guard \
-  --test rbac_migration_registration_guard \
-  --test rbac_startup_invalidation_architecture_guard
-cargo clippy -p rustok-rbac --all-features -- -D warnings
-cargo clippy -p rustok-rbac-cli -- -D warnings
-cargo clippy -p rustok-server --lib -- -D warnings
-cargo xtask module validate rbac
-cargo xtask module test rbac
+cargo test -p rustok-events rbac_role_mutation
+cargo test -p rustok-events --test rbac_artifact_permission_contracts
+cargo test -p rustok-rbac role_mutation
+cargo test -p rustok-rbac --test artifact_permission_outbox_sqlite
+cargo test -p rustok-rbac --test artifact_permission_tenant_integrity_sqlite
+cargo test -p rustok-server auth_admin_mutation_provider
+cargo test -p rustok-server status_effective_change_ignores_exact_replay
+cargo test -p rustok-server --test rbac_permission_resolver_read_only_guard
+cargo test -p rustok-server --test rbac_auth_admin_effective_noop_guard
+cargo test -p rustok-server --test rbac_mutation_api_architecture_guard
+node scripts/verify/verify-rbac-owner-role-mutation-contract.mjs
+node scripts/verify/verify-rbac-artifact-permission-outbox.mjs
+node scripts/verify/verify-rbac-artifact-permission-tenant-integrity.mjs
 node scripts/verify/verify-rbac-explicit-principal-kind.mjs
 node scripts/verify/verify-rbac-invalidation-observability.mjs
-node scripts/verify/verify-rbac-admin-tenant-scope.mjs
-npm run verify:rbac:admin-boundary
-npm run verify:rbac:fba
+cargo xtask module validate rbac
+cargo xtask module test rbac
 ```
 
-PostgreSQL concurrency and multi-replica Redis failure/recovery scenarios remain
-manual or dedicated integration-environment gates until an approved automated
-harness owns them.
+No command above was executed in this connector-only source slice.
 
 ## Completion gates
 
-- Source-complete phases become **compiled verified** only after the targeted
-  commands pass on the same revision.
-- Durable invalidation becomes **operationally verified** only after PostgreSQL
-  concurrency and multi-replica failure/recovery evidence passes.
-- FBA remains `boundary_ready` until composed provider/consumer/fallback
-  evidence passes.
-- FFA remains `in_progress` until approved module-owned management flows and
-  native parity evidence are complete.
-
-## Change rules
-
-1. Keep permission evaluation, relation semantics, repair and durable generation
-   storage in `rustok-rbac`.
-2. Keep authenticated host orchestration, request/process cache adapters and
-   runtime worker supervision in `apps/server`; do not duplicate relation writes
-   there.
-3. Require a caller-owned transaction for low-level authorization mutations and
-   invalidate only after successful commit.
-4. Treat Redis/local PubSub as a fast path and the database generation as the
-   recovery source of truth.
-5. Update this plan with every RBAC contract or phase-status change; keep the
-   central implementation-plan registry limited to status and nearest priority.
-6. Update `rustok-module.toml`, local runtime docs and
-   `docs/modules/registry.md` when ownership or FFA/FBA boundary status changes.
-7. Do not mark source, compiled, live-service or transport verification complete
-   without the corresponding evidence.
+- Source-ready becomes verified only after exact-head commands pass.
+- Artifact event review requires the generated digest.
+- Artifact relation integrity requires retained SQLite and PostgreSQL execution.
+- Durable invalidation requires retained PostgreSQL/watchdog/Redis/CLI evidence.
+- FBA remains `boundary_ready`; FFA and `core/rbac` remain `in_progress`.
 
 ## Periodic release verification handoff
 
 - Cycle: `cycle-001`
 - Status: `in_progress`
 - Last verified at (UTC): `2026-08-01`
-- Scope inspected: `access-token claim validation and single-source typed principal classification; explicit principal propagation through HTTP/native middleware and GraphQL HTTP/WebSocket composition; GraphQL role reads/writes, REST artifact-role permission writes and native RBAC Admin admission; tenant-filtered relation resolution; generation-aware cache fill; committed role replacement; canonical repair; invalidation worker/gap-tracker composition and bounded recovery observability`
-- Findings: `P0=0, P1=1, P2=0, P3=0`
-- Fixed in this pass: `added host-neutral AuthPrincipalKind and server-only AuthPrincipalContext; made the access-token resolver the only classifier and stored the result on CurrentUser; made HTTP/native and GraphQL composition propagation-only; reduced RbacControlPlanePrincipal to typed kind plus tenant id; removed owner and adapter fallback to client_id/grant_type/session_id; required typed context before GraphQL, REST and native permission admission; added resolver/unit, Rust architecture and source regression guards plus an owner contract document`
-- Remaining risks or blockers: `the explicit-kind and observability corrections are source-ready but unexecuted. Same-SHA formatting, rustok-api default/server, RBAC all-feature, RBAC Admin SSR and server compilation, focused Rust/source verifiers, module gates and live negative transport requests remain absent. PostgreSQL mutation concurrency, unique durable generation allocation, multi-replica Redis outage/restart/missed-publication recovery, canonical repair propagation, one complete incident trace, module-owned management flow and FFA/FBA evidence remain open. Issue #2740 still blocks the known Rust-host path before the server build.`
-- Evidence: `source review confirms AuthPrincipalKind is available without rustok-api/server; classify_access_token_claims delegates to the shared fail-closed classifier and CurrentUser carries the typed result; middleware and GraphQL HTTP/WebSocket only propagate it; AuthPrincipalContext is mandatory in each RBAC transport; the owner policy contains no client_id, grant_type or session_id fields; delegated and service kinds are denied before effective management permission checks. Updated Rust/source guards lock the single-source typed contract and active cursor. No formatting, compilation, test, verifier, workflow, CI, PostgreSQL or Redis command is claimed as executed in this pass.`
-- Next action: `run the targeted API/auth-resolver/RBAC/Admin/server checks and focused principal/tenant source verifiers on one revision; resolve failures, then retain PostgreSQL concurrency and two-replica Redis recovery evidence before continuing module-owned role/permission management and incident-trace P1 work`
-- Resume command: `cargo fmt --all -- --check && cargo check -p rustok-api && cargo check -p rustok-api --features server && cargo check -p rustok-rbac --all-features && cargo check -p rustok-rbac-admin --features ssr && cargo check -p rustok-server --lib && cargo test -p rustok-api authenticated_facts_classify_fail_closed && cargo test -p rustok-server --lib token_claim_classifier_returns_explicit_principal_kinds && cargo test -p rustok-rbac --all-features && cargo test -p rustok-server --test rbac_artifact_permission_control_plane_guard && node scripts/verify/verify-rbac-explicit-principal-kind.mjs && node scripts/verify/verify-rbac-admin-tenant-scope.mjs && cargo xtask module validate rbac && cargo xtask module test rbac`
+- Scope inspected: `merged owner role mutation policy/events; effective status replay; read-only resolver ownership; artifact permission transaction event; artifact relation database integrity; durable invalidation and recovery packets`
+- Findings: `P0=1, P1=4, P2=0, P3=0`
+- Fixed in this pass: `draft PR #2866 is reconciled atop merged #2867. It removes resolver mutation composition, adds transactional artifact role-permission events, prevents exact status or role/status replay from updating the user row or advancing authorization state, and adds an incremental PostgreSQL/SQLite integrity migration for artifact grants and operation receipts. The migration cleans legacy malformed rows, enforces tenant-bound role/actor/catalog identity, protects parent changes, and keeps typed role/catalog errors by validating before receipt insertion. Historical drafts #2843, #2847, and #2863 were closed without merge. The branch is reconstructed as one commit on the latest main.`
+- Remaining risks or blockers: `#2866 is source-only and lacks the generated artifact event digest. Formatting, compilation, focused tests, SQLite/PostgreSQL migration execution, Node/module gates, live transports, retained #2849/#2853/#2856/#2862 execution, incident evidence, native operator parity, and FFA/FBA evidence remain absent. Hard-deletion cleanup ordering for referenced artifact receipts must be defined. Issue #2740 remains the known Rust-host PostgreSQL fixture blocker.`
+- Evidence: `source review confirms the new migration is registered after artifact tables, cleanup precedes trigger creation, SQLite up/down inventories are symmetric, validation precedes receipt insertion, DB triggers cover grant/receipt writes plus role/user/catalog parent changes, and the branch is one commit zero behind current main. No execution evidence is claimed.`
+- Next action: `generate and review the artifact event digest, then run exact-head compile/test/verifier/module and SQLite/PostgreSQL migration gates`
+- Resume command: `cargo fmt --all -- --check && cargo run -p rustok-events --example event_contract_digests -- --write && cargo check -p rustok-events --all-targets && cargo check -p rustok-rbac --all-features && cargo check -p rustok-rbac-admin --features ssr && cargo check -p rustok-server --lib && cargo test -p rustok-events --test rbac_artifact_permission_contracts && cargo test -p rustok-rbac --test artifact_permission_outbox_sqlite && cargo test -p rustok-rbac --test artifact_permission_tenant_integrity_sqlite && cargo test -p rustok-server --test rbac_permission_resolver_read_only_guard && cargo test -p rustok-server --test rbac_auth_admin_effective_noop_guard && node scripts/verify/verify-rbac-owner-role-mutation-contract.mjs && node scripts/verify/verify-rbac-artifact-permission-outbox.mjs && node scripts/verify/verify-rbac-artifact-permission-tenant-integrity.mjs && cargo xtask module validate rbac && cargo xtask module test rbac`

--- a/crates/rustok-rbac/rustok-module.toml
+++ b/crates/rustok-rbac/rustok-module.toml
@@ -8,6 +8,9 @@ trust_level = "core"
 ui_classification = "admin_only"
 recommended_admin_surfaces = ["leptos-admin"]
 
+[dependencies]
+outbox = { version_req = ">=0.1.0" }
+
 [crate]
 entry_type = "RbacModule"
 

--- a/crates/rustok-rbac/src/artifact_permission_assignment.rs
+++ b/crates/rustok-rbac/src/artifact_permission_assignment.rs
@@ -1,5 +1,9 @@
 //! RBAC-owned grants and checks for immutable artifact permission vocabulary.
 
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_events::RbacArtifactPermissionEvent;
 use sea_orm::{
     ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, Statement,
     TransactionTrait,
@@ -47,18 +51,44 @@ pub enum ArtifactPermissionAssignmentError {
     Database(String),
 }
 
+/// Host-neutral publisher used by the RBAC owner while its transaction is live.
+///
+/// Implementations must persist the typed event through the configured durable
+/// transport using the supplied owner transaction. Returning an error causes
+/// RBAC to roll back both the mutation and its idempotency receipt.
+#[async_trait]
+pub trait ArtifactPermissionEventPublisher: Send + Sync {
+    async fn publish_assignment_changed(
+        &self,
+        transaction: &DatabaseTransaction,
+        tenant_id: Uuid,
+        actor_id: Uuid,
+        event: RbacArtifactPermissionEvent,
+    ) -> Result<(), ArtifactPermissionAssignmentError>;
+}
+
 /// Durable RBAC owner service for explicit dynamic artifact permission grants.
 ///
 /// This service never writes the static `role_permissions` relation. Dynamic
 /// permissions remain bound to the admitted installation that declared them.
+/// The idempotency receipt, grant/revocation, and typed integration event are
+/// committed by one owner transaction. State no-ops commit their receipt but
+/// do not publish a false change event.
 #[derive(Clone)]
 pub struct RbacArtifactPermissionAssignmentService {
     db: DatabaseConnection,
+    event_publisher: Arc<dyn ArtifactPermissionEventPublisher>,
 }
 
 impl RbacArtifactPermissionAssignmentService {
-    pub fn new(db: DatabaseConnection) -> Self {
-        Self { db }
+    pub fn new(
+        db: DatabaseConnection,
+        event_publisher: Arc<dyn ArtifactPermissionEventPublisher>,
+    ) -> Self {
+        Self {
+            db,
+            event_publisher,
+        }
     }
 
     pub async fn assign(
@@ -73,30 +103,50 @@ impl RbacArtifactPermissionAssignmentService {
             return match_operation(existing, &command);
         }
 
-        let inserted_operation = insert_operation(&transaction, &command).await?;
-        if !inserted_operation {
-            let existing = find_operation(&transaction, &command)
-                .await?
-                .ok_or_else(|| {
-                    ArtifactPermissionAssignmentError::Database(
-                        "artifact permission operation disappeared after an idempotency conflict"
-                            .to_string(),
-                    )
-                })?;
-            return match_operation(existing, &command);
-        }
-
+        // Validate owner scope before inserting the receipt so database-integrity
+        // triggers preserve the stable RoleNotFound/PermissionNotRegistered contract.
         if !role_exists(&transaction, &command).await? {
+            transaction.rollback().await.map_err(database_error)?;
             return Err(ArtifactPermissionAssignmentError::RoleNotFound);
         }
         if !permission_is_registered(&transaction, &command).await? {
+            transaction.rollback().await.map_err(database_error)?;
             return Err(ArtifactPermissionAssignmentError::PermissionNotRegistered);
         }
 
-        if command.granted {
-            grant_permission(&transaction, &command).await?;
+        let operation_id = match insert_operation(&transaction, &command).await? {
+            Some(operation_id) => operation_id,
+            None => {
+                let existing = find_operation(&transaction, &command)
+                    .await?
+                    .ok_or_else(|| {
+                        ArtifactPermissionAssignmentError::Database(
+                            "artifact permission operation disappeared after an idempotency conflict"
+                                .to_string(),
+                        )
+                    })?;
+                return match_operation(existing, &command);
+            }
+        };
+
+        let changed = if command.granted {
+            grant_permission(&transaction, &command).await?
         } else {
-            revoke_permission(&transaction, &command).await?;
+            revoke_permission(&transaction, &command).await?
+        };
+        if changed
+            && let Err(error) = self
+                .event_publisher
+                .publish_assignment_changed(
+                    &transaction,
+                    command.tenant_id,
+                    command.actor_id,
+                    assignment_event(operation_id, &command),
+                )
+                .await
+        {
+            transaction.rollback().await.map_err(database_error)?;
+            return Err(error);
         }
         transaction.commit().await.map_err(database_error)?;
 
@@ -259,8 +309,9 @@ fn match_operation(
 async fn insert_operation(
     transaction: &DatabaseTransaction,
     command: &ArtifactRolePermissionAssignmentCommand,
-) -> Result<bool, ArtifactPermissionAssignmentError> {
+) -> Result<Option<Uuid>, ArtifactPermissionAssignmentError> {
     let backend = transaction.get_database_backend();
+    let operation_id = rustok_core::generate_id();
     let sql = placeholders(
         backend,
         "INSERT INTO rbac_artifact_role_permission_operations (id, tenant_id, idempotency_key, role_id, installation_id, permission_key, actor_id, granted) VALUES ({id}, {tenant_id}, {idempotency_key}, {role_id}, {installation_id}, {permission_key}, {actor_id}, {granted}) ON CONFLICT (tenant_id, idempotency_key) DO NOTHING",
@@ -270,7 +321,7 @@ async fn insert_operation(
             backend,
             sql,
             vec![
-                rustok_core::generate_id().into(),
+                operation_id.into(),
                 command.tenant_id.into(),
                 command.idempotency_key.clone().into(),
                 command.role_id.into(),
@@ -282,7 +333,7 @@ async fn insert_operation(
         ))
         .await
         .map_err(database_error)?;
-    Ok(result.rows_affected() == 1)
+    Ok((result.rows_affected() == 1).then_some(operation_id))
 }
 
 async fn role_exists(
@@ -333,13 +384,13 @@ async fn permission_is_registered(
 async fn grant_permission(
     transaction: &DatabaseTransaction,
     command: &ArtifactRolePermissionAssignmentCommand,
-) -> Result<(), ArtifactPermissionAssignmentError> {
+) -> Result<bool, ArtifactPermissionAssignmentError> {
     let backend = transaction.get_database_backend();
     let sql = placeholders(
         backend,
         "INSERT INTO rbac_artifact_role_permissions (id, tenant_id, role_id, installation_id, permission_key, granted_by_actor_id) VALUES ({id}, {tenant_id}, {role_id}, {installation_id}, {permission_key}, {actor_id}) ON CONFLICT (tenant_id, role_id, installation_id, permission_key) DO NOTHING",
     );
-    transaction
+    let result = transaction
         .execute(Statement::from_sql_and_values(
             backend,
             sql,
@@ -354,19 +405,19 @@ async fn grant_permission(
         ))
         .await
         .map_err(database_error)?;
-    Ok(())
+    Ok(result.rows_affected() == 1)
 }
 
 async fn revoke_permission(
     transaction: &DatabaseTransaction,
     command: &ArtifactRolePermissionAssignmentCommand,
-) -> Result<(), ArtifactPermissionAssignmentError> {
+) -> Result<bool, ArtifactPermissionAssignmentError> {
     let backend = transaction.get_database_backend();
     let sql = placeholders(
         backend,
         "DELETE FROM rbac_artifact_role_permissions WHERE tenant_id = {tenant_id} AND role_id = {role_id} AND installation_id = {installation_id} AND permission_key = {permission_key}",
     );
-    transaction
+    let result = transaction
         .execute(Statement::from_sql_and_values(
             backend,
             sql,
@@ -379,7 +430,20 @@ async fn revoke_permission(
         ))
         .await
         .map_err(database_error)?;
-    Ok(())
+    Ok(result.rows_affected() == 1)
+}
+
+fn assignment_event(
+    operation_id: Uuid,
+    command: &ArtifactRolePermissionAssignmentCommand,
+) -> RbacArtifactPermissionEvent {
+    RbacArtifactPermissionEvent::AssignmentChanged {
+        operation_id,
+        role_id: command.role_id,
+        installation_id: command.installation_id,
+        permission_key: command.permission_key.clone(),
+        granted: command.granted,
+    }
 }
 
 fn placeholders(backend: DbBackend, template: &str) -> String {
@@ -416,9 +480,8 @@ fn database_error(error: impl std::fmt::Display) -> ArtifactPermissionAssignment
 mod tests {
     use super::*;
 
-    #[test]
-    fn assignment_validation_rejects_empty_or_control_text_tokens() {
-        let mut command = ArtifactRolePermissionAssignmentCommand {
+    fn command() -> ArtifactRolePermissionAssignmentCommand {
+        ArtifactRolePermissionAssignmentCommand {
             tenant_id: Uuid::new_v4(),
             role_id: Uuid::new_v4(),
             installation_id: Uuid::new_v4(),
@@ -426,7 +489,12 @@ mod tests {
             actor_id: Uuid::new_v4(),
             granted: true,
             idempotency_key: "grant-1".to_string(),
-        };
+        }
+    }
+
+    #[test]
+    fn assignment_validation_rejects_empty_or_control_text_tokens() {
+        let mut command = command();
         command.permission_key = " sample.events.handle".to_string();
         assert!(matches!(
             validate_command(&command),
@@ -445,15 +513,7 @@ mod tests {
 
     #[test]
     fn exact_operation_retry_is_not_applied_twice() {
-        let command = ArtifactRolePermissionAssignmentCommand {
-            tenant_id: Uuid::new_v4(),
-            role_id: Uuid::new_v4(),
-            installation_id: Uuid::new_v4(),
-            permission_key: "sample.events.handle".to_string(),
-            actor_id: Uuid::new_v4(),
-            granted: true,
-            idempotency_key: "grant-1".to_string(),
-        };
+        let command = command();
         let result = match_operation(
             StoredOperation {
                 role_id: command.role_id,
@@ -466,5 +526,21 @@ mod tests {
         )
         .expect("exact retry");
         assert!(!result.applied);
+    }
+
+    #[test]
+    fn assignment_event_retains_operation_and_scope() {
+        let command = command();
+        let operation_id = Uuid::new_v4();
+        assert_eq!(
+            assignment_event(operation_id, &command),
+            RbacArtifactPermissionEvent::AssignmentChanged {
+                operation_id,
+                role_id: command.role_id,
+                installation_id: command.installation_id,
+                permission_key: command.permission_key,
+                granted: command.granted,
+            }
+        );
     }
 }

--- a/crates/rustok-rbac/src/lib.rs
+++ b/crates/rustok-rbac/src/lib.rs
@@ -14,15 +14,16 @@ mod m20260714_900001_enforce_rbac_relation_tenant_integrity;
 mod m20260714_900002_create_rbac_invalidation_state;
 mod m20260716_000001_artifact_permission_catalog;
 mod m20260717_000001_artifact_role_permissions;
+mod m20260801_000001_enforce_artifact_permission_tenant_integrity;
 pub mod ports;
 mod repair;
 mod role_mutation;
 pub mod services;
 
 pub use artifact_permission_assignment::{
-    ArtifactPermissionAssignmentError, ArtifactRolePermissionAssignmentCommand,
-    ArtifactRolePermissionAssignmentResult, RbacArtifactPermissionAssignmentService,
-    SeaOrmArtifactPermissionAuthorizer,
+    ArtifactPermissionAssignmentError, ArtifactPermissionEventPublisher,
+    ArtifactRolePermissionAssignmentCommand, ArtifactRolePermissionAssignmentResult,
+    RbacArtifactPermissionAssignmentService, SeaOrmArtifactPermissionAuthorizer,
 };
 pub use artifact_permission_catalog::RbacArtifactPermissionCatalog;
 pub use bootstrap::{RbacRoleAssignmentDbWriter, RbacRoleAssignmentError};
@@ -75,9 +76,8 @@ pub use services::relation_permission_resolver::{
     PermissionCache, PermissionCacheLookup, RelationPermissionStore, invalidate_cached_permissions,
     resolve_permissions_from_relations, resolve_permissions_with_cache,
 };
-pub use services::runtime_permission_resolver::{RoleAssignmentStore, RuntimePermissionResolver};
+pub use services::runtime_permission_resolver::RuntimePermissionResolver;
 
-/// Build a read-only canonical system-role repair plan.
 pub async fn plan_system_role_repair(
     db: &sea_orm::DatabaseConnection,
     tenant_id: Option<uuid::Uuid>,
@@ -92,10 +92,6 @@ pub async fn plan_system_role_repair(
     .await
 }
 
-/// Apply canonical system-role repair inside a caller-owned database
-/// transaction. Restricting this public boundary to `DatabaseTransaction`
-/// prevents external callers from mutating role definitions without an atomic
-/// commit boundary for the accompanying invalidation generation.
 pub async fn apply_system_role_repair_in_transaction(
     db: &sea_orm::DatabaseTransaction,
     tenant_id: Option<uuid::Uuid>,
@@ -127,6 +123,9 @@ impl MigrationSource for RbacModule {
             Box::new(m20260714_900002_create_rbac_invalidation_state::Migration),
             Box::new(m20260716_000001_artifact_permission_catalog::Migration),
             Box::new(m20260717_000001_artifact_role_permissions::Migration),
+            Box::new(
+                m20260801_000001_enforce_artifact_permission_tenant_integrity::Migration,
+            ),
         ]
     }
 }
@@ -147,6 +146,10 @@ impl RusToKModule for RbacModule {
 
     fn version(&self) -> &'static str {
         env!("CARGO_PKG_VERSION")
+    }
+
+    fn dependencies(&self) -> &[&'static str] {
+        &["outbox"]
     }
 
     fn kind(&self) -> ModuleKind {

--- a/crates/rustok-rbac/src/m20260801_000001_enforce_artifact_permission_tenant_integrity.rs
+++ b/crates/rustok-rbac/src/m20260801_000001_enforce_artifact_permission_tenant_integrity.rs
@@ -1,0 +1,555 @@
+//! Enforces database-level tenant and parent integrity for dynamic artifact grants.
+
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::{ConnectionTrait, DatabaseBackend};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DatabaseBackend::Postgres => up_postgres(manager).await,
+            DatabaseBackend::Sqlite => up_sqlite(manager).await,
+            backend => Err(DbErr::Custom(format!(
+                "RBAC artifact permission tenant-integrity migration does not support {backend:?}"
+            ))),
+        }
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DatabaseBackend::Postgres => down_postgres(manager).await,
+            DatabaseBackend::Sqlite => down_sqlite(manager).await,
+            backend => Err(DbErr::Custom(format!(
+                "RBAC artifact permission tenant-integrity migration does not support {backend:?}"
+            ))),
+        }
+    }
+}
+
+async fn up_postgres(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .get_connection()
+        .execute_unprepared(
+            r#"
+DELETE FROM rbac_artifact_role_permissions grant_row
+WHERE NOT EXISTS (
+    SELECT 1 FROM roles role_row
+    WHERE role_row.id = grant_row.role_id
+      AND role_row.tenant_id = grant_row.tenant_id
+) OR NOT EXISTS (
+    SELECT 1 FROM users actor_row
+    WHERE actor_row.id = grant_row.granted_by_actor_id
+      AND actor_row.tenant_id = grant_row.tenant_id
+) OR NOT EXISTS (
+    SELECT 1 FROM rbac_artifact_permission_catalog catalog_row
+    WHERE catalog_row.installation_id = grant_row.installation_id
+      AND catalog_row.permission_key = grant_row.permission_key
+      AND (
+          catalog_row.scope_key = 'platform'
+          OR catalog_row.scope_key = 'tenant:' || grant_row.tenant_id::text
+      )
+);
+
+DELETE FROM rbac_artifact_role_permission_operations operation_row
+WHERE NOT EXISTS (
+    SELECT 1 FROM roles role_row
+    WHERE role_row.id = operation_row.role_id
+      AND role_row.tenant_id = operation_row.tenant_id
+) OR NOT EXISTS (
+    SELECT 1 FROM users actor_row
+    WHERE actor_row.id = operation_row.actor_id
+      AND actor_row.tenant_id = operation_row.tenant_id
+) OR NOT EXISTS (
+    SELECT 1 FROM rbac_artifact_permission_catalog catalog_row
+    WHERE catalog_row.installation_id = operation_row.installation_id
+      AND catalog_row.permission_key = operation_row.permission_key
+      AND (
+          catalog_row.scope_key = 'platform'
+          OR catalog_row.scope_key = 'tenant:' || operation_row.tenant_id::text
+      )
+);
+
+CREATE INDEX IF NOT EXISTS idx_rbac_artifact_role_permissions_role_id
+    ON rbac_artifact_role_permissions (role_id);
+CREATE INDEX IF NOT EXISTS idx_rbac_artifact_role_permissions_actor_id
+    ON rbac_artifact_role_permissions (granted_by_actor_id);
+CREATE INDEX IF NOT EXISTS idx_rbac_artifact_role_permission_operations_role_id
+    ON rbac_artifact_role_permission_operations (role_id);
+CREATE INDEX IF NOT EXISTS idx_rbac_artifact_role_permission_operations_actor_id
+    ON rbac_artifact_role_permission_operations (actor_id);
+
+CREATE OR REPLACE FUNCTION rustok_enforce_artifact_role_permission_integrity()
+RETURNS trigger AS $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM roles
+        WHERE id = NEW.role_id AND tenant_id = NEW.tenant_id
+    ) THEN
+        RAISE EXCEPTION 'RBAC artifact grant role tenant mismatch'
+            USING ERRCODE = '23514';
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM users
+        WHERE id = NEW.granted_by_actor_id AND tenant_id = NEW.tenant_id
+    ) THEN
+        RAISE EXCEPTION 'RBAC artifact grant actor tenant mismatch'
+            USING ERRCODE = '23514';
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM rbac_artifact_permission_catalog
+        WHERE installation_id = NEW.installation_id
+          AND permission_key = NEW.permission_key
+          AND (scope_key = 'platform' OR scope_key = 'tenant:' || NEW.tenant_id::text)
+    ) THEN
+        RAISE EXCEPTION 'RBAC artifact grant permission is not admitted for tenant scope'
+            USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_rbac_artifact_role_permissions_integrity
+    ON rbac_artifact_role_permissions;
+CREATE TRIGGER trg_rbac_artifact_role_permissions_integrity
+BEFORE INSERT OR UPDATE OF tenant_id, role_id, installation_id, permission_key, granted_by_actor_id
+ON rbac_artifact_role_permissions
+FOR EACH ROW EXECUTE FUNCTION rustok_enforce_artifact_role_permission_integrity();
+
+CREATE OR REPLACE FUNCTION rustok_enforce_artifact_role_permission_operation_integrity()
+RETURNS trigger AS $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM roles
+        WHERE id = NEW.role_id AND tenant_id = NEW.tenant_id
+    ) THEN
+        RAISE EXCEPTION 'RBAC artifact operation role tenant mismatch'
+            USING ERRCODE = '23514';
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM users
+        WHERE id = NEW.actor_id AND tenant_id = NEW.tenant_id
+    ) THEN
+        RAISE EXCEPTION 'RBAC artifact operation actor tenant mismatch'
+            USING ERRCODE = '23514';
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM rbac_artifact_permission_catalog
+        WHERE installation_id = NEW.installation_id
+          AND permission_key = NEW.permission_key
+          AND (scope_key = 'platform' OR scope_key = 'tenant:' || NEW.tenant_id::text)
+    ) THEN
+        RAISE EXCEPTION 'RBAC artifact operation permission is not admitted for tenant scope'
+            USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_rbac_artifact_role_permission_operations_integrity
+    ON rbac_artifact_role_permission_operations;
+CREATE TRIGGER trg_rbac_artifact_role_permission_operations_integrity
+BEFORE INSERT OR UPDATE OF tenant_id, role_id, installation_id, permission_key, actor_id
+ON rbac_artifact_role_permission_operations
+FOR EACH ROW EXECUTE FUNCTION rustok_enforce_artifact_role_permission_operation_integrity();
+
+CREATE OR REPLACE FUNCTION rustok_guard_user_tenant_update()
+RETURNS trigger AS $$
+BEGIN
+    IF NEW.tenant_id IS DISTINCT FROM OLD.tenant_id AND (
+        EXISTS (
+            SELECT 1 FROM user_roles ur
+            JOIN roles r ON r.id = ur.role_id
+            WHERE ur.user_id = NEW.id AND r.tenant_id <> NEW.tenant_id
+        ) OR EXISTS (
+            SELECT 1 FROM rbac_artifact_role_permissions
+            WHERE granted_by_actor_id = NEW.id AND tenant_id <> NEW.tenant_id
+        ) OR EXISTS (
+            SELECT 1 FROM rbac_artifact_role_permission_operations
+            WHERE actor_id = NEW.id AND tenant_id <> NEW.tenant_id
+        )
+    ) THEN
+        RAISE EXCEPTION 'RBAC user tenant update would invalidate authorization relations'
+            USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION rustok_guard_role_tenant_update()
+RETURNS trigger AS $$
+BEGIN
+    IF NEW.tenant_id IS DISTINCT FROM OLD.tenant_id AND (
+        EXISTS (
+            SELECT 1 FROM user_roles ur
+            JOIN users u ON u.id = ur.user_id
+            WHERE ur.role_id = NEW.id AND u.tenant_id <> NEW.tenant_id
+        ) OR EXISTS (
+            SELECT 1 FROM role_permissions rp
+            JOIN permissions p ON p.id = rp.permission_id
+            WHERE rp.role_id = NEW.id AND p.tenant_id <> NEW.tenant_id
+        ) OR EXISTS (
+            SELECT 1 FROM rbac_artifact_role_permissions
+            WHERE role_id = NEW.id AND tenant_id <> NEW.tenant_id
+        ) OR EXISTS (
+            SELECT 1 FROM rbac_artifact_role_permission_operations
+            WHERE role_id = NEW.id AND tenant_id <> NEW.tenant_id
+        )
+    ) THEN
+        RAISE EXCEPTION 'RBAC role tenant update would invalidate authorization relations'
+            USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION rustok_guard_artifact_role_delete()
+RETURNS trigger AS $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM rbac_artifact_role_permissions WHERE role_id = OLD.id)
+       OR EXISTS (SELECT 1 FROM rbac_artifact_role_permission_operations WHERE role_id = OLD.id)
+    THEN
+        RAISE EXCEPTION 'RBAC role deletion would orphan artifact authorization state'
+            USING ERRCODE = '23514';
+    END IF;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_rbac_artifact_role_delete ON roles;
+CREATE TRIGGER trg_rbac_artifact_role_delete
+BEFORE DELETE ON roles
+FOR EACH ROW EXECUTE FUNCTION rustok_guard_artifact_role_delete();
+
+CREATE OR REPLACE FUNCTION rustok_guard_artifact_actor_delete()
+RETURNS trigger AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM rbac_artifact_role_permissions WHERE granted_by_actor_id = OLD.id
+    ) OR EXISTS (
+        SELECT 1 FROM rbac_artifact_role_permission_operations WHERE actor_id = OLD.id
+    ) THEN
+        RAISE EXCEPTION 'RBAC user deletion would orphan artifact authorization audit state'
+            USING ERRCODE = '23514';
+    END IF;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_rbac_artifact_actor_delete ON users;
+CREATE TRIGGER trg_rbac_artifact_actor_delete
+BEFORE DELETE ON users
+FOR EACH ROW EXECUTE FUNCTION rustok_guard_artifact_actor_delete();
+
+CREATE OR REPLACE FUNCTION rustok_guard_artifact_permission_catalog_identity()
+RETURNS trigger AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM (
+            SELECT tenant_id, installation_id, permission_key
+            FROM rbac_artifact_role_permissions
+            UNION
+            SELECT tenant_id, installation_id, permission_key
+            FROM rbac_artifact_role_permission_operations
+        ) reference_row
+        WHERE reference_row.installation_id = OLD.installation_id
+          AND reference_row.permission_key = OLD.permission_key
+          AND (OLD.scope_key = 'platform' OR OLD.scope_key = 'tenant:' || reference_row.tenant_id::text)
+    ) THEN
+        RAISE EXCEPTION 'RBAC referenced artifact permission identity is immutable'
+            USING ERRCODE = '23514';
+    END IF;
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_rbac_artifact_permission_catalog_identity_update
+    ON rbac_artifact_permission_catalog;
+CREATE TRIGGER trg_rbac_artifact_permission_catalog_identity_update
+BEFORE UPDATE OF scope_key, installation_id, permission_key
+ON rbac_artifact_permission_catalog
+FOR EACH ROW
+WHEN (
+    OLD.scope_key IS DISTINCT FROM NEW.scope_key
+    OR OLD.installation_id IS DISTINCT FROM NEW.installation_id
+    OR OLD.permission_key IS DISTINCT FROM NEW.permission_key
+)
+EXECUTE FUNCTION rustok_guard_artifact_permission_catalog_identity();
+
+DROP TRIGGER IF EXISTS trg_rbac_artifact_permission_catalog_delete
+    ON rbac_artifact_permission_catalog;
+CREATE TRIGGER trg_rbac_artifact_permission_catalog_delete
+BEFORE DELETE ON rbac_artifact_permission_catalog
+FOR EACH ROW EXECUTE FUNCTION rustok_guard_artifact_permission_catalog_identity();
+"#,
+        )
+        .await?;
+    Ok(())
+}
+
+async fn down_postgres(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .get_connection()
+        .execute_unprepared(
+            r#"
+DROP TRIGGER IF EXISTS trg_rbac_artifact_role_permissions_integrity
+    ON rbac_artifact_role_permissions;
+DROP TRIGGER IF EXISTS trg_rbac_artifact_role_permission_operations_integrity
+    ON rbac_artifact_role_permission_operations;
+DROP TRIGGER IF EXISTS trg_rbac_artifact_role_delete ON roles;
+DROP TRIGGER IF EXISTS trg_rbac_artifact_actor_delete ON users;
+DROP TRIGGER IF EXISTS trg_rbac_artifact_permission_catalog_identity_update
+    ON rbac_artifact_permission_catalog;
+DROP TRIGGER IF EXISTS trg_rbac_artifact_permission_catalog_delete
+    ON rbac_artifact_permission_catalog;
+
+DROP FUNCTION IF EXISTS rustok_enforce_artifact_role_permission_integrity();
+DROP FUNCTION IF EXISTS rustok_enforce_artifact_role_permission_operation_integrity();
+DROP FUNCTION IF EXISTS rustok_guard_artifact_role_delete();
+DROP FUNCTION IF EXISTS rustok_guard_artifact_actor_delete();
+DROP FUNCTION IF EXISTS rustok_guard_artifact_permission_catalog_identity();
+
+DROP INDEX IF EXISTS idx_rbac_artifact_role_permissions_role_id;
+DROP INDEX IF EXISTS idx_rbac_artifact_role_permissions_actor_id;
+DROP INDEX IF EXISTS idx_rbac_artifact_role_permission_operations_role_id;
+DROP INDEX IF EXISTS idx_rbac_artifact_role_permission_operations_actor_id;
+
+CREATE OR REPLACE FUNCTION rustok_guard_user_tenant_update()
+RETURNS trigger AS $$
+BEGIN
+    IF NEW.tenant_id IS DISTINCT FROM OLD.tenant_id AND EXISTS (
+        SELECT 1 FROM user_roles ur
+        JOIN roles r ON r.id = ur.role_id
+        WHERE ur.user_id = NEW.id AND r.tenant_id <> NEW.tenant_id
+    ) THEN
+        RAISE EXCEPTION 'RBAC user tenant update would invalidate role assignments'
+            USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION rustok_guard_role_tenant_update()
+RETURNS trigger AS $$
+BEGIN
+    IF NEW.tenant_id IS DISTINCT FROM OLD.tenant_id AND (
+        EXISTS (
+            SELECT 1 FROM user_roles ur
+            JOIN users u ON u.id = ur.user_id
+            WHERE ur.role_id = NEW.id AND u.tenant_id <> NEW.tenant_id
+        ) OR EXISTS (
+            SELECT 1 FROM role_permissions rp
+            JOIN permissions p ON p.id = rp.permission_id
+            WHERE rp.role_id = NEW.id AND p.tenant_id <> NEW.tenant_id
+        )
+    ) THEN
+        RAISE EXCEPTION 'RBAC role tenant update would invalidate relations'
+            USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"#,
+        )
+        .await?;
+    Ok(())
+}
+
+async fn up_sqlite(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    for statement in [
+        "DELETE FROM rbac_artifact_role_permissions WHERE NOT EXISTS (SELECT 1 FROM roles WHERE id = rbac_artifact_role_permissions.role_id AND tenant_id = rbac_artifact_role_permissions.tenant_id) OR NOT EXISTS (SELECT 1 FROM users WHERE id = rbac_artifact_role_permissions.granted_by_actor_id AND tenant_id = rbac_artifact_role_permissions.tenant_id) OR NOT EXISTS (SELECT 1 FROM rbac_artifact_permission_catalog WHERE installation_id = rbac_artifact_role_permissions.installation_id AND permission_key = rbac_artifact_role_permissions.permission_key AND (scope_key = 'platform' OR scope_key = 'tenant:' || rbac_artifact_role_permissions.tenant_id))",
+        "DELETE FROM rbac_artifact_role_permission_operations WHERE NOT EXISTS (SELECT 1 FROM roles WHERE id = rbac_artifact_role_permission_operations.role_id AND tenant_id = rbac_artifact_role_permission_operations.tenant_id) OR NOT EXISTS (SELECT 1 FROM users WHERE id = rbac_artifact_role_permission_operations.actor_id AND tenant_id = rbac_artifact_role_permission_operations.tenant_id) OR NOT EXISTS (SELECT 1 FROM rbac_artifact_permission_catalog WHERE installation_id = rbac_artifact_role_permission_operations.installation_id AND permission_key = rbac_artifact_role_permission_operations.permission_key AND (scope_key = 'platform' OR scope_key = 'tenant:' || rbac_artifact_role_permission_operations.tenant_id))",
+        "CREATE INDEX IF NOT EXISTS idx_rbac_artifact_role_permissions_role_id ON rbac_artifact_role_permissions (role_id)",
+        "CREATE INDEX IF NOT EXISTS idx_rbac_artifact_role_permissions_actor_id ON rbac_artifact_role_permissions (granted_by_actor_id)",
+        "CREATE INDEX IF NOT EXISTS idx_rbac_artifact_role_permission_operations_role_id ON rbac_artifact_role_permission_operations (role_id)",
+        "CREATE INDEX IF NOT EXISTS idx_rbac_artifact_role_permission_operations_actor_id ON rbac_artifact_role_permission_operations (actor_id)",
+        "DROP TRIGGER IF EXISTS trg_rbac_users_tenant_update",
+        "DROP TRIGGER IF EXISTS trg_rbac_roles_tenant_update",
+    ] {
+        manager
+            .get_connection()
+            .execute_unprepared(statement)
+            .await?;
+    }
+    for statement in sqlite_triggers() {
+        manager
+            .get_connection()
+            .execute_unprepared(statement)
+            .await?;
+    }
+    Ok(())
+}
+
+async fn down_sqlite(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    for name in sqlite_trigger_names() {
+        manager
+            .get_connection()
+            .execute_unprepared(&format!("DROP TRIGGER IF EXISTS {name}"))
+            .await?;
+    }
+    for statement in [
+        "DROP INDEX IF EXISTS idx_rbac_artifact_role_permissions_role_id",
+        "DROP INDEX IF EXISTS idx_rbac_artifact_role_permissions_actor_id",
+        "DROP INDEX IF EXISTS idx_rbac_artifact_role_permission_operations_role_id",
+        "DROP INDEX IF EXISTS idx_rbac_artifact_role_permission_operations_actor_id",
+        r#"CREATE TRIGGER trg_rbac_users_tenant_update
+           BEFORE UPDATE OF tenant_id ON users FOR EACH ROW
+           WHEN NEW.tenant_id <> OLD.tenant_id AND EXISTS (
+               SELECT 1 FROM user_roles ur JOIN roles r ON r.id = ur.role_id
+               WHERE ur.user_id = NEW.id AND r.tenant_id <> NEW.tenant_id
+           )
+           BEGIN SELECT RAISE(ABORT, 'RBAC user tenant update would invalidate role assignments'); END"#,
+        r#"CREATE TRIGGER trg_rbac_roles_tenant_update
+           BEFORE UPDATE OF tenant_id ON roles FOR EACH ROW
+           WHEN NEW.tenant_id <> OLD.tenant_id AND (
+               EXISTS (
+                   SELECT 1 FROM user_roles ur JOIN users u ON u.id = ur.user_id
+                   WHERE ur.role_id = NEW.id AND u.tenant_id <> NEW.tenant_id
+               ) OR EXISTS (
+                   SELECT 1 FROM role_permissions rp JOIN permissions p ON p.id = rp.permission_id
+                   WHERE rp.role_id = NEW.id AND p.tenant_id <> NEW.tenant_id
+               )
+           )
+           BEGIN SELECT RAISE(ABORT, 'RBAC role tenant update would invalidate relations'); END"#,
+    ] {
+        manager
+            .get_connection()
+            .execute_unprepared(statement)
+            .await?;
+    }
+    Ok(())
+}
+
+fn sqlite_trigger_names() -> [&'static str; 10] {
+    [
+        "trg_rbac_artifact_role_permissions_integrity_insert",
+        "trg_rbac_artifact_role_permissions_integrity_update",
+        "trg_rbac_artifact_role_permission_operations_integrity_insert",
+        "trg_rbac_artifact_role_permission_operations_integrity_update",
+        "trg_rbac_users_tenant_update",
+        "trg_rbac_roles_tenant_update",
+        "trg_rbac_artifact_role_delete",
+        "trg_rbac_artifact_actor_delete",
+        "trg_rbac_artifact_permission_catalog_identity_update",
+        "trg_rbac_artifact_permission_catalog_delete",
+    ]
+}
+
+fn sqlite_triggers() -> [&'static str; 10] {
+    [
+        r#"CREATE TRIGGER trg_rbac_artifact_role_permissions_integrity_insert
+           BEFORE INSERT ON rbac_artifact_role_permissions FOR EACH ROW
+           WHEN NOT EXISTS (SELECT 1 FROM roles WHERE id = NEW.role_id AND tenant_id = NEW.tenant_id)
+             OR NOT EXISTS (SELECT 1 FROM users WHERE id = NEW.granted_by_actor_id AND tenant_id = NEW.tenant_id)
+             OR NOT EXISTS (SELECT 1 FROM rbac_artifact_permission_catalog WHERE installation_id = NEW.installation_id AND permission_key = NEW.permission_key AND (scope_key = 'platform' OR scope_key = 'tenant:' || NEW.tenant_id))
+           BEGIN SELECT RAISE(ABORT, 'RBAC artifact grant tenant integrity violation'); END"#,
+        r#"CREATE TRIGGER trg_rbac_artifact_role_permissions_integrity_update
+           BEFORE UPDATE OF tenant_id, role_id, installation_id, permission_key, granted_by_actor_id ON rbac_artifact_role_permissions FOR EACH ROW
+           WHEN NOT EXISTS (SELECT 1 FROM roles WHERE id = NEW.role_id AND tenant_id = NEW.tenant_id)
+             OR NOT EXISTS (SELECT 1 FROM users WHERE id = NEW.granted_by_actor_id AND tenant_id = NEW.tenant_id)
+             OR NOT EXISTS (SELECT 1 FROM rbac_artifact_permission_catalog WHERE installation_id = NEW.installation_id AND permission_key = NEW.permission_key AND (scope_key = 'platform' OR scope_key = 'tenant:' || NEW.tenant_id))
+           BEGIN SELECT RAISE(ABORT, 'RBAC artifact grant tenant integrity violation'); END"#,
+        r#"CREATE TRIGGER trg_rbac_artifact_role_permission_operations_integrity_insert
+           BEFORE INSERT ON rbac_artifact_role_permission_operations FOR EACH ROW
+           WHEN NOT EXISTS (SELECT 1 FROM roles WHERE id = NEW.role_id AND tenant_id = NEW.tenant_id)
+             OR NOT EXISTS (SELECT 1 FROM users WHERE id = NEW.actor_id AND tenant_id = NEW.tenant_id)
+             OR NOT EXISTS (SELECT 1 FROM rbac_artifact_permission_catalog WHERE installation_id = NEW.installation_id AND permission_key = NEW.permission_key AND (scope_key = 'platform' OR scope_key = 'tenant:' || NEW.tenant_id))
+           BEGIN SELECT RAISE(ABORT, 'RBAC artifact operation tenant integrity violation'); END"#,
+        r#"CREATE TRIGGER trg_rbac_artifact_role_permission_operations_integrity_update
+           BEFORE UPDATE OF tenant_id, role_id, installation_id, permission_key, actor_id ON rbac_artifact_role_permission_operations FOR EACH ROW
+           WHEN NOT EXISTS (SELECT 1 FROM roles WHERE id = NEW.role_id AND tenant_id = NEW.tenant_id)
+             OR NOT EXISTS (SELECT 1 FROM users WHERE id = NEW.actor_id AND tenant_id = NEW.tenant_id)
+             OR NOT EXISTS (SELECT 1 FROM rbac_artifact_permission_catalog WHERE installation_id = NEW.installation_id AND permission_key = NEW.permission_key AND (scope_key = 'platform' OR scope_key = 'tenant:' || NEW.tenant_id))
+           BEGIN SELECT RAISE(ABORT, 'RBAC artifact operation tenant integrity violation'); END"#,
+        r#"CREATE TRIGGER trg_rbac_users_tenant_update
+           BEFORE UPDATE OF tenant_id ON users FOR EACH ROW
+           WHEN NEW.tenant_id <> OLD.tenant_id AND (
+               EXISTS (SELECT 1 FROM user_roles ur JOIN roles r ON r.id = ur.role_id WHERE ur.user_id = NEW.id AND r.tenant_id <> NEW.tenant_id)
+               OR EXISTS (SELECT 1 FROM rbac_artifact_role_permissions WHERE granted_by_actor_id = NEW.id AND tenant_id <> NEW.tenant_id)
+               OR EXISTS (SELECT 1 FROM rbac_artifact_role_permission_operations WHERE actor_id = NEW.id AND tenant_id <> NEW.tenant_id)
+           )
+           BEGIN SELECT RAISE(ABORT, 'RBAC user tenant update would invalidate authorization relations'); END"#,
+        r#"CREATE TRIGGER trg_rbac_roles_tenant_update
+           BEFORE UPDATE OF tenant_id ON roles FOR EACH ROW
+           WHEN NEW.tenant_id <> OLD.tenant_id AND (
+               EXISTS (SELECT 1 FROM user_roles ur JOIN users u ON u.id = ur.user_id WHERE ur.role_id = NEW.id AND u.tenant_id <> NEW.tenant_id)
+               OR EXISTS (SELECT 1 FROM role_permissions rp JOIN permissions p ON p.id = rp.permission_id WHERE rp.role_id = NEW.id AND p.tenant_id <> NEW.tenant_id)
+               OR EXISTS (SELECT 1 FROM rbac_artifact_role_permissions WHERE role_id = NEW.id AND tenant_id <> NEW.tenant_id)
+               OR EXISTS (SELECT 1 FROM rbac_artifact_role_permission_operations WHERE role_id = NEW.id AND tenant_id <> NEW.tenant_id)
+           )
+           BEGIN SELECT RAISE(ABORT, 'RBAC role tenant update would invalidate authorization relations'); END"#,
+        r#"CREATE TRIGGER trg_rbac_artifact_role_delete
+           BEFORE DELETE ON roles FOR EACH ROW
+           WHEN EXISTS (SELECT 1 FROM rbac_artifact_role_permissions WHERE role_id = OLD.id)
+             OR EXISTS (SELECT 1 FROM rbac_artifact_role_permission_operations WHERE role_id = OLD.id)
+           BEGIN SELECT RAISE(ABORT, 'RBAC role deletion would orphan artifact authorization state'); END"#,
+        r#"CREATE TRIGGER trg_rbac_artifact_actor_delete
+           BEFORE DELETE ON users FOR EACH ROW
+           WHEN EXISTS (SELECT 1 FROM rbac_artifact_role_permissions WHERE granted_by_actor_id = OLD.id)
+             OR EXISTS (SELECT 1 FROM rbac_artifact_role_permission_operations WHERE actor_id = OLD.id)
+           BEGIN SELECT RAISE(ABORT, 'RBAC user deletion would orphan artifact authorization audit state'); END"#,
+        r#"CREATE TRIGGER trg_rbac_artifact_permission_catalog_identity_update
+           BEFORE UPDATE OF scope_key, installation_id, permission_key ON rbac_artifact_permission_catalog FOR EACH ROW
+           WHEN (NEW.scope_key <> OLD.scope_key OR NEW.installation_id <> OLD.installation_id OR NEW.permission_key <> OLD.permission_key)
+             AND EXISTS (
+                 SELECT 1 FROM (
+                     SELECT tenant_id, installation_id, permission_key FROM rbac_artifact_role_permissions
+                     UNION
+                     SELECT tenant_id, installation_id, permission_key FROM rbac_artifact_role_permission_operations
+                 ) reference_row
+                 WHERE reference_row.installation_id = OLD.installation_id
+                   AND reference_row.permission_key = OLD.permission_key
+                   AND (OLD.scope_key = 'platform' OR OLD.scope_key = 'tenant:' || reference_row.tenant_id)
+             )
+           BEGIN SELECT RAISE(ABORT, 'RBAC referenced artifact permission identity is immutable'); END"#,
+        r#"CREATE TRIGGER trg_rbac_artifact_permission_catalog_delete
+           BEFORE DELETE ON rbac_artifact_permission_catalog FOR EACH ROW
+           WHEN EXISTS (
+               SELECT 1 FROM (
+                   SELECT tenant_id, installation_id, permission_key FROM rbac_artifact_role_permissions
+                   UNION
+                   SELECT tenant_id, installation_id, permission_key FROM rbac_artifact_role_permission_operations
+               ) reference_row
+               WHERE reference_row.installation_id = OLD.installation_id
+                 AND reference_row.permission_key = OLD.permission_key
+                 AND (OLD.scope_key = 'platform' OR OLD.scope_key = 'tenant:' || reference_row.tenant_id)
+           )
+           BEGIN SELECT RAISE(ABORT, 'RBAC referenced artifact permission identity is immutable'); END"#,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{sqlite_trigger_names, sqlite_triggers};
+
+    #[test]
+    fn sqlite_trigger_inventory_covers_children_and_parent_changes() {
+        assert_eq!(sqlite_triggers().len(), 10);
+        assert_eq!(sqlite_trigger_names().len(), 10);
+        for required in [
+            "artifact_role_permissions_integrity_insert",
+            "artifact_role_permissions_integrity_update",
+            "artifact_role_permission_operations_integrity_insert",
+            "artifact_role_permission_operations_integrity_update",
+            "users_tenant_update",
+            "roles_tenant_update",
+            "artifact_role_delete",
+            "artifact_actor_delete",
+            "artifact_permission_catalog_identity_update",
+            "artifact_permission_catalog_delete",
+        ] {
+            assert!(
+                sqlite_triggers()
+                    .iter()
+                    .any(|trigger| trigger.contains(required))
+            );
+            assert!(sqlite_trigger_names().contains(&format!("trg_rbac_{required}").as_str()));
+        }
+    }
+}

--- a/crates/rustok-rbac/src/services/permission_authorizer.rs
+++ b/crates/rustok-rbac/src/services/permission_authorizer.rs
@@ -135,7 +135,6 @@ mod tests {
     use crate::{AuthzEngine, PermissionResolution, PermissionResolver};
     use async_trait::async_trait;
     use rustok_api::Permission;
-    use rustok_core::UserRole;
 
     struct StubResolver {
         permissions: Vec<Permission>,
@@ -159,41 +158,6 @@ mod tests {
                 permissions: self.permissions.clone(),
                 cache_hit: self.cache_hit,
             })
-        }
-
-        async fn assign_role_permissions(
-            &self,
-            _tenant_id: &uuid::Uuid,
-            _user_id: &uuid::Uuid,
-            _role: UserRole,
-        ) -> Result<(), Self::Error> {
-            Ok(())
-        }
-
-        async fn replace_user_role(
-            &self,
-            _tenant_id: &uuid::Uuid,
-            _user_id: &uuid::Uuid,
-            _role: UserRole,
-        ) -> Result<(), Self::Error> {
-            Ok(())
-        }
-
-        async fn remove_tenant_role_assignments(
-            &self,
-            _tenant_id: &uuid::Uuid,
-            _user_id: &uuid::Uuid,
-        ) -> Result<(), Self::Error> {
-            Ok(())
-        }
-
-        async fn remove_user_role_assignment(
-            &self,
-            _tenant_id: &uuid::Uuid,
-            _user_id: &uuid::Uuid,
-            _role: UserRole,
-        ) -> Result<(), Self::Error> {
-            Ok(())
         }
     }
 
@@ -280,10 +244,14 @@ mod tests {
             fail_resolve: false,
         };
 
-        let decision =
-            authorize_all_permissions(&resolver, &uuid::Uuid::new_v4(), &uuid::Uuid::new_v4(), &[])
-                .await
-                .unwrap();
+        let decision = authorize_all_permissions(
+            &resolver,
+            &uuid::Uuid::new_v4(),
+            &uuid::Uuid::new_v4(),
+            &[],
+        )
+        .await
+        .unwrap();
 
         assert_eq!(decision.engine, AuthzEngine::Policy);
         assert!(decision.allowed);

--- a/crates/rustok-rbac/src/services/permission_resolver.rs
+++ b/crates/rustok-rbac/src/services/permission_resolver.rs
@@ -1,7 +1,6 @@
 use crate::{evaluate_all_permissions, evaluate_any_permission, evaluate_single_permission};
 use async_trait::async_trait;
 use rustok_api::Permission;
-use rustok_core::UserRole;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PermissionResolution {
@@ -9,6 +8,12 @@ pub struct PermissionResolution {
     pub cache_hit: bool,
 }
 
+/// Read-only owner contract for resolving effective tenant permissions.
+///
+/// Role and permission mutations intentionally do not belong to this trait.
+/// Existing-user writes must use transaction-owned or committed RBAC mutation
+/// entry points so continuity locks, durable invalidation generations and
+/// cross-replica cache recovery cannot be bypassed.
 #[async_trait]
 pub trait PermissionResolver {
     type Error;
@@ -48,33 +53,6 @@ pub trait PermissionResolver {
         let resolved = self.resolve_permissions(tenant_id, user_id).await?;
         Ok(evaluate_all_permissions(&resolved.permissions, required_permissions).allowed)
     }
-
-    async fn assign_role_permissions(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<(), Self::Error>;
-
-    async fn replace_user_role(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<(), Self::Error>;
-
-    async fn remove_tenant_role_assignments(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-    ) -> Result<(), Self::Error>;
-
-    async fn remove_user_role_assignment(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<(), Self::Error>;
 }
 
 #[cfg(test)]
@@ -82,7 +60,6 @@ mod tests {
     use super::{PermissionResolution, PermissionResolver};
     use async_trait::async_trait;
     use rustok_api::Permission;
-    use rustok_core::UserRole;
 
     struct StubResolver {
         permissions: Vec<Permission>,
@@ -101,41 +78,6 @@ mod tests {
                 permissions: self.permissions.clone(),
                 cache_hit: true,
             })
-        }
-
-        async fn assign_role_permissions(
-            &self,
-            _tenant_id: &uuid::Uuid,
-            _user_id: &uuid::Uuid,
-            _role: UserRole,
-        ) -> Result<(), Self::Error> {
-            Ok(())
-        }
-
-        async fn replace_user_role(
-            &self,
-            _tenant_id: &uuid::Uuid,
-            _user_id: &uuid::Uuid,
-            _role: UserRole,
-        ) -> Result<(), Self::Error> {
-            Ok(())
-        }
-
-        async fn remove_tenant_role_assignments(
-            &self,
-            _tenant_id: &uuid::Uuid,
-            _user_id: &uuid::Uuid,
-        ) -> Result<(), Self::Error> {
-            Ok(())
-        }
-
-        async fn remove_user_role_assignment(
-            &self,
-            _tenant_id: &uuid::Uuid,
-            _user_id: &uuid::Uuid,
-            _role: UserRole,
-        ) -> Result<(), Self::Error> {
-            Ok(())
         }
     }
 

--- a/crates/rustok-rbac/src/services/runtime_permission_resolver.rs
+++ b/crates/rustok-rbac/src/services/runtime_permission_resolver.rs
@@ -3,82 +3,42 @@ use crate::{
     resolve_permissions_with_cache,
 };
 use async_trait::async_trait;
-use rustok_core::UserRole;
 use std::marker::PhantomData;
 
+/// Runtime adapter for the read-only permission-resolution path.
 #[derive(Clone)]
-pub struct RuntimePermissionResolver<S, C, A, E>
+pub struct RuntimePermissionResolver<S, C, E>
 where
     S: RelationPermissionStore,
     C: PermissionCache,
-    A: RoleAssignmentStore,
     S::Error: Into<E>,
-    A::Error: Into<E>,
 {
     store: S,
     cache: C,
-    assignment_store: A,
     _error: PhantomData<E>,
 }
 
-impl<S, C, A, E> RuntimePermissionResolver<S, C, A, E>
+impl<S, C, E> RuntimePermissionResolver<S, C, E>
 where
     S: RelationPermissionStore,
     C: PermissionCache,
-    A: RoleAssignmentStore,
     S::Error: Into<E>,
-    A::Error: Into<E>,
 {
-    pub fn new(store: S, cache: C, assignment_store: A) -> Self {
+    pub fn new(store: S, cache: C) -> Self {
         Self {
             store,
             cache,
-            assignment_store,
             _error: PhantomData,
         }
     }
 }
 
 #[async_trait]
-pub trait RoleAssignmentStore {
-    type Error;
-
-    async fn assign_role_permissions(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<(), Self::Error>;
-
-    async fn replace_user_role(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<(), Self::Error>;
-
-    async fn remove_tenant_role_assignments(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-    ) -> Result<(), Self::Error>;
-
-    async fn remove_user_role_assignment(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<(), Self::Error>;
-}
-
-#[async_trait]
-impl<S, C, A, E> PermissionResolver for RuntimePermissionResolver<S, C, A, E>
+impl<S, C, E> PermissionResolver for RuntimePermissionResolver<S, C, E>
 where
     S: RelationPermissionStore + Send + Sync,
     C: PermissionCache + Send + Sync,
-    A: RoleAssignmentStore + Send + Sync,
     S::Error: Into<E> + Send + Sync,
-    A::Error: Into<E> + Send + Sync,
     E: Send + Sync,
 {
     type Error = E;
@@ -92,78 +52,14 @@ where
             .await
             .map_err(Into::into)
     }
-
-    async fn assign_role_permissions(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<(), Self::Error> {
-        self.assignment_store
-            .assign_role_permissions(tenant_id, user_id, role)
-            .await
-            .map_err(Into::into)?;
-
-        self.cache.invalidate(tenant_id, user_id).await;
-
-        Ok(())
-    }
-
-    async fn replace_user_role(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<(), Self::Error> {
-        self.assignment_store
-            .replace_user_role(tenant_id, user_id, role)
-            .await
-            .map_err(Into::into)?;
-
-        self.cache.invalidate(tenant_id, user_id).await;
-
-        Ok(())
-    }
-
-    async fn remove_tenant_role_assignments(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-    ) -> Result<(), Self::Error> {
-        self.assignment_store
-            .remove_tenant_role_assignments(tenant_id, user_id)
-            .await
-            .map_err(Into::into)?;
-
-        self.cache.invalidate(tenant_id, user_id).await;
-
-        Ok(())
-    }
-
-    async fn remove_user_role_assignment(
-        &self,
-        tenant_id: &uuid::Uuid,
-        user_id: &uuid::Uuid,
-        role: UserRole,
-    ) -> Result<(), Self::Error> {
-        self.assignment_store
-            .remove_user_role_assignment(tenant_id, user_id, role)
-            .await
-            .map_err(Into::into)?;
-
-        self.cache.invalidate(tenant_id, user_id).await;
-
-        Ok(())
-    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{RoleAssignmentStore, RuntimePermissionResolver};
+    use super::RuntimePermissionResolver;
     use crate::{PermissionCache, PermissionResolver, RelationPermissionStore};
     use async_trait::async_trait;
     use rustok_api::Permission;
-    use rustok_core::UserRole;
     use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::Mutex;
@@ -184,14 +80,8 @@ mod tests {
     }
 
     #[derive(Debug, Clone, PartialEq, Eq)]
-    enum StubAssignmentError {
-        Assign,
-    }
-
-    #[derive(Debug, Clone, PartialEq, Eq)]
     enum ResolverError {
         Store(StubStoreError),
-        Assignment(StubAssignmentError),
     }
 
     impl From<StubStoreError> for ResolverError {
@@ -200,24 +90,9 @@ mod tests {
         }
     }
 
-    impl From<StubAssignmentError> for ResolverError {
-        fn from(value: StubAssignmentError) -> Self {
-            Self::Assignment(value)
-        }
-    }
-
     #[derive(Default)]
     struct StubCache {
         values: Arc<Mutex<PermissionCacheMap>>,
-    }
-
-    #[derive(Default)]
-    struct StubAssignmentStore {
-        assigned: Arc<Mutex<Vec<(uuid::Uuid, uuid::Uuid, UserRole)>>>,
-        replaced: Arc<Mutex<Vec<(uuid::Uuid, uuid::Uuid, UserRole)>>>,
-        removed_tenant: Arc<Mutex<Vec<(uuid::Uuid, uuid::Uuid)>>>,
-        removed_single: Arc<Mutex<Vec<(uuid::Uuid, uuid::Uuid, UserRole)>>>,
-        fail_assign: bool,
     }
 
     #[async_trait]
@@ -282,71 +157,12 @@ mod tests {
         }
     }
 
-    #[async_trait]
-    impl RoleAssignmentStore for StubAssignmentStore {
-        type Error = StubAssignmentError;
-
-        async fn assign_role_permissions(
-            &self,
-            tenant_id: &uuid::Uuid,
-            user_id: &uuid::Uuid,
-            role: UserRole,
-        ) -> Result<(), Self::Error> {
-            if self.fail_assign {
-                return Err(StubAssignmentError::Assign);
-            }
-            self.assigned
-                .lock()
-                .await
-                .push((*tenant_id, *user_id, role));
-            Ok(())
-        }
-
-        async fn replace_user_role(
-            &self,
-            tenant_id: &uuid::Uuid,
-            user_id: &uuid::Uuid,
-            role: UserRole,
-        ) -> Result<(), Self::Error> {
-            self.replaced
-                .lock()
-                .await
-                .push((*tenant_id, *user_id, role));
-            Ok(())
-        }
-
-        async fn remove_tenant_role_assignments(
-            &self,
-            tenant_id: &uuid::Uuid,
-            user_id: &uuid::Uuid,
-        ) -> Result<(), Self::Error> {
-            self.removed_tenant
-                .lock()
-                .await
-                .push((*tenant_id, *user_id));
-            Ok(())
-        }
-
-        async fn remove_user_role_assignment(
-            &self,
-            tenant_id: &uuid::Uuid,
-            user_id: &uuid::Uuid,
-            role: UserRole,
-        ) -> Result<(), Self::Error> {
-            self.removed_single
-                .lock()
-                .await
-                .push((*tenant_id, *user_id, role));
-            Ok(())
-        }
-    }
-
     #[tokio::test]
     async fn resolve_permissions_delegates_to_relation_and_cache_layer() {
         let role_id = uuid::Uuid::new_v4();
         let tenant_id = uuid::Uuid::new_v4();
         let user_id = uuid::Uuid::new_v4();
-        let resolver: RuntimePermissionResolver<_, _, _, ResolverError> =
+        let resolver: RuntimePermissionResolver<_, _, ResolverError> =
             RuntimePermissionResolver::new(
                 StubStore {
                     role_ids: vec![role_id],
@@ -355,7 +171,6 @@ mod tests {
                     fail_load: false,
                 },
                 StubCache::default(),
-                StubAssignmentStore::default(),
             );
 
         let first = resolver
@@ -373,155 +188,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn role_assignment_operations_invalidate_cached_permissions() {
-        let cache = StubCache::default();
-        let resolver: RuntimePermissionResolver<_, _, _, ResolverError> =
-            RuntimePermissionResolver::new(
-                StubStore {
-                    role_ids: vec![uuid::Uuid::new_v4()],
-                    tenant_role_ids: vec![uuid::Uuid::new_v4()],
-                    permissions: vec![Permission::PRODUCTS_READ],
-                    fail_load: false,
-                },
-                cache,
-                StubAssignmentStore::default(),
-            );
-        let tenant_id = uuid::Uuid::new_v4();
-        let user_id = uuid::Uuid::new_v4();
-
-        let first = resolver
-            .resolve_permissions(&tenant_id, &user_id)
-            .await
-            .unwrap();
-        assert!(!first.cache_hit);
-
-        let second = resolver
-            .resolve_permissions(&tenant_id, &user_id)
-            .await
-            .unwrap();
-        assert!(second.cache_hit);
-
-        resolver
-            .replace_user_role(&tenant_id, &user_id, UserRole::Admin)
-            .await
-            .unwrap();
-
-        let after_replace = resolver
-            .resolve_permissions(&tenant_id, &user_id)
-            .await
-            .unwrap();
-        assert!(!after_replace.cache_hit);
-
-        let after_replace_cached = resolver
-            .resolve_permissions(&tenant_id, &user_id)
-            .await
-            .unwrap();
-        assert!(after_replace_cached.cache_hit);
-
-        resolver
-            .remove_tenant_role_assignments(&tenant_id, &user_id)
-            .await
-            .unwrap();
-
-        let after_remove = resolver
-            .resolve_permissions(&tenant_id, &user_id)
-            .await
-            .unwrap();
-        assert!(!after_remove.cache_hit);
-    }
-
-    #[tokio::test]
-    async fn role_assignment_use_cases_delegate_to_assignment_store() {
-        let assignment_store = StubAssignmentStore::default();
-        let resolver: RuntimePermissionResolver<_, _, _, ResolverError> =
-            RuntimePermissionResolver::new(
-                StubStore {
-                    role_ids: vec![],
-                    tenant_role_ids: vec![],
-                    permissions: vec![],
-                    fail_load: false,
-                },
-                StubCache::default(),
-                assignment_store,
-            );
-        let tenant_id = uuid::Uuid::new_v4();
-        let user_id = uuid::Uuid::new_v4();
-
-        resolver
-            .assign_role_permissions(&tenant_id, &user_id, UserRole::Manager)
-            .await
-            .unwrap();
-        resolver
-            .replace_user_role(&tenant_id, &user_id, UserRole::Admin)
-            .await
-            .unwrap();
-        resolver
-            .remove_tenant_role_assignments(&tenant_id, &user_id)
-            .await
-            .unwrap();
-        resolver
-            .remove_user_role_assignment(&tenant_id, &user_id, UserRole::Manager)
-            .await
-            .unwrap();
-
-        let assigned = resolver.assignment_store.assigned.lock().await.clone();
-        let replaced = resolver.assignment_store.replaced.lock().await.clone();
-        let removed_tenant = resolver
-            .assignment_store
-            .removed_tenant
-            .lock()
-            .await
-            .clone();
-        let removed_single = resolver
-            .assignment_store
-            .removed_single
-            .lock()
-            .await
-            .clone();
-
-        assert_eq!(assigned, vec![(tenant_id, user_id, UserRole::Manager)]);
-        assert_eq!(replaced, vec![(tenant_id, user_id, UserRole::Admin)]);
-        assert_eq!(removed_tenant, vec![(tenant_id, user_id)]);
-        assert_eq!(
-            removed_single,
-            vec![(tenant_id, user_id, UserRole::Manager)]
-        );
-    }
-
-    #[tokio::test]
-    async fn assignment_error_is_mapped_to_runtime_resolver_error_type() {
-        let resolver: RuntimePermissionResolver<_, _, _, ResolverError> =
-            RuntimePermissionResolver::new(
-                StubStore {
-                    role_ids: vec![],
-                    tenant_role_ids: vec![],
-                    permissions: vec![],
-                    fail_load: false,
-                },
-                StubCache::default(),
-                StubAssignmentStore {
-                    fail_assign: true,
-                    ..StubAssignmentStore::default()
-                },
-            );
-
-        let result = resolver
-            .assign_role_permissions(
-                &uuid::Uuid::new_v4(),
-                &uuid::Uuid::new_v4(),
-                UserRole::Admin,
-            )
-            .await;
-
-        assert_eq!(
-            result.err(),
-            Some(ResolverError::Assignment(StubAssignmentError::Assign))
-        );
-    }
-
-    #[tokio::test]
     async fn relation_store_error_is_mapped_to_runtime_resolver_error_type() {
-        let resolver: RuntimePermissionResolver<_, _, _, ResolverError> =
+        let resolver: RuntimePermissionResolver<_, _, ResolverError> =
             RuntimePermissionResolver::new(
                 StubStore {
                     role_ids: vec![],
@@ -530,7 +198,6 @@ mod tests {
                     fail_load: true,
                 },
                 StubCache::default(),
-                StubAssignmentStore::default(),
             );
 
         let result = resolver

--- a/crates/rustok-rbac/tests/artifact_permission_outbox_sqlite.rs
+++ b/crates/rustok-rbac/tests/artifact_permission_outbox_sqlite.rs
@@ -1,0 +1,273 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_events::RbacArtifactPermissionEvent;
+use rustok_rbac::{
+    ArtifactPermissionAssignmentError, ArtifactPermissionEventPublisher,
+    ArtifactRolePermissionAssignmentCommand, RbacArtifactPermissionAssignmentService,
+};
+use sea_orm::{
+    ConnectionTrait, Database, DatabaseConnection, DatabaseTransaction, Statement,
+};
+use uuid::Uuid;
+
+#[derive(Clone)]
+struct SqliteArtifactPermissionEventPublisher {
+    fail: bool,
+}
+
+#[async_trait]
+impl ArtifactPermissionEventPublisher for SqliteArtifactPermissionEventPublisher {
+    async fn publish_assignment_changed(
+        &self,
+        transaction: &DatabaseTransaction,
+        tenant_id: Uuid,
+        actor_id: Uuid,
+        event: RbacArtifactPermissionEvent,
+    ) -> Result<(), ArtifactPermissionAssignmentError> {
+        if self.fail {
+            return Err(ArtifactPermissionAssignmentError::Database(
+                "test publisher rejected the event".to_string(),
+            ));
+        }
+
+        let event_type = event.event_type();
+        let schema_version = event.schema_version();
+        let RbacArtifactPermissionEvent::AssignmentChanged {
+            operation_id,
+            role_id,
+            installation_id,
+            permission_key,
+            granted,
+        } = event;
+        transaction
+            .execute(Statement::from_sql_and_values(
+                transaction.get_database_backend(),
+                "INSERT INTO rbac_artifact_permission_events (operation_id, tenant_id, actor_id, role_id, installation_id, permission_key, granted, event_type, schema_version) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                vec![
+                    operation_id.into(),
+                    tenant_id.into(),
+                    actor_id.into(),
+                    role_id.into(),
+                    installation_id.into(),
+                    permission_key.into(),
+                    granted.into(),
+                    event_type.into(),
+                    i32::from(schema_version).into(),
+                ],
+            ))
+            .await
+            .map_err(|error| ArtifactPermissionAssignmentError::Database(error.to_string()))?;
+        Ok(())
+    }
+}
+
+async fn setup_database() -> DatabaseConnection {
+    let db = Database::connect("sqlite::memory:")
+        .await
+        .expect("connect sqlite");
+    for statement in [
+        "CREATE TABLE roles (id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL)",
+        "CREATE TABLE rbac_artifact_permission_catalog (id TEXT PRIMARY KEY, scope_key TEXT NOT NULL, installation_id TEXT NOT NULL, module_slug TEXT NOT NULL, release_digest TEXT NOT NULL, permission_key TEXT NOT NULL, locale TEXT NOT NULL, label TEXT NOT NULL, description TEXT NOT NULL, registered_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, UNIQUE (scope_key, installation_id, permission_key, locale))",
+        "CREATE TABLE rbac_artifact_role_permissions (id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, role_id TEXT NOT NULL, installation_id TEXT NOT NULL, permission_key TEXT NOT NULL, granted_by_actor_id TEXT NOT NULL, granted_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, UNIQUE (tenant_id, role_id, installation_id, permission_key))",
+        "CREATE TABLE rbac_artifact_role_permission_operations (id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, idempotency_key TEXT NOT NULL, role_id TEXT NOT NULL, installation_id TEXT NOT NULL, permission_key TEXT NOT NULL, actor_id TEXT NOT NULL, granted BOOLEAN NOT NULL, applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, UNIQUE (tenant_id, idempotency_key))",
+        "CREATE TABLE rbac_artifact_permission_events (operation_id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, actor_id TEXT NOT NULL, role_id TEXT NOT NULL, installation_id TEXT NOT NULL, permission_key TEXT NOT NULL, granted BOOLEAN NOT NULL, event_type TEXT NOT NULL, schema_version INTEGER NOT NULL)",
+    ] {
+        db.execute_unprepared(statement)
+            .await
+            .expect("create RBAC fixture table");
+    }
+    db
+}
+
+async fn insert_scope(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    role_id: Uuid,
+    installation_id: Uuid,
+    permission_key: &str,
+) {
+    db.execute(Statement::from_sql_and_values(
+        db.get_database_backend(),
+        "INSERT INTO roles (id, tenant_id) VALUES (?1, ?2)",
+        vec![role_id.into(), tenant_id.into()],
+    ))
+    .await
+    .expect("insert role");
+    db.execute(Statement::from_sql_and_values(
+        db.get_database_backend(),
+        "INSERT INTO rbac_artifact_permission_catalog (id, scope_key, installation_id, module_slug, release_digest, permission_key, locale, label, description) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        vec![
+            Uuid::new_v4().into(),
+            format!("tenant:{tenant_id}").into(),
+            installation_id.into(),
+            "sample".into(),
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+            permission_key.into(),
+            "en".into(),
+            "Handle events".into(),
+            "Allows the role to handle sample events".into(),
+        ],
+    ))
+    .await
+    .expect("insert artifact permission catalog row");
+}
+
+fn command(
+    tenant_id: Uuid,
+    role_id: Uuid,
+    installation_id: Uuid,
+    actor_id: Uuid,
+    permission_key: &str,
+    granted: bool,
+    idempotency_key: &str,
+) -> ArtifactRolePermissionAssignmentCommand {
+    ArtifactRolePermissionAssignmentCommand {
+        tenant_id,
+        role_id,
+        installation_id,
+        permission_key: permission_key.to_string(),
+        actor_id,
+        granted,
+        idempotency_key: idempotency_key.to_string(),
+    }
+}
+
+async fn table_count(db: &DatabaseConnection, table: &str) -> i64 {
+    db.query_one(Statement::from_string(
+        db.get_database_backend(),
+        format!("SELECT COUNT(*) AS count FROM {table}"),
+    ))
+    .await
+    .expect("count table")
+    .expect("count row")
+    .try_get("", "count")
+    .expect("decode count")
+}
+
+async fn event_grants(db: &DatabaseConnection) -> Vec<bool> {
+    db.query_all(Statement::from_string(
+        db.get_database_backend(),
+        "SELECT granted FROM rbac_artifact_permission_events ORDER BY rowid".to_string(),
+    ))
+    .await
+    .expect("load published events")
+    .into_iter()
+    .map(|row| row.try_get("", "granted").expect("decode granted"))
+    .collect()
+}
+
+#[tokio::test]
+async fn only_state_changes_publish_artifact_permission_events() {
+    let db = setup_database().await;
+    let tenant_id = Uuid::new_v4();
+    let role_id = Uuid::new_v4();
+    let installation_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    let permission_key = "sample.events.handle";
+    insert_scope(&db, tenant_id, role_id, installation_id, permission_key).await;
+
+    let service = RbacArtifactPermissionAssignmentService::new(
+        db.clone(),
+        Arc::new(SqliteArtifactPermissionEventPublisher { fail: false }),
+    );
+    let grant = command(
+        tenant_id,
+        role_id,
+        installation_id,
+        actor_id,
+        permission_key,
+        true,
+        "grant-1",
+    );
+
+    assert!(service.assign(grant.clone()).await.expect("grant").applied);
+    assert!(!service.assign(grant).await.expect("exact retry").applied);
+    assert!(
+        service
+            .assign(command(
+                tenant_id,
+                role_id,
+                installation_id,
+                actor_id,
+                permission_key,
+                true,
+                "grant-confirmation",
+            ))
+            .await
+            .expect("grant state confirmation")
+            .applied
+    );
+    assert_eq!(event_grants(&db).await, vec![true]);
+
+    assert!(
+        service
+            .assign(command(
+                tenant_id,
+                role_id,
+                installation_id,
+                actor_id,
+                permission_key,
+                false,
+                "revoke-1",
+            ))
+            .await
+            .expect("revoke")
+            .applied
+    );
+    assert!(
+        service
+            .assign(command(
+                tenant_id,
+                role_id,
+                installation_id,
+                actor_id,
+                permission_key,
+                false,
+                "revoke-confirmation",
+            ))
+            .await
+            .expect("revoke state confirmation")
+            .applied
+    );
+    assert_eq!(event_grants(&db).await, vec![true, false]);
+}
+
+#[tokio::test]
+async fn publication_failure_rolls_back_grant_and_idempotency_receipt() {
+    let db = setup_database().await;
+    let tenant_id = Uuid::new_v4();
+    let role_id = Uuid::new_v4();
+    let installation_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    let permission_key = "sample.events.handle";
+    insert_scope(&db, tenant_id, role_id, installation_id, permission_key).await;
+
+    let service = RbacArtifactPermissionAssignmentService::new(
+        db.clone(),
+        Arc::new(SqliteArtifactPermissionEventPublisher { fail: true }),
+    );
+    let error = service
+        .assign(command(
+            tenant_id,
+            role_id,
+            installation_id,
+            actor_id,
+            permission_key,
+            true,
+            "grant-without-publication",
+        ))
+        .await
+        .expect_err("publisher failure must fail closed");
+
+    assert!(matches!(
+        error,
+        ArtifactPermissionAssignmentError::Database(_)
+    ));
+    assert_eq!(table_count(&db, "rbac_artifact_role_permissions").await, 0);
+    assert_eq!(
+        table_count(&db, "rbac_artifact_role_permission_operations").await,
+        0
+    );
+    assert_eq!(table_count(&db, "rbac_artifact_permission_events").await, 0);
+}

--- a/crates/rustok-rbac/tests/artifact_permission_tenant_integrity_sqlite.rs
+++ b/crates/rustok-rbac/tests/artifact_permission_tenant_integrity_sqlite.rs
@@ -1,0 +1,242 @@
+use rustok_core::module::MigrationSource;
+use rustok_rbac::RbacModule;
+use sea_orm::{ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement};
+use sea_orm_migration::SchemaManager;
+use uuid::Uuid;
+
+async fn base_database() -> DatabaseConnection {
+    let db = Database::connect("sqlite::memory:")
+        .await
+        .expect("connect SQLite");
+    db.execute_unprepared(
+        r#"
+        PRAGMA foreign_keys = ON;
+        CREATE TABLE users (id TEXT PRIMARY KEY NOT NULL, tenant_id TEXT NOT NULL);
+        CREATE TABLE roles (id TEXT PRIMARY KEY NOT NULL, tenant_id TEXT NOT NULL);
+        CREATE TABLE permissions (id TEXT PRIMARY KEY NOT NULL, tenant_id TEXT NOT NULL);
+        CREATE TABLE user_roles (user_id TEXT NOT NULL, role_id TEXT NOT NULL);
+        CREATE TABLE role_permissions (role_id TEXT NOT NULL, permission_id TEXT NOT NULL);
+        "#,
+    )
+    .await
+    .expect("create RBAC parent tables");
+    db
+}
+
+async fn apply_migrations(db: &DatabaseConnection, count: usize) {
+    let manager = SchemaManager::new(db);
+    let migrations = RbacModule.migrations();
+    assert_eq!(migrations.len(), 5, "RBAC migration inventory changed");
+    for migration in migrations.into_iter().take(count) {
+        migration.up(&manager).await.expect("apply RBAC migration");
+    }
+}
+
+async fn execute(db: &DatabaseConnection, sql: impl Into<String>) -> Result<(), String> {
+    db.execute(Statement::from_string(DbBackend::Sqlite, sql.into()))
+        .await
+        .map(|_| ())
+        .map_err(|error| error.to_string())
+}
+
+async fn count(db: &DatabaseConnection, table: &str) -> i64 {
+    db.query_one(Statement::from_string(
+        DbBackend::Sqlite,
+        format!("SELECT COUNT(*) AS count FROM {table}"),
+    ))
+    .await
+    .expect("count query")
+    .expect("count row")
+    .try_get("", "count")
+    .expect("count value")
+}
+
+fn quoted(value: Uuid) -> String {
+    format!("'{value}'")
+}
+
+#[tokio::test]
+async fn migration_cleans_legacy_malformed_artifact_rows() {
+    let db = base_database().await;
+    apply_migrations(&db, 4).await;
+
+    let tenant_id = Uuid::new_v4();
+    let role_id = Uuid::new_v4();
+    let installation_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    execute(
+        &db,
+        format!(
+            "INSERT INTO rbac_artifact_role_permissions (id, tenant_id, role_id, installation_id, permission_key, granted_by_actor_id) VALUES ({}, {}, {}, {}, 'sample.events.handle', {})",
+            quoted(Uuid::new_v4()),
+            quoted(tenant_id),
+            quoted(role_id),
+            quoted(installation_id),
+            quoted(actor_id),
+        ),
+    )
+    .await
+    .expect("seed malformed grant");
+    execute(
+        &db,
+        format!(
+            "INSERT INTO rbac_artifact_role_permission_operations (id, tenant_id, idempotency_key, role_id, installation_id, permission_key, actor_id, granted) VALUES ({}, {}, 'legacy-op', {}, {}, 'sample.events.handle', {}, 1)",
+            quoted(Uuid::new_v4()),
+            quoted(tenant_id),
+            quoted(role_id),
+            quoted(installation_id),
+            quoted(actor_id),
+        ),
+    )
+    .await
+    .expect("seed malformed receipt");
+
+    let manager = SchemaManager::new(&db);
+    RbacModule
+        .migrations()
+        .into_iter()
+        .nth(4)
+        .expect("artifact integrity migration")
+        .up(&manager)
+        .await
+        .expect("apply artifact integrity migration");
+
+    assert_eq!(count(&db, "rbac_artifact_role_permissions").await, 0);
+    assert_eq!(
+        count(&db, "rbac_artifact_role_permission_operations").await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn database_rejects_cross_tenant_and_orphan_artifact_state() {
+    let db = base_database().await;
+    apply_migrations(&db, 5).await;
+
+    let tenant_a = Uuid::new_v4();
+    let tenant_b = Uuid::new_v4();
+    let role_a = Uuid::new_v4();
+    let role_b = Uuid::new_v4();
+    let actor_a = Uuid::new_v4();
+    let actor_b = Uuid::new_v4();
+    let installation_id = Uuid::new_v4();
+    let catalog_id = Uuid::new_v4();
+
+    for sql in [
+        format!(
+            "INSERT INTO roles (id, tenant_id) VALUES ({}, {})",
+            quoted(role_a),
+            quoted(tenant_a)
+        ),
+        format!(
+            "INSERT INTO roles (id, tenant_id) VALUES ({}, {})",
+            quoted(role_b),
+            quoted(tenant_b)
+        ),
+        format!(
+            "INSERT INTO users (id, tenant_id) VALUES ({}, {})",
+            quoted(actor_a),
+            quoted(tenant_a)
+        ),
+        format!(
+            "INSERT INTO users (id, tenant_id) VALUES ({}, {})",
+            quoted(actor_b),
+            quoted(tenant_b)
+        ),
+        format!(
+            "INSERT INTO rbac_artifact_permission_catalog (id, scope_key, installation_id, module_slug, release_digest, permission_key, locale, label, description, registered_at) VALUES ({}, 'tenant:{}', {}, 'sample', 'sha256:test', 'sample.events.handle', 'en', 'Handle events', 'Allows handling events', '2026-08-01T00:00:00Z')",
+            quoted(catalog_id),
+            tenant_a,
+            quoted(installation_id)
+        ),
+    ] {
+        execute(&db, sql).await.expect("seed valid parent state");
+    }
+
+    execute(
+        &db,
+        format!(
+            "INSERT INTO rbac_artifact_role_permissions (id, tenant_id, role_id, installation_id, permission_key, granted_by_actor_id) VALUES ({}, {}, {}, {}, 'sample.events.handle', {})",
+            quoted(Uuid::new_v4()),
+            quoted(tenant_a),
+            quoted(role_a),
+            quoted(installation_id),
+            quoted(actor_a),
+        ),
+    )
+    .await
+    .expect("valid artifact grant");
+    execute(
+        &db,
+        format!(
+            "INSERT INTO rbac_artifact_role_permission_operations (id, tenant_id, idempotency_key, role_id, installation_id, permission_key, actor_id, granted) VALUES ({}, {}, 'valid-op', {}, {}, 'sample.events.handle', {}, 1)",
+            quoted(Uuid::new_v4()),
+            quoted(tenant_a),
+            quoted(role_a),
+            quoted(installation_id),
+            quoted(actor_a),
+        ),
+    )
+    .await
+    .expect("valid artifact receipt");
+
+    execute(
+        &db,
+        format!(
+            "UPDATE rbac_artifact_permission_catalog SET label = 'Updated label', description = 'Updated description' WHERE id = {}",
+            quoted(catalog_id)
+        ),
+    )
+    .await
+    .expect("localized metadata update must remain allowed");
+
+    let rejected = [
+        format!(
+            "INSERT INTO rbac_artifact_role_permissions (id, tenant_id, role_id, installation_id, permission_key, granted_by_actor_id) VALUES ({}, {}, {}, {}, 'sample.events.handle', {})",
+            quoted(Uuid::new_v4()), quoted(tenant_a), quoted(role_b), quoted(installation_id), quoted(actor_a)
+        ),
+        format!(
+            "INSERT INTO rbac_artifact_role_permissions (id, tenant_id, role_id, installation_id, permission_key, granted_by_actor_id) VALUES ({}, {}, {}, {}, 'sample.events.handle', {})",
+            quoted(Uuid::new_v4()), quoted(tenant_a), quoted(role_a), quoted(installation_id), quoted(actor_b)
+        ),
+        format!(
+            "INSERT INTO rbac_artifact_role_permissions (id, tenant_id, role_id, installation_id, permission_key, granted_by_actor_id) VALUES ({}, {}, {}, {}, 'sample.unknown', {})",
+            quoted(Uuid::new_v4()), quoted(tenant_a), quoted(role_a), quoted(installation_id), quoted(actor_a)
+        ),
+        format!(
+            "INSERT INTO rbac_artifact_role_permission_operations (id, tenant_id, idempotency_key, role_id, installation_id, permission_key, actor_id, granted) VALUES ({}, {}, 'foreign-op', {}, {}, 'sample.events.handle', {}, 1)",
+            quoted(Uuid::new_v4()), quoted(tenant_a), quoted(role_b), quoted(installation_id), quoted(actor_a)
+        ),
+        format!(
+            "UPDATE roles SET tenant_id = {} WHERE id = {}",
+            quoted(tenant_b), quoted(role_a)
+        ),
+        format!(
+            "UPDATE users SET tenant_id = {} WHERE id = {}",
+            quoted(tenant_b), quoted(actor_a)
+        ),
+        format!("DELETE FROM roles WHERE id = {}", quoted(role_a)),
+        format!("DELETE FROM users WHERE id = {}", quoted(actor_a)),
+        format!(
+            "UPDATE rbac_artifact_permission_catalog SET permission_key = 'sample.changed' WHERE id = {}",
+            quoted(catalog_id)
+        ),
+        format!(
+            "DELETE FROM rbac_artifact_permission_catalog WHERE id = {}",
+            quoted(catalog_id)
+        ),
+    ];
+
+    for sql in rejected {
+        assert!(
+            execute(&db, sql).await.is_err(),
+            "database must reject malformed artifact authorization state"
+        );
+    }
+
+    assert_eq!(count(&db, "rbac_artifact_role_permissions").await, 1);
+    assert_eq!(
+        count(&db, "rbac_artifact_role_permission_operations").await,
+        1
+    );
+}

--- a/modules.toml
+++ b/modules.toml
@@ -42,7 +42,7 @@ search = { crate = "rustok-search", source = "path", path = "crates/rustok-searc
 outbox = { crate = "rustok-outbox", source = "path", path = "crates/rustok-outbox", required = true }
 events = { crate = "rustok-events-module", source = "path", path = "crates/rustok-events-module", required = true, depends_on = ["outbox"] }
 tenant = { crate = "rustok-tenant", source = "path", path = "crates/rustok-tenant", required = true }
-rbac = { crate = "rustok-rbac", source = "path", path = "crates/rustok-rbac", required = true }
+rbac = { crate = "rustok-rbac", source = "path", path = "crates/rustok-rbac", required = true, depends_on = ["outbox"] }
 
 # Domain modules (optional)
 content = { crate = "rustok-content", source = "path", path = "crates/rustok-content" }

--- a/modules.toml.example
+++ b/modules.toml.example
@@ -36,7 +36,7 @@ search = { crate = "rustok-search", source = "path", path = "crates/rustok-searc
 outbox = { crate = "rustok-outbox", source = "path", path = "crates/rustok-outbox", required = true }
 events = { crate = "rustok-events-module", source = "path", path = "crates/rustok-events-module", required = true, depends_on = ["outbox"] }
 tenant = { crate = "rustok-tenant", source = "path", path = "crates/rustok-tenant", required = true }
-rbac = { crate = "rustok-rbac", source = "path", path = "crates/rustok-rbac", required = true }
+rbac = { crate = "rustok-rbac", source = "path", path = "crates/rustok-rbac", required = true, depends_on = ["outbox"] }
 
 # Domain modules (optional)
 content = { crate = "rustok-content", source = "path", path = "crates/rustok-content" }

--- a/scripts/verify/verify-rbac-artifact-permission-outbox.mjs
+++ b/scripts/verify/verify-rbac-artifact-permission-outbox.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+// RBAC artifact permission owner-event and transactional-outbox guardrails.
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+function read(relativePath) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  if (!existsSync(absolutePath)) {
+    failures.push(`${relativePath}: expected file`);
+    return "";
+  }
+  return readFileSync(absolutePath, "utf8");
+}
+
+function requireMarker(text, marker, description) {
+  const found = typeof marker === "string" ? text.includes(marker) : marker.test(text);
+  if (!found) failures.push(description);
+}
+
+function forbidMarker(text, marker, description) {
+  const found = typeof marker === "string" ? text.includes(marker) : marker.test(text);
+  if (found) failures.push(description);
+}
+
+const paths = {
+  modules: "modules.toml",
+  modulesExample: "modules.toml.example",
+  moduleManifest: "crates/rustok-rbac/rustok-module.toml",
+  cargo: "crates/rustok-rbac/Cargo.toml",
+  event: "crates/rustok-events/src/rbac_artifact_permission.rs",
+  eventLib: "crates/rustok-events/src/lib.rs",
+  contract: "crates/rustok-events/src/contract.rs",
+  rbacLib: "crates/rustok-rbac/src/lib.rs",
+  owner: "crates/rustok-rbac/src/artifact_permission_assignment.rs",
+  host: "apps/server/src/controllers/artifact_permissions.rs",
+  integrationTest: "crates/rustok-rbac/tests/artifact_permission_outbox_sqlite.rs",
+};
+
+const content = Object.fromEntries(
+  Object.entries(paths).map(([name, relativePath]) => [name, read(relativePath)]),
+);
+
+const manifestMarker =
+  'rbac = { crate = "rustok-rbac", source = "path", path = "crates/rustok-rbac", required = true, depends_on = ["outbox"] }';
+requireMarker(
+  content.modules,
+  manifestMarker,
+  `${paths.modules}: RBAC Core module must declare Outbox dependency`,
+);
+requireMarker(
+  content.modulesExample,
+  manifestMarker,
+  `${paths.modulesExample}: example topology must mirror the RBAC Outbox dependency`,
+);
+requireMarker(
+  content.moduleManifest,
+  'outbox = { version_req = ">=0.1.0" }',
+  `${paths.moduleManifest}: Outbox module dependency missing`,
+);
+forbidMarker(
+  content.cargo,
+  "rustok-outbox.workspace = true",
+  `${paths.cargo}: RBAC owner must depend on its publisher port, not the concrete Outbox crate`,
+);
+
+for (const marker of [
+  "pub enum RbacArtifactPermissionEvent",
+  "AssignmentChanged",
+  'event_type: "rbac.artifact_role_permission.assignment_changed"',
+  "impl sealed::Sealed for RbacArtifactPermissionEvent",
+  "impl EventContract for RbacArtifactPermissionEvent",
+  "impl ValidateEvent for RbacArtifactPermissionEvent",
+  'validate_not_nil_uuid("operation_id", operation_id)',
+  "validate_max_length(",
+]) {
+  requireMarker(content.event, marker, `${paths.event}: event contract missing ${marker}`);
+}
+for (const marker of [
+  "mod rbac_artifact_permission;",
+  "RBAC_ARTIFACT_PERMISSION_EVENT_SCHEMAS",
+  "rbac_artifact_permission_event_schema",
+  ".chain(RBAC_ARTIFACT_PERMISSION_EVENT_SCHEMAS.iter())",
+]) {
+  requireMarker(content.eventLib, marker, `${paths.eventLib}: registry missing ${marker}`);
+}
+for (const marker of [
+  "RbacArtifactPermission(RbacArtifactPermissionEvent)",
+  "Self::RbacArtifactPermission(event) => event.event_type()",
+  "Self::RbacArtifactPermission(event) => event.schema_version()",
+  "Self::RbacArtifactPermission(event) => event.validate()",
+]) {
+  requireMarker(content.contract, marker, `${paths.contract}: sealed payload missing ${marker}`);
+}
+for (const marker of [
+  "ArtifactPermissionEventPublisher",
+  "fn dependencies(&self) -> &[&'static str]",
+  '&["outbox"]',
+]) {
+  requireMarker(content.rbacLib, marker, `${paths.rbacLib}: runtime contract missing ${marker}`);
+}
+
+for (const marker of [
+  "pub trait ArtifactPermissionEventPublisher",
+  "transaction: &DatabaseTransaction",
+  "event_publisher: Arc<dyn ArtifactPermissionEventPublisher>",
+  "let operation_id = match insert_operation",
+  "let changed = if command.granted",
+  "if changed",
+  ".publish_assignment_changed(",
+  "assignment_event(operation_id, &command)",
+  "transaction.rollback().await.map_err(database_error)?",
+  "transaction.commit().await.map_err(database_error)?",
+  "then_some(operation_id)",
+  "Ok(result.rows_affected() == 1)",
+]) {
+  requireMarker(content.owner, marker, `${paths.owner}: transactional owner path missing ${marker}`);
+}
+forbidMarker(
+  content.owner,
+  "rustok_outbox",
+  `${paths.owner}: owner must not import concrete Outbox types`,
+);
+const changedIndex = content.owner.indexOf("if changed");
+const publishIndex = content.owner.indexOf(".publish_assignment_changed(", changedIndex);
+const rollbackIndex = content.owner.indexOf(
+  "transaction.rollback().await.map_err(database_error)?",
+  publishIndex,
+);
+const commitIndex = content.owner.indexOf(
+  "transaction.commit().await.map_err(database_error)?",
+  publishIndex,
+);
+if (
+  !(
+    changedIndex >= 0 &&
+    publishIndex > changedIndex &&
+    rollbackIndex > publishIndex &&
+    commitIndex > rollbackIndex
+  )
+) {
+  failures.push(
+    `${paths.owner}: expected state change -> publisher port -> failure rollback -> commit order`,
+  );
+}
+const existingIndex = content.owner.indexOf("if let Some(existing) = find_operation");
+if (!(existingIndex >= 0 && existingIndex < publishIndex)) {
+  failures.push(`${paths.owner}: exact retry lookup must precede event publication`);
+}
+
+for (const marker of [
+  "TransactionalOutboxArtifactPermissionEventPublisher",
+  "impl ArtifactPermissionEventPublisher",
+  ".publish_contract_in_tx(",
+  "transactional_event_bus_from_context",
+  "Arc::new(TransactionalOutboxArtifactPermissionEventPublisher::new(",
+  "RbacArtifactPermissionAssignmentService::new(ctx.db_clone(), event_publisher)",
+  "transactional_outbox_adapter_writes_typed_event",
+  '"rbac.artifact_role_permission.assignment_changed"',
+]) {
+  requireMarker(content.host, marker, `${paths.host}: host Outbox adapter missing ${marker}`);
+}
+
+for (const marker of [
+  "impl ArtifactPermissionEventPublisher for SqliteArtifactPermissionEventPublisher",
+  "only_state_changes_publish_artifact_permission_events",
+  "assert_eq!(event_grants(&db).await, vec![true])",
+  "assert_eq!(event_grants(&db).await, vec![true, false])",
+  "publication_failure_rolls_back_grant_and_idempotency_receipt",
+  "publisher failure must fail closed",
+  'table_count(&db, "rbac_artifact_role_permissions")',
+  'table_count(&db, "rbac_artifact_role_permission_operations")',
+  'table_count(&db, "rbac_artifact_permission_events")',
+]) {
+  requireMarker(
+    content.integrationTest,
+    marker,
+    `${paths.integrationTest}: executable owner regression missing ${marker}`,
+  );
+}
+forbidMarker(
+  content.integrationTest,
+  "rustok_outbox",
+  `${paths.integrationTest}: owner regression must remain transport-neutral`,
+);
+
+if (failures.length > 0) {
+  console.error("RBAC artifact permission outbox verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("RBAC artifact permission outbox verification passed");

--- a/scripts/verify/verify-rbac-artifact-permission-tenant-integrity.mjs
+++ b/scripts/verify/verify-rbac-artifact-permission-tenant-integrity.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const root = process.cwd();
+const read = (relative) => readFileSync(path.join(root, relative), "utf8");
+const requireText = (source, text, label) => {
+  if (!source.includes(text)) {
+    throw new Error(`${label}: missing ${JSON.stringify(text)}`);
+  }
+};
+
+const migration = read(
+  "crates/rustok-rbac/src/m20260801_000001_enforce_artifact_permission_tenant_integrity.rs",
+);
+const exports = read("crates/rustok-rbac/src/lib.rs");
+const owner = read("crates/rustok-rbac/src/artifact_permission_assignment.rs");
+const sqliteProof = read(
+  "crates/rustok-rbac/tests/artifact_permission_tenant_integrity_sqlite.rs",
+);
+
+for (const text of [
+  "m20260801_000001_enforce_artifact_permission_tenant_integrity",
+  "m20260717_000001_artifact_role_permissions::Migration",
+  "m20260801_000001_enforce_artifact_permission_tenant_integrity::Migration",
+]) {
+  requireText(exports, text, "migration registration");
+}
+const tableMigration = exports.indexOf(
+  "m20260717_000001_artifact_role_permissions::Migration",
+);
+const integrityMigration = exports.indexOf(
+  "m20260801_000001_enforce_artifact_permission_tenant_integrity::Migration",
+);
+if (!(tableMigration < integrityMigration)) {
+  throw new Error("artifact integrity migration must run after artifact tables exist");
+}
+
+for (const text of [
+  "DELETE FROM rbac_artifact_role_permissions",
+  "DELETE FROM rbac_artifact_role_permission_operations",
+  "rustok_enforce_artifact_role_permission_integrity",
+  "rustok_enforce_artifact_role_permission_operation_integrity",
+  "trg_rbac_users_tenant_update",
+  "trg_rbac_roles_tenant_update",
+  "trg_rbac_artifact_role_delete",
+  "trg_rbac_artifact_actor_delete",
+  "trg_rbac_artifact_permission_catalog_identity_update",
+  "trg_rbac_artifact_permission_catalog_delete",
+  "RBAC referenced artifact permission identity is immutable",
+  "sqlite_trigger_names() -> [&'static str; 10]",
+  "sqlite_triggers() -> [&'static str; 10]",
+]) {
+  requireText(migration, text, "artifact tenant integrity migration");
+}
+
+const existing = owner.indexOf("find_operation(&transaction, &command)");
+const role = owner.indexOf("if !role_exists(&transaction, &command).await?");
+const permission = owner.indexOf(
+  "if !permission_is_registered(&transaction, &command).await?",
+);
+const insert = owner.indexOf("insert_operation(&transaction, &command)");
+if (!(existing < role && role < permission && permission < insert)) {
+  throw new Error(
+    "owner ordering must be existing receipt -> typed role/catalog validation -> receipt insert",
+  );
+}
+requireText(
+  owner,
+  "database-integrity\n        // triggers preserve the stable RoleNotFound/PermissionNotRegistered contract",
+  "stable typed error contract",
+);
+
+for (const text of [
+  "migration_cleans_legacy_malformed_artifact_rows",
+  "database_rejects_cross_tenant_and_orphan_artifact_state",
+  "module_slug, release_digest, permission_key, locale, label, description, registered_at",
+  "UPDATE rbac_artifact_permission_catalog SET label = 'Updated label'",
+  "UPDATE roles SET tenant_id",
+  "UPDATE users SET tenant_id",
+  "DELETE FROM roles WHERE id",
+  "DELETE FROM users WHERE id",
+  "UPDATE rbac_artifact_permission_catalog SET permission_key",
+  "DELETE FROM rbac_artifact_permission_catalog",
+]) {
+  requireText(sqliteProof, text, "SQLite artifact integrity proof");
+}
+
+console.log("RBAC artifact permission tenant-integrity source contract verified");


### PR DESCRIPTION
## Cycle scope

Continue `cycle-001` at the active `core/rbac` cursor without advancing or completing the component.

## Reconciled additive P1 packet

Merged PR #2867 owns canonical built-in user-role policy and the durable `rbac.user_role_replaced` / `rbac.user_role_assignment_repaired` event family. This draft is built directly on that merge and does not duplicate or replace it.

It reconciles four remaining P1 corrections.

### 1. Read-only permission resolver

- remove role-assignment mutation methods from `PermissionResolver` and `RuntimePermissionResolver`;
- remove `RoleAssignmentStore`, its server adapter and direct persistence delegation;
- retain no compatibility mutation alias, deprecated wrapper or local-only invalidation bypass;
- keep existing-user role mutation on the merged #2867 owner policy and caller transaction.

### 2. Transactional artifact-permission events

- add sealed `rbac.artifact_role_permission.assignment_changed` v1 alongside the merged role-mutation family;
- keep command validation, idempotency, state-change detection and publication timing in `rustok-rbac`;
- publish through the canonical Outbox in the same live owner transaction;
- roll back mutation and idempotency receipt when required publication fails;
- emit no event for an exact retry or state no-op;
- bind tenant and actor through envelope metadata;
- declare the RBAC -> Outbox runtime dependency consistently.

### 3. Auth admin effective status and row no-ops

- preserve merged #2867 `plan_user_role_mutation` as the canonical exact-role no-op / malformed-repair policy;
- compare requested status with the locked user row;
- skip `users` update when the request contains only exact role/status replay;
- reserve durable generation only for a real role plan or status transition;
- revoke sessions for disabled status only on an actual transition;
- retain merged #2867 typed role events for replacement and relation repair without adding a parallel family.

### 4. Artifact authorization database integrity

- add an incremental PostgreSQL/SQLite migration after the artifact tables;
- remove legacy grant and idempotency rows whose role, actor or admitted catalog scope is invalid;
- reject cross-tenant or orphan grant and receipt inserts/updates at the database boundary;
- extend role/user tenant-update guards to referenced artifact state;
- reject role/user deletes that would orphan active grants or operation receipts;
- keep referenced catalog identity immutable while allowing label/description upserts;
- validate role and catalog scope before receipt insertion so immediate database triggers preserve typed `RoleNotFound` and `PermissionNotRegistered` errors;
- add SQLite cleanup/integrity coverage and a fail-closed source verifier.

## Fresh-main state

Built on `main@449976b2a92b41e5b5d772708c2aad31e0e7eeed`, which includes merged #2867.

Current head: `f18212ac1d1dfa0dbc02aed938bef82ef680e332`.

The branch contains one clean commit, is one commit ahead and zero behind `main`, is mergeable, and changes 27 files with 2,494 additions and 1,245 deletions. The larger documentation delta intentionally consolidates stale RBAC/Events plans around the merged #2867 owner contract and this additive draft.

## Supersession boundary

Historical drafts #2843, #2847 and #2863 were cross-linked and closed without merge. Their unique corrections are retained here. They must not be reopened or merged in addition to #2866.

This draft deliberately retains all #2867 files and contracts, including owner policy, hierarchy/continuity decisions, role replacement/repair event variants and the existing source verifier.

## Digest and validation status

Only the artifact permission family adds a new digest relative to current `main`. The repository-generated artifact is intentionally absent and must not be guessed or hand-edited.

Required digest command:

```bash
cargo run -p rustok-events --example event_contract_digests -- --write
```

Targeted gates:

```bash
cargo fmt --all -- --check
cargo check -p rustok-events --all-targets
cargo check -p rustok-rbac --all-features
cargo check -p rustok-rbac-admin --features ssr
cargo check -p rustok-server --lib
cargo test -p rustok-events rbac_role_mutation
cargo test -p rustok-events --test rbac_artifact_permission_contracts
cargo test -p rustok-rbac role_mutation
cargo test -p rustok-rbac --test artifact_permission_outbox_sqlite
cargo test -p rustok-rbac --test artifact_permission_tenant_integrity_sqlite
cargo test -p rustok-server auth_admin_mutation_provider
cargo test -p rustok-server status_effective_change_ignores_exact_replay
cargo test -p rustok-server --test rbac_permission_resolver_read_only_guard
cargo test -p rustok-server --test rbac_auth_admin_effective_noop_guard
cargo test -p rustok-server --test rbac_mutation_api_architecture_guard
node scripts/verify/verify-rbac-owner-role-mutation-contract.mjs
node scripts/verify/verify-rbac-artifact-permission-outbox.mjs
node scripts/verify/verify-rbac-artifact-permission-tenant-integrity.mjs
cargo xtask module validate rbac
cargo xtask module test rbac
```

Real PostgreSQL apply/integrity/rollback execution remains mandatory for the new migration.

No formatting, compilation, Rust/Node test, verifier, digest generation, SQLite/PostgreSQL execution, Redis, subprocess, workflow or CI pass is claimed.

The `core/rbac` cursor remains `in_progress`. Exact-head execution, hard-deletion cleanup ordering, retained #2849/#2853/#2856/#2862 runtime evidence, incident execution, custom-role/permission ownership, native operator parity and FFA/FBA evidence remain open.