### PR TITLE
fix(commerce): bound admin checkout operation diagnostics

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/admin-checkout-operation-diagnostic-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/admin-checkout-operation-diagnostic-safety-source-review.json
@@ -1,0 +1,46 @@
+{
+  "status": "commerce_admin_checkout_operation_diagnostic_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-commerce/src/controllers/admin/checkout_operations.rs",
+    "crates/rustok-commerce/docs/admin-checkout-operation-diagnostic-safety.md",
+    "scripts/verify/verify-commerce-admin-checkout-operation-diagnostic-safety.mjs",
+    "scripts/verify/verify-commerce-admin-checkout-operation-error-context.mjs",
+    "crates/rustok-commerce/docs/implementation-plan.md"
+  ],
+  "source_contract": {
+    "raw_debug_error_logged": false,
+    "raw_tenant_uuid_logged": false,
+    "raw_actor_uuid_logged": false,
+    "raw_optional_domain_uuid_logged": false,
+    "error_redacted_marker_logged": true,
+    "required_uuid_shape_logged": true,
+    "optional_uuid_shape_logged": true,
+    "route_operation_logged": true,
+    "source_owner_logged": true,
+    "error_kind_logged": true,
+    "public_code_logged": true,
+    "http_status_logged": true,
+    "boundary_logged": true,
+    "existing_log_site_markers_preserved": true,
+    "operation_policy_preserved": true,
+    "compensation_policy_preserved": true,
+    "identity_adoption_preserved": true,
+    "permission_checks_preserved": true,
+    "service_calls_preserved": true,
+    "http_envelopes_preserved": true,
+    "broad_ecommerce_cleanup_closed": false,
+    "runtime_evidence_claimed": false
+  },
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed."
+}

--- a/crates/rustok-commerce/docs/admin-checkout-operation-diagnostic-safety.md
+++ b/crates/rustok-commerce/docs/admin-checkout-operation-diagnostic-safety.md
@@ -1,0 +1,60 @@
+# Admin checkout operation diagnostic safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens the shared `admin_checkout_operation_http_error` event used by:
+
+- admin checkout-operation lookup;
+- explicit checkout compensation;
+- compensation sweep storage failures.
+
+The mapper continues to receive the typed source error and the full internal context required for
+policy selection and identity adoption. Only the diagnostic projection is changed.
+
+## Bounded diagnostic projection
+
+Immediately before the `tracing::error!` event, the internal context is converted to
+`AdminCheckoutOperationDiagnosticContext`.
+
+Required tenant and actor UUIDs are represented only as `nil` or `non_nil`. Optional checkout,
+reservation, payment, refund, order, return, and change UUIDs are represented only as `absent`,
+`present_nil`, or `present_non_nil`.
+
+The typed error is replaced in the event by the stable marker `redacted`. The event still records the
+static route operation, owner, source owner, error kind, public code, HTTP status, boundary, and the
+existing static log message.
+
+## Preserved behavior
+
+This work does not change:
+
+- permission checks or route inputs;
+- operation, compensation, and sweep service calls;
+- typed policy matching;
+- source-owner routing;
+- not-found identity adoption;
+- public status, code, or message selection;
+- the single `HttpError::new(status, code, message)` constructor;
+- successful operation and sweep response bodies.
+
+The existing broad source verifier retains its original log-site markers. Those markers now point to
+the bounded diagnostic context rather than the raw request/error context.
+
+## Remaining boundary
+
+This slice does not close raw diagnostic payloads in other Commerce admin controllers, storefront
+transports, owner adapters, or remaining non-`PortError` envelopes. The broader ecommerce
+correlation-safe mapper task remains open.
+
+## Evidence
+
+- `crates/rustok-commerce/contracts/evidence/admin-checkout-operation-diagnostic-safety-source-review.json`
+- `scripts/verify/verify-commerce-admin-checkout-operation-diagnostic-safety.mjs`
+- `scripts/verify/verify-commerce-admin-checkout-operation-error-context.mjs`
+
+## Validation disclosure
+
+No tests, Node verifiers, formatting, Cargo commands, workflows, or CI were run. No compile or runtime
+status is promoted.

--- a/crates/rustok-commerce/src/controllers/admin/checkout_operations.rs
+++ b/crates/rustok-commerce/src/controllers/admin/checkout_operations.rs
@@ -57,6 +57,50 @@ impl AdminCheckoutOperationErrorContext {
     }
 }
 
