### PR TITLE
fix(order): bound checkout recovery admission diagnostics

### DIFF
--- a/crates/rustok-order/contracts/evidence/checkout-order-recovery-admission-diagnostic-safety-source-review.json
+++ b/crates/rustok-order/contracts/evidence/checkout-order-recovery-admission-diagnostic-safety-source-review.json
@@ -1,0 +1,59 @@
+{
+  "status": "order_checkout_recovery_admission_diagnostic_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-order/src/checkout_order_recovery.rs",
+    "crates/rustok-order/docs/checkout-order-recovery-admission-diagnostic-safety.md",
+    "crates/rustok-order/contracts/evidence/checkout-order-recovery-admission-diagnostic-safety-source-review.json",
+    "crates/rustok-commerce/docs/implementation-plan.md",
+    "scripts/verify/verify-order-checkout-recovery-admission-diagnostic-safety.mjs"
+  ],
+  "review_findings": {
+    "admission_helper_count": 3,
+    "covered_helpers": [
+      "require_operation_context",
+      "parse_tenant_id",
+      "parse_actor_id"
+    ],
+    "raw_uuid_parse_errors_logged": false,
+    "raw_tenant_id_logged_by_admission_helpers": false,
+    "raw_actor_id_logged_by_admission_helpers": false,
+    "raw_channel_logged_by_admission_helpers": false,
+    "raw_causation_id_logged_by_admission_helpers": false,
+    "expected_checkout_operation_uuid_logged": false,
+    "correlation_preserved": true,
+    "owner_operation_preserved": true,
+    "context_shape_logged": true,
+    "field_presence_and_length_logged": true,
+    "uuid_parseability_logged": true,
+    "uuid_non_nil_shape_logged": true,
+    "expected_uuid_non_nil_shape_logged": true,
+    "identity_match_result_logged": true,
+    "warning_severity_preserved": true,
+    "public_codes_preserved": true,
+    "public_kinds_preserved": true,
+    "public_messages_preserved": true,
+    "recovery_flow_changed": false,
+    "identity_validation_changed": false,
+    "hash_validation_changed": false,
+    "serde_diagnostics_changed": false,
+    "lifecycle_diagnostics_changed": false,
+    "read_not_found_diagnostics_changed": false,
+    "non_admission_recovery_diagnostics_remaining_open": true,
+    "commerce_orchestration_changed": false,
+    "order_status_promoted": false,
+    "broad_cleanup_remains_open": true,
+    "runtime_evidence_claimed": false
+  },
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed."
+}

--- a/crates/rustok-order/contracts/evidence/checkout-order-recovery-admission-diagnostic-safety-source-review.schema-note.md
+++ b/crates/rustok-order/contracts/evidence/checkout-order-recovery-admission-diagnostic-safety-source-review.schema-note.md
@@ -1,0 +1,1 @@
+This temporary file should not exist.

--- a/crates/rustok-order/contracts/evidence/checkout-order-recovery-admission-diagnostic-safety-source-review.schema-note.md
+++ b/crates/rustok-order/contracts/evidence/checkout-order-recovery-admission-diagnostic-safety-source-review.schema-note.md
@@ -1,1 +1,0 @@
-This temporary file should not exist.

