### PR TITLE
feat(forum): expose topic fork GraphQL command

### DIFF
--- a/crates/rustok-forum/contracts/forum-topic-fork-graphql-transport.json
+++ b/crates/rustok-forum/contracts/forum-topic-fork-graphql-transport.json
@@ -1,0 +1,99 @@
+{
+  "contract": "forum_topic_fork_graphql_transport_v1",
+  "task": "FORUM-21U",
+  "parent_task": "FORUM-21",
+  "extends": "FORUM-21Q",
+  "status": "source_ready_maintainer_execution_pending",
+  "canonical_plan_status": "planned",
+  "transport": "graphql",
+  "owner_service": "ForumTopicForkService",
+  "authorization": {
+    "module_must_be_enabled": "forum",
+    "required_permission": "forum_topics:manage",
+    "authenticated_human_actor_required_by_owner": true,
+    "tenant_is_derived_from_routed_TenantContext": true,
+    "optional_tenant_argument_must_equal_routed_tenant": true,
+    "tenant_mismatch_code": "PERMISSION_DENIED"
+  },
+  "command": {
+    "field": "forkForumTopicReplyBranch",
+    "input_type": "ForkForumTopicReplyBranchGraphqlInput",
+    "source_topic_id_is_separate_argument": true,
+    "input_fields": [
+      "operation_id",
+      "target_topic_id",
+      "root_reply_id",
+      "locale",
+      "title",
+      "slug",
+      "reason"
+    ],
+    "result_type": "GqlForumTopicFork",
+    "calls_owner_method": "fork_reply_branch"
+  },
+  "receipt_result": {
+    "type": "GqlForumTopicFork",
+    "fields": [
+      "operation_id",
+      "event_id",
+      "source_topic_id",
+      "target_topic_id",
+      "root_reply_id",
+      "category_id",
+      "actor_id",
+      "reason",
+      "copied_reply_count",
+      "copied_published_reply_count",
+      "copied_body_count",
+      "copied_reply_revision_count",
+      "copied_relation_revision_count",
+      "copied_mention_count",
+      "copied_quote_count",
+      "forked_at"
+    ],
+    "returns_immutable_owner_receipt": true,
+    "exact_replay_returns_same_result": true,
+    "event_id_equals_operation_id": true
+  },
+  "composition": {
+    "resolver_contains_no_fork_business_logic": true,
+    "database_and_transactional_event_bus_are_explicit_schema_data": true,
+    "security_context_uses_authenticated_permission_snapshot": true,
+    "domain_errors_preserve_ForumGraphqlErrorExtension_mapping": true,
+    "raw_fork_receipt_or_mapping_table_access_in_resolver": false,
+    "canonical_topic_alias_resolution_for_mutation": false,
+    "transport_local_copy_policy": false
+  },
+  "compatibility": {
+    "owner_command_changed": false,
+    "receipt_schema_changed": false,
+    "semantic_event_schema_changed": false,
+    "rest_contract_changed": false,
+    "admin_ui_added": false,
+    "storefront_ui_added": false,
+    "graphql_field_is_additive": true
+  },
+  "source_contract_test": "crates/rustok-forum/tests/topic_fork_graphql_contract.rs",
+  "authorization_unit_test": "crates/rustok-forum/src/graphql/topic_fork_mutation.rs",
+  "owner_runtime_test": "crates/rustok-forum/tests/topic_fork_sqlite.rs",
+  "documentation": "crates/rustok-forum/docs/forum-21u-topic-fork-graphql-transport.md",
+  "owner_contract": "crates/rustok-forum/contracts/forum-topic-fork-owner.json",
+  "owner_documentation": "crates/rustok-forum/docs/forum-21q-topic-fork-owner.md",
+  "verifier": "scripts/verify/verify-forum-topic-fork-graphql-transport.mjs",
+  "maintainer_commands": [
+    "node scripts/verify/verify-forum-topic-fork-owner.mjs",
+    "node scripts/verify/verify-forum-topic-fork-graphql-transport.mjs",
+    "cargo test -p rustok-forum graphql::topic_fork_mutation::tests -- --nocapture",
+    "cargo test -p rustok-forum --test topic_fork_graphql_contract -- --nocapture",
+    "cargo test -p rustok-forum --test topic_fork_sqlite -- --nocapture",
+    "cargo check -p rustok-forum --all-targets"
+  ],
+  "non_claims": [
+    "no verifier test formatter Cargo SQLite PostgreSQL workflow or CI execution is claimed",
+    "no REST native admin storefront or CLI fork command transport is added",
+    "no fork admin UI is added",
+    "no cross-category fork is added",
+    "no transport-local branch copy or relation policy is added",
+    "FORUM-21 remains planned"
+  ]
+}

--- a/crates/rustok-forum/docs/README.md
+++ b/crates/rustok-forum/docs/README.md
@@ -38,10 +38,11 @@ notifications module, and cross-module release gates.
 - FORUM-21N composes those commands in Leptos and Next-admin without changing the owner, receipt or event schema;
 - FORUM-21O selects direct authenticated native owner composition for Leptos SSR/hydrate while retaining GraphQL for CSR/headless with no fallback;
 - FORUM-21P adds the transport-neutral selected-reply split owner with immutable receipt/event, parent-closed movement, exact access-policy cloning and counter reconciliation;
