### PR TITLE
fix(payment): bound collection admission diagnostics

### DIFF
--- a/crates/rustok-payment/contracts/evidence/payment-collection-admission-diagnostic-safety-source.json
+++ b/crates/rustok-payment/contracts/evidence/payment-collection-admission-diagnostic-safety-source.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-08-03",
+  "status": "payment_collection_admission_diagnostic_safety_source_unvalidated",
+  "scope": "PaymentCollectionPort policy and write-semantics admission diagnostics only",
+  "source_contract": {
+    "admission_mapper_bounded": true,
+    "complete_admission_port_error_logged": false,
+    "admission_internal_message_text_logged": false,
+    "admission_context_shape_only": true,
+    "admission_correlation_preserved": true,
+    "admission_owner_operations_preserved": true,
+    "admission_phases_preserved": true,
+    "admission_error_kind_closed": true,
+    "admission_severity_split_preserved": true,
+    "original_admission_port_error_returned": true,
+    "read_write_admission_order_preserved": true,
+    "tenant_parser_cleanup_out_of_scope": true,
+    "canonical_payment_error_mapper_cleanup_out_of_scope": true,
+    "execution_behavior_changed": false,
+    "public_port_error_changed": false,
+    "ffa_promoted": false,
+    "fba_promoted": false
+  },
+  "closed_error_kinds": [
+    "validation",
+    "not_found",
+    "conflict",
+    "forbidden",
+    "unavailable",
+    "timeout",
+    "invariant_violation"
+  ],
+  "suggested_execution": [
+    "node scripts/verify/verify-payment-collection-admission-context.mjs",
+    "node scripts/verify/verify-payment-collection-tenant-context.mjs",
+    "node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs",
+    "cargo check -p rustok-payment --lib"
+  ],
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "runtime_proven": false
+  }
+}

--- a/crates/rustok-payment/docs/payment-collection-admission-context.md
+++ b/crates/rustok-payment/docs/payment-collection-admission-context.md
@@ -1,119 +1,133 @@
-# Payment collection owner admission context
+# Payment collection owner admission diagnostic safety
 
 Status: **source-ready / unvalidated**
 
 ## Scope
 
-This source slice closes the owner-side structured-context gap for admission
-rejections in `PaymentCollectionPort`:
+This bounded source slice hardens only admission diagnostics in
+`PaymentCollectionPort`:
 
 - `create_or_reuse_collection` write-policy admission;
 - `create_or_reuse_collection` write-semantics admission;
 - `read_collection_status` read-policy admission.
 
-Before this slice, the port called `PortContext::require_policy` and
-`PortContext::require_write_semantics` directly with `?`. A rejection therefore
-returned the original `PortError`, but the payment owner did not record the
-available correlation, actor, channel, locale, deadline, exact owner operation,
-or the admission phase that rejected the request.
+The public operations, policy selection, write-semantics requirement, tenant parsing, owner
+service calls, and public `PortError` behavior remain unchanged.
 
-This slice is deliberately limited to payment collection admission. Tenant-id
-parsing, request validation, provider execution, collection lifecycle mapping,
-checkout consumers, compensation consumers, and transport adapters remain
-separate concerns.
+## Preserved admission flow
 
-## Delivered source contract
+`create_or_reuse_collection` still evaluates:
 
-Both public owner operations now select their canonical owner operation before
-admission:
+1. write policy;
+2. write semantics;
+3. tenant parsing;
+4. reusable collection lookup and owner execution.
 
-- `create_or_reuse_collection` uses `create_or_reuse_collection`;
-- `read_collection_status` uses `read_collection_status`.
+`read_collection_status` still evaluates:
 
-The write path delegates admission to a payment-owned helper that:
+1. read policy;
+2. tenant parsing;
+3. owner status read.
 
