### PR TITLE
fix(fulfillment): bound checkout owner mapper diagnostics

### DIFF
--- a/crates/rustok-fulfillment/contracts/evidence/checkout-owner-mapper-diagnostic-safety-source.json
+++ b/crates/rustok-fulfillment/contracts/evidence/checkout-owner-mapper-diagnostic-safety-source.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-08-03",
+  "status": "fulfillment_checkout_owner_mapper_diagnostic_safety_source_unvalidated",
+  "scope": "Fulfillment checkout canonical FulfillmentError to PortError diagnostics only",
+  "source_contract": {
+    "canonical_owner_mapper_bounded": true,
+    "validation_cause_shape_only": true,
+    "shipping_option_identity_shape_only": true,
+    "fulfillment_identity_shape_only": true,
+    "transition_shape_only": true,
+    "database_cause_type_only": true,
+    "owner_context_shape_only": true,
+    "raw_owner_causes_logged": false,
+    "raw_owner_identifiers_logged": false,
+    "raw_owner_transition_values_logged": false,
+    "raw_owner_context_logged": false,
+    "owner_correlation_preserved": true,
+    "owner_operations_preserved": true,
+    "owner_error_kind_closed": true,
+    "owner_severity_preserved": true,
+    "stable_public_envelopes_preserved": true,
+    "service_mapper_call_sites_preserved": true,
+    "checkout_execution_mapper_cleanup_source_complete": true,
+    "execution_behavior_changed": false,
+    "public_port_error_changed": false,
+    "ffa_promoted": false,
+    "fba_promoted": false
+  },
+  "preserved_public_envelopes": [
+    "fulfillment.checkout_execution_validation",
+    "fulfillment.shipping_option_not_found",
+    "fulfillment.fulfillment_not_found",
+    "fulfillment.checkout_execution_state_conflict",
+    "fulfillment.database_unavailable"
+  ],
+  "suggested_execution": [
+    "node scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs",
+    "node scripts/verify/verify-fulfillment-checkout-context-validation.mjs",
+    "node scripts/verify/verify-fulfillment-checkout-local-validation-context.mjs",
+    "node scripts/verify/verify-fulfillment-checkout-admission-context.mjs",
+    "node scripts/verify/verify-fulfillment-checkout-local-porterror-diagnostic-safety.mjs",
+    "cargo check -p rustok-fulfillment --lib"
+  ],
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "runtime_proven": false
+  }
+}

--- a/crates/rustok-fulfillment/docs/checkout-admission-context.md
+++ b/crates/rustok-fulfillment/docs/checkout-admission-context.md
@@ -143,12 +143,27 @@ The tenant guard and evidence are:
 
 That contract does not change admission selection or ordering.
 
-## Remaining diagnostic boundaries
+## Related canonical owner contract
+
+Canonical `FulfillmentError` diagnostics are source-ready / unvalidated under their own bounded
+contract. Validation text, owner UUIDs, lifecycle transition strings, database errors, and raw
+delegated context are replaced with type/shape/closed-kind facts while every public envelope and
+service operation remains unchanged.
+
+The owner guard and evidence are:
+
+- `scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs`;
+- `crates/rustok-fulfillment/contracts/evidence/checkout-owner-mapper-diagnostic-safety-source.json`;
+- `crates/rustok-fulfillment/docs/checkout-owner-mapper-diagnostic-safety.md`.
+
+That contract does not change admission selection, phases, pass-through, or ordering.
+
+## Checkout execution source boundary
 
 Causation validation, tenant parsing, and canonical `FulfillmentError` diagnostics remain separate
-bounded slices in the admission contract's original scope. Causation and tenant parsing are now
-source-ready under the related contracts above; canonical `FulfillmentError` diagnostics remain
-open.
+bounded slices in the admission contract's original scope. All three are now source-ready under
+the related contracts above. Together with the admission and local-`PortError` contracts, the
+mounted Fulfillment checkout execution diagnostic mapper surface is source-complete.
 
 Compile, runtime, replay, restart, contention, mounted Commerce behavior, remote-port parity,
 workflows, CI, and production evidence remain open. The broad ecommerce correlation-safe

--- a/crates/rustok-fulfillment/docs/checkout-context-validation.md
+++ b/crates/rustok-fulfillment/docs/checkout-context-validation.md
@@ -117,7 +117,7 @@ This slice does not change:
 - request and immutable fulfillment-plan validation;
 - fulfillment create, post-error adoption, lookup, read, or sorting behavior;
 - metadata construction;
-- canonical `FulfillmentError` mappings;
+- canonical `FulfillmentError` public mapping behavior;
 - Commerce orchestration;
 - FBA, FFA, or ecommerce audit status.
 
@@ -142,10 +142,22 @@ Tenant source evidence is recorded in:
 
 Both records remain source-only: `execution` is empty and every validation flag remains false.
 
-## Remaining diagnostic boundary
+## Related owner mapper contract
 
-Canonical `FulfillmentError` diagnostics remain the next separate cleanup slice in
-`fulfillment_error_to_port_error`.
+Canonical `FulfillmentError` diagnostics are source-ready / unvalidated under their own bounded contract:
+
+- `scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs`;
+- `crates/rustok-fulfillment/contracts/evidence/checkout-owner-mapper-diagnostic-safety-source.json`;
+- `crates/rustok-fulfillment/docs/checkout-owner-mapper-diagnostic-safety.md`.
+
+That contract preserves all five public `PortError` envelopes and the existing warning/error
+severity while replacing raw owner causes, identities, transition values, database errors, and
+delegated context with bounded facts. It does not change either context validator covered here.
+
+## Checkout execution source boundary
+
+The admission, local-`PortError`, causation, tenant, and canonical owner mapper contracts now
+make the mounted Fulfillment checkout execution diagnostic mapper surface source-complete.
 
 Compile, runtime, replay, restart, contention, mounted Commerce behavior, remote-port parity,
 workflows, CI, and production evidence remain open. The broad ecommerce correlation-safe mapper

