### PR TITLE
feat(forum): redirect merged topic reads

### DIFF
--- a/crates/rustok-forum/Cargo.toml
+++ b/crates/rustok-forum/Cargo.toml
@@ -42,3 +42,4 @@ url = "2.5"
 rustok-notifications.workspace = true
 tokio.workspace = true
 toml.workspace = true
+tower.workspace = true

--- a/crates/rustok-forum/README.md
+++ b/crates/rustok-forum/README.md
@@ -36,10 +36,12 @@
 - Depends on `rustok-taxonomy` for the shared scope-aware term dictionary behind
   forum topic tags.
 - Category slugs are translation-local, while topic slugs remain stable thread
-  labels; current public forum lookup stays ID-based. A selected merged-source ID
-  resolves through the immutable `forum_topic_merge_operations` chain to the
-  terminal retained topic. HTTP 3xx responses and slug aliases are not part of
-  the current contract.
+  labels; current public Forum lookup stays ID-based. A selected merged-source
+  ID resolves through the immutable `forum_topic_merge_operations` chain to the
+  terminal retained topic. `GET /api/forum/topics/{id}` returns an
+  authorization-safe `308 Permanent Redirect` for a merged source and keeps the
+  existing `200 TopicResponse` for a direct target. Slug aliases and localized
+  public routes are not part of the current contract.
 - Shares SEO target ownership with `rustok-seo`: the shared SEO runtime now resolves
   `forum_category` and `forum_topic`, while owner-side SEO authoring stays embedded
   in `rustok-forum-admin`; public SEO for channel-restricted topics is resolved only
@@ -103,5 +105,5 @@ into README files, issues, or additional planning documents.
 
 - [Module docs](./docs/README.md)
 - [Canonical implementation plan](./docs/implementation-plan.md)
-- [Canonical merged-topic resolution](./docs/forum-21i-topic-canonical-resolution.md)
+- [Canonical merged-topic resolution and HTTP redirect](./docs/forum-21i-topic-canonical-resolution.md)
 - [Platform docs index](../../docs/index.md)

--- a/crates/rustok-forum/contracts/forum-topic-canonical-resolution.json
+++ b/crates/rustok-forum/contracts/forum-topic-canonical-resolution.json
@@ -1,6 +1,7 @@
 {
   "contract": "forum_topic_canonical_resolution_v1",
   "task": "FORUM-21I",
+  "latest_transport_slice": "FORUM-21J",
   "parent_task": "FORUM-21",
   "extends": "FORUM-21B",
   "status": "source_ready_maintainer_execution_pending",
@@ -32,9 +33,25 @@
     "topic_service_storefront_get": "evaluates_category_and_topic_visibility_on_the_canonical_target",
     "graphql_forum_topic": "inherits_canonical_target_resolution_from_TopicService",
     "seo_topic_load_and_route": "inherit_canonical_target_resolution_from_TopicService",
-    "rest_get_topic": "returns_the_canonical_target_representation_with_the_target_id",
+    "rest_get_direct_target": "returns_200_with_the_existing_target_representation",
+    "rest_get_merged_source": "returns_308_with_a_tenant_relative_canonical_Location",
     "list_reads_changed": false,
     "mutation_target_resolution_changed": false
+  },
+  "http_redirect": {
+    "task": "FORUM-21J",
+    "method": "GET",
+    "path": "/api/forum/topics/{id}",
+    "status": 308,
+    "location": "/api/forum/topics/{canonical_topic_id}",
+    "explicit_locale_query_is_preserved_and_percent_encoded": true,
+    "implicit_request_locale_is_not_materialized_into_location": true,
+    "authorization_is_checked_before_canonical_identity_disclosure": true,
+    "target_read_is_hydrated_before_redirect": true,
+    "missing_and_forbidden_responses_have_no_location": true,
+    "cache_control": "private, no-store",
+    "middleware_is_scoped_to_get_only": true,
+    "put_delete_and_other_mutations_follow_source_ids": false
   },
   "error": {
     "variant": "TopicCanonicalResolutionConflict",
@@ -47,27 +64,32 @@
     "topic_response_shape_changed": false,
     "graphql_schema_changed": false,
     "rest_route_shape_changed": false,
+    "rest_direct_target_status_changed": false,
+    "rest_merged_source_status_changed": true,
     "seo_target_contract_changed": false,
     "merge_input_result_receipt_or_event_changed": false,
     "shared_rustok_events_contract_changed": false
   },
-  "test": "crates/rustok-forum/tests/topic_canonical_resolution_sqlite.rs",
+  "canonical_resolution_test": "crates/rustok-forum/tests/topic_canonical_resolution_sqlite.rs",
+  "http_redirect_test": "crates/rustok-forum/src/controllers/topic_redirect.rs",
   "documentation": "crates/rustok-forum/docs/forum-21i-topic-canonical-resolution.md",
   "cumulative_contract": "crates/rustok-forum/contracts/forum-topic-merge-owner.json",
   "cumulative_documentation": "crates/rustok-forum/docs/forum-21b-topic-merge-owner.md",
   "verifier": "scripts/verify/verify-forum-topic-canonical-resolution.mjs",
+  "http_redirect_verifier": "scripts/verify/verify-forum-topic-http-redirect.mjs",
   "maintainer_commands": [
     "node scripts/verify/verify-forum-topic-merge-owner.mjs",
     "node scripts/verify/verify-forum-topic-canonical-resolution.mjs",
-    "cargo test -p rustok-forum --test topic_canonical_resolution_sqlite -- --nocapture"
+    "node scripts/verify/verify-forum-topic-http-redirect.mjs",
+    "cargo test -p rustok-forum --test topic_canonical_resolution_sqlite -- --nocapture",
+    "cargo test -p rustok-forum controllers::topic_redirect::tests -- --nocapture"
   ],
   "non_claims": [
     "no verifier test formatter Cargo command SQLite PostgreSQL workflow or CI execution is claimed",
-    "no HTTP 3xx Location redirect is added",
-    "no slug alias or slug route is added",
-    "no public merge transport is added",
+    "no slug alias localized public route or slug route tombstone is added",
+    "no public merge command transport is added",
     "no mutation command follows merged source identities",
     "no cross-category merge split fork or reply-range workflow is added",
-    "FORUM-21 is not promoted from planned"
+    "FORUM-21 and FORUM-24 are not promoted from planned"
   ]
 }

--- a/crates/rustok-forum/contracts/forum-topic-canonical-resolution.json
+++ b/crates/rustok-forum/contracts/forum-topic-canonical-resolution.json
@@ -48,6 +48,8 @@
     "implicit_request_locale_is_not_materialized_into_location": true,
     "authorization_is_checked_before_canonical_identity_disclosure": true,
     "target_read_is_hydrated_before_redirect": true,
+    "location_uses_hydrated_target_identity": true,
+    "runtime_topic_service_composition_is_reused": true,
     "missing_and_forbidden_responses_have_no_location": true,
     "cache_control": "private, no-store",
     "middleware_is_scoped_to_get_only": true,

--- a/crates/rustok-forum/contracts/forum-topic-canonical-resolution.json
+++ b/crates/rustok-forum/contracts/forum-topic-canonical-resolution.json
@@ -51,7 +51,8 @@
     "missing_and_forbidden_responses_have_no_location": true,
     "cache_control": "private, no-store",
     "middleware_is_scoped_to_get_only": true,
-    "put_delete_and_other_mutations_follow_source_ids": false
+    "mutation_commands_follow_canonical_target": false,
+    "put_delete_and_other_mutations_are_unchanged": true
   },
   "error": {
     "variant": "TopicCanonicalResolutionConflict",

--- a/crates/rustok-forum/contracts/forum-topic-merge-owner.json
+++ b/crates/rustok-forum/contracts/forum-topic-merge-owner.json
@@ -58,6 +58,8 @@
     "rest_direct_target_returns_200": true,
     "rest_merged_source_returns_308": true,
     "rest_location_is_tenant_relative": true,
+    "rest_location_uses_hydrated_target_identity": true,
+    "rest_runtime_topic_service_composition_is_reused": true,
     "rest_redirect_cache_control": "private, no-store",
     "rest_redirect_requires_read_authorization_and_target_hydration": true,
     "rest_redirect_is_get_only": true

--- a/crates/rustok-forum/contracts/forum-topic-merge-owner.json
+++ b/crates/rustok-forum/contracts/forum-topic-merge-owner.json
@@ -1,7 +1,7 @@
 {
   "contract": "forum_topic_merge_owner_v1",
   "task": "FORUM-21B",
-  "latest_policy_slice": "FORUM-21I",
+  "latest_policy_slice": "FORUM-21J",
   "parent_task": "FORUM-21",
   "status": "source_ready_maintainer_execution_pending",
   "canonical_plan_status": "planned",
@@ -55,7 +55,12 @@
     "selected_topic_reads_return_terminal_target": true,
     "storefront_visibility_uses_terminal_target": true,
     "graphql_and_seo_inherit_TopicService_resolution": true,
-    "rest_returns_target_representation_without_HTTP_3xx": true
+    "rest_direct_target_returns_200": true,
+    "rest_merged_source_returns_308": true,
+    "rest_location_is_tenant_relative": true,
+    "rest_redirect_cache_control": "private, no-store",
+    "rest_redirect_requires_read_authorization_and_target_hydration": true,
+    "rest_redirect_is_get_only": true
   },
   "transactional_invariants": [
     "the operation requires non-nil tenant operation source target and human actor identities",
@@ -106,8 +111,10 @@
   },
   "test": "crates/rustok-forum/tests/topic_merge_sqlite.rs",
   "canonical_resolution_test": "crates/rustok-forum/tests/topic_canonical_resolution_sqlite.rs",
+  "http_redirect_test": "crates/rustok-forum/src/controllers/topic_redirect.rs",
   "verifier": "scripts/verify/verify-forum-topic-merge-owner.mjs",
   "canonical_resolution_verifier": "scripts/verify/verify-forum-topic-canonical-resolution.mjs",
+  "http_redirect_verifier": "scripts/verify/verify-forum-topic-http-redirect.mjs",
   "documentation": "crates/rustok-forum/docs/forum-21b-topic-merge-owner.md",
   "solution_policy_contract": "crates/rustok-forum/contracts/forum-topic-merge-solution-policy.json",
   "solution_policy_documentation": "crates/rustok-forum/docs/forum-21h-topic-merge-solution-policy.md",
@@ -117,19 +124,21 @@
     "node scripts/verify/verify-forum-topic-merge-owner.mjs",
     "node scripts/verify/verify-forum-topic-merge-solution-policy.mjs",
     "node scripts/verify/verify-forum-topic-canonical-resolution.mjs",
+    "node scripts/verify/verify-forum-topic-http-redirect.mjs",
     "cargo test -p rustok-forum --test topic_merge_sqlite -- --nocapture",
-    "cargo test -p rustok-forum --test topic_canonical_resolution_sqlite -- --nocapture"
+    "cargo test -p rustok-forum --test topic_canonical_resolution_sqlite -- --nocapture",
+    "cargo test -p rustok-forum controllers::topic_redirect::tests -- --nocapture"
   ],
   "non_claims": [
     "this source-ready slice does not claim that verifiers SQLite tests Cargo checks formatting workflows or CI ran",
     "this source-ready slice does not promote the canonical FORUM-21 status before maintainer execution and remaining workflows",
-    "this slice does not add public REST GraphQL native admin or storefront merge transport",
-    "this slice does not add an HTTP 3xx Location redirect slug alias or slug route tombstone",
+    "this slice does not add public REST GraphQL native admin or storefront merge command transport",
+    "this slice does not add a slug alias localized public route or slug route tombstone",
     "this slice does not make mutation commands follow merged source identities",
     "this slice does not support cross-category merge split fork or reply-range operations",
     "dedicated bounded slices own subscriptions read state tags topic votes and topic-local audience reconciliation",
     "this slice does not choose a winner when source and target both have accepted solutions",
     "this slice does not provide PostgreSQL concurrency runtime evidence",
-    "this slice is not sufficient to mark FORUM-21 done"
+    "FORUM-21 and FORUM-24 remain planned"
   ]
 }

