### PR TITLE
fix(commerce): bound GraphQL query diagnostics

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/graphql-query-diagnostic-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/graphql-query-diagnostic-safety-source-review.json
@@ -1,0 +1,43 @@
+{
+  "status": "commerce_graphql_query_diagnostic_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-commerce/src/graphql/safe_query/query_error_boundary.rs",
+    "scripts/verify/verify-commerce-graphql-query-error-boundary.mjs",
+    "crates/rustok-commerce/docs/graphql-query-diagnostic-safety.md",
+    "crates/rustok-commerce/docs/implementation-plan.md"
+  ],
+  "source_contract": {
+    "dynamic_message_content_logged": false,
+    "database_error_logged": false,
+    "commerce_error_logged": false,
+    "fulfillment_error_logged": false,
+    "order_error_logged": false,
+    "payment_error_logged": false,
+    "diagnostic_error_debug_redacted": true,
+    "dynamic_message_presence_logged": true,
+    "dynamic_message_length_logged": true,
+    "typed_policy_selection_precedes_shadowing": true,
+    "six_diagnostic_shadow_points": true,
+    "graphql_public_messages_preserved": true,
+    "graphql_public_codes_preserved": true,
+    "graphql_retryability_preserved": true,
+    "graphql_pass_through_preserved": true,
+    "product_mapper_delegation_preserved": true,
+    "resolver_source_unchanged": true,
+    "query_correlation_context_added": false,
+    "broad_ecommerce_cleanup_closed": false,
+    "runtime_evidence_claimed": false
+  },
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, workflows, or CI were executed."
+}

--- a/crates/rustok-commerce/docs/graphql-query-diagnostic-safety.md
+++ b/crates/rustok-commerce/docs/graphql-query-diagnostic-safety.md
@@ -1,0 +1,56 @@
+# GraphQL query diagnostic safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens the Commerce GraphQL safe-query error boundary used by the unchanged query resolver source.
+
+The boundary already converted dynamic resolver failures and typed Commerce, Fulfillment, Order, Payment, and database errors into stable public GraphQL messages, codes, and retryability extensions. Its diagnostic events still emitted dynamic strings and complete typed owner/database errors.
+
+## Bounded diagnostics
+
+The boundary now uses one diagnostic error type whose `Debug` output is always `redacted`.
+
+Typed errors remain available until the existing public policy is selected. Only after policy selection does each mapper shadow the original value before `tracing::error!`.
+
+The six diagnostic projection points cover:
+
+- dynamic `String` compatibility errors;
+- SeaORM database errors;
+- Commerce owner errors;
+- Fulfillment owner errors;
+- Order owner errors;
+- Payment owner errors.
+
+Dynamic strings are represented only by `empty` / `present` and their byte length. Message content, validation details, database causes, owner internals, provider details, transition details, and resource identifiers are not emitted by this boundary.
+
+## Preserved GraphQL contract
+
+This work does not change:
+
+- `BoundaryError::Graphql` pass-through;
+- static `&str` GraphQL construction;
+- public messages;
+- extension codes;
+- retryability values;
+- product-service error mapper delegation;
+- resolver source inclusion or resolver behavior;
+- authentication, permission, module, tenant, or channel helpers.
+
+Temporary-unavailable policies remain retryable. Payment reconciliation remains non-retryable.
+
+## Remaining boundary
+
+The current conversion traits do not receive request-scoped tenant, actor, channel, locale, correlation, or deadline context. Adding truthful GraphQL query context without duplicating resolver policy remains open.
+
+The broader ecommerce correlation-safe mapper, inventory, customer, tax, promotion, storefront, native transport, and non-`PortError` cleanup also remains open.
+
+## Evidence
+
+- `crates/rustok-commerce/contracts/evidence/graphql-query-diagnostic-safety-source-review.json`
+- `scripts/verify/verify-commerce-graphql-query-error-boundary.mjs`
+
+## Validation disclosure
+
+No tests, Node verifiers, formatting, Cargo commands, mounted GraphQL scenarios, workflows, or CI were run. No compile, runtime, FFA, or FBA status is promoted.

