### PR TITLE
feat(index): schedule due reconciliation work

### DIFF
--- a/apps/server/docs/index-reconciliation-operator-runtime.md
+++ b/apps/server/docs/index-reconciliation-operator-runtime.md
@@ -1,107 +1,61 @@
 # Index reconciliation operator runtime
 
-Status: `source_complete_transport_and_scheduling_pending`.
+Status: `source_complete_transport_and_owner_execution_pending`.
 
 ## Purpose
 
-The server publishes one guarded `IndexReconciliationOperatorRuntime` after the existing Index replay composition has frozen the complete immutable source and schema registries.
+The server publishes one guarded `IndexReconciliationOperatorRuntime` after the replay composition freezes the immutable source and schema registries.
 
-The boundary wraps three canonical PostgreSQL capabilities exported by `rustok-index`:
+The boundary wraps:
 
 - `PostgresIndexReconciliationRunner` for bounded run and cancellation;
-- `PostgresIndexReconciliationDeadLetterInspector` for bounded read-only failed-job inspection;
-- `PostgresIndexReconciliationRecoveryStore` for audited same-job failed-to-pending recovery.
+- `PostgresIndexReconciliationDeadLetterInspector` for bounded read-only inspection;
+- `PostgresIndexReconciliationRecoveryStore` for audited same-job recovery.
 
-Composition performs no reconciliation database I/O, starts no task, and creates no second source catalog.
+The same registry-freezing composition now also publishes the separate module-owned reconciliation work registration. The operator runtime does not expose or own that scheduler.
 
 ## Request-bound authority
 
-Every operation requires an `IndexReconciliationOperatorContext` containing one non-nil tenant UUID and actor UUID.
+Every operation requires a non-nil tenant/actor `IndexReconciliationOperatorContext`, a current request-scoped RBAC snapshot, and effective `Permission::MODULES_MANAGE`.
 
-Authorization reads the current request-scoped RBAC snapshot through `permissions_for(tenant_id, actor_id)` and requires effective `Permission::MODULES_MANAGE`.
+Run rejects a tenant mismatch before runner delegation. Cancellation, inspection, and requeue accept no caller-selected tenant. Requeue accepts no caller-selected actor; the audit actor is always `context.actor_id()`.
 
-The boundary rejects:
-
-- a nil tenant or actor identity;
-- a missing request-bound permission snapshot;
-- a snapshot without `modules:manage`;
-- a run request whose tenant differs from the authorized context tenant.
-
-Run authorization compares the requested tenant before delegating to the inner reconciliation runner. The focused source regression uses a database without Index migrations and still receives `TenantMismatch`, retaining the pre-database denial boundary.
-
-Cancellation, dead-letter inspection, and dead-letter requeue accept no caller-selected tenant. Their tenant scope is derived only from the authorized context.
-
-Requeue also accepts no caller-selected actor. The actor written to the immutable recovery audit is always `context.actor_id()`.
-
-Inspection and requeue authorization run before adapter or recovery-request validation and before database access. Missing authority returns `MissingRequestAuthority`; `modules:read` alone returns `Forbidden`; only an authorized call reaches the bounded crate validation surface.
+Inspection and requeue authorization occur before adapter or recovery-request validation and before database access.
 
 ## Published surface
 
-The capability exposes only:
+The operator exposes only:
 
-- bounded `run(context, IndexReconciliationRunRequest)`;
-- tenant-scoped `request_cancel(context, job_id)`;
-- tenant-scoped read-only `inspect_dead_letter(context, job_id)`;
-- tenant/actor-bound `requeue_dead_letter(context, job_id, reason)`.
+- `run(context, request)`;
+- `request_cancel(context, job_id)`;
+- `inspect_dead_letter(context, job_id)`;
+- `requeue_dead_letter(context, job_id, reason)`.
 
-A successful dead-letter inspection returns only the bounded crate inspection result.
+It exposes no database connection, registry, scheduler handle, worker-spawn handle, raw failure details, direct SQL, or transport.
 
-A successful requeue returns only the bounded crate recovery outcome: generated audit UUID, retained job UUID, and incremented retry epoch. The server does not duplicate recovery SQL, cursor reset logic, scope locking, audit insertion, or job-state mutation.
+## Composition and scheduling
 
-Raw `last_error_details`, tenant identity, request/cursor JSON, worker and lease fields, timestamps, SQL, database causes, and payloads remain unavailable through the server runtime.
+The server replay composition remains the single source-freezing point:
 
-The runtime does not expose:
+1. PostgreSQL source factories are materialized;
+2. `SharedIndexSourceRegistry` is frozen;
+3. replay dry-run/runtime and the due-reconciliation module-work registration are published;
+4. this guarded reconciliation operator is built from the same source/schema registries and database.
 
-- the database connection;
-- source or schema registries;
-- mutable source catalogs;
-- scheduler, polling, takeover, or task ownership;
-- worker-spawn handles;
-- direct `index_jobs` or recovery-audit SQL;
-- caller-selected tenant or actor identity for recovery;
-- GraphQL, HTTP, CLI, MCP, or admin transport.
+Composition performs no reconciliation SQL and starts no task. The existing generic server module-work bootstrap later owns the one-second polling loop and shared `StopHandle` shutdown. The Index adapter discovers work; the canonical runner owns claim, takeover, attempt fencing, cancellation, retry, exhaustion, and terminal state.
 
-## Recovery ordering
-
-`requeue_dead_letter` performs these server-boundary steps in order:
-
-1. authorize the exact context tenant and actor with request-scoped `modules:manage`;
-2. construct `IndexReconciliationRequeueRequest` from `context.tenant_id()`, the caller job UUID, `context.actor_id()`, and the explicit reason;
-3. delegate to `PostgresIndexReconciliationRecoveryStore::requeue_failed`.
-
-The reason remains owned by the crate validation contract: non-empty, trimmed, control-character-free, and no more than 512 UTF-8 bytes.
-
-Authorization therefore wins over malformed job IDs or reasons, and unauthorized callers cannot use validation differences as a recovery oracle.
-
-## Composition
-
-The existing server replay composition remains the single source-freezing point:
-
-1. selected PostgreSQL source factories are materialized;
-2. the complete immutable `SharedIndexSourceRegistry` is inserted;
-3. the guarded replay capability is materialized from the shared registries;
-4. the guarded reconciliation operator is constructed from the same source registry, shared schema registry, and host database;
-5. the operator receives a recovery store and read-only inspector over cloned host database handles, plus the canonical runner over the retained handle.
-
-An absent source registry publishes no false reconciliation capability. A source registry without `SharedIndexSchemaRegistry` fails closed. Duplicate guarded reconciliation materialization also fails closed.
-
-## Preserved engine behavior
-
-This server slice changes no migration, recovery SQL, reconciliation runner, inspector query, state transition, lease, cursor, mutation, diagnostic, cancellation, or terminal-state contract.
-
-The same-job failed-to-pending reset, retry-epoch increment, scope advisory lock, attempt/epoch fencing, and immutable actor/reason audit remain entirely owned by `rustok-index`.
+The operator remains intentionally independent from automatic scheduling: manual authorized calls and host-scheduled calls converge only at the same canonical runner.
 
 ## Explicitly open
 
-- GraphQL, HTTP, CLI, MCP, admin, or other command transport;
-- automatic retry, backoff, exhaustion, scheduling, or takeover discovery;
-- graceful task shutdown and fleet coordination;
-- source/index digest comparison and orphan diagnosis;
-- targeted, full, or shadow repair modes;
-- locale or partition checkpoint dimensions;
-- retained PostgreSQL authorization, inspection, cancellation, restart, concurrency, and recovery evidence.
+- GraphQL, HTTP, CLI, MCP, native admin, or other command transport;
+- retained PostgreSQL authorization and scheduler execution evidence;
+- operator-visible scheduler health and metrics;
+- per-source retry policy, jitter, and dynamic configuration;
+- source/index digest comparison, orphan diagnosis, and targeted/full/shadow repair;
+- locale or partition checkpoint dimensions.
 
-The canonical bounded retry/global scheduling and drift-diagnosis/targeted-repair roadmap items remain open. Authorized manual recovery does not establish automatic scheduling, complete drift repair, or production readiness.
+The canonical bounded retry/global scheduling item remains open pending owner-retained production and multi-host evidence. The drift-diagnosis/targeted-repair item also remains open.
 
 ## Validation ownership
 

--- a/crates/rustok-index/Cargo.toml
+++ b/crates/rustok-index/Cargo.toml
@@ -6,7 +6,9 @@ description = "Cross-module relational index and query engine for RusToK"
 license.workspace = true
 
 [dependencies]
+rustok-api.workspace = true
 rustok-core.workspace = true
+rustok-runtime.workspace = true
 
 # Module metadata and M3 persistence
 async-trait.workspace = true

--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -38,6 +38,7 @@ This directory contains the detailed technical architecture documentation for `r
 - [M6 Replay Runtime Host Composition](./m6-replay-runtime-composition.md)
 - [M6 Reconciliation Retry Transition Store](./m6-reconciliation-retry-transition-store.md)
 - [M6 Reconciliation Runner Retry Wiring](./m6-reconciliation-runner-retry-wiring.md)
+- [M6 Reconciliation Host Scheduler](./m6-reconciliation-host-scheduler.md)
 - [M6 Reconciliation Dead-letter Admission](./m6-reconciliation-dead-letter-admission.md)
 - [M6 Reconciliation Dead-letter Inspection](./m6-reconciliation-dead-letter-inspection.md)
 - [M6 Reconciliation Dead-letter Requeue](./m6-reconciliation-dead-letter-requeue.md)

--- a/crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md
+++ b/crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md
@@ -4,74 +4,45 @@ Status: `source_complete_transport_pending`.
 
 ## Purpose
 
-`PostgresIndexReconciliationDeadLetterInspector` provides a bounded, read-only view of one terminal failed reconciliation job after ordinary admission has blocked its exact tenant/schema scope.
+`PostgresIndexReconciliationDeadLetterInspector` provides a bounded, read-only view of one terminal failed reconciliation job after ordinary admission blocks its exact tenant/schema scope.
 
-The adapter requires an exact non-nil tenant UUID and job UUID. Its query is restricted to the exact tenant/job with `kind = 'reconcile'` and `state = 'failed'`. Cross-tenant, active, pending, successful, cancelled, non-reconciliation, and unknown jobs therefore return no inspection.
-
-The adapter is published through `rustok_index::infrastructure::postgres`. It is a storage capability, not a public endpoint or an authorization boundary.
+The query is restricted to exact tenant/job, `kind = 'reconcile'`, and `state = 'failed'`. Cross-tenant, active, pending, successful, cancelled, non-reconciliation, and unknown jobs return no inspection.
 
 ## Returned contract
 
-A successful inspection contains only:
+A successful inspection contains only failed job UUID, positive attempt count, optional bounded `last_error_code`, bounded dependency code from `index_reconciliation_run_failure_v1`, and retryability.
 
-- failed job UUID;
-- positive durable attempt count;
-- optional bounded `last_error_code`;
-- bounded `dependency_code` from `index_reconciliation_run_failure_v1`;
-- retryability boolean.
+Diagnostics use `deny_unknown_fields`; malformed contracts, codes, JSON, zero attempts, and overflow fail closed. Raw diagnostic JSON is never returned.
 
-Both machine codes are limited to 128 ASCII bytes and lowercase letters, digits, `.`, `_`, or `-`.
+The query selects only attempt count, machine code, and diagnostic object. It does not expose tenant identity, request/cursor JSON, source/worker/lease/timestamps, payloads, SQL, database causes, transport, or stack text.
 
-Stored diagnostics use `#[serde(deny_unknown_fields)]` and must match the exact three-field reconciliation failure contract. Unknown fields, malformed JSON, unsupported contract versions, invalid machine codes, zero attempts, and overflowing attempts fail closed through `InvalidStoredJob`.
-
-## Privacy and read-only boundary
-
-Unlike ordinary dead-letter admission, inspection deliberately reads `last_error_details` so it can decode the bounded dependency code and retryability flag. The raw JSON object is never returned.
-
-The query selects only attempt count, `last_error_code`, and `last_error_details`. It does not select or return:
-
-- tenant identity;
-- schema request or cursor JSON;
-- source name, worker identity, lease ownership, or timestamps;
-- entity, relation, inbox, or mutation payloads;
-- SQL, database causes, transport context, or stack text.
-
-Database failures map to one stable `Storage` error with no embedded database detail. The inspector performs no insert, update, delete, retry, requeue, reset, scheduling, polling, sleep, or task creation.
+The inspector performs no insert, update, delete, retry, requeue, reset, scheduling, polling, sleep, or task creation.
 
 ## Authorized server composition
 
-The server-owned `IndexReconciliationOperatorRuntime` composes this inspector beside the canonical reconciliation runner and audited recovery store.
+`IndexReconciliationOperatorRuntime` composes the inspector beside the canonical runner and audited recovery store. Inspection accepts one validated context and job UUID; there is no caller-supplied tenant parameter.
 
-Inspection accepts only:
+Before adapter validation or database access, the server requires the exact request-scoped tenant/actor snapshot and effective `modules:manage`. The server returns only the bounded inspection object or typed bounded errors.
 
-- one validated `IndexReconciliationOperatorContext`;
-- one job UUID.
+GraphQL, HTTP, CLI, MCP, and admin transports remain open.
 
-The delegated tenant is derived exclusively from the context. There is no caller-supplied tenant parameter.
+## Scheduler compatibility
 
-Before adapter validation or database access, the server boundary reads the exact request-scoped tenant/actor permission snapshot and requires effective `modules:manage`. Missing request authority and insufficient permission fail before delegation. The server returns only the bounded inspection object or typed bounded errors; it does not expose the database adapter or raw diagnostic JSON.
+The module-owned host scheduler changes no inspector SQL or returned data. Retryable jobs remain pending and are not inspectable. Permanent or exhausted jobs become failed through the canonical retry store and retain the strict inspection-compatible diagnostic.
 
-The same guarded runtime also exposes manual audited requeue. That write operation is owned by `PostgresIndexReconciliationRecoveryStore`, not by the inspector, and requires the same request-bound context plus an explicit bounded reason. Tenant and actor are derived only from the authorized context.
-
-GraphQL, HTTP, CLI, MCP, and admin transports remain open. This slice publishes internal guarded capabilities only.
-
-## Compatibility
-
-Inspection remains read-only and changes no reconciliation query, failed-scope admission, retry policy, lease fence, cursor, source, mutation, schema, cancellation, or success behavior.
-
-The authorized recovery composition is additive: it delegates to the separately merged scope-locked same-job reset and immutable actor/reason audit contract without modifying inspector SQL or returned data.
+Manual audited requeue remains separately owned by `PostgresIndexReconciliationRecoveryStore`.
 
 ## Explicitly open
 
 - inspection and recovery transport mapping;
-- automatic retry, backoff, exhaustion, scheduling, and graceful shutdown;
+- retained PostgreSQL inspection, authorization, scheduler contention, and recovery evidence;
+- operator-visible scheduler health and metrics;
 - source/index digest comparison and orphan diagnosis;
 - targeted, full, or shadow repair admission;
 - locale or partition checkpoint dimensions;
-- retained PostgreSQL inspection, authorization, concurrency, and recovery evidence;
 - complete drift repair.
 
-The canonical bounded retry/global scheduling and drift-diagnosis/targeted-repair roadmap items remain open.
+The canonical bounded retry/global scheduling item remains open pending owner-retained production and multi-host evidence. The drift-diagnosis/targeted-repair item remains open.
 
 ## Validation ownership
 

--- a/crates/rustok-index/docs/m6-reconciliation-dead-letter-requeue.md
+++ b/crates/rustok-index/docs/m6-reconciliation-dead-letter-requeue.md
@@ -6,91 +6,61 @@ Status: `source_complete_authorized_server_composition_transport_pending`.
 
 `PostgresIndexReconciliationRecoveryStore` provides one explicit engine-level recovery operation for an exact terminal failed reconciliation job.
 
-The operation preserves the existing job UUID. It does not create a replacement job. Instead, it moves the same failed row back to `pending`, resets its bounded execution state, increments a durable retry epoch, and appends an immutable actor/reason audit record in the same database transaction.
+The operation preserves the existing job UUID. It moves the same failed row back to `pending`, resets bounded execution state, increments a durable retry epoch, and appends an immutable actor/reason audit record in the same database transaction.
 
-The server publishes this operation only through the request-bound `IndexReconciliationOperatorRuntime`; no transport is added by this slice.
+The server publishes this operation only through the request-bound `IndexReconciliationOperatorRuntime`; no transport is added.
 
-## Request contract
+## Request and scope contract
 
-`IndexReconciliationRequeueRequest` requires:
+`IndexReconciliationRequeueRequest` requires non-nil tenant, failed-job, and actor UUIDs plus one explicit trimmed, control-character-free reason of at most 512 UTF-8 bytes.
 
-- one non-nil tenant UUID;
-- one non-nil failed job UUID;
-- one non-nil actor UUID;
-- one explicit reason bounded to 512 UTF-8 bytes.
-
-The reason must be non-empty, trimmed, and free of control characters. The crate adapter does not infer an actor or reason.
-
-## Scope locking
-
-The recovery store first resolves the exact `kind = 'reconcile'` job and validates that it has schema scope.
-
-Before changing state it acquires the same PostgreSQL transaction-scoped advisory lock used by normal reconciliation admission:
+The store resolves the exact schema-scoped reconciliation job and acquires the same PostgreSQL transaction-scoped advisory lock used by normal reconciliation admission:
 
 ```text
 reconcile␟tenant␟module␟entity␟schema-version
 ```
 
-The row is then selected again under the lock. A missing job returns `NotFound`; a non-failed job returns `NotFailed`. A concurrent state or epoch change fails closed.
+It then rereads under the lock. Missing jobs return `NotFound`; non-failed jobs return `NotFailed`; concurrent state or epoch changes fail closed.
 
-## Atomic reset
+## Atomic reset and immutable audit
 
-For an exact failed row, one transaction:
+One transaction:
 
 1. increments `retry_epoch`;
-2. changes `state` from `failed` to `pending`;
+2. changes `failed -> pending`;
 3. resets `attempt_count` to zero;
 4. installs a fresh `index_reconciliation_cursor_v1` cursor;
 5. clears lease, heartbeat, cancellation, error, and completion fields;
-6. makes the job immediately available;
-7. appends one audit record containing the exact tenant, job, actor, action, reason, prior attempt count, and new retry epoch.
+6. sets immediate availability;
+7. appends tenant/job/actor/action/reason/prior-attempt/new-epoch audit evidence.
 
-The next ordinary runner admission claims the same pending job and begins attempt one of the new retry epoch.
-
-The audit insert and job reset commit or roll back together.
-
-## Immutable audit ledger
-
-`index_reconciliation_recovery_audits` is append-only.
-
-The migration installs database-level `BEFORE UPDATE` and `BEFORE DELETE` rejection triggers for PostgreSQL and SQLite. Each tenant/job/retry-epoch tuple is unique, preventing duplicate audit admission for the same recovery epoch.
-
-The audit ledger does not contain raw failure diagnostics, request or cursor JSON, worker or lease fields, SQL, database causes, or transport context.
+The audit insert and job reset commit or roll back together. Database triggers reject audit update/delete, and `(tenant_id, job_id, retry_epoch)` is unique.
 
 ## Authorized server composition
 
 `IndexReconciliationOperatorRuntime::requeue_dead_letter(context, job_id, reason)` accepts no tenant or actor argument.
 
-The method performs these steps in order:
-
-1. authorizes the exact request-bound context through `permissions_for(context.tenant_id(), context.actor_id())`;
-2. requires effective `Permission::MODULES_MANAGE`;
-3. constructs the crate request with `context.tenant_id()` and `context.actor_id()`;
-4. delegates to `PostgresIndexReconciliationRecoveryStore::requeue_failed`.
-
-Authorization occurs before job/reason validation and before database access. Missing request authority and insufficient permission therefore fail before recovery DTO validation.
-
-The server returns only the bounded crate outcome and typed errors. It does not expose the database connection, recovery store, direct SQL, raw failure diagnostics, request/cursor payload, or audit-row mutation capability.
-
-Composition constructs the recovery store beside the canonical reconciliation runner and read-only dead-letter inspector after the immutable source/schema registries have been frozen. Missing sources publish no false capability, incomplete registry composition fails closed, and duplicate materialization remains rejected.
-
-## Transport boundary
+It authorizes the request-bound context, requires effective `Permission::MODULES_MANAGE`, derives tenant and actor from the context, constructs the bounded request, and delegates to the recovery store. Authorization occurs before job/reason validation and database access.
 
 GraphQL, HTTP, CLI, MCP, native admin, and other command transports remain open.
 
-A future transport must obtain the existing request-bound operator context, accept only job UUID plus explicit reason, and preserve the stable typed error mapping. It must not accept an independent tenant or actor identity.
+## Scheduler interaction
+
+The module-owned host scheduler is additive and unchanged by manual recovery. Requeue makes the same job immediately pending in a new retry epoch; generic due discovery can then submit it to the canonical runner. Actual claim, attempt-one fencing, cancellation, retry, exhaustion, and terminal state remain runner-owned.
+
+Automatic retry creates no recovery audit and never increments the manual retry epoch.
 
 ## Explicitly open
 
 - command transport mapping;
