### PR TITLE
feat(index): add audited reconciliation requeue

### DIFF
--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -38,6 +38,7 @@ This directory contains the detailed technical architecture documentation for `r
 - [M6 Replay Runtime Host Composition](./m6-replay-runtime-composition.md)
 - [M6 Reconciliation Dead-letter Admission](./m6-reconciliation-dead-letter-admission.md)
 - [M6 Reconciliation Dead-letter Inspection](./m6-reconciliation-dead-letter-inspection.md)
+- [M6 Reconciliation Dead-letter Requeue](./m6-reconciliation-dead-letter-requeue.md)
 - [M4 Source-owned Schema Registry](./m4-source-schema-registry.md)
 - [M4 Query Runtime Composition](./m4-query-runtime-composition.md)
 - [M4 PostgreSQL Query Port Contract](./m4-postgres-query-port.md)

--- a/crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md
+++ b/crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md
@@ -55,20 +55,19 @@ GraphQL, HTTP, CLI, MCP, and admin transports remain open. This slice publishes 
 
 ## Compatibility
 
-This slice adds no migration and changes no reconciliation state transition, failed-scope admission, retry policy, lease fence, cursor, source, mutation, schema, cancellation, or success behavior.
+This inspection slice adds no migration and changes no reconciliation state transition, failed-scope admission, retry policy, lease fence, cursor, source, mutation, schema, cancellation, or success behavior.
 
-It composes additively with the replay retry store, replay dead-letter admission, reconciliation dead-letter admission, and guarded reconciliation runtime already present on `main`.
+It composes additively with the replay retry store, replay dead-letter admission, reconciliation dead-letter admission, guarded reconciliation runtime, and engine-level reconciliation recovery store already present on `main`.
 
 ## Explicitly open
 
 - inspection transport mapping;
-- actor/reason audit records;
-- manual requeue or retry-epoch reset under the reconciliation scope lock;
+- server-owned authorization and transport for manual requeue or retry-epoch reset;
 - automatic retry, backoff, exhaustion, scheduling, and graceful shutdown;
 - source/index digest comparison and orphan diagnosis;
 - targeted, full, or shadow repair admission;
 - locale or partition checkpoint dimensions;
-- retained PostgreSQL inspection and authorization evidence;
+- retained PostgreSQL inspection, authorization, and recovery evidence;
 - complete drift repair.
 
 The canonical M6 drift-diagnosis and targeted-repair roadmap item remains open.

--- a/crates/rustok-index/docs/m6-reconciliation-dead-letter-requeue.md
+++ b/crates/rustok-index/docs/m6-reconciliation-dead-letter-requeue.md
@@ -1,0 +1,86 @@
+# M6 reconciliation dead-letter requeue
+
+Status: `source_complete_authorized_server_composition_pending`.
+
+## Purpose
+
+`PostgresIndexReconciliationRecoveryStore` provides one explicit engine-level recovery operation for an exact terminal failed reconciliation job.
+
+The operation preserves the existing job UUID. It does not create a replacement job. Instead, it moves the same failed row back to `pending`, resets its bounded execution state, increments a durable retry epoch, and appends an immutable actor/reason audit record in the same database transaction.
+
+## Request contract
+
+`IndexReconciliationRequeueRequest` requires:
+
+- one non-nil tenant UUID;
+- one non-nil failed job UUID;
+- one non-nil actor UUID;
+- one explicit reason bounded to 512 UTF-8 bytes.
+
+The reason must be non-empty, trimmed, and free of control characters. The crate adapter does not infer an actor or reason.
+
+## Scope locking
+
+The recovery store first resolves the exact `kind = 'reconcile'` job and validates that it has schema scope.
+
+Before changing state it acquires the same PostgreSQL transaction-scoped advisory lock used by normal reconciliation admission:
+
+```text
+reconcile␟tenant␟module␟entity␟schema-version
+```
+
+The row is then selected again under the lock. A missing job returns `NotFound`; a non-failed job returns `NotFailed`. A concurrent state or epoch change fails closed.
+
+## Atomic reset
+
+For an exact failed row, one transaction:
+
+1. increments `retry_epoch`;
+2. changes `state` from `failed` to `pending`;
+3. resets `attempt_count` to zero;
+4. installs a fresh `index_reconciliation_cursor_v1` cursor;
+5. clears lease, heartbeat, cancellation, error, and completion fields;
+6. makes the job immediately available;
+7. appends one audit record containing the exact tenant, job, actor, action, reason, prior attempt count, and new retry epoch.
+
+The next ordinary runner admission claims the same pending job and begins attempt one of the new retry epoch.
+
+The audit insert and job reset commit or roll back together.
+
+## Immutable audit ledger
+
+`index_reconciliation_recovery_audits` is append-only.
+
+The migration installs database-level `BEFORE UPDATE` and `BEFORE DELETE` rejection triggers for PostgreSQL and SQLite. Each tenant/job/retry-epoch tuple is unique, preventing duplicate audit admission for the same recovery epoch.
+
+The audit ledger does not contain raw failure diagnostics, request or cursor JSON, worker or lease fields, SQL, database causes, or transport context.
+
+## Ownership boundary
+
+This slice publishes only the engine-level PostgreSQL recovery store.
+
+The existing server operator does not expose requeue. A later server-owned wrapper must:
+
+1. bind the exact request tenant and actor;
+2. require effective request-scoped `modules:manage`;
+3. pass the actor only from the authorized context;
+4. require an explicit bounded reason;
+5. delegate without accepting a separate caller-selected tenant.
+
+GraphQL, HTTP, CLI, MCP, and admin transports remain open.
+
+## Explicitly open
+
+- authorized server composition and transport mapping;
+- automatic retry, backoff, exhaustion, scheduling, and graceful shutdown;
+- retained PostgreSQL concurrency, authorization, and recovery execution evidence;
+- source/index digest comparison and orphan diagnosis;
+- targeted, full, or shadow repair admission;
+- locale or partition checkpoint dimensions;
+- complete drift repair.
+
+The canonical bounded retry/global scheduling and drift-diagnosis/targeted-repair roadmap items remain open.
+
+## Validation ownership
+
+Formatting, Cargo checks/tests, JavaScript verifiers, migration apply, PostgreSQL scenarios, workflows, and CI are maintainer-run and were not executed by the implementation agent.

--- a/crates/rustok-index/src/contract_tests.rs
+++ b/crates/rustok-index/src/contract_tests.rs
@@ -56,11 +56,12 @@ fn index_module_registers_canonical_storage_migrations() {
             "m20260727_000001_create_index_records",
             "m20260727_000002_create_index_delivery_state",
             "m20260727_000003_create_index_operations",
+            "m20260803_000004_create_index_reconciliation_recovery",
         ]
     );
 
     let dependencies = IndexModule.migration_dependencies();
-    assert_eq!(dependencies.len(), 3);
+    assert_eq!(dependencies.len(), 4);
 }
 
 #[tokio::test]
@@ -118,6 +119,7 @@ async fn canonical_storage_migrations_round_trip_on_sqlite() {
             "index_inbox".to_owned(),
             "index_jobs".to_owned(),
             "index_links".to_owned(),
+            "index_reconciliation_recovery_audits".to_owned(),
             "index_schemas".to_owned(),
         ])
     );
@@ -205,6 +207,25 @@ async fn canonical_storage_migrations_round_trip_on_sqlite() {
         .await
         .is_err(),
         "running jobs require a complete lease"
+    );
+    db.execute_unprepared(
+        "INSERT INTO index_reconciliation_recovery_audits (tenant_id, audit_id, job_id, actor_id, action, reason, prior_attempt_count, retry_epoch) VALUES ('11111111-1111-1111-1111-111111111111', '12121212-1212-1212-1212-121212121212', '77777777-7777-7777-7777-777777777777', '13131313-1313-1313-1313-131313131313', 'requeue', 'operator approved retry', 1, 1)",
+    )
+    .await
+    .expect("bounded recovery audit should be accepted");
+    assert!(
+        db.execute_unprepared(
+            "UPDATE index_reconciliation_recovery_audits SET reason = 'changed'"
+        )
+        .await
+        .is_err(),
+        "recovery audit rows must reject updates"
+    );
+    assert!(
+        db.execute_unprepared("DELETE FROM index_reconciliation_recovery_audits")
+            .await
+            .is_err(),
+        "recovery audit rows must reject deletes"
     );
     db.execute_unprepared(
         "INSERT INTO index_consistency_findings (tenant_id, finding_id, finding_key, check_name, severity, scope_kind, details) VALUES ('11111111-1111-1111-1111-111111111111', '99999999-9999-9999-9999-999999999999', 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd', 'entity_digest', 'error', 'global', '{}')",

--- a/crates/rustok-index/src/infrastructure/postgres/mod.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/mod.rs
@@ -8,6 +8,7 @@ mod schema_registration;
 mod secondary_index;
 mod source_factory;
 mod source_reconciliation_dead_letter_inspector;
+mod source_reconciliation_recovery;
 mod source_reconciliation_runner;
 mod source_replay;
 mod source_replay_job;
@@ -70,6 +71,10 @@ pub use source_factory::{
 pub use source_reconciliation_dead_letter_inspector::{
     IndexReconciliationDeadLetterInspection, IndexReconciliationDeadLetterInspectionError,
     PostgresIndexReconciliationDeadLetterInspector,
+};
+pub use source_reconciliation_recovery::{
+    IndexReconciliationRecoveryError, IndexReconciliationRequeueOutcome,
+    IndexReconciliationRequeueRequest, PostgresIndexReconciliationRecoveryStore,
 };
 pub use source_reconciliation_runner::{
     IndexReconciliationCancelOutcome, IndexReconciliationRunError,

--- a/crates/rustok-index/src/infrastructure/postgres/source_reconciliation_recovery.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_reconciliation_recovery.rs
@@ -1,0 +1,686 @@
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, QueryResult, Statement,
+    TransactionTrait, Value as SqlValue,
+};
+use serde_json::{json, Value as JsonValue};
+use thiserror::Error;
+use uuid::Uuid;
+
+const RECONCILIATION_CURSOR_CONTRACT: &str = "index_reconciliation_cursor_v1";
+const RECONCILIATION_RECOVERY_ACTION: &str = "requeue";
+const MAX_RECOVERY_REASON_BYTES: usize = 512;
+const MAX_SCOPE_NAME_BYTES: usize = 128;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexReconciliationRequeueRequest {
+    tenant_id: Uuid,
+    job_id: Uuid,
+    actor_id: Uuid,
+    reason: String,
+}
+
+impl IndexReconciliationRequeueRequest {
+    pub fn new(
+        tenant_id: Uuid,
+        job_id: Uuid,
+        actor_id: Uuid,
+        reason: impl Into<String>,
+    ) -> Result<Self, IndexReconciliationRecoveryError> {
+        if tenant_id.is_nil() {
+            return Err(IndexReconciliationRecoveryError::NilTenantId);
+        }
+        if job_id.is_nil() {
+            return Err(IndexReconciliationRecoveryError::NilJobId);
+        }
+        if actor_id.is_nil() {
+            return Err(IndexReconciliationRecoveryError::NilActorId);
+        }
+        let reason = reason.into();
+        validate_reason(&reason)?;
+        Ok(Self {
+            tenant_id,
+            job_id,
+            actor_id,
+            reason,
+        })
+    }
+
+    pub fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub fn job_id(&self) -> Uuid {
+        self.job_id
+    }
+
+    pub fn actor_id(&self) -> Uuid {
+        self.actor_id
+    }
+
+    pub fn reason(&self) -> &str {
+        &self.reason
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexReconciliationRequeueOutcome {
+    Requeued {
+        audit_id: Uuid,
+        job_id: Uuid,
+        retry_epoch: u32,
+    },
+    NotFound,
+    NotFailed,
+}
+
+#[derive(Clone)]
+pub struct PostgresIndexReconciliationRecoveryStore {
+    db: DatabaseConnection,
+}
+
+impl PostgresIndexReconciliationRecoveryStore {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    pub async fn requeue_failed(
+        &self,
+        request: IndexReconciliationRequeueRequest,
+    ) -> Result<IndexReconciliationRequeueOutcome, IndexReconciliationRecoveryError> {
+        let transaction = self
+            .db
+            .begin()
+            .await
+            .map_err(|_| IndexReconciliationRecoveryError::Storage)?;
+        let result = requeue_in_transaction(&transaction, &request).await;
+        match result {
+            Ok(outcome) => {
+                transaction
+                    .commit()
+                    .await
+                    .map_err(|_| IndexReconciliationRecoveryError::Storage)?;
+                Ok(outcome)
+            }
+            Err(error) => {
+                transaction
+                    .rollback()
+                    .await
+                    .map_err(|_| IndexReconciliationRecoveryError::Storage)?;
+                Err(error)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RecoveryScope {
+    module_name: String,
+    entity_name: String,
+    schema_version: u32,
+    state: String,
+    attempt_count: u32,
+    retry_epoch: u32,
+}
+
+async fn requeue_in_transaction(
+    transaction: &DatabaseTransaction,
+    request: &IndexReconciliationRequeueRequest,
+) -> Result<IndexReconciliationRequeueOutcome, IndexReconciliationRecoveryError> {
+    let backend = transaction.get_database_backend();
+    ensure_supported_backend(backend)?;
+
+    let Some(scope) = select_recovery_scope(transaction, request, backend, false).await? else {
+        return Ok(IndexReconciliationRequeueOutcome::NotFound);
+    };
+    lock_reconciliation_scope(transaction, request.tenant_id, &scope, backend).await?;
+
+    let Some(locked) = select_recovery_scope(transaction, request, backend, true).await? else {
+        return Ok(IndexReconciliationRequeueOutcome::NotFound);
+    };
+    if locked.module_name != scope.module_name
+        || locked.entity_name != scope.entity_name
+        || locked.schema_version != scope.schema_version
+    {
+        return Err(IndexReconciliationRecoveryError::RecoveryRace);
+    }
+    if locked.state != "failed" {
+        return Ok(IndexReconciliationRequeueOutcome::NotFailed);
+    }
+    if locked.attempt_count == 0 {
+        return Err(IndexReconciliationRecoveryError::InvalidStoredJob(
+            "failed reconciliation job attempt count must be positive",
+        ));
+    }
+
+    let retry_epoch = locked
+        .retry_epoch
+        .checked_add(1)
+        .ok_or(IndexReconciliationRecoveryError::CounterOverflow)?;
+    let cursor = initial_cursor();
+    let updated = transaction
+        .execute(Statement::from_sql_and_values(
+            backend,
+            update_failed_job_sql(backend),
+            vec![
+                uuid_value(request.tenant_id, backend),
+                uuid_value(request.job_id, backend),
+                i64::from(locked.attempt_count).into(),
+                i64::from(locked.retry_epoch).into(),
+                i64::from(retry_epoch).into(),
+                SqlValue::Json(Some(Box::new(cursor))),
+            ],
+        ))
+        .await
+        .map_err(|_| IndexReconciliationRecoveryError::Storage)?;
+    if updated.rows_affected() != 1 {
+        return Err(IndexReconciliationRecoveryError::RecoveryRace);
+    }
+
+    let audit_id = Uuid::new_v4();
+    transaction
+        .execute(Statement::from_sql_and_values(
+            backend,
+            insert_audit_sql(backend),
+            vec![
+                uuid_value(request.tenant_id, backend),
+                uuid_value(audit_id, backend),
+                uuid_value(request.job_id, backend),
+                uuid_value(request.actor_id, backend),
+                request.reason.clone().into(),
+                i64::from(locked.attempt_count).into(),
+                i64::from(retry_epoch).into(),
+            ],
+        ))
+        .await
+        .map_err(|_| IndexReconciliationRecoveryError::Storage)?;
+
+    Ok(IndexReconciliationRequeueOutcome::Requeued {
+        audit_id,
+        job_id: request.job_id,
+        retry_epoch,
+    })
+}
+
+async fn select_recovery_scope(
+    transaction: &DatabaseTransaction,
+    request: &IndexReconciliationRequeueRequest,
+    backend: DbBackend,
+    for_update: bool,
+) -> Result<Option<RecoveryScope>, IndexReconciliationRecoveryError> {
+    transaction
+        .query_one(Statement::from_sql_and_values(
+            backend,
+            select_job_sql(backend, for_update),
+            vec![
+                uuid_value(request.tenant_id, backend),
+                uuid_value(request.job_id, backend),
+            ],
+        ))
+        .await
+        .map_err(|_| IndexReconciliationRecoveryError::Storage)?
+        .map(|row| decode_scope(&row))
+        .transpose()
+}
+
+fn decode_scope(row: &QueryResult) -> Result<RecoveryScope, IndexReconciliationRecoveryError> {
+    let scope_kind: String = row
+        .try_get("", "scope_kind")
+        .map_err(|_| IndexReconciliationRecoveryError::Storage)?;
+    if scope_kind != "schema" {
+        return Err(IndexReconciliationRecoveryError::InvalidStoredJob(
+            "reconciliation recovery requires schema scope",
+        ));
+    }
+    let module_name: String = row
+        .try_get("", "module_name")
+        .map_err(|_| IndexReconciliationRecoveryError::Storage)?;
+    let entity_name: String = row
+        .try_get("", "entity_name")
+        .map_err(|_| IndexReconciliationRecoveryError::Storage)?;
+    validate_scope_name(&module_name)?;
+    validate_scope_name(&entity_name)?;
+
+    let schema_version: i64 = row
+        .try_get("", "schema_version_value")
+        .map_err(|_| IndexReconciliationRecoveryError::Storage)?;
+    let schema_version = u32::try_from(schema_version).map_err(|_| {
+        IndexReconciliationRecoveryError::InvalidStoredJob(
+            "reconciliation recovery schema version is invalid",
+        )
+    })?;
+    if schema_version == 0 {
+        return Err(IndexReconciliationRecoveryError::InvalidStoredJob(
+            "reconciliation recovery schema version must be positive",
+        ));
+    }
+
+    let attempt_count: i64 = row
+        .try_get("", "attempt_count_value")
+        .map_err(|_| IndexReconciliationRecoveryError::Storage)?;
+    let attempt_count = u32::try_from(attempt_count).map_err(|_| {
+        IndexReconciliationRecoveryError::InvalidStoredJob(
+            "reconciliation recovery attempt count is invalid",
+        )
+    })?;
+    let retry_epoch: i64 = row
+        .try_get("", "retry_epoch_value")
+        .map_err(|_| IndexReconciliationRecoveryError::Storage)?;
+    let retry_epoch = u32::try_from(retry_epoch).map_err(|_| {
+        IndexReconciliationRecoveryError::InvalidStoredJob(
+            "reconciliation recovery retry epoch is invalid",
+        )
+    })?;
+
+    Ok(RecoveryScope {
+        module_name,
+        entity_name,
+        schema_version,
+        state: row
+            .try_get("", "state")
+            .map_err(|_| IndexReconciliationRecoveryError::Storage)?,
+        attempt_count,
+        retry_epoch,
+    })
+}
+
+async fn lock_reconciliation_scope(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+    scope: &RecoveryScope,
+    backend: DbBackend,
+) -> Result<(), IndexReconciliationRecoveryError> {
+    if backend == DbBackend::Sqlite {
+        return Ok(());
+    }
+    let lock_key = format!(
+        "reconcile\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}",
+        tenant_id, scope.module_name, scope.entity_name, scope.schema_version,
+    );
+    transaction
+        .execute(Statement::from_sql_and_values(
+            backend,
+            "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+            vec![lock_key.into()],
+        ))
+        .await
+        .map_err(|_| IndexReconciliationRecoveryError::Storage)?;
+    Ok(())
+}
+
+fn initial_cursor() -> JsonValue {
+    json!({
+        "contract": RECONCILIATION_CURSOR_CONTRACT,
+        "completed_passes": 0,
+        "source_cursor": null,
+        "pages_processed": 0,
+        "mutation_count": 0,
+        "applied_count": 0,
+        "duplicate_count": 0,
+        "stale_count": 0
+    })
+}
+
+fn validate_reason(value: &str) -> Result<(), IndexReconciliationRecoveryError> {
+    if value.is_empty() {
+        return Err(IndexReconciliationRecoveryError::InvalidReason(
+            "reason must not be empty",
+        ));
+    }
+    if value.len() > MAX_RECOVERY_REASON_BYTES {
+        return Err(IndexReconciliationRecoveryError::InvalidReason(
+            "reason exceeds 512 bytes",
+        ));
+    }
+    if value.trim() != value {
+        return Err(IndexReconciliationRecoveryError::InvalidReason(
+            "reason must be trimmed",
+        ));
+    }
+    if value.chars().any(char::is_control) {
+        return Err(IndexReconciliationRecoveryError::InvalidReason(
+            "reason must not contain control characters",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_scope_name(value: &str) -> Result<(), IndexReconciliationRecoveryError> {
+    if value.is_empty()
+        || value.len() > MAX_SCOPE_NAME_BYTES
+        || value.trim() != value
+        || value.chars().any(char::is_control)
+    {
+        return Err(IndexReconciliationRecoveryError::InvalidStoredJob(
+            "reconciliation recovery scope name is invalid",
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_supported_backend(
+    backend: DbBackend,
+) -> Result<(), IndexReconciliationRecoveryError> {
+    match backend {
+        DbBackend::Postgres => Ok(()),
+        DbBackend::Sqlite if cfg!(test) => Ok(()),
+        _ => Err(IndexReconciliationRecoveryError::UnsupportedBackend),
+    }
+}
+
+fn placeholder_prefix(backend: DbBackend) -> &'static str {
+    match backend {
+        DbBackend::Postgres => "$",
+        DbBackend::Sqlite => "?",
+        _ => unreachable!("unsupported backend was validated"),
+    }
+}
+
+fn uuid_value(value: Uuid, backend: DbBackend) -> SqlValue {
+    match backend {
+        DbBackend::Postgres => value.into(),
+        DbBackend::Sqlite => value.to_string().into(),
+        _ => unreachable!("unsupported backend was validated"),
+    }
+}
+
+fn select_job_sql(backend: DbBackend, for_update: bool) -> String {
+    let prefix = placeholder_prefix(backend);
+    let lock = if backend == DbBackend::Postgres && for_update {
+        " FOR UPDATE"
+    } else {
+        ""
+    };
+    format!(
+        "SELECT scope_kind, module_name, entity_name, CAST(schema_version AS BIGINT) AS schema_version_value, state, CAST(attempt_count AS BIGINT) AS attempt_count_value, CAST(retry_epoch AS BIGINT) AS retry_epoch_value FROM index_jobs WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'reconcile' LIMIT 1{lock}"
+    )
+}
+
+fn update_failed_job_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    format!(
+        "UPDATE index_jobs SET state = 'pending', cursor = {prefix}6, attempt_count = 0, available_at = CURRENT_TIMESTAMP, lease_owner = NULL, lease_expires_at = NULL, heartbeat_at = NULL, cancel_requested = FALSE, last_error_code = NULL, last_error_details = NULL, completed_at = NULL, updated_at = CURRENT_TIMESTAMP, retry_epoch = {prefix}5 WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'reconcile' AND state = 'failed' AND attempt_count = {prefix}3 AND retry_epoch = {prefix}4"
+    )
+}
+
+fn insert_audit_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    format!(
+        "INSERT INTO index_reconciliation_recovery_audits (tenant_id, audit_id, job_id, actor_id, action, reason, prior_attempt_count, retry_epoch) VALUES ({prefix}1, {prefix}2, {prefix}3, {prefix}4, '{RECONCILIATION_RECOVERY_ACTION}', {prefix}5, {prefix}6, {prefix}7)"
+    )
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum IndexReconciliationRecoveryError {
+    #[error("Index reconciliation recovery tenant id must not be nil")]
+    NilTenantId,
+    #[error("Index reconciliation recovery job id must not be nil")]
+    NilJobId,
+    #[error("Index reconciliation recovery actor id must not be nil")]
+    NilActorId,
+    #[error("Index reconciliation recovery reason is invalid: {0}")]
+    InvalidReason(&'static str),
+    #[error("stored Index reconciliation recovery state is invalid: {0}")]
+    InvalidStoredJob(&'static str),
+    #[error("Index reconciliation recovery counter overflow")]
+    CounterOverflow,
+    #[error("Index reconciliation recovery raced with another state transition")]
+    RecoveryRace,
+    #[error("Index reconciliation recovery does not support this database backend")]
+    UnsupportedBackend,
+    #[error("Index reconciliation recovery storage operation failed")]
+    Storage,
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{ConnectionTrait, Database, DbBackend, Statement};
+
+    use super::*;
+
+    async fn database() -> DatabaseConnection {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+        for statement in [
+            r#"CREATE TABLE index_jobs (
+                tenant_id TEXT NOT NULL,
+                job_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                state TEXT NOT NULL,
+                scope_kind TEXT NOT NULL,
+                module_name TEXT,
+                entity_name TEXT,
+                schema_version INTEGER,
+                cursor JSON,
+                attempt_count INTEGER NOT NULL,
+                available_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                lease_owner TEXT,
+                lease_expires_at TEXT,
+                heartbeat_at TEXT,
+                cancel_requested INTEGER NOT NULL DEFAULT 0,
+                last_error_code TEXT,
+                last_error_details JSON,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                completed_at TEXT,
+                retry_epoch INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (tenant_id, job_id)
+            )"#,
+            r#"CREATE TABLE index_reconciliation_recovery_audits (
+                tenant_id TEXT NOT NULL,
+                audit_id TEXT NOT NULL,
+                job_id TEXT NOT NULL,
+                actor_id TEXT NOT NULL,
+                action TEXT NOT NULL,
+                reason TEXT NOT NULL,
+                prior_attempt_count INTEGER NOT NULL,
+                retry_epoch INTEGER NOT NULL,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (tenant_id, audit_id),
+                UNIQUE (tenant_id, job_id, retry_epoch)
+            )"#,
+            r#"CREATE TRIGGER index_reconciliation_recovery_audits_immutable_update
+                BEFORE UPDATE ON index_reconciliation_recovery_audits
+                FOR EACH ROW BEGIN
+                    SELECT RAISE(ABORT, 'append-only');
+                END"#,
+            r#"CREATE TRIGGER index_reconciliation_recovery_audits_immutable_delete
+                BEFORE DELETE ON index_reconciliation_recovery_audits
+                FOR EACH ROW BEGIN
+                    SELECT RAISE(ABORT, 'append-only');
+                END"#,
+        ] {
+            db.execute_unprepared(statement)
+                .await
+                .expect("recovery fixture");
+        }
+        db
+    }
+
+    async fn insert_failed(
+        db: &DatabaseConnection,
+        tenant_id: Uuid,
+        job_id: Uuid,
+        attempt_count: u32,
+    ) {
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO index_jobs (tenant_id, job_id, kind, state, scope_kind, module_name, entity_name, schema_version, cursor, attempt_count, last_error_code, last_error_details, completed_at) VALUES (?1, ?2, 'reconcile', 'failed', 'schema', 'catalog', 'product', 1, '{}', ?3, 'index.reconciliation_page_failed', '{}', CURRENT_TIMESTAMP)",
+            vec![
+                tenant_id.to_string().into(),
+                job_id.to_string().into(),
+                i64::from(attempt_count).into(),
+            ],
+        ))
+        .await
+        .expect("failed reconciliation job");
+    }
+
+    #[tokio::test]
+    async fn requeue_resets_same_job_and_appends_immutable_audit() {
+        let db = database().await;
+        let tenant_id = Uuid::new_v4();
+        let job_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        insert_failed(&db, tenant_id, job_id, 3).await;
+
+        let outcome = PostgresIndexReconciliationRecoveryStore::new(db.clone())
+            .requeue_failed(
+                IndexReconciliationRequeueRequest::new(
+                    tenant_id,
+                    job_id,
+                    actor_id,
+                    "operator approved bounded retry",
+                )
+                .unwrap(),
+            )
+            .await
+            .expect("requeue");
+        let IndexReconciliationRequeueOutcome::Requeued {
+            audit_id,
+            job_id: returned_job_id,
+            retry_epoch,
+        } = outcome
+        else {
+            panic!("expected requeue");
+        };
+        assert_eq!(returned_job_id, job_id);
+        assert_eq!(retry_epoch, 1);
+
+        let job = db
+            .query_one(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                "SELECT state, cursor, attempt_count, cancel_requested, last_error_code, last_error_details, completed_at, retry_epoch FROM index_jobs WHERE tenant_id = ?1 AND job_id = ?2",
+                vec![tenant_id.to_string().into(), job_id.to_string().into()],
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(job.try_get::<String>("", "state").unwrap(), "pending");
+        assert_eq!(job.try_get::<i64>("", "attempt_count").unwrap(), 0);
+        assert_eq!(job.try_get::<i64>("", "cancel_requested").unwrap(), 0);
+        assert_eq!(job.try_get::<i64>("", "retry_epoch").unwrap(), 1);
+        assert!(job.try_get::<Option<String>>("", "last_error_code").unwrap().is_none());
+        assert!(job.try_get::<Option<JsonValue>>("", "last_error_details").unwrap().is_none());
+        assert!(job.try_get::<Option<String>>("", "completed_at").unwrap().is_none());
+        let cursor: JsonValue = job.try_get("", "cursor").unwrap();
+        assert_eq!(cursor, initial_cursor());
+
+        let audit = db
+            .query_one(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                "SELECT actor_id, action, reason, prior_attempt_count, retry_epoch FROM index_reconciliation_recovery_audits WHERE tenant_id = ?1 AND audit_id = ?2",
+                vec![tenant_id.to_string().into(), audit_id.to_string().into()],
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(audit.try_get::<String>("", "actor_id").unwrap(), actor_id.to_string());
+        assert_eq!(audit.try_get::<String>("", "action").unwrap(), "requeue");
+        assert_eq!(
+            audit.try_get::<String>("", "reason").unwrap(),
+            "operator approved bounded retry"
+        );
+        assert_eq!(audit.try_get::<i64>("", "prior_attempt_count").unwrap(), 3);
+        assert_eq!(audit.try_get::<i64>("", "retry_epoch").unwrap(), 1);
+
+        assert!(
+            db.execute_unprepared(
+                "UPDATE index_reconciliation_recovery_audits SET reason = 'changed'"
+            )
+            .await
+            .is_err()
+        );
+        assert!(
+            db.execute_unprepared("DELETE FROM index_reconciliation_recovery_audits")
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn requeue_is_one_shot_for_each_failed_epoch() {
+        let db = database().await;
+        let tenant_id = Uuid::new_v4();
+        let job_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        insert_failed(&db, tenant_id, job_id, 1).await;
+        let store = PostgresIndexReconciliationRecoveryStore::new(db.clone());
+        let request = IndexReconciliationRequeueRequest::new(
+            tenant_id,
+            job_id,
+            actor_id,
+            "approved retry",
+        )
+        .unwrap();
+
+        assert!(matches!(
+            store.requeue_failed(request.clone()).await.unwrap(),
+            IndexReconciliationRequeueOutcome::Requeued { retry_epoch: 1, .. }
+        ));
+        assert_eq!(
+            store.requeue_failed(request).await.unwrap(),
+            IndexReconciliationRequeueOutcome::NotFailed
+        );
+        let count = db
+            .query_one(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT COUNT(*) AS count_value FROM index_reconciliation_recovery_audits"
+                    .to_owned(),
+            ))
+            .await
+            .unwrap()
+            .unwrap()
+            .try_get::<i64>("", "count_value")
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn request_rejects_nil_identity_and_unbounded_reason() {
+        assert!(matches!(
+            IndexReconciliationRequeueRequest::new(
+                Uuid::nil(),
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                "reason"
+            ),
+            Err(IndexReconciliationRecoveryError::NilTenantId)
+        ));
+        assert!(matches!(
+            IndexReconciliationRequeueRequest::new(
+                Uuid::new_v4(),
+                Uuid::nil(),
+                Uuid::new_v4(),
+                "reason"
+            ),
+            Err(IndexReconciliationRecoveryError::NilJobId)
+        ));
+        assert!(matches!(
+            IndexReconciliationRequeueRequest::new(
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                Uuid::nil(),
+                "reason"
+            ),
+            Err(IndexReconciliationRecoveryError::NilActorId)
+        ));
+        assert!(matches!(
+            IndexReconciliationRequeueRequest::new(
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                " reason "
+            ),
+            Err(IndexReconciliationRecoveryError::InvalidReason(_))
+        ));
+        assert!(matches!(
+            IndexReconciliationRequeueRequest::new(
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                "x".repeat(MAX_RECOVERY_REASON_BYTES + 1)
+            ),
+            Err(IndexReconciliationRecoveryError::InvalidReason(_))
+        ));
+    }
+}

--- a/crates/rustok-index/src/migrations/m20260803_000004_create_index_reconciliation_recovery.rs
+++ b/crates/rustok-index/src/migrations/m20260803_000004_create_index_reconciliation_recovery.rs
@@ -1,0 +1,155 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::{ConnectionTrait, DbBackend};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DbBackend::Postgres => postgres_up(manager).await,
+            DbBackend::Sqlite => sqlite_up(manager).await,
+            DbBackend::MySql => Err(DbErr::Migration(
+                "Index reconciliation recovery supports PostgreSQL and SQLite only".to_string(),
+            )),
+        }
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DbBackend::Postgres => postgres_down(manager).await,
+            DbBackend::Sqlite => sqlite_down(manager).await,
+            DbBackend::MySql => Ok(()),
+        }
+    }
+}
+
+async fn postgres_up(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .get_connection()
+        .execute_unprepared(
+            r#"
+ALTER TABLE index_jobs
+    ADD COLUMN retry_epoch INTEGER NOT NULL DEFAULT 0
+    CONSTRAINT chk_index_jobs_retry_epoch CHECK (retry_epoch >= 0);
+
+CREATE TABLE index_reconciliation_recovery_audits (
+    tenant_id UUID NOT NULL,
+    audit_id UUID NOT NULL,
+    job_id UUID NOT NULL,
+    actor_id UUID NOT NULL,
+    action VARCHAR(32) NOT NULL,
+    reason VARCHAR(512) NOT NULL,
+    prior_attempt_count INTEGER NOT NULL,
+    retry_epoch INTEGER NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_index_reconciliation_recovery_audits
+        PRIMARY KEY (tenant_id, audit_id),
+    CONSTRAINT uq_index_reconciliation_recovery_job_epoch
+        UNIQUE (tenant_id, job_id, retry_epoch),
+    CONSTRAINT chk_index_reconciliation_recovery_action
+        CHECK (action = 'requeue'),
+    CONSTRAINT chk_index_reconciliation_recovery_reason
+        CHECK (length(reason) BETWEEN 1 AND 512 AND reason = btrim(reason)),
+    CONSTRAINT chk_index_reconciliation_recovery_prior_attempt
+        CHECK (prior_attempt_count > 0),
+    CONSTRAINT chk_index_reconciliation_recovery_epoch
+        CHECK (retry_epoch > 0)
+);
+
+CREATE INDEX idx_index_reconciliation_recovery_job
+    ON index_reconciliation_recovery_audits (tenant_id, job_id, created_at);
+
+CREATE OR REPLACE FUNCTION index_reconciliation_recovery_reject_mutation()
+RETURNS trigger AS $$
+BEGIN
+    RAISE EXCEPTION 'Index reconciliation recovery audits are append-only';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER index_reconciliation_recovery_audits_immutable_update
+BEFORE UPDATE ON index_reconciliation_recovery_audits
+FOR EACH ROW EXECUTE FUNCTION index_reconciliation_recovery_reject_mutation();
+
+CREATE TRIGGER index_reconciliation_recovery_audits_immutable_delete
+BEFORE DELETE ON index_reconciliation_recovery_audits
+FOR EACH ROW EXECUTE FUNCTION index_reconciliation_recovery_reject_mutation();
+"#,
+        )
+        .await?;
+    Ok(())
+}
+
+async fn sqlite_up(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    let connection = manager.get_connection();
+    for statement in [
+        r#"ALTER TABLE index_jobs
+ADD COLUMN retry_epoch INTEGER NOT NULL DEFAULT 0
+CHECK (retry_epoch >= 0)"#,
+        r#"CREATE TABLE index_reconciliation_recovery_audits (
+    tenant_id TEXT NOT NULL,
+    audit_id TEXT NOT NULL,
+    job_id TEXT NOT NULL,
+    actor_id TEXT NOT NULL,
+    action TEXT NOT NULL CHECK (action = 'requeue'),
+    reason TEXT NOT NULL CHECK (
+        length(reason) BETWEEN 1 AND 512
+        AND reason = trim(reason)
+    ),
+    prior_attempt_count INTEGER NOT NULL CHECK (prior_attempt_count > 0),
+    retry_epoch INTEGER NOT NULL CHECK (retry_epoch > 0),
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (tenant_id, audit_id),
+    UNIQUE (tenant_id, job_id, retry_epoch)
+)"#,
+        r#"CREATE INDEX idx_index_reconciliation_recovery_job
+ON index_reconciliation_recovery_audits (tenant_id, job_id, created_at)"#,
+        r#"CREATE TRIGGER index_reconciliation_recovery_audits_immutable_update
+BEFORE UPDATE ON index_reconciliation_recovery_audits
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT, 'Index reconciliation recovery audits are append-only');
+END"#,
+        r#"CREATE TRIGGER index_reconciliation_recovery_audits_immutable_delete
+BEFORE DELETE ON index_reconciliation_recovery_audits
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT, 'Index reconciliation recovery audits are append-only');
+END"#,
+    ] {
+        connection.execute_unprepared(statement).await?;
+    }
+    Ok(())
+}
+
+async fn postgres_down(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .get_connection()
+        .execute_unprepared(
+            r#"
+DROP TRIGGER IF EXISTS index_reconciliation_recovery_audits_immutable_update
+    ON index_reconciliation_recovery_audits;
+DROP TRIGGER IF EXISTS index_reconciliation_recovery_audits_immutable_delete
+    ON index_reconciliation_recovery_audits;
+DROP FUNCTION IF EXISTS index_reconciliation_recovery_reject_mutation();
+DROP TABLE IF EXISTS index_reconciliation_recovery_audits;
+ALTER TABLE index_jobs DROP COLUMN retry_epoch;
+"#,
+        )
+        .await?;
+    Ok(())
+}
+
+async fn sqlite_down(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    let connection = manager.get_connection();
+    for statement in [
+        "DROP TRIGGER IF EXISTS index_reconciliation_recovery_audits_immutable_update",
+        "DROP TRIGGER IF EXISTS index_reconciliation_recovery_audits_immutable_delete",
+        "DROP TABLE IF EXISTS index_reconciliation_recovery_audits",
+        "ALTER TABLE index_jobs DROP COLUMN retry_epoch",
+    ] {
+        connection.execute_unprepared(statement).await?;
+    }
+    Ok(())
+}

--- a/crates/rustok-index/src/migrations/mod.rs
+++ b/crates/rustok-index/src/migrations/mod.rs
@@ -1,6 +1,7 @@
 mod m20260727_000001_create_index_records;
 mod m20260727_000002_create_index_delivery_state;
 mod m20260727_000003_create_index_operations;
+mod m20260803_000004_create_index_reconciliation_recovery;
 
 use rustok_core::MigrationDependencyDescriptor;
 use sea_orm_migration::sea_orm::DbBackend;
@@ -32,6 +33,7 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260727_000001_create_index_records::Migration),
         Box::new(m20260727_000002_create_index_delivery_state::Migration),
         Box::new(m20260727_000003_create_index_operations::Migration),
+        Box::new(m20260803_000004_create_index_reconciliation_recovery::Migration),
     ]
 }
 
@@ -48,6 +50,10 @@ pub fn migration_dependencies() -> Vec<MigrationDependencyDescriptor> {
         MigrationDependencyDescriptor::new(
             "m20260727_000003_create_index_operations",
             vec!["m20260727_000001_create_index_records"],
+        ),
+        MigrationDependencyDescriptor::new(
+            "m20260803_000004_create_index_reconciliation_recovery",
+            vec!["m20260727_000003_create_index_operations"],
         ),
     ]
 }

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -25,6 +25,7 @@ const scripts = [
   'verify-index-server-reconciliation-guard.mjs',
   'verify-index-reconciliation-dead-letter-admission.mjs',
   'verify-index-reconciliation-dead-letter-inspection.mjs',
+  'verify-index-reconciliation-dead-letter-requeue.mjs',
   'verify-index-replay-dry-run.mjs',
   'verify-index-replay-page-interruption.mjs',
   'verify-index-replay-retry-store.mjs',

--- a/scripts/verify/verify-index-reconciliation-dead-letter-requeue.mjs
+++ b/scripts/verify/verify-index-reconciliation-dead-letter-requeue.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-reconciliation-dead-letter-requeue] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const migrationModulePath = 'crates/rustok-index/src/migrations/mod.rs';
+const migrationPath =
+  'crates/rustok-index/src/migrations/m20260803_000004_create_index_reconciliation_recovery.rs';
+const recoveryPath =
+  'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_recovery.rs';
+const postgresPath = 'crates/rustok-index/src/infrastructure/postgres/mod.rs';
+const runnerPath =
+  'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner.rs';
+const serverPath = 'apps/server/src/services/index_reconciliation_operator.rs';
+const docsPath = 'crates/rustok-index/docs/m6-reconciliation-dead-letter-requeue.md';
+const docsIndexPath = 'crates/rustok-index/docs/README.md';
+const planPath = 'crates/rustok-index/docs/implementation-plan.md';
+const aggregatePath = 'scripts/verify/verify-index-query-contract.mjs';
+
+requireMarkers(migrationModulePath, [
+  'mod m20260803_000004_create_index_reconciliation_recovery;',
+  'm20260803_000004_create_index_reconciliation_recovery::Migration',
+  '"m20260803_000004_create_index_reconciliation_recovery"',
+  'vec!["m20260727_000003_create_index_operations"]',
+]);
+
+const migration = requireMarkers(migrationPath, [
+  'ALTER TABLE index_jobs',
+  'ADD COLUMN retry_epoch INTEGER NOT NULL DEFAULT 0',
+  'CREATE TABLE index_reconciliation_recovery_audits',
+  'tenant_id UUID NOT NULL',
+  'audit_id UUID NOT NULL',
+  'job_id UUID NOT NULL',
+  'actor_id UUID NOT NULL',
+  "CHECK (action = 'requeue')",
+  'reason VARCHAR(512) NOT NULL',
+  'prior_attempt_count INTEGER NOT NULL',
+  'retry_epoch INTEGER NOT NULL',
+  'UNIQUE (tenant_id, job_id, retry_epoch)',
+  'index_reconciliation_recovery_audits_immutable_update',
+  'index_reconciliation_recovery_audits_immutable_delete',
+  "RAISE EXCEPTION 'Index reconciliation recovery audits are append-only'",
+  "SELECT RAISE(ABORT, 'Index reconciliation recovery audits are append-only')",
+  'ALTER TABLE index_jobs DROP COLUMN retry_epoch',
+]);
+for (const forbidden of [
+  'ON UPDATE CASCADE',
+  'ON DELETE CASCADE',
+  '.if_not_exists()',
+]) {
+  if (migration.includes(forbidden)) {
+    fail(`${migrationPath} contains forbidden drift/mutability marker ${forbidden}`);
+  }
+}
+
+const recovery = requireMarkers(recoveryPath, [
+  'const RECONCILIATION_CURSOR_CONTRACT: &str = "index_reconciliation_cursor_v1";',
+  'const RECONCILIATION_RECOVERY_ACTION: &str = "requeue";',
+  'const MAX_RECOVERY_REASON_BYTES: usize = 512;',
+  'pub struct IndexReconciliationRequeueRequest',
+  'pub enum IndexReconciliationRequeueOutcome',
+  'pub struct PostgresIndexReconciliationRecoveryStore',
+  'pub async fn requeue_failed(',
+  'select_recovery_scope(transaction, request, backend, false).await?',
+  'lock_reconciliation_scope(transaction, request.tenant_id, &scope, backend).await?;',
+  'select_recovery_scope(transaction, request, backend, true).await?',
+  'if locked.state != "failed"',
+  '.checked_add(1)',
+  'update_failed_job_sql(backend)',
+  'insert_audit_sql(backend)',
+  'transaction.commit()',
+  'transaction.rollback()',
+  'requeue_resets_same_job_and_appends_immutable_audit',
+  'requeue_is_one_shot_for_each_failed_epoch',
+  'request_rejects_nil_identity_and_unbounded_reason',
+]);
+
+const transactionStart = recovery.indexOf('async fn requeue_in_transaction(');
+const transactionEnd = recovery.indexOf('\nasync fn select_recovery_scope(', transactionStart);
+if (transactionStart < 0 || transactionEnd <= transactionStart) {
+  fail(`${recoveryPath} bounded recovery transaction is missing`);
+}
+const transaction = recovery.slice(transactionStart, transactionEnd);
+const firstSelect = transaction.indexOf(
+  'select_recovery_scope(transaction, request, backend, false)',
+);
+const scopeLock = transaction.indexOf('lock_reconciliation_scope(');
+const lockedSelect = transaction.indexOf(
+  'select_recovery_scope(transaction, request, backend, true)',
+);
+const failedCheck = transaction.indexOf('if locked.state != "failed"');
+const jobUpdate = transaction.indexOf('update_failed_job_sql(backend)');
+const auditInsert = transaction.indexOf('insert_audit_sql(backend)');
+if (
+  firstSelect < 0
+  || scopeLock <= firstSelect
+  || lockedSelect <= scopeLock
+  || failedCheck <= lockedSelect
+  || jobUpdate <= failedCheck
+  || auditInsert <= jobUpdate
+) {
+  fail(`${recoveryPath} must resolve, lock, re-read, validate, reset, then audit`);
+}
+
+const lockStart = recovery.indexOf('async fn lock_reconciliation_scope(');
+const lockEnd = recovery.indexOf('\nfn initial_cursor()', lockStart);
+const lock = recovery.slice(lockStart, lockEnd);
+for (const marker of [
+  '"reconcile\\u{1f}{}\\u{1f}{}\\u{1f}{}\\u{1f}{}"',
+  'tenant_id, scope.module_name, scope.entity_name, scope.schema_version',
+  'SELECT pg_advisory_xact_lock(hashtextextended($1, 0))',
+]) {
+  if (!lock.includes(marker)) fail(`${recoveryPath} scope lock is missing ${marker}`);
+}
+
+const runner = requireMarkers(runnerPath, [
+  '"reconcile\\u{1f}{}\\u{1f}{}\\u{1f}{}\\u{1f}{}"',
+  'SELECT pg_advisory_xact_lock(hashtextextended($1, 0))',
+  'IndexReconciliationRunError::DeadLettered',
+]);
+if (!runner.includes("state IN ('pending', 'running', 'succeeded', 'failed')")) {
+  fail(`${runnerPath} failed-scope admission must remain active`);
+}
+
+const updateStart = recovery.indexOf('fn update_failed_job_sql(');
+const updateEnd = recovery.indexOf('\nfn insert_audit_sql(', updateStart);
+const update = recovery.slice(updateStart, updateEnd);
+for (const marker of [
+  "state = 'pending'",
+  'cursor = {prefix}6',
+  'attempt_count = 0',
+  'available_at = CURRENT_TIMESTAMP',
+  'lease_owner = NULL',
+  'lease_expires_at = NULL',
+  'heartbeat_at = NULL',
+  'cancel_requested = FALSE',
+  'last_error_code = NULL',
+  'last_error_details = NULL',
+  'completed_at = NULL',
+  'retry_epoch = {prefix}5',
+  "kind = 'reconcile'",
+  "state = 'failed'",
+  'attempt_count = {prefix}3',
+  'retry_epoch = {prefix}4',
+]) {
+  if (!update.includes(marker)) fail(`${recoveryPath} failed-job reset is missing ${marker}`);
+}
+
+const production = recovery.split('\n#[cfg(test)]')[0];
+for (const forbidden of [
+  'INSERT INTO index_jobs',
+  '.sources.scan(',
+  '.sources.load(',
+  'tokio::spawn',
+  'spawn_blocking',
+  'tokio::time::sleep',
+  'Router::new',
+  'async_graphql',
+  'poll',
+  'scheduler',
+]) {
+  if (production.includes(forbidden)) {
+    fail(`${recoveryPath} production boundary contains forbidden marker ${forbidden}`);
+  }
+}
+if (production.includes('Storage(String)') || production.includes('Storage(#[source]')) {
+  fail(`${recoveryPath} storage errors must not retain database details`);
+}
+
+requireMarkers(postgresPath, [
+  'mod source_reconciliation_recovery;',
+  'pub use source_reconciliation_recovery::{',
+  'IndexReconciliationRecoveryError, IndexReconciliationRequeueOutcome,',
+  'IndexReconciliationRequeueRequest, PostgresIndexReconciliationRecoveryStore,',
+  'PostgresIndexReconciliationDeadLetterInspector,',
+  'PostgresIndexReconciliationRunner,',
+]);
+
+const server = requireMarkers(serverPath, [
+  'pub async fn run(',
+  'pub async fn request_cancel(',
+  'pub async fn inspect_dead_letter(',
+  'Permission::MODULES_MANAGE',
+]);
+const serverProduction = server.split('\n#[cfg(test)]')[0];
+for (const forbidden of [
+  'PostgresIndexReconciliationRecoveryStore',
+  'IndexReconciliationRequeueRequest',
+  'requeue_dead_letter',
+  'pub async fn requeue',
+]) {
+  if (serverProduction.includes(forbidden)) {
+    fail(`${serverPath} prematurely exposes recovery through ${forbidden}`);
+  }
+}
+
+requireMarkers(docsPath, [
+  'Status: `source_complete_authorized_server_composition_pending`.',
+  'same PostgreSQL transaction-scoped advisory lock used by normal reconciliation admission',
+  'preserves the existing job UUID',
+  'increments `retry_epoch`',
+  'appends an immutable actor/reason audit record',
+  'The audit insert and job reset commit or roll back together.',
+  'database-level `BEFORE UPDATE` and `BEFORE DELETE` rejection triggers',
+  'The existing server operator does not expose requeue.',
+  'automatic retry, backoff, exhaustion, scheduling, and graceful shutdown',
+  'maintainer-run',
+]);
+requireMarkers(docsIndexPath, [
+  '[M6 Reconciliation Dead-letter Inspection](./m6-reconciliation-dead-letter-inspection.md)',
+  '[M6 Reconciliation Dead-letter Requeue](./m6-reconciliation-dead-letter-requeue.md)',
+]);
+requireMarkers(planPath, [
+  '- [ ] Add bounded retry/backoff, dead-letter state, and global scheduling ownership.',
+  '- [ ] Add drift diagnosis, targeted repair commands, and admitted repair evidence.',
+]);
+requireMarkers(aggregatePath, [
+  "'verify-index-reconciliation-dead-letter-inspection.mjs'",
+  "'verify-index-reconciliation-dead-letter-requeue.mjs'",
+  "'verify-index-server-reconciliation-guard.mjs'",
+]);
+
+console.log('[verify-index-reconciliation-dead-letter-requeue] OK');

--- a/scripts/verify/verify-index-storage-migrations.mjs
+++ b/scripts/verify/verify-index-storage-migrations.mjs
@@ -13,7 +13,12 @@ const migrationModule = read('crates/rustok-index/src/migrations/mod.rs');
 const records = read('crates/rustok-index/src/migrations/m20260727_000001_create_index_records.rs');
 const delivery = read('crates/rustok-index/src/migrations/m20260727_000002_create_index_delivery_state.rs');
 const operations = read('crates/rustok-index/src/migrations/m20260727_000003_create_index_operations.rs');
-const migrations = normalize([migrationModule, records, delivery, operations].join('\n'));
+const recovery = read(
+  'crates/rustok-index/src/migrations/m20260803_000004_create_index_reconciliation_recovery.rs',
+);
+const migrations = normalize(
+  [migrationModule, records, delivery, operations, recovery].join('\n'),
+);
 const tests = read('crates/rustok-index/src/contract_tests.rs');
 const plan = read('crates/rustok-index/docs/implementation-plan.md');
 const crateReadme = read('crates/rustok-index/README.md');
@@ -32,10 +37,13 @@ for (const marker of [
   'mod m20260727_000001_create_index_records;',
   'mod m20260727_000002_create_index_delivery_state;',
   'mod m20260727_000003_create_index_operations;',
+  'mod m20260803_000004_create_index_reconciliation_recovery;',
   'm20260727_000001_create_index_records::Migration',
   'm20260727_000002_create_index_delivery_state::Migration',
   'm20260727_000003_create_index_operations::Migration',
+  'm20260803_000004_create_index_reconciliation_recovery::Migration',
   'm20250101_000001_create_tenants',
+  'vec!["m20260727_000003_create_index_operations"]',
 ]) {
   if (!migrationModule.includes(marker)) fail(`migration registry missing ${marker}`);
 }
@@ -48,6 +56,7 @@ for (const marker of [
   'IndexCheckpoints::Table',
   'IndexJobs::Table',
   'IndexConsistencyFindings::Table',
+  'CREATE TABLE index_reconciliation_recovery_audits',
 ]) {
   if (!migrations.includes(marker)) fail(`canonical storage table missing ${marker}`);
 }
@@ -131,8 +140,35 @@ for (const marker of [
 }
 
 for (const marker of [
+  'ADD COLUMN retry_epoch INTEGER NOT NULL DEFAULT 0',
+  'CHECK (retry_epoch >= 0)',
+  'tenant_id UUID NOT NULL',
+  'audit_id UUID NOT NULL',
+  'job_id UUID NOT NULL',
+  'actor_id UUID NOT NULL',
+  "CHECK (action = 'requeue')",
+  'reason VARCHAR(512) NOT NULL',
+  'prior_attempt_count INTEGER NOT NULL',
+  'UNIQUE (tenant_id, job_id, retry_epoch)',
+  'index_reconciliation_recovery_audits_immutable_update',
+  'index_reconciliation_recovery_audits_immutable_delete',
+  'Index reconciliation recovery audits are append-only',
+]) {
+  if (!recovery.includes(marker)) fail(`reconciliation recovery migration missing ${marker}`);
+}
+for (const forbidden of ['ON DELETE CASCADE', 'ON UPDATE CASCADE']) {
+  if (recovery.includes(forbidden)) {
+    fail(`append-only reconciliation recovery audit must not contain ${forbidden}`);
+  }
+}
+
+for (const marker of [
   'index_module_registers_canonical_storage_migrations',
   'canonical_storage_migrations_round_trip_on_sqlite',
+  'm20260803_000004_create_index_reconciliation_recovery',
+  'index_reconciliation_recovery_audits',
+  'recovery audit rows must reject updates',
+  'recovery audit rows must reject deletes',
   'source-version changes must not strand links on an older entity version',
   'processing deliveries require a complete lease',
   'down migrations must remove all Index tables',
@@ -159,6 +195,9 @@ for (const document of [crateReadme, moduleDocs, databaseDocs]) {
   ]) {
     if (!document.includes(table)) fail(`storage documentation missing ${table}`);
   }
+}
+if (!moduleDocs.includes('[M6 Reconciliation Dead-letter Requeue]')) {
+  fail('Index architecture docs must link the reconciliation recovery contract');
 }
 
 console.log('[verify-index-storage-migrations] ok');


### PR DESCRIPTION
## Summary

- add one engine-level manual recovery owner for exact failed reconciliation jobs;
- preserve the existing job UUID while moving the same row from `failed` to `pending`;
- acquire the exact schema advisory lock already used by reconciliation admission;
- reset attempt, cursor, lease, cancellation, error, and completion state atomically;
- increment a durable `retry_epoch`;
- append the exact actor, bounded reason, prior attempt count, and new epoch to an immutable audit ledger in the same transaction;
- reject audit UPDATE and DELETE at the database layer on PostgreSQL and SQLite;
- leave server authorization and all transports for a separate follow-up slice;
- document and register focused fail-closed verification.

## Fresh-main audit

The branch is built directly on `main@21d374899043ccc127f576079b8738c6f24a6c9c`, contains one clean commit, and is one commit ahead and zero behind `main`.

The three intervening Cart, Blog, and Forum commits touched no Index files. No stale PR existed for this exact recovery-owner slice; historical consolidated #2754 only documented the required sequence of immutable actor/reason audit followed by scope-locked requeue.

## Recovery request

`IndexReconciliationRequeueRequest` requires exact non-nil tenant, job, and actor UUIDs plus an explicit reason.

The reason is bounded to 512 UTF-8 bytes and must be non-empty, trimmed, and control-character-free. The engine adapter does not infer actor identity or reason text.

## Scope and concurrency

The recovery store first loads the exact tenant/job with `kind = 'reconcile'` and validates schema scope. It then acquires the same transaction-scoped PostgreSQL advisory lock as ordinary reconciliation admission:

```text
reconcile␟tenant␟module␟entity␟schema-version
```

The row is selected again under the lock. Missing jobs return `NotFound`; jobs no longer in `failed` return `NotFailed`; incompatible scope/state and concurrent fenced updates fail closed.

## Atomic reset

For one exact failed row, the same transaction:

- increments `retry_epoch`;
- changes the existing job to `pending` without generating a new job UUID;
- resets `attempt_count` to zero;
- installs a fresh `index_reconciliation_cursor_v1` cursor;
- clears lease owner/expiry, heartbeat, cancellation, last error, diagnostics, and completion timestamp;
- makes the job immediately available;
- inserts one recovery audit with tenant, generated audit UUID, job UUID, actor UUID, action, reason, prior attempts, and new retry epoch.

The update is fenced by exact failed state, prior attempt count, and prior retry epoch. The audit insert and job reset commit or roll back together. Ordinary runner admission later claims the same pending job as attempt one of the new epoch.

## Immutable audit migration

The new migration adds `index_jobs.retry_epoch` and creates `index_reconciliation_recovery_audits`.

The ledger has a unique `(tenant_id, job_id, retry_epoch)` contract and database-level `BEFORE UPDATE` / `BEFORE DELETE` rejection triggers for PostgreSQL and SQLite. It stores no raw failure diagnostics, request/cursor payload, worker/lease data, SQL, or transport context.

## Ownership boundary

This PR deliberately does not add a server write method. `IndexReconciliationOperatorRuntime` remains run/cancel/read-only-inspection only.

A later server slice must bind tenant and actor from the request context, require effective request-scoped `modules:manage`, require an explicit bounded reason, and delegate without accepting a caller-selected tenant.

## Verification actualization

The focused verifier checks:

- migration registry and dependency order;
- retry epoch and append-only audit schema;
- PostgreSQL and SQLite immutability triggers;
- exact resolve → advisory lock → re-read → failed check → reset → audit ordering;
- lock-key parity with the canonical reconciliation runner;
- same-job reset and exact attempt/epoch fencing;
- absence of new job insertion, source calls, tasks, polling, scheduler, or transport;
- absence of premature server recovery publication;
- documentation and aggregate verifier registration.

The canonical retry/global scheduling and drift-diagnosis/targeted-repair roadmap items remain open.

## Scope boundaries

This PR does not add or claim:

- server-owned requeue authorization or GraphQL/HTTP/CLI/MCP/admin transport;
- automatic retry, backoff, exhaustion, polling, scheduling, or graceful shutdown;
- a replacement job identity;
- changes to reconciliation admission, execution, source scanning, mutation application, leases, cancellation, failure terminalization, success handling, or inspector SQL;
- source/index digest comparison, orphan diagnosis, or targeted/full/shadow repair modes;
- locale or partition checkpoint dimensions;
- retained PostgreSQL concurrency or recovery execution evidence.

## Validation

Not run per maintainer instruction:

- formatting;
- Cargo checks, tests, or Clippy;
- JavaScript verifiers;
- migration apply or PostgreSQL scenarios;
- workflows and CI.

Suggested maintainer commands:

```bash
cargo test -p rustok-index source_reconciliation_recovery -- --nocapture
cargo test -p rustok-index canonical_storage_migrations_round_trip_on_sqlite -- --nocapture
cargo check -p rustok-index --all-targets
node scripts/verify/verify-index-reconciliation-dead-letter-requeue.mjs
node scripts/verify/verify-index-storage-migrations.mjs
node scripts/verify/verify-index-query-contract.mjs
```
