### PR TITLE
feat(index): publish guarded reconciliation runtime

### DIFF
--- a/apps/server/docs/index-reconciliation-operator-runtime.md
+++ b/apps/server/docs/index-reconciliation-operator-runtime.md
@@ -1,0 +1,82 @@
+# Index reconciliation operator runtime
+
+Status: `source_complete_transport_and_recovery_work_pending`.
+
+## Purpose
+
+The server publishes one guarded `IndexReconciliationOperatorRuntime` after the existing Index replay composition has frozen the complete immutable source and schema registries.
+
+The boundary wraps the canonical `PostgresIndexReconciliationRunner` already exported by `rustok-index`. It performs no reconciliation database I/O during composition, starts no task, and does not create another source catalog.
+
+## Request-bound authority
+
+Every operation requires an `IndexReconciliationOperatorContext` containing one non-nil tenant UUID and actor UUID.
+
+Authorization reads the current request-scoped RBAC snapshot through `permissions_for(tenant_id, actor_id)` and requires effective `Permission::MODULES_MANAGE`.
+
+The boundary rejects:
+
+- a nil tenant or actor identity;
+- a missing request-bound permission snapshot;
+- a snapshot without `modules:manage`;
+- a run request whose tenant differs from the authorized context tenant.
+
+Run authorization compares the requested tenant before delegating to the inner reconciliation runner. The focused source regression uses a database without Index migrations and still receives `TenantMismatch`, retaining the pre-database denial boundary.
+
+Cancellation accepts only a job UUID from the caller. The tenant passed to the reconciliation runner is always derived from the authorized context; there is no separate caller-selected tenant parameter.
+
+## Published surface
+
+The capability exposes only:
+
+- bounded `run(context, IndexReconciliationRunRequest)`;
+- tenant-scoped `request_cancel(context, job_id)`.
+
+It does not expose:
+
+- the database connection;
+- source or schema registries;
+- mutable source catalogs;
+- scheduler, polling, takeover, or task ownership;
+- worker-spawn handles;
+- direct `index_jobs` SQL;
+- dead-letter inspection or requeue;
+- GraphQL, HTTP, CLI, MCP, or admin transport.
+
+## Composition
+
+The existing server replay composition remains the single source-freezing point:
+
+1. selected PostgreSQL source factories are materialized;
+2. the complete immutable `SharedIndexSourceRegistry` is inserted;
+3. the guarded replay capability is materialized from the shared registries;
+4. the guarded reconciliation operator is constructed from the same source registry, shared schema registry, and host database.
+
+An absent source registry publishes no false reconciliation capability. A source registry without `SharedIndexSchemaRegistry` fails closed. Duplicate guarded reconciliation materialization also fails closed.
+
+The replay retry transition store and replay failed-scope admission merged separately. They do not alter this reconciliation operator and are not reused as reconciliation scheduling or dead-letter APIs.
+
+## Preserved engine behavior
+
+This server slice changes no reconciliation runner, migration, SQL, lease, cursor, mutation, diagnostic, cancellation, or terminal-state contract.
+
+It preserves the existing bounded page/pass execution, heartbeat, yield, cancellation, attempt fencing, inbox deduplication, source-version monotonicity, and bounded machine-readable failure diagnostics.
+
+## Explicitly open
+
+- reconciliation failed-scope admission;
+- bounded reconciliation dead-letter inspection;
+- authorized requeue with actor/reason audit and retry-epoch semantics;
+- automatic scheduling or takeover discovery;
+- graceful task shutdown and fleet coordination;
+- source/index digest comparison and orphan diagnosis;
+- targeted, full, or shadow repair modes;
+- locale or partition checkpoint dimensions;
+- retained PostgreSQL authorization, cancellation, restart, concurrency, and recovery evidence;
+- command and transport publication.
+
+The canonical M6 drift-diagnosis and targeted-repair roadmap item remains open. Runtime publication alone does not establish complete drift repair or production readiness.
+
+## Validation ownership
+
+Formatting, Cargo checks/tests, JavaScript verifiers, database scenarios, workflows, and CI are maintainer-run and were not executed by the implementation agent.

