### PR TITLE
test(pages): guard metadata revision isolation

### DIFF
--- a/crates/rustok-page-builder/contracts/page-builder-consumer-properties.json
+++ b/crates/rustok-page-builder/contracts/page-builder-consumer-properties.json
@@ -92,6 +92,13 @@
       "state": "removed",
       "direct_persistence_path_removed": true,
       "replacement": "registered_consumer_property_surfaces"
+    },
+    "source_evidence": {
+      "metadata_revision_isolation": {
+        "state": "source_ready_execution_pending",
+        "contract": "crates/rustok-pages/contracts/evidence/pages-metadata-revision-isolation-source.json",
+        "verifier": "crates/rustok-pages/scripts/verify/verify-pages-metadata-revision-isolation.mjs"
+      }
     }
   },
   "source_guard": "crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs",

--- a/crates/rustok-page-builder/docs/implementation-plan.md
+++ b/crates/rustok-page-builder/docs/implementation-plan.md
@@ -60,17 +60,26 @@ resolves the exact registered property schema from `ContributionAssemblyResult`,
 schema equality with the runtime, loads an optimistic-revision snapshot through the consumer port and
 returns only a typed save receipt. The current Leptos panel is an adapter; persistence, transport,
 revision semantics and field values remain consumer-owned. A facade may supply the runtime directly,
-or an owner composition root may provide it through Leptos context. The same contract is intended for
-a future Dioxus adapter without changing consumer persistence.
+or an owner composition root may provide it through Leptos context. The exported
+`ConsumerPropertiesPanel` can render in a canvas or standalone host without transferring persistence
+ownership. The same contract is intended for a future Dioxus adapter without changing consumer
+persistence.
 
 `rustok-pages` is the first production contextual consumer. Preview projects the active Fly page,
 passes selected runtime context/scenario and rejects late responses when project hash, active page,
-context or scenario changed. Pages now also registers `rustok.pages.metadata` with six typed fields and
+context or scenario changed. Pages registers `rustok.pages.metadata` with six typed fields and
 provides a port that loads through `fetch_page`, saves through `patch_page_metadata`, binds the command
 to `pages:{page_id}:metadata:v{version}`, rejects stale versions and never writes the Fly document.
-The executable panel is mounted in the Fly properties column for draft workspaces. The older bespoke
-`PageMetadataEditor` still exists in the Pages composition and must be removed in a separate cutover
-that preserves metadata editing for published pages.
+The canonical panel is mounted in the Fly properties column for draft workspaces and in the
+Pages-owned standalone published surface without mounting an editable Fly canvas. The bespoke
+`PageMetadataEditor` and its direct workspace persistence path are removed.
+
+The metadata owner port also exposes a private source-test transport seam. Production still delegates
+to the same Pages fetch and patch transports. Focused regressions require the current metadata version
+to be rechecked before patch transport, require exact `REVISION_CONFLICT` on stale input with zero
+patch calls, and record a metadata-only request while an external dirty Fly sentinel remains unchanged.
+These regressions and the corresponding static evidence are source-ready and unvalidated; no executed
+packet is claimed.
 
 For durable page publication, Pages owns one atomic service boundary:
 
@@ -146,7 +155,8 @@ rotation. Cache failures fail open to source reads. Accepted execution evidence 
 
 - `contracts/page-builder-service-boundary.json` records capability/preview ports and composition.
 - `contracts/page-builder-consumer-properties.json` records the framework-neutral property schema,
-  port/runtime, Pages owner adapter, independent metadata revision and pending bespoke-form removal.
+  port/runtime, Pages owner adapter, independent metadata revision, complete registered UI cutover and
+  the source-ready metadata revision/isolation evidence registration.
 - `contracts/page-builder-fba-registry.json` records provider/consumer versions, executable consumer
   properties, policy-bound sanitization/materialization persistence, exact publish manifests,
   immutable rollback and the Pages cache consumer boundary.
@@ -160,8 +170,11 @@ rotation. Cache failures fail open to source reads. Accepted execution evidence 
   publication and source-locks GraphQL, HTTP, admin reviewed DTO/receipt, scenario-selection and
   non-builder lifecycle boundaries.
 - `crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs` source-locks exact
-  contribution-schema binding, Pages ownership, optimistic metadata revision and the absence of Fly
-  document writes. Its current contract explicitly reports the bespoke form as pending removal.
+  contribution-schema binding, Pages ownership, optimistic metadata revision, registered draft and
+  published surfaces, legacy-form absence and the absence of production Fly document writes.
+- `crates/rustok-pages/scripts/verify/verify-pages-metadata-revision-isolation.mjs` source-locks
+  conflict-before-patch ordering, exact stale conflict, metadata-only transport shape, dirty Fly
+  isolation regressions and the unvalidated machine evidence boundary.
 - `crates/rustok-pages/scripts/verify/verify-pages-cache-invalidation.mjs` source-locks Pages ownership
   of cache scopes/keys, event-driven invalidation, neutral server capabilities and authorization/cache/
   owner-source ordering in storefront and artifact readers.
@@ -172,9 +185,9 @@ rotation. Cache failures fail open to source reads. Accepted execution evidence 
 ## FFA/FBA status
 
 - **FFA:** `core_transport_ui` for the browser-host slice. Explicit promoted-scenario selection,
-  rollback transport, generation-aware Pages storefront/artifact readers and executable typed Pages
-  metadata properties are connected. Removing the bespoke metadata form, preserving the property
-  surface for published pages and inline edit mode remain open.
+  typed rollback control, generation-aware Pages storefront/artifact readers and registered draft and
+  published Pages metadata properties are connected. Executed metadata conflict/isolation evidence,
+  inline edit mode and anonymous bundle evidence remain open.
 - **FBA:** `boundary_ready` for preview, consumer-property contracts and policy-bound
   sanitization/materialization, and `service_and_public_transport_integrated` for Pages reviewed
   publication and immutable rollback. The default-runtime lifecycle is removed and source-level cache
@@ -198,7 +211,11 @@ rotation. Cache failures fail open to source reads. Accepted execution evidence 
   - `admin/src/editor/publish_scenario_selector.rs`;
   - `crates/rustok-pages/admin/src/contributions.rs`;
   - `crates/rustok-pages/admin/src/metadata_properties.rs`;
+  - `crates/rustok-pages/admin/src/standalone_metadata.rs`;
   - `crates/rustok-pages/admin/src/lib.rs`;
+  - `crates/rustok-pages/contracts/evidence/pages-metadata-revision-isolation-source.json`;
+  - `crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs`;
+  - `crates/rustok-pages/scripts/verify/verify-pages-metadata-revision-isolation.mjs`;
   - `crates/rustok-pages/src/dto/page.rs`;
   - `crates/rustok-pages/src/services/page/reviewed_publish.rs`;
   - `crates/rustok-pages/src/services/page/rollback.rs`;
@@ -219,16 +236,14 @@ rotation. Cache failures fail open to source reads. Accepted execution evidence 
   - `crates/rustok-pages/src/migrations/m20260722_000009_create_page_rollback_operations.rs`;
   - `scripts/verify/verify-page-builder-publish-runtime-review.mjs`;
   - `scripts/verify/verify-page-builder-publish-transport-cutover.mjs`;
-  - `crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs`;
   - `crates/rustok-pages/scripts/verify/verify-pages-cache-invalidation.mjs`;
   - `crates/rustok-pages/scripts/verify/verify-pages-artifact-rollback.mjs`.
 
 ## Open results
 
