### PR TITLE
feat(blog): add atomic canonical audit handoff

### DIFF
--- a/apps/server/src/services/comments_provider_runtime.rs
+++ b/apps/server/src/services/comments_provider_runtime.rs
@@ -46,6 +46,10 @@ mod keyring_schedule_audit_canonical_writer {
     include!("comments_provider_runtime_keyring_schedule_audit_canonical_writer.rs");
 }
 
+mod keyring_schedule_audit_handoff_postgres {
+    include!("comments_provider_runtime_keyring_schedule_audit_handoff_postgres.rs");
+}
+
 mod keyring_schedule_persisted_trigger {
     include!("comments_provider_runtime_keyring_schedule_persisted_trigger.rs");
 }
@@ -90,6 +94,12 @@ pub use keyring_schedule::{
     SharedCommentsTcpDelegationScheduleHandle,
 };
 pub use keyring_schedule_audit_canonical_writer::RustokOutboxCommentsTcpDelegationScheduleAuditCanonicalWriter;
+pub use keyring_schedule_audit_handoff_postgres::{
+    COMMENTS_TCP_DELEGATION_SCHEDULE_AUDIT_HANDOFF_MAX_CLAIM_SECONDS,
+    CommentsTcpDelegationScheduleAuditHandoffClaim,
+    CommentsTcpDelegationScheduleAuditHandoffError,
+    PostgresCommentsTcpDelegationScheduleAuditCanonicalHandoff,
+};
 pub use keyring_schedule_audit_publication::{
     COMMENTS_TCP_DELEGATION_SCHEDULE_CANONICAL_AUDIT_EVENT_TYPE,
     COMMENTS_TCP_DELEGATION_SCHEDULE_CANONICAL_AUDIT_SCHEMA_VERSION,

--- a/apps/server/src/services/comments_provider_runtime_keyring_schedule_audit_handoff_postgres.rs
+++ b/apps/server/src/services/comments_provider_runtime_keyring_schedule_audit_handoff_postgres.rs
@@ -1,0 +1,586 @@
+use std::{fmt, time::Duration};
+
+use rustok_api::AuthPrincipalKind;
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, QueryResult,
+    Statement, TransactionTrait,
+};
+use uuid::Uuid;
+
+use super::{
+    keyring,
+    keyring_schedule_audit_publication::{
+        CommentsTcpDelegationScheduleAuditCanonicalPublication,
+        CommentsTcpDelegationScheduleAuditCanonicalWriteError,
+        SharedCommentsTcpDelegationScheduleAuditCanonicalWriter,
+    },
+    keyring_schedule_persistence_postgres as postgres,
+    keyring_schedule_persistence_postgres_audit as postgres_audit,
+    keyring_schedule_trigger as trigger,
+};
+
+pub const COMMENTS_TCP_DELEGATION_SCHEDULE_AUDIT_HANDOFF_MAX_CLAIM_SECONDS: u64 = 300;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CommentsTcpDelegationScheduleAuditHandoffError {
+    Conflict,
+    Unavailable,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CommentsTcpDelegationScheduleAuditHandoffClaim {
+    request_id: Uuid,
+    claim_token: Uuid,
+    attempt_count: i64,
+}
+
+impl CommentsTcpDelegationScheduleAuditHandoffClaim {
+    pub fn request_id(&self) -> Uuid {
+        self.request_id
+    }
+
+    pub fn claim_token(&self) -> Uuid {
+        self.claim_token
+    }
+
+    pub fn attempt_count(&self) -> i64 {
+        self.attempt_count
+    }
+}
+
+#[derive(Clone)]
+pub struct PostgresCommentsTcpDelegationScheduleAuditCanonicalHandoff {
+    database: DatabaseConnection,
+    control_plane_tenant_id: Uuid,
+    writer: SharedCommentsTcpDelegationScheduleAuditCanonicalWriter,
+    claim_ttl_seconds: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct StoredAuditHandoffRecord {
+    audit_schema_version: i16,
+    request_id: Uuid,
+    state_key: String,
+    event_type: String,
+    occurred_at_unix_ms: i64,
+    actor_id: Uuid,
+    principal_kind: String,
+    operation: String,
+    source: String,
+    previous_generation: i64,
+    candidate_generation: i64,
+    outcome: String,
+    canonical_envelope_id: Option<Uuid>,
+    published: bool,
+    claim_token: Option<Uuid>,
+    claim_attempt_count: i64,
+    claim_active: bool,
+}
+
+impl PostgresCommentsTcpDelegationScheduleAuditCanonicalHandoff {
+    pub fn new(
+        database: DatabaseConnection,
+        control_plane_tenant_id: Uuid,
+        writer: SharedCommentsTcpDelegationScheduleAuditCanonicalWriter,
+        claim_ttl: Duration,
+    ) -> std::result::Result<Self, String> {
+        if database.get_database_backend() != DbBackend::Postgres {
+            return Err(
+                "Comments schedule audit canonical handoff requires PostgreSQL"
+                    .to_string(),
+            );
+        }
+        if control_plane_tenant_id.is_nil() {
+            return Err(
+                "Comments schedule audit canonical handoff requires a non-nil control-plane tenant ID"
+                    .to_string(),
+            );
+        }
+        let claim_ttl_seconds = claim_ttl.as_secs();
+        if claim_ttl_seconds == 0
+            || claim_ttl_seconds
+                > COMMENTS_TCP_DELEGATION_SCHEDULE_AUDIT_HANDOFF_MAX_CLAIM_SECONDS
+            || claim_ttl != Duration::from_secs(claim_ttl_seconds)
+        {
+            return Err(format!(
+                "Comments schedule audit canonical handoff claim TTL must be a whole second in 1..={COMMENTS_TCP_DELEGATION_SCHEDULE_AUDIT_HANDOFF_MAX_CLAIM_SECONDS}"
+            ));
+        }
+        let claim_ttl_seconds = i64::try_from(claim_ttl_seconds).map_err(|_| {
+            "Comments schedule audit canonical handoff claim TTL is out of range"
+                .to_string()
+        })?;
+        Ok(Self {
+            database,
+            control_plane_tenant_id,
+            writer,
+            claim_ttl_seconds,
+        })
+    }
+
+    /// Claims one unpublished Blog audit row without waiting behind another
+    /// claimant. Expired claims are eligible for bounded recovery.
+    pub async fn claim_next(
+        &self,
+    ) -> std::result::Result<
+        Option<CommentsTcpDelegationScheduleAuditHandoffClaim>,
+        CommentsTcpDelegationScheduleAuditHandoffError,
+    > {
+        let claim_token = Uuid::new_v4();
+        let transaction = self.database.begin().await.map_err(unavailable)?;
+        let row = transaction
+            .query_one(claim_next_statement(claim_token, self.claim_ttl_seconds))
+            .await
+            .map_err(unavailable)?;
+        let Some(row) = row else {
+            transaction.commit().await.map_err(unavailable)?;
+            return Ok(None);
+        };
+        let claim = decode_claim(&row, claim_token)?;
+        match transaction.commit().await {
+            Ok(()) => Ok(Some(claim)),
+            Err(error) => {
+                tracing::warn!(error = %error, claim_token = %claim_token, "Comments schedule audit claim commit acknowledgement was ambiguous");
+                self.reconcile_claim(claim_token).await.map(Some)
+            }
+        }
+    }
+
+    /// Writes the canonical event and marks the exact Blog audit row published
+    /// in one caller transaction. The source claim token and attempt count fence
+    /// stale workers. Exact terminal replay returns the stored envelope UUID.
+    pub async fn publish_claimed(
+        &self,
+        claim: CommentsTcpDelegationScheduleAuditHandoffClaim,
+    ) -> std::result::Result<Uuid, CommentsTcpDelegationScheduleAuditHandoffError> {
+        validate_claim(claim)?;
+        let transaction = self.database.begin().await.map_err(unavailable)?;
+        let row = transaction
+            .query_one(read_for_publish_statement(claim.request_id))
+            .await
+            .map_err(unavailable)?;
+        let Some(row) = row else {
+            let _ = transaction.rollback().await;
+            return Err(CommentsTcpDelegationScheduleAuditHandoffError::Conflict);
+        };
+        let stored = StoredAuditHandoffRecord::from_row(&row)?;
+
+        if stored.is_exact_terminal() {
+            let _ = transaction.rollback().await;
+            return Ok(claim.request_id);
+        }
+        if stored.has_invalid_terminal_pair() {
+            let _ = transaction.rollback().await;
+            return Err(CommentsTcpDelegationScheduleAuditHandoffError::Unavailable);
+        }
+        if !stored.matches_claim(claim) {
+            let _ = transaction.rollback().await;
+            return Err(CommentsTcpDelegationScheduleAuditHandoffError::Conflict);
+        }
+
+        let publication = stored.publication(self.control_plane_tenant_id)?;
+        let canonical_envelope_id = match self
+            .writer
+            .write_once_in_transaction(&transaction, &publication)
+            .await
+        {
+            Ok(envelope_id) if envelope_id == claim.request_id => envelope_id,
+            Ok(_) => {
+                let _ = transaction.rollback().await;
+                return Err(CommentsTcpDelegationScheduleAuditHandoffError::Unavailable);
+            }
+            Err(error) => {
+                let mapped = map_writer_error(error);
+                let _ = transaction.rollback().await;
+                return Err(mapped);
+            }
+        };
+
+        let updated = transaction
+            .execute(mark_published_statement(claim))
+            .await
+            .map_err(unavailable)?
+            .rows_affected();
+        if updated != 1 {
+            let _ = transaction.rollback().await;
+            return Err(CommentsTcpDelegationScheduleAuditHandoffError::Conflict);
+        }
+
+        match transaction.commit().await {
+            Ok(()) => Ok(canonical_envelope_id),
+            Err(error) => {
+                tracing::warn!(error = %error, request_id = %claim.request_id, "Comments schedule audit publication commit acknowledgement was ambiguous");
+                self.reconcile_publication(claim.request_id).await
+            }
+        }
+    }
+
+    pub async fn publish_next(
+        &self,
+    ) -> std::result::Result<Option<Uuid>, CommentsTcpDelegationScheduleAuditHandoffError> {
+        let Some(claim) = self.claim_next().await? else {
+            return Ok(None);
+        };
+        self.publish_claimed(claim).await.map(Some)
+    }
+
+    async fn reconcile_claim(
+        &self,
+        claim_token: Uuid,
+    ) -> std::result::Result<
+        CommentsTcpDelegationScheduleAuditHandoffClaim,
+        CommentsTcpDelegationScheduleAuditHandoffError,
+    > {
+        let row = self
+            .database
+            .query_one(read_claim_statement(claim_token))
+            .await
+            .map_err(unavailable)?
+            .ok_or(CommentsTcpDelegationScheduleAuditHandoffError::Unavailable)?;
+        let request_id: Uuid = row.try_get("", "request_id").map_err(unavailable)?;
+        let attempt_count: i64 = row
+            .try_get("", "handoff_attempt_count")
+            .map_err(unavailable)?;
+        let claim_active: bool = row.try_get("", "claim_active").map_err(unavailable)?;
+        let claim = CommentsTcpDelegationScheduleAuditHandoffClaim {
+            request_id,
+            claim_token,
+            attempt_count,
+        };
+        validate_claim(claim)?;
+        if !claim_active {
+            return Err(CommentsTcpDelegationScheduleAuditHandoffError::Unavailable);
+        }
+        Ok(claim)
+    }
+
+    async fn reconcile_publication(
+        &self,
+        request_id: Uuid,
+    ) -> std::result::Result<Uuid, CommentsTcpDelegationScheduleAuditHandoffError> {
+        let row = self
+            .database
+            .query_one(read_publication_statement(request_id))
+            .await
+            .map_err(unavailable)?
+            .ok_or(CommentsTcpDelegationScheduleAuditHandoffError::Unavailable)?;
+        let canonical_envelope_id: Option<Uuid> = row
+            .try_get("", "canonical_envelope_id")
+            .map_err(unavailable)?;
+        let published: bool = row.try_get("", "published").map_err(unavailable)?;
+        if published && canonical_envelope_id == Some(request_id) {
+            Ok(request_id)
+        } else {
+            Err(CommentsTcpDelegationScheduleAuditHandoffError::Unavailable)
+        }
+    }
+}
+
+impl fmt::Debug for PostgresCommentsTcpDelegationScheduleAuditCanonicalHandoff {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PostgresCommentsTcpDelegationScheduleAuditCanonicalHandoff")
+            .field("database", &"[CONFIGURED]")
+            .field("control_plane_tenant_id", &self.control_plane_tenant_id)
+            .field("writer", &"[CONFIGURED]")
+            .field("claim_ttl_seconds", &self.claim_ttl_seconds)
+            .finish()
+    }
+}
+
+impl StoredAuditHandoffRecord {
+    fn from_row(row: &QueryResult) -> std::result::Result<Self, CommentsTcpDelegationScheduleAuditHandoffError> {
+        Ok(Self {
+            audit_schema_version: row.try_get("", "audit_schema_version").map_err(unavailable)?,
+            request_id: row.try_get("", "request_id").map_err(unavailable)?,
+            state_key: row.try_get("", "state_key").map_err(unavailable)?,
+            event_type: row.try_get("", "event_type").map_err(unavailable)?,
+            occurred_at_unix_ms: row.try_get("", "occurred_at_unix_ms").map_err(unavailable)?,
+            actor_id: row.try_get("", "actor_id").map_err(unavailable)?,
+            principal_kind: row.try_get("", "principal_kind").map_err(unavailable)?,
+            operation: row.try_get("", "operation").map_err(unavailable)?,
+            source: row.try_get("", "source").map_err(unavailable)?,
+            previous_generation: row.try_get("", "previous_generation").map_err(unavailable)?,
+            candidate_generation: row.try_get("", "candidate_generation").map_err(unavailable)?,
+            outcome: row.try_get("", "outcome").map_err(unavailable)?,
+            canonical_envelope_id: row.try_get("", "canonical_envelope_id").map_err(unavailable)?,
+            published: row.try_get("", "published").map_err(unavailable)?,
+            claim_token: row.try_get("", "handoff_claim_token").map_err(unavailable)?,
+            claim_attempt_count: row.try_get("", "handoff_attempt_count").map_err(unavailable)?,
+            claim_active: row.try_get("", "claim_active").map_err(unavailable)?,
+        })
+    }
+
+    fn is_exact_terminal(&self) -> bool {
+        self.published
+            && self.canonical_envelope_id == Some(self.request_id)
+            && self.claim_token.is_none()
+    }
+
+    fn has_invalid_terminal_pair(&self) -> bool {
+        self.published != self.canonical_envelope_id.is_some()
+            || self
+                .canonical_envelope_id
+                .is_some_and(|envelope_id| envelope_id != self.request_id)
+    }
+
+    fn matches_claim(&self, claim: CommentsTcpDelegationScheduleAuditHandoffClaim) -> bool {
+        !self.published
+            && self.canonical_envelope_id.is_none()
+            && self.claim_token == Some(claim.claim_token)
+            && self.claim_attempt_count == claim.attempt_count
+            && self.claim_active
+    }
+
+    fn publication(
+        &self,
+        control_plane_tenant_id: Uuid,
+    ) -> std::result::Result<
+        CommentsTcpDelegationScheduleAuditCanonicalPublication,
+        CommentsTcpDelegationScheduleAuditHandoffError,
+    > {
+        if self.audit_schema_version
+            != i16::try_from(
+                postgres_audit::COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_AUDIT_SCHEMA_VERSION,
+            )
+            .map_err(unavailable)?
+            || self.request_id.is_nil()
+            || self.actor_id.is_nil()
+            || self.state_key != postgres::COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_STATE_KEY
+            || self.event_type
+                != postgres_audit::COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_AUDIT_EVENT_TYPE
+            || self.occurred_at_unix_ms <= 0
+            || self.previous_generation <= 0
+            || self.candidate_generation <= self.previous_generation
+            || self.outcome != "replacement_succeeded"
+        {
+            return Err(CommentsTcpDelegationScheduleAuditHandoffError::Unavailable);
+        }
+        let principal_kind = principal_kind_from_text(self.principal_kind.as_str())
+            .ok_or(CommentsTcpDelegationScheduleAuditHandoffError::Unavailable)?;
+        let operation = operation_from_text(self.operation.as_str())
+            .ok_or(CommentsTcpDelegationScheduleAuditHandoffError::Unavailable)?;
+        let source = source_from_text(self.source.as_str())
+            .ok_or(CommentsTcpDelegationScheduleAuditHandoffError::Unavailable)?;
+        CommentsTcpDelegationScheduleAuditCanonicalPublication::new(
+            control_plane_tenant_id,
+            self.request_id,
+            self.actor_id,
+            principal_kind,
+            operation,
+            source,
+            u64::try_from(self.occurred_at_unix_ms).map_err(unavailable)?,
+            u64::try_from(self.previous_generation).map_err(unavailable)?,
+            u64::try_from(self.candidate_generation).map_err(unavailable)?,
+        )
+        .map_err(unavailable)
+    }
+}
+
+fn validate_claim(
+    claim: CommentsTcpDelegationScheduleAuditHandoffClaim,
+) -> std::result::Result<(), CommentsTcpDelegationScheduleAuditHandoffError> {
+    if claim.request_id.is_nil() || claim.claim_token.is_nil() || claim.attempt_count <= 0 {
+        return Err(CommentsTcpDelegationScheduleAuditHandoffError::Unavailable);
+    }
+    Ok(())
+}
+
+fn decode_claim(
+    row: &QueryResult,
+    claim_token: Uuid,
+) -> std::result::Result<
+    CommentsTcpDelegationScheduleAuditHandoffClaim,
+    CommentsTcpDelegationScheduleAuditHandoffError,
+> {
+    let claim = CommentsTcpDelegationScheduleAuditHandoffClaim {
+        request_id: row.try_get("", "request_id").map_err(unavailable)?,
+        claim_token,
+        attempt_count: row
+            .try_get("", "handoff_attempt_count")
+            .map_err(unavailable)?,
+    };
+    validate_claim(claim)?;
+    Ok(claim)
+}
+
+const fn map_writer_error(
+    error: CommentsTcpDelegationScheduleAuditCanonicalWriteError,
+) -> CommentsTcpDelegationScheduleAuditHandoffError {
+    match error {
+        CommentsTcpDelegationScheduleAuditCanonicalWriteError::Conflict => {
+            CommentsTcpDelegationScheduleAuditHandoffError::Conflict
+        }
+        CommentsTcpDelegationScheduleAuditCanonicalWriteError::Unavailable => {
+            CommentsTcpDelegationScheduleAuditHandoffError::Unavailable
+        }
+    }
+}
+
+fn unavailable(error: impl fmt::Display) -> CommentsTcpDelegationScheduleAuditHandoffError {
+    tracing::error!(error = %error, "Comments schedule audit canonical handoff is unavailable");
+    CommentsTcpDelegationScheduleAuditHandoffError::Unavailable
+}
+
+fn principal_kind_from_text(value: &str) -> Option<AuthPrincipalKind> {
+    match value {
+        "direct_user" => Some(AuthPrincipalKind::DirectUser),
+        "service" => Some(AuthPrincipalKind::Service),
+        _ => None,
+    }
+}
+
+fn operation_from_text(value: &str) -> Option<trigger::CommentsTcpDelegationScheduleTriggerOperation> {
+    match value {
+        "reload_file" => Some(trigger::CommentsTcpDelegationScheduleTriggerOperation::ReloadFile),
+        "replace_host_schedule" => Some(
+            trigger::CommentsTcpDelegationScheduleTriggerOperation::ReplaceHostSchedule,
+        ),
+        _ => None,
+    }
+}
+
+fn source_from_text(value: &str) -> Option<keyring::CommentsTcpDelegationKeyringSource> {
+    match value {
+        "host_provided" => Some(keyring::CommentsTcpDelegationKeyringSource::HostProvided),
+        "file" => Some(keyring::CommentsTcpDelegationKeyringSource::File),
+        _ => None,
+    }
+}
+
+fn claim_next_statement(claim_token: Uuid, claim_ttl_seconds: i64) -> Statement {
+    Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        format!(
+            "WITH candidate AS ( \
+                 SELECT request_id \
+                 FROM {table} \
+                 WHERE published_at IS NULL \
+                   AND canonical_envelope_id IS NULL \
+                   AND (handoff_claim_token IS NULL OR handoff_claim_expires_at <= NOW()) \
+                 ORDER BY created_at ASC, request_id ASC \
+                 FOR UPDATE SKIP LOCKED \
+                 LIMIT 1 \
+             ) \
+             UPDATE {table} AS audit \
+             SET handoff_claim_token = $1, \
+                 handoff_claim_expires_at = NOW() + ($2::bigint * INTERVAL '1 second'), \
+                 handoff_attempt_count = handoff_attempt_count + 1 \
+             FROM candidate \
+             WHERE audit.request_id = candidate.request_id \
+             RETURNING audit.request_id, audit.handoff_attempt_count",
+            table = postgres_audit::COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_AUDIT_OUTBOX_TABLE,
+        ),
+        vec![claim_token.into(), claim_ttl_seconds.into()],
+    )
+}
+
+fn read_claim_statement(claim_token: Uuid) -> Statement {
+    Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        format!(
+            "SELECT request_id, handoff_attempt_count, \
+                    COALESCE(handoff_claim_expires_at > NOW(), FALSE) AS claim_active \
+             FROM {table} \
+             WHERE handoff_claim_token = $1 \
+               AND published_at IS NULL \
+               AND canonical_envelope_id IS NULL",
+            table = postgres_audit::COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_AUDIT_OUTBOX_TABLE,
+        ),
+        vec![claim_token.into()],
+    )
+}
+
+fn read_for_publish_statement(request_id: Uuid) -> Statement {
+    Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        format!(
+            "SELECT audit_schema_version, request_id, state_key, event_type, \
+                    occurred_at_unix_ms, actor_id, principal_kind, operation, source, \
+                    previous_generation, candidate_generation, outcome, \
+                    canonical_envelope_id, published_at IS NOT NULL AS published, \
+                    handoff_claim_token, handoff_attempt_count, \
+                    COALESCE(handoff_claim_expires_at > NOW(), FALSE) AS claim_active \
+             FROM {table} \
+             WHERE request_id = $1 \
+             FOR UPDATE",
+            table = postgres_audit::COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_AUDIT_OUTBOX_TABLE,
+        ),
+        vec![request_id.into()],
+    )
+}
+
+fn mark_published_statement(claim: CommentsTcpDelegationScheduleAuditHandoffClaim) -> Statement {
+    Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        format!(
+            "UPDATE {table} \
+             SET canonical_envelope_id = request_id, \
+                 published_at = NOW(), \
+                 handoff_claim_token = NULL, \
+                 handoff_claim_expires_at = NULL \
+             WHERE request_id = $1 \
+               AND published_at IS NULL \
+               AND canonical_envelope_id IS NULL \
+               AND handoff_claim_token = $2 \
+               AND handoff_attempt_count = $3 \
+               AND handoff_claim_expires_at > NOW()",
+            table = postgres_audit::COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_AUDIT_OUTBOX_TABLE,
+        ),
+        vec![
+            claim.request_id.into(),
+            claim.claim_token.into(),
+            claim.attempt_count.into(),
+        ],
+    )
+}
+
+fn read_publication_statement(request_id: Uuid) -> Statement {
+    Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        format!(
+            "SELECT canonical_envelope_id, published_at IS NOT NULL AS published \
+             FROM {table} WHERE request_id = $1",
+            table = postgres_audit::COMMENTS_TCP_DELEGATION_SCHEDULE_POSTGRES_AUDIT_OUTBOX_TABLE,
+        ),
+        vec![request_id.into()],
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_value_parsers_reject_unknown_contract_values() {
+        assert_eq!(principal_kind_from_text("service"), Some(AuthPrincipalKind::Service));
+        assert!(principal_kind_from_text("delegated_user").is_none());
+        assert!(operation_from_text("unknown").is_none());
+        assert!(source_from_text("unknown").is_none());
+    }
+
+    #[test]
+    fn claim_requires_non_nil_fencing_identity_and_positive_attempt() {
+        assert!(validate_claim(CommentsTcpDelegationScheduleAuditHandoffClaim {
+            request_id: Uuid::nil(),
+            claim_token: Uuid::new_v4(),
+            attempt_count: 1,
+        })
+        .is_err());
+        assert!(validate_claim(CommentsTcpDelegationScheduleAuditHandoffClaim {
+            request_id: Uuid::new_v4(),
+            claim_token: Uuid::new_v4(),
+            attempt_count: 0,
+        })
+        .is_err());
+    }
+
+    #[test]
+    fn claim_sql_is_skip_locked_and_expiry_bounded() {
+        let statement = claim_next_statement(Uuid::new_v4(), 60);
+        let sql = statement.sql.as_str();
+        assert!(sql.contains("FOR UPDATE SKIP LOCKED"));
+        assert!(sql.contains("handoff_claim_expires_at <= NOW()"));
+        assert!(sql.contains("handoff_attempt_count = handoff_attempt_count + 1"));
+    }
+}

