### PR TITLE
fix(commerce): bound return completion operator envelopes

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/return-completion-operator-envelope-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/return-completion-operator-envelope-safety-source-review.json
@@ -1,0 +1,44 @@
+{
+  "status": "return_completion_operator_envelope_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-commerce/src/controllers/return_completion_operations.rs",
+    "scripts/verify/verify-commerce-return-completion-envelope-safety.mjs",
+    "crates/rustok-commerce/docs/return-completion-operator-envelope-safety.md",
+    "crates/rustok-commerce/docs/implementation-plan.md"
+  ],
+  "source_contract": {
+    "raw_conflict_validation_message_public": false,
+    "static_conflict_envelope": true,
+    "typed_operator_policy_selection_precedes_shadowing": true,
+    "specialized_error_debug_redacted": true,
+    "raw_tenant_uuid_logged_by_specialized_mapper": false,
+    "raw_actor_uuid_logged_by_specialized_mapper": false,
+    "raw_operation_uuid_logged_by_specialized_mapper": false,
+    "required_uuid_shapes_logged": true,
+    "optional_uuid_shapes_logged": true,
+    "not_found_policy_preserved": true,
+    "conflict_status_and_code_preserved": true,
+    "storage_unavailable_policy_preserved": true,
+    "shared_fallback_preserved": true,
+    "three_route_callsites_preserved": true,
+    "permissions_preserved": true,
+    "owner_calls_preserved": true,
+    "provider_registry_composition_preserved": true,
+    "pagination_and_success_envelopes_preserved": true,
+    "string_classification_removed": false,
+    "broad_ecommerce_cleanup_closed": false,
+    "runtime_evidence_claimed": false
+  },
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed."
+}

--- a/crates/rustok-commerce/docs/return-completion-operator-envelope-safety.md
+++ b/crates/rustok-commerce/docs/return-completion-operator-envelope-safety.md
@@ -1,0 +1,58 @@
+# Return completion operator envelope safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens the Admin Return Completion operator boundary used by:
+
+- operation list;
+- operation detail;
+- explicit retry.
+
+The previous conflict branch classified lease, reconciliation, terminal, replay, command-binding, and command-hash validation text, then returned that internal text directly in the public `409` envelope.
+
+## Bounded public envelope
+
+The operator still evaluates the existing typed `PostOrderOrchestrationError` before projection. The specialized policies remain:
+
+- missing operation: `404` / `return_completion_operation_not_found`;
+- leased, reconciliation, terminal, replay, or command conflict: `409` / `return_completion_operation_conflict`;
+- order recovery database/core failure: `503` / `return_completion_storage_unavailable`.
+
+The conflict message is now static: `Return completion operation conflicts with the current state`. Internal owner validation text is no longer returned to the client.
+
+## Bounded diagnostics
+
+Each route supplies typed tenant, actor, optional operation identity, and a static operation label. After specialized policy selection and before `tracing::error!`:
+
+- the error becomes a diagnostic type whose `Debug` output is always `redacted`;
+- tenant and actor UUIDs become `nil` / `non_nil` shapes;
+- optional operation UUID becomes `absent` / `present_nil` / `present_non_nil`;
+- owner, source owner, route operation, error kind, public code, HTTP status, boundary, and static event message remain observable.
+
+## Preserved behavior
+
+This work does not change:
+
+- the three mounted routes or their response DTOs;
+- `ORDERS_READ` authorization for list/detail;
+- combined `ORDERS_MANAGE` and `PAYMENTS_MANAGE` authorization for retry;
+- pagination, filtering, totals, and success envelopes;
+- `ReturnCompletionOrchestrationService` calls;
+- payment-provider registry composition;
+- existing internal string classifiers used to distinguish specialized operator states;
+- delegation of unmatched errors to the shared post-order mapper.
+
+## Remaining boundary
+
+The owner still represents these operator states through validation text, so replacing internal string classification with typed owner variants remains open. The shared fallback mapper and the broader ecommerce correlation-safe/non-`PortError` cleanup also remain open.
+
+## Evidence
+
+- `crates/rustok-commerce/contracts/evidence/return-completion-operator-envelope-safety-source-review.json`
+- `scripts/verify/verify-commerce-return-completion-envelope-safety.mjs`
+
+## Validation disclosure
+
+No tests, Node verifiers, formatting, Cargo commands, mounted HTTP scenarios, workflows, or CI were run. No compile, runtime, FFA, or FBA status is promoted.