-1. requires `PortCallPolicy::write()`;
-2. records a rejection with admission phase `policy` before returning the
-   original `PortError`;
-3. requires write semantics;
-4. records a rejection with admission phase `write_semantics` before returning
-   the original `PortError`.
+The exact original admission `PortError` continues through `inspect_err` unchanged. The
+diagnostic helper does not construct a replacement code, message, kind, or retryability value.
 
-The read path delegates admission to a payment-owned helper that requires
-`PortCallPolicy::read()` and records phase `policy` before returning the original
-`PortError`.
+## Bounded diagnostic policy
 
-Admission diagnostics record:
+Admission diagnostics retain only bounded context and message-shape facts.
+
+The helper records one closed error-kind label:
+
+- `validation`;
+- `not_found`;
+- `conflict`;
+- `forbidden`;
+- `unavailable`;
+- `timeout`;
+- `invariant_violation`.
+
+Both severity paths retain:
 
 - truthful owner `rustok_payment`;
 - exact owner operation;
-- admission phase;
-- correlation id and tenant id;
-- actor, channel, and locale;
-- causation id and traceparent when available;
-- idempotency key and deadline when available;
-- original error code, message, typed kind, and retryability;
-- boundary `payment_collection_port`.
+- exact admission phase `policy` or `write_semantics`;
+- boundary `payment_collection_port`;
+- correlation id;
+- stable original error code and retryability;
+- internal-message presence and character length;
+- tenant-id and actor-id character lengths;
+- closed actor-kind label;
+- claim and role counts;
+- channel presence and optional character length;
+- locale character length;
+- causation-id, traceparent, and idempotency-key presence plus optional character lengths;
+- optional deadline milliseconds.
 
-Unavailable, timeout, and invariant failures use error severity. Other
-admission rejections use warning severity.
+The helper does not record the complete admission `PortError`, human-readable internal message,
+raw tenant, actor, channel, locale, causation, traceparent, or idempotency values, or Debug
+`PortErrorKind` output.
+
+## Preserved severity
+
+Unavailable, timeout, and invariant-violation failures continue through `tracing::error!`.
+Validation, not-found, conflict, forbidden, and other ordinary admission rejections continue
+through `tracing::warn!`.
 
 ## Preserved behavior
 
 This slice does not change:
 
 - public `PaymentCollectionPort` trait signatures;
-- create/reuse request fields or status request identity;
-- status snapshot fields or typed status conversion;
-- write policy or write-semantics requirements;
-- read policy requirements;
-- tenant UUID parsing or its validation code/message;
-- reusable collection lookup by cart;
-- create-after-read behavior;
-- race adoption after a create error;
-- granular owner operation labels for existing lookup, race adoption, and
-  collection creation errors;
-- payment validation, not-found, lifecycle, provider, reconciliation,
-  configuration, or database `PortError` codes and public messages;
-- provider ids or provider operation diagnostics;
-- retryability values;
-- checkout payment execution or compensation consumer behavior;
-- FBA, FFA, or ecommerce audit status.
-
-Admission helpers return the same original `PortError` produced by
-`PortContext`; they only emit structured diagnostics before propagation.
+- create/reuse or status request and response DTOs;
+- canonical owner operation selection;
+- read/write policy selection;
+- write-semantics requirements;
+- admission-before-tenant-parsing ordering;
+- tenant UUID parsing or its validation envelope;
+- reusable collection lookup, create, or race-adoption behavior;
+- collection status reads or snapshot conversion;
+- `PaymentError` variant mapping;
+- provider, lifecycle, reconciliation, configuration, or database public envelopes;
+- checkout execution or compensation consumers;
+- Commerce orchestration;
+- ecommerce audit, Payment FFA, or Payment FBA status.
 
 ## Static evidence
 
-`scripts/verify/verify-payment-collection-admission-context.mjs` guards:
+The focused guard is:
 