--- a/crates/rustok-forum/docs/README.md
+++ b/crates/rustok-forum/docs/README.md
@@ -16,7 +16,8 @@ documents describe stable contracts only and must not duplicate its backlog.
 - publish the canonical forum runtime contract for categories, topics, replies and moderation;
 - keep forum-owned transport surfaces, Q&A capabilities and UI packages inside the module;
 - keep REST handlers on a narrow `ForumHttpRuntime` with explicit DB/event bus handles; `controllers::axum_router` builds it from `HostRuntimeContext` and generated host composition mounts it without a framework adapter;
-- resolve selected merged-source topic IDs through the immutable merge receipt ledger to one retained canonical target while keeping the public lookup contract ID-based;
+- resolve selected merged-source topic IDs through the immutable merge receipt ledger to one retained canonical target;
+- return an authorization-safe permanent redirect from the existing ID-based REST GET route when its path ID is a merged source, while direct targets retain the existing JSON response;
 - evolve the forum as a taxonomy-aware and channel-aware domain with an explicit observability surface.
 
 ## Scope
@@ -51,8 +52,8 @@ documents describe stable contracts only and must not duplicate its backlog.
 - `cargo xtask module test forum`
 - `npm run verify:page-builder:consumer:forum` for fast FBA consumer guardrail without compilation, including Wave 1 smoke/SLO/trace anti-drift checks;
 - targeted tests for topic/reply lifecycle, moderation, votes, subscriptions,
-  visibility contracts, merged-topic canonical resolution, and request-scoped
-  profile author-summary filtering;
+  visibility contracts, merged-topic canonical resolution and HTTP redirects,
+  and request-scoped profile author-summary filtering;
 - `npm run verify:channel:proof-points` for no-compile capture of forum channel-aware read-path/SEO markers
 
 ## Related documents
@@ -60,7 +61,7 @@ documents describe stable contracts only and must not duplicate its backlog.
 - [README crate](../README.md)
 - [Canonical implementation plan](./implementation-plan.md)
 - [FORUM-21B merge owner](./forum-21b-topic-merge-owner.md)
-- [FORUM-21I canonical merged-topic resolution](./forum-21i-topic-canonical-resolution.md)
+- [FORUM-21I/J canonical resolution and HTTP redirect](./forum-21i-topic-canonical-resolution.md)
 - [Admin UI package](../admin/README.md)
 - [Storefront UI package](../storefront/README.md)
 - [Event flow contract](../../../docs/architecture/event-flow-contract.md)

--- a/crates/rustok-forum/docs/forum-21b-topic-merge-owner.md
+++ b/crates/rustok-forum/docs/forum-21b-topic-merge-owner.md
@@ -9,7 +9,8 @@ umbrella: merge one active source topic into one retained active target topic
 when both topics belong to the same active category. FORUM-21H extends that
 same transaction with the accepted-solution policy. FORUM-21I uses the
 immutable receipt as the canonical selected-read edge from an archived source
-tombstone to the retained target.
+tombstone to the retained target. FORUM-21J composes that edge into an
+authorization-safe permanent redirect for the existing REST topic GET route.
 
 The cumulative machine contract is:
 
@@ -64,10 +65,10 @@ target must differ.
 - the category retains both topic rows and therefore keeps its retained
   `topic_count`; its published `reply_count` also remains unchanged.
 
-Cross-category merge, HTTP redirects, slug aliases, split, fork and reply-range
-workflows remain separate policies. Subscription, read-state, tag, vote,
-topic-local audience and canonical selected-read resolution are delivered by
-their dedicated FORUM-21 slices.
+Cross-category merge, slug aliases, localized public routes, split, fork and
+reply-range workflows remain separate policies. Subscription, read-state, tag,
+vote, topic-local audience, canonical selected-read resolution and REST source
+redirects are delivered by their dedicated FORUM-21 slices.
 
 ## Idempotency
 
@@ -142,7 +143,7 @@ PostgreSQL and SQLite reject solution inserts or owner-key updates unless:
 Delete remains available to clear a solution and to perform the source-only
 transfer sequence inside the merge transaction.
 
-## Canonical selected reads
+## Canonical selected reads and REST redirect
 
 `m20260803_000017_add_forum_topic_canonical_resolution` makes the append-only
 merge receipt the only source-to-target canonical edge. No alias table or
@@ -160,9 +161,22 @@ parallel redirect registry is introduced.
 - `TopicService`, GraphQL selected-topic lookup, storefront selected-topic
   lookup and Forum SEO target loading all use the terminal target identity.
 
-REST remains ID-based and returns the canonical target representation with the
-target ID. HTTP 3xx responses, `Location` headers, slug aliases and route
-tombstones remain a later route-contract slice.
+The existing ID-based REST route now distinguishes direct and merged IDs:
+
+- `GET /api/forum/topics/{target}` returns the existing `200 TopicResponse`;
+- `GET /api/forum/topics/{source}` returns `308 Permanent Redirect` with a
+  tenant-relative `Location` pointing at the retained target;
+- an explicit locale query is preserved and percent-encoded;
+- the redirect is emitted only after read authorization, owner resolution and
+  target locale/fallback hydration;
+- missing and forbidden responses disclose no `Location`;
+- redirect responses use `Cache-Control: private, no-store`;
+- the route layer is attached only to GET, so PUT, DELETE and all other command
+  paths retain exact-identity behavior.
+
+The generated OpenAPI path records the existing `200` response and the new
+`308` response headers without adding a second route or response DTO. Slug
+aliases, localized storefront URLs and slug tombstones remain FORUM-24 work.
 
 ## Persistence and events
 
@@ -174,8 +188,8 @@ target topic, category and human actor. The semantic event remains:
 forum.topic.merged / schema version 1
 ```
 
-FORUM-21H and FORUM-21I do not change the shared event payload or receipt row
-shape. The existing source-topic, target-topic and category projection
+FORUM-21H through FORUM-21J do not change the shared event payload or receipt
+row shape. The existing source-topic, target-topic and category projection
 invalidations remain the durable cross-consumer repair signal.
 
 ## Regression coverage
@@ -208,17 +222,28 @@ invalidations remain the durable cross-consumer repair signal.
 - unknown IDs remain not found;
 - duplicate source edges and active-source receipt inserts are rejected.
 
+The controller tests in `topic_redirect.rs` are source-ready to verify a real
+SQLite merge through a real Axum route:
+
+- source GET returns `308`, canonical `Location` and `private, no-store`;
+- direct target GET reaches the existing JSON handler;
+- missing and forbidden reads have no `Location`;
+- PUT bypasses the GET-only redirect middleware.
+
 ## Remaining FORUM-21 work
 
-The canonical `FORUM-21` entry remains `planned`. FORUM-21A through FORUM-21I
+The canonical `FORUM-21` entry remains `planned`. FORUM-21A through FORUM-21J
 are bounded partial slices; remaining work includes:
 
 - maintainer execution and retained SQLite/PostgreSQL evidence;
-- public/admin merge transport composition and exact authorization context;
-- HTTP redirects, slug aliases and route tombstones;
+- public/admin merge command transport composition and exact authorization
+  context;
 - an explicit manager-selected resolution command for competing solutions;
 - cross-category merge and checked category ownership policy;
 - split, fork and reply-range workflows.
+
+Localized routes, canonical storefront URLs, slug aliases and route tombstones
+remain the separate planned FORUM-24 task.
 
 ## Maintainer verification
 
@@ -226,8 +251,10 @@ are bounded partial slices; remaining work includes:
 node scripts/verify/verify-forum-topic-merge-owner.mjs
 node scripts/verify/verify-forum-topic-merge-solution-policy.mjs
 node scripts/verify/verify-forum-topic-canonical-resolution.mjs
+node scripts/verify/verify-forum-topic-http-redirect.mjs
 cargo test -p rustok-forum --test topic_merge_sqlite -- --nocapture
 cargo test -p rustok-forum --test topic_canonical_resolution_sqlite -- --nocapture
+cargo test -p rustok-forum controllers::topic_redirect::tests -- --nocapture
 ```
 
 No command above was run by the implementation agent, per maintainer request.

--- a/crates/rustok-forum/docs/forum-21i-topic-canonical-resolution.md
+++ b/crates/rustok-forum/docs/forum-21i-topic-canonical-resolution.md
@@ -1,4 +1,4 @@
-# FORUM-21I canonical merged-topic resolution
+# FORUM-21I/J canonical merged-topic resolution and HTTP redirect
 
 ## Status
 
@@ -6,8 +6,9 @@
 
 FORUM-21I adds one bounded read-side policy beneath the planned `FORUM-21`
 umbrella. A selected topic ID that previously became the archived source of a
-successful FORUM-21B merge now resolves through the immutable merge receipt
-ledger to the terminal retained topic.
+successful FORUM-21B merge resolves through the immutable merge receipt ledger
+to the terminal retained topic. FORUM-21J composes that owner evidence into the
+existing ID-based REST topic route as an authorization-safe permanent redirect.
 
 Machine contract:
 
@@ -25,8 +26,8 @@ crates/rustok-forum/contracts/forum-topic-merge-owner.json
 
 No alias table, compatibility registry or parallel redirect model is added.
 `forum_topic_merge_operations` already records the committed source and target
-inside the original merge transaction and is append-only. FORUM-21I makes that
-ledger the sole canonical source-to-target edge.
+inside the original merge transaction and is append-only. FORUM-21I/J keeps
+that ledger as the sole canonical source-to-target edge.
 
 Migration
 `m20260803_000017_add_forum_topic_canonical_resolution` adds:
@@ -83,25 +84,63 @@ selected-topic hydration:
   through the same owner path.
 
 The returned `TopicResponse.id` is the terminal target ID. Response shapes,
-GraphQL fields, REST path parameters and SEO target contracts do not change.
+GraphQL fields and SEO target contracts do not change.
 
-## REST boundary
+## REST permanent redirect
 
