### PR TITLE
fix(commerce): bound GraphQL cart owner diagnostics

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/graphql-cart-owner-diagnostic-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/graphql-cart-owner-diagnostic-safety-source-review.json
@@ -1,0 +1,51 @@
+{
+  "status": "commerce_graphql_cart_owner_diagnostic_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-commerce/src/graphql/mutations/safe_cart.rs",
+    "scripts/verify/verify-commerce-graphql-cart-owner-context.mjs",
+    "crates/rustok-commerce/docs/graphql-cart-owner-diagnostic-safety.md",
+    "crates/rustok-commerce/docs/implementation-plan.md"
+  ],
+  "source_contract": {
+    "cart_port_error_payload_logged": false,
+    "cart_port_internal_message_logged": false,
+    "raw_tenant_identity_logged": false,
+    "raw_actor_identity_logged": false,
+    "raw_channel_logged": false,
+    "raw_locale_logged": false,
+    "raw_correlation_id_logged": false,
+    "raw_causation_id_logged": false,
+    "raw_traceparent_logged": false,
+    "raw_idempotency_key_logged": false,
+    "diagnostic_error_debug_redacted": true,
+    "owner_code_preserved": true,
+    "owner_kind_preserved": true,
+    "owner_retryability_preserved": true,
+    "owner_message_shape_logged": true,
+    "owner_message_length_logged": true,
+    "bounded_context_facts_logged": true,
+    "original_port_error_returned_downstream": true,
+    "cart_owner_operation_preserved": true,
+    "cart_owner_delegation_count_preserved": true,
+    "cart_owner_constructor_preserved": true,
+    "cart_public_mapper_preserved": true,
+    "cart_public_envelopes_preserved": true,
+    "pricing_owner_cleanup_closed": false,
+    "store_context_cleanup_closed": false,
+    "typed_line_item_cleanup_closed": false,
+    "broad_ecommerce_cleanup_closed": false,
+    "runtime_evidence_claimed": false
+  },
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, mounted GraphQL scenarios, workflows, or CI were executed."
+}

--- a/crates/rustok-commerce/docs/graphql-cart-owner-diagnostic-safety.md
+++ b/crates/rustok-commerce/docs/graphql-cart-owner-diagnostic-safety.md
@@ -1,0 +1,65 @@
+# GraphQL cart owner diagnostic safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens the contextual Cart owner wrapper in `safe_cart.rs`.
+
+The wrapper surrounds eight storefront Cart port calls so the diagnostic event retains the original operation and `PortContext` when the owner returns a `PortError`. Before this change, that event emitted the complete owner error and raw tenant, actor, channel, locale, correlation, causation, traceparent, and idempotency values.
+
+## Bounded diagnostic projection
+
+The wrapper now projects the retained `PortContext` to closed facts:
+
+- tenant and actor identities become `empty`, `uuid_nil`, `uuid_non_nil`, or `opaque`;
+- actor kind remains `user`, `service`, or `system`;
+- claims and roles become counts;
+- channel, locale, correlation, causation, traceparent, and idempotency values become presence shapes;
+- the deadline remains an optional millisecond value.
+
+The diagnostic event keeps exact owner code, typed owner kind, owner retryability, and only owner-message shape and byte length. The logged error field uses `CartOwnerDiagnosticError`, whose custom `Debug` output is always `redacted`.
+
+The original `PortError` is not consumed because the contextual wrapper must return it unchanged to the existing `cart_port_error` public mapper. It is retained only for downstream behavior and is never formatted by the owner-context event.
+
+## Preserved behavior
+
+This work does not change:
+
+- any of the eight `CartStorefrontPort` delegations;
+- the exact diagnostic operation selected for each delegation;
+- cloning the original `PortContext` before each owner call;
+- the canonical in-process Cart owner constructor;
+- Cart resolver routing or mutation signatures;
+- the downstream `cart_port_error` mapper;
+- public `CART_*` messages, codes, and retryability;
+- the previously hardened Cart/Pricing public mapper diagnostics.
+
+The event remains error-level and retains the truthful `rustok_cart` owner and `commerce_graphql_cart` boundary.
+
+## Verifier correction
+
+`verify-commerce-graphql-cart-owner-context.mjs` previously required raw context fields. It now isolates the Cart owner module, requires bounded projections and safe owner facts, forbids raw context/error payloads, and preserves the eight-call delegation contract.
+
+The verifier also follows the current precomputed Cart/Pricing `source_owner` contract in `safe_helpers.rs`.
+
+## Remaining work
+
+This slice does not close the complete Commerce GraphQL Cart boundary.
+
+Still open:
+
+- the Pricing read owner wrapper in `safe_cart.rs`;
+- the Cart store-context error diagnostic in `safe_cart.rs`;
+- typed line-item source and identity diagnostics;
+- compatibility string classification;
+- storefront shared/cart-shipping, tax, promotion, native transport, and remaining adapter cleanup.
+
+## Evidence
+
+- `crates/rustok-commerce/contracts/evidence/graphql-cart-owner-diagnostic-safety-source-review.json`
+- `scripts/verify/verify-commerce-graphql-cart-owner-context.mjs`
+
+## Validation disclosure
+
+No tests, Node verifiers, formatting, Cargo commands, mounted GraphQL scenarios, workflows, or CI were run. No compile, runtime, FFA, or FBA status is promoted.

