### PR TITLE
fix(forum): validate storefront route descriptors

### DIFF
--- a/apps/storefront/src/forum_category_route.rs
+++ b/apps/storefront/src/forum_category_route.rs
@@ -90,10 +90,29 @@ pub(crate) async fn render_forum_category_route_response(
     }
 }
 
-fn safe_owner_path(path: &str) -> bool {
-    path.starts_with('/')
-        && !path.starts_with("//")
-        && !path.chars().any(char::is_control)
+fn safe_route_segment(segment: &str) -> bool {
+    !segment.is_empty()
+        && segment == segment.trim()
+        && !matches!(segment, "." | "..")
+        && !segment.chars().any(|character| {
+            character.is_control()
+                || character.is_whitespace()
+                || matches!(character, '/' | '\\' | '?' | '#' | '%')
+        })
+}
+
+fn valid_category_descriptor(
+    canonical: &rustok_forum_storefront::StorefrontForumCategoryRouteDescriptor,
+) -> bool {
+    let locale = canonical.locale.trim();
+    let slug = canonical.slug.trim();
+
+    !canonical.category_id.trim().is_empty()
+        && canonical.locale == locale
+        && canonical.slug == slug
+        && rustok_api::normalize_locale_tag(locale).as_deref() == Some(locale)
+        && safe_route_segment(slug)
+        && canonical.path == format!("/{locale}/forum/c/{slug}")
 }
 
 fn forum_category_host_action(
@@ -101,11 +120,7 @@ fn forum_category_host_action(
     resolution: &StorefrontForumCategoryRouteResolution,
 ) -> ForumCategoryHostAction {
     let canonical = &resolution.canonical;
-    if canonical.category_id.trim().is_empty()
-        || canonical.locale.trim().is_empty()
-        || canonical.slug.trim().is_empty()
-        || !safe_owner_path(canonical.path.as_str())
-    {
+    if !valid_category_descriptor(canonical) {
         return ForumCategoryHostAction::Invalid;
     }
 
@@ -197,6 +212,18 @@ mod tests {
         protocol_relative.canonical.path = "//example.invalid/forum".to_string();
         let mut header_injection = resolution(StorefrontForumCategoryRouteDisposition::Redirect);
         header_injection.canonical.path = "/en/forum/c/general\r\nX-Test: injected".to_string();
+        let mut internal_target = resolution(StorefrontForumCategoryRouteDisposition::Redirect);
+        internal_target.canonical.path = "/admin".to_string();
+        let mut mismatched_slug = resolution(StorefrontForumCategoryRouteDisposition::Redirect);
+        mismatched_slug.canonical.path = "/en/forum/c/another-category".to_string();
+        let mut query_target = resolution(StorefrontForumCategoryRouteDisposition::Redirect);
+        query_target.canonical.path = "/en/forum/c/general?preview=true".to_string();
+        let mut invalid_locale = resolution(StorefrontForumCategoryRouteDisposition::Redirect);
+        invalid_locale.canonical.locale = "EN".to_string();
+        invalid_locale.canonical.path = "/EN/forum/c/general".to_string();
+        let mut invalid_slug = resolution(StorefrontForumCategoryRouteDisposition::Redirect);
+        invalid_slug.canonical.slug = "../admin".to_string();
+        invalid_slug.canonical.path = "/en/forum/c/../admin".to_string();
 
         for resolution in [
             missing_path,
@@ -204,6 +231,11 @@ mod tests {
             external_target,
             protocol_relative,
             header_injection,
+            internal_target,
+            mismatched_slug,
+            query_target,
+            invalid_locale,
+            invalid_slug,
         ] {
             assert_eq!(
                 forum_category_host_action("/en/forum/c/general", &resolution),

--- a/apps/storefront/src/forum_topic_route.rs
+++ b/apps/storefront/src/forum_topic_route.rs
@@ -98,10 +98,35 @@ pub(crate) async fn render_forum_topic_route_response(
     }
 }
 
-fn safe_owner_path(path: &str) -> bool {
-    path.starts_with('/')
-        && !path.starts_with("//")
-        && !path.chars().any(char::is_control)
+fn safe_route_segment(segment: &str) -> bool {
+    !segment.is_empty()
+        && segment == segment.trim()
+        && !matches!(segment, "." | "..")
+        && !segment.chars().any(|character| {
+            character.is_control()
+                || character.is_whitespace()
+                || matches!(character, '/' | '\\' | '?' | '#' | '%')
+        })
+}
+
+fn valid_topic_descriptor(
+    canonical: &rustok_forum_storefront::StorefrontForumTopicRouteDescriptor,
+) -> bool {
+    let locale = canonical.locale.trim();
+    let short_id = canonical.short_id.trim();
+    let slug = canonical.slug.trim();
+
+    !canonical.topic_id.trim().is_empty()
+        && canonical.locale == locale
+        && canonical.short_id == short_id
+        && canonical.slug == slug
+        && rustok_api::normalize_locale_tag(locale).as_deref() == Some(locale)
+        && short_id.len() == 12
+        && short_id
+            .bytes()
+            .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
+        && safe_route_segment(slug)
+        && canonical.path == format!("/{locale}/forum/t/{short_id}/{slug}")
 }
 
 fn forum_topic_host_action(
@@ -133,16 +158,6 @@ fn forum_topic_host_action(
         }
         _ => ForumTopicHostAction::Invalid,
     }
-}
-
-fn valid_topic_descriptor(
-    canonical: &rustok_forum_storefront::StorefrontForumTopicRouteDescriptor,
-) -> bool {
-    !canonical.topic_id.trim().is_empty()
-        && !canonical.locale.trim().is_empty()
-        && !canonical.short_id.trim().is_empty()
-        && !canonical.slug.trim().is_empty()
-        && safe_owner_path(canonical.path.as_str())
 }
 
 #[cfg(test)]
@@ -239,6 +254,24 @@ mod tests {
         header_injection.path = "/en/forum/t/123456789abc/welcome\r\nX-Test: injected".to_string();
         let mut missing_identity = descriptor();
         missing_identity.topic_id.clear();
+        let mut internal_target = descriptor();
+        internal_target.path = "/admin".to_string();
+        let mut mismatched_slug = descriptor();
+        mismatched_slug.path = "/en/forum/t/123456789abc/another-topic".to_string();
+        let mut query_target = descriptor();
+        query_target.path = "/en/forum/t/123456789abc/welcome?preview=true".to_string();
+        let mut invalid_locale = descriptor();
+        invalid_locale.locale = "EN".to_string();
+        invalid_locale.path = "/EN/forum/t/123456789abc/welcome".to_string();
+        let mut uppercase_short_id = descriptor();
+        uppercase_short_id.short_id = "123456789ABC".to_string();
+        uppercase_short_id.path = "/en/forum/t/123456789ABC/welcome".to_string();
+        let mut short_short_id = descriptor();
+        short_short_id.short_id = "1234".to_string();
+        short_short_id.path = "/en/forum/t/1234/welcome".to_string();
+        let mut invalid_slug = descriptor();
+        invalid_slug.slug = "../admin".to_string();
+        invalid_slug.path = "/en/forum/t/123456789abc/../admin".to_string();
 
         for resolution in [
             resolution(StorefrontForumTopicRouteDisposition::Gone, Some(descriptor())),
@@ -256,6 +289,34 @@ mod tests {
             resolution(
                 StorefrontForumTopicRouteDisposition::Canonical,
                 Some(missing_identity),
+            ),
+            resolution(
+                StorefrontForumTopicRouteDisposition::Redirect,
+                Some(internal_target),
+            ),
+            resolution(
+                StorefrontForumTopicRouteDisposition::Redirect,
+                Some(mismatched_slug),
+            ),
+            resolution(
+                StorefrontForumTopicRouteDisposition::Redirect,
+                Some(query_target),
+            ),
+            resolution(
+                StorefrontForumTopicRouteDisposition::Redirect,
+                Some(invalid_locale),
+            ),
+            resolution(
+                StorefrontForumTopicRouteDisposition::Redirect,
+                Some(uppercase_short_id),
+            ),
+            resolution(
+                StorefrontForumTopicRouteDisposition::Redirect,
+                Some(short_short_id),
+            ),
+            resolution(
+                StorefrontForumTopicRouteDisposition::Redirect,
+                Some(invalid_slug),
             ),
         ] {
             assert_eq!(


### PR DESCRIPTION
## Summary

Static recheck of the merged FORUM-24 storefront route mounts found that the host accepted any root-relative `canonical.path` supplied by a category or topic transport descriptor. A structurally inconsistent descriptor could therefore select an unrelated internal redirect target instead of failing closed.

This PR:

- validates category descriptor locale and slug fields before render or redirect;
- requires the category path to equal `/{locale}/forum/c/{slug}` exactly;
- validates topic locale, twelve-character lowercase hexadecimal short identity, and slug fields;
- requires the topic path to equal `/{locale}/forum/t/{short_id}/{slug}` exactly;
- rejects internal path substitution, descriptor/path mismatches, query injection, noncanonical locale/short-id forms, traversal-like segments, protocol-relative/external paths, and header controls;
- preserves canonical render, historical alias redirect, authorized gone, not-found, visibility, channel, SEO, and owner route behavior.

## Recheck

- based directly on `main@4c7aa1a1c7907841a3507438e29af155e3e2a13c`;
- two intended files changed;
- zero commits behind `main` at PR creation;
- no schema, migration, transport DTO, route-owner, Search, or event changes.

## Validation

Not run per maintainer instruction:

- Rust unit tests;
- Cargo check, formatting, or Clippy;
- Node verifiers;
- HTTP/browser scenarios;
- workflows or CI.

Suggested maintainer commands:

```bash
cargo test -p rustok-storefront forum_category_route -- --nocapture
cargo test -p rustok-storefront forum_topic_route -- --nocapture
cargo check -p rustok-storefront --features ssr
```

The canonical FORUM-24 ledger remains stale relative to merged A-S slices; this corrective PR does not replace or duplicate the authoritative roadmap.