### PR TITLE
feat(forum): expose topic slug rename over GraphQL

### DIFF
--- a/crates/rustok-forum/contracts/forum-topic-slug-rename-graphql-transport.json
+++ b/crates/rustok-forum/contracts/forum-topic-slug-rename-graphql-transport.json
@@ -1,0 +1,83 @@
+{
+  "contract": "forum_topic_slug_rename_graphql_transport_v1",
+  "task": "FORUM-24F",
+  "parent_task": "FORUM-24",
+  "extends": "FORUM-24D",
+  "status": "source_ready_maintainer_execution_pending",
+  "canonical_plan_status": "planned",
+  "transport": "graphql",
+  "owner_service": "TopicService",
+  "authorization": {
+    "module_must_be_enabled": "forum",
+    "required_permission": "forum_topics:update",
+    "ownership_semantics_remain_owner_defined": true,
+    "tenant_is_derived_from_routed_TenantContext": true,
+    "optional_tenant_argument_must_equal_routed_tenant": true,
+    "tenant_mismatch_code": "PERMISSION_DENIED"
+  },
+  "command": {
+    "field": "renameForumTopicSlug",
+    "topic_id_is_separate_argument": true,
+    "input_type": "RenameForumTopicSlugGraphqlInput",
+    "input_fields": ["locale", "slug"],
+    "result_type": "GqlForumTopicSlugRename",
+    "calls_owner_method": "rename_slug"
+  },
+  "result": {
+    "type": "GqlForumTopicSlugRename",
+    "fields": [
+      "topic_id",
+      "locale",
+      "previous_slug",
+      "slug",
+      "previous_path",
+      "canonical",
+      "alias_id",
+      "changed"
+    ],
+    "canonical_type": "GqlForumTopicRouteDescriptor",
+    "canonical_fields": ["topic_id", "locale", "short_id", "slug", "path"],
+    "exact_normalized_replay_reports_changed_false": true,
+    "changed_write_returns_immutable_alias_id": true
+  },
+  "composition": {
+    "resolver_contains_no_route_business_logic": true,
+    "database_and_transactional_event_bus_are_explicit_schema_data": true,
+    "security_context_uses_authenticated_permission_snapshot": true,
+    "domain_errors_preserve_ForumGraphqlErrorExtension_mapping": true,
+    "raw_route_alias_table_access_in_resolver": false,
+    "canonical_merge_resolution_in_resolver": false
+  },
+  "compatibility": {
+    "owner_command_changed": false,
+    "route_alias_schema_changed": false,
+    "semantic_event_schema_changed": false,
+    "rest_contract_changed": false,
+    "admin_ui_added": false,
+    "storefront_ui_added": false,
+    "graphql_field_is_additive": true
+  },
+  "source_contract_test": "crates/rustok-forum/tests/topic_slug_rename_graphql_contract.rs",
+  "authorization_unit_test": "crates/rustok-forum/src/graphql/topic_slug_rename_mutation.rs",
+  "owner_runtime_test": "crates/rustok-forum/tests/topic_slug_rename_sqlite.rs",
+  "documentation": "crates/rustok-forum/docs/forum-24f-topic-slug-rename-graphql-transport.md",
+  "owner_contract": "crates/rustok-forum/contracts/forum-topic-slug-rename-owner.json",
+  "owner_documentation": "crates/rustok-forum/docs/forum-24d-topic-slug-rename-owner.md",
+  "verifier": "scripts/verify/verify-forum-topic-slug-rename-graphql-transport.mjs",
+  "maintainer_commands": [
+    "node scripts/verify/verify-forum-topic-slug-rename-owner.mjs",
+    "node scripts/verify/verify-forum-topic-slug-rename-graphql-transport.mjs",
+    "cargo test -p rustok-forum graphql::topic_slug_rename_mutation::tests -- --nocapture",
+    "cargo test -p rustok-forum --test topic_slug_rename_graphql_contract -- --nocapture",
+    "cargo test -p rustok-forum --test topic_slug_rename_sqlite -- --nocapture",
+    "cargo check -p rustok-forum --all-targets"
+  ],
+  "non_claims": [
+    "no verifier test formatter Cargo SQLite PostgreSQL workflow or CI execution is claimed",
+    "no REST native admin storefront or CLI rename transport is added",
+    "no admin UI is added",
+    "no public localized topic route mount is added",
+    "no category route or hreflang SEO policy is added",
+    "FORUM-24 remains planned"
+  ]
+}