-- FORUM-21Q adds the transport-neutral reply-branch fork owner with deterministic copied identities, complete bounded revision/relation provenance, source immutability and explicit non-copy policy; public manager transport remains follow-up scope;
+- FORUM-21Q adds the transport-neutral reply-branch fork owner with deterministic copied identities, complete bounded revision/relation provenance, source immutability and explicit non-copy policy; FORUM-21U provides its manager GraphQL transport;
 - FORUM-21R exposes `splitForumTopicReplies` as a routed-tenant, `forum_topics:manage` GraphQL adapter over the unchanged split owner and immutable receipt; admin composition remains follow-up scope;
-- FORUM-21S adds the transport-neutral bounded reply-range move owner with deterministic append positions, explicit asymmetric parent policy, unchanged reply-owned references and checked ACL/solution/counter reconciliation; public manager transport remains follow-up scope;
-- FORUM-21T exposes `moveForumTopicReplyRange` as a routed-tenant, `forum_topics:manage` GraphQL adapter over the unchanged reply-range owner and immutable receipt; admin composition remains follow-up scope.
+- FORUM-21S adds the transport-neutral bounded reply-range move owner with deterministic append positions, explicit asymmetric parent policy, unchanged reply-owned references and checked ACL/solution/counter reconciliation; FORUM-21T provides its manager GraphQL transport;
+- FORUM-21T exposes `moveForumTopicReplyRange` as a routed-tenant, `forum_topics:manage` GraphQL adapter over the unchanged reply-range owner and immutable receipt; admin composition remains follow-up scope;
+- FORUM-21U exposes `forkForumTopicReplyBranch` as a routed-tenant, `forum_topics:manage` GraphQL adapter over the unchanged fork owner and immutable receipt; admin composition remains follow-up scope.
 
 ## Verification
 
@@ -66,6 +67,7 @@ notifications module, and cross-module release gates.
 - [FORUM-21R topic split GraphQL transport](./forum-21r-topic-split-graphql-transport.md)
 - [FORUM-21S bounded reply-range move owner](./forum-21s-reply-range-move-owner.md)
 - [FORUM-21T reply-range move GraphQL transport](./forum-21t-reply-range-move-graphql-transport.md)
+- [FORUM-21U topic fork GraphQL transport](./forum-21u-topic-fork-graphql-transport.md)
 - [FORUM-21I/J canonical resolution and HTTP redirect](./forum-21i-topic-canonical-resolution.md)
 - [FORUM-21K topic merge GraphQL transport](./forum-21k-topic-merge-graphql-transport.md)
 - [Admin UI package](../admin/README.md)

--- a/crates/rustok-forum/docs/forum-21u-topic-fork-graphql-transport.md
+++ b/crates/rustok-forum/docs/forum-21u-topic-fork-graphql-transport.md
@@ -1,0 +1,89 @@
+# FORUM-21U topic fork GraphQL transport
+
+## Status
+
+`source_ready_maintainer_execution_pending`
+
+FORUM-21U exposes the FORUM-21Q reply-branch fork owner through one additive manager-only GraphQL command. The resolver is a thin transport adapter: it derives trusted tenant and actor state from schema context, checks module admission and `forum_topics:manage`, maps the wire input to `ForumTopicForkService::fork_reply_branch`, and returns the immutable owner receipt without reading fork operation or mapping tables.
+
+Machine contract:
+
+```text
+crates/rustok-forum/contracts/forum-topic-fork-graphql-transport.json
+```
+
+## Command
+
+The GraphQL field is:
+
+```graphql
+forkForumTopicReplyBranch(
+  tenantId: UUID
+  sourceTopicId: UUID!
+  input: ForkForumTopicReplyBranchGraphqlInput!
+): GqlForumTopicFork!
+```
+
+`tenantId` is assertion-only. When supplied it must equal the routed `TenantContext`; omission uses the routed tenant. A mismatched assertion fails with `PERMISSION_DENIED` before owner execution.
+
+The input carries the complete owner command shape except the source topic identity, which remains an explicit field argument:
+
+- `operationId`;
+- `targetTopicId`;
+- `rootReplyId`;
+- normalized `locale`;
+- bounded `title`;
+- optional normalized `slug`;
+- bounded `reason`.
+
+The owner remains authoritative for branch discovery, the 500-reply bound, deterministic copied identities, detached-root and copied-parent policy, source immutability, complete bounded body/revision/relation provenance, quote-target preservation, exact access/tag cloning, deliberate vote/subscription/read-state/solution non-copy policy, counters, immutable audit and replay conflict detection.
+
+## Authorization and composition
+
+The resolver requires the `forum` module to be enabled and an authenticated `AuthContext` with `forum_topics:manage`. It builds `SecurityContext` from the authenticated user ID and exact permission snapshot, then delegates through explicit `DatabaseConnection` and `TransactionalEventBus` schema data.
+
+The resolver does not:
+
+- resolve canonical merged-topic aliases for a mutation;
+- query `forum_topic_fork_operations`, reply mappings or revision mappings;
+- discover descendants or derive copied reply IDs;
+- copy reply bodies, revisions, mentions, quotes, access policy or tags;
+- update counters or source/target rows directly;
+- infer an accepted solution or copy votes, subscriptions or read state;
+- hydrate a localized topic after the command.
+
+Domain errors continue through `ForumGraphqlErrorExtension`, including exact replay conflicts and owner validation failures.
+
+## Receipt
+
+`GqlForumTopicFork` exposes the immutable owner receipt:
+
+- operation and event IDs;
+- source and target topic IDs;
+- selected root reply and category IDs;
+- actor and reason;
+- copied reply and approved-reply counts;
+- copied body, reply-revision and relation-revision counts;
+- copied mention and quote counts;
+- fork timestamp.
+
+An exact replay returns the same owner result. The transport does not create a second idempotency record, mapping set or event.
+
+## Compatibility and remaining scope
+
+FORUM-21U adds one GraphQL field and no migration, REST route, native command, admin UI, storefront UI, owner method, receipt shape or semantic-event change. Existing FORUM-21Q direct owner callers remain unchanged.
+
+Public admin composition, retained runtime/browser evidence and FORUM-24 localized route work remain open. The canonical `FORUM-21` entry remains `planned`.
+
+## Maintainer verification
+
+```bash
+node scripts/verify/verify-forum-topic-fork-owner.mjs
+node scripts/verify/verify-forum-topic-fork-graphql-transport.mjs
+cargo test -p rustok-forum graphql::topic_fork_mutation::tests -- --nocapture
+cargo test -p rustok-forum --test topic_fork_graphql_contract -- --nocapture
+cargo test -p rustok-forum --test topic_fork_sqlite -- --nocapture
+cargo check -p rustok-forum --all-targets
+```
+
+No command above was run by the implementation agent, per maintainer request.

