### PR TITLE
fix(commerce): bound admin reconciliation diagnostics

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/admin-reconciliation-diagnostic-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/admin-reconciliation-diagnostic-safety-source-review.json
@@ -1,0 +1,44 @@
+{
+  "status": "commerce_admin_reconciliation_diagnostic_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-commerce/src/controllers/reconciliation.rs",
+    "scripts/verify/verify-commerce-admin-fulfillment-reconciliation-error-context.mjs",
+    "crates/rustok-commerce/docs/admin-reconciliation-diagnostic-safety.md",
+    "crates/rustok-commerce/docs/implementation-plan.md"
+  ],
+  "source_contract": {
+    "raw_fulfillment_error_logged": false,
+    "raw_fulfillment_orchestration_error_logged": false,
+    "raw_serialization_error_logged": false,
+    "raw_tenant_uuid_logged": false,
+    "raw_actor_uuid_logged": false,
+    "raw_provider_operation_uuid_logged": false,
+    "redacted_error_debug_logged": true,
+    "required_uuid_shapes_logged": true,
+    "optional_uuid_shapes_logged": true,
+    "typed_policy_selection_precedes_projection": true,
+    "fulfillment_owner_policy_preserved": true,
+    "orchestration_policy_preserved": true,
+    "encoding_policy_preserved": true,
+    "six_route_contexts_preserved": true,
+    "manage_permission_preserved": true,
+    "owner_calls_preserved": true,
+    "provider_registry_composition_preserved": true,
+    "limits_and_stale_clamp_preserved": true,
+    "successful_response_envelopes_preserved": true,
+    "broad_ecommerce_cleanup_closed": false,
+    "runtime_evidence_claimed": false
+  },
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed."
+}

--- a/crates/rustok-commerce/docs/admin-reconciliation-diagnostic-safety.md
+++ b/crates/rustok-commerce/docs/admin-reconciliation-diagnostic-safety.md
@@ -1,0 +1,65 @@
+# Admin reconciliation diagnostic safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens the complete Commerce Admin Fulfillment Reconciliation HTTP boundary:
+
+- list operations requiring reconciliation;
+- quarantine stale executing operations;
+- resolve an unknown provider operation as failed;
+- resolve an unknown provider operation as succeeded;
+- retry local fulfillment persistence;
+- retry provider label creation.
+
+The six mounted routes, their permissions, owner calls, provider composition, limits, stale-time clamp, and successful response DTOs remain unchanged.
+
+## Bounded diagnostic projection
+
+Each route now supplies typed tenant, actor, optional provider-operation identity, and a static route-operation label. Typed `FulfillmentError`, `FulfillmentOrchestrationError`, and `serde_json::Error` values remain available until the mapper selects the existing HTTP policy.
+
+Before each `tracing::error!` event:
+
+- the typed error is shadowed by a diagnostic type whose `Debug` output is always `redacted`;
+- tenant and actor UUIDs become `nil` / `non_nil`;
+- optional provider-operation identity becomes `absent` / `present_nil` / `present_non_nil`;
+- owner, route operation, error kind, public code, HTTP status, boundary, and static event message remain observable.
+
+No validation detail, database cause, provider payload, transition detail, serialization detail, UUID, or actor identifier is emitted by these mappers.
+
+## Preserved HTTP policy
+
+This work does not change:
+
+- fulfillment validation, not-found, state-conflict, and storage-unavailable status/code/message policy;
+- orchestration order-not-found, validation, storage-unavailable, and reconciliation-required policy;
+- nested fulfillment-error delegation;
+- fail-closed provider-result encoding status, code, and static message;
+- `HttpError::new(status, code, message)` construction.
+
+## Preserved route behavior
+
+This work does not change:
+
+- `FULFILLMENTS_MANAGE` authorization;
+- `FulfillmentProviderOperationRecovery` list, quarantine, and resolve calls;
+- `FulfillmentReconciliationService` local-persistence retry;
+- `FulfillmentCreateLabelRecoveryService` provider retry;
+- fulfillment provider-registry composition;
+- the default limit of 100;
+- the stale interval clamp from 60 seconds through seven days;
+- successful provider-operation and fulfillment response envelopes.
+
+## Remaining boundary
+
+The broad ecommerce correlation-safe mapper and non-`PortError` public-envelope cleanup remains open. Storefront shared context/customer/channel, storefront cart shipping, inventory, tax, promotion, remaining owner adapters, GraphQL/native transports, and runtime verification are not completed by this slice.
+
+## Evidence
+
+- `crates/rustok-commerce/contracts/evidence/admin-reconciliation-diagnostic-safety-source-review.json`
+- `scripts/verify/verify-commerce-admin-fulfillment-reconciliation-error-context.mjs`
+
+## Validation disclosure
+
+No tests, Node verifiers, formatting, Cargo commands, mounted HTTP scenarios, workflows, or CI were run. No compile, runtime, FFA, or FBA status is promoted.

