### PR TITLE
feat(forum): resolve merged topic identities

### DIFF
--- a/crates/rustok-forum/README.md
+++ b/crates/rustok-forum/README.md
@@ -36,7 +36,10 @@
 - Depends on `rustok-taxonomy` for the shared scope-aware term dictionary behind
   forum topic tags.
 - Category slugs are translation-local, while topic slugs remain stable thread
-  labels; current public forum lookup stays ID-based.
+  labels; current public forum lookup stays ID-based. A selected merged-source ID
+  resolves through the immutable `forum_topic_merge_operations` chain to the
+  terminal retained topic. HTTP 3xx responses and slug aliases are not part of
+  the current contract.
 - Shares SEO target ownership with `rustok-seo`: the shared SEO runtime now resolves
   `forum_category` and `forum_topic`, while owner-side SEO authoring stays embedded
   in `rustok-forum-admin`; public SEO for channel-restricted topics is resolved only
@@ -100,4 +103,5 @@ into README files, issues, or additional planning documents.
 
 - [Module docs](./docs/README.md)
 - [Canonical implementation plan](./docs/implementation-plan.md)
+- [Canonical merged-topic resolution](./docs/forum-21i-topic-canonical-resolution.md)
 - [Platform docs index](../../docs/index.md)

--- a/crates/rustok-forum/contracts/forum-topic-canonical-resolution.json
+++ b/crates/rustok-forum/contracts/forum-topic-canonical-resolution.json
@@ -39,7 +39,7 @@
     "variant": "TopicCanonicalResolutionConflict",
     "stable_code": "FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT",
     "http_status": 500,
