### PR TITLE
fix(payment): bound collection owner error mapping

### DIFF
--- a/crates/rustok-payment/contracts/evidence/payment-collection-owner-error-diagnostic-safety-source.json
+++ b/crates/rustok-payment/contracts/evidence/payment-collection-owner-error-diagnostic-safety-source.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-08-03",
+  "status": "payment_collection_owner_error_diagnostic_safety_source_unvalidated",
+  "scope": "PaymentCollectionPort canonical PaymentError mapping only",
+  "source_contract": {
+    "payment_error_variant_count": 11,
+    "complete_payment_error_logged": false,
+    "database_error_text_logged": false,
+    "validation_text_logged": false,
+    "transition_text_logged": false,
+    "provider_id_text_logged": false,
+    "provider_operation_text_logged": false,
+    "raw_context_values_logged": false,
+    "static_error_variant_logged": true,
+    "text_field_shape_logged": true,
+    "uuid_field_shape_logged": true,
+    "opaque_database_payload_presence_logged": true,
+    "correlation_preserved": true,
+    "owner_operations_preserved": true,
+    "severity_split_preserved": true,
+    "static_not_found_public_messages": true,
+    "public_codes_kinds_retryability_preserved": true,
+    "collection_flow_changed": false,
+    "admission_mapper_changed": false,
+    "tenant_parser_changed": false,
+    "commerce_orchestration_changed": false,
+    "ffa_promoted": false,
+    "fba_promoted": false
+  },
+  "suggested_execution": [
+    "node scripts/verify/verify-payment-collection-owner-error-diagnostic-safety.mjs",
+    "node scripts/verify/verify-payment-collection-tenant-context.mjs",
+    "node scripts/verify/verify-payment-collection-admission-context.mjs",
+    "node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs",
+    "node --test scripts/verify/verify-ecommerce-public-port-error-safety-v2.test.mjs",
+    "cargo check -p rustok-payment --lib"
+  ],
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "runtime_proven": false
+  }
+}

--- a/crates/rustok-payment/docs/payment-collection-admission-context.md
+++ b/crates/rustok-payment/docs/payment-collection-admission-context.md
@@ -1,153 +1,54 @@
-# Payment collection owner admission diagnostic safety
+# Payment collection admission diagnostic safety
 
 Status: **source-ready / unvalidated**
 
 ## Scope
 
-This bounded source slice hardens only admission diagnostics in
-`PaymentCollectionPort`:
+This source-only contract covers read-policy admission for payment collection status and write
+policy plus write-semantics admission for collection create/reuse.
 
-- `create_or_reuse_collection` write-policy admission;
-- `create_or_reuse_collection` write-semantics admission;
-- `read_collection_status` read-policy admission.
-
-The public operations, policy selection, write-semantics requirement, tenant parsing, owner
-service calls, and public `PortError` behavior remain unchanged.
-
-## Preserved admission flow
-
-`create_or_reuse_collection` still evaluates:
-
-1. write policy;
-2. write semantics;
-3. tenant parsing;
-4. reusable collection lookup and owner execution.
-
-`read_collection_status` still evaluates:
-
-1. read policy;
-2. tenant parsing;
-3. owner status read.
-
-The exact original admission `PortError` continues through `inspect_err` unchanged. The
-diagnostic helper does not construct a replacement code, message, kind, or retryability value.
+Admission remains before tenant parsing and owner work. Read operations do not require write
+semantics; create/reuse retains policy-before-write-semantics ordering.
 
 ## Bounded diagnostic policy
 
-Admission diagnostics retain only bounded context and message-shape facts.
+Admission diagnostics retain only bounded context and message-shape facts: truthful owner, exact
+operation and admission phase, correlation, actor kind, identity/text lengths, optional-field
+presence, claim/role counts, deadline, stable code, message presence/length, closed error kind,
+retryability, and boundary.
 
-The helper records one closed error-kind label:
+They do not record complete `PortError` payloads, raw context values, internal message text, or Debug
+kind output. Technical admission failures remain error severity; ordinary rejections remain warning
+severity.
 
-- `validation`;
-- `not_found`;
-- `conflict`;
-- `forbidden`;
-- `unavailable`;
-- `timeout`;
-- `invariant_violation`.
+The exact original admission `PortError` continues through `inspect_err` unchanged.
 
-Both severity paths retain:
+## Related source-only contracts
 
-- truthful owner `rustok_payment`;
-- exact owner operation;
-- exact admission phase `policy` or `write_semantics`;
-- boundary `payment_collection_port`;
-- correlation id;
-- stable original error code and retryability;
-- internal-message presence and character length;
-- tenant-id and actor-id character lengths;
-- closed actor-kind label;
-- claim and role counts;
-- channel presence and optional character length;
-- locale character length;
-- causation-id, traceparent, and idempotency-key presence plus optional character lengths;
-- optional deadline milliseconds.
+Tenant UUID parsing and canonical `payment_error_to_port_error` are now closed by separate
+source-only contracts:
 
-The helper does not record the complete admission `PortError`, human-readable internal message,
-raw tenant, actor, channel, locale, causation, traceparent, or idempotency values, or Debug
-`PortErrorKind` output.
+- tenant verifier: `scripts/verify/verify-payment-collection-tenant-context.mjs`;
+- owner mapper verifier: `scripts/verify/verify-payment-collection-owner-error-diagnostic-safety.mjs`.
 
-## Preserved severity
-
-Unavailable, timeout, and invariant-violation failures continue through `tracing::error!`.
-Validation, not-found, conflict, forbidden, and other ordinary admission rejections continue
-through `tracing::warn!`.
+The owner mapper contract also replaces identifier-bearing collection/payment/refund not-found
+messages with static public envelopes while preserving codes, kinds, and retryability.
 
 ## Preserved behavior
 
-This slice does not change:
+No trait, DTO, collection lookup/create/race adoption/status flow, owner service call, tenant
+validation envelope, provider execution, persistence, checkout/compensation consumer, Commerce
+orchestration, or FFA/FBA status is changed by this admission contract.
 
-- public `PaymentCollectionPort` trait signatures;
-- create/reuse or status request and response DTOs;
-- canonical owner operation selection;
-- read/write policy selection;
-- write-semantics requirements;
-- admission-before-tenant-parsing ordering;
-- tenant UUID validation envelope;
-- reusable collection lookup, create, or race-adoption behavior;
-- collection status reads or snapshot conversion;
-- `PaymentError` variant mapping;
-- provider, lifecycle, reconciliation, configuration, or database public envelopes;
-- checkout execution or compensation consumers;
-- Commerce orchestration;
-- ecommerce audit, Payment FFA, or Payment FBA status.
-
-## Static evidence
-
-The focused guard is:
-
-- `scripts/verify/verify-payment-collection-admission-context.mjs`.
-
-It requires:
-
-- one read and one write admission helper;
-- three preserved diagnostic call sites through `inspect_err`;
-- exact owner-operation and admission-phase attribution;
-- the closed error-kind classification;
-- bounded message and delegated-context facts;
-- technical-versus-ordinary severity;
-- original-error pass-through and admission-before-tenant ordering;
-- unchanged collection lookup, create, adoption, status-read, and snapshot behavior;
-- absence of complete errors, raw context values, raw message text, and Debug kind output inside
-  the covered helper.
-
-Source evidence is recorded in:
-
-- `crates/rustok-payment/contracts/evidence/payment-collection-admission-diagnostic-safety-source.json`.
-
-The evidence remains source-only: `execution` is empty and every validation flag is false.
-
-## Related tenant contract
-
-Tenant UUID parsing is now closed by a separate source-only contract:
-
-- verifier: `scripts/verify/verify-payment-collection-tenant-context.mjs`;
-- evidence:
-  `crates/rustok-payment/contracts/evidence/payment-collection-tenant-diagnostic-safety-source.json`;
-- documentation: `crates/rustok-payment/docs/payment-collection-tenant-context.md`.
-
-That contract replaces the complete parse error, complete constructed `PortError`, raw delegated
-context, internal message text, and Debug kind output with type/shape-only facts while preserving
-the same parser call sites and validation envelope. It does not change the admission mapper
-covered here.
-
-## Remaining diagnostic boundary
-
-Canonical `payment_error_to_port_error` remains the next open collection boundary. It still
-contains raw validation and transition text, provider identifiers and operations, database errors,
-raw tenant values, and public not-found messages that interpolate owner UUIDs.
-
-Compile, runtime, replay, restart, remote-port parity, workflows, CI, and production evidence
-remain open. The broad ecommerce correlation-safe mapper cleanup remains open, and no FFA/FBA
-status is promoted.
+Execution evidence remains empty; compile, verifier, runtime, replay, restart, remote-port,
+workflow, CI, and production evidence remain open.
 
 ## Suggested maintainer checks
-
-These commands were intentionally not run by the implementation agent:
 
 ```bash
 node scripts/verify/verify-payment-collection-admission-context.mjs
 node scripts/verify/verify-payment-collection-tenant-context.mjs
+node scripts/verify/verify-payment-collection-owner-error-diagnostic-safety.mjs
 node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
 cargo check -p rustok-payment --lib
 ```

--- a/crates/rustok-payment/docs/payment-collection-admission-context.md
+++ b/crates/rustok-payment/docs/payment-collection-admission-context.md
@@ -1,49 +1,150 @@
-# Payment collection admission diagnostic safety
+# Payment collection owner admission diagnostic safety
 
 Status: **source-ready / unvalidated**
 
 ## Scope
 
-This source-only contract covers read-policy admission for payment collection status and write
-policy plus write-semantics admission for collection create/reuse.
+This bounded source slice hardens only admission diagnostics in
+`PaymentCollectionPort`:
 
-Admission remains before tenant parsing and owner work. Read operations do not require write
-semantics; create/reuse retains policy-before-write-semantics ordering.
+- `create_or_reuse_collection` write-policy admission;
+- `create_or_reuse_collection` write-semantics admission;
+- `read_collection_status` read-policy admission.
+
+The public operations, policy selection, write-semantics requirement, tenant parsing, owner
+service calls, and public `PortError` behavior remain unchanged.
+
+## Preserved admission flow
+
+`create_or_reuse_collection` still evaluates:
+
+1. write policy;
+2. write semantics;
+3. tenant parsing;
+4. reusable collection lookup and owner execution.
+
+`read_collection_status` still evaluates:
+
+1. read policy;
+2. tenant parsing;
+3. owner status read.
+
+The exact original admission `PortError` continues through `inspect_err` unchanged. The
+diagnostic helper does not construct a replacement code, message, kind, or retryability value.
 
 ## Bounded diagnostic policy
 
-Admission diagnostics retain only bounded context and message-shape facts: truthful owner, exact
-operation and admission phase, correlation, actor kind, identity/text lengths, optional-field
-presence, claim/role counts, deadline, stable code, message presence/length, closed error kind,
-retryability, and boundary.
+Admission diagnostics retain only bounded context and message-shape facts.
 
-They do not record complete `PortError` payloads, raw context values, internal message text, or Debug
-kind output. Technical admission failures remain error severity; ordinary rejections remain warning
-severity.
+The helper records one closed error-kind label:
 
-The exact original admission `PortError` continues through `inspect_err` unchanged.
+- `validation`;
+- `not_found`;
+- `conflict`;
+- `forbidden`;
+- `unavailable`;
+- `timeout`;
+- `invariant_violation`.
 
-## Related source-only contracts
+Both severity paths retain:
+
+- truthful owner `rustok_payment`;
+- exact owner operation;
+- exact admission phase `policy` or `write_semantics`;
+- boundary `payment_collection_port`;
+- correlation id;
+- stable original error code and retryability;
+- internal-message presence and character length;
+- tenant-id and actor-id character lengths;
+- closed actor-kind label;
+- claim and role counts;
+- channel presence and optional character length;
+- locale character length;
+- causation-id, traceparent, and idempotency-key presence plus optional character lengths;
+- optional deadline milliseconds.
+
+The helper does not record the complete admission `PortError`, human-readable internal message,
+raw tenant, actor, channel, locale, causation, traceparent, or idempotency values, or Debug
+`PortErrorKind` output.
+
+## Preserved severity
+
+Unavailable, timeout, and invariant-violation failures continue through `tracing::error!`.
+Validation, not-found, conflict, forbidden, and other ordinary admission rejections continue
+through `tracing::warn!`.
+
+## Preserved behavior
+
+This slice does not change:
+
+- public `PaymentCollectionPort` trait signatures;
+- create/reuse or status request and response DTOs;
+- canonical owner operation selection;
+- read/write policy selection;
+- write-semantics requirements;
+- admission-before-tenant-parsing ordering;
+- tenant UUID validation envelope;
+- reusable collection lookup, create, or race-adoption behavior;
+- collection status reads or snapshot conversion;
+- provider, lifecycle, reconciliation, configuration, or database public kinds/retryability;
+- checkout execution or compensation consumers;
+- Commerce orchestration;
+- ecommerce audit, Payment FFA, or Payment FBA status.
+
+## Static evidence
+
+The focused guard is:
+
+- `scripts/verify/verify-payment-collection-admission-context.mjs`.
+
+It requires:
+
+- one read and one write admission helper;
+- three preserved diagnostic call sites through `inspect_err`;
+- exact owner-operation and admission-phase attribution;
+- the closed error-kind classification;
+- bounded message and delegated-context facts;
+- technical-versus-ordinary severity;
+- original-error pass-through and admission-before-tenant ordering;
+- unchanged collection lookup, create, adoption, status-read, and snapshot behavior;
+- absence of complete errors, raw context values, raw message text, and Debug kind output inside
+  the covered helper.
+
+Source evidence is recorded in:
+
+- `crates/rustok-payment/contracts/evidence/payment-collection-admission-diagnostic-safety-source.json`.
+
+The evidence remains source-only: `execution` is empty and every validation flag is false.
+
+## Related tenant and owner contracts
 
 Tenant UUID parsing and canonical `payment_error_to_port_error` are now closed by separate
 source-only contracts:
 
 - tenant verifier: `scripts/verify/verify-payment-collection-tenant-context.mjs`;
-- owner mapper verifier: `scripts/verify/verify-payment-collection-owner-error-diagnostic-safety.mjs`.
+- tenant evidence:
+  `crates/rustok-payment/contracts/evidence/payment-collection-tenant-diagnostic-safety-source.json`;
+- owner mapper verifier:
+  `scripts/verify/verify-payment-collection-owner-error-diagnostic-safety.mjs`;
+- owner mapper evidence:
+  `crates/rustok-payment/contracts/evidence/payment-collection-owner-error-diagnostic-safety-source.json`.
 
-The owner mapper contract also replaces identifier-bearing collection/payment/refund not-found
-messages with static public envelopes while preserving codes, kinds, and retryability.
+The tenant contract replaces the complete parse error, complete constructed `PortError`, raw
+delegated context, internal message text, and Debug kind output with type/shape-only facts while
+preserving parser call sites and the validation envelope.
 
