### PR TITLE
feat(index): bound stale and orphan drift candidates

### DIFF
--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -19,7 +19,7 @@ This directory contains the detailed technical architecture documentation for `r
 
 1. **Schema-Agnostic PostgreSQL JSONB Storage**: Envelopes entity state into benchmarked `JSONB` structures while maintaining independent relational graphs (`index_links`).
 2. **Derived Secondary Indexes**: Automatically creates typed PostgreSQL partial B-Tree expression indexes for scalar fields and GIN containment indexes for arrays.
-3. **Derived and Sealed Cursor Boundaries**: Query keyset cursors are checksummed and scope-bound; owner source cursors use a separate authenticated, confidential, tenant/schema/source-bound codec plus a private server `SecretRef` keyring, sealed one-page service boundary, and bounded GraphQL transport.
+3. **Derived and Sealed Cursor Boundaries**: Query keyset cursors are checksummed and scope-bound; owner source cursors use a separate authenticated, confidential, tenant/schema/source-bound codec plus a private server `SecretRef` keyring, sealed one-page service boundary, and bounded GraphQL transport. Drift discovery candidates use a separate exact-scope, immutable-fence, opaque-keyset contract before any PostgreSQL reader or public transport is admitted.
 4. **Durable Rebuilds & Outbox Inbox**: Fences stale checkpoint writers with advisory locks, deduplicates mutations via `index_inbox`, and logs consistency findings (`index_consistency_findings`).
 
 ---
@@ -31,6 +31,7 @@ This directory contains the detailed technical architecture documentation for `r
 - [M6 Explicit Source Absence Watermark](./m6-explicit-source-absence-watermark.md)
 - [M6 Confidential Source Continuation Codec](./m6-source-continuation-codec.md)
 - [M6 Server-owned Source Continuation Keyring](./m6-source-continuation-server-keyring.md)
+- [M6 Bounded Stale-entity and Orphan-link Candidates](./m6-bounded-drift-candidates.md)
 - [M6 Product Locale Absence PostgreSQL Harness](./m6-product-locale-absence-postgres-harness.md)
 - [M6 GraphQL Exact-entity Diagnosis Transport](../../../apps/server/docs/index-drift-diagnosis-graphql-transport.md)
 - [M6 One-page Missing-entity Diagnosis](../../../apps/server/docs/index-drift-source-page-diagnosis.md)

--- a/crates/rustok-index/docs/implementation-main-delta-2026-08-06-0812.md
+++ b/crates/rustok-index/docs/implementation-main-delta-2026-08-06-0812.md
@@ -1,0 +1,25 @@
+# `rustok-index` main delta — 2026-08-06 08:12 UTC
+
+Previous checked default branch: `main@66f36254ce5607f38fa480968e69b355a0128fe6`.
+Latest checked default branch: `main@d1a4e71d8b9d212d96067eb7c186def64ed4e48e`.
+
+## Delta
+
+The single intervening commit is:
+
+- `fix(commerce): bound admin shipping diagnostics (#3034)`.
+
+It changes Commerce Admin Shipping diagnostic projection, documentation, evidence, and Commerce
+verifiers. It does not modify:
+
+- `crates/rustok-index`;
+- Product Index composition;
+- Index GraphQL transports or server diagnosis services;
+- the bounded drift candidate contract or its guards.
+
+## Result
+
+No implementation change is required in PR #3033. Its exact-scope, fence, cursor, ordering, and typed
+candidate boundaries remain source-review compatible with the latest default branch.
+
+No tests, verifiers, formatting, Cargo checks, workflows, or CI were run by the implementation agent.

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-03.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-03.md
@@ -1,32 +1,30 @@
 # Current `rustok-index` implementation plan — 2026-08-03
 
 Status overlay for `implementation-plan.md` rechecked through
-`main@dd9020b8d259d9466423c47bd92b2c93c6c39225` and active PR #2986.
+`main@66f36254ce5607f38fa480968e69b355a0128fe6` and active draft PR #3033.
 
-The forty-seven commits after this branch merge base cover Commerce diagnostics, Forum GraphQL/admin
-work, Pages/Page Builder routes and delivery, event settings, and supporting server configuration.
-The latest delta adds bounded Pages historical-route import. These commits do not modify
-`crates/rustok-index`, Product Index composition, Index GraphQL transports, Index diagnosis/page
-composition, or Index guards changed by this branch.
+The only default-branch commit after the sealed source-page merge is the Pages storefront
+Navigation/SEO ETag composition. It does not modify `crates/rustok-index`, Product Index composition,
+Index GraphQL transports, Index diagnosis/page composition, or Index guards changed by this branch.
 
 When this dated overlay conflicts with the older canonical plan, this file is the current source of
 truth. Historical architecture and milestone context remain in `implementation-plan.md`.
 
 ## Current cursor
 
-`M6 - bound stale Index-only entity and orphan-link diagnosis`
+`M6 - compose the bounded PostgreSQL drift candidate reader`
 
 Exact drift diagnosis, Product locale absence proof, missing-only page classification, confidential
-continuation, private server keyring composition, sealed one-page service execution, and bounded
-GraphQL transport are source complete.
+continuation, private server keyring composition, sealed one-page service execution, bounded GraphQL
+transport, and the database-neutral stale-entity/orphan-link candidate contract are source complete.
 
-`diagnoseIndexSourcePage` now derives tenant and actor from authenticated context, authorizes before
-schema/limit/token parsing, accepts one exact schema plus an optional opaque continuation, delegates
-exactly once to `diagnose_source_page_sealed`, and returns only bounded current-page counters,
-finding receipts, completion state, and the sealed token.
+The candidate contract fixes one exact tenant/schema scope, a page size in `1..=32`, an immutable
+reader fence, an opaque advancing cursor, and strict deterministic candidate ordering. It exposes
+separate typed stale-entity and orphan-link identities without indexed records, owner records, link
+payloads, SQL, or database causes.
 
-Execution evidence, stale Index-only discovery, orphan-link diagnosis, finding lifecycle commands,
-and repair remain open.
+The PostgreSQL candidate reader, execution evidence, exact source proof for stale candidates,
+orphan-link confirmation, finding lifecycle commands, and repair remain open.
 
 ## Rechecked status
 
@@ -66,6 +64,8 @@ and repair remain open.
   `source_complete_owner_execution_pending`
 - M6 bounded GraphQL sealed source-page diagnosis transport:
   `source_complete_owner_execution_pending`
+- M6 bounded stale-entity and orphan-link candidate contract:
+  `source_complete_postgres_reader_pending`
 - M6 explicit source absence watermark registry, Product provider, and reader fence:
   `source_complete_owner_execution_pending`
 - M6 Product locale absence PostgreSQL harness:
