### PR TITLE
test(index): lock concrete repair evidence admission

### DIFF
--- a/crates/rustok-index/contracts/evidence/concrete-repair-postgres-execution-contract.json
+++ b/crates/rustok-index/contracts/evidence/concrete-repair-postgres-execution-contract.json
@@ -1,0 +1,139 @@
+{
+  "schema_version": 1,
+  "module": "rustok-index",
+  "packet": "concrete-repair-postgres-execution-contract",
+  "status": "runtime_execution_contract_locked",
+  "runner": "scripts/evidence/capture-index-repair-postgres.mjs",
+  "verifier": "scripts/verify/verify-index-repair-retained-evidence.mjs",
+  "evidence_path": "crates/rustok-index/contracts/evidence/concrete-repair-postgres-execution.json",
+  "stdout_path": "crates/rustok-index/contracts/evidence/concrete-repair-postgres-execution.stdout.log",
+  "stderr_path": "crates/rustok-index/contracts/evidence/concrete-repair-postgres-execution.stderr.log",
+  "execution_scope": "opt_in_postgresql_runtime_execution_pending",
+  "promotion_gate": "requires_clean_commit_current_sources_and_all_required_cases_passed",
+  "database_url_env": "RUSTOK_INDEX_TEST_DATABASE_URL",
+  "database_url_fallback_env": "DATABASE_URL",
+  "commands": [
+    {
+      "program": "cargo",
+      "args": [
+        "test",
+        "-p",
+        "rustok-index",
+        "--test",
+        "drift_repair_postgres_environment_test",
+        "--",
+        "--nocapture",
+        "--test-threads=1"
+      ]
+    },
+    {
+      "program": "cargo",
+      "args": [
+        "test",
+        "-p",
+        "rustok-index",
+        "--test",
+        "drift_repair_recovery_postgres_test",
+        "--",
+        "--nocapture",
+        "--test-threads=1"
+      ]
+    },
+    {
+      "program": "cargo",
+      "args": [
+        "test",
+        "-p",
+        "rustok-index",
+        "--test",
+        "drift_repair_concrete_execution_postgres_test",
+        "--",
+        "--nocapture",
+        "--test-threads=1"
+      ]
+    }
+  ],
+  "source_files": [
+    "crates/rustok-index/tests/drift_repair_postgres_environment_test.rs",
+    "crates/rustok-index/tests/drift_repair_recovery_postgres_test.rs",
+    "crates/rustok-index/tests/drift_repair_concrete_execution_postgres_test.rs",
+    "crates/rustok-index/tests/support/drift_repair.rs",
+    "crates/rustok-index/src/infrastructure/postgres/drift_repair.rs",
+    "crates/rustok-index/src/infrastructure/postgres/drift_repair_recovery.rs",
+    "crates/rustok-index/src/infrastructure/postgres/drift_missing_entity_repair.rs",
+    "crates/rustok-index/src/infrastructure/postgres/drift_orphan_link_repair.rs",
+    "crates/rustok-index/src/infrastructure/postgres/mutation_store.rs",
+    "crates/rustok-index/src/infrastructure/postgres/drift_confirmed_candidate_writer.rs",
+    "crates/rustok-index/src/infrastructure/postgres/schema_registration.rs",
+    "crates/rustok-index/src/migrations/mod.rs",
+    "crates/rustok-index/src/migrations/m20260806_000007_add_index_finding_repair_commands.rs",
+    "crates/rustok-index/src/migrations/m20260806_000008_add_index_finding_repair_recovery.rs"
+  ],
+  "required_metadata": [
+    "git_commit",
+    "started_at",
+    "completed_at",
+    "database_url_source",
+    "database_url_class",
+    "postgres_server_version",
+    "postgres_server_version_num",
+    "cargo_version",
+    "rustc_version",
+    "source_sha256",
+    "stdout_sha256",
+    "stderr_sha256",
+    "final_status"
+  ],
+  "required_cases": [
+    {
+      "case": "migrations_recovery_guard_and_concurrent_reservation_are_executable",
+      "command_index": 1,
+      "assertions": [
+        "one_active_command_per_finding",
+        "revision_zero_activation_retained",
+        "command_uuid_payload_reuse_rejected",
+        "pause_exact_replay_and_stale_revision_retained",
+        "paused_completion_trigger_rejected",
+        "authorized_resume_allows_completion",
+        "completed_command_identity_immutable",
+        "repair_and_recovery_migrations_reverse_cleanly"
+      ]
+    },
+    {
+      "case": "missing_and_orphan_crash_windows_resume_exactly",
+      "command_index": 2,
+      "assertions": [
+        "missing_owner_commit_survives_pre_receipt_crash",
+        "missing_exact_command_retry_converges",
+        "orphan_edge_and_inbox_commit_atomically",
+        "orphan_exact_command_retry_requires_applied_delivery",
+        "source_version_and_unrelated_ordinal_preserved",
+        "terminal_replay_returns_already_completed"
+      ]
+    },
+    {
+      "case": "recovery_admission_fences_side_effect_and_completion",
+      "command_index": 2,
+      "assertions": [
+        "pause_before_owner_prevents_side_effect",
+        "authorized_resume_reuses_exact_command",
+        "abandon_after_side_effect_prevents_completion",
+        "abandoned_retry_remains_terminally_fenced",
+        "database_trigger_rejects_abandoned_completion"
+      ]
+    },
+    {
+      "case": "orphan_commitments_and_normal_mutations_fail_closed",
+      "command_index": 2,
+      "assertions": [
+        "source_version_movement_rejected",
+        "exact_link_substitution_rejected",
+        "target_restoration_rejected",
+        "absence_version_movement_rejected",
+        "normal_full_mutation_serializes_before_exact_edge_owner",
+        "newer_source_and_link_graph_preserved"
+      ]
+    }
+  ],
+  "evidence_status": "runtime_execution_pending"
+}