-- stable payment owner and boundary identity;
-- canonical read and write owner operations;
-- operation selection before admission and tenant parsing;
-- read-policy admission without write semantics;
-- write-policy admission followed by write-semantics admission;
-- distinct `policy` and `write_semantics` diagnostic phases;
-- complete available `PortContext` fields;
-- original error code, message, typed kind, and retryability;
-- technical versus ordinary rejection severity;
-- existing create/read/race owner mappings;
-- unchanged status request and snapshot mapping;
-- stable payment public `PortError` messages;
-- absence of the old direct context-dropping admission paths.
+- `scripts/verify/verify-payment-collection-admission-context.mjs`.
 
-## Remaining gaps
+It requires:
 
-The master ecommerce correlation-safe mapper task remains open for:
+- one read and one write admission helper;
+- three preserved diagnostic call sites through `inspect_err`;
+- exact owner-operation and admission-phase attribution;
+- the closed error-kind classification;
+- bounded message and delegated-context facts;
+- technical-versus-ordinary severity;
+- original-error pass-through and admission-before-tenant ordering;
+- unchanged collection lookup, create, adoption, status-read, and snapshot behavior;
+- absence of complete errors, raw context values, raw message text, and Debug kind output inside
+  the covered helper.
 
-- payment tenant-context validation diagnostics;
-- remaining payment execution and compensation consumers;
-- storefront customer read consumers;
-- remaining order, fulfillment, inventory, customer, tax, and promotion
-  adapters;
-- non-`PortError` public envelopes;
-- compile, runtime, replay, restart, remote-port, and cross-transport evidence.
+Source evidence is recorded in:
 
-No architecture status is promoted from source-only evidence.
+- `crates/rustok-payment/contracts/evidence/payment-collection-admission-diagnostic-safety-source.json`.
+
+The evidence remains source-only: `execution` is empty and every validation flag is false.
+
+## Remaining diagnostic boundaries
+
+Tenant UUID parsing and canonical `PaymentError` mapping remain separate cleanup slices. The
+current tenant parser still records its complete parse cause, constructed `PortError`, raw
+context, message text, and Debug kind. The canonical mapper still contains raw validation,
+lifecycle, provider, identifier, database, and tenant diagnostics; some not-found public
+envelopes also still interpolate internal UUIDs.
+
+Compile, runtime, replay, restart, remote-port parity, workflows, CI, and production evidence
+remain open. The broad ecommerce correlation-safe mapper cleanup remains open, and no FFA/FBA
+status is promoted.
 
 ## Suggested maintainer checks
 
@@ -121,6 +135,7 @@ These commands were intentionally not run by the implementation agent:
 
 ```bash
 node scripts/verify/verify-payment-collection-admission-context.mjs
+node scripts/verify/verify-payment-collection-tenant-context.mjs
 node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
 cargo check -p rustok-payment --lib
 ```