--- a/crates/rustok-blog/contracts/evidence/blog-comments-audit-canonical-handoff-postgres.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-audit-canonical-handoff-postgres.json
@@ -1,0 +1,116 @@
+{
+  "schema_version": 1,
+  "reviewed_at_utc": "2026-08-03T11:55:00Z",
+  "review_base": "e557f06aec0dd55f1b15e5319c5557a8b302a35c",
+  "logical_tree_base": "0fc0c3130307a9ec514f8cc278ba882545a45d5a",
+  "status": "canonical_handoff_source_ready_maintainer_execution_pending",
+  "scope": "Blog Comments schedule audit PostgreSQL source-to-canonical handoff",
+  "source_row": {
+    "table": "blog_comments_tcp_delegation_schedule_audit_outbox",
+    "source_identity": "request_id",
+    "source_identity_is_canonical_envelope_id": true,
+    "state_and_source_audit_insert_remain_atomic": true,
+    "legacy_published_rows_fail_migration_closed": true
+  },
+  "migration": {
+    "name": "m20260803_000009_add_blog_comments_audit_canonical_handoff",
+    "irreversible": true,
+    "canonical_envelope_id_added": true,
+    "handoff_claim_token_added": true,
+    "handoff_claim_expires_at_added": true,
+    "handoff_attempt_count_added": true,
+    "canonical_envelope_unique": true,
+    "claim_token_unique": true,
+    "pending_scan_index_added": true,
+    "attempt_non_negative_check": true,
+    "claim_token_expiry_pair_check": true,
+    "claim_token_non_nil_check": true,
+    "terminal_identity_pair_check": true,
+    "terminal_row_unclaimed_check": true
+  },
+  "claim": {
+    "api": "PostgresCommentsTcpDelegationScheduleAuditCanonicalHandoff::claim_next",
+    "oldest_first": true,
+    "for_update_skip_locked": true,
+    "unpublished_only": true,
+    "uncanonicalized_only": true,
+    "expired_claim_recovery": true,
+    "random_non_nil_claim_token": true,
+    "durable_attempt_increment": true,
+    "claim_ttl_seconds_min": 1,
+    "claim_ttl_seconds_max": 300,
+    "claim_commit_ambiguity_readback_by_unique_token": true
+  },
+  "publication": {
+    "api": "PostgresCommentsTcpDelegationScheduleAuditCanonicalHandoff::publish_claimed",
+    "source_row_locked_for_update": true,
+    "claim_token_fenced": true,
+    "attempt_count_fenced": true,
+    "active_expiry_fenced": true,
+    "source_payload_revalidated": true,
+    "canonical_writer_called_in_same_transaction": true,
+    "returned_envelope_must_equal_request_id": true,
+    "source_terminal_update_in_same_transaction": true,
+    "terminal_update_repeats_claim_fence": true,
+    "exact_terminal_replay_returns_request_id": true,
+    "ambiguous_commit_reconciled_by_terminal_identity_pair": true
+  },
+  "closed_errors": {
+    "conflict": "claim or stable identity mismatch",
+    "unavailable": "invalid durable state or infrastructure failure",
+    "raw_database_details_returned": false,
+    "raw_writer_details_returned": false
+  },
+  "ownership": {
+    "blog_owns_source_claim": true,
+    "blog_owns_source_fencing": true,
+    "blog_owns_source_terminal_acknowledgement": true,
+    "rustok_outbox_owns_sys_events": true,
+    "rustok_outbox_owns_canonical_relay": true,
+    "rustok_outbox_owns_retry_and_dlq": true,
+    "second_relay_added": false,
+    "second_canonical_claim_added": false
+  },
+  "runtime_boundary": {
+    "public_owner_exported": true,
+    "runtime_extension_registered": false,
+    "worker_spawned": false,
+    "polling_loop_added": false,
+    "environment_switch_added": false,
+    "heartbeat_added": false,
+    "automatic_retry_policy_added": false,
+    "source_dead_letter_added": false
+  },
+  "preserved_contracts": {
+    "registered_event_payload_changed": false,
+    "event_type_changed": false,
+    "event_digest_changed": false,
+    "sys_events_schema_changed": false,
+    "outbox_relay_changed": false,
+    "schedule_authorization_changed": false,
+    "schedule_state_write_changed": false,
+    "blog_audit_insert_changed": false,
+    "module_manifest_changed": false
+  },
+  "validation": {
+    "cargo_check_run": false,
+    "rust_unit_tests_run": false,
+    "rust_integration_tests_run": false,
+    "javascript_verifier_run": false,
+    "migration_applied": false,
+    "postgresql_run": false,
+    "concurrency_run": false,
+    "restart_run": false,
+    "runtime_run": false,
+    "production_run": false
+  },
+  "next_cursor": {
+    "compose_host_owned_runner": true,
+    "add_cooperative_shutdown": true,
+    "define_retry_and_exhaustion_policy": true,
+    "define_source_dead_letter_and_requeue": true,
+    "add_claim_heartbeat_if_required": true,
+    "prove_postgresql_concurrency_and_recovery": true,
+    "define_source_retention": true
+  }
+}

