### PR TITLE
feat(forum): expose reply range move GraphQL command

### DIFF
--- a/crates/rustok-forum/contracts/forum-reply-range-move-graphql-transport.json
+++ b/crates/rustok-forum/contracts/forum-reply-range-move-graphql-transport.json
@@ -1,0 +1,99 @@
+{
+  "contract": "forum_reply_range_move_graphql_transport_v1",
+  "task": "FORUM-21T",
+  "parent_task": "FORUM-21",
+  "extends": "FORUM-21S",
+  "status": "source_ready_maintainer_execution_pending",
+  "canonical_plan_status": "planned",
+  "transport": "graphql",
+  "owner_service": "ForumReplyRangeMoveService",
+  "authorization": {
+    "module_must_be_enabled": "forum",
+    "required_permission": "forum_topics:manage",
+    "authenticated_human_actor_required_by_owner": true,
+    "tenant_is_derived_from_routed_TenantContext": true,
+    "optional_tenant_argument_must_equal_routed_tenant": true,
+    "tenant_mismatch_code": "PERMISSION_DENIED"
+  },
+  "command": {
+    "field": "moveForumTopicReplyRange",
+    "input_type": "MoveForumTopicReplyRangeGraphqlInput",
+    "source_topic_id_is_separate_argument": true,
+    "input_fields": [
+      "operation_id",
+      "target_topic_id",
+      "start_position",
+      "end_position",
+      "reason"
+    ],
+    "result_type": "GqlForumReplyRangeMove",
+    "calls_owner_method": "move_reply_range"
+  },
+  "receipt_result": {
+    "type": "GqlForumReplyRangeMove",
+    "fields": [
+      "operation_id",
+      "event_id",
+      "source_topic_id",
+      "target_topic_id",
+      "source_category_id",
+      "target_category_id",
+      "actor_id",
+      "reason",
+      "source_start_position",
+      "source_end_position",
+      "target_start_position",
+      "target_end_position",
+      "moved_reply_count",
+      "moved_published_reply_count",
+      "source_resulting_published_reply_count",
+      "target_resulting_published_reply_count",
+      "moved_solution_reply_id",
+      "source_resulting_solution_reply_id",
+      "target_resulting_solution_reply_id",
+      "moved_at"
+    ],
+    "returns_immutable_owner_receipt": true,
+    "exact_replay_returns_same_result": true,
+    "event_id_equals_operation_id": true
+  },
+  "composition": {
+    "resolver_contains_no_range_move_business_logic": true,
+    "database_and_transactional_event_bus_are_explicit_schema_data": true,
+    "security_context_uses_authenticated_permission_snapshot": true,
+    "domain_errors_preserve_ForumGraphqlErrorExtension_mapping": true,
+    "raw_range_move_receipt_or_item_table_access_in_resolver": false,
+    "canonical_topic_alias_resolution_for_mutation": false
+  },
+  "compatibility": {
+    "owner_command_changed": false,
+    "receipt_schema_changed": false,
+    "semantic_event_schema_changed": false,
+    "rest_contract_changed": false,
+    "admin_ui_added": false,
+    "storefront_ui_added": false,
+    "graphql_field_is_additive": true
+  },
+  "source_contract_test": "crates/rustok-forum/tests/reply_range_move_graphql_contract.rs",
+  "authorization_unit_test": "crates/rustok-forum/src/graphql/topic_reply_range_move_mutation.rs",
+  "owner_runtime_test": "crates/rustok-forum/tests/reply_range_move_sqlite.rs",
+  "documentation": "crates/rustok-forum/docs/forum-21t-reply-range-move-graphql-transport.md",
+  "owner_contract": "crates/rustok-forum/contracts/forum-reply-range-move-owner.json",
+  "owner_documentation": "crates/rustok-forum/docs/forum-21s-reply-range-move-owner.md",
+  "verifier": "scripts/verify/verify-forum-reply-range-move-graphql-transport.mjs",
+  "maintainer_commands": [
+    "node scripts/verify/verify-forum-reply-range-move-owner.mjs",
+    "node scripts/verify/verify-forum-reply-range-move-graphql-transport.mjs",
+    "cargo test -p rustok-forum graphql::topic_reply_range_move_mutation::tests -- --nocapture",
+    "cargo test -p rustok-forum --test reply_range_move_graphql_contract -- --nocapture",
+    "cargo test -p rustok-forum --test reply_range_move_sqlite -- --nocapture",
+    "cargo check -p rustok-forum --all-targets"
+  ],
+  "non_claims": [
+    "no verifier test formatter Cargo SQLite PostgreSQL workflow or CI execution is claimed",
+    "no REST native admin storefront or CLI reply-range transport is added",
+    "no reply-range admin UI is added",
+    "no owner transaction receipt or event schema is changed",
+    "FORUM-21 remains planned"
+  ]
+}

