### PR TITLE
feat(index): authorize drift finding inspection

### DIFF
--- a/apps/server/docs/index-reconciliation-operator-runtime.md
+++ b/apps/server/docs/index-reconciliation-operator-runtime.md
@@ -9,18 +9,19 @@ The server publishes one guarded `IndexReconciliationOperatorRuntime` after the 
 The boundary wraps:
 
 - `PostgresIndexReconciliationRunner` for bounded run and cancellation;
-- `PostgresIndexReconciliationDeadLetterInspector` for bounded read-only inspection;
+- `PostgresIndexReconciliationDeadLetterInspector` for bounded read-only dead-letter inspection;
+- `PostgresIndexDriftFindingInspector` for bounded read-only open-finding diagnosis;
 - `PostgresIndexReconciliationRecoveryStore` for audited same-job recovery.
 
-The same registry-freezing composition now also publishes the separate module-owned reconciliation work registration. The operator runtime does not expose or own that scheduler.
+The same registry-freezing composition also publishes the separate module-owned reconciliation work registration. The operator runtime does not expose or own that scheduler.
 
 ## Request-bound authority
 
 Every operation requires a non-nil tenant/actor `IndexReconciliationOperatorContext`, a current request-scoped RBAC snapshot, and effective `Permission::MODULES_MANAGE`.
 
-Run rejects a tenant mismatch before runner delegation. Cancellation, inspection, and requeue accept no caller-selected tenant. Requeue accepts no caller-selected actor; the audit actor is always `context.actor_id()`.
+Run rejects a tenant mismatch before runner delegation. Cancellation, dead-letter inspection, drift-finding inspection, and requeue accept no caller-selected tenant. Requeue accepts no caller-selected actor; the audit actor is always `context.actor_id()`.
 
-Inspection and requeue authorization occur before adapter or recovery-request validation and before database access.
+Both inspection methods and requeue authorize before adapter or recovery-request validation and before database access. An unauthorized caller therefore cannot use nil identifiers, malformed requests, or storage behavior as a tenant-scoped oracle.
 
 ## Published surface
 
@@ -29,9 +30,12 @@ The operator exposes only:
 - `run(context, request)`;
 - `request_cancel(context, job_id)`;
 - `inspect_dead_letter(context, job_id)`;
+- `inspect_drift_finding(context, finding_id)`;
 - `requeue_dead_letter(context, job_id, reason)`.
 
-It exposes no database connection, registry, scheduler handle, worker-spawn handle, raw failure details, direct SQL, or transport.
+Drift inspection returns only the bounded crate value: finding UUID and key, check name, severity, typed scope, and optional expected/actual digests. It does not return tenant identity, raw finding details, detection timestamps, closure state, SQL, or database causes.
+
+The runtime exposes no database connection, registry, scheduler handle, worker-spawn handle, raw failure or finding details, direct SQL, or transport.
 
 ## Composition and scheduling
 
@@ -40,22 +44,26 @@ The server replay composition remains the single source-freezing point:
 1. PostgreSQL source factories are materialized;
 2. `SharedIndexSourceRegistry` is frozen;
 3. replay dry-run/runtime and the due-reconciliation module-work registration are published;
-4. this guarded reconciliation operator is built from the same source/schema registries and database.
+4. this guarded reconciliation operator is built from the same source/schema registries and database;
+5. the canonical runner, both read-only inspectors, and the audited recovery store are inserted into one private runtime.
 
-Composition performs no reconciliation SQL and starts no task. The existing generic server module-work bootstrap later owns the one-second polling loop and shared `StopHandle` shutdown. The Index adapter discovers work; the canonical runner owns claim, takeover, attempt fencing, cancellation, retry, exhaustion, and terminal state.
+Composition performs no reconciliation or drift SQL and starts no task. The existing generic server module-work bootstrap later owns the one-second polling loop and shared `StopHandle` shutdown. The Index adapter discovers work; the canonical runner owns claim, takeover, attempt fencing, cancellation, retry, exhaustion, and terminal state.
 
