### PR TITLE
fix(payment): bound collection tenant diagnostics

### DIFF
--- a/crates/rustok-payment/contracts/evidence/payment-collection-tenant-diagnostic-safety-source.json
+++ b/crates/rustok-payment/contracts/evidence/payment-collection-tenant-diagnostic-safety-source.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-08-03",
+  "status": "payment_collection_tenant_diagnostic_safety_source_unvalidated",
+  "scope": "PaymentCollectionPort tenant UUID parse-failure diagnostics only",
+  "source_contract": {
+    "tenant_parser_bounded": true,
+    "complete_parse_error_logged": false,
+    "constructed_port_error_logged": false,
+    "tenant_internal_message_text_logged": false,
+    "tenant_context_shape_only": true,
+    "tenant_correlation_preserved": true,
+    "tenant_owner_operations_preserved": true,
+    "tenant_validation_phase_preserved": true,
+    "tenant_error_kind_closed": true,
+    "tenant_warning_severity_preserved": true,
+    "same_validation_port_error_returned": true,
+    "tenant_parser_call_sites_preserved": true,
+    "admission_mapper_changed": false,
+    "canonical_payment_error_mapper_cleanup_out_of_scope": true,
+    "execution_behavior_changed": false,
+    "public_port_error_changed": false,
+    "ffa_promoted": false,
+    "fba_promoted": false
+  },
+  "suggested_execution": [
+    "node scripts/verify/verify-payment-collection-tenant-context.mjs",
+    "node scripts/verify/verify-payment-collection-admission-context.mjs",
+    "node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs",
+    "cargo check -p rustok-payment --lib"
+  ],
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "runtime_proven": false
+  }
+}

--- a/crates/rustok-payment/docs/payment-collection-admission-context.md
+++ b/crates/rustok-payment/docs/payment-collection-admission-context.md
@@ -83,7 +83,7 @@ This slice does not change:
 - read/write policy selection;
 - write-semantics requirements;
 - admission-before-tenant-parsing ordering;
-- tenant UUID parsing or its validation envelope;
+- tenant UUID validation envelope;
 - reusable collection lookup, create, or race-adoption behavior;
 - collection status reads or snapshot conversion;
 - `PaymentError` variant mapping;
@@ -117,13 +117,25 @@ Source evidence is recorded in:
 
 The evidence remains source-only: `execution` is empty and every validation flag is false.
 
-## Remaining diagnostic boundaries
+## Related tenant contract
 
-Tenant UUID parsing and canonical `PaymentError` mapping remain separate cleanup slices. The
-current tenant parser still records its complete parse cause, constructed `PortError`, raw
-context, message text, and Debug kind. The canonical mapper still contains raw validation,
-lifecycle, provider, identifier, database, and tenant diagnostics; some not-found public
-envelopes also still interpolate internal UUIDs.
+Tenant UUID parsing is now closed by a separate source-only contract:
+
+- verifier: `scripts/verify/verify-payment-collection-tenant-context.mjs`;
+- evidence:
+  `crates/rustok-payment/contracts/evidence/payment-collection-tenant-diagnostic-safety-source.json`;
+- documentation: `crates/rustok-payment/docs/payment-collection-tenant-context.md`.
+
+That contract replaces the complete parse error, complete constructed `PortError`, raw delegated
+context, internal message text, and Debug kind output with type/shape-only facts while preserving
+the same parser call sites and validation envelope. It does not change the admission mapper
+covered here.
+
+## Remaining diagnostic boundary
+
+Canonical `payment_error_to_port_error` remains the next open collection boundary. It still
+contains raw validation and transition text, provider identifiers and operations, database errors,
+raw tenant values, and public not-found messages that interpolate owner UUIDs.
 
 Compile, runtime, replay, restart, remote-port parity, workflows, CI, and production evidence
 remain open. The broad ecommerce correlation-safe mapper cleanup remains open, and no FFA/FBA

--- a/crates/rustok-payment/docs/payment-collection-tenant-context.md
+++ b/crates/rustok-payment/docs/payment-collection-tenant-context.md
@@ -1,114 +1,124 @@
-# Payment collection tenant validation owner context
+# Payment collection tenant diagnostic safety
 
 Status: **source-ready / unvalidated**
 
 ## Scope
 
-This source slice closes the owner-side structured-context gap for invalid tenant
-identity in `PaymentCollectionPort`:
+This bounded source slice hardens only invalid tenant UUID diagnostics in
+`PaymentCollectionPort`:
 