--- a/crates/rustok-forum/docs/README.md
+++ b/crates/rustok-forum/docs/README.md
@@ -40,7 +40,8 @@ notifications module, and cross-module release gates.
 - FORUM-21P adds the transport-neutral selected-reply split owner with immutable receipt/event, parent-closed movement, exact access-policy cloning and counter reconciliation;
 - FORUM-21Q adds the transport-neutral reply-branch fork owner with deterministic copied identities, complete bounded revision/relation provenance, source immutability and explicit non-copy policy; public manager transport remains follow-up scope;
 - FORUM-21R exposes `splitForumTopicReplies` as a routed-tenant, `forum_topics:manage` GraphQL adapter over the unchanged split owner and immutable receipt; admin composition remains follow-up scope;
-- FORUM-21S adds the transport-neutral bounded reply-range move owner with deterministic append positions, explicit asymmetric parent policy, unchanged reply-owned references and checked ACL/solution/counter reconciliation; public manager transport remains follow-up scope.
+- FORUM-21S adds the transport-neutral bounded reply-range move owner with deterministic append positions, explicit asymmetric parent policy, unchanged reply-owned references and checked ACL/solution/counter reconciliation; public manager transport remains follow-up scope;
+- FORUM-21T exposes `moveForumTopicReplyRange` as a routed-tenant, `forum_topics:manage` GraphQL adapter over the unchanged reply-range owner and immutable receipt; admin composition remains follow-up scope.
 
 ## Verification
 
@@ -64,6 +65,7 @@ notifications module, and cross-module release gates.
 - [FORUM-21Q reply-branch fork owner](./forum-21q-topic-fork-owner.md)
 - [FORUM-21R topic split GraphQL transport](./forum-21r-topic-split-graphql-transport.md)
 - [FORUM-21S bounded reply-range move owner](./forum-21s-reply-range-move-owner.md)
+- [FORUM-21T reply-range move GraphQL transport](./forum-21t-reply-range-move-graphql-transport.md)
 - [FORUM-21I/J canonical resolution and HTTP redirect](./forum-21i-topic-canonical-resolution.md)
 - [FORUM-21K topic merge GraphQL transport](./forum-21k-topic-merge-graphql-transport.md)
 - [Admin UI package](../admin/README.md)

