### PR TITLE
feat(index): replay SalesChannel tombstones

### DIFF
--- a/crates/rustok-channel/README.md
+++ b/crates/rustok-channel/README.md
@@ -16,9 +16,9 @@
 - Back the shared request-level `ChannelContext` used by host transport layers.
 - Own the domain resolution pipeline (`RequestFacts -> ResolutionDecision`) that host middleware applies.
 - Own the durable database generation used to recover channel-resolution caches across serving replicas.
-- Own a positive monotonic `channels.index_revision` storage column. Every Channel update advances it exactly once; the value remains storage-internal and is not exposed through Channel DTOs or the SeaORM write model.
+- Own a positive monotonic `channels.index_revision` storage column and retained `channel_index_tombstones`. Every Channel update advances the live revision exactly once; hard deletion retains an exact source version strictly above the final live row. These values remain storage-internal and are not exposed through Channel DTOs or the SeaORM write model.
 - Publish only a neutral `ChannelRuntimeSelected` marker for selected cross-module composition. The Channel crate does not depend on `rustok-index` and does not construct generic Index mutations.
-- The selected `rustok-distribution` bridge publishes the non-localized `rustok-channel::sales_channel@1` schema and a bounded current-state source. Replay enumeration uses stable `channel_id` ordering, while `index_revision` is used only as generic mutation `source_version`. Hard-delete tombstones, versioned Product links, and authoritative consumer cutover remain later slices.
+- The selected `rustok-distribution` bridge publishes the non-localized `rustok-channel::sales_channel@1` schema and one bounded source. Replay enumeration uses stable `channel_id` ordering and returns live upserts or retained hard-delete mutations from the same source identity; `index_revision` is used only as generic mutation `source_version`. Incremental acknowledgement, versioned Product links, and authoritative consumer cutover remain later slices.
 - Ship the module-owned Leptos admin UI package for channel management.
 - Expose `ChannelReadPort` / `channel.read_projection.v1` as the FBA provider boundary for channel/default/host-target read projections, with deadline-aware read semantics and no-compile executable fallback smoke evidence until executable runtime smoke is available.
 
@@ -27,6 +27,7 @@
 This crate intentionally ships a minimal v0 model:
 
 - `channels`
+- `channel_index_tombstones` as storage-internal replay identity state
 - `channel_targets`
 - `channel_module_bindings`
 - `channel_oauth_apps`
@@ -57,7 +58,7 @@ Previously validated baseline:
 - `npm run verify:channel:resolution-contract` (no-compile resolution order and built-in host fast-path decision gate)
 - `npm run verify:channel:proof-points` (no-compile pages/blog/commerce/forum proof-point source/docs sync gate)
 
-The new durable-generation path remains source-complete until the current permanent cache workflow and multi-replica failure-recovery scenarios pass on the same revision.
+The new durable-generation path remains source-complete until the current permanent cache workflow and multi-replica failure-recovery scenarios pass on the same revision. The Index tombstone path likewise remains source-complete until the owner executes delete/recreate and replay evidence.
 
 It does not yet provide:
 
@@ -73,7 +74,7 @@ It does not yet provide:
 - `rustok-cache` supplies bounded invalidation transport; Redis PubSub is an acceleration path rather than the durable source of truth.
 - `rustok-api` hosts the shared `ChannelContext` and request-level contracts.
 - `rustok-auth` remains the source of truth for OAuth applications and tokens.
-- `rustok-distribution` consumes the neutral selection marker and Channel-owned table contract to publish generic SalesChannel Index schema/source capabilities; Index core and server remain Channel-agnostic.
+- `rustok-distribution` consumes the neutral selection marker and Channel-owned live/tombstone table contract to publish generic SalesChannel Index schema/source capabilities; Index core and server remain Channel-agnostic.
 - Domain modules may gradually become channel-aware by reading channel context or channel bindings.
 - The Leptos admin UI lives in `crates/rustok-channel/admin` and is mounted by `apps/admin` through manifest-driven wiring.
 
@@ -89,6 +90,7 @@ It does not yet provide:
 ## Next Steps
 
 - Execute the permanent cache workflow and multi-replica durable-generation recovery scenarios.
+- Execute SalesChannel hard-delete, identity-reuse, replay, reconciliation, and restart evidence before admitting an authoritative Index consumer.
 - Keep the current `channel_module_bindings + metadata` model for v0 while `pages` and `blog` continue to serve as proof points.
 - Revisit a dedicated relation model only if future domains need stronger DB-level querying, authoring UX, or semantics that request-time filtering can no longer cover cleanly.
 - Decide later whether `target`, `connector`, and publishable credentials should become separate concepts.

