### PR TITLE
fix(commerce): stabilize checkout compensation state errors

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/checkout-compensation-public-envelope-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/checkout-compensation-public-envelope-safety-source-review.json
@@ -1,0 +1,48 @@
+{
+  "status": "commerce_checkout_compensation_public_envelope_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-commerce/src/services/checkout_compensation.rs",
+    "crates/rustok-commerce/docs/checkout-compensation-public-envelope-safety.md",
+    "scripts/verify/verify-commerce-checkout-compensation-public-envelope-safety.mjs",
+    "crates/rustok-commerce/docs/implementation-plan.md"
+  ],
+  "source_contract": {
+    "manual_reconciliation_state_site_count": 7,
+    "conflict_state_site_count": 10,
+    "total_state_envelope_site_count": 17,
+    "dynamic_uuid_in_state_envelopes": false,
+    "dynamic_status_in_state_envelopes": false,
+    "dynamic_lease_owner_in_state_envelopes": false,
+    "stable_branch_specific_messages": true,
+    "manual_reconciliation_variant_preserved": true,
+    "conflict_variant_preserved": true,
+    "compensation_error_codes_preserved": true,
+    "journal_error_code_preserved": true,
+    "journal_message_persistence_preserved": true,
+    "claim_behavior_preserved": true,
+    "stage_gate_preserved": true,
+    "payment_provider_safety_gate_preserved": true,
+    "payment_cancellation_behavior_preserved": true,
+    "order_cancellation_behavior_preserved": true,
+    "inventory_release_behavior_preserved": true,
+    "cart_release_behavior_preserved": true,
+    "identity_validation_preserved": true,
+    "transparent_owner_error_envelopes_closed": false,
+    "boundary_error_envelope_closed": false,
+    "compensation_and_journal_envelope_closed": false,
+    "broad_ecommerce_cleanup_closed": false,
+    "runtime_evidence_claimed": false
+  },
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed."
+}

--- a/crates/rustok-commerce/docs/checkout-compensation-public-envelope-safety.md
+++ b/crates/rustok-commerce/docs/checkout-compensation-public-envelope-safety.md
@@ -1,0 +1,68 @@
+# Checkout compensation public state-envelope safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens the legacy `CheckoutCompensationService` state-derived
+`CheckoutCompensationError::ManualReconciliation` and
+`CheckoutCompensationError::Conflict` envelopes.
+
+The covered branches include claim contention, captured checkout stages, missing
+order identity, unsafe payment-provider operations, payment/order lifecycle
+rejections, inventory release and reservation-state mismatches, cart lifecycle
+rejections, typed identity mismatch, and unsupported checkout stages.
+
+## Stable public reasons
+
+The seven manual-reconciliation branches and ten conflict branches now use
+branch-specific static reasons. They no longer interpolate checkout operation,
+order, payment collection, payment-provider operation, inventory reservation,
+or cart UUIDs. They also no longer include runtime status or lease-owner values.
+
+The enum variants and their display prefixes remain unchanged:
+
+- `checkout compensation requires manual reconciliation: ...`;
+- `checkout compensation conflict: ...`.
+
+The existing compensation error-code classification remains unchanged.
+
+## Preserved execution behavior
+
+This work does not change:
+
+- operation claim and already-compensated replay behavior;
+- the captured-stage refund-reconciliation gate;
+- order-identity read/adoption and validation;
+- provider-operation safety classification;
+- payment cancellation eligibility and cancellation call;
+- order cancellation eligibility and cancellation call;
+- inventory release comparison and journal update;
+- cart snapshot/release handling;
+- compensation retry journal code selection, message persistence, or mutation
+  ordering.
+
+For covered variants, the persisted journal message is still derived from
+`compensation.to_string()`, but the state-derived reason is now stable and does
+not contain runtime identity or state values.
+
+## Remaining boundary
+
+This slice does not close transparent `CheckoutOperationError`,
+`CheckoutInventoryReservationError`, `PaymentError`,
+`PaymentOrchestrationError`, or `OrderError` display payloads. It also leaves
+`CheckoutCompensationError::Boundary` and
+`CheckoutCompensationError::CompensationAndJournal` for separate review.
+
+The broader ecommerce correlation-safe mapper and non-`PortError` public-envelope
+task remains open.
+
+## Evidence
+
+- `crates/rustok-commerce/contracts/evidence/checkout-compensation-public-envelope-safety-source-review.json`
+- `scripts/verify/verify-commerce-checkout-compensation-public-envelope-safety.mjs`
+
+## Validation disclosure
+
+No tests, Node verifiers, formatting, Cargo commands, workflows, or CI were run.
+No compile or runtime status is promoted.

