### PR TITLE
fix(commerce): redact GraphQL cart context diagnostics

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/graphql-cart-context-diagnostic-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/graphql-cart-context-diagnostic-safety-source-review.json
@@ -1,0 +1,45 @@
+{
+  "status": "commerce_graphql_cart_context_diagnostic_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-commerce/src/graphql/mutations/safe_cart.rs",
+    "scripts/verify/verify-commerce-graphql-cart-context-diagnostic-safety.mjs",
+    "scripts/verify/verify-commerce-graphql-cart-context-error-safety.mjs",
+    "crates/rustok-commerce/docs/graphql-cart-context-diagnostic-safety.md",
+    "crates/rustok-commerce/docs/implementation-plan.md"
+  ],
+  "source_contract": {
+    "complete_store_context_error_logged": false,
+    "tenant_uuid_payload_logged": false,
+    "validation_payload_logged": false,
+    "currency_region_payload_logged": false,
+    "tenant_boundary_payload_logged": false,
+    "region_boundary_payload_logged": false,
+    "database_payload_logged": false,
+    "diagnostic_error_zero_sized": true,
+    "diagnostic_error_debug_redacted": true,
+    "typed_error_kind_preserved": true,
+    "public_code_preserved": true,
+    "public_retryability_preserved": true,
+    "public_message_preserved": true,
+    "graphql_pass_through_preserved": true,
+    "store_context_service_call_count_preserved": true,
+    "cart_owner_cleanup_preserved": true,
+    "pricing_owner_cleanup_preserved": true,
+    "typed_line_item_cleanup_closed": false,
+    "compatibility_string_classification_closed": false,
+    "broad_ecommerce_cleanup_closed": false,
+    "runtime_evidence_claimed": false
+  },
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, mounted GraphQL scenarios, workflows, or CI were executed."
+}

--- a/crates/rustok-commerce/docs/graphql-cart-context-diagnostic-safety.md
+++ b/crates/rustok-commerce/docs/graphql-cart-context-diagnostic-safety.md
@@ -1,0 +1,94 @@
+# GraphQL cart store-context diagnostic safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice hardens only `cart_context_boundary` in
+`crates/rustok-commerce/src/graphql/mutations/safe_cart.rs`.
+
+The boundary converts `StoreContextError` into a cloneable GraphQL-safe public envelope for the two
+store-context resolution call sites used by storefront Cart mutations. Public policy was already
+selected from typed variants, but the diagnostic event still formatted the complete owner error.
+That could expose tenant UUIDs, validation text, currency/region details, boundary codes and messages,
+or a database cause.
+
+## Redacted diagnostic boundary
+
+The conversion now performs these steps in order:
+
+1. select the existing typed public message, code, retryability, and `error_kind`;
+2. shadow the complete `StoreContextError` with a zero-sized `StoreContextDiagnosticError`;
+3. emit the same error-level event using the redacted diagnostic token;
+4. return the unchanged cloneable public envelope.
+
+`StoreContextDiagnosticError` has a custom `Debug` implementation whose only output is
+`redacted`. It contains no fields and cannot retain a tenant, region, currency, validation,
+boundary, database, or correlation payload.
+
+The event still retains only bounded policy facts:
+
+- owner `rustok_commerce.store_context`;
+- typed `error_kind`;
+- public code;
+- public retryability;
+- operation `resolve_store_context`;
+- boundary `commerce_graphql_cart`;
+- the existing static event message.
+
+## Preserved behavior
+
+This work does not change:
+
+- `StoreContextError` variants or owner-service behavior;
+- the two `StoreContextService::new` and `resolve_context` resolver paths;
+- GraphQL error pass-through through `BoundaryError::Graphql`;
+- the cloneable `BoundaryError::Public` representation;
+- public messages, codes, or retryability;
+- Cart owner diagnostics;
+- Pricing owner diagnostics;
+- resolver inclusion, shims, or mutation signatures.
+
+The preserved public policies are:
+
+- `TenantNotFound` → `STORE_CONTEXT_NOT_FOUND`, non-retryable;
+- `Validation` and `CurrencyRegionMismatch` → `STORE_CONTEXT_REQUEST_INVALID`, non-retryable;
+- `TenantBoundary` and `RegionBoundary` → `STORE_CONTEXT_RESOLUTION_FAILED`, non-retryable;
+- `Database` → `STORE_CONTEXT_TEMPORARILY_UNAVAILABLE`, retryable.
+
+## Static guards
+
+The existing `verify-commerce-graphql-cart-context-error-safety.mjs` continues to guard the typed
+public boundary and resolver routing.
+
+The new `verify-commerce-graphql-cart-context-diagnostic-safety.mjs` additionally checks:
+
+- the zero-sized diagnostic token and custom redacted `Debug`;
+- typed envelope selection before payload shadowing;
+- exactly one shadow and one diagnostic event;
+- shadowing before event emission and public-envelope construction;
+- absence of stringification and raw owner payload fields;
+- preservation of all typed public policies and both resolver call sites.
+
+## Remaining work
+
+Still open:
+
+- typed line-item source and identity diagnostics;
+- compatibility string classification;
+- storefront shared and cart-shipping mappers;
+- tax and promotion diagnostics;
+- native transports and remaining owner adapters;
+- mounted execution, compilation, workflow, and CI evidence.
+
+The broad ecommerce correlation-safe mapper cleanup remains open.
+
+## Evidence
+
+- `crates/rustok-commerce/contracts/evidence/graphql-cart-context-diagnostic-safety-source-review.json`
+- `scripts/verify/verify-commerce-graphql-cart-context-diagnostic-safety.mjs`
+
+## Validation disclosure
+
+No tests, Node verifiers, formatting, Cargo commands, mounted GraphQL scenarios, workflows, or CI
+were run. No compile or runtime status is claimed.

