### PR TITLE
fix(commerce): bound GraphQL cart port diagnostics

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/graphql-cart-port-diagnostic-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/graphql-cart-port-diagnostic-safety-source-review.json
@@ -1,0 +1,44 @@
+{
+  "status": "commerce_graphql_cart_port_diagnostic_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs",
+    "scripts/verify/verify-commerce-graphql-cart-port-diagnostic-safety.mjs",
+    "scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs",
+    "crates/rustok-commerce/docs/graphql-cart-port-diagnostic-safety.md",
+    "crates/rustok-commerce/docs/implementation-plan.md"
+  ],
+  "source_contract": {
+    "cart_or_pricing_port_error_payload_logged": false,
+    "cart_or_pricing_internal_message_logged": false,
+    "diagnostic_error_debug_redacted": true,
+    "source_owner_classification_preserved": true,
+    "owner_code_preserved": true,
+    "owner_kind_preserved": true,
+    "owner_retryability_preserved": true,
+    "owner_message_shape_logged": true,
+    "owner_message_length_logged": true,
+    "typed_public_policy_preserved": true,
+    "public_messages_preserved": true,
+    "public_codes_preserved": true,
+    "public_retryability_preserved": true,
+    "diagnostic_severity_preserved": true,
+    "existing_cart_helper_verifier_contract_preserved": true,
+    "customer_mapper_cleanup_preserved": true,
+    "legacy_helper_cleanup_closed": false,
+    "typed_line_item_cleanup_closed": false,
+    "broad_ecommerce_cleanup_closed": false,
+    "runtime_evidence_claimed": false
+  },
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, mounted GraphQL scenarios, workflows, or CI were executed."
+}

--- a/crates/rustok-commerce/docs/graphql-cart-port-diagnostic-safety.md
+++ b/crates/rustok-commerce/docs/graphql-cart-port-diagnostic-safety.md
@@ -1,0 +1,62 @@
+# GraphQL cart port diagnostic safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens `cart_port_error` in the Commerce GraphQL storefront cart helper facade.
+
+The mapper accepts `PortError` values originating from the Cart or Pricing owner boundary. It already selected stable public GraphQL messages, codes, and retryability from `PortErrorKind`, but its diagnostic event emitted the complete owner error, including its message.
+
+## Bounded projection
+
+The mapper now completes public policy selection and source-owner classification before replacing the original owner error with `StorefrontCartPortDiagnosticError`.
+
+The diagnostic object retains only:
+
+- exact owner code;
+- typed owner kind;
+- owner retryability;
+- owner-message `empty` / `present` shape;
+- owner-message byte length.
+
+Its custom `Debug` implementation always emits `redacted`, so `error = ?error` no longer serializes the original Cart/Pricing `PortError`.
+
+The event continues to retain the static Commerce boundary owner, classified source owner, operation, public code, public retryability, shared boundary, and static event message.
+
+## Preserved GraphQL behavior
+
+This work does not change:
+
+- Cart/Pricing source-owner classification from the stable code prefix;
+- validation, not-found, conflict, forbidden, unavailable/timeout, or invariant public policy;
+- public GraphQL messages;
+- public GraphQL codes;
+- public retryability;
+- the existing error-level diagnostic severity;
+- the `public_graphql_error` envelope;
+- the already-hardened customer mapper;
+- helper routing or owner calls.
+
+The existing broad cart-helper verifier markers remain valid because `owner_code`, typed `owner_kind`, owner retryability, and source-owner classification are still present, but they now refer to bounded facts rather than the original error payload.
+
+## Remaining helper work
+
+This slice does not close the complete storefront cart helper diagnostic boundary.
+
+Still open:
+
+- `legacy_graphql_error`, which logs the complete GraphQL error and raw tenant/resource UUIDs;
+- typed line-item diagnostics, which log typed source payloads and raw tenant/product/variant context;
+- storefront shared and cart-shipping mappers;
+- tax, promotion, native transport, and remaining owner-adapter cleanup.
+
+## Evidence
+
+- `crates/rustok-commerce/contracts/evidence/graphql-cart-port-diagnostic-safety-source-review.json`
+- `scripts/verify/verify-commerce-graphql-cart-port-diagnostic-safety.mjs`
+- `scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs`
+
+## Validation disclosure
+
+No tests, Node verifiers, formatting, Cargo commands, mounted GraphQL scenarios, workflows, or CI were run. No compile, runtime, FFA, or FBA status is promoted.

--- a/crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs
@@ -57,6 +57,20 @@ impl std::fmt::Debug for StorefrontCustomerDiagnosticError {
     }
 }
 
+struct StorefrontCartPortDiagnosticError {
+    code: String,
+    kind: PortErrorKind,
+    retryable: bool,
+    message_shape: &'static str,
+    message_len: usize,
+}
+
+impl std::fmt::Debug for StorefrontCartPortDiagnosticError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("redacted")
+    }
+}
+
 fn actor_kind_name(kind: &PortActorKind) -> &'static str {
     match kind {
         PortActorKind::User => "user",
@@ -254,12 +268,25 @@ pub(crate) fn cart_port_error(error: PortError) -> async_graphql::Error {
         ),
     };
 