@@ -133,8 +133,17 @@ and repair remain open.
       finding receipts, completion, and the opaque token.
 - [ ] Retain authorization, secret resolution, rotation, expiry, sealed-result, and dependency-error
       execution evidence.
-- [ ] Add bounded stale Index-only entity diagnosis without unbounded ID collection.
-- [ ] Add bounded orphan-link diagnosis without exposing raw graph payloads.
+- [x] Add a database-neutral bounded candidate contract for stale Index-only entities and orphan
+      links with one exact tenant/schema scope and page size at most 32.
+- [x] Require fence and cursor together for continuation, preserve one immutable fence, reject
+      non-advancing cursors, empty continuation pages, scope escape, and unstable ordering.
+- [x] Expose only typed stale entity identity/version and typed orphan source/link/target identity;
+      carry no indexed record, owner record, link payload, SQL, database cause, lifecycle, or repair.
+- [ ] Add one PostgreSQL `IndexDriftCandidateReader` using bounded keyset reads under one immutable
+      read-only fence.
+- [ ] Confirm stale entity candidates with exact source load/absence proof before recording findings.
+- [ ] Confirm orphan links against typed target materialization/owner policy before recording
+      findings.
 - [ ] Add resolve/ignore lifecycle commands with actor/reason audit and fail-closed authorization.
 - [ ] Add targeted repair with before/after admitted evidence.
 
@@ -152,26 +161,31 @@ and repair remain open.
 
 ## Next implementation step
 
-Add a database-neutral bounded candidate contract for stale Index-only entities and orphan links.
+Add one PostgreSQL `IndexDriftCandidateReader` over the existing `index_entities` and `index_links`
+storage contract.
 
-The next slice must not start with an unbounded table scan or collect arbitrary IDs in memory. It
-must define:
+The reader must:
 
-- one exact tenant and schema scope;
-- a bounded page limit and opaque server-owned continuation;
-- stable ordering and snapshot/fence semantics;
-- separate typed outcomes for stale entity and orphan link candidates;
-- no raw indexed record, owner record, link payload, SQL, or database cause in public outcomes;
-- no finding lifecycle mutation or repair authority;
-- authorization before untrusted scope/cursor parsing for any future transport.
+- accept only `IndexDriftCandidateRequest` and preserve its exact tenant/schema scope;
+- choose one immutable read-only fence on the first page and require it on every continuation;
+- use bounded keyset SQL with `limit + 1`, never an unbounded scan or in-memory ID collection;
+- enumerate candidate phases deterministically: stale entity identities before orphan link identities;
+- return only live, non-deleted source-schema `index_entities` as stale candidates for later exact
+  owner proof;
+- return only links whose typed target row is absent or deleted as orphan candidates;
+- preserve strict ordering by entity key, then source key/link/ordinal/target identity;
+- encode only phase and last ordering tuple in the private cursor;
+- map database failures to bounded retryable/permanent machine codes without SQL or database causes;
+- perform no source call, finding write, lifecycle transition, scheduler registration, or repair.
 
-The first implementation should remain internal and database-neutral until the PostgreSQL candidate
-reader and bounded evidence contract are separately reviewed. Do not add a scheduler, cross-page
-accumulator, automatic resolution, or repair in that slice.
+Keep the PostgreSQL reader internal and unmounted. Do not add public transport or seal the candidate
+cursor until the reader, cursor contents, and fence implementation have been separately source
+reviewed.
 