--- a/crates/rustok-forum/docs/forum-21t-reply-range-move-graphql-transport.md
+++ b/crates/rustok-forum/docs/forum-21t-reply-range-move-graphql-transport.md
@@ -1,0 +1,84 @@
+# FORUM-21T reply-range move GraphQL transport
+
+## Status
+
+`source_ready_maintainer_execution_pending`
+
+FORUM-21T exposes the FORUM-21S bounded reply-range move owner through one additive manager-only GraphQL command. The resolver is a thin transport adapter: it derives trusted tenant and actor state from schema context, checks module admission and `forum_topics:manage`, maps the wire input to `ForumReplyRangeMoveService::move_reply_range`, and returns the immutable owner receipt without reading operation or per-reply audit tables.
+
+Machine contract:
+
+```text
+crates/rustok-forum/contracts/forum-reply-range-move-graphql-transport.json
+```
+
+## Command
+
+The GraphQL field is:
+
+```graphql
+moveForumTopicReplyRange(
+  tenantId: UUID
+  sourceTopicId: UUID!
+  input: MoveForumTopicReplyRangeGraphqlInput!
+): GqlForumReplyRangeMove!
+```
+
+`tenantId` is assertion-only. When supplied it must equal the routed `TenantContext`; omission uses the routed tenant. A mismatched assertion fails with `PERMISSION_DENIED` before owner execution.
+
+The input carries the complete owner command shape except the source topic identity, which remains an explicit field argument:
+
+- `operationId`;
+- `targetTopicId`;
+- inclusive `startPosition` and `endPosition`;
+- bounded `reason`.
+
+The owner remains authoritative for endpoint occupancy, the 500-reply bound, source non-emptiness, parent-edge policy, deterministic target positions, exact effective access equality, solution conflict handling, counters, category contribution, immutable audit and replay conflict detection.
+
+## Authorization and composition
+
+The resolver requires the `forum` module to be enabled and an authenticated `AuthContext` with `forum_topics:manage`. It builds `SecurityContext` from the authenticated user ID and exact permission snapshot, then delegates through explicit `DatabaseConnection` and `TransactionalEventBus` schema data.
+
+The resolver does not:
+
+- resolve canonical merged-topic aliases for a mutation;
+- query `forum_reply_range_move_operations` or per-reply audit rows;
+- update replies or topic/category counters directly;
+- duplicate parent, ACL, solution, idempotency or transaction policy;
+- hydrate a localized topic after the command.
+
+Domain errors continue through `ForumGraphqlErrorExtension`, including exact replay conflicts, solution conflicts and owner validation failures.
+
+## Receipt
+
+`GqlForumReplyRangeMove` exposes the immutable owner receipt:
+
+- operation and event IDs;
+- source/target topic and category IDs;
+- actor and reason;
+- source and target position ranges;
+- moved total and published reply counts;
+- resulting source and target published counters;
+- moved and resulting solution reply IDs;
+- move timestamp.
+
+An exact replay returns the same owner result. The transport does not create a second idempotency record or event.
+
+## Compatibility and remaining scope
+
+FORUM-21T adds one GraphQL field and no migration, REST route, admin UI, storefront UI, owner method, receipt shape or semantic-event change. Existing FORUM-21S direct owner callers remain unchanged.
+
+Public admin composition, REST/native transports and retained runtime evidence remain open. The canonical `FORUM-21` entry remains `planned`.
+
+## Maintainer verification
+
+```bash
+node scripts/verify/verify-forum-reply-range-move-owner.mjs
+node scripts/verify/verify-forum-reply-range-move-graphql-transport.mjs
+cargo test -p rustok-forum graphql::topic_reply_range_move_mutation::tests -- --nocapture
+cargo test -p rustok-forum --test reply_range_move_graphql_contract -- --nocapture
+cargo test -p rustok-forum --test reply_range_move_sqlite -- --nocapture
+cargo check -p rustok-forum --all-targets
+```
+
+No command above was run by the implementation agent, per maintainer request.

--- a/crates/rustok-forum/src/graphql/mod.rs
+++ b/crates/rustok-forum/src/graphql/mod.rs
@@ -16,6 +16,7 @@ mod storefront_audience_topic;
 mod storefront_audience_topics;
 mod storefront_read_state;
 mod topic_merge_mutation;
+mod topic_reply_range_move_mutation;
 mod topic_split_mutation;
 mod types;
 
@@ -47,6 +48,9 @@ pub use topic_merge_mutation::{
     GqlForumTopicMerge, GqlForumTopicMergeSolutionResolution, MergeForumTopicGraphqlInput,
     ResolveForumTopicMergeSolutionGraphqlInput,
 };
+pub use topic_reply_range_move_mutation::{
+    GqlForumReplyRangeMove, MoveForumTopicReplyRangeGraphqlInput,
+};
 pub use topic_split_mutation::{GqlForumTopicSplit, SplitForumTopicRepliesGraphqlInput};
 pub use types::*;
 
@@ -73,5 +77,6 @@ pub struct ForumMutation(
     read_state::ForumReadStateMutation,
     storefront_read_state::ForumStorefrontReadStateMutation,
     topic_merge_mutation::ForumTopicMergeMutation,
+    topic_reply_range_move_mutation::ForumTopicReplyRangeMoveMutation,
     topic_split_mutation::ForumTopicSplitMutation,
 );