-- `create_or_reuse_collection` tenant UUID validation;
-- `read_collection_status` tenant UUID validation.
+- `create_or_reuse_collection` tenant parsing;
+- `read_collection_status` tenant parsing.
 
-Both public operations already selected a canonical owner operation and completed
-policy admission before parsing `PortContext.tenant_id`. Before this slice, tenant
-parsing returned `payment.tenant_id_invalid` directly from a context-free closure.
-The original validation envelope was stable, but the payment owner did not record
-the available correlation, actor, channel, locale, deadline, exact owner operation,
-or the UUID parse cause.
+Both public operations continue to select their canonical owner operation and complete admission
+before invoking `parse_port_tenant_id`.
 
-This slice is deliberately limited to tenant UUID validation. Payment collection
-admission diagnostics were closed by the preceding slice. Request validation,
-provider execution, collection lifecycle mapping, checkout consumers,
-compensation consumers, and transport adapters remain separate concerns.
+## Preserved parser flow
 
-## Delivered source contract
+The payment-owned parser still:
 
-Both public owner operations now pass their already-selected canonical operation
-to the tenant parser:
+1. calls `Uuid::parse_str(&context.tenant_id)`;
+2. enters the same `map_err` path on parse failure;
+3. constructs the exact same validation `PortError`;
+4. emits one warning diagnostic;
+5. returns that same constructed validation `PortError`.
 
-- `create_or_reuse_collection` passes `create_or_reuse_collection`;
-- `read_collection_status` passes `read_collection_status`.
+The validation envelope remains:
 
-The payment-owned tenant parser now:
+- kind: validation;
+- code: `payment.tenant_id_invalid`;
+- message: `PortContext.tenant_id must be a UUID for payment ports`;
+- retryability: unchanged.
 
-1. parses the existing `PortContext.tenant_id` as a UUID;
-2. constructs the same validation `PortError` on failure;
-3. records the UUID parse cause and complete available owner context;
-4. returns that same validation error after diagnostics.
+The same constructed validation `PortError` is returned after diagnostics. No replacement error is
+constructed after the warning event.
 
-Tenant validation diagnostics record:
+## Bounded diagnostic policy
 
+Tenant diagnostics retain only the parse-error type and bounded context/message-shape facts.
+
+The parser records:
+
+- concrete parse-error type through `type_name_of_val`;
+- explicit `tenant_id_parse_failed = true`;
 - truthful owner `rustok_payment`;
 - exact owner operation;
 - validation phase `tenant_id`;
-- correlation id and tenant id;
-- actor, channel, and locale;
-- causation id and traceparent when available;
-- idempotency key and deadline when available;
-- original validation code, message, typed kind, and retryability;
-- internal UUID parse cause;
-- boundary `payment_collection_port`.
+- boundary `payment_collection_port`;
+- correlation id;
+- tenant-id and actor-id character lengths;
+- closed actor-kind label;
+- claim and role counts;
+- channel presence and optional character length;
+- locale character length;
+- causation-id, traceparent, and idempotency-key presence plus optional character lengths;
+- optional deadline milliseconds;
+- stable validation code and retryability;
+- internal-message presence and character length;
+- closed error-kind label `validation`.
 
-Invalid tenant identity is a caller/context validation rejection and therefore uses
-warning severity.
+The parser does not record:
+
+- the complete UUID parse error;
+- the complete constructed `PortError`;
+- raw tenant, actor, channel, locale, causation, traceparent, or idempotency values;
+- human-readable internal message text;
+- Debug `PortErrorKind` output.
 
 ## Preserved behavior
 
 This slice does not change:
 
 - public `PaymentCollectionPort` trait signatures;
-- write-policy or write-semantics admission;
-- read-policy admission;
-- admission ordering before tenant parsing;
-- tenant validation code `payment.tenant_id_invalid`;
-- tenant validation message
-  `PortContext.tenant_id must be a UUID for payment ports`;
-- validation kind or retryability;
-- reusable collection lookup by cart;
-- create-after-read behavior;
-- race adoption after a create error;
-- granular owner operation labels for existing lookup, race adoption, and
-  collection creation errors;
-- status collection identity or status snapshot mapping;
-- payment validation, not-found, lifecycle, provider, reconciliation,
-  configuration, or database `PortError` codes and public messages;
-- provider ids or provider operation diagnostics;
-- checkout payment execution or compensation consumer behavior;
-- FBA, FFA, or ecommerce audit status.
+- create/reuse or status DTOs;
+- canonical owner-operation selection;
+- read/write admission or write-semantics behavior;
+- admission-before-tenant ordering;
+- the two operation-aware parser call sites;
+- reusable collection lookup, create, or race-adoption behavior;
+- collection status reads or snapshot conversion;
+- the admission diagnostic mapper closed by the preceding source slice;
+- canonical `PaymentError` variant mapping;
+- provider, lifecycle, reconciliation, configuration, or database public envelopes;
+- checkout execution or compensation consumers;
+- Commerce orchestration;
+- ecommerce audit, Payment FFA, or Payment FBA status.
 
 ## Static evidence
 
