### PR TITLE
feat(forum): preserve merged topic solutions

### DIFF
--- a/crates/rustok-forum/contracts/forum-topic-merge-owner.json
+++ b/crates/rustok-forum/contracts/forum-topic-merge-owner.json
@@ -1,15 +1,19 @@
 {
   "contract": "forum_topic_merge_owner_v1",
   "task": "FORUM-21B",
+  "latest_policy_slice": "FORUM-21H",
   "parent_task": "FORUM-21",
   "status": "source_ready_maintainer_execution_pending",
   "canonical_plan_status": "planned",
-  "canonical_plan_promotion_requires": "maintainer_verifier_and_sqlite_execution",
+  "canonical_plan_promotion_requires": "maintainer_verifier_and_sqlite_execution_plus_remaining_workflows",
   "scope": "bounded_same_category_source_into_retained_target",
   "owner_service": "ForumTopicMergeService",
   "input": "MergeForumTopicInput",
   "result": "ForumTopicMergeResult",
-  "migration": "m20260801_000010_add_forum_topic_merge_operations",
+  "migrations": [
+    "m20260801_000010_add_forum_topic_merge_operations",
+    "m20260803_000016_add_forum_topic_merge_solution_policy"
+  ],
   "receipt_table": "forum_topic_merge_operations",
   "semantic_event": {
     "journal": "forum_domain_events",
@@ -27,7 +31,17 @@
     "source_reply_rows_max": 500,
     "one_source_topic_per_operation": true,
     "one_target_topic_per_operation": true,
-    "same_category_only": true
+    "same_category_only": true,
+    "accepted_solutions_per_topic_max": 1
+  },
+  "solution_policy": {
+    "neither_topic_has_solution": "merge_without_solution_mutation",
+    "target_only": "preserve_target_solution_and_marker_metadata",
+    "source_only": "move_solution_to_target_after_reply_move_preserving_reply_id_marked_by_user_id_and_marked_at",
+    "source_and_target": "fail_before_mutation_with_FORUM_TOPIC_MERGE_SOLUTION_CONFLICT",
+    "source_solution_reply_must_be_approved": true,
+    "target_solution_reply_must_be_approved": true,
+    "solution_count_delta_during_merge": 0
   },
   "transactional_invariants": [
     "the operation requires non-nil tenant operation source target and human actor identities",
@@ -36,16 +50,20 @@
     "the exact existing receipt is resolved before current topic state so a valid retry returns the original result",
     "reusing an operation identifier with a different source target actor or normalized reason fails with FORUM_TOPIC_MERGE_OPERATION_CONFLICT",
     "source and target topics must exist in the tenant remain non-deleted non-archived and belong to the same active category",
+    "sorted source and target solution scopes are acquired after topic row locks and ordinary solution writes use the same database-enforced scope",
+    "any stored source or target solution must reference an approved non-deleted reply owned by that exact topic",
+    "two accepted solutions fail with FORUM_TOPIC_MERGE_SOLUTION_CONFLICT before solution deletion reply movement topic archival event receipt counter or invalidation mutation",
+    "a source-only accepted solution is deleted before its reply moves and is inserted on the target after the reply move with unchanged reply_id marked_by_user_id and marked_at",
+    "a target-only accepted solution remains unchanged and a merge never adjusts forum user solution_count",
     "the source contains at most 500 reply rows and its approved reply count equals its owner counter",
-    "the target approved reply count equals its owner counter and any target solution remains an approved reply owned by the target",
-    "a source accepted solution is rejected until an explicit competing-solution policy exists",
+    "the target approved reply count equals its owner counter",
     "all source reply identities move to the target in one bounded statement and positions shift after the target maximum without renumbering existing target replies",
-    "reply-owned bodies revisions votes mentions quotes attachments and parent identities remain attached through unchanged reply identifiers",
+    "reply-owned bodies revisions votes mentions quotes attachments parent identities and a transferred accepted-solution identity remain attached through unchanged reply identifiers",
     "the target published reply counter becomes the checked sum and the source becomes archived locked with zero replies",
     "category retained topic_count and published reply_count remain unchanged because the archived source tombstone is not soft-deleted",
     "source target and category projection invalidations are published in that order",
-    "semantic event receipt owner state reply remap counters and invalidations commit in one transaction",
-    "exact replay creates no additional event receipt invalidation reply movement or counter change"
+    "semantic event receipt owner state reply remap solution policy counters and invalidations commit in one transaction",
+    "exact replay creates no additional event receipt invalidation reply movement solution mutation or counter change"
   ],
   "database_guards": [
     "tenant-composite foreign keys bind the receipt to source topic target topic category and human actor",
@@ -53,12 +71,16 @@
     "source and target topics differ",
     "event_id equals operation_id",
     "reason counts and position offset are bounded",
-    "receipt updates and deletes are rejected for PostgreSQL and SQLite"
+    "receipt updates and deletes are rejected for PostgreSQL and SQLite",
+    "forum solution insert update and delete serialize through deterministic topic rows and solution scope 31",
+    "forum solution insert or owner-key update requires an active non-deleted topic and an approved non-deleted reply owned by that topic"
   ],
   "retained_identity": {
     "target_topic_id": "unchanged",
     "source_topic_id": "archived_locked_redirect_ready",
     "reply_ids": "unchanged",
+    "accepted_solution_reply_id": "unchanged_when_source_only_transfers",
+    "accepted_solution_marker_metadata": "unchanged_when_transferred_or_target_only",
     "existing_target_reply_positions": "unchanged",
     "source_reply_parent_ids": "unchanged",
     "category_topic_count": "unchanged_until_source_soft_delete"
@@ -66,18 +88,21 @@
   "test": "crates/rustok-forum/tests/topic_merge_sqlite.rs",
   "verifier": "scripts/verify/verify-forum-topic-merge-owner.mjs",
   "documentation": "crates/rustok-forum/docs/forum-21b-topic-merge-owner.md",
+  "solution_policy_contract": "crates/rustok-forum/contracts/forum-topic-merge-solution-policy.json",
+  "solution_policy_documentation": "crates/rustok-forum/docs/forum-21h-topic-merge-solution-policy.md",
   "maintainer_commands": [
     "node scripts/verify/verify-forum-topic-merge-owner.mjs",
+    "node scripts/verify/verify-forum-topic-merge-solution-policy.mjs",
     "cargo test -p rustok-forum --test topic_merge_sqlite -- --nocapture"
   ],
   "non_claims": [
-    "this source-ready slice does not claim that the verifier SQLite test Cargo checks formatting workflows or CI ran",
-    "this source-ready slice does not promote the canonical FORUM-21 status before maintainer execution",
+    "this source-ready slice does not claim that verifiers SQLite tests Cargo checks formatting workflows or CI ran",
+    "this source-ready slice does not promote the canonical FORUM-21 status before maintainer execution and remaining workflows",
     "this slice does not add public REST GraphQL native admin or storefront merge transport",
     "this slice does not add canonical URL aliases redirects or route tombstones",
     "this slice does not support cross-category merge split fork or reply-range operations",
-    "this slice does not remap or deduplicate topic subscriptions read state tags topic votes or topic-level audience relations",
-    "this slice does not resolve a source accepted solution or competing source and target solutions",
+    "dedicated bounded slices own subscriptions read state tags topic votes and topic-local audience reconciliation",
+    "this slice does not choose a winner when source and target both have accepted solutions",
     "this slice does not provide PostgreSQL concurrency runtime evidence",
     "this slice is not sufficient to mark FORUM-21 done"
   ]

--- a/crates/rustok-forum/contracts/forum-topic-merge-solution-policy.json
+++ b/crates/rustok-forum/contracts/forum-topic-merge-solution-policy.json
@@ -10,6 +10,7 @@
   "migration": "m20260803_000016_add_forum_topic_merge_solution_policy",
   "solution_table": "forum_solutions",
   "lock_table": "forum_topic_solution_locks",
+  "shared_lock_helper": "topic_solution_lock::lock_topic_solution_scopes_in_tx",
   "postgres_advisory_seed": 31,
   "conflict": {
     "error": "TopicMergeSolutionConflict",
@@ -59,6 +60,14 @@
     "competing_solution_conflict_precedes_projection_invalidation": true,
     "transfer_commits_with_existing_merge_transaction": true,
     "exact_merge_replay_adds_no_solution_mutation": true
+  },
+  "serialization": {
+    "merge_locks_sorted_topic_rows_before_sorted_solution_scopes": true,
+    "mark_solution_locks_scope_before_reply_and_current_marker_reads": true,
+    "clear_solution_locks_scope_before_current_marker_and_author_reads": true,
+    "stats_delta_is_computed_under_the_same_solution_scope": true,
+    "direct_writers_are_guarded_by_database_triggers": true,
+    "sqlite_serializes_all_solution_updates_including_marker_only_updates": true
   },
   "database_guards": {
     "postgres_and_sqlite": true,

--- a/crates/rustok-forum/contracts/forum-topic-merge-solution-policy.json
+++ b/crates/rustok-forum/contracts/forum-topic-merge-solution-policy.json
@@ -1,0 +1,98 @@
+{
+  "contract": "forum_topic_merge_solution_policy_v1",
+  "task": "FORUM-21H",
+  "parent_task": "FORUM-21",
+  "extends": "FORUM-21B",
+  "status": "source_ready_maintainer_execution_pending",
+  "canonical_plan_status": "planned",
+  "owner_service": "ForumTopicMergeService",
+  "operation": "merge_topic",
+  "migration": "m20260803_000016_add_forum_topic_merge_solution_policy",
+  "solution_table": "forum_solutions",
+  "lock_table": "forum_topic_solution_locks",
+  "postgres_advisory_seed": 31,
+  "conflict": {
+    "error": "TopicMergeSolutionConflict",
+    "stable_code": "FORUM_TOPIC_MERGE_SOLUTION_CONFLICT",
+    "operation_id_is_reported": true,
+    "retryable": false
+  },
+  "policy_matrix": [
+    {
+      "source": "none",
+      "target": "none",
+      "outcome": "merge_without_solution_mutation"
+    },
+    {
+      "source": "none",
+      "target": "accepted_solution",
+      "outcome": "preserve_target_solution"
+    },
+    {
+      "source": "accepted_solution",
+      "target": "none",
+      "outcome": "transfer_source_solution_to_target"
+    },
+    {
+      "source": "accepted_solution",
+      "target": "accepted_solution",
+      "outcome": "fail_before_mutation"
+    }
+  ],
+  "transfer_invariants": [
+    "the accepted reply identity is unchanged",
+    "the accepted reply must be approved non-deleted and owned by the source before transfer",
+    "the source solution row is deleted before the source reply set moves",
+    "the moved reply remains approved non-deleted and becomes owned by the retained target",
+    "the target solution row is inserted after reply movement",
+    "marked_by_user_id is preserved exactly including null",
+    "marked_at is preserved exactly",
+    "the transferred target relation is revalidated before topic lifecycle event receipt and invalidation writes",
+    "forum_user_stats.solution_count is not adjusted because accepted reply identity and author do not change"
+  ],
+  "atomicity": {
+    "competing_solution_conflict_precedes_solution_delete": true,
+    "competing_solution_conflict_precedes_reply_move": true,
+    "competing_solution_conflict_precedes_topic_archive": true,
+    "competing_solution_conflict_precedes_semantic_event": true,
+    "competing_solution_conflict_precedes_receipt": true,
+    "competing_solution_conflict_precedes_projection_invalidation": true,
+    "transfer_commits_with_existing_merge_transaction": true,
+    "exact_merge_replay_adds_no_solution_mutation": true
+  },
+  "database_guards": {
+    "postgres_and_sqlite": true,
+    "insert_or_owner_key_update_requires_active_non_deleted_topic": true,
+    "insert_or_owner_key_update_requires_approved_non_deleted_reply": true,
+    "reply_must_belong_to_exact_tenant_and_topic": true,
+    "ordinary_solution_mutations_share_merge_solution_scope": true,
+    "solution_delete_remains_allowed": true
+  },
+  "compatibility": {
+    "merge_input_changed": false,
+    "merge_result_changed": false,
+    "merge_receipt_changed": false,
+    "forum_topic_merged_event_changed": false,
+    "shared_rustok_events_contract_changed": false,
+    "existing_projection_invalidation_targets_changed": false,
+    "public_transport_added": false
+  },
+  "test": "crates/rustok-forum/tests/topic_merge_sqlite.rs",
+  "cumulative_contract": "crates/rustok-forum/contracts/forum-topic-merge-owner.json",
+  "documentation": "crates/rustok-forum/docs/forum-21h-topic-merge-solution-policy.md",
+  "cumulative_documentation": "crates/rustok-forum/docs/forum-21b-topic-merge-owner.md",
+  "verifier": "scripts/verify/verify-forum-topic-merge-solution-policy.mjs",
+  "maintainer_commands": [
+    "node scripts/verify/verify-forum-topic-merge-owner.mjs",
+    "node scripts/verify/verify-forum-topic-merge-solution-policy.mjs",
+    "cargo test -p rustok-forum --test topic_merge_sqlite -- --nocapture"
+  ],
+  "non_claims": [
+    "no verifier test formatter Cargo command workflow or CI run is claimed",
+    "no PostgreSQL concurrency execution is claimed",
+    "no explicit winner selection for two accepted solutions is added",
+    "no public transport is added",
+    "no canonical alias redirect cross-category split fork or reply-range workflow is added",
+    "FORUM-21 is not promoted from planned"
+  ]
+}

--- a/crates/rustok-forum/docs/forum-21b-topic-merge-owner.md
+++ b/crates/rustok-forum/docs/forum-21b-topic-merge-owner.md
@@ -6,15 +6,23 @@
 
 FORUM-21B adds one bounded owner workflow under the planned `FORUM-21`
 umbrella: merge one active source topic into one retained active target topic
-when both topics belong to the same active category.
+when both topics belong to the same active category. FORUM-21H extends that
+same transaction with the accepted-solution policy described below.
 
-The machine contract is:
+The cumulative machine contract is:
 
 ```text
 crates/rustok-forum/contracts/forum-topic-merge-owner.json
 ```
 
-The owner API is:
+The FORUM-21H policy handoff is:
+
+```text
+crates/rustok-forum/contracts/forum-topic-merge-solution-policy.json
+crates/rustok-forum/docs/forum-21h-topic-merge-solution-policy.md
+```
+
+The owner API remains:
 
 ```rust
 ForumTopicMergeService::merge_topic(
@@ -33,9 +41,7 @@ The command requires `forum_topics:manage`, a non-nil human actor and a bounded
 reason. `target_topic_id` is the retained canonical identity; the source and
 target must differ.
 
-## Deliberate first-merge boundary
-
-This slice keeps the first merge transaction auditable and bounded:
+## Bounded merge boundary
 
 - source and target must be active topics in the same active category;
 - the source may contain at most 500 reply rows;
@@ -45,15 +51,18 @@ This slice keeps the first merge transaction auditable and bounded:
 - source reply positions shift by the target's previous maximum position;
 - reply bodies, revisions, votes, mentions, quotes, attachments and parent reply
   IDs remain attached through unchanged reply IDs;
+- a source-only accepted solution follows its unchanged reply ID and preserves
+  `marked_by_user_id` and `marked_at`;
+- a target-only accepted solution remains unchanged;
+- two accepted solutions require explicit resolution and block the merge before
+  mutation;
 - the source topic becomes archived and locked with zero replies;
 - the category retains both topic rows and therefore keeps its retained
   `topic_count`; its published `reply_count` also remains unchanged.
 
-Cross-category merge, subscription deduplication, topic-tag union, topic vote and
-read-state remapping, topic-level audience union and canonical redirects remain
-separate policies. The source topic identity is retained in archived,
-redirect-ready form so those later slices can migrate relations without losing
-history.
+Cross-category merge, canonical redirects, split, fork and reply-range workflows
+remain separate policies. Subscription, read-state, tag, vote and topic-local
+audience reconciliation are delivered by their dedicated FORUM-21 slices.
 
 ## Idempotency
 
@@ -64,7 +73,8 @@ reading an existing receipt.
 - first execution performs the bounded merge and stores one receipt;
 - an exact retry with the same source, target, actor and normalized reason returns
   the original result;
-- retry is resolved before reading the now-archived source or moved replies;
+- retry is resolved before reading the now-archived source, moved replies or the
+  transferred accepted solution;
 - source, target, actor or reason drift under the same operation ID fails with
   `FORUM_TOPIC_MERGE_OPERATION_CONFLICT`.
 
@@ -76,99 +86,110 @@ The first execution performs one owner transaction:
 2. resolve an immutable replay receipt before current owner state;
 3. read source and target category identities without mutation and require the
    same category;
-4. acquire the existing category counter scope followed by source and target
-   topic counter scopes in deterministic UUID order;
+4. acquire the category counter scope followed by source and target topic
+   counter scopes in deterministic UUID order;
 5. row-lock source and target topics in deterministic UUID order, re-read both
    rows and reject category drift;
 6. require non-deleted, non-archived topics in the same active category;
-7. reject a source accepted solution until a later conflict policy exists;
-8. verify any target solution still points to an approved target reply;
-9. require the source reply set to remain within 500 rows and verify source and
-   target approved-reply counters against authoritative rows;
-10. compute a checked position offset from the target maximum;
-11. move every source reply to the target and shift its position in one bounded
+7. acquire source and target solution scopes in deterministic UUID order;
+8. validate every stored solution against an approved, non-deleted reply owned by
+   that exact topic;
+9. reject two accepted solutions with
+   `FORUM_TOPIC_MERGE_SOLUTION_CONFLICT` before any mutation;
+10. require the source reply set to remain within 500 rows and verify source and
+    target approved-reply counters against authoritative rows;
+11. compute a checked position offset from the target maximum;
+12. for a source-only solution, delete the source marker while retaining its
+    reply ID, marking actor and timestamp in transaction memory;
+13. move every source reply to the target and shift its position in one bounded
     statement;
-12. update the target reply counter and archive and lock the source with zero
+14. restore a source-only marker on the target with unchanged metadata and
+    revalidate it against the moved approved reply;
+15. update the target reply counter and archive and lock the source with zero
     replies while preserving category retained-row counters;
-13. validate the retained target audience composition;
-14. append one `forum.topic.merged` journal record and one immutable operation
+16. validate retained target audience composition;
+17. append one `forum.topic.merged` journal record and one immutable operation
     receipt;
-15. publish source-topic, target-topic and category projection invalidations in
+18. publish source-topic, target-topic and category projection invalidations in
     that order;
-16. commit.
+19. commit.
 
-The counter scopes are the same scopes used by normal reply and category owner
-mutations. A reply creation that began first finishes before the merge counts
-rows; a later reply creation waits until commit and then observes the archived
-source. This prevents a reply from escaping between the source count and bulk
-move without introducing a separate locking protocol.
+The merge does not change `forum_user_stats.solution_count`: the accepted reply
+identity and its author remain unchanged. Any error rolls back solution state,
+reply ownership, positions, counters, topic lifecycle, journal event, receipt
+and invalidations.
 
-`category.topic_count` is a retained non-deleted-row counter in the existing
-owner model. The archived source remains a redirect-ready retained row, so merge
-does not decrement that counter. A later explicit source soft-delete remains the
-single owner of its eventual decrement.
+## Solution serialization and database guards
 
-Any error rolls back reply ownership, positions, counters, topic lifecycle,
-journal event, receipt and invalidations.
+`m20260803_000016_add_forum_topic_merge_solution_policy` adds the shared
+per-topic solution scope. PostgreSQL locks the affected topic rows before
+advisory scope seed `31`; SQLite uses a durable topic-solution lock row under its
+write transaction. Ordinary mark, replace and clear writes pass through the same
+database trigger boundary, so they cannot race the merge between solution
+inspection and reply movement.
 
-## Accepted-solution boundary
+PostgreSQL and SQLite also reject solution inserts or owner-key updates unless:
 
-A valid target accepted solution is preserved. A source accepted solution is
-rejected before any mutation. Moving or choosing between source and target
-solutions changes Q&A semantics and therefore requires a separate explicit
-policy rather than an implicit winner.
+- the topic exists, is not deleted and is not archived;
+- the reply exists in that exact tenant and topic;
+- the reply is not deleted and is approved.
 
-## Persistence
+Delete remains available to clear a solution and to perform the source-only
+transfer sequence inside the merge transaction.
 
-`forum_topic_merge_operations` is append-only on PostgreSQL and SQLite.
+## Persistence and events
+
+`forum_topic_merge_operations` remains append-only on PostgreSQL and SQLite.
 Tenant-composite foreign keys bind each receipt to its source topic, retained
-target topic, category and human actor. Database checks require different topic
-identities, bounded reason and reply counts, non-negative position offset and
-`event_id = operation_id`.
-
-The semantic event is Forum-local:
+target topic, category and human actor. The semantic event remains:
 
 ```text
 forum.topic.merged / schema version 1
 ```
 
-The existing projection invalidation event remains the durable cross-consumer
-repair signal; this slice does not change the shared `rustok-events` wire
-catalog.
+FORUM-21H does not change the shared event payload or receipt shape. The
+existing source-topic, target-topic and category projection invalidations already
+cover the solved-state change and remain the durable cross-consumer repair
+signal.
 
 ## Regression coverage
 
 `topic_merge_sqlite` is source-ready to verify:
 
-- target identity and existing target reply position remain unchanged;
+- target identity and existing target reply positions remain unchanged;
 - source reply IDs and parent links survive while positions move after the target
   maximum;
 - target/source reply counters and lifecycle change exactly once while category
   retained topic and published reply counters remain unchanged;
+- source-only accepted solution metadata is preserved on the retained target;
+- target-only accepted solution metadata remains unchanged;
+- solution author statistics receive no merge delta;
+- two accepted solutions fail with the typed conflict and no partial state,
+  event, receipt, counter or invalidation;
+- direct solution writes cannot target a pending reply or archived topic;
 - one immutable receipt and one matching semantic event are stored;
 - exactly three new projection invalidations target source, target and category;
 - exact replay is side-effect free;
-- command drift fails with the typed conflict;
-- cross-category merge and source accepted solution fail without partial state;
+- command drift and cross-category merge fail closed;
 - direct receipt update and deletion are rejected.
 
 ## Remaining FORUM-21 work
 
-The canonical `FORUM-21` entry remains `planned`. Later slices still need:
+The canonical `FORUM-21` entry remains `planned`. FORUM-21A through FORUM-21H
+are bounded partial slices; remaining work includes:
 
-- maintainer execution of the FORUM-21A and FORUM-21B verifiers and regressions;
-- public/admin transport composition and explicit authorization context;
+- maintainer execution and retained SQLite/PostgreSQL evidence;
+- public/admin transport composition and exact authorization context;
 - canonical aliases, redirects and route tombstones;
-- subscription/read-state/tag/vote/audience relation merge policy;
-- source/target accepted-solution conflict policy;
+- an explicit manager-selected resolution command for competing solutions;
 - cross-category merge and checked category ownership policy;
-- split, fork and reply-range workflows;
-- PostgreSQL concurrency evidence and retained runtime artifacts.
+- split, fork and reply-range workflows.
 
 ## Maintainer verification
 
 ```bash
 node scripts/verify/verify-forum-topic-merge-owner.mjs
+node scripts/verify/verify-forum-topic-merge-solution-policy.mjs
 cargo test -p rustok-forum --test topic_merge_sqlite -- --nocapture
 ```
 

--- a/crates/rustok-forum/docs/forum-21h-topic-merge-solution-policy.md
+++ b/crates/rustok-forum/docs/forum-21h-topic-merge-solution-policy.md
@@ -1,0 +1,176 @@
+# FORUM-21H topic merge accepted-solution policy
+
+## Status
+
+`source_ready_maintainer_execution_pending`
+
+FORUM-21H closes the accepted-solution subpolicy inside the existing bounded
+FORUM-21B same-category topic merge owner. It does not add a second merge
+command, receipt or semantic event.
+
+Machine contract:
+
+```text
+crates/rustok-forum/contracts/forum-topic-merge-solution-policy.json
+```
+
+Cumulative merge contract:
+
+```text
+crates/rustok-forum/contracts/forum-topic-merge-owner.json
+```
+
+## Why this policy is explicit
+
+`forum_solutions` identifies one accepted reply for one topic. Moving replies
+between topics changes the composite solution relation even when the reply ID is
+stable. The database also requires the solution's tenant, topic and reply to
+match exactly.
+
+The merge owner therefore cannot update reply ownership while a source solution
+still points at the old topic, and it cannot silently choose between two
+accepted replies without changing Q&A meaning.
+
+## Outcome matrix
+
+| Source | Retained target | Outcome |
+| --- | --- | --- |
+| no solution | no solution | merge without solution mutation |
+| no solution | one valid solution | preserve the target row unchanged |
+| one valid solution | no solution | transfer the source row to the target |
+| one valid solution | one valid solution | fail with `FORUM_TOPIC_MERGE_SOLUTION_CONFLICT` |
+
+A stored solution is valid only when its reply is non-deleted, approved and
+owned by the exact tenant/topic relation recorded by the solution row.
+
+## Source-only transfer
+
+The transfer is part of the original merge transaction:
+
+1. lock source and target topic rows;
+2. acquire source and target solution scopes in deterministic UUID order;
+3. read and validate source and target solution state;
+4. retain source `reply_id`, nullable `marked_by_user_id` and `marked_at` in
+   transaction memory;
+5. delete the source solution row;
+6. move the complete bounded source reply set to the retained target;
+7. insert the solution row for the target with the retained marker fields;
+8. re-read and validate the transferred relation;
+9. continue the existing topic counters, source archival, semantic event,
+   immutable receipt and projection invalidation writes;
+10. commit once.
+
+The intermediate deleted marker is never visible outside the transaction. Any
+failure rolls back the delete, reply movement and every later merge mutation.
+
+## Statistics
+
+The transfer does not call `UserStatsService` and does not change
+`forum_user_stats.solution_count`.
+
+The accepted reply ID and reply author do not change. Only the parent topic
+relation changes, so decrementing and incrementing the same author's solution
+count would add failure surface without changing the canonical statistic.
+
+## Competing solutions
+
+When both source and target have accepted solutions, the merge returns:
+
+```text
+FORUM_TOPIC_MERGE_SOLUTION_CONFLICT
+```
+
+The error contains the attempted merge operation ID. It is detected after
+solution locks and validity checks but before:
+
+- solution deletion or insertion;
+- reply movement or position changes;
+- topic counter or lifecycle changes;
+- `forum.topic.merged` publication;
+- merge receipt insertion;
+- Search projection invalidation.
+
+No implicit target authority, newest-marker choice, author preference or reply
+score heuristic is used. A future manager-selected resolution command may
+choose a winner explicitly and audit that decision as a separate bounded slice.
+
+## Shared solution mutation scope
+
+Migration
+`m20260803_000016_add_forum_topic_merge_solution_policy` installs a common
+solution mutation boundary.
+
+PostgreSQL:
+
+- solution INSERT/UPDATE/DELETE locks affected topic rows in deterministic order;
+- advisory lock seed `31` serializes the exact tenant/topic solution scope;
+- merge takes the same scopes after its stronger source/target topic row locks.
+
+SQLite:
+
+- `forum_topic_solution_locks` records the touched tenant/topic scope;
+- trigger writes participate in SQLite's database write transaction;
+- merge explicitly touches both scopes before inspecting solution state.
+
+Ordinary mark, replacement and clear operations pass through these database
+triggers, so they cannot commit a competing solution between merge inspection
+and transfer.
+
+## Database validity guard
+
+PostgreSQL and SQLite reject solution INSERT and owner-key UPDATE unless:
+
+- the topic exists in the exact tenant;
+- the topic is non-deleted and not archived;
+- the reply exists in the exact tenant and topic;
+- the reply is non-deleted and approved.
+
+DELETE remains permitted because clear-solution and the source-only transfer
+must remove a valid row.
+
+## Compatibility
+
+FORUM-21H changes no public merge input or result, merge receipt schema,
+`forum.topic.merged` payload, shared event catalog or projection target list.
+
+The existing source-topic, target-topic and category invalidations already force
+Search to rebuild solved-state projections after a successful merge. An exact
+operation replay resolves the immutable merge receipt before current topic or
+solution state and creates no additional solution mutation.
+
+## Source-ready regression
+
+`crates/rustok-forum/tests/topic_merge_sqlite.rs` covers:
+
+- source-only transfer with exact marker-field preservation;
+- owner read paths reporting the moved reply as the target solution;
+- unchanged solution author statistics;
+- exact replay preserving one transferred marker;
+- target-only marker preservation;
+- two-solution typed conflict with unchanged topics, replies, solutions,
+  statistics, events, receipts and invalidations;
+- cross-category rejection;
+- direct pending-reply and archived-topic solution write rejection;
+- cumulative merge atomicity, idempotency and append-only receipt behavior.
+
+## Remaining scope
+
+FORUM-21 remains `planned`. FORUM-21A through FORUM-21H are bounded source-ready
+partial slices. Remaining work includes:
+
+- maintainer execution and retained SQLite/PostgreSQL evidence;
+- explicit manager-selected resolution for competing solutions;
+- public/admin merge transport composition;
+- canonical aliases, redirects and route tombstones;
+- cross-category merge;
+- split, fork and reply-range workflows.
+
+## Maintainer verification
+
+```bash
+node scripts/verify/verify-forum-topic-merge-owner.mjs
+node scripts/verify/verify-forum-topic-merge-solution-policy.mjs
+cargo test -p rustok-forum --test topic_merge_sqlite -- --nocapture
+```
+
+No command above was run by the implementation agent, per maintainer request.

--- a/crates/rustok-forum/docs/forum-21h-topic-merge-solution-policy.md
+++ b/crates/rustok-forum/docs/forum-21h-topic-merge-solution-policy.md
@@ -110,11 +110,14 @@ SQLite:
 
 - `forum_topic_solution_locks` records the touched tenant/topic scope;
 - trigger writes participate in SQLite's database write transaction;
+- all solution updates, including marker-only updates, touch the scope;
 - merge explicitly touches both scopes before inspecting solution state.
 
-Ordinary mark, replacement and clear operations pass through these database
-triggers, so they cannot commit a competing solution between merge inspection
-and transfer.
+The public moderation owner also acquires the shared topic/solution scope before
+reading the current marker, accepted reply or author used for a statistics
+delta. Mark, replacement and clear therefore compute their mutation from state
+that cannot change underneath the transaction. Database triggers enforce the
+same scope for direct writers that bypass the owner API.
 
 ## Database validity guard
 
@@ -152,6 +155,9 @@ solution state and creates no additional solution mutation.
 - cross-category rejection;
 - direct pending-reply and archived-topic solution write rejection;
 - cumulative merge atomicity, idempotency and append-only receipt behavior.
+
+The focused source verifier additionally proves that moderation mark and clear
+lock the solution scope before current-marker reads and statistics calculations.
 
 ## Remaining scope
 

--- a/crates/rustok-forum/src/error.rs
+++ b/crates/rustok-forum/src/error.rs
@@ -70,6 +70,9 @@ pub enum ForumError {
     #[error("Forum topic merge operation conflicts with an existing command: {0}")]
     TopicMergeOperationConflict(Uuid),
 
+    #[error("Forum topic merge accepted solutions require explicit resolution: {0}")]
+    TopicMergeSolutionConflict(Uuid),
+
     #[error("Forum topic merge audience reconciliation conflicts with an existing command: {0}")]
     TopicMergeAudienceReconciliationConflict(Uuid),
 
@@ -156,6 +159,7 @@ impl ForumError {
             Self::RelationRevisionConflict => "FORUM_RELATION_REVISION_CONFLICT",
             Self::TopicMoveOperationConflict(_) => "FORUM_TOPIC_MOVE_OPERATION_CONFLICT",
             Self::TopicMergeOperationConflict(_) => "FORUM_TOPIC_MERGE_OPERATION_CONFLICT",
+            Self::TopicMergeSolutionConflict(_) => "FORUM_TOPIC_MERGE_SOLUTION_CONFLICT",
             Self::TopicMergeAudienceReconciliationConflict(_) => {
                 "FORUM_TOPIC_MERGE_AUDIENCE_RECONCILIATION_CONFLICT"
             }

--- a/crates/rustok-forum/src/migrations/m20260803_000016_add_forum_topic_merge_solution_policy.rs
+++ b/crates/rustok-forum/src/migrations/m20260803_000016_add_forum_topic_merge_solution_policy.rs
@@ -1,0 +1,247 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::DatabaseBackend;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DatabaseBackend::Postgres => execute(manager, POSTGRES_UP).await,
+            DatabaseBackend::Sqlite => execute(manager, SQLITE_UP).await,
+            backend => Err(DbErr::Custom(format!(
+                "rustok-forum topic merge solution policy migration does not support {backend:?}"
+            ))),
+        }
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DatabaseBackend::Postgres => execute(manager, POSTGRES_DOWN).await,
+            DatabaseBackend::Sqlite => execute(manager, SQLITE_DOWN).await,
+            backend => Err(DbErr::Custom(format!(
+                "rustok-forum topic merge solution policy migration does not support {backend:?}"
+            ))),
+        }
+    }
+}
+
+async fn execute(manager: &SchemaManager<'_>, sql: &str) -> Result<(), DbErr> {
+    manager
+        .get_connection()
+        .execute_unprepared(sql)
+        .await
+        .map(|_| ())
+}
+
+const POSTGRES_UP: &str = r#"
+CREATE TABLE IF NOT EXISTS forum_topic_solution_locks (
+    tenant_id UUID NOT NULL,
+    topic_id UUID NOT NULL,
+    touched_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, topic_id),
+    CONSTRAINT fk_forum_topic_solution_locks_topic
+        FOREIGN KEY (tenant_id, topic_id)
+        REFERENCES forum_topics (tenant_id, id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE OR REPLACE FUNCTION forum_lock_topic_solution_mutation()
+RETURNS trigger AS $$
+DECLARE
+    row_tenant_id uuid;
+    first_topic_id uuid;
+    second_topic_id uuid;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        row_tenant_id := OLD.tenant_id;
+        first_topic_id := OLD.topic_id;
+    ELSIF TG_OP = 'INSERT' THEN
+        row_tenant_id := NEW.tenant_id;
+        first_topic_id := NEW.topic_id;
+    ELSE
+        IF OLD.tenant_id <> NEW.tenant_id THEN
+            RAISE EXCEPTION 'forum solution tenant is immutable';
+        END IF;
+        row_tenant_id := NEW.tenant_id;
+        IF OLD.topic_id <= NEW.topic_id THEN
+            first_topic_id := OLD.topic_id;
+            second_topic_id := NEW.topic_id;
+        ELSE
+            first_topic_id := NEW.topic_id;
+            second_topic_id := OLD.topic_id;
+        END IF;
+    END IF;
+
+    PERFORM 1
+      FROM forum_topics
+     WHERE tenant_id = row_tenant_id
+       AND id = first_topic_id
+     FOR SHARE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'forum solution topic is unavailable';
+    END IF;
+    IF second_topic_id IS NOT NULL AND second_topic_id <> first_topic_id THEN
+        PERFORM 1
+          FROM forum_topics
+         WHERE tenant_id = row_tenant_id
+           AND id = second_topic_id
+         FOR SHARE;
+        IF NOT FOUND THEN
+            RAISE EXCEPTION 'forum solution topic is unavailable';
+        END IF;
+    END IF;
+
+    PERFORM pg_advisory_xact_lock(hashtextextended(
+        format('%s:%s', row_tenant_id, first_topic_id),
+        31
+    ));
+    IF second_topic_id IS NOT NULL AND second_topic_id <> first_topic_id THEN
+        PERFORM pg_advisory_xact_lock(hashtextextended(
+            format('%s:%s', row_tenant_id, second_topic_id),
+            31
+        ));
+    END IF;
+
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION forum_validate_topic_solution_target()
+RETURNS trigger AS $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM forum_topics topic
+        JOIN forum_replies reply
+          ON reply.tenant_id = topic.tenant_id
+         AND reply.topic_id = topic.id
+         AND reply.id = NEW.reply_id
+        WHERE topic.tenant_id = NEW.tenant_id
+          AND topic.id = NEW.topic_id
+          AND topic.deleted_at IS NULL
+          AND topic.status::text <> 'archived'
+          AND reply.deleted_at IS NULL
+          AND reply.status::text = 'approved'
+    ) THEN
+        RAISE EXCEPTION 'forum solution requires an active topic and approved reply';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS forum_00_topic_solution_scope ON forum_solutions;
+CREATE TRIGGER forum_00_topic_solution_scope
+BEFORE INSERT OR UPDATE OR DELETE ON forum_solutions
+FOR EACH ROW EXECUTE FUNCTION forum_lock_topic_solution_mutation();
+
+DROP TRIGGER IF EXISTS forum_10_topic_solution_target ON forum_solutions;
+CREATE TRIGGER forum_10_topic_solution_target
+BEFORE INSERT OR UPDATE OF tenant_id, topic_id, reply_id ON forum_solutions
+FOR EACH ROW EXECUTE FUNCTION forum_validate_topic_solution_target();
+"#;
+
+const POSTGRES_DOWN: &str = r#"
+DROP TRIGGER IF EXISTS forum_10_topic_solution_target ON forum_solutions;
+DROP TRIGGER IF EXISTS forum_00_topic_solution_scope ON forum_solutions;
+DROP FUNCTION IF EXISTS forum_validate_topic_solution_target();
+DROP FUNCTION IF EXISTS forum_lock_topic_solution_mutation();
+DROP TABLE IF EXISTS forum_topic_solution_locks;
+"#;
+
+const SQLITE_UP: &str = r#"
+CREATE TABLE IF NOT EXISTS forum_topic_solution_locks (
+    tenant_id TEXT NOT NULL,
+    topic_id TEXT NOT NULL,
+    touched_at TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, topic_id),
+    FOREIGN KEY (tenant_id, topic_id)
+        REFERENCES forum_topics (tenant_id, id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TRIGGER IF NOT EXISTS forum_00_topic_solution_scope_insert
+BEFORE INSERT ON forum_solutions
+FOR EACH ROW
+BEGIN
+    INSERT INTO forum_topic_solution_locks (tenant_id, topic_id, touched_at)
+    VALUES (NEW.tenant_id, NEW.topic_id, CURRENT_TIMESTAMP)
+    ON CONFLICT(tenant_id, topic_id) DO UPDATE SET touched_at = CURRENT_TIMESTAMP;
+END;
+
+CREATE TRIGGER IF NOT EXISTS forum_00_topic_solution_scope_update
+BEFORE UPDATE OF tenant_id, topic_id, reply_id ON forum_solutions
+FOR EACH ROW
+BEGIN
+    INSERT INTO forum_topic_solution_locks (tenant_id, topic_id, touched_at)
+    VALUES (OLD.tenant_id, OLD.topic_id, CURRENT_TIMESTAMP)
+    ON CONFLICT(tenant_id, topic_id) DO UPDATE SET touched_at = CURRENT_TIMESTAMP;
+    INSERT INTO forum_topic_solution_locks (tenant_id, topic_id, touched_at)
+    VALUES (NEW.tenant_id, NEW.topic_id, CURRENT_TIMESTAMP)
+    ON CONFLICT(tenant_id, topic_id) DO UPDATE SET touched_at = CURRENT_TIMESTAMP;
+END;
+
+CREATE TRIGGER IF NOT EXISTS forum_00_topic_solution_scope_delete
+BEFORE DELETE ON forum_solutions
+FOR EACH ROW
+BEGIN
+    INSERT INTO forum_topic_solution_locks (tenant_id, topic_id, touched_at)
+    VALUES (OLD.tenant_id, OLD.topic_id, CURRENT_TIMESTAMP)
+    ON CONFLICT(tenant_id, topic_id) DO UPDATE SET touched_at = CURRENT_TIMESTAMP;
+END;
+
+CREATE TRIGGER IF NOT EXISTS forum_10_topic_solution_target_insert
+BEFORE INSERT ON forum_solutions
+FOR EACH ROW
+WHEN NOT EXISTS (
+    SELECT 1
+    FROM forum_topics topic
+    JOIN forum_replies reply
+      ON reply.tenant_id = topic.tenant_id
+     AND reply.topic_id = topic.id
+     AND reply.id = NEW.reply_id
+    WHERE topic.tenant_id = NEW.tenant_id
+      AND topic.id = NEW.topic_id
+      AND topic.deleted_at IS NULL
+      AND topic.status <> 'archived'
+      AND reply.deleted_at IS NULL
+      AND reply.status = 'approved'
+)
+BEGIN
+    SELECT RAISE(ABORT, 'forum solution requires an active topic and approved reply');
+END;
+
+CREATE TRIGGER IF NOT EXISTS forum_10_topic_solution_target_update
+BEFORE UPDATE OF tenant_id, topic_id, reply_id ON forum_solutions
+FOR EACH ROW
+WHEN NOT EXISTS (
+    SELECT 1
+    FROM forum_topics topic
+    JOIN forum_replies reply
+      ON reply.tenant_id = topic.tenant_id
+     AND reply.topic_id = topic.id
+     AND reply.id = NEW.reply_id
+    WHERE topic.tenant_id = NEW.tenant_id
+      AND topic.id = NEW.topic_id
+      AND topic.deleted_at IS NULL
+      AND topic.status <> 'archived'
+      AND reply.deleted_at IS NULL
+      AND reply.status = 'approved'
+)
+BEGIN
+    SELECT RAISE(ABORT, 'forum solution requires an active topic and approved reply');
+END;
+"#;
+
+const SQLITE_DOWN: &str = r#"
+DROP TRIGGER IF EXISTS forum_10_topic_solution_target_update;
+DROP TRIGGER IF EXISTS forum_10_topic_solution_target_insert;
+DROP TRIGGER IF EXISTS forum_00_topic_solution_scope_delete;
+DROP TRIGGER IF EXISTS forum_00_topic_solution_scope_update;
+DROP TRIGGER IF EXISTS forum_00_topic_solution_scope_insert;
+DROP TABLE IF EXISTS forum_topic_solution_locks;
+"#;

--- a/crates/rustok-forum/src/migrations/m20260803_000016_add_forum_topic_merge_solution_policy.rs
+++ b/crates/rustok-forum/src/migrations/m20260803_000016_add_forum_topic_merge_solution_policy.rs
@@ -174,7 +174,7 @@ BEGIN
 END;
 
 CREATE TRIGGER IF NOT EXISTS forum_00_topic_solution_scope_update
-BEFORE UPDATE OF tenant_id, topic_id, reply_id ON forum_solutions
+BEFORE UPDATE ON forum_solutions
 FOR EACH ROW
 BEGIN
     INSERT INTO forum_topic_solution_locks (tenant_id, topic_id, touched_at)

--- a/crates/rustok-forum/src/migrations/mod.rs
+++ b/crates/rustok-forum/src/migrations/mod.rs
@@ -45,6 +45,7 @@ mod m20260801_000012_add_forum_topic_merge_read_state_reconciliations;
 mod m20260803_000013_add_forum_topic_merge_tag_reconciliations;
 mod m20260803_000014_add_forum_topic_merge_vote_reconciliations;
 mod m20260803_000015_add_forum_topic_merge_audience_reconciliations;
+mod m20260803_000016_add_forum_topic_merge_solution_policy;
 
 use rustok_core::MigrationDependencyDescriptor;
 use sea_orm_migration::MigrationTrait;
@@ -102,6 +103,7 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260803_000013_add_forum_topic_merge_tag_reconciliations::Migration),
         Box::new(m20260803_000014_add_forum_topic_merge_vote_reconciliations::Migration),
         Box::new(m20260803_000015_add_forum_topic_merge_audience_reconciliations::Migration),
+        Box::new(m20260803_000016_add_forum_topic_merge_solution_policy::Migration),
     ]
 }
 

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -121,6 +121,7 @@ mod topic_owner {
 }
 mod topic_read_state_lock;
 mod topic_reply_create_audience;
+mod topic_solution_lock;
 mod topic_subscription_lock;
 mod topic_tag_lock;
 mod topic_vote_lock;

--- a/crates/rustok-forum/src/services/moderation_owner.rs
+++ b/crates/rustok-forum/src/services/moderation_owner.rs
@@ -20,6 +20,7 @@ use crate::services::moderation_audience_authorization::ForumModerationAudienceA
 use crate::services::projection_invalidation::{
     publish_forum_category_projection_in_tx, publish_forum_topic_projection_in_tx,
 };
+use crate::services::topic_solution_lock::lock_topic_solution_scopes_in_tx;
 use crate::services::user_stats::UserStatsService;
 use crate::services::{CategoryService, ReplyService, TopicService};
 use crate::state_machine::ReplyStatus;
@@ -342,14 +343,16 @@ impl ModerationService {
         context: Option<PortContext>,
     ) -> ForumResult<()> {
         let topic_service = TopicService::new(self.db.clone(), self.event_bus.clone());
-        let reply_service = ReplyService::new(self.db.clone(), self.event_bus.clone());
         let topic = topic_service.find_topic(tenant_id, topic_id).await?;
         if !is_exact_topic_author(&security, topic.author_id) {
             self.audience
                 .require_topic(tenant_id, topic_id, &security, context)
                 .await?;
         }
-        let reply = reply_service.find_reply(tenant_id, reply_id).await?;
+
+        let txn = self.db.begin().await?;
+        lock_topic_solution_scopes_in_tx(&txn, tenant_id, &[topic_id]).await?;
+        let reply = ReplyService::find_reply_in_tx(&txn, tenant_id, reply_id).await?;
         if reply.topic_id != topic_id {
             return Err(ForumError::Validation(
                 "Reply belongs to another topic".to_string(),
@@ -361,7 +364,6 @@ impl ModerationService {
             ));
         }
 
-        let txn = self.db.begin().await?;
         let previous_solution_reply_id = forum_solution::Entity::find()
             .filter(forum_solution::Column::TenantId.eq(tenant_id))
             .filter(forum_solution::Column::TopicId.eq(topic_id))
@@ -429,6 +431,7 @@ impl ModerationService {
         }
 
         let txn = self.db.begin().await?;
+        lock_topic_solution_scopes_in_tx(&txn, tenant_id, &[topic_id]).await?;
         let solution_author_id = if let Some(solution) = forum_solution::Entity::find()
             .filter(forum_solution::Column::TenantId.eq(tenant_id))
             .filter(forum_solution::Column::TopicId.eq(topic_id))

--- a/crates/rustok-forum/src/services/topic_merge.rs
+++ b/crates/rustok-forum/src/services/topic_merge.rs
@@ -578,14 +578,26 @@ async fn load_valid_solution_in_tx(
     let Some(solution) = solution else {
         return Ok(None);
     };
-    let reply = forum_reply::Entity::find_by_id(solution.reply_id)
-        .filter(forum_reply::Column::TenantId.eq(tenant_id))
-        .filter(forum_reply::Column::TopicId.eq(topic_id))
-        .one(txn)
-        .await?;
-    if !reply.is_some_and(|reply| reply.status == ReplyStatus::Approved) {
+    let statement = match txn.get_database_backend() {
+        DatabaseBackend::Postgres => Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            "SELECT 1 FROM forum_replies WHERE tenant_id = $1 AND topic_id = $2 AND id = $3 AND deleted_at IS NULL AND status = 'approved'",
+            vec![tenant_id.into(), topic_id.into(), solution.reply_id.into()],
+        ),
+        DatabaseBackend::Sqlite => Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            "SELECT 1 FROM forum_replies WHERE tenant_id = ? AND topic_id = ? AND id = ? AND deleted_at IS NULL AND status = 'approved'",
+            vec![tenant_id.into(), topic_id.into(), solution.reply_id.into()],
+        ),
+        backend => {
+            return Err(ForumError::Validation(format!(
+                "Forum topic merge solution validation does not support database backend {backend:?}"
+            )));
+        }
+    };
+    if txn.query_one(statement).await?.is_none() {
         return Err(ForumError::Validation(format!(
-            "Forum topic merge requires a valid approved {label} solution"
+            "Forum topic merge requires a valid approved non-deleted {label} solution"
         )));
     }
     Ok(Some(solution))

--- a/crates/rustok-forum/src/services/topic_merge.rs
+++ b/crates/rustok-forum/src/services/topic_merge.rs
@@ -4,6 +4,7 @@ use sea_orm::{
     ActiveValue::{NotSet, Set},
     ColumnTrait, ConnectionTrait, DatabaseBackend, DatabaseConnection, DatabaseTransaction,
     EntityTrait, PaginatorTrait, QueryFilter, QueryOrder, Statement, TransactionTrait,
+    prelude::DateTimeWithTimeZone,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, json};
@@ -55,13 +56,20 @@ pub struct ForumTopicMergeResult {
     pub merged_at: DateTime<Utc>,
 }
 
+struct ForumTopicMergeSolutionTransfer {
+    reply_id: Uuid,
+    marked_by_user_id: Option<Uuid>,
+    marked_at: DateTimeWithTimeZone,
+}
+
 /// Idempotent same-category merge of one active source topic into one retained target topic.
 ///
 /// The target identity and topic-owned policy remain authoritative. Reply identities and all
 /// reply-owned relations are retained while reply positions are shifted after the target's
-/// current maximum. The source topic becomes an archived, locked redirect-ready identity.
-/// Topic subscriptions, tags and topic-level audience relations are intentionally not remapped
-/// by this bounded slice.
+/// current maximum. A source-only accepted solution follows its unchanged reply identity and
+/// preserves its marker metadata; two accepted solutions require explicit resolution. The source
+/// topic becomes an archived, locked redirect-ready identity. Topic subscriptions, tags and
+/// topic-level audience relations are reconciled by their dedicated bounded policies.
 pub struct ForumTopicMergeService {
     db: DatabaseConnection,
     event_bus: TransactionalEventBus,
@@ -149,18 +157,27 @@ impl ForumTopicMergeService {
             ));
         }
         ensure_category_active_in_tx(&txn, tenant_id, target.category_id).await?;
-        if forum_solution::Entity::find()
-            .filter(forum_solution::Column::TenantId.eq(tenant_id))
-            .filter(forum_solution::Column::TopicId.eq(source.id))
-            .one(&txn)
-            .await?
-            .is_some()
-        {
-            return Err(ForumError::Validation(
-                "Forum topic merge does not yet support a source accepted solution".to_string(),
-            ));
+
+        lock_topic_solution_scopes_in_tx(
+            &txn,
+            tenant_id,
+            &[source.id, target.id],
+        )
+        .await?;
+        let source_solution =
+            load_valid_solution_in_tx(&txn, tenant_id, source.id, "source").await?;
+        let target_solution =
+            load_valid_solution_in_tx(&txn, tenant_id, target.id, "target").await?;
+        if source_solution.is_some() && target_solution.is_some() {
+            return Err(ForumError::TopicMergeSolutionConflict(input.operation_id));
         }
-        validate_target_solution_in_tx(&txn, tenant_id, target.id).await?;
+        let source_solution_transfer = source_solution.map(|solution| {
+            ForumTopicMergeSolutionTransfer {
+                reply_id: solution.reply_id,
+                marked_by_user_id: solution.marked_by_user_id,
+                marked_at: solution.marked_at,
+            }
+        });
 
         let source_reply_count = forum_reply::Entity::find()
             .filter(forum_reply::Column::TenantId.eq(tenant_id))
@@ -205,6 +222,9 @@ impl ForumTopicMergeService {
                 ForumError::Validation("Forum merged reply position overflow".to_string())
             })?;
 
+        if source_solution_transfer.is_some() {
+            delete_source_solution_in_tx(&txn, tenant_id, source.id).await?;
+        }
         move_replies_in_tx(
             &txn,
             tenant_id,
@@ -214,6 +234,10 @@ impl ForumTopicMergeService {
             source_reply_count,
         )
         .await?;
+        if let Some(solution) = source_solution_transfer {
+            insert_transferred_solution_in_tx(&txn, tenant_id, target.id, solution).await?;
+            load_valid_solution_in_tx(&txn, tenant_id, target.id, "transferred target").await?;
+        }
 
         let now = Utc::now();
         let mut target_active: forum_topic::ActiveModel = target.into();
@@ -455,6 +479,49 @@ async fn lock_topics_in_tx(
     Ok(())
 }
 
+async fn lock_topic_solution_scopes_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    topic_ids: &[Uuid],
+) -> ForumResult<()> {
+    let mut ids = topic_ids.to_vec();
+    ids.sort();
+    ids.dedup();
+    match txn.get_database_backend() {
+        DatabaseBackend::Postgres => {
+            for topic_id in ids {
+                txn.execute(Statement::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    "SELECT pg_advisory_xact_lock(hashtextextended($1, 31))",
+                    vec![format!("{tenant_id}:{topic_id}").into()],
+                ))
+                .await?;
+            }
+        }
+        DatabaseBackend::Sqlite => {
+            for topic_id in ids {
+                txn.execute(Statement::from_sql_and_values(
+                    DatabaseBackend::Sqlite,
+                    r#"
+                    INSERT INTO forum_topic_solution_locks (tenant_id, topic_id, touched_at)
+                    VALUES (?, ?, CURRENT_TIMESTAMP)
+                    ON CONFLICT(tenant_id, topic_id)
+                    DO UPDATE SET touched_at = CURRENT_TIMESTAMP
+                    "#,
+                    vec![tenant_id.into(), topic_id.into()],
+                ))
+                .await?;
+            }
+        }
+        backend => {
+            return Err(ForumError::Validation(format!(
+                "Forum topic merge solution policy does not support database backend {backend:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
 async fn find_topic_in_tx(
     txn: &DatabaseTransaction,
     tenant_id: Uuid,
@@ -486,29 +553,66 @@ async fn ensure_category_active_in_tx(
     Ok(())
 }
 
-async fn validate_target_solution_in_tx(
+async fn load_valid_solution_in_tx(
     txn: &DatabaseTransaction,
     tenant_id: Uuid,
-    target_topic_id: Uuid,
-) -> ForumResult<()> {
-    let Some(solution) = forum_solution::Entity::find()
+    topic_id: Uuid,
+    label: &str,
+) -> ForumResult<Option<forum_solution::Model>> {
+    let solution = forum_solution::Entity::find()
         .filter(forum_solution::Column::TenantId.eq(tenant_id))
-        .filter(forum_solution::Column::TopicId.eq(target_topic_id))
+        .filter(forum_solution::Column::TopicId.eq(topic_id))
         .one(txn)
-        .await?
-    else {
-        return Ok(());
+        .await?;
+    let Some(solution) = solution else {
+        return Ok(None);
     };
     let reply = forum_reply::Entity::find_by_id(solution.reply_id)
         .filter(forum_reply::Column::TenantId.eq(tenant_id))
-        .filter(forum_reply::Column::TopicId.eq(target_topic_id))
+        .filter(forum_reply::Column::TopicId.eq(topic_id))
         .one(txn)
         .await?;
     if !reply.is_some_and(|reply| reply.status == ReplyStatus::Approved) {
+        return Err(ForumError::Validation(format!(
+            "Forum topic merge requires a valid approved {label} solution"
+        )));
+    }
+    Ok(Some(solution))
+}
+
+async fn delete_source_solution_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    source_topic_id: Uuid,
+) -> ForumResult<()> {
+    let result = forum_solution::Entity::delete_many()
+        .filter(forum_solution::Column::TenantId.eq(tenant_id))
+        .filter(forum_solution::Column::TopicId.eq(source_topic_id))
+        .exec(txn)
+        .await?;
+    if result.rows_affected != 1 {
         return Err(ForumError::Validation(
-            "Forum topic merge requires a valid approved target solution".to_string(),
+            "Forum source accepted solution changed concurrently".to_string(),
         ));
     }
+    Ok(())
+}
+
+async fn insert_transferred_solution_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    target_topic_id: Uuid,
+    solution: ForumTopicMergeSolutionTransfer,
+) -> ForumResult<()> {
+    forum_solution::ActiveModel {
+        topic_id: Set(target_topic_id),
+        tenant_id: Set(tenant_id),
+        reply_id: Set(solution.reply_id),
+        marked_by_user_id: Set(solution.marked_by_user_id),
+        marked_at: Set(solution.marked_at),
+    }
+    .insert(txn)
+    .await?;
     Ok(())
 }
 

--- a/crates/rustok-forum/src/services/topic_merge.rs
+++ b/crates/rustok-forum/src/services/topic_merge.rs
@@ -56,6 +56,7 @@ pub struct ForumTopicMergeResult {
     pub merged_at: DateTime<Utc>,
 }
 
+#[derive(Clone)]
 struct ForumTopicMergeSolutionTransfer {
     reply_id: Uuid,
     marked_by_user_id: Option<Uuid>,
@@ -158,12 +159,7 @@ impl ForumTopicMergeService {
         }
         ensure_category_active_in_tx(&txn, tenant_id, target.category_id).await?;
 
-        lock_topic_solution_scopes_in_tx(
-            &txn,
-            tenant_id,
-            &[source.id, target.id],
-        )
-        .await?;
+        lock_topic_solution_scopes_in_tx(&txn, tenant_id, &[source.id, target.id]).await?;
         let source_solution =
             load_valid_solution_in_tx(&txn, tenant_id, source.id, "source").await?;
         let target_solution =
@@ -235,8 +231,23 @@ impl ForumTopicMergeService {
         )
         .await?;
         if let Some(solution) = source_solution_transfer {
-            insert_transferred_solution_in_tx(&txn, tenant_id, target.id, solution).await?;
-            load_valid_solution_in_tx(&txn, tenant_id, target.id, "transferred target").await?;
+            insert_transferred_solution_in_tx(&txn, tenant_id, target.id, &solution).await?;
+            let transferred =
+                load_valid_solution_in_tx(&txn, tenant_id, target.id, "transferred target")
+                    .await?
+                    .ok_or_else(|| {
+                        ForumError::Validation(
+                            "Forum transferred accepted solution is missing".to_string(),
+                        )
+                    })?;
+            if transferred.reply_id != solution.reply_id
+                || transferred.marked_by_user_id != solution.marked_by_user_id
+                || transferred.marked_at != solution.marked_at
+            {
+                return Err(ForumError::Validation(
+                    "Forum transferred accepted solution metadata changed".to_string(),
+                ));
+            }
         }
 
         let now = Utc::now();
@@ -602,7 +613,7 @@ async fn insert_transferred_solution_in_tx(
     txn: &DatabaseTransaction,
     tenant_id: Uuid,
     target_topic_id: Uuid,
-    solution: ForumTopicMergeSolutionTransfer,
+    solution: &ForumTopicMergeSolutionTransfer,
 ) -> ForumResult<()> {
     forum_solution::ActiveModel {
         topic_id: Set(target_topic_id),

--- a/crates/rustok-forum/src/services/topic_solution_lock.rs
+++ b/crates/rustok-forum/src/services/topic_solution_lock.rs
@@ -1,0 +1,71 @@
+use sea_orm::{ConnectionTrait, DatabaseBackend, DatabaseTransaction, Statement};
+use uuid::Uuid;
+
+use crate::error::{ForumError, ForumResult};
+
+pub(crate) async fn lock_topic_solution_scopes_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    topic_ids: &[Uuid],
+) -> ForumResult<()> {
+    let mut ids = topic_ids.to_vec();
+    ids.sort();
+    ids.dedup();
+
+    for topic_id in &ids {
+        let statement = match txn.get_database_backend() {
+            DatabaseBackend::Postgres => Statement::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                "SELECT id FROM forum_topics WHERE tenant_id = $1 AND id = $2 AND deleted_at IS NULL FOR SHARE",
+                vec![tenant_id.into(), (*topic_id).into()],
+            ),
+            DatabaseBackend::Sqlite => Statement::from_sql_and_values(
+                DatabaseBackend::Sqlite,
+                "SELECT id FROM forum_topics WHERE tenant_id = ? AND id = ? AND deleted_at IS NULL",
+                vec![tenant_id.into(), (*topic_id).into()],
+            ),
+            backend => {
+                return Err(ForumError::Validation(format!(
+                    "Forum topic solution locking does not support database backend {backend:?}"
+                )));
+            }
+        };
+        if txn.query_one(statement).await?.is_none() {
+            return Err(ForumError::TopicNotFound(*topic_id));
+        }
+    }
+
+    match txn.get_database_backend() {
+        DatabaseBackend::Postgres => {
+            for topic_id in ids {
+                txn.execute(Statement::from_sql_and_values(
+                    DatabaseBackend::Postgres,
+                    "SELECT pg_advisory_xact_lock(hashtextextended($1, 31))",
+                    vec![format!("{tenant_id}:{topic_id}").into()],
+                ))
+                .await?;
+            }
+        }
+        DatabaseBackend::Sqlite => {
+            for topic_id in ids {
+                txn.execute(Statement::from_sql_and_values(
+                    DatabaseBackend::Sqlite,
+                    r#"
+                    INSERT INTO forum_topic_solution_locks (tenant_id, topic_id, touched_at)
+                    VALUES (?, ?, CURRENT_TIMESTAMP)
+                    ON CONFLICT(tenant_id, topic_id)
+                    DO UPDATE SET touched_at = CURRENT_TIMESTAMP
+                    "#,
+                    vec![tenant_id.into(), topic_id.into()],
+                ))
+                .await?;
+            }
+        }
+        backend => {
+            return Err(ForumError::Validation(format!(
+                "Forum topic solution locking does not support database backend {backend:?}"
+            )));
+        }
+    }
+    Ok(())
+}

--- a/crates/rustok-forum/tests/topic_merge_sqlite.rs
+++ b/crates/rustok-forum/tests/topic_merge_sqlite.rs
@@ -586,11 +586,11 @@ async fn topic_merge_rejects_cross_category_and_competing_solutions_without_part
         )
         .await;
     let error = competing.expect_err("competing solutions must block merge");
-    assert!(matches!(
-        error,
-        ForumError::TopicMergeSolutionConflict(id) if id == operation_id
-    ));
     assert_eq!(error.stable_code(), "FORUM_TOPIC_MERGE_SOLUTION_CONFLICT");
+    assert!(matches!(
+        &error,
+        ForumError::TopicMergeSolutionConflict(id) if *id == operation_id
+    ));
 
     assert_topic_state(&db, tenant_id, target_topic_id, "open", false, 1).await?;
     assert_topic_state(&db, tenant_id, source_topic_id, "open", false, 1).await?;
@@ -620,8 +620,12 @@ async fn topic_solution_database_guard_requires_active_topic_and_approved_reply(
     let (db, event_bus) = setup().await?;
     let tenant_id = Uuid::new_v4();
     let actor_id = Uuid::new_v4();
-    insert_user(&db, tenant_id, actor_id).await?;
+    let reply_author_id = Uuid::new_v4();
+    for user_id in [actor_id, reply_author_id] {
+        insert_user(&db, tenant_id, user_id).await?;
+    }
     let admin = SecurityContext::new(UserRole::Admin, Some(actor_id));
+    let reply_author = SecurityContext::new(UserRole::Customer, Some(reply_author_id));
 
     let moderated_category_id =
         create_category(&db, tenant_id, admin.clone(), "solution-pending", true).await?;
@@ -639,11 +643,12 @@ async fn topic_solution_database_guard_requires_active_topic_and_approved_reply(
         &event_bus,
         tenant_id,
         pending_topic_id,
-        admin.clone(),
+        reply_author,
         "Pending answer",
         None,
     )
     .await?;
+    assert_eq!(reply_status(&db, tenant_id, pending_reply_id).await?, "pending");
     assert!(db
         .execute(Statement::from_sql_and_values(
             DbBackend::Sqlite,
@@ -679,6 +684,7 @@ async fn topic_solution_database_guard_requires_active_topic_and_approved_reply(
         None,
     )
     .await?;
+    assert_eq!(reply_status(&db, tenant_id, approved_reply_id).await?, "approved");
     db.execute(Statement::from_sql_and_values(
         DbBackend::Sqlite,
         "UPDATE forum_topics SET status = 'archived', is_locked = TRUE WHERE tenant_id = ? AND id = ?",
@@ -737,6 +743,22 @@ async fn user_solution_count(
         .await?
         .ok_or("forum user stat row missing")?;
     Ok(row.try_get("", "solution_count")?)
+}
+
+async fn reply_status(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    reply_id: Uuid,
+) -> TestResult<String> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT status FROM forum_replies WHERE tenant_id = ? AND id = ?",
+            vec![tenant_id.into(), reply_id.into()],
+        ))
+        .await?
+        .ok_or("reply row missing")?;
+    Ok(row.try_get("", "status")?)
 }
 
 async fn assert_topic_state(

--- a/crates/rustok-forum/tests/topic_merge_sqlite.rs
+++ b/crates/rustok-forum/tests/topic_merge_sqlite.rs
@@ -5,7 +5,8 @@ use rustok_core::{MigrationSource, SecurityContext, UserRole};
 use rustok_events::{DomainEvent, EventEnvelope};
 use rustok_forum::{
     CategoryService, CreateCategoryInput, CreateReplyInput, CreateTopicInput, ForumError,
-    ForumModule, ForumTopicMergeService, MergeForumTopicInput, ReplyService, TopicService,
+    ForumModule, ForumTopicMergeService, MergeForumTopicInput, ModerationService, ReplyService,
+    TopicService,
 };
 use rustok_outbox::{OutboxModule, OutboxTransport, TransactionalEventBus};
 use rustok_taxonomy::TaxonomyModule;
@@ -19,6 +20,13 @@ use uuid::Uuid;
 
 type TestResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SolutionSnapshot {
+    reply_id: Uuid,
+    marked_by_user_id: Option<Uuid>,
+    marked_at: String,
+}
+
 async fn setup() -> TestResult<(DatabaseConnection, TransactionalEventBus)> {
     let db_url = format!(
         "sqlite:file:forum_topic_merge_{}?mode=memory&cache=shared",
@@ -28,7 +36,11 @@ async fn setup() -> TestResult<(DatabaseConnection, TransactionalEventBus)> {
     options.max_connections(5).min_connections(1).sqlx_logging(false);
     let db = Database::connect(options).await?;
     db.execute_unprepared(
-        "CREATE TABLE users (id TEXT NOT NULL PRIMARY KEY, tenant_id TEXT NOT NULL)",
+        "CREATE TABLE users (\
+            id TEXT NOT NULL PRIMARY KEY, \
+            tenant_id TEXT NOT NULL, \
+            UNIQUE (tenant_id, id)\
+        )",
     )
     .await?;
     let schema = SchemaManager::new(&db);
@@ -64,6 +76,7 @@ async fn create_category(
     tenant_id: Uuid,
     security: SecurityContext,
     slug: &str,
+    moderated: bool,
 ) -> TestResult<Uuid> {
     Ok(CategoryService::new(db.clone())
         .create(
@@ -78,7 +91,7 @@ async fn create_category(
                 color: None,
                 parent_id: None,
                 position: Some(0),
-                moderated: false,
+                moderated,
             },
         )
         .await?
@@ -123,7 +136,7 @@ async fn create_reply(
     text: &str,
     parent_reply_id: Option<Uuid>,
 ) -> TestResult<Uuid> {
-    let reply = ReplyService::new(db.clone(), event_bus.clone())
+    Ok(ReplyService::new(db.clone(), event_bus.clone())
         .create(
             tenant_id,
             security,
@@ -134,9 +147,8 @@ async fn create_reply(
                 parent_reply_id,
             },
         )
-        .await?;
-    assert_eq!(reply.status, "approved");
-    Ok(reply.id)
+        .await?
+        .id)
 }
 
 #[tokio::test]
@@ -146,7 +158,8 @@ async fn topic_merge_is_atomic_idempotent_and_append_only() -> TestResult<()> {
     let actor_id = Uuid::new_v4();
     insert_user(&db, tenant_id, actor_id).await?;
     let admin = SecurityContext::new(UserRole::Admin, Some(actor_id));
-    let category_id = create_category(&db, tenant_id, admin.clone(), "merge-category").await?;
+    let category_id =
+        create_category(&db, tenant_id, admin.clone(), "merge-category", false).await?;
     let target_topic_id = create_topic(
         &db,
         &event_bus,
@@ -303,14 +316,184 @@ async fn topic_merge_is_atomic_idempotent_and_append_only() -> TestResult<()> {
 }
 
 #[tokio::test]
-async fn topic_merge_rejects_cross_category_and_source_solution_without_partial_state() -> TestResult<()> {
+async fn topic_merge_transfers_source_only_solution_and_preserves_target_only_solution() -> TestResult<()> {
     let (db, event_bus) = setup().await?;
     let tenant_id = Uuid::new_v4();
     let actor_id = Uuid::new_v4();
-    insert_user(&db, tenant_id, actor_id).await?;
+    let source_author_id = Uuid::new_v4();
+    let target_author_id = Uuid::new_v4();
+    for user_id in [actor_id, source_author_id, target_author_id] {
+        insert_user(&db, tenant_id, user_id).await?;
+    }
     let admin = SecurityContext::new(UserRole::Admin, Some(actor_id));
-    let category_id = create_category(&db, tenant_id, admin.clone(), "merge-guard").await?;
-    let other_category_id = create_category(&db, tenant_id, admin.clone(), "merge-other").await?;
+    let source_author = SecurityContext::new(UserRole::Customer, Some(source_author_id));
+    let target_author = SecurityContext::new(UserRole::Customer, Some(target_author_id));
+    let category_id =
+        create_category(&db, tenant_id, admin.clone(), "merge-solution", false).await?;
+
+    let target_topic_id = create_topic(
+        &db,
+        &event_bus,
+        tenant_id,
+        category_id,
+        admin.clone(),
+        "solution-target",
+    )
+    .await?;
+    let source_topic_id = create_topic(
+        &db,
+        &event_bus,
+        tenant_id,
+        category_id,
+        admin.clone(),
+        "solution-source",
+    )
+    .await?;
+    let source_reply_id = create_reply(
+        &db,
+        &event_bus,
+        tenant_id,
+        source_topic_id,
+        source_author.clone(),
+        "Source accepted answer",
+        None,
+    )
+    .await?;
+    ModerationService::new(db.clone(), event_bus.clone())
+        .mark_solution(tenant_id, source_topic_id, source_reply_id, admin.clone())
+        .await?;
+    let source_solution_before = solution_snapshot(&db, tenant_id, source_topic_id)
+        .await?
+        .ok_or("source solution missing")?;
+    let source_solution_count_before =
+        user_solution_count(&db, tenant_id, source_author_id).await?;
+    assert_eq!(source_solution_count_before, 1);
+
+    let operation_id = Uuid::new_v4();
+    let input = MergeForumTopicInput {
+        operation_id,
+        source_topic_id,
+        reason: "Retain the source accepted answer".to_string(),
+    };
+    let service = ForumTopicMergeService::new(db.clone(), event_bus.clone());
+    let merged = service
+        .merge_topic(tenant_id, target_topic_id, admin.clone(), input.clone())
+        .await?;
+    assert_eq!(merged.operation_id, operation_id);
+    assert_eq!(solution_snapshot(&db, tenant_id, source_topic_id).await?, None);
+    assert_eq!(
+        solution_snapshot(&db, tenant_id, target_topic_id).await?,
+        Some(source_solution_before.clone())
+    );
+    assert_eq!(
+        user_solution_count(&db, tenant_id, source_author_id).await?,
+        source_solution_count_before
+    );
+    assert_reply_location(
+        &db,
+        tenant_id,
+        source_reply_id,
+        target_topic_id,
+        1,
+        None,
+    )
+    .await?;
+    let target_read = TopicService::new(db.clone(), event_bus.clone())
+        .get(tenant_id, admin.clone(), target_topic_id, "en")
+        .await?;
+    assert_eq!(target_read.solution_reply_id, Some(source_reply_id));
+    let moved_reply_read = ReplyService::new(db.clone(), event_bus.clone())
+        .get(tenant_id, admin.clone(), source_reply_id, "en")
+        .await?;
+    assert!(moved_reply_read.is_solution);
+
+    let replay = service
+        .merge_topic(tenant_id, target_topic_id, admin.clone(), input)
+        .await?;
+    assert_eq!(replay, merged);
+    assert_eq!(
+        solution_snapshot(&db, tenant_id, target_topic_id).await?,
+        Some(source_solution_before)
+    );
+
+    let retained_target_topic_id = create_topic(
+        &db,
+        &event_bus,
+        tenant_id,
+        category_id,
+        admin.clone(),
+        "retained-solution-target",
+    )
+    .await?;
+    let empty_source_topic_id = create_topic(
+        &db,
+        &event_bus,
+        tenant_id,
+        category_id,
+        admin.clone(),
+        "retained-solution-source",
+    )
+    .await?;
+    let target_reply_id = create_reply(
+        &db,
+        &event_bus,
+        tenant_id,
+        retained_target_topic_id,
+        target_author,
+        "Target accepted answer",
+        None,
+    )
+    .await?;
+    ModerationService::new(db.clone(), event_bus.clone())
+        .mark_solution(
+            tenant_id,
+            retained_target_topic_id,
+            target_reply_id,
+            admin.clone(),
+        )
+        .await?;
+    let target_solution_before = solution_snapshot(&db, tenant_id, retained_target_topic_id)
+        .await?
+        .ok_or("target solution missing")?;
+
+    service
+        .merge_topic(
+            tenant_id,
+            retained_target_topic_id,
+            admin,
+            MergeForumTopicInput {
+                operation_id: Uuid::new_v4(),
+                source_topic_id: empty_source_topic_id,
+                reason: "Preserve the retained target solution".to_string(),
+            },
+        )
+        .await?;
+    assert_eq!(
+        solution_snapshot(&db, tenant_id, retained_target_topic_id).await?,
+        Some(target_solution_before)
+    );
+    assert_eq!(solution_snapshot(&db, tenant_id, empty_source_topic_id).await?, None);
+    Ok(())
+}
+
+#[tokio::test]
+async fn topic_merge_rejects_cross_category_and_competing_solutions_without_partial_state(
+) -> TestResult<()> {
+    let (db, event_bus) = setup().await?;
+    let tenant_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    let source_author_id = Uuid::new_v4();
+    let target_author_id = Uuid::new_v4();
+    for user_id in [actor_id, source_author_id, target_author_id] {
+        insert_user(&db, tenant_id, user_id).await?;
+    }
+    let admin = SecurityContext::new(UserRole::Admin, Some(actor_id));
+    let source_author = SecurityContext::new(UserRole::Customer, Some(source_author_id));
+    let target_author = SecurityContext::new(UserRole::Customer, Some(target_author_id));
+    let category_id =
+        create_category(&db, tenant_id, admin.clone(), "merge-guard", false).await?;
+    let other_category_id =
+        create_category(&db, tenant_id, admin.clone(), "merge-other", false).await?;
     let target_topic_id = create_topic(
         &db,
         &event_bus,
@@ -343,11 +526,36 @@ async fn topic_merge_rejects_cross_category_and_source_solution_without_partial_
         &event_bus,
         tenant_id,
         source_topic_id,
-        admin.clone(),
+        source_author,
         "Source accepted solution",
         None,
     )
     .await?;
+    let target_reply_id = create_reply(
+        &db,
+        &event_bus,
+        tenant_id,
+        target_topic_id,
+        target_author,
+        "Target accepted solution",
+        None,
+    )
+    .await?;
+    let moderation = ModerationService::new(db.clone(), event_bus.clone());
+    moderation
+        .mark_solution(tenant_id, source_topic_id, source_reply_id, admin.clone())
+        .await?;
+    moderation
+        .mark_solution(tenant_id, target_topic_id, target_reply_id, admin.clone())
+        .await?;
+    let source_solution_before = solution_snapshot(&db, tenant_id, source_topic_id).await?;
+    let target_solution_before = solution_snapshot(&db, tenant_id, target_topic_id).await?;
+    let source_solution_count_before =
+        user_solution_count(&db, tenant_id, source_author_id).await?;
+    let target_solution_count_before =
+        user_solution_count(&db, tenant_id, target_author_id).await?;
+    let baseline_projection_ids = projection_root_ids(&db, tenant_id).await?;
+    let baseline_merge_events = merge_event_count(&db, tenant_id).await?;
     let service = ForumTopicMergeService::new(db.clone(), event_bus);
 
     let cross = service
@@ -364,38 +572,171 @@ async fn topic_merge_rejects_cross_category_and_source_solution_without_partial_
         .await;
     assert!(matches!(cross, Err(ForumError::Validation(_))));
 
-    db.execute(Statement::from_sql_and_values(
-        DbBackend::Sqlite,
-        "INSERT INTO forum_solutions (topic_id, tenant_id, reply_id, marked_by_user_id, marked_at) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)",
-        vec![
-            source_topic_id.into(),
-            tenant_id.into(),
-            source_reply_id.into(),
-            actor_id.into(),
-        ],
-    ))
-    .await?;
-    let source_solution = service
+    let operation_id = Uuid::new_v4();
+    let competing = service
         .merge_topic(
             tenant_id,
             target_topic_id,
             admin,
             MergeForumTopicInput {
-                operation_id: Uuid::new_v4(),
+                operation_id,
                 source_topic_id,
-                reason: "Source solutions require an explicit conflict policy".to_string(),
+                reason: "Competing solutions require an explicit winner".to_string(),
             },
         )
         .await;
-    assert!(matches!(source_solution, Err(ForumError::Validation(_))));
+    let error = competing.expect_err("competing solutions must block merge");
+    assert!(matches!(
+        error,
+        ForumError::TopicMergeSolutionConflict(id) if id == operation_id
+    ));
+    assert_eq!(error.stable_code(), "FORUM_TOPIC_MERGE_SOLUTION_CONFLICT");
 
-    assert_topic_state(&db, tenant_id, target_topic_id, "open", false, 0).await?;
+    assert_topic_state(&db, tenant_id, target_topic_id, "open", false, 1).await?;
     assert_topic_state(&db, tenant_id, source_topic_id, "open", false, 1).await?;
     assert_topic_state(&db, tenant_id, cross_topic_id, "open", false, 0).await?;
-    assert_category_counters(&db, tenant_id, category_id, 2, 1).await?;
+    assert_reply_location(&db, tenant_id, source_reply_id, source_topic_id, 1, None).await?;
+    assert_reply_location(&db, tenant_id, target_reply_id, target_topic_id, 1, None).await?;
+    assert_eq!(solution_snapshot(&db, tenant_id, source_topic_id).await?, source_solution_before);
+    assert_eq!(solution_snapshot(&db, tenant_id, target_topic_id).await?, target_solution_before);
+    assert_eq!(
+        user_solution_count(&db, tenant_id, source_author_id).await?,
+        source_solution_count_before
+    );
+    assert_eq!(
+        user_solution_count(&db, tenant_id, target_author_id).await?,
+        target_solution_count_before
+    );
+    assert_category_counters(&db, tenant_id, category_id, 2, 2).await?;
     assert_category_counters(&db, tenant_id, other_category_id, 1, 0).await?;
     assert_eq!(merge_operation_count(&db, tenant_id).await?, 0);
+    assert_eq!(merge_event_count(&db, tenant_id).await?, baseline_merge_events);
+    assert_eq!(projection_root_ids(&db, tenant_id).await?, baseline_projection_ids);
     Ok(())
+}
+
+#[tokio::test]
+async fn topic_solution_database_guard_requires_active_topic_and_approved_reply() -> TestResult<()> {
+    let (db, event_bus) = setup().await?;
+    let tenant_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    insert_user(&db, tenant_id, actor_id).await?;
+    let admin = SecurityContext::new(UserRole::Admin, Some(actor_id));
+
+    let moderated_category_id =
+        create_category(&db, tenant_id, admin.clone(), "solution-pending", true).await?;
+    let pending_topic_id = create_topic(
+        &db,
+        &event_bus,
+        tenant_id,
+        moderated_category_id,
+        admin.clone(),
+        "pending-topic",
+    )
+    .await?;
+    let pending_reply_id = create_reply(
+        &db,
+        &event_bus,
+        tenant_id,
+        pending_topic_id,
+        admin.clone(),
+        "Pending answer",
+        None,
+    )
+    .await?;
+    assert!(db
+        .execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO forum_solutions (topic_id, tenant_id, reply_id, marked_by_user_id, marked_at) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)",
+            vec![
+                pending_topic_id.into(),
+                tenant_id.into(),
+                pending_reply_id.into(),
+                actor_id.into(),
+            ],
+        ))
+        .await
+        .is_err());
+
+    let active_category_id =
+        create_category(&db, tenant_id, admin.clone(), "solution-archived", false).await?;
+    let archived_topic_id = create_topic(
+        &db,
+        &event_bus,
+        tenant_id,
+        active_category_id,
+        admin.clone(),
+        "archived-topic",
+    )
+    .await?;
+    let approved_reply_id = create_reply(
+        &db,
+        &event_bus,
+        tenant_id,
+        archived_topic_id,
+        admin,
+        "Approved answer",
+        None,
+    )
+    .await?;
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        "UPDATE forum_topics SET status = 'archived', is_locked = TRUE WHERE tenant_id = ? AND id = ?",
+        vec![tenant_id.into(), archived_topic_id.into()],
+    ))
+    .await?;
+    assert!(db
+        .execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO forum_solutions (topic_id, tenant_id, reply_id, marked_by_user_id, marked_at) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)",
+            vec![
+                archived_topic_id.into(),
+                tenant_id.into(),
+                approved_reply_id.into(),
+                actor_id.into(),
+            ],
+        ))
+        .await
+        .is_err());
+    Ok(())
+}
+
+async fn solution_snapshot(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    topic_id: Uuid,
+) -> TestResult<Option<SolutionSnapshot>> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT reply_id, marked_by_user_id, marked_at FROM forum_solutions WHERE tenant_id = ? AND topic_id = ?",
+            vec![tenant_id.into(), topic_id.into()],
+        ))
+        .await?;
+    row.map(|row| {
+        Ok(SolutionSnapshot {
+            reply_id: row.try_get("", "reply_id")?,
+            marked_by_user_id: row.try_get("", "marked_by_user_id")?,
+            marked_at: row.try_get("", "marked_at")?,
+        })
+    })
+    .transpose()
+}
+
+async fn user_solution_count(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    user_id: Uuid,
+) -> TestResult<i32> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT solution_count FROM forum_user_stats WHERE tenant_id = ? AND user_id = ?",
+            vec![tenant_id.into(), user_id.into()],
+        ))
+        .await?
+        .ok_or("forum user stat row missing")?;
+    Ok(row.try_get("", "solution_count")?)
 }
 
 async fn assert_topic_state(
@@ -458,7 +799,10 @@ async fn assert_reply_location(
         .ok_or("reply row missing")?;
     assert_eq!(row.try_get::<Uuid>("", "topic_id")?, expected_topic_id);
     assert_eq!(row.try_get::<i64>("", "position")?, expected_position);
-    assert_eq!(row.try_get::<Option<Uuid>>("", "parent_reply_id")?, expected_parent_reply_id);
+    assert_eq!(
+        row.try_get::<Option<Uuid>>("", "parent_reply_id")?,
+        expected_parent_reply_id
+    );
     Ok(())
 }
 
@@ -471,6 +815,18 @@ async fn merge_operation_count(
         Statement::from_sql_and_values(
             DbBackend::Sqlite,
             "SELECT COUNT(*) AS value FROM forum_topic_merge_operations WHERE tenant_id = ?",
+            vec![tenant_id.into()],
+        ),
+    )
+    .await
+}
+
+async fn merge_event_count(db: &DatabaseConnection, tenant_id: Uuid) -> TestResult<i64> {
+    scalar_i64(
+        db,
+        Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT COUNT(*) AS value FROM forum_domain_events WHERE tenant_id = ? AND event_type = 'forum.topic.merged'",
             vec![tenant_id.into()],
         ),
     )
@@ -502,8 +858,14 @@ async fn assert_semantic_event(
     assert_eq!(payload["target_topic_id"], merged.target_topic_id.to_string());
     assert_eq!(payload["category_id"], merged.category_id.to_string());
     assert_eq!(payload["moved_reply_count"], merged.moved_reply_count);
-    assert_eq!(payload["moved_published_reply_count"], merged.moved_published_reply_count);
-    assert_eq!(payload["resulting_published_reply_count"], merged.resulting_published_reply_count);
+    assert_eq!(
+        payload["moved_published_reply_count"],
+        merged.moved_published_reply_count
+    );
+    assert_eq!(
+        payload["resulting_published_reply_count"],
+        merged.resulting_published_reply_count
+    );
     assert_eq!(payload["position_offset"], merged.position_offset);
     assert_eq!(payload["reason"], merged.reason);
     Ok(())

--- a/scripts/verify/verify-forum-topic-merge-owner.mjs
+++ b/scripts/verify/verify-forum-topic-merge-owner.mjs
@@ -3,20 +3,26 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
-const contractPath = "crates/rustok-forum/contracts/forum-topic-merge-owner.json";
-const docsPath = "crates/rustok-forum/docs/forum-21b-topic-merge-owner.md";
-const entityPath = "crates/rustok-forum/src/entities/forum_topic_merge_operation.rs";
-const entitiesModPath = "crates/rustok-forum/src/entities/mod.rs";
-const errorPath = "crates/rustok-forum/src/error.rs";
-const libPath = "crates/rustok-forum/src/lib.rs";
-const migrationPath =
-  "crates/rustok-forum/src/migrations/m20260801_000010_add_forum_topic_merge_operations.rs";
-const migrationsModPath = "crates/rustok-forum/src/migrations/mod.rs";
-const servicePath = "crates/rustok-forum/src/services/topic_merge.rs";
-const servicesModPath = "crates/rustok-forum/src/services/mod.rs";
-const testPath = "crates/rustok-forum/tests/topic_merge_sqlite.rs";
-const planPath = "crates/rustok-forum/docs/implementation-plan.md";
-const verifierPath = "scripts/verify/verify-forum-topic-merge-owner.mjs";
+const paths = {
+  contract: "crates/rustok-forum/contracts/forum-topic-merge-owner.json",
+  solutionContract:
+    "crates/rustok-forum/contracts/forum-topic-merge-solution-policy.json",
+  docs: "crates/rustok-forum/docs/forum-21b-topic-merge-owner.md",
+  entity: "crates/rustok-forum/src/entities/forum_topic_merge_operation.rs",
+  entitiesMod: "crates/rustok-forum/src/entities/mod.rs",
+  error: "crates/rustok-forum/src/error.rs",
+  lib: "crates/rustok-forum/src/lib.rs",
+  receiptMigration:
+    "crates/rustok-forum/src/migrations/m20260801_000010_add_forum_topic_merge_operations.rs",
+  solutionMigration:
+    "crates/rustok-forum/src/migrations/m20260803_000016_add_forum_topic_merge_solution_policy.rs",
+  migrationsMod: "crates/rustok-forum/src/migrations/mod.rs",
+  service: "crates/rustok-forum/src/services/topic_merge.rs",
+  servicesMod: "crates/rustok-forum/src/services/mod.rs",
+  test: "crates/rustok-forum/tests/topic_merge_sqlite.rs",
+  plan: "crates/rustok-forum/docs/implementation-plan.md",
+  verifier: "scripts/verify/verify-forum-topic-merge-owner.mjs",
+};
 
 function read(path) {
   return readFileSync(path, "utf8");
@@ -28,22 +34,25 @@ function includesAll(text, markers, label) {
   }
 }
 
-const contract = JSON.parse(read(contractPath));
-const docs = read(docsPath);
-const entity = read(entityPath);
-const entitiesMod = read(entitiesModPath);
-const error = read(errorPath);
-const lib = read(libPath);
-const migration = read(migrationPath);
-const migrationsMod = read(migrationsModPath);
-const service = read(servicePath);
-const servicesMod = read(servicesModPath);
-const test = read(testPath);
-const plan = read(planPath);
-const verifier = read(verifierPath);
+const contract = JSON.parse(read(paths.contract));
+const solutionContract = JSON.parse(read(paths.solutionContract));
+const docs = read(paths.docs);
+const entity = read(paths.entity);
+const entitiesMod = read(paths.entitiesMod);
+const error = read(paths.error);
+const lib = read(paths.lib);
+const receiptMigration = read(paths.receiptMigration);
+const solutionMigration = read(paths.solutionMigration);
+const migrationsMod = read(paths.migrationsMod);
+const service = read(paths.service);
+const servicesMod = read(paths.servicesMod);
+const test = read(paths.test);
+const plan = read(paths.plan);
+const verifier = read(paths.verifier);
 
 assert.equal(contract.contract, "forum_topic_merge_owner_v1");
 assert.equal(contract.task, "FORUM-21B");
+assert.equal(contract.latest_policy_slice, "FORUM-21H");
 assert.equal(contract.parent_task, "FORUM-21");
 assert.equal(contract.status, "source_ready_maintainer_execution_pending");
 assert.equal(contract.canonical_plan_status, "planned");
@@ -51,42 +60,26 @@ assert.equal(contract.scope, "bounded_same_category_source_into_retained_target"
 assert.equal(contract.owner_service, "ForumTopicMergeService");
 assert.equal(contract.input, "MergeForumTopicInput");
 assert.equal(contract.result, "ForumTopicMergeResult");
-assert.equal(contract.migration, "m20260801_000010_add_forum_topic_merge_operations");
+assert.deepEqual(contract.migrations, [
+  "m20260801_000010_add_forum_topic_merge_operations",
+  "m20260803_000016_add_forum_topic_merge_solution_policy",
+]);
 assert.equal(contract.receipt_table, "forum_topic_merge_operations");
 assert.deepEqual(contract.required_permissions, ["forum_topics:manage"]);
-assert.deepEqual(contract.bounds, {
-  reason_max_characters: 500,
-  source_reply_rows_max: 500,
-  one_source_topic_per_operation: true,
-  one_target_topic_per_operation: true,
-  same_category_only: true,
-});
+assert.equal(contract.bounds.reason_max_characters, 500);
+assert.equal(contract.bounds.source_reply_rows_max, 500);
+assert.equal(contract.bounds.same_category_only, true);
+assert.equal(contract.bounds.accepted_solutions_per_topic_max, 1);
 assert.equal(contract.semantic_event.event_type, "forum.topic.merged");
 assert.equal(contract.semantic_event.schema_version, 1);
-assert.equal(contract.semantic_event.aggregate_is_retained_target, true);
 assert.equal(contract.semantic_event.event_id_equals_operation_id, true);
-assert.equal(contract.semantic_event.shared_rustok_events_contract_changed, false);
-assert.equal(contract.transactional_invariants.length, 16);
-assert.ok(
-  contract.transactional_invariants.some((value) =>
-    value.includes("category lifecycle") &&
-    value.includes("counter scopes are acquired before topic row locks"),
-  ),
+assert.equal(contract.solution_policy.solution_count_delta_during_merge, 0);
+assert.equal(
+  contract.solution_policy.source_and_target,
+  "fail_before_mutation_with_FORUM_TOPIC_MERGE_SOLUTION_CONFLICT",
 );
-assert.ok(
-  contract.transactional_invariants.some((value) =>
-    value.includes("category retained topic_count") && value.includes("remain unchanged"),
-  ),
-);
-assert.equal(contract.database_guards.length, 6);
-assert.equal(contract.retained_identity.category_topic_count, "unchanged_until_source_soft_delete");
-assert.equal(contract.test, testPath);
-assert.equal(contract.verifier, verifierPath);
-assert.equal(contract.documentation, docsPath);
-assert.deepEqual(contract.maintainer_commands, [
-  `node ${verifierPath}`,
-  "cargo test -p rustok-forum --test topic_merge_sqlite -- --nocapture",
-]);
+assert.equal(solutionContract.task, "FORUM-21H");
+assert.equal(solutionContract.extends, "FORUM-21B");
 
 includesAll(
   entity,
@@ -117,7 +110,9 @@ includesAll(
   error,
   [
     "TopicMergeOperationConflict(Uuid)",
+    "TopicMergeSolutionConflict(Uuid)",
     '"FORUM_TOPIC_MERGE_OPERATION_CONFLICT"',
+    '"FORUM_TOPIC_MERGE_SOLUTION_CONFLICT"',
   ],
   "ForumError",
 );
@@ -126,27 +121,35 @@ includesAll(
   [
     "mod m20260801_000010_add_forum_topic_merge_operations;",
     "Box::new(m20260801_000010_add_forum_topic_merge_operations::Migration)",
+    "mod m20260803_000016_add_forum_topic_merge_solution_policy;",
+    "Box::new(m20260803_000016_add_forum_topic_merge_solution_policy::Migration)",
   ],
   "migration registration",
 );
 includesAll(
-  migration,
+  receiptMigration,
   [
     "CREATE TABLE IF NOT EXISTS forum_topic_merge_locks",
     "CREATE TABLE IF NOT EXISTS forum_topic_merge_operations",
     "PRIMARY KEY (tenant_id, operation_id)",
-    "FOREIGN KEY (tenant_id, source_topic_id)",
-    "FOREIGN KEY (tenant_id, target_topic_id)",
-    "FOREIGN KEY (tenant_id, category_id)",
-    "FOREIGN KEY (tenant_id, actor_id)",
     "source_topic_id <> target_topic_id",
     "moved_reply_count BETWEEN 0 AND 500",
     "event_id = operation_id",
     "forum topic merge operations are append-only",
-    "forum_topic_merge_operation_update",
-    "forum_topic_merge_operation_delete",
   ],
-  "topic merge migration",
+  "receipt migration",
+);
+includesAll(
+  solutionMigration,
+  [
+    "CREATE TABLE IF NOT EXISTS forum_topic_solution_locks",
+    "forum_lock_topic_solution_mutation",
+    "forum_validate_topic_solution_target",
+    "hashtextextended(",
+    "31",
+    "forum solution requires an active topic and approved reply",
+  ],
+  "solution policy migration",
 );
 
 includesAll(
@@ -161,26 +164,18 @@ includesAll(
     "pub async fn merge_topic(",
     "enforce_scope(&security, Resource::ForumTopics, Action::Manage)?;",
     "lock_topic_merge_tenant_in_tx(&txn, tenant_id).await?;",
-    '"SELECT pg_advisory_xact_lock(hashtextextended($1, 0))"',
     "forum_topic_merge_operation::Entity::find_by_id",
     "TopicMergeOperationConflict(input.operation_id)",
-    "let preliminary_source =",
-    "let preliminary_target =",
     "lock_merge_counter_scopes_in_tx(",
-    'format!("forum:category:{tenant_id}:{category_id}")',
-    'format!("forum:topic:{tenant_id}:{}", topic_ids[0])',
-    'format!("forum:topic:{tenant_id}:{}", topic_ids[1])',
-    '"SELECT forum_counter_lock($1)"',
     "lock_topics_in_tx(&txn, tenant_id, input.source_topic_id, target_topic_id).await?;",
-    "Forum topic merge category changed concurrently",
-    "source.category_id != target.category_id",
-    "source accepted solution",
+    "lock_topic_solution_scopes_in_tx(",
+    "TopicMergeSolutionConflict(input.operation_id)",
+    "delete_source_solution_in_tx",
+    "move_replies_in_tx(",
+    "insert_transferred_solution_in_tx",
     "source_reply_count > MAX_FORUM_TOPIC_MERGE_REPLIES",
     "moved_published_reply_count != source.reply_count",
     "target_published_reply_count != target.reply_count",
-    "position_offset",
-    ".checked_add(source_max_position)",
-    "move_replies_in_tx(",
     "source_active.status = Set(TopicStatus::Archived);",
     "source_active.is_locked = Set(true);",
     "source_active.reply_count = Set(0);",
@@ -193,19 +188,28 @@ includesAll(
   ],
   "topic merge service",
 );
+assert.ok(!service.includes("does not yet support a source accepted solution"));
+assert.ok(!service.includes("UserStatsService"));
 const receiptLookup = service.indexOf("forum_topic_merge_operation::Entity::find_by_id");
 const preliminaryRead = service.indexOf("let preliminary_source =");
 const counterLocks = service.indexOf("lock_merge_counter_scopes_in_tx(");
 const topicLocks = service.indexOf("lock_topics_in_tx(&txn");
-const replyCount = service.indexOf("let source_reply_count =");
+const solutionLocks = service.indexOf("lock_topic_solution_scopes_in_tx(");
+const solutionConflict = service.indexOf("TopicMergeSolutionConflict(input.operation_id)");
+const solutionDelete = service.indexOf("delete_source_solution_in_tx(&txn");
+const replyMove = service.indexOf("move_replies_in_tx(", solutionDelete);
+const solutionInsert = service.indexOf("insert_transferred_solution_in_tx(&txn");
 assert.ok(receiptLookup < preliminaryRead);
 assert.ok(preliminaryRead < counterLocks);
 assert.ok(counterLocks < topicLocks);
-assert.ok(topicLocks < replyCount);
+assert.ok(topicLocks < solutionLocks);
+assert.ok(solutionLocks < solutionConflict);
+assert.ok(solutionConflict < solutionDelete);
+assert.ok(solutionDelete < replyMove);
+assert.ok(replyMove < solutionInsert);
 assert.equal((service.match(/publish_forum_topic_projection_in_tx\(/g) ?? []).length, 2);
 assert.equal((service.match(/publish_forum_category_projection_in_tx\(/g) ?? []).length, 1);
 for (const forbidden of [
-  "delete_many()",
   "forum_topic::Entity::delete",
   "forum_reply::Entity::delete",
   "category_active.topic_count",
@@ -242,15 +246,15 @@ includesAll(
   test,
   [
     "topic_merge_is_atomic_idempotent_and_append_only",
-    "topic_merge_rejects_cross_category_and_source_solution_without_partial_state",
-    "ForumTopicMergeService",
-    "MergeForumTopicInput",
+    "topic_merge_transfers_source_only_solution_and_preserves_target_only_solution",
+    "topic_merge_rejects_cross_category_and_competing_solutions_without_partial_state",
+    "topic_solution_database_guard_requires_active_topic_and_approved_reply",
     "moved_reply_count, 2",
     '"archived", true, 0',
-    "category_id, 2, 3",
     "source_root_reply_id",
     "source_child_reply_id",
     "TopicMergeOperationConflict",
+    "TopicMergeSolutionConflict",
     "UPDATE forum_topic_merge_operations",
     "DELETE FROM forum_topic_merge_operations",
     '"forum.topic.merged"',
@@ -262,16 +266,13 @@ includesAll(
   [
     "# FORUM-21B idempotent topic merge owner",
     "`source_ready_maintainer_execution_pending`",
-    contractPath,
-    "same active category",
-    "source may contain at most 500 reply rows",
-    "category-tree lifecycle lock",
-    "category counter scope followed by source and target",
-    "retained non-deleted-row counter",
-    "source topic becomes archived and locked",
-    "FORUM_TOPIC_MERGE_OPERATION_CONFLICT",
-    "topic subscriptions",
-    "source accepted solution",
+    paths.contract,
+    paths.solutionContract,
+    "source-only accepted solution",
+    "target-only accepted solution",
+    "two accepted solutions",
+    "FORUM_TOPIC_MERGE_SOLUTION_CONFLICT",
+    "FORUM-21A through FORUM-21H",
     "No command above was run by the implementation agent",
   ],
   "FORUM-21B handoff",
@@ -282,5 +283,5 @@ assert.ok(!plan.includes("| `FORUM-21` | `in_progress` |"));
 assert.ok(verifier.includes("source_ready_maintainer_execution_pending"));
 
 console.log(
-  "FORUM-21B topic merge owner source is ready and canonical FORUM-21 remains planned.",
+  "FORUM-21B/H topic merge owner source is ready and canonical FORUM-21 remains planned.",
 );

--- a/scripts/verify/verify-forum-topic-merge-solution-policy.mjs
+++ b/scripts/verify/verify-forum-topic-merge-solution-policy.mjs
@@ -18,10 +18,7 @@ const paths = {
   verifier: "scripts/verify/verify-forum-topic-merge-solution-policy.mjs",
 };
 
-function read(path) {
-  return readFileSync(path, "utf8");
-}
-
+const read = (path) => readFileSync(path, "utf8");
 function includesAll(text, markers, label) {
   for (const marker of markers) {
     assert.ok(text.includes(marker), `${label} is missing marker: ${marker}`);
@@ -70,13 +67,9 @@ assert.equal(cumulativeContract.solution_policy.solution_count_delta_during_merg
 
 includesAll(
   error,
-  [
-    "TopicMergeSolutionConflict(Uuid)",
-    '"FORUM_TOPIC_MERGE_SOLUTION_CONFLICT"',
-  ],
+  ["TopicMergeSolutionConflict(Uuid)", '"FORUM_TOPIC_MERGE_SOLUTION_CONFLICT"'],
   "ForumError",
 );
-
 includesAll(
   migrationsMod,
   [
@@ -85,7 +78,6 @@ includesAll(
   ],
   "migration registry",
 );
-
 includesAll(
   migration,
   [
@@ -110,14 +102,8 @@ includesAll(
   ],
   "solution migration",
 );
-assert.equal(
-  (migration.match(/forum_00_topic_solution_scope/g) ?? []).length >= 4,
-  true,
-);
-assert.equal(
-  (migration.match(/forum_10_topic_solution_target/g) ?? []).length >= 4,
-  true,
-);
+assert.ok((migration.match(/forum_00_topic_solution_scope/g) ?? []).length >= 4);
+assert.ok((migration.match(/forum_10_topic_solution_target/g) ?? []).length >= 4);
 
 includesAll(
   merge,
@@ -130,10 +116,12 @@ includesAll(
     "TopicMergeSolutionConflict(input.operation_id)",
     "delete_source_solution_in_tx(&txn, tenant_id, source.id).await?;",
     "move_replies_in_tx(",
-    "insert_transferred_solution_in_tx(&txn, tenant_id, target.id, solution).await?;",
+    "insert_transferred_solution_in_tx(&txn, tenant_id, target.id, &solution).await?;",
     "marked_by_user_id: Set(solution.marked_by_user_id)",
     "marked_at: Set(solution.marked_at)",
+    "deleted_at IS NULL AND status = 'approved'",
     "load_valid_solution_in_tx(&txn, tenant_id, target.id, \"transferred target\")",
+    "Forum transferred accepted solution metadata changed",
     "forum_domain_event::ActiveModel",
     "forum_topic_merge_operation::ActiveModel",
     "txn.commit().await?;",
@@ -154,7 +142,7 @@ const sourceDelete = merge.indexOf(
 );
 const replyMove = merge.indexOf("move_replies_in_tx(", sourceDelete);
 const solutionInsert = merge.indexOf(
-  "insert_transferred_solution_in_tx(&txn, tenant_id, target.id, solution).await?;",
+  "insert_transferred_solution_in_tx(&txn, tenant_id, target.id, &solution).await?;",
 );
 const sourceArchive = merge.indexOf("source_active.status = Set(TopicStatus::Archived);");
 const semanticEvent = merge.indexOf("forum_domain_event::ActiveModel");
@@ -222,7 +210,6 @@ includesAll(
   ],
   "cumulative merge docs",
 );
-
 assert.ok(plan.includes("| `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |"));
 assert.ok(plan.includes("## `FORUM-21` — move, merge, split and fork topics"));
 assert.ok(plan.includes("**Status:** `planned`"));

--- a/scripts/verify/verify-forum-topic-merge-solution-policy.mjs
+++ b/scripts/verify/verify-forum-topic-merge-solution-policy.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const paths = {
+  contract: "crates/rustok-forum/contracts/forum-topic-merge-solution-policy.json",
+  cumulativeContract: "crates/rustok-forum/contracts/forum-topic-merge-owner.json",
+  docs: "crates/rustok-forum/docs/forum-21h-topic-merge-solution-policy.md",
+  cumulativeDocs: "crates/rustok-forum/docs/forum-21b-topic-merge-owner.md",
+  error: "crates/rustok-forum/src/error.rs",
+  merge: "crates/rustok-forum/src/services/topic_merge.rs",
+  migration:
+    "crates/rustok-forum/src/migrations/m20260803_000016_add_forum_topic_merge_solution_policy.rs",
+  migrationsMod: "crates/rustok-forum/src/migrations/mod.rs",
+  test: "crates/rustok-forum/tests/topic_merge_sqlite.rs",
+  plan: "crates/rustok-forum/docs/implementation-plan.md",
+  verifier: "scripts/verify/verify-forum-topic-merge-solution-policy.mjs",
+};
+
+function read(path) {
+  return readFileSync(path, "utf8");
+}
+
+function includesAll(text, markers, label) {
+  for (const marker of markers) {
+    assert.ok(text.includes(marker), `${label} is missing marker: ${marker}`);
+  }
+}
+
+const contract = JSON.parse(read(paths.contract));
+const cumulativeContract = JSON.parse(read(paths.cumulativeContract));
+const docs = read(paths.docs);
+const cumulativeDocs = read(paths.cumulativeDocs);
+const error = read(paths.error);
+const merge = read(paths.merge);
+const migration = read(paths.migration);
+const migrationsMod = read(paths.migrationsMod);
+const test = read(paths.test);
+const plan = read(paths.plan);
+const verifier = read(paths.verifier);
+
+assert.equal(contract.contract, "forum_topic_merge_solution_policy_v1");
+assert.equal(contract.task, "FORUM-21H");
+assert.equal(contract.parent_task, "FORUM-21");
+assert.equal(contract.extends, "FORUM-21B");
+assert.equal(contract.status, "source_ready_maintainer_execution_pending");
+assert.equal(contract.canonical_plan_status, "planned");
+assert.equal(contract.owner_service, "ForumTopicMergeService");
+assert.equal(contract.postgres_advisory_seed, 31);
+assert.equal(contract.conflict.stable_code, "FORUM_TOPIC_MERGE_SOLUTION_CONFLICT");
+assert.deepEqual(
+  contract.policy_matrix.map(({ source, target, outcome }) => [source, target, outcome]),
+  [
+    ["none", "none", "merge_without_solution_mutation"],
+    ["none", "accepted_solution", "preserve_target_solution"],
+    ["accepted_solution", "none", "transfer_source_solution_to_target"],
+    ["accepted_solution", "accepted_solution", "fail_before_mutation"],
+  ],
+);
+assert.equal(contract.atomicity.transfer_commits_with_existing_merge_transaction, true);
+assert.equal(contract.atomicity.exact_merge_replay_adds_no_solution_mutation, true);
+assert.equal(contract.compatibility.merge_input_changed, false);
+assert.equal(contract.compatibility.merge_result_changed, false);
+assert.equal(contract.compatibility.merge_receipt_changed, false);
+assert.equal(contract.compatibility.forum_topic_merged_event_changed, false);
+assert.equal(contract.compatibility.existing_projection_invalidation_targets_changed, false);
+assert.equal(cumulativeContract.latest_policy_slice, "FORUM-21H");
+assert.equal(cumulativeContract.solution_policy.solution_count_delta_during_merge, 0);
+
+includesAll(
+  error,
+  [
+    "TopicMergeSolutionConflict(Uuid)",
+    '"FORUM_TOPIC_MERGE_SOLUTION_CONFLICT"',
+  ],
+  "ForumError",
+);
+
+includesAll(
+  migrationsMod,
+  [
+    "mod m20260803_000016_add_forum_topic_merge_solution_policy;",
+    "Box::new(m20260803_000016_add_forum_topic_merge_solution_policy::Migration)",
+  ],
+  "migration registry",
+);
+
+includesAll(
+  migration,
+  [
+    "CREATE TABLE IF NOT EXISTS forum_topic_solution_locks",
+    "forum_lock_topic_solution_mutation",
+    "forum_validate_topic_solution_target",
+    "forum_00_topic_solution_scope",
+    "forum_10_topic_solution_target",
+    "FOR SHARE",
+    "hashtextextended(",
+    "31",
+    "forum solution requires an active topic and approved reply",
+    "CREATE TRIGGER IF NOT EXISTS forum_00_topic_solution_scope_insert",
+    "CREATE TRIGGER IF NOT EXISTS forum_00_topic_solution_scope_update",
+    "CREATE TRIGGER IF NOT EXISTS forum_00_topic_solution_scope_delete",
+    "CREATE TRIGGER IF NOT EXISTS forum_10_topic_solution_target_insert",
+    "CREATE TRIGGER IF NOT EXISTS forum_10_topic_solution_target_update",
+    "topic.deleted_at IS NULL",
+    "topic.status <> 'archived'",
+    "reply.deleted_at IS NULL",
+    "reply.status = 'approved'",
+  ],
+  "solution migration",
+);
+assert.equal(
+  (migration.match(/forum_00_topic_solution_scope/g) ?? []).length >= 4,
+  true,
+);
+assert.equal(
+  (migration.match(/forum_10_topic_solution_target/g) ?? []).length >= 4,
+  true,
+);
+
+includesAll(
+  merge,
+  [
+    "struct ForumTopicMergeSolutionTransfer",
+    "lock_topic_solution_scopes_in_tx(",
+    "load_valid_solution_in_tx(&txn, tenant_id, source.id, \"source\")",
+    "load_valid_solution_in_tx(&txn, tenant_id, target.id, \"target\")",
+    "source_solution.is_some() && target_solution.is_some()",
+    "TopicMergeSolutionConflict(input.operation_id)",
+    "delete_source_solution_in_tx(&txn, tenant_id, source.id).await?;",
+    "move_replies_in_tx(",
+    "insert_transferred_solution_in_tx(&txn, tenant_id, target.id, solution).await?;",
+    "marked_by_user_id: Set(solution.marked_by_user_id)",
+    "marked_at: Set(solution.marked_at)",
+    "load_valid_solution_in_tx(&txn, tenant_id, target.id, \"transferred target\")",
+    "forum_domain_event::ActiveModel",
+    "forum_topic_merge_operation::ActiveModel",
+    "txn.commit().await?;",
+  ],
+  "merge owner",
+);
+assert.ok(!merge.includes("does not yet support a source accepted solution"));
+assert.ok(!merge.includes("UserStatsService"));
+
+const topicLocks = merge.indexOf("lock_topics_in_tx(&txn");
+const solutionLocks = merge.indexOf("lock_topic_solution_scopes_in_tx(");
+const sourceSolutionRead = merge.indexOf(
+  "load_valid_solution_in_tx(&txn, tenant_id, source.id, \"source\")",
+);
+const conflict = merge.indexOf("TopicMergeSolutionConflict(input.operation_id)");
+const sourceDelete = merge.indexOf(
+  "delete_source_solution_in_tx(&txn, tenant_id, source.id).await?;",
+);
+const replyMove = merge.indexOf("move_replies_in_tx(", sourceDelete);
+const solutionInsert = merge.indexOf(
+  "insert_transferred_solution_in_tx(&txn, tenant_id, target.id, solution).await?;",
+);
+const sourceArchive = merge.indexOf("source_active.status = Set(TopicStatus::Archived);");
+const semanticEvent = merge.indexOf("forum_domain_event::ActiveModel");
+const receipt = merge.indexOf("forum_topic_merge_operation::ActiveModel");
+const invalidation = merge.indexOf("publish_forum_topic_projection_in_tx");
+assert.ok(topicLocks < solutionLocks);
+assert.ok(solutionLocks < sourceSolutionRead);
+assert.ok(sourceSolutionRead < conflict);
+assert.ok(conflict < sourceDelete);
+assert.ok(sourceDelete < replyMove);
+assert.ok(replyMove < solutionInsert);
+assert.ok(solutionInsert < sourceArchive);
+assert.ok(sourceArchive < semanticEvent);
+assert.ok(semanticEvent < receipt);
+assert.ok(receipt < invalidation);
+
+includesAll(
+  test,
+  [
+    "topic_merge_is_atomic_idempotent_and_append_only",
+    "topic_merge_transfers_source_only_solution_and_preserves_target_only_solution",
+    "topic_merge_rejects_cross_category_and_competing_solutions_without_partial_state",
+    "topic_solution_database_guard_requires_active_topic_and_approved_reply",
+    "ModerationService",
+    "SolutionSnapshot",
+    "source_solution_before",
+    "target_solution_before",
+    "user_solution_count",
+    "TopicMergeSolutionConflict",
+    '"FORUM_TOPIC_MERGE_SOLUTION_CONFLICT"',
+    "merge_event_count",
+    "baseline_projection_ids",
+    "forum_user_stats",
+    "pending_reply_id",
+    "archived_topic_id",
+  ],
+  "SQLite regression",
+);
+assert.ok(!test.includes("source_solution_without_partial_state"));
+
+includesAll(
+  docs,
+  [
+    "# FORUM-21H topic merge accepted-solution policy",
+    "`source_ready_maintainer_execution_pending`",
+    "Outcome matrix",
+    "Source-only transfer",
+    "Statistics",
+    "Competing solutions",
+    "advisory lock seed `31`",
+    "FORUM_TOPIC_MERGE_SOLUTION_CONFLICT",
+    "No command above was run by the implementation agent",
+  ],
+  "FORUM-21H docs",
+);
+includesAll(
+  cumulativeDocs,
+  [
+    "FORUM-21H extends",
+    "source-only accepted solution",
+    "target-only accepted solution",
+    "two accepted solutions",
+    "FORUM_TOPIC_MERGE_SOLUTION_CONFLICT",
+    "FORUM-21A through FORUM-21H",
+  ],
+  "cumulative merge docs",
+);
+
+assert.ok(plan.includes("| `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |"));
+assert.ok(plan.includes("## `FORUM-21` — move, merge, split and fork topics"));
+assert.ok(plan.includes("**Status:** `planned`"));
+assert.ok(plan.includes("revalidate solutions and ACL"));
+assert.ok(!plan.includes("| `FORUM-21` | `done` |"));
+assert.ok(!plan.includes("| `FORUM-21` | `in_progress` |"));
+assert.ok(verifier.includes("source_ready_maintainer_execution_pending"));
+
+console.log(
+  "FORUM-21H topic merge accepted-solution policy source is ready; canonical FORUM-21 remains planned.",
+);

--- a/scripts/verify/verify-forum-topic-merge-solution-policy.mjs
+++ b/scripts/verify/verify-forum-topic-merge-solution-policy.mjs
@@ -92,6 +92,7 @@ includesAll(
     "forum solution requires an active topic and approved reply",
     "CREATE TRIGGER IF NOT EXISTS forum_00_topic_solution_scope_insert",
     "CREATE TRIGGER IF NOT EXISTS forum_00_topic_solution_scope_update",
+    "BEFORE UPDATE ON forum_solutions",
     "CREATE TRIGGER IF NOT EXISTS forum_00_topic_solution_scope_delete",
     "CREATE TRIGGER IF NOT EXISTS forum_10_topic_solution_target_insert",
     "CREATE TRIGGER IF NOT EXISTS forum_10_topic_solution_target_update",
@@ -147,7 +148,7 @@ const solutionInsert = merge.indexOf(
 const sourceArchive = merge.indexOf("source_active.status = Set(TopicStatus::Archived);");
 const semanticEvent = merge.indexOf("forum_domain_event::ActiveModel");
 const receipt = merge.indexOf("forum_topic_merge_operation::ActiveModel");
-const invalidation = merge.indexOf("publish_forum_topic_projection_in_tx");
+const invalidation = merge.indexOf("publish_forum_topic_projection_in_tx", receipt);
 assert.ok(topicLocks < solutionLocks);
 assert.ok(solutionLocks < sourceSolutionRead);
 assert.ok(sourceSolutionRead < conflict);

--- a/scripts/verify/verify-forum-topic-merge-solution-policy.mjs
+++ b/scripts/verify/verify-forum-topic-merge-solution-policy.mjs
@@ -10,6 +10,9 @@ const paths = {
   cumulativeDocs: "crates/rustok-forum/docs/forum-21b-topic-merge-owner.md",
   error: "crates/rustok-forum/src/error.rs",
   merge: "crates/rustok-forum/src/services/topic_merge.rs",
+  moderationOwner: "crates/rustok-forum/src/services/moderation_owner.rs",
+  solutionLock: "crates/rustok-forum/src/services/topic_solution_lock.rs",
+  servicesMod: "crates/rustok-forum/src/services/mod.rs",
   migration:
     "crates/rustok-forum/src/migrations/m20260803_000016_add_forum_topic_merge_solution_policy.rs",
   migrationsMod: "crates/rustok-forum/src/migrations/mod.rs",
@@ -31,6 +34,9 @@ const docs = read(paths.docs);
 const cumulativeDocs = read(paths.cumulativeDocs);
 const error = read(paths.error);
 const merge = read(paths.merge);
+const moderationOwner = read(paths.moderationOwner);
+const solutionLock = read(paths.solutionLock);
+const servicesMod = read(paths.servicesMod);
 const migration = read(paths.migration);
 const migrationsMod = read(paths.migrationsMod);
 const test = read(paths.test);
@@ -79,6 +85,11 @@ includesAll(
   "migration registry",
 );
 includesAll(
+  servicesMod,
+  ["mod topic_solution_lock;"],
+  "service registry",
+);
+includesAll(
   migration,
   [
     "CREATE TABLE IF NOT EXISTS forum_topic_solution_locks",
@@ -105,6 +116,61 @@ includesAll(
 );
 assert.ok((migration.match(/forum_00_topic_solution_scope/g) ?? []).length >= 4);
 assert.ok((migration.match(/forum_10_topic_solution_target/g) ?? []).length >= 4);
+
+includesAll(
+  solutionLock,
+  [
+    "pub(crate) async fn lock_topic_solution_scopes_in_tx(",
+    "ids.sort();",
+    "ids.dedup();",
+    "deleted_at IS NULL FOR SHARE",
+    "pg_advisory_xact_lock(hashtextextended($1, 31))",
+    "INSERT INTO forum_topic_solution_locks",
+  ],
+  "shared solution lock",
+);
+includesAll(
+  moderationOwner,
+  [
+    "use crate::services::topic_solution_lock::lock_topic_solution_scopes_in_tx;",
+    "ReplyService::find_reply_in_tx(&txn, tenant_id, reply_id)",
+    "let previous_solution_reply_id = forum_solution::Entity::find()",
+    "let solution_author_id = if let Some(solution) = forum_solution::Entity::find()",
+  ],
+  "moderation solution owner",
+);
+const markStart = moderationOwner.indexOf(
+  "async fn mark_solution_with_optional_audience_context(",
+);
+const markTxn = moderationOwner.indexOf("let txn = self.db.begin().await?;", markStart);
+const markLock = moderationOwner.indexOf(
+  "lock_topic_solution_scopes_in_tx(&txn, tenant_id, &[topic_id]).await?;",
+  markTxn,
+);
+const markReplyRead = moderationOwner.indexOf(
+  "ReplyService::find_reply_in_tx(&txn, tenant_id, reply_id)",
+  markLock,
+);
+const markSolutionRead = moderationOwner.indexOf(
+  "let previous_solution_reply_id = forum_solution::Entity::find()",
+  markReplyRead,
+);
+assert.ok(markStart < markTxn && markTxn < markLock);
+assert.ok(markLock < markReplyRead && markReplyRead < markSolutionRead);
+const clearStart = moderationOwner.indexOf(
+  "async fn clear_solution_with_optional_audience_context(",
+);
+const clearTxn = moderationOwner.indexOf("let txn = self.db.begin().await?;", clearStart);
+const clearLock = moderationOwner.indexOf(
+  "lock_topic_solution_scopes_in_tx(&txn, tenant_id, &[topic_id]).await?;",
+  clearTxn,
+);
+const clearSolutionRead = moderationOwner.indexOf(
+  "let solution_author_id = if let Some(solution) = forum_solution::Entity::find()",
+  clearLock,
+);
+assert.ok(clearStart < clearTxn && clearTxn < clearLock);
+assert.ok(clearLock < clearSolutionRead);
 
 includesAll(
   merge,


### PR DESCRIPTION
## What changed

- add source-ready `FORUM-21H` inside the existing bounded `FORUM-21B` same-category merge owner;
- preserve a retained-target accepted solution unchanged;
- transfer a source-only accepted solution after reply movement while preserving the exact `reply_id`, nullable `marked_by_user_id` and `marked_at`;
- reject source+target accepted solutions with `FORUM_TOPIC_MERGE_SOLUTION_CONFLICT` before solution, reply, topic, event, receipt, counter or Search invalidation mutation;
- keep `forum_user_stats.solution_count` unchanged because accepted reply identity and author do not change;
- validate stored and transferred solutions against approved, non-deleted replies owned by the exact tenant/topic;
- add a shared topic-solution lock helper and require moderation mark/replace/clear to acquire the scope before reading the current marker, reply author or statistics delta;
- serialize direct solution INSERT/UPDATE/DELETE and merge inspection through deterministic topic rows plus PostgreSQL advisory scope seed `31` or the SQLite durable lock row;
- serialize SQLite marker-only solution updates as well as owner-key updates;
- reject solution INSERT or owner-key UPDATE targeting an archived/deleted topic, deleted reply, pending reply or reply owned by another topic;
- retain the existing merge input/result, immutable receipt, `forum.topic.merged` payload and source/target/category projection invalidation targets;
- update the cumulative FORUM-21B contract, handoff, SQLite regression and verifier, and add a focused FORUM-21H contract, handoff and verifier.

## Solution matrix

- no source / no target solution: merge without solution mutation;
- no source / target solution: preserve target marker;
- source solution / no target solution: transfer source marker to the retained target;
- source solution / target solution: fail closed pending an explicit manager-selected winner policy.

## Concurrency boundary

Merge locks source and target topic rows before solution scopes. Ordinary mark and clear lock the same tenant/topic scope before reading current solution state and computing any `solution_count` change. Database triggers acquire the same scope for direct writers. This prevents a concurrent merge from moving a marker between an owner read and its statistics update.

## Deliberate boundary

This slice does not add winner selection for two accepted solutions, public merge transport, canonical aliases or redirects, cross-category merge, split, fork or reply-range workflows. Canonical `FORUM-21` remains `planned`; FORUM-21A through FORUM-21H remain bounded partial slices.

## Validation

Tests, Node verifiers, formatting, Cargo checks, SQLite/PostgreSQL execution, workflows and CI were intentionally not run, per maintainer request.

## Branch state

Current `main` advanced through unrelated Commerce/Index/Inventory work with no Forum path overlap. Squash merge is requested so the final mainline change remains one Forum work unit.