### PR TITLE
feat(forum): expose topic split GraphQL transport

### DIFF
--- a/crates/rustok-forum/contracts/forum-topic-split-graphql-transport.json
+++ b/crates/rustok-forum/contracts/forum-topic-split-graphql-transport.json
@@ -1,0 +1,95 @@
+{
+  "contract": "forum_topic_split_graphql_transport_v1",
+  "task": "FORUM-21R",
+  "parent_task": "FORUM-21",
+  "extends": "FORUM-21P",
+  "status": "source_ready_maintainer_execution_pending",
+  "canonical_plan_status": "planned",
+  "transport": "graphql",
+  "owner_service": "ForumTopicSplitService",
+  "authorization": {
+    "module_must_be_enabled": "forum",
+    "required_permission": "forum_topics:manage",
+    "authenticated_human_actor_required_by_owner": true,
+    "tenant_is_derived_from_routed_TenantContext": true,
+    "optional_tenant_argument_must_equal_routed_tenant": true,
+    "tenant_mismatch_code": "PERMISSION_DENIED"
+  },
+  "command": {
+    "field": "splitForumTopicReplies",
+    "input_type": "SplitForumTopicRepliesGraphqlInput",
+    "source_topic_id_is_separate_argument": true,
+    "input_fields": [
+      "operation_id",
+      "target_topic_id",
+      "reply_ids",
+      "locale",
+      "title",
+      "slug",
+      "reason"
+    ],
+    "result_type": "GqlForumTopicSplit",
+    "calls_owner_method": "split_selected_replies"
+  },
+  "receipt_result": {
+    "type": "GqlForumTopicSplit",
+    "fields": [
+      "operation_id",
+      "event_id",
+      "source_topic_id",
+      "target_topic_id",
+      "category_id",
+      "actor_id",
+      "reason",
+      "moved_reply_count",
+      "moved_published_reply_count",
+      "source_resulting_published_reply_count",
+      "target_resulting_published_reply_count",
+      "solution_reply_id",
+      "split_at"
+    ],
+    "returns_immutable_owner_receipt": true,
+    "exact_replay_returns_same_result": true,
+    "event_id_equals_operation_id": true
+  },
+  "composition": {
+    "resolver_contains_no_split_business_logic": true,
+    "database_and_transactional_event_bus_are_explicit_schema_data": true,
+    "security_context_uses_authenticated_permission_snapshot": true,
+    "domain_errors_preserve_ForumGraphqlErrorExtension_mapping": true,
+    "raw_split_receipt_or_item_table_access_in_resolver": false,
+    "canonical_topic_alias_resolution_for_mutation": false
+  },
+  "compatibility": {
+    "owner_command_changed": false,
+    "receipt_schema_changed": false,
+    "semantic_event_schema_changed": false,
+    "rest_contract_changed": false,
+    "admin_ui_added": false,
+    "storefront_ui_added": false,
+    "graphql_field_is_additive": true
+  },
+  "source_contract_test": "crates/rustok-forum/tests/topic_split_graphql_contract.rs",
+  "authorization_unit_test": "crates/rustok-forum/src/graphql/topic_split_mutation.rs",
+  "owner_runtime_test": "crates/rustok-forum/tests/topic_split_sqlite.rs",
+  "documentation": "crates/rustok-forum/docs/forum-21r-topic-split-graphql-transport.md",
+  "owner_contract": "crates/rustok-forum/contracts/forum-topic-split-owner.json",
+  "owner_documentation": "crates/rustok-forum/docs/forum-21p-topic-split-owner.md",
+  "verifier": "scripts/verify/verify-forum-topic-split-graphql-transport.mjs",
+  "maintainer_commands": [
+    "node scripts/verify/verify-forum-topic-split-owner.mjs",
+    "node scripts/verify/verify-forum-topic-split-graphql-transport.mjs",
+    "cargo test -p rustok-forum graphql::topic_split_mutation::tests -- --nocapture",
+    "cargo test -p rustok-forum --test topic_split_graphql_contract -- --nocapture",
+    "cargo test -p rustok-forum --test topic_split_sqlite -- --nocapture",
+    "cargo check -p rustok-forum --all-targets"
+  ],
+  "non_claims": [
+    "no verifier test formatter Cargo SQLite PostgreSQL workflow or CI execution is claimed",
+    "no REST native admin storefront or CLI split command transport is added",
+    "no split admin UI is added",
+    "no cross-category split is added",
+    "no fork or reply-range transport is added",
+    "FORUM-21 remains planned"
+  ]
+}

--- a/crates/rustok-forum/docs/README.md
+++ b/crates/rustok-forum/docs/README.md
@@ -38,7 +38,8 @@ notifications module, and cross-module release gates.
 - FORUM-21N composes those commands in Leptos and Next-admin without changing the owner, receipt or event schema;
 - FORUM-21O selects direct authenticated native owner composition for Leptos SSR/hydrate while retaining GraphQL for CSR/headless with no fallback;
 - FORUM-21P adds the transport-neutral selected-reply split owner with immutable receipt/event, parent-closed movement, exact access-policy cloning and counter reconciliation;
