### PR TITLE
feat(index): guard exact-entity drift diagnosis

### DIFF
--- a/apps/server/docs/index-reconciliation-operator-runtime.md
+++ b/apps/server/docs/index-reconciliation-operator-runtime.md
@@ -4,16 +4,18 @@ Status: `source_complete_transport_and_owner_execution_pending`.
 
 ## Purpose
 
-The server publishes one guarded `IndexReconciliationOperatorRuntime` after the replay composition freezes the immutable source and schema registries.
+The server publishes guarded Index reconciliation capabilities after replay composition freezes the immutable source and schema registries.
 
-The boundary wraps:
+The reconciliation boundary wraps:
 
 - `PostgresIndexReconciliationRunner` for bounded run and cancellation;
 - `PostgresIndexReconciliationDeadLetterInspector` for bounded read-only dead-letter inspection;
-- `PostgresIndexDriftFindingInspector` for bounded read-only open-finding diagnosis;
+- `PostgresIndexDriftFindingInspector` for bounded read-only finding inspection;
 - `PostgresIndexReconciliationRecoveryStore` for audited same-job recovery.
 
-The same registry-freezing composition also publishes the separate module-owned reconciliation work registration. The operator runtime does not expose or own that scheduler.
+The same source-freezing point now also publishes a separate `IndexDriftDiagnosisOperatorRuntime`. Keeping exact-entity diagnosis in a sibling capability prevents the runner/recovery runtime from owning a snapshot reader or finding writer while preserving the same request-bound authority and composition order.
+
+The registry-freezing composition also publishes the separate module-owned reconciliation work registration. Neither guarded operator exposes or owns that scheduler.
 
 ## Request-bound authority
 