--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -6,7 +6,7 @@ status: active
 owners:
   - rustok-forum
   - rustok-notifications-program
-last_reviewed: 2026-08-04
+last_reviewed: 2026-08-05
 ---
 
 # `rustok-forum` canonical implementation plan
@@ -234,7 +234,7 @@ at the end of this file remain authoritative.
 | `FORUM-18` | `planned` | Atomic votes, reactions, reputation ledger and badges. |
 | `FORUM-19` | `planned` | Reports, moderation queue, restrictions and audit. |
 | `FORUM-20` | `in_progress` | FORUM-20A-AZ provide inherited and richer category/topic visibility, recipient-aware Forum notification authorization, the Notifications inbox/group owner plane, authenticated storefront ports, native and GraphQL read/open/write transport parity, grouped UI and navigation, exact topic/reply create authorization, topic-local reply narrowing, inherited moderation audiences, and existing solution-route transport composition. FORUM-20BA synchronizes the canonical ledger and owner notes after FORUM-20AV-AZ. Remaining read/search/index/SEO/deep-link migration, visibility-scoped bulk read commands, future moderation transport reuse, scheduled reconciliation/redaction, delivery transports and PostgreSQL cross-consumer evidence remain. |
-| `FORUM-21` | `planned` | Move, merge, split and fork topic workflows. |
+| `FORUM-21` | `planned` | FORUM-21A-U provide move, merge, split, fork and reply-range owners plus manager GraphQL transports; admin composition, runtime evidence and FORUM-24 aliases remain. |
 | `FORUM-22` | `planned` | Topic kinds, wiki/announcement/Q&A policies and scheduled lifecycle. |
 | `FORUM-23` | `in_progress` | FORUM-23A through FORUM-23A11 harden public-author Search projections and durable privacy invalidation; FORUM-23B1 through FORUM-23B2F4 add exact Forum category, audience, result-eligibility, trusted-channel, author, tag, solved, locale, date and current-channel filtering; FORUM-23B2G1 adds durable Search ingest ordering; FORUM-23B2G2A/A1 add the Forum owner revision ledger and database hardening; FORUM-23B2G2B1/B2 add the bounded owner source, Search checkpoint and repair protocol; FORUM-23B2G2B3A-C add the caused sealed wire event, atomic dual publisher and default-off persistent one-inbox consumer; FORUM-23B2G2B3D0 freezes executable runtime evidence and FORUM-23B2G2B3D1 reconciles this canonical plan. Arbitrary channel/group filtering remains owner-contract blocked, kind waits on FORUM-22, attachment presence waits on FORUM-14, and maintainer PostgreSQL/Iggy plus LINK-FORUM-03 runtime evidence remain. |
 | `FORUM-24` | `planned` | Localized routes, canonical URLs and aliases. |
@@ -1584,7 +1584,7 @@ Preserve revisions, attachments, mentions and audit. Remap reply positions
 safely, deduplicate subscriptions, revalidate solutions and ACL, update
 category counters and create canonical URL aliases.
 
-### Delivered through `FORUM-21R`
+### Delivered through `FORUM-21U`
 
 - FORUM-21A adds the bounded idempotent topic-move owner with checked category
   counters, immutable operation receipt and unchanged topic identity;
@@ -1624,6 +1624,18 @@ category counters and create canonical URL aliases.
   additive `splitForumTopicReplies` field delegates the complete command to
   `ForumTopicSplitService::split_selected_replies` and returns the immutable
   owner receipt without reading split audit tables or duplicating owner policy;
+- FORUM-21S adds the idempotent bounded reply-range move owner with deterministic
+  append positions, explicit asymmetric parent policy, unchanged reply-owned
+  references, exact topic-local access equality and checked solution/counter
+  reconciliation;
+- FORUM-21T adds the routed-tenant, manager-only GraphQL reply-range transport.
+  The additive `moveForumTopicReplyRange` field delegates the complete command
+  to `ForumReplyRangeMoveService::move_reply_range` and returns the immutable
+  owner receipt without reading move audit tables or duplicating owner policy;
+- FORUM-21U adds the routed-tenant, manager-only GraphQL fork transport. The
+  additive `forkForumTopicReplyBranch` field delegates the complete command to
+  `ForumTopicForkService::fork_reply_branch` and returns the immutable owner
+  receipt without reading fork audit/mapping tables or duplicating copy policy;
 - every ordinary, resolved, same-category and cross-category merge retains the
   exact `forum.topic.merged` schema-version-1 payload so existing post-merge
   reconciliation owners remain compatible.
