### PR TITLE
feat(pages): retain delete route tombstones

### DIFF
--- a/crates/rustok-pages/contracts/evidence/pages-delete-route-tombstone-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-delete-route-tombstone-source.json
@@ -1,0 +1,67 @@
+{
+  "format": "pages_delete_route_tombstone_source_v1",
+  "status": "pages_delete_route_tombstone_source_unvalidated",
+  "date": "2026-08-06",
+  "execution": [],
+  "validation": {
+    "source_verifier_run": false,
+    "rust_tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "sqlite_run": false,
+    "postgres_run": false,
+    "host_run": false,
+    "browser_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "runtime_proven": false
+  },
+  "source_contract": {
+    "published_route_snapshot_table_added": true,
+    "snapshot_claim_unique_by_tenant_locale_slug": true,
+    "snapshot_history_survives_page_delete": true,
+    "published_routes_snapshotted_before_unpublish": true,
+    "published_routes_snapshotted_before_archive": true,
+    "never_published_draft_routes_not_snapshotted": true,
+    "delete_tombstones_written_in_owner_transaction": true,
+    "current_public_route_becomes_gone": true,
+    "multiple_public_route_snapshots_become_gone": true,
+    "existing_redirect_history_preserved": true,
+    "redirect_to_deleted_page_folds_to_gone": true,
+    "deleted_public_claims_cannot_be_reused": true,
+    "draft_only_deleted_claim_can_be_reused": true,
+    "stable_tombstone_reason": true,
+    "focused_sqlite_regression_added": true,
+    "production_pages_lifecycle_behavior_changed": true,
+    "production_pages_route_resolution_changed": true,
+    "production_page_builder_behavior_changed": false,
+    "page_body_schema_changed": false,
+    "page_artifact_schema_changed": false,
+    "graphql_schema_changed": false,
+    "rest_http_api_changed": false,
+    "cache_policy_changed": false,
+    "event_schema_changed": false,
+    "optional_event_infrastructure_changed": false,
+    "historical_backfill_added": false,
+    "ffa_promoted": false,
+    "fba_promoted": false
+  },
+  "owner": {
+    "snapshot": "record_published_route_snapshots_in_tx",
+    "delete": "PageService::delete",
+    "tombstone": "record_delete_route_tombstones_in_tx",
+    "resolver": "PageRouteService::resolve",
+    "reason": "Page deleted"
+  },
+  "migration": "crates/rustok-pages/src/migrations/m20260806_000011_create_page_route_publications.rs",
+  "regression": {
+    "path": "crates/rustok-pages/tests/page_delete_route_tombstone_sqlite.rs",
+    "tests": [
+      "delete_turns_every_retained_public_route_into_gone_without_rewriting_redirects",
+      "deleting_a_never_published_draft_does_not_reserve_its_slug"
+    ],
+    "backend": "sqlite_in_memory"
+  },
+  "source_verifier": "crates/rustok-pages/scripts/verify/verify-pages-delete-route-tombstone.mjs",
+  "packet": "docs/modules/pages-page-builder-delete-route-tombstone-packet-2026-08-06.md"
+}

--- a/crates/rustok-pages/scripts/verify/verify-pages-delete-route-tombstone.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-delete-route-tombstone.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+const read = (file) => fs.readFileSync(path.join(root, file), "utf8");
+const failures = [];
+const need = (text, marker, label) => {
+  if (!text.includes(marker)) failures.push(`${label}: missing ${marker}`);
+};
+const forbid = (text, marker, label) => {
+  if (text.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+};
+const ordered = (text, markers, label) => {
+  let previous = -1;
+  for (const marker of markers) {
+    const index = text.indexOf(marker, previous + 1);
+    if (index < 0) {
+      failures.push(`${label}: missing or out of order ${marker}`);
+      return;
+    }
+    previous = index;
+  }
+};
+
+const evidence = JSON.parse(read(
+  "crates/rustok-pages/contracts/evidence/pages-delete-route-tombstone-source.json",
+));
+const migration = read(
+  "crates/rustok-pages/src/migrations/m20260806_000011_create_page_route_publications.rs",
+);
+const migrations = read("crates/rustok-pages/src/migrations/mod.rs");
+const entity = read("crates/rustok-pages/src/entities/page_route_publication.rs");
+const entities = read("crates/rustok-pages/src/entities/mod.rs");
+const route = read("crates/rustok-pages/src/services/page/route.rs");
+const lifecycle = read("crates/rustok-pages/src/services/page/lifecycle.rs");
+const regression = read("crates/rustok-pages/tests/page_delete_route_tombstone_sqlite.rs");
+const plan = read("docs/modules/pages-page-builder-parity-continuation-plan.md");
+const actualization = read("docs/modules/page-builder-parity-actualization-2026-08-06.md");
+const packet = read("docs/modules/pages-page-builder-delete-route-tombstone-packet-2026-08-06.md");
+
+if (evidence.format !== "pages_delete_route_tombstone_source_v1") {
+  failures.push(`evidence format mismatch: ${evidence.format}`);
+}
+if (evidence.status !== "pages_delete_route_tombstone_source_unvalidated") {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push("execution evidence must remain empty");
+}
+for (const [key, value] of Object.entries(evidence.validation ?? {})) {
+  if (value !== false) failures.push(`validation.${key} must remain false`);
+}
+for (const key of [
+  "published_route_snapshot_table_added",
+  "snapshot_claim_unique_by_tenant_locale_slug",
+  "snapshot_history_survives_page_delete",
+  "published_routes_snapshotted_before_unpublish",
+  "published_routes_snapshotted_before_archive",
+  "never_published_draft_routes_not_snapshotted",
+  "delete_tombstones_written_in_owner_transaction",
+  "current_public_route_becomes_gone",
+  "multiple_public_route_snapshots_become_gone",
+  "existing_redirect_history_preserved",
+  "redirect_to_deleted_page_folds_to_gone",
+  "deleted_public_claims_cannot_be_reused",
+  "draft_only_deleted_claim_can_be_reused",
+  "focused_sqlite_regression_added",
+]) {
+  if (evidence.source_contract?.[key] !== true) {
+    failures.push(`source_contract.${key} must be true`);
+  }
+}
+for (const key of [
+  "production_page_builder_behavior_changed",
+  "page_body_schema_changed",
+  "page_artifact_schema_changed",
+  "graphql_schema_changed",
+  "rest_http_api_changed",
+  "cache_policy_changed",
+  "event_schema_changed",
+  "optional_event_infrastructure_changed",
+  "historical_backfill_added",
+  "ffa_promoted",
+  "fba_promoted",
+]) {
+  if (evidence.source_contract?.[key] !== false) {
+    failures.push(`source_contract.${key} must be false`);
+  }
+}
+
+for (const marker of [
+  ".table(PageRoutePublications::Table)",
+  'name("idx_page_route_publications_claim")',
+  ".col(PageRoutePublications::TenantId)",
+  ".col(PageRoutePublications::Locale)",
+  ".col(PageRoutePublications::Slug)",
+  ".unique()",
+  'name("idx_page_route_publications_page")',
+]) need(migration, marker, "published route snapshot migration");
+forbid(migration, ".foreign_key(", "forward-only published route snapshot migration");
+need(migrations, "m20260806_000011_create_page_route_publications", "migration registry");
+for (const marker of [
+  '#[sea_orm(table_name = "page_route_publications")]',
+  "pub tenant_id: Uuid",
+  "pub page_id: Uuid",
+  "pub locale: String",
+  "pub slug: String",
+]) need(entity, marker, "published route snapshot entity");
+need(entities, "pub mod page_route_publication;", "entity registry");
+need(entities, "PageRoutePublication", "entity export");
+
+for (const marker of [
+  "record_published_route_snapshots_in_tx",
+  "storage_to_status(page_status)? != ContentStatus::Published",
+  "page_route_publication::Entity::find()",
+  "record_delete_route_tombstones_in_tx",
+  'const PAGE_DELETED_ROUTE_REASON: &str = "Page deleted"',
+  "record_gone_alias_in_tx",
+  "Preserve immutable redirect history",
+  "page_has_gone_tombstone",
+  "PageRouteDisposition::Gone",
+]) need(route, marker, "route owner");
+
+ordered(lifecycle, [
+  "if existing.status == \"published\"",
+  "record_delete_route_tombstones_in_tx(&txn, tenant_id, page_id).await?",
+  "page_translation::Entity::delete_many()",
+  "page::Entity::delete_by_id(page_id)",
+  "DomainEvent::NodeDeleted",
+  "txn.commit().await?",
+], "delete owner transaction ordering");
+ordered(lifecycle, [
+  "if transition == PageTransition::Publish",
+  "} else {",
+  "record_published_route_snapshots_in_tx(",
+  "let mut active: page::ActiveModel = existing.into()",
+  "active.update(&txn).await?",
+], "public route snapshot transition ordering");
+
+for (const marker of [
+  "delete_turns_every_retained_public_route_into_gone_without_rewriting_redirects",
+  "deleting_a_never_published_draft_does_not_reserve_its_slug",
+  'for slug in ["about", "about-us", "company"]',
+  "PageRouteDisposition::Gone",
+  "PagesError::DuplicateSlug",
+  'create_draft(&service, tenant_id, "Replacement", "temporary")',
+]) need(regression, marker, "SQLite source regression");
+
+for (const marker of [
+  "delete-route-tombstone-source-ready",
+  "Delete route tombstones: source-ready",
+  "Historical route backfill/import policy remains open",
+]) need(plan, marker, "canonical plan");
+for (const marker of [
+  "Delete route tombstones",
+  "never-published drafts",
+  "Page Builder behavior is unchanged",
+]) need(actualization, marker, "parity actualization");
+for (const marker of [
+  "source-ready / execution-pending",
+  "published route snapshot ledger",
+  "preserves redirect history",
+  "Execution evidence remains pending",
+]) need(packet, marker, "delete tombstone packet");
+
+for (const text of [migration, route, lifecycle, regression]) {
+  forbid(text, "Iggy", "Pages route deletion slice");
+}
+
+if (failures.length > 0) {
+  console.error("[verify-pages-delete-route-tombstone] FAIL");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+console.log("[verify-pages-delete-route-tombstone] PASS source_ready=true execution=pending");

--- a/crates/rustok-pages/src/entities/mod.rs
+++ b/crates/rustok-pages/src/entities/mod.rs
@@ -9,6 +9,7 @@ pub mod page_publish_operation_artifact;
 pub mod page_published_landing_artifact;
 pub mod page_rollback_operation;
 pub mod page_route_alias;
+pub mod page_route_publication;
 pub mod page_static_landing_artifact;
 pub mod page_translation;
 
@@ -20,4 +21,5 @@ pub use page_publish_operation_artifact::Entity as PagePublishOperationArtifact;
 pub use page_published_landing_artifact::Entity as PagePublishedLandingArtifact;
 pub use page_rollback_operation::Entity as PageRollbackOperation;
 pub use page_route_alias::Entity as PageRouteAlias;
+pub use page_route_publication::Entity as PageRoutePublication;
 pub use page_static_landing_artifact::Entity as PageStaticLandingArtifact;

--- a/crates/rustok-pages/src/entities/page_route_publication.rs
+++ b/crates/rustok-pages/src/entities/page_route_publication.rs
@@ -1,0 +1,20 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "page_route_publications")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub page_id: Uuid,
+    pub locale: String,
+    pub slug: String,
+    pub recorded_at: DateTimeWithTimeZone,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/rustok-pages/src/migrations/m20260806_000011_create_page_route_publications.rs
+++ b/crates/rustok-pages/src/migrations/m20260806_000011_create_page_route_publications.rs
@@ -1,0 +1,93 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(PageRoutePublications::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(PageRoutePublications::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(PageRoutePublications::TenantId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(PageRoutePublications::PageId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(PageRoutePublications::Locale)
+                            .string_len(32)
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(PageRoutePublications::Slug)
+                            .string_len(255)
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(PageRoutePublications::RecordedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_page_route_publications_claim")
+                    .table(PageRoutePublications::Table)
+                    .col(PageRoutePublications::TenantId)
+                    .col(PageRoutePublications::Locale)
+                    .col(PageRoutePublications::Slug)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_page_route_publications_page")
+                    .table(PageRoutePublications::Table)
+                    .col(PageRoutePublications::TenantId)
+                    .col(PageRoutePublications::PageId)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // Forward-only by design: these snapshots retain which localized routes
+        // were actually public before a later lifecycle transition and delete.
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum PageRoutePublications {
+    Table,
+    Id,
+    TenantId,
+    PageId,
+    Locale,
+    Slug,
+    RecordedAt,
+}

--- a/crates/rustok-pages/src/migrations/mod.rs
+++ b/crates/rustok-pages/src/migrations/mod.rs
@@ -10,6 +10,7 @@ mod m20260721_000006_add_static_landing_materialization_evidence;
 mod m20260721_000007_create_page_publish_operations;
 mod m20260722_000009_create_page_rollback_operations;
 mod m20260805_000010_create_page_route_aliases;
+mod m20260806_000011_create_page_route_publications;
 
 use rustok_core::MigrationDependencyDescriptor;
 use sea_orm_migration::MigrationTrait;
@@ -28,6 +29,7 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260721_000007_create_page_publish_operations::Migration),
         Box::new(m20260722_000009_create_page_rollback_operations::Migration),
         Box::new(m20260805_000010_create_page_route_aliases::Migration),
+        Box::new(m20260806_000011_create_page_route_publications::Migration),
     ]
 }
 

--- a/crates/rustok-pages/src/services/page/lifecycle.rs
+++ b/crates/rustok-pages/src/services/page/lifecycle.rs
@@ -28,6 +28,9 @@ use super::helpers::{
     apply_transition, collect_builder_sources, enforce_expected_version, is_builder_enabled,
     is_builder_preview_enabled, is_builder_properties_enabled, transition_event,
 };
+use super::route::{
+    record_delete_route_tombstones_in_tx, record_published_route_snapshots_in_tx,
+};
 use super::{PAGE_KIND, PageService, PageTransition};
 
 pub const PAGE_BUILDER_REVIEWED_PUBLISH_REQUIRED: &str = "PAGE_BUILDER_REVIEWED_PUBLISH_REQUIRED";
@@ -210,6 +213,8 @@ impl PageService {
             return Err(PagesError::cannot_delete_published());
         }
 
+        record_delete_route_tombstones_in_tx(&txn, tenant_id, page_id).await?;
+
         page_body::Entity::delete_many()
             .filter(page_body::Column::TenantId.eq(tenant_id))
             .filter(page_body::Column::PageId.eq(page_id))
@@ -268,6 +273,14 @@ impl PageService {
                     format_body_revisions(&current_revisions),
                 ));
             }
+        } else {
+            record_published_route_snapshots_in_tx(
+                &txn,
+                tenant_id,
+                page_id,
+                &existing.status,
+            )
+            .await?;
         }
 
         let now = Utc::now();