--- a/crates/rustok-blog/docs/implementation-plan-slice-90.md
+++ b/crates/rustok-blog/docs/implementation-plan-slice-90.md
@@ -1,0 +1,232 @@
+# rustok-blog implementation plan — slice 90 continuation
+
+This document continues
+`crates/rustok-blog/docs/implementation-plan-slice-89.md`.
+
+Slices 83–89 retain the PostgreSQL schedule-state/audit transaction, fail-stop
+handling for indeterminate audited writes, the bounded canonical publication
+port, the sealed registered Blog Comments schedule-audit event, and the
+`rustok-outbox` typed write-once canonical writer.
+
+## 2026-08-03 continuation audit
+
+A fresh audit of `main` found that one ownership gap remained:
+
+- successful schedule replacement already commits the new schedule state and one
+  immutable Blog audit row in the same PostgreSQL transaction;
+- the Blog audit row already owns the durable non-nil `request_id` used by slice
+  89 as the canonical envelope UUID;
+- the slice-89 writer can insert or resolve the exact typed `sys_events` row in a
+  caller-owned transaction;
+- no production path claims an unpublished Blog audit row, invokes that writer,
+  and marks the exact source row published in the same transaction;
+- the existing nullable `published_at` field has no canonical envelope identity
+  or stale-worker fencing metadata;
+- `rustok-outbox` already owns canonical relay, retry, claim, DLQ, and retention,
+  so the Blog side must only own source-row handoff admission.
+
+## Slice 90 — PostgreSQL atomic source-to-canonical handoff
+
+### Irreversible schema extension
+
+Migration
+`m20260803_000009_add_blog_comments_audit_canonical_handoff` adds:
+
+```text
+canonical_envelope_id UUID NULL
+handoff_claim_token UUID NULL
+handoff_claim_expires_at TIMESTAMPTZ NULL
+handoff_attempt_count BIGINT NOT NULL DEFAULT 0
+```
+
+The migration is intentionally irreversible. PostgreSQL checks require:
+
+- a non-negative handoff attempt count;
+- claim token and expiry to be both null or both present;
+- every claim token to be non-nil;
+- a terminal row to have both `published_at` and
+  `canonical_envelope_id = request_id`;
+- a published row to have no remaining source claim.
+
+Unique indexes bind one canonical envelope identity and one claim token to at
+most one Blog audit row. A bounded pending index supports oldest-first claim
+selection.
+
+The migration fails closed if a pre-existing row already uses `published_at`
+without the canonical identity introduced here. It does not guess or backfill a
+canonical event that cannot be proven.
+
+### Explicit handoff owner
+
+The server publishes:
+
+```text
+PostgresCommentsTcpDelegationScheduleAuditCanonicalHandoff
+```
+
+Construction requires:
+
+- a PostgreSQL `DatabaseConnection`;
+- a non-nil host control-plane tenant UUID;
+- the slice-87 canonical writer port;
+- a whole-second source claim TTL in `1..=300` seconds.
+
+The owner exposes explicit calls only:
+
+```text
+claim_next()
+publish_claimed(claim)
+publish_next()
+```
+
+This slice does not register the owner in runtime extensions, spawn a task, add
+an environment switch, or start a polling loop.
+
+### Bounded source-row claiming
+
+`claim_next()` opens a short PostgreSQL transaction and selects one oldest
+eligible source row using:
+
+```text
+FOR UPDATE SKIP LOCKED
+```
+
+A row is eligible only when:
+
+- `published_at IS NULL`;
+- `canonical_envelope_id IS NULL`;
+- no claim exists, or the previous claim has expired.
+
+The same statement writes one random non-nil claim token, a bounded expiry, and
+increments the durable attempt count. The returned claim contains only:
+
+```text
+request_id
+claim_token
+attempt_count
+```
+
+A claim-commit acknowledgement failure is reconciled by the unique claim token.
+No transport or canonical outbox row is touched during claim acquisition.
+
+### Fenced atomic publication
+
+`publish_claimed()` locks the exact Blog audit row with `FOR UPDATE` and validates:
+
+- the request, actor, state, source, operation, generations, outcome, and schema;
+- the exact claim token;
+- the exact durable attempt count;
+- a still-active claim expiry;
+- absence of a conflicting canonical/published terminal pair.
+
+It then builds the bounded slice-87 publication and invokes:
+
+```text
+CommentsTcpDelegationScheduleAuditCanonicalWriter::write_once_in_transaction
+```
+
+inside the same PostgreSQL transaction. The writer must return the exact source
+`request_id` as the canonical envelope UUID.
+
+Only after canonical admission succeeds does the same transaction update the
+source row to:
+
+```text
+canonical_envelope_id = request_id
+published_at = NOW()
+handoff_claim_token = NULL
+handoff_claim_expires_at = NULL
+```
+
+The final update repeats the request/token/attempt/active-expiry fence. If a
+claim expires or is replaced, both the canonical insert and source update roll
+back together.
+
+### Exact replay and ambiguous commit handling
+
+An already-terminal exact source row returns its stored `request_id` without a
+second canonical event. A mismatched claim or replaced attempt returns the
+closed `Conflict` error. Invalid or unreadable durable state returns the closed
+`Unavailable` error.
+
+If the final commit acknowledgement is ambiguous, the owner reads the exact
+source row. Success is admitted only when:
+
+```text
+published_at IS NOT NULL
+canonical_envelope_id = request_id
+```
+
+Because the `sys_events` write and source terminal update share one transaction,
+that pair is the durable acknowledgement boundary. No separate Blog receipt or
+canonical relay lease is introduced.
+
+### Preserved ownership
+
+Slice 90 does not modify:
+
+- the registered Blog event type, payload, schema version, or generated digest;
+- the generic slice-89 write-once comparison algorithm;
+- `sys_events` schema or migration;
+- `OutboxRelay`, canonical claims, retry/backoff, DLQ, or retention;
+- schedule replacement authorization, signing, verification, replay, channel,
+  or key lifecycle behavior;
+- the existing atomic schedule-state plus Blog-audit insert transaction;
+- listener startup, runtime manifests, module dependencies, or environment
+  configuration.
+
+### Explicit non-claims
+
+Slice 90 does not claim:
+
+- that a host-owned handoff loop is mounted or running;
+- heartbeat or claim extension during long publication;
+- automatic retry, delay, jitter, exhaustion, or operator requeue policy;
+- a dead-letter state for the Blog source row;
+- source-row retention or cleanup;
+- PostgreSQL migration, concurrency, restart, or ambiguous-commit execution;
+- Rust unit or integration test execution;
+- JavaScript verifier execution;
+- Cargo check, formatting, Clippy, workflow, runtime, or production validation.
+
+Status: `canonical_handoff_source_ready_maintainer_execution_pending`.
+Test policy: `not_run_by_request`.
+Verifier policy: `not_run_by_request`.
+
+## Next implementation results
+
+1. Compose one host-owned bounded handoff runner from this explicit owner and the
+   slice-89 writer.
+2. Define idle polling, retry delay, attempt exhaustion, source dead-letter and
+   operator recovery policy without reusing canonical outbox relay fields.
+3. Add cooperative shutdown and, if publication work can exceed the bounded
+   claim TTL, a fenced source-claim heartbeat.
+4. Prove concurrent `SKIP LOCKED` claiming, stale claim takeover, stale-worker
+   rollback, exact replay, writer conflict, and commit-acknowledgement ambiguity
+   against PostgreSQL.
+5. Prove restart recovery and canonical `OutboxRelay` delivery/retry/DLQ as a
+   separate execution lane.
+6. Define Blog source-audit retention independently from canonical `sys_events`
+   retention.
+
+## Suggested maintainer verification — intentionally not run
+
+```bash
+cargo check -p rustok-blog --all-targets --locked
+cargo check -p rustok-server --no-default-features --features mod-blog --locked
+cargo test -p rustok-server --features mod-blog \
+  comments_provider_runtime::keyring_schedule_audit_handoff_postgres \
+  -- --nocapture
+node scripts/verify/verify-blog-comments-audit-canonical-handoff-postgres.mjs
+```
+
+## Ownership retained
+
+- Blog owns the durable source audit row, source claim, source fencing, terminal
+  source acknowledgement, and future source retention policy.
+- The server owns control-plane tenant selection and the explicit handoff owner.
+- `rustok-events` owns the sealed canonical payload and envelope validation.
+- `rustok-outbox` owns canonical `sys_events` admission, relay, retry, DLQ, and
+  canonical retention.
+- Maintainers own migration, test, verifier, PostgreSQL, runtime, and production
+  validation.