--- a/apps/server/src/services/index_reconciliation_operator.rs
+++ b/apps/server/src/services/index_reconciliation_operator.rs
@@ -1,0 +1,417 @@
+use std::fmt;
+
+use rustok_api::{Permission, has_effective_permission};
+use rustok_core::ModuleRuntimeExtensions;
+use sea_orm::DatabaseConnection;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::error::{Error as ServerError, Result};
+use crate::services::rbac_request_scope::permissions_for;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndexReconciliationOperatorContext {
+    tenant_id: Uuid,
+    actor_id: Uuid,
+}
+
+impl IndexReconciliationOperatorContext {
+    pub fn new(
+        tenant_id: Uuid,
+        actor_id: Uuid,
+    ) -> std::result::Result<Self, IndexReconciliationOperatorError> {
+        if tenant_id.is_nil() || actor_id.is_nil() {
+            return Err(IndexReconciliationOperatorError::InvalidContext);
+        }
+        Ok(Self {
+            tenant_id,
+            actor_id,
+        })
+    }
+
+    pub fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub fn actor_id(&self) -> Uuid {
+        self.actor_id
+    }
+
+    fn authorize_for(
+        &self,
+        requested_tenant: Uuid,
+    ) -> std::result::Result<(), IndexReconciliationOperatorError> {
+        if requested_tenant != self.tenant_id {
+            return Err(IndexReconciliationOperatorError::TenantMismatch);
+        }
+        let permissions = permissions_for(&self.tenant_id, &self.actor_id)
+            .ok_or(IndexReconciliationOperatorError::MissingRequestAuthority)?;
+        if !has_effective_permission(&permissions, &Permission::MODULES_MANAGE) {
+            return Err(IndexReconciliationOperatorError::Forbidden);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum IndexReconciliationOperatorError {
+    #[error("Index reconciliation operator tenant and actor must not be nil")]
+    InvalidContext,
+    #[error("Index reconciliation request tenant does not match the authorized operator tenant")]
+    TenantMismatch,
+    #[error("Index reconciliation operations require a request-bound effective permission snapshot")]
+    MissingRequestAuthority,
+    #[error("modules:manage is required for Index reconciliation operations")]
+    Forbidden,
+    #[error(transparent)]
+    Reconciliation(#[from] rustok_index::IndexReconciliationRunError),
+}
+
+/// Server-owned guarded operator boundary over the canonical PostgreSQL Index reconciliation runner.
+///
+/// Transport adapters must provide an exact request-bound tenant/actor context. The boundary
+/// accepts only `modules:manage`, rejects cross-tenant requests before database access, and exposes
+/// no connection, source registry, scheduler, task handle, or worker-spawn capability.
+#[derive(Clone)]
+pub struct IndexReconciliationOperatorRuntime {
+    inner: rustok_index::PostgresIndexReconciliationRunner,
+}
+
+impl IndexReconciliationOperatorRuntime {
+    fn new(inner: rustok_index::PostgresIndexReconciliationRunner) -> Self {
+        Self { inner }
+    }
+
+    pub async fn run(
+        &self,
+        context: IndexReconciliationOperatorContext,
+        request: rustok_index::IndexReconciliationRunRequest,
+    ) -> std::result::Result<
+        rustok_index::IndexReconciliationRunOutcome,
+        IndexReconciliationOperatorError,
+    > {
+        context.authorize_for(request.tenant_id())?;
+        self.inner.run(request).await.map_err(Into::into)
+    }
+
+    pub async fn request_cancel(
+        &self,
+        context: IndexReconciliationOperatorContext,
+        job_id: Uuid,
+    ) -> std::result::Result<
+        rustok_index::IndexReconciliationCancelOutcome,
+        IndexReconciliationOperatorError,
+    > {
+        context.authorize_for(context.tenant_id())?;
+        self.inner
+            .request_cancel(context.tenant_id(), job_id)
+            .await
+            .map_err(Into::into)
+    }
+}
+
+impl fmt::Debug for IndexReconciliationOperatorRuntime {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("IndexReconciliationOperatorRuntime")
+            .finish_non_exhaustive()
+    }
+}
+
+/// Publishes the guarded reconciliation operator after replay composition has frozen the complete
+/// immutable source and schema registries.
+///
+/// This function performs no database I/O and starts no task. An absent source registry remains an
+/// optional capability; a source registry without its shared schema registry fails closed.
+pub(super) fn materialize_index_reconciliation_operator(
+    extensions: &mut ModuleRuntimeExtensions,
+    db: DatabaseConnection,
+) -> Result<()> {
+    if extensions.contains::<IndexReconciliationOperatorRuntime>() {
+        return Err(ServerError::Message(
+            "guarded Index reconciliation runtime is already materialized".to_string(),
+        ));
+    }
+
+    let Some(sources) = extensions
+        .get::<rustok_index::SharedIndexSourceRegistry>()
+        .cloned()
+    else {
+        return Ok(());
+    };
+    let schemas = extensions
+        .get::<rustok_index::SharedIndexSchemaRegistry>()
+        .cloned()
+        .ok_or_else(|| {
+            ServerError::Message(
+                "Index reconciliation source registry exists without the shared schema registry"
+                    .to_string(),
+            )
+        })?;
+
+    extensions.insert(IndexReconciliationOperatorRuntime::new(
+        rustok_index::PostgresIndexReconciliationRunner::new(db, sources, schemas.shared()),
+    ));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use rustok_api::Permission;
+    use rustok_core::{ModuleRuntimeExtensions, UserRole};
+    use rustok_index::{
+        EntityName, FieldCardinality, FieldName, IndexField, IndexReconciliationRunRequest,
+        IndexSchema, IndexSource, IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest,
+        IndexSourcePage, IndexSourceScanRequest, IndexValueType, LocaleMode, ModuleName, SchemaRef,
+        SchemaVersion, SharedIndexSchemaRegistry, SharedIndexSourceRegistry,
+        materialize_index_schema_registry, materialize_index_source_registry,
+        register_index_schema_source, register_index_source,
+    };
+    use sea_orm::Database;
+    use uuid::Uuid;
+
+    use super::{
+        IndexReconciliationOperatorContext, IndexReconciliationOperatorError,
+        IndexReconciliationOperatorRuntime, materialize_index_reconciliation_operator,
+    };
+    use crate::services::rbac_request_scope::{RbacRequestScope, with_rbac_request_scope};
+
+    struct NoopSource;
+
+    #[async_trait]
+    impl IndexSource for NoopSource {
+        async fn scan(
+            &self,
+            request: IndexSourceScanRequest,
+        ) -> std::result::Result<IndexSourcePage, IndexSourceFailure> {
+            Ok(IndexSourcePage::new(&request, Vec::new(), None)
+                .expect("empty final reconciliation page should be valid"))
+        }
+
+        async fn load(
+            &self,
+            request: IndexSourceLoadRequest,
+        ) -> std::result::Result<IndexSourceLoadBatch, IndexSourceFailure> {
+            Ok(IndexSourceLoadBatch::new(&request, Vec::new())
+                .expect("empty targeted load should be valid"))
+        }
+    }
+
+    fn schema() -> IndexSchema {
+        IndexSchema {
+            reference: SchemaRef {
+                module: ModuleName::new("server-reconciliation").unwrap(),
+                entity: EntityName::new("item").unwrap(),
+                version: SchemaVersion::INITIAL,
+            },
+            locale_mode: LocaleMode::None,
+            fields: vec![IndexField {
+                name: FieldName::new("id").unwrap(),
+                value_type: IndexValueType::Uuid,
+                cardinality: FieldCardinality::One,
+                nullable: false,
+                selectable: true,
+                filterable: true,
+                sortable: true,
+            }],
+            links: Vec::new(),
+        }
+    }
+
+    fn catalogs() -> ModuleRuntimeExtensions {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        let schema = schema();
+        register_index_schema_source(&mut extensions, "server_reconciliation", schema.clone())
+            .expect("schema source should register");
+        register_index_source(
+            &mut extensions,
+            "server_reconciliation",
+            "server-reconciliation-primary",
+            [schema.reference],
+            NoopSource,
+        )
+        .expect("reconciliation source should register");
+        extensions
+    }
+
+    fn complete_registries() -> ModuleRuntimeExtensions {
+        let mut extensions = catalogs();
+        let schemas = materialize_index_schema_registry(&extensions)
+            .expect("schema registry materialization")
+            .expect("schema registry");
+        let sources = materialize_index_source_registry(&extensions)
+            .expect("source registry materialization")
+            .expect("source registry");
+        extensions.insert(schemas);
+        extensions.insert(sources);
+        extensions
+    }
+
+    #[tokio::test]
+    async fn missing_sources_do_not_publish_false_reconciliation_capability() {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+
+        materialize_index_reconciliation_operator(&mut extensions, db)
+            .expect("missing sources should remain optional");
+        assert!(!extensions.contains::<IndexReconciliationOperatorRuntime>());
+    }
+
+    #[tokio::test]
+    async fn source_registry_without_shared_schema_registry_fails_closed() {
+        let mut extensions = catalogs();
+        let sources = materialize_index_source_registry(&extensions)
+            .expect("source registry materialization")
+            .expect("source registry");
+        extensions.insert(sources);
+        assert!(!extensions.contains::<SharedIndexSchemaRegistry>());
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+
+        let error = materialize_index_reconciliation_operator(&mut extensions, db)
+            .expect_err("missing shared schema registry must fail");
+        assert!(error.to_string().contains("without the shared schema registry"));
+    }
+
+    #[tokio::test]
+    async fn complete_registries_publish_guarded_runtime_to_host_context() {
+        let mut extensions = complete_registries();
+        assert!(extensions.contains::<SharedIndexSchemaRegistry>());
+        assert!(extensions.contains::<SharedIndexSourceRegistry>());
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+
+        materialize_index_reconciliation_operator(&mut extensions, db.clone())
+            .expect("guarded reconciliation runtime should compose");
+        assert!(extensions.contains::<IndexReconciliationOperatorRuntime>());
+
+        let host = extensions.apply_to_host_runtime(rustok_api::HostRuntimeContext::new(db));
+        assert!(
+            host.shared_get::<IndexReconciliationOperatorRuntime>()
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn duplicate_guarded_reconciliation_materialization_fails_closed() {
+        let mut extensions = complete_registries();
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+        materialize_index_reconciliation_operator(&mut extensions, db.clone())
+            .expect("first materialization");
+
+        let error = materialize_index_reconciliation_operator(&mut extensions, db)
+            .expect_err("duplicate materialization must fail");
+        assert!(error.to_string().contains("already materialized"));
+    }
+
+    #[tokio::test]
+    async fn operator_authorization_requires_exact_tenant_actor_and_modules_manage() {
+        let tenant_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let context = IndexReconciliationOperatorContext::new(tenant_id, actor_id).unwrap();
+        assert!(matches!(
+            context.authorize_for(tenant_id),
+            Err(IndexReconciliationOperatorError::MissingRequestAuthority)
+        ));
+
+        with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_READ],
+                UserRole::Admin,
+            )),
+            async {
+                assert!(matches!(
+                    context.authorize_for(tenant_id),
+                    Err(IndexReconciliationOperatorError::Forbidden)
+                ));
+            },
+        )
+        .await;
+
+        with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_MANAGE],
+                UserRole::Admin,
+            )),
+            async {
+                assert!(context.authorize_for(tenant_id).is_ok());
+                assert!(matches!(
+                    context.authorize_for(Uuid::new_v4()),
+                    Err(IndexReconciliationOperatorError::TenantMismatch)
+                ));
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn cross_tenant_run_is_denied_before_database_access() {
+        let mut extensions = complete_registries();
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database without Index migrations");
+        materialize_index_reconciliation_operator(&mut extensions, db)
+            .expect("runtime materialization");
+        let runtime = extensions
+            .get::<IndexReconciliationOperatorRuntime>()
+            .cloned()
+            .expect("guarded runtime");
+        let authorized_tenant = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let request = IndexReconciliationRunRequest::new(
+            Uuid::new_v4(),
+            schema().reference,
+            "server-reconciliation-worker",
+            1,
+            1,
+            1,
+            1,
+            Duration::from_secs(30),
+        )
+        .expect("valid bounded request");
+
+        let error = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                authorized_tenant,
+                actor_id,
+                vec![Permission::MODULES_MANAGE],
+                UserRole::Admin,
+            )),
+            runtime.run(
+                IndexReconciliationOperatorContext::new(authorized_tenant, actor_id).unwrap(),
+                request,
+            ),
+        )
+        .await
+        .expect_err("cross-tenant run must fail before touching the database");
+        assert!(matches!(
+            error,
+            IndexReconciliationOperatorError::TenantMismatch
+        ));
+    }
+
+    #[test]
+    fn operator_context_rejects_nil_identity() {
+        assert!(matches!(
+            IndexReconciliationOperatorContext::new(Uuid::nil(), Uuid::new_v4()),
+            Err(IndexReconciliationOperatorError::InvalidContext)
+        ));
+        assert!(matches!(
+            IndexReconciliationOperatorContext::new(Uuid::new_v4(), Uuid::nil()),
+            Err(IndexReconciliationOperatorError::InvalidContext)
+        ));
+    }
+}

