### PR TITLE
fix(commerce): bound storefront HTTP diagnostics

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/storefront-checkout-http-diagnostic-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/storefront-checkout-http-diagnostic-safety-source-review.json
@@ -1,0 +1,49 @@
+{
+  "status": "commerce_storefront_checkout_http_diagnostic_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-commerce/src/controllers/store/checkout.rs",
+    "crates/rustok-commerce/src/storefront_staged_checkout_runtime.rs",
+    "crates/rustok-payment/src/error.rs",
+    "crates/rustok-commerce/docs/storefront-checkout-http-diagnostic-safety.md",
+    "scripts/verify/verify-commerce-storefront-checkout-http-error-context.mjs",
+    "crates/rustok-commerce/docs/implementation-plan.md"
+  ],
+  "review_findings": {
+    "checkout_runtime_variant_count": 7,
+    "payment_error_variant_count": 11,
+    "complete_checkout_error_logged": false,
+    "checkout_validation_text_logged": false,
+    "complete_payment_error_logged": false,
+    "payment_validation_text_logged": false,
+    "payment_transition_text_logged": false,
+    "payment_provider_text_logged": false,
+    "payment_resource_uuid_values_logged": false,
+    "raw_route_identifiers_logged": false,
+    "raw_channel_or_locale_logged": false,
+    "closed_checkout_variant_logged": true,
+    "checkout_text_shape_logged": true,
+    "closed_payment_variant_logged": true,
+    "payment_text_shape_logged": true,
+    "payment_uuid_shape_logged": true,
+    "payment_opaque_payload_presence_logged": true,
+    "public_checkout_policy_preserved": true,
+    "public_payment_policy_preserved": true,
+    "route_flow_changed": false,
+    "idempotency_contract_changed": false,
+    "runtime_retryability_changed": false,
+    "broad_cleanup_remains_open": true,
+    "runtime_evidence_claimed": false
+  },
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed."
+}

