### PR TITLE
fix(commerce): bound GraphQL channel diagnostics

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/graphql-channel-diagnostic-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/graphql-channel-diagnostic-safety-source-review.json
@@ -1,0 +1,42 @@
+{
+  "status": "commerce_graphql_channel_diagnostic_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-commerce/src/graphql/mod.rs",
+    "scripts/verify/verify-commerce-graphql-root-error-safety.mjs",
+    "crates/rustok-commerce/docs/graphql-channel-diagnostic-safety.md",
+    "crates/rustok-commerce/docs/implementation-plan.md"
+  ],
+  "source_contract": {
+    "storage_error_payload_logged": false,
+    "raw_tenant_uuid_logged": false,
+    "raw_channel_uuid_logged": false,
+    "raw_channel_slug_logged": false,
+    "diagnostic_error_debug_redacted": true,
+    "tenant_uuid_shape_logged": true,
+    "optional_channel_uuid_shape_logged": true,
+    "optional_channel_slug_shape_logged": true,
+    "dependency_error_event_bounded": true,
+    "disabled_channel_warning_bounded": true,
+    "channel_owner_call_preserved": true,
+    "request_context_optional_behavior_preserved": true,
+    "availability_public_message_preserved": true,
+    "disabled_public_message_preserved": true,
+    "module_not_enabled_code_preserved": true,
+    "product_mapper_delegation_preserved": true,
+    "query_routing_preserved": true,
+    "broad_ecommerce_cleanup_closed": false,
+    "runtime_evidence_claimed": false
+  },
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, workflows, mounted GraphQL scenarios, or CI were executed."
+}

--- a/crates/rustok-commerce/docs/graphql-channel-diagnostic-safety.md
+++ b/crates/rustok-commerce/docs/graphql-channel-diagnostic-safety.md
@@ -1,0 +1,56 @@
+# GraphQL channel diagnostic safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens the Commerce GraphQL storefront-channel admission boundary in `crates/rustok-commerce/src/graphql/mod.rs`.
+
+The boundary performs one owner call to determine whether Commerce is enabled for the request channel. Before this change, its dependency-failure event logged the complete storage error together with the raw tenant UUID, optional channel UUID, and optional channel slug. Its disabled-channel warning logged the same request identities.
+
+## Bounded projection
+
+The root now creates one diagnostic context from the existing `RequestContext`:
+
+- tenant UUID becomes `nil` / `non_nil`;
+- optional channel UUID becomes `absent` / `present_nil` / `present_non_nil`;
+- optional channel slug becomes `absent` / `empty` / `present`.
+
+The dependency failure discards the storage cause before logging and shadows it with a diagnostic type whose `Debug` output is always `redacted`.
+
+Both the dependency-error event and disabled-channel warning retain only stable owner, operation, error kind, public code, retryability, boundary, event message, and the closed identity shapes above.
+
+## Preserved GraphQL behavior
+
+This work does not change:
+
+- optional `RequestContext` compatibility;
+- `DatabaseConnection` resolution;
+- `is_module_enabled_for_request_channel` ownership or arguments;
+- the module slug;
+- the public dependency-failure message `Commerce availability could not be verified`;
+- the disabled-channel message `Commerce is not enabled for the current channel`;
+- the `MODULE_NOT_ENABLED` GraphQL extension;
+- Commerce query-root composition, mutation exports, or routing;
+- Product public-error delegation and correlation extension behavior.
+
+The additional `COMMERCE_AVAILABILITY_UNAVAILABLE` value is diagnostic metadata only and is not added to the public GraphQL envelope.
+
+## Verifier correction
+
+The previous root verifier expected raw internal and request identity logging. It also expected inline Product `CommerceError` variant matching that no longer exists in this root because Product public mapping is delegated to `rustok_product::map_product_public_error`.
+
+The updated verifier follows the current source architecture and fails closed on raw channel diagnostics.
+
+## Remaining boundary
+
+The broad ecommerce correlation-safe mapper and non-`PortError` cleanup remains open. Storefront shared context/customer/channel mappers, storefront cart shipping, tax, promotion, remaining owner adapters, native transports, and runtime evidence are not completed by this slice.
+
+## Evidence
+
+- `crates/rustok-commerce/contracts/evidence/graphql-channel-diagnostic-safety-source-review.json`
+- `scripts/verify/verify-commerce-graphql-root-error-safety.mjs`
+
+## Validation disclosure
+
+No tests, Node verifiers, formatting, Cargo commands, mounted GraphQL scenarios, workflows, or CI were run. No compile, runtime, FFA, or FBA status is promoted.

