### PR TITLE
fix(customer): redact read correlation diagnostics

### DIFF
--- a/crates/rustok-commerce/docs/graphql-query-customer-error-safety.md
+++ b/crates/rustok-commerce/docs/graphql-query-customer-error-safety.md
@@ -4,7 +4,7 @@ Status: `source_closed_unvalidated`
 
 ## Scope
 
-This source wave closes the currently identified dynamic customer `PortError` handling gap in the mounted Commerce GraphQL query facade.
+This source contract closes the currently identified dynamic customer `PortError` handling gap in the mounted Commerce GraphQL query facade and records the correlation-safe Customer read diagnostics consumed by that facade.
 
 The compatibility resolver source in `crates/rustok-commerce/src/graphql/query.rs` remains unchanged. Its three customer-by-user reads continue to serve:
 
@@ -43,20 +43,11 @@ The complete owner `PortError`, owner message content, owner code, and owner ret
 
 ## Bounded diagnostics
 
-The transport boundary retains:
+The Commerce transport boundary retains a redacted diagnostic token, closed owner kind, stable owner code, owner retryability, owner-message presence/length, selected public code, and retryability. The complete `PortError` and owner-message content are not logged.
 
-- a diagnostic token whose `Debug` output is always `redacted`;
-- closed owner kind;
-- stable owner code;
-- owner retryability;
-- owner-message presence and character length;
-- selected public code and retryability;
-- error severity for unavailable, timeout, and invariant failures;
-- warning severity for validation, conflict, forbidden, and other ordinary rejections.
+The Customer owner and canonical in-process read layers now retain correlation-ID character length instead of the raw correlation ID across policy admission, list validation, tenant parsing, owner failure, and local delegated-outcome events. Other context and request values remain represented only through bounded presence, length, count, and closed-label facts.
 
-The complete `PortError` and owner-message content are not logged.
-
-Identity-not-found outcomes are already recorded by the Customer owner boundary and preserve their existing auth/optional transport semantics without a duplicate Commerce failure event.
+Identity-not-found outcomes preserve their existing auth/optional transport semantics without a duplicate Commerce failure event.
 
 ## Preserved contracts
 
@@ -68,15 +59,17 @@ Identity-not-found outcomes are already recorded by the Customer owner boundary 
 
 ## Still open
 
-- Execute the focused source verifier and Cargo checks.
+- Execute the focused source verifiers and Cargo checks.
 - Retain mounted success, missing identity, validation, unavailable, timeout, and invariant GraphQL evidence.
-- Remove raw correlation-id payloads from remaining Customer owner diagnostics.
-- Continue tax, promotion, inventory, remaining adapter, and non-`PortError` ecommerce envelope cleanup.
+- Continue tax, promotion, inventory, remaining adapter, write-side Customer, and non-`PortError` ecommerce envelope cleanup.
 
 ## Intended checks
 
 ```bash
 node scripts/verify/verify-commerce-graphql-query-customer-error-safety.mjs
+node scripts/verify/verify-customer-owner-error-diagnostic-safety.mjs
+node scripts/verify/verify-customer-read-policy-context.mjs
+node scripts/verify/verify-customer-read-local-context.mjs
 cargo check -p rustok-commerce --lib
 cargo check -p rustok-customer --lib
 ```