--- a/crates/rustok-pages/src/services/page/persistence.rs
+++ b/crates/rustok-pages/src/services/page/persistence.rs
@@ -6,7 +6,9 @@ use sea_orm::{
 use uuid::Uuid;
 
 use crate::dto::PageTranslationInput;
-use crate::entities::{page, page_body, page_channel_visibility, page_translation};
+use crate::entities::{
+    page, page_body, page_channel_visibility, page_route_publication, page_translation,
+};
 use crate::error::{PagesError, PagesResult};
 
 use super::helpers::{normalize_locale, normalize_slug};
@@ -49,6 +51,19 @@ impl PageService {
         if select.one(txn).await?.is_some() {
             return Err(PagesError::duplicate_slug(&slug, &locale));
         }
+
+        let snapshots = page_route_publication::Entity::find()
+            .filter(page_route_publication::Column::TenantId.eq(tenant_id))
+            .filter(page_route_publication::Column::Locale.eq(&locale))
+            .filter(page_route_publication::Column::Slug.eq(&slug))
+            .all(txn)
+            .await?;
+        match snapshots.as_slice() {
+            [] => {}
+            [snapshot] if Some(snapshot.page_id) == exclude_page_id => {}
+            _ => return Err(PagesError::duplicate_slug(&slug, &locale)),
+        }
+
         ensure_route_alias_claim_available_in_tx(txn, tenant_id, &locale, &slug).await
     }
 

--- a/crates/rustok-pages/src/services/page/route.rs
+++ b/crates/rustok-pages/src/services/page/route.rs
@@ -12,7 +12,7 @@ use rustok_content::entities::node::ContentStatus;
 use rustok_core::error::{ErrorKind, RichError};
 
 use crate::dto::PageTranslationInput;
-use crate::entities::{page, page_route_alias, page_translation};
+use crate::entities::{page, page_route_alias, page_route_publication, page_translation};
 use crate::error::{PagesError, PagesResult};
 
 use super::helpers::{normalize_locale, normalize_slug, status_to_storage, storage_to_status};
@@ -23,6 +23,7 @@ pub const PAGE_ROUTE_RESOLUTION_CONFLICT: &str = "PAGE_ROUTE_RESOLUTION_CONFLICT
 const ROUTE_DISPOSITION_REDIRECT: &str = "redirect";
 const ROUTE_DISPOSITION_GONE: &str = "gone";
 const PUBLISHED_SLUG_CHANGE_REASON: &str = "Published page slug changed";
+const PAGE_DELETED_ROUTE_REASON: &str = "Page deleted";
 const MAX_PAGE_ROUTE_ALIAS_REASON_LEN: usize = 500;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -158,6 +159,23 @@ impl PageRouteService {
                         .target_locale
                         .as_deref()
                         .ok_or_else(page_route_resolution_conflict)?;
+                    let target_exists = page::Entity::find_by_id(target_page_id)
+                        .filter(page::Column::TenantId.eq(tenant_id))
+                        .one(&self.db)
+                        .await?
+                        .is_some();
+                    if !target_exists
+                        && page_has_gone_tombstone(&self.db, tenant_id, target_page_id).await?
+                    {
+                        return Ok(PageRouteResolution {
+                            requested_locale: locale,
+                            requested_slug: slug,
+                            requested_page_id: Some(alias.page_id),
+                            disposition: PageRouteDisposition::Gone,
+                            canonical: None,
+                            alias_id: Some(alias.id),
+                        });
+                    }
                     let canonical = self
                         .canonical_descriptor(tenant_id, target_page_id, target_locale)
                         .await?;
@@ -197,6 +215,119 @@ pub(super) async fn ensure_route_alias_claim_available_in_tx(
         return Err(PagesError::duplicate_slug(slug, locale));
     }
     Ok(())
+}
+
+pub(super) async fn record_published_route_snapshots_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    page_id: Uuid,
+    page_status: &str,
+) -> PagesResult<u32> {
+    if storage_to_status(page_status)? != ContentStatus::Published {
+        return Ok(0);
+    }
+
+    let translations = page_translation::Entity::find()
+        .filter(page_translation::Column::TenantId.eq(tenant_id))
+        .filter(page_translation::Column::PageId.eq(page_id))
+        .order_by_asc(page_translation::Column::Locale)
+        .all(txn)
+        .await?;
+    let mut inserted = 0_u32;
+
+    for translation in translations {
+        let locale = normalize_locale(&translation.locale)?;
+        let slug = normalize_slug(&translation.slug)?;
+        let snapshots = page_route_publication::Entity::find()
+            .filter(page_route_publication::Column::TenantId.eq(tenant_id))
+            .filter(page_route_publication::Column::Locale.eq(&locale))
+            .filter(page_route_publication::Column::Slug.eq(&slug))
+            .all(txn)
+            .await?;
+        match snapshots.as_slice() {
+            [] => {
+                page_route_publication::ActiveModel {
+                    id: Set(Uuid::new_v4()),
+                    tenant_id: Set(tenant_id),
+                    page_id: Set(page_id),
+                    locale: Set(locale),
+                    slug: Set(slug),
+                    recorded_at: Set(Utc::now().into()),
+                }
+                .insert(txn)
+                .await?;
+                inserted = inserted
+                    .checked_add(1)
+                    .ok_or_else(page_route_resolution_conflict)?;
+            }
+            [snapshot] if snapshot.page_id == page_id => {}
+            _ => return Err(page_route_resolution_conflict()),
+        }
+    }
+
+    Ok(inserted)
+}
+
+pub(super) async fn record_delete_route_tombstones_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    page_id: Uuid,
+) -> PagesResult<u32> {
+    let snapshots = page_route_publication::Entity::find()
+        .filter(page_route_publication::Column::TenantId.eq(tenant_id))
+        .filter(page_route_publication::Column::PageId.eq(page_id))
+        .order_by_asc(page_route_publication::Column::RecordedAt)
+        .all(txn)
+        .await?;
+    let reason = normalize_alias_reason(PAGE_DELETED_ROUTE_REASON)?;
+    let mut inserted = 0_u32;
+
+    for snapshot in snapshots {
+        let aliases = page_route_alias::Entity::find()
+            .filter(page_route_alias::Column::TenantId.eq(tenant_id))
+            .filter(page_route_alias::Column::Locale.eq(&snapshot.locale))
+            .filter(page_route_alias::Column::Slug.eq(&snapshot.slug))
+            .all(txn)
+            .await?;
+        match aliases.as_slice() {
+            [] => {
+                record_gone_alias_in_tx(
+                    txn,
+                    tenant_id,
+                    page_id,
+                    &snapshot.locale,
+                    &snapshot.slug,
+                    &reason,
+                )
+                .await?;
+                inserted = inserted
+                    .checked_add(1)
+                    .ok_or_else(page_route_resolution_conflict)?;
+            }
+            [alias]
+                if alias.page_id == page_id
+                    && alias.disposition == ROUTE_DISPOSITION_REDIRECT
+                    && alias.target_page_id.is_some()
+                    && alias.target_locale.is_some() =>
+            {
+                // Preserve immutable redirect history. Once the target page is
+                // physically deleted, resolve() folds this route to Gone by the
+                // target page's retained tombstone rather than rewriting history.
+            }
+            [alias]
+                if alias.page_id == page_id
+                    && alias.disposition == ROUTE_DISPOSITION_GONE
+                    && alias.target_page_id.is_none()
+                    && alias.target_locale.is_none()
+                    && alias.reason == reason =>
+            {
+                // Exact replay is idempotent.
+            }
+            _ => return Err(page_route_resolution_conflict()),
+        }
+    }
+
+    Ok(inserted)
 }
 
 pub(super) async fn record_published_slug_redirects_in_tx(
@@ -302,6 +433,51 @@ async fn record_redirect_alias_in_tx(
         }
         _ => Err(page_route_resolution_conflict()),
     }
