### PR TITLE
fix(commerce): stabilize storefront shipping public envelope

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/storefront-shipping-public-envelope-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/storefront-shipping-public-envelope-safety-source-review.json
@@ -1,0 +1,46 @@
+{
+  "status": "commerce_storefront_shipping_public_envelope_source_reviewed_unvalidated",
+  "scope": [
+    "crates/rustok-commerce/src/storefront_shipping.rs",
+    "scripts/verify/verify-commerce-storefront-shipping-public-envelope-safety.mjs",
+    "scripts/verify/verify-commerce-storefront-shipping-enrichment-context.mjs",
+    "scripts/verify/verify-commerce-storefront-cart-shipping-http-error-safety.mjs",
+    "scripts/verify/verify-commerce-storefront-shipping-enrichment-diagnostic-safety.mjs",
+    "crates/rustok-commerce/docs/implementation-plan.md"
+  ],
+  "source_review": {
+    "compatibility_signature_preserved": true,
+    "compatibility_result_preserved": true,
+    "typed_delegation_preserved": true,
+    "typed_argument_order_preserved": true,
+    "diagnostic_runs_before_mapping": true,
+    "owner_text_returned_to_caller": false,
+    "stable_message_returned": true,
+    "validation_variant_preserved": true,
+    "diagnostic_redaction_preserved": true,
+    "diagnostic_shapes_preserved": true,
+    "owner_classification_preserved": true,
+    "severity_split_preserved": true,
+    "filtering_and_projection_preserved": true,
+    "callers_changed": false,
+    "http_shipping_mapper_complete": false,
+    "shared_http_mappers_complete": false,
+    "tax_cleanup_complete": false,
+    "promotion_cleanup_complete": false,
+    "native_cleanup_complete": false,
+    "remaining_adapter_cleanup_complete": false,
+    "broad_cleanup_complete": false,
+    "runtime_claimed": false
+  },
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "workflows_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "disclosure": "No tests, Node verifiers, Cargo commands, formatting, mounted scenarios, workflows, or CI were executed."
+}