-1. Remove the bespoke Pages `PageMetadataEditor` and render the registered consumer property surface
-   for both draft and published metadata without mounting an editable Fly document for published pages.
-2. Retain an accepted metadata packet proving independent revision conflicts and that metadata saves
-   cannot mutate or replace a dirty Fly document.
+1. Run and retain the focused stale metadata revision and dirty Fly isolation packets.
+2. Retain a published metadata browser packet proving the registered save advances only metadata
+   version while the editable Fly canvas remains unmounted.
 3. Retain an accepted sanitizer packet covering unsafe authoring input and runtime-injected URL/CSS
    rejection with policy hash, reviewed publish receipt and zero persisted artifact/event side effects.
 4. Retain accepted publish and rollback cache packets correlating receipt, `NodePublished`, handler
@@ -248,6 +263,9 @@ rotation. Cache failures fail open to source reads. Accepted execution evidence 
 - `node crates/rustok-page-builder/scripts/verify/verify-page-builder-publish-runtime-review.mjs`;
 - `node crates/rustok-page-builder/scripts/verify/verify-page-builder-publish-transport-cutover.mjs`;
 - `node crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs`;
+- `node crates/rustok-pages/scripts/verify/verify-pages-metadata-revision-isolation.mjs`;
+- `cargo test -p rustok-pages-admin stale_metadata_revision_short_circuits_before_patch_transport`;
+- `cargo test -p rustok-pages-admin metadata_save_is_document_free_and_preserves_dirty_fly_state`;
 - `node crates/rustok-pages/scripts/verify/verify-pages-cache-invalidation.mjs`;
 - `node crates/rustok-pages/scripts/verify/verify-pages-artifact-rollback.mjs`;
 - `node crates/rustok-page-builder/scripts/verify/verify-page-builder-adapter-seams.mjs`;

--- a/crates/rustok-pages/admin/Cargo.toml
+++ b/crates/rustok-pages/admin/Cargo.toml
@@ -38,3 +38,6 @@ rustok-api = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+tokio.workspace = true

--- a/crates/rustok-pages/admin/src/metadata_properties.rs
+++ b/crates/rustok-pages/admin/src/metadata_properties.rs
@@ -12,12 +12,94 @@ use rustok_page_builder_admin::{
     ConsumerPropertySaveReceipt, SaveConsumerPropertiesInput,
 };
 use std::collections::BTreeMap;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 
 const PAGE_METADATA_REVISION_CONFLICT: &str = "REVISION_CONFLICT";
 
 type SnapshotProvider = Arc<dyn Fn() -> PagesBuilderSaveSnapshot + Send + Sync>;
 type SavedHandler = Arc<dyn Fn(PageMutationResult) + Send + Sync>;
+
+#[cfg(not(target_arch = "wasm32"))]
+type MetadataPageLoadFuture = Pin<
+    Box<
+        dyn Future<Output = Result<Option<PageDetail>, ConsumerPropertyEditorError>>
+            + Send
+            + 'static,
+    >,
+>;
+
+#[cfg(target_arch = "wasm32")]
+type MetadataPageLoadFuture = Pin<
+    Box<
+        dyn Future<Output = Result<Option<PageDetail>, ConsumerPropertyEditorError>> + 'static,
+    >,
+>;
+
+#[cfg(not(target_arch = "wasm32"))]
+type MetadataPageSaveFuture = Pin<
+    Box<
+        dyn Future<Output = Result<PageDetail, ConsumerPropertyEditorError>> + Send + 'static,
+    >,
+>;
+
+#[cfg(target_arch = "wasm32")]
+type MetadataPageSaveFuture =
+    Pin<Box<dyn Future<Output = Result<PageDetail, ConsumerPropertyEditorError>> + 'static>>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MetadataPatchRequest {
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    page_id: String,
+    expected_version: i32,
+    locale: String,
+    title: String,
+    slug: String,
+    meta_title: Option<String>,
+    meta_description: Option<String>,
+    template: Option<String>,
+    channel_slugs: Vec<String>,
+}
+
+trait PagesMetadataTransport: Send + Sync {
+    fn fetch_page(&self, snapshot: PagesBuilderSaveSnapshot) -> MetadataPageLoadFuture;
+
+    fn patch_metadata(&self, request: MetadataPatchRequest) -> MetadataPageSaveFuture;
+}
+
+struct ServerPagesMetadataTransport;
+
+impl PagesMetadataTransport for ServerPagesMetadataTransport {
+    fn fetch_page(&self, snapshot: PagesBuilderSaveSnapshot) -> MetadataPageLoadFuture {
+        Box::pin(async move {
+            transport::fetch_page(snapshot.token, snapshot.tenant_slug, snapshot.page_id)
+                .await
+                .map_err(|error| ConsumerPropertyEditorError::unavailable(error.to_string()))
+        })
+    }
+
+    fn patch_metadata(&self, request: MetadataPatchRequest) -> MetadataPageSaveFuture {
+        Box::pin(async move {
+            transport::patch_page_metadata(
+                request.token,
+                request.tenant_slug,
+                request.page_id,
+                request.expected_version,
+                request.locale,
+                request.title,
+                request.slug,
+                request.meta_title,
+                request.meta_description,
+                request.template,
+                request.channel_slugs,
+            )
+            .await
+            .map_err(|error| ConsumerPropertyEditorError::save(error.to_string()))
+        })
+    }
+}
 
 pub fn pages_metadata_property_runtime(
     snapshot: impl Fn() -> PagesBuilderSaveSnapshot + Send + Sync + 'static,
@@ -34,6 +116,7 @@ pub fn pages_metadata_property_runtime(
             snapshot: Arc::new(snapshot),
             on_saved: Arc::new(on_saved),
             schema,
+            transport: Arc::new(ServerPagesMetadataTransport),
         }),
     ))
 }