@@ -1641,9 +1653,11 @@ FORUM-21O changes only the Leptos admin transport selection and host composition
 SSR/hydrate use direct authenticated native owner state, CSR/headless retain
 GraphQL, and no fallback is introduced. FORUM-21P and FORUM-21Q add append-only
 PostgreSQL/SQLite owner receipt and mapping migrations without changing existing
-move or merge receipts and events. FORUM-21R adds one GraphQL field and no
-migration, REST route, admin UI, owner method, receipt shape or semantic-event
-change. Direct owner callers remain source-compatible.
+move or merge receipts and events. FORUM-21S adds append-only PostgreSQL/SQLite
+owner receipt and mapping state without changing earlier commands. FORUM-21R,
+FORUM-21T and FORUM-21U each add one additive GraphQL field and no REST route,
+admin UI, owner method, receipt shape or semantic-event change. Direct owner
+callers remain source-compatible.
 
 Forum move, merge, split and fork commands remain independent from Notifications,
 Search, Page Builder and other optional integrations. Owner state, the Forum
@@ -1660,11 +1674,9 @@ maintainer-executed:
   merge, split and fork owner/migration chain, including cross-category
   concurrency, replay and rollback;
 - mounted-browser and runtime transport evidence for the native/GraphQL merge
-  paths and the new split GraphQL field;
-- public admin composition for split and fork workflows, plus an additive
-  manager transport for the fork owner without transport-local copy policy;
-- bounded reply-range movement with deterministic positions, parent/reference
-  policy and partial-move prevention;
+  paths plus the split, fork and reply-range GraphQL fields;
+- public admin composition for split, fork and reply-range workflows without
+  transport-local movement or copy policy;
 - final canonical localized URL aliases and route tombstones under FORUM-24,
   rather than a parallel FORUM-21 slug authority.
 
@@ -1689,7 +1701,10 @@ node scripts/verify/verify-forum-topic-merge-admin-ui.mjs
 node scripts/verify/verify-forum-topic-merge-native-admin.mjs
 node scripts/verify/verify-forum-topic-split-owner.mjs
 node scripts/verify/verify-forum-topic-fork-owner.mjs
+node scripts/verify/verify-forum-reply-range-move-owner.mjs
 node scripts/verify/verify-forum-topic-split-graphql-transport.mjs
+node scripts/verify/verify-forum-reply-range-move-graphql-transport.mjs
+node scripts/verify/verify-forum-topic-fork-graphql-transport.mjs
 npm run verify:forum:admin-boundary
 npm run verify:blog:forum-ui-ownership
 cargo test -p rustok-forum --test topic_move_sqlite -- --nocapture
@@ -1702,13 +1717,18 @@ cargo test -p rustok-forum --test topic_merge_graphql_contract -- --nocapture
 cargo test -p rustok-forum graphql::topic_split_mutation::tests -- --nocapture
 cargo test -p rustok-forum --test topic_split_graphql_contract -- --nocapture
 cargo test -p rustok-forum --test topic_split_sqlite -- --nocapture
