### PR TITLE
feat(index): authorize reconciliation dead-letter inspection

### DIFF
--- a/apps/server/docs/index-reconciliation-operator-runtime.md
+++ b/apps/server/docs/index-reconciliation-operator-runtime.md
@@ -6,7 +6,12 @@ Status: `source_complete_transport_and_recovery_work_pending`.
 
 The server publishes one guarded `IndexReconciliationOperatorRuntime` after the existing Index replay composition has frozen the complete immutable source and schema registries.
 
-The boundary wraps the canonical `PostgresIndexReconciliationRunner` already exported by `rustok-index`. It performs no reconciliation database I/O during composition, starts no task, and does not create another source catalog.
+The boundary wraps both canonical PostgreSQL capabilities exported by `rustok-index`:
+
+- `PostgresIndexReconciliationRunner` for bounded run and cancellation;
+- `PostgresIndexReconciliationDeadLetterInspector` for bounded read-only failed-job inspection.
+
+Composition performs no reconciliation database I/O, starts no task, and creates no second source catalog.
 
 ## Request-bound authority
 
@@ -23,16 +28,29 @@ The boundary rejects:
 
 Run authorization compares the requested tenant before delegating to the inner reconciliation runner. The focused source regression uses a database without Index migrations and still receives `TenantMismatch`, retaining the pre-database denial boundary.
 
-Cancellation accepts only a job UUID from the caller. The tenant passed to the reconciliation runner is always derived from the authorized context; there is no separate caller-selected tenant parameter.
+Cancellation and dead-letter inspection accept only a job UUID from the caller. The tenant delegated to the runner or inspector is always derived from the authorized context; neither operation accepts a separate caller-selected tenant.
+
+Inspection authorization runs before adapter validation or database access. Without request authority it returns `MissingRequestAuthority`; `modules:read` alone returns `Forbidden`; an authorized call then delegates to the bounded crate inspector.
 
 ## Published surface
 
 The capability exposes only:
 
 - bounded `run(context, IndexReconciliationRunRequest)`;
-- tenant-scoped `request_cancel(context, job_id)`.
+- tenant-scoped `request_cancel(context, job_id)`;
+- tenant-scoped read-only `inspect_dead_letter(context, job_id)`.
 
-It does not expose:
+A successful dead-letter inspection returns only:
+
+- failed job UUID;
+- positive durable attempt count;
+- optional bounded `last_error_code`;
+- bounded dependency code;
+- retryability.
+
+Raw `last_error_details`, tenant identity, request/cursor JSON, worker and lease fields, timestamps, SQL, database causes, and payloads remain unavailable through the server runtime.
+
+The runtime does not expose:
 
 - the database connection;
 - source or schema registries;
@@ -40,7 +58,7 @@ It does not expose:
 - scheduler, polling, takeover, or task ownership;
 - worker-spawn handles;
 - direct `index_jobs` SQL;
-- dead-letter inspection or requeue;
+- retry, requeue, retry-epoch reset, or failed-row mutation;
 - GraphQL, HTTP, CLI, MCP, or admin transport.
 
 ## Composition
@@ -50,32 +68,32 @@ The existing server replay composition remains the single source-freezing point:
 1. selected PostgreSQL source factories are materialized;
 2. the complete immutable `SharedIndexSourceRegistry` is inserted;
 3. the guarded replay capability is materialized from the shared registries;
-4. the guarded reconciliation operator is constructed from the same source registry, shared schema registry, and host database.
+4. the guarded reconciliation operator is constructed from the same source registry, shared schema registry, and host database;
+5. the same operator receives a read-only dead-letter inspector over a clone of the host database handle.
 
 An absent source registry publishes no false reconciliation capability. A source registry without `SharedIndexSchemaRegistry` fails closed. Duplicate guarded reconciliation materialization also fails closed.
 
