### PR TITLE
feat(index): inspect reconciliation dead letters

### DIFF
--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -37,6 +37,7 @@ This directory contains the detailed technical architecture documentation for `r
 - [M6 Bounded Multi-page Replay Runner](./m6-bounded-multipage-runner.md)
 - [M6 Replay Runtime Host Composition](./m6-replay-runtime-composition.md)
 - [M6 Reconciliation Dead-letter Admission](./m6-reconciliation-dead-letter-admission.md)
+- [M6 Reconciliation Dead-letter Inspection](./m6-reconciliation-dead-letter-inspection.md)
 - [M4 Source-owned Schema Registry](./m4-source-schema-registry.md)
 - [M4 Query Runtime Composition](./m4-query-runtime-composition.md)
 - [M4 PostgreSQL Query Port Contract](./m4-postgres-query-port.md)

--- a/crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md
+++ b/crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md
@@ -1,0 +1,76 @@
+# M6 reconciliation dead-letter inspection
+
+Status: `source_complete_authorized_composition_pending`.
+
+## Purpose
+
+`PostgresIndexReconciliationDeadLetterInspector` provides a bounded, read-only view of one terminal failed reconciliation job after ordinary admission has blocked its exact tenant/schema scope.
+
+The adapter requires an exact non-nil tenant UUID and job UUID. Its query is restricted to the exact tenant/job with `kind = 'reconcile'` and `state = 'failed'`. Cross-tenant, active, pending, successful, cancelled, non-reconciliation, and unknown jobs therefore return no inspection.
+
+The adapter is published only through `rustok_index::infrastructure::postgres`. It is a storage capability, not a public endpoint or an authorization boundary.
+
+## Returned contract
+
+A successful inspection contains only:
+
+- failed job UUID;
+- positive durable attempt count;
+- optional bounded `last_error_code`;
+- bounded `dependency_code` from `index_reconciliation_run_failure_v1`;
+- retryability boolean.
+
+Both machine codes are limited to 128 ASCII bytes and lowercase letters, digits, `.`, `_`, or `-`.
+
+Stored diagnostics use `#[serde(deny_unknown_fields)]` and must match the exact three-field reconciliation failure contract. Unknown fields, malformed JSON, unsupported contract versions, invalid machine codes, zero attempts, and overflowing attempts fail closed through `InvalidStoredJob`.
+
+## Privacy and read-only boundary
+
+Unlike ordinary dead-letter admission, inspection deliberately reads `last_error_details` so it can decode the bounded dependency code and retryability flag. The raw JSON object is never returned.
+
+The query selects only attempt count, `last_error_code`, and `last_error_details`. It does not select or return:
+
+- tenant identity;
+- schema request or cursor JSON;
+- source name, worker identity, lease ownership, or timestamps;
+- entity, relation, inbox, or mutation payloads;
+- SQL, database causes, transport context, or stack text.
+
+Database failures map to one stable `Storage` error with no embedded database detail. The production implementation performs no insert, update, delete, retry, requeue, reset, scheduling, polling, sleep, or task creation.
+
+## Authorization ownership
+
+The crate adapter intentionally accepts no actor or permission object.
+
+The merged server reconciliation runtime currently exposes only guarded `run` and `request_cancel` operations. A later server-owned inspection wrapper must:
+
+1. bind the exact request tenant and actor;
+2. reject cross-tenant requests before storage delegation;
+3. require the request-scoped effective `modules:manage` permission;
+4. keep the database adapter and raw diagnostics inaccessible to transports.
+
+GraphQL, HTTP, CLI, MCP, and admin inspection transports remain open. This slice does not extend the current server operator surface.
+
+## Compatibility
+
+This slice adds no migration and changes no reconciliation state transition, failed-scope admission, retry policy, lease fence, cursor, source, mutation, schema, cancellation, or success behavior.
+
+It composes additively with the replay retry store, replay dead-letter admission, reconciliation dead-letter admission, and guarded reconciliation runtime already present on `main`.
+
+## Explicitly open
+
+- server-owned authorized inspection composition and transport mapping;
+- actor/reason audit records;
+- manual requeue or retry-epoch reset under the reconciliation scope lock;
+- automatic retry, backoff, exhaustion, scheduling, and graceful shutdown;
+- source/index digest comparison and orphan diagnosis;
+- targeted, full, or shadow repair admission;
+- locale or partition checkpoint dimensions;
+- retained PostgreSQL inspection and authorization evidence;
+- complete drift repair.
+
+The canonical M6 drift-diagnosis and targeted-repair roadmap item remains open.
+
+## Validation ownership
+
+Formatting, Cargo checks/tests, JavaScript verifiers, PostgreSQL scenarios, workflows, and CI are maintainer-run and were not executed by the implementation agent.