--- a/crates/rustok-blog/src/migrations/m20260803_000009_add_blog_comments_audit_canonical_handoff.rs
+++ b/crates/rustok-blog/src/migrations/m20260803_000009_add_blog_comments_audit_canonical_handoff.rs
@@ -1,0 +1,141 @@
+use sea_orm_migration::{prelude::*, sea_orm::ConnectionTrait};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        add_column_if_missing(
+            manager,
+            ColumnDef::new(BlogCommentsDelegationScheduleAuditOutbox::CanonicalEnvelopeId)
+                .uuid()
+                .to_owned(),
+        )
+        .await?;
+        add_column_if_missing(
+            manager,
+            ColumnDef::new(BlogCommentsDelegationScheduleAuditOutbox::HandoffClaimToken)
+                .uuid()
+                .to_owned(),
+        )
+        .await?;
+        add_column_if_missing(
+            manager,
+            ColumnDef::new(BlogCommentsDelegationScheduleAuditOutbox::HandoffClaimExpiresAt)
+                .timestamp_with_time_zone()
+                .to_owned(),
+        )
+        .await?;
+        add_column_if_missing(
+            manager,
+            ColumnDef::new(BlogCommentsDelegationScheduleAuditOutbox::HandoffAttemptCount)
+                .big_integer()
+                .not_null()
+                .default(0)
+                .to_owned(),
+        )
+        .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("uq_blog_comments_delegation_audit_canonical_envelope")
+                    .table(BlogCommentsDelegationScheduleAuditOutbox::Table)
+                    .col(BlogCommentsDelegationScheduleAuditOutbox::CanonicalEnvelopeId)
+                    .unique()
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_blog_comments_delegation_audit_handoff_pending")
+                    .table(BlogCommentsDelegationScheduleAuditOutbox::Table)
+                    .col(BlogCommentsDelegationScheduleAuditOutbox::PublishedAt)
+                    .col(BlogCommentsDelegationScheduleAuditOutbox::HandoffClaimExpiresAt)
+                    .col(BlogCommentsDelegationScheduleAuditOutbox::CreatedAt)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        if manager.get_database_backend() == DbBackend::Postgres {
+            manager
+                .get_connection()
+                .execute_unprepared(
+                    r#"
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM blog_comments_tcp_delegation_schedule_audit_outbox
+        WHERE published_at IS NOT NULL
+    ) THEN
+        RAISE EXCEPTION 'legacy Comments schedule audit rows already use published_at without canonical identity';
+    END IF;
+END
+$$;
+
+ALTER TABLE blog_comments_tcp_delegation_schedule_audit_outbox
+    ADD CONSTRAINT ck_blog_comments_delegation_audit_handoff_attempt_count
+    CHECK (handoff_attempt_count >= 0),
+    ADD CONSTRAINT ck_blog_comments_delegation_audit_handoff_claim_pair
+    CHECK ((handoff_claim_token IS NULL) = (handoff_claim_expires_at IS NULL)),
+    ADD CONSTRAINT ck_blog_comments_delegation_audit_handoff_claim_token_non_nil
+    CHECK (
+        handoff_claim_token IS NULL
+        OR handoff_claim_token <> '00000000-0000-0000-0000-000000000000'::uuid
+    ),
+    ADD CONSTRAINT ck_blog_comments_delegation_audit_handoff_publication_pair
+    CHECK (
+        (canonical_envelope_id IS NULL AND published_at IS NULL)
+        OR (canonical_envelope_id = request_id AND published_at IS NOT NULL)
+    ),
+    ADD CONSTRAINT ck_blog_comments_delegation_audit_handoff_terminal_unclaimed
+    CHECK (
+        published_at IS NULL
+        OR (handoff_claim_token IS NULL AND handoff_claim_expires_at IS NULL)
+    );
+"#,
+                )
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        Err(DbErr::Migration(
+            "Comments schedule audit canonical handoff metadata is security-sensitive and intentionally irreversible"
+                .to_string(),
+        ))
+    }
+}
+
+async fn add_column_if_missing(
+    manager: &SchemaManager<'_>,
+    column: ColumnDef,
+) -> Result<(), DbErr> {
+    manager
+        .alter_table(
+            Table::alter()
+                .table(BlogCommentsDelegationScheduleAuditOutbox::Table)
+                .add_column_if_not_exists(column)
+                .to_owned(),
+        )
+        .await
+}
+
+#[derive(DeriveIden)]
+enum BlogCommentsDelegationScheduleAuditOutbox {
+    #[sea_orm(iden = "blog_comments_tcp_delegation_schedule_audit_outbox")]
+    Table,
+    CanonicalEnvelopeId,
+    HandoffClaimToken,
+    HandoffClaimExpiresAt,
+    HandoffAttemptCount,
+    PublishedAt,
+    CreatedAt,
+}