--- a/crates/rustok-channel/src/migrations/m20260731_000011_add_channel_index_tombstones.rs
+++ b/crates/rustok-channel/src/migrations/m20260731_000011_add_channel_index_tombstones.rs
@@ -1,0 +1,220 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::DatabaseBackend;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() != DatabaseBackend::Postgres {
+            return Err(DbErr::Custom(
+                "rustok-channel migrations require PostgreSQL".to_owned(),
+            ));
+        }
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+CREATE TABLE channel_index_tombstones (
+    tenant_id UUID NOT NULL,
+    channel_id UUID NOT NULL,
+    source_version BIGINT NOT NULL,
+    deleted_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (tenant_id, channel_id),
+    CONSTRAINT chk_channel_index_tombstones_source_version_positive CHECK (source_version > 0)
+);
+
+CREATE OR REPLACE FUNCTION rustok_channel_store_index_tombstone(
+    target_tenant_id UUID,
+    target_channel_id UUID,
+    target_source_version BIGINT
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    INSERT INTO channel_index_tombstones (
+        tenant_id,
+        channel_id,
+        source_version,
+        deleted_at
+    ) VALUES (
+        target_tenant_id,
+        target_channel_id,
+        target_source_version,
+        CURRENT_TIMESTAMP
+    )
+    ON CONFLICT (tenant_id, channel_id) DO UPDATE
+    SET source_version = GREATEST(
+            channel_index_tombstones.source_version,
+            EXCLUDED.source_version
+        ),
+        deleted_at = CURRENT_TIMESTAMP;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION rustok_channel_clear_superseded_index_tombstone(
+    target_tenant_id UUID,
+    target_channel_id UUID,
+    live_source_version BIGINT
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM channel_index_tombstones tombstone
+        WHERE tombstone.tenant_id = target_tenant_id
+          AND tombstone.channel_id = target_channel_id
+          AND tombstone.source_version >= live_source_version
+    ) THEN
+        RAISE EXCEPTION
+            'channel live index revision does not supersede retained tombstone for channel %',
+            target_channel_id;
+    END IF;
+
+    DELETE FROM channel_index_tombstones
+    WHERE tenant_id = target_tenant_id
+      AND channel_id = target_channel_id
+      AND source_version < live_source_version;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION rustok_channel_seed_index_revision_from_tombstone()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    retained_source_version BIGINT;
+BEGIN
+    SELECT source_version
+      INTO retained_source_version
+      FROM channel_index_tombstones
+     WHERE tenant_id = NEW.tenant_id
+       AND channel_id = NEW.id;
+
+    IF retained_source_version IS NOT NULL THEN
+        IF retained_source_version = 9223372036854775807 THEN
+            RAISE EXCEPTION 'channel index revision exhausted for reused channel %', NEW.id;
+        END IF;
+        NEW.index_revision := GREATEST(NEW.index_revision, retained_source_version + 1);
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_channels_seed_index_revision
+BEFORE INSERT ON channels
+FOR EACH ROW
+EXECUTE FUNCTION rustok_channel_seed_index_revision_from_tombstone();
+
+CREATE OR REPLACE FUNCTION rustok_channel_capture_index_tombstone()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.index_revision = 9223372036854775807 THEN
+        RAISE EXCEPTION 'channel index revision exhausted for deleted channel %', OLD.id;
+    END IF;
+
+    PERFORM rustok_channel_store_index_tombstone(
+        OLD.tenant_id,
+        OLD.id,
+        OLD.index_revision + 1
+    );
+    RETURN OLD;
+END;
+$$;
+
+CREATE TRIGGER trg_channels_capture_index_tombstone
+BEFORE DELETE ON channels
+FOR EACH ROW
+EXECUTE FUNCTION rustok_channel_capture_index_tombstone();
+
+CREATE OR REPLACE FUNCTION rustok_channel_clear_inserted_index_tombstone()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM rustok_channel_clear_superseded_index_tombstone(
+        NEW.tenant_id,
+        NEW.id,
+        NEW.index_revision
+    );
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_channels_clear_index_tombstone
+AFTER INSERT ON channels
+FOR EACH ROW
+EXECUTE FUNCTION rustok_channel_clear_inserted_index_tombstone();
+
+CREATE OR REPLACE FUNCTION rustok_channel_move_index_tombstone()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.tenant_id IS NOT DISTINCT FROM NEW.tenant_id
+       AND OLD.id IS NOT DISTINCT FROM NEW.id THEN
+        RETURN NEW;
+    END IF;
+
+    PERFORM rustok_channel_store_index_tombstone(
+        OLD.tenant_id,
+        OLD.id,
+        NEW.index_revision
+    );
+    PERFORM rustok_channel_clear_superseded_index_tombstone(
+        NEW.tenant_id,
+        NEW.id,
+        NEW.index_revision
+    );
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_channels_move_index_tombstone
+AFTER UPDATE OF id, tenant_id ON channels
+FOR EACH ROW
+EXECUTE FUNCTION rustok_channel_move_index_tombstone();
+"#,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() != DatabaseBackend::Postgres {
+            return Err(DbErr::Custom(
+                "rustok-channel migrations require PostgreSQL".to_owned(),
+            ));
+        }
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+DROP TRIGGER IF EXISTS trg_channels_move_index_tombstone ON channels;
+DROP TRIGGER IF EXISTS trg_channels_clear_index_tombstone ON channels;
+DROP TRIGGER IF EXISTS trg_channels_capture_index_tombstone ON channels;
+DROP TRIGGER IF EXISTS trg_channels_seed_index_revision ON channels;
+DROP FUNCTION IF EXISTS rustok_channel_move_index_tombstone();
+DROP FUNCTION IF EXISTS rustok_channel_clear_inserted_index_tombstone();
+DROP FUNCTION IF EXISTS rustok_channel_capture_index_tombstone();
+DROP FUNCTION IF EXISTS rustok_channel_seed_index_revision_from_tombstone();
+DROP FUNCTION IF EXISTS rustok_channel_clear_superseded_index_tombstone(UUID, UUID, BIGINT);
+DROP FUNCTION IF EXISTS rustok_channel_store_index_tombstone(UUID, UUID, BIGINT);
+DROP TABLE IF EXISTS channel_index_tombstones;
+"#,
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/crates/rustok-channel/src/migrations/mod.rs
+++ b/crates/rustok-channel/src/migrations/mod.rs
@@ -10,6 +10,7 @@ mod m20260327_000007_create_channel_resolution_policy_sets;
 mod m20260327_000008_create_channel_resolution_policy_rules;
 mod m20260716_000009_create_channel_resolution_invalidation_state;
 mod m20260730_000010_add_channel_index_revision;
+mod m20260731_000011_add_channel_index_tombstones;
 
 use rustok_core::MigrationDependencyDescriptor;
 use sea_orm_migration::MigrationTrait;
@@ -26,6 +27,7 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260327_000008_create_channel_resolution_policy_rules::Migration),
         Box::new(m20260716_000009_create_channel_resolution_invalidation_state::Migration),
         Box::new(m20260730_000010_add_channel_index_revision::Migration),
+        Box::new(m20260731_000011_add_channel_index_tombstones::Migration),
     ]
 }
 

--- a/crates/rustok-distribution/src/channel_index.rs
+++ b/crates/rustok-distribution/src/channel_index.rs
@@ -19,17 +19,59 @@ pub(crate) const SALES_CHANNEL_INDEX_SOURCE: &str = "sales-channel-postgres-prim
 const SALES_CHANNEL_INDEX_FACTORY: &str = "sales-channel-postgres-primary";
 const SALES_CHANNEL_EVENT_DOMAIN: &str = "rustok-channel.sales-channel-replay-v1";
 
-const SALES_CHANNEL_SELECT: &str = r#"
+const SALES_CHANNEL_ROWS_CTE: &str = r#"
+sales_channel_index_union AS (
+    SELECT
+        FALSE AS is_deleted,
+        c.tenant_id,
+        c.id AS channel_id,
+        c.index_revision,
+        c.slug,
+        c.name,
+        c.is_active,
+        c.is_default,
+        c.status
+    FROM channels c
+    WHERE c.tenant_id = $1
+
+    UNION ALL
+
+    SELECT
+        TRUE AS is_deleted,
+        tombstone.tenant_id,
+        tombstone.channel_id,
+        tombstone.source_version AS index_revision,
+        NULL::text AS slug,
+        NULL::text AS name,
+        NULL::boolean AS is_active,
+        NULL::boolean AS is_default,
+        NULL::text AS status
+    FROM channel_index_tombstones tombstone
+    WHERE tombstone.tenant_id = $1
+),
+sales_channel_index_rows AS (
+    SELECT
+        row.*,
+        COUNT(*) OVER (
+            PARTITION BY row.tenant_id, row.channel_id
+        ) AS identity_count
+    FROM sales_channel_index_union row
+)
+"#;
+
+const SALES_CHANNEL_ROW_SELECT: &str = r#"
 SELECT
-    c.tenant_id,
-    c.id AS channel_id,
-    c.index_revision,
-    c.slug,
-    c.name,
-    c.is_active,
-    c.is_default,
-    c.status
-FROM channels c
+    row.is_deleted,
+    row.identity_count,
+    row.tenant_id,
+    row.channel_id,
+    row.index_revision,
+    row.slug,
+    row.name,
+    row.is_active,
+    row.is_default,
+    row.status
+FROM sales_channel_index_rows row
 "#;
 
 #[derive(Debug, Error)]