--- a/crates/rustok-index/src/infrastructure/postgres/mod.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/mod.rs
@@ -7,6 +7,7 @@ mod schema_lease;
 mod schema_registration;
 mod secondary_index;
 mod source_factory;
+mod source_reconciliation_dead_letter_inspector;
 mod source_reconciliation_runner;
 mod source_replay;
 mod source_replay_job;
@@ -65,6 +66,10 @@ pub use source_factory::{
     PostgresIndexSourceFactory, PostgresIndexSourceFactoryCatalog,
     PostgresIndexSourceFactoryDescriptor, PostgresIndexSourceFactoryError,
     materialize_postgres_index_sources, register_postgres_index_source_factory,
+};
+pub use source_reconciliation_dead_letter_inspector::{
+    IndexReconciliationDeadLetterInspection, IndexReconciliationDeadLetterInspectionError,
+    PostgresIndexReconciliationDeadLetterInspector,
 };
 pub use source_reconciliation_runner::{
     IndexReconciliationCancelOutcome, IndexReconciliationRunError,

--- a/crates/rustok-index/src/infrastructure/postgres/source_reconciliation_dead_letter_inspector.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_reconciliation_dead_letter_inspector.rs
@@ -1,0 +1,323 @@
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DbBackend, QueryResult, Statement, Value as SqlValue,
+};
+use serde::Deserialize;
+use serde_json::Value as JsonValue;
+use thiserror::Error;
+use uuid::Uuid;
+
+const RECONCILIATION_FAILURE_CONTRACT: &str = "index_reconciliation_run_failure_v1";
+const MAX_ERROR_CODE_BYTES: usize = 128;
+
+/// A bounded, read-only view of one failed reconciliation job.
+///
+/// The inspection intentionally excludes the tenant, schema request, cursor, worker,
+/// lease, timestamps, and raw diagnostic JSON. Callers receive only stable machine
+/// fields that are safe to expose behind an operator authorization boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexReconciliationDeadLetterInspection {
+    job_id: Uuid,
+    attempt_count: u32,
+    error_code: Option<String>,
+    dependency_code: String,
+    retryable: bool,
+}
+
+impl IndexReconciliationDeadLetterInspection {
+    pub fn job_id(&self) -> Uuid {
+        self.job_id
+    }
+
+    pub fn attempt_count(&self) -> u32 {
+        self.attempt_count
+    }
+
+    pub fn error_code(&self) -> Option<&str> {
+        self.error_code.as_deref()
+    }
+
+    pub fn dependency_code(&self) -> &str {
+        &self.dependency_code
+    }
+
+    pub fn retryable(&self) -> bool {
+        self.retryable
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StoredReconciliationFailure {
+    contract: String,
+    dependency_code: String,
+    retryable: bool,
+}
+
+/// PostgreSQL-backed read-only dead-letter inspector.
+///
+/// Authorization is deliberately not accepted as data by this adapter. Server,
+/// GraphQL, HTTP, CLI, and admin callers must authorize the exact tenant and actor
+/// before invoking `inspect`.
+#[derive(Clone)]
+pub struct PostgresIndexReconciliationDeadLetterInspector {
+    db: DatabaseConnection,
+}
+
+impl PostgresIndexReconciliationDeadLetterInspector {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    pub async fn inspect(
+        &self,
+        tenant_id: Uuid,
+        job_id: Uuid,
+    ) -> Result<Option<IndexReconciliationDeadLetterInspection>, IndexReconciliationDeadLetterInspectionError>
+    {
+        if tenant_id.is_nil() {
+            return Err(IndexReconciliationDeadLetterInspectionError::NilTenantId);
+        }
+        if job_id.is_nil() {
+            return Err(IndexReconciliationDeadLetterInspectionError::NilJobId);
+        }
+
+        let backend = self.db.get_database_backend();
+        ensure_supported_backend(backend)?;
+        let row = self
+            .db
+            .query_one(Statement::from_sql_and_values(
+                backend,
+                select_failed_job_sql(backend),
+                vec![uuid_value(tenant_id, backend), uuid_value(job_id, backend)],
+            ))
+            .await
+            .map_err(|_| IndexReconciliationDeadLetterInspectionError::Storage)?;
+        row.map(|row| decode_failed_job(&row, job_id))
+            .transpose()
+    }
+}
+
+fn decode_failed_job(
+    row: &QueryResult,
+    job_id: Uuid,
+) -> Result<IndexReconciliationDeadLetterInspection, IndexReconciliationDeadLetterInspectionError> {
+    let attempt_count: i64 = row
+        .try_get("", "attempt_count_value")
+        .map_err(|_| IndexReconciliationDeadLetterInspectionError::Storage)?;
+    let attempt_count = u32::try_from(attempt_count).map_err(|_| {
+        IndexReconciliationDeadLetterInspectionError::InvalidStoredJob(
+            "attempt count is outside the u32 range",
+        )
+    })?;
+    if attempt_count == 0 {
+        return Err(IndexReconciliationDeadLetterInspectionError::InvalidStoredJob(
+            "attempt count must be positive",
+        ));
+    }
+
+    let error_code: Option<String> = row
+        .try_get("", "last_error_code")
+        .map_err(|_| IndexReconciliationDeadLetterInspectionError::Storage)?;
+    if let Some(code) = &error_code {
+        validate_machine_code(code).map_err(|_| {
+            IndexReconciliationDeadLetterInspectionError::InvalidStoredJob(
+                "last_error_code is outside the bounded machine-code contract",
+            )
+        })?;
+    }
+
+    let details: JsonValue = row
+        .try_get("", "last_error_details")
+        .map_err(|_| IndexReconciliationDeadLetterInspectionError::Storage)?;
+    let details: StoredReconciliationFailure = serde_json::from_value(details).map_err(|_| {
+        IndexReconciliationDeadLetterInspectionError::InvalidStoredJob(
+            "last_error_details does not match the reconciliation failure contract",
+        )
+    })?;
+    if details.contract != RECONCILIATION_FAILURE_CONTRACT {
+        return Err(IndexReconciliationDeadLetterInspectionError::InvalidStoredJob(
+            "last_error_details contract is unsupported",
+        ));
+    }
+    validate_machine_code(&details.dependency_code).map_err(|_| {
+        IndexReconciliationDeadLetterInspectionError::InvalidStoredJob(
+            "dependency_code is outside the bounded machine-code contract",
+        )
+    })?;
+
+    Ok(IndexReconciliationDeadLetterInspection {
+        job_id,
+        attempt_count,
+        error_code,
+        dependency_code: details.dependency_code,
+        retryable: details.retryable,
+    })
+}
+
+fn validate_machine_code(value: &str) -> Result<(), ()> {
+    if value.is_empty()
+        || value.len() > MAX_ERROR_CODE_BYTES
+        || value.trim() != value
+        || !value.bytes().all(|byte| {
+            byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || matches!(byte, b'.' | b'_' | b'-')
+        })
+    {
+        return Err(());
+    }
+    Ok(())
+}
+
+fn ensure_supported_backend(
+    backend: DbBackend,
+) -> Result<(), IndexReconciliationDeadLetterInspectionError> {
+    match backend {
+        DbBackend::Postgres => Ok(()),
+        DbBackend::Sqlite if cfg!(test) => Ok(()),
+        _ => Err(IndexReconciliationDeadLetterInspectionError::UnsupportedBackend),
+    }
+}
+
+fn placeholder_prefix(backend: DbBackend) -> &'static str {
+    match backend {
+        DbBackend::Postgres => "$",
+        DbBackend::Sqlite => "?",
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+fn uuid_value(value: Uuid, backend: DbBackend) -> SqlValue {
+    match backend {
+        DbBackend::Postgres => value.into(),
+        DbBackend::Sqlite => value.to_string().into(),
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+fn select_failed_job_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    let attempt_count = match backend {
+        DbBackend::Postgres => "CAST(attempt_count AS BIGINT)",
+        DbBackend::Sqlite => "CAST(attempt_count AS INTEGER)",
+        _ => unreachable!("unsupported database backend was validated"),
+    };
+    format!(
+        "SELECT {attempt_count} AS attempt_count_value, last_error_code, last_error_details FROM index_jobs WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'reconcile' AND state = 'failed' LIMIT 1"
+    )
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum IndexReconciliationDeadLetterInspectionError {
+    #[error("Index reconciliation dead-letter inspection tenant id must not be nil")]
+    NilTenantId,
+    #[error("Index reconciliation dead-letter inspection job id must not be nil")]
+    NilJobId,
+    #[error("stored Index reconciliation dead letter is invalid: {0}")]
+    InvalidStoredJob(&'static str),
+    #[error("Index reconciliation dead-letter inspection does not support this database backend")]
+    UnsupportedBackend,
+    #[error("Index reconciliation dead-letter inspection storage operation failed")]
+    Storage,
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{Database, DbBackend, Statement};
+    use serde_json::json;
+
+    use super::*;
+
+    async fn database() -> DatabaseConnection {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+        db.execute(Statement::from_string(
+            DbBackend::Sqlite,
+            "CREATE TABLE index_jobs (tenant_id TEXT NOT NULL, job_id TEXT NOT NULL, kind TEXT NOT NULL, state TEXT NOT NULL, attempt_count INTEGER NOT NULL, last_error_code TEXT NULL, last_error_details JSON NOT NULL)"
+                .to_owned(),
+        ))
+        .await
+        .expect("index_jobs fixture");
+        db
+    }
+
+    async fn insert_failed(
+        db: &DatabaseConnection,
+        tenant_id: Uuid,
+        job_id: Uuid,
+        details: JsonValue,
+    ) {
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO index_jobs (tenant_id, job_id, kind, state, attempt_count, last_error_code, last_error_details) VALUES (?1, ?2, 'reconcile', 'failed', 3, ?3, ?4)",
+            vec![
+                tenant_id.to_string().into(),
+                job_id.to_string().into(),
+                "index.reconciliation_page_failed".into(),
+                SqlValue::Json(Some(Box::new(details))),
+            ],
+        ))
+        .await
+        .expect("failed job fixture");
+    }
+
+    #[tokio::test]
+    async fn inspection_is_tenant_scoped_and_bounded() {
+        let db = database().await;
+        let tenant_id = Uuid::new_v4();
+        let job_id = Uuid::new_v4();
+        insert_failed(
+            &db,
+            tenant_id,
+            job_id,
+            json!({
+                "contract": RECONCILIATION_FAILURE_CONTRACT,
+                "dependency_code": "owner_source_retryable",
+                "retryable": true
+            }),
+        )
+        .await;
+        let inspector = PostgresIndexReconciliationDeadLetterInspector::new(db);
+
+        assert!(inspector.inspect(Uuid::new_v4(), job_id).await.unwrap().is_none());
+        let inspection = inspector
+            .inspect(tenant_id, job_id)
+            .await
+            .unwrap()
+            .expect("exact tenant failed job");
+        assert_eq!(inspection.job_id(), job_id);
+        assert_eq!(inspection.attempt_count(), 3);
+        assert_eq!(
+            inspection.error_code(),
+            Some("index.reconciliation_page_failed")
+        );
+        assert_eq!(inspection.dependency_code(), "owner_source_retryable");
+        assert!(inspection.retryable());
+    }
+
+    #[tokio::test]
+    async fn inspection_fails_closed_on_unbounded_diagnostic_shape() {
+        let db = database().await;
+        let tenant_id = Uuid::new_v4();
+        let job_id = Uuid::new_v4();
+        insert_failed(
+            &db,
+            tenant_id,
+            job_id,
+            json!({
+                "contract": RECONCILIATION_FAILURE_CONTRACT,
+                "dependency_code": "owner_source_permanent",
+                "retryable": false,
+                "private_detail": "must-not-pass"
+            }),
+        )
+        .await;
+        let inspector = PostgresIndexReconciliationDeadLetterInspector::new(db);
+
+        assert!(matches!(
+            inspector.inspect(tenant_id, job_id).await,
+            Err(IndexReconciliationDeadLetterInspectionError::InvalidStoredJob(_))
+        ));
+    }
+}

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -24,6 +24,7 @@ const scripts = [
   'verify-index-replay-runtime-composition.mjs',
   'verify-index-server-reconciliation-guard.mjs',
   'verify-index-reconciliation-dead-letter-admission.mjs',
+  'verify-index-reconciliation-dead-letter-inspection.mjs',
   'verify-index-replay-dry-run.mjs',
   'verify-index-replay-page-interruption.mjs',
   'verify-index-replay-retry-store.mjs',

--- a/scripts/verify/verify-index-reconciliation-dead-letter-inspection.mjs
+++ b/scripts/verify/verify-index-reconciliation-dead-letter-inspection.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-reconciliation-dead-letter-inspection] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const inspectorPath =
+  'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_dead_letter_inspector.rs';
+const postgresPath = 'crates/rustok-index/src/infrastructure/postgres/mod.rs';
+const admissionPath =
+  'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner.rs';
+const serverPath = 'apps/server/src/services/index_reconciliation_operator.rs';
+const docsPath = 'crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md';
+const docsIndexPath = 'crates/rustok-index/docs/README.md';
+const planPath = 'crates/rustok-index/docs/implementation-plan.md';
+const aggregatePath = 'scripts/verify/verify-index-query-contract.mjs';
+
+const inspector = requireMarkers(inspectorPath, [
+  'const RECONCILIATION_FAILURE_CONTRACT: &str = "index_reconciliation_run_failure_v1";',
+  'const MAX_ERROR_CODE_BYTES: usize = 128;',
+  'pub struct IndexReconciliationDeadLetterInspection',
+  'job_id: Uuid,',
+  'attempt_count: u32,',
+  'error_code: Option<String>,',
+  'dependency_code: String,',
+  'retryable: bool,',
+  '#[serde(deny_unknown_fields)]',
+  'struct StoredReconciliationFailure',
+  'pub struct PostgresIndexReconciliationDeadLetterInspector',
+  'pub async fn inspect(',
+  'IndexReconciliationDeadLetterInspectionError::NilTenantId',
+  'IndexReconciliationDeadLetterInspectionError::NilJobId',
+  'row.map(|row| decode_failed_job(&row, job_id))',
+  'inspection_is_tenant_scoped_and_bounded',
+  'inspection_fails_closed_on_unbounded_diagnostic_shape',
+]);
+
+const production = inspector.split('\n#[cfg(test)]')[0];
+for (const forbidden of [
+  'tokio::spawn',
+  'spawn_blocking',
+  'tokio::time::sleep',
+  'std::thread::sleep',
+  'INSERT INTO index_jobs',
+  'UPDATE index_jobs',
+  'DELETE FROM index_jobs',
+  "state = 'pending'",
+  'requeue',
+  'retry_epoch',
+  'Router::new',
+  'async_graphql',
+]) {
+  if (production.includes(forbidden)) {
+    fail(`${inspectorPath} production boundary contains forbidden marker ${forbidden}`);
+  }
+}
+
+const selectStart = production.indexOf('fn select_failed_job_sql(');
+const selectEnd = production.indexOf('\n#[derive(Debug, Error', selectStart);
+if (selectStart < 0 || selectEnd <= selectStart) {
+  fail(`${inspectorPath} must retain one bounded failed-job SELECT`);
+}
+const select = production.slice(selectStart, selectEnd);
+for (const marker of [
+  'SELECT {attempt_count} AS attempt_count_value, last_error_code, last_error_details',
+  'FROM index_jobs',
+  'tenant_id = {prefix}1',
+  'job_id = {prefix}2',
+  "kind = 'reconcile'",
+  "state = 'failed'",
+  'LIMIT 1',
+]) {
+  if (!select.includes(marker)) fail(`${inspectorPath} SELECT is missing ${marker}`);
+}
+for (const forbidden of [
+  'SELECT *',
+  'request',
+  'cursor',
+  'source_name',
+  'worker_id',
+  'lease_owner',
+  'lease_expires_at',
+  'completed_at',
+  'module_name',
+  'entity_name',
+]) {
+  if (select.includes(forbidden)) {
+    fail(`${inspectorPath} SELECT contains forbidden field ${forbidden}`);
+  }
+}
+
+const decodeStart = production.indexOf('fn decode_failed_job(');
+const decodeEnd = production.indexOf('\nfn validate_machine_code(', decodeStart);
+if (decodeStart < 0 || decodeEnd <= decodeStart) {
+  fail(`${inspectorPath} stored dead-letter decoder is missing`);
+}
+const decode = production.slice(decodeStart, decodeEnd);
+for (const marker of [
+  'u32::try_from(attempt_count)',
+  'if attempt_count == 0',
+  'validate_machine_code(code)',
+  '.try_get("", "last_error_details")',
+  'serde_json::from_value(details)',
+  'details.contract != RECONCILIATION_FAILURE_CONTRACT',
+  'validate_machine_code(&details.dependency_code)',
+]) {
+  if (!decode.includes(marker)) fail(`${inspectorPath} decoder is missing ${marker}`);
+}
+
+const machineCodeStart = production.indexOf('fn validate_machine_code(');
+const backendStart = production.indexOf('\nfn ensure_supported_backend(', machineCodeStart);
+const machineCode = production.slice(machineCodeStart, backendStart);
+for (const marker of [
+  'value.is_empty()',
+  'value.len() > MAX_ERROR_CODE_BYTES',
+  'value.trim() != value',
+  'byte.is_ascii_lowercase()',
+  'byte.is_ascii_digit()',
+  "matches!(byte, b'.' | b'_' | b'-')",
+]) {
+  if (!machineCode.includes(marker)) fail(`${inspectorPath} machine-code guard is missing ${marker}`);
+}
+
+for (const marker of [
+  '.map_err(|_| IndexReconciliationDeadLetterInspectionError::Storage)?;',
+  '#[error("Index reconciliation dead-letter inspection storage operation failed")]',
+  'Storage,',
+]) {
+  if (!production.includes(marker)) fail(`${inspectorPath} stable storage error is missing ${marker}`);
+}
+if (production.includes('Storage(String)') || production.includes('Storage(#[source]')) {
+  fail(`${inspectorPath} storage error must not retain database details`);
+}
+
+requireMarkers(postgresPath, [
+  'mod source_reconciliation_dead_letter_inspector;',
+  'pub use source_reconciliation_dead_letter_inspector::{',
+  'IndexReconciliationDeadLetterInspection, IndexReconciliationDeadLetterInspectionError,',
+  'PostgresIndexReconciliationDeadLetterInspector,',
+  'mod source_reconciliation_runner;',
+  'mod source_replay_retry;',
+  'PostgresIndexReconciliationRunner,',
+  'PostgresIndexReplayRetryStore,',
+]);
+
+const admission = requireMarkers(admissionPath, [
+  'IndexReconciliationRunError::DeadLettered',
+  "state IN ('pending', 'running', 'succeeded', 'failed')",
+  'SELECT job_id, state, request, cursor, last_error_code',
+]);
+const admissionSelectStart = admission.indexOf('fn select_jobs_sql(');
+const admissionSelectEnd = admission.indexOf('\nfn insert_job_sql(', admissionSelectStart);
+const admissionSelect = admission.slice(admissionSelectStart, admissionSelectEnd);
+if (admissionSelect.includes('last_error_details')) {
+  fail(`${admissionPath} ordinary admission must still exclude last_error_details`);
+}
+
+const server = requireMarkers(serverPath, [
+  'Permission::MODULES_MANAGE',
+  'pub async fn run(',
+  'pub async fn request_cancel(',
+  'PostgresIndexReconciliationRunner::new',
+]);
+const serverProduction = server.split('\n#[cfg(test)]')[0];
+for (const forbidden of [
+  'PostgresIndexReconciliationDeadLetterInspector',
+  'IndexReconciliationDeadLetterInspection',
+  'inspect_dead_letter',
+  'pub async fn inspect(',
+]) {
+  if (serverProduction.includes(forbidden)) {
+    fail(`${serverPath} prematurely exposes reconciliation inspection via ${forbidden}`);
+  }
+}
+
+requireMarkers(docsPath, [
+  'Status: `source_complete_authorized_composition_pending`.',
+  'Unlike ordinary dead-letter admission, inspection deliberately reads `last_error_details`',
+  'The raw JSON object is never returned.',
+  'requires the request-scoped effective `modules:manage` permission',
+  'currently exposes only guarded `run` and `request_cancel` operations',
+  'manual requeue or retry-epoch reset',
+  'canonical M6 drift-diagnosis and targeted-repair roadmap item remains open',
+  'maintainer-run',
+]);
+requireMarkers(docsIndexPath, [
+  '[M6 Reconciliation Dead-letter Admission](./m6-reconciliation-dead-letter-admission.md)',
+  '[M6 Reconciliation Dead-letter Inspection](./m6-reconciliation-dead-letter-inspection.md)',
+]);
+requireMarkers(planPath, [
+  '- [ ] Add bounded retry/backoff, dead-letter state, and global scheduling ownership.',
+  '- [ ] Add drift diagnosis, targeted repair commands, and admitted repair evidence.',
+]);
+requireMarkers(aggregatePath, [
+  "'verify-index-server-reconciliation-guard.mjs'",
+  "'verify-index-reconciliation-dead-letter-admission.mjs'",
+  "'verify-index-reconciliation-dead-letter-inspection.mjs'",
+  "'verify-index-replay-dead-letter-admission.mjs'",
+]);
+
+console.log('[verify-index-reconciliation-dead-letter-inspection] OK');


### PR DESCRIPTION
## Summary

- rebuild the bounded reconciliation dead-letter inspector directly on current `main@e4452e7be0c007a6e253647c91ef5ffd6b8a134c`;
- preserve the reviewed read-only inspector implementation from stale #2834;
- require exact non-nil tenant and job UUIDs;
- restrict inspection to the exact tenant/job with `kind = 'reconcile'` and `state = 'failed'`;
- return only failed job UUID, positive durable attempt count, optional bounded page-failure code, bounded dependency code, and retryability;
- fail closed on malformed or extended diagnostic JSON, unsupported contracts, invalid machine codes, and invalid attempt counts;
- keep database failures behind one stable detail-free storage error;
- register the adapter additively beside the merged reconciliation runner and replay retry store;
- index the documentation and register a strengthened verifier in the aggregate Index contract.

## Fresh-main audit

The stale branch was 71 commits behind `main`. Its new inspector remained applicable, while its `postgres/mod.rs` registration was obsolete because replay retry storage and reconciliation admission/runtime work had since merged.

The fresh branch is one commit ahead and zero behind `main`, changing six expected files. The production inspector blob is preserved exactly from stale #2834; module registration, documentation, and verification are rebuilt against current `main`.

## Read-only contract

`PostgresIndexReconciliationDeadLetterInspector::inspect(tenant_id, job_id)` performs one bounded SELECT over the exact failed reconciliation row.

The public result contains only:

- job UUID;
- positive attempt count;
- optional `last_error_code`;
- `dependency_code` from `index_reconciliation_run_failure_v1`;
- retryability boolean.

Both codes accept only lowercase ASCII letters, digits, `.`, `_`, and `-`, with a 128-byte maximum. Stored diagnostics use `#[serde(deny_unknown_fields)]` and must match the exact three-field contract.

The raw `last_error_details` object is decoded but never returned. The query does not select request/cursor JSON, source/worker/lease fields, timestamps, entity/inbox/mutation payloads, or other scope metadata.

## Authorization boundary

This crate-level adapter accepts no actor or permission object and is not a transport endpoint.

The merged server reconciliation operator still exposes only guarded `run` and `request_cancel`. A later server-owned inspection wrapper must bind the exact request tenant/actor, require effective request-scoped `modules:manage`, and reject cross-tenant requests before delegation.

This PR deliberately adds no GraphQL, HTTP, CLI, MCP, admin, or other inspection transport.

## Verification improvements

The focused verifier checks:

- exact selected columns and tenant/job/reconcile/failed predicates;
- absence of request, cursor, source, worker, lease, timestamp, and schema fields from the SELECT;
- positive attempt decoding and strict diagnostic deserialization;
- exact failure-contract and bounded machine-code validation;
- stable storage-error redaction;
- absence of production writes, requeue, reset, polling, sleeps, tasks, and transports;
- additive PostgreSQL module registration preserving retry and runner exports;
- ordinary reconciliation admission still excludes `last_error_details`;
- the guarded server operator has not prematurely gained inspection methods;
- documentation indexing, open roadmap items, and aggregate verifier registration.

## Scope boundaries

This PR does not add or claim:

- server-owned authorized inspection composition or transport mapping;
- manual requeue, retry-epoch reset, actor/reason audit, or failed-row mutation;
- automatic retry/backoff/exhaustion, scheduling, polling, or graceful shutdown;
- migrations or table-shape changes;
- reconciliation admission, runner, lease, cursor, source, mutation, cancellation, or success-state changes;
- digest comparison, orphan diagnosis, or targeted/full/shadow repair modes;
- locale/partition checkpoint dimensions;
- retained PostgreSQL execution evidence.

The canonical M6 drift-diagnosis and targeted-repair roadmap item remains open.

## Validation

Not run per maintainer instruction:

- formatting;
- Cargo checks, tests, or Clippy;
- JavaScript verifiers;
- PostgreSQL scenarios;
- workflows and CI.

Suggested maintainer commands:

```bash
cargo test -p rustok-index source_reconciliation_dead_letter_inspector -- --nocapture
cargo check -p rustok-index --all-targets
node scripts/verify/verify-index-reconciliation-dead-letter-inspection.mjs
node scripts/verify/verify-index-query-contract.mjs
```

## History

Supersedes stale #2834 and restores only the read-only inspector portion of closed #2751/#2754 without reviving consolidated plan, SalesChannel, admission, server-composition, or recovery changes.