--- a/crates/rustok-commerce/src/services/checkout_compensation.rs
+++ b/crates/rustok-commerce/src/services/checkout_compensation.rs
@@ -150,12 +150,9 @@ impl CheckoutCompensationService {
             if current.status == CheckoutOperationStatus::Compensated.as_str() {
                 return Ok(current);
             }
-            return Err(CheckoutCompensationError::Conflict(format!(
-                "checkout operation {} cannot be claimed for compensation; status={}, lease_owner={}",
-                current.id,
-                current.status,
-                current.lease_owner.as_deref().unwrap_or("none")
-            )));
+            return Err(compensation_conflict(
+                "checkout operation cannot be claimed for compensation",
+            ));
         };
 
         let result = self
@@ -200,10 +197,9 @@ impl CheckoutCompensationService {
         if stage_rank(operation.stage.as_str())?
             >= stage_rank(CheckoutOperationStage::PaymentCaptured.as_str())?
         {
-            return Err(CheckoutCompensationError::ManualReconciliation(format!(
-                "checkout operation {} reached `{}`; captured funds must be reconciled through refund policy",
-                operation.id, operation.stage
-            )));
+            return Err(manual_reconciliation(
+                "captured checkout state requires refund reconciliation",
+            ));
         }
 
         self.compensate_payment(tenant_id, operation).await?;
@@ -260,11 +256,7 @@ impl CheckoutCompensationService {
                 Ok(Some(identity.order_id))
             }
             None if operation.order_id.is_none() => Ok(None),
-            None => Err(CheckoutCompensationError::ManualReconciliation(format!(
-                "checkout operation {} records order {} but has no order-owner identity",
-                operation.id,
-                operation.order_id.expect("checked as present")
-            ))),
+            None => Err(manual_reconciliation("checkout order identity is missing")),
         }
     }
 