--- a/crates/rustok-fulfillment/docs/checkout-execution-local-porterror-diagnostic-safety.md
+++ b/crates/rustok-fulfillment/docs/checkout-execution-local-porterror-diagnostic-safety.md
@@ -70,7 +70,7 @@ This slice does not change:
 - request and immutable-plan validation rules;
 - duplicate and incomplete-set behavior;
 - fulfillment sorting, metadata, or identity construction;
-- canonical `FulfillmentError` to `PortError` mapping;
+- canonical `FulfillmentError` to `PortError` public mapping behavior;
 - Commerce orchestration;
 - FFA or FBA status.
 
@@ -104,9 +104,20 @@ Causation records only bounded context and identity-shape facts. Tenant parsing 
 parse-cause type and bounded context/message facts. Neither related contract changes the local
 mapper covered here.
 
-The canonical `FulfillmentError` mapper remains a separate bounded slice. The local, admission,
-causation, and tenant contracts together do not claim that the complete `checkout_execution.rs`
-diagnostic surface is source-closed.
+## Related canonical owner contract
+
+Canonical `FulfillmentError` diagnostics are source-ready / unvalidated under a separate bounded
+contract. The owner mapper preserves all five static `PortError` envelopes and the existing
+warning/error severity while replacing raw causes, UUIDs, transition strings, database errors,
+and delegated context with bounded facts.
+
+The owner guard and evidence are:
+
+- `scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs`;
+- `crates/rustok-fulfillment/contracts/evidence/checkout-owner-mapper-diagnostic-safety-source.json`;
+- `crates/rustok-fulfillment/docs/checkout-owner-mapper-diagnostic-safety.md`.
+
+That contract does not change the local mapper or its eight call sites.
 
 ## Static evidence
 
@@ -124,11 +135,15 @@ Local source evidence is recorded in:
 
 - `crates/rustok-fulfillment/contracts/evidence/checkout-execution-local-porterror-diagnostic-safety-source.json`.
 
-## Evidence boundary
+## Checkout execution source boundary
+
+The local, admission, causation, tenant, and canonical owner contracts now make the mounted
+Fulfillment checkout execution diagnostic mapper surface source-complete.
 
 These slices are source-only. They do not claim compilation, execution, replay, restart,
 contention, mounted Commerce behavior, remote-port parity, workflows, CI, or production
-readiness. The broad ecommerce correlation-safe mapper cleanup remains open.
+readiness. The broad ecommerce correlation-safe mapper cleanup remains open, and FFA/FBA status
+is not promoted.
 
 Suggested maintainer checks:
 

--- a/crates/rustok-fulfillment/docs/checkout-local-validation-context.md
+++ b/crates/rustok-fulfillment/docs/checkout-local-validation-context.md
@@ -109,7 +109,7 @@ This slice does not change:
 - duplicate or missing identity detection;
 - immutable plan comparison rules;
 - create, adoption, lookup, or read service ordering;
-- stable `FulfillmentError` mapping;
+- stable `FulfillmentError` public mapping;
 - fulfillment or item metadata construction;
 - fulfillment sorting;
 - FBA, FFA, or ecommerce audit status.
@@ -160,10 +160,20 @@ The context guard preserves exact parsing and matching behavior while forbidding
 complete parse causes, raw delegated values, message text, and Debug kind output inside both
 covered validators.
 
-## Remaining gap
+Canonical `FulfillmentError` diagnostics are source-ready / unvalidated under their own bounded
+contract:
 
-Canonical `FulfillmentError` diagnostics in `fulfillment_error_to_port_error` remain the next
-separate bounded slice.
+- `scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs`;
+- `crates/rustok-fulfillment/contracts/evidence/checkout-owner-mapper-diagnostic-safety-source.json`;
+- `crates/rustok-fulfillment/docs/checkout-owner-mapper-diagnostic-safety.md`.
+
+The canonical mapper preserves all five static public envelopes and the existing warning/error
+severity while recording only bounded variant and context facts.
+
+## Checkout execution source boundary
+
+The local, admission, causation, tenant, and canonical owner contracts now make the mounted
+Fulfillment checkout execution diagnostic mapper surface source-complete.
 
 Compile, runtime, replay, restart, remote-port, workflow, and CI evidence remain open. The
 broad ecommerce correlation-safe mapper cleanup and FFA/FBA status are not promoted.

