### PR TITLE
fix(commerce): redact GraphQL checkout service diagnostics

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/graphql-checkout-service-diagnostic-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/graphql-checkout-service-diagnostic-safety-source-review.json
@@ -1,0 +1,39 @@
+{
+  "status": "commerce_graphql_checkout_service_diagnostic_safety_source_reviewed_unvalidated",
+  "reviewed_scope": [
+    "crates/rustok-commerce/src/graphql/mutations/safe_checkout.rs",
+    "crates/rustok-commerce/src/graphql/mutations/checkout.rs",
+    "scripts/verify/verify-commerce-graphql-checkout-service-error-safety.mjs",
+    "crates/rustok-commerce/docs/graphql-checkout-service-diagnostic-safety.md"
+  ],
+  "source_contract": {
+    "complete_commerce_error_logged": false,
+    "complete_fulfillment_error_logged": false,
+    "diagnostic_debug_redacted": true,
+    "owner_name_preserved": true,
+    "classified_error_kind_preserved": true,
+    "public_code_preserved": true,
+    "retryability_preserved": true,
+    "graphql_error_passthrough_preserved": true,
+    "shipping_profile_public_policy_preserved": true,
+    "shipping_option_public_policy_preserved": true,
+    "resolver_source_unchanged": true,
+    "shipping_option_service_call_count": 4,
+    "shipping_profile_service_call_count": 4,
+    "broad_ecommerce_cleanup_closed": false,
+    "runtime_evidence_claimed": false
+  },
+  "execution": [],
+  "validation": {
+    "tests_run": false,
+    "cargo_run": false,
+    "format_run": false,
+    "verifiers_run": false,
+    "mounted_graphql_run": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "compile_proven": false,
+    "runtime_proven": false
+  },
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, mounted GraphQL scenarios, workflows, or CI were executed."
+}

--- a/crates/rustok-commerce/docs/graphql-checkout-service-diagnostic-safety.md
+++ b/crates/rustok-commerce/docs/graphql-checkout-service-diagnostic-safety.md
@@ -1,0 +1,59 @@
+# GraphQL checkout service diagnostic safety
+
+Status: `source_hardened_unvalidated`
+
+## Scope
+
+This source wave continues the canonical ecommerce correlation-safe mapper cleanup at the Commerce GraphQL checkout shipping-service boundary.
+
+The private `safe_checkout.rs` facade still owns the eight unchanged checkout resolver service calls:
+
+- four shipping-option calls delegated to Fulfillment;
+- four shipping-profile calls delegated to Commerce.
+
+The resolver source, mutation signatures, permission checks, request fields, owner calls, result DTOs, and existing GraphQL errors remain unchanged.
+
+## Public policy preserved
+
+Shipping profiles retain:
+
+- `SHIPPING_PROFILE_REQUEST_INVALID`;
+- `SHIPPING_PROFILE_NOT_FOUND`;
+- `SHIPPING_PROFILE_STATE_CONFLICT`;
+- `SHIPPING_PROFILE_TEMPORARILY_UNAVAILABLE`;
+- `SHIPPING_PROFILE_OPERATION_FAILED`.
+
+Shipping options retain:
+
+- `SHIPPING_OPTION_REQUEST_INVALID`;
+- `SHIPPING_OPTION_NOT_FOUND`;
+- `SHIPPING_OPTION_STATE_CONFLICT`;
+- `SHIPPING_OPTION_TEMPORARILY_UNAVAILABLE`;
+- `SHIPPING_OPTION_OPERATION_FAILED`.
+
+Only the existing database envelopes remain retryable. Already-constructed `async_graphql::Error` values continue to pass through unchanged.
+
+## Diagnostic policy
+
+Complete `CommerceError` and `FulfillmentError` values are no longer formatted into tracing events. Both owner mappers consume their source structurally, classify it through the existing exhaustive match, and emit only:
+
+- a zero-sized diagnostic token whose `Debug` representation is `redacted`;
+- the static owner name;
+- the stable classified error kind;
+- the public code and retryability;
+- the static checkout boundary and event message.
+
+Validation text, UUIDs, slugs, transition values, database causes, rich/core details, and inventory state remain outside diagnostics and public envelopes.
+
+## Deliberate limits
+
+This slice does not change checkout orchestration, owner services, public GraphQL schema, resolver source, severity policy, other Commerce adapters, native/REST transports, or FFA/FBA status. The broader ecommerce correlation-safe mapper cleanup remains open.
+
+## Intended maintainer checks
+
+```bash
+node scripts/verify/verify-commerce-graphql-checkout-service-error-safety.mjs
+cargo check -p rustok-commerce --lib
+```
+
+Tests, Node verifiers, Cargo commands, formatting, mounted GraphQL execution, workflows, and CI were not run for this source wave.