-    "retryable": true,
+    "retryable": false,
     "public_message_contains_storage_details": false
   },
   "compatibility": {

--- a/crates/rustok-forum/contracts/forum-topic-canonical-resolution.json
+++ b/crates/rustok-forum/contracts/forum-topic-canonical-resolution.json
@@ -12,6 +12,7 @@
     "requested_identity_preserved_in_evidence": true,
     "canonical_identity_is_terminal_target": true,
     "maximum_hops": 32,
+    "each_hop_topic_and_edges_share_one_statement_snapshot": true,
     "duplicate_source_edges_fail_closed": true,
     "cycles_fail_closed": true,
     "soft_deleted_terminal_targets_fail_closed": true,

--- a/crates/rustok-forum/contracts/forum-topic-canonical-resolution.json
+++ b/crates/rustok-forum/contracts/forum-topic-canonical-resolution.json
@@ -1,0 +1,72 @@
+{
+  "contract": "forum_topic_canonical_resolution_v1",
+  "task": "FORUM-21I",
+  "parent_task": "FORUM-21",
+  "extends": "FORUM-21B",
+  "status": "source_ready_maintainer_execution_pending",
+  "canonical_plan_status": "planned",
+  "owner_service": "TopicService",
+  "source_of_truth": "forum_topic_merge_operations",
+  "migration": "m20260803_000017_add_forum_topic_canonical_resolution",
+  "resolution": {
+    "requested_identity_preserved_in_evidence": true,
+    "canonical_identity_is_terminal_target": true,
+    "maximum_hops": 32,
+    "duplicate_source_edges_fail_closed": true,
+    "cycles_fail_closed": true,
+    "soft_deleted_terminal_targets_fail_closed": true,
+    "missing_unmerged_topics_return_topic_not_found": true,
+    "merge_operation_ids_are_returned_in_chain_order": true
+  },
+  "database_guards": {
+    "one_source_edge_per_tenant_topic": true,
+    "receipt_table_remains_append_only": true,
+    "source_must_be_non_deleted_archived_locked_zero_reply_tombstone_on_insert": true,
+    "target_must_be_non_deleted_non_archived_and_same_category_on_insert": true,
+    "postgres_and_sqlite": true,
+    "parallel_alias_table_added": false
+  },
+  "selected_read_cutover": {
+    "topic_service_get": "returns_the_canonical_target_representation",
+    "topic_service_storefront_get": "evaluates_category_and_topic_visibility_on_the_canonical_target",
+    "graphql_forum_topic": "inherits_canonical_target_resolution_from_TopicService",
+    "seo_topic_load_and_route": "inherit_canonical_target_resolution_from_TopicService",
+    "rest_get_topic": "returns_the_canonical_target_representation_with_the_target_id",
+    "list_reads_changed": false,
+    "mutation_target_resolution_changed": false
+  },
+  "error": {
+    "variant": "TopicCanonicalResolutionConflict",
+    "stable_code": "FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT",
+    "http_status": 500,
+    "retryable": true,
+    "public_message_contains_storage_details": false
+  },
+  "compatibility": {
+    "topic_response_shape_changed": false,
+    "graphql_schema_changed": false,
+    "rest_route_shape_changed": false,
+    "seo_target_contract_changed": false,
+    "merge_input_result_receipt_or_event_changed": false,
+    "shared_rustok_events_contract_changed": false
+  },
+  "test": "crates/rustok-forum/tests/topic_canonical_resolution_sqlite.rs",
+  "documentation": "crates/rustok-forum/docs/forum-21i-topic-canonical-resolution.md",
+  "cumulative_contract": "crates/rustok-forum/contracts/forum-topic-merge-owner.json",
+  "cumulative_documentation": "crates/rustok-forum/docs/forum-21b-topic-merge-owner.md",
+  "verifier": "scripts/verify/verify-forum-topic-canonical-resolution.mjs",
+  "maintainer_commands": [
+    "node scripts/verify/verify-forum-topic-merge-owner.mjs",
+    "node scripts/verify/verify-forum-topic-canonical-resolution.mjs",
+    "cargo test -p rustok-forum --test topic_canonical_resolution_sqlite -- --nocapture"
+  ],
+  "non_claims": [
+    "no verifier test formatter Cargo command SQLite PostgreSQL workflow or CI execution is claimed",
+    "no HTTP 3xx Location redirect is added",
+    "no slug alias or slug route is added",
+    "no public merge transport is added",
+    "no mutation command follows merged source identities",
+    "no cross-category merge split fork or reply-range workflow is added",
+    "FORUM-21 is not promoted from planned"
+  ]
+}

--- a/crates/rustok-forum/contracts/forum-topic-merge-owner.json
+++ b/crates/rustok-forum/contracts/forum-topic-merge-owner.json
@@ -49,6 +49,7 @@
     "source_of_truth": "forum_topic_merge_operations",
     "one_edge_per_source_topic": true,
     "parallel_alias_store": false,
+    "each_hop_topic_and_edges_share_one_statement_snapshot": true,
     "terminal_target_must_be_non_deleted": true,
     "duplicate_edge_or_cycle": "fail_with_FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT",
     "selected_topic_reads_return_terminal_target": true,
@@ -76,6 +77,7 @@
     "category retained topic_count and published reply_count remain unchanged because the archived source tombstone is not soft-deleted",
     "the immutable receipt is also the only canonical source-to-target resolution edge",
     "one tenant source topic can own only one immutable canonical edge while a retained target may later become the source of the next edge",
+    "each canonical hop reads topic existence and up to two outgoing edges under one statement snapshot",
     "source target and category projection invalidations are published in that order",
     "semantic event receipt owner state reply remap solution policy counters and invalidations commit in one transaction",
     "exact replay creates no additional event receipt invalidation reply movement solution mutation counter change or canonical edge"

--- a/crates/rustok-forum/contracts/forum-topic-merge-owner.json
+++ b/crates/rustok-forum/contracts/forum-topic-merge-owner.json
@@ -1,7 +1,7 @@
 {
   "contract": "forum_topic_merge_owner_v1",
   "task": "FORUM-21B",
-  "latest_policy_slice": "FORUM-21H",
+  "latest_policy_slice": "FORUM-21I",
   "parent_task": "FORUM-21",
   "status": "source_ready_maintainer_execution_pending",
   "canonical_plan_status": "planned",
@@ -12,7 +12,8 @@
   "result": "ForumTopicMergeResult",
   "migrations": [
     "m20260801_000010_add_forum_topic_merge_operations",
-    "m20260803_000016_add_forum_topic_merge_solution_policy"
+    "m20260803_000016_add_forum_topic_merge_solution_policy",
+    "m20260803_000017_add_forum_topic_canonical_resolution"
   ],
   "receipt_table": "forum_topic_merge_operations",
   "semantic_event": {
@@ -32,7 +33,8 @@
     "one_source_topic_per_operation": true,
     "one_target_topic_per_operation": true,
     "same_category_only": true,
-    "accepted_solutions_per_topic_max": 1
+    "accepted_solutions_per_topic_max": 1,
+    "canonical_resolution_hops_max": 32
   },
   "solution_policy": {
     "neither_topic_has_solution": "merge_without_solution_mutation",
@@ -42,6 +44,17 @@
     "source_solution_reply_must_be_approved": true,
     "target_solution_reply_must_be_approved": true,
     "solution_count_delta_during_merge": 0
+  },
+  "canonical_resolution": {
+    "source_of_truth": "forum_topic_merge_operations",
+    "one_edge_per_source_topic": true,
+    "parallel_alias_store": false,
+    "terminal_target_must_be_non_deleted": true,
+    "duplicate_edge_or_cycle": "fail_with_FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT",
+    "selected_topic_reads_return_terminal_target": true,
+    "storefront_visibility_uses_terminal_target": true,
+    "graphql_and_seo_inherit_TopicService_resolution": true,
+    "rest_returns_target_representation_without_HTTP_3xx": true
   },
   "transactional_invariants": [
     "the operation requires non-nil tenant operation source target and human actor identities",
@@ -61,9 +74,11 @@
     "reply-owned bodies revisions votes mentions quotes attachments parent identities and a transferred accepted-solution identity remain attached through unchanged reply identifiers",
     "the target published reply counter becomes the checked sum and the source becomes archived locked with zero replies",
     "category retained topic_count and published reply_count remain unchanged because the archived source tombstone is not soft-deleted",
+    "the immutable receipt is also the only canonical source-to-target resolution edge",
+    "one tenant source topic can own only one immutable canonical edge while a retained target may later become the source of the next edge",
     "source target and category projection invalidations are published in that order",
     "semantic event receipt owner state reply remap solution policy counters and invalidations commit in one transaction",
-    "exact replay creates no additional event receipt invalidation reply movement solution mutation or counter change"
+    "exact replay creates no additional event receipt invalidation reply movement solution mutation counter change or canonical edge"
   ],
   "database_guards": [
     "tenant-composite foreign keys bind the receipt to source topic target topic category and human actor",
@@ -72,12 +87,14 @@
     "event_id equals operation_id",
     "reason counts and position offset are bounded",
     "receipt updates and deletes are rejected for PostgreSQL and SQLite",
+    "one unique receipt edge exists per tenant source topic",
+    "a new canonical edge requires an archived locked non-deleted zero-reply source tombstone and a non-deleted non-archived target in the receipt category",
     "forum solution insert update and delete serialize through deterministic topic rows and solution scope 31",
     "forum solution insert or owner-key update requires an active non-deleted topic and an approved non-deleted reply owned by that topic"
   ],
   "retained_identity": {
-    "target_topic_id": "unchanged",
-    "source_topic_id": "archived_locked_redirect_ready",
+    "target_topic_id": "unchanged_and_canonical_for_selected_reads",
+    "source_topic_id": "archived_locked_tombstone_resolving_through_receipt_edge",
     "reply_ids": "unchanged",
     "accepted_solution_reply_id": "unchanged_when_source_only_transfers",
     "accepted_solution_marker_metadata": "unchanged_when_transferred_or_target_only",
@@ -86,20 +103,27 @@
     "category_topic_count": "unchanged_until_source_soft_delete"
   },
   "test": "crates/rustok-forum/tests/topic_merge_sqlite.rs",
+  "canonical_resolution_test": "crates/rustok-forum/tests/topic_canonical_resolution_sqlite.rs",
   "verifier": "scripts/verify/verify-forum-topic-merge-owner.mjs",
+  "canonical_resolution_verifier": "scripts/verify/verify-forum-topic-canonical-resolution.mjs",
   "documentation": "crates/rustok-forum/docs/forum-21b-topic-merge-owner.md",
   "solution_policy_contract": "crates/rustok-forum/contracts/forum-topic-merge-solution-policy.json",
   "solution_policy_documentation": "crates/rustok-forum/docs/forum-21h-topic-merge-solution-policy.md",
+  "canonical_resolution_contract": "crates/rustok-forum/contracts/forum-topic-canonical-resolution.json",
+  "canonical_resolution_documentation": "crates/rustok-forum/docs/forum-21i-topic-canonical-resolution.md",
   "maintainer_commands": [
     "node scripts/verify/verify-forum-topic-merge-owner.mjs",
     "node scripts/verify/verify-forum-topic-merge-solution-policy.mjs",
-    "cargo test -p rustok-forum --test topic_merge_sqlite -- --nocapture"
+    "node scripts/verify/verify-forum-topic-canonical-resolution.mjs",
+    "cargo test -p rustok-forum --test topic_merge_sqlite -- --nocapture",
+    "cargo test -p rustok-forum --test topic_canonical_resolution_sqlite -- --nocapture"
   ],
   "non_claims": [
     "this source-ready slice does not claim that verifiers SQLite tests Cargo checks formatting workflows or CI ran",
     "this source-ready slice does not promote the canonical FORUM-21 status before maintainer execution and remaining workflows",
     "this slice does not add public REST GraphQL native admin or storefront merge transport",
-    "this slice does not add canonical URL aliases redirects or route tombstones",
+    "this slice does not add an HTTP 3xx Location redirect slug alias or slug route tombstone",
+    "this slice does not make mutation commands follow merged source identities",
     "this slice does not support cross-category merge split fork or reply-range operations",
     "dedicated bounded slices own subscriptions read state tags topic votes and topic-local audience reconciliation",
     "this slice does not choose a winner when source and target both have accepted solutions",

--- a/crates/rustok-forum/docs/README.md
+++ b/crates/rustok-forum/docs/README.md
@@ -16,6 +16,7 @@ documents describe stable contracts only and must not duplicate its backlog.
 - publish the canonical forum runtime contract for categories, topics, replies and moderation;
 - keep forum-owned transport surfaces, Q&A capabilities and UI packages inside the module;
 - keep REST handlers on a narrow `ForumHttpRuntime` with explicit DB/event bus handles; `controllers::axum_router` builds it from `HostRuntimeContext` and generated host composition mounts it without a framework adapter;
+- resolve selected merged-source topic IDs through the immutable merge receipt ledger to one retained canonical target while keeping the public lookup contract ID-based;
 - evolve the forum as a taxonomy-aware and channel-aware domain with an explicit observability surface.
 
 ## Scope
@@ -50,13 +51,16 @@ documents describe stable contracts only and must not duplicate its backlog.
 - `cargo xtask module test forum`
 - `npm run verify:page-builder:consumer:forum` for fast FBA consumer guardrail without compilation, including Wave 1 smoke/SLO/trace anti-drift checks;
 - targeted tests for topic/reply lifecycle, moderation, votes, subscriptions,
-  visibility contracts, and request-scoped profile author-summary filtering;
+  visibility contracts, merged-topic canonical resolution, and request-scoped
+  profile author-summary filtering;
 - `npm run verify:channel:proof-points` for no-compile capture of forum channel-aware read-path/SEO markers
 
 ## Related documents
 
 - [README crate](../README.md)
 - [Canonical implementation plan](./implementation-plan.md)
+- [FORUM-21B merge owner](./forum-21b-topic-merge-owner.md)
+- [FORUM-21I canonical merged-topic resolution](./forum-21i-topic-canonical-resolution.md)
 - [Admin UI package](../admin/README.md)
 - [Storefront UI package](../storefront/README.md)
 - [Event flow contract](../../../docs/architecture/event-flow-contract.md)

--- a/crates/rustok-forum/docs/forum-21b-topic-merge-owner.md
+++ b/crates/rustok-forum/docs/forum-21b-topic-merge-owner.md
@@ -7,7 +7,9 @@
 FORUM-21B adds one bounded owner workflow under the planned `FORUM-21`
 umbrella: merge one active source topic into one retained active target topic
 when both topics belong to the same active category. FORUM-21H extends that
-same transaction with the accepted-solution policy described below.
+same transaction with the accepted-solution policy. FORUM-21I uses the
+immutable receipt as the canonical selected-read edge from an archived source
+tombstone to the retained target.
 
 The cumulative machine contract is:
 
@@ -15,14 +17,16 @@ The cumulative machine contract is:
 crates/rustok-forum/contracts/forum-topic-merge-owner.json
 ```
 
-The FORUM-21H policy handoff is:
+Focused policy handoffs are:
 
 ```text
 crates/rustok-forum/contracts/forum-topic-merge-solution-policy.json
 crates/rustok-forum/docs/forum-21h-topic-merge-solution-policy.md
+crates/rustok-forum/contracts/forum-topic-canonical-resolution.json
+crates/rustok-forum/docs/forum-21i-topic-canonical-resolution.md
 ```
 
-The owner API remains:
+The merge owner API remains:
 
 ```rust
 ForumTopicMergeService::merge_topic(
@@ -60,9 +64,10 @@ target must differ.
 - the category retains both topic rows and therefore keeps its retained
   `topic_count`; its published `reply_count` also remains unchanged.
 
-Cross-category merge, canonical redirects, split, fork and reply-range workflows
-remain separate policies. Subscription, read-state, tag, vote and topic-local
-audience reconciliation are delivered by their dedicated FORUM-21 slices.
+Cross-category merge, HTTP redirects, slug aliases, split, fork and reply-range
+workflows remain separate policies. Subscription, read-state, tag, vote,
+topic-local audience and canonical selected-read resolution are delivered by
+their dedicated FORUM-21 slices.
 
 ## Idempotency
 
@@ -124,11 +129,11 @@ and invalidations.
 `m20260803_000016_add_forum_topic_merge_solution_policy` adds the shared
 per-topic solution scope. PostgreSQL locks the affected topic rows before
 advisory scope seed `31`; SQLite uses a durable topic-solution lock row under its
-write transaction. Ordinary mark, replace and clear writes pass through the same
-database trigger boundary, so they cannot race the merge between solution
-inspection and reply movement.
+write transaction. Ordinary mark, replace and clear writes take the same owner
+scope before current-marker reads and statistics deltas, while database triggers
+cover direct writers.
 
-PostgreSQL and SQLite also reject solution inserts or owner-key updates unless:
+PostgreSQL and SQLite reject solution inserts or owner-key updates unless:
 
 - the topic exists, is not deleted and is not archived;
 - the reply exists in that exact tenant and topic;
@@ -136,6 +141,28 @@ PostgreSQL and SQLite also reject solution inserts or owner-key updates unless:
 
 Delete remains available to clear a solution and to perform the source-only
 transfer sequence inside the merge transaction.
+
+## Canonical selected reads
+
+`m20260803_000017_add_forum_topic_canonical_resolution` makes the append-only
+merge receipt the only source-to-target canonical edge. No alias table or
+parallel redirect registry is introduced.
+
+- `(tenant_id, source_topic_id)` is unique;
+- a new edge requires an archived, locked, non-deleted, zero-reply source
+  tombstone and a non-deleted, non-archived target in the receipt category;
+- a retained target may later become another merge source, forming a forward
+  chain;
+- selected reads follow at most 32 edges and reject duplicate, cyclic or
+  otherwise ambiguous history with
+  `FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT`;
+- the terminal target must remain non-deleted;
+- `TopicService`, GraphQL selected-topic lookup, storefront selected-topic
+  lookup and Forum SEO target loading all use the terminal target identity.
+
+REST remains ID-based and returns the canonical target representation with the
+target ID. HTTP 3xx responses, `Location` headers, slug aliases and route
+tombstones remain a later route-contract slice.
 
 ## Persistence and events
 
@@ -147,10 +174,9 @@ target topic, category and human actor. The semantic event remains:
 forum.topic.merged / schema version 1
 ```
 
-FORUM-21H does not change the shared event payload or receipt shape. The
-existing source-topic, target-topic and category projection invalidations already
-cover the solved-state change and remain the durable cross-consumer repair
-signal.
+FORUM-21H and FORUM-21I do not change the shared event payload or receipt row
+shape. The existing source-topic, target-topic and category projection
+invalidations remain the durable cross-consumer repair signal.
 
 ## Regression coverage
 
@@ -173,14 +199,23 @@ signal.
 - command drift and cross-category merge fail closed;
 - direct receipt update and deletion are rejected.
 
+`topic_canonical_resolution_sqlite` is source-ready to verify:
+
+- an `A -> B -> C` receipt chain resolves both archived source IDs to `C`;
+- traversal operation IDs remain ordered and direct target resolution has zero
+  hops;
+- selected and storefront reads hydrate `C`, not either source tombstone;
+- unknown IDs remain not found;
+- duplicate source edges and active-source receipt inserts are rejected.
+
 ## Remaining FORUM-21 work
 
-The canonical `FORUM-21` entry remains `planned`. FORUM-21A through FORUM-21H
+The canonical `FORUM-21` entry remains `planned`. FORUM-21A through FORUM-21I
 are bounded partial slices; remaining work includes:
 
 - maintainer execution and retained SQLite/PostgreSQL evidence;
-- public/admin transport composition and exact authorization context;
-- canonical aliases, redirects and route tombstones;
+- public/admin merge transport composition and exact authorization context;
+- HTTP redirects, slug aliases and route tombstones;
 - an explicit manager-selected resolution command for competing solutions;
 - cross-category merge and checked category ownership policy;
 - split, fork and reply-range workflows.
@@ -190,7 +225,9 @@ are bounded partial slices; remaining work includes:
 ```bash
 node scripts/verify/verify-forum-topic-merge-owner.mjs
 node scripts/verify/verify-forum-topic-merge-solution-policy.mjs
+node scripts/verify/verify-forum-topic-canonical-resolution.mjs
 cargo test -p rustok-forum --test topic_merge_sqlite -- --nocapture
+cargo test -p rustok-forum --test topic_canonical_resolution_sqlite -- --nocapture
 ```
 
 No command above was run by the implementation agent, per maintainer request.

--- a/crates/rustok-forum/docs/forum-21i-topic-canonical-resolution.md
+++ b/crates/rustok-forum/docs/forum-21i-topic-canonical-resolution.md
@@ -1,0 +1,143 @@
+# FORUM-21I canonical merged-topic resolution
+
+## Status
+
+`source_ready_maintainer_execution_pending`
+
+FORUM-21I adds one bounded read-side policy beneath the planned `FORUM-21`
+umbrella. A selected topic ID that previously became the archived source of a
+successful FORUM-21B merge now resolves through the immutable merge receipt
+ledger to the terminal retained topic.
+
+Machine contract:
+
+```text
+crates/rustok-forum/contracts/forum-topic-canonical-resolution.json
+```
+
+Cumulative merge contract:
+
+```text
+crates/rustok-forum/contracts/forum-topic-merge-owner.json
+```
+
+## One source of truth
+
+No alias table, compatibility registry or parallel redirect model is added.
+`forum_topic_merge_operations` already records the committed source and target
+inside the original merge transaction and is append-only. FORUM-21I makes that
+ledger the sole canonical source-to-target edge.
+
+Migration
+`m20260803_000017_add_forum_topic_canonical_resolution` adds:
+
+- one unique `(tenant_id, source_topic_id)` edge;
+- a PostgreSQL and SQLite insert guard requiring the source to be a non-deleted,
+  archived, locked, zero-reply tombstone;
+- a matching requirement that the target is non-deleted, non-archived and in the
+  receipt category.
+
+A retained target may later become the source of another merge. This forms a
+forward chain without allowing one source identity to branch to multiple
+canonical targets.
+
+## Bounded resolution
+
+`TopicService::resolve_canonical_topic` returns:
+
+- the requested topic ID;
+- the terminal canonical topic ID;
+- whether the request was redirected;
+- the bounded hop count;
+- immutable merge operation IDs in traversal order.
+
+The resolver follows at most 32 edges. Duplicate source edges, cycles, hop
+exhaustion or other ambiguous history fail closed with:
+
+```text
+FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT
+```
+
+The terminal topic must still exist in the tenant and must not be soft-deleted.
+An unknown unmerged ID returns the original `FORUM_TOPIC_NOT_FOUND` boundary.
+
+## Selected read cutover
+
+Canonical resolution is composed into the public topic owner facade before
+selected-topic hydration:
+
+- `TopicService::get` and `get_with_locale_fallback` return the terminal target
+  representation;
+- `get_with_canonical_resolution_and_locale_fallback` also returns traversal
+  evidence for transports that need the requested-versus-canonical distinction;
+- storefront selected-topic reads evaluate category and topic visibility against
+  the canonical target, never the archived source tombstone;
+- GraphQL `forumTopic` inherits the same target resolution because it already
+  uses `TopicService`;
+- Forum SEO target load and route resolution inherit the same target identity
+  through the same owner path.
+
+The returned `TopicResponse.id` is the terminal target ID. Response shapes,
+GraphQL fields, REST path parameters and SEO target contracts do not change.
+
+## REST boundary
+
+Forum public topic lookup remains ID-based. `GET /api/forum/topics/{id}` now
+returns the canonical target representation when `{id}` is a merged source.
+This slice deliberately does not emit an HTTP 3xx status or `Location` header.
+
+A later route-focused slice may add permanent HTTP redirects and slug aliases
+once the public URL contract is explicitly selected. FORUM-21I does not invent
+that route model inside the domain resolver.
+
+## Mutation boundary
+
+Only selected reads follow canonical merge history. Update, delete, vote,
+subscription, moderation and reply commands continue to require their exact
+current topic identity. This prevents a stale source ID from silently mutating a
+retained target without an explicit command-transport policy and authorization
+review.
+
+## Failure mapping
+
+Canonical history inconsistency is an internal integrity failure. REST maps
+`FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT` to a generic HTTP 500 response;
+public messages do not expose storage rows, SQL or traversal details. The error
+is marked retryable so operators can repair corrupted historical evidence before
+a caller retries.
+
+## Source-ready regression
+
+`crates/rustok-forum/tests/topic_canonical_resolution_sqlite.rs` is source-ready
+to verify:
+
+- a two-edge `A -> B -> C` chain resolves both archived source IDs to `C`;
+- traversal evidence retains operation IDs in chain order;
+- direct lookup of `C` has zero hops;
+- selected owner read returns the target ID and target content;
+- storefront visibility is evaluated for the target;
+- an unknown ID remains not found;
+- a second edge for the same source is rejected;
+- a direct receipt with an active source is rejected.
+
+## Remaining FORUM-21 work
+
+The canonical `FORUM-21` entry remains `planned`. FORUM-21A through FORUM-21I
+are bounded source-ready slices. Remaining work includes:
+
+- maintainer execution and retained SQLite/PostgreSQL evidence;
+- an explicit public HTTP redirect and slug/route tombstone contract;
+- public/admin merge transport composition;
+- manager-selected resolution when both topics have accepted solutions;
+- cross-category merge;
+- split, fork and reply-range workflows.
+
+## Maintainer verification
+
+```bash
+node scripts/verify/verify-forum-topic-merge-owner.mjs
+node scripts/verify/verify-forum-topic-canonical-resolution.mjs
+cargo test -p rustok-forum --test topic_canonical_resolution_sqlite -- --nocapture
+```
+
+No command above was run by the implementation agent, per maintainer request.

--- a/crates/rustok-forum/docs/forum-21i-topic-canonical-resolution.md
+++ b/crates/rustok-forum/docs/forum-21i-topic-canonical-resolution.md
@@ -58,6 +58,11 @@ exhaustion or other ambiguous history fail closed with:
 FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT
 ```
 
+Each hop uses one database statement that reads both non-deleted topic existence
+and at most two outgoing receipt edges under the same statement snapshot. A
+concurrent merge therefore linearizes either before that hop or after it; the
+resolver cannot combine a pre-commit edge result with post-commit topic state.
+
 The terminal topic must still exist in the tenant and must not be soft-deleted.
 An unknown unmerged ID returns the original `FORUM_TOPIC_NOT_FOUND` boundary.
 

--- a/crates/rustok-forum/docs/forum-21i-topic-canonical-resolution.md
+++ b/crates/rustok-forum/docs/forum-21i-topic-canonical-resolution.md
@@ -103,8 +103,8 @@ review.
 Canonical history inconsistency is an internal integrity failure. REST maps
 `FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT` to a generic HTTP 500 response;
 public messages do not expose storage rows, SQL or traversal details. The error
-is marked retryable so operators can repair corrupted historical evidence before
-a caller retries.
+is non-retryable because duplicate or cyclic immutable history requires an
+explicit operator repair rather than automatic request replay.
 
 ## Source-ready regression
 

--- a/crates/rustok-forum/src/controllers/mod.rs
+++ b/crates/rustok-forum/src/controllers/mod.rs
@@ -117,13 +117,14 @@ pub(crate) fn map_forum_error(error: crate::ForumError) -> HttpError {
                 "A required forum capability is temporarily unavailable",
             )
         }
-        ForumError::Database(_) | ForumError::Content(_) | ForumError::Internal(_) => {
-            HttpError::new(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                code,
-                "The forum operation could not be completed",
-            )
-        }
+        ForumError::Database(_)
+        | ForumError::Content(_)
+        | ForumError::Internal(_)
+        | ForumError::TopicCanonicalResolutionConflict(_) => HttpError::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            code,
+            "The forum operation could not be completed",
+        ),
         error => HttpError::bad_request(code, error.to_string()),
     }
 }

