### PR TITLE
feat(forum): expose authorized gone topic routes

### DIFF
--- a/apps/storefront/src/forum_topic_route.rs
+++ b/apps/storefront/src/forum_topic_route.rs
@@ -18,6 +18,8 @@ enum ForumTopicHostAction {
         canonical_path: String,
     },
     Redirect(String),
+    Gone,
+    Invalid,
 }
 
 pub(crate) async fn render_forum_topic_route_response(
@@ -51,6 +53,14 @@ pub(crate) async fn render_forum_topic_route_response(
 
     match forum_topic_host_action(requested_path.as_str(), &resolution) {
         ForumTopicHostAction::Redirect(location) => private_permanent_redirect(location.as_str()),
+        ForumTopicHostAction::Gone => private_status_response(
+            StatusCode::GONE,
+            "This Forum topic route is no longer available",
+        ),
+        ForumTopicHostAction::Invalid => private_status_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Forum topic route resolution is temporarily unavailable",
+        ),
         ForumTopicHostAction::Render {
             topic_id,
             canonical_path: _,
@@ -76,15 +86,24 @@ fn forum_topic_host_action(
     requested_path: &str,
     resolution: &StorefrontForumTopicRouteResolution,
 ) -> ForumTopicHostAction {
-    let canonical_path = resolution.canonical.path.clone();
-    if resolution.disposition == StorefrontForumTopicRouteDisposition::Redirect
-        || requested_path != canonical_path
-    {
-        ForumTopicHostAction::Redirect(canonical_path)
-    } else {
-        ForumTopicHostAction::Render {
-            topic_id: resolution.canonical.topic_id.clone(),
-            canonical_path,
+    match (resolution.disposition, resolution.canonical.as_ref()) {
+        (StorefrontForumTopicRouteDisposition::Gone, None) => ForumTopicHostAction::Gone,
+        (StorefrontForumTopicRouteDisposition::Gone, Some(_))
+        | (StorefrontForumTopicRouteDisposition::Canonical, None)
+        | (StorefrontForumTopicRouteDisposition::Redirect, None) => ForumTopicHostAction::Invalid,
+        (StorefrontForumTopicRouteDisposition::Redirect, Some(canonical)) => {
+            ForumTopicHostAction::Redirect(canonical.path.clone())
+        }
+        (StorefrontForumTopicRouteDisposition::Canonical, Some(canonical))
+            if requested_path != canonical.path =>
+        {
+            ForumTopicHostAction::Redirect(canonical.path.clone())
+        }
+        (StorefrontForumTopicRouteDisposition::Canonical, Some(canonical)) => {
+            ForumTopicHostAction::Render {
+                topic_id: canonical.topic_id.clone(),
+                canonical_path: canonical.path.clone(),
+            }
         }
     }
 }
@@ -94,21 +113,26 @@ mod tests {
     use super::*;
     use rustok_forum_storefront::StorefrontForumTopicRouteDescriptor;
 
+    fn descriptor() -> StorefrontForumTopicRouteDescriptor {
+        StorefrontForumTopicRouteDescriptor {
+            topic_id: "12345678-9abc-4def-8123-456789abcdef".to_string(),
+            locale: "en".to_string(),
+            short_id: "123456789abc".to_string(),
+            slug: "welcome".to_string(),
+            path: "/en/forum/t/123456789abc/welcome".to_string(),
+        }
+    }
+
     fn resolution(
         disposition: StorefrontForumTopicRouteDisposition,
+        canonical: Option<StorefrontForumTopicRouteDescriptor>,
     ) -> StorefrontForumTopicRouteResolution {
         StorefrontForumTopicRouteResolution {
             requested_locale: "en".to_string(),
             requested_short_id: "123456789abc".to_string(),
             requested_slug: "welcome".to_string(),
             disposition,
-            canonical: StorefrontForumTopicRouteDescriptor {
-                topic_id: "12345678-9abc-4def-8123-456789abcdef".to_string(),
-                locale: "en".to_string(),
-                short_id: "123456789abc".to_string(),
-                slug: "welcome".to_string(),
-                path: "/en/forum/t/123456789abc/welcome".to_string(),
-            },
+            canonical,
         }
     }
 
@@ -117,7 +141,10 @@ mod tests {
         assert_eq!(
             forum_topic_host_action(
                 "/en/forum/t/123456789abc/welcome",
-                &resolution(StorefrontForumTopicRouteDisposition::Canonical),
+                &resolution(
+                    StorefrontForumTopicRouteDisposition::Canonical,
+                    Some(descriptor()),
+                ),
             ),
             ForumTopicHostAction::Render {
                 topic_id: "12345678-9abc-4def-8123-456789abcdef".to_string(),
@@ -143,10 +170,41 @@ mod tests {
             ),
         ] {
             assert_eq!(
-                forum_topic_host_action(requested_path, &resolution(disposition)),
+                forum_topic_host_action(
+                    requested_path,
+                    &resolution(disposition, Some(descriptor())),
+                ),
                 ForumTopicHostAction::Redirect(
                     "/en/forum/t/123456789abc/welcome".to_string()
                 )
+            );
+        }
+    }
+
+    #[test]
+    fn authorized_gone_has_terminal_host_action() {
+        assert_eq!(
+            forum_topic_host_action(
+                "/en/forum/t/123456789abc/retired-topic",
+                &resolution(StorefrontForumTopicRouteDisposition::Gone, None),
+            ),
+            ForumTopicHostAction::Gone
+        );
+    }
+
+    #[test]
+    fn malformed_transport_shapes_fail_closed() {
+        for resolution in [
+            resolution(StorefrontForumTopicRouteDisposition::Gone, Some(descriptor())),
+            resolution(StorefrontForumTopicRouteDisposition::Canonical, None),
+            resolution(StorefrontForumTopicRouteDisposition::Redirect, None),
+        ] {
+            assert_eq!(
+                forum_topic_host_action(
+                    "/en/forum/t/123456789abc/welcome",
+                    &resolution,
+                ),
+                ForumTopicHostAction::Invalid
             );
         }
     }

--- a/crates/rustok-forum/contracts/forum-topic-route-authorized-gone-transport.json
+++ b/crates/rustok-forum/contracts/forum-topic-route-authorized-gone-transport.json
@@ -1,0 +1,108 @@
+{
+  "contract": "forum_topic_route_authorized_gone_transport_v1",
+  "task": "FORUM-24K",
+  "parent_task": "FORUM-24",
+  "extends": ["FORUM-24H", "FORUM-24I", "FORUM-24J"],
+  "status": "source_ready_maintainer_execution_pending",
+  "canonical_plan_status": "planned",
+  "owner": "ForumTopicRouteTombstoneVisibilityService::can_disclose_public_gone",
+  "graphql": {
+    "legacy_field": "forumStorefrontTopicRoute",
+    "legacy_field_changed": false,
+    "legacy_gone_exposed": false,
+    "decision_field": "forumStorefrontTopicRouteDecision",
+    "decision_field_additive": true,
+    "decision_dispositions": ["CANONICAL", "REDIRECT", "GONE"],
+    "decision_canonical_nullable_only_for_gone": true,
+    "requested_topic_id_exposed": false,
+    "alias_id_exposed": false,
+    "snapshot_payload_exposed": false
+  },
+  "native_storefront": {
+    "endpoint": "forum/storefront-topic-route",
+    "selected_for": ["ssr", "hydrate"],
+    "automatic_graphql_fallback": false,
+    "owner_boolean_consumed": true,
+    "gone_canonical": null,
+    "snapshot_storage_read_directly": false
+  },
+  "graphql_storefront": {
+    "selected_for": ["headless", "csr"],
+    "query": "StorefrontForumTopicRouteDecision",
+    "field": "forumStorefrontTopicRouteDecision",
+    "owner_boolean_consumed_server_side": true
+  },
+  "authorization": {
+    "tenant_authority": "routed_context",
+    "optional_tenant_id_is_assertion_only": true,
+    "forum_module_required": true,
+    "gone_requires_current_channel_module_enabled": true,
+    "gone_requires_deletion_time_public_snapshot": true,
+    "gone_requires_exact_snapshot_channel_match_when_restricted": true,
+    "authenticated_requests_do_not_broaden_public_snapshot": true,
+    "missing_snapshot_hidden": true,
+    "private_snapshot_hidden": true,
+    "channel_mismatch_hidden": true,
+    "snapshot_integrity_conflict": "transport_error"
+  },
+  "host": {
+    "application": "apps/storefront",
+    "authorized_gone_status": 410,
+    "authorized_gone_cache_control": "private, no-store",
+    "missing_or_unauthorized_status": 404,
+    "malformed_decision_status": 503,
+    "canonical_status": 200,
+    "redirect_status": 308,
+    "host_reads_forum_storage": false,
+    "host_reauthorizes_gone": false
+  },
+  "shape_invariants": {
+    "canonical_requires_target": true,
+    "redirect_requires_target": true,
+    "gone_forbids_target": true,
+    "malformed_shapes_fail_closed": true
+  },
+  "compatibility": {
+    "database_schema_changed": false,
+    "migration_added": false,
+    "delete_owner_changed": false,
+    "route_identity_changed": false,
+    "semantic_event_changed": false,
+    "admin_contract_changed": false,
+    "seo_changed": false,
+    "legacy_graphql_generated_clients_preserved": true
+  },
+  "historical_policy": {
+    "topics_deleted_before_FORUM_24J": "hidden",
+    "formerly_private_topics": "hidden",
+    "formerly_public_unrestricted_topics": "eligible_for_gone",
+    "formerly_public_channel_restricted_topics": "eligible_only_on_snapshotted_channel",
+    "cross_topic_redirect_target_disappearance": "hidden_without_source_route_snapshot_proof"
+  },
+  "verification": {
+    "contract_test": "crates/rustok-forum/tests/topic_route_authorized_gone_transport_contract.rs",
+    "verifier": "scripts/verify/verify-forum-topic-route-authorized-gone.mjs",
+    "maintainer_commands": [
+      "node scripts/verify/verify-forum-topic-route-authorized-gone.mjs",
+      "cargo test -p rustok-forum --test topic_route_authorized_gone_transport_contract -- --nocapture",
+      "cargo test -p rustok-forum graphql::topic_route_query::tests -- --nocapture",
+      "cargo test -p rustok-forum-storefront model::tests -- --nocapture",
+      "cargo test -p rustok-storefront forum_topic_route::tests -- --nocapture",
+      "cargo check -p rustok-forum --all-targets",
+      "cargo check -p rustok-forum-storefront --all-targets --features ssr",
+      "cargo check -p rustok-storefront --all-targets --features ssr"
+    ]
+  },
+  "remaining_scope": [
+    "category route identity",
+    "canonical and hreflang document policy",
+    "Forum SEO composition",
+    "maintainer migration runtime and browser evidence"
+  ],
+  "non_claims": [
+    "no test verifier formatter Cargo migration workflow browser or CI execution is claimed",
+    "no historical visibility snapshot backfill is claimed",
+    "no private or authenticated-only tombstone disclosure is claimed",
+    "FORUM-24 remains planned"
+  ]
+}

--- a/crates/rustok-forum/contracts/forum-topic-route-storefront-graphql.json
+++ b/crates/rustok-forum/contracts/forum-topic-route-storefront-graphql.json
@@ -3,14 +3,14 @@
   "task": "FORUM-24H",
   "parent_task": "FORUM-24",
   "extends": ["FORUM-24A", "FORUM-24B", "FORUM-24C", "FORUM-24E"],
+  "extended_by": ["FORUM-24I", "FORUM-24J", "FORUM-24K"],
   "status": "source_ready_maintainer_execution_pending",
   "canonical_plan_status": "planned",
   "graphql_field": "forumStorefrontTopicRoute",
   "owner": "ForumTopicRouteService",
   "storefront_visibility_owner": "ForumTopicAudienceReadService",
-  "followup_mount_task": "FORUM-24I",
-  "followup_tombstone_snapshot_task": "FORUM-24J",
-  "followup_gone_consumer_task": "FORUM-24K",
+  "authorized_gone_decision_field": "forumStorefrontTopicRouteDecision",
+  "authorized_gone_owner": "ForumTopicRouteTombstoneVisibilityService",
   "input": {
     "tenant_id": "optional routed-tenant assertion",
     "locale": "required localized route segment",
@@ -25,7 +25,8 @@
     "canonical_descriptor": true,
     "requested_topic_id_exposed": false,
     "alias_id_exposed": false,
-    "gone_exposed": false
+    "gone_exposed": false,
+    "legacy_field_shape_changed_by_FORUM_24K": false
   },
   "authorization": {
     "module_enabled_required": true,
@@ -48,31 +49,32 @@
     "canonical_resolution_reimplemented": false,
     "redirect_target_taken_from_owner": true,
     "resolution_conflicts_fail_closed": true,
-    "gone_policy": "hidden_until_FORUM_24K_consumes_FORUM_24J_boolean_owner_decision"
+    "gone_policy": "legacy_field_stays_hidden; FORUM_24K_adds_separate_authorized_decision_field"
   },
   "compatibility": {
-    "graphql_change": "additive_query",
+    "graphql_change": "legacy_additive_query_retained",
+    "FORUM_24K_change": "separate_additive_decision_query",
     "owner_changed": false,
     "database_schema_changed": false,
     "migration_added": false,
     "semantic_event_changed": false,
     "admin_mutation_changed": false,
-    "storefront_mount_added_in_this_slice": false,
     "seo_or_hreflang_policy_changed": false
   },
   "verification": {
     "contract_test": "crates/rustok-forum/tests/topic_route_storefront_graphql_contract.rs",
     "verifier": "scripts/verify/verify-forum-topic-route-storefront-graphql.mjs",
+    "FORUM_24K_verifier": "scripts/verify/verify-forum-topic-route-authorized-gone.mjs",
     "maintainer_commands": [
       "node scripts/verify/verify-forum-topic-route-identity-owner.mjs",
       "node scripts/verify/verify-forum-topic-route-storefront-graphql.mjs",
+      "node scripts/verify/verify-forum-topic-route-authorized-gone.mjs",
       "cargo test -p rustok-forum graphql::topic_route_query::tests -- --nocapture",
       "cargo test -p rustok-forum --test topic_route_storefront_graphql_contract -- --nocapture",
       "cargo check -p rustok-forum --all-targets"
     ]
   },
   "remaining_scope": [
-    "consume the FORUM-24J boolean tombstone decision and publish authorized GONE",
     "category route identity",
     "canonical link and hreflang policy",
     "SEO integration",
@@ -80,7 +82,7 @@
   ],
   "non_claims": [
     "no test verifier formatter Cargo workflow browser or CI execution is claimed",
-    "no public gone response is claimed",
+    "FORUM-24H legacy field itself exposes no public gone response",
     "FORUM-24H itself did not mount storefront HTTP routes",
     "no category route identity is claimed",
     "FORUM-24 remains planned"

--- a/crates/rustok-forum/contracts/forum-topic-route-storefront-mount.json
+++ b/crates/rustok-forum/contracts/forum-topic-route-storefront-mount.json
@@ -3,13 +3,13 @@
   "task": "FORUM-24I",
   "parent_task": "FORUM-24",
   "extends": ["FORUM-24A", "FORUM-24H"],
+  "extended_by": ["FORUM-24J", "FORUM-24K"],
   "status": "source_ready_maintainer_execution_pending",
   "canonical_plan_status": "planned",
   "canonical_route": "/{locale}/forum/t/{short_id}/{slug}",
   "route_owner": "ForumTopicRouteService",
   "visibility_owner": "ForumTopicAudienceReadService",
-  "followup_tombstone_snapshot_task": "FORUM-24J",
-  "followup_gone_consumer_task": "FORUM-24K",
+  "tombstone_visibility_owner": "ForumTopicRouteTombstoneVisibilityService",
   "package": "rustok-forum-storefront",
   "host": "rustok-storefront",
   "transport": {
@@ -17,9 +17,11 @@
     "native_selected_for": ["ssr", "hydrate"],
     "graphql_selected_for": ["headless", "csr"],
     "automatic_fallback": false,
-    "graphql_field": "forumStorefrontTopicRoute",
+    "legacy_graphql_field": "forumStorefrontTopicRoute",
+    "selected_graphql_field_after_FORUM_24K": "forumStorefrontTopicRouteDecision",
     "native_endpoint": "forum/storefront-topic-route",
-    "exact_audience_recheck_both_paths": true
+    "exact_audience_recheck_both_paths": true,
+    "authorized_gone_owner_parity_both_paths": true
   },
   "topic_card_cutover": {
     "legacy_topic_query_links_emitted": false,
@@ -38,28 +40,32 @@
     "host_reads_forum_storage": false,
     "host_reads_alias_ledger": false,
     "host_recomputes_redirect_target": false,
+    "host_reauthorizes_gone": false,
     "canonical_exact": "SSR existing Forum module page with owner topic UUID",
     "redirect_or_nonexact_raw_path": "308 private no-store",
-    "missing_hidden_deleted_or_gone": "404 private no-store",
-    "transport_or_untyped_domain_failure": "503 private no-store",
+    "missing_hidden_or_unauthorized": "404 private no-store",
+    "authorized_gone_after_FORUM_24K": "410 private no-store",
+    "transport_or_malformed_domain_result": "503 private no-store",
     "query_topic_identity_overwritten_by_owner": true
   },
   "disclosure": {
-    "public_dispositions": ["CANONICAL", "REDIRECT"],
+    "public_dispositions_after_FORUM_24K": ["CANONICAL", "REDIRECT", "GONE"],
     "historical_topic_id_exposed": false,
     "alias_id_exposed": false,
     "alias_reason_exposed": false,
-    "gone_exposed": false,
+    "snapshot_payload_exposed": false,
+    "authorized_gone_exposed": true,
     "hidden_and_missing_indistinguishable": true,
-    "FORUM_24J_snapshot_consumed": false
+    "FORUM_24J_snapshot_consumed": true,
+    "authenticated_requests_broaden_public_snapshot": false
   },
   "compatibility": {
-    "database_schema_changed": false,
-    "migration_added": false,
+    "database_schema_changed_by_FORUM_24K": false,
+    "migration_added_by_FORUM_24K": false,
     "owner_write_changed": false,
     "semantic_event_changed": false,
     "admin_contract_changed": false,
-    "graphql_change": "existing additive field retained",
+    "legacy_graphql_field_retained": true,
     "generic_module_category_route_retained": true,
     "seo_changed": false,
     "hreflang_changed": false
@@ -67,11 +73,14 @@
   "verification": {
     "graphql_guard": "scripts/verify/verify-forum-topic-route-storefront-graphql.mjs",
     "mount_guard": "scripts/verify/verify-forum-topic-route-storefront-mount.mjs",
+    "authorized_gone_guard": "scripts/verify/verify-forum-topic-route-authorized-gone.mjs",
     "maintainer_commands": [
       "node scripts/verify/verify-forum-topic-route-storefront-graphql.mjs",
       "node scripts/verify/verify-forum-topic-route-storefront-mount.mjs",
+      "node scripts/verify/verify-forum-topic-route-authorized-gone.mjs",
       "cargo test -p rustok-forum --test topic_route_storefront_graphql_contract -- --nocapture",
-      "cargo test -p rustok-forum-storefront core::tests -- --nocapture",
+      "cargo test -p rustok-forum --test topic_route_authorized_gone_transport_contract -- --nocapture",
+      "cargo test -p rustok-forum-storefront model::tests -- --nocapture",
       "cargo test -p rustok-storefront forum_topic_route::tests -- --nocapture",
       "cargo check -p rustok-forum --all-targets",
       "cargo check -p rustok-forum-storefront --all-targets --features ssr",
@@ -79,7 +88,6 @@
     ]
   },
   "remaining_scope": [
-    "consume the FORUM-24J boolean tombstone decision and add authorized GONE/410",
     "category route identity",
     "canonical and hreflang document policy",
     "Forum SEO composition",
@@ -88,7 +96,7 @@
   ],
   "non_claims": [
     "no test verifier formatter Cargo workflow registered-host browser or CI execution is claimed",
-    "no public 410 response is claimed",
+    "no private or authenticated-only tombstone disclosure is claimed",
     "no category route identity is claimed",
     "no SEO or hreflang integration is claimed",
     "FORUM-24 remains planned"

--- a/crates/rustok-forum/contracts/forum-topic-route-tombstone-visibility-owner.json
+++ b/crates/rustok-forum/contracts/forum-topic-route-tombstone-visibility-owner.json
@@ -3,6 +3,7 @@
   "task": "FORUM-24J",
   "parent_task": "FORUM-24",
   "extends": ["FORUM-24C", "FORUM-24H", "FORUM-24I"],
+  "extended_by": ["FORUM-24K"],
   "status": "source_ready_maintainer_execution_pending",
   "canonical_plan_status": "planned",
   "owner": "ForumTopicRouteTombstoneVisibilityService",
@@ -29,11 +30,7 @@
     "category_tree_scope_locked": true,
     "topic_audience_scope_locked": true
   },
-  "lock_order": [
-    "category_tree",
-    "topic_row",
-    "topic_audience"
-  ],
+  "lock_order": ["category_tree", "topic_row", "topic_audience"],
   "lock_owner_reuse": {
     "category_tree": "category_audience::lock_category_tree_in_tx",
     "topic_audience": "topic_audience_lock::lock_topic_audience_scopes_in_tx",
@@ -66,37 +63,42 @@
     "existing_channels_appended": false,
     "payload_drift": "fail_closed_conflict"
   },
-  "compatibility": {
+  "FORUM_24J_compatibility": {
     "graphql_changed": false,
     "native_storefront_transport_changed": false,
     "storefront_http_changed": false,
-    "public_gone_exposed": false,
-    "public_410_added": false,
+    "public_gone_exposed_in_this_slice": false,
+    "public_410_added_in_this_slice": false,
     "route_identity_changed": false,
     "alias_schema_changed": false,
     "semantic_event_changed": false,
     "admin_contract_changed": false
   },
+  "consumer": {
+    "task": "FORUM-24K",
+    "graphql_and_native_use_boolean_only": true,
+    "host_reads_snapshot_storage": false,
+    "authorized_gone_status": 410,
+    "unauthorized_or_missing_snapshot_status": 404
+  },
   "historical_policy": {
     "topics_deleted_before_snapshot_migration": "hidden",
-    "same_topic_slug_alias_after_snapshotted_delete": "future_consumer_may_authorize",
+    "same_topic_slug_alias_after_snapshotted_delete": "FORUM_24K_may_authorize",
     "cross_topic_merge_target_disappearance": "hidden_without_separate_source_snapshot_proof"
   },
   "verification": {
     "contract_test": "crates/rustok-forum/tests/topic_route_tombstone_visibility_contract.rs",
     "verifier": "scripts/verify/verify-forum-topic-route-tombstone-visibility-owner.mjs",
+    "consumer_verifier": "scripts/verify/verify-forum-topic-route-authorized-gone.mjs",
     "maintainer_commands": [
       "node scripts/verify/verify-forum-topic-route-tombstone-visibility-owner.mjs",
+      "node scripts/verify/verify-forum-topic-route-authorized-gone.mjs",
       "cargo test -p rustok-forum --test topic_route_tombstone_visibility_contract -- --nocapture",
       "cargo test -p rustok-forum topic_owner::route_tombstone_visibility::tests -- --nocapture",
       "cargo check -p rustok-forum --all-targets"
     ]
   },
-  "next_task": "FORUM-24K consume the boolean owner decision in GraphQL, native storefront transport and Rust host HTTP composition",
   "remaining_scope": [
-    "publish authorized GONE through GraphQL and native storefront DTOs",
-    "map authorized GONE to private 410 in the Rust host",
-    "retain hidden and missing indistinguishability when snapshot authorization fails",
     "category route identity",
     "canonical and hreflang document policy",
     "Forum SEO composition",
@@ -104,8 +106,7 @@
   ],
   "non_claims": [
     "no test verifier formatter Cargo migration workflow browser or CI execution is claimed",
-    "no public GONE transport is claimed",
-    "no public 410 response is claimed",
+    "FORUM-24J itself added no transport or HTTP behavior",
     "no historical snapshot backfill is claimed",
     "FORUM-24 remains planned"
   ]

--- a/crates/rustok-forum/docs/README.md
+++ b/crates/rustok-forum/docs/README.md
@@ -52,9 +52,10 @@ notifications module, and cross-module release gates.
 - FORUM-24E provides a bounded, cursor-resumable owner repair that ensures exact route aliases for immutable merge receipts created before FORUM-24B.
 - FORUM-24F exposes the localized topic slug rename owner through an additive routed-tenant GraphQL mutation while preserving owner-defined update and ownership semantics.
 - FORUM-24G composes that mutation in the module-owned Leptos and Next-admin packages without adding route, alias, merge or locale-selection policy to either UI.
-- FORUM-24H exposes visibility-safe storefront canonical/redirect resolution through GraphQL, rechecks the canonical topic through the exact category/topic audience owner, and keeps `gone` hidden at the public transport boundary.
-- FORUM-24I composes the canonical localized topic route in `rustok-forum-storefront` and the shared Rust storefront router, cuts topic-card navigation over from UUID query links, preserves native/GraphQL audience parity, and keeps missing/hidden/deleted/`gone` indistinguishable as public `404`.
-- FORUM-24J records an immutable anonymous visibility and route-channel snapshot before topic deletion, seals channel scope with count and SHA-256 digest, exposes only an internal boolean owner decision, and leaves GraphQL/native/HTTP `GONE` consumption to FORUM-24K.
+- FORUM-24H exposes visibility-safe storefront canonical/redirect resolution through a legacy-compatible GraphQL field and exact category/topic audience recheck.
+- FORUM-24I composes the canonical localized topic route in `rustok-forum-storefront` and the shared Rust storefront router, cuts topic-card navigation over from UUID query links, and preserves native/GraphQL selected-path parity.
+- FORUM-24J records an immutable anonymous visibility and route-channel snapshot before topic deletion, seals channel scope with count and SHA-256 digest, and exposes only a boolean owner decision.
+- FORUM-24K adds a separate GraphQL route decision field, consumes the FORUM-24J boolean in GraphQL and native storefront paths, and maps only owner-authorized tombstones to private no-store `410 Gone` while preserving `404` for missing or unauthorized history.
 
 ## Verification
 
@@ -65,6 +66,7 @@ notifications module, and cross-module release gates.
 - `node scripts/verify/verify-forum-topic-route-storefront-graphql.mjs`
 - `node scripts/verify/verify-forum-topic-route-storefront-mount.mjs`
 - `node scripts/verify/verify-forum-topic-route-tombstone-visibility-owner.mjs`
+- `node scripts/verify/verify-forum-topic-route-authorized-gone.mjs`
 - task-specific owner, transport, UI and runtime commands from the canonical plan
 
 ## Related documents
@@ -98,6 +100,7 @@ notifications module, and cross-module release gates.
 - [FORUM-24H storefront topic route GraphQL transport](./forum-24h-topic-route-storefront-graphql.md)
 - [FORUM-24I storefront topic route mount](./forum-24i-topic-route-storefront-mount.md)
 - [FORUM-24J topic route tombstone visibility owner](./forum-24j-topic-route-tombstone-visibility.md)
+- [FORUM-24K authorized topic route gone transport](./forum-24k-topic-route-authorized-gone.md)
 - [Admin UI package](../admin/README.md)
 - [Storefront UI package](../storefront/README.md)
 - [Event flow contract](../../../docs/architecture/event-flow-contract.md)

--- a/crates/rustok-forum/docs/forum-24h-topic-route-storefront-graphql.md
+++ b/crates/rustok-forum/docs/forum-24h-topic-route-storefront-graphql.md
@@ -48,15 +48,17 @@ It intentionally does not expose:
 - alias reasons or persistence metadata;
 - a public `GONE` disposition.
 
-## Why `GONE` remains hidden
+## Why `GONE` was hidden
 
 At the time of FORUM-24H, the tombstone ledger had no visibility snapshot, so returning a public `410 Gone` could disclose a formerly private or channel-restricted topic.
 
-FORUM-24J later adds an immutable boolean-and-channel visibility snapshot owner for newly deleted topics. FORUM-24H itself remains unchanged and still returns `null` for `ForumTopicRouteDisposition::Gone`; the GraphQL consumer is deliberately deferred to FORUM-24K. Until that consumer validates the snapshot through the owner, this transport does not expose public `GONE`.
+FORUM-24J later adds an immutable boolean-and-channel visibility snapshot owner for newly deleted topics. The FORUM-24H legacy field remains schema-compatible and still returns `null` for `ForumTopicRouteDisposition::Gone`.
+
+FORUM-24K adds a separate additive `forumStorefrontTopicRouteDecision` field. Only that new field may expose `GONE`, and only after `ForumTopicRouteTombstoneVisibilityService::can_disclose_public_gone` admits the deletion-time public route for the current routed channel. The legacy response still does not expose historical topic IDs, alias IDs, snapshot payloads, audience selectors, or channel lists.
 
 ## Compatibility
 
-This is an additive GraphQL query. It changes no route owner method, mutation, database schema, migration, event or admin workflow. FORUM-24I later composes the query and equivalent native owner path into the Rust storefront host. FORUM-24J changes delete-side owner storage only and does not alter this query output.
+The FORUM-24H field remains additive and unchanged. FORUM-24K does not make its enum wider or its canonical target nullable; it adds a separate decision type instead. This preserves existing generated clients while allowing the module-owned storefront package to opt into authorized terminal decisions.
 
 ## Verification handoff
 
@@ -65,14 +67,14 @@ No commands were executed while preparing or aligning this source slice. Maintai
 ```bash
 node scripts/verify/verify-forum-topic-route-identity-owner.mjs
 node scripts/verify/verify-forum-topic-route-storefront-graphql.mjs
+node scripts/verify/verify-forum-topic-route-authorized-gone.mjs
 cargo test -p rustok-forum graphql::topic_route_query::tests -- --nocapture
 cargo test -p rustok-forum --test topic_route_storefront_graphql_contract -- --nocapture
 cargo check -p rustok-forum --all-targets
 ```
 
-## Remaining FORUM-24 scope after FORUM-24J
+## Remaining FORUM-24 scope after FORUM-24K
 
-- consume the visibility-authorized snapshot in GraphQL/native transport and host HTTP policy;
 - add category route identity;
 - define canonical and hreflang document policy;
 - integrate SEO and capture runtime evidence.

--- a/crates/rustok-forum/docs/forum-24i-topic-route-storefront-mount.md
+++ b/crates/rustok-forum/docs/forum-24i-topic-route-storefront-mount.md
@@ -23,16 +23,22 @@ The slice includes:
 
 `rustok-forum-storefront` owns route DTOs, selected-path transport selection and topic-card href policy. The host does not query Forum persistence, inspect the alias ledger, resolve merge receipts, calculate redirect targets or authorize topics.
 
-The host receives only a visibility-admitted route resolution and performs HTTP composition:
+The original FORUM-24I host composition was:
 
-- exact `CANONICAL` path: render the existing Forum module page with the owner-resolved topic UUID injected into request context;
-- `REDIRECT` or a nonexact raw locale/identity/slug path: return private `308 Permanent Redirect` to `canonical.path`;
-- missing, deleted, hidden, channel-restricted or `GONE`: return private `404 Not Found`;
-- transport/domain failure without a public typed route result: return private `503 Service Unavailable`.
+- exact `CANONICAL`: render the existing Forum module page;
+- `REDIRECT` or nonexact raw path: private `308 Permanent Redirect`;
+- missing, hidden, deleted, channel-restricted or `GONE`: private `404 Not Found`;
+- transport failure: private `503 Service Unavailable`.
+
+FORUM-24K extends only the terminal decision:
+
+- an owner-authorized `GONE` becomes private `410 Gone`;
+- missing, unsnapshotted, formerly private, disabled-channel or channel-mismatched routes remain private `404`;
+- malformed decision shapes and snapshot integrity conflicts become private `503`.
+
+The host still does not authorize `GONE`; GraphQL or native transport must already have consumed `ForumTopicRouteTombstoneVisibilityService::can_disclose_public_gone`. Redirect and terminal responses use `Cache-Control: private, no-store`.
 
 Axum-decoded route segments are passed only to the module owner for resolution. Canonical equality is checked against `OriginalUri.path()`, so case variants and percent-encoded noncanonical paths redirect instead of being mistaken for exact canonical requests.
-
-Redirect and terminal responses use `Cache-Control: private, no-store`.
 
 ## Dual transport
 
@@ -42,9 +48,11 @@ The storefront package exposes one facade:
 resolve_storefront_topic_route(locale, short_id, slug)
 ```
 
-SSR/hydrate selects the native server function. Headless/CSR selects the additive `forumStorefrontTopicRoute` GraphQL query. There is no automatic fallback between selected paths.
+SSR/hydrate selects the native server function. Headless/CSR selects GraphQL. There is no automatic fallback between selected paths.
 
-The native path composes `ForumTopicRouteService` with `ForumTopicAudienceReadService`, the routed tenant, optional trusted auth snapshot, request channel and exact native audience port context. The GraphQL query is aligned to the same audience owner and exact GraphQL port context.
+FORUM-24K switches the GraphQL adapter from the legacy canonical/redirect-only `forumStorefrontTopicRoute` field to additive `forumStorefrontTopicRouteDecision`. The native endpoint remains `forum/storefront-topic-route`. Both paths consume the same boolean tombstone owner and share the same `CANONICAL | REDIRECT | GONE` DTO.
+
+Canonical and redirect results retain exact `ForumTopicAudienceReadService` parity. Authentication does not broaden deletion-time public tombstone disclosure.
 
 ## Topic-card cutover
 
@@ -52,25 +60,11 @@ Topic cards no longer emit `?topic=<uuid>` links. The module core derives the de
 
 Category selection remains on the existing module query route. Selecting a canonical topic route reopens the topic through the owner-resolved UUID before rendering.
 
-## Deliberate exclusions
-
-FORUM-24I does not add:
-
-- public `410 Gone` responses;
-- a consumer for a visibility-authorized deleted-route snapshot;
-- category route identity;
-- canonical, hreflang or alternate document metadata;
-- Forum-specific SEO head composition;
-- Next storefront route mounting;
-- runtime, browser or registered-host evidence.
-
-FORUM-24J later adds an immutable boolean-and-channel tombstone visibility owner for newly deleted topics. FORUM-24I remains unchanged: GraphQL and native route DTOs do not expose `GONE`, so the host continues to collapse it to the same public `404` as hidden or missing content. FORUM-24K is responsible for consuming the boolean decision and adding authorized HTTP `410` composition.
-
 ## Compatibility
 
-The GraphQL field remains additive. FORUM-24I itself adds no migration, storage schema, owner write method, semantic event, admin mutation or receipt changes. FORUM-24J is a separate delete-side storage owner slice and does not alter the I transport or HTTP contract.
+FORUM-24K adds a new GraphQL field instead of widening the legacy enum or making the legacy canonical field nullable. The existing generic module route remains available for category navigation and direct noncanonical module access.
 
-The existing generic module route remains available for category navigation and direct noncanonical module access. Topic-card navigation cuts over to the canonical topic route.
+No FORUM-24K migration, owner write, semantic event, admin mutation, SEO or hreflang change is introduced.
 
 ## Verification handoff
 
@@ -81,18 +75,19 @@ Maintainers can run:
 ```bash
 node scripts/verify/verify-forum-topic-route-storefront-graphql.mjs
 node scripts/verify/verify-forum-topic-route-storefront-mount.mjs
+node scripts/verify/verify-forum-topic-route-authorized-gone.mjs
 cargo test -p rustok-forum --test topic_route_storefront_graphql_contract -- --nocapture
-cargo test -p rustok-forum-storefront core::tests -- --nocapture
+cargo test -p rustok-forum --test topic_route_authorized_gone_transport_contract -- --nocapture
+cargo test -p rustok-forum-storefront model::tests -- --nocapture
 cargo test -p rustok-storefront forum_topic_route::tests -- --nocapture
 cargo check -p rustok-forum --all-targets
 cargo check -p rustok-forum-storefront --all-targets --features ssr
 cargo check -p rustok-storefront --all-targets --features ssr
 ```
 
-## Remaining FORUM-24 scope after FORUM-24J
+## Remaining FORUM-24 scope after FORUM-24K
 
-- consume the boolean deleted-route disclosure owner and add authorized public `410`;
 - category route identity and historical aliases;
 - canonical/hreflang document policy;
 - SEO integration across storefront hosts;
-- maintainer runtime evidence.
+- maintainer migration, runtime and browser evidence.

--- a/crates/rustok-forum/docs/forum-24k-topic-route-authorized-gone.md
+++ b/crates/rustok-forum/docs/forum-24k-topic-route-authorized-gone.md
@@ -1,0 +1,109 @@
+# FORUM-24K authorized topic route `GONE` transport
+
+Status: **source-ready / maintainer execution pending**
+
+## Scope
+
+FORUM-24K consumes the immutable FORUM-24J boolean disclosure owner in the selected Forum storefront route paths and maps an authorized terminal decision to private HTTP `410 Gone`.
+
+The slice changes no route identity, alias persistence, deletion snapshot, audience policy, semantic event, admin command, SEO document or category route.
+
+## Additive GraphQL compatibility
+
+The legacy field remains unchanged:
+
+```graphql
+forumStorefrontTopicRoute(...): GqlForumStorefrontTopicRouteResolution
+```
+
+It continues to expose only `CANONICAL` and `REDIRECT`, keeps `canonical` non-null, and returns `null` for `GONE`.
+
+FORUM-24K adds a separate field:
+
+```graphql
+forumStorefrontTopicRouteDecision(...): GqlForumStorefrontTopicRouteDecision
+```
+
+The decision enum contains `CANONICAL`, `REDIRECT`, and `GONE`. Its `canonical` field is nullable because an authorized terminal route has no redirect or render target. Existing generated clients are not forced to accept a wider legacy enum or nullable legacy field.
+
+## Authorization
+
+Both GraphQL and native server composition resolve route identity through `ForumTopicRouteService`.
+
+Canonical and redirect results retain the existing exact `ForumTopicAudienceReadService` recheck.
+
+A `GONE` result is returned only when all of these conditions hold:
+
+- the current routed channel has the Forum module enabled when a channel is present;
+- the route owner provides its historical topic identity internally;
+- `ForumTopicRouteTombstoneVisibilityService::can_disclose_public_gone` returns `true`;
+- the deletion-time snapshot was publicly disclosable;
+- a channel-restricted snapshot contains the current routed channel slug;
+- the sealed channel count and digest remain valid.
+
+Authentication never broadens this public tombstone decision. A formerly private, authenticated-only, hidden, or differently channel-scoped topic remains indistinguishable from a missing route.
+
+The transports do not query the snapshot tables, alias table, category storage or audience relation storage directly. They receive only the boolean owner decision.
+
+## Dual transport
+
+`rustok-forum-storefront` keeps one selected-path facade:
+
+```rust
+resolve_storefront_topic_route(locale, short_id, slug)
+```
+
+SSR/hydrate uses the existing native server endpoint. Headless/CSR uses the new additive GraphQL decision field. There is no automatic fallback between paths.
+
+The shared DTO enforces these semantic shapes at the host boundary:
+
+- `CANONICAL` requires a canonical descriptor;
+- `REDIRECT` requires a canonical descriptor;
+- `GONE` forbids a canonical descriptor.
+
+Malformed transport shapes fail closed as `503 Service Unavailable`.
+
+## HTTP composition
+
+The Rust storefront host maps the selected decision as follows:
+
+- exact `CANONICAL`: render the existing Forum module page;
+- `REDIRECT` or nonexact raw canonical path: private `308 Permanent Redirect`;
+- authorized `GONE`: private `410 Gone`;
+- missing, unauthorized, unsnapshotted or mismatched-channel route: private `404 Not Found`;
+- malformed decision, snapshot integrity conflict or transport failure: private `503 Service Unavailable`.
+
+Terminal and redirect responses retain `Cache-Control: private, no-store` through the existing host helper.
+
+## Historical policy
+
+Topics deleted before FORUM-24J have no deletion-time proof and remain hidden. No backfill is attempted.
+
+Same-topic localized slug aliases may inherit the topic snapshot because their historical owner is the deleted topic. A cross-topic redirect whose target later disappears remains hidden unless a separate source-route proof exists.
+
+## Verification handoff
+
+No tests, verifiers, formatting, Cargo commands, migrations, workflows, registered-host runs or browser scenarios were executed while preparing this source slice.
+
+Maintainers can run:
+
+```bash
+node scripts/verify/verify-forum-topic-route-storefront-graphql.mjs
+node scripts/verify/verify-forum-topic-route-storefront-mount.mjs
+node scripts/verify/verify-forum-topic-route-authorized-gone.mjs
+cargo test -p rustok-forum --test topic_route_storefront_graphql_contract -- --nocapture
+cargo test -p rustok-forum --test topic_route_authorized_gone_transport_contract -- --nocapture
+cargo test -p rustok-forum graphql::topic_route_query::tests -- --nocapture
+cargo test -p rustok-forum-storefront model::tests -- --nocapture
+cargo test -p rustok-storefront forum_topic_route::tests -- --nocapture
+cargo check -p rustok-forum --all-targets
+cargo check -p rustok-forum-storefront --all-targets --features ssr
+cargo check -p rustok-storefront --all-targets --features ssr
+```
+
+## Remaining FORUM-24 scope
+
+- category route identity and historical aliases;
+- canonical and hreflang document policy;
+- Forum SEO composition across storefront hosts;
+- maintainer migration, runtime and browser evidence.

--- a/crates/rustok-forum/src/graphql/mod.rs
+++ b/crates/rustok-forum/src/graphql/mod.rs
@@ -58,6 +58,7 @@ pub use topic_reply_range_move_mutation::{
     GqlForumReplyRangeMove, MoveForumTopicReplyRangeGraphqlInput,
 };
 pub use topic_route_query::{
+    GqlForumStorefrontTopicRouteDecision, GqlForumStorefrontTopicRouteDecisionDisposition,
     GqlForumStorefrontTopicRouteDisposition, GqlForumStorefrontTopicRouteResolution,
 };
 pub use topic_slug_rename_mutation::{

--- a/crates/rustok-forum/src/graphql/topic_route_query.rs
+++ b/crates/rustok-forum/src/graphql/topic_route_query.rs
@@ -108,8 +108,13 @@ async fn resolve_authorized_public_route(
     let db = ctx.data::<DatabaseConnection>()?;
     let tenant = ctx.data::<TenantContext>()?;
     let tenant_id = resolve_tenant_scope(tenant, requested_tenant_id)?;
-    let channel_enabled = forum_channel_enabled(ctx).await?;
-    if ctx.data_opt::<AuthContext>().is_none() && !channel_enabled {
+    let authenticated = ctx.data_opt::<AuthContext>().is_some();
+    let anonymous_channel_enabled = if authenticated {
+        true
+    } else {
+        forum_channel_enabled(ctx).await?
+    };
+    if !anonymous_channel_enabled {
         return Err(async_graphql::Error::new(
             "Forum module is not enabled for this channel",
         )
@@ -128,7 +133,15 @@ async fn resolve_authorized_public_route(
     };
 
     if resolution.disposition == ForumTopicRouteDisposition::Gone {
-        if !disclose_gone || !channel_enabled {
+        if !disclose_gone {
+            return Ok(None);
+        }
+        let gone_channel_enabled = if authenticated {
+            forum_channel_enabled(ctx).await?
+        } else {
+            anonymous_channel_enabled
+        };
+        if !gone_channel_enabled {
             return Ok(None);
         }
         let topic_id = resolution.requested_topic_id.ok_or_else(|| {

--- a/crates/rustok-forum/src/graphql/topic_route_query.rs
+++ b/crates/rustok-forum/src/graphql/topic_route_query.rs
@@ -11,7 +11,8 @@ use uuid::Uuid;
 
 use crate::{
     ForumError, ForumTopicReadOperation, ForumTopicReadTransport, ForumTopicRouteDisposition,
-    ForumTopicRouteResolution, ForumTopicRouteService, topic_read_audience_port_context,
+    ForumTopicRouteResolution, ForumTopicRouteService,
+    ForumTopicRouteTombstoneVisibilityService, topic_read_audience_port_context,
 };
 
 use super::{ForumGraphqlRuntimeData, GqlForumTopicRouteDescriptor};
@@ -23,11 +24,7 @@ pub(crate) struct ForumTopicRouteQuery;
 
 #[Object]
 impl ForumTopicRouteQuery {
-    /// Resolves one public Forum topic route after rechecking the canonical topic through the
-    /// exact storefront audience contract.
-    ///
-    /// Deleted-route tombstones intentionally remain hidden until Forum owns a visibility
-    /// snapshot that can authorize a public `gone` response without disclosing private history.
+    /// Legacy canonical/redirect-only route query retained for existing clients.
     async fn forum_storefront_topic_route(
         &self,
         ctx: &Context<'_>,
@@ -36,83 +33,34 @@ impl ForumTopicRouteQuery {
         short_id: String,
         slug: String,
     ) -> Result<Option<GqlForumStorefrontTopicRouteResolution>> {
-        require_module_enabled(ctx, MODULE_SLUG).await?;
-        require_public_forum_channel_enabled(ctx).await?;
-
-        let db = ctx.data::<DatabaseConnection>()?;
-        let event_bus = ctx.data::<TransactionalEventBus>()?;
-        let tenant = ctx.data::<TenantContext>()?;
-        let tenant_id = resolve_tenant_scope(tenant, tenant_id)?;
-
-        let resolution = match ForumTopicRouteService::new(db.clone())
-            .resolve(tenant_id, &locale, &short_id, &slug)
-            .await
-        {
-            Ok(resolution) => resolution,
-            Err(ForumError::TopicNotFound(_))
-            | Err(ForumError::TopicDeleted)
-            | Err(ForumError::TopicRouteNotFound) => return Ok(None),
-            Err(error) => return Err(async_graphql::Error::new(error.to_string())),
+        let Some(resolution) = resolve_authorized_public_route(
+            ctx, tenant_id, locale, short_id, slug,
+        )
+        .await?
+        else {
+            return Ok(None);
         };
+        map_legacy_public_route_resolution(resolution)
+    }
 
-        let canonical = match resolution.disposition {
-            ForumTopicRouteDisposition::Canonical | ForumTopicRouteDisposition::Redirect => {
-                resolution.canonical.as_ref().ok_or_else(|| {
-                    async_graphql::Error::new(
-                        "Forum topic route resolution did not provide a canonical target",
-                    )
-                    .extend_with(|_, extension| {
-                        extension.set("code", "INTERNAL_SERVER_ERROR")
-                    })
-                })?
-            }
-            ForumTopicRouteDisposition::Gone => return Ok(None),
+    /// Resolves one storefront topic route and may disclose `GONE` only through the immutable
+    /// FORUM-24J public tombstone decision for the current routed channel.
+    async fn forum_storefront_topic_route_decision(
+        &self,
+        ctx: &Context<'_>,
+        tenant_id: Option<Uuid>,
+        locale: String,
+        short_id: String,
+        slug: String,
+    ) -> Result<Option<GqlForumStorefrontTopicRouteDecision>> {
+        let Some(resolution) = resolve_authorized_public_route(
+            ctx, tenant_id, locale, short_id, slug,
+        )
+        .await?
+        else {
+            return Ok(None);
         };
-
-        let runtime = ctx
-            .data_opt::<ForumGraphqlRuntimeData>()
-            .cloned()
-            .unwrap_or_default();
-        let service = runtime.topic_audience_read_service(db.clone(), event_bus.clone());
-        let visible = if let Some(auth) = ctx.data_opt::<AuthContext>() {
-            let security =
-                SecurityContext::from_permission_snapshot(Some(auth.user_id), &auth.permissions);
-            let audience_context = topic_read_audience_port_context(
-                ForumTopicReadTransport::Graphql,
-                ForumTopicReadOperation::SelectedTopic,
-                tenant_id,
-                auth,
-                ctx.data_opt::<RequestContext>(),
-                canonical.locale.as_str(),
-            )?;
-            service
-                .get_authenticated_storefront_visible_with_audience_context(
-                    tenant_id,
-                    security,
-                    audience_context,
-                    canonical.topic_id,
-                    Some(tenant.default_locale.as_str()),
-                )
-                .await
-        } else {
-            service
-                .get_public_storefront_visible_with_locale_fallback(
-                    tenant_id,
-                    canonical.topic_id,
-                    canonical.locale.as_str(),
-                    Some(tenant.default_locale.as_str()),
-                    public_channel_slug(ctx).as_deref(),
-                )
-                .await
-        };
-        match visible {
-            Ok(Some(_)) => map_public_route_resolution(resolution),
-            Ok(None)
-            | Err(ForumError::TopicNotFound(_))
-            | Err(ForumError::TopicDeleted)
-            | Err(ForumError::TopicRouteNotFound) => Ok(None),
-            Err(error) => Err(async_graphql::Error::new(error.to_string())),
-        }
+        map_public_route_decision(resolution).map(Some)
     }
 }
 
@@ -131,7 +79,122 @@ pub struct GqlForumStorefrontTopicRouteResolution {
     pub canonical: GqlForumTopicRouteDescriptor,
 }
 
-fn map_public_route_resolution(
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Enum)]
+pub enum GqlForumStorefrontTopicRouteDecisionDisposition {
+    Canonical,
+    Redirect,
+    Gone,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, SimpleObject)]
+pub struct GqlForumStorefrontTopicRouteDecision {
+    pub requested_locale: String,
+    pub requested_short_id: String,
+    pub requested_slug: String,
+    pub disposition: GqlForumStorefrontTopicRouteDecisionDisposition,
+    pub canonical: Option<GqlForumTopicRouteDescriptor>,
+}
+
+async fn resolve_authorized_public_route(
+    ctx: &Context<'_>,
+    requested_tenant_id: Option<Uuid>,
+    locale: String,
+    short_id: String,
+    slug: String,
+) -> Result<Option<ForumTopicRouteResolution>> {
+    require_module_enabled(ctx, MODULE_SLUG).await?;
+
+    let db = ctx.data::<DatabaseConnection>()?;
+    let tenant = ctx.data::<TenantContext>()?;
+    let tenant_id = resolve_tenant_scope(tenant, requested_tenant_id)?;
+    let channel_enabled = forum_channel_enabled(ctx).await?;
+    if ctx.data_opt::<AuthContext>().is_none() && !channel_enabled {
+        return Err(async_graphql::Error::new(
+            "Forum module is not enabled for this channel",
+        )
+        .extend_with(|_, extension| extension.set("code", "FORBIDDEN")));
+    }
+
+    let resolution = match ForumTopicRouteService::new(db.clone())
+        .resolve(tenant_id, &locale, &short_id, &slug)
+        .await
+    {
+        Ok(resolution) => resolution,
+        Err(ForumError::TopicNotFound(_))
+        | Err(ForumError::TopicDeleted)
+        | Err(ForumError::TopicRouteNotFound) => return Ok(None),
+        Err(error) => return Err(async_graphql::Error::new(error.to_string())),
+    };
+
+    if resolution.disposition == ForumTopicRouteDisposition::Gone {
+        if !channel_enabled {
+            return Ok(None);
+        }
+        let topic_id = resolution.requested_topic_id.ok_or_else(|| {
+            internal_error("Forum gone route resolution did not provide its historical topic identity")
+        })?;
+        let disclose = ForumTopicRouteTombstoneVisibilityService::new(db.clone())
+            .can_disclose_public_gone(
+                tenant_id,
+                topic_id,
+                public_channel_slug(ctx).as_deref(),
+            )
+            .await
+            .map_err(|error| async_graphql::Error::new(error.to_string()))?;
+        return Ok(disclose.then_some(resolution));
+    }
+
+    let canonical = resolution.canonical.as_ref().ok_or_else(|| {
+        internal_error("Forum topic route resolution did not provide a canonical target")
+    })?;
+    let event_bus = ctx.data::<TransactionalEventBus>()?;
+    let runtime = ctx
+        .data_opt::<ForumGraphqlRuntimeData>()
+        .cloned()
+        .unwrap_or_default();
+    let service = runtime.topic_audience_read_service(db.clone(), event_bus.clone());
+    let visible = if let Some(auth) = ctx.data_opt::<AuthContext>() {
+        let security =
+            SecurityContext::from_permission_snapshot(Some(auth.user_id), &auth.permissions);
+        let audience_context = topic_read_audience_port_context(
+            ForumTopicReadTransport::Graphql,
+            ForumTopicReadOperation::SelectedTopic,
+            tenant_id,
+            auth,
+            ctx.data_opt::<RequestContext>(),
+            canonical.locale.as_str(),
+        )?;
+        service
+            .get_authenticated_storefront_visible_with_audience_context(
+                tenant_id,
+                security,
+                audience_context,
+                canonical.topic_id,
+                Some(tenant.default_locale.as_str()),
+            )
+            .await
+    } else {
+        service
+            .get_public_storefront_visible_with_locale_fallback(
+                tenant_id,
+                canonical.topic_id,
+                canonical.locale.as_str(),
+                Some(tenant.default_locale.as_str()),
+                public_channel_slug(ctx).as_deref(),
+            )
+            .await
+    };
+    match visible {
+        Ok(Some(_)) => Ok(Some(resolution)),
+        Ok(None)
+        | Err(ForumError::TopicNotFound(_))
+        | Err(ForumError::TopicDeleted)
+        | Err(ForumError::TopicRouteNotFound) => Ok(None),
+        Err(error) => Err(async_graphql::Error::new(error.to_string())),
+    }
+}
+
+fn map_legacy_public_route_resolution(
     resolution: ForumTopicRouteResolution,
 ) -> Result<Option<GqlForumStorefrontTopicRouteResolution>> {
     let disposition = match resolution.disposition {
@@ -144,10 +207,7 @@ fn map_public_route_resolution(
         ForumTopicRouteDisposition::Gone => return Ok(None),
     };
     let canonical = resolution.canonical.ok_or_else(|| {
-        async_graphql::Error::new(
-            "Forum topic route resolution did not provide a canonical target",
-        )
-        .extend_with(|_, extension| extension.set("code", "INTERNAL_SERVER_ERROR"))
+        internal_error("Forum topic route resolution did not provide a canonical target")
     })?;
 
     Ok(Some(GqlForumStorefrontTopicRouteResolution {
@@ -159,33 +219,78 @@ fn map_public_route_resolution(
     }))
 }
 
-async fn require_public_forum_channel_enabled(ctx: &Context<'_>) -> Result<()> {
-    let db = ctx.data::<DatabaseConnection>()?;
-    if ctx.data_opt::<AuthContext>().is_some() {
-        return Ok(());
-    }
-    let Some(request_context) = ctx.data_opt::<RequestContext>() else {
-        return Ok(());
-    };
-    let Some(channel_id) = request_context.channel_id else {
-        return Ok(());
+fn map_public_route_decision(
+    resolution: ForumTopicRouteResolution,
+) -> Result<GqlForumStorefrontTopicRouteDecision> {
+    let (disposition, canonical) = match resolution.disposition {
+        ForumTopicRouteDisposition::Canonical => (
+            GqlForumStorefrontTopicRouteDecisionDisposition::Canonical,
+            Some(
+                resolution
+                    .canonical
+                    .ok_or_else(|| {
+                        internal_error(
+                            "Forum topic route resolution did not provide a canonical target",
+                        )
+                    })?
+                    .into(),
+            ),
+        ),
+        ForumTopicRouteDisposition::Redirect => (
+            GqlForumStorefrontTopicRouteDecisionDisposition::Redirect,
+            Some(
+                resolution
+                    .canonical
+                    .ok_or_else(|| {
+                        internal_error(
+                            "Forum topic route resolution did not provide a canonical target",
+                        )
+                    })?
+                    .into(),
+            ),
+        ),
+        ForumTopicRouteDisposition::Gone => {
+            if resolution.canonical.is_some() {
+                return Err(internal_error(
+                    "Forum gone route resolution unexpectedly provided a canonical target",
+                ));
+            }
+            (
+                GqlForumStorefrontTopicRouteDecisionDisposition::Gone,
+                None,
+            )
+        }
     };
 
-    let enabled = ChannelService::new(db.clone())
+    Ok(GqlForumStorefrontTopicRouteDecision {
+        requested_locale: resolution.requested_locale,
+        requested_short_id: resolution.requested_short_id,
+        requested_slug: resolution.requested_slug,
+        disposition,
+        canonical,
+    })
+}
+
+async fn forum_channel_enabled(ctx: &Context<'_>) -> Result<bool> {
+    let Some(request_context) = ctx.data_opt::<RequestContext>() else {
+        return Ok(true);
+    };
+    let Some(channel_id) = request_context.channel_id else {
+        return Ok(true);
+    };
+    let db = ctx.data::<DatabaseConnection>()?;
+    ChannelService::new(db.clone())
         .is_module_enabled(channel_id, MODULE_SLUG)
         .await
         .map_err(|error| {
             async_graphql::Error::new(format!("Channel module check failed: {error}"))
                 .extend_with(|_, extension| extension.set("code", "INTERNAL_SERVER_ERROR"))
-        })?;
-    if enabled {
-        Ok(())
-    } else {
-        Err(
-            async_graphql::Error::new("Forum module is not enabled for this channel")
-                .extend_with(|_, extension| extension.set("code", "FORBIDDEN")),
-        )
-    }
+        })
+}
+
+fn internal_error(message: &'static str) -> async_graphql::Error {
+    async_graphql::Error::new(message)
+        .extend_with(|_, extension| extension.set("code", "INTERNAL_SERVER_ERROR"))
 }
 
 fn resolve_tenant_scope(tenant: &TenantContext, requested_tenant_id: Option<Uuid>) -> Result<Uuid> {
@@ -229,7 +334,10 @@ mod tests {
             requested_locale: "en".to_string(),
             requested_short_id: "000000000000".to_string(),
             requested_slug: "old-welcome".to_string(),
-            requested_topic_id: None,
+            requested_topic_id: Some(
+                Uuid::parse_str("00000000-0000-4000-8000-000000000001")
+                    .expect("topic id"),
+            ),
             disposition,
             canonical,
             alias_id: None,
@@ -237,8 +345,8 @@ mod tests {
     }
 
     #[test]
-    fn maps_only_canonical_and_redirect_public_results() {
-        let canonical = map_public_route_resolution(resolution(
+    fn legacy_mapping_keeps_canonical_and_redirect_only() {
+        let canonical = map_legacy_public_route_resolution(resolution(
             ForumTopicRouteDisposition::Canonical,
             Some(descriptor()),
         ))
@@ -249,31 +357,31 @@ mod tests {
             GqlForumStorefrontTopicRouteDisposition::Canonical
         );
 
-        let redirect = map_public_route_resolution(resolution(
-            ForumTopicRouteDisposition::Redirect,
-            Some(descriptor()),
-        ))
-        .expect("redirect mapping")
-        .expect("redirect result");
+        assert!(
+            map_legacy_public_route_resolution(resolution(
+                ForumTopicRouteDisposition::Gone,
+                None,
+            ))
+            .expect("gone mapping")
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn decision_mapping_exposes_authorized_gone_without_canonical_target() {
+        let gone = map_public_route_decision(resolution(ForumTopicRouteDisposition::Gone, None))
+            .expect("gone decision");
         assert_eq!(
-            redirect.disposition,
-            GqlForumStorefrontTopicRouteDisposition::Redirect
+            gone.disposition,
+            GqlForumStorefrontTopicRouteDecisionDisposition::Gone
         );
+        assert!(gone.canonical.is_none());
     }
 
     #[test]
-    fn hides_gone_routes_without_a_visibility_snapshot() {
+    fn disclosed_nonterminal_decisions_require_canonical_target() {
         assert!(
-            map_public_route_resolution(resolution(ForumTopicRouteDisposition::Gone, None))
-                .expect("gone mapping")
-                .is_none()
-        );
-    }
-
-    #[test]
-    fn requires_canonical_target_for_disclosed_results() {
-        assert!(
-            map_public_route_resolution(resolution(
+            map_public_route_decision(resolution(
                 ForumTopicRouteDisposition::Redirect,
                 None,
             ))

--- a/crates/rustok-forum/src/graphql/topic_route_query.rs
+++ b/crates/rustok-forum/src/graphql/topic_route_query.rs
@@ -34,7 +34,7 @@ impl ForumTopicRouteQuery {
         slug: String,
     ) -> Result<Option<GqlForumStorefrontTopicRouteResolution>> {
         let Some(resolution) = resolve_authorized_public_route(
-            ctx, tenant_id, locale, short_id, slug,
+            ctx, tenant_id, locale, short_id, slug, false,
         )
         .await?
         else {
@@ -54,7 +54,7 @@ impl ForumTopicRouteQuery {
         slug: String,
     ) -> Result<Option<GqlForumStorefrontTopicRouteDecision>> {
         let Some(resolution) = resolve_authorized_public_route(
-            ctx, tenant_id, locale, short_id, slug,
+            ctx, tenant_id, locale, short_id, slug, true,
         )
         .await?
         else {
@@ -101,6 +101,7 @@ async fn resolve_authorized_public_route(
     locale: String,
     short_id: String,
     slug: String,
+    disclose_gone: bool,
 ) -> Result<Option<ForumTopicRouteResolution>> {
     require_module_enabled(ctx, MODULE_SLUG).await?;
 
@@ -127,7 +128,7 @@ async fn resolve_authorized_public_route(
     };
 
     if resolution.disposition == ForumTopicRouteDisposition::Gone {
-        if !channel_enabled {
+        if !disclose_gone || !channel_enabled {
             return Ok(None);
         }
         let topic_id = resolution.requested_topic_id.ok_or_else(|| {

--- a/crates/rustok-forum/src/graphql/topic_route_query.rs
+++ b/crates/rustok-forum/src/graphql/topic_route_query.rs
@@ -9,10 +9,10 @@ use rustok_outbox::TransactionalEventBus;
 use sea_orm::DatabaseConnection;
 use uuid::Uuid;
 
+use crate::services::ForumTopicRouteTombstoneVisibilityService;
 use crate::{
     ForumError, ForumTopicReadOperation, ForumTopicReadTransport, ForumTopicRouteDisposition,
-    ForumTopicRouteResolution, ForumTopicRouteService,
-    ForumTopicRouteTombstoneVisibilityService, topic_read_audience_port_context,
+    ForumTopicRouteResolution, ForumTopicRouteService, topic_read_audience_port_context,
 };
 
 use super::{ForumGraphqlRuntimeData, GqlForumTopicRouteDescriptor};

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -248,6 +248,7 @@ pub use topic_route_backfill::{
     ForumTopicMergeRouteBackfillResult, ForumTopicMergeRouteBackfillService,
     MAX_FORUM_TOPIC_MERGE_ROUTE_BACKFILL_OPERATIONS,
 };
+pub use topic_owner::route_tombstone_visibility::ForumTopicRouteTombstoneVisibilityService;
 pub use topic_create_audience_authorization::{
     ForumTopicCreateAudienceAuthorization, ForumTopicCreateAudienceAuthorizationService,
 };

--- a/crates/rustok-forum/src/services/topic_owner_inline.rs
+++ b/crates/rustok-forum/src/services/topic_owner_inline.rs
@@ -2,7 +2,7 @@ use super::{
     category_audience, category_visibility, topic_audience, topic_audience_lock,
 };
 
-pub(crate) mod route_tombstone_visibility {
+pub mod route_tombstone_visibility {
     include!("topic_route_tombstone_visibility.rs");
 }
 

--- a/crates/rustok-forum/storefront/src/model.rs
+++ b/crates/rustok-forum/storefront/src/model.rs
@@ -141,6 +141,7 @@ pub struct ForumReplyDetail {
 pub enum StorefrontForumTopicRouteDisposition {
     Canonical,
     Redirect,
+    Gone,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -163,7 +164,7 @@ pub struct StorefrontForumTopicRouteResolution {
     #[serde(rename = "requestedSlug")]
     pub requested_slug: String,
     pub disposition: StorefrontForumTopicRouteDisposition,
-    pub canonical: StorefrontForumTopicRouteDescriptor,
+    pub canonical: Option<StorefrontForumTopicRouteDescriptor>,
 }
 
 #[cfg(test)]
@@ -245,6 +246,28 @@ mod tests {
             route.disposition,
             StorefrontForumTopicRouteDisposition::Redirect
         );
-        assert_eq!(route.canonical.slug, "welcome");
+        assert_eq!(
+            route.canonical.as_ref().map(|canonical| canonical.slug.as_str()),
+            Some("welcome")
+        );
+    }
+
+    #[test]
+    fn gone_route_payload_has_no_canonical_target() {
+        let route: StorefrontForumTopicRouteResolution = serde_json::from_value(
+            serde_json::json!({
+                "requestedLocale": "en",
+                "requestedShortId": "123456789abc",
+                "requestedSlug": "retired-topic",
+                "disposition": "GONE",
+                "canonical": null
+            }),
+        )
+        .expect("gone route payload");
+        assert_eq!(
+            route.disposition,
+            StorefrontForumTopicRouteDisposition::Gone
+        );
+        assert!(route.canonical.is_none());
     }
 }

--- a/crates/rustok-forum/storefront/src/transport/native_server_adapter_topic_route.rs
+++ b/crates/rustok-forum/storefront/src/transport/native_server_adapter_topic_route.rs
@@ -23,6 +23,7 @@ async fn storefront_topic_route_native(
     {
         use rustok_api::{HostRuntimeContext, OptionalAuthContext, RequestContext, TenantContext};
         use rustok_core::SecurityContext;
+        use rustok_forum::services::ForumTopicRouteTombstoneVisibilityService;
         use rustok_forum::{
             ForumError, ForumTopicAudienceReadService, ForumTopicReadOperation,
             ForumTopicReadTransport, ForumTopicRouteDisposition, ForumTopicRouteService,
@@ -43,16 +44,16 @@ async fn storefront_topic_route_native(
             .map_err(ServerFnError::new)?;
         let db = runtime_ctx.db_clone();
 
-        if auth.is_none() {
-            if let Some(channel_id) = request.channel_id {
-                let enabled = rustok_channel::ChannelService::new(db.clone())
-                    .is_module_enabled(channel_id, "forum")
-                    .await
-                    .map_err(server_error)?;
-                if !enabled {
-                    return Ok(None);
-                }
-            }
+        let channel_enabled = if let Some(channel_id) = request.channel_id {
+            rustok_channel::ChannelService::new(db.clone())
+                .is_module_enabled(channel_id, "forum")
+                .await
+                .map_err(server_error)?
+        } else {
+            true
+        };
+        if auth.is_none() && !channel_enabled {
+            return Ok(None);
         }
 
         let resolution = match ForumTopicRouteService::new(db.clone())
@@ -65,17 +66,35 @@ async fn storefront_topic_route_native(
             | Err(ForumError::TopicRouteNotFound) => return Ok(None),
             Err(error) => return Err(server_error(error)),
         };
-        let canonical = match resolution.disposition {
-            ForumTopicRouteDisposition::Canonical | ForumTopicRouteDisposition::Redirect => {
-                resolution.canonical.as_ref().ok_or_else(|| {
-                    ServerFnError::new(
-                        "Forum topic route resolution did not provide a canonical target",
-                    )
-                })?
-            }
-            ForumTopicRouteDisposition::Gone => return Ok(None),
-        };
 
+        if resolution.disposition == ForumTopicRouteDisposition::Gone {
+            if !channel_enabled {
+                return Ok(None);
+            }
+            let topic_id = resolution.requested_topic_id.ok_or_else(|| {
+                ServerFnError::new(
+                    "Forum gone route resolution did not provide its historical topic identity",
+                )
+            })?;
+            let disclose = ForumTopicRouteTombstoneVisibilityService::new(db.clone())
+                .can_disclose_public_gone(
+                    tenant.id,
+                    topic_id,
+                    request.channel_slug.as_deref(),
+                )
+                .await
+                .map_err(server_error)?;
+            if !disclose {
+                return Ok(None);
+            }
+            return map_native_topic_route_resolution(resolution);
+        }
+
+        let canonical = resolution.canonical.as_ref().ok_or_else(|| {
+            ServerFnError::new(
+                "Forum topic route resolution did not provide a canonical target",
+            )
+        })?;
         let event_bus = runtime_ctx
             .shared_get::<TransactionalEventBus>()
             .ok_or_else(|| {
@@ -142,29 +161,55 @@ async fn storefront_topic_route_native(
 fn map_native_topic_route_resolution(
     resolution: rustok_forum::ForumTopicRouteResolution,
 ) -> Result<Option<StorefrontForumTopicRouteResolution>, ServerFnError> {
-    let disposition = match resolution.disposition {
-        rustok_forum::ForumTopicRouteDisposition::Canonical => {
-            StorefrontForumTopicRouteDisposition::Canonical
+    let (disposition, canonical) = match resolution.disposition {
+        rustok_forum::ForumTopicRouteDisposition::Canonical => (
+            StorefrontForumTopicRouteDisposition::Canonical,
+            Some(map_native_canonical_descriptor(
+                resolution.canonical.ok_or_else(|| {
+                    ServerFnError::new(
+                        "Forum topic route resolution did not provide a canonical target",
+                    )
+                })?,
+            )),
+        ),
+        rustok_forum::ForumTopicRouteDisposition::Redirect => (
+            StorefrontForumTopicRouteDisposition::Redirect,
+            Some(map_native_canonical_descriptor(
+                resolution.canonical.ok_or_else(|| {
+                    ServerFnError::new(
+                        "Forum topic route resolution did not provide a canonical target",
+                    )
+                })?,
+            )),
+        ),
+        rustok_forum::ForumTopicRouteDisposition::Gone => {
+            if resolution.canonical.is_some() {
+                return Err(ServerFnError::new(
+                    "Forum gone route resolution unexpectedly provided a canonical target",
+                ));
+            }
+            (StorefrontForumTopicRouteDisposition::Gone, None)
         }
-        rustok_forum::ForumTopicRouteDisposition::Redirect => {
-            StorefrontForumTopicRouteDisposition::Redirect
-        }
-        rustok_forum::ForumTopicRouteDisposition::Gone => return Ok(None),
     };
-    let canonical = resolution.canonical.ok_or_else(|| {
-        ServerFnError::new("Forum topic route resolution did not provide a canonical target")
-    })?;
+
     Ok(Some(StorefrontForumTopicRouteResolution {
         requested_locale: resolution.requested_locale,
         requested_short_id: resolution.requested_short_id,
         requested_slug: resolution.requested_slug,
         disposition,
-        canonical: StorefrontForumTopicRouteDescriptor {
-            topic_id: canonical.topic_id.to_string(),
-            locale: canonical.locale,
-            short_id: canonical.short_id,
-            slug: canonical.slug,
-            path: canonical.path,
-        },
+        canonical,
     }))
+}
+
+#[cfg(feature = "ssr")]
+fn map_native_canonical_descriptor(
+    canonical: rustok_forum::ForumTopicRouteDescriptor,
+) -> StorefrontForumTopicRouteDescriptor {
+    StorefrontForumTopicRouteDescriptor {
+        topic_id: canonical.topic_id.to_string(),
+        locale: canonical.locale,
+        short_id: canonical.short_id,
+        slug: canonical.slug,
+        path: canonical.path,
+    }
 }

--- a/crates/rustok-forum/storefront/src/transport/native_server_adapter_topic_route.rs
+++ b/crates/rustok-forum/storefront/src/transport/native_server_adapter_topic_route.rs
@@ -43,8 +43,11 @@ async fn storefront_topic_route_native(
             .await
             .map_err(ServerFnError::new)?;
         let db = runtime_ctx.db_clone();
+        let authenticated = auth.is_some();
 
-        let channel_enabled = if let Some(channel_id) = request.channel_id {
+        let anonymous_channel_enabled = if authenticated {
+            true
+        } else if let Some(channel_id) = request.channel_id {
             rustok_channel::ChannelService::new(db.clone())
                 .is_module_enabled(channel_id, "forum")
                 .await
@@ -52,7 +55,7 @@ async fn storefront_topic_route_native(
         } else {
             true
         };
-        if auth.is_none() && !channel_enabled {
+        if !anonymous_channel_enabled {
             return Ok(None);
         }
 
@@ -68,7 +71,19 @@ async fn storefront_topic_route_native(
         };
 
         if resolution.disposition == ForumTopicRouteDisposition::Gone {
-            if !channel_enabled {
+            let gone_channel_enabled = if authenticated {
+                if let Some(channel_id) = request.channel_id {
+                    rustok_channel::ChannelService::new(db.clone())
+                        .is_module_enabled(channel_id, "forum")
+                        .await
+                        .map_err(server_error)?
+                } else {
+                    true
+                }
+            } else {
+                anonymous_channel_enabled
+            };
+            if !gone_channel_enabled {
                 return Ok(None);
             }
             let topic_id = resolution.requested_topic_id.ok_or_else(|| {

--- a/crates/rustok-forum/storefront/src/transport/topic_route_graphql_adapter.rs
+++ b/crates/rustok-forum/storefront/src/transport/topic_route_graphql_adapter.rs
@@ -1,11 +1,11 @@
 use crate::model::StorefrontForumTopicRouteResolution;
 
-const STOREFRONT_FORUM_TOPIC_ROUTE_QUERY: &str = "query StorefrontForumTopicRoute($tenantId: UUID, $locale: String!, $shortId: String!, $slug: String!) { forumStorefrontTopicRoute(tenantId: $tenantId, locale: $locale, shortId: $shortId, slug: $slug) { requestedLocale requestedShortId requestedSlug disposition canonical { topicId locale shortId slug path } } }";
+const STOREFRONT_FORUM_TOPIC_ROUTE_QUERY: &str = "query StorefrontForumTopicRouteDecision($tenantId: UUID, $locale: String!, $shortId: String!, $slug: String!) { forumStorefrontTopicRouteDecision(tenantId: $tenantId, locale: $locale, shortId: $shortId, slug: $slug) { requestedLocale requestedShortId requestedSlug disposition canonical { topicId locale shortId slug path } } }";
 
 #[derive(Debug, Deserialize)]
 struct StorefrontForumTopicRouteResponse {
-    #[serde(rename = "forumStorefrontTopicRoute")]
-    forum_storefront_topic_route: Option<StorefrontForumTopicRouteResolution>,
+    #[serde(rename = "forumStorefrontTopicRouteDecision")]
+    forum_storefront_topic_route_decision: Option<StorefrontForumTopicRouteResolution>,
 }
 
 #[derive(Debug, Serialize)]
@@ -33,5 +33,5 @@ pub async fn resolve_storefront_topic_route_graphql(
         },
     )
     .await?;
-    Ok(response.forum_storefront_topic_route)
+    Ok(response.forum_storefront_topic_route_decision)
 }

--- a/crates/rustok-forum/tests/topic_route_authorized_gone_transport_contract.rs
+++ b/crates/rustok-forum/tests/topic_route_authorized_gone_transport_contract.rs
@@ -1,0 +1,137 @@
+const GRAPHQL_QUERY: &str = include_str!("../src/graphql/topic_route_query.rs");
+const GRAPHQL_MOD: &str = include_str!("../src/graphql/mod.rs");
+const SERVICES_MOD: &str = include_str!("../src/services/mod.rs");
+const STOREFRONT_MODEL: &str = include_str!("../storefront/src/model.rs");
+const GRAPHQL_ADAPTER: &str =
+    include_str!("../storefront/src/transport/topic_route_graphql_adapter.rs");
+const NATIVE_ADAPTER: &str =
+    include_str!("../storefront/src/transport/native_server_adapter_topic_route.rs");
+const HOST: &str = include_str!("../../../apps/storefront/src/forum_topic_route.rs");
+
+fn require(source: &str, markers: &[&str]) {
+    for marker in markers {
+        assert!(source.contains(marker), "missing source marker {marker}");
+    }
+}
+
+fn forbid(source: &str, markers: &[&str]) {
+    for marker in markers {
+        assert!(!source.contains(marker), "forbidden source marker {marker}");
+    }
+}
+
+#[test]
+fn graphql_keeps_legacy_field_and_adds_authorized_decision() {
+    require(
+        GRAPHQL_QUERY,
+        &[
+            "async fn forum_storefront_topic_route(",
+            "map_legacy_public_route_resolution(resolution)",
+            "ForumTopicRouteDisposition::Gone => return Ok(None)",
+            "async fn forum_storefront_topic_route_decision(",
+            "GqlForumStorefrontTopicRouteDecisionDisposition",
+            "Gone",
+            "pub canonical: Option<GqlForumTopicRouteDescriptor>",
+            "ForumTopicRouteTombstoneVisibilityService::new(db.clone())",
+            ".can_disclose_public_gone(",
+            "public_channel_slug(ctx).as_deref()",
+        ],
+    );
+    require(
+        GRAPHQL_MOD,
+        &[
+            "GqlForumStorefrontTopicRouteDecision",
+            "GqlForumStorefrontTopicRouteDecisionDisposition",
+        ],
+    );
+    forbid(
+        GRAPHQL_QUERY,
+        &[
+            "GqlForumStorefrontTopicRouteDisposition::Gone",
+            "forum_topic_route_tombstone_visibility",
+            "forum_topic_route_tombstone_channels",
+            "forum_topic_route_aliases",
+            "Statement::from_sql_and_values",
+        ],
+    );
+}
+
+#[test]
+fn owner_export_reveals_service_not_snapshot_payload() {
+    require(
+        SERVICES_MOD,
+        &["ForumTopicRouteTombstoneVisibilityService"],
+    );
+    forbid(
+        SERVICES_MOD,
+        &[
+            "StoredForumTopicRouteTombstoneVisibility",
+            "route_channel_digest",
+            "load_snapshot_channel_slugs",
+        ],
+    );
+}
+
+#[test]
+fn storefront_transports_share_terminal_decision_shape() {
+    require(
+        STOREFRONT_MODEL,
+        &[
+            "StorefrontForumTopicRouteDisposition",
+            "Gone",
+            "pub canonical: Option<StorefrontForumTopicRouteDescriptor>",
+        ],
+    );
+    require(
+        GRAPHQL_ADAPTER,
+        &[
+            "forumStorefrontTopicRouteDecision",
+            "StorefrontForumTopicRouteDecision",
+            "canonical { topicId locale shortId slug path }",
+        ],
+    );
+    require(
+        NATIVE_ADAPTER,
+        &[
+            "ForumTopicRouteTombstoneVisibilityService",
+            ".can_disclose_public_gone(",
+            "request.channel_slug.as_deref()",
+            "StorefrontForumTopicRouteDisposition::Gone",
+            "(StorefrontForumTopicRouteDisposition::Gone, None)",
+        ],
+    );
+    forbid(
+        NATIVE_ADAPTER,
+        &[
+            "forum_topic_route_tombstone_visibility",
+            "forum_topic_route_tombstone_channels",
+            "forum_topic_route_aliases",
+            "Statement::from_sql_and_values",
+        ],
+    );
+}
+
+#[test]
+fn host_maps_only_authorized_terminal_decision_to_private_gone() {
+    require(
+        HOST,
+        &[
+            "ForumTopicHostAction::Gone",
+            "StatusCode::GONE",
+            "This Forum topic route is no longer available",
+            "ForumTopicHostAction::Invalid",
+            "StatusCode::SERVICE_UNAVAILABLE",
+            "StorefrontForumTopicRouteDisposition::Gone, None",
+            "StorefrontForumTopicRouteDisposition::Gone, Some(_)",
+        ],
+    );
+    forbid(
+        HOST,
+        &[
+            "ForumTopicRouteTombstoneVisibilityService",
+            "can_disclose_public_gone",
+            "forum_topic_route_tombstone_visibility",
+            "forum_topic_route_aliases",
+        ],
+    );
+}

--- a/crates/rustok-forum/tests/topic_route_storefront_graphql_contract.rs
+++ b/crates/rustok-forum/tests/topic_route_storefront_graphql_contract.rs
@@ -6,7 +6,7 @@ const TOPIC_ROUTE_QUERY: &str = include_str!("../src/graphql/topic_route_query.r
 const GRAPHQL_MOD: &str = include_str!("../src/graphql/mod.rs");
 
 #[test]
-fn graphql_schema_exposes_visibility_safe_storefront_topic_route_resolution() {
+fn graphql_schema_retains_legacy_route_and_adds_authorized_decision() {
     let schema = Schema::build(
         ForumQuery::default(),
         ForumMutation::default(),
@@ -20,8 +20,12 @@ fn graphql_schema_exposes_visibility_safe_storefront_topic_route_resolution() {
         "forumStorefrontTopicRoute",
         "GqlForumStorefrontTopicRouteResolution",
         "GqlForumStorefrontTopicRouteDisposition",
+        "forumStorefrontTopicRouteDecision",
+        "GqlForumStorefrontTopicRouteDecision",
+        "GqlForumStorefrontTopicRouteDecisionDisposition",
         "CANONICAL",
         "REDIRECT",
+        "GONE",
         "requestedLocale",
         "requestedShortId",
         "requestedSlug",
@@ -38,10 +42,10 @@ fn graphql_schema_exposes_visibility_safe_storefront_topic_route_resolution() {
 }
 
 #[test]
-fn storefront_topic_route_query_rechecks_exact_audience_and_hides_tombstone_identity() {
+fn route_query_reuses_exact_audience_and_tombstone_decision_owners() {
     for marker in [
         "require_module_enabled(ctx, MODULE_SLUG).await?",
-        "require_public_forum_channel_enabled(ctx).await?",
+        "forum_channel_enabled(ctx).await?",
         "Permission denied: tenant scope mismatch",
         "ForumTopicRouteService::new(db.clone())",
         ".resolve(tenant_id, &locale, &short_id, &slug)",
@@ -52,7 +56,9 @@ fn storefront_topic_route_query_rechecks_exact_audience_and_hides_tombstone_iden
         ".get_authenticated_storefront_visible_with_audience_context(",
         ".get_public_storefront_visible_with_locale_fallback(",
         "SecurityContext::from_permission_snapshot",
-        "ForumTopicRouteDisposition::Gone => return Ok(None)",
+        "ForumTopicRouteTombstoneVisibilityService::new(db.clone())",
+        ".can_disclose_public_gone(",
+        "GqlForumStorefrontTopicRouteDecisionDisposition::Gone",
         "ChannelService::new(db.clone())",
     ] {
         assert!(
@@ -69,6 +75,8 @@ fn storefront_topic_route_query_rechecks_exact_audience_and_hides_tombstone_iden
         "pub alias_id",
         "GqlForumStorefrontTopicRouteDisposition::Gone",
         "forum_topic_route_aliases",
+        "forum_topic_route_tombstone_visibility",
+        "forum_topic_route_tombstone_channels",
         "Statement::from_sql_and_values",
         "SELECT ",
         "record_redirect_alias",
@@ -78,6 +86,21 @@ fn storefront_topic_route_query_rechecks_exact_audience_and_hides_tombstone_iden
             !TOPIC_ROUTE_QUERY.contains(forbidden),
             "storefront route query contains forbidden marker {forbidden}"
         );
+    }
+}
+
+#[test]
+fn legacy_field_still_hides_gone_while_decision_field_can_expose_it() {
+    for marker in [
+        "async fn forum_storefront_topic_route(",
+        "map_legacy_public_route_resolution(resolution)",
+        "ForumTopicRouteDisposition::Gone => return Ok(None)",
+        "async fn forum_storefront_topic_route_decision(",
+        "map_public_route_decision(resolution).map(Some)",
+        "GqlForumStorefrontTopicRouteDecisionDisposition::Gone",
+        "pub canonical: Option<GqlForumTopicRouteDescriptor>",
+    ] {
+        assert!(TOPIC_ROUTE_QUERY.contains(marker), "missing marker {marker}");
     }
 }
 

--- a/scripts/verify/verify-forum-topic-route-authorized-gone.mjs
+++ b/scripts/verify/verify-forum-topic-route-authorized-gone.mjs
@@ -58,15 +58,16 @@ try {
 
 for (const marker of [
   "async fn forum_storefront_topic_route(",
-  "map_legacy_public_route_resolution(resolution)",
+  "resolve_authorized_public_route(\n            ctx, tenant_id, locale, short_id, slug, false,",
   "ForumTopicRouteDisposition::Gone => return Ok(None)",
   "async fn forum_storefront_topic_route_decision(",
+  "resolve_authorized_public_route(\n            ctx, tenant_id, locale, short_id, slug, true,",
   "GqlForumStorefrontTopicRouteDecisionDisposition::Gone",
   "pub canonical: Option<GqlForumTopicRouteDescriptor>",
   "ForumTopicRouteTombstoneVisibilityService::new(db.clone())",
   ".can_disclose_public_gone(",
   "public_channel_slug(ctx).as_deref()",
-  "if !channel_enabled",
+  "if !gone_channel_enabled",
 ]) {
   requireText(source.graphql, marker, paths.graphql);
 }
@@ -106,6 +107,7 @@ for (const marker of [
   "request.channel_slug.as_deref()",
   "StorefrontForumTopicRouteDisposition::Gone",
   "(StorefrontForumTopicRouteDisposition::Gone, None)",
+  "let gone_channel_enabled = if authenticated",
 ]) {
   requireText(source.nativeAdapter, marker, paths.nativeAdapter);
 }
@@ -156,7 +158,7 @@ for (const marker of [
 for (const marker of [
   "legacy",
   "forumStorefrontTopicRouteDecision",
-  "private `410 Gone`",
+  "private HTTP `410 Gone`",
   "Authentication never broadens",
   "No tests, verifiers, formatting, Cargo commands",
 ]) {
@@ -173,7 +175,7 @@ for (const marker of [
   requireText(source.contract, marker, paths.contract);
 }
 for (const marker of [
-  "legacy_field_still_hides_gone",
+  "graphql_keeps_legacy_field_and_adds_authorized_decision",
   "storefront_transports_share_terminal_decision_shape",
   "host_maps_only_authorized_terminal_decision_to_private_gone",
 ]) {

--- a/scripts/verify/verify-forum-topic-route-authorized-gone.mjs
+++ b/scripts/verify/verify-forum-topic-route-authorized-gone.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "../..");
+const failures = [];
+
+const paths = {
+  graphql: "crates/rustok-forum/src/graphql/topic_route_query.rs",
+  graphqlMod: "crates/rustok-forum/src/graphql/mod.rs",
+  servicesMod: "crates/rustok-forum/src/services/mod.rs",
+  owner: "crates/rustok-forum/src/services/topic_route_tombstone_visibility.rs",
+  model: "crates/rustok-forum/storefront/src/model.rs",
+  graphqlAdapter:
+    "crates/rustok-forum/storefront/src/transport/topic_route_graphql_adapter.rs",
+  nativeAdapter:
+    "crates/rustok-forum/storefront/src/transport/native_server_adapter_topic_route.rs",
+  host: "apps/storefront/src/forum_topic_route.rs",
+  hostLib: "apps/storefront/src/lib.rs",
+  contract:
+    "crates/rustok-forum/contracts/forum-topic-route-authorized-gone-transport.json",
+  test: "crates/rustok-forum/tests/topic_route_authorized_gone_transport_contract.rs",
+  docs: "crates/rustok-forum/docs/forum-24k-topic-route-authorized-gone.md",
+};
+
+function read(relativePath) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  if (!existsSync(absolutePath)) {
+    failures.push(`${relativePath}: expected file is missing`);
+    return "";
+  }
+  return readFileSync(absolutePath, "utf8");
+}
+
+function requireText(content, marker, label) {
+  if (!content.includes(marker)) failures.push(`${label}: missing ${marker}`);
+}
+
+function forbidText(content, marker, label) {
+  if (content.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+}
+
+const source = Object.fromEntries(
+  Object.entries(paths).map(([key, value]) => [key, read(value)]),
+);
+
+let contract = null;
+try {
+  contract = JSON.parse(source.contract);
+} catch (error) {
+  failures.push(`${paths.contract}: invalid JSON (${error.message})`);
+}
+
+for (const marker of [
+  "async fn forum_storefront_topic_route(",
+  "map_legacy_public_route_resolution(resolution)",
+  "ForumTopicRouteDisposition::Gone => return Ok(None)",
+  "async fn forum_storefront_topic_route_decision(",
+  "GqlForumStorefrontTopicRouteDecisionDisposition::Gone",
+  "pub canonical: Option<GqlForumTopicRouteDescriptor>",
+  "ForumTopicRouteTombstoneVisibilityService::new(db.clone())",
+  ".can_disclose_public_gone(",
+  "public_channel_slug(ctx).as_deref()",
+  "if !channel_enabled",
+]) {
+  requireText(source.graphql, marker, paths.graphql);
+}
+
+for (const marker of [
+  "GqlForumStorefrontTopicRouteDecision",
+  "GqlForumStorefrontTopicRouteDecisionDisposition",
+]) {
+  requireText(source.graphqlMod, marker, paths.graphqlMod);
+}
+requireText(
+  source.servicesMod,
+  "ForumTopicRouteTombstoneVisibilityService",
+  paths.servicesMod,
+);
+requireText(
+  source.owner,
+  "pub async fn can_disclose_public_gone(",
+  paths.owner,
+);
+
+for (const marker of [
+  "Gone",
+  "pub canonical: Option<StorefrontForumTopicRouteDescriptor>",
+]) {
+  requireText(source.model, marker, paths.model);
+}
+for (const marker of [
+  "forumStorefrontTopicRouteDecision",
+  "StorefrontForumTopicRouteDecision",
+]) {
+  requireText(source.graphqlAdapter, marker, paths.graphqlAdapter);
+}
+for (const marker of [
+  "ForumTopicRouteTombstoneVisibilityService",
+  ".can_disclose_public_gone(",
+  "request.channel_slug.as_deref()",
+  "StorefrontForumTopicRouteDisposition::Gone",
+  "(StorefrontForumTopicRouteDisposition::Gone, None)",
+]) {
+  requireText(source.nativeAdapter, marker, paths.nativeAdapter);
+}
+for (const marker of [
+  "ForumTopicHostAction::Gone",
+  "StatusCode::GONE",
+  "This Forum topic route is no longer available",
+  "ForumTopicHostAction::Invalid",
+  "StatusCode::SERVICE_UNAVAILABLE",
+]) {
+  requireText(source.host, marker, paths.host);
+}
+for (const marker of [
+  "const PRIVATE_NO_STORE: &str = \"private, no-store\"",
+  "fn private_status_response",
+]) {
+  requireText(source.hostLib, marker, paths.hostLib);
+}
+
+for (const [label, content] of [
+  [paths.graphql, source.graphql],
+  [paths.nativeAdapter, source.nativeAdapter],
+  [paths.host, source.host],
+]) {
+  for (const marker of [
+    "forum_topic_route_tombstone_visibility",
+    "forum_topic_route_tombstone_channels",
+    "forum_topic_route_aliases",
+    "SELECT ",
+  ]) {
+    forbidText(content, marker, label);
+  }
+}
+for (const marker of [
+  "ForumTopicRouteTombstoneVisibilityService",
+  "can_disclose_public_gone",
+]) {
+  forbidText(source.host, marker, paths.host);
+}
+for (const marker of [
+  "StoredForumTopicRouteTombstoneVisibility",
+  "route_channel_digest",
+  "load_snapshot_channel_slugs",
+]) {
+  forbidText(source.servicesMod, marker, paths.servicesMod);
+}
+
+for (const marker of [
+  "legacy",
+  "forumStorefrontTopicRouteDecision",
+  "private `410 Gone`",
+  "Authentication never broadens",
+  "No tests, verifiers, formatting, Cargo commands",
+]) {
+  requireText(source.docs, marker, paths.docs);
+}
+for (const marker of [
+  "legacy_field_changed",
+  "decision_field_additive",
+  "gone_requires_deletion_time_public_snapshot",
+  "authenticated_requests_do_not_broaden_public_snapshot",
+  "authorized_gone_status",
+  "malformed_shapes_fail_closed",
+]) {
+  requireText(source.contract, marker, paths.contract);
+}
+for (const marker of [
+  "legacy_field_still_hides_gone",
+  "storefront_transports_share_terminal_decision_shape",
+  "host_maps_only_authorized_terminal_decision_to_private_gone",
+]) {
+  requireText(source.test, marker, paths.test);
+}
+
+if (contract) {
+  if (contract.task !== "FORUM-24K") {
+    failures.push(`${paths.contract}: task must be FORUM-24K`);
+  }
+  if (contract.graphql?.legacy_field_changed !== false) {
+    failures.push(`${paths.contract}: legacy GraphQL field must remain unchanged`);
+  }
+  if (contract.graphql?.decision_field_additive !== true) {
+    failures.push(`${paths.contract}: decision field must be additive`);
+  }
+  if (contract.authorization?.authenticated_requests_do_not_broaden_public_snapshot !== true) {
+    failures.push(`${paths.contract}: authentication must not broaden tombstone disclosure`);
+  }
+  if (contract.host?.authorized_gone_status !== 410) {
+    failures.push(`${paths.contract}: authorized gone status must be 410`);
+  }
+  if (contract.host?.authorized_gone_cache_control !== "private, no-store") {
+    failures.push(`${paths.contract}: authorized gone cache policy must be private, no-store`);
+  }
+  if (contract.shape_invariants?.malformed_shapes_fail_closed !== true) {
+    failures.push(`${paths.contract}: malformed shapes must fail closed`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("forum authorized topic route gone verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("forum authorized topic route gone verification passed");

--- a/scripts/verify/verify-forum-topic-route-storefront-graphql.mjs
+++ b/scripts/verify/verify-forum-topic-route-storefront-graphql.mjs
@@ -15,6 +15,7 @@ const paths = {
   graphqlMod: "crates/rustok-forum/src/graphql/mod.rs",
   owner: "crates/rustok-forum/src/services/topic_route.rs",
   audienceOwner: "crates/rustok-forum/src/services/topic_audience_read.rs",
+  tombstoneOwner: "crates/rustok-forum/src/services/topic_route_tombstone_visibility.rs",
   contract: "crates/rustok-forum/contracts/forum-topic-route-storefront-graphql.json",
   test: "crates/rustok-forum/tests/topic_route_storefront_graphql_contract.rs",
   docs: "crates/rustok-forum/docs/forum-24h-topic-route-storefront-graphql.md",
@@ -44,6 +45,7 @@ const query = read(paths.query);
 const graphqlMod = read(paths.graphqlMod);
 const owner = read(paths.owner);
 const audienceOwner = read(paths.audienceOwner);
+const tombstoneOwner = read(paths.tombstoneOwner);
 const contractText = read(paths.contract);
 const test = read(paths.test);
 const docs = read(paths.docs);
@@ -57,33 +59,33 @@ try {
 
 for (const marker of [
   "async fn forum_storefront_topic_route(",
+  "map_legacy_public_route_resolution(resolution)",
+  "ForumTopicRouteDisposition::Gone => return Ok(None)",
+  "async fn forum_storefront_topic_route_decision(",
+  "ForumTopicRouteTombstoneVisibilityService::new(db.clone())",
+  ".can_disclose_public_gone(",
+  "GqlForumStorefrontTopicRouteDecisionDisposition::Gone",
+  "pub canonical: Option<GqlForumTopicRouteDescriptor>",
   "require_module_enabled(ctx, MODULE_SLUG).await?",
-  "require_public_forum_channel_enabled(ctx).await?",
+  "forum_channel_enabled(ctx).await?",
   "Permission denied: tenant scope mismatch",
   "ForumTopicRouteService::new(db.clone())",
-  ".resolve(tenant_id, &locale, &short_id, &slug)",
   ".topic_audience_read_service(db.clone(), event_bus.clone())",
   "topic_read_audience_port_context(",
-  "ForumTopicReadTransport::Graphql",
-  "ForumTopicReadOperation::SelectedTopic",
   ".get_authenticated_storefront_visible_with_audience_context(",
   ".get_public_storefront_visible_with_locale_fallback(",
-  "SecurityContext::from_permission_snapshot",
-  "ForumTopicRouteDisposition::Gone => return Ok(None)",
-  "GqlForumStorefrontTopicRouteDisposition::Canonical",
-  "GqlForumStorefrontTopicRouteDisposition::Redirect",
 ]) {
   requireText(query, marker, paths.query);
 }
 
 for (const marker of [
   "TopicService::new",
-  "is_topic_visible_for_channel(",
-  "crate::constants::topic_status::OPEN",
   "pub requested_topic_id",
   "pub alias_id",
   "GqlForumStorefrontTopicRouteDisposition::Gone",
   "forum_topic_route_aliases",
+  "forum_topic_route_tombstone_visibility",
+  "forum_topic_route_tombstone_channels",
   "Statement::from_sql_and_values",
   "record_redirect_alias_in_tx",
   "record_gone_alias_in_tx",
@@ -93,11 +95,7 @@ for (const marker of [
 }
 
 requireText(graphqlMod, "mod topic_route_query;", paths.graphqlMod);
-requireText(
-  graphqlMod,
-  "topic_route_query::ForumTopicRouteQuery",
-  paths.graphqlMod,
-);
+requireText(graphqlMod, "topic_route_query::ForumTopicRouteQuery", paths.graphqlMod);
 requireText(owner, "pub async fn resolve(", paths.owner);
 requireText(
   owner,
@@ -108,29 +106,30 @@ for (const marker of [
   "pub struct ForumTopicAudienceReadService",
   "get_authenticated_storefront_visible_with_audience_context",
   "get_public_storefront_visible_with_locale_fallback",
-  "ForumTopicAudienceVisibilityService",
 ]) {
   requireText(audienceOwner, marker, paths.audienceOwner);
 }
+requireText(
+  tombstoneOwner,
+  "pub async fn can_disclose_public_gone(",
+  paths.tombstoneOwner,
+);
 
 for (const marker of [
   "forumStorefrontTopicRoute",
-  "GqlForumStorefrontTopicRouteResolution",
-  "CANONICAL",
-  "REDIRECT",
-  "requestedLocale",
-  "requestedShortId",
-  "requestedSlug",
-  ".topic_audience_read_service",
+  "forumStorefrontTopicRouteDecision",
+  "GqlForumStorefrontTopicRouteDecision",
+  "GONE",
+  ".can_disclose_public_gone(",
 ]) {
   requireText(test, marker, paths.test);
 }
 
 for (const marker of [
-  "visibility snapshot",
-  "returns `null`",
+  "FORUM-24J",
+  "FORUM-24K",
+  "legacy",
   "does not expose",
-  "public `GONE`",
   "No commands were executed",
 ]) {
   requireText(docs, marker, paths.docs);
@@ -143,26 +142,14 @@ if (contract) {
   if (contract.status !== "source_ready_maintainer_execution_pending") {
     failures.push(`${paths.contract}: unexpected source status`);
   }
-  if (contract.storefront_visibility_owner !== "ForumTopicAudienceReadService") {
-    failures.push(`${paths.contract}: exact audience owner must be declared`);
-  }
   if (contract.output?.gone_exposed !== false) {
-    failures.push(`${paths.contract}: gone_exposed must remain false`);
+    failures.push(`${paths.contract}: legacy gone_exposed must remain false`);
   }
   if (contract.output?.requested_topic_id_exposed !== false) {
     failures.push(`${paths.contract}: requested topic identity must stay hidden`);
   }
-  if (contract.output?.alias_id_exposed !== false) {
-    failures.push(`${paths.contract}: alias identity must stay hidden`);
-  }
   if (contract.authorization?.canonical_topic_rechecked !== true) {
     failures.push(`${paths.contract}: canonical topic visibility recheck is required`);
-  }
-  if (contract.authorization?.exact_audience_owner_rechecked !== true) {
-    failures.push(`${paths.contract}: exact audience recheck is required`);
-  }
-  if (contract.route_policy?.canonical_resolution_reimplemented !== false) {
-    failures.push(`${paths.contract}: canonical resolution must remain owner-defined`);
   }
 }
 

--- a/scripts/verify/verify-forum-topic-route-storefront-mount.mjs
+++ b/scripts/verify/verify-forum-topic-route-storefront-mount.mjs
@@ -17,23 +17,19 @@ const paths = {
   transport: "crates/rustok-forum/storefront/src/transport/mod.rs",
   graphql: "crates/rustok-forum/storefront/src/transport/topic_route_graphql_adapter.rs",
   native: "crates/rustok-forum/storefront/src/transport/native_server_adapter_topic_route.rs",
-  graphqlOwner: "crates/rustok-forum/src/graphql/topic_route_query.rs",
   host: "apps/storefront/src/forum_topic_route.rs",
   hostLib: "apps/storefront/src/lib.rs",
   contract: "crates/rustok-forum/contracts/forum-topic-route-storefront-mount.json",
   docs: "crates/rustok-forum/docs/forum-24i-topic-route-storefront-mount.md",
 };
 
-function absolute(relativePath) {
-  return path.join(repoRoot, relativePath);
-}
-
 function read(relativePath) {
-  if (!existsSync(absolute(relativePath))) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  if (!existsSync(absolutePath)) {
     failures.push(`${relativePath}: expected file is missing`);
     return "";
   }
-  return readFileSync(absolute(relativePath), "utf8");
+  return readFileSync(absolutePath, "utf8");
 }
 
 function requireText(content, marker, label) {
@@ -44,21 +40,13 @@ function forbidText(content, marker, label) {
   if (content.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
 }
 
-const core = read(paths.core);
-const model = read(paths.model);
-const packageLib = read(paths.packageLib);
-const transport = read(paths.transport);
-const graphql = read(paths.graphql);
-const native = read(paths.native);
-const graphqlOwner = read(paths.graphqlOwner);
-const host = read(paths.host);
-const hostLib = read(paths.hostLib);
-const contractText = read(paths.contract);
-const docs = read(paths.docs);
+const source = Object.fromEntries(
+  Object.entries(paths).map(([key, value]) => [key, read(value)]),
+);
 
 let contract = null;
 try {
-  contract = JSON.parse(contractText);
+  contract = JSON.parse(source.contract);
 } catch (error) {
   failures.push(`${paths.contract}: invalid JSON (${error.message})`);
 }
@@ -68,80 +56,57 @@ for (const marker of [
   "Uuid::parse_str(topic_id.trim())",
   "FORUM_TOPIC_ROUTE_SHORT_ID_LEN: usize = 12",
   "Some(format!(\"/{locale}/forum/t/{short_id}/{slug}\"))",
-  "item.effective_locale.as_str()",
-  "item.slug.as_str()",
 ]) {
-  requireText(core, marker, paths.core);
+  requireText(source.core, marker, paths.core);
 }
-forbidText(core, "&topic={topic_id}", paths.core);
-forbidText(core, "?topic={topic_id}", paths.core);
+forbidText(source.core, "?topic={topic_id}", paths.core);
 
 for (const marker of [
   "pub enum StorefrontForumTopicRouteDisposition",
   "Canonical",
   "Redirect",
-  "pub struct StorefrontForumTopicRouteResolution",
-  "pub canonical: StorefrontForumTopicRouteDescriptor",
+  "Gone",
+  "pub canonical: Option<StorefrontForumTopicRouteDescriptor>",
 ]) {
-  requireText(model, marker, paths.model);
+  requireText(source.model, marker, paths.model);
 }
 
 for (const marker of [
-  "include!(\"topic_route_graphql_adapter.rs\")",
-  "include!(\"native_server_adapter_topic_route.rs\")",
   "pub async fn resolve_storefront_topic_route(",
   "if use_native_transport()",
   "resolve_storefront_topic_route_server",
   "resolve_storefront_topic_route_graphql",
 ]) {
-  requireText(transport, marker, paths.transport);
+  requireText(source.transport, marker, paths.transport);
 }
 
 for (const marker of [
-  "forumStorefrontTopicRoute",
+  "forumStorefrontTopicRouteDecision",
   "requestedLocale requestedShortId requestedSlug disposition canonical",
-  "tenant_id: None",
   "resolve_storefront_topic_route_graphql",
 ]) {
-  requireText(graphql, marker, paths.graphql);
+  requireText(source.graphql, marker, paths.graphql);
 }
-forbidText(graphql, "fetch(", paths.graphql);
-forbidText(graphql, "reqwest", paths.graphql);
+forbidText(source.graphql, "reqwest", paths.graphql);
 
 for (const marker of [
   "endpoint = \"forum/storefront-topic-route\"",
   "ForumTopicRouteService::new(db.clone())",
-  ".resolve(tenant.id, &locale, &short_id, &slug)",
   "ForumTopicAudienceReadService::with_audience_facts",
-  "ForumTopicAudienceReadService::new",
-  "topic_read_audience_port_context(",
-  "ForumTopicReadTransport::NativeServer",
-  "ForumTopicReadOperation::SelectedTopic",
-  ".get_authenticated_storefront_visible_with_audience_context(",
-  ".get_public_storefront_visible_with_locale_fallback(",
-  "ForumTopicRouteDisposition::Gone => return Ok(None)",
-  "ChannelService::new(db.clone())",
+  "ForumTopicRouteTombstoneVisibilityService",
+  ".can_disclose_public_gone(",
+  "request.channel_slug.as_deref()",
+  "StorefrontForumTopicRouteDisposition::Gone",
 ]) {
-  requireText(native, marker, paths.native);
+  requireText(source.native, marker, paths.native);
 }
 for (const marker of [
   "forum_topic_route_aliases",
+  "forum_topic_route_tombstone_visibility",
   "Statement::from_sql_and_values",
   "SELECT ",
-  "record_redirect_alias",
-  "record_gone_alias",
 ]) {
-  forbidText(native, marker, paths.native);
-}
-
-for (const marker of [
-  ".topic_audience_read_service(db.clone(), event_bus.clone())",
-  "ForumTopicReadTransport::Graphql",
-  "ForumTopicReadOperation::SelectedTopic",
-  ".get_authenticated_storefront_visible_with_audience_context(",
-  ".get_public_storefront_visible_with_locale_fallback(",
-]) {
-  requireText(graphqlOwner, marker, paths.graphqlOwner);
+  forbidText(source.native, marker, paths.native);
 }
 
 for (const marker of [
@@ -149,33 +114,30 @@ for (const marker of [
   "StorefrontForumTopicRouteDisposition",
   "StorefrontForumTopicRouteResolution",
 ]) {
-  requireText(packageLib, marker, paths.packageLib);
+  requireText(source.packageLib, marker, paths.packageLib);
 }
 
 for (const marker of [
-  "requested_path: String",
   "rustok_forum_storefront::resolve_storefront_topic_route(",
-  "StorefrontForumTopicRouteDisposition::Redirect",
-  "requested_path != canonical_path",
-  "private_permanent_redirect(location.as_str())",
-  "StatusCode::NOT_FOUND",
+  "ForumTopicHostAction::Gone",
+  "StatusCode::GONE",
+  "ForumTopicHostAction::Invalid",
   "StatusCode::SERVICE_UNAVAILABLE",
+  "StatusCode::NOT_FOUND",
+  "private_permanent_redirect(location.as_str())",
   "query_params.insert(\"topic\".to_string(), topic_id)",
-  "render_module_page_with_nonce(",
-  "FORUM_ROUTE_SEGMENT",
 ]) {
-  requireText(host, marker, paths.host);
+  requireText(source.host, marker, paths.host);
 }
 for (const marker of [
-  "let requested_path = format!",
   "ForumTopicRouteService",
   "ForumTopicAudienceReadService",
+  "ForumTopicRouteTombstoneVisibilityService",
+  "can_disclose_public_gone",
   "forum_topic_route_aliases",
-  "Uuid::parse_str",
-  "record_redirect_alias",
-  "record_gone_alias",
+  "forum_topic_route_tombstone_visibility",
 ]) {
-  forbidText(host, marker, paths.host);
+  forbidText(source.host, marker, paths.host);
 }
 
 for (const marker of [
@@ -183,50 +145,41 @@ for (const marker of [
   "\"/{locale}/forum/t/{short_id}/{slug}\"",
   "original_uri: axum::extract::OriginalUri",
   "original_uri.0.path().to_string()",
-  "forum_topic_route::render_forum_topic_route_response(",
+  "const PRIVATE_NO_STORE: &str = \"private, no-store\"",
 ]) {
-  requireText(hostLib, marker, paths.hostLib);
+  requireText(source.hostLib, marker, paths.hostLib);
 }
 
 for (const marker of [
   "private `308 Permanent Redirect`",
-  "private `404 Not Found`",
-  "private `503 Service Unavailable`",
+  "private `410 Gone`",
+  "private `404`",
+  "private `503`",
   "There is no automatic fallback",
-  "does not add:",
-  "public `410 Gone`",
+  "host still does not authorize `GONE`",
   "No tests, verifiers, formatting, Cargo commands",
 ]) {
-  requireText(docs, marker, paths.docs);
+  requireText(source.docs, marker, paths.docs);
 }
 
 if (contract) {
   if (contract.task !== "FORUM-24I") {
-    failures.push(`${paths.contract}: task must be FORUM-24I`);
-  }
-  if (contract.status !== "source_ready_maintainer_execution_pending") {
-    failures.push(`${paths.contract}: unexpected source status`);
-  }
-  if (contract.canonical_route !== "/{locale}/forum/t/{short_id}/{slug}") {
-    failures.push(`${paths.contract}: unexpected canonical route`);
+    failures.push(`${paths.contract}: task must remain FORUM-24I`);
   }
   if (contract.transport?.automatic_fallback !== false) {
     failures.push(`${paths.contract}: automatic fallback must remain disabled`);
   }
-  if (contract.transport?.exact_audience_recheck_both_paths !== true) {
-    failures.push(`${paths.contract}: exact audience parity is required`);
-  }
-  if (contract.topic_card_cutover?.legacy_topic_query_links_emitted !== false) {
-    failures.push(`${paths.contract}: legacy topic query links must stay disabled`);
-  }
   if (contract.host_composition?.host_reads_forum_storage !== false) {
     failures.push(`${paths.contract}: host must not read Forum storage`);
   }
-  if (contract.host_composition?.host_recomputes_redirect_target !== false) {
-    failures.push(`${paths.contract}: host must trust the owner canonical target`);
+  if (contract.host_composition?.host_reauthorizes_gone !== false) {
+    failures.push(`${paths.contract}: host must not reauthorize gone`);
   }
-  if (contract.disclosure?.gone_exposed !== false) {
-    failures.push(`${paths.contract}: public gone must remain hidden`);
+  if (contract.disclosure?.authorized_gone_exposed !== true) {
+    failures.push(`${paths.contract}: FORUM-24K authorized gone extension is missing`);
+  }
+  if (contract.disclosure?.authenticated_requests_broaden_public_snapshot !== false) {
+    failures.push(`${paths.contract}: authentication must not broaden snapshot disclosure`);
   }
   if (contract.compatibility?.seo_changed !== false) {
     failures.push(`${paths.contract}: SEO must remain out of scope`);

--- a/scripts/verify/verify-forum-topic-route-tombstone-visibility-owner.mjs
+++ b/scripts/verify/verify-forum-topic-route-tombstone-visibility-owner.mjs
@@ -16,6 +16,7 @@ const paths = {
   migrationsMod: "crates/rustok-forum/src/migrations/mod.rs",
   topicOwner: "crates/rustok-forum/src/services/topic_owner.rs",
   topicOwnerInline: "crates/rustok-forum/src/services/topic_owner_inline.rs",
+  servicesMod: "crates/rustok-forum/src/services/mod.rs",
   snapshotOwner:
     "crates/rustok-forum/src/services/topic_route_tombstone_visibility.rs",
   categoryVisibility: "crates/rustok-forum/src/services/category_visibility.rs",
@@ -30,16 +31,13 @@ const paths = {
   docs: "crates/rustok-forum/docs/forum-24j-topic-route-tombstone-visibility.md",
 };
 
-function absolute(relativePath) {
-  return path.join(repoRoot, relativePath);
-}
-
 function read(relativePath) {
-  if (!existsSync(absolute(relativePath))) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  if (!existsSync(absolutePath)) {
     failures.push(`${relativePath}: expected file is missing`);
     return "";
   }
-  return readFileSync(absolute(relativePath), "utf8");
+  return readFileSync(absolutePath, "utf8");
 }
 
 function requireText(content, marker, label) {
@@ -58,30 +56,18 @@ function requireOrder(content, markers, label) {
       failures.push(`${label}: missing ordered marker ${marker}`);
       continue;
     }
-    if (position < previous) {
-      failures.push(`${label}: marker appears out of order ${marker}`);
-    }
+    if (position < previous) failures.push(`${label}: marker appears out of order ${marker}`);
     previous = position;
   }
 }
 
-const migration = read(paths.migration);
-const migrationsMod = read(paths.migrationsMod);
-const topicOwner = read(paths.topicOwner);
-const topicOwnerInline = read(paths.topicOwnerInline);
-const snapshotOwner = read(paths.snapshotOwner);
-const categoryVisibility = read(paths.categoryVisibility);
-const topicAudienceLock = read(paths.topicAudienceLock);
-const graphql = read(paths.graphql);
-const native = read(paths.native);
-const host = read(paths.host);
-const contractText = read(paths.contract);
-const test = read(paths.test);
-const docs = read(paths.docs);
+const source = Object.fromEntries(
+  Object.entries(paths).map(([key, value]) => [key, read(value)]),
+);
 
 let contract = null;
 try {
-  contract = JSON.parse(contractText);
+  contract = JSON.parse(source.contract);
 } catch (error) {
   failures.push(`${paths.contract}: invalid JSON (${error.message})`);
 }
@@ -94,20 +80,19 @@ for (const marker of [
   "route_channel_digest ~ '^[0-9a-f]{64}$'",
   "route_channel_digest NOT GLOB '*[^0-9a-f]*'",
   "forum topic route tombstone visibility is append-only",
-  "idx_forum_topic_route_tombstone_channel_lookup",
   "DatabaseBackend::Postgres",
   "DatabaseBackend::Sqlite",
 ]) {
-  requireText(migration, marker, paths.migration);
+  requireText(source.migration, marker, paths.migration);
 }
 requireText(
-  migrationsMod,
+  source.migrationsMod,
   "m20260806_000025_add_forum_topic_route_tombstone_visibility",
   paths.migrationsMod,
 );
 
 requireOrder(
-  topicOwner,
+  source.topicOwner,
   [
     "ForumTopicRouteTombstoneVisibilityService::lock_category_scope_in_tx(",
     "claim_topic_delete_in_tx(&txn, tenant_id, topic_id).await?",
@@ -119,14 +104,14 @@ requireOrder(
   paths.topicOwner,
 );
 requireText(
-  topicOwnerInline,
+  source.topicOwnerInline,
   'include!("topic_route_tombstone_visibility.rs")',
   paths.topicOwnerInline,
 );
 requireText(
-  topicOwnerInline,
-  "topic_audience_lock",
-  paths.topicOwnerInline,
+  source.servicesMod,
+  "ForumTopicRouteTombstoneVisibilityService",
+  paths.servicesMod,
 );
 
 for (const marker of [
@@ -139,63 +124,63 @@ for (const marker of [
   "topic.status == TopicStatus::Open",
   "route_channel_count",
   "route_channel_digest",
-  "Some(existing)",
-  "None =>",
   "stored_channels != channel_slugs",
   "validate_sealed_channel_scope",
   "pub async fn can_disclose_public_gone(",
 ]) {
-  requireText(snapshotOwner, marker, paths.snapshotOwner);
+  requireText(source.snapshotOwner, marker, paths.snapshotOwner);
 }
 for (const marker of [
   "async_graphql",
   "axum::",
   "forum_category_policy::",
-  "hashtextextended",
-  "GqlForumStorefrontTopicRouteDisposition::Gone",
-  "StorefrontForumTopicRouteDisposition::Gone",
+  "GqlForumStorefrontTopicRouteDecisionDisposition",
+  "StorefrontForumTopicRouteDisposition",
   "StatusCode::GONE",
 ]) {
-  forbidText(snapshotOwner, marker, paths.snapshotOwner);
+  forbidText(source.snapshotOwner, marker, paths.snapshotOwner);
 }
+for (const marker of [
+  "StoredForumTopicRouteTombstoneVisibility",
+  "route_channel_digest",
+  "load_snapshot_channel_slugs",
+]) {
+  forbidText(source.servicesMod, marker, paths.servicesMod);
+}
+
 requireText(
-  topicAudienceLock,
+  source.topicAudienceLock,
   "pub(crate) async fn lock_topic_audience_scopes_in_tx(",
   paths.topicAudienceLock,
 );
 requireText(
-  topicAudienceLock,
-  '"SELECT pg_advisory_xact_lock(hashtextextended($1, 5))"',
-  paths.topicAudienceLock,
-);
-
-requireText(
-  categoryVisibility,
+  source.categoryVisibility,
   "pub(crate) async fn is_category_public_to_anonymous",
   paths.categoryVisibility,
 );
-requireText(
-  categoryVisibility,
-  "super::category_audience::lock_category_tree_in_tx(&txn, tenant_id).await?",
-  paths.categoryVisibility,
-);
 
-requireText(
-  graphql,
-  "ForumTopicRouteDisposition::Gone => return Ok(None)",
-  paths.graphql,
-);
+for (const content of [source.graphql, source.native]) {
+  requireText(
+    content,
+    "ForumTopicRouteTombstoneVisibilityService",
+    "FORUM-24K transport consumer",
+  );
+  requireText(content, ".can_disclose_public_gone(", "FORUM-24K transport consumer");
+  for (const forbidden of [
+    "forum_topic_route_tombstone_visibility",
+    "forum_topic_route_tombstone_channels",
+    "SELECT ",
+  ]) {
+    forbidText(content, forbidden, "FORUM-24K transport consumer");
+  }
+}
+requireText(source.host, "StatusCode::GONE", paths.host);
 forbidText(
-  graphql,
-  "GqlForumStorefrontTopicRouteDisposition::Gone",
-  paths.graphql,
+  source.host,
+  "ForumTopicRouteTombstoneVisibilityService",
+  paths.host,
 );
-forbidText(
-  native,
-  "StorefrontForumTopicRouteDisposition::Gone",
-  paths.native,
-);
-forbidText(host, "StatusCode::GONE", paths.host);
+forbidText(source.host, "can_disclose_public_gone", paths.host);
 
 for (const marker of [
   "migration_adds_sealed_append_only_snapshot_storage",
@@ -203,7 +188,7 @@ for (const marker of [
   "snapshot_reuses_visibility_and_lock_owners_and_seals_exact_channel_scope",
   "this_slice_does_not_publish_gone_transport_or_http_policy",
 ]) {
-  requireText(test, marker, paths.test);
+  requireText(source.test, marker, paths.test);
 }
 
 for (const marker of [
@@ -212,19 +197,13 @@ for (const marker of [
   "route_channel_count",
   "SHA-256",
   "same order as the canonical topic audience owner",
-  "does not change",
   "No tests, verifiers, formatting, Cargo commands, migrations, workflows",
 ]) {
-  requireText(docs, marker, paths.docs);
+  requireText(source.docs, marker, paths.docs);
 }
 
 if (contract) {
-  if (contract.task !== "FORUM-24J") {
-    failures.push(`${paths.contract}: task must be FORUM-24J`);
-  }
-  if (contract.status !== "source_ready_maintainer_execution_pending") {
-    failures.push(`${paths.contract}: unexpected source status`);
-  }
+  if (contract.task !== "FORUM-24J") failures.push(`${paths.contract}: task must be FORUM-24J`);
   if (contract.owner !== "ForumTopicRouteTombstoneVisibilityService") {
     failures.push(`${paths.contract}: unexpected owner`);
   }
@@ -234,17 +213,8 @@ if (contract) {
   if (contract.storage?.route_channel_sha256_digest_sealed !== true) {
     failures.push(`${paths.contract}: channel digest must be sealed`);
   }
-  if (contract.lock_owner_reuse?.custom_advisory_namespace_added !== false) {
-    failures.push(`${paths.contract}: snapshot must reuse canonical lock owners`);
-  }
   if (contract.replay?.existing_channels_appended !== false) {
     failures.push(`${paths.contract}: replay must never append channels`);
-  }
-  if (contract.compatibility?.public_gone_exposed !== false) {
-    failures.push(`${paths.contract}: public GONE must remain hidden`);
-  }
-  if (contract.compatibility?.public_410_added !== false) {
-    failures.push(`${paths.contract}: public 410 must remain out of scope`);
   }
 }
 


### PR DESCRIPTION
## Summary

- add FORUM-24K authorized deleted-topic route composition over the immutable FORUM-24J boolean owner;
- retain the legacy `forumStorefrontTopicRoute` GraphQL field unchanged: its enum remains `CANONICAL | REDIRECT`, its canonical descriptor remains non-null, and `GONE` still returns `null` without reading the snapshot owner;
- add the separate additive `forumStorefrontTopicRouteDecision` field with `CANONICAL | REDIRECT | GONE` and a nullable canonical descriptor;
- call `ForumTopicRouteTombstoneVisibilityService::can_disclose_public_gone` only for the new decision field and only after the route owner returns `GONE`;
- require the current routed channel to have Forum enabled before disclosing a terminal decision, including authenticated requests;
- do not allow authentication to broaden a deletion-time public snapshot;
- switch the module-owned storefront GraphQL adapter to the new decision field;
- align the native server endpoint to the same boolean owner and current routed channel;
- extend the shared Rust storefront DTO with terminal `GONE` and an optional canonical descriptor;
- map only an owner-authorized terminal decision to private no-store HTTP `410 Gone`;
- retain private `404` for missing, unsnapshotted, formerly private, disabled-channel and channel-mismatched routes;
- map malformed decision shapes and snapshot integrity/transport failures to private `503 Service Unavailable`;
- keep the host free of Forum storage reads and authorization calls;
- add task contract, source contract test, documentation and a static verifier;
- realign FORUM-24H/I/J historical contracts and guards without changing their original slice claims.

## Compatibility

The legacy GraphQL field is not widened and does not make `canonical` nullable. Existing generated clients remain compatible. The new decision field is additive and is consumed only by the module-owned storefront adapter.

Authenticated canonical and redirect requests preserve their previous ChannelService behavior. An authenticated channel-module check is added only after the new decision resolves to `GONE`.

No migration, deletion owner write, route identity, alias schema, semantic event, admin command, SEO or hreflang behavior changes in this slice.

## Disclosure boundary

The transports receive only a boolean decision from `ForumTopicRouteTombstoneVisibilityService`. They do not query snapshot tables, route aliases, category policy or audience relations directly. The host does not call the owner at all; it maps an already authorized typed decision to HTTP.

Topics deleted before FORUM-24J remain hidden. Formerly private or authenticated-only topics remain hidden. Cross-topic redirects whose target later disappears remain hidden without separate source-route proof.

## Canonical plan note

`crates/rustok-forum/docs/implementation-plan.md` remains stale after FORUM-24E through FORUM-24K. The connected contents writer requires complete-file replacement, while the canonical plan cannot be retrieved losslessly as one complete payload through the available connector response. This PR updates task-specific contracts and documentation without creating a duplicate roadmap or claiming ledger synchronization.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Node verifiers;
- Cargo check, formatting or clippy;
- migrations or database scenarios;
- workflows or CI;
- registered-host, HTTP or browser scenarios.

Suggested maintainer commands:

```bash
node scripts/verify/verify-forum-topic-route-storefront-graphql.mjs
node scripts/verify/verify-forum-topic-route-storefront-mount.mjs
node scripts/verify/verify-forum-topic-route-tombstone-visibility-owner.mjs
node scripts/verify/verify-forum-topic-route-authorized-gone.mjs
cargo test -p rustok-forum --test topic_route_storefront_graphql_contract -- --nocapture
cargo test -p rustok-forum --test topic_route_authorized_gone_transport_contract -- --nocapture
cargo test -p rustok-forum graphql::topic_route_query::tests -- --nocapture
cargo test -p rustok-forum-storefront model::tests -- --nocapture
cargo test -p rustok-storefront forum_topic_route::tests -- --nocapture
cargo check -p rustok-forum --all-targets
cargo check -p rustok-forum-storefront --all-targets --features ssr
cargo check -p rustok-storefront --all-targets --features ssr
```

Source status remains `source_ready_maintainer_execution_pending`.