### PR TITLE
fix(forum): align FORUM-21D verifier with topic lifecycle

### DIFF
--- a/scripts/verify/verify-forum-topic-merge-read-state-reconciliation.mjs
+++ b/scripts/verify/verify-forum-topic-merge-read-state-reconciliation.mjs
@@ -9,6 +9,7 @@ const docsPath =
   "crates/rustok-forum/docs/forum-21d-topic-merge-read-state-reconciliation.md";
 const entityPath =
   "crates/rustok-forum/src/entities/forum_topic_merge_read_state_reconciliation.rs";
+const topicEntityPath = "crates/rustok-forum/src/entities/forum_topic.rs";
 const entitiesModPath = "crates/rustok-forum/src/entities/mod.rs";
 const errorPath = "crates/rustok-forum/src/error.rs";
 const libPath = "crates/rustok-forum/src/lib.rs";
@@ -41,6 +42,7 @@ function includesAll(text, markers, label) {
 const contract = JSON.parse(read(contractPath));
 const docs = read(docsPath);
 const entity = read(entityPath);
+const topicEntity = read(topicEntityPath);
 const entitiesMod = read(entitiesModPath);
 const error = read(errorPath);
 const lib = read(libPath);
@@ -196,12 +198,19 @@ includesAll(
   [
     "lock_active_topic_read_state_write_in_tx(&txn, tenant_id, topic_id).await?;",
     "lock_topic_read_state_scopes_in_tx(&txn, tenant_id, &[topic_id]).await?;",
-    "forum_topic::Column::DeletedAt.is_null()",
     "forum_topic::Column::Status.ne(TopicStatus::Archived)",
     "lock_active_topic_read_state_writes_in_tx(&txn, tenant_id, &topic_ids).await?;",
     "lock_topic_read_state_scopes_in_tx(&txn, tenant_id, &topic_ids).await?;",
   ],
   "raw read tracking",
+);
+assert.ok(
+  !topicEntity.includes("pub deleted_at:"),
+  "forum topic entity must not expose a nonexistent deleted_at field",
+);
+assert.ok(
+  !readTracking.includes("forum_topic::Column::DeletedAt"),
+  "raw read tracking must not reference the nonexistent forum topic DeletedAt column",
 );
 const singleTopicLock = readTracking.indexOf(
   "lock_active_topic_read_state_write_in_tx(&txn, tenant_id, topic_id).await?;",
@@ -229,13 +238,16 @@ assert.ok(bulkScopeLock < bulkHighWater);
 includesAll(
   readTrackingAudience,
   [
-    "forum_topic::Column::DeletedAt.is_null()",
     "forum_topic::Column::Status.ne(TopicStatus::Archived)",
     "lock_active_topic_read_state_writes_in_tx(",
     "lock_topic_read_state_scopes_in_tx(&write_txn, tenant_id, &visible_topic_ids)",
     "latest_public_positions_in_tx(&write_txn, tenant_id, &visible_topic_ids)",
   ],
   "visibility-scoped read tracking",
+);
+assert.ok(
+  !readTrackingAudience.includes("forum_topic::Column::DeletedAt"),
+  "visibility-scoped read tracking must not reference the nonexistent forum topic DeletedAt column",
 );
 assert.ok(
   readTrackingAudience.indexOf("lock_active_topic_read_state_writes_in_tx(") <


### PR DESCRIPTION
## Audit finding

The merged `FORUM-21D` source verifier still required `forum_topic::Column::DeletedAt.is_null()` in both raw and visibility-scoped read tracking. Commit `3024675a5050a7b86291ac2e1cee1729317de77e` correctly removed those filters because `forum_topic::Model` has no `deleted_at` field, leaving the maintainer verifier guaranteed to fail against current `main`.

## What changed

- remove the stale positive markers for the nonexistent `DeletedAt` column;
- retain the real archived-topic exclusion marker;
- read the canonical `forum_topic` entity in the verifier;
- fail closed if a `deleted_at` field or `forum_topic::Column::DeletedAt` reference is reintroduced in either read-state path.

## Recheck scope

The `FORUM-21A` through `FORUM-21D` merged sequence and its current plan boundary were reviewed. No other repository occurrence of `forum_topic::Column::DeletedAt` remains outside the stale D verifier. Canonical `FORUM-21` stays `planned`; this PR changes no runtime behavior, migration, API, event, task status or evidence claim.

## Validation

Tests, Node verifiers, formatting, Cargo checks, workflows and CI were not run, per maintainer request.