### PR TITLE
test(index): retain drift finding PostgreSQL lifecycle

### DIFF
--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-03.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-03.md
@@ -1,0 +1,107 @@
+# Current `rustok-index` implementation plan — 2026-08-03
+
+Status overlay for `implementation-plan.md` audited at
+`main@e66540bceffe0ae23ee2d04e0f39a1a6ab08aaeb`.
+
+When the older canonical plan's current-state bullets conflict with this dated overlay, this
+overlay is the rechecked source of truth. Historical architecture, ownership, and milestone
+details remain in `implementation-plan.md`.
+
+## Current cursor
+
+`M6 - bounded drift diagnosis and repair admission`
+
+Bounded finding inspection and persistence for already-computed digest mismatches are source
+complete. Authoritative digest production, lifecycle commands, targeted repair, transports, and
+retained evidence remain open.
+
+## Rechecked status
+
+- M0 reset and M1 domain/application core: `complete`
+- M2 JSONB storage decision and replacement benchmark packet: `complete`
+- M3 production storage/evidence tooling: `source_complete_owner_execution_pending`
+- M4 query planning/compiler/runtime and privacy shadow: `source_complete_owner_execution_pending`
+- M5 inbox deduplication and monotonic source versions: `complete`
+- M5 mutation event registry and commit-before-ack orchestration:
+  `source_complete_broker_wiring_pending`
+- M5/M6 bounded source replay contract: `source_complete_owner_execution_pending`
+- M6 one-page replay and durable checkpoint progression: `source_complete`
+- M6 replay jobs, attempt fencing, multi-page execution, cancellation, and reconciliation:
+  `source_complete_owner_execution_pending`
+- M6 replay operator composition and authorization: `source_complete_owner_execution_pending`
+- M6 bounded replay interruption, source timeout, and no-write dry-run:
+  `source_complete_owner_execution_pending`
+- M6 reconciliation retry, dead-letter, recovery, and generic host scheduling:
+  `source_complete_owner_execution_pending`
+- M6 bounded drift-finding inspection and persistence:
+  `source_complete_owner_execution_pending`
+- M7 Product/ProductVariant/SalesChannel bounded replay graph:
+  `source_complete_owner_execution_pending`
+
+## M5 incremental ingestion
+
+- [x] Add a source replay registry with bounded failure classification.
+- [x] Add inbox deduplication and monotonic source versions.
+- [x] Add a database-neutral mutation-source event registry and commit-before-ack orchestration.
+- [ ] Register production owner event routes and compose a concrete broker consumer/acknowledger.
+- [ ] Add batch transactions, retry classification, bounded backoff, dead-letter state, and lag
+      metrics around production event routes.
+- [ ] Retain crash-between-commit-and-ack and redelivery evidence.
+
+## M6 rebuild, reconciliation, and repair
+
+- [x] Add bounded source scan/targeted-load contracts and stable replay event identities.
+- [x] Add durable replay jobs, leases, heartbeats, attempt fences, and checkpoint progression.
+- [x] Add bounded multi-page replay, durable cancellation, and bounded multi-pass reconciliation.
+- [x] Add production source-call timeouts, bounded no-write dry-run, and cooperative page
+      interruption safe points.
+- [ ] Bind interruption to active runner lease/cancellation state and already-pending futures.
+- [ ] Add targeted, full, and shadow rebuild modes.
+- [x] Add bounded retry/backoff transitions, failed-scope dead-letter admission/inspection,
+      authorized requeue, and generic host scheduling ownership.
+- [ ] Retain multi-host scheduler, retry/dead-letter, restart, graceful-shutdown, and command-
+      transport evidence.
+- [ ] Add locale/partition replay checkpoint dimensions.
+- [x] Add bounded drift-finding inspection and persistence for already-computed digest mismatches.
+- [x] Add a real-migration PostgreSQL harness for deterministic finding-key serialization and
+      create/refresh/reopen/suppression lifecycle preservation.
+- [ ] Run and admit `drift_finding_writer_postgres_test` evidence.
+- [ ] Add authoritative digest production under a defined owner snapshot or watermark.
+- [ ] Add missing/stale entity and orphan-link diagnosis without unbounded ID collection.
+- [ ] Add resolve/ignore lifecycle commands with actor/reason audit and fail-closed authorization.
+- [ ] Add targeted repair with before/after admitted evidence.
+
+## M7 production graph and cutover
+
+- [x] Add Product, ProductVariant, and SalesChannel schemas and bounded current-state sources.
+- [x] Add stable Product/ProductVariant/SalesChannel replay identities and retained deletes.
+- [x] Add Product-to-ProductVariant graph materialization.
+- [ ] Add production owner event routes and concrete incremental consumer wiring.
+- [ ] Persist and enforce per-tenant schema readiness.
+- [ ] Complete durable Product-to-SalesChannel relation semantics and retained evidence.
+- [ ] Admit tombstone purge, freshness/outage/restart/backlog recovery, and delete/recreate evidence.
+- [ ] Admit live PostgreSQL/reference query equivalence and one full partition packet.
+- [ ] Keep authoritative consumer and production partition cutover forbidden until admission.
+
+## Next implementation step
+
+Define a bounded producer contract that computes exactly one authoritative source/index digest
+pair for an exact tenant/schema/entity scope under one admitted consistency boundary. Delegate
+only unequal SHA-256 digests to the existing writer. Keep diagnosis separate from lifecycle
+commands and repair execution.
+
+## Owner verification for this slice
+
+```bash
+RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
+  cargo test -p rustok-index \
+  --test drift_finding_writer_postgres_test \
+  -- --nocapture --test-threads=1
+
+node scripts/verify/verify-index-drift-finding-postgres-harness.mjs
+cargo check -p rustok-index --all-targets
+git diff --check
+```
+
+No tests, verifiers, formatting, Cargo checks, PostgreSQL runs, workflows, or CI were executed by
+the implementation agent.