-## Preserved behavior
+The owner mapper contract replaces raw validation/transition text, provider identifiers and
+operations, database errors, raw delegated context, and UUID-bearing public not-found messages with
+closed variant and aggregate shape facts plus static public envelopes. Stable codes, kinds,
+retryability, exact owner operations, and technical-versus-ordinary severity remain explicit.
 
-No trait, DTO, collection lookup/create/race adoption/status flow, owner service call, tenant
-validation envelope, provider execution, persistence, checkout/compensation consumer, Commerce
-orchestration, or FFA/FBA status is changed by this admission contract.
-
-Execution evidence remains empty; compile, verifier, runtime, replay, restart, remote-port,
-workflow, CI, and production evidence remain open.
+Compile, runtime, replay, restart, remote-port parity, workflows, CI, and production evidence
+remain open. The broad ecommerce correlation-safe mapper cleanup remains open, and no FFA/FBA
+status is promoted.
 
 ## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
 
 ```bash
 node scripts/verify/verify-payment-collection-admission-context.mjs

--- a/crates/rustok-payment/docs/payment-collection-owner-error-diagnostic-safety.md
+++ b/crates/rustok-payment/docs/payment-collection-owner-error-diagnostic-safety.md
@@ -1,0 +1,83 @@
+# Payment collection owner-error diagnostic safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This bounded source slice closes the canonical `payment_error_to_port_error` mapper used by
+`PaymentCollectionPort` create/reuse and status operations.
+
+The preceding source-only slices already bounded payment collection admission and tenant UUID
+rejection diagnostics. This slice changes only post-delegation `PaymentError` diagnostics and the
+three identifier-bearing not-found public messages.
+
+## Bounded diagnostic policy
+
+The mapper records only a closed variant and aggregate field shape:
+
+- the stable owner and exact owner operation;
+- correlation id and bounded `PortContext` presence/length/count facts;
+- one of eleven closed `PaymentError` variant labels;
+- text-field count and total character length;
+- UUID-field count and non-nil count;
+- opaque database-payload presence;
+- stable internal code and the payment collection boundary.
+
+It does not record the complete `PaymentError`, validation or transition text, provider identity or
+operation text, database details, owner UUIDs, or raw tenant/actor/channel/locale/causation/trace/
+idempotency values.
+
+Technical failures (`ProviderUnavailable`, invalid/unknown provider outcomes, provider
+configuration, and database failure) remain error severity. Validation, not-found, lifecycle
+conflict, and provider rejection use warning severity.
+
+## Public envelopes
+
+Payment collection not-found envelopes no longer interpolate owner UUIDs:
+
+- `payment.collection_not_found` → `payment collection was not found`;
+- `payment.payment_not_found` → `payment was not found`;
+- `payment.refund_not_found` → `refund was not found`.
+
+All public codes, kinds, retryability values, and the other existing static messages remain
+unchanged.
+
+## Preserved behavior
+
+This slice does not change:
+
+- `PaymentCollectionPort` traits or DTOs;
+- admission, tenant parsing, or their ordering;
+- reusable collection lookup, create, race adoption, or status reads;
+- owner service calls or snapshot conversion;
+- payment provider execution, reconciliation policy, or persistence;
+- checkout execution, compensation, or Commerce orchestration;
+- ecommerce audit, Payment FFA, or Payment FBA status.
+
+## Static evidence
+
+The focused guard is:
+
+- `scripts/verify/verify-payment-collection-owner-error-diagnostic-safety.mjs`.
+
+Source evidence is recorded in:
+
+- `crates/rustok-payment/contracts/evidence/payment-collection-owner-error-diagnostic-safety-source.json`.
+
+The aggregate ecommerce guard and its negative fixture are synchronized so raw Payment collection
+context or owner payloads fail closed instead of being treated as canonical.
+
+Execution evidence remains empty. Compile, verifier, runtime, replay, restart, remote-port,
+workflow, CI, and production evidence remain open. The broad ecommerce correlation-safe mapper
+cleanup remains open, and no FFA/FBA status is promoted.
+
+## Suggested maintainer checks
+
+```bash
+node scripts/verify/verify-payment-collection-owner-error-diagnostic-safety.mjs
+node scripts/verify/verify-payment-collection-tenant-context.mjs
+node scripts/verify/verify-payment-collection-admission-context.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+node --test scripts/verify/verify-ecommerce-public-port-error-safety-v2.test.mjs
+cargo check -p rustok-payment --lib
+```

--- a/crates/rustok-payment/docs/payment-collection-tenant-context.md
+++ b/crates/rustok-payment/docs/payment-collection-tenant-context.md
@@ -4,60 +4,133 @@ Status: **source-ready / unvalidated**
 
 ## Scope
 
-This source-only contract hardens invalid tenant UUID diagnostics in
-`PaymentCollectionPort::create_or_reuse_collection` and
-`PaymentCollectionPort::read_collection_status`.
+This bounded source slice hardens only invalid tenant UUID diagnostics in
+`PaymentCollectionPort`:
 
-Both operations still select their canonical owner operation, complete admission, and then call the
-same payment-owned tenant parser before any owner storage or service work.
+- `create_or_reuse_collection` tenant parsing;
+- `read_collection_status` tenant parsing.
+
+Both public operations continue to select their canonical owner operation and complete admission
+before invoking `parse_port_tenant_id`.
 
 ## Preserved parser flow
 
-The parser still calls `Uuid::parse_str(&context.tenant_id)`, constructs the same validation
-`PortError` on failure, emits one warning, and returns that same constructed error.
+The payment-owned parser still:
+
+1. calls `Uuid::parse_str(&context.tenant_id)`;
+2. enters the same `map_err` path on parse failure;
+3. constructs the exact same validation `PortError`;
+4. emits one warning diagnostic;
+5. returns that same constructed validation `PortError`.
 
 The validation envelope remains:
 
-- code `payment.tenant_id_invalid`;
-- message `PortContext.tenant_id must be a UUID for payment ports`;
-- validation kind and existing retryability.
+- kind: validation;
+- code: `payment.tenant_id_invalid`;
+- message: `PortContext.tenant_id must be a UUID for payment ports`;
+- retryability: unchanged.
 
-The same constructed validation `PortError` is returned after diagnostics.
+The same constructed validation `PortError` is returned after diagnostics. No replacement error is
+constructed after the warning event.
 
 ## Bounded diagnostic policy
 
-Tenant diagnostics retain only the parse-error type and bounded context/message-shape facts:
-correlation, exact owner operation, validation phase, actor kind, identity/text lengths, optional
-field presence, claim/role counts, deadline, stable code, message presence/length, closed kind, and
-boundary.
+Tenant diagnostics retain only the parse-error type and bounded context/message-shape facts.
 
-The parser does not record the complete parse error, the constructed `PortError`, raw context
-values, internal message text, or Debug kind output.
+The parser records:
 
-## Related source-only contracts
+- concrete parse-error type through `type_name_of_val`;
+- explicit `tenant_id_parse_failed = true`;
+- truthful owner `rustok_payment`;
+- exact owner operation;
+- validation phase `tenant_id`;
+- boundary `payment_collection_port`;
+- correlation id;
+- tenant-id and actor-id character lengths;
+- closed actor-kind label;
+- claim and role counts;
+- channel presence and optional character length;
+- locale character length;
+- causation-id, traceparent, and idempotency-key presence plus optional character lengths;
+- optional deadline milliseconds;
+- stable validation code and retryability;
+- internal-message presence and character length;
+- closed error-kind label `validation`.
 
-Admission diagnostics remain closed by
-`scripts/verify/verify-payment-collection-admission-context.mjs`.
+The parser does not record:
+
+- the complete UUID parse error;
+- the complete constructed `PortError`;
+- raw tenant, actor, channel, locale, causation, traceparent, or idempotency values;
+- human-readable internal message text;
+- Debug `PortErrorKind` output.
+
+## Preserved behavior
+
+This slice does not change:
+
+- public `PaymentCollectionPort` trait signatures;
+- create/reuse or status DTOs;
+- canonical owner-operation selection;
+- read/write admission or write-semantics behavior;
+- admission-before-tenant ordering;
+- the two operation-aware parser call sites;
+- reusable collection lookup, create, or race-adoption behavior;
+- collection status reads or snapshot conversion;
+- the admission diagnostic mapper closed by the preceding source slice;
+- provider, lifecycle, reconciliation, configuration, or database public kinds/retryability;
+- checkout execution or compensation consumers;
+- Commerce orchestration;
+- ecommerce audit, Payment FFA, or Payment FBA status.
+
+## Static evidence
+
+The focused guard is:
+
+- `scripts/verify/verify-payment-collection-tenant-context.mjs`.
+
+It requires:
+
+- exactly two operation-aware parser call sites;
+- operation selection and admission before tenant parsing;
+- tenant parsing before owner storage or service work;
+- exact validation code, message, kind, and retryability;
+- type-only parse cause and explicit parse-failure fact;
+- bounded context and message-shape facts;
+- one warning path followed by return of the same constructed error;
+- unchanged admission helpers and collection flow;
+- the separately closed canonical Payment owner mapper contract;
+- absence of complete parse errors, complete `PortError`, raw context, message text, and Debug kind
+  output inside the covered parser.
+
+Source evidence is recorded in:
+
+- `crates/rustok-payment/contracts/evidence/payment-collection-tenant-diagnostic-safety-source.json`.
+
+The evidence remains source-only: `execution` is empty and every validation flag is false.
+
+## Related owner mapper contract
 
 Canonical `payment_error_to_port_error` is now closed by a separate source-only contract:
 
 - verifier: `scripts/verify/verify-payment-collection-owner-error-diagnostic-safety.mjs`;
-- evidence: `crates/rustok-payment/contracts/evidence/payment-collection-owner-error-diagnostic-safety-source.json`;
-- documentation: `crates/rustok-payment/docs/payment-collection-owner-error-diagnostic-safety.md`.
+- evidence:
+  `crates/rustok-payment/contracts/evidence/payment-collection-owner-error-diagnostic-safety-source.json`;
+- documentation:
+  `crates/rustok-payment/docs/payment-collection-owner-error-diagnostic-safety.md`.
 
-The owner contract removes raw validation, transition, provider, database, context, and identifier
-payloads while preserving stable codes/kinds/retryability and using static not-found messages.
+That contract replaces raw validation/transition text, provider identifiers and operations,
+database errors, raw delegated context, and UUID-bearing public not-found messages with closed
+variant and aggregate shape facts plus static public envelopes. Stable codes, kinds, retryability,
+owner operations, and technical-versus-ordinary severity remain explicit.
 
-## Preserved behavior
-
-No trait, DTO, admission policy, collection lookup/create/race adoption/status behavior, provider
-execution, persistence, checkout/compensation consumer, Commerce orchestration, or FFA/FBA status is
-changed.
-
-Execution evidence remains empty; compile, verifier, runtime, replay, restart, remote-port,
-workflow, CI, and production evidence remain open.
+Compile, runtime, replay, restart, remote-port parity, workflows, CI, and production evidence
+remain open. The broad ecommerce correlation-safe mapper cleanup remains open, and no FFA/FBA
+status is promoted.
 
 ## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
 
 ```bash
 node scripts/verify/verify-payment-collection-tenant-context.mjs

--- a/crates/rustok-payment/docs/payment-collection-tenant-context.md
+++ b/crates/rustok-payment/docs/payment-collection-tenant-context.md
@@ -4,128 +4,64 @@ Status: **source-ready / unvalidated**
 
 ## Scope
 
-This bounded source slice hardens only invalid tenant UUID diagnostics in
-`PaymentCollectionPort`:
+This source-only contract hardens invalid tenant UUID diagnostics in
+`PaymentCollectionPort::create_or_reuse_collection` and
+`PaymentCollectionPort::read_collection_status`.
 
-- `create_or_reuse_collection` tenant parsing;
-- `read_collection_status` tenant parsing.
-
-Both public operations continue to select their canonical owner operation and complete admission
-before invoking `parse_port_tenant_id`.
+Both operations still select their canonical owner operation, complete admission, and then call the
+same payment-owned tenant parser before any owner storage or service work.
 
 ## Preserved parser flow
 
-The payment-owned parser still:
-
-1. calls `Uuid::parse_str(&context.tenant_id)`;
-2. enters the same `map_err` path on parse failure;
-3. constructs the exact same validation `PortError`;
-4. emits one warning diagnostic;
-5. returns that same constructed validation `PortError`.
+The parser still calls `Uuid::parse_str(&context.tenant_id)`, constructs the same validation
+`PortError` on failure, emits one warning, and returns that same constructed error.
 
 The validation envelope remains:
 
-- kind: validation;
-- code: `payment.tenant_id_invalid`;
-- message: `PortContext.tenant_id must be a UUID for payment ports`;
-- retryability: unchanged.
+- code `payment.tenant_id_invalid`;
+- message `PortContext.tenant_id must be a UUID for payment ports`;
+- validation kind and existing retryability.
 
-The same constructed validation `PortError` is returned after diagnostics. No replacement error is
-constructed after the warning event.
+The same constructed validation `PortError` is returned after diagnostics.
 
 ## Bounded diagnostic policy
 
-Tenant diagnostics retain only the parse-error type and bounded context/message-shape facts.
+Tenant diagnostics retain only the parse-error type and bounded context/message-shape facts:
+correlation, exact owner operation, validation phase, actor kind, identity/text lengths, optional
+field presence, claim/role counts, deadline, stable code, message presence/length, closed kind, and
+boundary.
 
-The parser records:
+The parser does not record the complete parse error, the constructed `PortError`, raw context
+values, internal message text, or Debug kind output.
 
-- concrete parse-error type through `type_name_of_val`;
-- explicit `tenant_id_parse_failed = true`;
-- truthful owner `rustok_payment`;
-- exact owner operation;
-- validation phase `tenant_id`;
-- boundary `payment_collection_port`;
-- correlation id;
-- tenant-id and actor-id character lengths;
-- closed actor-kind label;
-- claim and role counts;
-- channel presence and optional character length;
-- locale character length;
-- causation-id, traceparent, and idempotency-key presence plus optional character lengths;
-- optional deadline milliseconds;
-- stable validation code and retryability;
-- internal-message presence and character length;
-- closed error-kind label `validation`.
+## Related source-only contracts
 
-The parser does not record:
+Admission diagnostics remain closed by
+`scripts/verify/verify-payment-collection-admission-context.mjs`.
 
-- the complete UUID parse error;
-- the complete constructed `PortError`;
-- raw tenant, actor, channel, locale, causation, traceparent, or idempotency values;
-- human-readable internal message text;
-- Debug `PortErrorKind` output.
+Canonical `payment_error_to_port_error` is now closed by a separate source-only contract:
+
+- verifier: `scripts/verify/verify-payment-collection-owner-error-diagnostic-safety.mjs`;
+- evidence: `crates/rustok-payment/contracts/evidence/payment-collection-owner-error-diagnostic-safety-source.json`;
+- documentation: `crates/rustok-payment/docs/payment-collection-owner-error-diagnostic-safety.md`.
+
+The owner contract removes raw validation, transition, provider, database, context, and identifier
+payloads while preserving stable codes/kinds/retryability and using static not-found messages.
 
 ## Preserved behavior
 