-Forum public topic lookup remains ID-based. `GET /api/forum/topics/{id}` now
-returns the canonical target representation when `{id}` is a merged source.
-This slice deliberately does not emit an HTTP 3xx status or `Location` header.
+Forum public topic lookup remains ID-based at:
 
-A later route-focused slice may add permanent HTTP redirects and slug aliases
-once the public URL contract is explicitly selected. FORUM-21I does not invent
-that route model inside the domain resolver.
+```text
+GET /api/forum/topics/{id}
+```
 
-## Mutation boundary
+A direct canonical target keeps the existing `200` response and existing
+`TopicResponse` body. A merged source now returns:
 
-Only selected reads follow canonical merge history. Update, delete, vote,
-subscription, moderation and reply commands continue to require their exact
-current topic identity. This prevents a stale source ID from silently mutating a
-retained target without an explicit command-transport policy and authorization
-review.
+```text
+308 Permanent Redirect
+Location: /api/forum/topics/{canonical_topic_id}
+Cache-Control: private, no-store
+```
+
+The `Location` value is tenant-relative because tenant identity remains owned by
+the host request context rather than embedded into an owner-module path. An
+explicit `locale` query parameter is preserved through
+`url::form_urlencoded::Serializer`; an implicit locale selected from headers,
+cookies or tenant fallback is not materialized into the redirect URI.
+
+The route middleware follows these boundaries:
+
+1. missing authentication is rejected by the existing extractor;
+2. a caller without `forum_topics:read` passes to the existing handler, which
+   retains its exact `forum_permission_denied` response and receives no
+   canonical identity evidence;
+3. an authorized caller resolves the canonical topic;
+4. a direct target passes to the existing GET handler;
+5. a merged source performs the same target locale/fallback hydration before
+   emitting `Location`;
+6. missing, hidden, invalid-locale and integrity failures return their existing
+   non-redirect response without a `Location` header.
+
+The middleware is attached to the GET method before PUT and DELETE methods are
+registered on the same `MethodRouter`. Update, delete, vote, subscription,
+moderation, reply and other commands continue to require their exact current
+topic identity. A stale source ID never silently mutates the retained target.
+
+`private, no-store` prevents a shared intermediary from retaining a redirect
+that was authorized under one tenant or viewer context. This source-ready slice
+does not introduce a host/domain cache key contract.
+
+## OpenAPI boundary
+
+The generated Forum OpenAPI path is owned by the real redirect middleware
+symbol and records both outcomes:
+
+- `200` with `TopicResponse` for the direct canonical target;
+- `308` with `Location` and `Cache-Control` headers for a merged source.
+
+The path shape is unchanged. There is no parallel REST endpoint and no second
+response DTO.
 
 ## Failure mapping
 
@@ -125,14 +164,26 @@ to verify:
 - a second edge for the same source is rejected;
 - a direct receipt with an active source is rejected.
 
-## Remaining FORUM-21 work
+The controller tests in
+`crates/rustok-forum/src/controllers/topic_redirect.rs` are source-ready to
+verify through a real Axum router and real SQLite owner merge:
 
-The canonical `FORUM-21` entry remains `planned`. FORUM-21A through FORUM-21I
-are bounded source-ready slices. Remaining work includes:
+- merged source GET returns `308` with the target ID;
+- an explicit locale survives in the encoded `Location` value;
+- redirect cache policy is `private, no-store`;
+- direct target GET reaches the existing handler and returns target JSON;
+- missing and forbidden reads expose no `Location`;
+- PUT registered after the GET route layer does not execute redirect logic.
+
+## Remaining FORUM-21 and FORUM-24 work
+
+The canonical `FORUM-21` and `FORUM-24` entries remain `planned`. FORUM-21A
+through FORUM-21J are bounded source-ready slices. Remaining work includes:
 
 - maintainer execution and retained SQLite/PostgreSQL evidence;
-- an explicit public HTTP redirect and slug/route tombstone contract;
-- public/admin merge transport composition;
+- localized public routes, canonical storefront URLs, slug aliases and slug
+  tombstones under FORUM-24;
+- public/admin merge command transport composition;
 - manager-selected resolution when both topics have accepted solutions;
 - cross-category merge;
 - split, fork and reply-range workflows.
@@ -142,7 +193,9 @@ are bounded source-ready slices. Remaining work includes:
 ```bash
 node scripts/verify/verify-forum-topic-merge-owner.mjs
 node scripts/verify/verify-forum-topic-canonical-resolution.mjs
+node scripts/verify/verify-forum-topic-http-redirect.mjs
 cargo test -p rustok-forum --test topic_canonical_resolution_sqlite -- --nocapture
+cargo test -p rustok-forum controllers::topic_redirect::tests -- --nocapture
 ```
 
 No command above was run by the implementation agent, per maintainer request.

--- a/crates/rustok-forum/src/controllers/mod.rs
+++ b/crates/rustok-forum/src/controllers/mod.rs
@@ -19,6 +19,7 @@ pub mod quote_commands;
 pub mod read_state;
 pub mod replies;
 pub mod subscriptions;
+mod topic_redirect;
 pub mod topics;
 pub mod users;
 pub mod widgets;