--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -42,6 +42,7 @@ This directory contains the detailed technical architecture documentation for `r
 - [M6 Concrete Orphan-link Repair](./m6-orphan-link-repair-composition.md)
 - [M6 Prepared Repair Recovery](./m6-prepared-repair-recovery.md)
 - [M6 Concrete Repair PostgreSQL Harness](./m6-repair-execution-postgres-harness.md)
+- [M6 Concrete Repair Retained Evidence Admission](./m6-repair-retained-evidence-admission.md)
 - [M6 Product Locale Absence PostgreSQL Harness](./m6-product-locale-absence-postgres-harness.md)
 - [M6 GraphQL Exact-entity Diagnosis Transport](../../../apps/server/docs/index-drift-diagnosis-graphql-transport.md)
 - [M6 One-page Missing-entity Diagnosis](../../../apps/server/docs/index-drift-source-page-diagnosis.md)

--- a/crates/rustok-index/docs/implementation-main-delta-2026-08-06-1525.md
+++ b/crates/rustok-index/docs/implementation-main-delta-2026-08-06-1525.md
@@ -1,46 +1,58 @@
-# `rustok-index` main delta — 2026-08-06 15:37 UTC
+# `rustok-index` main delta — 2026-08-06 admission recheck
 
-Active branch: `agent/index-m6-repair-execution-evidence-20260806`.
+Active branch: `agent/index-m6-repair-evidence-admission-20260806`.
 
-Stack parent: `agent/index-m6-orphan-link-repair-20260806@8c36960608ef387b5e36f2b5904c6ea83ceda752` / PR #3075.
+Stack parent: `agent/index-m6-repair-execution-evidence-20260806@aab4f9418317f965d540adf538ede2e1660785d1` / PR #3083.
 
-Parent PR dependency: `agent/index-m6-prepared-repair-recovery-20260806@7ababf39e26de9d2039c864d5092147d52d50d1a` / PR #3067.
+Parent dependencies:
 
-Latest rechecked main: `main@af2677a1784f7072c7bf3460eb9d03035785d9c4`.
+- `agent/index-m6-orphan-link-repair-20260806@8c36960608ef387b5e36f2b5904c6ea83ceda752` / PR #3075;
+- `agent/index-m6-prepared-repair-recovery-20260806@7ababf39e26de9d2039c864d5092147d52d50d1a` / PR #3067.
+
+Latest rechecked main: `main@fae8e537e9712e63350ab93248cab23a8c1eafaf`.
 
 ## Intervening main delta
 
-The complete `main@b564f764fc28b12da55b2a0db0d8b4e94c97b0d4..main@af2677a1784f7072c7bf3460eb9d03035785d9c4`
-delta contains seven commits. Changed paths are confined to Commerce and Customer diagnostic safety,
-Forum/Search canonical route cutover and its source-ready PostgreSQL reindex harness, and Page Builder
-inline-session DOM hardening.
+The complete `main@b564f764fc28b12da55b2a0db0d8b4e94c97b0d4..main@fae8e537e9712e63350ab93248cab23a8c1eafaf`
+delta contains ten commits. Changed paths are confined to:
 
-No `crates/rustok-index` source, migration, documentation, integration-test, or Index verifier path
-changed. There is no path overlap with the prepared-repair recovery slice, orphan-link repair slice,
-or this repair execution harness.
+- Commerce, Customer, and Region diagnostic or GraphQL error-boundary hardening;
+- Forum/Search canonical route projection, reindex evidence, native-host route evidence, and exact
+  storefront route validation;
+- Page Builder inline-session DOM hardening;
+- Storefront Forum category/topic route validation.
+
+No `crates/rustok-index` source, migration, documentation, contract, integration-test, evidence
+runner, or Index verifier path changed. There is no path overlap with the prepared-repair recovery,
+orphan-link repair, repair execution harness, or retained-evidence admission slices.
 
 ## Stacked PR boundary
 
-This branch deliberately starts from PR #3075 because the executable scenarios exercise the concrete
-orphan-link owner introduced there and the recovery-aware boundary from #3067. A pull request from
-this branch to `main` therefore includes both parent slices until they land. After #3067 and #3075
-merge, the remaining diff is the repair execution evidence packet only.
+This branch deliberately starts from PR #3083 because the locked admission commands execute the
+metadata target and both concrete PostgreSQL targets introduced there. PR #3083 is stacked on #3075,
+which is stacked on #3067.
+
+A pull request from this branch to `main` therefore includes all parent slices until they land. After
+#3067, #3075, and #3083 merge, the remaining diff is the concrete repair retained-evidence admission
+packet only.
 
 ## Review scope
 
 The new slice adds only:
 
-- two env-gated `rustok-index` PostgreSQL integration targets;
-- their shared isolated-schema fixture;
-- one architecture/runbook document;
-- live plan and documentation index updates;
-- one static source guard and aggregate registration.
+- one bounded PostgreSQL environment metadata integration target;
+- one locked JSON execution contract;
+- one clean-commit capture runner with source hashing and credential redaction;
+- one pending/executed retained-evidence verifier;
+- admission and harness documentation updates;
+- live plan, documentation index, static harness guard, and aggregate verifier updates.
 
 No production runtime, public transport, migration, domain, application, or PostgreSQL adapter source
-is modified.
+is modified. No runtime evidence packet or retained stdout/stderr log is included before owner
+execution.
 
 ## Validation boundary
 
-This is a source-level overlap and concurrency review only. Tests, Node verifiers, formatting, Cargo
-checks, migrations, PostgreSQL scenarios, workflows, and CI were not executed by the implementation
-agent.
+This is a source-level contract and overlap review only. Tests, Node verifiers, formatting, Cargo
+checks, migrations, PostgreSQL scenarios, evidence capture, workflows, and CI were not executed by
+the implementation agent.

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-03.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-03.md
@@ -1,9 +1,9 @@
 # Current `rustok-index` implementation plan — 2026-08-03
 
 Status overlay rechecked against the current main snapshot retained in
-`implementation-main-delta-2026-08-06-1525.md`, stacked parent PR #3075 at
-`8c36960608ef387b5e36f2b5904c6ea83ceda752`, and active branch
-`agent/index-m6-repair-execution-evidence-20260806`.
+`implementation-main-delta-2026-08-06-1525.md`, stacked parent PR #3083 at
+`aab4f9418317f965d540adf538ede2e1660785d1`, and active branch
+`agent/index-m6-repair-evidence-admission-20260806`.
 
 When this dated overlay conflicts with the older canonical plan, this file is the current source of
 truth. Historical architecture and milestone context remain in `implementation-plan.md`.
@@ -26,6 +26,12 @@ mutation, finding, repair, recovery, evidence, and owner adapters through these 
 
 - `drift_repair_recovery_postgres_test`;
 - `drift_repair_concrete_execution_postgres_test`.
+
+The clean-commit retained-evidence admission boundary is
+`source_complete_owner_execution_pending`. It locks one PostgreSQL metadata target, both scenario
+commands, current source hashes, required case names, bounded database/toolchain metadata, complete
+credential-redacted stdout/stderr, and an atomic terminal pass packet. The packet and logs remain
+absent until the repository owner executes the capture runner.
 
 Concrete missing-entity repair:
 
@@ -96,6 +102,8 @@ remain open.
   `source_complete_recovery_aware_owner_execution_pending`
 - M6 concrete repair PostgreSQL execution harness:
   `source_ready_owner_execution_pending`
+- M6 concrete repair retained evidence admission tooling:
+  `source_complete_owner_execution_pending`
 - M7 Product/ProductVariant/SalesChannel bounded replay graph:
   `source_complete_owner_execution_pending`
 
@@ -171,6 +179,8 @@ remain open.
 - [x] Require exact applied inbox proof before admitting an absent edge as convergence.
 - [x] Add env-gated real-migration PostgreSQL targets for concrete repair crash, retry, recovery,
       commitment-change, and concurrency scenarios.
+- [x] Lock a clean-commit capture contract with source hashes, bounded PostgreSQL/toolchain metadata,
+      required case names, complete credential-redacted logs, and atomic admission verification.
 - [ ] Run and admit the concrete repair PostgreSQL targets with retained database/version/result
       metadata.
 - [ ] Add time-derived lease expiry only with retained owner-liveness and crash-window evidence.
@@ -192,17 +202,17 @@ remain open.
 Execute and admit the source-ready concrete repair PostgreSQL packet before exposing repair through a
 public command surface or automatic iterator.
 
-The owner run must retain:
+The owner must run the locked capture command from a clean commit. The retained packet must include:
 
 - PostgreSQL server version and database URL class without credentials;
-- exact commit SHA and both target command lines;
+- exact commit SHA and the metadata plus both scenario target command lines;
 - migration up/down and repair/recovery trigger results;
 - missing-entity and orphan-link post-owner crash/retry results;
 - pause-before-owner and abandon-before-completion race results;
 - command UUID reuse, stale revision, duplicate decision, and completion immutability results;
 - changed source/link/target/absence commitment results;
 - normal full-mutation versus exact edge-owner serialization results;
-- complete stdout/stderr and final pass/fail status.
+- complete credential-redacted stdout/stderr and final pass status.
 
 Public authorization transport, automatic iteration, time-derived leases, and lifecycle
 auto-resolution remain separate later slices.
@@ -211,15 +221,9 @@ auto-resolution remain separate later slices.
 
 ```bash
 RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
-  cargo test -p rustok-index \
-  --test drift_repair_recovery_postgres_test \
-  -- --nocapture --test-threads=1
+  node scripts/evidence/capture-index-repair-postgres.mjs
 
-RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
-  cargo test -p rustok-index \
-  --test drift_repair_concrete_execution_postgres_test \
-  -- --nocapture --test-threads=1
-
+node scripts/verify/verify-index-repair-retained-evidence.mjs
 node scripts/verify/verify-index-repair-execution-postgres-harness.mjs
 node scripts/verify/verify-index-prepared-repair-recovery.mjs
 node scripts/verify/verify-index-missing-entity-repair-composition.mjs

--- a/crates/rustok-index/docs/m6-repair-execution-postgres-harness.md
+++ b/crates/rustok-index/docs/m6-repair-execution-postgres-harness.md
@@ -12,18 +12,24 @@ The packet is executable source, not admitted production evidence. It retains th
 assertions the repository owner must run before a public command surface, automatic iterator, or
 time-derived ownership policy can be considered.
 
+The locked retained-evidence contract, clean-commit capture runner, and admission verifier are
+documented separately in
+[`m6-repair-retained-evidence-admission.md`](./m6-repair-retained-evidence-admission.md).
+
 ## Executable targets
 
 The harness lives in:
 
 ```text
+crates/rustok-index/tests/drift_repair_postgres_environment_test.rs
 crates/rustok-index/tests/drift_repair_recovery_postgres_test.rs
 crates/rustok-index/tests/drift_repair_concrete_execution_postgres_test.rs
 crates/rustok-index/tests/support/drift_repair.rs
 ```
 
-Both targets read `RUSTOK_INDEX_TEST_DATABASE_URL`, with PostgreSQL `DATABASE_URL` as a fallback.
-When no PostgreSQL URL is available, each target reports a skip and succeeds.
+All targets read `RUSTOK_INDEX_TEST_DATABASE_URL`, with PostgreSQL `DATABASE_URL` as a fallback. When
+no PostgreSQL URL is available, each target reports a skip and succeeds. The retained-evidence runner
+rejects that skip state and therefore cannot promote an environment-less run.
 
 Every test creates a unique PostgreSQL schema, creates the tenant-owner fixture table, applies the
 real `IndexModule` migrations, uses production schema registration, mutation, finding, repair, and
@@ -33,6 +39,17 @@ The shared fixture intentionally creates independent one-connection pools for th
 store, base repair store, recovery-aware owner, concrete owner, and evidence reader. This preserves
 the real nested transaction shape without allowing an outer command fence to starve an inner owner
 transaction on a single pooled connection.
+
+## Environment metadata target
+
+`drift_repair_postgres_environment_test` queries PostgreSQL through the same isolated-schema fixture
+and emits exactly two bounded capture markers:
+
+- `postgres_server_version`;
+- `postgres_server_version_num`.
+
+It does not emit the connection URL, host, database name, username, or password. URL source and a
+bounded URL class are derived only by the capture runner and are retained without credentials.
 
 ## Migration and recovery target
 
@@ -110,6 +127,21 @@ The first four cases must complete as `NotRepaired(before_not_repairable)` witho
 mutation delivery. The normal mutation case must preserve the newer source entity and link graph,
 leave the repair command prepared, and reject the stale exact-edge owner call.
 
