### PR TITLE
feat(forum): add native Leptos topic merge transport

### DIFF
--- a/apps/admin/Cargo.toml
+++ b/apps/admin/Cargo.toml
@@ -31,6 +31,7 @@ csr = [
   "rustok-auth-admin/csr",
   "rustok-page-builder-admin/csr",
   "rustok-blog-admin/csr",
+  "rustok-forum-admin/csr",
 ]
 hydrate = [
   "leptos/hydrate",
@@ -60,6 +61,7 @@ hydrate = [
   "rustok-pages-admin/hydrate",
   "rustok-seo-admin/hydrate",
   "rustok-fulfillment-admin/hydrate",
+  "rustok-forum-admin/hydrate",
   "rustok-inventory-admin/hydrate",
   "rustok-order-admin/hydrate",
   "rustok-pricing-admin/hydrate",
@@ -115,6 +117,7 @@ ssr = [
   "rustok-pages-admin/ssr",
   "rustok-seo-admin/ssr",
   "rustok-fulfillment-admin/ssr",
+  "rustok-forum-admin/ssr",
   "rustok-inventory-admin/ssr",
   "rustok-order-admin/ssr",
   "rustok-pricing-admin/ssr",

--- a/crates/rustok-forum/README.md
+++ b/crates/rustok-forum/README.md
@@ -64,8 +64,11 @@
   route `/modules/forum/merge` and Next-admin route `/dashboard/forum/merge`.
   Both keep one UUID operation identity across an exact retry, derive any selected
   accepted-solution reply from current candidate state, and display the immutable
-  owner receipt. The Leptos package remains explicitly GraphQL-only until a
-  direct authenticated native owner adapter is delivered.
+  owner receipt.
+- FORUM-21O selects direct authenticated native server functions for the Leptos
+  merge route in SSR/hydrate builds while retaining the existing GraphQL adapter
+  for CSR/headless builds. Native DTOs carry no access token or owner identity,
+  and a failed selected transport never falls back to the other path.
 - Resolved and ordinary merges retain the exact `forum.topic.merged` schema-1
   event contract so subscription, read-state, tag, vote and audience
   reconciliation owners remain unchanged.
@@ -148,4 +151,5 @@ into README files, issues, or additional planning documents.
 - [Canonical merged-topic resolution and HTTP redirect](./docs/forum-21i-topic-canonical-resolution.md)
 - [Topic merge GraphQL transport](./docs/forum-21k-topic-merge-graphql-transport.md)
 - [Admin topic merge workflow](./docs/forum-21n-topic-merge-admin-ui.md)
+- [Native Leptos admin merge transport](./docs/forum-21o-topic-merge-native-admin.md)
 - [Platform docs index](../../docs/index.md)

--- a/crates/rustok-forum/admin/Cargo.toml
+++ b/crates/rustok-forum/admin/Cargo.toml
@@ -8,14 +8,33 @@ description = "Leptos admin UI package for the rustok-forum module"
 [lib]
 crate-type = ["rlib"]
 
+[features]
+default = []
+csr = ["leptos/csr"]
+hydrate = ["leptos/hydrate"]
+ssr = [
+  "leptos/ssr",
+  "dep:leptos_axum",
+  "rustok-api/server",
+  "dep:rustok-core",
+  "dep:rustok-forum",
+  "dep:rustok-outbox",
+  "dep:uuid",
+]
+
 [dependencies]
 rustok-ui-core.workspace = true
-leptos = { workspace = true, features = ["csr"] }
+rustok-ui-transport.workspace = true
+leptos.workspace = true
+leptos_axum = { workspace = true, optional = true }
 leptos-auth.workspace = true
 leptos-ui.workspace = true
 rustok-graphql.workspace = true
 rustok-api = { workspace = true, default-features = false }
-
+rustok-core = { workspace = true, optional = true }
+rustok-forum = { path = "..", optional = true }
+rustok-outbox = { workspace = true, optional = true }
+uuid = { workspace = true, optional = true }
 
 rustok-ui-i18n-leptos.workspace = true
 rustok-seo-targets = { path = "../../rustok-seo-targets", default-features = false }

--- a/crates/rustok-forum/admin/README.md
+++ b/crates/rustok-forum/admin/README.md
@@ -12,7 +12,8 @@ Leptos admin UI package for the `rustok-forum` module.
 - Exposes the forum admin root view used by `apps/admin`.
 - Keeps forum-specific admin UX inside the module package.
 - Participates in manifest-driven UI composition through `rustok-module.toml`.
-- Owns one explicit GraphQL transport for category/topic CRUD, reply previews, and the FORUM-21N topic-merge workflow; no REST fallback is retained.
+- Keeps category/topic CRUD and reply previews on their existing explicit GraphQL transport.
+- Selects direct authenticated native server functions for the FORUM-21 topic-merge workflow in SSR/hydrate builds and retains GraphQL for CSR/headless builds, without fallback.
 - Presents category, topic, reply-preview, and merge workflows as module-owned Forum pages.
 - Ships package-owned `admin/locales/en.json` and `admin/locales/ru.json` bundles.
 - Embeds owner-side SEO panels through `rustok-seo-admin-support`.
@@ -26,20 +27,28 @@ Leptos admin UI package for the `rustok-forum` module.
 
 - `admin/src/core.rs` owns the existing framework-agnostic category/topic view policy.
 - `admin/src/topic_merge_model.rs` owns merge candidate, command, receipt, validation, accepted-solution selection, and retry-identity policy without Leptos imports.
-- `admin/src/transport.rs` is the only UI-facing transport facade.
-- `admin/src/transport/topic_merge_graphql_adapter.rs` composes `mergeForumTopic` and `mergeForumTopicResolvingSolution` through `rustok-graphql`.
+- `admin/src/transport.rs` is the only UI-facing transport facade and selects exactly one merge transport per compile profile.
+- `admin/src/transport/topic_merge_native_server_adapter.rs` extracts server-side auth/tenant/runtime context and calls `TopicService` plus `ForumTopicMergeService` directly.
+- `admin/src/transport/topic_merge_graphql_adapter.rs` preserves CSR/headless parity through `mergeForumTopic` and `mergeForumTopicResolvingSolution`.
 - `admin/src/ui/root.rs` performs route-only composition.
 - `admin/src/ui/topic_merge.rs` is the thin Leptos render/effect adapter.
 
 ## Transport state
 
-The package remains a documented single-adapter GraphQL state. FORUM-21N does not pretend that a GraphQL call wrapped by a server function is a native owner path and never sends an access token inside a server-function DTO. A future native parity slice must add direct authenticated owner composition and preserve GraphQL for CSR/headless use.
+FORUM-21O replaces the historical FORUM-21N GraphQL-only Leptos state with compile-profile selection:
+
+- `ssr` and `hydrate` use native server functions;
+- `csr` and headless/default builds use GraphQL;
+- a failed selected path is returned as an error and never triggers cross-path fallback;
+- native request DTOs contain locale or the framework-neutral merge command only, never access tokens, tenant IDs, actor IDs, permission snapshots, database handles, or event-bus handles.
+
+The native adapter derives tenant and actor authority from `TenantContext` and `AuthContext`, obtains the database and `TransactionalEventBus` from `HostRuntimeContext`, rechecks `forum_topics:list` or `forum_topics:manage`, and delegates to the existing Forum owners.
 
 ## Interactions
 
 - Consumed by `apps/admin` through manifest-driven code generation.
 - Mounted under `/modules/forum` with child pages for topics, categories, and merge.
-- Requires the routed tenant and `forum_topics:manage`; the backend owner revalidates both.
+- Requires the routed tenant and `forum_topics:manage`; both transport adapters and the backend owner revalidate authority.
 - Keeps one operation ID stable across an exact retry and rotates it whenever source, target, reason, or accepted-solution selection changes.
 - Uses explicit source/target accepted-solution choice only when both topics are solved.
 
@@ -47,3 +56,4 @@ The package remains a documented single-adapter GraphQL state. FORUM-21N does no
 
 - See [platform docs](../../../docs/index.md).
 - See [FORUM-21N admin merge UI](../docs/forum-21n-topic-merge-admin-ui.md).
+- See [FORUM-21O native admin merge transport](../docs/forum-21o-topic-merge-native-admin.md).

--- a/crates/rustok-forum/admin/README.md
+++ b/crates/rustok-forum/admin/README.md
@@ -28,7 +28,7 @@ Leptos admin UI package for the `rustok-forum` module.
 - `admin/src/core.rs` owns the existing framework-agnostic category/topic view policy.
 - `admin/src/topic_merge_model.rs` owns merge candidate, command, receipt, validation, accepted-solution selection, and retry-identity policy without Leptos imports.
 - `admin/src/transport.rs` is the only UI-facing transport facade and selects exactly one merge transport per compile profile.
-- `admin/src/transport/topic_merge_native_server_adapter.rs` extracts server-side auth/tenant/runtime context and calls `TopicService` plus `ForumTopicMergeService` directly.
+- `crates/rustok-forum/admin/src/transport/topic_merge_native_server_adapter.rs` extracts server-side auth/tenant/runtime context and calls `TopicService` plus `ForumTopicMergeService` directly.
 - `admin/src/transport/topic_merge_graphql_adapter.rs` preserves CSR/headless parity through `mergeForumTopic` and `mergeForumTopicResolvingSolution`.
 - `admin/src/ui/root.rs` performs route-only composition.
 - `admin/src/ui/topic_merge.rs` is the thin Leptos render/effect adapter.

--- a/crates/rustok-forum/admin/src/transport.rs
+++ b/crates/rustok-forum/admin/src/transport.rs
@@ -1,6 +1,9 @@
 mod category_tree_graphql_adapter;
 mod graphql_adapter;
 mod topic_merge_graphql_adapter;
+mod topic_merge_native_server_adapter;
+
+use rustok_ui_transport::{UiTransportPath, execute_selected_transport};
 
 use crate::model::{
     CategoryDetail, CategoryDraft, CategoryListItem, ReplyListItem, TopicDetail, TopicDraft,
@@ -11,6 +14,17 @@ use crate::topic_merge_model::{
 };
 
 pub type ApiError = String;
+
+fn selected_topic_merge_transport_path() -> UiTransportPath {
+    #[cfg(any(feature = "ssr", feature = "hydrate"))]
+    {
+        UiTransportPath::NativeServer
+    }
+    #[cfg(not(any(feature = "ssr", feature = "hydrate")))]
+    {
+        UiTransportPath::Graphql
+    }
+}
 
 pub async fn fetch_category_tree(
     token: Option<String>,
@@ -156,7 +170,17 @@ pub async fn fetch_topic_merge_candidates(
     tenant_slug: Option<String>,
     locale: String,
 ) -> Result<Vec<ForumTopicMergeCandidate>, ApiError> {
-    topic_merge_graphql_adapter::fetch_candidates(token, tenant_slug, locale).await
+    let native_locale = locale.clone();
+    execute_selected_transport(
+        "forum_topic_merge_admin",
+        selected_topic_merge_transport_path(),
+        move || {
+            topic_merge_native_server_adapter::fetch_topic_merge_candidates_native(native_locale)
+        },
+        move || topic_merge_graphql_adapter::fetch_candidates(token, tenant_slug, locale),
+    )
+    .await
+    .map_err(|error| error.to_string())
 }
 
 pub async fn merge_topic(
@@ -164,7 +188,15 @@ pub async fn merge_topic(
     tenant_slug: Option<String>,
     command: ForumTopicMergeCommand,
 ) -> Result<ForumTopicMergeReceipt, ApiError> {
-    topic_merge_graphql_adapter::merge_topic(token, tenant_slug, command).await
+    let native_command = command.clone();
+    execute_selected_transport(
+        "forum_topic_merge_admin",
+        selected_topic_merge_transport_path(),
+        move || topic_merge_native_server_adapter::merge_topic_native(native_command),
+        move || topic_merge_graphql_adapter::merge_topic(token, tenant_slug, command),
+    )
+    .await
+    .map_err(|error| error.to_string())
 }
 
 fn placement_position(position: i32) -> Result<u32, ApiError> {
@@ -190,7 +222,7 @@ mod tests {
     }
 
     #[test]
-    fn forum_admin_operations_use_one_explicit_graphql_transport() {
+    fn legacy_forum_admin_operations_keep_one_explicit_graphql_transport() {
         for operation in [
             "fetch_category_tree",
             "fetch_category",
@@ -204,18 +236,31 @@ mod tests {
             "update_topic",
             "delete_topic",
             "fetch_replies",
-            "fetch_topic_merge_candidates",
-            "merge_topic",
         ] {
             let source = function_source(operation);
             assert!(!source.contains("rest_adapter"));
             assert!(!source.contains("native_server_adapter"));
             assert!(
                 source.contains("graphql_adapter::")
-                    || source.contains("category_tree_graphql_adapter::")
-                    || source.contains("topic_merge_graphql_adapter::"),
+                    || source.contains("category_tree_graphql_adapter::"),
                 "{operation} must keep one explicit GraphQL owner transport"
             );
         }
+    }
+
+    #[test]
+    fn topic_merge_selects_native_or_graphql_without_fallback() {
+        for operation in ["fetch_topic_merge_candidates", "merge_topic"] {
+            let source = function_source(operation);
+            assert!(source.contains("execute_selected_transport"));
+            assert!(source.contains("topic_merge_native_server_adapter::"));
+            assert!(source.contains("topic_merge_graphql_adapter::"));
+            assert!(!source.contains("or_else"));
+            assert!(!source.contains("fallback"));
+        }
+
+        assert!(SOURCE.contains("cfg(any(feature = \"ssr\", feature = \"hydrate\"))"));
+        assert!(SOURCE.contains("UiTransportPath::NativeServer"));
+        assert!(SOURCE.contains("UiTransportPath::Graphql"));
     }
 }

--- a/crates/rustok-forum/admin/src/transport/topic_merge_native_server_adapter.rs
+++ b/crates/rustok-forum/admin/src/transport/topic_merge_native_server_adapter.rs
@@ -30,6 +30,20 @@ fn require_permission(
 }
 
 #[cfg(feature = "ssr")]
+async fn require_forum_module_enabled(
+    host: &rustok_api::HostRuntimeContext,
+    tenant_id: uuid::Uuid,
+) -> Result<(), ServerFnError> {
+    match rustok_api::is_tenant_module_enabled(host.db(), tenant_id, "forum").await {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(ServerFnError::new("Forum module is not enabled")),
+        Err(error) => Err(ServerFnError::new(format!(
+            "Forum module state is unavailable: {error}"
+        ))),
+    }
+}
+
+#[cfg(feature = "ssr")]
 fn runtime() -> Result<
     (
         rustok_api::HostRuntimeContext,
@@ -88,13 +102,14 @@ pub(super) async fn fetch_topic_merge_candidates_native(
             .map_err(ServerFnError::new)?;
 
         require_tenant_scope(&auth, &tenant)?;
+        let (host, event_bus) = runtime()?;
+        require_forum_module_enabled(&host, tenant.id).await?;
         require_permission(
             &auth,
             rustok_api::Permission::FORUM_TOPICS_LIST,
             "forum_topics:list required",
         )?;
 
-        let (host, event_bus) = runtime()?;
         let service = rustok_forum::TopicService::new(host.db_clone(), event_bus);
         let (topics, _) = service
             .list_with_locale_fallback(
@@ -149,6 +164,8 @@ pub(super) async fn merge_topic_native(
             .map_err(ServerFnError::new)?;
 
         require_tenant_scope(&auth, &tenant)?;
+        let (host, event_bus) = runtime()?;
+        require_forum_module_enabled(&host, tenant.id).await?;
         require_permission(
             &auth,
             rustok_api::Permission::FORUM_TOPICS_MANAGE,
@@ -164,7 +181,6 @@ pub(super) async fn merge_topic_native(
             .map(|value| parse_uuid(value, "selected_solution_reply_id"))
             .transpose()?;
 
-        let (host, event_bus) = runtime()?;
         let service = rustok_forum::ForumTopicMergeService::new(host.db_clone(), event_bus);
         let security = rustok_core::SecurityContext::from_permission_snapshot(
             Some(auth.user_id),

--- a/crates/rustok-forum/admin/src/transport/topic_merge_native_server_adapter.rs
+++ b/crates/rustok-forum/admin/src/transport/topic_merge_native_server_adapter.rs
@@ -1,0 +1,208 @@
+use leptos::prelude::*;
+
+use crate::topic_merge_model::{
+    ForumTopicMergeCandidate, ForumTopicMergeCommand, ForumTopicMergeReceipt,
+};
+
+#[cfg(feature = "ssr")]
+fn require_tenant_scope(
+    auth: &rustok_api::AuthContext,
+    tenant: &rustok_api::TenantContext,
+) -> Result<(), ServerFnError> {
+    if auth.tenant_id == tenant.id {
+        Ok(())
+    } else {
+        Err(ServerFnError::new("Forum admin tenant scope mismatch"))
+    }
+}
+
+#[cfg(feature = "ssr")]
+fn require_permission(
+    auth: &rustok_api::AuthContext,
+    permission: rustok_api::Permission,
+    message: &'static str,
+) -> Result<(), ServerFnError> {
+    if rustok_api::has_any_effective_permission(&auth.permissions, &[permission]) {
+        Ok(())
+    } else {
+        Err(ServerFnError::new(message))
+    }
+}
+
+#[cfg(feature = "ssr")]
+fn runtime() -> Result<
+    (
+        rustok_api::HostRuntimeContext,
+        rustok_outbox::TransactionalEventBus,
+    ),
+    ServerFnError,
+> {
+    use leptos::prelude::expect_context;
+
+    let host = expect_context::<rustok_api::HostRuntimeContext>();
+    let event_bus = host
+        .shared_get::<rustok_outbox::TransactionalEventBus>()
+        .ok_or_else(|| {
+            ServerFnError::new(
+                "Forum admin requires TransactionalEventBus in host runtime context",
+            )
+        })?;
+    Ok((host, event_bus))
+}
+
+#[cfg(feature = "ssr")]
+fn parse_uuid(value: &str, field: &'static str) -> Result<uuid::Uuid, ServerFnError> {
+    uuid::Uuid::parse_str(value.trim())
+        .map_err(|_| ServerFnError::new(format!("Invalid {field}")))
+}
+
+#[cfg(feature = "ssr")]
+fn map_receipt(result: rustok_forum::ForumTopicMergeResult) -> ForumTopicMergeReceipt {
+    ForumTopicMergeReceipt {
+        operation_id: result.operation_id.to_string(),
+        event_id: result.event_id.to_string(),
+        source_topic_id: result.source_topic_id.to_string(),
+        target_topic_id: result.target_topic_id.to_string(),
+        category_id: result.category_id.to_string(),
+        actor_id: result.actor_id.to_string(),
+        reason: result.reason,
+        moved_reply_count: result.moved_reply_count,
+        moved_published_reply_count: result.moved_published_reply_count,
+        resulting_published_reply_count: result.resulting_published_reply_count,
+        position_offset: result.position_offset,
+        merged_at: result.merged_at.to_rfc3339(),
+    }
+}
+
+#[server(prefix = "/api/fn", endpoint = "forum/topic-merge-candidates")]
+pub(super) async fn fetch_topic_merge_candidates_native(
+    locale: String,
+) -> Result<Vec<ForumTopicMergeCandidate>, ServerFnError> {
+    #[cfg(feature = "ssr")]
+    {
+        let auth = leptos_axum::extract::<rustok_api::AuthContext>()
+            .await
+            .map_err(ServerFnError::new)?;
+        let tenant = leptos_axum::extract::<rustok_api::TenantContext>()
+            .await
+            .map_err(ServerFnError::new)?;
+
+        require_tenant_scope(&auth, &tenant)?;
+        require_permission(
+            &auth,
+            rustok_api::Permission::FORUM_TOPICS_LIST,
+            "forum_topics:list required",
+        )?;
+
+        let (host, event_bus) = runtime()?;
+        let service = rustok_forum::TopicService::new(host.db_clone(), event_bus);
+        let (topics, _) = service
+            .list_with_locale_fallback(
+                tenant.id,
+                rustok_core::SecurityContext::from_permission_snapshot(
+                    Some(auth.user_id),
+                    &auth.permissions,
+                ),
+                rustok_forum::ListTopicsFilter {
+                    category_id: None,
+                    status: None,
+                    locale: Some(locale),
+                    page: 1,
+                    per_page: 100,
+                },
+                Some(tenant.default_locale.as_str()),
+            )
+            .await
+            .map_err(|error| ServerFnError::new(error.to_string()))?;
+
+        Ok(topics
+            .into_iter()
+            .map(|topic| ForumTopicMergeCandidate {
+                id: topic.id.to_string(),
+                title: topic.title,
+                category_id: topic.category_id.to_string(),
+                reply_count: topic.reply_count,
+                solution_reply_id: topic.solution_reply_id.map(|value| value.to_string()),
+            })
+            .collect())
+    }
+    #[cfg(not(feature = "ssr"))]
+    {
+        let _ = locale;
+        Err(ServerFnError::new(
+            "forum/topic-merge-candidates requires the `ssr` feature",
+        ))
+    }
+}
+
+#[server(prefix = "/api/fn", endpoint = "forum/topic-merge")]
+pub(super) async fn merge_topic_native(
+    command: ForumTopicMergeCommand,
+) -> Result<ForumTopicMergeReceipt, ServerFnError> {
+    #[cfg(feature = "ssr")]
+    {
+        let auth = leptos_axum::extract::<rustok_api::AuthContext>()
+            .await
+            .map_err(ServerFnError::new)?;
+        let tenant = leptos_axum::extract::<rustok_api::TenantContext>()
+            .await
+            .map_err(ServerFnError::new)?;
+
+        require_tenant_scope(&auth, &tenant)?;
+        require_permission(
+            &auth,
+            rustok_api::Permission::FORUM_TOPICS_MANAGE,
+            "forum_topics:manage required",
+        )?;
+
+        let operation_id = parse_uuid(&command.operation_id, "operation_id")?;
+        let source_topic_id = parse_uuid(&command.source_topic_id, "source_topic_id")?;
+        let target_topic_id = parse_uuid(&command.target_topic_id, "target_topic_id")?;
+        let selected_solution_reply_id = command
+            .selected_solution_reply_id
+            .as_deref()
+            .map(|value| parse_uuid(value, "selected_solution_reply_id"))
+            .transpose()?;
+
+        let (host, event_bus) = runtime()?;
+        let service = rustok_forum::ForumTopicMergeService::new(host.db_clone(), event_bus);
+        let security = rustok_core::SecurityContext::from_permission_snapshot(
+            Some(auth.user_id),
+            &auth.permissions,
+        );
+        let input = rustok_forum::MergeForumTopicInput {
+            operation_id,
+            source_topic_id,
+            reason: command.reason,
+        };
+
+        let result = match selected_solution_reply_id {
+            Some(selected_solution_reply_id) => {
+                service
+                    .merge_topic_resolving_solution(
+                        tenant.id,
+                        target_topic_id,
+                        security,
+                        selected_solution_reply_id,
+                        input,
+                    )
+                    .await
+            }
+            None => {
+                service
+                    .merge_topic(tenant.id, target_topic_id, security, input)
+                    .await
+            }
+        }
+        .map_err(|error| ServerFnError::new(error.to_string()))?;
+
+        Ok(map_receipt(result))
+    }
+    #[cfg(not(feature = "ssr"))]
+    {
+        let _ = command;
+        Err(ServerFnError::new(
+            "forum/topic-merge requires the `ssr` feature",
+        ))
+    }
+}

--- a/crates/rustok-forum/contracts/forum-topic-merge-native-admin.json
+++ b/crates/rustok-forum/contracts/forum-topic-merge-native-admin.json
@@ -21,6 +21,9 @@
     "merge_endpoint": "/api/fn/forum/topic-merge",
     "candidate_owner": "TopicService::list_with_locale_fallback",
     "merge_owner": "ForumTopicMergeService",
+    "module_slug": "forum",
+    "module_lifecycle_check": "rustok_api::is_tenant_module_enabled",
+    "module_must_be_enabled": true,
     "server_context": [
       "AuthContext",
       "TenantContext",

--- a/crates/rustok-forum/contracts/forum-topic-merge-native-admin.json
+++ b/crates/rustok-forum/contracts/forum-topic-merge-native-admin.json
@@ -1,0 +1,93 @@
+{
+  "contract": "forum_topic_merge_native_admin_v1",
+  "task": "FORUM-21O",
+  "parent_task": "FORUM-21",
+  "extends": ["FORUM-21N"],
+  "status": "source_ready_maintainer_execution_pending",
+  "canonical_plan_status": "planned",
+  "surface": "rustok-forum-admin",
+  "route": "/modules/forum/merge",
+  "transport_selection": {
+    "ssr": "native_server",
+    "hydrate": "native_server",
+    "csr": "graphql",
+    "headless_default": "graphql",
+    "fallback": false,
+    "selector": "rustok_ui_transport::execute_selected_transport"
+  },
+  "native_server": {
+    "adapter": "crates/rustok-forum/admin/src/transport/topic_merge_native_server_adapter.rs",
+    "candidate_endpoint": "/api/fn/forum/topic-merge-candidates",
+    "merge_endpoint": "/api/fn/forum/topic-merge",
+    "candidate_owner": "TopicService::list_with_locale_fallback",
+    "merge_owner": "ForumTopicMergeService",
+    "server_context": [
+      "AuthContext",
+      "TenantContext",
+      "HostRuntimeContext",
+      "TransactionalEventBus"
+    ],
+    "candidate_permission": "forum_topics:list",
+    "merge_permission": "forum_topics:manage",
+    "auth_tenant_must_equal_routed_tenant": true,
+    "candidate_limit": 100,
+    "selected_solution_path_preserved": true
+  },
+  "request_dto_policy": {
+    "access_token": false,
+    "tenant_id": false,
+    "actor_id": false,
+    "permission_snapshot": false,
+    "database_handle": false,
+    "event_bus_handle": false,
+    "candidate_request_fields": ["locale"],
+    "merge_request_fields": ["command"]
+  },
+  "graphql_parity": {
+    "adapter": "crates/rustok-forum/admin/src/transport/topic_merge_graphql_adapter.rs",
+    "candidate_query_retained": true,
+    "ordinary_merge_mutation_retained": true,
+    "solution_resolution_mutation_retained": true,
+    "csr_and_headless_only": true
+  },
+  "host_composition": {
+    "host_manifest": "apps/admin/Cargo.toml",
+    "csr_feature_forwarded": true,
+    "hydrate_feature_forwarded": true,
+    "ssr_feature_forwarded": true
+  },
+  "compatibility": {
+    "owner_changed": false,
+    "graphql_schema_changed": false,
+    "rest_route_changed": false,
+    "receipt_changed": false,
+    "semantic_event_changed": false,
+    "migration_added": false,
+    "next_admin_changed": false
+  },
+  "verification": {
+    "verifier": "scripts/verify/verify-forum-topic-merge-native-admin.mjs",
+    "maintainer_commands": [
+      "node scripts/verify/verify-forum-topic-merge-native-admin.mjs",
+      "node scripts/verify/verify-forum-topic-merge-admin-ui.mjs",
+      "cargo check -p rustok-forum-admin --features ssr --all-targets",
+      "cargo check -p rustok-forum-admin --features hydrate --target wasm32-unknown-unknown",
+      "cargo check -p rustok-forum-admin --features csr --target wasm32-unknown-unknown",
+      "cargo check -p rustok-admin --no-default-features --features ssr",
+      "cargo check -p rustok-admin --no-default-features --features hydrate --target wasm32-unknown-unknown"
+    ]
+  },
+  "remaining_scope": [
+    "maintainer mounted-browser and runtime transport evidence",
+    "idempotent split-selected-replies workflow",
+    "idempotent reply-branch fork workflow",
+    "bounded reply-range movement",
+    "final canonical localized aliases and route tombstones under FORUM-24"
+  ],
+  "non_claims": [
+    "no verifier Cargo formatter workflow browser or CI execution is claimed",
+    "no cross-path runtime fallback is added",
+    "no Next-admin transport change is added",
+    "FORUM-21 remains planned"
+  ]
+}

--- a/crates/rustok-forum/docs/README.md
+++ b/crates/rustok-forum/docs/README.md
@@ -35,7 +35,8 @@ notifications module, and cross-module release gates.
 - uses `rustok-channel` for visibility and SEO gating;
 - selected merge reads resolve through the immutable receipt, while mutation commands keep exact identity semantics;
 - `mergeForumTopic` and `mergeForumTopicResolvingSolution` remain the only admin merge command contracts;
-- FORUM-21N composes those commands in Leptos and Next-admin without changing the owner, receipt or event schema.
+- FORUM-21N composes those commands in Leptos and Next-admin without changing the owner, receipt or event schema;
+- FORUM-21O selects direct authenticated native owner composition for Leptos SSR/hydrate while retaining GraphQL for CSR/headless with no fallback.
 
 ## Verification
 
@@ -54,6 +55,7 @@ notifications module, and cross-module release gates.
 - [FORUM-21L competing solution resolution](./forum-21l-topic-merge-solution-resolution.md)
 - [FORUM-21M checked cross-category merge](./forum-21m-topic-merge-cross-category.md)
 - [FORUM-21N admin merge workflow](./forum-21n-topic-merge-admin-ui.md)
+- [FORUM-21O native Leptos merge transport](./forum-21o-topic-merge-native-admin.md)
 - [FORUM-21I/J canonical resolution and HTTP redirect](./forum-21i-topic-canonical-resolution.md)
 - [FORUM-21K topic merge GraphQL transport](./forum-21k-topic-merge-graphql-transport.md)
 - [Admin UI package](../admin/README.md)

--- a/crates/rustok-forum/docs/forum-21o-topic-merge-native-admin.md
+++ b/crates/rustok-forum/docs/forum-21o-topic-merge-native-admin.md
@@ -38,11 +38,16 @@ functions:
 /api/fn/forum/topic-merge
 ```
 
-The candidate endpoint accepts only locale. It extracts `AuthContext` and
-`TenantContext`, requires exact auth/routed tenant agreement plus
+Both endpoints extract `AuthContext` and `TenantContext`, require exact
+auth/routed tenant agreement, load `HostRuntimeContext`, and call
+`rustok_api::is_tenant_module_enabled(..., "forum")` before entering the Forum
+owner. A disabled module therefore fails closed on the native path just as it
+does through GraphQL.
+
+The candidate endpoint accepts only locale. After module admission it requires
 `forum_topics:list`, obtains the database and `TransactionalEventBus` from the
-server-only `HostRuntimeContext`, and calls
-`TopicService::list_with_locale_fallback` with the existing 100-topic bound.
+server-only host context, and calls `TopicService::list_with_locale_fallback`
+with the existing 100-topic bound.
 
 The merge endpoint accepts only the framework-neutral
 `ForumTopicMergeCommand`. It derives tenant and actor from server context,

--- a/crates/rustok-forum/docs/forum-21o-topic-merge-native-admin.md
+++ b/crates/rustok-forum/docs/forum-21o-topic-merge-native-admin.md
@@ -1,0 +1,111 @@
+# FORUM-21O native Leptos admin topic-merge transport
+
+## Status
+
+`source_ready_maintainer_execution_pending`
+
+FORUM-21O closes the Leptos transport gap left by FORUM-21N. The module-owned
+merge page now selects a direct authenticated native server-function path in
+SSR/hydrate builds while retaining the existing GraphQL adapter for CSR and
+headless/default builds.
+
+Machine contract:
+
+```text
+crates/rustok-forum/contracts/forum-topic-merge-native-admin.json
+```
+
+## Selected transport, no fallback
+
+`admin/src/transport.rs` uses
+`rustok_ui_transport::execute_selected_transport` and chooses exactly one path:
+
+- `ssr` and `hydrate`: native server functions;
+- `csr` and default/headless: GraphQL;
+- a failure on the selected path is returned to the UI and never causes an
+  implicit retry through the other transport.
+
+This preserves deterministic transport ownership and avoids duplicate merge
+commands with the same operation identity crossing two transport paths.
+
+## Native owner composition
+
+`admin/src/transport/topic_merge_native_server_adapter.rs` owns two server
+functions:
+
+```text
+/api/fn/forum/topic-merge-candidates
+/api/fn/forum/topic-merge
+```
+
+The candidate endpoint accepts only locale. It extracts `AuthContext` and
+`TenantContext`, requires exact auth/routed tenant agreement plus
+`forum_topics:list`, obtains the database and `TransactionalEventBus` from the
+server-only `HostRuntimeContext`, and calls
+`TopicService::list_with_locale_fallback` with the existing 100-topic bound.
+
+The merge endpoint accepts only the framework-neutral
+`ForumTopicMergeCommand`. It derives tenant and actor from server context,
+requires `forum_topics:manage`, parses the bounded UUID identities, and calls
+the existing `ForumTopicMergeService`. Ordinary and explicit accepted-solution
+resolution paths return the same immutable owner receipt used by GraphQL.
+
+No native DTO accepts an access token, tenant ID, actor ID, permission snapshot,
+database handle or event-bus handle.
+
+## GraphQL parity
+
+`admin/src/transport/topic_merge_graphql_adapter.rs` remains unchanged and
+continues to own:
+
+- the bounded candidate query;
+- `mergeForumTopic`;
+- `mergeForumTopicResolvingSolution`.
+
+CSR/headless builds therefore retain the existing external transport contract.
+The native path is direct owner composition rather than GraphQL wrapped inside
+a server function.
+
+## Host feature propagation
+
+`apps/admin/Cargo.toml` forwards all three Forum admin profiles:
+
+```text
+rustok-forum-admin/csr
+rustok-forum-admin/hydrate
+rustok-forum-admin/ssr
+```
+
+The package itself exposes matching features and enables its server-only owner,
+outbox, UUID and `leptos_axum` dependencies only for `ssr`.
+
+## Compatibility
+
+FORUM-21O changes no Forum owner method, GraphQL schema, REST route, merge
+receipt, semantic event, migration, canonical source resolution or Next-admin
+composition. The FORUM-21N UI policy, retry identity and accepted-solution
+selection remain unchanged.
+
+## Remaining FORUM-21 scope
+
+The canonical task remains `planned`. Remaining work includes:
+
+- maintainer SQLite/PostgreSQL, mounted-browser and transport execution evidence;
+- idempotent split-selected-replies workflow;
+- idempotent reply-branch fork workflow;
+- bounded reply-range movement;
+- final localized canonical aliases and route tombstones under FORUM-24.
+
+## Maintainer verification
+
+```bash
+node scripts/verify/verify-forum-topic-merge-native-admin.mjs
+node scripts/verify/verify-forum-topic-merge-admin-ui.mjs
+cargo check -p rustok-forum-admin --features ssr --all-targets
+cargo check -p rustok-forum-admin --features hydrate --target wasm32-unknown-unknown
+cargo check -p rustok-forum-admin --features csr --target wasm32-unknown-unknown
+cargo check -p rustok-admin --no-default-features --features ssr
+cargo check -p rustok-admin --no-default-features --features hydrate --target wasm32-unknown-unknown
+```
+
+No command above was run by the implementation agent, per maintainer request.

--- a/scripts/verify/verify-forum-topic-merge-admin-ui.mjs
+++ b/scripts/verify/verify-forum-topic-merge-admin-ui.mjs
@@ -6,12 +6,17 @@ import { readFileSync } from "node:fs";
 const paths = {
   contract: "crates/rustok-forum/contracts/forum-topic-merge-admin-ui.json",
   docs: "crates/rustok-forum/docs/forum-21n-topic-merge-admin-ui.md",
+  nativeContract:
+    "crates/rustok-forum/contracts/forum-topic-merge-native-admin.json",
+  nativeDocs: "crates/rustok-forum/docs/forum-21o-topic-merge-native-admin.md",
   plan: "crates/rustok-forum/docs/implementation-plan.md",
   backend: "crates/rustok-forum/src/graphql/topic_merge_mutation.rs",
   manifest: "crates/rustok-forum/rustok-module.toml",
   leptosReadme: "crates/rustok-forum/admin/README.md",
   leptosModel: "crates/rustok-forum/admin/src/topic_merge_model.rs",
   leptosFacade: "crates/rustok-forum/admin/src/transport.rs",
+  leptosNative:
+    "crates/rustok-forum/admin/src/transport/topic_merge_native_server_adapter.rs",
   leptosGraphql:
     "crates/rustok-forum/admin/src/transport/topic_merge_graphql_adapter.rs",
   leptosRoot: "crates/rustok-forum/admin/src/ui/root.rs",
@@ -37,12 +42,15 @@ const includesAll = (text, markers, label) => {
 
 const contract = JSON.parse(read(paths.contract));
 const docs = read(paths.docs);
+const nativeContract = JSON.parse(read(paths.nativeContract));
+const nativeDocs = read(paths.nativeDocs);
 const plan = read(paths.plan);
 const backend = read(paths.backend);
 const manifest = read(paths.manifest);
 const leptosReadme = read(paths.leptosReadme);
 const leptosModel = read(paths.leptosModel);
 const leptosFacade = read(paths.leptosFacade);
+const leptosNative = read(paths.leptosNative);
 const leptosGraphql = read(paths.leptosGraphql);
 const leptosRoot = read(paths.leptosRoot);
 const leptosUi = read(paths.leptosUi);
@@ -86,6 +94,16 @@ assert.equal(contract.compatibility.backend_owner_changed, false);
 assert.equal(contract.compatibility.graphql_schema_changed, false);
 assert.equal(contract.compatibility.migration_added, false);
 
+assert.equal(nativeContract.contract, "forum_topic_merge_native_admin_v1");
+assert.equal(nativeContract.task, "FORUM-21O");
+assert.deepEqual(nativeContract.extends, ["FORUM-21N"]);
+assert.equal(nativeContract.transport_selection.ssr, "native_server");
+assert.equal(nativeContract.transport_selection.hydrate, "native_server");
+assert.equal(nativeContract.transport_selection.csr, "graphql");
+assert.equal(nativeContract.transport_selection.fallback, false);
+assert.equal(nativeContract.request_dto_policy.access_token, false);
+assert.equal(nativeContract.request_dto_policy.tenant_id, false);
+
 includesAll(
   backend,
   [
@@ -128,22 +146,37 @@ includesAll(
     "limit: 100",
     "execute_graphql",
   ],
-  "Leptos GraphQL adapter",
+  "Leptos GraphQL parity adapter",
 );
 assert.ok(!leptosGraphql.includes("reqwest"));
 assert.ok(!leptosGraphql.includes("rest_adapter"));
 assert.ok(!leptosGraphql.includes("#[server"));
 includesAll(
+  leptosNative,
+  [
+    "fetch_topic_merge_candidates_native",
+    "merge_topic_native",
+    "ForumTopicMergeService::new",
+    "TopicService::new",
+    "shared_get::<rustok_outbox::TransactionalEventBus>()",
+  ],
+  "Leptos native owner adapter",
+);
+assert.ok(!leptosNative.includes("token: Option<String>"));
+includesAll(
   leptosFacade,
   [
     "fetch_topic_merge_candidates",
-    "topic_merge_graphql_adapter::fetch_candidates",
     "pub async fn merge_topic(",
+    "execute_selected_transport",
+    "topic_merge_native_server_adapter::fetch_topic_merge_candidates_native",
+    "topic_merge_native_server_adapter::merge_topic_native",
+    "topic_merge_graphql_adapter::fetch_candidates",
     "topic_merge_graphql_adapter::merge_topic",
   ],
   "Leptos transport facade",
 );
-assert.ok(!leptosFacade.includes("native_server_adapter"));
+assert.ok(!leptosFacade.includes("fallback_failed"));
 includesAll(
   leptosRoot,
   ["subpath_matches(\"merge\")", "ForumTopicMergeAdmin", "super::leptos::ForumAdmin"],
@@ -161,14 +194,17 @@ includesAll(
   "Leptos merge UI",
 );
 assert.ok(!leptosUi.includes("graphql_adapter"));
+assert.ok(!leptosUi.includes("native_server_adapter"));
 assert.ok(!leptosUi.includes("ForumTopicMergeService"));
 assert.equal(leptosEn["forum.merge.title"], "Merge topics");
 assert.equal(leptosRu["forum.merge.title"], "Объединение тем");
 includesAll(
   leptosReadme,
   [
-    "single-adapter GraphQL state",
-    "does not pretend that a GraphQL call wrapped by a server function is a native owner path",
+    "FORUM-21O",
+    "ssr` and `hydrate` use native server functions",
+    "csr` and headless/default builds use GraphQL",
+    "never triggers cross-path fallback",
     "one operation ID stable across an exact retry",
   ],
   "Leptos package handoff",
@@ -249,14 +285,26 @@ includesAll(
     "never serializes that token into the client component",
     "No command above was run by the implementation agent",
   ],
-  "FORUM-21N handoff",
+  "historical FORUM-21N handoff",
 );
-assert.ok(plan.includes("### Delivered through `FORUM-21N`"));
+includesAll(
+  nativeDocs,
+  [
+    "# FORUM-21O native Leptos admin topic-merge transport",
+    paths.nativeContract,
+    "direct authenticated native server-function path",
+    "No command above was run by the implementation agent",
+  ],
+  "FORUM-21O extension handoff",
+);
+assert.ok(
+  plan.includes("### Delivered through `FORUM-21N`") ||
+    plan.includes("### Delivered through `FORUM-21O`"),
+);
 assert.ok(plan.includes("admin topic merge workflow"));
-assert.ok(plan.includes("direct authenticated Leptos native server-function owner composition"));
 assert.ok(plan.includes("| `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |"));
 assert.ok(!plan.includes("| `FORUM-21` | `done` |"));
 
 console.log(
-  "FORUM-21N admin topic merge workflow source is ready; native owner parity and FORUM-21 completion remain pending.",
+  "FORUM-21N admin topic merge UI remains source-ready and is extended by FORUM-21O native Leptos transport selection; FORUM-21 completion remains pending.",
 );

--- a/scripts/verify/verify-forum-topic-merge-native-admin.mjs
+++ b/scripts/verify/verify-forum-topic-merge-native-admin.mjs
@@ -45,6 +45,12 @@ assert.equal(contract.transport_selection.hydrate, "native_server");
 assert.equal(contract.transport_selection.csr, "graphql");
 assert.equal(contract.transport_selection.headless_default, "graphql");
 assert.equal(contract.transport_selection.fallback, false);
+assert.equal(contract.native_server.module_slug, "forum");
+assert.equal(
+  contract.native_server.module_lifecycle_check,
+  "rustok_api::is_tenant_module_enabled",
+);
+assert.equal(contract.native_server.module_must_be_enabled, true);
 assert.equal(contract.native_server.candidate_limit, 100);
 assert.equal(contract.native_server.candidate_permission, "forum_topics:list");
 assert.equal(contract.native_server.merge_permission, "forum_topics:manage");
@@ -115,6 +121,8 @@ includesAll(
     "leptos_axum::extract::<rustok_api::AuthContext>()",
     "leptos_axum::extract::<rustok_api::TenantContext>()",
     "auth.tenant_id == tenant.id",
+    "require_forum_module_enabled",
+    "rustok_api::is_tenant_module_enabled(host.db(), tenant_id, \"forum\")",
     "Permission::FORUM_TOPICS_LIST",
     "Permission::FORUM_TOPICS_MANAGE",
     "shared_get::<rustok_outbox::TransactionalEventBus>()",
@@ -181,6 +189,8 @@ includesAll(
     paths.contract,
     "direct authenticated native server-function path",
     "never causes an implicit retry through the other transport",
+    "rustok_api::is_tenant_module_enabled(..., \"forum\")",
+    "A disabled module therefore fails closed",
     "No native DTO accepts an access token",
     "No command above was run by the implementation agent",
   ],

--- a/scripts/verify/verify-forum-topic-merge-native-admin.mjs
+++ b/scripts/verify/verify-forum-topic-merge-native-admin.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const paths = {
+  contract: "crates/rustok-forum/contracts/forum-topic-merge-native-admin.json",
+  docs: "crates/rustok-forum/docs/forum-21o-topic-merge-native-admin.md",
+  readme: "crates/rustok-forum/admin/README.md",
+  packageCargo: "crates/rustok-forum/admin/Cargo.toml",
+  hostCargo: "apps/admin/Cargo.toml",
+  facade: "crates/rustok-forum/admin/src/transport.rs",
+  native:
+    "crates/rustok-forum/admin/src/transport/topic_merge_native_server_adapter.rs",
+  graphql:
+    "crates/rustok-forum/admin/src/transport/topic_merge_graphql_adapter.rs",
+  ui: "crates/rustok-forum/admin/src/ui/topic_merge.rs",
+};
+
+const read = (path) => readFileSync(path, "utf8");
+const includesAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(text.includes(marker), `${label} is missing marker: ${marker}`);
+  }
+};
+
+const contract = JSON.parse(read(paths.contract));
+const docs = read(paths.docs);
+const readme = read(paths.readme);
+const packageCargo = read(paths.packageCargo);
+const hostCargo = read(paths.hostCargo);
+const facade = read(paths.facade);
+const native = read(paths.native);
+const graphql = read(paths.graphql);
+const ui = read(paths.ui);
+
+assert.equal(contract.contract, "forum_topic_merge_native_admin_v1");
+assert.equal(contract.task, "FORUM-21O");
+assert.equal(contract.parent_task, "FORUM-21");
+assert.deepEqual(contract.extends, ["FORUM-21N"]);
+assert.equal(contract.status, "source_ready_maintainer_execution_pending");
+assert.equal(contract.canonical_plan_status, "planned");
+assert.equal(contract.transport_selection.ssr, "native_server");
+assert.equal(contract.transport_selection.hydrate, "native_server");
+assert.equal(contract.transport_selection.csr, "graphql");
+assert.equal(contract.transport_selection.headless_default, "graphql");
+assert.equal(contract.transport_selection.fallback, false);
+assert.equal(contract.native_server.candidate_limit, 100);
+assert.equal(contract.native_server.candidate_permission, "forum_topics:list");
+assert.equal(contract.native_server.merge_permission, "forum_topics:manage");
+assert.equal(contract.native_server.auth_tenant_must_equal_routed_tenant, true);
+assert.equal(contract.request_dto_policy.access_token, false);
+assert.equal(contract.request_dto_policy.tenant_id, false);
+assert.equal(contract.request_dto_policy.actor_id, false);
+assert.equal(contract.graphql_parity.csr_and_headless_only, true);
+assert.equal(contract.compatibility.owner_changed, false);
+assert.equal(contract.compatibility.graphql_schema_changed, false);
+assert.equal(contract.compatibility.migration_added, false);
+assert.equal(contract.compatibility.next_admin_changed, false);
+
+includesAll(
+  packageCargo,
+  [
+    'csr = ["leptos/csr"]',
+    'hydrate = ["leptos/hydrate"]',
+    '"leptos/ssr"',
+    '"dep:leptos_axum"',
+    '"rustok-api/server"',
+    '"dep:rustok-core"',
+    '"dep:rustok-forum"',
+    '"dep:rustok-outbox"',
+    'rustok-ui-transport.workspace = true',
+    'rustok-forum = { path = "..", optional = true }',
+  ],
+  "Forum admin Cargo features",
+);
+assert.ok(!packageCargo.includes('leptos = { workspace = true, features = ["csr"] }'));
+
+includesAll(
+  hostCargo,
+  [
+    '"rustok-forum-admin/csr"',
+    '"rustok-forum-admin/hydrate"',
+    '"rustok-forum-admin/ssr"',
+  ],
+  "apps/admin feature forwarding",
+);
+
+includesAll(
+  facade,
+  [
+    "mod topic_merge_native_server_adapter;",
+    "selected_topic_merge_transport_path",
+    'cfg(any(feature = "ssr", feature = "hydrate"))',
+    "UiTransportPath::NativeServer",
+    "UiTransportPath::Graphql",
+    "execute_selected_transport",
+    "topic_merge_native_server_adapter::fetch_topic_merge_candidates_native",
+    "topic_merge_native_server_adapter::merge_topic_native",
+    "topic_merge_graphql_adapter::fetch_candidates",
+    "topic_merge_graphql_adapter::merge_topic",
+  ],
+  "Forum merge transport facade",
+);
+assert.ok(!facade.includes("or_else"));
+assert.ok(!facade.includes("fallback_failed"));
+
+includesAll(
+  native,
+  [
+    '#[server(prefix = "/api/fn", endpoint = "forum/topic-merge-candidates")]',
+    '#[server(prefix = "/api/fn", endpoint = "forum/topic-merge")]',
+    "fetch_topic_merge_candidates_native(\n    locale: String,",
+    "merge_topic_native(\n    command: ForumTopicMergeCommand,",
+    "leptos_axum::extract::<rustok_api::AuthContext>()",
+    "leptos_axum::extract::<rustok_api::TenantContext>()",
+    "auth.tenant_id == tenant.id",
+    "Permission::FORUM_TOPICS_LIST",
+    "Permission::FORUM_TOPICS_MANAGE",
+    "shared_get::<rustok_outbox::TransactionalEventBus>()",
+    "TopicService::new",
+    "list_with_locale_fallback",
+    "per_page: 100",
+    "ForumTopicMergeService::new",
+    "merge_topic_resolving_solution",
+    ".merge_topic(tenant.id",
+    "SecurityContext::from_permission_snapshot",
+    "map_receipt",
+  ],
+  "Forum native merge adapter",
+);
+assert.ok(!native.includes("token: Option<String>"));
+assert.ok(!native.includes("tenant_id: String"));
+assert.ok(!native.includes("execute_graphql"));
+assert.ok(!native.includes("GraphqlRequest"));
+
+includesAll(
+  graphql,
+  [
+    "MERGE_CANDIDATES_QUERY",
+    "MERGE_TOPIC_MUTATION",
+    "MERGE_TOPIC_RESOLVING_SOLUTION_MUTATION",
+    "mergeForumTopic(",
+    "mergeForumTopicResolvingSolution(",
+    "limit: 100",
+    "execute_graphql",
+  ],
+  "retained Forum GraphQL parity adapter",
+);
+
+includesAll(
+  ui,
+  [
+    "transport::fetch_topic_merge_candidates",
+    "transport::merge_topic",
+    "build_forum_topic_merge_command",
+  ],
+  "Forum merge UI facade usage",
+);
+assert.ok(!ui.includes("topic_merge_native_server_adapter"));
+assert.ok(!ui.includes("topic_merge_graphql_adapter"));
+assert.ok(!ui.includes("ForumTopicMergeService"));
+
+includesAll(
+  readme,
+  [
+    "FORUM-21O",
+    "ssr` and `hydrate` use native server functions",
+    "csr` and headless/default builds use GraphQL",
+    "never triggers cross-path fallback",
+    paths.native,
+  ],
+  "Forum admin README",
+);
+
+includesAll(
+  docs,
+  [
+    "# FORUM-21O native Leptos admin topic-merge transport",
+    "`source_ready_maintainer_execution_pending`",
+    paths.contract,
+    "direct authenticated native server-function path",
+    "never causes an implicit retry through the other transport",
+    "No native DTO accepts an access token",
+    "No command above was run by the implementation agent",
+  ],
+  "FORUM-21O handoff",
+);
+
+console.log(
+  "FORUM-21O native Leptos topic-merge transport source is ready; maintainer runtime evidence and remaining FORUM-21 workflows are pending.",
+);


### PR DESCRIPTION
## Summary

Continue the canonical FORUM-21 improvement line with source-ready `FORUM-21O`.

### Native Leptos composition

- add direct authenticated server-function endpoints for bounded merge candidates and topic merge execution;
- resolve `AuthContext`, `TenantContext`, `HostRuntimeContext` and `TransactionalEventBus` only on the server;
- require the Forum tenant module to be enabled before entering either native owner path;
- require exact auth/routed tenant agreement plus `forum_topics:list` for candidates and `forum_topics:manage` for merge execution;
- call the existing `TopicService` and `ForumTopicMergeService` directly without wrapping GraphQL in a server function;
- preserve ordinary merge and explicit accepted-solution resolution receipts.

### Deterministic transport selection

- use native server functions for `ssr` and `hydrate` builds;
- retain the existing GraphQL query/mutations for `csr` and headless/default builds;
- return failures from the selected path without cross-transport fallback;
- keep tokens, tenant IDs, actor IDs, permission snapshots and runtime handles out of native request DTOs.

### Host and contracts

- propagate `rustok-forum-admin/{csr,hydrate,ssr}` from `apps/admin`;
- add the FORUM-21O machine contract, handoff document and focused static verifier;
- reconcile the historical FORUM-21N verifier and Forum package documentation with the native extension;
- keep canonical `FORUM-21` status `planned` pending maintainer runtime evidence and split/fork/range workflows.

## Compatibility

- no Forum owner method, GraphQL schema, REST route, receipt, semantic event or migration change;
- no Next-admin behavior change;
- no automatic native-to-GraphQL fallback.

## Validation

Tests, verifiers, formatters, Cargo checks, browser execution, workflows and CI were not run, per maintainer request.