### PR TITLE
feat(index): authorize reconciliation dead-letter requeue

### DIFF
--- a/apps/server/docs/index-reconciliation-operator-runtime.md
+++ b/apps/server/docs/index-reconciliation-operator-runtime.md
@@ -1,15 +1,16 @@
 # Index reconciliation operator runtime
 
-Status: `source_complete_transport_and_recovery_work_pending`.
+Status: `source_complete_transport_and_scheduling_pending`.
 
 ## Purpose
 
 The server publishes one guarded `IndexReconciliationOperatorRuntime` after the existing Index replay composition has frozen the complete immutable source and schema registries.
 
-The boundary wraps both canonical PostgreSQL capabilities exported by `rustok-index`:
+The boundary wraps three canonical PostgreSQL capabilities exported by `rustok-index`:
 
 - `PostgresIndexReconciliationRunner` for bounded run and cancellation;
-- `PostgresIndexReconciliationDeadLetterInspector` for bounded read-only failed-job inspection.
+- `PostgresIndexReconciliationDeadLetterInspector` for bounded read-only failed-job inspection;
+- `PostgresIndexReconciliationRecoveryStore` for audited same-job failed-to-pending recovery.
 
 Composition performs no reconciliation database I/O, starts no task, and creates no second source catalog.
 
@@ -28,9 +29,11 @@ The boundary rejects:
 
 Run authorization compares the requested tenant before delegating to the inner reconciliation runner. The focused source regression uses a database without Index migrations and still receives `TenantMismatch`, retaining the pre-database denial boundary.
 
-Cancellation and dead-letter inspection accept only a job UUID from the caller. The tenant delegated to the runner or inspector is always derived from the authorized context; neither operation accepts a separate caller-selected tenant.
+Cancellation, dead-letter inspection, and dead-letter requeue accept no caller-selected tenant. Their tenant scope is derived only from the authorized context.
 
-Inspection authorization runs before adapter validation or database access. Without request authority it returns `MissingRequestAuthority`; `modules:read` alone returns `Forbidden`; an authorized call then delegates to the bounded crate inspector.
+Requeue also accepts no caller-selected actor. The actor written to the immutable recovery audit is always `context.actor_id()`.
+
+Inspection and requeue authorization run before adapter or recovery-request validation and before database access. Missing authority returns `MissingRequestAuthority`; `modules:read` alone returns `Forbidden`; only an authorized call reaches the bounded crate validation surface.
 
 ## Published surface
 
@@ -38,15 +41,12 @@ The capability exposes only:
 
 - bounded `run(context, IndexReconciliationRunRequest)`;
 - tenant-scoped `request_cancel(context, job_id)`;
-- tenant-scoped read-only `inspect_dead_letter(context, job_id)`.
+- tenant-scoped read-only `inspect_dead_letter(context, job_id)`;
+- tenant/actor-bound `requeue_dead_letter(context, job_id, reason)`.
 
-A successful dead-letter inspection returns only:
+A successful dead-letter inspection returns only the bounded crate inspection result.
 
-- failed job UUID;
-- positive durable attempt count;
-- optional bounded `last_error_code`;
-- bounded dependency code;
-- retryability.
+A successful requeue returns only the bounded crate recovery outcome: generated audit UUID, retained job UUID, and incremented retry epoch. The server does not duplicate recovery SQL, cursor reset logic, scope locking, audit insertion, or job-state mutation.
 
 Raw `last_error_details`, tenant identity, request/cursor JSON, worker and lease fields, timestamps, SQL, database causes, and payloads remain unavailable through the server runtime.
 
@@ -57,9 +57,21 @@ The runtime does not expose:
 - mutable source catalogs;
 - scheduler, polling, takeover, or task ownership;
 - worker-spawn handles;
-- direct `index_jobs` SQL;
-- retry, requeue, retry-epoch reset, or failed-row mutation;
+- direct `index_jobs` or recovery-audit SQL;
+- caller-selected tenant or actor identity for recovery;
 - GraphQL, HTTP, CLI, MCP, or admin transport.
+
+## Recovery ordering
+
+`requeue_dead_letter` performs these server-boundary steps in order:
+
+1. authorize the exact context tenant and actor with request-scoped `modules:manage`;
+2. construct `IndexReconciliationRequeueRequest` from `context.tenant_id()`, the caller job UUID, `context.actor_id()`, and the explicit reason;
+3. delegate to `PostgresIndexReconciliationRecoveryStore::requeue_failed`.
+
+The reason remains owned by the crate validation contract: non-empty, trimmed, control-character-free, and no more than 512 UTF-8 bytes.
+
+Authorization therefore wins over malformed job IDs or reasons, and unauthorized callers cannot use validation differences as a recovery oracle.
 
 ## Composition
 
@@ -69,31 +81,27 @@ The existing server replay composition remains the single source-freezing point:
 2. the complete immutable `SharedIndexSourceRegistry` is inserted;
 3. the guarded replay capability is materialized from the shared registries;
 4. the guarded reconciliation operator is constructed from the same source registry, shared schema registry, and host database;
-5. the same operator receives a read-only dead-letter inspector over a clone of the host database handle.
+5. the operator receives a recovery store and read-only inspector over cloned host database handles, plus the canonical runner over the retained handle.
 
 An absent source registry publishes no false reconciliation capability. A source registry without `SharedIndexSchemaRegistry` fails closed. Duplicate guarded reconciliation materialization also fails closed.
 
-The replay retry transition store, replay failed-scope admission, and reconciliation failed-scope admission remain independent engine contracts. They are not reused as server scheduling or recovery APIs.
-
 ## Preserved engine behavior
 
-This server slice changes no reconciliation runner, inspector SQL, migration, state transition, lease, cursor, mutation, diagnostic, cancellation, or terminal-state contract.
+This server slice changes no migration, recovery SQL, reconciliation runner, inspector query, state transition, lease, cursor, mutation, diagnostic, cancellation, or terminal-state contract.
 
-It preserves the existing bounded page/pass execution, heartbeat, yield, cancellation, attempt fencing, inbox deduplication, source-version monotonicity, failed-scope admission, strict dead-letter diagnostic decoding, and bounded machine-readable results.
+The same-job failed-to-pending reset, retry-epoch increment, scope advisory lock, attempt/epoch fencing, and immutable actor/reason audit remain entirely owned by `rustok-index`.
 
 ## Explicitly open
 