-This slice does not change:
+No trait, DTO, admission policy, collection lookup/create/race adoption/status behavior, provider
+execution, persistence, checkout/compensation consumer, Commerce orchestration, or FFA/FBA status is
+changed.
 
-- public `PaymentCollectionPort` trait signatures;
-- create/reuse or status DTOs;
-- canonical owner-operation selection;
-- read/write admission or write-semantics behavior;
-- admission-before-tenant ordering;
-- the two operation-aware parser call sites;
-- reusable collection lookup, create, or race-adoption behavior;
-- collection status reads or snapshot conversion;
-- the admission diagnostic mapper closed by the preceding source slice;
-- canonical `PaymentError` variant mapping;
-- provider, lifecycle, reconciliation, configuration, or database public envelopes;
-- checkout execution or compensation consumers;
-- Commerce orchestration;
-- ecommerce audit, Payment FFA, or Payment FBA status.
-
-## Static evidence
-
-The focused guard is:
-
-- `scripts/verify/verify-payment-collection-tenant-context.mjs`.
-
-It requires:
-
-- exactly two operation-aware parser call sites;
-- operation selection and admission before tenant parsing;
-- tenant parsing before owner storage or service work;
-- exact validation code, message, kind, and retryability;
-- type-only parse cause and explicit parse-failure fact;
-- bounded context and message-shape facts;
-- one warning path followed by return of the same constructed error;
-- unchanged admission helpers and collection flow;
-- explicit preservation of the canonical Payment mapper as a separate open boundary;
-- absence of complete parse errors, complete `PortError`, raw context, message text, and Debug kind
-  output inside the covered parser.
-
-Source evidence is recorded in:
-
-- `crates/rustok-payment/contracts/evidence/payment-collection-tenant-diagnostic-safety-source.json`.
-
-The evidence remains source-only: `execution` is empty and every validation flag is false.
-
-## Remaining diagnostic boundary
-
-Canonical `payment_error_to_port_error` remains the next separate cleanup slice. It still contains
-raw validation and transition text, provider identifiers and operations, database errors, raw
-tenant values, and public not-found messages that interpolate owner UUIDs.
-
-Compile, runtime, replay, restart, remote-port parity, workflows, CI, and production evidence
-remain open. The broad ecommerce correlation-safe mapper cleanup remains open, and no FFA/FBA
-status is promoted.
+Execution evidence remains empty; compile, verifier, runtime, replay, restart, remote-port,
+workflow, CI, and production evidence remain open.
 
 ## Suggested maintainer checks
 
-These commands were intentionally not run by the implementation agent:
-
 ```bash
 node scripts/verify/verify-payment-collection-tenant-context.mjs
+node scripts/verify/verify-payment-collection-owner-error-diagnostic-safety.mjs
 node scripts/verify/verify-payment-collection-admission-context.mjs
 node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
 cargo check -p rustok-payment --lib

--- a/crates/rustok-payment/src/ports.rs
+++ b/crates/rustok-payment/src/ports.rs
@@ -370,154 +370,303 @@ fn parse_port_tenant_id(
     })
 }
 
+#[derive(Debug)]
+struct PaymentCollectionOwnerErrorFacts {
+    error_variant: &'static str,
+    text_field_count: usize,
+    text_total_length: usize,
+    uuid_field_count: usize,
+    uuid_non_nil_count: usize,
+    opaque_payload_present: bool,
+}
+
+fn payment_collection_owner_error_facts(
+    error: &crate::PaymentError,
+) -> PaymentCollectionOwnerErrorFacts {
+    let (
+        error_variant,
+        text_field_count,
+        text_total_length,
+        uuid_field_count,
+        uuid_non_nil_count,
+        opaque_payload_present,
+    ) = match error {
+        crate::PaymentError::Validation(value) => {
+            ("validation", 1, value.chars().count(), 0, 0, false)
+        }
+        crate::PaymentError::PaymentCollectionNotFound(id) => (
+            "payment_collection_not_found",
+            0,
+            0,
+            1,
+            if id.is_nil() { 0 } else { 1 },
+            false,
+        ),
+        crate::PaymentError::PaymentNotFound(id) => (
+            "payment_not_found",
+            0,
+            0,
+            1,
+            if id.is_nil() { 0 } else { 1 },
+            false,
+        ),
+        crate::PaymentError::RefundNotFound(id) => (
+            "refund_not_found",
+            0,
+            0,
+            1,
+            if id.is_nil() { 0 } else { 1 },
+            false,
+        ),
+        crate::PaymentError::InvalidTransition { from, to } => (
+            "invalid_transition",
+            2,
+            from.chars().count() + to.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        crate::PaymentError::ProviderUnavailable {
+            provider_id,
+            operation,
+        } => (
+            "provider_unavailable",
+            2,
+            provider_id.chars().count() + operation.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        crate::PaymentError::ProviderRejected {
+            provider_id,
+            operation,
+        } => (
+            "provider_rejected",
+            2,
+            provider_id.chars().count() + operation.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        crate::PaymentError::ProviderInvalidResponse {
+            provider_id,
+            operation,
+        } => (
+            "provider_invalid_response",
+            2,
+            provider_id.chars().count() + operation.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        crate::PaymentError::ProviderOutcomeUnknown {
+            provider_id,
+            operation,
+        } => (
+            "provider_outcome_unknown",
+            2,
+            provider_id.chars().count() + operation.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        crate::PaymentError::ProviderConfiguration { provider_id } => (
+            "provider_configuration",
+            1,
+            provider_id.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        crate::PaymentError::Database(_) => ("database", 0, 0, 0, 0, true),
+    };
+
+    PaymentCollectionOwnerErrorFacts {
+        error_variant,
+        text_field_count,
+        text_total_length,
+        uuid_field_count,
+        uuid_non_nil_count,
+        opaque_payload_present,
+    }
+}
+
+fn payment_collection_owner_error_code(error: &crate::PaymentError) -> &'static str {
+    match error {
+        crate::PaymentError::Validation(_) => "payment.validation",
+        crate::PaymentError::PaymentCollectionNotFound(_) => "payment.collection_not_found",
+        crate::PaymentError::PaymentNotFound(_) => "payment.payment_not_found",
+        crate::PaymentError::RefundNotFound(_) => "payment.refund_not_found",
+        crate::PaymentError::InvalidTransition { .. } => "payment.invalid_transition",
+        crate::PaymentError::ProviderUnavailable { .. } => "payment.provider_unavailable",
+        crate::PaymentError::ProviderRejected { .. } => "payment.provider_rejected",
+        crate::PaymentError::ProviderInvalidResponse { .. } => {
+            "payment.provider_invalid_response"
+        }
+        crate::PaymentError::ProviderOutcomeUnknown { .. } => {
+            "payment.provider_outcome_unknown"
+        }
+        crate::PaymentError::ProviderConfiguration { .. } => "payment.provider_not_configured",
+        crate::PaymentError::Database(_) => "payment.database_unavailable",
+    }
+}
+
+fn payment_collection_owner_error_is_technical(error: &crate::PaymentError) -> bool {
+    matches!(
+        error,
+        crate::PaymentError::ProviderUnavailable { .. }
+            | crate::PaymentError::ProviderInvalidResponse { .. }
+            | crate::PaymentError::ProviderOutcomeUnknown { .. }
+            | crate::PaymentError::ProviderConfiguration { .. }
+            | crate::PaymentError::Database(_)
+    )
+}
+
 fn payment_error_to_port_error(
     context: &PortContext,
     owner_operation: &'static str,
     error: crate::PaymentError,
 ) -> PortError {
+    let code = payment_collection_owner_error_code(&error);
+    let technical_failure = payment_collection_owner_error_is_technical(&error);
+    let error_facts = payment_collection_owner_error_facts(&error);
+    let actor_kind = match &context.actor.kind {
+        rustok_api::PortActorKind::User => "user",
+        rustok_api::PortActorKind::Service => "service",
+        rustok_api::PortActorKind::System => "system",
+    };
+    let tenant_id_length = context.tenant_id.chars().count();
+    let actor_id_length = context.actor.id.chars().count();
+    let claim_count = context.claims.len();
+    let role_count = context.roles.len();
+    let channel_present = context.channel.is_some();
+    let channel_length = context.channel.as_ref().map(|value| value.chars().count());
+    let locale_length = context.locale.chars().count();
+    let causation_id_present = context.causation_id.is_some();
+    let causation_id_length = context
+        .causation_id
+        .as_ref()
+        .map(|value| value.chars().count());
+    let traceparent_present = context.traceparent.is_some();
+    let traceparent_length = context
+        .traceparent
+        .as_ref()
+        .map(|value| value.chars().count());
+    let idempotency_key_present = context.idempotency_key.is_some();
+    let idempotency_key_length = context
+        .idempotency_key
+        .as_ref()
+        .map(|value| value.chars().count());
+
+    if technical_failure {
+        tracing::error!(
+            owner = PAYMENT_COLLECTION_OWNER,
+            owner_error_variant = error_facts.error_variant,
+            owner_error_text_field_count = error_facts.text_field_count,
+            owner_error_text_total_length = error_facts.text_total_length,
+            owner_error_uuid_field_count = error_facts.uuid_field_count,
+            owner_error_uuid_non_nil_count = error_facts.uuid_non_nil_count,
+            owner_error_opaque_payload_present = error_facts.opaque_payload_present,
+            correlation_id = %context.correlation_id,
+            tenant_id_length,
+            actor_kind,
+            actor_id_length,
+            claim_count,
+            role_count,
+            channel_present,
+            channel_length = ?channel_length,
+            locale_length,
+            causation_id_present,
+            causation_id_length = ?causation_id_length,
+            traceparent_present,
+            traceparent_length = ?traceparent_length,
+            idempotency_key_present,
+            idempotency_key_length = ?idempotency_key_length,
+            deadline_ms = ?context.deadline_ms,
+            operation = owner_operation,
+            code,
+            boundary = PAYMENT_COLLECTION_PORT_BOUNDARY,
+            "payment collection owner operation failed"
+        );
+    } else {
+        tracing::warn!(
+            owner = PAYMENT_COLLECTION_OWNER,
+            owner_error_variant = error_facts.error_variant,
+            owner_error_text_field_count = error_facts.text_field_count,
+            owner_error_text_total_length = error_facts.text_total_length,
+            owner_error_uuid_field_count = error_facts.uuid_field_count,
+            owner_error_uuid_non_nil_count = error_facts.uuid_non_nil_count,
+            owner_error_opaque_payload_present = error_facts.opaque_payload_present,
+            correlation_id = %context.correlation_id,
+            tenant_id_length,
+            actor_kind,
+            actor_id_length,
+            claim_count,
+            role_count,
+            channel_present,
+            channel_length = ?channel_length,
+            locale_length,
+            causation_id_present,
+            causation_id_length = ?causation_id_length,
+            traceparent_present,
+            traceparent_length = ?traceparent_length,
+            idempotency_key_present,
+            idempotency_key_length = ?idempotency_key_length,
+            deadline_ms = ?context.deadline_ms,
+            operation = owner_operation,
+            code,
+            boundary = PAYMENT_COLLECTION_PORT_BOUNDARY,
+            "payment collection owner operation was rejected"
+        );
+    }
+
     match error {
-        crate::PaymentError::Validation(message) => {
-            tracing::warn!(
-                cause = %message,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                operation = owner_operation,
-                code = "payment.validation",
-                "payment owner rejected a collection request"
-            );
+        crate::PaymentError::Validation(_) => {
             PortError::validation("payment.validation", "payment request is invalid")
         }
-        crate::PaymentError::PaymentCollectionNotFound(id) => PortError::not_found(
+        crate::PaymentError::PaymentCollectionNotFound(_) => PortError::not_found(
             "payment.collection_not_found",
-            format!("payment collection {id} not found"),
+            "payment collection was not found",
         ),
-        crate::PaymentError::PaymentNotFound(id) => PortError::not_found(
-            "payment.payment_not_found",
-            format!("payment for collection {id} not found"),
+        crate::PaymentError::PaymentNotFound(_) => {
+            PortError::not_found("payment.payment_not_found", "payment was not found")
+        }
+        crate::PaymentError::RefundNotFound(_) => {
+            PortError::not_found("payment.refund_not_found", "refund was not found")
+        }
+        crate::PaymentError::InvalidTransition { .. } => PortError::conflict(
+            "payment.invalid_transition",
+            "payment lifecycle conflicts with the requested operation",
         ),
-        crate::PaymentError::RefundNotFound(id) => {
-            PortError::not_found("payment.refund_not_found", format!("refund {id} not found"))
-        }
-        crate::PaymentError::InvalidTransition { from, to } => {
-            tracing::warn!(
-                from = %from,
-                to = %to,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                operation = owner_operation,
-                code = "payment.invalid_transition",
-                "payment owner rejected a lifecycle transition"
-            );
-            PortError::conflict(
-                "payment.invalid_transition",
-                "payment lifecycle conflicts with the requested operation",
-            )
-        }
-        crate::PaymentError::ProviderUnavailable {
-            provider_id,
-            operation,
-        } => {
-            tracing::error!(
-                provider_id = %provider_id,
-                provider_operation = %operation,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                operation = owner_operation,
-                code = "payment.provider_unavailable",
-                "payment provider is unavailable"
-            );
-            PortError::unavailable(
-                "payment.provider_unavailable",
-                "payment provider is temporarily unavailable",
-            )
-        }
-        crate::PaymentError::ProviderRejected {
-            provider_id,
-            operation,
-        } => {
-            tracing::warn!(
-                provider_id = %provider_id,
-                provider_operation = %operation,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                operation = owner_operation,
-                code = "payment.provider_rejected",
-                "payment provider rejected an owner operation"
-            );
-            PortError::conflict(
-                "payment.provider_rejected",
-                "payment provider rejected the requested operation",
-            )
-        }
-        crate::PaymentError::ProviderInvalidResponse {
-            provider_id,
-            operation,
-        } => {
-            tracing::error!(
-                provider_id = %provider_id,
-                provider_operation = %operation,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                operation = owner_operation,
-                code = "payment.provider_invalid_response",
-                "payment provider returned invalid normalized facts"
-            );
-            PortError::new(
-                PortErrorKind::InvariantViolation,
-                "payment.provider_invalid_response",
-                "payment provider response could not be applied safely",
-                false,
-            )
-        }
-        crate::PaymentError::ProviderOutcomeUnknown {
-            provider_id,
-            operation,
-        } => {
-            tracing::error!(
-                provider_id = %provider_id,
-                provider_operation = %operation,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                operation = owner_operation,
-                code = "payment.provider_outcome_unknown",
-                "payment provider outcome requires reconciliation"
-            );
-            PortError::new(
-                PortErrorKind::Conflict,
-                "payment.provider_outcome_unknown",
-                "payment provider outcome requires reconciliation",
-                false,
-            )
-        }
-        crate::PaymentError::ProviderConfiguration { provider_id } => {
-            tracing::error!(
-                provider_id = %provider_id,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                operation = owner_operation,
-                code = "payment.provider_not_configured",
-                "payment provider configuration is unavailable"
-            );
-            PortError::new(
-                PortErrorKind::InvariantViolation,
-                "payment.provider_not_configured",
-                "payment provider is not configured for the requested operation",
-                false,
-            )
-        }
-        crate::PaymentError::Database(error) => {
-            tracing::error!(
-                error = ?error,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                operation = owner_operation,
-                code = "payment.database_unavailable",
-                "payment owner storage operation failed"
-            );
-            PortError::unavailable(
-                "payment.database_unavailable",
-                "payment storage is temporarily unavailable",
-            )
-        }
+        crate::PaymentError::ProviderUnavailable { .. } => PortError::unavailable(
+            "payment.provider_unavailable",
+            "payment provider is temporarily unavailable",
+        ),
+        crate::PaymentError::ProviderRejected { .. } => PortError::conflict(
+            "payment.provider_rejected",
+            "payment provider rejected the requested operation",
+        ),
+        crate::PaymentError::ProviderInvalidResponse { .. } => PortError::new(
+            PortErrorKind::InvariantViolation,
+            "payment.provider_invalid_response",
+            "payment provider response could not be applied safely",
+            false,
+        ),
+        crate::PaymentError::ProviderOutcomeUnknown { .. } => PortError::new(
+            PortErrorKind::Conflict,
+            "payment.provider_outcome_unknown",
+            "payment provider outcome requires reconciliation",
+            false,
+        ),
+        crate::PaymentError::ProviderConfiguration { .. } => PortError::new(
+            PortErrorKind::InvariantViolation,
+            "payment.provider_not_configured",
+            "payment provider is not configured for the requested operation",
+            false,
+        ),
+        crate::PaymentError::Database(_) => PortError::unavailable(
+            "payment.database_unavailable",
+            "payment storage is temporarily unavailable",
+        ),
     }
 }

--- a/scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+++ b/scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
@@ -37,8 +37,7 @@ const order = read('crates/rustok-order/src/ports.rs');
 const orderCompensation = read('crates/rustok-order/src/checkout_compensation.rs');
 const orderPaymentSettlement = read('crates/rustok-order/src/checkout_payment_settlement.rs');
 const orderRecovery = read('crates/rustok-order/src/checkout_order_recovery.rs');
-const orderCheckoutAdapters =
-  orderCompensation + orderPaymentSettlement + orderRecovery;
+const orderCheckoutAdapters = orderCompensation + orderPaymentSettlement + orderRecovery;
 
 for (const [source, label] of [
   [channel, 'channel port'],
@@ -115,8 +114,27 @@ forbidAll(payment, [
   'format!("payment provider `{provider_id}` is unavailable for `{operation}`")',
   'format!("payment provider `{provider_id}` rejected `{operation}`")',
   'format!("payment provider `{provider_id}` outcome is unknown for `{operation}`")',
+  'format!("payment collection {id} not found")',
+  'format!("payment for collection {id} not found")',
+  'format!("refund {id} not found")',
   '.map_err(payment_error_to_port_error)',
 ], 'payment collection public error mapping');
+forbidAll(payment, [
+  'cause = %message',
+  'error = ?error',
+  'error = %error',
+  'tenant_id = %context.tenant_id',
+  'actor = ?context.actor',
+  'channel = ?context.channel',
+  'locale = %context.locale',
+  'causation_id = ?context.causation_id',
+  'traceparent = ?context.traceparent',
+  'idempotency_key = ?context.idempotency_key',
+  'provider_id = %provider_id',
+  'provider_operation = %operation',
+  'from = %from',
+  'to = %to',
+], 'payment collection payload diagnostics');
 
 forbidAll(paymentCompensation, [
   'fn manual_reconciliation(message: impl Into<String>)',
@@ -222,27 +240,11 @@ requireText(payment, 'operation = owner_operation', 'payment owner operation log
 requireText(fulfillment, 'correlation_id = %context.correlation_id', 'fulfillment correlation logging');
 requireText(customer, 'correlation_id = %context.correlation_id', 'customer correlation logging');
 requireText(inventory, 'correlation_id = %context.correlation_id', 'inventory correlation logging');
-requireText(
-  inventory,
-  'storage_unavailable_with_context(&context, owner_operation, error)',
-  'inventory identity storage mapping',
-);
-requireText(
-  inventory,
-  'storage_unavailable_with_context(context, owner_operation, error)',
-  'inventory helper storage mapping',
-);
+requireText(inventory, 'storage_unavailable_with_context(&context, owner_operation, error)', 'inventory identity storage mapping');
+requireText(inventory, 'storage_unavailable_with_context(context, owner_operation, error)', 'inventory helper storage mapping');
 requireText(order, 'correlation_id = %context.correlation_id', 'order generic correlation logging');
-requireText(
-  orderCompensation,
-  'correlation_id = %context.correlation_id',
-  'order compensation correlation logging',
-);
-requireText(
-  orderRecovery,
-  'correlation_id = %context.correlation_id',
-  'order recovery correlation logging',
-);
+requireText(orderCompensation, 'correlation_id = %context.correlation_id', 'order compensation correlation logging');
+requireText(orderRecovery, 'correlation_id = %context.correlation_id', 'order recovery correlation logging');
 
 const required = [
   [pricing, [
@@ -287,23 +289,43 @@ const required = [
     'let owner_operation = "upsert_variant_price"',
   ], 'pricing'],
   [payment, [
+    'struct PaymentCollectionOwnerErrorFacts',
+    'fn payment_collection_owner_error_facts(',
+    'fn payment_collection_owner_error_code(',
+    'fn payment_collection_owner_error_is_technical(',
+    'owner_error_variant = error_facts.error_variant',
+    'owner_error_text_field_count = error_facts.text_field_count',
+    'owner_error_text_total_length = error_facts.text_total_length',
+    'owner_error_uuid_field_count = error_facts.uuid_field_count',
+    'owner_error_uuid_non_nil_count = error_facts.uuid_non_nil_count',
+    'owner_error_opaque_payload_present = error_facts.opaque_payload_present',
     'correlation_id = %context.correlation_id',
-    'tenant_id = %context.tenant_id',
+    'tenant_id_length',
+    'actor_kind',
+    'claim_count',
+    'role_count',
     'operation = owner_operation',
-    'code = "payment.validation"',
-    'code = "payment.invalid_transition"',
-    'code = "payment.provider_unavailable"',
-    'code = "payment.provider_rejected"',
-    'code = "payment.provider_invalid_response"',
-    'code = "payment.provider_outcome_unknown"',
-    'code = "payment.provider_not_configured"',
-    'code = "payment.database_unavailable"',
+    'boundary = PAYMENT_COLLECTION_PORT_BOUNDARY',
+    '"payment.validation"',
+    '"payment.collection_not_found"',
+    '"payment.payment_not_found"',
+    '"payment.refund_not_found"',
+    '"payment.invalid_transition"',
+    '"payment.provider_unavailable"',
+    '"payment.provider_rejected"',
+    '"payment.provider_invalid_response"',
+    '"payment.provider_outcome_unknown"',
+    '"payment.provider_not_configured"',
+    '"payment.database_unavailable"',
+    '"payment collection was not found"',
+    '"payment was not found"',
+    '"refund was not found"',
     '"payment storage is temporarily unavailable"',
     '"payment provider outcome requires reconciliation"',
     '"payment provider response could not be applied safely"',
     '"payment provider rejected the requested operation"',
     '"payment request is invalid"',
-    'payment_error_to_port_error(&context, "read_collection_status"',
+    'payment_error_to_port_error(&context, owner_operation, error)',
   ], 'payment'],
   [paymentCompensation, [
     'correlation_id = %context.correlation_id',

--- a/scripts/verify/verify-ecommerce-public-port-error-safety-v2.test.mjs
+++ b/scripts/verify/verify-ecommerce-public-port-error-safety-v2.test.mjs
@@ -7,9 +7,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 
-const scriptPath = path.resolve(
-  'scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs',
-);
+const scriptPath = path.resolve('scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs');
 
 function put(root, relativePath, content) {
   const filePath = path.join(root, relativePath);
@@ -68,25 +66,46 @@ let owner_operation = "upsert_variant_price";
 
 function canonicalPayment() {
   return `
