### PR TITLE
test(pages): guard published metadata surface

### DIFF
--- a/crates/rustok-page-builder/contracts/page-builder-consumer-properties.json
+++ b/crates/rustok-page-builder/contracts/page-builder-consumer-properties.json
@@ -81,10 +81,24 @@
       "component": "PagesPublishedMetadataSurface",
       "state": "source_connected",
       "selection": "selected_published_page_only",
+      "admission": "exact_status_published_case_insensitive",
+      "draft_hidden": true,
+      "archived_hidden": true,
+      "missing_selection_hidden": true,
       "fly_canvas_mounted": false,
+      "document_authoring_mounted": false,
       "runtime": "existing_pages_metadata_property_runtime",
       "contribution_assembly": "pages_admin_contribution_policy",
-      "workspace_refresh": "shared_refresh_generation"
+      "persistence": "delegated_to_pages_metadata_owner_port",
+      "workspace_refresh": "shared_refresh_generation",
+      "dom_contract": {
+        "surface": "data-pages-published-metadata-surface=registered",
+        "admission": "data-pages-published-metadata-admission=published-only",
+        "fly_canvas": "data-pages-fly-canvas-mounted=false",
+        "document_authoring": "data-pages-document-authoring=false",
+        "runtime": "data-pages-metadata-runtime=registered",
+        "persistence": "data-pages-metadata-persistence=owner-port"
+      }
     },
     "legacy_form": {
       "source": "crates/rustok-pages/admin/src/composition.rs",
@@ -98,6 +112,11 @@
         "state": "source_ready_execution_pending",
         "contract": "crates/rustok-pages/contracts/evidence/pages-metadata-revision-isolation-source.json",
         "verifier": "crates/rustok-pages/scripts/verify/verify-pages-metadata-revision-isolation.mjs"
+      },
+      "published_metadata_surface": {
+        "state": "source_ready_execution_pending",
+        "contract": "crates/rustok-pages/contracts/evidence/pages-published-metadata-surface-source.json",
+        "verifier": "crates/rustok-pages/scripts/verify/verify-pages-published-metadata-surface.mjs"
       }
     }
   },

--- a/crates/rustok-pages/admin/src/standalone_metadata.rs
+++ b/crates/rustok-pages/admin/src/standalone_metadata.rs
@@ -1,6 +1,7 @@
 use crate::contributions::{
     build_pages_admin_contribution_registry, pages_admin_contribution_policy,
 };
+use crate::model::PageDetail;
 use crate::transport;
 use leptos::prelude::*;
 use leptos_auth::hooks::{use_tenant, use_token};