-- GraphQL, HTTP, CLI, MCP, or admin inspection transport;
-- authorized requeue with actor/reason audit and retry-epoch semantics;
-- automatic scheduling or takeover discovery;
+- GraphQL, HTTP, CLI, MCP, admin, or other command transport;
+- automatic retry, backoff, exhaustion, scheduling, or takeover discovery;
 - graceful task shutdown and fleet coordination;
 - source/index digest comparison and orphan diagnosis;
 - targeted, full, or shadow repair modes;
 - locale or partition checkpoint dimensions;
-- retained PostgreSQL authorization, inspection, cancellation, restart, concurrency, and recovery evidence;
-- command and recovery publication.
+- retained PostgreSQL authorization, inspection, cancellation, restart, concurrency, and recovery evidence.
 
-The canonical M6 drift-diagnosis and targeted-repair roadmap item remains open. Authorized read-only inspection does not establish recovery, complete drift repair, or production readiness.
+The canonical bounded retry/global scheduling and drift-diagnosis/targeted-repair roadmap items remain open. Authorized manual recovery does not establish automatic scheduling, complete drift repair, or production readiness.
 
 ## Validation ownership
 

--- a/apps/server/src/services/index_reconciliation_operator.rs
+++ b/apps/server/src/services/index_reconciliation_operator.rs
@@ -67,29 +67,35 @@ pub enum IndexReconciliationOperatorError {
     Reconciliation(#[from] rustok_index::IndexReconciliationRunError),
     #[error(transparent)]
     Inspection(#[from] rustok_index::infrastructure::postgres::IndexReconciliationDeadLetterInspectionError),
+    #[error(transparent)]
+    Recovery(#[from] rustok_index::infrastructure::postgres::IndexReconciliationRecoveryError),
 }
 
 /// Server-owned guarded operator boundary over the canonical PostgreSQL Index reconciliation
-/// runner and bounded dead-letter inspector.
+/// runner, bounded dead-letter inspector, and audited recovery store.
 ///
 /// Transport adapters must provide an exact request-bound tenant/actor context. The boundary
 /// accepts only `modules:manage`, rejects cross-tenant run requests before database access, derives
-/// inspection and cancellation tenant scope from the authorized context, and exposes no connection,
-/// source registry, scheduler, task handle, or worker-spawn capability.
+/// cancellation, inspection, and recovery tenant scope from the authorized context, binds recovery
+/// actor identity to that same context, and exposes no connection, source registry, scheduler, task
+/// handle, or worker-spawn capability.
 #[derive(Clone)]
 pub struct IndexReconciliationOperatorRuntime {
     inner: rustok_index::PostgresIndexReconciliationRunner,
     dead_letters: rustok_index::infrastructure::postgres::PostgresIndexReconciliationDeadLetterInspector,
+    recovery: rustok_index::infrastructure::postgres::PostgresIndexReconciliationRecoveryStore,
 }
 
 impl IndexReconciliationOperatorRuntime {
     fn new(
         inner: rustok_index::PostgresIndexReconciliationRunner,
         dead_letters: rustok_index::infrastructure::postgres::PostgresIndexReconciliationDeadLetterInspector,
+        recovery: rustok_index::infrastructure::postgres::PostgresIndexReconciliationRecoveryStore,
     ) -> Self {
         Self {
             inner,
             dead_letters,
+            recovery,
         }
     }
 
@@ -134,6 +140,29 @@ impl IndexReconciliationOperatorRuntime {
             .await
             .map_err(Into::into)
     }
+
+    pub async fn requeue_dead_letter(
+        &self,
+        context: IndexReconciliationOperatorContext,
+        job_id: Uuid,
+        reason: impl Into<String>,
+    ) -> std::result::Result<
+        rustok_index::infrastructure::postgres::IndexReconciliationRequeueOutcome,
+        IndexReconciliationOperatorError,
+    > {
+        context.authorize_for(context.tenant_id())?;
+        let request =
+            rustok_index::infrastructure::postgres::IndexReconciliationRequeueRequest::new(
+                context.tenant_id(),
+                job_id,
+                context.actor_id(),
+                reason,
+            )?;
+        self.recovery
+            .requeue_failed(request)
+            .await
+            .map_err(Into::into)
+    }
 }
 
 impl fmt::Debug for IndexReconciliationOperatorRuntime {
@@ -175,13 +204,20 @@ pub(super) fn materialize_index_reconciliation_operator(
             )
         })?;
 
+    let recovery =
+        rustok_index::infrastructure::postgres::PostgresIndexReconciliationRecoveryStore::new(
+            db.clone(),
+        );
     let dead_letters =
-        rustok_index::infrastructure::postgres::PostgresIndexReconciliationDeadLetterInspector::new(db.clone());
+        rustok_index::infrastructure::postgres::PostgresIndexReconciliationDeadLetterInspector::new(
+            db.clone(),
+        );
     let runner =
         rustok_index::PostgresIndexReconciliationRunner::new(db, sources, schemas.shared());
     extensions.insert(IndexReconciliationOperatorRuntime::new(
         runner,
         dead_letters,
+        recovery,
     ));
     Ok(())
 }
@@ -490,6 +526,84 @@ mod tests {
             delegated,
             IndexReconciliationOperatorError::Inspection(
                 rustok_index::infrastructure::postgres::IndexReconciliationDeadLetterInspectionError::NilJobId
+            )
+        ));
+    }
+
+    #[tokio::test]
+    async fn dead_letter_requeue_authorizes_before_request_validation() {
+        let mut extensions = complete_registries();
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database without Index migrations");
+        materialize_index_reconciliation_operator(&mut extensions, db)
+            .expect("runtime materialization");
+        let runtime = extensions
+            .get::<IndexReconciliationOperatorRuntime>()
+            .cloned()
+            .expect("guarded runtime");
+        let tenant_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let context = IndexReconciliationOperatorContext::new(tenant_id, actor_id).unwrap();
+
+        let missing = runtime
+            .requeue_dead_letter(context, Uuid::nil(), "")
+            .await
+            .expect_err("missing authority must fail before recovery request validation");
+        assert!(matches!(
+            missing,
+            IndexReconciliationOperatorError::MissingRequestAuthority
+        ));
+
+        let forbidden = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_READ],
+                UserRole::Admin,
+            )),
+            runtime.requeue_dead_letter(context, Uuid::nil(), ""),
+        )
+        .await
+        .expect_err("modules:read must not requeue dead letters");
+        assert!(matches!(
+            forbidden,
+            IndexReconciliationOperatorError::Forbidden
+        ));
+
+        let delegated = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_MANAGE],
+                UserRole::Admin,
+            )),
+            runtime.requeue_dead_letter(context, Uuid::nil(), ""),
+        )
+        .await
+        .expect_err("authorized request must reach bounded recovery DTO validation");
+        assert!(matches!(
+            delegated,
+            IndexReconciliationOperatorError::Recovery(
+                rustok_index::infrastructure::postgres::IndexReconciliationRecoveryError::NilJobId
+            )
+        ));
+
+        let reason = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_MANAGE],
+                UserRole::Admin,
+            )),
+            runtime.requeue_dead_letter(context, Uuid::new_v4(), ""),
+        )
+        .await
+        .expect_err("authorized request must bind context identity before reason validation");
+        assert!(matches!(
+            reason,
+            IndexReconciliationOperatorError::Recovery(
+                rustok_index::infrastructure::postgres::IndexReconciliationRecoveryError::InvalidReason(_)
             )
         ));
     }