+struct PaymentCollectionOwnerErrorFacts {}
+fn payment_collection_owner_error_facts() {}
+fn payment_collection_owner_error_code() {}
+fn payment_collection_owner_error_is_technical() {}
 tracing::error!(
+  owner_error_variant = error_facts.error_variant,
+  owner_error_text_field_count = error_facts.text_field_count,
+  owner_error_text_total_length = error_facts.text_total_length,
+  owner_error_uuid_field_count = error_facts.uuid_field_count,
+  owner_error_uuid_non_nil_count = error_facts.uuid_non_nil_count,
+  owner_error_opaque_payload_present = error_facts.opaque_payload_present,
   correlation_id = %context.correlation_id,
-  tenant_id = %context.tenant_id,
+  tenant_id_length,
+  actor_kind,
+  claim_count,
+  role_count,
   operation = owner_operation,
-  code = "payment.database_unavailable",
+  boundary = PAYMENT_COLLECTION_PORT_BOUNDARY,
 );
-tracing::warn!(code = "payment.validation");
-tracing::warn!(code = "payment.invalid_transition");
-tracing::error!(code = "payment.provider_unavailable");
-tracing::warn!(code = "payment.provider_rejected");
-tracing::error!(code = "payment.provider_invalid_response");
-tracing::error!(code = "payment.provider_outcome_unknown");
-tracing::error!(code = "payment.provider_not_configured");
-PortError::unavailable("payment.database_unavailable", "payment storage is temporarily unavailable");
-PortError::conflict("payment.provider_outcome_unknown", "payment provider outcome requires reconciliation");
-PortError::invariant_violation("payment.provider_invalid_response", "payment provider response could not be applied safely");
-PortError::conflict("payment.provider_rejected", "payment provider rejected the requested operation");
-PortError::validation("payment.validation", "payment request is invalid");
-.map_err(|error| payment_error_to_port_error(&context, "read_collection_status", error));
+tracing::warn!(operation = owner_operation);
+"payment.validation";
+"payment.collection_not_found";
+"payment.payment_not_found";
+"payment.refund_not_found";
+"payment.invalid_transition";
+"payment.provider_unavailable";
+"payment.provider_rejected";
+"payment.provider_invalid_response";
+"payment.provider_outcome_unknown";
+"payment.provider_not_configured";
+"payment.database_unavailable";
+"payment collection was not found";
+"payment was not found";
+"refund was not found";
+"payment storage is temporarily unavailable";
+"payment provider outcome requires reconciliation";
+"payment provider response could not be applied safely";
+"payment provider rejected the requested operation";
+"payment request is invalid";
+payment_error_to_port_error(&context, owner_operation, error);
 `;
 }
 
@@ -325,119 +344,46 @@ hash_json(context, "encode_checkout_snapshot_hash", snapshot);
 
 function fixture(options = {}) {
   const root = mkdtempSync(path.join(tmpdir(), 'rustok-public-port-errors-'));
-  put(
-    root,
-    'crates/rustok-channel/src/ports.rs',
-    `tracing::error!();\n"channel storage is temporarily unavailable";\n${options.channelAppend ?? ''}`,
-  );
-  put(
-    root,
-    'crates/rustok-region/src/ports.rs',
-    `tracing::error!();\n"region storage is temporarily unavailable";\n${options.regionAppend ?? ''}`,
-  );
-  put(
-    root,
-    'crates/rustok-cart/src/checkout_snapshot.rs',
-    `tracing::error!();\n"cart checkout request or projection is invalid";\n"cart checkout snapshot could not be encoded";\n${options.cartAppend ?? ''}`,
-  );
+  put(root, 'crates/rustok-channel/src/ports.rs', `tracing::error!();\n"channel storage is temporarily unavailable";\n${options.channelAppend ?? ''}`);
+  put(root, 'crates/rustok-region/src/ports.rs', `tracing::error!();\n"region storage is temporarily unavailable";\n${options.regionAppend ?? ''}`);
+  put(root, 'crates/rustok-cart/src/checkout_snapshot.rs', `tracing::error!();\n"cart checkout request or projection is invalid";\n"cart checkout snapshot could not be encoded";\n${options.cartAppend ?? ''}`);
 
   let pricing = `${canonicalPricing()}${options.pricingAppend ?? ''}`;
-  if (options.removePricingCorrelation) {
-    pricing = pricing.replace(
-      'correlation_id = %context.correlation_id',
-      'correlation_id = omitted',
-    );
-  }
+  if (options.removePricingCorrelation) pricing = pricing.replace('correlation_id = %context.correlation_id', 'correlation_id = omitted');
   put(root, 'crates/rustok-pricing/src/ports.rs', pricing);
 
   let payment = `${canonicalPayment()}${options.paymentAppend ?? ''}`;
-  if (options.removePaymentOperation) {
-    payment = payment.replace('operation = owner_operation', 'operation = omitted');
-  }
+  if (options.removePaymentOperation) payment = payment.replaceAll('operation = owner_operation', 'operation = omitted');
   put(root, 'crates/rustok-payment/src/ports.rs', payment);
 
-  const paymentCompensation = `${canonicalPaymentCompensation()}${options.paymentCompensationAppend ?? ''}`;
-  put(
-    root,
-    'crates/rustok-payment/src/checkout_compensation.rs',
-    paymentCompensation,
-  );
+  put(root, 'crates/rustok-payment/src/checkout_compensation.rs', `${canonicalPaymentCompensation()}${options.paymentCompensationAppend ?? ''}`);
 
   let fulfillment = `${canonicalFulfillment()}${options.fulfillmentAppend ?? ''}`;
-  if (options.removeFulfillmentCorrelation) {
-    fulfillment = fulfillment.replace(
-      'correlation_id = %context.correlation_id',
-      'correlation_id = omitted',
-    );
-  }
+  if (options.removeFulfillmentCorrelation) fulfillment = fulfillment.replace('correlation_id = %context.correlation_id', 'correlation_id = omitted');
   put(root, 'crates/rustok-fulfillment/src/ports.rs', fulfillment);
 
   let customer = `${canonicalCustomer()}${options.customerAppend ?? ''}`;
-  if (options.removeCustomerCorrelation) {
-    customer = customer.replace(
-      'correlation_id = %context.correlation_id',
-      'correlation_id = omitted',
-    );
-  }
+  if (options.removeCustomerCorrelation) customer = customer.replace('correlation_id = %context.correlation_id', 'correlation_id = omitted');
   put(root, 'crates/rustok-customer/src/ports.rs', customer);
 
   let inventory = `${canonicalInventory()}${options.inventoryAppend ?? ''}`;
-  if (options.removeInventoryCorrelation) {
-    inventory = inventory.replace(
-      'correlation_id = %context.correlation_id',
-      'correlation_id = omitted',
-    );
-  }
-  if (options.removeInventoryIdentityStorageContext) {
-    inventory = inventory.replace(
-      'storage_unavailable_with_context(&context, owner_operation, error)',
-      'storage_context_omitted(error)',
-    );
-  }
-  if (options.removeInventoryHelperStorageContext) {
-    inventory = inventory.replace(
-      'storage_unavailable_with_context(context, owner_operation, error)',
-      'storage_context_omitted(error)',
-    );
-  }
+  if (options.removeInventoryCorrelation) inventory = inventory.replace('correlation_id = %context.correlation_id', 'correlation_id = omitted');
+  if (options.removeInventoryIdentityStorageContext) inventory = inventory.replace('storage_unavailable_with_context(&context, owner_operation, error)', 'storage_context_omitted(error)');
+  if (options.removeInventoryHelperStorageContext) inventory = inventory.replace('storage_unavailable_with_context(context, owner_operation, error)', 'storage_context_omitted(error)');
   put(root, 'crates/rustok-inventory/src/ports.rs', inventory);
 
   let order = `${canonicalOrder()}${options.orderAppend ?? ''}`;
-  if (options.removeOrderCorrelation) {
-    order = order.replace(
-      'correlation_id = %context.correlation_id',
-      'correlation_id = omitted',
-    );
-  }
+  if (options.removeOrderCorrelation) order = order.replace('correlation_id = %context.correlation_id', 'correlation_id = omitted');
   put(root, 'crates/rustok-order/src/ports.rs', order);
 
   let orderCompensation = `${canonicalOrderCompensation()}${options.orderCompensationAppend ?? ''}`;
-  if (options.removeOrderCompensationCorrelation) {
-    orderCompensation = orderCompensation.replace(
-      'correlation_id = %context.correlation_id',
-      'correlation_id = omitted',
-    );
-  }
-  put(
-    root,
-    'crates/rustok-order/src/checkout_compensation.rs',
-    orderCompensation,
-  );
+  if (options.removeOrderCompensationCorrelation) orderCompensation = orderCompensation.replace('correlation_id = %context.correlation_id', 'correlation_id = omitted');
+  put(root, 'crates/rustok-order/src/checkout_compensation.rs', orderCompensation);
 
-  const orderPaymentSettlement = `${canonicalOrderPaymentSettlement()}${options.orderPaymentSettlementAppend ?? ''}`;
-  put(
-    root,
-    'crates/rustok-order/src/checkout_payment_settlement.rs',
-    orderPaymentSettlement,
-  );
+  put(root, 'crates/rustok-order/src/checkout_payment_settlement.rs', `${canonicalOrderPaymentSettlement()}${options.orderPaymentSettlementAppend ?? ''}`);
 
   let orderRecovery = `${canonicalOrderRecovery()}${options.orderRecoveryAppend ?? ''}`;
-  if (options.removeOrderRecoveryCorrelation) {
-    orderRecovery = orderRecovery.replace(
-      'correlation_id = %context.correlation_id',
-      'correlation_id = omitted',
-    );
-  }
+  if (options.removeOrderRecoveryCorrelation) orderRecovery = orderRecovery.replace('correlation_id = %context.correlation_id', 'correlation_id = omitted');
   put(root, 'crates/rustok-order/src/checkout_order_recovery.rs', orderRecovery);
   return root;
 }
@@ -476,7 +422,16 @@ const failureCases = [
   ["provider id in unavailable message", { paymentAppend: 'format!("payment provider `{provider_id}` is unavailable for `{operation}`");' }, /payment collection public error mapping: forbidden/],
   ["provider id in rejection message", { paymentAppend: 'format!("payment provider `{provider_id}` rejected `{operation}`");' }, /payment collection public error mapping: forbidden/],
   ["provider id in unknown-outcome message", { paymentAppend: 'format!("payment provider `{provider_id}` outcome is unknown for `{operation}`");' }, /payment collection public error mapping: forbidden/],
+  ["collection id in not-found message", { paymentAppend: 'format!("payment collection {id} not found");' }, /payment collection public error mapping: forbidden/],
+  ["payment id in not-found message", { paymentAppend: 'format!("payment for collection {id} not found");' }, /payment collection public error mapping: forbidden/],
+  ["refund id in not-found message", { paymentAppend: 'format!("refund {id} not found");' }, /payment collection public error mapping: forbidden/],
   ["raw payment validation cause", { paymentAppend: 'PortError::validation("payment.validation", message);' }, /payment collection public error mapping: forbidden/],
+  ["raw payment validation diagnostics", { paymentAppend: 'cause = %message;' }, /payment collection payload diagnostics: forbidden/],
+  ["complete payment database diagnostics", { paymentAppend: 'tracing::error!(error = ?error);' }, /payment collection payload diagnostics: forbidden/],
+  ["raw payment tenant diagnostics", { paymentAppend: 'tenant_id = %context.tenant_id;' }, /payment collection payload diagnostics: forbidden/],
+  ["payment provider identity diagnostics", { paymentAppend: 'provider_id = %provider_id;' }, /payment collection payload diagnostics: forbidden/],
+  ["payment provider operation diagnostics", { paymentAppend: 'provider_operation = %operation;' }, /payment collection payload diagnostics: forbidden/],
+  ["payment transition diagnostics", { paymentAppend: 'from = %from;' }, /payment collection payload diagnostics: forbidden/],
   ["raw pricing validation cause", { pricingAppend: 'PortError::validation("pricing.validation", message);' }, /pricing public error mapping: forbidden/],
   ["dynamic pricing product message", { pricingAppend: 'format!("product {id} not found");' }, /pricing public error mapping: forbidden/],
   ["dynamic pricing mismatch message", { pricingAppend: 'format!("variant {variant_id} does not belong to product {product_id}");' }, /pricing public error mapping: forbidden/],
@@ -527,7 +482,5 @@ const failureCases = [
 ];
 
 for (const [name, options, pattern] of failureCases) {
-  test(`public port error verifier rejects ${name}`, () => {
-    expectFailure(options, pattern);
-  });
+  test(`public port error verifier rejects ${name}`, () => expectFailure(options, pattern));
 }

--- a/scripts/verify/verify-payment-collection-admission-context.mjs
+++ b/scripts/verify/verify-payment-collection-admission-context.mjs
@@ -10,102 +10,35 @@ const root = configuredRoot
   : new URL('../../', import.meta.url);
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
 const source = read('crates/rustok-payment/src/ports.rs');
-const admissionEvidence = JSON.parse(
-  read(
-    'crates/rustok-payment/contracts/evidence/payment-collection-admission-diagnostic-safety-source.json',
-  ),
-);
-const tenantEvidence = JSON.parse(
-  read(
-    'crates/rustok-payment/contracts/evidence/payment-collection-tenant-diagnostic-safety-source.json',
-  ),
-);
+const admissionEvidence = JSON.parse(read('crates/rustok-payment/contracts/evidence/payment-collection-admission-diagnostic-safety-source.json'));
+const tenantEvidence = JSON.parse(read('crates/rustok-payment/contracts/evidence/payment-collection-tenant-diagnostic-safety-source.json'));
+const ownerEvidence = JSON.parse(read('crates/rustok-payment/contracts/evidence/payment-collection-owner-error-diagnostic-safety-source.json'));
 const doc = read('crates/rustok-payment/docs/payment-collection-admission-context.md');
 const failures = [];
 
-const requireText = (content, value, label) => {
-  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
-};
-const forbidText = (content, value, label) => {
-  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
-};
+const requireText = (content, value, label) => { if (!content.includes(value)) failures.push(`${label}: missing ${value}`); };
+const forbidText = (content, value, label) => { if (content.includes(value)) failures.push(`${label}: forbidden ${value}`); };
 const countText = (content, value) => content.split(value).length - 1;
 const between = (content, start, end, label) => {
   const startIndex = content.indexOf(start);
   const endIndex = content.indexOf(end, startIndex + start.length);
-  if (startIndex < 0 || endIndex < 0) {
-    failures.push(`${label}: unable to isolate source block`);
-    return '';
-  }
+  if (startIndex < 0 || endIndex < 0) { failures.push(`${label}: unable to isolate source block`); return ''; }
   return content.slice(startIndex, endIndex);
 };
 
-const createBlock = between(
-  source,
-  '    async fn create_or_reuse_collection(',
-  '    async fn read_collection_status(',
-  'create or reuse implementation',
-);
-const readBlock = between(
-  source,
-  '    async fn read_collection_status(',
-  '\n}\n\nfn require_payment_collection_read_admission(',
-  'status read implementation',
-);
-const readAdmission = between(
-  source,
-  'fn require_payment_collection_read_admission(',
-  'fn require_payment_collection_write_admission(',
-  'read admission helper',
-);
-const writeAdmission = between(
-  source,
-  'fn require_payment_collection_write_admission(',
-  'fn log_payment_collection_admission_rejection(',
-  'write admission helper',
-);
-const admissionLogger = between(
-  source,
-  'fn log_payment_collection_admission_rejection(',
-  'fn parse_port_tenant_id(',
-  'admission diagnostic helper',
-);
-const tenantParser = between(
-  source,
-  'fn parse_port_tenant_id(',
-  'fn payment_error_to_port_error(',
-  'tenant parser',
-);
-const ownerMapperStart = source.indexOf('fn payment_error_to_port_error(');
-if (ownerMapperStart < 0) failures.push('payment owner mapper: unable to isolate source block');
-const ownerMapper = ownerMapperStart >= 0 ? source.slice(ownerMapperStart) : '';
-
-for (const [value, label] of [
-  ['const PAYMENT_COLLECTION_PORT_BOUNDARY: &str = "payment_collection_port";', 'stable boundary identity'],
-  ['const PAYMENT_COLLECTION_OWNER: &str = "rustok_payment";', 'truthful payment owner'],
-  ['const CREATE_OR_REUSE_COLLECTION_OPERATION: &str = "create_or_reuse_collection";', 'write owner operation'],
-  ['const READ_COLLECTION_STATUS_OPERATION: &str = "read_collection_status";', 'read owner operation'],
-]) requireText(source, value, label);
+const createBlock = between(source, '    async fn create_or_reuse_collection(', '    async fn read_collection_status(', 'create implementation');
+const readBlock = between(source, '    async fn read_collection_status(', '\n}\n\nfn require_payment_collection_read_admission(', 'status implementation');
+const readAdmission = between(source, 'fn require_payment_collection_read_admission(', 'fn require_payment_collection_write_admission(', 'read admission');
+const writeAdmission = between(source, 'fn require_payment_collection_write_admission(', 'fn log_payment_collection_admission_rejection(', 'write admission');
+const admissionLogger = between(source, 'fn log_payment_collection_admission_rejection(', 'fn parse_port_tenant_id(', 'admission logger');
+const tenantParser = between(source, 'fn parse_port_tenant_id(', '#[derive(Debug)]\nstruct PaymentCollectionOwnerErrorFacts', 'tenant parser');
+const ownerStart = source.indexOf('#[derive(Debug)]\nstruct PaymentCollectionOwnerErrorFacts');
+const ownerMapper = ownerStart >= 0 ? source.slice(ownerStart) : '';
+if (ownerStart < 0) failures.push('owner mapper contract: unable to isolate source block');
 
 for (const [content, values, label] of [
-  [
-    createBlock,
-    [
-      'let owner_operation = CREATE_OR_REUSE_COLLECTION_OPERATION;',
-      'require_payment_collection_write_admission(&context, owner_operation)?;',
-      'let tenant_id = parse_port_tenant_id(&context, owner_operation)?;',
-    ],
-    'write admission ordering',
-  ],
-  [
-    readBlock,
-    [
-      'let owner_operation = READ_COLLECTION_STATUS_OPERATION;',
-      'require_payment_collection_read_admission(&context, owner_operation)?;',
-      'let tenant_id = parse_port_tenant_id(&context, owner_operation)?;',
-    ],
-    'read admission ordering',
-  ],
+  [createBlock, ['let owner_operation = CREATE_OR_REUSE_COLLECTION_OPERATION;', 'require_payment_collection_write_admission(&context, owner_operation)?;', 'let tenant_id = parse_port_tenant_id(&context, owner_operation)?;'], 'write ordering'],
+  [readBlock, ['let owner_operation = READ_COLLECTION_STATUS_OPERATION;', 'require_payment_collection_read_admission(&context, owner_operation)?;', 'let tenant_id = parse_port_tenant_id(&context, owner_operation)?;'], 'read ordering'],
 ]) {
   let previous = -1;
   for (const value of values) {
@@ -116,258 +49,78 @@ for (const [content, values, label] of [
   }
 }
 
-for (const [content, values, label] of [
-  [
-    readAdmission,
-    [
-      'context.require_policy(PortCallPolicy::read())',
-      '.inspect_err(|error| {',
-      'log_payment_collection_admission_rejection(context, owner_operation, "policy", error);',
-    ],
-    'read admission pass-through',
-  ],
-  [
-    writeAdmission,
-    [
-      'context.require_policy(PortCallPolicy::write())',
-      '.inspect_err(|error| {',
-      'log_payment_collection_admission_rejection(context, owner_operation, "policy", error);',
-      'context.require_write_semantics().inspect_err(|error| {',
-      '"write_semantics",',
-    ],
-    'write admission pass-through',
-  ],
-]) {
-  for (const value of values) requireText(content, value, label);
-}
-forbidText(readAdmission, 'require_write_semantics', 'read admission must remain non-write');
-forbidText(readAdmission + writeAdmission, 'PortError::', 'admission helper error reconstruction');
-forbidText(readAdmission + writeAdmission, '.map_err(', 'admission helper error replacement');
+for (const marker of ['context.require_policy(PortCallPolicy::read())', '.inspect_err(|error| {', 'log_payment_collection_admission_rejection(context, owner_operation, "policy", error);']) requireText(readAdmission, marker, 'read pass-through');
+for (const marker of ['context.require_policy(PortCallPolicy::write())', 'log_payment_collection_admission_rejection(context, owner_operation, "policy", error);', 'context.require_write_semantics().inspect_err(|error| {', '"write_semantics",']) requireText(writeAdmission, marker, 'write pass-through');
+forbidText(readAdmission, 'require_write_semantics', 'read admission');
+forbidText(readAdmission + writeAdmission, 'PortError::', 'admission error reconstruction');
+forbidText(readAdmission + writeAdmission, '.map_err(', 'admission error replacement');
 
-for (const [value, label] of [
-  ['context: &PortContext', 'retained context input'],
-  ["owner_operation: &'static str", 'exact owner operation input'],
-  ["admission: &'static str", 'admission phase input'],
-  ['error: &PortError', 'borrowed original port error'],
-  ['let error_kind = match &error.kind', 'closed error-kind classification'],
-  ['PortErrorKind::Validation => "validation"', 'validation kind label'],
-  ['PortErrorKind::NotFound => "not_found"', 'not-found kind label'],
-  ['PortErrorKind::Conflict => "conflict"', 'conflict kind label'],
-  ['PortErrorKind::Forbidden => "forbidden"', 'forbidden kind label'],
-  ['PortErrorKind::Unavailable => "unavailable"', 'unavailable kind label'],
-  ['PortErrorKind::Timeout => "timeout"', 'timeout kind label'],
-  ['PortErrorKind::InvariantViolation => "invariant_violation"', 'invariant kind label'],
-  ['let technical_failure = matches!(', 'technical severity classification'],
-  ['let actor_kind = match &context.actor.kind', 'bounded actor kind'],
-  ['let tenant_id_length = context.tenant_id.chars().count();', 'tenant shape'],
-  ['let actor_id_length = context.actor.id.chars().count();', 'actor identity shape'],
-  ['let claim_count = context.claims.len();', 'claim count'],
-  ['let role_count = context.roles.len();', 'role count'],
-  ['let channel_present = context.channel.is_some();', 'channel presence'],
-  ['let locale_length = context.locale.chars().count();', 'locale length'],
-  ['let causation_id_present = context.causation_id.is_some();', 'causation presence'],
-  ['let traceparent_present = context.traceparent.is_some();', 'trace presence'],
-  ['let idempotency_key_present = context.idempotency_key.is_some();', 'idempotency presence'],
-  ['let internal_message_present = !error.message.trim().is_empty();', 'message presence'],
-  ['let internal_message_length = error.message.chars().count();', 'message length'],
-  ['owner = PAYMENT_COLLECTION_OWNER', 'truthful owner field'],
-  ['correlation_id = %context.correlation_id', 'correlation context'],
-  ['deadline_ms = ?context.deadline_ms', 'deadline context'],
-  ['operation = owner_operation', 'owner operation field'],
-  ['admission,', 'admission phase field'],
-  ['code = %error.code', 'stable error code'],
-  ['internal_message_present', 'message presence diagnostic'],
-  ['internal_message_length', 'message length diagnostic'],
-  ['error_kind', 'closed kind diagnostic'],
-  ['retryable = error.retryable', 'retryability'],
-  ['boundary = PAYMENT_COLLECTION_PORT_BOUNDARY', 'boundary field'],
-  ['tracing::error!(', 'technical severity'],
-  ['tracing::warn!(', 'ordinary rejection severity'],
-  ['"payment collection admission failed"', 'technical event'],
-  ['"payment collection admission was rejected"', 'rejection event'],
-]) requireText(admissionLogger, value, label);
-
-for (const value of [
-  'error = ?error',
-  'error = %error',
-  'tenant_id = %context.tenant_id',
-  'actor = ?context.actor',
-  'channel = ?context.channel',
-  'locale = %context.locale',
-  'causation_id = ?context.causation_id',
-  'traceparent = ?context.traceparent',
-  'idempotency_key = ?context.idempotency_key',
-  'internal_message = %error.message',
-  'error_kind = ?error.kind',
-]) forbidText(admissionLogger, value, 'unsafe admission diagnostic payload');
-
-if (countText(admissionLogger, 'tracing::error!(') !== 1) {
-  failures.push('expected exactly one admission technical diagnostic path');
-}
-if (countText(admissionLogger, 'tracing::warn!(') !== 1) {
-  failures.push('expected exactly one admission rejection diagnostic path');
-}
 for (const marker of [
-  'owner = PAYMENT_COLLECTION_OWNER',
-  'correlation_id = %context.correlation_id',
-  'operation = owner_operation',
-  'admission,',
-  'code = %error.code',
-  'internal_message_present',
-  'internal_message_length',
-  'error_kind',
-  'retryable = error.retryable',
-  'boundary = PAYMENT_COLLECTION_PORT_BOUNDARY',
-]) {
-  if (countText(admissionLogger, marker) < 2) {
-    failures.push(`both admission severity paths must retain ${marker}`);
-  }
-}
-
-for (const [pattern, expected, label] of [
-  [/log_payment_collection_admission_rejection\(/g, 4, 'diagnostic helper definition/use count'],
-  [/"policy"/g, 2, 'policy phase count'],
-  [/"write_semantics"/g, 1, 'write semantics phase count'],
-]) {
-  const count = source.match(pattern)?.length ?? 0;
-  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
-}
-
-for (const [value, label] of [
-  ['Uuid::parse_str(&context.tenant_id).map_err(|parse_error| {', 'tenant parser routing'],
-  ['let parse_error_type = std::any::type_name_of_val(&parse_error);', 'tenant type-only parse cause'],
-  ['tenant_id_parse_failed = true', 'tenant parse-failure fact'],
-  ['tenant_id_length', 'tenant shape fact'],
-  ['actor_kind', 'tenant actor-kind fact'],
-  ['internal_message_present', 'tenant message presence'],
-  ['internal_message_length', 'tenant message length'],
-  ['let error_kind = "validation";', 'tenant closed validation kind'],
-  ['validation = "tenant_id"', 'tenant validation phase'],
-  ['"payment.tenant_id_invalid"', 'tenant stable code'],
-]) requireText(tenantParser, value, label);
+  'error: &PortError', 'let error_kind = match &error.kind', 'PortErrorKind::Validation => "validation"',
+  'PortErrorKind::NotFound => "not_found"', 'PortErrorKind::Conflict => "conflict"',
+  'PortErrorKind::Forbidden => "forbidden"', 'PortErrorKind::Unavailable => "unavailable"',
+  'PortErrorKind::Timeout => "timeout"', 'PortErrorKind::InvariantViolation => "invariant_violation"',
+  'let technical_failure = matches!(', 'tenant_id_length', 'actor_kind', 'actor_id_length',
+  'claim_count', 'role_count', 'channel_present', 'locale_length', 'causation_id_present',
+  'traceparent_present', 'idempotency_key_present', 'internal_message_present',
+  'internal_message_length', 'owner = PAYMENT_COLLECTION_OWNER',
+  'correlation_id = %context.correlation_id', 'operation = owner_operation', 'admission,',
+  'code = %error.code', 'retryable = error.retryable', 'boundary = PAYMENT_COLLECTION_PORT_BOUNDARY',
+  '"payment collection admission failed"', '"payment collection admission was rejected"',
+]) requireText(admissionLogger, marker, 'bounded admission logger');
 for (const value of [
-  'parse_error = ?parse_error',
-  'error = ?error',
-  'tenant_id = %context.tenant_id',
-  'actor = ?context.actor',
-  'channel = ?context.channel',
-  'locale = %context.locale',
-  'causation_id = ?context.causation_id',
-  'traceparent = ?context.traceparent',
-  'idempotency_key = ?context.idempotency_key',
-  'internal_message = %error.message',
-  'error_kind = ?error.kind',
-]) forbidText(tenantParser, value, 'unsafe tenant parser payload after separate cleanup');
+  'error = ?error', 'error = %error', 'tenant_id = %context.tenant_id', 'actor = ?context.actor',
+  'channel = ?context.channel', 'locale = %context.locale', 'causation_id = ?context.causation_id',
+  'traceparent = ?context.traceparent', 'idempotency_key = ?context.idempotency_key',
+  'internal_message = %error.message', 'error_kind = ?error.kind',
+]) forbidText(admissionLogger, value, 'unsafe admission payload');
+if (countText(admissionLogger, 'tracing::error!(') !== 1 || countText(admissionLogger, 'tracing::warn!(') !== 1) failures.push('admission severity split must retain one error and one warning path');
+if ((source.match(/log_payment_collection_admission_rejection\(/g) ?? []).length !== 4) failures.push('admission helper definition/use count must remain four');
 
-for (const [value, label] of [
-  ['fn payment_error_to_port_error(', 'canonical mapper remains separate'],
-  ['cause = %message', 'canonical validation payload remains open'],
-  ['provider_id = %provider_id', 'canonical provider payload remains open'],
-  ['error = ?error', 'canonical database payload remains open'],
-  ['"payment request is invalid"', 'stable validation envelope'],
-  ['"payment storage is temporarily unavailable"', 'stable storage envelope'],
-]) requireText(ownerMapper, value, label);
+for (const marker of ['Uuid::parse_str(&context.tenant_id).map_err(|parse_error| {', 'tenant_id_parse_failed = true', 'let parse_error_type = std::any::type_name_of_val(&parse_error);', 'validation = "tenant_id"']) requireText(tenantParser, marker, 'separate tenant contract');
+for (const value of ['parse_error = ?parse_error', 'error = ?error', 'tenant_id = %context.tenant_id']) forbidText(tenantParser, value, 'tenant regression');
 
-for (const [value, label] of [
-  ['"create_or_reuse_collection.read_existing"', 'existing collection read mapping'],
-  ['"create_or_reuse_collection.adopt_race"', 'race adoption mapping'],
-  ['"create_or_reuse_collection.create"', 'collection create mapping'],
-  ['find_reusable_collection_by_cart(tenant_id, cart_id)', 'reusable collection lookup'],
-  ['create_collection(', 'collection creation'],
-]) requireText(createBlock, value, label);
-for (const [value, label] of [
-  ['get_collection(tenant_id, request.collection_id)', 'status collection identity'],
-  ['payment_error_to_port_error(&context, owner_operation, error)', 'status owner mapping'],
-  ['PaymentCollectionStatusSnapshot::from_response(&response)', 'status snapshot mapping'],
-]) requireText(readBlock, value, label);
+for (const marker of [
+  'struct PaymentCollectionOwnerErrorFacts', 'payment_collection_owner_error_facts(&error)',
+  'owner_error_variant = error_facts.error_variant', 'owner_error_text_total_length = error_facts.text_total_length',
+  'owner_error_uuid_non_nil_count = error_facts.uuid_non_nil_count',
+  'owner_error_opaque_payload_present = error_facts.opaque_payload_present',
+  '"payment collection was not found"', '"payment was not found"', '"refund was not found"',
+]) requireText(ownerMapper, marker, 'separate owner contract');
+for (const value of ['cause = %message', 'provider_id = %provider_id', 'error = ?error', 'tenant_id = %context.tenant_id']) forbidText(ownerMapper, value, 'owner mapper regression');
 
-if (
-  admissionEvidence.status !==
-  'payment_collection_admission_diagnostic_safety_source_unvalidated'
-) {
-  failures.push(`admission evidence status mismatch: ${admissionEvidence.status}`);
-}
+if (admissionEvidence.status !== 'payment_collection_admission_diagnostic_safety_source_unvalidated') failures.push(`admission evidence status mismatch: ${admissionEvidence.status}`);
 for (const [key, expected] of Object.entries({
-  admission_mapper_bounded: true,
-  complete_admission_port_error_logged: false,
-  admission_internal_message_text_logged: false,
-  admission_context_shape_only: true,
-  admission_correlation_preserved: true,
-  admission_owner_operations_preserved: true,
-  admission_phases_preserved: true,
-  admission_error_kind_closed: true,
-  admission_severity_split_preserved: true,
-  original_admission_port_error_returned: true,
-  read_write_admission_order_preserved: true,
-  tenant_parser_cleanup_out_of_scope: true,
-  canonical_payment_error_mapper_cleanup_out_of_scope: true,
-  execution_behavior_changed: false,
-  public_port_error_changed: false,
-  ffa_promoted: false,
-  fba_promoted: false,
-})) {
-  if (admissionEvidence.source_contract?.[key] !== expected) {
-    failures.push(`admission evidence source_contract.${key} must be ${expected}`);
-  }
-}
-if (
-  tenantEvidence.status !==
-  'payment_collection_tenant_diagnostic_safety_source_unvalidated'
-) {
-  failures.push(`tenant evidence status mismatch: ${tenantEvidence.status}`);
-}
-for (const [key, expected] of Object.entries({
-  tenant_parser_bounded: true,
-  complete_parse_error_logged: false,
-  constructed_port_error_logged: false,
-  tenant_internal_message_text_logged: false,
-  tenant_context_shape_only: true,
-  same_validation_port_error_returned: true,
-  admission_mapper_changed: false,
-  canonical_payment_error_mapper_cleanup_out_of_scope: true,
-  ffa_promoted: false,
-  fba_promoted: false,
-})) {
-  if (tenantEvidence.source_contract?.[key] !== expected) {
-    failures.push(`tenant evidence source_contract.${key} must be ${expected}`);
-  }
-}
-for (const [label, evidence] of [
-  ['admission', admissionEvidence],
-  ['tenant', tenantEvidence],
-]) {
-  if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
-    failures.push(`${label} evidence execution must remain empty`);
-  }
-  for (const key of [
-    'tests_run',
-    'cargo_run',
-    'format_run',
-    'verifiers_run',
-    'workflow_checks_run',
-    'ci_run',
-    'runtime_proven',
-  ]) {
-    if (evidence.validation?.[key] !== false) {
-      failures.push(`${label} evidence validation.${key} must remain false`);
-    }
-  }
+  admission_mapper_bounded: true, complete_admission_port_error_logged: false,
+  admission_internal_message_text_logged: false, admission_context_shape_only: true,
+  admission_correlation_preserved: true, admission_owner_operations_preserved: true,
+  admission_phases_preserved: true, admission_error_kind_closed: true,
+  admission_severity_split_preserved: true, original_admission_port_error_returned: true,
+  read_write_admission_order_preserved: true, tenant_parser_cleanup_out_of_scope: true,
+  canonical_payment_error_mapper_cleanup_out_of_scope: true, execution_behavior_changed: false,
+  public_port_error_changed: false, ffa_promoted: false, fba_promoted: false,
+})) if (admissionEvidence.source_contract?.[key] !== expected) failures.push(`admission evidence ${key} must be ${expected}`);
+
+if (tenantEvidence.status !== 'payment_collection_tenant_diagnostic_safety_source_unvalidated') failures.push(`tenant evidence status mismatch: ${tenantEvidence.status}`);
+if (tenantEvidence.source_contract?.tenant_parser_bounded !== true) failures.push('tenant evidence must remain bounded');
+if (ownerEvidence.status !== 'payment_collection_owner_error_diagnostic_safety_source_unvalidated') failures.push(`owner evidence status mismatch: ${ownerEvidence.status}`);
+if (ownerEvidence.source_contract?.complete_payment_error_logged !== false || ownerEvidence.source_contract?.static_not_found_public_messages !== true) failures.push('owner evidence must retain safe mapper contract');
+
+for (const [label, evidence] of [['admission', admissionEvidence], ['tenant', tenantEvidence], ['owner', ownerEvidence]]) {
+  if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) failures.push(`${label} execution must remain empty`);
+  for (const key of ['tests_run','cargo_run','format_run','verifiers_run','workflow_checks_run','ci_run','runtime_proven']) if (evidence.validation?.[key] !== false) failures.push(`${label} validation.${key} must remain false`);
 }
 
-for (const [value, label] of [
-  ['Status: **source-ready / unvalidated**', 'documentation status'],
-  ['Admission diagnostics retain only bounded context and message-shape facts', 'documentation bounded policy'],
-  ['The exact original admission `PortError` continues through `inspect_err` unchanged', 'documentation pass-through policy'],
-  ['Tenant UUID parsing is now closed by a separate source-only contract', 'documentation tenant current state'],
-  ['Canonical `payment_error_to_port_error` remains the next open collection boundary', 'documentation residual boundary'],
-]) requireText(doc, value, label);
+for (const marker of [
+  'Status: **source-ready / unvalidated**',
+  'Admission diagnostics retain only bounded context and message-shape facts',
+  'The exact original admission `PortError` continues through `inspect_err` unchanged',
+  'Tenant UUID parsing and canonical `payment_error_to_port_error` are now closed by separate source-only contracts',
+]) requireText(doc, marker, 'documentation');
 
 if (failures.length > 0) {
   console.error('Payment collection admission diagnostic-safety verification failed:');
   for (const failure of failures) console.error(`✗ ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