@@ -8,6 +9,23 @@ use leptos_ui_routing::use_route_query_value;
 use rustok_page_builder_admin::{ConsumerPropertiesPanel, ConsumerPropertyEditorRuntime};
 use rustok_ui_core::AdminQueryKey;
 use std::sync::Arc;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PublishedMetadataSurfaceAdmission {
+    Hidden,
+    Registered,
+}
+
+fn published_metadata_surface_admission(
+    page: Option<&PageDetail>,
+) -> PublishedMetadataSurfaceAdmission {
+    match page {
+        Some(page) if page.status.eq_ignore_ascii_case("published") => {
+            PublishedMetadataSurfaceAdmission::Registered
+        }
+        _ => PublishedMetadataSurfaceAdmission::Hidden,
+    }
+}
 
 #[component]
 pub(crate) fn PagesPublishedMetadataSurface(
@@ -42,22 +60,29 @@ pub(crate) fn PagesPublishedMetadataSurface(
                 let runtime = runtime.clone();
                 let contribution_assembly = contribution_assembly.clone();
                 page_resource.get().map(|result| match result {
-                    Ok(Some(page)) if page.status.eq_ignore_ascii_case("published") => view! {
-                        <div
-                            class="space-y-2"
-                            data-pages-published-metadata-surface="registered"
-                        >
-                            <div class="rounded-xl border border-border bg-muted/40 px-4 py-3 text-sm text-muted-foreground">
-                                "Published metadata uses the registered Pages property contract. The immutable Fly document remains unmounted."
+                    Ok(page) => match published_metadata_surface_admission(page.as_ref()) {
+                        PublishedMetadataSurfaceAdmission::Registered => view! {
+                            <div
+                                class="space-y-2"
+                                data-pages-published-metadata-surface="registered"
+                                data-pages-published-metadata-admission="published-only"
+                                data-pages-fly-canvas-mounted="false"
+                                data-pages-document-authoring="false"
+                                data-pages-metadata-runtime="registered"
+                                data-pages-metadata-persistence="owner-port"
+                            >
+                                <div class="rounded-xl border border-border bg-muted/40 px-4 py-3 text-sm text-muted-foreground">
+                                    "Published metadata uses the registered Pages property contract. The immutable Fly document remains unmounted."
+                                </div>
+                                <ConsumerPropertiesPanel
+                                    runtime=runtime.clone()
+                                    contribution_assembly=contribution_assembly.clone()
+                                />
                             </div>
-                            <ConsumerPropertiesPanel
-                                runtime=runtime.clone()
-                                contribution_assembly=contribution_assembly.clone()
-                            />
-                        </div>
-                    }
-                    .into_any(),
-                    Ok(_) => ().into_any(),
+                        }
+                        .into_any(),
+                        PublishedMetadataSurfaceAdmission::Hidden => ().into_any(),
+                    },
                     Err(load_error) => view! {
                         <div
                             class="rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive"
@@ -71,5 +96,50 @@ pub(crate) fn PagesPublishedMetadataSurface(
                 })
             }}
         </Suspense>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn page(status: &str) -> PageDetail {
+        PageDetail {
+            id: "page-1".to_string(),
+            version: 7,
+            status: status.to_string(),
+            template: "default".to_string(),
+            updated_at: "2026-08-03T00:00:00Z".to_string(),
+            available_locales: vec!["en".to_string()],
+            channel_slugs: vec!["web".to_string()],
+            translation: None,
+            body: None,
+        }
+    }
+
+    #[test]
+    fn published_page_admits_registered_metadata_surface() {
+        assert_eq!(
+            published_metadata_surface_admission(Some(&page("published"))),
+            PublishedMetadataSurfaceAdmission::Registered
+        );
+        assert_eq!(
+            published_metadata_surface_admission(Some(&page("PUBLISHED"))),
+            PublishedMetadataSurfaceAdmission::Registered
+        );
+    }
+
+    #[test]
+    fn non_published_or_missing_page_hides_registered_metadata_surface() {
+        for status in ["draft", "archived", ""] {
+            assert_eq!(
+                published_metadata_surface_admission(Some(&page(status))),
+                PublishedMetadataSurfaceAdmission::Hidden
+            );
+        }
+        assert_eq!(
+            published_metadata_surface_admission(None),
+            PublishedMetadataSurfaceAdmission::Hidden
+        );
     }
 }

--- a/crates/rustok-pages/contracts/evidence/pages-published-metadata-surface-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-published-metadata-surface-source.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-08-03",
+  "status": "pages_published_metadata_surface_source_unvalidated",
+  "scope": "Pages selected published metadata standalone registered surface without Fly authoring",
+  "source_contract": {
+    "selected_page_read_preserved": true,
+    "published_status_case_insensitive": true,
+    "published_page_admits_registered_surface": true,
+    "draft_page_admits_registered_surface": false,
+    "archived_page_admits_registered_surface": false,
+    "missing_page_admits_registered_surface": false,
+    "registered_consumer_properties_panel_used": true,
+    "existing_metadata_runtime_reused": true,
+    "pages_contribution_assembly_reused": true,
+    "shared_refresh_generation_preserved": true,
+    "fly_canvas_mounted": false,
+    "document_authoring_mounted": false,
+    "page_builder_facade_mounted": false,
+    "direct_metadata_patch_in_surface": false,
+    "metadata_persistence_delegated_to_owner_port": true,
+    "metadata_revision_isolation_evidence_linked": true,
+    "stable_dom_contract_added": true,
+    "unit_regressions_added": true,
+    "execution_behavior_changed": false,
+    "public_transport_changed": false,
+    "ffa_promoted": false,
+    "fba_promoted": false
+  },
+  "dom_contract": {
+    "surface": "data-pages-published-metadata-surface=registered",
+    "admission": "data-pages-published-metadata-admission=published-only",
+    "fly_canvas": "data-pages-fly-canvas-mounted=false",
+    "document_authoring": "data-pages-document-authoring=false",
+    "runtime": "data-pages-metadata-runtime=registered",
+    "persistence": "data-pages-metadata-persistence=owner-port"
+  },
+  "unit_regressions": [
+    "published_page_admits_registered_metadata_surface",
+    "non_published_or_missing_page_hides_registered_metadata_surface"
+  ],
+  "linked_source_evidence": [
+    "crates/rustok-pages/contracts/evidence/pages-metadata-revision-isolation-source.json"
+  ],
+  "suggested_execution": [
+    "node crates/rustok-pages/scripts/verify/verify-pages-published-metadata-surface.mjs",
+    "cargo test -p rustok-pages-admin published_page_admits_registered_metadata_surface",
+    "cargo test -p rustok-pages-admin non_published_or_missing_page_hides_registered_metadata_surface",
+    "cargo check -p rustok-pages-admin --all-targets"
+  ],
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "browser_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "runtime_proven": false
+  }
+}

