### PR TITLE
feat(index): admit Product channel relation epochs

### DIFF
--- a/crates/rustok-distribution/src/product_index/mod.rs
+++ b/crates/rustok-distribution/src/product_index/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod graph;
 #[cfg(test)]
 pub(crate) use graph::{PRODUCT_INDEX_SOURCE, PRODUCT_VARIANT_INDEX_SOURCE};
 mod product;
+pub(crate) mod relation_admission;
 #[path = "../product_variant_index.rs"]
 mod variant;
 

--- a/crates/rustok-distribution/src/product_index/relation_admission.rs
+++ b/crates/rustok-distribution/src/product_index/relation_admission.rs
@@ -1,0 +1,338 @@
+//! Admission contract for a future Product -> SalesChannel Index relation.
+//!
+//! Production persistence and source wiring are intentionally pending. Keeping this contract
+//! compiled before wiring prevents Product or Channel owner revisions from being combined through
+//! lossy `max`, hash, or pair encodings that can fail to advance after a relation-only change.
+#![allow(dead_code)]
+
+use rustok_index::{IndexSourceEventIdError, LocaleKey, derive_index_source_event_id};
+use thiserror::Error;
+use uuid::Uuid;
+
+const PRODUCT_SALES_CHANNEL_RELATION_EVENT_DOMAIN_V1: &str =
+    "rustok-distribution.product-sales-channel-relation-v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct ProductSalesChannelRelationEpoch(u64);
+
+impl ProductSalesChannelRelationEpoch {
+    pub(crate) fn new(value: u64) -> Result<Self, ProductSalesChannelRelationAdmissionError> {
+        if value == 0 {
+            return Err(ProductSalesChannelRelationAdmissionError::ZeroEpoch);
+        }
+        Ok(Self(value))
+    }
+
+    pub(crate) fn get(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProductSalesChannelRelationAdmission {
+    Initial,
+    Retry,
+    Advanced,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProductSalesChannelRelationSnapshot {
+    tenant_id: Uuid,
+    product_id: Uuid,
+    locale: LocaleKey,
+    epoch: ProductSalesChannelRelationEpoch,
+    channel_ids: Vec<Uuid>,
+    event_id: Uuid,
+}
+
+impl ProductSalesChannelRelationSnapshot {
+    pub(crate) fn new(
+        tenant_id: Uuid,
+        product_id: Uuid,
+        locale: LocaleKey,
+        epoch: ProductSalesChannelRelationEpoch,
+        channel_ids: impl IntoIterator<Item = Uuid>,
+    ) -> Result<Self, ProductSalesChannelRelationAdmissionError> {
+        if tenant_id.is_nil() {
+            return Err(ProductSalesChannelRelationAdmissionError::NilTenantId);
+        }
+        if product_id.is_nil() {
+            return Err(ProductSalesChannelRelationAdmissionError::NilProductId);
+        }
+
+        let mut channel_ids = channel_ids.into_iter().collect::<Vec<_>>();
+        if channel_ids.iter().any(Uuid::is_nil) {
+            return Err(ProductSalesChannelRelationAdmissionError::NilChannelId);
+        }
+        channel_ids.sort_unstable();
+        if channel_ids.windows(2).any(|pair| pair[0] == pair[1]) {
+            return Err(ProductSalesChannelRelationAdmissionError::DuplicateChannelId);
+        }
+
+        let event_id = derive_index_source_event_id(
+            PRODUCT_SALES_CHANNEL_RELATION_EVENT_DOMAIN_V1,
+            tenant_id,
+            product_id,
+            Some(&locale),
+            epoch.get(),
+        )?;
+
+        Ok(Self {
+            tenant_id,
+            product_id,
+            locale,
+            epoch,
+            channel_ids,
+            event_id,
+        })
+    }
+
+    pub(crate) fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub(crate) fn product_id(&self) -> Uuid {
+        self.product_id
+    }
+
+    pub(crate) fn locale(&self) -> &LocaleKey {
+        &self.locale
+    }
+
+    pub(crate) fn epoch(&self) -> ProductSalesChannelRelationEpoch {
+        self.epoch
+    }
+
+    pub(crate) fn channel_ids(&self) -> &[Uuid] {
+        &self.channel_ids
+    }
+
+    pub(crate) fn event_id(&self) -> Uuid {
+        self.event_id
+    }
+
+    pub(crate) fn admit(
+        previous: Option<&Self>,
+        next: &Self,
+    ) -> Result<ProductSalesChannelRelationAdmission, ProductSalesChannelRelationAdmissionError>
+    {
+        let Some(previous) = previous else {
+            return Ok(ProductSalesChannelRelationAdmission::Initial);
+        };
+        if previous.tenant_id != next.tenant_id
+            || previous.product_id != next.product_id
+            || previous.locale != next.locale
+        {
+            return Err(ProductSalesChannelRelationAdmissionError::ScopeChanged);
+        }
+        if next.epoch < previous.epoch {
+            return Err(ProductSalesChannelRelationAdmissionError::EpochRegressed {
+                previous: previous.epoch.get(),
+                next: next.epoch.get(),
+            });
+        }
+        if next.epoch == previous.epoch {
+            if next.channel_ids != previous.channel_ids || next.event_id != previous.event_id {
+                return Err(
+                    ProductSalesChannelRelationAdmissionError::SameEpochMembershipChanged,
+                );
+            }
+            return Ok(ProductSalesChannelRelationAdmission::Retry);
+        }
+        Ok(ProductSalesChannelRelationAdmission::Advanced)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub(crate) enum ProductSalesChannelRelationAdmissionError {
+    #[error("Product-SalesChannel relation epoch must be positive")]
+    ZeroEpoch,
+    #[error("Product-SalesChannel relation tenant id must not be nil")]
+    NilTenantId,
+    #[error("Product-SalesChannel relation product id must not be nil")]
+    NilProductId,
+    #[error("Product-SalesChannel relation channel id must not be nil")]
+    NilChannelId,
+    #[error("Product-SalesChannel relation channel ids must be unique")]
+    DuplicateChannelId,
+    #[error("Product-SalesChannel relation admission cannot change tenant, product, or locale")]
+    ScopeChanged,
+    #[error(
+        "Product-SalesChannel relation epoch regressed: previous={previous}, next={next}"
+    )]
+    EpochRegressed { previous: u64, next: u64 },
+    #[error("Product-SalesChannel membership changed without advancing its relation epoch")]
+    SameEpochMembershipChanged,
+    #[error(transparent)]
+    EventIdentity(#[from] IndexSourceEventIdError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn locale(value: &str) -> LocaleKey {
+        LocaleKey::new(value).unwrap()
+    }
+
+    fn scoped_snapshot(
+        tenant_id: Uuid,
+        product_id: Uuid,
+        epoch: u64,
+        locale: &str,
+        channel_ids: impl IntoIterator<Item = Uuid>,
+    ) -> ProductSalesChannelRelationSnapshot {
+        ProductSalesChannelRelationSnapshot::new(
+            tenant_id,
+            product_id,
+            self::locale(locale),
+            ProductSalesChannelRelationEpoch::new(epoch).unwrap(),
+            channel_ids,
+        )
+        .unwrap()
+    }
+
+    fn snapshot(
+        epoch: u64,
+        locale: &str,
+        channel_ids: impl IntoIterator<Item = Uuid>,
+    ) -> ProductSalesChannelRelationSnapshot {
+        scoped_snapshot(
+            Uuid::from_u128(1),
+            Uuid::from_u128(2),
+            epoch,
+            locale,
+            channel_ids,
+        )
+    }
+
+    #[test]
+    fn product_sales_channel_relation_canonical_membership_and_retry_identity_are_stable() {
+        let first = snapshot(
+            7,
+            "en-US",
+            [Uuid::from_u128(4), Uuid::from_u128(3)],
+        );
+        let retry = snapshot(
+            7,
+            "en-US",
+            [Uuid::from_u128(3), Uuid::from_u128(4)],
+        );
+
+        assert_eq!(first, retry);
+        assert_eq!(
+            first.channel_ids(),
+            &[Uuid::from_u128(3), Uuid::from_u128(4)]
+        );
+        assert!(!first.event_id().is_nil());
+        assert_eq!(
+            ProductSalesChannelRelationSnapshot::admit(None, &first),
+            Ok(ProductSalesChannelRelationAdmission::Initial)
+        );
+        assert_eq!(
+            ProductSalesChannelRelationSnapshot::admit(Some(&first), &retry),
+            Ok(ProductSalesChannelRelationAdmission::Retry)
+        );
+    }
+
+    #[test]
+    fn product_sales_channel_relation_change_requires_a_strictly_larger_epoch() {
+        let previous = snapshot(8, "en-US", [Uuid::from_u128(3)]);
+        let changed_same_epoch = snapshot(8, "en-US", [Uuid::from_u128(4)]);
+        let regressed = snapshot(7, "en-US", [Uuid::from_u128(4)]);
+        let advanced = snapshot(9, "en-US", [Uuid::from_u128(4)]);
+
+        assert_eq!(
+            ProductSalesChannelRelationSnapshot::admit(Some(&previous), &changed_same_epoch),
+            Err(ProductSalesChannelRelationAdmissionError::SameEpochMembershipChanged)
+        );
+        assert_eq!(
+            ProductSalesChannelRelationSnapshot::admit(Some(&previous), &regressed),
+            Err(ProductSalesChannelRelationAdmissionError::EpochRegressed {
+                previous: 8,
+                next: 7,
+            })
+        );
+        assert_eq!(
+            ProductSalesChannelRelationSnapshot::admit(Some(&previous), &advanced),
+            Ok(ProductSalesChannelRelationAdmission::Advanced)
+        );
+        assert_ne!(previous.event_id(), advanced.event_id());
+    }
+
+    #[test]
+    fn product_sales_channel_relation_invalid_identity_and_duplicates_fail_closed() {
+        assert_eq!(
+            ProductSalesChannelRelationEpoch::new(0),
+            Err(ProductSalesChannelRelationAdmissionError::ZeroEpoch)
+        );
+        assert_eq!(
+            ProductSalesChannelRelationSnapshot::new(
+                Uuid::nil(),
+                Uuid::from_u128(2),
+                locale("en-US"),
+                ProductSalesChannelRelationEpoch::new(1).unwrap(),
+                [],
+            ),
+            Err(ProductSalesChannelRelationAdmissionError::NilTenantId)
+        );
+        assert_eq!(
+            ProductSalesChannelRelationSnapshot::new(
+                Uuid::from_u128(1),
+                Uuid::nil(),
+                locale("en-US"),
+                ProductSalesChannelRelationEpoch::new(1).unwrap(),
+                [],
+            ),
+            Err(ProductSalesChannelRelationAdmissionError::NilProductId)
+        );
+        assert_eq!(
+            ProductSalesChannelRelationSnapshot::new(
+                Uuid::from_u128(1),
+                Uuid::from_u128(2),
+                locale("en-US"),
+                ProductSalesChannelRelationEpoch::new(1).unwrap(),
+                [Uuid::nil()],
+            ),
+            Err(ProductSalesChannelRelationAdmissionError::NilChannelId)
+        );
+        assert_eq!(
+            ProductSalesChannelRelationSnapshot::new(
+                Uuid::from_u128(1),
+                Uuid::from_u128(2),
+                locale("en-US"),
+                ProductSalesChannelRelationEpoch::new(1).unwrap(),
+                [Uuid::from_u128(3), Uuid::from_u128(3)],
+            ),
+            Err(ProductSalesChannelRelationAdmissionError::DuplicateChannelId)
+        );
+    }
+
+    #[test]
+    fn product_sales_channel_relation_empty_membership_is_valid_but_scope_cannot_change() {
+        let previous = snapshot(1, "en-US", []);
+        let other_locale = snapshot(2, "fr-FR", []);
+        let other_tenant = scoped_snapshot(
+            Uuid::from_u128(9),
+            Uuid::from_u128(2),
+            2,
+            "en-US",
+            [],
+        );
+        let other_product = scoped_snapshot(
+            Uuid::from_u128(1),
+            Uuid::from_u128(9),
+            2,
+            "en-US",
+            [],
+        );
+
+        assert!(previous.channel_ids().is_empty());
+        for changed_scope in [&other_locale, &other_tenant, &other_product] {
+            assert_eq!(
+                ProductSalesChannelRelationSnapshot::admit(Some(&previous), changed_scope),
+                Err(ProductSalesChannelRelationAdmissionError::ScopeChanged)
+            );
+        }
+    }
+}

--- a/crates/rustok-index/docs/m7-product-sales-channel-relation-admission.md
+++ b/crates/rustok-index/docs/m7-product-sales-channel-relation-admission.md
@@ -1,0 +1,91 @@
+# Product to SalesChannel relation admission
+
+Status: `source_contract_complete_persistence_and_wiring_pending`
+
+Rechecked on 2026-08-03 against current `main` after the database-neutral mutation-event
+acknowledgement contract and production source-call timeout landed. The canonical
+implementation plan remains unchanged because it correctly keeps durable
+Product-to-SalesChannel relations open; this admission-only slice does not complete that
+roadmap item.
+
+## Problem
+
+The Product Index source currently owns Product scalar state, ProductVariant links, and
+Product-owned channel visibility metadata. A real `IndexLink` from Product to the
+SalesChannel schema is different: Channel create, delete, reassignment, or identity
+changes can alter the resolved relation without changing `Product.index_revision`.
+Re-emitting the same Product source version would be treated as duplicate or stale and
+could retain obsolete links.
+
+A relation version must therefore not be derived with `max(product_revision,
+channel_revision)`, a hash, truncated pairing function, timestamp, row count, or the
+current Product revision. Independent owner counters do not guarantee that any of
+those encodings advances for every relation-only change.
+
+## Compiled admission contract
+
+`rustok-distribution::product_index::relation_admission` defines the bounded
+pre-persistence contract:
+
+- `ProductSalesChannelRelationEpoch` is a positive `u64` intended to be persisted by
+  the eventual authoritative relation owner;
+- `ProductSalesChannelRelationSnapshot` is scoped by exact non-nil tenant, non-nil
+  Product, and canonical locale;
+- channel UUIDs must be non-nil and unique, and are sorted canonically;
+- an empty set is valid and represents removal of all Product-to-Channel links;
+- event identity is derived with the versioned
+  `rustok-distribution.product-sales-channel-relation-v1` domain and the exact
+  relation epoch;
+- an identical epoch is accepted only for an identical retry;
+- changed membership under the same epoch fails closed;
+- epoch regression and tenant/Product/locale scope changes fail closed;
+- a strictly greater epoch is admitted as an advanced relation snapshot.
+
+The locale dimension is retained because Product Index records are locale-required.
+One durable relation epoch may fan out to each current Product locale, but every
+locale-specific mutation gets its own stable Index event identity.
+
+## Production admission requirements
+
+The relation must remain unwired until one authoritative owner provides all of the
+following atomically:
+
+1. durable epoch storage for the exact tenant/Product relation identity;
+2. a strictly monotonic increment on assignment create/delete, Channel deletion,
+   Channel identity movement, and any change that alters the resolved target set;
+3. one transaction boundary that commits membership and the new epoch together;
+4. bounded current-state scan and targeted-load access ordered by relation identity
+   and epoch;
+5. retained delete/empty-membership state so removed links replay after restart;
+6. stable event identity and source-version reuse for retries of the same epoch;
+7. a registered relation event descriptor, owner delivery route, broker adapter, and
+   commit-before-ack worker wiring for changes committed after a replay page was read;
+8. PostgreSQL evidence for concurrent assignment, delete/recreate, restart, retry,
+   out-of-order delivery, and locale fan-out.
+
+The generic mutation-event acknowledgement and source timeout substrates now exist,
+but no Product-to-SalesChannel descriptor, source route, owner storage, broker consumer,
+or host worker is added by this slice.
+
+## Explicit non-claims
+
+This slice does not add a Product-to-SalesChannel `IndexLink`, schema version, source
+query, migration, relation owner table, event consumer, checkpoint dimension, or
+Storefront cutover. It does not select which source module owns the durable epoch.
+
+The existing `allowed_channel_slugs` Product field remains Product-owned visibility
+metadata and is not evidence that the cross-owner relation epoch exists.
+
+The canonical M7 Product/Variant/Channel link item remains open until persistence,
+source wiring, retained empty-membership behavior, incremental ingestion, and retained
+PostgreSQL evidence satisfy the requirements above.
+
+## Maintainer validation
+
+Execution is maintainer-owned. Suggested commands:
+
+```bash
+cargo test -p rustok-distribution product_sales_channel_relation -- --nocapture
+cargo check -p rustok-distribution --all-targets
+node scripts/verify/verify-index-product-channel-relation-admission.mjs
+```

--- a/scripts/verify/verify-index-product-channel-relation-admission.mjs
+++ b/scripts/verify/verify-index-product-channel-relation-admission.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-channel-relation-admission] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
+  'pub(crate) mod relation_admission;',
+]);
+
+const admissionPath =
+  'crates/rustok-distribution/src/product_index/relation_admission.rs';
+const admission = requireMarkers(admissionPath, [
+  'PRODUCT_SALES_CHANNEL_RELATION_EVENT_DOMAIN_V1',
+  'rustok-distribution.product-sales-channel-relation-v1',
+  'ProductSalesChannelRelationEpoch',
+  'ProductSalesChannelRelationSnapshot',
+  'ProductSalesChannelRelationAdmission::Initial',
+  'ProductSalesChannelRelationAdmission::Retry',
+  'ProductSalesChannelRelationAdmission::Advanced',
+  'SameEpochMembershipChanged',
+  'EpochRegressed',
+  'NilTenantId',
+  'NilProductId',
+  'ScopeChanged',
+  'channel_ids.sort_unstable();',
+  'channel_ids.windows(2)',
+  'derive_index_source_event_id(',
+  'Some(&locale)',
+  'epoch.get()',
+  'product_sales_channel_relation_canonical_membership_and_retry_identity_are_stable',
+  'product_sales_channel_relation_change_requires_a_strictly_larger_epoch',
+  'product_sales_channel_relation_invalid_identity_and_duplicates_fail_closed',
+  'product_sales_channel_relation_empty_membership_is_valid_but_scope_cannot_change',
+  'other_tenant',
+  'other_product',
+]);
+
+for (const forbidden of [
+  'SystemTime',
+  'Instant',
+  'DefaultHasher',
+  'wrapping_',
+  'saturating_',
+  'product_revision.max',
+  'channel_revision.max',
+  'Utc::now',
+  'CURRENT_TIMESTAMP',
+]) {
+  if (admission.includes(forbidden)) {
+    fail(`${admissionPath} contains forbidden revision derivation ${forbidden}`);
+  }
+}
+
+const graphPath = 'crates/rustok-distribution/src/product_index/graph.rs';
+const graph = read(graphPath);
+for (const forbidden of [
+  'sales_channel',
+  'link_name("channels")',
+  'product_sales_channel_relation_epoch',
+]) {
+  if (graph.includes(forbidden)) {
+    fail(
+      `${graphPath} wires Product-to-SalesChannel links before durable epoch admission: ${forbidden}`,
+    );
+  }
+}
+
+const documentPath =
+  'crates/rustok-index/docs/m7-product-sales-channel-relation-admission.md';
+const document = requireMarkers(documentPath, [
+  'Status: `source_contract_complete_persistence_and_wiring_pending`',
+  'Rechecked on 2026-08-03 against current `main`',
+  'correctly keeps durable',
+  'Product-to-SalesChannel relations open',
+  'must therefore not be derived with `max(product_revision,',
+  '`ProductSalesChannelRelationEpoch`',
+  '`ProductSalesChannelRelationSnapshot`',
+  'exact non-nil tenant, non-nil',
+  'an identical epoch is accepted only for an identical retry',
+  'changed membership under the same epoch fails closed',
+  'durable epoch storage for the exact tenant/Product relation identity',
+  'a registered relation event descriptor',
+  'generic mutation-event acknowledgement and source timeout substrates now exist',
+  'This slice does not add a Product-to-SalesChannel `IndexLink`',
+  'The canonical M7 Product/Variant/Channel link item remains open',
+  'Execution is maintainer-owned',
+]);
+if (document.includes('PR #2793 currently owns')) {
+  fail(`${documentPath} retains obsolete implementation-plan ownership text`);
+}
+
+requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
+  'durable Product-to-SalesChannel relations',
+  'bounded scalar projection until the owner has a durable relational contract',
+]);
+requireMarkers('crates/rustok-index/src/application/mutation_event.rs', [
+  'pub struct IndexMutationEventCatalog',
+  'pub struct IndexMutationEventWorker',
+]);
+requireMarkers('crates/rustok-index/src/application/source_timeout.rs', [
+  'const DEFAULT_INDEX_SOURCE_CALL_TIMEOUT: Duration = Duration::from_secs(30);',
+  'index_source_scan_timeout',
+  'index_source_load_timeout',
+]);
+
+console.log('[verify-index-product-channel-relation-admission] OK');


