### PR TITLE
refactor(commerce): cut line item compatibility wrappers to typed helpers

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/graphql-line-item-compatibility-cutover-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/graphql-line-item-compatibility-cutover-source-review.json
@@ -1,0 +1,51 @@
+{
+  "status": "commerce_graphql_line_item_compatibility_cutover_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs",
+    "crates/rustok-commerce/src/graphql/mutations/typed_line_item_helpers.rs",
+    "crates/rustok-commerce/src/graphql/mutations/layered_order_helpers.rs",
+    "scripts/verify/verify-commerce-graphql-line-item-compatibility-cutover.mjs",
+    "scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs",
+    "crates/rustok-commerce/docs/graphql-line-item-compatibility-cutover.md",
+    "crates/rustok-commerce/docs/implementation-plan.md"
+  ],
+  "source_contract": {
+    "resolve_wrapper_signature_preserved": true,
+    "quantity_wrapper_signature_preserved": true,
+    "resolve_wrapper_argument_order_preserved": true,
+    "quantity_wrapper_argument_order_preserved": true,
+    "resolve_wrapper_delegates_to_typed_helper": true,
+    "quantity_wrapper_delegates_to_typed_helper": true,
+    "resolve_legacy_helper_call_removed": true,
+    "quantity_legacy_helper_call_removed": true,
+    "debug_string_classification_removed": true,
+    "substring_policy_matching_removed": true,
+    "compatibility_envelope_remapping_removed": true,
+    "typed_public_policy_preserved": true,
+    "typed_diagnostic_redaction_preserved": true,
+    "typed_pricing_delegation_preserved": true,
+    "typed_inventory_delegation_preserved": true,
+    "layered_typed_exports_preserved": true,
+    "remaining_enrichment_legacy_wrapper_preserved": true,
+    "remaining_shipping_option_legacy_wrapper_preserved": true,
+    "remaining_repricing_legacy_wrapper_preserved": true,
+    "customer_diagnostic_contract_preserved": true,
+    "cart_port_diagnostic_contract_preserved": true,
+    "legacy_graphql_diagnostic_contract_preserved": true,
+    "remaining_adapter_cleanup_closed": false,
+    "broad_ecommerce_cleanup_closed": false,
+    "runtime_evidence_claimed": false
+  },
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, mounted GraphQL scenarios, workflows, or CI were executed."
+}

