### PR TITLE
fix(index): block failed reconciliation scopes

### DIFF
--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -36,6 +36,7 @@ This directory contains the detailed technical architecture documentation for `r
 - [M6 Replay Job Leases](./m6-replay-job-leases.md)
 - [M6 Bounded Multi-page Replay Runner](./m6-bounded-multipage-runner.md)
 - [M6 Replay Runtime Host Composition](./m6-replay-runtime-composition.md)
+- [M6 Reconciliation Dead-letter Admission](./m6-reconciliation-dead-letter-admission.md)
 - [M4 Source-owned Schema Registry](./m4-source-schema-registry.md)
 - [M4 Query Runtime Composition](./m4-query-runtime-composition.md)
 - [M4 PostgreSQL Query Port Contract](./m4-postgres-query-port.md)

--- a/crates/rustok-index/docs/m6-reconciliation-dead-letter-admission.md
+++ b/crates/rustok-index/docs/m6-reconciliation-dead-letter-admission.md
@@ -1,0 +1,78 @@
+# M6 reconciliation dead-letter admission
+
+Status: `source_complete_operator_recovery_pending`.
+
+## Purpose
+
+A terminal failed reconciliation job now blocks later ordinary runs for the same exact tenant and schema scope. The runner no longer treats terminal failure as permission to silently insert a fresh reconciliation job identity.
+
+The acquisition transaction keeps its existing boundaries:
+
+1. take the tenant/schema reconciliation advisory lock;
+2. verify that the persisted schema is present and active;
+3. resolve retained jobs for the exact scope;
+4. claim existing eligible work or create a new job only when no authoritative retained row exists.
+
+## Admission precedence
+
+Scope selection includes `pending`, `running`, `succeeded`, and `failed` rows and orders them by state authority before creation time:
+
+1. retained `succeeded` work remains authoritative completion;
+2. existing `running` work remains authoritative active work;
+3. existing `pending` work remains authoritative delayed or claimable work;
+4. only when no successful or active row exists does the newest `failed` row block admission.
+
+Expired running work and eligible pending work keep their existing reclaim path. A failed row cannot bypass a newer or otherwise authoritative active job.
+
+When failure is authoritative, acquisition returns `IndexReconciliationRunError::DeadLettered` with only:
+
+- the retained job UUID;
+- its durable attempt count;
+- its optional bounded and validated `last_error_code`.
+
+The blocked invocation does not call the source, insert another `index_jobs` row, reset attempt state, change the cursor, or mutate the failed row.
+
+## Privacy boundary
+
+The acquisition query selects `last_error_code` but deliberately does not select `last_error_details`.
+
+Stored error codes must be non-empty, trimmed, free of control characters, and at most 128 bytes. Invalid stored codes fail closed through `InvalidStoredJob` rather than being returned.
+
+Database causes, source or mutation dependency details, arbitrary diagnostic JSON, tenant/request values, worker and lease values, SQL, transport context, and stack text are not available through the dead-letter admission error.
+
+The current page-failure transition stores `index.reconciliation_page_failed` as the public machine code. The bounded source or mutation dependency code remains inside the separately persisted reconciliation failure diagnostic and is not returned by ordinary admission.
+
+## Retained PostgreSQL target
+
+The environment-gated target creates a unique PostgreSQL schema, creates one tenant, applies the real `IndexModule` migrations, persists an active schema, and composes the canonical source and schema registries.
+
+A counted source fails its first scan permanently. The target retains evidence that the runner creates exactly one attempt-1 reconciliation job and terminalizes it with released lease ownership, a completion timestamp, zero processed pages, no entity/inbox writes, the generic page-failure code, and the bounded reconciliation diagnostic.
+
+The target then replaces only `last_error_details` with a private marker and invokes the same scope through a newly constructed runner. Admission must return the same failed job UUID and attempt count without calling the source again, creating another job, mutating the failed row, or exposing the private marker or dependency code through Debug or Display output.
+
+This target is retained source evidence only; it was not executed by the implementation agent.
+
+## Compatibility and ownership
+
+This slice changes no migration, table shape, request or cursor wire contract, source ownership, mutation identity, schema fingerprint, failure transition, cancellation transition, lease fence, success behavior, or server authorization surface.
+
+The guarded server reconciliation runtime merged separately and can surface this typed runner error only after its existing request-bound tenant/actor and `modules:manage` authorization. This slice does not add a transport or operator recovery command.
+
+## Explicitly open
+
+- bounded authorized dead-letter inspection;
+- actor/reason audit records;
+- manual requeue or retry-epoch reset;
+- automatic retry, backoff, exhaustion, or scheduling;
+- host polling, takeover discovery, or graceful shutdown;
+- source/index digest comparison and orphan diagnosis;
+- targeted, full, or shadow repair admission;
+- locale or partition checkpoint dimensions;
+- retained multi-instance PostgreSQL recovery evidence;
+- complete drift repair.
+
+The canonical M6 drift-diagnosis and targeted-repair roadmap item remains open.
+
+## Validation ownership
+
+Formatting, Cargo checks/tests, JavaScript verifiers, PostgreSQL scenarios, workflows, and CI are maintainer-run and were not executed by the implementation agent.

--- a/crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner.rs
@@ -29,6 +29,7 @@ const MAX_PAGES_PER_RUN: usize = 1_024;
 const MAX_PASSES: u32 = 8;
 const MAX_SOURCE_NAME_BYTES: usize = 128;
 const MAX_WORKER_ID_BYTES: usize = 191;
+const MAX_ERROR_CODE_BYTES: usize = 128;
 const MAX_LEASE_SECONDS: u64 = 86_400;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -529,6 +530,7 @@ struct StoredReconciliationJob {
     cursor: ReconciliationCursor,
     attempt_count: u32,
     claimable: bool,
+    last_error_code: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -596,6 +598,13 @@ async fn acquire_in_transaction(
             "running" | "pending" => {
                 claimable = Some(stored);
                 break;
+            }
+            "failed" => {
+                return Err(IndexReconciliationRunError::DeadLettered {
+                    job_id: stored.job_id,
+                    attempt_count: stored.attempt_count,
+                    error_code: stored.last_error_code,
+                });
             }
             state => {
                 return Err(IndexReconciliationRunError::InvalidStoredJob(format!(
@@ -715,6 +724,16 @@ fn stored_job(
             "attempt count is outside the u32 range".to_owned(),
         )
     })?;
+    let last_error_code: Option<String> = row
+        .try_get("", "last_error_code")
+        .map_err(storage_error)?;
+    if let Some(code) = &last_error_code {
+        validate_storage_text(code, MAX_ERROR_CODE_BYTES).map_err(|_| {
+            IndexReconciliationRunError::InvalidStoredJob(
+                "last_error_code is outside the reconciliation error contract".to_owned(),
+            )
+        })?;
+    }
     Ok(StoredReconciliationJob {
         job_id: stored_uuid(row, "job_id", backend)?,
         state: row.try_get("", "state").map_err(storage_error)?,
@@ -722,6 +741,7 @@ fn stored_job(
         cursor,
         attempt_count,
         claimable: row.try_get("", "claimable").map_err(storage_error)?,
+        last_error_code,
     })
 }
 
@@ -1178,7 +1198,7 @@ fn select_jobs_sql(backend: DbBackend) -> String {
         _ => unreachable!("unsupported database backend was validated"),
     };
     format!(
-        "SELECT job_id, state, request, cursor, {attempt_count} AS attempt_count_value, {claimable} AS claimable FROM index_jobs WHERE tenant_id = {prefix}1 AND module_name = {prefix}2 AND entity_name = {prefix}3 AND schema_version = {prefix}4 AND kind = 'reconcile' AND scope_kind = 'schema' AND state IN ('pending', 'running', 'succeeded') ORDER BY CASE state WHEN 'succeeded' THEN 0 WHEN 'running' THEN 1 ELSE 2 END, created_at DESC"
+        "SELECT job_id, state, request, cursor, last_error_code, {attempt_count} AS attempt_count_value, {claimable} AS claimable FROM index_jobs WHERE tenant_id = {prefix}1 AND module_name = {prefix}2 AND entity_name = {prefix}3 AND schema_version = {prefix}4 AND kind = 'reconcile' AND scope_kind = 'schema' AND state IN ('pending', 'running', 'succeeded', 'failed') ORDER BY CASE state WHEN 'succeeded' THEN 0 WHEN 'running' THEN 1 WHEN 'pending' THEN 2 ELSE 3 END, created_at DESC"
     )
 }
 
@@ -1302,6 +1322,14 @@ pub enum IndexReconciliationRunError {
     SchemaNotRegistered(SchemaRef),
     #[error("Index reconciliation schema is retired: {0}")]
     SchemaRetired(SchemaRef),
+    #[error(
+        "Index reconciliation scope is blocked by failed job {job_id} after attempt {attempt_count}"
+    )]
+    DeadLettered {
+        job_id: Uuid,
+        attempt_count: u32,
+        error_code: Option<String>,
+    },
     #[error("stored Index reconciliation job is invalid: {0}")]
     InvalidStoredJob(String),
     #[error("stored Index reconciliation job has unsupported state {0}")]

--- a/crates/rustok-index/tests/source_reconciliation_dead_letter_admission_postgres_test.rs
+++ b/crates/rustok-index/tests/source_reconciliation_dead_letter_admission_postgres_test.rs
@@ -1,0 +1,404 @@
+use std::{
+    env,
+    error::Error,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use rustok_core::MigrationSource;
+use rustok_index::{
+    EntityName, FieldCardinality, FieldName, IndexField, IndexModule,
+    IndexReconciliationRunError, IndexReconciliationRunRequest, IndexSchema,
+    IndexSchemaSourceCatalog, IndexSource, IndexSourceCatalog, IndexSourceError,
+    IndexSourceFailure, IndexSourceFailureKind, IndexSourceLoadBatch, IndexSourceLoadRequest,
+    IndexSourcePage, IndexSourceScanRequest, IndexValueType, LocaleMode, ModuleName,
+    PostgresIndexReconciliationRunner, SchemaRef, SchemaRegistry, SchemaVersion,
+};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, QueryResult,
+    Statement, Value as SqlValue,
+};
+use sea_orm_migration::SchemaManager;
+use serde_json::{Value as JsonValue, json};
+use uuid::Uuid;
+
+const DATABASE_ENV: &str = "RUSTOK_INDEX_TEST_DATABASE_URL";
+const SOURCE_NAME: &str = "reconciliation-dead-letter-primary";
+const MODULE_NAME: &str = "reconciliation-dead-letter-harness";
+const DEPENDENCY_CODE: &str = "owner_source_permanent_dead_letter";
+const PAGE_FAILURE_CODE: &str = "index.reconciliation_page_failed";
+const PRIVATE_MARKER: &str = "private-reconciliation-failure-detail";
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+#[derive(Clone)]
+struct CountedFailingSource {
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl IndexSource for CountedFailingSource {
+    async fn scan(
+        &self,
+        _request: IndexSourceScanRequest,
+    ) -> Result<IndexSourcePage, IndexSourceFailure> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Err(
+            IndexSourceFailure::permanent(DEPENDENCY_CODE)
+                .expect("fixture dependency code must be valid"),
+        )
+    }
+
+    async fn load(
+        &self,
+        request: IndexSourceLoadRequest,
+    ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+        Ok(IndexSourceLoadBatch::new(&request, Vec::new()).expect("empty targeted load"))
+    }
+}
+
+struct TestDatabase {
+    control: DatabaseConnection,
+    database_url: String,
+    schema_name: String,
+    tenant_id: Uuid,
+}
+
+impl TestDatabase {
+    async fn setup() -> TestResult<Option<Self>> {
+        let Some(database_url) = database_url() else {
+            eprintln!(
+                "{DATABASE_ENV} is not set to a PostgreSQL URL; skipping reconciliation dead-letter admission harness"
+            );
+            return Ok(None);
+        };
+        let control = connect(&database_url).await?;
+        let schema_name = format!(
+            "rustok_index_reconciliation_dead_letter_{}",
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let tenant_id = Uuid::new_v4();
+        let db = scoped_connection(&database_url, &schema_name).await?;
+        db.execute_unprepared("CREATE TABLE tenants (id UUID NOT NULL PRIMARY KEY)")
+            .await?;
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "INSERT INTO tenants (id) VALUES ($1)",
+            vec![tenant_id.into()],
+        ))
+        .await?;
+
+        let manager = SchemaManager::new(&db);
+        for migration in IndexModule.migrations() {
+            migration.up(&manager).await?;
+        }
+        persist_schema(&db, tenant_id).await?;
+
+        Ok(Some(Self {
+            control,
+            database_url,
+            schema_name,
+            tenant_id,
+        }))
+    }
+
+    async fn connection(&self) -> TestResult<DatabaseConnection> {
+        scoped_connection(&self.database_url, &self.schema_name).await
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct FailedJobEvidence {
+    job_id: Uuid,
+    state: String,
+    attempt_count: i64,
+    completed_passes: i64,
+    pages_processed: i64,
+    last_error_code: String,
+    last_error_details: JsonValue,
+    lease_released: bool,
+    completed: bool,
+}
+
+#[tokio::test]
+async fn failed_reconciliation_scope_blocks_new_jobs_without_exposing_details() -> TestResult<()> {
+    let Some(database) = TestDatabase::setup().await? else {
+        return Ok(());
+    };
+    let calls = Arc::new(AtomicUsize::new(0));
+    let first_runner = runner(database.connection().await?, calls.clone());
+
+    let first_error = first_runner
+        .run(request(database.tenant_id, "dead-letter-worker-a"))
+        .await
+        .expect_err("fixture source failure must terminalize the first job");
+    match first_error {
+        IndexReconciliationRunError::Source(IndexSourceError::SourceFailure {
+            source_name,
+            failure,
+        }) => {
+            assert_eq!(source_name, SOURCE_NAME);
+            assert_eq!(failure.code(), DEPENDENCY_CODE);
+            assert_eq!(failure.kind(), IndexSourceFailureKind::Permanent);
+        }
+        other => panic!("unexpected first reconciliation error: {other:?}"),
+    }
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    let evidence_db = database.connection().await?;
+    let failed = read_failed_job(&evidence_db, database.tenant_id).await?;
+    assert_eq!(failed.state, "failed");
+    assert_eq!(failed.attempt_count, 1);
+    assert_eq!(failed.completed_passes, 0);
+    assert_eq!(failed.pages_processed, 0);
+    assert_eq!(failed.last_error_code, PAGE_FAILURE_CODE);
+    assert_eq!(
+        failed.last_error_details,
+        json!({
+            "contract": "index_reconciliation_run_failure_v1",
+            "dependency_code": DEPENDENCY_CODE,
+            "retryable": false,
+        })
+    );
+    assert!(failed.lease_released);
+    assert!(failed.completed);
+    assert_eq!(count(&evidence_db, "index_jobs").await?, 1);
+    assert_eq!(count(&evidence_db, "index_entities").await?, 0);
+    assert_eq!(count(&evidence_db, "index_inbox").await?, 0);
+
+    replace_private_failure_details(&evidence_db, database.tenant_id, failed.job_id).await?;
+
+    let second_runner = runner(database.connection().await?, calls.clone());
+    let blocked = second_runner
+        .run(request(database.tenant_id, "dead-letter-worker-b"))
+        .await
+        .expect_err("failed reconciliation scope must remain blocked");
+    let debug = format!("{blocked:?}");
+    let display = blocked.to_string();
+    match blocked {
+        IndexReconciliationRunError::DeadLettered {
+            job_id,
+            attempt_count,
+            error_code,
+        } => {
+            assert_eq!(job_id, failed.job_id);
+            assert_eq!(attempt_count, 1);
+            assert_eq!(error_code.as_deref(), Some(PAGE_FAILURE_CODE));
+        }
+        other => panic!("unexpected blocked reconciliation error: {other:?}"),
+    }
+    assert!(!debug.contains(PRIVATE_MARKER));
+    assert!(!debug.contains(DEPENDENCY_CODE));
+    assert!(!display.contains(PRIVATE_MARKER));
+    assert!(!display.contains(DEPENDENCY_CODE));
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    let retained = read_failed_job(&evidence_db, database.tenant_id).await?;
+    assert_eq!(retained.job_id, failed.job_id);
+    assert_eq!(retained.state, "failed");
+    assert_eq!(retained.attempt_count, 1);
+    assert_eq!(retained.last_error_code, PAGE_FAILURE_CODE);
+    assert_eq!(retained.last_error_details, json!({ "private": PRIVATE_MARKER }));
+    assert!(retained.lease_released);
+    assert!(retained.completed);
+    assert_eq!(count(&evidence_db, "index_jobs").await?, 1);
+    assert_eq!(count(&evidence_db, "index_entities").await?, 0);
+    assert_eq!(count(&evidence_db, "index_inbox").await?, 0);
+
+    database.cleanup().await
+}
+
+fn runner(
+    db: DatabaseConnection,
+    calls: Arc<AtomicUsize>,
+) -> PostgresIndexReconciliationRunner {
+    let schema = schema();
+    let mut schema_catalog = IndexSchemaSourceCatalog::new();
+    schema_catalog
+        .register(MODULE_NAME, schema.clone())
+        .expect("fixture schema source must register");
+
+    let mut source_catalog = IndexSourceCatalog::new();
+    source_catalog
+        .register(
+            MODULE_NAME,
+            SOURCE_NAME,
+            [schema.reference.clone()],
+            CountedFailingSource { calls },
+        )
+        .expect("fixture source must register");
+    let sources = source_catalog
+        .materialize(&schema_catalog)
+        .expect("fixture source registry must materialize");
+
+    let mut registry = SchemaRegistry::new();
+    registry
+        .register(schema)
+        .expect("fixture schema registry must materialize");
+
+    PostgresIndexReconciliationRunner::new(db, sources, Arc::new(registry))
+}
+
+fn request(tenant_id: Uuid, worker_id: &str) -> IndexReconciliationRunRequest {
+    IndexReconciliationRunRequest::new(
+        tenant_id,
+        schema_ref(),
+        worker_id,
+        1,
+        1,
+        1,
+        1,
+        Duration::from_secs(60),
+    )
+    .expect("fixture reconciliation request must be valid")
+}
+
+fn schema_ref() -> SchemaRef {
+    SchemaRef {
+        module: ModuleName::new(MODULE_NAME).unwrap(),
+        entity: EntityName::new("item").unwrap(),
+        version: SchemaVersion::INITIAL,
+    }
+}
+
+fn schema() -> IndexSchema {
+    IndexSchema {
+        reference: schema_ref(),
+        locale_mode: LocaleMode::None,
+        fields: vec![IndexField {
+            name: FieldName::new("id").unwrap(),
+            value_type: IndexValueType::Uuid,
+            cardinality: FieldCardinality::One,
+            nullable: false,
+            selectable: true,
+            filterable: true,
+            sortable: true,
+        }],
+        links: Vec::new(),
+    }
+}
+
+async fn persist_schema(db: &DatabaseConnection, tenant_id: Uuid) -> TestResult<()> {
+    let schema = schema();
+    let fingerprint = schema.fingerprint()?.to_string();
+    let schema_json = serde_json::to_value(&schema)?;
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "INSERT INTO index_schemas (tenant_id, module_name, entity_name, schema_version, schema_fingerprint, schema_json, status) VALUES ($1, $2, $3, $4, $5, $6, 'active')",
+        vec![
+            tenant_id.into(),
+            schema.reference.module.as_str().to_owned().into(),
+            schema.reference.entity.as_str().to_owned().into(),
+            i64::from(schema.reference.version.get()).into(),
+            fingerprint.into(),
+            SqlValue::Json(Some(Box::new(schema_json))),
+        ],
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn read_failed_job(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+) -> TestResult<FailedJobEvidence> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT job_id, state, attempt_count::bigint AS attempt_count_value, (cursor->>'completed_passes')::bigint AS completed_passes, (cursor->>'pages_processed')::bigint AS pages_processed, last_error_code, last_error_details, (lease_owner IS NULL AND lease_expires_at IS NULL) AS lease_released, (completed_at IS NOT NULL) AS completed FROM index_jobs WHERE tenant_id = $1 AND kind = 'reconcile' AND state = 'failed' ORDER BY created_at DESC LIMIT 1",
+            vec![tenant_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("failed reconciliation job is missing"))?;
+    Ok(FailedJobEvidence {
+        job_id: row.try_get("", "job_id")?,
+        state: row.try_get("", "state")?,
+        attempt_count: row.try_get("", "attempt_count_value")?,
+        completed_passes: row.try_get("", "completed_passes")?,
+        pages_processed: row.try_get("", "pages_processed")?,
+        last_error_code: row.try_get("", "last_error_code")?,
+        last_error_details: row.try_get("", "last_error_details")?,
+        lease_released: row.try_get("", "lease_released")?,
+        completed: row.try_get("", "completed")?,
+    })
+}
+
+async fn replace_private_failure_details(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    job_id: Uuid,
+) -> TestResult<()> {
+    let updated = db
+        .execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "UPDATE index_jobs SET last_error_details = $3 WHERE tenant_id = $1 AND job_id = $2 AND kind = 'reconcile' AND state = 'failed'",
+            vec![
+                tenant_id.into(),
+                job_id.into(),
+                SqlValue::Json(Some(Box::new(json!({ "private": PRIVATE_MARKER })))),
+            ],
+        ))
+        .await?;
+    if updated.rows_affected() != 1 {
+        return Err(std::io::Error::other("failed reconciliation details update lost scope").into());
+    }
+    Ok(())
+}
+
+async fn count(db: &DatabaseConnection, table: &str) -> TestResult<i64> {
+    let sql = match table {
+        "index_jobs" => "SELECT COUNT(*)::bigint AS value FROM index_jobs WHERE kind = 'reconcile'",
+        "index_entities" => "SELECT COUNT(*)::bigint AS value FROM index_entities",
+        "index_inbox" => "SELECT COUNT(*)::bigint AS value FROM index_inbox",
+        _ => panic!("unsupported fixture table"),
+    };
+    let row: QueryResult = db
+        .query_one(Statement::from_string(DbBackend::Postgres, sql.to_owned()))
+        .await?
+        .ok_or_else(|| std::io::Error::other("count query returned no row"))?;
+    Ok(row.try_get("", "value")?)
+}
+
+fn database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn scoped_connection(
+    database_url: &str,
+    schema_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url).await?;
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}""#))
+        .await?;
+    Ok(db)
+}

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -23,6 +23,7 @@ const scripts = [
   'verify-index-source-reconciliation.mjs',
   'verify-index-replay-runtime-composition.mjs',
   'verify-index-server-reconciliation-guard.mjs',
+  'verify-index-reconciliation-dead-letter-admission.mjs',
   'verify-index-replay-dry-run.mjs',
   'verify-index-replay-page-interruption.mjs',
   'verify-index-replay-retry-store.mjs',

--- a/scripts/verify/verify-index-reconciliation-dead-letter-admission.mjs
+++ b/scripts/verify/verify-index-reconciliation-dead-letter-admission.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-reconciliation-dead-letter-admission] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const runnerPath =
+  'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner.rs';
+const targetPath =
+  'crates/rustok-index/tests/source_reconciliation_dead_letter_admission_postgres_test.rs';
+const docsPath =
+  'crates/rustok-index/docs/m6-reconciliation-dead-letter-admission.md';
+const docsIndexPath = 'crates/rustok-index/docs/README.md';
+const planPath = 'crates/rustok-index/docs/implementation-plan.md';
+const aggregatePath = 'scripts/verify/verify-index-query-contract.mjs';
+
+const runner = requireMarkers(runnerPath, [
+  'const MAX_ERROR_CODE_BYTES: usize = 128;',
+  'DeadLettered {',
+  'job_id: Uuid,',
+  'attempt_count: u32,',
+  'error_code: Option<String>,',
+  'last_error_code: Option<String>,',
+  '.try_get("", "last_error_code")',
+  'last_error_code is outside the reconciliation error contract',
+]);
+
+const acquireStart = runner.indexOf('async fn acquire_in_transaction(');
+const acquireEnd = runner.indexOf('\nfn validate_stored_request(', acquireStart);
+if (acquireStart < 0 || acquireEnd <= acquireStart) {
+  fail(`${runnerPath} must retain one bounded acquisition transaction`);
+}
+const acquire = runner.slice(acquireStart, acquireEnd);
+for (const marker of [
+  'lock_reconciliation_scope(transaction, request, backend).await?;',
+  'verify_schema_registration(transaction, request, backend).await?;',
+  '"succeeded" => {',
+  '"running" | "pending" if !stored.claimable',
+  '"running" | "pending" => {',
+  '"failed" => {',
+  'return Err(IndexReconciliationRunError::DeadLettered {',
+  'error_code: stored.last_error_code,',
+]) {
+  if (!acquire.includes(marker)) fail(`${runnerPath} acquisition is missing ${marker}`);
+}
+const succeededBranch = acquire.indexOf('"succeeded" => {');
+const busyBranch = acquire.indexOf('"running" | "pending" if !stored.claimable');
+const claimableBranch = acquire.indexOf('"running" | "pending" => {');
+const failedBranch = acquire.indexOf('"failed" => {');
+const insertBranch = acquire.indexOf('let job_id = Uuid::new_v4();');
+if (
+  succeededBranch < 0
+  || busyBranch <= succeededBranch
+  || claimableBranch <= busyBranch
+  || failedBranch <= claimableBranch
+  || insertBranch <= failedBranch
+) {
+  fail(`${runnerPath} must preserve succeeded, active, failed, then create precedence`);
+}
+const deadLetterBlock = acquire.slice(
+  failedBranch,
+  acquire.indexOf('state => {', failedBranch),
+);
+for (const forbidden of [
+  'last_error_details',
+  'INSERT INTO index_jobs',
+  'UPDATE index_jobs',
+  'Uuid::new_v4()',
+  '.scan(',
+]) {
+  if (deadLetterBlock.includes(forbidden)) {
+    fail(`${runnerPath} dead-letter branch contains forbidden marker ${forbidden}`);
+  }
+}
+
+const selectStart = runner.indexOf('fn select_jobs_sql(');
+const selectEnd = runner.indexOf('\nfn insert_job_sql(', selectStart);
+if (selectStart < 0 || selectEnd <= selectStart) {
+  fail(`${runnerPath} must retain one bounded job-selection function`);
+}
+const select = runner.slice(selectStart, selectEnd);
+for (const marker of [
+  'SELECT job_id, state, request, cursor, last_error_code',
+  "kind = 'reconcile'",
+  "scope_kind = 'schema'",
+  "state IN ('pending', 'running', 'succeeded', 'failed')",
+  "WHEN 'succeeded' THEN 0 WHEN 'running' THEN 1 WHEN 'pending' THEN 2 ELSE 3",
+  'created_at DESC',
+]) {
+  if (!select.includes(marker)) fail(`${runnerPath} job selection is missing ${marker}`);
+}
+if (select.includes('last_error_details')) {
+  fail(`${runnerPath} ordinary dead-letter admission must not select last_error_details`);
+}
+
+const storedStart = runner.indexOf('fn stored_job(');
+const storedEnd = runner.indexOf('\nasync fn lock_reconciliation_scope(', storedStart);
+if (storedStart < 0 || storedEnd <= storedStart) {
+  fail(`${runnerPath} stored-job decoder is missing`);
+}
+const stored = runner.slice(storedStart, storedEnd);
+for (const marker of [
+  'u32::try_from(attempt_count)',
+  'validate_storage_text(code, MAX_ERROR_CODE_BYTES)',
+  'last_error_code is outside the reconciliation error contract',
+]) {
+  if (!stored.includes(marker)) fail(`${runnerPath} stored-job decoder is missing ${marker}`);
+}
+
+const target = requireMarkers(targetPath, [
+  'failed_reconciliation_scope_blocks_new_jobs_without_exposing_details',
+  'RUSTOK_INDEX_TEST_DATABASE_URL',
+  'IndexModule.migrations()',
+  'owner_source_permanent_dead_letter',
+  'IndexReconciliationRunError::Source',
+  'IndexReconciliationRunError::DeadLettered',
+  'private-reconciliation-failure-detail',
+  'assert!(!debug.contains(PRIVATE_MARKER))',
+  'assert!(!debug.contains(DEPENDENCY_CODE))',
+  'assert!(!display.contains(PRIVATE_MARKER))',
+  'assert!(!display.contains(DEPENDENCY_CODE))',
+  'assert_eq!(calls.load(Ordering::SeqCst), 1)',
+  'count(&evidence_db, "index_jobs")',
+  'count(&evidence_db, "index_entities")',
+  'count(&evidence_db, "index_inbox")',
+  'DROP SCHEMA IF EXISTS',
+]);
+for (const forbidden of [
+  'tokio::time::sleep',
+  'std::thread::sleep',
+  'DELETE FROM index_jobs',
+  'INSERT INTO index_jobs',
+]) {
+  if (target.includes(forbidden)) {
+    fail(`${targetPath} contains forbidden recovery shortcut ${forbidden}`);
+  }
+}
+
+requireMarkers(docsPath, [
+  'Status: `source_complete_operator_recovery_pending`.',
+  'ordinary runs for the same exact tenant and schema scope',
+  'Scope selection includes `pending`, `running`, `succeeded`, and `failed` rows',
+  'does not select `last_error_details`',
+  'does not call the source, insert another `index_jobs` row',
+  'guarded server reconciliation runtime merged separately',
+  'canonical M6 drift-diagnosis and targeted-repair roadmap item remains open',
+  'maintainer-run',
+]);
+requireMarkers(docsIndexPath, [
+  '[M6 Reconciliation Dead-letter Admission](./m6-reconciliation-dead-letter-admission.md)',
+]);
+requireMarkers(planPath, [
+  '- [ ] Add bounded retry/backoff, dead-letter state, and global scheduling ownership.',
+  '- [ ] Add drift diagnosis, targeted repair commands, and admitted repair evidence.',
+]);
+requireMarkers(aggregatePath, [
+  "'verify-index-server-reconciliation-guard.mjs'",
+  "'verify-index-reconciliation-dead-letter-admission.mjs'",
+  "'verify-index-replay-dead-letter-admission.mjs'",
+]);
+
+console.log('[verify-index-reconciliation-dead-letter-admission] OK');


### PR DESCRIPTION
## Summary

- rebuild reconciliation failed-scope admission directly on current `main@7e2ceff0dd7eed90ed5fd67e63d94c1803fd58cf`;
- preserve the reviewed isolated runner and PostgreSQL target from stale #2832;
- include terminal `failed` reconciliation jobs in exact tenant/schema scope resolution;
- preserve deterministic precedence: retained `succeeded`, then active `running`/`pending`, then the newest `failed` row;
- return typed `IndexReconciliationRunError::DeadLettered` instead of silently creating a new reconciliation job identity;
- expose only failed job UUID, durable attempt count, and optional bounded validated `last_error_code`;
- deliberately exclude `last_error_details` from ordinary admission;
- refresh the contract documentation, index it in the architecture README, strengthen the fail-closed verifier, and register that verifier in the aggregate Index contract.

## Fresh-main audit

The stale branch was 69 commits behind current `main`. Its only pre-existing production path remained byte-identical on current `main` before reconstruction:

- `crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner.rs`: `4dfb80cc5894c75336a0bfd18c43c49296cf561a`.

The fresh branch contains one clean commit, is one commit ahead and zero behind `main`, and changes six expected files. Replay retry/dead-letter storage and the guarded server reconciliation runtime merged independently and have no conflicting production-file overlap with this runner admission slice.

## Admission semantics

The existing acquisition transaction still:

1. takes the reconciliation advisory lock for the exact tenant/schema scope;
2. verifies the persisted schema is active;
3. selects retained jobs for that exact scope;
4. claims eligible active work or creates a new job only when no authoritative retained row exists.

Selection now includes `failed` rows and orders states as:

1. `succeeded`;
2. `running`;
3. `pending`;
4. `failed`.

A retained success remains authoritative completion. Non-claimable active work remains `Busy`; expired running or eligible pending work keeps its existing claim path. Only when no successful or active row exists does the newest failed row return `DeadLettered`.

The failed branch executes before job creation and does not scan the source, generate a new job UUID, insert a job, reset attempts, change the cursor, or mutate the failed row.

## Bounded privacy contract

`DeadLettered` contains only:

- retained job UUID;
- durable attempt count;
- optional `last_error_code`.

The job query selects no `last_error_details`. Stored error codes must be non-empty, trimmed, control-character-free, and at most 128 bytes; invalid stored values fail closed through `InvalidStoredJob`.

Source/mutation dependency details, arbitrary diagnostic JSON, tenant/request identity, worker/lease values, SQL, database causes, transport data, and stack text are not returned.

## Retained PostgreSQL target

The environment-gated target applies the real Index migrations in a unique PostgreSQL schema, persists an active schema, and uses the canonical runner and registries.

It retains source evidence that a permanent first scan failure creates and terminalizes exactly one reconciliation job, then a second invocation of the same scope returns the same failed identity without another source call, job insertion, entity/inbox mutation, or private diagnostic disclosure.

## Verification improvements

The refreshed verifier isolates and checks:

- lock and schema verification before retained-job resolution;
- succeeded/active/failed/create ordering inside the acquisition transaction;
- absence of source calls, SQL writes, or UUID generation in the dead-letter branch;
- exact tenant/schema reconcile selection and state ordering;
- selection of `last_error_code` but not `last_error_details`;
- bounded stored-code decoding;
- PostgreSQL evidence markers and absence of recovery shortcuts;
- documentation indexing;
- continued open roadmap items;
- aggregate contract registration alongside replay dead-letter and guarded reconciliation verification.

## Scope boundaries

This PR does not add or claim:

- authorized dead-letter inspection;
- actor/reason audit records;
- manual requeue or retry-epoch reset;
- automatic retry/backoff/exhaustion or host scheduling;
- polling, takeover discovery, or graceful shutdown;
- source/index digest comparison, orphan diagnosis, or targeted/full/shadow repair modes;
- locale/partition checkpoint dimensions;
- migration, table-shape, source, cursor, mutation, event-identity, failure-transition, cancellation, lease, or success-state changes;
- transport changes or new authorization surfaces;
- retained executed PostgreSQL evidence.

The canonical M6 drift-diagnosis and targeted-repair roadmap item remains open.

## Validation

Not run per maintainer instruction:

- formatting;
- Cargo checks, tests, or Clippy;
- JavaScript verifiers;
- PostgreSQL scenarios;
- workflows and CI.

Suggested maintainer commands:

```bash
RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
  cargo test -p rustok-index \
  --test source_reconciliation_dead_letter_admission_postgres_test \
  -- --nocapture
cargo check -p rustok-index --all-targets
node scripts/verify/verify-index-reconciliation-dead-letter-admission.mjs
node scripts/verify/verify-index-query-contract.mjs
```

## History

Supersedes stale #2832 and isolated historical #2743 without carrying stale branch history. Contradictory test-only drafts that expect terminal failure to create a new identity remain superseded by this fail-closed admission contract.