-The replay retry transition store and replay failed-scope admission merged separately. They do not alter this reconciliation operator and are not reused as reconciliation scheduling or dead-letter APIs.
+The replay retry transition store, replay failed-scope admission, and reconciliation failed-scope admission remain independent engine contracts. They are not reused as server scheduling or recovery APIs.
 
 ## Preserved engine behavior
 
-This server slice changes no reconciliation runner, migration, SQL, lease, cursor, mutation, diagnostic, cancellation, or terminal-state contract.
+This server slice changes no reconciliation runner, inspector SQL, migration, state transition, lease, cursor, mutation, diagnostic, cancellation, or terminal-state contract.
 
-It preserves the existing bounded page/pass execution, heartbeat, yield, cancellation, attempt fencing, inbox deduplication, source-version monotonicity, and bounded machine-readable failure diagnostics.
+It preserves the existing bounded page/pass execution, heartbeat, yield, cancellation, attempt fencing, inbox deduplication, source-version monotonicity, failed-scope admission, strict dead-letter diagnostic decoding, and bounded machine-readable results.
 
 ## Explicitly open
 
-- reconciliation failed-scope admission;
-- bounded reconciliation dead-letter inspection;
+- GraphQL, HTTP, CLI, MCP, or admin inspection transport;
 - authorized requeue with actor/reason audit and retry-epoch semantics;
 - automatic scheduling or takeover discovery;
 - graceful task shutdown and fleet coordination;
 - source/index digest comparison and orphan diagnosis;
 - targeted, full, or shadow repair modes;
 - locale or partition checkpoint dimensions;
-- retained PostgreSQL authorization, cancellation, restart, concurrency, and recovery evidence;
-- command and transport publication.
+- retained PostgreSQL authorization, inspection, cancellation, restart, concurrency, and recovery evidence;
+- command and recovery publication.
 
-The canonical M6 drift-diagnosis and targeted-repair roadmap item remains open. Runtime publication alone does not establish complete drift repair or production readiness.
+The canonical M6 drift-diagnosis and targeted-repair roadmap item remains open. Authorized read-only inspection does not establish recovery, complete drift repair, or production readiness.
 
 ## Validation ownership
 

