### PR TITLE
fix(commerce): bound GraphQL customer diagnostics

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/graphql-customer-diagnostic-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/graphql-customer-diagnostic-safety-source-review.json
@@ -1,0 +1,49 @@
+{
+  "status": "commerce_graphql_customer_diagnostic_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs",
+    "scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs",
+    "crates/rustok-commerce/docs/graphql-customer-diagnostic-safety.md",
+    "crates/rustok-commerce/docs/implementation-plan.md"
+  ],
+  "source_contract": {
+    "customer_port_error_payload_logged": false,
+    "customer_internal_message_logged": false,
+    "raw_tenant_identity_logged": false,
+    "raw_actor_identity_logged": false,
+    "raw_channel_logged": false,
+    "raw_locale_logged": false,
+    "raw_correlation_id_logged": false,
+    "raw_causation_id_logged": false,
+    "raw_traceparent_logged": false,
+    "raw_idempotency_key_logged": false,
+    "diagnostic_error_debug_redacted": true,
+    "owner_code_preserved": true,
+    "owner_kind_preserved": true,
+    "owner_retryability_preserved": true,
+    "owner_message_shape_logged": true,
+    "bounded_context_facts_logged": true,
+    "typed_public_policy_preserved": true,
+    "technical_error_severity_preserved": true,
+    "ordinary_rejection_severity_preserved": true,
+    "optional_customer_not_found_fallback_preserved": true,
+    "customer_owner_call_preserved": true,
+    "cart_mapper_cleanup_closed": false,
+    "legacy_helper_cleanup_closed": false,
+    "typed_line_item_cleanup_closed": false,
+    "broad_ecommerce_cleanup_closed": false,
+    "runtime_evidence_claimed": false
+  },
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, mounted GraphQL scenarios, workflows, or CI were executed."
+}

--- a/crates/rustok-commerce/docs/graphql-customer-diagnostic-safety.md
+++ b/crates/rustok-commerce/docs/graphql-customer-diagnostic-safety.md
@@ -1,0 +1,63 @@
+# GraphQL customer diagnostic safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens the customer-owner error mapper used by the Commerce GraphQL storefront cart helpers.
+
+The mapper already selected stable GraphQL messages, codes, retryability, and error/warn severity from `PortErrorKind`. Its diagnostic events still emitted the complete `PortError`, internal message, tenant identity, actor identity, channel, locale, correlation value, causation value, traceparent, and idempotency key.
+
+The constructed storefront customer correlation value includes the user UUID, so logging it verbatim would also disclose the actor identity.
+
+## Bounded diagnostic projection
+
+The mapper now preserves the original `PortError` only until public policy, severity, and safe owner facts are selected. It then shadows the error with a diagnostic type whose `Debug` output is always `redacted`.
+
+The diagnostic events retain:
+
+- truthful customer owner and owner operation;
+- consumer operation;
+- exact owner code, typed owner kind, and owner retryability;
+- owner-message `empty` / `present` shape and byte length;
+- tenant and actor identity shape without values;
+- actor kind;
+- claim and role counts;
+- channel, locale, correlation, causation, traceparent, and idempotency presence shapes;
+- deadline value;
+- public code, public retryability, shared boundary, and static event message.
+
+Identity strings are classified as `empty`, `uuid_nil`, `uuid_non_nil`, or `opaque`. Optional text is classified as `absent`, `empty`, or `present`.
+
+## Preserved GraphQL behavior
+
+This work does not change:
+
+- the customer owner call or request;
+- the two-second read deadline;
+- anonymous-customer behavior;
+- the owner-specific `customer.customer_by_user_not_found` fallback to `None`;
+- public messages and codes for validation, not-found, conflict, forbidden, unavailable/timeout, and invariant failures;
+- retryability values;
+- error severity for unavailable, timeout, and invariant failures;
+- warning severity for ordinary owner rejections.
+
+## Remaining helper work
+
+This slice does not close the complete storefront cart helper diagnostic boundary.
+
+Still open:
+
+- `cart_port_error`, which logs the complete Cart/Pricing `PortError`;
+- `legacy_graphql_error`, which logs the complete GraphQL error and raw tenant/resource UUIDs;
+- typed line-item diagnostics, which still log typed source payloads and raw product/variant/tenant context;
+- remaining storefront, tax, promotion, native transport, and owner-adapter cleanup.
+
+## Evidence
+
+- `crates/rustok-commerce/contracts/evidence/graphql-customer-diagnostic-safety-source-review.json`
+- `scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs`
+
+## Validation disclosure
+
+No tests, Node verifiers, formatting, Cargo commands, mounted GraphQL scenarios, workflows, or CI were run. No compile, runtime, FFA, or FBA status is promoted.