+cargo test -p rustok-forum graphql::topic_reply_range_move_mutation::tests -- --nocapture
+cargo test -p rustok-forum --test reply_range_move_graphql_contract -- --nocapture
+cargo test -p rustok-forum --test reply_range_move_sqlite -- --nocapture
+cargo test -p rustok-forum graphql::topic_fork_mutation::tests -- --nocapture
+cargo test -p rustok-forum --test topic_fork_graphql_contract -- --nocapture
 cargo test -p rustok-forum --test topic_fork_sqlite -- --nocapture
 cargo test -p rustok-forum-admin topic_merge_model -- --nocapture
 cargo check -p rustok-forum-admin --all-targets
 npm --prefix apps/next-admin run typecheck
 ```
 
-The FORUM-21A through FORUM-21R source and contract records do not claim
+The FORUM-21A through FORUM-21U source and contract records do not claim
 successful verifier, SQLite, PostgreSQL, Cargo, formatting, npm, browser,
 workflow or CI execution. The canonical task remains `planned` until the
 remaining workflows and maintainer evidence are complete.

--- a/crates/rustok-forum/src/graphql/mod.rs
+++ b/crates/rustok-forum/src/graphql/mod.rs
@@ -15,6 +15,7 @@ mod runtime_data;
 mod storefront_audience_topic;
 mod storefront_audience_topics;
 mod storefront_read_state;
+mod topic_fork_mutation;
 mod topic_merge_mutation;
 mod topic_reply_range_move_mutation;
 mod topic_split_mutation;
@@ -44,6 +45,9 @@ pub use quote_commands::{
 pub use read_state::*;
 pub use runtime_data::{ForumGraphqlRuntimeData, attach_schema_data};
 pub use storefront_read_state::*;
+pub use topic_fork_mutation::{
+    ForkForumTopicReplyBranchGraphqlInput, GqlForumTopicFork,
+};
 pub use topic_merge_mutation::{
     GqlForumTopicMerge, GqlForumTopicMergeSolutionResolution, MergeForumTopicGraphqlInput,
     ResolveForumTopicMergeSolutionGraphqlInput,
@@ -76,6 +80,7 @@ pub struct ForumMutation(
     content_commands::ForumContentCommandMutation,
     read_state::ForumReadStateMutation,
     storefront_read_state::ForumStorefrontReadStateMutation,
+    topic_fork_mutation::ForumTopicForkMutation,
     topic_merge_mutation::ForumTopicMergeMutation,
     topic_reply_range_move_mutation::ForumTopicReplyRangeMoveMutation,
     topic_split_mutation::ForumTopicSplitMutation,

--- a/crates/rustok-forum/src/graphql/topic_fork_mutation.rs
+++ b/crates/rustok-forum/src/graphql/topic_fork_mutation.rs
@@ -1,0 +1,233 @@
+use async_graphql::{Context, FieldError, InputObject, Object, Result, SimpleObject};
+use rustok_api::{
+    AuthContext, Permission, TenantContext,
+    graphql::{GraphQLError, require_module_enabled},
+    has_any_effective_permission,
+};
+use rustok_outbox::TransactionalEventBus;
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use crate::{ForkForumReplyBranchInput, ForumTopicForkResult, ForumTopicForkService};
+
+const MODULE_SLUG: &str = "forum";
+
+#[derive(Default)]
+pub(crate) struct ForumTopicForkMutation;
+
+#[Object]
+impl ForumTopicForkMutation {
+    async fn fork_forum_topic_reply_branch(
+        &self,
+        ctx: &Context<'_>,
+        tenant_id: Option<Uuid>,
+        source_topic_id: Uuid,
+        input: ForkForumTopicReplyBranchGraphqlInput,
+    ) -> Result<GqlForumTopicFork> {
+        require_module_enabled(ctx, MODULE_SLUG).await?;
+        let db = ctx.data::<DatabaseConnection>()?;
+        let event_bus = ctx.data::<TransactionalEventBus>()?;
+        let auth = ctx
+            .data::<AuthContext>()
+            .map_err(|_| <FieldError as GraphQLError>::unauthenticated())?
+            .clone();
+        let tenant = ctx.data::<TenantContext>()?;
+
+        execute_fork_forum_topic_reply_branch(
+            db,
+            event_bus,
+            tenant,
+            &auth,
+            tenant_id,
+            source_topic_id,
+            input,
+        )
+        .await
+    }
+}
+
+async fn execute_fork_forum_topic_reply_branch(
+    db: &DatabaseConnection,
+    event_bus: &TransactionalEventBus,
+    tenant: &TenantContext,
+    auth: &AuthContext,
+    requested_tenant_id: Option<Uuid>,
+    source_topic_id: Uuid,
+    input: ForkForumTopicReplyBranchGraphqlInput,
+) -> Result<GqlForumTopicFork> {
+    require_topic_manage_permission(auth)?;
+    let tenant_id = resolve_tenant_scope(tenant, requested_tenant_id)?;
+
+    let result = ForumTopicForkService::new(db.clone(), event_bus.clone())
+        .fork_reply_branch(
+            tenant_id,
+            source_topic_id,
+            rustok_core::SecurityContext::from_permission_snapshot(
+                Some(auth.user_id),
+                &auth.permissions,
+            ),
+            ForkForumReplyBranchInput {
+                operation_id: input.operation_id,
+                target_topic_id: input.target_topic_id,
+                root_reply_id: input.root_reply_id,
+                locale: input.locale,
+                title: input.title,
+                slug: input.slug,
+                reason: input.reason,
+            },
+        )
+        .await?;
+
+    Ok(result.into())
+}
+
+fn require_topic_manage_permission(auth: &AuthContext) -> Result<()> {
+    if !has_any_effective_permission(&auth.permissions, &[Permission::FORUM_TOPICS_MANAGE]) {
+        return Err(<FieldError as GraphQLError>::permission_denied(
+            "Permission denied: forum_topics:manage required",
+        ));
+    }
+    Ok(())
+}
+
+fn resolve_tenant_scope(tenant: &TenantContext, requested_tenant_id: Option<Uuid>) -> Result<Uuid> {
+    match requested_tenant_id {
+        Some(requested_tenant_id) if requested_tenant_id != tenant.id => {
+            Err(<FieldError as GraphQLError>::permission_denied(
+                "Permission denied: tenant scope mismatch",
+            ))
+        }
+        Some(requested_tenant_id) => Ok(requested_tenant_id),
+        None => Ok(tenant.id),
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, InputObject)]
+pub struct ForkForumTopicReplyBranchGraphqlInput {
+    pub operation_id: Uuid,
+    pub target_topic_id: Uuid,
+    pub root_reply_id: Uuid,
+    pub locale: String,
+    pub title: String,
+    pub slug: Option<String>,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, SimpleObject)]
+pub struct GqlForumTopicFork {
+    pub operation_id: Uuid,
+    pub event_id: Uuid,
+    pub source_topic_id: Uuid,
+    pub target_topic_id: Uuid,
+    pub root_reply_id: Uuid,
+    pub category_id: Uuid,
+    pub actor_id: Uuid,
+    pub reason: String,
+    pub copied_reply_count: i32,
+    pub copied_published_reply_count: i32,
+    pub copied_body_count: i32,
+    pub copied_reply_revision_count: i32,
+    pub copied_relation_revision_count: i32,
+    pub copied_mention_count: i32,
+    pub copied_quote_count: i32,
+    pub forked_at: String,
+}
+
+impl From<ForumTopicForkResult> for GqlForumTopicFork {
+    fn from(value: ForumTopicForkResult) -> Self {
+        Self {
+            operation_id: value.operation_id,
+            event_id: value.event_id,
+            source_topic_id: value.source_topic_id,
+            target_topic_id: value.target_topic_id,
+            root_reply_id: value.root_reply_id,
+            category_id: value.category_id,
+            actor_id: value.actor_id,
+            reason: value.reason,
+            copied_reply_count: value.copied_reply_count,
+            copied_published_reply_count: value.copied_published_reply_count,
+            copied_body_count: value.copied_body_count,
+            copied_reply_revision_count: value.copied_reply_revision_count,
+            copied_relation_revision_count: value.copied_relation_revision_count,
+            copied_mention_count: value.copied_mention_count,
+            copied_quote_count: value.copied_quote_count,
+            forked_at: value.forked_at.to_rfc3339(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rustok_api::{AuthContext, Permission, TenantContext};
+    use uuid::Uuid;
+
+    use super::{require_topic_manage_permission, resolve_tenant_scope};
+
+    fn auth_context(permissions: Vec<Permission>) -> AuthContext {
+        AuthContext {
+            user_id: Uuid::new_v4(),
+            session_id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            permissions,
+            client_id: None,
+            scopes: Vec::new(),
+            grant_type: "direct".to_string(),
+        }
+    }
+
+    fn tenant_context(tenant_id: Uuid) -> TenantContext {
+        TenantContext {
+            id: tenant_id,
+            name: "Topic fork GraphQL tenant".to_string(),
+            slug: "topic-fork-graphql".to_string(),
+            domain: None,
+            settings: serde_json::json!({}),
+            default_locale: "en".to_string(),
+            is_active: true,
+        }
+    }
+
+    fn error_code(error: &async_graphql::Error) -> Option<String> {
+        error
+            .extensions
+            .as_ref()
+            .and_then(|extensions| extensions.get("code"))
+            .cloned()
+            .and_then(|value| value.into_json().ok())
+            .and_then(|value| value.as_str().map(ToOwned::to_owned))
+    }
+
+    #[test]
+    fn fork_transport_requires_topic_manage_permission() {
+        let denied = require_topic_manage_permission(&auth_context(vec![
+            Permission::FORUM_TOPICS_READ,
+        ]))
+        .expect_err("read-only actor must not fork reply branches");
+        assert_eq!(error_code(&denied).as_deref(), Some("PERMISSION_DENIED"));
+
+        require_topic_manage_permission(&auth_context(vec![
+            Permission::FORUM_TOPICS_MANAGE,
+        ]))
+        .expect("manager permission must be accepted");
+    }
+
+    #[test]
+    fn fork_transport_rejects_tenant_override_mismatch() {
+        let tenant_id = Uuid::new_v4();
+        let tenant = tenant_context(tenant_id);
+
+        assert_eq!(
+            resolve_tenant_scope(&tenant, None).expect("routed tenant must resolve"),
+            tenant_id
+        );
+        assert_eq!(
+            resolve_tenant_scope(&tenant, Some(tenant_id))
+                .expect("matching tenant assertion must resolve"),
+            tenant_id
+        );
+
+        let denied = resolve_tenant_scope(&tenant, Some(Uuid::new_v4()))
+            .expect_err("mismatched tenant assertion must fail closed");
+        assert_eq!(error_code(&denied).as_deref(), Some("PERMISSION_DENIED"));
+    }
+}

--- a/crates/rustok-forum/tests/topic_fork_graphql_contract.rs
+++ b/crates/rustok-forum/tests/topic_fork_graphql_contract.rs
@@ -1,0 +1,81 @@
+use async_graphql::{EmptySubscription, Schema};
+use rustok_forum::graphql::ForumGraphqlErrorExtension;
+use rustok_forum::{ForumMutation, ForumQuery};
+
+const TOPIC_FORK_GRAPHQL: &str = include_str!("../src/graphql/topic_fork_mutation.rs");
+
+#[test]
+fn graphql_schema_exposes_idempotent_topic_fork_command() {
+    let schema = Schema::build(
+        ForumQuery::default(),
+        ForumMutation::default(),
+        EmptySubscription,
+    )
+    .extension(ForumGraphqlErrorExtension)
+    .finish();
+    let sdl = schema.sdl();
+
+    for marker in [
+        "forkForumTopicReplyBranch",
+        "ForkForumTopicReplyBranchGraphqlInput",
+        "GqlForumTopicFork",
+        "operationId",
+        "sourceTopicId",
+        "targetTopicId",
+        "rootReplyId",
+        "eventId",
+        "categoryId",
+        "actorId",
+        "copiedReplyCount",
+        "copiedPublishedReplyCount",
+        "copiedBodyCount",
+        "copiedReplyRevisionCount",
+        "copiedRelationRevisionCount",
+        "copiedMentionCount",
+        "copiedQuoteCount",
+        "forkedAt",
+    ] {
+        assert!(sdl.contains(marker), "missing GraphQL fork marker {marker}");
+    }
+}
+
+#[test]
+fn graphql_fork_adapter_uses_routed_tenant_manage_scope_and_owner_service() {
+    for marker in [
+        "require_module_enabled(ctx, MODULE_SLUG).await?",
+        "Permission::FORUM_TOPICS_MANAGE",
+        "Permission denied: forum_topics:manage required",
+        "Permission denied: tenant scope mismatch",
+        "ForumTopicForkService::new(db.clone(), event_bus.clone())",
+        ".fork_reply_branch(",
+        "SecurityContext::from_permission_snapshot",
+        "operation_id: input.operation_id",
+        "target_topic_id: input.target_topic_id",
+        "root_reply_id: input.root_reply_id",
+        "locale: input.locale",
+        "title: input.title",
+        "slug: input.slug",
+        "reason: input.reason",
+    ] {
+        assert!(
+            TOPIC_FORK_GRAPHQL.contains(marker),
+            "missing fork adapter marker {marker}"
+        );
+    }
+
+    for forbidden in [
+        "resolve_canonical_topic",
+        "forum_topic_fork_operations",
+        "forum_topic_fork_reply_items",
+        "forum_topic_fork_revision_items",
+        "ForumTopicMoveService",
+        "ForumTopicMergeService",
+        "ForumTopicSplitService",
+        "TopicService::new",
+    ] {
+        assert!(
+            !TOPIC_FORK_GRAPHQL.contains(forbidden),
+            "fork adapter contains forbidden marker {forbidden}"
+        );
+    }
+}

--- a/scripts/verify/verify-forum-topic-fork-graphql-transport.mjs
+++ b/scripts/verify/verify-forum-topic-fork-graphql-transport.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const paths = {
+  contract: "crates/rustok-forum/contracts/forum-topic-fork-graphql-transport.json",
+  ownerContract: "crates/rustok-forum/contracts/forum-topic-fork-owner.json",
+  docs: "crates/rustok-forum/docs/forum-21u-topic-fork-graphql-transport.md",
+  ownerDocs: "crates/rustok-forum/docs/forum-21q-topic-fork-owner.md",
+  graphql: "crates/rustok-forum/src/graphql/topic_fork_mutation.rs",
+  graphqlMod: "crates/rustok-forum/src/graphql/mod.rs",
+  owner: "crates/rustok-forum/src/services/topic_fork_owner.rs",
+  schemaTest: "crates/rustok-forum/tests/topic_fork_graphql_contract.rs",
+  ownerRuntimeTest: "crates/rustok-forum/tests/topic_fork_sqlite.rs",
+  docsIndex: "crates/rustok-forum/docs/README.md",
+  plan: "crates/rustok-forum/docs/implementation-plan.md",
+};
+
+const read = (path) => readFileSync(path, "utf8");
+const includesAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(text.includes(marker), `${label} is missing marker: ${marker}`);
+  }
+};
+
+const contract = JSON.parse(read(paths.contract));
+const ownerContract = JSON.parse(read(paths.ownerContract));
+const docs = read(paths.docs);
+const ownerDocs = read(paths.ownerDocs);
+const graphql = read(paths.graphql);
+const graphqlMod = read(paths.graphqlMod);
+const owner = read(paths.owner);
+const schemaTest = read(paths.schemaTest);
+const ownerRuntimeTest = read(paths.ownerRuntimeTest);
+const docsIndex = read(paths.docsIndex);
+const plan = read(paths.plan);
+
+assert.equal(contract.contract, "forum_topic_fork_graphql_transport_v1");
+assert.equal(contract.task, "FORUM-21U");
+assert.equal(contract.parent_task, "FORUM-21");
+assert.equal(contract.extends, "FORUM-21Q");
+assert.equal(contract.status, "source_ready_maintainer_execution_pending");
+assert.equal(contract.canonical_plan_status, "planned");
+assert.equal(contract.transport, "graphql");
+assert.equal(contract.owner_service, "ForumTopicForkService");
+assert.equal(contract.authorization.module_must_be_enabled, "forum");
+assert.equal(contract.authorization.required_permission, "forum_topics:manage");
+assert.equal(contract.authorization.tenant_is_derived_from_routed_TenantContext, true);
+assert.equal(contract.authorization.optional_tenant_argument_must_equal_routed_tenant, true);
+assert.equal(contract.command.field, "forkForumTopicReplyBranch");
+assert.equal(contract.command.input_type, "ForkForumTopicReplyBranchGraphqlInput");
+assert.equal(contract.command.result_type, "GqlForumTopicFork");
+assert.equal(contract.command.calls_owner_method, "fork_reply_branch");
+assert.equal(contract.receipt_result.returns_immutable_owner_receipt, true);
+assert.equal(contract.receipt_result.exact_replay_returns_same_result, true);
+assert.equal(contract.composition.resolver_contains_no_fork_business_logic, true);
+assert.equal(contract.composition.raw_fork_receipt_or_mapping_table_access_in_resolver, false);
+assert.equal(contract.composition.transport_local_copy_policy, false);
+assert.equal(contract.compatibility.owner_command_changed, false);
+assert.equal(contract.compatibility.receipt_schema_changed, false);
+assert.equal(contract.compatibility.semantic_event_schema_changed, false);
+assert.equal(contract.compatibility.graphql_field_is_additive, true);
+assert.equal(ownerContract.contract, "forum_topic_fork_owner_v1");
+assert.equal(ownerContract.task, "FORUM-21Q");
+assert.equal(ownerContract.command, "fork_reply_branch");
+assert.equal(ownerContract.audit.semantic_event, "forum.topic.forked");
+
+includesAll(
+  graphql,
+  [
+    "pub(crate) struct ForumTopicForkMutation",
+    "async fn fork_forum_topic_reply_branch(",
+    "require_module_enabled(ctx, MODULE_SLUG).await?;",
+    "ctx.data::<DatabaseConnection>()?",
+    "ctx.data::<TransactionalEventBus>()?",
+    "ctx.data::<AuthContext>()",
+    "ctx.data::<TenantContext>()?",
+    "Permission::FORUM_TOPICS_MANAGE",
+    "Permission denied: forum_topics:manage required",
+    "Permission denied: tenant scope mismatch",
+    "SecurityContext::from_permission_snapshot",
+    "ForumTopicForkService::new(db.clone(), event_bus.clone())",
+    ".fork_reply_branch(",
+    "pub struct ForkForumTopicReplyBranchGraphqlInput",
+    "pub struct GqlForumTopicFork",
+    "root_reply_id: input.root_reply_id",
+    "copied_reply_revision_count",
+    "copied_relation_revision_count",
+    "copied_mention_count",
+    "copied_quote_count",
+    "forked_at: value.forked_at.to_rfc3339()",
+  ],
+  "topic fork GraphQL adapter",
+);
+
+for (const forbidden of [
+  "resolve_canonical_topic",
+  "forum_topic_fork_operations",
+  "forum_topic_fork_reply_items",
+  "forum_topic_fork_revision_items",
+  "ForumTopicMoveService",
+  "ForumTopicMergeService",
+  "ForumTopicSplitService",
+  "TopicService::new",
+  "bestEffort",
+  "ALLOW_MISSING",
+  "SKIP_VALIDATION",
+]) {
+  assert.ok(!graphql.includes(forbidden), `GraphQL adapter contains forbidden marker: ${forbidden}`);
+}
+
+includesAll(
+  graphqlMod,
+  [
+    "mod topic_fork_mutation;",
+    "ForkForumTopicReplyBranchGraphqlInput",
+    "GqlForumTopicFork",
+    "topic_fork_mutation::ForumTopicForkMutation",
+  ],
+  "GraphQL root registration",
+);
+includesAll(
+  owner,
+  [
+    "pub struct ForumTopicForkService",
+    "pub async fn fork_reply_branch(",
+    "Resource::ForumTopics, Action::Manage",
+    "load_reply_branch_ids_in_tx",
+    "derive_reply_id_map",
+    "insert_fork_operation_in_tx",
+    'const FORUM_TOPIC_FORK_EVENT_TYPE: &str = "forum.topic.forked"',
+  ],
+  "topic fork owner",
+);
+includesAll(
+  schemaTest,
+  [
+    "graphql_schema_exposes_idempotent_topic_fork_command",
+    '"forkForumTopicReplyBranch"',
+    '"ForkForumTopicReplyBranchGraphqlInput"',
+    '"GqlForumTopicFork"',
+    '"rootReplyId"',
+    '"copiedReplyRevisionCount"',
+    '"copiedRelationRevisionCount"',
+    "graphql_fork_adapter_uses_routed_tenant_manage_scope_and_owner_service",
+  ],
+  "GraphQL schema contract",
+);
+includesAll(
+  ownerRuntimeTest,
+  [
+    "reply_branch_fork_is_atomic_idempotent_and_preserves_provenance",
+    "reply_branch_fork_rejects_non_topological_source_positions_atomically",
+    "forum_topic_fork_operations",
+    "forum.topic.forked",
+  ],
+  "owner runtime contract source",
+);
+includesAll(
+  docs,
+  [
+    "# FORUM-21U topic fork GraphQL transport",
+    "`source_ready_maintainer_execution_pending`",
+    "forkForumTopicReplyBranch",
+    "forum_topics:manage",
+    "ForumTopicForkService::fork_reply_branch",
+    "immutable owner receipt",
+    "FORUM-21` entry remains `planned`",
+    "No command above was run by the implementation agent",
+  ],
+  "FORUM-21U handoff",
+);
+includesAll(
+  ownerDocs,
+  [
+    "# FORUM-21Q reply-branch fork owner",
+    "deterministically derived",
+    "forum.topic.forked",
+  ],
+  "FORUM-21Q owner handoff",
+);
+includesAll(
+  docsIndex,
+  [
+    "FORUM-21U topic fork GraphQL transport",
+    "forkForumTopicReplyBranch",
+  ],
+  "Forum docs index",
+);
+includesAll(
+  plan,
+  [
+    "### Delivered through `FORUM-21U`",
+    "FORUM-21Q adds the idempotent reply-branch fork owner",
+    "FORUM-21S adds the idempotent bounded reply-range move owner",
+    "FORUM-21T adds the routed-tenant, manager-only GraphQL reply-range transport",
+    "FORUM-21U adds the routed-tenant, manager-only GraphQL fork transport",
+    "public admin composition for split, fork and reply-range workflows",
+  ],
+  "canonical FORUM-21 plan",
+);
+assert.ok(plan.includes("| `FORUM-21` | `planned` |"));
+assert.ok(plan.includes("**Status:** `planned`"));
+assert.ok(!plan.includes("plus an additive\n  manager transport for the fork owner"));
+assert.ok(!plan.includes("bounded reply-range movement with deterministic positions"));
+
+console.log(
+  "FORUM-21U topic fork GraphQL transport source is ready; maintainer execution and admin composition remain pending.",
+);


### PR DESCRIPTION
## Summary
- add the FORUM-21U routed-tenant, manager-only GraphQL adapter `forkForumTopicReplyBranch`
- delegate the complete command to the existing FORUM-21Q owner and expose its immutable receipt
- add source contract, SDL/source checks, documentation/verifier, and synchronize the canonical plan through FORUM-21U

## Validation
- Not run per maintainer request. Tests and verifier were added only as source contracts.