### PR TITLE
test(pages): retain anonymous storefront graph boundary

### DIFF
--- a/crates/rustok-pages/contracts/evidence/pages-anonymous-storefront-graph-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-anonymous-storefront-graph-source.json
@@ -1,0 +1,107 @@
+{
+  "format": "pages_anonymous_storefront_graph_source_v1",
+  "status": "pages_anonymous_storefront_graph_source_unvalidated",
+  "date": "2026-08-05",
+  "scope": "Pages and Page Builder anonymous storefront dependency graph",
+  "execution": [],
+  "validation": {
+    "verifier_run": false,
+    "cargo_metadata_run": false,
+    "cargo_build_run": false,
+    "csr_bundle_run": false,
+    "hydrate_bundle_run": false,
+    "ssr_bundle_run": false,
+    "bundle_bytes_inspected": false,
+    "browser_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "runtime_proven": false
+  },
+  "source_contract": {
+    "pages_storefront_manifest_checked": true,
+    "page_builder_storefront_manifest_checked": true,
+    "host_storefront_manifest_checked": true,
+    "pages_storefront_default_profile_defined": true,
+    "pages_storefront_hydrate_profile_defined": true,
+    "pages_storefront_ssr_profile_defined": true,
+    "host_storefront_csr_profile_defined": true,
+    "host_storefront_hydrate_profile_defined": true,
+    "host_storefront_ssr_profile_defined": true,
+    "feature_resolved_cargo_metadata_required": true,
+    "dev_dependencies_excluded_from_reachability": true,
+    "storefront_source_trees_scanned": true,
+    "pages_admin_forbidden": true,
+    "page_builder_admin_forbidden": true,
+    "admin_host_forbidden": true,
+    "fly_browser_forbidden": true,
+    "fly_ui_forbidden": true,
+    "fly_leptos_forbidden": true,
+    "page_builder_storefront_required_for_pages_profiles": true,
+    "pages_storefront_required_for_host_ssr": true,
+    "host_client_profiles_keep_optional_pages_module_disabled": true,
+    "actual_bundle_artifact_proof_complete": false,
+    "production_pages_behavior_changed": false,
+    "production_page_builder_behavior_changed": false,
+    "production_storefront_behavior_changed": false,
+    "dependencies_changed": false,
+    "features_changed": false,
+    "database_schema_changed": false,
+    "public_route_changed": false,
+    "ffa_promoted": false,
+    "fba_promoted": false
+  },
+  "profiles": [
+    {
+      "id": "pages-storefront-default",
+      "manifest": "crates/rustok-pages/storefront/Cargo.toml",
+      "features": [],
+      "target": null
+    },
+    {
+      "id": "pages-storefront-hydrate",
+      "manifest": "crates/rustok-pages/storefront/Cargo.toml",
+      "features": ["hydrate"],
+      "target": "wasm32-unknown-unknown"
+    },
+    {
+      "id": "pages-storefront-ssr",
+      "manifest": "crates/rustok-pages/storefront/Cargo.toml",
+      "features": ["ssr"],
+      "target": null
+    },
+    {
+      "id": "host-storefront-csr",
+      "manifest": "apps/storefront/Cargo.toml",
+      "features": ["csr"],
+      "target": "wasm32-unknown-unknown"
+    },
+    {
+      "id": "host-storefront-hydrate",
+      "manifest": "apps/storefront/Cargo.toml",
+      "features": ["hydrate"],
+      "target": "wasm32-unknown-unknown"
+    },
+    {
+      "id": "host-storefront-ssr",
+      "manifest": "apps/storefront/Cargo.toml",
+      "features": ["ssr"],
+      "target": null
+    }
+  ],
+  "forbidden_packages": [
+    "rustok-pages-admin",
+    "rustok-page-builder-admin",
+    "rustok-admin",
+    "fly-browser",
+    "fly-ui",
+    "fly-leptos"
+  ],
+  "verifier": "crates/rustok-pages/scripts/verify/verify-pages-anonymous-storefront-graph.mjs",
+  "packet": "docs/modules/pages-page-builder-anonymous-storefront-graph-packet-2026-08-05.md",
+  "notes": [
+    "The verifier is source-ready but has not been executed.",
+    "cargo metadata reachability is a dependency-graph proof, not compiled bundle-byte evidence.",
+    "CSR and hydrate host profiles currently leave the optional Pages module disabled; the Pages storefront hydrate profile is checked separately.",
+    "Accepted SSR/CSR/hydrate build and bundle artifact evidence remains pending."
+  ]
+}

--- a/crates/rustok-pages/docs/implementation-plan.md
+++ b/crates/rustok-pages/docs/implementation-plan.md
@@ -132,6 +132,10 @@ Pages persistence, cache scope or tenant policy.
   exact/fallback owner reads and a persisted draft body mutation. The binding,
   artifact hash and document HTML remain unchanged and the draft-only marker never
   becomes public output.
+- [x] An anonymous storefront dependency graph verifier defines six feature-resolved
+  `cargo metadata` profiles for Pages default/hydrate/SSR and host CSR/hydrate/SSR.
+  It excludes dev-dependencies and fails if any non-dev edge reaches Pages admin,
+  Page Builder admin, the admin host, or Fly browser/editor crates.
 - [ ] Accepted evidence must prove publish and rollback events rotate generations,
   causing misses and refills on storefront and artifact delivery paths through the
   production gate.
@@ -139,7 +143,7 @@ Pages persistence, cache scope or tenant policy.
   content is not public render authority and can become public only through a later
   reviewed publish or rollback binding replacement.
 - [ ] Authenticated real-DOM inline editing is not implemented.