+## Retained admission boundary
+
+The source-ready packet is locked by:
+
+```text
+crates/rustok-index/contracts/evidence/concrete-repair-postgres-execution-contract.json
+scripts/evidence/capture-index-repair-postgres.mjs
+scripts/verify/verify-index-repair-retained-evidence.mjs
+```
+
+The runner requires a clean commit, executes the metadata target followed by both scenario targets,
+rejects skips and non-zero results, retains current source hashes, and writes credential-redacted
+complete stdout/stderr plus one final pass packet. Until the runner is executed, all three retained
+output files must remain absent and the verifier reports execution pending.
+
 ## Deliberate limits
 
 This packet does not add or claim:
@@ -123,22 +155,21 @@ This packet does not add or claim:
 
 ## Owner verification
 
+The admitted path is:
+
 ```bash
 RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
-  cargo test -p rustok-index \
-  --test drift_repair_recovery_postgres_test \
-  -- --nocapture --test-threads=1
+  node scripts/evidence/capture-index-repair-postgres.mjs
 
-RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
-  cargo test -p rustok-index \
-  --test drift_repair_concrete_execution_postgres_test \
-  -- --nocapture --test-threads=1
-
+node scripts/verify/verify-index-repair-retained-evidence.mjs
 node scripts/verify/verify-index-repair-execution-postgres-harness.mjs
 node scripts/verify/verify-index-query-contract.mjs
 cargo check -p rustok-index --all-targets
 git diff --check
 ```
+
+The two scenario targets may still be run directly for diagnosis, but only the capture runner writes
+the bounded retained packet and complete redacted logs.
 
 Tests, Node verifiers, formatting, Cargo checks, migrations, PostgreSQL scenarios, workflows, and CI
 were not executed by the implementation agent, per maintainer instruction.

--- a/crates/rustok-index/docs/m6-repair-retained-evidence-admission.md
+++ b/crates/rustok-index/docs/m6-repair-retained-evidence-admission.md
@@ -1,0 +1,137 @@
+# M6 concrete repair retained evidence admission
+
+Status: `source_complete_owner_execution_pending`.
+
+## Purpose
+
+This slice locks the maintainer-run admission boundary for the source-ready concrete repair
+PostgreSQL harness. It does not execute the database scenarios and does not claim retained runtime
+evidence.
+
+The admission tooling makes one successful owner run reproducible and reviewable by binding it to:
+
+- one clean Git commit;
+- the exact environment, recovery, and concrete execution commands;
+- the current hashes of every retained test, production adapter, and repair migration source;
+- bounded PostgreSQL server and toolchain metadata;
+- all required test case names and their asserted behavior;
+- complete retained stdout and stderr after credential-bearing PostgreSQL URL redaction;
+- one terminal `pass` packet written only after every command succeeds.
+
+## Locked contract
+
+The immutable source contract is:
+
+```text
+crates/rustok-index/contracts/evidence/concrete-repair-postgres-execution-contract.json
+```
+
+It allowlists three commands:
+
+1. `drift_repair_postgres_environment_test` for PostgreSQL server metadata;
+2. `drift_repair_recovery_postgres_test` for migration, reservation, recovery, and trigger behavior;
+3. `drift_repair_concrete_execution_postgres_test` for concrete crash, retry, recovery-race,
+   commitment-change, and ordinary-mutation serialization behavior.
+
+The environment target does not emit the connection URL, host, database name, username, or password.
+
+The contract remains `runtime_execution_pending`. A missing runtime packet and missing logs are the
+expected repository state before the owner executes the capture runner.
+
+## Capture runner
+
+The only admitted capture path is:
+
+```text
+scripts/evidence/capture-index-repair-postgres.mjs
+```
+
+The runner requires `RUSTOK_INDEX_TEST_DATABASE_URL`, with PostgreSQL `DATABASE_URL` as a fallback.
+It rejects non-PostgreSQL URLs, a dirty working tree, a changing HEAD, source drift during execution,
+skipped database targets, missing test-case success lines, duplicate or missing PostgreSQL metadata,
+and any non-zero command result.
+
+The runner never persists the database URL, username, password, or connection string. It retains only
+the environment variable name used and a bounded URL class such as `loopback`, `private_ipv4`,
+`dns_name`, or `unix_socket`.
+
+Before writing logs it replaces the exact database URL, any PostgreSQL URL-shaped token, and password
+assignments. It then rejects the retained text if a PostgreSQL URL or unredacted password assignment
+remains.
+
+## Retained outputs
+
+A successful run writes one atomic logical set:
+
+```text
+crates/rustok-index/contracts/evidence/concrete-repair-postgres-execution.json
+crates/rustok-index/contracts/evidence/concrete-repair-postgres-execution.stdout.log
+crates/rustok-index/contracts/evidence/concrete-repair-postgres-execution.stderr.log
+```
+
+The JSON packet retains:
+
+- exact commit SHA and clean-tree/source-stability facts;
+- start and completion timestamps;
+- PostgreSQL server version and numeric version;
+- Cargo and Rust compiler versions;
+- the exact command allowlist and zero exit status for every command;
+- current SHA-256 hashes for every source file named by the contract;
+- SHA-256 and byte counts for both complete redacted logs;
+- all four required test cases with the locked assertion list;
+- `status = postgres_runtime_executed` and `final_status = pass`.
+
+The runtime packet is written last. A partial set is rejected by the verifier.
+
+## Admission verifier
+
+The verifier is:
+
+```text
+scripts/verify/verify-index-repair-retained-evidence.mjs
+```
+
+Before owner execution it verifies the locked contract, runner boundaries, environment metadata test,
+and required scenario test functions, then reports execution as pending.
+
+After owner execution it additionally requires:
+
+- the packet and both logs to exist together;
+- exact packet fields and bounded metadata;
+- current source hashes matching the retained run;
+- all allowlisted commands with status `0`;
+- all required cases with result `pass`;
+- retained log hashes and byte counts matching the files;
+- no PostgreSQL URL or unredacted password assignment in any retained output.
+
+## Owner execution
+
+Run from the exact clean commit intended for admission:
+
+```bash
+RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
+  node scripts/evidence/capture-index-repair-postgres.mjs
+
+node scripts/verify/verify-index-repair-retained-evidence.mjs
+node scripts/verify/verify-index-repair-execution-postgres-harness.mjs
+node scripts/verify/verify-index-query-contract.mjs
+cargo check -p rustok-index --all-targets
+git diff --check
+```
+
+After a successful capture, review the redacted logs and packet before committing them. Do not hand
+edit the runtime packet or either retained log.
+
+## Deliberate limits
+
+This slice does not add or claim:
+
+- execution of the PostgreSQL targets;
+- a retained runtime packet, logs, timings, or database result;
+- public GraphQL, HTTP, CLI, MCP, or native-admin repair transport;
+- automatic finding iteration, scheduling, repair loops, or lifecycle auto-resolution;
+- time-derived lease expiry or automatic owner inference;
+- CI execution or workflow admission.
+
+Tests, Node verifiers, formatting, Cargo checks, migrations, PostgreSQL scenarios, workflows, and CI
+were not executed by the implementation agent, per maintainer instruction.