-The operator remains intentionally independent from automatic scheduling: manual authorized calls and host-scheduled calls converge only at the same canonical runner.
+The operator remains intentionally independent from automatic scheduling: manual authorized calls and host-scheduled calls converge only at the same canonical runner. Drift inspection is read-only and is not scheduled.
 
 ## Explicitly open
 
 - GraphQL, HTTP, CLI, MCP, native admin, or other command transport;
-- retained PostgreSQL authorization and scheduler execution evidence;
+- retained PostgreSQL authorization, inspection, and scheduler execution evidence;
 - operator-visible scheduler health and metrics;
 - per-source retry policy, jitter, and dynamic configuration;
-- source/index digest comparison, orphan diagnosis, and targeted/full/shadow repair;
+- source/index digest comparison and consistency-finding production;
+- orphan diagnosis;
+- finding resolution or ignore transitions;
+- targeted/full/shadow repair admission, execution, audit, and evidence;
 - locale or partition checkpoint dimensions.
 
-The canonical bounded retry/global scheduling item remains open pending owner-retained production and multi-host evidence. The drift-diagnosis/targeted-repair item also remains open.
+The canonical bounded retry/global scheduling item remains open pending owner-retained production and multi-host evidence. The drift-diagnosis/targeted-repair item also remains open because this runtime only authorizes bounded inspection of findings that already exist.
 
 ## Validation ownership
 