--- a/crates/rustok-commerce/docs/storefront-checkout-http-diagnostic-safety.md
+++ b/crates/rustok-commerce/docs/storefront-checkout-http-diagnostic-safety.md
@@ -1,0 +1,90 @@
+# Storefront checkout HTTP diagnostic safety
+
+Status: **source-ready / unvalidated**
+
+## Boundary
+
+This source slice hardens the two public HTTP error mappers in
+`crates/rustok-commerce/src/controllers/store/checkout.rs`:
+
+- `storefront_checkout_http_error`, which maps the staged storefront checkout runtime envelope;
+- `payment_collection_http_error`, which maps direct storefront payment-collection owner errors.
+
+Both mappers already returned stable public `HttpError` envelopes, but their private diagnostics
+recorded complete error payloads and raw tenant, actor, cart, customer, channel, and locale values.
+
+## Checkout runtime mapper
+
+`StorefrontStagedCheckoutRuntimeError` has seven closed variants. The mapper now records only:
+
+- the stable closed variant;
+- text-field count and aggregate character length for `Validation`;
+- boolean/non-nil identity shape for tenant, actor, and cart;
+- channel-ID presence/non-nil shape;
+- channel-slug presence and length;
+- locale length;
+- the static route operation;
+- policy error kind, public code, retryability, numeric HTTP status, and boundary.
+
+It does not record the complete runtime error, validation text, UUID values, channel slug, or
+locale value.
+
+The existing status/code/message/retryability policy is unchanged.
+
+## Payment collection mapper
+
+`PaymentError` has eleven variants. The mapper now records only:
+
+- the stable closed variant;
+- text-field count and aggregate character length;
+- UUID-field count and non-nil count;
+- whether an opaque database payload exists;
+- boolean/non-nil identity shape for tenant, actor, cart, and optional customer;
+- bounded channel and locale shape;
+- the static owner operation;
+- policy error kind, public code, numeric HTTP status, and boundary.
+
+It does not record the complete `PaymentError`, database payload, validation text, transition
+values, provider IDs, provider operation text, collection/payment/refund UUIDs, or raw route
+context.
+
+The existing public payment status, code, message, and route behavior are unchanged.
+
+## Preserved behavior
+
+This source slice does not change:
+
+- storefront channel admission;
+- customer/cart access checks;
+- repricing and context resolution;
+- reusable payment collection lookup;
+- payment collection creation;
+- staged checkout orchestration;
+- request forwarding;
+- idempotency-key validation;
+- checkout runtime public code/message/retryability selection;
+- payment collection HTTP policy;
+- response types or OpenAPI declarations;
+- Commerce or Payment FFA/FBA status.
+
+## Remaining work
+
+The master ecommerce correlation-safe mapper-cleanup item remains open. Separate public-envelope
+and adapter diagnostics remain across other commerce routes and owner modules.
+
+## Evidence
+
+- `crates/rustok-commerce/contracts/evidence/storefront-checkout-http-diagnostic-safety-source-review.json`
+- `scripts/verify/verify-commerce-storefront-checkout-http-error-context.mjs`
+
+Evidence is source-only. The execution list is empty and every validation flag remains false.
+
+## Suggested maintainer checks
+
+These commands were intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-commerce-storefront-checkout-http-error-context.mjs
+node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs
+cargo check -p rustok-commerce --lib
+```

--- a/crates/rustok-commerce/src/controllers/store/checkout.rs
+++ b/crates/rustok-commerce/src/controllers/store/checkout.rs
@@ -19,74 +19,109 @@ const MAX_IDEMPOTENCY_KEY_LENGTH: usize = 191;
 const STOREFRONT_CHECKOUT_OWNER: &str = "rustok_commerce.storefront_staged_checkout_runtime";
 const STOREFRONT_CHECKOUT_BOUNDARY: &str = "commerce_storefront_checkout_http";
 const STOREFRONT_PAYMENT_COLLECTION_OWNER: &str = "rustok_payment.storefront_payment_collections";
-const STOREFRONT_PAYMENT_COLLECTION_BOUNDARY: &str = "commerce_storefront_payment_collection_http";
+const STOREFRONT_PAYMENT_COLLECTION_BOUNDARY: &str =
+    "commerce_storefront_payment_collection_http";
 
 type StorefrontCheckoutHttpPolicy = (StatusCode, &'static str);
-type StorefrontPaymentCollectionHttpPolicy = (StatusCode, &'static str, &'static str, &'static str);
+type StorefrontPaymentCollectionHttpPolicy =
+    (StatusCode, &'static str, &'static str, &'static str);
 
 #[derive(Clone, Copy)]
-struct StorefrontCheckoutErrorContext<'a> {
-    tenant_id: Uuid,
-    actor_id: Uuid,
-    cart_id: Uuid,
-    channel_id: Option<Uuid>,
-    channel_slug: Option<&'a str>,
-    locale: &'a str,
+struct StorefrontCheckoutErrorContext {
+    tenant_id_non_nil: bool,
+    actor_id_non_nil: bool,
+    cart_id_non_nil: bool,
+    channel_id_present: bool,
+    channel_id_non_nil: Option<bool>,
+    channel_slug_present: bool,
+    channel_slug_length: Option<usize>,
+    locale_length: usize,
     operation: &'static str,
 }
 
-impl<'a> StorefrontCheckoutErrorContext<'a> {
+impl StorefrontCheckoutErrorContext {
     fn new(
         tenant_id: Uuid,
         actor_id: Uuid,
         cart_id: Uuid,
-        request_context: &'a RequestContext,
+        request_context: &RequestContext,
         operation: &'static str,
     ) -> Self {
         Self {
-            tenant_id,
-            actor_id,
-            cart_id,
-            channel_id: request_context.channel_id,
-            channel_slug: request_context.channel_slug.as_deref(),
-            locale: request_context.locale.as_str(),
+            tenant_id_non_nil: !tenant_id.is_nil(),
+            actor_id_non_nil: !actor_id.is_nil(),
+            cart_id_non_nil: !cart_id.is_nil(),
+            channel_id_present: request_context.channel_id.is_some(),
+            channel_id_non_nil: request_context.channel_id.map(|value| !value.is_nil()),
+            channel_slug_present: request_context.channel_slug.is_some(),
+            channel_slug_length: request_context
+                .channel_slug
+                .as_ref()
+                .map(|value| value.chars().count()),
+            locale_length: request_context.locale.chars().count(),
             operation,
         }
     }
 }
 
 #[derive(Clone, Copy)]
-struct StorefrontPaymentCollectionErrorContext<'a> {
-    tenant_id: Uuid,
-    actor_id: Uuid,
-    cart_id: Uuid,
-    customer_id: Option<Uuid>,
-    channel_id: Option<Uuid>,
-    channel_slug: Option<&'a str>,
-    locale: &'a str,
+struct StorefrontPaymentCollectionErrorContext {
+    tenant_id_non_nil: bool,
+    actor_id_non_nil: bool,
+    cart_id_non_nil: bool,
+    customer_id_present: bool,
+    customer_id_non_nil: Option<bool>,
+    channel_id_present: bool,
+    channel_id_non_nil: Option<bool>,
+    channel_slug_present: bool,
+    channel_slug_length: Option<usize>,
+    locale_length: usize,
     operation: &'static str,
 }
 
-impl<'a> StorefrontPaymentCollectionErrorContext<'a> {
+impl StorefrontPaymentCollectionErrorContext {
     fn new(
         tenant_id: Uuid,
         actor_id: Uuid,
         cart_id: Uuid,
         customer_id: Option<Uuid>,
-        request_context: &'a RequestContext,
+        request_context: &RequestContext,
         operation: &'static str,
     ) -> Self {
         Self {
-            tenant_id,
-            actor_id,
-            cart_id,
-            customer_id,
-            channel_id: request_context.channel_id,
-            channel_slug: request_context.channel_slug.as_deref(),
-            locale: request_context.locale.as_str(),
+            tenant_id_non_nil: !tenant_id.is_nil(),
+            actor_id_non_nil: !actor_id.is_nil(),
+            cart_id_non_nil: !cart_id.is_nil(),
+            customer_id_present: customer_id.is_some(),
+            customer_id_non_nil: customer_id.map(|value| !value.is_nil()),
+            channel_id_present: request_context.channel_id.is_some(),
+            channel_id_non_nil: request_context.channel_id.map(|value| !value.is_nil()),
+            channel_slug_present: request_context.channel_slug.is_some(),
+            channel_slug_length: request_context
+                .channel_slug
+                .as_ref()
+                .map(|value| value.chars().count()),
+            locale_length: request_context.locale.chars().count(),
             operation,
         }
     }
+}
+
+#[derive(Clone, Copy)]
+struct StorefrontCheckoutRuntimeErrorFacts {
+    error_variant: &'static str,
+    text_field_count: usize,
+    text_total_length: usize,
+}
+
+#[derive(Clone, Copy)]
+struct StorefrontPaymentCollectionErrorFacts {
+    error_variant: &'static str,
+    text_field_count: usize,
+    text_total_length: usize,
+    uuid_field_count: usize,
+    uuid_non_nil_count: usize,
+    opaque_payload_present: bool,
 }
 
 /// Create payment collection from storefront cart
@@ -336,29 +371,90 @@ fn storefront_checkout_error_policy(
     }
 }
 
+fn storefront_checkout_runtime_error_facts(
+    error: &crate::services::storefront_staged_checkout_runtime::StorefrontStagedCheckoutRuntimeError,
+) -> StorefrontCheckoutRuntimeErrorFacts {
+    use crate::services::storefront_staged_checkout_runtime::StorefrontStagedCheckoutRuntimeError;
+
+    match error {
+        StorefrontStagedCheckoutRuntimeError::Validation(message) => {
+            StorefrontCheckoutRuntimeErrorFacts {
+                error_variant: "validation",
+                text_field_count: 1,
+                text_total_length: message.chars().count(),
+            }
+        }
+        StorefrontStagedCheckoutRuntimeError::CartAccess => StorefrontCheckoutRuntimeErrorFacts {
+            error_variant: "cart_access",
+            text_field_count: 0,
+            text_total_length: 0,
+        },
+        StorefrontStagedCheckoutRuntimeError::AuthenticationRequired => {
+            StorefrontCheckoutRuntimeErrorFacts {
+                error_variant: "authentication_required",
+                text_field_count: 0,
+                text_total_length: 0,
+            }
+        }
+        StorefrontStagedCheckoutRuntimeError::TemporarilyUnavailable => {
+            StorefrontCheckoutRuntimeErrorFacts {
+                error_variant: "temporarily_unavailable",
+                text_field_count: 0,
+                text_total_length: 0,
+            }
+        }
+        StorefrontStagedCheckoutRuntimeError::CheckoutFailed => {
+            StorefrontCheckoutRuntimeErrorFacts {
+                error_variant: "checkout_failed",
+                text_field_count: 0,
+                text_total_length: 0,
+            }
+        }
+        StorefrontStagedCheckoutRuntimeError::CompensationPending => {
+            StorefrontCheckoutRuntimeErrorFacts {
+                error_variant: "compensation_pending",
+                text_field_count: 0,
+                text_total_length: 0,
+            }
+        }
+        StorefrontStagedCheckoutRuntimeError::ReconciliationRequired => {
+            StorefrontCheckoutRuntimeErrorFacts {
+                error_variant: "reconciliation_required",
+                text_field_count: 0,
+                text_total_length: 0,
+            }
+        }
+    }
+}
+
 fn storefront_checkout_http_error(
-    context: StorefrontCheckoutErrorContext<'_>,
+    context: StorefrontCheckoutErrorContext,
     error: crate::services::storefront_staged_checkout_runtime::StorefrontStagedCheckoutRuntimeError,
 ) -> HttpError {
     let (status, error_kind) = storefront_checkout_error_policy(&error);
+    let error_facts = storefront_checkout_runtime_error_facts(&error);
     let code = error.public_code();
     let message = error.public_message();
     tracing::error!(
-        error = ?error,
         owner = STOREFRONT_CHECKOUT_OWNER,
-        tenant_id = %context.tenant_id,
-        actor_id = %context.actor_id,
-        cart_id = %context.cart_id,
-        channel_id = ?context.channel_id,
-        channel = ?context.channel_slug,
-        locale = %context.locale,
-        operation = %context.operation,
+        tenant_id_non_nil = context.tenant_id_non_nil,
+        actor_id_non_nil = context.actor_id_non_nil,
+        cart_id_non_nil = context.cart_id_non_nil,
+        channel_id_present = context.channel_id_present,
+        channel_id_non_nil = ?context.channel_id_non_nil,
+        channel_slug_present = context.channel_slug_present,
+        channel_slug_length = ?context.channel_slug_length,
+        locale_length = context.locale_length,
+        operation = context.operation,
+        error_variant = error_facts.error_variant,
+        error_text_field_count = error_facts.text_field_count,
+        error_text_total_length = error_facts.text_total_length,
         error_kind,
         public_code = code,
         retryable = error.retryable(),
-        status = %status,
+        status = status.as_u16(),
         boundary = STOREFRONT_CHECKOUT_BOUNDARY,
-        "storefront checkout request failed"
+        "storefront checkout request failed with bounded diagnostics"
     );
     HttpError::new(status, code, message)
 }
@@ -424,27 +520,146 @@ fn payment_collection_error_policy(error: &PaymentError) -> StorefrontPaymentCol
     }
 }
 
+fn storefront_payment_collection_error_facts(
+    error: &PaymentError,
+) -> StorefrontPaymentCollectionErrorFacts {
+    let (
+        error_variant,
+        text_field_count,
+        text_total_length,
+        uuid_field_count,
+        uuid_non_nil_count,
+        opaque_payload_present,
+    ) = match error {
+        PaymentError::Validation(value) => {
+            ("validation", 1, value.chars().count(), 0, 0, false)
+        }
+        PaymentError::PaymentCollectionNotFound(id) => (
+            "payment_collection_not_found",
+            0,
+            0,
+            1,
+            if id.is_nil() { 0 } else { 1 },
+            false,
+        ),
+        PaymentError::PaymentNotFound(id) => (
+            "payment_not_found",
+            0,
+            0,
+            1,
+            if id.is_nil() { 0 } else { 1 },
+            false,
+        ),
+        PaymentError::RefundNotFound(id) => (
+            "refund_not_found",
+            0,
+            0,
+            1,
+            if id.is_nil() { 0 } else { 1 },
+            false,
+        ),
+        PaymentError::InvalidTransition { from, to } => (
+            "invalid_transition",
+            2,
+            from.chars().count() + to.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        PaymentError::ProviderUnavailable {
+            provider_id,
+            operation,
+        } => (
+            "provider_unavailable",
+            2,
+            provider_id.chars().count() + operation.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        PaymentError::ProviderRejected {
+            provider_id,
+            operation,
+        } => (
+            "provider_rejected",
+            2,
+            provider_id.chars().count() + operation.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        PaymentError::ProviderInvalidResponse {
+            provider_id,
+            operation,
+        } => (
+            "provider_invalid_response",
+            2,
+            provider_id.chars().count() + operation.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        PaymentError::ProviderOutcomeUnknown {
+            provider_id,
+            operation,
+        } => (
+            "provider_outcome_unknown",
+            2,
+            provider_id.chars().count() + operation.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        PaymentError::ProviderConfiguration { provider_id } => (
+            "provider_configuration",
+            1,
+            provider_id.chars().count(),
+            0,
+            0,
+            false,
+        ),
+        PaymentError::Database(_) => ("database", 0, 0, 0, 0, true),
+    };
+    StorefrontPaymentCollectionErrorFacts {
+        error_variant,
+        text_field_count,
+        text_total_length,
+        uuid_field_count,
+        uuid_non_nil_count,
+        opaque_payload_present,
+    }
+}
+
 fn payment_collection_http_error(
-    context: StorefrontPaymentCollectionErrorContext<'_>,
+    context: StorefrontPaymentCollectionErrorContext,
     error: PaymentError,
 ) -> HttpError {
     let (status, code, message, error_kind) = payment_collection_error_policy(&error);
+    let error_facts = storefront_payment_collection_error_facts(&error);
     tracing::error!(
-        error = ?error,
         owner = STOREFRONT_PAYMENT_COLLECTION_OWNER,
-        tenant_id = %context.tenant_id,
-        actor_id = %context.actor_id,
-        cart_id = %context.cart_id,
-        customer_id = ?context.customer_id,
-        channel_id = ?context.channel_id,
-        channel = ?context.channel_slug,
-        locale = %context.locale,
-        operation = %context.operation,
+        tenant_id_non_nil = context.tenant_id_non_nil,
+        actor_id_non_nil = context.actor_id_non_nil,
+        cart_id_non_nil = context.cart_id_non_nil,
+        customer_id_present = context.customer_id_present,
+        customer_id_non_nil = ?context.customer_id_non_nil,
+        channel_id_present = context.channel_id_present,
+        channel_id_non_nil = ?context.channel_id_non_nil,
+        channel_slug_present = context.channel_slug_present,
+        channel_slug_length = ?context.channel_slug_length,
+        locale_length = context.locale_length,
+        operation = context.operation,
+        error_variant = error_facts.error_variant,
+        error_text_field_count = error_facts.text_field_count,
+        error_text_total_length = error_facts.text_total_length,
+        error_uuid_field_count = error_facts.uuid_field_count,
+        error_uuid_non_nil_count = error_facts.uuid_non_nil_count,
+        error_opaque_payload_present = error_facts.opaque_payload_present,
         error_kind,
         public_code = code,
-        status = %status,
+        status = status.as_u16(),
         boundary = STOREFRONT_PAYMENT_COLLECTION_BOUNDARY,
-        "storefront payment collection operation failed"
+        "storefront payment collection operation failed with bounded diagnostics"
     );
     HttpError::new(status, code, message)
 }

--- a/scripts/verify/verify-commerce-storefront-checkout-http-error-context.mjs
+++ b/scripts/verify/verify-commerce-storefront-checkout-http-error-context.mjs
@@ -9,241 +9,403 @@ const root = configuredRoot
   ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
   : new URL('../../', import.meta.url);
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
-
-const checkout = read('crates/rustok-commerce/src/controllers/store/checkout.rs');
-const stagedRuntime = read(
-  'crates/rustok-commerce/src/storefront_staged_checkout_runtime.rs',
-);
 const failures = [];
 
-const requireText = (content, value, label) => {
-  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
 };
-const forbidText = (content, value, label) => {
-  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
 };
-const between = (content, start, end, label) => {
-  const startIndex = content.indexOf(start);
-  const endIndex = content.indexOf(end, startIndex + start.length);
+const requireCount = (source, value, expected, label) => {
+  const count = source.split(value).length - 1;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+};
+const between = (source, start, end, label) => {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
   if (startIndex < 0 || endIndex < 0) {
     failures.push(`${label}: unable to isolate source block`);
     return '';
   }
-  return content.slice(startIndex, endIndex);
+  return source.slice(startIndex, endIndex);
 };
 
-const paymentCollectionRoute = between(
+const checkout = read('crates/rustok-commerce/src/controllers/store/checkout.rs');
+const runtime = read('crates/rustok-commerce/src/storefront_staged_checkout_runtime.rs');
+const evidencePath =
+  'crates/rustok-commerce/contracts/evidence/storefront-checkout-http-diagnostic-safety-source-review.json';
+const docPath = 'crates/rustok-commerce/docs/storefront-checkout-http-diagnostic-safety.md';
+const evidence = JSON.parse(read(evidencePath));
+const documentation = read(docPath);
+const plan = read('crates/rustok-commerce/docs/implementation-plan.md');
+
+const checkoutContext = between(
+  checkout,
+  'struct StorefrontCheckoutErrorContext {',
+  '#[derive(Clone, Copy)]\nstruct StorefrontPaymentCollectionErrorContext {',
+  'checkout route context',
+);
+const paymentContext = between(
+  checkout,
+  'struct StorefrontPaymentCollectionErrorContext {',
+  '#[derive(Clone, Copy)]\nstruct StorefrontCheckoutRuntimeErrorFacts {',
+  'payment route context',
+);
+const paymentRoute = between(
   checkout,
   'pub async fn create_payment_collection(',
   '/// Complete storefront cart checkout',
-  'payment collection route',
+  'payment route',
 );
-const completionRoute = between(
+const checkoutRoute = between(
   checkout,
   'pub async fn complete_cart_checkout(',
   'fn required_idempotency_key(',
-  'checkout completion route',
+  'checkout route',
 );
-const idempotencyHelper = between(
-  checkout,
-  'fn required_idempotency_key(',
-  'fn storefront_checkout_error_policy(',
-  'idempotency helper',
-);
-const policy = between(
+const checkoutPolicy = between(
   checkout,
   'fn storefront_checkout_error_policy(',
-  'fn storefront_checkout_http_error(',
-  'checkout HTTP policy',
+  'fn storefront_checkout_runtime_error_facts(',
+  'checkout policy',
 );
-const mapper = between(
+const checkoutFacts = between(
+  checkout,
+  'fn storefront_checkout_runtime_error_facts(',
+  'fn storefront_checkout_http_error(',
+  'checkout facts',
+);
+const checkoutMapper = between(
   checkout,
   'fn storefront_checkout_http_error(',
+  'fn payment_collection_error_policy(',
+  'checkout mapper',
+);
+const paymentPolicy = between(
+  checkout,
+  'fn payment_collection_error_policy(',
+  'fn storefront_payment_collection_error_facts(',
+  'payment policy',
+);
+const paymentFacts = between(
+  checkout,
+  'fn storefront_payment_collection_error_facts(',
   'fn payment_collection_http_error(',
-  'checkout HTTP mapper',
+  'payment facts',
 );
+const paymentMapper = checkout.slice(checkout.indexOf('fn payment_collection_http_error('));
 
-for (const [value, label] of [
-  [
-    'const STOREFRONT_CHECKOUT_OWNER: &str = "rustok_commerce.storefront_staged_checkout_runtime";',
-    'owner constant',
-  ],
-  [
-    'const STOREFRONT_CHECKOUT_BOUNDARY: &str = "commerce_storefront_checkout_http";',
-    'boundary constant',
-  ],
-  ['type StorefrontCheckoutHttpPolicy = (StatusCode, &\'static str);', 'policy type'],
-  ['struct StorefrontCheckoutErrorContext<\'a> {', 'typed route context'],
-  ['tenant_id: Uuid,', 'tenant context field'],
-  ['actor_id: Uuid,', 'actor context field'],
-  ['cart_id: Uuid,', 'cart context field'],
-  ['channel_id: Option<Uuid>,', 'channel ID context field'],
-  ['channel_slug: Option<&\'a str>,', 'channel slug context field'],
-  ['locale: &\'a str,', 'locale context field'],
-  ['operation: &\'static str,', 'operation context field'],
-  ['channel_id: request_context.channel_id,', 'channel ID adoption'],
-  [
-    'channel_slug: request_context.channel_slug.as_deref(),',
-    'channel slug adoption',
-  ],
-  ['locale: request_context.locale.as_str(),', 'locale adoption'],
-]) requireText(checkout, value, label);
+for (const marker of [
+  'const STOREFRONT_CHECKOUT_OWNER: &str = "rustok_commerce.storefront_staged_checkout_runtime";',
+  'const STOREFRONT_CHECKOUT_BOUNDARY: &str = "commerce_storefront_checkout_http";',
+  'const STOREFRONT_PAYMENT_COLLECTION_OWNER: &str = "rustok_payment.storefront_payment_collections";',
+  '"commerce_storefront_payment_collection_http";',
+  'type StorefrontCheckoutHttpPolicy = (StatusCode, &\'static str);',
+  'type StorefrontPaymentCollectionHttpPolicy =',
+]) requireText(checkout, marker, 'stable HTTP boundary');
 
-for (const [value, label] of [
-  ['StorefrontStagedCheckoutRuntimeError::Validation(_)', 'validation variant'],
-  ['StatusCode::BAD_REQUEST', 'validation status'],
-  ['"validation"', 'validation kind'],
-  ['StorefrontStagedCheckoutRuntimeError::CartAccess', 'cart-access variant'],
-  ['StatusCode::NOT_FOUND', 'cart-access status'],
-  ['"cart_access"', 'cart-access kind'],
+for (const [block, label, markers] of [
   [
-    'StorefrontStagedCheckoutRuntimeError::AuthenticationRequired',
-    'authentication variant',
-  ],
-  ['StatusCode::UNAUTHORIZED', 'authentication status'],
-  ['"authentication_required"', 'authentication kind'],
-  [
-    'StorefrontStagedCheckoutRuntimeError::TemporarilyUnavailable',
-    'temporary variant',
-  ],
-  ['StatusCode::SERVICE_UNAVAILABLE', 'temporary status'],
-  ['"temporarily_unavailable"', 'temporary kind'],
-  ['StorefrontStagedCheckoutRuntimeError::CheckoutFailed', 'failure variant'],
-  ['StatusCode::INTERNAL_SERVER_ERROR', 'failure status'],
-  ['"checkout_failed"', 'failure kind'],
-  [
-    'StorefrontStagedCheckoutRuntimeError::CompensationPending',
-    'compensation variant',
-  ],
-  ['"compensation_pending"', 'compensation kind'],
-  [
-    'StorefrontStagedCheckoutRuntimeError::ReconciliationRequired',
-    'reconciliation variant',
-  ],
-  ['"reconciliation_required"', 'reconciliation kind'],
-  ['StatusCode::CONFLICT', 'conflict status'],
-]) requireText(policy, value, label);
-
-for (const [value, label] of [
-  ['error = ?error', 'typed runtime cause log'],
-  ['owner = STOREFRONT_CHECKOUT_OWNER', 'owner log'],
-  ['tenant_id = %context.tenant_id', 'tenant log'],
-  ['actor_id = %context.actor_id', 'actor log'],
-  ['cart_id = %context.cart_id', 'cart log'],
-  ['channel_id = ?context.channel_id', 'channel ID log'],
-  ['channel = ?context.channel_slug', 'channel slug log'],
-  ['locale = %context.locale', 'locale log'],
-  ['operation = %context.operation', 'operation log'],
-  ['error_kind,', 'error-kind log'],
-  ['public_code = code', 'public code log'],
-  ['retryable = error.retryable()', 'retryability log'],
-  ['status = %status', 'status log'],
-  ['boundary = STOREFRONT_CHECKOUT_BOUNDARY', 'boundary log'],
-  ['HttpError::new(status, code, message)', 'stable public envelope'],
-]) requireText(mapper, value, label);
-
-for (const [value, label] of [
-  [
-    'super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;',
-    'channel guard',
+    checkoutContext,
+    'checkout context',
+    [
+      'tenant_id_non_nil: bool,',
+      'actor_id_non_nil: bool,',
+      'cart_id_non_nil: bool,',
+      'channel_id_present: bool,',
+      'channel_id_non_nil: Option<bool>,',
+      'channel_slug_present: bool,',
+      'channel_slug_length: Option<usize>,',
+      'locale_length: usize,',
+      'tenant_id_non_nil: !tenant_id.is_nil(),',
+      'actor_id_non_nil: !actor_id.is_nil(),',
+      'cart_id_non_nil: !cart_id.is_nil(),',
+      'channel_id_present: request_context.channel_id.is_some(),',
+      'channel_id_non_nil: request_context.channel_id.map(|value| !value.is_nil()),',
+      'channel_slug_present: request_context.channel_slug.is_some(),',
+      'locale_length: request_context.locale.chars().count(),',
+    ],
   ],
   [
-    'let idempotency_key = required_idempotency_key(&headers)?;',
-    'idempotency extraction',
+    paymentContext,
+    'payment context',
+    [
+      'customer_id_present: bool,',
+      'customer_id_non_nil: Option<bool>,',
+      'customer_id_present: customer_id.is_some(),',
+      'customer_id_non_nil: customer_id.map(|value| !value.is_nil()),',
+      'channel_slug_length: Option<usize>,',
+      'locale_length: usize,',
+    ],
   ],
-  [
-    'let actor_id = super::checkout_actor_id(auth.0.as_ref());',
-    'actor resolution',
-  ],
-  ['shipping_option_id: input.shipping_option_id,', 'shipping option forwarding'],
-  ['shipping_selections: input.shipping_selections.map(|items| {', 'shipping selections'],
-  ['region_id: input.region_id,', 'region forwarding'],
-  ['country_code: input.country_code,', 'country forwarding'],
-  ['locale: input.locale,', 'checkout locale forwarding'],
-  ['create_fulfillment: input.create_fulfillment,', 'fulfillment flag forwarding'],
-  ['metadata: input.metadata,', 'metadata forwarding'],
-  [
-    'runtime.payment_provider_registry(),',
-    'payment provider registry forwarding',
-  ],
-  ['tenant.id,', 'tenant forwarding'],
-  ['&request_context,', 'request context forwarding'],
-  ['auth.0,', 'auth forwarding'],
-  ['idempotency_key,', 'idempotency forwarding'],
-  ['checkout_input,', 'checkout input forwarding'],
-  ['StorefrontCheckoutErrorContext::new(', 'typed HTTP context'],
-  ['actor_id,', 'actor context forwarding'],
-  ['cart_id,', 'cart context forwarding'],
-  ['"complete_cart_checkout"', 'route operation'],
-  ['Ok(Json(response))', 'response contract'],
-]) requireText(completionRoute, value, label);
-
-for (const [value, label] of [
-  ['const IDEMPOTENCY_KEY_HEADER: &str = "idempotency-key";', 'header constant'],
-  ['const MAX_IDEMPOTENCY_KEY_LENGTH: usize = 191;', 'maximum length'],
-  ['"idempotency_key_required"', 'required-key code'],
-  ['"Idempotency-Key header is required for checkout"', 'required-key message'],
-  ['"idempotency_key_invalid"', 'invalid-key code'],
-  ['"Idempotency-Key header must be valid ASCII"', 'ASCII message'],
-  [
-    'format!("Idempotency-Key must contain 1 to {MAX_IDEMPOTENCY_KEY_LENGTH} characters")',
-    'length message',
-  ],
-]) requireText(`${checkout}\n${idempotencyHelper}`, value, label);
-
-for (const [value, label] of [
-  ['.find_reusable_collection_by_cart(tenant.id, cart.id)', 'reusable collection lookup'],
-  ['payment_collection_http_error(', 'payment collection mapper call'],
-  ['.create_collection(', 'collection creation'],
-  ['Ok((StatusCode::CREATED, Json(collection)))', 'collection response'],
-]) requireText(paymentCollectionRoute, value, label);
-
-for (const [value, label] of [
-  ['pub enum StorefrontStagedCheckoutRuntimeError {', 'runtime error enum'],
-  ['Validation(String),', 'runtime validation source variant'],
-  ['CartAccess,', 'runtime cart source variant'],
-  ['AuthenticationRequired,', 'runtime auth source variant'],
-  ['TemporarilyUnavailable,', 'runtime temporary source variant'],
-  ['CheckoutFailed,', 'runtime failure source variant'],
-  ['CompensationPending,', 'runtime compensation source variant'],
-  ['ReconciliationRequired,', 'runtime reconciliation source variant'],
-  ['pub const fn public_code(&self)', 'runtime public-code contract'],
-  ['pub const fn public_message(&self)', 'runtime public-message contract'],
-  ['pub const fn retryable(&self)', 'runtime retryability contract'],
-]) requireText(stagedRuntime, value, label);
-
-const mapperUses =
-  completionRoute.match(
-    /storefront_checkout_http_error\(\s+StorefrontCheckoutErrorContext::new\(/g,
-  ) ?? [];
-if (mapperUses.length !== 1) {
-  failures.push(
-    `expected one context-aware storefront checkout HTTP mapper callsite, found ${mapperUses.length}`,
-  );
+]) {
+  for (const marker of markers) requireText(block, marker, label);
+  for (const raw of [
+    'tenant_id: Uuid,',
+    'actor_id: Uuid,',
+    'cart_id: Uuid,',
+    'customer_id: Option<Uuid>,',
+    'channel_id: Option<Uuid>,',
+    'channel_slug: Option<&',
+    'locale: &',
+  ]) forbidText(block, raw, `${label} raw field`);
 }
 
-for (const value of [
-  'storefront_checkout_http_error(error)',
-  'code = error.public_code()',
-  'tracing::error!(',
-  'error.to_string()',
-  'err.to_string()',
-  'format!("Checkout',
-]) forbidText(completionRoute, value, 'stale or unsafe completion-route mapping');
+for (const marker of [
+  'StorefrontStagedCheckoutRuntimeError::Validation(_)',
+  'StorefrontStagedCheckoutRuntimeError::CartAccess',
+  'StorefrontStagedCheckoutRuntimeError::AuthenticationRequired',
+  'StorefrontStagedCheckoutRuntimeError::TemporarilyUnavailable',
+  'StorefrontStagedCheckoutRuntimeError::CheckoutFailed',
+  'StorefrontStagedCheckoutRuntimeError::CompensationPending',
+  'StorefrontStagedCheckoutRuntimeError::ReconciliationRequired',
+  'StatusCode::BAD_REQUEST',
+  'StatusCode::NOT_FOUND',
+  'StatusCode::UNAUTHORIZED',
+  'StatusCode::SERVICE_UNAVAILABLE',
+  'StatusCode::INTERNAL_SERVER_ERROR',
+  'StatusCode::CONFLICT',
+  '"validation"',
+  '"cart_access"',
+  '"authentication_required"',
+  '"temporarily_unavailable"',
+  '"checkout_failed"',
+  '"compensation_pending"',
+  '"reconciliation_required"',
+]) requireText(checkoutPolicy, marker, 'checkout HTTP policy');
 
-for (const value of [
+for (const marker of [
+  'StorefrontCheckoutRuntimeErrorFacts',
+  'error_variant: "validation"',
+  'text_field_count: 1',
+  'text_total_length: message.chars().count()',
+  'error_variant: "cart_access"',
+  'error_variant: "authentication_required"',
+  'error_variant: "temporarily_unavailable"',
+  'error_variant: "checkout_failed"',
+  'error_variant: "compensation_pending"',
+  'error_variant: "reconciliation_required"',
+]) requireText(checkoutFacts, marker, 'checkout error shape');
+for (const raw of ['error = ?', 'message =', 'cause =', 'error.to_string()']) {
+  forbidText(checkoutFacts, raw, 'checkout error payload');
+}
+
+for (const marker of [
+  'let error_facts = storefront_checkout_runtime_error_facts(&error);',
+  'owner = STOREFRONT_CHECKOUT_OWNER',
+  'tenant_id_non_nil = context.tenant_id_non_nil',
+  'actor_id_non_nil = context.actor_id_non_nil',
+  'cart_id_non_nil = context.cart_id_non_nil',
+  'channel_id_present = context.channel_id_present',
+  'channel_id_non_nil = ?context.channel_id_non_nil',
+  'channel_slug_present = context.channel_slug_present',
+  'channel_slug_length = ?context.channel_slug_length',
+  'locale_length = context.locale_length',
+  'operation = context.operation',
+  'error_variant = error_facts.error_variant',
+  'error_text_field_count = error_facts.text_field_count',
+  'error_text_total_length = error_facts.text_total_length',
+  'public_code = code',
+  'retryable = error.retryable()',
+  'status = status.as_u16()',
+  'boundary = STOREFRONT_CHECKOUT_BOUNDARY',
+  'HttpError::new(status, code, message)',
+]) requireText(checkoutMapper, marker, 'bounded checkout mapper');
+for (const raw of [
+  'error = ?error',
+  'tenant_id = %context.',
+  'actor_id = %context.',
+  'cart_id = %context.',
+  'channel_id = ?context.',
+  'channel = ?context.',
+  'locale = %context.',
+]) forbidText(checkoutMapper, raw, 'checkout mapper raw diagnostic');
+
+for (const marker of [
+  'PaymentError::Validation(_)',
+  'PaymentError::PaymentCollectionNotFound(_)',
+  'PaymentError::PaymentNotFound(_)',
+  'PaymentError::RefundNotFound(_)',
+  'PaymentError::InvalidTransition { .. }',
+  'PaymentError::ProviderUnavailable { .. }',
+  'PaymentError::ProviderConfiguration { .. }',
+  'PaymentError::ProviderRejected { .. }',
+  'PaymentError::ProviderInvalidResponse { .. }',
+  'PaymentError::ProviderOutcomeUnknown { .. }',
+  'PaymentError::Database(_)',
+  '"payment_request_invalid"',
+  '"payment_resource_not_found"',
+  '"payment_state_conflict"',
+  '"payment_temporarily_unavailable"',
+  '"payment_provider_rejected"',
+  '"payment_reconciliation_required"',
+  '"payment_storage_unavailable"',
+]) requireText(paymentPolicy, marker, 'payment HTTP policy');
+
+for (const marker of [
+  'StorefrontPaymentCollectionErrorFacts',
+  '"validation"',
+  '"payment_collection_not_found"',
+  '"payment_not_found"',
+  '"refund_not_found"',
+  '"invalid_transition"',
+  '"provider_unavailable"',
+  '"provider_rejected"',
+  '"provider_invalid_response"',
+  '"provider_outcome_unknown"',
+  '"provider_configuration"',
+  'PaymentError::Database(_) => ("database", 0, 0, 0, 0, true)',
+  'value.chars().count()',
+  'from.chars().count() + to.chars().count()',
+  'provider_id.chars().count() + operation.chars().count()',
+  'if id.is_nil() { 0 } else { 1 }',
+]) requireText(paymentFacts, marker, 'payment error shape');
+requireCount(paymentFacts, 'if id.is_nil() { 0 } else { 1 }', 3, 'payment UUID variants');
+for (const raw of [
+  'provider_id =',
+  'provider_operation =',
+  'from =',
+  'to =',
+  'resource_id =',
+  'error = ?',
   'error.to_string()',
-  'err.to_string()',
-  'HttpError::internal(error',
-  'HttpError::bad_request(error',
-]) forbidText(mapper, value, 'unsafe checkout HTTP mapper');
+]) forbidText(paymentFacts, raw, 'payment error payload');
+
+for (const marker of [
+  'let error_facts = storefront_payment_collection_error_facts(&error);',
+  'owner = STOREFRONT_PAYMENT_COLLECTION_OWNER',
+  'tenant_id_non_nil = context.tenant_id_non_nil',
+  'actor_id_non_nil = context.actor_id_non_nil',
+  'cart_id_non_nil = context.cart_id_non_nil',
+  'customer_id_present = context.customer_id_present',
+  'customer_id_non_nil = ?context.customer_id_non_nil',
+  'channel_id_present = context.channel_id_present',
+  'channel_id_non_nil = ?context.channel_id_non_nil',
+  'channel_slug_present = context.channel_slug_present',
+  'channel_slug_length = ?context.channel_slug_length',
+  'locale_length = context.locale_length',
+  'operation = context.operation',
+  'error_variant = error_facts.error_variant',
+  'error_text_field_count = error_facts.text_field_count',
+  'error_text_total_length = error_facts.text_total_length',
+  'error_uuid_field_count = error_facts.uuid_field_count',
+  'error_uuid_non_nil_count = error_facts.uuid_non_nil_count',
+  'error_opaque_payload_present = error_facts.opaque_payload_present',
+  'public_code = code',
+  'status = status.as_u16()',
+  'boundary = STOREFRONT_PAYMENT_COLLECTION_BOUNDARY',
+  'HttpError::new(status, code, message)',
+]) requireText(paymentMapper, marker, 'bounded payment mapper');
+for (const raw of [
+  'error = ?error',
+  'tenant_id = %context.',
+  'actor_id = %context.',
+  'cart_id = %context.',
+  'customer_id = ?context.',
+  'channel_id = ?context.',
+  'channel = ?context.',
+  'locale = %context.',
+]) forbidText(paymentMapper, raw, 'payment mapper raw diagnostic');
+
+for (const marker of [
+  'StorefrontCheckoutErrorContext::new(',
+  '"complete_cart_checkout"',
+  'runtime.payment_provider_registry(),',
+  'runtime.product_catalog_read_port(),',
+  'idempotency_key,',
+  'checkout_input,',
+  'Ok(Json(response))',
+]) requireText(checkoutRoute, marker, 'checkout route flow');
+for (const marker of [
+  '.find_reusable_collection_by_cart(tenant.id, cart.id)',
+  'StorefrontPaymentCollectionErrorContext::new(',
+  '"find_reusable_collection_by_cart"',
+  '.create_collection(',
+  '"create_collection"',
+  'Ok((StatusCode::CREATED, Json(collection)))',
+]) requireText(paymentRoute, marker, 'payment route flow');
+
+for (const marker of [
+  'pub enum StorefrontStagedCheckoutRuntimeError {',
+  'Validation(String),',
+  'pub const fn public_code(&self)',
+  'pub const fn public_message(&self)',
+  'pub const fn retryable(&self)',
+]) requireText(runtime, marker, 'runtime public contract');
+
+if (
+  evidence.status !==
+  'commerce_storefront_checkout_http_diagnostic_safety_source_reviewed_unvalidated'
+) failures.push(`${evidencePath}: unexpected status ${evidence.status}`);
+for (const [key, expected] of Object.entries({
+  checkout_runtime_variant_count: 7,
+  payment_error_variant_count: 11,
+  complete_checkout_error_logged: false,
+  checkout_validation_text_logged: false,
+  complete_payment_error_logged: false,
+  payment_validation_text_logged: false,
+  payment_transition_text_logged: false,
+  payment_provider_text_logged: false,
+  payment_resource_uuid_values_logged: false,
+  raw_route_identifiers_logged: false,
+  raw_channel_or_locale_logged: false,
+  closed_checkout_variant_logged: true,
+  checkout_text_shape_logged: true,
+  closed_payment_variant_logged: true,
+  payment_text_shape_logged: true,
+  payment_uuid_shape_logged: true,
+  payment_opaque_payload_presence_logged: true,
+  public_checkout_policy_preserved: true,
+  public_payment_policy_preserved: true,
+  route_flow_changed: false,
+  idempotency_contract_changed: false,
+  runtime_retryability_changed: false,
+  broad_cleanup_remains_open: true,
+  runtime_evidence_claimed: false,
+})) {
+  if (evidence.review_findings?.[key] !== expected) {
+    failures.push(`${evidencePath}: review_findings.${key} must be ${expected}`);
+  }
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push(`${evidencePath}: execution must remain empty`);
+}
+for (const key of [
+  'tests_run',
+  'cargo_run',
+  'format_run',
+  'verifiers_run',
+  'workflow_checks_run',
+  'ci_run',
+  'compile_proven',
+  'runtime_proven',
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${evidencePath}: validation.${key} must remain false`);
+  }
+}
+
+requireText(documentation, 'Status: **source-ready / unvalidated**', `${docPath}: status`);
+requireText(documentation, '`storefront_checkout_http_error`', `${docPath}: checkout mapper`);
+requireText(documentation, '`payment_collection_http_error`', `${docPath}: payment mapper`);
+requireText(
+  documentation,
+  'The master ecommerce correlation-safe mapper-cleanup item remains open.',
+  `${docPath}: remaining work`,
+);
+requireText(
+  plan,
+  'Finish correlation-safe mapper cleanup for order, payment execution/compensation,',
+  'implementation plan broad cleanup',
+);
 
 if (failures.length > 0) {
-  console.error('Commerce storefront checkout HTTP error-context verification failed:');
+  console.error('Commerce storefront checkout HTTP diagnostic-safety verification failed:');
   for (const failure of failures) console.error(`✗ ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
 
 console.log(
-  '✔ Storefront checkout HTTP failures retain typed route context and stable public contracts',
+  '✔ Storefront checkout and payment-collection HTTP mappers preserve public envelopes with bounded error and route-context diagnostics',
 );


### PR DESCRIPTION
## Summary

Continue the ecommerce correlation-safe mapper cleanup at the public storefront HTTP boundary.

- replace complete staged-checkout runtime error logging with a closed seven-variant error shape
- replace complete `PaymentError` logging with closed variant, aggregate text/UUID shape, and opaque-payload presence
- replace raw tenant, actor, cart, customer, channel, and locale diagnostics with bounded presence/non-nil/length facts
- preserve checkout and payment HTTP status, code, message, retryability, owner operation, and route flow
- update the existing storefront HTTP source guard and add source-only evidence/documentation

## Preserved behavior

- storefront channel and cart/customer admission
- repricing and cart-context resolution
- reusable payment collection lookup and creation
- staged checkout orchestration and request forwarding
- idempotency-key validation
- OpenAPI declarations and response types
- Commerce and Payment FFA/FBA status

## Validation

Tests, Node verifiers, formatting, Cargo checks, workflows, and CI were not run per maintainer request. The evidence remains source-reviewed/unvalidated and the master ecommerce mapper-cleanup item remains open.