### PR TITLE
fix(product): bound admin catalog-option diagnostics

### DIFF
--- a/crates/rustok-product/admin/src/catalog_transport.rs
+++ b/crates/rustok-product/admin/src/catalog_transport.rs
@@ -53,8 +53,12 @@ impl CatalogSearchOptionsErrorContext {
     }
 
     fn map_error(&self, raw_error: String) -> String {
+        let raw_error_present = !raw_error.is_empty();
+        let raw_error_length = raw_error.chars().count();
+
         tracing::error!(
-            raw_error = %raw_error,
+            raw_error_present,
+            raw_error_length,
             owner = PRODUCT_ADMIN_CATALOG_OPTIONS_OWNER,
             owner_operation = PRODUCT_ADMIN_CATALOG_OPTIONS_OPERATION,
             correlation_id = %self.correlation_id,

--- a/crates/rustok-product/contracts/evidence/admin-catalog-search-options-error-safety-source-review.json
+++ b/crates/rustok-product/contracts/evidence/admin-catalog-search-options-error-safety-source-review.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "reviewed_at_utc": "2026-08-03T08:35:00Z",
-  "review_base": "13c3e5a190e5e0f01d68dad9952ac8f53eb2872e",
+  "review_base": "725700addfab58b7ad32b00ae166a2f86482fbe0",
   "status": "product_admin_catalog_search_options_error_safety_source_reviewed_unvalidated",
   "scope": "Product Admin catalog search-options public error and private diagnostic boundary",
   "reviewed_sources": [

--- a/crates/rustok-product/contracts/evidence/admin-catalog-search-options-error-safety-source-review.json
+++ b/crates/rustok-product/contracts/evidence/admin-catalog-search-options-error-safety-source-review.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
-  "reviewed_at_utc": "2026-07-30T19:18:00Z",
-  "review_base": "1c27a58320db2d91179beabfda064f22bcf82619",
+  "reviewed_at_utc": "2026-08-03T08:35:00Z",
+  "review_base": "13c3e5a190e5e0f01d68dad9952ac8f53eb2872e",
   "status": "product_admin_catalog_search_options_error_safety_source_reviewed_unvalidated",
-  "scope": "Product Admin catalog search-options public error boundary",
+  "scope": "Product Admin catalog search-options public error and private diagnostic boundary",
   "reviewed_sources": [
     "crates/rustok-commerce/docs/implementation-plan.md",
     "crates/rustok-product/docs/implementation-plan.md",
@@ -14,28 +14,29 @@
     "crates/rustok-product/admin/src/transport/native_server_adapter.rs",
     "crates/rustok-product/admin/src/transport/graphql_adapter.rs",
     "crates/rustok-product/admin/src/ui/catalog_admin.rs",
-    "scripts/verify/verify-product-admin-boundary.mjs"
+    "scripts/verify/verify-product-admin-boundary.mjs",
+    "scripts/verify/verify-product-admin-catalog-options-error-safety.mjs"
   ],
   "findings": [
     {
       "id": "catalog-options-public-string-cause",
+      "severity": "preserved_closed",
+      "finding": "The Product Admin catalog search-options wrapper already replaces three GraphQL String handoffs with one static public message, so GraphQL server messages, HTTP status text, and transport classification do not cross the public UI resource boundary."
+    },
+    {
+      "id": "catalog-options-private-raw-error",
       "severity": "confirmed",
-      "finding": "The Product Admin catalog search-options fallback converted three GraphQL failures with err.to_string() and returned the resulting String to the UI resource boundary. GraphQL server messages, HTTP status text, or transport classification could therefore become the public error value."
+      "finding": "Current main still writes the complete captured GraphQL String through raw_error = %raw_error in structured tracing. The focused verifier and retained evidence explicitly required that payload even though correlation, stable classification, and error shape are sufficient."
+    },
+    {
+      "id": "bounded-private-diagnostics",
+      "severity": "selected",
+      "finding": "The smallest compatible correction keeps the existing String handoff and public result type but records only raw-error presence and character length with the existing correlation and bounded request shape."
     },
     {
       "id": "native-first-sequence",
       "severity": "preserved",
       "finding": "The native search-options endpoint remains the first attempt. Only after native failure does the legacy fallback load bootstrap, categories, and attributes in that order."
-    },
-    {
-      "id": "smallest-compatible-boundary",
-      "severity": "selected",
-      "finding": "The crate-root catalog transport wrapper is the smallest compatible public boundary because it receives the final String after the existing fallback sequence without changing owner calls, projections, or the UI result type."
-    },
-    {
-      "id": "private-cause-safe-shape",
-      "severity": "confirmed",
-      "finding": "The wrapper retains the captured String only in private tracing with a unique correlation id and token/tenant/locale shape facts. It exposes one static public message and does not log request values."
     },
     {
       "id": "remaining-product-admin-scope",
@@ -44,7 +45,6 @@
     }
   ],
   "changed_files_expected": [
-    "crates/rustok-product/admin/Cargo.toml",
     "crates/rustok-product/admin/src/catalog_transport.rs",
     "crates/rustok-product/contracts/evidence/admin-catalog-search-options-error-safety-source.json",
     "crates/rustok-product/contracts/evidence/admin-catalog-search-options-error-safety-source-review.json",
@@ -57,6 +57,7 @@
     "search-option projection and labels",
     "UI resource call shape",
     "ProductCatalogSearchOptions DTO",
+    "static public error message",
     "no fallback or retry expansion"
   ],
   "remaining_scope": [

--- a/crates/rustok-product/contracts/evidence/admin-catalog-search-options-error-safety-source.json
+++ b/crates/rustok-product/contracts/evidence/admin-catalog-search-options-error-safety-source.json
@@ -1,15 +1,17 @@
 {
   "schema_version": 1,
-  "generated_at_utc": "2026-07-30T19:18:00Z",
+  "generated_at_utc": "2026-08-03T08:35:00Z",
   "status": "product_admin_catalog_search_options_error_safety_source_unvalidated",
-  "scope": "Product Admin catalog search-options GraphQL fallback public String envelope",
+  "scope": "Product Admin catalog search-options GraphQL fallback public String and private diagnostic envelope",
   "operation": "fetch_catalog_search_options",
   "boundary": "product_admin_catalog_search_options_graphql_fallback",
   "public_message": "Product catalog search options are temporarily unavailable",
   "source_contract": {
     "native_first_preserved": true,
     "graphql_bootstrap_categories_attributes_order_preserved": true,
-    "legacy_raw_error_capture_private": true,
+    "legacy_raw_error_capture_private": false,
+    "raw_error_shape_only": true,
+    "raw_graphql_error_logged": false,
     "raw_graphql_error_public": false,
     "unique_correlation_id": true,
     "safe_request_shape_only": true,
@@ -28,9 +30,10 @@
     "tenant_slug_present",
     "tenant_slug_length",
     "locale_length",
+    "raw_error_present",
+    "raw_error_length",
     "stable_code",
-    "boundary",
-    "private_raw_graphql_error"
+    "boundary"
   ],
   "forbidden_public_or_structured_values": [
     "authentication token",
@@ -40,7 +43,8 @@
     "category ids",
     "attribute codes",
     "GraphQL server error message",
-    "HTTP status text"
+    "HTTP status text",
+    "complete GraphQL or transport error payload"
   ],
   "preserved": [
     "native catalog search-options attempt remains first",

--- a/crates/rustok-product/docs/admin-catalog-search-options-error-safety.md
+++ b/crates/rustok-product/docs/admin-catalog-search-options-error-safety.md
@@ -4,7 +4,7 @@ Status: **source-ready / unvalidated**
 
 ## Scope
 
-This slice hardens only the final public `String` error returned by Product Admin catalog search-option discovery:
+This slice hardens the final public `String` error and its private diagnostic envelope for Product Admin catalog search-option discovery:
 
 - `crates/rustok-product/admin/src/catalog_transport.rs`;
 - public `fetch_catalog_search_options` re-exported from the Product Admin crate root.
@@ -16,21 +16,22 @@ The existing implementation in `transport.rs` remains the private compatibility 
 3. load product attributes;
 4. build category and attribute search options.
 
-## Confirmed gap
+## Recheck finding
 
-The compatibility executor converted each GraphQL failure with `err.to_string()` and returned `Result<ProductCatalogSearchOptions, String>`. The UI resource consumed that result directly.
+The public boundary was already static and safe. The compatibility executor converted each GraphQL failure with `err.to_string()`, and the crate-root wrapper replaced that value with `Product catalog search options are temporarily unavailable` before returning it to the UI.
 
-The captured string can include GraphQL server messages, HTTP status text, or transport classification details. Those values are useful for private diagnostics but are not a stable Product Admin public contract.
+The residual gap was private diagnostics: `CatalogSearchOptionsErrorContext::map_error` still wrote the complete captured String through `raw_error = %raw_error`. Depending on the failure, that payload could contain GraphQL server messages, HTTP status text, parse details, or transport classification. The focused verifier and retained evidence explicitly required that complete payload.
 
 ## Boundary placement
 
-The crate-root catalog transport now owns a public wrapper around the unchanged compatibility executor. It creates `CatalogSearchOptionsErrorContext` before the native/GraphQL fallback begins.
+The crate-root catalog transport continues to own the public wrapper around the unchanged compatibility executor. It creates `CatalogSearchOptionsErrorContext` before the native/GraphQL fallback begins.
 
-When the compatibility executor returns an error, the wrapper:
+When the compatibility executor returns an error, the wrapper now:
 
-- logs the captured string only in private tracing;
+- does not write the captured error text to structured tracing;
+- records only whether the raw error is present and its character length;
 - attaches a unique correlation id;
-- records only token presence, tenant-slug presence/length, and locale length;
+- records token presence, tenant-slug presence/length, and locale length;
 - returns `Product catalog search options are temporarily unavailable`.
 
 The public success DTO and `Result<_, String>` shape remain unchanged.
@@ -51,8 +52,9 @@ product.admin_catalog_search_options_graphql_unavailable
 
 ## Data minimization
 
-Structured diagnostics do not contain:
+Structured diagnostics contain only bounded classification and shape facts. They do not contain:
 
+- the complete GraphQL, HTTP, parse, or transport error payload;
 - the authentication token;
 - tenant slug or tenant id;
 - locale value;
@@ -61,7 +63,7 @@ Structured diagnostics do not contain:
 - option labels;
 - GraphQL variables or response data.
 
-Only presence and character-length facts are retained alongside the private captured error.
+The raw error is consumed only to derive presence and character length before the static public message is returned.
 
 ## Preserved behavior
 
@@ -84,7 +86,7 @@ This slice does not change:
 - `crates/rustok-product/contracts/evidence/admin-catalog-search-options-error-safety-source-review.json`;
 - `scripts/verify/verify-product-admin-catalog-options-error-safety.mjs`.
 
-All execution fields remain false. Source review does not prove compilation, verifier execution, browser behavior, or mounted fallback behavior.
+The focused verifier now fails closed if the complete raw error returns to structured tracing. All execution fields remain false. Source review does not prove compilation, verifier execution, browser behavior, or mounted fallback behavior.
 
 ## Remaining work
 

--- a/scripts/verify/verify-product-admin-catalog-options-error-safety.mjs
+++ b/scripts/verify/verify-product-admin-catalog-options-error-safety.mjs
@@ -105,7 +105,10 @@ for (const marker of [
   "uuid::Uuid::new_v4()",
   '"product-admin-catalog-options:{PRODUCT_ADMIN_CATALOG_OPTIONS_OPERATION}:{}"',
   "fn map_error(&self, raw_error: String) -> String",
-  "raw_error = %raw_error",
+  "let raw_error_present = !raw_error.is_empty();",
+  "let raw_error_length = raw_error.chars().count();",
+  "raw_error_present,",
+  "raw_error_length,",
   "correlation_id = %self.correlation_id",
   "token_present = self.token_present",
   "tenant_slug_length = ?self.tenant_slug_length",
@@ -117,6 +120,10 @@ for (const marker of [
   requireText(publicTransport, marker, `${paths.publicTransport}: correlation-safe static mapping`);
 }
 for (const marker of [
+  "raw_error = %raw_error",
+  "raw_error = ?raw_error",
+  "error = %raw_error",
+  "error = ?raw_error",
   "token = %",
   "token = ?",
   "tenant_slug = %",
@@ -126,7 +133,7 @@ for (const marker of [
   "tenant_id = %",
   "tenant_id = ?",
 ]) {
-  forbidText(publicTransport, marker, `${paths.publicTransport}: raw request values must not be logged`);
+  forbidText(publicTransport, marker, `${paths.publicTransport}: raw diagnostic or request values must not be logged`);
 }
 
 const legacyBlock = between(
@@ -190,7 +197,9 @@ if (
 for (const [key, expected] of Object.entries({
   native_first_preserved: true,
   graphql_bootstrap_categories_attributes_order_preserved: true,
-  legacy_raw_error_capture_private: true,
+  legacy_raw_error_capture_private: false,
+  raw_error_shape_only: true,
+  raw_graphql_error_logged: false,
   raw_graphql_error_public: false,
   unique_correlation_id: true,
   safe_request_shape_only: true,
@@ -204,6 +213,17 @@ for (const [key, expected] of Object.entries({
   if (evidence.source_contract?.[key] !== expected) {
     failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
   }
+}
+for (const marker of [
+  "raw_error_present",
+  "raw_error_length",
+]) {
+  if (!evidence.safe_diagnostics?.includes(marker)) {
+    failures.push(`${paths.evidence}: safe_diagnostics must include ${marker}`);
+  }
+}
+if (evidence.safe_diagnostics?.includes("private_raw_graphql_error")) {
+  failures.push(`${paths.evidence}: safe_diagnostics must not retain private_raw_graphql_error`);
 }
 for (const key of [
   "tests_run",
@@ -237,6 +257,7 @@ requireText(
   `${paths.doc}: static public contract`,
 );
 requireText(doc, "native-first fallback policy", `${paths.doc}: preserved fallback policy`);
+requireText(doc, "does not write the captured error text", `${paths.doc}: bounded diagnostic policy`);
 
 if (failures.length > 0) {
   console.error("Product Admin catalog search-options error-safety verification failed:");
@@ -245,5 +266,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Product Admin catalog search-option failures use one correlation-safe static public String; execution evidence remains open",
+  "Product Admin catalog search-option failures use one static public String and bounded private diagnostics; execution evidence remains open",
 );


### PR DESCRIPTION
## Summary

- continue the ecommerce correlation-safe mapper cleanup for the Product Admin catalog search-options fallback;
- preserve the native-first attempt, GraphQL bootstrap/categories/attributes order, public `Result<_, String>` shape, static public message, correlation id, and bounded request-shape facts;
- stop writing the complete captured GraphQL/HTTP/transport String into structured tracing;
- retain only raw-error presence and character length in the private diagnostic envelope;
- make the focused verifier fail closed against raw error payload logging;
- update source evidence, review evidence, and operator documentation without promoting Product or ecommerce FFA/FBA status.

## Recheck

The public Product Admin error was already static and safe, but `CatalogSearchOptionsErrorContext::map_error` still emitted `raw_error = %raw_error`. The existing focused verifier and retained evidence explicitly required that complete private payload. This PR removes that residual diagnostic leak while preserving the compatibility executor and all public behavior.

The canonical ecommerce plan remains open for the broader correlation-safe mapper cleanup across remaining adapters and non-`PortError` envelopes.

## Deliberate boundary

This change does not alter GraphQL documents, variables, DTOs, native/GraphQL selection, fallback order/count, retries, Product owner policy, dependencies, workflows, CI configuration, browser behavior, mounted behavior, or FFA/FBA status.

## Validation

Tests, Node verifiers, formatting, Cargo checks, browser execution, workflows, and CI were not run, per maintainer request.

Suggested maintainer commands:

```bash
node scripts/verify/verify-product-admin-catalog-options-error-safety.mjs
node scripts/verify/verify-product-admin-boundary.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-product-admin
cargo check -p rustok-product-admin --features hydrate
cargo check -p rustok-product-admin --features ssr
```

Branch merge base: `725700addfab58b7ad32b00ae166a2f86482fbe0`.
Current `main` contains one later non-overlapping Index/Channel commit.