--- a/crates/rustok-commerce/docs/graphql-line-item-compatibility-cutover.md
+++ b/crates/rustok-commerce/docs/graphql-line-item-compatibility-cutover.md
@@ -1,0 +1,117 @@
+# GraphQL line-item compatibility cutover
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice closes only the private storefront line-item compatibility wrappers in
+`crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs`.
+
+The layered Commerce GraphQL helper surface already selected
+`typed_line_item_helpers::{resolve_storefront_line_item_input,
+validate_storefront_line_item_quantity}` explicitly. The private compatibility wrappers still called
+the older legacy implementations, formatted `async_graphql::Error` with `Debug`, and selected public
+policy by matching English substrings.
+
+Those two wrappers now delegate directly to the typed helper module.
+
+## Removed compatibility policy
+
+The removed source performed all of the following after a legacy helper failure:
+
+- formatted the complete GraphQL error through `format!("{error:?}")`;
+- searched for `Variant not found`, `Product not found`, inventory text, or metadata text;
+- reconstructed `CART_PRODUCT_UNAVAILABLE`, `CART_INVENTORY_INSUFFICIENT`,
+  `CART_LINE_ITEM_INVALID`, `CART_LINE_ITEM_RESOLUTION_FAILED`, or
+  `CART_INVENTORY_UNAVAILABLE` envelopes;
+- routed the original GraphQL error through the generic legacy diagnostic mapper.
+
+The wrappers no longer inspect, classify, or remap errors. The typed owner boundary remains the single
+policy owner for both line-item operations.
+
+## Preserved signatures and arguments
+
+`resolve_storefront_line_item_input` retains:
+
+- database connection;
+- tenant ID;
+- `PricingReadPort`;
+- `PortContext`;
+- `PriceResolutionContext`;
+- locale and default locale;
+- public channel slug;
+- complete `AddStorefrontCartLineItemInput`;
+- `Result<ResolvedStorefrontLineItemInput>`.
+
+`validate_storefront_line_item_quantity` retains:
+
+- database connection;
+- tenant ID;
+- variant ID;
+- requested quantity;
+- public channel slug;
+- `Result<()>`.
+
+Both wrappers forward these arguments in the original order and await exactly one typed helper call.
+
+## Preserved public policy
+
+The typed helper continues to own these stable outcomes:
+
+- unavailable product → `CART_PRODUCT_UNAVAILABLE`, non-retryable;
+- insufficient inventory → `CART_INVENTORY_INSUFFICIENT`, non-retryable;
+- invalid resolve input → `CART_LINE_ITEM_INVALID`, non-retryable;
+- other resolve failures → `CART_LINE_ITEM_RESOLUTION_FAILED`, retryable;
+- other quantity-validation failures → `CART_INVENTORY_UNAVAILABLE`, retryable.
+
+The typed helper also continues to preserve Pricing and Inventory delegations, bounded diagnostic
+projection, error/warn severity split, and redacted owner-source diagnostics.
+
+## Unchanged compatibility boundaries
+
+This slice does not change the remaining private wrappers for:
+
+- storefront cart shipping enrichment;
+- selected shipping-option validation;
+- storefront cart repricing.
+
+It also does not change customer diagnostics, cart/pricing port diagnostics, the generic legacy
+GraphQL diagnostic token, typed line-item implementation details, or layered export names.
+
+## Static guards
+
+`verify-commerce-graphql-line-item-compatibility-cutover.mjs` checks:
+
+- both compatibility signatures and return types;
+- exact typed delegation argument order;
+- one typed call per wrapper;
+- absence of legacy calls, `map_err`, Debug formatting, substring matching, and local envelope
+  remapping in the two wrappers;
+- preservation of the three unrelated legacy helper calls;
+- preservation of typed public policy, typed diagnostic redaction, and layered exports.
+
+`verify-commerce-graphql-cart-helper-error-safety.mjs` continues to guard customer, cart-port,
+legacy-diagnostic, typed mapper, and layered-routing contracts. Its compatibility count now requires
+three remaining legacy calls and two typed line-item compatibility calls.
+
+## Remaining work
+
+Still open:
+
+- storefront shared and cart-shipping mappers;
+- tax and promotion diagnostics;
+- native transports and remaining owner adapters;
+- compilation, mounted execution, workflow, and CI evidence.
+
+The broad ecommerce correlation-safe mapper cleanup remains open.
+
+## Evidence
+
+- `crates/rustok-commerce/contracts/evidence/graphql-line-item-compatibility-cutover-source-review.json`
+- `scripts/verify/verify-commerce-graphql-line-item-compatibility-cutover.mjs`
+- `scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs`
+
+## Validation disclosure
+
+No tests, Node verifiers, formatting, Cargo commands, mounted GraphQL scenarios, workflows, or CI
+were run. No compile or runtime status is claimed.

