### PR TITLE
fix(commerce): bound GraphQL pricing owner diagnostics

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/graphql-pricing-owner-diagnostic-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/graphql-pricing-owner-diagnostic-safety-source-review.json
@@ -1,0 +1,51 @@
+{
+  "status": "commerce_graphql_pricing_owner_diagnostic_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-commerce/src/graphql/mutations/safe_cart.rs",
+    "scripts/verify/verify-commerce-graphql-pricing-owner-diagnostic-safety.mjs",
+    "crates/rustok-commerce/docs/graphql-pricing-owner-diagnostic-safety.md",
+    "crates/rustok-commerce/docs/implementation-plan.md"
+  ],
+  "source_contract": {
+    "pricing_port_error_payload_logged": false,
+    "pricing_port_internal_message_logged": false,
+    "raw_tenant_identity_logged": false,
+    "raw_actor_identity_logged": false,
+    "raw_channel_logged": false,
+    "raw_locale_logged": false,
+    "raw_correlation_id_logged": false,
+    "raw_causation_id_logged": false,
+    "raw_traceparent_logged": false,
+    "raw_idempotency_key_logged": false,
+    "diagnostic_error_debug_redacted": true,
+    "owner_code_preserved": true,
+    "owner_kind_preserved": true,
+    "owner_retryability_preserved": true,
+    "owner_message_shape_logged": true,
+    "owner_message_length_logged": true,
+    "bounded_context_facts_logged": true,
+    "original_port_error_returned_downstream": true,
+    "pricing_owner_operation_preserved": true,
+    "pricing_owner_delegation_count_preserved": true,
+    "pricing_owner_constructor_preserved": true,
+    "cart_public_mapper_preserved": true,
+    "cart_public_envelopes_preserved": true,
+    "cart_owner_cleanup_preserved": true,
+    "store_context_cleanup_closed": false,
+    "typed_line_item_cleanup_closed": false,
+    "broad_ecommerce_cleanup_closed": false,
+    "runtime_evidence_claimed": false
+  },
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, mounted GraphQL scenarios, workflows, or CI were executed."
+}

--- a/crates/rustok-commerce/docs/graphql-pricing-owner-diagnostic-safety.md
+++ b/crates/rustok-commerce/docs/graphql-pricing-owner-diagnostic-safety.md
@@ -1,0 +1,76 @@
+# GraphQL pricing owner diagnostic safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens the contextual Pricing read-owner wrapper in `safe_cart.rs`.
+
+The wrapper surrounds six `PricingReadPort` calls so the diagnostic event retains the exact operation and original `PortContext` when the owner returns a `PortError`. Before this change, that event emitted the complete owner error together with raw tenant, actor, channel, locale, correlation, and causation values.
+
+## Bounded diagnostic projection
+
+The Pricing wrapper now projects retained request context to closed facts:
+
+- tenant and actor identities become `empty`, `uuid_nil`, `uuid_non_nil`, or `opaque`;
+- actor kind remains `user`, `service`, or `system`;
+- claims and roles become counts;
+- channel, locale, correlation, causation, traceparent, and idempotency values become presence shapes;
+- the optional deadline remains a millisecond value.
+
+The event keeps exact owner code, typed owner kind, owner retryability, and only owner-message shape and byte length. Its error field uses `PricingOwnerDiagnosticError`, whose `Debug` implementation always emits `redacted`.
+
+The original `PortError` is intentionally not consumed because the wrapper must return it unchanged to the existing `cart_port_error` mapper. It remains available only for downstream public-policy mapping and is never formatted by the Pricing owner event.
+
+## Preserved behavior
+
+This work does not change:
+
+- `resolve_product_price` delegation;
+- `read_price_list_projection` delegation;
+- `list_active_price_list_projections` delegation;
+- `read_admin_product_pricing_projection` delegation;
+- `read_storefront_product_pricing_projection` delegation;
+- `preview_variant_discount` delegation;
+- the exact operation label and `PortContext` clone for each call;
+- the canonical in-process Pricing read-port constructor;
+- the downstream `cart_port_error` mapper and its source-owner classifier;
+- public `CART_*` messages, codes, and retryability;
+- the previously hardened Cart owner wrapper;
+- resolver inclusion and shim routing.
+
+The event remains error-level and continues to identify `rustok_pricing` and the `commerce_graphql_cart` boundary.
+
+## Focused verifier
+
+`verify-commerce-graphql-pricing-owner-diagnostic-safety.mjs` isolates only `pricing_read_owner_boundary` and checks:
+
+- bounded context projection before diagnostic emission;
+- redacted error formatting;
+- preservation of safe owner facts;
+- absence of raw context and internal owner messages;
+- the six exact owner delegations and context clones;
+- preservation of the canonical constructor;
+- preservation of Pricing source classification and public `CART_*` envelopes in `safe_helpers.rs`.
+
+## Remaining work
+
+Still open:
+
+- the Cart store-context diagnostic in `safe_cart.rs`;
+- typed line-item source and identity diagnostics;
+- compatibility string classification;
+- storefront shared and cart-shipping mappers;
+- tax, promotion, native transport, and remaining owner-adapter cleanup;
+- mounted execution, compile, and runtime evidence.
+
+The broad ecommerce correlation-safe mapper cleanup remains open.
+
+## Evidence
+
+- `crates/rustok-commerce/contracts/evidence/graphql-pricing-owner-diagnostic-safety-source-review.json`
+- `scripts/verify/verify-commerce-graphql-pricing-owner-diagnostic-safety.mjs`
+
+## Validation disclosure
+
+No tests, Node verifiers, formatting, Cargo commands, mounted GraphQL scenarios, workflows, or CI were run. No compile or runtime status is claimed.