@@ -163,7 +205,7 @@ impl SalesChannelPostgresIndexSource {
         let (sql, values): (String, Vec<Value>) = match cursor {
             Some(cursor) => (
                 format!(
-                    "{SALES_CHANNEL_SELECT}\nWHERE c.tenant_id = $1\n  AND c.id > $2\nORDER BY c.id ASC\nLIMIT $3"
+                    "WITH {SALES_CHANNEL_ROWS_CTE}\n{SALES_CHANNEL_ROW_SELECT}\nWHERE row.channel_id > $2\nORDER BY row.channel_id ASC\nLIMIT $3"
                 ),
                 vec![
                     request.tenant_id().into(),
@@ -173,7 +215,7 @@ impl SalesChannelPostgresIndexSource {
             ),
             None => (
                 format!(
-                    "{SALES_CHANNEL_SELECT}\nWHERE c.tenant_id = $1\nORDER BY c.id ASC\nLIMIT $2"
+                    "WITH {SALES_CHANNEL_ROWS_CTE}\n{SALES_CHANNEL_ROW_SELECT}\nORDER BY row.channel_id ASC\nLIMIT $2"
                 ),
                 vec![request.tenant_id().into(), fetch_limit.into()],
             ),
@@ -200,7 +242,7 @@ impl SalesChannelPostgresIndexSource {
             values.push(key.entity_id.into());
         }
         let sql = format!(
-            "WITH requested(channel_id) AS (VALUES {})\n{SALES_CHANNEL_SELECT}\nJOIN requested r ON r.channel_id = c.id\nWHERE c.tenant_id = $1\nORDER BY c.id ASC",
+            "WITH requested(channel_id) AS (VALUES {}),\n{SALES_CHANNEL_ROWS_CTE}\n{SALES_CHANNEL_ROW_SELECT}\nJOIN requested requested_key ON requested_key.channel_id = row.channel_id\nORDER BY row.channel_id ASC",
             rows.join(", ")
         );
         self.db
@@ -295,6 +337,17 @@ struct SalesChannelRow {
     tenant_id: Uuid,
     channel_id: Uuid,
     source_version: u64,
+    state: SalesChannelRowState,
+}
+
+#[derive(Debug)]
+enum SalesChannelRowState {
+    Live(SalesChannelLiveFields),
+    Deleted,
+}
+
+#[derive(Debug)]
+struct SalesChannelLiveFields {
     slug: String,
     name: String,
     is_active: bool,
@@ -307,6 +360,12 @@ impl SalesChannelRow {
         row: QueryResult,
         expected_tenant: Uuid,
     ) -> Result<Self, SalesChannelIndexBridgeError> {
+        let is_deleted = row
+            .try_get::<bool>("", "is_deleted")
+            .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
+        let identity_count = row
+            .try_get::<i64>("", "identity_count")
+            .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
         let tenant_id = row
             .try_get::<Uuid>("", "tenant_id")
             .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
@@ -316,27 +375,41 @@ impl SalesChannelRow {
         let revision = row
             .try_get::<i64>("", "index_revision")
             .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
-        if tenant_id != expected_tenant
+        if identity_count != 1
+            || tenant_id != expected_tenant
             || tenant_id.is_nil()
             || channel_id.is_nil()
             || revision <= 0
         {
             return Err(SalesChannelIndexBridgeError::InvalidRow);
         }
+        let source_version =
+            u64::try_from(revision).map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
+
+        if is_deleted {
+            return Ok(Self {
+                tenant_id,
+                channel_id,
+                source_version,
+                state: SalesChannelRowState::Deleted,
+            });
+        }
+
         Ok(Self {
             tenant_id,
             channel_id,
-            source_version: u64::try_from(revision)
-                .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?,
-            slug: required_string(&row, "slug")?,
-            name: required_string(&row, "name")?,
-            is_active: row
-                .try_get::<bool>("", "is_active")
-                .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?,
-            is_default: row
-                .try_get::<bool>("", "is_default")
-                .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?,
-            status: required_string(&row, "status")?,
+            source_version,
+            state: SalesChannelRowState::Live(SalesChannelLiveFields {
+                slug: required_string(&row, "slug")?,
+                name: required_string(&row, "name")?,
+                is_active: row
+                    .try_get::<bool>("", "is_active")
+                    .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?,
+                is_default: row
+                    .try_get::<bool>("", "is_default")
+                    .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?,
+                status: required_string(&row, "status")?,
+            }),
         })
     }
 
@@ -355,27 +428,40 @@ impl SalesChannelRow {
             self.source_version,
         )
         .map_err(|_| SalesChannelIndexBridgeError::InvalidRow)?;
+        let key = EntityKey {
+            tenant_id: self.tenant_id,
+            schema: sales_channel_schema_ref()
+                .map_err(SalesChannelIndexBridgeError::InvalidContract)?,
+            entity_id: self.channel_id,
+            locale: None,
+        };
+
+        let SalesChannelRowState::Live(live) = self.state else {
+            return Ok(IndexMutation::Delete {
+                event_id,
+                key,
+                source_version: self.source_version,
+            });
+        };
+
         let fields = BTreeMap::from([
             (field_name("id")?, IndexValue::Uuid(self.channel_id)),
-            (field_name("slug")?, IndexValue::String(self.slug)),
-            (field_name("name")?, IndexValue::String(self.name)),
-            (field_name("is_active")?, IndexValue::Boolean(self.is_active)),
+            (field_name("slug")?, IndexValue::String(live.slug)),
+            (field_name("name")?, IndexValue::String(live.name)),
+            (
+                field_name("is_active")?,
+                IndexValue::Boolean(live.is_active),
+            ),
             (
                 field_name("is_default")?,
-                IndexValue::Boolean(self.is_default),
+                IndexValue::Boolean(live.is_default),
             ),
-            (field_name("status")?, IndexValue::String(self.status)),
+            (field_name("status")?, IndexValue::String(live.status)),
         ]);
         Ok(IndexMutation::Upsert {
             event_id,
             record: IndexRecord {
-                key: EntityKey {
-                    tenant_id: self.tenant_id,
-                    schema: sales_channel_schema_ref()
-                        .map_err(SalesChannelIndexBridgeError::InvalidContract)?,
-                    entity_id: self.channel_id,
-                    locale: None,
-                },
+                key,
                 source_version: self.source_version,
                 fields,
                 links: Vec::new(),
@@ -440,6 +526,45 @@ mod tests {
         ] {
             let cursor = IndexSourceCursor::new(value).unwrap();
             assert!(SalesChannelCursor::decode(&cursor).is_err());
+        }
+    }
+
+    #[test]
+    fn selected_sales_channel_tombstone_emits_delete_with_stable_identity() {
+        let tenant_id = Uuid::from_u128(1);
+        let channel_id = Uuid::from_u128(2);
+        let mutation = SalesChannelRow {
+            tenant_id,
+            channel_id,
+            source_version: 7,
+            state: SalesChannelRowState::Deleted,
+        }
+        .into_mutation()
+        .unwrap();
+
+        match mutation {
+            IndexMutation::Delete {
+                event_id,
+                key,
+                source_version,
+            } => {
+                assert_eq!(key.tenant_id, tenant_id);
+                assert_eq!(key.entity_id, channel_id);
+                assert_eq!(key.locale, None);
+                assert_eq!(source_version, 7);
+                assert_eq!(
+                    event_id,
+                    derive_index_source_event_id(
+                        SALES_CHANNEL_EVENT_DOMAIN,
+                        tenant_id,
+                        channel_id,
+                        None,
+                        7,
+                    )
+                    .unwrap()
+                );
+            }
+            IndexMutation::Upsert { .. } => panic!("retained delete must not become an upsert"),
         }
     }
 

--- a/crates/rustok-index/docs/implementation-plan.md
+++ b/crates/rustok-index/docs/implementation-plan.md
@@ -26,7 +26,7 @@ pull requests record checks and PostgreSQL runs that were not executed.
 ## Current state
 
 - Rewrite status: `in_progress`
-- Current milestone: `M7 - first Product schema and bounded replay source (source complete; tombstones, incremental events, related entities, consumer cutover, and retained evidence open)`
+- Current milestone: `M7 - Product/ProductVariant/SalesChannel bounded replay graph (live sources, Product/ProductVariant/SalesChannel tombstones, and bounded reconciliation source-complete; incremental events, persisted readiness, durable Product-to-Channel relations, consumer cutover, and retained evidence open)`
 - FFA status: `in_progress`
 - FBA status: `in_progress`
 - M0 code reset: `complete`
@@ -63,12 +63,14 @@ pull requests record checks and PostgreSQL runs that were not executed.
 - M4 source-owned schema catalog and shared query runtime: `source_complete`
 - M4 first Social Graph privacy parity shadow: `source_complete_metrics_evidence_tooling_execution_pending`
 - M5 inbox deduplication and monotonic source-version persistence: `complete`
-- M5/M6 bounded source replay contract: `source_complete_worker_pending`
+- M5/M6 bounded source replay contract: `source_complete_owner_execution_pending`
 - M6 one-page replay and durable checkpoint progression: `source_complete`
 - M6 replay job leases and checkpoint attempt fencing: `source_complete_owner_execution_pending`
 - M6 bounded multi-page replay and cancellation: `source_complete_owner_execution_pending`
+- M6 bounded multi-pass source reconciliation: `source_complete_owner_execution_pending`
 - M6 replay runtime host composition and operator guard: `source_complete_owner_execution_pending`
-- M7 first Product schema and bounded source bridge: `source_complete_owner_execution_pending`
+- M7 Product/ProductVariant graph schemas and bounded sources: `source_complete_owner_execution_pending`
+- M7 SalesChannel schema, bounded source, and retained deletes: `source_complete_owner_execution_pending`
 - Production persistence: mutation writes, schema/index coordination, fail-closed
   partition admission, snapshot/query/mutation/maintenance/cutover evidence tooling,
   full-capture orchestration, exact-byte packet assembly, retained bundle review,
@@ -84,14 +86,18 @@ pull requests record checks and PostgreSQL runs that were not executed.
   rebuild checkpoint progression, schema-scoped rebuild job claims, lease/heartbeat,
   attempt fencing, fenced checkpoint writes, bounded multi-page execution, immediate
   pending resume, durable cancellation requests, fenced between-page terminal
-  cancellation, immutable source-registry host materialization, shared replay-runtime
-  publication, request-bound operator authorization, atomic PostgreSQL source-factory
-  composition, stable source event identities, and one selected Product current-state
-  replay source are implemented; one retained admitted packet, live PostgreSQL/reference
-  equivalence, in-page interruption, retry/backoff, dead-letter scheduling, host
-  scheduling, graceful task shutdown, command transport, Product tombstones and
-  incremental ingestion, additional vertical schemas, freshness/recovery evidence,
-  authoritative consumer cutover, and production partition lifecycle remain open
+  cancellation, bounded multi-pass reconciliation, immutable source-registry host
+  materialization, shared replay-runtime publication, request-bound operator
+  authorization, atomic PostgreSQL source-factory composition, stable source event
+  identities, Product/ProductVariant/SalesChannel current-state sources, versioned
+  Product-to-ProductVariant links, and retained Product/ProductVariant/SalesChannel
+  hard-delete mutations are implemented; one retained admitted packet, live
+  PostgreSQL/reference equivalence, in-page interruption, retry/backoff, dead-letter
+  scheduling, host scheduling, graceful task shutdown, command transport, incremental
+  event acknowledgement, persisted per-tenant schema readiness, durable
+  Product-to-SalesChannel relations, freshness/recovery evidence, authoritative
+  consumer cutover, tombstone purge admission, and production partition lifecycle
+  remain open
 
 The production crate contains the generic domain/application core, seven canonical
 M3 tables, an atomic mutation adapter, durable schema leases, secondary-index
@@ -107,12 +113,14 @@ repeatable-read page/count snapshot, source-owned schema and replay catalogs, a
 neutral bounded `IndexSource` scan/load boundary, a one-page replay executor,
 `PostgresIndexReplayJobStore` for durable fenced schema-scoped rebuild ownership,
 a lease-bound PostgreSQL rebuild-checkpoint adapter, `PostgresIndexReplayRunner` for
-bounded heartbeat/yield/cancellation execution, `SharedIndexReplayRuntime` for host
-capability transfer, and atomic host-database-aware source factory composition. The
-server publishes `IndexReplayOperatorRuntime` as the request-bound authorization
-boundary. The selected distribution now contributes the first Product schema/source
-bridge without adding a Product dependency to Index core. Owner-operated evidence
-tools live under `ops/benches`; they do not become runtime storage code.
+bounded heartbeat/yield/cancellation execution, a bounded multi-pass source
+reconciliation runner with durable pass/source cursor state, `SharedIndexReplayRuntime`
+for host capability transfer, and atomic host-database-aware source factory composition.
+The server publishes `IndexReplayOperatorRuntime` as the request-bound authorization
+boundary. The selected distribution contributes Product, ProductVariant, and
+SalesChannel schemas/sources without adding source-domain dependencies to Index core
+or server. Owner-operated evidence tools live under `ops/benches`; they do not become
+runtime storage code.
 
 ## Ownership
 
@@ -123,9 +131,10 @@ reconciliation, drift repair, distributed coordination, and operator diagnostics
 
 Source modules own normalized domain data, schema declarations, conversion to
 generic Index records/mutations, bounded `IndexSource::scan` and targeted `load`
-adapters, stable replay event identities, and source ordering and version information.
-Selected cross-module adapters that require both owner storage and Index contracts
-live in `rustok-distribution`; they do not move storage ownership into Index or server.
+adapters, stable replay event identities, source ordering and version information,
+and retained deletion identities needed for replay. Selected cross-module adapters
+that require both owner storage and Index contracts live in `rustok-distribution`;
+they do not move storage ownership into Index or server.
 
 ## Target architecture
 
@@ -160,6 +169,7 @@ crates/rustok-index/src/
     source_replay.rs
     source_replay_job.rs
     source_replay_runner.rs
+    source_reconciliation_runner.rs
     replay_runtime.rs
     schema_lease.rs
     secondary_index.rs
@@ -168,7 +178,8 @@ crates/rustok-index/src/
   api/
 
 crates/rustok-distribution/src/
-  product_index.rs
+  product_index/
+  channel_index.rs
 
 apps/server/src/services/
   index_replay_runtime_composition.rs
@@ -467,20 +478,21 @@ database, or transport causes stay in owner logs.
 - [x] Add bounded multi-page execution with heartbeat cadence and immediate pending resume.
 - [x] Add durable cancellation requests and fenced between-page terminal cancellation.
 - [x] Bind job requests directly to the materialized source registry in server composition.
+- [x] Add bounded multi-pass source reconciliation with durable pass/source cursor state.
 - [ ] Add in-page interruption/timeouts, dry-run, and targeted/full/shadow rebuild modes.
 - [ ] Add bounded retry/backoff, dead-letter state, and global scheduling ownership.
 - [ ] Add locale/partition replay checkpoint dimensions.
-- [ ] Add reconciliation and drift repair.
+- [ ] Add drift diagnosis, targeted repair commands, and admitted repair evidence.
 - [ ] Cover crash, lease expiry, restart, cancellation, authorization, and incremental/full
       equivalence with retained PostgreSQL evidence.
 
 The one-page executor, replay job store, checkpoint adapter, bounded multi-page runner,
-cancellation path, and host composition are source complete. `PostgresIndexReplayJobStore`
-serializes one tenant/schema claim, validates the exact `index_replay_job_v1` request and
-active persisted schema, reclaims expired attempts with an incremented fence, and rejects
-stale heartbeat or terminal updates. `PostgresIndexReplayCheckpointStore` is constructed
-from the acquired lease; it locks and validates that exact attempt before every checkpoint
-read or write.
+cancellation path, bounded reconciliation runner, and host composition are source complete.
+`PostgresIndexReplayJobStore` serializes one tenant/schema claim, validates the exact
+`index_replay_job_v1` request and active persisted schema, reclaims expired attempts with an
+incremented fence, and rejects stale heartbeat or terminal updates.
+`PostgresIndexReplayCheckpointStore` is constructed from the acquired lease; it locks and
+validates that exact attempt before every checkpoint read or write.
 
 `PostgresIndexReplayRunner` resolves the source from the materialized registry, executes at
 most 1024 pages, heartbeats between pages, completes only after a durable JSON null cursor,
@@ -490,6 +502,13 @@ marks running jobs for observation before/after pages; success, failure, and yie
 require `cancel_requested = FALSE`, so cancellation committed first cannot be overwritten.
 A running cancel request survives reclaim and is terminalized by the next fenced attempt
 before source access.
+
+The bounded reconciliation runner performs durable multi-pass source scans without
+collecting all IDs, persists pass and source cursor state, applies stable source mutations
+through the same monotonic mutation store, and can be cancelled or reclaimed under the
+existing attempt fence. It repairs replay-visible stale and missing materialized state but
+does not claim an owner snapshot/high-watermark, proof against every concurrent final-pass
+write, or authoritative drift-repair admission.
 
 The server materializes `SharedIndexSourceRegistry` only after all selected modules have
 registered their source-owned schema and replay contracts. The Index-owned
@@ -513,20 +532,35 @@ Entities: Product, ProductVariant, SalesChannel.
 - [x] Add stable `(product_id, locale)` replay cursor, targeted loads, and one-row lookahead.
 - [x] Add Product-owned monotonic `index_revision` and stable Index-owned event identity.
 - [x] Compose selected Product schema/source through atomic distribution source factories.
-- [ ] Add Product and translation delete tombstones plus incremental event acknowledgement.
-- [ ] Add ProductVariant and SalesChannel schemas, links, and bounded sources.
+- [x] Add Product and translation delete tombstones.
+- [x] Add ProductVariant and SalesChannel schemas and bounded sources.
+- [x] Add Product-to-ProductVariant v2 links and bounded graph projection fields.
+- [x] Add ProductVariant and SalesChannel hard-delete tombstones.
+- [ ] Add source-versioned Product, ProductVariant, and SalesChannel incremental event acknowledgement.
+- [ ] Add durable Product/ProductVariant-to-SalesChannel relations with owner revision semantics.
 - [ ] Support tenant, locale, status, projection, link filters, sorting, and cursor
       pagination across the complete Product/Variant/Channel slice.
 - [ ] Move one Storefront query to Index.
 - [ ] Prove no source-module filtering fan-out.
 
-The first Product source is source complete for bounded current-state upserts. Product owns
-its storage and revision triggers; `rustok-distribution` owns the selected generic bridge;
-Index owns schema/source/runtime contracts and mutation persistence. The Product crate does
-not depend on Index, Index/server do not import Product, and factory composition commits the
-source catalog only after every selected factory succeeds. See
-[`m7-product-source.md`](./m7-product-source.md) for exact scope and open tombstone,
-concurrency, persisted-schema-readiness, evidence, and cutover boundaries.
+Product v1/v2, ProductVariant v1/v2, and SalesChannel v1 schemas are source complete.
+Product v2 links to ProductVariant v2; Product channel visibility remains represented by
+bounded scalar projection until the owner has a durable relational contract. Product,
+translation, ProductVariant, and SalesChannel deletion identities are retained with
+monotonic source versions and replayed through the existing stable sources as generic
+`IndexMutation::Delete` values. Recreated identities must strictly supersede retained
+deletes, and live/tombstone coexistence fails closed.
+
+Product and Channel crates own normalized storage, revisions, and tombstones without
+depending on Index. `rustok-distribution` owns the selected generic bridges. Index owns
+schema/source/runtime contracts, reconciliation, and mutation persistence. Runtime
+capability presence does not establish persisted schema readiness. Incremental event
+acknowledgement, durable Product-to-SalesChannel links, owner evidence, and consumer
+cutover remain open. See [`m7-product-source.md`](./m7-product-source.md),
+[`m7-product-variant-source.md`](./m7-product-variant-source.md),
+[`m7-product-graph-source.md`](./m7-product-graph-source.md),
+[`m7-product-tombstone-source.md`](./m7-product-tombstone-source.md), and
+[`m7-sales-channel-source.md`](./m7-sales-channel-source.md).
 
 ### M8 - Commerce scale slice
 
@@ -573,6 +607,7 @@ cargo test -p rustok-index source_event_id --lib -- --nocapture
 cargo test -p rustok-index source_replay --lib -- --nocapture
 cargo test -p rustok-index source_replay_job --lib -- --nocapture
 cargo test -p rustok-index source_replay_runner --lib -- --nocapture
+cargo test -p rustok-index source_reconciliation_runner --lib -- --nocapture
 cargo test -p rustok-index source_factory --lib -- --nocapture
 cargo test -p rustok-index replay_runtime --lib -- --nocapture
 cargo test -p rustok-distribution --all-targets --features mod-product -- --nocapture
@@ -621,8 +656,13 @@ node scripts/verify/verify-index-many-link-filtering.mjs
 node scripts/verify/verify-index-source-replay-contract.mjs
 node scripts/verify/verify-index-replay-job-leases.mjs
 node scripts/verify/verify-index-replay-multipage-runner.mjs
+node scripts/verify/verify-index-source-reconciliation.mjs
 node scripts/verify/verify-index-replay-runtime-composition.mjs
 node scripts/verify/verify-index-product-source.mjs
+node scripts/verify/verify-index-product-variant-source.mjs
+node scripts/verify/verify-index-product-graph-source.mjs
+node scripts/verify/verify-index-product-tombstone-source.mjs
+node scripts/verify/verify-index-sales-channel-source.mjs
 ```
 
 ## Progress log
@@ -683,22 +723,31 @@ node scripts/verify/verify-index-product-source.mjs
   selected locale-required Product current-state source with stable `(product_id,
   locale)` cursor and targeted loads. Product delete/translation tombstones,
   incremental acknowledgement, related schemas, and live evidence remain open.
+- 2026-07-31: rechecked merged M7 work and actualized this plan. ProductVariant and
+  SalesChannel sources, Product v2 graph links, retained Product/translation/
+  ProductVariant hard deletes, and bounded multi-pass reconciliation were already in
+  `main` but had stale open checklist entries.
+- 2026-07-31: added retained SalesChannel hard-delete identities, strict identity-reuse
+  fencing, live/tombstone conflict rejection, and generic replay deletes through the
+  existing stable SalesChannel source. No schema fingerprint, source name, cursor shape,
+  or event domain changed.
 - Repository test/fixture suites, verifiers, in-page interruption, automatic retry/backoff,
   dead-letter and host scheduling, graceful task shutdown, authorized command transports,
-  Product tombstones and incremental ingestion, ProductVariant/SalesChannel sources,
-  live freshness/recovery evidence, one admitted PostgreSQL/reference equivalence bundle,
-  and one real full PostgreSQL partition packet remain for the owner to execute and admit
-  before authoritative consumer or production partition cutover.
+  incremental event acknowledgement, persisted per-tenant schema readiness, durable
+  Product-to-SalesChannel relations, tombstone purge admission, live freshness/recovery
+  evidence, one admitted PostgreSQL/reference equivalence bundle, and one real full
+  PostgreSQL partition packet remain for the owner to execute and admit before
+  authoritative consumer or production partition cutover.
 
 ## Periodic release verification handoff
 
 - Cycle: `cycle-001`
 - Status: `blocked`
-- Last verified at (UTC): `2026-07-30`
-- Scope inspected: `Index ownership, migrations, mutation/version ordering, query execution, partition evidence guards, Social Graph consumer authority, privacy shadow deadline behavior, source replay ownership, replay checkpoint ordering, replay job attempt fencing, bounded multi-page replay progression, cancellation ordering, host replay composition, operator authorization, selected Product source composition, stable source identity, and source/search/server boundaries`
+- Last verified at (UTC): `2026-07-31`
+- Scope inspected: `Index ownership, migrations, mutation/version ordering, query execution, partition evidence guards, Social Graph consumer authority, privacy shadow deadline behavior, source replay ownership, replay checkpoint ordering, replay job attempt fencing, bounded multi-page replay progression, bounded multi-pass reconciliation, cancellation ordering, host replay composition, operator authorization, Product/ProductVariant/SalesChannel source composition, Product graph links, retained delete identities, stable source identity, and source/search/server boundaries`
 - Findings: `P0=0, P1=2, P2=0, P3=1`
-- Fixed in this pass: `bounded the non-authoritative Social Graph privacy comparison by the remaining caller deadline while preserving the owner result; repaired stale Index scale/FBA and retained-artifact guards; added a canonical bounded source replay/load registry; added one-page replay mutation application with stable event checks and checkpoint progression only after durable mutation outcomes; added schema-scoped rebuild job claims with lease/heartbeat, expired-attempt reclaim, attempt fencing, fenced checkpoint access, durable null-cursor-gated success, bounded multi-page execution with between-page heartbeat and immediate pending resume, durable cancel-first terminalization, immutable source-registry host materialization, one shared replay runtime, a request-bound modules:manage operator guard, atomic host source factories, stable source event identities, Product revision fencing, and the first selected Product current-state source`
-- Remaining risks or blockers: `one retained admitted real PostgreSQL partition packet is absent; live PostgreSQL/reference query equivalence remains open; in-page interruption, automatic retry/backoff, dead-letter scheduling, host scheduling, graceful task shutdown, authorized command transports, locale/partition checkpoint dimensions, Product hard-delete and translation-delete tombstones, incremental Product event acknowledgement, ProductVariant/SalesChannel sources, and additional production source adapters remain absent; no retained per-tenant freshness/watermark, lag, negative-result safety, outage/restart/backlog catch-up, cancellation, authorization, Product replay, or replay-repair evidence exists; consumer and production partition cutover remain forbidden`
-- Evidence: `PR #2544 merged as b647a5a17f27b34a07c20cd57525ed1806994c49; PR #2554 merged as 5b9d49e65295819ee9e8e9c199688c0e2ac73d35; PR #2576 merged as aef96f57d3babc2efdc65cc0c57cfea6fb48b5ad; PR #2578 merged as 9d725de7bac2039c86d5b5dffdf5d6be1b4812a8; PR #2585 merged as 1863a28fa2ebccdab39f19fce5b6971078e7e9f3; same-SHA Index Storage Scale Run Contract and full Scale Evidence contract passed JavaScript syntax, workflow contracts, repository contracts, direct validator arguments and fixture suites; source replay registry, one-page checkpoint progression, replay job fencing, bounded multi-page runner, cancellation, shared replay runtime, operator guard, source factory, stable event identity, and selected Product source are present without implementation-agent test execution; general CI/Hardening received no jobs; Rust-hosted smoke previously stopped before compilation because Cargo.lock required an Athanor update under --locked`
-- Next action: `add Product and translation tombstones plus source-versioned incremental event acknowledgement, then add ProductVariant and SalesChannel schemas/links/sources; implement scheduler/retry/shutdown ownership only after command and source contracts are fixed; execute retained PostgreSQL packet, live query equivalence, and per-tenant freshness/outage/recovery evidence before authoritative cutover`
-- Resume command: `cargo fmt --all -- --check && cargo check -p rustok-index --all-targets && cargo check -p rustok-distribution --all-targets --features mod-product && cargo check -p rustok-server --all-targets && node scripts/verify/verify-index-product-source.mjs && node scripts/verify/verify-index-query-contract.mjs && node scripts/verify/index-storage-tooling.mjs contract && node scripts/verify/index-storage-tooling.mjs fixtures`
+- Fixed in this pass: `actualized stale M6/M7 plan state; preserved bounded replay and reconciliation non-claims; added Channel-owned retained hard-delete identities with monotonic reuse fencing; replayed SalesChannel deletes through the existing source with the same schema fingerprint, source name, cursor and event domain; added fail-closed live/tombstone identity checks, documentation, and a static repository guard`
+- Remaining risks or blockers: `one retained admitted real PostgreSQL partition packet is absent; live PostgreSQL/reference query equivalence remains open; in-page interruption, automatic retry/backoff, dead-letter scheduling, host scheduling, graceful task shutdown, authorized command transports, locale/partition checkpoint dimensions, mutation-source event acknowledgement, persisted per-tenant schema readiness, durable Product-to-SalesChannel relations, tombstone purge admission, and additional production source adapters remain absent; no retained per-tenant freshness/watermark, lag, negative-result safety, outage/restart/backlog catch-up, delete/recreate, cancellation, authorization, replay, reconciliation, or repair evidence exists; consumer and production partition cutover remain forbidden`
+- Evidence: `PR #2604 added the first Product source; PR #2611 added ProductVariant; PR #2616 added SalesChannel; PR #2623 added Product graph v2 and Product-to-ProductVariant links; PR #2628 added retained Product/translation/ProductVariant deletes; PR #2632 added bounded source reconciliation. This SalesChannel tombstone slice is source-ready without implementation-agent test, verifier, Cargo, CI, or PostgreSQL execution.`
+- Next action: `define the source-versioned incremental mutation event and acknowledgement contract, then persist/apply exact per-tenant M7 schemas and add durable Product-to-SalesChannel relations; execute retained delete/recreate, replay/reconciliation, freshness/outage/recovery, live query equivalence, and partition evidence before authoritative cutover`
+- Resume command: `cargo fmt --all -- --check && cargo check -p rustok-channel --all-targets && cargo check -p rustok-index --all-targets && cargo check -p rustok-distribution --all-targets --features mod-product && cargo check -p rustok-server --all-targets && node scripts/verify/verify-index-sales-channel-source.mjs && node scripts/verify/verify-index-source-reconciliation.mjs && node scripts/verify/verify-index-product-tombstone-source.mjs && node scripts/verify/verify-index-query-contract.mjs && node scripts/verify/index-storage-tooling.mjs contract && node scripts/verify/index-storage-tooling.mjs fixtures`

--- a/crates/rustok-index/docs/implementation-recheck-2026-08-01.md
+++ b/crates/rustok-index/docs/implementation-recheck-2026-08-01.md
@@ -1,0 +1,48 @@
+# `rustok-index` implementation recheck — 2026-08-01
+
+## Audited baseline
+
+- Repository: `RusTokRs/RusTok`
+- Target branch: `main`
+- Audited commit: `1cc032d6ceba0e55b5f3a1dfa2a64b066dc73f71`
+- Validation owner: repository maintainer
+
+This recheck compares the canonical implementation plan with the source and recent Index pull-request history. Tests, verifiers, Cargo commands, CI, and PostgreSQL execution were not run, per maintainer instruction.
+
+## Confirmed on `main`
+
+- Product v1/v2 bounded replay sources and stable Product event identities.
+- ProductVariant v1/v2 bounded replay sources.
+- Product v2 to ProductVariant v2 graph links and bounded graph projection fields.
+- Product, translation, and ProductVariant retained hard-delete mutations.
+- SalesChannel v1 bounded current-state replay source.
+- Bounded multi-pass source reconciliation with durable pass/source cursor state.
+
+The pre-existing canonical plan still described several of these delivered slices as open. The plan update in this branch corrects those entries without promoting owner-executed evidence.
+
+## Confirmed missing on `main`
+
+SalesChannel hard-delete identities were not retained. A physical Channel deletion could therefore disappear from current-state replay without producing a generic Index delete, and identity reuse had no retained-delete revision fence.
+
+## Continued slice
+
+This branch adds the missing bounded SalesChannel delete path:
+
+- Channel-owned `channel_index_tombstones` storage;
+- delete, identity-move, and identity-reuse revision fencing;
+- replay of live rows and retained deletes through the existing `sales-channel-postgres-primary` source;
+- fail-closed rejection when one identity exists as both live and tombstoned;
+- synchronized Channel, Index, and verifier documentation.
+
+The following contracts remain unchanged:
+
+- `rustok-channel::sales_channel@1` schema fingerprint;
+- replay source and factory name;
+- stable `channel_id` cursor ordering;
+- targeted-load key shape;
+- replay event domain;
+- Index core ownership boundaries.
+
+## Remaining work
+
+Incremental mutation-event acknowledgement, persisted per-tenant schema readiness, durable Product-to-SalesChannel relation revisions, tombstone purge admission, authoritative Storefront cutover, and retained PostgreSQL replay/reconciliation/delete-recreate evidence remain open.

--- a/crates/rustok-index/docs/m7-sales-channel-source.md
+++ b/crates/rustok-index/docs/m7-sales-channel-source.md
@@ -1,24 +1,26 @@
-# M7 SalesChannel schema and bounded replay source
+# M7 SalesChannel schema, bounded replay source, and retained deletes
 
 Status: `source_complete_owner_execution_pending`
 
-This slice publishes the first Channel-owned current-state replay contract for
+This slice publishes the Channel-owned replay contract for
 `rustok-channel::sales_channel@1` without adding Channel semantics to Index core or the
-server.
+server. The stable source now covers both current rows and retained hard-delete
+identities.
 
 ## Ownership
 
 `rustok-channel` owns the `channels` table, the `ChannelRuntimeSelected` composition marker,
-and the positive monotonic `channels.index_revision` storage contract. The owner crate does
-not depend on `rustok-index` and does not construct generic Index mutations.
+the positive monotonic `channels.index_revision` storage contract, and the
+`channel_index_tombstones` replay-identity table. The owner crate does not depend on
+`rustok-index` and does not construct generic Index mutations.
 
 `rustok-distribution` owns the selected cross-module adapter because it already composes both
 Channel and Index. The adapter registers one schema and one host-database-aware source factory
 only when `ChannelModule` participated in runtime extension registration.
 
 `rustok-index` owns generic schema/source registration, deterministic event identity, immutable
-source registry materialization, replay jobs/checkpoints, mutation persistence, and query
-execution. The server remains Channel-agnostic.
+source registry materialization, replay jobs/checkpoints, reconciliation, mutation persistence,
+and query execution. The server remains Channel-agnostic.
 
 ## Schema
 
@@ -43,22 +45,40 @@ this schema.
 
 The selected `sales-channel-postgres-primary` source:
 
-- reads only the Channel-owned `channels` table;
+- reads only Channel-owned `channels` and `channel_index_tombstones` tables;
 - requires exact tenant and exact schema scope;
-- scans in stable `channel_id` UUID order with one-row lookahead;
+- scans live and deleted identities in stable `channel_id` UUID order with one-row lookahead;
 - persists an opaque cursor containing only `channel_id`;
 - never orders or paginates by mutable `index_revision`;
 - supports bounded targeted loads over exact non-localized entity keys;
 - rejects locale-bearing targeted keys;
-- rejects nil tenant/channel identities, non-positive revisions, and empty required strings;
-- emits generic `IndexMutation::Upsert` records with no links;
-- derives stable event UUIDs from tenant, channel, and source revision;
+- rejects nil tenant/channel identities and non-positive revisions;
+- rejects any live/tombstone coexistence for the same `(tenant_id, channel_id)` identity;
+- emits generic `IndexMutation::Upsert` records for live rows and `IndexMutation::Delete`
+  values for retained deletes;
+- derives stable event UUIDs from tenant, channel, and source revision for both mutation kinds;
 - maps storage failures to one bounded retryable code and contract/backend failures to bounded
   permanent codes.
 
 `index_revision` is the mutation `source_version`; it is not the scan cursor. A PostgreSQL
 trigger advances it exactly once for every Channel update and rejects revision exhaustion.
 The SeaORM owner model and public Channel DTOs do not expose the storage-internal column.
+
+## Retained deletion and identity reuse
+
+A `BEFORE DELETE` trigger stores the exact Channel identity at `OLD.index_revision + 1`.
+The tombstone table has no foreign key back to `channels` or `tenants`, so owner deletion and
+tenant cascade cannot erase the replay identity before Index observes it.
+
+A recreated `(tenant_id, channel_id)` is seeded strictly above the retained delete version.
+The retained row is removed only after the live revision is greater. Equal or lower live
+revisions fail the owner write instead of allowing a stale upsert to suppress a delete.
+Channel identity moves retain the old key at the newly advanced revision and clear the new key
+only after the same strict supersession check.
+
+The replay query unions current rows and retained deletes, then computes an exact identity
+count. A count other than one is a permanent source-contract failure; the adapter never chooses
+nondeterministically between live and deleted state.
 
 ## Composition
 
@@ -72,15 +92,16 @@ started by this slice.
 
 ## Explicitly open
 
-- Channel hard-delete tombstones;
 - incremental Channel event ingestion and broker acknowledgement;
+- tombstone retention and purge admission after every relevant consumer checkpoint is newer;
 - persisted per-tenant schema application;
-- repeatable-read full-scan snapshot and concurrent-insert reconciliation semantics;
-- versioned Product/ProductVariant to SalesChannel links;
+- owner snapshot/high-watermark semantics beyond bounded multi-pass reconciliation;
+- durable Product/ProductVariant to SalesChannel relations and revision semantics;
 - Channel target, binding, and resolution-policy schemas;
 - authoritative Storefront/Admin/Search consumer cutover;
 - retry/backoff/dead-letter scheduling and graceful host task ownership;
-- retained PostgreSQL replay, restart, drift, freshness, and equivalence evidence.
+- retained PostgreSQL delete/recreate, replay, restart, drift, freshness, and equivalence
+  evidence.
 
 Runtime capability presence does not establish persisted schema readiness. Consumers must not
 query this schema authoritatively until the exact tenant schema is applied and the relevant

--- a/scripts/verify/verify-index-sales-channel-source.mjs
+++ b/scripts/verify/verify-index-sales-channel-source.mjs
@@ -54,9 +54,9 @@ requireMarkers('crates/rustok-channel/tests/index_selection.rs', [
   'assert!(!cargo.contains("rustok-index"));',
 ]);
 
-const migrationPath =
+const revisionMigrationPath =
   'crates/rustok-channel/src/migrations/m20260730_000010_add_channel_index_revision.rs';
-const migration = requireMarkers(migrationPath, [
+const revisionMigration = requireMarkers(revisionMigrationPath, [
   'ALTER TABLE channels',
   'ADD COLUMN index_revision BIGINT NOT NULL DEFAULT 1',
   'chk_channels_index_revision_positive',
@@ -65,7 +65,38 @@ const migration = requireMarkers(migrationPath, [
   'trg_channels_bump_index_revision',
   'BEFORE UPDATE ON channels',
 ]);
-forbidMarkers(migrationPath, migration, [
+forbidMarkers(revisionMigrationPath, revisionMigration, [
+  'index_entities',
+  'index_links',
+  'index_jobs',
+  'index_checkpoints',
+]);
+
+const tombstoneMigrationPath =
+  'crates/rustok-channel/src/migrations/m20260731_000011_add_channel_index_tombstones.rs';
+const tombstoneMigration = requireMarkers(tombstoneMigrationPath, [
+  'CREATE TABLE channel_index_tombstones',
+  'PRIMARY KEY (tenant_id, channel_id)',
+  'chk_channel_index_tombstones_source_version_positive',
+  'rustok_channel_store_index_tombstone(',
+  'rustok_channel_clear_superseded_index_tombstone(',
+  'rustok_channel_seed_index_revision_from_tombstone()',
+  'retained_source_version + 1',
+  'trg_channels_seed_index_revision',
+  'BEFORE INSERT ON channels',
+  'rustok_channel_capture_index_tombstone()',
+  'OLD.index_revision + 1',
+  'trg_channels_capture_index_tombstone',
+  'BEFORE DELETE ON channels',
+  'trg_channels_clear_index_tombstone',
+  'AFTER INSERT ON channels',
+  'rustok_channel_move_index_tombstone()',
+  'AFTER UPDATE OF id, tenant_id ON channels',
+  'NEW.index_revision',
+]);
+forbidMarkers(tombstoneMigrationPath, tombstoneMigration, [
+  'REFERENCES channels',
+  'REFERENCES tenants',
   'index_entities',
   'index_links',
   'index_jobs',
@@ -74,6 +105,8 @@ forbidMarkers(migrationPath, migration, [
 requireMarkers('crates/rustok-channel/src/migrations/mod.rs', [
   'mod m20260730_000010_add_channel_index_revision;',
   'Box::new(m20260730_000010_add_channel_index_revision::Migration)',
+  'mod m20260731_000011_add_channel_index_tombstones;',
+  'Box::new(m20260731_000011_add_channel_index_tombstones::Migration)',
 ]);
 requireMarkers('crates/rustok-channel/src/migrations/m20260325_000001_create_channels.rs', [
   '.name("idx_channels_tenant_slug")',
@@ -104,6 +137,15 @@ const sourcePath = 'crates/rustok-distribution/src/channel_index.rs';
 const source = requireMarkers(sourcePath, [
   'SALES_CHANNEL_INDEX_SOURCE: &str = "sales-channel-postgres-primary"',
   'SALES_CHANNEL_EVENT_DOMAIN: &str = "rustok-channel.sales-channel-replay-v1"',
+  'SALES_CHANNEL_ROWS_CTE',
+  'sales_channel_index_union AS (',
+  'FALSE AS is_deleted',
+  'TRUE AS is_deleted',
+  'FROM channels c',
+  'FROM channel_index_tombstones tombstone',
+  'COUNT(*) OVER (',
+  'PARTITION BY row.tenant_id, row.channel_id',
+  'row.identity_count',
   'extensions.contains::<rustok_channel::ChannelRuntimeSelected>()',
   'register_index_schema_source(extensions, "channel", schema)',
   'register_postgres_index_source_factory(',
@@ -112,17 +154,18 @@ const source = requireMarkers(sourcePath, [
   'field("id", IndexValueType::Uuid, true, true)?',
   'field("slug", IndexValueType::String, true, true)?',
   'field("is_active", IndexValueType::Boolean, true, true)?',
-  'field_name("id")?, IndexValue::Uuid(self.channel_id)',
   'impl PostgresIndexSourceFactory for SalesChannelPostgresIndexSourceFactory',
   'impl IndexSource for SalesChannelPostgresIndexSource',
-  'FROM channels c',
-  'c.index_revision,',
-  'c.id > $2',
-  'ORDER BY c.id ASC',
+  'row.channel_id > $2',
+  'ORDER BY row.channel_id ASC',
   'request.limit() + 1',
   'WITH requested(channel_id) AS (VALUES {})',
-  'JOIN requested r ON r.channel_id = c.id',
+  'JOIN requested requested_key ON requested_key.channel_id = row.channel_id',
   'sales_channel_index_locale_forbidden',
+  'identity_count != 1',
+  'enum SalesChannelRowState',
+  'SalesChannelRowState::Deleted',
+  'IndexMutation::Delete',
   'derive_index_source_event_id(',
   'locale: None',
   'links: Vec::new()',
@@ -130,6 +173,7 @@ const source = requireMarkers(sourcePath, [
   'assert_eq!(schema.fields.len(), 6);',
   'selected_sales_channel_schema_is_nonlocalized_and_link_free',
   'selected_sales_channel_cursor_rejects_nil_and_unknown_fields',
+  'selected_sales_channel_tombstone_emits_delete_with_stable_identity',
   'selected_sales_channel_bridge_skips_partial_registry_without_channel_module',
   'selected_sales_channel_bridge_registers_schema_and_factory',
 ]);
@@ -138,8 +182,8 @@ forbidMarkers(sourcePath, source, [
   'IndexLink',
   'IndexLinkValue',
   'LocaleKey',
-  'ORDER BY c.index_revision',
-  '(c.index_revision, c.id)',
+  'ORDER BY row.index_revision',
+  '(row.index_revision, row.channel_id)',
   'SELECT *',
   'index_entities',
   'index_links',
@@ -161,9 +205,11 @@ requireMarkers('crates/rustok-distribution/tests/channel_index.rs', [
 
 requireMarkers('crates/rustok-channel/README.md', [
   '`channels.index_revision`',
+  '`channel_index_tombstones`',
   '`ChannelRuntimeSelected`',
   '`rustok-channel::sales_channel@1`',
   'stable `channel_id` ordering',
+  'retained hard-delete mutations',
   'does not depend on `rustok-index`',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-sales-channel-source.md', [
@@ -174,7 +220,9 @@ requireMarkers('crates/rustok-index/docs/m7-sales-channel-source.md', [
   'stable `channel_id` UUID order',
   '`index_revision` is the mutation `source_version`; it is not the scan cursor.',
   'The schema itself is link-free.',
-  'Channel hard-delete tombstones',
+  '`channel_index_tombstones`',
+  '`IndexMutation::Delete`',
+  'A count other than one is a permanent source-contract failure',
   'Runtime capability presence does not establish persisted schema readiness.',
   'maintainer-run',
 ]);


### PR DESCRIPTION
## Summary

- rebuild the SalesChannel retained-delete slice directly on current `main@725700addfab58b7ad32b00ae166a2f86482fbe0`;
- actualize the canonical `rustok-index` implementation plan against the source present on `main`;
- retain hard-deleted Channel identities in Channel-owned `channel_index_tombstones` storage;
- fence hard delete, identity movement, and identity reuse with monotonic source-version semantics;
- extend `sales-channel-postgres-primary` to replay both live upserts and retained `IndexMutation::Delete` mutations;
- fail closed when one SalesChannel identity is simultaneously live and tombstoned;
- preserve the existing SalesChannel schema fingerprint, source/factory name, stable `channel_id` cursor, targeted-load shape, and event domain;
- update Channel and Index documentation plus the fail-closed source verifier.

## Fresh-main reconstruction

This PR replaces conflict-stale draft #2806. Its six existing touched files were rechecked by blob SHA against both #2806's base and current `main`; all remained byte-identical. The two added files remained absent. The reviewed final blobs were therefore rebuilt as one clean commit directly on current `main`, without carrying the stale branch history.

The branch is one commit ahead and zero behind `main` and changes only the expected eight files.

## Implementation recheck

The source-level audit confirmed on `main`:

- Product and ProductVariant bounded sources, graph links, retained tombstones, and the bounded reconciliation runner are present;
- SalesChannel live bounded replay is present;
- Channel retained tombstone storage and delete replay were absent before this PR;
- incremental mutation-event acknowledgement remains absent and is not marked complete;
- retry/backoff/dead-letter scheduling, in-page interruption/timeouts, persisted readiness, durable Product-to-SalesChannel relations, consumer cutover, and retained PostgreSQL execution evidence remain open.

The canonical plan is updated to distinguish source-complete work from owner-execution and production-cutover work rather than treating open PRs as merged capability.

## Scope boundaries

This PR does not add or claim:

- incremental mutation ingestion or broker acknowledgement;
- persisted per-tenant Index schema readiness;
- durable Product/ProductVariant-to-SalesChannel relation revisions;
- tombstone purge admission;
- scheduler, retry/backoff, dead-letter, or graceful task ownership;
- authoritative Storefront cutover;
- retained PostgreSQL delete/recreate, replay, reconciliation, freshness, restart, or equivalence evidence.

## Validation

Not run per maintainer instruction:

- formatting;
- Cargo checks, tests, or Clippy;
- JavaScript verifiers;
- PostgreSQL migration or replay scenarios;
- CI workflows.

## History

Supersedes #2806 and the earlier historical drafts #2793 and #2636.