-- FORUM-21Q adds the transport-neutral reply-branch fork owner with deterministic copied identities, complete bounded revision/relation provenance, source immutability and explicit non-copy policy; public manager transport remains follow-up scope.
+- FORUM-21Q adds the transport-neutral reply-branch fork owner with deterministic copied identities, complete bounded revision/relation provenance, source immutability and explicit non-copy policy; public manager transport remains follow-up scope;
+- FORUM-21R exposes `splitForumTopicReplies` as a routed-tenant, `forum_topics:manage` GraphQL adapter over the unchanged split owner and immutable receipt; admin composition remains follow-up scope.
 
 ## Verification
 
@@ -60,6 +61,7 @@ notifications module, and cross-module release gates.
 - [FORUM-21O native Leptos merge transport](./forum-21o-topic-merge-native-admin.md)
 - [FORUM-21P selected-reply split owner](./forum-21p-topic-split-owner.md)
 - [FORUM-21Q reply-branch fork owner](./forum-21q-topic-fork-owner.md)
+- [FORUM-21R topic split GraphQL transport](./forum-21r-topic-split-graphql-transport.md)
 - [FORUM-21I/J canonical resolution and HTTP redirect](./forum-21i-topic-canonical-resolution.md)
 - [FORUM-21K topic merge GraphQL transport](./forum-21k-topic-merge-graphql-transport.md)
 - [Admin UI package](../admin/README.md)

--- a/crates/rustok-forum/docs/forum-21r-topic-split-graphql-transport.md
+++ b/crates/rustok-forum/docs/forum-21r-topic-split-graphql-transport.md
@@ -1,0 +1,86 @@
+# FORUM-21R topic split GraphQL transport
+
+## Status
+
+`source_ready_maintainer_execution_pending`
+
+FORUM-21R exposes the FORUM-21P selected-reply split owner through one additive manager-only GraphQL command. The resolver is a thin transport adapter: it derives trusted tenant and actor state from schema context, checks module admission and `forum_topics:manage`, maps the wire input to `ForumTopicSplitService::split_selected_replies`, and returns the immutable owner receipt without reading owner audit tables.
+
+Machine contract:
+
+```text
+crates/rustok-forum/contracts/forum-topic-split-graphql-transport.json
+```
+
+## Command
+
+The GraphQL field is:
+
+```graphql
+splitForumTopicReplies(
+  tenantId: UUID
+  sourceTopicId: UUID!
+  input: SplitForumTopicRepliesGraphqlInput!
+): GqlForumTopicSplit!
+```
+
+`tenantId` is assertion-only. When supplied it must equal the routed `TenantContext`; omission uses the routed tenant. A mismatched assertion fails with `PERMISSION_DENIED` before owner execution.
+
+The input carries the complete owner command shape except the source topic identity, which remains an explicit field argument:
+
+- `operationId`;
+- `targetTopicId`;
+- bounded `replyIds`;
+- `locale`;
+- `title`;
+- optional `slug`;
+- `reason`.
+
+The owner remains authoritative for normalization, bounds, parent closure, target absence, source non-emptiness, access-policy cloning, solution transfer, counters, receipt replay and conflict detection.
+
+## Authorization and composition
+
+The resolver requires the `forum` module to be enabled and an authenticated `AuthContext` with `forum_topics:manage`. It builds `SecurityContext` from the authenticated user ID and exact permission snapshot, then delegates through explicit `DatabaseConnection` and `TransactionalEventBus` schema data.
+
+The resolver does not:
+
+- resolve canonical merged-topic aliases for a mutation;
+- query `forum_topic_split_operations` or `forum_topic_split_reply_items`;
+- create a topic through `TopicService`;
+- move replies directly;
+- duplicate owner validation or transaction logic.
+
+Domain errors continue through `ForumGraphqlErrorExtension`, including exact replay conflicts and owner validation failures.
+
+## Receipt
+
+`GqlForumTopicSplit` exposes the immutable owner receipt:
+
+- operation and event IDs;
+- source, target and category IDs;
+- actor and reason;
+- moved total and published reply counts;
+- resulting source and target published counters;
+- optional transferred solution reply ID;
+- split timestamp.
+
+An exact replay returns the same owner result. The transport does not create a second idempotency record or event.
+
+## Compatibility and remaining scope
+
+FORUM-21R adds one GraphQL field and no migration, REST route, admin UI, storefront UI, owner method, receipt shape or semantic-event change. Existing FORUM-21P direct owner callers remain unchanged.
+
+Public manager UI composition remains open. FORUM-21Q reply-branch fork still has no public transport, bounded reply-range movement remains open, and retained SQLite/PostgreSQL plus mounted-host runtime evidence is still required. The canonical `FORUM-21` entry remains `planned`.
+
+## Maintainer verification
+
+```bash
+node scripts/verify/verify-forum-topic-split-owner.mjs
+node scripts/verify/verify-forum-topic-split-graphql-transport.mjs
+cargo test -p rustok-forum graphql::topic_split_mutation::tests -- --nocapture
+cargo test -p rustok-forum --test topic_split_graphql_contract -- --nocapture
+cargo test -p rustok-forum --test topic_split_sqlite -- --nocapture
+cargo check -p rustok-forum --all-targets
+```
+
+No command above was run by the implementation agent, per maintainer request.

