### PR TITLE
fix(fulfillment): bound storefront native diagnostics

### DIFF
--- a/crates/rustok-fulfillment/contracts/evidence/storefront-native-error-safety-source.json
+++ b/crates/rustok-fulfillment/contracts/evidence/storefront-native-error-safety-source.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-30",
+  "generated_at": "2026-08-03",
   "status": "fulfillment_storefront_native_error_safety_source_unvalidated",
   "scope": "fulfillment-owned storefront native shipping-selection server function",
   "source_contract": {
@@ -10,10 +10,15 @@
     "owner_runtime_static_public_envelope": true,
     "optional_request_context_preserved": true,
     "optional_request_context_failure_logged": true,
+    "framework_error_type_only": true,
+    "optional_request_context_error_type_only": true,
+    "owner_runtime_error_type_only": true,
+    "complete_internal_error_logged": false,
     "correlation_logging_when_available": true,
-    "tenant_logging": true,
-    "channel_logging_when_available": true,
-    "locale_logging_when_available": true,
+    "tenant_identity_shape_only": true,
+    "channel_context_shape_only_when_available": true,
+    "locale_shape_only_when_available": true,
+    "raw_tenant_channel_locale_logged": false,
     "stable_owner_operation": true,
     "outer_transport_variant_changed": false,
     "validation_messages_changed": false,
@@ -25,12 +30,32 @@
     "shipping_selection_unavailable": "Shipping selection is temporarily unavailable",
     "shipping_selection_context_unavailable": "Shipping selection context is unavailable"
   },
+  "preserved_behavior": [
+    "fulfillment/select-shipping-option endpoint path",
+    "TransactionalEventBus runtime resolution",
+    "tenant and optional authentication extraction order",
+    "optional RequestContext fallback to None",
+    "cart and shipping-option UUID validation messages",
+    "selection-plan validation and materialization",
+    "StorefrontShippingSelectionCommand payload",
+    "select_storefront_shipping_option owner call",
+    "outer ShippingSelectionTransportError::ServerFn compatibility wrapper"
+  ],
+  "forbidden_diagnostics": [
+    "complete framework or owner error payload",
+    "raw tenant UUID",
+    "raw channel UUID",
+    "raw channel slug",
+    "raw locale"
+  ],
   "suggested_execution": [
     "node scripts/verify/verify-fulfillment-storefront-native-error-safety.mjs",
+    "node scripts/verify/verify-fulfillment-storefront-native-client-error-safety.mjs",
     "node scripts/verify/verify-fulfillment-storefront-boundary.mjs",
     "node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs",
     "cargo check -p rustok-fulfillment-storefront --all-features"
   ],
