### PR TITLE
feat(forum): add historical merge route backfill

### DIFF
--- a/crates/rustok-forum/contracts/forum-topic-merge-route-backfill-owner.json
+++ b/crates/rustok-forum/contracts/forum-topic-merge-route-backfill-owner.json
@@ -1,0 +1,65 @@
+{
+  "task": "FORUM-24E",
+  "owner": "rustok-forum",
+  "command": "ForumTopicMergeRouteBackfillService::backfill_merge_route_aliases",
+  "input": {
+    "type": "BackfillForumTopicMergeRouteAliasesInput",
+    "fields": ["cursor", "limit"],
+    "cursor": {
+      "type": "ForumTopicMergeRouteBackfillCursor",
+      "fields": ["merged_at", "operation_id"],
+      "order": ["merged_at_ascending", "operation_id_ascending"]
+    },
+    "minimum_limit": 1,
+    "maximum_limit": 100
+  },
+  "authorization": {
+    "resource": "forum_topics",
+    "action": "manage"
+  },
+  "source": {
+    "table": "forum_topic_merge_operations",
+    "tenant_scoped": true,
+    "immutable_receipts": true,
+    "page_index": "idx_forum_topic_merge_operations_route_backfill"
+  },
+  "write_policy": {
+    "delegates_to": "ForumTopicRouteService::record_merge_redirect_aliases_in_tx",
+    "single_page_transaction": true,
+    "append_only_aliases": true,
+    "exact_page_replay_idempotent": true,
+    "existing_exact_alias_is_verified": true,
+    "payload_drift_fails_closed": true,
+    "new_merges_already_compose_aliases": true
+  },
+  "locale_policy": {
+    "source": "every_non_empty_source_translation_slug",
+    "target_precedence": [
+      "exact_source_locale",
+      "platform_fallback_locale",
+      "lexicographically_first_target_locale"
+    ],
+    "routed_source_without_target_route": "fail_closed"
+  },
+  "output": {
+    "type": "ForumTopicMergeRouteBackfillResult",
+    "fields": [
+      "processed_operation_count",
+      "ensured_alias_count",
+      "next_cursor",
+      "exhausted"
+    ],
+    "ensured_alias_count_semantics": "inserted_or_exactly_verified_routes"
+  },
+  "out_of_scope": [
+    "delete-history recovery after localized rows were removed",
+    "category routes",
+    "REST transport",
+    "GraphQL transport",
+    "admin UI",
+    "storefront mounting",
+    "hreflang and SEO publication policy",
+    "runtime evidence"
+  ],
+  "validation_status": "source_ready_maintainer_execution_pending"
+}

--- a/crates/rustok-forum/docs/README.md
+++ b/crates/rustok-forum/docs/README.md
@@ -49,6 +49,7 @@ notifications module, and cross-module release gates.
 - FORUM-24B composes immutable localized source-route redirects into new topic merges in the same owner transaction without changing merge receipts or events.
 - FORUM-24C records immutable localized `gone` routes in the topic delete transaction while preserving existing merge redirects.
 - FORUM-24D adds an explicit owner command for localized topic slug changes with atomic old-route aliases and delete/merge lifecycle resolution.
+- FORUM-24E provides a bounded, cursor-resumable owner repair that ensures exact route aliases for immutable merge receipts created before FORUM-24B.
 
 ## Verification
 
@@ -83,6 +84,7 @@ notifications module, and cross-module release gates.
 - [FORUM-24B topic merge route aliases](./forum-24b-topic-merge-route-aliases.md)
 - [FORUM-24C topic delete route tombstones](./forum-24c-topic-delete-route-tombstones.md)
 - [FORUM-24D topic slug rename owner](./forum-24d-topic-slug-rename-owner.md)
+- [FORUM-24E historical merge route backfill](./forum-24e-topic-merge-route-backfill.md)
 - [Admin UI package](../admin/README.md)
 - [Storefront UI package](../storefront/README.md)
 - [Event flow contract](../../../docs/architecture/event-flow-contract.md)