--- a/crates/rustok-fulfillment/docs/checkout-owner-mapper-diagnostic-safety.md
+++ b/crates/rustok-fulfillment/docs/checkout-owner-mapper-diagnostic-safety.md
@@ -1,0 +1,110 @@
+# Fulfillment checkout owner mapper diagnostic safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This bounded source slice hardens only `fulfillment_error_to_port_error` in
+`crates/rustok-fulfillment/src/checkout_execution.rs`.
+
+The mapper still translates the same five `FulfillmentError` variants into the same typed
+`PortError` envelopes for checkout fulfillment create, lookup, adoption, and read operations.
+Only structured diagnostics change.
+
+## Bounded diagnostic policy
+
+Every branch retains:
+
+- truthful owner `rustok_fulfillment`;
+- exact delegated service operation;
+- boundary `checkout_fulfillment_execution_port`;
+- correlation id;
+- one closed owner-error-kind label;
+- tenant-id and actor-id character lengths;
+- closed actor-kind label;
+- claim and role counts;
+- channel presence and optional character length;
+- locale character length;
+- causation-id, traceparent, and idempotency-key presence plus optional character lengths;
+- optional deadline milliseconds;
+- the existing stable diagnostic code.
+
+Variant-specific evidence is bounded as follows:
+
+- validation retains only cause presence and character length;
+- shipping-option not-found retains only whether the UUID is non-nil;
+- fulfillment not-found retains only whether the UUID is non-nil;
+- invalid transition retains from/to presence, character lengths, and whether the values differ;
+- database failure retains only the concrete `DbErr` type through `type_name_of_val`.
+
+The mapper does not record full validation text, raw shipping-option or fulfillment UUIDs, raw
+transition values, complete database errors, or raw delegated context values.
+
+## Preserved severity
+
+The validation, shipping-option not-found, fulfillment not-found, and invalid-transition
+branches remain `tracing::warn!` events. The database branch remains a `tracing::error!` event.
+
+## Preserved public envelopes
+
+The mapper keeps the exact existing constructors, codes, messages, kinds, and retryability:
+
+- validation → `fulfillment.checkout_execution_validation` / `checkout fulfillment request is invalid`;
+- shipping option not found → `fulfillment.shipping_option_not_found` / `shipping option was not found`;
+- fulfillment not found → `fulfillment.fulfillment_not_found` / `fulfillment was not found`;
+- invalid transition → `fulfillment.checkout_execution_state_conflict` / `fulfillment lifecycle conflicts with checkout execution`;
+- database failure → `fulfillment.database_unavailable` / `fulfillment storage is temporarily unavailable`.
+
+No branch forwards an internal cause, UUID, lifecycle value, or database error into a public
+message.
+
+## Preserved routing and behavior
+
+This slice does not change:
+
+- the mapper signature or `FulfillmentError` variant matching;
+- create-failure mapping through `create_checkout_fulfillment`;
+- read-list mapping through `list_checkout_fulfillments_for_read`;
+- lookup mapping through the caller-selected service operation;
+- fulfillment create, post-error adoption, lookup, read, validation, or sorting behavior;
+- admission, tenant, causation, or local-`PortError` mappers;
+- request/response DTOs, metadata, Commerce orchestration, FFA, or FBA status.
+
+## Checkout execution source boundary
+
+Together with the existing admission, tenant, causation, and local-`PortError` contracts, this
+slice makes the mounted Fulfillment checkout execution diagnostic mapper surface source-complete.
+This is a source-contract statement only. It does not prove compilation, runtime behavior,
+replay, restart, contention, mounted Commerce parity, remote-port parity, workflows, CI, or
+production readiness.
+
+The broad ecommerce correlation-safe mapper item remains open for other owner and adapter
+boundaries. No ecommerce audit, FFA, or FBA gate is promoted.
+
+## Static evidence
+
+The focused guard is:
+
+- `scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs`.
+
+It requires all five closed owner-error-kind branches, bounded context and variant facts, exact
+public envelopes, four warning paths, one error path, and all three existing service mappings.
+It forbids raw causes, UUIDs, transition values, database errors, and delegated context inside
+the covered mapper.
+
+Source evidence is recorded in:
+
+- `crates/rustok-fulfillment/contracts/evidence/checkout-owner-mapper-diagnostic-safety-source.json`.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs
+node scripts/verify/verify-fulfillment-checkout-context-validation.mjs
+node scripts/verify/verify-fulfillment-checkout-local-validation-context.mjs
+node scripts/verify/verify-fulfillment-checkout-admission-context.mjs
+node scripts/verify/verify-fulfillment-checkout-local-porterror-diagnostic-safety.mjs
+cargo check -p rustok-fulfillment --lib
+```

--- a/crates/rustok-fulfillment/src/checkout_execution.rs
+++ b/crates/rustok-fulfillment/src/checkout_execution.rs
@@ -995,15 +995,62 @@ fn fulfillment_error_to_port_error(
     owner_operation: &'static str,
     error: FulfillmentError,
 ) -> PortError {
+    let actor_kind = match &context.actor.kind {
+        rustok_api::PortActorKind::User => "user",
+        rustok_api::PortActorKind::Service => "service",
+        rustok_api::PortActorKind::System => "system",
+    };
+    let tenant_id_length = context.tenant_id.chars().count();
+    let actor_id_length = context.actor.id.chars().count();
+    let claim_count = context.claims.len();
+    let role_count = context.roles.len();
+    let channel_present = context.channel.is_some();
+    let channel_length = context.channel.as_ref().map(|value| value.chars().count());
+    let locale_length = context.locale.chars().count();
+    let causation_id_present = context.causation_id.is_some();
+    let causation_id_length = context
+        .causation_id
+        .as_ref()
+        .map(|value| value.chars().count());
+    let traceparent_present = context.traceparent.is_some();
+    let traceparent_length = context
+        .traceparent
+        .as_ref()
+        .map(|value| value.chars().count());
+    let idempotency_key_present = context.idempotency_key.is_some();
+    let idempotency_key_length = context
+        .idempotency_key
+        .as_ref()
+        .map(|value| value.chars().count());
+
     match error {
         FulfillmentError::Validation(cause) => {
+            let validation_cause_present = !cause.trim().is_empty();
+            let validation_cause_length = cause.chars().count();
             tracing::warn!(
-                cause = %cause,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                channel = ?context.channel,
+                owner = CHECKOUT_FULFILLMENT_OWNER,
                 operation = owner_operation,
+                owner_error_kind = "validation",
+                correlation_id = %context.correlation_id,
+                tenant_id_length,
+                actor_kind,
+                actor_id_length,
+                claim_count,
+                role_count,
+                channel_present,
+                channel_length = ?channel_length,
+                locale_length,
+                causation_id_present,
+                causation_id_length = ?causation_id_length,
+                traceparent_present,
+                traceparent_length = ?traceparent_length,
+                idempotency_key_present,
+                idempotency_key_length = ?idempotency_key_length,
+                deadline_ms = ?context.deadline_ms,
+                validation_cause_present,
+                validation_cause_length,
                 code = "fulfillment.checkout_execution_validation",
+                boundary = CHECKOUT_FULFILLMENT_BOUNDARY,
                 "fulfillment owner rejected checkout execution request"
             );
             PortError::validation(
@@ -1012,13 +1059,30 @@ fn fulfillment_error_to_port_error(
             )
         }
         FulfillmentError::ShippingOptionNotFound(id) => {
+            let shipping_option_id_non_nil = !id.is_nil();
             tracing::warn!(
-                shipping_option_id = %id,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                channel = ?context.channel,
+                owner = CHECKOUT_FULFILLMENT_OWNER,
                 operation = owner_operation,
+                owner_error_kind = "shipping_option_not_found",
+                correlation_id = %context.correlation_id,
+                tenant_id_length,
+                actor_kind,
+                actor_id_length,
+                claim_count,
+                role_count,
+                channel_present,
+                channel_length = ?channel_length,
+                locale_length,
+                causation_id_present,
+                causation_id_length = ?causation_id_length,
+                traceparent_present,
+                traceparent_length = ?traceparent_length,
+                idempotency_key_present,
+                idempotency_key_length = ?idempotency_key_length,
+                deadline_ms = ?context.deadline_ms,
+                shipping_option_id_non_nil,
                 code = "fulfillment.shipping_option_not_found",
+                boundary = CHECKOUT_FULFILLMENT_BOUNDARY,
                 "checkout fulfillment shipping option was not found"
             );
             PortError::new(
@@ -1029,13 +1093,30 @@ fn fulfillment_error_to_port_error(
             )
         }
         FulfillmentError::FulfillmentNotFound(id) => {
+            let fulfillment_id_non_nil = !id.is_nil();
             tracing::warn!(
-                fulfillment_id = %id,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                channel = ?context.channel,
+                owner = CHECKOUT_FULFILLMENT_OWNER,
                 operation = owner_operation,
+                owner_error_kind = "fulfillment_not_found",
+                correlation_id = %context.correlation_id,
+                tenant_id_length,
+                actor_kind,
+                actor_id_length,
+                claim_count,
+                role_count,
+                channel_present,
+                channel_length = ?channel_length,
+                locale_length,
+                causation_id_present,
+                causation_id_length = ?causation_id_length,
+                traceparent_present,
+                traceparent_length = ?traceparent_length,
+                idempotency_key_present,
+                idempotency_key_length = ?idempotency_key_length,
+                deadline_ms = ?context.deadline_ms,
+                fulfillment_id_non_nil,
                 code = "fulfillment.fulfillment_not_found",
+                boundary = CHECKOUT_FULFILLMENT_BOUNDARY,
                 "checkout fulfillment resource was not found"
             );
             PortError::new(
@@ -1046,14 +1127,38 @@ fn fulfillment_error_to_port_error(
             )
         }
         FulfillmentError::InvalidTransition { from, to } => {
+            let transition_from_present = !from.trim().is_empty();
+            let transition_from_length = from.chars().count();
+            let transition_to_present = !to.trim().is_empty();
+            let transition_to_length = to.chars().count();
+            let transition_changes_state = from != to;
             tracing::warn!(
-                from = %from,
-                to = %to,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                channel = ?context.channel,
+                owner = CHECKOUT_FULFILLMENT_OWNER,
                 operation = owner_operation,
+                owner_error_kind = "invalid_transition",
+                correlation_id = %context.correlation_id,
+                tenant_id_length,
+                actor_kind,
+                actor_id_length,
+                claim_count,
+                role_count,
+                channel_present,
+                channel_length = ?channel_length,
+                locale_length,
+                causation_id_present,
+                causation_id_length = ?causation_id_length,
+                traceparent_present,
+                traceparent_length = ?traceparent_length,
+                idempotency_key_present,
+                idempotency_key_length = ?idempotency_key_length,
+                deadline_ms = ?context.deadline_ms,
+                transition_from_present,
+                transition_from_length,
+                transition_to_present,
+                transition_to_length,
+                transition_changes_state,
                 code = "fulfillment.checkout_execution_state_conflict",
+                boundary = CHECKOUT_FULFILLMENT_BOUNDARY,
                 "fulfillment lifecycle conflicts with checkout execution"
             );
             PortError::conflict(
@@ -1062,13 +1167,30 @@ fn fulfillment_error_to_port_error(
             )
         }
         FulfillmentError::Database(error) => {
+            let database_error_type = std::any::type_name_of_val(&error);
             tracing::error!(
-                error = ?error,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                channel = ?context.channel,
+                owner = CHECKOUT_FULFILLMENT_OWNER,
                 operation = owner_operation,
+                owner_error_kind = "database",
+                correlation_id = %context.correlation_id,
+                tenant_id_length,
+                actor_kind,
+                actor_id_length,
+                claim_count,
+                role_count,
+                channel_present,
+                channel_length = ?channel_length,
+                locale_length,
+                causation_id_present,
+                causation_id_length = ?causation_id_length,
+                traceparent_present,
+                traceparent_length = ?traceparent_length,
+                idempotency_key_present,
+                idempotency_key_length = ?idempotency_key_length,
+                deadline_ms = ?context.deadline_ms,
+                database_error_type,
                 code = "fulfillment.database_unavailable",
+                boundary = CHECKOUT_FULFILLMENT_BOUNDARY,
                 "checkout fulfillment storage operation failed"
             );
             PortError::unavailable(

--- a/scripts/verify/verify-fulfillment-checkout-context-validation.mjs
+++ b/scripts/verify/verify-fulfillment-checkout-context-validation.mjs
@@ -251,8 +251,8 @@ for (const [block, values, label] of [
 for (const [pattern, expected, label] of [
   [/validation_phase = "causation_id"/g, 1, 'causation phase count'],
   [/validation_phase = "tenant_id"/g, 1, 'tenant phase count'],
-  [/owner = CHECKOUT_FULFILLMENT_OWNER/g, 6, 'owner diagnostic count'],
-  [/boundary = CHECKOUT_FULFILLMENT_BOUNDARY/g, 6, 'boundary diagnostic count'],
+  [/owner = CHECKOUT_FULFILLMENT_OWNER/g, 11, 'owner diagnostic count'],
+  [/boundary = CHECKOUT_FULFILLMENT_BOUNDARY/g, 11, 'boundary diagnostic count'],
 ]) {
   const count = source.match(pattern)?.length ?? 0;
   if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
@@ -342,7 +342,7 @@ for (const [value, label] of [
   ['Causation diagnostics retain only bounded context and identity-shape facts', 'documentation causation policy'],
   ['Tenant parse-failure diagnostics retain only type and bounded context-shape facts', 'documentation tenant policy'],
   ['The exact constructed tenant `PortError` is returned unchanged', 'documentation tenant pass-through policy'],
-  ['Canonical `FulfillmentError` diagnostics remain the next separate cleanup slice', 'documentation remaining boundary'],
+  ['Canonical `FulfillmentError` diagnostics are source-ready / unvalidated under their own bounded contract', 'documentation related owner contract'],
 ]) requireText(doc, value, label);
 
 if (failures.length > 0) {

--- a/scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs
+++ b/scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs
@@ -12,6 +12,12 @@ const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8')
 
 const source = read('crates/rustok-fulfillment/src/checkout_execution.rs');
 const portContract = read('crates/rustok-api/src/ports.rs');
+const evidence = JSON.parse(
+  read(
+    'crates/rustok-fulfillment/contracts/evidence/checkout-owner-mapper-diagnostic-safety-source.json',
+  ),
+);
+const doc = read('crates/rustok-fulfillment/docs/checkout-owner-mapper-diagnostic-safety.md');
 const failures = [];
 
 const requireText = (content, value, label) => {
@@ -20,6 +26,7 @@ const requireText = (content, value, label) => {
 const forbidText = (content, value, label) => {
   if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
 };
+const countText = (content, value) => content.split(value).length - 1;
 const between = (content, start, end, label) => {
   const startIndex = content.indexOf(start);
   const endIndex = content.indexOf(end, startIndex + start.length);
@@ -81,6 +88,11 @@ const mapper = from(
 );
 
 for (const [value, label] of [
+  ['const CHECKOUT_FULFILLMENT_OWNER: &str = "rustok_fulfillment";', 'truthful owner constant'],
+  [
+    'const CHECKOUT_FULFILLMENT_BOUNDARY: &str = "checkout_fulfillment_execution_port";',
+    'fulfillment execution boundary',
+  ],
   ['const ENSURE_OPERATION: &str = "ensure_checkout_fulfillments";', 'ensure operation constant'],
   ['const READ_OPERATION: &str = "read_checkout_fulfillments";', 'read operation constant'],
   ['use rustok_api::{PortCallPolicy, PortContext, PortError, PortErrorKind};', 'typed port imports'],
@@ -99,71 +111,103 @@ for (const [content, value, label] of [
   [findHelper, "owner_operation: &'static str", 'lookup operation input'],
   [findHelper, "service_operation: &'static str", 'lookup service operation input'],
   [findHelper, 'fulfillment_error_to_port_error(context, service_operation, error)', 'lookup mapper handoff'],
-  [portImpl, 'parse_tenant_id(&context, ENSURE_OPERATION)', 'ensure context validation'],
+  [portImpl, 'parse_tenant_id(&context, ENSURE_OPERATION)', 'ensure tenant validation'],
   [portImpl, 'require_operation_context(&context, ENSURE_OPERATION', 'ensure causation validation'],
   [portImpl, 'self.ensure(&context, tenant_id, request).await', 'ensure context propagation'],
-  [portImpl, 'parse_tenant_id(&context, READ_OPERATION)', 'read context validation'],
+  [portImpl, 'parse_tenant_id(&context, READ_OPERATION)', 'read tenant validation'],
   [portImpl, 'require_operation_context(&context, READ_OPERATION', 'read causation validation'],
   [portImpl, 'self.read(&context, tenant_id, request).await', 'read context propagation'],
 ]) requireText(content, value, label);
 
-for (const [value, label] of [
-  ['correlation_id = %context.correlation_id', 'causation correlation log'],
-  ['tenant_id_length', 'causation tenant shape'],
-  ['actor_kind', 'causation actor shape'],
-  ['channel_present', 'causation channel shape'],
-  ['causation_id_parse_succeeded', 'causation parse fact'],
-  ['causation_id_matches_expected', 'causation match fact'],
-  ['expected_checkout_operation_id_non_nil', 'expected operation shape'],
-  ['operation = owner_operation', 'causation operation log'],
-  ['code = "fulfillment.checkout_operation_id_invalid"', 'causation code log'],
-  ['internal_message_present', 'causation message shape'],
-  ['error_kind', 'causation closed kind'],
-]) requireText(operationContext, value, label);
-for (const value of [
-  'error = ?error',
-  'tenant_id = %context.tenant_id',
-  'actor = ?context.actor',
-  'channel = ?context.channel',
-  'locale = %context.locale',
-  'causation_id = ?context.causation_id',
-  'traceparent = ?context.traceparent',
-  'idempotency_key = ?context.idempotency_key',
-  'expected_checkout_operation_id = %checkout_operation_id',
-  'internal_message = %error.message',
-  'error_kind = ?error.kind',
-]) forbidText(operationContext, value, 'unsafe causation diagnostic payload');
+for (const [content, values, label] of [
+  [
+    operationContext,
+    [
+      'causation_id_parse_succeeded',
+      'causation_id_matches_expected',
+      'expected_checkout_operation_id_non_nil',
+      'code = "fulfillment.checkout_operation_id_invalid"',
+      'return Err(error);',
+    ],
+    'bounded causation validator',
+  ],
+  [
+    tenantParser,
+    [
+      'Uuid::parse_str(&context.tenant_id).map_err(|cause| {',
+      'let parse_cause_type = std::any::type_name_of_val(&cause);',
+      'let tenant_id_parse_failed = true;',
+      'code = "fulfillment.tenant_id_invalid"',
+      'error\n    })',
+    ],
+    'bounded tenant parser',
+  ],
+]) {
+  for (const value of values) requireText(content, value, label);
+}
 
 for (const [value, label] of [
-  ['Uuid::parse_str(&context.tenant_id).map_err(|cause| {', 'tenant parsing'],
-  ['let parse_cause_type = std::any::type_name_of_val(&cause);', 'tenant parse-cause type'],
-  ['let tenant_id_length = context.tenant_id.chars().count();', 'tenant identity shape'],
-  ['let tenant_id_parse_failed = true;', 'tenant parse-failure fact'],
-  ['let actor_kind = match &context.actor.kind', 'tenant actor shape'],
-  ['let actor_id_length = context.actor.id.chars().count();', 'tenant actor identity shape'],
-  ['let claim_count = context.claims.len();', 'tenant claim count'],
-  ['let role_count = context.roles.len();', 'tenant role count'],
-  ['let channel_present = context.channel.is_some();', 'tenant channel shape'],
-  ['let locale_length = context.locale.chars().count();', 'tenant locale shape'],
-  ['let causation_id_present = context.causation_id.is_some();', 'tenant causation shape'],
-  ['let traceparent_present = context.traceparent.is_some();', 'tenant trace shape'],
-  ['let idempotency_key_present = context.idempotency_key.is_some();', 'tenant idempotency shape'],
-  ['let internal_message_present = !error.message.trim().is_empty();', 'tenant message presence'],
-  ['let internal_message_length = error.message.chars().count();', 'tenant message length'],
-  ['let error_kind = "validation";', 'tenant closed kind'],
-  ['parse_cause_type,', 'tenant type-only cause diagnostic'],
-  ['correlation_id = %context.correlation_id', 'tenant correlation log'],
-  ['operation = owner_operation', 'tenant operation log'],
-  ['validation_phase = "tenant_id"', 'tenant validation phase'],
-  ['code = "fulfillment.tenant_id_invalid"', 'tenant code log'],
-  ['internal_code = %error.code', 'tenant internal code'],
-  ['retryable = error.retryable', 'tenant retryability'],
-  ['boundary = CHECKOUT_FULFILLMENT_BOUNDARY', 'tenant boundary'],
-  ['error\n    })', 'same tenant error returned'],
-]) requireText(tenantParser, value, label);
+  ['context: &PortContext', 'mapper context input'],
+  ["owner_operation: &'static str", 'mapper operation input'],
+  ['error: FulfillmentError', 'typed owner error input'],
+  ['let actor_kind = match &context.actor.kind', 'bounded actor kind'],
+  ['let tenant_id_length = context.tenant_id.chars().count();', 'tenant shape'],
+  ['let actor_id_length = context.actor.id.chars().count();', 'actor identity shape'],
+  ['let claim_count = context.claims.len();', 'claim count'],
+  ['let role_count = context.roles.len();', 'role count'],
+  ['let channel_present = context.channel.is_some();', 'channel presence'],
+  ['let channel_length = context.channel.as_ref()', 'channel length'],
+  ['let locale_length = context.locale.chars().count();', 'locale length'],
+  ['let causation_id_present = context.causation_id.is_some();', 'causation presence'],
+  ['let causation_id_length = context', 'causation length'],
+  ['let traceparent_present = context.traceparent.is_some();', 'traceparent presence'],
+  ['let traceparent_length = context', 'traceparent length'],
+  ['let idempotency_key_present = context.idempotency_key.is_some();', 'idempotency presence'],
+  ['let idempotency_key_length = context', 'idempotency length'],
+  ['FulfillmentError::Validation(cause)', 'validation branch'],
+  ['let validation_cause_present = !cause.trim().is_empty();', 'validation cause presence'],
+  ['let validation_cause_length = cause.chars().count();', 'validation cause length'],
+  ['owner_error_kind = "validation"', 'validation closed kind'],
+  ['FulfillmentError::ShippingOptionNotFound(id)', 'shipping option branch'],
+  ['let shipping_option_id_non_nil = !id.is_nil();', 'shipping identity shape'],
+  ['owner_error_kind = "shipping_option_not_found"', 'shipping closed kind'],
+  ['FulfillmentError::FulfillmentNotFound(id)', 'fulfillment branch'],
+  ['let fulfillment_id_non_nil = !id.is_nil();', 'fulfillment identity shape'],
+  ['owner_error_kind = "fulfillment_not_found"', 'fulfillment closed kind'],
+  ['FulfillmentError::InvalidTransition { from, to }', 'transition branch'],
+  ['let transition_from_present = !from.trim().is_empty();', 'transition from presence'],
+  ['let transition_from_length = from.chars().count();', 'transition from length'],
+  ['let transition_to_present = !to.trim().is_empty();', 'transition to presence'],
+  ['let transition_to_length = to.chars().count();', 'transition to length'],
+  ['let transition_changes_state = from != to;', 'transition relation fact'],
+  ['owner_error_kind = "invalid_transition"', 'transition closed kind'],
+  ['FulfillmentError::Database(error)', 'database branch'],
+  ['let database_error_type = std::any::type_name_of_val(&error);', 'database type-only cause'],
+  ['owner_error_kind = "database"', 'database closed kind'],
+  ['owner = CHECKOUT_FULFILLMENT_OWNER', 'truthful owner diagnostic'],
+  ['operation = owner_operation', 'exact owner operation diagnostic'],
+  ['correlation_id = %context.correlation_id', 'correlation diagnostic'],
+  ['deadline_ms = ?context.deadline_ms', 'deadline diagnostic'],
+  ['boundary = CHECKOUT_FULFILLMENT_BOUNDARY', 'owner mapper boundary'],
+  ['code = "fulfillment.checkout_execution_validation"', 'validation stable code'],
+  ['code = "fulfillment.shipping_option_not_found"', 'shipping stable code'],
+  ['code = "fulfillment.fulfillment_not_found"', 'fulfillment stable code'],
+  ['code = "fulfillment.checkout_execution_state_conflict"', 'transition stable code'],
+  ['code = "fulfillment.database_unavailable"', 'database stable code'],
+  ['"checkout fulfillment request is invalid"', 'static validation public message'],
+  ['"shipping option was not found"', 'static shipping public message'],
+  ['"fulfillment was not found"', 'static fulfillment public message'],
+  ['"fulfillment lifecycle conflicts with checkout execution"', 'static transition public message'],
+  ['"fulfillment storage is temporarily unavailable"', 'static database public message'],
+]) requireText(mapper, value, label);
+
 for (const value of [
-  'cause = ?cause',
   'cause = %cause',
+  'cause = ?cause',
+  'shipping_option_id = %id',
+  'fulfillment_id = %id',
+  'from = %from',
+  'to = %to',
   'error = ?error',
   'error = %error',
   'tenant_id = %context.tenant_id',
@@ -173,43 +217,87 @@ for (const value of [
   'causation_id = ?context.causation_id',
   'traceparent = ?context.traceparent',
   'idempotency_key = ?context.idempotency_key',
-  'internal_message = %error.message',
-  'error_kind = ?error.kind',
-]) forbidText(tenantParser, value, 'unsafe tenant diagnostic payload');
+]) forbidText(mapper, value, 'unsafe canonical owner diagnostic payload');
 
-for (const [value, label] of [
-  ['context: &PortContext', 'mapper context input'],
-  ["owner_operation: &'static str", 'mapper operation input'],
-  ['FulfillmentError::Validation(cause)', 'validation cause capture'],
-  ['FulfillmentError::ShippingOptionNotFound(id)', 'shipping option identity capture'],
-  ['FulfillmentError::FulfillmentNotFound(id)', 'fulfillment identity capture'],
-  ['FulfillmentError::InvalidTransition { from, to }', 'transition cause capture'],
-  ['FulfillmentError::Database(error)', 'database cause capture'],
-  ['correlation_id = %context.correlation_id', 'mapper correlation log'],
-  ['tenant_id = %context.tenant_id', 'mapper tenant log'],
-  ['channel = ?context.channel', 'mapper channel log'],
-  ['operation = owner_operation', 'mapper operation log'],
-  ['code = "fulfillment.checkout_execution_validation"', 'validation stable code log'],
-  ['code = "fulfillment.shipping_option_not_found"', 'shipping stable code log'],
-  ['code = "fulfillment.fulfillment_not_found"', 'fulfillment stable code log'],
-  ['code = "fulfillment.checkout_execution_state_conflict"', 'transition stable code log'],
-  ['code = "fulfillment.database_unavailable"', 'database stable code log'],
-  ['"checkout fulfillment request is invalid"', 'static validation public message'],
-  ['"shipping option was not found"', 'static shipping public message'],
-  ['"fulfillment was not found"', 'static fulfillment public message'],
-  ['"fulfillment lifecycle conflicts with checkout execution"', 'static transition public message'],
-  ['"fulfillment storage is temporarily unavailable"', 'static database public message'],
-]) requireText(mapper, value, label);
-
-for (const value of [
-  '.map_err(fulfillment_error_to_port_error)',
-  'tracing::error!(error = ?error, "checkout fulfillment storage failed")',
-  'FulfillmentError::Validation(_) =>',
-]) forbidText(source, value, 'context-free checkout fulfillment mapping');
+if (countText(mapper, 'tracing::warn!(') !== 4) {
+  failures.push('expected exactly four ordinary owner warning branches');
+}
+if (countText(mapper, 'tracing::error!(') !== 1) {
+  failures.push('expected exactly one database owner error branch');
+}
+for (const marker of [
+  'owner = CHECKOUT_FULFILLMENT_OWNER',
+  'operation = owner_operation',
+  'correlation_id = %context.correlation_id',
+  'boundary = CHECKOUT_FULFILLMENT_BOUNDARY',
+]) {
+  if (countText(mapper, marker) !== 5) {
+    failures.push(`all five owner branches must retain ${marker}`);
+  }
+}
 
 const mapperUses = source.match(/fulfillment_error_to_port_error\(/g) ?? [];
 if (mapperUses.length !== 4) {
   failures.push(`expected mapper definition plus three service mappings, found ${mapperUses.length}`);
+}
+for (const [value, label] of [
+  ['"create_checkout_fulfillment"', 'create service operation'],
+  ['"list_checkout_fulfillments_for_read"', 'read service operation'],
+  ['"find_checkout_fulfillment_before_create"', 'pre-create lookup service operation'],
+  ['"adopt_checkout_fulfillment_after_create_error"', 'post-error lookup service operation'],
+]) requireText(source, value, label);
+
+for (const value of [
+  '.map_err(fulfillment_error_to_port_error)',
+  'FulfillmentError::Validation(_) =>',
+]) forbidText(source, value, 'context-free checkout fulfillment mapping');
+
+if (evidence.status !== 'fulfillment_checkout_owner_mapper_diagnostic_safety_source_unvalidated') {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  canonical_owner_mapper_bounded: true,
+  validation_cause_shape_only: true,
+  shipping_option_identity_shape_only: true,
+  fulfillment_identity_shape_only: true,
+  transition_shape_only: true,
+  database_cause_type_only: true,
+  owner_context_shape_only: true,
+  raw_owner_causes_logged: false,
+  raw_owner_identifiers_logged: false,
+  raw_owner_transition_values_logged: false,
+  raw_owner_context_logged: false,
+  owner_correlation_preserved: true,
+  owner_operations_preserved: true,
+  owner_error_kind_closed: true,
+  owner_severity_preserved: true,
+  stable_public_envelopes_preserved: true,
+  service_mapper_call_sites_preserved: true,
+  checkout_execution_mapper_cleanup_source_complete: true,
+  execution_behavior_changed: false,
+  public_port_error_changed: false,
+  ffa_promoted: false,
+  fba_promoted: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push('evidence execution must remain empty');
+}
+for (const key of [
+  'tests_run',
+  'cargo_run',
+  'format_run',
+  'verifiers_run',
+  'workflow_checks_run',
+  'ci_run',
+  'runtime_proven',
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
 }
 
 for (const [value, label] of [
@@ -221,10 +309,21 @@ for (const [value, label] of [
   ['pub fn unavailable(', 'typed unavailable constructor'],
 ]) requireText(portContract, value, label);
 
+for (const [value, label] of [
+  ['Status: **source-ready / unvalidated**', 'documentation status'],
+  ['Variant-specific evidence is bounded as follows', 'documentation variant policy'],
+  ['The validation, shipping-option not-found, fulfillment not-found, and invalid-transition', 'documentation warning severity'],
+  ['The database branch remains a `tracing::error!` event', 'documentation database severity'],
+  ['makes the mounted Fulfillment checkout execution diagnostic mapper surface source-complete', 'documentation source completion boundary'],
+  ['The broad ecommerce correlation-safe mapper item remains open', 'documentation broad residual'],
+]) requireText(doc, value, label);
+
 if (failures.length > 0) {
-  console.error('Fulfillment checkout execution error-safety verification failed:');
+  console.error('Fulfillment checkout execution owner mapper diagnostic-safety verification failed:');
   for (const failure of failures) console.error(`✗ ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log('✔ Fulfillment checkout execution owner errors retain bounded causation and tenant context with stable public envelopes');
