### PR TITLE
feat(reactions): add neutral capability foundation

### DIFF
--- a/crates/rustok-forum/contracts/forum-shared-capability-ownership.json
+++ b/crates/rustok-forum/contracts/forum-shared-capability-ownership.json
@@ -8,6 +8,7 @@
     "public_profile": "rustok-profiles",
     "binary_media": "rustok-media",
     "social_relations": "rustok-social-graph",
+    "reactions": "rustok-reactions",
     "moderation_cases": "rustok-moderation",
     "notification_inbox": "rustok-notifications",
     "translation_workflow": "rustok-translation",
@@ -15,7 +16,6 @@
     "generic_index": "rustok-index",
     "seo": "rustok-seo",
     "durable_events": ["rustok-outbox", "rustok-events"],
-    "planned_reactions": "rustok-reactions",
     "planned_reputation": "rustok-reputation"
   },
   "forum_owned": [
@@ -26,6 +26,7 @@
     "forum drafts and bookmarks",
     "forum attachment relations",
     "forum trust and posting policy",
+    "forum reaction subject adapter",
     "forum moderation effect adapter and local enforcement state",
     "forum visibility, semantic events and projections",
     "forum statistics and module-owned UI"
@@ -39,7 +40,7 @@
   ],
   "required_plan_fragments": [
     "Forum is an installable domain application composed from platform modules",
-    "planned `rustok-reactions`",
+    "`rustok-reactions`",
     "planned `rustok-reputation`",
     "`rustok-moderation` through `rustok-moderation-api`",
     "Profiles remains the sole public member identity and directory owner",
@@ -49,6 +50,7 @@
   "archive_snapshot": "crates/rustok-forum/docs/archive/implementation-plan-2026-08-06.snapshot",
   "verification": [
     "node scripts/verify/verify-forum-shared-capability-ownership.mjs",
+    "node scripts/verify/verify-reactions-foundation.mjs",
     "cargo xtask module validate forum",
     "git diff --check"
   ]

--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -14,20 +14,18 @@ last_reviewed: 2026-08-06
 
 This file is the single source of truth for Forum product scope, Forum-owned
 implementation work, shared-capability integration work, task status, execution
-order, and release gates.
+order and release gates.
 
 The exact pre-correction snapshot is retained at
-`docs/archive/implementation-plan-2026-08-06.snapshot` for audit only. The
-snapshot is not authoritative even though its preserved bytes contain the old
-header and task language. Do not copy task status or ownership from it.
+`docs/archive/implementation-plan-2026-08-06.snapshot` for audit only. It is not
+authoritative. Do not copy ownership or task status from it.
 
-Every pull request that changes a task below must update this plan in the same
-pull request when it changes status, remaining scope, ownership, verification,
-compatibility, migration, or degraded-mode behavior.
-
-A task is `done` only after its implementation, integration, migration or
-backfill, tests, public contracts, documentation, and required runtime evidence
-are complete. Source-ready or merged partial slices remain `in_progress`.
+Every pull request that changes a task below must update this plan when it
+changes status, remaining scope, ownership, verification, compatibility,
+migration or degraded-mode behavior. A task is `done` only after implementation,
+integration, migration/backfill, tests, public contracts, documentation and
+required runtime evidence are complete. Source-ready slices remain
+`in_progress`.
 
 ## Product model
 
@@ -35,14 +33,12 @@ Forum is an installable domain application composed from platform modules. It
 must not recreate common social-platform capabilities inside `rustok-forum`.
 The target is comparable to an application-oriented platform such as phpFox:
 each module owns one capability and Forum contributes only Forum-specific state,
-policy, adapters, semantic events, and UI composition.
+policy, adapters, semantic events and UI composition.
 
-The Forum product still includes categories, discussions, Q&A, wiki and
-announcement modes, subscriptions, unread state, drafts, bookmarks, mentions,
-attachments, reactions, reputation presentation, moderation, search, SEO,
-notifications, realtime acceleration, member views, admin, storefront,
-observability, and import/export. Product inclusion does not imply Forum storage
-ownership.
+Product inclusion does not imply Forum persistence ownership. Forum may present
+profiles, media, reactions, reputation, moderation, notifications, search, SEO,
+translation and realtime behavior while consuming those owners through public
+contracts.
 
 ## Ownership rules
 
@@ -50,17 +46,15 @@ ownership.
 
 `rustok-forum` owns only:
 
-- category hierarchy, category policy, topic/reply lifecycle and revisions;
-- localized Forum content and route identity;
-- topic kinds, solution semantics, subscriptions and Forum read state;
-- Forum drafts and bookmarks unless a proven neutral owner contract replaces
-  them;
-- Forum attachment relations, usage, order, caption and target revision;
-- Forum trust state, Forum posting policy and Forum-local enforcement state;
+- category hierarchy and policy;
+- localized topic/reply content, lifecycle, revisions and route identity;
+- topic kinds, accepted-solution semantics, subscriptions and Forum read state;
+- Forum drafts and bookmarks unless a proven neutral owner replaces them;
+- Forum attachment relations, usage, order, caption and source revision;
+- Forum trust, posting policy and Forum-local enforcement state;
 - Forum subject adapters for reactions and moderation;
 - Forum visibility, source authorization, semantic events and projections;
-- Forum-specific statistics and activity projections;
-- module-owned Forum admin/storefront packages.
+- Forum statistics/activity projections and module-owned admin/storefront UI.
 
 Forum tables may reference another owner by typed tenant-scoped identity, but
 must not copy that owner's source-of-truth data or read its private tables.
@@ -73,51 +67,50 @@ must not copy that owner's source-of-truth data or read its private tables.
 | Public handle, display name, biography, locale and profile privacy | `rustok-profiles` | Batch summaries and compose Forum statistics. |
 | Avatar/banner and all binary asset lifecycle | `rustok-media` | Store typed media references and attachment policy only. |
 | Follow/block relationship facts | `rustok-social-graph` and profile privacy ports | Request exact bounded facts; never read relation tables. |
-| Reaction catalog, actor reactions and aggregate reaction counts | planned `rustok-reactions` | Publish Forum subject adapter, authorization and UI. |
+| Reaction catalog, actor reactions and aggregate reaction counts | `rustok-reactions` | Publish Forum subject adapter, authorization, events and UI composition. |
 | Cross-domain reputation ledger and achievements/badges | planned `rustok-reputation` / achievement capability | Publish semantic facts and display permitted projections. |
 | Reports, cases, queues, decisions, appeals and cross-domain audit | `rustok-moderation` through `rustok-moderation-api` | Report subjects and apply validated effects to Forum state. |
 | Notification inbox, fan-out, grouping, preferences, digests and deliveries | `rustok-notifications` | Publish source events/providers and authorize current targets. |
 | Translation workflow | `rustok-translation` | Publish exact Forum translation targets and apply owner writes. |
-| Search storage and retrieval | `rustok-search`; generic materialized indexing in `rustok-index` | Publish visibility-safe Forum projections and repair sources. |
+| Search storage and retrieval | `rustok-search`; generic indexing in `rustok-index` | Publish visibility-safe projections and repair sources. |
 | SEO aggregation and host head composition | `rustok-seo` | Publish canonical Forum targets and structured semantics. |
-| Durable event delivery | `rustok-outbox` / `rustok-events` | Commit owner state and semantic events atomically. |
-| Realtime transport | shared host/runtime capability | Publish revisions/cursors; reload canonical owner state on reconnect. |
+| Durable event delivery | `rustok-outbox` / `rustok-events` | Commit Forum state and semantic events atomically. |
+| Realtime transport | shared host/runtime capability | Publish revisions/cursors and reload canonical owner state. |
 | Import orchestration | shared bounded import framework when available | Provide Forum mapping, validation, receipts and reconciliation. |
 
 ### Non-duplication gates
 
-The following are forbidden without a platform ADR and an ownership migration:
+Without a platform ADR and ownership migration, the following are forbidden:
 
-- `forum_member_profiles`, copied display names, copied avatars or a new member
-  module;
-- Forum-owned media uploads, storage keys, delivery URLs, quarantine or deletion
-  lifecycle;
-- Forum-owned report/case/appeal queues or a second cross-domain moderation
-  audit ledger;
-- Forum-owned notification inbox, preferences, grouping, digests or delivery
-  attempts;
-- a Forum-specific reaction catalog once `rustok-reactions` is composed;
-- a Forum-only reputation ledger or badge catalog intended for reuse by other
-  modules;
-- transport-local visibility, profile, reaction or moderation policy;
+- copied Profile identity, avatar or a second member directory;
+- Forum-owned uploads, storage keys, delivery URLs, quarantine or Media deletion;
+- Forum-owned report/case/appeal queues or a second cross-domain moderation log;
+- Forum-owned notification inbox, preferences, grouping, digests or delivery;
+- a Forum-specific reaction catalog after `rustok-reactions` composition;
+- a reusable Forum-only reputation ledger or universal badge catalog;
+- transport-local visibility/reaction/moderation policy;
 - direct reads of another module's persistence tables.
 
-Optional shared modules must have explicit unavailable/degraded behavior. Their
-absence must not make an otherwise valid Forum owner command fail unless that
-command explicitly requires the capability, such as assigning a Media asset.
+Optional capabilities must expose explicit unavailable/degraded behavior. Their
+absence must not break unrelated Forum owner commands.
 
 ## Current verified baseline
 
-The current source already provides categories, localized topics/replies,
-typed lifecycle, revisions and tombstones, bounded reads, subscription levels,
-accepted solutions, topic tags, Forum statistics, transactional events,
-visibility-aware Search/SEO providers, shared rich text, module-owned admin and
-storefront packages, and Page Builder consumer contracts.
+Forum already provides categories, localized topics/replies, lifecycle,
+revisions/tombstones, bounded reads, subscription levels, accepted solutions,
+tags, Forum statistics, transactional events, visibility-aware Search/SEO,
+shared rich text, module-owned admin/storefront packages and Page Builder
+contracts.
 
-The repository also already contains the relevant shared owners: Profiles,
-Media, Social Graph, Moderation, Notifications, Translation, SEO, Search/Index,
-Outbox/Events, Taxonomy, Workflow, Comments, Groups and Channel. New Forum work
-must integrate those boundaries instead of cloning their data models.
+Profiles, Media, Social Graph, Reactions, Moderation, Notifications,
+Translation, SEO, Search/Index, Outbox/Events, Taxonomy, Workflow, Comments,
+Groups and Channel are separate platform capabilities. New Forum work must
+integrate them instead of cloning their data models.
+
+The Reactions foundation now provides neutral bounded contracts, revisioned
+subject identity, idempotency identity, read/write ports and unique source
+provider/factory registries. It has no persistence, producer adapter, transport
+or UI yet.
 
 ## Program ledger
 
@@ -125,213 +118,154 @@ must integrate those boundaries instead of cloning their data models.
 | --- | --- | --- |
 | `FORUM-00` | `done` | PostgreSQL/SQLite runtime baseline. |
 | `FORUM-01` | `done` | Tenant-composite integrity and locale width. |
-| `FORUM-02` | `done` | Typed topic/reply lifecycle and revision fields. |
+| `FORUM-02` | `done` | Typed topic/reply lifecycle and revisions. |
 | `FORUM-03` | `done` | Atomic category writes and translations. |
-| `FORUM-04` | `done` | Bounded tree, placement, policy, subtree lifecycle and admin DnD. |
+| `FORUM-04` | `done` | Tree, placement, policy, subtree lifecycle and admin DnD. |
 | `FORUM-05` | `done` | Serialized publication-aware counters. |
 | `FORUM-06` | `done` | Locked topic and moderation publication semantics. |
 | `FORUM-07` | `done` | Monotonic reply positions. |
 | `FORUM-08` | `done` | Revisions, tombstones and owner soft-delete paths. |
 | `FORUM-09` | `done` | Versioned Forum event catalog and journal. |
-| `FORUM-10` | `done` | Bounded cursor read models. |
+| `FORUM-10` | `done` | Bounded cursor reads. |
 | `FORUM-11` | `done` | Subscription levels and participation policy. |
-| `FORUM-12` | `in_progress` | Mention/quote owner relations and notification source exist. Maintainer runtime execution, profile/block privacy, moderator audience expansion and final Notifications policy/evidence remain. |
-| `FORUM-13` | `in_progress` | Category presentation and optional Media read policy exist. Persist only typed `cover_media_id`; Media owns upload, lifecycle and descriptors. Owner command, transports, UI and runtime evidence remain. |
-| `FORUM-14` | `planned` | Add Forum attachment relations and target policy over Media-owned upload sessions/assets. Do not implement upload or asset lifecycle in Forum. |
-| `FORUM-15` | `in_progress` | Profiles already supplies Forum through `ProfilesReader` and batched summaries. Complete member-card composition, privacy/block behavior, Forum-stat enrichment and no-N+1 runtime evidence. |
-| `FORUM-16` | `in_progress` | Monotonic read state, unread projections, bounded bulk owners and transports exist. Visibility-scoped storefront bulk commands and maintainer PostgreSQL evidence remain. |
-| `FORUM-17` | `planned` | Forum drafts/bookmarks with optional Notifications reminders and Media session references; no Forum timers or asset lifecycle. |
-| `FORUM-18` | `planned` | Keep atomic Forum vote hardening in Forum. Move reusable reactions to `rustok-reactions`; move cross-domain reputation and achievements to shared owners. Forum provides subject authorization, events and UI composition. |
-| `FORUM-19` | `planned` | Integrate `rustok-moderation-api`: Forum subject adapter, effect application and Forum-local restrictions. Moderation owns reports, cases, queues, decisions, appeals and cross-domain audit. |
-| `FORUM-20` | `in_progress` | Rich visibility, create/moderate audiences, recipient-aware Notifications and inbox UI are largely source-complete. Remaining read/search/index/SEO/deep-link migration, scoped bulk reads, scheduled reconciliation/redaction, deliveries and PostgreSQL evidence remain. |
-| `FORUM-21` | `in_progress` | A-X provide move, merge, split, fork and range owners/transports/UI. Retained owner/transport runtime evidence remains; localized canonical history is completed under FORUM-24. |
-| `FORUM-22` | `planned` | Forum-owned topic kinds, Q&A/wiki/announcement policy and scheduled lifecycle. Polls use a neutral capability when available. |
-| `FORUM-23` | `in_progress` | Visibility-safe Search projection/filtering, durable ordering, owner revisions and repair protocol exist. Maintainer PostgreSQL/Iggy and cross-module runtime evidence remain; kind/attachment filters wait on owners. |
-| `FORUM-24` | `in_progress` | A-S plus the storefront descriptor correction provide topic/category routes, aliases/tombstones, transports, shared storefront mounts, SEO/hreflang, Search canonical URLs and source-ready evidence. Execute SQLite registered-host, mounted HTTP, browser navigation, PostgreSQL reindex and deployment reindex evidence. |
-| `FORUM-25` | `planned` | Forum translation target/provider integration and complete multilingual/RTL UI. Translation workflow remains shared. |
-| `FORUM-26` | `in_progress` | Forum trust and posting-policy facts exist. Add Moderation facts, shared Reputation facts, policy persistence/enforcement, shared rate-limit execution, duplicate detection, transports/UI and runtime evidence. |
-| `FORUM-27` | `planned` | Compose the Profiles-owned public profile/directory with Forum stats, activity and permitted shared reputation/achievement views. No duplicate Forum profile store. |
-| `FORUM-28` | `done` | Shared canonical editor, renderer, projections and Next/Leptos adapters. |
-| `FORUM-29` | `planned` | Shared realtime transport integration with Forum cursors/revisions and canonical reload. |
-| `FORUM-30` | `planned` | Complete Forum-owned admin product by composing owner transports and shared Moderation/Media/Reaction components. |
-| `FORUM-31` | `planned` | Complete Forum storefront product by composing Profiles, Media, Reactions, Notifications, Search and Forum owners. |
+| `FORUM-12` | `in_progress` | Mention/quote relations and notification source exist. Runtime execution, profile/block privacy, moderator audience and final Notifications evidence remain. |
+| `FORUM-13` | `in_progress` | Optional Media presentation policy exists. Add typed category-cover owner command, transports, UI and runtime evidence; Media keeps lifecycle ownership. |
+| `FORUM-14` | `planned` | Forum attachment relations over Media-owned sessions/assets; no upload or asset lifecycle in Forum. |
+| `FORUM-15` | `in_progress` | Profiles supplies `ProfilesReader`. Finish member-card composition, privacy/block behavior, Forum-stat enrichment and no-N+1 evidence. |
+| `FORUM-16` | `in_progress` | Read state, unread projections, bounded bulk owners and transports exist. Visibility-scoped storefront bulk commands and PostgreSQL evidence remain. |
+| `FORUM-17` | `planned` | Forum drafts/bookmarks with optional Notifications reminders and Media references. |
+| `FORUM-18` | `in_progress` | Neutral `rustok-reactions-api`, optional `rustok-reactions` registration and provider registry now exist. Add owner persistence, then Forum topic/reply provider, transports/UI and evidence; Forum votes remain separate. |
+| `FORUM-19` | `planned` | Integrate `rustok-moderation-api` subject/effect adapters and Forum-local restrictions. Moderation owns cases and audit. |
+| `FORUM-20` | `in_progress` | Rich visibility and recipient-aware source/inbox slices largely exist. Complete remaining reads, Search/SEO/deep links, reconciliation, delivery and PostgreSQL evidence. |
+| `FORUM-21` | `in_progress` | A-X provide move/merge/split/fork/range owners, transports and UI. Retained runtime evidence remains. |
+| `FORUM-22` | `planned` | Forum-owned Q&A/wiki/announcement kinds and scheduled lifecycle. |
+| `FORUM-23` | `in_progress` | Search projection/filtering, ordering, owner revisions and repair exist. PostgreSQL/Iggy and cross-module evidence remain. |
+| `FORUM-24` | `in_progress` | A-S plus descriptor correction provide category/topic routes, transports, mounts, SEO/hreflang and Search URLs. Execute registered-host, HTTP, browser and reindex evidence. |
+| `FORUM-25` | `planned` | Forum Translation provider and complete multilingual/RTL UI. |
+| `FORUM-26` | `in_progress` | Forum trust/posting facts exist. Add Moderation/Reputation facts, persistence/enforcement, shared rate limits, transports/UI and evidence. |
+| `FORUM-27` | `planned` | Compose Profiles directory/profile with Forum stats/activity and permitted reputation/achievements. |
+| `FORUM-28` | `done` | Shared editor, renderer, projections and Next/Leptos adapters. |
+| `FORUM-29` | `planned` | Shared realtime transport with Forum cursors/revisions and canonical reload. |
+| `FORUM-30` | `planned` | Complete Forum admin by composing Forum and shared owners. |
+| `FORUM-31` | `planned` | Complete Forum storefront by composing Profiles, Media, Reactions, Notifications and Search. |
 | `FORUM-32` | `in_progress` | Widget contracts exist; richer widgets and observed Page Builder evidence remain. |
-| `FORUM-33` | `planned` | Forum-local metrics and reconciliation providers integrated with platform observability/job owners. No second generic telemetry system. |
-| `FORUM-34` | `planned` | Forum import/export adapter and NodeBB mapping over a bounded shared import runner when available. |
-| `NOTIFY-00` | `in_progress` | Neutral API, optional runtime composition and Forum providers exist; executable distribution evidence remains. |
-| `NOTIFY-01` | `in_progress` | Owner persistence and source inbox exist; final commands, global migrations, retention and reconciliation remain. |
+| `FORUM-33` | `planned` | Forum metrics/reconciliation providers integrated with platform operations. |
+| `FORUM-34` | `planned` | Forum import/export adapter and NodeBB mapping over a shared runner. |
+| `NOTIFY-00` | `in_progress` | Neutral API/runtime composition and Forum providers exist; executable distribution evidence remains. |
+| `NOTIFY-01` | `in_progress` | Persistence/source inbox exist; final commands, migrations, retention and reconciliation remain. |
 | `NOTIFY-02` | `planned` | Preferences, quiet hours and digests. |
-| `NOTIFY-03` | `in_progress` | Durable source acceptance and candidate materialization exist; policy, final rows, delivery and PostgreSQL lease evidence remain. |
-| `NOTIFY-04` | `planned` | Owner inbox/read APIs; existing source slices must be reconciled into this task. |
+| `NOTIFY-03` | `in_progress` | Source acceptance/candidate materialization exist; policy, final rows, delivery and lease evidence remain. |
+| `NOTIFY-04` | `planned` | Owner inbox/read APIs and reconciliation of existing slices. |
 | `NOTIFY-05` | `planned` | Delivery provider SPI. |
 | `NOTIFY-06` | `planned` | Localized semantic templates. |
 | `NOTIFY-07` | `planned` | Privacy, blocking and target-open authorization. |
-| `NOTIFY-08` | `planned` | Notification UI ownership and parity evidence. |
-| `NOTIFY-09` | `planned` | FBA and degraded profiles. |
-| `LINK-FORUM-01` | `planned` | Forum-to-Notifications executable proof. |
-| `LINK-FORUM-02` | `planned` | Profiles/Media/Forum executable proof. |
+| `NOTIFY-08` | `planned` | Notification UI and parity evidence. |
+| `NOTIFY-09` | `planned` | FBA/degraded profiles. |
+| `LINK-FORUM-01` | `planned` | Forum-to-Notifications proof. |
+| `LINK-FORUM-02` | `planned` | Profiles/Media/Forum proof. |
 | `LINK-FORUM-03` | `planned` | Forum/Search/Index ordering and visibility proof. |
-| `LINK-FORUM-04` | `planned` | Required/optional capability profiles and startup validation. |
+| `LINK-FORUM-04` | `planned` | Capability profiles and startup validation. |
 | `LINK-FORUM-05` | `planned` | Waiver-free production release gate. |
 
 ## Corrected task boundaries
 
-### `FORUM-13` and `FORUM-14`: Media integration
+### `FORUM-13`/`FORUM-14`: Media
 
-Media owns upload preparation/completion, blob storage, MIME, dimensions,
-renditions, quarantine, deletion, delivery descriptors, shared-reference
-lifecycle and reconciliation. Forum validates an owner descriptor and stores
-only a tenant-scoped typed relation to the Media asset plus Forum usage/order,
-caption and source revision.
+Media owns upload, blobs, MIME, dimensions, renditions, quarantine, deletion,
+delivery and reconciliation. Forum stores only typed tenant-scoped relations,
+Forum usage/order/caption and source revision. Text-only Forum remains available
+when Media is disabled.
 
-A Media-disabled deployment keeps text-only Forum behavior. A command that
-explicitly assigns an asset fails with typed capability unavailable. Reads may
-omit optional presentation only for the documented disabled profile; provider
-failures are not converted to absence.
+### `FORUM-15`/`FORUM-27`: Profiles
 
-### `FORUM-15` and `FORUM-27`: Profiles composition
-
-Profiles is the canonical public member identity and directory owner. Forum
-adds only bounded Forum statistics, trust, permitted activity and references to
-shared reputation/achievement projections. Author lists use batched
-`ProfilesReader` calls or a revisioned projection with reconciliation. Forum
-never stores copied handle/display-name/avatar source data.
+Profiles owns public member identity and directory. Forum adds bounded stats,
+trust and activity. Author lists use batched `ProfilesReader` calls or a
+revisioned reconciled projection. Forum never stores copied profile source data.
 
 ### `FORUM-18`: votes, reactions, reputation and achievements
 
-Existing Forum votes remain Forum semantics and must be made atomic and
-reconcilable. Reusable reactions become a separate platform capability with a
-neutral subject identity, bounded catalog, actor uniqueness, idempotent writes,
-aggregate projections and subject authorization adapters.
+Existing Forum votes remain Forum semantics and must be hardened independently.
+`rustok-reactions` owns reusable reaction catalogs, actor state, receipts and
+aggregate projections. Forum owns topic/reply existence, current revision,
+visibility and reaction-policy authorization through its provider.
 
-Forum supplies subject existence/current revision/visibility/reaction-policy
-checks for topic and reply targets. The Reactions owner never reads Forum
-tables. Forum UI consumes reaction ports and owner aggregates.
+Reputation and achievements remain separate shared capabilities consuming
+semantic facts. Forum trust remains Forum-owned because it controls Forum
+posting policy.
 
-Reputation and achievements are separate from reactions. They consume semantic
-facts from Forum, Blog, Comments, Groups, Profiles, Commerce and other modules.
-Forum does not create a reusable reputation ledger or universal badge catalog.
-Forum trust remains Forum-owned because it controls Forum posting policy.
+### `FORUM-19`: Moderation
 
-### `FORUM-19`: Moderation integration
+Moderation owns reports, cases, queues, decisions/effects, appeals, application
+operations, receipts and cross-domain audit. Forum publishes subject references
+and applies validated effects through `ModerationSubjectCommandPort`, retaining
+only Forum enforcement state and bounded decision provenance.
 
-`rustok-moderation` owns reports, deduplicated cases, assignment queues,
-immutable decisions/effects, appeals, application operations, receipts and
-cross-domain audit. Forum publishes subject references and a
-`ModerationSubjectCommandPort` adapter that applies validated effects to Forum
-owner state.
+### `FORUM-30`/`FORUM-31`: UI composition
 
-Forum may store current Forum enforcement state required by its read/write
-policy, such as topic visibility, lock state, premoderation and scoped posting
-restrictions. It stores bounded decision provenance and an owner receipt, not
-copied case notes, queue state or policy snapshots.
-
-### `FORUM-26`: trust and anti-spam
-
-Forum owns Forum trust and versioned posting decisions. Authoritative active
-flag/moderation history comes from Moderation; reputation comes from the shared
-Reputation owner; account and profile facts come from their owners; distributed
-rate limiting is a shared execution capability. Missing required facts fail
-closed with typed retryability. Optional scoring never becomes correctness.
-
-### `FORUM-30` and `FORUM-31`: product UI
-
-Module-owned Forum packages own navigation and Forum workflows. Shared modules
-own their reusable widgets and transports. The Forum admin/storefront composes
-Profiles cards, Media pickers/descriptors, Moderation case links, Reaction
-controls, Notification inbox/navigation, Search, Translation and SEO through
-public contracts. Hosts register and mount packages; they do not absorb policy.
+Forum packages own Forum workflows. Shared modules own reusable profile, media,
+moderation, reaction, notification, search, translation and SEO components.
+Hosts register/mount packages and do not absorb policy.
 
 ## Execution order
 
-### Track 1 — ownership-safe shared capabilities
+### Track 1 — shared capabilities
 
-1. Introduce the neutral `rustok-reactions` API and owner module as a separate
-   platform task, without changing existing Forum vote behavior.
-2. Add Forum topic/reply reaction subject adapters and bounded UI composition.
-3. Introduce shared reputation/achievement owners only after at least two real
-   producer modules agree on the neutral fact and projection contracts.
-4. Integrate Forum with `rustok-moderation-api`; do not add Forum case queues.
+1. Reactions neutral API/optional module foundation: source-ready, maintainer verification pending.
+2. Implement Reactions persistence and command receipts without producer adapters.
+3. Add Forum topic/reply provider and degraded profile.
+4. Add a second producer before freezing shared presentation contracts.
+5. Introduce Reputation/Achievements only after at least two producers agree.
+6. Integrate Forum with `rustok-moderation-api`; never add Forum case queues.
 
-### Track 2 — close already implemented Forum work
+### Track 2 — close existing Forum work
 
-1. Execute and retain FORUM-24 SQLite registered-host evidence.
-2. Add mounted shared-storefront HTTP response evidence.
+1. Execute FORUM-24 SQLite registered-host evidence.
+2. Add mounted shared-storefront HTTP evidence.
 3. Add browser navigation evidence for category/topic/reply Search links.
-4. Execute the FORUM-24 PostgreSQL reindex harness and production deployment
-   reindex evidence.
-5. Execute retained FORUM-16, FORUM-21, FORUM-23 and FORUM-26 evidence.
+4. Execute PostgreSQL and deployment reindex evidence.
+5. Execute retained FORUM-16/21/23/26 evidence.
 
-### Track 3 — Profiles and Media integration
+### Track 3 — Profiles/Media and Forum product
 
-1. Finish category cover persistence and transport composition over Media.
-2. Add topic/reply attachment relations over Media-owned sessions/assets.
-3. Finish batched Profiles member-card and directory composition.
-4. Retain LINK-FORUM-02 evidence for privacy, quarantine, deletion and disabled
-   profiles.
+1. Category cover and attachment relations over Media.
+2. Batched Profiles member composition.
+3. Topic kinds, drafts/bookmarks, read-state bulk completion and trust enforcement.
+4. Full admin/storefront assembly and release integrations.
 
-### Track 4 — Forum-owned product semantics
+## Compatibility and migration
 
-1. Topic kinds and scheduled policies.
-2. Drafts, bookmarks and optional reminder integration.
-3. Read-state visibility-scoped bulk completion.
-4. Posting-policy persistence/enforcement and Forum trust operations.
-5. Full admin/storefront assembly.
-
-### Track 5 — release integration
-
-1. Complete Notifications policy/delivery and LINK-FORUM-01.
-2. Complete Search/Index runtime evidence and LINK-FORUM-03.
-3. Complete capability profiles, import adapter and production release gate.
-
-Independent UI work may run only after the owner contracts it consumes are
-stable.
-
-## Compatibility and migration policy
-
-- Existing Forum votes remain source-compatible while Reactions is introduced.
-  Do not reinterpret vote rows as generic reactions without an explicit data
-  migration and semantic mapping.
-- Existing Forum statistics remain Forum projections; they may be inputs to a
-  shared reputation owner but are not a reputation ledger.
-- Existing topic/reply moderation state remains authoritative Forum state.
-  New Moderation integration records decision provenance and idempotent effect
-  application without moving Forum tables to Moderation.
-- Existing Profile, Media, Notifications, Search and SEO integrations remain
-  additive. No private-table fallback is permitted.
-- Optional shared capabilities are default-off or explicitly unavailable until
-  composed. Forum commands continue to commit semantic events when optional
-  consumers are absent.
+- Existing Forum votes remain source-compatible. Do not reinterpret them as
+  reactions without explicit semantic mapping and migration.
+- Forum statistics are projections, not a reputation ledger.
+- Forum moderation state remains authoritative Forum state while Moderation
+  decisions are applied idempotently through an adapter.
+- Profile, Media, Notifications, Reactions, Search and SEO integrations are
+  additive; private-table fallbacks are forbidden.
+- Reactions remains optional and outside `default_enabled` until persistence,
+  adapters and degraded profiles are executable.
 
 ## Required verification
 
-Use the task-specific existing commands plus these ownership guards:
-
 ```bash
 node scripts/verify/verify-forum-shared-capability-ownership.mjs
+node scripts/verify/verify-reactions-foundation.mjs
+cargo test -p rustok-reactions-api
+cargo test -p rustok-reactions
 cargo xtask module validate forum
 npm run verify:forum:admin-boundary
 npm run verify:forum:storefront-boundary
 git diff --check
 ```
 
-Runtime evidence must be generated by executable scenarios. Source contracts,
-static fixtures and documentation do not promote runtime status.
+Tests and runtime evidence are maintainer-run. Source contracts do not promote
+runtime status.
 
 ## Release gates
 
-Forum is not production-ready while any of the following is possible:
-
-- cross-tenant owner references or direct private-table reads;
-- copied Profile identity or Media lifecycle state in Forum;
-- duplicate reaction, reputation, moderation or notification owners;
-- partial category/topic/reply mutation or missing owner event;
-- pending/private content leaking through reads, Search, SEO, notifications or
-  reactions;
-- another transport bypassing Forum visibility, trust or moderation effects;
-- optional-module absence turning unrelated Forum commands into outages;
-- unbounded lists, fan-out, imports or reconciliation;
-- runtime claims without retained executable evidence.
+Forum is not production-ready while there are cross-tenant references, copied
+owner data, duplicate capability owners, partial owner mutations, private data
+leaks, transport policy bypasses, optional-capability outages, unbounded work or
+runtime claims without retained executable evidence.
 
 ## Decisions requiring an ADR to reopen
 
@@ -339,16 +273,13 @@ Forum is not production-ready while any of the following is possible:
 2. Media remains the sole binary asset and delivery-lifecycle owner.
 3. Moderation remains the cross-domain report/case/decision/appeal/audit owner.
 4. Notifications remains the inbox/fan-out/preferences/delivery owner.
-5. Reusable reactions and cross-domain reputation/achievements are separate
-   shared capabilities, not Forum-owned universal models.
+5. Reactions and cross-domain reputation/achievements are separate shared owners.
 6. Forum trust remains Forum-owned and is not equivalent to reputation.
-7. Search, SEO, Translation, Outbox/Events and realtime transports remain shared
-   platform capabilities consumed through public contracts.
+7. Search, SEO, Translation, Outbox/Events and realtime remain shared.
 
 ## Immediate next action
 
-Create the first bounded `rustok-reactions` platform slice: neutral subject and
-reaction contracts, strict bounds, typed errors, idempotency identity and a
-provider registry. Do not add persistence, Forum table reads, transports or UI
-in that first slice. Follow it with a separate Forum topic/reply subject adapter
-PR while preserving existing vote behavior.
+Implement Reactions persistence and command receipts as a separate owner PR,
+then add the Forum topic/reply `ReactionSubjectProvider` adapter in its own PR.
+The adapter must validate current revision, visibility and catalog policy through
+Forum owners, expose no private denial reason and preserve existing vote behavior.

--- a/crates/rustok-reactions-api/Cargo.toml
+++ b/crates/rustok-reactions-api/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "rustok-reactions-api"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Neutral reaction subject, catalog, command, and provider contracts"
+
+[features]
+default = ["server"]
+server = ["dep:async-trait", "dep:rustok-api", "dep:rustok-core"]
+
+[dependencies]
+async-trait = { workspace = true, optional = true }
+rustok-api = { workspace = true, optional = true }
+rustok-core = { workspace = true, optional = true }
+serde.workspace = true
+thiserror.workspace = true
+uuid.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/rustok-reactions-api/README.md
+++ b/crates/rustok-reactions-api/README.md
@@ -1,0 +1,45 @@
+# rustok-reactions-api
+
+## Purpose
+
+`rustok-reactions-api` defines neutral contracts for reusable reactions without
+owning persistence, transports, UI, or any producer module's subject data.
+
+## Responsibilities
+
+- Validate bounded source slugs, subject kinds, reaction keys and catalogs.
+- Bind every subject to tenant, source, kind, UUID and positive owner revision.
+- Bind writes to a caller-provided command UUID and authenticated actor UUID.
+- Support explicit single- or bounded multi-selection policy.
+- Publish bounded actor state, aggregate snapshots and read/write ports.
+- Publish a unique runtime registry for source-owned subject authorization.
+- Preserve typed unavailable, invalid, conflict and retryable provider failures.
+
+## Ownership boundary
+
+A subject provider remains in the module that owns the subject. It validates the
+current subject revision, visibility and reaction policy through its own owner
+services. The Reactions owner never reads Forum, Blog, Comments, Profiles,
+Groups, Media or Commerce tables.
+
+The neutral crate contains no SeaORM entities, migrations, GraphQL, HTTP,
+Leptos, React, event worker, catalog persistence or aggregate persistence.
+
+Forum votes are not reactions. Any future migration from a module-specific vote
+to a shared reaction requires an explicit semantic mapping and data migration.
+
+## Entry points
+
+- `ReactionSubjectRef`
+- `ReactionCatalog`
+- `ReactionSelectionPolicy`
+- `ReactionCommandIdentity`
+- `ApplyReactionCommand`
+- `ReactionReadPort`
+- `ReactionWritePort`
+- `ReactionSubjectProvider`
+- `ReactionSubjectProviderFactory`
+- `ReactionSubjectRegistry`
+
+See [module contract](docs/README.md) and
+[implementation plan](docs/implementation-plan.md).

--- a/crates/rustok-reactions-api/docs/README.md
+++ b/crates/rustok-reactions-api/docs/README.md
@@ -1,0 +1,37 @@
+# Reactions neutral contract
+
+`rustok-reactions-api` is a support crate, not a persistence owner or installable
+application. It allows an optional Reactions owner to work with revisioned
+subjects without depending on their domain crates.
+
+## Subject contract
+
+A subject is exactly `(tenant_id, source, kind, subject_id, subject_revision)`.
+The source module owns existence, current revision, visibility, lifecycle and
+which reaction catalog is allowed for the current actor and operation.
+
+Providers are unique by source slug. Duplicate registration, empty/duplicate or
+over-bound kind sets, factory/provider source mismatch and malformed subject
+identity fail closed.
+
+## Reaction contract
+
+Catalogs are bounded and explicit. Selection is either one key or a bounded
+number of keys. Actor state and aggregates may contain only keys in the
+currently authorized catalog. Writes carry a stable command UUID and actor UUID
+for future owner idempotency.
+
+## Deliberate omissions
+
+This foundation does not define persistence, SQL migrations, event schemas,
+transport DTOs, UI presentation, emoji/media rendering, ranking, reputation,
+achievements, notifications or module-specific votes.
+
+## Verification
+
+```bash
+cargo test -p rustok-reactions-api
+node scripts/verify/verify-reactions-foundation.mjs
+```
+
+Source status remains unvalidated until the maintainer runs these commands.

--- a/crates/rustok-reactions-api/docs/implementation-plan.md
+++ b/crates/rustok-reactions-api/docs/implementation-plan.md
@@ -1,0 +1,53 @@
+---
+id: doc://crates/rustok-reactions-api/docs/implementation-plan.md
+kind: capability_implementation_plan
+language: en
+status: active
+owners:
+  - rustok-reactions
+last_reviewed: 2026-08-06
+---
+
+# `rustok-reactions-api` implementation plan
+
+## Current status
+
+`REACTIONS-00` is `in_progress`. The neutral source contract provides bounded
+semantic keys, revisioned subjects, explicit catalog selection policy,
+idempotency identity, actor/aggregate snapshots, typed read/write ports and a
+unique source-provider/factory registry.
+
+No runtime validation is claimed yet.
+
+## Remaining foundation scope
+
+1. Maintainer compilation and unit verification.
+2. Add the `rustok-reactions` persistence owner with tenant-composite integrity,
+   immutable catalog revisions, actor uniqueness and command receipts.
+3. Add transactional semantic events and bounded aggregate reconciliation.
+4. Add the first real source adapter in Forum for topic/reply authorization.
+5. Add a second producer before freezing cross-module presentation contracts.
+6. Add GraphQL/native transports and module-owned UI only after owner commands
+   and degraded profiles are executable.
+
+## Invariants
+
+- The neutral API never imports a producer domain crate.
+- Subject providers never grant access using copied transport policy.
+- A stale subject revision conflicts or becomes unavailable; it is not silently
+  rewritten to a newer target.
+- Command UUID reuse with different actor/subject/reaction/action must conflict
+  in the future persistence owner.
+- Forum votes remain outside this contract until an explicit migration exists.
+- Reputation, achievements and notifications are separate capabilities.
+
+## Verification
+
+```bash
+cargo test -p rustok-reactions-api
+cargo check -p rustok-reactions-api --all-targets
+node scripts/verify/verify-reactions-foundation.mjs
+git diff --check
+```
+
+Tests and checks are maintainer-run.

--- a/crates/rustok-reactions-api/src/lib.rs
+++ b/crates/rustok-reactions-api/src/lib.rs
@@ -1,0 +1,140 @@
+mod model;
+#[cfg(feature = "server")]
+mod provider;
+
+pub use model::*;
+#[cfg(feature = "server")]
+pub use provider::*;
+#[cfg(feature = "server")]
+pub use rustok_api::{PortContext, PortError};
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use super::*;
+
+    fn subject(kind: &str) -> ReactionSubjectRef {
+        ReactionSubjectRef::new(
+            Uuid::new_v4(),
+            ReactionSourceSlug::new("forum").expect("source"),
+            ReactionSubjectKind::new(kind).expect("kind"),
+            Uuid::new_v4(),
+            1,
+        )
+        .expect("subject")
+    }
+
+    #[test]
+    fn semantic_keys_fail_closed_for_ambiguous_values() {
+        assert!(ReactionSourceSlug::new("forum").is_ok());
+        assert!(ReactionSubjectKind::new("reply").is_ok());
+        assert!(ReactionKey::new("thumbs-up").is_ok());
+
+        for invalid in ["Forum", " forum", "forum ", "forum/reply", "forum.reply"] {
+            assert!(ReactionSourceSlug::new(invalid).is_err(), "accepted {invalid:?}");
+        }
+        for invalid in ["Reply", "reply-kind", "reply/kind", "reply kind"] {
+            assert!(ReactionSubjectKind::new(invalid).is_err(), "accepted {invalid:?}");
+        }
+    }
+
+    #[test]
+    fn catalogs_validate_on_construction_and_deserialization() {
+        let catalog = ReactionCatalog::try_new(
+            ReactionSelectionPolicy::Single,
+            vec![ReactionKey::new("like").expect("key")],
+        )
+        .expect("catalog");
+        assert_eq!(catalog.selection().maximum_selected(), 1);
+
+        let duplicate = serde_json::json!({
+            "selection": { "mode": "single" },
+            "keys": ["like", "like"]
+        });
+        assert!(serde_json::from_value::<ReactionCatalog>(duplicate).is_err());
+
+        let invalid_multiple = serde_json::json!({
+            "selection": { "mode": "multiple", "max_selected": 0 },
+            "keys": ["like", "love"]
+        });
+        assert!(serde_json::from_value::<ReactionCatalog>(invalid_multiple).is_err());
+    }
+
+    #[test]
+    fn identities_require_non_nil_ids_and_positive_subject_revision() {
+        assert!(ReactionCommandIdentity::new(Uuid::nil(), Uuid::new_v4()).is_err());
+        assert!(ReactionSubjectRef::new(
+            Uuid::new_v4(),
+            ReactionSourceSlug::new("forum").expect("source"),
+            ReactionSubjectKind::new("reply").expect("kind"),
+            Uuid::new_v4(),
+            0,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn snapshot_rejects_values_outside_the_authorized_catalog() {
+        let catalog = ReactionCatalog::try_new(
+            ReactionSelectionPolicy::Single,
+            vec![ReactionKey::new("like").expect("key")],
+        )
+        .expect("catalog");
+        let aggregates = vec![ReactionAggregate {
+            reaction: ReactionKey::new("love").expect("key"),
+            count: 1,
+        }];
+        assert!(ReactionSnapshot::try_new(subject("topic"), catalog, None, aggregates).is_err());
+    }
+
+    #[cfg(feature = "server")]
+    mod server {
+        use async_trait::async_trait;
+        use rustok_core::ModuleRuntimeExtensions;
+
+        use super::*;
+
+        struct DummyProvider;
+
+        #[async_trait]
+        impl ReactionSubjectProvider for DummyProvider {
+            fn source(&self) -> ReactionSourceSlug {
+                ReactionSourceSlug::new("forum").expect("source")
+            }
+
+            fn display_name(&self) -> &'static str {
+                "Forum"
+            }
+
+            fn supported_kinds(&self) -> Vec<ReactionSubjectKind> {
+                vec![
+                    ReactionSubjectKind::new("topic").expect("kind"),
+                    ReactionSubjectKind::new("reply").expect("kind"),
+                ]
+            }
+
+            async fn authorize(
+                &self,
+                _context: PortContext,
+                _request: ReactionSubjectRequest,
+            ) -> ReactionProviderResult<ReactionSubjectAuthorization> {
+                Ok(ReactionSubjectAuthorization::Unavailable)
+            }
+        }
+
+        #[test]
+        fn runtime_registry_is_unique_and_discoverable() {
+            let mut extensions = ModuleRuntimeExtensions::default();
+            register_reaction_subject_provider(&mut extensions, DummyProvider)
+                .expect("first registration");
+            assert!(register_reaction_subject_provider(&mut extensions, DummyProvider).is_err());
+
+            let registry = reaction_subject_registry_from_extensions(&extensions)
+                .expect("registry should be present");
+            assert_eq!(registry.len(), 1);
+            assert_eq!(registry.entries()[0].supported_kinds.len(), 2);
+            assert!(registry.get_by_str("forum").is_some());
+        }
+    }
+}

--- a/crates/rustok-reactions-api/src/model.rs
+++ b/crates/rustok-reactions-api/src/model.rs
@@ -1,0 +1,677 @@
+use std::collections::BTreeSet;
+use std::fmt;
+
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize};
+use thiserror::Error;
+use uuid::Uuid;
+
+pub const MAX_REACTION_SOURCE_SLUG_BYTES: usize = 64;
+pub const MAX_REACTION_SUBJECT_KIND_BYTES: usize = 64;
+pub const MAX_REACTION_KEY_BYTES: usize = 64;
+pub const MAX_REACTION_CATALOG_SIZE: usize = 64;
+pub const MAX_REACTIONS_PER_ACTOR: usize = 64;
+
+#[derive(Debug, Error, Clone, Eq, PartialEq)]
+pub enum ReactionContractError {
+    #[error("reaction source slug is invalid")]
+    InvalidSourceSlug,
+    #[error("reaction subject kind is invalid")]
+    InvalidSubjectKind,
+    #[error("reaction key is invalid")]
+    InvalidReactionKey,
+    #[error("reaction identity contains a nil UUID")]
+    NilIdentity,
+    #[error("reaction subject revision must be positive")]
+    InvalidSubjectRevision,
+    #[error("reaction catalog must contain at least one entry")]
+    EmptyCatalog,
+    #[error("reaction catalog exceeds the bounded size")]
+    CatalogTooLarge,
+    #[error("reaction catalog contains a duplicate key")]
+    DuplicateCatalogKey,
+    #[error("reaction selection limit is invalid")]
+    InvalidSelectionLimit,
+    #[error("actor reaction state exceeds the bounded size")]
+    ActorStateTooLarge,
+    #[error("actor reaction state contains a duplicate key")]
+    DuplicateActorReaction,
+    #[error("reaction aggregate contains a duplicate key")]
+    DuplicateAggregate,
+    #[error("reaction state references a key outside the catalog")]
+    KeyOutsideCatalog,
+    #[error("reaction subject provider returned a different subject identity")]
+    ProviderSubjectMismatch,
+}
+
+fn valid_segment(
+    value: &str,
+    maximum_bytes: usize,
+    allow_hyphen: bool,
+    allow_underscore: bool,
+) -> bool {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > maximum_bytes
+        || value.starts_with('-')
+        || value.starts_with('_')
+        || value.ends_with('-')
+        || value.ends_with('_')
+    {
+        return false;
+    }
+
+    value.bytes().all(|byte| {
+        byte.is_ascii_lowercase()
+            || byte.is_ascii_digit()
+            || (allow_hyphen && byte == b'-')
+            || (allow_underscore && byte == b'_')
+    })
+}
+
+macro_rules! string_key {
+    ($name:ident, $max:expr, $allow_hyphen:expr, $allow_underscore:expr, $error:expr) => {
+        #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn new(value: impl Into<String>) -> Result<Self, ReactionContractError> {
+                let value = value.into();
+                if !valid_segment(&value, $max, $allow_hyphen, $allow_underscore) {
+                    return Err($error);
+                }
+                Ok(Self(value))
+            }
+
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str(&self.0)
+            }
+        }
+
+        impl AsRef<str> for $name {
+            fn as_ref(&self) -> &str {
+                self.as_str()
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let value = String::deserialize(deserializer)?;
+                Self::new(value).map_err(D::Error::custom)
+            }
+        }
+    };
+}
+
+string_key!(
+    ReactionSourceSlug,
+    MAX_REACTION_SOURCE_SLUG_BYTES,
+    true,
+    true,
+    ReactionContractError::InvalidSourceSlug
+);
+string_key!(
+    ReactionSubjectKind,
+    MAX_REACTION_SUBJECT_KIND_BYTES,
+    false,
+    true,
+    ReactionContractError::InvalidSubjectKind
+);
+string_key!(
+    ReactionKey,
+    MAX_REACTION_KEY_BYTES,
+    true,
+    true,
+    ReactionContractError::InvalidReactionKey
+);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum ReactionSelectionPolicy {
+    Single,
+    Multiple { max_selected: u8 },
+}
+
+impl ReactionSelectionPolicy {
+    pub fn multiple(max_selected: u8) -> Result<Self, ReactionContractError> {
+        if max_selected < 2 || usize::from(max_selected) > MAX_REACTIONS_PER_ACTOR {
+            return Err(ReactionContractError::InvalidSelectionLimit);
+        }
+        Ok(Self::Multiple { max_selected })
+    }
+
+    pub const fn maximum_selected(self) -> usize {
+        match self {
+            Self::Single => 1,
+            Self::Multiple { max_selected } => max_selected as usize,
+        }
+    }
+
+    fn validate(self) -> Result<Self, ReactionContractError> {
+        match self {
+            Self::Single => Ok(self),
+            Self::Multiple { max_selected } => Self::multiple(max_selected),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ReactionSelectionPolicy {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(tag = "mode", rename_all = "snake_case")]
+        enum RawPolicy {
+            Single,
+            Multiple { max_selected: u8 },
+        }
+
+        let policy = match RawPolicy::deserialize(deserializer)? {
+            RawPolicy::Single => Self::Single,
+            RawPolicy::Multiple { max_selected } => Self::Multiple { max_selected },
+        };
+        policy.validate().map_err(D::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ReactionCatalog {
+    selection: ReactionSelectionPolicy,
+    keys: Vec<ReactionKey>,
+}
+
+impl ReactionCatalog {
+    pub fn try_new(
+        selection: ReactionSelectionPolicy,
+        keys: Vec<ReactionKey>,
+    ) -> Result<Self, ReactionContractError> {
+        let selection = selection.validate()?;
+        if keys.is_empty() {
+            return Err(ReactionContractError::EmptyCatalog);
+        }
+        if keys.len() > MAX_REACTION_CATALOG_SIZE {
+            return Err(ReactionContractError::CatalogTooLarge);
+        }
+        if keys.iter().collect::<BTreeSet<_>>().len() != keys.len() {
+            return Err(ReactionContractError::DuplicateCatalogKey);
+        }
+        if selection.maximum_selected() > keys.len() {
+            return Err(ReactionContractError::InvalidSelectionLimit);
+        }
+        Ok(Self { selection, keys })
+    }
+
+    pub const fn selection(&self) -> ReactionSelectionPolicy {
+        self.selection
+    }
+
+    pub fn keys(&self) -> &[ReactionKey] {
+        &self.keys
+    }
+
+    pub fn contains(&self, key: &ReactionKey) -> bool {
+        self.keys.contains(key)
+    }
+}
+
+impl<'de> Deserialize<'de> for ReactionCatalog {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawCatalog {
+            selection: ReactionSelectionPolicy,
+            keys: Vec<ReactionKey>,
+        }
+
+        let raw = RawCatalog::deserialize(deserializer)?;
+        Self::try_new(raw.selection, raw.keys).map_err(D::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ReactionSubjectRef {
+    tenant_id: Uuid,
+    source: ReactionSourceSlug,
+    kind: ReactionSubjectKind,
+    subject_id: Uuid,
+    subject_revision: u64,
+}
+
+impl ReactionSubjectRef {
+    pub fn new(
+        tenant_id: Uuid,
+        source: ReactionSourceSlug,
+        kind: ReactionSubjectKind,
+        subject_id: Uuid,
+        subject_revision: u64,
+    ) -> Result<Self, ReactionContractError> {
+        if tenant_id.is_nil() || subject_id.is_nil() {
+            return Err(ReactionContractError::NilIdentity);
+        }
+        if subject_revision == 0 {
+            return Err(ReactionContractError::InvalidSubjectRevision);
+        }
+        Ok(Self {
+            tenant_id,
+            source,
+            kind,
+            subject_id,
+            subject_revision,
+        })
+    }
+
+    pub const fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub fn source(&self) -> &ReactionSourceSlug {
+        &self.source
+    }
+
+    pub fn kind(&self) -> &ReactionSubjectKind {
+        &self.kind
+    }
+
+    pub const fn subject_id(&self) -> Uuid {
+        self.subject_id
+    }
+
+    pub const fn subject_revision(&self) -> u64 {
+        self.subject_revision
+    }
+
+    pub fn has_same_identity(&self, other: &Self) -> bool {
+        self.tenant_id == other.tenant_id
+            && self.source == other.source
+            && self.kind == other.kind
+            && self.subject_id == other.subject_id
+    }
+}
+
+impl<'de> Deserialize<'de> for ReactionSubjectRef {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawSubject {
+            tenant_id: Uuid,
+            source: ReactionSourceSlug,
+            kind: ReactionSubjectKind,
+            subject_id: Uuid,
+            subject_revision: u64,
+        }
+
+        let raw = RawSubject::deserialize(deserializer)?;
+        Self::new(
+            raw.tenant_id,
+            raw.source,
+            raw.kind,
+            raw.subject_id,
+            raw.subject_revision,
+        )
+        .map_err(D::Error::custom)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReactionAction {
+    Add,
+    Remove,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ReactionCommandIdentity {
+    command_id: Uuid,
+    actor_id: Uuid,
+}
+
+impl ReactionCommandIdentity {
+    pub fn new(command_id: Uuid, actor_id: Uuid) -> Result<Self, ReactionContractError> {
+        if command_id.is_nil() || actor_id.is_nil() {
+            return Err(ReactionContractError::NilIdentity);
+        }
+        Ok(Self {
+            command_id,
+            actor_id,
+        })
+    }
+
+    pub const fn command_id(&self) -> Uuid {
+        self.command_id
+    }
+
+    pub const fn actor_id(&self) -> Uuid {
+        self.actor_id
+    }
+}
+
+impl<'de> Deserialize<'de> for ReactionCommandIdentity {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawIdentity {
+            command_id: Uuid,
+            actor_id: Uuid,
+        }
+        let raw = RawIdentity::deserialize(deserializer)?;
+        Self::new(raw.command_id, raw.actor_id).map_err(D::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ApplyReactionCommand {
+    identity: ReactionCommandIdentity,
+    subject: ReactionSubjectRef,
+    reaction: ReactionKey,
+    action: ReactionAction,
+}
+
+impl ApplyReactionCommand {
+    pub fn new(
+        identity: ReactionCommandIdentity,
+        subject: ReactionSubjectRef,
+        reaction: ReactionKey,
+        action: ReactionAction,
+    ) -> Self {
+        Self {
+            identity,
+            subject,
+            reaction,
+            action,
+        }
+    }
+
+    pub fn identity(&self) -> &ReactionCommandIdentity {
+        &self.identity
+    }
+
+    pub fn subject(&self) -> &ReactionSubjectRef {
+        &self.subject
+    }
+
+    pub fn reaction(&self) -> &ReactionKey {
+        &self.reaction
+    }
+
+    pub const fn action(&self) -> ReactionAction {
+        self.action
+    }
+}
+
+impl<'de> Deserialize<'de> for ApplyReactionCommand {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawCommand {
+            identity: ReactionCommandIdentity,
+            subject: ReactionSubjectRef,
+            reaction: ReactionKey,
+            action: ReactionAction,
+        }
+        let raw = RawCommand::deserialize(deserializer)?;
+        Ok(Self::new(
+            raw.identity,
+            raw.subject,
+            raw.reaction,
+            raw.action,
+        ))
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ReactionActorState {
+    revision: u64,
+    selected: Vec<ReactionKey>,
+}
+
+impl ReactionActorState {
+    pub fn try_new(
+        revision: u64,
+        selected: Vec<ReactionKey>,
+    ) -> Result<Self, ReactionContractError> {
+        if selected.len() > MAX_REACTIONS_PER_ACTOR {
+            return Err(ReactionContractError::ActorStateTooLarge);
+        }
+        if selected.iter().collect::<BTreeSet<_>>().len() != selected.len() {
+            return Err(ReactionContractError::DuplicateActorReaction);
+        }
+        Ok(Self { revision, selected })
+    }
+
+    pub const fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    pub fn selected(&self) -> &[ReactionKey] {
+        &self.selected
+    }
+}
+
+impl<'de> Deserialize<'de> for ReactionActorState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawState {
+            revision: u64,
+            selected: Vec<ReactionKey>,
+        }
+        let raw = RawState::deserialize(deserializer)?;
+        Self::try_new(raw.revision, raw.selected).map_err(D::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ReactionAggregate {
+    pub reaction: ReactionKey,
+    pub count: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ReactionSnapshot {
+    subject: ReactionSubjectRef,
+    catalog: ReactionCatalog,
+    actor_state: Option<ReactionActorState>,
+    aggregates: Vec<ReactionAggregate>,
+}
+
+impl ReactionSnapshot {
+    pub fn try_new(
+        subject: ReactionSubjectRef,
+        catalog: ReactionCatalog,
+        actor_state: Option<ReactionActorState>,
+        aggregates: Vec<ReactionAggregate>,
+    ) -> Result<Self, ReactionContractError> {
+        let mut aggregate_keys = BTreeSet::new();
+        for aggregate in &aggregates {
+            if !catalog.contains(&aggregate.reaction) {
+                return Err(ReactionContractError::KeyOutsideCatalog);
+            }
+            if !aggregate_keys.insert(aggregate.reaction.clone()) {
+                return Err(ReactionContractError::DuplicateAggregate);
+            }
+        }
+        if let Some(state) = &actor_state {
+            if state.selected().iter().any(|key| !catalog.contains(key)) {
+                return Err(ReactionContractError::KeyOutsideCatalog);
+            }
+            if state.selected().len() > catalog.selection().maximum_selected() {
+                return Err(ReactionContractError::InvalidSelectionLimit);
+            }
+        }
+        Ok(Self {
+            subject,
+            catalog,
+            actor_state,
+            aggregates,
+        })
+    }
+
+    pub fn subject(&self) -> &ReactionSubjectRef {
+        &self.subject
+    }
+
+    pub fn catalog(&self) -> &ReactionCatalog {
+        &self.catalog
+    }
+
+    pub fn actor_state(&self) -> Option<&ReactionActorState> {
+        self.actor_state.as_ref()
+    }
+
+    pub fn aggregates(&self) -> &[ReactionAggregate] {
+        &self.aggregates
+    }
+}
+
+impl<'de> Deserialize<'de> for ReactionSnapshot {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawSnapshot {
+            subject: ReactionSubjectRef,
+            catalog: ReactionCatalog,
+            actor_state: Option<ReactionActorState>,
+            aggregates: Vec<ReactionAggregate>,
+        }
+        let raw = RawSnapshot::deserialize(deserializer)?;
+        Self::try_new(raw.subject, raw.catalog, raw.actor_state, raw.aggregates)
+            .map_err(D::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ReactionReadRequest {
+    subject: ReactionSubjectRef,
+    actor_id: Option<Uuid>,
+}
+
+impl ReactionReadRequest {
+    pub fn new(
+        subject: ReactionSubjectRef,
+        actor_id: Option<Uuid>,
+    ) -> Result<Self, ReactionContractError> {
+        if actor_id.is_some_and(|actor_id| actor_id.is_nil()) {
+            return Err(ReactionContractError::NilIdentity);
+        }
+        Ok(Self { subject, actor_id })
+    }
+
+    pub fn subject(&self) -> &ReactionSubjectRef {
+        &self.subject
+    }
+
+    pub const fn actor_id(&self) -> Option<Uuid> {
+        self.actor_id
+    }
+}
+
+impl<'de> Deserialize<'de> for ReactionReadRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawRequest {
+            subject: ReactionSubjectRef,
+            actor_id: Option<Uuid>,
+        }
+        let raw = RawRequest::deserialize(deserializer)?;
+        Self::new(raw.subject, raw.actor_id).map_err(D::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ReactionWriteReceipt {
+    command_id: Uuid,
+    actor_id: Uuid,
+    subject: ReactionSubjectRef,
+    reaction: ReactionKey,
+    action: ReactionAction,
+    changed: bool,
+    actor_state_revision: u64,
+}
+
+impl ReactionWriteReceipt {
+    pub fn new(
+        command_id: Uuid,
+        actor_id: Uuid,
+        subject: ReactionSubjectRef,
+        reaction: ReactionKey,
+        action: ReactionAction,
+        changed: bool,
+        actor_state_revision: u64,
+    ) -> Result<Self, ReactionContractError> {
+        if command_id.is_nil() || actor_id.is_nil() {
+            return Err(ReactionContractError::NilIdentity);
+        }
+        Ok(Self {
+            command_id,
+            actor_id,
+            subject,
+            reaction,
+            action,
+            changed,
+            actor_state_revision,
+        })
+    }
+
+    pub const fn command_id(&self) -> Uuid {
+        self.command_id
+    }
+
+    pub const fn changed(&self) -> bool {
+        self.changed
+    }
+}
+
+impl<'de> Deserialize<'de> for ReactionWriteReceipt {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawReceipt {
+            command_id: Uuid,
+            actor_id: Uuid,
+            subject: ReactionSubjectRef,
+            reaction: ReactionKey,
+            action: ReactionAction,
+            changed: bool,
+            actor_state_revision: u64,
+        }
+        let raw = RawReceipt::deserialize(deserializer)?;
+        Self::new(
+            raw.command_id,
+            raw.actor_id,
+            raw.subject,
+            raw.reaction,
+            raw.action,
+            raw.changed,
+            raw.actor_state_revision,
+        )
+        .map_err(D::Error::custom)
+    }
+}

--- a/crates/rustok-reactions-api/src/provider.rs
+++ b/crates/rustok-reactions-api/src/provider.rs
@@ -1,0 +1,379 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{HostRuntimeContext, PortContext, PortError};
+use rustok_core::ModuleRuntimeExtensions;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::{
+    ApplyReactionCommand, ReactionCatalog, ReactionContractError, ReactionReadRequest,
+    ReactionSnapshot, ReactionSourceSlug, ReactionSubjectKind, ReactionSubjectRef,
+    ReactionWriteReceipt,
+};
+
+pub const MAX_REACTION_PROVIDER_KINDS: usize = 32;
+
+#[derive(Debug, Error, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "code", rename_all = "snake_case")]
+pub enum ReactionProviderError {
+    #[error("reaction subject capability is unavailable")]
+    CapabilityUnavailable { retryable: bool },
+    #[error("reaction subject request is invalid")]
+    InvalidRequest,
+    #[error("reaction subject is unavailable")]
+    Unavailable,
+    #[error("reaction subject changed concurrently")]
+    Conflict,
+    #[error("reaction subject provider failed")]
+    Internal { retryable: bool },
+}
+
+impl ReactionProviderError {
+    pub const fn is_retryable(self) -> bool {
+        match self {
+            Self::CapabilityUnavailable { retryable } | Self::Internal { retryable } => retryable,
+            Self::Conflict => true,
+            Self::InvalidRequest | Self::Unavailable => false,
+        }
+    }
+}
+
+pub type ReactionProviderResult<T> = Result<T, ReactionProviderError>;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "operation", rename_all = "snake_case")]
+pub enum ReactionSubjectAccess {
+    Read { actor_id: Option<Uuid> },
+    Apply { command: ApplyReactionCommand },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ReactionSubjectRequest {
+    pub subject: ReactionSubjectRef,
+    pub access: ReactionSubjectAccess,
+}
+
+impl ReactionSubjectRequest {
+    pub fn validate(&self) -> Result<(), ReactionContractError> {
+        match &self.access {
+            ReactionSubjectAccess::Read { actor_id } => {
+                if actor_id.is_some_and(|actor_id| actor_id.is_nil()) {
+                    return Err(ReactionContractError::NilIdentity);
+                }
+            }
+            ReactionSubjectAccess::Apply { command } => {
+                if &self.subject != command.subject() {
+                    return Err(ReactionContractError::ProviderSubjectMismatch);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "decision", rename_all = "snake_case")]
+pub enum ReactionSubjectAuthorization {
+    Allowed {
+        canonical_subject: ReactionSubjectRef,
+        catalog: ReactionCatalog,
+    },
+    Unavailable,
+}
+
+impl ReactionSubjectAuthorization {
+    pub fn validate_for(
+        &self,
+        request: &ReactionSubjectRequest,
+    ) -> Result<(), ReactionContractError> {
+        if let Self::Allowed {
+            canonical_subject, ..
+        } = self
+        {
+            if canonical_subject != &request.subject {
+                return Err(ReactionContractError::ProviderSubjectMismatch);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ReactionSubjectRegistryEntry {
+    pub source: ReactionSourceSlug,
+    pub display_name: String,
+    pub supported_kinds: Vec<ReactionSubjectKind>,
+}
+
+#[async_trait]
+pub trait ReactionSubjectProvider: Send + Sync {
+    fn source(&self) -> ReactionSourceSlug;
+
+    fn display_name(&self) -> &'static str;
+
+    fn supported_kinds(&self) -> Vec<ReactionSubjectKind>;
+
+    async fn authorize(
+        &self,
+        context: PortContext,
+        request: ReactionSubjectRequest,
+    ) -> ReactionProviderResult<ReactionSubjectAuthorization>;
+}
+
+pub trait ReactionSubjectProviderFactory: Send + Sync {
+    fn source(&self) -> ReactionSourceSlug;
+
+    fn build(
+        &self,
+        host: &HostRuntimeContext,
+    ) -> ReactionProviderResult<Arc<dyn ReactionSubjectProvider>>;
+}
+
+#[async_trait]
+pub trait ReactionReadPort: Send + Sync {
+    async fn read_reactions(
+        &self,
+        context: PortContext,
+        request: ReactionReadRequest,
+    ) -> Result<ReactionSnapshot, PortError>;
+}
+
+#[async_trait]
+pub trait ReactionWritePort: Send + Sync {
+    async fn apply_reaction(
+        &self,
+        context: PortContext,
+        command: ApplyReactionCommand,
+    ) -> Result<ReactionWriteReceipt, PortError>;
+}
+
+#[derive(Debug, Error, Clone, Eq, PartialEq)]
+pub enum ReactionSubjectRegistryError {
+    #[error("reaction subject source `{0}` is already registered")]
+    DuplicateSource(ReactionSourceSlug),
+    #[error("reaction subject factory `{0}` is already registered")]
+    DuplicateFactory(ReactionSourceSlug),
+    #[error("reaction subject provider `{source}` exposes an invalid kind set")]
+    InvalidKinds { source: ReactionSourceSlug },
+    #[error("reaction subject factory `{declared}` built provider `{built}`")]
+    FactorySourceMismatch {
+        declared: ReactionSourceSlug,
+        built: ReactionSourceSlug,
+    },
+    #[error("reaction subject factory `{source}` failed: {error}")]
+    FactoryBuild {
+        source: ReactionSourceSlug,
+        #[source]
+        error: ReactionProviderError,
+    },
+}
+
+#[derive(Clone, Default)]
+pub struct ReactionSubjectRegistry {
+    providers: BTreeMap<ReactionSourceSlug, Arc<dyn ReactionSubjectProvider>>,
+}
+
+impl ReactionSubjectRegistry {
+    pub fn register<P>(&mut self, provider: P) -> Result<(), ReactionSubjectRegistryError>
+    where
+        P: ReactionSubjectProvider + 'static,
+    {
+        self.register_arc(Arc::new(provider))
+    }
+
+    pub fn register_arc(
+        &mut self,
+        provider: Arc<dyn ReactionSubjectProvider>,
+    ) -> Result<(), ReactionSubjectRegistryError> {
+        let source = provider.source();
+        validate_provider_kinds(&source, provider.supported_kinds())?;
+        if self.providers.contains_key(&source) {
+            return Err(ReactionSubjectRegistryError::DuplicateSource(source));
+        }
+        self.providers.insert(source, provider);
+        Ok(())
+    }
+
+    pub fn get(
+        &self,
+        source: &ReactionSourceSlug,
+    ) -> Option<Arc<dyn ReactionSubjectProvider>> {
+        self.providers.get(source).cloned()
+    }
+
+    pub fn get_by_str(&self, source: &str) -> Option<Arc<dyn ReactionSubjectProvider>> {
+        ReactionSourceSlug::new(source)
+            .ok()
+            .and_then(|source| self.get(&source))
+    }
+
+    pub fn entries(&self) -> Vec<ReactionSubjectRegistryEntry> {
+        self.providers
+            .iter()
+            .map(|(source, provider)| {
+                let mut supported_kinds = provider.supported_kinds();
+                supported_kinds.sort();
+                ReactionSubjectRegistryEntry {
+                    source: source.clone(),
+                    display_name: provider.display_name().to_string(),
+                    supported_kinds,
+                }
+            })
+            .collect()
+    }
+
+    pub fn len(&self) -> usize {
+        self.providers.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.providers.is_empty()
+    }
+}
+
+fn validate_provider_kinds(
+    source: &ReactionSourceSlug,
+    kinds: Vec<ReactionSubjectKind>,
+) -> Result<(), ReactionSubjectRegistryError> {
+    if kinds.is_empty() || kinds.len() > MAX_REACTION_PROVIDER_KINDS {
+        return Err(ReactionSubjectRegistryError::InvalidKinds {
+            source: source.clone(),
+        });
+    }
+    if kinds.iter().collect::<BTreeSet<_>>().len() != kinds.len() {
+        return Err(ReactionSubjectRegistryError::InvalidKinds {
+            source: source.clone(),
+        });
+    }
+    Ok(())
+}
+
+#[derive(Clone, Default)]
+pub struct ReactionSubjectFactoryRegistry {
+    factories: BTreeMap<ReactionSourceSlug, Arc<dyn ReactionSubjectProviderFactory>>,
+}
+
+impl ReactionSubjectFactoryRegistry {
+    pub fn register<F>(&mut self, factory: F) -> Result<(), ReactionSubjectRegistryError>
+    where
+        F: ReactionSubjectProviderFactory + 'static,
+    {
+        self.register_arc(Arc::new(factory))
+    }
+
+    pub fn register_arc(
+        &mut self,
+        factory: Arc<dyn ReactionSubjectProviderFactory>,
+    ) -> Result<(), ReactionSubjectRegistryError> {
+        let source = factory.source();
+        if self.factories.contains_key(&source) {
+            return Err(ReactionSubjectRegistryError::DuplicateFactory(source));
+        }
+        self.factories.insert(source, factory);
+        Ok(())
+    }
+
+    pub fn len(&self) -> usize {
+        self.factories.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.factories.is_empty()
+    }
+}
+
+pub fn ensure_reaction_subject_registry(
+    extensions: &mut ModuleRuntimeExtensions,
+) -> Arc<ReactionSubjectRegistry> {
+    extensions
+        .get_or_insert_with::<Arc<ReactionSubjectRegistry>, _>(|| {
+            Arc::new(ReactionSubjectRegistry::default())
+        })
+        .clone()
+}
+
+pub fn ensure_reaction_subject_factory_registry(
+    extensions: &mut ModuleRuntimeExtensions,
+) -> Arc<ReactionSubjectFactoryRegistry> {
+    extensions
+        .get_or_insert_with::<Arc<ReactionSubjectFactoryRegistry>, _>(|| {
+            Arc::new(ReactionSubjectFactoryRegistry::default())
+        })
+        .clone()
+}
+
+pub fn register_reaction_subject_provider<P>(
+    extensions: &mut ModuleRuntimeExtensions,
+    provider: P,
+) -> Result<(), ReactionSubjectRegistryError>
+where
+    P: ReactionSubjectProvider + 'static,
+{
+    let registry = extensions.get_or_insert_with::<Arc<ReactionSubjectRegistry>, _>(|| {
+        Arc::new(ReactionSubjectRegistry::default())
+    });
+    Arc::make_mut(registry).register(provider)
+}
+
+pub fn register_reaction_subject_provider_factory<F>(
+    extensions: &mut ModuleRuntimeExtensions,
+    factory: F,
+) -> Result<(), ReactionSubjectRegistryError>
+where
+    F: ReactionSubjectProviderFactory + 'static,
+{
+    let registry =
+        extensions.get_or_insert_with::<Arc<ReactionSubjectFactoryRegistry>, _>(|| {
+            Arc::new(ReactionSubjectFactoryRegistry::default())
+        });
+    Arc::make_mut(registry).register(factory)
+}
+
+pub fn materialize_reaction_subject_registry(
+    extensions: &mut ModuleRuntimeExtensions,
+    host: &HostRuntimeContext,
+) -> Result<Arc<ReactionSubjectRegistry>, ReactionSubjectRegistryError> {
+    let mut providers = reaction_subject_registry_from_extensions(extensions)
+        .map(|registry| registry.as_ref().clone())
+        .unwrap_or_default();
+    let factories = reaction_subject_factory_registry_from_extensions(extensions)
+        .unwrap_or_else(|| Arc::new(ReactionSubjectFactoryRegistry::default()));
+
+    for (declared, factory) in &factories.factories {
+        let provider = factory.build(host).map_err(|error| {
+            ReactionSubjectRegistryError::FactoryBuild {
+                source: declared.clone(),
+                error,
+            }
+        })?;
+        let built = provider.source();
+        if &built != declared {
+            return Err(ReactionSubjectRegistryError::FactorySourceMismatch {
+                declared: declared.clone(),
+                built,
+            });
+        }
+        providers.register_arc(provider)?;
+    }
+
+    let providers = Arc::new(providers);
+    extensions.insert(providers.clone());
+    Ok(providers)
+}
+
+pub fn reaction_subject_registry_from_extensions(
+    extensions: &ModuleRuntimeExtensions,
+) -> Option<Arc<ReactionSubjectRegistry>> {
+    extensions.get::<Arc<ReactionSubjectRegistry>>().cloned()
+}
+
+pub fn reaction_subject_factory_registry_from_extensions(
+    extensions: &ModuleRuntimeExtensions,
+) -> Option<Arc<ReactionSubjectFactoryRegistry>> {
+    extensions
+        .get::<Arc<ReactionSubjectFactoryRegistry>>()
+        .cloned()
+}

--- a/crates/rustok-reactions/Cargo.toml
+++ b/crates/rustok-reactions/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rustok-reactions"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Shared reaction catalog, actor state, aggregate, and subject orchestration owner"
+
+[dependencies]
+async-trait.workspace = true
+rustok-core.workspace = true
+rustok-reactions-api = { path = "../rustok-reactions-api" }
+
+[dev-dependencies]
+uuid.workspace = true

--- a/crates/rustok-reactions/README.md
+++ b/crates/rustok-reactions/README.md
@@ -1,0 +1,39 @@
+# rustok-reactions
+
+## Purpose
+
+`rustok-reactions` is the optional shared owner for reusable reactions across
+revisioned subjects owned by other RusToK modules.
+
+## Current source slice
+
+The module currently initializes the neutral subject-provider and deferred
+factory registries and exposes their bounded metadata through
+`ReactionsService`. It contains no persistence, migration, event, worker,
+transport or UI implementation.
+
+## Ownership
+
+The future owner will persist reaction catalogs, actor state, idempotent command
+receipts and aggregate projections. It will not own subject existence,
+visibility, lifecycle, content, profile identity, reputation, achievements or
+notifications.
+
+Each producer module publishes a provider through `rustok-reactions-api` and
+remains authoritative for the current subject revision and reaction policy. The
+Reactions owner never reads producer-private tables.
+
+## Degraded mode
+
+The module is optional and is not default-enabled. With Reactions absent,
+producer modules keep their ordinary owner commands and may hide reaction UI.
+Existing Forum votes remain unchanged.
+
+## Entry points
+
+- `ReactionsModule`
+- `ReactionsService`
+- re-exported `rustok_reactions_api` contracts
+
+See [module contract](docs/README.md) and
+[implementation plan](docs/implementation-plan.md).

--- a/crates/rustok-reactions/contracts/reactions-foundation.json
+++ b/crates/rustok-reactions/contracts/reactions-foundation.json
@@ -1,0 +1,84 @@
+{
+  "schema_version": 1,
+  "module": "reactions",
+  "contract": "reactions_foundation_v1",
+  "status": "source_ready_maintainer_execution_pending",
+  "api_crate": "crates/rustok-reactions-api",
+  "owner_crate": "crates/rustok-reactions",
+  "required_files": [
+    "crates/rustok-reactions-api/Cargo.toml",
+    "crates/rustok-reactions-api/src/lib.rs",
+    "crates/rustok-reactions-api/src/model.rs",
+    "crates/rustok-reactions-api/src/provider.rs",
+    "crates/rustok-reactions-api/README.md",
+    "crates/rustok-reactions-api/docs/README.md",
+    "crates/rustok-reactions-api/docs/implementation-plan.md",
+    "crates/rustok-reactions/Cargo.toml",
+    "crates/rustok-reactions/src/lib.rs",
+    "crates/rustok-reactions/rustok-module.toml",
+    "crates/rustok-reactions/README.md",
+    "crates/rustok-reactions/docs/README.md",
+    "crates/rustok-reactions/docs/implementation-plan.md"
+  ],
+  "required_api_symbols": [
+    "ReactionSourceSlug",
+    "ReactionSubjectKind",
+    "ReactionKey",
+    "ReactionSubjectRef",
+    "ReactionSelectionPolicy",
+    "ReactionCatalog",
+    "ReactionCommandIdentity",
+    "ApplyReactionCommand",
+    "ReactionReadPort",
+    "ReactionWritePort",
+    "ReactionSubjectProvider",
+    "ReactionSubjectProviderFactory",
+    "ReactionSubjectRegistry"
+  ],
+  "required_limits": [
+    "MAX_REACTION_CATALOG_SIZE",
+    "MAX_REACTIONS_PER_ACTOR",
+    "MAX_REACTION_PROVIDER_KINDS"
+  ],
+  "forbidden_api_dependencies": [
+    "rustok-forum",
+    "rustok-blog",
+    "rustok-comments",
+    "rustok-profiles",
+    "rustok-media",
+    "sea-orm",
+    "sea-orm-migration",
+    "async-graphql",
+    "axum",
+    "leptos"
+  ],
+  "forbidden_owner_dependencies": [
+    "rustok-forum",
+    "rustok-blog",
+    "rustok-comments",
+    "rustok-profiles",
+    "rustok-media",
+    "sea-orm",
+    "sea-orm-migration",
+    "async-graphql",
+    "axum",
+    "leptos"
+  ],
+  "deliberate_limits": [
+    "no persistence",
+    "no migrations",
+    "no producer-private table reads",
+    "no transports",
+    "no UI",
+    "no Forum vote migration",
+    "no reputation or achievement ownership"
+  ],
+  "verification": [
+    "cargo test -p rustok-reactions-api",
+    "cargo test -p rustok-reactions",
+    "cargo check -p rustok-reactions-api --all-targets",
+    "cargo check -p rustok-reactions --all-targets",
+    "node scripts/verify/verify-reactions-foundation.mjs",
+    "git diff --check"
+  ]
+}

--- a/crates/rustok-reactions/docs/README.md
+++ b/crates/rustok-reactions/docs/README.md
@@ -1,0 +1,39 @@
+# Reactions module contract
+
+`rustok-reactions` is an optional first-party module. It depends on Outbox for
+its future transactional event boundary but this foundation does not yet publish
+or consume events.
+
+## Runtime composition
+
+Module registration initializes two empty runtime-extension registries:
+
+- immediate `ReactionSubjectProvider` instances;
+- deferred `ReactionSubjectProviderFactory` instances materialized after
+  `HostRuntimeContext` exists.
+
+A source slug is unique across both the materialized provider set and each
+registry. Missing providers are explicit capability-unavailable states and do
+not authorize a subject.
+
+## Data boundary
+
+No reaction tables, migrations or owner commands exist in this source slice.
+The eventual owner must persist complete tenant/source/kind/subject/revision
+identity, actor identity, canonical reaction key, action and command UUID. It
+must never use a subject label or route as identity.
+
+## UI and transports
+
+No GraphQL, REST, native server functions, Leptos or Next package is registered.
+UI remains hidden while the owner persistence boundary is absent.
+
+## Verification
+
+```bash
+cargo test -p rustok-reactions
+cargo check -p rustok-reactions --all-targets
+node scripts/verify/verify-reactions-foundation.mjs
+```
+
+No successful execution is claimed by the implementation source.

--- a/crates/rustok-reactions/docs/implementation-plan.md
+++ b/crates/rustok-reactions/docs/implementation-plan.md
@@ -1,0 +1,52 @@
+---
+id: doc://crates/rustok-reactions/docs/implementation-plan.md
+kind: module_implementation_plan
+language: en
+status: active
+owners:
+  - rustok-reactions
+last_reviewed: 2026-08-06
+---
+
+# `rustok-reactions` implementation plan
+
+## Program ledger
+
+| Task | Status | Deliverable |
+| --- | --- | --- |
+| `REACTIONS-00` | `in_progress` | Neutral API, optional module registration and provider registry exist; maintainer verification remains. |
+| `REACTIONS-01` | `planned` | PostgreSQL/SQLite owner persistence, catalog revisions, actor uniqueness and idempotent command receipts. |
+| `REACTIONS-02` | `planned` | Atomic aggregate updates, semantic events and reconciliation. |
+| `REACTIONS-03` | `planned` | Forum topic/reply subject adapter and degraded profile. |
+| `REACTIONS-04` | `planned` | Second real producer adapter and neutral-contract review. |
+| `REACTIONS-05` | `planned` | Bounded read/write transports and module-owned UI. |
+| `REACTIONS-06` | `planned` | Runtime evidence, FBA contracts, import/reconciliation and release profiles. |
+
+## Ownership
+
+Reactions owns catalog revisions, actor reaction state, write receipts and
+aggregate projections. Producer modules own subject existence, content,
+revision, visibility and reaction policy. Profiles owns actor presentation.
+Reputation and achievements consume semantic facts but do not mutate reaction
+state. Notifications may consume reaction events but are not part of reaction
+command correctness.
+
+## Immediate next action
+
+Implement `REACTIONS-01` as one bounded persistence owner. Require tenant-
+composite identity, one actor/key relation, one command UUID payload identity,
+explicit catalog revision, checked single/multi selection and atomic aggregate
+changes. Do not add Forum adapters, transports or UI in the persistence PR.
+
+## Verification
+
+```bash
+cargo test -p rustok-reactions-api
+cargo test -p rustok-reactions
+cargo check -p rustok-reactions-api --all-targets
+cargo check -p rustok-reactions --all-targets
+node scripts/verify/verify-reactions-foundation.mjs
+git diff --check
+```
+
+Tests and checks are maintainer-run.

--- a/crates/rustok-reactions/rustok-module.toml
+++ b/crates/rustok-reactions/rustok-module.toml
@@ -1,0 +1,20 @@
+[module]
+slug = "reactions"
+name = "Reactions"
+version = "0.1.0"
+description = "Shared bounded reactions with source-owned subject authorization"
+ownership = "first_party"
+trust_level = "verified"
+ui_classification = "future_ui"
+
+[dependencies]
+outbox = { version_req = ">=0.1.0" }
+
+[crate]
+entry_type = "ReactionsModule"
+
+[marketplace]
+category = "content"
+publisher = "rustok"
+tags = ["reactions", "social", "engagement"]
+description = "Reusable reactions for revisioned subjects owned by platform modules."

--- a/crates/rustok-reactions/src/lib.rs
+++ b/crates/rustok-reactions/src/lib.rs
@@ -1,0 +1,100 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_core::{ModuleRuntimeExtensions, RusToKModule};
+use rustok_reactions_api::{
+    ReactionSubjectRegistry, ReactionSubjectRegistryEntry,
+    ensure_reaction_subject_factory_registry, ensure_reaction_subject_registry,
+    reaction_subject_registry_from_extensions,
+};
+
+pub use rustok_reactions_api as api;
+
+#[derive(Clone)]
+pub struct ReactionsService {
+    subjects: Arc<ReactionSubjectRegistry>,
+}
+
+impl ReactionsService {
+    pub fn from_runtime_extensions(extensions: &ModuleRuntimeExtensions) -> Self {
+        let subjects = reaction_subject_registry_from_extensions(extensions)
+            .unwrap_or_else(|| Arc::new(ReactionSubjectRegistry::default()));
+        Self { subjects }
+    }
+
+    pub fn subject_sources(&self) -> Vec<ReactionSubjectRegistryEntry> {
+        self.subjects.entries()
+    }
+
+    pub fn subject_source_count(&self) -> usize {
+        self.subjects.len()
+    }
+
+    pub fn has_subject_sources(&self) -> bool {
+        !self.subjects.is_empty()
+    }
+}
+
+pub struct ReactionsModule;
+
+#[async_trait]
+impl RusToKModule for ReactionsModule {
+    fn slug(&self) -> &'static str {
+        "reactions"
+    }
+
+    fn name(&self) -> &'static str {
+        "Reactions"
+    }
+
+    fn description(&self) -> &'static str {
+        "Shared bounded reactions with source-owned subject authorization"
+    }
+
+    fn version(&self) -> &'static str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    fn dependencies(&self) -> &[&'static str] {
+        &["outbox"]
+    }
+
+    fn register_runtime_extensions(
+        &self,
+        extensions: &mut ModuleRuntimeExtensions,
+    ) -> rustok_core::Result<()> {
+        let _ = ensure_reaction_subject_registry(extensions);
+        let _ = ensure_reaction_subject_factory_registry(extensions);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rustok_core::{ModuleRuntimeExtensions, RusToKModule};
+    use rustok_reactions_api::{
+        reaction_subject_factory_registry_from_extensions,
+        reaction_subject_registry_from_extensions,
+    };
+
+    use super::{ReactionsModule, ReactionsService};
+
+    #[test]
+    fn module_initializes_empty_subject_registries() {
+        let module = ReactionsModule;
+        assert_eq!(module.slug(), "reactions");
+        assert_eq!(module.dependencies(), &["outbox"]);
+
+        let mut extensions = ModuleRuntimeExtensions::default();
+        module
+            .register_runtime_extensions(&mut extensions)
+            .expect("reaction runtime extensions should initialize");
+
+        assert!(reaction_subject_registry_from_extensions(&extensions).is_some());
+        assert!(reaction_subject_factory_registry_from_extensions(&extensions).is_some());
+
+        let service = ReactionsService::from_runtime_extensions(&extensions);
+        assert_eq!(service.subject_source_count(), 0);
+        assert!(!service.has_subject_sources());
+    }
+}

--- a/modules.toml
+++ b/modules.toml
@@ -51,6 +51,7 @@ customer = { crate = "rustok-customer", source = "path", path = "crates/rustok-c
 product = { crate = "rustok-product", source = "path", path = "crates/rustok-product", depends_on = ["taxonomy"] }
 profiles = { crate = "rustok-profiles", source = "path", path = "crates/rustok-profiles", depends_on = ["media", "social_graph", "taxonomy"] }
 social_graph = { crate = "rustok-social-graph", source = "path", path = "crates/rustok-social-graph", depends_on = ["outbox"] }
+reactions = { crate = "rustok-reactions", source = "path", path = "crates/rustok-reactions", depends_on = ["outbox"] }
 groups = { crate = "rustok-groups", source = "path", path = "crates/rustok-groups" }
 region = { crate = "rustok-region", source = "path", path = "crates/rustok-region" }
 pricing = { crate = "rustok-pricing", source = "path", path = "crates/rustok-pricing", depends_on = ["product"] }

--- a/scripts/verify/verify-forum-shared-capability-ownership.mjs
+++ b/scripts/verify/verify-forum-shared-capability-ownership.mjs
@@ -42,6 +42,7 @@ for (const slug of [
   "profiles",
   "media",
   "social_graph",
+  "reactions",
   "moderation",
   "notifications",
   "translation",
@@ -70,6 +71,17 @@ for (const fragment of [
   "MediaAssetReadPort",
 ]) {
   if (!media.includes(fragment)) fail(`Media owner contract is missing: ${fragment}`);
+}
+
+const reactions = read("crates/rustok-reactions/README.md");
+for (const fragment of [
+  "optional shared owner for reusable reactions",
+  "never reads producer-private tables",
+  "Existing Forum votes remain unchanged",
+]) {
+  if (!reactions.includes(fragment)) {
+    fail(`Reactions owner contract is missing: ${fragment}`);
+  }
 }
 
 const moderation = read("crates/rustok-moderation/README.md");

--- a/scripts/verify/verify-reactions-foundation.mjs
+++ b/scripts/verify/verify-reactions-foundation.mjs
@@ -1,0 +1,124 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath = path.join(
+  repoRoot,
+  "crates/rustok-reactions/contracts/reactions-foundation.json",
+);
+const contract = JSON.parse(readFileSync(contractPath, "utf8"));
+
+function fail(message) {
+  throw new Error(`Reactions foundation verification failed: ${message}`);
+}
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!existsSync(absolute)) fail(`missing required file ${relativePath}`);
+  return readFileSync(absolute, "utf8");
+}
+
+if (contract.schema_version !== 1) fail("unsupported contract schema version");
+if (contract.module !== "reactions") fail("contract module must be reactions");
+if (contract.contract !== "reactions_foundation_v1") {
+  fail("unexpected contract identity");
+}
+
+for (const relativePath of contract.required_files) read(relativePath);
+
+const apiCargo = read("crates/rustok-reactions-api/Cargo.toml");
+const apiSource = [
+  read("crates/rustok-reactions-api/src/lib.rs"),
+  read("crates/rustok-reactions-api/src/model.rs"),
+  read("crates/rustok-reactions-api/src/provider.rs"),
+].join("\n");
+const ownerCargo = read("crates/rustok-reactions/Cargo.toml");
+const ownerSource = read("crates/rustok-reactions/src/lib.rs");
+
+for (const symbol of contract.required_api_symbols) {
+  if (!apiSource.includes(symbol)) fail(`neutral API is missing ${symbol}`);
+}
+for (const limit of contract.required_limits) {
+  if (!apiSource.includes(limit)) fail(`neutral API is missing bound ${limit}`);
+}
+for (const dependency of contract.forbidden_api_dependencies) {
+  if (apiCargo.includes(dependency)) {
+    fail(`neutral API imports forbidden dependency ${dependency}`);
+  }
+}
+for (const dependency of contract.forbidden_owner_dependencies) {
+  if (ownerCargo.includes(dependency)) {
+    fail(`foundation owner imports forbidden dependency ${dependency}`);
+  }
+}
+
+for (const fragment of [
+  "tenant_id",
+  "subject_revision",
+  "command_id",
+  "actor_id",
+  "ReactionSelectionPolicy",
+  "register_reaction_subject_provider",
+  "materialize_reaction_subject_registry",
+]) {
+  if (!apiSource.includes(fragment)) fail(`neutral API is missing ${fragment}`);
+}
+
+for (const fragment of [
+  "ReactionsModule",
+  "ensure_reaction_subject_registry",
+  "ensure_reaction_subject_factory_registry",
+  "&[\"outbox\"]",
+]) {
+  if (!ownerSource.includes(fragment)) fail(`owner foundation is missing ${fragment}`);
+}
+
+for (const forbiddenPath of [
+  "crates/rustok-reactions/src/entities",
+  "crates/rustok-reactions/src/migrations",
+  "crates/rustok-reactions/migrations",
+  "crates/rustok-reactions/admin",
+  "crates/rustok-reactions/storefront",
+]) {
+  if (existsSync(path.join(repoRoot, forbiddenPath))) {
+    fail(`foundation unexpectedly contains ${forbiddenPath}`);
+  }
+}
+
+const modules = read("modules.toml");
+if (!/^reactions\s*=\s*\{[^\n]*crate\s*=\s*"rustok-reactions"/mu.test(modules)) {
+  fail("modules.toml does not register the reactions owner");
+}
+const defaultEnabled = modules.match(/default_enabled\s*=\s*\[[\s\S]*?\]/mu)?.[0] ?? "";
+if (/"reactions"/u.test(defaultEnabled)) {
+  fail("reactions must remain outside default_enabled in this foundation slice");
+}
+
+const manifest = read("crates/rustok-reactions/rustok-module.toml");
+for (const fragment of [
+  'slug = "reactions"',
+  'entry_type = "ReactionsModule"',
+  'outbox = { version_req = ">=0.1.0" }',
+]) {
+  if (!manifest.includes(fragment)) fail(`module manifest is missing ${fragment}`);
+}
+
+const forumPlan = read("crates/rustok-forum/docs/implementation-plan.md");
+for (const fragment of [
+  "| Reaction catalog, actor reactions and aggregate reaction counts | `rustok-reactions` |",
+  "| `FORUM-18` | `in_progress` |",
+  "Add the Forum topic/reply `ReactionSubjectProvider` adapter",
+  "Existing Forum votes remain Forum semantics",
+]) {
+  if (!forumPlan.includes(fragment)) fail(`Forum plan is missing ${fragment}`);
+}
+
+const forumOwnership = JSON.parse(
+  read("crates/rustok-forum/contracts/forum-shared-capability-ownership.json"),
+);
+if (forumOwnership.required_shared_owners.reactions !== "rustok-reactions") {
+  fail("Forum ownership contract does not name the active Reactions owner");
+}
+
+console.log("Reactions neutral capability foundation verified.");


### PR DESCRIPTION
## Summary

Introduce the first ownership-safe shared Reactions slice without coupling it to Forum or any other producer module.

- add `rustok-reactions-api` with bounded source/kind/key contracts;
- bind every subject to tenant, source, kind, UUID and positive owner revision;
- add explicit single- or bounded multi-selection catalogs;
- add caller-provided command UUID plus actor identity for future idempotent writes;
- add bounded actor state and aggregate snapshots that reject keys outside the authorized catalog;
- publish neutral read/write ports with typed `PortError` results;
- publish source-owned `ReactionSubjectProvider` and deferred factory contracts;
- add unique runtime-extension provider/factory registries with exact source and kind validation;
- add optional `rustok-reactions` module registration outside `default_enabled`;
- initialize only empty registries through `ReactionsModule` and expose bounded registry metadata through `ReactionsService`;
- add machine-readable ownership/source contracts and fail-closed verifiers;
- update the canonical Forum plan so FORUM-18 is `in_progress` only for the neutral foundation.

## Ownership boundary

Producer modules remain authoritative for subject existence, current revision, visibility, lifecycle and reaction policy. The Reactions owner never reads Forum, Blog, Comments, Profiles, Media, Groups or Commerce private tables.

Existing Forum votes remain Forum-specific semantics. This PR does not reinterpret, migrate or replace them. Reputation, achievements and Notifications remain separate capabilities.

## Deliberate limits

This PR does not add:

- SeaORM entities or PostgreSQL/SQLite migrations;
- reaction catalog, actor-state, receipt or aggregate persistence;
- transactional reaction events or workers;
- Forum topic/reply adapters or any producer dependency;
- GraphQL, REST, native server functions or host routes;
- Leptos/Next UI packages;
- reputation, achievements, ranking or notification behavior;
- default enablement.

## Main recheck

Based directly on `main@d4014c06a3d1fedb04461b08367c2ea1c57e5b83`, one commit ahead and zero behind at PR creation. The intervening main delta was Index-only and did not overlap this slice.

## Validation

Not run per maintainer instruction:

- Rust unit tests;
- Cargo checks, formatting or Clippy;
- Node verifiers;
- module validation;
- workflows or CI.

Suggested maintainer commands:

```bash
cargo test -p rustok-reactions-api
cargo test -p rustok-reactions
cargo check -p rustok-reactions-api --all-targets
cargo check -p rustok-reactions --all-targets
node scripts/verify/verify-reactions-foundation.mjs
node scripts/verify/verify-forum-shared-capability-ownership.mjs
git diff --check
```

Source status remains `source_ready_maintainer_execution_pending`.