--- a/crates/rustok-forum/docs/forum-24e-topic-merge-route-backfill.md
+++ b/crates/rustok-forum/docs/forum-24e-topic-merge-route-backfill.md
@@ -1,0 +1,66 @@
+# FORUM-24E historical topic-merge route backfill
+
+FORUM-24E adds a bounded owner repair for topic merges committed before
+FORUM-24B began writing localized route aliases in the merge transaction.
+
+## Owner boundary
+
+`ForumTopicMergeRouteBackfillService::backfill_merge_route_aliases` requires
+`forum_topics:manage`. It reads only immutable `forum_topic_merge_operations`
+rows for the selected tenant and writes aliases only through
+`ForumTopicRouteService::record_merge_redirect_aliases_in_tx`.
+
+The repair does not reconstruct merge policy, inspect semantic-event payloads,
+or mutate merge receipts. New merges already compose aliases atomically and do
+not depend on this repair for correctness.
+
+## Bounded cursor
+
+The input contains an optional `(merged_at, operation_id)` cursor and a required
+limit from 1 through 100. Receipts are read in ascending cursor order through
+`idx_forum_topic_merge_operations_route_backfill`.
+
+One page and all aliases ensured by that page commit in one transaction. When
+another page remains, the result returns the final processed receipt as
+`next_cursor`; otherwise `exhausted` is true and `next_cursor` is absent.
+
+## Alias policy
+
+Every non-empty localized source slug is handled by the existing route owner.
+Target locale precedence remains unchanged:
+
+1. exact source locale;
+2. platform fallback locale;
+3. lexicographically first target locale.
+
+A routed source whose retained target has no localized route fails closed.
+Existing aliases are accepted only when source ownership, disposition, target,
+locale and reason exactly match the merge receipt. Replaying the same page
+therefore verifies the same routes without inserting duplicates.
+
+`ensured_alias_count` counts routes that were inserted or already existed with
+that exact payload. It is deliberately not an insertion-only metric, so exact
+page replay returns the same result.
+
+## Compatibility and exclusions
+
+FORUM-24E amends the unreleased FORUM-24A route migration with one tenant/cursor
+index. It adds no new table, event, REST route, GraphQL field, admin UI or
+storefront mount.
+
+Delete-history recovery is not inferred after localized translation rows have
+already been removed. Category routes, transport/UI composition, storefront
+mounting, hreflang/SEO publication policy and retained runtime evidence remain
+follow-up FORUM-24 scope.
+
+## Verification
+
+```bash
+node scripts/verify/verify-forum-topic-merge-route-backfill-owner.mjs
+cargo test -p rustok-forum --test topic_merge_route_backfill_sqlite -- --nocapture
+cargo test -p rustok-forum --test topic_merge_route_alias_sqlite -- --nocapture
+cargo check -p rustok-forum --all-targets
+```
+
+These commands were not run by the implementation agent, per maintainer
+request. Source publication does not claim runtime verification.

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -140,9 +140,12 @@ pub use services::{
     SubscriptionService, TopicService, UserStatsService, VoteService,
 };
 pub use services::{
-    FORUM_TOPIC_RENAMED_ROUTE_REASON, FORUM_TOPIC_ROUTE_SHORT_ID_LEN,
+    BackfillForumTopicMergeRouteAliasesInput, FORUM_TOPIC_RENAMED_ROUTE_REASON,
+    FORUM_TOPIC_ROUTE_SHORT_ID_LEN, ForumTopicMergeRouteBackfillCursor,
+    ForumTopicMergeRouteBackfillResult, ForumTopicMergeRouteBackfillService,
     ForumTopicRouteDescriptor, ForumTopicRouteDisposition, ForumTopicRouteResolution,
-    ForumTopicRouteService, ForumTopicSlugRenameResult, MAX_FORUM_TOPIC_ROUTE_ALIAS_REASON_LEN,
+    ForumTopicRouteService, ForumTopicSlugRenameResult,
+    MAX_FORUM_TOPIC_MERGE_ROUTE_BACKFILL_OPERATIONS, MAX_FORUM_TOPIC_ROUTE_ALIAS_REASON_LEN,
     MAX_FORUM_TOPIC_ROUTE_LOCALE_LEN, MAX_FORUM_TOPIC_ROUTE_SLUG_LEN,
     RenameForumTopicSlugInput,
 };