--- a/crates/rustok-commerce/src/graphql/safe_query/query_error_boundary.rs
+++ b/crates/rustok-commerce/src/graphql/safe_query/query_error_boundary.rs
@@ -3,6 +3,20 @@ use ::rustok_fulfillment::error::FulfillmentError;
 use ::rustok_order::error::OrderError;
 use ::rustok_payment::error::PaymentError;
 
+const QUERY_ERROR_BOUNDARY: &str = "commerce_graphql_query";
+
+struct QueryDiagnosticError;
+
+impl std::fmt::Debug for QueryDiagnosticError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("redacted")
+    }
+}
+
+fn text_presence_shape(value: &str) -> &'static str {
+    if value.is_empty() { "empty" } else { "present" }
+}
+
 #[derive(Clone, Debug)]
 pub(crate) enum BoundaryError {
     Graphql(Error),
@@ -36,11 +50,18 @@ impl BoundaryError {
 
 impl QueryGraphqlMessage for String {
     fn into_query_boundary(self) -> BoundaryError {
+        let message_presence = text_presence_shape(&self);
+        let message_len = self.len();
+        let error = QueryDiagnosticError;
         tracing::error!(
-            error_message = %self,
+            error = ?error,
+            source_owner = "commerce_graphql_query.dynamic_message",
+            error_kind = "dynamic_message",
+            message_presence,
+            message_len,
             public_code = "COMMERCE_QUERY_OPERATION_FAILED",
             retryable = false,
-            boundary = "commerce_graphql_query",
+            boundary = QUERY_ERROR_BOUNDARY,
             "commerce GraphQL query dynamic error was redacted"
         );
         BoundaryError::public(
@@ -76,14 +97,15 @@ impl From<String> for BoundaryError {
 }
 
 impl From<sea_orm::DbErr> for BoundaryError {
-    fn from(error: sea_orm::DbErr) -> Self {
+    fn from(_error: sea_orm::DbErr) -> Self {
+        let error = QueryDiagnosticError;
         tracing::error!(
             error = ?error,
             owner = "sea_orm",
             error_kind = "database",
             public_code = "COMMERCE_QUERY_TEMPORARILY_UNAVAILABLE",
             retryable = true,
-            boundary = "commerce_graphql_query",
+            boundary = QUERY_ERROR_BOUNDARY,
             "commerce GraphQL query database operation failed"
         );
         Self::public(
@@ -105,7 +127,7 @@ impl From<rustok_product::CommerceError> for BoundaryError {
 
 impl From<crate::CommerceError> for BoundaryError {
     fn from(error: crate::CommerceError) -> Self {
-        let (message, code, retryable, error_kind) = match error {
+        let (message, code, retryable, error_kind) = match &error {
             crate::CommerceError::Database(_) => (
                 "Commerce data is temporarily unavailable",
                 "COMMERCE_QUERY_TEMPORARILY_UNAVAILABLE",
@@ -119,12 +141,14 @@ impl From<crate::CommerceError> for BoundaryError {
                 "commerce",
             ),
         };
+        let error = QueryDiagnosticError;
         tracing::error!(
             error = ?error,
+            owner = "rustok_commerce",
             error_kind,
             public_code = code,
             retryable,
-            boundary = "commerce_graphql_query",
+            boundary = QUERY_ERROR_BOUNDARY,
             "commerce GraphQL owner operation failed"
         );
         Self::public(message, code, retryable)
@@ -160,13 +184,14 @@ impl From<FulfillmentError> for BoundaryError {
                 "database",
             ),
         };
+        let error = QueryDiagnosticError;
         tracing::error!(
             error = ?error,
             owner = "rustok_fulfillment",
             error_kind,
             public_code = code,
             retryable,
-            boundary = "commerce_graphql_query",
+            boundary = QUERY_ERROR_BOUNDARY,
             "commerce GraphQL fulfillment query failed"
         );
         Self::public(message, code, retryable)
@@ -209,13 +234,14 @@ impl From<OrderError> for BoundaryError {
                 "core",
             ),
         };
+        let error = QueryDiagnosticError;
         tracing::error!(
             error = ?error,
             owner = "rustok_order",
             error_kind,
             public_code = code,
             retryable,
-            boundary = "commerce_graphql_query",
+            boundary = QUERY_ERROR_BOUNDARY,
             "commerce GraphQL order query failed"
         );
         Self::public(message, code, retryable)
@@ -265,13 +291,14 @@ impl From<PaymentError> for BoundaryError {
                 "configuration",
             ),
         };
+        let error = QueryDiagnosticError;
         tracing::error!(
             error = ?error,
             owner = "rustok_payment",
             error_kind,
             public_code = code,
             retryable,
-            boundary = "commerce_graphql_query",
+            boundary = QUERY_ERROR_BOUNDARY,
             "commerce GraphQL payment query failed"
         );
         Self::public(message, code, retryable)

--- a/scripts/verify/verify-commerce-graphql-query-error-boundary.mjs
+++ b/scripts/verify/verify-commerce-graphql-query-error-boundary.mjs
@@ -14,6 +14,9 @@ const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8')
 
 const routing = read('crates/rustok-commerce/src/graphql/mod.rs');
 const facade = readCommerceSafeQuerySource(read);
+const boundary = read(
+  'crates/rustok-commerce/src/graphql/safe_query/query_error_boundary.rs',
+);
 const source = read('crates/rustok-commerce/src/graphql/query.rs');
 const orderErrors = read('crates/rustok-order/src/error.rs');
 const paymentErrors = read('crates/rustok-payment/src/error.rs');
@@ -26,6 +29,59 @@ const requireText = (content, value, label) => {
 const forbidText = (content, value, label) => {
   if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
 };
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+const requireBefore = (content, first, second, label) => {
+  const firstIndex = content.indexOf(first);
+  const secondIndex = content.indexOf(second);
+  if (firstIndex < 0 || secondIndex < 0 || firstIndex > secondIndex) {
+    failures.push(`${label}: ${first} must precede ${second}`);
+  }
+};
+
+const dynamicMapper = between(
+  boundary,
+  'impl QueryGraphqlMessage for String {',
+  'impl QueryGraphqlMessage for &str {',
+  'dynamic string mapper',
+);
+const databaseMapper = between(
+  boundary,
+  'impl From<sea_orm::DbErr> for BoundaryError {',
+  'impl From<rustok_product::CommerceError> for BoundaryError {',
+  'database mapper',
+);
+const commerceMapper = between(
+  boundary,
+  'impl From<crate::CommerceError> for BoundaryError {',
+  'impl From<FulfillmentError> for BoundaryError {',
+  'commerce mapper',
+);
+const fulfillmentMapper = between(
+  boundary,
+  'impl From<FulfillmentError> for BoundaryError {',
+  'impl From<OrderError> for BoundaryError {',
+  'fulfillment mapper',
+);
+const orderMapper = between(
+  boundary,
+  'impl From<OrderError> for BoundaryError {',
+  'impl From<PaymentError> for BoundaryError {',
+  'order mapper',
+);
+const paymentMapper = between(
+  boundary,
+  'impl From<PaymentError> for BoundaryError {',
+  'impl From<BoundaryError> for Error {',
+  'payment mapper',
+);
 
 requireText(routing, '#[path = "safe_query.rs"]\nmod query;', 'safe query routing');
 if ((routing.match(/\bmod query;/g) ?? []).length !== 1) {
@@ -44,51 +100,74 @@ for (const [value, label] of [
   ['impl From<String> for BoundaryError', 'string conversion'],
   ['impl From<sea_orm::DbErr> for BoundaryError', 'database conversion'],
   ['impl From<crate::CommerceError> for BoundaryError', 'commerce conversion'],
-]) requireText(facade, value, label);
-
-for (const [value, label] of [
   ['impl From<FulfillmentError> for BoundaryError', 'fulfillment conversion'],
   ['impl From<OrderError> for BoundaryError', 'order conversion'],
   ['impl From<PaymentError> for BoundaryError', 'payment conversion'],
   ['impl From<BoundaryError> for Error', 'GraphQL restoration'],
   ['extensions.set("code", code)', 'code extension'],
   ['extensions.set("retryable", retryable)', 'retryability extension'],
+  ['const QUERY_ERROR_BOUNDARY: &str = "commerce_graphql_query";', 'boundary constant'],
+  ['struct QueryDiagnosticError;', 'diagnostic error type'],
+  ['formatter.write_str("redacted")', 'redacted diagnostic Debug'],
+  ['fn text_presence_shape(value: &str)', 'dynamic text shape helper'],
+]) requireText(boundary, value, label);
+
+for (const [value, label] of [
+  ['let message_presence = text_presence_shape(&self);', 'dynamic message shape'],
+  ['let message_len = self.len();', 'dynamic message length'],
+  ['source_owner = "commerce_graphql_query.dynamic_message"', 'dynamic source owner'],
+  ['error_kind = "dynamic_message"', 'dynamic error kind'],
+  ['message_presence,', 'dynamic presence log'],
+  ['message_len,', 'dynamic length log'],
   ['"COMMERCE_QUERY_OPERATION_FAILED"', 'dynamic safe code'],
-  ['"COMMERCE_QUERY_TEMPORARILY_UNAVAILABLE"', 'database safe code'],
-  ['error_message = %self', 'dynamic error logging'],
-  ['boundary = "commerce_graphql_query"', 'boundary logging'],
-  ['pub(crate) const MODULE_SLUG: &str = super::MODULE_SLUG;', 'module forwarding'],
-  ['pub(crate) const PRODUCT_MODULE_SLUG: &str = super::PRODUCT_MODULE_SLUG;', 'product forwarding'],
-  ['pub(crate) fn map_product_service_error(', 'product mapper forwarding'],
-  ['pub(crate) fn product_query_tenant(', 'tenant helper forwarding'],
-  ['pub(crate) fn require_commerce_permission(', 'permission forwarding'],
-  ['pub(crate) async fn require_storefront_channel_enabled(', 'channel forwarding'],
-  ['mod source;', 'source module'],
-  ['mod async_graphql_shim {', 'GraphQL shim'],
-  ['use self::async_graphql_shim as async_graphql;', 'GraphQL alias'],
-  ['pub type Error = super::super::query_error_boundary::BoundaryError;', 'custom Error'],
-  ['pub type FieldError = super::super::query_error_boundary::BoundaryError;', 'custom FieldError'],
-  ['mod rustok_api_shim {', 'API shim'],
-  ['mod rustok_fulfillment_shim;', 'fulfillment shim'],
-  ['use self::rustok_api_shim as rustok_api;', 'API alias'],
-  ['use self::rustok_fulfillment_shim as rustok_fulfillment;', 'fulfillment alias'],
-  ['include!("../query.rs");', 'unchanged query inclusion'],
-  ['pub use source::CommerceQuery;', 'query export'],
-]) requireText(facade, value, label);
+  ['"Commerce query could not be completed safely"', 'dynamic safe message'],
+]) requireText(dynamicMapper, value, label);
+for (const value of ['error_message = %self', 'message = %self', 'error = %self']) {
+  forbidText(dynamicMapper, value, 'raw dynamic string diagnostic');
+}
 
-for (const value of [
-  'BoundaryError::Graphql(error) => error',
-  'BoundaryError::Graphql(Error::new(self))',
-  '<::async_graphql::FieldError as ::rustok_api::graphql::GraphQLError>::unauthenticated()',
-  '<::async_graphql::FieldError as ::rustok_api::graphql::GraphQLError>::permission_denied(message)',
-  '::rustok_api::graphql::require_module_enabled(ctx, module_slug)',
-]) requireText(facade, value, 'existing GraphQL preservation');
+for (const mapper of [
+  ['dynamic', dynamicMapper],
+  ['database', databaseMapper],
+  ['commerce', commerceMapper],
+  ['fulfillment', fulfillmentMapper],
+  ['order', orderMapper],
+  ['payment', paymentMapper],
+]) {
+  const [label, content] = mapper;
+  requireText(content, 'let error = QueryDiagnosticError;', `${label} diagnostic shadow`);
+  requireText(content, 'error = ?error', `${label} redacted error log`);
+  requireText(content, 'boundary = QUERY_ERROR_BOUNDARY', `${label} boundary log`);
+  requireBefore(
+    content,
+    'let error = QueryDiagnosticError;',
+    'tracing::error!(',
+    `${label} shadow order`,
+  );
+}
 
+requireText(databaseMapper, 'fn from(_error: sea_orm::DbErr)', 'discarded database cause');
+requireText(databaseMapper, 'owner = "sea_orm"', 'database owner');
+requireText(
+  databaseMapper,
+  '"COMMERCE_QUERY_TEMPORARILY_UNAVAILABLE"',
+  'database safe code',
+);
+requireText(databaseMapper, '"Commerce data is temporarily unavailable"', 'database message');
+
+requireText(commerceMapper, 'match &error {', 'borrowed commerce policy selection');
+requireText(commerceMapper, 'owner = "rustok_commerce"', 'commerce owner');
 for (const value of [
-  'Error::new(error.to_string())',
-  'Error::new(err.to_string())',
-  'Error::new(format!("{error}"))',
-]) forbidText(facade, value, 'facade dynamic public constructor');
+  'crate::CommerceError::Database(_)',
+  '"COMMERCE_QUERY_TEMPORARILY_UNAVAILABLE"',
+  '"COMMERCE_QUERY_OPERATION_FAILED"',
+]) requireText(commerceMapper, value, 'commerce policy');
+requireBefore(
+  commerceMapper,
+  'let (message, code, retryable, error_kind) = match &error',
+  'let error = QueryDiagnosticError;',
+  'commerce policy before projection',
+);
 
 for (const [value, label] of [
   ['FulfillmentError::Validation(_)', 'fulfillment validation'],
@@ -100,10 +179,14 @@ for (const [value, label] of [
   ['"FULFILLMENT_RESOURCE_NOT_FOUND"', 'fulfillment not-found code'],
   ['"FULFILLMENT_STATE_CONFLICT"', 'fulfillment conflict code'],
   ['"FULFILLMENT_TEMPORARILY_UNAVAILABLE"', 'fulfillment unavailable code'],
-  ['"FULFILLMENT_ACCESS_DENIED"', 'fulfillment forbidden code'],
-  ['"FULFILLMENT_OPERATION_FAILED"', 'fulfillment invariant code'],
+  ['owner = "rustok_fulfillment"', 'fulfillment owner'],
+]) requireText(fulfillmentMapper, value, label);
+
+for (const [value, label] of [
   ['OrderError::Validation(_)', 'order validation'],
   ['OrderError::OrderNotFound(_)', 'order not-found'],
+  ['OrderError::OrderReturnNotFound(_)', 'return not-found'],
+  ['OrderError::OrderChangeNotFound(_)', 'change not-found'],
   ['OrderError::InvalidTransition { .. }', 'order conflict'],
   ['OrderError::Database(_)', 'order unavailable'],
   ['OrderError::Core(_)', 'order internal'],
@@ -112,6 +195,10 @@ for (const [value, label] of [
   ['"ORDER_STATE_CONFLICT"', 'order conflict code'],
   ['"ORDER_TEMPORARILY_UNAVAILABLE"', 'order unavailable code'],
   ['"ORDER_OPERATION_FAILED"', 'order internal code'],
+  ['owner = "rustok_order"', 'order owner'],
+]) requireText(orderMapper, value, label);
+
+for (const [value, label] of [
   ['PaymentError::Validation(_)', 'payment validation'],
   ['PaymentError::PaymentCollectionNotFound(_)', 'payment collection not-found'],
   ['PaymentError::PaymentNotFound(_)', 'payment not-found'],
@@ -127,7 +214,8 @@ for (const [value, label] of [
   ['"PAYMENT_TEMPORARILY_UNAVAILABLE"', 'payment unavailable code'],
   ['"PAYMENT_RECONCILIATION_REQUIRED"', 'payment reconciliation code'],
   ['"PAYMENT_CONFIGURATION_ERROR"', 'payment configuration code'],
-]) requireText(facade, value, label);
+  ['owner = "rustok_payment"', 'payment owner'],
+]) requireText(paymentMapper, value, label);
 
 for (const [ownerSource, value, label] of [
   [orderErrors, 'OrderNotFound(Uuid)', 'owner order not-found'],
@@ -139,6 +227,29 @@ for (const [ownerSource, value, label] of [
   [fulfillmentErrors, 'ShippingOptionNotFound(Uuid)', 'owner option not-found'],
   [fulfillmentErrors, 'FulfillmentNotFound(Uuid)', 'owner fulfillment not-found'],
 ]) requireText(ownerSource, value, label);
+
+for (const value of [
+  'BoundaryError::Graphql(error) => error',
+  'BoundaryError::Graphql(Error::new(self))',
+  '<::async_graphql::FieldError as ::rustok_api::graphql::GraphQLError>::unauthenticated()',
+  '<::async_graphql::FieldError as ::rustok_api::graphql::GraphQLError>::permission_denied(message)',
+  '::rustok_api::graphql::require_module_enabled(ctx, module_slug)',
+  'pub(crate) const MODULE_SLUG: &str = super::MODULE_SLUG;',
+  'pub(crate) const PRODUCT_MODULE_SLUG: &str = super::PRODUCT_MODULE_SLUG;',
+  'pub(crate) fn map_product_service_error(',
+  'pub(crate) fn product_query_tenant(',
+  'pub(crate) fn require_commerce_permission(',
+  'pub(crate) async fn require_storefront_channel_enabled(',
+  'mod source;',
+  'include!("../query.rs");',
+  'pub use source::CommerceQuery;',
+]) requireText(facade, value, 'existing GraphQL preservation');
+
+for (const value of [
+  'Error::new(error.to_string())',
+  'Error::new(err.to_string())',
+  'Error::new(format!("{error}"))',
+]) forbidText(facade, value, 'facade dynamic public constructor');
 
 for (const value of [
   'async fn storefront_returns(',
@@ -164,10 +275,26 @@ const dynamicSites = dynamicPatterns.reduce(
   (total, pattern) => total + (source.match(pattern) ?? []).length,
   0,
 );
-if (dynamicSites < 10) failures.push(`expected unchanged resolver compatibility sites, found ${dynamicSites}`);
+if (dynamicSites < 10) {
+  failures.push(`expected unchanged resolver compatibility sites, found ${dynamicSites}`);
+}
 if ((facade.match(/include!\("\.\.\/query\.rs"\)/g) ?? []).length !== 1) {
   failures.push('expected one unchanged query source include');
 }
+
+const shadows = boundary.match(/let error = QueryDiagnosticError;/g) ?? [];
+if (shadows.length !== 6) {
+  failures.push(`expected six diagnostic shadows, found ${shadows.length}`);
+}
+if ((boundary.match(/error = \?error/g) ?? []).length !== 6) {
+  failures.push('expected six redacted diagnostic error fields');
+}
+for (const value of [
+  'error_message = %self',
+  'error = ?_error',
+  'error = ?self',
+  'boundary = "commerce_graphql_query"',
+]) forbidText(boundary, value, 'unsafe or duplicated diagnostic source');
 
 for (const code of [
   'COMMERCE_QUERY_TEMPORARILY_UNAVAILABLE',
@@ -176,18 +303,20 @@ for (const code of [
   'PAYMENT_TEMPORARILY_UNAVAILABLE',
 ]) {
   const policy = new RegExp(`"${code}"[\\s\\S]{0,80}true`);
-  if (!policy.test(facade)) failures.push(`retryable temporary envelope missing for ${code}`);
+  if (!policy.test(boundary)) {
+    failures.push(`retryable temporary envelope missing for ${code}`);
+  }
 }
-if (!/"PAYMENT_RECONCILIATION_REQUIRED"[\s\S]{0,80}false/.test(facade)) {
+if (!/"PAYMENT_RECONCILIATION_REQUIRED"[\s\S]{0,80}false/.test(boundary)) {
   failures.push('non-retryable reconciliation envelope missing');
 }
 
 if (failures.length > 0) {
-  console.error('Commerce GraphQL query error-boundary verification failed:');
+  console.error('Commerce GraphQL query diagnostic-safety verification failed:');
   for (const failure of failures) console.error(`✗ ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
 
 console.log(
-  '✔ Commerce GraphQL query errors remain isolated behind stable typed envelopes while query.rs stays unchanged',
+  '✔ Commerce GraphQL query errors retain stable envelopes and emit bounded redacted diagnostics',
 );


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce correlation-safe mapper cleanup at the Commerce GraphQL safe-query boundary.

- preserve the existing stable GraphQL public messages, extension codes, and retryability policies;
- preserve `BoundaryError::Graphql` pass-through, static `&str` handling, product mapper delegation, and unchanged resolver source inclusion;
- stop logging dynamic compatibility strings and complete SeaORM, Commerce, Fulfillment, Order, and Payment errors;
- retain typed owner errors through existing public-policy selection;
- shadow all six diagnostic values before `tracing::error!` with a type whose `Debug` output is always `redacted`;
- emit only dynamic-message presence and byte length instead of message content;
- preserve stable owner, error-kind, public-code, retryability, boundary, and event-message fields;
- update the focused fail-closed source verifier;
- add source-only evidence and documentation while leaving request-scoped GraphQL correlation context and the broad ecommerce cleanup open.

## Recheck

Current `main` includes the Admin Product, Fulfillment, Payment, Shipping, Return Completion, and Fulfillment Reconciliation safety slices. The GraphQL safe-query boundary still emitted dynamic strings, database causes, provider details, transition details, and complete typed owner errors. No open PR overlaps this Commerce boundary.

The branch starts from `main@e8253de72d3619b03704a2b4f75ed31a1aa8fae4` and changes four intended files.

## Preserved behavior

- unchanged Commerce query resolver source;
- unchanged query module routing and source inclusion;
- existing authentication, permission, module, tenant, and channel helpers;
- GraphQL pass-through for already-constructed errors;
- static message construction for `&str`;
- public messages, codes, and retryability values for database, Commerce, Fulfillment, Order, and Payment failures;
- retryable temporarily-unavailable policies;
- non-retryable payment reconciliation policy;
- product-service error mapper delegation.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Node verifiers;
- Cargo checks, builds, clippy, or formatting;
- mounted GraphQL execution;
- workflows or CI.

Execution evidence remains pending. Request-scoped tenant, actor, channel, locale, correlation, and deadline propagation into this conversion boundary remains open, and the broad ecommerce cleanup remains open.