### PR TITLE
fix(commerce): bound legacy GraphQL helper diagnostics

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/graphql-legacy-helper-diagnostic-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/graphql-legacy-helper-diagnostic-safety-source-review.json
@@ -1,0 +1,50 @@
+{
+  "status": "commerce_graphql_legacy_helper_diagnostic_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs",
+    "scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs",
+    "crates/rustok-commerce/docs/graphql-legacy-helper-diagnostic-safety.md",
+    "crates/rustok-commerce/docs/implementation-plan.md"
+  ],
+  "source_contract": {
+    "legacy_graphql_error_payload_logged": false,
+    "raw_tenant_uuid_logged": false,
+    "raw_resource_uuid_logged": false,
+    "diagnostic_error_debug_redacted": true,
+    "original_error_consumed_before_event": true,
+    "tenant_uuid_shape_logged": true,
+    "optional_resource_uuid_shape_logged": true,
+    "operation_preserved": true,
+    "error_kind_preserved": true,
+    "public_messages_preserved": true,
+    "public_codes_preserved": true,
+    "public_retryability_preserved": true,
+    "diagnostic_severity_preserved": true,
+    "cart_enrichment_call_preserved": true,
+    "shipping_validation_call_preserved": true,
+    "line_item_resolution_call_preserved": true,
+    "cart_reprice_call_preserved": true,
+    "quantity_validation_call_preserved": true,
+    "customer_mapper_cleanup_preserved": true,
+    "cart_port_mapper_cleanup_preserved": true,
+    "typed_line_item_cleanup_closed": false,
+    "storefront_shared_cleanup_closed": false,
+    "cart_shipping_cleanup_closed": false,
+    "tax_cleanup_closed": false,
+    "promotion_cleanup_closed": false,
+    "broad_ecommerce_cleanup_closed": false,
+    "runtime_evidence_claimed": false
+  },
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, mounted GraphQL scenarios, workflows, or CI were executed."
+}

--- a/crates/rustok-commerce/docs/graphql-legacy-helper-diagnostic-safety.md
+++ b/crates/rustok-commerce/docs/graphql-legacy-helper-diagnostic-safety.md
@@ -1,0 +1,65 @@
+# GraphQL legacy helper diagnostic safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens `legacy_graphql_error` in the Commerce GraphQL storefront cart helper facade.
+
+The mapper wraps failures from five compatibility helper calls. Its public message, code, and retryability are already supplied as stable static policy by each caller. Before this change, the diagnostic event emitted the complete `async_graphql::Error`, raw tenant UUID, and optional raw resource UUID.
+
+## Bounded projection
+
+The mapper now projects request identity before the diagnostic event:
+
+- tenant UUID becomes `nil` / `non_nil`;
+- optional resource UUID becomes `absent` / `present_nil` / `present_non_nil`.
+
+The original `async_graphql::Error` is consumed by `StorefrontLegacyGraphqlDiagnosticError::from`. The resulting zero-sized diagnostic token has a custom `Debug` implementation that always emits `redacted`. The original GraphQL payload is therefore unavailable to the event.
+
+The event continues to retain only the static Commerce boundary owner, operation, `legacy_graphql_error` kind, public code, public retryability, shared boundary, static event message, and the two closed UUID shapes.
+
+## Preserved GraphQL behavior
+
+This work does not change:
+
+- `enrich_storefront_cart` delegation or its `CART_ENRICHMENT_UNAVAILABLE` envelope;
+- `validate_selected_shipping_option` delegation or its `SHIPPING_OPTION_INVALID` envelope;
+- compatibility line-item resolution delegation or its existing selected public envelope;
+- `reprice_storefront_cart_line_items` delegation or its `CART_REPRICE_FAILED` envelope;
+- compatibility quantity validation delegation or its existing selected public envelope;
+- error-level diagnostic severity;
+- `public_graphql_error` construction;
+- the previously hardened customer and Cart/Pricing port mappers;
+- private compatibility helper routing.
+
+The compatibility line-item callers still classify legacy error debug text before calling this mapper. Removing that string classification belongs to the separate typed line-item/legacy compatibility cleanup and is not claimed here.
+
+## Verifier correction
+
+The broad cart-helper verifier previously required raw resource UUID logging and still expected the pre-hardening inline Cart/Pricing source-owner expression. It now requires:
+
+- UUID shape helpers;
+- consuming conversion of the GraphQL error;
+- redacted diagnostic output;
+- shape projection before conversion and event emission;
+- absence of raw tenant/resource diagnostics;
+- the current precomputed Cart/Pricing source-owner contract.
+
+## Remaining helper work
+
+Still open:
+
+- typed line-item diagnostics and remaining compatibility string classification;
+- storefront shared and cart-shipping mappers;
+- tax, promotion, native transport, and remaining owner-adapter cleanup;
+- mounted execution, compile, and runtime evidence.
+
+## Evidence
+
+- `crates/rustok-commerce/contracts/evidence/graphql-legacy-helper-diagnostic-safety-source-review.json`
+- `scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs`
+
+## Validation disclosure
+
+No tests, Node verifiers, formatting, Cargo commands, mounted GraphQL scenarios, workflows, or CI were run. No compile, runtime, FFA, or FBA status is promoted.

