### PR TITLE
feat(forum): add visibility-safe storefront topic route query

### DIFF
--- a/crates/rustok-forum/contracts/forum-topic-route-storefront-graphql.json
+++ b/crates/rustok-forum/contracts/forum-topic-route-storefront-graphql.json
@@ -1,0 +1,84 @@
+{
+  "contract": "forum_topic_route_storefront_graphql_v1",
+  "task": "FORUM-24H",
+  "parent_task": "FORUM-24",
+  "extends": ["FORUM-24A", "FORUM-24B", "FORUM-24C", "FORUM-24E"],
+  "status": "source_ready_maintainer_execution_pending",
+  "canonical_plan_status": "planned",
+  "graphql_field": "forumStorefrontTopicRoute",
+  "owner": "ForumTopicRouteService",
+  "storefront_visibility_owner": "TopicService",
+  "input": {
+    "tenant_id": "optional routed-tenant assertion",
+    "locale": "required localized route segment",
+    "short_id": "required deterministic route identity segment",
+    "slug": "required route slug segment"
+  },
+  "output": {
+    "requested_locale": true,
+    "requested_short_id": true,
+    "requested_slug": true,
+    "dispositions": ["CANONICAL", "REDIRECT"],
+    "canonical_descriptor": true,
+    "requested_topic_id_exposed": false,
+    "alias_id_exposed": false,
+    "gone_exposed": false
+  },
+  "authorization": {
+    "module_enabled_required": true,
+    "anonymous_channel_module_check": true,
+    "tenant_authority": "routed_context",
+    "optional_tenant_id_is_assertion_only": true,
+    "canonical_topic_rechecked": true,
+    "authenticated_security": "trusted_permission_snapshot",
+    "anonymous_security": "public_read",
+    "anonymous_topic_status": "open",
+    "anonymous_channel_visibility_rechecked": true,
+    "hidden_or_deleted_routes_return_null": true
+  },
+  "route_policy": {
+    "short_identity_computed_in_transport": false,
+    "slug_normalized_in_transport": false,
+    "alias_storage_read_directly": false,
+    "canonical_resolution_reimplemented": false,
+    "redirect_target_taken_from_owner": true,
+    "resolution_conflicts_fail_closed": true,
+    "gone_policy": "hidden_until_visibility_snapshot_exists"
+  },
+  "compatibility": {
+    "graphql_change": "additive_query",
+    "owner_changed": false,
+    "database_schema_changed": false,
+    "migration_added": false,
+    "semantic_event_changed": false,
+    "admin_mutation_changed": false,
+    "storefront_mount_added": false,
+    "seo_or_hreflang_policy_changed": false
+  },
+  "verification": {
+    "contract_test": "crates/rustok-forum/tests/topic_route_storefront_graphql_contract.rs",
+    "verifier": "scripts/verify/verify-forum-topic-route-storefront-graphql.mjs",
+    "maintainer_commands": [
+      "node scripts/verify/verify-forum-topic-route-identity-owner.mjs",
+      "node scripts/verify/verify-forum-topic-route-storefront-graphql.mjs",
+      "cargo test -p rustok-forum graphql::topic_route_query::tests -- --nocapture",
+      "cargo test -p rustok-forum --test topic_route_storefront_graphql_contract -- --nocapture",
+      "cargo check -p rustok-forum --all-targets"
+    ]
+  },
+  "remaining_scope": [
+    "storefront host route mounting and HTTP redirect composition",
+    "visibility-authorized gone tombstones",
+    "category route identity",
+    "canonical link and hreflang policy",
+    "SEO integration",
+    "maintainer runtime evidence"
+  ],
+  "non_claims": [
+    "no test verifier formatter Cargo workflow browser or CI execution is claimed",
+    "no public gone response is claimed",
+    "no storefront route mount or HTTP status handling is claimed",
+    "no category route identity is claimed",
+    "FORUM-24 remains planned"
+  ]
+}

--- a/crates/rustok-forum/docs/README.md
+++ b/crates/rustok-forum/docs/README.md
@@ -52,6 +52,7 @@ notifications module, and cross-module release gates.
 - FORUM-24E provides a bounded, cursor-resumable owner repair that ensures exact route aliases for immutable merge receipts created before FORUM-24B.
 - FORUM-24F exposes the localized topic slug rename owner through an additive routed-tenant GraphQL mutation while preserving owner-defined update and ownership semantics.
 - FORUM-24G composes that mutation in the module-owned Leptos and Next-admin packages without adding route, alias, merge or locale-selection policy to either UI.