@@ -197,6 +198,10 @@ pub fn axum_router(runtime: &HostRuntimeContext) -> anyhow::Result<Router> {
         .route(
             "/api/forum/topics/{id}",
             get(topics::get_topic)
+                .route_layer(axum::middleware::from_fn_with_state(
+                    state.clone(),
+                    topic_redirect::redirect_merged_topic,
+                ))
                 .put(content_commands::update_topic)
                 .delete(topics::delete_topic),
         )

--- a/crates/rustok-forum/src/controllers/mod.rs
+++ b/crates/rustok-forum/src/controllers/mod.rs
@@ -19,7 +19,7 @@ pub mod quote_commands;
 pub mod read_state;
 pub mod replies;
 pub mod subscriptions;
-mod topic_redirect;
+pub(crate) mod topic_redirect;
 pub mod topics;
 pub mod users;
 pub mod widgets;

--- a/crates/rustok-forum/src/controllers/topic_redirect.rs
+++ b/crates/rustok-forum/src/controllers/topic_redirect.rs
@@ -13,7 +13,7 @@ use rustok_api::{
 use rustok_web::HttpResult;
 use uuid::Uuid;
 
-use crate::{ListTopicsFilter, TopicService};
+use crate::ListTopicsFilter;
 
 use super::ForumHttpRuntime;
 
@@ -58,7 +58,7 @@ pub(crate) async fn redirect_merged_topic(
         Some(auth.user_id),
         &auth.permissions,
     );
-    let service = TopicService::new(runtime.db_clone(), runtime.event_bus());
+    let service = runtime.topic_service();
     let resolution = service
         .resolve_canonical_topic(tenant.id, security.clone(), topic_id)
         .await
@@ -72,7 +72,7 @@ pub(crate) async fn redirect_merged_topic(
         .locale
         .as_deref()
         .unwrap_or(request_context.locale.as_str());
-    service
+    let canonical_topic = service
         .get_with_locale_fallback(
             tenant.id,
             security,
@@ -83,8 +83,7 @@ pub(crate) async fn redirect_merged_topic(
         .await
         .map_err(super::map_forum_error)?;
 
-    let location =
-        canonical_topic_location(resolution.canonical_topic_id, filter.locale.as_deref());
+    let location = canonical_topic_location(canonical_topic.id, filter.locale.as_deref());
     Ok((
         StatusCode::PERMANENT_REDIRECT,
         [

--- a/crates/rustok-forum/src/controllers/topic_redirect.rs
+++ b/crates/rustok-forum/src/controllers/topic_redirect.rs
@@ -1,10 +1,15 @@
 use axum::{
     extract::{Path, Query, Request, State},
-    http::{StatusCode, header::{CACHE_CONTROL, LOCATION}},
+    http::{
+        StatusCode,
+        header::{CACHE_CONTROL, LOCATION},
+    },
     middleware::Next,
     response::{IntoResponse, Response},
 };
-use rustok_api::{AuthContext, TenantContext};
+use rustok_api::{
+    AuthContext, Permission, RequestContext, TenantContext, has_any_effective_permission,
+};
 use rustok_web::HttpResult;
 use uuid::Uuid;
 
@@ -12,24 +17,50 @@ use crate::{ListTopicsFilter, TopicService};
 
 use super::ForumHttpRuntime;
 
+#[utoipa::path(
+    get,
+    path = "/api/forum/topics/{id}",
+    tag = "forum",
+    params(
+        ("id" = Uuid, Path, description = "Topic ID"),
+        ("locale" = Option<String>, Query, description = "Locale")
+    ),
+    responses(
+        (status = 200, description = "Topic details", body = crate::TopicResponse),
+        (
+            status = 308,
+            description = "Merged source topic redirects to the retained canonical topic",
+            headers(
+                ("Location" = String, description = "Tenant-relative canonical topic API path"),
+                ("Cache-Control" = String, description = "Private no-store redirect policy")
+            )
+        ),
+        (status = 404, description = "Topic not found"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden")
+    )
+)]
 pub(crate) async fn redirect_merged_topic(
     State(runtime): State<ForumHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
     Path(topic_id): Path<Uuid>,
     Query(filter): Query<ListTopicsFilter>,
     request: Request,
     next: Next,
 ) -> HttpResult<Response> {
-    let resolution = TopicService::new(runtime.db_clone(), runtime.event_bus())
-        .resolve_canonical_topic(
-            tenant.id,
-            rustok_core::SecurityContext::from_permission_snapshot(
-                Some(auth.user_id),
-                &auth.permissions,
-            ),
-            topic_id,
-        )
+    if !has_any_effective_permission(&auth.permissions, &[Permission::FORUM_TOPICS_READ]) {
+        return Ok(next.run(request).await);
+    }
+
+    let security = rustok_core::SecurityContext::from_permission_snapshot(
+        Some(auth.user_id),
+        &auth.permissions,
+    );
+    let service = TopicService::new(runtime.db_clone(), runtime.event_bus());
+    let resolution = service
+        .resolve_canonical_topic(tenant.id, security.clone(), topic_id)
         .await
         .map_err(super::map_forum_error)?;
 
@@ -37,10 +68,23 @@ pub(crate) async fn redirect_merged_topic(
         return Ok(next.run(request).await);
     }
 
-    let location = canonical_topic_location(
-        resolution.canonical_topic_id,
-        filter.locale.as_deref(),
-    );
+    let locale = filter
+        .locale
+        .as_deref()
+        .unwrap_or(request_context.locale.as_str());
+    service
+        .get_with_locale_fallback(
+            tenant.id,
+            security,
+            resolution.canonical_topic_id,
+            locale,
+            Some(tenant.default_locale.as_str()),
+        )
+        .await
+        .map_err(super::map_forum_error)?;
+
+    let location =
+        canonical_topic_location(resolution.canonical_topic_id, filter.locale.as_deref());
     Ok((
         StatusCode::PERMANENT_REDIRECT,
         [
@@ -68,8 +112,11 @@ mod tests {
 
     use axum::{
         Router,
-        body::Body,
-        http::{Request, StatusCode, header::{CACHE_CONTROL, LOCATION}},
+        body::{Body, to_bytes},
+        http::{
+            Method, Request, StatusCode,
+            header::{CACHE_CONTROL, LOCATION},
+        },
         middleware,
         routing::get,
     };
@@ -84,10 +131,11 @@ mod tests {
     };
     use sea_orm_migration::SchemaManager;
     use tower::ServiceExt;
+    use uuid::Uuid;
 
     use crate::{
         CategoryService, CreateCategoryInput, CreateTopicInput, ForumModule,
-        ForumTopicMergeService, MergeForumTopicInput, TopicService,
+        ForumTopicMergeService, MergeForumTopicInput, TopicResponse, TopicService,
     };
 
     use super::{ForumHttpRuntime, canonical_topic_location, redirect_merged_topic};
@@ -219,11 +267,7 @@ mod tests {
         }
     }
 
-    fn request(
-        uri: String,
-        tenant: TenantContext,
-        auth: AuthContext,
-    ) -> Request<Body> {
+    fn request(uri: String, tenant: TenantContext, auth: AuthContext) -> Request<Body> {
         let mut request = Request::builder()
             .uri(uri)
             .body(Body::empty())
@@ -237,7 +281,7 @@ mod tests {
         request
     }
 
-    async fn passthrough() -> StatusCode {
+    async fn put_passthrough() -> StatusCode {
         StatusCode::NO_CONTENT
     }
 
@@ -255,7 +299,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn merged_source_redirects_privately_while_target_passes_through() -> TestResult<()> {
+    async fn merged_source_redirects_privately_while_target_uses_existing_handler() -> TestResult<()>
+    {
         let (db, event_bus) = setup().await?;
         let tenant_id = Uuid::new_v4();
         let actor_id = Uuid::new_v4();
@@ -301,10 +346,12 @@ mod tests {
         let app = Router::new()
             .route(
                 "/api/forum/topics/{id}",
-                get(passthrough).route_layer(middleware::from_fn_with_state(
-                    runtime.clone(),
-                    redirect_merged_topic,
-                )),
+                get(crate::controllers::topics::get_topic)
+                    .route_layer(middleware::from_fn_with_state(
+                        runtime.clone(),
+                        redirect_merged_topic,
+                    ))
+                    .put(put_passthrough),
             )
             .with_state(runtime);
         let tenant = tenant_context(tenant_id);
@@ -317,18 +364,19 @@ mod tests {
         let source_response = app
             .clone()
             .oneshot(request(
-                format!("/api/forum/topics/{source_topic_id}?locale=en%2FUS"),
+                format!("/api/forum/topics/{source_topic_id}?locale=en-US"),
                 tenant.clone(),
                 read_auth.clone(),
             ))
             .await?;
         assert_eq!(source_response.status(), StatusCode::PERMANENT_REDIRECT);
+        let expected_location = format!("/api/forum/topics/{target_topic_id}?locale=en-US");
         assert_eq!(
             source_response
                 .headers()
                 .get(LOCATION)
                 .and_then(|value| value.to_str().ok()),
-            Some(format!("/api/forum/topics/{target_topic_id}?locale=en%2FUS").as_str())
+            Some(expected_location.as_str())
         );
         assert_eq!(
             source_response
@@ -346,8 +394,11 @@ mod tests {
                 read_auth.clone(),
             ))
             .await?;
-        assert_eq!(target_response.status(), StatusCode::NO_CONTENT);
+        assert_eq!(target_response.status(), StatusCode::OK);
         assert!(target_response.headers().get(LOCATION).is_none());
+        let target_body = to_bytes(target_response.into_body(), usize::MAX).await?;
+        let target: TopicResponse = serde_json::from_slice(&target_body)?;
+        assert_eq!(target.id, target_topic_id);
 
         let missing_response = app
             .clone()
@@ -361,6 +412,7 @@ mod tests {
         assert!(missing_response.headers().get(LOCATION).is_none());
 
         let forbidden_response = app
+            .clone()
             .oneshot(request(
                 format!("/api/forum/topics/{source_topic_id}"),
                 tenant,
@@ -369,6 +421,17 @@ mod tests {
             .await?;
         assert_eq!(forbidden_response.status(), StatusCode::FORBIDDEN);
         assert!(forbidden_response.headers().get(LOCATION).is_none());
+
+        let put_response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::PUT)
+                    .uri(format!("/api/forum/topics/{source_topic_id}"))
+                    .body(Body::empty())?,
+            )
+            .await?;
+        assert_eq!(put_response.status(), StatusCode::NO_CONTENT);
+        assert!(put_response.headers().get(LOCATION).is_none());
 
         Ok(())
     }

--- a/crates/rustok-forum/src/controllers/topic_redirect.rs
+++ b/crates/rustok-forum/src/controllers/topic_redirect.rs
@@ -1,0 +1,375 @@
+use axum::{
+    extract::{Path, Query, Request, State},
+    http::{StatusCode, header::{CACHE_CONTROL, LOCATION}},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use rustok_api::{AuthContext, TenantContext};
+use rustok_web::HttpResult;
+use uuid::Uuid;
+
+use crate::{ListTopicsFilter, TopicService};
+
+use super::ForumHttpRuntime;
+
+pub(crate) async fn redirect_merged_topic(
+    State(runtime): State<ForumHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    Path(topic_id): Path<Uuid>,
+    Query(filter): Query<ListTopicsFilter>,
+    request: Request,
+    next: Next,
+) -> HttpResult<Response> {
+    let resolution = TopicService::new(runtime.db_clone(), runtime.event_bus())
+        .resolve_canonical_topic(
+            tenant.id,
+            rustok_core::SecurityContext::from_permission_snapshot(
+                Some(auth.user_id),
+                &auth.permissions,
+            ),
+            topic_id,
+        )
+        .await
+        .map_err(super::map_forum_error)?;
+
+    if !resolution.redirected {
+        return Ok(next.run(request).await);
+    }
+
+    let location = canonical_topic_location(
+        resolution.canonical_topic_id,
+        filter.locale.as_deref(),
+    );
+    Ok((
+        StatusCode::PERMANENT_REDIRECT,
+        [
+            (LOCATION, location),
+            (CACHE_CONTROL, "private, no-store".to_string()),
+        ],
+    )
+        .into_response())
+}
+
+fn canonical_topic_location(topic_id: Uuid, locale: Option<&str>) -> String {
+    let path = format!("/api/forum/topics/{topic_id}");
+    let Some(locale) = locale.filter(|locale| !locale.is_empty()) else {
+        return path;
+    };
+
+    let mut query = url::form_urlencoded::Serializer::new(String::new());
+    query.append_pair("locale", locale);
+    format!("{path}?{}", query.finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use axum::{
+        Router,
+        body::Body,
+        http::{Request, StatusCode, header::{CACHE_CONTROL, LOCATION}},
+        middleware,
+        routing::get,
+    };
+    use rustok_api::{
+        AuthContext, AuthContextExtension, Permission, TenantContext, TenantContextExtension,
+    };
+    use rustok_core::{MigrationSource, SecurityContext, UserRole};
+    use rustok_outbox::{OutboxModule, OutboxTransport, TransactionalEventBus};
+    use rustok_taxonomy::TaxonomyModule;
+    use sea_orm::{
+        ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
+    };
+    use sea_orm_migration::SchemaManager;
+    use tower::ServiceExt;
+
+    use crate::{
+        CategoryService, CreateCategoryInput, CreateTopicInput, ForumModule,
+        ForumTopicMergeService, MergeForumTopicInput, TopicService,
+    };
+
+    use super::{ForumHttpRuntime, canonical_topic_location, redirect_merged_topic};
+
+    type TestResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+    async fn setup() -> TestResult<(DatabaseConnection, TransactionalEventBus)> {
+        let db_url = format!(
+            "sqlite:file:forum_topic_http_redirect_{}?mode=memory&cache=shared",
+            Uuid::new_v4()
+        );
+        let mut options = ConnectOptions::new(db_url);
+        options
+            .max_connections(5)
+            .min_connections(1)
+            .sqlx_logging(false);
+        let db = Database::connect(options).await?;
+        db.execute_unprepared(
+            "CREATE TABLE users (\
+                id TEXT NOT NULL PRIMARY KEY, \
+                tenant_id TEXT NOT NULL, \
+                UNIQUE (tenant_id, id)\
+            )",
+        )
+        .await?;
+        let schema = SchemaManager::new(&db);
+        for migration in OutboxModule.migrations() {
+            migration.up(&schema).await?;
+        }
+        for migration in TaxonomyModule.migrations() {
+            migration.up(&schema).await?;
+        }
+        for migration in ForumModule.migrations() {
+            migration.up(&schema).await?;
+        }
+        let event_bus = TransactionalEventBus::new(Arc::new(OutboxTransport::new(db.clone())));
+        Ok((db, event_bus))
+    }
+
+    async fn insert_user(
+        db: &DatabaseConnection,
+        tenant_id: Uuid,
+        user_id: Uuid,
+    ) -> TestResult<()> {
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO users (id, tenant_id) VALUES (?, ?)",
+            vec![user_id.into(), tenant_id.into()],
+        ))
+        .await?;
+        Ok(())
+    }
+
+    async fn create_category(
+        db: &DatabaseConnection,
+        tenant_id: Uuid,
+        security: SecurityContext,
+    ) -> TestResult<Uuid> {
+        Ok(CategoryService::new(db.clone())
+            .create(
+                tenant_id,
+                security,
+                CreateCategoryInput {
+                    locale: "en".to_string(),
+                    name: "HTTP redirects".to_string(),
+                    slug: "http-redirects".to_string(),
+                    description: None,
+                    icon: None,
+                    color: None,
+                    parent_id: None,
+                    position: Some(0),
+                    moderated: false,
+                },
+            )
+            .await?
+            .id)
+    }
+
+    async fn create_topic(
+        db: &DatabaseConnection,
+        event_bus: &TransactionalEventBus,
+        tenant_id: Uuid,
+        category_id: Uuid,
+        security: SecurityContext,
+        key: &str,
+    ) -> TestResult<Uuid> {
+        Ok(TopicService::new(db.clone(), event_bus.clone())
+            .create(
+                tenant_id,
+                security,
+                CreateTopicInput {
+                    locale: "en".to_string(),
+                    category_id,
+                    title: format!("Redirect {key}"),
+                    slug: Some(format!("redirect-{key}")),
+                    body: rustok_api::RichTextDocument::single_paragraph(format!(
+                        "Redirect {key} body"
+                    )),
+                    metadata: serde_json::json!({}),
+                    tags: Vec::new(),
+                    channel_slugs: None,
+                },
+            )
+            .await?
+            .id)
+    }
+
+    fn tenant_context(tenant_id: Uuid) -> TenantContext {
+        TenantContext {
+            id: tenant_id,
+            name: "HTTP redirect tenant".to_string(),
+            slug: "http-redirect-tenant".to_string(),
+            domain: None,
+            settings: serde_json::json!({}),
+            default_locale: "en".to_string(),
+            is_active: true,
+        }
+    }
+
+    fn auth_context(tenant_id: Uuid, user_id: Uuid, permissions: Vec<Permission>) -> AuthContext {
+        AuthContext {
+            user_id,
+            session_id: Uuid::new_v4(),
+            tenant_id,
+            permissions,
+            client_id: None,
+            scopes: Vec::new(),
+            grant_type: "direct".to_string(),
+        }
+    }
+
+    fn request(
+        uri: String,
+        tenant: TenantContext,
+        auth: AuthContext,
+    ) -> Request<Body> {
+        let mut request = Request::builder()
+            .uri(uri)
+            .body(Body::empty())
+            .expect("redirect request");
+        request
+            .extensions_mut()
+            .insert(TenantContextExtension(tenant));
+        request
+            .extensions_mut()
+            .insert(AuthContextExtension(auth));
+        request
+    }
+
+    async fn passthrough() -> StatusCode {
+        StatusCode::NO_CONTENT
+    }
+
+    #[test]
+    fn canonical_location_encodes_explicit_locale() {
+        let topic_id = Uuid::new_v4();
+        assert_eq!(
+            canonical_topic_location(topic_id, Some("en/US")),
+            format!("/api/forum/topics/{topic_id}?locale=en%2FUS")
+        );
+        assert_eq!(
+            canonical_topic_location(topic_id, None),
+            format!("/api/forum/topics/{topic_id}")
+        );
+    }
+
+    #[tokio::test]
+    async fn merged_source_redirects_privately_while_target_passes_through() -> TestResult<()> {
+        let (db, event_bus) = setup().await?;
+        let tenant_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        insert_user(&db, tenant_id, actor_id).await?;
+        let admin = SecurityContext::new(UserRole::Admin, Some(actor_id));
+        let category_id = create_category(&db, tenant_id, admin.clone()).await?;
+        let source_topic_id = create_topic(
+            &db,
+            &event_bus,
+            tenant_id,
+            category_id,
+            admin.clone(),
+            "source",
+        )
+        .await?;
+        let target_topic_id = create_topic(
+            &db,
+            &event_bus,
+            tenant_id,
+            category_id,
+            admin.clone(),
+            "target",
+        )
+        .await?;
+        ForumTopicMergeService::new(db.clone(), event_bus.clone())
+            .merge_topic(
+                tenant_id,
+                target_topic_id,
+                admin,
+                MergeForumTopicInput {
+                    operation_id: Uuid::new_v4(),
+                    source_topic_id,
+                    reason: "Redirect the merged source".to_string(),
+                },
+            )
+            .await?;
+
+        let runtime = ForumHttpRuntime {
+            db,
+            event_bus,
+            audience_facts: None,
+        };
+        let app = Router::new()
+            .route(
+                "/api/forum/topics/{id}",
+                get(passthrough).route_layer(middleware::from_fn_with_state(
+                    runtime.clone(),
+                    redirect_merged_topic,
+                )),
+            )
+            .with_state(runtime);
+        let tenant = tenant_context(tenant_id);
+        let read_auth = auth_context(
+            tenant_id,
+            actor_id,
+            vec![Permission::FORUM_TOPICS_READ],
+        );
+
+        let source_response = app
+            .clone()
+            .oneshot(request(
+                format!("/api/forum/topics/{source_topic_id}?locale=en%2FUS"),
+                tenant.clone(),
+                read_auth.clone(),
+            ))
+            .await?;
+        assert_eq!(source_response.status(), StatusCode::PERMANENT_REDIRECT);
+        assert_eq!(
+            source_response
+                .headers()
+                .get(LOCATION)
+                .and_then(|value| value.to_str().ok()),
+            Some(format!("/api/forum/topics/{target_topic_id}?locale=en%2FUS").as_str())
+        );
+        assert_eq!(
+            source_response
+                .headers()
+                .get(CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok()),
+            Some("private, no-store")
+        );
+
+        let target_response = app
+            .clone()
+            .oneshot(request(
+                format!("/api/forum/topics/{target_topic_id}"),
+                tenant.clone(),
+                read_auth.clone(),
+            ))
+            .await?;
+        assert_eq!(target_response.status(), StatusCode::NO_CONTENT);
+        assert!(target_response.headers().get(LOCATION).is_none());
+
+        let missing_response = app
+            .clone()
+            .oneshot(request(
+                format!("/api/forum/topics/{}", Uuid::new_v4()),
+                tenant.clone(),
+                read_auth,
+            ))
+            .await?;
+        assert_eq!(missing_response.status(), StatusCode::NOT_FOUND);
+        assert!(missing_response.headers().get(LOCATION).is_none());
+
+        let forbidden_response = app
+            .oneshot(request(
+                format!("/api/forum/topics/{source_topic_id}"),
+                tenant,
+                auth_context(tenant_id, actor_id, Vec::new()),
+            ))
+            .await?;
+        assert_eq!(forbidden_response.status(), StatusCode::FORBIDDEN);
+        assert!(forbidden_response.headers().get(LOCATION).is_none());
+
+        Ok(())
+    }
+}

--- a/crates/rustok-forum/src/openapi.rs
+++ b/crates/rustok-forum/src/openapi.rs
@@ -21,7 +21,7 @@ use utoipa::OpenApi;
         crate::controllers::read_state::mark_all_topics_read,
         crate::controllers::read_state::get_topic_read_state,
         crate::controllers::read_state::mark_topic_read,
-        crate::controllers::topics::get_topic,
+        crate::controllers::topic_redirect::redirect_merged_topic,
         crate::controllers::content_commands::create_topic,
         crate::controllers::content_commands::update_topic,
         crate::controllers::topics::delete_topic,

--- a/crates/rustok-forum/tests/public_boundary_contract.rs
+++ b/crates/rustok-forum/tests/public_boundary_contract.rs
@@ -43,6 +43,7 @@ fn http_controllers_use_stable_forum_error_mapping() {
         include_str!("../src/controllers/quote_commands.rs"),
         include_str!("../src/controllers/replies.rs"),
         include_str!("../src/controllers/subscriptions.rs"),
+        include_str!("../src/controllers/topic_redirect.rs"),
         include_str!("../src/controllers/topics.rs"),
         include_str!("../src/controllers/users.rs"),
         include_str!("../src/controllers/widgets.rs"),

--- a/docs/architecture/routing.md
+++ b/docs/architecture/routing.md
@@ -99,6 +99,34 @@ New HTTP response formatting must use `rustok-web` helpers such as
 `rustok_web::json_response`. The active host and generated module composition
 use Axum routers and a single response/error boundary.
 
+## Owner-authorized canonical redirects
+
+A module may redirect an obsolete or merged resource identity to its canonical
+owner identity only when the owner already has durable canonical-resolution
+evidence. The redirect must not become a parallel alias registry or move domain
+resolution into the host.
+
+The canonical redirect boundary is:
+
+- resolve tenant and authenticated principal before canonical identity lookup;
+- apply the same read authorization and visibility admission required by the
+  canonical resource before disclosing its identity in `Location`;
+- preserve the existing not-found/forbidden response without a `Location`
+  header when admission fails;
+- use a method-preserving permanent status such as `308` only on explicitly
+  selected read methods; do not make mutation methods silently follow stale
+  identities;
+- keep `Location` tenant-relative unless the host owns and supplies an explicit
+  canonical origin contract;
+- percent-encode preserved query values with a standard URL serializer rather
+  than string concatenation;
+- use `Cache-Control: private, no-store` when redirect admission depends on
+  tenant, principal, visibility or request context and no complete shared-cache
+  key contract exists;
+- publish the redirect status and headers in the owner module's OpenAPI surface;
+- keep localized routes, slug aliases and route tombstones in the routing owner
+  that defines those public URL contracts.
+
 ## Route-selection Contract for Module-owned Admin UI
 
 For module-owned admin UI, a single platform contract applies:

--- a/scripts/verify/verify-forum-topic-canonical-resolution.mjs
+++ b/scripts/verify/verify-forum-topic-canonical-resolution.mjs
@@ -17,12 +17,15 @@ const paths = {
   servicesMod: "crates/rustok-forum/src/services/mod.rs",
   lib: "crates/rustok-forum/src/lib.rs",
   controller: "crates/rustok-forum/src/controllers/mod.rs",
+  redirect: "crates/rustok-forum/src/controllers/topic_redirect.rs",
   restTopics: "crates/rustok-forum/src/controllers/topics.rs",
+  openapi: "crates/rustok-forum/src/openapi.rs",
   graphql: "crates/rustok-forum/src/graphql/query_runtime.rs",
   seo: "crates/rustok-forum/src/seo_targets.rs",
   test: "crates/rustok-forum/tests/topic_canonical_resolution_sqlite.rs",
   readme: "crates/rustok-forum/README.md",
   docsIndex: "crates/rustok-forum/docs/README.md",
+  routing: "docs/architecture/routing.md",
   plan: "crates/rustok-forum/docs/implementation-plan.md",
   verifier: "scripts/verify/verify-forum-topic-canonical-resolution.mjs",
 };
@@ -46,17 +49,21 @@ const facade = read(paths.facade);
 const servicesMod = read(paths.servicesMod);
 const lib = read(paths.lib);
 const controller = read(paths.controller);
+const redirect = read(paths.redirect);
 const restTopics = read(paths.restTopics);
+const openapi = read(paths.openapi);
 const graphql = read(paths.graphql);
 const seo = read(paths.seo);
 const test = read(paths.test);
 const readme = read(paths.readme);
 const docsIndex = read(paths.docsIndex);
+const routing = read(paths.routing);
 const plan = read(paths.plan);
 const verifier = read(paths.verifier);
 
 assert.equal(contract.contract, "forum_topic_canonical_resolution_v1");
 assert.equal(contract.task, "FORUM-21I");
+assert.equal(contract.latest_transport_slice, "FORUM-21J");
 assert.equal(contract.parent_task, "FORUM-21");
 assert.equal(contract.extends, "FORUM-21B");
 assert.equal(contract.status, "source_ready_maintainer_execution_pending");
@@ -70,18 +77,24 @@ assert.equal(
 );
 assert.equal(contract.database_guards.one_source_edge_per_tenant_topic, true);
 assert.equal(contract.database_guards.parallel_alias_table_added, false);
-assert.equal(
-  contract.selected_read_cutover.rest_get_topic,
-  "returns_the_canonical_target_representation_with_the_target_id",
-);
+assert.equal(contract.selected_read_cutover.rest_get_direct_target.includes("200"), true);
+assert.equal(contract.selected_read_cutover.rest_get_merged_source.includes("308"), true);
 assert.equal(contract.selected_read_cutover.list_reads_changed, false);
 assert.equal(contract.selected_read_cutover.mutation_target_resolution_changed, false);
+assert.equal(contract.http_redirect.task, "FORUM-21J");
+assert.equal(contract.http_redirect.status, 308);
+assert.equal(contract.http_redirect.cache_control, "private, no-store");
+assert.equal(contract.http_redirect.middleware_is_scoped_to_get_only, true);
 assert.equal(contract.error.stable_code, "FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT");
 assert.equal(contract.error.http_status, 500);
 assert.equal(contract.error.retryable, false);
 assert.equal(contract.compatibility.topic_response_shape_changed, false);
-assert.equal(cumulativeContract.latest_policy_slice, "FORUM-21I");
+assert.equal(contract.compatibility.rest_route_shape_changed, false);
+assert.equal(contract.compatibility.rest_direct_target_status_changed, false);
+assert.equal(contract.compatibility.rest_merged_source_status_changed, true);
+assert.equal(cumulativeContract.latest_policy_slice, "FORUM-21J");
 assert.equal(cumulativeContract.canonical_resolution.parallel_alias_store, false);
+assert.equal(cumulativeContract.canonical_resolution.rest_merged_source_returns_308, true);
 assert.equal(cumulativeContract.bounds.canonical_resolution_hops_max, 32);
 
 includesAll(
@@ -147,7 +160,6 @@ includesAll(
 assert.ok(!service.includes("forum_topic_alias"));
 assert.ok(!service.includes("forum_topic_redirects"));
 assert.ok(!service.includes("bestEffort"));
-assert.ok(!service.includes("topic_exists(&self.db"));
 
 includesAll(
   facade,
@@ -190,18 +202,38 @@ includesAll(
   [
     "ForumError::TopicCanonicalResolutionConflict(_)",
     "StatusCode::INTERNAL_SERVER_ERROR",
-    '"The forum operation could not be completed"',
+    "mod topic_redirect;",
+    "topic_redirect::redirect_merged_topic",
   ],
-  "HTTP error mapping",
+  "HTTP composition",
 );
+includesAll(
+  redirect,
+  [
+    "pub(crate) async fn redirect_merged_topic(",
+    "StatusCode::PERMANENT_REDIRECT",
+    '(CACHE_CONTROL, "private, no-store".to_string())',
+    "has_any_effective_permission(&auth.permissions, &[Permission::FORUM_TOPICS_READ])",
+    ".get_with_locale_fallback(",
+    "url::form_urlencoded::Serializer::new",
+  ],
+  "HTTP redirect owner",
+);
+assert.ok(!redirect.includes("forum_topic_alias"));
+assert.ok(!redirect.includes("forum_topic_redirects"));
 
 includesAll(
   restTopics,
   ["pub async fn get_topic(", ".get_with_locale_fallback(", "Ok(Json(topic))"],
-  "REST selected-topic path",
+  "REST target hydration path",
 );
 assert.ok(!restTopics.includes("PERMANENT_REDIRECT"));
-assert.ok(!restTopics.includes("Location"));
+includesAll(
+  openapi,
+  ["crate::controllers::topic_redirect::redirect_merged_topic"],
+  "Forum OpenAPI path",
+);
+assert.ok(!openapi.includes("crate::controllers::topics::get_topic,"));
 includesAll(
   graphql,
   [
@@ -236,30 +268,42 @@ includesAll(
     "insert_direct_merge_receipt",
     "active_topic",
   ],
-  "SQLite regression",
+  "SQLite canonical regression",
+);
+includesAll(
+  redirect,
+  [
+    "merged_source_redirects_privately_while_target_uses_existing_handler",
+    "assert_eq!(target_response.status(), StatusCode::OK)",
+    "assert_eq!(missing_response.status(), StatusCode::NOT_FOUND)",
+    "assert_eq!(forbidden_response.status(), StatusCode::FORBIDDEN)",
+    "assert_eq!(put_response.status(), StatusCode::NO_CONTENT)",
+  ],
+  "Axum redirect regression",
 );
 
 includesAll(
   docs,
   [
-    "# FORUM-21I canonical merged-topic resolution",
+    "# FORUM-21I/J canonical merged-topic resolution and HTTP redirect",
     "`source_ready_maintainer_execution_pending`",
     "One source of truth",
     "at most 32 edges",
     "FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT",
-    "does not emit an HTTP 3xx status",
-    "non-retryable",
+    "308 Permanent Redirect",
+    "Cache-Control: private, no-store",
+    "FORUM-21A through FORUM-21J",
     "No command above was run by the implementation agent",
   ],
-  "FORUM-21I handoff",
+  "FORUM-21I/J handoff",
 );
 includesAll(
   cumulativeDocs,
   [
-    "FORUM-21I",
+    "FORUM-21J",
     "the only source-to-target canonical edge",
     "FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT",
-    "FORUM-21A through FORUM-21I",
+    "FORUM-21A through FORUM-21J",
   ],
   "cumulative merge handoff",
 );
@@ -267,27 +311,31 @@ includesAll(
   readme,
   [
     "immutable `forum_topic_merge_operations` chain",
-    "HTTP 3xx responses and slug aliases are not part of the current contract",
-    "Canonical merged-topic resolution",
+    "authorization-safe `308 Permanent Redirect`",
+    "Canonical merged-topic resolution and HTTP redirect",
   ],
   "crate README",
 );
 includesAll(
   docsIndex,
   [
-    "resolve selected merged-source topic IDs",
-    "FORUM-21I canonical merged-topic resolution",
+    "authorization-safe permanent redirect",
+    "FORUM-21I/J canonical resolution and HTTP redirect",
   ],
   "forum docs index",
 );
+includesAll(
+  routing,
+  ["## Owner-authorized canonical redirects", "Cache-Control: private, no-store"],
+  "routing contract",
+);
 
 assert.ok(plan.includes("| `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |"));
-assert.ok(plan.includes("## `FORUM-21` — move, merge, split and fork topics"));
-assert.ok(plan.includes("**Status:** `planned`"));
+assert.ok(plan.includes("| `FORUM-24` | `planned` | Localized routes, canonical URLs and aliases. |"));
 assert.ok(!plan.includes("| `FORUM-21` | `done` |"));
-assert.ok(!plan.includes("| `FORUM-21` | `in_progress` |"));
+assert.ok(!plan.includes("| `FORUM-24` | `done` |"));
 assert.ok(verifier.includes("source_ready_maintainer_execution_pending"));
 
 console.log(
-  "FORUM-21I canonical merged-topic resolution source is ready; canonical FORUM-21 remains planned.",
+  "FORUM-21I/J canonical resolution and HTTP redirect source is ready; FORUM-21 and FORUM-24 remain planned.",
 );

--- a/scripts/verify/verify-forum-topic-http-redirect.mjs
+++ b/scripts/verify/verify-forum-topic-http-redirect.mjs
@@ -4,11 +4,171 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const read = (path) => readFileSync(path, "utf8");
+const includesAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(text.includes(marker), `${label} is missing marker: ${marker}`);
+  }
+};
+
 const contract = JSON.parse(
   read("crates/rustok-forum/contracts/forum-topic-canonical-resolution.json"),
 );
+const cumulative = JSON.parse(
+  read("crates/rustok-forum/contracts/forum-topic-merge-owner.json"),
+);
+const redirect = read("crates/rustok-forum/src/controllers/topic_redirect.rs");
+const controller = read("crates/rustok-forum/src/controllers/mod.rs");
+const topics = read("crates/rustok-forum/src/controllers/topics.rs");
+const openapi = read("crates/rustok-forum/src/openapi.rs");
+const cargo = read("crates/rustok-forum/Cargo.toml");
+const docs = read("crates/rustok-forum/docs/forum-21i-topic-canonical-resolution.md");
+const cumulativeDocs = read("crates/rustok-forum/docs/forum-21b-topic-merge-owner.md");
+const readme = read("crates/rustok-forum/README.md");
+const docsIndex = read("crates/rustok-forum/docs/README.md");
+const routing = read("docs/architecture/routing.md");
+const plan = read("crates/rustok-forum/docs/implementation-plan.md");
 
+assert.equal(contract.contract, "forum_topic_canonical_resolution_v1");
 assert.equal(contract.latest_transport_slice, "FORUM-21J");
 assert.equal(contract.status, "source_ready_maintainer_execution_pending");
+assert.equal(contract.canonical_plan_status, "planned");
+assert.equal(contract.http_redirect.task, "FORUM-21J");
+assert.equal(contract.http_redirect.method, "GET");
+assert.equal(contract.http_redirect.status, 308);
+assert.equal(contract.http_redirect.cache_control, "private, no-store");
+assert.equal(
+  contract.http_redirect.authorization_is_checked_before_canonical_identity_disclosure,
+  true,
+);
+assert.equal(contract.http_redirect.target_read_is_hydrated_before_redirect, true);
+assert.equal(contract.http_redirect.missing_and_forbidden_responses_have_no_location, true);
+assert.equal(contract.http_redirect.middleware_is_scoped_to_get_only, true);
+assert.equal(contract.compatibility.rest_route_shape_changed, false);
+assert.equal(contract.compatibility.rest_direct_target_status_changed, false);
+assert.equal(contract.compatibility.rest_merged_source_status_changed, true);
+assert.equal(cumulative.latest_policy_slice, "FORUM-21J");
+assert.equal(cumulative.canonical_resolution.rest_direct_target_returns_200, true);
+assert.equal(cumulative.canonical_resolution.rest_merged_source_returns_308, true);
+assert.equal(cumulative.canonical_resolution.rest_redirect_is_get_only, true);
 
-console.log("FORUM-21J redirect source is ready.");
+includesAll(
+  redirect,
+  [
+    "#[utoipa::path(",
+    'path = "/api/forum/topics/{id}"',
+    "status = 308",
+    '"Location" = String',
+    '"Cache-Control" = String',
+    "pub(crate) async fn redirect_merged_topic(",
+    "has_any_effective_permission(&auth.permissions, &[Permission::FORUM_TOPICS_READ])",
+    ".resolve_canonical_topic(tenant.id, security.clone(), topic_id)",
+    "if !resolution.redirected",
+    ".get_with_locale_fallback(",
+    "StatusCode::PERMANENT_REDIRECT",
+    "(LOCATION, location)",
+    '(CACHE_CONTROL, "private, no-store".to_string())',
+    "url::form_urlencoded::Serializer::new",
+    'query.append_pair("locale", locale)',
+  ],
+  "redirect middleware",
+);
+assert.ok(!redirect.includes("forum_topic_alias"));
+assert.ok(!redirect.includes("forum_topic_redirects"));
+
+const permissionCheck = redirect.indexOf("has_any_effective_permission(");
+const canonicalResolve = redirect.indexOf(".resolve_canonical_topic(");
+const targetHydration = redirect.indexOf(".get_with_locale_fallback(", canonicalResolve);
+const responseRedirect = redirect.indexOf("StatusCode::PERMANENT_REDIRECT", targetHydration);
+assert.ok(permissionCheck >= 0 && permissionCheck < canonicalResolve);
+assert.ok(canonicalResolve < targetHydration && targetHydration < responseRedirect);
+
+includesAll(
+  redirect,
+  [
+    "canonical_location_encodes_explicit_locale",
+    "merged_source_redirects_privately_while_target_uses_existing_handler",
+    "ForumTopicMergeService::new",
+    "crate::controllers::topics::get_topic",
+    "Some(expected_location.as_str())",
+    'Some("private, no-store")',
+    "assert_eq!(target_response.status(), StatusCode::OK)",
+    "let target: TopicResponse = serde_json::from_slice(&target_body)?;",
+    "assert_eq!(missing_response.status(), StatusCode::NOT_FOUND)",
+    "assert_eq!(forbidden_response.status(), StatusCode::FORBIDDEN)",
+    "Method::PUT",
+    "assert_eq!(put_response.status(), StatusCode::NO_CONTENT)",
+  ],
+  "redirect tests",
+);
+
+includesAll(
+  controller,
+  [
+    "mod topic_redirect;",
+    "get(topics::get_topic)",
+    ".route_layer(axum::middleware::from_fn_with_state(",
+    "topic_redirect::redirect_merged_topic",
+    ".put(content_commands::update_topic)",
+    ".delete(topics::delete_topic)",
+  ],
+  "Forum route wiring",
+);
+const getRoute = controller.indexOf("get(topics::get_topic)");
+const getLayer = controller.indexOf("topic_redirect::redirect_merged_topic", getRoute);
+const putRoute = controller.indexOf(".put(content_commands::update_topic)", getLayer);
+const deleteRoute = controller.indexOf(".delete(topics::delete_topic)", putRoute);
+assert.ok(getRoute >= 0 && getRoute < getLayer && getLayer < putRoute && putRoute < deleteRoute);
+
+includesAll(
+  topics,
+  ["pub async fn get_topic(", "ensure_forum_permission(", ".get_with_locale_fallback(", "Ok(Json(topic))"],
+  "existing topic GET handler",
+);
+assert.ok(!topics.includes("StatusCode::PERMANENT_REDIRECT"));
+includesAll(openapi, ["crate::controllers::topic_redirect::redirect_merged_topic"], "OpenAPI");
+assert.ok(!openapi.includes("crate::controllers::topics::get_topic,"));
+includesAll(cargo, ["[dev-dependencies]", "tower.workspace = true"], "Cargo test support");
+
+includesAll(
+  docs,
+  [
+    "# FORUM-21I/J canonical merged-topic resolution and HTTP redirect",
+    "308 Permanent Redirect",
+    "Location: /api/forum/topics/{canonical_topic_id}",
+    "Cache-Control: private, no-store",
+    "forum_permission_denied",
+    "FORUM-21A through FORUM-21J",
+    "FORUM-24",
+    "No command above was run by the implementation agent",
+  ],
+  "canonical handoff",
+);
+includesAll(
+  cumulativeDocs,
+  ["FORUM-21J", "308 Permanent Redirect", "private, no-store", "FORUM-21A through FORUM-21J"],
+  "merge handoff",
+);
+includesAll(
+  readme,
+  ["authorization-safe `308 Permanent Redirect`", "Slug aliases and localized public routes are not part of the current contract"],
+  "Forum README",
+);
+includesAll(
+  docsIndex,
+  ["authorization-safe permanent redirect", "FORUM-21I/J canonical resolution and HTTP redirect"],
+  "Forum docs index",
+);
+includesAll(
+  routing,
+  ["## Owner-authorized canonical redirects", "Cache-Control: private, no-store", "owner module's OpenAPI surface"],
+  "routing contract",
+);
+
+assert.ok(plan.includes("| `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |"));
+assert.ok(plan.includes("| `FORUM-24` | `planned` | Localized routes, canonical URLs and aliases. |"));
+assert.ok(!plan.includes("| `FORUM-21` | `done` |"));
+assert.ok(!plan.includes("| `FORUM-24` | `done` |"));
+
+console.log(
+  "FORUM-21J merged-topic HTTP redirect source is ready; FORUM-21 and FORUM-24 remain planned.",
+);

--- a/scripts/verify/verify-forum-topic-http-redirect.mjs
+++ b/scripts/verify/verify-forum-topic-http-redirect.mjs
@@ -19,6 +19,7 @@ const cumulative = JSON.parse(
 const redirect = read("crates/rustok-forum/src/controllers/topic_redirect.rs");
 const controller = read("crates/rustok-forum/src/controllers/mod.rs");
 const topics = read("crates/rustok-forum/src/controllers/topics.rs");
+const publicBoundary = read("crates/rustok-forum/tests/public_boundary_contract.rs");
 const openapi = read("crates/rustok-forum/src/openapi.rs");
 const cargo = read("crates/rustok-forum/Cargo.toml");
 const docs = read("crates/rustok-forum/docs/forum-21i-topic-canonical-resolution.md");
@@ -43,6 +44,8 @@ assert.equal(
 assert.equal(contract.http_redirect.target_read_is_hydrated_before_redirect, true);
 assert.equal(contract.http_redirect.missing_and_forbidden_responses_have_no_location, true);
 assert.equal(contract.http_redirect.middleware_is_scoped_to_get_only, true);
+assert.equal(contract.http_redirect.mutation_commands_follow_canonical_target, false);
+assert.equal(contract.http_redirect.put_delete_and_other_mutations_are_unchanged, true);
 assert.equal(contract.compatibility.rest_route_shape_changed, false);
 assert.equal(contract.compatibility.rest_direct_target_status_changed, false);
 assert.equal(contract.compatibility.rest_merged_source_status_changed, true);
@@ -104,7 +107,7 @@ includesAll(
 includesAll(
   controller,
   [
-    "mod topic_redirect;",
+    "pub(crate) mod topic_redirect;",
     "get(topics::get_topic)",
     ".route_layer(axum::middleware::from_fn_with_state(",
     "topic_redirect::redirect_merged_topic",
@@ -121,10 +124,21 @@ assert.ok(getRoute >= 0 && getRoute < getLayer && getLayer < putRoute && putRout
 
 includesAll(
   topics,
-  ["pub async fn get_topic(", "ensure_forum_permission(", ".get_with_locale_fallback(", "Ok(Json(topic))"],
+  [
+    "pub async fn get_topic(",
+    "ensure_forum_permission(",
+    '"forum_permission_denied"',
+    ".get_with_locale_fallback(",
+    "Ok(Json(topic))",
+  ],
   "existing topic GET handler",
 );
 assert.ok(!topics.includes("StatusCode::PERMANENT_REDIRECT"));
+includesAll(
+  publicBoundary,
+  ['include_str!("../src/controllers/topic_redirect.rs")'],
+  "public boundary controller guard",
+);
 includesAll(openapi, ["crate::controllers::topic_redirect::redirect_merged_topic"], "OpenAPI");
 assert.ok(!openapi.includes("crate::controllers::topics::get_topic,"));
 includesAll(cargo, ["[dev-dependencies]", "tower.workspace = true"], "Cargo test support");

--- a/scripts/verify/verify-forum-topic-http-redirect.mjs
+++ b/scripts/verify/verify-forum-topic-http-redirect.mjs
@@ -42,6 +42,8 @@ assert.equal(
   true,
 );
 assert.equal(contract.http_redirect.target_read_is_hydrated_before_redirect, true);
+assert.equal(contract.http_redirect.location_uses_hydrated_target_identity, true);
+assert.equal(contract.http_redirect.runtime_topic_service_composition_is_reused, true);
 assert.equal(contract.http_redirect.missing_and_forbidden_responses_have_no_location, true);
 assert.equal(contract.http_redirect.middleware_is_scoped_to_get_only, true);
 assert.equal(contract.http_redirect.mutation_commands_follow_canonical_target, false);
@@ -52,6 +54,8 @@ assert.equal(contract.compatibility.rest_merged_source_status_changed, true);
 assert.equal(cumulative.latest_policy_slice, "FORUM-21J");
 assert.equal(cumulative.canonical_resolution.rest_direct_target_returns_200, true);
 assert.equal(cumulative.canonical_resolution.rest_merged_source_returns_308, true);
+assert.equal(cumulative.canonical_resolution.rest_location_uses_hydrated_target_identity, true);
+assert.equal(cumulative.canonical_resolution.rest_runtime_topic_service_composition_is_reused, true);
 assert.equal(cumulative.canonical_resolution.rest_redirect_is_get_only, true);
 
 includesAll(
@@ -64,9 +68,12 @@ includesAll(
     '"Cache-Control" = String',
     "pub(crate) async fn redirect_merged_topic(",
     "has_any_effective_permission(&auth.permissions, &[Permission::FORUM_TOPICS_READ])",
+    "let service = runtime.topic_service();",
     ".resolve_canonical_topic(tenant.id, security.clone(), topic_id)",
     "if !resolution.redirected",
+    "let canonical_topic = service",
     ".get_with_locale_fallback(",
+    "canonical_topic_location(canonical_topic.id, filter.locale.as_deref())",
     "StatusCode::PERMANENT_REDIRECT",
     "(LOCATION, location)",
     '(CACHE_CONTROL, "private, no-store".to_string())',
@@ -77,13 +84,16 @@ includesAll(
 );
 assert.ok(!redirect.includes("forum_topic_alias"));
 assert.ok(!redirect.includes("forum_topic_redirects"));
+assert.ok(!redirect.includes("TopicService::new(runtime.db_clone()"));
 
 const permissionCheck = redirect.indexOf("has_any_effective_permission(");
 const canonicalResolve = redirect.indexOf(".resolve_canonical_topic(");
-const targetHydration = redirect.indexOf(".get_with_locale_fallback(", canonicalResolve);
-const responseRedirect = redirect.indexOf("StatusCode::PERMANENT_REDIRECT", targetHydration);
+const targetHydration = redirect.indexOf("let canonical_topic = service", canonicalResolve);
+const hydratedLocation = redirect.indexOf("canonical_topic_location(canonical_topic.id", targetHydration);
+const responseRedirect = redirect.indexOf("StatusCode::PERMANENT_REDIRECT", hydratedLocation);
 assert.ok(permissionCheck >= 0 && permissionCheck < canonicalResolve);
-assert.ok(canonicalResolve < targetHydration && targetHydration < responseRedirect);
+assert.ok(canonicalResolve < targetHydration && targetHydration < hydratedLocation);
+assert.ok(hydratedLocation < responseRedirect);
 
 includesAll(
   redirect,

--- a/scripts/verify/verify-forum-topic-http-redirect.mjs
+++ b/scripts/verify/verify-forum-topic-http-redirect.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (path) => readFileSync(path, "utf8");
+const contract = JSON.parse(
+  read("crates/rustok-forum/contracts/forum-topic-canonical-resolution.json"),
+);
+
+assert.equal(contract.latest_transport_slice, "FORUM-21J");
+assert.equal(contract.status, "source_ready_maintainer_execution_pending");
+
+console.log("FORUM-21J redirect source is ready.");

--- a/scripts/verify/verify-forum-topic-merge-owner.mjs
+++ b/scripts/verify/verify-forum-topic-merge-owner.mjs
@@ -5,10 +5,8 @@ import { readFileSync } from "node:fs";
 
 const paths = {
   contract: "crates/rustok-forum/contracts/forum-topic-merge-owner.json",
-  solutionContract:
-    "crates/rustok-forum/contracts/forum-topic-merge-solution-policy.json",
-  canonicalContract:
-    "crates/rustok-forum/contracts/forum-topic-canonical-resolution.json",
+  solutionContract: "crates/rustok-forum/contracts/forum-topic-merge-solution-policy.json",
+  canonicalContract: "crates/rustok-forum/contracts/forum-topic-canonical-resolution.json",
   docs: "crates/rustok-forum/docs/forum-21b-topic-merge-owner.md",
   entity: "crates/rustok-forum/src/entities/forum_topic_merge_operation.rs",
   entitiesMod: "crates/rustok-forum/src/entities/mod.rs",
@@ -25,6 +23,9 @@ const paths = {
   canonicalService: "crates/rustok-forum/src/services/topic_canonical_resolution.rs",
   facade: "crates/rustok-forum/src/services/topic_facade.rs",
   servicesMod: "crates/rustok-forum/src/services/mod.rs",
+  redirect: "crates/rustok-forum/src/controllers/topic_redirect.rs",
+  controller: "crates/rustok-forum/src/controllers/mod.rs",
+  openapi: "crates/rustok-forum/src/openapi.rs",
   test: "crates/rustok-forum/tests/topic_merge_sqlite.rs",
   canonicalTest: "crates/rustok-forum/tests/topic_canonical_resolution_sqlite.rs",
   plan: "crates/rustok-forum/docs/implementation-plan.md",
@@ -54,6 +55,9 @@ const service = read(paths.service);
 const canonicalService = read(paths.canonicalService);
 const facade = read(paths.facade);
 const servicesMod = read(paths.servicesMod);
+const redirect = read(paths.redirect);
+const controller = read(paths.controller);
+const openapi = read(paths.openapi);
 const test = read(paths.test);
 const canonicalTest = read(paths.canonicalTest);
 const plan = read(paths.plan);
@@ -61,7 +65,7 @@ const verifier = read(paths.verifier);
 
 assert.equal(contract.contract, "forum_topic_merge_owner_v1");
 assert.equal(contract.task, "FORUM-21B");
-assert.equal(contract.latest_policy_slice, "FORUM-21I");
+assert.equal(contract.latest_policy_slice, "FORUM-21J");
 assert.equal(contract.parent_task, "FORUM-21");
 assert.equal(contract.status, "source_ready_maintainer_execution_pending");
 assert.equal(contract.canonical_plan_status, "planned");
@@ -91,14 +95,20 @@ assert.equal(
 );
 assert.equal(contract.canonical_resolution.source_of_truth, "forum_topic_merge_operations");
 assert.equal(contract.canonical_resolution.parallel_alias_store, false);
+assert.equal(contract.canonical_resolution.rest_direct_target_returns_200, true);
+assert.equal(contract.canonical_resolution.rest_merged_source_returns_308, true);
+assert.equal(contract.canonical_resolution.rest_redirect_is_get_only, true);
 assert.equal(solutionContract.task, "FORUM-21H");
 assert.equal(solutionContract.extends, "FORUM-21B");
 assert.equal(canonicalContract.task, "FORUM-21I");
+assert.equal(canonicalContract.latest_transport_slice, "FORUM-21J");
 assert.equal(canonicalContract.extends, "FORUM-21B");
 assert.equal(
   canonicalContract.resolution.each_hop_topic_and_edges_share_one_statement_snapshot,
   true,
 );
+assert.equal(canonicalContract.http_redirect.status, 308);
+assert.equal(canonicalContract.http_redirect.cache_control, "private, no-store");
 
 includesAll(
   entity,
@@ -209,9 +219,6 @@ includesAll(
     "delete_source_solution_in_tx",
     "move_replies_in_tx(",
     "insert_transferred_solution_in_tx",
-    "source_reply_count > MAX_FORUM_TOPIC_MERGE_REPLIES",
-    "moved_published_reply_count != source.reply_count",
-    "target_published_reply_count != target.reply_count",
     "source_active.status = Set(TopicStatus::Archived);",
     "source_active.is_locked = Set(true);",
     "source_active.reply_count = Set(0);",
@@ -236,16 +243,13 @@ const solutionDelete = service.indexOf("delete_source_solution_in_tx(&txn");
 const replyMove = service.indexOf("move_replies_in_tx(", solutionDelete);
 const solutionInsert = service.indexOf("insert_transferred_solution_in_tx(&txn");
 assert.ok(receiptLookup < preliminaryRead);
-assert.ok(preliminaryRead < counterLocks);
-assert.ok(counterLocks < topicLocks);
-assert.ok(topicLocks < solutionLocks);
-assert.ok(solutionLocks < solutionConflict);
-assert.ok(solutionConflict < solutionDelete);
-assert.ok(solutionDelete < replyMove);
+assert.ok(preliminaryRead < counterLocks && counterLocks < topicLocks);
+assert.ok(topicLocks < solutionLocks && solutionLocks < solutionConflict);
+assert.ok(solutionConflict < solutionDelete && solutionDelete < replyMove);
 assert.ok(replyMove < solutionInsert);
 assert.equal((service.match(/publish_forum_topic_projection_in_tx\(/g) ?? []).length, 2);
 assert.equal((service.match(/publish_forum_category_projection_in_tx\(/g) ?? []).length, 1);
-for (const forbidden of [
+for (const marker of [
   "forum_topic::Entity::delete",
   "forum_reply::Entity::delete",
   "category_active.topic_count",
@@ -254,7 +258,7 @@ for (const forbidden of [
   "sourceCommitOverride",
   "bestEffort",
 ]) {
-  assert.ok(!service.includes(forbidden), `service contains forbidden marker: ${forbidden}`);
+  assert.ok(!service.includes(marker), `service contains forbidden marker: ${marker}`);
 }
 
 includesAll(
@@ -288,7 +292,6 @@ includesAll(
   ],
   "canonical topic facade",
 );
-
 includesAll(
   servicesMod,
   [
@@ -315,6 +318,31 @@ includesAll(
   ],
   "crate exports",
 );
+
+includesAll(
+  redirect,
+  [
+    "pub(crate) async fn redirect_merged_topic(",
+    "StatusCode::PERMANENT_REDIRECT",
+    '(CACHE_CONTROL, "private, no-store".to_string())',
+    "merged_source_redirects_privately_while_target_uses_existing_handler",
+    "assert_eq!(put_response.status(), StatusCode::NO_CONTENT)",
+  ],
+  "merged source redirect",
+);
+includesAll(
+  controller,
+  [
+    "mod topic_redirect;",
+    "get(topics::get_topic)",
+    "topic_redirect::redirect_merged_topic",
+    ".put(content_commands::update_topic)",
+    ".delete(topics::delete_topic)",
+  ],
+  "redirect wiring",
+);
+includesAll(openapi, ["crate::controllers::topic_redirect::redirect_merged_topic"], "OpenAPI");
+
 includesAll(
   test,
   [
@@ -322,8 +350,6 @@ includesAll(
     "topic_merge_transfers_source_only_solution_and_preserves_target_only_solution",
     "topic_merge_rejects_cross_category_and_competing_solutions_without_partial_state",
     "topic_solution_database_guard_requires_active_topic_and_approved_reply",
-    "moved_reply_count, 2",
-    '"archived", true, 0',
     "source_root_reply_id",
     "source_child_reply_id",
     "TopicMergeOperationConflict",
@@ -358,16 +384,18 @@ includesAll(
     "two accepted solutions",
     "FORUM_TOPIC_MERGE_SOLUTION_CONFLICT",
     "FORUM_TOPIC_CANONICAL_RESOLUTION_CONFLICT",
-    "FORUM-21A through FORUM-21I",
+    "308 Permanent Redirect",
+    "FORUM-21A through FORUM-21J",
     "No command above was run by the implementation agent",
   ],
   "FORUM-21B handoff",
 );
 assert.ok(plan.includes("| `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |"));
+assert.ok(plan.includes("| `FORUM-24` | `planned` | Localized routes, canonical URLs and aliases. |"));
 assert.ok(!plan.includes("| `FORUM-21` | `done` |"));
-assert.ok(!plan.includes("| `FORUM-21` | `in_progress` |"));
+assert.ok(!plan.includes("| `FORUM-24` | `done` |"));
 assert.ok(verifier.includes("source_ready_maintainer_execution_pending"));
 
 console.log(
-  "FORUM-21B/H/I topic merge owner source is ready and canonical FORUM-21 remains planned.",
+  "FORUM-21B/H/I/J topic merge owner source is ready; FORUM-21 and FORUM-24 remain planned.",
 );


### PR DESCRIPTION
## What changed

- add source-ready `FORUM-21J` beneath the planned `FORUM-21` merge workflow;
- compose the existing immutable receipt-backed canonical resolver into `GET /api/forum/topics/{id}`;
- return the existing `200 TopicResponse` for a direct canonical target;
- return `308 Permanent Redirect` for an archived merged source with a tenant-relative canonical `Location`;
- preserve an explicit `locale` query through standard URL percent encoding;
- leave implicit request locale in request context rather than materializing it into the redirect URI;
- check `forum_topics:read` before canonical identity disclosure and retain the existing downstream `forum_permission_denied` response for callers without read permission;
- resolve through the shared `runtime.topic_service()` composition and hydrate the canonical target with the existing locale/fallback owner read before emitting a redirect;
- build `Location` from the hydrated target response ID, so a target that has already entered a later merge chain does not leave the response pinned to the earlier intermediate ID;
- expose no `Location` for missing, forbidden, invalid-locale or integrity failures;
- set `Cache-Control: private, no-store` because redirect admission is tenant/viewer scoped;
- apply the middleware only to GET while PUT, DELETE and all other mutation paths keep exact source-ID semantics;
- publish the `200` and `308` outcomes from the real middleware symbol in the Forum OpenAPI document;
- include the new controller in the existing public-boundary stable-error-mapping guard;
- extend the existing canonical-resolution contract/handoff, cumulative merge contract/handoff, crate docs, routing contract and fail-closed verifiers.

## Route boundary

No second REST endpoint or response DTO is added. The path remains `/api/forum/topics/{id}`. No alias table, slug alias, localized public route, host/domain origin contract or mutation aliasing is introduced.

## Compatibility

- no merge input, result, receipt row, event schema or persistence change;
- no GraphQL or SEO contract change;
- direct target GET remains `200` with the existing JSON body;
- only a merged source GET changes from target-body `200` to canonical `308`;
- canonical `FORUM-21` and `FORUM-24` remain `planned`.

## Validation

Tests, Node verifiers, formatting, Cargo checks, SQLite/PostgreSQL execution, workflows and CI were intentionally not run, per maintainer request.

## Branch state

Current `main` advanced through unrelated Blog/Index work with no Forum path overlap. The final diff contains only the bounded Forum redirect slice and shared routing-contract documentation. Squash merge is requested so the final mainline change remains one Forum work unit.