+  "execution": [],
   "validation": {
     "tests_run": false,
     "cargo_run": false,

--- a/crates/rustok-fulfillment/docs/storefront-native-error-safety.md
+++ b/crates/rustok-fulfillment/docs/storefront-native-error-safety.md
@@ -15,19 +15,27 @@ The mounted boundary covers host runtime dependency resolution, tenant and authe
 
 ## Mounted server-function contract
 
-Internal failures are retained only in server-side diagnostics with the available:
+Mounted tenant, authentication, optional request-context, and owner failures retain only bounded server-side diagnostics:
 
 - fulfillment owner and exact owner operation;
-- tenant id;
-- correlation id, channel id, channel slug, and locale when optional `RequestContext` extraction succeeds;
 - stable internal code and native boundary;
-- original internal error where one exists.
+- the static Rust error type where an error value exists;
+- tenant UUID non-nil state rather than the UUID value;
+- request-context presence;
+- correlation id when optional `RequestContext` extraction succeeds;
+- channel UUID presence/non-nil state;
+- channel-slug presence and length;
+- locale presence and length.
 
-Public `ServerFnError` messages remain static for missing runtime composition, tenant/authentication context extraction, and shipping-selection owner runtime failure. `RequestContext` remains optional for the owner call; failed extraction is logged and still results in `None`.
+The complete framework and owner errors are not logged. Tenant and request-context identity values are not logged: tenant UUID, channel UUID, channel slug, and locale remain outside structured diagnostic values.
+
+Public `ServerFnError` messages remain static for missing runtime composition, tenant/authentication context extraction, and shipping-selection owner runtime failure. `RequestContext` remains optional for the owner call; failed extraction is recorded with the error type and bounded tenant/request-context facts and still results in `None`.
+
+Missing `TransactionalEventBus` diagnostics remain dependency-name only and keep the static shipping-selection availability envelope.
 
 ## Native client contract
 
-The private native adapter now performs the same fail-fast validation order before the server-function call:
+The private native adapter performs the same fail-fast validation order before the server-function call:
 
 1. cart UUID parsing;
 2. `build_shipping_selection_updates` selection-plan validation;
@@ -37,11 +45,11 @@ These failures return `ShippingSelectionTransportError::Validation` with the exi
 
 `Shipping selection request could not be completed`
 
-The complete compatibility error remains private to structured diagnostics. Diagnostics record only operation, correlation id, stable code, boundary, identifier lengths, delivery-group/available-option counts, and seller/option presence. Cart ids, profile slugs, seller ids, option ids, delivery-group values, and request payloads are not logged.
+The complete compatibility error remains private to the client adapter's structured diagnostics. Diagnostics record only operation, correlation id, stable code, boundary, identifier lengths, delivery-group/available-option counts, and seller/option presence. Cart ids, profile slugs, seller ids, option ids, delivery-group values, and request payloads are not logged.
 
 ## Preserved behavior
 
-This slice does not change:
+This mounted diagnostic cleanup does not change:
 
 - `select_shipping_option` public signature or `UiTransportError` result;
 - `SelectShippingOptionRequest`, delivery-group, update, or response types;
@@ -49,22 +57,32 @@ This slice does not change:
 - `build_shipping_selection_plan` or update materialization;
 - cart, selection-plan, and shipping-option validation messages;
 - `StorefrontShippingSelectionCommand` or its payload;
+- tenant/authentication extraction order or optional `RequestContext` fallback;
+- `select_storefront_shipping_option` owner invocation;
 - the mounted `ShippingSelectionTransportError::ServerFn(error.to_string())` compatibility wrapper;
-- the storefront transport facade, GraphQL adapter, GraphQL error policy, or native/GraphQL selection;
+- the storefront transport facade, native client adapter, GraphQL adapter, GraphQL error policy, or native/GraphQL selection;
 - fallback policy;
 - fulfillment FBA or FFA status.
 
 ## Static evidence
 
-The retained server-side guard remains:
+Mounted server-side guard:
 
 - `scripts/verify/verify-fulfillment-storefront-native-error-safety.mjs`.
 
-The new focused guard is:
+It requires the four bound-free type-only error sites, bounded tenant/request-context facts, static public envelopes, unchanged endpoint and owner-call markers, and source-only validation flags. It rejects complete error payloads and full tenant/channel/slug/locale diagnostic values.
+
+Native client guard:
 
 - `scripts/verify/verify-fulfillment-storefront-native-client-error-safety.mjs`.
 
-It locks validation ordering and messages, adapter context placement, the static technical envelope, private raw-cause diagnostics, safe request-shape fields, unchanged facade/GraphQL/server-function source, source evidence statuses, and the still-open broad ecommerce mapper cleanup.
+It locks validation ordering and messages, adapter context placement, the static technical envelope, private client compatibility diagnostics, safe request-shape fields, unchanged facade/GraphQL contracts, source evidence statuses, and the still-open broad ecommerce mapper cleanup.
+
+Retained mounted source evidence:
+
+- `crates/rustok-fulfillment/contracts/evidence/storefront-native-error-safety-source.json`.
+
+No test, verifier, Cargo command, formatting command, mounted execution, workflow, CI job, or runtime trace was executed for this source slice.
 
 ## Remaining gaps
 

--- a/crates/rustok-fulfillment/storefront/src/transport/native_server_adapter/server_functions.rs
+++ b/crates/rustok-fulfillment/storefront/src/transport/native_server_adapter/server_functions.rs
@@ -27,9 +27,10 @@ fn map_runtime_dependency_error(dependency: &'static str) -> ServerFnError {
 }
 
 #[cfg(feature = "ssr")]
-fn map_tenant_context_error<E: std::fmt::Debug>(error: E) -> ServerFnError {
+fn map_tenant_context_error<E>(_error: E) -> ServerFnError {
+    let error_type = std::any::type_name::<E>();
     tracing::error!(
-        error = ?error,
+        error_type,
         owner = FULFILLMENT_STOREFRONT_NATIVE_OWNER,
         owner_operation = FULFILLMENT_STOREFRONT_NATIVE_OPERATION,
         code = "fulfillment.storefront_tenant_context_unavailable",
@@ -40,12 +41,13 @@ fn map_tenant_context_error<E: std::fmt::Debug>(error: E) -> ServerFnError {
 }
 
 #[cfg(feature = "ssr")]
-fn map_auth_context_error<E: std::fmt::Debug>(tenant_id: Uuid, error: E) -> ServerFnError {
+fn map_auth_context_error<E>(tenant_id: Uuid, _error: E) -> ServerFnError {
+    let error_type = std::any::type_name::<E>();
     tracing::error!(
-        error = ?error,
+        error_type,
         owner = FULFILLMENT_STOREFRONT_NATIVE_OWNER,
         owner_operation = FULFILLMENT_STOREFRONT_NATIVE_OPERATION,
-        tenant_id = %tenant_id,
+        tenant_id_non_nil = !tenant_id.is_nil(),
         code = "fulfillment.storefront_auth_context_unavailable",
         boundary = FULFILLMENT_STOREFRONT_NATIVE_BOUNDARY,
         "fulfillment storefront authentication context extraction failed"
@@ -54,12 +56,14 @@ fn map_auth_context_error<E: std::fmt::Debug>(tenant_id: Uuid, error: E) -> Serv
 }
 
 #[cfg(feature = "ssr")]
-fn record_optional_request_context_error<E: std::fmt::Debug>(tenant_id: Uuid, error: E) {
+fn record_optional_request_context_error<E>(tenant_id: Uuid, _error: E) {
+    let error_type = std::any::type_name::<E>();
     tracing::warn!(
-        error = ?error,
+        error_type,
         owner = FULFILLMENT_STOREFRONT_NATIVE_OWNER,
         owner_operation = FULFILLMENT_STOREFRONT_NATIVE_OPERATION,
-        tenant_id = %tenant_id,
+        tenant_id_non_nil = !tenant_id.is_nil(),
+        request_context_present = false,
         code = "fulfillment.storefront_request_context_unavailable",
         boundary = FULFILLMENT_STOREFRONT_NATIVE_BOUNDARY,
         "optional fulfillment storefront request context extraction failed"
@@ -67,30 +71,37 @@ fn record_optional_request_context_error<E: std::fmt::Debug>(tenant_id: Uuid, er
 }
 
 #[cfg(feature = "ssr")]
-fn map_owner_runtime_error<E: std::fmt::Debug>(
+fn map_owner_runtime_error<E>(
     request_context: Option<&rustok_api::RequestContext>,
     tenant_id: Uuid,
-    error: E,
+    _error: E,
 ) -> ServerFnError {
+    let error_type = std::any::type_name::<E>();
     if let Some(request_context) = request_context {
         tracing::error!(
-            error = ?error,
+            error_type,
             owner = FULFILLMENT_STOREFRONT_NATIVE_OWNER,
             owner_operation = FULFILLMENT_STOREFRONT_NATIVE_OPERATION,
-            tenant_id = %tenant_id,
-            channel_id = ?request_context.channel_id,
-            channel_slug = ?request_context.channel_slug,
-            locale = %request_context.locale,
+            tenant_id_non_nil = !tenant_id.is_nil(),
+            request_context_present = true,
+            correlation_id = %request_context.correlation_id,
+            channel_id_present = request_context.channel_id.is_some(),
+            channel_id_non_nil = ?request_context.channel_id.map(|value| !value.is_nil()),
+            channel_slug_present = request_context.channel_slug.is_some(),
+            channel_slug_length = ?request_context.channel_slug.as_ref().map(|value| value.chars().count()),
+            locale_present = !request_context.locale.trim().is_empty(),
+            locale_length = request_context.locale.chars().count(),
             code = "fulfillment.storefront_shipping_selection_failed",
             boundary = FULFILLMENT_STOREFRONT_NATIVE_BOUNDARY,
             "fulfillment storefront owner runtime call failed"
         );
     } else {
         tracing::error!(
-            error = ?error,
+            error_type,
             owner = FULFILLMENT_STOREFRONT_NATIVE_OWNER,
             owner_operation = FULFILLMENT_STOREFRONT_NATIVE_OPERATION,
-            tenant_id = %tenant_id,
+            tenant_id_non_nil = !tenant_id.is_nil(),
+            request_context_present = false,
             code = "fulfillment.storefront_shipping_selection_failed",
             boundary = FULFILLMENT_STOREFRONT_NATIVE_BOUNDARY,
             "fulfillment storefront owner runtime call failed without request context"

--- a/scripts/verify/verify-fulfillment-storefront-native-error-safety.mjs
+++ b/scripts/verify/verify-fulfillment-storefront-native-error-safety.mjs
@@ -10,15 +10,15 @@ const rootPath = configuredRoot
   : fileURLToPath(new URL("../../", import.meta.url));
 const read = (relativePath) => readFileSync(path.join(rootPath, relativePath), "utf8");
 
+const sourcePath =
+  "crates/rustok-fulfillment/storefront/src/transport/native_server_adapter/server_functions.rs";
+const evidencePath =
+  "crates/rustok-fulfillment/contracts/evidence/storefront-native-error-safety-source.json";
+const docPath = "crates/rustok-fulfillment/docs/storefront-native-error-safety.md";
 const cargo = read("crates/rustok-fulfillment/storefront/Cargo.toml");
-const source = read(
-  "crates/rustok-fulfillment/storefront/src/transport/native_server_adapter/server_functions.rs",
-);
-const evidence = JSON.parse(
-  read(
-    "crates/rustok-fulfillment/contracts/evidence/storefront-native-error-safety-source.json",
-  ),
-);
+const source = read(sourcePath);
+const evidence = JSON.parse(read(evidencePath));
+const doc = read(docPath);
 
 const failures = [];
 const requireText = (content, value, label) => {
@@ -29,6 +29,32 @@ const forbidText = (content, value, label) => {
 };
 const countText = (content, value) => content.split(value).length - 1;
 
+function functionBody(text, functionName) {
+  const signature = new RegExp(
+    `(?:pub(?:\\([^)]*\\))?\\s+)?(?:async\\s+)?fn\\s+${functionName}(?:<[^>]*>)?\\s*\\(`,
+  );
+  const match = signature.exec(text);
+  if (!match) {
+    failures.push(`${sourcePath}: missing function ${functionName}`);
+    return "";
+  }
+  const openBrace = text.indexOf("{", match.index);
+  if (openBrace === -1) {
+    failures.push(`${sourcePath}: missing body for ${functionName}`);
+    return "";
+  }
+  let depth = 0;
+  for (let index = openBrace; index < text.length; index += 1) {
+    if (text[index] === "{") depth += 1;
+    if (text[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return text.slice(openBrace, index + 1);
+    }
+  }
+  failures.push(`${sourcePath}: unterminated body for ${functionName}`);
+  return "";
+}
+
 requireText(cargo, "tracing.workspace = true", "fulfillment storefront diagnostics dependency");
 
 for (const [value, label] of [
@@ -36,20 +62,68 @@ for (const [value, label] of [
   ["const FULFILLMENT_STOREFRONT_NATIVE_OPERATION", "native operation constant"],
   ["const FULFILLMENT_STOREFRONT_NATIVE_BOUNDARY", "native boundary constant"],
   ["fn map_runtime_dependency_error(", "runtime dependency mapper"],
-  ["fn map_tenant_context_error<E: std::fmt::Debug>(", "tenant context mapper"],
-  ["fn map_auth_context_error<E: std::fmt::Debug>(", "auth context mapper"],
-  ["fn record_optional_request_context_error<E: std::fmt::Debug>(", "optional request context logger"],
-  ["fn map_owner_runtime_error<E: std::fmt::Debug>(", "owner runtime mapper"],
+  ["fn map_tenant_context_error<E>(", "tenant context mapper"],
+  ["fn map_auth_context_error<E>(", "auth context mapper"],
+  ["fn record_optional_request_context_error<E>(", "optional request context logger"],
+  ["fn map_owner_runtime_error<E>(", "owner runtime mapper"],
   ["owner = FULFILLMENT_STOREFRONT_NATIVE_OWNER", "owner diagnostics"],
   ["owner_operation = FULFILLMENT_STOREFRONT_NATIVE_OPERATION", "operation diagnostics"],
-  ["tenant_id = %tenant_id", "tenant diagnostics"],
-  ["correlation_id = %request_context.correlation_id", "correlation diagnostics"],
-  ["channel_id = ?request_context.channel_id", "channel id diagnostics"],
-  ["channel_slug = ?request_context.channel_slug", "channel slug diagnostics"],
-  ["locale = %request_context.locale", "locale diagnostics"],
   ["boundary = FULFILLMENT_STOREFRONT_NATIVE_BOUNDARY", "boundary diagnostics"],
-  ["error = ?error", "internal cause diagnostics"],
 ]) requireText(source, value, label);
+
+for (const obsolete of [
+  "fn map_tenant_context_error<E: std::fmt::Debug>(",
+  "fn map_auth_context_error<E: std::fmt::Debug>(",
+  "fn record_optional_request_context_error<E: std::fmt::Debug>(",
+  "fn map_owner_runtime_error<E: std::fmt::Debug>(",
+]) forbidText(source, obsolete, "obsolete fulfillment storefront diagnostic contract");
+
+for (const functionName of [
+  "map_tenant_context_error",
+  "map_auth_context_error",
+  "record_optional_request_context_error",
+  "map_owner_runtime_error",
+]) {
+  const body = functionBody(source, functionName);
+  requireText(
+    body,
+    "let error_type = std::any::type_name::<E>();",
+    `${functionName} bounded error type`,
+  );
+  requireText(body, "error_type", `${functionName} error type diagnostic`);
+  for (const forbidden of [
+    "error = ?error",
+    "error = %error",
+    "error = ?_error",
+    "error = %_error",
+  ]) forbidText(body, forbidden, `${functionName} complete error payload`);
+}
+
+if (countText(source, "let error_type = std::any::type_name::<E>();") !== 4) {
+  failures.push("expected exactly four type-only fulfillment storefront diagnostic sites");
+}
+if (countText(source, "tenant_id_non_nil = !tenant_id.is_nil()") !== 4) {
+  failures.push("expected bounded tenant identity facts in auth, optional-request, and both owner branches");
+}
+if (countText(source, "request_context_present = true") !== 1) {
+  failures.push("owner diagnostics must record one successful request-context presence fact");
+}
+if (countText(source, "request_context_present = false") !== 2) {
+  failures.push("optional extraction and owner fallback must record absent request context");
+}
+for (const marker of [
+  "correlation_id = %request_context.correlation_id",
+  "channel_id_present = request_context.channel_id.is_some()",
+  "channel_id_non_nil = ?request_context.channel_id.map(|value| !value.is_nil())",
+  "channel_slug_present = request_context.channel_slug.is_some()",
+  "channel_slug_length = ?request_context.channel_slug.as_ref().map(|value| value.chars().count())",
+  "locale_present = !request_context.locale.trim().is_empty()",
+  "locale_length = request_context.locale.chars().count()",
+]) {
+  if (countText(source, marker) !== 1) {
+    failures.push(`expected exactly one bounded owner request-context site for ${marker}`);
+  }
+}
 
 for (const [value, label] of [
   ["endpoint = \"fulfillment/select-shipping-option\"", "shipping-selection endpoint"],
@@ -89,12 +163,18 @@ if (countText(source, "request_context.as_ref()") !== 2) {
 }
 
 for (const value of [
+  "error = ?error",
+  "error = %error",
+  "tenant_id = %tenant_id",
+  "channel_id = ?request_context.channel_id",
+  "channel_slug = ?request_context.channel_slug",
+  "locale = %request_context.locale",
   ".map_err(ServerFnError::new)",
   "ServerFnError::new(error.to_string())",
   "ServerFnError::new(err.to_string())",
   ".map_err(|error| ServerFnError::new(error.to_string()))",
   "fulfillment/select-shipping-option requires TransactionalEventBus in host runtime context",
-]) forbidText(source, value, "raw fulfillment storefront native public mapping");
+]) forbidText(source, value, "unsafe fulfillment storefront native diagnostic or public mapping");
 
 if (evidence.status !== "fulfillment_storefront_native_error_safety_source_unvalidated") {
   failures.push(`evidence status mismatch: ${evidence.status}`);
@@ -106,6 +186,15 @@ for (const [key, expected] of Object.entries({
   owner_runtime_static_public_envelope: true,
   optional_request_context_preserved: true,
   optional_request_context_failure_logged: true,
+  framework_error_type_only: true,
+  optional_request_context_error_type_only: true,
+  owner_runtime_error_type_only: true,
+  complete_internal_error_logged: false,
+  correlation_logging_when_available: true,
+  tenant_identity_shape_only: true,
+  channel_context_shape_only_when_available: true,
+  locale_shape_only_when_available: true,
+  raw_tenant_channel_locale_logged: false,
   outer_transport_variant_changed: false,
   validation_messages_changed: false,
   graphql_adapter_changed: false,
@@ -115,6 +204,9 @@ for (const [key, expected] of Object.entries({
   if (evidence.source_contract?.[key] !== expected) {
     failures.push(`evidence source_contract.${key} must be ${expected}`);
   }
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push("evidence execution must remain empty");
 }
 for (const key of [
   "tests_run",
@@ -131,6 +223,10 @@ for (const key of [
   }
 }
 
+requireText(doc, "Status: **source-ready / unvalidated**", "documentation status");
+requireText(doc, "complete framework and owner errors are not logged", "documentation error policy");
+requireText(doc, "tenant and request-context identity values are not logged", "documentation identity policy");
+
 if (failures.length > 0) {
   console.error("Fulfillment storefront native error-safety verification failed:");
   for (const failure of failures) console.error(`✗ ${failure}`);
@@ -138,5 +234,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "✔ fulfillment storefront native failures retain server diagnostics and static public envelopes; runtime evidence remains open",
+  "✔ fulfillment storefront native diagnostics use bounded type and request-shape facts with static public envelopes; runtime evidence remains open",
 );


### PR DESCRIPTION
## Summary

- continue the ecommerce correlation-safe mapper cleanup at the Fulfillment Storefront native boundary;
- replace complete tenant/auth/request-context/owner `Debug` payloads with Rust error-type diagnostics;
- replace raw tenant/channel/slug/locale values with tenant non-nil, request-context presence, UUID presence/non-nil, and text length facts;
- preserve correlation IDs when optional `RequestContext` exists;
- preserve the missing `TransactionalEventBus` dependency-only diagnostic;
- preserve the mounted shipping-selection endpoint, extraction order, optional request-context fallback, validation messages, command payload, owner call, outer transport wrapper, and static public envelopes;
- strengthen the focused mounted verifier and refresh source evidence and shared documentation without changing client, GraphQL, FFA, or FBA contracts.

## Covered endpoint

- `fulfillment/select-shipping-option`

## Deliberate boundary

No native client adapter, client verifier/evidence, GraphQL adapter, facade selection, DTO, shipping-selection policy, owner runtime operation, Cargo dependency, workflow, or CI configuration changes.

The shared documentation retains `Status: source-ready / unvalidated` because the independent native-client verifier requires that status and remains outside this mounted-server slice.

## Validation

Tests, Node verifiers, formatting, Cargo checks, mounted execution, workflows, and CI were not run, per maintainer request.

Suggested maintainer commands:

```bash
node scripts/verify/verify-fulfillment-storefront-native-error-safety.mjs
node scripts/verify/verify-fulfillment-storefront-native-client-error-safety.mjs
node scripts/verify/verify-fulfillment-storefront-graphql-error-safety.mjs
npm run verify:fulfillment:storefront-boundary
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-fulfillment-storefront --all-features
```

Branch base: `03160a948158f5835c3719a8a6277323d7f9e8bd`.