### PR TITLE
feat(index): add bounded drift digest producer

### DIFF
--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-03.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-03.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-03
 
-Status overlay for `implementation-plan.md` audited at
-`main@e66540bceffe0ae23ee2d04e0f39a1a6ab08aaeb`.
+Status overlay for `implementation-plan.md` audited through
+`main@2c24dbf93cfa1ecb436755c7986232f05e4ddab5`.
 
 When the older canonical plan's current-state bullets conflict with this dated overlay, this
 overlay is the rechecked source of truth. Historical architecture, ownership, and milestone
@@ -9,11 +9,12 @@ details remain in `implementation-plan.md`.
 
 ## Current cursor
 
-`M6 - bounded drift diagnosis and repair admission`
+`M6 - locale-complete persisted findings and authoritative snapshot capture`
 
-Bounded finding inspection and persistence for already-computed digest mismatches are source
-complete. Authoritative digest production, lifecycle commands, targeted repair, transports, and
-retained evidence remain open.
+The database-neutral snapshot-pair digest producer is source complete and delegates unequal
+locale-bearing entity digests to the existing finding writer. A production snapshot reader,
+locale-free persisted entity scope, lifecycle commands, targeted repair, transports, and retained
+evidence remain open.
 
 ## Rechecked status
 
@@ -35,6 +36,8 @@ retained evidence remain open.
   `source_complete_owner_execution_pending`
 - M6 bounded drift-finding inspection and persistence:
   `source_complete_owner_execution_pending`
+- M6 snapshot-pair digest producer and mismatch-only recorder delegation:
+  `source_complete_snapshot_reader_pending`
 - M7 Product/ProductVariant/SalesChannel bounded replay graph:
   `source_complete_owner_execution_pending`
 
@@ -66,7 +69,14 @@ retained evidence remain open.
 - [x] Add a real-migration PostgreSQL harness for deterministic finding-key serialization and
       create/refresh/reopen/suppression lifecycle preservation.
 - [ ] Run and admit `drift_finding_writer_postgres_test` evidence.
-- [ ] Add authoritative digest production under a defined owner snapshot or watermark.
+- [x] Add a database-neutral producer for one exact source/materialized snapshot pair with one
+      bounded consistency token, exact scope revalidation, typed-state validation, deterministic
+      SHA-256 production, and mismatch-only recorder delegation.
+- [x] Adapt locale-bearing producer mismatches to `PostgresIndexDriftFindingWriter` with bounded
+      retryable/permanent failure classification.
+- [ ] Extend persisted entity finding scope to locale-free `EntityKey` values without changing
+      existing locale-bearing finding identities.
+- [ ] Add one production snapshot reader under a defined PostgreSQL snapshot or owner watermark.
 - [ ] Add missing/stale entity and orphan-link diagnosis without unbounded ID collection.
 - [ ] Add resolve/ignore lifecycle commands with actor/reason audit and fail-closed authorization.
 - [ ] Add targeted repair with before/after admitted evidence.
@@ -85,21 +95,24 @@ retained evidence remain open.
 
 ## Next implementation step
 
-Define a bounded producer contract that computes exactly one authoritative source/index digest
-pair for an exact tenant/schema/entity scope under one admitted consistency boundary. Delegate
-only unequal SHA-256 digests to the existing writer. Keep diagnosis separate from lifecycle
-commands and repair execution.
+Make persisted entity finding scope locale-optional while preserving the existing finding-key bytes
+for every locale-bearing scope. Add a distinct deterministic no-locale key component, update writer
+and inspector validation, and retain SQLite/static coverage. Only then compose the first production
+snapshot reader so generic no-locale schemas cannot fail after an otherwise valid comparison.
 
 ## Owner verification for this slice
 
 ```bash
+cargo test -p rustok-index drift_digest -- --nocapture
+cargo check -p rustok-index --all-targets
+node scripts/verify/verify-index-drift-digest-producer.mjs
+
 RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
   cargo test -p rustok-index \
   --test drift_finding_writer_postgres_test \
   -- --nocapture --test-threads=1
 
 node scripts/verify/verify-index-drift-finding-postgres-harness.mjs
-cargo check -p rustok-index --all-targets
 git diff --check
 ```
 

--- a/crates/rustok-index/docs/m6-drift-digest-producer.md
+++ b/crates/rustok-index/docs/m6-drift-digest-producer.md
@@ -1,0 +1,94 @@
+# M6 bounded drift digest producer
+
+Status: `producer_contract_source_complete_snapshot_reader_and_scope_completion_pending`
+
+## Purpose
+
+The existing drift-finding writer accepts already-computed source and materialized digests. This
+slice adds the database-neutral producer between an admitted snapshot reader and that persistence
+boundary. It does not invent a snapshot, open source tables, scan unbounded identifiers, or perform
+repair.
+
+## Snapshot contract
+
+`IndexDriftSnapshotReader` captures exactly one requested `EntityKey` and returns two typed views:
+
+- authoritative source state;
+- current materialized Index state.
+
+Both views must carry the same bounded opaque `IndexDriftSnapshotBoundary`. Pair construction fails
+when boundaries or entity keys differ. The producer independently rechecks both returned keys
+against the request before validating or hashing either state.
+
+A state is exactly one of:
+
+- `missing` with the complete entity key;
+- `upsert` with a complete `IndexRecord`;
+- `delete` with the complete entity key and positive source version.
+
+Every source and materialized state is validated through the current `SchemaRegistry`. Invalid
+schema, tenant, entity, locale, field, link, value, or source-version state fails before hashing and
+before persistence.
+
+The opaque boundary is evidence that the reader captured both views under one owner-defined
+consistency rule. This slice does not define PostgreSQL snapshot export, owner high-watermarks, or
+cross-database transaction semantics. A reader that cannot establish one truthful boundary must
+return a bounded dependency failure rather than fabricate a pair.
+
+## Digest contract
+
+The producer serializes the typed state with postcard, prefixes the
+`index_drift_entity_state_digest_v1` domain, length-prefixes both components, and computes lowercase
+SHA-256. `missing`, `delete`, and `upsert` have distinct enum domains. `IndexRecord.fields` retain
+`BTreeMap` ordering; link and target order remains significant because it represents materialized
+relation ordinal semantics.
+
+Equal digests return `Consistent` and never call the recorder. Unequal digests create one bounded
+`IndexDriftDigestMismatch` containing only:
+
+- the exact entity key;
+- the opaque consistency-boundary token;
+- source digest;
+- materialized digest.
+
+Raw records, fields, links, source payloads, SQL, database errors, and transport context are not
+accepted by the recorder contract.
+
+## PostgreSQL writer adapter
+
+`PostgresIndexDriftFindingWriter` implements `IndexDriftMismatchRecorder` and maps writer lifecycle
+outcomes to `Created`, `Refreshed`, `Reopened`, or `Suppressed` receipts. Storage failure remains a
+bounded retryable dependency code; unsupported backend and request/receipt contract failures are
+bounded permanent codes.
+
+The current persisted `IndexDriftFindingScope::Entity` requires a locale. Therefore the adapter
+fails closed with `index_drift_locale_free_scope_unsupported` for `EntityKey { locale: None }`.
+It does not collapse such findings into schema scope or invent a locale. The generic producer itself
+supports locale-free keys; extending persisted finding scope is the next required storage-contract
+slice.
+
+## Deliberate limits
+
+This slice does not add or claim:
+
+- a production source/materialized snapshot reader;
+- PostgreSQL exported-snapshot or owner high-watermark admission;
+- automatic entity discovery, full scans, or orphan-link diagnosis;
+- locale-free persisted entity findings;
+- finding resolution when states converge;
+- resolve/ignore commands, actor/reason audit, or authorization;
+- targeted/full/shadow repair;
+- GraphQL, HTTP, CLI, admin, scheduler, or graceful-shutdown composition;
+- retained PostgreSQL or production-source execution evidence.
+
+## Maintainer verification
+
+```bash
+cargo test -p rustok-index drift_digest -- --nocapture
+cargo check -p rustok-index --all-targets
+node scripts/verify/verify-index-drift-digest-producer.mjs
+git diff --check
+```
+
+Tests, verifiers, formatting, Cargo commands, PostgreSQL runs, workflows, and CI were not executed by
+the implementation agent.