-`scripts/verify/verify-payment-collection-tenant-context.mjs` guards:
+The focused guard is:
 
-- two operation-aware tenant parser callsites;
+- `scripts/verify/verify-payment-collection-tenant-context.mjs`.
+
+It requires:
+
+- exactly two operation-aware parser call sites;
 - operation selection and admission before tenant parsing;
-- tenant parsing before owner storage/service work;
-- stable tenant validation code, message, kind, and retryability;
-- UUID parse cause plus complete available `PortContext` fields;
-- truthful payment owner, exact operation, validation phase, and boundary;
-- diagnostics before returning the validation error;
-- unchanged admission helpers;
-- unchanged reusable lookup, race adoption, status projection, provider,
-  reconciliation, and storage envelopes;
-- absence of the old operation-free and silent parser paths.
+- tenant parsing before owner storage or service work;
+- exact validation code, message, kind, and retryability;
+- type-only parse cause and explicit parse-failure fact;
+- bounded context and message-shape facts;
+- one warning path followed by return of the same constructed error;
+- unchanged admission helpers and collection flow;
+- explicit preservation of the canonical Payment mapper as a separate open boundary;
+- absence of complete parse errors, complete `PortError`, raw context, message text, and Debug kind
+  output inside the covered parser.
 
-The preceding
-`scripts/verify/verify-payment-collection-admission-context.mjs` is synchronized
-to the operation-aware parser signature while preserving all admission assertions.
+Source evidence is recorded in:
 
-## Remaining gaps
+- `crates/rustok-payment/contracts/evidence/payment-collection-tenant-diagnostic-safety-source.json`.
 
-The master ecommerce correlation-safe mapper task remains open for:
+The evidence remains source-only: `execution` is empty and every validation flag is false.
 
-- remaining payment execution and compensation consumers;
-- storefront customer read consumers;
-- remaining order, fulfillment, inventory, customer, tax, and promotion
-  adapters;
-- non-`PortError` public envelopes;
-- compile, runtime, replay, restart, remote-port, and cross-transport evidence.
+## Remaining diagnostic boundary
 
-No architecture status is promoted from source-only evidence.
+Canonical `payment_error_to_port_error` remains the next separate cleanup slice. It still contains
+raw validation and transition text, provider identifiers and operations, database errors, raw
+tenant values, and public not-found messages that interpolate owner UUIDs.
+
+Compile, runtime, replay, restart, remote-port parity, workflows, CI, and production evidence
+remain open. The broad ecommerce correlation-safe mapper cleanup remains open, and no FFA/FBA
+status is promoted.
 
 ## Suggested maintainer checks
 

--- a/crates/rustok-payment/src/ports.rs
+++ b/crates/rustok-payment/src/ports.rs
@@ -304,24 +304,64 @@ fn parse_port_tenant_id(
             "payment.tenant_id_invalid",
             "PortContext.tenant_id must be a UUID for payment ports",
         );