@@ -42,14 +125,16 @@ struct PagesMetadataPropertyPort {
     snapshot: SnapshotProvider,
     on_saved: SavedHandler,
     schema: rustok_page_builder_admin::ConsumerPropertyEditorSchema,
+    transport: Arc<dyn PagesMetadataTransport>,
 }
 
 impl ConsumerPropertyEditorPort for PagesMetadataPropertyPort {
     fn load(&self) -> ConsumerPropertyLoadFuture {
         let snapshot = (self.snapshot)();
         let schema = self.schema.clone();
+        let transport = Arc::clone(&self.transport);
         Box::pin(async move {
-            let page = fetch_expected_page(&snapshot).await?;
+            let page = fetch_expected_page(transport.as_ref(), &snapshot).await?;
             metadata_snapshot(&schema, &page, &snapshot.default_locale)
         })
     }
@@ -57,56 +142,33 @@ impl ConsumerPropertyEditorPort for PagesMetadataPropertyPort {
     fn save(&self, input: SaveConsumerPropertiesInput) -> ConsumerPropertySaveFuture {
         let snapshot = (self.snapshot)();
         let schema = self.schema.clone();
+        let transport = Arc::clone(&self.transport);
         let on_saved = Arc::clone(&self.on_saved);
         Box::pin(async move {
-            if input.contribution_id != PAGES_METADATA_CONTRIBUTION_ID
-                || input.property_editor_id != PAGES_METADATA_PROPERTY_EDITOR_ID
-            {
-                return Err(ConsumerPropertyEditorError::contract(
-                    "Pages metadata save does not match the registered contribution",
-                ));
-            }
-            schema.validate_values(&input.values)?;
-            let expected_version =
-                expected_metadata_version(&snapshot.page_id, &input.expected_revision)?;
-            let current = fetch_expected_page(&snapshot).await?;
-            if current.version != expected_version {
-                return Err(metadata_revision_conflict(
-                    expected_version,
-                    current.version,
-                ));
-            }
-
-            let locale = page_locale(&current, &snapshot.default_locale);
-            let title = required_value(&input.values, "title")?;
-            let slug = required_value(&input.values, "slug")?;
-            let meta_title = optional_value(&input.values, "meta_title")?;
-            let meta_description = optional_value(&input.values, "meta_description")?;
-            let template = optional_value(&input.values, "template")?;
-            let channel_slugs = core::parse_channel_slugs(value(&input.values, "channel_slugs")?);
-
-            let page = transport::patch_page_metadata(
-                snapshot.token,
-                snapshot.tenant_slug,
-                snapshot.page_id.clone(),
-                expected_version,
-                locale,
-                title,
-                slug,
-                meta_title,
-                meta_description,
-                template,
-                channel_slugs,
-            )
-            .await
-            .map_err(|error| ConsumerPropertyEditorError::save(error.to_string()))?;
+            let command = metadata_save_command(&schema, &snapshot, &input)?;
+            let current = fetch_expected_page(transport.as_ref(), &snapshot).await?;
+            require_current_metadata_version(command.expected_version, current.version)?;
+            let request = MetadataPatchRequest {
+                token: snapshot.token,
+                tenant_slug: snapshot.tenant_slug,
+                page_id: snapshot.page_id.clone(),
+                expected_version: command.expected_version,
+                locale: page_locale(&current, &snapshot.default_locale),
+                title: command.title,
+                slug: command.slug,
+                meta_title: command.meta_title,
+                meta_description: command.meta_description,
+                template: command.template,
+                channel_slugs: command.channel_slugs,
+            };
+            let page = transport.patch_metadata(request).await?;
             if page.id != snapshot.page_id {
                 return Err(ConsumerPropertyEditorError::save(format!(
                     "Pages metadata save returned page `{}` for `{}`",
                     page.id, snapshot.page_id
                 )));
             }
-            if page.version <= expected_version {
+            if page.version <= command.expected_version {
                 return Err(ConsumerPropertyEditorError::save(format!(
                     "Pages metadata save returned non-advancing version {}",
                     page.version
@@ -127,7 +189,59 @@ impl ConsumerPropertyEditorPort for PagesMetadataPropertyPort {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MetadataSaveCommand {
+    expected_version: i32,
+    title: String,
+    slug: String,
+    meta_title: Option<String>,
+    meta_description: Option<String>,
+    template: Option<String>,
+    channel_slugs: Vec<String>,
+}
+
+fn metadata_save_command(
+    schema: &rustok_page_builder_admin::ConsumerPropertyEditorSchema,
+    snapshot: &PagesBuilderSaveSnapshot,
+    input: &SaveConsumerPropertiesInput,
+) -> Result<MetadataSaveCommand, ConsumerPropertyEditorError> {
+    if input.contribution_id != PAGES_METADATA_CONTRIBUTION_ID
+        || input.property_editor_id != PAGES_METADATA_PROPERTY_EDITOR_ID
+    {
+        return Err(ConsumerPropertyEditorError::contract(
+            "Pages metadata save does not match the registered contribution",
+        ));
+    }
+    schema.validate_values(&input.values)?;
+    let expected_version =
+        expected_metadata_version(&snapshot.page_id, &input.expected_revision)?;
+    Ok(MetadataSaveCommand {
+        expected_version,
+        title: required_value(&input.values, "title")?,
+        slug: required_value(&input.values, "slug")?,
+        meta_title: optional_value(&input.values, "meta_title")?,
+        meta_description: optional_value(&input.values, "meta_description")?,
+        template: optional_value(&input.values, "template")?,
+        channel_slugs: core::parse_channel_slugs(value(&input.values, "channel_slugs")?),
+    })
+}
+
+fn require_current_metadata_version(
+    expected_version: i32,
+    current_version: i32,
+) -> Result<(), ConsumerPropertyEditorError> {
+    if current_version == expected_version {
+        Ok(())
+    } else {
+        Err(metadata_revision_conflict(
+            expected_version,
+            current_version,
+        ))
+    }
+}
+
 async fn fetch_expected_page(
+    transport: &dyn PagesMetadataTransport,
     snapshot: &PagesBuilderSaveSnapshot,
 ) -> Result<PageDetail, ConsumerPropertyEditorError> {
     if snapshot.page_id.trim().is_empty() {
@@ -135,14 +249,10 @@ async fn fetch_expected_page(
             "Pages metadata properties require a selected page",
         ));
     }
-    let page = transport::fetch_page(
-        snapshot.token.clone(),
-        snapshot.tenant_slug.clone(),
-        snapshot.page_id.clone(),
-    )
-    .await
-    .map_err(|error| ConsumerPropertyEditorError::unavailable(error.to_string()))?
-    .ok_or_else(|| ConsumerPropertyEditorError::unavailable("Selected page was not found"))?;
+    let page = transport
+        .fetch_page(snapshot.clone())
+        .await?
+        .ok_or_else(|| ConsumerPropertyEditorError::unavailable("Selected page was not found"))?;
     if page.id != snapshot.page_id {
         return Err(ConsumerPropertyEditorError::unavailable(format!(
             "Pages metadata load returned page `{}` for `{}`",
@@ -268,9 +378,38 @@ fn optional_value(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::PageTranslation;
+    use crate::model::{PageBody, PageTranslation};
+    use serde_json::json;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Clone)]
+    struct RecordingTransport {
+        current: PageDetail,
+        saved: PageDetail,
+        patch_calls: Arc<AtomicUsize>,
+        last_patch: Arc<Mutex<Option<MetadataPatchRequest>>>,
+    }
+
+    impl PagesMetadataTransport for RecordingTransport {
+        fn fetch_page(&self, _snapshot: PagesBuilderSaveSnapshot) -> MetadataPageLoadFuture {
+            let current = self.current.clone();
+            Box::pin(async move { Ok(Some(current)) })
+        }
+
+        fn patch_metadata(&self, request: MetadataPatchRequest) -> MetadataPageSaveFuture {
+            self.patch_calls.fetch_add(1, Ordering::SeqCst);
+            *self.last_patch.lock().expect("last patch lock") = Some(request);
+            let saved = self.saved.clone();
+            Box::pin(async move { Ok(saved) })
+        }
+    }
 
     fn page(version: i32) -> PageDetail {
+        page_with_title(version, "Home")
+    }
+
+    fn page_with_title(version: i32, title: &str) -> PageDetail {
         PageDetail {
             id: "page-1".to_string(),
             version,
@@ -281,12 +420,57 @@ mod tests {
             channel_slugs: vec!["web".to_string()],
             translation: Some(PageTranslation {
                 locale: "en".to_string(),
-                title: Some("Home".to_string()),
+                title: Some(title.to_string()),
                 slug: Some("home".to_string()),
                 meta_title: None,
                 meta_description: None,
             }),
-            body: None,
+            body: Some(PageBody {
+                locale: "en".to_string(),
+                content: "<section>persisted</section>".to_string(),
+                format: "grapesjs".to_string(),
+                content_json: Some(json!({
+                    "pages": [{
+                        "component": {
+                            "tagName": "section",
+                            "attributes": {"data-persisted": "true"}
+                        }
+                    }]
+                })),
+                updated_at: "2026-07-23T00:00:00Z".to_string(),
+            }),
+        }
+    }
+
+    fn snapshot() -> PagesBuilderSaveSnapshot {
+        PagesBuilderSaveSnapshot {
+            token: Some("token".to_string()),
+            tenant_slug: Some("tenant".to_string()),
+            page_id: "page-1".to_string(),
+            default_locale: "en".to_string(),
+        }
+    }
+
+    fn save_input(version: i32, title: &str) -> SaveConsumerPropertiesInput {
+        let mut values = metadata_values(&page(version));
+        values.insert("title".to_string(), title.to_string());
+        SaveConsumerPropertiesInput {
+            contribution_id: PAGES_METADATA_CONTRIBUTION_ID.to_string(),
+            property_editor_id: PAGES_METADATA_PROPERTY_EDITOR_ID.to_string(),
+            expected_revision: metadata_revision("page-1", version),
+            values,
+        }
+    }
+
+    fn port(
+        transport: RecordingTransport,
+        on_saved: impl Fn(PageMutationResult) + Send + Sync + 'static,
+    ) -> PagesMetadataPropertyPort {
+        PagesMetadataPropertyPort {
+            snapshot: Arc::new(snapshot),
+            on_saved: Arc::new(on_saved),
+            schema: pages_metadata_property_schema(),
+            transport: Arc::new(transport),
         }
     }
 
@@ -305,5 +489,89 @@ mod tests {
             7
         );
         assert!(expected_metadata_version("page-2", "pages:page-1:metadata:v7").is_err());
+    }
+
+    #[tokio::test]
+    async fn stale_metadata_revision_short_circuits_before_patch_transport() {
+        let patch_calls = Arc::new(AtomicUsize::new(0));
+        let transport = RecordingTransport {
+            current: page(8),
+            saved: page(9),
+            patch_calls: Arc::clone(&patch_calls),
+            last_patch: Arc::new(Mutex::new(None)),
+        };
+        let error = port(transport, |_| {})
+            .save(save_input(7, "Changed"))
+            .await
+            .expect_err("stale metadata revision must fail");
+
+        assert_eq!(error.stable_code, PAGE_METADATA_REVISION_CONFLICT);
+        assert_eq!(
+            error.message,
+            "Pages metadata version changed from 7 to 8; reload and retry"
+        );
+        assert_eq!(patch_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn metadata_save_is_document_free_and_preserves_dirty_fly_state() {
+        let patch_calls = Arc::new(AtomicUsize::new(0));
+        let last_patch = Arc::new(Mutex::new(None));
+        let dirty_fly_state = Arc::new(Mutex::new(json!({
+            "revision": "draft-local-9",
+            "dirty": true,
+            "projectData": {
+                "pages": [{
+                    "component": {
+                        "tagName": "main",
+                        "attributes": {"data-unsaved": "true"}
+                    }
+                }]
+            }
+        })));
+        let dirty_before = dirty_fly_state.lock().expect("dirty Fly lock").clone();
+        let saved_mutation = Arc::new(Mutex::new(None::<PageMutationResult>));
+        let saved_mutation_capture = Arc::clone(&saved_mutation);
+        let transport = RecordingTransport {
+            current: page(7),
+            saved: page_with_title(8, "Updated Home"),
+            patch_calls: Arc::clone(&patch_calls),
+            last_patch: Arc::clone(&last_patch),
+        };
+
+        let receipt = port(transport, move |result| {
+            *saved_mutation_capture.lock().expect("saved mutation lock") = Some(result);
+        })
+        .save(save_input(7, "Updated Home"))
+        .await
+        .expect("metadata save");
+
+        assert_eq!(patch_calls.load(Ordering::SeqCst), 1);
+        let request = last_patch
+            .lock()
+            .expect("last patch lock")
+            .clone()
+            .expect("metadata patch request");
+        assert_eq!(request.page_id, "page-1");
+        assert_eq!(request.expected_version, 7);
+        assert_eq!(request.title, "Updated Home");
+        assert_eq!(request.slug, "home");
+        assert_eq!(request.locale, "en");
+        assert_eq!(request.channel_slugs, vec!["web".to_string()]);
+        assert_eq!(
+            *dirty_fly_state.lock().expect("dirty Fly lock"),
+            dirty_before
+        );
+        assert_eq!(receipt.revision, "pages:page-1:metadata:v8");
+        assert_eq!(receipt.values["title"], "Updated Home");
+        assert_eq!(
+            saved_mutation
+                .lock()
+                .expect("saved mutation lock")
+                .as_ref()
+                .expect("saved mutation")
+                .version,
+            8
+        );
     }
 }

--- a/crates/rustok-pages/contracts/evidence/pages-metadata-revision-isolation-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-metadata-revision-isolation-source.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-08-03",
+  "status": "pages_metadata_revision_isolation_source_unvalidated",
+  "scope": "Pages registered metadata owner-port revision conflict and dirty Fly isolation",
+  "source_contract": {
+    "registered_metadata_runtime_preserved": true,
+    "metadata_transport_injected_for_regression_only": true,
+    "production_fetch_transport_preserved": true,
+    "production_patch_transport_preserved": true,
+    "exact_metadata_revision_parsed_before_current_read": true,
+    "current_page_version_rechecked_before_patch": true,
+    "stale_revision_rejected_before_patch_transport": true,
+    "stable_conflict_code": "REVISION_CONFLICT",
+    "metadata_patch_request_contains_document_payload": false,
+    "metadata_patch_request_contains_project_data": false,
+    "metadata_patch_request_contains_controller": false,
+    "metadata_save_callback_contains_project_data": false,
+    "dirty_fly_state_mutated_by_metadata_port": false,
+    "metadata_revision_advances_independently": true,
+    "unit_regressions_added": true,
+    "execution_behavior_changed": false,
+    "public_transport_changed": false,
+    "ffa_promoted": false,
+    "fba_promoted": false
+  },
+  "unit_regressions": [
+    "stale_metadata_revision_short_circuits_before_patch_transport",
+    "metadata_save_is_document_free_and_preserves_dirty_fly_state"
+  ],
+  "suggested_execution": [
+    "node crates/rustok-pages/scripts/verify/verify-pages-metadata-revision-isolation.mjs",
+    "cargo test -p rustok-pages-admin stale_metadata_revision_short_circuits_before_patch_transport",
+    "cargo test -p rustok-pages-admin metadata_save_is_document_free_and_preserves_dirty_fly_state",
+    "cargo check -p rustok-pages-admin --all-targets"
+  ],
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "runtime_proven": false
+  }
+}

--- a/crates/rustok-pages/docs/implementation-plan.md
+++ b/crates/rustok-pages/docs/implementation-plan.md
@@ -84,9 +84,14 @@ Pages persistence, cache scope or tenant policy.
   multiple scenarios require an explicit exact selection.
 - [x] Missing baseline, empty scenarios, missing selection, stale selection and
   foreign scenario ids fail closed before the reviewed command is built.
-- [ ] Add the rollback action to the Pages workspace header using the typed admin
-  transport; transport and receipt validation are already connected.
-- [ ] Metadata editing still needs a typed metadata-only property contribution.
+- [x] `PagesRollbackControl` mounts the typed rollback action for selected published
+  pages, requires prepare/confirm and refreshes the workspace from the returned
+  advancing result version.
+- [x] Pages registers the typed `rustok.pages.metadata` contribution and renders the
+  canonical consumer-property panel inside draft Fly and in a published-only
+  standalone host without mounting an editable published Fly document.
+- [x] The bespoke `PageMetadataEditor` and its direct workspace persistence path are
+  removed; metadata persistence remains owned by `PagesMetadataPropertyPort`.
 
 ### Storefront FFA
 
@@ -165,15 +170,16 @@ Pages persistence, cache scope or tenant policy.
 
 ## FFA/FBA status
 
-- **FFA:** `in_progress` — reviewed publication, rollback transport, explicit
-  promoted-scenario selection and generation-aware storefront/artifact readers are
-  connected; the workspace rollback action, typed metadata properties and inline
-  edit mode remain open.
+- **FFA:** `in_progress` — reviewed publication, typed rollback control, explicit
+  promoted-scenario selection, registered draft/published metadata surfaces and
+  generation-aware storefront/artifact readers are connected. Executed metadata
+  conflict/isolation packets, inline edit mode and anonymous bundle evidence remain
+  open.
 - **FBA:** `in_progress` — reviewed runtime, authoritative sanitizer, immutable
   materialization evidence, idempotent publish and rollback services,
   GraphQL/HTTP/admin transports, default-runtime removal and cache
-  invalidation/read boundaries are integrated at source level. Executed rollback
-  and cache proof, verification and observed rollout evidence remain open.
+  invalidation/read boundaries are integrated at source level. Executed metadata,
+  rollback and cache proof, verification and observed rollout evidence remain open.
 - **Structural shape:** `core_transport_ui` with one current document authority.
 
 ## Ownership boundaries
@@ -349,14 +355,33 @@ Invariants:
   machine contracts.
 - Source guards and runtime tests were not executed in this slice.
 
+## Completed slice — 2026-08-03
+
+- Mounted the typed Pages rollback prepare/confirm control for published pages.
+- Registered six typed metadata fields and one Pages-owned optimistic metadata
+  owner port.
+- Exported and reused the canonical consumer-property panel for draft and published
+  Pages lifecycle surfaces.
+- Removed the bespoke metadata editor and its direct workspace persistence path.
+- Added private source-test transport injection, exact conflict-before-patch ordering
+  and focused stale-revision / dirty-Fly isolation regressions.
+- Added machine-readable source evidence and static guards while retaining empty
+  execution packets and false validation flags.
+- Tests, verifiers, formatters, Cargo commands, browser scenarios, workflows and CI
+  were not executed in this slice.
+
 ## Next implementation order
 
 ### P0 — separate metadata and document writes
 
-- [ ] Finish Pages-owned typed metadata property contributions.
-- [ ] Track metadata and document revisions independently in every transport.
-- [ ] Add conflict tests proving metadata saves cannot replace a dirty/current Fly
-  document and Fly saves cannot revert metadata.
+- [x] Finish Pages-owned typed metadata property contributions.
+- [x] Track metadata and document revisions independently in source transports.
+- [x] Add source regressions proving stale metadata saves stop before patch transport
+  and a metadata-only save cannot mutate an unsaved dirty Fly sentinel.
+- [ ] Retain executed conflict and dirty-Fly isolation packets from the focused tests
+  and static verifier.
+- [ ] Retain a browser packet proving published metadata saves advance only metadata
+  version while the editable Fly canvas remains unmounted.
 
 ### P0 — atomic artifact publication
 
@@ -380,7 +405,7 @@ Invariants:
   delivery reader.
 - [x] Add idempotent rollback to the previous distinct immutable artifact set with a
   separate receipt and transactional outbox semantics.
-- [ ] Add the typed rollback action to the Pages workspace header.
+- [x] Add the typed rollback action to the Pages workspace header.
 - [ ] Retain accepted evidence for publish/rollback outbox event → handler receipt →
   generation rotation → cache miss/refill.
 - [ ] Correlate publish/rollback receipt, editor save, page/body revisions, runtime
@@ -427,6 +452,10 @@ Invariants:
 - `cargo test -p rustok-pages-admin --lib`
 - `cargo check -p rustok-pages-storefront --lib`
 - `cargo clippy -p rustok-pages-storefront --lib -- -D warnings`
+- `node crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs`
+- `node crates/rustok-pages/scripts/verify/verify-pages-metadata-revision-isolation.mjs`
+- `cargo test -p rustok-pages-admin stale_metadata_revision_short_circuits_before_patch_transport`
+- `cargo test -p rustok-pages-admin metadata_save_is_document_free_and_preserves_dirty_fly_state`
 - `node crates/rustok-pages/scripts/verify/verify-pages-cache-invalidation.mjs`
 - `node crates/rustok-pages/scripts/verify/verify-pages-artifact-rollback.mjs`
 - `node crates/rustok-page-builder/scripts/verify/verify-page-builder-preview-runtime-contract.mjs`

--- a/crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs
@@ -19,6 +19,7 @@ const providerPanelExport = read(contract.provider.panel_export_source);
 const providerCanvas = read(contract.provider.composition_source);
 const pagesContributions = read(contract.pages_consumer.contribution_source);
 const pagesOwnerPort = read(contract.pages_consumer.owner_port_source);
+const pagesOwnerPortProduction = pagesOwnerPort.split("#[cfg(test)]")[0];
 const pagesBoundary = read(contract.pages_consumer.composition_source);
 const pagesWorkspace = read(contract.pages_consumer.workspace_source);
 const pagesPublishedSurface = read(contract.pages_consumer.published_surface_source);
@@ -111,6 +112,18 @@ if (
   fail("legacy metadata cutover contract is invalid");
 }
 
+const metadataEvidence =
+  contract.pages_consumer.source_evidence?.metadata_revision_isolation;
+if (
+  metadataEvidence?.state !== "source_ready_execution_pending" ||
+  metadataEvidence?.contract !==
+    "crates/rustok-pages/contracts/evidence/pages-metadata-revision-isolation-source.json" ||
+  metadataEvidence?.verifier !==
+    "crates/rustok-pages/scripts/verify/verify-pages-metadata-revision-isolation.mjs"
+) {
+  fail("metadata revision/isolation source evidence registration is invalid");
+}
+
 for (const marker of [
   '"page_builder_consumer_properties_v1"',
   "pub struct ConsumerPropertyEditorSchema",
@@ -196,21 +209,38 @@ for (const field of contract.pages_consumer.fields) {
 
 for (const marker of [
   "pub fn pages_metadata_property_runtime(",
+  "trait PagesMetadataTransport: Send + Sync",
+  "transport: Arc<dyn PagesMetadataTransport>",
+  "transport: Arc::new(ServerPagesMetadataTransport)",
   "impl ConsumerPropertyEditorPort for PagesMetadataPropertyPort",
   "fn load(&self) -> ConsumerPropertyLoadFuture",
   "fn save(&self, input: SaveConsumerPropertiesInput)",
-  "fetch_expected_page(&snapshot).await?",
+  "let command = metadata_save_command(&schema, &snapshot, &input)?;",
+  "fetch_expected_page(transport.as_ref(), &snapshot).await?",
+  "require_current_metadata_version(command.expected_version, current.version)?;",
+  "let request = MetadataPatchRequest {",
+  "transport.patch_metadata(request).await?",
   "schema.validate_values(&input.values)?",
   "expected_metadata_version(&snapshot.page_id, &input.expected_revision)",
-  "current.version != expected_version",
   "transport::patch_page_metadata(",
-  "page.version <= expected_version",
+  "page.version <= command.expected_version",
   "on_saved(PageMutationResult::from(&page))",
   'format!("pages:{page_id}:metadata:v{version}")',
   "PAGE_METADATA_REVISION_CONFLICT",
 ]) {
-  requireMarker(pagesOwnerPort, marker, "Pages metadata owner port");
+  requireMarker(pagesOwnerPortProduction, marker, "Pages metadata owner port");
 }
+requireOrderedMarkers(
+  pagesOwnerPortProduction,
+  [
+    "let command = metadata_save_command(&schema, &snapshot, &input)?;",
+    "fetch_expected_page(transport.as_ref(), &snapshot).await?",
+    "require_current_metadata_version(command.expected_version, current.version)?;",
+    "let request = MetadataPatchRequest {",
+    "transport.patch_metadata(request).await?",
+  ],
+  "Pages metadata conflict-before-patch ordering",
+);
 for (const forbidden of [
   "save_page_document",
   "PageBuilderCapabilityRequest::Publish",
@@ -219,7 +249,7 @@ for (const forbidden of [
   "content_json",
   "project_data",
 ]) {
-  forbidMarker(pagesOwnerPort, forbidden, "Pages metadata owner port");
+  forbidMarker(pagesOwnerPortProduction, forbidden, "Pages metadata owner port");
 }
 
 for (const marker of [
@@ -284,6 +314,7 @@ for (const forbidden of [
 
 for (const marker of [
   "Metadata UI cutover: source-complete",
+  "Metadata revision/isolation source packet: ready, unvalidated",
   "Draft registered metadata surface: source-connected",
   "Published registered metadata surface: source-connected",
   "Legacy PageMetadataEditor: removed",
@@ -293,5 +324,5 @@ for (const marker of [
 }
 
 console.log(
-  "[verify-pages-metadata-properties] PASS metadata_surface_cutover_complete=true execution_evidence=pending",
+  "[verify-pages-metadata-properties] PASS metadata_surface_cutover_complete=true metadata_revision_isolation_source_ready=true execution_evidence=pending",
 );

--- a/crates/rustok-pages/scripts/verify/verify-pages-metadata-revision-isolation.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-metadata-revision-isolation.mjs
@@ -1,0 +1,333 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(__filename), "..", "..", "..", "..");
+const read = (relativePath) =>
+  fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+
+const sourcePath = "crates/rustok-pages/admin/src/metadata_properties.rs";
+const evidencePath =
+  "crates/rustok-pages/contracts/evidence/pages-metadata-revision-isolation-source.json";
+const planPath = "docs/modules/pages-page-builder-parity-continuation-plan.md";
+const consumerContractPath =
+  "crates/rustok-page-builder/contracts/page-builder-consumer-properties.json";
+const cargoPath = "crates/rustok-pages/admin/Cargo.toml";
+
+const source = read(sourcePath);
+const evidence = JSON.parse(read(evidencePath));
+const plan = read(planPath);
+const consumerContract = JSON.parse(read(consumerContractPath));
+const cargo = read(cargoPath);
+const failures = [];
+
+function requireText(content, value, label) {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+}
+
+function forbidText(content, value, label) {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+}
+
+function between(content, start, end, label) {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return "";
+  }
+  return content.slice(startIndex, endIndex);
+}
+
+function requireOrdered(content, markers, label) {
+  let previous = -1;
+  for (const marker of markers) {
+    const index = content.indexOf(marker, previous + 1);
+    if (index < 0) {
+      failures.push(`${label}: missing or out of order at ${marker}`);
+      return;
+    }
+    previous = index;
+  }
+}
+
+const patchRequest = between(
+  source,
+  "struct MetadataPatchRequest {",
+  "trait PagesMetadataTransport",
+  "metadata-only patch request",
+);
+const serverTransport = between(
+  source,
+  "impl PagesMetadataTransport for ServerPagesMetadataTransport",
+  "pub fn pages_metadata_property_runtime(",
+  "production metadata transport",
+);
+const saveBlock = between(
+  source,
+  "    fn save(&self, input: SaveConsumerPropertiesInput) -> ConsumerPropertySaveFuture {",
+  "#[derive(Debug, Clone, PartialEq, Eq)]\nstruct MetadataSaveCommand",
+  "metadata owner-port save",
+);
+const commandBlock = between(
+  source,
+  "fn metadata_save_command(",
+  "fn require_current_metadata_version(",
+  "metadata save command",
+);
+const versionBlock = between(
+  source,
+  "fn require_current_metadata_version(",
+  "async fn fetch_expected_page(",
+  "metadata version recheck",
+);
+const tests = source.slice(source.indexOf("#[cfg(test)]"));
+
+for (const marker of [
+  "trait PagesMetadataTransport: Send + Sync",
+  "fn fetch_page(&self, snapshot: PagesBuilderSaveSnapshot)",
+  "fn patch_metadata(&self, request: MetadataPatchRequest)",
+  "transport: Arc<dyn PagesMetadataTransport>",
+  "transport: Arc::new(ServerPagesMetadataTransport)",
+]) {
+  requireText(source, marker, "metadata transport seam");
+}
+
+for (const marker of [
+  "transport::fetch_page(",
+  "snapshot.token",
+  "snapshot.tenant_slug",
+  "snapshot.page_id",
+  "ConsumerPropertyEditorError::unavailable(error.to_string())",
+  "transport::patch_page_metadata(",
+  "request.expected_version",
+  "request.locale",
+  "request.title",
+  "request.slug",
+  "request.meta_title",
+  "request.meta_description",
+  "request.template",
+  "request.channel_slugs",
+  "ConsumerPropertyEditorError::save(error.to_string())",
+]) {
+  requireText(serverTransport, marker, "production metadata transport preservation");
+}
+
+for (const marker of [
+  "token: Option<String>",
+  "tenant_slug: Option<String>",
+  "page_id: String",
+  "expected_version: i32",
+  "locale: String",
+  "title: String",
+  "slug: String",
+  "meta_title: Option<String>",
+  "meta_description: Option<String>",
+  "template: Option<String>",
+  "channel_slugs: Vec<String>",
+]) {
+  requireText(patchRequest, marker, "metadata patch request");
+}
+
+for (const forbidden of [
+  "body",
+  "content:",
+  "content_json",
+  "project_data",
+  "controller",
+  "revision_id",
+  "PageBuilder",
+  "EditorCommand",
+  "PageCommand",
+]) {
+  forbidText(patchRequest, forbidden, "metadata patch request document isolation");
+}
+
+requireOrdered(
+  saveBlock,
+  [
+    "let command = metadata_save_command(&schema, &snapshot, &input)?;",
+    "let current = fetch_expected_page(transport.as_ref(), &snapshot).await?;",
+    "require_current_metadata_version(command.expected_version, current.version)?;",
+    "let request = MetadataPatchRequest {",
+    "let page = transport.patch_metadata(request).await?;",
+    "if page.id != snapshot.page_id",
+    "if page.version <= command.expected_version",
+    "on_saved(PageMutationResult::from(&page));",
+  ],
+  "metadata save conflict-before-patch ordering",
+);
+
+for (const forbidden of [
+  "save_page_document",
+  "project_data",
+  "content_json",
+  "AdminCanvasController",
+  "PagesBuilderFacade",
+  "PageBuilderAdminFacade",
+  "PageBuilderCapabilityRequest",
+]) {
+  forbidText(saveBlock, forbidden, "metadata owner-port Fly isolation");
+}
+
+for (const marker of [
+  "input.contribution_id != PAGES_METADATA_CONTRIBUTION_ID",
+  "input.property_editor_id != PAGES_METADATA_PROPERTY_EDITOR_ID",
+  "schema.validate_values(&input.values)?;",
+  "expected_metadata_version(&snapshot.page_id, &input.expected_revision)?",
+  "required_value(&input.values, \"title\")?",
+  "required_value(&input.values, \"slug\")?",
+  "optional_value(&input.values, \"meta_title\")?",
+  "optional_value(&input.values, \"meta_description\")?",
+  "optional_value(&input.values, \"template\")?",
+  "core::parse_channel_slugs(value(&input.values, \"channel_slugs\")?)",
+]) {
+  requireText(commandBlock, marker, "metadata command preparation");
+}
+
+for (const marker of [
+  "if current_version == expected_version",
+  "Err(metadata_revision_conflict(",
+  "expected_version,",
+  "current_version,",
+]) {
+  requireText(versionBlock, marker, "metadata exact version recheck");
+}
+
+for (const marker of [
+  "const PAGE_METADATA_REVISION_CONFLICT: &str = \"REVISION_CONFLICT\";",
+  "ConsumerPropertyEditorError::with_stable_code(",
+  "Pages metadata version changed from {expected} to {actual}; reload and retry",
+  "PAGE_METADATA_REVISION_CONFLICT",
+]) {
+  requireText(source, marker, "stable metadata conflict");
+}
+
+for (const marker of [
+  "#[tokio::test]",
+  "async fn stale_metadata_revision_short_circuits_before_patch_transport()",
+  "expect_err(\"stale metadata revision must fail\")",
+  "assert_eq!(error.stable_code, PAGE_METADATA_REVISION_CONFLICT);",
+  "assert_eq!(patch_calls.load(Ordering::SeqCst), 0);",
+  "async fn metadata_save_is_document_free_and_preserves_dirty_fly_state()",
+  "\"dirty\": true",
+  "\"projectData\"",
+  "let dirty_before = dirty_fly_state.lock()",
+  "assert_eq!(patch_calls.load(Ordering::SeqCst), 1);",
+  "let request = last_patch",
+  "assert_eq!(request.expected_version, 7);",
+  "assert_eq!(request.title, \"Updated Home\");",
+  "assert_eq!(\n            *dirty_fly_state.lock().expect(\"dirty Fly lock\"),\n            dirty_before\n        );",
+  "assert_eq!(receipt.revision, \"pages:page-1:metadata:v8\");",
+]) {
+  requireText(tests, marker, "metadata regression tests");
+}
+
+requireText(cargo, "[dev-dependencies]", "Pages admin test runtime");
+requireText(cargo, "tokio.workspace = true", "Pages admin Tokio test runtime");
+
+if (
+  evidence.status !==
+  "pages_metadata_revision_isolation_source_unvalidated"
+) {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+
+const expectedContract = {
+  registered_metadata_runtime_preserved: true,
+  metadata_transport_injected_for_regression_only: true,
+  production_fetch_transport_preserved: true,
+  production_patch_transport_preserved: true,
+  exact_metadata_revision_parsed_before_current_read: true,
+  current_page_version_rechecked_before_patch: true,
+  stale_revision_rejected_before_patch_transport: true,
+  metadata_patch_request_contains_document_payload: false,
+  metadata_patch_request_contains_project_data: false,
+  metadata_patch_request_contains_controller: false,
+  metadata_save_callback_contains_project_data: false,
+  dirty_fly_state_mutated_by_metadata_port: false,
+  metadata_revision_advances_independently: true,
+  unit_regressions_added: true,
+  execution_behavior_changed: false,
+  public_transport_changed: false,
+  ffa_promoted: false,
+  fba_promoted: false,
+};
+
+for (const [key, expected] of Object.entries(expectedContract)) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+
+if (evidence.source_contract?.stable_conflict_code !== "REVISION_CONFLICT") {
+  failures.push("evidence stable conflict code must remain REVISION_CONFLICT");
+}
+
+const expectedTests = [
+  "stale_metadata_revision_short_circuits_before_patch_transport",
+  "metadata_save_is_document_free_and_preserves_dirty_fly_state",
+];
+if (JSON.stringify(evidence.unit_regressions) !== JSON.stringify(expectedTests)) {
+  failures.push("evidence unit regression list is invalid");
+}
+
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push("source-only evidence must not contain executed packets");
+}
+
+for (const [key, expected] of Object.entries({
+  tests_run: false,
+  cargo_run: false,
+  format_run: false,
+  verifiers_run: false,
+  workflow_checks_run: false,
+  ci_run: false,
+  runtime_proven: false,
+})) {
+  if (evidence.validation?.[key] !== expected) {
+    failures.push(`evidence validation.${key} must be ${expected}`);
+  }
+}
+
+if (
+  consumerContract.status !== "metadata_surface_cutover_complete" ||
+  consumerContract.executed_evidence !== "pending"
+) {
+  failures.push("consumer property cutover status or execution boundary changed");
+}
+
+const evidenceRegistration =
+  consumerContract.pages_consumer?.source_evidence?.metadata_revision_isolation;
+if (
+  evidenceRegistration?.state !== "source_ready_execution_pending" ||
+  evidenceRegistration?.contract !== evidencePath ||
+  evidenceRegistration?.verifier !==
+    "crates/rustok-pages/scripts/verify/verify-pages-metadata-revision-isolation.mjs"
+) {
+  failures.push("consumer property metadata revision/isolation evidence registration is invalid");
+}
+
+for (const marker of [
+  "Metadata revision/isolation source packet: ready, unvalidated",
+  "stale metadata revision short-circuits before patch transport",
+  "metadata-only transport request",
+  "dirty Fly state is not accepted by the metadata owner port",
+  "Execution evidence remains pending",
+  "verify-pages-metadata-revision-isolation.mjs",
+]) {
+  requireText(plan, marker, "Pages/Page Builder parity plan");
+}
+
+if (failures.length > 0) {
+  console.error("[verify-pages-metadata-revision-isolation] FAIL");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "[verify-pages-metadata-revision-isolation] PASS source_ready=true execution_evidence=pending",
+);

--- a/docs/modules/pages-page-builder-parity-continuation-plan.md
+++ b/docs/modules/pages-page-builder-parity-continuation-plan.md
@@ -1,7 +1,7 @@
 # Pages / Page Builder Parity Continuation Plan
 
 Date: 2026-08-03
-Status: source-cutover-complete / execution-evidence-pending
+Status: source-cutover-complete / source-regressions-ready / execution-evidence-pending
 Scope: `rustok-pages` admin FFA and `rustok-page-builder` consumer-property surface
 
 ## Audit basis
@@ -61,30 +61,77 @@ The bespoke `PageMetadataEditor` call and component are absent from
 `crates/rustok-pages/admin/src/composition.rs`. Its direct
 `transport::patch_page_metadata` UI path is also absent.
 
-Draft metadata is now reachable only through the registered Fly properties surface.
+Draft metadata is reachable only through the registered Fly properties surface.
 Published metadata is reachable only through the registered standalone surface.
 Persistence remains owned by `PagesMetadataPropertyPort`; no second runtime or owner
 port was introduced.
 
 ### Metadata UI cutover: source-complete
 
-The source now has one registered metadata contract and two lifecycle-specific host
+The source has one registered metadata contract and two lifecycle-specific host
 placements:
 
 - draft: canonical panel inside Fly;
 - published: canonical panel outside Fly, with the immutable document unmounted.
 
-The machine contract and source guard treat the legacy editor as removed. Execution
-evidence remains pending.
+The machine contract and source guard treat the legacy editor as removed.
+
+### Metadata revision/isolation source packet: ready, unvalidated
+
+`PagesMetadataPropertyPort` now separates production transport from metadata command
+preparation through a private `PagesMetadataTransport` seam. The production adapter
+still delegates to the same `fetch_page` and `patch_page_metadata` calls.
+
+The save path has an explicit, guarded order:
+
+1. validate the registered contribution and exact field set;
+2. parse the page-scoped metadata revision;
+3. read the current page;
+4. require the current page version to equal the expected metadata version;
+5. construct a metadata-only transport request;
+6. call the metadata patch transport;
+7. require the returned page version to advance;
+8. publish only `PageMutationResult` to the owner callback.
+
+The focused stale metadata revision short-circuits before patch transport and returns
+the exact stable code `REVISION_CONFLICT`.
+
+The metadata-only transport request contains token, tenant, page identity, expected
+metadata version, locale and the six registered metadata values. It contains no Fly
+body, `content_json`, project data, controller, document revision or Page Builder
+command.
+
+The regression harness also retains an unsaved dirty Fly sentinel beside a successful
+metadata save. The dirty Fly state is not accepted by the metadata owner port and is
+asserted byte-for-byte unchanged after the metadata receipt advances from metadata
+version 7 to 8.
+
+Source evidence is recorded in:
+
+- `crates/rustok-pages/contracts/evidence/pages-metadata-revision-isolation-source.json`;
+- `crates/rustok-pages/scripts/verify/verify-pages-metadata-revision-isolation.mjs`;
+- the focused tests in `crates/rustok-pages/admin/src/metadata_properties.rs`.
+
+Execution evidence remains pending. The new tests and verifier were not run by this
+implementation update.
+
+### Canonical plans: actualized to source parity
+
+The Pages and Page Builder canonical implementation plans now mark the typed rollback
+control, registered metadata contribution, draft/published panel composition and
+legacy editor removal as source-complete. They list the focused conflict/isolation
+regressions as source-ready while keeping every executed packet, browser proof,
+workflow check and rollout gate open.
 
 ## Parity matrix
 
 | Capability | Pages owner | Page Builder owner | Source state | Evidence state |
 | --- | --- | --- | --- | --- |
-| Metadata schema and values | Pages | Contract/runtime validation | Connected | Pending execution |
-| Metadata optimistic revision | Pages | Typed save envelope | Connected | Pending conflict packet |
-| Draft metadata panel inside Fly | Pages runtime/port | Leptos consumer panel | Connected | Pending execution |
-| Published metadata without Fly canvas | Pages shell composition | Standalone consumer panel | Connected | Pending execution |
+| Metadata schema and values | Pages | Contract/runtime validation | Connected | Source regression ready; execution pending |
+| Metadata optimistic revision | Pages | Typed save envelope | Connected | Conflict regression ready; execution pending |
+| Dirty Fly isolation during metadata save | Pages metadata port | Fly/Page Builder controller | Source-guarded | Isolation regression ready; execution pending |
+| Draft metadata panel inside Fly | Pages runtime/port | Leptos consumer panel | Connected | Pending browser execution |
+| Published metadata without Fly canvas | Pages shell composition | Standalone consumer panel | Connected | Pending browser execution |
 | Legacy metadata form | None | None | Removed | Not applicable |
 | Immutable artifact rollback action | Pages | No lifecycle ownership | Connected | Pending rollback/cache packet |
 | Fly document mutation | Pages builder facade | Fly/Page Builder | Draft-only | Pending observed packet |
@@ -92,20 +139,25 @@ evidence remains pending.
 
 ## Changes in this slice
 
-1. Remove the duplicated `PageMetadataEditor` invocation and implementation.
-2. Remove the direct metadata persistence call from the Pages workspace composition.
-3. Preserve draft metadata through the existing Fly properties panel.
-4. Preserve published metadata through `PagesPublishedMetadataSurface`.
-5. Promote the machine contract to `metadata_surface_cutover_complete`.
-6. Strengthen the source guard to require the old component, invocation and direct
-   persistence path to remain absent.
-7. Actualize this parity plan while keeping every execution claim open.
+1. Introduce a private metadata transport seam without changing the public runtime or
+   production transport.
+2. Extract an exact metadata save command before the current page read.
+3. Recheck the current page version before constructing or invoking the patch request.
+4. Add a stale-revision regression that requires zero patch transport calls.
+5. Add a metadata-only success regression that records the exact patch request and
+   preserves an external dirty Fly sentinel.
+6. Add a machine-readable source evidence contract and focused static verifier.
+7. Synchronize the existing metadata guard with the private transport seam and keep
+   production document-payload prohibitions scoped before the test module.
+8. Actualize the canonical Pages, Page Builder and parity plans while keeping every
+   execution claim open.
 
 ## Boundaries
 
 This slice does not:
 
-- change Pages metadata persistence, DTOs, GraphQL, HTTP or browser transport;
+- change Pages metadata DTOs, GraphQL, HTTP or browser transport;
+- change the public `ConsumerPropertyEditorRuntime` contract;
 - add a second metadata runtime or owner port;
 - mount an editable Fly document for published pages;
 - change Page Builder capability authorization, rollout policy or contribution
@@ -116,14 +168,12 @@ This slice does not:
 
 ## Next cursor
 
-1. Retain an accepted metadata packet proving exact stale-revision conflict behavior.
-2. Retain an accepted dirty-Fly isolation packet proving metadata save cannot mutate,
-   reset or replace an unsaved Fly document.
-3. Retain a published metadata packet proving the Fly canvas remains unmounted while
+1. Run and retain the focused metadata conflict and dirty-Fly isolation packets.
+2. Retain a published metadata packet proving the Fly canvas remains unmounted while
    the registered property save advances only the metadata version.
-4. Retain publish/rollback cache packets correlating receipts, outbox events, handler
+3. Retain publish/rollback cache packets correlating receipts, outbox events, handler
    receipts, generation rotation and storefront/artifact misses and refills.
-5. Complete compile, browser, workflow and rollout evidence before promoting FFA/FBA
+4. Complete compile, browser, workflow and rollout evidence before promoting FFA/FBA
    status beyond source-connected.
 
 ## Maintainer validation
@@ -132,6 +182,9 @@ Suggested commands, intentionally not run in this slice:
 
 ```bash
 node crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs
+node crates/rustok-pages/scripts/verify/verify-pages-metadata-revision-isolation.mjs
+cargo test -p rustok-pages-admin stale_metadata_revision_short_circuits_before_patch_transport
+cargo test -p rustok-pages-admin metadata_save_is_document_free_and_preserves_dirty_fly_state
 cargo check -p rustok-page-builder-admin --all-targets
 cargo check -p rustok-pages-admin --all-targets
 ```


### PR DESCRIPTION
## Summary

- continue the Pages/Page Builder parity cursor after PR #2938;
- add a private `PagesMetadataTransport` seam while preserving the public consumer-property runtime and the same production `fetch_page` / `patch_page_metadata` adapters;
- extract exact metadata command preparation and enforce current-version equality before constructing or invoking the patch request;
- add a stale-revision regression requiring exact `REVISION_CONFLICT` and zero patch transport calls;
- add a successful metadata-only regression that records the exact patch request and proves an external dirty Fly sentinel remains unchanged while the metadata revision advances;
- add a machine-readable source evidence contract with empty execution packets and all validation flags false;
- add a focused source verifier and synchronize the existing metadata property guard with the private test seam;
- actualize the canonical Pages, Page Builder and parity plans to the current source state.

## Ownership and behavior

Pages continues to own metadata values, optimistic page metadata versions and persistence through `PagesMetadataPropertyPort`.

Page Builder continues to own the framework-neutral consumer-property contract and canonical panel. No second runtime, owner port or persistence path is introduced.

The production adapters still call the same Pages transports. Metadata patch requests contain only identity, expected metadata version, locale and the six registered metadata fields; they contain no Fly body, project data, controller or document command.

## Source evidence state

- registered metadata UI cutover: source-complete;
- stale metadata conflict-before-patch regression: source-ready;
- metadata-only/dirty-Fly isolation regression: source-ready;
- focused static evidence contract: source-ready / unvalidated;
- executed test, verifier, browser and workflow packets: pending;
- FFA/FBA status: not promoted.

## Canonical plan corrections

The Pages plan now marks the typed rollback control, typed metadata contribution, registered draft/published surfaces and legacy editor removal as complete source work. The Page Builder plan no longer claims that `PageMetadataEditor` exists or that the published metadata surface is open. Both plans keep execution and rollout evidence open.

## Validation

Tests, Node verifiers, formatting, Cargo checks, browser scenarios, workflows and CI were intentionally not run, per maintainer request.

Suggested maintainer commands:

```bash
node crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs
node crates/rustok-pages/scripts/verify/verify-pages-metadata-revision-isolation.mjs
cargo test -p rustok-pages-admin stale_metadata_revision_short_circuits_before_patch_transport
cargo test -p rustok-pages-admin metadata_save_is_document_free_and_preserves_dirty_fly_state
cargo check -p rustok-page-builder-admin --all-targets
cargo check -p rustok-pages-admin --all-targets
```

The branch is one atomic commit ahead and zero behind `main`.