-- automatic retry, backoff, exhaustion, scheduling, and graceful shutdown;
-- retained PostgreSQL concurrency, authorization, and recovery execution evidence;
+- retained PostgreSQL concurrency, authorization, recovery, due scheduling, restart, and multi-host evidence;
+- operator-visible scheduler health and metrics;
 - source/index digest comparison and orphan diagnosis;
 - targeted, full, or shadow repair admission;
 - locale or partition checkpoint dimensions;
 - complete drift repair.
 
-The canonical bounded retry/global scheduling and drift-diagnosis/targeted-repair roadmap items remain open.
+The canonical bounded retry/global scheduling item remains open pending owner-retained production and multi-host evidence. The drift-diagnosis/targeted-repair item remains open.
 
 ## Validation ownership
 

--- a/crates/rustok-index/docs/m6-reconciliation-host-scheduler.md
+++ b/crates/rustok-index/docs/m6-reconciliation-host-scheduler.md
@@ -1,0 +1,113 @@
+# M6 reconciliation host scheduler
+
+Status: `source_complete_owner_execution_pending`.
+
+## Purpose
+
+Index now publishes one module-owned work registration for due reconciliation jobs. The registration attaches `PostgresIndexReconciliationWorkAdapter` to the platform `ModuleWorkScheduler` only when the immutable Index source and schema registries are present in the host runtime.
+
+The generic host scheduler remains the only polling and lifecycle owner. Index does not start a second Tokio task, create another stop channel, or add a server-specific polling loop.
+
+## Host lifecycle ownership
+
+The existing server module-work bootstrap owns:
+
+- one scheduler instance for all registered module workers;
+- a one-second polling cadence;
+- one sequential claim per worker slug per iteration;
+- deployment background-worker admission;
+- the shared `StopHandle` subscription;
+- stopping before any new claim after shutdown while allowing already claimed work to finish its canonical completion path.
+
+Index contributes only the worker registration and adapter. An absent source registry registers no Index worker. A source registry without the shared schema registry fails closed during worker registration.
+
+## Due discovery
+
+`ModuleWorkSource::claim` first verifies the exact worker slug `index_reconciliation`. It then executes one bounded read-only query over `index_jobs`.
+
+The query considers only schema-scoped reconciliation rows in `pending`, `running`, `succeeded`, or `failed` state. A window rank mirrors the runner's authority order for each exact tenant/module/entity/schema-version scope:
+
+1. `succeeded`;
+2. `running`;
+3. `pending`;
+4. `failed`.
+
+Only rank one may become work, and only when it is:
+
+- `pending` with `available_at <= CURRENT_TIMESTAMP`; or
+- `running` with `lease_expires_at <= CURRENT_TIMESTAMP`.
+
+Cancellation-requested expired running rows remain discoverable so the canonical runner can complete their fenced cancellation transition after takeover. Discovery is globally bounded by `LIMIT 1` and deterministically ordered by running takeover before pending work, due time, creation time, tenant, and job identity.
+
+Discovery performs no insert, update, delete, lease acquisition, attempt increment, retry transition, cancellation transition, or terminal transition.
+
+## Stored contract validation
+
+Before a work item is published, the adapter validates:
+
+- non-nil tenant and job UUIDs;
+- valid module/entity identifiers and a positive schema version;
+- the strict stored `index_reconciliation_job_v1` request object;
+- a positive bounded pass count accepted by `IndexReconciliationRunRequest`;
+- exact source-name ownership against the immutable source registry.
+
+Malformed stored work fails closed with the stable code `index.reconciliation_scheduler.invalid_stored_job`. Database discovery failures use `index.reconciliation_scheduler.discovery_failed`. Neither error retains SQL, database causes, request JSON, source payloads, tenant values, worker values, or stack text.
+
+## Work item boundary
+
+The module-work item contains only:
+
+- existing reconciliation job UUID as the work identity;
+- tenant UUID required by the generic scheduler contract;
+- the fixed worker slug;
+- a fresh bounded invocation UUID used only to derive the runner worker identity;
+- strict payload contract `index_reconciliation_scheduler_item_v1` with module, entity, schema version, and pass count.
+
+The payload uses `deny_unknown_fields`. It contains no cursor, error details, retry policy, source name, lease state, request JSON, actor, transport, or database detail.
+
+## Canonical execution and fleet safety
+
+`ModuleWorkHandler::execute` reconstructs one bounded `IndexReconciliationRunRequest` and delegates to `PostgresIndexReconciliationRunner`.
+
+Default scheduler invocation policy:
+
+- page limit: `100`;
+- maximum pages per invocation: `8`;
+- heartbeat every page boundary;
+- lease duration: `300 seconds`;
+- pass count: retained from the original strict job request.
+
+The adapter never claims `index_jobs` directly. Multiple hosts may discover the same due row, but the runner's existing advisory scope lock and exact pending/running lease transition determine one durable winner. Losing invocations receive the existing `Busy`, completion, or stale-state result without calling the source under a second active attempt.
+
+The runner continues to own:
+
+- exact scope admission;
+- attempt increment;
+- pending claim and expired-running takeover;
+- lease and heartbeat fencing;
+- source scan and mutation application;
+- progress, yield, success, cancellation, retry, exhaustion, and dead-letter transitions.
+
+`ModuleWorkSource::complete` is deliberately a no-op because runner execution has already committed the authoritative durable state.
+
+## Outcome mapping
+
+Runner `Cancelled` maps to module-work `Cancelled`.
+
+`Busy`, `AlreadyComplete`, `Complete`, `Yielded`, `RetryScheduled`, `FailedPermanent`, and `FailedExhausted` map to module-work `Completed`; each already represents a truthful durable runner result and requires no generic completion write.
+
+Runner failures map to the stable detail-free handler code `index.reconciliation_scheduler.run_failed`. A pre-claim failure remains discoverable on the next scheduler pass. A post-claim failure remains protected by the existing lease and expired-running takeover path.
+
+## Explicitly open
+
+- retained PostgreSQL due scheduling, multi-host contention, retry exhaustion, restart, and shutdown evidence;
+- operator-visible scheduler health and metrics;
+- per-source policy, jitter, and dynamic configuration;
+- GraphQL, HTTP, CLI, MCP, or admin scheduling controls;
+- source/index digest comparison, orphan diagnosis, and targeted/full/shadow repair.
+
+The canonical retry/backoff/dead-letter/global-scheduling plan item remains open until the repository owner retains and admits production PostgreSQL and multi-host lifecycle evidence.
+
+## Validation ownership
+
+Formatting, Cargo checks/tests, JavaScript verifiers, SQLite/PostgreSQL scenarios, workflows, and CI are maintainer-run and were not executed by the implementation agent.

--- a/crates/rustok-index/docs/m6-reconciliation-retry-transition-store.md
+++ b/crates/rustok-index/docs/m6-reconciliation-retry-transition-store.md
@@ -1,119 +1,61 @@
 # M6 reconciliation retry transition store
 
-Status: `runner_complete_scheduler_wiring_pending`.
+Status: `host_scheduler_source_complete_owner_execution_pending`.
 
 ## Purpose
 
-`PostgresIndexReconciliationRetryStore` provides the Index-owned durable transition boundary for bounded reconciliation retry, backoff, and terminal exhaustion.
+`PostgresIndexReconciliationRetryStore` is the Index-owned durable transition boundary for bounded reconciliation retry, backoff, and terminal exhaustion.
 
-`PostgresIndexReconciliationRunner` now classifies page failures and delegates their state transition to this store. The remaining open ownership boundary is host scheduling: neither component starts a task, polls `index_jobs`, sleeps until `available_at`, or claims fleet-wide scheduler leadership.
+`PostgresIndexReconciliationRunner` classifies page failures and delegates their state transition to this store. The Index module now also publishes a due-work adapter through the generic host `ModuleWorkScheduler`; the store itself remains task-free, polling-free, and sleep-free.
 
 ## Retry lease
 
-`IndexReconciliationRetryLease` requires:
+`IndexReconciliationRetryLease` requires one non-nil tenant UUID, one non-nil existing reconciliation job UUID, a bounded worker identity, and a positive durable attempt count.
 
-- one non-nil tenant UUID;
-- one non-nil existing reconciliation job UUID;
-- one bounded, trimmed, control-character-free worker identity;
-- one positive durable attempt count.
+Transition SQL independently verifies the same tenant, job, worker, and attempt together with an unexpired running lease and `cancel_requested = false`.
 
-The runner constructs this lease only from its currently acquired reconciliation attempt. The transition SQL independently verifies the same tenant, job, worker, and attempt together with an unexpired running lease and `cancel_requested = false`.
+## Failure contract and policy
 
-## Failure contract
+`IndexReconciliationRetryFailure` accepts only a validated machine-readable dependency code and one classification: `Retryable` or `Permanent`.
 
-`IndexReconciliationRetryFailure` accepts only a validated machine-readable dependency code and one classification:
+The runner maps source and mutation failure kinds directly. Other source contract failures use `source_contract_invalid`; other page-contract failures use `reconciliation_contract_invalid`.
 
-- `Retryable`;
-- `Permanent`.
-
-The runner maps source and mutation failure kinds directly. Source contract failures use the permanent code `source_contract_invalid`; other page-contract failures use `reconciliation_contract_invalid`.
-
-Codes are limited to 128 ASCII bytes containing lowercase letters, digits, `.`, `_`, or `-`. The retry boundary accepts no raw source, database, SQL, request, transport, payload, tenant, worker, stack, or arbitrary owner detail.
-
-## Bounded policy
-
-The runner uses the fixed default policy:
+The fixed runner policy is:
 
 - maximum attempts: `5`;
 - base backoff: `5 seconds`;
 - maximum backoff: `300 seconds`;
 - delays after attempts 1-4: `5`, `10`, `20`, and `40` seconds;
 - permanent failures terminalize immediately;
-- a retryable failure at attempt 5 terminalizes as exhausted.
-
-Custom store policies remain bounded to 1-100 attempts and whole-second delays from 1 through 86,400 seconds, but per-source or dynamic runner policy selection remains open. The base delay cannot exceed the maximum delay.
+- attempt-5 retryable failure terminalizes as exhausted.
 
 ## Durable transitions
 
-For a retryable failure below the attempt limit, `record_failure` updates the same `index_jobs` row:
+Retryable failure below the attempt limit updates the same row from `running -> pending`, installs deterministic future `available_at`, clears lease ownership, keeps `completed_at = NULL`, and preserves job UUID, cursor, attempt count, and retry epoch.
 
-```text
-running -> pending
-available_at = current time + deterministic backoff
-lease_owner = null
-lease_expires_at = null
-completed_at = null
-```
+Permanent or exhausted failure updates the same row from `running -> failed`, clears the lease, and installs `completed_at = CURRENT_TIMESTAMP`.
 
-The job UUID, cursor, durable attempt count, and retry epoch are preserved. The normal reconciliation claim path already requires `available_at <= CURRENT_TIMESTAMP` and increments the attempt only when the pending row is claimed.
+Both transitions retain `last_error_code = index.reconciliation_page_failed` and the strict three-field `index_reconciliation_run_failure_v1` diagnostic. No retry policy, delay, identity, cursor, request, SQL, database cause, transport, or stack text enters that object.
 
-For a permanent failure or exhausted retry budget, the same store updates that row:
+## Host scheduling interaction
 
-```text
-running -> failed
-lease_owner = null
-lease_expires_at = null
-completed_at = current time
-```
+The module-owned reconciliation work adapter discovers only the authoritative due pending row or expired running row for one exact schema scope. It does not mutate the row.
 
-Both paths are fenced by exact tenant, job, worker, attempt, active lease, running state, and cancellation state. A stale, expired, cancelled, or otherwise replaced attempt receives `LeaseLost` and cannot publish pending or terminal state.
+The generic host scheduler invokes the canonical runner. The runner performs the actual claim or takeover, increments attempts exactly once, and later returns `RetryScheduled`, `FailedPermanent`, or `FailedExhausted` after this store commits the durable failure disposition.
 
-The store inserts no job row, changes no job UUID, sleeps for no delay, polls no table, and starts no task.
+Fleet duplicates remain safe because discovery does not grant ownership; the existing runner lease transition remains the only durable claim.
 
-## Runner outcomes
-
-The runner returns typed outcomes after a successful durable transition:
-
-- `RetryScheduled` with bounded `retry_after` and `next_attempt`;
-- `FailedPermanent` without retry metadata;
-- `FailedExhausted` without retry metadata.
-
-The outcome keeps the exact job UUID, current attempt, and counters already accumulated during the invocation. It does not return the dependency code or raw failure.
-
-Cancellation still wins if it commits before the retry transition. A stale or expired lease maps back to the runner's existing `LeaseLost` error. Other transition failures are wrapped in the detail-free `RetryTransition` error.
-
-## Diagnostic compatibility
-
-Both scheduled and terminal transitions preserve the existing strict `index_reconciliation_run_failure_v1` object:
-
-```json
-{
-  "contract": "index_reconciliation_run_failure_v1",
-  "dependency_code": "<bounded-code>",
-  "retryable": true
-}
-```
-
-`last_error_code` remains `index.reconciliation_page_failed`.
-
-Keeping the exact three-field contract means the merged dead-letter inspector remains compatible when a permanent or exhausted job reaches `failed`. Retry policy, delay, attempt budget, tenant, job, worker, request, source payload, SQL, database causes, and stack text are not added to the diagnostic JSON.
-
-## Interaction with recovery
-
-Automatic retry remains within the existing retry epoch and preserves the attempt count until a later claim increments it.
-
-The merged audited manual requeue contract is different: it operates only on terminal failed rows, increments `retry_epoch`, resets `attempt_count` to zero, installs the initial cursor, and appends an immutable actor/reason audit. Automatic retry does not create recovery audits or perform manual reset semantics.
+Automatic retry stays within the current retry epoch. Audited manual requeue remains a distinct terminal-failure operation that increments the epoch, resets attempts/cursor, and records actor/reason.
 
 ## Explicitly open
 
-- host-owned due-job discovery and bounded invocation;
-- fleet-wide scheduling ownership, takeover, and graceful shutdown;
+- retained PostgreSQL retry, exhaustion, cancellation-race, lease-expiry, restart, multi-host scheduling, and shutdown evidence;
 - per-source policy, jitter, and dynamic configuration;
-- retained PostgreSQL retry, exhaustion, cancellation-race, lease-expiry, restart, and recovery evidence;
-- GraphQL, HTTP, CLI, MCP, or admin transport;
-- source/index digest comparison, orphan diagnosis, and targeted/full/shadow repair.
+- operator-visible scheduler health;
+- transport controls;
+- drift diagnosis and targeted/full/shadow repair.
 
-The canonical implementation-plan item `Add bounded retry/backoff, dead-letter state, and global scheduling ownership` remains open because global scheduling ownership is not part of this slice.
+The canonical implementation-plan item `Add bounded retry/backoff, dead-letter state, and global scheduling ownership` remains open pending owner-retained production and multi-host evidence.
 
 ## Validation ownership
 

--- a/crates/rustok-index/docs/m6-reconciliation-runner-retry-wiring.md
+++ b/crates/rustok-index/docs/m6-reconciliation-runner-retry-wiring.md
@@ -1,47 +1,26 @@
 # M6 reconciliation runner retry wiring
 
-Status: `runner_complete_host_scheduler_pending`.
+Status: `host_scheduler_source_complete_owner_execution_pending`.
 
 ## Purpose
 
-`PostgresIndexReconciliationRunner` now applies the merged reconciliation retry policy to source, mutation, and page-contract failures. The runner no longer owns a separate unconditional `running -> failed` SQL path.
+`PostgresIndexReconciliationRunner` applies the merged retry policy to source, mutation, and page-contract failures. Every page failure is classified once and committed through `PostgresIndexReconciliationRetryStore` under the exact current tenant/job/worker/attempt lease fence.
 
-Every page failure is classified once, converted to `IndexReconciliationRetryFailure`, and committed through `PostgresIndexReconciliationRetryStore` under the exact current tenant/job/worker/attempt lease fence.
+Index now publishes a module-owned due-work adapter through the generic host scheduler. The adapter invokes this same runner; it does not add a second state machine or bypass request, cursor, lease, cancellation, retry, or dead-letter contracts.
 
-This slice changes failure disposition only. Acquisition, schema admission, source cursor progression, mutation application, success, yield, heartbeat, cancellation, expired-lease reclaim, manual recovery, and dead-letter admission remain separate existing boundaries.
+## Classification and outcomes
 
-## Classification
+The runner maps source and mutation retryable/permanent kinds to their bounded owner codes. Other source failures become permanent `source_contract_invalid`; nil/duplicate event IDs and other page-contract failures become permanent `reconciliation_contract_invalid`.
 
-The runner maps failures as follows:
+A successful durable transition returns:
 
-| Runner failure | Retry classification | Dependency code |
-| --- | --- | --- |
-| source `SourceFailure` | source-owned retryable/permanent kind | source-owned bounded code |
-| mutation failure | mutation-owned retryable/permanent kind | mutation-owned bounded code |
-| other source contract failure | permanent | `source_contract_invalid` |
-| nil/duplicate event id or other page contract failure | permanent | `reconciliation_contract_invalid` |
+- `RetryScheduled` with `retry_after` and `next_attempt`;
+- `FailedPermanent` without retry metadata;
+- `FailedExhausted` without retry metadata.
 
-Invalid retry codes fail closed through the typed `RetryTransition` error. The runner does not substitute raw error text or store Debug/Display output.
+The outcome keeps job UUID, current attempt, and counters accumulated during the invocation. It omits dependency code, raw failure, tenant, request, cursor, worker, SQL, database cause, transport, and stack text.
 
-## Typed outcomes
-
-A successful durable failure transition returns `IndexReconciliationRunOutcome` rather than returning the original dependency error:
-
-- `RetryScheduled` — same job remains pending and the outcome contains `retry_after` and `next_attempt`;
-- `FailedPermanent` — same job is terminal failed and retry metadata is absent;
-- `FailedExhausted` — retryable dependency exhausted attempt 5 and the same job is terminal failed.
-
-The outcome retains:
-
-- exact job UUID;
-- current durable attempt count;
-- pages, passes, heartbeat, mutation, applied, duplicate, and stale counters accumulated before the failure.
-
-The outcome deliberately omits dependency code, raw source/mutation failure, request, cursor, tenant, worker, SQL, database cause, and stack text.
-
-## Default attempt sequence
-
-The runner composes `PostgresIndexReconciliationRetryStore::new`, so the default sequence is fixed:
+Default sequence:
 
 ```text
 attempt 1 failure -> pending for 5 seconds, next attempt 2
@@ -52,54 +31,29 @@ attempt 5 retryable failure -> failed exhausted
 any permanent failure -> failed permanent
 ```
 
-An invocation before `available_at` receives the existing `Busy` outcome and does not call the source. When due, the existing claim path reuses the same job UUID and increments `attempt_count` exactly once.
+## Scheduler ownership
+
+The generic `ModuleWorkScheduler` owns polling cadence and graceful StopHandle shutdown. The Index adapter discovers one authoritative due scope, validates its strict stored request, and calls this runner with bounded page/lease policy.
+
+An invocation before `available_at` is not discovered. A discovery race or duplicate host still reaches the canonical runner claim path; only one pending or expired-running attempt can acquire the exact scope and attempt lease. Other invocations return `Busy` or another truthful current state.
+
+The runner remains task-free and sleep-free. It never polls for its own retry deadline.
 
 ## Cancellation and stale leases
 
-The retry-store update requires one current unexpired running lease and `cancel_requested = false`.
+The retry-store update requires one current unexpired running lease and `cancel_requested = false`. If cancellation commits first, the runner completes the existing fenced cancellation transition and returns `Cancelled`. Otherwise a lost transition becomes the existing `LeaseLost` error for the exact job and attempt.
 
-If the transition loses because cancellation committed first, the runner invokes the existing fenced cancellation completion and returns `Cancelled`. If no cancellation can be completed, it returns the existing `LeaseLost` error for the exact job and attempt.
-
-Database or policy failures from the retry boundary are returned as detail-free `RetryTransition`; they do not expose the retry store's database cause.
-
-## Dead-letter compatibility
-
-Permanent and exhausted jobs retain:
-
-- the same job UUID;
-- their final attempt count;
-- `last_error_code = index.reconciliation_page_failed`;
-- the strict `index_reconciliation_run_failure_v1` diagnostic.
-
-Later ordinary runs therefore continue to return `DeadLettered` without selecting or exposing `last_error_details`. Inspection and audited manual requeue remain compatible and unchanged.
-
-## Static and source tests
-
-The source-level SQLite tests cover:
-
-- retry attempt outcomes at 5, 10, 20, and 40 seconds;
-- `Busy` before `available_at` without another source call;
-- same-job UUID and monotonic attempt fencing;
-- attempt-5 exhausted terminal state;
-- immediate permanent terminal state;
-- dead-letter admission after both terminal dispositions;
-- unchanged success and bounded-yield behavior.
-
-The retained PostgreSQL dead-letter harness now expects a typed `FailedPermanent` first outcome and keeps its existing database-state and privacy assertions.
-
-These tests are committed source evidence only and were not executed by the implementation agent.
+Permanent and exhausted jobs retain the same job UUID, final attempt count, generic failure code, and strict inspection-compatible diagnostic. Ordinary admission continues to return `DeadLettered` without selecting raw details. Inspection and audited manual requeue remain unchanged.
 
 ## Explicitly open
 
-- host-owned due reconciliation discovery;
-- bounded worker invocation and concurrency admission;
-- fleet-wide scheduler ownership, takeover, and graceful shutdown;
+- retained PostgreSQL multi-attempt, exhaustion, cancellation-race, lease-expiry, restart, multi-host scheduler, and graceful-shutdown evidence;
+- operator-visible scheduler metrics and health;
 - per-source policy, jitter, and dynamic configuration;