--- a/apps/server/src/services/index_reconciliation_operator.rs
+++ b/apps/server/src/services/index_reconciliation_operator.rs
@@ -68,21 +68,24 @@ pub enum IndexReconciliationOperatorError {
     #[error(transparent)]
     Inspection(#[from] rustok_index::infrastructure::postgres::IndexReconciliationDeadLetterInspectionError),
     #[error(transparent)]
+    DriftInspection(#[from] rustok_index::infrastructure::postgres::IndexDriftFindingInspectionError),
+    #[error(transparent)]
     Recovery(#[from] rustok_index::infrastructure::postgres::IndexReconciliationRecoveryError),
 }
 
 /// Server-owned guarded operator boundary over the canonical PostgreSQL Index reconciliation
-/// runner, bounded dead-letter inspector, and audited recovery store.
+/// runner, bounded dead-letter and drift-finding inspectors, and audited recovery store.
 ///
 /// Transport adapters must provide an exact request-bound tenant/actor context. The boundary
 /// accepts only `modules:manage`, rejects cross-tenant run requests before database access, derives
-/// cancellation, inspection, and recovery tenant scope from the authorized context, binds recovery
-/// actor identity to that same context, and exposes no connection, source registry, scheduler, task
-/// handle, or worker-spawn capability.
+/// cancellation, inspection, drift-diagnosis, and recovery tenant scope from the authorized
+/// context, binds recovery actor identity to that same context, and exposes no connection, source
+/// registry, scheduler, task handle, or worker-spawn capability.
 #[derive(Clone)]
 pub struct IndexReconciliationOperatorRuntime {
     inner: rustok_index::PostgresIndexReconciliationRunner,
     dead_letters: rustok_index::infrastructure::postgres::PostgresIndexReconciliationDeadLetterInspector,
+    drift_findings: rustok_index::infrastructure::postgres::PostgresIndexDriftFindingInspector,
     recovery: rustok_index::infrastructure::postgres::PostgresIndexReconciliationRecoveryStore,
 }
 
@@ -90,11 +93,13 @@ impl IndexReconciliationOperatorRuntime {
     fn new(
         inner: rustok_index::PostgresIndexReconciliationRunner,
         dead_letters: rustok_index::infrastructure::postgres::PostgresIndexReconciliationDeadLetterInspector,
+        drift_findings: rustok_index::infrastructure::postgres::PostgresIndexDriftFindingInspector,
         recovery: rustok_index::infrastructure::postgres::PostgresIndexReconciliationRecoveryStore,
     ) -> Self {
         Self {
             inner,
             dead_letters,
+            drift_findings,
             recovery,
         }
     }
@@ -137,6 +142,21 @@ impl IndexReconciliationOperatorRuntime {
         context.authorize_for(context.tenant_id())?;
         self.dead_letters
             .inspect(context.tenant_id(), job_id)
+            .await
+            .map_err(Into::into)
+    }
+
+    pub async fn inspect_drift_finding(
+        &self,
+        context: IndexReconciliationOperatorContext,
+        finding_id: Uuid,
+    ) -> std::result::Result<
+        Option<rustok_index::infrastructure::postgres::IndexDriftFindingInspection>,
+        IndexReconciliationOperatorError,
+    > {
+        context.authorize_for(context.tenant_id())?;
+        self.drift_findings
+            .inspect(context.tenant_id(), finding_id)
             .await
             .map_err(Into::into)
     }
@@ -212,11 +232,14 @@ pub(super) fn materialize_index_reconciliation_operator(
         rustok_index::infrastructure::postgres::PostgresIndexReconciliationDeadLetterInspector::new(
             db.clone(),
         );
+    let drift_findings =
+        rustok_index::infrastructure::postgres::PostgresIndexDriftFindingInspector::new(db.clone());
     let runner =
         rustok_index::PostgresIndexReconciliationRunner::new(db, sources, schemas.shared());
     extensions.insert(IndexReconciliationOperatorRuntime::new(
         runner,
         dead_letters,
+        drift_findings,
         recovery,
     ));
     Ok(())
@@ -526,6 +549,66 @@ mod tests {
             delegated,
             IndexReconciliationOperatorError::Inspection(
                 rustok_index::infrastructure::postgres::IndexReconciliationDeadLetterInspectionError::NilJobId
+            )
+        ));
+    }
+
+    #[tokio::test]
+    async fn drift_finding_inspection_authorizes_before_adapter_validation() {
+        let mut extensions = complete_registries();
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database without Index migrations");
+        materialize_index_reconciliation_operator(&mut extensions, db)
+            .expect("runtime materialization");
+        let runtime = extensions
+            .get::<IndexReconciliationOperatorRuntime>()
+            .cloned()
+            .expect("guarded runtime");
+        let tenant_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let context = IndexReconciliationOperatorContext::new(tenant_id, actor_id).unwrap();
+
+        let missing = runtime
+            .inspect_drift_finding(context, Uuid::nil())
+            .await
+            .expect_err("missing request authority must fail before adapter validation");
+        assert!(matches!(
+            missing,
+            IndexReconciliationOperatorError::MissingRequestAuthority
+        ));
+
+        let forbidden = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_READ],
+                UserRole::Admin,
+            )),
+            runtime.inspect_drift_finding(context, Uuid::nil()),
+        )
+        .await
+        .expect_err("modules:read must not inspect drift findings");
+        assert!(matches!(
+            forbidden,
+            IndexReconciliationOperatorError::Forbidden
+        ));
+
+        let delegated = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_MANAGE],
+                UserRole::Admin,
+            )),
+            runtime.inspect_drift_finding(context, Uuid::nil()),
+        )
+        .await
+        .expect_err("authorized nil finding must reach bounded adapter validation");
+        assert!(matches!(
+            delegated,
+            IndexReconciliationOperatorError::DriftInspection(
+                rustok_index::infrastructure::postgres::IndexDriftFindingInspectionError::NilFindingId
             )
         ));
     }

--- a/crates/rustok-index/docs/m6-drift-finding-inspection.md
+++ b/crates/rustok-index/docs/m6-drift-finding-inspection.md
@@ -1,6 +1,6 @@
 # M6 drift finding inspection
 
-Status: `source_complete_server_authorization_and_repair_pending`.
+Status: `source_complete_server_authorized_repair_pending`.
 
 ## Purpose
 
@@ -43,11 +43,20 @@ Database failures map to one stable detail-free `Storage` error.
 
 The adapter performs no insert, update, delete, state transition, finding acknowledgement, repair admission, source scan, targeted load, scheduling, polling, sleep, or task creation.
 
-## Authorization boundary
+## Authorized server boundary
 
-This crate adapter is not an authorization or transport surface. It accepts no actor, permission snapshot, bearer identity, or caller-selected repair action.
+The guarded server `IndexReconciliationOperatorRuntime` now composes one private `PostgresIndexDriftFindingInspector` beside the canonical runner, dead-letter inspector, and recovery store.
 