--- a/crates/rustok-blog/src/migrations/m20260803_000009_add_blog_comments_audit_canonical_handoff.rs
+++ b/crates/rustok-blog/src/migrations/m20260803_000009_add_blog_comments_audit_canonical_handoff.rs
@@ -51,6 +51,17 @@ impl MigrationTrait for Migration {
         manager
             .create_index(
                 Index::create()
+                    .name("uq_blog_comments_delegation_audit_handoff_claim_token")
+                    .table(BlogCommentsDelegationScheduleAuditOutbox::Table)
+                    .col(BlogCommentsDelegationScheduleAuditOutbox::HandoffClaimToken)
+                    .unique()
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
                     .name("idx_blog_comments_delegation_audit_handoff_pending")
                     .table(BlogCommentsDelegationScheduleAuditOutbox::Table)
                     .col(BlogCommentsDelegationScheduleAuditOutbox::PublishedAt)

--- a/crates/rustok-blog/src/migrations/mod.rs
+++ b/crates/rustok-blog/src/migrations/mod.rs
@@ -6,6 +6,7 @@ mod m20260721_000005_expand_blog_locale_storage_columns;
 mod m20260730_000006_cutover_blog_article_richtext;
 mod m20260801_000007_create_blog_comments_delegation_schedule_state;
 mod m20260801_000008_create_blog_comments_delegation_schedule_audit_outbox;
+mod m20260803_000009_add_blog_comments_audit_canonical_handoff;
 
 use rustok_core::MigrationDependencyDescriptor;
 use sea_orm_migration::MigrationTrait;
@@ -23,6 +24,9 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         ),
         Box::new(
             m20260801_000008_create_blog_comments_delegation_schedule_audit_outbox::Migration,
+        ),
+        Box::new(
+            m20260803_000009_add_blog_comments_audit_canonical_handoff::Migration,
         ),
     ]
 }