--- a/apps/server/src/services/index_replay_runtime_composition.rs
+++ b/apps/server/src/services/index_replay_runtime_composition.rs
@@ -1,3 +1,11 @@
+#[path = "index_reconciliation_operator.rs"]
+mod reconciliation_operator;
+
+pub use reconciliation_operator::{
+    IndexReconciliationOperatorContext, IndexReconciliationOperatorError,
+    IndexReconciliationOperatorRuntime,
+};
+
 use std::fmt;
 
 use rustok_api::{Permission, has_effective_permission};
@@ -110,8 +118,8 @@ impl fmt::Debug for IndexReplayOperatorRuntime {
 ///
 /// This function performs no database I/O and starts no worker. It invokes selected source
 /// factories only to construct adapters, freezes the complete source catalog, binds the immutable
-/// schema/source registries to the host database, and publishes the guarded bounded operator
-/// capability through `ModuleRuntimeExtensions`.
+/// schema/source registries to the host database, and publishes the guarded bounded replay and
+/// reconciliation operator capabilities through `ModuleRuntimeExtensions`.
 pub(crate) fn materialize_index_replay_runtime(
     extensions: &mut ModuleRuntimeExtensions,
     db: DatabaseConnection,
@@ -138,12 +146,14 @@ pub(crate) fn materialize_index_replay_runtime(
         extensions.insert(sources);
     }
 
-    let runtime = rustok_index::materialize_postgres_index_replay_runtime(extensions, db).map_err(
-        |error| ServerError::Message(format!("Index replay runtime composition failed: {error}")),
-    )?;
+    let runtime = rustok_index::materialize_postgres_index_replay_runtime(extensions, db.clone())
+        .map_err(|error| {
+            ServerError::Message(format!("Index replay runtime composition failed: {error}"))
+        })?;
     if let Some(runtime) = runtime {
         extensions.insert(IndexReplayOperatorRuntime::new(runtime));
     }
+    reconciliation_operator::materialize_index_reconciliation_operator(extensions, db)?;
     Ok(())
 }
 

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -22,6 +22,7 @@ const scripts = [
   'verify-index-replay-multipage-runner.mjs',
   'verify-index-source-reconciliation.mjs',
   'verify-index-replay-runtime-composition.mjs',
+  'verify-index-server-reconciliation-guard.mjs',
   'verify-index-replay-dry-run.mjs',
   'verify-index-replay-page-interruption.mjs',
   'verify-index-replay-retry-store.mjs',

--- a/scripts/verify/verify-index-server-reconciliation-guard.mjs
+++ b/scripts/verify/verify-index-server-reconciliation-guard.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-server-reconciliation-guard] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const compositionPath =
+  'apps/server/src/services/index_replay_runtime_composition.rs';
+const operatorPath =
+  'apps/server/src/services/index_reconciliation_operator.rs';
+const docsPath =
+  'apps/server/docs/index-reconciliation-operator-runtime.md';
+
+const composition = requireMarkers(compositionPath, [
+  '#[path = "index_reconciliation_operator.rs"]',
+  'mod reconciliation_operator;',
+  'pub use reconciliation_operator::{',
+  'IndexReconciliationOperatorRuntime,',
+  'materialize_postgres_index_replay_runtime(extensions, db.clone())',
+  'reconciliation_operator::materialize_index_reconciliation_operator(extensions, db)?;',
+]);
+const replayMaterialization = composition.indexOf(
+  'materialize_postgres_index_replay_runtime(extensions, db.clone())',
+);
+const reconciliationMaterialization = composition.indexOf(
+  'reconciliation_operator::materialize_index_reconciliation_operator(extensions, db)?;',
+);
+if (
+  replayMaterialization < 0
+  || reconciliationMaterialization <= replayMaterialization
+) {
+  fail(`${compositionPath} must publish reconciliation only after replay source freezing`);
+}
+
+const operator = requireMarkers(operatorPath, [
+  'pub struct IndexReconciliationOperatorContext',
+  'tenant_id.is_nil() || actor_id.is_nil()',
+  'IndexReconciliationOperatorError::TenantMismatch',
+  'permissions_for(&self.tenant_id, &self.actor_id)',
+  'Permission::MODULES_MANAGE',
+  'pub struct IndexReconciliationOperatorRuntime',
+  'inner: rustok_index::PostgresIndexReconciliationRunner,',
+  'context.authorize_for(request.tenant_id())?;',
+  'self.inner.run(request).await.map_err(Into::into)',
+  'context.authorize_for(context.tenant_id())?;',
+  '.request_cancel(context.tenant_id(), job_id)',
+  'extensions.get::<rustok_index::SharedIndexSourceRegistry>()',
+  'extensions.get::<rustok_index::SharedIndexSchemaRegistry>()',
+  'PostgresIndexReconciliationRunner::new(db, sources, schemas.shared())',
+  'missing_sources_do_not_publish_false_reconciliation_capability',
+  'source_registry_without_shared_schema_registry_fails_closed',
+  'complete_registries_publish_guarded_runtime_to_host_context',
+  'duplicate_guarded_reconciliation_materialization_fails_closed',
+  'operator_authorization_requires_exact_tenant_actor_and_modules_manage',
+  'cross_tenant_run_is_denied_before_database_access',
+  'operator_context_rejects_nil_identity',
+]);
+
+const authorizeStart = operator.indexOf('    fn authorize_for(');
+const authorizeEnd = operator.indexOf('\n}\n\n#[derive(Debug, Error)]', authorizeStart);
+if (authorizeStart < 0 || authorizeEnd <= authorizeStart) {
+  fail(`${operatorPath} must retain one bounded authorize_for implementation`);
+}
+const authorize = operator.slice(authorizeStart, authorizeEnd);
+const tenantCheck = authorize.indexOf('if requested_tenant != self.tenant_id');
+const permissionLookup = authorize.indexOf(
+  'permissions_for(&self.tenant_id, &self.actor_id)',
+);
+const manageCheck = authorize.indexOf('Permission::MODULES_MANAGE');
+if (
+  tenantCheck < 0
+  || permissionLookup <= tenantCheck
+  || manageCheck <= permissionLookup
+) {
+  fail(`${operatorPath} must reject tenant mismatch before request-bound permission evaluation`);
+}
+
+const runStart = operator.indexOf('    pub async fn run(');
+const cancelStart = operator.indexOf('    pub async fn request_cancel(', runStart);
+const runtimeEnd = operator.indexOf('\n}\n\nimpl fmt::Debug', cancelStart);
+if (runStart < 0 || cancelStart <= runStart || runtimeEnd <= cancelStart) {
+  fail(`${operatorPath} guarded run/cancel surface is malformed`);
+}
+const run = operator.slice(runStart, cancelStart);
+const cancel = operator.slice(cancelStart, runtimeEnd);
+if (
+  run.indexOf('context.authorize_for(request.tenant_id())?;') < 0
+  || run.indexOf('self.inner.run(request)')
+    <= run.indexOf('context.authorize_for(request.tenant_id())?;')
+) {
+  fail(`${operatorPath} run must authorize the request tenant before runner delegation`);
+}
+if (cancel.includes('tenant_id: Uuid')) {
+  fail(`${operatorPath} cancellation must not accept a separate caller-supplied tenant`);
+}
+if (
+  cancel.indexOf('context.authorize_for(context.tenant_id())?;') < 0
+  || cancel.indexOf('.request_cancel(context.tenant_id(), job_id)')
+    <= cancel.indexOf('context.authorize_for(context.tenant_id())?;')
+) {
+  fail(`${operatorPath} cancellation must authorize and derive tenant scope from context`);
+}
+
+const productionOperator = operator.split('\n#[cfg(test)]')[0];
+for (const forbidden of [
+  'tokio::spawn',
+  'spawn_blocking',
+  'SELECT ',
+  'INSERT ',
+  'UPDATE ',
+  'DELETE ',
+  'Router::new',
+  'route(',
+  'async_graphql',
+  'PostgresIndexReconciliationDeadLetterInspector',
+  'inspect_dead_letter',
+  'requeue',
+  "state = 'pending'",
+]) {
+  if (productionOperator.includes(forbidden)) {
+    fail(`${operatorPath} production boundary contains forbidden transport/SQL/recovery marker ${forbidden}`);
+  }
+}
+
+requireMarkers(docsPath, [
+  'Status: `source_complete_transport_and_recovery_work_pending`.',
+  'requires effective `Permission::MODULES_MANAGE`',
+  'retaining the pre-database denial boundary',
+  'there is no separate caller-selected tenant parameter',
+  'single source-freezing point',
+  'publishes no false reconciliation capability',
+  'reconciliation failed-scope admission',
+  'bounded reconciliation dead-letter inspection',
+  'authorized requeue with actor/reason audit',
+  'canonical M6 drift-diagnosis and targeted-repair roadmap item remains open',
+  'maintainer-run',
+]);
+requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
+  '- [ ] Add drift diagnosis, targeted repair commands, and admitted repair evidence.',
+  '- [ ] Add bounded retry/backoff, dead-letter state, and global scheduling ownership.',
+]);
+requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
+  "'verify-index-server-reconciliation-guard.mjs'",
+  "'verify-index-replay-retry-store.mjs'",
+  "'verify-index-replay-dead-letter-admission.mjs'",
+]);
+
+console.log('[verify-index-server-reconciliation-guard] OK');


