### PR TITLE
fix(commerce): bound admin shipping diagnostics

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/admin-shipping-diagnostic-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/admin-shipping-diagnostic-safety-source-review.json
@@ -1,0 +1,51 @@
+{
+  "status": "commerce_admin_shipping_diagnostic_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-commerce/src/controllers/admin/shipping.rs",
+    "scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs",
+    "scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs",
+    "crates/rustok-commerce/docs/admin-shipping-diagnostic-safety.md",
+    "crates/rustok-commerce/docs/implementation-plan.md"
+  ],
+  "source_contract": {
+    "raw_commerce_error_logged": false,
+    "raw_fulfillment_error_logged": false,
+    "raw_port_error_logged": false,
+    "raw_tenant_uuid_logged": false,
+    "raw_shipping_option_uuid_logged": false,
+    "raw_actor_identifier_logged": false,
+    "raw_correlation_identifier_logged": false,
+    "raw_channel_logged": false,
+    "raw_locale_logged": false,
+    "redacted_error_debug_logged": true,
+    "required_uuid_shapes_logged": true,
+    "optional_uuid_shapes_logged": true,
+    "port_text_presence_shapes_logged": true,
+    "locale_length_logged": true,
+    "deadline_retained": true,
+    "internal_code_and_retryability_retained": true,
+    "typed_policy_selection_precedes_shadowing": true,
+    "shipping_profile_http_policy_preserved": true,
+    "shipping_option_mutation_http_policy_preserved": true,
+    "shipping_option_port_http_policy_preserved": true,
+    "twelve_route_contracts_preserved": true,
+    "profile_validation_preserved": true,
+    "permissions_preserved": true,
+    "owner_calls_preserved": true,
+    "filters_pagination_and_locales_preserved": true,
+    "broad_ecommerce_cleanup_closed": false,
+    "runtime_evidence_claimed": false
+  },
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed."
+}

--- a/crates/rustok-commerce/docs/admin-shipping-diagnostic-safety.md
+++ b/crates/rustok-commerce/docs/admin-shipping-diagnostic-safety.md
@@ -1,0 +1,56 @@
+# Admin shipping diagnostic safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens the three failure mappers used by the Commerce Admin Shipping HTTP boundary:
+
+- shipping-profile owner operations and shipping-profile slug validation;
+- direct fulfillment-owner shipping-option mutations;
+- host-composed shipping-option list and detail reads.
+
+All twelve mounted shipping-profile and shipping-option routes remain unchanged. Only the diagnostic projection emitted after typed HTTP policy selection changes.
+
+## Bounded diagnostic projection
+
+Typed `CommerceError`, `FulfillmentError`, `PortError`, `PortContext`, and `AdminShippingOptionErrorContext` remain available while HTTP policy is selected. Before each `tracing::error!` event:
+
+- the typed error is shadowed by a diagnostic type whose `Debug` output is always `redacted`;
+- tenant identity becomes `nil` / `non_nil`;
+- optional shipping-option identity becomes `absent` / `present_nil` / `present_non_nil`;
+- correlation, actor, and channel values become closed presence-shape labels;
+- locale becomes its length rather than its content;
+- deadline, stable internal code, retryability, owner operation, route operation, error kind, public code, HTTP status, owner, boundary, and static event messages remain observable where they existed before.
+
+No validation text, database cause, provider payload, transition detail, UUID, actor identifier, correlation identifier, channel value, or locale value is emitted by these mappers.
+
+## Preserved behavior
+
+This work does not change:
+
+- shipping-profile `CommerceError` status/code/message policy;
+- shipping-option `FulfillmentError` mutation policy;
+- shipping-option `PortErrorKind` read policy;
+- `HttpError::new(status, code, message)` construction;
+- `FULFILLMENTS_READ`, `FULFILLMENTS_CREATE`, and `FULFILLMENTS_UPDATE` permissions;
+- profile slug validation before option create/update;
+- shipping-profile list/create/show/update/deactivate/reactivate owner calls;
+- host-composed shipping-option list/detail reads;
+- direct shipping-option create/update/deactivate/reactivate owner calls;
+- active, currency, provider, and search filters;
+- pagination, locale forwarding, tenant default-locale fallback, and successful response DTOs.
+
+## Remaining boundary
+
+The broad ecommerce correlation-safe mapper and non-`PortError` public-envelope cleanup remains open. This slice does not claim completion for inventory, customer, tax, promotion, checkout-operation, storefront, native, GraphQL, owner-adapter, or runtime verification work.
+
+## Evidence
+
+- `crates/rustok-commerce/contracts/evidence/admin-shipping-diagnostic-safety-source-review.json`
+- `scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs`
+- `scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs`
+
+## Validation disclosure
+
+No tests, Node verifiers, formatting, Cargo commands, mounted HTTP scenarios, workflows, or CI were run. No compile, runtime, FFA, or FBA status is promoted.

--- a/crates/rustok-commerce/src/controllers/admin/shipping.rs
+++ b/crates/rustok-commerce/src/controllers/admin/shipping.rs
@@ -48,6 +48,89 @@ impl AdminShippingOptionErrorContext {
     }
 }
 