@@ -284,7 +276,7 @@ impl CheckoutCompensationService {
             .payment_operation_journal
             .list_by_collection(tenant_id, collection_id)
             .await?;
-        if let Some(unsafe_operation) = provider_operations.iter().find(|provider_operation| {
+        if provider_operations.iter().any(|provider_operation| {
             matches!(
                 provider_operation.status.as_str(),
                 PROVIDER_OPERATION_EXECUTING
@@ -292,10 +284,9 @@ impl CheckoutCompensationService {
                     | PROVIDER_OPERATION_RECONCILIATION_REQUIRED
             )
         }) {
-            return Err(CheckoutCompensationError::ManualReconciliation(format!(
-                "payment provider operation {} is `{}` for collection {}",
-                unsafe_operation.id, unsafe_operation.status, collection_id
-            )));
+            return Err(manual_reconciliation(
+                "payment provider operation requires reconciliation",
+            ));
         }
 
         match collection.status.as_str() {
@@ -318,14 +309,14 @@ impl CheckoutCompensationService {
             }
             "cancelled" => {}
             "captured" => {
-                return Err(CheckoutCompensationError::ManualReconciliation(format!(
-                    "payment collection {collection_id} is captured"
-                )));
+                return Err(manual_reconciliation(
+                    "captured payment collection requires reconciliation",
+                ));
             }
-            status => {
-                return Err(CheckoutCompensationError::Conflict(format!(
-                    "payment collection {collection_id} cannot compensate from `{status}`"
-                )));
+            _ => {
+                return Err(compensation_conflict(
+                    "payment collection state does not allow compensation",
+                ));
             }
         }
         Ok(())
@@ -343,10 +334,9 @@ impl CheckoutCompensationService {
             .get_order_with_locale_fallback(tenant_id, order_id, PLATFORM_FALLBACK_LOCALE, None)
             .await?;
         if operation.order_id.is_some() && operation.order_id != Some(order.id) {
-            return Err(CheckoutCompensationError::Conflict(format!(
-                "order {} does not match checkout operation {} checkpoint",
-                order.id, operation.id
-            )));
+            return Err(compensation_conflict(
+                "order checkpoint does not match checkout operation",
+            ));
         }
 
         match order.status.as_str() {
@@ -362,15 +352,14 @@ impl CheckoutCompensationService {
             }
             "cancelled" => {}
             "paid" | "shipped" | "delivered" => {
-                return Err(CheckoutCompensationError::ManualReconciliation(format!(
-                    "order {order_id} is `{}` and cannot be automatically cancelled",
-                    order.status
-                )));
+                return Err(manual_reconciliation(
+                    "order state requires manual cancellation reconciliation",
+                ));
             }
-            status => {
-                return Err(CheckoutCompensationError::Conflict(format!(
-                    "order {order_id} cannot compensate from `{status}`"
-                )));
+            _ => {
+                return Err(compensation_conflict(
+                    "order state does not allow compensation",
+                ));
             }
         }
         Ok(())
@@ -410,26 +399,23 @@ impl CheckoutCompensationService {
                         || released.external_id != reservation.external_id
                         || released.variant_id != reservation.variant_id
                     {
-                        return Err(CheckoutCompensationError::Conflict(format!(
-                            "inventory release response does not match checkout reservation {}",
-                            reservation.reservation_id
-                        )));
+                        return Err(compensation_conflict(
+                            "inventory release result does not match reservation",
+                        ));
                     }
                     self.reservation_journal
                         .mark_released(tenant_id, reservation.reservation_id)
                         .await?;
                 }
                 status if status == CheckoutInventoryReservationStatus::Consumed.as_str() => {
-                    return Err(CheckoutCompensationError::ManualReconciliation(format!(
-                        "inventory reservation {} is already consumed",
-                        reservation.reservation_id
-                    )));
+                    return Err(manual_reconciliation(
+                        "consumed inventory reservation requires reconciliation",
+                    ));
                 }
-                status => {
-                    return Err(CheckoutCompensationError::Conflict(format!(
-                        "inventory reservation {} has unsupported status `{status}`",
-                        reservation.reservation_id
-                    )));
+                _ => {
+                    return Err(compensation_conflict(
+                        "inventory reservation state does not allow compensation",
+                    ));
                 }
             }
         }
@@ -465,24 +451,21 @@ impl CheckoutCompensationService {
                     .await
                     .map_err(|error| boundary_error("release_cart", error))?;
                 if released.status != CartStatus::Active.as_str() {
-                    return Err(CheckoutCompensationError::Conflict(format!(
-                        "cart {} is `{}` after checkout release",
-                        released.id, released.status
-                    )));
+                    return Err(compensation_conflict(
+                        "cart release did not restore the active state",
+                    ));
                 }
             }
             status if status == CartStatus::Active.as_str() => {}
             status if status == CartStatus::Completed.as_str() => {
-                return Err(CheckoutCompensationError::ManualReconciliation(format!(
-                    "cart {} is already completed",
-                    current.id
-                )));
+                return Err(manual_reconciliation(
+                    "completed cart requires reconciliation",
+                ));
             }
-            status => {
-                return Err(CheckoutCompensationError::Conflict(format!(
-                    "cart {} cannot be released from `{status}`",
-                    current.id
-                )));
+            _ => {
+                return Err(compensation_conflict(
+                    "cart state does not allow release",
+                ));
             }
         }
         Ok(())
@@ -499,10 +482,9 @@ fn validate_compensation_identity(
         || identity.source_cart_id.is_some() && identity.source_cart_id != Some(operation.cart_id)
         || operation.order_id.is_some() && operation.order_id != Some(identity.order_id)
     {
-        return Err(CheckoutCompensationError::Conflict(format!(
-            "typed order identity does not match checkout operation {}",
-            operation.id
-        )));
+        return Err(compensation_conflict(
+            "order identity does not match checkout operation",
+        ));
     }
     Ok(())
 }
@@ -580,6 +562,14 @@ fn order_identity_context(
     }
 }
 
+fn manual_reconciliation(message: &'static str) -> CheckoutCompensationError {
+    CheckoutCompensationError::ManualReconciliation(message.to_string())
+}
+
+fn compensation_conflict(message: &'static str) -> CheckoutCompensationError {
+    CheckoutCompensationError::Conflict(message.to_string())
+}
+
 fn boundary_error(stage: &'static str, error: PortError) -> CheckoutCompensationError {
     CheckoutCompensationError::Boundary {
         stage,
@@ -623,8 +613,8 @@ fn stage_rank(stage: &str) -> CheckoutCompensationResult<u8> {
         "fulfillment_created" => Ok(7),
         "cart_completed" => Ok(8),
         "completed" => Ok(9),
-        other => Err(CheckoutCompensationError::Conflict(format!(
-            "unsupported checkout stage `{other}`"
-        ))),
+        _ => Err(compensation_conflict(
+            "checkout stage does not allow compensation",
+        )),
     }
 }

--- a/scripts/verify/verify-commerce-checkout-compensation-public-envelope-safety.mjs
+++ b/scripts/verify/verify-commerce-checkout-compensation-public-envelope-safety.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+
+const paths = {
+  source: "crates/rustok-commerce/src/services/checkout_compensation.rs",
+  evidence:
+    "crates/rustok-commerce/contracts/evidence/checkout-compensation-public-envelope-safety-source-review.json",
+  doc: "crates/rustok-commerce/docs/checkout-compensation-public-envelope-safety.md",
+  plan: "crates/rustok-commerce/docs/implementation-plan.md",
+};
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const requireCount = (source, value, expected, label) => {
+  const count = source.split(value).length - 1;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+};
+
+function functionBody(source, functionName) {
+  const signature = new RegExp(
+    `(?:pub(?:\\([^)]*\\))?\\s+)?(?:async\\s+)?fn\\s+${functionName}(?:<[^>]*>)?\\s*\\(`,
+  );
+  const match = signature.exec(source);
+  if (!match) {
+    failures.push(`missing function ${functionName}`);
+    return "";
+  }
+  const openBrace = source.indexOf("{", match.index);
+  let depth = 0;
+  for (let index = openBrace; index >= 0 && index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(openBrace, index + 1);
+    }
+  }
+  failures.push(`unterminated function ${functionName}`);
+  return "";
+}
+
+function requireOrder(source, markers, label) {
+  let previous = -1;
+  for (const marker of markers) {
+    const index = source.indexOf(marker);
+    if (index < 0) {
+      failures.push(`${label}: missing ${marker}`);
+      return;
+    }
+    if (index <= previous) {
+      failures.push(`${label}: ${marker} is out of order`);
+      return;
+    }
+    previous = index;
+  }
+}
+
+const source = read(paths.source);
+const evidence = JSON.parse(read(paths.evidence));
+const doc = read(paths.doc);
+const plan = read(paths.plan);
+
+for (const marker of [
+  '#[error("checkout compensation requires manual reconciliation: {0}")]',
+  "ManualReconciliation(String)",
+  '#[error("checkout compensation conflict: {0}")]',
+  "Conflict(String)",
+  "Payment(#[from] PaymentError)",
+  "PaymentOrchestration(#[from] PaymentOrchestrationError)",
+  "Order(#[from] OrderError)",
+  "Boundary {",
+  "CompensationAndJournal {",
+]) requireText(source, marker, `${paths.source}: preserved error shape`);
+
+const manualHelper = functionBody(source, "manual_reconciliation");
+for (const marker of [
+  "message: &'static str",
+  "CheckoutCompensationError::ManualReconciliation(message.to_string())",
+]) requireText(manualHelper, marker, `${paths.source}: manual helper`);
+
+const conflictHelper = functionBody(source, "compensation_conflict");
+for (const marker of [
+  "message: &'static str",
+  "CheckoutCompensationError::Conflict(message.to_string())",
+]) requireText(conflictHelper, marker, `${paths.source}: conflict helper`);
+
+requireCount(source, "manual_reconciliation(", 8, "seven manual sites plus helper");
+requireCount(source, "compensation_conflict(", 11, "ten conflict sites plus helper");
+
+for (const message of [
+  "checkout operation cannot be claimed for compensation",
+  "captured checkout state requires refund reconciliation",
+  "checkout order identity is missing",
+  "payment provider operation requires reconciliation",
+  "captured payment collection requires reconciliation",
+  "payment collection state does not allow compensation",
+  "order checkpoint does not match checkout operation",
+  "order state requires manual cancellation reconciliation",
+  "order state does not allow compensation",
+  "inventory release result does not match reservation",
+  "consumed inventory reservation requires reconciliation",
+  "inventory reservation state does not allow compensation",
+  "cart release did not restore the active state",
+  "completed cart requires reconciliation",
+  "cart state does not allow release",
+  "order identity does not match checkout operation",
+  "checkout stage does not allow compensation",
+]) requireText(source, `"${message}"`, `${paths.source}: stable branch reason`);
+
+for (const forbidden of [
+  "CheckoutCompensationError::ManualReconciliation(format!",
+  "CheckoutCompensationError::Conflict(format!",
+  "cannot be claimed for compensation; status=",
+  "captured funds must be reconciled through refund policy",
+  "but has no order-owner identity",
+  "payment provider operation {} is",
+  "payment collection {collection_id}",
+  "order {order_id}",
+  "checkout reservation {}",
+  "inventory reservation {}",
+  "cart {}",
+  "typed order identity does not match checkout operation {}",
+  "unsupported checkout stage `{other}`",
+  "lease_owner={}",
+]) forbidText(source, forbidden, `${paths.source}: dynamic state envelope`);
+
+const compensate = functionBody(source, "compensate");
+for (const marker of [
+  ".claim_compensation(",
+  "if current.status == CheckoutOperationStatus::Compensated.as_str()",
+  "return Ok(current);",
+  "compensation_error_code(&compensation)",
+  "let message = compensation.to_string();",
+  ".mark_compensation_retryable(",
+  "Ok(_) => Err(compensation)",
+  "CheckoutCompensationError::CompensationAndJournal",
+]) requireText(compensate, marker, `${paths.source}: preserved compensation journal flow`);
+requireOrder(
+  compensate,
+  [
+    "compensation_error_code(&compensation)",
+    "let message = compensation.to_string();",
+    ".mark_compensation_retryable(",
+  ],
+  `${paths.source}: journal code-message-mutation order`,
+);
+
+const payment = functionBody(source, "compensate_payment");
+for (const marker of [
+  ".list_by_collection(tenant_id, collection_id)",
+  "provider_operations.iter().any(|provider_operation|",
+  "PROVIDER_OPERATION_EXECUTING",
+  "PROVIDER_OPERATION_SUCCEEDED",
+  "PROVIDER_OPERATION_RECONCILIATION_REQUIRED",
+  ".cancel_collection(",
+  'reason: Some("checkout_compensation".to_string())',
+]) requireText(payment, marker, `${paths.source}: preserved payment behavior`);
+
+const order = functionBody(source, "compensate_order");
+for (const marker of [
+  ".get_order_with_locale_fallback(",
+  "operation.order_id.is_some() && operation.order_id != Some(order.id)",
+  '"pending" | "confirmed"',
+  ".cancel_order(",
+  'Some("checkout_compensation".to_string())',
+  '"paid" | "shipped" | "delivered"',
+]) requireText(order, marker, `${paths.source}: preserved order behavior`);
+
+const inventory = functionBody(source, "release_remaining_reservations");
+for (const marker of [
+  ".list_by_operation(tenant_id, operation.id)",
+  "CheckoutInventoryReservationStatus::Reserved.as_str()",
+  ".release_inventory_by_identity(",
+  "released.reservation_id != reservation.reservation_id",
+  "released.external_id != reservation.external_id",
+  "released.variant_id != reservation.variant_id",
+  ".mark_released(tenant_id, reservation.reservation_id)",
+  "CheckoutInventoryReservationStatus::Consumed.as_str()",
+]) requireText(inventory, marker, `${paths.source}: preserved inventory behavior`);
+
+const cart = functionBody(source, "release_cart");
+for (const marker of [
+  ".read_cart_checkout_snapshot(",
+  "CartStatus::CheckingOut.as_str()",
+  ".release_cart_checkout(",
+  "released.status != CartStatus::Active.as_str()",
+  "CartStatus::Active.as_str()",
+  "CartStatus::Completed.as_str()",
+]) requireText(cart, marker, `${paths.source}: preserved cart behavior`);
+
+const boundary = functionBody(source, "boundary_error");
+for (const marker of [
+  "CheckoutCompensationError::Boundary {",
+  "stage,",
+  "code: error.code",
+  "message: error.message",
+  "retryable: error.retryable",
+]) requireText(boundary, marker, `${paths.source}: unchanged boundary envelope`);
+
+const codes = functionBody(source, "compensation_error_code");
+for (const marker of [
+  '"checkout.compensation_manual_reconciliation"',
+  '"checkout.compensation_boundary_failed"',
+  '"checkout.compensation_payment_failed"',
+  '"checkout.compensation_order_failed"',
+  '"checkout.compensation_inventory_failed"',
+  '"checkout.compensation_failed"',
+]) requireText(codes, marker, `${paths.source}: preserved compensation code`);
+
+if (
+  evidence.status !==
+  "commerce_checkout_compensation_public_envelope_safety_source_reviewed_unvalidated"
+) failures.push(`${paths.evidence}: unexpected status ${evidence.status}`);
+for (const [key, expected] of Object.entries({
+  manual_reconciliation_state_site_count: 7,
+  conflict_state_site_count: 10,
+  total_state_envelope_site_count: 17,
+  dynamic_uuid_in_state_envelopes: false,
+  dynamic_status_in_state_envelopes: false,
+  dynamic_lease_owner_in_state_envelopes: false,
+  stable_branch_specific_messages: true,
+  compensation_error_codes_preserved: true,
+  journal_message_persistence_preserved: true,
+  transparent_owner_error_envelopes_closed: false,
+  boundary_error_envelope_closed: false,
+  compensation_and_journal_envelope_closed: false,
+  broad_ecommerce_cleanup_closed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "compile_proven",
+  "runtime_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+
+requireText(doc, "Status: **source-ready / unvalidated**", `${paths.doc}: status`);
+requireText(doc, "seven manual-reconciliation branches and ten conflict branches", `${paths.doc}: site count`);
+requireText(doc, "They also no longer include runtime status or lease-owner values.", `${paths.doc}: payload policy`);
+requireText(doc, "leaves `CheckoutCompensationError::Boundary`", `${paths.doc}: remaining boundary`);
+requireText(
+  plan,
+  "Finish correlation-safe mapper cleanup",
+  `${paths.plan}: broad ecommerce cleanup remains open`,
+);
+
+if (failures.length > 0) {
+  console.error("Commerce checkout compensation public-envelope verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "Commerce checkout compensation state-derived manual-reconciliation and conflict envelopes are stable and payload-free; execution validation remains open",
+);


### PR DESCRIPTION
## Summary

Continue the ecommerce correlation-safe mapper and non-`PortError` public-envelope cleanup in the legacy checkout compensation service.

- replace 7 state-derived `ManualReconciliation` payloads with stable branch-specific reasons
- replace 10 state-derived `Conflict` payloads with stable branch-specific reasons
- remove checkout operation, order, payment collection, provider operation, inventory reservation, and cart UUID interpolation from those envelopes
- remove runtime status and lease-owner interpolation from those envelopes
- retain the existing enum variants, display prefixes, compensation error-code mapping, retry journal message persistence, and mutation ordering
- add focused source-only evidence, documentation, and a fail-closed static guard
- leave transparent owner errors, `Boundary`, `CompensationAndJournal`, and the broader ecommerce cleanup open

## Preserved behavior

- compensation claim and already-compensated replay behavior
- captured-stage refund reconciliation gate
- order identity read/adoption and validation
- provider operation safety gate
- payment and order cancellation eligibility and calls
- inventory release comparison and journal update
- cart snapshot/release handling
- compensation retry code selection and same error return

## Validation

Tests, Node verifiers, formatting, Cargo checks, workflows, and CI were not run per maintainer request. Evidence remains source-reviewed/unvalidated.