### PR DESCRIPTION
## Summary

- rebuild the guarded M6 reconciliation operator directly on current `main@e557f06aec0dd55f1b15e5319c5557a8b302a35c`;
- preserve the reviewed server operator implementation from stale #2825;
- publish `IndexReconciliationOperatorRuntime` only after replay composition has frozen the complete immutable source and schema registries;
- require a non-nil request-bound tenant/actor context and effective `modules:manage`;
- reject cross-tenant run requests before inner runner or database delegation;
- derive cancellation tenant scope only from the authorized context while accepting only a job UUID from the caller;
- publish no false capability when no source registry exists;
- fail closed when sources exist without the shared schema registry or guarded materialization is repeated;
- expose only bounded run and cancellation operations over `PostgresIndexReconciliationRunner`;
- actualize documentation and register a strengthened fail-closed verifier in the aggregate Index contract.

## Fresh-main audit

The only pre-existing production file touched by stale #2825 remained byte-identical on current `main`:

- `apps/server/src/services/index_replay_runtime_composition.rs`: `0b35247ed02f537cabc5996e7cb392c2198645e0`.

The canonical reconciliation runner remains exported with the required `run`, `request_cancel`, source registry, schema registry, and request tenant contracts. Replay retry transition storage and replay failed-scope admission merged independently and have no changed-file overlap with this server composition slice.