+struct AdminShippingOptionDiagnosticContext {
+    tenant_id: &'static str,
+    shipping_option_id: &'static str,
+    operation: &'static str,
+}
+
+impl From<&AdminShippingOptionErrorContext> for AdminShippingOptionDiagnosticContext {
+    fn from(context: &AdminShippingOptionErrorContext) -> Self {
+        Self {
+            tenant_id: uuid_shape(context.tenant_id),
+            shipping_option_id: optional_uuid_shape(context.shipping_option_id),
+            operation: context.operation,
+        }
+    }
+}
+
+struct AdminShippingOptionPortDiagnosticContext {
+    correlation_id: &'static str,
+    actor: &'static str,
+    channel: &'static str,
+    locale: usize,
+    deadline_ms: Option<u64>,
+}
+
+impl From<&PortContext> for AdminShippingOptionPortDiagnosticContext {
+    fn from(context: &PortContext) -> Self {
+        Self {
+            correlation_id: text_presence_shape(context.correlation_id.as_str()),
+            actor: text_presence_shape(context.actor.id.as_str()),
+            channel: optional_text_presence_shape(context.channel.as_deref()),
+            locale: context.locale.len(),
+            deadline_ms: context.deadline_ms,
+        }
+    }
+}
+
+struct AdminShippingOptionPortDiagnosticError<'a> {
+    code: &'a str,
+    retryable: bool,
+}
+
+impl std::fmt::Debug for AdminShippingOptionPortDiagnosticError<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("redacted")
+    }
+}
+
+struct AdminShippingDiagnosticError;
+
+impl std::fmt::Debug for AdminShippingDiagnosticError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("redacted")
+    }
+}
+
+fn uuid_shape(value: Uuid) -> &'static str {
+    if value.is_nil() { "nil" } else { "non_nil" }
+}
+
+fn optional_uuid_shape(value: Option<Uuid>) -> &'static str {
+    match value {
+        None => "absent",
+        Some(value) if value.is_nil() => "present_nil",
+        Some(_) => "present_non_nil",
+    }
+}
+
+fn text_presence_shape(value: &str) -> &'static str {
+    if value.is_empty() {
+        "empty"
+    } else {
+        "present_non_empty"
+    }
+}
+
+fn optional_text_presence_shape(value: Option<&str>) -> &'static str {
+    match value {
+        None => "absent",
+        Some("") => "present_empty",
+        Some(_) => "present_non_empty",
+    }
+}
+
 fn map_shipping_profile_error(error: CommerceError) -> HttpError {
     let (status, code, message, error_kind) = match &error {
         CommerceError::ShippingProfileNotFound(_) => (
@@ -91,6 +174,7 @@ fn map_shipping_profile_error(error: CommerceError) -> HttpError {
             "unexpected_commerce_error",
         ),
     };
+    let error = AdminShippingDiagnosticError;
     tracing::error!(
         error = ?error,
         owner = "rustok_commerce.shipping_profile",
@@ -133,6 +217,8 @@ fn map_admin_shipping_option_error(
             "database",
         ),
     };
+    let context = AdminShippingOptionDiagnosticContext::from(&context);
+    let error = AdminShippingDiagnosticError;
     tracing::error!(
         error = ?error,
         owner = ADMIN_SHIPPING_OPTION_OWNER,
@@ -212,6 +298,12 @@ fn map_admin_shipping_option_port_error(
             "Fulfillment operation could not be completed safely",
             "invariant_violation",
         ),
+    };
+    let context = AdminShippingOptionDiagnosticContext::from(&context);
+    let port_context = AdminShippingOptionPortDiagnosticContext::from(port_context);
+    let error = AdminShippingOptionPortDiagnosticError {
+        code: error.code.as_str(),
+        retryable: error.retryable,
     };
     tracing::error!(
         error = ?error,

--- a/scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs
@@ -11,10 +11,6 @@ const root = configuredRoot
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
 
 const shipping = read('crates/rustok-commerce/src/controllers/admin/shipping.rs');
-const commerceErrors = read('crates/rustok-commerce-foundation/src/error.rs');
-const fulfillmentErrors = read('crates/rustok-fulfillment/src/error.rs');
-const apiPorts = read('crates/rustok-api/src/ports.rs');
-const shippingService = read('crates/rustok-commerce/src/services/shipping_profile.rs');
 const failures = [];
 
 const requireText = (content, value, label) => {
@@ -32,6 +28,13 @@ const between = (content, start, end, label) => {
   }
   return content.slice(startIndex, endIndex);
 };
+const requireBefore = (content, first, second, label) => {
+  const firstIndex = content.indexOf(first);
+  const secondIndex = content.indexOf(second);
+  if (firstIndex < 0 || secondIndex < 0 || firstIndex > secondIndex) {
+    failures.push(`${label}: ${first} must precede ${second}`);
+  }
+};
 
 const profileMapper = between(
   shipping,
@@ -45,65 +48,18 @@ const mutationMapper = between(
   'fn admin_shipping_option_read_port_context(',
   'shipping-option mutation mapper',
 );
-const readContext = between(
-  shipping,
-  'fn admin_shipping_option_read_port_context(',
-  'fn map_admin_shipping_option_port_error(',
-  'shipping-option read context',
-);
 const readMapper = between(
   shipping,
   'fn map_admin_shipping_option_port_error(',
   'async fn validate_shipping_option_profile_inputs(',
   'shipping-option read mapper',
 );
-const listRoute = between(
+const validationHelper = between(
   shipping,
-  'pub async fn list_shipping_options(',
-  '/// Create admin shipping option',
-  'shipping-option list route',
+  'async fn validate_shipping_option_profile_inputs(',
+  '/// List admin shipping profiles',
+  'shipping-profile validation helper',
 );
-const createRoute = between(
-  shipping,
-  'pub async fn create_shipping_option(',
-  '/// Show admin shipping option',
-  'shipping-option create route',
-);
-const showRoute = between(
-  shipping,
-  'pub async fn show_shipping_option(',
-  '/// Update admin shipping option',
-  'shipping-option show route',
-);
-const updateRoute = between(
-  shipping,
-  'pub async fn update_shipping_option(',
-  '/// Deactivate admin shipping option',
-  'shipping-option update route',
-);
-const deactivateRoute = between(
-  shipping,
-  'pub async fn deactivate_shipping_option(',
-  '/// Reactivate admin shipping option',
-  'shipping-option deactivate route',
-);
-const reactivateStart = shipping.indexOf('pub async fn reactivate_shipping_option(');
-const reactivateRoute = reactivateStart < 0 ? '' : shipping.slice(reactivateStart);
-if (reactivateStart < 0) failures.push('shipping-option reactivate route: unable to isolate source block');
-
-for (const [value, label] of [
-  ['CommerceError, ShippingProfileService', 'typed commerce error import'],
-  ['use rustok_fulfillment::error::FulfillmentError;', 'typed mutation error import'],
-  ['PortActor, PortContext, PortError, PortErrorKind, RequestContext', 'typed read error imports'],
-  ['ListAllShippingOptionProjectionsRequest', 'typed admin list request'],
-  ['ReadShippingOptionProjectionRequest', 'typed admin lookup request'],
-  ['fn map_shipping_profile_error(error: CommerceError)', 'profile mapper'],
-  ['fn map_admin_shipping_option_error(', 'mutation mapper'],
-  ['fn admin_shipping_option_read_port_context(', 'read context builder'],
-  ['fn map_admin_shipping_option_port_error(', 'read port mapper'],
-  ['async fn validate_shipping_option_profile_inputs(', 'profile validation helper'],
-  ['const ADMIN_SHIPPING_BOUNDARY: &str = "commerce_admin_shipping_http";', 'HTTP boundary'],
-]) requireText(shipping, value, label);
 
 for (const [value, label] of [
   ['CommerceError::ShippingProfileNotFound(_)', 'profile not-found mapping'],
@@ -119,8 +75,24 @@ for (const [value, label] of [
   ['"commerce_admin_shipping_profile_invalid"', 'profile invalid code'],
   ['"commerce_admin_shipping_profile_storage_unavailable"', 'profile storage code'],
   ['"commerce_admin_shipping_profile_failed"', 'profile fail-closed code'],
+  ['let error = AdminShippingDiagnosticError;', 'profile diagnostic shadow'],
+  ['error = ?error', 'profile redacted error event'],
+  ['owner = "rustok_commerce.shipping_profile"', 'profile owner event'],
+  ['boundary = ADMIN_SHIPPING_BOUNDARY', 'profile boundary event'],
   ['HttpError::new(status, code, message)', 'profile static envelope'],
 ]) requireText(profileMapper, value, label);
+requireBefore(
+  profileMapper,
+  'CommerceError::ShippingProfileNotFound(_)',
+  'let error = AdminShippingDiagnosticError;',
+  'profile typed policy selection',
+);
+requireBefore(
+  profileMapper,
+  'let error = AdminShippingDiagnosticError;',
+  'tracing::error!(',
+  'profile diagnostic shadow',
+);
 
 for (const [value, label] of [
   ['FulfillmentError::Validation(_)', 'mutation validation mapping'],
@@ -132,16 +104,10 @@ for (const [value, label] of [
   ['"commerce_admin_not_found"', 'mutation not-found code'],
   ['"commerce_admin_fulfillment_state_conflict"', 'mutation conflict code'],
   ['"commerce_admin_fulfillment_storage_unavailable"', 'mutation unavailable code'],
+  ['let context = AdminShippingOptionDiagnosticContext::from(&context);', 'mutation context projection'],
+  ['let error = AdminShippingDiagnosticError;', 'mutation diagnostic shadow'],
   ['HttpError::new(status, code, message)', 'mutation static envelope'],
 ]) requireText(mutationMapper, value, label);
-
-for (const [value, label] of [
-  ['PortActor::user(auth.user_id.to_string())', 'read user actor'],
-  ['request_context.locale.as_str()', 'read locale'],
-  ['format!("commerce-admin-shipping-option:{operation}:{resource_id}")', 'read correlation id'],
-  ['with_deadline(std::time::Duration::from_secs(2))', 'read deadline'],
-  ['request_context.channel_slug.as_deref()', 'read channel'],
-]) requireText(readContext, value, label);
 
 for (const [value, label] of [
   ['PortErrorKind::Validation', 'read validation kind'],
@@ -150,85 +116,72 @@ for (const [value, label] of [
   ['PortErrorKind::Forbidden', 'read forbidden kind'],
   ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'read unavailable kinds'],
   ['PortErrorKind::InvariantViolation', 'read invariant kind'],
-  ['StatusCode::BAD_REQUEST', 'read validation status'],
-  ['StatusCode::NOT_FOUND', 'read not-found status'],
-  ['StatusCode::CONFLICT', 'read conflict status'],
   ['StatusCode::UNAUTHORIZED', 'read forbidden status'],
-  ['StatusCode::SERVICE_UNAVAILABLE', 'read unavailable status'],
   ['StatusCode::INTERNAL_SERVER_ERROR', 'read invariant status'],
-  ['"commerce_admin_fulfillment_invalid"', 'read validation code'],
-  ['"commerce_admin_not_found"', 'read not-found code'],
-  ['"commerce_admin_fulfillment_state_conflict"', 'read conflict code'],
   ['"commerce_permission_denied"', 'read forbidden code'],
-  ['"commerce_admin_fulfillment_storage_unavailable"', 'read unavailable code'],
   ['"commerce_admin_fulfillment_failed"', 'read invariant code'],
-  ['error = ?error', 'typed owner cause'],
-  ['correlation_id = %port_context.correlation_id', 'correlation log'],
-  ['internal_code = %error.code', 'owner code log'],
-  ['retryable = error.retryable', 'retryability log'],
+  ['let context = AdminShippingOptionDiagnosticContext::from(&context);', 'read route context projection'],
+  ['let port_context = AdminShippingOptionPortDiagnosticContext::from(port_context);', 'read port context projection'],
+  ['let error = AdminShippingOptionPortDiagnosticError {', 'read diagnostic error shadow'],
+  ['internal_code = %error.code', 'read stable owner code'],
+  ['retryable = error.retryable', 'read retryability'],
   ['HttpError::new(status, code, message)', 'read static envelope'],
 ]) requireText(readMapper, value, label);
 
-for (const [block, getter, operation, request, label] of [
-  [
-    listRoute,
-    '.shipping_option_admin_read_port()',
-    '.list_all_shipping_option_projections(',
-    'ListAllShippingOptionProjectionsRequest {',
-    'list route',
-  ],
-  [
-    showRoute,
-    '.shipping_option_read_port()',
-    '.read_shipping_option_projection(',
-    'ReadShippingOptionProjectionRequest {',
-    'show route',
-  ],
-]) {
-  requireText(block, getter, `${label} host runtime getter`);
-  requireText(block, operation, `${label} owner operation`);
-  requireText(block, request, `${label} typed request`);
-  requireText(block, 'map_admin_shipping_option_port_error(', `${label} port mapper`);
-  requireText(block, 'requested_locale: Some(request_context.locale.clone())', `${label} locale forwarding`);
-  requireText(block, 'tenant_default_locale: Some(tenant.default_locale.clone())', `${label} fallback forwarding`);
-  forbidText(block, 'FulfillmentService::new(', `${label} concrete read service`);
-}
+for (const [value, label] of [
+  ['ShippingProfileService::new(db.clone())', 'profile validation service'],
+  ['.ensure_shipping_profile_slugs_exist(tenant_id, slugs.iter())', 'profile validation operation'],
+  ['.map_err(map_shipping_profile_error)?;', 'profile validation mapper'],
+]) requireText(validationHelper, value, label);
 
-for (const [block, operation, label] of [
-  [createRoute, '.create_shipping_option(tenant.id, input)', 'create route'],
-  [updateRoute, '.update_shipping_option(tenant.id, id, input)', 'update route'],
-  [deactivateRoute, '.deactivate_shipping_option(tenant.id, id)', 'deactivate route'],
-  [reactivateRoute, '.reactivate_shipping_option(tenant.id, id)', 'reactivate route'],
+for (const route of [
+  'list_shipping_profiles',
+  'create_shipping_profile',
+  'show_shipping_profile',
+  'update_shipping_profile',
+  'deactivate_shipping_profile',
+  'reactivate_shipping_profile',
+  'list_shipping_options',
+  'create_shipping_option',
+  'show_shipping_option',
+  'update_shipping_option',
+  'deactivate_shipping_option',
+  'reactivate_shipping_option',
 ]) {
-  requireText(block, 'FulfillmentService::new(runtime.db_clone())', `${label} concrete mutation service`);
-  requireText(block, operation, `${label} mutation operation`);
-  requireText(block, 'map_admin_shipping_option_error(', `${label} mutation mapper`);
+  requireText(shipping, `pub async fn ${route}(`, `${route} route`);
 }
 
 for (const [value, label] of [
+  ['[Permission::FULFILLMENTS_READ]', 'read permission'],
+  ['[Permission::FULFILLMENTS_CREATE]', 'create permission'],
+  ['[Permission::FULFILLMENTS_UPDATE]', 'update permission'],
+  ['.shipping_option_admin_read_port()', 'admin list read port'],
+  ['.list_all_shipping_option_projections(', 'admin list read operation'],
+  ['.shipping_option_read_port()', 'detail read port'],
+  ['.read_shipping_option_projection(', 'detail read operation'],
+  ['FulfillmentService::new(runtime.db_clone())', 'shipping-option mutation owner'],
+  ['.create_shipping_option(tenant.id, input)', 'create option operation'],
+  ['.update_shipping_option(tenant.id, id, input)', 'update option operation'],
+  ['.deactivate_shipping_option(tenant.id, id)', 'deactivate option operation'],
+  ['.reactivate_shipping_option(tenant.id, id)', 'reactivate option operation'],
+  ['ShippingProfileService::new(runtime.db_clone())', 'shipping-profile owner'],
+  ['.list_shipping_profiles(', 'list profile operation'],
+  ['.create_shipping_profile(tenant.id, input)', 'create profile operation'],
+  ['.get_shipping_profile(', 'show profile operation'],
+  ['.update_shipping_profile(tenant.id, id, input)', 'update profile operation'],
+  ['.deactivate_shipping_profile(tenant.id, id)', 'deactivate profile operation'],
+  ['.reactivate_shipping_profile(tenant.id, id)', 'reactivate profile operation'],
   ['items.retain(|option| option.active == active)', 'active filter'],
   ['option.currency_code.eq_ignore_ascii_case(currency_code)', 'currency filter'],
   ['option.provider_id.eq_ignore_ascii_case(provider_id)', 'provider filter'],
   ['option.name.to_ascii_lowercase().contains(&search)', 'search filter'],
   ['skip(pagination.offset() as usize)', 'pagination offset'],
   ['take(pagination.limit() as usize)', 'pagination limit'],
-  ['validate_shipping_option_profile_inputs(', 'profile validation helper'],
+  ['validate_shipping_option_profile_inputs(', 'profile validation helper use'],
 ]) requireText(shipping, value, label);
 
-for (const [content, value, label] of [
-  [commerceErrors, 'Database(#[from] sea_orm::DbErr)', 'commerce database variant'],
-  [commerceErrors, 'Validation(String)', 'commerce validation variant'],
-  [fulfillmentErrors, 'Validation(String)', 'fulfillment validation variant'],
-  [fulfillmentErrors, 'ShippingOptionNotFound(Uuid)', 'fulfillment shipping-option variant'],
-  [fulfillmentErrors, 'FulfillmentNotFound(Uuid)', 'fulfillment resource variant'],
-  [fulfillmentErrors, 'InvalidTransition { from: String, to: String }', 'fulfillment transition variant'],
-  [fulfillmentErrors, 'Database(#[from] DbErr)', 'fulfillment database variant'],
-  [apiPorts, 'pub enum PortErrorKind {', 'port kind enum'],
-  [apiPorts, 'InvariantViolation,', 'invariant port kind'],
-  [shippingService, 'CommerceError::Validation(error.to_string())', 'profile validation construction'],
-]) requireText(content, value, label);
-
 for (const value of [
+  'error.to_string()',
   'err.to_string()',
   'other.to_string()',
   'error.message',
@@ -237,6 +190,10 @@ for (const value of [
   '.map_err(super::map_fulfillment_error)?;',
 ]) forbidText(shipping, value, 'unsafe admin shipping public conversion');
 
+const profileMapperUses = shipping.match(/map_shipping_profile_error/g) ?? [];
+if (profileMapperUses.length !== 8) {
+  failures.push(`expected profile mapper definition plus seven uses, found ${profileMapperUses.length}`);
+}
 const mutationMapperUses = shipping.match(/map_admin_shipping_option_error\(/g) ?? [];
 if (mutationMapperUses.length !== 5) {
   failures.push(`expected mutation mapper definition plus four uses, found ${mutationMapperUses.length}`);
@@ -245,9 +202,17 @@ const readMapperUses = shipping.match(/map_admin_shipping_option_port_error\(/g)
 if (readMapperUses.length !== 3) {
   failures.push(`expected read mapper definition plus two uses, found ${readMapperUses.length}`);
 }
-const localValidationUses = shipping.match(/validate_shipping_option_profile_inputs\(/g) ?? [];
-if (localValidationUses.length !== 3) {
-  failures.push(`expected validation helper definition plus two uses, found ${localValidationUses.length}`);
+const validationUses = shipping.match(/validate_shipping_option_profile_inputs\(/g) ?? [];
+if (validationUses.length !== 3) {
+  failures.push(`expected validation helper definition plus two uses, found ${validationUses.length}`);
+}
+const redactedDebugUses = shipping.match(/formatter\.write_str\("redacted"\)/g) ?? [];
+if (redactedDebugUses.length !== 2) {
+  failures.push(`expected two redacted diagnostic Debug implementations, found ${redactedDebugUses.length}`);
+}
+const traceUses = shipping.match(/tracing::error!\(/g) ?? [];
+if (traceUses.length !== 3) {
+  failures.push(`expected three bounded shipping error events, found ${traceUses.length}`);
 }
 
 if (failures.length > 0) {
@@ -257,5 +222,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce admin shipping reads use host-composed owner ports and stable HTTP envelopes while mutations retain lifecycle services',
+  '✔ Commerce admin shipping profiles and options preserve HTTP policy while emitting only bounded diagnostics',
 );

--- a/scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs
+++ b/scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs
@@ -11,8 +11,6 @@ const root = configuredRoot
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
 
 const shipping = read('crates/rustok-commerce/src/controllers/admin/shipping.rs');
-const apiPorts = read('crates/rustok-api/src/ports.rs');
-const fulfillmentErrors = read('crates/rustok-fulfillment/src/error.rs');
 const failures = [];
 
 const requireText = (content, value, label) => {
@@ -30,8 +28,21 @@ const between = (content, start, end, label) => {
   }
   return content.slice(startIndex, endIndex);
 };
+const requireBefore = (content, first, second, label) => {
+  const firstIndex = content.indexOf(first);
+  const secondIndex = content.indexOf(second);
+  if (firstIndex < 0 || secondIndex < 0 || firstIndex > secondIndex) {
+    failures.push(`${label}: ${first} must precede ${second}`);
+  }
+};
 
-const legacyMapper = between(
+const diagnosticProjection = between(
+  shipping,
+  'struct AdminShippingOptionDiagnosticContext {',
+  'fn map_shipping_profile_error(',
+  'admin shipping diagnostic projection',
+);
+const mutationMapper = between(
   shipping,
   'fn map_admin_shipping_option_error(',
   'fn admin_shipping_option_read_port_context(',
@@ -81,26 +92,44 @@ const deactivateRoute = between(
 );
 const reactivateStart = shipping.indexOf('pub async fn reactivate_shipping_option(');
 const reactivateRoute = reactivateStart < 0 ? '' : shipping.slice(reactivateStart);
-if (reactivateStart < 0) failures.push('reactivate shipping option route: unable to isolate source block');
+if (reactivateStart < 0) {
+  failures.push('reactivate shipping option route: unable to isolate source block');
+}
 
 for (const [value, label] of [
-  ['PortActor, PortContext, PortError, PortErrorKind, RequestContext', 'typed port imports'],
-  ['use rustok_fulfillment::error::FulfillmentError;', 'typed mutation error import'],
-  ['ListAllShippingOptionProjectionsRequest', 'admin list request'],
-  ['ReadShippingOptionProjectionRequest', 'admin lookup request'],
-  [
-    'const ADMIN_SHIPPING_OPTION_OWNER: &str = "rustok_fulfillment.admin_shipping_options";',
-    'owner constant',
-  ],
-  [
-    'const ADMIN_SHIPPING_BOUNDARY: &str = "commerce_admin_shipping_http";',
-    'boundary constant',
-  ],
-  ['struct AdminShippingOptionErrorContext {', 'error context'],
-  ['tenant_id: Uuid,', 'tenant field'],
-  ['shipping_option_id: Option<Uuid>,', 'option identity field'],
-  ["operation: &'static str,", 'operation field'],
+  ['struct AdminShippingOptionErrorContext {', 'typed error context'],
+  ['tenant_id: Uuid,', 'typed tenant identity'],
+  ['shipping_option_id: Option<Uuid>,', 'typed option identity'],
+  ["operation: &'static str,", 'typed operation'],
+  ['struct AdminShippingOptionDiagnosticContext {', 'bounded route diagnostic context'],
+  ['struct AdminShippingOptionPortDiagnosticContext {', 'bounded port diagnostic context'],
+  ['struct AdminShippingOptionPortDiagnosticError', 'bounded port diagnostic error'],
+  ['struct AdminShippingDiagnosticError;', 'bounded owner diagnostic error'],
+  ['formatter.write_str("redacted")', 'redacted Debug output'],
+  ["fn uuid_shape(value: Uuid) -> &'static str", 'required UUID shape helper'],
+  ["fn optional_uuid_shape(value: Option<Uuid>) -> &'static str", 'optional UUID shape helper'],
+  ["fn text_presence_shape(value: &str) -> &'static str", 'text presence helper'],
+  ["fn optional_text_presence_shape(value: Option<&str>) -> &'static str", 'optional text presence helper'],
+  ['"nil"', 'nil UUID shape'],
+  ['"non_nil"', 'non-nil UUID shape'],
+  ['"absent"', 'absent optional shape'],
+  ['"present_nil"', 'present nil optional shape'],
+  ['"present_non_nil"', 'present non-nil optional shape'],
+  ['"empty"', 'empty text shape'],
+  ['"present_empty"', 'present empty text shape'],
+  ['"present_non_empty"', 'present non-empty text shape'],
 ]) requireText(shipping, value, label);
+
+for (const [value, label] of [
+  ['tenant_id: uuid_shape(context.tenant_id)', 'tenant projection'],
+  ['shipping_option_id: optional_uuid_shape(context.shipping_option_id)', 'option projection'],
+  ['operation: context.operation', 'operation projection'],
+  ['correlation_id: text_presence_shape(context.correlation_id.as_str())', 'correlation projection'],
+  ['actor: text_presence_shape(context.actor.id.as_str())', 'actor projection'],
+  ['channel: optional_text_presence_shape(context.channel.as_deref())', 'channel projection'],
+  ['locale: context.locale.len()', 'locale projection'],
+  ['deadline_ms: context.deadline_ms', 'deadline projection'],
+]) requireText(diagnosticProjection, value, label);
 
 for (const [value, label] of [
   ['PortActor::user(auth.user_id.to_string())', 'authenticated actor'],
@@ -111,36 +140,64 @@ for (const [value, label] of [
 ]) requireText(readContextBuilder, value, label);
 
 for (const [value, label] of [
-  ['error: PortError,', 'owned typed port cause'],
-  ['PortErrorKind::Validation', 'validation kind'],
-  ['PortErrorKind::NotFound', 'not-found kind'],
-  ['PortErrorKind::Conflict', 'conflict kind'],
-  ['PortErrorKind::Forbidden', 'forbidden kind'],
-  ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'unavailable kinds'],
-  ['PortErrorKind::InvariantViolation', 'invariant kind'],
-  ['StatusCode::BAD_REQUEST', 'bad-request status'],
-  ['StatusCode::NOT_FOUND', 'not-found status'],
-  ['StatusCode::CONFLICT', 'conflict status'],
-  ['StatusCode::UNAUTHORIZED', 'forbidden status'],
-  ['StatusCode::SERVICE_UNAVAILABLE', 'unavailable status'],
-  ['StatusCode::INTERNAL_SERVER_ERROR', 'invariant status'],
-  ['"commerce_admin_fulfillment_invalid"', 'validation code'],
-  ['"commerce_admin_not_found"', 'not-found code'],
-  ['"commerce_admin_fulfillment_state_conflict"', 'conflict code'],
-  ['"commerce_permission_denied"', 'forbidden code'],
-  ['"commerce_admin_fulfillment_storage_unavailable"', 'storage code'],
-  ['"commerce_admin_fulfillment_failed"', 'fail-closed code'],
-  ['error = ?error', 'typed internal cause'],
-  ['owner_operation,', 'owner operation log'],
-  ['correlation_id = %port_context.correlation_id', 'correlation log'],
-  ['actor = ?port_context.actor', 'actor log'],
-  ['channel = ?port_context.channel', 'channel log'],
-  ['locale = %port_context.locale', 'locale log'],
-  ['deadline_ms = ?port_context.deadline_ms', 'deadline log'],
-  ['internal_code = %error.code', 'owner code log'],
-  ['retryable = error.retryable', 'retryability log'],
-  ['HttpError::new(status, code, message)', 'static public envelope'],
+  ['FulfillmentError::Validation(_)', 'mutation validation variant'],
+  ['FulfillmentError::ShippingOptionNotFound(_)', 'mutation option not-found variant'],
+  ['FulfillmentError::FulfillmentNotFound(_)', 'mutation fulfillment not-found variant'],
+  ['FulfillmentError::InvalidTransition { .. }', 'mutation conflict variant'],
+  ['FulfillmentError::Database(_)', 'mutation database variant'],
+  ['let context = AdminShippingOptionDiagnosticContext::from(&context);', 'mutation context shadow'],
+  ['let error = AdminShippingDiagnosticError;', 'mutation error shadow'],
+  ['error = ?error', 'redacted mutation error event'],
+  ['tenant_id = %context.tenant_id', 'bounded mutation tenant event'],
+  ['shipping_option_id = ?context.shipping_option_id', 'bounded mutation option event'],
+  ['HttpError::new(status, code, message)', 'mutation static envelope'],
+]) requireText(mutationMapper, value, label);
+requireBefore(
+  mutationMapper,
+  'FulfillmentError::Validation(_)',
+  'let context = AdminShippingOptionDiagnosticContext::from(&context);',
+  'mutation typed policy selection',
+);
+requireBefore(
+  mutationMapper,
+  'let error = AdminShippingDiagnosticError;',
+  'tracing::error!(',
+  'mutation diagnostic shadow',
+);
+
+for (const [value, label] of [
+  ['PortErrorKind::Validation', 'port validation kind'],
+  ['PortErrorKind::NotFound', 'port not-found kind'],
+  ['PortErrorKind::Conflict', 'port conflict kind'],
+  ['PortErrorKind::Forbidden', 'port forbidden kind'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'port unavailable kinds'],
+  ['PortErrorKind::InvariantViolation', 'port invariant kind'],
+  ['let context = AdminShippingOptionDiagnosticContext::from(&context);', 'port route context shadow'],
+  ['let port_context = AdminShippingOptionPortDiagnosticContext::from(port_context);', 'port metadata shadow'],
+  ['let error = AdminShippingOptionPortDiagnosticError {', 'port error shadow'],
+  ['code: error.code.as_str()', 'stable internal code capture'],
+  ['retryable: error.retryable', 'retryability capture'],
+  ['correlation_id = %port_context.correlation_id', 'bounded correlation event'],
+  ['actor = ?port_context.actor', 'bounded actor event'],
+  ['channel = ?port_context.channel', 'bounded channel event'],
+  ['locale = %port_context.locale', 'bounded locale event'],
+  ['deadline_ms = ?port_context.deadline_ms', 'deadline event'],
+  ['internal_code = %error.code', 'stable code event'],
+  ['retryable = error.retryable', 'retryability event'],
+  ['HttpError::new(status, code, message)', 'port static envelope'],
 ]) requireText(portMapper, value, label);
+requireBefore(
+  portMapper,
+  'PortErrorKind::Validation',
+  'let context = AdminShippingOptionDiagnosticContext::from(&context);',
+  'port typed policy selection',
+);
+requireBefore(
+  portMapper,
+  'let error = AdminShippingOptionPortDiagnosticError {',
+  'tracing::error!(',
+  'port diagnostic shadow',
+);
 
 for (const [block, operation, request, label] of [
   [
@@ -173,22 +230,8 @@ for (const [block, operation, label] of [
 ]) {
   requireText(block, 'FulfillmentService::new(runtime.db_clone())', `${label} lifecycle service`);
   requireText(block, operation, `${label} service operation`);
-  requireText(block, 'map_admin_shipping_option_error(', `${label} legacy typed mapper`);
+  requireText(block, 'map_admin_shipping_option_error(', `${label} typed mapper`);
 }
-
-for (const [value, label] of [
-  ['FulfillmentError::Validation(_)', 'mutation validation variant'],
-  ['FulfillmentError::ShippingOptionNotFound(_)', 'mutation not-found variant'],
-  ['FulfillmentError::FulfillmentNotFound(_)', 'mutation fulfillment variant'],
-  ['FulfillmentError::InvalidTransition { .. }', 'mutation conflict variant'],
-  ['FulfillmentError::Database(_)', 'mutation database variant'],
-]) requireText(legacyMapper, value, label);
-
-for (const [content, value, label] of [
-  [apiPorts, 'pub enum PortErrorKind {', 'owner port error kinds'],
-  [apiPorts, 'InvariantViolation,', 'owner invariant kind'],
-  [fulfillmentErrors, 'ShippingOptionNotFound(Uuid)', 'owner shipping-option variant'],
-]) requireText(content, value, label);
 
 for (const value of [
   'error.to_string()',
@@ -199,9 +242,9 @@ for (const value of [
   '.map_err(super::map_fulfillment_error)?;',
 ]) forbidText(shipping, value, 'unsafe admin shipping-option public conversion');
 
-const legacyMapperUses = shipping.match(/map_admin_shipping_option_error\(/g) ?? [];
-if (legacyMapperUses.length !== 5) {
-  failures.push(`expected mutation mapper definition plus four uses, found ${legacyMapperUses.length}`);
+const mutationMapperUses = shipping.match(/map_admin_shipping_option_error\(/g) ?? [];
+if (mutationMapperUses.length !== 5) {
+  failures.push(`expected mutation mapper definition plus four uses, found ${mutationMapperUses.length}`);
 }
 const portMapperUses = shipping.match(/map_admin_shipping_option_port_error\(/g) ?? [];
 if (portMapperUses.length !== 3) {
@@ -215,5 +258,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce admin shipping-option reads use typed owner-port context while mutations retain typed lifecycle envelopes',
+  '✔ Commerce admin shipping-option reads and mutations retain typed policy while emitting only bounded diagnostics',
 );


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce correlation-safe mapper cleanup across the complete Commerce Admin Shipping HTTP boundary.

- retain typed `CommerceError`, `FulfillmentError`, `PortError`, `PortContext`, and route context through HTTP policy selection;
- shadow typed errors before the three failure events with diagnostic types whose `Debug` output is always `redacted`;
- replace tenant and shipping-option UUID payloads with closed shape labels;
- replace correlation, actor, and channel values with closed presence labels and locale content with its length;
- preserve deadline, stable internal code, retryability, owner operation, route operation, error kind, public code, HTTP status, owner, boundary, and static event messages where previously available;
- preserve all twelve shipping-profile and shipping-option routes, permissions, filters, pagination, locale fallback, profile-slug validation, owner calls, and response envelopes;
- update both existing focused shipping verifiers;
- add source-only evidence and documentation while leaving the broad ecommerce cleanup open.

## Recheck

Current `main` includes the Admin Product, Fulfillment, and Payment diagnostic slices. The separate Admin Shipping file still emitted complete `CommerceError`, `FulfillmentError`, and `PortError` values; shipping-option events additionally emitted raw tenant/option UUIDs and raw correlation, actor, channel, and locale values. No open PR overlaps this boundary.

The branch started from `main@53aeddfbf05ceccea27f6c2f639af904c3ace6b2`. Current `main` later advanced by the Pages/storefront-only #3032 commit; that change does not overlap any Commerce file in this PR. The PR changes five intended files.

## Preserved behavior

- exhaustive shipping-profile `CommerceError` HTTP policy;
- exhaustive shipping-option mutation and owner-port read policies;
- `HttpError::new(status, code, message)` construction;
- `FULFILLMENTS_READ`, `FULFILLMENTS_CREATE`, and `FULFILLMENTS_UPDATE` authorization;
- profile slug validation before option create/update;
- host-composed option list/detail reads and direct lifecycle mutation calls;
- profile list/create/show/update/deactivate/reactivate operations;
- active, currency, provider, search, pagination, requested-locale, and tenant-default-locale behavior;
- all successful response DTOs.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Node verifiers;
- Cargo checks, builds, clippy, or formatting;
- mounted HTTP execution;
- workflows or CI.

Execution evidence remains pending and the broad ecommerce cleanup remains open.