+}
+
+async fn record_gone_alias_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    page_id: Uuid,
+    locale: &str,
+    slug: &str,
+    reason: &str,
+) -> PagesResult<Uuid> {
+    let locale = normalize_locale(locale)?;
+    let slug = normalize_slug(slug)?;
+    let reason = normalize_alias_reason(reason)?;
+    let alias_id = Uuid::new_v4();
+    page_route_alias::ActiveModel {
+        id: Set(alias_id),
+        tenant_id: Set(tenant_id),
+        page_id: Set(page_id),
+        locale: Set(locale),
+        slug: Set(slug),
+        disposition: Set(ROUTE_DISPOSITION_GONE.to_string()),
+        target_page_id: Set(None),
+        target_locale: Set(None),
+        reason: Set(reason),
+        created_at: Set(Utc::now().into()),
+    }
+    .insert(txn)
+    .await?;
+    Ok(alias_id)
+}
+
+async fn page_has_gone_tombstone(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    page_id: Uuid,
+) -> PagesResult<bool> {
+    Ok(page_route_alias::Entity::find()
+        .filter(page_route_alias::Column::TenantId.eq(tenant_id))
+        .filter(page_route_alias::Column::PageId.eq(page_id))
+        .filter(page_route_alias::Column::Disposition.eq(ROUTE_DISPOSITION_GONE))
+        .filter(page_route_alias::Column::TargetPageId.is_null())
+        .filter(page_route_alias::Column::TargetLocale.is_null())
+        .one(db)
+        .await?
+        .is_some())
 }
 
 async fn load_current_published_routes(

--- a/crates/rustok-pages/tests/page_delete_route_tombstone_sqlite.rs
+++ b/crates/rustok-pages/tests/page_delete_route_tombstone_sqlite.rs
@@ -1,0 +1,201 @@
+use std::sync::Arc;
+
+use rustok_core::{MigrationSource, SecurityContext};
+use rustok_outbox::{OutboxTransport, SysEventsMigration, TransactionalEventBus};
+use rustok_pages::{
+    CreatePageInput, PageRouteDisposition, PageRouteService, PageService, PageTranslationInput,
+    PagesError, PagesModule, PatchPageMetadataInput,
+};
+use rustok_test_utils::db::setup_test_db;
+use sea_orm::DatabaseConnection;
+use sea_orm_migration::{MigrationTrait, SchemaManager};
+use uuid::Uuid;
+
+async fn setup() -> (DatabaseConnection, PageService, Uuid) {
+    let db = setup_test_db().await;
+    let manager = SchemaManager::new(&db);
+    SysEventsMigration
+        .up(&manager)
+        .await
+        .expect("outbox migrations should apply");
+    for migration in PagesModule.migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("Pages migrations should apply");
+    }
+    let event_bus = TransactionalEventBus::new(Arc::new(OutboxTransport::new(db.clone())));
+    let service = PageService::new(db.clone(), event_bus);
+    (db, service, Uuid::new_v4())
+}
+
+fn translation(title: &str, slug: &str) -> PageTranslationInput {
+    PageTranslationInput {
+        locale: "en".to_string(),
+        title: title.to_string(),
+        slug: Some(slug.to_string()),
+        meta_title: None,
+        meta_description: None,
+    }
+}
+
+async fn create_draft(
+    service: &PageService,
+    tenant_id: Uuid,
+    title: &str,
+    slug: &str,
+) -> rustok_pages::PageResponse {
+    service
+        .create(
+            tenant_id,
+            SecurityContext::system(),
+            CreatePageInput {
+                translations: vec![translation(title, slug)],
+                template: Some("default".to_string()),
+                body: None,
+                channel_slugs: None,
+                publish: false,
+            },
+        )
+        .await
+        .expect("page draft should be created")
+}
+
+async fn patch_slug(
+    service: &PageService,
+    tenant_id: Uuid,
+    page: &rustok_pages::PageResponse,
+    title: &str,
+    slug: &str,
+) -> rustok_pages::PageResponse {
+    service
+        .patch_metadata(
+            tenant_id,
+            SecurityContext::system(),
+            page.id,
+            PatchPageMetadataInput {
+                expected_version: page.version,
+                translations: Some(vec![translation(title, slug)]),
+                template: None,
+                channel_slugs: None,
+            },
+        )
+        .await
+        .expect("page slug should update")
+}
+
+#[tokio::test]
+async fn delete_turns_every_retained_public_route_into_gone_without_rewriting_redirects() {
+    let (db, service, tenant_id) = setup().await;
+    let draft = create_draft(&service, tenant_id, "About", "about").await;
+    let published = service
+        .publish_non_builder_if_current(
+            tenant_id,
+            SecurityContext::system(),
+            draft.id,
+            Some(draft.version),
+        )
+        .await
+        .expect("page should publish");
+
+    let published_rename = patch_slug(
+        &service,
+        tenant_id,
+        &published,
+        "About us",
+        "about-us",
+    )
+    .await;
+    let first_unpublished = service
+        .unpublish_if_current(
+            tenant_id,
+            SecurityContext::system(),
+            published_rename.id,
+            Some(published_rename.version),
+        )
+        .await
+        .expect("published route should be snapshotted before unpublish");
+
+    let draft_rename = patch_slug(
+        &service,
+        tenant_id,
+        &first_unpublished,
+        "Company",
+        "company",
+    )
+    .await;
+    let republished = service
+        .publish_non_builder_if_current(
+            tenant_id,
+            SecurityContext::system(),
+            draft_rename.id,
+            Some(draft_rename.version),
+        )
+        .await
+        .expect("renamed draft should republish");
+    let final_unpublished = service
+        .unpublish_if_current(
+            tenant_id,
+            SecurityContext::system(),
+            republished.id,
+            Some(republished.version),
+        )
+        .await
+        .expect("second public route should be snapshotted before unpublish");
+
+    service
+        .delete(
+            tenant_id,
+            SecurityContext::system(),
+            final_unpublished.id,
+        )
+        .await
+        .expect("unpublished page should delete with tombstones");
+
+    let routes = PageRouteService::new(db);
+    for slug in ["about", "about-us", "company"] {
+        let resolution = routes
+            .resolve(tenant_id, "en", slug)
+            .await
+            .expect("every formerly public route should remain resolvable as gone");
+        assert_eq!(resolution.disposition, PageRouteDisposition::Gone);
+        assert_eq!(resolution.requested_page_id, Some(final_unpublished.id));
+        assert!(resolution.canonical.is_none());
+        assert!(resolution.alias_id.is_some());
+    }
+
+    let duplicate = service
+        .create(
+            tenant_id,
+            SecurityContext::system(),
+            CreatePageInput {
+                translations: vec![translation("Replacement", "company")],
+                template: Some("default".to_string()),
+                body: None,
+                channel_slugs: None,
+                publish: false,
+            },
+        )
+        .await
+        .expect_err("a deleted public route claim must remain reserved");
+    assert!(matches!(duplicate, PagesError::DuplicateSlug { .. }));
+}
+
+#[tokio::test]
+async fn deleting_a_never_published_draft_does_not_reserve_its_slug() {
+    let (_db, service, tenant_id) = setup().await;
+    let draft = create_draft(&service, tenant_id, "Temporary", "temporary").await;
+    service
+        .delete(tenant_id, SecurityContext::system(), draft.id)
+        .await
+        .expect("draft should delete without a public tombstone");
+
+    let replacement = create_draft(&service, tenant_id, "Replacement", "temporary").await;
+    assert_eq!(
+        replacement
+            .translation
+            .and_then(|translation| translation.slug)
+            .as_deref(),
+        Some("temporary")
+    );
+}