-
-console.log(
-  '✔ Payment collection admission diagnostics remain bounded while the separate tenant parser contract is also bounded; canonical PaymentError mapping remains open',
-);
+console.log('✔ Payment collection admission remains bounded while tenant and owner mapper contracts are separately source-closed');

--- a/scripts/verify/verify-payment-collection-owner-error-diagnostic-safety.mjs
+++ b/scripts/verify/verify-payment-collection-owner-error-diagnostic-safety.mjs
@@ -1,0 +1,281 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const requireCount = (source, value, expected, label) => {
+  const count = source.split(value).length - 1;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+};
+
+function functionBody(source, functionName) {
+  const match = new RegExp(`fn\\s+${functionName}\\s*\\(`).exec(source);
+  if (!match) {
+    failures.push(`missing function ${functionName}`);
+    return '';
+  }
+  const openBrace = source.indexOf('{', match.index);
+  if (openBrace < 0) {
+    failures.push(`missing body for ${functionName}`);
+    return '';
+  }
+  let depth = 0;
+  for (let index = openBrace; index < source.length; index += 1) {
+    if (source[index] === '{') depth += 1;
+    if (source[index] === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(openBrace, index + 1);
+    }
+  }
+  failures.push(`unterminated body for ${functionName}`);
+  return '';
+}
+
+const paths = {
+  error: 'crates/rustok-payment/src/error.rs',
+  mapper: 'crates/rustok-payment/src/ports.rs',
+  evidence:
+    'crates/rustok-payment/contracts/evidence/payment-collection-owner-error-diagnostic-safety-source.json',
+  doc: 'crates/rustok-payment/docs/payment-collection-owner-error-diagnostic-safety.md',
+  plan: 'crates/rustok-commerce/docs/implementation-plan.md',
+};
+
+const errorSource = read(paths.error);
+const mapperSource = read(paths.mapper);
+const evidence = JSON.parse(read(paths.evidence));
+const doc = read(paths.doc);
+const plan = read(paths.plan);
+
+for (const marker of [
+  'Validation(String)',
+  'PaymentCollectionNotFound(Uuid)',
+  'PaymentNotFound(Uuid)',
+  'RefundNotFound(Uuid)',
+  'InvalidTransition { from: String, to: String }',
+  'ProviderUnavailable {',
+  'ProviderRejected {',
+  'ProviderInvalidResponse {',
+  'ProviderOutcomeUnknown {',
+  'ProviderConfiguration { provider_id: String }',
+  'Database(#[from] DbErr)',
+]) requireText(errorSource, marker, `${paths.error}: retained PaymentError variant`);
+
+const facts = functionBody(mapperSource, 'payment_collection_owner_error_facts');
+for (const marker of [
+  'PaymentCollectionOwnerErrorFacts',
+  '"validation"',
+  '"payment_collection_not_found"',
+  '"payment_not_found"',
+  '"refund_not_found"',
+  '"invalid_transition"',
+  '"provider_unavailable"',
+  '"provider_rejected"',
+  '"provider_invalid_response"',
+  '"provider_outcome_unknown"',
+  '"provider_configuration"',
+  'crate::PaymentError::Database(_) => ("database", 0, 0, 0, 0, true)',
+  'value.chars().count()',
+  'from.chars().count() + to.chars().count()',
+  'provider_id.chars().count() + operation.chars().count()',
+  'if id.is_nil() { 0 } else { 1 }',
+]) requireText(facts, marker, `${paths.mapper}: owner error shape policy`);
+for (const forbidden of [
+  'format!(',
+  '.to_string()',
+  'error.to_string()',
+  'provider_id =',
+  'provider_operation =',
+  'database_error =',
+]) forbidText(facts, forbidden, `${paths.mapper}: owner payload values`);
+requireCount(
+  facts,
+  'if id.is_nil() { 0 } else { 1 }',
+  3,
+  `${paths.mapper}: three UUID-bearing variants`,
+);
+
+const stableCode = functionBody(mapperSource, 'payment_collection_owner_error_code');
+for (const marker of [
+  'crate::PaymentError::Validation(_) => "payment.validation"',
+  'crate::PaymentError::PaymentCollectionNotFound(_) => "payment.collection_not_found"',
+  'crate::PaymentError::PaymentNotFound(_) => "payment.payment_not_found"',
+  'crate::PaymentError::RefundNotFound(_) => "payment.refund_not_found"',
+  'crate::PaymentError::InvalidTransition { .. } => "payment.invalid_transition"',
+  'crate::PaymentError::ProviderUnavailable { .. } => "payment.provider_unavailable"',
+  'crate::PaymentError::ProviderRejected { .. } => "payment.provider_rejected"',
+  '"payment.provider_invalid_response"',
+  '"payment.provider_outcome_unknown"',
+  'crate::PaymentError::ProviderConfiguration { .. } => "payment.provider_not_configured"',
+  'crate::PaymentError::Database(_) => "payment.database_unavailable"',
+]) requireText(stableCode, marker, `${paths.mapper}: stable owner code`);
+
+const severity = functionBody(
+  mapperSource,
+  'payment_collection_owner_error_is_technical',
+);
+for (const marker of [
+  'crate::PaymentError::ProviderUnavailable { .. }',
+  'crate::PaymentError::ProviderInvalidResponse { .. }',
+  'crate::PaymentError::ProviderOutcomeUnknown { .. }',
+  'crate::PaymentError::ProviderConfiguration { .. }',
+  'crate::PaymentError::Database(_)',
+]) requireText(severity, marker, `${paths.mapper}: technical severity policy`);
+
+const mapper = functionBody(mapperSource, 'payment_error_to_port_error');
+for (const marker of [
+  'let code = payment_collection_owner_error_code(&error);',
+  'let technical_failure = payment_collection_owner_error_is_technical(&error);',
+  'let error_facts = payment_collection_owner_error_facts(&error);',
+  'owner = PAYMENT_COLLECTION_OWNER',
+  'owner_error_variant = error_facts.error_variant',
+  'owner_error_text_field_count = error_facts.text_field_count',
+  'owner_error_text_total_length = error_facts.text_total_length',
+  'owner_error_uuid_field_count = error_facts.uuid_field_count',
+  'owner_error_uuid_non_nil_count = error_facts.uuid_non_nil_count',
+  'owner_error_opaque_payload_present = error_facts.opaque_payload_present',
+  'correlation_id = %context.correlation_id',
+  'tenant_id_length',
+  'actor_kind',
+  'actor_id_length',
+  'claim_count',
+  'role_count',
+  'channel_present',
+  'locale_length',
+  'causation_id_present',
+  'traceparent_present',
+  'idempotency_key_present',
+  'deadline_ms = ?context.deadline_ms',
+  'operation = owner_operation',
+  'code,',
+  'boundary = PAYMENT_COLLECTION_PORT_BOUNDARY',
+  '"payment collection owner operation failed"',
+  '"payment collection owner operation was rejected"',
+]) requireText(mapper, marker, `${paths.mapper}: safe owner mapper diagnostics`);
+for (const forbidden of [
+  'error = ?error',
+  'error = %error',
+  'cause = %message',
+  'tenant_id = %context.tenant_id',
+  'actor = ?context.actor',
+  'channel = ?context.channel',
+  'locale = %context.locale',
+  'causation_id = ?context.causation_id',
+  'traceparent = ?context.traceparent',
+  'idempotency_key = ?context.idempotency_key',
+  'provider_id = %provider_id',
+  'provider_operation = %operation',
+  'from = %from',
+  'to = %to',
+]) forbidText(mapper, forbidden, `${paths.mapper}: complete owner payload diagnostics`);
+requireCount(mapper, 'tracing::error!(', 1, `${paths.mapper}: technical event count`);
+requireCount(mapper, 'tracing::warn!(', 1, `${paths.mapper}: ordinary event count`);
+
+for (const marker of [
+  'PortError::validation("payment.validation", "payment request is invalid")',
+  '"payment.collection_not_found",\n            "payment collection was not found"',
+  'PortError::not_found("payment.payment_not_found", "payment was not found")',
+  'PortError::not_found("payment.refund_not_found", "refund was not found")',
+  '"payment.invalid_transition",\n            "payment lifecycle conflicts with the requested operation"',
+  '"payment.provider_unavailable",\n            "payment provider is temporarily unavailable"',
+  '"payment.provider_rejected",\n            "payment provider rejected the requested operation"',
+  '"payment.provider_invalid_response",\n            "payment provider response could not be applied safely"',
+  '"payment.provider_outcome_unknown",\n            "payment provider outcome requires reconciliation"',
+  '"payment.provider_not_configured",\n            "payment provider is not configured for the requested operation"',
+  '"payment.database_unavailable",\n            "payment storage is temporarily unavailable"',
+]) requireText(mapper, marker, `${paths.mapper}: preserved public mapping`);
+for (const forbidden of [
+  'format!("payment collection {id} not found")',
+  'format!("payment for collection {id} not found")',
+  'format!("refund {id} not found")',
+]) forbidText(mapper, forbidden, `${paths.mapper}: identifier-bearing public message`);
+
+if (
+  evidence.status !==
+  'payment_collection_owner_error_diagnostic_safety_source_unvalidated'
+) failures.push(`${paths.evidence}: unexpected status ${evidence.status}`);
+for (const [key, expected] of Object.entries({
+  payment_error_variant_count: 11,
+  complete_payment_error_logged: false,
+  database_error_text_logged: false,
+  validation_text_logged: false,
+  transition_text_logged: false,
+  provider_id_text_logged: false,
+  provider_operation_text_logged: false,
+  raw_context_values_logged: false,
+  static_error_variant_logged: true,
+  text_field_shape_logged: true,
+  uuid_field_shape_logged: true,
+  opaque_database_payload_presence_logged: true,
+  correlation_preserved: true,
+  owner_operations_preserved: true,
+  severity_split_preserved: true,
+  static_not_found_public_messages: true,
+  public_codes_kinds_retryability_preserved: true,
+  collection_flow_changed: false,
+  admission_mapper_changed: false,
+  tenant_parser_changed: false,
+  commerce_orchestration_changed: false,
+  ffa_promoted: false,
+  fba_promoted: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push(`${paths.evidence}: execution must remain empty`);
+}
+for (const key of [
+  'tests_run',
+  'cargo_run',
+  'format_run',
+  'verifiers_run',
+  'workflow_checks_run',
+  'ci_run',
+  'runtime_proven',
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+
+requireText(doc, 'Status: **source-ready / unvalidated**', `${paths.doc}: status`);
+requireText(
+  doc,
+  'The mapper records only a closed variant and aggregate field shape',
+  `${paths.doc}: bounded policy`,
+);
+requireText(
+  doc,
+  'Payment collection not-found envelopes no longer interpolate owner UUIDs',
+  `${paths.doc}: static not-found messages`,
+);
+requireText(
+  plan,
+  'Finish correlation-safe mapper cleanup',
+  `${paths.plan}: broad ecommerce cleanup remains open`,
+);
+
+if (failures.length > 0) {
+  console.error('Payment collection owner-error diagnostic-safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Payment collection owner mapping uses bounded PaymentError/context shape, static public not-found messages, and stable correlation-aware severity',
+);

--- a/scripts/verify/verify-payment-collection-tenant-context.mjs
+++ b/scripts/verify/verify-payment-collection-tenant-context.mjs
@@ -10,11 +10,12 @@ const root = configuredRoot
   : new URL('../../', import.meta.url);
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
 const source = read('crates/rustok-payment/src/ports.rs');
-const evidence = JSON.parse(
-  read(
-    'crates/rustok-payment/contracts/evidence/payment-collection-tenant-diagnostic-safety-source.json',
-  ),
-);
+const tenantEvidence = JSON.parse(read(
+  'crates/rustok-payment/contracts/evidence/payment-collection-tenant-diagnostic-safety-source.json',
+));
+const ownerEvidence = JSON.parse(read(
+  'crates/rustok-payment/contracts/evidence/payment-collection-owner-error-diagnostic-safety-source.json',
+));
 const doc = read('crates/rustok-payment/docs/payment-collection-tenant-context.md');
 const failures = [];
 
@@ -35,62 +36,27 @@ const between = (content, start, end, label) => {
   return content.slice(startIndex, endIndex);
 };
 
-const createBlock = between(
-  source,
-  '    async fn create_or_reuse_collection(',
-  '    async fn read_collection_status(',
-  'create or reuse implementation',
-);
-const readBlock = between(
-  source,
-  '    async fn read_collection_status(',
-  '\n}\n\nfn require_payment_collection_read_admission(',
-  'status read implementation',
-);
-const admissionBlock = between(
-  source,
-  'fn require_payment_collection_read_admission(',
-  'fn parse_port_tenant_id(',
-  'payment collection admission block',
-);
-const tenantParser = between(
-  source,
-  'fn parse_port_tenant_id(',
-  'fn payment_error_to_port_error(',
-  'tenant parser and diagnostics',
-);
-const ownerMapperStart = source.indexOf('fn payment_error_to_port_error(');
-if (ownerMapperStart < 0) failures.push('payment owner mapper: unable to isolate source block');
+const createBlock = between(source, '    async fn create_or_reuse_collection(', '    async fn read_collection_status(', 'create implementation');
+const readBlock = between(source, '    async fn read_collection_status(', '\n}\n\nfn require_payment_collection_read_admission(', 'status implementation');
+const admissionBlock = between(source, 'fn require_payment_collection_read_admission(', 'fn parse_port_tenant_id(', 'admission block');
+const tenantParser = between(source, 'fn parse_port_tenant_id(', '#[derive(Debug)]\nstruct PaymentCollectionOwnerErrorFacts', 'tenant parser');
+const ownerMapperStart = source.indexOf('#[derive(Debug)]\nstruct PaymentCollectionOwnerErrorFacts');
 const ownerMapper = ownerMapperStart >= 0 ? source.slice(ownerMapperStart) : '';
-
-for (const [value, label] of [
-  ['const PAYMENT_COLLECTION_PORT_BOUNDARY: &str = "payment_collection_port";', 'stable boundary identity'],
-  ['const PAYMENT_COLLECTION_OWNER: &str = "rustok_payment";', 'truthful owner identity'],
-  ['const CREATE_OR_REUSE_COLLECTION_OPERATION: &str = "create_or_reuse_collection";', 'create owner operation'],
-  ['const READ_COLLECTION_STATUS_OPERATION: &str = "read_collection_status";', 'status owner operation'],
-]) requireText(source, value, label);
+if (ownerMapperStart < 0) failures.push('owner mapper contract: unable to isolate source block');
 
 for (const [content, values, label] of [
-  [
-    createBlock,
-    [
-      'let owner_operation = CREATE_OR_REUSE_COLLECTION_OPERATION;',
-      'require_payment_collection_write_admission(&context, owner_operation)?;',
-      'let tenant_id = parse_port_tenant_id(&context, owner_operation)?;',
-      'find_reusable_collection_by_cart(tenant_id, cart_id)',
-    ],
-    'create tenant parsing order',
-  ],
-  [
-    readBlock,
-    [
-      'let owner_operation = READ_COLLECTION_STATUS_OPERATION;',
-      'require_payment_collection_read_admission(&context, owner_operation)?;',
-      'let tenant_id = parse_port_tenant_id(&context, owner_operation)?;',
-      'get_collection(tenant_id, request.collection_id)',
-    ],
-    'read tenant parsing order',
-  ],
+  [createBlock, [
+    'let owner_operation = CREATE_OR_REUSE_COLLECTION_OPERATION;',
+    'require_payment_collection_write_admission(&context, owner_operation)?;',
+    'let tenant_id = parse_port_tenant_id(&context, owner_operation)?;',
+    'find_reusable_collection_by_cart(tenant_id, cart_id)',
+  ], 'create tenant ordering'],
+  [readBlock, [
+    'let owner_operation = READ_COLLECTION_STATUS_OPERATION;',
+    'require_payment_collection_read_admission(&context, owner_operation)?;',
+    'let tenant_id = parse_port_tenant_id(&context, owner_operation)?;',
+    'get_collection(tenant_id, request.collection_id)',
+  ], 'read tenant ordering'],
 ]) {
   let previous = -1;
   for (const value of values) {
@@ -101,115 +67,73 @@ for (const [content, values, label] of [
   }
 }
 
-const parserCalls = source.match(/parse_port_tenant_id\(&context, owner_operation\)\?/g) ?? [];
-if (parserCalls.length !== 2) {
-  failures.push(`expected two operation-aware tenant parser calls, found ${parserCalls.length}`);
+if ((source.match(/parse_port_tenant_id\(&context, owner_operation\)\?/g) ?? []).length !== 2) {
+  failures.push('expected exactly two operation-aware tenant parser calls');
 }
 
 for (const [value, label] of [
-  ['context: &PortContext', 'retained context input'],
-  ["owner_operation: &'static str", 'exact owner operation input'],
-  ['Uuid::parse_str(&context.tenant_id).map_err(|parse_error| {', 'tenant UUID parsing and mapping'],
+  ['Uuid::parse_str(&context.tenant_id).map_err(|parse_error| {', 'tenant UUID parsing'],
   ['let error = PortError::validation(', 'stable validation construction'],
   ['"payment.tenant_id_invalid"', 'stable validation code'],
   ['"PortContext.tenant_id must be a UUID for payment ports"', 'stable validation message'],
   ['let parse_error_type = std::any::type_name_of_val(&parse_error);', 'type-only parse cause'],
-  ['tenant_id_parse_failed = true', 'explicit parse-failure fact'],
-  ['let actor_kind = match &context.actor.kind', 'closed actor kind'],
-  ['let tenant_id_length = context.tenant_id.chars().count();', 'tenant identity shape'],
-  ['let actor_id_length = context.actor.id.chars().count();', 'actor identity shape'],
-  ['let claim_count = context.claims.len();', 'claim count'],
-  ['let role_count = context.roles.len();', 'role count'],
-  ['let channel_present = context.channel.is_some();', 'channel presence'],
-  ['let channel_length = context.channel.as_ref()', 'channel length'],
-  ['let locale_length = context.locale.chars().count();', 'locale length'],
-  ['let causation_id_present = context.causation_id.is_some();', 'causation presence'],
-  ['let causation_id_length = context', 'causation length'],
-  ['let traceparent_present = context.traceparent.is_some();', 'trace presence'],
-  ['let traceparent_length = context', 'trace length'],
-  ['let idempotency_key_present = context.idempotency_key.is_some();', 'idempotency presence'],
-  ['let idempotency_key_length = context', 'idempotency length'],
-  ['let internal_message_present = !error.message.trim().is_empty();', 'message presence'],
-  ['let internal_message_length = error.message.chars().count();', 'message length'],
-  ['let error_kind = "validation";', 'closed validation kind'],
-  ['owner = PAYMENT_COLLECTION_OWNER', 'truthful owner field'],
-  ['correlation_id = %context.correlation_id', 'correlation context'],
-  ['deadline_ms = ?context.deadline_ms', 'deadline context'],
-  ['operation = owner_operation', 'exact operation field'],
+  ['tenant_id_parse_failed = true', 'parse-failure fact'],
+  ['tenant_id_length', 'tenant shape'],
+  ['actor_kind', 'actor kind'],
+  ['claim_count', 'claim count'],
+  ['role_count', 'role count'],
+  ['channel_present', 'channel presence'],
+  ['locale_length', 'locale length'],
+  ['causation_id_present', 'causation presence'],
+  ['traceparent_present', 'trace presence'],
+  ['idempotency_key_present', 'idempotency presence'],
+  ['internal_message_present', 'message presence'],
+  ['internal_message_length', 'message length'],
+  ['let error_kind = "validation";', 'closed kind'],
+  ['correlation_id = %context.correlation_id', 'correlation'],
+  ['operation = owner_operation', 'owner operation'],
   ['validation = "tenant_id"', 'validation phase'],
-  ['code = %error.code', 'mapped code'],
-  ['internal_message_present', 'message presence diagnostic'],
-  ['internal_message_length', 'message length diagnostic'],
-  ['error_kind', 'closed kind diagnostic'],
-  ['retryable = error.retryable', 'retryability'],
-  ['boundary = PAYMENT_COLLECTION_PORT_BOUNDARY', 'boundary field'],
-  ['tracing::warn!(', 'validation rejection severity'],
-  ['"payment collection tenant context was rejected"', 'tenant rejection event'],
+  ['boundary = PAYMENT_COLLECTION_PORT_BOUNDARY', 'boundary'],
+  ['"payment collection tenant context was rejected"', 'event'],
 ]) requireText(tenantParser, value, label);
-
 for (const value of [
-  'parse_error = ?parse_error',
-  'parse_error = %parse_error',
-  'error = ?error',
-  'error = %error',
-  'tenant_id = %context.tenant_id',
-  'actor = ?context.actor',
-  'channel = ?context.channel',
-  'locale = %context.locale',
-  'causation_id = ?context.causation_id',
-  'traceparent = ?context.traceparent',
-  'idempotency_key = ?context.idempotency_key',
-  'internal_message = %error.message',
+  'parse_error = ?parse_error', 'parse_error = %parse_error', 'error = ?error',
+  'error = %error', 'tenant_id = %context.tenant_id', 'actor = ?context.actor',
+  'channel = ?context.channel', 'locale = %context.locale',
+  'causation_id = ?context.causation_id', 'traceparent = ?context.traceparent',
+  'idempotency_key = ?context.idempotency_key', 'internal_message = %error.message',
   'error_kind = ?error.kind',
-]) forbidText(tenantParser, value, 'unsafe tenant diagnostic payload');
+]) forbidText(tenantParser, value, 'unsafe tenant payload');
+if (countText(tenantParser, 'tracing::warn!(') !== 1) failures.push('tenant parser must have one warning path');
 
-if (countText(tenantParser, 'tracing::warn!(') !== 1) {
-  failures.push('tenant parser must retain exactly one warning diagnostic path');
-}
+for (const marker of [
+  'context.require_policy(PortCallPolicy::read())',
+  'context.require_policy(PortCallPolicy::write())',
+  'context.require_write_semantics()',
+  'log_payment_collection_admission_rejection(',
+]) requireText(admissionBlock, marker, 'admission remains mounted');
 
-const validationIndex = tenantParser.indexOf('let error = PortError::validation(');
-const factsIndex = tenantParser.indexOf('let parse_error_type =');
-const diagnosticsIndex = tenantParser.indexOf('tracing::warn!(');
-const returnIndex = tenantParser.lastIndexOf('\n        error');
-if (
-  !(
-    validationIndex >= 0 &&
-    validationIndex < factsIndex &&
-    factsIndex < diagnosticsIndex &&
-    diagnosticsIndex < returnIndex
-  )
-) {
-  failures.push('tenant validation must be constructed, reduced to bounded facts, diagnosed, and returned in order');
-}
+for (const marker of [
+  'struct PaymentCollectionOwnerErrorFacts',
+  'payment_collection_owner_error_facts(&error)',
+  'owner_error_variant = error_facts.error_variant',
+  'owner_error_text_total_length = error_facts.text_total_length',
+  'owner_error_uuid_non_nil_count = error_facts.uuid_non_nil_count',
+  'owner_error_opaque_payload_present = error_facts.opaque_payload_present',
+  '"payment collection was not found"',
+  '"payment was not found"',
+  '"refund was not found"',
+]) requireText(ownerMapper, marker, 'separately closed owner mapper');
+for (const value of [
+  'cause = %message', 'provider_id = %provider_id', 'provider_operation = %operation',
+  'from = %from', 'to = %to', 'error = ?error', 'tenant_id = %context.tenant_id',
+  'format!("payment collection {id} not found")',
+  'format!("payment for collection {id} not found")',
+  'format!("refund {id} not found")',
+]) forbidText(ownerMapper, value, 'owner mapper regression');
 
-for (const [value, label] of [
-  ['log_payment_collection_admission_rejection(', 'admission diagnostics remain mounted'],
-  ['context.require_policy(PortCallPolicy::read())', 'read policy remains unchanged'],
-  ['context.require_policy(PortCallPolicy::write())', 'write policy remains unchanged'],
-  ['context.require_write_semantics()', 'write semantics remain unchanged'],
-  ['let error_kind = match &error.kind', 'bounded admission kind remains unchanged'],
-]) requireText(admissionBlock, value, label);
-
-for (const [value, label] of [
-  ['"create_or_reuse_collection.read_existing"', 'existing lookup operation'],
-  ['"create_or_reuse_collection.adopt_race"', 'race adoption operation'],
-  ['"create_or_reuse_collection.create"', 'create operation'],
-  ['cause = %message', 'canonical validation payload remains separate'],
-  ['provider_id = %provider_id', 'canonical provider payload remains separate'],
-  ['error = ?error', 'canonical database payload remains separate'],
-  ['"payment provider outcome requires reconciliation"', 'stable reconciliation envelope'],
-  ['"payment storage is temporarily unavailable"', 'stable storage envelope'],
-]) requireText(ownerMapper, value, label);
-
-forbidText(source, 'parse_port_tenant_id(&context)?', 'operation-free tenant parser call');
-forbidText(
-  tenantParser,
-  'Uuid::parse_str(&context.tenant_id).map_err(|_|',
-  'silent tenant parse rejection',
-);
-
-if (evidence.status !== 'payment_collection_tenant_diagnostic_safety_source_unvalidated') {
-  failures.push(`evidence status mismatch: ${evidence.status}`);
+if (tenantEvidence.status !== 'payment_collection_tenant_diagnostic_safety_source_unvalidated') {
+  failures.push(`tenant evidence status mismatch: ${tenantEvidence.status}`);
 }
 for (const [key, expected] of Object.entries({
   tenant_parser_bounded: true,
@@ -230,41 +154,33 @@ for (const [key, expected] of Object.entries({
   public_port_error_changed: false,
   ffa_promoted: false,
   fba_promoted: false,
-})) {
-  if (evidence.source_contract?.[key] !== expected) {
-    failures.push(`evidence source_contract.${key} must be ${expected}`);
-  }
+})) if (tenantEvidence.source_contract?.[key] !== expected) failures.push(`tenant evidence ${key} must be ${expected}`);
+
+if (ownerEvidence.status !== 'payment_collection_owner_error_diagnostic_safety_source_unvalidated') {
+  failures.push(`owner evidence status mismatch: ${ownerEvidence.status}`);
 }
-if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
-  failures.push('evidence execution must remain empty');
+if (ownerEvidence.source_contract?.complete_payment_error_logged !== false ||
+    ownerEvidence.source_contract?.static_not_found_public_messages !== true) {
+  failures.push('owner evidence must retain bounded mapper and static not-found contract');
 }
-for (const key of [
-  'tests_run',
-  'cargo_run',
-  'format_run',
-  'verifiers_run',
-  'workflow_checks_run',
-  'ci_run',
-  'runtime_proven',
-]) {
-  if (evidence.validation?.[key] !== false) {
-    failures.push(`evidence validation.${key} must remain false`);
+
+for (const [label, evidence] of [['tenant', tenantEvidence], ['owner', ownerEvidence]]) {
+  if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) failures.push(`${label} execution must remain empty`);
+  for (const key of ['tests_run','cargo_run','format_run','verifiers_run','workflow_checks_run','ci_run','runtime_proven']) {
+    if (evidence.validation?.[key] !== false) failures.push(`${label} validation.${key} must remain false`);
   }
 }
 
-for (const [value, label] of [
-  ['Status: **source-ready / unvalidated**', 'documentation status'],
-  ['Tenant diagnostics retain only the parse-error type and bounded context/message-shape facts', 'documentation bounded policy'],
-  ['The same constructed validation `PortError` is returned after diagnostics', 'documentation error pass-through'],
-  ['Canonical `payment_error_to_port_error` remains the next separate cleanup slice', 'documentation residual boundary'],
-]) requireText(doc, value, label);
+for (const marker of [
+  'Status: **source-ready / unvalidated**',
+  'Tenant diagnostics retain only the parse-error type and bounded context/message-shape facts',
+  'The same constructed validation `PortError` is returned after diagnostics',
+  'Canonical `payment_error_to_port_error` is now closed by a separate source-only contract',
+]) requireText(doc, marker, 'documentation');
 
 if (failures.length > 0) {
   console.error('Payment collection tenant diagnostic-safety verification failed:');
   for (const failure of failures) console.error(`✗ ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
-
-console.log(
-  '✔ Payment collection tenant UUID rejection uses type-only parse cause and bounded context/message facts while preserving the exact validation envelope and operation-aware routing',
-);
+console.log('✔ Payment collection tenant rejection remains bounded and the canonical owner mapper is separately source-closed');


### PR DESCRIPTION
## Summary

Continue the ecommerce correlation-safe mapper cleanup at the next documented Payment Collection boundary.

- replace raw `PaymentError`, provider, database, transition, and delegated-context diagnostics in the canonical collection mapper with a closed owner-error variant and aggregate field-shape facts
- keep correlation id, exact owner operation, stable code, bounded context shape, and the existing technical-versus-ordinary severity split
- replace collection/payment/refund not-found messages that interpolated owner UUIDs with static public envelopes
- add a focused source-only evidence contract, documentation, and verifier
- synchronize the existing admission, tenant, and aggregate ecommerce guards without promoting Payment FFA/FBA status

## Preserved behavior

- `PaymentCollectionPort` traits and DTOs
- admission and tenant parsing order
- collection lookup, create, race adoption, and status reads
- public error codes, kinds, retryability, and provider reconciliation policy
- checkout execution, compensation, and Commerce orchestration

## Validation

Tests, verifiers, formatting, Cargo checks, workflow checks, and CI were not run per maintainer request. Suggested commands are retained in the source-only evidence and documentation.