--- a/crates/rustok-index/docs/implementation-recheck-2026-08-03.md
+++ b/crates/rustok-index/docs/implementation-recheck-2026-08-03.md
@@ -1,0 +1,66 @@
+# `rustok-index` implementation recheck — 2026-08-03
+
+## Audited baseline
+
+- Repository: `RusTokRs/RusTok`
+- Target branch: `main`
+- Audited commit: `e66540bceffe0ae23ee2d04e0f39a1a6ab08aaeb`
+- Validation owner: repository maintainer
+
+The source tree, current canonical plan, recent Index pull-request history, and still-open
+PostgreSQL evidence pull requests were rechecked. Tests, verifiers, formatting, Cargo commands,
+PostgreSQL execution, workflows, and CI were not run, per maintainer instruction.
+
+## Corrected merged state
+
+The canonical plan understated several source-complete M5/M6 slices already present on
+`main`:
+
+- source-versioned mutation event acknowledgement substrate;
+- production source-call timeout classification;
+- bounded no-write replay dry-run;
+- cooperative replay page interruption safe points;
+- reconciliation retry transition storage and runner wiring;
+- failed-scope dead-letter admission, bounded inspection, and authorized requeue;
+- generic bounded reconciliation host scheduling ownership;
+- bounded drift-finding inspection and persistence for already-computed digest mismatches.
+
+Those capabilities remain narrower than their former combined checklist bullets. In
+particular, cooperative interruption is not yet bound to the active PostgreSQL runner lease,
+dry-run does not provide targeted/full/shadow rebuild modes, and scheduling does not establish
+retained multi-host or graceful-shutdown evidence.
+
+## Continued slice
+
+This branch adds an environment-gated PostgreSQL lifecycle harness for the drift-finding
+writer. It uses the real Index migrations and independent PostgreSQL connections to retain:
+
+- advisory-lock serialization for one tenant/finding key;
+- one stable finding identity across create and refresh;
+- exact bounded entity-scope and digest storage;
+- resolved-to-open reopen semantics;
+- ignored-state suppression preservation;
+- tenant-separated deterministic finding identities.
+
+The harness is source-ready only. No execution or retained evidence is claimed until the
+repository owner runs and admits it.
+
+## Remaining open work
+
+- produce and compare authoritative source/index digests under a defined snapshot or watermark;
+- diagnose missing entities, stale entities, and orphan links without unbounded ID collection;
+- bind cooperative interruption to active runner cancellation and deadlines;
+- add targeted/full/shadow rebuild and repair modes;
+- add finding resolve/ignore commands with actor/reason audit and fail-closed authorization;
+- retain before/after repair, retry/dead-letter, scheduler, restart, and multi-instance evidence;
+- add locale/partition checkpoint dimensions, graceful shutdown, and authorized transports;
+- complete incremental acknowledgement evidence, persisted per-tenant readiness, durable
+  Product-to-SalesChannel relation evidence, consumer cutover, query equivalence, and partition
+  admission execution.
+
+## Next implementation cursor
+
+Define the bounded producer contract that computes one authoritative source/index digest pair
+for an exact tenant/schema/entity scope and calls the existing writer only after both digests
+are available under the same admitted consistency boundary. Keep repair and lifecycle commands
+separate from diagnosis.