--- a/crates/rustok-commerce/src/controllers/reconciliation.rs
+++ b/crates/rustok-commerce/src/controllers/reconciliation.rs
@@ -23,6 +23,68 @@ const ADMIN_RECONCILIATION_FULFILLMENT_OWNER: &str = "rustok_fulfillment.admin_r
 const ADMIN_RECONCILIATION_ORCHESTRATION_OWNER: &str = "rustok_commerce.fulfillment_reconciliation";
 const ADMIN_RECONCILIATION_BOUNDARY: &str = "commerce_admin_reconciliation_http";
 
+#[derive(Clone, Copy)]
+struct AdminReconciliationErrorContext {
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    provider_operation_id: Option<Uuid>,
+    operation: &'static str,
+}
+
+impl AdminReconciliationErrorContext {
+    fn new(
+        tenant_id: Uuid,
+        actor_id: Uuid,
+        provider_operation_id: Option<Uuid>,
+        operation: &'static str,
+    ) -> Self {
+        Self {
+            tenant_id,
+            actor_id,
+            provider_operation_id,
+            operation,
+        }
+    }
+}
+
+struct AdminReconciliationDiagnosticContext {
+    tenant_id: &'static str,
+    actor_id: &'static str,
+    provider_operation_id: &'static str,
+    operation: &'static str,
+}
+
+impl From<&AdminReconciliationErrorContext> for AdminReconciliationDiagnosticContext {
+    fn from(context: &AdminReconciliationErrorContext) -> Self {
+        Self {
+            tenant_id: uuid_shape(context.tenant_id),
+            actor_id: uuid_shape(context.actor_id),
+            provider_operation_id: optional_uuid_shape(context.provider_operation_id),
+            operation: context.operation,
+        }
+    }
+}
+
+struct AdminReconciliationDiagnosticError;
+
+impl std::fmt::Debug for AdminReconciliationDiagnosticError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("redacted")
+    }
+}
+
+fn uuid_shape(value: Uuid) -> &'static str {
+    if value.is_nil() { "nil" } else { "non_nil" }
+}
+
+fn optional_uuid_shape(value: Option<Uuid>) -> &'static str {
+    match value {
+        None => "absent",
+        Some(value) if value.is_nil() => "present_nil",
+        Some(_) => "present_non_nil",
+    }
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct ListReconciliationParams {
     pub limit: Option<u64>,
@@ -74,9 +136,12 @@ async fn list_reconciliation_required(
         .await
         .map_err(|error| {
             map_reconciliation_fulfillment_error(
-                tenant.id,
-                None,
-                "list_reconciliation_required",
+                AdminReconciliationErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    None,
+                    "list_reconciliation_required",
+                ),
                 error,
             )
         })?;
@@ -97,9 +162,12 @@ async fn quarantine_stale_executing(
         .await
         .map_err(|error| {
             map_reconciliation_fulfillment_error(
-                tenant.id,
-                None,
-                "quarantine_stale_executing",
+                AdminReconciliationErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    None,
+                    "quarantine_stale_executing",
+                ),
                 error,
             )
         })?;
@@ -119,9 +187,12 @@ async fn resolve_unknown_as_failed(
         .await
         .map_err(|error| {
             map_reconciliation_fulfillment_error(
-                tenant.id,
-                Some(operation_id),
-                "resolve_unknown_as_failed",
+                AdminReconciliationErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    Some(operation_id),
+                    "resolve_unknown_as_failed",
+                ),
                 error,
             )
         })?;
@@ -136,20 +207,19 @@ async fn resolve_unknown_as_succeeded(
     Json(input): Json<ResolveUnknownSucceededInput>,
 ) -> HttpResult<Json<provider_operation::Model>> {
     require_manage_permission(&auth)?;
+    let context = AdminReconciliationErrorContext::new(
+        tenant.id,
+        auth.user_id,
+        Some(operation_id),
+        "resolve_unknown_as_succeeded",
+    );
     let provider_reference = input.provider_result.external_reference.clone();
     let provider_result = serde_json::to_value(input.provider_result)
-        .map_err(|error| map_provider_result_encoding_error(tenant.id, operation_id, error))?;
+        .map_err(|error| map_provider_result_encoding_error(context, error))?;
     let operation = FulfillmentProviderOperationRecovery::new(runtime.db_clone())
         .resolve_unknown_as_succeeded(tenant.id, operation_id, provider_reference, provider_result)
         .await
-        .map_err(|error| {
-            map_reconciliation_fulfillment_error(
-                tenant.id,
-                Some(operation_id),
-                "resolve_unknown_as_succeeded",
-                error,
-            )
-        })?;
+        .map_err(|error| map_reconciliation_fulfillment_error(context, error))?;
     Ok(Json(operation))
 }
 
@@ -165,9 +235,12 @@ async fn retry_local_persistence(
         .await
         .map_err(|error| {
             map_reconciliation_orchestration_error(
-                tenant.id,
-                Some(operation_id),
-                "retry_local_persistence",
+                AdminReconciliationErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    Some(operation_id),
+                    "retry_local_persistence",
+                ),
                 error,
             )
         })?;
@@ -187,9 +260,12 @@ async fn retry_create_label(
         .await
         .map_err(|error| {
             map_reconciliation_orchestration_error(
-                tenant.id,
-                Some(operation_id),
-                "retry_create_label",
+                AdminReconciliationErrorContext::new(
+                    tenant.id,
+                    auth.user_id,
+                    Some(operation_id),
+                    "retry_create_label",
+                ),
                 error,
             )
         })?;
@@ -197,9 +273,7 @@ async fn retry_create_label(
 }
 
 fn map_reconciliation_fulfillment_error(
-    tenant_id: Uuid,
-    provider_operation_id: Option<Uuid>,
-    operation: &'static str,
+    context: AdminReconciliationErrorContext,
     error: FulfillmentError,
 ) -> HttpError {
     let (status, code, message, error_kind) = match &error {
@@ -228,12 +302,15 @@ fn map_reconciliation_fulfillment_error(
             "database",
         ),
     };
+    let context = AdminReconciliationDiagnosticContext::from(&context);
+    let error = AdminReconciliationDiagnosticError;
     tracing::error!(
         error = ?error,
         owner = ADMIN_RECONCILIATION_FULFILLMENT_OWNER,
-        tenant_id = %tenant_id,
-        provider_operation_id = ?provider_operation_id,
-        operation,
+        tenant_id = %context.tenant_id,
+        actor_id = %context.actor_id,
+        provider_operation_id = %context.provider_operation_id,
+        operation = %context.operation,
         error_kind,
         public_code = code,
         status = %status,
@@ -244,14 +321,12 @@ fn map_reconciliation_fulfillment_error(
 }
 
 fn map_reconciliation_orchestration_error(
-    tenant_id: Uuid,
-    provider_operation_id: Option<Uuid>,
-    operation: &'static str,
+    context: AdminReconciliationErrorContext,
     error: FulfillmentOrchestrationError,
 ) -> HttpError {
     match error {
         FulfillmentOrchestrationError::Fulfillment(error) => {
-            map_reconciliation_fulfillment_error(tenant_id, provider_operation_id, operation, error)
+            map_reconciliation_fulfillment_error(context, error)
         }
         error => {
             let (status, code, message, error_kind) = match &error {
@@ -284,12 +359,15 @@ fn map_reconciliation_orchestration_error(
                     "nested fulfillment errors are handled before orchestration mapping"
                 ),
             };
+            let context = AdminReconciliationDiagnosticContext::from(&context);
+            let error = AdminReconciliationDiagnosticError;
             tracing::error!(
                 error = ?error,
                 owner = ADMIN_RECONCILIATION_ORCHESTRATION_OWNER,
-                tenant_id = %tenant_id,
-                provider_operation_id = ?provider_operation_id,
-                operation,
+                tenant_id = %context.tenant_id,
+                actor_id = %context.actor_id,
+                provider_operation_id = %context.provider_operation_id,
+                operation = %context.operation,
                 error_kind,
                 public_code = code,
                 status = %status,
@@ -302,18 +380,20 @@ fn map_reconciliation_orchestration_error(
 }
 
 fn map_provider_result_encoding_error(
-    tenant_id: Uuid,
-    provider_operation_id: Uuid,
-    error: serde_json::Error,
+    context: AdminReconciliationErrorContext,
+    _error: serde_json::Error,
 ) -> HttpError {
     let status = axum::http::StatusCode::INTERNAL_SERVER_ERROR;
     let code = "commerce_admin_fulfillment_reconciliation_encoding_failed";
+    let context = AdminReconciliationDiagnosticContext::from(&context);
+    let error = AdminReconciliationDiagnosticError;
     tracing::error!(
         error = ?error,
         owner = ADMIN_RECONCILIATION_ORCHESTRATION_OWNER,
-        tenant_id = %tenant_id,
-        provider_operation_id = %provider_operation_id,
-        operation = "resolve_unknown_as_succeeded",
+        tenant_id = %context.tenant_id,
+        actor_id = %context.actor_id,
+        provider_operation_id = %context.provider_operation_id,
+        operation = %context.operation,
         error_kind = "encoding",
         public_code = code,
         status = %status,

--- a/scripts/verify/verify-commerce-admin-fulfillment-reconciliation-error-context.mjs
+++ b/scripts/verify/verify-commerce-admin-fulfillment-reconciliation-error-context.mjs
@@ -11,10 +11,6 @@ const root = configuredRoot
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
 
 const source = read('crates/rustok-commerce/src/controllers/reconciliation.rs');
-const fulfillmentErrors = read('crates/rustok-fulfillment/src/error.rs');
-const orchestrationErrors = read(
-  'crates/rustok-commerce/src/services/fulfillment_orchestration.rs',
-);
 const failures = [];
 
 const requireText = (content, value, label) => {
@@ -31,6 +27,13 @@ const between = (content, start, end, label) => {
     return '';
   }
   return content.slice(startIndex, endIndex);
+};
+const requireBefore = (content, first, second, label) => {
+  const firstIndex = content.indexOf(first);
+  const secondIndex = content.indexOf(second);
+  if (firstIndex < 0 || secondIndex < 0 || firstIndex > secondIndex) {
+    failures.push(`${label}: ${first} must precede ${second}`);
+  }
 };
 
 const ownerMapper = between(
@@ -53,20 +56,27 @@ const encodingMapper = between(
 );
 
 for (const [value, label] of [
-  ['FulfillmentError, FulfillmentProviderOperationRecovery', 'typed fulfillment error import'],
-  ['FulfillmentOrchestrationError,', 'typed orchestration error import'],
+  ['struct AdminReconciliationErrorContext {', 'typed route context'],
+  ['tenant_id: Uuid,', 'typed tenant identity'],
+  ['actor_id: Uuid,', 'typed actor identity'],
+  ['provider_operation_id: Option<Uuid>,', 'typed optional operation identity'],
+  ["operation: &'static str,", 'static route operation'],
+  ['struct AdminReconciliationDiagnosticContext {', 'diagnostic context'],
+  ['tenant_id: uuid_shape(context.tenant_id)', 'tenant shape projection'],
+  ['actor_id: uuid_shape(context.actor_id)', 'actor shape projection'],
   [
-    'const ADMIN_RECONCILIATION_FULFILLMENT_OWNER: &str =',
-    'fulfillment owner constant',
+    'provider_operation_id: optional_uuid_shape(context.provider_operation_id)',
+    'operation shape projection',
   ],
-  [
-    'const ADMIN_RECONCILIATION_ORCHESTRATION_OWNER: &str =',
-    'orchestration owner constant',
-  ],
-  [
-    'const ADMIN_RECONCILIATION_BOUNDARY: &str = "commerce_admin_reconciliation_http";',
-    'HTTP boundary constant',
-  ],
+  ['struct AdminReconciliationDiagnosticError;', 'redacted diagnostic error'],
+  ['formatter.write_str("redacted")', 'redacted debug output'],
+  ["fn uuid_shape(value: Uuid) -> &'static str", 'required UUID shape helper'],
+  ["fn optional_uuid_shape(value: Option<Uuid>) -> &'static str", 'optional UUID shape helper'],
+  ['"nil"', 'nil shape'],
+  ['"non_nil"', 'non-nil shape'],
+  ['"absent"', 'absent optional shape'],
+  ['"present_nil"', 'present nil optional shape'],
+  ['"present_non_nil"', 'present non-nil optional shape'],
   ['[Permission::FULFILLMENTS_MANAGE]', 'manage permission'],
 ]) requireText(source, value, label);
 
@@ -77,10 +87,11 @@ for (const [value, label] of [
   ['"resolve_unknown_as_succeeded"', 'resolve-succeeded operation context'],
   ['"retry_local_persistence"', 'retry-local operation context'],
   ['"retry_create_label"', 'retry-label operation context'],
+  ['auth.user_id', 'truthful actor identity'],
   ['Some(operation_id)', 'truthful provider operation identity'],
   ['map_reconciliation_fulfillment_error(', 'owner mapper handoff'],
   ['map_reconciliation_orchestration_error(', 'orchestration mapper handoff'],
-  ['map_provider_result_encoding_error(tenant.id, operation_id, error)', 'encoding mapper handoff'],
+  ['map_provider_result_encoding_error(context, error)', 'encoding mapper handoff'],
 ]) requireText(source, value, label);
 
 for (const [value, label] of [
@@ -89,14 +100,20 @@ for (const [value, label] of [
   ['FulfillmentError::FulfillmentNotFound(_)', 'fulfillment not-found variant'],
   ['FulfillmentError::InvalidTransition { .. }', 'transition variant'],
   ['FulfillmentError::Database(_)', 'database variant'],
-  ['error = ?error', 'typed internal cause'],
+  [
+    'let context = AdminReconciliationDiagnosticContext::from(&context);',
+    'owner diagnostic projection',
+  ],
+  ['let error = AdminReconciliationDiagnosticError;', 'owner error shadow'],
+  ['error = ?error', 'redacted owner error event'],
+  ['tenant_id = %context.tenant_id', 'bounded tenant log'],
+  ['actor_id = %context.actor_id', 'bounded actor log'],
+  [
+    'provider_operation_id = %context.provider_operation_id',
+    'bounded optional operation log',
+  ],
+  ['operation = %context.operation', 'bounded route operation log'],
   ['owner = ADMIN_RECONCILIATION_FULFILLMENT_OWNER', 'owner log'],
-  ['tenant_id = %tenant_id', 'tenant log'],
-  ['provider_operation_id = ?provider_operation_id', 'optional operation identity log'],
-  ['operation,', 'owner operation log'],
-  ['error_kind,', 'error-kind log'],
-  ['public_code = code', 'public code log'],
-  ['status = %status', 'status log'],
   ['boundary = ADMIN_RECONCILIATION_BOUNDARY', 'boundary log'],
   ['"Fulfillment request is invalid"', 'static validation envelope'],
   ['"Commerce resource not found"', 'static not-found envelope'],
@@ -107,6 +124,18 @@ for (const [value, label] of [
   ['"Fulfillment storage is temporarily unavailable"', 'static storage envelope'],
   ['HttpError::new(status, code, message)', 'single owner envelope constructor'],
 ]) requireText(ownerMapper, value, label);
+requireBefore(
+  ownerMapper,
+  'FulfillmentError::Validation(_)',
+  'let context = AdminReconciliationDiagnosticContext::from(&context);',
+  'owner typed policy before projection',
+);
+requireBefore(
+  ownerMapper,
+  'let error = AdminReconciliationDiagnosticError;',
+  'tracing::error!(',
+  'owner error shadow before event',
+);
 
 for (const [value, label] of [
   ['FulfillmentOrchestrationError::Fulfillment(error)', 'nested owner delegation'],
@@ -121,57 +150,107 @@ for (const [value, label] of [
     'FulfillmentOrchestrationError::PersistenceAfterProvider { .. }',
     'persistence-after-provider variant',
   ],
+  [
+    'let context = AdminReconciliationDiagnosticContext::from(&context);',
+    'orchestration diagnostic projection',
+  ],
+  ['let error = AdminReconciliationDiagnosticError;', 'orchestration error shadow'],
   ['owner = ADMIN_RECONCILIATION_ORCHESTRATION_OWNER', 'orchestration owner log'],
-  ['provider_operation_id = ?provider_operation_id', 'orchestration operation identity log'],
+  ['tenant_id = %context.tenant_id', 'bounded orchestration tenant log'],
+  ['actor_id = %context.actor_id', 'bounded orchestration actor log'],
+  [
+    'provider_operation_id = %context.provider_operation_id',
+    'bounded orchestration operation identity log',
+  ],
   ['"Fulfillment operation requires reconciliation"', 'static reconciliation envelope'],
   ['HttpError::new(status, code, message)', 'single orchestration envelope constructor'],
 ]) requireText(orchestrationMapper, value, label);
+requireBefore(
+  orchestrationMapper,
+  'FulfillmentOrchestrationError::OrderNotFound(_)',
+  'let context = AdminReconciliationDiagnosticContext::from(&context);',
+  'orchestration typed policy before projection',
+);
+requireBefore(
+  orchestrationMapper,
+  'let error = AdminReconciliationDiagnosticError;',
+  'tracing::error!(',
+  'orchestration error shadow before event',
+);
 
 for (const [value, label] of [
+  ['_error: serde_json::Error', 'typed encoding error retained'],
   ['axum::http::StatusCode::INTERNAL_SERVER_ERROR', 'fail-closed encoding status'],
   [
     '"commerce_admin_fulfillment_reconciliation_encoding_failed"',
     'stable encoding code',
   ],
-  ['error = ?error', 'encoding cause log'],
-  ['tenant_id = %tenant_id', 'encoding tenant log'],
-  ['provider_operation_id = %provider_operation_id', 'encoding operation identity log'],
-  ['operation = "resolve_unknown_as_succeeded"', 'encoding operation log'],
+  [
+    'let context = AdminReconciliationDiagnosticContext::from(&context);',
+    'encoding diagnostic projection',
+  ],
+  ['let error = AdminReconciliationDiagnosticError;', 'encoding error shadow'],
+  ['tenant_id = %context.tenant_id', 'bounded encoding tenant log'],
+  ['actor_id = %context.actor_id', 'bounded encoding actor log'],
+  [
+    'provider_operation_id = %context.provider_operation_id',
+    'bounded encoding operation identity log',
+  ],
+  ['operation = %context.operation', 'encoding operation log'],
   ['error_kind = "encoding"', 'encoding kind log'],
   [
     '"Fulfillment reconciliation result could not be processed safely"',
     'static fail-closed encoding envelope',
   ],
 ]) requireText(encodingMapper, value, label);
-
-for (const [ownerSource, value, label] of [
-  [fulfillmentErrors, 'Validation(String)', 'owner validation variant'],
-  [fulfillmentErrors, 'ShippingOptionNotFound(Uuid)', 'owner shipping-option variant'],
-  [fulfillmentErrors, 'FulfillmentNotFound(Uuid)', 'owner fulfillment variant'],
-  [fulfillmentErrors, 'InvalidTransition { from: String, to: String }', 'owner transition variant'],
-  [fulfillmentErrors, 'Database(#[from] DbErr)', 'owner database variant'],
-  [orchestrationErrors, 'OrderNotFound(Uuid)', 'orchestration order-not-found variant'],
-  [orchestrationErrors, 'Database(#[from] sea_orm::DbErr)', 'orchestration database variant'],
-  [orchestrationErrors, 'Fulfillment(#[from] rustok_fulfillment::error::FulfillmentError)', 'orchestration fulfillment variant'],
-  [orchestrationErrors, 'Validation(String)', 'orchestration validation variant'],
-  [orchestrationErrors, 'ProviderAfterPersistence {', 'provider-after-persistence variant'],
-  [orchestrationErrors, 'PersistenceAfterProvider {', 'persistence-after-provider variant'],
-]) requireText(ownerSource, value, label);
+requireBefore(
+  encodingMapper,
+  'let error = AdminReconciliationDiagnosticError;',
+  'tracing::error!(',
+  'encoding error shadow before event',
+);
 
 for (const value of [
-  'super::admin::map_fulfillment_error',
-  'map_fulfillment_orchestration_error',
-  'format!("failed to serialize provider result:',
-  'HttpError::bad_request(',
+  'tenant_id = %tenant_id',
+  'actor_id = %actor_id',
+  'provider_operation_id = ?provider_operation_id',
+  'provider_operation_id = %provider_operation_id',
   'error.to_string()',
-]) forbidText(source, value, 'unsafe reconciliation public mapping');
+  'HttpError::bad_request(',
+  'format!("failed to serialize provider result:',
+]) forbidText(source, value, 'unsafe reconciliation diagnostic or public mapping');
+
+for (const [value, expected, label] of [
+  ['AdminReconciliationErrorContext::new(', 6, 'six route contexts'],
+  ['map_reconciliation_fulfillment_error(', 6, 'owner mapper definition and five handoffs'],
+  ['map_reconciliation_orchestration_error(', 3, 'orchestration mapper definition and two handoffs'],
+  ['map_provider_result_encoding_error(', 2, 'encoding mapper definition and handoff'],
+]) {
+  const count = source.split(value).length - 1;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+}
+
+for (const [value, label] of [
+  ['.route("/reconciliation", get(list_reconciliation_required))', 'list route'],
+  ['.route("/quarantine-stale", post(quarantine_stale_executing))', 'quarantine route'],
+  ['.route("/{id}/resolve-failed", post(resolve_unknown_as_failed))', 'resolve-failed route'],
+  ['"/{id}/resolve-succeeded"', 'resolve-succeeded route'],
+  ['.route("/{id}/retry-local", post(retry_local_persistence))', 'retry-local route'],
+  ['.route("/{id}/retry-create-label", post(retry_create_label))', 'retry-label route'],
+  ['FulfillmentProviderOperationRecovery::new(runtime.db_clone())', 'recovery owner construction'],
+  ['FulfillmentReconciliationService::new(runtime.db_clone())', 'local reconciliation construction'],
+  ['FulfillmentCreateLabelRecoveryService::new(runtime.db_clone())', 'label recovery construction'],
+  ['.with_provider_registry(runtime.fulfillment_provider_registry())', 'provider registry composition'],
+  ['input.limit.unwrap_or(100)', 'bounded input limit'],
+  ['input.stale_after_seconds.clamp(60, 7 * 24 * 60 * 60)', 'stale interval clamp'],
+]) requireText(source, value, label);
 
 if (failures.length > 0) {
-  console.error('Commerce admin fulfillment reconciliation error-context verification failed:');
+  console.error('Commerce admin fulfillment reconciliation diagnostic-safety verification failed:');
   for (const failure of failures) console.error(`✗ ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
 
 console.log(
-  '✔ Commerce admin fulfillment reconciliation retains typed causes and returns static public envelopes',
+  '✔ Commerce admin fulfillment reconciliation retains typed policies and emits bounded diagnostics',
 );


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce correlation-safe mapper cleanup across the complete Commerce Admin Fulfillment Reconciliation HTTP boundary.

- retain typed `FulfillmentError`, `FulfillmentOrchestrationError`, and `serde_json::Error` values through existing HTTP policy selection;
- add typed tenant, actor, optional provider-operation identity, and static route-operation context at all six mounted callsites;
- shadow typed errors before the three failure events with a diagnostic type whose `Debug` output is always `redacted`;
- replace tenant, actor, and provider-operation UUID payloads with closed shape labels;
- preserve owner, route operation, error kind, public code, HTTP status, boundary, and static event messages;
- preserve all fulfillment-owner, orchestration, and encoding status/code/message policies;
- preserve routes, permissions, owner calls, provider-registry composition, default limits, stale-time clamp, and successful response envelopes;
- update the existing focused reconciliation verifier;
- add source-only evidence and documentation while leaving the broad ecommerce cleanup open.

## Recheck

Current `main` includes the Admin Product, Fulfillment, Payment, Shipping, and Return Completion safety slices. The separate reconciliation transport still emitted complete fulfillment, orchestration, and serialization errors together with raw tenant and provider-operation UUIDs. No open PR overlaps this boundary.

The branch starts from `main@f785996a3442f433420cd150b68c82602def5d84` and changes four intended files.

## Preserved behavior

- six mounted reconciliation routes;
- `FULFILLMENTS_MANAGE` authorization;
- fulfillment validation, not-found, state-conflict, storage-unavailable, and reconciliation-required envelopes;
- fail-closed provider-result encoding envelope;
- `FulfillmentProviderOperationRecovery` operations;
- `FulfillmentReconciliationService` local-persistence retry;
- `FulfillmentCreateLabelRecoveryService` provider retry;
- fulfillment provider-registry composition;
- default limit of 100 and stale interval clamp from 60 seconds through seven days;
- successful provider-operation and fulfillment DTOs.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Node verifiers;
- Cargo checks, builds, clippy, or formatting;
- mounted HTTP execution;
- workflows or CI.

Execution evidence remains pending and the broad ecommerce cleanup remains open.