-A later server composition must bind the tenant exclusively from the existing request-bound operator context, require effective `modules:manage` before adapter validation or database access, and expose only the bounded inspection value. GraphQL, HTTP, CLI, MCP, native admin, and other transports remain open.
+`inspect_drift_finding(context, finding_id)` accepts no tenant or actor parameter. It:
+
+1. validates the existing request-bound operator context;
+2. resolves the current exact tenant/actor RBAC snapshot;
+3. requires effective `modules:manage`;
+4. only then calls `inspect(context.tenant_id(), finding_id)`.
+
+Missing request authority and `modules:read` fail before nil-finding validation or database access. An authorized nil finding reaches the bounded crate adapter and returns typed `NilFindingId`.
+
+The server returns only `Option<IndexDriftFindingInspection>`. It contains no direct SQL, does not decode or copy raw `details`, and exposes neither the adapter nor the database connection. GraphQL, HTTP, CLI, MCP, native admin, and other transports remain open.
 
 ## Repair boundary
 
@@ -67,17 +76,16 @@ No automatic finding closure or mutation is allowed from inspection alone.
 
 ## Explicitly open
 
-- request-bound server authorization and internal operator composition;
 - source/index digest comparison and finding persistence;
 - orphan diagnosis;
 - targeted repair request/admission and immutable repair audit;
 - full and shadow repair modes;
 - automatic finding resolution after admitted repair;
 - locale or partition checkpoint dimensions;
-- retained PostgreSQL inspection, diagnosis, repair, and concurrency evidence;
+- retained PostgreSQL authorization, inspection, diagnosis, repair, and concurrency evidence;
 - public/admin command transport.
 
-The canonical roadmap item `Add drift diagnosis, targeted repair commands, and admitted repair evidence` remains open. This slice establishes only the bounded read-only inspection substrate.
+The canonical roadmap item `Add drift diagnosis, targeted repair commands, and admitted repair evidence` remains open. This slice establishes bounded read-only inspection plus internal request-bound authorization only.
 
 ## Validation ownership
 

--- a/scripts/verify/verify-index-drift-finding-inspection.mjs
+++ b/scripts/verify/verify-index-drift-finding-inspection.mjs
@@ -119,27 +119,65 @@ requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
   'IndexDriftFindingSeverity, PostgresIndexDriftFindingInspector,',
 ]);
 
