### PR TITLE
fix(index): block replay scopes on failed jobs

### DIFF
--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -32,6 +32,7 @@ This directory contains the detailed technical architecture documentation for `r
 - [M6 Bounded Replay Dry-run](./m6-bounded-replay-dry-run.md)
 - [M6 Cooperative Replay-page Interruption](./m6-cooperative-page-interruption.md)
 - [M6 Replay Retry Transition Store](./m6-replay-retry-transition-store.md)
+- [M6 Replay Dead-letter Admission](./m6-replay-dead-letter-admission.md)
 - [M6 Replay Job Leases](./m6-replay-job-leases.md)
 - [M6 Bounded Multi-page Replay Runner](./m6-bounded-multipage-runner.md)
 - [M6 Replay Runtime Host Composition](./m6-replay-runtime-composition.md)

--- a/crates/rustok-index/docs/m6-replay-dead-letter-admission.md
+++ b/crates/rustok-index/docs/m6-replay-dead-letter-admission.md
@@ -1,0 +1,87 @@
+# M6 replay dead-letter admission
+
+Status: `source_complete_operator_requeue_pending`
+
+## Purpose
+
+This slice makes terminal replay failure fail closed at schema-scope admission. A durable
+`failed` rebuild job becomes the ordinary replay admission barrier instead of being ignored while
+a later invocation creates a fresh job identity.
+
+`PostgresIndexReplayJobStore::acquire` retains its existing tenant/schema advisory lock and schema
+registration checks. It changes only the set and precedence of matching replay jobs.
+
+## Admission precedence
+
+The job query includes `pending`, `running`, `succeeded`, and `failed` rows and orders them by
+state authority before creation time:
+
+1. a retained `succeeded` row proves the scope is already complete;
+2. an existing `running` row remains authoritative active work;
+3. an existing `pending` row remains authoritative delayed or immediately claimable work;
+4. only when no successful or active work exists does the newest `failed` row block admission.
+
+Expired `running` work and eligible `pending` work preserve their existing reclaim path. A delayed
+retry produced by `PostgresIndexReplayRetryStore` remains `Busy` until
+`available_at <= CURRENT_TIMESTAMP`; an older failed row cannot bypass that active retry state.
+
+When the failed row is authoritative, acquisition returns
+`IndexReplayJobError::DeadLettered` with only:
+
+- the existing job UUID;
+- the durable attempt count;
+- the optional bounded and validated `last_error_code`.
+
+The SELECT does not load `last_error_details`. Source/database/transport causes, tenant or request
+values, mutation data, SQL, and stack text are not available through the admission error.
+
+## Identity and retry boundary
+
+A blocked scope inserts no new `index_jobs` row, changes no checkpoint, resets no attempt budget,
+and does not mutate the failed job. The existing failed row remains the durable operator decision
+point.
+
+This contract complements the merged retry transition store:
+
+- retryable work below the limit may move the same job from `running` to delayed `pending`;
+- permanent or exhausted work may move the same job from `running` to `failed`;
+- once `failed` is authoritative, ordinary acquisition cannot bypass it with a new job UUID.
+
+The current replay runner can also terminalize a page failure through its existing failure path.
+Dead-letter admission applies to either producer of a valid failed replay job; it does not claim
+that runner failure classification is already wired into the retry store.
+
+## Ownership boundaries
+
+This slice does not add or claim:
+
+- operator dead-letter listing or detail inspection;
+- authorized requeue or a failed-to-pending transition;
+- actor, reason, approval, or audit evidence for requeue;
+- retry-budget reset or retry-epoch semantics;
+- host scheduling of eligible pending jobs;
+- replay-runner integration with `PostgresIndexReplayRetryStore`;
+- graceful scheduler shutdown or fleet coordination;
+- retained PostgreSQL failure, exhaustion, restart, concurrent admission, or requeue evidence;
+- migration, table-shape, source, cursor, mutation, checkpoint, or event-identity changes.
+
+A later requeue contract must authorize the exact tenant and schema scope, identify the blocked
+job, define attempt/epoch semantics, retain actor and reason audit data, and preserve concurrent
+admission fencing. This source slice deliberately provides none of those mutation capabilities.
+
+The canonical implementation-plan item `Add bounded retry/backoff, dead-letter state, and global
+scheduling ownership` remains open.
+
+## Source evidence
+
+Focused source coverage retains:
+
+- one terminal failed job blocks a second ordinary acquisition;
+- the returned error exposes only job UUID, attempt count, and bounded error code;
+- private `last_error_details` are not returned;
+- no second rebuild job row is created for the blocked scope;
+- existing success, busy, reclaim, checkpoint, schema, source, and stored-request invariants remain
+  in the same fixture suite.
+
+Formatting, Cargo checks/tests, JavaScript verifiers, live PostgreSQL scenarios, workflows, and CI
+are maintainer-run and were not executed by the implementation agent.

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_job.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_job.rs
@@ -130,6 +130,14 @@ pub enum IndexReplayJobError {
     SchemaNotRegistered(SchemaRef),
     #[error("Index replay schema is retired: {0}")]
     SchemaRetired(SchemaRef),
+    #[error(
+        "Index replay scope is blocked by failed job {job_id} after attempt {attempt_count}"
+    )]
+    DeadLettered {
+        job_id: Uuid,
+        attempt_count: u32,
+        error_code: Option<String>,
+    },
     #[error("stored Index replay job is invalid: {0}")]
     InvalidStoredJob(String),
     #[error("Index replay completion checkpoint is missing")]
@@ -299,6 +307,13 @@ impl PostgresIndexReplayJobStore {
                     claimable = Some(stored);
                     break;
                 }
+                "failed" => {
+                    return Err(IndexReplayJobError::DeadLettered {
+                        job_id: stored.job_id,
+                        attempt_count: stored.attempt_count,
+                        error_code: stored.last_error_code,
+                    });
+                }
                 state => {
                     return Err(IndexReplayJobError::InvalidStoredJob(format!(
                         "unexpected active state {state}"
@@ -379,6 +394,7 @@ struct StoredJob {
     source_name: String,
     attempt_count: u32,
     claimable: bool,
+    last_error_code: Option<String>,
 }
 
 fn stored_job(row: &QueryResult, backend: DbBackend) -> Result<StoredJob, IndexReplayJobError> {
@@ -414,12 +430,23 @@ fn stored_job(row: &QueryResult, backend: DbBackend) -> Result<StoredJob, IndexR
     let attempt_count = u32::try_from(attempt_count).map_err(|_| {
         IndexReplayJobError::InvalidStoredJob("attempt count is outside the u32 range".to_owned())
     })?;
+    let last_error_code: Option<String> = row
+        .try_get("", "last_error_code")
+        .map_err(storage_error)?;
+    if let Some(code) = &last_error_code {
+        validate_error_code(code).map_err(|_| {
+            IndexReplayJobError::InvalidStoredJob(
+                "last_error_code is outside the replay error contract".to_owned(),
+            )
+        })?;
+    }
     Ok(StoredJob {
         job_id: stored_uuid(row, "job_id", backend)?,
         state: row.try_get("", "state").map_err(storage_error)?,
         source_name,
         attempt_count,
         claimable: row.try_get("", "claimable").map_err(storage_error)?,
+        last_error_code,
     })
 }
 
@@ -694,7 +721,7 @@ fn select_replay_jobs_sql(backend: DbBackend) -> String {
         _ => unreachable!("unsupported database backend was validated"),
     };
     format!(
-        "SELECT job_id, state, request, {attempt_count} AS attempt_count_value, {claimable} AS claimable FROM index_jobs WHERE tenant_id = {prefix}1 AND module_name = {prefix}2 AND entity_name = {prefix}3 AND schema_version = {prefix}4 AND kind = 'rebuild' AND scope_kind = 'schema' AND state IN ('pending', 'running', 'succeeded') ORDER BY CASE state WHEN 'succeeded' THEN 0 WHEN 'running' THEN 1 ELSE 2 END, created_at DESC"
+        "SELECT job_id, state, request, last_error_code, {attempt_count} AS attempt_count_value, {claimable} AS claimable FROM index_jobs WHERE tenant_id = {prefix}1 AND module_name = {prefix}2 AND entity_name = {prefix}3 AND schema_version = {prefix}4 AND kind = 'rebuild' AND scope_kind = 'schema' AND state IN ('pending', 'running', 'succeeded', 'failed') ORDER BY CASE state WHEN 'succeeded' THEN 0 WHEN 'running' THEN 1 WHEN 'pending' THEN 2 ELSE 3 END, created_at DESC"
     )
 }
 

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_job_tests.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_job_tests.rs
@@ -225,18 +225,41 @@ async fn expired_replay_job_is_reclaimed_and_old_checkpoint_writer_is_fenced() {
 }
 
 #[tokio::test]
-async fn failed_terminal_replay_job_allows_a_new_job_identity() {
+async fn failed_terminal_replay_job_blocks_scope_without_raw_details() {
     let fixture = Fixture::new("active").await;
     let first = fixture.acquire("worker-a").await;
     fixture
         .jobs
-        .fail(&first, "index.replay_source_failed", json!({"retryable": false}))
+        .fail(
+            &first,
+            "index.replay_source_failed",
+            json!({"retryable": false, "private": "must-not-be-returned"}),
+        )
         .await
         .unwrap();
 
-    let second = fixture.acquire("worker-b").await;
-    assert_ne!(second.job_id(), first.job_id());
-    assert_eq!(second.attempt_count(), 1);
+    assert_eq!(
+        fixture.jobs.acquire(&fixture.request("worker-b")).await,
+        Err(IndexReplayJobError::DeadLettered {
+            job_id: first.job_id(),
+            attempt_count: 1,
+            error_code: Some("index.replay_source_failed".to_owned()),
+        })
+    );
+
+    let count: i64 = fixture
+        .db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT COUNT(*) AS job_count FROM index_jobs WHERE tenant_id = ?1 AND kind = 'rebuild'",
+            vec![TENANT.to_owned().into()],
+        ))
+        .await
+        .unwrap()
+        .unwrap()
+        .try_get("", "job_count")
+        .unwrap();
+    assert_eq!(count, 1);
 }
 
 #[tokio::test]

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -25,6 +25,7 @@ const scripts = [
   'verify-index-replay-dry-run.mjs',
   'verify-index-replay-page-interruption.mjs',
   'verify-index-replay-retry-store.mjs',
+  'verify-index-replay-dead-letter-admission.mjs',
   'verify-index-product-source.mjs',
   'verify-index-product-variant-source.mjs',
   'verify-index-product-graph-source.mjs',

--- a/scripts/verify/verify-index-replay-dead-letter-admission.mjs
+++ b/scripts/verify/verify-index-replay-dead-letter-admission.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-replay-dead-letter-admission] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const jobPath =
+  'crates/rustok-index/src/infrastructure/postgres/source_replay_job.rs';
+const jobs = requireMarkers(jobPath, [
+  'DeadLettered {',
+  'job_id: Uuid,',
+  'attempt_count: u32,',
+  'error_code: Option<String>,',
+  '"failed" => {',
+  'error_code: stored.last_error_code,',
+  'last_error_code: Option<String>,',
+  'last_error_code is outside the replay error contract',
+]);
+
+const selectStart = jobs.indexOf('fn select_replay_jobs_sql(');
+const selectEnd = jobs.indexOf('\nfn insert_job_sql(', selectStart);
+if (selectStart < 0 || selectEnd <= selectStart) {
+  fail(`${jobPath} must retain one bounded replay-job selection function`);
+}
+const select = jobs.slice(selectStart, selectEnd);
+for (const marker of [
+  'SELECT job_id, state, request, last_error_code',
+  "state IN ('pending', 'running', 'succeeded', 'failed')",
+  "WHEN 'succeeded' THEN 0 WHEN 'running' THEN 1 WHEN 'pending' THEN 2 ELSE 3",
+  'created_at DESC',
+]) {
+  if (!select.includes(marker)) fail(`${jobPath} replay-job selection is missing ${marker}`);
+}
+if (select.includes('last_error_details')) {
+  fail(`${jobPath} dead-letter admission must not select last_error_details`);
+}
+
+const succeededOrder = select.indexOf("WHEN 'succeeded' THEN 0");
+const runningOrder = select.indexOf("WHEN 'running' THEN 1");
+const pendingOrder = select.indexOf("WHEN 'pending' THEN 2");
+const failedOrder = select.indexOf('ELSE 3');
+if (
+  succeededOrder < 0
+  || runningOrder <= succeededOrder
+  || pendingOrder <= runningOrder
+  || failedOrder <= pendingOrder
+) {
+  fail(`${jobPath} must preserve succeeded/running/pending/failed admission precedence`);
+}
+
+const deadLetterStart = jobs.indexOf('"failed" => {');
+const deadLetterEnd = jobs.indexOf('state => {', deadLetterStart);
+if (deadLetterStart < 0 || deadLetterEnd <= deadLetterStart) {
+  fail(`${jobPath} dead-letter match block is missing`);
+}
+const deadLetterBlock = jobs.slice(deadLetterStart, deadLetterEnd);
+for (const forbidden of [
+  'last_error_details',
+  'error_details',
+  'INSERT INTO index_jobs',
+  'Storage(',
+]) {
+  if (deadLetterBlock.includes(forbidden)) {
+    fail(`${jobPath} dead-letter admission contains forbidden marker ${forbidden}`);
+  }
+}
+if (jobs.includes("UPDATE index_jobs SET state = 'pending'")) {
+  fail(`${jobPath} must not implement an unauthorized failed-to-pending requeue transition`);
+}
+
+const testsPath =
+  'crates/rustok-index/src/infrastructure/postgres/source_replay_job_tests.rs';
+requireMarkers(testsPath, [
+  'failed_terminal_replay_job_blocks_scope_without_raw_details',
+  'Err(IndexReplayJobError::DeadLettered {',
+  'error_code: Some("index.replay_source_failed".to_owned()),',
+  '"private": "must-not-be-returned"',
+  'SELECT COUNT(*) AS job_count FROM index_jobs',
+  'assert_eq!(count, 1);',
+  'replay_job_excludes_other_workers_and_requires_complete_checkpoint',
+  'expired_replay_job_is_reclaimed_and_old_checkpoint_writer_is_fenced',
+]);
+
+requireMarkers(
+  'crates/rustok-index/src/infrastructure/postgres/source_replay_retry.rs',
+  [
+    'pub struct PostgresIndexReplayRetryStore',
+    'IndexReplayRetryDisposition::TerminalPermanent',
+    'IndexReplayRetryDisposition::TerminalExhausted',
+    "state = 'failed'",
+  ],
+);
+
+const runnerPath =
+  'crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs';
+const runner = requireMarkers(runnerPath, [
+  'match finish_failure(&self.db, &lease, details).await?',
+]);
+for (const premature of [
+  'PostgresIndexReplayRetryStore',
+  'IndexReplayRetryFailure',
+  '.record_failure(',
+]) {
+  if (runner.includes(premature)) {
+    fail(`${runnerPath} prematurely claims retry-store wiring through ${premature}`);
+  }
+}
+
+requireMarkers('crates/rustok-index/docs/m6-replay-dead-letter-admission.md', [
+  'Status: `source_complete_operator_requeue_pending`',
+  '`failed` rebuild job becomes the ordinary replay admission barrier',
+  '`IndexReplayJobError::DeadLettered`',
+  'The SELECT does not load `last_error_details`',
+  'ordinary acquisition cannot bypass it with a new job UUID',
+  'authorized requeue or a failed-to-pending transition',
+  'canonical implementation-plan item',
+  'maintainer-run',
+]);
+requireMarkers('crates/rustok-index/docs/README.md', [
+  '[M6 Replay Dead-letter Admission](./m6-replay-dead-letter-admission.md)',
+]);
+requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
+  '- [ ] Add bounded retry/backoff, dead-letter state, and global scheduling ownership.',
+]);
+requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
+  "'verify-index-replay-dead-letter-admission.mjs'",
+]);
+
+console.log('[verify-index-replay-dead-letter-admission] OK');


### PR DESCRIPTION
## Summary

- rebuild the M6 replay dead-letter admission slice directly on current `main@db9087a9a3ce29a0b8437c08f4ad67fcc6abf237`;
- preserve the reviewed failed-scope admission implementation and focused fixture change from stale draft #2817;
- include terminal `failed` rebuild jobs when resolving one tenant/schema replay scope;
- preserve deterministic authority: retained `succeeded`, then `running`, then `pending`, then the newest `failed` row;
- return typed `IndexReplayJobError::DeadLettered` instead of silently creating another job UUID;
- expose only the existing job UUID, durable attempt count, and optional validated `last_error_code`;
- never select or return `last_error_details` through admission;
- preserve retry-store delayed `pending` semantics and existing reclaim behavior;
- register current documentation and fail-closed verification in the Index aggregate contract.

## Fresh-main reconstruction

The two pre-existing Rust files remained byte-identical on current `main` to the source base used by stale #2817:

- `source_replay_job.rs`: `67cde726db9a7082cb0ee96b6f3260dac645cb3a`;
- `source_replay_job_tests.rs`: `166a4841328c2c4520891148b01d05debe49e117`.

The replacement preserves the reviewed final Rust blobs while actualizing documentation and verification against the merged retry transition store from #2894. The branch was rebuilt again after unrelated Blog commit #2897 advanced `main`.

The final branch contains one clean commit, is one commit ahead and zero behind `main`, and changes six expected files.

## Admission semantics

The acquisition transaction retains the tenant/schema advisory lock and existing schema checks. Matching jobs are ordered by state authority before creation time:

1. `succeeded` returns `AlreadyComplete`;
2. `running` retains busy or expired-lease reclaim behavior;
3. `pending` retains delayed-busy or eligible-claim behavior;
4. only when no successful or active work exists does the newest `failed` row return `DeadLettered`.

This means a retry scheduled by `PostgresIndexReplayRetryStore` remains authoritative while delayed. An older failed row cannot bypass a pending retry, and an authoritative failed row cannot be bypassed with a fresh ordinary job UUID.

## Bounded dead-letter error

`DeadLettered` carries only:

- `job_id`;
- `attempt_count`;
- optional validated `last_error_code`.

The selection query does not load `last_error_details`. The admission path has no access to raw dependency, database, SQL, transport, tenant, request, mutation, or stack data.

## Verification improvements

The refreshed verifier checks:

- exact succeeded/running/pending/failed ordering;
- `last_error_code` selection and validation;
- absence of `last_error_details` from the job selection function;
- absence of an unauthorized failed-to-pending requeue transition;
- one-row preservation in the focused failed-scope fixture;
- coexistence with the merged retry transition store;
- continued absence of premature runner-to-retry-store wiring;
- the still-open canonical retry/dead-letter/scheduling roadmap item.

## Scope boundaries

This PR does not add or claim:

- operator dead-letter listing or raw-detail inspection;
- authorized requeue;
- actor/reason/approval audit records;
- retry-budget reset or retry-epoch semantics;
- host scheduling or graceful task shutdown;
- `PostgresIndexReplayRunner` integration with the retry transition store;
- retained PostgreSQL failure, exhaustion, restart, concurrency, or requeue evidence;
- migration or table-shape changes.

The canonical retry/backoff, dead-letter state, and global scheduling roadmap item remains open.

## Validation

Not run per maintainer instruction:

- formatting;
- Cargo checks, tests, or Clippy;
- JavaScript verifiers;
- SQLite/PostgreSQL scenarios;
- workflows and CI.

Suggested maintainer commands:

```bash
cargo test -p rustok-index source_replay_job -- --nocapture
cargo check -p rustok-index --all-targets
node scripts/verify/verify-index-replay-dead-letter-admission.mjs
node scripts/verify/verify-index-query-contract.mjs
```

## History

Supersedes stale #2817 and historical #2648 without carrying stale branch history.