--- a/crates/rustok-index/docs/implementation-recheck-2026-08-03.md
+++ b/crates/rustok-index/docs/implementation-recheck-2026-08-03.md
@@ -8,8 +8,10 @@
 - Validation owner: repository maintainer
 
 The source tree, current canonical plan, recent Index pull-request history, and still-open
-PostgreSQL evidence pull requests were rechecked. Tests, verifiers, formatting, Cargo commands,
-PostgreSQL execution, workflows, and CI were not run, per maintainer instruction.
+PostgreSQL evidence pull requests were rechecked. The dated
+`implementation-plan-current-2026-08-03.md` overlay records the corrected current checklist
+without rewriting historical architecture and evidence sections. Tests, verifiers, formatting,
+Cargo commands, PostgreSQL execution, workflows, and CI were not run, per maintainer instruction.
 
 ## Corrected merged state
 

--- a/crates/rustok-index/docs/m6-drift-finding-postgres-harness.md
+++ b/crates/rustok-index/docs/m6-drift-finding-postgres-harness.md
@@ -1,0 +1,66 @@
+# M6 drift-finding PostgreSQL lifecycle harness
+
+## Purpose
+
+This slice retains an environment-gated PostgreSQL integration target for the bounded
+`PostgresIndexDriftFindingWriter` added in PR #2959. It verifies the production migration
+shape and transaction semantics without claiming that the source/index digest producer,
+repair admission, or an operator transport exists.
+
+## Executable boundary
+
+The target lives at:
+
+```text
+crates/rustok-index/tests/drift_finding_writer_postgres_test.rs
+```
+
+It reads `RUSTOK_INDEX_TEST_DATABASE_URL`, with PostgreSQL `DATABASE_URL` as a fallback.
+When no PostgreSQL URL is available, the target reports a skip and succeeds.
+
+For every invocation the harness:
+
+1. creates an isolated PostgreSQL schema;
+2. creates the tenant-owner fixture table;
+3. applies every real `IndexModule` migration;
+4. uses two independent connections to race the same deterministic finding key;
+5. requires one `Created` and one `Refreshed` result with one retained row;
+6. verifies exact tenant, key, check, severity, entity scope, digest, and bounded-details fields;
+7. refreshes an open finding without changing its identity;
+8. reopens a resolved finding and clears `closed_at`;
+9. refreshes an ignored finding while preserving suppression;
+10. proves the same logical scope under another tenant derives another key and row;
+11. drops the isolated schema after successful assertions.
+
+The concurrent first write retains advisory-lock serialization on PostgreSQL rather than the
+SQLite contract fixture. The lifecycle transitions read production columns directly and
+require deterministic identity preservation across refresh, reopen, and suppression.
+
+## Deliberate limits
+
+This harness does not add or claim:
+
+- a source/index digest producer or comparator;
+- owner snapshot or high-watermark semantics;
+- orphan-link or missing-entity diagnosis;
+- automatic finding resolution when digests converge;
+- ignore/resolve commands, actor/reason audit, or repair authorization;
+- targeted, full, or shadow repair execution;
+- GraphQL, HTTP, CLI, admin, or scheduler invocation;
+- retained execution evidence until the repository owner runs and admits the target.
+
+## Owner verification
+
+```bash
+RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
+  cargo test -p rustok-index \
+  --test drift_finding_writer_postgres_test \
+  -- --nocapture --test-threads=1
+
+node scripts/verify/verify-index-drift-finding-postgres-harness.mjs
+cargo check -p rustok-index --all-targets
+git diff --check
+```
+
+Tests, verifiers, formatting, Cargo checks, PostgreSQL execution, workflows, and CI were not
+run by the implementation agent, per maintainer instruction.