+console.log(
+  '✔ Fulfillment checkout owner mapper diagnostics use bounded variant and context facts while preserving all public envelopes and service mappings',
+);

--- a/scripts/verify/verify-fulfillment-checkout-local-validation-context.mjs
+++ b/scripts/verify/verify-fulfillment-checkout-local-validation-context.mjs
@@ -236,8 +236,8 @@ for (const [pattern, expected, label] of [
   [/"collect_checkout_fulfillment_set"/g, 1, 'set collection operation count'],
   [/"require_complete_checkout_fulfillment_set"/g, 2, 'set completeness operation count'],
   [/"find_checkout_fulfillment_by_key"/g, 1, 'identity lookup operation count'],
-  [/owner = CHECKOUT_FULFILLMENT_OWNER/g, 6, 'owner diagnostic count'],
-  [/boundary = CHECKOUT_FULFILLMENT_BOUNDARY/g, 6, 'boundary diagnostic count'],
+  [/owner = CHECKOUT_FULFILLMENT_OWNER/g, 11, 'owner diagnostic count'],
+  [/boundary = CHECKOUT_FULFILLMENT_BOUNDARY/g, 11, 'boundary diagnostic count'],
 ]) {
   const count = source.match(pattern)?.length ?? 0;
   if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);


### PR DESCRIPTION
## Summary