+- FORUM-24H exposes visibility-safe storefront canonical/redirect resolution through GraphQL, rechecks the canonical topic through the existing storefront read contract, and hides `gone` until a visibility-authorized tombstone policy exists.
 
 ## Verification
 
@@ -89,6 +90,7 @@ notifications module, and cross-module release gates.
 - [FORUM-24E historical merge route backfill](./forum-24e-topic-merge-route-backfill.md)
 - [FORUM-24F topic slug rename GraphQL transport](./forum-24f-topic-slug-rename-graphql-transport.md)
 - [FORUM-24G topic slug rename admin UI](./forum-24g-topic-slug-rename-admin-ui.md)
+- [FORUM-24H storefront topic route GraphQL transport](./forum-24h-topic-route-storefront-graphql.md)
 - [Admin UI package](../admin/README.md)
 - [Storefront UI package](../storefront/README.md)
 - [Event flow contract](../../../docs/architecture/event-flow-contract.md)

--- a/crates/rustok-forum/docs/forum-24h-topic-route-storefront-graphql.md
+++ b/crates/rustok-forum/docs/forum-24h-topic-route-storefront-graphql.md
@@ -1,0 +1,81 @@
+# FORUM-24H visibility-safe storefront topic route GraphQL transport
+
+Status: **source-ready / maintainer execution pending**
+
+## Scope
+
+FORUM-24H adds one additive GraphQL query for resolving an incoming localized Forum topic route:
+
+```graphql
+forumStorefrontTopicRoute(
+  tenantId: UUID
+  locale: String!
+  shortId: String!
+  slug: String!
+): GqlForumStorefrontTopicRouteResolution
+```
+
+The query composes the existing `ForumTopicRouteService` and then rechecks the returned canonical topic through the same `TopicService` storefront read contract used by `forumStorefrontTopic`.
+
+## Visibility contract
+
+The resolver:
+
+- requires the Forum module to be enabled;
+- treats `tenantId` only as an assertion against the routed tenant;
+- checks the public channel module toggle for anonymous requests;
+- resolves canonical and redirect history through `ForumTopicRouteService`;
+- reopens the owner-provided canonical topic through `TopicService::get_with_locale_fallback`;
+- uses the trusted permission snapshot for authenticated requests and `SecurityContext::public_read()` for anonymous requests;
+- requires an anonymous canonical topic to remain open and visible in the routed public channel;
+- returns `null` when the route or canonical topic is missing, deleted, or not storefront-visible.
+
+The transport does not read the alias table, calculate short identities, normalize route segments, or recompute redirect targets.
+
+## Public response
+
+The response contains only:
+
+- the normalized requested locale, short identity, and slug returned by the owner;
+- `CANONICAL` or `REDIRECT`;
+- the authorized canonical topic route descriptor.
+
+It intentionally does not expose:
+
+- the historical topic UUID;
+- the immutable alias UUID;
+- alias reasons or persistence metadata;
+- a public `GONE` disposition.
+
+## Why `GONE` remains hidden
+
+The existing tombstone ledger proves route history but does not retain the visibility policy that applied before deletion. Returning a public `410 Gone` for every stored tombstone could therefore disclose a formerly private or channel-restricted topic.
+
+FORUM-24H fails closed and returns `null` for `ForumTopicRouteDisposition::Gone`. A later slice must define a visibility-authorized tombstone snapshot or another owner-approved disclosure policy before storefront hosts may emit `410`.
+
+## Compatibility
+
+This is an additive GraphQL query. It changes no owner method, mutation, database schema, migration, event, admin workflow, storefront host route, canonical link, hreflang, or SEO policy.
+
+The existing query-string storefront links remain unchanged in this slice. The new transport is the prerequisite for a later canonical route mount and redirect composition.
+
+## Verification handoff
+
+No commands were executed while preparing this source slice. Maintainers can run:
+
+```bash
+node scripts/verify/verify-forum-topic-route-identity-owner.mjs
+node scripts/verify/verify-forum-topic-route-storefront-graphql.mjs
+cargo test -p rustok-forum graphql::topic_route_query::tests -- --nocapture
+cargo test -p rustok-forum --test topic_route_storefront_graphql_contract -- --nocapture
+cargo check -p rustok-forum --all-targets
+```
+
+## Remaining FORUM-24 scope
+
+- mount canonical topic routes in storefront hosts;
+- compose HTTP redirect behavior;
+- define visibility-authorized deleted-route handling;
+- add category route identity;
+- define canonical and hreflang policy;
+- integrate SEO and capture runtime evidence.