--- a/crates/rustok-forum/src/error.rs
+++ b/crates/rustok-forum/src/error.rs
@@ -204,10 +204,7 @@ impl ForumError {
     pub const fn is_retryable(&self) -> bool {
         match self {
             Self::CapabilityFailure { retryable, .. } => *retryable,
-            Self::Database(_)
-            | Self::Internal(_)
-            | Self::RelationRevisionConflict
-            | Self::TopicCanonicalResolutionConflict(_) => true,
+            Self::Database(_) | Self::Internal(_) | Self::RelationRevisionConflict => true,
             _ => false,
         }
     }

--- a/crates/rustok-forum/src/error.rs
+++ b/crates/rustok-forum/src/error.rs
@@ -73,6 +73,9 @@ pub enum ForumError {
     #[error("Forum topic merge accepted solutions require explicit resolution: {0}")]
     TopicMergeSolutionConflict(Uuid),
 
+    #[error("Forum topic canonical resolution is inconsistent: {0}")]
+    TopicCanonicalResolutionConflict(Uuid),
+
     #[error("Forum topic merge audience reconciliation conflicts with an existing command: {0}")]
     TopicMergeAudienceReconciliationConflict(Uuid),
 
@@ -160,6 +163,9 @@ impl ForumError {
             Self::TopicMoveOperationConflict(_) => "FORUM_TOPIC_MOVE_OPERATION_CONFLICT",
             Self::TopicMergeOperationConflict(_) => "FORUM_TOPIC_MERGE_OPERATION_CONFLICT",
             Self::TopicMergeSolutionConflict(_) => "FORUM_TOPIC_MERGE_SOLUTION_CONFLICT",
+            Self::TopicCanonicalResolutionConflict(_) => {
+                "FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT"
+            }
             Self::TopicMergeAudienceReconciliationConflict(_) => {
                 "FORUM_TOPIC_MERGE_AUDIENCE_RECONCILIATION_CONFLICT"
             }
@@ -198,7 +204,10 @@ impl ForumError {
     pub const fn is_retryable(&self) -> bool {
         match self {
             Self::CapabilityFailure { retryable, .. } => *retryable,
-            Self::Database(_) | Self::Internal(_) | Self::RelationRevisionConflict => true,
+            Self::Database(_)
+            | Self::Internal(_)
+            | Self::RelationRevisionConflict
+            | Self::TopicCanonicalResolutionConflict(_) => true,
             _ => false,
         }
     }

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -92,11 +92,10 @@ pub use services::{
     ForumStorefrontReadStateService, ForumStorefrontUnreadTopic, ForumStorefrontUnreadTopicPage,
     ForumTopicAudienceListService, ForumTopicAudiencePage, ForumTopicAudiencePolicy,
     ForumTopicAudiencePolicyService, ForumTopicAudienceReadService, ForumTopicAudienceViewer,
-    ForumTopicAudienceVisibilityService, ForumTopicCreateAudienceAuthorization,
-    ForumTopicCreateAudienceAuthorizationService, ForumTopicCreatesWindowFactPort,
-    ForumTopicMergeAudienceReconciliationResult,
-    ForumTopicMergeAudienceReconciliationService,
-    ForumTopicMergeReadStateReconciliationResult,
+    ForumTopicAudienceVisibilityService, ForumTopicCanonicalResolution,
+    ForumTopicCreateAudienceAuthorization, ForumTopicCreateAudienceAuthorizationService,
+    ForumTopicCreatesWindowFactPort, ForumTopicMergeAudienceReconciliationResult,
+    ForumTopicMergeAudienceReconciliationService, ForumTopicMergeReadStateReconciliationResult,
     ForumTopicMergeReadStateReconciliationService, ForumTopicMergeResult,
     ForumTopicMergeService, ForumTopicMergeSubscriptionReconciliationResult,
     ForumTopicMergeSubscriptionReconciliationService, ForumTopicMergeTagReconciliationResult,
@@ -110,7 +109,7 @@ pub use services::{
     ForumVisibilityScopedReadStateService, ForumWidgetContractService,
     MAX_FORUM_POSTING_POLICY_FACTS, MAX_FORUM_POSTING_UNAVAILABLE_REASON_CODE_LENGTH,
     MAX_FORUM_SEARCH_RESULT_ELIGIBILITY_CANDIDATES,
-    MAX_FORUM_TOPIC_MERGE_AUDIENCE_REASON_LEN,
+    MAX_FORUM_TOPIC_CANONICAL_REDIRECT_HOPS, MAX_FORUM_TOPIC_MERGE_AUDIENCE_REASON_LEN,
     MAX_FORUM_TOPIC_MERGE_READ_STATE_REASON_LEN, MAX_FORUM_TOPIC_MERGE_READ_STATES,
     MAX_FORUM_TOPIC_MERGE_REASON_LEN, MAX_FORUM_TOPIC_MERGE_REPLIES,
     MAX_FORUM_TOPIC_MERGE_SUBSCRIPTION_REASON_LEN, MAX_FORUM_TOPIC_MERGE_SUBSCRIPTIONS,
@@ -237,6 +236,3 @@ impl MigrationSource for ForumModule {
         migrations::migration_dependencies()
     }
 }
-
-#[cfg(test)]
-mod contract_tests;

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -236,3 +236,6 @@ impl MigrationSource for ForumModule {
         migrations::migration_dependencies()
     }
 }
+
+#[cfg(test)]
+mod contract_tests;

--- a/crates/rustok-forum/src/migrations/m20260803_000017_add_forum_topic_canonical_resolution.rs
+++ b/crates/rustok-forum/src/migrations/m20260803_000017_add_forum_topic_canonical_resolution.rs
@@ -1,0 +1,123 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::DatabaseBackend;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DatabaseBackend::Postgres => execute(manager, POSTGRES_UP).await,
+            DatabaseBackend::Sqlite => execute(manager, SQLITE_UP).await,
+            backend => Err(DbErr::Custom(format!(
+                "rustok-forum topic canonical resolution migration does not support {backend:?}"
+            ))),
+        }
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DatabaseBackend::Postgres => execute(manager, POSTGRES_DOWN).await,
+            DatabaseBackend::Sqlite => execute(manager, SQLITE_DOWN).await,
+            backend => Err(DbErr::Custom(format!(
+                "rustok-forum topic canonical resolution migration does not support {backend:?}"
+            ))),
+        }
+    }
+}
+
+async fn execute(manager: &SchemaManager<'_>, sql: &str) -> Result<(), DbErr> {
+    manager
+        .get_connection()
+        .execute_unprepared(sql)
+        .await
+        .map(|_| ())
+}
+
+const POSTGRES_UP: &str = r#"
+CREATE UNIQUE INDEX IF NOT EXISTS uq_forum_topic_merge_operations_source
+    ON forum_topic_merge_operations (tenant_id, source_topic_id);
+
+CREATE OR REPLACE FUNCTION forum_validate_topic_merge_redirect_edge()
+RETURNS trigger AS $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM forum_topics source
+        WHERE source.tenant_id = NEW.tenant_id
+          AND source.id = NEW.source_topic_id
+          AND source.category_id = NEW.category_id
+          AND source.deleted_at IS NULL
+          AND source.status::text = 'archived'
+          AND source.is_locked = TRUE
+          AND source.reply_count = 0
+    ) THEN
+        RAISE EXCEPTION 'forum topic merge redirect source is not an archived tombstone';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM forum_topics target
+        WHERE target.tenant_id = NEW.tenant_id
+          AND target.id = NEW.target_topic_id
+          AND target.category_id = NEW.category_id
+          AND target.deleted_at IS NULL
+          AND target.status::text <> 'archived'
+    ) THEN
+        RAISE EXCEPTION 'forum topic merge redirect target is not active';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS forum_05_topic_merge_redirect_edge
+    ON forum_topic_merge_operations;
+CREATE TRIGGER forum_05_topic_merge_redirect_edge
+BEFORE INSERT ON forum_topic_merge_operations
+FOR EACH ROW EXECUTE FUNCTION forum_validate_topic_merge_redirect_edge();
+"#;
+
+const POSTGRES_DOWN: &str = r#"
+DROP TRIGGER IF EXISTS forum_05_topic_merge_redirect_edge
+    ON forum_topic_merge_operations;
+DROP FUNCTION IF EXISTS forum_validate_topic_merge_redirect_edge();
+DROP INDEX IF EXISTS uq_forum_topic_merge_operations_source;
+"#;
+
+const SQLITE_UP: &str = r#"
+CREATE UNIQUE INDEX IF NOT EXISTS uq_forum_topic_merge_operations_source
+    ON forum_topic_merge_operations (tenant_id, source_topic_id);
+
+CREATE TRIGGER IF NOT EXISTS forum_05_topic_merge_redirect_edge
+BEFORE INSERT ON forum_topic_merge_operations
+FOR EACH ROW
+WHEN NOT EXISTS (
+    SELECT 1
+    FROM forum_topics source
+    WHERE source.tenant_id = NEW.tenant_id
+      AND source.id = NEW.source_topic_id
+      AND source.category_id = NEW.category_id
+      AND source.deleted_at IS NULL
+      AND source.status = 'archived'
+      AND source.is_locked = TRUE
+      AND source.reply_count = 0
+) OR NOT EXISTS (
+    SELECT 1
+    FROM forum_topics target
+    WHERE target.tenant_id = NEW.tenant_id
+      AND target.id = NEW.target_topic_id
+      AND target.category_id = NEW.category_id
+      AND target.deleted_at IS NULL
+      AND target.status <> 'archived'
+)
+BEGIN
+    SELECT RAISE(ABORT, 'forum topic merge redirect edge is invalid');
+END;
+"#;
+
+const SQLITE_DOWN: &str = r#"
+DROP TRIGGER IF EXISTS forum_05_topic_merge_redirect_edge;
+DROP INDEX IF EXISTS uq_forum_topic_merge_operations_source;
+"#;