--- a/crates/rustok-commerce/src/controllers/return_completion_operations.rs
+++ b/crates/rustok-commerce/src/controllers/return_completion_operations.rs
@@ -17,6 +17,78 @@ use crate::dto::OrderReturnResponse;
 use crate::services::{ListReturnCompletionOperationsInput, ReturnCompletionOperationResponse};
 use crate::{PostOrderOrchestrationError, ReturnCompletionOrchestrationService};
 
+const RETURN_COMPLETION_OPERATOR_OWNER: &str =
+    "rustok_commerce.return_completion_operation";
+const RETURN_COMPLETION_OPERATOR_BOUNDARY: &str =
+    "commerce_admin_return_completion_operation_http";
+
+type ReturnCompletionOperatorHttpPolicy =
+    (StatusCode, &'static str, &'static str, &'static str);
+
+#[derive(Clone, Copy)]
+struct ReturnCompletionOperatorErrorContext {
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    operation_id: Option<Uuid>,
+    operation: &'static str,
+}
+
+impl ReturnCompletionOperatorErrorContext {
+    fn new(
+        tenant_id: Uuid,
+        actor_id: Uuid,
+        operation_id: Option<Uuid>,
+        operation: &'static str,
+    ) -> Self {
+        Self {
+            tenant_id,
+            actor_id,
+            operation_id,
+            operation,
+        }
+    }
+}
+
+struct ReturnCompletionOperatorDiagnosticContext {
+    tenant_id: &'static str,
+    actor_id: &'static str,
+    operation_id: &'static str,
+    operation: &'static str,
+}
+
+impl From<&ReturnCompletionOperatorErrorContext>
+    for ReturnCompletionOperatorDiagnosticContext
+{
+    fn from(context: &ReturnCompletionOperatorErrorContext) -> Self {
+        Self {
+            tenant_id: uuid_shape(context.tenant_id),
+            actor_id: uuid_shape(context.actor_id),
+            operation_id: optional_uuid_shape(context.operation_id),
+            operation: context.operation,
+        }
+    }
+}
+
+struct ReturnCompletionOperatorDiagnosticError;
+
+impl std::fmt::Debug for ReturnCompletionOperatorDiagnosticError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("redacted")
+    }
+}
+
+fn uuid_shape(value: Uuid) -> &'static str {
+    if value.is_nil() { "nil" } else { "non_nil" }
+}
+
+fn optional_uuid_shape(value: Option<Uuid>) -> &'static str {
+    match value {
+        None => "absent",
+        Some(value) if value.is_nil() => "present_nil",
+        Some(_) => "present_non_nil",
+    }
+}
+
 #[derive(Clone, Debug, Default, Deserialize, ToSchema, IntoParams)]
 pub struct AdminListReturnCompletionOperationsParams {
     #[serde(flatten)]
@@ -71,7 +143,17 @@ pub async fn list_return_completion_operations(
                 },
             )
             .await