@@ -21,11 +23,13 @@ Every operation requires a non-nil tenant/actor `IndexReconciliationOperatorCont
 
 Run rejects a tenant mismatch before runner delegation. Cancellation, dead-letter inspection, drift-finding inspection, and requeue accept no caller-selected tenant. Requeue accepts no caller-selected actor; the audit actor is always `context.actor_id()`.
 
-Both inspection methods and requeue authorize before adapter or recovery-request validation and before database access. An unauthorized caller therefore cannot use nil identifiers, malformed requests, or storage behavior as a tenant-scoped oracle.
+Exact-entity diagnosis accepts one typed `EntityKey`. Its embedded tenant must equal `context.tenant_id()`. Authorization runs before `IndexDriftDigestRequest` validation, snapshot capture, digest production, or finding persistence, so malformed or cross-tenant keys cannot be used as a source or storage oracle.
+
+Inspection, diagnosis, and requeue authorize before adapter or request validation and before database access.
 
 ## Published surface
 
-The operator exposes only:
+`IndexReconciliationOperatorRuntime` exposes only:
 
 - `run(context, request)`;
 - `request_cancel(context, job_id)`;
@@ -33,9 +37,15 @@ The operator exposes only:
 - `inspect_drift_finding(context, finding_id)`;
 - `requeue_dead_letter(context, job_id, reason)`.
 
-Drift inspection returns only the bounded crate value: finding UUID and key, check name, severity, typed scope, and optional expected/actual digests. It does not return tenant identity, raw finding details, detection timestamps, closure state, SQL, or database causes.
+`IndexDriftDiagnosisOperatorRuntime` exposes only:
 
-The runtime exposes no database connection, registry, scheduler handle, worker-spawn handle, raw failure or finding details, direct SQL, or transport.
+- `diagnose_entity(context, key)`.
+
+Diagnosis composes `PostgresIndexDriftSnapshotReader`, `IndexDriftDigestProducer`, and `PostgresIndexDriftFindingWriter`. A consistent pair returns the bounded digest. A mismatch returns only source/materialized digests and the finding receipt. The operator does not return raw records, fields, links, SQL, database causes, source payloads, credentials, or transaction details.
+
+Drift-finding inspection returns only the bounded crate value: finding UUID and key, check name, severity, typed scope, and optional expected/actual digests. It does not return tenant identity, raw finding details, detection timestamps, closure state, SQL, or database causes.
+
+The runtimes expose no database connection, source/schema registry, scheduler handle, worker-spawn handle, snapshot reader, finding writer, raw failure details, direct SQL, or transport.
 
 ## Composition and scheduling
 
@@ -43,27 +53,32 @@ The server replay composition remains the single source-freezing point:
 
 1. PostgreSQL source factories are materialized;
 2. `SharedIndexSourceRegistry` is frozen;
-3. replay dry-run/runtime and the due-reconciliation module-work registration are published;
-4. this guarded reconciliation operator is built from the same source/schema registries and database;
-5. the canonical runner, both read-only inspectors, and the audited recovery store are inserted into one private runtime.
+3. replay dry-run/runtime and due-reconciliation module-work registration are published;
+4. the guarded reconciliation operator is built from the immutable source/schema registries and host database;
+5. the guarded exact-entity diagnosis operator is built from those same registries and database;
+6. both capabilities are inserted into `ModuleRuntimeExtensions` before host context publication.
 
-Composition performs no reconciliation or drift SQL and starts no task. The existing generic server module-work bootstrap later owns the one-second polling loop and shared `StopHandle` shutdown. The Index adapter discovers work; the canonical runner owns claim, takeover, attempt fencing, cancellation, retry, exhaustion, and terminal state.
+Composition performs no reconciliation or diagnosis SQL and starts no task. PostgreSQL backend enforcement occurs inside the snapshot reader before source or materialized reads. The existing generic server module-work bootstrap later owns the polling loop and shared shutdown. Diagnosis is explicit, request-bound, and never scheduled by this slice.
 
-The operator remains intentionally independent from automatic scheduling: manual authorized calls and host-scheduled calls converge only at the same canonical runner. Drift inspection is read-only and is not scheduled.
+## Exact-entity diagnosis limits
+
+The command accepts exactly one key and invokes no source scan. Empty targeted owner loads remain permanent `index_drift_source_watermark_missing`; the operator does not reinterpret unproven absence as authoritative `Missing`.
+
+The command can create, refresh, reopen, or suppress the deterministic digest-mismatch finding through the existing writer lifecycle. It does not resolve a finding when states converge, ignore findings, choose repair policy, or execute repair.
 
 ## Explicitly open
 
-- GraphQL, HTTP, CLI, MCP, native admin, or other command transport;
-- retained PostgreSQL authorization, inspection, and scheduler execution evidence;
+- GraphQL, HTTP, CLI, MCP, native admin, or other diagnosis transport;
+- retained PostgreSQL authorization, diagnosis, finding-lifecycle, and scheduler execution evidence;
+- explicit retained absence/tombstone watermark support for empty targeted loads;
+- bounded entity discovery, missing/stale enumeration, and orphan-link diagnosis;
+- finding resolution or ignore transitions with actor/reason audit;
+- targeted/full/shadow repair admission, execution, audit, and evidence;
 - operator-visible scheduler health and metrics;
 - per-source retry policy, jitter, and dynamic configuration;
-- source/index digest comparison and consistency-finding production;
-- orphan diagnosis;
-- finding resolution or ignore transitions;
-- targeted/full/shadow repair admission, execution, audit, and evidence;
 - locale or partition checkpoint dimensions.
 
-The canonical bounded retry/global scheduling item remains open pending owner-retained production and multi-host evidence. The drift-diagnosis/targeted-repair item also remains open because this runtime only authorizes bounded inspection of findings that already exist.
+The canonical bounded retry/global scheduling item remains open pending owner-retained production and multi-host evidence. Exact-entity digest diagnosis is source complete; broader diagnosis and all repair remain open.
 
 ## Validation ownership
 

--- a/apps/server/src/services/index_drift_diagnosis_operator.rs
+++ b/apps/server/src/services/index_drift_diagnosis_operator.rs
@@ -1,0 +1,365 @@
+use std::{fmt, sync::Arc};
+
+use rustok_api::{Permission, has_effective_permission};
+use rustok_core::ModuleRuntimeExtensions;
+use sea_orm::DatabaseConnection;
+use thiserror::Error;
+
+use super::reconciliation_operator::IndexReconciliationOperatorContext;
+use crate::error::{Error as ServerError, Result};
+use crate::services::rbac_request_scope::permissions_for;
+
+type IndexDriftDiagnosisProducer = rustok_index::IndexDriftDigestProducer<
+    rustok_index::PostgresIndexDriftSnapshotReader,
+    rustok_index::infrastructure::postgres::PostgresIndexDriftFindingWriter,
+>;
+
+#[derive(Debug, Error)]
+pub enum IndexDriftDiagnosisOperatorError {
+    #[error("Index drift diagnosis key tenant does not match the authorized operator tenant")]
+    TenantMismatch,
+    #[error("Index drift diagnosis requires a request-bound effective permission snapshot")]
+    MissingRequestAuthority,
+    #[error("modules:manage is required for Index drift diagnosis")]
+    Forbidden,
+    #[error(transparent)]
+    Diagnosis(#[from] rustok_index::IndexDriftDigestError),
+}
+
+/// Server-owned guarded exact-entity drift diagnosis boundary.
+///
+/// The runtime composes the production snapshot reader, database-neutral digest producer, and
+/// PostgreSQL finding writer behind one request-bound `modules:manage` check. It accepts only one
+/// exact `EntityKey` and exposes no scan, discovery, lifecycle, repair, connection, source registry,
+/// snapshot reader, or writer handle.
+#[derive(Clone)]
+pub struct IndexDriftDiagnosisOperatorRuntime {
+    inner: Arc<IndexDriftDiagnosisProducer>,
+}
+
+impl IndexDriftDiagnosisOperatorRuntime {
+    fn new(inner: IndexDriftDiagnosisProducer) -> Self {
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+
+    pub async fn diagnose_entity(
+        &self,
+        context: IndexReconciliationOperatorContext,
+        key: rustok_index::EntityKey,
+    ) -> std::result::Result<
+        rustok_index::IndexDriftDigestOutcome,
+        IndexDriftDiagnosisOperatorError,
+    > {
+        authorize_for(&context, key.tenant_id)?;
+        let request = rustok_index::IndexDriftDigestRequest::new(key)?;
+        self.inner.produce(request).await.map_err(Into::into)
+    }
+}
+
+impl fmt::Debug for IndexDriftDiagnosisOperatorRuntime {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("IndexDriftDiagnosisOperatorRuntime")
+            .finish_non_exhaustive()
+    }
+}
+
+fn authorize_for(
+    context: &IndexReconciliationOperatorContext,
+    requested_tenant: uuid::Uuid,
+) -> std::result::Result<(), IndexDriftDiagnosisOperatorError> {
+    if requested_tenant != context.tenant_id() {
+        return Err(IndexDriftDiagnosisOperatorError::TenantMismatch);
+    }
+    let permissions = permissions_for(&context.tenant_id(), &context.actor_id())
+        .ok_or(IndexDriftDiagnosisOperatorError::MissingRequestAuthority)?;
+    if !has_effective_permission(&permissions, &Permission::MODULES_MANAGE) {
+        return Err(IndexDriftDiagnosisOperatorError::Forbidden);
+    }
+    Ok(())
+}
+
+/// Publishes exact-entity diagnosis after replay composition has frozen source/schema registries.
+///
+/// Composition performs no SQL and starts no task. An absent source registry leaves the capability
+/// unpublished; a source registry without its shared schema registry fails closed. PostgreSQL
+/// backend enforcement remains inside the snapshot reader before source or database reads.
+pub(super) fn materialize_index_drift_diagnosis_operator(
+    extensions: &mut ModuleRuntimeExtensions,
+    db: DatabaseConnection,
+) -> Result<()> {
+    if extensions.contains::<IndexDriftDiagnosisOperatorRuntime>() {
+        return Err(ServerError::Message(
+            "guarded Index drift diagnosis runtime is already materialized".to_string(),
+        ));
+    }
+
+    let Some(sources) = extensions
+        .get::<rustok_index::SharedIndexSourceRegistry>()
+        .cloned()
+    else {
+        return Ok(());
+    };
+    let schemas = extensions
+        .get::<rustok_index::SharedIndexSchemaRegistry>()
+        .cloned()
+        .ok_or_else(|| {
+            ServerError::Message(
+                "Index drift diagnosis source registry exists without the shared schema registry"
+                    .to_string(),
+            )
+        })?;
+
+    let reader = rustok_index::PostgresIndexDriftSnapshotReader::new(
+        db.clone(),
+        sources,
+        schemas.clone(),
+    );
+    let writer =
+        rustok_index::infrastructure::postgres::PostgresIndexDriftFindingWriter::new(db);
+    let producer = rustok_index::IndexDriftDigestProducer::new(
+        schemas.shared(),
+        reader,
+        writer,
+    );
+    extensions.insert(IndexDriftDiagnosisOperatorRuntime::new(producer));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use rustok_api::Permission;
+    use rustok_core::{ModuleRuntimeExtensions, UserRole};
+    use rustok_index::{
+        EntityKey, EntityName, FieldCardinality, FieldName, IndexField, IndexSchema, IndexSource,
+        IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest, IndexSourcePage,
+        IndexSourceScanRequest, IndexValueType, LocaleMode, ModuleName, SchemaRef, SchemaVersion,
+        SharedIndexSchemaRegistry, SharedIndexSourceRegistry, materialize_index_schema_registry,
+        materialize_index_source_registry, register_index_schema_source, register_index_source,
+    };
+    use sea_orm::Database;
+    use uuid::Uuid;
+
+    use super::{
+        IndexDriftDiagnosisOperatorError, IndexDriftDiagnosisOperatorRuntime,
+        materialize_index_drift_diagnosis_operator,
+    };
+    use crate::services::index_replay_runtime_composition::IndexReconciliationOperatorContext;
+    use crate::services::rbac_request_scope::{RbacRequestScope, with_rbac_request_scope};
+
+    struct NoopSource;
+
+    #[async_trait]
+    impl IndexSource for NoopSource {
+        async fn scan(
+            &self,
+            request: IndexSourceScanRequest,
+        ) -> std::result::Result<IndexSourcePage, IndexSourceFailure> {
+            Ok(IndexSourcePage::new(&request, Vec::new(), None)
+                .expect("empty final page should be valid"))
+        }
+
+        async fn load(
+            &self,
+            request: IndexSourceLoadRequest,
+        ) -> std::result::Result<IndexSourceLoadBatch, IndexSourceFailure> {
+            Ok(IndexSourceLoadBatch::new(&request, Vec::new())
+                .expect("empty targeted load should be valid"))
+        }
+    }
+
+    fn schema() -> IndexSchema {
+        IndexSchema {
+            reference: SchemaRef {
+                module: ModuleName::new("server-drift-diagnosis").unwrap(),
+                entity: EntityName::new("item").unwrap(),
+                version: SchemaVersion::INITIAL,
+            },
+            locale_mode: LocaleMode::None,
+            fields: vec![IndexField {
+                name: FieldName::new("id").unwrap(),
+                value_type: IndexValueType::Uuid,
+                cardinality: FieldCardinality::One,
+                nullable: false,
+                selectable: true,
+                filterable: true,
+                sortable: true,
+            }],
+            links: Vec::new(),
+        }
+    }
+
+    fn catalogs() -> ModuleRuntimeExtensions {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        let schema = schema();
+        register_index_schema_source(&mut extensions, "server_drift_diagnosis", schema.clone())
+            .expect("schema source should register");
+        register_index_source(
+            &mut extensions,
+            "server_drift_diagnosis",
+            "server-drift-diagnosis-primary",
+            [schema.reference],
+            NoopSource,
+        )
+        .expect("source should register");
+        extensions
+    }
+
+    fn complete_registries() -> ModuleRuntimeExtensions {
+        let mut extensions = catalogs();
+        let schemas = materialize_index_schema_registry(&extensions)
+            .expect("schema materialization")
+            .expect("schema registry");
+        let sources = materialize_index_source_registry(&extensions)
+            .expect("source materialization")
+            .expect("source registry");
+        extensions.insert(schemas);
+        extensions.insert(sources);
+        extensions
+    }
+
+    fn key(tenant_id: Uuid, entity_id: Uuid) -> EntityKey {
+        EntityKey {
+            tenant_id,
+            schema: schema().reference,
+            entity_id,
+            locale: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_sources_do_not_publish_false_diagnosis_capability() {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+        materialize_index_drift_diagnosis_operator(&mut extensions, db)
+            .expect("missing sources should remain optional");
+        assert!(!extensions.contains::<IndexDriftDiagnosisOperatorRuntime>());
+    }
+
+    #[tokio::test]
+    async fn source_registry_without_schema_registry_fails_closed() {
+        let mut extensions = catalogs();
+        let sources = materialize_index_source_registry(&extensions)
+            .expect("source materialization")
+            .expect("source registry");
+        extensions.insert(sources);
+        assert!(!extensions.contains::<SharedIndexSchemaRegistry>());
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+        let error = materialize_index_drift_diagnosis_operator(&mut extensions, db)
+            .expect_err("missing schema registry must fail");
+        assert!(error.to_string().contains("without the shared schema registry"));
+    }
+
+    #[tokio::test]
+    async fn complete_registries_publish_guarded_diagnosis_to_host_context() {
+        let mut extensions = complete_registries();
+        assert!(extensions.contains::<SharedIndexSourceRegistry>());
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+        materialize_index_drift_diagnosis_operator(&mut extensions, db.clone())
+            .expect("diagnosis composition");
+        assert!(extensions.contains::<IndexDriftDiagnosisOperatorRuntime>());
+        let host = extensions.apply_to_host_runtime(rustok_api::HostRuntimeContext::new(db));
+        assert!(host
+            .shared_get::<IndexDriftDiagnosisOperatorRuntime>()
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn duplicate_diagnosis_materialization_fails_closed() {
+        let mut extensions = complete_registries();
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+        materialize_index_drift_diagnosis_operator(&mut extensions, db.clone())
+            .expect("first diagnosis composition");
+        let error = materialize_index_drift_diagnosis_operator(&mut extensions, db)
+            .expect_err("duplicate diagnosis composition must fail");
+        assert!(error.to_string().contains("already materialized"));
+    }
+
+    #[tokio::test]
+    async fn exact_entity_diagnosis_authorizes_before_request_validation() {
+        let mut extensions = complete_registries();
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database without Index migrations");
+        materialize_index_drift_diagnosis_operator(&mut extensions, db)
+            .expect("diagnosis composition");
+        let runtime = extensions
+            .get::<IndexDriftDiagnosisOperatorRuntime>()
+            .cloned()
+            .expect("diagnosis runtime");
+        let tenant_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let context = IndexReconciliationOperatorContext::new(tenant_id, actor_id).unwrap();
+        let invalid = key(tenant_id, Uuid::nil());
+
+        let missing = runtime
+            .diagnose_entity(context, invalid.clone())
+            .await
+            .expect_err("missing authority must fail before request validation");
+        assert!(matches!(
+            missing,
+            IndexDriftDiagnosisOperatorError::MissingRequestAuthority
+        ));
+
+        let forbidden = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_READ],
+                UserRole::Admin,
+            )),
+            runtime.diagnose_entity(context, invalid.clone()),
+        )
+        .await
+        .expect_err("modules:read must not diagnose drift");
+        assert!(matches!(
+            forbidden,
+            IndexDriftDiagnosisOperatorError::Forbidden
+        ));
+
+        let delegated = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_MANAGE],
+                UserRole::Admin,
+            )),
+            runtime.diagnose_entity(context, invalid),
+        )
+        .await
+        .expect_err("authorized invalid key must reach bounded request validation");
+        assert!(matches!(
+            delegated,
+            IndexDriftDiagnosisOperatorError::Diagnosis(
+                rustok_index::IndexDriftDigestError::NilEntityId
+            )
+        ));
+
+        let cross_tenant = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_MANAGE],
+                UserRole::Admin,
+            )),
+            runtime.diagnose_entity(context, key(Uuid::new_v4(), Uuid::new_v4())),
+        )
+        .await
+        .expect_err("cross-tenant diagnosis must fail before producer delegation");
+        assert!(matches!(
+            cross_tenant,
+            IndexDriftDiagnosisOperatorError::TenantMismatch
+        ));
+    }
+}

--- a/apps/server/src/services/index_replay_runtime_composition.rs
+++ b/apps/server/src/services/index_replay_runtime_composition.rs
@@ -1,6 +1,11 @@
 #[path = "index_reconciliation_operator.rs"]
 mod reconciliation_operator;
+#[path = "index_drift_diagnosis_operator.rs"]
+mod drift_diagnosis_operator;
 
+pub use drift_diagnosis_operator::{
+    IndexDriftDiagnosisOperatorError, IndexDriftDiagnosisOperatorRuntime,
+};
 pub use reconciliation_operator::{
     IndexReconciliationOperatorContext, IndexReconciliationOperatorError,
     IndexReconciliationOperatorRuntime,
@@ -118,8 +123,8 @@ impl fmt::Debug for IndexReplayOperatorRuntime {
 ///
 /// This function performs no database I/O and starts no worker. It invokes selected source
 /// factories only to construct adapters, freezes the complete source catalog, binds the immutable
-/// schema/source registries to the host database, and publishes the guarded bounded replay and
-/// reconciliation operator capabilities through `ModuleRuntimeExtensions`.
+/// schema/source registries to the host database, and publishes the guarded bounded replay,
+/// reconciliation, and exact-entity drift diagnosis capabilities through `ModuleRuntimeExtensions`.
 pub(crate) fn materialize_index_replay_runtime(
     extensions: &mut ModuleRuntimeExtensions,
     db: DatabaseConnection,
@@ -153,7 +158,8 @@ pub(crate) fn materialize_index_replay_runtime(
     if let Some(runtime) = runtime {
         extensions.insert(IndexReplayOperatorRuntime::new(runtime));
     }
-    reconciliation_operator::materialize_index_reconciliation_operator(extensions, db)?;
+    reconciliation_operator::materialize_index_reconciliation_operator(extensions, db.clone())?;
+    drift_diagnosis_operator::materialize_index_drift_diagnosis_operator(extensions, db)?;
     Ok(())
 }
 
@@ -176,8 +182,8 @@ mod tests {
     use uuid::Uuid;
 
     use super::{
-        IndexReplayOperatorContext, IndexReplayOperatorError, IndexReplayOperatorRuntime,
-        materialize_index_replay_runtime,
+        IndexDriftDiagnosisOperatorRuntime, IndexReplayOperatorContext, IndexReplayOperatorError,
+        IndexReplayOperatorRuntime, materialize_index_replay_runtime,
     };
     use crate::services::rbac_request_scope::{RbacRequestScope, with_rbac_request_scope};
 
@@ -289,6 +295,7 @@ mod tests {
         assert!(!extensions.contains::<SharedIndexSourceRegistry>());
         assert!(!extensions.contains::<SharedIndexReplayRuntime>());
         assert!(!extensions.contains::<IndexReplayOperatorRuntime>());
+        assert!(!extensions.contains::<IndexDriftDiagnosisOperatorRuntime>());
     }
 
     #[tokio::test]
@@ -309,9 +316,13 @@ mod tests {
         assert!(extensions.contains::<SharedIndexSourceRegistry>());
         assert!(extensions.contains::<SharedIndexReplayRuntime>());
         assert!(extensions.contains::<IndexReplayOperatorRuntime>());
+        assert!(extensions.contains::<IndexDriftDiagnosisOperatorRuntime>());
 
         let host = extensions.apply_to_host_runtime(rustok_api::HostRuntimeContext::new(db));
         assert!(host.shared_get::<IndexReplayOperatorRuntime>().is_some());
+        assert!(host
+            .shared_get::<IndexDriftDiagnosisOperatorRuntime>()
+            .is_some());
     }
 
     #[tokio::test]

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-03.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-03.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-03
 
 Status overlay for `implementation-plan.md` audited through
-`main@5da25b28be5e1bf4f9cd9802337a3efa560179a4`.
+`main@c6ae3db0caf64c4578cb76073e9b719e483fb953`.
 
 When the older canonical plan's current-state bullets conflict with this dated overlay, this
 overlay is the rechecked source of truth. Historical architecture, ownership, and milestone
@@ -9,12 +9,12 @@ details remain in `implementation-plan.md`.
 
 ## Current cursor
 
-`M6 - guarded exact-entity diagnosis composition and explicit absence watermarks`
+`M6 - explicit absence watermarks and bounded diagnosis transport`
 
 The database-neutral digest producer, mismatch-only writer adapter, locale-complete finding scope,
-and source-version-fenced PostgreSQL snapshot reader are source complete. Server-owned composition
-of reader, producer, and writer for one authorized exact `EntityKey`, truthful missing-source
-watermarks, lifecycle commands, repair, transports, and retained evidence remain open.
+source-version-fenced PostgreSQL snapshot reader, and guarded exact-entity diagnosis capability are
+source complete. Truthful missing-source watermarks, diagnosis transports, lifecycle commands,
+repair, and retained evidence remain open.
 
 ## Rechecked status
 
@@ -41,7 +41,9 @@ watermarks, lifecycle commands, repair, transports, and retained evidence remain
 - M6 locale-optional persisted entity finding scope:
   `source_complete_owner_execution_pending`
 - M6 source-version-fenced PostgreSQL drift snapshot reader:
-  `source_complete_host_diagnosis_composition_owner_execution_pending`
+  `source_complete_owner_execution_pending`
+- M6 guarded exact-entity drift diagnosis operator:
+  `source_complete_transport_and_owner_execution_pending`
 - M7 Product/ProductVariant/SalesChannel bounded replay graph:
   `source_complete_owner_execution_pending`
 
@@ -90,10 +92,13 @@ watermarks, lifecycle commands, repair, transports, and retained evidence remain
 - [x] Add an environment-gated real-migration PostgreSQL harness for stable capture, source-change
       rejection, and missing-watermark rejection.
 - [ ] Run and admit `drift_snapshot_reader_postgres_test` evidence.
-- [ ] Compose the reader, digest producer, and finding writer inside the guarded server operator for
-      one authorized exact `EntityKey` without adding discovery or repair.
+- [x] Compose the snapshot reader, digest producer, and finding writer behind one request-bound
+      `modules:manage` exact-entity diagnosis capability using the frozen source/schema registries.
+- [x] Reject cross-tenant and unauthorized diagnosis before request validation, source access,
+      materialized reads, digest production, or finding persistence.
 - [ ] Add an explicit retained absence/tombstone watermark contract before empty targeted loads can
       produce authoritative source `Missing` state.
+- [ ] Expose the exact-entity diagnosis capability through one bounded operator transport.
 - [ ] Add missing/stale entity and orphan-link diagnosis without unbounded ID collection.
 - [ ] Add resolve/ignore lifecycle commands with actor/reason audit and fail-closed authorization.
 - [ ] Add targeted repair with before/after admitted evidence.
@@ -112,15 +117,18 @@ watermarks, lifecycle commands, repair, transports, and retained evidence remain
 
 ## Next implementation step
 
-Compose `PostgresIndexDriftSnapshotReader`, `IndexDriftDigestProducer`, and
-`PostgresIndexDriftFindingWriter` inside the existing guarded server reconciliation operator. Accept
-only one request-bound authorized exact `EntityKey`; keep scans, discovery, lifecycle commands, and
-repair forbidden. Preserve `index_drift_source_watermark_missing` until each owner source can return
-a retained delete or another explicit positive absence watermark.
+Extend the targeted owner-load contract with an explicit retained absence/tombstone watermark so an
+empty current-state row can become an authoritative positive-version source `Missing` state without
+weakening the existing source-version fence. Keep scan/discovery, automatic resolution, and repair
+outside that slice. After the watermark contract is admitted, expose the exact-entity diagnosis
+capability through one bounded request transport.
 
 ## Owner verification for this slice
 
 ```bash