--- a/crates/rustok-payment/src/ports.rs
+++ b/crates/rustok-payment/src/ports.rs
@@ -191,53 +191,107 @@ fn log_payment_collection_admission_rejection(
     admission: &'static str,
     error: &PortError,
 ) {
-    match &error.kind {
-        PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation => {
-            tracing::error!(
-                error = ?error,
-                owner = PAYMENT_COLLECTION_OWNER,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                actor = ?context.actor,
-                channel = ?context.channel,
-                locale = %context.locale,
-                causation_id = ?context.causation_id,
-                traceparent = ?context.traceparent,
-                idempotency_key = ?context.idempotency_key,
-                deadline_ms = ?context.deadline_ms,
-                operation = owner_operation,
-                admission,
-                code = %error.code,
-                internal_message = %error.message,
-                error_kind = ?error.kind,
-                retryable = error.retryable,
-                boundary = PAYMENT_COLLECTION_PORT_BOUNDARY,
-                "payment collection admission failed"
-            );
-        }
-        _ => {
-            tracing::warn!(
-                error = ?error,
-                owner = PAYMENT_COLLECTION_OWNER,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                actor = ?context.actor,
-                channel = ?context.channel,
-                locale = %context.locale,
-                causation_id = ?context.causation_id,
-                traceparent = ?context.traceparent,
-                idempotency_key = ?context.idempotency_key,
-                deadline_ms = ?context.deadline_ms,
-                operation = owner_operation,
-                admission,
-                code = %error.code,
-                internal_message = %error.message,
-                error_kind = ?error.kind,
-                retryable = error.retryable,
-                boundary = PAYMENT_COLLECTION_PORT_BOUNDARY,
-                "payment collection admission was rejected"
-            );
-        }
+    let error_kind = match &error.kind {
+        PortErrorKind::Validation => "validation",
+        PortErrorKind::NotFound => "not_found",
+        PortErrorKind::Conflict => "conflict",
+        PortErrorKind::Forbidden => "forbidden",
+        PortErrorKind::Unavailable => "unavailable",
+        PortErrorKind::Timeout => "timeout",
+        PortErrorKind::InvariantViolation => "invariant_violation",
+    };
+    let technical_failure = matches!(
+        &error.kind,
+        PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation
+    );
+    let actor_kind = match &context.actor.kind {
+        rustok_api::PortActorKind::User => "user",
+        rustok_api::PortActorKind::Service => "service",
+        rustok_api::PortActorKind::System => "system",
+    };
+    let tenant_id_length = context.tenant_id.chars().count();
+    let actor_id_length = context.actor.id.chars().count();
+    let claim_count = context.claims.len();
+    let role_count = context.roles.len();
+    let channel_present = context.channel.is_some();
+    let channel_length = context.channel.as_ref().map(|value| value.chars().count());
+    let locale_length = context.locale.chars().count();
+    let causation_id_present = context.causation_id.is_some();
+    let causation_id_length = context
+        .causation_id
+        .as_ref()
+        .map(|value| value.chars().count());
+    let traceparent_present = context.traceparent.is_some();
+    let traceparent_length = context
+        .traceparent
+        .as_ref()
+        .map(|value| value.chars().count());
+    let idempotency_key_present = context.idempotency_key.is_some();
+    let idempotency_key_length = context
+        .idempotency_key
+        .as_ref()
+        .map(|value| value.chars().count());
+    let internal_message_present = !error.message.trim().is_empty();
+    let internal_message_length = error.message.chars().count();
+
+    if technical_failure {
+        tracing::error!(
+            owner = PAYMENT_COLLECTION_OWNER,
+            correlation_id = %context.correlation_id,
+            tenant_id_length,
+            actor_kind,
+            actor_id_length,
+            claim_count,
+            role_count,
+            channel_present,
+            channel_length = ?channel_length,
+            locale_length,
+            causation_id_present,
+            causation_id_length = ?causation_id_length,
+            traceparent_present,
+            traceparent_length = ?traceparent_length,
+            idempotency_key_present,
+            idempotency_key_length = ?idempotency_key_length,
+            deadline_ms = ?context.deadline_ms,
+            operation = owner_operation,
+            admission,
+            code = %error.code,
+            internal_message_present,
+            internal_message_length,
+            error_kind,
+            retryable = error.retryable,
+            boundary = PAYMENT_COLLECTION_PORT_BOUNDARY,
+            "payment collection admission failed"
+        );
+    } else {
+        tracing::warn!(
+            owner = PAYMENT_COLLECTION_OWNER,
+            correlation_id = %context.correlation_id,
+            tenant_id_length,
+            actor_kind,
+            actor_id_length,
+            claim_count,
+            role_count,
+            channel_present,
+            channel_length = ?channel_length,
+            locale_length,
+            causation_id_present,
+            causation_id_length = ?causation_id_length,
+            traceparent_present,
+            traceparent_length = ?traceparent_length,
+            idempotency_key_present,
+            idempotency_key_length = ?idempotency_key_length,
+            deadline_ms = ?context.deadline_ms,
+            operation = owner_operation,
+            admission,
+            code = %error.code,
+            internal_message_present,
+            internal_message_length,
+            error_kind,
+            retryable = error.retryable,
+            boundary = PAYMENT_COLLECTION_PORT_BOUNDARY,
+            "payment collection admission was rejected"
+        );
     }
 }
 

--- a/scripts/verify/verify-payment-collection-admission-context.mjs
+++ b/scripts/verify/verify-payment-collection-admission-context.mjs
@@ -8,10 +8,14 @@ const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
 const root = configuredRoot
   ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
   : new URL('../../', import.meta.url);
-const source = readFileSync(
-  new URL('crates/rustok-payment/src/ports.rs', root),
-  'utf8',
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const source = read('crates/rustok-payment/src/ports.rs');
+const evidence = JSON.parse(
+  read(
+    'crates/rustok-payment/contracts/evidence/payment-collection-admission-diagnostic-safety-source.json',
+  ),
 );
+const doc = read('crates/rustok-payment/docs/payment-collection-admission-context.md');
 const failures = [];
 
 const requireText = (content, value, label) => {
@@ -20,6 +24,7 @@ const requireText = (content, value, label) => {
 const forbidText = (content, value, label) => {
   if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
 };
+const countText = (content, value) => content.split(value).length - 1;
 const between = (content, start, end, label) => {
   const startIndex = content.indexOf(start);
   const endIndex = content.indexOf(end, startIndex + start.length);
@@ -60,12 +65,13 @@ const admissionLogger = between(
   'fn parse_port_tenant_id(',
   'admission diagnostic helper',
 );
-const ownerMapper = between(
+const tenantParser = between(
   source,
+  'fn parse_port_tenant_id(',
   'fn payment_error_to_port_error(',
-  '\n}',
-  'payment owner mapper',
+  'tenant parser',
 );
+const ownerMapper = source.slice(source.indexOf('fn payment_error_to_port_error('));
 
 for (const [value, label] of [
   ['const PAYMENT_COLLECTION_PORT_BOUNDARY: &str = "payment_collection_port";', 'stable boundary identity'],
@@ -103,48 +109,154 @@ for (const [content, values, label] of [
   }
 }
 
-for (const [value, label] of [
-  ['context.require_policy(PortCallPolicy::read())', 'read policy'],
-  ['log_payment_collection_admission_rejection(context, owner_operation, "policy", &error);', 'read policy diagnostics'],
-]) requireText(readAdmission, value, label);
+for (const [content, values, label] of [
+  [
+    readAdmission,
+    [
+      'context.require_policy(PortCallPolicy::read())',
+      '.inspect_err(|error| {',
+      'log_payment_collection_admission_rejection(context, owner_operation, "policy", error);',
+    ],
+    'read admission pass-through',
+  ],
+  [
+    writeAdmission,
+    [
+      'context.require_policy(PortCallPolicy::write())',
+      '.inspect_err(|error| {',
+      'log_payment_collection_admission_rejection(context, owner_operation, "policy", error);',
+      'context.require_write_semantics().inspect_err(|error| {',
+      '"write_semantics",',
+    ],
+    'write admission pass-through',
+  ],
+]) {
+  for (const value of values) requireText(content, value, label);
+}
 forbidText(readAdmission, 'require_write_semantics', 'read admission must remain non-write');
-
-for (const [value, label] of [
-  ['context.require_policy(PortCallPolicy::write())', 'write policy'],
-  ['log_payment_collection_admission_rejection(context, owner_operation, "policy", &error);', 'write policy diagnostics'],
-  ['context.require_write_semantics()', 'write semantics'],
-  ['"write_semantics"', 'write semantics diagnostic classification'],
-]) requireText(writeAdmission, value, label);
+forbidText(readAdmission + writeAdmission, 'PortError::', 'admission helper error reconstruction');
+forbidText(readAdmission + writeAdmission, '.map_err(', 'admission helper error replacement');
 
 for (const [value, label] of [
   ['context: &PortContext', 'retained context input'],
   ["owner_operation: &'static str", 'exact owner operation input'],
   ["admission: &'static str", 'admission phase input'],
-  ['error: &PortError', 'original port error input'],
-  ['error = ?error', 'original error'],
+  ['error: &PortError', 'borrowed original port error'],
+  ['let error_kind = match &error.kind', 'closed error-kind classification'],
+  ['PortErrorKind::Validation => "validation"', 'validation kind label'],
+  ['PortErrorKind::NotFound => "not_found"', 'not-found kind label'],
+  ['PortErrorKind::Conflict => "conflict"', 'conflict kind label'],
+  ['PortErrorKind::Forbidden => "forbidden"', 'forbidden kind label'],
+  ['PortErrorKind::Unavailable => "unavailable"', 'unavailable kind label'],
+  ['PortErrorKind::Timeout => "timeout"', 'timeout kind label'],
+  ['PortErrorKind::InvariantViolation => "invariant_violation"', 'invariant kind label'],
+  ['let technical_failure = matches!(', 'technical severity classification'],
+  ['let actor_kind = match &context.actor.kind', 'bounded actor kind'],
+  ['let tenant_id_length = context.tenant_id.chars().count();', 'tenant shape'],
+  ['let actor_id_length = context.actor.id.chars().count();', 'actor identity shape'],
+  ['let claim_count = context.claims.len();', 'claim count'],
+  ['let role_count = context.roles.len();', 'role count'],
+  ['let channel_present = context.channel.is_some();', 'channel presence'],
+  ['let channel_length = context.channel.as_ref()', 'channel length'],
+  ['let locale_length = context.locale.chars().count();', 'locale length'],
+  ['let causation_id_present = context.causation_id.is_some();', 'causation presence'],
+  ['let causation_id_length = context', 'causation length'],
+  ['let traceparent_present = context.traceparent.is_some();', 'trace presence'],
+  ['let traceparent_length = context', 'trace length'],
+  ['let idempotency_key_present = context.idempotency_key.is_some();', 'idempotency presence'],
+  ['let idempotency_key_length = context', 'idempotency length'],
+  ['let internal_message_present = !error.message.trim().is_empty();', 'message presence'],
+  ['let internal_message_length = error.message.chars().count();', 'message length'],
   ['owner = PAYMENT_COLLECTION_OWNER', 'truthful owner field'],
   ['correlation_id = %context.correlation_id', 'correlation context'],
-  ['tenant_id = %context.tenant_id', 'tenant context'],
-  ['actor = ?context.actor', 'actor context'],
-  ['channel = ?context.channel', 'channel context'],
-  ['locale = %context.locale', 'locale context'],
-  ['causation_id = ?context.causation_id', 'causation context'],
-  ['traceparent = ?context.traceparent', 'trace context'],
-  ['idempotency_key = ?context.idempotency_key', 'idempotency context'],
   ['deadline_ms = ?context.deadline_ms', 'deadline context'],
   ['operation = owner_operation', 'owner operation field'],
   ['admission,', 'admission phase field'],
-  ['code = %error.code', 'error code'],
-  ['internal_message = %error.message', 'error message'],
-  ['error_kind = ?error.kind', 'typed error kind'],
+  ['code = %error.code', 'stable error code'],
+  ['internal_message_present', 'message presence diagnostic'],
+  ['internal_message_length', 'message length diagnostic'],
+  ['error_kind', 'closed kind diagnostic'],
   ['retryable = error.retryable', 'retryability'],
   ['boundary = PAYMENT_COLLECTION_PORT_BOUNDARY', 'boundary field'],
-  ['PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation', 'technical severity classification'],
   ['tracing::error!(', 'technical severity'],
   ['tracing::warn!(', 'ordinary rejection severity'],
   ['"payment collection admission failed"', 'technical event'],
   ['"payment collection admission was rejected"', 'rejection event'],
 ]) requireText(admissionLogger, value, label);
+
+for (const value of [
+  'error = ?error',
+  'error = %error',
+  'tenant_id = %context.tenant_id',
+  'actor = ?context.actor',
+  'channel = ?context.channel',
+  'locale = %context.locale',
+  'causation_id = ?context.causation_id',
+  'traceparent = ?context.traceparent',
+  'idempotency_key = ?context.idempotency_key',
+  'internal_message = %error.message',
+  'error_kind = ?error.kind',
+]) forbidText(admissionLogger, value, 'unsafe admission diagnostic payload');
+
+if (countText(admissionLogger, 'tracing::error!(') !== 1) {
+  failures.push('expected exactly one admission technical diagnostic path');
+}
+if (countText(admissionLogger, 'tracing::warn!(') !== 1) {
+  failures.push('expected exactly one admission rejection diagnostic path');
+}
+for (const marker of [
+  'owner = PAYMENT_COLLECTION_OWNER',
+  'correlation_id = %context.correlation_id',
+  'operation = owner_operation',
+  'admission,',
+  'code = %error.code',
+  'internal_message_present',
+  'internal_message_length',
+  'error_kind',
+  'retryable = error.retryable',
+  'boundary = PAYMENT_COLLECTION_PORT_BOUNDARY',
+]) {
+  if (countText(admissionLogger, marker) < 2) {
+    failures.push(`both admission severity paths must retain ${marker}`);
+  }
+}
+
+for (const [pattern, expected, label] of [
+  [/log_payment_collection_admission_rejection\(/g, 4, 'diagnostic helper definition/use count'],
+  [/"policy"/g, 2, 'policy phase count'],
+  [/"write_semantics"/g, 1, 'write semantics phase count'],
+]) {
+  const count = source.match(pattern)?.length ?? 0;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+}
+
+for (const [content, values, label] of [
+  [
+    tenantParser,
+    [
+      'Uuid::parse_str(&context.tenant_id).map_err(|parse_error| {',
+      'parse_error = ?parse_error',
+      'error = ?error',
+      'validation = "tenant_id"',
+      '"payment.tenant_id_invalid"',
+    ],
+    'tenant parser remains separate',
+  ],
+  [
+    ownerMapper,
+    [
+      'fn payment_error_to_port_error(',
+      'cause = %message',
+      'provider_id = %provider_id',
+      'error = ?error',
+      '"payment request is invalid"',
+      '"payment storage is temporarily unavailable"',
+    ],
+    'canonical payment mapper remains separate',
+  ],
+]) {
+  for (const value of values) requireText(content, value, label);
+}
 
 for (const [value, label] of [
   ['"create_or_reuse_collection.read_existing"', 'existing collection read mapping'],
@@ -153,34 +265,68 @@ for (const [value, label] of [
   ['find_reusable_collection_by_cart(tenant_id, cart_id)', 'reusable collection lookup'],
   ['create_collection(', 'collection creation'],
 ]) requireText(createBlock, value, label);
-
 for (const [value, label] of [
   ['get_collection(tenant_id, request.collection_id)', 'status collection identity'],
   ['payment_error_to_port_error(&context, owner_operation, error)', 'status owner mapping'],
   ['PaymentCollectionStatusSnapshot::from_response(&response)', 'status snapshot mapping'],
 ]) requireText(readBlock, value, label);
 
-for (const [value, label] of [
-  ['PortError::validation("payment.validation", "payment request is invalid")', 'stable validation envelope'],
-  ['PortError::unavailable(', 'stable unavailable envelope'],
-  ['"payment provider outcome requires reconciliation"', 'stable reconciliation envelope'],
-  ['"payment storage is temporarily unavailable"', 'stable storage envelope'],
-]) requireText(source, value, label);
+if (evidence.status !== 'payment_collection_admission_diagnostic_safety_source_unvalidated') {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  admission_mapper_bounded: true,
+  complete_admission_port_error_logged: false,
+  admission_internal_message_text_logged: false,
+  admission_context_shape_only: true,
+  admission_correlation_preserved: true,
+  admission_owner_operations_preserved: true,
+  admission_phases_preserved: true,
+  admission_error_kind_closed: true,
+  admission_severity_split_preserved: true,
+  original_admission_port_error_returned: true,
+  read_write_admission_order_preserved: true,
+  tenant_parser_cleanup_out_of_scope: true,
+  canonical_payment_error_mapper_cleanup_out_of_scope: true,
+  execution_behavior_changed: false,
+  public_port_error_changed: false,
+  ffa_promoted: false,
+  fba_promoted: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push('evidence execution must remain empty');
+}
+for (const key of [
+  'tests_run',
+  'cargo_run',
+  'format_run',
+  'verifiers_run',
+  'workflow_checks_run',
+  'ci_run',
+  'runtime_proven',
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
+}
 
-forbidText(createBlock, 'context.require_policy(', 'direct write policy admission');
-forbidText(createBlock, 'context.require_write_semantics()', 'direct write semantics admission');
-forbidText(readBlock, 'context.require_policy(', 'direct read policy admission');
-forbidText(source, 'context.require_policy(PortCallPolicy::write())?;', 'context-dropping write policy rejection');
-forbidText(source, 'context.require_write_semantics()?;', 'context-dropping write semantics rejection');
-forbidText(source, 'context.require_policy(PortCallPolicy::read())?;', 'context-dropping read policy rejection');
-forbidText(source, 'parse_port_tenant_id(&context)?', 'operation-free tenant parsing');
+for (const [value, label] of [
+  ['Status: **source-ready / unvalidated**', 'documentation status'],
+  ['Admission diagnostics retain only bounded context and message-shape facts', 'documentation bounded policy'],
+  ['The exact original admission `PortError` continues through `inspect_err` unchanged', 'documentation pass-through policy'],
+  ['Tenant UUID parsing and canonical `PaymentError` mapping remain separate cleanup slices', 'documentation residual boundary'],
+]) requireText(doc, value, label);
 
 if (failures.length > 0) {
-  console.error('Payment collection admission context verification failed:');
+  console.error('Payment collection admission diagnostic-safety verification failed:');
   for (const failure of failures) console.error(`✗ ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
 
 console.log(
-  '✔ Payment collection read/write admission rejections retain truthful owner context without changing collection lifecycle or public PortError behavior',
+  '✔ Payment collection admission diagnostics use bounded kind, message-shape, and context-shape facts while preserving admission ordering and original-error pass-through',
 );


### PR DESCRIPTION
## Summary

- continue the ecommerce correlation-safe mapper cleanup at the Payment collection owner boundary;
- harden only `log_payment_collection_admission_rejection` at runtime;
- replace complete admission `PortError`, raw delegated context, internal message text, and Debug `PortErrorKind` output with closed kind, message-shape, and context-shape facts;
- preserve the exact read/write policy and write-semantics ordering;
- preserve the three existing `inspect_err` diagnostic call sites and propagation of the original admission `PortError`;
- preserve technical `error!` versus ordinary `warn!` severity;
- add source-only evidence and a focused fail-closed verifier;
- update the Payment collection admission documentation without promoting ecommerce or Payment gates.

## Covered runtime boundary

- `log_payment_collection_admission_rejection`

## Deliberate boundary

This PR does not change `parse_port_tenant_id`, `payment_error_to_port_error`, collection lookup/create/adoption/status behavior, request or response DTOs, public `PortError` envelopes, checkout execution, compensation, Commerce orchestration, or FFA/FBA status.

## Validation

Tests, Node verifiers, formatting, Cargo checks, mounted execution, workflows, and CI were not run, per maintainer request.

Suggested maintainer commands:

```bash
node scripts/verify/verify-payment-collection-admission-context.mjs
node scripts/verify/verify-payment-collection-tenant-context.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-payment --lib
```

Branch base: `0df579d45198876bdec1f148a77790ca95ef65cc`.