--- a/crates/rustok-commerce/src/graphql/mutations/safe_cart.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_cart.rs
@@ -355,9 +355,83 @@ mod pricing_read_owner_boundary {
         ResolveProductPriceRequest, ResolvedProductPriceSnapshot,
         StorefrontProductPricingProjectionRequest,
     };
-    use rustok_api::{PortContext, PortError};
+    use rustok_api::{PortActorKind, PortContext, PortError};
 
     const PRICING_GRAPHQL_OWNER_BOUNDARY: &str = "commerce_graphql_cart";
+
+    #[derive(Clone, Copy)]
+    struct PricingOwnerDiagnosticContext {
+        tenant_id_shape: &'static str,
+        actor_kind: &'static str,
+        actor_id_shape: &'static str,
+        claim_count: usize,
+        role_count: usize,
+        channel_shape: &'static str,
+        locale_shape: &'static str,
+        correlation_id_shape: &'static str,
+        causation_id_shape: &'static str,
+        traceparent_shape: &'static str,
+        idempotency_key_shape: &'static str,
+        deadline_ms: Option<u64>,
+    }
+
+    impl From<&PortContext> for PricingOwnerDiagnosticContext {
+        fn from(context: &PortContext) -> Self {
+            Self {
+                tenant_id_shape: identity_text_shape(context.tenant_id.as_str()),
+                actor_kind: actor_kind_name(&context.actor.kind),
+                actor_id_shape: identity_text_shape(context.actor.id.as_str()),
+                claim_count: context.claims.len(),
+                role_count: context.roles.len(),
+                channel_shape: optional_text_shape(context.channel.as_deref()),
+                locale_shape: text_shape(context.locale.as_str()),
+                correlation_id_shape: text_shape(context.correlation_id.as_str()),
+                causation_id_shape: optional_text_shape(context.causation_id.as_deref()),
+                traceparent_shape: optional_text_shape(context.traceparent.as_deref()),
+                idempotency_key_shape: optional_text_shape(context.idempotency_key.as_deref()),
+                deadline_ms: context.deadline_ms,
+            }
+        }
+    }
+
+    struct PricingOwnerDiagnosticError;
+
+    impl std::fmt::Debug for PricingOwnerDiagnosticError {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("redacted")
+        }
+    }
+
+    fn actor_kind_name(kind: &PortActorKind) -> &'static str {
+        match kind {
+            PortActorKind::User => "user",
+            PortActorKind::Service => "service",
+            PortActorKind::System => "system",
+        }
+    }
+
+    fn identity_text_shape(value: &str) -> &'static str {
+        if value.is_empty() {
+            return "empty";
+        }
+        match uuid::Uuid::parse_str(value) {
+            Ok(value) if value.is_nil() => "uuid_nil",
+            Ok(_) => "uuid_non_nil",
+            Err(_) => "opaque",
+        }
+    }
+
+    fn text_shape(value: &str) -> &'static str {
+        if value.is_empty() { "empty" } else { "present" }
+    }
+
+    fn optional_text_shape(value: Option<&str>) -> &'static str {
+        match value {
+            None => "absent",
+            Some(value) if value.is_empty() => "empty",
+            Some(_) => "present",
+        }
+    }
 
     fn retain_pricing_owner_context<T>(
         context: &PortContext,
@@ -365,20 +439,35 @@ mod pricing_read_owner_boundary {
         result: Result<T, PortError>,
     ) -> Result<T, PortError> {
         result.map_err(|error| {
+            let diagnostic_context = PricingOwnerDiagnosticContext::from(context);
+            let owner_code = error.code.clone();
+            let owner_kind = error.kind.clone();
+            let owner_retryable = error.retryable;
+            let owner_message_shape = text_shape(error.message.as_str());
+            let owner_message_len = error.message.len();
+            let diagnostic_error = PricingOwnerDiagnosticError;
+
             tracing::error!(
-                error = ?error,
+                error = ?diagnostic_error,
                 owner = "rustok_pricing",
-                correlation_id = %context.correlation_id,
-                tenant_id = %context.tenant_id,
-                channel = ?context.channel,
-                locale = %context.locale,
-                actor_kind = ?context.actor.kind,
-                actor_id = %context.actor.id,
-                causation_id = ?context.causation_id,
+                tenant_id_shape = diagnostic_context.tenant_id_shape,
+                actor_kind = diagnostic_context.actor_kind,
+                actor_id_shape = diagnostic_context.actor_id_shape,
+                claim_count = diagnostic_context.claim_count,
+                role_count = diagnostic_context.role_count,
+                channel_shape = diagnostic_context.channel_shape,
+                locale_shape = diagnostic_context.locale_shape,
+                correlation_id_shape = diagnostic_context.correlation_id_shape,
+                causation_id_shape = diagnostic_context.causation_id_shape,
+                traceparent_shape = diagnostic_context.traceparent_shape,
+                idempotency_key_shape = diagnostic_context.idempotency_key_shape,
+                deadline_ms = ?diagnostic_context.deadline_ms,
                 operation,
-                owner_code = %error.code,
-                owner_kind = ?error.kind,
-                owner_retryable = error.retryable,
+                owner_code = %owner_code,
+                owner_message_shape,
+                owner_message_len,
+                owner_kind = ?owner_kind,
+                owner_retryable,
                 boundary = PRICING_GRAPHQL_OWNER_BOUNDARY,
                 "commerce GraphQL storefront cart pricing owner call failed"
             );

--- a/scripts/verify/verify-commerce-graphql-pricing-owner-diagnostic-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-pricing-owner-diagnostic-safety.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const facade = read('crates/rustok-commerce/src/graphql/mutations/safe_cart.rs');
+const helperFacade = read('crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const pricingBoundary = between(
+  facade,
+  'mod pricing_read_owner_boundary {',
+  'pub(crate) use pricing_read_owner_boundary::in_process_pricing_read_port',
+  'pricing owner boundary module',
+);
+
+for (const [value, label] of [
+  ['PortActorKind, PortContext, PortError', 'pricing diagnostic imports'],
+  ['const PRICING_GRAPHQL_OWNER_BOUNDARY: &str = "commerce_graphql_cart";', 'pricing boundary'],
+  ['struct PricingOwnerDiagnosticContext {', 'bounded pricing context'],
+  ['impl From<&PortContext> for PricingOwnerDiagnosticContext', 'pricing context projection'],
+  ['tenant_id_shape: identity_text_shape(context.tenant_id.as_str())', 'tenant identity shape'],
+  ['actor_kind: actor_kind_name(&context.actor.kind)', 'actor kind projection'],
+  ['actor_id_shape: identity_text_shape(context.actor.id.as_str())', 'actor identity shape'],
+  ['claim_count: context.claims.len()', 'claim count'],
+  ['role_count: context.roles.len()', 'role count'],
+  ['channel_shape: optional_text_shape(context.channel.as_deref())', 'channel shape'],
+  ['locale_shape: text_shape(context.locale.as_str())', 'locale shape'],
+  ['correlation_id_shape: text_shape(context.correlation_id.as_str())', 'correlation shape'],
+  ['causation_id_shape: optional_text_shape(context.causation_id.as_deref())', 'causation shape'],
+  ['traceparent_shape: optional_text_shape(context.traceparent.as_deref())', 'trace shape'],
+  [
+    'idempotency_key_shape: optional_text_shape(context.idempotency_key.as_deref())',
+    'idempotency shape',
+  ],
+  ['deadline_ms: context.deadline_ms', 'deadline fact'],
+  ['struct PricingOwnerDiagnosticError;', 'redacted pricing diagnostic token'],
+  ['impl std::fmt::Debug for PricingOwnerDiagnosticError', 'custom pricing diagnostic Debug'],
+  ['formatter.write_str("redacted")', 'redacted pricing diagnostic output'],
+  ['fn actor_kind_name(kind: &PortActorKind)', 'actor kind helper'],
+  ['fn identity_text_shape(value: &str)', 'identity shape helper'],
+  ['fn text_shape(value: &str)', 'text shape helper'],
+  ['fn optional_text_shape(value: Option<&str>)', 'optional text shape helper'],
+  ['fn retain_pricing_owner_context<T>(', 'pricing context retention mapper'],
+  ['let diagnostic_context = PricingOwnerDiagnosticContext::from(context);', 'context projection'],
+  ['let owner_code = error.code.clone();', 'owner code projection'],
+  ['let owner_kind = error.kind.clone();', 'owner kind projection'],
+  ['let owner_retryable = error.retryable;', 'owner retryability projection'],
+  ['let owner_message_shape = text_shape(error.message.as_str());', 'owner message shape'],
+  ['let owner_message_len = error.message.len();', 'owner message length'],
+  ['let diagnostic_error = PricingOwnerDiagnosticError;', 'diagnostic shadow token'],
+  ['tracing::error!(', 'pricing owner error event'],
+  ['error = ?diagnostic_error', 'redacted diagnostic field'],
+  ['owner = "rustok_pricing"', 'pricing owner field'],
+  ['tenant_id_shape = diagnostic_context.tenant_id_shape', 'tenant shape field'],
+  ['actor_kind = diagnostic_context.actor_kind', 'actor kind field'],
+  ['actor_id_shape = diagnostic_context.actor_id_shape', 'actor identity shape field'],
+  ['claim_count = diagnostic_context.claim_count', 'claim count field'],
+  ['role_count = diagnostic_context.role_count', 'role count field'],
+  ['channel_shape = diagnostic_context.channel_shape', 'channel shape field'],
+  ['locale_shape = diagnostic_context.locale_shape', 'locale shape field'],
+  ['correlation_id_shape = diagnostic_context.correlation_id_shape', 'correlation shape field'],
+  ['causation_id_shape = diagnostic_context.causation_id_shape', 'causation shape field'],
+  ['traceparent_shape = diagnostic_context.traceparent_shape', 'trace shape field'],
+  [
+    'idempotency_key_shape = diagnostic_context.idempotency_key_shape',
+    'idempotency shape field',
+  ],
+  ['deadline_ms = ?diagnostic_context.deadline_ms', 'deadline field'],
+  ['operation,', 'exact operation field'],
+  ['owner_code = %owner_code', 'owner code field'],
+  ['owner_message_shape,', 'owner message shape field'],
+  ['owner_message_len,', 'owner message length field'],
+  ['owner_kind = ?owner_kind', 'owner kind field'],
+  ['owner_retryable,', 'owner retryability field'],
+  ['boundary = PRICING_GRAPHQL_OWNER_BOUNDARY', 'boundary field'],
+  ['"commerce GraphQL storefront cart pricing owner call failed"', 'static pricing event'],
+  ['struct ContextualPricingReadPort {', 'contextual pricing adapter'],
+  ['inner: Arc<dyn PricingReadPort>', 'canonical pricing port delegation'],
+  ['inner: ::rustok_pricing::in_process_pricing_read_port(db, event_bus)', 'canonical constructor'],
+]) {
+  requireText(pricingBoundary, value, label);
+}
+
+for (const value of [
+  'error = ?error',
+  'correlation_id = %context.correlation_id',
+  'correlation_id = ?context.correlation_id',
+  'tenant_id = %context.tenant_id',
+  'tenant_id = ?context.tenant_id',
+  'channel = ?context.channel',
+  'channel = %context.channel',
+  'locale = %context.locale',
+  'locale = ?context.locale',
+  'actor_kind = ?context.actor.kind',
+  'actor_id = %context.actor.id',
+  'actor_id = ?context.actor.id',
+  'causation_id = ?context.causation_id',
+  'traceparent = ?context.traceparent',
+  'idempotency_key = ?context.idempotency_key',
+  'internal_message =',
+  'owner_message =',
+  'message = %error.message',
+  'message = ?error.message',
+]) {
+  forbidText(pricingBoundary, value, 'raw pricing owner diagnostic');
+}
+
+const operations = [
+  'resolve_product_price',
+  'read_price_list_projection',
+  'list_active_price_list_projections',
+  'read_admin_product_pricing_projection',
+  'read_storefront_product_pricing_projection',
+  'preview_variant_discount',
+];
+for (const operation of operations) {
+  requireText(pricingBoundary, `"${operation}"`, `${operation} diagnostic operation`);
+  requireText(pricingBoundary, `.${operation}(context, request)`, `${operation} owner delegation`);
+}
+
+for (const [pattern, expected, label] of [
+  [/let error_context = context\.clone\(\);/g, 6, 'owner context clone count'],
+  [/retain_pricing_owner_context\(/g, 6, 'pricing context retention call count'],
+  [/owner = "rustok_pricing"/g, 1, 'pricing owner event count'],
+  [/::rustok_pricing::in_process_pricing_read_port\(db, event_bus\)/g, 1, 'constructor count'],
+]) {
+  const count = pricingBoundary.match(pattern)?.length ?? 0;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+}
+
+const projectionIndex = pricingBoundary.indexOf(
+  'let diagnostic_context = PricingOwnerDiagnosticContext::from(context);',
+);
+const ownerFactsIndex = pricingBoundary.indexOf('let owner_code = error.code.clone();');
+const tokenIndex = pricingBoundary.indexOf('let diagnostic_error = PricingOwnerDiagnosticError;');
+const eventIndex = pricingBoundary.indexOf('tracing::error!(');
+const returnIndex = pricingBoundary.indexOf('\n            error\n        })', eventIndex);
+if (
+  !(
+    projectionIndex >= 0 &&
+    projectionIndex < ownerFactsIndex &&
+    ownerFactsIndex < tokenIndex &&
+    tokenIndex < eventIndex &&
+    eventIndex < returnIndex
+  )
+) {
+  failures.push('pricing owner error must be projected, redacted, diagnosed, and returned in order');
+}
+
+for (const [value, label] of [
+  ['fn cart_port_source_owner(error: &PortError)', 'source-owner classifier'],
+  ['Some(("pricing", _)) => "rustok_pricing"', 'pricing source-owner classification'],
+  ['pub(crate) fn cart_port_error(error: PortError)', 'downstream public mapper'],
+  ['let source_owner = cart_port_source_owner(&error);', 'downstream source projection'],
+  ['source_owner,', 'downstream source field'],
+  ['"CART_REQUEST_INVALID"', 'validation envelope'],
+  ['"CART_RESOURCE_NOT_FOUND"', 'not-found envelope'],
+  ['"CART_STATE_CONFLICT"', 'conflict envelope'],
+  ['"CART_ACCESS_DENIED"', 'forbidden envelope'],
+  ['"CART_TEMPORARILY_UNAVAILABLE"', 'availability envelope'],
+  ['"CART_OPERATION_FAILED"', 'invariant envelope'],
+]) {
+  requireText(helperFacade, value, label);
+}
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL pricing owner diagnostic verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce GraphQL Pricing read-owner calls retain exact delegation and public envelopes while diagnostics expose only bounded context and owner facts',
+);


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce correlation-safe mapper cleanup at the Commerce GraphQL storefront Pricing read-owner wrapper.

- preserve all six `PricingReadPort` delegations, exact operation labels, context cloning, and the canonical in-process constructor;
- preserve the original `PortError` for the existing downstream `cart_port_error` public mapper;
- stop formatting the complete Pricing `PortError` in the owner-context event;
- stop logging raw tenant, actor, channel, locale, correlation, causation, traceparent, and idempotency values;
- project identities and optional text to closed shapes and retain claim/role counts plus deadline;
- retain exact owner code, typed owner kind, owner retryability, and only owner-message shape/length;
- log a dedicated diagnostic token whose `Debug` output is always `redacted`;
- add a focused verifier, source-only evidence, and documentation;
- leave the Cart store-context diagnostic, typed line-item diagnostics/string classification, storefront shared/cart-shipping, tax, promotion, native transport, and remaining adapters open.

## Recheck

Current base is `main@dae5188364586e216730210111a5e7a6b230d50c`. The branch was rebuilt on that commit after an exact blob check confirmed `safe_cart.rs` had not changed. No open PR overlaps this Commerce boundary.

The branch is one commit ahead and changes four intended files.

## Preserved behavior

- six Pricing read-owner calls and request arguments;
- exact diagnostic operation for every call;
- original `PortContext` clone before each call;
- original `PortError` returned downstream;
- `cart_port_error`, Pricing source classification, and public `CART_*` envelopes;
- resolver inclusion and shim routing;
- error-level diagnostic severity;
- Cart owner and store-context modules.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Node verifiers;
- Cargo checks, builds, clippy, or formatting;
- mounted GraphQL execution;
- workflows or CI.

Execution evidence remains pending and the broad ecommerce cleanup remains open.