--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -6,7 +6,7 @@ status: active
 owners:
   - rustok-forum
   - rustok-notifications-program
-last_reviewed: 2026-08-03
+last_reviewed: 2026-08-04
 ---
 
 # `rustok-forum` canonical implementation plan
@@ -1584,7 +1584,7 @@ Preserve revisions, attachments, mentions and audit. Remap reply positions
 safely, deduplicate subscriptions, revalidate solutions and ACL, update
 category counters and create canonical URL aliases.
 
-### Delivered through `FORUM-21N`
+### Delivered through `FORUM-21R`
 
 - FORUM-21A adds the bounded idempotent topic-move owner with checked category
   counters, immutable operation receipt and unchanged topic identity;
@@ -1609,6 +1609,21 @@ category counters and create canonical URL aliases.
   one UUID operation identity across an exact retry, rotate it when the command
   shape changes, require an explicit source/target solution winner only when
   both topics are solved, and display the immutable owner receipt;
+- FORUM-21O selects direct authenticated native owner composition for Leptos
+  SSR/hydrate while retaining the existing GraphQL mutations for CSR/headless
+  parity, with no cross-path fallback and no owner identity in request DTOs;
+- FORUM-21P adds the idempotent selected-reply split owner with an immutable
+  receipt and `forum.topic.split` event, parent-closed movement, preserved reply
+  identity and relations, exact topic-local access cloning and checked counter
+  reconciliation;
+- FORUM-21Q adds the idempotent reply-branch fork owner with deterministic copied
+  reply identities, bounded revision/mention/quote provenance, exact access and
+  tag cloning, source immutability and an explicit votes/subscriptions/read-state/
+  solution non-copy policy;
+- FORUM-21R adds the routed-tenant, manager-only GraphQL split transport. The
+  additive `splitForumTopicReplies` field delegates the complete command to
+  `ForumTopicSplitService::split_selected_replies` and returns the immutable
+  owner receipt without reading split audit tables or duplicating owner policy;
 - every ordinary, resolved, same-category and cross-category merge retains the
   exact `forum.topic.merged` schema-version-1 payload so existing post-merge
   reconciliation owners remain compatible.
@@ -1622,31 +1637,32 @@ lane or reconciliation owner. Existing same-category receipts and merges keep
 their previous behavior. The source category remains discoverable from the
 archived source topic and is not copied into the semantic event or receipt.
 
-The Leptos package remains in an explicit single-adapter GraphQL state. It does
-not wrap GraphQL in a server function, does not place an access token inside a
-server-function DTO and does not claim a direct native owner path. A later
-native cutover must compose authenticated owner state directly while retaining
-GraphQL for CSR/headless parity.
+FORUM-21O changes only the Leptos admin transport selection and host composition:
+SSR/hydrate use direct authenticated native owner state, CSR/headless retain
+GraphQL, and no fallback is introduced. FORUM-21P and FORUM-21Q add append-only
+PostgreSQL/SQLite owner receipt and mapping migrations without changing existing
+move or merge receipts and events. FORUM-21R adds one GraphQL field and no
+migration, REST route, admin UI, owner method, receipt shape or semantic-event
+change. Direct owner callers remain source-compatible.
 
-Forum move and merge commands remain independent from Notifications, Search,
-Page Builder and other optional integrations. Owner state, the Forum semantic
-event, receipt, optional solution-resolution audit and projection invalidations
-commit atomically; optional consumers reconcile after commit. A disabled
-optional capability cannot turn a valid Forum owner command into a synchronous
-outage.
+Forum move, merge, split and fork commands remain independent from Notifications,
+Search, Page Builder and other optional integrations. Owner state, the Forum
+semantic event, receipt, mapping/audit rows and projection invalidations commit
+atomically; optional consumers reconcile after commit. A disabled optional
+capability cannot turn a valid Forum owner command into a synchronous outage.
 
 ### Remaining scope
 
 `FORUM-21` remains `planned` until all of the following are delivered and
 maintainer-executed:
 
-- retained SQLite and PostgreSQL execution evidence for the complete move/merge
-  owner and migration chain, including cross-category concurrency and rollback;
-- direct authenticated Leptos native server-function owner composition while
-  retaining GraphQL parity, plus mounted-browser evidence for both admin hosts;
-- idempotent split-selected-replies workflow with immutable receipt, event,
-  relation preservation and counter reconciliation;
-- idempotent reply-branch fork workflow with explicit copy/identity policy;
+- retained SQLite and PostgreSQL execution evidence for the complete move,
+  merge, split and fork owner/migration chain, including cross-category
+  concurrency, replay and rollback;
+- mounted-browser and runtime transport evidence for the native/GraphQL merge
+  paths and the new split GraphQL field;
+- public admin composition for split and fork workflows, plus an additive
+  manager transport for the fork owner without transport-local copy policy;
 - bounded reply-range movement with deterministic positions, parent/reference
   policy and partial-move prevention;
 - final canonical localized URL aliases and route tombstones under FORUM-24,