--- a/crates/rustok-forum/docs/README.md
+++ b/crates/rustok-forum/docs/README.md
@@ -50,6 +50,7 @@ notifications module, and cross-module release gates.
 - FORUM-24C records immutable localized `gone` routes in the topic delete transaction while preserving existing merge redirects.
 - FORUM-24D adds an explicit owner command for localized topic slug changes with atomic old-route aliases and delete/merge lifecycle resolution.
 - FORUM-24E provides a bounded, cursor-resumable owner repair that ensures exact route aliases for immutable merge receipts created before FORUM-24B.
+- FORUM-24F exposes the localized topic slug rename owner through an additive routed-tenant GraphQL mutation while preserving owner-defined update and ownership semantics.
 
 ## Verification
 
@@ -85,6 +86,7 @@ notifications module, and cross-module release gates.
 - [FORUM-24C topic delete route tombstones](./forum-24c-topic-delete-route-tombstones.md)
 - [FORUM-24D topic slug rename owner](./forum-24d-topic-slug-rename-owner.md)
 - [FORUM-24E historical merge route backfill](./forum-24e-topic-merge-route-backfill.md)
+- [FORUM-24F topic slug rename GraphQL transport](./forum-24f-topic-slug-rename-graphql-transport.md)
 - [Admin UI package](../admin/README.md)
 - [Storefront UI package](../storefront/README.md)
 - [Event flow contract](../../../docs/architecture/event-flow-contract.md)

--- a/crates/rustok-forum/docs/forum-24f-topic-slug-rename-graphql-transport.md
+++ b/crates/rustok-forum/docs/forum-24f-topic-slug-rename-graphql-transport.md
@@ -1,0 +1,62 @@
+# FORUM-24F topic slug rename GraphQL transport
+
+FORUM-24F exposes the existing FORUM-24D localized topic slug rename owner
+through one additive GraphQL mutation. The adapter contains no route ownership,
+alias, locale-selection or merge/delete lifecycle policy.
+
+## GraphQL command
+
+`renameForumTopicSlug` accepts the routed topic ID plus
+`RenameForumTopicSlugGraphqlInput`:
+
+- `locale` selects one existing localized topic translation;
+- `slug` is the new non-empty localized route segment.
+
+The result is `GqlForumTopicSlugRename`, containing the previous slug and path,
+the current canonical route descriptor, the immutable alias ID when a change
+was written, and the owner-provided `changed` replay flag.
+
+## Authorization and tenant boundary
+
+The Forum module must be enabled. The adapter requires
+`forum_topics:update`, derives the tenant from `TenantContext`, and rejects an
+optional mismatched tenant assertion with `PERMISSION_DENIED`.
+
+The adapter then forwards the authenticated permission snapshot to
+`TopicService::rename_slug`. Author ownership and manager override semantics
+remain exclusively owner-defined and match ordinary topic update behavior.
+
+## Owner composition
+
+The resolver passes only `topic_id`, `locale` and `slug` to the owner. It does
+not read `forum_topic_route_aliases`, open a transaction, choose canonical
+locales, resolve merge history or duplicate alias validation.
+
+FORUM-24D therefore remains authoritative for localized-route locking, atomic
+old-route redirect creation, topic timestamp/projection updates, exact replay,
+payload-drift failure, merge canonicalization and delete-to-gone behavior.
+
+## Compatibility and exclusions
+
+This slice adds one GraphQL field and no migration. It changes no owner method,
+route alias schema, semantic event, REST endpoint, admin/storefront UI or public
+localized route mount.
+
+Category routes, storefront mounting, host redirect/gone composition,
+hreflang/SEO publication policy and retained runtime evidence remain follow-up
+FORUM-24 scope. The canonical task remains `planned` until those release gates
+and maintainer execution are complete.
+
+## Verification
+
+```bash
+node scripts/verify/verify-forum-topic-slug-rename-owner.mjs
+node scripts/verify/verify-forum-topic-slug-rename-graphql-transport.mjs
+cargo test -p rustok-forum graphql::topic_slug_rename_mutation::tests -- --nocapture
+cargo test -p rustok-forum --test topic_slug_rename_graphql_contract -- --nocapture
+cargo test -p rustok-forum --test topic_slug_rename_sqlite -- --nocapture
+cargo check -p rustok-forum --all-targets
+```
+
+No command above was run by the implementation agent, per maintainer request.
+The source status is `source_ready_maintainer_execution_pending`.

