### PR TITLE
feat(index): inspect open drift findings

### DIFF
--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -39,6 +39,7 @@ This directory contains the detailed technical architecture documentation for `r
 - [M6 Reconciliation Retry Transition Store](./m6-reconciliation-retry-transition-store.md)
 - [M6 Reconciliation Runner Retry Wiring](./m6-reconciliation-runner-retry-wiring.md)
 - [M6 Reconciliation Host Scheduler](./m6-reconciliation-host-scheduler.md)
+- [M6 Drift Finding Inspection](./m6-drift-finding-inspection.md)
 - [M6 Reconciliation Dead-letter Admission](./m6-reconciliation-dead-letter-admission.md)
 - [M6 Reconciliation Dead-letter Inspection](./m6-reconciliation-dead-letter-inspection.md)
 - [M6 Reconciliation Dead-letter Requeue](./m6-reconciliation-dead-letter-requeue.md)

--- a/crates/rustok-index/docs/m6-drift-finding-inspection.md
+++ b/crates/rustok-index/docs/m6-drift-finding-inspection.md
@@ -1,0 +1,84 @@
+# M6 drift finding inspection
+
+Status: `source_complete_server_authorization_and_repair_pending`.
+
+## Purpose
+
+`PostgresIndexDriftFindingInspector` provides one bounded read-only diagnosis boundary over an exact open row in `index_consistency_findings`.
+
+The adapter accepts one non-nil tenant UUID and one non-nil finding UUID. Its query is restricted to that exact pair and `state = 'open'`. Resolved, ignored, cross-tenant, and unknown findings return no inspection.
+
+This slice consumes the existing canonical findings table. It does not create a finding writer, compare source and Index state, infer drift, or mutate repair state.
+
+## Returned contract
+
+A successful inspection contains only:
+
+- finding UUID;
+- exact lowercase SHA-256 finding key;
+- bounded check name;
+- typed `info`, `warning`, or `error` severity;
+- typed global, schema, or entity scope;
+- optional exact lowercase SHA-256 expected digest;
+- optional exact lowercase SHA-256 actual digest.
+
+Schema scope returns a validated `SchemaRef`. Entity scope additionally returns one non-nil entity UUID and one canonical `LocaleKey`.
+
+Stored scope columns must match the existing migration contract exactly. Global scope carries no schema/entity/locale identity. Schema scope carries module, entity, and positive schema version only. Entity scope carries that schema plus non-nil entity UUID and canonical locale. Any mismatch fails closed through `InvalidStoredFinding`.
+
+Finding keys and digests must be exactly 64 lowercase hexadecimal bytes. Check names must be non-empty, trimmed, control-character-free, and at most 128 UTF-8 bytes.
+
+## Privacy and read-only boundary
+
+The SELECT deliberately excludes:
+
+- tenant identity;
+- raw `details` JSON;
+- first- and last-detected timestamps;
+- closure timestamp;
+- job, worker, lease, cursor, source, mutation, and transport data;
+- SQL and database causes.
+
+Database failures map to one stable detail-free `Storage` error.
+
+The adapter performs no insert, update, delete, state transition, finding acknowledgement, repair admission, source scan, targeted load, scheduling, polling, sleep, or task creation.
+
+## Authorization boundary
+
+This crate adapter is not an authorization or transport surface. It accepts no actor, permission snapshot, bearer identity, or caller-selected repair action.
+
+A later server composition must bind the tenant exclusively from the existing request-bound operator context, require effective `modules:manage` before adapter validation or database access, and expose only the bounded inspection value. GraphQL, HTTP, CLI, MCP, native admin, and other transports remain open.
+
+## Repair boundary
+
+This inspection does not claim that an open finding is correct, current, repairable, or admitted for production mutation.
+
+Targeted repair requires separate contracts for:
+
+- authoritative source snapshot or high-watermark identity;
+- supported finding/check classes;
+- exact target keys and bounded targeted loads;
+- advisory locking and concurrency fencing;
+- immutable actor/reason and before/after evidence;
+- dry-run, targeted, full, and shadow modes;
+- post-repair digest verification and retained PostgreSQL evidence.
+
+No automatic finding closure or mutation is allowed from inspection alone.
+
+## Explicitly open
+
+- request-bound server authorization and internal operator composition;
+- source/index digest comparison and finding persistence;
+- orphan diagnosis;
+- targeted repair request/admission and immutable repair audit;
+- full and shadow repair modes;
+- automatic finding resolution after admitted repair;
+- locale or partition checkpoint dimensions;
+- retained PostgreSQL inspection, diagnosis, repair, and concurrency evidence;
+- public/admin command transport.
+
+The canonical roadmap item `Add drift diagnosis, targeted repair commands, and admitted repair evidence` remains open. This slice establishes only the bounded read-only inspection substrate.
+
+## Validation ownership
+
+Formatting, Cargo checks/tests, JavaScript verifiers, SQLite/PostgreSQL scenarios, workflows, and CI are maintainer-run and were not executed by the implementation agent.

--- a/crates/rustok-index/src/infrastructure/postgres/drift_finding_inspector.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/drift_finding_inspector.rs
@@ -1,0 +1,531 @@
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DbBackend, QueryResult, Statement, Value as SqlValue,
+};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::{EntityName, LocaleKey, ModuleName, SchemaRef, SchemaVersion};
+
+const DIGEST_BYTES: usize = 64;
+const MAX_CHECK_NAME_BYTES: usize = 128;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexDriftFindingSeverity {
+    Info,
+    Warning,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IndexDriftFindingScope {
+    Global,
+    Schema { schema: SchemaRef },
+    Entity {
+        schema: SchemaRef,
+        entity_id: Uuid,
+        locale: LocaleKey,
+    },
+}
+
+/// Bounded read-only diagnosis of one open consistency finding.
+///
+/// The result intentionally excludes tenant identity, raw `details`, detection
+/// timestamps, and closure state. It exposes only stable finding identity, bounded
+/// classification, exact typed scope, and optional digest evidence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexDriftFindingInspection {
+    finding_id: Uuid,
+    finding_key: String,
+    check_name: String,
+    severity: IndexDriftFindingSeverity,
+    scope: IndexDriftFindingScope,
+    expected_digest: Option<String>,
+    actual_digest: Option<String>,
+}
+
+impl IndexDriftFindingInspection {
+    pub fn finding_id(&self) -> Uuid {
+        self.finding_id
+    }
+
+    pub fn finding_key(&self) -> &str {
+        &self.finding_key
+    }
+
+    pub fn check_name(&self) -> &str {
+        &self.check_name
+    }
+
+    pub fn severity(&self) -> IndexDriftFindingSeverity {
+        self.severity
+    }
+
+    pub fn scope(&self) -> &IndexDriftFindingScope {
+        &self.scope
+    }
+
+    pub fn expected_digest(&self) -> Option<&str> {
+        self.expected_digest.as_deref()
+    }
+
+    pub fn actual_digest(&self) -> Option<&str> {
+        self.actual_digest.as_deref()
+    }
+}
+
+/// PostgreSQL-backed read-only inspector for one exact open drift finding.
+///
+/// Authorization is deliberately not accepted as adapter data. A server or other
+/// operator boundary must authorize the exact tenant before calling `inspect`.
+#[derive(Clone)]
+pub struct PostgresIndexDriftFindingInspector {
+    db: DatabaseConnection,
+}
+
+impl PostgresIndexDriftFindingInspector {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    pub async fn inspect(
+        &self,
+        tenant_id: Uuid,
+        finding_id: Uuid,
+    ) -> Result<Option<IndexDriftFindingInspection>, IndexDriftFindingInspectionError> {
+        if tenant_id.is_nil() {
+            return Err(IndexDriftFindingInspectionError::NilTenantId);
+        }
+        if finding_id.is_nil() {
+            return Err(IndexDriftFindingInspectionError::NilFindingId);
+        }
+
+        let backend = self.db.get_database_backend();
+        ensure_supported_backend(backend)?;
+        let row = self
+            .db
+            .query_one(Statement::from_sql_and_values(
+                backend,
+                select_open_finding_sql(backend),
+                vec![uuid_value(tenant_id, backend), uuid_value(finding_id, backend)],
+            ))
+            .await
+            .map_err(|_| IndexDriftFindingInspectionError::Storage)?;
+        row.map(|row| decode_open_finding(&row, finding_id, backend))
+            .transpose()
+    }
+}
+
+fn decode_open_finding(
+    row: &QueryResult,
+    finding_id: Uuid,
+    backend: DbBackend,
+) -> Result<IndexDriftFindingInspection, IndexDriftFindingInspectionError> {
+    let finding_key: String = row
+        .try_get("", "finding_key")
+        .map_err(|_| IndexDriftFindingInspectionError::Storage)?;
+    validate_digest(&finding_key).map_err(|_| {
+        IndexDriftFindingInspectionError::InvalidStoredFinding(
+            "finding key is outside the lowercase SHA-256 contract",
+        )
+    })?;
+
+    let check_name: String = row
+        .try_get("", "check_name")
+        .map_err(|_| IndexDriftFindingInspectionError::Storage)?;
+    validate_check_name(&check_name).map_err(|_| {
+        IndexDriftFindingInspectionError::InvalidStoredFinding(
+            "check name is outside the bounded text contract",
+        )
+    })?;
+
+    let severity: String = row
+        .try_get("", "severity")
+        .map_err(|_| IndexDriftFindingInspectionError::Storage)?;
+    let severity = match severity.as_str() {
+        "info" => IndexDriftFindingSeverity::Info,
+        "warning" => IndexDriftFindingSeverity::Warning,
+        "error" => IndexDriftFindingSeverity::Error,
+        _ => {
+            return Err(IndexDriftFindingInspectionError::InvalidStoredFinding(
+                "severity is unsupported",
+            ));
+        }
+    };
+
+    let scope_kind: String = row
+        .try_get("", "scope_kind")
+        .map_err(|_| IndexDriftFindingInspectionError::Storage)?;
+    let module_name: Option<String> = row
+        .try_get("", "module_name")
+        .map_err(|_| IndexDriftFindingInspectionError::Storage)?;
+    let entity_name: Option<String> = row
+        .try_get("", "entity_name")
+        .map_err(|_| IndexDriftFindingInspectionError::Storage)?;
+    let schema_version: Option<i64> = row
+        .try_get("", "schema_version_value")
+        .map_err(|_| IndexDriftFindingInspectionError::Storage)?;
+    let entity_id = optional_uuid(row, "entity_id", backend)?;
+    let locale_key: Option<String> = row
+        .try_get("", "locale_key")
+        .map_err(|_| IndexDriftFindingInspectionError::Storage)?;
+    let scope = decode_scope(
+        &scope_kind,
+        module_name,
+        entity_name,
+        schema_version,
+        entity_id,
+        locale_key,
+    )?;
+
+    let expected_digest: Option<String> = row
+        .try_get("", "expected_digest")
+        .map_err(|_| IndexDriftFindingInspectionError::Storage)?;
+    validate_optional_digest(expected_digest.as_deref(), "expected digest")?;
+    let actual_digest: Option<String> = row
+        .try_get("", "actual_digest")
+        .map_err(|_| IndexDriftFindingInspectionError::Storage)?;
+    validate_optional_digest(actual_digest.as_deref(), "actual digest")?;
+
+    Ok(IndexDriftFindingInspection {
+        finding_id,
+        finding_key,
+        check_name,
+        severity,
+        scope,
+        expected_digest,
+        actual_digest,
+    })
+}
+
+fn decode_scope(
+    scope_kind: &str,
+    module_name: Option<String>,
+    entity_name: Option<String>,
+    schema_version: Option<i64>,
+    entity_id: Option<Uuid>,
+    locale_key: Option<String>,
+) -> Result<IndexDriftFindingScope, IndexDriftFindingInspectionError> {
+    match scope_kind {
+        "global" => {
+            if module_name.is_some()
+                || entity_name.is_some()
+                || schema_version.is_some()
+                || entity_id.is_some()
+                || locale_key.is_some()
+            {
+                return Err(invalid_scope());
+            }
+            Ok(IndexDriftFindingScope::Global)
+        }
+        "schema" => {
+            if entity_id.is_some() || locale_key.is_some() {
+                return Err(invalid_scope());
+            }
+            Ok(IndexDriftFindingScope::Schema {
+                schema: decode_schema(module_name, entity_name, schema_version)?,
+            })
+        }
+        "entity" => {
+            let schema = decode_schema(module_name, entity_name, schema_version)?;
+            let entity_id = entity_id.filter(|value| !value.is_nil()).ok_or_else(invalid_scope)?;
+            let stored_locale = locale_key.ok_or_else(invalid_scope)?;
+            let locale = LocaleKey::new(&stored_locale).map_err(|_| invalid_scope())?;
+            if locale.as_str() != stored_locale {
+                return Err(invalid_scope());
+            }
+            Ok(IndexDriftFindingScope::Entity {
+                schema,
+                entity_id,
+                locale,
+            })
+        }
+        _ => Err(invalid_scope()),
+    }
+}
+
+fn decode_schema(
+    module_name: Option<String>,
+    entity_name: Option<String>,
+    schema_version: Option<i64>,
+) -> Result<SchemaRef, IndexDriftFindingInspectionError> {
+    let module = ModuleName::new(module_name.ok_or_else(invalid_scope)?)
+        .map_err(|_| invalid_scope())?;
+    let entity = EntityName::new(entity_name.ok_or_else(invalid_scope)?)
+        .map_err(|_| invalid_scope())?;
+    let version = schema_version.ok_or_else(invalid_scope)?;
+    let version = u32::try_from(version).map_err(|_| invalid_scope())?;
+    if version == 0 {
+        return Err(invalid_scope());
+    }
+    Ok(SchemaRef {
+        module,
+        entity,
+        version: SchemaVersion::new(version),
+    })
+}
+
+fn validate_check_name(value: &str) -> Result<(), ()> {
+    if value.is_empty()
+        || value.len() > MAX_CHECK_NAME_BYTES
+        || value.trim() != value
+        || value.chars().any(char::is_control)
+    {
+        return Err(());
+    }
+    Ok(())
+}
+
+fn validate_optional_digest(
+    value: Option<&str>,
+    label: &'static str,
+) -> Result<(), IndexDriftFindingInspectionError> {
+    if value.is_some_and(|value| validate_digest(value).is_err()) {
+        return Err(IndexDriftFindingInspectionError::InvalidStoredFinding(
+            match label {
+                "expected digest" => "expected digest is outside the lowercase SHA-256 contract",
+                _ => "actual digest is outside the lowercase SHA-256 contract",
+            },
+        ));
+    }
+    Ok(())
+}
+
+fn validate_digest(value: &str) -> Result<(), ()> {
+    if value.len() != DIGEST_BYTES
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(());
+    }
+    Ok(())
+}
+
+fn invalid_scope() -> IndexDriftFindingInspectionError {
+    IndexDriftFindingInspectionError::InvalidStoredFinding(
+        "finding scope does not match the persisted scope contract",
+    )
+}
+
+fn ensure_supported_backend(
+    backend: DbBackend,
+) -> Result<(), IndexDriftFindingInspectionError> {
+    match backend {
+        DbBackend::Postgres => Ok(()),
+        DbBackend::Sqlite if cfg!(test) => Ok(()),
+        _ => Err(IndexDriftFindingInspectionError::UnsupportedBackend),
+    }
+}
+
+fn placeholder_prefix(backend: DbBackend) -> &'static str {
+    match backend {
+        DbBackend::Postgres => "$",
+        DbBackend::Sqlite => "?",
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+fn uuid_value(value: Uuid, backend: DbBackend) -> SqlValue {
+    match backend {
+        DbBackend::Postgres => value.into(),
+        DbBackend::Sqlite => value.to_string().into(),
+        _ => unreachable!("unsupported database backend was validated"),
+    }
+}
+
+fn optional_uuid(
+    row: &QueryResult,
+    column: &str,
+    backend: DbBackend,
+) -> Result<Option<Uuid>, IndexDriftFindingInspectionError> {
+    match backend {
+        DbBackend::Postgres => row
+            .try_get("", column)
+            .map_err(|_| IndexDriftFindingInspectionError::Storage),
+        DbBackend::Sqlite => {
+            let value: Option<String> = row
+                .try_get("", column)
+                .map_err(|_| IndexDriftFindingInspectionError::Storage)?;
+            value
+                .map(|value| Uuid::parse_str(&value).map_err(|_| invalid_scope()))
+                .transpose()
+        }
+        _ => Err(IndexDriftFindingInspectionError::UnsupportedBackend),
+    }
+}
+
+fn select_open_finding_sql(backend: DbBackend) -> String {
+    let prefix = placeholder_prefix(backend);
+    let schema_version = match backend {
+        DbBackend::Postgres => "CAST(schema_version AS BIGINT)",
+        DbBackend::Sqlite => "CAST(schema_version AS INTEGER)",
+        _ => unreachable!("unsupported database backend was validated"),
+    };
+    format!(
+        "SELECT finding_key, check_name, severity, scope_kind, module_name, entity_name, {schema_version} AS schema_version_value, entity_id, locale_key, expected_digest, actual_digest FROM index_consistency_findings WHERE tenant_id = {prefix}1 AND finding_id = {prefix}2 AND state = 'open' LIMIT 1"
+    )
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum IndexDriftFindingInspectionError {
+    #[error("Index drift finding inspection tenant id must not be nil")]
+    NilTenantId,
+    #[error("Index drift finding inspection finding id must not be nil")]
+    NilFindingId,
+    #[error("stored Index drift finding is invalid: {0}")]
+    InvalidStoredFinding(&'static str),
+    #[error("Index drift finding inspection does not support this database backend")]
+    UnsupportedBackend,
+    #[error("Index drift finding inspection storage operation failed")]
+    Storage,
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{Database, DbBackend, Statement};
+    use serde_json::json;
+
+    use super::*;
+
+    async fn database() -> DatabaseConnection {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+        db.execute(Statement::from_string(
+            DbBackend::Sqlite,
+            "CREATE TABLE index_consistency_findings (tenant_id TEXT NOT NULL, finding_id TEXT NOT NULL, finding_key TEXT NOT NULL, check_name TEXT NOT NULL, severity TEXT NOT NULL, state TEXT NOT NULL, scope_kind TEXT NOT NULL, module_name TEXT NULL, entity_name TEXT NULL, schema_version INTEGER NULL, entity_id TEXT NULL, locale_key TEXT NULL, expected_digest TEXT NULL, actual_digest TEXT NULL, details JSON NOT NULL)"
+                .to_owned(),
+        ))
+        .await
+        .expect("finding fixture");
+        db
+    }
+
+    async fn insert_entity_finding(
+        db: &DatabaseConnection,
+        tenant_id: Uuid,
+        finding_id: Uuid,
+        state: &str,
+        actual_digest: &str,
+    ) {
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO index_consistency_findings (tenant_id, finding_id, finding_key, check_name, severity, state, scope_kind, module_name, entity_name, schema_version, entity_id, locale_key, expected_digest, actual_digest, details) VALUES (?1, ?2, ?3, ?4, 'error', ?5, 'entity', 'rustok-product', 'product', 2, ?6, 'en-US', ?7, ?8, ?9)",
+            vec![
+                tenant_id.to_string().into(),
+                finding_id.to_string().into(),
+                "a".repeat(DIGEST_BYTES).into(),
+                "entity_digest_mismatch".into(),
+                state.into(),
+                Uuid::from_u128(7).to_string().into(),
+                "b".repeat(DIGEST_BYTES).into(),
+                actual_digest.into(),
+                SqlValue::Json(Some(Box::new(json!({
+                    "private_owner_detail": "must-not-cross-inspection-boundary"
+                })))),
+            ],
+        ))
+        .await
+        .expect("finding insert");
+    }
+
+    #[tokio::test]
+    async fn inspection_is_tenant_scoped_open_and_bounded() {
+        let db = database().await;
+        let tenant_id = Uuid::new_v4();
+        let finding_id = Uuid::new_v4();
+        insert_entity_finding(
+            &db,
+            tenant_id,
+            finding_id,
+            "open",
+            &"c".repeat(DIGEST_BYTES),
+        )
+        .await;
+        let inspector = PostgresIndexDriftFindingInspector::new(db.clone());
+
+        assert!(
+            inspector
+                .inspect(Uuid::new_v4(), finding_id)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        let inspection = inspector
+            .inspect(tenant_id, finding_id)
+            .await
+            .unwrap()
+            .expect("exact open finding");
+        assert_eq!(inspection.finding_id(), finding_id);
+        assert_eq!(inspection.finding_key(), "a".repeat(DIGEST_BYTES));
+        assert_eq!(inspection.check_name(), "entity_digest_mismatch");
+        assert_eq!(inspection.severity(), IndexDriftFindingSeverity::Error);
+        assert_eq!(inspection.expected_digest(), Some("b".repeat(DIGEST_BYTES).as_str()));
+        assert_eq!(inspection.actual_digest(), Some("c".repeat(DIGEST_BYTES).as_str()));
+        match inspection.scope() {
+            IndexDriftFindingScope::Entity {
+                schema,
+                entity_id,
+                locale,
+            } => {
+                assert_eq!(schema.module.as_str(), "rustok-product");
+                assert_eq!(schema.entity.as_str(), "product");
+                assert_eq!(schema.version.get(), 2);
+                assert_eq!(*entity_id, Uuid::from_u128(7));
+                assert_eq!(locale.as_str(), "en-US");
+            }
+            other => panic!("unexpected scope: {other:?}"),
+        }
+
+        let resolved_id = Uuid::new_v4();
+        insert_entity_finding(
+            &db,
+            tenant_id,
+            resolved_id,
+            "resolved",
+            &"d".repeat(DIGEST_BYTES),
+        )
+        .await;
+        assert!(inspector.inspect(tenant_id, resolved_id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn inspection_fails_closed_on_invalid_digest() {
+        let db = database().await;
+        let tenant_id = Uuid::new_v4();
+        let finding_id = Uuid::new_v4();
+        insert_entity_finding(&db, tenant_id, finding_id, "open", "not-a-digest").await;
+        let inspector = PostgresIndexDriftFindingInspector::new(db);
+
+        assert!(matches!(
+            inspector.inspect(tenant_id, finding_id).await,
+            Err(IndexDriftFindingInspectionError::InvalidStoredFinding(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn inspection_fails_closed_on_scope_mismatch() {
+        let db = database().await;
+        let tenant_id = Uuid::new_v4();
+        let finding_id = Uuid::new_v4();
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO index_consistency_findings (tenant_id, finding_id, finding_key, check_name, severity, state, scope_kind, module_name, entity_name, schema_version, entity_id, locale_key, expected_digest, actual_digest, details) VALUES (?1, ?2, ?3, 'scope_mismatch', 'warning', 'open', 'schema', 'rustok-product', 'product', 1, ?4, NULL, NULL, NULL, ?5)",
+            vec![
+                tenant_id.to_string().into(),
+                finding_id.to_string().into(),
+                "e".repeat(DIGEST_BYTES).into(),
+                Uuid::new_v4().to_string().into(),
+                SqlValue::Json(Some(Box::new(json!({})))),
+            ],
+        ))
+        .await
+        .expect("invalid scope fixture");
+        let inspector = PostgresIndexDriftFindingInspector::new(db);
+
+        assert!(matches!(
+            inspector.inspect(tenant_id, finding_id).await,
+            Err(IndexDriftFindingInspectionError::InvalidStoredFinding(_))
+        ));
+    }
+}

--- a/crates/rustok-index/src/infrastructure/postgres/mod.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/mod.rs
@@ -1,3 +1,4 @@
+mod drift_finding_inspector;
 mod mutation_store;
 mod partition_admission;
 mod query_port;
@@ -36,6 +37,10 @@ mod source_replay_job_tests;
 #[cfg(test)]
 mod source_replay_runner_tests;
 
+pub use drift_finding_inspector::{
+    IndexDriftFindingInspection, IndexDriftFindingInspectionError, IndexDriftFindingScope,
+    IndexDriftFindingSeverity, PostgresIndexDriftFindingInspector,
+};
 pub use mutation_store::{
     MutationApplyOutcome, MutationDelivery, MutationStorageError, PostgresMutationStore,
 };

--- a/scripts/verify/verify-index-drift-finding-inspection.mjs
+++ b/scripts/verify/verify-index-drift-finding-inspection.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-drift-finding-inspection] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const inspectorPath =
+  'crates/rustok-index/src/infrastructure/postgres/drift_finding_inspector.rs';
+const inspector = requireMarkers(inspectorPath, [
+  'pub enum IndexDriftFindingSeverity',
+  'pub enum IndexDriftFindingScope',
+  'pub struct IndexDriftFindingInspection',
+  'pub struct PostgresIndexDriftFindingInspector',
+  'pub async fn inspect(',
+  'if tenant_id.is_nil()',
+  'if finding_id.is_nil()',
+  'fn decode_open_finding(',
+  'fn decode_scope(',
+  'fn decode_schema(',
+  'fn validate_check_name(',
+  'fn validate_digest(',
+  'fn select_open_finding_sql(',
+  'IndexDriftFindingInspectionError::InvalidStoredFinding',
+  'inspection_is_tenant_scoped_open_and_bounded',
+  'inspection_fails_closed_on_invalid_digest',
+  'inspection_fails_closed_on_scope_mismatch',
+]);
+
+const production = inspector.split('\n#[cfg(test)]')[0];
+for (const forbidden of [
+  'INSERT INTO',
+  'UPDATE ',
+  'DELETE ',
+  'tokio::spawn',
+  'spawn_blocking',
+  'tokio::time::sleep',
+  'Router::new',
+  'async_graphql',
+  'PostgresMutationStore',
+  '.sources.scan(',
+  '.sources.load(',
+  'repair_finding',
+  'resolve_finding',
+]) {
+  if (production.includes(forbidden)) {
+    fail(`${inspectorPath} production boundary contains forbidden marker ${forbidden}`);
+  }
+}
+
+const sqlStart = production.indexOf('fn select_open_finding_sql(');
+const errorStart = production.indexOf('\n#[derive(Debug, Error', sqlStart);
+if (sqlStart < 0 || errorStart <= sqlStart) {
+  fail(`${inspectorPath} bounded SELECT segment is missing`);
+}
+const sql = production.slice(sqlStart, errorStart);
+for (const marker of [
+  'SELECT finding_key, check_name, severity, scope_kind, module_name, entity_name,',
+  'schema_version_value, entity_id, locale_key, expected_digest, actual_digest',
+  'FROM index_consistency_findings',
+  'WHERE tenant_id = {prefix}1',
+  'finding_id = {prefix}2',
+  "state = 'open'",
+  'LIMIT 1',
+]) {
+  if (!sql.includes(marker)) fail(`${inspectorPath} SELECT is missing ${marker}`);
+}
+for (const forbidden of [
+  'SELECT tenant_id',
+  'details',
+  'first_detected_at',
+  'last_detected_at',
+  'closed_at',
+  'job_id',
+  'lease_owner',
+  'cursor',
+]) {
+  if (sql.includes(forbidden)) {
+    fail(`${inspectorPath} SELECT exposes forbidden field ${forbidden}`);
+  }
+}
+
+for (const marker of [
+  'value.len() != DIGEST_BYTES',
+  "matches!(byte, b'a'..=b'f')",
+  'value.len() > MAX_CHECK_NAME_BYTES',
+  'value.trim() != value',
+  'value.chars().any(char::is_control)',
+  '"global" =>',
+  '"schema" =>',
+  '"entity" =>',
+  'entity_id.filter(|value| !value.is_nil())',
+  'LocaleKey::new(&stored_locale)',
+  'locale.as_str() != stored_locale',
+  'version == 0',
+]) {
+  if (!production.includes(marker)) {
+    fail(`${inspectorPath} fail-closed decoding is missing ${marker}`);
+  }
+}
+
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
+  'mod drift_finding_inspector;',
+  'pub use drift_finding_inspector::{',
+  'IndexDriftFindingInspection, IndexDriftFindingInspectionError, IndexDriftFindingScope,',
+  'IndexDriftFindingSeverity, PostgresIndexDriftFindingInspector,',
+]);
+
+const serverPath = 'apps/server/src/services/index_reconciliation_operator.rs';
+const server = read(serverPath);
+for (const premature of [
+  'PostgresIndexDriftFindingInspector',
+  'inspect_drift_finding(',
+  'IndexDriftFindingInspectionError',
+]) {
+  if (server.includes(premature)) {
+    fail(`${serverPath} prematurely publishes drift inspection marker ${premature}`);
+  }
+}
+
+requireMarkers('crates/rustok-index/docs/m6-drift-finding-inspection.md', [
+  'Status: `source_complete_server_authorization_and_repair_pending`.',
+  '`PostgresIndexDriftFindingInspector`',
+  "`state = 'open'`",
+  'raw `details` JSON',
+  'No automatic finding closure or mutation is allowed from inspection alone.',
+  'request-bound server authorization and internal operator composition',
+  'The canonical roadmap item `Add drift diagnosis, targeted repair commands, and admitted repair evidence` remains open.',
+  'maintainer-run',
+]);
+requireMarkers('crates/rustok-index/docs/README.md', [
+  '[M6 Drift Finding Inspection](./m6-drift-finding-inspection.md)',
+]);
+requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
+  '- [ ] Add drift diagnosis, targeted repair commands, and admitted repair evidence.',
+  '- [ ] Add in-page interruption/timeouts, dry-run, and targeted/full/shadow rebuild modes.',
+]);
+requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
+  "'verify-index-drift-finding-inspection.mjs'",
+]);
+
+console.log('[verify-index-drift-finding-inspection] OK');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -26,6 +26,7 @@ const scripts = [
   'verify-index-reconciliation-retry-store.mjs',
   'verify-index-reconciliation-runner-retry.mjs',
   'verify-index-reconciliation-host-scheduler.mjs',
+  'verify-index-drift-finding-inspection.mjs',
   'verify-index-reconciliation-dead-letter-admission.mjs',
   'verify-index-reconciliation-dead-letter-inspection.mjs',
   'verify-index-reconciliation-dead-letter-requeue.mjs',


### PR DESCRIPTION
## Summary

- add one bounded read-only PostgreSQL inspector for exact open `index_consistency_findings` rows;
- require exact non-nil tenant and finding UUIDs;
- restrict lookup to the exact tenant/finding with `state = 'open'`;
- return only finding identity, bounded check classification, typed scope, severity, and optional SHA-256 digest evidence;
- strictly decode global, schema, and entity scope against the existing migration contract;
- validate canonical module/entity identifiers, positive schema version, non-nil entity UUID, and canonical locale;
- deliberately exclude raw finding `details`, detection/closure timestamps, tenant identity, database causes, and transport data;
- export the adapter only through `rustok_index::infrastructure::postgres`;
- add focused documentation and fail-closed static verification;
- leave server authorization, finding production, repair admission, mutation, and retained evidence to separate PRs.

## Fresh-main audit

The branch is built directly on `main@a8fde54755c75d867b15e469eb14e2be45916695`.

Current state:

- one clean commit;
- one commit ahead and zero behind `main`;
- six changed files;
- intervening Forum and Fulfillment commits do not overlap Index paths;
- no open PR or branch implements this exact drift-finding inspection substrate.

## Existing storage contract

This slice consumes the canonical `index_consistency_findings` table already created by M3. It does not add or modify a migration.

The table already owns tenant/finding identity, deterministic lowercase finding key, check name, severity, lifecycle state, strict global/schema/entity scope columns, optional expected and actual digests, private JSON details, and detection timestamps.

## Read-only query

`PostgresIndexDriftFindingInspector::inspect(tenant_id, finding_id)` performs one exact bounded SELECT using the exact tenant UUID, exact finding UUID, `state = 'open'`, and `LIMIT 1`.

Resolved, ignored, cross-tenant, and unknown findings return `None`.

The SELECT includes only finding key, check name, severity, scope discriminator and identity columns, and optional expected/actual digests. It does not select tenant identity, raw `details`, detection/closure timestamps, jobs, leases, cursors, source payloads, or mutations.

## Bounded result

`IndexDriftFindingInspection` contains:

- finding UUID;
- exact 64-byte lowercase hexadecimal finding key;
- non-empty, trimmed, control-character-free check name bounded to 128 UTF-8 bytes;
- typed `Info`, `Warning`, or `Error` severity;
- typed `Global`, `Schema`, or `Entity` scope;
- optional exact 64-byte lowercase expected digest;
- optional exact 64-byte lowercase actual digest.

Schema scope returns a validated `SchemaRef`. Entity scope additionally requires a non-nil entity UUID and a persisted locale already canonical under `LocaleKey`.

Malformed stored scope, identifiers, version, locale, finding key, severity, or digests fail closed through `InvalidStoredFinding`.

## Privacy and error boundary

The adapter never reads or returns raw `details`. Database failures map to one stable detail-free `Storage` error.

The public value exposes no tenant identity, owner payload, timestamps, SQL, database causes, actor, permission snapshot, or transport context.

## Ownership boundary

This PR intentionally does not compose the adapter into `IndexReconciliationOperatorRuntime`. The existing server operator remains unchanged and cannot call drift inspection yet.

A follow-up server PR must bind tenant exclusively from the existing request-bound context, require effective `modules:manage` before adapter validation or database access, accept only a finding UUID, and return only the bounded inspection value.

## Scope boundaries

This PR does not add or claim:

- source/index comparison or a finding writer;
- orphan detection;
- finding acknowledgement, resolution, or ignore transitions;
- targeted load or mutation execution;
- targeted/full/shadow repair modes;
- repair advisory locking or concurrency fencing;
- actor/reason repair audit records;
- before/after repair evidence or automatic finding closure;
- GraphQL, HTTP, CLI, MCP, native admin, or other transport;
- scheduler integration;
- migrations or table-shape changes;
- retained PostgreSQL inspection, diagnosis, repair, or concurrency evidence.

The canonical roadmap item `Add drift diagnosis, targeted repair commands, and admitted repair evidence` remains open because this PR establishes only the bounded read-only inspection substrate.

## Validation

Not run per maintainer instruction:

- formatting;
- Cargo checks, tests, or Clippy;
- JavaScript verifiers;
- SQLite or PostgreSQL scenarios;
- workflows and CI.