### PR DESCRIPTION
## Summary

- rebuild the Product-to-SalesChannel relation-epoch admission slice directly on current `main@1643e3c91260e82372b2c96d726cafdaee945002`;
- require a positive authoritative `ProductSalesChannelRelationEpoch` instead of combining independent Product and Channel revisions;
- canonicalize one exact tenant/Product/locale snapshot with sorted unique non-nil SalesChannel UUIDs;
- derive a stable locale-specific Index event identity from the exact relation epoch;
- admit an equal epoch only as an identical retry;
- reject changed membership without epoch advancement, epoch regression, and tenant/Product/locale scope movement;
- preserve an empty channel set as the explicit remove-all-links snapshot;
- add focused source tests, updated contract documentation, and a fail-closed repository verifier.

## Fresh-main reconstruction

This PR replaces conflict-stale draft #2796 and historical draft #2652. The implementation was rechecked against current `main`, including the mutation-event acknowledgement substrate from #2874 and production source-call timeout from #2877.

The relation admission implementation and current `product_index/mod.rs` addition are preserved from #2796. The documentation and verifier were actualized:

- the obsolete statement that #2793 owns the implementation plan was removed;
- the canonical plan is now checked directly and remains unchanged because it correctly keeps durable Product-to-SalesChannel relations open;
- the verifier confirms the existing mutation-event and source-timeout substrates without claiming relation-specific wiring;
- the verifier fails closed if Product graph wiring appears before durable epoch ownership exists.