--- a/crates/rustok-index/tests/drift_finding_writer_postgres_test.rs
+++ b/crates/rustok-index/tests/drift_finding_writer_postgres_test.rs
@@ -1,0 +1,363 @@
+use std::{env, error::Error};
+
+use rustok_core::MigrationSource;
+use rustok_index::{
+    EntityName, IndexModule, LocaleKey, ModuleName, SchemaRef, SchemaVersion,
+    infrastructure::postgres::{
+        IndexDriftDigestFindingRequest, IndexDriftFindingScope, IndexDriftFindingSeverity,
+        IndexDriftFindingWriteOutcome, PostgresIndexDriftFindingWriter,
+    },
+};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, QueryResult,
+    Statement,
+};
+use sea_orm_migration::SchemaManager;
+use serde_json::{Value as JsonValue, json};
+use uuid::Uuid;
+
+const DATABASE_ENV: &str = "RUSTOK_INDEX_TEST_DATABASE_URL";
+const CHECK_NAME: &str = "source_index_digest_mismatch";
+const DETAILS_CONTRACT: &str = "index_drift_digest_finding_v1";
+const DIGEST_BYTES: usize = 64;
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+struct TestDatabase {
+    control: DatabaseConnection,
+    database_url: String,
+    schema_name: String,
+    tenant_id: Uuid,
+}
+
+impl TestDatabase {
+    async fn setup() -> TestResult<Option<Self>> {
+        let Some(database_url) = database_url() else {
+            eprintln!(
+                "{DATABASE_ENV} is not set to a PostgreSQL URL; skipping drift-finding writer harness"
+            );
+            return Ok(None);
+        };
+        let control = connect(&database_url).await?;
+        let schema_name = format!(
+            "rustok_index_drift_finding_writer_{}",
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let tenant_id = Uuid::new_v4();
+        let db = scoped_connection(&database_url, &schema_name).await?;
+        db.execute_unprepared("CREATE TABLE tenants (id UUID NOT NULL PRIMARY KEY)")
+            .await?;
+        insert_tenant(&db, tenant_id).await?;
+
+        let manager = SchemaManager::new(&db);
+        for migration in IndexModule.migrations() {
+            migration.up(&manager).await?;
+        }
+
+        Ok(Some(Self {
+            control,
+            database_url,
+            schema_name,
+            tenant_id,
+        }))
+    }
+
+    async fn connection(&self) -> TestResult<DatabaseConnection> {
+        scoped_connection(&self.database_url, &self.schema_name).await
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct FindingEvidence {
+    finding_id: Uuid,
+    finding_key: String,
+    check_name: String,
+    severity: String,
+    state: String,
+    scope_kind: String,
+    module_name: String,
+    entity_name: String,
+    schema_version: i64,
+    entity_id: Uuid,
+    locale_key: String,
+    expected_digest: String,
+    actual_digest: String,
+    details: JsonValue,
+    closed: bool,
+}
+
+#[tokio::test]
+async fn writer_serializes_identity_and_preserves_lifecycle_on_postgres() -> TestResult<()> {
+    let Some(database) = TestDatabase::setup().await? else {
+        return Ok(());
+    };
+    let scope = entity_scope();
+    let first_request = request(database.tenant_id, scope.clone(), 'b');
+
+    let writer_a = PostgresIndexDriftFindingWriter::new(database.connection().await?);
+    let writer_b = PostgresIndexDriftFindingWriter::new(database.connection().await?);
+    let (first, second) = tokio::join!(
+        writer_a.record_digest_mismatch(&first_request),
+        writer_b.record_digest_mismatch(&first_request),
+    );
+    let first = first?;
+    let second = second?;
+    assert!(matches!(
+        (&first, &second),
+        (
+            IndexDriftFindingWriteOutcome::Created { .. },
+            IndexDriftFindingWriteOutcome::Refreshed { .. }
+        ) | (
+            IndexDriftFindingWriteOutcome::Refreshed { .. },
+            IndexDriftFindingWriteOutcome::Created { .. }
+        )
+    ));
+    assert_eq!(first.finding_id(), second.finding_id());
+    assert_eq!(first.finding_key(), second.finding_key());
+
+    let evidence_db = database.connection().await?;
+    let created = read_finding(&evidence_db, database.tenant_id).await?;
+    assert_eq!(created.finding_id, first.finding_id());
+    assert_eq!(created.finding_key, first.finding_key());
+    assert_eq!(created.check_name, CHECK_NAME);
+    assert_eq!(created.severity, "error");
+    assert_eq!(created.state, "open");
+    assert_eq!(created.scope_kind, "entity");
+    assert_eq!(created.module_name, "rustok-product");
+    assert_eq!(created.entity_name, "product");
+    assert_eq!(created.schema_version, 2);
+    assert_eq!(created.entity_id, scope_entity_id(&scope));
+    assert_eq!(created.locale_key, "en-US");
+    assert_eq!(created.expected_digest, "a".repeat(DIGEST_BYTES));
+    assert_eq!(created.actual_digest, "b".repeat(DIGEST_BYTES));
+    assert_eq!(created.details, json!({ "contract": DETAILS_CONTRACT }));
+    assert!(!created.closed);
+    assert_eq!(count_findings(&evidence_db, database.tenant_id).await?, 1);
+
+    let refreshed = PostgresIndexDriftFindingWriter::new(database.connection().await?)
+        .record_digest_mismatch(&request(database.tenant_id, scope.clone(), 'c'))
+        .await?;
+    assert!(matches!(
+        refreshed,
+        IndexDriftFindingWriteOutcome::Refreshed { .. }
+    ));
+    assert_eq!(refreshed.finding_id(), created.finding_id);
+    let refreshed_row = read_finding(&evidence_db, database.tenant_id).await?;
+    assert_eq!(refreshed_row.actual_digest, "c".repeat(DIGEST_BYTES));
+    assert_eq!(refreshed_row.state, "open");
+
+    set_state(
+        &evidence_db,
+        database.tenant_id,
+        created.finding_id,
+        "resolved",
+    )
+    .await?;
+    let reopened = PostgresIndexDriftFindingWriter::new(database.connection().await?)
+        .record_digest_mismatch(&request(database.tenant_id, scope.clone(), 'd'))
+        .await?;
+    assert!(matches!(
+        reopened,
+        IndexDriftFindingWriteOutcome::Reopened { .. }
+    ));
+    assert_eq!(reopened.finding_id(), created.finding_id);
+    let reopened_row = read_finding(&evidence_db, database.tenant_id).await?;
+    assert_eq!(reopened_row.state, "open");
+    assert!(!reopened_row.closed);
+    assert_eq!(reopened_row.actual_digest, "d".repeat(DIGEST_BYTES));
+
+    set_state(
+        &evidence_db,
+        database.tenant_id,
+        created.finding_id,
+        "ignored",
+    )
+    .await?;
+    let suppressed = PostgresIndexDriftFindingWriter::new(database.connection().await?)
+        .record_digest_mismatch(&request(database.tenant_id, scope.clone(), 'e'))
+        .await?;
+    assert!(matches!(
+        suppressed,
+        IndexDriftFindingWriteOutcome::Suppressed { .. }
+    ));
+    assert_eq!(suppressed.finding_id(), created.finding_id);
+    let ignored_row = read_finding(&evidence_db, database.tenant_id).await?;
+    assert_eq!(ignored_row.state, "ignored");
+    assert!(ignored_row.closed);
+    assert_eq!(ignored_row.actual_digest, "e".repeat(DIGEST_BYTES));
+    assert_eq!(count_findings(&evidence_db, database.tenant_id).await?, 1);
+
+    let other_tenant = Uuid::new_v4();
+    insert_tenant(&evidence_db, other_tenant).await?;
+    let other = PostgresIndexDriftFindingWriter::new(database.connection().await?)
+        .record_digest_mismatch(&request(other_tenant, scope, 'b'))
+        .await?;
+    assert!(matches!(other, IndexDriftFindingWriteOutcome::Created { .. }));
+    assert_ne!(other.finding_key(), created.finding_key);
+    assert_eq!(count_findings(&evidence_db, other_tenant).await?, 1);
+    assert_eq!(count_all_findings(&evidence_db).await?, 2);
+
+    database.cleanup().await
+}
+
+fn entity_scope() -> IndexDriftFindingScope {
+    IndexDriftFindingScope::Entity {
+        schema: SchemaRef {
+            module: ModuleName::new("rustok-product").unwrap(),
+            entity: EntityName::new("product").unwrap(),
+            version: SchemaVersion::new(2),
+        },
+        entity_id: Uuid::new_v4(),
+        locale: LocaleKey::new("en-US").unwrap(),
+    }
+}
+
+fn scope_entity_id(scope: &IndexDriftFindingScope) -> Uuid {
+    match scope {
+        IndexDriftFindingScope::Entity { entity_id, .. } => *entity_id,
+        _ => panic!("fixture scope must be entity-scoped"),
+    }
+}
+
+fn request(
+    tenant_id: Uuid,
+    scope: IndexDriftFindingScope,
+    actual: char,
+) -> IndexDriftDigestFindingRequest {
+    IndexDriftDigestFindingRequest::new(
+        tenant_id,
+        CHECK_NAME,
+        IndexDriftFindingSeverity::Error,
+        scope,
+        "a".repeat(DIGEST_BYTES),
+        actual.to_string().repeat(DIGEST_BYTES),
+    )
+    .expect("fixture mismatch request must be valid")
+}
+
+async fn insert_tenant(db: &DatabaseConnection, tenant_id: Uuid) -> TestResult<()> {
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "INSERT INTO tenants (id) VALUES ($1)",
+        vec![tenant_id.into()],
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn read_finding(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+) -> TestResult<FindingEvidence> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT finding_id, finding_key, check_name, severity, state, scope_kind, module_name, entity_name, schema_version::bigint AS schema_version_value, entity_id, locale_key, expected_digest, actual_digest, details, (closed_at IS NOT NULL) AS closed FROM index_consistency_findings WHERE tenant_id = $1 ORDER BY first_detected_at, finding_id LIMIT 1",
+            vec![tenant_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("drift finding row is missing"))?;
+    finding_evidence(row)
+}
+
+fn finding_evidence(row: QueryResult) -> TestResult<FindingEvidence> {
+    Ok(FindingEvidence {
+        finding_id: row.try_get("", "finding_id")?,
+        finding_key: row.try_get("", "finding_key")?,
+        check_name: row.try_get("", "check_name")?,
+        severity: row.try_get("", "severity")?,
+        state: row.try_get("", "state")?,
+        scope_kind: row.try_get("", "scope_kind")?,
+        module_name: row.try_get("", "module_name")?,
+        entity_name: row.try_get("", "entity_name")?,
+        schema_version: row.try_get("", "schema_version_value")?,
+        entity_id: row.try_get("", "entity_id")?,
+        locale_key: row.try_get("", "locale_key")?,
+        expected_digest: row.try_get("", "expected_digest")?,
+        actual_digest: row.try_get("", "actual_digest")?,
+        details: row.try_get("", "details")?,
+        closed: row.try_get("", "closed")?,
+    })
+}
+
+async fn set_state(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    finding_id: Uuid,
+    state: &str,
+) -> TestResult<()> {
+    let updated = db
+        .execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "UPDATE index_consistency_findings SET state = $3, closed_at = CURRENT_TIMESTAMP WHERE tenant_id = $1 AND finding_id = $2",
+            vec![tenant_id.into(), finding_id.into(), state.to_owned().into()],
+        ))
+        .await?;
+    if updated.rows_affected() != 1 {
+        return Err(std::io::Error::other("drift finding lifecycle update lost scope").into());
+    }
+    Ok(())
+}
+
+async fn count_findings(db: &DatabaseConnection, tenant_id: Uuid) -> TestResult<i64> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT COUNT(*)::bigint AS value FROM index_consistency_findings WHERE tenant_id = $1",
+            vec![tenant_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("tenant finding count returned no row"))?;
+    Ok(row.try_get("", "value")?)
+}
+
+async fn count_all_findings(db: &DatabaseConnection) -> TestResult<i64> {
+    let row = db
+        .query_one(Statement::from_string(
+            DbBackend::Postgres,
+            "SELECT COUNT(*)::bigint AS value FROM index_consistency_findings".to_owned(),
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("finding count returned no row"))?;
+    Ok(row.try_get("", "value")?)
+}
+
+fn database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn scoped_connection(
+    database_url: &str,
+    schema_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url).await?;
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}""#))
+        .await?;
+    Ok(db)
+}