--- a/apps/server/src/services/index_reconciliation_operator.rs
+++ b/apps/server/src/services/index_reconciliation_operator.rs
@@ -65,21 +65,32 @@ pub enum IndexReconciliationOperatorError {
     Forbidden,
     #[error(transparent)]
     Reconciliation(#[from] rustok_index::IndexReconciliationRunError),
+    #[error(transparent)]
+    Inspection(#[from] rustok_index::infrastructure::postgres::IndexReconciliationDeadLetterInspectionError),
 }
 
-/// Server-owned guarded operator boundary over the canonical PostgreSQL Index reconciliation runner.
+/// Server-owned guarded operator boundary over the canonical PostgreSQL Index reconciliation
+/// runner and bounded dead-letter inspector.
 ///
 /// Transport adapters must provide an exact request-bound tenant/actor context. The boundary
-/// accepts only `modules:manage`, rejects cross-tenant requests before database access, and exposes
-/// no connection, source registry, scheduler, task handle, or worker-spawn capability.
+/// accepts only `modules:manage`, rejects cross-tenant run requests before database access, derives
+/// inspection and cancellation tenant scope from the authorized context, and exposes no connection,
+/// source registry, scheduler, task handle, or worker-spawn capability.
 #[derive(Clone)]
 pub struct IndexReconciliationOperatorRuntime {
     inner: rustok_index::PostgresIndexReconciliationRunner,
+    dead_letters: rustok_index::infrastructure::postgres::PostgresIndexReconciliationDeadLetterInspector,
 }
 
 impl IndexReconciliationOperatorRuntime {
-    fn new(inner: rustok_index::PostgresIndexReconciliationRunner) -> Self {
-        Self { inner }
+    fn new(
+        inner: rustok_index::PostgresIndexReconciliationRunner,
+        dead_letters: rustok_index::infrastructure::postgres::PostgresIndexReconciliationDeadLetterInspector,
+    ) -> Self {
+        Self {
+            inner,
+            dead_letters,
+        }
     }
 
     pub async fn run(
@@ -105,6 +116,21 @@ impl IndexReconciliationOperatorRuntime {
         context.authorize_for(context.tenant_id())?;
         self.inner
             .request_cancel(context.tenant_id(), job_id)
+            .await
+            .map_err(Into::into)
+    }
+
+    pub async fn inspect_dead_letter(
+        &self,
+        context: IndexReconciliationOperatorContext,
+        job_id: Uuid,
+    ) -> std::result::Result<
+        Option<rustok_index::infrastructure::postgres::IndexReconciliationDeadLetterInspection>,
+        IndexReconciliationOperatorError,
+    > {
+        context.authorize_for(context.tenant_id())?;
+        self.dead_letters
+            .inspect(context.tenant_id(), job_id)
             .await
             .map_err(Into::into)
     }
@@ -149,8 +175,13 @@ pub(super) fn materialize_index_reconciliation_operator(
             )
         })?;
 
+    let dead_letters =
+        rustok_index::infrastructure::postgres::PostgresIndexReconciliationDeadLetterInspector::new(db.clone());
+    let runner =
+        rustok_index::PostgresIndexReconciliationRunner::new(db, sources, schemas.shared());
     extensions.insert(IndexReconciliationOperatorRuntime::new(
-        rustok_index::PostgresIndexReconciliationRunner::new(db, sources, schemas.shared()),
+        runner,
+        dead_letters,
     ));
     Ok(())
 }
@@ -400,6 +431,66 @@ mod tests {
         assert!(matches!(
             error,
             IndexReconciliationOperatorError::TenantMismatch
+        ));
+    }
+
+    #[tokio::test]
+    async fn dead_letter_inspection_authorizes_before_adapter_validation() {
+        let mut extensions = complete_registries();
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database without Index migrations");
+        materialize_index_reconciliation_operator(&mut extensions, db)
+            .expect("runtime materialization");
+        let runtime = extensions
+            .get::<IndexReconciliationOperatorRuntime>()
+            .cloned()
+            .expect("guarded runtime");
+        let tenant_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let context = IndexReconciliationOperatorContext::new(tenant_id, actor_id).unwrap();
+
+        let missing = runtime
+            .inspect_dead_letter(context, Uuid::nil())
+            .await
+            .expect_err("missing request authority must fail before adapter validation");
+        assert!(matches!(
+            missing,
+            IndexReconciliationOperatorError::MissingRequestAuthority
+        ));
+
+        let forbidden = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_READ],
+                UserRole::Admin,
+            )),
+            runtime.inspect_dead_letter(context, Uuid::nil()),
+        )
+        .await
+        .expect_err("modules:read must not inspect dead letters");
+        assert!(matches!(
+            forbidden,
+            IndexReconciliationOperatorError::Forbidden
+        ));
+
+        let delegated = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_MANAGE],
+                UserRole::Admin,
+            )),
+            runtime.inspect_dead_letter(context, Uuid::nil()),
+        )
+        .await
+        .expect_err("authorized nil job must reach bounded adapter validation");
+        assert!(matches!(
+            delegated,
+            IndexReconciliationOperatorError::Inspection(
+                rustok_index::infrastructure::postgres::IndexReconciliationDeadLetterInspectionError::NilJobId
+            )
         ));
     }
 

--- a/crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md
+++ b/crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md
@@ -1,6 +1,6 @@
 # M6 reconciliation dead-letter inspection
 
-Status: `source_complete_authorized_composition_pending`.
+Status: `source_complete_transport_and_recovery_pending`.
 
 ## Purpose
 
@@ -8,7 +8,7 @@ Status: `source_complete_authorized_composition_pending`.
 
 The adapter requires an exact non-nil tenant UUID and job UUID. Its query is restricted to the exact tenant/job with `kind = 'reconcile'` and `state = 'failed'`. Cross-tenant, active, pending, successful, cancelled, non-reconciliation, and unknown jobs therefore return no inspection.
 
