### PR TITLE
fix(commerce): remove order-change diagnostic Debug bounds

### DIFF
--- a/crates/rustok-commerce/admin/src/transport/native_server_adapter_ssr.rs
+++ b/crates/rustok-commerce/admin/src/transport/native_server_adapter_ssr.rs
@@ -754,7 +754,7 @@ fn order_change_correlation_id(operation: &'static str) -> String {
     transport_correlation_id("commerce-admin-order-change", operation)
 }
 
-fn order_change_context_error<E: std::fmt::Debug>(
+fn order_change_context_error<E>(
     _error: E,
     operation: &'static str,
     context_kind: &'static str,
@@ -776,7 +776,7 @@ fn order_change_context_error<E: std::fmt::Debug>(
     ServerFnError::new(public_message)
 }
 
-fn order_change_auth_context_error<E: std::fmt::Debug>(
+fn order_change_auth_context_error<E>(
     error: E,
     operation: &'static str,
     correlation_id: &str,
@@ -791,7 +791,7 @@ fn order_change_auth_context_error<E: std::fmt::Debug>(
     )
 }
 
-fn order_change_tenant_context_error<E: std::fmt::Debug>(
+fn order_change_tenant_context_error<E>(
     error: E,
     operation: &'static str,
     correlation_id: &str,

--- a/crates/rustok-commerce/contracts/evidence/admin-order-change-native-error-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/admin-order-change-native-error-safety-source-review.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "status": "commerce_admin_order_change_native_error_safety_source_reviewed_unvalidated",
-  "captured_at": "2026-07-31",
-  "base_main_sha": "b4889de03d881c08e39dd1f933291bfd87d44b3d",
+  "captured_at": "2026-08-03",
+  "base_main_sha": "5089a0221420c8001a34302f4fed5228e3140baf",
   "review": {
     "mounted_endpoint_names_preserved": true,
     "public_function_signatures_preserved": true,
@@ -19,6 +19,7 @@
       "Core"
     ],
     "framework_error_text_removed": true,
+    "framework_debug_bounds_removed": true,
     "runtime_identity_values_removed": true,
     "owner_error_text_removed": true,
     "owner_identity_values_removed": true,

--- a/crates/rustok-commerce/contracts/evidence/admin-order-change-native-error-safety-source.json
+++ b/crates/rustok-commerce/contracts/evidence/admin-order-change-native-error-safety-source.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0.0",
   "status": "commerce_admin_order_change_native_error_safety_source_unvalidated",
-  "captured_at": "2026-07-31",
+  "captured_at": "2026-08-03",
   "scope": {
     "package": "rustok-commerce-admin",
     "boundary": "commerce_admin_order_change_native_transport",
@@ -25,6 +25,7 @@
     "tenant_match_and_input_validation_preserved": true,
     "framework_extraction_errors_use_static_public_envelopes": true,
     "framework_error_type_only": true,
+    "framework_debug_bounds_removed": true,
     "complete_framework_error_logged": false,
     "request_context_is_diagnostic_only": true,
     "correlation_is_unique_per_transport_call": true,
@@ -47,6 +48,7 @@
     "mounted_http_parity_executed": false,
     "ci_executed": false
   },
+  "execution": [],
   "reviewed_sources": [
     "crates/rustok-commerce/admin/src/transport/mod.rs",
     "crates/rustok-commerce/admin/src/transport/native_server_adapter.rs",

--- a/crates/rustok-commerce/docs/admin-order-change-native-error-safety.md
+++ b/crates/rustok-commerce/docs/admin-order-change-native-error-safety.md
@@ -1,6 +1,6 @@
 # Commerce admin order-change native diagnostic safety
 
-Date: 2026-07-31
+Date: 2026-08-03
 
 Status: `source-complete / unvalidated`
 
@@ -44,6 +44,11 @@ operation, context kind, correlation ID, stable code, boundary, and Rust error t
 complete framework extraction errors are not logged; neither debug nor display text is
 retained.
 
+The order-change auth, tenant, and shared context helpers no longer require a `Debug`
+implementation from the framework extraction error type. This makes the type-only policy
+explicit in the function contract: the payload is accepted for ownership and immediately
+discarded, while only `std::any::type_name::<E>()` is retained for diagnostics.
+
 Optional `RequestContext` extraction remains diagnostic-only. Failure still falls back
 without changing authentication, authorization, tenant matching, validation, or owner-call
 admission.
@@ -51,7 +56,7 @@ admission.
 ## Runtime composition diagnostics
 
 Missing `TransactionalEventBus` still produces the static runtime envelope and stable
-runtime diagnostic code. The event now records only:
+runtime diagnostic code. The event records only:
 
 - tenant and actor UUID non-nil facts;
 - request-context presence;
@@ -65,7 +70,7 @@ full values.
 ## Owner diagnostics
 
 The owner mapper still covers all seven `OrderError` variants and preserves the original
-warning/error split. Diagnostics now retain only:
+warning/error split. Diagnostics retain only:
 
 - owner, consumer, operation, correlation ID, typed error kind, stable public code, and
   boundary;
@@ -100,12 +105,23 @@ framework type-only diagnostics, promotion request-context facts, safe `PortErro
 endpoints, permissions, channel/locale forwarding, deadline, idempotency, public message,
 and owner calls remain unchanged.
 
+The promotion verifier now treats the independently guarded order-change type-only mapper as
+a preserved compatibility marker and fails if the obsolete order-change `Debug` bound
+returns. Promotion evidence and runtime behavior are not promoted or reinterpreted by this
+slice.
+
 ## Evidence boundary
 
 Focused guard:
 
 ```text
 scripts/verify/verify-commerce-admin-order-change-native-error-safety.mjs
+```
+
+Compatibility guard:
+
+```text
+scripts/verify/verify-commerce-admin-promotion-native-error-safety.mjs
 ```
 
 Retained evidence:

--- a/scripts/verify/verify-commerce-admin-order-change-native-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-order-change-native-error-safety.mjs
@@ -89,9 +89,9 @@ for (const marker of [
   "fn order_change_request_context_facts(",
   "struct OrderChangeOwnerErrorFacts",
   "fn order_change_owner_error_facts(",
-  "fn order_change_context_error",
-  "fn order_change_auth_context_error",
-  "fn order_change_tenant_context_error",
+  "fn order_change_context_error<E>(",
+  "fn order_change_auth_context_error<E>(",
+  "fn order_change_tenant_context_error<E>(",
   "optional_order_change_request_context",
   "struct OrderChangeOwnerErrorContext",
   "fn order_change_owner_error(",
@@ -99,6 +99,18 @@ for (const marker of [
   "Commerce order-change runtime is temporarily unavailable",
 ]) {
   assertContains(adapter, marker, `${adapterPath}: missing order-change safety marker ${marker}`);
+}
+
+for (const obsolete of [
+  "fn order_change_context_error<E: std::fmt::Debug>(",
+  "fn order_change_auth_context_error<E: std::fmt::Debug>(",
+  "fn order_change_tenant_context_error<E: std::fmt::Debug>(",
+]) {
+  assertNotContains(
+    adapter,
+    obsolete,
+    `${adapterPath}: type-only context helper must not require Debug: ${obsolete}`,
+  );
 }
 
 for (const [variant, publicMessage] of [
@@ -303,6 +315,7 @@ if (evidence.status !== "commerce_admin_order_change_native_error_safety_source_
 }
 for (const [field, expected] of Object.entries({
   framework_error_type_only: true,
+  framework_debug_bounds_removed: true,
   complete_framework_error_logged: false,
   runtime_identity_shape_only: true,
   owner_error_shape_only: true,
@@ -328,12 +341,16 @@ for (const field of [
     fail(`${evidencePath}: validation.${field} must remain false until execution evidence exists`);
   }
 }
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  fail(`${evidencePath}: execution must remain empty`);
+}
 
 if (review.status !== "commerce_admin_order_change_native_error_safety_source_reviewed_unvalidated") {
   fail(`${reviewPath}: source review must remain explicitly unvalidated`);
 }
 for (const field of [
   "framework_error_text_removed",
+  "framework_debug_bounds_removed",
   "runtime_identity_values_removed",
   "owner_error_text_removed",
   "owner_identity_values_removed",
@@ -348,6 +365,7 @@ for (const field of [
 
 assertContains(doc, "Status: `source-complete / unvalidated`", `${docPath}: status must remain unvalidated`);
 assertContains(doc, "complete framework extraction errors are not logged", `${docPath}: framework diagnostic policy`);
+assertContains(doc, "no longer require a `Debug`", `${docPath}: type-only helper contract`);
 assertContains(doc, "complete `OrderError` and identity values are not logged", `${docPath}: owner diagnostic policy`);
 
 if (failures.length > 0) {
@@ -356,4 +374,4 @@ if (failures.length > 0) {
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log("✔ Commerce admin order-change native diagnostics use correlation-safe shape only; execution evidence remains open");
+console.log("✔ Commerce admin order-change native diagnostics use correlation-safe type/shape only; execution evidence remains open");

--- a/scripts/verify/verify-commerce-admin-promotion-native-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-promotion-native-error-safety.mjs
@@ -212,8 +212,13 @@ for (const functionName of [
 
 assertContains(
   safeAdapter,
+  "fn order_change_context_error<E>(",
+  `${safeAdapterPath}: independently guarded order-change type-only context mapper must remain present`,
+);
+assertNotContains(
+  safeAdapter,
   "fn order_change_context_error<E: std::fmt::Debug>(",
-  `${safeAdapterPath}: order-change source must remain present and explicitly out of scope`,
+  `${safeAdapterPath}: promotion guard must not require an obsolete order-change Debug bound`,
 );
 
 if (evidence.status !== "commerce_admin_promotion_native_error_safety_source_unvalidated") {


### PR DESCRIPTION
## Summary

- continue the ecommerce correlation-safe mapper cleanup at the Commerce Admin order-change native boundary;
- remove unnecessary `std::fmt::Debug` bounds from the shared order-change context mapper plus its auth and tenant wrappers;
- preserve type-only diagnostics through `std::any::type_name::<E>()` without formatting or logging the framework payload;
- preserve all three mounted endpoints, public envelopes, permissions, tenant matching, request-context fallback, runtime composition, typed `OrderError` shape diagnostics, severity, correlation, owner calls, DTO mapping, and persisted behavior;
- strengthen the focused order-change verifier to require the bound-free signatures and forbid the obsolete signatures;
- reconcile the shared promotion verifier so it preserves the independently guarded order-change contract rather than requiring the old `Debug` marker;
- refresh source evidence, source review, and documentation without promoting ecommerce FFA/FBA status.

## Recheck

The order-change runtime was already payload-safe: complete framework errors and complete `OrderError` values were not logged. The remaining inconsistency was contractual—the type-only context helpers still required `E: Debug` even though the value was discarded and never formatted.

The semantic runtime diff is exactly three signature changes. GitHub's contents API also records an EOF newline-only hunk in the shared SSR file; it does not change Rust behavior.

## Deliberate boundary

No promotion runtime logic, order-change owner mapping, public messages, endpoint paths, API models, Cargo dependencies, orchestration, database behavior, workflows, CI configuration, or validation status changes.

## Validation

Tests, Node verifiers, formatting, Cargo checks, mounted execution, workflows, and CI were not run, per maintainer request.

Suggested maintainer commands:

```bash
node scripts/verify/verify-commerce-admin-order-change-native-error-safety.mjs
node scripts/verify/verify-commerce-admin-promotion-native-error-safety.mjs
node scripts/verify/verify-commerce-admin-order-change-client-transport-error-safety.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-commerce-admin
cargo check -p rustok-commerce-admin --features hydrate
cargo check -p rustok-commerce-admin --features ssr
```

Branch base: `5089a0221420c8001a34302f4fed5228e3140baf`. Current `main` contains one later non-overlapping Index commit.