-## Owner verification for the completed sealed transport slice
+## Owner verification for this slice
 
 ```bash
+cargo test -p rustok-index drift_candidates -- --nocapture
 cargo test -p rustok-index source_continuation -- --nocapture
 cargo test -p rustok-index drift_digest -- --nocapture
 cargo test -p rustok-index source_absence -- --nocapture
@@ -187,6 +201,7 @@ RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
   --test product_locale_absence_postgres \
   -- --nocapture --test-threads=1
 
+node scripts/verify/verify-index-drift-candidate-contract.mjs
 node scripts/verify/verify-index-source-continuation.mjs
 node scripts/verify/verify-index-source-continuation-server.mjs
 node scripts/verify/verify-index-drift-diagnosis-graphql-transport.mjs

--- a/crates/rustok-index/docs/implementation-recheck-2026-08-06-bounded-drift-candidates.md
+++ b/crates/rustok-index/docs/implementation-recheck-2026-08-06-bounded-drift-candidates.md
@@ -1,0 +1,98 @@
+# `rustok-index` implementation recheck — bounded drift candidates
+
+Audited baseline: `main@53aeddfbf05ceccea27f6c2f639af904c3ace6b2`.
+Latest default branch checked through
+`main@66f36254ce5607f38fa480968e69b355a0128fe6`.
+
+The only main delta after the baseline is Pages storefront Navigation/SEO ETag composition. It does
+not touch `crates/rustok-index`, Product Index composition, Index GraphQL transports, Index diagnosis
+services, or Index verifier files changed by PR #3033.
+
+## Rechecked scope
+
+This slice adds only the database-neutral discovery contract:
+
+- `IndexDriftCandidateScope`;
+- `IndexDriftCandidateFence`;
+- `IndexDriftCandidateCursor`;
+- `IndexDriftCandidateRequest`;
+- `IndexDriftStaleEntityCandidate`;
+- `IndexDriftOrphanLinkCandidate`;
+- `IndexDriftCandidatePage`;
+- `IndexDriftCandidateReader` and bounded failure classification.
+
+No PostgreSQL reader, server composition, GraphQL resolver, scheduler, finding writer, lifecycle
+command, or repair adapter is added.
+
+## Request and continuation checks
+
+The request constructor requires:
+
+- one non-nil tenant;
+- one exact positive-version `SchemaRef`;
+- one limit in `1..=32`;
+- either no continuation or both an opaque fence and opaque cursor.
+
+Cursor content is bounded to 4 KiB. Fence content is bounded to 512 bytes. Their `Debug`
+implementations reveal only encoded length.
+
+The contract intentionally keeps fence and cursor separate. The future PostgreSQL reader owns their
+contents, and a later transport must seal both values before publication.
+
+## Candidate checks
+
+Stale entity construction requires one valid exact `EntityKey` and one positive indexed source
+version.
+
+Orphan link construction requires:
+
+- one valid source `EntityKey`;
+- one positive indexed source version;
+- one typed `LinkName`;
+- one `u32` ordinal;
+- one non-nil positive-version `LinkedEntityKey` target.
+
+The candidate values contain identity and version metadata only. No indexed fields, owner fields,
+schema fingerprint, record body, link payload, SQL row, database cause, finding state, or repair
+intent crosses this boundary.
+
+## Page checks
+
+`IndexDriftCandidatePage::new` verifies before page return:
+
+1. candidate count does not exceed the request limit;
+2. a continuation request keeps the same fence;
+3. an empty page cannot advertise continuation;
+4. the next cursor differs from the request cursor;
+5. every source candidate remains inside the exact tenant/schema scope;
+6. candidate identities are strictly increasing.
+
+Ordering is phase-stable: stale entity keys first, then orphan links ordered by source key, link name,
+ordinal, and target identity. The PostgreSQL reader must encode the phase and last ordering tuple in
+its private cursor.
+
+## Failure boundary
+
+Reader failures expose only retryable/permanent classification and one bounded machine code. The
+contract itself imports no SeaORM, database connection, GraphQL, environment, secret resolver,
+scheduler, lifecycle, or repair capability.
+
+## Source-review limitations
+
+This recheck does not claim:
+
+- successful compilation;
+- test or verifier execution;
+- correctness of a future SQL query or index selection;
+- an admitted repeatable-read or high-watermark fence implementation;
+- proof that an enumerated entity is actually absent from its owner source;
+- proof that an orphan target violates owner visibility or lifecycle policy;
+- finding persistence, lifecycle, or repair behavior.
+
+The next slice must compose and separately review a PostgreSQL `IndexDriftCandidateReader` using
+bounded keyset reads and an immutable read-only fence.
+
+## Validation ownership
+
+Per maintainer instruction, the implementation agent did not run tests, JavaScript verifiers,
+formatting, Cargo checks, PostgreSQL scenarios, workflows, or CI.

--- a/crates/rustok-index/docs/m6-bounded-drift-candidates.md
+++ b/crates/rustok-index/docs/m6-bounded-drift-candidates.md
@@ -1,0 +1,134 @@
+# M6 bounded stale-entity and orphan-link candidate contract
+
+Status: `source_complete_postgres_reader_pending`.
+
+## Purpose
+
+`IndexDriftCandidateReader` defines the database-neutral boundary for discovering materialized Index
+state that may no longer be justified by an owner source:
+
+- an Index entity may be stale because the exact source entity is now absent;
+- an Index link may be orphaned because its typed target is missing or deleted.
+
+This contract discovers bounded candidates only. It does not prove source absence, record a finding,
+resolve or ignore a finding, mutate Index storage, or repair owner state.
+
+## Exact request scope
+
+Every request carries one `IndexDriftCandidateScope`:
+
+- one non-nil tenant UUID;
+- one exact `SchemaRef`, including a positive schema version.
+
+`IndexDriftCandidateRequest` accepts a page limit in `1..=32`.
+
+The first request has no continuation. Every later request must carry both:
+
+- one opaque `IndexDriftCandidateFence` bounded to 512 bytes;
+- one opaque `IndexDriftCandidateCursor` bounded to 4 KiB.
+
+Supplying only a fence or only a cursor fails before reader access.
+
+## Fence and continuation semantics
+
+The concrete reader chooses the fence on the first page. A PostgreSQL implementation may use a
+captured high-watermark, exported snapshot identity, or another immutable repeatable boundary, but
+it must preserve the same fence for every continuation page.
+
+`IndexDriftCandidatePage::new` rejects:
+
+- a changed fence;
+- a cursor that does not advance;
+- an empty page with a continuation;
+- more candidates than the requested limit;
+- candidates outside the exact tenant/schema scope;
+- duplicate or descending candidate identities.
+
+Cursor and fence `Debug` output reveals only encoded length. A future transport must seal them in an
+authenticated confidential envelope rather than expose either value directly.
+
+## Typed candidates
+
+`IndexDriftCandidate` has two separate variants.
+
+### Stale entity
+
+`IndexDriftStaleEntityCandidate` carries only:
+
+- the exact indexed `EntityKey`;
+- the positive indexed source version.
+
+It does not carry indexed fields, links, schema fingerprint, owner payload, absence proof, finding
+state, or repair intent.
+
+### Orphan link
+
+`IndexDriftOrphanLinkCandidate` carries only:
+
+- the exact source `EntityKey`;
+- the positive source entity version stored by Index;
+- one typed `LinkName`;
+- one bounded `u32` ordinal;
+- one typed `LinkedEntityKey` target identity.
+
+It does not carry the source record, target record, link payload, SQL row, database cause, or a
+caller-selected target list.
+
+## Stable ordering
+
+Candidate ordering is strict and deterministic:
+
+1. stale entity identities ordered by exact `EntityKey`;
+2. orphan link identities ordered by source key, link name, ordinal, and target identity.
+
+The concrete reader owns the opaque keyset encoding and phase transition. A page cannot return a
+duplicate or descending identity. This permits bounded continuation without collecting arbitrary IDs
+in memory.
+
+## Failure boundary
+
+`IndexDriftCandidateFailure` exposes only:
+
+- retryable or permanent classification;
+- one bounded lowercase machine code.
+
+The contract exposes no SQL, connection error, table name, row payload, owner error, or secret.
+
+## Deliberate limits
+
+This slice does not add:
+
+- a PostgreSQL candidate reader;
+- a GraphQL, HTTP, CLI, MCP, or native-admin transport;
+- source absence verification for a stale candidate;
+- target visibility or owner validation for an orphan link;
+- drift finding persistence or lifecycle commands;
+- cursor persistence, background scanning, scheduling, or cross-page accumulation;
+- targeted, full, shadow, or automatic repair;
+- retained execution evidence.
+
+## Next implementation step
+
+Add one PostgreSQL `IndexDriftCandidateReader` that:
+
+- uses one read-only repeatable boundary or immutable high-watermark fence;
+- performs bounded keyset reads only;
+- never starts with an unbounded in-memory ID collection;
+- returns live, non-deleted `index_entities` as stale candidates for later exact source proof;
+- returns `index_links` whose typed target is absent or deleted as orphan candidates;
+- preserves the contract ordering and exact scope;
+- maps database failures to bounded candidate failure codes;
+- performs no finding write, lifecycle transition, or repair.
+
+## Suggested maintainer validation
+
+```bash
+cargo test -p rustok-index drift_candidates -- --nocapture
+node scripts/verify/verify-index-drift-candidate-contract.mjs
+node scripts/verify/verify-index-query-contract.mjs
+cargo check -p rustok-index --all-targets
+git diff --check
+```
+
+No tests, verifiers, formatting, Cargo checks, PostgreSQL scenarios, workflows, or CI were executed by
+the implementation agent.

--- a/crates/rustok-index/src/application/drift_candidates.rs
+++ b/crates/rustok-index/src/application/drift_candidates.rs
@@ -1,0 +1,659 @@
+use std::fmt;
+
+use async_trait::async_trait;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::domain::{EntityKey, LinkName, LinkedEntityKey, SchemaRef};
+
+const MAX_CANDIDATE_PAGE_SIZE: usize = 32;
+const MAX_CANDIDATE_CURSOR_BYTES: usize = 4 * 1024;
+const MAX_CANDIDATE_FENCE_BYTES: usize = 512;
+const MAX_FAILURE_CODE_BYTES: usize = 128;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexDriftCandidateScope {
+    tenant_id: Uuid,
+    schema: SchemaRef,
+}
+
+impl IndexDriftCandidateScope {
+    pub fn new(tenant_id: Uuid, schema: SchemaRef) -> Result<Self, IndexDriftCandidateError> {
+        if tenant_id.is_nil() {
+            return Err(IndexDriftCandidateError::NilTenantId);
+        }
+        if schema.version.get() == 0 {
+            return Err(IndexDriftCandidateError::ZeroSchemaVersion);
+        }
+        Ok(Self { tenant_id, schema })
+    }
+
+    pub fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+}
+
+/// Opaque reader-owned continuation state.
+///
+/// Debug output deliberately reveals only the encoded length. A future transport must wrap this
+/// value in an authenticated confidential envelope rather than expose it directly.
+#[derive(Clone, PartialEq, Eq)]
+pub struct IndexDriftCandidateCursor(String);
+
+impl IndexDriftCandidateCursor {
+    pub fn new(value: impl Into<String>) -> Result<Self, IndexDriftCandidateError> {
+        let value = value.into();
+        validate_opaque_value(
+            &value,
+            MAX_CANDIDATE_CURSOR_BYTES,
+            IndexDriftCandidateError::EmptyCursor,
+            |actual, max| IndexDriftCandidateError::CursorTooLarge { actual, max },
+        )?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Debug for IndexDriftCandidateCursor {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("IndexDriftCandidateCursor")
+            .field("encoded_bytes", &self.0.len())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Immutable snapshot/high-watermark identity chosen by the concrete candidate reader.
+///
+/// Every continuation request must carry the same fence. The database-neutral contract does not
+/// prescribe whether PostgreSQL later implements this as an exported snapshot, a captured
+/// high-watermark, or another read-only repeatable boundary.
+#[derive(Clone, PartialEq, Eq)]
+pub struct IndexDriftCandidateFence(String);
+
+impl IndexDriftCandidateFence {
+    pub fn new(value: impl Into<String>) -> Result<Self, IndexDriftCandidateError> {
+        let value = value.into();
+        validate_opaque_value(
+            &value,
+            MAX_CANDIDATE_FENCE_BYTES,
+            IndexDriftCandidateError::EmptyFence,
+            |actual, max| IndexDriftCandidateError::FenceTooLarge { actual, max },
+        )?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Debug for IndexDriftCandidateFence {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("IndexDriftCandidateFence")
+            .field("encoded_bytes", &self.0.len())
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexDriftCandidateRequest {
+    scope: IndexDriftCandidateScope,
+    fence: Option<IndexDriftCandidateFence>,
+    cursor: Option<IndexDriftCandidateCursor>,
+    limit: usize,
+}
+
+impl IndexDriftCandidateRequest {
+    pub fn new(
+        scope: IndexDriftCandidateScope,
+        fence: Option<IndexDriftCandidateFence>,
+        cursor: Option<IndexDriftCandidateCursor>,
+        limit: usize,
+    ) -> Result<Self, IndexDriftCandidateError> {
+        if !(1..=MAX_CANDIDATE_PAGE_SIZE).contains(&limit) {
+            return Err(IndexDriftCandidateError::InvalidPageLimit {
+                actual: limit,
+                max: MAX_CANDIDATE_PAGE_SIZE,
+            });
+        }
+        if fence.is_some() != cursor.is_some() {
+            return Err(IndexDriftCandidateError::IncompleteContinuation);
+        }
+        Ok(Self {
+            scope,
+            fence,
+            cursor,
+            limit,
+        })
+    }
+
+    pub fn first_page(
+        scope: IndexDriftCandidateScope,
+        limit: usize,
+    ) -> Result<Self, IndexDriftCandidateError> {
+        Self::new(scope, None, None, limit)
+    }
+
+    pub fn scope(&self) -> &IndexDriftCandidateScope {
+        &self.scope
+    }
+
+    pub fn fence(&self) -> Option<&IndexDriftCandidateFence> {
+        self.fence.as_ref()
+    }
+
+    pub fn cursor(&self) -> Option<&IndexDriftCandidateCursor> {
+        self.cursor.as_ref()
+    }
+
+    pub fn limit(&self) -> usize {
+        self.limit
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexDriftStaleEntityCandidate {
+    key: EntityKey,
+    indexed_source_version: u64,
+}
+
+impl IndexDriftStaleEntityCandidate {
+    pub fn new(
+        key: EntityKey,
+        indexed_source_version: u64,
+    ) -> Result<Self, IndexDriftCandidateError> {
+        validate_entity_key(&key)?;
+        if indexed_source_version == 0 {
+            return Err(IndexDriftCandidateError::ZeroIndexedSourceVersion);
+        }
+        Ok(Self {
+            key,
+            indexed_source_version,
+        })
+    }
+
+    pub fn key(&self) -> &EntityKey {
+        &self.key
+    }
+
+    pub fn indexed_source_version(&self) -> u64 {
+        self.indexed_source_version
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexDriftOrphanLinkCandidate {
+    source_key: EntityKey,
+    indexed_source_version: u64,
+    link_name: LinkName,
+    ordinal: u32,
+    target: LinkedEntityKey,
+}
+
+impl IndexDriftOrphanLinkCandidate {
+    pub fn new(
+        source_key: EntityKey,
+        indexed_source_version: u64,
+        link_name: LinkName,
+        ordinal: u32,
+        target: LinkedEntityKey,
+    ) -> Result<Self, IndexDriftCandidateError> {
+        validate_entity_key(&source_key)?;
+        if indexed_source_version == 0 {
+            return Err(IndexDriftCandidateError::ZeroIndexedSourceVersion);
+        }
+        if target.entity_id.is_nil() {
+            return Err(IndexDriftCandidateError::NilTargetEntityId);
+        }
+        if target.schema.version.get() == 0 {
+            return Err(IndexDriftCandidateError::ZeroTargetSchemaVersion);
+        }
+        Ok(Self {
+            source_key,
+            indexed_source_version,
+            link_name,
+            ordinal,
+            target,
+        })
+    }
+
+    pub fn source_key(&self) -> &EntityKey {
+        &self.source_key
+    }
+
+    pub fn indexed_source_version(&self) -> u64 {
+        self.indexed_source_version
+    }
+
+    pub fn link_name(&self) -> &LinkName {
+        &self.link_name
+    }
+
+    pub fn ordinal(&self) -> u32 {
+        self.ordinal
+    }
+
+    pub fn target(&self) -> &LinkedEntityKey {
+        &self.target
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IndexDriftCandidate {
+    StaleEntity(IndexDriftStaleEntityCandidate),
+    OrphanLink(IndexDriftOrphanLinkCandidate),
+}
+
+impl IndexDriftCandidate {
+    pub fn stale_entity(
+        key: EntityKey,
+        indexed_source_version: u64,
+    ) -> Result<Self, IndexDriftCandidateError> {
+        IndexDriftStaleEntityCandidate::new(key, indexed_source_version).map(Self::StaleEntity)
+    }
+
+    pub fn orphan_link(
+        source_key: EntityKey,
+        indexed_source_version: u64,
+        link_name: LinkName,
+        ordinal: u32,
+        target: LinkedEntityKey,
+    ) -> Result<Self, IndexDriftCandidateError> {
+        IndexDriftOrphanLinkCandidate::new(
+            source_key,
+            indexed_source_version,
+            link_name,
+            ordinal,
+            target,
+        )
+        .map(Self::OrphanLink)
+    }
+
+    fn source_key(&self) -> &EntityKey {
+        match self {
+            Self::StaleEntity(candidate) => candidate.key(),
+            Self::OrphanLink(candidate) => candidate.source_key(),
+        }
+    }
+
+    fn order_key(&self) -> IndexDriftCandidateOrderKey {
+        match self {
+            Self::StaleEntity(candidate) => {
+                IndexDriftCandidateOrderKey::StaleEntity(candidate.key.clone())
+            }
+            Self::OrphanLink(candidate) => IndexDriftCandidateOrderKey::OrphanLink {
+                source_key: candidate.source_key.clone(),
+                link_name: candidate.link_name.clone(),
+                ordinal: candidate.ordinal,
+                target: candidate.target.clone(),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum IndexDriftCandidateOrderKey {
+    StaleEntity(EntityKey),
+    OrphanLink {
+        source_key: EntityKey,
+        link_name: LinkName,
+        ordinal: u32,
+        target: LinkedEntityKey,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexDriftCandidatePage {
+    fence: IndexDriftCandidateFence,
+    candidates: Vec<IndexDriftCandidate>,
+    next_cursor: Option<IndexDriftCandidateCursor>,
+}
+
+impl IndexDriftCandidatePage {
+    pub fn new(
+        request: &IndexDriftCandidateRequest,
+        fence: IndexDriftCandidateFence,
+        candidates: Vec<IndexDriftCandidate>,
+        next_cursor: Option<IndexDriftCandidateCursor>,
+    ) -> Result<Self, IndexDriftCandidateError> {
+        if candidates.len() > request.limit {
+            return Err(IndexDriftCandidateError::PageTooLarge {
+                actual: candidates.len(),
+                max: request.limit,
+            });
+        }
+        if request.fence.as_ref().is_some_and(|expected| expected != &fence) {
+            return Err(IndexDriftCandidateError::FenceChanged);
+        }
+        if next_cursor.is_some() && candidates.is_empty() {
+            return Err(IndexDriftCandidateError::EmptyPageContinuation);
+        }
+        if request.cursor.as_ref().is_some_and(|current| {
+            next_cursor.as_ref().is_some_and(|next| current == next)
+        }) {
+            return Err(IndexDriftCandidateError::CursorDidNotAdvance);
+        }
+
+        let mut previous = None;
+        for (position, candidate) in candidates.iter().enumerate() {
+            let key = candidate.source_key();
+            if key.tenant_id != request.scope.tenant_id || key.schema != request.scope.schema {
+                return Err(IndexDriftCandidateError::CandidateScopeMismatch { position });
+            }
+            let order_key = candidate.order_key();
+            if previous.as_ref().is_some_and(|previous| previous >= &order_key) {
+                return Err(IndexDriftCandidateError::UnstableCandidateOrder { position });
+            }
+            previous = Some(order_key);
+        }
+
+        Ok(Self {
+            fence,
+            candidates,
+            next_cursor,
+        })
+    }
+
+    pub fn fence(&self) -> &IndexDriftCandidateFence {
+        &self.fence
+    }
+
+    pub fn candidates(&self) -> &[IndexDriftCandidate] {
+        &self.candidates
+    }
+
+    pub fn next_cursor(&self) -> Option<&IndexDriftCandidateCursor> {
+        self.next_cursor.as_ref()
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.next_cursor.is_none()
+    }
+
+    pub fn into_parts(
+        self,
+    ) -> (
+        IndexDriftCandidateFence,
+        Vec<IndexDriftCandidate>,
+        Option<IndexDriftCandidateCursor>,
+    ) {
+        (self.fence, self.candidates, self.next_cursor)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexDriftCandidateFailureKind {
+    Retryable,
+    Permanent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("Index drift candidate reader reported a {kind:?} failure ({code})")]
+pub struct IndexDriftCandidateFailure {
+    kind: IndexDriftCandidateFailureKind,
+    code: String,
+}
+
+impl IndexDriftCandidateFailure {
+    pub fn retryable(code: impl Into<String>) -> Result<Self, IndexDriftCandidateError> {
+        Self::new(IndexDriftCandidateFailureKind::Retryable, code)
+    }
+
+    pub fn permanent(code: impl Into<String>) -> Result<Self, IndexDriftCandidateError> {
+        Self::new(IndexDriftCandidateFailureKind::Permanent, code)
+    }
+
+    fn new(
+        kind: IndexDriftCandidateFailureKind,
+        code: impl Into<String>,
+    ) -> Result<Self, IndexDriftCandidateError> {
+        let code = code.into();
+        if !valid_machine_name(&code) {
+            return Err(IndexDriftCandidateError::InvalidFailureCode(code));
+        }
+        Ok(Self { kind, code })
+    }
+
+    pub fn kind(&self) -> IndexDriftCandidateFailureKind {
+        self.kind
+    }
+
+    pub fn code(&self) -> &str {
+        &self.code
+    }
+}
+
+#[async_trait]
+pub trait IndexDriftCandidateReader: Send + Sync {
+    async fn read_candidate_page(
+        &self,
+        request: IndexDriftCandidateRequest,
+    ) -> Result<IndexDriftCandidatePage, IndexDriftCandidateFailure>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum IndexDriftCandidateError {
+    #[error("Index drift candidate tenant cannot be nil")]
+    NilTenantId,
+    #[error("Index drift candidate schema version must be positive")]
+    ZeroSchemaVersion,
+    #[error("Index drift candidate entity cannot be nil")]
+    NilEntityId,
+    #[error("Index drift candidate target entity cannot be nil")]
+    NilTargetEntityId,
+    #[error("Index drift candidate target schema version must be positive")]
+    ZeroTargetSchemaVersion,
+    #[error("Index drift candidate indexed source version must be positive")]
+    ZeroIndexedSourceVersion,
+    #[error("Index drift candidate page limit is invalid: actual={actual}, max={max}")]
+    InvalidPageLimit { actual: usize, max: usize },
+    #[error("Index drift candidate continuation requires both fence and cursor")]
+    IncompleteContinuation,
+    #[error("Index drift candidate cursor cannot be empty")]
+    EmptyCursor,
+    #[error("Index drift candidate cursor is too large: actual={actual}, max={max}")]
+    CursorTooLarge { actual: usize, max: usize },
+    #[error("Index drift candidate fence cannot be empty")]
+    EmptyFence,
+    #[error("Index drift candidate fence is too large: actual={actual}, max={max}")]
+    FenceTooLarge { actual: usize, max: usize },
+    #[error("Index drift candidate page exceeds its request: actual={actual}, max={max}")]
+    PageTooLarge { actual: usize, max: usize },
+    #[error("Index drift candidate page changed its immutable fence")]
+    FenceChanged,
+    #[error("Index drift candidate page returned an empty page with continuation")]
+    EmptyPageContinuation,
+    #[error("Index drift candidate continuation cursor did not advance")]
+    CursorDidNotAdvance,
+    #[error("Index drift candidate at position {position} escapes the request scope")]
+    CandidateScopeMismatch { position: usize },
+    #[error("Index drift candidate order is unstable at position {position}")]
+    UnstableCandidateOrder { position: usize },
+    #[error("Index drift candidate failure code is invalid: {0}")]
+    InvalidFailureCode(String),
+}
+
+fn validate_entity_key(key: &EntityKey) -> Result<(), IndexDriftCandidateError> {
+    if key.tenant_id.is_nil() {
+        return Err(IndexDriftCandidateError::NilTenantId);
+    }
+    if key.schema.version.get() == 0 {
+        return Err(IndexDriftCandidateError::ZeroSchemaVersion);
+    }
+    if key.entity_id.is_nil() {
+        return Err(IndexDriftCandidateError::NilEntityId);
+    }
+    Ok(())
+}
+
+fn validate_opaque_value<TooLarge>(
+    value: &str,
+    max: usize,
+    empty: IndexDriftCandidateError,
+    too_large: TooLarge,
+) -> Result<(), IndexDriftCandidateError>
+where
+    TooLarge: FnOnce(usize, usize) -> IndexDriftCandidateError,
+{
+    if value.is_empty() {
+        return Err(empty);
+    }
+    if value.len() > max {
+        return Err(too_large(value.len(), max));
+    }
+    Ok(())
+}
+
+fn valid_machine_name(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_FAILURE_CODE_BYTES
+        && value.bytes().all(|byte| {
+            byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || matches!(byte, b'-' | b'_' | b'.')
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{EntityName, LocaleKey, ModuleName, SchemaVersion};
+
+    fn schema(entity: &str) -> SchemaRef {
+        SchemaRef {
+            module: ModuleName::new("rustok-product").expect("valid module"),
+            entity: EntityName::new(entity).expect("valid entity"),
+            version: SchemaVersion::new(1),
+        }
+    }
+
+    fn key(entity_id: Uuid) -> EntityKey {
+        EntityKey {
+            tenant_id: Uuid::from_u128(1),
+            schema: schema("product"),
+            entity_id,
+            locale: Some(LocaleKey::new("en-US").expect("valid locale")),
+        }
+    }
+
+    #[test]
+    fn continuation_requires_fence_and_cursor_together() {
+        let scope = IndexDriftCandidateScope::new(Uuid::from_u128(1), schema("product"))
+            .expect("valid scope");
+        let fence = IndexDriftCandidateFence::new("snapshot-1").expect("valid fence");
+        let error = IndexDriftCandidateRequest::new(scope, Some(fence), None, 16)
+            .expect_err("partial continuation must fail");
+        assert_eq!(error, IndexDriftCandidateError::IncompleteContinuation);
+    }
+
+    #[test]
+    fn page_rejects_scope_escape_and_unstable_order() {
+        let scope = IndexDriftCandidateScope::new(Uuid::from_u128(1), schema("product"))
+            .expect("valid scope");
+        let request = IndexDriftCandidateRequest::first_page(scope, 16).expect("valid request");
+        let fence = IndexDriftCandidateFence::new("snapshot-1").expect("valid fence");
+
+        let later = IndexDriftCandidate::stale_entity(key(Uuid::from_u128(3)), 3)
+            .expect("valid candidate");
+        let earlier = IndexDriftCandidate::stale_entity(key(Uuid::from_u128(2)), 2)
+            .expect("valid candidate");
+        let error = IndexDriftCandidatePage::new(
+            &request,
+            fence.clone(),
+            vec![later, earlier],
+            None,
+        )
+        .expect_err("descending candidates must fail");
+        assert_eq!(
+            error,
+            IndexDriftCandidateError::UnstableCandidateOrder { position: 1 }
+        );
+
+        let mut escaped = key(Uuid::from_u128(4));
+        escaped.tenant_id = Uuid::from_u128(2);
+        let escaped = IndexDriftCandidate::stale_entity(escaped, 4).expect("valid candidate");
+        let error = IndexDriftCandidatePage::new(&request, fence, vec![escaped], None)
+            .expect_err("cross-tenant candidate must fail");
+        assert_eq!(
+            error,
+            IndexDriftCandidateError::CandidateScopeMismatch { position: 0 }
+        );
+    }
+
+    #[test]
+    fn page_requires_fence_stability_and_cursor_progress() {
+        let scope = IndexDriftCandidateScope::new(Uuid::from_u128(1), schema("product"))
+            .expect("valid scope");
+        let request = IndexDriftCandidateRequest::new(
+            scope,
+            Some(IndexDriftCandidateFence::new("snapshot-1").expect("valid fence")),
+            Some(IndexDriftCandidateCursor::new("cursor-1").expect("valid cursor")),
+            16,
+        )
+        .expect("valid continuation request");
+        let candidate = IndexDriftCandidate::stale_entity(key(Uuid::from_u128(2)), 2)
+            .expect("valid candidate");
+
+        let error = IndexDriftCandidatePage::new(
+            &request,
+            IndexDriftCandidateFence::new("snapshot-2").expect("valid fence"),
+            vec![candidate.clone()],
+            None,
+        )
+        .expect_err("changed fence must fail");
+        assert_eq!(error, IndexDriftCandidateError::FenceChanged);
+
+        let error = IndexDriftCandidatePage::new(
+            &request,
+            IndexDriftCandidateFence::new("snapshot-1").expect("valid fence"),
+            vec![candidate],
+            Some(IndexDriftCandidateCursor::new("cursor-1").expect("valid cursor")),
+        )
+        .expect_err("same cursor must fail");
+        assert_eq!(error, IndexDriftCandidateError::CursorDidNotAdvance);
+    }
+
+    #[test]
+    fn orphan_candidate_keeps_only_typed_identity() {
+        let source_key = key(Uuid::from_u128(2));
+        let target = LinkedEntityKey {
+            schema: schema("product-variant"),
+            entity_id: Uuid::from_u128(3),
+            locale: None,
+        };
+        let candidate = IndexDriftCandidate::orphan_link(
+            source_key,
+            7,
+            LinkName::new("variants").expect("valid link"),
+            0,
+            target,
+        )
+        .expect("valid orphan candidate");
+        assert!(matches!(candidate, IndexDriftCandidate::OrphanLink(_)));
+    }
+
+    #[test]
+    fn opaque_debug_does_not_reveal_values() {
+        let cursor = IndexDriftCandidateCursor::new("private-cursor").expect("valid cursor");
+        let fence = IndexDriftCandidateFence::new("private-fence").expect("valid fence");
+        assert!(!format!("{cursor:?}").contains("private-cursor"));
+        assert!(!format!("{fence:?}").contains("private-fence"));
+    }
+}

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -1,5 +1,6 @@
 mod aggregate_ordering;
 mod cursor;
+mod drift_candidates;
 mod drift_digest;
 mod mutation_event;
 mod planner;
@@ -37,6 +38,12 @@ mod source_replay_tests;
 
 pub use aggregate_ordering::AggregateOrderValidationError;
 pub use cursor::{CursorCodec, CursorCodecError, CursorValidationError, IndexCursor};
+pub use drift_candidates::{
+    IndexDriftCandidate, IndexDriftCandidateCursor, IndexDriftCandidateError,
+    IndexDriftCandidateFailure, IndexDriftCandidateFailureKind, IndexDriftCandidateFence,
+    IndexDriftCandidatePage, IndexDriftCandidateReader, IndexDriftCandidateRequest,
+    IndexDriftCandidateScope, IndexDriftOrphanLinkCandidate, IndexDriftStaleEntityCandidate,
+};
 pub use drift_digest::{
     IndexDriftDependencyFailure, IndexDriftDependencyFailureKind, IndexDriftDigestError,
     IndexDriftDigestMismatch, IndexDriftDigestOutcome, IndexDriftDigestProducer,

--- a/scripts/verify/verify-index-drift-candidate-contract.mjs
+++ b/scripts/verify/verify-index-drift-candidate-contract.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises';
+
+const files = {
+  source: 'crates/rustok-index/src/application/drift_candidates.rs',
+  applicationMod: 'crates/rustok-index/src/application/mod.rs',
+  doc: 'crates/rustok-index/docs/m6-bounded-drift-candidates.md',
+  plan: 'crates/rustok-index/docs/implementation-plan-current-2026-08-03.md',
+  aggregate: 'scripts/verify/verify-index-query-contract.mjs',
+};
+
+const content = Object.fromEntries(
+  await Promise.all(
+    Object.entries(files).map(async ([name, path]) => [name, await readFile(path, 'utf8')]),
+  ),
+);
+
+function requireMarkers(name, markers) {
+  for (const marker of markers) {
+    if (!content[name].includes(marker)) {
+      throw new Error(`${files[name]} missing ${marker}`);
+    }
+  }
+}
+
+requireMarkers('applicationMod', [
+  'mod drift_candidates;',
+  'IndexDriftCandidateReader',
+  'IndexDriftCandidateRequest',
+  'IndexDriftStaleEntityCandidate',
+  'IndexDriftOrphanLinkCandidate',
+]);
+
+requireMarkers('source', [
+  'const MAX_CANDIDATE_PAGE_SIZE: usize = 32;',
+  'const MAX_CANDIDATE_CURSOR_BYTES: usize = 4 * 1024;',
+  'const MAX_CANDIDATE_FENCE_BYTES: usize = 512;',
+  'pub struct IndexDriftCandidateScope',
+  'tenant_id.is_nil()',
+  'schema.version.get() == 0',
+  'pub struct IndexDriftCandidateCursor(String);',
+  'pub struct IndexDriftCandidateFence(String);',
+  'pub struct IndexDriftCandidateRequest',
+  'if fence.is_some() != cursor.is_some()',
+  'pub struct IndexDriftStaleEntityCandidate',
+  'pub struct IndexDriftOrphanLinkCandidate',
+  'pub enum IndexDriftCandidate',
+  'StaleEntity(IndexDriftStaleEntityCandidate)',
+  'OrphanLink(IndexDriftOrphanLinkCandidate)',
+  'enum IndexDriftCandidateOrderKey',
+  'pub struct IndexDriftCandidatePage',
+  'if candidates.len() > request.limit',
+  'IndexDriftCandidateError::FenceChanged',
+  'IndexDriftCandidateError::EmptyPageContinuation',
+  'IndexDriftCandidateError::CursorDidNotAdvance',
+  'IndexDriftCandidateError::CandidateScopeMismatch',
+  'IndexDriftCandidateError::UnstableCandidateOrder',
+  'pub trait IndexDriftCandidateReader: Send + Sync',
+  'async fn read_candidate_page(',
+  'continuation_requires_fence_and_cursor_together',
+  'page_rejects_scope_escape_and_unstable_order',
+  'page_requires_fence_stability_and_cursor_progress',
+  'orphan_candidate_keeps_only_typed_identity',
+  'opaque_debug_does_not_reveal_values',
+]);
+
+const production = content.source.split('\n#[cfg(test)]')[0];
+for (const forbidden of [
+  'sea_orm',
+  'DatabaseConnection',
+  'DatabaseTransaction',
+  'SELECT ',
+  'INSERT ',
+  'UPDATE ',
+  'DELETE FROM',
+  'async_graphql',
+  'Router::new',
+  'tokio::spawn',
+  'spawn_blocking',
+  'std::env',
+  'SecretResolverRegistry',
+  'resolve_finding',
+  'ignore_finding',
+  'repair_finding',
+]) {
+  if (production.includes(forbidden)) {
+    throw new Error(`drift candidate contract contains forbidden capability: ${forbidden}`);
+  }
+}
+
+const pageStart = production.indexOf('    pub fn new(\n        request: &IndexDriftCandidateRequest,');
+const pageEnd = production.indexOf('\n    pub fn fence(&self)', pageStart);
+if (pageStart < 0 || pageEnd <= pageStart) {
+  throw new Error('candidate page constructor segment is incomplete');
+}
+const page = production.slice(pageStart, pageEnd);
+const size = page.indexOf('if candidates.len() > request.limit');
+const fence = page.indexOf('IndexDriftCandidateError::FenceChanged', size);
+const empty = page.indexOf('IndexDriftCandidateError::EmptyPageContinuation', fence);
+const progress = page.indexOf('IndexDriftCandidateError::CursorDidNotAdvance', empty);
+const scope = page.indexOf('IndexDriftCandidateError::CandidateScopeMismatch', progress);
+const order = page.indexOf('IndexDriftCandidateError::UnstableCandidateOrder', scope);
+if (size < 0 || fence <= size || empty <= fence || progress <= empty || scope <= progress || order <= scope) {
+  throw new Error('candidate page must bound, fence, advance, scope, then order candidates');
+}
+
+for (const leak of [
+  '.field("value"',
+  '.field("cursor"',
+  '.field("fence"',
+  'derive(Debug, Clone, PartialEq, Eq)\npub struct IndexDriftCandidateCursor',
+  'derive(Debug, Clone, PartialEq, Eq)\npub struct IndexDriftCandidateFence',
+]) {
+  if (production.includes(leak)) {
+    throw new Error(`opaque candidate continuation leaks through Debug: ${leak}`);
+  }
+}
+
+requireMarkers('doc', [
+  'Status: `source_complete_postgres_reader_pending`.',
+  'page limit in `1..=32`',
+  'bounded to 512 bytes',
+  'bounded to 4 KiB',
+  'Stale entity',
+  'Orphan link',
+  'strict and deterministic',
+  'does not add:',
+  'PostgreSQL `IndexDriftCandidateReader`',
+]);
+requireMarkers('plan', [
+  'M6 - bound stale Index-only entity and orphan-link diagnosis',
+]);
+requireMarkers('aggregate', [
+  "'verify-index-drift-candidate-contract.mjs'",
+]);
+
+console.log('Index bounded drift candidate contract verified');

--- a/scripts/verify/verify-index-drift-candidate-contract.mjs
+++ b/scripts/verify/verify-index-drift-candidate-contract.mjs
@@ -7,6 +7,7 @@ const files = {
   applicationMod: 'crates/rustok-index/src/application/mod.rs',
   doc: 'crates/rustok-index/docs/m6-bounded-drift-candidates.md',
   plan: 'crates/rustok-index/docs/implementation-plan-current-2026-08-03.md',
+  recheck: 'crates/rustok-index/docs/implementation-recheck-2026-08-06-bounded-drift-candidates.md',
   aggregate: 'scripts/verify/verify-index-query-contract.mjs',
 };
 
@@ -129,7 +130,16 @@ requireMarkers('doc', [
   'PostgreSQL `IndexDriftCandidateReader`',
 ]);
 requireMarkers('plan', [
-  'M6 - bound stale Index-only entity and orphan-link diagnosis',
+  'M6 - compose the bounded PostgreSQL drift candidate reader',
+  'M6 bounded stale-entity and orphan-link candidate contract',
+  'source_complete_postgres_reader_pending',
+  '[x] Add a database-neutral bounded candidate contract',
+]);
+requireMarkers('recheck', [
+  'Audited baseline: `main@53aeddfbf05ceccea27f6c2f639af904c3ace6b2`.',
+  'The only main delta after the baseline is Pages storefront Navigation/SEO ETag composition.',
+  'This recheck does not claim:',
+  'did not run tests, JavaScript verifiers',
 ]);
 requireMarkers('aggregate', [
   "'verify-index-drift-candidate-contract.mjs'",

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -30,6 +30,7 @@ const scripts = [
   'verify-index-drift-diagnosis-graphql-transport.mjs',
   'verify-index-drift-source-page-diagnosis.mjs',
   'verify-index-drift-source-page-graphql-transport.mjs',
+  'verify-index-drift-candidate-contract.mjs',
   'verify-index-reconciliation-retry-store.mjs',
   'verify-index-reconciliation-runner-retry.mjs',
   'verify-index-reconciliation-host-scheduler.mjs',


### PR DESCRIPTION
## Summary

- add a database-neutral bounded discovery contract for stale Index-only entity candidates and orphan-link candidates;
- require one exact non-nil tenant and positive-version `SchemaRef` scope;
- bound each page to `1..=32` candidates;
- require an opaque fence and cursor together on every continuation request;
- bound the private fence to 512 bytes and private cursor to 4 KiB;
- reject changed fences, non-advancing cursors, empty continuation pages, scope escape, duplicate or descending identities, and oversized pages;
- expose separate typed stale-entity and orphan-link variants without indexed records, owner records, link payloads, SQL, database causes, lifecycle state, or repair intent;
- define phase-stable ordering: stale entity keys first, then orphan links by source key, link name, ordinal, and target identity;
- expose a database-neutral `IndexDriftCandidateReader` with bounded retryable/permanent machine-code failures;
- add dedicated documentation, recheck, and aggregate static guard coverage.

## Contract boundaries

This PR contains no SeaORM or database connection, no SQL, no server composition, no GraphQL/HTTP/CLI/MCP/native-admin transport, no source call, no finding write, no lifecycle transition, no scheduler, and no repair.

The first request has no continuation. Later requests must carry both the same immutable reader fence and an advancing opaque cursor. Cursor and fence `Debug` output reveals only encoded length. A future transport must seal both values rather than expose them directly.

Stale candidates carry only an exact `EntityKey` and positive indexed source version. Orphan-link candidates carry only the exact source key/version, one typed link name, one `u32` ordinal, and one typed target identity.

## Latest main recheck

The branch started from `main@53aeddfbf05ceccea27f6c2f639af904c3ace6b2`. Latest checked `main` is `d1a4e71d8b9d212d96067eb7c186def64ed4e48e`.

The intervening commits compose Pages storefront Navigation/SEO ETags and harden Commerce Admin Shipping diagnostics. They do not modify `crates/rustok-index`, Product Index composition, Index transports/services, or Index guards changed by this PR.

The latest concurrency record is `crates/rustok-index/docs/implementation-main-delta-2026-08-06-0812.md`.

## Deliberate limits

This PR does not add or claim:

- a PostgreSQL candidate reader;
- proof that a stale candidate is absent from its owner source;
- proof that an orphan target violates owner visibility or lifecycle policy;
- public transport or sealed candidate continuation;
- finding persistence, resolve/ignore lifecycle, or repair;
- cursor persistence, background scanning, scheduling, or cross-page accumulation;
- retained execution evidence.

## Next cursor

Compose one internal PostgreSQL `IndexDriftCandidateReader` over `index_entities` and `index_links` using bounded keyset reads under one immutable read-only fence. It must encode only phase plus the last ordering tuple, map database failures to bounded machine codes, and perform no source call, finding write, lifecycle transition, scheduling, or repair.

## Suggested maintainer validation

```bash
cargo test -p rustok-index drift_candidates -- --nocapture
node scripts/verify/verify-index-drift-candidate-contract.mjs
node scripts/verify/verify-index-query-contract.mjs
cargo check -p rustok-index --all-targets
git diff --check
```

No tests, verifiers, formatting, Cargo checks, PostgreSQL scenarios, workflows, or CI were run by the implementation agent.