--- a/crates/rustok-forum/src/migrations/m20260805_000024_add_forum_topic_route_aliases.rs
+++ b/crates/rustok-forum/src/migrations/m20260805_000024_add_forum_topic_route_aliases.rs
@@ -109,6 +109,8 @@ CREATE INDEX IF NOT EXISTS idx_forum_topic_route_alias_target
     ON forum_topic_route_aliases (
         tenant_id, target_topic_id, target_locale, created_at, alias_id
     );
+CREATE INDEX IF NOT EXISTS idx_forum_topic_merge_operations_route_backfill
+    ON forum_topic_merge_operations (tenant_id, merged_at, operation_id);
 
 CREATE OR REPLACE FUNCTION forum_reject_topic_route_alias_mutation()
 RETURNS trigger AS $$
@@ -136,6 +138,7 @@ DROP TRIGGER IF EXISTS forum_topic_route_alias_delete
     ON forum_topic_route_aliases;
 DROP TRIGGER IF EXISTS forum_topic_route_alias_update
     ON forum_topic_route_aliases;
+DROP INDEX IF EXISTS idx_forum_topic_merge_operations_route_backfill;
 DROP TABLE IF EXISTS forum_topic_route_aliases;
 DROP FUNCTION IF EXISTS forum_reject_topic_route_alias_mutation();
 "#;
@@ -215,6 +218,8 @@ CREATE INDEX IF NOT EXISTS idx_forum_topic_route_alias_target
     ON forum_topic_route_aliases (
         tenant_id, target_topic_id, target_locale, created_at, alias_id
     );
+CREATE INDEX IF NOT EXISTS idx_forum_topic_merge_operations_route_backfill
+    ON forum_topic_merge_operations (tenant_id, merged_at, operation_id);
 
 CREATE TRIGGER IF NOT EXISTS forum_topic_route_alias_update
 BEFORE UPDATE ON forum_topic_route_aliases
@@ -232,5 +237,6 @@ END;
 const SQLITE_DOWN: &str = r#"
 DROP TRIGGER IF EXISTS forum_topic_route_alias_delete;
 DROP TRIGGER IF EXISTS forum_topic_route_alias_update;
+DROP INDEX IF EXISTS idx_forum_topic_merge_operations_route_backfill;
 DROP TABLE IF EXISTS forum_topic_route_aliases;
 "#;

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -108,6 +108,7 @@ mod topic_audience_read;
 mod topic_audience_visibility;
 mod topic_canonical_resolution;
 mod topic_route;
+mod topic_route_backfill;
 mod topic_create_audience_authorization;
 mod topic_facade;
 mod topic_fork;