--- a/crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs
@@ -93,11 +93,19 @@ if (
   contract.pages_consumer.published_surface.state !== "source_connected" ||
   contract.pages_consumer.published_surface.selection !==
     "selected_published_page_only" ||
+  contract.pages_consumer.published_surface.admission !==
+    "exact_status_published_case_insensitive" ||
+  contract.pages_consumer.published_surface.draft_hidden !== true ||
+  contract.pages_consumer.published_surface.archived_hidden !== true ||
+  contract.pages_consumer.published_surface.missing_selection_hidden !== true ||
   contract.pages_consumer.published_surface.fly_canvas_mounted !== false ||
+  contract.pages_consumer.published_surface.document_authoring_mounted !== false ||
   contract.pages_consumer.published_surface.runtime !==
     "existing_pages_metadata_property_runtime" ||
   contract.pages_consumer.published_surface.contribution_assembly !==
-    "pages_admin_contribution_policy"
+    "pages_admin_contribution_policy" ||
+  contract.pages_consumer.published_surface.persistence !==
+    "delegated_to_pages_metadata_owner_port"
 ) {
   fail("Pages draft or published metadata surface contract is invalid");
 }
@@ -122,6 +130,18 @@ if (
     "crates/rustok-pages/scripts/verify/verify-pages-metadata-revision-isolation.mjs"
 ) {
   fail("metadata revision/isolation source evidence registration is invalid");
+}
+
+const publishedSurfaceEvidence =
+  contract.pages_consumer.source_evidence?.published_metadata_surface;
+if (
+  publishedSurfaceEvidence?.state !== "source_ready_execution_pending" ||
+  publishedSurfaceEvidence?.contract !==
+    "crates/rustok-pages/contracts/evidence/pages-published-metadata-surface-source.json" ||
+  publishedSurfaceEvidence?.verifier !==
+    "crates/rustok-pages/scripts/verify/verify-pages-published-metadata-surface.mjs"
+) {
+  fail("published metadata surface source evidence registration is invalid");
 }
 
 for (const marker of [
@@ -265,13 +285,21 @@ for (const marker of [
 }
 
 for (const marker of [
+  "enum PublishedMetadataSurfaceAdmission",
+  "fn published_metadata_surface_admission(",
+  'page.status.eq_ignore_ascii_case("published")',
   "pub(crate) fn PagesPublishedMetadataSurface(",
   "use_context::<Arc<ConsumerPropertyEditorRuntime>>()",
   "build_pages_admin_contribution_registry(",
   "&pages_admin_contribution_policy()",
   "transport::fetch_page(token, tenant, page_id).await",
-  'page.status.eq_ignore_ascii_case("published")',
+  "Ok(page) => match published_metadata_surface_admission(page.as_ref())",
   'data-pages-published-metadata-surface="registered"',
+  'data-pages-published-metadata-admission="published-only"',
+  'data-pages-fly-canvas-mounted="false"',
+  'data-pages-document-authoring="false"',
+  'data-pages-metadata-runtime="registered"',
+  'data-pages-metadata-persistence="owner-port"',
   "<ConsumerPropertiesPanel",
   "runtime=runtime.clone()",
   "contribution_assembly=contribution_assembly.clone()",
@@ -315,6 +343,7 @@ for (const forbidden of [
 for (const marker of [
   "Metadata UI cutover: source-complete",
   "Metadata revision/isolation source packet: ready, unvalidated",
+  "Published metadata source packet: ready, unvalidated",
   "Draft registered metadata surface: source-connected",
   "Published registered metadata surface: source-connected",
   "Legacy PageMetadataEditor: removed",
@@ -324,5 +353,5 @@ for (const marker of [
 }
 
 console.log(
-  "[verify-pages-metadata-properties] PASS metadata_surface_cutover_complete=true metadata_revision_isolation_source_ready=true execution_evidence=pending",
+  "[verify-pages-metadata-properties] PASS metadata_surface_cutover_complete=true metadata_revision_isolation_source_ready=true published_metadata_surface_source_ready=true execution_evidence=pending",
 );

--- a/crates/rustok-pages/scripts/verify/verify-pages-published-metadata-surface.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-published-metadata-surface.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(__filename), "..", "..", "..", "..");
+const read = (relativePath) =>
+  fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+
+const contract = JSON.parse(
+  read("crates/rustok-page-builder/contracts/page-builder-consumer-properties.json"),
+);
+const evidence = JSON.parse(
+  read(
+    "crates/rustok-pages/contracts/evidence/pages-published-metadata-surface-source.json",
+  ),
+);
+const revisionEvidence = JSON.parse(
+  read(
+    "crates/rustok-pages/contracts/evidence/pages-metadata-revision-isolation-source.json",
+  ),
+);
+const surface = read(contract.pages_consumer.published_surface_source);
+const surfaceProduction = surface.split("#[cfg(test)]")[0];
+const surfaceTests = surface.includes("#[cfg(test)]")
+  ? surface.slice(surface.indexOf("#[cfg(test)]"))
+  : "";
+const parityPlan = read(contract.parity_plan);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const requireOrdered = (content, values, label) => {
+  let previous = -1;
+  for (const value of values) {
+    const index = content.indexOf(value, previous + 1);
+    if (index < 0) {
+      failures.push(`${label}: missing or out of order ${value}`);
+      return;
+    }
+    previous = index;
+  }
+};
+
+if (evidence.status !== "pages_published_metadata_surface_source_unvalidated") {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push("executed evidence must remain empty");
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "browser_run",
+  "workflow_checks_run",
+  "ci_run",
+  "runtime_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`validation.${key} must remain false`);
+  }
+}
+
+for (const [key, expected] of Object.entries({
+  selected_page_read_preserved: true,
+  published_status_case_insensitive: true,
+  published_page_admits_registered_surface: true,
+  draft_page_admits_registered_surface: false,
+  archived_page_admits_registered_surface: false,
+  missing_page_admits_registered_surface: false,
+  registered_consumer_properties_panel_used: true,
+  existing_metadata_runtime_reused: true,
+  pages_contribution_assembly_reused: true,
+  shared_refresh_generation_preserved: true,
+  fly_canvas_mounted: false,
+  document_authoring_mounted: false,
+  page_builder_facade_mounted: false,
+  direct_metadata_patch_in_surface: false,
+  metadata_persistence_delegated_to_owner_port: true,
+  metadata_revision_isolation_evidence_linked: true,
+  stable_dom_contract_added: true,
+  unit_regressions_added: true,
+  execution_behavior_changed: false,
+  public_transport_changed: false,
+  ffa_promoted: false,
+  fba_promoted: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`source_contract.${key} must be ${expected}`);
+  }
+}
+
+const published = contract.pages_consumer.published_surface;
+if (
+  published?.component !== "PagesPublishedMetadataSurface" ||
+  published?.selection !== "selected_published_page_only" ||
+  published?.admission !== "exact_status_published_case_insensitive" ||
+  published?.draft_hidden !== true ||
+  published?.archived_hidden !== true ||
+  published?.missing_selection_hidden !== true ||
+  published?.fly_canvas_mounted !== false ||
+  published?.document_authoring_mounted !== false ||
+  published?.runtime !== "existing_pages_metadata_property_runtime" ||
+  published?.contribution_assembly !== "pages_admin_contribution_policy" ||
+  published?.persistence !== "delegated_to_pages_metadata_owner_port"
+) {
+  failures.push("published metadata surface machine contract is invalid");
+}
+
+for (const [key, expected] of Object.entries({
+  surface: "data-pages-published-metadata-surface=registered",
+  admission: "data-pages-published-metadata-admission=published-only",
+  fly_canvas: "data-pages-fly-canvas-mounted=false",
+  document_authoring: "data-pages-document-authoring=false",
+  runtime: "data-pages-metadata-runtime=registered",
+  persistence: "data-pages-metadata-persistence=owner-port",
+})) {
+  if (published?.dom_contract?.[key] !== expected) {
+    failures.push(`published_surface.dom_contract.${key} mismatch`);
+  }
+  if (evidence.dom_contract?.[key] !== expected) {
+    failures.push(`evidence.dom_contract.${key} mismatch`);
+  }
+}
+
+const registration =
+  contract.pages_consumer.source_evidence?.published_metadata_surface;
+if (
+  registration?.state !== "source_ready_execution_pending" ||
+  registration?.contract !==
+    "crates/rustok-pages/contracts/evidence/pages-published-metadata-surface-source.json" ||
+  registration?.verifier !==
+    "crates/rustok-pages/scripts/verify/verify-pages-published-metadata-surface.mjs"
+) {
+  failures.push("published metadata surface evidence registration is invalid");
+}
+
+for (const [value, label] of [
+  ["enum PublishedMetadataSurfaceAdmission", "closed admission state"],
+  ["Hidden,", "hidden admission state"],
+  ["Registered,", "registered admission state"],
+  ["fn published_metadata_surface_admission(", "admission function"],
+  [
+    'Some(page) if page.status.eq_ignore_ascii_case("published")',
+    "case-insensitive published gate",
+  ],
+  [
+    "Ok(page) => match published_metadata_surface_admission(page.as_ref())",
+    "loaded page admission routing",
+  ],
+  [
+    "PublishedMetadataSurfaceAdmission::Registered => view!",
+    "registered render branch",
+  ],
+  [
+    "PublishedMetadataSurfaceAdmission::Hidden => ().into_any()",
+    "hidden render branch",
+  ],
+  ["use_context::<Arc<ConsumerPropertyEditorRuntime>>()", "existing runtime"],
+  ["build_pages_admin_contribution_registry(", "Pages contribution assembly"],
+  ["&pages_admin_contribution_policy()", "Pages contribution policy"],
+  ["transport::fetch_page(token, tenant, page_id).await", "selected page read"],
+  ["let _generation = refresh_generation.get();", "shared refresh generation"],
+  ['data-pages-published-metadata-surface="registered"', "surface DOM marker"],
+  [
+    'data-pages-published-metadata-admission="published-only"',
+    "admission DOM marker",
+  ],
+  ['data-pages-fly-canvas-mounted="false"', "Fly canvas DOM marker"],
+  ['data-pages-document-authoring="false"', "authoring DOM marker"],
+  ['data-pages-metadata-runtime="registered"', "runtime DOM marker"],
+  ['data-pages-metadata-persistence="owner-port"', "persistence DOM marker"],
+  ["<ConsumerPropertiesPanel", "canonical registered panel"],
+  ["runtime=runtime.clone()", "runtime binding"],
+  ["contribution_assembly=contribution_assembly.clone()", "assembly binding"],
+  ["The immutable Fly document remains unmounted.", "immutable document message"],
+]) {
+  requireText(surfaceProduction, value, label);
+}
+
+requireOrdered(
+  surfaceProduction,
+  [
+    "transport::fetch_page(token, tenant, page_id).await",
+    "Ok(page) => match published_metadata_surface_admission(page.as_ref())",
+    "PublishedMetadataSurfaceAdmission::Registered => view!",
+    "<ConsumerPropertiesPanel",
+  ],
+  "published surface read-admit-render ordering",
+);
+
+for (const value of [
+  "PagesBuilderFacade",
+  "PageBuilderAdminHostContext",
+  "PagesFlyBuilder",
+  "PageBuilderAdmin",
+  "patch_page_metadata(",
+  "save_page_document",
+  "provide_context(",
+  "project_data",
+  "content_json",
+]) {
+  forbidText(surfaceProduction, value, "published surface authoring boundary");
+}
+
+for (const [value, label] of [
+  [
+    "fn published_page_admits_registered_metadata_surface()",
+    "published admission regression",
+  ],
+  [
+    "fn non_published_or_missing_page_hides_registered_metadata_surface()",
+    "hidden admission regression",
+  ],
+  [
+    'published_metadata_surface_admission(Some(&page("published")))',
+    "lowercase published case",
+  ],
+  [
+    'published_metadata_surface_admission(Some(&page("PUBLISHED")))',
+    "uppercase published case",
+  ],
+  ['for status in ["draft", "archived", ""]', "non-published cases"],
+  ["published_metadata_surface_admission(None)", "missing page case"],
+  ["PublishedMetadataSurfaceAdmission::Registered", "registered assertion"],
+  ["PublishedMetadataSurfaceAdmission::Hidden", "hidden assertion"],
+]) {
+  requireText(surfaceTests, value, label);
+}
+
+if (
+  revisionEvidence.status !== "pages_metadata_revision_isolation_source_unvalidated" ||
+  revisionEvidence.source_contract?.metadata_patch_request_contains_document_payload !== false ||
+  revisionEvidence.source_contract?.metadata_patch_request_contains_project_data !== false ||
+  revisionEvidence.source_contract?.dirty_fly_state_mutated_by_metadata_port !== false ||
+  revisionEvidence.source_contract?.metadata_revision_advances_independently !== true
+) {
+  failures.push("linked metadata revision/isolation evidence is invalid");
+}
+
+for (const marker of [
+  "Published metadata source packet: ready, unvalidated",
+  "published-only admission",
+  "stable DOM contract",
+  "browser execution remains pending",
+]) {
+  requireText(parityPlan, marker, "parity continuation plan");
+}
+
+if (failures.length > 0) {
+  console.error("[verify-pages-published-metadata-surface] FAIL");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "[verify-pages-published-metadata-surface] PASS source_ready=true browser_execution=pending fly_canvas_mounted=false",
+);

--- a/docs/modules/pages-page-builder-parity-continuation-plan.md
+++ b/docs/modules/pages-page-builder-parity-continuation-plan.md
@@ -1,7 +1,7 @@
 # Pages / Page Builder Parity Continuation Plan
 
 Date: 2026-08-03
-Status: source-cutover-complete / source-regressions-ready / execution-evidence-pending
+Status: source-cutover-complete / published-surface-regression-ready / execution-evidence-pending
 Scope: `rustok-pages` admin FFA and `rustok-page-builder` consumer-property surface
 
 ## Audit basis
@@ -78,7 +78,7 @@ The machine contract and source guard treat the legacy editor as removed.
 
 ### Metadata revision/isolation source packet: ready, unvalidated
 
-`PagesMetadataPropertyPort` now separates production transport from metadata command
+`PagesMetadataPropertyPort` separates production transport from metadata command
 preparation through a private `PagesMetadataTransport` seam. The production adapter
 still delegates to the same `fetch_page` and `patch_page_metadata` calls.
 
@@ -101,7 +101,7 @@ metadata version, locale and the six registered metadata values. It contains no 
 body, `content_json`, project data, controller, document revision or Page Builder
 command.
 
-The regression harness also retains an unsaved dirty Fly sentinel beside a successful
+The regression harness retains an unsaved dirty Fly sentinel beside a successful
 metadata save. The dirty Fly state is not accepted by the metadata owner port and is
 asserted byte-for-byte unchanged after the metadata receipt advances from metadata
 version 7 to 8.
@@ -112,12 +112,48 @@ Source evidence is recorded in:
 - `crates/rustok-pages/scripts/verify/verify-pages-metadata-revision-isolation.mjs`;
 - the focused tests in `crates/rustok-pages/admin/src/metadata_properties.rs`.
 
-Execution evidence remains pending. The new tests and verifier were not run by this
-implementation update.
+Execution evidence remains pending.
+
+### Published metadata source packet: ready, unvalidated
+
+The standalone published surface now uses one closed admission state:
+
+- a selected page whose status equals `published` case-insensitively admits the
+  registered metadata panel;
+- draft, archived, empty-status and missing-page states remain hidden.
+
+The source regressions retain this published-only admission policy without requiring a
+browser or network transport. The production surface still reads the selected page,
+reuses the existing `ConsumerPropertyEditorRuntime`, builds the Pages contribution
+assembly and renders the canonical `ConsumerPropertiesPanel`.
+
+The surface publishes a stable DOM contract for a future browser packet:
+
+- `data-pages-published-metadata-surface="registered"`;
+- `data-pages-published-metadata-admission="published-only"`;
+- `data-pages-fly-canvas-mounted="false"`;
+- `data-pages-document-authoring="false"`;
+- `data-pages-metadata-runtime="registered"`;
+- `data-pages-metadata-persistence="owner-port"`.
+
+The source and guard forbid a Pages builder facade, Page Builder host context, Fly
+builder, direct metadata patch call, document save or local runtime provisioning in
+the standalone surface. Persistence remains delegated to the existing metadata owner
+port, whose independent revision and dirty-Fly isolation packet is linked by the new
+evidence contract.
+
+Source evidence is recorded in:
+
+- `crates/rustok-pages/contracts/evidence/pages-published-metadata-surface-source.json`;
+- `crates/rustok-pages/scripts/verify/verify-pages-published-metadata-surface.mjs`;
+- the focused tests in `crates/rustok-pages/admin/src/standalone_metadata.rs`.
+
+Browser execution remains pending. The DOM markers are selectors for a retained
+browser packet; they are not a claim that the browser scenario ran.
 
 ### Canonical plans: actualized to source parity
 
-The Pages and Page Builder canonical implementation plans now mark the typed rollback
+The Pages and Page Builder canonical implementation plans mark the typed rollback
 control, registered metadata contribution, draft/published panel composition and
 legacy editor removal as source-complete. They list the focused conflict/isolation
 regressions as source-ready while keeping every executed packet, browser proof,
@@ -131,7 +167,7 @@ workflow check and rollout gate open.
 | Metadata optimistic revision | Pages | Typed save envelope | Connected | Conflict regression ready; execution pending |
 | Dirty Fly isolation during metadata save | Pages metadata port | Fly/Page Builder controller | Source-guarded | Isolation regression ready; execution pending |
 | Draft metadata panel inside Fly | Pages runtime/port | Leptos consumer panel | Connected | Pending browser execution |
-| Published metadata without Fly canvas | Pages shell composition | Standalone consumer panel | Connected | Pending browser execution |
+| Published metadata without Fly canvas | Pages shell composition | Standalone consumer panel | Admission and DOM source-guarded | Browser execution pending |
 | Legacy metadata form | None | None | Removed | Not applicable |
 | Immutable artifact rollback action | Pages | No lifecycle ownership | Connected | Pending rollback/cache packet |
 | Fly document mutation | Pages builder facade | Fly/Page Builder | Draft-only | Pending observed packet |
@@ -139,18 +175,18 @@ workflow check and rollout gate open.
 
 ## Changes in this slice
 
-1. Introduce a private metadata transport seam without changing the public runtime or
-   production transport.
-2. Extract an exact metadata save command before the current page read.
-3. Recheck the current page version before constructing or invoking the patch request.
-4. Add a stale-revision regression that requires zero patch transport calls.
-5. Add a metadata-only success regression that records the exact patch request and
-   preserves an external dirty Fly sentinel.
-6. Add a machine-readable source evidence contract and focused static verifier.
-7. Synchronize the existing metadata guard with the private transport seam and keep
-   production document-payload prohibitions scoped before the test module.
-8. Actualize the canonical Pages, Page Builder and parity plans while keeping every
-   execution claim open.
+1. Extract one deterministic published metadata surface admission policy.
+2. Add focused source regressions for published, uppercase published, draft,
+   archived, empty-status and missing-page states.
+3. Add stable DOM markers describing the registered panel, published-only admission,
+   absent Fly canvas, absent document authoring, reused runtime and owner-port
+   persistence.
+4. Add a machine-readable published-surface source evidence contract.
+5. Add a focused static verifier that links published admission to the existing
+   metadata revision/isolation evidence.
+6. Register the packet in the Page Builder consumer-properties machine contract and
+   the shared metadata source guard.
+7. Actualize this parity plan while keeping every execution claim open.
 
 ## Boundaries
 
@@ -163,14 +199,15 @@ This slice does not:
 - change Page Builder capability authorization, rollout policy or contribution
   assembly semantics;
 - alter publish, unpublish, rollback, artifact, cache or storefront behavior;
-- add Dioxus or mobile rendering;
+- add a browser harness, Dioxus or mobile rendering;
 - claim executed evidence or test results.
 
 ## Next cursor
 
 1. Run and retain the focused metadata conflict and dirty-Fly isolation packets.
-2. Retain a published metadata packet proving the Fly canvas remains unmounted while
-   the registered property save advances only the metadata version.
+2. Run and retain the published metadata browser packet using the stable DOM contract,
+   proving the registered save advances only metadata version while the Fly canvas
+   and document authoring remain absent.
 3. Retain publish/rollback cache packets correlating receipts, outbox events, handler
    receipts, generation rotation and storefront/artifact misses and refills.
 4. Complete compile, browser, workflow and rollout evidence before promoting FFA/FBA
@@ -183,8 +220,11 @@ Suggested commands, intentionally not run in this slice:
 ```bash
 node crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-metadata-revision-isolation.mjs
+node crates/rustok-pages/scripts/verify/verify-pages-published-metadata-surface.mjs
 cargo test -p rustok-pages-admin stale_metadata_revision_short_circuits_before_patch_transport
 cargo test -p rustok-pages-admin metadata_save_is_document_free_and_preserves_dirty_fly_state
+cargo test -p rustok-pages-admin published_page_admits_registered_metadata_surface
+cargo test -p rustok-pages-admin non_published_or_missing_page_hides_registered_metadata_surface
 cargo check -p rustok-page-builder-admin --all-targets
 cargo check -p rustok-pages-admin --all-targets
 ```


### PR DESCRIPTION
## Summary

- continue the Pages/Page Builder parity cursor after PR #2949;
- extract a deterministic published metadata surface admission policy;
- admit the registered standalone panel only for a selected page whose status is `published` case-insensitively;
- keep draft, archived, empty-status and missing-page states hidden;
- add stable DOM markers for the future browser packet proving published-only admission, absent Fly canvas, absent document authoring, reused registered runtime and owner-port persistence;
- add focused unit regressions for admitted and hidden states;
- add a machine-readable source evidence packet and dedicated static verifier;
- register the packet in the shared consumer-properties contract and source guard;
- actualize the parity continuation plan without claiming executed browser/runtime evidence.

## Ownership and behavior

The standalone surface continues to read the selected page, reuse the existing `ConsumerPropertyEditorRuntime`, build the Pages contribution assembly and render `ConsumerPropertiesPanel`.

It does not mount `PagesBuilderFacade`, Page Builder host context, Fly builder or document authoring. It does not call metadata persistence directly. Saves remain delegated to `PagesMetadataPropertyPort`, whose independent revision and dirty-Fly isolation source packet remains linked.

## Source evidence state

- registered published metadata surface: source-connected;
- published-only admission regression: source-ready;
- stable browser DOM contract: source-ready;
- Fly canvas/document authoring absence: source-guarded;
- browser execution packet: pending;
- tests, verifiers, Cargo and CI execution: pending;
- FFA/FBA status: not promoted.

## Validation

Tests, Node verifiers, formatting, Cargo checks, browser scenarios, workflows and CI were intentionally not run, per maintainer request.

Suggested maintainer commands:

```bash
node crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs
node crates/rustok-pages/scripts/verify/verify-pages-published-metadata-surface.mjs
cargo test -p rustok-pages-admin published_page_admits_registered_metadata_surface
cargo test -p rustok-pages-admin non_published_or_missing_page_hides_registered_metadata_surface
cargo check -p rustok-pages-admin --all-targets
```

The PR branch is one atomic commit ahead and zero behind `main`.