### PR TITLE
fix(commerce): remove promotion diagnostic Debug bounds

### DIFF
--- a/crates/rustok-commerce/admin/src/transport/native_server_adapter_ssr.rs
+++ b/crates/rustok-commerce/admin/src/transport/native_server_adapter_ssr.rs
@@ -286,7 +286,7 @@ fn promotion_correlation_id(operation: &'static str) -> String {
     transport_correlation_id("commerce-admin-cart-promotion", operation)
 }
 
-fn promotion_context_error<E: std::fmt::Debug>(
+fn promotion_context_error<E>(
     _error: E,
     operation: &'static str,
     context_kind: &'static str,
@@ -308,7 +308,7 @@ fn promotion_context_error<E: std::fmt::Debug>(
     ServerFnError::new(public_message)
 }
 
-fn promotion_auth_context_error<E: std::fmt::Debug>(
+fn promotion_auth_context_error<E>(
     error: E,
     operation: &'static str,
     correlation_id: &str,
@@ -323,7 +323,7 @@ fn promotion_auth_context_error<E: std::fmt::Debug>(
     )
 }
 
-fn promotion_tenant_context_error<E: std::fmt::Debug>(
+fn promotion_tenant_context_error<E>(
     error: E,
     operation: &'static str,
     correlation_id: &str,

--- a/crates/rustok-commerce/contracts/evidence/admin-promotion-native-error-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/admin-promotion-native-error-safety-source-review.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "status": "commerce_admin_promotion_native_error_safety_source_reviewed_unvalidated",
-  "captured_at": "2026-07-31",
-  "base_main_sha": "c4149652fa9c5835336daa29156b1d3e7ba68ac9",
+  "captured_at": "2026-08-03",
+  "base_main_sha": "da09970d6a8f504b24dcf60dbc942b117e4d77fd",
   "review": {
     "mounted_endpoint_names_preserved": true,
     "public_function_signatures_preserved": true,
@@ -12,6 +12,7 @@
     "cart_promotion_owner_guard_reviewed": true,
     "port_error_public_sanitization_reviewed": true,
     "framework_error_text_removed": true,
+    "framework_debug_bounds_removed": true,
     "owner_port_error_text_removed": true,
     "identity_values_removed": true,
     "safe_shape_diagnostics_reviewed": true,
@@ -20,7 +21,8 @@
     "write_idempotency_preserved": true,
     "client_hydrate_contract_remains_on_canonical_adapter": true,
     "ssr_routes_to_safe_adapter": true,
-    "order_change_source_explicitly_not_claimed_safe": true
+    "order_change_type_only_contract_preserved": true,
+    "feature_diff_is_commerce_only": true
   },
   "execution": {
     "commands_run": [],
@@ -34,6 +36,6 @@
     "Compiler evidence is not retained.",
     "Runtime request and owner-failure traces are not retained.",
     "The focused source guard is updated but not executed.",
-    "Commerce admin order-change failures remain a separate mapper-cleanup slice."
+    "Other ecommerce mapper cleanup and non-PortError public envelopes remain open."
   ]
 }

--- a/crates/rustok-commerce/contracts/evidence/admin-promotion-native-error-safety-source.json
+++ b/crates/rustok-commerce/contracts/evidence/admin-promotion-native-error-safety-source.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0.0",
   "status": "commerce_admin_promotion_native_error_safety_source_unvalidated",
-  "captured_at": "2026-07-31",
+  "captured_at": "2026-08-03",
   "scope": {
     "package": "rustok-commerce-admin",
     "boundary": "commerce_admin_promotion_native_transport",
@@ -19,6 +19,7 @@
     "ssr_routes_through_safe_adapter": true,
     "framework_extraction_errors_use_static_public_envelopes": true,
     "framework_error_type_only": true,
+    "framework_debug_bounds_removed": true,
     "complete_framework_error_logged": false,
     "request_context_is_diagnostic_and_attribution_only": true,
     "request_locale_and_channel_cross_port_context_when_available": true,
@@ -34,7 +35,7 @@
     "public_message_presence_and_length_only": true,
     "public_port_error_message_preserved": true,
     "permission_and_input_validation_messages_are_preserved": true,
-    "order_change_cleanup_is_out_of_scope": true
+    "order_change_type_only_context_contract_preserved": true
   },
   "validation": {
     "focused_verifier_executed": false,
@@ -44,6 +45,7 @@
     "runtime_trace_retained": false,
     "ci_executed": false
   },
+  "execution": [],
   "reviewed_sources": [
     "crates/rustok-commerce/admin/src/transport/mod.rs",
     "crates/rustok-commerce/admin/src/transport/native_server_adapter.rs",
@@ -52,6 +54,14 @@
     "crates/rustok-api/src/ports.rs",
     "crates/rustok-cart/src/promotion_guard.rs",
     "scripts/verify/verify-commerce-admin-boundary.mjs",
-    "scripts/verify/verify-commerce-admin-promotion-native-error-safety.mjs"
+    "scripts/verify/verify-commerce-admin-promotion-native-error-safety.mjs",
+    "scripts/verify/verify-commerce-admin-order-change-native-error-safety.mjs"
+  ],
+  "non_claims": [
+    "No Cargo or compiler evidence is retained.",
+    "No static verifier was executed.",
+    "No mounted HTTP or runtime failure trace is retained.",
+    "This slice does not change CartPromotionPort behavior or public envelopes.",
+    "Remaining ecommerce mapper cleanup and non-PortError envelopes stay open."
   ]
 }

--- a/crates/rustok-commerce/docs/admin-promotion-native-error-safety.md
+++ b/crates/rustok-commerce/docs/admin-promotion-native-error-safety.md
@@ -35,6 +35,11 @@ correlation id, stable code, boundary, and the Rust error type. The complete
 framework extraction errors are not logged, including their debug or display
 text.
 
+The type-only `promotion_context_error`, `promotion_auth_context_error`, and
+`promotion_tenant_context_error` helpers no longer require a `Debug` bound. The
+error value remains unformatted and the diagnostic contract now reflects the
+actual type-only implementation.
+
 Optional `RequestContext` extraction remains attribution-only. Failure still
 falls back without changing permission or operation admission, but only the error
 type is retained in diagnostics.
@@ -68,6 +73,9 @@ When `RequestContext` is available, its effective locale and resolved channel
 continue to cross the owner `PortContext`; tenant default locale remains the
 fallback.
 
+The independently guarded order-change boundary in the same SSR adapter retains
+its bound-free type-only context helpers and typed owner-error shape contract.
+
 ## Source guard and evidence
 
 Focused guard:
@@ -88,7 +96,6 @@ trace was executed for this source slice.
 
 ## Remaining work
 
-Commerce admin order-change diagnostics in the same SSR adapter remain explicitly
-outside this slice. The broad ecommerce mapper-cleanup item stays open for that
-boundary and the remaining order, payment, fulfillment, inventory, customer, tax,
-promotion, adapter, and non-`PortError` envelopes.
+The broad ecommerce mapper-cleanup item stays open for remaining order, payment,
+fulfillment, inventory, customer, tax, promotion, adapter, and non-`PortError`
+envelopes. This source slice does not promote ecommerce FFA or FBA status.

--- a/scripts/verify/verify-commerce-admin-promotion-native-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-promotion-native-error-safety.mjs
@@ -96,6 +96,9 @@ for (const marker of [
   "uuid::Uuid::new_v4()",
   "struct PromotionRequestContextFacts",
   "fn promotion_request_context_facts(",
+  "fn promotion_context_error<E>(",
+  "fn promotion_auth_context_error<E>(",
+  "fn promotion_tenant_context_error<E>(",
   "optional_promotion_request_context",
   ".map(|context| context.locale.as_str())",
   "context.with_channel(channel)",
@@ -105,6 +108,18 @@ for (const marker of [
   "ServerFnError::new(error.message)",
 ]) {
   assertContains(safeAdapter, marker, `${safeAdapterPath}: missing preserved or safe promotion marker ${marker}`);
+}
+
+for (const obsolete of [
+  "fn promotion_context_error<E: std::fmt::Debug>(",
+  "fn promotion_auth_context_error<E: std::fmt::Debug>(",
+  "fn promotion_tenant_context_error<E: std::fmt::Debug>(",
+]) {
+  assertNotContains(
+    safeAdapter,
+    obsolete,
+    `${safeAdapterPath}: type-only promotion context helper must not require Debug: ${obsolete}`,
+  );
 }
 
 const contextErrorBody = functionBody(safeAdapter, "promotion_context_error");
@@ -226,13 +241,14 @@ if (evidence.status !== "commerce_admin_promotion_native_error_safety_source_unv
 }
 for (const [field, expected] of Object.entries({
   framework_error_type_only: true,
+  framework_debug_bounds_removed: true,
   complete_framework_error_logged: false,
   owner_port_error_shape_only: true,
   complete_owner_port_error_logged: false,
   raw_tenant_actor_cart_logged: false,
   raw_request_context_values_logged: false,
   public_port_error_message_preserved: true,
-  order_change_cleanup_is_out_of_scope: true,
+  order_change_type_only_context_contract_preserved: true,
 })) {
   if (evidence.source_claims?.[field] !== expected) {
     fail(`${evidencePath}: source_claims.${field} must be ${expected}`);
@@ -250,17 +266,21 @@ for (const field of [
     fail(`${evidencePath}: validation.${field} must remain false until execution evidence exists`);
   }
 }
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  fail(`${evidencePath}: execution must remain empty`);
+}
 
 if (review.status !== "commerce_admin_promotion_native_error_safety_source_reviewed_unvalidated") {
   fail(`${reviewPath}: source review must remain explicitly unvalidated`);
 }
 for (const field of [
   "framework_error_text_removed",
+  "framework_debug_bounds_removed",
   "owner_port_error_text_removed",
   "identity_values_removed",
   "safe_shape_diagnostics_reviewed",
   "public_envelopes_preserved",
-  "order_change_source_explicitly_not_claimed_safe",
+  "order_change_type_only_contract_preserved",
 ]) {
   if (review.review?.[field] !== true) {
     fail(`${reviewPath}: review.${field} must be true`);
@@ -269,6 +289,7 @@ for (const field of [
 
 assertContains(doc, "Status: `source-complete / unvalidated`", `${docPath}: status must remain unvalidated`);
 assertContains(doc, "complete framework extraction errors are not logged", `${docPath}: framework diagnostic policy`);
+assertContains(doc, "no longer require a `Debug`", `${docPath}: type-only helper contract`);
 assertContains(doc, "complete `PortError` and identity values are not logged", `${docPath}: owner diagnostic policy`);
 
 if (failures.length > 0) {
@@ -277,4 +298,4 @@ if (failures.length > 0) {
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log("✔ Commerce admin promotion native diagnostics use correlation-safe shape only; execution evidence remains open");
+console.log("✔ Commerce admin promotion native diagnostics use correlation-safe type/shape only; execution evidence remains open");


### PR DESCRIPTION
## Summary

- continue the ecommerce correlation-safe mapper cleanup at the Commerce Admin promotion native boundary;
- remove unnecessary `std::fmt::Debug` bounds from `promotion_context_error`, `promotion_auth_context_error`, and `promotion_tenant_context_error`;
- preserve type-only diagnostics through `std::any::type_name::<E>()` without formatting or logging framework payloads;
- preserve both mounted promotion endpoints, public envelopes, permissions, input validation, optional request attribution, channel/locale forwarding, deadline, idempotency, `PortError` mapping, severity, owner calls, DTOs, and cart behavior;
- strengthen the focused verifier to require bound-free signatures and reject obsolete `Debug` signatures;
- refresh source evidence, source review, and documentation while preserving the independently guarded order-change contract.

## Recheck

Promotion diagnostics were already payload-safe. The remaining inconsistency was contractual: the type-only context helpers required `E: Debug` even though the value is discarded and never formatted.

The runtime diff is exactly three additions and three deletions, limited to those signatures.

## Deliberate boundary

No order-change runtime logic, promotion owner mapping, public messages, endpoint paths, API models, Cargo dependencies, orchestration, database behavior, workflow, CI configuration, or FFA/FBA status changes.

## Validation

Tests, Node verifiers, formatting, Cargo checks, mounted execution, workflows, and CI were not run, per maintainer request.

Suggested maintainer commands:

```bash
node scripts/verify/verify-commerce-admin-promotion-native-error-safety.mjs
node scripts/verify/verify-commerce-admin-order-change-native-error-safety.mjs
node scripts/verify/verify-commerce-admin-promotion-client-transport-error-safety.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-commerce-admin
cargo check -p rustok-commerce-admin --features hydrate
cargo check -p rustok-commerce-admin --features ssr
```

Branch base: `da09970d6a8f504b24dcf60dbc942b117e4d77fd`. Current `main` contains two later non-overlapping Forum and Blog commits.