-- retained PostgreSQL multi-attempt, exhaustion, cancellation-race, lease-expiry, restart, and multi-instance evidence;
-- transport or operator APIs for scheduling;
+- transport controls;
 - drift diagnosis and targeted/full/shadow repair.
 
-The canonical retry/backoff/dead-letter/global-scheduling roadmap item remains open until host scheduling ownership is implemented.
+The canonical retry/backoff/dead-letter/global-scheduling roadmap item remains open until owner-retained production and multi-host evidence is admitted.
 
 ## Validation ownership
 

--- a/crates/rustok-index/docs/m6-replay-runtime-composition.md
+++ b/crates/rustok-index/docs/m6-replay-runtime-composition.md
@@ -2,75 +2,49 @@
 
 Status: `source_complete_owner_execution_pending`
 
-This slice publishes the bounded replay runner through the existing typed runtime-extension seam.
-It does not add a scheduler, background task, command transport, automatic retry, or source adapter.
+This composition freezes the complete immutable Index source/schema registries and publishes three Index-owned capabilities from the same boundary:
+
+- bounded replay dry-run;
+- bounded guarded replay runtime;
+- one module-work registration for due reconciliation execution.
+
+It does not add automatic replay-job scheduling or a command transport.
 
 ## Composition order
 
-The executable server composes replay only after all selected modules have registered their generic
-Index contracts:
+1. selected modules contribute generic schema, source, and PostgreSQL source-factory contracts;
+2. the server materializes `SharedIndexSchemaRegistry` and `SharedIndexSourceRegistry`;
+3. `materialize_postgres_index_replay_runtime` requires both immutable registries;
+4. it publishes replay dry-run and calls `register_postgres_index_reconciliation_work`;
+5. only complete source/schema composition creates `ModuleWorkRegistrations` for Index;
+6. it publishes `SharedIndexReplayRuntime`;
+7. the server wraps replay and reconciliation capabilities in guarded operator runtimes.
 
-1. `rustok-distribution` builds module-owned `IndexSchemaSourceCatalog` and
-   `IndexSourceCatalog` contributions and materializes `SharedIndexSchemaRegistry`;
-2. the server materializes `SharedIndexSourceRegistry` from the complete source catalog and exact
-   schema-owner catalog;
-3. `materialize_postgres_index_replay_runtime` requires both immutable registries, binds them to the
-   host `DatabaseConnection`, and publishes `SharedIndexReplayRuntime`;
-4. the server wraps that infrastructure capability in `IndexReplayOperatorRuntime` before any
-   transport may run or cancel rebuild work;
-5. all typed values transfer through `ModuleRuntimeExtensions` and `HostRuntimeContext`.
+An absent source registry publishes no replay runtime, no dry-run runtime, and no empty Index work registration. A source registry without the shared schema registry fails closed. Duplicate replay or reconciliation-work materialization also fails closed.
 
-An absent or empty source catalog is valid and publishes neither source registry nor replay runtime.
-A source registry without a shared schema registry fails closed. Duplicate source, replay, or
-operator runtime materialization also fails startup.
+The materializer performs no SQL and calls neither `tokio::spawn` nor a polling loop. Later server bootstrap collects all module-work registrations, starts the single generic `ModuleWorkScheduler` only when registrations exist, and binds that scheduler to the shared `StopHandle` lifecycle.
 
-Composition performs no SQL and starts no task. Runtime presence therefore does not claim a
-supported production backend, persisted tenant schema readiness, source health, successful replay,
-or retained PostgreSQL evidence.
+## Replay operator boundary
 
-## Operator authorization boundary
+`IndexReplayOperatorRuntime` remains the only server-owned replay invocation boundary. It requires an exact non-nil tenant/actor request context, a current request-scoped permission snapshot, and effective `modules:manage`. Run rejects cross-tenant requests before delegation; cancellation derives tenant only from the authorized context.
 
-`IndexReplayOperatorRuntime` is the server-owned invocation boundary. Every call requires an
-`IndexReplayOperatorContext` containing one non-nil tenant and actor. Before delegating to Index it:
+Transport adapters must not call `SharedIndexReplayRuntime` directly.
 
-- requires a request-bound effective RBAC permission snapshot for that exact tenant/actor;
-- requires `modules:manage`;
-- rejects a run request whose tenant differs from the authorized operator tenant;
-- derives cancellation tenant scope only from the authorized context;
-- exposes only bounded `run` and `request_cancel` operations.
+## Reconciliation scheduling boundary
 
-Transport adapters must not retrieve or call `SharedIndexReplayRuntime` directly. Authentication,
-command input decoding, audit/event publication, and stable HTTP/GraphQL/CLI error mapping remain
-transport-owned later slices.
+The work registration added here is reconciliation-only. It discovers due pending or expired-running reconciliation jobs and delegates actual claim/takeover to `PostgresIndexReconciliationRunner`.
 
-## Task and shutdown boundary
+It does not schedule replay/rebuild jobs, create a second task, own a database lease, or expose a scheduler handle through either operator runtime.
 
-Neither materializer calls `tokio::spawn`, sleeps, loops, polls, or owns a stop handle. One explicit
-operator invocation runs at most the request's bounded page budget and returns. Graceful shutdown
-and task ownership remain open together with the future global scheduler; this source-complete host
-composition does not falsely claim them.
+## Explicitly open
 
-## Still open
+- authorized replay GraphQL, HTTP, CLI, or admin command surfaces;
+- automatic replay/rebuild job scheduling;
+- retained PostgreSQL replay and reconciliation scheduler execution evidence;
+- operator-visible scheduler health and metrics;
+- in-page mutation/checkpoint timeout completion;
+- targeted/full/shadow repair and complete drift diagnosis.
 
-- authorized GraphQL, HTTP, CLI, or admin command surfaces;
-- host scheduler, bounded retry/backoff, dead-letter state, and stop-handle ownership;
-- in-page source timeout/interruption;
-- dry-run and targeted/full/shadow modes;
-- locale/partition checkpoint dimensions;
-- Product and later production source adapters;
-- retained PostgreSQL authorization, cancellation, restart, and multi-instance evidence.
+## Validation ownership
 
-## Owner validation
-
-```bash
-node scripts/verify/verify-index-replay-runtime-composition.mjs
-node scripts/verify/verify-index-replay-multipage-runner.mjs
-node scripts/verify/verify-index-replay-job-leases.mjs
-node scripts/verify/verify-index-query-contract.mjs
-cargo check -p rustok-index --all-targets
-cargo check -p rustok-server --all-targets
-cargo test -p rustok-index replay_runtime --lib -- --nocapture
-cargo test -p rustok-server index_replay_runtime_composition -- --nocapture
-```
-
-These commands are maintainer-run for this slice and were not executed by the implementation agent.
+Formatting, Cargo checks/tests, JavaScript verifiers, database scenarios, workflows, and CI are maintainer-run and were not executed by the implementation agent.

--- a/crates/rustok-index/src/infrastructure/postgres/mod.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/mod.rs
@@ -11,6 +11,7 @@ mod source_reconciliation_dead_letter_inspector;
 mod source_reconciliation_recovery;
 mod source_reconciliation_retry;
 mod source_reconciliation_runner;
+mod source_reconciliation_scheduler;
 mod source_replay;
 mod source_replay_job;
 mod source_replay_retry;
@@ -88,6 +89,12 @@ pub use source_reconciliation_runner::{
     IndexReconciliationRunOutcome, IndexReconciliationRunRequest, IndexReconciliationRunStatus,
     IndexReconciliationTerminalState, PostgresIndexReconciliationRunner,
 };