--- a/crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs
@@ -1,5 +1,7 @@
 use async_graphql::{ErrorExtensions, Result};
-use rustok_api::{AuthContext, PortActor, PortContext, PortError, PortErrorKind, RequestContext};
+use rustok_api::{
+    AuthContext, PortActor, PortActorKind, PortContext, PortError, PortErrorKind, RequestContext,
+};
 use rustok_cart::CartStorefrontPort;
 use rustok_customer::{CustomerUserProjectionRequest, in_process_customer_read_port};
 use rustok_pricing::{PriceResolutionContext, PricingReadPort};
@@ -11,6 +13,80 @@ pub(crate) use super::legacy_helpers::*;
 const STOREFRONT_CART_HELPER_BOUNDARY: &str = "commerce_graphql_storefront_cart_helper";
 const STOREFRONT_CUSTOMER_OWNER: &str = "rustok_customer";
 const STOREFRONT_CUSTOMER_OWNER_OPERATION: &str = "read_customer_projection_by_user";
+
+#[derive(Clone, Copy)]
+struct StorefrontCustomerDiagnosticContext {
+    tenant_id_shape: &'static str,
+    actor_kind: &'static str,
+    actor_id_shape: &'static str,
+    claim_count: usize,
+    role_count: usize,
+    channel_shape: &'static str,
+    locale_shape: &'static str,
+    correlation_id_shape: &'static str,
+    causation_id_shape: &'static str,
+    traceparent_shape: &'static str,
+    idempotency_key_shape: &'static str,
+    deadline_ms: Option<u64>,
+}
+
+impl From<&PortContext> for StorefrontCustomerDiagnosticContext {
+    fn from(context: &PortContext) -> Self {
+        Self {
+            tenant_id_shape: identity_text_shape(context.tenant_id.as_str()),
+            actor_kind: actor_kind_name(&context.actor.kind),
+            actor_id_shape: identity_text_shape(context.actor.id.as_str()),
+            claim_count: context.claims.len(),
+            role_count: context.roles.len(),
+            channel_shape: optional_text_shape(context.channel.as_deref()),
+            locale_shape: text_shape(context.locale.as_str()),
+            correlation_id_shape: text_shape(context.correlation_id.as_str()),
+            causation_id_shape: optional_text_shape(context.causation_id.as_deref()),
+            traceparent_shape: optional_text_shape(context.traceparent.as_deref()),
+            idempotency_key_shape: optional_text_shape(context.idempotency_key.as_deref()),
+            deadline_ms: context.deadline_ms,
+        }
+    }
+}
+
+struct StorefrontCustomerDiagnosticError;
+
+impl std::fmt::Debug for StorefrontCustomerDiagnosticError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("redacted")
+    }
+}
+
+fn actor_kind_name(kind: &PortActorKind) -> &'static str {
+    match kind {
+        PortActorKind::User => "user",
+        PortActorKind::Service => "service",
+        PortActorKind::System => "system",
+    }
+}
+
+fn identity_text_shape(value: &str) -> &'static str {
+    if value.is_empty() {
+        return "empty";
+    }
+    match Uuid::parse_str(value) {
+        Ok(value) if value.is_nil() => "uuid_nil",
+        Ok(_) => "uuid_non_nil",
+        Err(_) => "opaque",
+    }
+}
+
+fn text_shape(value: &str) -> &'static str {
+    if value.is_empty() { "empty" } else { "present" }
+}
+
+fn optional_text_shape(value: Option<&str>) -> &'static str {
+    match value {
+        None => "absent",
+        Some(value) if value.is_empty() => "empty",
+        Some(_) => "present",
+    }
+}
 
 fn public_graphql_error(
     message: &'static str,
@@ -67,57 +143,74 @@ fn customer_port_graphql_error(
         ),
     };
 