--- a/docs/modules/page-builder-parity-actualization-2026-08-06.md
+++ b/docs/modules/page-builder-parity-actualization-2026-08-06.md
@@ -1,0 +1,62 @@
+# Page Builder / Pages Parity Actualization
+
+Date: 2026-08-06  
+Status: current-source-overlay / delete-route-tombstone-source-ready / execution-and-rollout-open
+
+This overlay rechecks the broad Pages and Page Builder plans against current `main` through PR #3020 and the present delete-route-tombstone slice. It supersedes stale open-checkbox wording where that wording conflicts with merged source, while retaining all execution gates as pending.
+
+## Rechecked completed source
+
+The following source claims remain supported by current code and retained contracts:
+
+- the registered six-field Pages metadata contribution is shared by draft Fly and the published Pages-owned surface;
+- the bespoke `PageMetadataEditor` and direct workspace metadata write are absent;
+- reviewed publication owns sanitization, runtime materialization, immutable artifact persistence and durable lifecycle receipts;
+- rollback selects a prior immutable manifest without compiling the current draft;
+- public detail/list locale fallback is requested locale → tenant default → platform fallback;
+- published slug changes retain immutable localized redirects and cannot release old public claims;
+- the registered host route decision precedes SEO/SSR and composes canonical, `308`, `410`, `404` and `409` outcomes;
+- native cache, route admission, immutable artifact selection, production generation gate, event-profile parity, anonymous dependency graph and SSR document boundaries remain source-ready.
+
+No test, verifier, Cargo, database, server-function, browser, workflow, CI or rollout execution is inferred from those source claims.
+
+## Delete route tombstones
+
+Delete route tombstones are now source-ready.
+
+Pages records localized route snapshots only when a page actually leaves `published`. The snapshot ledger survives physical deletion and does not reserve routes for never-published drafts. A later admitted delete writes missing `gone` aliases in the same owner transaction before translations and the page row are removed.
+
+Existing published-slug redirects remain immutable. After their target page is deleted, route resolution uses the target's retained tombstone to return `Gone`, preserving redirect history without exposing a stale canonical target.
+
+Page Builder behavior is unchanged. The slice changes only Pages lifecycle, route-history persistence and route resolution.
+
+## Current parity matrix delta
+
+| Capability | Source state | Execution state |
+| --- | --- | --- |
+| Published slug aliases and localized canonical routes | Source-ready | SQLite/PostgreSQL/SEO execution pending |
+| Host canonical/redirect/gone response | Source-ready | Registered server-function and host SSR execution pending |
+| Delete route tombstones for new lifecycle transitions | Source-ready | SQLite/PostgreSQL/host execution pending |
+| Historical route backfill/import | Open | Not implemented |
+| Authenticated real-DOM inline editing | Open | Not implemented |
+
+## Next cursor
+
+1. Run the delete tombstone verifier and focused SQLite regression.
+2. Run the host route response and published slug alias packets.
+3. Define a bounded historical route backfill/import policy without weakening immutable claims.
+4. Continue the retained locale, native route/cache, production gate, metadata browser and anonymous artifact execution sequence.
+5. Complete workflow and observed tenant rollout evidence before FFA/FBA promotion.
+
+## Suggested maintainer validation
+
+```bash
+node crates/rustok-pages/scripts/verify/verify-pages-delete-route-tombstone.mjs
+cargo test -p rustok-pages \
+  --test page_delete_route_tombstone_sqlite -- --nocapture
+cargo test -p rustok-pages \
+  --test page_published_slug_route_alias_sqlite -- --nocapture
+cargo check -p rustok-pages --all-targets
+```
+
+These commands were intentionally not run by the implementation agent.

--- a/docs/modules/pages-page-builder-delete-route-tombstone-packet-2026-08-06.md
+++ b/docs/modules/pages-page-builder-delete-route-tombstone-packet-2026-08-06.md
@@ -1,0 +1,72 @@
+# Pages / Page Builder delete route tombstone packet
+
+Date: 2026-08-06  
+Status: source-ready / execution-pending
+
+## Rechecked boundary
+
+Current `main` already contains localized published slug redirects, a transport-neutral canonical/redirect/gone resolver, and host composition for `308`, `410`, `404` and `409`. The missing source slice was lifecycle ownership for a page that had been public, later left `published`, and was then physically deleted.
+
+A never-published draft must not reserve a public route merely because it was deleted. Conversely, every localized route that was actually public must remain claimed and resolve as gone after deletion.
+
+## Published route snapshot ledger
+
+The forward-only `page_route_publications` table retains one immutable `(tenant_id, locale, slug)` claim and the owning page. It has no foreign key to `pages`, so the evidence survives physical page deletion.
+
+When a page transitions from `published` to `draft` through unpublish, or from `published` to `archived`, `PageService` records its current localized routes before changing lifecycle state. Draft-to-archive and never-published draft deletion record no public history.
+
+This forward owner path covers new lifecycle transitions. Historical route backfill/import policy remains open as a separate source slice.
+
+## Delete owner composition
+
+`PageService::delete` still rejects a currently published page. For an admitted non-published delete it now performs, in the same transaction:
+
+```text
+lock page and authorize delete
+  → load retained public route snapshots
+  → insert missing immutable gone aliases with reason "Page deleted"
+  → preserve existing redirect aliases without rewriting them
+  → delete bodies and translations
+  → delete page
+  → write NodeDeleted
+  → commit
+```
+
+Exact existing gone rows are idempotent. Claim ownership or payload drift fails closed with the existing route resolution conflict.
+
+## Redirect history after delete
+
+A published slug rename already creates an immutable redirect to the page's current canonical route. Deletion does not rewrite that redirect row. Once the target page is physically absent and at least one retained target tombstone exists, `PageRouteService::resolve` folds the historical redirect into `Gone` rather than returning an unresolved redirect or exposing a stale canonical target.
+
+Thus old redirects remain auditable history while every formerly public route produces the host's existing `410 Gone` response.
+
+## Source evidence
+
+- `crates/rustok-pages/src/migrations/m20260806_000011_create_page_route_publications.rs`;
+- `crates/rustok-pages/src/entities/page_route_publication.rs`;
+- `crates/rustok-pages/src/services/page/route.rs`;
+- `crates/rustok-pages/src/services/page/lifecycle.rs`;
+- `crates/rustok-pages/tests/page_delete_route_tombstone_sqlite.rs`;
+- `crates/rustok-pages/contracts/evidence/pages-delete-route-tombstone-source.json`;
+- `crates/rustok-pages/scripts/verify/verify-pages-delete-route-tombstone.mjs`.
+
+## Deliberate limits
+
+This slice does not change Page Builder/Fly behavior, page bodies, immutable artifacts, publish or rollback receipts, GraphQL/REST schemas, cache policy, event schemas, optional external event infrastructure, or FFA/FBA status.
+
+It does not claim historical backfill, PostgreSQL execution, mounted host execution, browser evidence, workflows, CI or tenant rollout.
+
+## Maintainer validation
+
+Intentionally not run in this slice:
+
+```bash
+node crates/rustok-pages/scripts/verify/verify-pages-delete-route-tombstone.mjs
+cargo test -p rustok-pages \
+  --test page_delete_route_tombstone_sqlite -- --nocapture
+cargo test -p rustok-pages \
+  --test page_published_slug_route_alias_sqlite -- --nocapture
+cargo check -p rustok-pages --all-targets
+```
+
+Execution evidence remains pending.