-            .map_err(map_operator_error)?;
+            .map_err(|error| {
+                map_operator_error(
+                    ReturnCompletionOperatorErrorContext::new(
+                        tenant.id,
+                        auth.user_id,
+                        None,
+                        "list_return_completion_operations",
+                    ),
+                    error,
+                )
+            })?;
 
     Ok(Json(PaginatedResponse {
         data: items,
@@ -106,7 +188,17 @@ pub async fn show_return_completion_operation(
             .with_payment_provider_registry(runtime.payment_provider_registry())
             .get_operation(tenant.id, id)
             .await
-            .map_err(map_operator_error)?;
+            .map_err(|error| {
+                map_operator_error(
+                    ReturnCompletionOperatorErrorContext::new(
+                        tenant.id,
+                        auth.user_id,
+                        Some(id),
+                        "show_return_completion_operation",
+                    ),
+                    error,
+                )
+            })?;
     Ok(Json(operation))
 }
 
@@ -139,17 +231,31 @@ pub async fn retry_return_completion_operation(
             .with_payment_provider_registry(runtime.payment_provider_registry())
             .retry_operation(tenant.id, auth.user_id, id)
             .await
-            .map_err(map_operator_error)?;
+            .map_err(|error| {
+                map_operator_error(
+                    ReturnCompletionOperatorErrorContext::new(
+                        tenant.id,
+                        auth.user_id,
+                        Some(id),
+                        "retry_return_completion_operation",
+                    ),
+                    error,
+                )
+            })?;
     Ok(Json(order_return))
 }
 
-fn map_operator_error(error: PostOrderOrchestrationError) -> HttpError {
+fn return_completion_operator_policy(
+    error: &PostOrderOrchestrationError,
+) -> Option<ReturnCompletionOperatorHttpPolicy> {
     match error {
         PostOrderOrchestrationError::Validation(message) if message.contains("was not found") => {
-            HttpError::not_found(
+            Some((
+                StatusCode::NOT_FOUND,
                 "return_completion_operation_not_found",
                 "Return completion operation not found",
-            )
+                "not_found",
+            ))
         }
         PostOrderOrchestrationError::Validation(message)
             if message.contains("currently leased")
@@ -160,19 +266,49 @@ fn map_operator_error(error: PostOrderOrchestrationError) -> HttpError {
                 || message.contains("already bound to another command")
                 || message.contains("command hash does not match") =>
         {
-            HttpError::new(
+            Some((
                 StatusCode::CONFLICT,
                 "return_completion_operation_conflict",
-                message,
-            )
+                "Return completion operation conflicts with the current state",
+                "conflict",
+            ))
         }
         PostOrderOrchestrationError::Order(
             rustok_order::error::OrderError::Database(_) | rustok_order::error::OrderError::Core(_),
-        ) => HttpError::new(
+        ) => Some((
             StatusCode::SERVICE_UNAVAILABLE,
             "return_completion_storage_unavailable",
             "Return completion recovery storage is unavailable",
-        ),
-        other => super::admin::map_post_order_orchestration_error(other),
+            "storage_unavailable",
+        )),
+        _ => None,
     }
+}
+
+fn map_operator_error(
+    context: ReturnCompletionOperatorErrorContext,
+    error: PostOrderOrchestrationError,
+) -> HttpError {
+    let Some((status, code, message, error_kind)) =
+        return_completion_operator_policy(&error)
+    else {
+        return super::admin::map_post_order_orchestration_error(error);
+    };
+    let context = ReturnCompletionOperatorDiagnosticContext::from(&context);
+    let error = ReturnCompletionOperatorDiagnosticError;
+    tracing::error!(
+        error = ?error,
+        owner = RETURN_COMPLETION_OPERATOR_OWNER,
+        source_owner = "rustok_commerce.post_order_orchestration",
+        tenant_id = %context.tenant_id,
+        actor_id = %context.actor_id,
+        operation_id = ?context.operation_id,
+        operation = %context.operation,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = RETURN_COMPLETION_OPERATOR_BOUNDARY,
+        "commerce admin return completion operation failed"
+    );
+    HttpError::new(status, code, message)
 }

--- a/scripts/verify/verify-commerce-return-completion-envelope-safety.mjs
+++ b/scripts/verify/verify-commerce-return-completion-envelope-safety.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const source = read(
+  'crates/rustok-commerce/src/controllers/return_completion_operations.rs',
+);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+const requireBefore = (content, first, second, label) => {
+  const firstIndex = content.indexOf(first);
+  const secondIndex = content.indexOf(second);
+  if (firstIndex < 0 || secondIndex < 0 || firstIndex > secondIndex) {
+    failures.push(`${label}: ${first} must precede ${second}`);
+  }
+};
+
+const listRoute = between(
+  source,
+  'pub async fn list_return_completion_operations(',
+  '#[utoipa::path(\n    get,\n    path = "/admin/return-completion-operations/{id}"',
+  'return completion list route',
+);
+const showRoute = between(
+  source,
+  'pub async fn show_return_completion_operation(',
+  '#[utoipa::path(\n    post,\n    path = "/admin/return-completion-operations/{id}/retry"',
+  'return completion show route',
+);
+const retryRoute = between(
+  source,
+  'pub async fn retry_return_completion_operation(',
+  'fn return_completion_operator_policy(',
+  'return completion retry route',
+);
+const policy = between(
+  source,
+  'fn return_completion_operator_policy(',
+  'fn map_operator_error(',
+  'return completion operator policy',
+);
+const mapperStart = source.indexOf('fn map_operator_error(');
+const mapper = mapperStart < 0 ? '' : source.slice(mapperStart);
+if (mapperStart < 0) failures.push('return completion mapper: unable to isolate source block');
+
+for (const [value, label] of [
+  [
+    'const RETURN_COMPLETION_OPERATOR_OWNER: &str =',
+    'bounded owner constant',
+  ],
+  [
+    'const RETURN_COMPLETION_OPERATOR_BOUNDARY: &str =',
+    'bounded boundary constant',
+  ],
+  ['struct ReturnCompletionOperatorErrorContext {', 'typed route context'],
+  ['tenant_id: Uuid,', 'typed tenant identity'],
+  ['actor_id: Uuid,', 'typed actor identity'],
+  ['operation_id: Option<Uuid>,', 'typed operation identity'],
+  ["operation: &'static str,", 'typed route operation'],
+  [
+    'struct ReturnCompletionOperatorDiagnosticContext {',
+    'bounded diagnostic context',
+  ],
+  [
+    'impl From<&ReturnCompletionOperatorErrorContext>',
+    'typed-to-diagnostic conversion',
+  ],
+  [
+    'struct ReturnCompletionOperatorDiagnosticError;',
+    'bounded diagnostic error',
+  ],
+  ['formatter.write_str("redacted")', 'redacted Debug output'],
+  ["fn uuid_shape(value: Uuid) -> &'static str", 'required UUID shape'],
+  [
+    "fn optional_uuid_shape(value: Option<Uuid>) -> &'static str",
+    'optional UUID shape',
+  ],
+  ['"nil"', 'nil UUID shape'],
+  ['"non_nil"', 'non-nil UUID shape'],
+  ['"absent"', 'absent optional UUID shape'],
+  ['"present_nil"', 'present nil optional UUID shape'],
+  ['"present_non_nil"', 'present non-nil optional UUID shape'],
+]) requireText(source, value, label);
+
+for (const [block, operationId, operation, ownerCall, permission, label] of [
+  [
+    listRoute,
+    'None,',
+    '"list_return_completion_operations"',
+    '.list_operations(',
+    'Permission::ORDERS_READ',
+    'list route',
+  ],
+  [
+    showRoute,
+    'Some(id),',
+    '"show_return_completion_operation"',
+    '.get_operation(tenant.id, id)',
+    'Permission::ORDERS_READ',
+    'show route',
+  ],
+  [
+    retryRoute,
+    'Some(id),',
+    '"retry_return_completion_operation"',
+    '.retry_operation(tenant.id, auth.user_id, id)',
+    'Permission::ORDERS_MANAGE, Permission::PAYMENTS_MANAGE',
+    'retry route',
+  ],
+]) {
+  requireText(block, 'ReturnCompletionOperatorErrorContext::new(', `${label} context`);
+  requireText(block, 'tenant.id,', `${label} tenant identity`);
+  requireText(block, 'auth.user_id,', `${label} actor identity`);
+  requireText(block, operationId, `${label} operation identity`);
+  requireText(block, operation, `${label} operation label`);
+  requireText(block, ownerCall, `${label} owner call`);
+  requireText(block, permission, `${label} permission`);
+  requireText(block, 'map_operator_error(', `${label} mapper`);
+  requireText(
+    block,
+    '.with_payment_provider_registry(runtime.payment_provider_registry())',
+    `${label} provider registry`,
+  );
+}
+
+for (const [value, label] of [
+  [
+    'PostOrderOrchestrationError::Validation(message) if message.contains("was not found")',
+    'not-found classifier',
+  ],
+  ['StatusCode::NOT_FOUND', 'not-found status'],
+  ['"return_completion_operation_not_found"', 'not-found code'],
+  ['"Return completion operation not found"', 'not-found message'],
+  ['message.contains("currently leased")', 'lease conflict classifier'],
+  ['message.contains("requires reconciliation")', 'reconciliation classifier'],
+  ['message.contains("terminally failed")', 'terminal failure classifier'],
+  ['message.contains("already completed")', 'completed classifier'],
+  ['message.contains("different completion command")', 'command classifier'],
+  [
+    'message.contains("already bound to another command")',
+    'bound command classifier',
+  ],
+  ['message.contains("command hash does not match")', 'hash classifier'],
+  ['StatusCode::CONFLICT', 'conflict status'],
+  ['"return_completion_operation_conflict"', 'conflict code'],
+  [
+    '"Return completion operation conflicts with the current state"',
+    'static conflict message',
+  ],
+  ['OrderError::Database(_) | rustok_order::error::OrderError::Core(_)', 'storage classifier'],
+  ['StatusCode::SERVICE_UNAVAILABLE', 'storage unavailable status'],
+  ['"return_completion_storage_unavailable"', 'storage unavailable code'],
+  [
+    '"Return completion recovery storage is unavailable"',
+    'storage unavailable message',
+  ],
+  ['_ => None', 'shared fallback admission'],
+]) requireText(policy, value, label);
+
+for (const [value, label] of [
+  [
+    'return_completion_operator_policy(&error)',
+    'typed route policy selection',
+  ],
+  [
+    'return super::admin::map_post_order_orchestration_error(error);',
+    'shared fallback',
+  ],
+  [
+    'let context = ReturnCompletionOperatorDiagnosticContext::from(&context);',
+    'diagnostic context shadow',
+  ],
+  [
+    'let error = ReturnCompletionOperatorDiagnosticError;',
+    'diagnostic error shadow',
+  ],
+  ['error = ?error', 'redacted diagnostic event'],
+  ['owner = RETURN_COMPLETION_OPERATOR_OWNER', 'owner event'],
+  [
+    'source_owner = "rustok_commerce.post_order_orchestration"',
+    'source owner event',
+  ],
+  ['tenant_id = %context.tenant_id', 'tenant shape event'],
+  ['actor_id = %context.actor_id', 'actor shape event'],
+  ['operation_id = ?context.operation_id', 'operation ID shape event'],
+  ['operation = %context.operation', 'route operation event'],
+  ['error_kind,', 'error kind event'],
+  ['public_code = code', 'public code event'],
+  ['status = %status', 'HTTP status event'],
+  ['boundary = RETURN_COMPLETION_OPERATOR_BOUNDARY', 'boundary event'],
+  ['HttpError::new(status, code, message)', 'static public envelope'],
+]) requireText(mapper, value, label);
+
+requireBefore(
+  mapper,
+  'return_completion_operator_policy(&error)',
+  'let error = ReturnCompletionOperatorDiagnosticError;',
+  'typed policy before diagnostic shadow',
+);
+requireBefore(
+  mapper,
+  'let error = ReturnCompletionOperatorDiagnosticError;',
+  'tracing::error!(',
+  'diagnostic shadow before event',
+);
+
+for (const value of [
+  'HttpError::new(\n                StatusCode::CONFLICT,\n                "return_completion_operation_conflict",\n                message,',
+  'HttpError::new(StatusCode::CONFLICT, "return_completion_operation_conflict", message)',
+]) forbidText(source, value, 'unsafe raw conflict envelope');
+
+const mapperUses = source.match(/map_operator_error\(/g) ?? [];
+if (mapperUses.length !== 4) {
+  failures.push(`expected mapper definition plus three uses, found ${mapperUses.length}`);
+}
+const contextUses = source.match(/ReturnCompletionOperatorErrorContext::new\(/g) ?? [];
+if (contextUses.length !== 3) {
+  failures.push(`expected three route contexts, found ${contextUses.length}`);
+}
+
+for (const [value, label] of [
+  ['pub fn axum_router()', 'router'],
+  ['"/compensation-sweep"', 'unrelated route absence guard'],
+  ['PaginationMeta::new(pagination.page, pagination.limit(), total)', 'list pagination'],
+  ['Ok(Json(operation))', 'show response'],
+  ['Ok(Json(order_return))', 'retry response'],
+]) {
+  if (label === 'unrelated route absence guard') {
+    forbidText(source, value, label);
+  } else {
+    requireText(source, value, label);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Commerce return completion envelope-safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Return completion operator conflicts use static envelopes and bounded route diagnostics',
+);


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce non-`PortError` public-envelope and correlation-safe mapper cleanup at the Admin Return Completion operator boundary.

- stop returning internal `PostOrderOrchestrationError::Validation(message)` text in the public conflict envelope;
- preserve the existing not-found, conflict, and storage-unavailable status/code classifications;
- replace the conflict message with a static public message;
- add typed tenant, actor, optional operation identity, and route-operation context at all three mounted callsites;
- retain typed policy selection before diagnostic projection;
- shadow specialized operator errors before logging with a diagnostic type whose `Debug` output is always `redacted`;
- replace tenant, actor, and optional operation UUIDs with closed shape labels;
- preserve the shared fallback for unmatched post-order errors;
- add a focused fail-closed source verifier, source-only evidence, and documentation while leaving the broad ecommerce cleanup open.

## Recheck

Current `main` includes the Admin Product, Fulfillment, Payment, and Shipping diagnostic slices. The Return Completion operator mapper still returned raw validation text for lease, reconciliation, terminal, replay, command-binding, and command-hash conflicts. No open PR overlaps this boundary.

The branch started from `main@d1a4e71d8b9d212d96067eb7c186def64ed4e48e`. Current `main` later advanced through Index-only commits to `9dc052897d1b4e423d422b92850dfe62a05a6e03`; the target Return Completion file remains at the same blob SHA and is not overlapped. The PR changes four intended files.

## Preserved behavior

- all three mounted routes and success DTOs;
- `ORDERS_READ` authorization for list/detail;
- combined `ORDERS_MANAGE` and `PAYMENTS_MANAGE` authorization for retry;
- pagination, filtering, totals, and response envelopes;
- `ReturnCompletionOrchestrationService` owner calls;
- payment-provider registry composition;
- existing internal string classifiers;
- not-found status/code/message;
- conflict status/code;
- storage-unavailable status/code/message;
- delegation of unmatched errors to the shared post-order mapper.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Node verifiers;
- Cargo checks, builds, clippy, or formatting;
- mounted HTTP execution;
- workflows or CI.

Execution evidence remains pending. Typed owner variants for the operator states, the shared fallback diagnostic cleanup, and the broad ecommerce cleanup remain open.