-The adapter is published only through `rustok_index::infrastructure::postgres`. It is a storage capability, not a public endpoint or an authorization boundary.
+The adapter is published through `rustok_index::infrastructure::postgres`. It is a storage capability, not a public endpoint or an authorization boundary.
 
 ## Returned contract
 
@@ -38,18 +38,20 @@ The query selects only attempt count, `last_error_code`, and `last_error_details
 
 Database failures map to one stable `Storage` error with no embedded database detail. The production implementation performs no insert, update, delete, retry, requeue, reset, scheduling, polling, sleep, or task creation.
 
-## Authorization ownership
+## Authorized server composition
 
-The crate adapter intentionally accepts no actor or permission object.
+The server-owned `IndexReconciliationOperatorRuntime` now composes this inspector beside the canonical reconciliation runner.
 
-The merged server reconciliation runtime currently exposes only guarded `run` and `request_cancel` operations. A later server-owned inspection wrapper must:
+Inspection accepts only:
 
-1. bind the exact request tenant and actor;
-2. reject cross-tenant requests before storage delegation;
-3. require the request-scoped effective `modules:manage` permission;
-4. keep the database adapter and raw diagnostics inaccessible to transports.
+- one validated `IndexReconciliationOperatorContext`;
+- one job UUID.
 
-GraphQL, HTTP, CLI, MCP, and admin inspection transports remain open. This slice does not extend the current server operator surface.
+The delegated tenant is derived exclusively from the context. There is no caller-supplied tenant parameter.
+
+Before adapter validation or database access, the server boundary reads the exact request-scoped tenant/actor permission snapshot and requires effective `modules:manage`. Missing request authority and insufficient permission fail before delegation. The server returns only the bounded inspection object or typed bounded errors; it does not expose the database adapter or raw diagnostic JSON.
+
+GraphQL, HTTP, CLI, MCP, and admin transports remain open. This slice publishes an internal guarded capability only.
 
 ## Compatibility
 
@@ -59,7 +61,7 @@ It composes additively with the replay retry store, replay dead-letter admission
 
 ## Explicitly open
 
-- server-owned authorized inspection composition and transport mapping;
+- inspection transport mapping;
 - actor/reason audit records;
 - manual requeue or retry-epoch reset under the reconciliation scope lock;
 - automatic retry, backoff, exhaustion, scheduling, and graceful shutdown;

--- a/scripts/verify/verify-index-reconciliation-dead-letter-inspection.mjs
+++ b/scripts/verify/verify-index-reconciliation-dead-letter-inspection.mjs
@@ -25,6 +25,7 @@ const admissionPath =
   'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner.rs';
 const serverPath = 'apps/server/src/services/index_reconciliation_operator.rs';
 const docsPath = 'crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md';
+const serverDocsPath = 'apps/server/docs/index-reconciliation-operator-runtime.md';
 const docsIndexPath = 'crates/rustok-index/docs/README.md';
 const planPath = 'crates/rustok-index/docs/implementation-plan.md';
 const aggregatePath = 'scripts/verify/verify-index-query-contract.mjs';
@@ -173,29 +174,66 @@ const server = requireMarkers(serverPath, [
   'Permission::MODULES_MANAGE',
   'pub async fn run(',
   'pub async fn request_cancel(',
+  'pub async fn inspect_dead_letter(',
   'PostgresIndexReconciliationRunner::new',
+  'PostgresIndexReconciliationDeadLetterInspector::new(db.clone())',
+  'dead_letters: rustok_index::infrastructure::postgres::PostgresIndexReconciliationDeadLetterInspector,',
+  'Option<rustok_index::infrastructure::postgres::IndexReconciliationDeadLetterInspection>',
+  '.inspect(context.tenant_id(), job_id)',
+  'dead_letter_inspection_authorizes_before_adapter_validation',
 ]);
 const serverProduction = server.split('\n#[cfg(test)]')[0];
+const inspectStart = serverProduction.indexOf('    pub async fn inspect_dead_letter(');
+const inspectEnd = serverProduction.indexOf('\n    }\n}', inspectStart);
+if (inspectStart < 0 || inspectEnd <= inspectStart) {
+  fail(`${serverPath} guarded dead-letter inspection method is malformed`);
+}
+const serverInspect = serverProduction.slice(inspectStart, inspectEnd);
+if (serverInspect.includes('tenant_id: Uuid')) {
+  fail(`${serverPath} inspection must not accept a caller-supplied tenant`);
+}
+const serverAuthorize = serverInspect.indexOf(
+  'context.authorize_for(context.tenant_id())?;',
+);
+const serverDelegate = serverInspect.indexOf(
+  '.inspect(context.tenant_id(), job_id)',
+);
+if (serverAuthorize < 0 || serverDelegate <= serverAuthorize) {
+  fail(`${serverPath} inspection must authorize before tenant-derived adapter delegation`);
+}
 for (const forbidden of [
-  'PostgresIndexReconciliationDeadLetterInspector',
-  'IndexReconciliationDeadLetterInspection',
-  'inspect_dead_letter',
-  'pub async fn inspect(',
+  'last_error_details',
+  'SELECT ',
+  'INSERT ',
+  'UPDATE ',
+  'DELETE ',
+  'Router::new',
+  'async_graphql',
+  'requeue',
+  'retry_epoch',
+  "state = 'pending'",
 ]) {
   if (serverProduction.includes(forbidden)) {
-    fail(`${serverPath} prematurely exposes reconciliation inspection via ${forbidden}`);
+    fail(`${serverPath} guarded composition contains forbidden marker ${forbidden}`);
   }
 }
 
 requireMarkers(docsPath, [
-  'Status: `source_complete_authorized_composition_pending`.',
+  'Status: `source_complete_transport_and_recovery_pending`.',
   'Unlike ordinary dead-letter admission, inspection deliberately reads `last_error_details`',
   'The raw JSON object is never returned.',
-  'requires the request-scoped effective `modules:manage` permission',
-  'currently exposes only guarded `run` and `request_cancel` operations',
+  '## Authorized server composition',
+  'requires effective `modules:manage`',
+  'There is no caller-supplied tenant parameter.',
   'manual requeue or retry-epoch reset',
   'canonical M6 drift-diagnosis and targeted-repair roadmap item remains open',
   'maintainer-run',
+]);
+requireMarkers(serverDocsPath, [
+  'tenant-scoped read-only `inspect_dead_letter(context, job_id)`',
+  'Inspection authorization runs before adapter validation or database access',
+  'Raw `last_error_details`',
+  'GraphQL, HTTP, CLI, MCP, or admin transport',
 ]);
 requireMarkers(docsIndexPath, [
   '[M6 Reconciliation Dead-letter Admission](./m6-reconciliation-dead-letter-admission.md)',

--- a/scripts/verify/verify-index-server-reconciliation-guard.mjs
+++ b/scripts/verify/verify-index-server-reconciliation-guard.mjs
@@ -24,6 +24,8 @@ const operatorPath =
   'apps/server/src/services/index_reconciliation_operator.rs';
 const docsPath =
   'apps/server/docs/index-reconciliation-operator-runtime.md';
+const inspectionDocsPath =
+  'crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md';
 
 const composition = requireMarkers(compositionPath, [
   '#[path = "index_reconciliation_operator.rs"]',
@@ -54,12 +56,17 @@ const operator = requireMarkers(operatorPath, [
   'Permission::MODULES_MANAGE',
   'pub struct IndexReconciliationOperatorRuntime',
   'inner: rustok_index::PostgresIndexReconciliationRunner,',
+  'dead_letters: rustok_index::infrastructure::postgres::PostgresIndexReconciliationDeadLetterInspector,',
+  'Inspection(#[from] rustok_index::infrastructure::postgres::IndexReconciliationDeadLetterInspectionError),',
   'context.authorize_for(request.tenant_id())?;',
   'self.inner.run(request).await.map_err(Into::into)',
   'context.authorize_for(context.tenant_id())?;',
   '.request_cancel(context.tenant_id(), job_id)',
+  'pub async fn inspect_dead_letter(',
+  '.inspect(context.tenant_id(), job_id)',
   'extensions.get::<rustok_index::SharedIndexSourceRegistry>()',
   'extensions.get::<rustok_index::SharedIndexSchemaRegistry>()',
+  'PostgresIndexReconciliationDeadLetterInspector::new(db.clone())',
   'PostgresIndexReconciliationRunner::new(db, sources, schemas.shared())',
   'missing_sources_do_not_publish_false_reconciliation_capability',
   'source_registry_without_shared_schema_registry_fails_closed',
@@ -67,6 +74,7 @@ const operator = requireMarkers(operatorPath, [
   'duplicate_guarded_reconciliation_materialization_fails_closed',
   'operator_authorization_requires_exact_tenant_actor_and_modules_manage',
   'cross_tenant_run_is_denied_before_database_access',
+  'dead_letter_inspection_authorizes_before_adapter_validation',
   'operator_context_rejects_nil_identity',
 ]);
 
@@ -91,12 +99,20 @@ if (
 
 const runStart = operator.indexOf('    pub async fn run(');
 const cancelStart = operator.indexOf('    pub async fn request_cancel(', runStart);
-const runtimeEnd = operator.indexOf('\n}\n\nimpl fmt::Debug', cancelStart);
-if (runStart < 0 || cancelStart <= runStart || runtimeEnd <= cancelStart) {
-  fail(`${operatorPath} guarded run/cancel surface is malformed`);
+const inspectStart = operator.indexOf('    pub async fn inspect_dead_letter(', cancelStart);
+const runtimeEnd = operator.indexOf('\n}\n\nimpl fmt::Debug', inspectStart);
+if (
+  runStart < 0
+  || cancelStart <= runStart
+  || inspectStart <= cancelStart
+  || runtimeEnd <= inspectStart
+) {
+  fail(`${operatorPath} guarded run/cancel/inspection surface is malformed`);
 }
 const run = operator.slice(runStart, cancelStart);
-const cancel = operator.slice(cancelStart, runtimeEnd);
+const cancel = operator.slice(cancelStart, inspectStart);
+const inspect = operator.slice(inspectStart, runtimeEnd);
+
 if (
   run.indexOf('context.authorize_for(request.tenant_id())?;') < 0
   || run.indexOf('self.inner.run(request)')
@@ -104,15 +120,52 @@ if (
 ) {
   fail(`${operatorPath} run must authorize the request tenant before runner delegation`);
 }
-if (cancel.includes('tenant_id: Uuid')) {
-  fail(`${operatorPath} cancellation must not accept a separate caller-supplied tenant`);
+
+for (const [name, body, delegation] of [
+  ['cancellation', cancel, '.request_cancel(context.tenant_id(), job_id)'],
+  ['inspection', inspect, '.inspect(context.tenant_id(), job_id)'],
+]) {
+  if (body.includes('tenant_id: Uuid')) {
+    fail(`${operatorPath} ${name} must not accept a separate caller-supplied tenant`);
+  }
+  const auth = body.indexOf('context.authorize_for(context.tenant_id())?;');
+  const delegate = body.indexOf(delegation);
+  if (auth < 0 || delegate <= auth) {
+    fail(`${operatorPath} ${name} must authorize and derive tenant scope from context`);
+  }
 }
+
+for (const forbidden of [
+  'last_error_details',
+  'dependency_code: String',
+  'DatabaseConnection',
+  'PostgresIndexReconciliationDeadLetterInspector::new',
+]) {
+  if (inspect.includes(forbidden)) {
+    fail(`${operatorPath} inspection method exposes forbidden adapter detail ${forbidden}`);
+  }
+}
+
+const materializeStart = operator.indexOf(
+  'pub(super) fn materialize_index_reconciliation_operator(',
+);
+const testsStart = operator.indexOf('\n#[cfg(test)]', materializeStart);
+const materialize = operator.slice(materializeStart, testsStart);
+const inspectorConstruction = materialize.indexOf(
+  'PostgresIndexReconciliationDeadLetterInspector::new(db.clone())',
+);
+const runnerConstruction = materialize.indexOf(
+  'PostgresIndexReconciliationRunner::new(db, sources, schemas.shared())',
+);
+const runtimeInsertion = materialize.indexOf(
+  'extensions.insert(IndexReconciliationOperatorRuntime::new(',
+);
 if (
-  cancel.indexOf('context.authorize_for(context.tenant_id())?;') < 0
-  || cancel.indexOf('.request_cancel(context.tenant_id(), job_id)')
-    <= cancel.indexOf('context.authorize_for(context.tenant_id())?;')
+  inspectorConstruction < 0
+  || runnerConstruction <= inspectorConstruction
+  || runtimeInsertion <= runnerConstruction
 ) {
-  fail(`${operatorPath} cancellation must authorize and derive tenant scope from context`);
+  fail(`${operatorPath} must compose inspector and runner into one guarded runtime`);
 }
 
 const productionOperator = operator.split('\n#[cfg(test)]')[0];
@@ -126,9 +179,8 @@ for (const forbidden of [
   'Router::new',
   'route(',
   'async_graphql',
-  'PostgresIndexReconciliationDeadLetterInspector',
-  'inspect_dead_letter',
   'requeue',
+  'retry_epoch',
   "state = 'pending'",
 ]) {
   if (productionOperator.includes(forbidden)) {
@@ -140,14 +192,21 @@ requireMarkers(docsPath, [
   'Status: `source_complete_transport_and_recovery_work_pending`.',
   'requires effective `Permission::MODULES_MANAGE`',
   'retaining the pre-database denial boundary',
-  'there is no separate caller-selected tenant parameter',
-  'single source-freezing point',
-  'publishes no false reconciliation capability',
-  'reconciliation failed-scope admission',
-  'bounded reconciliation dead-letter inspection',
+  'neither operation accepts a separate caller-selected tenant',
+  'Inspection authorization runs before adapter validation or database access',
+  'tenant-scoped read-only `inspect_dead_letter(context, job_id)`',
+  'The existing server replay composition remains the single source-freezing point',
+  'read-only dead-letter inspector over a clone of the host database handle',
   'authorized requeue with actor/reason audit',
   'canonical M6 drift-diagnosis and targeted-repair roadmap item remains open',
   'maintainer-run',
+]);
+requireMarkers(inspectionDocsPath, [
+  'Status: `source_complete_transport_and_recovery_pending`.',
+  '## Authorized server composition',
+  'There is no caller-supplied tenant parameter.',
+  'requires effective `modules:manage`',
+  'GraphQL, HTTP, CLI, MCP, and admin transports remain open',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
   '- [ ] Add drift diagnosis, targeted repair commands, and admitted repair evidence.',
@@ -155,6 +214,7 @@ requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
 ]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-server-reconciliation-guard.mjs'",
+  "'verify-index-reconciliation-dead-letter-inspection.mjs'",
   "'verify-index-replay-retry-store.mjs'",
   "'verify-index-replay-dead-letter-admission.mjs'",
 ]);


### PR DESCRIPTION
## Summary

- extend the existing server-owned `IndexReconciliationOperatorRuntime` with bounded read-only dead-letter inspection;
- compose `PostgresIndexReconciliationDeadLetterInspector` beside the canonical reconciliation runner after source/schema registry freezing;
- accept only the existing validated operator context and a job UUID;
- derive tenant scope exclusively from the request-bound context;
- require effective request-scoped `modules:manage` before adapter validation or database access;
- return only the bounded crate inspection object or typed bounded errors;
- preserve the existing run/cancel surface and all fail-closed composition behavior;
- actualize the server and Index handoff documents;
- strengthen both existing reconciliation guard verifiers instead of bypassing their previous inspection prohibition.

## Fresh-main audit

The branch is built directly on `main@9f3fe4090cf65541a5f5d108860f6282f8777bd0`, contains one clean commit, and is one commit ahead and zero behind `main`.

The latest intervening Cart and Blog changes have no overlap with the five touched Index/server paths.

No separate stale PR existed for this exact authorized-composition slice. It follows merged guarded runtime #2900 and bounded storage inspector #2907.

## Authorization boundary

`inspect_dead_letter(context, job_id)` accepts no tenant parameter.

The method first calls the existing guarded `authorize_for(context.tenant_id())` path, which resolves the exact request-scoped tenant/actor permission snapshot and requires `Permission::MODULES_MANAGE`. Only after that succeeds does it delegate:

```text
PostgresIndexReconciliationDeadLetterInspector::inspect(context.tenant_id(), job_id)
```

The focused source regression retains the ordering with a nil job UUID:

- no request authority returns `MissingRequestAuthority` before adapter validation;
- `modules:read` returns `Forbidden` before adapter validation;
- `modules:manage` reaches the bounded inspector and returns its typed `NilJobId` validation error.

## Returned contract

The server exposes the existing bounded inspection value only:

- failed job UUID;
- positive durable attempt count;
- optional bounded `last_error_code`;
- bounded dependency code;
- retryability.

The runtime does not decode, copy, log, or return raw `last_error_details`. It performs no direct SQL and does not expose the database connection or inspector adapter.

## Composition

The existing replay composition remains the single source-freezing point. The reconciliation materializer now builds:

- the canonical `PostgresIndexReconciliationRunner` from the frozen source/schema registries;
- one read-only `PostgresIndexReconciliationDeadLetterInspector` over a clone of the host database handle;
- one `IndexReconciliationOperatorRuntime` containing both capabilities.

Missing sources still publish no false capability. Sources without the shared schema registry and duplicate materialization still fail closed. Composition starts no task and performs no database I/O.

## Verification actualization

`verify-index-server-reconciliation-guard.mjs` now checks:

- run, cancellation, and inspection method ordering;
- no caller-supplied tenant for cancellation or inspection;
- authorization before tenant-derived inspection delegation;
- runner and inspector composition into one guarded runtime;
- absence of direct SQL, transport, tasks, requeue, retry reset, and failed-row mutation;
- retained registry and duplicate-materialization guards.

`verify-index-reconciliation-dead-letter-inspection.mjs` continues to check the exact storage SELECT, strict diagnostic decoding, bounded machine codes, stable storage errors, and ordinary-admission exclusion of `last_error_details`; it now also requires the guarded server composition and forbids raw diagnostics, SQL, transport, and recovery markers at that boundary.

## Scope boundaries

This PR does not add or claim:

- GraphQL, HTTP, CLI, MCP, or admin inspection transport;
- manual requeue or retry-epoch reset;
- actor/reason audit records;
- automatic retry, backoff, exhaustion, scheduling, polling, or graceful shutdown;
- migrations or table-shape changes;
- reconciliation runner, inspector SQL, admission, state, lease, cursor, source, mutation, cancellation, or success changes;
- digest comparison, orphan diagnosis, or targeted/full/shadow repair modes;
- locale/partition checkpoint dimensions;
- retained PostgreSQL authorization or inspection execution evidence.

The canonical M6 drift-diagnosis and targeted-repair roadmap item remains open.

## Validation

Not run per maintainer instruction:

- formatting;
- Cargo checks, tests, or Clippy;
- JavaScript verifiers;
- PostgreSQL scenarios;
- workflows and CI.

Suggested maintainer commands:

```bash
cargo test -p rustok-server index_reconciliation_operator -- --nocapture
cargo check -p rustok-server --all-targets
node scripts/verify/verify-index-server-reconciliation-guard.mjs
node scripts/verify/verify-index-reconciliation-dead-letter-inspection.mjs
node scripts/verify/verify-index-query-contract.mjs
```