+cargo test -p rustok-server index_drift_diagnosis_operator -- --nocapture
+cargo test -p rustok-server index_replay_runtime_composition -- --nocapture
+
 RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
   cargo test -p rustok-index \
   --test drift_snapshot_reader_postgres_test \
@@ -138,10 +146,12 @@ RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
   --test drift_finding_writer_postgres_test \
   -- --nocapture --test-threads=1
 
+node scripts/verify/verify-index-server-reconciliation-guard.mjs
 node scripts/verify/verify-index-drift-snapshot-reader.mjs
 node scripts/verify/verify-index-drift-finding-locale-scope.mjs
 node scripts/verify/verify-index-drift-digest-producer.mjs
 node scripts/verify/verify-index-drift-finding-postgres-harness.mjs
+cargo check -p rustok-server --all-targets
 cargo check -p rustok-index --all-targets
 git diff --check
 ```

--- a/crates/rustok-index/docs/implementation-recheck-2026-08-04-guarded-drift-diagnosis.md
+++ b/crates/rustok-index/docs/implementation-recheck-2026-08-04-guarded-drift-diagnosis.md
@@ -1,0 +1,59 @@
+# M6 guarded exact-entity drift diagnosis recheck — 2026-08-04
+
+Audited baseline: `main@c6ae3db0caf64c4578cb76073e9b719e483fb953`.
+
+## Rechecked inputs
+
+- `IndexDriftDigestProducer` already validates one exact snapshot pair, hashes typed states, and
+  delegates unequal digests only to `IndexDriftMismatchRecorder`.
+- `PostgresIndexDriftSnapshotReader` already enforces a positive owner source-version fence around
+  one PostgreSQL `REPEATABLE READ READ ONLY` materialized snapshot.
+- `PostgresIndexDriftFindingWriter` already owns deterministic create/refresh/reopen/suppression
+  lifecycle for locale-bearing and locale-free entity findings.
+- `IndexReconciliationOperatorContext` already owns the server request-bound tenant/actor identity
+  and `Permission::MODULES_MANAGE` authorization pattern.
+- The server replay composition is the only point where PostgreSQL source factories are invoked and
+  immutable source/schema registries are frozen.
+
+## Selected composition
+
+A separate `IndexDriftDiagnosisOperatorRuntime` is published beside the reconciliation runtime from
+the same source-freezing function. This is intentionally a sibling capability rather than another
+field on the runner/recovery runtime:
+
+- both use the same `IndexReconciliationOperatorContext` and effective permission snapshot;
+- diagnosis owns the snapshot reader, digest producer, and finding writer privately;
+- reconciliation retains only runner, inspection, and recovery ownership;
+- neither capability exposes database, registries, adapters, schedulers, or worker handles.
+
+The public diagnosis surface is exactly `diagnose_entity(context, key)`. The key tenant is compared
+with the authorized context before `IndexDriftDigestRequest` construction or dependency access.
+No batch, scan, cursor, repair mode, lifecycle command, caller-selected actor, or caller-selected
+separate tenant is accepted.
+
+## Result boundary
+
+The command returns only `IndexDriftDigestOutcome`:
+
+- `Consistent { digest }`; or
+- `MismatchRecorded { source_digest, materialized_digest, receipt }`.
+
+It never returns raw source/materialized records, fields, links, SQL, storage causes, snapshot text,
+credentials, registry handles, or finding details beyond the existing bounded receipt.
+
+## Deliberate open work
+
+- Empty owner targeted loads remain `index_drift_source_watermark_missing`; no absence is invented.
+- No transport is added.
+- No automatic resolution occurs when the pair is consistent.
+- No resolve/ignore command, actor/reason audit, discovery, orphan diagnosis, or repair is added.
+- PostgreSQL, authorization, and end-to-end finding evidence remain maintainer-run.
+
+## Next cursor
+
+Define an explicit retained absence/tombstone watermark in the targeted owner-load contract so a
+truthful positive-version source `Missing` state can participate in the same fence. Keep scans,
+automatic lifecycle changes, and repair outside that contract slice.
+
+No tests, verifiers, formatting, Cargo checks, PostgreSQL scenarios, workflows, or CI were executed
+by the implementation agent.

--- a/crates/rustok-index/docs/m6-drift-digest-producer.md
+++ b/crates/rustok-index/docs/m6-drift-digest-producer.md
@@ -1,13 +1,13 @@
 # M6 bounded drift digest producer
 
-Status: `producer_reader_and_locale_scope_source_complete_host_diagnosis_pending`
+Status: `producer_reader_locale_scope_and_guarded_diagnosis_source_complete`
 
 ## Purpose
 
-The drift-finding writer accepts already-computed source and materialized digests. The
+The drift-finding writer accepts already-computed source and materialized digests.
 `IndexDriftDigestProducer` is the database-neutral boundary between an admitted snapshot reader and
 that persistence adapter. It does not invent a snapshot, open source tables, scan unbounded
-identifiers, or perform repair.
+identifiers, choose finding lifecycle policy, or perform repair.
 
 ## Snapshot contract
 
@@ -31,7 +31,7 @@ schema, tenant, entity, locale, field, link, value, or source-version state fail
 before persistence.
 
 The opaque boundary is evidence that the reader captured both views under one owner-defined
-consistency rule. The producer itself still does not define PostgreSQL snapshot export, owner
+consistency rule. The producer itself does not define PostgreSQL snapshot export, owner
 high-watermarks, or cross-database transaction semantics. A reader that cannot establish one
 truthful boundary must return a bounded dependency failure rather than fabricate a pair.
 
@@ -51,20 +51,20 @@ Equal digests return `Consistent` and never call the recorder. Unequal digests c
 - source digest;
 - materialized digest.
 
-Raw records, fields, links, source payloads, SQL, database errors, and transport context are not
-accepted by the recorder contract.
+Raw records, fields, links, source payloads, SQL, database errors, credentials, transaction handles,
+and transport context are not accepted by the recorder contract.
 
 ## PostgreSQL snapshot reader
 
-`PostgresIndexDriftSnapshotReader` is now source complete. It observes one positive-version owner
+`PostgresIndexDriftSnapshotReader` is source complete. It observes one exact positive-version owner
 state, reads materialized entity/link state inside one PostgreSQL `REPEATABLE READ READ ONLY`
 transaction, and accepts the pair only when the complete owner state is identical on a second
 observation while that transaction remains open.
 
-The reader returns bounded retryable failure when the owner changes and permanent failure when an
-empty targeted load has no retained tombstone or other absence watermark. It does not claim an
-exported snapshot across arbitrary owner adapters. Full details are retained in
-`m6-postgres-drift-snapshot-reader.md`.
+The reader returns bounded retryable failure when the owner changes. An empty targeted load remains
+permanent `index_drift_source_watermark_missing` until the owner can provide a retained tombstone or
+another explicit positive absence watermark. The reader does not claim an exported snapshot across
+arbitrary owner adapters. Full details are retained in `m6-postgres-drift-snapshot-reader.md`.
 
 ## PostgreSQL writer adapter
 
@@ -82,25 +82,41 @@ The locale-free variant persists `locale_key = NULL`; it is never collapsed into
 locale is invented. Locale-bearing finding-key bytes retain their original v1 component sequence.
 The locale-free scope uses a distinct impossible-for-`LocaleKey` NUL component.
 
+## Guarded server diagnosis
+
+The server privately composes the production reader, this producer, and the writer inside
+`IndexDriftDiagnosisOperatorRuntime`. The capability is published only after the immutable
+`SharedIndexSourceRegistry` and `SharedIndexSchemaRegistry` have been frozen by replay composition.
+
+The public surface accepts one exact `EntityKey` plus the existing request-bound
+`IndexReconciliationOperatorContext`. It requires effective `Permission::MODULES_MANAGE`, rejects a
+cross-tenant key, and performs authorization before `IndexDriftDigestRequest` validation, source
+access, materialized reads, hashing, or finding persistence.
+
+The result remains exactly `IndexDriftDigestOutcome`: either one consistent digest or bounded source
+and materialized digests plus the deterministic finding receipt. The operator exposes no database
+connection, source/schema registry, snapshot reader, finding writer, raw record, scan, lifecycle,
+repair, scheduler, worker, or transport handle.
+
 ## Deliberate limits
 
 This slice does not add or claim:
 
-- server-owned composition of reader, producer, and writer;
 - exported PostgreSQL snapshots shared with arbitrary owner adapters;
-- source absence admission without a retained tombstone or explicit positive watermark;
-- automatic entity discovery, full scans, or orphan-link diagnosis;
+- source `Missing` admission without a retained tombstone or explicit positive watermark;
+- automatic entity discovery, full scans, stale enumeration, or orphan-link diagnosis;
 - finding resolution when states converge;
-- resolve/ignore commands, actor/reason audit, or authorization;
+- resolve/ignore commands, actor/reason audit, or additional authorization policy;
 - targeted/full/shadow repair;
-- GraphQL, HTTP, CLI, admin, scheduler, or graceful-shutdown composition;
-- retained PostgreSQL or production-source execution evidence.
+- GraphQL, HTTP, CLI, admin, MCP, or another diagnosis transport;
+- retained PostgreSQL, authorization, lifecycle, or production-source execution evidence.
 
 ## Maintainer verification
 
 ```bash
 cargo test -p rustok-index drift_digest -- --nocapture
 cargo test -p rustok-index --test drift_finding_locale_key_contract