--- a/crates/rustok-index/tests/drift_repair_postgres_environment_test.rs
+++ b/crates/rustok-index/tests/drift_repair_postgres_environment_test.rs
@@ -1,0 +1,32 @@
+#[path = "support/drift_repair.rs"]
+mod support;
+
+use sea_orm::{ConnectionTrait, DbBackend, Statement};
+
+use support::{TestDatabase, TestResult};
+
+#[tokio::test]
+async fn repair_evidence_environment_reports_postgres_version() -> TestResult<()> {
+    let Some(database) = TestDatabase::setup("repair_environment").await? else {
+        return Ok(());
+    };
+    let db = database.connection().await?;
+    let row = db
+        .query_one(Statement::from_string(
+            DbBackend::Postgres,
+            "SELECT current_setting('server_version') AS server_version, current_setting('server_version_num') AS server_version_num".to_owned(),
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("PostgreSQL version metadata returned no row"))?;
+    let server_version: String = row.try_get("", "server_version")?;
+    let server_version_num: String = row.try_get("", "server_version_num")?;
+
+    println!(
+        "RUSTOK_INDEX_REPAIR_EVIDENCE postgres_server_version={server_version}"
+    );
+    println!(
+        "RUSTOK_INDEX_REPAIR_EVIDENCE postgres_server_version_num={server_version_num}"
+    );
+
+    database.cleanup().await
+}

--- a/scripts/evidence/capture-index-repair-postgres.mjs
+++ b/scripts/evidence/capture-index-repair-postgres.mjs
@@ -1,0 +1,530 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { isIP } from "node:net";
+import { dirname, resolve, sep } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-index/contracts/evidence/concrete-repair-postgres-execution-contract.json";
+const expectedRunnerPath = "scripts/evidence/capture-index-repair-postgres.mjs";
+const expectedVerifierPath = "scripts/verify/verify-index-repair-retained-evidence.mjs";
+const expectedEvidencePath =
+  "crates/rustok-index/contracts/evidence/concrete-repair-postgres-execution.json";
+const expectedStdoutPath =
+  "crates/rustok-index/contracts/evidence/concrete-repair-postgres-execution.stdout.log";
+const expectedStderrPath =
+  "crates/rustok-index/contracts/evidence/concrete-repair-postgres-execution.stderr.log";
+const expectedCommands = [
+  {
+    program: "cargo",
+    args: [
+      "test",
+      "-p",
+      "rustok-index",
+      "--test",
+      "drift_repair_postgres_environment_test",
+      "--",
+      "--nocapture",
+      "--test-threads=1",
+    ],
+  },
+  {
+    program: "cargo",
+    args: [
+      "test",
+      "-p",
+      "rustok-index",
+      "--test",
+      "drift_repair_recovery_postgres_test",
+      "--",
+      "--nocapture",
+      "--test-threads=1",
+    ],
+  },
+  {
+    program: "cargo",
+    args: [
+      "test",
+      "-p",
+      "rustok-index",
+      "--test",
+      "drift_repair_concrete_execution_postgres_test",
+      "--",
+      "--nocapture",
+      "--test-threads=1",
+    ],
+  },
+];
+const expectedSourceFiles = [
+  "crates/rustok-index/tests/drift_repair_postgres_environment_test.rs",
+  "crates/rustok-index/tests/drift_repair_recovery_postgres_test.rs",
+  "crates/rustok-index/tests/drift_repair_concrete_execution_postgres_test.rs",
+  "crates/rustok-index/tests/support/drift_repair.rs",
+  "crates/rustok-index/src/infrastructure/postgres/drift_repair.rs",
+  "crates/rustok-index/src/infrastructure/postgres/drift_repair_recovery.rs",
+  "crates/rustok-index/src/infrastructure/postgres/drift_missing_entity_repair.rs",
+  "crates/rustok-index/src/infrastructure/postgres/drift_orphan_link_repair.rs",
+  "crates/rustok-index/src/infrastructure/postgres/mutation_store.rs",
+  "crates/rustok-index/src/infrastructure/postgres/drift_confirmed_candidate_writer.rs",
+  "crates/rustok-index/src/infrastructure/postgres/schema_registration.rs",
+  "crates/rustok-index/src/migrations/mod.rs",
+  "crates/rustok-index/src/migrations/m20260806_000007_add_index_finding_repair_commands.rs",
+  "crates/rustok-index/src/migrations/m20260806_000008_add_index_finding_repair_recovery.rs",
+];
+const expectedCases = [
+  {
+    case: "migrations_recovery_guard_and_concurrent_reservation_are_executable",
+    command_index: 1,
+    assertions: [
+      "one_active_command_per_finding",
+      "revision_zero_activation_retained",
+      "command_uuid_payload_reuse_rejected",
+      "pause_exact_replay_and_stale_revision_retained",
+      "paused_completion_trigger_rejected",
+      "authorized_resume_allows_completion",
+      "completed_command_identity_immutable",
+      "repair_and_recovery_migrations_reverse_cleanly",
+    ],
+  },
+  {
+    case: "missing_and_orphan_crash_windows_resume_exactly",
+    command_index: 2,
+    assertions: [
+      "missing_owner_commit_survives_pre_receipt_crash",
+      "missing_exact_command_retry_converges",
+      "orphan_edge_and_inbox_commit_atomically",
+      "orphan_exact_command_retry_requires_applied_delivery",
+      "source_version_and_unrelated_ordinal_preserved",
+      "terminal_replay_returns_already_completed",
+    ],
+  },
+  {
+    case: "recovery_admission_fences_side_effect_and_completion",
+    command_index: 2,
+    assertions: [
+      "pause_before_owner_prevents_side_effect",
+      "authorized_resume_reuses_exact_command",
+      "abandon_after_side_effect_prevents_completion",
+      "abandoned_retry_remains_terminally_fenced",
+      "database_trigger_rejects_abandoned_completion",
+    ],
+  },
+  {
+    case: "orphan_commitments_and_normal_mutations_fail_closed",
+    command_index: 2,
+    assertions: [
+      "source_version_movement_rejected",
+      "exact_link_substitution_rejected",
+      "target_restoration_rejected",
+      "absence_version_movement_rejected",
+      "normal_full_mutation_serializes_before_exact_edge_owner",
+      "newer_source_and_link_graph_preserved",
+    ],
+  },
+];
+const contract = JSON.parse(readFileSync(resolve(repoRoot, contractPath), "utf8"));
+const outputPaths = {
+  evidence: resolve(repoRoot, contract.evidence_path),
+  stdout: resolve(repoRoot, contract.stdout_path),
+  stderr: resolve(repoRoot, contract.stderr_path),
+};
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function sameRecord(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function fileSha256(relativePath) {
+  return sha256(readFileSync(resolve(repoRoot, relativePath)));
+}
+
+function sourceHashes() {
+  return Object.fromEntries(
+    contract.source_files.map((relativePath) => [relativePath, fileSha256(relativePath)]),
+  );
+}
+
+function run(program, args, env = process.env) {
+  const result = spawnSync(program, args, {
+    cwd: repoRoot,
+    env,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.error) {
+    fail(`${program} could not start: ${result.error.message}`);
+  }
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function runChecked(program, args, env = process.env) {
+  const result = run(program, args, env);
+  if (result.status !== 0) {
+    fail(`${program} exited with status ${result.status}; no retained evidence was written`);
+  }
+  return result;
+}
+
+function oneLine(value, field, maxLength = 256) {
+  const line = value.trim().split(/\r?\n/u, 1)[0]?.trim() ?? "";
+  if (!line || line.length > maxLength || /[\u0000-\u001f\u007f]/u.test(line)) {
+    fail(`${field} is missing or outside the retained evidence boundary`);
+  }
+  return line;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function requirePassedCase(output, caseName) {
+  const pattern = new RegExp(
+    `(?:^|\\r?\\n)test ${escapeRegExp(caseName)} \\.\\.\\. ok(?:\\r?\\n|$)`,
+    "u",
+  );
+  if (!pattern.test(output)) {
+    fail(`required PostgreSQL case did not report success: ${caseName}`);
+  }
+}
+
+function markerValues(output, marker) {
+  const prefix = `RUSTOK_INDEX_REPAIR_EVIDENCE ${marker}=`;
+  return output
+    .split(/\r?\n/u)
+    .filter((line) => line.startsWith(prefix))
+    .map((line) => line.slice(prefix.length).trim())
+    .filter(Boolean);
+}
+
+function requireOneMarker(output, marker) {
+  const values = [...new Set(markerValues(output, marker))];
+  if (values.length !== 1) {
+    fail(`expected exactly one retained evidence marker for ${marker}`);
+  }
+  return oneLine(values[0], marker, 128);
+}
+
+function ensurePathsInsideRepository() {
+  const root = resolve(repoRoot) + sep;
+  for (const [name, outputPath] of Object.entries(outputPaths)) {
+    if (!outputPath.startsWith(root)) {
+      fail(`${name} retained evidence path must stay inside the repository`);
+    }
+  }
+}
+
+function validateContractBoundary() {
+  if (
+    contract.schema_version !== 1 ||
+    contract.module !== "rustok-index" ||
+    contract.packet !== "concrete-repair-postgres-execution-contract" ||
+    contract.status !== "runtime_execution_contract_locked"
+  ) {
+    fail("concrete repair retained evidence contract identity drift");
+  }
+  if (
+    contract.runner !== expectedRunnerPath ||
+    contract.verifier !== expectedVerifierPath ||
+    contract.evidence_path !== expectedEvidencePath ||
+    contract.stdout_path !== expectedStdoutPath ||
+    contract.stderr_path !== expectedStderrPath ||
+    contract.evidence_status !== "runtime_execution_pending"
+  ) {
+    fail("concrete repair retained evidence tooling or output boundary drift");
+  }
+  if (
+    contract.execution_scope !== "opt_in_postgresql_runtime_execution_pending" ||
+    contract.promotion_gate !==
+      "requires_clean_commit_current_sources_and_all_required_cases_passed"
+  ) {
+    fail("concrete repair retained evidence promotion boundary drift");
+  }
+  if (!sameRecord(contract.commands, expectedCommands)) {
+    fail("concrete repair retained evidence command allowlist drift");
+  }
+  if (!sameRecord(contract.source_files, expectedSourceFiles)) {
+    fail("concrete repair retained evidence source file allowlist drift");
+  }
+  if (!sameRecord(contract.required_cases, expectedCases)) {
+    fail("concrete repair retained evidence required case allowlist drift");
+  }
+}
+
+function isPrivateIpv4(host) {
+  const octets = host.split(".").map(Number);
+  return (
+    octets[0] === 10 ||
+    (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) ||
+    (octets[0] === 192 && octets[1] === 168) ||
+    (octets[0] === 169 && octets[1] === 254)
+  );
+}
+
+function classifyDatabaseUrl(value) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    fail("the opt-in PostgreSQL URL is invalid");
+  }
+  if (parsed.protocol !== "postgres:" && parsed.protocol !== "postgresql:") {
+    fail("the retained evidence runner accepts PostgreSQL URLs only");
+  }
+  const socketHost = parsed.searchParams.get("host");
+  if (socketHost?.startsWith("/")) return "unix_socket";
+
+  const host = parsed.hostname.replace(/^\[|\]$/gu, "").toLowerCase();
+  if (!host) return "empty_host";
+  if (host === "localhost" || host === "::1" || host.startsWith("127.")) {
+    return "loopback";
+  }
+  const family = isIP(host);
+  if (family === 4) return isPrivateIpv4(host) ? "private_ipv4" : "public_ipv4";
+  if (family === 6) {
+    if (/^(?:fc|fd)/u.test(host)) return "private_ipv6";
+    if (/^fe[89ab]/u.test(host)) return "link_local_ipv6";
+    return "public_ipv6";
+  }
+  return "dns_name";
+}
+
+function validateDatabaseUrl() {
+  const primary = process.env[contract.database_url_env];
+  const fallback = process.env[contract.database_url_fallback_env];
+  const value = primary || fallback;
+  if (!value) {
+    fail(
+      `${contract.database_url_env} or ${contract.database_url_fallback_env} must provide an opt-in PostgreSQL URL`,
+    );
+  }
+  return {
+    value,
+    source: primary ? contract.database_url_env : contract.database_url_fallback_env,
+    className: classifyDatabaseUrl(value),
+  };
+}
+
+function workingTreeStatus() {
+  return runChecked("git", ["status", "--porcelain=v1", "--untracked-files=all"]).stdout;
+}
+
+function ensureCleanCommit() {
+  if (workingTreeStatus().trim()) {
+    fail("working tree must be clean before retained evidence execution");
+  }
+  const commit = oneLine(runChecked("git", ["rev-parse", "HEAD"]).stdout, "git_commit");
+  if (!/^[0-9a-f]{40}$/u.test(commit)) {
+    fail("git commit must be a full lowercase SHA-1");
+  }
+  return commit;
+}
+
+function ensureCleanAfterExecution() {
+  if (workingTreeStatus().trim()) {
+    fail("working tree changed during retained evidence execution");
+  }
+}
+
+function sanitizeOutput(value, databaseUrl) {
+  let sanitized = value.split(databaseUrl).join("[REDACTED_POSTGRES_URL]");
+  sanitized = sanitized.replace(
+    /postgres(?:ql)?:\/\/[^\s"'`<>]+/giu,
+    "[REDACTED_POSTGRES_URL]",
+  );
+  sanitized = sanitized.replace(
+    /\b(password|passwd|pwd)\s*=\s*[^\s;]+/giu,
+    "$1=[REDACTED]",
+  );
+  return sanitized;
+}
+
+function commandHeading(index, command) {
+  return `=== command ${index}: ${command.program} ${command.args.join(" ")} ===`;
+}
+
+function retainedLog(results, stream, databaseUrl) {
+  return `${results
+    .map((result, index) => {
+      const value = sanitizeOutput(result[stream], databaseUrl);
+      return `${commandHeading(index, expectedCommands[index])}\n${value}`;
+    })
+    .join("\n\n")}\n`;
+}
+
+function assertSanitizedLog(name, value) {
+  if (/postgres(?:ql)?:\/\//iu.test(value)) {
+    fail(`${name} still contains a PostgreSQL connection URL after redaction`);
+  }
+  if (/\b(?:password|passwd|pwd)\s*=\s*(?!\[REDACTED\])/iu.test(value)) {
+    fail(`${name} still contains an unredacted password assignment`);
+  }
+}
+
+function temporaryPath(outputPath) {
+  return `${outputPath}.tmp-${process.pid}`;
+}
+
+function writeFileAtomically(outputPath, content) {
+  mkdirSync(dirname(outputPath), { recursive: true });
+  const temporary = temporaryPath(outputPath);
+  if (existsSync(temporary)) unlinkSync(temporary);
+  writeFileSync(temporary, content, "utf8");
+  renameSync(temporary, outputPath);
+}
+
+function writePacketAndLogs(packet, stdoutLog, stderrLog) {
+  ensurePathsInsideRepository();
+  writeFileAtomically(outputPaths.stdout, stdoutLog);
+  writeFileAtomically(outputPaths.stderr, stderrLog);
+  writeFileAtomically(outputPaths.evidence, `${JSON.stringify(packet, null, 2)}\n`);
+}
+
+try {
+  ensurePathsInsideRepository();
+  validateContractBoundary();
+  const databaseUrl = validateDatabaseUrl();
+  const gitCommit = ensureCleanCommit();
+  const initialSourceSha256 = sourceHashes();
+  const cargoVersion = oneLine(runChecked("cargo", ["--version"]).stdout, "cargo_version");
+  const rustcVersion = oneLine(runChecked("rustc", ["--version"]).stdout, "rustc_version");
+  const startedAt = new Date().toISOString();
+
+  const commandResults = expectedCommands.map((command) =>
+    runChecked(command.program, command.args),
+  );
+  const combinedOutputs = commandResults.map(
+    (result) => `${result.stdout}\n${result.stderr}`,
+  );
+  const environmentOutput = combinedOutputs[0];
+  const postgresServerVersion = requireOneMarker(
+    environmentOutput,
+    "postgres_server_version",
+  );
+  const postgresServerVersionNum = requireOneMarker(
+    environmentOutput,
+    "postgres_server_version_num",
+  );
+  if (!/^\d+$/u.test(postgresServerVersionNum)) {
+    fail("postgres_server_version_num must contain digits only");
+  }
+
+  for (const requiredCase of contract.required_cases) {
+    const output = combinedOutputs[requiredCase.command_index];
+    if (output === undefined) {
+      fail(`required case references an unavailable command: ${requiredCase.case}`);
+    }
+    requirePassedCase(output, requiredCase.case);
+  }
+  if (
+    combinedOutputs.some(
+      (output) =>
+        output.includes("is not set to a PostgreSQL URL; skipping") ||
+        output.includes("skipping repair_"),
+    )
+  ) {
+    fail("repair evidence tests reported a skip instead of PostgreSQL execution");
+  }
+
+  const finalCommit = oneLine(
+    runChecked("git", ["rev-parse", "HEAD"]).stdout,
+    "final_git_commit",
+  );
+  if (finalCommit !== gitCommit) {
+    fail("git commit changed during retained evidence execution");
+  }
+  const finalSourceSha256 = sourceHashes();
+  if (!sameRecord(finalSourceSha256, initialSourceSha256)) {
+    fail("retained evidence source files changed during execution");
+  }
+  ensureCleanAfterExecution();
+  const completedAt = new Date().toISOString();
+
+  const stdoutLog = retainedLog(commandResults, "stdout", databaseUrl.value);
+  const stderrLog = retainedLog(commandResults, "stderr", databaseUrl.value);
+  assertSanitizedLog("retained stdout", stdoutLog);
+  assertSanitizedLog("retained stderr", stderrLog);
+
+  const packet = {
+    schema_version: 1,
+    module: contract.module,
+    packet: "concrete-repair-postgres-runtime-evidence",
+    status: "postgres_runtime_executed",
+    final_status: "pass",
+    generated_from: contractPath,
+    runner: contract.runner,
+    verifier: contract.verifier,
+    git_commit: gitCommit,
+    working_tree_clean_before_run: true,
+    source_unchanged_during_run: true,
+    started_at: startedAt,
+    completed_at: completedAt,
+    database_url_source: databaseUrl.source,
+    database_url_class: databaseUrl.className,
+    database: {
+      backend: "postgresql",
+      server_version: postgresServerVersion,
+      server_version_num: postgresServerVersionNum,
+    },
+    toolchain: {
+      cargo: cargoVersion,
+      rustc: rustcVersion,
+    },
+    commands: expectedCommands,
+    command_results: commandResults.map((result, index) => ({
+      command_index: index,
+      status: result.status,
+      stdout_sha256: sha256(sanitizeOutput(result.stdout, databaseUrl.value)),
+      stderr_sha256: sha256(sanitizeOutput(result.stderr, databaseUrl.value)),
+      stdout_bytes: Buffer.byteLength(sanitizeOutput(result.stdout, databaseUrl.value)),
+      stderr_bytes: Buffer.byteLength(sanitizeOutput(result.stderr, databaseUrl.value)),
+    })),
+    source_sha256: finalSourceSha256,
+    logs: {
+      stdout_path: contract.stdout_path,
+      stderr_path: contract.stderr_path,
+      stdout_sha256: sha256(stdoutLog),
+      stderr_sha256: sha256(stderrLog),
+      stdout_bytes: Buffer.byteLength(stdoutLog),
+      stderr_bytes: Buffer.byteLength(stderrLog),
+      redactions: [
+        "exact_database_url",
+        "postgresql_url_pattern",
+        "password_assignment",
+      ],
+    },
+    executed_cases: contract.required_cases.map((requiredCase) => ({
+      case: requiredCase.case,
+      command_index: requiredCase.command_index,
+      result: "pass",
+      assertions: requiredCase.assertions,
+    })),
+  };
+
+  writePacketAndLogs(packet, stdoutLog, stderrLog);
+  console.log(`Retained Index repair PostgreSQL evidence written to ${contract.evidence_path}`);
+} catch (error) {
+  console.error(`Index repair PostgreSQL evidence capture failed: ${error.message}`);
+  process.exit(1);
+}

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -40,6 +40,7 @@ const scripts = [
   'verify-index-orphan-link-repair-composition.mjs',
   'verify-index-prepared-repair-recovery.mjs',
   'verify-index-repair-execution-postgres-harness.mjs',
+  'verify-index-repair-retained-evidence.mjs',
   'verify-index-reconciliation-retry-store.mjs',
   'verify-index-reconciliation-runner-retry.mjs',
   'verify-index-reconciliation-host-scheduler.mjs',

--- a/scripts/verify/verify-index-repair-execution-postgres-harness.mjs
+++ b/scripts/verify/verify-index-repair-execution-postgres-harness.mjs
@@ -4,9 +4,15 @@ import { readFile } from 'node:fs/promises';
 
 const files = {
   support: 'crates/rustok-index/tests/support/drift_repair.rs',
+  environment: 'crates/rustok-index/tests/drift_repair_postgres_environment_test.rs',
   recovery: 'crates/rustok-index/tests/drift_repair_recovery_postgres_test.rs',
   execution: 'crates/rustok-index/tests/drift_repair_concrete_execution_postgres_test.rs',
+  contract:
+    'crates/rustok-index/contracts/evidence/concrete-repair-postgres-execution-contract.json',
+  runner: 'scripts/evidence/capture-index-repair-postgres.mjs',
+  retainedVerifier: 'scripts/verify/verify-index-repair-retained-evidence.mjs',
   doc: 'crates/rustok-index/docs/m6-repair-execution-postgres-harness.md',
+  admissionDoc: 'crates/rustok-index/docs/m6-repair-retained-evidence-admission.md',
   plan: 'crates/rustok-index/docs/implementation-plan-current-2026-08-03.md',
   aggregate: 'scripts/verify/verify-index-query-contract.mjs',
 };
@@ -49,6 +55,14 @@ requireMarkers('support', [
   'index_confirmed_orphan_link_identity_v1',
   'max_connections(1)',
   'SET search_path TO',
+]);
+
+requireMarkers('environment', [
+  'repair_evidence_environment_reports_postgres_version',
+  "current_setting('server_version') AS server_version",
+  "current_setting('server_version_num') AS server_version_num",
+  'RUSTOK_INDEX_REPAIR_EVIDENCE postgres_server_version=',
+  'RUSTOK_INDEX_REPAIR_EVIDENCE postgres_server_version_num=',
 ]);
 
 requireMarkers('recovery', [
@@ -94,7 +108,7 @@ requireMarkers('execution', [
   'index_drift_repair_owner_unavailable',
 ]);
 
-for (const name of ['support', 'recovery', 'execution']) {
+for (const name of ['support', 'environment', 'recovery', 'execution']) {
   for (const forbidden of [
     '#[ignore]',
     'async_graphql',
@@ -110,28 +124,82 @@ for (const name of ['support', 'recovery', 'execution']) {
   }
 }
 
+requireMarkers('contract', [
+  '"packet": "concrete-repair-postgres-execution-contract"',
+  '"status": "runtime_execution_contract_locked"',
+  '"execution_scope": "opt_in_postgresql_runtime_execution_pending"',
+  '"evidence_status": "runtime_execution_pending"',
+  '"drift_repair_postgres_environment_test"',
+  '"drift_repair_recovery_postgres_test"',
+  '"drift_repair_concrete_execution_postgres_test"',
+  '"migrations_recovery_guard_and_concurrent_reservation_are_executable"',
+  '"missing_and_orphan_crash_windows_resume_exactly"',
+  '"recovery_admission_fences_side_effect_and_completion"',
+  '"orphan_commitments_and_normal_mutations_fail_closed"',
+]);
+
+requireMarkers('runner', [
+  'validateDatabaseUrl()',
+  'classifyDatabaseUrl(value)',
+  'ensureCleanCommit()',
+  '["status", "--porcelain=v1", "--untracked-files=all"]',
+  'const initialSourceSha256 = sourceHashes();',
+  'const finalSourceSha256 = sourceHashes();',
+  'requireOneMarker(',
+  'requirePassedCase(output, requiredCase.case)',
+  'sanitizeOutput(result.stdout, databaseUrl.value)',
+  'assertSanitizedLog("retained stdout", stdoutLog)',
+  'writePacketAndLogs(packet, stdoutLog, stderrLog)',
+  'working_tree_clean_before_run: true',
+  'source_unchanged_during_run: true',
+  'final_status: "pass"',
+]);
+
+requireMarkers('retainedVerifier', [
+  'PostgreSQL owner execution remains pending',
+  'retained evidence packet and both logs must appear atomically',
+  'retained evidence is stale for source file',
+  'verifyNoSecrets("retained evidence packet", evidenceText)',
+  'all required cases passed',
+]);
+
 requireMarkers('doc', [
   'Status: `source_ready_owner_execution_pending`.',
   'executable source, not admitted production evidence',
   '`RUSTOK_INDEX_TEST_DATABASE_URL`',
   'independent one-connection pools',
+  '`drift_repair_postgres_environment_test`',
   '**pause before owner admission**',
   '**abandon after side effect but before completion**',
   'source-version movement',
   'exact link substitution',
   'authoritative target restoration',
   'target absence-version movement',
+  '`capture-index-repair-postgres.mjs`',
   'Tests, Node verifiers, formatting, Cargo checks',
 ]);
 
-for (const forbidden of [
-  'Status: `complete`',
-  'PostgreSQL execution passed',
-  'all scenarios passed',
-  'CI passed',
-]) {
-  if (content.doc.includes(forbidden)) {
-    throw new Error(`${files.doc} overclaims unexecuted evidence with ${forbidden}`);
+requireMarkers('admissionDoc', [
+  'Status: `source_complete_owner_execution_pending`.',
+  'runtime_execution_pending',
+  'clean Git commit',
+  'complete retained stdout and stderr',
+  'does not emit the connection URL',
+  'A partial set is rejected by the verifier.',
+  'Do not hand edit the runtime packet',
+  'were not executed by the implementation agent',
+]);
+
+for (const name of ['doc', 'admissionDoc']) {
+  for (const forbidden of [
+    'Status: `complete`',
+    'PostgreSQL execution passed',
+    'all scenarios passed',
+    'CI passed',
+  ]) {
+    if (content[name].includes(forbidden)) {
+      throw new Error(`${files[name]} overclaims unexecuted evidence with ${forbidden}`);
+    }
   }
 }
 
@@ -143,6 +211,7 @@ requireMarkers('plan', [
 ]);
 requireMarkers('aggregate', [
   "'verify-index-repair-execution-postgres-harness.mjs'",
+  "'verify-index-repair-retained-evidence.mjs'",
 ]);
 
-console.log('Index concrete repair PostgreSQL harness verified');
+console.log('Index concrete repair PostgreSQL harness and admission contract verified');

--- a/scripts/verify/verify-index-repair-retained-evidence.mjs
+++ b/scripts/verify/verify-index-repair-retained-evidence.mjs
@@ -1,0 +1,550 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-index/contracts/evidence/concrete-repair-postgres-execution-contract.json";
+const runnerPath = "scripts/evidence/capture-index-repair-postgres.mjs";
+const verifierPath = "scripts/verify/verify-index-repair-retained-evidence.mjs";
+const environmentTestPath =
+  "crates/rustok-index/tests/drift_repair_postgres_environment_test.rs";
+const recoveryTestPath =
+  "crates/rustok-index/tests/drift_repair_recovery_postgres_test.rs";
+const concreteTestPath =
+  "crates/rustok-index/tests/drift_repair_concrete_execution_postgres_test.rs";
+
+const expectedEvidencePath =
+  "crates/rustok-index/contracts/evidence/concrete-repair-postgres-execution.json";
+const expectedStdoutPath =
+  "crates/rustok-index/contracts/evidence/concrete-repair-postgres-execution.stdout.log";
+const expectedStderrPath =
+  "crates/rustok-index/contracts/evidence/concrete-repair-postgres-execution.stderr.log";
+const expectedCommands = [
+  {
+    program: "cargo",
+    args: [
+      "test",
+      "-p",
+      "rustok-index",
+      "--test",
+      "drift_repair_postgres_environment_test",
+      "--",
+      "--nocapture",
+      "--test-threads=1",
+    ],
+  },
+  {
+    program: "cargo",
+    args: [
+      "test",
+      "-p",
+      "rustok-index",
+      "--test",
+      "drift_repair_recovery_postgres_test",
+      "--",
+      "--nocapture",
+      "--test-threads=1",
+    ],
+  },
+  {
+    program: "cargo",
+    args: [
+      "test",
+      "-p",
+      "rustok-index",
+      "--test",
+      "drift_repair_concrete_execution_postgres_test",
+      "--",
+      "--nocapture",
+      "--test-threads=1",
+    ],
+  },
+];
+const expectedSourceFiles = [
+  environmentTestPath,
+  recoveryTestPath,
+  concreteTestPath,
+  "crates/rustok-index/tests/support/drift_repair.rs",
+  "crates/rustok-index/src/infrastructure/postgres/drift_repair.rs",
+  "crates/rustok-index/src/infrastructure/postgres/drift_repair_recovery.rs",
+  "crates/rustok-index/src/infrastructure/postgres/drift_missing_entity_repair.rs",
+  "crates/rustok-index/src/infrastructure/postgres/drift_orphan_link_repair.rs",
+  "crates/rustok-index/src/infrastructure/postgres/mutation_store.rs",
+  "crates/rustok-index/src/infrastructure/postgres/drift_confirmed_candidate_writer.rs",
+  "crates/rustok-index/src/infrastructure/postgres/schema_registration.rs",
+  "crates/rustok-index/src/migrations/mod.rs",
+  "crates/rustok-index/src/migrations/m20260806_000007_add_index_finding_repair_commands.rs",
+  "crates/rustok-index/src/migrations/m20260806_000008_add_index_finding_repair_recovery.rs",
+];
+const expectedMetadata = [
+  "git_commit",
+  "started_at",
+  "completed_at",
+  "database_url_source",
+  "database_url_class",
+  "postgres_server_version",
+  "postgres_server_version_num",
+  "cargo_version",
+  "rustc_version",
+  "source_sha256",
+  "stdout_sha256",
+  "stderr_sha256",
+  "final_status",
+];
+const expectedCases = [
+  {
+    case: "migrations_recovery_guard_and_concurrent_reservation_are_executable",
+    command_index: 1,
+    assertions: [
+      "one_active_command_per_finding",
+      "revision_zero_activation_retained",
+      "command_uuid_payload_reuse_rejected",
+      "pause_exact_replay_and_stale_revision_retained",
+      "paused_completion_trigger_rejected",
+      "authorized_resume_allows_completion",
+      "completed_command_identity_immutable",
+      "repair_and_recovery_migrations_reverse_cleanly",
+    ],
+  },
+  {
+    case: "missing_and_orphan_crash_windows_resume_exactly",
+    command_index: 2,
+    assertions: [
+      "missing_owner_commit_survives_pre_receipt_crash",
+      "missing_exact_command_retry_converges",
+      "orphan_edge_and_inbox_commit_atomically",
+      "orphan_exact_command_retry_requires_applied_delivery",
+      "source_version_and_unrelated_ordinal_preserved",
+      "terminal_replay_returns_already_completed",
+    ],
+  },
+  {
+    case: "recovery_admission_fences_side_effect_and_completion",
+    command_index: 2,
+    assertions: [
+      "pause_before_owner_prevents_side_effect",
+      "authorized_resume_reuses_exact_command",
+      "abandon_after_side_effect_prevents_completion",
+      "abandoned_retry_remains_terminally_fenced",
+      "database_trigger_rejects_abandoned_completion",
+    ],
+  },
+  {
+    case: "orphan_commitments_and_normal_mutations_fail_closed",
+    command_index: 2,
+    assertions: [
+      "source_version_movement_rejected",
+      "exact_link_substitution_rejected",
+      "target_restoration_rejected",
+      "absence_version_movement_rejected",
+      "normal_full_mutation_serializes_before_exact_edge_owner",
+      "newer_source_and_link_graph_preserved",
+    ],
+  },
+];
+const allowedDatabaseClasses = [
+  "unix_socket",
+  "empty_host",
+  "loopback",
+  "private_ipv4",
+  "public_ipv4",
+  "private_ipv6",
+  "link_local_ipv6",
+  "public_ipv6",
+  "dns_name",
+];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function readText(relativePath) {
+  return readFileSync(resolve(repoRoot, relativePath), "utf8");
+}
+
+function readJson(relativePath) {
+  return JSON.parse(readText(relativePath));
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function sha256File(relativePath) {
+  return sha256(readFileSync(resolve(repoRoot, relativePath)));
+}
+
+function sameValue(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function sameSet(actual, expected) {
+  return (
+    Array.isArray(actual) &&
+    actual.length === expected.length &&
+    expected.every((value) => actual.includes(value))
+  );
+}
+
+function requireText(name, source, marker) {
+  if (!source.includes(marker)) {
+    fail(`${name} is missing required marker: ${marker}`);
+  }
+}
+
+function requireExactKeys(name, value, expectedKeys) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${name} must be an object`);
+  }
+  if (!sameSet(Object.keys(value), expectedKeys)) {
+    fail(`${name} contains missing or unexpected fields`);
+  }
+}
+
+function requireIsoTimestamp(name, value) {
+  if (typeof value !== "string" || Number.isNaN(Date.parse(value))) {
+    fail(`${name} must be an ISO-8601 timestamp`);
+  }
+}
+
+function requireSha256(name, value) {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/u.test(value)) {
+    fail(`${name} must be a lowercase SHA-256 digest`);
+  }
+}
+
+const contract = readJson(contractPath);
+const runner = readText(runnerPath);
+const environmentTest = readText(environmentTestPath);
+const recoveryTest = readText(recoveryTestPath);
+const concreteTest = readText(concreteTestPath);
+
+function verifyContract() {
+  if (contract.schema_version !== 1) fail("retained evidence contract schema_version drift");
+  if (contract.module !== "rustok-index") fail("retained evidence contract module drift");
+  if (contract.packet !== "concrete-repair-postgres-execution-contract") {
+    fail("retained evidence contract packet drift");
+  }
+  if (contract.status !== "runtime_execution_contract_locked") {
+    fail("retained evidence contract status drift");
+  }
+  if (contract.runner !== runnerPath) fail("retained evidence runner path drift");
+  if (contract.verifier !== verifierPath) fail("retained evidence verifier path drift");
+  if (contract.evidence_path !== expectedEvidencePath) fail("retained evidence path drift");
+  if (contract.stdout_path !== expectedStdoutPath) fail("retained stdout path drift");
+  if (contract.stderr_path !== expectedStderrPath) fail("retained stderr path drift");
+  if (contract.execution_scope !== "opt_in_postgresql_runtime_execution_pending") {
+    fail("retained evidence execution scope must remain explicitly pending until execution");
+  }
+  if (
+    contract.promotion_gate !==
+    "requires_clean_commit_current_sources_and_all_required_cases_passed"
+  ) {
+    fail("retained evidence promotion gate drift");
+  }
+  if (contract.database_url_env !== "RUSTOK_INDEX_TEST_DATABASE_URL") {
+    fail("retained evidence database env drift");
+  }
+  if (contract.database_url_fallback_env !== "DATABASE_URL") {
+    fail("retained evidence fallback database env drift");
+  }
+  if (!sameValue(contract.commands, expectedCommands)) fail("retained evidence commands drift");
+  if (!sameValue(contract.source_files, expectedSourceFiles)) {
+    fail("retained evidence source file set drift");
+  }
+  if (!sameSet(contract.required_metadata, expectedMetadata)) {
+    fail("retained evidence metadata contract drift");
+  }
+  if (!sameValue(contract.required_cases, expectedCases)) {
+    fail("retained evidence required case contract drift");
+  }
+  if (contract.evidence_status !== "runtime_execution_pending") {
+    fail("retained evidence contract must not claim unexecuted PostgreSQL proof");
+  }
+}
+
+function verifySourceBoundaries() {
+  for (const marker of [
+    "validateDatabaseUrl()",
+    "classifyDatabaseUrl(value)",
+    "ensureCleanCommit()",
+    '["status", "--porcelain=v1", "--untracked-files=all"]',
+    '["rev-parse", "HEAD"]',
+    "const initialSourceSha256 = sourceHashes();",
+    "const finalSourceSha256 = sourceHashes();",
+    "requireOneMarker(",
+    "requirePassedCase(output, requiredCase.case)",
+    "sanitizeOutput(result.stdout, databaseUrl.value)",
+    "assertSanitizedLog(\"retained stdout\", stdoutLog)",
+    "writePacketAndLogs(packet, stdoutLog, stderrLog)",
+    "working_tree_clean_before_run: true",
+    "source_unchanged_during_run: true",
+    'final_status: "pass"',
+  ]) {
+    requireText("retained evidence runner", runner, marker);
+  }
+  for (const forbidden of [
+    "database_url: databaseUrl.value",
+    "connection_string:",
+    "raw_database_url:",
+    "password: parsed.password",
+    "username: parsed.username",
+  ]) {
+    if (runner.includes(forbidden)) {
+      fail(`retained evidence runner contains forbidden persisted field: ${forbidden}`);
+    }
+  }
+
+  for (const marker of [
+    "repair_evidence_environment_reports_postgres_version",
+    "current_setting('server_version') AS server_version",
+    "current_setting('server_version_num') AS server_version_num",
+    "RUSTOK_INDEX_REPAIR_EVIDENCE postgres_server_version=",
+    "RUSTOK_INDEX_REPAIR_EVIDENCE postgres_server_version_num=",
+  ]) {
+    requireText("PostgreSQL environment evidence test", environmentTest, marker);
+  }
+  requireText(
+    "PostgreSQL recovery evidence test",
+    recoveryTest,
+    "async fn migrations_recovery_guard_and_concurrent_reservation_are_executable()",
+  );
+  for (const requiredCase of expectedCases.filter((entry) => entry.command_index === 2)) {
+    requireText(
+      "PostgreSQL concrete repair evidence test",
+      concreteTest,
+      `async fn ${requiredCase.case}()`,
+    );
+  }
+}
+
+function verifyNoSecrets(name, value) {
+  if (/postgres(?:ql)?:\/\//iu.test(value)) {
+    fail(`${name} contains a PostgreSQL connection URL`);
+  }
+  if (/\b(?:password|passwd|pwd)\s*=\s*(?!\[REDACTED\])/iu.test(value)) {
+    fail(`${name} contains an unredacted password assignment`);
+  }
+}
+
+function verifyExecutedEvidence() {
+  const existence = {
+    evidence: existsSync(resolve(repoRoot, contract.evidence_path)),
+    stdout: existsSync(resolve(repoRoot, contract.stdout_path)),
+    stderr: existsSync(resolve(repoRoot, contract.stderr_path)),
+  };
+  const presentCount = Object.values(existence).filter(Boolean).length;
+  if (presentCount === 0) {
+    console.log(
+      "Index concrete repair retained evidence contract verified; PostgreSQL owner execution remains pending.",
+    );
+    return;
+  }
+  if (presentCount !== 3) {
+    fail("retained evidence packet and both logs must appear atomically as one complete set");
+  }
+
+  const evidenceText = readText(contract.evidence_path);
+  const stdoutLog = readText(contract.stdout_path);
+  const stderrLog = readText(contract.stderr_path);
+  const evidence = JSON.parse(evidenceText);
+
+  requireExactKeys("retained evidence packet", evidence, [
+    "schema_version",
+    "module",
+    "packet",
+    "status",
+    "final_status",
+    "generated_from",
+    "runner",
+    "verifier",
+    "git_commit",
+    "working_tree_clean_before_run",
+    "source_unchanged_during_run",
+    "started_at",
+    "completed_at",
+    "database_url_source",
+    "database_url_class",
+    "database",
+    "toolchain",
+    "commands",
+    "command_results",
+    "source_sha256",
+    "logs",
+    "executed_cases",
+  ]);
+  if (evidence.schema_version !== 1) fail("retained evidence schema_version drift");
+  if (evidence.module !== contract.module) fail("retained evidence module drift");
+  if (evidence.packet !== "concrete-repair-postgres-runtime-evidence") {
+    fail("retained evidence packet identity drift");
+  }
+  if (evidence.status !== "postgres_runtime_executed" || evidence.final_status !== "pass") {
+    fail("retained evidence must record successful PostgreSQL execution");
+  }
+  if (evidence.generated_from !== contractPath) fail("retained evidence contract path drift");
+  if (evidence.runner !== contract.runner) fail("retained evidence runner drift");
+  if (evidence.verifier !== contract.verifier) fail("retained evidence verifier drift");
+  if (!/^[0-9a-f]{40}$/u.test(evidence.git_commit)) fail("retained evidence commit is invalid");
+  if (evidence.working_tree_clean_before_run !== true) {
+    fail("retained evidence must originate from a clean working tree");
+  }
+  if (evidence.source_unchanged_during_run !== true) {
+    fail("retained evidence must retain unchanged source files during execution");
+  }
+  requireIsoTimestamp("retained evidence started_at", evidence.started_at);
+  requireIsoTimestamp("retained evidence completed_at", evidence.completed_at);
+  if (Date.parse(evidence.completed_at) < Date.parse(evidence.started_at)) {
+    fail("retained evidence completed_at precedes started_at");
+  }
+  if (
+    evidence.database_url_source !== contract.database_url_env &&
+    evidence.database_url_source !== contract.database_url_fallback_env
+  ) {
+    fail("retained evidence database URL source drift");
+  }
+  if (!allowedDatabaseClasses.includes(evidence.database_url_class)) {
+    fail("retained evidence database URL class is invalid");
+  }
+
+  requireExactKeys("retained evidence database", evidence.database, [
+    "backend",
+    "server_version",
+    "server_version_num",
+  ]);
+  if (evidence.database.backend !== "postgresql") fail("retained evidence backend drift");
+  if (
+    typeof evidence.database.server_version !== "string" ||
+    !evidence.database.server_version.trim() ||
+    evidence.database.server_version.length > 128
+  ) {
+    fail("retained evidence PostgreSQL server version is invalid");
+  }
+  if (!/^\d+$/u.test(evidence.database.server_version_num)) {
+    fail("retained evidence PostgreSQL numeric version is invalid");
+  }
+
+  requireExactKeys("retained evidence toolchain", evidence.toolchain, ["cargo", "rustc"]);
+  if (!/^cargo\s/u.test(evidence.toolchain.cargo)) fail("retained Cargo version is invalid");
+  if (!/^rustc\s/u.test(evidence.toolchain.rustc)) fail("retained Rust version is invalid");
+  if (!sameValue(evidence.commands, expectedCommands)) fail("retained evidence command drift");
+
+  if (
+    !Array.isArray(evidence.command_results) ||
+    evidence.command_results.length !== expectedCommands.length
+  ) {
+    fail("retained evidence command result count drift");
+  }
+  for (let index = 0; index < expectedCommands.length; index += 1) {
+    const result = evidence.command_results[index];
+    requireExactKeys(`retained command result ${index}`, result, [
+      "command_index",
+      "status",
+      "stdout_sha256",
+      "stderr_sha256",
+      "stdout_bytes",
+      "stderr_bytes",
+    ]);
+    if (result.command_index !== index || result.status !== 0) {
+      fail(`retained command result ${index} did not pass exactly`);
+    }
+    requireSha256(`retained command ${index} stdout`, result.stdout_sha256);
+    requireSha256(`retained command ${index} stderr`, result.stderr_sha256);
+    for (const field of ["stdout_bytes", "stderr_bytes"]) {
+      if (!Number.isSafeInteger(result[field]) || result[field] < 0) {
+        fail(`retained command result ${index} ${field} is invalid`);
+      }
+    }
+  }
+
+  requireExactKeys("retained source hashes", evidence.source_sha256, expectedSourceFiles);
+  for (const relativePath of expectedSourceFiles) {
+    const retainedHash = evidence.source_sha256[relativePath];
+    requireSha256(`retained source hash ${relativePath}`, retainedHash);
+    if (retainedHash !== sha256File(relativePath)) {
+      fail(`retained evidence is stale for source file: ${relativePath}`);
+    }
+  }
+
+  requireExactKeys("retained logs", evidence.logs, [
+    "stdout_path",
+    "stderr_path",
+    "stdout_sha256",
+    "stderr_sha256",
+    "stdout_bytes",
+    "stderr_bytes",
+    "redactions",
+  ]);
+  if (
+    evidence.logs.stdout_path !== contract.stdout_path ||
+    evidence.logs.stderr_path !== contract.stderr_path
+  ) {
+    fail("retained evidence log path drift");
+  }
+  requireSha256("retained stdout log", evidence.logs.stdout_sha256);
+  requireSha256("retained stderr log", evidence.logs.stderr_sha256);
+  if (evidence.logs.stdout_sha256 !== sha256(stdoutLog)) fail("retained stdout hash drift");
+  if (evidence.logs.stderr_sha256 !== sha256(stderrLog)) fail("retained stderr hash drift");
+  if (evidence.logs.stdout_bytes !== Buffer.byteLength(stdoutLog)) {
+    fail("retained stdout byte count drift");
+  }
+  if (evidence.logs.stderr_bytes !== Buffer.byteLength(stderrLog)) {
+    fail("retained stderr byte count drift");
+  }
+  if (
+    !sameValue(evidence.logs.redactions, [
+      "exact_database_url",
+      "postgresql_url_pattern",
+      "password_assignment",
+    ])
+  ) {
+    fail("retained evidence redaction contract drift");
+  }
+
+  if (!Array.isArray(evidence.executed_cases) || evidence.executed_cases.length !== expectedCases.length) {
+    fail("retained evidence executed case count drift");
+  }
+  for (const requiredCase of expectedCases) {
+    const executedCase = evidence.executed_cases.find(
+      (candidate) => candidate.case === requiredCase.case,
+    );
+    requireExactKeys(`retained case ${requiredCase.case}`, executedCase, [
+      "case",
+      "command_index",
+      "result",
+      "assertions",
+    ]);
+    if (
+      executedCase.command_index !== requiredCase.command_index ||
+      executedCase.result !== "pass" ||
+      !sameValue(executedCase.assertions, requiredCase.assertions)
+    ) {
+      fail(`retained evidence case drift: ${requiredCase.case}`);
+    }
+  }
+
+  verifyNoSecrets("retained evidence packet", evidenceText);
+  verifyNoSecrets("retained stdout", stdoutLog);
+  verifyNoSecrets("retained stderr", stderrLog);
+  for (let index = 0; index < expectedCommands.length; index += 1) {
+    const heading = `=== command ${index}: ${expectedCommands[index].program} ${expectedCommands[index].args.join(" ")} ===`;
+    requireText("retained stdout", stdoutLog, heading);
+    requireText("retained stderr", stderrLog, heading);
+  }
+
+  console.log(
+    "Index concrete repair retained PostgreSQL evidence verified: clean commit, bounded metadata, redacted complete logs, current source hashes, and all required cases passed.",
+  );
+}
+
+try {
+  verifyContract();
+  verifySourceBoundaries();
+  verifyExecutedEvidence();
+} catch (error) {
+  console.error(`Index repair retained evidence verification failed: ${error.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Replay the exact 11-file retained-evidence admission slice from PR #3088 on top of current `main` after all three parent slices were squash-merged.

- add the clean-commit PostgreSQL execution contract;
- add the bounded environment metadata target;
- add the credential-redacting capture runner and atomic terminal packet;
- add pending/executed retained-evidence verification;
- wire the admission verifier into the aggregate Index guard;
- update the execution harness and live plan;
- preserve the Source Module Integration documentation already present on `main`.

## Replay boundary

The branch was rebuilt from the exact relative comparison:

```text
aab4f9418317f965d540adf538ede2e1660785d1
  ...
8319e071b117db77a9eef019f4a3d542e2fed3a7
```

The resulting diff is exactly 11 files and contains no duplicate recovery, orphan-link, or execution-harness parent changes.

## Runtime status

The source boundary remains `source_complete_owner_execution_pending`. No retained PostgreSQL packet or stdout/stderr logs are included.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL/SQLite scenarios, evidence capture, workflows, or CI were run.