The branch contains one clean commit, is one commit ahead and zero behind `main`, and changes only four expected files.

## Correctness boundary

A Product-to-SalesChannel `IndexLink` cannot safely reuse `Product.index_revision`. Channel assignment, deletion/recreation, or target identity changes can alter the resolved target set while Product revision remains unchanged. Replaying that version could be deduplicated or ignored as stale while obsolete links remain.

This contract therefore rejects deriving relation versions from `max(product_revision, channel_revision)`, hashes, truncated pair encodings, timestamps, row counts, or Product revision alone. The eventual relation owner must persist one strictly monotonic epoch and commit membership plus epoch atomically.

## Recheck findings

- epochs must be positive;
- tenant, Product, and Channel UUIDs must be non-nil;
- channel UUIDs are sorted canonically and duplicates fail closed;
- event identity is scoped by tenant, Product, canonical locale, event-domain version, and relation epoch;
- same-epoch retries require identical membership;
- lower epochs fail closed;
- tenant, Product, or locale movement fails closed;
- a larger epoch is admitted;
- empty membership remains a valid explicit remove-all state;
- no Product-to-SalesChannel link is wired into the current Product graph.

## Scope boundaries

This PR does not add or claim:

- durable epoch storage or a relation owner table;
- Product-to-SalesChannel schema links or schema-version changes;
- source SQL, scan/load wiring, retained empty-membership persistence, or migrations;
- relation-specific event registration, broker delivery, host worker, or commit-before-ack execution;
- Storefront/Search consumer cutover;
- PostgreSQL concurrency, restart, retry, ordering, or locale-fan-out evidence.

The canonical durable Product-to-SalesChannel relation item remains open.

## Validation

Not run per maintainer instruction:

- formatting;
- Cargo checks, tests, or Clippy;
- JavaScript verifier;
- PostgreSQL scenarios;
- CI workflows.

Suggested maintainer commands:

```bash
cargo test -p rustok-distribution product_sales_channel_relation -- --nocapture
cargo check -p rustok-distribution --all-targets
node scripts/verify/verify-index-product-channel-relation-admission.mjs
```

## History

Supersedes #2796 and #2652 without carrying stale branch history or obsolete plan-ownership text.