### PR TITLE
fix(commerce): bound admin order mutation diagnostics

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/admin-order-mutation-diagnostic-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/admin-order-mutation-diagnostic-safety-source-review.json
@@ -1,0 +1,45 @@
+{
+  "status": "commerce_admin_order_mutation_diagnostic_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-commerce/src/controllers/admin/orders.rs",
+    "crates/rustok-commerce/docs/admin-order-mutation-diagnostic-safety.md",
+    "scripts/verify/verify-commerce-admin-order-mutation-diagnostic-safety.mjs",
+    "scripts/verify/verify-commerce-admin-order-route-error-context.mjs",
+    "crates/rustok-commerce/docs/implementation-plan.md"
+  ],
+  "source_contract": {
+    "raw_order_error_logged": false,
+    "raw_tenant_uuid_logged": false,
+    "raw_actor_uuid_logged": false,
+    "raw_order_uuid_logged": false,
+    "raw_customer_uuid_logged": false,
+    "redacted_error_debug_logged": true,
+    "required_uuid_shapes_logged": true,
+    "optional_uuid_shapes_logged": true,
+    "operation_preserved": true,
+    "order_not_found_identity_adoption_preserved": true,
+    "typed_policy_selection_precedes_shadowing": true,
+    "order_error_policy_preserved": true,
+    "http_envelopes_preserved": true,
+    "four_mutation_callsites_preserved": true,
+    "orders_update_permission_preserved": true,
+    "read_mapper_unchanged": true,
+    "detail_payment_mapper_unchanged": true,
+    "detail_fulfillment_mapper_unchanged": true,
+    "existing_broad_verifier_markers_preserved": true,
+    "broad_ecommerce_cleanup_closed": false,
+    "runtime_evidence_claimed": false
+  },
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed."
+}

--- a/crates/rustok-commerce/docs/admin-order-mutation-diagnostic-safety.md
+++ b/crates/rustok-commerce/docs/admin-order-mutation-diagnostic-safety.md
@@ -1,0 +1,48 @@
+# Admin order mutation diagnostic safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens `map_admin_order_error`, the shared typed `OrderError` mapper used by the four mounted Commerce admin order mutations: mark paid, ship, deliver, and cancel.
+
+The routes continue to call the concrete order owner with the same tenant, actor, order, input, permission, and operation values. Only the failure diagnostic projection changes.
+
+## Bounded diagnostic projection
+
+The typed `OrderError` and `AdminOrderErrorContext` remain available for order-not-found identity adoption and HTTP policy selection. After those decisions, both bindings are shadowed before `tracing::error!`:
+
+- the error becomes a diagnostic type whose Debug output is always `redacted`;
+- tenant and actor identifiers become `nil` / `non_nil` shapes;
+- optional order and customer identifiers become `absent` / `present_nil` / `present_non_nil` shapes;
+- the static consumer operation remains visible;
+- error kind, public code, HTTP status, owner, boundary, and static event message remain visible.
+
+The existing broad verifier expressions remain present, but they reference bounded shadow values at the log site rather than the original typed error and UUID payloads.
+
+## Preserved behavior
+
+This work does not change:
+
+- `OrderError` to HTTP policy mapping;
+- adoption of the UUID carried by `OrderError::OrderNotFound`;
+- public status, code, or message selection;
+- `HttpError::new(status, code, message)` construction;
+- the four mutation routes or their `ORDERS_UPDATE` permission;
+- mutation owner calls or forwarded inputs;
+- the admin order read mapper;
+- order-detail payment and fulfillment mappers.
+
+## Remaining boundary
+
+This slice does not close raw diagnostic payloads in order-detail payment and fulfillment mappers, return/change mutations, shipping, payment, fulfillment, product, or storefront transports. The broader ecommerce correlation-safe mapper and non-`PortError` envelope cleanup remains open.
+
+## Evidence
+
+- `crates/rustok-commerce/contracts/evidence/admin-order-mutation-diagnostic-safety-source-review.json`
+- `scripts/verify/verify-commerce-admin-order-mutation-diagnostic-safety.mjs`
+- `scripts/verify/verify-commerce-admin-order-route-error-context.mjs`
+
+## Validation disclosure
+
+No tests, Node verifiers, formatting, Cargo commands, workflows, or CI were run. No compile or runtime status is promoted.

--- a/crates/rustok-commerce/src/controllers/admin/orders.rs
+++ b/crates/rustok-commerce/src/controllers/admin/orders.rs
@@ -109,6 +109,34 @@ impl std::fmt::Debug for AdminOrderReadPortDiagnosticError<'_> {
     }
 }
 