--- a/crates/rustok-forum/src/graphql/topic_reply_range_move_mutation.rs
+++ b/crates/rustok-forum/src/graphql/topic_reply_range_move_mutation.rs
@@ -1,0 +1,239 @@
+use async_graphql::{Context, FieldError, InputObject, Object, Result, SimpleObject};
+use rustok_api::{
+    AuthContext, Permission, TenantContext,
+    graphql::{GraphQLError, require_module_enabled},
+    has_any_effective_permission,
+};
+use rustok_outbox::TransactionalEventBus;
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use crate::{ForumReplyRangeMoveResult, ForumReplyRangeMoveService, MoveForumReplyRangeInput};
+
+const MODULE_SLUG: &str = "forum";
+
+#[derive(Default)]
+pub(crate) struct ForumTopicReplyRangeMoveMutation;
+
+#[Object]
+impl ForumTopicReplyRangeMoveMutation {
+    async fn move_forum_topic_reply_range(
+        &self,
+        ctx: &Context<'_>,
+        tenant_id: Option<Uuid>,
+        source_topic_id: Uuid,
+        input: MoveForumTopicReplyRangeGraphqlInput,
+    ) -> Result<GqlForumReplyRangeMove> {
+        require_module_enabled(ctx, MODULE_SLUG).await?;
+        let db = ctx.data::<DatabaseConnection>()?;
+        let event_bus = ctx.data::<TransactionalEventBus>()?;
+        let auth = ctx
+            .data::<AuthContext>()
+            .map_err(|_| <FieldError as GraphQLError>::unauthenticated())?
+            .clone();
+        let tenant = ctx.data::<TenantContext>()?;
+
+        execute_move_forum_topic_reply_range(
+            db,
+            event_bus,
+            tenant,
+            &auth,
+            tenant_id,
+            source_topic_id,
+            input,
+        )
+        .await
+    }
+}
+
+async fn execute_move_forum_topic_reply_range(
+    db: &DatabaseConnection,
+    event_bus: &TransactionalEventBus,
+    tenant: &TenantContext,
+    auth: &AuthContext,
+    requested_tenant_id: Option<Uuid>,
+    source_topic_id: Uuid,
+    input: MoveForumTopicReplyRangeGraphqlInput,
+) -> Result<GqlForumReplyRangeMove> {
+    require_topic_manage_permission(auth)?;
+    let tenant_id = resolve_tenant_scope(tenant, requested_tenant_id)?;
+
+    let result = ForumReplyRangeMoveService::new(db.clone(), event_bus.clone())
+        .move_reply_range(
+            tenant_id,
+            source_topic_id,
+            rustok_core::SecurityContext::from_permission_snapshot(
+                Some(auth.user_id),
+                &auth.permissions,
+            ),
+            MoveForumReplyRangeInput {
+                operation_id: input.operation_id,
+                target_topic_id: input.target_topic_id,
+                start_position: input.start_position,
+                end_position: input.end_position,
+                reason: input.reason,
+            },
+        )
+        .await?;
+
+    Ok(result.into())
+}
+
+fn require_topic_manage_permission(auth: &AuthContext) -> Result<()> {
+    if !has_any_effective_permission(&auth.permissions, &[Permission::FORUM_TOPICS_MANAGE]) {
+        return Err(<FieldError as GraphQLError>::permission_denied(
+            "Permission denied: forum_topics:manage required",
+        ));
+    }
+    Ok(())
+}
+
+fn resolve_tenant_scope(tenant: &TenantContext, requested_tenant_id: Option<Uuid>) -> Result<Uuid> {
+    match requested_tenant_id {
+        Some(requested_tenant_id) if requested_tenant_id != tenant.id => {
+            Err(<FieldError as GraphQLError>::permission_denied(
+                "Permission denied: tenant scope mismatch",
+            ))
+        }
+        Some(requested_tenant_id) => Ok(requested_tenant_id),
+        None => Ok(tenant.id),
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, InputObject)]
+pub struct MoveForumTopicReplyRangeGraphqlInput {
+    pub operation_id: Uuid,
+    pub target_topic_id: Uuid,
+    pub start_position: i64,
+    pub end_position: i64,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, SimpleObject)]
+pub struct GqlForumReplyRangeMove {
+    pub operation_id: Uuid,
+    pub event_id: Uuid,
+    pub source_topic_id: Uuid,
+    pub target_topic_id: Uuid,
+    pub source_category_id: Uuid,
+    pub target_category_id: Uuid,
+    pub actor_id: Uuid,
+    pub reason: String,
+    pub source_start_position: i64,
+    pub source_end_position: i64,
+    pub target_start_position: i64,
+    pub target_end_position: i64,
+    pub moved_reply_count: i32,
+    pub moved_published_reply_count: i32,
+    pub source_resulting_published_reply_count: i32,
+    pub target_resulting_published_reply_count: i32,
+    pub moved_solution_reply_id: Option<Uuid>,
+    pub source_resulting_solution_reply_id: Option<Uuid>,
+    pub target_resulting_solution_reply_id: Option<Uuid>,
+    pub moved_at: String,
+}
+
+impl From<ForumReplyRangeMoveResult> for GqlForumReplyRangeMove {
+    fn from(value: ForumReplyRangeMoveResult) -> Self {
+        Self {
+            operation_id: value.operation_id,
+            event_id: value.event_id,
+            source_topic_id: value.source_topic_id,
+            target_topic_id: value.target_topic_id,
+            source_category_id: value.source_category_id,
+            target_category_id: value.target_category_id,
+            actor_id: value.actor_id,
+            reason: value.reason,
+            source_start_position: value.source_start_position,
+            source_end_position: value.source_end_position,
+            target_start_position: value.target_start_position,
+            target_end_position: value.target_end_position,
+            moved_reply_count: value.moved_reply_count,
+            moved_published_reply_count: value.moved_published_reply_count,
+            source_resulting_published_reply_count: value
+                .source_resulting_published_reply_count,
+            target_resulting_published_reply_count: value
+                .target_resulting_published_reply_count,
+            moved_solution_reply_id: value.moved_solution_reply_id,
+            source_resulting_solution_reply_id: value.source_resulting_solution_reply_id,
+            target_resulting_solution_reply_id: value.target_resulting_solution_reply_id,
+            moved_at: value.moved_at.to_rfc3339(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rustok_api::{AuthContext, Permission, TenantContext};
+    use uuid::Uuid;
+
+    use super::{require_topic_manage_permission, resolve_tenant_scope};
+
+    fn auth_context(permissions: Vec<Permission>) -> AuthContext {
+        AuthContext {
+            user_id: Uuid::new_v4(),
+            session_id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            permissions,
+            client_id: None,
+            scopes: Vec::new(),
+            grant_type: "direct".to_string(),
+        }
+    }
+
+    fn tenant_context(tenant_id: Uuid) -> TenantContext {
+        TenantContext {
+            id: tenant_id,
+            name: "Reply range GraphQL tenant".to_string(),
+            slug: "reply-range-graphql".to_string(),
+            domain: None,
+            settings: serde_json::json!({}),
+            default_locale: "en".to_string(),
+            is_active: true,
+        }
+    }
+
+    fn error_code(error: &async_graphql::Error) -> Option<String> {
+        error
+            .extensions
+            .as_ref()
+            .and_then(|extensions| extensions.get("code"))
+            .cloned()
+            .and_then(|value| value.into_json().ok())
+            .and_then(|value| value.as_str().map(ToOwned::to_owned))
+    }
+
+    #[test]
+    fn reply_range_transport_requires_topic_manage_permission() {
+        let denied = require_topic_manage_permission(&auth_context(vec![
+            Permission::FORUM_TOPICS_READ,
+        ]))
+        .expect_err("read-only actor must not move reply ranges");
+        assert_eq!(error_code(&denied).as_deref(), Some("PERMISSION_DENIED"));
+
+        require_topic_manage_permission(&auth_context(vec![
+            Permission::FORUM_TOPICS_MANAGE,
+        ]))
+        .expect("manager permission must be accepted");
+    }
+
+    #[test]
+    fn reply_range_transport_rejects_tenant_override_mismatch() {
+        let tenant_id = Uuid::new_v4();
+        let tenant = tenant_context(tenant_id);
+
+        assert_eq!(
+            resolve_tenant_scope(&tenant, None).expect("routed tenant must resolve"),
+            tenant_id
+        );
+        assert_eq!(
+            resolve_tenant_scope(&tenant, Some(tenant_id))
+                .expect("matching tenant assertion must resolve"),
+            tenant_id
+        );
+
+        let denied = resolve_tenant_scope(&tenant, Some(Uuid::new_v4()))
+            .expect_err("mismatched tenant assertion must fail closed");
+        assert_eq!(error_code(&denied).as_deref(), Some("PERMISSION_DENIED"));
+    }
+}

--- a/crates/rustok-forum/tests/reply_range_move_graphql_contract.rs
+++ b/crates/rustok-forum/tests/reply_range_move_graphql_contract.rs
@@ -1,0 +1,88 @@
+use async_graphql::{EmptySubscription, Schema};
+use rustok_forum::graphql::ForumGraphqlErrorExtension;
+use rustok_forum::{ForumMutation, ForumQuery};
+
+const REPLY_RANGE_MOVE_GRAPHQL: &str =
+    include_str!("../src/graphql/topic_reply_range_move_mutation.rs");
+
+#[test]
+fn graphql_schema_exposes_idempotent_reply_range_move_command() {
+    let schema = Schema::build(
+        ForumQuery::default(),
+        ForumMutation::default(),
+        EmptySubscription,
+    )
+    .extension(ForumGraphqlErrorExtension)
+    .finish();
+    let sdl = schema.sdl();
+
+    for marker in [
+        "moveForumTopicReplyRange",
+        "MoveForumTopicReplyRangeGraphqlInput",
+        "GqlForumReplyRangeMove",
+        "operationId",
+        "sourceTopicId",
+        "targetTopicId",
+        "startPosition",
+        "endPosition",
+        "eventId",
+        "sourceCategoryId",
+        "targetCategoryId",
+        "actorId",
+        "sourceStartPosition",
+        "sourceEndPosition",
+        "targetStartPosition",
+        "targetEndPosition",
+        "movedReplyCount",
+        "movedPublishedReplyCount",
+        "sourceResultingPublishedReplyCount",
+        "targetResultingPublishedReplyCount",
+        "movedSolutionReplyId",
+        "sourceResultingSolutionReplyId",
+        "targetResultingSolutionReplyId",
+        "movedAt",
+    ] {
+        assert!(
+            sdl.contains(marker),
+            "missing GraphQL reply-range marker {marker}"
+        );
+    }
+}
+
+#[test]
+fn graphql_reply_range_adapter_uses_routed_tenant_manage_scope_and_owner_service() {
+    for marker in [
+        "require_module_enabled(ctx, MODULE_SLUG).await?",
+        "Permission::FORUM_TOPICS_MANAGE",
+        "Permission denied: forum_topics:manage required",
+        "Permission denied: tenant scope mismatch",
+        "ForumReplyRangeMoveService::new(db.clone(), event_bus.clone())",
+        ".move_reply_range(",
+        "SecurityContext::from_permission_snapshot",
+        "operation_id: input.operation_id",
+        "target_topic_id: input.target_topic_id",
+        "start_position: input.start_position",
+        "end_position: input.end_position",
+        "reason: input.reason",
+    ] {
+        assert!(
+            REPLY_RANGE_MOVE_GRAPHQL.contains(marker),
+            "missing reply-range adapter marker {marker}"
+        );
+    }
+
+    for forbidden in [
+        "ForumTopicMoveService",
+        "ForumTopicMergeService",
+        "ForumTopicSplitService",
+        "resolve_canonical_topic",
+        "forum_reply_range_move_operations",
+        "forum_reply_range_move_items",
+        "ReplyService::new",
+    ] {
+        assert!(
+            !REPLY_RANGE_MOVE_GRAPHQL.contains(forbidden),
+            "reply-range adapter contains forbidden marker {forbidden}"
+        );
+    }
+}

--- a/scripts/verify/verify-forum-reply-range-move-graphql-transport.mjs
+++ b/scripts/verify/verify-forum-reply-range-move-graphql-transport.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const paths = {
+  contract: "crates/rustok-forum/contracts/forum-reply-range-move-graphql-transport.json",
+  ownerContract: "crates/rustok-forum/contracts/forum-reply-range-move-owner.json",
+  docs: "crates/rustok-forum/docs/forum-21t-reply-range-move-graphql-transport.md",
+  ownerDocs: "crates/rustok-forum/docs/forum-21s-reply-range-move-owner.md",
+  graphql: "crates/rustok-forum/src/graphql/topic_reply_range_move_mutation.rs",
+  graphqlMod: "crates/rustok-forum/src/graphql/mod.rs",
+  owner: "crates/rustok-forum/src/services/topic_reply_range_move.rs",
+  schemaTest: "crates/rustok-forum/tests/reply_range_move_graphql_contract.rs",
+  ownerRuntimeTest: "crates/rustok-forum/tests/reply_range_move_sqlite.rs",
+  docsIndex: "crates/rustok-forum/docs/README.md",
+};
+
+const read = (path) => readFileSync(path, "utf8");
+const includesAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(text.includes(marker), `${label} is missing marker: ${marker}`);
+  }
+};
+
+const contract = JSON.parse(read(paths.contract));
+const ownerContract = JSON.parse(read(paths.ownerContract));
+const docs = read(paths.docs);
+const ownerDocs = read(paths.ownerDocs);
+const graphql = read(paths.graphql);
+const graphqlMod = read(paths.graphqlMod);
+const owner = read(paths.owner);
+const schemaTest = read(paths.schemaTest);
+const ownerRuntimeTest = read(paths.ownerRuntimeTest);
+const docsIndex = read(paths.docsIndex);
+
+assert.equal(contract.contract, "forum_reply_range_move_graphql_transport_v1");
+assert.equal(contract.task, "FORUM-21T");
+assert.equal(contract.parent_task, "FORUM-21");
+assert.equal(contract.extends, "FORUM-21S");
+assert.equal(contract.status, "source_ready_maintainer_execution_pending");
+assert.equal(contract.canonical_plan_status, "planned");
+assert.equal(contract.transport, "graphql");
+assert.equal(contract.owner_service, "ForumReplyRangeMoveService");
+assert.equal(contract.authorization.module_must_be_enabled, "forum");
+assert.equal(contract.authorization.required_permission, "forum_topics:manage");
+assert.equal(contract.authorization.tenant_is_derived_from_routed_TenantContext, true);
+assert.equal(contract.authorization.optional_tenant_argument_must_equal_routed_tenant, true);
+assert.equal(contract.command.field, "moveForumTopicReplyRange");
+assert.equal(contract.command.input_type, "MoveForumTopicReplyRangeGraphqlInput");
+assert.equal(contract.command.result_type, "GqlForumReplyRangeMove");
+assert.equal(contract.command.calls_owner_method, "move_reply_range");
+assert.equal(contract.receipt_result.returns_immutable_owner_receipt, true);
+assert.equal(contract.receipt_result.exact_replay_returns_same_result, true);
+assert.equal(contract.composition.resolver_contains_no_range_move_business_logic, true);
+assert.equal(contract.composition.raw_range_move_receipt_or_item_table_access_in_resolver, false);
+assert.equal(contract.compatibility.owner_command_changed, false);
+assert.equal(contract.compatibility.receipt_schema_changed, false);
+assert.equal(contract.compatibility.semantic_event_schema_changed, false);
+assert.equal(contract.compatibility.graphql_field_is_additive, true);
+assert.equal(ownerContract.contract, "forum_reply_range_move_owner_v1");
+assert.equal(ownerContract.task, "FORUM-21S");
+assert.equal(ownerContract.command, "move_reply_range");
+assert.equal(ownerContract.audit.semantic_event, "forum.topic.reply_range_moved");
+
+includesAll(graphql, [
+  "pub(crate) struct ForumTopicReplyRangeMoveMutation",
+  "async fn move_forum_topic_reply_range(",
+  "require_module_enabled(ctx, MODULE_SLUG).await?;",
+  "Permission::FORUM_TOPICS_MANAGE",
+  "Permission denied: tenant scope mismatch",
+  "SecurityContext::from_permission_snapshot",
+  "ForumReplyRangeMoveService::new(db.clone(), event_bus.clone())",
+  ".move_reply_range(",
+  "pub struct MoveForumTopicReplyRangeGraphqlInput",
+  "pub struct GqlForumReplyRangeMove",
+  "moved_at: value.moved_at.to_rfc3339()",
+], "reply-range GraphQL adapter");
+
+for (const forbidden of [
+  "resolve_canonical_topic",
+  "forum_reply_range_move_operations",
+  "forum_reply_range_move_items",
+  "ForumTopicMoveService",
+  "ForumTopicMergeService",
+  "ForumTopicSplitService",
+  "ReplyService::new",
+]) {
+  assert.ok(!graphql.includes(forbidden), `GraphQL adapter contains forbidden marker: ${forbidden}`);
+}
+
+includesAll(graphqlMod, [
+  "mod topic_reply_range_move_mutation;",
+  "GqlForumReplyRangeMove",
+  "MoveForumTopicReplyRangeGraphqlInput",
+  "topic_reply_range_move_mutation::ForumTopicReplyRangeMoveMutation",
+], "GraphQL root registration");
+
+includesAll(owner, [
+  "pub struct ForumReplyRangeMoveService",
+  "pub async fn move_reply_range(",
+  "Resource::ForumTopics, Action::Manage",
+  "validate_parent_boundary_in_tx",
+  "validate_equal_access_in_tx",
+  "insert_operation_in_tx",
+  'const FORUM_REPLY_RANGE_MOVE_EVENT_TYPE: &str = "forum.topic.reply_range_moved"',
+], "reply-range owner");
+
+includesAll(schemaTest, [
+  "graphql_schema_exposes_idempotent_reply_range_move_command",
+  '"moveForumTopicReplyRange"',
+  '"MoveForumTopicReplyRangeGraphqlInput"',
+  '"GqlForumReplyRangeMove"',
+  '"startPosition"',
+  "graphql_reply_range_adapter_uses_routed_tenant_manage_scope_and_owner_service",
+], "GraphQL schema contract");
+
+includesAll(ownerRuntimeTest, [
+  "reply_range_move_is_atomic_idempotent_and_preserves_identity",
+  "forum_reply_range_move_operations",
+  "forum.topic.reply_range_moved",
+], "owner runtime contract source");
+
+includesAll(docs, [
+  "# FORUM-21T reply-range move GraphQL transport",
+  "`source_ready_maintainer_execution_pending`",
+  "moveForumTopicReplyRange",
+  "forum_topics:manage",
+  "ForumReplyRangeMoveService::move_reply_range",
+  "immutable owner receipt",
+  "FORUM-21` entry remains `planned`",
+  "No command above was run by the implementation agent",
+], "FORUM-21T handoff");
+
+includesAll(ownerDocs, [
+  "# FORUM-21S bounded reply-range move owner",
+  "forum.topic.reply_range_moved",
+], "FORUM-21S owner handoff");
+
+includesAll(docsIndex, [
+  "FORUM-21T reply-range move GraphQL transport",
+  "moveForumTopicReplyRange",
+], "Forum docs index");
+
+console.log(
+  "FORUM-21T reply-range GraphQL transport source is ready; maintainer execution and admin composition remain pending.",
+);


### PR DESCRIPTION
## Summary

Continue the canonical FORUM-21 workflow with source-ready `FORUM-21T`.

- expose additive manager-only `moveForumTopicReplyRange` GraphQL transport;
- derive tenant and actor only from routed authenticated schema context;
- reject tenant assertion mismatch and require `forum_topics:manage`;
- delegate the complete command to `ForumReplyRangeMoveService::move_reply_range`;
- return the immutable FORUM-21S owner receipt without resolver access to operation or item audit tables;
- register the adapter in the merged Forum mutation root;
- add SDL/source contracts, machine contract, maintainer handoff and a focused static verifier;
- update the Forum documentation index to record FORUM-21S and FORUM-21T sequencing.

## Recheck

The merged FORUM-21 owner and transport chain was reviewed before selecting this slice. Topic move/merge, selected-reply split, reply-branch fork and bounded reply-range movement are present. The reply-range owner remained transport-neutral, making a thin manager GraphQL adapter the next bounded gap.

## Compatibility

- additive GraphQL field only;
- no owner transaction, migration, receipt or semantic-event schema change;
- no REST route, native server function, admin UI or storefront UI change;
- no canonical alias resolution for mutation commands;
- FORUM-21 remains `planned` pending admin composition and maintainer runtime evidence.

## Validation

Tests, verifiers, formatters, Cargo commands, workflows and CI were not run, per maintainer request.