### PR TITLE
fix(page-builder): remove inline grant session from DOM

### DIFF
--- a/crates/rustok-page-builder-storefront/src/inline_edit.rs
+++ b/crates/rustok-page-builder-storefront/src/inline_edit.rs
@@ -446,7 +446,7 @@ pub fn PageBuilderAuthenticatedInlineStorefront(
     let selection = selection.unwrap_or(PageSelection::First);
     let policy = policy.unwrap_or_default();
     let class = class.unwrap_or_else(|| "rustok-page-builder-inline-storefront".to_string());
-    let root_id = format!("fly-inline-{}", dom_id(grant.session_id()));
+    let root_id = inline_root_id(&grant);
     let editable_ids = inline_editable_component_ids(&project_data, &selection).unwrap_or_default();
     let rendered = render_authenticated_inline_page(project_data, selection, policy, context);
 
@@ -491,7 +491,6 @@ pub fn PageBuilderAuthenticatedInlineStorefront(
                     class=class
                     data-rustok-page-builder-inline-storefront="true"
                     data-page-id=page_id
-                    data-inline-session=grant.session_id().to_string()
                     data-inline-revision=grant.revision_id().to_string()
                     data-inline-project-hash=grant.expected_project_hash().hex()
                     data-runtime-diagnostics=diagnostic_count
@@ -516,6 +515,14 @@ pub fn PageBuilderAuthenticatedInlineStorefront(
         }
         .into_any(),
     }
+}
+
+fn inline_root_id(grant: &AuthenticatedInlineEditGrant) -> String {
+    format!(
+        "fly-inline-{}-{}",
+        dom_id(grant.page_id()),
+        grant.expected_project_hash().hex()
+    )
 }
 
 fn dom_id(value: &str) -> String {
@@ -703,6 +710,19 @@ mod tests {
             Err(InlineEditError::SequenceReplay { .. })
                 | Err(InlineEditError::StaleProjectHash { .. })
         ));
+    }
+
+    #[test]
+    fn inline_dom_identity_excludes_grant_session_and_authorization_proof() {
+        let project = project();
+        let grant = grant(&project);
+        let root_id = inline_root_id(&grant);
+        assert_eq!(
+            root_id,
+            format!("fly-inline-home-{}", grant.expected_project_hash().hex())
+        );
+        assert!(!root_id.contains(grant.session_id()));
+        assert!(!root_id.contains("signed-proof"));
     }
 
     #[test]