--- a/crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md
+++ b/crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md
@@ -1,6 +1,6 @@
 # M6 reconciliation dead-letter inspection
 
-Status: `source_complete_transport_and_recovery_pending`.
+Status: `source_complete_transport_pending`.
 
 ## Purpose
 
@@ -36,11 +36,11 @@ The query selects only attempt count, `last_error_code`, and `last_error_details
 - entity, relation, inbox, or mutation payloads;
 - SQL, database causes, transport context, or stack text.
 
-Database failures map to one stable `Storage` error with no embedded database detail. The production implementation performs no insert, update, delete, retry, requeue, reset, scheduling, polling, sleep, or task creation.
+Database failures map to one stable `Storage` error with no embedded database detail. The inspector performs no insert, update, delete, retry, requeue, reset, scheduling, polling, sleep, or task creation.
 
 ## Authorized server composition
 
-The server-owned `IndexReconciliationOperatorRuntime` now composes this inspector beside the canonical reconciliation runner.
+The server-owned `IndexReconciliationOperatorRuntime` composes this inspector beside the canonical reconciliation runner and audited recovery store.
 
 Inspection accepts only:
 
@@ -51,26 +51,27 @@ The delegated tenant is derived exclusively from the context. There is no caller
 
 Before adapter validation or database access, the server boundary reads the exact request-scoped tenant/actor permission snapshot and requires effective `modules:manage`. Missing request authority and insufficient permission fail before delegation. The server returns only the bounded inspection object or typed bounded errors; it does not expose the database adapter or raw diagnostic JSON.
 
-GraphQL, HTTP, CLI, MCP, and admin transports remain open. This slice publishes an internal guarded capability only.
+The same guarded runtime also exposes manual audited requeue. That write operation is owned by `PostgresIndexReconciliationRecoveryStore`, not by the inspector, and requires the same request-bound context plus an explicit bounded reason. Tenant and actor are derived only from the authorized context.
+
+GraphQL, HTTP, CLI, MCP, and admin transports remain open. This slice publishes internal guarded capabilities only.
 
 ## Compatibility
 
-This inspection slice adds no migration and changes no reconciliation state transition, failed-scope admission, retry policy, lease fence, cursor, source, mutation, schema, cancellation, or success behavior.
+Inspection remains read-only and changes no reconciliation query, failed-scope admission, retry policy, lease fence, cursor, source, mutation, schema, cancellation, or success behavior.
 
-It composes additively with the replay retry store, replay dead-letter admission, reconciliation dead-letter admission, guarded reconciliation runtime, and engine-level reconciliation recovery store already present on `main`.
+The authorized recovery composition is additive: it delegates to the separately merged scope-locked same-job reset and immutable actor/reason audit contract without modifying inspector SQL or returned data.
 
 ## Explicitly open
 
-- inspection transport mapping;
-- server-owned authorization and transport for manual requeue or retry-epoch reset;
+- inspection and recovery transport mapping;
 - automatic retry, backoff, exhaustion, scheduling, and graceful shutdown;
 - source/index digest comparison and orphan diagnosis;
 - targeted, full, or shadow repair admission;
 - locale or partition checkpoint dimensions;
-- retained PostgreSQL inspection, authorization, and recovery evidence;
+- retained PostgreSQL inspection, authorization, concurrency, and recovery evidence;
 - complete drift repair.
 
-The canonical M6 drift-diagnosis and targeted-repair roadmap item remains open.
+The canonical bounded retry/global scheduling and drift-diagnosis/targeted-repair roadmap items remain open.
 
 ## Validation ownership
 

--- a/crates/rustok-index/docs/m6-reconciliation-dead-letter-requeue.md
+++ b/crates/rustok-index/docs/m6-reconciliation-dead-letter-requeue.md
@@ -1,12 +1,14 @@
 # M6 reconciliation dead-letter requeue
 
-Status: `source_complete_authorized_server_composition_pending`.
+Status: `source_complete_authorized_server_composition_transport_pending`.
 
 ## Purpose
 
 `PostgresIndexReconciliationRecoveryStore` provides one explicit engine-level recovery operation for an exact terminal failed reconciliation job.
 
 The operation preserves the existing job UUID. It does not create a replacement job. Instead, it moves the same failed row back to `pending`, resets its bounded execution state, increments a durable retry epoch, and appends an immutable actor/reason audit record in the same database transaction.
+
+The server publishes this operation only through the request-bound `IndexReconciliationOperatorRuntime`; no transport is added by this slice.
 
 ## Request contract
 
@@ -55,23 +57,32 @@ The migration installs database-level `BEFORE UPDATE` and `BEFORE DELETE` reject
 
 The audit ledger does not contain raw failure diagnostics, request or cursor JSON, worker or lease fields, SQL, database causes, or transport context.
 
-## Ownership boundary
+## Authorized server composition
 
-This slice publishes only the engine-level PostgreSQL recovery store.
+`IndexReconciliationOperatorRuntime::requeue_dead_letter(context, job_id, reason)` accepts no tenant or actor argument.
 
-The existing server operator does not expose requeue. A later server-owned wrapper must:
+The method performs these steps in order:
 
-1. bind the exact request tenant and actor;
-2. require effective request-scoped `modules:manage`;
-3. pass the actor only from the authorized context;
-4. require an explicit bounded reason;
-5. delegate without accepting a separate caller-selected tenant.
+1. authorizes the exact request-bound context through `permissions_for(context.tenant_id(), context.actor_id())`;
+2. requires effective `Permission::MODULES_MANAGE`;
+3. constructs the crate request with `context.tenant_id()` and `context.actor_id()`;
+4. delegates to `PostgresIndexReconciliationRecoveryStore::requeue_failed`.
 
-GraphQL, HTTP, CLI, MCP, and admin transports remain open.
+Authorization occurs before job/reason validation and before database access. Missing request authority and insufficient permission therefore fail before recovery DTO validation.
+
+The server returns only the bounded crate outcome and typed errors. It does not expose the database connection, recovery store, direct SQL, raw failure diagnostics, request/cursor payload, or audit-row mutation capability.
+
+Composition constructs the recovery store beside the canonical reconciliation runner and read-only dead-letter inspector after the immutable source/schema registries have been frozen. Missing sources publish no false capability, incomplete registry composition fails closed, and duplicate materialization remains rejected.
+
+## Transport boundary
+
+GraphQL, HTTP, CLI, MCP, native admin, and other command transports remain open.
+
+A future transport must obtain the existing request-bound operator context, accept only job UUID plus explicit reason, and preserve the stable typed error mapping. It must not accept an independent tenant or actor identity.
 
 ## Explicitly open
 
-- authorized server composition and transport mapping;
+- command transport mapping;
 - automatic retry, backoff, exhaustion, scheduling, and graceful shutdown;
 - retained PostgreSQL concurrency, authorization, and recovery execution evidence;
 - source/index digest comparison and orphan diagnosis;

--- a/scripts/verify/verify-index-reconciliation-dead-letter-inspection.mjs
+++ b/scripts/verify/verify-index-reconciliation-dead-letter-inspection.mjs
@@ -152,10 +152,8 @@ requireMarkers(postgresPath, [
   'pub use source_reconciliation_dead_letter_inspector::{',
   'IndexReconciliationDeadLetterInspection, IndexReconciliationDeadLetterInspectionError,',
   'PostgresIndexReconciliationDeadLetterInspector,',
-  'mod source_reconciliation_runner;',
-  'mod source_replay_retry;',
+  'PostgresIndexReconciliationRecoveryStore,',
   'PostgresIndexReconciliationRunner,',
-  'PostgresIndexReplayRetryStore,',
 ]);
 
 const admission = requireMarkers(admissionPath, [
@@ -172,19 +170,17 @@ if (admissionSelect.includes('last_error_details')) {
 
 const server = requireMarkers(serverPath, [
   'Permission::MODULES_MANAGE',
-  'pub async fn run(',
-  'pub async fn request_cancel(',
   'pub async fn inspect_dead_letter(',
-  'PostgresIndexReconciliationRunner::new',
-  'PostgresIndexReconciliationDeadLetterInspector::new(db.clone())',
+  'PostgresIndexReconciliationDeadLetterInspector::new(',
   'dead_letters: rustok_index::infrastructure::postgres::PostgresIndexReconciliationDeadLetterInspector,',
   'Option<rustok_index::infrastructure::postgres::IndexReconciliationDeadLetterInspection>',
   '.inspect(context.tenant_id(), job_id)',
   'dead_letter_inspection_authorizes_before_adapter_validation',
+  'pub async fn requeue_dead_letter(',
 ]);
 const serverProduction = server.split('\n#[cfg(test)]')[0];
 const inspectStart = serverProduction.indexOf('    pub async fn inspect_dead_letter(');
-const inspectEnd = serverProduction.indexOf('\n    }\n}', inspectStart);
+const inspectEnd = serverProduction.indexOf('    pub async fn requeue_dead_letter(', inspectStart);
 if (inspectStart < 0 || inspectEnd <= inspectStart) {
   fail(`${serverPath} guarded dead-letter inspection method is malformed`);
 }
@@ -199,7 +195,7 @@ const serverDelegate = serverInspect.indexOf(
   '.inspect(context.tenant_id(), job_id)',
 );
 if (serverAuthorize < 0 || serverDelegate <= serverAuthorize) {
-  fail(`${serverPath} inspection must authorize before tenant-derived adapter delegation`);
+  fail(`${serverPath} inspection must authorize before tenant-derived delegation`);
 }
 for (const forbidden of [
   'last_error_details',
@@ -213,25 +209,25 @@ for (const forbidden of [
   'retry_epoch',
   "state = 'pending'",
 ]) {
-  if (serverProduction.includes(forbidden)) {
-    fail(`${serverPath} guarded composition contains forbidden marker ${forbidden}`);
+  if (serverInspect.includes(forbidden)) {
+    fail(`${serverPath} inspection method contains forbidden marker ${forbidden}`);
   }
 }
 
 requireMarkers(docsPath, [
-  'Status: `source_complete_transport_and_recovery_pending`.',
+  'Status: `source_complete_transport_pending`.',
   'Unlike ordinary dead-letter admission, inspection deliberately reads `last_error_details`',
   'The raw JSON object is never returned.',
   '## Authorized server composition',
   'requires effective `modules:manage`',
   'There is no caller-supplied tenant parameter.',
-  'manual requeue or retry-epoch reset',
-  'canonical M6 drift-diagnosis and targeted-repair roadmap item remains open',
+  'same guarded runtime also exposes manual audited requeue',
+  'canonical bounded retry/global scheduling and drift-diagnosis/targeted-repair roadmap items remain open',
   'maintainer-run',
 ]);
 requireMarkers(serverDocsPath, [
   'tenant-scoped read-only `inspect_dead_letter(context, job_id)`',
-  'Inspection authorization runs before adapter validation or database access',
+  'Inspection and requeue authorization run before adapter or recovery-request validation',
   'Raw `last_error_details`',
   'GraphQL, HTTP, CLI, MCP, or admin transport',
 ]);
@@ -247,7 +243,7 @@ requireMarkers(aggregatePath, [
   "'verify-index-server-reconciliation-guard.mjs'",
   "'verify-index-reconciliation-dead-letter-admission.mjs'",
   "'verify-index-reconciliation-dead-letter-inspection.mjs'",
-  "'verify-index-replay-dead-letter-admission.mjs'",
+  "'verify-index-reconciliation-dead-letter-requeue.mjs'",
 ]);
 
 console.log('[verify-index-reconciliation-dead-letter-inspection] OK');

--- a/scripts/verify/verify-index-reconciliation-dead-letter-requeue.mjs
+++ b/scripts/verify/verify-index-reconciliation-dead-letter-requeue.mjs
@@ -27,6 +27,7 @@ const postgresPath = 'crates/rustok-index/src/infrastructure/postgres/mod.rs';
 const runnerPath =
   'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner.rs';
 const serverPath = 'apps/server/src/services/index_reconciliation_operator.rs';
+const serverDocsPath = 'apps/server/docs/index-reconciliation-operator-runtime.md';
 const docsPath = 'crates/rustok-index/docs/m6-reconciliation-dead-letter-requeue.md';
 const docsIndexPath = 'crates/rustok-index/docs/README.md';
 const planPath = 'crates/rustok-index/docs/implementation-plan.md';
@@ -43,9 +44,6 @@ const migration = requireMarkers(migrationPath, [
   'ALTER TABLE index_jobs',
   'ADD COLUMN retry_epoch INTEGER NOT NULL DEFAULT 0',
   'CREATE TABLE index_reconciliation_recovery_audits',
-  'tenant_id UUID NOT NULL',
-  'audit_id UUID NOT NULL',
-  'job_id UUID NOT NULL',
   'actor_id UUID NOT NULL',
   "CHECK (action = 'requeue')",
   'reason VARCHAR(512) NOT NULL',
@@ -56,15 +54,10 @@ const migration = requireMarkers(migrationPath, [
   'index_reconciliation_recovery_audits_immutable_delete',
   "RAISE EXCEPTION 'Index reconciliation recovery audits are append-only'",
   "SELECT RAISE(ABORT, 'Index reconciliation recovery audits are append-only')",
-  'ALTER TABLE index_jobs DROP COLUMN retry_epoch',
 ]);
-for (const forbidden of [
-  'ON UPDATE CASCADE',
-  'ON DELETE CASCADE',
-  '.if_not_exists()',
-]) {
+for (const forbidden of ['ON UPDATE CASCADE', 'ON DELETE CASCADE', '.if_not_exists()']) {
   if (migration.includes(forbidden)) {
-    fail(`${migrationPath} contains forbidden drift/mutability marker ${forbidden}`);
+    fail(`${migrationPath} contains forbidden mutability/drift marker ${forbidden}`);
   }
 }
 
@@ -192,34 +185,67 @@ requireMarkers(postgresPath, [
 ]);
 
 const server = requireMarkers(serverPath, [
-  'pub async fn run(',
-  'pub async fn request_cancel(',
-  'pub async fn inspect_dead_letter(',
-  'Permission::MODULES_MANAGE',
+  'recovery: rustok_index::infrastructure::postgres::PostgresIndexReconciliationRecoveryStore,',
+  'Recovery(#[from] rustok_index::infrastructure::postgres::IndexReconciliationRecoveryError),',
+  'pub async fn requeue_dead_letter(',
+  'context.authorize_for(context.tenant_id())?;',
+  'IndexReconciliationRequeueRequest::new(',
+  'context.tenant_id(),',
+  'context.actor_id(),',
+  '.requeue_failed(request)',
+  'PostgresIndexReconciliationRecoveryStore::new(',
+  'dead_letter_requeue_authorizes_before_request_validation',
 ]);
-const serverProduction = server.split('\n#[cfg(test)]')[0];
-for (const forbidden of [
-  'PostgresIndexReconciliationRecoveryStore',
-  'IndexReconciliationRequeueRequest',
-  'requeue_dead_letter',
-  'pub async fn requeue',
-]) {
-  if (serverProduction.includes(forbidden)) {
-    fail(`${serverPath} prematurely exposes recovery through ${forbidden}`);
+const requeueStart = server.indexOf('    pub async fn requeue_dead_letter(');
+const requeueEnd = server.indexOf('\n}\n\nimpl fmt::Debug', requeueStart);
+if (requeueStart < 0 || requeueEnd <= requeueStart) {
+  fail(`${serverPath} guarded requeue method is malformed`);
+}
+const requeue = server.slice(requeueStart, requeueEnd);
+for (const forbidden of ['tenant_id: Uuid', 'actor_id: Uuid']) {
+  if (requeue.includes(forbidden)) {
+    fail(`${serverPath} guarded requeue accepts caller-selected ${forbidden}`);
+  }
+}
+const authorization = requeue.indexOf('context.authorize_for(context.tenant_id())?;');
+const request = requeue.indexOf('IndexReconciliationRequeueRequest::new(');
+const tenant = requeue.indexOf('context.tenant_id(),', request);
+const actor = requeue.indexOf('context.actor_id(),', tenant);
+const delegation = requeue.indexOf('.requeue_failed(request)');
+if (
+  authorization < 0
+  || request <= authorization
+  || tenant <= request
+  || actor <= tenant
+  || delegation <= actor
+) {
+  fail(`${serverPath} must authorize, bind context tenant/actor, then delegate`);
+}
+for (const forbidden of ['SELECT ', 'INSERT ', 'UPDATE ', 'DELETE ', "state = 'pending'"]) {
+  if (requeue.includes(forbidden)) {
+    fail(`${serverPath} guarded requeue duplicates engine detail ${forbidden}`);
   }
 }
 
 requireMarkers(docsPath, [
-  'Status: `source_complete_authorized_server_composition_pending`.',
+  'Status: `source_complete_authorized_server_composition_transport_pending`.',
   'same PostgreSQL transaction-scoped advisory lock used by normal reconciliation admission',
   'preserves the existing job UUID',
   'increments `retry_epoch`',
   'appends an immutable actor/reason audit record',
   'The audit insert and job reset commit or roll back together.',
-  'database-level `BEFORE UPDATE` and `BEFORE DELETE` rejection triggers',
-  'The existing server operator does not expose requeue.',
+  '## Authorized server composition',
+  'accepts no tenant or actor argument',
+  'Authorization occurs before job/reason validation',
+  'GraphQL, HTTP, CLI, MCP, native admin',
   'automatic retry, backoff, exhaustion, scheduling, and graceful shutdown',
   'maintainer-run',
+]);
+requireMarkers(serverDocsPath, [
+  'Status: `source_complete_transport_and_scheduling_pending`.',
+  'tenant/actor-bound `requeue_dead_letter(context, job_id, reason)`',
+  'caller-selected tenant or actor identity for recovery',
+  'The same-job failed-to-pending reset',
 ]);
 requireMarkers(docsIndexPath, [
   '[M6 Reconciliation Dead-letter Inspection](./m6-reconciliation-dead-letter-inspection.md)',

--- a/scripts/verify/verify-index-server-reconciliation-guard.mjs
+++ b/scripts/verify/verify-index-server-reconciliation-guard.mjs
@@ -26,6 +26,8 @@ const docsPath =
   'apps/server/docs/index-reconciliation-operator-runtime.md';
 const inspectionDocsPath =
   'crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md';
+const recoveryDocsPath =
+  'crates/rustok-index/docs/m6-reconciliation-dead-letter-requeue.md';
 
 const composition = requireMarkers(compositionPath, [
   '#[path = "index_reconciliation_operator.rs"]',
@@ -51,31 +53,26 @@ if (
 const operator = requireMarkers(operatorPath, [
   'pub struct IndexReconciliationOperatorContext',
   'tenant_id.is_nil() || actor_id.is_nil()',
-  'IndexReconciliationOperatorError::TenantMismatch',
   'permissions_for(&self.tenant_id, &self.actor_id)',
   'Permission::MODULES_MANAGE',
   'pub struct IndexReconciliationOperatorRuntime',
   'inner: rustok_index::PostgresIndexReconciliationRunner,',
   'dead_letters: rustok_index::infrastructure::postgres::PostgresIndexReconciliationDeadLetterInspector,',
+  'recovery: rustok_index::infrastructure::postgres::PostgresIndexReconciliationRecoveryStore,',
   'Inspection(#[from] rustok_index::infrastructure::postgres::IndexReconciliationDeadLetterInspectionError),',
+  'Recovery(#[from] rustok_index::infrastructure::postgres::IndexReconciliationRecoveryError),',
   'context.authorize_for(request.tenant_id())?;',
-  'self.inner.run(request).await.map_err(Into::into)',
-  'context.authorize_for(context.tenant_id())?;',
-  '.request_cancel(context.tenant_id(), job_id)',
+  'pub async fn request_cancel(',
   'pub async fn inspect_dead_letter(',
-  '.inspect(context.tenant_id(), job_id)',
-  'extensions.get::<rustok_index::SharedIndexSourceRegistry>()',
-  'extensions.get::<rustok_index::SharedIndexSchemaRegistry>()',
-  'PostgresIndexReconciliationDeadLetterInspector::new(db.clone())',
+  'pub async fn requeue_dead_letter(',
+  'IndexReconciliationRequeueRequest::new(',
+  'context.tenant_id(),',
+  'context.actor_id(),',
+  '.requeue_failed(request)',
+  'PostgresIndexReconciliationRecoveryStore::new(',
+  'PostgresIndexReconciliationDeadLetterInspector::new(',
   'PostgresIndexReconciliationRunner::new(db, sources, schemas.shared())',
-  'missing_sources_do_not_publish_false_reconciliation_capability',
-  'source_registry_without_shared_schema_registry_fails_closed',
-  'complete_registries_publish_guarded_runtime_to_host_context',
-  'duplicate_guarded_reconciliation_materialization_fails_closed',
-  'operator_authorization_requires_exact_tenant_actor_and_modules_manage',
-  'cross_tenant_run_is_denied_before_database_access',
-  'dead_letter_inspection_authorizes_before_adapter_validation',
-  'operator_context_rejects_nil_identity',
+  'dead_letter_requeue_authorizes_before_request_validation',
 ]);
 
 const authorizeStart = operator.indexOf('    fn authorize_for(');
@@ -94,31 +91,34 @@ if (
   || permissionLookup <= tenantCheck
   || manageCheck <= permissionLookup
 ) {
-  fail(`${operatorPath} must reject tenant mismatch before request-bound permission evaluation`);
+  fail(`${operatorPath} must reject tenant mismatch before permission evaluation`);
 }
 
 const runStart = operator.indexOf('    pub async fn run(');
 const cancelStart = operator.indexOf('    pub async fn request_cancel(', runStart);
 const inspectStart = operator.indexOf('    pub async fn inspect_dead_letter(', cancelStart);
-const runtimeEnd = operator.indexOf('\n}\n\nimpl fmt::Debug', inspectStart);
+const requeueStart = operator.indexOf('    pub async fn requeue_dead_letter(', inspectStart);
+const runtimeEnd = operator.indexOf('\n}\n\nimpl fmt::Debug', requeueStart);
 if (
   runStart < 0
   || cancelStart <= runStart
   || inspectStart <= cancelStart
-  || runtimeEnd <= inspectStart
+  || requeueStart <= inspectStart
+  || runtimeEnd <= requeueStart
 ) {
-  fail(`${operatorPath} guarded run/cancel/inspection surface is malformed`);
+  fail(`${operatorPath} guarded surface is malformed`);
 }
 const run = operator.slice(runStart, cancelStart);
 const cancel = operator.slice(cancelStart, inspectStart);
-const inspect = operator.slice(inspectStart, runtimeEnd);
+const inspect = operator.slice(inspectStart, requeueStart);
+const requeue = operator.slice(requeueStart, runtimeEnd);
 
 if (
   run.indexOf('context.authorize_for(request.tenant_id())?;') < 0
   || run.indexOf('self.inner.run(request)')
     <= run.indexOf('context.authorize_for(request.tenant_id())?;')
 ) {
-  fail(`${operatorPath} run must authorize the request tenant before runner delegation`);
+  fail(`${operatorPath} run must authorize before runner delegation`);
 }
 
 for (const [name, body, delegation] of [
@@ -126,23 +126,49 @@ for (const [name, body, delegation] of [
   ['inspection', inspect, '.inspect(context.tenant_id(), job_id)'],
 ]) {
   if (body.includes('tenant_id: Uuid')) {
-    fail(`${operatorPath} ${name} must not accept a separate caller-supplied tenant`);
+    fail(`${operatorPath} ${name} must not accept a separate tenant`);
   }
   const auth = body.indexOf('context.authorize_for(context.tenant_id())?;');
   const delegate = body.indexOf(delegation);
   if (auth < 0 || delegate <= auth) {
-    fail(`${operatorPath} ${name} must authorize and derive tenant scope from context`);
+    fail(`${operatorPath} ${name} must authorize and derive tenant from context`);
   }
 }
 
+for (const forbidden of ['tenant_id: Uuid', 'actor_id: Uuid']) {
+  if (requeue.includes(forbidden)) {
+    fail(`${operatorPath} recovery must not accept caller-selected ${forbidden}`);
+  }
+}
+const recoveryAuth = requeue.indexOf(
+  'context.authorize_for(context.tenant_id())?;',
+);
+const requestConstruction = requeue.indexOf(
+  'IndexReconciliationRequeueRequest::new(',
+);
+const tenantBinding = requeue.indexOf('context.tenant_id(),', requestConstruction);
+const actorBinding = requeue.indexOf('context.actor_id(),', tenantBinding);
+const recoveryDelegation = requeue.indexOf('.requeue_failed(request)');
+if (
+  recoveryAuth < 0
+  || requestConstruction <= recoveryAuth
+  || tenantBinding <= requestConstruction
+  || actorBinding <= tenantBinding
+  || recoveryDelegation <= actorBinding
+) {
+  fail(`${operatorPath} recovery must authorize, bind context tenant/actor, then delegate`);
+}
 for (const forbidden of [
-  'last_error_details',
-  'dependency_code: String',
   'DatabaseConnection',
-  'PostgresIndexReconciliationDeadLetterInspector::new',
+  'SELECT ',
+  'INSERT ',
+  'UPDATE ',
+  'DELETE ',
+  'last_error_details',
+  "state = 'pending'",
 ]) {
-  if (inspect.includes(forbidden)) {
-    fail(`${operatorPath} inspection method exposes forbidden adapter detail ${forbidden}`);
+  if (requeue.includes(forbidden)) {
+    fail(`${operatorPath} recovery method contains forbidden engine detail ${forbidden}`);
   }
 }
 
@@ -151,8 +177,11 @@ const materializeStart = operator.indexOf(
 );
 const testsStart = operator.indexOf('\n#[cfg(test)]', materializeStart);
 const materialize = operator.slice(materializeStart, testsStart);
+const recoveryConstruction = materialize.indexOf(
+  'PostgresIndexReconciliationRecoveryStore::new(',
+);
 const inspectorConstruction = materialize.indexOf(
-  'PostgresIndexReconciliationDeadLetterInspector::new(db.clone())',
+  'PostgresIndexReconciliationDeadLetterInspector::new(',
 );
 const runnerConstruction = materialize.indexOf(
   'PostgresIndexReconciliationRunner::new(db, sources, schemas.shared())',
@@ -161,11 +190,12 @@ const runtimeInsertion = materialize.indexOf(
   'extensions.insert(IndexReconciliationOperatorRuntime::new(',
 );
 if (
-  inspectorConstruction < 0
+  recoveryConstruction < 0
+  || inspectorConstruction <= recoveryConstruction
   || runnerConstruction <= inspectorConstruction
   || runtimeInsertion <= runnerConstruction
 ) {
-  fail(`${operatorPath} must compose inspector and runner into one guarded runtime`);
+  fail(`${operatorPath} must compose recovery, inspector, and runner into one runtime`);
 }
 
 const productionOperator = operator.split('\n#[cfg(test)]')[0];
@@ -179,34 +209,39 @@ for (const forbidden of [
   'Router::new',
   'route(',
   'async_graphql',
-  'requeue',
-  'retry_epoch',
   "state = 'pending'",
 ]) {
   if (productionOperator.includes(forbidden)) {
-    fail(`${operatorPath} production boundary contains forbidden transport/SQL/recovery marker ${forbidden}`);
+    fail(`${operatorPath} production boundary contains forbidden marker ${forbidden}`);
   }
 }
 
 requireMarkers(docsPath, [
-  'Status: `source_complete_transport_and_recovery_work_pending`.',
+  'Status: `source_complete_transport_and_scheduling_pending`.',
   'requires effective `Permission::MODULES_MANAGE`',
-  'retaining the pre-database denial boundary',
-  'neither operation accepts a separate caller-selected tenant',
-  'Inspection authorization runs before adapter validation or database access',
-  'tenant-scoped read-only `inspect_dead_letter(context, job_id)`',
-  'The existing server replay composition remains the single source-freezing point',
-  'read-only dead-letter inspector over a clone of the host database handle',
-  'authorized requeue with actor/reason audit',
-  'canonical M6 drift-diagnosis and targeted-repair roadmap item remains open',
+  'accept no caller-selected tenant',
+  'accepts no caller-selected actor',
+  'authorization run before adapter or recovery-request validation',
+  'tenant/actor-bound `requeue_dead_letter(context, job_id, reason)`',
+  'construct `IndexReconciliationRequeueRequest` from `context.tenant_id()`',
+  'The same-job failed-to-pending reset',
+  'canonical bounded retry/global scheduling and drift-diagnosis/targeted-repair roadmap items remain open',
   'maintainer-run',
 ]);
 requireMarkers(inspectionDocsPath, [
-  'Status: `source_complete_transport_and_recovery_pending`.',
-  '## Authorized server composition',
+  'Status: `source_complete_transport_pending`.',
+  'beside the canonical reconciliation runner and audited recovery store',
   'There is no caller-supplied tenant parameter.',
-  'requires effective `modules:manage`',
+  'same guarded runtime also exposes manual audited requeue',
   'GraphQL, HTTP, CLI, MCP, and admin transports remain open',
+]);
+requireMarkers(recoveryDocsPath, [
+  'Status: `source_complete_authorized_server_composition_transport_pending`.',
+  '## Authorized server composition',
+  'accepts no tenant or actor argument',
+  'requires effective `Permission::MODULES_MANAGE`',
+  'Authorization occurs before job/reason validation',
+  'GraphQL, HTTP, CLI, MCP, native admin',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
   '- [ ] Add drift diagnosis, targeted repair commands, and admitted repair evidence.',
@@ -215,8 +250,7 @@ requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-server-reconciliation-guard.mjs'",
   "'verify-index-reconciliation-dead-letter-inspection.mjs'",
-  "'verify-index-replay-retry-store.mjs'",
-  "'verify-index-replay-dead-letter-admission.mjs'",
+  "'verify-index-reconciliation-dead-letter-requeue.mjs'",
 ]);
 
 console.log('[verify-index-server-reconciliation-guard] OK');


### PR DESCRIPTION
## Summary

- extend the existing guarded `IndexReconciliationOperatorRuntime` with audited dead-letter requeue;
- compose `PostgresIndexReconciliationRecoveryStore` beside the canonical runner and bounded inspector;
- accept only the existing request-bound operator context, job UUID, and explicit reason;
- derive both tenant and actor exclusively from `IndexReconciliationOperatorContext`;
- require effective request-scoped `modules:manage` before recovery DTO validation or database access;
- delegate the same-job failed-to-pending reset, retry-epoch increment, scope lock, and immutable audit entirely to `rustok-index`;
- preserve all existing run, cancellation, inspection, composition, and fail-closed behavior;
- actualize server/recovery/inspection documentation and all three focused reconciliation verifiers;
- add no transport, scheduler, polling, automatic retry, or direct server SQL.

## Fresh-main audit

The branch is built directly on `main@14c19bc7fd62a154092a73d27962969b2f9ec10f`, contains one clean commit, and is one commit ahead and zero behind `main`.

The intervening Cart diagnostics commit touched no Index or reconciliation server paths. No stale PR exists for this exact authorized recovery composition; it follows engine recovery #2917, guarded run/cancel #2900, bounded inspector #2907, and authorized inspection #2912.

## Guarded method

`requeue_dead_letter(context, job_id, reason)` accepts no tenant or actor parameter.

The method performs these steps in order:

1. calls the existing `context.authorize_for(context.tenant_id())` boundary;
2. resolves the exact request-scoped tenant/actor permission snapshot;
3. requires effective `Permission::MODULES_MANAGE`;
4. constructs `IndexReconciliationRequeueRequest` with `context.tenant_id()` and `context.actor_id()`;
5. delegates to `PostgresIndexReconciliationRecoveryStore::requeue_failed`.

Authorization occurs before nil-job or invalid-reason validation. Missing request authority and `modules:read` therefore fail before the crate DTO or database adapter is reached.

## Identity binding

The caller supplies only:

- failed job UUID;
- explicit reason.

Tenant identity and the actor persisted in the immutable recovery audit are always derived from the validated context. A transport cannot authorize one tenant/actor pair and then select another pair for the recovery write.

The reason remains validated by the merged crate contract: non-empty, trimmed, control-character-free, and no more than 512 UTF-8 bytes.

## Composition

The existing replay composition remains the single source-freezing point. After immutable source/schema registry materialization, the guarded reconciliation materializer now constructs:

- `PostgresIndexReconciliationRecoveryStore` over a cloned host database handle;
- `PostgresIndexReconciliationDeadLetterInspector` over a cloned host database handle;
- `PostgresIndexReconciliationRunner` over the retained handle and frozen registries;
- one `IndexReconciliationOperatorRuntime` containing all three capabilities.

Missing sources still publish no false capability. Sources without the shared schema registry and duplicate materialization still fail closed. Composition performs no database I/O and starts no task.

## Engine ownership preserved

The server method contains no SQL and does not duplicate:

- reconciliation scope advisory locking;
- failed-state, attempt-count, or retry-epoch fencing;
- cursor reset or lease/error/completion clearing;
- failed-to-pending mutation;
- immutable actor/reason audit insertion;
- transaction commit/rollback behavior.

Those contracts remain owned by the recovery store merged in #2917. The guarded result exposes only the bounded crate outcome and typed errors.

## Source regressions

The focused source test uses a database without Index migrations and retains ordering:

- no request authority returns `MissingRequestAuthority` before recovery request validation;
- `modules:read` returns `Forbidden` before recovery request validation;
- authorized nil job reaches the crate DTO and returns typed `NilJobId`;
- authorized valid job plus empty reason returns typed `InvalidReason` before database access.

## Verification actualization

- the server guard now checks authorization, tenant/actor context binding, DTO construction, delegation, and three-capability composition;
- the recovery guard now requires the authorized server wrapper instead of forbidding it;
- the inspection guard continues to prove the inspector method itself is read-only while allowing the separate guarded requeue method;
- documentation statuses now distinguish source-complete internal authorization from still-open transport and scheduling work;
- canonical retry/global scheduling and drift-repair roadmap items remain open.

## Scope boundaries

This PR does not add or claim:

- GraphQL, HTTP, CLI, MCP, native admin, or other command transport;
- automatic retry, backoff, exhaustion, polling, scheduling, or graceful shutdown;
- direct server SQL or database-handle exposure;
- a caller-selected recovery tenant or actor;
- a replacement job identity;
- changes to the recovery migration, transaction, lock key, reset SQL, audit schema, runner, inspector query, source scanning, mutation application, leases, cancellation, or success handling;
- source/index digest comparison, orphan diagnosis, or targeted/full/shadow repair modes;
- retained PostgreSQL authorization, concurrency, or recovery execution evidence.

## Validation

Not run per maintainer instruction:

- formatting;
- Cargo checks, tests, or Clippy;
- JavaScript verifiers;
- migration apply or database scenarios;
- workflows and CI.

Suggested maintainer commands:

```bash
cargo test -p rustok-server index_reconciliation_operator -- --nocapture
cargo check -p rustok-server --all-targets
node scripts/verify/verify-index-server-reconciliation-guard.mjs
node scripts/verify/verify-index-reconciliation-dead-letter-requeue.mjs
node scripts/verify/verify-index-reconciliation-dead-letter-inspection.mjs
node scripts/verify/verify-index-query-contract.mjs
```