-const serverPath = 'apps/server/src/services/index_reconciliation_operator.rs';
-const server = read(serverPath);
-for (const premature of [
-  'PostgresIndexDriftFindingInspector',
-  'inspect_drift_finding(',
-  'IndexDriftFindingInspectionError',
+const operatorPath = 'apps/server/src/services/index_reconciliation_operator.rs';
+const operator = requireMarkers(operatorPath, [
+  'PostgresIndexDriftFindingInspector,',
+  'DriftInspection(#[from] rustok_index::infrastructure::postgres::IndexDriftFindingInspectionError)',
+  'pub async fn inspect_drift_finding(',
+  'Option<rustok_index::infrastructure::postgres::IndexDriftFindingInspection>',
+  'self.drift_findings',
+  '.inspect(context.tenant_id(), finding_id)',
+  'PostgresIndexDriftFindingInspector::new(db.clone())',
+  'drift_finding_inspection_authorizes_before_adapter_validation',
+  'IndexDriftFindingInspectionError::NilFindingId',
+]);
+const operatorProduction = operator.split('\n#[cfg(test)]')[0];
+const driftStart = operatorProduction.indexOf('    pub async fn inspect_drift_finding(');
+const requeueStart = operatorProduction.indexOf('    pub async fn requeue_dead_letter(', driftStart);
+if (driftStart < 0 || requeueStart <= driftStart) {
+  fail(`${operatorPath} drift inspection method segment is missing`);
+}
+const drift = operatorProduction.slice(driftStart, requeueStart);
+const authorization = drift.indexOf('context.authorize_for(context.tenant_id())?;');
+const delegation = drift.indexOf('.inspect(context.tenant_id(), finding_id)');
+if (drift.includes('tenant_id: Uuid') || authorization < 0 || delegation <= authorization) {
+  fail(`${operatorPath} drift inspection must authorize before tenant-bound delegation`);
+}
+for (const forbidden of [
+  'SELECT ',
+  'INSERT ',
+  'UPDATE ',
+  'DELETE ',
+  'details',
+  'first_detected_at',
+  'last_detected_at',
+  'closed_at',
+  'PostgresMutationStore',
+  'repair_finding',
+  'resolve_finding',
 ]) {
-  if (server.includes(premature)) {
-    fail(`${serverPath} prematurely publishes drift inspection marker ${premature}`);
+  if (drift.includes(forbidden)) {
+    fail(`${operatorPath} drift inspection contains forbidden marker ${forbidden}`);
   }
 }
 
 requireMarkers('crates/rustok-index/docs/m6-drift-finding-inspection.md', [
-  'Status: `source_complete_server_authorization_and_repair_pending`.',
+  'Status: `source_complete_server_authorized_repair_pending`.',
   '`PostgresIndexDriftFindingInspector`',
   "`state = 'open'`",
   'raw `details` JSON',
+  '`inspect_drift_finding(context, finding_id)`',
+  'requires effective `modules:manage`',
+  'Missing request authority and `modules:read` fail before nil-finding validation or database access.',
   'No automatic finding closure or mutation is allowed from inspection alone.',
-  'request-bound server authorization and internal operator composition',
   'The canonical roadmap item `Add drift diagnosis, targeted repair commands, and admitted repair evidence` remains open.',
   'maintainer-run',
+]);
+requireMarkers('apps/server/docs/index-reconciliation-operator-runtime.md', [
+  '`PostgresIndexDriftFindingInspector` for bounded read-only open-finding diagnosis',
+  '`inspect_drift_finding(context, finding_id)`',
+  'Both inspection methods and requeue authorize before adapter or recovery-request validation',
+  'Drift inspection is read-only and is not scheduled.',
 ]);
 requireMarkers('crates/rustok-index/docs/README.md', [
   '[M6 Drift Finding Inspection](./m6-drift-finding-inspection.md)',
@@ -150,6 +188,7 @@ requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
 ]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-drift-finding-inspection.mjs'",
+  "'verify-index-server-reconciliation-guard.mjs'",
 ]);
 
 console.log('[verify-index-drift-finding-inspection] OK');

--- a/scripts/verify/verify-index-server-reconciliation-guard.mjs
+++ b/scripts/verify/verify-index-server-reconciliation-guard.mjs
@@ -44,15 +44,19 @@ const operator = requireMarkers(operatorPath, [
   'pub struct IndexReconciliationOperatorRuntime',
   'inner: rustok_index::PostgresIndexReconciliationRunner,',
   'PostgresIndexReconciliationDeadLetterInspector,',
+  'PostgresIndexDriftFindingInspector,',
   'PostgresIndexReconciliationRecoveryStore,',
+  'DriftInspection(#[from] rustok_index::infrastructure::postgres::IndexDriftFindingInspectionError)',
   'context.authorize_for(request.tenant_id())?;',
   'pub async fn request_cancel(',
   'pub async fn inspect_dead_letter(',
+  'pub async fn inspect_drift_finding(',
   'pub async fn requeue_dead_letter(',
   'IndexReconciliationRequeueRequest::new(',
   'context.tenant_id(),',
   'context.actor_id(),',
   '.requeue_failed(request)',
+  'drift_finding_inspection_authorizes_before_adapter_validation',
 ]);
 const production = operator.split('\n#[cfg(test)]')[0];
 for (const forbidden of [
@@ -64,12 +68,17 @@ for (const forbidden of [
 
 const runStart = production.indexOf('    pub async fn run(');
 const cancelStart = production.indexOf('    pub async fn request_cancel(', runStart);
-const inspectStart = production.indexOf('    pub async fn inspect_dead_letter(', cancelStart);
-const requeueStart = production.indexOf('    pub async fn requeue_dead_letter(', inspectStart);
+const deadLetterStart = production.indexOf('    pub async fn inspect_dead_letter(', cancelStart);
+const driftStart = production.indexOf('    pub async fn inspect_drift_finding(', deadLetterStart);
+const requeueStart = production.indexOf('    pub async fn requeue_dead_letter(', driftStart);
 const runtimeEnd = production.indexOf('\n}\n\nimpl fmt::Debug', requeueStart);
+if ([runStart, cancelStart, deadLetterStart, driftStart, requeueStart, runtimeEnd].some((value) => value < 0)) {
+  fail(`${operatorPath} guarded method segments are incomplete`);
+}
 const run = production.slice(runStart, cancelStart);
-const cancel = production.slice(cancelStart, inspectStart);
-const inspect = production.slice(inspectStart, requeueStart);
+const cancel = production.slice(cancelStart, deadLetterStart);
+const deadLetter = production.slice(deadLetterStart, driftStart);
+const drift = production.slice(driftStart, requeueStart);
 const requeue = production.slice(requeueStart, runtimeEnd);
 if (run.indexOf('context.authorize_for(request.tenant_id())?;') < 0
     || run.indexOf('self.inner.run(request)') <= run.indexOf('context.authorize_for(request.tenant_id())?;')) {
@@ -77,7 +86,8 @@ if (run.indexOf('context.authorize_for(request.tenant_id())?;') < 0
 }
 for (const [name, body, marker] of [
   ['cancel', cancel, '.request_cancel(context.tenant_id(), job_id)'],
-  ['inspect', inspect, '.inspect(context.tenant_id(), job_id)'],
+  ['dead-letter inspection', deadLetter, '.inspect(context.tenant_id(), job_id)'],
+  ['drift-finding inspection', drift, '.inspect(context.tenant_id(), finding_id)'],
 ]) {
   const auth = body.indexOf('context.authorize_for(context.tenant_id())?;');
   const delegate = body.indexOf(marker);
@@ -94,6 +104,16 @@ if (auth < 0 || request <= auth || tenant <= request || actor <= tenant || deleg
   fail(`${operatorPath} requeue must authorize, bind tenant/actor, then delegate`);
 }
 
+const driftComposition = production.indexOf('let drift_findings =');
+const driftConstructor = production.indexOf('PostgresIndexDriftFindingInspector::new(db.clone())', driftComposition);
+const runnerComposition = production.indexOf('PostgresIndexReconciliationRunner::new(db, sources, schemas.shared())');
+const runtimeComposition = production.indexOf('IndexReconciliationOperatorRuntime::new(', runnerComposition);
+const driftArgument = production.indexOf('drift_findings,', runtimeComposition);
+if (driftComposition < 0 || driftConstructor <= driftComposition || runnerComposition <= driftConstructor
+    || runtimeComposition <= runnerComposition || driftArgument <= runtimeComposition) {
+  fail(`${operatorPath} must privately compose drift inspection before runtime publication`);
+}
+
 requireMarkers('crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs', [
   'register_postgres_index_reconciliation_work(extensions)?;',
 ]);
@@ -105,10 +125,12 @@ requireMarkers(docsPath, [
   'Status: `source_complete_transport_and_owner_execution_pending`.',
   'effective `Permission::MODULES_MANAGE`',
   'accept no caller-selected tenant',
-  'The same registry-freezing composition now also publishes',
+  '`inspect_drift_finding(context, finding_id)`',
+  'The same registry-freezing composition also publishes',
   'The operator runtime does not expose or own that scheduler',
   'existing generic server module-work bootstrap',
-  'automatic scheduling: manual authorized calls and host-scheduled calls converge',
+  'Drift inspection is read-only and is not scheduled.',
+  'only authorizes bounded inspection of findings that already exist',
   'maintainer-run',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
@@ -118,6 +140,7 @@ requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-server-reconciliation-guard.mjs'",
   "'verify-index-reconciliation-host-scheduler.mjs'",
+  "'verify-index-drift-finding-inspection.mjs'",
 ]);
 
 console.log('[verify-index-server-reconciliation-guard] OK');


### PR DESCRIPTION
## Summary

- extend the existing guarded `IndexReconciliationOperatorRuntime` with bounded open drift-finding inspection;
- compose `PostgresIndexDriftFindingInspector` beside the canonical reconciliation runner, dead-letter inspector, and audited recovery store;
- accept only the existing request-bound operator context and a finding UUID;
- derive tenant scope exclusively from `IndexReconciliationOperatorContext`;
- require effective request-scoped `modules:manage` before adapter validation or database access;
- return only the bounded crate inspection value or typed bounded errors;
- preserve existing run, cancellation, dead-letter inspection, requeue, scheduler, and fail-closed composition behavior;
- actualize server and drift-inspection documentation plus both focused static guards;
- add no transport, direct SQL, finding mutation, source comparison, repair execution, or scheduler behavior.

## Fresh-main audit

The final branch head was rebuilt directly on `main@ded2193759693aa13b9aaa4dad5379430eb640d7`.

Final pre-merge state:

- one clean commit;
- one commit ahead and zero behind `main`;
- five changed files;
- intervening Pages and Payment commits after #2948 touched no Index or reconciliation-server paths;
- no existing PR or branch implemented this exact request-bound drift-inspection composition.

## Guarded method

`inspect_drift_finding(context, finding_id)` accepts no tenant or actor parameter.

The method performs these operations in order:

1. calls the existing `context.authorize_for(context.tenant_id())` boundary;
2. resolves the exact request-scoped tenant/actor permission snapshot;
3. requires effective `Permission::MODULES_MANAGE`;
4. delegates to `PostgresIndexDriftFindingInspector::inspect(context.tenant_id(), finding_id)`.

Authorization occurs before nil-finding validation and before database access. Missing request authority and `modules:read` therefore fail before the crate adapter is reached.

## Bounded result

The server returns only `Option<IndexDriftFindingInspection>` from the merged crate contract:

- finding UUID and deterministic finding key;
- bounded check name;
- typed severity;
- typed global/schema/entity scope;
- optional expected and actual SHA-256 digests.

The runtime does not select, decode, copy, log, or return raw finding `details`, detection timestamps, closure state, tenant identity, SQL, database causes, source payloads, or mutation payloads.

## Composition

The existing replay composition remains the single source-freezing point. After immutable source/schema registry materialization, the guarded operator now privately contains:

- `PostgresIndexReconciliationRunner`;
- `PostgresIndexReconciliationDeadLetterInspector`;
- `PostgresIndexDriftFindingInspector`;
- `PostgresIndexReconciliationRecoveryStore`.

Missing sources still publish no false capability. Sources without the shared schema registry and duplicate materialization still fail closed. Composition performs no database I/O and starts no task.

## Source regression

The focused server test uses a database without Index migrations and proves ordering:

- no request authority plus nil finding returns `MissingRequestAuthority`;
- `modules:read` plus nil finding returns `Forbidden`;
- `modules:manage` plus nil finding reaches the crate adapter and returns typed `NilFindingId`.

## Ownership boundary

The server contains no direct SQL and does not duplicate persisted scope, identifier, locale, severity, or digest decoding. Those contracts remain owned by `PostgresIndexDriftFindingInspector` merged in #2948.

The existing reconciliation work registration and generic host scheduler remain unchanged. Drift inspection is read-only and is not scheduled.

## Scope boundaries

This PR does not add or claim:

- GraphQL, HTTP, CLI, MCP, native admin, or other command transport;
- source/index digest comparison or finding production;
- orphan diagnosis;
- finding resolution or ignore transitions;
- targeted source loads or mutation execution;
- targeted/full/shadow repair modes;
- repair advisory locking, concurrency fencing, or automatic finding closure;
- actor/reason repair audit records;
- before/after repair evidence;
- migrations or table-shape changes;
- retained PostgreSQL authorization, inspection, diagnosis, repair, or concurrency evidence.

The canonical roadmap item `Add drift diagnosis, targeted repair commands, and admitted repair evidence` remains open because this PR only authorizes bounded read-only inspection of findings that already exist.

## Validation

Not run per maintainer instruction:

- formatting;
- Cargo checks, tests, or Clippy;
- JavaScript verifiers;
- SQLite or PostgreSQL scenarios;
- workflows and CI.