-    match &error.kind {
-        PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation => {
-            tracing::error!(
-                error = ?error,
-                owner = STOREFRONT_CUSTOMER_OWNER,
-                owner_operation = STOREFRONT_CUSTOMER_OWNER_OPERATION,
-                consumer_operation,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                actor = ?context.actor,
-                channel = ?context.channel,
-                locale = %context.locale,
-                causation_id = ?context.causation_id,
-                traceparent = ?context.traceparent,
-                idempotency_key = ?context.idempotency_key,
-                deadline_ms = ?context.deadline_ms,
-                internal_code = %error.code,
-                internal_message = %error.message,
-                error_kind = ?error.kind,
-                owner_retryable = error.retryable,
-                public_code = code,
-                public_retryable = retryable,
-                boundary = STOREFRONT_CART_HELPER_BOUNDARY,
-                "commerce GraphQL storefront customer owner port failed"
-            );
-        }
-        _ => {
-            tracing::warn!(
-                error = ?error,
-                owner = STOREFRONT_CUSTOMER_OWNER,
-                owner_operation = STOREFRONT_CUSTOMER_OWNER_OPERATION,
-                consumer_operation,
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                actor = ?context.actor,
-                channel = ?context.channel,
-                locale = %context.locale,
-                causation_id = ?context.causation_id,
-                traceparent = ?context.traceparent,
-                idempotency_key = ?context.idempotency_key,
-                deadline_ms = ?context.deadline_ms,
-                internal_code = %error.code,
-                internal_message = %error.message,
-                error_kind = ?error.kind,
-                owner_retryable = error.retryable,
-                public_code = code,
-                public_retryable = retryable,
-                boundary = STOREFRONT_CART_HELPER_BOUNDARY,
-                "commerce GraphQL storefront customer owner port was rejected"
-            );
-        }
+    let technical = matches!(
+        error.kind,
+        PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation
+    );
+    let diagnostic_context = StorefrontCustomerDiagnosticContext::from(context);
+    let owner_code = error.code.clone();
+    let owner_kind = error.kind.clone();
+    let owner_retryable = error.retryable;
+    let owner_message_shape = text_shape(error.message.as_str());
+    let owner_message_len = error.message.len();
+    let error = StorefrontCustomerDiagnosticError;
+
+    if technical {
+        tracing::error!(
+            error = ?error,
+            owner = STOREFRONT_CUSTOMER_OWNER,
+            owner_operation = STOREFRONT_CUSTOMER_OWNER_OPERATION,
+            consumer_operation,
+            tenant_id_shape = diagnostic_context.tenant_id_shape,
+            actor_kind = diagnostic_context.actor_kind,
+            actor_id_shape = diagnostic_context.actor_id_shape,
+            claim_count = diagnostic_context.claim_count,
+            role_count = diagnostic_context.role_count,
+            channel_shape = diagnostic_context.channel_shape,
+            locale_shape = diagnostic_context.locale_shape,
+            correlation_id_shape = diagnostic_context.correlation_id_shape,
+            causation_id_shape = diagnostic_context.causation_id_shape,
+            traceparent_shape = diagnostic_context.traceparent_shape,
+            idempotency_key_shape = diagnostic_context.idempotency_key_shape,
+            deadline_ms = ?diagnostic_context.deadline_ms,
+            owner_code = %owner_code,
+            owner_message_shape,
+            owner_message_len,
+            owner_kind = ?owner_kind,
+            owner_retryable,
+            public_code = code,
+            public_retryable = retryable,
+            boundary = STOREFRONT_CART_HELPER_BOUNDARY,
+            "commerce GraphQL storefront customer owner port failed"
+        );
+    } else {
+        tracing::warn!(
+            error = ?error,
+            owner = STOREFRONT_CUSTOMER_OWNER,
+            owner_operation = STOREFRONT_CUSTOMER_OWNER_OPERATION,
+            consumer_operation,
+            tenant_id_shape = diagnostic_context.tenant_id_shape,
+            actor_kind = diagnostic_context.actor_kind,
+            actor_id_shape = diagnostic_context.actor_id_shape,
+            claim_count = diagnostic_context.claim_count,
+            role_count = diagnostic_context.role_count,
+            channel_shape = diagnostic_context.channel_shape,
+            locale_shape = diagnostic_context.locale_shape,
+            correlation_id_shape = diagnostic_context.correlation_id_shape,
+            causation_id_shape = diagnostic_context.causation_id_shape,
+            traceparent_shape = diagnostic_context.traceparent_shape,
+            idempotency_key_shape = diagnostic_context.idempotency_key_shape,
+            deadline_ms = ?diagnostic_context.deadline_ms,
+            owner_code = %owner_code,
+            owner_message_shape,
+            owner_message_len,
+            owner_kind = ?owner_kind,
+            owner_retryable,
+            public_code = code,
+            public_retryable = retryable,
+            boundary = STOREFRONT_CART_HELPER_BOUNDARY,
+            "commerce GraphQL storefront customer owner port was rejected"
+        );
     }
 
     public_graphql_error(message, code, retryable)

--- a/crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs
@@ -144,7 +144,7 @@ fn customer_port_graphql_error(
     };
 
     let technical = matches!(
-        error.kind,
+        &error.kind,
         PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation
     );
     let diagnostic_context = StorefrontCustomerDiagnosticContext::from(context);

--- a/scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
@@ -94,6 +94,7 @@ for (const value of [
 }
 
 for (const [value, label] of [
+  ['PortActorKind', 'actor kind import'],
   ['PortError, PortErrorKind', 'port error imports'],
   [
     'const STOREFRONT_CART_HELPER_BOUNDARY: &str = "commerce_graphql_storefront_cart_helper";',
@@ -104,6 +105,38 @@ for (const [value, label] of [
     'const STOREFRONT_CUSTOMER_OWNER_OPERATION: &str = "read_customer_projection_by_user";',
     'exact customer owner operation',
   ],
+  ['struct StorefrontCustomerDiagnosticContext', 'bounded customer context'],
+  ['impl From<&PortContext> for StorefrontCustomerDiagnosticContext', 'customer context projection'],
+  ['tenant_id_shape: identity_text_shape(context.tenant_id.as_str())', 'tenant identity shape'],
+  ['actor_kind: actor_kind_name(&context.actor.kind)', 'actor kind projection'],
+  ['actor_id_shape: identity_text_shape(context.actor.id.as_str())', 'actor identity shape'],
+  ['claim_count: context.claims.len()', 'claim count'],
+  ['role_count: context.roles.len()', 'role count'],
+  ['channel_shape: optional_text_shape(context.channel.as_deref())', 'channel shape'],
+  ['locale_shape: text_shape(context.locale.as_str())', 'locale shape'],
+  [
+    'correlation_id_shape: text_shape(context.correlation_id.as_str())',
+    'correlation shape',
+  ],
+  [
+    'causation_id_shape: optional_text_shape(context.causation_id.as_deref())',
+    'causation shape',
+  ],
+  [
+    'traceparent_shape: optional_text_shape(context.traceparent.as_deref())',
+    'trace shape',
+  ],
+  [
+    'idempotency_key_shape: optional_text_shape(context.idempotency_key.as_deref())',
+    'idempotency shape',
+  ],
+  ['deadline_ms: context.deadline_ms', 'deadline fact'],
+  ['struct StorefrontCustomerDiagnosticError;', 'redacted customer diagnostic error'],
+  ['formatter.write_str("redacted")', 'redacted customer Debug'],
+  ['fn actor_kind_name(kind: &PortActorKind)', 'actor kind helper'],
+  ['fn identity_text_shape(value: &str)', 'identity shape helper'],
+  ['fn text_shape(value: &str)', 'text shape helper'],
+  ['fn optional_text_shape(value: Option<&str>)', 'optional text shape helper'],
   ['fn customer_port_graphql_error(', 'customer mapper'],
   ['fn cart_port_source_owner(', 'cart source-owner classifier'],
   ['pub(crate) fn cart_port_error(', 'cart mapper'],
@@ -140,29 +173,51 @@ for (const [value, label] of [
   ['"CUSTOMER_ACCESS_DENIED"', 'customer forbidden code'],
   ['"CUSTOMER_TEMPORARILY_UNAVAILABLE"', 'customer availability code'],
   ['"CUSTOMER_OPERATION_FAILED"', 'customer invariant code'],
+  ['let technical = matches!(', 'technical severity selection'],
   [
     'PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation',
     'technical customer severity classification',
   ],
+  [
+    'let diagnostic_context = StorefrontCustomerDiagnosticContext::from(context);',
+    'bounded customer context projection',
+  ],
+  ['let owner_code = error.code.clone();', 'retained owner code'],
+  ['let owner_kind = error.kind.clone();', 'retained owner kind'],
+  ['let owner_retryable = error.retryable;', 'retained owner retryability'],
+  ['let owner_message_shape = text_shape(error.message.as_str());', 'owner message shape'],
+  ['let owner_message_len = error.message.len();', 'owner message length'],
+  ['let error = StorefrontCustomerDiagnosticError;', 'customer diagnostic shadow'],
+  ['if technical {', 'technical branch'],
   ['tracing::error!(', 'technical customer error severity'],
   ['tracing::warn!(', 'ordinary customer rejection severity'],
-  ['error = ?error', 'original customer error evidence'],
+  ['error = ?error', 'redacted customer error field'],
   ['owner = STOREFRONT_CUSTOMER_OWNER', 'truthful customer owner field'],
   ['owner_operation = STOREFRONT_CUSTOMER_OWNER_OPERATION', 'exact owner operation field'],
   ['consumer_operation,', 'consumer operation field'],
-  ['correlation_id = %context.correlation_id', 'customer correlation context'],
-  ['tenant_id = %context.tenant_id', 'customer tenant context'],
-  ['actor = ?context.actor', 'customer actor context'],
-  ['channel = ?context.channel', 'customer channel context'],
-  ['locale = %context.locale', 'customer locale context'],
-  ['causation_id = ?context.causation_id', 'customer causation context'],
-  ['traceparent = ?context.traceparent', 'customer trace context'],
-  ['idempotency_key = ?context.idempotency_key', 'customer idempotency context'],
-  ['deadline_ms = ?context.deadline_ms', 'customer deadline context'],
-  ['internal_code = %error.code', 'customer internal code'],
-  ['internal_message = %error.message', 'customer internal message'],
-  ['error_kind = ?error.kind', 'customer typed error kind'],
-  ['owner_retryable = error.retryable', 'customer owner retryability'],
+  ['tenant_id_shape = diagnostic_context.tenant_id_shape', 'tenant shape log'],
+  ['actor_kind = diagnostic_context.actor_kind', 'actor kind log'],
+  ['actor_id_shape = diagnostic_context.actor_id_shape', 'actor identity shape log'],
+  ['claim_count = diagnostic_context.claim_count', 'claim count log'],
+  ['role_count = diagnostic_context.role_count', 'role count log'],
+  ['channel_shape = diagnostic_context.channel_shape', 'channel shape log'],
+  ['locale_shape = diagnostic_context.locale_shape', 'locale shape log'],
+  [
+    'correlation_id_shape = diagnostic_context.correlation_id_shape',
+    'correlation shape log',
+  ],
+  ['causation_id_shape = diagnostic_context.causation_id_shape', 'causation shape log'],
+  ['traceparent_shape = diagnostic_context.traceparent_shape', 'trace shape log'],
+  [
+    'idempotency_key_shape = diagnostic_context.idempotency_key_shape',
+    'idempotency shape log',
+  ],
+  ['deadline_ms = ?diagnostic_context.deadline_ms', 'customer deadline fact'],
+  ['owner_code = %owner_code', 'customer owner code'],
+  ['owner_message_shape,', 'customer owner message shape'],
+  ['owner_message_len,', 'customer owner message length'],
+  ['owner_kind = ?owner_kind', 'customer typed owner kind'],
+  ['owner_retryable,', 'customer owner retryability'],
   ['public_code = code', 'customer public code'],
   ['public_retryable = retryable', 'customer public retryability'],
   ['boundary = STOREFRONT_CART_HELPER_BOUNDARY', 'customer GraphQL boundary'],
@@ -176,11 +231,46 @@ for (const [value, label] of [
   requireText(customerMapper, value, label);
 }
 
+for (const value of [
+  'correlation_id = %context.correlation_id',
+  'tenant_id = %context.tenant_id',
+  'actor = ?context.actor',
+  'channel = ?context.channel',
+  'locale = %context.locale',
+  'causation_id = ?context.causation_id',
+  'traceparent = ?context.traceparent',
+  'idempotency_key = ?context.idempotency_key',
+  'internal_code = %error.code',
+  'internal_message = %error.message',
+  'owner_kind = ?error.kind',
+  'owner_retryable = error.retryable',
+]) {
+  forbidText(customerMapper, value, 'raw customer diagnostic');
+}
+
 const policyIndex = customerMapper.indexOf('let (message, code, retryable) = match &error.kind');
-const diagnosticsIndex = customerMapper.indexOf('match &error.kind', policyIndex + 1);
+const projectionIndex = customerMapper.indexOf(
+  'let diagnostic_context = StorefrontCustomerDiagnosticContext::from(context);',
+);
+const shadowIndex = customerMapper.indexOf('let error = StorefrontCustomerDiagnosticError;');
+const diagnosticIndex = customerMapper.indexOf('tracing::error!(');
 const returnIndex = customerMapper.lastIndexOf('public_graphql_error(message, code, retryable)');
-if (!(policyIndex >= 0 && policyIndex < diagnosticsIndex && diagnosticsIndex < returnIndex)) {
-  failures.push('customer error must be mapped, diagnosed, and then returned in order');
+if (
+  !(
+    policyIndex >= 0 &&
+    policyIndex < projectionIndex &&
+    projectionIndex < shadowIndex &&
+    shadowIndex < diagnosticIndex &&
+    diagnosticIndex < returnIndex
+  )
+) {
+  failures.push('customer error must be mapped, projected, shadowed, diagnosed, and returned in order');
+}
+if ((customerMapper.match(/let error = StorefrontCustomerDiagnosticError;/g) ?? []).length !== 1) {
+  failures.push('expected one customer diagnostic shadow');
+}
+if ((customerMapper.match(/error = \?error/g) ?? []).length !== 2) {
+  failures.push('expected two redacted customer diagnostic error fields');
 }
 
 for (const [value, label] of [
@@ -317,5 +407,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce GraphQL storefront cart helpers use typed line-item outcomes, stable public envelopes, retained owner context, and private layered routing',
+  '✔ Commerce GraphQL storefront cart helpers keep stable envelopes, bounded customer diagnostics, typed line-item outcomes, and private layered routing',
 );


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce correlation-safe mapper cleanup at the Commerce GraphQL storefront cart customer-owner boundary.

- preserve the existing typed `PortErrorKind` public policy, messages, codes, retryability, and error/warn severity;
- preserve the customer owner call, two-second read deadline, anonymous behavior, and owner-specific not-found fallback;
- stop logging the complete customer `PortError`, internal message, raw tenant identity, actor identity, channel, locale, correlation value, causation value, traceparent, and idempotency key;
- retain exact owner code, typed owner kind, and owner retryability;
- retain only owner-message shape/length and bounded context facts;
- classify tenant and actor identities as `empty`, `uuid_nil`, `uuid_non_nil`, or `opaque`;
- classify optional text as `absent`, `empty`, or `present`;
- shadow the owner error before both diagnostic events with a type whose `Debug` output is always `redacted`;
- update the focused cart-helper verifier and add source-only evidence/documentation;
- leave cart, legacy helper, typed line-item, storefront, tax, promotion, native transport, and remaining adapter diagnostics open.

## Recheck

Current `main` includes the previously merged Admin, reconciliation, GraphQL safe-query, and GraphQL channel diagnostic slices. The storefront cart customer mapper still emitted raw owner and request context. No open PR overlaps this boundary.

The branch starts from `main@392a41a4b81c99b6dda89c4b0cbb88e1261b2718` and changes four intended files.

## Preserved behavior

- `read_customer_projection_by_user` owner call and request;
- two-second deadline;
- anonymous caller returns `None`;
- `customer.customer_by_user_not_found` returns `None`;
- public validation, not-found, conflict, forbidden, availability, and invariant envelopes;
- public retryability;
- error severity for unavailable, timeout, and invariant failures;
- warning severity for ordinary rejections;
- cart, legacy helper, and typed line-item source outside this customer mapper.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Node verifiers;
- Cargo checks, builds, clippy, or formatting;
- mounted GraphQL execution;
- workflows or CI.

Execution evidence remains pending and the broad ecommerce cleanup remains open.