--- a/crates/rustok-commerce/src/graphql/mutations/safe_cart.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_cart.rs
@@ -19,6 +19,14 @@ mod cart_context_boundary {
         }
     }
 
+    struct StoreContextDiagnosticError;
+
+    impl std::fmt::Debug for StoreContextDiagnosticError {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("redacted")
+        }
+    }
+
     fn public_graphql_error(message: &'static str, code: &'static str, retryable: bool) -> Error {
         Error::new(message).extend_with(|_, extensions| {
             extensions.set("code", code);
@@ -68,6 +76,7 @@ mod cart_context_boundary {
     impl From<StoreContextError> for BoundaryError {
         fn from(error: StoreContextError) -> Self {
             let (message, code, retryable, error_kind) = store_context_error_envelope(&error);
+            let error = StoreContextDiagnosticError;
             tracing::error!(
                 error = ?error,
                 owner = "rustok_commerce.store_context",

--- a/scripts/verify/verify-commerce-graphql-cart-context-diagnostic-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-cart-context-diagnostic-safety.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const facade = read('crates/rustok-commerce/src/graphql/mutations/safe_cart.rs');
+const ownerSource = read('crates/rustok-commerce/src/services/context.rs');
+const resolverSource = read('crates/rustok-commerce/src/graphql/mutations/cart.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const boundary = between(
+  facade,
+  'mod cart_context_boundary {',
+  'mod cart_storefront_owner_boundary {',
+  'cart store-context diagnostic boundary',
+);
+
+for (const [value, label] of [
+  ['struct StoreContextDiagnosticError;', 'zero-sized diagnostic token'],
+  ['impl std::fmt::Debug for StoreContextDiagnosticError', 'custom diagnostic Debug'],
+  ['formatter.write_str("redacted")', 'redacted diagnostic output'],
+  ['fn store_context_error_envelope(', 'typed public mapper'],
+  ['impl From<StoreContextError> for BoundaryError', 'store-context conversion'],
+  [
+    'let (message, code, retryable, error_kind) = store_context_error_envelope(&error);',
+    'typed envelope selection',
+  ],
+  ['let error = StoreContextDiagnosticError;', 'fail-closed diagnostic shadow'],
+  ['tracing::error!(', 'single diagnostic event'],
+  ['error = ?error', 'redacted diagnostic field'],
+  ['owner = "rustok_commerce.store_context"', 'owner field'],
+  ['error_kind,', 'typed owner kind'],
+  ['public_code = code', 'public code field'],
+  ['retryable,', 'retryability field'],
+  ['operation = "resolve_store_context"', 'operation field'],
+  ['boundary = "commerce_graphql_cart"', 'boundary field'],
+  [
+    '"commerce GraphQL cart store context resolution failed"',
+    'static diagnostic message',
+  ],
+  ['Self::Public {', 'public envelope construction'],
+  ['message,', 'public message field'],
+  ['code,', 'public code envelope field'],
+  ['retryable,', 'public retryability envelope field'],
+  ['BoundaryError::Graphql(error) => error', 'GraphQL pass-through preservation'],
+  [
+    '} => public_graphql_error(message, code, retryable)',
+    'public GraphQL restoration',
+  ],
+]) {
+  requireText(boundary, value, label);
+}
+
+for (const [value, label] of [
+  ['StoreContextError::TenantNotFound(_)', 'tenant not-found policy'],
+  ['StoreContextError::Validation(_)', 'validation policy'],
+  ['StoreContextError::CurrencyRegionMismatch { .. }', 'currency-region policy'],
+  ['StoreContextError::TenantBoundary { .. }', 'tenant boundary policy'],
+  ['StoreContextError::RegionBoundary { .. }', 'region boundary policy'],
+  ['StoreContextError::Database(_)', 'database policy'],
+  ['"STORE_CONTEXT_NOT_FOUND"', 'not-found code'],
+  ['"STORE_CONTEXT_REQUEST_INVALID"', 'request-invalid code'],
+  ['"STORE_CONTEXT_RESOLUTION_FAILED"', 'resolution-failed code'],
+  ['"STORE_CONTEXT_TEMPORARILY_UNAVAILABLE"', 'temporary code'],
+  ['"tenant_not_found"', 'tenant error kind'],
+  ['"validation"', 'validation error kind'],
+  ['"tenant_boundary"', 'tenant-boundary error kind'],
+  ['"region_boundary"', 'region-boundary error kind'],
+  ['"database"', 'database error kind'],
+]) {
+  requireText(boundary, value, label);
+}
+
+for (const value of [
+  '#[derive(Debug)]\n    struct StoreContextDiagnosticError',
+  '#[derive(Debug,',
+  'async_graphql::Error::new(error.to_string())',
+  'Error::new(error.to_string())',
+  'format!("{error}")',
+  'format!("{:?}", error)',
+  'internal_message =',
+  'database_error =',
+  'validation_message =',
+  'boundary_message =',
+  'tenant_id =',
+  'region_id =',
+  'currency_code =',
+  'region_currency_code =',
+]) {
+  forbidText(boundary, value, 'raw store-context diagnostic');
+}
+
+const envelopeIndex = boundary.indexOf(
+  'let (message, code, retryable, error_kind) = store_context_error_envelope(&error);',
+);
+const shadowIndex = boundary.indexOf('let error = StoreContextDiagnosticError;');
+const eventIndex = boundary.indexOf('tracing::error!(', shadowIndex);
+const publicIndex = boundary.indexOf('Self::Public {', eventIndex);
+if (
+  !(
+    envelopeIndex >= 0 &&
+    envelopeIndex < shadowIndex &&
+    shadowIndex < eventIndex &&
+    eventIndex < publicIndex
+  )
+) {
+  failures.push('store-context error must map policy, shadow payload, emit, and return in order');
+}
+
+for (const [pattern, expected, label] of [
+  [/struct StoreContextDiagnosticError;/g, 1, 'diagnostic token count'],
+  [/let error = StoreContextDiagnosticError;/g, 1, 'diagnostic shadow count'],
+  [/tracing::error!\(/g, 1, 'diagnostic event count'],
+  [/"STORE_CONTEXT_TEMPORARILY_UNAVAILABLE"/g, 1, 'retryable policy count'],
+]) {
+  const count = boundary.match(pattern)?.length ?? 0;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+}
+
+for (const [value, label] of [
+  ['TenantNotFound(Uuid)', 'owner tenant payload variant'],
+  ['Validation(String)', 'owner validation payload variant'],
+  ['CurrencyRegionMismatch {', 'owner currency payload variant'],
+  ['TenantBoundary { code: String, message: String }', 'tenant boundary payload variant'],
+  ['RegionBoundary { code: String, message: String }', 'region boundary payload variant'],
+  ['Database(#[from] sea_orm::DbErr)', 'database payload variant'],
+]) {
+  requireText(ownerSource, value, label);
+}
+
+for (const [pattern, expected, label] of [
+  [/StoreContextService::new\(/g, 2, 'store-context service constructor count'],
+  [/\.resolve_context\(/g, 2, 'store-context resolution call count'],
+]) {
+  const count = resolverSource.match(pattern)?.length ?? 0;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+}
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL cart context diagnostic verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce GraphQL cart store-context diagnostics expose only typed policy and a redacted error token while public envelopes remain unchanged',
+);


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce correlation-safe mapper cleanup at the Commerce GraphQL Cart store-context boundary.

- preserve the existing typed `StoreContextError` → public GraphQL envelope mapping;
- preserve all `STORE_CONTEXT_*` messages, codes, retryability, and typed `error_kind` values;
- stop formatting the complete `StoreContextError` in the diagnostic event;
- shadow the owner payload with a zero-sized `StoreContextDiagnosticError` before emission;
- ensure the diagnostic token's custom `Debug` output is always `redacted`;
- preserve owner, operation, boundary, public code, retryability, severity, and static event message;
- preserve existing GraphQL error pass-through and the two store-context resolver call sites;
- leave Cart owner, Pricing owner, typed line-item, storefront shared/cart-shipping, tax, promotion, native transport, and remaining adapter cleanup unchanged/open;
- add a focused verifier, source-only evidence, and documentation.

## Recheck

Current base is `main@e903e9e5d2a0e186432e436a4dc353b752218219`. No open PR overlaps this Commerce boundary.

The branch is four commits ahead and changes four intended files. The production source diff is only `+9/-0` in `cart_context_boundary`.

## Preserved behavior

- `TenantNotFound` → `STORE_CONTEXT_NOT_FOUND`, non-retryable;
- `Validation` and `CurrencyRegionMismatch` → `STORE_CONTEXT_REQUEST_INVALID`, non-retryable;
- `TenantBoundary` and `RegionBoundary` → `STORE_CONTEXT_RESOLUTION_FAILED`, non-retryable;
- `Database` → `STORE_CONTEXT_TEMPORARILY_UNAVAILABLE`, retryable;
- `BoundaryError::Graphql` pass-through;
- cloneable `BoundaryError::Public` construction and restoration;
- both `StoreContextService::new` / `resolve_context` resolver paths;
- Cart and Pricing owner diagnostic modules;
- resolver inclusion and mutation signatures.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Node verifiers;
- Cargo checks, builds, clippy, or formatting;
- mounted GraphQL execution;
- workflows or CI.

Execution evidence remains pending and the broad ecommerce cleanup remains open.