--- a/crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs
@@ -71,6 +71,20 @@ impl std::fmt::Debug for StorefrontCartPortDiagnosticError {
     }
 }
 
+struct StorefrontLegacyGraphqlDiagnosticError;
+
+impl From<async_graphql::Error> for StorefrontLegacyGraphqlDiagnosticError {
+    fn from(_error: async_graphql::Error) -> Self {
+        Self
+    }
+}
+
+impl std::fmt::Debug for StorefrontLegacyGraphqlDiagnosticError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("redacted")
+    }
+}
+
 fn actor_kind_name(kind: &PortActorKind) -> &'static str {
     match kind {
         PortActorKind::User => "user",
@@ -87,6 +101,18 @@ fn identity_text_shape(value: &str) -> &'static str {
         Ok(value) if value.is_nil() => "uuid_nil",
         Ok(_) => "uuid_non_nil",
         Err(_) => "opaque",
+    }
+}
+
+fn uuid_shape(value: Uuid) -> &'static str {
+    if value.is_nil() { "nil" } else { "non_nil" }
+}
+
+fn optional_uuid_shape(value: Option<Uuid>) -> &'static str {
+    match value {
+        None => "absent",
+        Some(value) if value.is_nil() => "present_nil",
+        Some(_) => "present_non_nil",
     }
 }
 
