### PR TITLE
fix(product): bound primary mutation diagnostics

### DIFF
--- a/crates/rustok-product/admin/src/transport/graphql_error_safety.rs
+++ b/crates/rustok-product/admin/src/transport/graphql_error_safety.rs
@@ -424,10 +424,18 @@ impl GraphqlMutationContext {
                 false,
             ),
         };
+        let error_payload_length = match &error {
+            GraphqlHttpError::Http(value) | GraphqlHttpError::Graphql(value) => {
+                Some(value.chars().count())
+            }
+            GraphqlHttpError::Network | GraphqlHttpError::Unauthorized => None,
+        };
+        let error_payload_present = error_payload_length.is_some_and(|length| length > 0);
 
         if technical_failure {
             tracing::error!(
-                raw_error = ?error,
+                error_payload_present,
+                error_payload_length = ?error_payload_length,
                 owner = PRODUCT_ADMIN_GRAPHQL_OWNER,
                 owner_operation = self.operation,
                 correlation_id = %self.correlation_id,
@@ -448,7 +456,8 @@ impl GraphqlMutationContext {
             );
         } else {
             tracing::warn!(
-                raw_error = ?error,
+                error_payload_present,
+                error_payload_length = ?error_payload_length,
                 owner = PRODUCT_ADMIN_GRAPHQL_OWNER,
                 owner_operation = self.operation,
                 correlation_id = %self.correlation_id,

--- a/crates/rustok-product/contracts/evidence/admin-primary-graphql-mutation-error-safety-source-review.json
+++ b/crates/rustok-product/contracts/evidence/admin-primary-graphql-mutation-error-safety-source-review.json
@@ -1,31 +1,38 @@
 {
   "schema_version": 1,
-  "reviewed_at_utc": "2026-07-30T19:52:00Z",
-  "review_base": "06c1aa0fa694cdaf5f8e88d3422777fd052ffd61",
+  "reviewed_at_utc": "2026-08-03T09:27:00Z",
+  "review_base": "14e268b8c71d8e88390cee0b8f5eafd037a54dca",
   "status": "product_admin_primary_graphql_mutation_error_safety_source_reviewed_unvalidated",
-  "scope": "Product Admin primary GraphQL mutation public error boundary",
+  "scope": "Product Admin primary GraphQL mutation public and private diagnostic boundary",
   "reviewed_sources": [
     "crates/rustok-commerce/docs/implementation-plan.md",
     "crates/rustok-product/docs/implementation-plan.md",
     "crates/rustok-product/admin/src/catalog_transport.rs",
     "crates/rustok-product/admin/src/transport.rs",
     "crates/rustok-product/admin/src/transport/graphql_error_safety.rs",
+    "crates/rustok-product/admin/src/transport/graphql_fallback_mutation_error_safety.rs",
     "crates/rustok-product/admin/src/transport/graphql_adapter.rs",
     "crates/rustok-product/admin/src/ui/leptos.rs",
     "crates/rustok-graphql/src/lib.rs",
-    "scripts/verify/verify-product-admin-primary-read-error-safety.mjs",
-    "scripts/verify/verify-product-admin-category-read-error-safety.mjs"
+    "scripts/verify/verify-product-admin-primary-mutation-error-safety.mjs",
+    "scripts/verify/verify-product-admin-fallback-mutation-error-safety.mjs",
+    "scripts/verify/verify-product-admin-graphql-read-diagnostic-safety.mjs"
   ],
   "findings": [
     {
-      "id": "product-admin-primary-mutation-raw-graphql-errors",
-      "severity": "confirmed",
-      "finding": "create_product, update_product, change_product_status and delete_product delegated directly to the GraphQL adapter. Http carried response status text and Graphql carried the first server error message into UI command errors."
+      "id": "primary-mutation-public-envelope-already-safe",
+      "severity": "preserved",
+      "finding": "create_product, update_product, change_product_status and delete_product already map Http and Graphql variants to fixed Product Admin public messages while preserving typed Network and Unauthorized variants."
     },
     {
-      "id": "typed-envelope-compatible-fix",
+      "id": "primary-mutation-private-debug-payload",
+      "severity": "confirmed",
+      "finding": "GraphqlMutationContext::map_error still emitted raw_error = ?error in both severity branches. Http(String) and Graphql(String) could therefore copy complete backend-controlled status or server-message text into structured tracing."
+    },
+    {
+      "id": "bounded-payload-shape-fix",
       "severity": "selected",
-      "finding": "The bounded fix keeps GraphqlHttpError as the result type, preserves Network and Unauthorized, and replaces only Http and Graphql payloads with the existing Product Admin static messages."
+      "finding": "The compatible fix preserves typed variant classification, stable codes, severity and public errors but retains only payload presence and character length for Http and Graphql. Network and Unauthorized retain no invented payload."
     },
     {
       "id": "mutation-command-shapes-preserved",
@@ -33,18 +40,17 @@
       "finding": "CreateProductInput, UpdateProductInput, status-only update construction, delete variables, tenant/user variables and response DTO mapping remain in the unchanged private GraphQL adapter."
     },
     {
-      "id": "safe-mutation-diagnostics",
+      "id": "request-shape-diagnostics-preserved",
       "severity": "confirmed",
-      "finding": "The owner policy records token presence and character lengths for tenant, actor, resource and status fields plus draft presence. It does not structure raw request values or draft content."
+      "finding": "The owner policy continues to record token presence and bounded tenant, actor, resource and status shape plus draft presence. Raw request values, draft content and the complete typed error are not structured fields."
     },
     {
-      "id": "prior-read-slices-preserved",
-      "severity": "preserved",
-      "finding": "Catalog-options, primary-read and category-read wrappers remain unchanged. Mutation wrappers use a distinct mapper variable so prior exact-count guards retain their original scopes."
+      "id": "remaining-fallback-mutation-diagnostic-gap",
+      "severity": "open",
+      "finding": "The separate GraphqlFallbackMutationContext still emits the complete typed error and remains the next Product Admin diagnostic cleanup slice."
     }
   ],
   "changed_files_expected": [
-    "crates/rustok-product/admin/src/catalog_transport.rs",
     "crates/rustok-product/admin/src/transport/graphql_error_safety.rs",
     "crates/rustok-product/contracts/evidence/admin-primary-graphql-mutation-error-safety-source.json",
     "crates/rustok-product/contracts/evidence/admin-primary-graphql-mutation-error-safety-source-review.json",
@@ -56,11 +62,13 @@
     "mutation input and response mapping",
     "primary mutation function result types",
     "Product Admin UI command composition",
+    "static public error messages",
+    "typed error classification and severity",
     "absence of new retry or fallback paths",
-    "all previously merged read error-safety policies"
+    "all previously merged read diagnostic policies"
   ],
   "remaining_scope": [
-    "Product Admin category, schema and attribute-value GraphQL mutations",
+    "Product Admin native-first GraphQL fallback mutation diagnostic envelope",
     "Product Admin focused verifier execution and Cargo compilation",
     "browser and mounted transport evidence",
     "remaining ecommerce non-PortError public envelopes"

--- a/crates/rustok-product/contracts/evidence/admin-primary-graphql-mutation-error-safety-source.json
+++ b/crates/rustok-product/contracts/evidence/admin-primary-graphql-mutation-error-safety-source.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
-  "generated_at_utc": "2026-07-30T19:52:00Z",
+  "generated_at_utc": "2026-08-03T09:27:00Z",
   "status": "product_admin_primary_graphql_mutation_error_safety_source_unvalidated",
-  "scope": "Product Admin primary GraphQL mutation public envelopes",
+  "scope": "Product Admin primary GraphQL mutation public and private diagnostic envelopes",
   "operations": [
     "create_product",
     "update_product",
@@ -26,7 +26,9 @@
     "graphql_static_public_envelope": true,
     "raw_http_status_public": false,
     "raw_graphql_message_public": false,
-    "private_typed_error_diagnostics": true,
+    "complete_typed_error_logged": false,
+    "error_payload_shape_only": true,
+    "private_typed_error_classification": true,
     "safe_request_shape_only": true,
     "result_types_changed": false,
     "graphql_documents_changed": false,
@@ -50,10 +52,11 @@
     "status_present",
     "status_length",
     "draft_present",
+    "error_payload_present",
+    "error_payload_length",
     "error_kind",
     "code",
-    "boundary",
-    "private_typed_graphql_error"
+    "boundary"
   ],
   "forbidden_public_or_structured_values": [
     "token",
@@ -63,6 +66,7 @@
     "product_id",
     "status",
     "product draft fields",
+    "complete typed GraphqlHttpError",
     "HTTP status text",
     "GraphQL server message"
   ],
@@ -71,18 +75,21 @@
     "CreateProductInput and UpdateProductInput construction",
     "tenant and actor GraphQL variables",
     "create, update, status and delete mutation documents",
+    "public static error envelopes",
+    "typed variant classification and severity",
     "UI command composition",
     "absence of retry or fallback behavior"
   ],
   "remaining_scope": [
-    "Product Admin category, schema and attribute-value GraphQL mutations",
+    "Product Admin native-first GraphQL fallback mutation diagnostic envelopes",
     "Product Admin browser and mounted transport evidence",
     "remaining ecommerce non-PortError public envelopes"
   ],
   "suggested_execution": [
     "node scripts/verify/verify-product-admin-primary-mutation-error-safety.mjs",
-    "node scripts/verify/verify-product-admin-category-read-error-safety.mjs",
-    "node scripts/verify/verify-product-admin-primary-read-error-safety.mjs",
+    "node scripts/verify/verify-product-admin-fallback-mutation-error-safety.mjs",
+    "node scripts/verify/verify-product-admin-graphql-read-diagnostic-safety.mjs",
+    "node scripts/verify/verify-product-admin-catalog-options-error-safety.mjs",
     "node scripts/verify/verify-product-admin-boundary.mjs",
     "node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs",
     "cargo check -p rustok-product-admin",

--- a/crates/rustok-product/docs/admin-primary-graphql-mutation-error-safety.md
+++ b/crates/rustok-product/docs/admin-primary-graphql-mutation-error-safety.md
@@ -4,7 +4,7 @@ Status: **source-ready / unvalidated**
 
 ## Scope
 
-This slice hardens the final public error envelope for four Product Admin mutations:
+This slice covers the public and private diagnostic envelopes for four Product Admin mutations:
 
 - `create_product`;
 - `update_product`;
@@ -18,22 +18,26 @@ The boundary lives in:
 
 The GraphQL mutation documents, variables, input builders, response DTOs and Product owner policy are unchanged.
 
-## Confirmed gap
+## Confirmed diagnostic gap
 
-The four primary product commands delegated directly through the compatibility transport to the GraphQL adapter.
+The four operations already used a Product-owned public mapper. `Http(String)` and
+`Graphql(String)` were replaced with static Product Admin messages before crossing the facade.
 
-`GraphqlHttpError::Http(String)` can contain HTTP status text and
-`GraphqlHttpError::Graphql(String)` can contain the first GraphQL server message. Those payloads could therefore reach Product Admin UI command errors.
+The same mapper still emitted `raw_error = ?error` in private structured tracing. A backend-controlled
+HTTP status or GraphQL server message could therefore be copied in full into the diagnostic event even
+though the public envelope was safe.
 
 ## Boundary placement
 
-A `GraphqlMutationContext` is created before each selected compatibility transport call. The wrapper maps only a final returned `GraphqlHttpError`.
+A `GraphqlMutationContext` remains created before each selected compatibility transport call. The
+wrapper still maps only a final returned `GraphqlHttpError`.
 
-No retry, fallback, extra owner call, mutation document, variable or response mapping is introduced.
+No retry, fallback, extra owner call, mutation document, variable, response mapping or public type is
+introduced.
 
 ## Public policy
 
-The result error type remains `GraphqlHttpError`.
+The result error type and messages remain unchanged.
 
 | Captured condition | Public error |
 | --- | --- |
@@ -42,11 +46,16 @@ The result error type remains `GraphqlHttpError`.
 | Unauthorized | `Unauthorized` |
 | GraphQL rejection | `GraphQL error: Product admin request could not be completed` |
 
-`Network` and `Unauthorized` remain fixed non-identifying variants. HTTP status text and GraphQL server messages are replaced with static Product Admin messages.
+`Network` and `Unauthorized` remain fixed non-identifying variants. HTTP status text and GraphQL server
+messages remain absent from the public result.
 
 ## Internal diagnostics
 
-The original typed error remains available only to private tracing. Each event records:
+The mapper preserves typed variant classification, stable code, technical-versus-ordinary severity and
+correlation. It no longer writes the complete `GraphqlHttpError` Debug representation.
+
+For `Http` and `Graphql`, tracing retains only payload presence and character length. `Network` and
+`Unauthorized` retain no invented payload. Each event also records:
 
 - owner, operation and boundary;
 - a unique correlation ID;
@@ -58,7 +67,8 @@ The original typed error remains available only to private tracing. Each event r
 - whether a product draft was supplied;
 - error kind and stable code.
 
-Raw token, tenant slug, tenant ID, actor ID, product ID, status and draft content are not structured fields.
+Raw token, tenant slug, tenant ID, actor ID, product ID, status, draft content and complete backend error
+text are not structured fields. The complete typed error is not logged.
 
 ## Preserved behavior
 
@@ -70,8 +80,10 @@ This slice does not change:
 - status-only update behavior;
 - delete-product variables;
 - UI save, status and delete command composition;
+- public error messages;
+- typed error classification or log severity;
 - retries or fallback behavior;
-- previously merged Product Admin read error policies;
+- previously merged Product Admin read diagnostic policies;
 - Product FFA/FBA, browser, mounted-runtime, workflow, CI or production status.
 
 ## Static evidence
@@ -80,13 +92,14 @@ This slice does not change:
 - `crates/rustok-product/contracts/evidence/admin-primary-graphql-mutation-error-safety-source-review.json`;
 - `scripts/verify/verify-product-admin-primary-mutation-error-safety.mjs`.
 
-All execution flags remain `false`. Source review does not prove compilation, browser behavior, mounted transport behavior, workflow execution, CI or production behavior.
+All execution flags remain `false`. Source review does not prove compilation, browser behavior, mounted
+transport behavior, workflow execution, CI or production behavior.
 
 ## Remaining work
 
 The ecommerce mapper cleanup remains open for:
 
-- Product Admin category, schema and attribute-value GraphQL mutations;
+- Product Admin native-first GraphQL fallback mutation diagnostics;
 - Product Admin browser and mounted transport evidence;
 - other ecommerce adapters and non-`PortError` public envelopes.
 
@@ -96,8 +109,9 @@ These commands were intentionally not run by the implementation agent:
 
 ```bash
 node scripts/verify/verify-product-admin-primary-mutation-error-safety.mjs
-node scripts/verify/verify-product-admin-category-read-error-safety.mjs
-node scripts/verify/verify-product-admin-primary-read-error-safety.mjs
+node scripts/verify/verify-product-admin-fallback-mutation-error-safety.mjs
+node scripts/verify/verify-product-admin-graphql-read-diagnostic-safety.mjs
+node scripts/verify/verify-product-admin-catalog-options-error-safety.mjs
 node scripts/verify/verify-product-admin-boundary.mjs
 node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
 cargo check -p rustok-product-admin

--- a/scripts/verify/verify-product-admin-primary-mutation-error-safety.mjs
+++ b/scripts/verify/verify-product-admin-primary-mutation-error-safety.mjs
@@ -37,6 +37,10 @@ const paths = {
   ui: "crates/rustok-product/admin/src/ui/leptos.rs",
   primaryReadGuard: "scripts/verify/verify-product-admin-primary-read-error-safety.mjs",
   categoryReadGuard: "scripts/verify/verify-product-admin-category-read-error-safety.mjs",
+  readDiagnosticGuard:
+    "scripts/verify/verify-product-admin-graphql-read-diagnostic-safety.mjs",
+  fallbackMutationGuard:
+    "scripts/verify/verify-product-admin-fallback-mutation-error-safety.mjs",
   evidence:
     "crates/rustok-product/contracts/evidence/admin-primary-graphql-mutation-error-safety-source.json",
   review:
@@ -53,6 +57,8 @@ const graphqlHttp = read(paths.graphqlHttp);
 const ui = read(paths.ui);
 const primaryReadGuard = read(paths.primaryReadGuard);
 const categoryReadGuard = read(paths.categoryReadGuard);
+const readDiagnosticGuard = read(paths.readDiagnosticGuard);
+const fallbackMutationGuard = read(paths.fallbackMutationGuard);
 const evidence = JSON.parse(read(paths.evidence));
 const review = JSON.parse(read(paths.review));
 const doc = read(paths.doc);
@@ -98,7 +104,9 @@ for (const operation of operations) {
   ]) {
     requireText(block, marker, `${paths.facade}: ${operation.name} final boundary`);
   }
-  if (block.indexOf(operation.context) > block.indexOf(operation.call)) {
+  const contextIndex = block.indexOf(operation.context);
+  const callIndex = block.indexOf(operation.call);
+  if (!(contextIndex >= 0 && callIndex >= 0 && contextIndex < callIndex)) {
     failures.push(`${paths.facade}: ${operation.name} context must precede the GraphQL call`);
   }
 }
@@ -122,6 +130,12 @@ if (countText(facade, ".map_err(|mutation_error| context.map_error(mutation_erro
   failures.push(`${paths.facade}: expected exactly four primary mutation mappers`);
 }
 
+const mutationBlock = between(
+  safety,
+  "pub(super) struct GraphqlMutationContext",
+  "fn text_length",
+  paths.safety,
+);
 for (const [marker, label] of [
   ["const PRODUCT_ADMIN_MUTATION_GRAPHQL_BOUNDARY", "mutation boundary"],
   ['"product_admin_primary_graphql_mutations"', "mutation boundary identity"],
@@ -142,7 +156,13 @@ for (const [marker, label] of [
   ['"product.admin_graphql_http_unavailable"', "HTTP code"],
   ['"product.admin_graphql_authentication_required"', "auth code"],
   ['"product.admin_graphql_request_rejected"', "GraphQL code"],
-  ["raw_error = ?error", "private typed diagnostics"],
+  ["let error_payload_length = match &error", "bounded payload derivation"],
+  ["GraphqlHttpError::Http(value) | GraphqlHttpError::Graphql(value)", "payload variants"],
+  ["Some(value.chars().count())", "payload character length"],
+  ["GraphqlHttpError::Network | GraphqlHttpError::Unauthorized => None", "payload-free variants"],
+  ["let error_payload_present = error_payload_length.is_some_and(|length| length > 0);", "payload presence"],
+  ["error_payload_present,", "payload presence diagnostic"],
+  ["error_payload_length = ?error_payload_length", "payload length diagnostic"],
   ["correlation_id = %self.correlation_id", "correlation diagnostics"],
   ["token_present = self.token_present", "token presence"],
   ["tenant_slug_length = ?self.tenant_slug_length", "tenant slug shape"],
@@ -153,9 +173,24 @@ for (const [marker, label] of [
   ["draft_present = self.draft_present", "draft presence"],
   ["boundary = PRODUCT_ADMIN_MUTATION_GRAPHQL_BOUNDARY", "mutation boundary log"],
 ]) {
-  requireText(safety, marker, `${paths.safety}: ${label}`);
+  requireText(mutationBlock, marker, `${paths.safety}: ${label}`);
 }
-
+if (countText(mutationBlock, "error_payload_present,") !== 2) {
+  failures.push(`${paths.safety}: both mutation severity branches must record payload presence`);
+}
+if (countText(mutationBlock, "error_payload_length = ?error_payload_length") !== 2) {
+  failures.push(`${paths.safety}: both mutation severity branches must record payload length`);
+}
+for (const marker of [
+  "raw_error = ?error",
+  "raw_error = %error",
+  "error = ?error",
+  "error = %error",
+  "internal_message = %",
+  "parsed_error = ?",
+]) {
+  forbidText(mutationBlock, marker, `${paths.safety}: complete mutation error payload`);
+}
 for (const marker of [
   "token = %",
   "token = ?",
@@ -172,7 +207,7 @@ for (const marker of [
   "draft = %",
   "draft = ?",
 ]) {
-  forbidText(safety, marker, `${paths.safety}: raw mutation values must not be logged`);
+  forbidText(mutationBlock, marker, `${paths.safety}: raw mutation value`);
 }
 
 for (const marker of [
@@ -183,7 +218,6 @@ for (const marker of [
 ]) {
   requireText(legacy, marker, `${paths.legacy}: preserved private mutation delegation`);
 }
-
 for (const marker of [
   "const CREATE_PRODUCT_MUTATION",
   "const UPDATE_PRODUCT_MUTATION",
@@ -214,16 +248,14 @@ for (const marker of [
 ]) {
   requireText(ui, marker, `${paths.ui}: preserved UI mutation composition`);
 }
-requireText(
-  primaryReadGuard,
-  "Product Admin primary GraphQL read error-safety verification failed:",
-  `${paths.primaryReadGuard}: prior primary-read guard remains present`,
-);
-requireText(
-  categoryReadGuard,
-  "Product Admin category GraphQL read error-safety verification failed:",
-  `${paths.categoryReadGuard}: prior category-read guard remains present`,
-);
+for (const [source, marker, label] of [
+  [primaryReadGuard, "verify-product-admin-graphql-read-diagnostic-safety.mjs", "primary read compatibility guard"],
+  [categoryReadGuard, "verify-product-admin-graphql-read-diagnostic-safety.mjs", "category read compatibility guard"],
+  [readDiagnosticGuard, "Product Admin GraphQL read diagnostic-safety verification failed:", "shared read diagnostic guard"],
+  [fallbackMutationGuard, "GraphqlFallbackMutationContext", "fallback mutation guard"],
+]) {
+  requireText(source, marker, `${label}: prior focused guard remains present`);
+}
 
 if (evidence.schema_version !== 1) failures.push(`${paths.evidence}: schema_version must be 1`);
 if (
@@ -253,7 +285,9 @@ for (const [key, expected] of Object.entries({
   graphql_static_public_envelope: true,
   raw_http_status_public: false,
   raw_graphql_message_public: false,
-  private_typed_error_diagnostics: true,
+  complete_typed_error_logged: false,
+  error_payload_shape_only: true,
+  private_typed_error_classification: true,
   safe_request_shape_only: true,
   result_types_changed: false,
   graphql_documents_changed: false,
@@ -265,6 +299,20 @@ for (const [key, expected] of Object.entries({
 })) {
   if (evidence.source_contract?.[key] !== expected) {
     failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+if (evidence.safe_diagnostics?.includes("private_typed_graphql_error")) {
+  failures.push(`${paths.evidence}: safe_diagnostics must not retain private_typed_graphql_error`);
+}
+for (const marker of [
+  "error_payload_present",
+  "error_payload_length",
+  "error_kind",
+  "code",
+  "boundary",
+]) {
+  if (!evidence.safe_diagnostics?.includes(marker)) {
+    failures.push(`${paths.evidence}: safe_diagnostics must include ${marker}`);
   }
 }
 for (const key of [
@@ -297,6 +345,8 @@ requireText(doc, "Status: **source-ready / unvalidated**", `${paths.doc}: source
 requireText(doc, "Product admin service is temporarily unavailable", `${paths.doc}: HTTP policy`);
 requireText(doc, "Product admin request could not be completed", `${paths.doc}: GraphQL policy`);
 requireText(doc, "status-only update behavior", `${paths.doc}: preserved status behavior`);
+requireText(doc, "payload presence and character length", `${paths.doc}: bounded payload policy`);
+requireText(doc, "complete typed error is not logged", `${paths.doc}: no complete payload claim`);
 requireText(
   masterPlan,
   "Finish correlation-safe mapper cleanup",
@@ -310,5 +360,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Product Admin primary GraphQL mutations retain typed errors with correlation-safe static public payloads; execution evidence remains open",
+  "Product Admin primary GraphQL mutations retain typed classification and static public errors with bounded payload-shape diagnostics; execution evidence remains open",
 );


### PR DESCRIPTION
## Summary

- continue the ecommerce correlation-safe mapper cleanup at the Product Admin primary GraphQL mutation boundary;
- cover `create_product`, `update_product`, `change_product_status`, and `delete_product`;
- preserve typed `GraphqlHttpError` classification, static public envelopes, stable codes, correlation, technical-versus-ordinary severity, bounded request shape, result types, mutation documents, variables, input mapping, response mapping, and UI command composition;
- stop writing the complete `GraphqlHttpError` Debug payload in both primary mutation severity branches;
- retain only payload presence and character length for `Http` and `Graphql`, with no invented payload for `Network` or `Unauthorized`;
- strengthen the existing fail-closed verifier and reconcile source/review evidence plus documentation without promoting Product or ecommerce FFA/FBA status.

## Recheck

The public mutation envelope was already static and safe, but `GraphqlMutationContext::map_error` still emitted `raw_error = ?error`. `GraphqlHttpError::Http(String)` and `GraphqlHttpError::Graphql(String)` could therefore copy complete backend-controlled status or server-message payloads into structured tracing.

This PR closes only the four primary mutations. The separate native-first `GraphqlFallbackMutationContext` remains unchanged and explicitly open as the next Product Admin cleanup slice.

## Deliberate boundary

No GraphQL document, variable, DTO, mutation input, response mapping, public error type/message, retry policy, fallback behavior, owner call, UI composition, dependency, workflow, CI configuration, browser behavior, mounted behavior, or FFA/FBA status changes.

## Validation

Tests, Node verifiers, formatting, Cargo checks, browser execution, workflows, and CI were not run, per maintainer request.

Suggested maintainer commands:

```bash
node scripts/verify/verify-product-admin-primary-mutation-error-safety.mjs
node scripts/verify/verify-product-admin-fallback-mutation-error-safety.mjs
node scripts/verify/verify-product-admin-graphql-read-diagnostic-safety.mjs
node scripts/verify/verify-product-admin-catalog-options-error-safety.mjs
node scripts/verify/verify-product-admin-boundary.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-product-admin
cargo check -p rustok-product-admin --features hydrate
cargo check -p rustok-product-admin --features ssr
```

Branch merge base: `14e268b8c71d8e88390cee0b8f5eafd037a54dca`. Current `main` contains later non-overlapping Index changes.