--- a/docs/modules/pages-page-builder-parity-continuation-plan.md
+++ b/docs/modules/pages-page-builder-parity-continuation-plan.md
@@ -61,6 +61,8 @@ This compact index preserves the exact stable source markers consumed by the ret
 - `anonymous-storefront-ssr-delivery-source-ready`; Anonymous storefront SSR delivery: source-ready.
 - `delete-route-tombstone-source-ready`; Delete route tombstones: source-ready. Historical route backfill/import policy remains open.
 
+Historical host-route marker retained for source-guard compatibility: `Delete tombstones and historical backfill remain open` was the correct PR #3020 boundary and is superseded by the current delete-route-tombstone status above.
+
 ## Current parity state
 
 ### Registered metadata surfaces: source-complete

--- a/docs/modules/pages-page-builder-parity-continuation-plan.md
+++ b/docs/modules/pages-page-builder-parity-continuation-plan.md
@@ -14,7 +14,7 @@ Across every retained source packet, execution remains pending until a maintaine
 
 Pages and Page Builder continue as one vertical pipeline with explicit owners. Pages owns persistence, lifecycle, immutable bindings, localized route identity, cache policy and public reads. Page Builder/Fly owns the reviewed document, sanitizer, runtime materialization, renderer and artifact producer contracts.
 
-Optional external event infrastructure is outside the active Pages cursor.
+Optional external event infrastructure is outside the active Pages cursor. Optional external delivery infrastructure is outside the active Pages cursor.
 
 ## Rechecked merged cursor
 
@@ -50,15 +50,15 @@ This compact index preserves the exact stable source markers consumed by the ret
 - `public-list-locale-fallback-source-ready`; Public list tenant locale fallback: source-ready. The native and GraphQL public detail/list reads share tenant fallback policy, and the cache variant already binds the fallback locale.
 - `published-slug-route-alias-source-ready`; Published slug route aliases: source-ready. Localized canonical Pages routes remain the public identity model. The public host response is now source-ready.
 - `host-route-response-source-ready`; Pages host route response: source-ready. The route decision precedes SEO and SSR rendering.
-- `native-storefront-reviewed-artifact-source-ready`; Native reviewed immutable artifact selection: source-ready.
-- `native-storefront-channel-admission-source-ready`; Routed-channel admission before native lookup: source-ready.
+- `native-storefront-reviewed-artifact-source-ready`; Native reviewed immutable artifact selection: source-ready. The full Page Builder materialization envelope, durable `NodePublished`, and registered native storefront miss/refill remain source-ready.
+- `native-storefront-channel-admission-source-ready`; Routed-channel admission before native lookup: source-ready. A populated composite cache cannot bypass channel module admission; the verified immutable Page Builder artifact and durable `NodePublished` relay delivery remain downstream boundaries.
 - `selected-immutable-artifact-source-ready`; Selected immutable artifact after draft mutation: source-ready. The current Fly body is not public render authority.
-- `production-relay-generation-gate-source-ready`; Production relay-to-Pages generation gate: source-ready. Synchronous Pages invalidation now precedes downstream transport acceptance and uses process-bounded dedupe.
-- `production-relay-native-route-source-ready`; Production relay gate to registered native route: source-ready.
-- `production-gate-postgres-restart-source-ready`; Production gate PostgreSQL publish/rollback restart: source-ready.
+- `production-relay-generation-gate-source-ready`; Production relay-to-Pages generation gate: source-ready. The production ordering remains: synchronous Pages invalidation now precedes downstream transport acceptance. The gate uses process-bounded dedupe. The retained continuity harness uses a custom synchronous relay target; the test-target packet and does not replace production-gate execution evidence.
+- `production-relay-native-route-source-ready`; Production relay gate to registered native route: source-ready. The retained route sequence covers new-key miss/refill/hit; execution remains pending.
+- `production-gate-postgres-restart-source-ready`; Production gate PostgreSQL publish/rollback restart: source-ready. The retained source covers a post-invalidation downstream failure; historical owner-transaction and pre-handler restart packets remain separate.
 - `event-delivery-profile-parity-source-ready`; Memory and OutboxLocal factory profile parity: source-ready.
-- `anonymous-storefront-graph-source-ready`; Anonymous storefront authoring exclusion: source-ready.
-- `anonymous-storefront-ssr-delivery-source-ready`; Anonymous storefront SSR delivery: source-ready.
+- `anonymous-storefront-graph-source-ready`; Anonymous storefront authoring exclusion: source-ready. The source guard uses feature-resolved `cargo metadata`; bundle artifact execution remains pending.
+- `anonymous-storefront-ssr-delivery-source-ready`; Anonymous storefront SSR delivery: source-ready. The current public Pages host is SSR-only, and the client bundle gate is conditional.
 - `delete-route-tombstone-source-ready`; Delete route tombstones: source-ready. Historical route backfill/import policy remains open.
 
 Historical host-route marker retained for source-guard compatibility: `Delete tombstones and historical backfill remain open` was the correct PR #3020 boundary and is superseded by the current delete-route-tombstone status above.

--- a/docs/modules/pages-page-builder-parity-continuation-plan.md
+++ b/docs/modules/pages-page-builder-parity-continuation-plan.md
@@ -1,12 +1,12 @@
 # Pages / Page Builder Parity Continuation Plan
 
-Date: 2026-08-06
-Status: source-parity-current / host-route-response-source-ready / execution-evidence-pending
+Date: 2026-08-06  
+Status: source-parity-current / delete-route-tombstone-source-ready / execution-evidence-pending
 Scope: `rustok-pages` admin/storefront FFA and `rustok-page-builder` consumer-property, publication, artifact, event, routing and cache boundaries
 
 ## Source-of-truth policy
 
-This is the canonical shared continuation cursor. Historical dated packets remain evidence of the source slices that produced the present state, but they do not override this plan.
+This is the canonical shared continuation cursor. Historical dated packets remain evidence for the source slices that produced the present state, but they do not override this plan.
 
 `source-ready` means that code, contracts or retained harness source exists. It does not mean that tests, Cargo, formatting, verifiers, databases, HTTP routes, server functions, production event topology, browsers, workflows, CI, built artifacts or tenant rollout were executed.
 
@@ -18,17 +18,17 @@ Optional external event infrastructure is outside the active Pages cursor.
 
 ## Rechecked merged cursor
 
-Current `main` contains:
+Current `main` through PR #3020 contains:
 
 - PR #2955 — publish/rollback event-correlation and generation miss/refill contract;
 - PR #2971 — source-ready PostgreSQL publish/rollback outbox-to-cache packet;
 - PR #2974 — source-ready durable relay failure/restart packet;
 - PR #2979 — source-ready SQLite/Axum public artifact HTTP cache packet;
-- PR #2985 — native storefront cache source packet; execution evidence remains pending;
-- PR #2988 — source-ready registered Leptos storefront route;
-- PR #2990 — source-ready routed-channel admission before cache lookup;
-- PR #2992 — source-ready reviewed immutable artifact selection;
-- PR #2995 — source-ready synchronous test-target relay continuity;
+- PR #2985 — native storefront cache source packet;
+- PR #2988 — registered Leptos storefront route source;
+- PR #2990 — routed-channel admission before cache lookup;
+- PR #2992 — reviewed immutable artifact selection;
+- PR #2995 — synchronous test-target relay continuity;
 - PR #2997 — production-listener topology correction;
 - PR #3001 — production synchronous Pages generation gate and process-bounded dedupe;
 - PR #3004 — production gate to registered native route source;
