### PR TITLE
docs(module-template): define Index compatibility contract

### DIFF
--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -26,6 +26,7 @@ This directory contains the detailed technical architecture documentation for `r
 
 ## Reference Documents
 
+- [Source Module Integration Contract](./module-source-integration.md)
 - [Live Implementation Plan](./implementation-plan.md)
 - [M5/M6 Source Replay Contract](./m5-m6-source-replay-contract.md)
 - [M6 Explicit Source Absence Watermark](./m6-explicit-source-absence-watermark.md)

--- a/crates/rustok-index/docs/module-source-integration.md
+++ b/crates/rustok-index/docs/module-source-integration.md
@@ -1,0 +1,448 @@
+# Integrating a source module with `rustok-index`
+
+This document is the normative integration guide for an in-repository/native
+RusToK module that wants its domain data materialized and queried through
+`rustok-index`.
+
+The Index engine is domain-neutral. It must not depend on the source module,
+read the source module's tables directly, or accept direct writes from the
+source module into Index-owned tables. The source module or its distribution
+bridge owns conversion from authoritative domain state into the generic Index
+contracts.
+
+## Important boundary: native modules versus standalone components
+
+This guide applies to native Rust modules selected into the server distribution.
+A standalone `wasm32-wasip2` component produced by `rustok-module-template`
+cannot link `rustok-index`, register runtime extensions, access PostgreSQL, or
+claim Index compatibility merely by publishing `platform.events` messages.
+
+A standalone component requires a separately admitted host-owned broker
+capability or event-to-Index bridge. No `platform.index` capability exists in
+the current component ABI. Until such a boundary is implemented and documented,
+standalone modules must treat Index integration as unavailable rather than
+inventing a private payload contract.
+
+## Compatibility levels
+
+A module should state the highest level it implements.
+
+| Level | Required contribution | Available behavior |
+| --- | --- | --- |
+| Schema | Versioned `IndexSchema` registration | Query planning and validation after data exists |
+| Replay | Schema plus bounded `IndexSource::scan` and `load` | Initial build, rebuild, targeted reload |
+| Incremental | Replay plus stable `IndexMutation` delivery | Ongoing updates without full rebuild |
+| Drift-aware | Incremental plus authoritative absence/version evidence | Diagnosis and reconciliation |
+| Repair-ready | Drift-aware plus admitted owner semantics and retained evidence | Targeted repair where supported |
+
+Registering only a schema does not populate data. Implementing replay without
+incremental delivery means the Index can be rebuilt but may become stale between
+rebuilds.
+
+## Recommended source-module layout
+
+Keep Index-specific conversion at the module boundary instead of mixing it into
+the domain model.
+
+```text
+src/
+  domain/
+  application/
+  infrastructure/
+  index/
+    mod.rs
+    schema.rs
+    record.rs
+    source.rs
+    events.rs
+    absence.rs        # only when authoritative absence is supported
+
+tests/
+  index_contract.rs
+  index_postgres.rs   # environment-gated when PostgreSQL evidence is required
+```
+
+A distribution-owned bridge is also valid when the domain crate must not depend
+on `rustok-index`. The existing Product integration follows that model: the
+bridge registers schemas and PostgreSQL source factories only when Product is
+selected.
+
+## 1. Publish a stable schema
+
+Every indexed entity requires a versioned `IndexSchema`. The complete schema
+identity consists of its module namespace, entity name, and schema version.
+
+```rust
+use rustok_index::{
+    EntityName, FieldCardinality, FieldName, IndexField, IndexSchema,
+    IndexValueType, LocaleMode, ModuleName, SchemaRef, SchemaVersion,
+};
+
+fn listing_schema_v1() -> Result<IndexSchema, rustok_index::DomainError> {
+    let schema = IndexSchema {
+        reference: SchemaRef {
+            module: ModuleName::new("classifieds")?,
+            entity: EntityName::new("listing")?,
+            version: SchemaVersion::new(1),
+        },
+        locale_mode: LocaleMode::None,
+        fields: vec![
+            IndexField {
+                name: FieldName::new("id")?,
+                value_type: IndexValueType::Uuid,
+                cardinality: FieldCardinality::One,
+                nullable: false,
+                selectable: true,
+                filterable: true,
+                sortable: true,
+            },
+            IndexField {
+                name: FieldName::new("title")?,
+                value_type: IndexValueType::String,
+                cardinality: FieldCardinality::One,
+                nullable: false,
+                selectable: true,
+                filterable: true,
+                sortable: true,
+            },
+            IndexField {
+                name: FieldName::new("price_minor")?,
+                value_type: IndexValueType::Integer,
+                cardinality: FieldCardinality::One,
+                nullable: false,
+                selectable: true,
+                filterable: true,
+                sortable: true,
+            },
+        ],
+        links: Vec::new(),
+    };
+    schema.validate()?;
+    Ok(schema)
+}
+```
+
+Register schemas during module/distribution composition:
+
+```rust
+use rustok_core::ModuleRuntimeExtensions;
+use rustok_index::register_index_schema_source;
+
+pub fn register_index_contracts(
+    extensions: &mut ModuleRuntimeExtensions,
+) -> rustok_core::Result<()> {
+    register_index_schema_source(
+        extensions,
+        "classifieds",
+        listing_schema_v1().map_err(|error| {
+            rustok_core::Error::Validation(format!(
+                "classifieds Index schema is invalid: {error}"
+            ))
+        })?,
+    )
+    .map_err(|error| {
+        rustok_core::Error::Validation(format!(
+            "classifieds Index schema registration failed: {error}"
+        ))
+    })?;
+    Ok(())
+}
+```
+
+### Schema rules
+
+A compatible module MUST:
+
+- use a stable lowercase owner slug;
+- keep one owner for every version of one schema identity;
+- create a new schema version for semantic field/link changes;
+- validate the schema before or during registration;
+- mark only genuinely supported fields as selectable, filterable, or sortable;
+- use a locale mode that matches the authoritative identity model;
+- keep field and link types stable within a schema version.
+
+A compatible module MUST NOT:
+
+- reuse one schema version for a changed contract;
+- split versions of one entity between different owners;
+- register a link to a schema that is absent from the selected distribution;
+- expose confidential fields merely because the storage model can hold them.
+
+## 2. Convert authoritative state into generic records
+
+Keep conversion deterministic and side-effect free. Given the same authoritative
+row and schema version, conversion must produce the same key, fields, links, and
+source version.
+
+```rust
+fn listing_record(row: &ListingRow) -> Result<rustok_index::IndexRecord, ListingIndexError> {
+    // Convert the domain row into the generic Index envelope here.
+    // Do not query Index storage or mutate domain state from this function.
+    todo!()
+}
+```
+
+The record identity MUST include the exact tenant, schema, entity identity, and
+locale identity required by the schema. Links MUST represent the complete link
+set for that source version because a normal upsert replaces the materialized
+state for the entity.
+
+## 3. Implement bounded replay and targeted load
+
+`IndexSource` is the database-neutral source-owner boundary.
+
+```rust
+use async_trait::async_trait;
+use rustok_index::{
+    IndexSource, IndexSourceFailure, IndexSourceLoadBatch,
+    IndexSourceLoadRequest, IndexSourcePage, IndexSourceScanRequest,
+};
+
+struct ClassifiedsIndexSource {
+    // Usually an owner database/repository handle.
+}
+
+#[async_trait]
+impl IndexSource for ClassifiedsIndexSource {
+    async fn scan(
+        &self,
+        request: IndexSourceScanRequest,
+    ) -> Result<IndexSourcePage, IndexSourceFailure> {
+        // Use a bounded deterministic keyset scan owned by this module.
+        // The returned cursor is opaque to Index but must advance.
+        todo!()
+    }
+
+    async fn load(
+        &self,
+        request: IndexSourceLoadRequest,
+    ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+        // Load only the exact requested keys from the authoritative source.
+        todo!()
+    }
+}
+```
+
+The engine validates the generic boundary, but the source remains responsible
+for authoritative semantics.
+
+### `scan` requirements
+
+`scan` MUST:
+
+- remain within the requested tenant and exact schema;
+- return no more than the requested limit;
+- use deterministic keyset ordering;
+- return unique entity keys;
+- return a non-null bounded cursor only when another page exists;
+- advance the cursor whenever a continuation is returned;
+- return no continuation for an empty final page;
+- classify transient failures as retryable and invariant/data failures as
+  permanent.
+
+`scan` MUST NOT use an unbounded offset walk, return another tenant, or expose
+raw credentials in its cursor.
+
+### `load` requirements
+
+`load` MUST:
+
+- load only the exact requested keys;
+- return no duplicate key;
+- return no more mutations than requested keys;
+- preserve the request tenant/schema scope;
+- distinguish a current entity, a retained deletion/tombstone, and an unknown or
+  not-authoritatively-proven absence according to the source contract.
+
+A missing SQL row by itself is not automatically an authoritative deletion
+proof.
+
+## 4. Register the source or PostgreSQL source factory
+
+For an already materialized source object:
+
+```rust
+rustok_index::register_index_source(
+    extensions,
+    "classifieds",
+    "classifieds-listing-primary",
+    [listing_schema_ref_v1()],
+    ClassifiedsIndexSource::new(repository),
+)?;
+```
+
+When the database connection exists only during server composition, register a
+`PostgresIndexSourceFactory` instead. The factory should create the concrete
+source from the host-owned connection and then call the same generic source
+registration boundary.
+
+Owner slug, source name, and schema ownership must match exactly. One schema can
+have only one replay source, and all versions of one schema identity must remain
+with the same owner/source pair.
+
+## 5. Publish incremental mutations
+
+Replay is not a replacement for ongoing ingestion. Every committed domain
+change that affects indexed state should produce one generic mutation delivery
+through the admitted event/outbox path.
+
+A mutation delivery requires:
+
+- a stable delivery/event UUID;
+- the exact tenant and schema reference;
+- the exact entity key and locale identity;
+- a monotonic source version;
+- a complete record for upsert or an explicit delete/tombstone;
+- complete links for the admitted version;
+- commit-before-ack behavior.
+
+The same logical event MUST reuse the same delivery UUID on retry. A delivery
+UUID MUST NOT be reused for a different payload. The Index inbox treats exact
+redelivery as idempotent and rejects identity reuse with changed content.
+
+### Source version
+
+Use an authoritative version that advances whenever indexed state changes. It
+must not be derived from wall-clock time unless the source can prove strict
+monotonicity for the complete entity identity.
+
+Good sources include:
+
+- a transactionally incremented revision;
+- an append-only sequence position;
+- a source-owned durable version column.
+
+Do not use random numbers or process-local counters.
+
+### Deletes
+
+Deletion MUST be retained as an explicit mutation/tombstone with a source
+version newer than the last live version. Hard-deleting the source row without
+retained version evidence prevents safe reconciliation and repair.
+
+## 6. Cross-module links
+
+Index schemas may link to schemas owned by other selected modules.
+
+```text
+classifieds.listing.seller
+    -> identity.user.id
+```
+
+A cross-module link requires:
+
+- the target schema to be registered in the same materialized catalog;
+- compatible source and target field types;
+- stable target identity;
+- defined behavior when the target module is not selected;
+- defined behavior when the target entity is deleted;
+- complete ordered values when cardinality is `many`.
+
+The source module owns the link contribution. The target module does not write
+into the source module's Index record.
+
+## 7. Absence, diagnosis, and repair readiness
+
+Drift-aware integration requires more than replay.
+
+The source owner must be able to prove:
+
+- the exact current source version when an entity exists;
+- an explicit absence/tombstone watermark when it is authoritatively deleted;
+- stable link identity and target authority for orphan-link diagnosis;
+- that evidence was read within the documented consistency boundary.
+
+Do not advertise repair readiness until the concrete owner path and PostgreSQL
+evidence have been admitted. Generic registration alone does not make a module
+repair-ready.
+
+## 8. Distribution composition
+
+A typical bridge should register only when its source module is selected.
+
+```rust
+pub(crate) fn register(
+    extensions: &mut rustok_core::ModuleRuntimeExtensions,
+) -> rustok_core::Result<()> {
+    if !extensions.contains::<ClassifiedsRuntimeSelected>() {
+        return Ok(());
+    }
+
+    register_listing_schemas(extensions)?;
+    register_listing_source_factory(extensions)?;
+    register_listing_absence_provider(extensions)?; // optional level
+    Ok(())
+}
+```
+
+The server materializes and freezes the complete schema/source catalogs after
+all selected modules have contributed. Registration is therefore a startup
+composition contract, not hot-plug discovery.
+
+## 9. Required tests
+
+At minimum, add contract tests for:
+
+- schema validation and stable fingerprint;
+- owner/source conflict rejection;
+- deterministic record conversion;
+- bounded scan page size and cursor progression;
+- targeted load scope and duplicate rejection;
+- monotonic source versions;
+- exact redelivery idempotency;
+- delete/tombstone retention;
+- link type/cardinality correctness;
+- selection gating in distribution composition.
+
+For production PostgreSQL adapters, add environment-gated evidence for real
+migrations, replay, redelivery, deletion, restart, and any claimed drift/repair
+behavior. Never replace production persistence with a fake store while claiming
+PostgreSQL admission.
+
+## 10. Compatibility checklist
+
+### Required for schema compatibility
+
+- [ ] Stable owner slug
+- [ ] Versioned validated `IndexSchema`
+- [ ] Correct locale mode
+- [ ] Supported field capabilities only
+- [ ] Cross-module targets present and type-compatible
+
+### Required for replay compatibility
+
+- [ ] Bounded deterministic `scan`
+- [ ] Exact bounded `load`
+- [ ] Stable opaque cursor
+- [ ] Retryable/permanent failure classification
+- [ ] Source registration or PostgreSQL source factory
+
+### Required for incremental compatibility
+
+- [ ] Stable delivery UUID
+- [ ] Monotonic source version
+- [ ] Complete upsert record and links
+- [ ] Explicit delete/tombstone
+- [ ] Commit-before-ack orchestration
+
+### Required before claiming drift or repair readiness
+
+- [ ] Authoritative absence/version evidence
+- [ ] Retained PostgreSQL execution evidence
+- [ ] Crash/redelivery behavior admitted
+- [ ] Owner authorization and recovery policy admitted
+- [ ] No direct public or automatic repair surface beyond the admitted boundary
+
+## Prohibited shortcuts
+
+A module is not Index-compatible if it:
+
+- writes directly to `index_entities`, `index_links`, `index_inbox`, jobs, or
+  findings tables;
+- asks `rustok-index` to query source-domain tables directly;
+- emits unstable event IDs or non-monotonic source versions;
+- treats a missing row as proven deletion without an owner contract;
+- registers different owners/sources for versions of one schema identity;
+- claims standalone component compatibility through `platform.events` without
+  an admitted host bridge;
+- bypasses schema validation, tenant scope, or authorization.

--- a/crates/rustok-module-template/README.md
+++ b/crates/rustok-module-template/README.md
@@ -11,8 +11,21 @@ component source tree used by owner-local CLI authoring flows.
 - Render a strict source manifest, native WASI P2 project, pinned Rust
   toolchain, dependency policy, tests, localization, schemas, and a brokered
   capability example.
+- Render an Index compatibility guide that distinguishes standalone Component
+  Model modules from native server modules and fails closed while no admitted
+  `platform.index` or event-to-Index bridge exists.
 - Validate the rendered source manifest and bounded local sandbox scenario
   through their canonical contracts before returning files.
+
+## Index boundary
+
+The generated crate is a standalone `wasm32-wasip2` component. It must not
+link the host's `rustok-index` crate, access PostgreSQL, register
+`ModuleRuntimeExtensions`, or treat `platform.events` publication as automatic
+indexing. Native source-module integration is documented in
+`../rustok-index/docs/module-source-integration.md`; generated components receive
+`docs/index-integration.md` with the standalone boundary and readiness
+checklist.
 
 ## Interactions
 

--- a/crates/rustok-module-template/assets/README.md.template
+++ b/crates/rustok-module-template/assets/README.md.template
@@ -16,3 +16,17 @@ through declared brokered capabilities.
 The build worker derives `module-artifact-descriptor.json` after it verifies
 the Component payload. Source code must never create that final descriptor or
 declare `artifact_digest`.
+
+## Index compatibility
+
+`platform.events` is a constrained event broker, not an automatic Index bridge.
+This standalone component cannot depend on the host's `rustok-index` crate,
+register `ModuleRuntimeExtensions`, access PostgreSQL, or write Index-owned
+tables. Do not declare Index compatibility until the host publishes a documented
+and admitted capability or event-to-Index bridge.
+
+Read the generated integration boundary guide:
+
+```text
+docs/index-integration.md
+```

--- a/crates/rustok-module-template/assets/docs/index-integration.md.template
+++ b/crates/rustok-module-template/assets/docs/index-integration.md.template
@@ -1,0 +1,123 @@
+# Index integration for `{{slug}}`
+
+This generated project is a standalone RusToK Component Model module. It is not
+an in-process Rust module and does not link the host's `rustok-index` crate.
+
+## Current compatibility status
+
+The component receives platform access only through the single broker import
+provided by `rustok-module-sdk`:
+
+```rust
+rustok_module_sdk::rustok::module::host::invoke(
+    capability,
+    operation,
+    json_input,
+)
+```
+
+The current component ABI does not publish a `platform.index` capability. The
+example `platform.events/publish` call in `src/lib.rs` demonstrates a constrained
+event capability only. Publishing an event does **not** automatically register
+an Index schema, populate Index storage, provide replay, or make the module
+repair-ready.
+
+Do not add `rustok-index` to this crate's dependencies. A standalone component
+has no ambient PostgreSQL access, no `ModuleRuntimeExtensions`, and no right to
+write Index-owned tables.
+
+## When Index integration becomes available
+
+A standalone component can participate only after the host provides and admits
+one of these explicit boundaries:
+
+1. a typed broker capability dedicated to Index schema, replay, and mutation
+   operations; or
+2. a documented host-owned event-to-Index bridge with a versioned payload
+   contract and retained execution evidence.
+
+Until one of those boundaries exists, treat direct Index integration as
+unsupported. Do not invent private event payloads and call them Index mutations.
+
+## Data contract to prepare in advance
+
+Even before a host bridge exists, design domain state so it can satisfy the
+future Index contract without destructive migration.
+
+For every entity intended for indexing, define:
+
+- a stable entity type and identifier;
+- the exact tenant identity;
+- a versioned schema identity;
+- a monotonic source version that advances on every indexed change;
+- a stable event/delivery UUID reused on retry;
+- a complete upsert representation;
+- an explicit delete/tombstone representation;
+- complete ordered link values;
+- a bounded deterministic replay cursor;
+- an exact targeted-load operation;
+- authoritative absence evidence when deletion diagnosis is required.
+
+Wall-clock timestamps are not automatically valid source versions. Random IDs
+are not valid source versions. A missing data row is not automatically proof of
+deletion.
+
+## Safe use of `platform.events`
+
+The template publishes this example topic:
+
+```text
+module.{{slug}}.executed
+```
+
+Use module-owned topics for domain notifications only when they are declared in
+`module-artifact.json` and granted by policy. Keep the event payload versioned
+and deterministic, but do not imply that it is consumed by Index unless the
+host bridge documentation names the exact topic and payload version.
+
+Example application-level payload shape:
+
+```json
+{
+  "schema_version": 1,
+  "event_id": "00000000-0000-0000-0000-000000000000",
+  "entity_type": "listing",
+  "entity_id": "00000000-0000-0000-0000-000000000000",
+  "source_version": "42",
+  "change": "updated"
+}
+```
+
+This is only an example domain event envelope. It is deliberately **not** a
+canonical Index mutation contract.
+
+## Native module integration
+
+When the implementation is an in-repository native Rust module selected into
+the server distribution, use the host integration guide instead:
+
+```text
+crates/rustok-index/docs/module-source-integration.md
+```
+
+That path registers versioned `IndexSchema` contracts, bounded `IndexSource`
+replay/load adapters, incremental `IndexMutation` deliveries, and optional
+absence/repair evidence through host-owned composition.
+
+## Standalone compatibility checklist
+
+Before claiming that this component works with Index, require all of the
+following:
+
+- [ ] A documented host capability or event bridge exists.
+- [ ] The capability is declared in `module-artifact.json`.
+- [ ] Runtime policy grants the exact operations and scopes.
+- [ ] Schema identity and versioning are documented.
+- [ ] Delivery UUID and source-version rules are documented.
+- [ ] Upsert, delete, links, replay, and targeted load are defined.
+- [ ] Tenant and authorization boundaries are explicit.
+- [ ] Redelivery and crash behavior have retained evidence.
+- [ ] The host, not the guest, owns PostgreSQL and Index table access.
+
+Without those conditions, the correct status is: **Index integration not yet
+available for this standalone component**.

--- a/crates/rustok-module-template/assets/src/lib.rs.template
+++ b/crates/rustok-module-template/assets/src/lib.rs.template
@@ -2,6 +2,10 @@ struct Module;
 
 impl rustok_module_sdk::Guest for Module {
     fn run(input: String) -> Result<String, String> {
+        // This is a brokered domain event example only. It does not register an
+        // Index schema, write Index storage, or provide replay/load semantics.
+        // See `docs/index-integration.md` in the template documentation before
+        // claiming compatibility with the host-owned `rustok-index` engine.
         let event = [
             "{\"topic\":\"module.{{slug}}.executed\",\"payload\":",
             input.as_str(),

--- a/crates/rustok-module-template/docs/README.md
+++ b/crates/rustok-module-template/docs/README.md
@@ -19,4 +19,23 @@ component digest into the final descriptor after Component and WIT inspection.
 sandbox limits, and the expected output. The guest publishes
 `module.<slug>.executed` with `{topic, payload}` input, so the example passes the
 same Events capability constraint validator as an admitted runtime execution.
-The renderer validates this scenario before returning the file set.
+
+## Index compatibility boundary
+
+Every rendered project includes `docs/index-integration.md`. The guide records
+that the generated project is a standalone Component Model guest and therefore
+cannot directly depend on `rustok-index`, register host runtime extensions,
+access PostgreSQL, or write Index-owned storage.
+
+The current component ABI exposes no `platform.index` capability. The Events
+example is intentionally not presented as an Index mutation contract. A future
+standalone integration must be host-owned, versioned, capability-constrained,
+and admitted before the template can generate executable Index-specific code.
+
+Native in-repository modules use the separate host integration contract in
+`crates/rustok-index/docs/module-source-integration.md`.
+
+The renderer validates the sandbox scenario and renders the Index boundary
+guide before returning the ordered file set. The static verifier additionally
+rejects a direct `rustok-index` dependency or an invented `platform.index`
+capability in the standalone template.

--- a/crates/rustok-module-template/docs/implementation-plan.md
+++ b/crates/rustok-module-template/docs/implementation-plan.md
@@ -6,6 +6,10 @@ Own the independently versioned canonical Rust component project template.
 Filesystem mutation, Cargo execution, builds, publication, admission, and
 runtime execution remain outside this crate.
 
+The template may document host integration boundaries, but it must not invent
+host capabilities or link host-only crates into a standalone Component Model
+guest.
+
 ## Current State
 
 - [x] Render a standalone Rust edition 2024 `cdylib` project targeting native
@@ -17,13 +21,20 @@ runtime execution remain outside this crate.
 - [x] Validate the rendered source manifest through the owner contract.
 - [x] Render and validate a bounded local Component sandbox scenario with an
   exact Events grant, fixture response, input, limits, and expected output.
+- [x] Render an Index compatibility guide that distinguishes standalone guests
+  from native source modules and rejects direct `rustok-index`/PostgreSQL access.
+- [x] Guard the absence of an invented `platform.index` capability while no
+  admitted standalone Index broker contract exists.
 - [x] Connect create-new writes and lockfile generation through the owner-local
   `rustok module init` CLI provider.
 - [ ] Compile the rendered fixture with the pinned native component target in
   isolated CI evidence.
+- [ ] Add executable standalone Index integration only after a host-owned,
+  versioned, capability-constrained broker contract is implemented and admitted.
 
 ## Completion Condition
 
 The template is complete when the canonical CLI creates a locked standalone
-project and isolated CI proves that the exact rendered fixture exports only the
-admitted WIT surface.
+project, generated documentation accurately describes every available host
+boundary, and isolated CI proves that the exact rendered fixture exports only
+the admitted WIT surface.

--- a/crates/rustok-module-template/src/lib.rs
+++ b/crates/rustok-module-template/src/lib.rs
@@ -11,6 +11,8 @@ const JSON_SCHEMA_DRAFT_2020_12: &str = "https://json-schema.org/draft/2020-12/s
 const CARGO_TEMPLATE: &str = include_str!("../assets/Cargo.toml.template");
 const LIB_TEMPLATE: &str = include_str!("../assets/src/lib.rs.template");
 const README_TEMPLATE: &str = include_str!("../assets/README.md.template");
+const INDEX_INTEGRATION_GUIDE_TEMPLATE: &str =
+    include_str!("../assets/docs/index-integration.md.template");
 const TOOLCHAIN_TEMPLATE: &str = include_str!("../assets/rust-toolchain.toml.template");
 const BUILD_POLICY: &str = include_str!("../assets/module-build-policy.toml");
 const CONTRACT_TEST: &str = include_str!("../assets/tests/contract.rs");
@@ -92,6 +94,10 @@ pub fn render(input: &ModuleTemplateInput) -> Result<RenderedModule, ModuleTempl
     let files = vec![
         text_file("Cargo.toml", render_text(CARGO_TEMPLATE, &replacements)?),
         text_file("README.md", render_text(README_TEMPLATE, &replacements)?),
+        text_file(
+            "docs/index-integration.md",
+            render_text(INDEX_INTEGRATION_GUIDE_TEMPLATE, &replacements)?,
+        ),
         text_file("src/lib.rs", render_text(LIB_TEMPLATE, &replacements)?),
         text_file(
             "rust-toolchain.toml",
@@ -259,6 +265,24 @@ mod tests {
             .expect("UTF-8 source");
         assert!(source.contains("module.sample_module.executed"));
         assert!(source.contains("\\\"topic\\\""));
+        assert!(source.contains("does not register an"));
+        assert!(!cargo.contains("rustok-index"));
+    }
+
+    #[test]
+    fn rendered_project_documents_the_fail_closed_index_boundary() {
+        let rendered = render(&input()).expect("render template");
+        let guide = std::str::from_utf8(
+            rendered
+                .file("docs/index-integration.md")
+                .expect("Index integration guide"),
+        )
+        .expect("UTF-8 Index integration guide");
+        assert!(guide.contains("standalone RusToK Component Model module"));
+        assert!(guide.contains("does not publish a `platform.index` capability"));
+        assert!(guide.contains("module.sample_module.executed"));
+        assert!(guide.contains("Index integration not yet"));
+        assert!(!guide.contains("{{"));
     }
 
     #[test]

--- a/docs/modules/_template/_index.md
+++ b/docs/modules/_template/_index.md
@@ -26,5 +26,6 @@ Describe the domain and responsibilities of this module.
 - [Queries](./queries.md)
 - [Events](./events.md)
 - [Storage](./storage.md)
+- [Index integration](./indexing.md)
 - [Workflows](./workflows.md)
 - [Testing](./testing.md)

--- a/docs/modules/_template/indexing.md
+++ b/docs/modules/_template/indexing.md
@@ -1,0 +1,126 @@
+---
+id: doc://docs/modules/_template/indexing.md
+kind: integration_contract
+language: markdown
+last_verified_snapshot: snap_jsonl_00000021
+source_language: markdown
+status: draft
+---
+# Index integration
+
+Use this document to state whether the module participates in `rustok-index`
+and which compatibility level is implemented.
+
+## Module form
+
+Choose exactly one:
+
+- [ ] Native in-repository module selected into the server distribution
+- [ ] Standalone `wasm32-wasip2` component
+
+A standalone component cannot directly depend on `rustok-index`, access
+PostgreSQL, register `ModuleRuntimeExtensions`, or claim that
+`platform.events` publication is automatic indexing. Record the admitted host
+capability or event bridge here; otherwise state that Index integration is not
+available.
+
+## Compatibility level
+
+Choose the highest completed level:
+
+- [ ] No Index integration
+- [ ] Schema/query compatible
+- [ ] Replay compatible
+- [ ] Incremental compatible
+- [ ] Drift-aware
+- [ ] Repair-ready
+
+## Native registration
+
+Document:
+
+- owner module slug;
+- every versioned `SchemaRef`;
+- registration entry point;
+- replay source or PostgreSQL source factory;
+- selected-distribution gate;
+- cross-module target schemas.
+
+Reference implementation contract:
+
+```text
+crates/rustok-index/docs/module-source-integration.md
+```
+
+## Schema contract
+
+For each indexed entity, record:
+
+- schema identity and version;
+- locale mode;
+- selectable/filterable/sortable fields;
+- field types and cardinality;
+- links and target schemas;
+- confidentiality restrictions;
+- schema migration/versioning policy.
+
+## Replay and targeted load
+
+Document:
+
+- deterministic scan order;
+- cursor representation and bounds;
+- maximum page size;
+- targeted-load key limit;
+- retryable and permanent failures;
+- authoritative deletion/absence behavior.
+
+## Incremental ingestion
+
+Document:
+
+- stable event/delivery UUID derivation;
+- monotonic source-version source;
+- complete upsert payload;
+- delete/tombstone retention;
+- link replacement semantics;
+- commit-before-ack path;
+- redelivery and payload-reuse behavior.
+
+## Drift and repair
+
+Document only admitted behavior:
+
+- current-version evidence;
+- explicit absence watermark;
+- link/target authority;
+- authorization boundary;
+- recovery policy;
+- retained PostgreSQL evidence;
+- public or automatic surfaces, when admitted.
+
+## Prohibited shortcuts
+
+Confirm that the module does not:
+
+- [ ] write Index-owned tables directly;
+- [ ] require Index to read source-domain tables directly;
+- [ ] use unstable delivery IDs;
+- [ ] use non-monotonic source versions;
+- [ ] treat a missing row as proven deletion without an owner contract;
+- [ ] invent a standalone `platform.index` capability;
+- [ ] describe an ordinary Events message as an Index mutation without an
+      admitted bridge.
+
+## Verification
+
+List contract tests and retained evidence for the claimed level:
+
+- schema/fingerprint:
+- scan/load bounds:
+- redelivery:
+- deletion:
+- cross-module links:
+- PostgreSQL:
+- restart/crash windows:
+- authorization/recovery:

--- a/scripts/verify/verify-module-template.mjs
+++ b/scripts/verify/verify-module-template.mjs
@@ -12,6 +12,14 @@ const cargoTemplate = fs.readFileSync(
   path.join(templateRoot, 'assets/Cargo.toml.template'),
   'utf8',
 );
+const readmeTemplate = fs.readFileSync(
+  path.join(templateRoot, 'assets/README.md.template'),
+  'utf8',
+);
+const indexIntegrationGuide = fs.readFileSync(
+  path.join(templateRoot, 'assets/docs/index-integration.md.template'),
+  'utf8',
+);
 const guestTemplate = fs.readFileSync(
   path.join(templateRoot, 'assets/src/lib.rs.template'),
   'utf8',
@@ -32,6 +40,10 @@ const sdkManifest = fs.readFileSync(
   path.join(root, 'crates/rustok-module-sdk/Cargo.toml'),
   'utf8',
 );
+const nativeIndexGuide = fs.readFileSync(
+  path.join(root, 'crates/rustok-index/docs/module-source-integration.md'),
+  'utf8',
+);
 
 for (const marker of [
   'ModuleArtifactSourceManifest::parse(&bytes)',
@@ -42,6 +54,8 @@ for (const marker of [
   'pub const TEMPLATE_VERSION: &str = env!("CARGO_PKG_VERSION")',
   'pub const RUST_TOOLCHAIN: &str = "1.96.0"',
   'LocalSandboxScenario::parse(sandbox_scenario.as_bytes())',
+  'INDEX_INTEGRATION_GUIDE_TEMPLATE',
+  '"docs/index-integration.md"',
 ]) {
   assert.ok(source.includes(marker), `template renderer is missing ${marker}`);
 }
@@ -77,6 +91,31 @@ assert.ok(
     !cargoTemplate.includes('cargo-component'),
   'template must not duplicate WIT bindings or retain cargo-component',
 );
+
+assert.ok(
+  readmeTemplate.includes('docs/index-integration.md') &&
+    readmeTemplate.includes('not an automatic Index bridge') &&
+    guestTemplate.includes('does not register an') &&
+    indexIntegrationGuide.includes('does not publish a `platform.index` capability') &&
+    indexIntegrationGuide.includes('Index integration not yet available') &&
+    indexIntegrationGuide.includes('crates/rustok-index/docs/module-source-integration.md'),
+  'standalone template must explain the fail-closed Index compatibility boundary',
+);
+assert.ok(
+  !cargoTemplate.includes('rustok-index') &&
+    !guestTemplate.includes('"platform.index"') &&
+    !sandboxScenario.includes('"platform.index"'),
+  'standalone component template must not invent a direct rustok-index dependency or capability',
+);
+assert.ok(
+  nativeIndexGuide.includes('register_index_schema_source') &&
+    nativeIndexGuide.includes('IndexSource for ClassifiedsIndexSource') &&
+    nativeIndexGuide.includes('commit-before-ack') &&
+    nativeIndexGuide.includes('writes directly to `index_entities`'),
+  'native module guide must retain schema, replay, ingestion, and ownership requirements',
+);
 assert.match(sdkManifest, /^version = "0\.1\.0"$/m);
 
-console.log('[verify-module-template] canonical standalone Rust module template verified');
+console.log(
+  '[verify-module-template] canonical standalone template and Index boundary verified',
+);


### PR DESCRIPTION
## Summary

Recheck the actual module-template boundary and document the correct path for `rustok-index` compatibility without inventing unsupported guest capabilities.

- add a normative native source-module integration contract for schema registration, replay/load, incremental mutations, source versions, tombstones, cross-module links, absence evidence, distribution composition, and required tests;
- add a generated `docs/index-integration.md` guide to every standalone module project;
- clarify in generated source comments and README that `platform.events` is a domain-event capability, not automatic indexing;
- keep standalone components fail-closed: no direct `rustok-index` dependency, PostgreSQL access, `ModuleRuntimeExtensions`, Index table writes, or invented `platform.index` capability;
- add a documentation template for every module to record its Index compatibility level and evidence;
- extend the module-template verifier and renderer tests to guard the generated guide and the native/standalone ownership boundary.

## Architecture correction

The existing `rustok-module-template` creates a standalone Rust Component Model guest targeting `wasm32-wasip2`. It is not the same integration surface as a native Rust module selected into the server distribution.

Therefore this PR deliberately does **not** add `rustok-index` to the generated Cargo manifest and does **not** add executable `platform.index` guest calls. The current component ABI exposes only the generic broker import, and the repository currently has no admitted standalone Index capability or event-to-Index payload contract.

Native modules should follow:

```text
crates/rustok-index/docs/module-source-integration.md
```

Generated standalone modules receive:

```text
docs/index-integration.md
```

## Native compatibility contract

The native guide defines progressive levels:

1. schema/query compatibility;
2. replay compatibility;
3. incremental compatibility;
4. drift-aware compatibility;
5. repair-ready compatibility.

It includes commented examples and mandatory rules for:

- `register_index_schema_source`;
- deterministic record conversion;
- bounded `IndexSource::scan` and `load`;
- source/factory registration;
- stable delivery UUIDs and monotonic source versions;
- explicit deletes/tombstones;
- cross-module links;
- authoritative absence evidence;
- selection-gated distribution composition;
- contract and PostgreSQL evidence.

## Standalone template boundary

The generated guide states that publishing `module.<slug>.executed` through `platform.events` does not register a schema, populate Index storage, provide replay, or make the module repair-ready.

Executable standalone support remains blocked until the host provides an admitted typed broker capability or a documented event-to-Index bridge with versioned payloads and retained evidence.

## Verification changes

The static verifier now checks that:

- the renderer emits `docs/index-integration.md`;
- generated README/source comments explain the boundary;
- the standalone Cargo template does not depend on `rustok-index`;
- the guest and sandbox scenario do not invent `platform.index`;
- the native guide retains schema, replay, ingestion, and table-ownership requirements.

## Main recheck

The branch was created from `face786f9c8ff51f55735a856abe739a74858183`.

Current `main` is two commits ahead. Their delta is limited to Forum ownership documentation/verification and Pages inline-edit rollout evidence. No file overlaps this PR's `rustok-index`, `rustok-module-template`, module documentation template, or module-template verifier paths.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatting, builds, sandbox scenarios, workflows, or CI were run.