--- a/crates/rustok-forum/src/migrations/mod.rs
+++ b/crates/rustok-forum/src/migrations/mod.rs
@@ -46,6 +46,7 @@ mod m20260803_000013_add_forum_topic_merge_tag_reconciliations;
 mod m20260803_000014_add_forum_topic_merge_vote_reconciliations;
 mod m20260803_000015_add_forum_topic_merge_audience_reconciliations;
 mod m20260803_000016_add_forum_topic_merge_solution_policy;
+mod m20260803_000017_add_forum_topic_canonical_resolution;
 
 use rustok_core::MigrationDependencyDescriptor;
 use sea_orm_migration::MigrationTrait;
@@ -104,6 +105,7 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260803_000014_add_forum_topic_merge_vote_reconciliations::Migration),
         Box::new(m20260803_000015_add_forum_topic_merge_audience_reconciliations::Migration),
         Box::new(m20260803_000016_add_forum_topic_merge_solution_policy::Migration),
+        Box::new(m20260803_000017_add_forum_topic_canonical_resolution::Migration),
     ]
 }
 

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -106,6 +106,7 @@ mod topic_audience_list;
 mod topic_audience_lock;
 mod topic_audience_read;
 mod topic_audience_visibility;
+mod topic_canonical_resolution;
 mod topic_create_audience_authorization;
 mod topic_facade;
 mod topic_merge;