- continue the ecommerce correlation-safe mapper cleanup at the Fulfillment checkout execution boundary;
- harden only `fulfillment_error_to_port_error` at runtime;
- replace raw validation text, shipping-option and fulfillment UUIDs, transition strings, complete database errors, and raw delegated context with bounded variant/context facts;
- preserve the five exact `PortError` constructors, codes, messages, kinds, retryability values, and the existing four-warning/one-error severity split;
- preserve create, read-list, pre-create lookup, and post-error adoption service operation routing;
- add source-only owner-mapper evidence and a focused fail-closed guard;
- synchronize existing context/local guards and related documentation with the completed Fulfillment checkout execution mapper source boundary.

## Covered runtime boundary

- `fulfillment_error_to_port_error`

## Deliberate boundary

This PR does not change admission, tenant, causation, or local-`PortError` mappers, request/immutable-plan validation, service call sites, create/adoption/read ordering, DTOs, metadata, Commerce orchestration, or public `PortError` envelopes.

Together with the previously merged admission, tenant, causation, and local-`PortError` slices, this makes only the mounted Fulfillment checkout execution diagnostic mapper surface source-complete. The broad ecommerce correlation-safe mapper P0 remains open. Ecommerce audit, FFA, and FBA gates are not promoted.

## Validation

Tests, Node verifiers, formatting, Cargo checks, mounted execution, workflows, and CI were not run, per maintainer request.

Suggested maintainer commands:

```bash
node scripts/verify/verify-fulfillment-checkout-execution-error-safety.mjs
node scripts/verify/verify-fulfillment-checkout-context-validation.mjs
node scripts/verify/verify-fulfillment-checkout-local-validation-context.mjs
node scripts/verify/verify-fulfillment-checkout-admission-context.mjs
node scripts/verify/verify-fulfillment-checkout-local-porterror-diagnostic-safety.mjs
cargo check -p rustok-fulfillment --lib
```

Branch base: `f272dd25a4753923dd7954f8791dc2d734ad820d`. Current `main` contains a later unrelated Forum commit.