The branch was rebuilt as `main` advanced through temporary marker commits; the final head is directly based on `e557f06aec0dd55f1b15e5319c5557a8b302a35c`, contains one clean commit, is one commit ahead and zero behind `main`, and changes five expected files.

## Authorization boundary

`IndexReconciliationOperatorContext` requires exact non-nil tenant and actor UUIDs.

For every operation the boundary reads the current request-scoped RBAC snapshot through `permissions_for(tenant_id, actor_id)` and requires effective `Permission::MODULES_MANAGE`.

Run authorization checks `request.tenant_id()` against the context tenant before `self.inner.run(request)`. The focused source regression uses a database without Index migrations and still receives `TenantMismatch`, retaining the pre-database denial boundary.

Cancellation has no separate tenant parameter. It authorizes the context and calls `request_cancel(context.tenant_id(), job_id)`.

## Composition

The existing replay composition remains the single source-freezing point:

1. PostgreSQL source factories are materialized;
2. the immutable source registry is inserted;
3. the guarded replay runtime is materialized;
4. the guarded reconciliation operator is built from the same source registry, shared schema registry, and host database.

Composition performs no reconciliation SQL and starts no task.

## Guarded surface

The runtime exposes only:

- `run(context, IndexReconciliationRunRequest)`;
- `request_cancel(context, job_id)`.