--- a/crates/rustok-customer/docs/customer-owner-error-diagnostic-safety.md
+++ b/crates/rustok-customer/docs/customer-owner-error-diagnostic-safety.md
@@ -13,66 +13,58 @@ This contract closes the currently identified payload-diagnostic gaps in `crates
 
 The four `CustomerReadPort` operations, request/response DTOs, admission and validation order, tenant parsing result, owner service delegation, pagination and enrichment behavior remain unchanged.
 
-All seven current `CustomerError` variants retain their existing public `PortError` mapping:
+All seven current `CustomerError` variants retain their existing public `PortError` mapping: database unavailable, customer not found, customer-by-user not found, duplicate email, duplicate user link, validation, and profile unavailable.
 
-- database unavailable;
-- customer not found;
-- customer by user not found;
-- duplicate email;
-- duplicate user link;
-- validation;
-- profile unavailable.
+## Correlation-safe bounded context
 
-## Admission diagnostics
+Every Customer owner read event now retains only correlation-id character length. The raw correlation id is not recorded by admission, list-validation, tenant-parser, or owner-error diagnostics.
 
-A rejected read policy still returns the exact `PortError` produced by `PortContext::require_policy`. The warning event retains:
+Other context remains represented only through bounded facts:
 
-- correlation id, owner operation and boundary;
-- stable code and retryability;
-- a closed static `PortErrorKind` label;
-- message presence and character length;
-- bounded context shape such as tenant/actor lengths, actor kind, claim/role counts, optional metadata presence/length and deadline.
+- tenant and actor-ID character lengths;
+- a closed actor-kind label;
+- claim and role counts;
+- optional channel, causation, traceparent, and idempotency presence/length;
+- locale length and deadline.
 
-The complete `PortError`, public message text, raw tenant, actor, channel, locale, causation id and traceparent are not recorded.
+Raw tenant, actor, channel, locale, causation, traceparent, idempotency, and request identity values are not recorded.
 
-## List-validation diagnostics
+## Admission, validation, and parser diagnostics
 
-The existing `customer.page_invalid` and `customer.per_page_invalid` codes, messages, warning severity and validation order remain unchanged.
+A rejected read policy still returns the exact `PortError` produced by `PortContext::require_policy`. The warning event retains stable code, retryability, a closed `PortErrorKind` label, message presence/length, operation, boundary, and bounded context shape.
 
-Events retain only the static validation field, numeric page/per-page bounds, search presence/length and bounded context shape. Search text and raw context values are not recorded.
-
-## Tenant-parser diagnostics
-
-Invalid tenant input still returns `customer.context_invalid` with `customer request context is invalid`.
-
-The parser event retains only `tenant_id_parse_failed = true`, tenant input length, bounded context shape, operation, code and boundary. The UUID parser error and raw tenant value are not recorded.
+The existing `customer.page_invalid`, `customer.per_page_invalid`, and `customer.context_invalid` outcomes retain their messages, validation order, warning severity, and request behavior. List events retain only numeric pagination bounds plus search presence/length. Tenant parsing retains only a static parse-failure fact and bounded context.
 
 ## Owner-error diagnostics
 
-The owner mapper records correlation id, owner operation, boundary, stable code and bounded context shape. Owner failures retain only:
+Owner failures retain only:
 
+- exact owner operation and stable code;
 - a closed static error variant;
 - text-field count and total character length;
 - UUID-field count and non-nil count;
-- opaque-payload presence for database and profile failures.
+- opaque-payload presence for database and profile failures;
+- bounded context shape and correlation-id character length.
 
-Database/Profile errors, validation messages, email values, customer IDs, user IDs and complete `CustomerError` debug/display payloads are not recorded.
+Database/Profile errors, validation messages, email values, customer IDs, user IDs, complete `CustomerError` payloads, and the raw correlation id are not recorded.
 
 ## Preserved behavior
 
 - database and profile failures remain error severity;
-- admission, list-validation, tenant-parser, not-found, conflict and validation failures remain warning severity;
+- admission, list-validation, tenant-parser, not-found, conflict, and validation failures remain warning severity;
 - all public codes, messages, kinds and retryability are unchanged;
 - all four owner service calls and their arguments are unchanged;
-- read policy, list validation and tenant parsing still execute in their previous order.
+- read policy, list validation, and tenant parsing still execute in their previous order;
+- Customer FFA/FBA status is unchanged.
 
-## Evidence
+## Evidence and remaining work
 
 - `crates/rustok-customer/contracts/evidence/customer-owner-error-diagnostic-safety-source.json`
 - `crates/rustok-customer/contracts/evidence/customer-owner-error-diagnostic-safety-source-review.json`
 - `scripts/verify/verify-customer-owner-error-diagnostic-safety.mjs`
+- `scripts/verify/verify-customer-read-policy-context.mjs`
 - `scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs`
 
-Compile validation, focused and aggregate verifier execution, mounted runtime evidence and the broader ecommerce cleanup remain open.
+Compile validation, focused and aggregate verifier execution, mounted runtime evidence, write-side Customer cleanup, remote adapters, and the broader ecommerce cleanup remain open.
 
 No test, verifier, formatter, Cargo, workflow or CI command was executed for this source contract.

--- a/crates/rustok-customer/docs/read-local-context.md
+++ b/crates/rustok-customer/docs/read-local-context.md
@@ -4,26 +4,20 @@ Status: **source-ready / unvalidated**
 
 ## Scope
 
-The canonical root `InProcessCustomerReadPort` retains actionable diagnostics for all
-four `CustomerReadPort` operations while delegating the original context and request to
-the unchanged `CustomerService` implementation:
+The canonical root `InProcessCustomerReadPort` retains actionable diagnostics for all four `CustomerReadPort` operations while delegating the original context and request to the unchanged `CustomerService` implementation:
 
 - `read_customer_projection`;
 - `read_customer_projection_by_user`;
 - `list_customer_projections`;
 - `list_profile_enrichment`.
 
-The module-path factory under `rustok_customer::ports` remains an explicit compatibility
-path. Root construction continues through `in_process_customer_read_port` and the
-canonical wrapper.
+The module-path factory under `rustok_customer::ports` remains an explicit compatibility path. Root construction continues through `in_process_customer_read_port` and the canonical wrapper.
 
 ## Bounded context shape
 
-This bounded context shape keeps attribution useful without copying delegated identity
-or routing values into the event.
+Covered events retain owner operation, local operation, stable boundary, and correlation-ID character length. Raw correlation IDs are not recorded.
 
-Covered events retain correlation ID, owner operation, local operation, stable boundary,
-and only bounded delegated context:
+The remaining delegated context is represented only through bounded facts:
 
 - tenant and actor-ID character lengths;
 - a closed actor-kind label;
@@ -31,8 +25,7 @@ and only bounded delegated context:
 - optional channel, causation, traceparent, and idempotency presence/length;
 - locale length and deadline.
 
-Raw tenant, actor, channel, locale, causation, traceparent, and idempotency values are not
-recorded by the wrapper.
+Raw tenant, actor, channel, locale, causation, traceparent, and idempotency values are not recorded by the wrapper.
 
 ## Bounded request shape
 
@@ -43,30 +36,17 @@ Operation-specific diagnostics retain only:
 - search presence and character length;
 - enrichment-list emptiness and duplicate-user-ID presence.
 
-Raw customer/user UUIDs, exact pagination values, exact profile-enrichment counts, search
-text, email, customer names, profile names, preferred locale values, rows, and result
-payloads are not recorded.
+Raw customer/user UUIDs, exact pagination values, exact profile-enrichment counts, search text, email, customer names, profile names, preferred locale values, rows, and result payloads are not recorded.
 
 ## Stable local classification
 
-The wrapper preserves the exact stable `operation + code + message` classification for:
+The wrapper preserves the exact stable `operation + code + message` classification for invalid tenant context, invalid page and page size, storage unavailability, customer and customer-by-user not found, owner validation, and profile projection unavailability.
 
-- invalid tenant context;
-- invalid page and page size;
-- storage unavailability;
-- customer and customer-by-user not found;
-- owner validation;
-- profile projection unavailability.
-
-Unknown envelopes pass through without an additional local event. Unavailable, timeout,
-and invariant kinds remain error severity; ordinary validation, not-found, and conflict
-outcomes remain warning severity.
+Unknown envelopes pass through without an additional local event. Unavailable, timeout, and invariant kinds remain error severity; ordinary validation, not-found, and conflict outcomes remain warning severity.
 
 ## Bounded error shape
 
-Covered events retain stable code, retryability, message presence/length, and a closed
-seven-value error-kind label. The complete delegated `PortError`, its message text, and
-debug-formatted kind are not copied into diagnostics.
+Covered events retain stable code, retryability, message presence/length, and a closed seven-value error-kind label. The complete delegated `PortError`, its message text, and debug-formatted kind are not copied into diagnostics.
 
 The same delegated `PortError` is returned unchanged.
 
@@ -83,22 +63,13 @@ This source slice does not change:
 - Commerce not-found handling or GraphQL fallback behavior;
 - Customer FFA/FBA status.
 
-## Evidence
+## Evidence and remaining gaps
 
 - `scripts/verify/verify-customer-read-local-context.mjs`;
 - `scripts/verify/verify-customer-read-policy-context.mjs`;
 - `crates/rustok-customer/contracts/evidence/customer-read-diagnostic-safety-source.json`;
 - `crates/rustok-customer/contracts/evidence/customer-read-diagnostic-safety-source-review.json`.
 
-The guards are fail-closed for complete error formatting, raw delegated context, raw
-request UUIDs, exact pagination/count values, raw message text, debug-kind output, and
-customer/profile payloads.
+Direct compatibility-path callers, customer write adapters, consumer-side transport mappers, profile transports, and runtime/remote evidence remain separate work. The broader ecommerce correlation-safe mapper cleanup remains open.
 
-## Remaining gaps
-
-Direct compatibility-path callers, customer write adapters, consumer-side transport
-mappers, profile transports, and runtime/remote evidence remain separate work. The
-broader ecommerce correlation-safe mapper cleanup remains open.
-
-No test, Node verifier, Cargo command, formatter, workflow, CI, or mounted runtime target
-was executed for this source slice.
+No test, Node verifier, Cargo command, formatter, workflow, CI, or mounted runtime target was executed for this source slice.

--- a/crates/rustok-customer/docs/read-port-policy-context.md
+++ b/crates/rustok-customer/docs/read-port-policy-context.md
@@ -4,60 +4,45 @@ Status: `source_ready_unvalidated`
 
 ## Scope
 
-All four owner read methods assign their canonical operation before applying the shared
-`PortCallPolicy::read()` admission helper:
+All four owner read methods assign their canonical operation before applying the shared `PortCallPolicy::read()` admission helper:
 
 - `read_customer_projection`;
 - `read_customer_projection_by_user`;
 - `list_customer_projections`;
 - `list_profile_enrichment`.
 
-A rejected admission is diagnosed and the original admission `PortError` is returned
-unchanged.
+A rejected admission is diagnosed and the original admission `PortError` is returned unchanged.
 
 ## Bounded context shape
-
-This bounded context shape preserves attribution without copying delegated identity or
-routing values into the admission event.
 
 The owner policy event retains:
 
 - owner `rustok_customer`;
 - exact operation and boundary `customer_read_port`;
-- correlation ID;
+- correlation-ID character length;
 - tenant and actor-ID character lengths;
 - a closed actor-kind label;
 - claim and role counts;
 - optional channel, causation, traceparent, and idempotency presence/length;
 - locale length and deadline.
 
-Raw tenant, actor, channel, locale, causation, traceparent, and idempotency values are not
-recorded.
+The raw correlation ID is not recorded. Raw tenant, actor, channel, locale, causation, traceparent, and idempotency values are also excluded.
 
 ## Bounded admission error shape
 
-The event retains stable code, retryability, message presence/length, and a closed
-seven-value error-kind label. The complete `PortError` is not copied into the event,
-message text is not recorded, and the kind is not debug-formatted.
+The event retains stable code, retryability, message presence/length, and a closed seven-value error-kind label. The complete `PortError` is not copied into the event, message text is not recorded, and the kind is not debug-formatted.
 
 The original admission `PortError` is returned unchanged.
 
-Technical unavailable, timeout, and invariant admission failures retain their typed
-error semantics. The current read-policy helper emits the existing warning admission
-event without changing admission behavior or public envelopes.
+Technical unavailable, timeout, and invariant admission failures retain their typed error semantics. The current read-policy helper emits the existing warning admission event without changing admission behavior or public envelopes.
 
 ## Canonical local outcomes
 
-Canonical root construction separately uses `InProcessCustomerReadPort` to retain
-bounded context/request/error shape after owner delegation. The wrapper classifies only
-exact stable `operation + code + message` outcomes and returns the same delegated
-`PortError` unchanged. Its contract is documented in
-[`read-local-context.md`](./read-local-context.md).
+Canonical root construction separately uses `InProcessCustomerReadPort` to retain bounded context/request/error shape after owner delegation. Its diagnostics also retain only correlation-ID character length and do not record the raw correlation ID.
 
-Policy rejection occurs before owner delegation. Covered local outcomes occur after the
-unchanged persistent implementation returns. Direct callers of the compatibility
-factory under `rustok_customer::ports` do not pass through the root wrapper, but they
-still use the bounded owner policy helper.
+The wrapper classifies only exact stable `operation + code + message` outcomes and returns the same delegated `PortError` unchanged. Its contract is documented in [`read-local-context.md`](./read-local-context.md).
+
+Policy rejection occurs before owner delegation. Covered local outcomes occur after the unchanged persistent implementation returns. Direct callers of the compatibility factory under `rustok_customer::ports` do not pass through the root wrapper, but they still use the bounded owner policy helper.
 
 ## Preserved contracts
 
@@ -80,10 +65,6 @@ The source contract is guarded by:
 - `crates/rustok-customer/contracts/evidence/customer-read-diagnostic-safety-source.json`;
 - `crates/rustok-customer/contracts/evidence/customer-read-diagnostic-safety-source-review.json`.
 
-Direct compatibility callers, consumer-side transport mappings, customer writes,
-profile transports, compile/runtime traces, restart behavior, and remote-profile
-execution remain open. The wider ecommerce correlation-safe mapper cleanup also remains
-open.
+Direct compatibility callers, consumer-side transport mappings, customer writes, profile transports, compile/runtime traces, restart behavior, and remote-profile execution remain open. The wider ecommerce correlation-safe mapper cleanup also remains open.
 
-No test, Node verifier, Cargo command, formatter, workflow, CI, or mounted runtime target
-was executed for this source slice.
+No test, Node verifier, Cargo command, formatter, workflow, CI, or mounted runtime target was executed for this source slice.

--- a/crates/rustok-customer/src/ports.rs
+++ b/crates/rustok-customer/src/ports.rs
@@ -207,6 +207,7 @@ fn parse_port_tenant_id(
 
 struct CustomerReadContextFacts {
     tenant_id_length: usize,
+    correlation_id_length: usize,
     actor_kind: &'static str,
     actor_id_length: usize,
     claim_count: usize,
@@ -247,6 +248,7 @@ fn customer_read_context_facts(context: &PortContext) -> CustomerReadContextFact
     };
     CustomerReadContextFacts {
         tenant_id_length: context.tenant_id.chars().count(),
+        correlation_id_length: context.correlation_id.chars().count(),
         actor_kind,
         actor_id_length: context.actor.id.chars().count(),
         claim_count: context.claims.len(),
@@ -304,7 +306,7 @@ fn log_customer_read_admission_rejection(
     let context_facts = customer_read_context_facts(context);
     tracing::warn!(
         owner = "rustok_customer",
-        correlation_id = %context.correlation_id,
+        correlation_id_length = context_facts.correlation_id_length,
         tenant_id_length = context_facts.tenant_id_length,
         actor_kind = context_facts.actor_kind,
         actor_id_length = context_facts.actor_id_length,
@@ -342,7 +344,7 @@ fn log_customer_list_validation_rejection(
     let request_facts = customer_list_request_facts(request);
     tracing::warn!(
         owner = "rustok_customer",
-        correlation_id = %context.correlation_id,
+        correlation_id_length = context_facts.correlation_id_length,
         tenant_id_length = context_facts.tenant_id_length,
         actor_kind = context_facts.actor_kind,
         actor_id_length = context_facts.actor_id_length,
@@ -368,7 +370,7 @@ fn log_customer_tenant_parse_rejection(context: &PortContext, owner_operation: &
     let context_facts = customer_read_context_facts(context);
     tracing::warn!(
         owner = "rustok_customer",
-        correlation_id = %context.correlation_id,
+        correlation_id_length = context_facts.correlation_id_length,
         tenant_id_length = context_facts.tenant_id_length,
         actor_kind = context_facts.actor_kind,
         actor_id_length = context_facts.actor_id_length,
@@ -455,7 +457,7 @@ fn log_customer_owner_failure(
     if technical_failure {
         tracing::error!(
             owner = "rustok_customer",
-            correlation_id = %context.correlation_id,
+            correlation_id_length = context_facts.correlation_id_length,
             tenant_id_length = context_facts.tenant_id_length,
             actor_kind = context_facts.actor_kind,
             actor_id_length = context_facts.actor_id_length,
@@ -485,7 +487,7 @@ fn log_customer_owner_failure(
     } else {
         tracing::warn!(
             owner = "rustok_customer",
-            correlation_id = %context.correlation_id,
+            correlation_id_length = context_facts.correlation_id_length,
             tenant_id_length = context_facts.tenant_id_length,
             actor_kind = context_facts.actor_kind,
             actor_id_length = context_facts.actor_id_length,

--- a/crates/rustok-customer/src/read_context.rs
+++ b/crates/rustok-customer/src/read_context.rs
@@ -23,6 +23,7 @@ const LIST_PROFILE_ENRICHMENT_OPERATION: &str = "list_profile_enrichment";
 
 struct CustomerReadContextFacts {
     tenant_id_length: usize,
+    correlation_id_length: usize,
     actor_kind: &'static str,
     actor_id_length: usize,
     claim_count: usize,
@@ -211,6 +212,7 @@ fn customer_read_context_facts(context: &PortContext) -> CustomerReadContextFact
     };
     CustomerReadContextFacts {
         tenant_id_length: context.tenant_id.chars().count(),
+        correlation_id_length: context.correlation_id.chars().count(),
         actor_kind,
         actor_id_length: context.actor.id.chars().count(),
         claim_count: context.claims.len(),
@@ -313,7 +315,7 @@ fn log_customer_read_local_outcome(
             owner = CUSTOMER_OWNER,
             operation = owner_operation,
             local_operation,
-            correlation_id = %context.correlation_id,
+            correlation_id_length = context_facts.correlation_id_length,
             tenant_id_length = context_facts.tenant_id_length,
             actor_kind = context_facts.actor_kind,
             actor_id_length = context_facts.actor_id_length,
@@ -355,7 +357,7 @@ fn log_customer_read_local_outcome(
             owner = CUSTOMER_OWNER,
             operation = owner_operation,
             local_operation,
-            correlation_id = %context.correlation_id,
+            correlation_id_length = context_facts.correlation_id_length,
             tenant_id_length = context_facts.tenant_id_length,
             actor_kind = context_facts.actor_kind,
             actor_id_length = context_facts.actor_id_length,

--- a/scripts/verify/verify-customer-owner-error-diagnostic-safety.mjs
+++ b/scripts/verify/verify-customer-owner-error-diagnostic-safety.mjs
@@ -19,7 +19,6 @@ const paths = {
   review:
     'crates/rustok-customer/contracts/evidence/customer-owner-error-diagnostic-safety-source-review.json',
   document: 'crates/rustok-customer/docs/customer-owner-error-diagnostic-safety.md',
-  broad: 'scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs',
 };
 
 const ports = read(paths.ports);
@@ -27,7 +26,6 @@ const errorSource = read(paths.error);
 const evidence = JSON.parse(read(paths.evidence));
 const review = JSON.parse(read(paths.review));
 const document = read(paths.document);
-const broad = read(paths.broad);
 
 const requireText = (source, value, label) => {
   if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
@@ -47,7 +45,7 @@ function functionBody(source, functionName) {
   }
   const openBrace = source.indexOf('{', match.index);
   let depth = 0;
-  for (let index = openBrace; index >= 0 && index < source.length; index += 1) {
+  for (let index = openBrace; index < source.length; index += 1) {
     if (source[index] === '{') depth += 1;
     if (source[index] === '}') {
       depth -= 1;
@@ -64,7 +62,6 @@ for (const marker of [
   'async fn read_customer_projection_by_user(',
   'async fn list_customer_projections(',
   'async fn list_profile_enrichment(',
-  'pub fn in_process_customer_read_port(',
   'self.get_customer(tenant_id, request.customer_id)',
   'self.get_customer_by_user(tenant_id, request.user_id)',
   'self.list_customers(',
@@ -86,36 +83,16 @@ for (const marker of [
 ]) requireText(errorSource, marker, `${paths.error}: owner error shape`);
 
 const contextFacts = functionBody(ports, 'customer_read_context_facts');
-const listFacts = functionBody(ports, 'customer_list_request_facts');
-const kindMapper = functionBody(ports, 'customer_port_error_kind');
-const admission = functionBody(ports, 'require_customer_read_policy');
 const admissionLogger = functionBody(ports, 'log_customer_read_admission_rejection');
-const listValidation = functionBody(ports, 'validate_customer_list_projection_request');
 const listLogger = functionBody(ports, 'log_customer_list_validation_rejection');
-const tenantParser = functionBody(ports, 'parse_port_tenant_id');
 const tenantLogger = functionBody(ports, 'log_customer_tenant_parse_rejection');
-const errorFacts = functionBody(ports, 'customer_owner_error_facts');
 const ownerLogger = functionBody(ports, 'log_customer_owner_failure');
 const mapper = functionBody(ports, 'customer_error_to_port_error');
-const diagnosticScope = [
-  contextFacts,
-  listFacts,
-  kindMapper,
-  admission,
-  admissionLogger,
-  listValidation,
-  listLogger,
-  tenantParser,
-  tenantLogger,
-  errorFacts,
-  ownerLogger,
-  mapper,
-].join('\n');
+const diagnosticScope = [contextFacts, admissionLogger, listLogger, tenantLogger, ownerLogger].join('\n');
 
 for (const marker of [
-  'struct CustomerReadContextFacts',
+  'correlation_id_length: context.correlation_id.chars().count()',
   'tenant_id_length: context.tenant_id.chars().count()',
-  'actor_kind',
   'actor_id_length: context.actor.id.chars().count()',
   'claim_count: context.claims.len()',
   'role_count: context.roles.len()',
@@ -125,193 +102,28 @@ for (const marker of [
   'traceparent_present: context.traceparent.is_some()',
   'idempotency_key_present: context.idempotency_key.is_some()',
   'deadline_ms: context.deadline_ms',
-  'struct CustomerListRequestFacts',
-  'search_present: request.search.is_some()',
-  'search_length: request.search.as_ref().map(|value| value.chars().count())',
-  'page: request.page',
-  'per_page: request.per_page',
-  'struct CustomerOwnerErrorFacts',
-  'CustomerError::Validation(message)',
-  '("validation", 1, message.chars().count(), 0, 0, false)',
-  'CustomerError::CustomerNotFound(customer_id)',
-  '"customer_not_found"',
-  'CustomerError::CustomerByUserNotFound(user_id)',
-  '"customer_by_user_not_found"',
-  'CustomerError::DuplicateEmail(email)',
-  '("duplicate_email", 1, email.chars().count(), 0, 0, false)',
-  'CustomerError::DuplicateUserLink(user_id)',
-  '"duplicate_user_link"',
-  'CustomerError::Profile(_) => ("profile", 0, 0, 0, 0, true)',
-  'CustomerError::Database(_) => ("database", 0, 0, 0, 0, true)',
-]) requireText(ports, marker, `${paths.ports}: bounded diagnostic facts`);
+]) requireText(contextFacts, marker, `${paths.ports}: bounded context facts`);
 
-for (const marker of [
-  'PortErrorKind::Validation => "validation"',
-  'PortErrorKind::NotFound => "not_found"',
-  'PortErrorKind::Conflict => "conflict"',
-  'PortErrorKind::Forbidden => "forbidden"',
-  'PortErrorKind::Unavailable => "unavailable"',
-  'PortErrorKind::Timeout => "timeout"',
-  'PortErrorKind::InvariantViolation => "invariant_violation"',
-]) requireText(kindMapper, marker, `${paths.ports}: closed PortError kind`);
-
-for (const marker of [
-  '.require_policy(PortCallPolicy::read())',
-  'log_customer_read_admission_rejection(context, owner_operation, &error);',
-  'error',
-]) requireText(admission, marker, `${paths.ports}: preserved admission return`);
-
-for (const marker of [
-  'tracing::warn!(',
-  'owner = "rustok_customer"',
-  'correlation_id = %context.correlation_id',
-  'tenant_id_length = context_facts.tenant_id_length',
-  'actor_kind = context_facts.actor_kind',
-  'actor_id_length = context_facts.actor_id_length',
-  'claim_count = context_facts.claim_count',
-  'role_count = context_facts.role_count',
-  'channel_present = context_facts.channel_present',
-  'locale_length = context_facts.locale_length',
-  'causation_id_present = context_facts.causation_id_present',
-  'traceparent_present = context_facts.traceparent_present',
-  'idempotency_key_present = context_facts.idempotency_key_present',
-  'deadline_ms = ?context_facts.deadline_ms',
-  'operation = owner_operation',
-  'code = %error.code',
-  'error_kind = customer_port_error_kind(&error.kind)',
-  'error_message_present = !error.message.is_empty()',
-  'error_message_length = error.message.chars().count()',
-  'retryable = error.retryable',
-  'boundary = CUSTOMER_READ_PORT_BOUNDARY',
-]) requireText(admissionLogger, marker, `${paths.ports}: bounded admission logger`);
-
-for (const marker of [
-  'if request.page == 0',
-  '"page"',
-  '"customer.page_invalid"',
-  '"customer projection page is invalid"',
-  'if !(1..=MAX_CUSTOMERS_PER_PAGE).contains(&request.per_page)',
-  '"per_page"',
-  '"customer.per_page_invalid"',
-  '"customer projection page size is invalid"',
-]) requireText(listValidation, marker, `${paths.ports}: preserved list validation`);
-
-for (const marker of [
-  'tracing::warn!(',
-  'validation_field,',
-  'code,',
-  'search_present = request_facts.search_present',
-  'search_length = ?request_facts.search_length',
-  'page = request_facts.page',
-  'per_page = request_facts.per_page',
-  'max_per_page = MAX_CUSTOMERS_PER_PAGE',
-  'tenant_id_length = context_facts.tenant_id_length',
-  'actor_kind = context_facts.actor_kind',
-  'boundary = CUSTOMER_READ_PORT_BOUNDARY',
-]) requireText(listLogger, marker, `${paths.ports}: bounded list logger`);
-
-for (const marker of [
-  'Uuid::parse_str(&context.tenant_id).map_err(|_|',
-  'log_customer_tenant_parse_rejection(context, owner_operation);',
-  '"customer.context_invalid"',
-  '"customer request context is invalid"',
-]) requireText(tenantParser, marker, `${paths.ports}: stable tenant parser`);
-
-for (const marker of [
-  'tracing::warn!(',
-  'tenant_id_length = context_facts.tenant_id_length',
-  'actor_kind = context_facts.actor_kind',
-  'operation = owner_operation',
-  'code = "customer.context_invalid"',
-  'tenant_id_parse_failed = true',
-  'boundary = CUSTOMER_READ_PORT_BOUNDARY',
-]) requireText(tenantLogger, marker, `${paths.ports}: bounded tenant parser logger`);
-
-for (const marker of [
-  'tracing::error!(',
-  'tracing::warn!(',
-  'owner = "rustok_customer"',
-  'correlation_id = %context.correlation_id',
-  'tenant_id_length = context_facts.tenant_id_length',
-  'actor_kind = context_facts.actor_kind',
-  'claim_count = context_facts.claim_count',
-  'role_count = context_facts.role_count',
-  'operation = owner_operation',
-  'error_variant = error_facts.error_variant',
-  'text_field_count = error_facts.text_field_count',
-  'text_total_length = error_facts.text_total_length',
-  'uuid_field_count = error_facts.uuid_field_count',
-  'uuid_non_nil_count = error_facts.uuid_non_nil_count',
-  'opaque_payload_present = error_facts.opaque_payload_present',
-  'boundary = CUSTOMER_READ_PORT_BOUNDARY',
-]) requireText(ownerLogger, marker, `${paths.ports}: bounded owner logger`);
-
-for (const [variant, code, message, constructor, technical] of [
-  [
-    'CustomerError::Database(_)',
-    'customer.database_unavailable',
-    'customer storage is temporarily unavailable',
-    'PortError::unavailable',
-    'true',
-  ],
-  [
-    'CustomerError::CustomerNotFound(_)',
-    'customer.customer_not_found',
-    'customer was not found',
-    'PortError::not_found',
-    'false',
-  ],
-  [
-    'CustomerError::CustomerByUserNotFound(_)',
-    'customer.customer_by_user_not_found',
-    'customer was not found for the requested user',
-    'PortError::not_found',
-    'false',
-  ],
-  [
-    'CustomerError::DuplicateEmail(_)',
-    'customer.duplicate_email',
-    'customer email is already in use',
-    'PortError::conflict',
-    'false',
-  ],
-  [
-    'CustomerError::DuplicateUserLink(_)',
-    'customer.duplicate_user_link',
-    'customer user link already exists',
-    'PortError::conflict',
-    'false',
-  ],
-  [
-    'CustomerError::Validation(_)',
-    'customer.validation',
-    'customer request is invalid',
-    'PortError::validation',
-    'false',
-  ],
-  [
-    'CustomerError::Profile(_)',
-    'customer.profile_unavailable',
-    'customer profile projection is temporarily unavailable',
-    'PortError::unavailable',
-    'true',
-  ],
+for (const [source, label] of [
+  [admissionLogger, 'admission logger'],
+  [listLogger, 'list-validation logger'],
+  [tenantLogger, 'tenant-parser logger'],
+  [ownerLogger, 'owner-error logger'],
 ]) {
-  for (const marker of [variant, `"${code}"`, `"${message}"`, constructor]) {
-    requireText(mapper, marker, `${paths.ports}: stable ${code} mapping`);
-  }
-  const call = new RegExp(
-    `"${code.replaceAll('.', '\\.')}",[\\s\\S]*?&error_facts,[\\s\\S]*?${technical},`,
+  requireText(
+    source,
+    'correlation_id_length = context_facts.correlation_id_length',
+    `${paths.ports}: ${label}`,
   );
-  if (!call.test(mapper)) {
-    failures.push(`${paths.ports}: ${code} severity classification drift`);
-  }
+  requireText(source, 'tenant_id_length = context_facts.tenant_id_length', `${label} tenant shape`);
+  requireText(source, 'operation = owner_operation', `${label} operation`);
+  requireText(source, 'boundary = CUSTOMER_READ_PORT_BOUNDARY', `${label} boundary`);
 }
 
 for (const forbidden of [
+  'correlation_id = %context.correlation_id',
   'error = ?error',
   'error = %error',
-  'error = %message',
   'tenant_id = %context.tenant_id',
   'actor = ?context.actor',
   'channel = ?context.channel',
@@ -323,62 +135,41 @@ for (const forbidden of [
   'email = %',
   'search = %',
   'search = ?',
-]) forbidText(diagnosticScope, forbidden, `${paths.ports}: read-boundary payload diagnostics`);
+]) forbidText(diagnosticScope, forbidden, `${paths.ports}: diagnostic payload`);
 
-for (const marker of [
-  "[customer, 'tenant_id_length = context_facts.tenant_id_length', 'customer tenant shape logging']",
-  "[customer, 'tenant_id_parse_failed = true', 'customer tenant parse failure']",
-  "[customer, 'error_kind = customer_port_error_kind(&error.kind)', 'customer admission error kind']",
-  "[customer, 'search_present = request_facts.search_present', 'customer list request shape']",
-  "[customer, 'customer_error_to_port_error(&context, owner_operation, error)', 'customer context-aware mapping']",
-]) requireText(broad, marker, `${paths.broad}: aggregate customer coverage`);
+for (const [variant, code, message, constructor] of [
+  ['CustomerError::Database(_)', 'customer.database_unavailable', 'customer storage is temporarily unavailable', 'PortError::unavailable'],
+  ['CustomerError::CustomerNotFound(_)', 'customer.customer_not_found', 'customer was not found', 'PortError::not_found'],
+  ['CustomerError::CustomerByUserNotFound(_)', 'customer.customer_by_user_not_found', 'customer was not found for the requested user', 'PortError::not_found'],
+  ['CustomerError::DuplicateEmail(_)', 'customer.duplicate_email', 'customer email is already in use', 'PortError::conflict'],
+  ['CustomerError::DuplicateUserLink(_)', 'customer.duplicate_user_link', 'customer user link already exists', 'PortError::conflict'],
+  ['CustomerError::Validation(_)', 'customer.validation', 'customer request is invalid', 'PortError::validation'],
+  ['CustomerError::Profile(_)', 'customer.profile_unavailable', 'customer profile projection is temporarily unavailable', 'PortError::unavailable'],
+]) {
+  for (const marker of [variant, `"${code}"`, `"${message}"`, constructor]) {
+    requireText(mapper, marker, `${paths.ports}: stable ${code} mapping`);
+  }
+}
 
 for (const [key, expected] of Object.entries({
-  owner_error_variant_count: 7,
   complete_customer_error_logged: false,
-  database_error_payload_logged: false,
-  profile_error_payload_logged: false,
-  validation_email_text_logged: false,
-  customer_user_uuid_logged: false,
   raw_context_logged_by_owner_mapper: false,
-  static_error_variant_logged: true,
-  aggregate_text_shape_logged: true,
-  aggregate_uuid_shape_logged: true,
-  opaque_payload_presence_logged: true,
   bounded_context_shape_logged: true,
   complete_port_error_logged_by_admission: false,
-  port_error_message_text_logged_by_admission: false,
   raw_context_logged_by_admission: false,
-  static_port_error_kind_logged_by_admission: true,
-  port_error_message_shape_logged_by_admission: true,
   raw_context_logged_by_list_validation: false,
-  list_search_text_logged: false,
-  bounded_list_request_shape_logged: true,
-  uuid_parse_error_payload_logged: false,
-  raw_tenant_logged_by_parser: false,
-  static_tenant_parse_failure_logged: true,
-  database_profile_error_severity_changed: false,
-  ordinary_warning_severity_changed: false,
-  admission_warning_severity_changed: false,
-  list_validation_warning_severity_changed: false,
-  tenant_parser_warning_severity_changed: false,
   public_code_changed: false,
   public_message_changed: false,
   public_kind_changed: false,
   public_retryability_changed: false,
   owner_delegation_changed: false,
   read_operations_changed: false,
-  admission_diagnostic_cleanup_closed: true,
-  tenant_parser_diagnostic_cleanup_closed: true,
-  list_validation_diagnostic_cleanup_closed: true,
-  customer_read_boundary_diagnostic_cleanup_closed: true,
   broad_ecommerce_cleanup_closed: false,
 })) {
   if (evidence.source_contract?.[key] !== expected) {
     failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
   }
 }
-
 for (const key of [
   'tests_run',
   'verifiers_run',
@@ -402,26 +193,9 @@ for (const [key, expected] of Object.entries({
   public_request_response_contracts_preserved: true,
   owner_delegation_preserved: true,
   all_seven_public_mappings_preserved: true,
-  database_profile_severity_preserved: true,
-  ordinary_warning_severity_preserved: true,
-  admission_list_parser_warning_severity_preserved: true,
-  complete_customer_error_logging_removed_from_owner_mapper: true,
-  database_profile_payload_removed: true,
-  validation_email_text_removed: true,
-  customer_user_uuid_removed: true,
   raw_context_removed_from_owner_mapper: true,
   bounded_context_shape_retained: true,
-  bounded_owner_error_shape_retained: true,
-  complete_port_error_logging_removed_from_admission: true,
-  port_error_message_text_removed_from_admission: true,
-  static_port_error_kind_and_message_shape_retained: true,
   raw_context_removed_from_admission_and_list_validation: true,
-  list_search_text_removed: true,
-  bounded_list_request_shape_retained: true,
-  uuid_parser_payload_removed: true,
-  raw_tenant_removed_from_parser: true,
-  static_tenant_parse_failure_retained: true,
-  admission_parser_list_validation_diagnostics_source_closed: true,
   customer_read_boundary_source_closed: true,
   broad_ecommerce_cleanup_remains_open: true,
   runtime_evidence_claimed: false,
@@ -434,14 +208,11 @@ for (const [key, expected] of Object.entries({
 for (const marker of [
   '# Customer read-boundary diagnostic safety',
   'Status: **source-ready / unvalidated**',
-  'read-policy admission',
-  'list request validation',
-  'tenant UUID parsing',
-  '`customer_error_to_port_error`',
-  'All seven current `CustomerError` variants',
-  'database and profile failures remain error severity',
-  'The UUID parser error and raw tenant value are not recorded.',
-  'the broader ecommerce cleanup remain open',
+  'correlation-id character length',
+  'raw correlation id',
+  'all public codes, messages, kinds and retryability are unchanged',
+  'broader ecommerce cleanup remain open',
+  'No test, verifier, formatter, Cargo, workflow or CI command was executed',
 ]) requireText(document, marker, `${paths.document}: truthful source scope`);
 
 if (failures.length > 0) {
@@ -451,5 +222,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Customer read admission, list validation, tenant parsing, and owner errors retain bounded diagnostics while preserving public behavior; execution evidence remains open',
+  '✔ Customer owner read diagnostics retain correlation length and bounded context without raw correlation payloads; execution evidence remains open',
 );

--- a/scripts/verify/verify-customer-read-local-context.mjs
+++ b/scripts/verify/verify-customer-read-local-context.mjs
@@ -37,7 +37,6 @@ const requireText = (source, value, label) => {
 const forbidText = (source, value, label) => {
   if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
 };
-
 function functionBody(source, functionName) {
   const signature = new RegExp(
     `(?:pub(?:\\([^)]*\\))?\\s+)?(?:async\\s+)?fn\\s+${functionName}(?:<[^>]*>)?\\s*\\(`,
@@ -49,7 +48,7 @@ function functionBody(source, functionName) {
   }
   const openBrace = source.indexOf('{', match.index);
   let depth = 0;
-  for (let index = openBrace; index >= 0 && index < source.length; index += 1) {
+  for (let index = openBrace; index < source.length; index += 1) {
     if (source[index] === '{') depth += 1;
     if (source[index] === '}') {
       depth -= 1;
@@ -60,24 +59,16 @@ function functionBody(source, functionName) {
   return '';
 }
 
-for (const [source, value, label] of [
+for (const [source, marker, label] of [
   [lib, 'pub mod ports;', 'legacy customer ports module'],
-  [lib, 'mod read_context;', 'private customer context wrapper module'],
-  [lib, 'pub use ports::{', 'selective root contract exports'],
-  [lib, 'CustomerReadPort,', 'root customer read trait export'],
-  [
-    lib,
-    'pub use read_context::{InProcessCustomerReadPort, in_process_customer_read_port};',
-    'canonical root wrapper exports',
-  ],
-  [ports, 'pub fn in_process_customer_read_port(db: DatabaseConnection)', 'legacy module factory'],
-  [ports, 'Arc::new(crate::CustomerService::new(db))', 'legacy owner construction'],
+  [lib, 'mod read_context;', 'private wrapper module'],
+  [lib, 'pub use read_context::{InProcessCustomerReadPort, in_process_customer_read_port};', 'canonical exports'],
+  [ports, 'pub fn in_process_customer_read_port(db: DatabaseConnection)', 'compatibility factory'],
   [wrapper, 'pub struct InProcessCustomerReadPort', 'canonical wrapper type'],
   [wrapper, 'inner: CustomerService', 'owner implementation delegation'],
-  [wrapper, 'pub fn from_service(inner: CustomerService) -> Self', 'host-composed constructor'],
-  [wrapper, 'Arc::new(InProcessCustomerReadPort::new(db))', 'canonical wrapper construction'],
+  [wrapper, 'Arc::new(InProcessCustomerReadPort::new(db))', 'canonical construction'],
   [wrapper, 'impl CustomerReadPort for InProcessCustomerReadPort', 'wrapper trait implementation'],
-]) requireText(source, value, label);
+]) requireText(source, marker, label);
 
 for (const [operation, request, response] of [
   ['read_customer_projection', 'CustomerProjectionRequest', 'CustomerResponse'],
@@ -85,9 +76,9 @@ for (const [operation, request, response] of [
   ['list_customer_projections', 'CustomerListProjectionRequest', 'CustomerListProjectionResponse'],
   ['list_profile_enrichment', 'CustomerProfileEnrichmentRequest', 'Vec<CustomerProfileEnrichment>'],
 ]) {
-  requireText(wrapper, `async fn ${operation}(`, `${operation} wrapper operation`);
-  requireText(wrapper, `request: ${request}`, `${operation} request contract`);
-  requireText(wrapper, `Result<${response}, PortError>`, `${operation} response contract`);
+  requireText(wrapper, `async fn ${operation}(`, `${operation} operation`);
+  requireText(wrapper, `request: ${request}`, `${operation} request`);
+  requireText(wrapper, `Result<${response}, PortError>`, `${operation} response`);
   requireText(
     wrapper,
     `CustomerReadPort::${operation}(&self.inner, context, request).await`,
@@ -95,94 +86,62 @@ for (const [operation, request, response] of [
   );
 }
 
-for (const [value, label] of [
-  ['struct CustomerReadContextFacts', 'bounded context fact type'],
-  ['struct CustomerReadDiagnosticFacts', 'bounded request fact type'],
-  ['fn customer_read_context_facts(', 'bounded context helper'],
-  ['fn customer_read_port_error_kind(', 'closed error-kind helper'],
-  ['fn log_customer_read_local_outcome(', 'bounded local logger'],
-  ['CustomerReadDiagnosticFacts::customer(request.customer_id)', 'customer-id shape capture'],
-  ['CustomerReadDiagnosticFacts::user(request.user_id)', 'user-id shape capture'],
-  ['CustomerReadDiagnosticFacts::list(&request)', 'list shape capture'],
-  ['CustomerReadDiagnosticFacts::enrichment(&request)', 'enrichment shape capture'],
-  ['customer_id_non_nil: !customer_id.is_nil()', 'customer UUID shape'],
-  ['user_id_non_nil: !user_id.is_nil()', 'user UUID shape'],
-  ['page_nonzero: request.page != 0', 'page zero shape'],
-  ['per_page_nonzero: request.per_page != 0', 'page-size zero shape'],
-  ['search_present: request.search.is_some()', 'search presence shape'],
-  ['search_length: request.search.as_ref().map(|value| value.chars().count())', 'search length'],
-  ['requested_user_ids_empty: request.user_ids.is_empty()', 'enrichment emptiness shape'],
-  ['duplicate_user_ids_present: unique_user_count < requested_user_count', 'duplicate shape'],
-  ['tenant_id_length: context.tenant_id.chars().count()', 'tenant length'],
-  ['actor_id_length: context.actor.id.chars().count()', 'actor-id length'],
-  ['claim_count: context.claims.len()', 'claim count'],
-  ['role_count: context.roles.len()', 'role count'],
-  ['channel_present: context.channel.is_some()', 'channel presence'],
-  ['locale_length: context.locale.chars().count()', 'locale length'],
-  ['causation_id_present: context.causation_id.is_some()', 'causation presence'],
-  ['traceparent_present: context.traceparent.is_some()', 'trace presence'],
-  ['idempotency_key_present: context.idempotency_key.is_some()', 'idempotency presence'],
-  ['deadline_ms: context.deadline_ms', 'deadline shape'],
-  ['PortErrorKind::Validation => "validation"', 'validation kind label'],
-  ['PortErrorKind::NotFound => "not_found"', 'not-found kind label'],
-  ['PortErrorKind::Conflict => "conflict"', 'conflict kind label'],
-  ['PortErrorKind::Forbidden => "forbidden"', 'forbidden kind label'],
-  ['PortErrorKind::Unavailable => "unavailable"', 'unavailable kind label'],
-  ['PortErrorKind::Timeout => "timeout"', 'timeout kind label'],
-  ['PortErrorKind::InvariantViolation => "invariant_violation"', 'invariant kind label'],
-]) requireText(wrapper, value, label);
-
+const contextFacts = functionBody(wrapper, 'customer_read_context_facts');
 const mapper = functionBody(wrapper, 'map_customer_read_local_port_error');
 const logger = functionBody(wrapper, 'log_customer_read_local_outcome');
-const diagnosticScope = [
-  functionBody(wrapper, 'customer_read_context_facts'),
-  functionBody(wrapper, 'customer_read_port_error_kind'),
-  logger,
-].join('\n');
+const diagnosticScope = [contextFacts, logger].join('\n');
 
-for (const [value, label] of [
-  ['owner = CUSTOMER_OWNER', 'truthful owner'],
-  ['operation = owner_operation', 'exact owner operation'],
-  ['local_operation,', 'local operation label'],
-  ['correlation_id = %context.correlation_id', 'correlation context'],
-  ['tenant_id_length = context_facts.tenant_id_length', 'tenant shape'],
-  ['actor_kind = context_facts.actor_kind', 'actor kind'],
-  ['actor_id_length = context_facts.actor_id_length', 'actor-id shape'],
-  ['claim_count = context_facts.claim_count', 'claim shape'],
-  ['role_count = context_facts.role_count', 'role shape'],
-  ['channel_present = context_facts.channel_present', 'channel shape'],
-  ['locale_length = context_facts.locale_length', 'locale shape'],
-  ['customer_id_present = request_facts.customer_id_present', 'customer presence'],
-  ['customer_id_non_nil = request_facts.customer_id_non_nil', 'customer non-nil'],
-  ['user_id_present = request_facts.user_id_present', 'user presence'],
-  ['user_id_non_nil = request_facts.user_id_non_nil', 'user non-nil'],
-  ['page_present = request_facts.page_present', 'page presence'],
-  ['page_nonzero = request_facts.page_nonzero', 'page shape'],
-  ['per_page_present = request_facts.per_page_present', 'page-size presence'],
-  ['per_page_nonzero = request_facts.per_page_nonzero', 'page-size shape'],
-  ['search_present = request_facts.search_present', 'search presence'],
-  ['search_length = ?request_facts.search_length', 'search length logging'],
-  ['requested_user_ids_empty = request_facts.requested_user_ids_empty', 'enrichment empty shape'],
-  [
-    'duplicate_user_ids_present = request_facts.duplicate_user_ids_present',
-    'enrichment duplicate shape',
-  ],
-  ['code = %error.code', 'stable code'],
-  ['error_message_present = !error.message.is_empty()', 'message presence'],
-  ['error_message_length = error.message.chars().count()', 'message length'],
-  ['error_kind = customer_read_port_error_kind(&error.kind)', 'closed error kind'],
-  ['retryable = error.retryable', 'retryability'],
-  ['boundary = CUSTOMER_READ_BOUNDARY', 'customer read boundary'],
-  [
-    'PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation',
-    'technical severity classification',
-  ],
-  [
-    '"customer read local technical outcome retained bounded delegated context"',
-    'technical event',
-  ],
-  ['"customer read local outcome retained bounded delegated context"', 'ordinary event'],
-]) requireText(logger, value, label);
+for (const marker of [
+  'correlation_id_length: context.correlation_id.chars().count()',
+  'tenant_id_length: context.tenant_id.chars().count()',
+  'actor_id_length: context.actor.id.chars().count()',
+  'claim_count: context.claims.len()',
+  'role_count: context.roles.len()',
+  'channel_present: context.channel.is_some()',
+  'locale_length: context.locale.chars().count()',
+  'causation_id_present: context.causation_id.is_some()',
+  'traceparent_present: context.traceparent.is_some()',
+  'idempotency_key_present: context.idempotency_key.is_some()',
+  'deadline_ms: context.deadline_ms',
+]) requireText(contextFacts, marker, `wrapper context: ${marker}`);
+
+for (const marker of [
+  'CustomerReadDiagnosticFacts::customer(request.customer_id)',
+  'CustomerReadDiagnosticFacts::user(request.user_id)',
+  'CustomerReadDiagnosticFacts::list(&request)',
+  'CustomerReadDiagnosticFacts::enrichment(&request)',
+  'customer_id_non_nil: !customer_id.is_nil()',
+  'user_id_non_nil: !user_id.is_nil()',
+  'page_nonzero: request.page != 0',
+  'per_page_nonzero: request.per_page != 0',
+  'search_present: request.search.is_some()',
+  'requested_user_ids_empty: request.user_ids.is_empty()',
+  'duplicate_user_ids_present: unique_user_count < requested_user_count',
+]) requireText(wrapper, marker, `bounded request facts: ${marker}`);
+
+for (const marker of [
+  'owner = CUSTOMER_OWNER',
+  'operation = owner_operation',
+  'local_operation,',
+  'correlation_id_length = context_facts.correlation_id_length',
+  'tenant_id_length = context_facts.tenant_id_length',
+  'actor_kind = context_facts.actor_kind',
+  'customer_id_present = request_facts.customer_id_present',
+  'user_id_present = request_facts.user_id_present',
+  'page_nonzero = request_facts.page_nonzero',
+  'per_page_nonzero = request_facts.per_page_nonzero',
+  'search_length = ?request_facts.search_length',
+  'duplicate_user_ids_present = request_facts.duplicate_user_ids_present',
+  'code = %error.code',
+  'error_message_present = !error.message.is_empty()',
+  'error_message_length = error.message.chars().count()',
+  'error_kind = customer_read_port_error_kind(&error.kind)',
+  'retryable = error.retryable',
+  'boundary = CUSTOMER_READ_BOUNDARY',
+  'PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation',
+  '"customer read local technical outcome retained bounded delegated context"',
+  '"customer read local outcome retained bounded delegated context"',
+]) requireText(logger, marker, `bounded local logger: ${marker}`);
 
 for (const [code, message, operation] of [
   ['customer.context_invalid', 'customer request context is invalid', 'validate_tenant_context'],
@@ -190,20 +149,12 @@ for (const [code, message, operation] of [
   ['customer.per_page_invalid', 'customer projection page size is invalid', 'validate_page_size'],
   ['customer.database_unavailable', 'customer storage is temporarily unavailable', 'owner_storage'],
   ['customer.customer_not_found', 'customer was not found', 'load_customer'],
-  [
-    'customer.customer_by_user_not_found',
-    'customer was not found for the requested user',
-    'load_customer_by_user',
-  ],
+  ['customer.customer_by_user_not_found', 'customer was not found for the requested user', 'load_customer_by_user'],
   ['customer.validation', 'customer request is invalid', 'validate_owner_request'],
-  [
-    'customer.profile_unavailable',
-    'customer profile projection is temporarily unavailable',
-    'load_profile_projection',
-  ],
+  ['customer.profile_unavailable', 'customer profile projection is temporarily unavailable', 'load_profile_projection'],
 ]) {
-  requireText(mapper, `"${code}"`, `${code} exact code`);
-  requireText(mapper, `"${message}"`, `${code} exact message`);
+  requireText(mapper, `"${code}"`, `${code} code`);
+  requireText(mapper, `"${message}"`, `${code} message`);
   requireText(mapper, `"${operation}"`, `${code} local operation`);
 }
 requireText(mapper, '_ => return error', 'unknown envelope pass-through');
@@ -212,43 +163,36 @@ if (!/\n\s*error\n\}/.test(mapper)) {
   failures.push('same delegated PortError return: missing terminal error return');
 }
 
-for (const [value, label] of [
-  ['error = ?error', 'complete PortError debug payload'],
-  ['error = %error', 'complete PortError display payload'],
-  ['internal_message = %error.message', 'raw PortError message'],
-  ['message = %error.message', 'raw PortError message alias'],
-  ['error_kind = ?error.kind', 'debug-formatted error kind'],
-  ['tenant_id = %context.tenant_id', 'raw tenant context'],
-  ['actor = ?context.actor', 'raw actor context'],
-  ['channel = ?context.channel', 'raw channel context'],
-  ['locale = %context.locale', 'raw locale context'],
-  ['causation_id = ?context.causation_id', 'raw causation context'],
-  ['traceparent = ?context.traceparent', 'raw trace context'],
-  ['idempotency_key = ?context.idempotency_key', 'raw idempotency context'],
-  ['customer_id = ?request_facts.customer_id', 'raw customer UUID'],
-  ['user_id = ?request_facts.user_id', 'raw user UUID'],
-  ['page = ?request_facts.page', 'exact page'],
-  ['per_page = ?request_facts.per_page', 'exact page size'],
-  ['requested_user_count =', 'exact requested user count'],
-  ['unique_user_count =', 'exact unique user count'],
-  ['search = ?', 'raw search text'],
-  ['search = %', 'raw search text'],
-  ['email = ?', 'raw email'],
-  ['email = %', 'raw email'],
-  ['first_name =', 'raw first name'],
-  ['last_name =', 'raw last name'],
-  ['preferred_locale =', 'raw preferred locale'],
-  ['request = ?', 'raw request payload'],
-  ['result = ?', 'raw result payload'],
-  ['items = ?', 'raw customer rows'],
-]) forbidText(diagnosticScope, value, `${paths.wrapper}: ${label}`);
+for (const forbidden of [
+  'correlation_id = %context.correlation_id',
+  'error = ?error',
+  'error = %error',
+  'message = %error.message',
+  'error_kind = ?error.kind',
+  'tenant_id = %context.tenant_id',
+  'actor = ?context.actor',
+  'channel = ?context.channel',
+  'locale = %context.locale',
+  'causation_id = ?context.causation_id',
+  'traceparent = ?context.traceparent',
+  'idempotency_key = ?context.idempotency_key',
+  'customer_id = ?',
+  'user_id = ?',
+  'page = ?request_facts.page',
+  'per_page = ?request_facts.per_page',
+  'search = ?',
+  'search = %',
+  'request = ?',
+  'result = ?',
+  'items = ?',
+]) forbidText(diagnosticScope, forbidden, `wrapper payload: ${forbidden}`);
 
 for (const marker of [
   'require_customer_read_policy(&context, owner_operation)?;',
   'parse_port_tenant_id(&context, owner_operation)?;',
   'validate_customer_list_projection_request(&context, owner_operation, &request)?;',
   'customer_error_to_port_error(&context, owner_operation, error)',
-]) requireText(ports, marker, `${paths.ports}: unchanged owner behavior`);
+]) requireText(ports, marker, `unchanged owner behavior: ${marker}`);
 
 for (const [key, expected] of Object.entries({
   owner_policy_diagnostics_bounded: true,
@@ -256,17 +200,8 @@ for (const [key, expected] of Object.entries({
   complete_port_error_logged: false,
   raw_context_logged: false,
   raw_request_uuid_logged: false,
-  canonical_wrapper_exact_pagination_logged: false,
-  canonical_wrapper_exact_profile_counts_logged: false,
-  raw_search_logged: false,
-  bounded_context_shape_logged: true,
-  bounded_request_shape_logged: true,
-  stable_code_logged: true,
-  error_message_shape_logged: true,
-  closed_error_kind_logged: true,
   exact_local_classification_changed: false,
   delegated_error_return_changed: false,
-  owner_list_validation_contract_changed: false,
   public_contract_changed: false,
   owner_delegation_changed: false,
   customer_ffa_fba_status_promoted: false,
@@ -303,14 +238,9 @@ for (const [key, expected] of Object.entries({
   unknown_error_pass_through_preserved: true,
   complete_wrapper_error_removed: true,
   raw_wrapper_context_removed: true,
-  raw_customer_and_user_ids_removed: true,
-  exact_wrapper_pagination_and_counts_removed: true,
-  owner_list_validation_contract_preserved: true,
   bounded_context_shape_retained: true,
   bounded_request_shape_retained: true,
   same_delegated_error_returned: true,
-  owner_policy_source_already_bounded: true,
-  stale_policy_verifier_corrected: true,
   customer_status_not_promoted: true,
   broad_ecommerce_cleanup_remains_open: true,
   runtime_evidence_claimed: false,
@@ -323,25 +253,23 @@ for (const [key, expected] of Object.entries({
 for (const marker of [
   '# Customer read local diagnostic safety',
   'Status: **source-ready / unvalidated**',
-  'bounded context shape',
-  'UUID presence and non-nil status',
-  'exact stable `operation + code + message`',
+  'correlation-ID character length',
+  'raw correlation IDs',
   'The same delegated `PortError` is returned unchanged.',
   'The broader ecommerce correlation-safe mapper cleanup remains open.',
 ]) requireText(document, marker, `${paths.document}: truthful source scope`);
 for (const marker of [
   '# Customer read port policy context',
-  'bounded context shape',
+  'correlation-ID character length',
+  'raw correlation ID',
   'The original admission `PortError` is returned unchanged.',
-  'complete `PortError` is not copied into the event',
-]) requireText(policyDocument, marker, `${paths.policyDocument}: bounded policy scope`);
+]) requireText(policyDocument, marker, `${paths.policyDocument}: policy scope`);
 
 if (failures.length > 0) {
   console.error('Customer read local diagnostic-safety verification failed:');
   for (const failure of failures) console.error(`✗ ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
-
 console.log(
-  '✔ Canonical customer reads retain bounded context/request/error shape and unchanged owner behavior; execution evidence remains open',
+  '✔ Canonical customer reads retain correlation length and bounded context/request/error shape without raw correlation payloads; execution evidence remains open',
 );

--- a/scripts/verify/verify-customer-read-policy-context.mjs
+++ b/scripts/verify/verify-customer-read-policy-context.mjs
@@ -9,7 +9,6 @@ const root = configuredRoot
   ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
   : new URL('../../', import.meta.url);
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
-
 const customer = read('crates/rustok-customer/src/ports.rs');
 const commerceQuery = read('crates/rustok-commerce/src/graphql/query.rs');
 const document = read('crates/rustok-customer/docs/read-port-policy-context.md');
@@ -21,7 +20,6 @@ const requireText = (source, value, label) => {
 const forbidText = (source, value, label) => {
   if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
 };
-
 function functionBody(source, functionName) {
   const signature = new RegExp(
     `(?:pub(?:\\([^)]*\\))?\\s+)?(?:async\\s+)?fn\\s+${functionName}(?:<[^>]*>)?\\s*\\(`,
@@ -33,7 +31,7 @@ function functionBody(source, functionName) {
   }
   const openBrace = source.indexOf('{', match.index);
   let depth = 0;
-  for (let index = openBrace; index >= 0 && index < source.length; index += 1) {
+  for (let index = openBrace; index < source.length; index += 1) {
     if (source[index] === '{') depth += 1;
     if (source[index] === '}') {
       depth -= 1;
@@ -44,15 +42,15 @@ function functionBody(source, functionName) {
   return '';
 }
 
-for (const [value, label] of [
-  ['const CUSTOMER_READ_PORT_BOUNDARY: &str = "customer_read_port";', 'stable owner boundary'],
-  ['fn require_customer_read_policy(', 'shared read policy helper'],
-  ['.require_policy(PortCallPolicy::read())', 'canonical read policy'],
-  ['log_customer_read_admission_rejection(context, owner_operation, &error);', 'admission diagnostics'],
-  ['fn customer_read_context_facts(', 'bounded context helper'],
-  ['fn customer_port_error_kind(', 'closed kind helper'],
-  ['fn log_customer_read_admission_rejection(', 'bounded admission logger'],
-]) requireText(customer, value, label);
+for (const marker of [
+  'const CUSTOMER_READ_PORT_BOUNDARY: &str = "customer_read_port";',
+  'fn require_customer_read_policy(',
+  '.require_policy(PortCallPolicy::read())',
+  'log_customer_read_admission_rejection(context, owner_operation, &error);',
+  'fn customer_read_context_facts(',
+  'fn customer_port_error_kind(',
+  'fn log_customer_read_admission_rejection(',
+]) requireText(customer, marker, `customer policy: ${marker}`);
 
 const policyCalls = customer.match(/require_customer_read_policy\(&context, owner_operation\)\?;/g) ?? [];
 if (policyCalls.length !== 4) {
@@ -71,115 +69,82 @@ for (const operation of [
     assignmentIndex,
   );
   if (assignmentIndex < 0 || policyIndex < assignmentIndex) {
-    failures.push(`${operation}: owner operation must be assigned before policy admission`);
+    failures.push(`${operation}: operation must be assigned before policy admission`);
   }
 }
-forbidText(
-  customer,
-  '        context.require_policy(PortCallPolicy::read())?;',
-  'direct unlogged customer read policy admission',
-);
 
 const contextFacts = functionBody(customer, 'customer_read_context_facts');
 const kindHelper = functionBody(customer, 'customer_port_error_kind');
 const admissionLogger = functionBody(customer, 'log_customer_read_admission_rejection');
 const admissionScope = [contextFacts, kindHelper, admissionLogger].join('\n');
 
-for (const [value, label] of [
-  ['tenant_id_length: context.tenant_id.chars().count()', 'tenant length'],
-  ['actor_id_length: context.actor.id.chars().count()', 'actor-id length'],
-  ['claim_count: context.claims.len()', 'claim count'],
-  ['role_count: context.roles.len()', 'role count'],
-  ['channel_present: context.channel.is_some()', 'channel presence'],
-  ['locale_length: context.locale.chars().count()', 'locale length'],
-  ['causation_id_present: context.causation_id.is_some()', 'causation presence'],
-  ['traceparent_present: context.traceparent.is_some()', 'trace presence'],
-  ['idempotency_key_present: context.idempotency_key.is_some()', 'idempotency presence'],
-  ['deadline_ms: context.deadline_ms', 'deadline shape'],
-]) requireText(contextFacts, value, label);
+for (const marker of [
+  'correlation_id_length: context.correlation_id.chars().count()',
+  'tenant_id_length: context.tenant_id.chars().count()',
+  'actor_id_length: context.actor.id.chars().count()',
+  'claim_count: context.claims.len()',
+  'role_count: context.roles.len()',
+  'channel_present: context.channel.is_some()',
+  'locale_length: context.locale.chars().count()',
+  'causation_id_present: context.causation_id.is_some()',
+  'traceparent_present: context.traceparent.is_some()',
+  'idempotency_key_present: context.idempotency_key.is_some()',
+  'deadline_ms: context.deadline_ms',
+]) requireText(contextFacts, marker, `bounded context: ${marker}`);
+for (const marker of [
+  'PortErrorKind::Validation => "validation"',
+  'PortErrorKind::NotFound => "not_found"',
+  'PortErrorKind::Conflict => "conflict"',
+  'PortErrorKind::Forbidden => "forbidden"',
+  'PortErrorKind::Unavailable => "unavailable"',
+  'PortErrorKind::Timeout => "timeout"',
+  'PortErrorKind::InvariantViolation => "invariant_violation"',
+]) requireText(kindHelper, marker, `closed kind: ${marker}`);
+for (const marker of [
+  'owner = "rustok_customer"',
+  'correlation_id_length = context_facts.correlation_id_length',
+  'tenant_id_length = context_facts.tenant_id_length',
+  'actor_kind = context_facts.actor_kind',
+  'operation = owner_operation',
+  'code = %error.code',
+  'error_kind = customer_port_error_kind(&error.kind)',
+  'error_message_present = !error.message.is_empty()',
+  'error_message_length = error.message.chars().count()',
+  'retryable = error.retryable',
+  'boundary = CUSTOMER_READ_PORT_BOUNDARY',
+  '"customer read port admission was rejected with bounded diagnostics"',
+]) requireText(admissionLogger, marker, `admission logger: ${marker}`);
 
-for (const [value, label] of [
-  ['PortErrorKind::Validation => "validation"', 'validation kind label'],
-  ['PortErrorKind::NotFound => "not_found"', 'not-found kind label'],
-  ['PortErrorKind::Conflict => "conflict"', 'conflict kind label'],
-  ['PortErrorKind::Forbidden => "forbidden"', 'forbidden kind label'],
-  ['PortErrorKind::Unavailable => "unavailable"', 'unavailable kind label'],
-  ['PortErrorKind::Timeout => "timeout"', 'timeout kind label'],
-  ['PortErrorKind::InvariantViolation => "invariant_violation"', 'invariant kind label'],
-]) requireText(kindHelper, value, label);
+for (const forbidden of [
+  'correlation_id = %context.correlation_id',
+  'error = ?error',
+  'error = %error',
+  'message = %error.message',
+  'error_kind = ?error.kind',
+  'tenant_id = %context.tenant_id',
+  'actor = ?context.actor',
+  'channel = ?context.channel',
+  'locale = %context.locale',
+  'causation_id = ?context.causation_id',
+  'traceparent = ?context.traceparent',
+  'idempotency_key = ?context.idempotency_key',
+]) forbidText(admissionScope, forbidden, `admission payload: ${forbidden}`);
 
-for (const [value, label] of [
-  ['owner = "rustok_customer"', 'truthful owner identity'],
-  ['correlation_id = %context.correlation_id', 'correlation context'],
-  ['tenant_id_length = context_facts.tenant_id_length', 'tenant shape'],
-  ['actor_kind = context_facts.actor_kind', 'actor kind'],
-  ['actor_id_length = context_facts.actor_id_length', 'actor-id shape'],
-  ['claim_count = context_facts.claim_count', 'claim shape'],
-  ['role_count = context_facts.role_count', 'role shape'],
-  ['channel_present = context_facts.channel_present', 'channel shape'],
-  ['channel_length = ?context_facts.channel_length', 'channel length'],
-  ['locale_length = context_facts.locale_length', 'locale shape'],
-  ['causation_id_present = context_facts.causation_id_present', 'causation shape'],
-  ['traceparent_present = context_facts.traceparent_present', 'trace shape'],
-  ['idempotency_key_present = context_facts.idempotency_key_present', 'idempotency shape'],
-  ['deadline_ms = ?context_facts.deadline_ms', 'deadline context'],
-  ['operation = owner_operation', 'exact owner operation'],
-  ['code = %error.code', 'stable public code'],
-  ['error_kind = customer_port_error_kind(&error.kind)', 'closed error kind'],
-  ['error_message_present = !error.message.is_empty()', 'message presence'],
-  ['error_message_length = error.message.chars().count()', 'message length'],
-  ['retryable = error.retryable', 'owner retryability'],
-  ['boundary = CUSTOMER_READ_PORT_BOUNDARY', 'boundary context'],
-  ['"customer read port admission was rejected with bounded diagnostics"', 'bounded event'],
-]) requireText(admissionLogger, value, label);
-
-for (const [value, label] of [
-  ['error = ?error', 'complete PortError debug payload'],
-  ['error = %error', 'complete PortError display payload'],
-  ['internal_message = %error.message', 'raw error message'],
-  ['message = %error.message', 'raw error message alias'],
-  ['error_kind = ?error.kind', 'debug-formatted kind'],
-  ['tenant_id = %context.tenant_id', 'raw tenant context'],
-  ['actor = ?context.actor', 'raw actor context'],
-  ['channel = ?context.channel', 'raw channel context'],
-  ['locale = %context.locale', 'raw locale context'],
-  ['causation_id = ?context.causation_id', 'raw causation context'],
-  ['traceparent = ?context.traceparent', 'raw trace context'],
-  ['idempotency_key = ?context.idempotency_key', 'raw idempotency context'],
-]) forbidText(admissionScope, value, label);
-
-for (const [value, label] of [
-  ['"customer.database_unavailable"', 'database mapping'],
-  ['"customer.customer_not_found"', 'customer not-found mapping'],
-  ['"customer.customer_by_user_not_found"', 'user not-found mapping'],
-  ['"customer.duplicate_email"', 'duplicate email mapping'],
-  ['"customer.duplicate_user_link"', 'duplicate user-link mapping'],
-  ['"customer.validation"', 'validation mapping'],
-  ['"customer.profile_unavailable"', 'profile mapping'],
-  ['"customer storage is temporarily unavailable"', 'stable storage message'],
-  ['"customer request is invalid"', 'stable validation message'],
-]) requireText(customer, value, label);
-
-const graphqlCustomerConstructors =
-  commerceQuery.match(/in_process_customer_read_port\(db\.clone\(\)\)/g) ?? [];
-if (graphqlCustomerConstructors.length !== 3) {
-  failures.push(
-    `expected three unchanged commerce GraphQL customer read constructors, found ${graphqlCustomerConstructors.length}`,
-  );
+const constructors = commerceQuery.match(/in_process_customer_read_port\(db\.clone\(\)\)/g) ?? [];
+if (constructors.length !== 3) {
+  failures.push(`expected three unchanged Commerce customer constructors, found ${constructors.length}`);
 }
-for (const [value, label] of [
-  ['"customer.customer_by_user_not_found" => {', 'storefront unauthenticated not-found branch'],
-  [
-    'Err(error) if error.code == "customer.customer_by_user_not_found" => Ok(None)',
-    'optional customer not-found branch',
-  ],
-  ['async_graphql::Error::new(error.message)', 'existing GraphQL fallback mapping'],
-]) requireText(commerceQuery, value, label);
+for (const marker of [
+  '"customer.customer_by_user_not_found" => {',
+  'Err(error) if error.code == "customer.customer_by_user_not_found" => Ok(None)',
+  'async_graphql::Error::new(error.message)',
+]) requireText(commerceQuery, marker, `unchanged compatibility source: ${marker}`);
 
 for (const marker of [
   '# Customer read port policy context',
   'Status: `source_ready_unvalidated`',
-  'bounded context shape',
+  'correlation-ID character length',
+  'raw correlation ID',
   'closed seven-value error-kind label',
   'complete `PortError` is not copied into the event',
   'The original admission `PortError` is returned unchanged.',
@@ -190,7 +155,6 @@ if (failures.length > 0) {
   for (const failure of failures) console.error(`✗ ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
-
 console.log(
-  '✔ Customer read policy admission retains bounded context/error shape and returns the original PortError unchanged',
+  '✔ Customer read policy admission retains correlation length and bounded error shape while returning the original PortError unchanged',
 );


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce correlation-safe diagnostic cleanup at the Customer read boundary.

- replace raw correlation-id emission with correlation-id character length in all five owner read events covering policy admission, list validation, tenant parsing, and owner-error mapping;
- apply the same bounded projection to both canonical in-process wrapper events after owner delegation;
- preserve all four `CustomerReadPort` operations, owner calls, request/response DTOs, policy ordering, validation ordering, tenant parsing, exact local classification, unknown-envelope pass-through, and returned `PortError` values;
- preserve every Customer public code, message, `PortErrorKind`, retryability, and diagnostic severity;
- keep bounded tenant/actor/channel/locale/causation/trace/idempotency and request-shape facts unchanged;
- update the three focused source guards so they require correlation length and fail closed on the previous raw field;
- update Customer and Commerce documentation to close the raw-correlation residual while leaving compile, runtime, remote-adapter, write-side, tax, promotion, inventory, and broader ecommerce work open.

## Recheck

The branch is based directly on `main@1902063ae58812882c1410986a3aae2a5074f1f6`, is one commit ahead and zero behind, and changes exactly nine intended files.

No open Commerce or Customer diagnostic-safety PR overlaps this boundary.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Node verifiers;
- Cargo checks, builds, Clippy, or formatting;
- mounted GraphQL/runtime scenarios;
- workflows or CI.

Suggested maintainer checks:

```bash
node scripts/verify/verify-customer-owner-error-diagnostic-safety.mjs
node scripts/verify/verify-customer-read-policy-context.mjs
node scripts/verify/verify-customer-read-local-context.mjs
node scripts/verify/verify-commerce-graphql-query-customer-error-safety.mjs
cargo check -p rustok-customer --lib
cargo check -p rustok-commerce --lib
```

Source status remains unvalidated. No runtime, FFA, or FBA status is promoted.