--- a/scripts/verify/verify-index-drift-finding-postgres-harness.mjs
+++ b/scripts/verify/verify-index-drift-finding-postgres-harness.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+
+const files = {
+  test: "crates/rustok-index/tests/drift_finding_writer_postgres_test.rs",
+  doc: "crates/rustok-index/docs/m6-drift-finding-postgres-harness.md",
+  recheck: "crates/rustok-index/docs/implementation-recheck-2026-08-03.md",
+  plan: "crates/rustok-index/docs/implementation-plan.md",
+};
+
+const [test, doc, recheck, plan] = await Promise.all(
+  Object.values(files).map((path) => readFile(path, "utf8")),
+);
+
+const requiredTestMarkers = [
+  'const DATABASE_ENV: &str = "RUSTOK_INDEX_TEST_DATABASE_URL";',
+  "for migration in IndexModule.migrations()",
+  "tokio::join!(",
+  "IndexDriftFindingWriteOutcome::Created",
+  "IndexDriftFindingWriteOutcome::Refreshed",
+  "IndexDriftFindingWriteOutcome::Reopened",
+  "IndexDriftFindingWriteOutcome::Suppressed",
+  "PostgresIndexDriftFindingWriter::new",
+  "count_all_findings",
+  'DROP SCHEMA IF EXISTS',
+];
+
+const requiredDocMarkers = [
+  "advisory-lock serialization",
+  "retained execution evidence until the repository owner runs",
+  "--test drift_finding_writer_postgres_test",
+];
+
+const requiredPlanMarkers = [
+  "M6 bounded replay interruption, timeout, and dry-run",
+  "M6 reconciliation retry, dead-letter, and host scheduling",
+  "M6 bounded drift-finding inspection and persistence",
+  "Add bounded drift-finding inspection and persistence for already-computed digest mismatches.",
+  "Add authoritative digest production, orphan diagnosis, finding lifecycle commands, targeted repair, and admitted repair evidence.",
+  "drift_finding_writer_postgres_test",
+];
+
+function requireMarkers(label, content, markers) {
+  for (const marker of markers) {
+    if (!content.includes(marker)) {
+      throw new Error(`${label} is missing required marker: ${marker}`);
+    }
+  }
+}
+
+requireMarkers(files.test, test, requiredTestMarkers);
+requireMarkers(files.doc, doc, requiredDocMarkers);
+requireMarkers(files.plan, plan, requiredPlanMarkers);
+requireMarkers(files.recheck, recheck, [
+  "Audited commit: `e66540bceffe0ae23ee2d04e0f39a1a6ab08aaeb`",
+  "The harness is source-ready only.",
+  "Define the bounded producer contract",
+]);
+
+const forbiddenClaims = [
+  "tests passed",
+  "PostgreSQL execution passed",
+  "retained evidence admitted",
+  "repair is complete",
+];
+for (const claim of forbiddenClaims) {
+  if (doc.toLowerCase().includes(claim.toLowerCase()) || recheck.toLowerCase().includes(claim.toLowerCase())) {
+    throw new Error(`documentation makes forbidden execution claim: ${claim}`);
+  }
+}
+
+if (!plan.includes("- [ ] Add authoritative digest production")) {
+  throw new Error("canonical plan must keep complete drift diagnosis and repair open");
+}
+
+console.log("Index drift-finding PostgreSQL harness contract verified");