@@ -226,6 +227,9 @@ pub use topic_audience_list::{ForumTopicAudienceListService, ForumTopicAudienceP
 pub use topic_audience_read::ForumTopicAudienceReadService;
 pub use topic_audience_visibility::{
     ForumTopicAudienceViewer, ForumTopicAudienceVisibilityService,
+};
+pub use topic_canonical_resolution::{
+    ForumTopicCanonicalResolution, MAX_FORUM_TOPIC_CANONICAL_REDIRECT_HOPS,
 };
 pub use topic_create_audience_authorization::{
     ForumTopicCreateAudienceAuthorization, ForumTopicCreateAudienceAuthorizationService,

--- a/crates/rustok-forum/src/services/topic_canonical_resolution.rs
+++ b/crates/rustok-forum/src/services/topic_canonical_resolution.rs
@@ -1,13 +1,9 @@
 use std::collections::HashSet;
 
-use sea_orm::{
-    ColumnTrait, ConnectionTrait, DatabaseBackend, DatabaseConnection, EntityTrait, QueryFilter,
-    QueryOrder, QuerySelect, Statement,
-};
+use sea_orm::{ConnectionTrait, DatabaseBackend, DatabaseConnection, Statement};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::entities::forum_topic_merge_operation;
 use crate::error::{ForumError, ForumResult};
 
 pub const MAX_FORUM_TOPIC_CANONICAL_REDIRECT_HOPS: usize = 32;
@@ -19,6 +15,17 @@ pub struct ForumTopicCanonicalResolution {
     pub redirected: bool,
     pub hop_count: u32,
     pub merge_operation_ids: Vec<Uuid>,
+}
+
+#[derive(Clone, Copy)]
+struct ForumTopicCanonicalEdge {
+    operation_id: Uuid,
+    target_topic_id: Uuid,
+}
+
+struct ForumTopicCanonicalStep {
+    topic_exists: bool,
+    edges: Vec<ForumTopicCanonicalEdge>,
 }
 
 pub(crate) struct ForumTopicCanonicalResolutionService {
@@ -40,18 +47,21 @@ impl ForumTopicCanonicalResolutionService {
         let mut visited = HashSet::from([requested_topic_id]);
 
         loop {
-            let edges = forum_topic_merge_operation::Entity::find()
-                .filter(forum_topic_merge_operation::Column::TenantId.eq(tenant_id))
-                .filter(
-                    forum_topic_merge_operation::Column::SourceTopicId.eq(canonical_topic_id),
-                )
-                .order_by_asc(forum_topic_merge_operation::Column::OperationId)
-                .limit(2)
-                .all(&self.db)
-                .await?;
+            let step = load_resolution_step(
+                &self.db,
+                tenant_id,
+                canonical_topic_id,
+                requested_topic_id,
+            )
+            .await?;
 
-            match edges.as_slice() {
-                [] => break,
+            match step.edges.as_slice() {
+                [] => {
+                    if !step.topic_exists {
+                        return Err(ForumError::TopicNotFound(requested_topic_id));
+                    }
+                    break;
+                }
                 [edge] => {
                     if merge_operation_ids.len() >= MAX_FORUM_TOPIC_CANONICAL_REDIRECT_HOPS
                         || !visited.insert(edge.target_topic_id)
@@ -71,10 +81,6 @@ impl ForumTopicCanonicalResolutionService {
             }
         }
 
-        if !topic_exists(&self.db, tenant_id, canonical_topic_id).await? {
-            return Err(ForumError::TopicNotFound(requested_topic_id));
-        }
-
         Ok(ForumTopicCanonicalResolution {
             requested_topic_id,
             canonical_topic_id,
@@ -87,21 +93,67 @@ impl ForumTopicCanonicalResolutionService {
     }
 }
 
-async fn topic_exists(
+async fn load_resolution_step(
     db: &DatabaseConnection,
     tenant_id: Uuid,
     topic_id: Uuid,
-) -> ForumResult<bool> {
+    requested_topic_id: Uuid,
+) -> ForumResult<ForumTopicCanonicalStep> {
     let statement = match db.get_database_backend() {
         DatabaseBackend::Postgres => Statement::from_sql_and_values(
             DatabaseBackend::Postgres,
-            "SELECT 1 FROM forum_topics WHERE tenant_id = $1 AND id = $2 AND deleted_at IS NULL",
+            r#"
+            SELECT
+                EXISTS (
+                    SELECT 1
+                    FROM forum_topics topic
+                    WHERE topic.tenant_id = $1
+                      AND topic.id = $2
+                      AND topic.deleted_at IS NULL
+                ) AS topic_exists,
+                edge.operation_id,
+                edge.target_topic_id
+            FROM (SELECT 1) AS seed
+            LEFT JOIN (
+                SELECT operation_id, target_topic_id
+                FROM forum_topic_merge_operations
+                WHERE tenant_id = $1
+                  AND source_topic_id = $2
+                ORDER BY operation_id
+                LIMIT 2
+            ) AS edge ON TRUE
+            "#,
             vec![tenant_id.into(), topic_id.into()],
         ),
         DatabaseBackend::Sqlite => Statement::from_sql_and_values(
             DatabaseBackend::Sqlite,
-            "SELECT 1 FROM forum_topics WHERE tenant_id = ? AND id = ? AND deleted_at IS NULL",
-            vec![tenant_id.into(), topic_id.into()],
+            r#"
+            SELECT
+                EXISTS (
+                    SELECT 1
+                    FROM forum_topics topic
+                    WHERE topic.tenant_id = ?
+                      AND topic.id = ?
+                      AND topic.deleted_at IS NULL
+                ) AS topic_exists,
+                edge.operation_id,
+                edge.target_topic_id
+            FROM (SELECT 1) AS seed
+            LEFT JOIN (
+                SELECT operation_id, target_topic_id
+                FROM forum_topic_merge_operations
+                WHERE tenant_id = ?
+                  AND source_topic_id = ?
+                ORDER BY operation_id
+                LIMIT 2
+            ) AS edge ON 1 = 1
+            "#,
+            vec![
+                tenant_id.into(),
+                topic_id.into(),
+                tenant_id.into(),
+                topic_id.into(),
+            ],
         ),
         backend => {
             return Err(ForumError::Validation(format!(
@@ -109,5 +161,34 @@ async fn topic_exists(
             )));
         }
     };
-    Ok(db.query_one(statement).await?.is_some())
+
+    let rows = db.query_all(statement).await?;
+    let Some(first) = rows.first() else {
+        return Err(ForumError::TopicCanonicalResolutionConflict(
+            requested_topic_id,
+        ));
+    };
+    let topic_exists = first.try_get("", "topic_exists")?;
+    let mut edges = Vec::new();
+    for row in rows {
+        let operation_id: Option<Uuid> = row.try_get("", "operation_id")?;
+        let target_topic_id: Option<Uuid> = row.try_get("", "target_topic_id")?;
+        match (operation_id, target_topic_id) {
+            (Some(operation_id), Some(target_topic_id)) => edges.push(ForumTopicCanonicalEdge {
+                operation_id,
+                target_topic_id,
+            }),
+            (None, None) => {}
+            _ => {
+                return Err(ForumError::TopicCanonicalResolutionConflict(
+                    requested_topic_id,
+                ));
+            }
+        }
+    }
+
+    Ok(ForumTopicCanonicalStep {
+        topic_exists,
+        edges,
+    })
 }

--- a/crates/rustok-forum/src/services/topic_canonical_resolution.rs
+++ b/crates/rustok-forum/src/services/topic_canonical_resolution.rs
@@ -1,0 +1,113 @@
+use std::collections::HashSet;
+
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, DatabaseBackend, DatabaseConnection, EntityTrait, QueryFilter,
+    QueryOrder, QuerySelect, Statement,
+};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::entities::forum_topic_merge_operation;
+use crate::error::{ForumError, ForumResult};
+
+pub const MAX_FORUM_TOPIC_CANONICAL_REDIRECT_HOPS: usize = 32;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ForumTopicCanonicalResolution {
+    pub requested_topic_id: Uuid,
+    pub canonical_topic_id: Uuid,
+    pub redirected: bool,
+    pub hop_count: u32,
+    pub merge_operation_ids: Vec<Uuid>,
+}
+
+pub(crate) struct ForumTopicCanonicalResolutionService {
+    db: DatabaseConnection,
+}
+
+impl ForumTopicCanonicalResolutionService {
+    pub(crate) fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    pub(crate) async fn resolve_unchecked(
+        &self,
+        tenant_id: Uuid,
+        requested_topic_id: Uuid,
+    ) -> ForumResult<ForumTopicCanonicalResolution> {
+        let mut canonical_topic_id = requested_topic_id;
+        let mut merge_operation_ids = Vec::new();
+        let mut visited = HashSet::from([requested_topic_id]);
+
+        loop {
+            let edges = forum_topic_merge_operation::Entity::find()
+                .filter(forum_topic_merge_operation::Column::TenantId.eq(tenant_id))
+                .filter(
+                    forum_topic_merge_operation::Column::SourceTopicId.eq(canonical_topic_id),
+                )
+                .order_by_asc(forum_topic_merge_operation::Column::OperationId)
+                .limit(2)
+                .all(&self.db)
+                .await?;
+
+            match edges.as_slice() {
+                [] => break,
+                [edge] => {
+                    if merge_operation_ids.len() >= MAX_FORUM_TOPIC_CANONICAL_REDIRECT_HOPS
+                        || !visited.insert(edge.target_topic_id)
+                    {
+                        return Err(ForumError::TopicCanonicalResolutionConflict(
+                            requested_topic_id,
+                        ));
+                    }
+                    merge_operation_ids.push(edge.operation_id);
+                    canonical_topic_id = edge.target_topic_id;
+                }
+                _ => {
+                    return Err(ForumError::TopicCanonicalResolutionConflict(
+                        requested_topic_id,
+                    ));
+                }
+            }
+        }
+
+        if !topic_exists(&self.db, tenant_id, canonical_topic_id).await? {
+            return Err(ForumError::TopicNotFound(requested_topic_id));
+        }
+
+        Ok(ForumTopicCanonicalResolution {
+            requested_topic_id,
+            canonical_topic_id,
+            redirected: requested_topic_id != canonical_topic_id,
+            hop_count: u32::try_from(merge_operation_ids.len()).map_err(|_| {
+                ForumError::TopicCanonicalResolutionConflict(requested_topic_id)
+            })?,
+            merge_operation_ids,
+        })
+    }
+}
+
+async fn topic_exists(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    topic_id: Uuid,
+) -> ForumResult<bool> {
+    let statement = match db.get_database_backend() {
+        DatabaseBackend::Postgres => Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            "SELECT 1 FROM forum_topics WHERE tenant_id = $1 AND id = $2 AND deleted_at IS NULL",
+            vec![tenant_id.into(), topic_id.into()],
+        ),
+        DatabaseBackend::Sqlite => Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            "SELECT 1 FROM forum_topics WHERE tenant_id = ? AND id = ? AND deleted_at IS NULL",
+            vec![tenant_id.into(), topic_id.into()],
+        ),
+        backend => {
+            return Err(ForumError::Validation(format!(
+                "Forum topic canonical resolution does not support database backend {backend:?}"
+            )));
+        }
+    };
+    Ok(db.query_one(statement).await?.is_some())
+}

--- a/crates/rustok-forum/src/services/topic_facade.rs
+++ b/crates/rustok-forum/src/services/topic_facade.rs
@@ -15,6 +15,9 @@ use crate::error::{ForumError, ForumResult};
 use crate::state_machine::TopicStatus;
 
 use super::rbac::enforce_scope;
+use super::topic_canonical_resolution::{
+    ForumTopicCanonicalResolution, ForumTopicCanonicalResolutionService,
+};
 use super::topic_create_audience_authorization::ForumTopicCreateAudienceAuthorizationService;
 use super::topic_owner;
 use super::topic_visibility::{ForumTopicVisibilityScope, ForumTopicVisibilityService};
@@ -126,6 +129,39 @@ impl TopicService {
         require_localized_topic_response(response)
     }
 
+    pub async fn resolve_canonical_topic(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        topic_id: Uuid,
+    ) -> ForumResult<ForumTopicCanonicalResolution> {
+        self.resolve_canonical_topic_for_security(tenant_id, &security, topic_id)
+            .await
+    }
+
+    async fn resolve_canonical_topic_for_security(
+        &self,
+        tenant_id: Uuid,
+        security: &SecurityContext,
+        topic_id: Uuid,
+    ) -> ForumResult<ForumTopicCanonicalResolution> {
+        enforce_scope(security, Resource::ForumTopics, Action::Read)?;
+        let resolution = ForumTopicCanonicalResolutionService::new(self.db.clone())
+            .resolve_unchecked(tenant_id, topic_id)
+            .await?;
+        let visible = ForumTopicVisibilityService::new(self.db.clone())
+            .is_topic_category_visible_to_viewer(
+                tenant_id,
+                resolution.canonical_topic_id,
+                !security.is_public_read(),
+            )
+            .await?;
+        if !visible {
+            return Err(ForumError::TopicNotFound(topic_id));
+        }
+        Ok(resolution)
+    }
+
     pub async fn get(
         &self,
         tenant_id: Uuid,
@@ -145,18 +181,39 @@ impl TopicService {
         locale: &str,
         fallback_locale: Option<&str>,
     ) -> ForumResult<TopicResponse> {
-        enforce_scope(&security, Resource::ForumTopics, Action::Read)?;
-        let visible = ForumTopicVisibilityService::new(self.db.clone())
-            .is_topic_category_visible_to_viewer(tenant_id, topic_id, !security.is_public_read())
+        self.get_with_canonical_resolution_and_locale_fallback(
+            tenant_id,
+            security,
+            topic_id,
+            locale,
+            fallback_locale,
+        )
+        .await
+        .map(|(_, topic)| topic)
+    }
+
+    pub async fn get_with_canonical_resolution_and_locale_fallback(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        topic_id: Uuid,
+        locale: &str,
+        fallback_locale: Option<&str>,
+    ) -> ForumResult<(ForumTopicCanonicalResolution, TopicResponse)> {
+        let resolution = self
+            .resolve_canonical_topic_for_security(tenant_id, &security, topic_id)
             .await?;
-        if !visible {
-            return Err(ForumError::TopicNotFound(topic_id));
-        }
         let response = self
             .inner
-            .get_with_locale_fallback(tenant_id, security, topic_id, locale, fallback_locale)
+            .get_with_locale_fallback(
+                tenant_id,
+                security,
+                resolution.canonical_topic_id,
+                locale,
+                fallback_locale,
+            )
             .await?;
-        require_localized_topic_response(response)
+        Ok((resolution, require_localized_topic_response(response)?))
     }
 
     pub async fn get_storefront_visible_with_locale_fallback(
@@ -172,16 +229,31 @@ impl TopicService {
             channel_slug,
             !security.is_public_read(),
         )?;
-        let topic = match self
-            .get_with_locale_fallback(tenant_id, security, topic_id, locale, fallback_locale)
+        let resolution = match self
+            .resolve_canonical_topic_for_security(tenant_id, &security, topic_id)
             .await
         {
-            Ok(topic) => topic,
+            Ok(resolution) => resolution,
+            Err(ForumError::TopicNotFound(_)) => return Ok(None),
+            Err(error) => return Err(error),
+        };
+        let topic = match self
+            .inner
+            .get_with_locale_fallback(
+                tenant_id,
+                security,
+                resolution.canonical_topic_id,
+                locale,
+                fallback_locale,
+            )
+            .await
+        {
+            Ok(topic) => require_localized_topic_response(topic)?,
             Err(ForumError::TopicNotFound(_)) => return Ok(None),
             Err(error) => return Err(error),
         };
         if !ForumTopicVisibilityService::new(self.db.clone())
-            .is_topic_visible(tenant_id, topic_id, &scope)
+            .is_topic_visible(tenant_id, resolution.canonical_topic_id, &scope)
             .await?
         {
             return Ok(None);

--- a/crates/rustok-forum/tests/topic_canonical_resolution_sqlite.rs
+++ b/crates/rustok-forum/tests/topic_canonical_resolution_sqlite.rs
@@ -1,0 +1,310 @@
+use std::sync::Arc;
+
+use rustok_core::{MigrationSource, SecurityContext, UserRole};
+use rustok_forum::{
+    CategoryService, CreateCategoryInput, CreateTopicInput, ForumError, ForumModule,
+    ForumTopicMergeService, MergeForumTopicInput, TopicService,
+};
+use rustok_outbox::{OutboxModule, OutboxTransport, TransactionalEventBus};
+use rustok_taxonomy::TaxonomyModule;
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
+};
+use sea_orm_migration::SchemaManager;
+use uuid::Uuid;
+
+type TestResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+async fn setup() -> TestResult<(DatabaseConnection, TransactionalEventBus)> {
+    let db_url = format!(
+        "sqlite:file:forum_topic_canonical_resolution_{}?mode=memory&cache=shared",
+        Uuid::new_v4()
+    );
+    let mut options = ConnectOptions::new(db_url);
+    options
+        .max_connections(5)
+        .min_connections(1)
+        .sqlx_logging(false);
+    let db = Database::connect(options).await?;
+    db.execute_unprepared(
+        "CREATE TABLE users (\
+            id TEXT NOT NULL PRIMARY KEY, \
+            tenant_id TEXT NOT NULL, \
+            UNIQUE (tenant_id, id)\
+        )",
+    )
+    .await?;
+    let schema = SchemaManager::new(&db);
+    for migration in OutboxModule.migrations() {
+        migration.up(&schema).await?;
+    }
+    for migration in TaxonomyModule.migrations() {
+        migration.up(&schema).await?;
+    }
+    for migration in ForumModule.migrations() {
+        migration.up(&schema).await?;
+    }
+    let event_bus = TransactionalEventBus::new(Arc::new(OutboxTransport::new(db.clone())));
+    Ok((db, event_bus))
+}
+
+async fn insert_user(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    user_id: Uuid,
+) -> TestResult<()> {
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        "INSERT INTO users (id, tenant_id) VALUES (?, ?)",
+        vec![user_id.into(), tenant_id.into()],
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn create_category(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    security: SecurityContext,
+) -> TestResult<Uuid> {
+    Ok(CategoryService::new(db.clone())
+        .create(
+            tenant_id,
+            security,
+            CreateCategoryInput {
+                locale: "en".to_string(),
+                name: "Canonical resolution".to_string(),
+                slug: "canonical-resolution".to_string(),
+                description: None,
+                icon: None,
+                color: None,
+                parent_id: None,
+                position: Some(0),
+                moderated: false,
+            },
+        )
+        .await?
+        .id)
+}
+
+async fn create_topic(
+    db: &DatabaseConnection,
+    event_bus: &TransactionalEventBus,
+    tenant_id: Uuid,
+    category_id: Uuid,
+    security: SecurityContext,
+    key: &str,
+) -> TestResult<Uuid> {
+    Ok(TopicService::new(db.clone(), event_bus.clone())
+        .create(
+            tenant_id,
+            security,
+            CreateTopicInput {
+                locale: "en".to_string(),
+                category_id,
+                title: format!("Canonical {key}"),
+                slug: Some(format!("canonical-{key}")),
+                body: rustok_api::RichTextDocument::single_paragraph(format!(
+                    "Canonical {key} body"
+                )),
+                metadata: serde_json::json!({}),
+                tags: Vec::new(),
+                channel_slugs: None,
+            },
+        )
+        .await?
+        .id)
+}
+
+async fn insert_direct_merge_receipt(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    operation_id: Uuid,
+    source_topic_id: Uuid,
+    target_topic_id: Uuid,
+    category_id: Uuid,
+    actor_id: Uuid,
+) -> Result<(), sea_orm::DbErr> {
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        "INSERT INTO forum_topic_merge_operations (\
+            tenant_id, operation_id, source_topic_id, target_topic_id, category_id, actor_id, \
+            reason, moved_reply_count, moved_published_reply_count, \
+            resulting_published_reply_count, position_offset, event_id, merged_at\
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 0, ?, CURRENT_TIMESTAMP)",
+        vec![
+            tenant_id.into(),
+            operation_id.into(),
+            source_topic_id.into(),
+            target_topic_id.into(),
+            category_id.into(),
+            actor_id.into(),
+            "Direct canonical edge probe".into(),
+            operation_id.into(),
+        ],
+    ))
+    .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn merged_topic_ids_resolve_to_one_visible_canonical_target() -> TestResult<()> {
+    let (db, event_bus) = setup().await?;
+    let tenant_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    insert_user(&db, tenant_id, actor_id).await?;
+    let admin = SecurityContext::new(UserRole::Admin, Some(actor_id));
+    let category_id = create_category(&db, tenant_id, admin.clone()).await?;
+    let topic_a = create_topic(
+        &db,
+        &event_bus,
+        tenant_id,
+        category_id,
+        admin.clone(),
+        "a",
+    )
+    .await?;
+    let topic_b = create_topic(
+        &db,
+        &event_bus,
+        tenant_id,
+        category_id,
+        admin.clone(),
+        "b",
+    )
+    .await?;
+    let topic_c = create_topic(
+        &db,
+        &event_bus,
+        tenant_id,
+        category_id,
+        admin.clone(),
+        "c",
+    )
+    .await?;
+    let active_topic = create_topic(
+        &db,
+        &event_bus,
+        tenant_id,
+        category_id,
+        admin.clone(),
+        "active-probe",
+    )
+    .await?;
+
+    let operation_ab = Uuid::new_v4();
+    ForumTopicMergeService::new(db.clone(), event_bus.clone())
+        .merge_topic(
+            tenant_id,
+            topic_b,
+            admin.clone(),
+            MergeForumTopicInput {
+                operation_id: operation_ab,
+                source_topic_id: topic_a,
+                reason: "Collapse the first duplicate topic".to_string(),
+            },
+        )
+        .await?;
+
+    let operation_bc = Uuid::new_v4();
+    ForumTopicMergeService::new(db.clone(), event_bus.clone())
+        .merge_topic(
+            tenant_id,
+            topic_c,
+            admin.clone(),
+            MergeForumTopicInput {
+                operation_id: operation_bc,
+                source_topic_id: topic_b,
+                reason: "Collapse the intermediate duplicate topic".to_string(),
+            },
+        )
+        .await?;
+
+    let service = TopicService::new(db.clone(), event_bus);
+    let resolution_a = service
+        .resolve_canonical_topic(tenant_id, admin.clone(), topic_a)
+        .await?;
+    assert_eq!(resolution_a.requested_topic_id, topic_a);
+    assert_eq!(resolution_a.canonical_topic_id, topic_c);
+    assert!(resolution_a.redirected);
+    assert_eq!(resolution_a.hop_count, 2);
+    assert_eq!(
+        resolution_a.merge_operation_ids,
+        vec![operation_ab, operation_bc]
+    );
+
+    let resolution_b = service
+        .resolve_canonical_topic(tenant_id, admin.clone(), topic_b)
+        .await?;
+    assert_eq!(resolution_b.canonical_topic_id, topic_c);
+    assert_eq!(resolution_b.hop_count, 1);
+    assert_eq!(resolution_b.merge_operation_ids, vec![operation_bc]);
+
+    let resolution_c = service
+        .resolve_canonical_topic(tenant_id, admin.clone(), topic_c)
+        .await?;
+    assert_eq!(resolution_c.canonical_topic_id, topic_c);
+    assert!(!resolution_c.redirected);
+    assert_eq!(resolution_c.hop_count, 0);
+    assert!(resolution_c.merge_operation_ids.is_empty());
+
+    let (selected_resolution, selected) = service
+        .get_with_canonical_resolution_and_locale_fallback(
+            tenant_id,
+            admin.clone(),
+            topic_a,
+            "en",
+            None,
+        )
+        .await?;
+    assert_eq!(selected_resolution, resolution_a);
+    assert_eq!(selected.id, topic_c);
+    assert_eq!(selected.title, "Canonical c");
+
+    let storefront = service
+        .get_storefront_visible_with_locale_fallback(
+            tenant_id,
+            admin.clone(),
+            topic_a,
+            "en",
+            None,
+            None,
+        )
+        .await?
+        .ok_or("canonical storefront topic missing")?;
+    assert_eq!(storefront.id, topic_c);
+
+    let missing_id = Uuid::new_v4();
+    assert!(matches!(
+        service
+            .resolve_canonical_topic(tenant_id, admin.clone(), missing_id)
+            .await,
+        Err(ForumError::TopicNotFound(id)) if id == missing_id
+    ));
+
+    assert!(insert_direct_merge_receipt(
+        &db,
+        tenant_id,
+        Uuid::new_v4(),
+        topic_a,
+        topic_c,
+        category_id,
+        actor_id,
+    )
+    .await
+    .is_err());
+
+    assert!(insert_direct_merge_receipt(
+        &db,
+        tenant_id,
+        Uuid::new_v4(),
+        active_topic,
+        topic_c,
+        category_id,
+        actor_id,
+    )
+    .await
+    .is_err());
+
+    Ok(())
+}

--- a/scripts/verify/verify-forum-topic-canonical-resolution.mjs
+++ b/scripts/verify/verify-forum-topic-canonical-resolution.mjs
@@ -74,6 +74,7 @@ assert.equal(contract.selected_read_cutover.list_reads_changed, false);
 assert.equal(contract.selected_read_cutover.mutation_target_resolution_changed, false);
 assert.equal(contract.error.stable_code, "FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT");
 assert.equal(contract.error.http_status, 500);
+assert.equal(contract.error.retryable, false);
 assert.equal(contract.compatibility.topic_response_shape_changed, false);
 assert.equal(cumulativeContract.latest_policy_slice, "FORUM-21I");
 assert.equal(cumulativeContract.canonical_resolution.parallel_alias_store, false);
@@ -110,10 +111,10 @@ includesAll(
   [
     "TopicCanonicalResolutionConflict(Uuid)",
     '"FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT"',
-    "Self::TopicCanonicalResolutionConflict(_) => true",
   ],
   "ForumError",
 );
+assert.ok(!error.includes("Self::TopicCanonicalResolutionConflict(_) => true"));
 includesAll(
   service,
   [
@@ -239,6 +240,7 @@ includesAll(
     "at most 32 edges",
     "FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT",
     "does not emit an HTTP 3xx status",
+    "non-retryable",
     "No command above was run by the implementation agent",
   ],
   "FORUM-21I handoff",

--- a/scripts/verify/verify-forum-topic-canonical-resolution.mjs
+++ b/scripts/verify/verify-forum-topic-canonical-resolution.mjs
@@ -163,7 +163,7 @@ includesAll(
 );
 const canonicalResolve = facade.indexOf("resolve_canonical_topic_for_security(");
 const selectedHydration = facade.indexOf(
-  "self.inner\n            .get_with_locale_fallback(",
+  ".inner\n            .get_with_locale_fallback(",
   canonicalResolve,
 );
 assert.ok(canonicalResolve >= 0 && canonicalResolve < selectedHydration);

--- a/scripts/verify/verify-forum-topic-canonical-resolution.mjs
+++ b/scripts/verify/verify-forum-topic-canonical-resolution.mjs
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const paths = {
+  contract: "crates/rustok-forum/contracts/forum-topic-canonical-resolution.json",
+  cumulativeContract: "crates/rustok-forum/contracts/forum-topic-merge-owner.json",
+  docs: "crates/rustok-forum/docs/forum-21i-topic-canonical-resolution.md",
+  cumulativeDocs: "crates/rustok-forum/docs/forum-21b-topic-merge-owner.md",
+  error: "crates/rustok-forum/src/error.rs",
+  migration:
+    "crates/rustok-forum/src/migrations/m20260803_000017_add_forum_topic_canonical_resolution.rs",
+  migrationsMod: "crates/rustok-forum/src/migrations/mod.rs",
+  service: "crates/rustok-forum/src/services/topic_canonical_resolution.rs",
+  facade: "crates/rustok-forum/src/services/topic_facade.rs",
+  servicesMod: "crates/rustok-forum/src/services/mod.rs",
+  lib: "crates/rustok-forum/src/lib.rs",
+  controller: "crates/rustok-forum/src/controllers/mod.rs",
+  restTopics: "crates/rustok-forum/src/controllers/topics.rs",
+  graphql: "crates/rustok-forum/src/graphql/query_runtime.rs",
+  seo: "crates/rustok-forum/src/seo_targets.rs",
+  test: "crates/rustok-forum/tests/topic_canonical_resolution_sqlite.rs",
+  readme: "crates/rustok-forum/README.md",
+  docsIndex: "crates/rustok-forum/docs/README.md",
+  plan: "crates/rustok-forum/docs/implementation-plan.md",
+  verifier: "scripts/verify/verify-forum-topic-canonical-resolution.mjs",
+};
+
+const read = (path) => readFileSync(path, "utf8");
+function includesAll(text, markers, label) {
+  for (const marker of markers) {
+    assert.ok(text.includes(marker), `${label} is missing marker: ${marker}`);
+  }
+}
+
+const contract = JSON.parse(read(paths.contract));
+const cumulativeContract = JSON.parse(read(paths.cumulativeContract));
+const docs = read(paths.docs);
+const cumulativeDocs = read(paths.cumulativeDocs);
+const error = read(paths.error);
+const migration = read(paths.migration);
+const migrationsMod = read(paths.migrationsMod);
+const service = read(paths.service);
+const facade = read(paths.facade);
+const servicesMod = read(paths.servicesMod);
+const lib = read(paths.lib);
+const controller = read(paths.controller);
+const restTopics = read(paths.restTopics);
+const graphql = read(paths.graphql);
+const seo = read(paths.seo);
+const test = read(paths.test);
+const readme = read(paths.readme);
+const docsIndex = read(paths.docsIndex);
+const plan = read(paths.plan);
+const verifier = read(paths.verifier);
+
+assert.equal(contract.contract, "forum_topic_canonical_resolution_v1");
+assert.equal(contract.task, "FORUM-21I");
+assert.equal(contract.parent_task, "FORUM-21");
+assert.equal(contract.extends, "FORUM-21B");
+assert.equal(contract.status, "source_ready_maintainer_execution_pending");
+assert.equal(contract.canonical_plan_status, "planned");
+assert.equal(contract.owner_service, "TopicService");
+assert.equal(contract.source_of_truth, "forum_topic_merge_operations");
+assert.equal(contract.resolution.maximum_hops, 32);
+assert.equal(contract.database_guards.one_source_edge_per_tenant_topic, true);
+assert.equal(contract.database_guards.parallel_alias_table_added, false);
+assert.equal(
+  contract.selected_read_cutover.rest_get_topic,
+  "returns_the_canonical_target_representation_with_the_target_id",
+);
+assert.equal(contract.selected_read_cutover.list_reads_changed, false);
+assert.equal(contract.selected_read_cutover.mutation_target_resolution_changed, false);
+assert.equal(contract.error.stable_code, "FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT");
+assert.equal(contract.error.http_status, 500);
+assert.equal(contract.compatibility.topic_response_shape_changed, false);
+assert.equal(cumulativeContract.latest_policy_slice, "FORUM-21I");
+assert.equal(cumulativeContract.canonical_resolution.parallel_alias_store, false);
+assert.equal(cumulativeContract.bounds.canonical_resolution_hops_max, 32);
+
+includesAll(
+  migrationsMod,
+  [
+    "mod m20260803_000017_add_forum_topic_canonical_resolution;",
+    "Box::new(m20260803_000017_add_forum_topic_canonical_resolution::Migration)",
+  ],
+  "migration registry",
+);
+includesAll(
+  migration,
+  [
+    "uq_forum_topic_merge_operations_source",
+    "ON forum_topic_merge_operations (tenant_id, source_topic_id)",
+    "forum_validate_topic_merge_redirect_edge",
+    "forum_05_topic_merge_redirect_edge",
+    "source.status::text = 'archived'",
+    "source.is_locked = TRUE",
+    "source.reply_count = 0",
+    "target.status::text <> 'archived'",
+    "source.status = 'archived'",
+    "target.status <> 'archived'",
+    "DROP INDEX IF EXISTS uq_forum_topic_merge_operations_source",
+  ],
+  "canonical resolution migration",
+);
+
+includesAll(
+  error,
+  [
+    "TopicCanonicalResolutionConflict(Uuid)",
+    '"FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT"',
+    "Self::TopicCanonicalResolutionConflict(_) => true",
+  ],
+  "ForumError",
+);
+includesAll(
+  service,
+  [
+    "pub const MAX_FORUM_TOPIC_CANONICAL_REDIRECT_HOPS: usize = 32;",
+    "pub struct ForumTopicCanonicalResolution",
+    "pub requested_topic_id: Uuid",
+    "pub canonical_topic_id: Uuid",
+    "pub merge_operation_ids: Vec<Uuid>",
+    "pub(crate) async fn resolve_unchecked(",
+    ".limit(2)",
+    "match edges.as_slice()",
+    "!visited.insert(edge.target_topic_id)",
+    "merge_operation_ids.len() >= MAX_FORUM_TOPIC_CANONICAL_REDIRECT_HOPS",
+    "TopicCanonicalResolutionConflict(requested_topic_id)",
+    "deleted_at IS NULL",
+  ],
+  "canonical resolution owner",
+);
+assert.ok(!service.includes("forum_topic_alias"));
+assert.ok(!service.includes("forum_topic_redirects"));
+assert.ok(!service.includes("bestEffort"));
+
+includesAll(
+  facade,
+  [
+    "pub async fn resolve_canonical_topic(",
+    "resolve_canonical_topic_for_security(",
+    "ForumTopicCanonicalResolutionService::new(self.db.clone())",
+    "resolution.canonical_topic_id",
+    "pub async fn get_with_canonical_resolution_and_locale_fallback(",
+    "get_with_locale_fallback(\n                tenant_id,\n                security,\n                resolution.canonical_topic_id",
+    ".is_topic_visible(tenant_id, resolution.canonical_topic_id, &scope)",
+  ],
+  "TopicService facade",
+);
+const canonicalResolve = facade.indexOf("resolve_canonical_topic_for_security(");
+const selectedHydration = facade.indexOf(
+  "self.inner\n            .get_with_locale_fallback(",
+  canonicalResolve,
+);
+assert.ok(canonicalResolve >= 0 && canonicalResolve < selectedHydration);
+
+includesAll(
+  servicesMod,
+  [
+    "mod topic_canonical_resolution;",
+    "ForumTopicCanonicalResolution, MAX_FORUM_TOPIC_CANONICAL_REDIRECT_HOPS",
+  ],
+  "service exports",
+);
+includesAll(
+  lib,
+  [
+    "ForumTopicCanonicalResolution",
+    "MAX_FORUM_TOPIC_CANONICAL_REDIRECT_HOPS",
+  ],
+  "crate exports",
+);
+includesAll(
+  controller,
+  [
+    "ForumError::TopicCanonicalResolutionConflict(_)",
+    "StatusCode::INTERNAL_SERVER_ERROR",
+    '"The forum operation could not be completed"',
+  ],
+  "HTTP error mapping",
+);
+
+includesAll(
+  restTopics,
+  [
+    "pub async fn get_topic(",
+    ".get_with_locale_fallback(",
+    "Ok(Json(topic))",
+  ],
+  "REST selected-topic path",
+);
+assert.ok(!restTopics.includes("PERMANENT_REDIRECT"));
+assert.ok(!restTopics.includes("Location"));
+includesAll(
+  graphql,
+  [
+    "async fn forum_topic(",
+    "let service = TopicService::new(db.clone(), event_bus.clone());",
+    ".get_with_locale_fallback(",
+    "Ok(Some(map_topic_response(topic, author_profile)))",
+  ],
+  "GraphQL selected-topic path",
+);
+includesAll(
+  seo,
+  [
+    "impl SeoTargetProvider for ForumTopicSeoTargetProvider",
+    "let service = TopicService::new(runtime.db.clone(), runtime.event_bus.clone());",
+    ".get_with_locale_fallback(",
+    "target_id: record.target_id",
+  ],
+  "Forum SEO topic path",
+);
+
+includesAll(
+  test,
+  [
+    "merged_topic_ids_resolve_to_one_visible_canonical_target",
+    "let operation_ab = Uuid::new_v4();",
+    "let operation_bc = Uuid::new_v4();",
+    "vec![operation_ab, operation_bc]",
+    "assert_eq!(selected.id, topic_c)",
+    "assert_eq!(storefront.id, topic_c)",
+    "Err(ForumError::TopicNotFound(id)) if id == missing_id",
+    "insert_direct_merge_receipt",
+    "active_topic",
+  ],
+  "SQLite regression",
+);
+
+includesAll(
+  docs,
+  [
+    "# FORUM-21I canonical merged-topic resolution",
+    "`source_ready_maintainer_execution_pending`",
+    "One source of truth",
+    "at most 32 edges",
+    "FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT",
+    "does not emit an HTTP 3xx status",
+    "No command above was run by the implementation agent",
+  ],
+  "FORUM-21I handoff",
+);
+includesAll(
+  cumulativeDocs,
+  [
+    "FORUM-21I",
+    "the only source-to-target canonical edge",
+    "FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT",
+    "FORUM-21A through FORUM-21I",
+  ],
+  "cumulative merge handoff",
+);
+includesAll(
+  readme,
+  [
+    "immutable `forum_topic_merge_operations` chain",
+    "HTTP 3xx responses and slug aliases are not part of the current contract",
+    "Canonical merged-topic resolution",
+  ],
+  "crate README",
+);
+includesAll(
+  docsIndex,
+  [
+    "resolve selected merged-source topic IDs",
+    "FORUM-21I canonical merged-topic resolution",
+  ],
+  "forum docs index",
+);
+
+assert.ok(plan.includes("| `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |"));
+assert.ok(plan.includes("## `FORUM-21` — move, merge, split and fork topics"));
+assert.ok(plan.includes("**Status:** `planned`"));
+assert.ok(!plan.includes("| `FORUM-21` | `done` |"));
+assert.ok(!plan.includes("| `FORUM-21` | `in_progress` |"));
+assert.ok(verifier.includes("source_ready_maintainer_execution_pending"));
+
+console.log(
+  "FORUM-21I canonical merged-topic resolution source is ready; canonical FORUM-21 remains planned.",
+);

--- a/scripts/verify/verify-forum-topic-canonical-resolution.mjs
+++ b/scripts/verify/verify-forum-topic-canonical-resolution.mjs
@@ -64,6 +64,10 @@ assert.equal(contract.canonical_plan_status, "planned");
 assert.equal(contract.owner_service, "TopicService");
 assert.equal(contract.source_of_truth, "forum_topic_merge_operations");
 assert.equal(contract.resolution.maximum_hops, 32);
+assert.equal(
+  contract.resolution.each_hop_topic_and_edges_share_one_statement_snapshot,
+  true,
+);
 assert.equal(contract.database_guards.one_source_edge_per_tenant_topic, true);
 assert.equal(contract.database_guards.parallel_alias_table_added, false);
 assert.equal(
@@ -115,6 +119,7 @@ includesAll(
   "ForumError",
 );
 assert.ok(!error.includes("Self::TopicCanonicalResolutionConflict(_) => true"));
+
 includesAll(
   service,
   [
@@ -123,19 +128,26 @@ includesAll(
     "pub requested_topic_id: Uuid",
     "pub canonical_topic_id: Uuid",
     "pub merge_operation_ids: Vec<Uuid>",
+    "struct ForumTopicCanonicalStep",
     "pub(crate) async fn resolve_unchecked(",
-    ".limit(2)",
-    "match edges.as_slice()",
+    "load_resolution_step(",
+    "match step.edges.as_slice()",
     "!visited.insert(edge.target_topic_id)",
     "merge_operation_ids.len() >= MAX_FORUM_TOPIC_CANONICAL_REDIRECT_HOPS",
     "TopicCanonicalResolutionConflict(requested_topic_id)",
-    "deleted_at IS NULL",
+    "EXISTS (",
+    "AS topic_exists",
+    "FROM forum_topic_merge_operations",
+    "LIMIT 2",
+    "LEFT JOIN (",
+    "topic.deleted_at IS NULL",
   ],
   "canonical resolution owner",
 );
 assert.ok(!service.includes("forum_topic_alias"));
 assert.ok(!service.includes("forum_topic_redirects"));
 assert.ok(!service.includes("bestEffort"));
+assert.ok(!service.includes("topic_exists(&self.db"));
 
 includesAll(
   facade,
@@ -145,7 +157,6 @@ includesAll(
     "ForumTopicCanonicalResolutionService::new(self.db.clone())",
     "resolution.canonical_topic_id",
     "pub async fn get_with_canonical_resolution_and_locale_fallback(",
-    "get_with_locale_fallback(\n                tenant_id,\n                security,\n                resolution.canonical_topic_id",
     ".is_topic_visible(tenant_id, resolution.canonical_topic_id, &scope)",
   ],
   "TopicService facade",
@@ -170,6 +181,7 @@ includesAll(
   [
     "ForumTopicCanonicalResolution",
     "MAX_FORUM_TOPIC_CANONICAL_REDIRECT_HOPS",
+    "mod contract_tests;",
   ],
   "crate exports",
 );
@@ -185,11 +197,7 @@ includesAll(
 
 includesAll(
   restTopics,
-  [
-    "pub async fn get_topic(",
-    ".get_with_locale_fallback(",
-    "Ok(Json(topic))",
-  ],
+  ["pub async fn get_topic(", ".get_with_locale_fallback(", "Ok(Json(topic))"],
   "REST selected-topic path",
 );
 assert.ok(!restTopics.includes("PERMANENT_REDIRECT"));

--- a/scripts/verify/verify-forum-topic-merge-owner.mjs
+++ b/scripts/verify/verify-forum-topic-merge-owner.mjs
@@ -7,6 +7,8 @@ const paths = {
   contract: "crates/rustok-forum/contracts/forum-topic-merge-owner.json",
   solutionContract:
     "crates/rustok-forum/contracts/forum-topic-merge-solution-policy.json",
+  canonicalContract:
+    "crates/rustok-forum/contracts/forum-topic-canonical-resolution.json",
   docs: "crates/rustok-forum/docs/forum-21b-topic-merge-owner.md",
   entity: "crates/rustok-forum/src/entities/forum_topic_merge_operation.rs",
   entitiesMod: "crates/rustok-forum/src/entities/mod.rs",
@@ -16,18 +18,20 @@ const paths = {
     "crates/rustok-forum/src/migrations/m20260801_000010_add_forum_topic_merge_operations.rs",
   solutionMigration:
     "crates/rustok-forum/src/migrations/m20260803_000016_add_forum_topic_merge_solution_policy.rs",
+  canonicalMigration:
+    "crates/rustok-forum/src/migrations/m20260803_000017_add_forum_topic_canonical_resolution.rs",
   migrationsMod: "crates/rustok-forum/src/migrations/mod.rs",
   service: "crates/rustok-forum/src/services/topic_merge.rs",
+  canonicalService: "crates/rustok-forum/src/services/topic_canonical_resolution.rs",
+  facade: "crates/rustok-forum/src/services/topic_facade.rs",
   servicesMod: "crates/rustok-forum/src/services/mod.rs",
   test: "crates/rustok-forum/tests/topic_merge_sqlite.rs",
+  canonicalTest: "crates/rustok-forum/tests/topic_canonical_resolution_sqlite.rs",
   plan: "crates/rustok-forum/docs/implementation-plan.md",
   verifier: "scripts/verify/verify-forum-topic-merge-owner.mjs",
 };
 
-function read(path) {
-  return readFileSync(path, "utf8");
-}
-
+const read = (path) => readFileSync(path, "utf8");
 function includesAll(text, markers, label) {
   for (const marker of markers) {
     assert.ok(text.includes(marker), `${label} is missing marker: ${marker}`);
@@ -36,6 +40,7 @@ function includesAll(text, markers, label) {
 
 const contract = JSON.parse(read(paths.contract));
 const solutionContract = JSON.parse(read(paths.solutionContract));
+const canonicalContract = JSON.parse(read(paths.canonicalContract));
 const docs = read(paths.docs);
 const entity = read(paths.entity);
 const entitiesMod = read(paths.entitiesMod);
@@ -43,16 +48,20 @@ const error = read(paths.error);
 const lib = read(paths.lib);
 const receiptMigration = read(paths.receiptMigration);
 const solutionMigration = read(paths.solutionMigration);
+const canonicalMigration = read(paths.canonicalMigration);
 const migrationsMod = read(paths.migrationsMod);
 const service = read(paths.service);
+const canonicalService = read(paths.canonicalService);
+const facade = read(paths.facade);
 const servicesMod = read(paths.servicesMod);
 const test = read(paths.test);
+const canonicalTest = read(paths.canonicalTest);
 const plan = read(paths.plan);
 const verifier = read(paths.verifier);
 
 assert.equal(contract.contract, "forum_topic_merge_owner_v1");
 assert.equal(contract.task, "FORUM-21B");
-assert.equal(contract.latest_policy_slice, "FORUM-21H");
+assert.equal(contract.latest_policy_slice, "FORUM-21I");
 assert.equal(contract.parent_task, "FORUM-21");
 assert.equal(contract.status, "source_ready_maintainer_execution_pending");
 assert.equal(contract.canonical_plan_status, "planned");
@@ -63,6 +72,7 @@ assert.equal(contract.result, "ForumTopicMergeResult");
 assert.deepEqual(contract.migrations, [
   "m20260801_000010_add_forum_topic_merge_operations",
   "m20260803_000016_add_forum_topic_merge_solution_policy",
+  "m20260803_000017_add_forum_topic_canonical_resolution",
 ]);
 assert.equal(contract.receipt_table, "forum_topic_merge_operations");
 assert.deepEqual(contract.required_permissions, ["forum_topics:manage"]);
@@ -70,6 +80,7 @@ assert.equal(contract.bounds.reason_max_characters, 500);
 assert.equal(contract.bounds.source_reply_rows_max, 500);
 assert.equal(contract.bounds.same_category_only, true);
 assert.equal(contract.bounds.accepted_solutions_per_topic_max, 1);
+assert.equal(contract.bounds.canonical_resolution_hops_max, 32);
 assert.equal(contract.semantic_event.event_type, "forum.topic.merged");
 assert.equal(contract.semantic_event.schema_version, 1);
 assert.equal(contract.semantic_event.event_id_equals_operation_id, true);
@@ -78,8 +89,12 @@ assert.equal(
   contract.solution_policy.source_and_target,
   "fail_before_mutation_with_FORUM_TOPIC_MERGE_SOLUTION_CONFLICT",
 );
+assert.equal(contract.canonical_resolution.source_of_truth, "forum_topic_merge_operations");
+assert.equal(contract.canonical_resolution.parallel_alias_store, false);
 assert.equal(solutionContract.task, "FORUM-21H");
 assert.equal(solutionContract.extends, "FORUM-21B");
+assert.equal(canonicalContract.task, "FORUM-21I");
+assert.equal(canonicalContract.extends, "FORUM-21B");
 
 includesAll(
   entity,
@@ -111,8 +126,10 @@ includesAll(
   [
     "TopicMergeOperationConflict(Uuid)",
     "TopicMergeSolutionConflict(Uuid)",
+    "TopicCanonicalResolutionConflict(Uuid)",
     '"FORUM_TOPIC_MERGE_OPERATION_CONFLICT"',
     '"FORUM_TOPIC_MERGE_SOLUTION_CONFLICT"',
+    '"FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT"',
   ],
   "ForumError",
 );
@@ -123,6 +140,8 @@ includesAll(
     "Box::new(m20260801_000010_add_forum_topic_merge_operations::Migration)",
     "mod m20260803_000016_add_forum_topic_merge_solution_policy;",
     "Box::new(m20260803_000016_add_forum_topic_merge_solution_policy::Migration)",
+    "mod m20260803_000017_add_forum_topic_canonical_resolution;",
+    "Box::new(m20260803_000017_add_forum_topic_canonical_resolution::Migration)",
   ],
   "migration registration",
 );
@@ -150,6 +169,19 @@ includesAll(
     "forum solution requires an active topic and approved reply",
   ],
   "solution policy migration",
+);
+includesAll(
+  canonicalMigration,
+  [
+    "uq_forum_topic_merge_operations_source",
+    "forum_validate_topic_merge_redirect_edge",
+    "forum_05_topic_merge_redirect_edge",
+    "source.status::text = 'archived'",
+    "source.is_locked = TRUE",
+    "source.reply_count = 0",
+    "target.status::text <> 'archived'",
+  ],
+  "canonical resolution migration",
 );
 
 includesAll(
@@ -222,13 +254,42 @@ for (const forbidden of [
 }
 
 includesAll(
+  canonicalService,
+  [
+    "pub const MAX_FORUM_TOPIC_CANONICAL_REDIRECT_HOPS: usize = 32;",
+    "pub struct ForumTopicCanonicalResolution",
+    "pub(crate) async fn resolve_unchecked(",
+    ".limit(2)",
+    "match edges.as_slice()",
+    "!visited.insert(edge.target_topic_id)",
+    "TopicCanonicalResolutionConflict(requested_topic_id)",
+    "deleted_at IS NULL",
+  ],
+  "canonical resolution service",
+);
+assert.ok(!canonicalService.includes("forum_topic_alias"));
+assert.ok(!canonicalService.includes("forum_topic_redirects"));
+includesAll(
+  facade,
+  [
+    "pub async fn resolve_canonical_topic(",
+    "pub async fn get_with_canonical_resolution_and_locale_fallback(",
+    "resolution.canonical_topic_id",
+    ".is_topic_visible(tenant_id, resolution.canonical_topic_id, &scope)",
+  ],
+  "canonical topic facade",
+);
+
+includesAll(
   servicesMod,
   [
     "mod topic_merge;",
+    "mod topic_canonical_resolution;",
     "ForumTopicMergeResult, ForumTopicMergeService",
     "MergeForumTopicInput",
     "MAX_FORUM_TOPIC_MERGE_REASON_LEN",
     "MAX_FORUM_TOPIC_MERGE_REPLIES",
+    "ForumTopicCanonicalResolution, MAX_FORUM_TOPIC_CANONICAL_REDIRECT_HOPS",
   ],
   "service exports",
 );
@@ -239,6 +300,8 @@ includesAll(
     "MergeForumTopicInput",
     "MAX_FORUM_TOPIC_MERGE_REASON_LEN",
     "MAX_FORUM_TOPIC_MERGE_REPLIES",
+    "ForumTopicCanonicalResolution",
+    "MAX_FORUM_TOPIC_CANONICAL_REDIRECT_HOPS",
   ],
   "crate exports",
 );
@@ -259,7 +322,18 @@ includesAll(
     "DELETE FROM forum_topic_merge_operations",
     '"forum.topic.merged"',
   ],
-  "SQLite regression",
+  "merge SQLite regression",
+);
+includesAll(
+  canonicalTest,
+  [
+    "merged_topic_ids_resolve_to_one_visible_canonical_target",
+    "vec![operation_ab, operation_bc]",
+    "assert_eq!(selected.id, topic_c)",
+    "assert_eq!(storefront.id, topic_c)",
+    "insert_direct_merge_receipt",
+  ],
+  "canonical resolution SQLite regression",
 );
 includesAll(
   docs,
@@ -268,11 +342,13 @@ includesAll(
     "`source_ready_maintainer_execution_pending`",
     paths.contract,
     paths.solutionContract,
+    paths.canonicalContract,
     "source-only accepted solution",
     "target-only accepted solution",
     "two accepted solutions",
     "FORUM_TOPIC_MERGE_SOLUTION_CONFLICT",
-    "FORUM-21A through FORUM-21H",
+    "FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT",
+    "FORUM-21A through FORUM-21I",
     "No command above was run by the implementation agent",
   ],
   "FORUM-21B handoff",
@@ -283,5 +359,5 @@ assert.ok(!plan.includes("| `FORUM-21` | `in_progress` |"));
 assert.ok(verifier.includes("source_ready_maintainer_execution_pending"));
 
 console.log(
-  "FORUM-21B/H topic merge owner source is ready and canonical FORUM-21 remains planned.",
+  "FORUM-21B/H/I topic merge owner source is ready and canonical FORUM-21 remains planned.",
 );

--- a/scripts/verify/verify-forum-topic-merge-owner.mjs
+++ b/scripts/verify/verify-forum-topic-merge-owner.mjs
@@ -95,6 +95,10 @@ assert.equal(solutionContract.task, "FORUM-21H");
 assert.equal(solutionContract.extends, "FORUM-21B");
 assert.equal(canonicalContract.task, "FORUM-21I");
 assert.equal(canonicalContract.extends, "FORUM-21B");
+assert.equal(
+  canonicalContract.resolution.each_hop_topic_and_edges_share_one_statement_snapshot,
+  true,
+);
 
 includesAll(
   entity,
@@ -259,11 +263,16 @@ includesAll(
     "pub const MAX_FORUM_TOPIC_CANONICAL_REDIRECT_HOPS: usize = 32;",
     "pub struct ForumTopicCanonicalResolution",
     "pub(crate) async fn resolve_unchecked(",
-    ".limit(2)",
-    "match edges.as_slice()",
+    "load_resolution_step(",
+    "match step.edges.as_slice()",
     "!visited.insert(edge.target_topic_id)",
     "TopicCanonicalResolutionConflict(requested_topic_id)",
-    "deleted_at IS NULL",
+    "EXISTS (",
+    "AS topic_exists",
+    "FROM forum_topic_merge_operations",
+    "LEFT JOIN (",
+    "LIMIT 2",
+    "topic.deleted_at IS NULL",
   ],
   "canonical resolution service",
 );
@@ -302,6 +311,7 @@ includesAll(
     "MAX_FORUM_TOPIC_MERGE_REPLIES",
     "ForumTopicCanonicalResolution",
     "MAX_FORUM_TOPIC_CANONICAL_REDIRECT_HOPS",
+    "mod contract_tests;",
   ],
   "crate exports",
 );


### PR DESCRIPTION
## What changed

- add source-ready `FORUM-21I` beneath the planned `FORUM-21` merge workflow;
- reuse immutable `forum_topic_merge_operations` as the only source-to-target canonical identity ledger instead of adding an alias table;
- require one canonical edge per tenant/source topic;
- guard new PostgreSQL and SQLite receipt edges so the source is an archived, locked, non-deleted, zero-reply tombstone and the target is non-deleted, non-archived and in the receipt category;
- add bounded canonical resolution with a 32-hop maximum, ordered operation evidence, duplicate-edge detection and cycle detection;
- read current-topic existence and at most two outgoing edges in one database statement per hop so a concurrent merge cannot mix pre-commit edge state with post-commit topic state;
- return `FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT` as a non-retryable internal integrity error;
- canonicalize `TopicService` selected-topic reads before hydration and visibility evaluation;
- make GraphQL selected-topic and Forum SEO target reads inherit the same canonical target through their existing `TopicService` composition;
- keep REST lookup ID-based and return the target representation with the target ID for a merged source;
- keep list and mutation target semantics unchanged;
- add focused contracts, handoff, README/docs index updates, SQLite source coverage and fail-closed verifiers.

## Resolution boundary

A chain such as `A -> B -> C` resolves `A` and `B` to `C`. The returned evidence preserves the originally requested ID, terminal target ID, hop count and immutable merge operation IDs in traversal order.

Each hop is statement-consistent: a concurrent merge linearizes before or after that hop instead of producing a mixed read.

No HTTP 3xx response, `Location` header, slug alias, slug route or second redirect store is introduced. Those remain a later route-contract slice.

## Compatibility

- no merge command, result, receipt row shape or `forum.topic.merged` event change;
- no REST path, GraphQL schema, topic response or SEO target contract change;
- no public merge transport or mutation aliasing;
- canonical `FORUM-21` remains `planned`.

## Validation

Tests, Node verifiers, formatting, Cargo checks, SQLite/PostgreSQL execution, workflows and CI were intentionally not run, per maintainer request.

## Branch state

Current `main` advanced through unrelated Index/Blog/Fulfillment work with no Forum path overlap. The accidental temporary empty marker is absent from the final diff. Squash merge is requested so the final mainline change remains one Forum work unit.