--- a/crates/rustok-commerce/src/graphql/mutations/safe_cart.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_cart.rs
@@ -109,9 +109,83 @@ mod cart_storefront_owner_boundary {
         CartStorefrontLineItemQuantityRequest, CartStorefrontPort, CartStorefrontReadRequest,
         CartStorefrontRemoveLineItemRequest, CartStorefrontRepriceRequest,
     };
-    use rustok_api::{PortContext, PortError};
+    use rustok_api::{PortActorKind, PortContext, PortError};
 
     const CART_GRAPHQL_OWNER_BOUNDARY: &str = "commerce_graphql_cart";
+
+    #[derive(Clone, Copy)]
+    struct CartOwnerDiagnosticContext {
+        tenant_id_shape: &'static str,
+        actor_kind: &'static str,
+        actor_id_shape: &'static str,
+        claim_count: usize,
+        role_count: usize,
+        channel_shape: &'static str,
+        locale_shape: &'static str,
+        correlation_id_shape: &'static str,
+        causation_id_shape: &'static str,
+        traceparent_shape: &'static str,
+        idempotency_key_shape: &'static str,
+        deadline_ms: Option<u64>,
+    }
+
+    impl From<&PortContext> for CartOwnerDiagnosticContext {
+        fn from(context: &PortContext) -> Self {
+            Self {
+                tenant_id_shape: identity_text_shape(context.tenant_id.as_str()),
+                actor_kind: actor_kind_name(&context.actor.kind),
+                actor_id_shape: identity_text_shape(context.actor.id.as_str()),
+                claim_count: context.claims.len(),
+                role_count: context.roles.len(),
+                channel_shape: optional_text_shape(context.channel.as_deref()),
+                locale_shape: text_shape(context.locale.as_str()),
+                correlation_id_shape: text_shape(context.correlation_id.as_str()),
+                causation_id_shape: optional_text_shape(context.causation_id.as_deref()),
+                traceparent_shape: optional_text_shape(context.traceparent.as_deref()),
+                idempotency_key_shape: optional_text_shape(context.idempotency_key.as_deref()),
+                deadline_ms: context.deadline_ms,
+            }
+        }
+    }
+
+    struct CartOwnerDiagnosticError;
+
+    impl std::fmt::Debug for CartOwnerDiagnosticError {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("redacted")
+        }
+    }
+
+    fn actor_kind_name(kind: &PortActorKind) -> &'static str {
+        match kind {
+            PortActorKind::User => "user",
+            PortActorKind::Service => "service",
+            PortActorKind::System => "system",
+        }
+    }
+
+    fn identity_text_shape(value: &str) -> &'static str {
+        if value.is_empty() {
+            return "empty";
+        }
+        match uuid::Uuid::parse_str(value) {
+            Ok(value) if value.is_nil() => "uuid_nil",
+            Ok(_) => "uuid_non_nil",
+            Err(_) => "opaque",
+        }
+    }
+
+    fn text_shape(value: &str) -> &'static str {
+        if value.is_empty() { "empty" } else { "present" }
+    }
+
+    fn optional_text_shape(value: Option<&str>) -> &'static str {
+        match value {
+            None => "absent",
+            Some(value) if value.is_empty() => "empty",
+            Some(_) => "present",
+        }
+    }
 
     fn retain_cart_owner_context<T>(
         context: &PortContext,
@@ -119,21 +193,35 @@ mod cart_storefront_owner_boundary {
         result: Result<T, PortError>,
     ) -> Result<T, PortError> {
         result.map_err(|error| {
+            let diagnostic_context = CartOwnerDiagnosticContext::from(context);
+            let owner_code = error.code.clone();
+            let owner_kind = error.kind.clone();
+            let owner_retryable = error.retryable;
+            let owner_message_shape = text_shape(error.message.as_str());
+            let owner_message_len = error.message.len();
+            let diagnostic_error = CartOwnerDiagnosticError;
+
             tracing::error!(
-                error = ?error,
+                error = ?diagnostic_error,
                 owner = "rustok_cart",
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                channel = ?context.channel,
-                locale = %context.locale,
-                actor_kind = ?context.actor.kind,
-                actor_id = %context.actor.id,
-                causation_id = ?context.causation_id,
-                idempotency_key = ?context.idempotency_key,
+                tenant_id_shape = diagnostic_context.tenant_id_shape,
+                actor_kind = diagnostic_context.actor_kind,
+                actor_id_shape = diagnostic_context.actor_id_shape,
+                claim_count = diagnostic_context.claim_count,
+                role_count = diagnostic_context.role_count,
+                channel_shape = diagnostic_context.channel_shape,
+                locale_shape = diagnostic_context.locale_shape,
+                correlation_id_shape = diagnostic_context.correlation_id_shape,
+                causation_id_shape = diagnostic_context.causation_id_shape,
+                traceparent_shape = diagnostic_context.traceparent_shape,
+                idempotency_key_shape = diagnostic_context.idempotency_key_shape,
+                deadline_ms = ?diagnostic_context.deadline_ms,
                 operation,
-                owner_code = %error.code,
-                owner_kind = ?error.kind,
-                owner_retryable = error.retryable,
+                owner_code = %owner_code,
+                owner_message_shape,
+                owner_message_len,
+                owner_kind = ?owner_kind,
+                owner_retryable,
                 boundary = CART_GRAPHQL_OWNER_BOUNDARY,
                 "commerce GraphQL storefront cart owner call failed"
             );

--- a/scripts/verify/verify-commerce-graphql-cart-owner-context.mjs
+++ b/scripts/verify/verify-commerce-graphql-cart-owner-context.mjs
@@ -21,34 +21,152 @@ const requireText = (content, value, label) => {
 const forbidText = (content, value, label) => {
   if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
 };
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const cartBoundary = between(
+  facade,
+  'mod cart_storefront_owner_boundary {',
+  'mod pricing_read_owner_boundary {',
+  'cart owner boundary module',
+);
 
 for (const [value, label] of [
   ['mod cart_storefront_owner_boundary {', 'cart owner boundary module'],
   ['const CART_GRAPHQL_OWNER_BOUNDARY: &str = "commerce_graphql_cart";', 'cart boundary constant'],
-  ['fn retain_cart_owner_context<T>(', 'context retention mapper'],
   ['struct ContextualCartStorefrontPort {', 'contextual cart adapter'],
   ['impl CartStorefrontPort for ContextualCartStorefrontPort', 'cart adapter implementation'],
   ['inner: Arc<dyn CartStorefrontPort>', 'owner port delegation'],
   ['inner: ::rustok_cart::in_process_cart_storefront_port(db)', 'canonical cart owner constructor'],
   ['mod rustok_cart_shim {', 'cart import shim'],
   ['use self::rustok_cart_shim as rustok_cart;', 'resolver cart shim alias'],
-  ['pub(crate) use super::cart_storefront_owner_boundary::in_process_cart_storefront_port;', 'contextual constructor export'],
-  ['correlation_id = %context.correlation_id', 'correlation logging'],
-  ['tenant_id = %context.tenant_id', 'tenant logging'],
-  ['channel = ?context.channel', 'channel logging'],
-  ['locale = %context.locale', 'locale logging'],
-  ['actor_kind = ?context.actor.kind', 'actor kind logging'],
-  ['actor_id = %context.actor.id', 'actor id logging'],
-  ['causation_id = ?context.causation_id', 'causation logging'],
-  ['idempotency_key = ?context.idempotency_key', 'idempotency logging'],
-  ['owner_code = %error.code', 'owner code logging'],
-  ['owner_kind = ?error.kind', 'owner kind logging'],
-  ['owner_retryable = error.retryable', 'owner retryability logging'],
-  ['owner = "rustok_cart"', 'cart owner logging'],
-  ['boundary = CART_GRAPHQL_OWNER_BOUNDARY', 'boundary logging'],
+  [
+    'pub(crate) use super::cart_storefront_owner_boundary::in_process_cart_storefront_port;',
+    'contextual constructor export',
+  ],
   ['include!("cart.rs");', 'unchanged resolver inclusion'],
 ]) {
   requireText(facade, value, label);
+}
+
+for (const [value, label] of [
+  ['PortActorKind, PortContext, PortError', 'cart diagnostic imports'],
+  ['struct CartOwnerDiagnosticContext {', 'bounded cart owner context'],
+  ['impl From<&PortContext> for CartOwnerDiagnosticContext', 'cart context projection'],
+  ['tenant_id_shape: identity_text_shape(context.tenant_id.as_str())', 'tenant identity shape'],
+  ['actor_kind: actor_kind_name(&context.actor.kind)', 'actor kind projection'],
+  ['actor_id_shape: identity_text_shape(context.actor.id.as_str())', 'actor identity shape'],
+  ['claim_count: context.claims.len()', 'claim count'],
+  ['role_count: context.roles.len()', 'role count'],
+  ['channel_shape: optional_text_shape(context.channel.as_deref())', 'channel shape'],
+  ['locale_shape: text_shape(context.locale.as_str())', 'locale shape'],
+  ['correlation_id_shape: text_shape(context.correlation_id.as_str())', 'correlation shape'],
+  ['causation_id_shape: optional_text_shape(context.causation_id.as_deref())', 'causation shape'],
+  ['traceparent_shape: optional_text_shape(context.traceparent.as_deref())', 'trace shape'],
+  [
+    'idempotency_key_shape: optional_text_shape(context.idempotency_key.as_deref())',
+    'idempotency shape',
+  ],
+  ['deadline_ms: context.deadline_ms', 'deadline fact'],
+  ['struct CartOwnerDiagnosticError;', 'redacted cart diagnostic token'],
+  ['impl std::fmt::Debug for CartOwnerDiagnosticError', 'custom cart diagnostic Debug'],
+  ['formatter.write_str("redacted")', 'redacted cart diagnostic output'],
+  ['fn actor_kind_name(kind: &PortActorKind)', 'actor kind helper'],
+  ['fn identity_text_shape(value: &str)', 'identity shape helper'],
+  ['fn text_shape(value: &str)', 'text shape helper'],
+  ['fn optional_text_shape(value: Option<&str>)', 'optional text shape helper'],
+  ['fn retain_cart_owner_context<T>(', 'context retention mapper'],
+  ['let diagnostic_context = CartOwnerDiagnosticContext::from(context);', 'context projection'],
+  ['let owner_code = error.code.clone();', 'owner code projection'],
+  ['let owner_kind = error.kind.clone();', 'owner kind projection'],
+  ['let owner_retryable = error.retryable;', 'owner retryability projection'],
+  ['let owner_message_shape = text_shape(error.message.as_str());', 'owner message shape'],
+  ['let owner_message_len = error.message.len();', 'owner message length'],
+  ['let diagnostic_error = CartOwnerDiagnosticError;', 'diagnostic shadow token'],
+  ['tracing::error!(', 'cart owner error event'],
+  ['error = ?diagnostic_error', 'redacted diagnostic field'],
+  ['owner = "rustok_cart"', 'cart owner logging'],
+  ['tenant_id_shape = diagnostic_context.tenant_id_shape', 'tenant shape field'],
+  ['actor_kind = diagnostic_context.actor_kind', 'actor kind field'],
+  ['actor_id_shape = diagnostic_context.actor_id_shape', 'actor identity shape field'],
+  ['claim_count = diagnostic_context.claim_count', 'claim count field'],
+  ['role_count = diagnostic_context.role_count', 'role count field'],
+  ['channel_shape = diagnostic_context.channel_shape', 'channel shape field'],
+  ['locale_shape = diagnostic_context.locale_shape', 'locale shape field'],
+  ['correlation_id_shape = diagnostic_context.correlation_id_shape', 'correlation shape field'],
+  ['causation_id_shape = diagnostic_context.causation_id_shape', 'causation shape field'],
+  ['traceparent_shape = diagnostic_context.traceparent_shape', 'trace shape field'],
+  [
+    'idempotency_key_shape = diagnostic_context.idempotency_key_shape',
+    'idempotency shape field',
+  ],
+  ['deadline_ms = ?diagnostic_context.deadline_ms', 'deadline field'],
+  ['operation,', 'exact operation field'],
+  ['owner_code = %owner_code', 'owner code field'],
+  ['owner_message_shape,', 'owner message shape field'],
+  ['owner_message_len,', 'owner message length field'],
+  ['owner_kind = ?owner_kind', 'owner kind field'],
+  ['owner_retryable,', 'owner retryability field'],
+  ['boundary = CART_GRAPHQL_OWNER_BOUNDARY', 'boundary logging'],
+  ['"commerce GraphQL storefront cart owner call failed"', 'static cart owner event'],
+]) {
+  requireText(cartBoundary, value, label);
+}
+
+for (const value of [
+  'error = ?error',
+  'correlation_id = %context.correlation_id',
+  'correlation_id = ?context.correlation_id',
+  'tenant_id = %context.tenant_id',
+  'tenant_id = ?context.tenant_id',
+  'channel = ?context.channel',
+  'channel = %context.channel',
+  'locale = %context.locale',
+  'locale = ?context.locale',
+  'actor_kind = ?context.actor.kind',
+  'actor_id = %context.actor.id',
+  'actor_id = ?context.actor.id',
+  'causation_id = ?context.causation_id',
+  'traceparent = ?context.traceparent',
+  'idempotency_key = ?context.idempotency_key',
+  'internal_message =',
+  'owner_message =',
+  'message = %error.message',
+  'message = ?error.message',
+]) {
+  forbidText(cartBoundary, value, 'raw cart owner diagnostic');
+}
+
+const projectionIndex = cartBoundary.indexOf(
+  'let diagnostic_context = CartOwnerDiagnosticContext::from(context);',
+);
+const ownerFactsIndex = cartBoundary.indexOf('let owner_code = error.code.clone();');
+const tokenIndex = cartBoundary.indexOf('let diagnostic_error = CartOwnerDiagnosticError;');
+const eventIndex = cartBoundary.indexOf('tracing::error!(');
+const returnIndex = cartBoundary.indexOf('\n            error\n        })', eventIndex);
+if (
+  !(
+    projectionIndex >= 0 &&
+    projectionIndex < ownerFactsIndex &&
+    ownerFactsIndex < tokenIndex &&
+    tokenIndex < eventIndex &&
+    eventIndex < returnIndex
+  )
+) {
+  failures.push('cart owner error must be projected, redacted, diagnosed, and returned in order');
+}
+if ((cartBoundary.match(/tracing::error!\(/g) ?? []).length !== 1) {
+  failures.push('expected one cart owner diagnostic event');
+}
+if ((cartBoundary.match(/error = \?diagnostic_error/g) ?? []).length !== 1) {
+  failures.push('expected one redacted cart owner diagnostic field');
 }
 
 for (const operation of [
@@ -61,8 +179,8 @@ for (const operation of [
   'remove_storefront_line_item',
   'reprice_storefront_line_items',
 ]) {
-  requireText(facade, `"${operation}"`, `${operation} diagnostic operation`);
-  requireText(facade, `.${operation}(context, request)`, `${operation} owner delegation`);
+  requireText(cartBoundary, `"${operation}"`, `${operation} diagnostic operation`);
+  requireText(cartBoundary, `.${operation}(context, request)`, `${operation} owner delegation`);
 }
 
 for (const [pattern, expected, label] of [
@@ -71,7 +189,7 @@ for (const [pattern, expected, label] of [
   [/owner = "rustok_cart"/g, 1, 'cart owner event count'],
   [/::rustok_cart::in_process_cart_storefront_port\(db\)/g, 1, 'canonical constructor count'],
 ]) {
-  const count = facade.match(pattern)?.length ?? 0;
+  const count = cartBoundary.match(pattern)?.length ?? 0;
   if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
 }
 
@@ -105,7 +223,8 @@ for (const [value, label] of [
   ['"CART_ACCESS_DENIED"', 'cart forbidden envelope'],
   ['"CART_TEMPORARILY_UNAVAILABLE"', 'cart availability envelope'],
   ['"CART_OPERATION_FAILED"', 'cart invariant envelope'],
-  ['source_owner = cart_port_source_owner(&error)', 'source owner boundary logging'],
+  ['let source_owner = cart_port_source_owner(&error);', 'source owner projection'],
+  ['source_owner,', 'source owner boundary logging'],
 ]) {
   requireText(helperFacade, value, label);
 }
@@ -117,5 +236,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce GraphQL storefront cart owner calls retain the original PortContext and exact operation while public CART_* envelopes remain unchanged',
+  '✔ Commerce GraphQL storefront cart owner calls retain exact delegation and public envelopes while diagnostics expose only bounded context and owner facts',
 );


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce correlation-safe mapper cleanup at the Commerce GraphQL storefront Cart owner wrapper.

- preserve all eight `CartStorefrontPort` delegations, exact operation labels, context cloning, and the canonical owner constructor;
- preserve the original `PortError` for the existing downstream `cart_port_error` public mapper;
- stop formatting the complete Cart `PortError` in the owner-context event;
- stop logging raw tenant, actor, channel, locale, correlation, causation, traceparent, and idempotency values;
- project identities and optional text to closed shapes and retain claim/role counts plus deadline;
- retain exact owner code, typed owner kind, owner retryability, and only owner-message shape/length;
- log a dedicated diagnostic token whose `Debug` output is always `redacted`;
- update the existing owner-context verifier to scope fail-closed assertions to the Cart wrapper and follow the current precomputed Cart/Pricing source-owner contract;
- add source-only evidence and documentation;
- leave the Pricing owner wrapper, Cart store-context diagnostic, typed line-item diagnostics/string classification, storefront shared/cart-shipping, tax, promotion, native transport, and remaining adapters open.

## Recheck

`main` advanced repeatedly during implementation. The branch was rebuilt on `main@a808d9cf20518ef58f64e737220c19205643b3fc` after exact blob checks confirmed that `safe_cart.rs` and `verify-commerce-graphql-cart-owner-context.mjs` had not changed. No open PR overlaps this Commerce boundary.

The final branch is one commit ahead and changes four intended files.

## Preserved behavior

- eight Cart owner calls and request arguments;
- exact diagnostic operation for every call;
- original `PortContext` clone before each call;
- original `PortError` returned downstream;
- `cart_port_error` public mapping and all `CART_*` envelopes;
- resolver inclusion and shim routing;
- error-level diagnostic severity;
- Pricing owner and store-context modules.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Node verifiers;
- Cargo checks, builds, clippy, or formatting;
- mounted GraphQL execution;
- workflows or CI.

Execution evidence remains pending and the broad ecommerce cleanup remains open.