--- a/crates/rustok-order/docs/checkout-order-recovery-admission-diagnostic-safety.md
+++ b/crates/rustok-order/docs/checkout-order-recovery-admission-diagnostic-safety.md
@@ -1,0 +1,88 @@
+# Checkout order recovery admission diagnostic safety
+
+Status: `source_reviewed_unvalidated`
+
+This continuation closes only the request-context admission diagnostics in
+`checkout_order_recovery.rs`:
+
+- `require_operation_context`;
+- `parse_tenant_id`;
+- `parse_actor_id`.
+
+The broad ecommerce correlation-safe mapper cleanup remains open.
+
+## Previous exposure
+
+The three helpers retained stable public `PortError` envelopes, but their
+warning logs included request-owned values or internal parser details:
+
+- the complete tenant identifier;
+- the complete actor tenant context through the tenant field;
+- the complete channel value;
+- the complete causation identifier;
+- the expected checkout operation UUID;
+- the debug representation of UUID parse failures.
+
+Those fields could carry request or identity payload across a public adapter
+boundary even though only admission shape is required for diagnosis.
+
+## Source change
+
+All three helpers now delegate rejection logging to
+`log_checkout_order_recovery_admission_rejection`.
+
+The logger retains:
+
+- owner and static operation;
+- correlation identifier;
+- bounded `PortContext` shape facts already shared by the owner-error mapper;
+- rejected field name;
+- field presence and character length;
+- UUID parseability;
+- optional non-nil shape for the parsed and expected UUID;
+- optional equality outcome;
+- stable code and adapter boundary.
+
+It does not retain the rejected field value, UUID parser error, parsed UUID, or
+expected operation UUID.
+
+## Preserved contracts
+
+No request ordering or owner operation changed. Recovery still validates:
+
+1. read/write policy and write semantics;
+2. tenant UUID;
+3. actor UUID for recovery writes;
+4. causation UUID equality with `checkout_operation_id`;
+5. hash evidence, owner identity, owner lifecycle, and projection loading.
+
+The exact public envelopes remain:
+
+- `order.checkout_operation_id_invalid` / validation /
+  `checkout operation context is invalid`;
+- `order.tenant_id_invalid` / validation /
+  `order request context is invalid`;
+- `order.actor_id_invalid` / validation /
+  `order request context is invalid`.
+
+Warning severity, correlation, owner operation, and boundary remain available.
+
+## Deliberately open
+
+This slice does not change diagnostics for:
+
+- identity conflict comparison;
+- request/hash serialization and canonical encoding;
+- hash normalization;
+- read projection not-found;
+- cancelled or unknown lifecycle states;
+- the already bounded owner `OrderError` mapper.
+
+Those boundaries must be reviewed independently before the master ecommerce
+cleanup item can close.
+
+## Validation disclosure
+
+No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were
+executed. The accompanying verifier is retained source contract only and was
+not run. No compile or runtime status is promoted from this review.