@@ -1670,6 +1686,10 @@ node scripts/verify/verify-forum-topic-canonical-resolution.mjs
 node scripts/verify/verify-forum-topic-http-redirect.mjs
 node scripts/verify/verify-forum-topic-merge-graphql-transport.mjs
 node scripts/verify/verify-forum-topic-merge-admin-ui.mjs
+node scripts/verify/verify-forum-topic-merge-native-admin.mjs
+node scripts/verify/verify-forum-topic-split-owner.mjs
+node scripts/verify/verify-forum-topic-fork-owner.mjs
+node scripts/verify/verify-forum-topic-split-graphql-transport.mjs
 npm run verify:forum:admin-boundary
 npm run verify:blog:forum-ui-ownership
 cargo test -p rustok-forum --test topic_move_sqlite -- --nocapture
@@ -1679,12 +1699,16 @@ cargo test -p rustok-forum --test topic_merge_solution_resolution_sqlite -- --no
 cargo test -p rustok-forum --test topic_canonical_resolution_sqlite -- --nocapture
 cargo test -p rustok-forum controllers::topic_redirect::tests -- --nocapture
 cargo test -p rustok-forum --test topic_merge_graphql_contract -- --nocapture
+cargo test -p rustok-forum graphql::topic_split_mutation::tests -- --nocapture
+cargo test -p rustok-forum --test topic_split_graphql_contract -- --nocapture
+cargo test -p rustok-forum --test topic_split_sqlite -- --nocapture
+cargo test -p rustok-forum --test topic_fork_sqlite -- --nocapture
 cargo test -p rustok-forum-admin topic_merge_model -- --nocapture
 cargo check -p rustok-forum-admin --all-targets
 npm --prefix apps/next-admin run typecheck
 ```
 
-The FORUM-21A through FORUM-21N source and contract records do not claim
+The FORUM-21A through FORUM-21R source and contract records do not claim
 successful verifier, SQLite, PostgreSQL, Cargo, formatting, npm, browser,
 workflow or CI execution. The canonical task remains `planned` until the
 remaining workflows and maintainer evidence are complete.

--- a/crates/rustok-forum/src/graphql/mod.rs
+++ b/crates/rustok-forum/src/graphql/mod.rs
@@ -16,6 +16,7 @@ mod storefront_audience_topic;
 mod storefront_audience_topics;
 mod storefront_read_state;
 mod topic_merge_mutation;
+mod topic_split_mutation;
 mod types;
 
 use async_graphql::MergedObject;
@@ -46,6 +47,7 @@ pub use topic_merge_mutation::{
     GqlForumTopicMerge, GqlForumTopicMergeSolutionResolution, MergeForumTopicGraphqlInput,
     ResolveForumTopicMergeSolutionGraphqlInput,
 };
+pub use topic_split_mutation::{GqlForumTopicSplit, SplitForumTopicRepliesGraphqlInput};
 pub use types::*;
 
 #[derive(MergedObject, Default)]
@@ -71,4 +73,5 @@ pub struct ForumMutation(
     read_state::ForumReadStateMutation,
     storefront_read_state::ForumStorefrontReadStateMutation,
     topic_merge_mutation::ForumTopicMergeMutation,
+    topic_split_mutation::ForumTopicSplitMutation,
 );

--- a/crates/rustok-forum/src/graphql/topic_split_mutation.rs
+++ b/crates/rustok-forum/src/graphql/topic_split_mutation.rs
@@ -1,0 +1,229 @@
+use async_graphql::{Context, FieldError, InputObject, Object, Result, SimpleObject};
+use rustok_api::{
+    AuthContext, Permission, TenantContext,
+    graphql::{GraphQLError, require_module_enabled},
+    has_any_effective_permission,
+};
+use rustok_outbox::TransactionalEventBus;
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use crate::{ForumTopicSplitResult, ForumTopicSplitService, SplitForumTopicRepliesInput};
+
+const MODULE_SLUG: &str = "forum";
+
+#[derive(Default)]
+pub(crate) struct ForumTopicSplitMutation;
+
+#[Object]
+impl ForumTopicSplitMutation {
+    async fn split_forum_topic_replies(
+        &self,
+        ctx: &Context<'_>,
+        tenant_id: Option<Uuid>,
+        source_topic_id: Uuid,
+        input: SplitForumTopicRepliesGraphqlInput,
+    ) -> Result<GqlForumTopicSplit> {
+        require_module_enabled(ctx, MODULE_SLUG).await?;
+        let db = ctx.data::<DatabaseConnection>()?;
+        let event_bus = ctx.data::<TransactionalEventBus>()?;
+        let auth = ctx
+            .data::<AuthContext>()
+            .map_err(|_| <FieldError as GraphQLError>::unauthenticated())?
+            .clone();
+        let tenant = ctx.data::<TenantContext>()?;
+
+        execute_split_forum_topic_replies(
+            db,
+            event_bus,
+            tenant,
+            &auth,
+            tenant_id,
+            source_topic_id,
+            input,
+        )
+        .await
+    }
+}
+
+async fn execute_split_forum_topic_replies(
+    db: &DatabaseConnection,
+    event_bus: &TransactionalEventBus,
+    tenant: &TenantContext,
+    auth: &AuthContext,
+    requested_tenant_id: Option<Uuid>,
+    source_topic_id: Uuid,
+    input: SplitForumTopicRepliesGraphqlInput,
+) -> Result<GqlForumTopicSplit> {
+    require_topic_manage_permission(auth)?;
+    let tenant_id = resolve_tenant_scope(tenant, requested_tenant_id)?;
+
+    let result = ForumTopicSplitService::new(db.clone(), event_bus.clone())
+        .split_selected_replies(
+            tenant_id,
+            source_topic_id,
+            rustok_core::SecurityContext::from_permission_snapshot(
+                Some(auth.user_id),
+                &auth.permissions,
+            ),
+            SplitForumTopicRepliesInput {
+                operation_id: input.operation_id,
+                target_topic_id: input.target_topic_id,
+                reply_ids: input.reply_ids,
+                locale: input.locale,
+                title: input.title,
+                slug: input.slug,
+                reason: input.reason,
+            },
+        )
+        .await?;
+
+    Ok(result.into())
+}
+
+fn require_topic_manage_permission(auth: &AuthContext) -> Result<()> {
+    if !has_any_effective_permission(&auth.permissions, &[Permission::FORUM_TOPICS_MANAGE]) {
+        return Err(<FieldError as GraphQLError>::permission_denied(
+            "Permission denied: forum_topics:manage required",
+        ));
+    }
+    Ok(())
+}
+
+fn resolve_tenant_scope(tenant: &TenantContext, requested_tenant_id: Option<Uuid>) -> Result<Uuid> {
+    match requested_tenant_id {
+        Some(requested_tenant_id) if requested_tenant_id != tenant.id => {
+            Err(<FieldError as GraphQLError>::permission_denied(
+                "Permission denied: tenant scope mismatch",
+            ))
+        }
+        Some(requested_tenant_id) => Ok(requested_tenant_id),
+        None => Ok(tenant.id),
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, InputObject)]
+pub struct SplitForumTopicRepliesGraphqlInput {
+    pub operation_id: Uuid,
+    pub target_topic_id: Uuid,
+    pub reply_ids: Vec<Uuid>,
+    pub locale: String,
+    pub title: String,
+    pub slug: Option<String>,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, SimpleObject)]
+pub struct GqlForumTopicSplit {
+    pub operation_id: Uuid,
+    pub event_id: Uuid,
+    pub source_topic_id: Uuid,
+    pub target_topic_id: Uuid,
+    pub category_id: Uuid,
+    pub actor_id: Uuid,
+    pub reason: String,
+    pub moved_reply_count: i32,
+    pub moved_published_reply_count: i32,
+    pub source_resulting_published_reply_count: i32,
+    pub target_resulting_published_reply_count: i32,
+    pub solution_reply_id: Option<Uuid>,
+    pub split_at: String,
+}
+
+impl From<ForumTopicSplitResult> for GqlForumTopicSplit {
+    fn from(value: ForumTopicSplitResult) -> Self {
+        Self {
+            operation_id: value.operation_id,
+            event_id: value.event_id,
+            source_topic_id: value.source_topic_id,
+            target_topic_id: value.target_topic_id,
+            category_id: value.category_id,
+            actor_id: value.actor_id,
+            reason: value.reason,
+            moved_reply_count: value.moved_reply_count,
+            moved_published_reply_count: value.moved_published_reply_count,
+            source_resulting_published_reply_count: value
+                .source_resulting_published_reply_count,
+            target_resulting_published_reply_count: value
+                .target_resulting_published_reply_count,
+            solution_reply_id: value.solution_reply_id,
+            split_at: value.split_at.to_rfc3339(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rustok_api::{AuthContext, Permission, TenantContext};
+    use uuid::Uuid;
+
+    use super::{require_topic_manage_permission, resolve_tenant_scope};
+
+    fn auth_context(permissions: Vec<Permission>) -> AuthContext {
+        AuthContext {
+            user_id: Uuid::new_v4(),
+            session_id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            permissions,
+            client_id: None,
+            scopes: Vec::new(),
+            grant_type: "direct".to_string(),
+        }
+    }
+
+    fn tenant_context(tenant_id: Uuid) -> TenantContext {
+        TenantContext {
+            id: tenant_id,
+            name: "Topic split GraphQL tenant".to_string(),
+            slug: "topic-split-graphql".to_string(),
+            domain: None,
+            settings: serde_json::json!({}),
+            default_locale: "en".to_string(),
+            is_active: true,
+        }
+    }
+
+    fn error_code(error: &async_graphql::Error) -> Option<String> {
+        error
+            .extensions
+            .as_ref()
+            .and_then(|extensions| extensions.get("code"))
+            .cloned()
+            .and_then(|value| value.into_json().ok())
+            .and_then(|value| value.as_str().map(ToOwned::to_owned))
+    }
+
+    #[test]
+    fn split_transport_requires_topic_manage_permission() {
+        let denied = require_topic_manage_permission(&auth_context(vec![
+            Permission::FORUM_TOPICS_READ,
+        ]))
+        .expect_err("read-only actor must not split topics");
+        assert_eq!(error_code(&denied).as_deref(), Some("PERMISSION_DENIED"));
+
+        require_topic_manage_permission(&auth_context(vec![
+            Permission::FORUM_TOPICS_MANAGE,
+        ]))
+        .expect("manager permission must be accepted");
+    }
+
+    #[test]
+    fn split_transport_rejects_tenant_override_mismatch() {
+        let tenant_id = Uuid::new_v4();
+        let tenant = tenant_context(tenant_id);
+
+        assert_eq!(
+            resolve_tenant_scope(&tenant, None).expect("routed tenant must resolve"),
+            tenant_id
+        );
+        assert_eq!(
+            resolve_tenant_scope(&tenant, Some(tenant_id))
+                .expect("matching tenant assertion must resolve"),
+            tenant_id
+        );
+
+        let denied = resolve_tenant_scope(&tenant, Some(Uuid::new_v4()))
+            .expect_err("mismatched tenant assertion must fail closed");
+        assert_eq!(error_code(&denied).as_deref(), Some("PERMISSION_DENIED"));
+    }
+}

--- a/crates/rustok-forum/tests/topic_split_graphql_contract.rs
+++ b/crates/rustok-forum/tests/topic_split_graphql_contract.rs
@@ -1,0 +1,77 @@
+use async_graphql::{EmptySubscription, Schema};
+use rustok_forum::graphql::ForumGraphqlErrorExtension;
+use rustok_forum::{ForumMutation, ForumQuery};
+
+const TOPIC_SPLIT_GRAPHQL: &str = include_str!("../src/graphql/topic_split_mutation.rs");
+
+#[test]
+fn graphql_schema_exposes_idempotent_topic_split_command() {
+    let schema = Schema::build(
+        ForumQuery::default(),
+        ForumMutation::default(),
+        EmptySubscription,
+    )
+    .extension(ForumGraphqlErrorExtension)
+    .finish();
+    let sdl = schema.sdl();
+
+    for marker in [
+        "splitForumTopicReplies",
+        "SplitForumTopicRepliesGraphqlInput",
+        "GqlForumTopicSplit",
+        "operationId",
+        "sourceTopicId",
+        "targetTopicId",
+        "replyIds",
+        "eventId",
+        "categoryId",
+        "actorId",
+        "movedReplyCount",
+        "movedPublishedReplyCount",
+        "sourceResultingPublishedReplyCount",
+        "targetResultingPublishedReplyCount",
+        "solutionReplyId",
+        "splitAt",
+    ] {
+        assert!(sdl.contains(marker), "missing GraphQL split marker {marker}");
+    }
+}
+
+#[test]
+fn graphql_split_adapter_uses_routed_tenant_manage_scope_and_owner_service() {
+    for marker in [
+        "require_module_enabled(ctx, MODULE_SLUG).await?",
+        "Permission::FORUM_TOPICS_MANAGE",
+        "Permission denied: forum_topics:manage required",
+        "Permission denied: tenant scope mismatch",
+        "ForumTopicSplitService::new(db.clone(), event_bus.clone())",
+        ".split_selected_replies(",
+        "SecurityContext::from_permission_snapshot",
+        "operation_id: input.operation_id",
+        "target_topic_id: input.target_topic_id",
+        "reply_ids: input.reply_ids",
+        "locale: input.locale",
+        "title: input.title",
+        "slug: input.slug",
+        "reason: input.reason",
+    ] {
+        assert!(
+            TOPIC_SPLIT_GRAPHQL.contains(marker),
+            "missing split adapter marker {marker}"
+        );
+    }
+
+    for forbidden in [
+        "ForumTopicMoveService",
+        "ForumTopicMergeService",
+        "resolve_canonical_topic",
+        "forum_topic_split_operations",
+        "forum_topic_split_reply_items",
+        "TopicService::new",
+    ] {
+        assert!(
+            !TOPIC_SPLIT_GRAPHQL.contains(forbidden),
+            "split adapter contains forbidden marker {forbidden}"
+        );
+    }
+}

--- a/scripts/verify/verify-forum-topic-split-graphql-transport.mjs
+++ b/scripts/verify/verify-forum-topic-split-graphql-transport.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const paths = {
+  contract: "crates/rustok-forum/contracts/forum-topic-split-graphql-transport.json",
+  ownerContract: "crates/rustok-forum/contracts/forum-topic-split-owner.json",
+  docs: "crates/rustok-forum/docs/forum-21r-topic-split-graphql-transport.md",
+  ownerDocs: "crates/rustok-forum/docs/forum-21p-topic-split-owner.md",
+  graphql: "crates/rustok-forum/src/graphql/topic_split_mutation.rs",
+  graphqlMod: "crates/rustok-forum/src/graphql/mod.rs",
+  owner: "crates/rustok-forum/src/services/topic_split.rs",
+  schemaTest: "crates/rustok-forum/tests/topic_split_graphql_contract.rs",
+  ownerRuntimeTest: "crates/rustok-forum/tests/topic_split_sqlite.rs",
+  docsIndex: "crates/rustok-forum/docs/README.md",
+  plan: "crates/rustok-forum/docs/implementation-plan.md",
+};
+
+const read = (path) => readFileSync(path, "utf8");
+const includesAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(text.includes(marker), `${label} is missing marker: ${marker}`);
+  }
+};
+
+const contract = JSON.parse(read(paths.contract));
+const ownerContract = JSON.parse(read(paths.ownerContract));
+const docs = read(paths.docs);
+const ownerDocs = read(paths.ownerDocs);
+const graphql = read(paths.graphql);
+const graphqlMod = read(paths.graphqlMod);
+const owner = read(paths.owner);
+const schemaTest = read(paths.schemaTest);
+const ownerRuntimeTest = read(paths.ownerRuntimeTest);
+const docsIndex = read(paths.docsIndex);
+const plan = read(paths.plan);
+
+assert.equal(contract.contract, "forum_topic_split_graphql_transport_v1");
+assert.equal(contract.task, "FORUM-21R");
+assert.equal(contract.parent_task, "FORUM-21");
+assert.equal(contract.extends, "FORUM-21P");
+assert.equal(contract.status, "source_ready_maintainer_execution_pending");
+assert.equal(contract.canonical_plan_status, "planned");
+assert.equal(contract.transport, "graphql");
+assert.equal(contract.owner_service, "ForumTopicSplitService");
+assert.equal(contract.authorization.module_must_be_enabled, "forum");
+assert.equal(contract.authorization.required_permission, "forum_topics:manage");
+assert.equal(contract.authorization.tenant_is_derived_from_routed_TenantContext, true);
+assert.equal(contract.authorization.optional_tenant_argument_must_equal_routed_tenant, true);
+assert.equal(contract.command.field, "splitForumTopicReplies");
+assert.equal(contract.command.input_type, "SplitForumTopicRepliesGraphqlInput");
+assert.equal(contract.command.result_type, "GqlForumTopicSplit");
+assert.equal(contract.command.calls_owner_method, "split_selected_replies");
+assert.equal(contract.receipt_result.returns_immutable_owner_receipt, true);
+assert.equal(contract.receipt_result.exact_replay_returns_same_result, true);
+assert.equal(contract.composition.resolver_contains_no_split_business_logic, true);
+assert.equal(contract.composition.raw_split_receipt_or_item_table_access_in_resolver, false);
+assert.equal(contract.compatibility.owner_command_changed, false);
+assert.equal(contract.compatibility.receipt_schema_changed, false);
+assert.equal(contract.compatibility.semantic_event_schema_changed, false);
+assert.equal(contract.compatibility.graphql_field_is_additive, true);
+assert.equal(ownerContract.contract, "forum_topic_split_owner_v1");
+assert.equal(ownerContract.task, "FORUM-21P");
+assert.equal(ownerContract.command, "split_selected_replies");
+assert.equal(ownerContract.audit.semantic_event, "forum.topic.split");
+
+includesAll(
+  graphql,
+  [
+    "pub(crate) struct ForumTopicSplitMutation",
+    "async fn split_forum_topic_replies(",
+    "require_module_enabled(ctx, MODULE_SLUG).await?;",
+    "ctx.data::<DatabaseConnection>()?",
+    "ctx.data::<TransactionalEventBus>()?",
+    "ctx.data::<AuthContext>()",
+    "ctx.data::<TenantContext>()?",
+    "Permission::FORUM_TOPICS_MANAGE",
+    "Permission denied: forum_topics:manage required",
+    "Permission denied: tenant scope mismatch",
+    "SecurityContext::from_permission_snapshot",
+    "ForumTopicSplitService::new(db.clone(), event_bus.clone())",
+    ".split_selected_replies(",
+    "pub struct SplitForumTopicRepliesGraphqlInput",
+    "pub struct GqlForumTopicSplit",
+    "source_resulting_published_reply_count",
+    "target_resulting_published_reply_count",
+    "solution_reply_id",
+    "split_at: value.split_at.to_rfc3339()",
+  ],
+  "topic split GraphQL adapter",
+);
+
+for (const forbidden of [
+  "resolve_canonical_topic",
+  "forum_topic_split_operations",
+  "forum_topic_split_reply_items",
+  "ForumTopicMoveService",
+  "ForumTopicMergeService",
+  "TopicService::new",
+  "bestEffort",
+  "ALLOW_MISSING",
+  "SKIP_VALIDATION",
+]) {
+  assert.ok(!graphql.includes(forbidden), `GraphQL adapter contains forbidden marker: ${forbidden}`);
+}
+
+includesAll(
+  graphqlMod,
+  [
+    "mod topic_split_mutation;",
+    "GqlForumTopicSplit",
+    "SplitForumTopicRepliesGraphqlInput",
+    "topic_split_mutation::ForumTopicSplitMutation",
+  ],
+  "GraphQL root registration",
+);
+includesAll(
+  owner,
+  [
+    "pub struct ForumTopicSplitService",
+    "pub async fn split_selected_replies(",
+    "Resource::ForumTopics, Action::Manage",
+    "validate_split_boundary_in_tx",
+    "clone_topic_access_in_tx",
+    "insert_split_operation_in_tx",
+    'const FORUM_TOPIC_SPLIT_EVENT_TYPE: &str = "forum.topic.split"',
+  ],
+  "topic split owner",
+);
+includesAll(
+  schemaTest,
+  [
+    "graphql_schema_exposes_idempotent_topic_split_command",
+    '"splitForumTopicReplies"',
+    '"SplitForumTopicRepliesGraphqlInput"',
+    '"GqlForumTopicSplit"',
+    '"replyIds"',
+    '"sourceResultingPublishedReplyCount"',
+    "graphql_split_adapter_uses_routed_tenant_manage_scope_and_owner_service",
+  ],
+  "GraphQL schema contract",
+);
+includesAll(
+  ownerRuntimeTest,
+  [
+    "selected_reply_split_is_atomic_idempotent_and_append_only",
+    "selected_reply_split_rejects_cross_boundary_parent_edges",
+    "forum_topic_split_operations",
+    "forum.topic.split",
+  ],
+  "owner runtime contract source",
+);
+includesAll(
+  docs,
+  [
+    "# FORUM-21R topic split GraphQL transport",
+    "`source_ready_maintainer_execution_pending`",
+    "splitForumTopicReplies",
+    "forum_topics:manage",
+    "ForumTopicSplitService::split_selected_replies",
+    "immutable owner receipt",
+    "FORUM-21` entry remains `planned`",
+    "No command above was run by the implementation agent",
+  ],
+  "FORUM-21R handoff",
+);
+includesAll(
+  ownerDocs,
+  [
+    "# FORUM-21P selected-reply topic split owner",
+    "parent-closed in both directions",
+    "forum.topic.split",
+  ],
+  "FORUM-21P owner handoff",
+);
+includesAll(
+  docsIndex,
+  [
+    "FORUM-21R topic split GraphQL transport",
+    "splitForumTopicReplies",
+  ],
+  "Forum docs index",
+);
+includesAll(
+  plan,
+  [
+    "### Delivered through `FORUM-21R`",
+    "FORUM-21P adds the idempotent selected-reply split owner",
+    "FORUM-21Q adds the idempotent reply-branch fork owner",
+    "FORUM-21R adds the routed-tenant, manager-only GraphQL split transport",
+    "public admin composition for split and fork workflows",
+    "bounded reply-range movement",
+  ],
+  "canonical FORUM-21 plan",
+);
+assert.ok(plan.includes("| `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |"));
+assert.ok(plan.includes("**Status:** `planned`"));
+assert.ok(!plan.includes("idempotent split-selected-replies workflow with immutable receipt"));
+assert.ok(!plan.includes("idempotent reply-branch fork workflow with explicit copy/identity policy"));
+
+console.log(
+  "FORUM-21R topic split GraphQL transport source is ready; maintainer execution and admin composition remain pending.",
+);


### PR DESCRIPTION
## Summary

Continue `FORUM-21` with source-ready `FORUM-21R`.

- expose additive manager-only `splitForumTopicReplies` GraphQL transport;
- derive tenant and actor only from routed authenticated schema context;
- reject tenant assertion mismatch and require `forum_topics:manage`;
- delegate the complete command to `ForumTopicSplitService::split_selected_replies`;
- return the immutable owner receipt without resolver access to split audit tables;
- add GraphQL SDL/source contracts, machine contract, handoff documentation and static verifier;
- synchronize the canonical Forum plan through merged `FORUM-21P`, `FORUM-21Q` and this `FORUM-21R` slice.

## Compatibility

This is an additive GraphQL field. It adds no migration, REST route, admin UI, owner method, receipt schema or semantic-event change. Existing direct owner callers remain unchanged. `FORUM-21` remains `planned` pending admin composition, fork transport, reply-range movement and retained runtime evidence.

## Verification

Tests, verifiers, formatters, Cargo/npm commands, workflows and CI were not run per maintainer request. The PR records the maintainer command set without claiming execution.