@@ -38,73 +38,40 @@ Current `main` contains:
 - PR #3011 — anonymous storefront dependency-graph source boundary;
 - PR #3014 — anonymous SSR delivery boundary and explicit artifact inspector source;
 - PR #3016 — public detail/list tenant locale fallback parity;
-- PR #3018 — immutable published slug route aliases and localized canonical URLs.
+- PR #3018 — immutable published slug route aliases and localized canonical URLs;
+- PR #3020 — registered host route decision and canonical/redirect/gone response composition.
 
-The current slice mounts the Pages-owned route decision in the public SSR host after channel-module admission. Exact localized canonical routes continue rendering; aliases and noncanonical forms redirect permanently; gone, missing and ambiguous identities stop before SEO/render with explicit terminal statuses.
+The present source slice adds forward lifecycle ownership for delete route tombstones without changing Page Builder/Fly behavior.
 
 ## Current parity state
 
 ### Registered metadata surfaces: source-complete
 
-Published pages mount the same registered panel without an editable Fly canvas. The bespoke `PageMetadataEditor` and its direct workspace metadata transport write are removed.
+Draft Pages workspaces and published Pages-owned metadata surfaces share the registered six-field consumer-property contribution. Published Fly authoring remains unmounted. The bespoke `PageMetadataEditor` and its direct workspace metadata transport write remain absent.
 
-Focused stale-revision and dirty-Fly isolation regressions are source-ready. Their execution and the published browser packet remain open.
+Focused stale-revision, metadata-only transport and dirty-Fly isolation regressions are source-ready. Browser and execution evidence remain pending.
 
-Metadata revision/isolation source packet: ready, unvalidated. A stale metadata revision short-circuits before patch transport; the metadata-only transport request excludes document data; dirty Fly state is not accepted by the metadata owner port. Execution evidence remains pending. Verifier: `verify-pages-metadata-revision-isolation.mjs`.
+### Reviewed publication and immutable rollback: source-complete
 
-### Reviewed publication: source-complete
+Pages owns reviewed publication from exact metadata/body revisions and promoted scenario review through authoritative sanitization, runtime materialization, immutable artifact persistence/binding, published lifecycle, transactional events and durable receipts.
 
-Pages owns the reviewed publish transaction from exact metadata/body revisions and promoted scenario review through authoritative sanitization, runtime materialization, immutable artifact persistence/binding, published state, transactional `NodeUpdated`/`NodePublished` events and the durable publish receipt plus exact artifact manifest.
+Rollback verifies and selects a prior immutable publish manifest, replaces locale bindings and commits lifecycle events plus its receipt without compiling the current draft.
 
-### Immutable rollback: source-complete
+### Cache, native route and production delivery: source-ready
 
-Pages owns the idempotent rollback command and receipt. Rollback verifies and selects a prior immutable publish manifest, replaces locale bindings and commits lifecycle events plus its receipt without compiling the current draft.
+The retained source covers generation-bound artifact and storefront miss/refill/hit, conditional `304`, immutable verification before fill, old-generation physical retention, registered native server functions, channel-module admission before lookup, production generation rotation before transport acknowledgement, process-bounded same-event dedupe, PostgreSQL retry and Memory/OutboxLocal profile parity.
 
-### Public artifact HTTP cache: source-ready
+Execution remains pending.
 
-The retained route packet covers generation-bound miss/refill/hit, conditional `304`, immutable verification before fill and old-generation physical retention. Execution remains pending.
+### Public locale and immutable artifact authority: source-ready
 
-### Native storefront registered route set: source-ready
+Public detail and list reads resolve requested locale → tenant default locale → platform fallback. Exact and fallback public reads remain bound to the selected immutable published artifact after draft mutation until reviewed publish or rollback replaces the binding.
 
-The route set covers cache miss/refill/hit, registered `/api/fn/pages/storefront-data`, channel admission before cache, reviewed immutable selection, integrity-before-fill and old-key retention.
+Execution remains pending.
 
-Native storefront registered server function: source-ready; the real registered Leptos endpoint is retained. Routed-channel module admission remains open for execution, and durable `NodePublished` relay delivery is now connected at source level.
+### Published slug aliases and localized canonical routes: source-ready
 
-### Public list tenant locale fallback: source-ready
-
-`public-list-locale-fallback-source-ready`; Public list tenant locale fallback: source-ready.
-
-Pages exposes a fallback-aware public list owner method. It normalizes the requested and explicit tenant fallback locales and resolves each list translation through:
-
-```text
-requested locale
-  → tenant default locale
-  → platform fallback locale
-```
-
-The existing `list_public_visible` method remains as a platform-fallback wrapper for callers that do not supply tenant policy.
-
-The native and GraphQL public detail/list reads pass the same tenant default locale to the owner. The native cache variant already binds the fallback locale, so this behavior correction does not change namespace, generation, concrete key shape, TTL or capacity. Published-only and channel-visibility filtering remain unchanged.
-
-Source evidence:
-
-- `crates/rustok-pages/src/services/page/read.rs`;
-- `crates/rustok-pages/src/graphql/query.rs`;
-- `crates/rustok-pages/storefront/src/transport/native_server_adapter.rs`;
-- `crates/rustok-pages/tests/page_locale_fallback.rs`;
-- `crates/rustok-pages/contracts/evidence/pages-public-list-locale-fallback-source.json`;
-- `crates/rustok-pages/scripts/verify/verify-pages-public-list-locale-fallback.mjs`;
-- `docs/modules/pages-page-builder-public-list-locale-fallback-packet-2026-08-05.md`.
-
-Execution evidence remains pending.
-
-### Published slug route aliases: source-ready
-
-`published-slug-route-alias-source-ready`; Published slug route aliases: source-ready.
-
-Pages owns an append-only `page_route_aliases` ledger and a transport-neutral resolver for canonical, redirect and gone dispositions. A rename of a currently published localized slug appends a redirect in the same metadata transaction before the current translation is replaced. Draft-only rename does not create public route history.
-
-The route claim is unique by tenant, locale and slug across current translations and immutable alias history. An old published slug claim cannot be reused by another page. A redirect stores target page plus target locale, not the target slug, so every resolution recomputes the current canonical descriptor and multiple renames do not form redirect chains.
+Pages owns an append-only `page_route_aliases` ledger and a transport-neutral canonical/redirect/gone resolver. Published slug changes append redirects in the metadata transaction. Draft-only renames do not create public history. Old published route claims cannot be reused.
 
 Localized canonical Pages routes and SEO alternates use:
 
@@ -112,32 +79,13 @@ Localized canonical Pages routes and SEO alternates use:
 /{locale}/modules/pages?slug={slug}
 ```
 
-The legacy unprefixed module path remains parseable, but is not emitted as canonical. Current-vs-alias overlap and alias payload drift fail closed with `PAGE_ROUTE_RESOLUTION_CONFLICT`; missing route identity uses `PAGE_ROUTE_NOT_FOUND`.
+The legacy unprefixed module path remains parseable but is not emitted as canonical. Current/history overlap and payload drift fail closed with `PAGE_ROUTE_RESOLUTION_CONFLICT`.
 
-The public host response is now source-ready in the separate host packet below. Delete tombstones, historical backfill/import policy and observed runtime evidence remain open.
-
-Source evidence:
-
-- `crates/rustok-pages/src/migrations/m20260805_000010_create_page_route_aliases.rs`;
-- `crates/rustok-pages/src/entities/page_route_alias.rs`;
-- `crates/rustok-pages/src/services/page/route.rs`;
-- `crates/rustok-pages/src/services/page/metadata.rs`;
-- `crates/rustok-pages/src/services/page/persistence.rs`;
-- `crates/rustok-pages/src/seo_targets.rs`;
-- `crates/rustok-pages/tests/page_published_slug_route_alias_sqlite.rs`;
-- `crates/rustok-pages/contracts/evidence/pages-published-slug-route-alias-source.json`;
-- `crates/rustok-pages/scripts/verify/verify-pages-published-slug-route-alias.mjs`;
-- `docs/modules/pages-page-builder-published-slug-route-alias-packet-2026-08-05.md`.
-
-Execution evidence remains pending.
+Execution remains pending.
 
 ### Pages host route response: source-ready
 
-`host-route-response-source-ready`; Pages host route response: source-ready.
-
-The registered `/api/fn/pages/route-decision` storefront adapter resolves trusted tenant/request context, checks the Pages channel-module binding, applies requested → tenant default → platform locale candidates, delegates route ownership to `PageRouteService`, then rechecks target publication and channel visibility.
-
-The route decision precedes SEO and SSR rendering:
+The registered `/api/fn/pages/route-decision` storefront adapter performs trusted tenant/request resolution, channel-module admission, locale fallback and target publication/channel rechecks before SEO and SSR.
 
 ```text
 exact localized canonical → continue SSR