+struct AdminCheckoutOperationDiagnosticContext {
+    tenant_id: &'static str,
+    actor_id: &'static str,
+    checkout_operation_id: &'static str,
+    reservation_id: &'static str,
+    payment_collection_id: &'static str,
+    payment_id: &'static str,
+    refund_id: &'static str,
+    order_id: &'static str,
+    order_return_id: &'static str,
+    order_change_id: &'static str,
+    operation: &'static str,
+}
+
+impl From<&AdminCheckoutOperationErrorContext> for AdminCheckoutOperationDiagnosticContext {
+    fn from(context: &AdminCheckoutOperationErrorContext) -> Self {
+        Self {
+            tenant_id: uuid_shape(context.tenant_id),
+            actor_id: uuid_shape(context.actor_id),
+            checkout_operation_id: optional_uuid_shape(context.checkout_operation_id),
+            reservation_id: optional_uuid_shape(context.reservation_id),
+            payment_collection_id: optional_uuid_shape(context.payment_collection_id),
+            payment_id: optional_uuid_shape(context.payment_id),
+            refund_id: optional_uuid_shape(context.refund_id),
+            order_id: optional_uuid_shape(context.order_id),
+            order_return_id: optional_uuid_shape(context.order_return_id),
+            order_change_id: optional_uuid_shape(context.order_change_id),
+            operation: context.operation,
+        }
+    }
+}
+
+fn uuid_shape(value: Uuid) -> &'static str {
+    if value.is_nil() { "nil" } else { "non_nil" }
+}
+
+fn optional_uuid_shape(value: Option<Uuid>) -> &'static str {
+    match value {
+        None => "absent",
+        Some(value) if value.is_nil() => "present_nil",
+        Some(_) => "present_non_nil",
+    }
+}
+
 #[derive(Clone, Debug, Serialize, ToSchema)]
 pub struct AdminCheckoutOperationResponse {
     pub id: Uuid,
@@ -340,10 +384,10 @@ fn admin_checkout_operation_http_error<E>(
     source_owner: &'static str,
     policy: AdminCheckoutOperationHttpPolicy,
     log_message: &'static str,
-) -> HttpError
-where
-    E: std::fmt::Debug,
-{
+) -> HttpError {
+    let _ = error;
+    let context = AdminCheckoutOperationDiagnosticContext::from(context);
+    let error = "redacted";
     let (status, code, message, error_kind) = policy;
     tracing::error!(
         error = ?error,

--- a/scripts/verify/verify-commerce-admin-checkout-operation-diagnostic-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-checkout-operation-diagnostic-safety.mjs
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+
+const paths = {
+  source: "crates/rustok-commerce/src/controllers/admin/checkout_operations.rs",
+  evidence:
+    "crates/rustok-commerce/contracts/evidence/admin-checkout-operation-diagnostic-safety-source-review.json",
+  doc: "crates/rustok-commerce/docs/admin-checkout-operation-diagnostic-safety.md",
+  broadVerifier: "scripts/verify/verify-commerce-admin-checkout-operation-error-context.mjs",
+  plan: "crates/rustok-commerce/docs/implementation-plan.md",
+};
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+function blockBetween(source, start, end, label) {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate block`);
+    return "";
+  }
+  return source.slice(startIndex, endIndex);
+}
+
+function requireOrder(source, markers, label) {
+  let previous = -1;
+  for (const marker of markers) {
+    const index = source.indexOf(marker);
+    if (index < 0) {
+      failures.push(`${label}: missing ${marker}`);
+      return;
+    }
+    if (index <= previous) {
+      failures.push(`${label}: ${marker} is out of order`);
+      return;
+    }
+    previous = index;
+  }
+}
+
+const source = read(paths.source);
+const evidence = JSON.parse(read(paths.evidence));
+const doc = read(paths.doc);
+const broadVerifier = read(paths.broadVerifier);
+const plan = read(paths.plan);
+
+const rawContext = blockBetween(
+  source,
+  "struct AdminCheckoutOperationErrorContext {",
+  "impl AdminCheckoutOperationErrorContext {",
+  "raw error context",
+);
+for (const marker of [
+  "tenant_id: Uuid",
+  "actor_id: Uuid",
+  "checkout_operation_id: Option<Uuid>",
+  "reservation_id: Option<Uuid>",
+  "payment_collection_id: Option<Uuid>",
+  "payment_id: Option<Uuid>",
+  "refund_id: Option<Uuid>",
+  "order_id: Option<Uuid>",
+  "order_return_id: Option<Uuid>",
+  "order_change_id: Option<Uuid>",
+  "operation: &'static str",
+]) requireText(rawContext, marker, `${paths.source}: internal context preserved`);
+
+const diagnosticContext = blockBetween(
+  source,
+  "struct AdminCheckoutOperationDiagnosticContext {",
+  "impl From<&AdminCheckoutOperationErrorContext> for AdminCheckoutOperationDiagnosticContext {",
+  "bounded diagnostic context",
+);
+for (const field of [
+  "tenant_id",
+  "actor_id",
+  "checkout_operation_id",
+  "reservation_id",
+  "payment_collection_id",
+  "payment_id",
+  "refund_id",
+  "order_id",
+  "order_return_id",
+  "order_change_id",
+  "operation",
+]) requireText(diagnosticContext, `${field}: &'static str`, `${paths.source}: bounded ${field}`);
+for (const forbidden of ["Uuid", "Option<", "String"]) {
+  forbidText(diagnosticContext, forbidden, `${paths.source}: bounded context storage`);
+}
+
+const conversion = blockBetween(
+  source,
+  "impl From<&AdminCheckoutOperationErrorContext> for AdminCheckoutOperationDiagnosticContext {",
+  "fn uuid_shape(",
+  "diagnostic conversion",
+);
+for (const marker of [
+  "tenant_id: uuid_shape(context.tenant_id)",
+  "actor_id: uuid_shape(context.actor_id)",
+  "checkout_operation_id: optional_uuid_shape(context.checkout_operation_id)",
+  "reservation_id: optional_uuid_shape(context.reservation_id)",
+  "payment_collection_id: optional_uuid_shape(context.payment_collection_id)",
+  "payment_id: optional_uuid_shape(context.payment_id)",
+  "refund_id: optional_uuid_shape(context.refund_id)",
+  "order_id: optional_uuid_shape(context.order_id)",
+  "order_return_id: optional_uuid_shape(context.order_return_id)",
+  "order_change_id: optional_uuid_shape(context.order_change_id)",
+  "operation: context.operation",
+]) requireText(conversion, marker, `${paths.source}: diagnostic conversion`);
+
+const requiredShape = blockBetween(
+  source,
+  "fn uuid_shape(",
+  "fn optional_uuid_shape(",
+  "required UUID shape",
+);
+for (const marker of ["value.is_nil()", '"nil"', '"non_nil"']) {
+  requireText(requiredShape, marker, `${paths.source}: required UUID shape`);
+}
+
+const optionalShape = blockBetween(
+  source,
+  "fn optional_uuid_shape(",
+  "#[derive(Clone, Debug, Serialize, ToSchema)]",
+  "optional UUID shape",
+);
+for (const marker of [
+  "None => \"absent\"",
+  "Some(value) if value.is_nil() => \"present_nil\"",
+  "Some(_) => \"present_non_nil\"",
+]) requireText(optionalShape, marker, `${paths.source}: optional UUID shape`);
+
+const logger = blockBetween(
+  source,
+  "fn admin_checkout_operation_http_error<E>(",
+  "fn map_operation_error(",
+  "admin checkout logger",
+);
+requireOrder(
+  logger,
+  [
+    "let _ = error;",
+    "let context = AdminCheckoutOperationDiagnosticContext::from(context);",
+    'let error = "redacted";',
+    "let (status, code, message, error_kind) = policy;",
+    "tracing::error!(",
+    "HttpError::new(status, code, message)",
+  ],
+  `${paths.source}: bounded logger order`,
+);
+for (const marker of [
+  "error = ?error",
+  "owner = ADMIN_CHECKOUT_OPERATION_OWNER",
+  "source_owner,",
+  "tenant_id = %context.tenant_id",
+  "actor_id = %context.actor_id",
+  "checkout_operation_id = ?context.checkout_operation_id",
+  "reservation_id = ?context.reservation_id",
+  "payment_collection_id = ?context.payment_collection_id",
+  "payment_id = ?context.payment_id",
+  "refund_id = ?context.refund_id",
+  "order_id = ?context.order_id",
+  "order_return_id = ?context.order_return_id",
+  "order_change_id = ?context.order_change_id",
+  "operation = %context.operation",
+  "error_kind,",
+  "public_code = code",
+  "status = %status",
+  "boundary = ADMIN_CHECKOUT_OPERATION_BOUNDARY",
+]) requireText(logger, marker, `${paths.source}: retained bounded field`);
+for (const forbidden of [
+  "where\n    E: std::fmt::Debug",
+  "format!(",
+  ".to_string()",
+  "error.message",
+]) forbidText(logger, forbidden, `${paths.source}: raw logger payload`);
+
+for (const marker of [
+  "CheckoutOperationError::NotFound(_)",
+  "CheckoutOperationError::Conflict(_)",
+  "CheckoutOperationError::Validation(_)",
+  "CheckoutOperationError::Database(_)",
+  "adopt_operation_error_identity(&mut context, &error)",
+  "adopt_reservation_error_identity(&mut context, source)",
+  "CheckoutCompensationError::ManualReconciliation(_)",
+  "CheckoutCompensationError::Conflict(_)",
+  "CheckoutCompensationError::Boundary {",
+  "CheckoutCompensationError::CompensationAndJournal { .. }",
+  "HttpError::new(status, code, message)",
+]) requireText(source, marker, `${paths.source}: preserved mapping behavior`);
+
+for (const marker of [
+  "error = ?error",
+  "tenant_id = %context.tenant_id",
+  "actor_id = %context.actor_id",
+  "checkout_operation_id = ?context.checkout_operation_id",
+  "HttpError::new(status, code, message)",
+]) requireText(broadVerifier, marker, `${paths.broadVerifier}: compatibility marker`);
+
+if (
+  evidence.status !==
+  "commerce_admin_checkout_operation_diagnostic_safety_source_reviewed_unvalidated"
+) failures.push(`${paths.evidence}: unexpected status ${evidence.status}`);
+for (const [key, expected] of Object.entries({
+  raw_debug_error_logged: false,
+  raw_tenant_uuid_logged: false,
+  raw_actor_uuid_logged: false,
+  raw_optional_domain_uuid_logged: false,
+  error_redacted_marker_logged: true,
+  required_uuid_shape_logged: true,
+  optional_uuid_shape_logged: true,
+  existing_log_site_markers_preserved: true,
+  operation_policy_preserved: true,
+  compensation_policy_preserved: true,
+  identity_adoption_preserved: true,
+  http_envelopes_preserved: true,
+  broad_ecommerce_cleanup_closed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "compile_proven",
+  "runtime_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+
+for (const marker of [
+  "Status: **source-ready / unvalidated**",
+  "Required tenant and actor UUIDs are represented only as `nil` or `non_nil`.",
+  "The typed error is replaced in the event by the stable marker `redacted`.",
+  "The broader ecommerce correlation-safe mapper task remains open.",
+]) requireText(doc, marker, `${paths.doc}: documentation contract`);
+requireText(
+  plan,
+  "Finish correlation-safe mapper cleanup",
+  `${paths.plan}: broad cleanup remains open`,
+);
+
+if (failures.length > 0) {
+  console.error("Commerce admin checkout-operation diagnostic verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "Commerce admin checkout-operation diagnostics use bounded UUID shapes and a redacted error marker; execution validation remains open",
+);


### PR DESCRIPTION
## Summary

Continue the ecommerce correlation-safe mapper cleanup at the Commerce admin checkout-operation HTTP boundary.

- convert tenant and actor UUIDs to closed `nil` / `non_nil` diagnostic shapes
- convert optional checkout, reservation, payment, refund, order, return, and change UUIDs to `absent` / `present_nil` / `present_non_nil` shapes
- replace the complete typed Debug error payload with a stable `redacted` marker
- preserve the existing owner/source-owner, route operation, error kind, public code, HTTP status, boundary, and static log message
- retain existing broad-verifier log-site markers while changing their values to bounded projections
- add focused source-only evidence, documentation, and a fail-closed static guard
- leave other Commerce admin controllers, storefront transports, owner adapters, and remaining non-`PortError` envelopes open

## Preserved behavior

- route permissions and inputs
- checkout-operation lookup, compensation, and sweep calls
- typed error policy selection and source-owner routing
- not-found identity adoption
- public HTTP status, code, and message selection
- successful operation and sweep response contracts
- the single `HttpError::new(status, code, message)` construction

## Validation

Tests, Node verifiers, formatting, Cargo checks, workflows, and CI were not run per maintainer request. Evidence remains source-reviewed/unvalidated.