@@ -336,11 +362,15 @@ fn legacy_graphql_error(
     code: &'static str,
     retryable: bool,
 ) -> async_graphql::Error {
+    let tenant_id_shape = uuid_shape(tenant_id);
+    let resource_id_shape = optional_uuid_shape(resource_id);
+    let error = StorefrontLegacyGraphqlDiagnosticError::from(error);
+
     tracing::error!(
         error = ?error,
         owner = "rustok_commerce.graphql_cart_helper",
-        tenant_id = %tenant_id,
-        resource_id = ?resource_id,
+        tenant_id_shape,
+        resource_id_shape,
         operation,
         error_kind = "legacy_graphql_error",
         public_code = code,

--- a/scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
@@ -47,6 +47,12 @@ const customerLookup = between(
   'fn legacy_graphql_error(',
   'optional storefront customer lookup',
 );
+const legacyMapper = between(
+  facadeSource,
+  'fn legacy_graphql_error(',
+  'pub(crate) async fn enrich_storefront_cart(',
+  'legacy GraphQL mapper',
+);
 const typedPolicy = between(
   typedSource,
   'fn storefront_line_item_public_policy(',
@@ -132,9 +138,16 @@ for (const [value, label] of [
   ],
   ['deadline_ms: context.deadline_ms', 'deadline fact'],
   ['struct StorefrontCustomerDiagnosticError;', 'redacted customer diagnostic error'],
-  ['formatter.write_str("redacted")', 'redacted customer Debug'],
+  ['struct StorefrontLegacyGraphqlDiagnosticError;', 'redacted legacy diagnostic error'],
+  [
+    'impl From<async_graphql::Error> for StorefrontLegacyGraphqlDiagnosticError',
+    'legacy error consumption',
+  ],
+  ['formatter.write_str("redacted")', 'redacted diagnostic Debug'],
   ['fn actor_kind_name(kind: &PortActorKind)', 'actor kind helper'],
   ['fn identity_text_shape(value: &str)', 'identity shape helper'],
+  ['fn uuid_shape(value: Uuid)', 'UUID shape helper'],
+  ['fn optional_uuid_shape(value: Option<Uuid>)', 'optional UUID shape helper'],
   ['fn text_shape(value: &str)', 'text shape helper'],
   ['fn optional_text_shape(value: Option<&str>)', 'optional text shape helper'],
   ['fn customer_port_graphql_error(', 'customer mapper'],
@@ -144,11 +157,13 @@ for (const [value, label] of [
   ['Some(("pricing", _)) => "rustok_pricing"', 'pricing owner classification'],
   ['_ => "unknown"', 'unknown owner classification'],
   ['owner = "rustok_commerce.graphql_cart_helper"', 'commerce boundary owner logging'],
-  ['source_owner = cart_port_source_owner(&error)', 'typed source owner logging'],
+  ['let source_owner = cart_port_source_owner(&error);', 'typed source owner projection'],
+  ['source_owner,', 'typed source owner logging'],
   ['owner_code = %error.code', 'cart owner code logging'],
   ['owner_kind = ?error.kind', 'cart owner kind logging'],
   ['error_kind = "legacy_graphql_error"', 'legacy error kind logging'],
-  ['resource_id = ?resource_id', 'resource logging'],
+  ['tenant_id_shape,', 'tenant shape logging'],
+  ['resource_id_shape,', 'resource shape logging'],
   ['"Cart shipping details are temporarily unavailable"', 'cart enrichment message'],
   ['"Selected shipping option is invalid"', 'shipping selection message'],
   ['"Cart pricing could not be refreshed"', 'reprice fallback message'],
@@ -293,6 +308,79 @@ for (const [value, label] of [
 }
 
 for (const [value, label] of [
+  ['error: async_graphql::Error', 'original legacy GraphQL error input'],
+  ['tenant_id: Uuid', 'legacy tenant input'],
+  ['resource_id: Option<Uuid>', 'legacy resource input'],
+  ["operation: &'static str", 'legacy operation input'],
+  ["message: &'static str", 'legacy public message input'],
+  ["code: &'static str", 'legacy public code input'],
+  ['retryable: bool', 'legacy public retryability input'],
+  ['let tenant_id_shape = uuid_shape(tenant_id);', 'legacy tenant projection'],
+  ['let resource_id_shape = optional_uuid_shape(resource_id);', 'legacy resource projection'],
+  [
+    'let error = StorefrontLegacyGraphqlDiagnosticError::from(error);',
+    'legacy error consumption and shadow',
+  ],
+  ['tracing::error!(', 'legacy error severity'],
+  ['error = ?error', 'redacted legacy error field'],
+  ['owner = "rustok_commerce.graphql_cart_helper"', 'legacy boundary owner'],
+  ['tenant_id_shape,', 'legacy tenant shape field'],
+  ['resource_id_shape,', 'legacy resource shape field'],
+  ['operation,', 'legacy operation field'],
+  ['error_kind = "legacy_graphql_error"', 'legacy error kind field'],
+  ['public_code = code', 'legacy public code field'],
+  ['public_retryable = retryable', 'legacy public retryability field'],
+  ['boundary = STOREFRONT_CART_HELPER_BOUNDARY', 'legacy shared boundary'],
+  ['"commerce GraphQL storefront cart helper failed"', 'legacy static event'],
+  ['public_graphql_error(message, code, retryable)', 'legacy stable public envelope'],
+]) {
+  requireText(legacyMapper, value, label);
+}
+
+for (const value of [
+  'tenant_id = %tenant_id',
+  'tenant_id = ?tenant_id',
+  'resource_id = ?resource_id',
+  'resource_id = %resource_id',
+  'format!("{error:?}")',
+  'error.to_string()',
+  'error.message',
+]) {
+  forbidText(legacyMapper, value, 'raw legacy GraphQL diagnostic');
+}
+
+const legacyTenantProjectionIndex = legacyMapper.indexOf(
+  'let tenant_id_shape = uuid_shape(tenant_id);',
+);
+const legacyResourceProjectionIndex = legacyMapper.indexOf(
+  'let resource_id_shape = optional_uuid_shape(resource_id);',
+);
+const legacyShadowIndex = legacyMapper.indexOf(
+  'let error = StorefrontLegacyGraphqlDiagnosticError::from(error);',
+);
+const legacyEventIndex = legacyMapper.indexOf('tracing::error!(');
+const legacyReturnIndex = legacyMapper.lastIndexOf(
+  'public_graphql_error(message, code, retryable)',
+);
+if (
+  !(
+    legacyTenantProjectionIndex >= 0 &&
+    legacyTenantProjectionIndex < legacyResourceProjectionIndex &&
+    legacyResourceProjectionIndex < legacyShadowIndex &&
+    legacyShadowIndex < legacyEventIndex &&
+    legacyEventIndex < legacyReturnIndex
+  )
+) {
+  failures.push('legacy error must be projected, consumed, diagnosed, and returned in order');
+}
+if ((legacyMapper.match(/tracing::error!\(/g) ?? []).length !== 1) {
+  failures.push('expected one legacy GraphQL diagnostic event');
+}
+if ((legacyMapper.match(/error = \?error/g) ?? []).length !== 1) {
+  failures.push('expected one redacted legacy GraphQL error field');
+}
+
+for (const [value, label] of [
   ['enum StorefrontLineItemFailureKind {', 'typed failure kind'],
   ['ProductUnavailable,', 'typed product outcome'],
   ['InventoryInsufficient,', 'typed inventory outcome'],
@@ -407,5 +495,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce GraphQL storefront cart helpers keep stable envelopes, bounded customer diagnostics, typed line-item outcomes, and private layered routing',
+  '✔ Commerce GraphQL storefront cart helpers keep stable envelopes, bounded customer and legacy diagnostics, typed line-item outcomes, and private layered routing',
 );


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce correlation-safe mapper cleanup at the Commerce GraphQL storefront cart compatibility helper boundary.

- preserve the five existing compatibility helper delegations and all caller-selected public messages, codes, and retryability;
- preserve the existing error-level event, operation, error kind, shared boundary, and static event message;
- stop logging the complete `async_graphql::Error`, raw tenant UUID, and optional raw resource UUID;
- project tenant UUID to `nil` / `non_nil`;
- project optional resource UUID to `absent` / `present_nil` / `present_non_nil`;
- consume the original GraphQL error through a zero-sized diagnostic conversion whose `Debug` output is always `redacted`;
- correct the broad cart-helper verifier so it fails closed on raw legacy diagnostics and follows the current precomputed Cart/Pricing source-owner contract;
- add source-only evidence and documentation;
- leave typed line-item diagnostics/string classification, storefront shared/cart-shipping, tax, promotion, native transport, and remaining adapter diagnostics open.

## Recheck

Current base is `main@69a2ae728f6e5c5a70612bb75812b8cfc5157353`. The canonical broad mapper-cleanup item remains open and no open PR overlaps this boundary.

The branch changes four intended files.

## Preserved behavior

- `enrich_storefront_cart` delegation and `CART_ENRICHMENT_UNAVAILABLE` envelope;
- `validate_selected_shipping_option` delegation and `SHIPPING_OPTION_INVALID` envelope;
- compatibility line-item resolution delegation and its existing selected envelope;
- `reprice_storefront_cart_line_items` delegation and `CART_REPRICE_FAILED` envelope;
- compatibility quantity validation delegation and its existing selected envelope;
- `public_graphql_error` construction;
- diagnostic error severity;
- previously hardened customer and Cart/Pricing port mappers;
- helper routing and all owner-call arguments, including `pricing_context`.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Node verifiers;
- Cargo checks, builds, clippy, or formatting;
- mounted GraphQL execution;
- workflows or CI.

Execution evidence remains pending and the broad ecommerce cleanup remains open.