+cargo test -p rustok-server index_drift_diagnosis_operator -- --nocapture
 
 RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
   cargo test -p rustok-index \
@@ -108,8 +124,10 @@ RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
   -- --nocapture --test-threads=1
 
 cargo check -p rustok-index --all-targets
+cargo check -p rustok-server --all-targets
 node scripts/verify/verify-index-drift-digest-producer.mjs
 node scripts/verify/verify-index-drift-snapshot-reader.mjs
+node scripts/verify/verify-index-server-reconciliation-guard.mjs
 node scripts/verify/verify-index-drift-finding-locale-scope.mjs
 git diff --check
 ```

--- a/crates/rustok-index/docs/m6-postgres-drift-snapshot-reader.md
+++ b/crates/rustok-index/docs/m6-postgres-drift-snapshot-reader.md
@@ -1,6 +1,6 @@
 # M6 PostgreSQL drift snapshot reader
 
-Status: `source_complete_host_diagnosis_composition_and_owner_execution_pending`.
+Status: `source_complete_owner_execution_pending`.
 
 ## Purpose
 
@@ -71,8 +71,11 @@ The existing producer validates both resulting states through `SchemaRegistry` b
 is missing or the backend is not PostgreSQL, and otherwise constructs the reader from immutable
 registries plus the host connection.
 
-The reader is exported through `rustok_index`, but this slice does not insert it into the server
-operator, call the digest producer, persist a finding, or expose a transport.
+The server now privately composes the same reader with `IndexDriftDigestProducer` and
+`PostgresIndexDriftFindingWriter` inside `IndexDriftDiagnosisOperatorRuntime`. That guarded sibling
+to the reconciliation operator accepts one exact request-bound authorized `EntityKey` and exposes
+no reader, writer, registry, connection, scan, lifecycle, or repair handle. No transport is added by
+this slice.
 
 ## Source-ready PostgreSQL harness
 
@@ -108,8 +111,11 @@ RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
   --test drift_snapshot_reader_postgres_test \
   -- --nocapture --test-threads=1
 
+cargo test -p rustok-server index_drift_diagnosis_operator -- --nocapture
 node scripts/verify/verify-index-drift-snapshot-reader.mjs
+node scripts/verify/verify-index-server-reconciliation-guard.mjs
 cargo check -p rustok-index --all-targets
+cargo check -p rustok-server --all-targets
 git diff --check
 ```
 