--- a/crates/rustok-commerce/src/graphql/mutations/safe_checkout.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_checkout.rs
@@ -4,6 +4,16 @@ mod checkout_boundary {
 
     use crate::CommerceError;
 
+    const CHECKOUT_ERROR_BOUNDARY: &str = "commerce_graphql_checkout";
+
+    struct CheckoutServiceDiagnosticError;
+
+    impl std::fmt::Debug for CheckoutServiceDiagnosticError {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("redacted")
+        }
+    }
+
     #[derive(Clone)]
     pub(crate) enum BoundaryError {
         Graphql(Error),
@@ -114,13 +124,14 @@ mod checkout_boundary {
     impl From<CommerceError> for BoundaryError {
         fn from(error: CommerceError) -> Self {
             let (message, code, retryable, error_kind) = commerce_error_envelope(&error);
+            let diagnostic_error = CheckoutServiceDiagnosticError;
             tracing::error!(
-                error = ?error,
+                error = ?diagnostic_error,
                 owner = "rustok_commerce",
                 error_kind,
                 public_code = code,
                 retryable,
-                boundary = "commerce_graphql_checkout",
+                boundary = CHECKOUT_ERROR_BOUNDARY,
                 "commerce GraphQL checkout shipping profile operation failed"
             );
             Self::Public {
@@ -134,13 +145,14 @@ mod checkout_boundary {
     impl From<FulfillmentError> for BoundaryError {
         fn from(error: FulfillmentError) -> Self {
             let (message, code, retryable, error_kind) = fulfillment_error_envelope(&error);
+            let diagnostic_error = CheckoutServiceDiagnosticError;
             tracing::error!(
-                error = ?error,
+                error = ?diagnostic_error,
                 owner = "rustok_fulfillment",
                 error_kind,
                 public_code = code,
                 retryable,
-                boundary = "commerce_graphql_checkout",
+                boundary = CHECKOUT_ERROR_BOUNDARY,
                 "commerce GraphQL checkout shipping option operation failed"
             );
             Self::Public {

--- a/scripts/verify/verify-commerce-graphql-checkout-service-error-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-checkout-service-error-safety.mjs
@@ -34,6 +34,10 @@ if (checkoutModuleDeclarations.length !== 1) {
 
 for (const [value, label] of [
   ['mod checkout_boundary {', 'checkout boundary module'],
+  ['const CHECKOUT_ERROR_BOUNDARY: &str = "commerce_graphql_checkout";', 'checkout boundary constant'],
+  ['struct CheckoutServiceDiagnosticError;', 'redacted diagnostic token'],
+  ['impl std::fmt::Debug for CheckoutServiceDiagnosticError', 'diagnostic Debug implementation'],
+  ['formatter.write_str("redacted")', 'redacted diagnostic rendering'],
   ['#[derive(Clone)]', 'async GraphQL clone requirement'],
   ['pub(crate) enum BoundaryError {', 'local boundary error'],
   ['Graphql(Error)', 'GraphQL pass-through variant'],
@@ -49,11 +53,13 @@ for (const [value, label] of [
   ['fn fulfillment_error_envelope(', 'shipping option mapper'],
   ['extensions.set("code", code)', 'stable code extension'],
   ['extensions.set("retryable", retryable)', 'retryability extension'],
+  ['let diagnostic_error = CheckoutServiceDiagnosticError;', 'diagnostic source consumption'],
+  ['error = ?diagnostic_error', 'redacted diagnostic field'],
   ['owner = "rustok_commerce"', 'commerce owner logging'],
   ['owner = "rustok_fulfillment"', 'fulfillment owner logging'],
   ['error_kind,', 'owner error kind logging'],
   ['public_code = code', 'public code logging'],
-  ['boundary = "commerce_graphql_checkout"', 'checkout boundary logging'],
+  ['boundary = CHECKOUT_ERROR_BOUNDARY', 'checkout boundary logging'],
   ['mod async_graphql_shim {', 'async GraphQL result shim'],
   ['pub use ::async_graphql::{Context, Error, ErrorExtensions, Object};', 'GraphQL API re-export'],
   [
@@ -69,13 +75,15 @@ for (const [value, label] of [
 for (const value of [
   'Commerce(CommerceError)',
   'Fulfillment(FulfillmentError)',
+  'error = ?error',
+  'error = %error',
   'async_graphql::Error::new(error.to_string())',
   'async_graphql::Error::new(err.to_string())',
   'Error::new(error.to_string())',
   'Error::new(err.to_string())',
   'format!("{error}")',
 ]) {
-  forbidText(facade, value, 'checkout facade public boundary');
+  forbidText(facade, value, 'checkout facade public and diagnostic boundary');
 }
 for (const value of [
   'async_graphql::Error::new(error.to_string())',
@@ -85,6 +93,13 @@ for (const value of [
   'format!("{error}")',
 ]) {
   forbidText(source, value, 'checkout resolver public boundary');
+}
+
+const redactedDiagnosticFields = facade.match(/error = \?diagnostic_error/g) ?? [];
+if (redactedDiagnosticFields.length !== 2) {
+  failures.push(
+    `expected two redacted checkout service diagnostic fields, found ${redactedDiagnosticFields.length}`,
+  );
 }
 
 for (const [value, label] of [
@@ -154,5 +169,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce GraphQL checkout shipping services use cloneable typed public envelopes while preserving existing GraphQL errors',
+  '✔ Commerce GraphQL checkout shipping services retain typed public envelopes and emit only redacted owner diagnostics while preserving existing GraphQL errors',
 );


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce correlation-safe mapper cleanup at the Commerce GraphQL checkout shipping-service boundary.

- replace complete `CommerceError` and `FulfillmentError` tracing payloads with a zero-sized redacted diagnostic token;
- preserve exhaustive structural classification for shipping-profile and shipping-option owner errors;
- preserve every existing public message, code, retryability value, and `async_graphql::Error` pass-through;
- preserve the unchanged checkout resolver source, mutation signatures, permission checks, DTOs, owner calls, and the four Fulfillment plus four Commerce service call sites;
- preserve the existing error-level diagnostic severity and static event messages;
- strengthen the existing source guard so complete owner diagnostics cannot be reintroduced;
- add source-only evidence and focused documentation;
- leave public-channel propagation, shared storefront HTTP mappers, inventory, customer, tax, promotion, native transports, remaining adapters, non-`PortError` envelopes, and the broad ecommerce cleanup open.

## Recheck

The branch is based directly on `main@809a557dd37d636ef1ad7fa1df06ab4c4daa03b4`, is four commits ahead and zero behind, and changes exactly four intended files.

Production source changes are limited to the local redacted diagnostic token, one boundary constant, and the two checkout owner logger bodies. The included `checkout.rs` resolver source remains unchanged.

No open Commerce PR overlaps this boundary.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Node verifiers;
- Cargo checks, builds, clippy, or formatting;
- mounted GraphQL execution;
- workflows or CI.

Suggested maintainer checks:

```bash
node scripts/verify/verify-commerce-graphql-checkout-service-error-safety.mjs
cargo check -p rustok-commerce --lib
```

Execution evidence remains pending and the broad ecommerce cleanup remains open.