-- [ ] Anonymous bundle exclusion evidence is not complete.
+- [ ] Compiled SSR/CSR/hydrate bundle artifact evidence remains open.
 
 ### Page Builder/FBA
 
@@ -202,6 +206,10 @@ Pages persistence, cache scope or tenant policy.
 - [x] The selected immutable published artifact regression proves Page Builder owns
   artifact production while Pages body identity and published binding own public
   selection; a persisted draft body mutation cannot replace the selected output.
+- [x] The anonymous dependency-graph source keeps the read-only
+  `rustok-page-builder-storefront → rustok-page-builder → fly` chain while
+  forbidding `rustok-page-builder-admin`, `fly-browser`, `fly-ui` and `fly-leptos`
+  in every retained non-dev graph.
 - [ ] Accepted execution evidence must correlate publish/rollback receipts, outbox
   events, production-gate receipts, generation changes, cache misses and refills.
 - [ ] Observed tenant Wave 0/Wave 1 evidence remains open.
@@ -211,16 +219,18 @@ Pages persistence, cache scope or tenant policy.
 - **FFA:** `in_progress` — reviewed publication, typed rollback control, explicit
   promoted-scenario selection, registered draft/published metadata surfaces,
   generation-aware storefront/artifact readers, production generation gating,
-  gate-to-native-route, PostgreSQL retry, local profile and selected immutable
-  artifact source packets are connected. Executed metadata conflict/isolation,
-  inline edit mode and anonymous bundle evidence remain open.
+  gate-to-native-route, PostgreSQL retry, local profile, selected immutable
+  artifact and anonymous dependency-graph source packets are connected. Executed
+  metadata conflict/isolation, inline edit mode and compiled bundle evidence remain
+  open.
 - **FBA:** `in_progress` — reviewed runtime, authoritative sanitizer, immutable
   materialization evidence, idempotent publish and rollback services,
   GraphQL/HTTP/admin transports, default-runtime removal and production-gated cache
   invalidation/read boundaries are integrated at source level. Server and owner
   harnesses retain native-route key rotation, PostgreSQL retry semantics,
-  Memory/OutboxLocal composition and draft-vs-published artifact isolation, but
-  execution, rollback proof, verification and observed rollout evidence remain open.
+  Memory/OutboxLocal composition, draft-vs-published artifact isolation and
+  storefront graph exclusion, but execution, bundle artifacts, rollback proof,
+  verification and observed rollout evidence remain open.
 - **Structural shape:** `core_transport_ui` with one current document authority.
 
 ## Ownership boundaries
@@ -357,7 +367,9 @@ Invariants:
     published binding, not the mutable body content.
 26. Missing providers fail visibly and never cause silent deletion.
 27. Dynamic widgets persist versioned configuration, not privileged snapshots.
-28. Anonymous storefront bundles contain no editor code.
+28. Feature-resolved anonymous storefront graphs exclude admin and Fly authoring
+    packages through non-dev dependencies; compiled bundle artifact proof remains
+    required.
 29. No block or shadow-editor fallback exists.
 
 ## Completed slice — 2026-07-21
@@ -459,6 +471,8 @@ Invariants:
   before relay-gated rotation, listener delivery and durable acknowledgement.
 - Added the selected immutable published artifact regression: exact and fallback
   reads retain the same binding/hash/HTML across a persisted draft body mutation.
+- Added the anonymous storefront dependency graph verifier for six feature-resolved
+  profiles, excluding dev-dependencies and forbidding admin/Fly authoring packages.
 - Added source evidence, static verifiers and dated production/owner packets.
 - Tests, verifiers, formatters, Cargo commands, databases, runtime profiles,
   workflows and CI were not executed in this slice.
@@ -533,7 +547,10 @@ Invariants:
 - [ ] Compose Navigation-owned menus, SEO and channel visibility with
   generation-aware deterministic cache keys.
 - [ ] Implement authenticated real-DOM inline editing behind permissions/flags.
-- [ ] Prove anonymous SSR/CSR/hydrate bundles exclude authoring code.
+- [x] Retain the anonymous storefront dependency graph verifier across Pages
+  default/hydrate/SSR and host CSR/hydrate/SSR profiles.
+- [ ] Retain compiled SSR/CSR/hydrate bundle artifact evidence proving authoring
+  code and packages remain absent.
 - [ ] Prove admin preview, published output and inline edit parity.
 
 ### P2 — operations and rollout
@@ -562,6 +579,7 @@ Invariants:
 - `cargo test -p rustok-pages-admin metadata_save_is_document_free_and_preserves_dirty_fly_state`
 - `node crates/rustok-pages/scripts/verify/verify-pages-selected-immutable-artifact.mjs`
 - `cargo test -p rustok-pages --test selected_immutable_published_artifact_sqlite -- --nocapture`
+- `node crates/rustok-pages/scripts/verify/verify-pages-anonymous-storefront-graph.mjs`
 - `node crates/rustok-pages/scripts/verify/verify-pages-cache-invalidation.mjs`
 - `node crates/rustok-pages/scripts/verify/verify-pages-production-relay-generation-gate.mjs`
 - `node crates/rustok-pages/scripts/verify/verify-pages-production-relay-native-route.mjs`