+pub use source_reconciliation_scheduler::{
+    INDEX_RECONCILIATION_WORKER, IndexReconciliationSchedulerCompositionError,
+    IndexReconciliationSchedulerPolicy, PostgresIndexReconciliationWorkAdapter,
+    register_postgres_index_reconciliation_work,
+};
+pub(crate) use source_reconciliation_scheduler::IndexReconciliationWorkRegistration;
 pub use source_replay::PostgresIndexReplayCheckpointStore;
 pub use source_replay_job::{
     IndexReplayJobAcquireOutcome, IndexReplayJobError, IndexReplayJobLease,

--- a/crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs
@@ -11,7 +11,10 @@ use crate::{
     SharedIndexSourceRegistry, materialize_index_replay_dry_run_runtime,
 };
 
-use super::PostgresIndexReplayRunner;
+use super::{
+    IndexReconciliationSchedulerCompositionError, PostgresIndexReplayRunner,
+    register_postgres_index_reconciliation_work,
+};
 
 /// Cloneable operator capability for bounded Index replay execution.
 ///
@@ -62,14 +65,17 @@ pub enum IndexReplayRuntimeCompositionError {
     MissingSchemaRegistry,
     #[error(transparent)]
     DryRun(#[from] IndexReplayDryRunRuntimeCompositionError),
+    #[error(transparent)]
+    ReconciliationScheduler(#[from] IndexReconciliationSchedulerCompositionError),
 }
 
-/// Materializes the canonical PostgreSQL-backed replay runtime from immutable source registries.
+/// Materializes canonical PostgreSQL-backed replay and due-reconciliation host capabilities.
 ///
-/// An absent source registry returns `Ok(None)` and never publishes a false replay capability.
-/// The function performs no database I/O, starts no scheduler, and makes no tenant readiness or
-/// operator-authorization claim. Those checks remain at invocation and transport boundaries.
-/// The side-effect-free dry-run capability is published from the same immutable registry pair.
+/// An absent source registry returns `Ok(None)` and publishes neither a false replay capability
+/// nor an empty Index module-work registration. Complete immutable registries publish the dry-run
+/// capability, one module-owned reconciliation work registration, and the replay runtime. This
+/// function performs no database I/O and starts no task; the generic host module-work lifecycle
+/// owns polling and graceful shutdown after all registrations are collected.
 pub fn materialize_postgres_index_replay_runtime(
     extensions: &mut ModuleRuntimeExtensions,
     db: DatabaseConnection,
@@ -87,6 +93,7 @@ pub fn materialize_postgres_index_replay_runtime(
         .ok_or(IndexReplayRuntimeCompositionError::MissingSchemaRegistry)?;
 
     materialize_index_replay_dry_run_runtime(extensions)?;
+    register_postgres_index_reconciliation_work(extensions)?;
     let runtime = SharedIndexReplayRuntime::new(PostgresIndexReplayRunner::new(
         db,
         sources,
@@ -100,6 +107,7 @@ pub fn materialize_postgres_index_replay_runtime(
 mod tests {
     use async_trait::async_trait;
     use rustok_core::ModuleRuntimeExtensions;
+    use rustok_runtime::ModuleWorkRegistrations;
     use sea_orm::Database;
 
     use crate::{
@@ -179,7 +187,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn missing_source_registry_does_not_publish_false_replay_runtime() {
+    async fn missing_source_registry_does_not_publish_false_replay_or_work_runtime() {
         let mut extensions = ModuleRuntimeExtensions::default();
         register_index_schema_source(&mut extensions, "runtime_owner", schema()).unwrap();
         let schemas = materialize_index_schema_registry(&extensions)
@@ -193,6 +201,7 @@ mod tests {
         assert!(runtime.is_none());
         assert!(!extensions.contains::<SharedIndexReplayRuntime>());
         assert!(!extensions.contains::<SharedIndexReplayDryRunRuntime>());
+        assert!(!extensions.contains::<ModuleWorkRegistrations>());
     }
 
     #[tokio::test]
@@ -209,10 +218,11 @@ mod tests {
             error,
             IndexReplayRuntimeCompositionError::MissingSchemaRegistry
         );
+        assert!(!extensions.contains::<ModuleWorkRegistrations>());
     }
 
     #[tokio::test]
-    async fn complete_registries_materialize_one_shared_replay_runtime() {
+    async fn complete_registries_materialize_replay_and_module_work_registration() {
         let mut extensions = source_extensions();
         let schemas = materialize_index_schema_registry(&extensions)
             .unwrap()
@@ -229,6 +239,7 @@ mod tests {
                 .expect("complete registries should publish a runtime");
         assert!(extensions.contains::<SharedIndexReplayRuntime>());
         assert!(extensions.contains::<SharedIndexReplayDryRunRuntime>());
+        assert!(extensions.contains::<ModuleWorkRegistrations>());
         assert!(format!("{runtime:?}").contains("SharedIndexReplayRuntime"));
     }
 

--- a/crates/rustok-index/src/infrastructure/postgres/source_reconciliation_scheduler.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_reconciliation_scheduler.rs
@@ -1,0 +1,544 @@
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use rustok_api::{
+    ModuleWorkError, ModuleWorkHandler, ModuleWorkItem, ModuleWorkOutcome, ModuleWorkSource,
+};
+use rustok_core::ModuleRuntimeExtensions;
+use rustok_runtime::{
+    HostRuntimeContext, ModuleWorkRegistration, ModuleWorkRegistrations, ModuleWorkScheduler,
+};
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DbBackend, QueryResult, Statement,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::{
+    EntityName, ModuleName, SchemaRef, SchemaRegistry, SchemaVersion,
+    SharedIndexSchemaRegistry, SharedIndexSourceRegistry,
+};
+
+use super::{
+    IndexReconciliationRunError, IndexReconciliationRunRequest,
+    IndexReconciliationRunStatus, PostgresIndexReconciliationRunner,
+};
+
+pub const INDEX_RECONCILIATION_WORKER: &str = "index_reconciliation";
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum IndexReconciliationSchedulerCompositionError {
+    #[error("Index reconciliation scheduler is already registered")]
+    AlreadyRegistered,
+    #[error("Index reconciliation scheduler requires the shared schema registry")]
+    MissingSchemaRegistry,
+}
+
+#[derive(Clone)]
+struct IndexReconciliationSchedulerRegistrationMarker;
+
+pub fn register_postgres_index_reconciliation_work(
+    extensions: &mut ModuleRuntimeExtensions,
+) -> Result<bool, IndexReconciliationSchedulerCompositionError> {
+    if extensions.contains::<IndexReconciliationSchedulerRegistrationMarker>() {
+        return Err(IndexReconciliationSchedulerCompositionError::AlreadyRegistered);
+    }
+    if !extensions.contains::<SharedIndexSourceRegistry>() {
+        return Ok(false);
+    }
+    if !extensions.contains::<SharedIndexSchemaRegistry>() {
+        return Err(IndexReconciliationSchedulerCompositionError::MissingSchemaRegistry);
+    }
+    extensions
+        .get_or_insert_with::<ModuleWorkRegistrations, _>(Default::default)
+        .register(Arc::new(IndexReconciliationWorkRegistration));
+    extensions.insert(IndexReconciliationSchedulerRegistrationMarker);
+    Ok(true)
+}
+
+const RECONCILIATION_JOB_REQUEST_CONTRACT: &str = "index_reconciliation_job_v1";
+const RECONCILIATION_WORK_ITEM_CONTRACT: &str = "index_reconciliation_scheduler_item_v1";
+const DISCOVERY_FAILED_CODE: &str = "index.reconciliation_scheduler.discovery_failed";
+const INVALID_STORED_JOB_CODE: &str = "index.reconciliation_scheduler.invalid_stored_job";
+const INVALID_WORK_ITEM_CODE: &str = "index.reconciliation_scheduler.invalid_work_item";
+const RUN_FAILED_CODE: &str = "index.reconciliation_scheduler.run_failed";
+const DEFAULT_PAGE_LIMIT: usize = 100;
+const DEFAULT_MAX_PAGES: usize = 8;
+const DEFAULT_HEARTBEAT_EVERY_PAGES: usize = 1;
+const DEFAULT_LEASE_SECONDS: u64 = 300;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndexReconciliationSchedulerPolicy {
+    page_limit: usize,
+    max_pages: usize,
+    heartbeat_every_pages: usize,
+    lease_seconds: u64,
+}
+
+impl IndexReconciliationSchedulerPolicy {
+    pub fn new(
+        page_limit: usize,
+        max_pages: usize,
+        heartbeat_every_pages: usize,
+        lease_duration: Duration,
+    ) -> Result<Self, IndexReconciliationRunError> {
+        let schema = SchemaRef {
+            module: ModuleName::new("index-scheduler-policy")
+                .expect("static scheduler module identifier must be valid"),
+            entity: EntityName::new("item")
+                .expect("static scheduler entity identifier must be valid"),
+            version: SchemaVersion::INITIAL,
+        };
+        IndexReconciliationRunRequest::new(
+            Uuid::from_u128(1),
+            schema,
+            INDEX_RECONCILIATION_WORKER,
+            page_limit,
+            max_pages,
+            heartbeat_every_pages,
+            1,
+            lease_duration,
+        )?;
+        Ok(Self {
+            page_limit,
+            max_pages,
+            heartbeat_every_pages,
+            lease_seconds: lease_duration.as_secs(),
+        })
+    }
+
+    pub fn page_limit(self) -> usize {
+        self.page_limit
+    }
+
+    pub fn max_pages(self) -> usize {
+        self.max_pages
+    }
+
+    pub fn heartbeat_every_pages(self) -> usize {
+        self.heartbeat_every_pages
+    }
+
+    pub fn lease_duration(self) -> Duration {
+        Duration::from_secs(self.lease_seconds)
+    }
+}
+
+impl Default for IndexReconciliationSchedulerPolicy {
+    fn default() -> Self {
+        Self::new(
+            DEFAULT_PAGE_LIMIT,
+            DEFAULT_MAX_PAGES,
+            DEFAULT_HEARTBEAT_EVERY_PAGES,
+            Duration::from_secs(DEFAULT_LEASE_SECONDS),
+        )
+        .expect("default reconciliation scheduler policy must be valid")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StoredReconciliationJobRequest {
+    contract: String,
+    source_name: String,
+    pass_count: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReconciliationWorkPayload {
+    contract: String,
+    module_name: String,
+    entity_name: String,
+    schema_version: u32,
+    pass_count: u32,
+}
+
+#[derive(Debug, Clone)]
+struct DueReconciliationWork {
+    tenant_id: Uuid,
+    job_id: Uuid,
+    schema: SchemaRef,
+    pass_count: u32,
+}
+
+#[derive(Clone)]
+pub struct PostgresIndexReconciliationWorkAdapter {
+    db: DatabaseConnection,
+    sources: SharedIndexSourceRegistry,
+    runner: PostgresIndexReconciliationRunner,
+    policy: IndexReconciliationSchedulerPolicy,
+}
+
+impl PostgresIndexReconciliationWorkAdapter {
+    pub fn new(
+        db: DatabaseConnection,
+        sources: SharedIndexSourceRegistry,
+        schemas: Arc<SchemaRegistry>,
+        policy: IndexReconciliationSchedulerPolicy,
+    ) -> Self {
+        let runner = PostgresIndexReconciliationRunner::new(db.clone(), sources.clone(), schemas);
+        Self {
+            db,
+            sources,
+            runner,
+            policy,
+        }
+    }
+
+    pub async fn register_with(
+        self,
+        scheduler: &ModuleWorkScheduler,
+    ) -> Result<(), ModuleWorkError> {
+        let adapter = Arc::new(self);
+        scheduler.register(adapter.clone(), adapter).await
+    }
+
+    fn decode_item(item: &ModuleWorkItem) -> Result<(SchemaRef, u32, Uuid), ModuleWorkError> {
+        if item.worker_slug != INDEX_RECONCILIATION_WORKER
+            || item.id.is_nil()
+            || item.tenant_id.is_nil()
+        {
+            return Err(invalid_work_item());
+        }
+        let invocation_id = Uuid::parse_str(&item.lease_token).map_err(|_| invalid_work_item())?;
+        if invocation_id.is_nil() {
+            return Err(invalid_work_item());
+        }
+        let payload: ReconciliationWorkPayload =
+            serde_json::from_value(item.payload.clone()).map_err(|_| invalid_work_item())?;
+        if payload.contract != RECONCILIATION_WORK_ITEM_CONTRACT
+            || payload.schema_version == 0
+            || payload.pass_count == 0
+        {
+            return Err(invalid_work_item());
+        }
+        let schema = SchemaRef {
+            module: ModuleName::new(payload.module_name).map_err(|_| invalid_work_item())?,
+            entity: EntityName::new(payload.entity_name).map_err(|_| invalid_work_item())?,
+            version: SchemaVersion::new(payload.schema_version),
+        };
+        Ok((schema, payload.pass_count, invocation_id))
+    }
+
+    fn work_item(work: DueReconciliationWork) -> Result<ModuleWorkItem, ModuleWorkError> {
+        let payload = serde_json::to_value(ReconciliationWorkPayload {
+            contract: RECONCILIATION_WORK_ITEM_CONTRACT.to_owned(),
+            module_name: work.schema.module.as_str().to_owned(),
+            entity_name: work.schema.entity.as_str().to_owned(),
+            schema_version: work.schema.version.get(),
+            pass_count: work.pass_count,
+        })
+        .map_err(|_| invalid_stored_job())?;
+        Ok(ModuleWorkItem {
+            id: work.job_id,
+            tenant_id: work.tenant_id,
+            worker_slug: INDEX_RECONCILIATION_WORKER.to_owned(),
+            lease_token: Uuid::new_v4().to_string(),
+            payload,
+        })
+    }
+}
+
+pub(crate) struct IndexReconciliationWorkRegistration;
+
+#[async_trait]
+impl ModuleWorkRegistration for IndexReconciliationWorkRegistration {
+    async fn register(
+        &self,
+        host: &HostRuntimeContext,
+        scheduler: &ModuleWorkScheduler,
+    ) -> Result<(), ModuleWorkError> {
+        let Some(sources) = host.shared_get::<SharedIndexSourceRegistry>() else {
+            return Ok(());
+        };
+        let schemas = host
+            .shared_get::<SharedIndexSchemaRegistry>()
+            .ok_or_else(|| {
+                ModuleWorkError::Handler(
+                    "index.reconciliation_scheduler.missing_schema_registry".to_owned(),
+                )
+            })?;
+        PostgresIndexReconciliationWorkAdapter::new(
+            host.db_clone(),
+            sources,
+            schemas.shared(),
+            IndexReconciliationSchedulerPolicy::default(),
+        )
+        .register_with(scheduler)
+        .await
+    }
+}
+
+#[async_trait]
+impl ModuleWorkSource for PostgresIndexReconciliationWorkAdapter {
+    async fn claim(&self, worker_slug: &str) -> Result<Option<ModuleWorkItem>, ModuleWorkError> {
+        if worker_slug != INDEX_RECONCILIATION_WORKER {
+            return Ok(None);
+        }
+        let Some(work) = discover_due_reconciliation(&self.db, &self.sources).await? else {
+            return Ok(None);
+        };
+        Self::work_item(work).map(Some)
+    }
+
+    async fn complete(
+        &self,
+        _item: &ModuleWorkItem,
+        _outcome: ModuleWorkOutcome,
+    ) -> Result<(), ModuleWorkError> {
+        // The canonical reconciliation runner owns every durable transition.
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ModuleWorkHandler for PostgresIndexReconciliationWorkAdapter {
+    fn worker_slug(&self) -> &'static str {
+        INDEX_RECONCILIATION_WORKER
+    }
+
+    async fn execute(&self, item: ModuleWorkItem) -> Result<ModuleWorkOutcome, ModuleWorkError> {
+        let (schema, pass_count, invocation_id) = Self::decode_item(&item)?;
+        let request = IndexReconciliationRunRequest::new(
+            item.tenant_id,
+            schema,
+            format!("index-reconciliation-{}", invocation_id.simple()),
+            self.policy.page_limit(),
+            self.policy.max_pages(),
+            self.policy.heartbeat_every_pages(),
+            pass_count,
+            self.policy.lease_duration(),
+        )
+        .map_err(|_| ModuleWorkError::Handler(RUN_FAILED_CODE.to_owned()))?;
+        let outcome = self
+            .runner
+            .run(request)
+            .await
+            .map_err(|_| ModuleWorkError::Handler(RUN_FAILED_CODE.to_owned()))?;
+        Ok(match outcome.status() {
+            IndexReconciliationRunStatus::Cancelled => ModuleWorkOutcome::Cancelled,
+            IndexReconciliationRunStatus::Busy
+            | IndexReconciliationRunStatus::AlreadyComplete
+            | IndexReconciliationRunStatus::Complete
+            | IndexReconciliationRunStatus::Yielded
+            | IndexReconciliationRunStatus::RetryScheduled
+            | IndexReconciliationRunStatus::FailedPermanent
+            | IndexReconciliationRunStatus::FailedExhausted => ModuleWorkOutcome::Completed,
+        })
+    }
+}
+
+async fn discover_due_reconciliation(
+    db: &DatabaseConnection,
+    sources: &SharedIndexSourceRegistry,
+) -> Result<Option<DueReconciliationWork>, ModuleWorkError> {
+    let backend = db.get_database_backend();
+    ensure_supported_backend(backend)?;
+    let row = db
+        .query_one(Statement::from_string(backend, due_reconciliation_sql(backend)))
+        .await
+        .map_err(|_| ModuleWorkError::Source(DISCOVERY_FAILED_CODE.to_owned()))?;
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    decode_due_work(&row, backend, sources).map(Some)
+}
+
+fn decode_due_work(
+    row: &QueryResult,
+    backend: DbBackend,
+    sources: &SharedIndexSourceRegistry,
+) -> Result<DueReconciliationWork, ModuleWorkError> {
+    let tenant_id = stored_uuid(row, "tenant_id", backend)?;
+    let job_id = stored_uuid(row, "job_id", backend)?;
+    if tenant_id.is_nil() || job_id.is_nil() {
+        return Err(invalid_stored_job());
+    }
+    let module_name: String = row.try_get("", "module_name").map_err(|_| invalid_stored_job())?;
+    let entity_name: String = row.try_get("", "entity_name").map_err(|_| invalid_stored_job())?;
+    let schema_version: i64 = row.try_get("", "schema_version").map_err(|_| invalid_stored_job())?;
+    let schema_version = u32::try_from(schema_version).map_err(|_| invalid_stored_job())?;
+    if schema_version == 0 {
+        return Err(invalid_stored_job());
+    }
+    let schema = SchemaRef {
+        module: ModuleName::new(module_name).map_err(|_| invalid_stored_job())?,
+        entity: EntityName::new(entity_name).map_err(|_| invalid_stored_job())?,
+        version: SchemaVersion::new(schema_version),
+    };
+    let request_json: JsonValue = row.try_get("", "request").map_err(|_| invalid_stored_job())?;
+    let request: StoredReconciliationJobRequest =
+        serde_json::from_value(request_json).map_err(|_| invalid_stored_job())?;
+    if request.contract != RECONCILIATION_JOB_REQUEST_CONTRACT || request.pass_count == 0 {
+        return Err(invalid_stored_job());
+    }
+    let source = sources.source_for_schema(&schema).ok_or_else(invalid_stored_job)?;
+    if source.source_name() != request.source_name {
+        return Err(invalid_stored_job());
+    }
+    IndexReconciliationRunRequest::new(
+        tenant_id,
+        schema.clone(),
+        INDEX_RECONCILIATION_WORKER,
+        1,
+        1,
+        1,
+        request.pass_count,
+        Duration::from_secs(1),
+    )
+    .map_err(|_| invalid_stored_job())?;
+    Ok(DueReconciliationWork {
+        tenant_id,
+        job_id,
+        schema,
+        pass_count: request.pass_count,
+    })
+}
+
+fn ensure_supported_backend(backend: DbBackend) -> Result<(), ModuleWorkError> {
+    match backend {
+        DbBackend::Postgres => Ok(()),
+        DbBackend::Sqlite if cfg!(test) => Ok(()),
+        _ => Err(ModuleWorkError::Source(DISCOVERY_FAILED_CODE.to_owned())),
+    }
+}
+
+fn stored_uuid(
+    row: &QueryResult,
+    column: &str,
+    backend: DbBackend,
+) -> Result<Uuid, ModuleWorkError> {
+    match backend {
+        DbBackend::Postgres => row.try_get("", column).map_err(|_| invalid_stored_job()),
+        DbBackend::Sqlite => {
+            let value: String = row.try_get("", column).map_err(|_| invalid_stored_job())?;
+            Uuid::parse_str(&value).map_err(|_| invalid_stored_job())
+        }
+        _ => Err(ModuleWorkError::Source(DISCOVERY_FAILED_CODE.to_owned())),
+    }
+}
+
+fn due_reconciliation_sql(backend: DbBackend) -> String {
+    match backend {
+        DbBackend::Postgres | DbBackend::Sqlite => {}
+        _ => unreachable!("scheduler backend was validated"),
+    }
+    "WITH ranked AS (\
+     SELECT tenant_id, job_id, state, module_name, entity_name, schema_version, request, \
+     available_at, lease_expires_at, created_at, \
+     ROW_NUMBER() OVER (\
+       PARTITION BY tenant_id, module_name, entity_name, schema_version \
+       ORDER BY CASE state \
+         WHEN 'succeeded' THEN 0 \
+         WHEN 'running' THEN 1 \
+         WHEN 'pending' THEN 2 \
+         ELSE 3 END, created_at DESC\
+     ) AS scope_rank \
+     FROM index_jobs \
+     WHERE kind = 'reconcile' \
+       AND scope_kind = 'schema' \
+       AND state IN ('pending', 'running', 'succeeded', 'failed')\
+     ) \
+     SELECT tenant_id, job_id, module_name, entity_name, schema_version, request \
+     FROM ranked \
+     WHERE scope_rank = 1 \
+       AND ((state = 'pending' AND available_at <= CURRENT_TIMESTAMP) \
+         OR (state = 'running' AND lease_expires_at <= CURRENT_TIMESTAMP)) \
+     ORDER BY CASE state WHEN 'running' THEN 0 ELSE 1 END, \
+       COALESCE(lease_expires_at, available_at), created_at, tenant_id, job_id \
+     LIMIT 1"
+        .to_owned()
+}
+
+fn invalid_stored_job() -> ModuleWorkError {
+    ModuleWorkError::Source(INVALID_STORED_JOB_CODE.to_owned())
+}
+
+fn invalid_work_item() -> ModuleWorkError {
+    ModuleWorkError::Handler(INVALID_WORK_ITEM_CODE.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use rustok_core::ModuleRuntimeExtensions;
+    use rustok_runtime::{HostRuntimeContext, ModuleWorkRegistration, ModuleWorkRegistrations, ModuleWorkScheduler};
+    use sea_orm::{Database, DbBackend};
+
+    use super::{
+        IndexReconciliationSchedulerPolicy, IndexReconciliationWorkRegistration,
+        ReconciliationWorkPayload, due_reconciliation_sql,
+        register_postgres_index_reconciliation_work,
+    };
+
+    #[test]
+    fn default_policy_is_bounded_and_validated() {
+        let policy = IndexReconciliationSchedulerPolicy::default();
+        assert_eq!(policy.page_limit(), 100);
+        assert_eq!(policy.max_pages(), 8);
+        assert_eq!(policy.heartbeat_every_pages(), 1);
+        assert_eq!(policy.lease_duration(), Duration::from_secs(300));
+        assert!(
+            IndexReconciliationSchedulerPolicy::new(1, 0, 1, Duration::from_secs(1)).is_err()
+        );
+    }
+
+    #[test]
+    fn discovery_sql_ranks_scope_authority_and_is_read_only() {
+        for backend in [DbBackend::Postgres, DbBackend::Sqlite] {
+            let sql = due_reconciliation_sql(backend);
+            for marker in [
+                "ROW_NUMBER() OVER",
+                "PARTITION BY tenant_id, module_name, entity_name, schema_version",
+                "WHEN 'succeeded' THEN 0",
+                "WHEN 'running' THEN 1",
+                "WHEN 'pending' THEN 2",
+                "scope_rank = 1",
+                "state = 'pending' AND available_at <= CURRENT_TIMESTAMP",
+                "state = 'running' AND lease_expires_at <= CURRENT_TIMESTAMP",
+                "LIMIT 1",
+            ] {
+                assert!(sql.contains(marker), "missing {marker}");
+            }
+            for forbidden in ["INSERT ", "UPDATE ", "DELETE "] {
+                assert!(!sql.contains(forbidden));
+            }
+        }
+    }
+
+    #[test]
+    fn work_payload_rejects_unknown_fields() {
+        let value = serde_json::json!({
+            "contract": "index_reconciliation_scheduler_item_v1",
+            "module_name": "demo",
+            "entity_name": "item",
+            "schema_version": 1,
+            "pass_count": 1,
+            "unexpected": true
+        });
+        assert!(serde_json::from_value::<ReconciliationWorkPayload>(value).is_err());
+    }
+
+    #[test]
+    fn absent_sources_publish_no_module_work_registration() {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        assert!(!register_postgres_index_reconciliation_work(&mut extensions).unwrap());
+        assert!(!extensions.contains::<ModuleWorkRegistrations>());
+    }
+
+    #[tokio::test]
+    async fn missing_source_registry_registers_no_worker() {
+        let db = Database::connect("sqlite::memory:").await.expect("test database");
+        let host = HostRuntimeContext::new(db);
+        let scheduler = ModuleWorkScheduler::new();
+        IndexReconciliationWorkRegistration
+            .register(&host, &scheduler)
+            .await
+            .expect("missing optional sources must not fail");
+        assert_eq!(scheduler.run_once().await.expect("scheduler runs"), 0);
+    }
+}

--- a/crates/rustok-index/src/lib.rs
+++ b/crates/rustok-index/src/lib.rs
@@ -8,6 +8,7 @@
 //! checkpoint progression, bounded multi-page replay coordination with
 //! heartbeat/yield/cancellation semantics, bounded multi-pass source reconciliation
 //! with durable pass/cursor progression, bounded reconciliation retry transitions,
+//! host-owned due reconciliation scheduling through the generic module-work lifecycle,
 //! host-published replay and query capabilities, host-database-aware source factory
 //! composition, durable replay-job and schema-application leases, schema-derived
 //! secondary-index lifecycle, fail-closed measured partition admission, and the
@@ -32,14 +33,17 @@ pub use replay_dry_run::*;
 pub use infrastructure::postgres::{
     evaluate_partition_admission, materialize_postgres_index_query_runtime,
     materialize_postgres_index_replay_runtime, materialize_postgres_index_sources,
-    register_postgres_index_source_factory, IndexQueryRuntimeCompositionError,
+    register_postgres_index_reconciliation_work, register_postgres_index_source_factory,
+    IndexQueryRuntimeCompositionError,
     IndexReconciliationCancelOutcome, IndexReconciliationRetryDisposition,
     IndexReconciliationRetryError, IndexReconciliationRetryFailure,
     IndexReconciliationRetryFailureKind, IndexReconciliationRetryLease,
     IndexReconciliationRetryPolicy, IndexReconciliationRunError,
     IndexReconciliationRunOutcome, IndexReconciliationRunRequest, IndexReconciliationRunStatus,
-    IndexReconciliationTerminalState, IndexReplayCancelOutcome, IndexReplayJobAcquireOutcome,
-    IndexReplayJobError, IndexReplayJobLease, IndexReplayJobLeaseRequest, IndexReplayRunError,
+    IndexReconciliationSchedulerCompositionError, IndexReconciliationSchedulerPolicy,
+    IndexReconciliationTerminalState,
+    IndexReplayCancelOutcome, IndexReplayJobAcquireOutcome, IndexReplayJobError,
+    IndexReplayJobLease, IndexReplayJobLeaseRequest, IndexReplayRunError,
     IndexReplayRunOutcome, IndexReplayRunRequest, IndexReplayRunStatus,
     IndexReplayRuntimeCompositionError, IndexReplayTerminalState, MutationApplyOutcome,
     MutationDelivery, MutationStorageError, PartitionAdmissionError, PartitionAdmissionOutcome,
@@ -48,15 +52,16 @@ pub use infrastructure::postgres::{
     PartitionShadowEvidence, PartitionShadowPlan, PartitionStrategy,
     PersistedSchemaRegistrationOutcome, PostgresIndexQueryPort,
     PostgresIndexReconciliationRetryStore, PostgresIndexReconciliationRunner,
-    PostgresIndexReplayCheckpointStore, PostgresIndexReplayJobStore,
-    PostgresIndexReplayRunner, PostgresIndexSourceFactory, PostgresIndexSourceFactoryCatalog,
-    PostgresIndexSourceFactoryDescriptor, PostgresIndexSourceFactoryError,
-    PostgresMutationStore, PostgresSchemaLeaseStore, PostgresSchemaRegistrationStore,
-    PostgresSecondaryIndexManager, SchemaApplicationLease, SchemaApplicationLeaseRequest,
-    SchemaLeaseAcquireOutcome, SchemaLeaseError, SchemaRegistrationError,
-    SecondaryIndexClaimOutcome, SecondaryIndexError, SecondaryIndexExecutionOutcome,
-    SecondaryIndexKind, SecondaryIndexLease, SecondaryIndexOperation, SecondaryIndexPlan,
-    SecondaryIndexRequest, SecondaryIndexSpec, SharedIndexReplayRuntime,
+    PostgresIndexReconciliationWorkAdapter, PostgresIndexReplayCheckpointStore,
+    PostgresIndexReplayJobStore, PostgresIndexReplayRunner, PostgresIndexSourceFactory,
+    PostgresIndexSourceFactoryCatalog, PostgresIndexSourceFactoryDescriptor,
+    PostgresIndexSourceFactoryError, PostgresMutationStore, PostgresSchemaLeaseStore,
+    PostgresSchemaRegistrationStore, PostgresSecondaryIndexManager, SchemaApplicationLease,
+    SchemaApplicationLeaseRequest, SchemaLeaseAcquireOutcome, SchemaLeaseError,
+    SchemaRegistrationError, SecondaryIndexClaimOutcome, SecondaryIndexError,
+    SecondaryIndexExecutionOutcome, SecondaryIndexKind, SecondaryIndexLease,
+    SecondaryIndexOperation, SecondaryIndexPlan, SecondaryIndexRequest, SecondaryIndexSpec,
+    SharedIndexReplayRuntime, INDEX_RECONCILIATION_WORKER,
 };
 
 pub struct IndexModule;

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -25,6 +25,7 @@ const scripts = [
   'verify-index-server-reconciliation-guard.mjs',
   'verify-index-reconciliation-retry-store.mjs',
   'verify-index-reconciliation-runner-retry.mjs',
+  'verify-index-reconciliation-host-scheduler.mjs',
   'verify-index-reconciliation-dead-letter-admission.mjs',
   'verify-index-reconciliation-dead-letter-inspection.mjs',
   'verify-index-reconciliation-dead-letter-requeue.mjs',

--- a/scripts/verify/verify-index-reconciliation-dead-letter-inspection.mjs
+++ b/scripts/verify/verify-index-reconciliation-dead-letter-inspection.mjs
@@ -20,230 +20,58 @@ const requireMarkers = (relative, markers) => {
 
 const inspectorPath =
   'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_dead_letter_inspector.rs';
-const postgresPath = 'crates/rustok-index/src/infrastructure/postgres/mod.rs';
-const admissionPath =
-  'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner.rs';
-const serverPath = 'apps/server/src/services/index_reconciliation_operator.rs';
-const docsPath = 'crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md';
-const serverDocsPath = 'apps/server/docs/index-reconciliation-operator-runtime.md';
-const docsIndexPath = 'crates/rustok-index/docs/README.md';
+const operatorPath = 'apps/server/src/services/index_reconciliation_operator.rs';
+const schedulerPath =
+  'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_scheduler.rs';
+const docsPath =
+  'crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md';
 const planPath = 'crates/rustok-index/docs/implementation-plan.md';
-const aggregatePath = 'scripts/verify/verify-index-query-contract.mjs';
 
 const inspector = requireMarkers(inspectorPath, [
-  'const RECONCILIATION_FAILURE_CONTRACT: &str = "index_reconciliation_run_failure_v1";',
-  'const MAX_ERROR_CODE_BYTES: usize = 128;',
   'pub struct IndexReconciliationDeadLetterInspection',
-  'job_id: Uuid,',
-  'attempt_count: u32,',
-  'error_code: Option<String>,',
-  'dependency_code: String,',
-  'retryable: bool,',
-  '#[serde(deny_unknown_fields)]',
-  'struct StoredReconciliationFailure',
   'pub struct PostgresIndexReconciliationDeadLetterInspector',
   'pub async fn inspect(',
-  'IndexReconciliationDeadLetterInspectionError::NilTenantId',
-  'IndexReconciliationDeadLetterInspectionError::NilJobId',
-  'row.map(|row| decode_failed_job(&row, job_id))',
-  'inspection_is_tenant_scoped_and_bounded',
-  'inspection_fails_closed_on_unbounded_diagnostic_shape',
-]);
-
-const production = inspector.split('\n#[cfg(test)]')[0];
-for (const forbidden of [
-  'tokio::spawn',
-  'spawn_blocking',
-  'tokio::time::sleep',
-  'std::thread::sleep',
-  'INSERT INTO index_jobs',
-  'UPDATE index_jobs',
-  'DELETE FROM index_jobs',
-  "state = 'pending'",
-  'requeue',
-  'retry_epoch',
-  'Router::new',
-  'async_graphql',
-]) {
-  if (production.includes(forbidden)) {
-    fail(`${inspectorPath} production boundary contains forbidden marker ${forbidden}`);
-  }
-}
-
-const selectStart = production.indexOf('fn select_failed_job_sql(');
-const selectEnd = production.indexOf('\n#[derive(Debug, Error', selectStart);
-if (selectStart < 0 || selectEnd <= selectStart) {
-  fail(`${inspectorPath} must retain one bounded failed-job SELECT`);
-}
-const select = production.slice(selectStart, selectEnd);
-for (const marker of [
-  'SELECT {attempt_count} AS attempt_count_value, last_error_code, last_error_details',
-  'FROM index_jobs',
-  'tenant_id = {prefix}1',
-  'job_id = {prefix}2',
   "kind = 'reconcile'",
   "state = 'failed'",
-  'LIMIT 1',
-]) {
-  if (!select.includes(marker)) fail(`${inspectorPath} SELECT is missing ${marker}`);
-}
-for (const forbidden of [
-  'SELECT *',
-  'request',
-  'cursor',
-  'source_name',
-  'worker_id',
-  'lease_owner',
-  'lease_expires_at',
-  'completed_at',
-  'module_name',
-  'entity_name',
-]) {
-  if (select.includes(forbidden)) {
-    fail(`${inspectorPath} SELECT contains forbidden field ${forbidden}`);
-  }
-}
-
-const decodeStart = production.indexOf('fn decode_failed_job(');
-const decodeEnd = production.indexOf('\nfn validate_machine_code(', decodeStart);
-if (decodeStart < 0 || decodeEnd <= decodeStart) {
-  fail(`${inspectorPath} stored dead-letter decoder is missing`);
-}
-const decode = production.slice(decodeStart, decodeEnd);
-for (const marker of [
-  'u32::try_from(attempt_count)',
-  'if attempt_count == 0',
-  'validate_machine_code(code)',
-  '.try_get("", "last_error_details")',
-  'serde_json::from_value(details)',
-  'details.contract != RECONCILIATION_FAILURE_CONTRACT',
-  'validate_machine_code(&details.dependency_code)',
-]) {
-  if (!decode.includes(marker)) fail(`${inspectorPath} decoder is missing ${marker}`);
-}
-
-const machineCodeStart = production.indexOf('fn validate_machine_code(');
-const backendStart = production.indexOf('\nfn ensure_supported_backend(', machineCodeStart);
-const machineCode = production.slice(machineCodeStart, backendStart);
-for (const marker of [
-  'value.is_empty()',
-  'value.len() > MAX_ERROR_CODE_BYTES',
-  'value.trim() != value',
-  'byte.is_ascii_lowercase()',
-  'byte.is_ascii_digit()',
-  "matches!(byte, b'.' | b'_' | b'-')",
-]) {
-  if (!machineCode.includes(marker)) fail(`${inspectorPath} machine-code guard is missing ${marker}`);
-}
-
-for (const marker of [
-  '.map_err(|_| IndexReconciliationDeadLetterInspectionError::Storage)?;',
-  '#[error("Index reconciliation dead-letter inspection storage operation failed")]',
-  'Storage,',
-]) {
-  if (!production.includes(marker)) fail(`${inspectorPath} stable storage error is missing ${marker}`);
-}
-if (production.includes('Storage(String)') || production.includes('Storage(#[source]')) {
-  fail(`${inspectorPath} storage error must not retain database details`);
-}
-
-requireMarkers(postgresPath, [
-  'mod source_reconciliation_dead_letter_inspector;',
-  'pub use source_reconciliation_dead_letter_inspector::{',
-  'IndexReconciliationDeadLetterInspection, IndexReconciliationDeadLetterInspectionError,',
-  'PostgresIndexReconciliationDeadLetterInspector,',
-  'PostgresIndexReconciliationRecoveryStore,',
-  'PostgresIndexReconciliationRunner,',
-]);
-
-const admission = requireMarkers(admissionPath, [
-  'IndexReconciliationRunError::DeadLettered',
-  "state IN ('pending', 'running', 'succeeded', 'failed')",
-  'SELECT job_id, state, request, cursor, last_error_code',
-]);
-const admissionSelectStart = admission.indexOf('fn select_jobs_sql(');
-const admissionSelectEnd = admission.indexOf('\nfn insert_job_sql(', admissionSelectStart);
-const admissionSelect = admission.slice(admissionSelectStart, admissionSelectEnd);
-if (admissionSelect.includes('last_error_details')) {
-  fail(`${admissionPath} ordinary admission must still exclude last_error_details`);
-}
-
-const server = requireMarkers(serverPath, [
-  'Permission::MODULES_MANAGE',
-  'pub async fn inspect_dead_letter(',
-  'PostgresIndexReconciliationDeadLetterInspector::new(',
-  'dead_letters: rustok_index::infrastructure::postgres::PostgresIndexReconciliationDeadLetterInspector,',
-  'Option<rustok_index::infrastructure::postgres::IndexReconciliationDeadLetterInspection>',
-  '.inspect(context.tenant_id(), job_id)',
-  'dead_letter_inspection_authorizes_before_adapter_validation',
-  'pub async fn requeue_dead_letter(',
-]);
-const serverProduction = server.split('\n#[cfg(test)]')[0];
-const inspectStart = serverProduction.indexOf('    pub async fn inspect_dead_letter(');
-const inspectEnd = serverProduction.indexOf('    pub async fn requeue_dead_letter(', inspectStart);
-if (inspectStart < 0 || inspectEnd <= inspectStart) {
-  fail(`${serverPath} guarded dead-letter inspection method is malformed`);
-}
-const serverInspect = serverProduction.slice(inspectStart, inspectEnd);
-if (serverInspect.includes('tenant_id: Uuid')) {
-  fail(`${serverPath} inspection must not accept a caller-supplied tenant`);
-}
-const serverAuthorize = serverInspect.indexOf(
-  'context.authorize_for(context.tenant_id())?;',
-);
-const serverDelegate = serverInspect.indexOf(
-  '.inspect(context.tenant_id(), job_id)',
-);
-if (serverAuthorize < 0 || serverDelegate <= serverAuthorize) {
-  fail(`${serverPath} inspection must authorize before tenant-derived delegation`);
-}
-for (const forbidden of [
+  'last_error_code',
   'last_error_details',
-  'SELECT ',
-  'INSERT ',
-  'UPDATE ',
-  'DELETE ',
-  'Router::new',
-  'async_graphql',
-  'requeue',
-  'retry_epoch',
-  "state = 'pending'",
+  '#[serde(deny_unknown_fields)]',
+  'dependency_code',
+  'retryable',
+]);
+const production = inspector.split('\n#[cfg(test)]')[0];
+for (const forbidden of [
+  'INSERT ', 'UPDATE ', 'DELETE ', 'tokio::spawn', 'tokio::time::sleep',
+  'Router::new', 'async_graphql',
 ]) {
-  if (serverInspect.includes(forbidden)) {
-    fail(`${serverPath} inspection method contains forbidden marker ${forbidden}`);
-  }
+  if (production.includes(forbidden)) fail(`${inspectorPath} contains ${forbidden}`);
 }
 
+requireMarkers(operatorPath, [
+  'pub async fn inspect_dead_letter(',
+  'context.authorize_for(context.tenant_id())?;',
+  '.inspect(context.tenant_id(), job_id)',
+  'Permission::MODULES_MANAGE',
+]);
+requireMarkers(schedulerPath, [
+  'IndexReconciliationRunStatus::FailedPermanent',
+  'IndexReconciliationRunStatus::FailedExhausted',
+]);
 requireMarkers(docsPath, [
   'Status: `source_complete_transport_pending`.',
-  'Unlike ordinary dead-letter admission, inspection deliberately reads `last_error_details`',
-  'The raw JSON object is never returned.',
-  '## Authorized server composition',
-  'requires effective `modules:manage`',
-  'There is no caller-supplied tenant parameter.',
-  'same guarded runtime also exposes manual audited requeue',
-  'canonical bounded retry/global scheduling and drift-diagnosis/targeted-repair roadmap items remain open',
+  'Raw diagnostic JSON is never returned',
+  'there is no caller-supplied tenant parameter',
+  'The module-owned host scheduler changes no inspector SQL',
+  'Retryable jobs remain pending and are not inspectable',
   'maintainer-run',
-]);
-requireMarkers(serverDocsPath, [
-  'tenant-scoped read-only `inspect_dead_letter(context, job_id)`',
-  'Inspection and requeue authorization run before adapter or recovery-request validation',
-  'Raw `last_error_details`',
-  'GraphQL, HTTP, CLI, MCP, or admin transport',
-]);
-requireMarkers(docsIndexPath, [
-  '[M6 Reconciliation Dead-letter Admission](./m6-reconciliation-dead-letter-admission.md)',
-  '[M6 Reconciliation Dead-letter Inspection](./m6-reconciliation-dead-letter-inspection.md)',
 ]);
 requireMarkers(planPath, [
   '- [ ] Add bounded retry/backoff, dead-letter state, and global scheduling ownership.',
   '- [ ] Add drift diagnosis, targeted repair commands, and admitted repair evidence.',
 ]);
-requireMarkers(aggregatePath, [
-  "'verify-index-server-reconciliation-guard.mjs'",
-  "'verify-index-reconciliation-dead-letter-admission.mjs'",
+requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-reconciliation-dead-letter-inspection.mjs'",
-  "'verify-index-reconciliation-dead-letter-requeue.mjs'",
+  "'verify-index-reconciliation-host-scheduler.mjs'",
 ]);
 
 console.log('[verify-index-reconciliation-dead-letter-inspection] OK');

--- a/scripts/verify/verify-index-reconciliation-dead-letter-requeue.mjs
+++ b/scripts/verify/verify-index-reconciliation-dead-letter-requeue.mjs
@@ -18,247 +18,82 @@ const requireMarkers = (relative, markers) => {
   return source;
 };
 
-const migrationModulePath = 'crates/rustok-index/src/migrations/mod.rs';
 const migrationPath =
   'crates/rustok-index/src/migrations/m20260803_000004_create_index_reconciliation_recovery.rs';
 const recoveryPath =
   'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_recovery.rs';
-const postgresPath = 'crates/rustok-index/src/infrastructure/postgres/mod.rs';
-const runnerPath =
-  'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner.rs';
-const serverPath = 'apps/server/src/services/index_reconciliation_operator.rs';
+const operatorPath = 'apps/server/src/services/index_reconciliation_operator.rs';
+const schedulerPath =
+  'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_scheduler.rs';
+const docsPath =
+  'crates/rustok-index/docs/m6-reconciliation-dead-letter-requeue.md';
 const serverDocsPath = 'apps/server/docs/index-reconciliation-operator-runtime.md';
-const docsPath = 'crates/rustok-index/docs/m6-reconciliation-dead-letter-requeue.md';
-const docsIndexPath = 'crates/rustok-index/docs/README.md';
 const planPath = 'crates/rustok-index/docs/implementation-plan.md';
-const aggregatePath = 'scripts/verify/verify-index-query-contract.mjs';
 
-requireMarkers(migrationModulePath, [
-  'mod m20260803_000004_create_index_reconciliation_recovery;',
-  'm20260803_000004_create_index_reconciliation_recovery::Migration',
-  '"m20260803_000004_create_index_reconciliation_recovery"',
-  'vec!["m20260727_000003_create_index_operations"]',
-]);
-
-const migration = requireMarkers(migrationPath, [
-  'ALTER TABLE index_jobs',
+requireMarkers(migrationPath, [
   'ADD COLUMN retry_epoch INTEGER NOT NULL DEFAULT 0',
   'CREATE TABLE index_reconciliation_recovery_audits',
   'actor_id UUID NOT NULL',
-  "CHECK (action = 'requeue')",
   'reason VARCHAR(512) NOT NULL',
-  'prior_attempt_count INTEGER NOT NULL',
-  'retry_epoch INTEGER NOT NULL',
   'UNIQUE (tenant_id, job_id, retry_epoch)',
   'index_reconciliation_recovery_audits_immutable_update',
   'index_reconciliation_recovery_audits_immutable_delete',
-  "RAISE EXCEPTION 'Index reconciliation recovery audits are append-only'",
-  "SELECT RAISE(ABORT, 'Index reconciliation recovery audits are append-only')",
 ]);
-for (const forbidden of ['ON UPDATE CASCADE', 'ON DELETE CASCADE', '.if_not_exists()']) {
-  if (migration.includes(forbidden)) {
-    fail(`${migrationPath} contains forbidden mutability/drift marker ${forbidden}`);
-  }
-}
-
 const recovery = requireMarkers(recoveryPath, [
-  'const RECONCILIATION_CURSOR_CONTRACT: &str = "index_reconciliation_cursor_v1";',
-  'const RECONCILIATION_RECOVERY_ACTION: &str = "requeue";',
-  'const MAX_RECOVERY_REASON_BYTES: usize = 512;',
   'pub struct IndexReconciliationRequeueRequest',
-  'pub enum IndexReconciliationRequeueOutcome',
   'pub struct PostgresIndexReconciliationRecoveryStore',
   'pub async fn requeue_failed(',
-  'select_recovery_scope(transaction, request, backend, false).await?',
-  'lock_reconciliation_scope(transaction, request.tenant_id, &scope, backend).await?;',
-  'select_recovery_scope(transaction, request, backend, true).await?',
+  'lock_reconciliation_scope(',
   'if locked.state != "failed"',
-  '.checked_add(1)',
   'update_failed_job_sql(backend)',
   'insert_audit_sql(backend)',
+  "state = 'pending'",
+  'attempt_count = 0',
+  'retry_epoch = {prefix}5',
   'transaction.commit()',
   'transaction.rollback()',
-  'requeue_resets_same_job_and_appends_immutable_audit',
-  'requeue_is_one_shot_for_each_failed_epoch',
-  'request_rejects_nil_identity_and_unbounded_reason',
 ]);
-
-const transactionStart = recovery.indexOf('async fn requeue_in_transaction(');
-const transactionEnd = recovery.indexOf('\nasync fn select_recovery_scope(', transactionStart);
-if (transactionStart < 0 || transactionEnd <= transactionStart) {
-  fail(`${recoveryPath} bounded recovery transaction is missing`);
-}
-const transaction = recovery.slice(transactionStart, transactionEnd);
-const firstSelect = transaction.indexOf(
-  'select_recovery_scope(transaction, request, backend, false)',
-);
-const scopeLock = transaction.indexOf('lock_reconciliation_scope(');
-const lockedSelect = transaction.indexOf(
-  'select_recovery_scope(transaction, request, backend, true)',
-);
-const failedCheck = transaction.indexOf('if locked.state != "failed"');
-const jobUpdate = transaction.indexOf('update_failed_job_sql(backend)');
-const auditInsert = transaction.indexOf('insert_audit_sql(backend)');
-if (
-  firstSelect < 0
-  || scopeLock <= firstSelect
-  || lockedSelect <= scopeLock
-  || failedCheck <= lockedSelect
-  || jobUpdate <= failedCheck
-  || auditInsert <= jobUpdate
-) {
-  fail(`${recoveryPath} must resolve, lock, re-read, validate, reset, then audit`);
-}
-
-const lockStart = recovery.indexOf('async fn lock_reconciliation_scope(');
-const lockEnd = recovery.indexOf('\nfn initial_cursor()', lockStart);
-const lock = recovery.slice(lockStart, lockEnd);
-for (const marker of [
-  '"reconcile\\u{1f}{}\\u{1f}{}\\u{1f}{}\\u{1f}{}"',
-  'tenant_id, scope.module_name, scope.entity_name, scope.schema_version',
-  'SELECT pg_advisory_xact_lock(hashtextextended($1, 0))',
-]) {
-  if (!lock.includes(marker)) fail(`${recoveryPath} scope lock is missing ${marker}`);
-}
-
-const runner = requireMarkers(runnerPath, [
-  '"reconcile\\u{1f}{}\\u{1f}{}\\u{1f}{}\\u{1f}{}"',
-  'SELECT pg_advisory_xact_lock(hashtextextended($1, 0))',
-  'IndexReconciliationRunError::DeadLettered',
-]);
-if (!runner.includes("state IN ('pending', 'running', 'succeeded', 'failed')")) {
-  fail(`${runnerPath} failed-scope admission must remain active`);
-}
-
-const updateStart = recovery.indexOf('fn update_failed_job_sql(');
-const updateEnd = recovery.indexOf('\nfn insert_audit_sql(', updateStart);
-const update = recovery.slice(updateStart, updateEnd);
-for (const marker of [
-  "state = 'pending'",
-  'cursor = {prefix}6',
-  'attempt_count = 0',
-  'available_at = CURRENT_TIMESTAMP',
-  'lease_owner = NULL',
-  'lease_expires_at = NULL',
-  'heartbeat_at = NULL',
-  'cancel_requested = FALSE',
-  'last_error_code = NULL',
-  'last_error_details = NULL',
-  'completed_at = NULL',
-  'retry_epoch = {prefix}5',
-  "kind = 'reconcile'",
-  "state = 'failed'",
-  'attempt_count = {prefix}3',
-  'retry_epoch = {prefix}4',
-]) {
-  if (!update.includes(marker)) fail(`${recoveryPath} failed-job reset is missing ${marker}`);
-}
-
 const production = recovery.split('\n#[cfg(test)]')[0];
 for (const forbidden of [
-  'INSERT INTO index_jobs',
-  '.sources.scan(',
-  '.sources.load(',
-  'tokio::spawn',
-  'spawn_blocking',
-  'tokio::time::sleep',
-  'Router::new',
-  'async_graphql',
-  'poll',
-  'scheduler',
+  'INSERT INTO index_jobs', '.sources.scan(', 'tokio::spawn', 'tokio::time::sleep',
+  'Router::new', 'async_graphql',
 ]) {
-  if (production.includes(forbidden)) {
-    fail(`${recoveryPath} production boundary contains forbidden marker ${forbidden}`);
-  }
-}
-if (production.includes('Storage(String)') || production.includes('Storage(#[source]')) {
-  fail(`${recoveryPath} storage errors must not retain database details`);
+  if (production.includes(forbidden)) fail(`${recoveryPath} contains ${forbidden}`);
 }
 
-requireMarkers(postgresPath, [
-  'mod source_reconciliation_recovery;',
-  'pub use source_reconciliation_recovery::{',
-  'IndexReconciliationRecoveryError, IndexReconciliationRequeueOutcome,',
-  'IndexReconciliationRequeueRequest, PostgresIndexReconciliationRecoveryStore,',
-  'PostgresIndexReconciliationDeadLetterInspector,',
-  'PostgresIndexReconciliationRunner,',
-]);
-
-const server = requireMarkers(serverPath, [
-  'recovery: rustok_index::infrastructure::postgres::PostgresIndexReconciliationRecoveryStore,',
-  'Recovery(#[from] rustok_index::infrastructure::postgres::IndexReconciliationRecoveryError),',
+requireMarkers(operatorPath, [
   'pub async fn requeue_dead_letter(',
   'context.authorize_for(context.tenant_id())?;',
   'IndexReconciliationRequeueRequest::new(',
   'context.tenant_id(),',
   'context.actor_id(),',
   '.requeue_failed(request)',
-  'PostgresIndexReconciliationRecoveryStore::new(',
-  'dead_letter_requeue_authorizes_before_request_validation',
 ]);
-const requeueStart = server.indexOf('    pub async fn requeue_dead_letter(');
-const requeueEnd = server.indexOf('\n}\n\nimpl fmt::Debug', requeueStart);
-if (requeueStart < 0 || requeueEnd <= requeueStart) {
-  fail(`${serverPath} guarded requeue method is malformed`);
-}
-const requeue = server.slice(requeueStart, requeueEnd);
-for (const forbidden of ['tenant_id: Uuid', 'actor_id: Uuid']) {
-  if (requeue.includes(forbidden)) {
-    fail(`${serverPath} guarded requeue accepts caller-selected ${forbidden}`);
-  }
-}
-const authorization = requeue.indexOf('context.authorize_for(context.tenant_id())?;');
-const request = requeue.indexOf('IndexReconciliationRequeueRequest::new(');
-const tenant = requeue.indexOf('context.tenant_id(),', request);
-const actor = requeue.indexOf('context.actor_id(),', tenant);
-const delegation = requeue.indexOf('.requeue_failed(request)');
-if (
-  authorization < 0
-  || request <= authorization
-  || tenant <= request
-  || actor <= tenant
-  || delegation <= actor
-) {
-  fail(`${serverPath} must authorize, bind context tenant/actor, then delegate`);
-}
-for (const forbidden of ['SELECT ', 'INSERT ', 'UPDATE ', 'DELETE ', "state = 'pending'"]) {
-  if (requeue.includes(forbidden)) {
-    fail(`${serverPath} guarded requeue duplicates engine detail ${forbidden}`);
-  }
-}
-
+requireMarkers(schedulerPath, [
+  "state = 'pending' AND available_at <= CURRENT_TIMESTAMP",
+  '.runner',
+  '.run(request)',
+]);
 requireMarkers(docsPath, [
   'Status: `source_complete_authorized_server_composition_transport_pending`.',
-  'same PostgreSQL transaction-scoped advisory lock used by normal reconciliation admission',
   'preserves the existing job UUID',
-  'increments `retry_epoch`',
-  'appends an immutable actor/reason audit record',
-  'The audit insert and job reset commit or roll back together.',
-  '## Authorized server composition',
+  'The audit insert and job reset commit or roll back together',
   'accepts no tenant or actor argument',
-  'Authorization occurs before job/reason validation',
-  'GraphQL, HTTP, CLI, MCP, native admin',
-  'automatic retry, backoff, exhaustion, scheduling, and graceful shutdown',
+  'The module-owned host scheduler is additive and unchanged by manual recovery',
+  'Automatic retry creates no recovery audit',
   'maintainer-run',
 ]);
 requireMarkers(serverDocsPath, [
-  'Status: `source_complete_transport_and_scheduling_pending`.',
-  'tenant/actor-bound `requeue_dead_letter(context, job_id, reason)`',
-  'caller-selected tenant or actor identity for recovery',
-  'The same-job failed-to-pending reset',
-]);
-requireMarkers(docsIndexPath, [
-  '[M6 Reconciliation Dead-letter Inspection](./m6-reconciliation-dead-letter-inspection.md)',
-  '[M6 Reconciliation Dead-letter Requeue](./m6-reconciliation-dead-letter-requeue.md)',
+  'Status: `source_complete_transport_and_owner_execution_pending`.',
+  'The operator runtime does not expose or own that scheduler',
 ]);
 requireMarkers(planPath, [
   '- [ ] Add bounded retry/backoff, dead-letter state, and global scheduling ownership.',
   '- [ ] Add drift diagnosis, targeted repair commands, and admitted repair evidence.',
 ]);
-requireMarkers(aggregatePath, [
-  "'verify-index-reconciliation-dead-letter-inspection.mjs'",
+requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-reconciliation-dead-letter-requeue.mjs'",
-  "'verify-index-server-reconciliation-guard.mjs'",
+  "'verify-index-reconciliation-host-scheduler.mjs'",
 ]);
 
 console.log('[verify-index-reconciliation-dead-letter-requeue] OK');

--- a/scripts/verify/verify-index-reconciliation-host-scheduler.mjs
+++ b/scripts/verify/verify-index-reconciliation-host-scheduler.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-reconciliation-host-scheduler] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const cargoPath = 'crates/rustok-index/Cargo.toml';
+const libPath = 'crates/rustok-index/src/lib.rs';
+const postgresPath = 'crates/rustok-index/src/infrastructure/postgres/mod.rs';
+const schedulerPath =
+  'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_scheduler.rs';
+const runnerPath =
+  'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner.rs';
+const replayRuntimePath =
+  'crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs';
+const runtimePath = 'crates/rustok-runtime/src/lib.rs';
+const appRuntimePath = 'apps/server/src/services/app_runtime.rs';
+const docsPath = 'crates/rustok-index/docs/m6-reconciliation-host-scheduler.md';
+const retryDocsPath =
+  'crates/rustok-index/docs/m6-reconciliation-retry-transition-store.md';
+const runnerDocsPath =
+  'crates/rustok-index/docs/m6-reconciliation-runner-retry-wiring.md';
+const docsIndexPath = 'crates/rustok-index/docs/README.md';
+const planPath = 'crates/rustok-index/docs/implementation-plan.md';
+const aggregatePath = 'scripts/verify/verify-index-query-contract.mjs';
+
+requireMarkers(cargoPath, [
+  'rustok-api.workspace = true',
+  'rustok-core.workspace = true',
+  'rustok-runtime.workspace = true',
+]);
+
+const scheduler = requireMarkers(schedulerPath, [
+  'pub const INDEX_RECONCILIATION_WORKER: &str = "index_reconciliation";',
+  'const RECONCILIATION_WORK_ITEM_CONTRACT: &str = "index_reconciliation_scheduler_item_v1";',
+  'const DEFAULT_PAGE_LIMIT: usize = 100;',
+  'const DEFAULT_MAX_PAGES: usize = 8;',
+  'const DEFAULT_HEARTBEAT_EVERY_PAGES: usize = 1;',
+  'const DEFAULT_LEASE_SECONDS: u64 = 300;',
+  'pub struct IndexReconciliationSchedulerPolicy',
+  'pub struct PostgresIndexReconciliationWorkAdapter',
+  'pub(crate) struct IndexReconciliationWorkRegistration;',
+  'impl ModuleWorkRegistration for IndexReconciliationWorkRegistration',
+  'impl ModuleWorkSource for PostgresIndexReconciliationWorkAdapter',
+  'impl ModuleWorkHandler for PostgresIndexReconciliationWorkAdapter',
+  '#[serde(deny_unknown_fields)]',
+]);
+const production = scheduler.split('\n#[cfg(test)]')[0];
+for (const forbidden of [
+  'tokio::spawn',
+  'spawn_blocking',
+  'tokio::time::sleep',
+  'std::thread::sleep',
+  'loop {',
+  'Router::new',
+  'async_graphql',
+  'reqwest',
+  'INSERT INTO index_jobs',
+  'UPDATE index_jobs',
+  'DELETE FROM index_jobs',
+]) {
+  if (production.includes(forbidden)) {
+    fail(`${schedulerPath} production boundary contains forbidden marker ${forbidden}`);
+  }
+}
+
+const registrationStart = production.indexOf('impl ModuleWorkRegistration');
+const sourceStart = production.indexOf('impl ModuleWorkSource', registrationStart);
+const registration = production.slice(registrationStart, sourceStart);
+for (const marker of [
+  'host.shared_get::<SharedIndexSourceRegistry>()',
+  'return Ok(());',
+  'host.shared_get::<SharedIndexSchemaRegistry>()',
+  'index.reconciliation_scheduler.missing_schema_registry',
+  'IndexReconciliationSchedulerPolicy::default()',
+  '.register_with(scheduler)',
+]) {
+  if (!registration.includes(marker)) {
+    fail(`${schedulerPath} registration is missing ${marker}`);
+  }
+}
+
+const claimStart = production.indexOf('    async fn claim(');
+const completeStart = production.indexOf('    async fn complete(', claimStart);
+const claim = production.slice(claimStart, completeStart);
+const slugCheck = claim.indexOf('worker_slug != INDEX_RECONCILIATION_WORKER');
+const discovery = claim.indexOf('discover_due_reconciliation(&self.db, &self.sources).await?');
+if (slugCheck < 0 || discovery <= slugCheck) {
+  fail(`${schedulerPath} must reject the wrong worker slug before database discovery`);
+}
+
+const sqlStart = production.indexOf('fn due_reconciliation_sql(');
+const sqlEnd = production.indexOf('\nfn invalid_stored_job(', sqlStart);
+const sql = production.slice(sqlStart, sqlEnd);
+for (const marker of [
+  'ROW_NUMBER() OVER',
+  'PARTITION BY tenant_id, module_name, entity_name, schema_version',
+  "WHEN 'succeeded' THEN 0",
+  "WHEN 'running' THEN 1",
+  "WHEN 'pending' THEN 2",
+  "kind = 'reconcile'",
+  "scope_kind = 'schema'",
+  "state IN ('pending', 'running', 'succeeded', 'failed')",
+  'scope_rank = 1',
+  "state = 'pending' AND available_at <= CURRENT_TIMESTAMP",
+  "state = 'running' AND lease_expires_at <= CURRENT_TIMESTAMP",
+  "CASE state WHEN 'running' THEN 0 ELSE 1 END",
+  'LIMIT 1',
+]) {
+  if (!sql.includes(marker)) fail(`${schedulerPath} due discovery SQL is missing ${marker}`);
+}
+for (const forbidden of ['INSERT ', 'UPDATE ', 'DELETE ', 'last_error_details']) {
+  if (sql.includes(forbidden)) fail(`${schedulerPath} due discovery SQL contains ${forbidden}`);
+}
+
+const decodeStart = production.indexOf('fn decode_due_work(');
+const backendStart = production.indexOf('fn ensure_supported_backend(', decodeStart);
+const decode = production.slice(decodeStart, backendStart);
+for (const marker of [
+  'tenant_id.is_nil() || job_id.is_nil()',
+  'schema_version == 0',
+  'serde_json::from_value(request_json)',
+  'request.contract != RECONCILIATION_JOB_REQUEST_CONTRACT',
+  'request.pass_count == 0',
+  'sources.source_for_schema(&schema)',
+  'source.source_name() != request.source_name',
+  'IndexReconciliationRunRequest::new(',
+]) {
+  if (!decode.includes(marker)) fail(`${schedulerPath} stored work validation is missing ${marker}`);
+}
+
+const executeStart = production.indexOf('    async fn execute(');
+const discoverStart = production.indexOf('\nasync fn discover_due_reconciliation(', executeStart);
+const execute = production.slice(executeStart, discoverStart);
+for (const marker of [
+  'Self::decode_item(&item)?',
+  'format!("index-reconciliation-{}", invocation_id.simple())',
+  'self.policy.page_limit()',
+  'self.policy.max_pages()',
+  'self.policy.heartbeat_every_pages()',
+  'self.policy.lease_duration()',
+  '.runner',
+  '.run(request)',
+  'IndexReconciliationRunStatus::Cancelled => ModuleWorkOutcome::Cancelled',
+  'IndexReconciliationRunStatus::Busy',
+  'IndexReconciliationRunStatus::RetryScheduled',
+  'IndexReconciliationRunStatus::FailedPermanent',
+  'IndexReconciliationRunStatus::FailedExhausted',
+  'ModuleWorkOutcome::Completed',
+  'RUN_FAILED_CODE.to_owned()',
+]) {
+  if (!execute.includes(marker)) fail(`${schedulerPath} handler is missing ${marker}`);
+}
+for (const forbidden of ['error.to_string()', 'format!("{error', 'last_error_details']) {
+  if (execute.includes(forbidden)) fail(`${schedulerPath} handler exposes ${forbidden}`);
+}
+
+const complete = production.slice(completeStart, production.indexOf('\n}\n\n#[async_trait]', completeStart));
+if (!complete.includes('The canonical reconciliation runner owns every durable transition.')) {
+  fail(`${schedulerPath} completion boundary must remain runner-owned`);
+}
+
+requireMarkers(runnerPath, [
+  'lock_reconciliation_scope(transaction, request, backend).await?;',
+  'claim_job_sql(backend)',
+  'attempt_count = {prefix}4',
+  'IndexReconciliationRunStatus::RetryScheduled',
+  'IndexReconciliationRunStatus::FailedPermanent',
+  'IndexReconciliationRunStatus::FailedExhausted',
+]);
+
+requireMarkers(postgresPath, [
+  'mod source_reconciliation_scheduler;',
+  'pub use source_reconciliation_scheduler::{',
+  'INDEX_RECONCILIATION_WORKER, IndexReconciliationSchedulerPolicy,',
+  'PostgresIndexReconciliationWorkAdapter,',
+  'pub(crate) use source_reconciliation_scheduler::IndexReconciliationWorkRegistration;',
+]);
+requireMarkers(libPath, [
+  'host-owned due reconciliation scheduling through the generic module-work lifecycle',
+  'IndexReconciliationSchedulerPolicy',
+  'PostgresIndexReconciliationWorkAdapter',
+  'INDEX_RECONCILIATION_WORKER',
+  'register_postgres_index_reconciliation_work',
+  'IndexReconciliationSchedulerCompositionError',
+]);
+
+requireMarkers(replayRuntimePath, [
+  'ReconciliationScheduler(#[from] IndexReconciliationSchedulerCompositionError)',
+  'register_postgres_index_reconciliation_work(extensions)?;',
+  'publishes neither a false replay capability',
+  'nor an empty Index module-work registration',
+  'assert!(!extensions.contains::<ModuleWorkRegistrations>());',
+  'assert!(extensions.contains::<ModuleWorkRegistrations>());',
+]);
+
+requireMarkers(runtimePath, [
+  'pub struct ModuleWorkScheduler',
+  'pub async fn run_once(&self)',
+  'pub async fn run_until_stopped(',
+  'A stop prevents future claims',
+  'work already claimed by an',
+  'adapter is allowed to finish its canonical completion path',
+]);
+requireMarkers(appRuntimePath, [
+  'initialize_module_work_runtime',
+  'ModuleWorkScheduler::new()',
+  '.register_all(&host, &scheduler)',
+  'runs_background_workers()',
+  'StopHandle',
+  '.run_until_stopped(stop, std::time::Duration::from_secs(1))',
+]);
+
+requireMarkers(docsPath, [
+  'Status: `source_complete_owner_execution_pending`.',
+  'The generic host scheduler remains the only polling and lifecycle owner',
+  'Only rank one may become work',
+  'Discovery performs no insert, update, delete, lease acquisition',
+  'Multiple hosts may discover the same due row',
+  'The canonical retry/backoff/dead-letter/global-scheduling plan item remains open',
+  'maintainer-run',
+]);
+requireMarkers(retryDocsPath, [
+  'Status: `host_scheduler_source_complete_owner_execution_pending`.',
+  'generic host `ModuleWorkScheduler`',
+  'Fleet duplicates remain safe',
+]);
+requireMarkers(runnerDocsPath, [
+  'Status: `host_scheduler_source_complete_owner_execution_pending`.',
+  'The generic `ModuleWorkScheduler` owns polling cadence and graceful StopHandle shutdown',
+  'only one pending or expired-running attempt can acquire',
+]);
+requireMarkers(docsIndexPath, [
+  '[M6 Reconciliation Host Scheduler](./m6-reconciliation-host-scheduler.md)',
+]);
+requireMarkers(planPath, [
+  '- [ ] Add bounded retry/backoff, dead-letter state, and global scheduling ownership.',
+  '- [ ] Add drift diagnosis, targeted repair commands, and admitted repair evidence.',
+]);
+requireMarkers(aggregatePath, [
+  "'verify-index-reconciliation-retry-store.mjs'",
+  "'verify-index-reconciliation-runner-retry.mjs'",
+  "'verify-index-reconciliation-host-scheduler.mjs'",
+]);
+
+console.log('[verify-index-reconciliation-host-scheduler] OK');

--- a/scripts/verify/verify-index-reconciliation-retry-store.mjs
+++ b/scripts/verify/verify-index-reconciliation-retry-store.mjs
@@ -20,159 +20,48 @@ const requireMarkers = (relative, markers) => {
 
 const retryPath =
   'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_retry.rs';
-const postgresPath = 'crates/rustok-index/src/infrastructure/postgres/mod.rs';
-const libPath = 'crates/rustok-index/src/lib.rs';
 const runnerPath =
   'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner.rs';
+const schedulerPath =
+  'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_scheduler.rs';
 const docsPath =
   'crates/rustok-index/docs/m6-reconciliation-retry-transition-store.md';
-const docsIndexPath = 'crates/rustok-index/docs/README.md';
+const schedulerDocsPath =
+  'crates/rustok-index/docs/m6-reconciliation-host-scheduler.md';
 const planPath = 'crates/rustok-index/docs/implementation-plan.md';
 const aggregatePath = 'scripts/verify/verify-index-query-contract.mjs';
 
 const retry = requireMarkers(retryPath, [
   'const MAX_RECONCILIATION_ATTEMPTS: u32 = 100;',
   'const MAX_BACKOFF_SECONDS: u64 = 86_400;',
-  'const MAX_FAILURE_CODE_BYTES: usize = 128;',
-  'const MAX_WORKER_ID_BYTES: usize = 191;',
   'const RECONCILIATION_FAILURE_CONTRACT: &str = "index_reconciliation_run_failure_v1";',
   'const RECONCILIATION_PAGE_FAILURE_CODE: &str = "index.reconciliation_page_failed";',
-  'pub struct IndexReconciliationRetryLease',
-  'pub enum IndexReconciliationRetryFailureKind',
-  'pub struct IndexReconciliationRetryFailure',
   'pub struct IndexReconciliationRetryPolicy',
-  'pub enum IndexReconciliationRetryDisposition',
-  'pub enum IndexReconciliationRetryError',
   'pub struct PostgresIndexReconciliationRetryStore',
-  'pub async fn record_failure(',
   'IndexReconciliationRetryDisposition::RetryScheduled',
   'IndexReconciliationRetryDisposition::TerminalPermanent',
   'IndexReconciliationRetryDisposition::TerminalExhausted',
   'Self::new(5, Duration::from_secs(5), Duration::from_secs(300))',
-  'default_policy_uses_bounded_exponential_backoff',
-  'diagnostics_keep_the_existing_inspection_contract',
 ]);
-
 const production = retry.split('\n#[cfg(test)]')[0];
 for (const forbidden of [
-  'INSERT INTO index_jobs',
-  'DELETE FROM index_jobs',
-  'tokio::spawn',
-  'spawn_blocking',
-  'tokio::time::sleep',
-  'std::thread::sleep',
-  'loop {',
-  'Router::new',
-  'async_graphql',
-  'reqwest',
+  'INSERT INTO index_jobs', 'DELETE FROM index_jobs', 'tokio::spawn',
+  'tokio::time::sleep', 'std::thread::sleep', 'loop {', 'Router::new',
 ]) {
-  if (production.includes(forbidden)) {
-    fail(`${retryPath} production boundary contains forbidden marker ${forbidden}`);
-  }
+  if (production.includes(forbidden)) fail(`${retryPath} contains ${forbidden}`);
 }
-if (production.includes('Storage(String)') || production.includes('Storage(#[source]')) {
-  fail(`${retryPath} storage errors must not retain database details`);
-}
-
-const policyStart = production.indexOf('impl IndexReconciliationRetryPolicy');
-const policyEnd = production.indexOf('\nimpl Default for IndexReconciliationRetryPolicy', policyStart);
-const policy = production.slice(policyStart, policyEnd);
 for (const marker of [
-  '1..=MAX_RECONCILIATION_ATTEMPTS',
-  'validate_backoff(base_backoff)?',
-  'validate_backoff(max_backoff)?',
-  'base_backoff_seconds > max_backoff_seconds',
-  'failure_kind == IndexReconciliationRetryFailureKind::Permanent',
-  'attempt_count >= self.max_attempts',
-  'saturating_mul(multiplier)',
-  '.min(self.max_backoff_seconds)',
-  '.checked_add(1)',
-]) {
-  if (!policy.includes(marker)) fail(`${retryPath} policy is missing ${marker}`);
-}
-
-const recordStart = production.indexOf('    pub async fn record_failure(');
-const recordEnd = production.indexOf('\n}\n\nasync fn terminalize_failure(', recordStart);
-const record = production.slice(recordStart, recordEnd);
-const evaluate = record.indexOf('.evaluate(lease.attempt_count(), failure.kind())?;');
-const backend = record.indexOf('let backend = self.db.get_database_backend();');
-const details = record.indexOf('let details = failure_details(failure);');
-const transition = record.indexOf('let rows_affected = match disposition');
-const fence = record.indexOf('if rows_affected != 1');
-if (evaluate < 0 || backend <= evaluate || details <= backend || transition <= details || fence <= transition) {
-  fail(`${retryPath} must evaluate policy, validate backend, build diagnostics, transition, then fence`);
-}
-
-const scheduleStart = production.indexOf('fn schedule_retry_sql(');
-const terminalStart = production.indexOf('fn terminal_failure_sql(', scheduleStart);
-const schedule = production.slice(scheduleStart, terminalStart);
-for (const marker of [
-  "state = 'pending'",
-  'available_at = {available_at}',
-  'completed_at = NULL',
-  'last_error_code = {prefix}6',
-  'last_error_details = {prefix}7',
-  "kind = 'reconcile'",
-  "state = 'running'",
-  'lease_owner = {prefix}3',
-  'attempt_count = {prefix}4',
-  'lease_expires_at > CURRENT_TIMESTAMP',
-  'cancel_requested = FALSE',
-]) {
-  if (!schedule.includes(marker)) fail(`${retryPath} retry SQL is missing ${marker}`);
-}
-const terminal = production.slice(terminalStart);
-for (const marker of [
-  "state = 'failed'",
-  'completed_at = CURRENT_TIMESTAMP',
-  'last_error_code = {prefix}5',
-  'last_error_details = {prefix}6',
-  "kind = 'reconcile'",
-  "state = 'running'",
-  'lease_owner = {prefix}3',
-  'attempt_count = {prefix}4',
-  'lease_expires_at > CURRENT_TIMESTAMP',
-  'cancel_requested = FALSE',
-]) {
-  if (!terminal.includes(marker)) fail(`${retryPath} terminal SQL is missing ${marker}`);
-}
-
-const diagnosticsStart = production.indexOf('fn failure_details(');
-const diagnosticsEnd = production.indexOf('\nfn validate_backoff(', diagnosticsStart);
-const diagnostics = production.slice(diagnosticsStart, diagnosticsEnd);
-for (const marker of [
+  "state = 'pending'", 'available_at = {available_at}',
+  "state = 'failed'", 'completed_at = CURRENT_TIMESTAMP',
+  'lease_owner = {prefix}3', 'attempt_count = {prefix}4',
+  'lease_expires_at > CURRENT_TIMESTAMP', 'cancel_requested = FALSE',
   '"contract": RECONCILIATION_FAILURE_CONTRACT',
   '"dependency_code": failure.code()',
-  '"retryable": failure.kind() == IndexReconciliationRetryFailureKind::Retryable',
 ]) {
-  if (!diagnostics.includes(marker)) fail(`${retryPath} diagnostics are missing ${marker}`);
-}
-for (const forbidden of [
-  'tenant_id', 'job_id', 'worker_id', 'attempt_count', 'max_attempts',
-  'retry_after', 'next_attempt', 'retry_epoch',
-]) {
-  if (diagnostics.includes(forbidden)) fail(`${retryPath} diagnostics contain forbidden field ${forbidden}`);
+  if (!production.includes(marker)) fail(`${retryPath} is missing ${marker}`);
 }
 
-requireMarkers(postgresPath, [
-  'mod source_reconciliation_retry;',
-  'pub use source_reconciliation_retry::{',
-  'IndexReconciliationRetryDisposition, IndexReconciliationRetryError,',
-  'IndexReconciliationRetryFailure, IndexReconciliationRetryFailureKind,',
-  'IndexReconciliationRetryLease, IndexReconciliationRetryPolicy,',
-  'PostgresIndexReconciliationRetryStore,',
-  'PostgresIndexReconciliationRecoveryStore,',
-  'PostgresIndexReconciliationRunner,',
-]);
-requireMarkers(libPath, [
-  'bounded reconciliation retry transitions',
-  'IndexReconciliationRetryDisposition',
-  'IndexReconciliationRetryLease',
-  'IndexReconciliationRetryPolicy',
-  'PostgresIndexReconciliationRetryStore',
-]);
-
-const runner = requireMarkers(runnerPath, [
+requireMarkers(runnerPath, [
   'PostgresIndexReconciliationRetryStore, PostgresMutationStore,',
   'IndexReconciliationRetryLease::new(',
   'retry_store.record_failure(&retry_lease, &failure).await',
@@ -180,24 +69,22 @@ const runner = requireMarkers(runnerPath, [
   'IndexReconciliationRunStatus::FailedPermanent',
   'IndexReconciliationRunStatus::FailedExhausted',
 ]);
-for (const forbidden of ['async fn finish_failure(', 'fn finish_failure_sql(']) {
-  if (runner.includes(forbidden)) fail(`${runnerPath} retains superseded failure SQL marker ${forbidden}`);
-}
-
+requireMarkers(schedulerPath, [
+  'PostgresIndexReconciliationRunner',
+  '.runner',
+  '.run(request)',
+  'impl ModuleWorkRegistration for IndexReconciliationWorkRegistration',
+]);
 requireMarkers(docsPath, [
-  'Status: `runner_complete_scheduler_wiring_pending`.',
-  '`PostgresIndexReconciliationRunner` now classifies page failures',
+  'Status: `host_scheduler_source_complete_owner_execution_pending`.',
   'maximum attempts: `5`',
   'delays after attempts 1-4: `5`, `10`, `20`, and `40` seconds',
-  '`RetryScheduled`',
-  '`FailedPermanent`',
-  '`FailedExhausted`',
-  'global scheduling ownership is not part of this slice',
+  'Fleet duplicates remain safe',
   'maintainer-run',
 ]);
-requireMarkers(docsIndexPath, [
-  '[M6 Reconciliation Retry Transition Store](./m6-reconciliation-retry-transition-store.md)',
-  '[M6 Reconciliation Runner Retry Wiring](./m6-reconciliation-runner-retry-wiring.md)',
+requireMarkers(schedulerDocsPath, [
+  'Status: `source_complete_owner_execution_pending`.',
+  'The generic host scheduler remains the only polling and lifecycle owner',
 ]);
 requireMarkers(planPath, [
   '- [ ] Add bounded retry/backoff, dead-letter state, and global scheduling ownership.',
@@ -205,8 +92,7 @@ requireMarkers(planPath, [
 ]);
 requireMarkers(aggregatePath, [
   "'verify-index-reconciliation-retry-store.mjs'",
-  "'verify-index-reconciliation-runner-retry.mjs'",
-  "'verify-index-reconciliation-dead-letter-admission.mjs'",
+  "'verify-index-reconciliation-host-scheduler.mjs'",
 ]);
 
 console.log('[verify-index-reconciliation-retry-store] OK');

--- a/scripts/verify/verify-index-reconciliation-runner-retry.mjs
+++ b/scripts/verify/verify-index-reconciliation-runner-retry.mjs
@@ -20,214 +20,85 @@ const requireMarkers = (relative, markers) => {
 
 const runnerPath =
   'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner.rs';
-const testsPath =
-  'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner_tests.rs';
-const postgresTargetPath =
-  'crates/rustok-index/tests/source_reconciliation_dead_letter_admission_postgres_test.rs';
-const retryPath =
-  'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_retry.rs';
+const schedulerPath =
+  'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_scheduler.rs';
 const docsPath =
   'crates/rustok-index/docs/m6-reconciliation-runner-retry-wiring.md';
-const storeDocsPath =
-  'crates/rustok-index/docs/m6-reconciliation-retry-transition-store.md';
-const docsIndexPath = 'crates/rustok-index/docs/README.md';
+const schedulerDocsPath =
+  'crates/rustok-index/docs/m6-reconciliation-host-scheduler.md';
+const testsPath =
+  'crates/rustok-index/src/infrastructure/postgres/source_reconciliation_runner_tests.rs';
 const planPath = 'crates/rustok-index/docs/implementation-plan.md';
 const aggregatePath = 'scripts/verify/verify-index-query-contract.mjs';
 
 const runner = requireMarkers(runnerPath, [
   'IndexReconciliationRetryDisposition, IndexReconciliationRetryError,',
-  'IndexReconciliationRetryFailure, IndexReconciliationRetryLease,',
   'PostgresIndexReconciliationRetryStore, PostgresMutationStore,',
-  'RetryScheduled,',
-  'FailedPermanent,',
-  'FailedExhausted,',
-  'retry_after: Option<Duration>,',
-  'next_attempt: Option<u32>,',
-  'pub fn retry_after(&self) -> Option<Duration>',
-  'pub fn next_attempt(&self) -> Option<u32>',
-  'async fn finish_page_error(',
-  'fn retry_failure(',
+  'RetryScheduled,', 'FailedPermanent,', 'FailedExhausted,',
+  'retry_after: Option<Duration>,', 'next_attempt: Option<u32>,',
+  'async fn finish_page_error(', 'fn retry_failure(',
   'RetryTransition(#[source] IndexReconciliationRetryError)',
 ]);
-
 const production = runner.split('\n#[cfg(test)]')[0];
 for (const forbidden of [
-  'const RECONCILIATION_FAILURE_CONTRACT',
-  'const RECONCILIATION_PAGE_FAILURE_CODE',
-  'async fn finish_failure(',
-  'fn finish_failure_sql(',
-  'json!({',
-  'tokio::spawn',
-  'spawn_blocking',
-  'tokio::time::sleep',
-  'std::thread::sleep',
-  'loop {',
-  'Router::new',
-  'async_graphql',
-  'reqwest',
+  'async fn finish_failure(', 'fn finish_failure_sql(', 'tokio::spawn',
+  'tokio::time::sleep', 'std::thread::sleep', 'loop {', 'Router::new',
 ]) {
-  if (production.includes(forbidden)) {
-    fail(`${runnerPath} production boundary contains forbidden marker ${forbidden}`);
-  }
+  if (production.includes(forbidden)) fail(`${runnerPath} contains ${forbidden}`);
 }
-
 const callMarker = 'finish_page_error(&self.db, &lease, outcome, run_error).await';
 if (production.split(callMarker).length - 1 !== 4) {
-  fail(`${runnerPath} must route exactly four page-failure call sites through the retry boundary`);
-}
-
-const outcomeStart = production.indexOf('let mut outcome = IndexReconciliationRunOutcome {');
-const loopStart = production.indexOf('for page_index in 0..request.max_pages', outcomeStart);
-if (outcomeStart < 0 || loopStart <= outcomeStart) {
-  fail(`${runnerPath} acquired outcome initialization is missing`);
-}
-const outcome = production.slice(outcomeStart, loopStart);
-for (const marker of [
-  'status: IndexReconciliationRunStatus::Yielded',
-  'job_id: Some(lease.job_id)',
-  'attempt_count: Some(lease.attempt_count)',
-  'retry_after: None',
-  'next_attempt: None',
-]) {
-  if (!outcome.includes(marker)) fail(`${runnerPath} acquired outcome is missing ${marker}`);
-}
-
-const finishStart = production.indexOf('async fn finish_page_error(');
-const finishEnd = production.indexOf('\nasync fn yield_for_resume(', finishStart);
-if (finishStart < 0 || finishEnd <= finishStart) {
-  fail(`${runnerPath} retry completion boundary is malformed`);
-}
-const finish = production.slice(finishStart, finishEnd);
-const classify = finish.indexOf('let failure = retry_failure(&error)?;');
-const lease = finish.indexOf('let retry_lease = IndexReconciliationRetryLease::new(');
-const store = finish.indexOf('let retry_store = PostgresIndexReconciliationRetryStore::new(db.clone());');
-const record = finish.indexOf('retry_store.record_failure(&retry_lease, &failure).await');
-if (classify < 0 || lease <= classify || store <= lease || record <= store) {
-  fail(`${runnerPath} must classify, bind the exact lease, construct the store, then record failure`);
+  fail(`${runnerPath} must retain exactly four page-failure call sites`);
 }
 for (const marker of [
   'IndexReconciliationRetryDisposition::RetryScheduled {',
   'outcome.status = IndexReconciliationRunStatus::RetryScheduled;',
-  'outcome.retry_after = Some(retry_after);',
-  'outcome.next_attempt = Some(next_attempt);',
   'IndexReconciliationRetryDisposition::TerminalPermanent',
   'outcome.status = IndexReconciliationRunStatus::FailedPermanent;',
   'IndexReconciliationRetryDisposition::TerminalExhausted',
   'outcome.status = IndexReconciliationRunStatus::FailedExhausted;',
   'Err(IndexReconciliationRetryError::LeaseLost)',
   'if cancel_if_requested(db, lease).await?',
-  'IndexReconciliationRunStatus::Cancelled',
-  'IndexReconciliationRunError::LeaseLost {',
-  'Err(error) => Err(IndexReconciliationRunError::RetryTransition(error))',
-]) {
-  if (!finish.includes(marker)) fail(`${runnerPath} retry completion is missing ${marker}`);
-}
-for (const forbidden of [
-  'dependency_code',
-  'last_error_details',
-  'error.to_string()',
-  'format!("{error',
-]) {
-  if (finish.includes(forbidden)) {
-    fail(`${runnerPath} retry outcome boundary exposes forbidden marker ${forbidden}`);
-  }
-}
-
-const classifyStart = production.indexOf('fn retry_failure(');
-const classifyEnd = production.indexOf('\nfn empty_outcome(', classifyStart);
-if (classifyStart < 0 || classifyEnd <= classifyStart) {
-  fail(`${runnerPath} failure classifier is malformed`);
-}
-const classifier = production.slice(classifyStart, classifyEnd);
-for (const marker of [
-  'IndexReconciliationRunError::Source(IndexSourceError::SourceFailure',
-  'IndexSourceFailureKind::Retryable',
-  'IndexReconciliationRetryFailure::retryable(failure.code())',
-  'IndexSourceFailureKind::Permanent',
-  'IndexReconciliationRetryFailure::permanent(failure.code())',
-  'IndexReconciliationRunError::MutationFailed',
-  'IndexReplayFailureKind::Retryable',
-  'IndexReplayFailureKind::Permanent',
-  'IndexReconciliationRunError::Source(_) =>',
   'IndexReconciliationRetryFailure::permanent("source_contract_invalid")',
   'IndexReconciliationRetryFailure::permanent("reconciliation_contract_invalid")',
-  'failure.map_err(IndexReconciliationRunError::RetryTransition)',
 ]) {
-  if (!classifier.includes(marker)) fail(`${runnerPath} failure classifier is missing ${marker}`);
+  if (!production.includes(marker)) fail(`${runnerPath} is missing ${marker}`);
 }
 
-const retry = requireMarkers(retryPath, [
-  'Self::new(5, Duration::from_secs(5), Duration::from_secs(300))',
-  "state = 'pending'",
-  "state = 'failed'",
-  'available_at = {available_at}',
-  'lease_owner = {prefix}3',
-  'attempt_count = {prefix}4',
-  'lease_expires_at > CURRENT_TIMESTAMP',
-  'cancel_requested = FALSE',
+requireMarkers(schedulerPath, [
+  'IndexReconciliationRunRequest::new(',
+  '.runner',
+  '.run(request)',
+  'IndexReconciliationRunStatus::Busy',
+  'IndexReconciliationRunStatus::RetryScheduled',
+  'IndexReconciliationRunStatus::FailedPermanent',
+  'IndexReconciliationRunStatus::FailedExhausted',
 ]);
-if (retry.includes('tokio::spawn') || retry.includes('tokio::time::sleep')) {
-  fail(`${retryPath} must remain task-free and sleep-free`);
-}
-
-const tests = requireMarkers(testsPath, [
+requireMarkers(testsPath, [
   'retryable_failure_schedules_due_attempts_and_terminally_exhausts',
   'permanent_failure_terminalizes_without_retry_metadata',
   'IndexReconciliationRunStatus::RetryScheduled',
   'IndexReconciliationRunStatus::FailedExhausted',
   'IndexReconciliationRunStatus::FailedPermanent',
-  'Some(Duration::from_secs(seconds))',
-  'assert_eq!(outcome.next_attempt(), Some(next_attempt));',
-  'IndexReconciliationRunStatus::Busy',
-  'fixture.make_retry_due().await;',
-  'attempt_count: 5',
-  'attempt_count: 1',
-  'IndexReconciliationRunError::DeadLettered',
-  "json_extract(last_error_details, '$.retryable')",
 ]);
-for (const forbidden of ['tokio::time::sleep', 'std::thread::sleep']) {
-  if (tests.includes(forbidden)) fail(`${testsPath} contains forbidden timing shortcut ${forbidden}`);
-}
-
-const postgresTarget = requireMarkers(postgresTargetPath, [
-  'failed_reconciliation_scope_blocks_new_jobs_without_exposing_details',
-  'IndexReconciliationRunStatus::FailedPermanent',
-  'first_outcome.retry_after(), None',
-  'first_outcome.next_attempt(), None',
-  'IndexReconciliationRunError::DeadLettered',
-  'private-reconciliation-failure-detail',
-]);
-if (postgresTarget.includes('IndexReconciliationRunError::Source(')) {
-  fail(`${postgresTargetPath} still expects the superseded first-run error contract`);
-}
-
 requireMarkers(docsPath, [
-  'Status: `runner_complete_host_scheduler_pending`.',
-  '`RetryScheduled`',
-  '`FailedPermanent`',
-  '`FailedExhausted`',
+  'Status: `host_scheduler_source_complete_owner_execution_pending`.',
+  '`RetryScheduled`', '`FailedPermanent`', '`FailedExhausted`',
   'attempt 1 failure -> pending for 5 seconds',
-  'attempt 5 retryable failure -> failed exhausted',
-  'An invocation before `available_at` receives the existing `Busy` outcome',
-  'The canonical retry/backoff/dead-letter/global-scheduling roadmap item remains open',
+  'The generic `ModuleWorkScheduler` owns polling cadence and graceful StopHandle shutdown',
   'maintainer-run',
 ]);
-requireMarkers(storeDocsPath, [
-  'Status: `runner_complete_scheduler_wiring_pending`.',
-  '`PostgresIndexReconciliationRunner` now classifies page failures',
-  'global scheduling ownership is not part of this slice',
-]);
-requireMarkers(docsIndexPath, [
-  '[M6 Reconciliation Runner Retry Wiring](./m6-reconciliation-runner-retry-wiring.md)',
+requireMarkers(schedulerDocsPath, [
+  'The adapter never claims `index_jobs` directly',
+  'The runner continues to own',
 ]);
 requireMarkers(planPath, [
   '- [ ] Add bounded retry/backoff, dead-letter state, and global scheduling ownership.',
   '- [ ] Add drift diagnosis, targeted repair commands, and admitted repair evidence.',
 ]);
 requireMarkers(aggregatePath, [
-  "'verify-index-reconciliation-retry-store.mjs'",
   "'verify-index-reconciliation-runner-retry.mjs'",
-  "'verify-index-reconciliation-dead-letter-admission.mjs'",
+  "'verify-index-reconciliation-host-scheduler.mjs'",
 ]);
 
 console.log('[verify-index-reconciliation-runner-retry] OK');

--- a/scripts/verify/verify-index-replay-runtime-composition.mjs
+++ b/scripts/verify/verify-index-replay-runtime-composition.mjs
@@ -18,163 +18,90 @@ const requireMarkers = (relative, markers) => {
   return source;
 };
 
-const indexRuntimePath = 'crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs';
-const indexRuntime = requireMarkers(indexRuntimePath, [
+const runtimePath = 'crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs';
+const runtime = requireMarkers(runtimePath, [
   'pub struct SharedIndexReplayRuntime',
-  'pub async fn run(',
-  'pub async fn request_cancel(',
   'pub enum IndexReplayRuntimeCompositionError',
   'AlreadyMaterialized',
   'MissingSchemaRegistry',
+  'ReconciliationScheduler(#[from] IndexReconciliationSchedulerCompositionError)',
   'pub fn materialize_postgres_index_replay_runtime(',
   'extensions.get::<SharedIndexSourceRegistry>().cloned()',
   '.get::<SharedIndexSchemaRegistry>()',
   'return Ok(None);',
+  'materialize_index_replay_dry_run_runtime(extensions)?;',
+  'register_postgres_index_reconciliation_work(extensions)?;',
   'PostgresIndexReplayRunner::new(',
   'extensions.insert(runtime.clone())',
-  'missing_source_registry_does_not_publish_false_replay_runtime',
+  'missing_source_registry_does_not_publish_false_replay_or_work_runtime',
   'source_registry_without_shared_schema_registry_fails_closed',
-  'complete_registries_materialize_one_shared_replay_runtime',
+  'complete_registries_materialize_replay_and_module_work_registration',
   'duplicate_replay_runtime_materialization_fails_closed',
+  'assert!(!extensions.contains::<ModuleWorkRegistrations>());',
+  'assert!(extensions.contains::<ModuleWorkRegistrations>());',
 ]);
 for (const forbidden of [
-  'tokio::spawn',
-  'tokio::time::sleep',
-  'loop {',
-  '.query_one(',
-  '.query_all(',
-  '.execute(',
-  '.begin()',
-  'permissions_for(',
-  'Permission::',
+  'tokio::spawn', 'tokio::time::sleep', 'loop {', '.query_one(',
+  '.query_all(', '.execute(', '.begin()', 'permissions_for(', 'Permission::',
 ]) {
-  if (indexRuntime.includes(forbidden)) {
-    fail(`${indexRuntimePath} contains host/IO/scheduler marker ${forbidden}`);
-  }
+  if (runtime.includes(forbidden)) fail(`${runtimePath} contains ${forbidden}`);
+}
+const dryRun = runtime.indexOf('materialize_index_replay_dry_run_runtime(extensions)?;');
+const work = runtime.indexOf('register_postgres_index_reconciliation_work(extensions)?;');
+const replay = runtime.indexOf('let runtime = SharedIndexReplayRuntime::new(', work);
+if (dryRun < 0 || work <= dryRun || replay <= work) {
+  fail(`${runtimePath} must publish dry-run, work registration, then replay runtime`);
 }
 
-const serverRuntimePath = 'apps/server/src/services/index_replay_runtime_composition.rs';
-const serverRuntime = requireMarkers(serverRuntimePath, [
+const serverPath = 'apps/server/src/services/index_replay_runtime_composition.rs';
+const server = requireMarkers(serverPath, [
   'pub struct IndexReplayOperatorContext',
   'pub struct IndexReplayOperatorRuntime',
-  'pub enum IndexReplayOperatorError',
   'Permission::MODULES_MANAGE',
   'permissions_for(&self.tenant_id, &self.actor_id)',
-  'requested_tenant != self.tenant_id',
-  'pub async fn run(',
-  'pub async fn request_cancel(',
   'materialize_postgres_index_sources(extensions, db.clone())',
   'materialize_index_source_registry(extensions)',
-  'materialize_postgres_index_replay_runtime(extensions, db)',
+  'materialize_postgres_index_replay_runtime(extensions, db.clone())',
   'extensions.insert(IndexReplayOperatorRuntime::new(runtime))',
-  'missing_replay_sources_do_not_publish_false_host_runtime',
-  'complete_source_catalog_publishes_guarded_runtime_to_host_context',
-  'duplicate_host_replay_materialization_fails_closed',
-  'operator_authorization_requires_exact_tenant_actor_and_modules_manage',
-  'operator_context_rejects_nil_identity',
+  'reconciliation_operator::materialize_index_reconciliation_operator(extensions, db)?;',
 ]);
-for (const forbidden of [
-  'tokio::spawn',
-  'tokio::time::sleep',
-  'loop {',
-  'StopHandle',
-  'runs_background_workers',
-  'rustok_product',
-  'rustok_content',
-  'rustok_flex',
-]) {
-  if (serverRuntime.includes(forbidden)) {
-    fail(`${serverRuntimePath} contains scheduler/source-domain marker ${forbidden}`);
-  }
+for (const forbidden of ['tokio::spawn', 'tokio::time::sleep', 'loop {', 'StopHandle']) {
+  if (server.includes(forbidden)) fail(`${serverPath} contains lifecycle marker ${forbidden}`);
 }
 
-const adapterMaterialization = serverRuntime.indexOf(
-  'materialize_postgres_index_sources(extensions, db.clone())',
-);
-const sourceMaterialization = serverRuntime.indexOf(
-  'materialize_index_source_registry(extensions)',
-  adapterMaterialization,
-);
-const replayMaterialization = serverRuntime.indexOf(
-  'materialize_postgres_index_replay_runtime(extensions, db)',
-  sourceMaterialization,
-);
-const operatorPublication = serverRuntime.indexOf(
-  'extensions.insert(IndexReplayOperatorRuntime::new(runtime))',
-  replayMaterialization,
-);
-if (
-  adapterMaterialization < 0
-  || sourceMaterialization <= adapterMaterialization
-  || replayMaterialization <= sourceMaterialization
-  || operatorPublication <= replayMaterialization
-) {
-  fail('server must construct source adapters before registry, replay runtime, and operator publication');
-}
-
-const servicesPath = 'apps/server/src/services/mod.rs';
-const services = requireMarkers(servicesPath, [
-  'pub mod index_replay_runtime_composition;',
-  'materialize_postgres_index_query_runtime(&mut extensions, db.clone())',
-  'index_replay_runtime_composition::materialize_index_replay_runtime(',
-  'canonical Index query and replay runtimes',
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/source_reconciliation_scheduler.rs', [
+  'impl ModuleWorkRegistration for IndexReconciliationWorkRegistration',
+  'impl ModuleWorkSource for PostgresIndexReconciliationWorkAdapter',
+  'impl ModuleWorkHandler for PostgresIndexReconciliationWorkAdapter',
 ]);
-const queryRuntime = services.indexOf(
-  'materialize_postgres_index_query_runtime(&mut extensions, db.clone())',
-);
-const replayRuntime = services.indexOf(
-  'index_replay_runtime_composition::materialize_index_replay_runtime(',
-  queryRuntime,
-);
-const optionalShadow = services.indexOf('social_graph_index_privacy_shadow_enabled()', replayRuntime);
-if (queryRuntime < 0 || replayRuntime <= queryRuntime || optionalShadow <= replayRuntime) {
-  fail('server must publish query then replay capabilities before optional Index shadows');
-}
-
 requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
   'mod replay_runtime;',
+  'mod source_reconciliation_scheduler;',
   'SharedIndexReplayRuntime',
-  'IndexReplayRuntimeCompositionError',
-  'materialize_postgres_index_replay_runtime',
+  'register_postgres_index_reconciliation_work',
 ]);
 requireMarkers('crates/rustok-index/src/lib.rs', [
-  'host-published',
+  'host-published replay and query capabilities',
+  'host-owned due reconciliation scheduling through the generic module-work lifecycle',
   'SharedIndexReplayRuntime',
-  'IndexReplayRuntimeCompositionError',
-  'materialize_postgres_index_replay_runtime',
+  'register_postgres_index_reconciliation_work',
 ]);
 requireMarkers('crates/rustok-index/docs/m6-replay-runtime-composition.md', [
   'Status: `source_complete_owner_execution_pending`',
-  '`IndexReplayOperatorRuntime`',
-  '`modules:manage`',
-  'Composition performs no SQL and starts no task.',
-  'Transport adapters must not retrieve or call `SharedIndexReplayRuntime` directly.',
-  'Graceful shutdown and task ownership remain open',
+  'one module-work registration for due reconciliation execution',
+  'publishes no replay runtime, no dry-run runtime, and no empty Index work registration',
+  'The materializer performs no SQL',
+  'starts the single generic `ModuleWorkScheduler` only when registrations exist',
+  'The work registration added here is reconciliation-only',
   'maintainer-run',
 ]);
-requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
-  '- M6 replay runtime host composition and operator guard: `source_complete_owner_execution_pending`',
-  '- [x] Bind job requests directly to the materialized source registry in server composition.',
-  '`IndexReplayOperatorRuntime` requires an exact request-bound tenant/actor permission snapshot',
-  'host scheduling, graceful task shutdown,',
-]);
-requireMarkers('crates/rustok-index/CRATE_API.md', [
-  '`SharedIndexReplayRuntime`',
-  '`materialize_postgres_index_replay_runtime`',
-  '`IndexReplayOperatorRuntime`',
-  'Runtime composition performs no SQL and starts no task.',
-]);
-requireMarkers('crates/rustok-index/README.md', [
-  'M6 replay runtime host composition and operator guard: source complete',
-  '`IndexReplayOperatorRuntime`',
-  '`modules:manage`',
-]);
-requireMarkers('crates/rustok-index/docs/README.md', [
-  'M6 replay runtime host composition and operator guard: `source_complete_owner_execution_pending`',
-  '[M6 replay runtime host composition](./m6-replay-runtime-composition.md)',
+requireMarkers('crates/rustok-index/docs/m6-reconciliation-host-scheduler.md', [
+  'Status: `source_complete_owner_execution_pending`.',
+  'The generic host scheduler remains the only polling and lifecycle owner',
 ]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-replay-runtime-composition.mjs'",
+  "'verify-index-reconciliation-host-scheduler.mjs'",
 ]);
 
 console.log('[verify-index-replay-runtime-composition] OK');

--- a/scripts/verify/verify-index-server-reconciliation-guard.mjs
+++ b/scripts/verify/verify-index-server-reconciliation-guard.mjs
@@ -18,36 +18,22 @@ const requireMarkers = (relative, markers) => {
   return source;
 };
 
-const compositionPath =
-  'apps/server/src/services/index_replay_runtime_composition.rs';
-const operatorPath =
-  'apps/server/src/services/index_reconciliation_operator.rs';
-const docsPath =
-  'apps/server/docs/index-reconciliation-operator-runtime.md';
-const inspectionDocsPath =
-  'crates/rustok-index/docs/m6-reconciliation-dead-letter-inspection.md';
-const recoveryDocsPath =
-  'crates/rustok-index/docs/m6-reconciliation-dead-letter-requeue.md';
+const compositionPath = 'apps/server/src/services/index_replay_runtime_composition.rs';
+const operatorPath = 'apps/server/src/services/index_reconciliation_operator.rs';
+const docsPath = 'apps/server/docs/index-reconciliation-operator-runtime.md';
 
 const composition = requireMarkers(compositionPath, [
   '#[path = "index_reconciliation_operator.rs"]',
   'mod reconciliation_operator;',
-  'pub use reconciliation_operator::{',
-  'IndexReconciliationOperatorRuntime,',
   'materialize_postgres_index_replay_runtime(extensions, db.clone())',
   'reconciliation_operator::materialize_index_reconciliation_operator(extensions, db)?;',
 ]);
-const replayMaterialization = composition.indexOf(
-  'materialize_postgres_index_replay_runtime(extensions, db.clone())',
-);
-const reconciliationMaterialization = composition.indexOf(
+const replay = composition.indexOf('materialize_postgres_index_replay_runtime(extensions, db.clone())');
+const reconciliation = composition.indexOf(
   'reconciliation_operator::materialize_index_reconciliation_operator(extensions, db)?;',
 );
-if (
-  replayMaterialization < 0
-  || reconciliationMaterialization <= replayMaterialization
-) {
-  fail(`${compositionPath} must publish reconciliation only after replay source freezing`);
+if (replay < 0 || reconciliation <= replay) {
+  fail(`${compositionPath} must freeze replay/work composition before operator publication`);
 }
 
 const operator = requireMarkers(operatorPath, [
@@ -57,10 +43,8 @@ const operator = requireMarkers(operatorPath, [
   'Permission::MODULES_MANAGE',
   'pub struct IndexReconciliationOperatorRuntime',
   'inner: rustok_index::PostgresIndexReconciliationRunner,',
-  'dead_letters: rustok_index::infrastructure::postgres::PostgresIndexReconciliationDeadLetterInspector,',
-  'recovery: rustok_index::infrastructure::postgres::PostgresIndexReconciliationRecoveryStore,',
-  'Inspection(#[from] rustok_index::infrastructure::postgres::IndexReconciliationDeadLetterInspectionError),',
-  'Recovery(#[from] rustok_index::infrastructure::postgres::IndexReconciliationRecoveryError),',
+  'PostgresIndexReconciliationDeadLetterInspector,',
+  'PostgresIndexReconciliationRecoveryStore,',
   'context.authorize_for(request.tenant_id())?;',
   'pub async fn request_cancel(',
   'pub async fn inspect_dead_letter(',
@@ -69,179 +53,63 @@ const operator = requireMarkers(operatorPath, [
   'context.tenant_id(),',
   'context.actor_id(),',
   '.requeue_failed(request)',
-  'PostgresIndexReconciliationRecoveryStore::new(',
-  'PostgresIndexReconciliationDeadLetterInspector::new(',
-  'PostgresIndexReconciliationRunner::new(db, sources, schemas.shared())',
-  'dead_letter_requeue_authorizes_before_request_validation',
 ]);
-
-const authorizeStart = operator.indexOf('    fn authorize_for(');
-const authorizeEnd = operator.indexOf('\n}\n\n#[derive(Debug, Error)]', authorizeStart);
-if (authorizeStart < 0 || authorizeEnd <= authorizeStart) {
-  fail(`${operatorPath} must retain one bounded authorize_for implementation`);
-}
-const authorize = operator.slice(authorizeStart, authorizeEnd);
-const tenantCheck = authorize.indexOf('if requested_tenant != self.tenant_id');
-const permissionLookup = authorize.indexOf(
-  'permissions_for(&self.tenant_id, &self.actor_id)',
-);
-const manageCheck = authorize.indexOf('Permission::MODULES_MANAGE');
-if (
-  tenantCheck < 0
-  || permissionLookup <= tenantCheck
-  || manageCheck <= permissionLookup
-) {
-  fail(`${operatorPath} must reject tenant mismatch before permission evaluation`);
-}
-
-const runStart = operator.indexOf('    pub async fn run(');
-const cancelStart = operator.indexOf('    pub async fn request_cancel(', runStart);
-const inspectStart = operator.indexOf('    pub async fn inspect_dead_letter(', cancelStart);
-const requeueStart = operator.indexOf('    pub async fn requeue_dead_letter(', inspectStart);
-const runtimeEnd = operator.indexOf('\n}\n\nimpl fmt::Debug', requeueStart);
-if (
-  runStart < 0
-  || cancelStart <= runStart
-  || inspectStart <= cancelStart
-  || requeueStart <= inspectStart
-  || runtimeEnd <= requeueStart
-) {
-  fail(`${operatorPath} guarded surface is malformed`);
-}
-const run = operator.slice(runStart, cancelStart);
-const cancel = operator.slice(cancelStart, inspectStart);
-const inspect = operator.slice(inspectStart, requeueStart);
-const requeue = operator.slice(requeueStart, runtimeEnd);
-
-if (
-  run.indexOf('context.authorize_for(request.tenant_id())?;') < 0
-  || run.indexOf('self.inner.run(request)')
-    <= run.indexOf('context.authorize_for(request.tenant_id())?;')
-) {
-  fail(`${operatorPath} run must authorize before runner delegation`);
-}
-
-for (const [name, body, delegation] of [
-  ['cancellation', cancel, '.request_cancel(context.tenant_id(), job_id)'],
-  ['inspection', inspect, '.inspect(context.tenant_id(), job_id)'],
+const production = operator.split('\n#[cfg(test)]')[0];
+for (const forbidden of [
+  'tokio::spawn', 'spawn_blocking', 'SELECT ', 'INSERT ', 'UPDATE ', 'DELETE ',
+  'Router::new', 'async_graphql', 'ModuleWorkScheduler', 'StopHandle',
 ]) {
-  if (body.includes('tenant_id: Uuid')) {
-    fail(`${operatorPath} ${name} must not accept a separate tenant`);
-  }
+  if (production.includes(forbidden)) fail(`${operatorPath} contains ${forbidden}`);
+}
+
+const runStart = production.indexOf('    pub async fn run(');
+const cancelStart = production.indexOf('    pub async fn request_cancel(', runStart);
+const inspectStart = production.indexOf('    pub async fn inspect_dead_letter(', cancelStart);
+const requeueStart = production.indexOf('    pub async fn requeue_dead_letter(', inspectStart);
+const runtimeEnd = production.indexOf('\n}\n\nimpl fmt::Debug', requeueStart);
+const run = production.slice(runStart, cancelStart);
+const cancel = production.slice(cancelStart, inspectStart);
+const inspect = production.slice(inspectStart, requeueStart);
+const requeue = production.slice(requeueStart, runtimeEnd);
+if (run.indexOf('context.authorize_for(request.tenant_id())?;') < 0
+    || run.indexOf('self.inner.run(request)') <= run.indexOf('context.authorize_for(request.tenant_id())?;')) {
+  fail(`${operatorPath} run must authorize before delegation`);
+}
+for (const [name, body, marker] of [
+  ['cancel', cancel, '.request_cancel(context.tenant_id(), job_id)'],
+  ['inspect', inspect, '.inspect(context.tenant_id(), job_id)'],
+]) {
   const auth = body.indexOf('context.authorize_for(context.tenant_id())?;');
-  const delegate = body.indexOf(delegation);
-  if (auth < 0 || delegate <= auth) {
-    fail(`${operatorPath} ${name} must authorize and derive tenant from context`);
+  const delegate = body.indexOf(marker);
+  if (body.includes('tenant_id: Uuid') || auth < 0 || delegate <= auth) {
+    fail(`${operatorPath} ${name} must bind tenant to authorized context`);
   }
 }
-
-for (const forbidden of ['tenant_id: Uuid', 'actor_id: Uuid']) {
-  if (requeue.includes(forbidden)) {
-    fail(`${operatorPath} recovery must not accept caller-selected ${forbidden}`);
-  }
-}
-const recoveryAuth = requeue.indexOf(
-  'context.authorize_for(context.tenant_id())?;',
-);
-const requestConstruction = requeue.indexOf(
-  'IndexReconciliationRequeueRequest::new(',
-);
-const tenantBinding = requeue.indexOf('context.tenant_id(),', requestConstruction);
-const actorBinding = requeue.indexOf('context.actor_id(),', tenantBinding);
-const recoveryDelegation = requeue.indexOf('.requeue_failed(request)');
-if (
-  recoveryAuth < 0
-  || requestConstruction <= recoveryAuth
-  || tenantBinding <= requestConstruction
-  || actorBinding <= tenantBinding
-  || recoveryDelegation <= actorBinding
-) {
-  fail(`${operatorPath} recovery must authorize, bind context tenant/actor, then delegate`);
-}
-for (const forbidden of [
-  'DatabaseConnection',
-  'SELECT ',
-  'INSERT ',
-  'UPDATE ',
-  'DELETE ',
-  'last_error_details',
-  "state = 'pending'",
-]) {
-  if (requeue.includes(forbidden)) {
-    fail(`${operatorPath} recovery method contains forbidden engine detail ${forbidden}`);
-  }
+const auth = requeue.indexOf('context.authorize_for(context.tenant_id())?;');
+const request = requeue.indexOf('IndexReconciliationRequeueRequest::new(');
+const tenant = requeue.indexOf('context.tenant_id(),', request);
+const actor = requeue.indexOf('context.actor_id(),', tenant);
+const delegate = requeue.indexOf('.requeue_failed(request)');
+if (auth < 0 || request <= auth || tenant <= request || actor <= tenant || delegate <= actor) {
+  fail(`${operatorPath} requeue must authorize, bind tenant/actor, then delegate`);
 }
 
-const materializeStart = operator.indexOf(
-  'pub(super) fn materialize_index_reconciliation_operator(',
-);
-const testsStart = operator.indexOf('\n#[cfg(test)]', materializeStart);
-const materialize = operator.slice(materializeStart, testsStart);
-const recoveryConstruction = materialize.indexOf(
-  'PostgresIndexReconciliationRecoveryStore::new(',
-);
-const inspectorConstruction = materialize.indexOf(
-  'PostgresIndexReconciliationDeadLetterInspector::new(',
-);
-const runnerConstruction = materialize.indexOf(
-  'PostgresIndexReconciliationRunner::new(db, sources, schemas.shared())',
-);
-const runtimeInsertion = materialize.indexOf(
-  'extensions.insert(IndexReconciliationOperatorRuntime::new(',
-);
-if (
-  recoveryConstruction < 0
-  || inspectorConstruction <= recoveryConstruction
-  || runnerConstruction <= inspectorConstruction
-  || runtimeInsertion <= runnerConstruction
-) {
-  fail(`${operatorPath} must compose recovery, inspector, and runner into one runtime`);
-}
-
-const productionOperator = operator.split('\n#[cfg(test)]')[0];
-for (const forbidden of [
-  'tokio::spawn',
-  'spawn_blocking',
-  'SELECT ',
-  'INSERT ',
-  'UPDATE ',
-  'DELETE ',
-  'Router::new',
-  'route(',
-  'async_graphql',
-  "state = 'pending'",
-]) {
-  if (productionOperator.includes(forbidden)) {
-    fail(`${operatorPath} production boundary contains forbidden marker ${forbidden}`);
-  }
-}
-
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs', [
+  'register_postgres_index_reconciliation_work(extensions)?;',
+]);
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/source_reconciliation_scheduler.rs', [
+  'impl ModuleWorkRegistration for IndexReconciliationWorkRegistration',
+  'PostgresIndexReconciliationRunner',
+]);
 requireMarkers(docsPath, [
-  'Status: `source_complete_transport_and_scheduling_pending`.',
-  'requires effective `Permission::MODULES_MANAGE`',
+  'Status: `source_complete_transport_and_owner_execution_pending`.',
+  'effective `Permission::MODULES_MANAGE`',
   'accept no caller-selected tenant',
-  'accepts no caller-selected actor',
-  'authorization run before adapter or recovery-request validation',
-  'tenant/actor-bound `requeue_dead_letter(context, job_id, reason)`',
-  'construct `IndexReconciliationRequeueRequest` from `context.tenant_id()`',
-  'The same-job failed-to-pending reset',
-  'canonical bounded retry/global scheduling and drift-diagnosis/targeted-repair roadmap items remain open',
+  'The same registry-freezing composition now also publishes',
+  'The operator runtime does not expose or own that scheduler',
+  'existing generic server module-work bootstrap',
+  'automatic scheduling: manual authorized calls and host-scheduled calls converge',
   'maintainer-run',
-]);
-requireMarkers(inspectionDocsPath, [
-  'Status: `source_complete_transport_pending`.',
-  'beside the canonical reconciliation runner and audited recovery store',
-  'There is no caller-supplied tenant parameter.',
-  'same guarded runtime also exposes manual audited requeue',
-  'GraphQL, HTTP, CLI, MCP, and admin transports remain open',
-]);
-requireMarkers(recoveryDocsPath, [
-  'Status: `source_complete_authorized_server_composition_transport_pending`.',
-  '## Authorized server composition',
-  'accepts no tenant or actor argument',
-  'requires effective `Permission::MODULES_MANAGE`',
-  'Authorization occurs before job/reason validation',
-  'GraphQL, HTTP, CLI, MCP, native admin',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
   '- [ ] Add drift diagnosis, targeted repair commands, and admitted repair evidence.',
@@ -249,8 +117,7 @@ requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
 ]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-server-reconciliation-guard.mjs'",
-  "'verify-index-reconciliation-dead-letter-inspection.mjs'",
-  "'verify-index-reconciliation-dead-letter-requeue.mjs'",
+  "'verify-index-reconciliation-host-scheduler.mjs'",
 ]);
 
 console.log('[verify-index-server-reconciliation-guard] OK');


### PR DESCRIPTION
## Summary

- publish one Index-owned `ModuleWorkRegistration` for due reconciliation jobs;
- reuse the existing generic `ModuleWorkScheduler` and shared `StopHandle` lifecycle instead of creating a second server poller;
- discover one authoritative due pending or expired-running schema scope through a bounded read-only query;
- validate the strict stored reconciliation request and immutable source ownership before publishing work;
- delegate actual claim, expired-lease takeover, attempt fencing, cancellation, retry, exhaustion, and terminal transitions to `PostgresIndexReconciliationRunner`;
- conditionally register the worker only after complete immutable source/schema registries exist;
- actualize replay composition, server/operator documentation, retry/dead-letter contracts, and focused static guards;
- keep retained PostgreSQL and multi-host execution evidence owner-run and the combined roadmap item open.

## Fresh-main audit

The branch is built directly on `main@c8e1ad667c4c062ee41332851a08e5b185480e0d`.

Before PR creation:

- one commit ahead;
- zero commits behind;
- 21 changed files;
- recent Pages and Fulfillment commits do not overlap Index or server reconciliation paths;
- no open PR or branch implements this exact host scheduler slice.

## Lifecycle ownership

The existing server module-work bootstrap remains the sole lifecycle owner:

- one generic scheduler instance;
- one-second polling cadence;
- deployment background-worker admission;
- shared `StopHandle` shutdown;
- no new claim after stop while already claimed work finishes its canonical path.

Index contributes only its registration, source, and handler. Replay materialization itself performs no SQL and starts no task. If no immutable source registry exists, it publishes neither a false replay capability nor an empty Index work registration.

## Due discovery

The adapter accepts only worker slug `index_reconciliation` and executes one read-only `index_jobs` query.

For each exact tenant/module/entity/schema-version scope it mirrors runner authority:

```text
succeeded -> running -> pending -> failed
```

Only rank one is eligible, and only when:

- pending and `available_at <= CURRENT_TIMESTAMP`; or
- running and `lease_expires_at <= CURRENT_TIMESTAMP`.

Expired cancellation-requested running rows intentionally remain discoverable so the runner can take over and complete its existing fenced cancellation transition.

The query is deterministic and globally limited to one row. It performs no insert, update, delete, lease acquisition, attempt increment, retry, cancellation, or terminal transition.

## Stored and work-item contracts

Discovery validates:

- non-nil tenant/job UUIDs;
- module/entity/schema-version shape;
- strict `index_reconciliation_job_v1` request JSON;
- positive bounded pass count;
- exact source-name ownership against the immutable source registry.

The strict module-work payload contains only module, entity, schema version, and pass count. A fresh invocation UUID derives the bounded runner worker id. It contains no cursor, raw error details, source payload, retry state, lease data, actor, SQL, database cause, or transport context.

## Canonical execution

The handler constructs one bounded runner request with:

- page limit `100`;
- maximum `8` pages;
- heartbeat every page boundary;
- `300` second lease;
- original retained pass count.

Multiple hosts may discover the same row, but only the canonical runner advisory lock and lease transition can acquire durable ownership. The generic completion hook is a no-op because the runner already owns every durable transition.

Runner `Cancelled` maps to module-work `Cancelled`. `Busy`, `AlreadyComplete`, `Complete`, `Yielded`, `RetryScheduled`, `FailedPermanent`, and `FailedExhausted` map to `Completed` because each is already a truthful durable result.

## Scope boundaries

This PR does not add or claim:

- a second Tokio polling task or stop channel;
- scheduler handles on replay/reconciliation operator runtimes;
- direct scheduler claim SQL;
- migrations or table-shape changes;
- GraphQL, HTTP, CLI, MCP, or admin controls;
- per-source policy, jitter, or dynamic configuration;
- operator scheduler health/metrics;
- retained PostgreSQL due scheduling, multi-host contention, restart, exhaustion, or graceful-shutdown evidence;
- source/index digest comparison, orphan diagnosis, or targeted/full/shadow repair.

The canonical retry/backoff/dead-letter/global-scheduling checkbox remains open until owner-retained PostgreSQL and multi-host lifecycle evidence is admitted.

## Validation

Not run per maintainer instruction:

- formatting;
- Cargo checks, tests, or Clippy;
- JavaScript verifiers;
- SQLite or PostgreSQL scenarios;
- workflows and CI.