--- a/crates/rustok-commerce/docs/storefront-shipping-public-envelope-safety.md
+++ b/crates/rustok-commerce/docs/storefront-shipping-public-envelope-safety.md
@@ -1,0 +1,96 @@
+# Storefront shipping public envelope safety
+
+Status: **source-ready / unvalidated**
+
+## Scope
+
+This slice closes only the non-`PortError` public conversion in the compatibility function
+`enrich_cart_delivery_groups` from
+`crates/rustok-commerce/src/storefront_shipping.rs`.
+
+The function already delegated to `enrich_cart_delivery_groups_typed`, logged the typed
+`FulfillmentError` through the bounded diagnostic introduced by the preceding shipping-enrichment
+work, and returned `CommerceResult<CartResponse>`. After logging, it still copied the complete owner
+error text into `CommerceError::Validation`.
+
+The compatibility result now contains one static message:
+
+`Cart shipping details are temporarily unavailable`
+
+## Preserved boundary
+
+This change does not alter the compatibility function signature or argument order:
+
+- database connection;
+- tenant ID;
+- cart payload;
+- public channel slug;
+- requested locale;
+- tenant default locale;
+- `CommerceResult<CartResponse>` return type.
+
+The function still calls `enrich_cart_delivery_groups_typed` once with those arguments in the same
+order. On failure it still calls `log_cart_delivery_group_enrichment_error` before constructing the
+compatibility result.
+
+The returned variant remains `CommerceError::Validation` so existing compatibility callers keep the
+same error type. Only the dynamic owner message has been removed from the returned payload.
+
+## Preserved typed behavior
+
+The typed enrichment path remains unchanged:
+
+- `FulfillmentService::list_shipping_options` is called with tenant and locale context;
+- owner errors propagate through `FulfillmentResult<CartResponse>`;
+- currency filtering is unchanged;
+- public-channel visibility filtering is unchanged;
+- shipping-profile compatibility filtering is unchanged;
+- option summaries and selected-option reconciliation are unchanged.
+
+The bounded diagnostic also remains unchanged. It preserves typed owner classification, owner code,
+owner kind, retryability, error/warn severity, and the `list_shipping_options` operation while using a
+redacted source token and shape-only request context.
+
+## Callers
+
+This slice does not edit GraphQL queries, GraphQL mutation helpers, storefront HTTP handlers, or
+routing. Existing compatibility callers receive the same `CommerceError::Validation` variant, now
+with the static message rather than validation, identity, transition, or database details from the
+fulfillment owner.
+
+## Static guards
+
+The following guards were advanced without being executed:
+
+- `verify-commerce-storefront-shipping-public-envelope-safety.mjs` checks the exact compatibility
+  signature, argument order, typed call, diagnostic-before-mapping order, static envelope, and absence
+  of owner-error stringification;
+- `verify-commerce-storefront-shipping-enrichment-context.mjs` now requires bounded diagnostics and
+  the stable compatibility envelope;
+- `verify-commerce-storefront-cart-shipping-http-error-safety.mjs` preserves all HTTP mapper and typed
+  enrichment checks while requiring the stable compatibility mapping;
+- `verify-commerce-storefront-shipping-enrichment-diagnostic-safety.mjs` retains all redaction,
+  classification, and severity checks and advances its compatibility assertion to the static message.
+
+## Remaining work
+
+This slice does not close:
+
+- raw diagnostics in `map_storefront_cart_shipping_error`;
+- shared storefront context, customer, and channel mapper cleanup;
+- direct GraphQL compatibility routing cleanup;
+- tax and promotion mapper cleanup;
+- native transport cleanup;
+- remaining ecommerce adapters.
+
+The broad canonical correlation-safe mapper cleanup remains unchecked.
+
+## Evidence
+
+- `crates/rustok-commerce/contracts/evidence/storefront-shipping-public-envelope-safety-source-review.json`
+- `scripts/verify/verify-commerce-storefront-shipping-public-envelope-safety.mjs`
+
+## Validation disclosure
+
+No tests, Node verifiers, formatting, Cargo commands, mounted HTTP or GraphQL scenarios, workflows, or
+CI were run. No compile or runtime status is claimed.

--- a/crates/rustok-commerce/src/storefront_shipping.rs
+++ b/crates/rustok-commerce/src/storefront_shipping.rs
@@ -225,7 +225,9 @@ pub async fn enrich_cart_delivery_groups(
             requested_locale,
             tenant_default_locale,
         );
-        crate::CommerceError::Validation(error.to_string())
+        crate::CommerceError::Validation(
+            "Cart shipping details are temporarily unavailable".to_string(),
+        )
     })
 }
 