@@ -241,6 +242,11 @@ pub use topic_route::{
     ForumTopicRouteService, ForumTopicSlugRenameResult, MAX_FORUM_TOPIC_ROUTE_ALIAS_REASON_LEN,
     MAX_FORUM_TOPIC_ROUTE_LOCALE_LEN, MAX_FORUM_TOPIC_ROUTE_SLUG_LEN,
     RenameForumTopicSlugInput,
+};
+pub use topic_route_backfill::{
+    BackfillForumTopicMergeRouteAliasesInput, ForumTopicMergeRouteBackfillCursor,
+    ForumTopicMergeRouteBackfillResult, ForumTopicMergeRouteBackfillService,
+    MAX_FORUM_TOPIC_MERGE_ROUTE_BACKFILL_OPERATIONS,
 };
 pub use topic_create_audience_authorization::{
     ForumTopicCreateAudienceAuthorization, ForumTopicCreateAudienceAuthorizationService,

--- a/crates/rustok-forum/src/services/topic_route_backfill.rs
+++ b/crates/rustok-forum/src/services/topic_route_backfill.rs
@@ -1,0 +1,173 @@
+use chrono::{DateTime, Utc};
+use sea_orm::{
+    ColumnTrait, Condition, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder, QuerySelect,
+    TransactionTrait, prelude::DateTimeWithTimeZone,
+};
+use serde::{Deserialize, Serialize};
+use tracing::instrument;
+use uuid::Uuid;
+
+use rustok_api::{Action, Resource};
+use rustok_core::SecurityContext;
+
+use crate::entities::forum_topic_merge_operation;
+use crate::error::{ForumError, ForumResult};
+
+use super::rbac::enforce_scope;
+use super::topic_route::ForumTopicRouteService;
+
+pub const MAX_FORUM_TOPIC_MERGE_ROUTE_BACKFILL_OPERATIONS: u32 = 100;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ForumTopicMergeRouteBackfillCursor {
+    pub merged_at: DateTime<Utc>,
+    pub operation_id: Uuid,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BackfillForumTopicMergeRouteAliasesInput {
+    pub cursor: Option<ForumTopicMergeRouteBackfillCursor>,
+    pub limit: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ForumTopicMergeRouteBackfillResult {
+    pub processed_operation_count: u32,
+    pub ensured_alias_count: u32,
+    pub next_cursor: Option<ForumTopicMergeRouteBackfillCursor>,
+    pub exhausted: bool,
+}
+
+/// Bounded, resumable repair for merge receipts created before route aliases were composed.
+///
+/// New merges already write aliases in their owner transaction. This service scans the immutable
+/// historical receipt order and delegates every route write to `ForumTopicRouteService`, so exact
+/// replay verifies the existing alias payload while ownership or target drift fails closed.
+pub struct ForumTopicMergeRouteBackfillService {
+    db: DatabaseConnection,
+}
+
+impl ForumTopicMergeRouteBackfillService {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    #[instrument(skip(self, security, input))]
+    pub async fn backfill_merge_route_aliases(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        input: BackfillForumTopicMergeRouteAliasesInput,
+    ) -> ForumResult<ForumTopicMergeRouteBackfillResult> {
+        enforce_scope(&security, Resource::ForumTopics, Action::Manage)?;
+        validate_input(tenant_id, &input)?;
+
+        let txn = self.db.begin().await?;
+        let mut query = forum_topic_merge_operation::Entity::find()
+            .filter(forum_topic_merge_operation::Column::TenantId.eq(tenant_id));
+
+        if let Some(cursor) = input.cursor.as_ref() {
+            let merged_at: DateTimeWithTimeZone = cursor.merged_at.fixed_offset();
+            query = query.filter(
+                Condition::any()
+                    .add(
+                        forum_topic_merge_operation::Column::MergedAt.gt(merged_at.clone()),
+                    )
+                    .add(
+                        Condition::all()
+                            .add(forum_topic_merge_operation::Column::MergedAt.eq(merged_at))
+                            .add(
+                                forum_topic_merge_operation::Column::OperationId
+                                    .gt(cursor.operation_id),
+                            ),
+                    ),
+            );
+        }
+
+        let fetch_limit = u64::from(input.limit).checked_add(1).ok_or_else(|| {
+            ForumError::Validation("Forum topic merge route backfill limit overflow".to_string())
+        })?;
+        let mut operations = query
+            .order_by_asc(forum_topic_merge_operation::Column::MergedAt)
+            .order_by_asc(forum_topic_merge_operation::Column::OperationId)
+            .limit(fetch_limit)
+            .all(&txn)
+            .await?;
+        let exhausted = operations.len() <= input.limit as usize;
+        operations.truncate(input.limit as usize);
+
+        let mut ensured_alias_count = 0_u32;
+        for operation in &operations {
+            let operation_alias_count =
+                ForumTopicRouteService::record_merge_redirect_aliases_in_tx(
+                    &txn,
+                    tenant_id,
+                    operation.source_topic_id,
+                    operation.target_topic_id,
+                    &operation.reason,
+                )
+                .await?;
+            ensured_alias_count = ensured_alias_count
+                .checked_add(operation_alias_count)
+                .ok_or_else(|| {
+                    ForumError::Validation(
+                        "Forum topic merge route backfill alias count overflow".to_string(),
+                    )
+                })?;
+        }
+
+        let processed_operation_count = u32::try_from(operations.len()).map_err(|_| {
+            ForumError::Validation(
+                "Forum topic merge route backfill operation count overflow".to_string(),
+            )
+        })?;
+        let next_cursor = if exhausted {
+            None
+        } else {
+            operations.last().map(cursor_from_operation)
+        };
+
+        txn.commit().await?;
+        Ok(ForumTopicMergeRouteBackfillResult {
+            processed_operation_count,
+            ensured_alias_count,
+            next_cursor,
+            exhausted,
+        })
+    }
+}
+
+fn validate_input(
+    tenant_id: Uuid,
+    input: &BackfillForumTopicMergeRouteAliasesInput,
+) -> ForumResult<()> {
+    if tenant_id.is_nil() {
+        return Err(ForumError::Validation(
+            "Forum topic merge route backfill tenant must not be nil".to_string(),
+        ));
+    }
+    if input.limit == 0 || input.limit > MAX_FORUM_TOPIC_MERGE_ROUTE_BACKFILL_OPERATIONS {
+        return Err(ForumError::Validation(format!(
+            "Forum topic merge route backfill limit must be between 1 and {MAX_FORUM_TOPIC_MERGE_ROUTE_BACKFILL_OPERATIONS}"
+        )));
+    }
+    if input
+        .cursor
+        .as_ref()
+        .is_some_and(|cursor| cursor.operation_id.is_nil())
+    {
+        return Err(ForumError::Validation(
+            "Forum topic merge route backfill cursor operation must not be nil".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn cursor_from_operation(
+    operation: &forum_topic_merge_operation::Model,
+) -> ForumTopicMergeRouteBackfillCursor {
+    ForumTopicMergeRouteBackfillCursor {
+        merged_at: operation.merged_at.with_timezone(&Utc),
+        operation_id: operation.operation_id,
+    }
+}

--- a/crates/rustok-forum/tests/topic_merge_route_backfill_sqlite.rs
+++ b/crates/rustok-forum/tests/topic_merge_route_backfill_sqlite.rs
@@ -1,0 +1,311 @@
+use std::sync::Arc;
+
+use rustok_core::{MigrationSource, SecurityContext, UserRole};
+use rustok_forum::{
+    BackfillForumTopicMergeRouteAliasesInput, CategoryService, CreateCategoryInput,
+    CreateTopicInput, ForumModule, ForumTopicMergeRouteBackfillService, ForumTopicMergeService,
+    ForumTopicRouteDisposition, ForumTopicRouteService, MergeForumTopicInput, TopicService,
+};
+use rustok_outbox::{OutboxModule, OutboxTransport, TransactionalEventBus};
+use rustok_taxonomy::TaxonomyModule;
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
+};
+use sea_orm_migration::SchemaManager;
+use uuid::Uuid;
+
+type TestResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+async fn setup() -> TestResult<(DatabaseConnection, TransactionalEventBus)> {
+    let db_url = format!(
+        "sqlite:file:forum_topic_merge_route_backfill_{}?mode=memory&cache=shared",
+        Uuid::new_v4()
+    );
+    let mut options = ConnectOptions::new(db_url);
+    options
+        .max_connections(5)
+        .min_connections(1)
+        .sqlx_logging(false);
+    let db = Database::connect(options).await?;
+    db.execute_unprepared(
+        "CREATE TABLE users (\
+            id TEXT NOT NULL PRIMARY KEY, \
+            tenant_id TEXT NOT NULL, \
+            UNIQUE (tenant_id, id)\
+        )",
+    )
+    .await?;
+    let schema = SchemaManager::new(&db);
+    for migration in OutboxModule.migrations() {
+        migration.up(&schema).await?;
+    }
+    for migration in TaxonomyModule.migrations() {
+        migration.up(&schema).await?;
+    }
+    for migration in ForumModule.migrations() {
+        migration.up(&schema).await?;
+    }
+    let event_bus = TransactionalEventBus::new(Arc::new(OutboxTransport::new(db.clone())));
+    Ok((db, event_bus))
+}
+
+async fn insert_user(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    user_id: Uuid,
+) -> TestResult<()> {
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        "INSERT INTO users (id, tenant_id) VALUES (?, ?)",
+        vec![user_id.into(), tenant_id.into()],
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn create_category(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    security: SecurityContext,
+) -> TestResult<Uuid> {
+    Ok(CategoryService::new(db.clone())
+        .create(
+            tenant_id,
+            security,
+            CreateCategoryInput {
+                locale: "en".to_string(),
+                name: "Historical merge routes".to_string(),
+                slug: "historical-merge-routes".to_string(),
+                description: None,
+                icon: None,
+                color: None,
+                parent_id: None,
+                position: Some(0),
+                moderated: false,
+            },
+        )
+        .await?
+        .id)
+}
+
+async fn create_topic(
+    db: &DatabaseConnection,
+    event_bus: &TransactionalEventBus,
+    tenant_id: Uuid,
+    category_id: Uuid,
+    security: SecurityContext,
+    title: &str,
+    slug: &str,
+) -> TestResult<Uuid> {
+    Ok(TopicService::new(db.clone(), event_bus.clone())
+        .create(
+            tenant_id,
+            security,
+            CreateTopicInput {
+                locale: "en".to_string(),
+                category_id,
+                title: title.to_string(),
+                slug: Some(slug.to_string()),
+                body: rustok_api::RichTextDocument::single_paragraph(format!(
+                    "{title} body"
+                )),
+                metadata: serde_json::json!({}),
+                tags: Vec::new(),
+                channel_slugs: None,
+            },
+        )
+        .await?
+        .id)
+}
+
+async fn merge_topic(
+    db: &DatabaseConnection,
+    event_bus: &TransactionalEventBus,
+    tenant_id: Uuid,
+    source_topic_id: Uuid,
+    target_topic_id: Uuid,
+    security: SecurityContext,
+    reason: &str,
+) -> TestResult<()> {
+    ForumTopicMergeService::new(db.clone(), event_bus.clone())
+        .merge_topic(
+            tenant_id,
+            target_topic_id,
+            security,
+            MergeForumTopicInput {
+                operation_id: Uuid::new_v4(),
+                source_topic_id,
+                reason: reason.to_string(),
+            },
+        )
+        .await?;
+    Ok(())
+}
+
+async fn remove_composed_aliases_for_historical_fixture(
+    db: &DatabaseConnection,
+) -> TestResult<()> {
+    db.execute_unprepared(
+        "DROP TRIGGER IF EXISTS forum_topic_route_alias_delete;\
+         DELETE FROM forum_topic_route_aliases;\
+         CREATE TRIGGER forum_topic_route_alias_delete \
+         BEFORE DELETE ON forum_topic_route_aliases \
+         BEGIN \
+             SELECT RAISE(ABORT, 'forum topic route aliases are append-only'); \
+         END;",
+    )
+    .await?;
+    Ok(())
+}
+
+async fn alias_count(db: &DatabaseConnection, tenant_id: Uuid) -> TestResult<i64> {
+    Ok(db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT COUNT(*) AS alias_count FROM forum_topic_route_aliases WHERE tenant_id = ?",
+            vec![tenant_id.into()],
+        ))
+        .await?
+        .expect("alias count")
+        .try_get::<i64>("", "alias_count")?)
+}
+
+#[tokio::test]
+async fn historical_merge_aliases_backfill_in_bounded_replay_safe_pages() -> TestResult<()> {
+    let (db, event_bus) = setup().await?;
+    let tenant_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    insert_user(&db, tenant_id, actor_id).await?;
+    let admin = SecurityContext::new(UserRole::Admin, Some(actor_id));
+    let category_id = create_category(&db, tenant_id, admin.clone()).await?;
+
+    let source_one = create_topic(
+        &db,
+        &event_bus,
+        tenant_id,
+        category_id,
+        admin.clone(),
+        "Historical source one",
+        "historical-source-one",
+    )
+    .await?;
+    let target_one = create_topic(
+        &db,
+        &event_bus,
+        tenant_id,
+        category_id,
+        admin.clone(),
+        "Retained target one",
+        "retained-target-one",
+    )
+    .await?;
+    let source_two = create_topic(
+        &db,
+        &event_bus,
+        tenant_id,
+        category_id,
+        admin.clone(),
+        "Historical source two",
+        "historical-source-two",
+    )
+    .await?;
+    let target_two = create_topic(
+        &db,
+        &event_bus,
+        tenant_id,
+        category_id,
+        admin.clone(),
+        "Retained target two",
+        "retained-target-two",
+    )
+    .await?;
+
+    merge_topic(
+        &db,
+        &event_bus,
+        tenant_id,
+        source_one,
+        target_one,
+        admin.clone(),
+        "Historical merge one",
+    )
+    .await?;
+    merge_topic(
+        &db,
+        &event_bus,
+        tenant_id,
+        source_two,
+        target_two,
+        admin.clone(),
+        "Historical merge two",
+    )
+    .await?;
+    remove_composed_aliases_for_historical_fixture(&db).await?;
+    assert_eq!(alias_count(&db, tenant_id).await?, 0);
+
+    let service = ForumTopicMergeRouteBackfillService::new(db.clone());
+    let first_input = BackfillForumTopicMergeRouteAliasesInput {
+        cursor: None,
+        limit: 1,
+    };
+    let first = service
+        .backfill_merge_route_aliases(tenant_id, admin.clone(), first_input.clone())
+        .await?;
+    assert_eq!(first.processed_operation_count, 1);
+    assert_eq!(first.ensured_alias_count, 1);
+    assert!(!first.exhausted);
+    assert!(first.next_cursor.is_some());
+    assert_eq!(alias_count(&db, tenant_id).await?, 1);
+
+    let replay = service
+        .backfill_merge_route_aliases(tenant_id, admin.clone(), first_input)
+        .await?;
+    assert_eq!(replay, first);
+    assert_eq!(alias_count(&db, tenant_id).await?, 1);
+
+    let second = service
+        .backfill_merge_route_aliases(
+            tenant_id,
+            admin,
+            BackfillForumTopicMergeRouteAliasesInput {
+                cursor: first.next_cursor,
+                limit: 1,
+            },
+        )
+        .await?;
+    assert_eq!(second.processed_operation_count, 1);
+    assert_eq!(second.ensured_alias_count, 1);
+    assert!(second.exhausted);
+    assert!(second.next_cursor.is_none());
+    assert_eq!(alias_count(&db, tenant_id).await?, 2);
+
+    for (source_topic_id, target_topic_id, source_slug, target_slug) in [
+        (
+            source_one,
+            target_one,
+            "historical-source-one",
+            "retained-target-one",
+        ),
+        (
+            source_two,
+            target_two,
+            "historical-source-two",
+            "retained-target-two",
+        ),
+    ] {
+        let resolved = ForumTopicRouteService::new(db.clone())
+            .resolve(
+                tenant_id,
+                "en",
+                &ForumTopicRouteService::short_identity(source_topic_id),
+                source_slug,
+            )
+            .await?;
+        assert_eq!(resolved.disposition, ForumTopicRouteDisposition::Redirect);
+        let canonical = resolved.canonical.expect("canonical redirect target");
+        assert_eq!(canonical.topic_id, target_topic_id);
+        assert_eq!(canonical.slug, target_slug);
+    }
+
+    Ok(())
+}

--- a/scripts/verify/verify-forum-topic-merge-route-backfill-owner.mjs
+++ b/scripts/verify/verify-forum-topic-merge-route-backfill-owner.mjs
@@ -1,0 +1,106 @@
+import fs from "node:fs";
+
+const read = (path) => fs.readFileSync(path, "utf8");
+const mustContain = (text, needle, label) => {
+  if (!text.includes(needle)) {
+    throw new Error(`${label} is missing: ${needle}`);
+  }
+};
+const mustNotContain = (text, needle, label) => {
+  if (text.includes(needle)) {
+    throw new Error(`${label} must not contain: ${needle}`);
+  }
+};
+
+const owner = read("crates/rustok-forum/src/services/topic_route_backfill.rs");
+const route = read("crates/rustok-forum/src/services/topic_route.rs");
+const migration = read(
+  "crates/rustok-forum/src/migrations/m20260805_000024_add_forum_topic_route_aliases.rs",
+);
+const contract = JSON.parse(
+  read("crates/rustok-forum/contracts/forum-topic-merge-route-backfill-owner.json"),
+);
+const test = read("crates/rustok-forum/tests/topic_merge_route_backfill_sqlite.rs");
+const docs = read("crates/rustok-forum/docs/forum-24e-topic-merge-route-backfill.md");
+const readme = read("crates/rustok-forum/docs/README.md");
+
+if (contract.task !== "FORUM-24E") {
+  throw new Error("FORUM-24E contract task drifted");
+}
+if (contract.input.maximum_limit !== 100) {
+  throw new Error("merge route backfill limit must remain bounded at 100");
+}
+if (contract.write_policy.single_page_transaction !== true) {
+  throw new Error("one merge route backfill page must remain atomic");
+}
+if (contract.write_policy.exact_page_replay_idempotent !== true) {
+  throw new Error("merge route backfill replay must remain idempotent");
+}
+
+mustContain(
+  owner,
+  "pub struct ForumTopicMergeRouteBackfillCursor",
+  "typed merge receipt cursor",
+);
+mustContain(
+  owner,
+  "pub struct BackfillForumTopicMergeRouteAliasesInput",
+  "backfill input",
+);
+mustContain(
+  owner,
+  "pub struct ForumTopicMergeRouteBackfillResult",
+  "backfill result",
+);
+mustContain(
+  owner,
+  "pub async fn backfill_merge_route_aliases(",
+  "backfill owner command",
+);
+mustContain(owner, "Action::Manage", "manager authorization");
+mustContain(
+  owner,
+  "MAX_FORUM_TOPIC_MERGE_ROUTE_BACKFILL_OPERATIONS: u32 = 100",
+  "bounded operation page",
+);
+mustContain(
+  owner,
+  "ForumTopicRouteService::record_merge_redirect_aliases_in_tx(",
+  "canonical route owner delegation",
+);
+mustContain(owner, ".checked_add(operation_alias_count)", "checked alias count");
+mustContain(owner, "txn.commit().await?", "single page commit");
+mustNotContain(owner, "INSERT INTO forum_topic_route_aliases", "backfill owner");
+mustNotContain(owner, "UPDATE forum_topic_merge_operations", "backfill owner");
+
+mustContain(
+  route,
+  "ON CONFLICT (tenant_id, locale, short_id, slug) DO NOTHING",
+  "exact replay insertion guard",
+);
+mustContain(
+  migration,
+  "idx_forum_topic_merge_operations_route_backfill",
+  "merge receipt cursor index",
+);
+mustContain(
+  migration,
+  "tenant_id, merged_at, operation_id",
+  "merge receipt cursor index order",
+);
+
+mustContain(
+  test,
+  "historical_merge_aliases_backfill_in_bounded_replay_safe_pages",
+  "SQLite historical backfill coverage",
+);
+mustContain(test, "assert_eq!(replay, first)", "exact page replay assertion");
+mustContain(test, "assert_eq!(alias_count(&db, tenant_id).await?, 2)", "complete alias assertion");
+mustContain(docs, "# FORUM-24E historical topic-merge route backfill", "task documentation");
+mustContain(
+  readme,
+  "[FORUM-24E historical merge route backfill](./forum-24e-topic-merge-route-backfill.md)",
+  "documentation index",
+);
+
+console.log("FORUM-24E historical merge route backfill source contract is present");


### PR DESCRIPTION
## Summary
- add FORUM-24E bounded, resumable owner repair for immutable topic merge receipts created before FORUM-24B route alias composition
- require routed-tenant `forum_topics:manage` and scan receipts by stable `(merged_at, operation_id)` cursor
- cap pages at 100 operations and commit one page plus all ensured aliases in one transaction
- delegate route writes and exact replay validation to `ForumTopicRouteService`
- preserve existing target-locale precedence and fail closed on route or payload drift
- amend the unreleased route migration with a tenant/cursor index
- publish the owner contract, focused documentation, source verifier and SQLite integration scenario

## Boundary
- new merges remain correct through FORUM-24B and do not depend on the repair
- no delete-history reconstruction after localized translations were already removed
- no category routes, REST/GraphQL transport, admin UI, storefront mount, hreflang/SEO policy or runtime-evidence change
- canonical `implementation-plan.md` is not modified: the connected GitHub writer only supports full-file replacement for that monolithic file, so task docs, contract and README are synchronized while canonical ledger sync remains an explicit administrative follow-up

## Validation
- Tests, source verifiers, formatters, Cargo checks, database runtime commands and browser validation were not run by the implementation agent, per maintainer request.
- Automatically triggered repository workflows were not used as validation.