It does not expose the database connection, registries, mutable catalogs, task handles, worker spawning, direct SQL, transports, scheduling, dead-letter inspection, or requeue.

## Verification improvements

The refreshed verifier checks:

- replay materialization precedes reconciliation publication;
- tenant mismatch is tested before request-bound permission lookup;
- `modules:manage` is required after exact tenant/actor lookup;
- run authorization precedes runner delegation;
- cancellation accepts no caller-selected tenant and derives scope from context;
- exact immutable registry composition and fail-closed source/schema handling;
- absence of direct SQL, transports, task spawning, inspection, requeue, or failed-to-pending mutation;
- continued presence of the open canonical drift-repair and scheduling roadmap items;
- aggregate Index verifier registration alongside the merged replay retry/dead-letter guards.

## Scope boundaries

This PR does not add or claim:

- reconciliation failed-scope admission;
- reconciliation dead-letter inspection or authorized requeue;
- actor/reason audit or retry-epoch reset;
- automatic scheduling, polling, takeover discovery, or graceful task shutdown;
- source/index digest comparison, orphan diagnosis, or targeted/full/shadow repair modes;
- locale/partition checkpoint dimensions;
- GraphQL, HTTP, CLI, MCP, or admin transport;
- runner, migration, SQL, lease, cursor, mutation, diagnostic, cancellation, or terminal-state changes;
- retained PostgreSQL authorization, cancellation, restart, concurrency, or recovery evidence.

The canonical M6 drift-diagnosis and targeted-repair roadmap item remains open.

## Validation

Not run per maintainer instruction:

- formatting;
- Cargo checks, tests, or Clippy;
- JavaScript verifiers;
- database scenarios;
- workflows and CI.

Suggested maintainer commands:

```bash
cargo test -p rustok-server index_reconciliation_operator -- --nocapture
cargo check -p rustok-server --all-targets
node scripts/verify/verify-index-server-reconciliation-guard.mjs
node scripts/verify/verify-index-query-contract.mjs
```

## History

Supersedes stale #2825 and historical #2693 without carrying stale branch history. Historical #2656 remains the intentionally rejected unguarded runtime direction.