--- a/scripts/verify/verify-blog-comments-audit-canonical-handoff-postgres.mjs
+++ b/scripts/verify/verify-blog-comments-audit-canonical-handoff-postgres.mjs
@@ -83,7 +83,7 @@ requireAll("handoff owner", service, [
   "FOR UPDATE SKIP LOCKED",
   "handoff_claim_expires_at <= NOW()",
   "handoff_attempt_count = handoff_attempt_count + 1",
-  "WHERE request_id = $1 \\\n             FOR UPDATE",
+  "WHERE request_id = $1",
   ".write_once_in_transaction(&transaction, &publication)",
   "canonical_envelope_id = request_id",
   "handoff_claim_token = NULL",

--- a/scripts/verify/verify-blog-comments-audit-canonical-handoff-postgres.mjs
+++ b/scripts/verify/verify-blog-comments-audit-canonical-handoff-postgres.mjs
@@ -83,7 +83,7 @@ requireAll("handoff owner", service, [
   "FOR UPDATE SKIP LOCKED",
   "handoff_claim_expires_at <= NOW()",
   "handoff_attempt_count = handoff_attempt_count + 1",
-  "FOR UPDATE\"",
+  "WHERE request_id = $1 \\\n             FOR UPDATE",
   ".write_once_in_transaction(&transaction, &publication)",
   "canonical_envelope_id = request_id",
   "handoff_claim_token = NULL",
@@ -137,7 +137,7 @@ requireAll("plan", plan, [
   "FOR UPDATE SKIP LOCKED",
   "same PostgreSQL transaction",
   "does not register the owner in runtime extensions",
-  "rustok-outbox already owns canonical relay",
+  "already owns canonical relay, retry, claim, DLQ, and retention",
 ]);
 
 if (

--- a/scripts/verify/verify-blog-comments-audit-canonical-handoff-postgres.mjs
+++ b/scripts/verify/verify-blog-comments-audit-canonical-handoff-postgres.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const read = (relativePath) =>
+  fs.readFileSync(path.join(root, relativePath), "utf8");
+
+const migrationPath =
+  "crates/rustok-blog/src/migrations/m20260803_000009_add_blog_comments_audit_canonical_handoff.rs";
+const migrationsModPath = "crates/rustok-blog/src/migrations/mod.rs";
+const servicePath =
+  "apps/server/src/services/comments_provider_runtime_keyring_schedule_audit_handoff_postgres.rs";
+const runtimePath = "apps/server/src/services/comments_provider_runtime.rs";
+const planPath = "crates/rustok-blog/docs/implementation-plan-slice-90.md";
+const evidencePath =
+  "crates/rustok-blog/contracts/evidence/blog-comments-audit-canonical-handoff-postgres.json";
+
+for (const file of [
+  migrationPath,
+  migrationsModPath,
+  servicePath,
+  runtimePath,
+  planPath,
+  evidencePath,
+]) {
+  if (!fs.existsSync(path.join(root, file))) {
+    throw new Error(`required slice-90 file is missing: ${file}`);
+  }
+}
+
+const migration = read(migrationPath);
+const migrationsMod = read(migrationsModPath);
+const service = read(servicePath);
+const runtime = read(runtimePath);
+const plan = read(planPath);
+const evidenceText = read(evidencePath);
+const evidence = JSON.parse(evidenceText);
+
+function requireAll(label, text, markers) {
+  for (const marker of markers) {
+    if (!text.includes(marker)) {
+      throw new Error(`${label} is missing required marker: ${marker}`);
+    }
+  }
+}
+
+function forbidAll(label, text, markers) {
+  for (const marker of markers) {
+    if (text.includes(marker)) {
+      throw new Error(`${label} contains forbidden marker: ${marker}`);
+    }
+  }
+}
+
+requireAll("migration", migration, [
+  "CanonicalEnvelopeId",
+  "HandoffClaimToken",
+  "HandoffClaimExpiresAt",
+  "HandoffAttemptCount",
+  "uq_blog_comments_delegation_audit_canonical_envelope",
+  "uq_blog_comments_delegation_audit_handoff_claim_token",
+  "idx_blog_comments_delegation_audit_handoff_pending",
+  "handoff_attempt_count >= 0",
+  "handoff_claim_token IS NULL) = (handoff_claim_expires_at IS NULL",
+  "canonical_envelope_id = request_id AND published_at IS NOT NULL",
+  "legacy Comments schedule audit rows already use published_at without canonical identity",
+  "intentionally irreversible",
+]);
+
+requireAll("migration registration", migrationsMod, [
+  "mod m20260803_000009_add_blog_comments_audit_canonical_handoff;",
+  "m20260803_000009_add_blog_comments_audit_canonical_handoff::Migration",
+]);
+
+requireAll("handoff owner", service, [
+  "pub struct PostgresCommentsTcpDelegationScheduleAuditCanonicalHandoff",
+  "COMMENTS_TCP_DELEGATION_SCHEDULE_AUDIT_HANDOFF_MAX_CLAIM_SECONDS: u64 = 300",
+  "pub async fn claim_next",
+  "pub async fn publish_claimed",
+  "pub async fn publish_next",
+  "FOR UPDATE SKIP LOCKED",
+  "handoff_claim_expires_at <= NOW()",
+  "handoff_attempt_count = handoff_attempt_count + 1",
+  "FOR UPDATE\"",
+  ".write_once_in_transaction(&transaction, &publication)",
+  "canonical_envelope_id = request_id",
+  "handoff_claim_token = NULL",
+  "handoff_attempt_count = $3",
+  "handoff_claim_expires_at > NOW()",
+  "self.reconcile_claim(claim_token).await",
+  "self.reconcile_publication(claim.request_id).await",
+  "canonical_envelope_id == Some(request_id)",
+]);
+
+const writerCall = service.indexOf(
+  ".write_once_in_transaction(&transaction, &publication)",
+);
+const sourceTerminalUpdate = service.indexOf(
+  "let updated = transaction\n            .execute(mark_published_statement(claim))",
+);
+const commit = service.indexOf("match transaction.commit().await", writerCall);
+if (writerCall < 0 || sourceTerminalUpdate < writerCall || commit < sourceTerminalUpdate) {
+  throw new Error(
+    "canonical writer, fenced source update, and commit are not ordered in one transaction",
+  );
+}
+
+forbidAll("handoff owner", service, [
+  "tokio::spawn",
+  "std::thread::spawn",
+  "OutboxRelay",
+  "OutboxTransport::new",
+  "start_worker",
+  "consumer_group",
+  "dead_letter",
+]);
+
+requireAll("runtime publication", runtime, [
+  "mod keyring_schedule_audit_handoff_postgres",
+  "comments_provider_runtime_keyring_schedule_audit_handoff_postgres.rs",
+  "PostgresCommentsTcpDelegationScheduleAuditCanonicalHandoff",
+  "CommentsTcpDelegationScheduleAuditHandoffClaim",
+  "CommentsTcpDelegationScheduleAuditHandoffError",
+]);
+
+forbidAll("runtime composition", runtime, [
+  "PostgresCommentsTcpDelegationScheduleAuditCanonicalHandoff::new(",
+  "publish_next().await",
+  "start_comments_schedule_audit_handoff",
+]);
+
+requireAll("plan", plan, [
+  "# rustok-blog implementation plan — slice 90 continuation",
+  "canonical_handoff_source_ready_maintainer_execution_pending",
+  "FOR UPDATE SKIP LOCKED",
+  "same PostgreSQL transaction",
+  "does not register the owner in runtime extensions",
+  "rustok-outbox already owns canonical relay",
+]);
+
+if (
+  evidence.status !==
+  "canonical_handoff_source_ready_maintainer_execution_pending"
+) {
+  throw new Error(`unexpected evidence status: ${evidence.status}`);
+}
+
+const requiredEvidence = [
+  [evidence.migration?.irreversible, "migration.irreversible"],
+  [evidence.migration?.claim_token_unique, "migration.claim_token_unique"],
+  [evidence.claim?.for_update_skip_locked, "claim.for_update_skip_locked"],
+  [
+    evidence.claim?.expired_claim_recovery,
+    "claim.expired_claim_recovery",
+  ],
+  [
+    evidence.publication?.canonical_writer_called_in_same_transaction,
+    "publication.canonical_writer_called_in_same_transaction",
+  ],
+  [
+    evidence.publication?.source_terminal_update_in_same_transaction,
+    "publication.source_terminal_update_in_same_transaction",
+  ],
+  [
+    evidence.publication?.terminal_update_repeats_claim_fence,
+    "publication.terminal_update_repeats_claim_fence",
+  ],
+  [evidence.ownership?.rustok_outbox_owns_canonical_relay, "ownership.relay"],
+];
+for (const [value, label] of requiredEvidence) {
+  if (value !== true) {
+    throw new Error(`evidence must retain ${label}=true`);
+  }
+}
+
+const requiredFalseEvidence = [
+  [evidence.ownership?.second_relay_added, "ownership.second_relay_added"],
+  [evidence.runtime_boundary?.worker_spawned, "runtime.worker_spawned"],
+  [evidence.runtime_boundary?.polling_loop_added, "runtime.polling_loop_added"],
+  [evidence.runtime_boundary?.heartbeat_added, "runtime.heartbeat_added"],
+  [evidence.validation?.cargo_check_run, "validation.cargo_check_run"],
+  [evidence.validation?.rust_unit_tests_run, "validation.rust_unit_tests_run"],
+  [
+    evidence.validation?.javascript_verifier_run,
+    "validation.javascript_verifier_run",
+  ],
+  [evidence.validation?.postgresql_run, "validation.postgresql_run"],
+];
+for (const [value, label] of requiredFalseEvidence) {
+  if (value !== false) {
+    throw new Error(`evidence must retain ${label}=false`);
+  }
+}
+
+if (!evidenceText.endsWith("\n")) {
+  throw new Error("evidence JSON must end with a newline");
+}
+
+console.log(
+  "Blog Comments PostgreSQL canonical audit handoff source guard passed.",
+);


### PR DESCRIPTION
## Summary

Implement slice 90 of the Blog Comments delegation schedule audit plan.

- extend the immutable Blog audit row with canonical envelope identity and bounded source-claim fencing metadata;
- fail migration closed if legacy rows already use `published_at` without provable canonical identity;
- claim one oldest unpublished row with `FOR UPDATE SKIP LOCKED`, a unique non-nil token, bounded expiry, and durable attempt count;
- recover expired source claims without reusing canonical outbox claim fields;
- validate and fence the exact request/token/attempt/active-expiry tuple;
- call the slice-89 canonical writer and mark the Blog source row published in the same PostgreSQL transaction;
- reconcile ambiguous claim commits by unique claim token and ambiguous publication commits by `canonical_envelope_id = request_id` plus `published_at`;
- publish the explicit owner API without mounting a worker, polling loop, heartbeat, environment switch, or second relay.

## Ownership boundaries

Blog owns only the source audit row, source claim/fencing, terminal source acknowledgement, and future source retention policy. `rustok-outbox` continues to own `sys_events`, canonical relay claims, retries, DLQ, and canonical retention.

This PR does not change the registered Blog event payload/type/digest, generic write-once semantics, `sys_events` schema, `OutboxRelay`, schedule authorization/signing/replay behavior, the existing atomic schedule-state plus source-audit insert, runtime manifests, or environment configuration.

## Validation

Per maintainer instruction, no tests, JavaScript verifier, Cargo checks, formatting, Clippy, migration apply, PostgreSQL scenarios, workflows, runtime, or production validation were run.

Suggested maintainer commands:

```bash
cargo check -p rustok-blog --all-targets --locked
cargo check -p rustok-server --no-default-features --features mod-blog --locked
cargo test -p rustok-server --features mod-blog \
  comments_provider_runtime::keyring_schedule_audit_handoff_postgres \
  -- --nocapture
node scripts/verify/verify-blog-comments-audit-canonical-handoff-postgres.mjs
```

## Next cursor

Compose one host-owned bounded runner with cooperative shutdown, then define source retry/exhaustion/dead-letter/operator recovery and prove concurrent claiming, stale takeover, stale-worker rollback, restart, and ambiguous commits against PostgreSQL. Canonical delivery remains a separate `rustok-outbox` execution lane.