--- a/crates/rustok-pages/scripts/verify/verify-pages-anonymous-storefront-graph.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-anonymous-storefront-graph.mjs
@@ -331,8 +331,8 @@ for (const raw of evidence.profiles) {
 
 for (const marker of [
   "source-ready / execution-pending",
-  "six feature-resolved graphs",
-  "dev-dependencies are excluded",
+  "Six feature-resolved graphs",
+  "Dev-dependencies are excluded",
   "compiled bundle artifact evidence remains pending"
 ]) {
   need(packet, marker, "anonymous storefront graph packet");
@@ -347,7 +347,7 @@ for (const marker of [
 }
 for (const marker of [
   "anonymous storefront dependency graph verifier",
-  "compiled SSR/CSR/hydrate bundle artifact evidence remains open"
+  "Compiled SSR/CSR/hydrate bundle artifact evidence remains open"
 ]) {
   need(localPlan, marker, "Pages local plan");
 }

--- a/crates/rustok-pages/scripts/verify/verify-pages-anonymous-storefront-graph.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-anonymous-storefront-graph.mjs
@@ -1,0 +1,362 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "..", "..", "..", "..");
+const failures = [];
+
+const evidencePath =
+  "crates/rustok-pages/contracts/evidence/pages-anonymous-storefront-graph-source.json";
+const packetPath =
+  "docs/modules/pages-page-builder-anonymous-storefront-graph-packet-2026-08-05.md";
+const planPath = "docs/modules/pages-page-builder-parity-continuation-plan.md";
+const localPlanPath = "crates/rustok-pages/docs/implementation-plan.md";
+
+const read = (relativePath) =>
+  readFileSync(path.join(repoRoot, relativePath), "utf8");
+const need = (text, marker, label) => {
+  if (!text.includes(marker)) failures.push(`${label}: missing ${marker}`);
+};
+const forbid = (text, marker, label) => {
+  if (text.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+};
+
+const evidence = JSON.parse(read(evidencePath));
+const packet = read(packetPath);
+const plan = read(planPath);
+const localPlan = read(localPlanPath);
+const pagesManifestPath = "crates/rustok-pages/storefront/Cargo.toml";
+const builderManifestPath = "crates/rustok-page-builder-storefront/Cargo.toml";
+const hostManifestPath = "apps/storefront/Cargo.toml";
+const pagesManifest = read(pagesManifestPath);
+const builderManifest = read(builderManifestPath);
+const hostManifest = read(hostManifestPath);
+
+if (evidence.format !== "pages_anonymous_storefront_graph_source_v1") {
+  failures.push(`evidence format mismatch: ${evidence.format}`);
+}
+if (evidence.status !== "pages_anonymous_storefront_graph_source_unvalidated") {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push("execution evidence must remain empty");
+}
+for (const [key, value] of Object.entries(evidence.validation ?? {})) {
+  if (value !== false) failures.push(`validation.${key} must remain false`);
+}
+for (const key of [
+  "pages_storefront_manifest_checked",
+  "page_builder_storefront_manifest_checked",
+  "host_storefront_manifest_checked",
+  "pages_storefront_default_profile_defined",
+  "pages_storefront_hydrate_profile_defined",
+  "pages_storefront_ssr_profile_defined",
+  "host_storefront_csr_profile_defined",
+  "host_storefront_hydrate_profile_defined",
+  "host_storefront_ssr_profile_defined",
+  "feature_resolved_cargo_metadata_required",
+  "dev_dependencies_excluded_from_reachability",
+  "storefront_source_trees_scanned",
+  "pages_admin_forbidden",
+  "page_builder_admin_forbidden",
+  "admin_host_forbidden",
+  "fly_browser_forbidden",
+  "fly_ui_forbidden",
+  "fly_leptos_forbidden",
+  "page_builder_storefront_required_for_pages_profiles",
+  "pages_storefront_required_for_host_ssr",
+  "host_client_profiles_keep_optional_pages_module_disabled"
+]) {
+  if (evidence.source_contract?.[key] !== true) {
+    failures.push(`source_contract.${key} must be true`);
+  }
+}
+for (const key of [
+  "actual_bundle_artifact_proof_complete",
+  "production_pages_behavior_changed",
+  "production_page_builder_behavior_changed",
+  "production_storefront_behavior_changed",
+  "dependencies_changed",
+  "features_changed",
+  "database_schema_changed",
+  "public_route_changed",
+  "ffa_promoted",
+  "fba_promoted"
+]) {
+  if (evidence.source_contract?.[key] !== false) {
+    failures.push(`source_contract.${key} must be false`);
+  }
+}
+
+const expectedProfiles = [
+  ["pages-storefront-default", pagesManifestPath, [], null],
+  ["pages-storefront-hydrate", pagesManifestPath, ["hydrate"], "wasm32-unknown-unknown"],
+  ["pages-storefront-ssr", pagesManifestPath, ["ssr"], null],
+  ["host-storefront-csr", hostManifestPath, ["csr"], "wasm32-unknown-unknown"],
+  ["host-storefront-hydrate", hostManifestPath, ["hydrate"], "wasm32-unknown-unknown"],
+  ["host-storefront-ssr", hostManifestPath, ["ssr"], null]
+];
+const actualProfiles = (evidence.profiles ?? []).map((profile) => [
+  profile.id,
+  profile.manifest,
+  profile.features,
+  profile.target
+]);
+if (JSON.stringify(actualProfiles) !== JSON.stringify(expectedProfiles)) {
+  failures.push("evidence profile matrix does not match the retained six-profile contract");
+}
+
+const forbiddenPackages = new Set([
+  "rustok-pages-admin",
+  "rustok-page-builder-admin",
+  "rustok-admin",
+  "fly-browser",
+  "fly-ui",
+  "fly-leptos"
+]);
+if (
+  JSON.stringify([...forbiddenPackages]) !==
+  JSON.stringify(evidence.forbidden_packages)
+) {
+  failures.push("forbidden package set does not match evidence");
+}
+
+for (const marker of [
+  'default = []',
+  '"rustok-page-builder-storefront/hydrate"',
+  '"rustok-page-builder-storefront/ssr"',
+  'rustok-page-builder-storefront = { path = "../../rustok-page-builder-storefront" }'
+]) {
+  need(pagesManifest, marker, "Pages storefront manifest");
+}
+for (const forbidden of [
+  "rustok-pages-admin",
+  "rustok-page-builder-admin",
+  "rustok-admin",
+  "fly-browser",
+  "fly-ui",
+  "fly-leptos"
+]) {
+  forbid(pagesManifest, forbidden, "Pages storefront manifest");
+}
+
+for (const marker of [
+  'default = []',
+  'hydrate = ["leptos/hydrate"]',
+  'ssr = ["leptos/ssr"]',
+  'fly = { path = "../fly" }',
+  'rustok-page-builder = { path = "../rustok-page-builder", default-features = false }'
+]) {
+  need(builderManifest, marker, "Page Builder storefront manifest");
+}
+for (const forbidden of forbiddenPackages) {
+  forbid(builderManifest, forbidden, "Page Builder storefront manifest");
+}
+
+for (const marker of [
+  'csr = ["leptos/csr", "leptos_i18n/csr"]',
+  'hydrate = ["leptos/hydrate", "leptos_i18n/hydrate"]',
+  '"rustok-pages-storefront/ssr"',
+  'rustok-pages-storefront = { path = "../../crates/rustok-pages/storefront", default-features = false, optional = true }'
+]) {
+  need(hostManifest, marker, "host storefront manifest");
+}
+for (const forbidden of forbiddenPackages) {
+  forbid(hostManifest, forbidden, "host storefront manifest");
+}
+
+function walkRustFiles(relativeDirectory) {
+  const absoluteDirectory = path.join(repoRoot, relativeDirectory);
+  if (!existsSync(absoluteDirectory)) {
+    failures.push(`source tree missing: ${relativeDirectory}`);
+    return [];
+  }
+  const result = [];
+  const stack = [absoluteDirectory];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    for (const entry of readdirSync(current)) {
+      const absolute = path.join(current, entry);
+      const stat = statSync(absolute);
+      if (stat.isDirectory()) stack.push(absolute);
+      else if (entry.endsWith(".rs")) result.push(absolute);
+    }
+  }
+  return result;
+}
+
+const forbiddenSourceMarkers = [
+  "rustok_pages_admin",
+  "rustok_page_builder_admin",
+  "fly_browser",
+  "fly_ui",
+  "fly_leptos",
+  "PagesAdmin",
+  "PagesFlyBuilder",
+  "PageBuilderAdminHostContext",
+  "PageBuilderAdmin",
+  "ConsumerPropertiesPanel"
+];
+for (const sourceRoot of [
+  "crates/rustok-pages/storefront/src",
+  "crates/rustok-page-builder-storefront/src",
+  "apps/storefront/src"
+]) {
+  for (const file of walkRustFiles(sourceRoot)) {
+    const source = readFileSync(file, "utf8");
+    const label = path.relative(repoRoot, file);
+    for (const marker of forbiddenSourceMarkers) {
+      forbid(source, marker, label);
+    }
+  }
+}
+
+function cargoMetadata(profile) {
+  const args = [
+    "metadata",
+    "--format-version",
+    "1",
+    "--manifest-path",
+    path.join(repoRoot, profile.manifest),
+    "--no-default-features"
+  ];
+  if (profile.features.length > 0) {
+    args.push("--features", profile.features.join(","));
+  }
+  if (profile.target) {
+    args.push("--filter-platform", profile.target);
+  }
+  const result = spawnSync("cargo", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, CARGO_TERM_COLOR: "never" }
+  });
+  if (result.error) {
+    failures.push(`${profile.id}: cargo metadata failed to start: ${result.error.message}`);
+    return null;
+  }
+  if (result.status !== 0) {
+    const diagnostic = `${result.stderr ?? ""}`.trim().slice(0, 4000);
+    failures.push(`${profile.id}: cargo metadata exited ${result.status}: ${diagnostic}`);
+    return null;
+  }
+  try {
+    return JSON.parse(result.stdout);
+  } catch (error) {
+    failures.push(`${profile.id}: invalid cargo metadata JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function reachableNonDevPackages(metadata, profile) {
+  const manifest = path.resolve(repoRoot, profile.manifest);
+  const rootPackage = metadata.packages.find(
+    (candidate) => path.resolve(candidate.manifest_path) === manifest
+  );
+  if (!rootPackage) {
+    failures.push(`${profile.id}: root package not found for ${profile.manifest}`);
+    return new Set();
+  }
+  const nodeById = new Map((metadata.resolve?.nodes ?? []).map((node) => [node.id, node]));
+  const packageById = new Map(metadata.packages.map((pkg) => [pkg.id, pkg]));
+  const seen = new Set();
+  const stack = [rootPackage.id];
+  while (stack.length > 0) {
+    const id = stack.pop();
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const node = nodeById.get(id);
+    if (!node) continue;
+    for (const dep of node.deps ?? []) {
+      const kinds = dep.dep_kinds ?? [];
+      const reachable =
+        kinds.length === 0 || kinds.some((kind) => kind.kind !== "dev");
+      if (reachable) stack.push(dep.pkg);
+    }
+  }
+  return new Set(
+    [...seen]
+      .map((id) => packageById.get(id)?.name)
+      .filter((name) => typeof name === "string")
+  );
+}
+
+for (const raw of evidence.profiles) {
+  const profile = {
+    id: raw.id,
+    manifest: raw.manifest,
+    features: raw.features,
+    target: raw.target
+  };
+  const metadata = cargoMetadata(profile);
+  if (!metadata) continue;
+  const packages = reachableNonDevPackages(metadata, profile);
+  for (const forbiddenPackage of forbiddenPackages) {
+    if (packages.has(forbiddenPackage)) {
+      failures.push(`${profile.id}: reaches forbidden authoring package ${forbiddenPackage}`);
+    }
+  }
+  const required = new Set();
+  if (profile.id.startsWith("pages-storefront-")) {
+    required.add("rustok-pages-storefront");
+    required.add("rustok-page-builder-storefront");
+    required.add("fly");
+    required.add("rustok-page-builder");
+  }
+  if (profile.id === "pages-storefront-ssr") required.add("rustok-pages");
+  if (profile.id === "host-storefront-ssr") {
+    required.add("rustok-storefront");
+    required.add("rustok-pages-storefront");
+    required.add("rustok-page-builder-storefront");
+  }
+  if (profile.id === "host-storefront-csr" || profile.id === "host-storefront-hydrate") {
+    required.add("rustok-storefront");
+    if (packages.has("rustok-pages-storefront")) {
+      failures.push(`${profile.id}: optional Pages storefront unexpectedly enabled`);
+    }
+  }
+  for (const packageName of required) {
+    if (!packages.has(packageName)) {
+      failures.push(`${profile.id}: missing required package ${packageName}`);
+    }
+  }
+}
+
+for (const marker of [
+  "source-ready / execution-pending",
+  "six feature-resolved graphs",
+  "dev-dependencies are excluded",
+  "compiled bundle artifact evidence remains pending"
+]) {
+  need(packet, marker, "anonymous storefront graph packet");
+}
+for (const marker of [
+  "anonymous-storefront-graph-source-ready",
+  "Anonymous storefront authoring exclusion: source-ready",
+  "feature-resolved `cargo metadata`",
+  "bundle artifact execution remains pending"
+]) {
+  need(plan, marker, "canonical Pages/Page Builder plan");
+}
+for (const marker of [
+  "anonymous storefront dependency graph verifier",
+  "compiled SSR/CSR/hydrate bundle artifact evidence remains open"
+]) {
+  need(localPlan, marker, "Pages local plan");
+}
+
+if (failures.length > 0) {
+  console.error("[verify-pages-anonymous-storefront-graph] FAIL");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+console.log(
+  "[verify-pages-anonymous-storefront-graph] PASS graph_profiles=6 authoring_packages=excluded bundle_artifact_execution=pending"
+);

--- a/crates/rustok-pages/scripts/verify/verify-pages-publish-rollback-cache-correlation.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-publish-rollback-cache-correlation.mjs
@@ -238,10 +238,11 @@ for (const [value, label] of [
 }
 
 for (const marker of [
-  "Publish/rollback cache correlation source packet: ready, unvalidated",
+  "production-relay-generation-gate-source-ready",
+  "Production gate PostgreSQL publish/rollback restart: source-ready",
   "event/correlation-bound receipt",
-  "old generation keys remain physically present but unreachable",
-  "Execution remains pending",
+  "retain old-generation values physically",
+  "execution remains pending",
 ]) {
   requireText(parityPlan, marker, "parity continuation plan");
 }

--- a/docs/modules/pages-page-builder-anonymous-storefront-graph-packet-2026-08-05.md
+++ b/docs/modules/pages-page-builder-anonymous-storefront-graph-packet-2026-08-05.md
@@ -1,0 +1,97 @@
+# Pages / Page Builder Anonymous Storefront Graph Packet
+
+Date: 2026-08-05  
+Status: **source-ready / execution-pending**
+
+## Purpose
+
+Retain a fail-closed dependency-graph guard for the anonymous storefront boundary without changing Pages, Page Builder or host runtime behavior.
+
+The packet addresses the source gap between two weaker claims:
+
+1. the storefront manifests do not directly name an admin package;
+2. the resolved anonymous SSR/CSR/hydrate dependency graph cannot reach an authoring package transitively.
+
+The existing Pages UI boundary verifier retains the first claim. This packet adds the second.
+
+## Six feature-resolved graphs
+
+The verifier invokes `cargo metadata` for these exact profiles:
+
+| Profile | Manifest | Features | Target |
+| --- | --- | --- | --- |
+| Pages storefront default | `crates/rustok-pages/storefront/Cargo.toml` | none | host |
+| Pages storefront hydrate | `crates/rustok-pages/storefront/Cargo.toml` | `hydrate` | `wasm32-unknown-unknown` |
+| Pages storefront SSR | `crates/rustok-pages/storefront/Cargo.toml` | `ssr` | host |
+| Host storefront CSR | `apps/storefront/Cargo.toml` | `csr` | `wasm32-unknown-unknown` |
+| Host storefront hydrate | `apps/storefront/Cargo.toml` | `hydrate` | `wasm32-unknown-unknown` |
+| Host storefront SSR | `apps/storefront/Cargo.toml` | `ssr` | host |
+
+Every command uses `--no-default-features`. Target filtering is explicit for browser profiles.
+
+## Reachability policy
+
+The verifier starts at the selected root package and walks the resolved Cargo graph. **Dev-dependencies are excluded** from reachability, while normal and build dependencies remain visible.
+
+The following packages are forbidden at every depth:
+
+- `rustok-pages-admin`;
+- `rustok-page-builder-admin`;
+- `rustok-admin`;
+- `fly-browser`;
+- `fly-ui`;
+- `fly-leptos`.
+
+The Pages storefront profiles must retain the read-only chain:
+
+```text
+rustok-pages-storefront
+  → rustok-page-builder-storefront
+  → rustok-page-builder
+  → fly
+```
+
+The Pages SSR profile must additionally reach the Pages owner crate. The host SSR profile must reach both Pages storefront crates. Current host CSR/hydrate profiles leave the optional Pages module disabled; the Pages hydrate graph is therefore checked separately rather than pretending the host currently ships it.
+
+## Source-tree guard
+
+The verifier also scans Rust sources under:
+
+- `crates/rustok-pages/storefront/src`;
+- `crates/rustok-page-builder-storefront/src`;
+- `apps/storefront/src`.
+
+Imports and composition markers for Pages admin, Page Builder admin and Fly browser/editor surfaces are forbidden. This protects the package graph and the module entrypoints together.
+
+## Boundaries
+
+This packet does not:
+
+- change Cargo dependencies or features;
+- change Pages or Page Builder production code;
+- change SSR, CSR or hydrate composition;
+- build a binary, WASM module or JavaScript bundle;
+- inspect compiled bundle bytes, source maps or chunk manifests;
+- prove runtime authentication or inline-edit behavior;
+- promote FFA or FBA status.
+
+A passing graph verifier proves that the selected Cargo feature graphs cannot reach the named authoring packages through non-dev dependencies. It is not compiled bundle-byte evidence.
+
+## Evidence
+
+- verifier: `crates/rustok-pages/scripts/verify/verify-pages-anonymous-storefront-graph.mjs`;
+- machine evidence: `crates/rustok-pages/contracts/evidence/pages-anonymous-storefront-graph-source.json`;
+- canonical cursor: `docs/modules/pages-page-builder-parity-continuation-plan.md`;
+- Pages-local cursor: `crates/rustok-pages/docs/implementation-plan.md`.
+
+The evidence execution list is empty and every validation flag remains false.
+
+## Maintainer validation
+
+Intentionally not run in this slice:
+
+```bash
+node crates/rustok-pages/scripts/verify/verify-pages-anonymous-storefront-graph.mjs
+```
+
+After the graph verifier passes, accepted compiled bundle artifact evidence remains pending for anonymous SSR, CSR and hydrate outputs.

--- a/docs/modules/pages-page-builder-parity-continuation-plan.md
+++ b/docs/modules/pages-page-builder-parity-continuation-plan.md
@@ -1,7 +1,7 @@
 # Pages / Page Builder Parity Continuation Plan
 
 Date: 2026-08-05
-Status: source-parity-current / selected-immutable-artifact-source-ready / execution-evidence-pending
+Status: source-parity-current / anonymous-storefront-graph-source-ready / execution-evidence-pending
 Scope: `rustok-pages` admin/storefront FFA and `rustok-page-builder` consumer-property, publication, artifact, event and cache boundaries
 
 ## Source-of-truth policy
@@ -31,6 +31,8 @@ The current source was rechecked against:
 - the module `EventDispatcher` filtering and asynchronous handler execution;
 - the native storefront adapter, registered Leptos server function and public artifact HTTP route;
 - `PageBuilderArtifactService::load_public_bound_artifact_with_fallback` and the locale-body published binding;
+- the Pages storefront, Page Builder storefront and host storefront manifests;
+- the feature-resolved non-dev dependency graphs selected by `cargo metadata`;
 - the Channel owner module-binding contract;
 - recent merged Pages parity PRs and their dated packets.
 
@@ -53,9 +55,10 @@ Current `main` contains:
 - PR #3001 — production synchronous Pages generation gate with process-bounded same-event dedupe;
 - PR #3004 — production gate to registered native route continuity source;
 - PR #3006 — production-gate PostgreSQL publish/rollback and restart-retry source;
-- PR #3008 — factory-selected Memory and OutboxLocal delivery profile parity source.
+- PR #3008 — factory-selected Memory and OutboxLocal delivery profile parity source;
+- PR #3010 — selected immutable artifact authority across persisted draft mutation.
 
-The current slice retains the Pages owner invariant that a persisted current Fly body can advance after publication without replacing the selected immutable published artifact. It changes no production behavior and does not extend optional event infrastructure.
+The current slice retains a feature-resolved anonymous storefront dependency-graph guard. It changes no production behavior, Cargo dependency, feature or optional event infrastructure.
 
 ## Current parity state
 
@@ -102,7 +105,7 @@ The route set remains unexecuted.
 
 ### Selected immutable artifact after draft mutation: source-ready
 
-The focused Pages owner harness now retains the authoring/publication separation directly:
+The focused Pages owner harness retains the authoring/publication separation directly:
 
 ```text
 PageService::create
@@ -131,6 +134,50 @@ Source evidence is retained in:
 - `docs/modules/pages-page-builder-selected-immutable-artifact-packet-2026-08-05.md`.
 
 SQLite execution remains pending.
+
+### Anonymous storefront authoring exclusion: source-ready
+
+The new source packet defines six feature-resolved `cargo metadata` profiles:
+
+```text
+Pages storefront
+  → default
+  → hydrate / wasm32-unknown-unknown
+  → ssr
+
+host storefront
+  → csr / wasm32-unknown-unknown
+  → hydrate / wasm32-unknown-unknown
+  → ssr
+```
+
+The verifier starts from each selected root package and walks normal/build dependency edges only; dev-dependencies are excluded. Every graph fails closed if it reaches:
+
+- `rustok-pages-admin`;
+- `rustok-page-builder-admin`;
+- `rustok-admin`;
+- `fly-browser`;
+- `fly-ui`;
+- `fly-leptos`.
+
+The retained read-only Pages chain is:
+
+```text
+rustok-pages-storefront
+  → rustok-page-builder-storefront
+  → rustok-page-builder
+  → fly
+```
+
+The source trees of Pages storefront, Page Builder storefront and the host storefront are also scanned for admin/editor imports and composition markers. Current host CSR/hydrate profiles leave the optional Pages module disabled, so the Pages hydrate graph is checked separately rather than overstating host client composition.
+
+Source evidence is retained in:
+
+- `crates/rustok-pages/contracts/evidence/pages-anonymous-storefront-graph-source.json`;
+- `crates/rustok-pages/scripts/verify/verify-pages-anonymous-storefront-graph.mjs`;
+- `docs/modules/pages-page-builder-anonymous-storefront-graph-packet-2026-08-05.md`.
+
+This is source-ready graph proof only. The verifier has not been executed, and compiled SSR/CSR/hydrate bundle artifact execution remains pending.
 
 ### Reviewed publish to native refill through synchronous test target: source-ready
 
@@ -312,6 +359,7 @@ This section keeps historical static guards stable while the canonical cursor ad
 - `native-storefront-reviewed-artifact-source-ready`; Native reviewed immutable artifact selection: source-ready. Verification reconstructs the full Page Builder materialization envelope before a registered native storefront miss/refill.
 - `native-storefront-channel-admission-source-ready`; Routed-channel admission before native lookup: source-ready. A populated composite cache cannot bypass channel module admission, and successful reads retain a verified immutable Page Builder artifact.
 - `selected-immutable-artifact-source-ready`; Selected immutable artifact after draft mutation: source-ready. The current Fly body is not public render authority; exact and fallback reads remain bound to the verified immutable artifact until binding replacement.
+- `anonymous-storefront-graph-source-ready`; Anonymous storefront authoring exclusion: source-ready. Six feature-resolved `cargo metadata` graphs forbid admin and Fly authoring packages through non-dev dependencies; bundle artifact execution remains pending.
 - Metadata revision/isolation source packet: ready, unvalidated. A stale metadata revision short-circuits before patch transport; the metadata-only transport request excludes document data; dirty Fly state is not accepted by the metadata owner port. Execution evidence remains pending. Verifier: `verify-pages-metadata-revision-isolation.mjs`.
 - `production-relay-generation-gate-source-ready`; synchronous Pages invalidation now precedes downstream transport acceptance and uses process-bounded dedupe.
 - `production-relay-native-route-source-ready`; Production relay gate to registered native route: source-ready.
@@ -332,24 +380,25 @@ This section keeps historical static guards stable while the canonical cursor ad
 | Native storefront route/cache/admission | Pages/Channel owners | Published artifact contract | Source-ready | SQLite/Axum route set pending |
 | Native reviewed immutable artifact selection | Pages publish/binding/route/cache owners | Review/sanitization/materialization/integrity | Source-ready | SQLite/Axum reviewed route pending |
 | Selected immutable artifact vs current draft body | Pages body/binding/artifact owner | Immutable artifact producer contract | Source-ready | Focused SQLite execution pending |
+| Anonymous storefront dependency graph | Pages/host storefront manifests | Read-only Page Builder storefront chain | Source-ready | Six-profile verifier and compiled bundle artifacts pending |
 | Relay + handler + native refill via test target | Pages publish/outbox/handler/route/cache owners | Reviewed artifact producer contract | Source-ready, topology-corrected | SQLite test-target execution pending |
 | Production relay acknowledgement after Pages invalidation | Server delivery gate / Pages invalidation owner | No delivery ownership | Source-ready | Server unit execution pending |
 | Production relay to registered native route | Server gate / Pages route/cache owners | Reviewed artifact producer contract | Source-ready | Server SQLite/Axum execution pending |
 | Production PostgreSQL publish/rollback and relay retry | Server gate / Pages outbox/cache owners | No delivery ownership | Source-ready | PostgreSQL execution pending |
 | Memory and OutboxLocal factory profiles | Server factory / Pages invalidation owner | No delivery ownership | Source-ready | SQLite profile execution pending |
 | Fly document mutation | Pages builder facade | Fly/Page Builder | Draft-only | Browser/runtime evidence pending |
-| Published Fly authoring | Not allowed | Not mounted | Correctly blocked | Bundle/runtime proof pending |
+| Published Fly authoring | Not allowed | Not mounted | Correctly blocked | Compiled bundle/runtime proof pending |
 
 ## Changes in this slice
 
-1. Add one focused Pages SQLite regression using real reviewed publication, immutable artifact persistence and the locale binding.
-2. Retain exact-locale and fallback-locale public reads before a current body mutation.
-3. Persist a different draft Fly document in `page_bodies.content` after publication.
-4. Prove the locale binding remains unchanged and still points to the selected immutable artifact.
-5. Prove artifact hash and document HTML remain unchanged for exact and fallback reads and exclude the draft-only marker.
-6. Add machine evidence, a fail-closed verifier and a dated packet.
-7. Close the source checkbox that storefront serves only the selected immutable published artifact.
-8. Leave production Pages, Page Builder, storefront, cache, event delivery, dependencies and schemas unchanged.
+1. Add one fail-closed anonymous storefront dependency-graph verifier.
+2. Resolve Pages storefront default, hydrate and SSR feature graphs through `cargo metadata`.
+3. Resolve host storefront CSR, hydrate and SSR feature graphs through `cargo metadata`.
+4. Exclude dev-dependencies while retaining normal and build dependency reachability.
+5. Forbid Pages admin, Page Builder admin, the admin host and Fly browser/editor packages at every depth.
+6. Scan Pages storefront, Page Builder storefront and host storefront Rust sources for authoring imports and composition markers.
+7. Add machine evidence, a dated packet and synchronized canonical/local plans.
+8. Leave production code, Cargo dependencies/features, routes, schemas and runtime behavior unchanged.
 
 ## Boundaries
 
@@ -360,19 +409,21 @@ This slice does not:
 - alter cache namespace names, composite key shape, TTL or capacity;
 - add cache scans or wildcard deletion;
 - change outbox, Pages or Page Builder migrations or DTOs;
+- change Cargo dependencies or feature definitions;
 - change optional event infrastructure;
-- claim tests, Cargo, formatting, verifiers, SQLite, Axum, Leptos, browsers, workflows, CI or rollout execution;
+- build or inspect actual SSR binaries, WASM modules, JavaScript chunks, source maps or bundle manifests;
+- claim tests, Cargo metadata, Cargo builds, formatting, verifiers, browsers, workflows, CI or rollout execution;
 - promote FFA or FBA status.
 
 ## Next cursor
 
-1. Run the selected immutable artifact verifier and focused Pages SQLite regression.
-2. Run the reviewed native storefront artifact verifier and route harness alongside it.
-3. Run the complete native SQLite/Axum route set, including channel admission and artifact HTTP cache.
-4. Run the production relay-native-route, generation-gate and PostgreSQL restart packets.
-5. Run metadata conflict/isolation and published metadata browser packets.
-6. Prove anonymous SSR/CSR/hydrate bundles exclude authoring code.
-7. Complete compile, workflow and observed tenant rollout evidence before promotion.
+1. Run the anonymous storefront graph verifier across all six profiles.
+2. Build anonymous host CSR, hydrate and SSR outputs and retain package/chunk evidence that authoring code remains absent.
+3. Run the selected immutable artifact verifier and focused Pages SQLite regression.
+4. Run the reviewed native storefront artifact verifier and complete native SQLite/Axum route set.
+5. Run the production relay-native-route, generation-gate and PostgreSQL restart packets.
+6. Run metadata conflict/isolation and published metadata browser packets.
+7. Complete workflow and observed tenant rollout evidence before promotion.
 
 Any failure or owner-model change must update this shared cursor first, then the owning local plan, so Pages and Page Builder cannot drift into different completion claims.
 
@@ -381,6 +432,7 @@ Any failure or owner-model change must update this shared cursor first, then the
 Suggested commands, intentionally not run in this slice:
 
 ```bash
+node crates/rustok-pages/scripts/verify/verify-pages-anonymous-storefront-graph.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-selected-immutable-artifact.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-native-storefront-reviewed-artifact.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-event-delivery-profile-parity.mjs


### PR DESCRIPTION
## Summary

- add a fail-closed Pages source verifier that resolves six anonymous storefront dependency graphs through `cargo metadata`;
- retain Pages storefront default, hydrate/WASM and SSR profiles plus host storefront CSR/WASM, hydrate/WASM and SSR profiles;
- walk only non-dev resolved dependency edges so test-only Page Builder dependencies cannot produce a false authoring reachability result;
- forbid `rustok-pages-admin`, `rustok-page-builder-admin`, `rustok-admin`, `fly-browser`, `fly-ui` and `fly-leptos` at every graph depth;
- require the read-only Pages chain `rustok-pages-storefront → rustok-page-builder-storefront → rustok-page-builder → fly`;
- scan Pages storefront, Page Builder storefront and host storefront Rust source trees for admin/editor imports and composition markers;
- record that current host CSR/hydrate profiles keep the optional Pages module disabled and verify the Pages hydrate graph separately;
- retain compiled SSR/CSR/hydrate bundle artifact proof as a separate open execution gate;
- add source-only machine evidence, a dated packet, and synchronize the canonical Pages/Page Builder and Pages-local plans;
- align one obsolete cache-correlation plan marker block with the current generation-gate/PostgreSQL cursor without weakening its owner, identity, key-rotation or refill assertions;
- change no production code, Cargo dependencies, feature definitions, schemas, DTOs, routes, cache policy or optional event infrastructure.

## Retained profile matrix

```text
Pages storefront
  default
  hydrate / wasm32-unknown-unknown
  ssr

host storefront
  csr / wasm32-unknown-unknown
  hydrate / wasm32-unknown-unknown
  ssr
```

## Validation

Not run per maintainer instruction:

- Node verifiers;
- `cargo metadata`;
- Cargo builds, checks, clippy or formatting;
- SSR binaries, WASM modules or JavaScript bundle generation;
- bundle-byte, source-map or chunk-manifest inspection;
- browser, workflow or CI execution.

Suggested maintainer command:

```bash
node crates/rustok-pages/scripts/verify/verify-pages-anonymous-storefront-graph.mjs
```

A passing verifier will prove package-graph exclusion for the selected profiles. Compiled bundle artifact evidence remains pending.