### PR TITLE
test(pages): correlate publish cache refill

### DIFF
--- a/crates/rustok-pages/contracts/evidence/pages-publish-rollback-cache-correlation-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-publish-rollback-cache-correlation-source.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-08-03",
+  "status": "pages_publish_rollback_cache_correlation_source_unvalidated",
+  "scope": "Pages reviewed publish and immutable rollback NodePublished outbox to cache generation miss/refill correlation",
+  "source_contract": {
+    "reviewed_publish_emits_node_published_in_owner_transaction": true,
+    "reviewed_publish_receipt_inserted_before_commit": true,
+    "rollback_emits_node_published_in_owner_transaction": true,
+    "rollback_receipt_inserted_before_commit": true,
+    "publish_and_rollback_share_cache_event_contract": true,
+    "node_published_rotates_route_page_and_artifact_generations": true,
+    "handler_request_binds_event_id": true,
+    "handler_request_binds_correlation_id": true,
+    "handler_receipt_validated_before_ack": true,
+    "storefront_key_binds_route_page_and_artifact_generations": true,
+    "artifact_key_binds_artifact_generation": true,
+    "old_generation_values_remain_physical_but_unreachable_by_current_keys": true,
+    "new_generation_storefront_key_misses_before_refill": true,
+    "new_generation_artifact_key_misses_before_refill": true,
+    "storefront_refill_becomes_hit": true,
+    "artifact_refill_becomes_hit": true,
+    "reader_fail_open_behavior_changed": false,
+    "publish_behavior_changed": false,
+    "rollback_behavior_changed": false,
+    "public_transport_changed": false,
+    "database_schema_changed": false,
+    "ffa_promoted": false,
+    "fba_promoted": false
+  },
+  "source_regression": {
+    "path": "crates/rustok-pages/tests/publish_rollback_cache_correlation.rs",
+    "test": "published_event_rotates_generations_and_forces_storefront_and_artifact_miss_refill"
+  },
+  "linked_sources": {
+    "reviewed_publish": "crates/rustok-pages/src/services/page/reviewed_publish.rs",
+    "rollback": "crates/rustok-pages/src/services/page/rollback.rs",
+    "cache_owner": "crates/rustok-pages/src/cache_invalidation.rs",
+    "storefront_reader": "crates/rustok-pages/storefront/src/transport/native_server_adapter.rs",
+    "artifact_reader": "crates/rustok-pages/src/controllers/mod.rs"
+  },
+  "suggested_execution": [
+    "node crates/rustok-pages/scripts/verify/verify-pages-publish-rollback-cache-correlation.mjs",
+    "node crates/rustok-pages/scripts/verify/verify-pages-cache-invalidation.mjs",
+    "cargo test -p rustok-pages --test publish_rollback_cache_correlation -- --nocapture",
+    "cargo check -p rustok-pages --all-targets"
+  ],
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "database_run": false,
+    "storefront_run": false,
+    "artifact_http_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "runtime_proven": false
+  }
+}

--- a/crates/rustok-pages/scripts/verify/verify-pages-cache-invalidation.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-cache-invalidation.mjs
@@ -14,6 +14,7 @@ const pagesModule = read("crates/rustok-pages/src/lib.rs");
 const reviewedPublish = read(
   "crates/rustok-pages/src/services/page/reviewed_publish.rs",
 );