--- a/crates/rustok-index/src/application/drift_digest.rs
+++ b/crates/rustok-index/src/application/drift_digest.rs
@@ -1,0 +1,703 @@
+use std::{fmt, sync::Arc};
+
+use async_trait::async_trait;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::{EntityKey, IndexMutation, IndexRecord, RecordValidationError, SchemaRegistry};
+
+const MAX_BOUNDARY_BYTES: usize = 191;
+const MAX_FAILURE_CODE_BYTES: usize = 128;
+const DIGEST_BYTES: usize = 64;
+const ENTITY_STATE_DIGEST_CONTRACT: &[u8] = b"index_drift_entity_state_digest_v1";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexDriftSnapshotBoundary(String);
+
+impl IndexDriftSnapshotBoundary {
+    pub fn new(value: impl Into<String>) -> Result<Self, IndexDriftDigestError> {
+        let value = value.into();
+        if value.is_empty()
+            || value.len() > MAX_BOUNDARY_BYTES
+            || value.trim() != value
+            || !value.bytes().all(|byte| {
+                byte.is_ascii_alphanumeric()
+                    || matches!(byte, b'-' | b'_' | b'.' | b':' | b'/')
+            })
+        {
+            return Err(IndexDriftDigestError::InvalidSnapshotBoundary);
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for IndexDriftSnapshotBoundary {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum IndexDriftEntityState {
+    Missing { key: EntityKey },
+    Upsert { record: IndexRecord },
+    Delete { key: EntityKey, source_version: u64 },
+}
+
+impl IndexDriftEntityState {
+    pub fn missing(key: EntityKey) -> Self {
+        Self::Missing { key }
+    }
+
+    pub fn upsert(record: IndexRecord) -> Self {
+        Self::Upsert { record }
+    }
+
+    pub fn delete(key: EntityKey, source_version: u64) -> Self {
+        Self::Delete {
+            key,
+            source_version,
+        }
+    }
+
+    pub fn from_mutation(mutation: IndexMutation) -> Self {
+        match mutation {
+            IndexMutation::Upsert { record, .. } => Self::Upsert { record },
+            IndexMutation::Delete {
+                key,
+                source_version,
+                ..
+            } => Self::Delete {
+                key,
+                source_version,
+            },
+        }
+    }
+
+    pub fn key(&self) -> &EntityKey {
+        match self {
+            Self::Missing { key } | Self::Delete { key, .. } => key,
+            Self::Upsert { record } => &record.key,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexDriftSnapshotView {
+    boundary: IndexDriftSnapshotBoundary,
+    state: IndexDriftEntityState,
+}
+
+impl IndexDriftSnapshotView {
+    pub fn new(boundary: IndexDriftSnapshotBoundary, state: IndexDriftEntityState) -> Self {
+        Self { boundary, state }
+    }
+
+    pub fn boundary(&self) -> &IndexDriftSnapshotBoundary {
+        &self.boundary
+    }
+
+    pub fn state(&self) -> &IndexDriftEntityState {
+        &self.state
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexDriftSnapshotPair {
+    boundary: IndexDriftSnapshotBoundary,
+    source: IndexDriftEntityState,
+    materialized: IndexDriftEntityState,
+}
+
+impl IndexDriftSnapshotPair {
+    pub fn new(
+        source: IndexDriftSnapshotView,
+        materialized: IndexDriftSnapshotView,
+    ) -> Result<Self, IndexDriftDigestError> {
+        if source.boundary != materialized.boundary {
+            return Err(IndexDriftDigestError::SnapshotBoundaryMismatch);
+        }
+        if source.state.key() != materialized.state.key() {
+            return Err(IndexDriftDigestError::SnapshotKeyMismatch);
+        }
+        Ok(Self {
+            boundary: source.boundary,
+            source: source.state,
+            materialized: materialized.state,
+        })
+    }
+
+    pub fn boundary(&self) -> &IndexDriftSnapshotBoundary {
+        &self.boundary
+    }
+
+    pub fn source(&self) -> &IndexDriftEntityState {
+        &self.source
+    }
+
+    pub fn materialized(&self) -> &IndexDriftEntityState {
+        &self.materialized
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexDriftDigestRequest {
+    key: EntityKey,
+}
+
+impl IndexDriftDigestRequest {
+    pub fn new(key: EntityKey) -> Result<Self, IndexDriftDigestError> {
+        if key.tenant_id.is_nil() {
+            return Err(IndexDriftDigestError::NilTenantId);
+        }
+        if key.entity_id.is_nil() {
+            return Err(IndexDriftDigestError::NilEntityId);
+        }
+        if key.schema.version.get() == 0 {
+            return Err(IndexDriftDigestError::ZeroSchemaVersion);
+        }
+        Ok(Self { key })
+    }
+
+    pub fn key(&self) -> &EntityKey {
+        &self.key
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexDriftDependencyFailureKind {
+    Retryable,
+    Permanent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("Index drift dependency reported a {kind:?} failure ({code})")]
+pub struct IndexDriftDependencyFailure {
+    kind: IndexDriftDependencyFailureKind,
+    code: String,
+}
+
+impl IndexDriftDependencyFailure {
+    pub fn retryable(code: impl Into<String>) -> Result<Self, IndexDriftDigestError> {
+        Self::new(IndexDriftDependencyFailureKind::Retryable, code)
+    }
+
+    pub fn permanent(code: impl Into<String>) -> Result<Self, IndexDriftDigestError> {
+        Self::new(IndexDriftDependencyFailureKind::Permanent, code)
+    }
+
+    fn new(
+        kind: IndexDriftDependencyFailureKind,
+        code: impl Into<String>,
+    ) -> Result<Self, IndexDriftDigestError> {
+        let code = code.into();
+        if !valid_machine_name(&code) {
+            return Err(IndexDriftDigestError::InvalidFailureCode(code));
+        }
+        Ok(Self { kind, code })
+    }
+
+    pub fn kind(&self) -> IndexDriftDependencyFailureKind {
+        self.kind
+    }
+
+    pub fn code(&self) -> &str {
+        &self.code
+    }
+}
+
+#[async_trait]
+pub trait IndexDriftSnapshotReader: Send + Sync {
+    async fn capture_entity_snapshot(
+        &self,
+        request: &IndexDriftDigestRequest,
+    ) -> Result<IndexDriftSnapshotPair, IndexDriftDependencyFailure>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexDriftMismatchRecordStatus {
+    Created,
+    Refreshed,
+    Reopened,
+    Suppressed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexDriftMismatchReceipt {
+    status: IndexDriftMismatchRecordStatus,
+    finding_id: Uuid,
+    finding_key: String,
+}
+
+impl IndexDriftMismatchReceipt {
+    pub(crate) fn new(
+        status: IndexDriftMismatchRecordStatus,
+        finding_id: Uuid,
+        finding_key: impl Into<String>,
+    ) -> Result<Self, IndexDriftDigestError> {
+        let finding_key = finding_key.into();
+        if finding_id.is_nil() || !valid_digest(&finding_key) {
+            return Err(IndexDriftDigestError::InvalidRecorderReceipt);
+        }
+        Ok(Self {
+            status,
+            finding_id,
+            finding_key,
+        })
+    }
+
+    pub fn status(&self) -> IndexDriftMismatchRecordStatus {
+        self.status
+    }
+
+    pub fn finding_id(&self) -> Uuid {
+        self.finding_id
+    }
+
+    pub fn finding_key(&self) -> &str {
+        &self.finding_key
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexDriftDigestMismatch {
+    boundary: IndexDriftSnapshotBoundary,
+    key: EntityKey,
+    source_digest: String,
+    materialized_digest: String,
+}
+
+impl IndexDriftDigestMismatch {
+    pub fn boundary(&self) -> &IndexDriftSnapshotBoundary {
+        &self.boundary
+    }
+
+    pub fn key(&self) -> &EntityKey {
+        &self.key
+    }
+
+    pub fn source_digest(&self) -> &str {
+        &self.source_digest
+    }
+
+    pub fn materialized_digest(&self) -> &str {
+        &self.materialized_digest
+    }
+}
+
+#[async_trait]
+pub trait IndexDriftMismatchRecorder: Send + Sync {
+    async fn record_digest_mismatch(
+        &self,
+        mismatch: &IndexDriftDigestMismatch,
+    ) -> Result<IndexDriftMismatchReceipt, IndexDriftDependencyFailure>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IndexDriftDigestOutcome {
+    Consistent {
+        digest: String,
+    },
+    MismatchRecorded {
+        source_digest: String,
+        materialized_digest: String,
+        receipt: IndexDriftMismatchReceipt,
+    },
+}
+
+pub struct IndexDriftDigestProducer<R, W> {
+    registry: Arc<SchemaRegistry>,
+    snapshots: R,
+    recorder: W,
+}
+
+impl<R, W> fmt::Debug for IndexDriftDigestProducer<R, W> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("IndexDriftDigestProducer")
+            .finish_non_exhaustive()
+    }
+}
+
+impl<R, W> IndexDriftDigestProducer<R, W>
+where
+    R: IndexDriftSnapshotReader,
+    W: IndexDriftMismatchRecorder,
+{
+    pub fn new(registry: Arc<SchemaRegistry>, snapshots: R, recorder: W) -> Self {
+        Self {
+            registry,
+            snapshots,
+            recorder,
+        }
+    }
+
+    pub async fn produce(
+        &self,
+        request: IndexDriftDigestRequest,
+    ) -> Result<IndexDriftDigestOutcome, IndexDriftDigestError> {
+        let pair = self
+            .snapshots
+            .capture_entity_snapshot(&request)
+            .await
+            .map_err(IndexDriftDigestError::SnapshotCaptureFailed)?;
+
+        if pair.source().key() != request.key() || pair.materialized().key() != request.key() {
+            return Err(IndexDriftDigestError::SnapshotScopeMismatch);
+        }
+
+        validate_state(self.registry.as_ref(), pair.source())
+            .map_err(IndexDriftDigestError::InvalidSourceState)?;
+        validate_state(self.registry.as_ref(), pair.materialized())
+            .map_err(IndexDriftDigestError::InvalidMaterializedState)?;
+
+        let source_digest = digest_state(pair.source())?;
+        let materialized_digest = digest_state(pair.materialized())?;
+        if source_digest == materialized_digest {
+            return Ok(IndexDriftDigestOutcome::Consistent {
+                digest: source_digest,
+            });
+        }
+
+        let mismatch = IndexDriftDigestMismatch {
+            boundary: pair.boundary().clone(),
+            key: request.key,
+            source_digest: source_digest.clone(),
+            materialized_digest: materialized_digest.clone(),
+        };
+        let receipt = self
+            .recorder
+            .record_digest_mismatch(&mismatch)
+            .await
+            .map_err(IndexDriftDigestError::MismatchRecordFailed)?;
+        Ok(IndexDriftDigestOutcome::MismatchRecorded {
+            source_digest,
+            materialized_digest,
+            receipt,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum IndexDriftDigestError {
+    #[error("Index drift digest tenant id must not be nil")]
+    NilTenantId,
+    #[error("Index drift digest entity id must not be nil")]
+    NilEntityId,
+    #[error("Index drift digest schema version must be positive")]
+    ZeroSchemaVersion,
+    #[error("Index drift snapshot boundary is invalid")]
+    InvalidSnapshotBoundary,
+    #[error("Index drift snapshot views do not share one consistency boundary")]
+    SnapshotBoundaryMismatch,
+    #[error("Index drift snapshot views do not describe the same entity key")]
+    SnapshotKeyMismatch,
+    #[error("Index drift snapshot does not match the requested entity scope")]
+    SnapshotScopeMismatch,
+    #[error("Index drift dependency failure code is invalid: {0}")]
+    InvalidFailureCode(String),
+    #[error("Index drift snapshot capture failed")]
+    SnapshotCaptureFailed(#[source] IndexDriftDependencyFailure),
+    #[error("Index drift source state is invalid")]
+    InvalidSourceState(#[source] RecordValidationError),
+    #[error("Index drift materialized state is invalid")]
+    InvalidMaterializedState(#[source] RecordValidationError),
+    #[error("Index drift state digest serialization failed")]
+    DigestSerializationFailed,
+    #[error("Index drift mismatch recorder returned an invalid receipt")]
+    InvalidRecorderReceipt,
+    #[error("Index drift mismatch persistence failed")]
+    MismatchRecordFailed(#[source] IndexDriftDependencyFailure),
+}
+
+fn validate_state(
+    registry: &SchemaRegistry,
+    state: &IndexDriftEntityState,
+) -> Result<(), RecordValidationError> {
+    let mutation = match state {
+        IndexDriftEntityState::Missing { key } => IndexMutation::Delete {
+            event_id: Uuid::nil(),
+            key: key.clone(),
+            source_version: 1,
+        },
+        IndexDriftEntityState::Upsert { record } => IndexMutation::Upsert {
+            event_id: Uuid::nil(),
+            record: record.clone(),
+        },
+        IndexDriftEntityState::Delete {
+            key,
+            source_version,
+        } => IndexMutation::Delete {
+            event_id: Uuid::nil(),
+            key: key.clone(),
+            source_version: *source_version,
+        },
+    };
+    registry.validate_mutation(&mutation)
+}
+
+fn digest_state(state: &IndexDriftEntityState) -> Result<String, IndexDriftDigestError> {
+    let encoded = postcard::to_allocvec(state)
+        .map_err(|_| IndexDriftDigestError::DigestSerializationFailed)?;
+    let mut hasher = Sha256::new();
+    write_bytes(&mut hasher, ENTITY_STATE_DIGEST_CONTRACT);
+    write_bytes(&mut hasher, &encoded);
+    Ok(hex::encode(hasher.finalize()))
+}
+
+fn write_bytes(hasher: &mut Sha256, value: &[u8]) {
+    hasher.update((value.len() as u64).to_be_bytes());
+    hasher.update(value);
+}
+
+fn valid_machine_name(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_FAILURE_CODE_BYTES
+        && value.bytes().all(|byte| {
+            byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || matches!(byte, b'-' | b'_' | b'.')
+        })
+}
+
+fn valid_digest(value: &str) -> bool {
+    value.len() == DIGEST_BYTES
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeMap,
+        sync::{Arc, Mutex},
+    };
+
+    use async_trait::async_trait;
+
+    use super::*;
+    use crate::{
+        EntityName, FieldCardinality, FieldName, IndexField, IndexSchema, IndexValue,
+        IndexValueType, LocaleMode, ModuleName, SchemaRef, SchemaVersion,
+    };
+
+    #[derive(Clone)]
+    struct SnapshotFixture {
+        pair: IndexDriftSnapshotPair,
+    }
+
+    #[async_trait]
+    impl IndexDriftSnapshotReader for SnapshotFixture {
+        async fn capture_entity_snapshot(
+            &self,
+            _request: &IndexDriftDigestRequest,
+        ) -> Result<IndexDriftSnapshotPair, IndexDriftDependencyFailure> {
+            Ok(self.pair.clone())
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct RecorderFixture {
+        mismatches: Arc<Mutex<Vec<IndexDriftDigestMismatch>>>,
+    }
+
+    #[async_trait]
+    impl IndexDriftMismatchRecorder for RecorderFixture {
+        async fn record_digest_mismatch(
+            &self,
+            mismatch: &IndexDriftDigestMismatch,
+        ) -> Result<IndexDriftMismatchReceipt, IndexDriftDependencyFailure> {
+            self.mismatches.lock().unwrap().push(mismatch.clone());
+            Ok(IndexDriftMismatchReceipt::new(
+                IndexDriftMismatchRecordStatus::Created,
+                Uuid::from_u128(9),
+                "a".repeat(DIGEST_BYTES),
+            )
+            .unwrap())
+        }
+    }
+
+    fn schema_ref() -> SchemaRef {
+        SchemaRef {
+            module: ModuleName::new("drift-test").unwrap(),
+            entity: EntityName::new("item").unwrap(),
+            version: SchemaVersion::INITIAL,
+        }
+    }
+
+    fn registry() -> Arc<SchemaRegistry> {
+        let mut registry = SchemaRegistry::new();
+        registry
+            .register(IndexSchema {
+                reference: schema_ref(),
+                locale_mode: LocaleMode::None,
+                fields: vec![IndexField {
+                    name: FieldName::new("name").unwrap(),
+                    value_type: IndexValueType::String,
+                    cardinality: FieldCardinality::One,
+                    nullable: false,
+                    selectable: true,
+                    filterable: true,
+                    sortable: true,
+                }],
+                links: Vec::new(),
+            })
+            .unwrap();
+        Arc::new(registry)
+    }
+
+    fn key() -> EntityKey {
+        EntityKey {
+            tenant_id: Uuid::from_u128(1),
+            schema: schema_ref(),
+            entity_id: Uuid::from_u128(2),
+            locale: None,
+        }
+    }
+
+    fn record(name: &str, source_version: u64) -> IndexRecord {
+        IndexRecord {
+            key: key(),
+            source_version,
+            fields: BTreeMap::from([(
+                FieldName::new("name").unwrap(),
+                IndexValue::String(name.to_owned()),
+            )]),
+            links: Vec::new(),
+        }
+    }
+
+    fn view(state: IndexDriftEntityState) -> IndexDriftSnapshotView {
+        IndexDriftSnapshotView::new(
+            IndexDriftSnapshotBoundary::new("snapshot:42/0").unwrap(),
+            state,
+        )
+    }
+
+    #[tokio::test]
+    async fn equal_snapshot_states_do_not_call_the_recorder() {
+        let pair = IndexDriftSnapshotPair::new(
+            view(IndexDriftEntityState::upsert(record("same", 7))),
+            view(IndexDriftEntityState::upsert(record("same", 7))),
+        )
+        .unwrap();
+        let recorder = RecorderFixture::default();
+        let producer = IndexDriftDigestProducer::new(
+            registry(),
+            SnapshotFixture { pair },
+            recorder.clone(),
+        );
+
+        let outcome = producer
+            .produce(IndexDriftDigestRequest::new(key()).unwrap())
+            .await
+            .unwrap();
+        assert!(matches!(outcome, IndexDriftDigestOutcome::Consistent { .. }));
+        assert!(recorder.mismatches.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn unequal_snapshot_states_record_only_bounded_digests() {
+        let pair = IndexDriftSnapshotPair::new(
+            view(IndexDriftEntityState::upsert(record("source", 8))),
+            view(IndexDriftEntityState::upsert(record("index", 7))),
+        )
+        .unwrap();
+        let recorder = RecorderFixture::default();
+        let producer = IndexDriftDigestProducer::new(
+            registry(),
+            SnapshotFixture { pair },
+            recorder.clone(),
+        );
+
+        let outcome = producer
+            .produce(IndexDriftDigestRequest::new(key()).unwrap())
+            .await
+            .unwrap();
+        let IndexDriftDigestOutcome::MismatchRecorded {
+            source_digest,
+            materialized_digest,
+            receipt,
+        } = outcome
+        else {
+            panic!("mismatch must be recorded");
+        };
+        assert_ne!(source_digest, materialized_digest);
+        assert!(valid_digest(&source_digest));
+        assert!(valid_digest(&materialized_digest));
+        assert_eq!(receipt.status(), IndexDriftMismatchRecordStatus::Created);
+
+        let retained = recorder.mismatches.lock().unwrap();
+        assert_eq!(retained.len(), 1);
+        assert_eq!(retained[0].key(), &key());
+        assert_eq!(retained[0].boundary().as_str(), "snapshot:42/0");
+        assert_eq!(retained[0].source_digest(), source_digest);
+        assert_eq!(retained[0].materialized_digest(), materialized_digest);
+    }
+
+    #[test]
+    fn snapshot_pair_rejects_different_boundaries_and_keys() {
+        let source = view(IndexDriftEntityState::missing(key()));
+        let materialized = IndexDriftSnapshotView::new(
+            IndexDriftSnapshotBoundary::new("snapshot:43/0").unwrap(),
+            IndexDriftEntityState::missing(key()),
+        );
+        assert!(matches!(
+            IndexDriftSnapshotPair::new(source, materialized),
+            Err(IndexDriftDigestError::SnapshotBoundaryMismatch)
+        ));
+
+        let mut other_key = key();
+        other_key.entity_id = Uuid::from_u128(3);
+        assert!(matches!(
+            IndexDriftSnapshotPair::new(
+                view(IndexDriftEntityState::missing(key())),
+                view(IndexDriftEntityState::missing(other_key)),
+            ),
+            Err(IndexDriftDigestError::SnapshotKeyMismatch)
+        ));
+    }
+
+    #[tokio::test]
+    async fn invalid_materialized_state_fails_before_recording() {
+        let pair = IndexDriftSnapshotPair::new(
+            view(IndexDriftEntityState::upsert(record("source", 8))),
+            view(IndexDriftEntityState::delete(key(), 0)),
+        )
+        .unwrap();
+        let recorder = RecorderFixture::default();
+        let producer = IndexDriftDigestProducer::new(
+            registry(),
+            SnapshotFixture { pair },
+            recorder.clone(),
+        );
+
+        assert!(matches!(
+            producer
+                .produce(IndexDriftDigestRequest::new(key()).unwrap())
+                .await,
+            Err(IndexDriftDigestError::InvalidMaterializedState(
+                RecordValidationError::ZeroSourceVersion
+            ))
+        ));
+        assert!(recorder.mismatches.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn missing_delete_and_upsert_states_have_distinct_digest_domains() {
+        let missing = digest_state(&IndexDriftEntityState::missing(key())).unwrap();
+        let deleted = digest_state(&IndexDriftEntityState::delete(key(), 1)).unwrap();
+        let upsert = digest_state(&IndexDriftEntityState::upsert(record("value", 1))).unwrap();
+        assert_ne!(missing, deleted);
+        assert_ne!(missing, upsert);
+        assert_ne!(deleted, upsert);
+    }
+}

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -1,5 +1,6 @@
 mod aggregate_ordering;
 mod cursor;
+mod drift_digest;
 mod mutation_event;
 mod planner;
 mod postgres_compiler;
@@ -34,11 +35,18 @@ mod source_replay_tests;
 
 pub use aggregate_ordering::AggregateOrderValidationError;
 pub use cursor::{CursorCodec, CursorCodecError, CursorValidationError, IndexCursor};
+pub use drift_digest::{
+    IndexDriftDependencyFailure, IndexDriftDependencyFailureKind, IndexDriftDigestError,
+    IndexDriftDigestMismatch, IndexDriftDigestOutcome, IndexDriftDigestProducer,
+    IndexDriftDigestRequest, IndexDriftEntityState, IndexDriftMismatchReceipt,
+    IndexDriftMismatchRecordStatus, IndexDriftMismatchRecorder, IndexDriftSnapshotBoundary,
+    IndexDriftSnapshotPair, IndexDriftSnapshotReader, IndexDriftSnapshotView,
+};
 pub use mutation_event::{
     IndexMutationAcknowledgeFailure, IndexMutationAcknowledgeFailureKind,
-    IndexMutationEventCatalog, IndexMutationEventDelivery, IndexMutationEventDescriptor,
-    IndexMutationEventError, IndexMutationEventProcessError, IndexMutationEventProcessOutcome,
-    IndexMutationEventWorker, IndexMutationEventAcknowledger, SharedIndexMutationEventRegistry,
+    IndexMutationEventAcknowledger, IndexMutationEventCatalog, IndexMutationEventDelivery,
+    IndexMutationEventDescriptor, IndexMutationEventError, IndexMutationEventProcessError,
+    IndexMutationEventProcessOutcome, IndexMutationEventWorker, SharedIndexMutationEventRegistry,
     materialize_index_mutation_event_registry, register_index_mutation_event,
 };
 pub use planner::{
@@ -47,14 +55,12 @@ pub use planner::{
 };
 pub use postgres_compiler::{
     CompiledManyRelationColumn, CompiledPostgresCount, CompiledPostgresQuery,
-    CompiledQueryColumn, PostgresBindValue, PostgresQueryBuildError,
-    PostgresQueryCompileError,
+    CompiledQueryColumn, PostgresBindValue, PostgresQueryBuildError, PostgresQueryCompileError,
 };
 pub use postgres_query_result::{
     CompiledPostgresCell, CompiledPostgresPageQuery, CompiledPostgresRow,
     IndexNestedRelationItem, IndexNestedRelationProjection, IndexProjectedValue, IndexQueryItem,
-    IndexQueryPage, IndexRelationIdentity, PostgresQueryDecodeError,
-    PostgresQueryPageBuildError,
+    IndexQueryPage, IndexRelationIdentity, PostgresQueryDecodeError, PostgresQueryPageBuildError,
 };
 pub use query_port::{
     IndexQueryExecutionError, IndexQueryPort, PersistedSchemaReadinessFailure,
@@ -63,9 +69,7 @@ pub use query_runtime::SharedIndexQueryRuntime;
 pub use registry::{
     LinkPathStep, RegisteredSchema, RegistrationOutcome, SchemaRegistry, SchemaRegistryError,
 };
-pub use source_event_id::{
-    IndexSourceEventIdError, derive_index_source_event_id,
-};
+pub use source_event_id::{IndexSourceEventIdError, derive_index_source_event_id};
 pub use source_registry::{
     IndexSource, IndexSourceCatalog, IndexSourceCursor, IndexSourceDescriptor, IndexSourceError,
     IndexSourceFailure, IndexSourceFailureKind, IndexSourceLoadBatch, IndexSourceLoadRequest,
@@ -74,9 +78,8 @@ pub use source_registry::{
 };
 pub use source_replay::{
     IndexReplayCheckpoint, IndexReplayCheckpointKey, IndexReplayCheckpointStore, IndexReplayError,
-    IndexReplayFailure, IndexReplayFailureKind, IndexReplayMutationOutcome,
-    IndexReplayMutationSink, IndexReplayPageOutcome, IndexReplayPageRequest,
-    IndexReplayPageStatus, IndexReplayWorker,
+    IndexReplayFailure, IndexReplayFailureKind, IndexReplayMutationOutcome, IndexReplayMutationSink,
+    IndexReplayPageOutcome, IndexReplayPageRequest, IndexReplayPageStatus, IndexReplayWorker,
 };
 pub use source_schema_registry::{
     IndexSchemaSourceCatalog, IndexSchemaSourceDescriptor, IndexSchemaSourceError,

--- a/crates/rustok-index/src/infrastructure/postgres/drift_digest_recorder.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/drift_digest_recorder.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 
 use crate::{
-    IndexDriftDependencyFailure, IndexDriftDigestError, IndexDriftDigestMismatch,
-    IndexDriftMismatchReceipt, IndexDriftMismatchRecordStatus, IndexDriftMismatchRecorder,
+    IndexDriftDependencyFailure, IndexDriftDigestMismatch, IndexDriftMismatchReceipt,
+    IndexDriftMismatchRecordStatus, IndexDriftMismatchRecorder,
 };
 
 use super::drift_finding_inspector::{IndexDriftFindingScope, IndexDriftFindingSeverity};
@@ -105,6 +105,3 @@ fn permanent_failure(code: &'static str) -> IndexDriftDependencyFailure {
     IndexDriftDependencyFailure::permanent(code)
         .expect("static Index drift permanent failure code is valid")
 }
-
-#[allow(dead_code)]
-fn _error_contract_is_public(_: IndexDriftDigestError) {}

--- a/crates/rustok-index/src/infrastructure/postgres/drift_digest_recorder.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/drift_digest_recorder.rs
@@ -1,0 +1,110 @@
+use async_trait::async_trait;
+
+use crate::{
+    IndexDriftDependencyFailure, IndexDriftDigestError, IndexDriftDigestMismatch,
+    IndexDriftMismatchReceipt, IndexDriftMismatchRecordStatus, IndexDriftMismatchRecorder,
+};
+
+use super::drift_finding_inspector::{IndexDriftFindingScope, IndexDriftFindingSeverity};
+use super::drift_finding_writer::{
+    IndexDriftDigestFindingRequest, IndexDriftFindingWriteError, IndexDriftFindingWriteOutcome,
+    PostgresIndexDriftFindingWriter,
+};
+
+const CHECK_NAME: &str = "source_index_digest_mismatch";
+const LOCALE_SCOPE_UNSUPPORTED: &str = "index_drift_locale_free_scope_unsupported";
+const REQUEST_REJECTED: &str = "index_drift_finding_request_rejected";
+const STORAGE_FAILED: &str = "index_drift_finding_storage_failed";
+const BACKEND_UNSUPPORTED: &str = "index_drift_finding_backend_unsupported";
+const RECEIPT_INVALID: &str = "index_drift_finding_receipt_invalid";
+
+#[async_trait]
+impl IndexDriftMismatchRecorder for PostgresIndexDriftFindingWriter {
+    async fn record_digest_mismatch(
+        &self,
+        mismatch: &IndexDriftDigestMismatch,
+    ) -> Result<IndexDriftMismatchReceipt, IndexDriftDependencyFailure> {
+        let key = mismatch.key();
+        let Some(locale) = key.locale.clone() else {
+            return Err(permanent_failure(LOCALE_SCOPE_UNSUPPORTED));
+        };
+        let request = IndexDriftDigestFindingRequest::new(
+            key.tenant_id,
+            CHECK_NAME,
+            IndexDriftFindingSeverity::Error,
+            IndexDriftFindingScope::Entity {
+                schema: key.schema.clone(),
+                entity_id: key.entity_id,
+                locale,
+            },
+            mismatch.source_digest(),
+            mismatch.materialized_digest(),
+        )
+        .map_err(map_request_error)?;
+
+        let outcome = PostgresIndexDriftFindingWriter::record_digest_mismatch(self, &request)
+            .await
+            .map_err(map_write_error)?;
+        let (status, finding_id, finding_key) = match outcome {
+            IndexDriftFindingWriteOutcome::Created {
+                finding_id,
+                finding_key,
+            } => (
+                IndexDriftMismatchRecordStatus::Created,
+                finding_id,
+                finding_key,
+            ),
+            IndexDriftFindingWriteOutcome::Refreshed {
+                finding_id,
+                finding_key,
+            } => (
+                IndexDriftMismatchRecordStatus::Refreshed,
+                finding_id,
+                finding_key,
+            ),
+            IndexDriftFindingWriteOutcome::Reopened {
+                finding_id,
+                finding_key,
+            } => (
+                IndexDriftMismatchRecordStatus::Reopened,
+                finding_id,
+                finding_key,
+            ),
+            IndexDriftFindingWriteOutcome::Suppressed {
+                finding_id,
+                finding_key,
+            } => (
+                IndexDriftMismatchRecordStatus::Suppressed,
+                finding_id,
+                finding_key,
+            ),
+        };
+        IndexDriftMismatchReceipt::new(status, finding_id, finding_key)
+            .map_err(|_| permanent_failure(RECEIPT_INVALID))
+    }
+}
+
+fn map_request_error(_error: IndexDriftFindingWriteError) -> IndexDriftDependencyFailure {
+    permanent_failure(REQUEST_REJECTED)
+}
+
+fn map_write_error(error: IndexDriftFindingWriteError) -> IndexDriftDependencyFailure {
+    match error {
+        IndexDriftFindingWriteError::Storage => retryable_failure(STORAGE_FAILED),
+        IndexDriftFindingWriteError::UnsupportedBackend => permanent_failure(BACKEND_UNSUPPORTED),
+        _ => permanent_failure(REQUEST_REJECTED),
+    }
+}
+
+fn retryable_failure(code: &'static str) -> IndexDriftDependencyFailure {
+    IndexDriftDependencyFailure::retryable(code)
+        .expect("static Index drift retryable failure code is valid")
+}
+
+fn permanent_failure(code: &'static str) -> IndexDriftDependencyFailure {
+    IndexDriftDependencyFailure::permanent(code)
+        .expect("static Index drift permanent failure code is valid")
+}
+
+#[allow(dead_code)]
+fn _error_contract_is_public(_: IndexDriftDigestError) {}

--- a/crates/rustok-index/src/infrastructure/postgres/mod.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/mod.rs
@@ -1,3 +1,4 @@
+mod drift_digest_recorder;
 mod drift_finding_inspector;
 mod drift_finding_writer;
 mod mutation_store;
@@ -50,10 +51,10 @@ pub use mutation_store::{
     MutationApplyOutcome, MutationDelivery, MutationStorageError, PostgresMutationStore,
 };
 pub use partition_admission::{
-    evaluate_partition_admission, PartitionAdmissionError, PartitionAdmissionOutcome,
-    PartitionAdmissionPolicy, PartitionAdmissionReason, PartitionBaselineEvidence,
-    PartitionEvidence, PartitionMeasurementCoverage, PartitionRelationPlan,
-    PartitionShadowEvidence, PartitionShadowPlan, PartitionStrategy,
+    PartitionAdmissionError, PartitionAdmissionOutcome, PartitionAdmissionPolicy,
+    PartitionAdmissionReason, PartitionBaselineEvidence, PartitionEvidence,
+    PartitionMeasurementCoverage, PartitionRelationPlan, PartitionShadowEvidence,
+    PartitionShadowPlan, PartitionStrategy, evaluate_partition_admission,
 };
 pub use query_port::PostgresIndexQueryPort;
 pub use query_runtime::{

--- a/scripts/verify/verify-index-drift-digest-producer.mjs
+++ b/scripts/verify/verify-index-drift-digest-producer.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+
+const files = {
+  producer: "crates/rustok-index/src/application/drift_digest.rs",
+  applicationMod: "crates/rustok-index/src/application/mod.rs",
+  recorder: "crates/rustok-index/src/infrastructure/postgres/drift_digest_recorder.rs",
+  postgresMod: "crates/rustok-index/src/infrastructure/postgres/mod.rs",
+  doc: "crates/rustok-index/docs/m6-drift-digest-producer.md",
+  plan: "crates/rustok-index/docs/implementation-plan-current-2026-08-03.md",
+};
+
+const [producer, applicationMod, recorder, postgresMod, doc, plan] = await Promise.all(
+  Object.values(files).map((path) => readFile(path, "utf8")),
+);
+
+function requireMarkers(label, content, markers) {
+  for (const marker of markers) {
+    if (!content.includes(marker)) {
+      throw new Error(`${label} is missing required marker: ${marker}`);
+    }
+  }
+}
+
+requireMarkers(files.producer, producer, [
+  'b"index_drift_entity_state_digest_v1"',
+  "pub trait IndexDriftSnapshotReader",
+  "pub trait IndexDriftMismatchRecorder",
+  "pub struct IndexDriftSnapshotPair",
+  "SnapshotBoundaryMismatch",
+  "SnapshotScopeMismatch",
+  "registry.validate_mutation(&mutation)",
+  "postcard::to_allocvec(state)",
+  "if source_digest == materialized_digest",
+  ".record_digest_mismatch(&mismatch)",
+  "IndexDriftEntityState::Missing",
+  "IndexDriftEntityState::Delete",
+  "IndexDriftEntityState::Upsert",
+]);
+
+requireMarkers(files.recorder, recorder, [
+  "impl IndexDriftMismatchRecorder for PostgresIndexDriftFindingWriter",
+  'const CHECK_NAME: &str = "source_index_digest_mismatch";',
+  'const LOCALE_SCOPE_UNSUPPORTED: &str = "index_drift_locale_free_scope_unsupported";',
+  "let Some(locale) = key.locale.clone() else",
+  "IndexDriftFindingScope::Entity",
+  "PostgresIndexDriftFindingWriter::record_digest_mismatch",
+  "IndexDriftMismatchRecordStatus::Suppressed",
+]);
+
+requireMarkers(files.applicationMod, applicationMod, [
+  "mod drift_digest;",
+  "IndexDriftDigestProducer",
+  "IndexDriftSnapshotReader",
+]);
+requireMarkers(files.postgresMod, postgresMod, ["mod drift_digest_recorder;"]);
+requireMarkers(files.doc, doc, [
+  "producer_contract_source_complete_snapshot_reader_and_scope_completion_pending",
+  "same bounded opaque `IndexDriftSnapshotBoundary`",
+  "Equal digests return `Consistent` and never call the recorder.",
+  "index_drift_locale_free_scope_unsupported",
+  "does not define PostgreSQL snapshot export",
+]);
+requireMarkers(files.plan, plan, [
+  "M6 snapshot-pair digest producer and mismatch-only recorder delegation",
+  "source_complete_snapshot_reader_pending",
+  "Extend persisted entity finding scope to locale-free",
+  "Add one production snapshot reader",
+]);
+
+const forbiddenProducerMarkers = [
+  "sea_orm",
+  "DatabaseConnection",
+  "SELECT ",
+  "INSERT ",
+  "UPDATE ",
+  "DELETE FROM",
+  "IndexSource::scan",
+  "index_entities",
+  "index_links",
+];
+for (const marker of forbiddenProducerMarkers) {
+  if (producer.includes(marker)) {
+    throw new Error(`database-neutral producer contains forbidden dependency marker: ${marker}`);
+  }
+}
+
+for (const claim of [
+  "tests passed",
+  "snapshot reader is complete",
+  "repair is complete",
+  "retained evidence admitted",
+]) {
+  if (doc.toLowerCase().includes(claim.toLowerCase())) {
+    throw new Error(`documentation makes forbidden completion claim: ${claim}`);
+  }
+}
+
+console.log("Index drift digest producer contract verified");


### PR DESCRIPTION
## Summary

- continue the rechecked `rustok-index` M6 cursor after merged PR #2963;
- add a database-neutral `IndexDriftDigestProducer` for one exact source/materialized entity snapshot pair;
- require both views to carry the same bounded opaque consistency-boundary token and the same exact `EntityKey`;
- recheck both returned keys against the request and validate both typed states through the current `SchemaRegistry` before hashing;
- distinguish `missing`, `delete`, and `upsert` states and compute deterministic lowercase SHA-256 over the versioned postcard state contract;
- return `Consistent` without invoking persistence when digests match;
- delegate only unequal bounded digests to an `IndexDriftMismatchRecorder`;
- implement that recorder for `PostgresIndexDriftFindingWriter`, preserving created/refreshed/reopened/suppressed lifecycle receipts and bounded retryable/permanent failures;
- fail closed for locale-free entity keys because the existing persisted finding scope still requires a locale;
- actualize the dated implementation plan and add focused documentation plus a fail-closed static verifier.

## Producer contract

`IndexDriftSnapshotReader` owns capture of one source state and one materialized Index state under one truthful consistency boundary. The producer does not open source tables, issue SQL, scan identifiers, create a transaction, or invent a watermark.

The reader returns two `IndexDriftSnapshotView` values. Pair construction rejects:

- different boundary tokens;
- different entity keys.

The producer then independently rejects a pair that does not match the requested key. Both states are validated with `SchemaRegistry::validate_mutation` before digest production.

The state wire is domain-separated as:

```text
index_drift_entity_state_digest_v1
```

and includes one exact typed state:

- missing key;
- complete upsert record;
- delete key plus positive source version.

Postcard bytes and the domain are length-prefixed before SHA-256. Field map order is deterministic through `BTreeMap`; link and target order remains significant because it represents relation ordinal semantics.

## Persistence adapter

`PostgresIndexDriftFindingWriter` implements `IndexDriftMismatchRecorder`.

- equal digests never reach the writer;
- unequal locale-bearing entity digests use check `source_index_digest_mismatch` and severity `error`;
- writer lifecycle outcomes map to bounded producer receipts;
- storage errors are retryable;
- unsupported backend and contract/receipt errors are permanent;
- raw source state, materialized state, SQL, database errors, and transport context are not accepted by the recorder DTO.

The current `IndexDriftFindingScope::Entity` contract requires `LocaleKey`, while generic `EntityKey` allows `locale=None`. This adapter explicitly returns `index_drift_locale_free_scope_unsupported` instead of collapsing multiple entities into schema scope or inventing a locale. The plan now makes locale-complete persisted scope the next step.

## Deliberate limits

This PR does not add or claim:

- a production source/materialized snapshot reader;
- PostgreSQL exported snapshots, owner high-watermarks, or cross-database transaction semantics;
- entity discovery, full scans, missing/stale enumeration, or orphan-link diagnosis;
- locale-free persisted entity findings;
- automatic resolution when states converge;
- resolve/ignore commands, actor/reason audit, or operator transport;
- targeted/full/shadow repair;
- scheduler or graceful-shutdown composition;
- retained PostgreSQL or production-source execution evidence.

## Validation

Not run per maintainer instruction:

- formatting;
- Cargo checks, tests, or Clippy;
- JavaScript verifier;
- PostgreSQL scenarios;
- workflows and CI.

Suggested maintainer commands:

```bash
cargo test -p rustok-index drift_digest -- --nocapture
cargo check -p rustok-index --all-targets
node scripts/verify/verify-index-drift-digest-producer.mjs
git diff --check
```

The branch was created from merged Index head `2c24dbf93cfa1ecb436755c7986232f05e4ddab5`. Current `main` subsequently advanced through unrelated Payment/storefront work; the PR diff remains limited to seven expected Index files.