--- a/crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs
@@ -459,8 +459,7 @@ pub(crate) async fn resolve_storefront_line_item_input(
     public_channel_slug: Option<&str>,
     input: AddStorefrontCartLineItemInput,
 ) -> Result<ResolvedStorefrontLineItemInput> {
-    let variant_id = input.variant_id;
-    super::legacy_helpers::resolve_storefront_line_item_input(
+    super::typed_line_item_helpers::resolve_storefront_line_item_input(
         db,
         tenant_id,
         pricing_read_port,
@@ -472,44 +471,6 @@ pub(crate) async fn resolve_storefront_line_item_input(
         input,
     )
     .await
-    .map_err(|error| {
-        let detail = format!("{error:?}");
-        let (message, code, retryable) =
-            if detail.contains("Variant not found") || detail.contains("Product not found") {
-                (
-                    "Product is not available",
-                    "CART_PRODUCT_UNAVAILABLE",
-                    false,
-                )
-            } else if detail.contains("does not have enough available inventory") {
-                (
-                    "Requested quantity is not available",
-                    "CART_INVENTORY_INSUFFICIENT",
-                    false,
-                )
-            } else if detail.contains("Invalid JSON metadata payload") {
-                (
-                    "Cart line item input is invalid",
-                    "CART_LINE_ITEM_INVALID",
-                    false,
-                )
-            } else {
-                (
-                    "Cart line item could not be resolved",
-                    "CART_LINE_ITEM_RESOLUTION_FAILED",
-                    true,
-                )
-            };
-        legacy_graphql_error(
-            error,
-            tenant_id,
-            Some(variant_id),
-            "resolve_storefront_line_item_input",
-            message,
-            code,
-            retryable,
-        )
-    })
 }
 
 pub(crate) async fn reprice_storefront_cart_line_items(
@@ -550,7 +511,7 @@ pub(crate) async fn validate_storefront_line_item_quantity(
     requested_quantity: i32,
     public_channel_slug: Option<&str>,
 ) -> Result<()> {
-    super::legacy_helpers::validate_storefront_line_item_quantity(
+    super::typed_line_item_helpers::validate_storefront_line_item_quantity(
         db,
         tenant_id,
         variant_id,
@@ -558,35 +519,4 @@ pub(crate) async fn validate_storefront_line_item_quantity(
         public_channel_slug,
     )
     .await
-    .map_err(|error| {
-        let detail = format!("{error:?}");
-        let (message, code, retryable) = if detail.contains("Variant not found") {
-            (
-                "Product is not available",
-                "CART_PRODUCT_UNAVAILABLE",
-                false,
-            )
-        } else if detail.contains("does not have enough available inventory") {
-            (
-                "Requested quantity is not available",
-                "CART_INVENTORY_INSUFFICIENT",
-                false,
-            )
-        } else {
-            (
-                "Inventory availability could not be verified",
-                "CART_INVENTORY_UNAVAILABLE",
-                true,
-            )
-        };
-        legacy_graphql_error(
-            error,
-            tenant_id,
-            Some(variant_id),
-            "validate_storefront_line_item_quantity",
-            message,
-            code,
-            retryable,
-        )
-    })
 }

--- a/scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-cart-helper-error-safety.mjs
@@ -95,6 +95,14 @@ for (const value of [
   'async_graphql::Error::new(error.to_string())',
   'async_graphql::Error::new(format!("{error}"))',
   'pub use super::legacy_helpers::*;',
+  'format!("{error:?}")',
+  'detail.contains(',
+  'super::legacy_helpers::resolve_storefront_line_item_input(',
+  'super::legacy_helpers::validate_storefront_line_item_quantity(',
+  'Variant not found',
+  'Product not found',
+  'does not have enough available inventory',
+  'Invalid JSON metadata payload',
 ]) {
   forbidText(facadeSource, value, 'storefront cart compatibility safe helper facade');
 }
@@ -168,6 +176,14 @@ for (const [value, label] of [
   ['"Selected shipping option is invalid"', 'shipping selection message'],
   ['"Cart pricing could not be refreshed"', 'reprice fallback message'],
   ['extensions.set("retryable", retryable)', 'retryability extension'],
+  [
+    'super::typed_line_item_helpers::resolve_storefront_line_item_input(',
+    'compatibility resolve cutover',
+  ],
+  [
+    'super::typed_line_item_helpers::validate_storefront_line_item_quantity(',
+    'compatibility quantity cutover',
+  ],
 ]) {
   requireText(facadeSource, value, label);
 }
@@ -547,8 +563,15 @@ for (const operation of [
 }
 
 const legacyCalls = facadeSource.match(/super::legacy_helpers::[a-z_]+\(/g) ?? [];
-if (legacyCalls.length !== 5) {
-  failures.push(`expected 5 compatibility legacy helper calls, found ${legacyCalls.length}`);
+if (legacyCalls.length !== 3) {
+  failures.push(`expected 3 remaining compatibility legacy helper calls, found ${legacyCalls.length}`);
+}
+const typedCompatibilityCalls =
+  facadeSource.match(
+    /super::typed_line_item_helpers::(?:resolve_storefront_line_item_input|validate_storefront_line_item_quantity)\(/g,
+  ) ?? [];
+if (typedCompatibilityCalls.length !== 2) {
+  failures.push(`expected 2 typed compatibility helper calls, found ${typedCompatibilityCalls.length}`);
 }
 const typedExports = layeredSource.match(
   /resolve_storefront_line_item_input|validate_storefront_line_item_quantity/g,
@@ -564,5 +587,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce GraphQL storefront cart helpers keep stable envelopes, bounded customer, legacy, and typed line-item diagnostics, typed outcomes, and private layered routing',
+  '✔ Commerce GraphQL storefront cart helpers keep stable envelopes, bounded diagnostics, typed line-item compatibility delegation, typed outcomes, and private layered routing',
 );

--- a/scripts/verify/verify-commerce-graphql-line-item-compatibility-cutover.mjs
+++ b/scripts/verify/verify-commerce-graphql-line-item-compatibility-cutover.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const facade = read('crates/rustok-commerce/src/graphql/mutations/safe_helpers.rs');
+const typed = read(
+  'crates/rustok-commerce/src/graphql/mutations/typed_line_item_helpers.rs',
+);
+const layered = read(
+  'crates/rustok-commerce/src/graphql/mutations/layered_order_helpers.rs',
+);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const resolveWrapper = between(
+  facade,
+  'pub(crate) async fn resolve_storefront_line_item_input(',
+  'pub(crate) async fn reprice_storefront_cart_line_items(',
+  'compatibility resolve wrapper',
+);
+const quantityStart = facade.indexOf(
+  'pub(crate) async fn validate_storefront_line_item_quantity(',
+);
+const quantityWrapper = quantityStart >= 0 ? facade.slice(quantityStart) : '';
+if (quantityStart < 0) failures.push('compatibility quantity wrapper: unable to isolate source block');
+
+for (const [value, label] of [
+  ['db: &sea_orm::DatabaseConnection', 'resolve database argument'],
+  ['tenant_id: Uuid', 'resolve tenant argument'],
+  ['pricing_read_port: &dyn PricingReadPort', 'resolve pricing port argument'],
+  ['pricing_port_context: PortContext', 'resolve port context argument'],
+  ['pricing_context: &PriceResolutionContext', 'resolve pricing context argument'],
+  ['locale: &str', 'resolve locale argument'],
+  ['default_locale: &str', 'resolve default-locale argument'],
+  ['public_channel_slug: Option<&str>', 'resolve channel argument'],
+  ['input: AddStorefrontCartLineItemInput', 'resolve input argument'],
+  ['-> Result<ResolvedStorefrontLineItemInput>', 'resolve return type'],
+  [
+    'super::typed_line_item_helpers::resolve_storefront_line_item_input(',
+    'resolve typed delegation',
+  ],
+  [
+    `super::typed_line_item_helpers::resolve_storefront_line_item_input(
+        db,
+        tenant_id,
+        pricing_read_port,
+        pricing_port_context,
+        pricing_context,
+        locale,
+        default_locale,
+        public_channel_slug,
+        input,
+    )
+    .await`,
+    'resolve exact delegation arguments',
+  ],
+]) {
+  requireText(resolveWrapper, value, label);
+}
+
+for (const [value, label] of [
+  ['db: &sea_orm::DatabaseConnection', 'quantity database argument'],
+  ['tenant_id: Uuid', 'quantity tenant argument'],
+  ['variant_id: Uuid', 'quantity variant argument'],
+  ['requested_quantity: i32', 'quantity amount argument'],
+  ['public_channel_slug: Option<&str>', 'quantity channel argument'],
+  ['-> Result<()>', 'quantity return type'],
+  [
+    'super::typed_line_item_helpers::validate_storefront_line_item_quantity(',
+    'quantity typed delegation',
+  ],
+  [
+    `super::typed_line_item_helpers::validate_storefront_line_item_quantity(
+        db,
+        tenant_id,
+        variant_id,
+        requested_quantity,
+        public_channel_slug,
+    )
+    .await`,
+    'quantity exact delegation arguments',
+  ],
+]) {
+  requireText(quantityWrapper, value, label);
+}
+
+for (const value of [
+  'super::legacy_helpers::resolve_storefront_line_item_input(',
+  'super::legacy_helpers::validate_storefront_line_item_quantity(',
+  '.map_err(',
+  'legacy_graphql_error(',
+  'format!("{error:?}")',
+  'detail.contains(',
+  'Variant not found',
+  'Product not found',
+  'does not have enough available inventory',
+  'Invalid JSON metadata payload',
+]) {
+  forbidText(`${resolveWrapper}\n${quantityWrapper}`, value, 'compatibility string classifier');
+}
+
+for (const [pattern, expected, label] of [
+  [
+    /super::typed_line_item_helpers::resolve_storefront_line_item_input\(/g,
+    1,
+    'resolve typed call count',
+  ],
+  [
+    /super::typed_line_item_helpers::validate_storefront_line_item_quantity\(/g,
+    1,
+    'quantity typed call count',
+  ],
+  [/\.map_err\(/g, 0, 'compatibility remap count'],
+]) {
+  const count = `${resolveWrapper}\n${quantityWrapper}`.match(pattern)?.length ?? 0;
+  if (count !== expected) failures.push(`${label}: expected ${expected}, found ${count}`);
+}
+
+for (const [value, label] of [
+  ['super::legacy_helpers::enrich_storefront_cart(', 'remaining enrichment compatibility call'],
+  [
+    'super::legacy_helpers::validate_selected_shipping_option(',
+    'remaining shipping-option compatibility call',
+  ],
+  [
+    'super::legacy_helpers::reprice_storefront_cart_line_items(',
+    'remaining repricing compatibility call',
+  ],
+  ['pub(crate) use super::legacy_helpers::*;', 'remaining legacy symbol compatibility'],
+]) {
+  requireText(facade, value, label);
+}
+const remainingLegacyCalls = facade.match(/super::legacy_helpers::[a-z_]+\(/g) ?? [];
+if (remainingLegacyCalls.length !== 3) {
+  failures.push(`remaining legacy helper count: expected 3, found ${remainingLegacyCalls.length}`);
+}
+
+for (const [value, label] of [
+  ['fn storefront_line_item_public_policy(', 'typed public policy'],
+  ['"CART_PRODUCT_UNAVAILABLE"', 'typed unavailable code'],
+  ['"CART_INVENTORY_INSUFFICIENT"', 'typed inventory code'],
+  ['"CART_LINE_ITEM_INVALID"', 'typed invalid-input code'],
+  ['"CART_LINE_ITEM_RESOLUTION_FAILED"', 'typed resolution fallback code'],
+  ['"CART_INVENTORY_UNAVAILABLE"', 'typed quantity fallback code'],
+  ['tracing::error!(', 'typed dependency severity'],
+  ['tracing::warn!(', 'typed rejection severity'],
+  ['struct StorefrontLineItemDiagnosticSource;', 'typed redacted source token'],
+  ['formatter.write_str("redacted")', 'typed redacted source output'],
+]) {
+  requireText(typed, value, label);
+}
+
+for (const [value, label] of [
+  [
+    'pub(crate) use super::typed_line_item_helpers::{',
+    'layered typed export owner',
+  ],
+  [
+    'resolve_storefront_line_item_input, validate_storefront_line_item_quantity,',
+    'layered typed exports',
+  ],
+]) {
+  requireText(layered, value, label);
+}
+const layeredTypedExports = layered.match(
+  /resolve_storefront_line_item_input|validate_storefront_line_item_quantity/g,
+) ?? [];
+if (layeredTypedExports.length !== 2) {
+  failures.push(`layered typed export count: expected 2, found ${layeredTypedExports.length}`);
+}
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL line-item compatibility cutover verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce GraphQL line-item compatibility wrappers delegate directly to typed helpers without Debug-string classification or envelope remapping',
+);


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce correlation-safe mapper cleanup at the private Commerce GraphQL storefront line-item compatibility boundary.

- preserve both compatibility wrapper signatures, return types, and exact argument order;
- replace the legacy resolve wrapper call with direct `typed_line_item_helpers::resolve_storefront_line_item_input` delegation;
- replace the legacy quantity wrapper call with direct `typed_line_item_helpers::validate_storefront_line_item_quantity` delegation;
- remove `Debug` formatting and English substring classification from both wrappers;
- remove compatibility-local `CART_*` envelope reconstruction and generic legacy diagnostic remapping;
- preserve the typed line-item public policy, diagnostic redaction, severity split, Pricing/Inventory delegations, and `pricing_context` fields;
- preserve explicit layered typed exports;
- preserve the unrelated shipping enrichment, shipping-option, and repricing compatibility wrappers;
- preserve customer, cart/pricing port, and generic legacy diagnostic contracts;
- update the broad cart-helper guard only for the compatibility cutover counts and prohibitions;
- add a focused verifier, source-only evidence, and documentation;
- leave storefront shared/cart-shipping, tax, promotion, native transport, and remaining adapter cleanup open.

## Recheck

Current base is `main@e42c7bffbfd99833ef3921213e72c69b860234de`. The two pre-existing Commerce target blobs were unchanged across intervening Forum/Pages commits, so the five reviewed file blobs were transplanted without adaptation. No open PR overlaps this boundary.

The branch is one commit ahead and changes five intended files. Production source is `+3/-73` and contains only the two compatibility wrapper cutovers.

## Preserved behavior

The typed helper remains the single policy owner for:

- unavailable product → `CART_PRODUCT_UNAVAILABLE`, non-retryable;
- insufficient inventory → `CART_INVENTORY_INSUFFICIENT`, non-retryable;
- invalid resolve input → `CART_LINE_ITEM_INVALID`, non-retryable;
- other resolve failures → `CART_LINE_ITEM_RESOLUTION_FAILED`, retryable;
- other quantity-validation failures → `CART_INVENTORY_UNAVAILABLE`, retryable;
- error-level dependency diagnostics and warning-level ordinary rejections;
- bounded/redacted source diagnostics;
- Pricing and Inventory owner delegations;
- layered typed routing.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Node verifiers;
- Cargo checks, builds, clippy, or formatting;
- mounted GraphQL execution;
- workflows or CI.

Execution evidence remains pending and the broad ecommerce cleanup remains open.