--- a/scripts/verify/verify-index-drift-finding-postgres-harness.mjs
+++ b/scripts/verify/verify-index-drift-finding-postgres-harness.mjs
@@ -1,13 +1,12 @@
 #!/usr/bin/env node
 
 import { readFile } from "node:fs/promises";
-import process from "node:process";
 
 const files = {
   test: "crates/rustok-index/tests/drift_finding_writer_postgres_test.rs",
   doc: "crates/rustok-index/docs/m6-drift-finding-postgres-harness.md",
   recheck: "crates/rustok-index/docs/implementation-recheck-2026-08-03.md",
-  plan: "crates/rustok-index/docs/implementation-plan.md",
+  plan: "crates/rustok-index/docs/implementation-plan-current-2026-08-03.md",
 };
 
 const [test, doc, recheck, plan] = await Promise.all(
@@ -34,11 +33,11 @@ const requiredDocMarkers = [
 ];
 
 const requiredPlanMarkers = [
-  "M6 bounded replay interruption, timeout, and dry-run",
-  "M6 reconciliation retry, dead-letter, and host scheduling",
+  "M6 bounded replay interruption, source timeout, and no-write dry-run",
+  "M6 reconciliation retry, dead-letter, recovery, and generic host scheduling",
   "M6 bounded drift-finding inspection and persistence",
   "Add bounded drift-finding inspection and persistence for already-computed digest mismatches.",
-  "Add authoritative digest production, orphan diagnosis, finding lifecycle commands, targeted repair, and admitted repair evidence.",
+  "Add authoritative digest production under a defined owner snapshot or watermark.",
   "drift_finding_writer_postgres_test",
 ];
 
@@ -66,13 +65,16 @@ const forbiddenClaims = [
   "repair is complete",
 ];
 for (const claim of forbiddenClaims) {
-  if (doc.toLowerCase().includes(claim.toLowerCase()) || recheck.toLowerCase().includes(claim.toLowerCase())) {
+  if (
+    doc.toLowerCase().includes(claim.toLowerCase()) ||
+    recheck.toLowerCase().includes(claim.toLowerCase())
+  ) {
     throw new Error(`documentation makes forbidden execution claim: ${claim}`);
   }
 }
 
 if (!plan.includes("- [ ] Add authoritative digest production")) {
-  throw new Error("canonical plan must keep complete drift diagnosis and repair open");
+  throw new Error("current plan overlay must keep complete drift diagnosis and repair open");
 }
 
 console.log("Index drift-finding PostgreSQL harness contract verified");


### PR DESCRIPTION
## Summary

- recheck the current `rustok-index` implementation against `main@e66540bceffe0ae23ee2d04e0f39a1a6ab08aaeb` and recent merged Index slices;
- publish a dated current-plan overlay that corrects stale M5/M6 status without rewriting historical architecture and evidence sections;
- distinguish source-complete mutation acknowledgement, timeout, dry-run, interruption, retry/dead-letter/recovery, scheduling, and bounded drift-finding work from still-open owner evidence and repair admission;
- add an environment-gated PostgreSQL lifecycle harness for `PostgresIndexDriftFindingWriter` using every real `IndexModule` migration;
- race two independent connections on one deterministic tenant/finding key and require one `Created` plus one `Refreshed` outcome with one retained identity;
- verify exact bounded entity scope, digest evidence, open refresh, resolved-to-open reopen, ignored-state suppression, and tenant isolation;
- add focused documentation and a fail-closed static verifier.

## Plan recheck

The older canonical plan understated source-complete work already merged into `main`. The dated overlay records the corrected state:

- the M5 mutation event registry and commit-before-ack substrate are source complete, while production owner routes, broker composition, and retained commit/ack evidence remain open;
- source timeouts, bounded no-write dry-run, and cooperative page interruption are source complete, while active-lease binding, pending-future interruption, and targeted/full/shadow modes remain open;
- retry transitions, failed-scope dead-letter admission/inspection, authorized requeue, and generic host scheduling are source complete, while multi-host, graceful-shutdown, transport, and retained scheduler evidence remain open;
- bounded drift-finding inspection and persistence are source complete for already-computed digest mismatches, while authoritative digest production, orphan diagnosis, lifecycle commands, targeted repair, and admitted repair evidence remain open.

## PostgreSQL harness

The target is:

```text
crates/rustok-index/tests/drift_finding_writer_postgres_test.rs
```

It reads `RUSTOK_INDEX_TEST_DATABASE_URL`, with PostgreSQL `DATABASE_URL` as a fallback. Without a PostgreSQL URL it reports a skip and succeeds.

For one isolated schema it:

1. creates the tenant owner fixture;
2. applies every real Index migration;
3. uses two independent connections to race the same deterministic finding key;
4. requires one created and one refreshed outcome with the same UUID/key and one retained row;
5. verifies exact check, severity, entity scope, schema version, locale, SHA-256 digests, and bounded details contract;
6. refreshes the open finding without changing identity;
7. reopens a resolved finding and clears `closed_at`;
8. refreshes an ignored finding without reopening it;
9. verifies the same logical scope under another tenant produces another key and row;
10. drops the isolated schema after successful assertions.

## Deliberate limits

This PR does not add or claim:

- a source/index digest producer or comparator;
- snapshot/high-watermark semantics;
- missing/stale entity or orphan-link diagnosis;
- automatic resolution when digests converge;
- finding resolve/ignore commands or actor/reason audit;
- targeted, full, or shadow repair execution;
- GraphQL, HTTP, CLI, admin, scheduler, or graceful-shutdown invocation;
- retained PostgreSQL evidence until the repository owner runs and admits the target.

## Validation

Not run per maintainer instruction:

- formatting;
- Cargo checks, tests, or Clippy;
- JavaScript verifier;
- PostgreSQL harness;
- workflows and CI.

Suggested maintainer commands:

```bash
RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
  cargo test -p rustok-index \
  --test drift_finding_writer_postgres_test \
  -- --nocapture --test-threads=1

node scripts/verify/verify-index-drift-finding-postgres-harness.mjs
cargo check -p rustok-index --all-targets
git diff --check
```

The branch was created from `main@e66540bceffe0ae23ee2d04e0f39a1a6ab08aaeb`. Current `main` advanced by one unrelated Forum commit after branch creation; the final diff is add-only and limited to five Index files.