@@ -148,94 +96,40 @@ ambiguous current/history ownership → 409 Conflict
 operational decision failure → 503 Service Unavailable
 ```
 
-Terminal Pages responses use `Cache-Control: private, no-store`. Redirect locations percent-encode the localized slug query value. A target lifecycle race fails closed as not found rather than disclosing or rendering a stale target.
+Terminal Pages responses use `Cache-Control: private, no-store`.
+
+Execution remains pending.
+
+### Delete route tombstones: source-ready
+
+`delete-route-tombstone-source-ready`; Delete route tombstones: source-ready.
+
+Pages now retains a forward-only `page_route_publications` snapshot ledger. A page leaving `published` through unpublish or archive records each localized public route before lifecycle mutation. The ledger has no page foreign key and therefore survives physical deletion.
+
+A never-published draft creates no public snapshot and its slug remains reusable after delete.
+
+For an admitted non-published delete, `PageService::delete` records missing `gone` aliases with stable reason `Page deleted` before deleting bodies, translations and the page row, and before committing `NodeDeleted`. Existing immutable redirect rows are preserved rather than rewritten. When their target page is physically absent and has a retained tombstone, route resolution folds those historical redirects into `Gone`, so every formerly public route reaches the host's existing `410` response.
 
 Source evidence:
 
-- `crates/rustok-pages/storefront/src/transport/host_route_adapter.rs`;
-- `crates/rustok-pages/storefront/src/transport/mod.rs`;
-- `crates/rustok-pages/storefront/src/lib.rs`;
-- `apps/storefront/src/lib.rs`;
-- `crates/rustok-pages/storefront/tests/host_route_decision_sqlite.rs`;
-- `crates/rustok-pages/contracts/evidence/pages-host-route-response-source.json`;
-- `crates/rustok-pages/scripts/verify/verify-pages-host-route-response.mjs`;
-- `docs/modules/pages-page-builder-host-route-response-packet-2026-08-06.md`.
+- `crates/rustok-pages/src/migrations/m20260806_000011_create_page_route_publications.rs`;
+- `crates/rustok-pages/src/entities/page_route_publication.rs`;
+- `crates/rustok-pages/src/services/page/route.rs`;
+- `crates/rustok-pages/src/services/page/lifecycle.rs`;
+- `crates/rustok-pages/tests/page_delete_route_tombstone_sqlite.rs`;
+- `crates/rustok-pages/contracts/evidence/pages-delete-route-tombstone-source.json`;
+- `crates/rustok-pages/scripts/verify/verify-pages-delete-route-tombstone.mjs`;
+- `docs/modules/pages-page-builder-delete-route-tombstone-packet-2026-08-06.md`.
 
-Execution evidence remains pending. Delete tombstones and historical backfill remain open.
+Historical route backfill/import policy remains open. Execution evidence remains pending.
 
-### Native reviewed immutable artifact selection: source-ready
+### Anonymous storefront boundary: source-ready
 
-`native-storefront-reviewed-artifact-source-ready`; Native reviewed immutable artifact selection: source-ready. Verification reconstructs the full Page Builder materialization envelope before a registered native storefront miss/refill. Durable `NodePublished` delivery remains connected at source level.
+The current public Pages host is SSR-only. Retained source guards exclude Pages/Page Builder/Fly authoring dependencies and executable hydration/bootstrap markers from the selected anonymous host profiles. The explicit built-artifact inspector remains source-ready; build and artifact inspection remain pending.
 
-### Routed-channel admission before native lookup: source-ready
+### Authenticated real-DOM inline editing: open
 
-`native-storefront-channel-admission-source-ready`; Routed-channel admission before native lookup: source-ready. A populated composite cache cannot bypass channel module admission, and successful reads retain a verified immutable Page Builder artifact.
-
-### Selected immutable artifact after draft mutation: source-ready
-
-`selected-immutable-artifact-source-ready`; Selected immutable artifact after draft mutation: source-ready. The current Fly body is not public render authority. Exact and fallback public reads remain bound to the selected immutable published artifact until reviewed publish or rollback replaces the binding.
-
-### Reviewed publish to native refill through synchronous test target: source-ready
-
-The retained PR #2995 harness uses a custom synchronous relay target and proves owner/outbox/handler/registered-route continuity. It is a test-target packet and does not replace production-gate execution evidence.
-
-### Production relay-to-Pages generation gate: source-ready
-
-`production-relay-generation-gate-source-ready`; Production relay-to-Pages generation gate: source-ready. Synchronous Pages invalidation now precedes downstream transport acceptance and uses process-bounded dedupe. The asynchronous module listener remains registered and becomes a same-event rotation no-op.
-
-The handler request and receipt retain event/correlation-bound receipt identity. Cache rotations retain old-generation values physically while current generation keys move to miss/refill.
-
-### Production relay gate to registered native route: source-ready
-
-`production-relay-native-route-source-ready`; Production relay gate to registered native route: source-ready. The source retains new-key miss/refill/hit after `NodePublished`, with one production `CacheService` owning generations and bytes. Execution remains pending.
-
-### Production gate PostgreSQL publish/rollback restart: source-ready
-
-`production-gate-postgres-restart-source-ready`; Production gate PostgreSQL publish/rollback restart: source-ready. A post-invalidation downstream failure leaves the durable row pending. Process-bounded dedupe prevents a second rotation when a new relay instance retries the same event in one process. The historical owner-transaction and pre-handler restart packets remain separate.
-
-### Memory and OutboxLocal factory profile parity: source-ready
-
-`event-delivery-profile-parity-source-ready`; Memory and OutboxLocal factory profile parity: source-ready. Memory rotates before listener delivery without a durable row. OutboxLocal writes a pending row first and rotates inside the real relay target before acknowledgement. Optional external delivery infrastructure is outside the active Pages cursor.
-
-### Anonymous storefront authoring exclusion: source-ready
-
-`anonymous-storefront-graph-source-ready`; Anonymous storefront authoring exclusion: source-ready.
-
-The retained verifier resolves six feature-resolved `cargo metadata` graphs and follows only normal/build edges; dev-dependencies are excluded. It forbids `rustok-pages-admin`, `rustok-page-builder-admin`, `rustok-admin`, `fly-browser`, `fly-ui` and `fly-leptos` at every reachable depth.
-
-The current host client profiles keep the optional Pages module disabled. The direct Pages hydrate graph remains a library capability check. Compiled bundle artifact execution remains pending.
-
-### Anonymous storefront SSR delivery: source-ready
-
-`anonymous-storefront-ssr-delivery-source-ready`; Anonymous storefront SSR delivery: source-ready.
-
-The current public Pages host is SSR-only:
-
-```text
-anonymous request
-  → apps/storefront SSR router
-  → Pages route decision before SEO/render
-  → Leptos render-to-HTML for exact canonical routes
-  → Pages read-only storefront composition
-  → document + /assets/app.css
-  → no executable client bootstrap
-```
-
-The source regression rejects module scripts, module preload, WASM URLs, hydration entrypoints and Pages/Page Builder/Fly authoring markers in the rendered public document source.
-
-The artifact inspector requires an explicit built SSR artifact, reruns the feature-resolved dependency-graph verifier, records SHA-256 and fails on authoring markers. Missing artifacts cannot pass.
-
-The client bundle gate is conditional: it reopens immediately when host CSR/hydrate enables Pages, a client bootstrap is introduced, or deployable Pages WASM/JS artifacts begin shipping. No client bundle proof is claimed for a bundle that does not currently exist.
-
-Source evidence:
-
-- `apps/storefront/tests/pages_anonymous_ssr_delivery.rs`;
-- `crates/rustok-pages/contracts/evidence/pages-anonymous-storefront-ssr-delivery-source.json`;
-- `crates/rustok-pages/scripts/verify/verify-pages-anonymous-storefront-ssr-delivery.mjs`;
-- `crates/rustok-pages/scripts/verify/inspect-pages-anonymous-storefront-ssr-artifact.mjs`;
-- `docs/modules/pages-page-builder-anonymous-storefront-ssr-delivery-packet-2026-08-05.md`.
-
-Execution evidence remains pending.
+Authenticated real-DOM inline editing is not implemented and remains outside this routing/lifecycle slice.
 
 ## Parity matrix
 
@@ -245,10 +139,11 @@ Execution evidence remains pending.
 | Draft/published registered metadata | Complete | Browser execution pending |
 | Reviewed publish and immutable manifest | Complete | Database/runtime evidence pending |
 | Immutable rollback | Complete | Database/runtime evidence pending |
-| Public detail/list tenant locale fallback parity | Source-ready | Focused SQLite/native/GraphQL execution pending |
+| Public detail/list tenant locale fallback | Source-ready | Focused SQLite/native/GraphQL execution pending |
 | Published slug alias ledger and localized canonical URLs | Source-ready | SQLite/PostgreSQL/SEO execution pending |
 | Host canonical/redirect/gone response | Source-ready | Registered server-function and host SSR execution pending |
-| Delete tombstones and historical route backfill | Open | Not implemented |
+| Delete route tombstones for new lifecycle transitions | Source-ready | SQLite/PostgreSQL/host execution pending |
+| Historical route backfill/import | Open | Not implemented |
 | Artifact HTTP cache | Source-ready | SQLite/Axum execution pending |
 | Native storefront route/cache/admission | Source-ready | Route-set execution pending |
 | Selected immutable artifact vs draft body | Source-ready | Focused SQLite execution pending |
@@ -259,30 +154,30 @@ Execution evidence remains pending.
 | Anonymous SSR document boundary | Source-ready | Source regression pending |
 | Anonymous SSR built artifact | Inspector source-ready | Build and inspection pending |
 | Anonymous Pages client bundle | Not currently mounted by host | Gate reopens if introduced |
-| Authenticated real-DOM inline editing | Not implemented | Open |
+| Authenticated real-DOM inline editing | Open | Not implemented |
 
 ## Boundaries
 
-This slice changes the production Pages storefront adapter and SSR host composition. It registers a typed route-decision server function and returns terminal HTTP responses before SEO/render for noncanonical, gone, missing or ambiguous Pages routes.
+This slice changes Pages route-history persistence, lifecycle composition and route resolution.
 
 It does not:
 
 - change Page Builder or Fly behavior;
-- change database schema, page bodies, artifacts, immutable bindings, publish or rollback receipts;
-- change GraphQL schema or REST HTTP API routes;
-- create deletion tombstones or historical route backfill;
-- change the existing channel visibility or module-admission owner policy;
-- change cache namespaces, generation scopes, concrete key shape, TTL or capacity;
+- change page bodies, immutable artifacts, publish or rollback receipts;
+- change GraphQL or REST schemas;
+- add historical route backfill/import;
+- change channel visibility or module-admission policy;
+- change cache namespaces, generation scopes, key shape, TTL or capacity;
 - change event schemas or optional external event infrastructure;
-- claim tests, Cargo, formatting, verifiers, SQLite, Axum, server functions, hosts, browsers, workflows, CI or rollout execution;
+- claim tests, Cargo, formatting, verifiers, SQLite, PostgreSQL, hosts, browsers, workflows, CI or rollout execution;
 - promote FFA or FBA.
 
 ## Next cursor
 
-1. Run the host route response verifier and registered SQLite/Axum server-function regression.
-2. Run the published slug route alias verifier and focused SQLite regression.
-3. Add deletion tombstones while preserving redirect history.
-4. Define historical route backfill/import policy as a separate source slice.
+1. Run the delete route tombstone verifier and focused SQLite regression.
+2. Run the host route response verifier and registered SQLite/Axum server-function regression.
+3. Run the published slug alias verifier and focused SQLite regression.
+4. Define bounded historical route backfill/import policy as a separate source slice.
 5. Run the public list locale fallback verifier and focused Pages locale regression.
 6. Run the native cache, registered server-function and channel-admission guards with their route harnesses.
 7. Run the anonymous dependency-graph and SSR delivery packets plus explicit built-artifact inspection.
@@ -296,17 +191,17 @@ It does not:
 Suggested commands, intentionally not run in this slice:
 
 ```bash