--- a/scripts/verify/verify-commerce-storefront-cart-shipping-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-cart-shipping-http-error-safety.mjs
@@ -174,9 +174,15 @@ for (const value of [
 for (const [value, label] of [
   ['-> CommerceResult<CartResponse>', 'legacy commerce return contract'],
   ['enrich_cart_delivery_groups_typed(', 'typed implementation delegation'],
-  ['.map_err(|error| crate::CommerceError::Validation(error.to_string()))', 'legacy GraphQL compatibility mapping'],
+  [
+    'crate::CommerceError::Validation(\n            "Cart shipping details are temporarily unavailable".to_string(),\n        )',
+    'stable GraphQL compatibility mapping',
+  ],
 ]) {
   requireText(compatibilityWrapper, value, label);
+}
+for (const value of ['error.to_string()', 'err.to_string()', 'format!("{error:?}")']) {
+  forbidText(compatibilityWrapper, value, 'unsafe legacy GraphQL compatibility mapping');
 }
 
 for (const [content, value, label] of [

--- a/scripts/verify/verify-commerce-storefront-shipping-enrichment-context.mjs
+++ b/scripts/verify/verify-commerce-storefront-shipping-enrichment-context.mjs
@@ -25,12 +25,37 @@ const requireText = (source, value, label) => {
 const forbidText = (source, value, label) => {
   if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
 };
+const between = (source, start, end, label) => {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return source.slice(startIndex, endIndex);
+};
+
+const compatibilityWrapper = between(
+  shipping,
+  'pub async fn enrich_cart_delivery_groups(',
+  'fn log_cart_delivery_group_enrichment_error(',
+  'shipping compatibility wrapper',
+);
+const diagnostic = between(
+  shipping,
+  'fn log_cart_delivery_group_enrichment_error(',
+  'fn extract_allowed_shipping_profile_slugs_from_metadata(',
+  'shipping enrichment diagnostic',
+);
 
 for (const [value, label] of [
   ['FulfillmentError, FulfillmentResult, FulfillmentService', 'typed fulfillment import'],
   ['const STOREFRONT_SHIPPING_ENRICHMENT_BOUNDARY: &str =', 'shared enrichment boundary'],
   ['"commerce_storefront_shipping_enrichment"', 'stable enrichment boundary value'],
-  ['let cart_id = cart.id;', 'cart identity retained before move'],
+  ['struct StorefrontShippingDiagnosticError;', 'redacted diagnostic token'],
+  ['formatter.write_str("redacted")', 'redacted diagnostic output'],
+  ['fn uuid_shape(value: Uuid)', 'UUID shape helper'],
+  ['fn optional_text_shape(value: Option<&str>)', 'optional text shape helper'],
   ['enrich_cart_delivery_groups_typed(', 'typed enrichment delegation'],
   ['log_cart_delivery_group_enrichment_error(', 'typed cause logger'],
   ['FulfillmentError::Validation(_)', 'validation classification'],
@@ -39,29 +64,61 @@ for (const [value, label] of [
   ['FulfillmentError::InvalidTransition { .. }', 'transition classification'],
   ['FulfillmentError::Database(_)', 'database classification'],
   ['owner = "rustok_fulfillment"', 'truthful owner identity'],
-  ['tenant_id = %tenant_id', 'tenant context'],
-  ['cart_id = %cart_id', 'cart context'],
-  ['public_channel_slug = ?public_channel_slug', 'channel context'],
-  ['requested_locale = ?requested_locale', 'requested locale context'],
-  ['tenant_default_locale = ?tenant_default_locale', 'default locale context'],
+  ['tenant_id_shape,', 'bounded tenant context'],
+  ['cart_id_shape,', 'bounded cart context'],
+  ['public_channel_slug_shape,', 'bounded channel context'],
+  ['requested_locale_shape,', 'bounded requested locale context'],
+  ['tenant_default_locale_shape,', 'bounded default locale context'],
   ['operation = "list_shipping_options"', 'exact owner operation'],
   ['owner_code,', 'stable owner code'],
   ['owner_kind,', 'owner error kind'],
   ['owner_retryable,', 'owner retryability'],
+  ['tracing::error!(', 'technical severity'],
+  ['tracing::warn!(', 'ordinary rejection severity'],
   ['boundary = STOREFRONT_SHIPPING_ENRICHMENT_BOUNDARY', 'boundary logging'],
-  ['crate::CommerceError::Validation(error.to_string())', 'compatibility error preservation'],
 ]) {
   requireText(shipping, value, label);
 }
 
+for (const [value, label] of [
+  ['-> CommerceResult<CartResponse>', 'compatibility return contract'],
+  ['enrich_cart_delivery_groups_typed(', 'compatibility typed delegation'],
+  ['log_cart_delivery_group_enrichment_error(', 'compatibility diagnostic call'],
+  [
+    'crate::CommerceError::Validation(\n            "Cart shipping details are temporarily unavailable".to_string(),\n        )',
+    'stable compatibility public envelope',
+  ],
+]) {
+  requireText(compatibilityWrapper, value, label);
+}
+
+for (const value of [
+  'error.to_string()',
+  'err.to_string()',
+  'format!("{error:?}")',
+]) {
+  forbidText(compatibilityWrapper, value, 'unsafe compatibility public conversion');
+}
+for (const value of [
+  'tenant_id = %tenant_id',
+  'cart_id = %cart_id',
+  'public_channel_slug = ?public_channel_slug',
+  'requested_locale = ?requested_locale',
+  'tenant_default_locale = ?tenant_default_locale',
+]) {
+  forbidText(diagnostic, value, 'raw shipping enrichment diagnostic context');
+}
+
 const typedCalls = shipping.match(/enrich_cart_delivery_groups_typed\(/g) ?? [];
 if (typedCalls.length !== 2) {
-  failures.push(`expected typed enrichment definition plus one compatibility call, found ${typedCalls.length}`);
+  failures.push(
+    `expected typed enrichment definition plus one compatibility call, found ${typedCalls.length}`,
+  );
 }
 const compatibilityMappers =
-  shipping.match(/crate::CommerceError::Validation\(error\.to_string\(\)\)/g) ?? [];
+  compatibilityWrapper.match(/crate::CommerceError::Validation\(/g) ?? [];
 if (compatibilityMappers.length !== 1) {
-  failures.push(`expected one unchanged compatibility mapper, found ${compatibilityMappers.length}`);
+  failures.push(`expected one stable compatibility mapper, found ${compatibilityMappers.length}`);
 }
 
 for (const [source, value, label] of [
@@ -76,13 +133,6 @@ for (const [source, value, label] of [
   requireText(source, value, label);
 }
 
-for (const value of [
-  'async_graphql::Error::new(error.to_string())',
-  'async_graphql::Error::new(format!("{error}"))',
-]) {
-  forbidText(shipping, value, 'shared shipping enrichment public conversion');
-}
-
 if (failures.length > 0) {
   console.error('Commerce storefront shipping enrichment context verification failed:');
   for (const failure of failures) console.error(`✗ ${failure}`);
@@ -90,5 +140,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Shared storefront cart shipping enrichment retains typed fulfillment owner diagnostics before the existing compatibility and GraphQL envelopes',
+  '✔ Shared storefront cart shipping enrichment retains typed owner diagnostics and a stable compatibility envelope',
 );

--- a/scripts/verify/verify-commerce-storefront-shipping-enrichment-diagnostic-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-shipping-enrichment-diagnostic-safety.mjs
@@ -201,11 +201,14 @@ for (const [value, label] of [
   ['enrich_cart_delivery_groups_typed(', 'typed implementation delegation'],
   ['log_cart_delivery_group_enrichment_error(', 'diagnostic call'],
   [
-    'crate::CommerceError::Validation(error.to_string())',
-    'legacy public conversion retained for separate cleanup',
+    'crate::CommerceError::Validation(\n            "Cart shipping details are temporarily unavailable".to_string(),\n        )',
+    'stable compatibility public envelope',
   ],
 ]) {
   requireText(compatibilityWrapper, value, label);
+}
+for (const value of ['error.to_string()', 'err.to_string()', 'format!("{error:?}")']) {
+  forbidText(compatibilityWrapper, value, 'unsafe compatibility public conversion');
 }
 
 for (const [value, label] of [
@@ -226,5 +229,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce storefront shipping enrichment diagnostics keep typed owner facts while redacting source payloads and raw request identities',
+  '✔ Commerce storefront shipping enrichment diagnostics keep typed owner facts, redact raw request context, and return a stable compatibility envelope',
 );

--- a/scripts/verify/verify-commerce-storefront-shipping-public-envelope-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-shipping-public-envelope-safety.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const shipping = read('crates/rustok-commerce/src/storefront_shipping.rs');
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const typedEnrichment = between(
+  shipping,
+  'pub async fn enrich_cart_delivery_groups_typed(',
+  'pub async fn enrich_cart_delivery_groups(',
+  'typed shipping enrichment',
+);
+const compatibilityWrapper = between(
+  shipping,
+  'pub async fn enrich_cart_delivery_groups(',
+  'fn log_cart_delivery_group_enrichment_error(',
+  'shipping compatibility wrapper',
+);
+const diagnostic = between(
+  shipping,
+  'fn log_cart_delivery_group_enrichment_error(',
+  'fn extract_allowed_shipping_profile_slugs_from_metadata(',
+  'shipping enrichment diagnostic',
+);
+
+for (const [value, label] of [
+  ['db: &DatabaseConnection', 'database argument'],
+  ['tenant_id: Uuid', 'tenant argument'],
+  ['cart: CartResponse', 'cart argument'],
+  ['public_channel_slug: Option<&str>', 'channel argument'],
+  ['requested_locale: Option<&str>', 'requested locale argument'],
+  ['tenant_default_locale: Option<&str>', 'default locale argument'],
+  ['-> CommerceResult<CartResponse>', 'compatibility return type'],
+  ['let cart_id = cart.id;', 'cart identity capture'],
+  ['enrich_cart_delivery_groups_typed(', 'typed enrichment delegation'],
+  [
+    `enrich_cart_delivery_groups_typed(
+        db,
+        tenant_id,
+        cart,
+        public_channel_slug,
+        requested_locale,
+        tenant_default_locale,
+    )
+    .await`,
+    'exact typed delegation arguments',
+  ],
+  ['.map_err(|error| {', 'compatibility error boundary'],
+  ['log_cart_delivery_group_enrichment_error(', 'bounded diagnostic call'],
+  [
+    `log_cart_delivery_group_enrichment_error(
+            &error,
+            tenant_id,
+            cart_id,
+            public_channel_slug,
+            requested_locale,
+            tenant_default_locale,
+        );`,
+    'exact diagnostic arguments',
+  ],
+  [
+    `crate::CommerceError::Validation(
+            "Cart shipping details are temporarily unavailable".to_string(),
+        )`,
+    'stable public validation envelope',
+  ],
+]) {
+  requireText(compatibilityWrapper, value, label);
+}
+
+for (const value of [
+  'error.to_string()',
+  'err.to_string()',
+  'format!("{error:?}")',
+  'format!("{error}")',
+  'CommerceError::Database',
+]) {
+  forbidText(compatibilityWrapper, value, 'unsafe compatibility public conversion');
+}
+
+const typedCallCount =
+  compatibilityWrapper.match(/enrich_cart_delivery_groups_typed\(/g)?.length ?? 0;
+if (typedCallCount !== 1) {
+  failures.push(`typed compatibility call count: expected 1, found ${typedCallCount}`);
+}
+const diagnosticCallCount =
+  compatibilityWrapper.match(/log_cart_delivery_group_enrichment_error\(/g)?.length ?? 0;
+if (diagnosticCallCount !== 1) {
+  failures.push(`compatibility diagnostic call count: expected 1, found ${diagnosticCallCount}`);
+}
+const validationEnvelopeCount =
+  compatibilityWrapper.match(/crate::CommerceError::Validation\(/g)?.length ?? 0;
+if (validationEnvelopeCount !== 1) {
+  failures.push(`stable validation envelope count: expected 1, found ${validationEnvelopeCount}`);
+}
+
+const diagnosticIndex = compatibilityWrapper.indexOf(
+  'log_cart_delivery_group_enrichment_error(',
+);
+const publicIndex = compatibilityWrapper.indexOf('crate::CommerceError::Validation(');
+if (!(diagnosticIndex >= 0 && diagnosticIndex < publicIndex)) {
+  failures.push('bounded diagnostic must run before the stable public mapping');
+}
+
+for (const [value, label] of [
+  ['-> FulfillmentResult<CartResponse>', 'typed owner result'],
+  ['FulfillmentService::new(db.clone())', 'fulfillment service construction'],
+  [
+    '.list_shipping_options(tenant_id, requested_locale, tenant_default_locale)',
+    'typed owner call and arguments',
+  ],
+  ['.await?;', 'typed owner error propagation'],
+  ['enrich_cart_delivery_groups_from_options(', 'pure option projection'],
+]) {
+  requireText(typedEnrichment, value, label);
+}
+for (const value of [
+  'CommerceError::Validation',
+  'error.to_string()',
+  'err.to_string()',
+]) {
+  forbidText(typedEnrichment, value, 'typed enrichment error erasure');
+}
+
+for (const [value, label] of [
+  ['struct StorefrontShippingDiagnosticError;', 'redacted diagnostic token'],
+  ['formatter.write_str("redacted")', 'redacted diagnostic output'],
+  ['FulfillmentError::Validation(_)', 'validation classification'],
+  ['FulfillmentError::ShippingOptionNotFound(_)', 'shipping-option classification'],
+  ['FulfillmentError::FulfillmentNotFound(_)', 'fulfillment classification'],
+  ['FulfillmentError::InvalidTransition { .. }', 'transition classification'],
+  ['FulfillmentError::Database(_)', 'database classification'],
+  ['tenant_id_shape,', 'bounded tenant field'],
+  ['cart_id_shape,', 'bounded cart field'],
+  ['public_channel_slug_shape,', 'bounded channel field'],
+  ['requested_locale_shape,', 'bounded locale field'],
+  ['tenant_default_locale_shape,', 'bounded default-locale field'],
+  ['tracing::error!(', 'technical severity'],
+  ['tracing::warn!(', 'ordinary rejection severity'],
+  ['operation = "list_shipping_options"', 'owner operation'],
+  ['boundary = STOREFRONT_SHIPPING_ENRICHMENT_BOUNDARY', 'diagnostic boundary'],
+]) {
+  requireText(`${shipping}\n${diagnostic}`, value, label);
+}
+for (const value of [
+  'tenant_id = %tenant_id',
+  'cart_id = %cart_id',
+  'public_channel_slug = ?public_channel_slug',
+  'requested_locale = ?requested_locale',
+  'tenant_default_locale = ?tenant_default_locale',
+]) {
+  forbidText(diagnostic, value, 'raw diagnostic context');
+}
+
+const compatibilityDefinitions =
+  shipping.match(/pub async fn enrich_cart_delivery_groups\(/g)?.length ?? 0;
+if (compatibilityDefinitions !== 1) {
+  failures.push(
+    `compatibility definition count: expected 1, found ${compatibilityDefinitions}`,
+  );
+}
+const typedDefinitions =
+  shipping.match(/pub async fn enrich_cart_delivery_groups_typed\(/g)?.length ?? 0;
+if (typedDefinitions !== 1) {
+  failures.push(`typed definition count: expected 1, found ${typedDefinitions}`);
+}
+
+if (failures.length > 0) {
+  console.error('Commerce storefront shipping public envelope verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce storefront shipping compatibility mapping logs bounded owner facts before returning one stable public envelope',
+);


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce correlation-safe mapper cleanup at the Commerce storefront shipping compatibility envelope.

- preserve the `enrich_cart_delivery_groups` signature, `CommerceResult<CartResponse>` contract, and exact argument order;
- preserve direct delegation to `enrich_cart_delivery_groups_typed`;
- preserve bounded owner diagnostics before compatibility mapping;
- stop copying complete `FulfillmentError` text into `CommerceError::Validation`;
- return the stable message `Cart shipping details are temporarily unavailable` while preserving the validation variant;
- preserve typed fulfillment propagation, option filtering/projection, selected-option reconciliation, and callers;
- advance the existing enrichment context, HTTP shipping, and diagnostic guards only through the bounded diagnostic and stable-envelope contracts;
- add a focused verifier, source-only evidence, and documentation;
- leave the storefront cart-shipping HTTP mapper, shared storefront mappers, direct GraphQL compatibility routing, tax, promotion, native transports, and remaining adapters open.

## Recheck

Current base is `main@6a5fb20d67ea20e726a4a782b79d591ec6a6ba72`. No later Commerce commit or open Commerce PR overlaps this boundary.

The branch is one commit ahead and changes seven intended files. Production source is `+3/-1` and contains one compatibility-envelope hunk.

## Preserved behavior

- `FulfillmentService::list_shipping_options` and typed owner-error propagation;
- currency, channel, and shipping-profile filtering;
- option summary and selected-option projection;
- typed owner classification, retryability, operation, and error/warn severity split;
- redacted diagnostics and shape-only request context;
- compatibility error variant and all existing callers;
- HTTP cart-shipping mapper behavior.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Node verifiers;
- Cargo checks, builds, clippy, or formatting;
- mounted HTTP or GraphQL execution;
- workflows or CI.

Execution evidence remains pending and the broad ecommerce cleanup remains open.