--- a/crates/rustok-page-builder/contracts/evidence/page-builder-authenticated-inline-edit-adapter-source.json
+++ b/crates/rustok-page-builder/contracts/evidence/page-builder-authenticated-inline-edit-adapter-source.json
@@ -1,7 +1,7 @@
 {
   "format": "page_builder_authenticated_inline_edit_adapter_source_v1",
   "status": "page_builder_authenticated_inline_edit_adapter_source_unvalidated",
-  "generated_at": "2026-08-06T08:18:00Z",
+  "generated_at": "2026-08-06T14:36:00Z",
   "scope": "feature-gated Page Builder authenticated real-DOM inline adapter",
   "source_contract": {
     "real_dom_adapter_owned_by_fly_leptos": true,
@@ -11,6 +11,8 @@
     "grant_binds_session_page_revision_hash_expiry_and_proof": true,
     "authorization_proof_is_redacted_from_debug": true,
     "authorization_proof_is_not_rendered_into_dom": true,
+    "grant_session_is_not_rendered_into_dom": true,
+    "dom_root_identity_uses_page_and_project_hash": true,
     "plain_text_is_bounded_and_normalized": true,
     "dom_is_a_temporary_focusout_buffer": true,
     "dom_listener_cleanup_restores_attributes": true,

--- a/crates/rustok-page-builder/scripts/verify/verify-page-builder-authenticated-inline-edit-adapter.mjs
+++ b/crates/rustok-page-builder/scripts/verify/verify-page-builder-authenticated-inline-edit-adapter.mjs
@@ -81,12 +81,17 @@ for (const key of [
   "grant_binds_session_page_revision_hash_expiry_and_proof",
   "authorization_proof_is_redacted_from_debug",
   "authorization_proof_is_not_rendered_into_dom",
+  "grant_session_is_not_rendered_into_dom",
+  "dom_root_identity_uses_page_and_project_hash",
   "plain_text_is_bounded_and_normalized",
   "dom_is_a_temporary_focusout_buffer",
   "dom_listener_cleanup_restores_attributes",
   "only_allowlisted_components_receive_contenteditable",
-  "runtime_bound_conditional_and_repeated_components_are_excluded",
-  "provider_and_nested_components_are_excluded",
+  "runtime_bound_conditional_and_repeated_subtrees_are_excluded",
+  "provider_and_composite_components_are_excluded",
+  "interactive_controls_are_excluded",
+  "static_leaf_children_in_unowned_layouts_remain_eligible",
+  "unchanged_focusout_does_not_consume_grant",
   "server_authorization_port_precedes_mutation",
   "exact_project_hash_precedes_mutation",
   "monotonic_sequence_precedes_mutation",
@@ -167,8 +172,17 @@ for (const marker of [
   "GrapesJsCodec::encode_value(self.editor.document())",
   "policy.instrument_components = true",
   "PageBuilderAuthenticatedInlineStorefront",
+  "let root_id = inline_root_id(&grant);",
+  "fn inline_root_id(grant: &AuthenticatedInlineEditGrant) -> String",
+  "dom_id(grant.page_id())",
+  "grant.expected_project_hash().hex()",
+  "inline_dom_identity_excludes_grant_session_and_authorization_proof",
 ]) need(inline, marker, "Page Builder canonical inline session");
-forbid(inline, "data-inline-proof", "Page Builder authorization proof DOM boundary");
+for (const marker of [
+  "data-inline-proof",
+  "data-inline-session",
+  "dom_id(grant.session_id())",
+]) forbid(inline, marker, "Page Builder secret/session DOM boundary");
 
 const apply = between(
   inline,
@@ -237,5 +251,5 @@ if (failures.length > 0) {
   process.exit(1);
 }
 console.log(
-  "[verify-page-builder-authenticated-inline-edit-adapter] PASS adapter_source_ready=true historical_consumer_boundary=retained execution=pending",
+  "[verify-page-builder-authenticated-inline-edit-adapter] PASS adapter_source_ready=true session_dom_exposure=false historical_consumer_boundary=retained execution=pending",
 );

--- a/crates/rustok-page-builder/scripts/verify/verify-page-builder-inline-session-dom-boundary.mjs
+++ b/crates/rustok-page-builder/scripts/verify/verify-page-builder-inline-session-dom-boundary.mjs
@@ -92,7 +92,7 @@ for (const marker of [
   "grant session identifier",
   "Fly page id + expected project hash",
   "data-inline-session",
-  "session remains available only inside the trusted Rust/WASM grant",
+  "The session remains available only inside the trusted Rust/WASM grant",
   "Browser evidence remains pending",
 ]) need(packet, marker, "corrective packet");
 for (const marker of [

--- a/crates/rustok-page-builder/scripts/verify/verify-page-builder-inline-session-dom-boundary.mjs
+++ b/crates/rustok-page-builder/scripts/verify/verify-page-builder-inline-session-dom-boundary.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+const failures = [];
+const files = {
+  evidence:
+    "crates/rustok-page-builder/contracts/evidence/page-builder-authenticated-inline-edit-adapter-source.json",
+  inline: "crates/rustok-page-builder-storefront/src/inline_edit.rs",
+  adapterGuard:
+    "crates/rustok-page-builder/scripts/verify/verify-page-builder-authenticated-inline-edit-adapter.mjs",
+  packet:
+    "docs/modules/pages-page-builder-inline-session-dom-boundary-packet-2026-08-06.md",
+  executionPlan: "docs/modules/pages-page-builder-inline-edit-execution-plan.md",
+};
+
+const absolute = (relativePath) => path.join(root, relativePath);
+const read = (relativePath) => fs.readFileSync(absolute(relativePath), "utf8");
+const need = (source, marker, label) => {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+};
+const forbid = (source, marker, label) => {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+};
+
+for (const [label, relativePath] of Object.entries(files)) {
+  if (!fs.existsSync(absolute(relativePath))) failures.push(`${label}: missing ${relativePath}`);
+}
+if (failures.length > 0) {
+  console.error("[verify-page-builder-inline-session-dom-boundary] FAIL");
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(1);
+}
+
+const evidence = JSON.parse(read(files.evidence));
+const inline = read(files.inline);
+const adapterGuard = read(files.adapterGuard);
+const packet = read(files.packet);
+const executionPlan = read(files.executionPlan);
+
+if (evidence.format !== "page_builder_authenticated_inline_edit_adapter_source_v1") {
+  failures.push(`evidence format mismatch: ${evidence.format}`);
+}
+if (evidence.status !== "page_builder_authenticated_inline_edit_adapter_source_unvalidated") {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+for (const key of [
+  "authorization_proof_is_not_rendered_into_dom",
+  "grant_session_is_not_rendered_into_dom",
+  "dom_root_identity_uses_page_and_project_hash",
+]) {
+  if (evidence.source_contract?.[key] !== true) {
+    failures.push(`evidence source_contract.${key} must be true`);
+  }
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push("source evidence execution must remain empty");
+}
+for (const [key, value] of Object.entries(evidence.validation ?? {})) {
+  if (value !== false) failures.push(`evidence validation.${key} must remain false`);
+}
+
+for (const marker of [
+  "let root_id = inline_root_id(&grant);",
+  "fn inline_root_id(grant: &AuthenticatedInlineEditGrant) -> String",
+  '"fly-inline-{}-{}"',
+  "dom_id(grant.page_id())",
+  "grant.expected_project_hash().hex()",
+  "inline_dom_identity_excludes_grant_session_and_authorization_proof",
+  "assert!(!root_id.contains(grant.session_id()))",
+  'assert!(!root_id.contains("signed-proof"))',
+]) need(inline, marker, "inline source");
+for (const marker of [
+  "data-inline-session",
+  "dom_id(grant.session_id())",
+  "data-inline-proof",
+]) forbid(inline, marker, "inline source");
+
+for (const marker of [
+  '"grant_session_is_not_rendered_into_dom"',
+  '"dom_root_identity_uses_page_and_project_hash"',
+  '"data-inline-session"',
+  '"dom_id(grant.session_id())"',
+  "session_dom_exposure=false",
+]) need(adapterGuard, marker, "adapter guard");
+
+for (const marker of [
+  "source-fixed / maintainer-validation-pending",
+  "grant session identifier",
+  "Fly page id + expected project hash",
+  "data-inline-session",
+  "session remains available only inside the trusted Rust/WASM grant",
+  "Browser evidence remains pending",
+]) need(packet, marker, "corrective packet");
+for (const marker of [
+  "session-dom-boundary-source-fixed",
+  "inline-edit-session-dom-boundary-source-fixed",
+  "no longer emits `data-inline-session`",
+  "session DOM exposure: source-fixed, validation pending",
+]) need(executionPlan, marker, "execution plan");
+
+if (failures.length > 0) {
+  console.error("[verify-page-builder-inline-session-dom-boundary] FAIL");
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(Math.min(failures.length, 255));
+}
+console.log(
+  "[verify-page-builder-inline-session-dom-boundary] PASS session_dom_exposure=false source_fixed=true execution=pending",
+);

--- a/docs/modules/pages-page-builder-inline-edit-execution-plan.md
+++ b/docs/modules/pages-page-builder-inline-edit-execution-plan.md
@@ -1,7 +1,7 @@
 # Pages / Page Builder Inline Edit Execution Plan
 
 Date: 2026-08-06  
-Status: `artifact-http-evidence-harness-source-ready / artifact-http-browser-rollout-execution-pending`
+Status: `artifact-http-evidence-harness-source-ready / session-dom-boundary-source-fixed / artifact-http-browser-rollout-execution-pending`
 Parent cursor: `docs/modules/pages-page-builder-parity-continuation-plan.md`
 
 ## Purpose
@@ -20,9 +20,19 @@ Artifact/HTTP evidence harness: source-ready.
 
 The machine contract, build snapshot capture, production image capture, HTTP capture and same-commit aggregate assembler now exist. No artifact, Docker, HTTP, browser, workflow or rollout result is claimed.
 
+Corrective security marker:
+
+```text
+inline-edit-session-dom-boundary-source-fixed
+```
+
+The Page Builder authoring root no longer derives its DOM id from the grant session and no longer emits `data-inline-session`. The deterministic hydration id now uses Fly page identity plus expected project hash. Maintainer validation and browser inspection remain pending.
+
 ## Gate A — source guards
 
 - [ ] Run the authenticated adapter, consumer, route, asset, admin launch and release-composition source guards.
+- [ ] Run `verify-page-builder-authenticated-inline-edit-adapter.mjs` and confirm it rejects session-derived DOM identity.
+- [ ] Confirm the source contains neither `data-inline-session` nor `dom_id(grant.session_id())`.
 - [ ] Run `verify-pages-inline-edit-artifact-http-evidence-harness.mjs`.
 - [ ] Run release infrastructure, supply-chain and readiness guards.
 - [ ] Record the exact source commit and command output hashes.
@@ -124,6 +134,8 @@ This status closes only artifact, production-image, HTTP and anonymous-artifact 
 - [ ] Confirm launch is hidden for published, missing, locale-less, unauthorized and standalone-admin states.
 - [ ] Confirm navigation is same-origin and uses the selected document's exact locale.
 - [ ] Confirm the bounded authoring root mounts the dedicated JS/WASM client.
+- [ ] Inspect both SSR HTML and hydrated DOM: no grant session, proof, bearer token, signing material or authenticated session identifier may appear in ids, attributes, URLs or logs.
+- [ ] Confirm the authoring root id uses document identity rather than grant/session identity.
 - [ ] Edit one eligible real-DOM text node.
 - [ ] Confirm one canonical Fly patch and one Pages document save.
 - [ ] Reload and confirm the saved document revision.
@@ -132,7 +144,6 @@ This status closes only artifact, production-image, HTTP and anonymous-artifact 
 - [ ] Confirm replayed grant/sequence fails.
 - [ ] Confirm expired grant fails.
 - [ ] Confirm provider-owned, composite, templated, interactive and runtime-owned subtrees remain read-only.
-- [ ] Confirm no grant, proof, signing material or session identifier appears in DOM, URL or browser logs.
 
 Gate G passing state:
 
@@ -172,6 +183,7 @@ Hashes, sizes, selected headers, environment variable names, immutable RepoDiges
 ```text
 source pipeline: ready
 artifact/HTTP evidence harness: source-ready
+session DOM exposure: source-fixed, validation pending
 artifact execution: pending
 HTTP execution: pending
 browser execution: pending

--- a/docs/modules/pages-page-builder-inline-session-dom-boundary-packet-2026-08-06.md
+++ b/docs/modules/pages-page-builder-inline-session-dom-boundary-packet-2026-08-06.md
@@ -1,0 +1,77 @@
+# Pages / Page Builder Inline Session DOM Boundary Packet
+
+Date: 2026-08-06  
+Status: `source-fixed / maintainer-validation-pending`
+
+## Finding
+
+The authenticated Page Builder inline storefront retained the grant session identifier in two browser-visible places:
+
+```text
+id="fly-inline-<grant session>"
+data-inline-session="<grant session>"
+```
+
+That contradicted the established Pages/Page Builder boundary that bearer material, sessions, grants and proofs must not enter authoring URLs or DOM attributes.
+
+## Fix
+
+`PageBuilderAuthenticatedInlineStorefront` now derives its deterministic hydration root from non-secret document identity:
+
+```text
+Fly page id + expected project hash
+```
+
+The `data-inline-session` attribute is removed entirely.
+
+The grant still binds the authenticated session internally. The session remains available only inside the trusted Rust/WASM grant and request objects used for authorization. It is no longer rendered into SSR HTML or hydrated DOM identity.
+
+## Preserved behavior
+
+This change does not alter:
+
+- grant signing or verification;
+- direct-user or authenticated-session admission;
+- page, locale, revision, project-hash or expiry binding;
+- monotonic request sequence validation;
+- editable component eligibility;
+- canonical `EditorCommand::Patch` mutation;
+- Pages `save_document(expected_revision)` persistence;
+- replacement grant issuance;
+- public or anonymous storefront rendering;
+- database, GraphQL, REST, event, publish or rollback schemas.
+
+## Regression boundary
+
+The existing authenticated inline adapter source guard now requires:
+
+```text
+let root_id = inline_root_id(&grant)
+dom_id(grant.page_id())
+grant.expected_project_hash().hex()
+```
+
+It rejects:
+
+```text
+data-inline-session
+dom_id(grant.session_id())
+data-inline-proof
+```
+
+A focused Rust regression assertion verifies that the generated root id contains neither the grant session nor authorization proof.
+
+## Validation status
+
+No tests, static verifiers, formatting, Cargo commands, WASM builds, server builds, browser scenarios, workflows or CI were run by the implementation agent.
+
+Suggested checks, intentionally not run:
+
+```bash
+node crates/rustok-page-builder/scripts/verify/verify-page-builder-authenticated-inline-edit-adapter.mjs
+cargo test -p rustok-page-builder-storefront inline_dom_identity_excludes_grant_session_and_authorization_proof
+cargo check -p rustok-page-builder-storefront --features inline-edit,ssr
+cargo check -p rustok-page-builder-storefront --target wasm32-unknown-unknown --features inline-edit,hydrate
+```
+
+Browser evidence remains pending and must additionally inspect the SSR response and hydrated DOM for session/proof absence.


### PR DESCRIPTION
## Finding

`PageBuilderAuthenticatedInlineStorefront` used the trusted inline-edit grant session identifier in both the SSR/hydrated root `id` and `data-inline-session`. That contradicted the existing Pages/Page Builder boundary that sessions, grants and proofs must not enter authoring DOM attributes or URLs.

## Fix

- derive the deterministic inline hydration root from Fly page identity plus expected project hash
- remove `data-inline-session` entirely
- keep the authenticated session bound only inside the trusted Rust/WASM grant and request objects
- add a focused regression assertion that the root identity contains neither session nor authorization proof
- update the existing adapter evidence and source guard
- add a focused session-DOM boundary guard and corrective packet
- update the active execution plan so SSR and hydrated DOM inspection explicitly verifies session/proof absence

## Preserved contracts

No changes to grant signing/verification, direct-user/session admission, locale/revision/project-hash/expiry binding, sequence checks, eligibility, canonical Fly patching, Pages `save_document(expected_revision)`, replacement grants, anonymous rendering, schemas, publication or rollout.

## Validation

Not run per maintainer instruction. No tests, static verifiers, formatting, Cargo commands, WASM/server builds, browser scenarios, workflows or CI were executed.