+node crates/rustok-pages/scripts/verify/verify-pages-delete-route-tombstone.mjs
+cargo test -p rustok-pages \
+  --test page_delete_route_tombstone_sqlite -- --nocapture
+cargo test -p rustok-pages \
+  --test page_published_slug_route_alias_sqlite -- --nocapture
+cargo check -p rustok-pages --all-targets
+
 node crates/rustok-pages/scripts/verify/verify-pages-host-route-response.mjs
 cargo test -p rustok-pages-storefront --features ssr \
   --test host_route_decision_sqlite -- --nocapture
 cargo test -p rustok-storefront --features ssr --lib -- --nocapture
-cargo check -p rustok-pages-storefront --features ssr --all-targets
-cargo check -p rustok-storefront --features ssr --all-targets
-
-node crates/rustok-pages/scripts/verify/verify-pages-published-slug-route-alias.mjs
-cargo test -p rustok-pages \
-  --test page_published_slug_route_alias_sqlite -- --nocapture
-cargo check -p rustok-pages --all-targets
 
 node crates/rustok-pages/scripts/verify/verify-pages-public-list-locale-fallback.mjs
 cargo test -p rustok-pages --test page_locale_fallback -- --nocapture
@@ -317,26 +212,6 @@ node crates/rustok-pages/scripts/verify/verify-pages-native-storefront-channel-a
 
 node crates/rustok-pages/scripts/verify/verify-pages-anonymous-storefront-graph.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-anonymous-storefront-ssr-delivery.mjs
-
-cargo test -p rustok-storefront --no-default-features --features ssr \
-  --test pages_anonymous_ssr_delivery -- --nocapture
-
-CARGO_TARGET_DIR=target/pages-anonymous-storefront-ssr \
-  cargo build -p rustok-storefront --no-default-features --features ssr --lib
-
-node crates/rustok-pages/scripts/verify/inspect-pages-anonymous-storefront-ssr-artifact.mjs \
-  --profile host-storefront-ssr \
-  --artifact target/pages-anonymous-storefront-ssr/debug/deps/librustok_storefront-<hash>.rlib \
-  --output /tmp/pages-anonymous-storefront-ssr-artifact.json
-
-node crates/rustok-pages/scripts/verify/verify-pages-selected-immutable-artifact.mjs
-node crates/rustok-pages/scripts/verify/verify-pages-native-storefront-reviewed-artifact.mjs
-node crates/rustok-pages/scripts/verify/verify-pages-production-relay-generation-gate.mjs
-node crates/rustok-pages/scripts/verify/verify-pages-production-relay-native-route.mjs
-node crates/rustok-pages/scripts/verify/verify-pages-production-gate-postgres-restart.mjs
-node crates/rustok-pages/scripts/verify/verify-pages-event-delivery-profile-parity.mjs
-node crates/rustok-pages/scripts/verify/verify-pages-metadata-revision-isolation.mjs
-node crates/rustok-pages/scripts/verify/verify-pages-published-metadata-surface.mjs
 ```
 
 Any failure or owner-model change must update this shared cursor before FFA/FBA promotion.

--- a/docs/modules/pages-page-builder-parity-continuation-plan.md
+++ b/docs/modules/pages-page-builder-parity-continuation-plan.md
@@ -43,6 +43,24 @@ Current `main` through PR #3020 contains:
 
 The present source slice adds forward lifecycle ownership for delete route tombstones without changing Page Builder/Fly behavior.
 
+## Retained source marker index
+
+This compact index preserves the exact stable source markers consumed by the retained static guards. It is descriptive only and does not promote execution evidence.
+
+- `public-list-locale-fallback-source-ready`; Public list tenant locale fallback: source-ready. The native and GraphQL public detail/list reads share tenant fallback policy, and the cache variant already binds the fallback locale.
+- `published-slug-route-alias-source-ready`; Published slug route aliases: source-ready. Localized canonical Pages routes remain the public identity model. The public host response is now source-ready.
+- `host-route-response-source-ready`; Pages host route response: source-ready. The route decision precedes SEO and SSR rendering.
+- `native-storefront-reviewed-artifact-source-ready`; Native reviewed immutable artifact selection: source-ready.
+- `native-storefront-channel-admission-source-ready`; Routed-channel admission before native lookup: source-ready.
+- `selected-immutable-artifact-source-ready`; Selected immutable artifact after draft mutation: source-ready. The current Fly body is not public render authority.
+- `production-relay-generation-gate-source-ready`; Production relay-to-Pages generation gate: source-ready. Synchronous Pages invalidation now precedes downstream transport acceptance and uses process-bounded dedupe.
+- `production-relay-native-route-source-ready`; Production relay gate to registered native route: source-ready.
+- `production-gate-postgres-restart-source-ready`; Production gate PostgreSQL publish/rollback restart: source-ready.
+- `event-delivery-profile-parity-source-ready`; Memory and OutboxLocal factory profile parity: source-ready.
+- `anonymous-storefront-graph-source-ready`; Anonymous storefront authoring exclusion: source-ready.
+- `anonymous-storefront-ssr-delivery-source-ready`; Anonymous storefront SSR delivery: source-ready.
+- `delete-route-tombstone-source-ready`; Delete route tombstones: source-ready. Historical route backfill/import policy remains open.
+
 ## Current parity state
 
 ### Registered metadata surfaces: source-complete


### PR DESCRIPTION
## Summary

- add a forward-only published-route snapshot ledger for localized Pages routes
- snapshot routes only when a page actually leaves `published`, so never-published draft deletion does not reserve a public slug
- write missing `gone` tombstones in the Pages delete transaction before translations and the page row are removed
- preserve immutable published-slug redirects and fold them to `Gone` after their target page is deleted
- reserve retained public route claims against reuse
- add focused SQLite regression source, source evidence, a static verifier, a packet, and refreshed Pages/Page Builder parity plans

## Rechecked boundary

Current `main` already contains published-slug aliases, localized canonical routes, and host canonical/redirect/gone response composition through PR #3020. The commits added after the branch point are Commerce/Forum-only and do not overlap this Pages slice.

## Validation

Not run per maintainer instruction. Suggested commands are recorded in the parity plan and packet, including:

```bash
node crates/rustok-pages/scripts/verify/verify-pages-delete-route-tombstone.mjs
cargo test -p rustok-pages --test page_delete_route_tombstone_sqlite -- --nocapture
cargo test -p rustok-pages --test page_published_slug_route_alias_sqlite -- --nocapture
cargo check -p rustok-pages --all-targets
```

Historical backfill/import remains the next open source slice. No FFA/FBA promotion is claimed.