+const rollback = read("crates/rustok-pages/src/services/page/rollback.rs");
 const pagesControllers = read("crates/rustok-pages/src/controllers/mod.rs");
 const storefrontReader = read(
   "crates/rustok-pages/storefront/src/transport/native_server_adapter.rs",
@@ -22,6 +23,17 @@ const serverAdapter = read(
   "apps/server/src/services/pages_cache_invalidation.rs",
 );
 const dispatcher = read("apps/server/src/services/module_event_dispatcher.rs");
+const correlationEvidence = JSON.parse(
+  read(
+    "crates/rustok-pages/contracts/evidence/pages-publish-rollback-cache-correlation-source.json",
+  ),
+);
+const correlationRegression = read(
+  "crates/rustok-pages/tests/publish_rollback_cache_correlation.rs",
+);
+const correlationVerifier = read(
+  "crates/rustok-pages/scripts/verify/verify-pages-publish-rollback-cache-correlation.mjs",
+);
 
 function fail(message) {
   console.error(`[verify-pages-cache-invalidation] ${message}`);
@@ -97,13 +109,21 @@ for (const marker of [
   requireMarker(pagesModule, marker, "Pages module cache exports and listener registration");
 }
 
-for (const marker of [
-  "DomainEvent::NodePublished",
-  "insert_publish_operation_in_tx",
-  "txn.commit().await?",
-]) {
-  requireMarker(reviewedPublish, marker, "Pages reviewed publish outbox boundary");
-}
+const reviewedPublishOwner = sliceBetween(
+  reviewedPublish,
+  "pub async fn publish_reviewed(",
+  "fn require_builder_sources(",
+  "Pages reviewed publish owner transaction",
+);
+requireOrder(
+  reviewedPublishOwner,
+  [
+    "DomainEvent::NodePublished",
+    "insert_publish_operation_in_tx",
+    "txn.commit().await?",
+  ],
+  "Pages reviewed publish outbox receipt commit order",
+);
 for (const forbidden of [
   "CacheService",
   "namespace_generations",
@@ -111,9 +131,37 @@ for (const forbidden of [
   "PagesCacheReadRuntime",
 ]) {
   forbidMarker(
-    reviewedPublish,
+    reviewedPublishOwner,
     forbidden,
     "reviewed publish must remain event-driven instead of invalidating caches inline",
+  );
+}
+
+const rollbackOwner = sliceBetween(
+  rollback,
+  "pub async fn rollback_to_previous(",
+  "async fn find_previous_publish_target_in_tx(",
+  "Pages rollback owner transaction",
+);
+requireOrder(
+  rollbackOwner,
+  [
+    "DomainEvent::NodePublished",
+    "insert_rollback_operation_in_tx",
+    "txn.commit().await?",
+  ],
+  "Pages rollback outbox receipt commit order",
+);
+for (const forbidden of [
+  "CacheService",
+  "namespace_generations",
+  "page_cache_namespace",
+  "PagesCacheReadRuntime",
+]) {
+  forbidMarker(
+    rollbackOwner,
+    forbidden,
+    "rollback must remain event-driven instead of invalidating caches inline",
   );
 }
 
@@ -249,4 +297,49 @@ requireOrder(
   "Pages artifact authorization/cache/source order",
 );
 
-console.log("[verify-pages-cache-invalidation] PASS");
+if (
+  correlationEvidence.status !==
+    "pages_publish_rollback_cache_correlation_source_unvalidated" ||
+  !Array.isArray(correlationEvidence.execution) ||
+  correlationEvidence.execution.length !== 0 ||
+  correlationEvidence.validation?.tests_run !== false ||
+  correlationEvidence.validation?.verifiers_run !== false ||
+  correlationEvidence.validation?.runtime_proven !== false
+) {
+  fail("publish/rollback cache correlation evidence status is invalid");
+}
+for (const marker of [
+  "published_event_rotates_generations_and_forces_storefront_and_artifact_miss_refill",
+  "struct CorrelatingCachePort",
+  "handler.handle(&envelope).await.unwrap()",
+  "assert_eq!(requests[0].event_id, envelope.id)",
+  "assert_eq!(receipts[0].correlation_id, envelope.correlation_id)",
+  "assert_ne!(new_storefront_key, old_storefront_key)",
+  "assert_ne!(new_artifact_key, old_artifact_key)",
+  "put_json(new_storefront_key.clone(), &refilled_storefront)",
+  "put_json(new_artifact_key.clone(), &refilled_artifact)",
+]) {
+  requireMarker(
+    correlationRegression,
+    marker,
+    "Pages publish/rollback cache correlation regression",
+  );
+}
+for (const marker of [
+  "pages_publish_rollback_cache_correlation_source_unvalidated",
+  "reviewed publish event receipt commit ordering",
+  "rollback event receipt commit ordering",
+  "storefront generation miss source refill order",
+  "artifact generation miss source refill order",
+  "source_ready=true execution=pending",
+]) {
+  requireMarker(
+    correlationVerifier,
+    marker,
+    "Pages publish/rollback cache correlation verifier",
+  );
+}
+
+console.log(
+  "[verify-pages-cache-invalidation] PASS correlation_source_ready=true execution=pending",
+);

--- a/crates/rustok-pages/scripts/verify/verify-pages-publish-rollback-cache-correlation.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-publish-rollback-cache-correlation.mjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(__filename), "..", "..", "..", "..");
+const read = (relativePath) =>
+  fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+
+const evidence = JSON.parse(
+  read(
+    "crates/rustok-pages/contracts/evidence/pages-publish-rollback-cache-correlation-source.json",
+  ),
+);
+const regression = read(
+  "crates/rustok-pages/tests/publish_rollback_cache_correlation.rs",
+);
+const reviewedPublish = read(
+  "crates/rustok-pages/src/services/page/reviewed_publish.rs",
+);
+const rollback = read("crates/rustok-pages/src/services/page/rollback.rs");
+const cacheOwner = read("crates/rustok-pages/src/cache_invalidation.rs");
+const storefront = read(
+  "crates/rustok-pages/storefront/src/transport/native_server_adapter.rs",
+);
+const artifact = read("crates/rustok-pages/src/controllers/mod.rs");
+const parityPlan = read("docs/modules/pages-page-builder-parity-continuation-plan.md");
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const requireOrder = (content, values, label) => {
+  let previous = -1;
+  for (const value of values) {
+    const index = content.indexOf(value, previous + 1);
+    if (index < 0) {
+      failures.push(`${label}: missing or out of order ${value}`);
+      return;
+    }
+    previous = index;
+  }
+};
+const sliceBetween = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  if (startIndex < 0) {
+    failures.push(`${label}: missing ${start}`);
+    return "";
+  }
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (endIndex < 0) {
+    failures.push(`${label}: missing ${end}`);
+    return "";
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+if (
+  evidence.status !==
+  "pages_publish_rollback_cache_correlation_source_unvalidated"
+) {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push("executed evidence must remain empty");
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "database_run",
+  "storefront_run",
+  "artifact_http_run",
+  "workflow_checks_run",
+  "ci_run",
+  "runtime_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`validation.${key} must remain false`);
+  }
+}
+
+for (const [key, expected] of Object.entries({
+  reviewed_publish_emits_node_published_in_owner_transaction: true,
+  reviewed_publish_receipt_inserted_before_commit: true,
+  rollback_emits_node_published_in_owner_transaction: true,
+  rollback_receipt_inserted_before_commit: true,
+  publish_and_rollback_share_cache_event_contract: true,
+  node_published_rotates_route_page_and_artifact_generations: true,
+  handler_request_binds_event_id: true,
+  handler_request_binds_correlation_id: true,
+  handler_receipt_validated_before_ack: true,
+  storefront_key_binds_route_page_and_artifact_generations: true,
+  artifact_key_binds_artifact_generation: true,
+  old_generation_values_remain_physical_but_unreachable_by_current_keys: true,
+  new_generation_storefront_key_misses_before_refill: true,
+  new_generation_artifact_key_misses_before_refill: true,
+  storefront_refill_becomes_hit: true,
+  artifact_refill_becomes_hit: true,
+  reader_fail_open_behavior_changed: false,
+  publish_behavior_changed: false,
+  rollback_behavior_changed: false,
+  public_transport_changed: false,
+  database_schema_changed: false,
+  ffa_promoted: false,
+  fba_promoted: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`source_contract.${key} must be ${expected}`);
+  }
+}
+
+const publishBody = sliceBetween(
+  reviewedPublish,
+  "pub async fn publish_reviewed(",
+  "fn require_builder_sources(",
+  "reviewed publish owner transaction",
+);
+requireOrder(
+  publishBody,
+  [
+    "let txn = self.db.begin().await?;",
+    "DomainEvent::NodePublished",
+    "insert_publish_operation_in_tx(",
+    "txn.commit().await?;",
+  ],
+  "reviewed publish event receipt commit ordering",
+);
+for (const forbidden of [
+  "CacheService",
+  "PagesCacheReadRuntime",
+  "page_cache_namespace",
+]) {
+  forbidText(
+    publishBody,
+    forbidden,
+    "reviewed publish must remain event-driven",
+  );
+}
+
+const rollbackBody = sliceBetween(
+  rollback,
+  "pub async fn rollback_to_previous(",
+  "async fn find_previous_publish_target_in_tx(",
+  "rollback owner transaction",
+);
+requireOrder(
+  rollbackBody,
+  [
+    "let txn = self.db.begin().await?;",
+    "DomainEvent::NodePublished",
+    "insert_rollback_operation_in_tx(",
+    "txn.commit().await?;",
+  ],
+  "rollback event receipt commit ordering",
+);
+for (const forbidden of [
+  "CacheService",
+  "PagesCacheReadRuntime",
+  "page_cache_namespace",
+]) {
+  forbidText(rollbackBody, forbidden, "rollback must remain event-driven");
+}
+
+for (const [value, label] of [
+  ["Self::Published | Self::Unpublished | Self::Deleted => &PAGE_CACHE_SCOPES", "published scope set"],
+  ["PAGE_CACHE_SCOPES", "route page artifact scopes"],
+  ["envelope.id", "event identity binding"],
+  ["envelope.correlation_id", "correlation identity binding"],
+  ["receipt.validate_for(&request)?", "receipt validation"],
+  ["storefront_pages_cache_key", "storefront generation key"],
+  ['"rg-{}:pg-{}:ag-{}"', "three-generation storefront identity"],
+  ['":g-{generation}:page:{page_id}:{variant_hash}"', "generation-bound artifact identity"],
+]) {
+  requireText(cacheOwner, value, label);
+}
+
+requireOrder(
+  storefront,
+  [
+    "generation_snapshot(tenant_id)",
+    "storefront_pages_cache_key(",
+    "get_json::<StorefrontPagesData>",
+    "get_by_slug_with_locale_fallback(",
+    "put_json(cache_key, &data)",
+  ],
+  "storefront generation miss source refill order",
+);
+requireOrder(
+  artifact,
+  [
+    "generation_snapshot(tenant_id)",
+    "PageCacheScope::Artifact",
+    "get_json::<CachedPublishedLandingArtifact>",
+    "load_public_bound_artifact_with_fallback(",
+    "put_json(cache_key, &artifact)",
+  ],
+  "artifact generation miss source refill order",
+);
+
+for (const [value, label] of [
+  [
+    "async fn published_event_rotates_generations_and_forces_storefront_and_artifact_miss_refill()",
+    "correlation regression",
+  ],
+  ["struct CorrelatingCachePort", "shared invalidation and read port"],
+  ["state.requests.push(request.clone())", "request recording"],
+  ["state.receipts.push(receipt.clone())", "receipt recording"],
+  ["state.generations.generation(*scope) + 1", "generation rotation"],
+  ["DomainEvent::NodePublished", "published event"],
+  ["handler.handle(&envelope).await.unwrap()", "handler execution"],
+  ["assert_eq!(requests[0].event_id, envelope.id)", "event id assertion"],
+  [
+    "assert_eq!(requests[0].correlation_id, envelope.correlation_id)",
+    "request correlation assertion",
+  ],
+  ["assert_eq!(receipts[0].event_id, envelope.id)", "receipt event assertion"],
+  [
+    "assert_eq!(receipts[0].correlation_id, envelope.correlation_id)",
+    "receipt correlation assertion",
+  ],
+  ["assert_ne!(new_storefront_key, old_storefront_key)", "storefront key rotation"],
+  ["assert_ne!(new_artifact_key, old_artifact_key)", "artifact key rotation"],
+  ["get_json::<Value>(&new_storefront_key)", "storefront miss and hit"],
+  ["get_json::<Value>(&new_artifact_key)", "artifact miss and hit"],
+  ["put_json(new_storefront_key.clone(), &refilled_storefront)", "storefront refill"],
+  ["put_json(new_artifact_key.clone(), &refilled_artifact)", "artifact refill"],
+  ["get_json::<Value>(&old_storefront_key)", "old storefront value retained"],
+  ["get_json::<Value>(&old_artifact_key)", "old artifact value retained"],
+]) {
+  requireText(regression, value, label);
+}
+
+for (const marker of [
+  "Publish/rollback cache correlation source packet: ready, unvalidated",
+  "event/correlation-bound receipt",
+  "old generation keys remain physically present but unreachable",
+  "Execution remains pending",
+]) {
+  requireText(parityPlan, marker, "parity continuation plan");
+}
+
+if (failures.length > 0) {
+  console.error("[verify-pages-publish-rollback-cache-correlation] FAIL");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "[verify-pages-publish-rollback-cache-correlation] PASS source_ready=true execution=pending",
+);

--- a/crates/rustok-pages/tests/publish_rollback_cache_correlation.rs
+++ b/crates/rustok-pages/tests/publish_rollback_cache_correlation.rs
@@ -1,0 +1,260 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rustok_core::events::EventHandler;
+use rustok_events::{DomainEvent, EventEnvelope};
+use rustok_pages::{
+    PAGES_CACHE_ENTITY_KIND, PageCacheError, PageCacheGenerationSnapshot,
+    PageCacheInvalidationEventHandler, PageCacheInvalidationPort, PageCacheInvalidationReceipt,
+    PageCacheInvalidationRequest, PageCacheScope, PagesCacheInvalidationRuntime,
+    PagesCacheReadPort, PagesCacheReadRuntime, page_cache_key, storefront_pages_cache_key,
+};
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+#[derive(Default)]
+struct CorrelationState {
+    generations: PageCacheGenerationSnapshot,
+    values: HashMap<String, Vec<u8>>,
+    requests: Vec<PageCacheInvalidationRequest>,
+    receipts: Vec<PageCacheInvalidationReceipt>,
+}
+
+struct CorrelatingCachePort {
+    state: Mutex<CorrelationState>,
+}
+
+impl CorrelatingCachePort {
+    fn new(generations: PageCacheGenerationSnapshot) -> Self {
+        Self {
+            state: Mutex::new(CorrelationState {
+                generations,
+                ..CorrelationState::default()
+            }),
+        }
+    }
+
+    fn recorded(
+        &self,
+    ) -> (
+        PageCacheGenerationSnapshot,
+        Vec<PageCacheInvalidationRequest>,
+        Vec<PageCacheInvalidationReceipt>,
+    ) {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        (
+            state.generations,
+            state.requests.clone(),
+            state.receipts.clone(),
+        )
+    }
+}
+
+#[async_trait]
+impl PageCacheInvalidationPort for CorrelatingCachePort {
+    async fn invalidate(
+        &self,
+        request: PageCacheInvalidationRequest,
+    ) -> Result<PageCacheInvalidationReceipt, PageCacheError> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.requests.push(request.clone());
+
+        let mut receipt = PageCacheInvalidationReceipt::new(&request);
+        for scope in request.scopes() {
+            let next = state.generations.generation(*scope) + 1;
+            state.generations.record(*scope, next);
+            receipt.record(*scope, next);
+        }
+        state.receipts.push(receipt.clone());
+        Ok(receipt)
+    }
+}
+
+#[async_trait]
+impl PagesCacheReadPort for CorrelatingCachePort {
+    async fn generation_snapshot(
+        &self,
+        _tenant_id: Uuid,
+    ) -> Result<PageCacheGenerationSnapshot, PageCacheError> {
+        Ok(self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .generations)
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, PageCacheError> {
+        Ok(self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .values
+            .get(key)
+            .cloned())
+    }
+
+    async fn put(
+        &self,
+        key: String,
+        value: Vec<u8>,
+        _ttl: Duration,
+    ) -> Result<(), PageCacheError> {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .values
+            .insert(key, value);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn published_event_rotates_generations_and_forces_storefront_and_artifact_miss_refill() {
+    let tenant_id = Uuid::from_u128(11);
+    let page_id = Uuid::from_u128(22);
+    let before = PageCacheGenerationSnapshot::new(3, 5, 7);
+    let port = Arc::new(CorrelatingCachePort::new(before));
+    let invalidation_port: Arc<dyn PageCacheInvalidationPort> = port.clone();
+    let read_port: Arc<dyn PagesCacheReadPort> = port.clone();
+    let handler = PageCacheInvalidationEventHandler::new(PagesCacheInvalidationRuntime::new(
+        invalidation_port,
+    ));
+    let reads = PagesCacheReadRuntime::new(read_port);
+
+    let storefront_variant = "home|en|en|web";
+    let artifact_variant = "en|en|web";
+    let old_storefront_key =
+        storefront_pages_cache_key(tenant_id, before, storefront_variant).unwrap();
+    let old_artifact_key = page_cache_key(
+        PageCacheScope::Artifact,
+        tenant_id,
+        page_id,
+        before.artifact,
+        artifact_variant,
+    )
+    .unwrap();
+    let old_storefront = json!({"generation": "before", "reader": "storefront"});
+    let old_artifact = json!({"generation": "before", "reader": "artifact"});
+    reads
+        .put_json(old_storefront_key.clone(), &old_storefront)
+        .await
+        .unwrap();
+    reads
+        .put_json(old_artifact_key.clone(), &old_artifact)
+        .await
+        .unwrap();
+    assert_eq!(
+        reads
+            .get_json::<Value>(&old_storefront_key)
+            .await
+            .unwrap(),
+        Some(old_storefront.clone())
+    );
+    assert_eq!(
+        reads.get_json::<Value>(&old_artifact_key).await.unwrap(),
+        Some(old_artifact.clone())
+    );
+
+    let envelope = EventEnvelope::new(
+        tenant_id,
+        Some(Uuid::from_u128(33)),
+        DomainEvent::NodePublished {
+            node_id: page_id,
+            kind: PAGES_CACHE_ENTITY_KIND.to_string(),
+        },
+    );
+    handler.handle(&envelope).await.unwrap();
+
+    let after = reads.generation_snapshot(tenant_id).await.unwrap();
+    assert_eq!(after.route, before.route + 1);
+    assert_eq!(after.page, before.page + 1);
+    assert_eq!(after.artifact, before.artifact + 1);
+
+    let (recorded_generations, requests, receipts) = port.recorded();
+    assert_eq!(recorded_generations, after);
+    assert_eq!(requests.len(), 1);
+    assert_eq!(receipts.len(), 1);
+    assert_eq!(requests[0].tenant_id, tenant_id);
+    assert_eq!(requests[0].page_id, page_id);
+    assert_eq!(requests[0].event_id, envelope.id);
+    assert_eq!(requests[0].correlation_id, envelope.correlation_id);
+    assert_eq!(
+        requests[0].scopes(),
+        &[
+            PageCacheScope::Route,
+            PageCacheScope::Page,
+            PageCacheScope::Artifact,
+        ]
+    );
+    assert_eq!(receipts[0].event_id, envelope.id);
+    assert_eq!(receipts[0].correlation_id, envelope.correlation_id);
+    assert_eq!(receipts[0].route_generation, Some(after.route));
+    assert_eq!(receipts[0].page_generation, Some(after.page));
+    assert_eq!(receipts[0].artifact_generation, Some(after.artifact));
+
+    let new_storefront_key =
+        storefront_pages_cache_key(tenant_id, after, storefront_variant).unwrap();
+    let new_artifact_key = page_cache_key(
+        PageCacheScope::Artifact,
+        tenant_id,
+        page_id,
+        after.artifact,
+        artifact_variant,
+    )
+    .unwrap();
+    assert_ne!(new_storefront_key, old_storefront_key);
+    assert_ne!(new_artifact_key, old_artifact_key);
+    assert_eq!(
+        reads
+            .get_json::<Value>(&new_storefront_key)
+            .await
+            .unwrap(),
+        None
+    );
+    assert_eq!(
+        reads.get_json::<Value>(&new_artifact_key).await.unwrap(),
+        None
+    );
+
+    let refilled_storefront = json!({"generation": "after", "reader": "storefront"});
+    let refilled_artifact = json!({"generation": "after", "reader": "artifact"});
+    reads
+        .put_json(new_storefront_key.clone(), &refilled_storefront)
+        .await
+        .unwrap();
+    reads
+        .put_json(new_artifact_key.clone(), &refilled_artifact)
+        .await
+        .unwrap();
+    assert_eq!(
+        reads
+            .get_json::<Value>(&new_storefront_key)
+            .await
+            .unwrap(),
+        Some(refilled_storefront)
+    );
+    assert_eq!(
+        reads.get_json::<Value>(&new_artifact_key).await.unwrap(),
+        Some(refilled_artifact)
+    );
+
+    assert_eq!(
+        reads
+            .get_json::<Value>(&old_storefront_key)
+            .await
+            .unwrap(),
+        Some(old_storefront)
+    );
+    assert_eq!(
+        reads.get_json::<Value>(&old_artifact_key).await.unwrap(),
+        Some(old_artifact)
+    );
+}

--- a/docs/modules/pages-page-builder-parity-continuation-plan.md
+++ b/docs/modules/pages-page-builder-parity-continuation-plan.md
@@ -1,8 +1,8 @@
 # Pages / Page Builder Parity Continuation Plan
 
 Date: 2026-08-03
-Status: source-cutover-complete / published-surface-regression-ready / execution-evidence-pending
-Scope: `rustok-pages` admin FFA and `rustok-page-builder` consumer-property surface
+Status: source-cutover-complete / published-surface-regression-ready / cache-correlation-source-ready / execution-evidence-pending
+Scope: `rustok-pages` admin FFA and `rustok-page-builder` consumer-property and publication/cache boundaries
 
 ## Audit basis
 
@@ -12,10 +12,13 @@ This plan reconciles the current source with:
 - `crates/rustok-page-builder/docs/implementation-plan.md`;
 - `crates/rustok-page-builder/contracts/page-builder-consumer-properties.json`;
 - the Pages admin composition, rollback control and metadata owner port;
+- reviewed publish and immutable rollback owner transactions;
+- the Pages cache invalidation owner and generation-aware storefront/artifact readers;
 - the Page Builder consumer-property runtime and Leptos panel.
 
 The audit remains source-only. No verifier, formatter, Cargo command, browser
-scenario, database scenario, workflow or CI run is claimed by this update.
+scenario, database scenario, storefront request, artifact HTTP request, workflow or
+CI run is claimed by this update.
 
 ## Corrected parity snapshot
 
@@ -26,8 +29,8 @@ only for published pages, requires prepare/confirm, delegates to the typed rollb
 transport, consumes the typed result version and refreshes the workspace after a
 successful receipt.
 
-Accepted rollback, outbox, cache-generation and storefront refill packets remain
-open.
+Accepted rollback, outbox, cache-generation and storefront refill execution packets
+remain open.
 
 ### Typed metadata contribution: source-connected
 
@@ -116,7 +119,7 @@ Execution evidence remains pending.
 
 ### Published metadata source packet: ready, unvalidated
 
-The standalone published surface now uses one closed admission state:
+The standalone published surface uses one closed admission state:
 
 - a selected page whose status equals `published` case-insensitively admits the
   registered metadata panel;
@@ -139,7 +142,7 @@ The surface publishes a stable DOM contract for a future browser packet:
 The source and guard forbid a Pages builder facade, Page Builder host context, Fly
 builder, direct metadata patch call, document save or local runtime provisioning in
 the standalone surface. Persistence remains delegated to the existing metadata owner
-port, whose independent revision and dirty-Fly isolation packet is linked by the new
+port, whose independent revision and dirty-Fly isolation packet is linked by the
 evidence contract.
 
 Source evidence is recorded in:
@@ -151,13 +154,54 @@ Source evidence is recorded in:
 Browser execution remains pending. The DOM markers are selectors for a retained
 browser packet; they are not a claim that the browser scenario ran.
 
+### Publish/rollback cache correlation source packet: ready, unvalidated
+
+Reviewed publish and immutable rollback each write `NodeUpdated` and `NodePublished`
+through the owner transaction, then insert their durable operation receipt before the
+same transaction commits. Neither service calls cache infrastructure inline.
+
+The Pages cache handler maps the root `NodePublished` envelope to a request carrying
+the exact event and correlation identities. Published invalidation owns the route,
+page and artifact scopes, and the runtime validates an event/correlation-bound receipt
+with a positive generation for every requested scope before the handler acknowledges
+the event.
+
+The focused integration regression uses one shared implementation of
+`PageCacheInvalidationPort` and `PagesCacheReadPort`. It pre-fills old storefront and
+artifact keys, dispatches one `NodePublished` envelope through the real
+`PageCacheInvalidationEventHandler`, and records the exact request, receipt and new
+generation snapshot.
+
+The regression then proves:
+
+- route, page and artifact generations each advance once;
+- the request and handler receipt retain the exact envelope event and correlation ids;
+- the composite storefront key changes when the generation snapshot changes;
+- the artifact key changes when the artifact generation changes;
+- new current-generation keys miss before refill and hit after refill;
+- old generation keys remain physically present but unreachable through current key
+  construction.
+
+The production storefront reader still orders authorization, generation snapshot,
+cache lookup, owner source/artifact read and cache fill. Artifact HTTP delivery keeps
+the equivalent authorization, generation, lookup, verified owner artifact and fill
+order. Reader failures continue to fail open to owner source reads.
+
+Source evidence is recorded in:
+
+- `crates/rustok-pages/contracts/evidence/pages-publish-rollback-cache-correlation-source.json`;
+- `crates/rustok-pages/scripts/verify/verify-pages-publish-rollback-cache-correlation.mjs`;
+- `crates/rustok-pages/tests/publish_rollback_cache_correlation.rs`.
+
+Execution remains pending. No database transaction, durable outbox relay, real cache,
+storefront request or artifact HTTP request was executed by this update.
+
 ### Canonical plans: actualized to source parity
 
 The Pages and Page Builder canonical implementation plans mark the typed rollback
 control, registered metadata contribution, draft/published panel composition and
-legacy editor removal as source-complete. They list the focused conflict/isolation
-regressions as source-ready while keeping every executed packet, browser proof,
-workflow check and rollout gate open.
+legacy editor removal as source-complete. Their executed metadata, cache, browser,
+workflow and rollout packets remain open.
 
 ## Parity matrix
 
@@ -168,38 +212,39 @@ workflow check and rollout gate open.
 | Dirty Fly isolation during metadata save | Pages metadata port | Fly/Page Builder controller | Source-guarded | Isolation regression ready; execution pending |
 | Draft metadata panel inside Fly | Pages runtime/port | Leptos consumer panel | Connected | Pending browser execution |
 | Published metadata without Fly canvas | Pages shell composition | Standalone consumer panel | Admission and DOM source-guarded | Browser execution pending |
+| Publish/rollback outbox to generation rotation | Pages lifecycle/cache owners | No cache ownership | Correlation regression ready | Execution pending |
+| Storefront/artifact generation miss and refill | Pages readers | Immutable artifact provider | Source regression ready | Real reader packet pending |
 | Legacy metadata form | None | None | Removed | Not applicable |
-| Immutable artifact rollback action | Pages | No lifecycle ownership | Connected | Pending rollback/cache packet |
+| Immutable artifact rollback action | Pages | No lifecycle ownership | Connected | Source correlation ready; database packet pending |
 | Fly document mutation | Pages builder facade | Fly/Page Builder | Draft-only | Pending observed packet |
 | Published Fly authoring | Not allowed | Not mounted | Correctly blocked | Pending bundle/runtime proof |
 
 ## Changes in this slice
 
-1. Extract one deterministic published metadata surface admission policy.
-2. Add focused source regressions for published, uppercase published, draft,
-   archived, empty-status and missing-page states.
-3. Add stable DOM markers describing the registered panel, published-only admission,
-   absent Fly canvas, absent document authoring, reused runtime and owner-port
-   persistence.
-4. Add a machine-readable published-surface source evidence contract.
-5. Add a focused static verifier that links published admission to the existing
-   metadata revision/isolation evidence.
-6. Register the packet in the Page Builder consumer-properties machine contract and
-   the shared metadata source guard.
-7. Actualize this parity plan while keeping every execution claim open.
+1. Add one integration regression over the public Pages cache invalidation and read
+   contracts.
+2. Pre-fill generation-bound storefront and artifact values before a published event.
+3. Dispatch `NodePublished` through the real Pages cache handler and retain exact
+   event/correlation request and receipt identities.
+4. Prove all three published generations advance and produce new current keys.
+5. Prove current keys miss, refill and then hit while old generation values remain
+   physically present.
+6. Add a machine-readable source evidence contract and focused cross-file verifier.
+7. Source-lock reviewed publish and rollback as transactional `NodePublished`
+   producers with durable receipts before commit and no inline cache calls.
+8. Actualize this parity plan while keeping every execution claim open.
 
 ## Boundaries
 
 This slice does not:
 
-- change Pages metadata DTOs, GraphQL, HTTP or browser transport;
-- change the public `ConsumerPropertyEditorRuntime` contract;
-- add a second metadata runtime or owner port;
-- mount an editable Fly document for published pages;
+- change Pages publish, rollback, cache, storefront or artifact production behavior;
+- change database entities, migrations, DTOs, GraphQL, HTTP or browser transport;
+- add inline cache invalidation to publish or rollback;
+- delete old cache values, scan namespaces or introduce per-page generation state;
 - change Page Builder capability authorization, rollout policy or contribution
   assembly semantics;
-- alter publish, unpublish, rollback, artifact, cache or storefront behavior;
-- add a browser harness, Dioxus or mobile rendering;
+- run a database, outbox relay, cache backend, storefront or artifact HTTP scenario;
 - claim executed evidence or test results.
 
 ## Next cursor
@@ -208,8 +253,10 @@ This slice does not:
 2. Run and retain the published metadata browser packet using the stable DOM contract,
    proving the registered save advances only metadata version while the Fly canvas
    and document authoring remain absent.
-3. Retain publish/rollback cache packets correlating receipts, outbox events, handler
-   receipts, generation rotation and storefront/artifact misses and refills.
+3. Run the cache correlation source packet, then retain a database/outbox/cache packet
+   tying real publish and rollback operation receipts to durable `NodePublished`
+   envelopes, handler receipts, generation changes and real storefront/artifact
+   miss/refill observations.
 4. Complete compile, browser, workflow and rollout evidence before promoting FFA/FBA
    status beyond source-connected.
 
@@ -221,10 +268,14 @@ Suggested commands, intentionally not run in this slice:
 node crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-metadata-revision-isolation.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-published-metadata-surface.mjs
+node crates/rustok-pages/scripts/verify/verify-pages-cache-invalidation.mjs
+node crates/rustok-pages/scripts/verify/verify-pages-publish-rollback-cache-correlation.mjs
 cargo test -p rustok-pages-admin stale_metadata_revision_short_circuits_before_patch_transport
 cargo test -p rustok-pages-admin metadata_save_is_document_free_and_preserves_dirty_fly_state
 cargo test -p rustok-pages-admin published_page_admits_registered_metadata_surface
 cargo test -p rustok-pages-admin non_published_or_missing_page_hides_registered_metadata_surface
+cargo test -p rustok-pages --test publish_rollback_cache_correlation -- --nocapture
 cargo check -p rustok-page-builder-admin --all-targets
 cargo check -p rustok-pages-admin --all-targets
+cargo check -p rustok-pages --all-targets
 ```


### PR DESCRIPTION
## Summary

- continue the Pages/Page Builder parity cursor after PR #2950;
- add one integration regression over the public Pages cache invalidation and read contracts;
- pre-fill generation-bound storefront and artifact cache values;
- dispatch one `NodePublished` envelope through the real `PageCacheInvalidationEventHandler`;
- retain exact event/correlation request and receipt identities;
- prove route, page and artifact generations each advance;
- prove current-generation storefront and artifact keys miss, refill and then hit;
- prove old generation values remain physically present but are unreachable through current key construction;
- source-lock reviewed publish and immutable rollback as transactional `NodePublished` producers whose durable operation receipts are inserted before commit;
- add a machine-readable source packet, dedicated verifier, strengthened shared cache guard and updated parity plan.

## Ownership and behavior

No production behavior changes. Publish and rollback remain event-driven and do not call cache services inline. `PageCacheInvalidationEventHandler` remains the owner of event-to-generation invalidation, while storefront and artifact readers retain authorization → generation → lookup → owner source → fill ordering and fail open on cache failures.

The regression uses one shared fake implementation of `PageCacheInvalidationPort` and `PagesCacheReadPort`; it does not introduce a production cache implementation or change public contracts.

## Source evidence state

- reviewed publish and rollback `NodePublished` transaction ordering: source-guarded;
- event/correlation-bound handler receipt: source-regression-ready;
- route/page/artifact generation rotation: source-regression-ready;
- storefront/artifact miss → refill → hit: source-regression-ready;
- real database/outbox/cache/storefront/artifact HTTP execution: pending;
- FFA/FBA status: not promoted.

## Validation

Tests, Node verifiers, formatting, Cargo checks, database scenarios, storefront requests, artifact HTTP requests, workflows and CI were intentionally not run, per maintainer request.

Suggested maintainer commands:

```bash
node crates/rustok-pages/scripts/verify/verify-pages-cache-invalidation.mjs
node crates/rustok-pages/scripts/verify/verify-pages-publish-rollback-cache-correlation.mjs
cargo test -p rustok-pages --test publish_rollback_cache_correlation -- --nocapture
cargo check -p rustok-pages --all-targets
```

The PR branch is one atomic commit ahead and zero behind `main`.