+struct AdminOrderMutationDiagnosticContext {
+    tenant_id: &'static str,
+    actor_id: &'static str,
+    order_id: &'static str,
+    customer_id: &'static str,
+    operation: &'static str,
+}
+
+impl From<&AdminOrderErrorContext> for AdminOrderMutationDiagnosticContext {
+    fn from(context: &AdminOrderErrorContext) -> Self {
+        Self {
+            tenant_id: uuid_shape(context.tenant_id),
+            actor_id: uuid_shape(context.actor_id),
+            order_id: optional_uuid_shape(context.order_id),
+            customer_id: optional_uuid_shape(context.customer_id),
+            operation: context.operation,
+        }
+    }
+}
+
+struct AdminOrderMutationDiagnosticError;
+
+impl std::fmt::Debug for AdminOrderMutationDiagnosticError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("redacted")
+    }
+}
+
 fn uuid_shape(value: Uuid) -> &'static str {
     if value.is_nil() { "nil" } else { "non_nil" }
 }
@@ -275,6 +303,8 @@ fn map_admin_order_error(mut context: AdminOrderErrorContext, error: OrderError)
         context.order_id = Some(*id);
     }
     let (status, code, message, error_kind) = admin_order_error_policy(&error);
+    let context = AdminOrderMutationDiagnosticContext::from(&context);
+    let error = AdminOrderMutationDiagnosticError;
     tracing::error!(
         error = ?error,
         owner = ADMIN_ORDER_OWNER,

--- a/scripts/verify/verify-commerce-admin-order-mutation-diagnostic-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-order-mutation-diagnostic-safety.mjs
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? path.resolve(configuredRoot)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+
+const paths = {
+  source: "crates/rustok-commerce/src/controllers/admin/orders.rs",
+  evidence:
+    "crates/rustok-commerce/contracts/evidence/admin-order-mutation-diagnostic-safety-source-review.json",
+  doc: "crates/rustok-commerce/docs/admin-order-mutation-diagnostic-safety.md",
+  broadVerifier: "scripts/verify/verify-commerce-admin-order-route-error-context.mjs",
+  plan: "crates/rustok-commerce/docs/implementation-plan.md",
+};
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const requireCount = (source, value, expected, label) => {
+  const actual = source.split(value).length - 1;
+  if (actual !== expected) failures.push(`${label}: expected ${expected}, found ${actual}`);
+};
+
+function blockBetween(source, start, end, label) {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate block`);
+    return "";
+  }
+  return source.slice(startIndex, endIndex);
+}
+
+function requireOrder(source, markers, label) {
+  let previous = -1;
+  for (const marker of markers) {
+    const index = source.indexOf(marker);
+    if (index < 0) {
+      failures.push(`${label}: missing ${marker}`);
+      return;
+    }
+    if (index <= previous) {
+      failures.push(`${label}: ${marker} is out of order`);
+      return;
+    }
+    previous = index;
+  }
+}
+
+const source = read(paths.source);
+const evidence = JSON.parse(read(paths.evidence));
+const doc = read(paths.doc);
+const broadVerifier = read(paths.broadVerifier);
+const plan = read(paths.plan);
+
+const diagnosticContext = blockBetween(
+  source,
+  "struct AdminOrderMutationDiagnosticContext {",
+  "impl From<&AdminOrderErrorContext> for AdminOrderMutationDiagnosticContext {",
+  "bounded mutation context",
+);
+for (const field of ["tenant_id", "actor_id", "order_id", "customer_id", "operation"]) {
+  requireText(diagnosticContext, `${field}: &'static str`, `${paths.source}: bounded ${field}`);
+}
+for (const forbidden of ["Uuid", "Option<", "String"]) {
+  forbidText(diagnosticContext, forbidden, `${paths.source}: mutation context storage`);
+}
+
+const contextConversion = blockBetween(
+  source,
+  "impl From<&AdminOrderErrorContext> for AdminOrderMutationDiagnosticContext {",
+  "struct AdminOrderMutationDiagnosticError;",
+  "mutation context conversion",
+);
+for (const marker of [
+  "tenant_id: uuid_shape(context.tenant_id)",
+  "actor_id: uuid_shape(context.actor_id)",
+  "order_id: optional_uuid_shape(context.order_id)",
+  "customer_id: optional_uuid_shape(context.customer_id)",
+  "operation: context.operation",
+]) requireText(contextConversion, marker, `${paths.source}: mutation context conversion`);
+
+const diagnosticError = blockBetween(
+  source,
+  "struct AdminOrderMutationDiagnosticError;",
+  "fn uuid_shape(",
+  "bounded mutation error",
+);
+for (const marker of [
+  "impl std::fmt::Debug for AdminOrderMutationDiagnosticError",
+  'formatter.write_str("redacted")',
+]) requireText(diagnosticError, marker, `${paths.source}: bounded mutation error`);
+for (const forbidden of ["OrderError", "message:", "source:", "String"]) {
+  forbidText(diagnosticError, forbidden, `${paths.source}: mutation error payload`);
+}
+
+const requiredShape = blockBetween(
+  source,
+  "fn uuid_shape(",
+  "fn optional_uuid_shape(",
+  "required UUID shape",
+);
+for (const marker of ["value.is_nil()", '"nil"', '"non_nil"']) {
+  requireText(requiredShape, marker, `${paths.source}: required UUID shape`);
+}
+
+const optionalShape = blockBetween(
+  source,
+  "fn optional_uuid_shape(",
+  "fn text_presence_shape(",
+  "optional UUID shape",
+);
+for (const marker of [
+  'None => "absent"',
+  'Some(value) if value.is_nil() => "present_nil"',
+  'Some(_) => "present_non_nil"',
+]) requireText(optionalShape, marker, `${paths.source}: optional UUID shape`);
+
+const policy = blockBetween(
+  source,
+  "fn admin_order_error_policy(",
+  "fn map_admin_order_error(",
+  "order mutation policy",
+);
+for (const marker of [
+  "OrderError::Validation(_)",
+  "OrderError::OrderNotFound(_)",
+  "OrderError::OrderReturnNotFound(_)",
+  "OrderError::OrderChangeNotFound(_)",
+  "OrderError::InvalidTransition { .. }",
+  "OrderError::Database(_)",
+  "OrderError::Core(_)",
+  '"commerce_admin_order_invalid"',
+  '"commerce_admin_not_found"',
+  '"commerce_admin_order_state_conflict"',
+  '"commerce_admin_order_storage_unavailable"',
+  '"commerce_admin_order_failed"',
+]) requireText(policy, marker, `${paths.source}: preserved mutation policy`);
+
+const mapper = blockBetween(
+  source,
+  "fn map_admin_order_error(",
+  "/// Show admin ecommerce order",
+  "admin order mutation mapper",
+);
+requireOrder(
+  mapper,
+  [
+    "if let OrderError::OrderNotFound(id) = &error",
+    "context.order_id = Some(*id);",
+    "let (status, code, message, error_kind) = admin_order_error_policy(&error);",
+    "let context = AdminOrderMutationDiagnosticContext::from(&context);",
+    "let error = AdminOrderMutationDiagnosticError;",
+    "tracing::error!(",
+    "HttpError::new(status, code, message)",
+  ],
+  `${paths.source}: identity policy and shadowing order`,
+);
+for (const marker of [
+  "error = ?error",
+  "owner = ADMIN_ORDER_OWNER",
+  "tenant_id = %context.tenant_id",
+  "actor_id = %context.actor_id",
+  "order_id = ?context.order_id",
+  "customer_id = ?context.customer_id",
+  "operation = %context.operation",
+  "error_kind,",
+  "public_code = code",
+  "status = %status",
+  "boundary = ADMIN_ORDER_BOUNDARY",
+  '"commerce admin order operation failed"',
+]) requireText(mapper, marker, `${paths.source}: bounded mutation log site`);
+for (const forbidden of [
+  "error.to_string()",
+  "error.message",
+  "format!(",
+  "tracing::error!(\n        error = ?error,\n        owner = ADMIN_ORDER_OWNER,\n        tenant_id = %context.tenant_id",
+]) {
+  if (forbidden.startsWith("tracing::error!")) continue;
+  forbidText(mapper, forbidden, `${paths.source}: raw mutation payload`);
+}
+
+requireCount(source, "map_admin_order_error(", 5, "one mutation mapper and four callsites");
+requireCount(source, "map_admin_order_port_error(", 3, "one read mapper and two callsites");
+requireCount(source, "&[Permission::ORDERS_UPDATE]", 4, "four mutation permissions");
+for (const marker of [
+  '"mark_order_paid"',
+  '"ship_order"',
+  '"deliver_order"',
+  '"cancel_order"',
+  ".mark_paid(",
+  ".ship_order(",
+  ".deliver_order(tenant.id, auth.user_id, id, input.delivered_signature)",
+  ".cancel_order(tenant.id, auth.user_id, id, input.reason)",
+]) requireText(source, marker, `${paths.source}: preserved mutation route`);
+
+for (const marker of [
+  "fn map_admin_order_port_error(",
+  "AdminOrderReadDiagnosticContext::from(&context)",
+  "AdminOrderReadPortDiagnosticContext::from(port_context)",
+  "fn map_order_detail_payment_error(",
+  "fn map_order_detail_fulfillment_error(",
+  '"commerce admin order detail payment lookup failed"',
+  '"commerce admin order detail fulfillment lookup failed"',
+]) requireText(source, marker, `${paths.source}: unchanged neighboring mapper`);
+
+for (const marker of [
+  "if let OrderError::OrderNotFound(id) = &error",
+  "context.order_id = Some(*id);",
+  "error = ?error",
+  "HttpError::new(status, code, message)",
+]) requireText(broadVerifier, marker, `${paths.broadVerifier}: compatibility marker`);
+
+if (
+  evidence.status !==
+  "commerce_admin_order_mutation_diagnostic_safety_source_reviewed_unvalidated"
+) failures.push(`${paths.evidence}: unexpected status ${evidence.status}`);
+for (const [key, expected] of Object.entries({
+  raw_order_error_logged: false,
+  raw_tenant_uuid_logged: false,
+  raw_actor_uuid_logged: false,
+  raw_order_uuid_logged: false,
+  raw_customer_uuid_logged: false,
+  redacted_error_debug_logged: true,
+  required_uuid_shapes_logged: true,
+  optional_uuid_shapes_logged: true,
+  operation_preserved: true,
+  order_not_found_identity_adoption_preserved: true,
+  typed_policy_selection_precedes_shadowing: true,
+  order_error_policy_preserved: true,
+  http_envelopes_preserved: true,
+  four_mutation_callsites_preserved: true,
+  orders_update_permission_preserved: true,
+  read_mapper_unchanged: true,
+  detail_payment_mapper_unchanged: true,
+  detail_fulfillment_mapper_unchanged: true,
+  existing_broad_verifier_markers_preserved: true,
+  broad_ecommerce_cleanup_closed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
+  }
+}
+for (const key of [
+  "tests_run",
+  "cargo_run",
+  "format_run",
+  "verifiers_run",
+  "workflow_checks_run",
+  "ci_run",
+  "compile_proven",
+  "runtime_proven",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`${paths.evidence}: validation.${key} must remain false`);
+  }
+}
+
+for (const marker of [
+  "Status: **source-ready / unvalidated**",
+  "order-not-found identity adoption and HTTP policy selection",
+  "Debug output is always `redacted`",
+  "The broader ecommerce correlation-safe mapper and non-`PortError` envelope cleanup remains open.",
+]) requireText(doc, marker, `${paths.doc}: documentation contract`);
+requireText(
+  plan,
+  "Finish correlation-safe mapper cleanup",
+  `${paths.plan}: broad cleanup remains open`,
+);
+
+if (failures.length > 0) {
+  console.error("Commerce admin order mutation diagnostic verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "Commerce admin order mutation diagnostics are bounded while identity adoption, four owner calls, permissions, and HTTP policies remain unchanged; execution validation remains open",
+);


### PR DESCRIPTION
## Summary

Continue the ecommerce correlation-safe mapper cleanup at the Commerce admin order mutation boundary.

- retain typed `OrderError` and `AdminOrderErrorContext` through order-not-found identity adoption and HTTP policy selection
- shadow the typed error before the shared mutation failure event with a diagnostic type whose Debug output is always `redacted`
- replace tenant, actor, order, and customer UUID payloads with closed UUID-shape labels
- preserve the static operation, error kind, public code, HTTP status, owner, boundary, and event message
- preserve all four mark-paid, ship, deliver, and cancel callsites, `ORDERS_UPDATE`, owner calls, and forwarded inputs
- leave the admin order read mapper and order-detail payment/fulfillment mappers unchanged
- retain existing broad-verifier log-site expressions against bounded shadow values
- add focused source-only evidence, documentation, and a fail-closed static guard

## Preserved behavior

- `OrderError` to HTTP policy mapping
- `OrderError::OrderNotFound` identity adoption
- public status, code, and message selection
- `HttpError::new(status, code, message)` construction
- four mutation routes, permissions, owner calls, and successful response contracts
- read, payment-detail, and fulfillment-detail mapper behavior

## Validation

Tests, Node verifiers, formatting, Cargo checks, workflows, and CI were not run per maintainer request. Evidence remains source-reviewed/unvalidated.