+        let parse_error_type = std::any::type_name_of_val(&parse_error);
+        let actor_kind = match &context.actor.kind {
+            rustok_api::PortActorKind::User => "user",
+            rustok_api::PortActorKind::Service => "service",
+            rustok_api::PortActorKind::System => "system",
+        };
+        let tenant_id_length = context.tenant_id.chars().count();
+        let actor_id_length = context.actor.id.chars().count();
+        let claim_count = context.claims.len();
+        let role_count = context.roles.len();
+        let channel_present = context.channel.is_some();
+        let channel_length = context.channel.as_ref().map(|value| value.chars().count());
+        let locale_length = context.locale.chars().count();
+        let causation_id_present = context.causation_id.is_some();
+        let causation_id_length = context
+            .causation_id
+            .as_ref()
+            .map(|value| value.chars().count());
+        let traceparent_present = context.traceparent.is_some();
+        let traceparent_length = context
+            .traceparent
+            .as_ref()
+            .map(|value| value.chars().count());
+        let idempotency_key_present = context.idempotency_key.is_some();
+        let idempotency_key_length = context
+            .idempotency_key
+            .as_ref()
+            .map(|value| value.chars().count());
+        let internal_message_present = !error.message.trim().is_empty();
+        let internal_message_length = error.message.chars().count();
+        let error_kind = "validation";
+
         tracing::warn!(
-            parse_error = ?parse_error,
-            error = ?error,
+            parse_error_type,
+            tenant_id_parse_failed = true,
             owner = PAYMENT_COLLECTION_OWNER,
             correlation_id = %context.correlation_id,
-            tenant_id = %context.tenant_id,
-            actor = ?context.actor,
-            channel = ?context.channel,
-            locale = %context.locale,
-            causation_id = ?context.causation_id,
-            traceparent = ?context.traceparent,
-            idempotency_key = ?context.idempotency_key,
+            tenant_id_length,
+            actor_kind,
+            actor_id_length,
+            claim_count,
+            role_count,
+            channel_present,
+            channel_length = ?channel_length,
+            locale_length,
+            causation_id_present,
+            causation_id_length = ?causation_id_length,
+            traceparent_present,
+            traceparent_length = ?traceparent_length,
+            idempotency_key_present,
+            idempotency_key_length = ?idempotency_key_length,
             deadline_ms = ?context.deadline_ms,
             operation = owner_operation,
             validation = "tenant_id",
             code = %error.code,
-            internal_message = %error.message,
-            error_kind = ?error.kind,
+            internal_message_present,
+            internal_message_length,
+            error_kind,
             retryable = error.retryable,
             boundary = PAYMENT_COLLECTION_PORT_BOUNDARY,
             "payment collection tenant context was rejected"

--- a/scripts/verify/verify-payment-collection-admission-context.mjs
+++ b/scripts/verify/verify-payment-collection-admission-context.mjs
@@ -10,9 +10,14 @@ const root = configuredRoot
   : new URL('../../', import.meta.url);
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
 const source = read('crates/rustok-payment/src/ports.rs');
-const evidence = JSON.parse(
+const admissionEvidence = JSON.parse(
   read(
     'crates/rustok-payment/contracts/evidence/payment-collection-admission-diagnostic-safety-source.json',
+  ),
+);
+const tenantEvidence = JSON.parse(
+  read(
+    'crates/rustok-payment/contracts/evidence/payment-collection-tenant-diagnostic-safety-source.json',
   ),
 );
 const doc = read('crates/rustok-payment/docs/payment-collection-admission-context.md');
@@ -71,7 +76,9 @@ const tenantParser = between(
   'fn payment_error_to_port_error(',
   'tenant parser',
 );
-const ownerMapper = source.slice(source.indexOf('fn payment_error_to_port_error('));
+const ownerMapperStart = source.indexOf('fn payment_error_to_port_error(');
+if (ownerMapperStart < 0) failures.push('payment owner mapper: unable to isolate source block');
+const ownerMapper = ownerMapperStart >= 0 ? source.slice(ownerMapperStart) : '';
 
 for (const [value, label] of [
   ['const PAYMENT_COLLECTION_PORT_BOUNDARY: &str = "payment_collection_port";', 'stable boundary identity'],
@@ -157,14 +164,10 @@ for (const [value, label] of [
   ['let claim_count = context.claims.len();', 'claim count'],
   ['let role_count = context.roles.len();', 'role count'],
   ['let channel_present = context.channel.is_some();', 'channel presence'],
-  ['let channel_length = context.channel.as_ref()', 'channel length'],
   ['let locale_length = context.locale.chars().count();', 'locale length'],
   ['let causation_id_present = context.causation_id.is_some();', 'causation presence'],
-  ['let causation_id_length = context', 'causation length'],
   ['let traceparent_present = context.traceparent.is_some();', 'trace presence'],
-  ['let traceparent_length = context', 'trace length'],
   ['let idempotency_key_present = context.idempotency_key.is_some();', 'idempotency presence'],
-  ['let idempotency_key_length = context', 'idempotency length'],
   ['let internal_message_present = !error.message.trim().is_empty();', 'message presence'],
   ['let internal_message_length = error.message.chars().count();', 'message length'],
   ['owner = PAYMENT_COLLECTION_OWNER', 'truthful owner field'],
@@ -230,33 +233,40 @@ for (const [pattern, expected, label] of [
   if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
 }
 
-for (const [content, values, label] of [
-  [
-    tenantParser,
-    [
-      'Uuid::parse_str(&context.tenant_id).map_err(|parse_error| {',
-      'parse_error = ?parse_error',
-      'error = ?error',
-      'validation = "tenant_id"',
-      '"payment.tenant_id_invalid"',
-    ],
-    'tenant parser remains separate',
-  ],
-  [
-    ownerMapper,
-    [
-      'fn payment_error_to_port_error(',
-      'cause = %message',
-      'provider_id = %provider_id',
-      'error = ?error',
-      '"payment request is invalid"',
-      '"payment storage is temporarily unavailable"',
-    ],
-    'canonical payment mapper remains separate',
-  ],
-]) {
-  for (const value of values) requireText(content, value, label);
-}
+for (const [value, label] of [
+  ['Uuid::parse_str(&context.tenant_id).map_err(|parse_error| {', 'tenant parser routing'],
+  ['let parse_error_type = std::any::type_name_of_val(&parse_error);', 'tenant type-only parse cause'],
+  ['tenant_id_parse_failed = true', 'tenant parse-failure fact'],
+  ['tenant_id_length', 'tenant shape fact'],
+  ['actor_kind', 'tenant actor-kind fact'],
+  ['internal_message_present', 'tenant message presence'],
+  ['internal_message_length', 'tenant message length'],
+  ['let error_kind = "validation";', 'tenant closed validation kind'],
+  ['validation = "tenant_id"', 'tenant validation phase'],
+  ['"payment.tenant_id_invalid"', 'tenant stable code'],
+]) requireText(tenantParser, value, label);
+for (const value of [
+  'parse_error = ?parse_error',
+  'error = ?error',
+  'tenant_id = %context.tenant_id',
+  'actor = ?context.actor',
+  'channel = ?context.channel',
+  'locale = %context.locale',
+  'causation_id = ?context.causation_id',
+  'traceparent = ?context.traceparent',
+  'idempotency_key = ?context.idempotency_key',
+  'internal_message = %error.message',
+  'error_kind = ?error.kind',
+]) forbidText(tenantParser, value, 'unsafe tenant parser payload after separate cleanup');
+
+for (const [value, label] of [
+  ['fn payment_error_to_port_error(', 'canonical mapper remains separate'],
+  ['cause = %message', 'canonical validation payload remains open'],
+  ['provider_id = %provider_id', 'canonical provider payload remains open'],
+  ['error = ?error', 'canonical database payload remains open'],
+  ['"payment request is invalid"', 'stable validation envelope'],
+  ['"payment storage is temporarily unavailable"', 'stable storage envelope'],
+]) requireText(ownerMapper, value, label);
 
 for (const [value, label] of [
   ['"create_or_reuse_collection.read_existing"', 'existing collection read mapping'],
@@ -271,8 +281,11 @@ for (const [value, label] of [
   ['PaymentCollectionStatusSnapshot::from_response(&response)', 'status snapshot mapping'],
 ]) requireText(readBlock, value, label);
 
-if (evidence.status !== 'payment_collection_admission_diagnostic_safety_source_unvalidated') {
-  failures.push(`evidence status mismatch: ${evidence.status}`);
+if (
+  admissionEvidence.status !==
+  'payment_collection_admission_diagnostic_safety_source_unvalidated'
+) {
+  failures.push(`admission evidence status mismatch: ${admissionEvidence.status}`);
 }
 for (const [key, expected] of Object.entries({
   admission_mapper_bounded: true,
@@ -293,24 +306,51 @@ for (const [key, expected] of Object.entries({
   ffa_promoted: false,
   fba_promoted: false,
 })) {
-  if (evidence.source_contract?.[key] !== expected) {
-    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  if (admissionEvidence.source_contract?.[key] !== expected) {
+    failures.push(`admission evidence source_contract.${key} must be ${expected}`);
   }
 }
-if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
-  failures.push('evidence execution must remain empty');
+if (
+  tenantEvidence.status !==
+  'payment_collection_tenant_diagnostic_safety_source_unvalidated'
+) {
+  failures.push(`tenant evidence status mismatch: ${tenantEvidence.status}`);
 }
-for (const key of [
-  'tests_run',
-  'cargo_run',
-  'format_run',
-  'verifiers_run',
-  'workflow_checks_run',
-  'ci_run',
-  'runtime_proven',
+for (const [key, expected] of Object.entries({
+  tenant_parser_bounded: true,
+  complete_parse_error_logged: false,
+  constructed_port_error_logged: false,
+  tenant_internal_message_text_logged: false,
+  tenant_context_shape_only: true,
+  same_validation_port_error_returned: true,
+  admission_mapper_changed: false,
+  canonical_payment_error_mapper_cleanup_out_of_scope: true,
+  ffa_promoted: false,
+  fba_promoted: false,
+})) {
+  if (tenantEvidence.source_contract?.[key] !== expected) {
+    failures.push(`tenant evidence source_contract.${key} must be ${expected}`);
+  }
+}
+for (const [label, evidence] of [
+  ['admission', admissionEvidence],
+  ['tenant', tenantEvidence],
 ]) {
-  if (evidence.validation?.[key] !== false) {
-    failures.push(`evidence validation.${key} must remain false`);
+  if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+    failures.push(`${label} evidence execution must remain empty`);
+  }
+  for (const key of [
+    'tests_run',
+    'cargo_run',
+    'format_run',
+    'verifiers_run',
+    'workflow_checks_run',
+    'ci_run',
+    'runtime_proven',
+  ]) {
+    if (evidence.validation?.[key] !== false) {
+      failures.push(`${label} evidence validation.${key} must remain false`);
+    }
   }
 }
 
@@ -318,7 +358,8 @@ for (const [value, label] of [
   ['Status: **source-ready / unvalidated**', 'documentation status'],
   ['Admission diagnostics retain only bounded context and message-shape facts', 'documentation bounded policy'],
   ['The exact original admission `PortError` continues through `inspect_err` unchanged', 'documentation pass-through policy'],
-  ['Tenant UUID parsing and canonical `PaymentError` mapping remain separate cleanup slices', 'documentation residual boundary'],
+  ['Tenant UUID parsing is now closed by a separate source-only contract', 'documentation tenant current state'],
+  ['Canonical `payment_error_to_port_error` remains the next open collection boundary', 'documentation residual boundary'],
 ]) requireText(doc, value, label);
 
 if (failures.length > 0) {
@@ -328,5 +369,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Payment collection admission diagnostics use bounded kind, message-shape, and context-shape facts while preserving admission ordering and original-error pass-through',
+  '✔ Payment collection admission diagnostics remain bounded while the separate tenant parser contract is also bounded; canonical PaymentError mapping remains open',
 );

--- a/scripts/verify/verify-payment-collection-tenant-context.mjs
+++ b/scripts/verify/verify-payment-collection-tenant-context.mjs
@@ -8,10 +8,14 @@ const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
 const root = configuredRoot
   ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
   : new URL('../../', import.meta.url);
-const source = readFileSync(
-  new URL('crates/rustok-payment/src/ports.rs', root),
-  'utf8',
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const source = read('crates/rustok-payment/src/ports.rs');
+const evidence = JSON.parse(
+  read(
+    'crates/rustok-payment/contracts/evidence/payment-collection-tenant-diagnostic-safety-source.json',
+  ),
 );
+const doc = read('crates/rustok-payment/docs/payment-collection-tenant-context.md');
 const failures = [];
 
 const requireText = (content, value, label) => {
@@ -20,6 +24,7 @@ const requireText = (content, value, label) => {
 const forbidText = (content, value, label) => {
   if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
 };
+const countText = (content, value) => content.split(value).length - 1;
 const between = (content, start, end, label) => {
   const startIndex = content.indexOf(start);
   const endIndex = content.indexOf(end, startIndex + start.length);
@@ -104,39 +109,77 @@ if (parserCalls.length !== 2) {
 for (const [value, label] of [
   ['context: &PortContext', 'retained context input'],
   ["owner_operation: &'static str", 'exact owner operation input'],
-  ['Uuid::parse_str(&context.tenant_id)', 'tenant UUID parsing'],
-  ['map_err(|parse_error|', 'parse failure mapping'],
+  ['Uuid::parse_str(&context.tenant_id).map_err(|parse_error| {', 'tenant UUID parsing and mapping'],
   ['let error = PortError::validation(', 'stable validation construction'],
   ['"payment.tenant_id_invalid"', 'stable validation code'],
   ['"PortContext.tenant_id must be a UUID for payment ports"', 'stable validation message'],
-  ['parse_error = ?parse_error', 'internal parse cause'],
-  ['error = ?error', 'mapped public error'],
+  ['let parse_error_type = std::any::type_name_of_val(&parse_error);', 'type-only parse cause'],
+  ['tenant_id_parse_failed = true', 'explicit parse-failure fact'],
+  ['let actor_kind = match &context.actor.kind', 'closed actor kind'],
+  ['let tenant_id_length = context.tenant_id.chars().count();', 'tenant identity shape'],
+  ['let actor_id_length = context.actor.id.chars().count();', 'actor identity shape'],
+  ['let claim_count = context.claims.len();', 'claim count'],
+  ['let role_count = context.roles.len();', 'role count'],
+  ['let channel_present = context.channel.is_some();', 'channel presence'],
+  ['let channel_length = context.channel.as_ref()', 'channel length'],
+  ['let locale_length = context.locale.chars().count();', 'locale length'],
+  ['let causation_id_present = context.causation_id.is_some();', 'causation presence'],
+  ['let causation_id_length = context', 'causation length'],
+  ['let traceparent_present = context.traceparent.is_some();', 'trace presence'],
+  ['let traceparent_length = context', 'trace length'],
+  ['let idempotency_key_present = context.idempotency_key.is_some();', 'idempotency presence'],
+  ['let idempotency_key_length = context', 'idempotency length'],
+  ['let internal_message_present = !error.message.trim().is_empty();', 'message presence'],
+  ['let internal_message_length = error.message.chars().count();', 'message length'],
+  ['let error_kind = "validation";', 'closed validation kind'],
   ['owner = PAYMENT_COLLECTION_OWNER', 'truthful owner field'],
   ['correlation_id = %context.correlation_id', 'correlation context'],
-  ['tenant_id = %context.tenant_id', 'tenant context'],
-  ['actor = ?context.actor', 'actor context'],
-  ['channel = ?context.channel', 'channel context'],
-  ['locale = %context.locale', 'locale context'],
-  ['causation_id = ?context.causation_id', 'causation context'],
-  ['traceparent = ?context.traceparent', 'trace context'],
-  ['idempotency_key = ?context.idempotency_key', 'idempotency context'],
   ['deadline_ms = ?context.deadline_ms', 'deadline context'],
   ['operation = owner_operation', 'exact operation field'],
   ['validation = "tenant_id"', 'validation phase'],
   ['code = %error.code', 'mapped code'],
-  ['internal_message = %error.message', 'mapped message'],
-  ['error_kind = ?error.kind', 'typed error kind'],
+  ['internal_message_present', 'message presence diagnostic'],
+  ['internal_message_length', 'message length diagnostic'],
+  ['error_kind', 'closed kind diagnostic'],
   ['retryable = error.retryable', 'retryability'],
   ['boundary = PAYMENT_COLLECTION_PORT_BOUNDARY', 'boundary field'],
   ['tracing::warn!(', 'validation rejection severity'],
   ['"payment collection tenant context was rejected"', 'tenant rejection event'],
 ]) requireText(tenantParser, value, label);
 
+for (const value of [
+  'parse_error = ?parse_error',
+  'parse_error = %parse_error',
+  'error = ?error',
+  'error = %error',
+  'tenant_id = %context.tenant_id',
+  'actor = ?context.actor',
+  'channel = ?context.channel',
+  'locale = %context.locale',
+  'causation_id = ?context.causation_id',
+  'traceparent = ?context.traceparent',
+  'idempotency_key = ?context.idempotency_key',
+  'internal_message = %error.message',
+  'error_kind = ?error.kind',
+]) forbidText(tenantParser, value, 'unsafe tenant diagnostic payload');
+
+if (countText(tenantParser, 'tracing::warn!(') !== 1) {
+  failures.push('tenant parser must retain exactly one warning diagnostic path');
+}
+
 const validationIndex = tenantParser.indexOf('let error = PortError::validation(');
+const factsIndex = tenantParser.indexOf('let parse_error_type =');
 const diagnosticsIndex = tenantParser.indexOf('tracing::warn!(');
 const returnIndex = tenantParser.lastIndexOf('\n        error');
-if (!(validationIndex >= 0 && validationIndex < diagnosticsIndex && diagnosticsIndex < returnIndex)) {
-  failures.push('tenant validation must be constructed, diagnosed, and then returned in order');
+if (
+  !(
+    validationIndex >= 0 &&
+    validationIndex < factsIndex &&
+    factsIndex < diagnosticsIndex &&
+    diagnosticsIndex < returnIndex
+  )
+) {
+  failures.push('tenant validation must be constructed, reduced to bounded facts, diagnosed, and returned in order');
 }
 
 for (const [value, label] of [
@@ -144,12 +187,16 @@ for (const [value, label] of [
   ['context.require_policy(PortCallPolicy::read())', 'read policy remains unchanged'],
   ['context.require_policy(PortCallPolicy::write())', 'write policy remains unchanged'],
   ['context.require_write_semantics()', 'write semantics remain unchanged'],
+  ['let error_kind = match &error.kind', 'bounded admission kind remains unchanged'],
 ]) requireText(admissionBlock, value, label);
 
 for (const [value, label] of [
   ['"create_or_reuse_collection.read_existing"', 'existing lookup operation'],
   ['"create_or_reuse_collection.adopt_race"', 'race adoption operation'],
   ['"create_or_reuse_collection.create"', 'create operation'],
+  ['cause = %message', 'canonical validation payload remains separate'],
+  ['provider_id = %provider_id', 'canonical provider payload remains separate'],
+  ['error = ?error', 'canonical database payload remains separate'],
   ['"payment provider outcome requires reconciliation"', 'stable reconciliation envelope'],
   ['"payment storage is temporarily unavailable"', 'stable storage envelope'],
 ]) requireText(ownerMapper, value, label);
@@ -160,22 +207,64 @@ forbidText(
   'Uuid::parse_str(&context.tenant_id).map_err(|_|',
   'silent tenant parse rejection',
 );
-forbidText(
-  tenantParser,
-  `PortError::validation(
-            "payment.tenant_id_invalid",
-            "PortContext.tenant_id must be a UUID for payment ports",
-        )
-    })`,
-  'undiagnosed tenant validation return',
-);
+
+if (evidence.status !== 'payment_collection_tenant_diagnostic_safety_source_unvalidated') {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  tenant_parser_bounded: true,
+  complete_parse_error_logged: false,
+  constructed_port_error_logged: false,
+  tenant_internal_message_text_logged: false,
+  tenant_context_shape_only: true,
+  tenant_correlation_preserved: true,
+  tenant_owner_operations_preserved: true,
+  tenant_validation_phase_preserved: true,
+  tenant_error_kind_closed: true,
+  tenant_warning_severity_preserved: true,
+  same_validation_port_error_returned: true,
+  tenant_parser_call_sites_preserved: true,
+  admission_mapper_changed: false,
+  canonical_payment_error_mapper_cleanup_out_of_scope: true,
+  execution_behavior_changed: false,
+  public_port_error_changed: false,
+  ffa_promoted: false,
+  fba_promoted: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push('evidence execution must remain empty');
+}
+for (const key of [
+  'tests_run',
+  'cargo_run',
+  'format_run',
+  'verifiers_run',
+  'workflow_checks_run',
+  'ci_run',
+  'runtime_proven',
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key} must remain false`);
+  }
+}
+
+for (const [value, label] of [
+  ['Status: **source-ready / unvalidated**', 'documentation status'],
+  ['Tenant diagnostics retain only the parse-error type and bounded context/message-shape facts', 'documentation bounded policy'],
+  ['The same constructed validation `PortError` is returned after diagnostics', 'documentation error pass-through'],
+  ['Canonical `payment_error_to_port_error` remains the next separate cleanup slice', 'documentation residual boundary'],
+]) requireText(doc, value, label);
 
 if (failures.length > 0) {
-  console.error('Payment collection tenant context verification failed:');
+  console.error('Payment collection tenant diagnostic-safety verification failed:');
   for (const failure of failures) console.error(`✗ ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
 
 console.log(
-  '✔ Payment collection tenant UUID rejection retains exact owner context without changing admission, lifecycle, or public PortError behavior',
+  '✔ Payment collection tenant UUID rejection uses type-only parse cause and bounded context/message facts while preserving the exact validation envelope and operation-aware routing',
 );


### PR DESCRIPTION
## Summary

- continue the ecommerce correlation-safe mapper cleanup at the Payment collection owner boundary;
- harden only `parse_port_tenant_id` at runtime;
- replace complete UUID parse errors, complete constructed `PortError`, raw delegated context, internal message text, and Debug error kind output with type-only and bounded shape facts;
- preserve `Uuid::parse_str`, the existing `map_err` path, warning severity, exact validation code/message/kind/retryability, and return of the same constructed error;
- preserve both operation-aware parser call sites and admission-before-tenant ordering;
- add source-only evidence and strengthen the tenant verifier;
- synchronize the preceding admission verifier/documentation with the separately closed tenant contract;
- leave canonical `payment_error_to_port_error` as the next open Payment collection mapper boundary.

## Covered runtime boundary

- `parse_port_tenant_id`

## Deliberate boundary

This PR does not change admission runtime diagnostics, `payment_error_to_port_error`, collection lookup/create/adoption/status behavior, request or response DTOs, checkout execution, compensation, Commerce orchestration, or FFA/FBA status.

## Validation

Tests, Node verifiers, formatting, Cargo checks, mounted execution, workflows, and CI were not run, per maintainer request.

Suggested maintainer commands:

```bash
node scripts/verify/verify-payment-collection-tenant-context.mjs
node scripts/verify/verify-payment-collection-admission-context.mjs
node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
cargo check -p rustok-payment --lib
```

Branch base: `e7216e3d3e8a9e9b13bf9cb28041113cd14ef4da`. Later main commits are Index lock/build-only and do not overlap this Payment scope.