--- a/crates/rustok-forum/src/graphql/mod.rs
+++ b/crates/rustok-forum/src/graphql/mod.rs
@@ -18,6 +18,7 @@ mod storefront_read_state;
 mod topic_fork_mutation;
 mod topic_merge_mutation;
 mod topic_reply_range_move_mutation;
+mod topic_slug_rename_mutation;
 mod topic_split_mutation;
 mod types;
 
@@ -55,6 +56,9 @@ pub use topic_merge_mutation::{
 pub use topic_reply_range_move_mutation::{
     GqlForumReplyRangeMove, MoveForumTopicReplyRangeGraphqlInput,
 };
+pub use topic_slug_rename_mutation::{
+    GqlForumTopicRouteDescriptor, GqlForumTopicSlugRename, RenameForumTopicSlugGraphqlInput,
+};
 pub use topic_split_mutation::{GqlForumTopicSplit, SplitForumTopicRepliesGraphqlInput};
 pub use types::*;
 
@@ -83,5 +87,6 @@ pub struct ForumMutation(
     topic_fork_mutation::ForumTopicForkMutation,
     topic_merge_mutation::ForumTopicMergeMutation,
     topic_reply_range_move_mutation::ForumTopicReplyRangeMoveMutation,
+    topic_slug_rename_mutation::ForumTopicSlugRenameMutation,
     topic_split_mutation::ForumTopicSplitMutation,
 );

--- a/crates/rustok-forum/src/graphql/topic_slug_rename_mutation.rs
+++ b/crates/rustok-forum/src/graphql/topic_slug_rename_mutation.rs
@@ -1,0 +1,231 @@
+use async_graphql::{Context, FieldError, InputObject, Object, Result, SimpleObject};
+use rustok_api::{
+    AuthContext, Permission, TenantContext,
+    graphql::{GraphQLError, require_module_enabled},
+    has_any_effective_permission,
+};
+use rustok_outbox::TransactionalEventBus;
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use crate::{
+    ForumTopicRouteDescriptor, ForumTopicSlugRenameResult, RenameForumTopicSlugInput,
+    TopicService,
+};
+
+const MODULE_SLUG: &str = "forum";
+
+#[derive(Default)]
+pub(crate) struct ForumTopicSlugRenameMutation;
+
+#[Object]
+impl ForumTopicSlugRenameMutation {
+    async fn rename_forum_topic_slug(
+        &self,
+        ctx: &Context<'_>,
+        tenant_id: Option<Uuid>,
+        topic_id: Uuid,
+        input: RenameForumTopicSlugGraphqlInput,
+    ) -> Result<GqlForumTopicSlugRename> {
+        require_module_enabled(ctx, MODULE_SLUG).await?;
+        let db = ctx.data::<DatabaseConnection>()?;
+        let event_bus = ctx.data::<TransactionalEventBus>()?;
+        let auth = ctx
+            .data::<AuthContext>()
+            .map_err(|_| <FieldError as GraphQLError>::unauthenticated())?
+            .clone();
+        let tenant = ctx.data::<TenantContext>()?;
+
+        execute_rename_forum_topic_slug(
+            db,
+            event_bus,
+            tenant,
+            &auth,
+            tenant_id,
+            topic_id,
+            input,
+        )
+        .await
+    }
+}
+
+async fn execute_rename_forum_topic_slug(
+    db: &DatabaseConnection,
+    event_bus: &TransactionalEventBus,
+    tenant: &TenantContext,
+    auth: &AuthContext,
+    requested_tenant_id: Option<Uuid>,
+    topic_id: Uuid,
+    input: RenameForumTopicSlugGraphqlInput,
+) -> Result<GqlForumTopicSlugRename> {
+    require_topic_update_permission(auth)?;
+    let tenant_id = resolve_tenant_scope(tenant, requested_tenant_id)?;
+
+    let result = TopicService::new(db.clone(), event_bus.clone())
+        .rename_slug(
+            tenant_id,
+            topic_id,
+            rustok_core::SecurityContext::from_permission_snapshot(
+                Some(auth.user_id),
+                &auth.permissions,
+            ),
+            RenameForumTopicSlugInput {
+                locale: input.locale,
+                slug: input.slug,
+            },
+        )
+        .await?;
+
+    Ok(result.into())
+}
+
+fn require_topic_update_permission(auth: &AuthContext) -> Result<()> {
+    if !has_any_effective_permission(&auth.permissions, &[Permission::FORUM_TOPICS_UPDATE]) {
+        return Err(<FieldError as GraphQLError>::permission_denied(
+            "Permission denied: forum_topics:update required",
+        ));
+    }
+    Ok(())
+}
+
+fn resolve_tenant_scope(tenant: &TenantContext, requested_tenant_id: Option<Uuid>) -> Result<Uuid> {
+    match requested_tenant_id {
+        Some(requested_tenant_id) if requested_tenant_id != tenant.id => {
+            Err(<FieldError as GraphQLError>::permission_denied(
+                "Permission denied: tenant scope mismatch",
+            ))
+        }
+        Some(requested_tenant_id) => Ok(requested_tenant_id),
+        None => Ok(tenant.id),
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, InputObject)]
+pub struct RenameForumTopicSlugGraphqlInput {
+    pub locale: String,
+    pub slug: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, SimpleObject)]
+pub struct GqlForumTopicRouteDescriptor {
+    pub topic_id: Uuid,
+    pub locale: String,
+    pub short_id: String,
+    pub slug: String,
+    pub path: String,
+}
+
+impl From<ForumTopicRouteDescriptor> for GqlForumTopicRouteDescriptor {
+    fn from(value: ForumTopicRouteDescriptor) -> Self {
+        Self {
+            topic_id: value.topic_id,
+            locale: value.locale,
+            short_id: value.short_id,
+            slug: value.slug,
+            path: value.path,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, SimpleObject)]
+pub struct GqlForumTopicSlugRename {
+    pub topic_id: Uuid,
+    pub locale: String,
+    pub previous_slug: String,
+    pub slug: String,
+    pub previous_path: String,
+    pub canonical: GqlForumTopicRouteDescriptor,
+    pub alias_id: Option<Uuid>,
+    pub changed: bool,
+}
+
+impl From<ForumTopicSlugRenameResult> for GqlForumTopicSlugRename {
+    fn from(value: ForumTopicSlugRenameResult) -> Self {
+        Self {
+            topic_id: value.topic_id,
+            locale: value.locale,
+            previous_slug: value.previous_slug,
+            slug: value.slug,
+            previous_path: value.previous_path,
+            canonical: value.canonical.into(),
+            alias_id: value.alias_id,
+            changed: value.changed,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rustok_api::{AuthContext, Permission, TenantContext};
+    use uuid::Uuid;
+
+    use super::{require_topic_update_permission, resolve_tenant_scope};
+
+    fn auth_context(permissions: Vec<Permission>) -> AuthContext {
+        AuthContext {
+            user_id: Uuid::new_v4(),
+            session_id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            permissions,
+            client_id: None,
+            scopes: Vec::new(),
+            grant_type: "direct".to_string(),
+        }
+    }
+
+    fn tenant_context(tenant_id: Uuid) -> TenantContext {
+        TenantContext {
+            id: tenant_id,
+            name: "Topic slug rename GraphQL tenant".to_string(),
+            slug: "topic-slug-rename-graphql".to_string(),
+            domain: None,
+            settings: serde_json::json!({}),
+            default_locale: "en".to_string(),
+            is_active: true,
+        }
+    }
+
+    fn error_code(error: &async_graphql::Error) -> Option<String> {
+        error
+            .extensions
+            .as_ref()
+            .and_then(|extensions| extensions.get("code"))
+            .cloned()
+            .and_then(|value| value.into_json().ok())
+            .and_then(|value| value.as_str().map(ToOwned::to_owned))
+    }
+
+    #[test]
+    fn rename_transport_requires_topic_update_permission() {
+        let denied = require_topic_update_permission(&auth_context(vec![
+            Permission::FORUM_TOPICS_READ,
+        ]))
+        .expect_err("read-only actor must not rename a topic slug");
+        assert_eq!(error_code(&denied).as_deref(), Some("PERMISSION_DENIED"));
+
+        require_topic_update_permission(&auth_context(vec![
+            Permission::FORUM_TOPICS_UPDATE,
+        ]))
+        .expect("topic update permission must be accepted");
+    }
+
+    #[test]
+    fn rename_transport_rejects_tenant_override_mismatch() {
+        let tenant_id = Uuid::new_v4();
+        let tenant = tenant_context(tenant_id);
+
+        assert_eq!(
+            resolve_tenant_scope(&tenant, None).expect("routed tenant must resolve"),
+            tenant_id
+        );
+        assert_eq!(
+            resolve_tenant_scope(&tenant, Some(tenant_id))
+                .expect("matching tenant assertion must resolve"),
+            tenant_id
+        );
+
+        let denied = resolve_tenant_scope(&tenant, Some(Uuid::new_v4()))
+            .expect_err("mismatched tenant assertion must fail closed");
+        assert_eq!(error_code(&denied).as_deref(), Some("PERMISSION_DENIED"));
+    }
+}

--- a/crates/rustok-forum/tests/topic_slug_rename_graphql_contract.rs
+++ b/crates/rustok-forum/tests/topic_slug_rename_graphql_contract.rs
@@ -1,0 +1,72 @@
+use async_graphql::{EmptySubscription, Schema};
+use rustok_forum::graphql::ForumGraphqlErrorExtension;
+use rustok_forum::{ForumMutation, ForumQuery};
+
+const TOPIC_SLUG_RENAME_GRAPHQL: &str =
+    include_str!("../src/graphql/topic_slug_rename_mutation.rs");
+
+#[test]
+fn graphql_schema_exposes_topic_slug_rename_command() {
+    let schema = Schema::build(
+        ForumQuery::default(),
+        ForumMutation::default(),
+        EmptySubscription,
+    )
+    .extension(ForumGraphqlErrorExtension)
+    .finish();
+    let sdl = schema.sdl();
+
+    for marker in [
+        "renameForumTopicSlug",
+        "RenameForumTopicSlugGraphqlInput",
+        "GqlForumTopicSlugRename",
+        "GqlForumTopicRouteDescriptor",
+        "topicId",
+        "locale",
+        "previousSlug",
+        "previousPath",
+        "canonical",
+        "shortId",
+        "aliasId",
+        "changed",
+    ] {
+        assert!(
+            sdl.contains(marker),
+            "missing GraphQL topic slug rename marker {marker}"
+        );
+    }
+}
+
+#[test]
+fn graphql_rename_adapter_uses_routed_tenant_update_scope_and_owner_service() {
+    for marker in [
+        "require_module_enabled(ctx, MODULE_SLUG).await?",
+        "Permission::FORUM_TOPICS_UPDATE",
+        "Permission denied: forum_topics:update required",
+        "Permission denied: tenant scope mismatch",
+        "TopicService::new(db.clone(), event_bus.clone())",
+        ".rename_slug(",
+        "SecurityContext::from_permission_snapshot",
+        "locale: input.locale",
+        "slug: input.slug",
+    ] {
+        assert!(
+            TOPIC_SLUG_RENAME_GRAPHQL.contains(marker),
+            "missing topic slug rename adapter marker {marker}"
+        );
+    }
+
+    for forbidden in [
+        "ForumTopicRouteService::new",
+        "rename_topic_slug_in_tx",
+        "forum_topic_route_aliases",
+        "resolve_canonical_topic",
+        "ForumTopicMergeService",
+        "ForumTopicMergeRouteBackfillService",
+    ] {
+        assert!(
+            !TOPIC_SLUG_RENAME_GRAPHQL.contains(forbidden),
+            "topic slug rename adapter contains forbidden marker {forbidden}"
+        );
+    }
+}

--- a/scripts/verify/verify-forum-topic-slug-rename-graphql-transport.mjs
+++ b/scripts/verify/verify-forum-topic-slug-rename-graphql-transport.mjs
@@ -156,9 +156,9 @@ includesAll(
 includesAll(
   ownerRuntimeTest,
   [
-    "renaming_slug_records_old_route_and_replay_is_idempotent",
-    "renamed_source_route_follows_merge_and_then_becomes_gone_after_delete",
+    "rename_records_one_alias_and_old_route_becomes_gone_after_delete",
     "forum_topic_route_aliases",
+    "Topic slug changed",
   ],
   "owner runtime contract source",
 );
@@ -178,7 +178,7 @@ includesAll(
 includesAll(
   ownerDocs,
   [
-    "# FORUM-24D localized topic slug rename owner",
+    "# FORUM-24D topic slug rename owner",
     "TopicService::rename_slug",
     "Topic slug changed",
   ],
@@ -187,7 +187,7 @@ includesAll(
 includesAll(
   docsIndex,
   [
-    "FORUM-24F exposes the localized topic slug rename owner through an additive GraphQL mutation",
+    "FORUM-24F exposes the localized topic slug rename owner through an additive routed-tenant GraphQL mutation",
     "FORUM-24F topic slug rename GraphQL transport",
   ],
   "Forum docs index",

--- a/scripts/verify/verify-forum-topic-slug-rename-graphql-transport.mjs
+++ b/scripts/verify/verify-forum-topic-slug-rename-graphql-transport.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const paths = {
+  contract:
+    "crates/rustok-forum/contracts/forum-topic-slug-rename-graphql-transport.json",
+  ownerContract: "crates/rustok-forum/contracts/forum-topic-slug-rename-owner.json",
+  docs: "crates/rustok-forum/docs/forum-24f-topic-slug-rename-graphql-transport.md",
+  ownerDocs: "crates/rustok-forum/docs/forum-24d-topic-slug-rename-owner.md",
+  graphql: "crates/rustok-forum/src/graphql/topic_slug_rename_mutation.rs",
+  graphqlMod: "crates/rustok-forum/src/graphql/mod.rs",
+  owner: "crates/rustok-forum/src/services/topic_owner.rs",
+  routeOwner: "crates/rustok-forum/src/services/topic_route.rs",
+  schemaTest: "crates/rustok-forum/tests/topic_slug_rename_graphql_contract.rs",
+  ownerRuntimeTest: "crates/rustok-forum/tests/topic_slug_rename_sqlite.rs",
+  docsIndex: "crates/rustok-forum/docs/README.md",
+};
+
+const read = (path) => readFileSync(path, "utf8");
+const includesAll = (text, markers, label) => {
+  for (const marker of markers) {
+    assert.ok(text.includes(marker), `${label} is missing marker: ${marker}`);
+  }
+};
+
+const contract = JSON.parse(read(paths.contract));
+const ownerContract = JSON.parse(read(paths.ownerContract));
+const docs = read(paths.docs);
+const ownerDocs = read(paths.ownerDocs);
+const graphql = read(paths.graphql);
+const graphqlMod = read(paths.graphqlMod);
+const owner = read(paths.owner);
+const routeOwner = read(paths.routeOwner);
+const schemaTest = read(paths.schemaTest);
+const ownerRuntimeTest = read(paths.ownerRuntimeTest);
+const docsIndex = read(paths.docsIndex);
+
+assert.equal(contract.contract, "forum_topic_slug_rename_graphql_transport_v1");
+assert.equal(contract.task, "FORUM-24F");
+assert.equal(contract.parent_task, "FORUM-24");
+assert.equal(contract.extends, "FORUM-24D");
+assert.equal(contract.status, "source_ready_maintainer_execution_pending");
+assert.equal(contract.transport, "graphql");
+assert.equal(contract.owner_service, "TopicService");
+assert.equal(contract.authorization.module_must_be_enabled, "forum");
+assert.equal(contract.authorization.required_permission, "forum_topics:update");
+assert.equal(contract.authorization.ownership_semantics_remain_owner_defined, true);
+assert.equal(contract.authorization.tenant_is_derived_from_routed_TenantContext, true);
+assert.equal(contract.authorization.optional_tenant_argument_must_equal_routed_tenant, true);
+assert.equal(contract.command.field, "renameForumTopicSlug");
+assert.equal(contract.command.input_type, "RenameForumTopicSlugGraphqlInput");
+assert.equal(contract.command.result_type, "GqlForumTopicSlugRename");
+assert.equal(contract.command.calls_owner_method, "rename_slug");
+assert.equal(contract.result.exact_normalized_replay_reports_changed_false, true);
+assert.equal(contract.result.changed_write_returns_immutable_alias_id, true);
+assert.equal(contract.composition.resolver_contains_no_route_business_logic, true);
+assert.equal(contract.composition.raw_route_alias_table_access_in_resolver, false);
+assert.equal(contract.compatibility.owner_command_changed, false);
+assert.equal(contract.compatibility.route_alias_schema_changed, false);
+assert.equal(contract.compatibility.semantic_event_schema_changed, false);
+assert.equal(contract.compatibility.graphql_field_is_additive, true);
+assert.equal(ownerContract.task, "FORUM-24D");
+assert.equal(ownerContract.command, "TopicService::rename_slug");
+assert.equal(ownerContract.authorization.action, "update");
+
+includesAll(
+  graphql,
+  [
+    "pub(crate) struct ForumTopicSlugRenameMutation",
+    "async fn rename_forum_topic_slug(",
+    "require_module_enabled(ctx, MODULE_SLUG).await?;",
+    "ctx.data::<DatabaseConnection>()?",
+    "ctx.data::<TransactionalEventBus>()?",
+    "ctx.data::<AuthContext>()",
+    "ctx.data::<TenantContext>()?",
+    "Permission::FORUM_TOPICS_UPDATE",
+    "Permission denied: forum_topics:update required",
+    "Permission denied: tenant scope mismatch",
+    "SecurityContext::from_permission_snapshot",
+    "TopicService::new(db.clone(), event_bus.clone())",
+    ".rename_slug(",
+    "pub struct RenameForumTopicSlugGraphqlInput",
+    "pub struct GqlForumTopicRouteDescriptor",
+    "pub struct GqlForumTopicSlugRename",
+    "previous_path: value.previous_path",
+    "canonical: value.canonical.into()",
+  ],
+  "topic slug rename GraphQL adapter",
+);
+
+for (const forbidden of [
+  "ForumTopicRouteService::new",
+  "rename_topic_slug_in_tx",
+  "forum_topic_route_aliases",
+  "resolve_canonical_topic",
+  "ForumTopicMergeService",
+  "ForumTopicMergeRouteBackfillService",
+  "bestEffort",
+  "ALLOW_MISSING",
+  "SKIP_VALIDATION",
+]) {
+  assert.ok(
+    !graphql.includes(forbidden),
+    `GraphQL adapter contains forbidden marker: ${forbidden}`,
+  );
+}
+
+includesAll(
+  graphqlMod,
+  [
+    "mod topic_slug_rename_mutation;",
+    "GqlForumTopicRouteDescriptor",
+    "GqlForumTopicSlugRename",
+    "RenameForumTopicSlugGraphqlInput",
+    "topic_slug_rename_mutation::ForumTopicSlugRenameMutation",
+  ],
+  "GraphQL root registration",
+);
+includesAll(
+  owner,
+  [
+    "pub async fn rename_slug(",
+    "Resource::ForumTopics",
+    "Action::Update",
+    "ForumTopicRouteService::rename_topic_slug_in_tx",
+    "publish_forum_topic_projection_in_tx",
+  ],
+  "topic owner",
+);
+includesAll(
+  routeOwner,
+  [
+    "pub(crate) async fn rename_topic_slug_in_tx(",
+    "FORUM_TOPIC_RENAMED_ROUTE_REASON",
+    "record_redirect_alias_in_tx",
+    "update_topic_route_slug_in_tx",
+  ],
+  "topic route owner",
+);
+includesAll(
+  schemaTest,
+  [
+    "graphql_schema_exposes_topic_slug_rename_command",
+    '"renameForumTopicSlug"',
+    '"RenameForumTopicSlugGraphqlInput"',
+    '"GqlForumTopicSlugRename"',
+    '"GqlForumTopicRouteDescriptor"',
+    '"previousPath"',
+    '"shortId"',
+    "graphql_rename_adapter_uses_routed_tenant_update_scope_and_owner_service",
+  ],
+  "GraphQL schema contract",
+);
+includesAll(
+  ownerRuntimeTest,
+  [
+    "renaming_slug_records_old_route_and_replay_is_idempotent",
+    "renamed_source_route_follows_merge_and_then_becomes_gone_after_delete",
+    "forum_topic_route_aliases",
+  ],
+  "owner runtime contract source",
+);
+includesAll(
+  docs,
+  [
+    "# FORUM-24F topic slug rename GraphQL transport",
+    "`source_ready_maintainer_execution_pending`",
+    "renameForumTopicSlug",
+    "forum_topics:update",
+    "TopicService::rename_slug",
+    "owner-defined",
+    "No command above was run by the implementation agent",
+  ],
+  "FORUM-24F handoff",
+);
+includesAll(
+  ownerDocs,
+  [
+    "# FORUM-24D localized topic slug rename owner",
+    "TopicService::rename_slug",
+    "Topic slug changed",
+  ],
+  "FORUM-24D owner handoff",
+);
+includesAll(
+  docsIndex,
+  [
+    "FORUM-24F exposes the localized topic slug rename owner through an additive GraphQL mutation",
+    "FORUM-24F topic slug rename GraphQL transport",
+  ],
+  "Forum docs index",
+);
+
+console.log(
+  "FORUM-24F topic slug rename GraphQL transport source is ready; maintainer execution and UI/public route composition remain pending.",
+);


### PR DESCRIPTION
## Summary

- add the additive `renameForumTopicSlug` GraphQL mutation for the existing FORUM-24D owner command;
- require the Forum module, routed tenant equality, authentication, and `forum_topics:update` at the transport boundary;
- preserve author/manager ownership semantics inside `TopicService::rename_slug`;
- return the previous route, canonical localized descriptor, immutable alias ID, and exact-replay `changed` result;
- keep route locking, alias persistence, merge/delete lifecycle behavior, transactions, and projection invalidation exclusively in the owner;
- add schema/source contract tests, a machine-readable FORUM-24F contract, documentation, and a static verifier;
- change no migration, REST route, event schema, admin UI, storefront UI, category route, public route mount, or SEO policy.

## Recheck

Reviewed the merged FORUM-24A through FORUM-24E owner chain and found no obvious source-level correctness defect in the route identity, merge/delete/rename composition, or bounded historical backfill. The canonical implementation plan is stale after FORUM-24E and does not yet mention FORUM-24F. It was not replaced here because the connected GitHub writer supports only complete-file replacement for that large document, not a safe localized patch.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Node verifiers;
- Cargo check/build/clippy/formatting;
- SQLite/PostgreSQL execution;
- workflows or CI.

Suggested maintainer commands:

```bash
node scripts/verify/verify-forum-topic-slug-rename-owner.mjs
node scripts/verify/verify-forum-topic-slug-rename-graphql-transport.mjs
cargo test -p rustok-forum graphql::topic_slug_rename_mutation::tests -- --nocapture
cargo test -p rustok-forum --test topic_slug_rename_graphql_contract -- --nocapture
cargo test -p rustok-forum --test topic_slug_rename_sqlite -- --nocapture
cargo check -p rustok-forum --all-targets
```

Source status remains `source_ready_maintainer_execution_pending`.