--- a/crates/rustok-forum/src/graphql/mod.rs
+++ b/crates/rustok-forum/src/graphql/mod.rs
@@ -18,6 +18,7 @@ mod storefront_read_state;
 mod topic_fork_mutation;
 mod topic_merge_mutation;
 mod topic_reply_range_move_mutation;
+mod topic_route_query;
 mod topic_slug_rename_mutation;
 mod topic_split_mutation;
 mod types;
@@ -56,6 +57,9 @@ pub use topic_merge_mutation::{
 pub use topic_reply_range_move_mutation::{
     GqlForumReplyRangeMove, MoveForumTopicReplyRangeGraphqlInput,
 };
+pub use topic_route_query::{
+    GqlForumStorefrontTopicRouteDisposition, GqlForumStorefrontTopicRouteResolution,
+};
 pub use topic_slug_rename_mutation::{
     GqlForumTopicRouteDescriptor, GqlForumTopicSlugRename, RenameForumTopicSlugGraphqlInput,
 };
@@ -72,6 +76,7 @@ pub struct ForumQuery(
     storefront_read_state::ForumStorefrontReadStateQuery,
     storefront_audience_topic::ForumStorefrontAudienceTopicQuery,
     storefront_audience_topics::ForumStorefrontAudienceTopicsQuery,
+    topic_route_query::ForumTopicRouteQuery,
 );
 
 #[derive(MergedObject, Default)]

--- a/crates/rustok-forum/src/graphql/topic_route_query.rs
+++ b/crates/rustok-forum/src/graphql/topic_route_query.rs
@@ -14,7 +14,7 @@ use crate::{
     ForumTopicRouteService, TopicService,
 };
 
-use super::GqlForumTopicRouteDescriptor;
+use super::{GqlForumTopicRouteDescriptor, query::is_topic_visible_for_channel};
 
 const MODULE_SLUG: &str = "forum";
 
@@ -49,7 +49,9 @@ impl ForumTopicRouteQuery {
             .await
         {
             Ok(resolution) => resolution,
-            Err(ForumError::TopicRouteNotFound) => return Ok(None),
+            Err(ForumError::TopicNotFound(_))
+            | Err(ForumError::TopicDeleted)
+            | Err(ForumError::TopicRouteNotFound) => return Ok(None),
             Err(error) => return Err(async_graphql::Error::new(error.to_string())),
         };
 
@@ -197,17 +199,6 @@ fn is_public_request(ctx: &Context<'_>) -> bool {
 fn public_channel_slug(ctx: &Context<'_>) -> Option<String> {
     ctx.data_opt::<RequestContext>()
         .and_then(|request| request.channel_slug.clone())
-}
-
-fn is_topic_visible_for_channel(channel_slugs: &[String], channel_slug: Option<&str>) -> bool {
-    if channel_slugs.is_empty() {
-        return true;
-    }
-    let Some(channel_slug) = channel_slug else {
-        return false;
-    };
-    let normalized = channel_slug.trim().to_ascii_lowercase();
-    !normalized.is_empty() && channel_slugs.iter().any(|item| item == &normalized)
 }
 
 #[cfg(test)]

--- a/crates/rustok-forum/src/graphql/topic_route_query.rs
+++ b/crates/rustok-forum/src/graphql/topic_route_query.rs
@@ -1,0 +1,288 @@
+use async_graphql::{Context, Enum, ErrorExtensions, FieldError, Object, Result, SimpleObject};
+use rustok_api::{
+    AuthContext, RequestContext, TenantContext,
+    graphql::{GraphQLError, require_module_enabled},
+};
+use rustok_channel::ChannelService;
+use rustok_core::SecurityContext;
+use rustok_outbox::TransactionalEventBus;
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use crate::{
+    ForumError, ForumTopicRouteDisposition, ForumTopicRouteResolution,
+    ForumTopicRouteService, TopicService,
+};
+
+use super::GqlForumTopicRouteDescriptor;
+
+const MODULE_SLUG: &str = "forum";
+
+#[derive(Default)]
+pub(crate) struct ForumTopicRouteQuery;
+
+#[Object]
+impl ForumTopicRouteQuery {
+    /// Resolves one public Forum topic route after rechecking the canonical topic through the
+    /// existing storefront visibility contract.
+    ///
+    /// Deleted-route tombstones intentionally remain hidden until Forum owns a visibility
+    /// snapshot that can authorize a public `gone` response without disclosing private history.
+    async fn forum_storefront_topic_route(
+        &self,
+        ctx: &Context<'_>,
+        tenant_id: Option<Uuid>,
+        locale: String,
+        short_id: String,
+        slug: String,
+    ) -> Result<Option<GqlForumStorefrontTopicRouteResolution>> {
+        require_module_enabled(ctx, MODULE_SLUG).await?;
+        require_public_forum_channel_enabled(ctx).await?;
+
+        let db = ctx.data::<DatabaseConnection>()?;
+        let event_bus = ctx.data::<TransactionalEventBus>()?;
+        let tenant = ctx.data::<TenantContext>()?;
+        let tenant_id = resolve_tenant_scope(tenant, tenant_id)?;
+
+        let resolution = match ForumTopicRouteService::new(db.clone())
+            .resolve(tenant_id, &locale, &short_id, &slug)
+            .await
+        {
+            Ok(resolution) => resolution,
+            Err(ForumError::TopicRouteNotFound) => return Ok(None),
+            Err(error) => return Err(async_graphql::Error::new(error.to_string())),
+        };
+
+        let canonical = match resolution.disposition {
+            ForumTopicRouteDisposition::Canonical | ForumTopicRouteDisposition::Redirect => {
+                resolution.canonical.as_ref().ok_or_else(|| {
+                    async_graphql::Error::new(
+                        "Forum topic route resolution did not provide a canonical target",
+                    )
+                    .extend_with(|_, extension| {
+                        extension.set("code", "INTERNAL_SERVER_ERROR")
+                    })
+                })?
+            }
+            ForumTopicRouteDisposition::Gone => return Ok(None),
+        };
+
+        let topic = match TopicService::new(db.clone(), event_bus.clone())
+            .get_with_locale_fallback(
+                tenant_id,
+                forum_request_security(ctx),
+                canonical.topic_id,
+                &canonical.locale,
+                Some(tenant.default_locale.as_str()),
+            )
+            .await
+        {
+            Ok(topic) => topic,
+            Err(ForumError::TopicNotFound(_))
+            | Err(ForumError::TopicDeleted)
+            | Err(ForumError::TopicRouteNotFound) => return Ok(None),
+            Err(error) => return Err(async_graphql::Error::new(error.to_string())),
+        };
+
+        if is_public_request(ctx)
+            && (topic.status != crate::constants::topic_status::OPEN
+                || !is_topic_visible_for_channel(
+                    &topic.channel_slugs,
+                    public_channel_slug(ctx).as_deref(),
+                ))
+        {
+            return Ok(None);
+        }
+
+        map_public_route_resolution(resolution)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Enum)]
+pub enum GqlForumStorefrontTopicRouteDisposition {
+    Canonical,
+    Redirect,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, SimpleObject)]
+pub struct GqlForumStorefrontTopicRouteResolution {
+    pub requested_locale: String,
+    pub requested_short_id: String,
+    pub requested_slug: String,
+    pub disposition: GqlForumStorefrontTopicRouteDisposition,
+    pub canonical: GqlForumTopicRouteDescriptor,
+}
+
+fn map_public_route_resolution(
+    resolution: ForumTopicRouteResolution,
+) -> Result<Option<GqlForumStorefrontTopicRouteResolution>> {
+    let disposition = match resolution.disposition {
+        ForumTopicRouteDisposition::Canonical => {
+            GqlForumStorefrontTopicRouteDisposition::Canonical
+        }
+        ForumTopicRouteDisposition::Redirect => {
+            GqlForumStorefrontTopicRouteDisposition::Redirect
+        }
+        ForumTopicRouteDisposition::Gone => return Ok(None),
+    };
+    let canonical = resolution.canonical.ok_or_else(|| {
+        async_graphql::Error::new(
+            "Forum topic route resolution did not provide a canonical target",
+        )
+        .extend_with(|_, extension| extension.set("code", "INTERNAL_SERVER_ERROR"))
+    })?;
+
+    Ok(Some(GqlForumStorefrontTopicRouteResolution {
+        requested_locale: resolution.requested_locale,
+        requested_short_id: resolution.requested_short_id,
+        requested_slug: resolution.requested_slug,
+        disposition,
+        canonical: canonical.into(),
+    }))
+}
+
+async fn require_public_forum_channel_enabled(ctx: &Context<'_>) -> Result<()> {
+    let db = ctx.data::<DatabaseConnection>()?;
+    if ctx.data_opt::<AuthContext>().is_some() {
+        return Ok(());
+    }
+    let Some(request_context) = ctx.data_opt::<RequestContext>() else {
+        return Ok(());
+    };
+    let Some(channel_id) = request_context.channel_id else {
+        return Ok(());
+    };
+
+    let enabled = ChannelService::new(db.clone())
+        .is_module_enabled(channel_id, MODULE_SLUG)
+        .await
+        .map_err(|error| {
+            async_graphql::Error::new(format!("Channel module check failed: {error}"))
+                .extend_with(|_, extension| extension.set("code", "INTERNAL_SERVER_ERROR"))
+        })?;
+    if enabled {
+        Ok(())
+    } else {
+        Err(
+            async_graphql::Error::new("Forum module is not enabled for this channel")
+                .extend_with(|_, extension| extension.set("code", "FORBIDDEN")),
+        )
+    }
+}
+
+fn resolve_tenant_scope(tenant: &TenantContext, requested_tenant_id: Option<Uuid>) -> Result<Uuid> {
+    match requested_tenant_id {
+        Some(requested_tenant_id) if requested_tenant_id != tenant.id => {
+            Err(<FieldError as GraphQLError>::permission_denied(
+                "Permission denied: tenant scope mismatch",
+            ))
+        }
+        Some(requested_tenant_id) => Ok(requested_tenant_id),
+        None => Ok(tenant.id),
+    }
+}
+
+fn forum_request_security(ctx: &Context<'_>) -> SecurityContext {
+    ctx.data_opt::<AuthContext>()
+        .map(|auth| {
+            SecurityContext::from_permission_snapshot(Some(auth.user_id), &auth.permissions)
+        })
+        .unwrap_or_else(SecurityContext::public_read)
+}
+
+fn is_public_request(ctx: &Context<'_>) -> bool {
+    ctx.data_opt::<AuthContext>().is_none()
+}
+
+fn public_channel_slug(ctx: &Context<'_>) -> Option<String> {
+    ctx.data_opt::<RequestContext>()
+        .and_then(|request| request.channel_slug.clone())
+}
+
+fn is_topic_visible_for_channel(channel_slugs: &[String], channel_slug: Option<&str>) -> bool {
+    if channel_slugs.is_empty() {
+        return true;
+    }
+    let Some(channel_slug) = channel_slug else {
+        return false;
+    };
+    let normalized = channel_slug.trim().to_ascii_lowercase();
+    !normalized.is_empty() && channel_slugs.iter().any(|item| item == &normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ForumTopicRouteDescriptor;
+
+    fn descriptor() -> ForumTopicRouteDescriptor {
+        ForumTopicRouteDescriptor {
+            topic_id: Uuid::parse_str("00000000-0000-4000-8000-000000000001")
+                .expect("topic id"),
+            locale: "en".to_string(),
+            short_id: "000000000000".to_string(),
+            slug: "welcome".to_string(),
+            path: "/forum/en/t/000000000000/welcome".to_string(),
+        }
+    }
+
+    fn resolution(
+        disposition: ForumTopicRouteDisposition,
+        canonical: Option<ForumTopicRouteDescriptor>,
+    ) -> ForumTopicRouteResolution {
+        ForumTopicRouteResolution {
+            requested_locale: "en".to_string(),
+            requested_short_id: "000000000000".to_string(),
+            requested_slug: "old-welcome".to_string(),
+            requested_topic_id: None,
+            disposition,
+            canonical,
+            alias_id: None,
+        }
+    }
+
+    #[test]
+    fn maps_only_canonical_and_redirect_public_results() {
+        let canonical = map_public_route_resolution(resolution(
+            ForumTopicRouteDisposition::Canonical,
+            Some(descriptor()),
+        ))
+        .expect("canonical mapping")
+        .expect("canonical result");
+        assert_eq!(
+            canonical.disposition,
+            GqlForumStorefrontTopicRouteDisposition::Canonical
+        );
+
+        let redirect = map_public_route_resolution(resolution(
+            ForumTopicRouteDisposition::Redirect,
+            Some(descriptor()),
+        ))
+        .expect("redirect mapping")
+        .expect("redirect result");
+        assert_eq!(
+            redirect.disposition,
+            GqlForumStorefrontTopicRouteDisposition::Redirect
+        );
+    }
+
+    #[test]
+    fn hides_gone_routes_without_a_visibility_snapshot() {
+        assert!(
+            map_public_route_resolution(resolution(ForumTopicRouteDisposition::Gone, None))
+                .expect("gone mapping")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn requires_canonical_target_for_disclosed_results() {
+        assert!(
+            map_public_route_resolution(resolution(
+                ForumTopicRouteDisposition::Redirect,
+                None,
+            ))
+            .is_err()
+        );
+    }
+}

--- a/crates/rustok-forum/tests/topic_route_storefront_graphql_contract.rs
+++ b/crates/rustok-forum/tests/topic_route_storefront_graphql_contract.rs
@@ -1,0 +1,89 @@
+use async_graphql::{EmptySubscription, Schema};
+use rustok_forum::graphql::ForumGraphqlErrorExtension;
+use rustok_forum::{ForumMutation, ForumQuery};
+
+const TOPIC_ROUTE_QUERY: &str = include_str!("../src/graphql/topic_route_query.rs");
+const GRAPHQL_MOD: &str = include_str!("../src/graphql/mod.rs");
+
+#[test]
+fn graphql_schema_exposes_visibility_safe_storefront_topic_route_resolution() {
+    let schema = Schema::build(
+        ForumQuery::default(),
+        ForumMutation::default(),
+        EmptySubscription,
+    )
+    .extension(ForumGraphqlErrorExtension)
+    .finish();
+    let sdl = schema.sdl();
+
+    for marker in [
+        "forumStorefrontTopicRoute",
+        "GqlForumStorefrontTopicRouteResolution",
+        "GqlForumStorefrontTopicRouteDisposition",
+        "CANONICAL",
+        "REDIRECT",
+        "requestedLocale",
+        "requestedShortId",
+        "requestedSlug",
+        "canonical",
+        "GqlForumTopicRouteDescriptor",
+        "shortId",
+        "path",
+    ] {
+        assert!(
+            sdl.contains(marker),
+            "missing storefront topic route GraphQL marker {marker}"
+        );
+    }
+}
+
+#[test]
+fn storefront_topic_route_query_rechecks_visibility_and_hides_tombstone_identity() {
+    for marker in [
+        "require_module_enabled(ctx, MODULE_SLUG).await?",
+        "require_public_forum_channel_enabled(ctx).await?",
+        "Permission denied: tenant scope mismatch",
+        "ForumTopicRouteService::new(db.clone())",
+        ".resolve(tenant_id, &locale, &short_id, &slug)",
+        "TopicService::new(db.clone(), event_bus.clone())",
+        ".get_with_locale_fallback(",
+        "forum_request_security(ctx)",
+        "crate::constants::topic_status::OPEN",
+        "is_topic_visible_for_channel(",
+        "ForumTopicRouteDisposition::Gone => return Ok(None)",
+        "SecurityContext::public_read",
+        "ChannelService::new(db.clone())",
+    ] {
+        assert!(
+            TOPIC_ROUTE_QUERY.contains(marker),
+            "missing visibility-safe storefront route marker {marker}"
+        );
+    }
+
+    for forbidden in [
+        "pub requested_topic_id",
+        "pub alias_id",
+        "GqlForumStorefrontTopicRouteDisposition::Gone",
+        "forum_topic_route_aliases",
+        "Statement::from_sql_and_values",
+        "SELECT ",
+        "record_redirect_alias",
+        "record_gone_alias",
+    ] {
+        assert!(
+            !TOPIC_ROUTE_QUERY.contains(forbidden),
+            "storefront route query contains forbidden marker {forbidden}"
+        );
+    }
+}
+
+#[test]
+fn forum_query_registers_the_route_transport_once() {
+    assert_eq!(GRAPHQL_MOD.matches("mod topic_route_query;").count(), 1);
+    assert_eq!(
+        GRAPHQL_MOD
+            .matches("topic_route_query::ForumTopicRouteQuery")
+            .count(),
+        1
+    );
+}

--- a/scripts/verify/verify-forum-topic-route-storefront-graphql.mjs
+++ b/scripts/verify/verify-forum-topic-route-storefront-graphql.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+const paths = {
+  query: "crates/rustok-forum/src/graphql/topic_route_query.rs",
+  graphqlMod: "crates/rustok-forum/src/graphql/mod.rs",
+  owner: "crates/rustok-forum/src/services/topic_route.rs",
+  contract: "crates/rustok-forum/contracts/forum-topic-route-storefront-graphql.json",
+  test: "crates/rustok-forum/tests/topic_route_storefront_graphql_contract.rs",
+  docs: "crates/rustok-forum/docs/forum-24h-topic-route-storefront-graphql.md",
+};
+
+function absolute(relativePath) {
+  return path.join(repoRoot, relativePath);
+}
+
+function read(relativePath) {
+  if (!existsSync(absolute(relativePath))) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return "";
+  }
+  return readFileSync(absolute(relativePath), "utf8");
+}
+
+function requireText(content, marker, label) {
+  if (!content.includes(marker)) failures.push(`${label}: missing ${marker}`);
+}
+
+function forbidText(content, marker, label) {
+  if (content.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+}
+
+const query = read(paths.query);
+const graphqlMod = read(paths.graphqlMod);
+const owner = read(paths.owner);
+const contractText = read(paths.contract);
+const test = read(paths.test);
+const docs = read(paths.docs);
+
+let contract = null;
+try {
+  contract = JSON.parse(contractText);
+} catch (error) {
+  failures.push(`${paths.contract}: invalid JSON (${error.message})`);
+}
+
+for (const marker of [
+  "async fn forum_storefront_topic_route(",
+  "require_module_enabled(ctx, MODULE_SLUG).await?",
+  "require_public_forum_channel_enabled(ctx).await?",
+  "Permission denied: tenant scope mismatch",
+  "ForumTopicRouteService::new(db.clone())",
+  ".resolve(tenant_id, &locale, &short_id, &slug)",
+  "TopicService::new(db.clone(), event_bus.clone())",
+  ".get_with_locale_fallback(",
+  "forum_request_security(ctx)",
+  "SecurityContext::public_read",
+  "crate::constants::topic_status::OPEN",
+  "is_topic_visible_for_channel(",
+  "ForumTopicRouteDisposition::Gone => return Ok(None)",
+  "GqlForumStorefrontTopicRouteDisposition::Canonical",
+  "GqlForumStorefrontTopicRouteDisposition::Redirect",
+]) {
+  requireText(query, marker, paths.query);
+}
+
+for (const marker of [
+  "pub requested_topic_id",
+  "pub alias_id",
+  "GqlForumStorefrontTopicRouteDisposition::Gone",
+  "forum_topic_route_aliases",
+  "Statement::from_sql_and_values",
+  "record_redirect_alias_in_tx",
+  "record_gone_alias_in_tx",
+  "ForumTopicRouteService::short_identity",
+]) {
+  forbidText(query, marker, paths.query);
+}
+
+requireText(graphqlMod, "mod topic_route_query;", paths.graphqlMod);
+requireText(
+  graphqlMod,
+  "topic_route_query::ForumTopicRouteQuery",
+  paths.graphqlMod,
+);
+requireText(owner, "pub async fn resolve(", paths.owner);
+requireText(
+  owner,
+  "Callers must perform the\n/// same visibility/read authorization required for the canonical topic",
+  paths.owner,
+);
+
+for (const marker of [
+  "forumStorefrontTopicRoute",
+  "GqlForumStorefrontTopicRouteResolution",
+  "CANONICAL",
+  "REDIRECT",
+  "requestedLocale",
+  "requestedShortId",
+  "requestedSlug",
+]) {
+  requireText(test, marker, paths.test);
+}
+
+for (const marker of [
+  "visibility snapshot",
+  "returns `null`",
+  "does not expose",
+  "public `GONE`",
+  "No commands were executed",
+]) {
+  requireText(docs, marker, paths.docs);
+}
+
+if (contract) {
+  if (contract.task !== "FORUM-24H") {
+    failures.push(`${paths.contract}: task must be FORUM-24H`);
+  }
+  if (contract.status !== "source_ready_maintainer_execution_pending") {
+    failures.push(`${paths.contract}: unexpected source status`);
+  }
+  if (contract.output?.gone_exposed !== false) {
+    failures.push(`${paths.contract}: gone_exposed must remain false`);
+  }
+  if (contract.output?.requested_topic_id_exposed !== false) {
+    failures.push(`${paths.contract}: requested topic identity must stay hidden`);
+  }
+  if (contract.output?.alias_id_exposed !== false) {
+    failures.push(`${paths.contract}: alias identity must stay hidden`);
+  }
+  if (contract.authorization?.canonical_topic_rechecked !== true) {
+    failures.push(`${paths.contract}: canonical topic visibility recheck is required`);
+  }
+  if (contract.route_policy?.canonical_resolution_reimplemented !== false) {
+    failures.push(`${paths.contract}: canonical resolution must remain owner-defined`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("forum storefront topic route GraphQL verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("forum storefront topic route GraphQL verification passed");


### PR DESCRIPTION
## Summary

- add FORUM-24H `forumStorefrontTopicRoute` as an additive GraphQL query over `ForumTopicRouteService`;
- accept only the routed-tenant assertion plus locale, short identity and slug route segments;
- return normalized requested segments, `CANONICAL` or `REDIRECT`, and the owner-provided canonical descriptor;
- recheck the canonical target through `TopicService::get_with_locale_fallback` using the same authenticated/public security contract as the existing storefront topic query;
- require open status and routed-channel visibility for anonymous disclosure;
- fail closed with `null` for missing, deleted, hidden, channel-restricted and `GONE` routes;
- expose neither historical topic UUID nor alias UUID/reason/storage metadata;
- add SDL/source contract coverage, a machine contract, module docs and a source verifier.

## Source recheck

- rechecked `ForumTopicRouteService::resolve` and its explicit requirement that transports authorize descriptors and redirect targets before disclosure;
- rechecked the existing `forumStorefrontTopic` visibility path and reused its owner read, public security, open-status and channel visibility semantics;
- fixed a source-review defect before PR creation so redirect targets deleted after alias creation return `null` instead of a GraphQL error;
- reused the existing query-runtime channel visibility helper rather than duplicating that policy.

## Deliberate fail-closed boundary

The route tombstone ledger does not retain the topic visibility policy that applied before deletion. This query therefore does not expose `GONE`; a later owner slice must define a visibility-authorized tombstone snapshot or equivalent policy before a storefront host can emit public `410 Gone` responses.

This PR does not mount a storefront URL, emit HTTP redirects/statuses, create category routes, or change canonical/hreflang/SEO policy.

## Canonical plan note

`crates/rustok-forum/docs/implementation-plan.md` remains stale after FORUM-24E through FORUM-24H. The connected GitHub contents writer requires complete-file replacement, while the canonical plan cannot be retrieved losslessly as one complete payload through the available connector response. This PR updates the module docs, contract and verifier without claiming ledger synchronization.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Node verifiers;
- Cargo check, formatting, clippy, workflows or CI;
- mounted GraphQL or storefront runtime scenarios.

Suggested maintainer commands:

```bash
node scripts/verify/verify-forum-topic-route-identity-owner.mjs
node scripts/verify/verify-forum-topic-route-storefront-graphql.mjs
cargo test -p rustok-forum graphql::topic_route_query::tests -- --nocapture
cargo test -p rustok-forum --test topic_route_storefront_graphql_contract -- --nocapture
cargo check -p rustok-forum --all-targets
```

Source status remains `source_ready_maintainer_execution_pending`.