--- a/crates/rustok-commerce/src/graphql/mod.rs
+++ b/crates/rustok-commerce/src/graphql/mod.rs
@@ -21,6 +21,55 @@ pub use marketplace_financial::{
 pub use mutations::CommerceMutation;
 pub use types::*;
 
+const COMMERCE_GRAPHQL_CHANNEL_OWNER: &str = "rustok_commerce.storefront_channel";
+const COMMERCE_GRAPHQL_CHANNEL_BOUNDARY: &str = "commerce_graphql_channel_admission";
+const COMMERCE_GRAPHQL_CHANNEL_OPERATION: &str = "require_storefront_channel_enabled";
+
+#[derive(Clone, Copy)]
+struct CommerceGraphqlChannelDiagnosticContext {
+    tenant_id_shape: &'static str,
+    channel_id_shape: &'static str,
+    channel_slug_shape: &'static str,
+}
+
+impl From<&RequestContext> for CommerceGraphqlChannelDiagnosticContext {
+    fn from(context: &RequestContext) -> Self {
+        Self {
+            tenant_id_shape: uuid_shape(context.tenant_id),
+            channel_id_shape: optional_uuid_shape(context.channel_id),
+            channel_slug_shape: optional_text_shape(context.channel_slug.as_deref()),
+        }
+    }
+}
+
+struct CommerceGraphqlChannelDiagnosticError;
+
+impl std::fmt::Debug for CommerceGraphqlChannelDiagnosticError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("redacted")
+    }
+}
+
+fn uuid_shape(value: uuid::Uuid) -> &'static str {
+    if value.is_nil() { "nil" } else { "non_nil" }
+}
+
+fn optional_uuid_shape(value: Option<uuid::Uuid>) -> &'static str {
+    match value {
+        None => "absent",
+        Some(value) if value.is_nil() => "present_nil",
+        Some(_) => "present_non_nil",
+    }
+}
+
+fn optional_text_shape(value: Option<&str>) -> &'static str {
+    match value {
+        None => "absent",
+        Some(value) if value.is_empty() => "empty",
+        Some(_) => "present",
+    }
+}
+
 #[derive(MergedObject, Default)]
 pub struct CommerceQueryRoot(
     query::CommerceQuery,
@@ -131,16 +180,23 @@ pub(crate) async fn require_storefront_channel_enabled(ctx: &Context<'_>) -> Res
         return Ok(());
     };
 
+    let diagnostic_context = CommerceGraphqlChannelDiagnosticContext::from(request_context);
     let db = ctx.data::<DatabaseConnection>()?;
     let enabled = is_module_enabled_for_request_channel(db, request_context, MODULE_SLUG)
         .await
-        .map_err(|error| {
+        .map_err(|_error| {
+            let error = CommerceGraphqlChannelDiagnosticError;
             tracing::error!(
                 error = ?error,
-                tenant_id = %request_context.tenant_id,
-                channel_id = ?request_context.channel_id,
-                channel_slug = ?request_context.channel_slug,
-                operation = "require_storefront_channel_enabled",
+                owner = COMMERCE_GRAPHQL_CHANNEL_OWNER,
+                tenant_id_shape = diagnostic_context.tenant_id_shape,
+                channel_id_shape = diagnostic_context.channel_id_shape,
+                channel_slug_shape = diagnostic_context.channel_slug_shape,
+                operation = COMMERCE_GRAPHQL_CHANNEL_OPERATION,
+                error_kind = "storage",
+                public_code = "COMMERCE_AVAILABILITY_UNAVAILABLE",
+                retryable = true,
+                boundary = COMMERCE_GRAPHQL_CHANNEL_BOUNDARY,
                 "commerce GraphQL channel module check failed"
             );
             <FieldError as GraphQLError>::internal_error(
@@ -150,10 +206,15 @@ pub(crate) async fn require_storefront_channel_enabled(ctx: &Context<'_>) -> Res
 
     if !enabled {
         tracing::warn!(
-            tenant_id = %request_context.tenant_id,
-            channel_id = ?request_context.channel_id,
-            channel_slug = ?request_context.channel_slug,
-            operation = "require_storefront_channel_enabled",
+            owner = COMMERCE_GRAPHQL_CHANNEL_OWNER,
+            tenant_id_shape = diagnostic_context.tenant_id_shape,
+            channel_id_shape = diagnostic_context.channel_id_shape,
+            channel_slug_shape = diagnostic_context.channel_slug_shape,
+            operation = COMMERCE_GRAPHQL_CHANNEL_OPERATION,
+            error_kind = "module_disabled",
+            public_code = "MODULE_NOT_ENABLED",
+            retryable = false,
+            boundary = COMMERCE_GRAPHQL_CHANNEL_BOUNDARY,
             "commerce GraphQL module is disabled for the request channel"
         );
         return Err(

--- a/scripts/verify/verify-commerce-graphql-root-error-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-root-error-safety.mjs
@@ -14,80 +14,173 @@ const source = readFileSync(
 );
 const failures = [];
 
-const requireText = (value, label) => {
-  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
 };
-const forbidText = (value, label) => {
-  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+const requireBefore = (content, first, second, label) => {
+  const firstIndex = content.indexOf(first);
+  const secondIndex = content.indexOf(second);
+  if (firstIndex < 0 || secondIndex < 0 || firstIndex > secondIndex) {
+    failures.push(`${label}: ${first} must precede ${second}`);
+  }
 };
 
-for (const value of [
-  'use rustok_core::error::RichError;',
-  'let rich: RichError = error.into();',
-  '.user_message',
-  '"Module check failed: {err}"',
-  'format!("Module check failed: {err}")',
-  '"Module \'{MODULE_SLUG}\' is not enabled for channel',
-  'request_context.channel_slug.as_deref().unwrap_or("current")',
-]) {
-  forbidText(value, 'commerce GraphQL root public error mapping');
-}
+const productMapper = between(
+  source,
+  'pub(crate) fn map_product_service_error(',
+  'pub(crate) fn current_tenant_scope(',
+  'product mapper',
+);
+const channelAdmission = between(
+  source,
+  'pub(crate) async fn require_storefront_channel_enabled(',
+  '#[cfg(test)]',
+  'channel admission',
+);
 
 for (const [value, label] of [
-  ['use rustok_commerce_foundation::CommerceError;', 'commerce error variant mapping'],
-  ['CommerceError::Database(_)', 'database mapping'],
-  ['CommerceError::ProductNotFound(_)', 'product not-found mapping'],
-  ['CommerceError::VariantNotFound(_)', 'variant not-found mapping'],
-  ['CommerceError::DuplicateHandle { .. }', 'duplicate handle mapping'],
-  ['CommerceError::DuplicateSku(_)', 'duplicate SKU mapping'],
-  ['CommerceError::InvalidPrice(_)', 'invalid price mapping'],
-  ['CommerceError::InsufficientInventory { .. }', 'inventory mapping'],
-  ['CommerceError::InvalidOptionCombination', 'option mapping'],
-  ['CommerceError::Validation(_)', 'validation mapping'],
-  ['CommerceError::ShippingProfileNotFound(_)', 'shipping profile mapping'],
-  ['CommerceError::DuplicateShippingProfileSlug(_)', 'shipping slug mapping'],
-  ['CommerceError::NoVariants', 'no variants mapping'],
-  ['CommerceError::CannotDeletePublished', 'published product mapping'],
-  ['CommerceError::Rich(_) | CommerceError::Core(_)', 'safe fallback mapping'],
-  ['"Product data is temporarily unavailable"', 'stable product storage message'],
-  ['"Product was not found"', 'stable product not-found message'],
-  ['"Product variant was not found"', 'stable variant not-found message'],
+  ['#[path = "safe_query.rs"]\nmod query;', 'safe query routing'],
+  ['pub struct CommerceQueryRoot(', 'query root'],
+  ['pub use mutations::CommerceMutation;', 'mutation export'],
+  ['pub(crate) const MODULE_SLUG: &str = "commerce";', 'module slug'],
+  ['pub(crate) const PRODUCT_MODULE_SLUG: &str = "product";', 'product module slug'],
   [
-    '"Product handle conflicts with an existing product"',
-    'stable duplicate handle message',
+    'const COMMERCE_GRAPHQL_CHANNEL_OWNER: &str = "rustok_commerce.storefront_channel";',
+    'channel owner',
   ],
-  ['"Product request is invalid"', 'stable validation message'],
   [
-    '"Product operation could not be completed safely"',
-    'stable product fallback message',
+    'const COMMERCE_GRAPHQL_CHANNEL_BOUNDARY: &str = "commerce_graphql_channel_admission";',
+    'channel boundary',
   ],
-  ['error = ?error', 'internal cause logging'],
-  ['tenant_id = %request_context.tenant_id', 'channel tenant logging'],
-  ['channel_id = ?request_context.channel_id', 'channel id logging'],
-  ['channel_slug = ?request_context.channel_slug', 'channel slug logging'],
   [
-    'operation = "require_storefront_channel_enabled"',
-    'channel operation logging',
+    'const COMMERCE_GRAPHQL_CHANNEL_OPERATION: &str = "require_storefront_channel_enabled";',
+    'channel operation',
   ],
+  ['struct CommerceGraphqlChannelDiagnosticContext', 'diagnostic context'],
+  ['impl From<&RequestContext> for CommerceGraphqlChannelDiagnosticContext', 'context projection'],
+  ['tenant_id_shape: uuid_shape(context.tenant_id)', 'tenant UUID shape'],
+  ['channel_id_shape: optional_uuid_shape(context.channel_id)', 'channel UUID shape'],
+  [
+    'channel_slug_shape: optional_text_shape(context.channel_slug.as_deref())',
+    'channel slug shape',
+  ],
+  ['struct CommerceGraphqlChannelDiagnosticError;', 'diagnostic error'],
+  ['formatter.write_str("redacted")', 'redacted Debug'],
+  ['fn uuid_shape(value: uuid::Uuid)', 'UUID shape helper'],
+  ['fn optional_uuid_shape(value: Option<uuid::Uuid>)', 'optional UUID shape helper'],
+  ['fn optional_text_shape(value: Option<&str>)', 'optional text shape helper'],
+]) requireText(source, value, label);
+
+for (const [value, label] of [
+  [
+    'rustok_product::map_product_public_error(&error, operation, "commerce_graphql_product")',
+    'owner product mapping',
+  ],
+  ['async_graphql::Error::new(public.message)', 'product public message'],
+  ['extensions.set("code", public.code)', 'product public code'],
+  ['extensions.set("retryable", public.retryable)', 'product retryability'],
+  [
+    'extensions.set("correlation_id", public.correlation_id.to_string())',
+    'product correlation extension',
+  ],
+]) requireText(productMapper, value, label);
+
+for (const [value, label] of [
+  ['let Some(request_context) = ctx.data_opt::<RequestContext>() else', 'optional request context'],
+  ['return Ok(());', 'context-free compatibility'],
+  [
+    'let diagnostic_context = CommerceGraphqlChannelDiagnosticContext::from(request_context);',
+    'diagnostic projection',
+  ],
+  ['let db = ctx.data::<DatabaseConnection>()?;', 'database dependency'],
+  [
+    'is_module_enabled_for_request_channel(db, request_context, MODULE_SLUG)',
+    'channel owner call',
+  ],
+  ['.map_err(|_error| {', 'discarded storage cause'],
+  ['let error = CommerceGraphqlChannelDiagnosticError;', 'redacted error shadow'],
+  ['error = ?error', 'redacted error field'],
+  ['owner = COMMERCE_GRAPHQL_CHANNEL_OWNER', 'owner log field'],
+  ['tenant_id_shape = diagnostic_context.tenant_id_shape', 'tenant shape log'],
+  ['channel_id_shape = diagnostic_context.channel_id_shape', 'channel ID shape log'],
+  ['channel_slug_shape = diagnostic_context.channel_slug_shape', 'channel slug shape log'],
+  ['operation = COMMERCE_GRAPHQL_CHANNEL_OPERATION', 'operation log'],
+  ['error_kind = "storage"', 'storage error kind'],
+  ['public_code = "COMMERCE_AVAILABILITY_UNAVAILABLE"', 'storage public code'],
+  ['retryable = true', 'storage retryability'],
+  ['boundary = COMMERCE_GRAPHQL_CHANNEL_BOUNDARY', 'storage boundary'],
   [
     '"Commerce availability could not be verified"',
-    'stable channel dependency message',
+    'stable availability message',
   ],
+  ['if !enabled {', 'disabled policy'],
+  ['tracing::warn!(', 'disabled warning'],
+  ['error_kind = "module_disabled"', 'disabled error kind'],
+  ['public_code = "MODULE_NOT_ENABLED"', 'disabled public code log'],
+  ['retryable = false', 'disabled retryability'],
   [
-    '"Commerce is not enabled for the current channel"',
-    'stable disabled-channel message',
+    'async_graphql::Error::new("Commerce is not enabled for the current channel")',
+    'stable disabled message',
   ],
-  ['ext.set("code", "MODULE_NOT_ENABLED")', 'stable disabled-channel code'],
-]) {
-  requireText(value, label);
+  ['ext.set("code", "MODULE_NOT_ENABLED")', 'stable disabled code'],
+]) requireText(channelAdmission, value, label);
+
+requireBefore(
+  channelAdmission,
+  'let diagnostic_context = CommerceGraphqlChannelDiagnosticContext::from(request_context);',
+  'is_module_enabled_for_request_channel(db, request_context, MODULE_SLUG)',
+  'projection before owner call',
+);
+requireBefore(
+  channelAdmission,
+  'let error = CommerceGraphqlChannelDiagnosticError;',
+  'tracing::error!(',
+  'error shadow before diagnostic event',
+);
+
+for (const value of [
+  'error = ?_error',
+  'error = ?error,\n                tenant_id =',
+  'tenant_id = %request_context.tenant_id',
+  'channel_id = ?request_context.channel_id',
+  'channel_slug = ?request_context.channel_slug',
+  'channel_slug = %request_context.channel_slug',
+  'tenant_id_shape = %request_context.tenant_id',
+  'channel_id_shape = ?request_context.channel_id',
+  'channel_slug_shape = ?request_context.channel_slug',
+  '"Module check failed: {err}"',
+  'format!("Module check failed: {err}")',
+  'request_context.channel_slug.as_deref().unwrap_or("current")',
+]) forbidText(channelAdmission, value, 'raw channel diagnostic or dynamic public error');
+
+if ((channelAdmission.match(/tracing::error!\(/g) ?? []).length !== 1) {
+  failures.push('expected one channel dependency error event');
+}
+if ((channelAdmission.match(/tracing::warn!\(/g) ?? []).length !== 1) {
+  failures.push('expected one disabled-channel warning event');
+}
+if ((channelAdmission.match(/boundary = COMMERCE_GRAPHQL_CHANNEL_BOUNDARY/g) ?? []).length !== 2) {
+  failures.push('expected both channel events to use the bounded boundary');
 }
 
 if (failures.length > 0) {
-  console.error('Commerce GraphQL root error safety verification failed:');
+  console.error('Commerce GraphQL root diagnostic-safety verification failed:');
   for (const failure of failures) console.error(`✗ ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
 
 console.log(
-  '✔ Commerce GraphQL root errors keep technical and identifying details in structured logs and expose stable public envelopes',
+  '✔ Commerce GraphQL channel admission keeps stable envelopes and emits bounded redacted diagnostics',
 );


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce correlation-safe mapper cleanup at the Commerce GraphQL storefront-channel admission boundary.

- preserve the existing optional `RequestContext` compatibility and channel owner call;
- preserve the dependency-failure and disabled-channel public GraphQL envelopes;
- stop logging the complete storage error, raw tenant UUID, raw optional channel UUID, and raw optional channel slug;
- project tenant identity to `nil` / `non_nil`;
- project optional channel identity to `absent` / `present_nil` / `present_non_nil`;
- project optional channel slug to `absent` / `empty` / `present`;
- shadow the storage error with a diagnostic type whose `Debug` output is always `redacted`;
- retain stable owner, operation, error kind, public code, retryability, boundary, and event messages;
- correct the focused root verifier to the current owner-delegated Product architecture and fail closed on raw channel diagnostics;
- add source-only evidence and documentation while leaving the broad ecommerce cleanup open.

## Recheck

Current `main` includes the Admin Product, Fulfillment, Payment, Shipping, Return Completion, Fulfillment Reconciliation, GraphQL safe-query diagnostic, and unrelated Page Builder slices. The Commerce GraphQL root still emitted raw channel request identity and the complete module-check storage error. No open PR overlaps this boundary.

The branch starts from `main@78ea5461d2ff8f071318ef23e6fa08aa6aea2f94` and changes four intended files.

## Preserved behavior

- Commerce query-root composition and mutation exports;
- safe-query routing;
- optional request-context behavior;
- `DatabaseConnection` resolution;
- `is_module_enabled_for_request_channel` ownership, arguments, and module slug;
- public dependency-failure message `Commerce availability could not be verified`;
- public disabled-channel message `Commerce is not enabled for the current channel`;
- public `MODULE_NOT_ENABLED` extension;
- Product public-error owner delegation, code, retryability, and correlation extension.

`COMMERCE_AVAILABILITY_UNAVAILABLE` is diagnostic metadata only and is not added to the public GraphQL envelope.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Node verifiers;
- Cargo checks, builds, clippy, or formatting;
- mounted GraphQL execution;
- workflows or CI.

Execution evidence remains pending and the broad ecommerce cleanup remains open.