--- a/scripts/verify/verify-index-drift-digest-producer.mjs
+++ b/scripts/verify/verify-index-drift-digest-producer.mjs
@@ -6,18 +6,15 @@ const files = {
   producer: "crates/rustok-index/src/application/drift_digest.rs",
   applicationMod: "crates/rustok-index/src/application/mod.rs",
   recorder: "crates/rustok-index/src/infrastructure/postgres/drift_digest_recorder.rs",
-  snapshotReader:
-    "crates/rustok-index/src/infrastructure/postgres/drift_snapshot_reader.rs",
+  reader: "crates/rustok-index/src/infrastructure/postgres/drift_snapshot_reader.rs",
+  diagnosis: "apps/server/src/services/index_drift_diagnosis_operator.rs",
   postgresMod: "crates/rustok-index/src/infrastructure/postgres/mod.rs",
   doc: "crates/rustok-index/docs/m6-drift-digest-producer.md",
   plan: "crates/rustok-index/docs/implementation-plan-current-2026-08-03.md",
 };
 
-const contents = Object.fromEntries(
-  await Promise.all(
-    Object.entries(files).map(async ([name, path]) => [name, await readFile(path, "utf8")]),
-  ),
-);
+const [producer, applicationMod, recorder, reader, diagnosis, postgresMod, doc, plan] =
+  await Promise.all(Object.values(files).map((path) => readFile(path, "utf8")));
 
 function requireMarkers(label, content, markers) {
   for (const marker of markers) {
@@ -27,7 +24,7 @@ function requireMarkers(label, content, markers) {
   }
 }
 
-requireMarkers(files.producer, contents.producer, [
+requireMarkers(files.producer, producer, [
   'b"index_drift_entity_state_digest_v1"',
   "pub trait IndexDriftSnapshotReader",
   "pub trait IndexDriftMismatchRecorder",
@@ -43,7 +40,7 @@ requireMarkers(files.producer, contents.producer, [
   "IndexDriftEntityState::Upsert",
 ]);
 
-requireMarkers(files.recorder, contents.recorder, [
+requireMarkers(files.recorder, recorder, [
   "impl IndexDriftMismatchRecorder for PostgresIndexDriftFindingWriter",
   'const CHECK_NAME: &str = "source_index_digest_mismatch";',
   "match key.locale.clone()",
@@ -52,36 +49,49 @@ requireMarkers(files.recorder, contents.recorder, [
   "PostgresIndexDriftFindingWriter::record_digest_mismatch",
   "IndexDriftMismatchRecordStatus::Suppressed",
 ]);
-requireMarkers(files.snapshotReader, contents.snapshotReader, [
+
+requireMarkers(files.reader, reader, [
   "impl IndexDriftSnapshotReader for PostgresIndexDriftSnapshotReader",
   "IsolationLevel::RepeatableRead",
   "AccessMode::ReadOnly",
-  "index_drift_source_changed_during_capture",
   "index_drift_source_watermark_missing",
+  "index_drift_source_changed_during_capture",
 ]);
 
-requireMarkers(files.applicationMod, contents.applicationMod, [
+requireMarkers(files.diagnosis, diagnosis, [
+  "type IndexDriftDiagnosisProducer = rustok_index::IndexDriftDigestProducer<",
+  "rustok_index::PostgresIndexDriftSnapshotReader",
+  "PostgresIndexDriftFindingWriter",
+  "pub async fn diagnose_entity(",
+  "authorize_for(&context, key.tenant_id)?;",
+  "IndexDriftDigestRequest::new(key)?;",
+  "self.inner.produce(request).await",
+]);
+
+requireMarkers(files.applicationMod, applicationMod, [
   "mod drift_digest;",
   "IndexDriftDigestProducer",
   "IndexDriftSnapshotReader",
 ]);
-requireMarkers(files.postgresMod, contents.postgresMod, [
+requireMarkers(files.postgresMod, postgresMod, [
   "mod drift_digest_recorder;",
   "mod drift_snapshot_reader;",
 ]);
-requireMarkers(files.doc, contents.doc, [
-  "producer_reader_and_locale_scope_source_complete_host_diagnosis_pending",
+requireMarkers(files.doc, doc, [
+  "producer_reader_locale_scope_and_guarded_diagnosis_source_complete",
   "same bounded opaque `IndexDriftSnapshotBoundary`",
   "Equal digests return `Consistent` and never call the recorder.",
   "`locale: None` maps to `IndexDriftFindingScope::EntityWithoutLocale`",
-  "`PostgresIndexDriftSnapshotReader` is now source complete",
-  "server-owned composition of reader, producer, and writer",
+  "IndexDriftDiagnosisOperatorRuntime",
+  "does not define PostgreSQL snapshot export",
 ]);
-requireMarkers(files.plan, contents.plan, [
+requireMarkers(files.plan, plan, [
   "M6 snapshot-pair digest producer and mismatch-only recorder delegation",
+  "M6 locale-optional persisted entity finding scope",
   "M6 source-version-fenced PostgreSQL drift snapshot reader",
-  "source_complete_host_diagnosis_composition_owner_execution_pending",
-  "Compose the reader, digest producer, and finding writer",
+  "M6 guarded exact-entity drift diagnosis operator",
+  "source_complete_transport_and_owner_execution_pending",
+  "explicit retained absence/tombstone watermark contract",
 ]);
 
 const forbiddenProducerMarkers = [
@@ -96,7 +106,7 @@ const forbiddenProducerMarkers = [
   "index_links",
 ];
 for (const marker of forbiddenProducerMarkers) {
-  if (contents.producer.includes(marker)) {
+  if (producer.includes(marker)) {
     throw new Error(`database-neutral producer contains forbidden dependency marker: ${marker}`);
   }
 }
@@ -105,17 +115,34 @@ for (const obsolete of [
   "index_drift_locale_free_scope_unsupported",
   "let Some(locale) = key.locale.clone() else",
 ]) {
-  if (contents.recorder.includes(obsolete) || contents.doc.includes(obsolete)) {
+  if (recorder.includes(obsolete) || doc.includes(obsolete)) {
     throw new Error(`producer adapter retains obsolete locale limitation: ${obsolete}`);
+  }
+}
+
+const diagnosisProduction = diagnosis.split("\n#[cfg(test)]")[0];
+for (const forbidden of [
+  "tokio::spawn",
+  "spawn_blocking",
+  "Router::new",
+  "async_graphql",
+  ".scan(",
+  "repair_finding",
+  "resolve_finding",
+  "ignore_finding",
+]) {
+  if (diagnosisProduction.includes(forbidden)) {
+    throw new Error(`guarded diagnosis contains forbidden marker: ${forbidden}`);
   }
 }
 
 for (const claim of [
   "tests passed",
+  "diagnosis transport is complete",
   "repair is complete",
   "retained evidence admitted",
 ]) {
-  if (contents.doc.toLowerCase().includes(claim.toLowerCase())) {
+  if (doc.toLowerCase().includes(claim.toLowerCase())) {
     throw new Error(`documentation makes forbidden completion claim: ${claim}`);
   }
 }

--- a/scripts/verify/verify-index-drift-snapshot-reader.mjs
+++ b/scripts/verify/verify-index-drift-snapshot-reader.mjs
@@ -4,34 +4,26 @@ import { readFile } from "node:fs/promises";
 
 const files = {
   reader: "crates/rustok-index/src/infrastructure/postgres/drift_snapshot_reader.rs",
-  postgresMod: "crates/rustok-index/src/infrastructure/postgres/mod.rs",
-  lib: "crates/rustok-index/src/lib.rs",
   test: "crates/rustok-index/tests/drift_snapshot_reader_postgres_test.rs",
+  diagnosis: "apps/server/src/services/index_drift_diagnosis_operator.rs",
   doc: "crates/rustok-index/docs/m6-postgres-drift-snapshot-reader.md",
-  recheck:
-    "crates/rustok-index/docs/implementation-recheck-2026-08-04-drift-snapshot-reader.md",
+  recheck: "crates/rustok-index/docs/implementation-recheck-2026-08-04-guarded-drift-diagnosis.md",
   plan: "crates/rustok-index/docs/implementation-plan-current-2026-08-03.md",
-  readme: "crates/rustok-index/docs/README.md",
-  queryVerifier: "scripts/verify/verify-index-query-contract.mjs",
 };
 
-const contents = Object.fromEntries(
-  await Promise.all(
-    Object.entries(files).map(async ([name, path]) => [name, await readFile(path, "utf8")]),
-  ),
+const c = Object.fromEntries(
+  await Promise.all(Object.entries(files).map(async ([name, path]) => [name, await readFile(path, "utf8")])),
 );
 
-function requireMarkers(label, content, markers) {
+function requireMarkers(name, markers) {
   for (const marker of markers) {
-    if (!content.includes(marker)) {
-      throw new Error(`${label} is missing required marker: ${marker}`);
-    }
+    if (!c[name].includes(marker)) throw new Error(`${files[name]} missing ${marker}`);
   }
 }
 
-requireMarkers(files.reader, contents.reader, [
+requireMarkers("reader", [
   "pub struct PostgresIndexDriftSnapshotReader",
-  "impl IndexDriftSnapshotReader for PostgresIndexDriftSnapshotReader",
+  "impl IndexDriftSnapshotReader for PostgreSIndexDriftSnapshotReader",
   "IndexSourceLoadRequest::new(vec![request.key().clone()])",
   "index_drift_source_watermark_missing",
   "index_drift_source_changed_during_capture",
@@ -49,85 +41,58 @@ requireMarkers(files.reader, contents.reader, [
   "pub fn materialize_postgres_index_drift_snapshot_reader",
 ]);
 
-const production = contents.reader.split("\n#[cfg(test)]")[0];
+const production = c.reader.split("\n#[cfg(test)]")[0];
 for (const forbidden of [
-  "INSERT INTO",
-  "UPDATE ",
-  "DELETE FROM",
-  "tokio::spawn",
-  "spawn_blocking",
-  "tokio::time::sleep",
-  "repair_finding",
-  "resolve_finding",
-  "ignore_finding",
-  "Router::new",
-  "async_graphql",
+  "INSERT INTO", "UPDATE ", "DELETE FROM", "tokio::spawn", "spawn_blocking",
+  "repair_finding", "resolve_finding", "ignore_finding", "Router::new", "async_graphql",
 ]) {
-  if (production.includes(forbidden)) {
-    throw new Error(`snapshot reader contains forbidden marker: ${forbidden}`);
-  }
+  if (production.includes(forbidden)) throw new Error(`snapshot reader contains ${forbidden}`);
 }
 
-requireMarkers(files.postgresMod, contents.postgresMod, [
-  "mod drift_snapshot_reader;",
-  "PostgresIndexDriftSnapshotReader",
-  "materialize_postgres_index_drift_snapshot_reader",
-]);
-requireMarkers(files.lib, contents.lib, [
-  "materialize_postgres_index_drift_snapshot_reader",
-  "IndexDriftSnapshotCompositionError",
-  "PostgresIndexDriftSnapshotReader",
-]);
-requireMarkers(files.test, contents.test, [
+requireMarkers("test", [
   'const DATABASE_ENV: &str = "RUSTOK_INDEX_TEST_DATABASE_URL";',
   "for migration in IndexModule.migrations()",
   "PostgresSchemaRegistrationStore",
   "PostgresMutationStore",
-  "materialize_postgres_index_drift_snapshot_reader",
   "source_version_fence_captures_and_rejects_unstable_postgres_snapshots",
   'assert_eq!(changed.code(), "index_drift_source_changed_during_capture")',
   'assert_eq!(missing.code(), "index_drift_source_watermark_missing")',
   'DROP SCHEMA IF EXISTS',
 ]);
-requireMarkers(files.doc, contents.doc, [
-  "source_complete_host_diagnosis_composition_and_owner_execution_pending",
+requireMarkers("diagnosis", [
+  "PostgresIndexDriftSnapshotReader::new(",
+  "IndexDriftDigestProducer::new(",
+  "PostgresIndexDriftFindingWriter::new(db)",
+  "pub async fn diagnose_entity(",
+  "authorize_for(&context, key.tenant_id)?;",
+  "IndexDriftDigestRequest::new(key)?;",
+]);
+requireMarkers("doc", [
+  "source_complete_owner_execution_pending",
   "source-version fence",
   "REPEATABLE READ READ ONLY",
   "txid_current_snapshot()",
   "unproven absence is never converted to `Missing`",
+  "IndexDriftDiagnosisOperatorRuntime",
+  "No transport is added by\nthis slice.",
   "retained execution evidence only after the repository owner runs and admits it",
 ]);
-requireMarkers(files.recheck, contents.recheck, [
-  "Audited baseline: `main@5da25b28be5e1bf4f9cd9802337a3efa560179a4`",
-  "source-version fence",
-  "Compose the reader, existing digest producer, and finding writer",
+requireMarkers("recheck", [
+  "Audited baseline: `main@c6ae3db0caf64c4578cb76073e9b719e483fb953`",
+  "IndexDriftDiagnosisOperatorRuntime",
+  "diagnose_entity(context, key)",
+  "index_drift_source_watermark_missing",
 ]);
-requireMarkers(files.plan, contents.plan, [
+requireMarkers("plan", [
   "M6 source-version-fenced PostgreSQL drift snapshot reader",
-  "source_complete_host_diagnosis_composition_owner_execution_pending",
-  "drift_snapshot_reader_postgres_test",
-  "Compose the reader, digest producer, and finding writer",
+  "M6 guarded exact-entity drift diagnosis operator",
+  "source_complete_transport_and_owner_execution_pending",
   "explicit retained absence/tombstone watermark contract",
 ]);
-requireMarkers(files.readme, contents.readme, [
-  "[M6 PostgreSQL Drift Snapshot Reader](./m6-postgres-drift-snapshot-reader.md)",
-]);
-requireMarkers(files.queryVerifier, contents.queryVerifier, [
-  "'verify-index-drift-snapshot-reader.mjs'",
-]);
 
-for (const claim of [
-  "tests passed",
-  "PostgreSQL execution passed",
-  "retained evidence admitted",
-  "server diagnosis is complete",
-  "repair is complete",
-]) {
-  if (
-    contents.doc.toLowerCase().includes(claim.toLowerCase()) ||
-    contents.recheck.toLowerCase().includes(claim.toLowerCase())
-  ) {
-    throw new Error(`snapshot reader documentation makes forbidden claim: ${claim}`);
+for (const claim of ["tests passed", "PostgreSQL execution passed", "retained evidence admitted", "diagnosis transport is complete", "repair is complete"]) {
+  if (c.doc.toLowerCase().includes(claim.toLowerCase()) || c.recheck.toLowerCase().includes(claim.toLowerCase())) {
+    throw new Error(`forbidden completion claim: ${claim}`);
   }
 }
 

--- a/scripts/verify/verify-index-server-reconciliation-guard.mjs
+++ b/scripts/verify/verify-index-server-reconciliation-guard.mjs
@@ -20,20 +20,31 @@ const requireMarkers = (relative, markers) => {
 
 const compositionPath = 'apps/server/src/services/index_replay_runtime_composition.rs';
 const operatorPath = 'apps/server/src/services/index_reconciliation_operator.rs';
+const diagnosisPath = 'apps/server/src/services/index_drift_diagnosis_operator.rs';
 const docsPath = 'apps/server/docs/index-reconciliation-operator-runtime.md';
+const planPath = 'crates/rustok-index/docs/implementation-plan-current-2026-08-03.md';
+const recheckPath = 'crates/rustok-index/docs/implementation-recheck-2026-08-04-guarded-drift-diagnosis.md';
 
 const composition = requireMarkers(compositionPath, [
   '#[path = "index_reconciliation_operator.rs"]',
   'mod reconciliation_operator;',
+  '#[path = "index_drift_diagnosis_operator.rs"]',
+  'mod drift_diagnosis_operator;',
+  'IndexDriftDiagnosisOperatorError, IndexDriftDiagnosisOperatorRuntime,',
   'materialize_postgres_index_replay_runtime(extensions, db.clone())',
-  'reconciliation_operator::materialize_index_reconciliation_operator(extensions, db)?;',
+  'reconciliation_operator::materialize_index_reconciliation_operator(extensions, db.clone())?;',
+  'drift_diagnosis_operator::materialize_index_drift_diagnosis_operator(extensions, db)?;',
+  'extensions.contains::<IndexDriftDiagnosisOperatorRuntime>()',
 ]);
 const replay = composition.indexOf('materialize_postgres_index_replay_runtime(extensions, db.clone())');
 const reconciliation = composition.indexOf(
-  'reconciliation_operator::materialize_index_reconciliation_operator(extensions, db)?;',
+  'reconciliation_operator::materialize_index_reconciliation_operator(extensions, db.clone())?;',
 );
-if (replay < 0 || reconciliation <= replay) {
-  fail(`${compositionPath} must freeze replay/work composition before operator publication`);
+const diagnosis = composition.indexOf(
+  'drift_diagnosis_operator::materialize_index_drift_diagnosis_operator(extensions, db)?;',
+);
+if (replay < 0 || reconciliation <= replay || diagnosis <= reconciliation) {
+  fail(`${compositionPath} must freeze replay before reconciliation and diagnosis publication`);
 }
 
 const operator = requireMarkers(operatorPath, [
@@ -62,6 +73,8 @@ const production = operator.split('\n#[cfg(test)]')[0];
 for (const forbidden of [
   'tokio::spawn', 'spawn_blocking', 'SELECT ', 'INSERT ', 'UPDATE ', 'DELETE ',
   'Router::new', 'async_graphql', 'ModuleWorkScheduler', 'StopHandle',
+  'PostgresIndexDriftSnapshotReader', 'IndexDriftDigestProducer',
+  'PostgresIndexDriftFindingWriter',
 ]) {
   if (production.includes(forbidden)) fail(`${operatorPath} contains ${forbidden}`);
 }
@@ -95,23 +108,64 @@ for (const [name, body, marker] of [
     fail(`${operatorPath} ${name} must bind tenant to authorized context`);
   }
 }
-const auth = requeue.indexOf('context.authorize_for(context.tenant_id())?;');
-const request = requeue.indexOf('IndexReconciliationRequeueRequest::new(');
-const tenant = requeue.indexOf('context.tenant_id(),', request);
-const actor = requeue.indexOf('context.actor_id(),', tenant);
-const delegate = requeue.indexOf('.requeue_failed(request)');
-if (auth < 0 || request <= auth || tenant <= request || actor <= tenant || delegate <= actor) {
+const requeueAuth = requeue.indexOf('context.authorize_for(context.tenant_id())?;');
+const requeueRequest = requeue.indexOf('IndexReconciliationRequeueRequest::new(');
+const requeueTenant = requeue.indexOf('context.tenant_id(),', requeueRequest);
+const requeueActor = requeue.indexOf('context.actor_id(),', requeueTenant);
+const requeueDelegate = requeue.indexOf('.requeue_failed(request)');
+if (requeueAuth < 0 || requeueRequest <= requeueAuth || requeueTenant <= requeueRequest
+    || requeueActor <= requeueTenant || requeueDelegate <= requeueActor) {
   fail(`${operatorPath} requeue must authorize, bind tenant/actor, then delegate`);
 }
 
 const driftComposition = production.indexOf('let drift_findings =');
 const driftConstructor = production.indexOf('PostgresIndexDriftFindingInspector::new(db.clone())', driftComposition);
-const runnerComposition = production.indexOf('PostgresIndexReconciliationRunner::new(db, sources, schemas.shared())');
+const runnerComposition = production.indexOf('PostgreSIndexReconciliationRunner::new(db, sources, schemas.shared())');
 const runtimeComposition = production.indexOf('IndexReconciliationOperatorRuntime::new(', runnerComposition);
 const driftArgument = production.indexOf('drift_findings,', runtimeComposition);
 if (driftComposition < 0 || driftConstructor <= driftComposition || runnerComposition <= driftConstructor
     || runtimeComposition <= runnerComposition || driftArgument <= runtimeComposition) {
   fail(`${operatorPath} must privately compose drift inspection before runtime publication`);
+}
+
+const diagnosisSource = requireMarkers(diagnosisPath, [
+  'type IndexDriftDiagnosisProducer = rustok_index::IndexDriftDigestProducer<',
+  'rustok_index::PostgresIndexDriftSnapshotReader,',
+  'PostgresIndexDriftFindingWriter,',
+  'pub struct IndexDriftDiagnosisOperatorRuntime',
+  'inner: Arc<IndexDriftDiagnosisProducer>,',
+  'pub async fn diagnose_entity(',
+  'authorize_for(&context, key.tenant_id)?;',
+  'IndexDriftDigestRequest::new(key)?;',
+  'self.inner.produce(request).await',
+  'Permission::MODULES_MANAGE',
+  'permissions_for(&context.tenant_id(), &context.actor_id())',
+  'PostgresIndexDriftSnapshotReader::new(',
+  'PostgresIndexDriftFindingWriter::new(db)',
+  'IndexDriftDigestProducer::new(',
+  'exact_entity_diagnosis_authorizes_before_request_validation',
+  'IndexDriftDigestError::NilEntityId',
+]);
+const diagnosisProduction = diagnosisSource.split('\n#[cfg(test)]')[0];
+for (const forbidden of [
+  'tokio::spawn', 'spawn_blocking', 'SELECT ', 'INSERT ', 'UPDATE ', 'DELETE ',
+  'Router::new', 'async_graphql', '.scan(', 'repair_finding', 'targeted_repair',
+  'resolve_finding', 'ignore_finding',
+]) {
+  if (diagnosisProduction.includes(forbidden)) fail(`${diagnosisPath} contains ${forbidden}`);
+}
+const methodStart = diagnosisProduction.indexOf('    pub async fn diagnose_entity(');
+const methodEnd = diagnosisProduction.indexOf('\n    }\n}', methodStart);
+if (methodStart < 0 || methodEnd < 0) fail(`${diagnosisPath} diagnosis method is incomplete`);
+const method = diagnosisProduction.slice(methodStart, methodEnd);
+const diagnosisAuth = method.indexOf('authorize_for(&context, key.tenant_id)?;');
+const diagnosisRequest = method.indexOf('IndexDriftDigestRequest::new(key)?;');
+const diagnosisDelegate = method.indexOf('self.inner.produce(request).await');
+if (diagnosisAuth < 0 || diagnosisRequest <= diagnosisAuth || diagnosisDelegate <= diagnosisRequest) {
+  fail(`${diagnosisPath} must authorize, validate one exact key, then delegate`);
+}
+if (method.includes('tenant_id:') || method.includes('actor_id:') || method.includes('Vec<')) {
+  fail(`${diagnosisPath} must not accept caller-selected authority or batch scope`);
 }
 
 requireMarkers('crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs', [
@@ -131,7 +185,26 @@ requireMarkers(docsPath, [
   'existing generic server module-work bootstrap',
   'Drift inspection is read-only and is not scheduled.',
   'only authorizes bounded inspection of findings that already exist',
+  '`IndexDriftDiagnosisOperatorRuntime`',
+  '`diagnose_entity(context, key)`',
+  'Authorization runs before `IndexDriftDigestRequest` validation',
+  'Empty targeted owner loads remain permanent `index_drift_source_watermark_missing`',
+  'does not resolve a finding when states converge',
   'maintainer-run',
+]);
+requireMarkers(recheckPath, [
+  'Audited baseline: `main@c6ae3db0caf64c4578cb76073e9b719e483fb953`.',
+  'A separate `IndexDriftDiagnosisOperatorRuntime` is published beside the reconciliation runtime',
+  'The public diagnosis surface is exactly `diagnose_entity(context, key)`.',
+  'Empty owner targeted loads remain `index_drift_source_watermark_missing`',
+  'No tests, verifiers, formatting, Cargo checks',
+]);
+requireMarkers(planPath, [
+  'M6 guarded exact-entity drift diagnosis operator',
+  'source_complete_transport_and_owner_execution_pending',
+  '[x] Compose the snapshot reader, digest producer, and finding writer',
+  '[ ] Add an explicit retained absence/tombstone watermark contract',
+  '[ ] Expose the exact-entity diagnosis capability through one bounded operator transport.',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
   '- [ ] Add drift diagnosis, targeted repair commands, and admitted repair evidence.',


### PR DESCRIPTION
## Summary

- continue the rechecked `rustok-index` M6 cursor after merged PR #2977;
- add a sibling server-owned `IndexDriftDiagnosisOperatorRuntime` beside the existing reconciliation operator;
- reuse the request-bound `IndexReconciliationOperatorContext` and require effective `modules:manage`;
- accept exactly one typed `EntityKey`, reject cross-tenant scope, and authorize before digest-request validation or dependency access;
- privately compose `PostgresIndexDriftSnapshotReader` → `IndexDriftDigestProducer` → `PostgresIndexDriftFindingWriter` after immutable source/schema registries are frozen;
- return only the existing bounded `IndexDriftDigestOutcome` and expose no connection, registry, reader, writer, scan, lifecycle, scheduler, worker, or repair handle;
- publish no false capability when sources are absent and fail closed when a source registry exists without its shared schema registry;
- retain `index_drift_source_watermark_missing` for empty targeted owner loads without an admitted tombstone/absence watermark;
- update the server operator documentation, implementation overlay/recheck, and existing static guards without weakening the prior reader/digest invariants.

## Authorization boundary

`diagnose_entity(context, key)` performs these steps in order:

1. compare `key.tenant_id` with the authorized context tenant;
2. require a current request-bound RBAC snapshot;
3. require effective `Permission::MODULES_MANAGE`;
4. construct the bounded `IndexDriftDigestRequest`;
5. delegate to the existing source-version-fenced reader, digest producer, and deterministic finding writer.

The ordering prevents malformed or cross-tenant keys from being used as a source/storage oracle before authority is established.

## Composition

The existing replay composition remains the single source-freezing point:

1. materialize selected PostgreSQL source factories;
2. freeze `SharedIndexSourceRegistry`;
3. publish replay and reconciliation capabilities;
4. publish the exact-entity diagnosis capability from the same immutable source/schema registries.

Composition performs no diagnosis SQL and starts no task. PostgreSQL backend enforcement remains inside the snapshot reader before source or materialized reads.

## Deliberate limits

This PR does not add or claim:

- GraphQL, HTTP, CLI, admin, MCP, or another diagnosis transport;
- source absence admission without a retained tombstone or explicit positive watermark;
- entity discovery, full scans, stale enumeration, or orphan-link diagnosis;
- automatic finding resolution when states converge;
- resolve/ignore commands or actor/reason lifecycle audit;
- targeted/full/shadow repair;
- retained PostgreSQL, authorization, lifecycle, or production-source execution evidence.

The next cursor is an explicit retained absence/tombstone watermark contract for targeted owner loads, followed by one bounded operator transport.

## Validation

Not run per maintainer instruction:

- formatting;
- Cargo checks, tests, or Clippy;
- JavaScript verifiers;
- PostgreSQL scenarios;
- workflows and CI.

Suggested maintainer commands:

```bash
cargo test -p rustok-server index_drift_diagnosis_operator -- --nocapture
cargo test -p rustok-server index_replay_runtime_composition -- --nocapture
node scripts/verify/verify-index-server-reconciliation-guard.mjs
node scripts/verify/verify-index-drift-snapshot-reader.mjs
node scripts/verify/verify-index-drift-digest-producer.mjs
cargo check -p rustok-server --all-targets
cargo check -p rustok-index --all-targets
git diff --check
```

The branch is one commit ahead of `main@9cfc43cf72284e16261f788070a47367613bf2e2` and changes only the expected 10 Index/server composition, documentation, and guard files.