+    let source_owner = cart_port_source_owner(&error);
+    let message_shape = text_shape(error.message.as_str());
+    let message_len = error.message.len();
+    let error = StorefrontCartPortDiagnosticError {
+        code: error.code,
+        kind: error.kind,
+        retryable: error.retryable,
+        message_shape,
+        message_len,
+    };
+
     tracing::error!(
         error = ?error,
         owner = "rustok_commerce.graphql_cart_helper",
-        source_owner = cart_port_source_owner(&error),
+        source_owner,
         operation = "storefront_cart_port",
         owner_code = %error.code,
+        owner_message_shape = error.message_shape,
+        owner_message_len = error.message_len,
         owner_kind = ?error.kind,
         owner_retryable = error.retryable,
         public_code = code,
@@ -408,7 +435,6 @@ pub(crate) async fn resolve_storefront_line_item_input(
         tenant_id,
         pricing_read_port,
         pricing_port_context,
-        pricing_context,
         locale,
         default_locale,
         public_channel_slug,

--- a/crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs
@@ -435,6 +435,7 @@ pub(crate) async fn resolve_storefront_line_item_input(
         tenant_id,
         pricing_read_port,
         pricing_port_context,
+        pricing_context,
         locale,
         default_locale,
         public_channel_slug,

--- a/scripts/verify/verify-commerce-graphql-cart-port-diagnostic-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-cart-port-diagnostic-safety.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const source = readFileSync(
+  new URL('crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs', root),
+  'utf8',
+);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const diagnosticType = between(
+  source,
+  'struct StorefrontCartPortDiagnosticError {',
+  'fn actor_kind_name(',
+  'cart diagnostic type',
+);
+const ownerClassifier = between(
+  source,
+  'fn cart_port_source_owner(',
+  'pub(crate) fn cart_port_error(',
+  'cart source-owner classifier',
+);
+const mapper = between(
+  source,
+  'pub(crate) fn cart_port_error(',
+  'pub(crate) async fn resolve_optional_storefront_customer_id(',
+  'cart port GraphQL mapper',
+);
+
+for (const [value, label] of [
+  ['struct StorefrontCartPortDiagnosticError {', 'diagnostic type'],
+  ['code: String,', 'owner code fact'],
+  ['kind: PortErrorKind,', 'typed owner kind fact'],
+  ['retryable: bool,', 'owner retryability fact'],
+  ["message_shape: &'static str,", 'owner message shape fact'],
+  ['message_len: usize,', 'owner message length fact'],
+  ['impl std::fmt::Debug for StorefrontCartPortDiagnosticError', 'custom diagnostic Debug'],
+  ['formatter.write_str("redacted")', 'redacted diagnostic Debug output'],
+]) requireText(diagnosticType, value, label);
+for (const value of ['#[derive(Debug)]', 'formatter.debug_struct(', '.field(']) {
+  forbidText(diagnosticType, value, 'cart diagnostic payload exposure');
+}
+
+for (const [value, label] of [
+  ['Some(("cart", _)) => "rustok_cart"', 'cart owner classification'],
+  ['Some(("pricing", _)) => "rustok_pricing"', 'pricing owner classification'],
+  ['_ => "unknown"', 'unknown owner classification'],
+]) requireText(ownerClassifier, value, label);
+
+for (const [value, label] of [
+  ['error: PortError', 'original owner error input'],
+  ['PortErrorKind::Validation', 'validation policy'],
+  ['PortErrorKind::NotFound', 'not-found policy'],
+  ['PortErrorKind::Conflict', 'conflict policy'],
+  ['PortErrorKind::Forbidden', 'forbidden policy'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'availability policy'],
+  ['PortErrorKind::InvariantViolation', 'invariant policy'],
+  ['"Cart request is invalid"', 'validation message'],
+  ['"CART_REQUEST_INVALID"', 'validation code'],
+  ['"Cart resource was not found"', 'not-found message'],
+  ['"CART_RESOURCE_NOT_FOUND"', 'not-found code'],
+  ['"Cart operation conflicts with the current state"', 'conflict message'],
+  ['"CART_STATE_CONFLICT"', 'conflict code'],
+  ['"Cart operation is not permitted"', 'forbidden message'],
+  ['"CART_ACCESS_DENIED"', 'forbidden code'],
+  ['"Cart is temporarily unavailable"', 'availability message'],
+  ['"CART_TEMPORARILY_UNAVAILABLE"', 'availability code'],
+  ['"Cart operation could not be completed safely"', 'invariant message'],
+  ['"CART_OPERATION_FAILED"', 'invariant code'],
+  ['let source_owner = cart_port_source_owner(&error);', 'source owner projection'],
+  ['let message_shape = text_shape(error.message.as_str());', 'message shape projection'],
+  ['let message_len = error.message.len();', 'message length projection'],
+  ['let error = StorefrontCartPortDiagnosticError {', 'diagnostic shadow'],
+  ['code: error.code,', 'owner code transfer'],
+  ['kind: error.kind,', 'owner kind transfer'],
+  ['retryable: error.retryable,', 'owner retryability transfer'],
+  ['message_shape,', 'message shape transfer'],
+  ['message_len,', 'message length transfer'],
+  ['tracing::error!(', 'diagnostic event'],
+  ['error = ?error', 'redacted error field'],
+  ['owner = "rustok_commerce.graphql_cart_helper"', 'boundary owner'],
+  ['source_owner,', 'source owner field'],
+  ['operation = "storefront_cart_port"', 'operation field'],
+  ['owner_code = %error.code', 'owner code field'],
+  ['owner_message_shape = error.message_shape', 'message shape field'],
+  ['owner_message_len = error.message_len', 'message length field'],
+  ['owner_kind = ?error.kind', 'typed owner kind field'],
+  ['owner_retryable = error.retryable', 'owner retryability field'],
+  ['public_code = code', 'public code field'],
+  ['public_retryable = retryable', 'public retryability field'],
+  ['boundary = STOREFRONT_CART_HELPER_BOUNDARY', 'shared boundary'],
+  [
+    '"commerce GraphQL storefront cart or pricing owner port failed"',
+    'static event message',
+  ],
+  ['public_graphql_error(message, code, retryable)', 'stable public envelope'],
+]) requireText(mapper, value, label);
+
+for (const value of [
+  'internal_message =',
+  'owner_message =',
+  'message = %error.message',
+  'message = ?error.message',
+  'error_message =',
+  'format!("{error:?}")',
+  'async_graphql::Error::new(error.message)',
+  'async_graphql::Error::new(error.to_string())',
+]) forbidText(mapper, value, 'raw cart port diagnostic or public error');
+
+const policyIndex = mapper.indexOf('let (message, code, retryable) = match &error.kind');
+const ownerIndex = mapper.indexOf('let source_owner = cart_port_source_owner(&error);');
+const shapeIndex = mapper.indexOf('let message_shape = text_shape(error.message.as_str());');
+const shadowIndex = mapper.indexOf('let error = StorefrontCartPortDiagnosticError {');
+const eventIndex = mapper.indexOf('tracing::error!(');
+const returnIndex = mapper.lastIndexOf('public_graphql_error(message, code, retryable)');
+if (
+  !(
+    policyIndex >= 0 &&
+    policyIndex < ownerIndex &&
+    ownerIndex < shapeIndex &&
+    shapeIndex < shadowIndex &&
+    shadowIndex < eventIndex &&
+    eventIndex < returnIndex
+  )
+) {
+  failures.push('cart port error must be mapped, projected, shadowed, diagnosed, and returned in order');
+}
+if ((mapper.match(/let error = StorefrontCartPortDiagnosticError \{/g) ?? []).length !== 1) {
+  failures.push('expected one cart port diagnostic shadow');
+}
+if ((mapper.match(/tracing::error!\(/g) ?? []).length !== 1) {
+  failures.push('expected one cart port diagnostic event');
+}
+if ((mapper.match(/error = \?error/g) ?? []).length !== 1) {
+  failures.push('expected one redacted cart port diagnostic error field');
+}
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL cart port diagnostic-safety verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce GraphQL cart/pricing port errors keep stable public envelopes and emit bounded redacted diagnostics',
+);


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce correlation-safe mapper cleanup at the Commerce GraphQL storefront cart/pricing port mapper.

- preserve all existing `PortErrorKind` public messages, codes, and retryability;
- preserve Cart/Pricing source-owner classification and the existing error-level event;
- stop logging the complete Cart/Pricing `PortError` and its message payload;
- select public policy and source owner before diagnostic projection;
- retain exact owner code, typed owner kind, owner retryability, and only owner-message shape/length;
- shadow the original error with a diagnostic object whose `Debug` output is always `redacted`;
- retain the existing shared boundary, operation, public code, public retryability, and static event message;
- add a focused fail-closed verifier, source-only evidence, and documentation;
- leave legacy GraphQL helper, typed line-item, storefront shared/cart-shipping, tax, promotion, native transport, and remaining adapter diagnostics open.

## Recheck

The branch was rebased after `main` advanced during implementation. Current base is `main@b18558e3f8443135a403780d1ef75bc4d14dba6d`; the target `safe_helpers.rs` blob was unchanged by the intervening Index, Forum, and admin UI commits. No open PR overlaps this Commerce boundary.

The branch changes four intended files.

## Preserved behavior

- validation, not-found, conflict, forbidden, unavailable/timeout, and invariant public mapping;
- public GraphQL messages, codes, and retryability;
- Cart/Pricing source-owner classification by stable code prefix;
- one error-level diagnostic event;
- `public_graphql_error` construction;
- already-hardened customer mapper;
- helper routing and owner calls;
- existing broad cart-helper verifier markers.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Node verifiers;
- Cargo checks, builds, clippy, or formatting;
- mounted GraphQL execution;
- workflows or CI.

Execution evidence remains pending and the broad ecommerce cleanup remains open.