--- a/crates/rustok-order/src/checkout_order_recovery.rs
+++ b/crates/rustok-order/src/checkout_order_recovery.rs
@@ -355,16 +355,20 @@ fn require_operation_context(
         .as_deref()
         .and_then(|value| Uuid::parse_str(value).ok());
     if context_operation != Some(checkout_operation_id) {
-        tracing::warn!(
-            owner = CHECKOUT_ORDER_RECOVERY_OWNER,
-            correlation_id = %context.correlation_id,
-            tenant_id = %context.tenant_id,
-            channel = ?context.channel,
+        log_checkout_order_recovery_admission_rejection(
+            context,
             operation,
-            code = "order.checkout_operation_id_invalid",
-            expected_checkout_operation_id = %checkout_operation_id,
-            actual_causation_id = ?context.causation_id,
-            "checkout recovery received invalid causation identity"
+            "causation_id",
+            context.causation_id.is_some(),
+            context
+                .causation_id
+                .as_ref()
+                .map(|value| value.chars().count()),
+            context_operation.is_some(),
+            context_operation.map(|value| !value.is_nil()),
+            Some(!checkout_operation_id.is_nil()),
+            Some(false),
+            "order.checkout_operation_id_invalid",
         );
         return Err(PortError::validation(
             "order.checkout_operation_id_invalid",
@@ -375,18 +379,18 @@ fn require_operation_context(
 }
 
 fn parse_tenant_id(context: &PortContext, operation: &'static str) -> Result<Uuid, PortError> {
-    Uuid::parse_str(&context.tenant_id).map_err(|error| {
-        tracing::warn!(
-            error = ?error,
-            owner = CHECKOUT_ORDER_RECOVERY_OWNER,
-            correlation_id = %context.correlation_id,
-            tenant_id = %context.tenant_id,
-            channel = ?context.channel,
+    Uuid::parse_str(&context.tenant_id).map_err(|_| {
+        log_checkout_order_recovery_admission_rejection(
+            context,
             operation,
-            field = "tenant_id",
-            value_length = context.tenant_id.len(),
-            code = "order.tenant_id_invalid",
-            "order port received invalid request context"
+            "tenant_id",
+            true,
+            Some(context.tenant_id.chars().count()),
+            false,
+            None,
+            None,
+            None,
+            "order.tenant_id_invalid",
         );
         PortError::validation(
             "order.tenant_id_invalid",
@@ -396,18 +400,18 @@ fn parse_tenant_id(context: &PortContext, operation: &'static str) -> Result<Uui
 }
 
 fn parse_actor_id(context: &PortContext, operation: &'static str) -> Result<Uuid, PortError> {
-    Uuid::parse_str(&context.actor.id).map_err(|error| {
-        tracing::warn!(
-            error = ?error,
-            owner = CHECKOUT_ORDER_RECOVERY_OWNER,
-            correlation_id = %context.correlation_id,
-            tenant_id = %context.tenant_id,
-            channel = ?context.channel,
+    Uuid::parse_str(&context.actor.id).map_err(|_| {
+        log_checkout_order_recovery_admission_rejection(
+            context,
             operation,
-            field = "actor_id",
-            value_length = context.actor.id.len(),
-            code = "order.actor_id_invalid",
-            "order port received invalid request context"
+            "actor_id",
+            true,
+            Some(context.actor.id.chars().count()),
+            false,
+            None,
+            None,
+            None,
+            "order.actor_id_invalid",
         );
         PortError::validation("order.actor_id_invalid", "order request context is invalid")
     })
@@ -588,6 +592,52 @@ fn checkout_order_recovery_context_facts(
             .map(|value| value.chars().count()),
         deadline_ms: context.deadline_ms,
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn log_checkout_order_recovery_admission_rejection(
+    context: &PortContext,
+    operation: &'static str,
+    field: &'static str,
+    field_value_present: bool,
+    field_value_length: Option<usize>,
+    uuid_parseable: bool,
+    uuid_non_nil: Option<bool>,
+    expected_uuid_non_nil: Option<bool>,
+    matches_expected: Option<bool>,
+    code: &'static str,
+) {
+    let context_facts = checkout_order_recovery_context_facts(context);
+    tracing::warn!(
+        owner = CHECKOUT_ORDER_RECOVERY_OWNER,
+        operation,
+        correlation_id = %context.correlation_id,
+        tenant_id_length = context_facts.tenant_id_length,
+        actor_kind = context_facts.actor_kind,
+        actor_id_length = context_facts.actor_id_length,
+        claim_count = context_facts.claim_count,
+        role_count = context_facts.role_count,
+        channel_present = context_facts.channel_present,
+        channel_length = ?context_facts.channel_length,
+        locale_length = context_facts.locale_length,
+        causation_id_present = context_facts.causation_id_present,
+        causation_id_length = ?context_facts.causation_id_length,
+        traceparent_present = context_facts.traceparent_present,
+        traceparent_length = ?context_facts.traceparent_length,
+        idempotency_key_present = context_facts.idempotency_key_present,
+        idempotency_key_length = ?context_facts.idempotency_key_length,
+        deadline_ms = ?context_facts.deadline_ms,
+        field,
+        field_value_present,
+        field_value_length = ?field_value_length,
+        uuid_parseable,
+        uuid_non_nil = ?uuid_non_nil,
+        expected_uuid_non_nil = ?expected_uuid_non_nil,
+        matches_expected = ?matches_expected,
+        code,
+        boundary = CHECKOUT_ORDER_RECOVERY_BOUNDARY,
+        "order checkout recovery admission was rejected with bounded diagnostics"
+    );
 }
 
 fn checkout_order_recovery_owner_error_facts(

--- a/scripts/verify/verify-order-checkout-recovery-admission-diagnostic-safety.mjs
+++ b/scripts/verify/verify-order-checkout-recovery-admission-diagnostic-safety.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const failures = [];
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (source, start, end, label) => {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return source.slice(startIndex, endIndex);
+};
+
+const sourcePath = 'crates/rustok-order/src/checkout_order_recovery.rs';
+const evidencePath =
+  'crates/rustok-order/contracts/evidence/checkout-order-recovery-admission-diagnostic-safety-source-review.json';
+const documentationPath =
+  'crates/rustok-order/docs/checkout-order-recovery-admission-diagnostic-safety.md';
+const source = read(sourcePath);
+const evidence = JSON.parse(read(evidencePath));
+const documentation = read(documentationPath);
+const plan = read('crates/rustok-commerce/docs/implementation-plan.md');
+
+const operationAdmission = between(
+  source,
+  'fn require_operation_context(',
+  'fn parse_tenant_id(',
+  'operation admission',
+);
+const tenantAdmission = between(
+  source,
+  'fn parse_tenant_id(',
+  'fn parse_actor_id(',
+  'tenant admission',
+);
+const actorAdmission = between(
+  source,
+  'fn parse_actor_id(',
+  'fn checkout_request_hashes(',
+  'actor admission',
+);
+const admissionLogger = between(
+  source,
+  'fn log_checkout_order_recovery_admission_rejection(',
+  'fn checkout_order_recovery_owner_error_facts(',
+  'admission logger',
+);
+const admissionHelpers = `${operationAdmission}\n${tenantAdmission}\n${actorAdmission}`;
+
+for (const marker of [
+  'const CHECKOUT_ORDER_RECOVERY_OWNER: &str = "rustok_order.checkout_order_recovery";',
+  'const CHECKOUT_ORDER_RECOVERY_BOUNDARY: &str = "checkout_order_recovery_adapter";',
+  'fn checkout_order_recovery_context_facts(',
+  'fn log_checkout_order_recovery_admission_rejection(',
+]) requireText(source, marker, 'shared admission contract');
+
+for (const marker of [
+  'log_checkout_order_recovery_admission_rejection(',
+  '"causation_id"',
+  'context.causation_id.is_some()',
+  '.map(|value| value.chars().count())',
+  'context_operation.is_some()',
+  'context_operation.map(|value| !value.is_nil())',
+  'Some(!checkout_operation_id.is_nil())',
+  'Some(false)',
+  '"order.checkout_operation_id_invalid"',
+  'PortError::validation(',
+  '"checkout operation context is invalid"',
+]) requireText(operationAdmission, marker, 'causation admission');
+
+for (const [block, field, code] of [
+  [tenantAdmission, 'tenant_id', 'order.tenant_id_invalid'],
+  [actorAdmission, 'actor_id', 'order.actor_id_invalid'],
+]) {
+  for (const marker of [
+    'Uuid::parse_str(',
+    '.map_err(|_| {',
+    'log_checkout_order_recovery_admission_rejection(',
+    `"${field}"`,
+    'true,',
+    'false,',
+    `"${code}"`,
+    'PortError::validation(',
+    '"order request context is invalid"',
+  ]) requireText(block, marker, `${field} admission`);
+}
+
+for (const marker of [
+  'owner = CHECKOUT_ORDER_RECOVERY_OWNER',
+  'operation,',
+  'correlation_id = %context.correlation_id',
+  'tenant_id_length = context_facts.tenant_id_length',
+  'actor_kind = context_facts.actor_kind',
+  'actor_id_length = context_facts.actor_id_length',
+  'claim_count = context_facts.claim_count',
+  'role_count = context_facts.role_count',
+  'channel_present = context_facts.channel_present',
+  'channel_length = ?context_facts.channel_length',
+  'locale_length = context_facts.locale_length',
+  'causation_id_present = context_facts.causation_id_present',
+  'causation_id_length = ?context_facts.causation_id_length',
+  'traceparent_present = context_facts.traceparent_present',
+  'traceparent_length = ?context_facts.traceparent_length',
+  'idempotency_key_present = context_facts.idempotency_key_present',
+  'idempotency_key_length = ?context_facts.idempotency_key_length',
+  'deadline_ms = ?context_facts.deadline_ms',
+  'field,',
+  'field_value_present,',
+  'field_value_length = ?field_value_length',
+  'uuid_parseable,',
+  'uuid_non_nil = ?uuid_non_nil',
+  'expected_uuid_non_nil = ?expected_uuid_non_nil',
+  'matches_expected = ?matches_expected',
+  'code,',
+  'boundary = CHECKOUT_ORDER_RECOVERY_BOUNDARY',
+  '"order checkout recovery admission was rejected with bounded diagnostics"',
+]) requireText(admissionLogger, marker, 'bounded admission logger');
+
+for (const raw of [
+  'error = ?error',
+  'error = %error',
+  'tenant_id = %context.tenant_id',
+  'actor_id = %context.actor.id',
+  'channel = ?context.channel',
+  'expected_checkout_operation_id = %checkout_operation_id',
+  'actual_causation_id = ?context.causation_id',
+  'causation_id = ?context.causation_id',
+]) forbidText(admissionHelpers, raw, 'raw admission diagnostic');
+
+for (const raw of [
+  'tenant_id = %context.tenant_id',
+  'actor_id = %context.actor.id',
+  'channel = ?context.channel',
+  'causation_id = ?context.causation_id',
+  'expected_checkout_operation_id = %checkout_operation_id',
+  'actual_causation_id = ?context.causation_id',
+  'error = ?error',
+  'error = %error',
+]) forbidText(admissionLogger, raw, 'raw shared admission logger');
+
+requireText(
+  plan,
+  'Finish correlation-safe mapper cleanup for order, payment execution/compensation,',
+  'open master cleanup item',
+);
+requireText(
+  documentation,
+  'Status: `source_reviewed_unvalidated`',
+  'documentation status',
+);
+requireText(
+  documentation,
+  'The broad ecommerce correlation-safe mapper cleanup remains open.',
+  'documentation open disclosure',
+);
+requireText(
+  documentation,
+  'No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were',
+  'documentation validation disclosure',
+);
+
+if (
+  evidence.status !==
+  'order_checkout_recovery_admission_diagnostic_safety_source_reviewed_unvalidated'
+) failures.push(`evidence status: unexpected ${evidence.status}`);
+
+for (const [key, expected] of Object.entries({
+  admission_helper_count: 3,
+  raw_uuid_parse_errors_logged: false,
+  raw_tenant_id_logged_by_admission_helpers: false,
+  raw_actor_id_logged_by_admission_helpers: false,
+  raw_channel_logged_by_admission_helpers: false,
+  raw_causation_id_logged_by_admission_helpers: false,
+  expected_checkout_operation_uuid_logged: false,
+  correlation_preserved: true,
+  owner_operation_preserved: true,
+  context_shape_logged: true,
+  field_presence_and_length_logged: true,
+  uuid_parseability_logged: true,
+  uuid_non_nil_shape_logged: true,
+  expected_uuid_non_nil_shape_logged: true,
+  identity_match_result_logged: true,
+  warning_severity_preserved: true,
+  public_codes_preserved: true,
+  public_kinds_preserved: true,
+  public_messages_preserved: true,
+  recovery_flow_changed: false,
+  identity_validation_changed: false,
+  hash_validation_changed: false,
+  serde_diagnostics_changed: false,
+  lifecycle_diagnostics_changed: false,
+  read_not_found_diagnostics_changed: false,
+  non_admission_recovery_diagnostics_remaining_open: true,
+  commerce_orchestration_changed: false,
+  order_status_promoted: false,
+  broad_cleanup_remains_open: true,
+  runtime_evidence_claimed: false,
+})) {
+  if (evidence.review_findings?.[key] !== expected) {
+    failures.push(
+      `evidence review_findings.${key}: expected ${expected}, found ${evidence.review_findings?.[key]}`,
+    );
+  }
+}
+
+for (const key of [
+  'tests_run',
+  'cargo_run',
+  'format_run',
+  'verifiers_run',
+  'workflow_checks_run',
+  'ci_run',
+  'compile_proven',
+  'runtime_proven',
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`evidence validation.${key}: expected false`);
+  }
+}
+
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push('evidence execution: expected empty array');
+}
+
+for (const reviewedPath of [
+  sourcePath,
+  documentationPath,
+  evidencePath,
+  'crates/rustok-commerce/docs/implementation-plan.md',
+  'scripts/verify/verify-order-checkout-recovery-admission-diagnostic-safety.mjs',
+]) {
+  if (!evidence.reviewed_scope?.includes(reviewedPath)) {
+    failures.push(`evidence reviewed_scope: missing ${reviewedPath}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Order checkout recovery admission diagnostic safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Order checkout recovery admission diagnostics retain bounded shape and stable public contracts',
+);


### PR DESCRIPTION
## Summary

Continue the ecommerce correlation-safe mapper cleanup at the Order checkout recovery admission boundary.

- replace raw causation, tenant, actor, channel, expected-operation UUID, and UUID parse-error diagnostics in the three admission helpers
- reuse the existing bounded `PortContext` shape and add field presence/length, parseability, non-nil, and equality facts
- preserve exact validation codes, kinds, messages, warning severity, owner operations, and recovery ordering
- add focused source-only evidence, documentation, and a retained static guard
- leave identity, hash/serde, read not-found, lifecycle, and broad ecommerce cleanup open

## Preserved behavior

- read/write policy and write-semantics admission
- tenant and actor UUID parsing
- causation equality with `checkout_operation_id`
- identity adoption and validation
- hash normalization and request hashing
- owner lifecycle recovery and projection loading
- Order and Commerce FFA/FBA status

## Validation

Tests, Node verifiers, formatting, Cargo checks, workflows, and CI were not run per maintainer request. The evidence remains source-reviewed/unvalidated and the master ecommerce mapper-cleanup item remains open.