### PR TITLE
feat(reactions): add owner persistence

### DIFF
--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -16,7 +16,7 @@ This file is the single source of truth for Forum product scope, Forum-owned
 implementation work, shared-capability integration work, task status, execution
 order and release gates.
 
-The exact pre-correction snapshot is retained at
+The exact pre-correction snapshot remains at
 `docs/archive/implementation-plan-2026-08-06.snapshot` for audit only. It is not
 authoritative. Do not copy ownership or task status from it.
 
@@ -31,8 +31,7 @@ required runtime evidence are complete. Source-ready slices remain
 
 Forum is an installable domain application composed from platform modules. It
 must not recreate common social-platform capabilities inside `rustok-forum`.
-The target is comparable to an application-oriented platform such as phpFox:
-each module owns one capability and Forum contributes only Forum-specific state,
+Each module owns one capability and Forum contributes only Forum-specific state,
 policy, adapters, semantic events and UI composition.
 
 Product inclusion does not imply Forum persistence ownership. Forum may present
@@ -107,10 +106,12 @@ Translation, SEO, Search/Index, Outbox/Events, Taxonomy, Workflow, Comments,
 Groups and Channel are separate platform capabilities. New Forum work must
 integrate them instead of cloning their data models.
 
-The Reactions foundation now provides neutral bounded contracts, revisioned
-subject identity, idempotency identity, read/write ports and unique source
-provider/factory registries. It has no persistence, producer adapter, transport
-or UI yet.
+The Reactions owner now has neutral bounded API contracts, unique source
+provider/factory registries, PostgreSQL/SQLite-compatible tenant-composite
+persistence, immutable catalog snapshots, shared Outbox command receipts and
+atomic actor-state/aggregate updates. Maintainer lockfile generation and runtime
+execution remain pending. No producer adapter, event/reconciliation layer,
+transport or UI exists yet.
 
 ## Program ledger
 
@@ -134,7 +135,7 @@ or UI yet.
 | `FORUM-15` | `in_progress` | Profiles supplies `ProfilesReader`. Finish member-card composition, privacy/block behavior, Forum-stat enrichment and no-N+1 evidence. |
 | `FORUM-16` | `in_progress` | Read state, unread projections, bounded bulk owners and transports exist. Visibility-scoped storefront bulk commands and PostgreSQL evidence remain. |
 | `FORUM-17` | `planned` | Forum drafts/bookmarks with optional Notifications reminders and Media references. |
-| `FORUM-18` | `in_progress` | Neutral `rustok-reactions-api`, optional `rustok-reactions` registration and provider registry now exist. Add owner persistence, then Forum topic/reply provider, transports/UI and evidence; Forum votes remain separate. |
+| `FORUM-18` | `in_progress` | Neutral API, optional owner registration, provider registry, tenant-composite persistence, immutable catalog snapshots, shared receipts and atomic actor aggregates are source-ready. Regenerate `Cargo.lock`, retain owner evidence, add events/reconciliation, then Forum provider, transports/UI and evidence; Forum votes remain separate. |
 | `FORUM-19` | `planned` | Integrate `rustok-moderation-api` subject/effect adapters and Forum-local restrictions. Moderation owns cases and audit. |
 | `FORUM-20` | `in_progress` | Rich visibility and recipient-aware source/inbox slices largely exist. Complete remaining reads, Search/SEO/deep links, reconciliation, delivery and PostgreSQL evidence. |
 | `FORUM-21` | `in_progress` | A-X provide move/merge/split/fork/range owners, transports and UI. Retained runtime evidence remains. |
@@ -185,9 +186,15 @@ revisioned reconciled projection. Forum never stores copied profile source data.
 ### `FORUM-18`: votes, reactions, reputation and achievements
 
 Existing Forum votes remain Forum semantics and must be hardened independently.
-`rustok-reactions` owns reusable reaction catalogs, actor state, receipts and
-aggregate projections. Forum owns topic/reply existence, current revision,
-visibility and reaction-policy authorization through its provider.
+`rustok-reactions` owns reusable reaction catalogs, actor state, shared-receipt
+command execution and aggregate projections. Forum owns topic/reply existence,
+current revision, visibility and reaction-policy authorization through its
+provider.
+
+The next integration slice is a Forum `topic` and `reply`
+`ReactionSubjectProvider`. It must use Forum-owned services, return the exact
+current revision and bounded catalog, hide private denial reasons and never let
+Reactions read Forum tables.
 
 Reputation and achievements remain separate shared capabilities consuming
 semantic facts. Forum trust remains Forum-owned because it controls Forum
@@ -211,9 +218,9 @@ Hosts register/mount packages and do not absorb policy.
 ### Track 1 — shared capabilities
 
 1. Reactions neutral API/optional module foundation: source-ready, maintainer verification pending.
-2. Implement Reactions persistence and command receipts without producer adapters.
-3. Add Forum topic/reply provider and degraded profile.
-4. Add a second producer before freezing shared presentation contracts.
+2. Reactions owner persistence/atomic aggregates: source-ready, lockfile and runtime evidence pending.
+3. Add the Forum `topic` and `reply` `ReactionSubjectProvider` and degraded profile.
+4. Add semantic events/reconciliation and a second producer before freezing shared presentation contracts.
 5. Introduce Reputation/Achievements only after at least two producers agree.
 6. Integrate Forum with `rustok-moderation-api`; never add Forum case queues.
 
@@ -242,13 +249,16 @@ Hosts register/mount packages and do not absorb policy.
 - Profile, Media, Notifications, Reactions, Search and SEO integrations are
   additive; private-table fallbacks are forbidden.
 - Reactions remains optional and outside `default_enabled` until persistence,
-  adapters and degraded profiles are executable.
+  adapters and degraded profiles are executable and verified.
+- Reactions owner tables contain no Forum routes, content, visibility or copied
+  profile data.
 
 ## Required verification
 
 ```bash
 node scripts/verify/verify-forum-shared-capability-ownership.mjs
 node scripts/verify/verify-reactions-foundation.mjs
+node scripts/verify/verify-reactions-owner-persistence.mjs
 cargo test -p rustok-reactions-api
 cargo test -p rustok-reactions
 cargo xtask module validate forum
@@ -257,8 +267,8 @@ npm run verify:forum:storefront-boundary
 git diff --check
 ```
 
-Tests and runtime evidence are maintainer-run. Source contracts do not promote
-runtime status.
+Tests, lockfile generation and runtime evidence are maintainer-run. Source
+contracts do not promote runtime status.
 
 ## Release gates
 
@@ -279,7 +289,7 @@ runtime claims without retained executable evidence.
 
 ## Immediate next action
 
-Implement Reactions persistence and command receipts as a separate owner PR,
-then add the Forum topic/reply `ReactionSubjectProvider` adapter in its own PR.
-The adapter must validate current revision, visibility and catalog policy through
-Forum owners, expose no private denial reason and preserve existing vote behavior.
+Add the Forum `topic` and `reply` `ReactionSubjectProvider` in its own PR. The
+adapter must validate current revision, visibility and catalog policy through
+Forum owners, expose no private denial reason, support an explicit Reactions-
+disabled profile and preserve existing vote behavior.

--- a/crates/rustok-reactions/Cargo.toml
+++ b/crates/rustok-reactions/Cargo.toml
@@ -7,8 +7,17 @@ description = "Shared reaction catalog, actor state, aggregate, and subject orch
 
 [dependencies]
 async-trait.workspace = true
+chrono.workspace = true
+rustok-api.workspace = true
 rustok-core.workspace = true
+rustok-outbox.workspace = true
 rustok-reactions-api = { path = "../rustok-reactions-api" }
+sea-orm.workspace = true
+sea-orm-migration.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
-uuid.workspace = true
+tokio.workspace = true

--- a/crates/rustok-reactions/README.md
+++ b/crates/rustok-reactions/README.md
@@ -7,33 +7,55 @@ revisioned subjects owned by other RusToK modules.
 
 ## Current source slice
 
-The module currently initializes the neutral subject-provider and deferred
-factory registries and exposes their bounded metadata through
-`ReactionsService`. It contains no persistence, migration, event, worker,
-transport or UI implementation.
+The module now provides:
+
+- source-owned subject authorization through `rustok-reactions-api`;
+- PostgreSQL/SQLite-compatible SeaORM migrations for tenant-composite owner state;
+- immutable catalog snapshots bound to an explicit catalog revision;
+- one bounded actor state per tenant, subject, and actor;
+- aggregate counts updated in the same owner transaction as actor state;
+- durable idempotency through the shared `rustok-outbox` owner-operation receipt
+  ledger;
+- transport-neutral `ReactionReadPort` and `ReactionWritePort` implementations.
+
+A reaction command UUID must equal the port idempotency key. The owner admits
+that key through Outbox, authorizes the subject through its producer provider,
+serializes the subject row, applies actor state and aggregate changes, completes
+the receipt in the same transaction, and persists a typed terminal failure after
+rollback when needed.
 
 ## Ownership
 
-The future owner will persist reaction catalogs, actor state, idempotent command
-receipts and aggregate projections. It will not own subject existence,
-visibility, lifecycle, content, profile identity, reputation, achievements or
-notifications.
+Reactions owns catalog snapshots, actor reaction state and aggregate projections.
+Producer modules own subject existence, current revision, visibility, lifecycle
+and reaction policy. Profiles owns actor presentation. Reputation, achievements
+and Notifications are separate capabilities.
 
-Each producer module publishes a provider through `rustok-reactions-api` and
-remains authoritative for the current subject revision and reaction policy. The
-Reactions owner never reads producer-private tables.
+The Reactions owner never reads Forum, Blog, Comments, Profiles, Media, Groups
+or Commerce private tables.
+
+## Deliberate limits
+
+This slice does not add producer adapters, semantic events, reconciliation,
+GraphQL, REST, native server functions, UI packages, default enablement, Forum
+vote migration, reputation or achievements.
+
+The initial catalog revision is the producer-authorized subject revision. A
+future independent catalog-revision contract requires an explicit API change and
+migration rather than implicit reinterpretation.
 
 ## Degraded mode
 
-The module is optional and is not default-enabled. With Reactions absent,
-producer modules keep their ordinary owner commands and may hide reaction UI.
-Existing Forum votes remain unchanged.
+The module remains optional and outside `default_enabled`. When it is absent,
+producer owner commands remain available and reaction UI stays hidden. Existing
+Forum votes remain unchanged.
 
 ## Entry points
 
 - `ReactionsModule`
 - `ReactionsService`
-- re-exported `rustok_reactions_api` contracts
+- `rustok_reactions_api::{ReactionReadPort, ReactionWritePort}`
+- `migrations::migrations()`
 
 See [module contract](docs/README.md) and
 [implementation plan](docs/implementation-plan.md).

--- a/crates/rustok-reactions/contracts/reactions-foundation.json
+++ b/crates/rustok-reactions/contracts/reactions-foundation.json
@@ -1,7 +1,7 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "module": "reactions",
-  "contract": "reactions_foundation_v1",
+  "contract": "reactions_foundation_v2",
   "status": "source_ready_maintainer_execution_pending",
   "api_crate": "crates/rustok-reactions-api",
   "owner_crate": "crates/rustok-reactions",
@@ -15,6 +15,7 @@
     "crates/rustok-reactions-api/docs/implementation-plan.md",
     "crates/rustok-reactions/Cargo.toml",
     "crates/rustok-reactions/src/lib.rs",
+    "crates/rustok-reactions/src/service.rs",
     "crates/rustok-reactions/rustok-module.toml",
     "crates/rustok-reactions/README.md",
     "crates/rustok-reactions/docs/README.md",
@@ -58,16 +59,15 @@
     "rustok-comments",
     "rustok-profiles",
     "rustok-media",
-    "sea-orm",
-    "sea-orm-migration",
+    "rustok-groups",
+    "rustok-commerce",
     "async-graphql",
     "axum",
     "leptos"
   ],
   "deliberate_limits": [
-    "no persistence",
-    "no migrations",
     "no producer-private table reads",
+    "no producer adapters",
     "no transports",
     "no UI",
     "no Forum vote migration",
@@ -79,6 +79,7 @@
     "cargo check -p rustok-reactions-api --all-targets",
     "cargo check -p rustok-reactions --all-targets",
     "node scripts/verify/verify-reactions-foundation.mjs",
+    "node scripts/verify/verify-reactions-owner-persistence.mjs",
     "git diff --check"
   ]
 }

--- a/crates/rustok-reactions/contracts/reactions-owner-persistence.json
+++ b/crates/rustok-reactions/contracts/reactions-owner-persistence.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": 1,
+  "module": "reactions",
+  "contract": "reactions_owner_persistence_v1",
+  "status": "source_ready_maintainer_execution_pending",
+  "migration": "m20260806_000001_create_reaction_owner_state",
+  "migration_dependency": "m20260803_000001_create_owner_operation_receipts",
+  "tables": [
+    "reaction_subjects",
+    "reaction_catalogs",
+    "reaction_actor_states",
+    "reaction_aggregates"
+  ],
+  "required_invariants": [
+    "tenant-composite subject identity",
+    "tenant-composite child foreign keys",
+    "immutable catalog revision binding",
+    "one actor state per subject and actor",
+    "bounded single or multiple selection",
+    "non-negative aggregate counts",
+    "actor state and aggregates in one transaction",
+    "command UUID equals port idempotency key",
+    "shared rustok-outbox owner-operation receipts",
+    "producer authorization before owner persistence",
+    "no producer-private table reads"
+  ],
+  "initial_catalog_revision": "producer_authorized_subject_revision",
+  "deliberate_limits": [
+    "no semantic reaction events",
+    "no reconciliation worker",
+    "no Forum or other producer adapter",
+    "no GraphQL REST native transport",
+    "no admin or storefront UI",
+    "no default enablement",
+    "Cargo.lock regeneration pending maintainer Cargo execution",
+    "no runtime evidence claimed"
+  ],
+  "verification": [
+    "cargo test -p rustok-reactions",
+    "cargo check -p rustok-reactions --all-targets",
+    "node scripts/verify/verify-reactions-owner-persistence.mjs",
+    "git diff --check"
+  ]
+}

--- a/crates/rustok-reactions/docs/README.md
+++ b/crates/rustok-reactions/docs/README.md
@@ -1,39 +1,67 @@
 # Reactions module contract
 
-`rustok-reactions` is an optional first-party module. It depends on Outbox for
-its future transactional event boundary but this foundation does not yet publish
-or consume events.
+`rustok-reactions` is an optional first-party owner. It depends on Outbox for
+the shared durable owner-operation receipt ledger.
 
 ## Runtime composition
 
-Module registration initializes two empty runtime-extension registries:
+Module registration initializes immediate and deferred
+`ReactionSubjectProvider` registries. A producer provider authorizes the exact
+tenant/source/kind/subject/revision and returns the bounded reaction catalog.
+Missing providers and unavailable subjects fail closed.
 
-- immediate `ReactionSubjectProvider` instances;
-- deferred `ReactionSubjectProviderFactory` instances materialized after
-  `HostRuntimeContext` exists.
+## Persistence boundary
 
-A source slug is unique across both the materialized provider set and each
-registry. Missing providers are explicit capability-unavailable states and do
-not authorize a subject.
+The owner schema contains:
 
-## Data boundary
+- `reaction_subjects`: one tenant-composite serialization row per producer
+  subject;
+- `reaction_catalogs`: immutable JSON catalog snapshots by subject and revision;
+- `reaction_actor_states`: one bounded selected-key set per subject and actor;
+- `reaction_aggregates`: one non-negative count per subject and reaction key.
 
-No reaction tables, migrations or owner commands exist in this source slice.
-The eventual owner must persist complete tenant/source/kind/subject/revision
-identity, actor identity, canonical reaction key, action and command UUID. It
-must never use a subject label or route as identity.
+All child tables carry `tenant_id` and use tenant-composite foreign keys. The
+schema deliberately does not store producer routes, titles, visibility, content
+or profile presentation.
 
-## UI and transports
+## Command boundary
 
-No GraphQL, REST, native server functions, Leptos or Next package is registered.
-UI remains hidden while the owner persistence boundary is absent.
+`ReactionWritePort::apply_reaction` requires deadline and idempotency semantics.
+The command UUID must equal `PortContext.idempotency_key`. User callers may only
+act as their own UUID; service/system callers require `reactions:act_as_actor`.
+
+The service authorizes the producer subject before persistence, admits the
+shared Outbox receipt, synchronizes the immutable catalog snapshot, serializes
+the subject row, updates actor state and aggregate deltas in one transaction, and
+completes the receipt in that transaction. A rolled-back command persists a
+terminal typed receipt failure outside the owner transaction.
+
+Single-selection replaces the previous key atomically. Multiple-selection is
+bounded by the authorized catalog. Removing an absent key and adding an already
+selected key are idempotent no-ops.
+
+## Catalog compatibility
+
+The initial catalog revision equals the producer-authorized subject revision.
+A revision cannot be rebound to different catalog JSON. Catalog advancement
+cannot remove a key with live aggregate state; reconciliation must happen first.
+
+## Exclusions
+
+No producer adapter, event catalog, outbox event write, reconciliation worker,
+transport, UI, default enablement, reputation, achievement or Forum vote
+migration is included.
 
 ## Verification
 
 ```bash
+cargo test -p rustok-reactions-api
 cargo test -p rustok-reactions
 cargo check -p rustok-reactions --all-targets
 node scripts/verify/verify-reactions-foundation.mjs
+node scripts/verify/verify-reactions-owner-persistence.mjs
+git diff --check
 ```
 
-No successful execution is claimed by the implementation source.
+Tests, checks and runtime evidence are maintainer-run. `Cargo.lock` regeneration
+is also maintainer-run for this source slice.

--- a/crates/rustok-reactions/docs/implementation-plan.md
+++ b/crates/rustok-reactions/docs/implementation-plan.md
@@ -14,29 +14,49 @@ last_reviewed: 2026-08-06
 
 | Task | Status | Deliverable |
 | --- | --- | --- |
-| `REACTIONS-00` | `in_progress` | Neutral API, optional module registration and provider registry exist; maintainer verification remains. |
-| `REACTIONS-01` | `planned` | PostgreSQL/SQLite owner persistence, catalog revisions, actor uniqueness and idempotent command receipts. |
-| `REACTIONS-02` | `planned` | Atomic aggregate updates, semantic events and reconciliation. |
-| `REACTIONS-03` | `planned` | Forum topic/reply subject adapter and degraded profile. |
+| `REACTIONS-00` | `in_progress` | Neutral API, optional module registration and provider registry are source-ready; maintainer Cargo/Node verification remains. |
+| `REACTIONS-01` | `in_progress` | Tenant-composite owner schema, immutable catalog snapshots, actor uniqueness and shared Outbox command receipts are source-ready. Regenerate `Cargo.lock` and retain SQLite/PostgreSQL execution evidence. |
+| `REACTIONS-02` | `in_progress` | Actor state and aggregate deltas commit atomically behind one subject serialization row. Add semantic events, repair/reconciliation and retained concurrency evidence. |
+| `REACTIONS-03` | `planned` | Forum topic/reply subject provider and explicit disabled/unavailable profile. |
 | `REACTIONS-04` | `planned` | Second real producer adapter and neutral-contract review. |
 | `REACTIONS-05` | `planned` | Bounded read/write transports and module-owned UI. |
 | `REACTIONS-06` | `planned` | Runtime evidence, FBA contracts, import/reconciliation and release profiles. |
 
 ## Ownership
 
-Reactions owns catalog revisions, actor reaction state, write receipts and
-aggregate projections. Producer modules own subject existence, content,
-revision, visibility and reaction policy. Profiles owns actor presentation.
-Reputation and achievements consume semantic facts but do not mutate reaction
-state. Notifications may consume reaction events but are not part of reaction
-command correctness.
+Reactions owns catalog snapshots, actor state, shared-receipt-bound command
+execution and aggregate projections. Producer modules own subject existence,
+current revision, visibility, lifecycle and reaction policy. Profiles owns actor
+presentation. Reputation and achievements consume semantic facts but do not
+mutate reaction state. Notifications may consume future events but are not part
+of command correctness.
+
+## Persistence invariants
+
+- Every row is tenant-scoped.
+- Subject identity is `(tenant, source, kind, subject UUID)`.
+- Subject and catalog revisions are positive and monotonic.
+- One catalog revision is immutably bound to one catalog payload.
+- One actor state exists per tenant/subject/actor.
+- Selection keys remain inside the authorized bounded catalog.
+- Aggregate counts never become negative and change atomically with actor state.
+- Command UUID equals the shared Outbox idempotency key.
+- Producer authorization happens before owner storage access.
+- Reactions never reads producer-private tables.
+
+The initial catalog revision is the producer subject revision. Independent
+catalog revisioning is a later explicit API/migration change.
 
 ## Immediate next action
 
-Implement `REACTIONS-01` as one bounded persistence owner. Require tenant-
-composite identity, one actor/key relation, one command UUID payload identity,
-explicit catalog revision, checked single/multi selection and atomic aggregate
-changes. Do not add Forum adapters, transports or UI in the persistence PR.
+Add the Forum `topic` and `reply` `ReactionSubjectProvider` in a separate PR.
+It must resolve current owner revision, visibility and catalog policy through
+Forum-owned services, expose no private denial reason, preserve existing Forum
+vote behavior and support an explicit Reactions-disabled profile.
+
+Before release, regenerate `Cargo.lock`, execute SQLite and PostgreSQL migrations,
+retain replay/concurrency/rollback evidence, add semantic reaction events and
+provide reconciliation for catalog and aggregate drift.
 
 ## Verification
 
@@ -46,7 +66,8 @@ cargo test -p rustok-reactions
 cargo check -p rustok-reactions-api --all-targets
 cargo check -p rustok-reactions --all-targets
 node scripts/verify/verify-reactions-foundation.mjs
+node scripts/verify/verify-reactions-owner-persistence.mjs
 git diff --check
 ```
 
-Tests and checks are maintainer-run.
+Tests, checks, lockfile generation and runtime evidence are maintainer-run.

--- a/crates/rustok-reactions/src/entities.rs
+++ b/crates/rustok-reactions/src/entities.rs
@@ -1,0 +1,89 @@
+pub mod subject {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "reaction_subjects")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub tenant_id: Uuid,
+        pub source_slug: String,
+        pub subject_kind: String,
+        pub subject_id: Uuid,
+        pub subject_revision: i64,
+        pub current_catalog_revision: i64,
+        pub created_at: DateTimeWithTimeZone,
+        pub updated_at: DateTimeWithTimeZone,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod catalog {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "reaction_catalogs")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub tenant_id: Uuid,
+        pub reaction_subject_id: Uuid,
+        pub catalog_revision: i64,
+        pub catalog_json: Json,
+        pub created_at: DateTimeWithTimeZone,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod actor_state {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "reaction_actor_states")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub tenant_id: Uuid,
+        pub reaction_subject_id: Uuid,
+        pub actor_id: Uuid,
+        pub revision: i64,
+        pub selected_json: Json,
+        pub created_at: DateTimeWithTimeZone,
+        pub updated_at: DateTimeWithTimeZone,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod aggregate {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "reaction_aggregates")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub tenant_id: Uuid,
+        pub reaction_subject_id: Uuid,
+        pub reaction_key: String,
+        pub count: i64,
+        pub created_at: DateTimeWithTimeZone,
+        pub updated_at: DateTimeWithTimeZone,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}

--- a/crates/rustok-reactions/src/lib.rs
+++ b/crates/rustok-reactions/src/lib.rs
@@ -1,39 +1,18 @@
-use std::sync::Arc;
+pub mod entities;
+pub mod migrations;
+mod service;
 
 use async_trait::async_trait;
-use rustok_core::{ModuleRuntimeExtensions, RusToKModule};
-use rustok_reactions_api::{
-    ReactionSubjectRegistry, ReactionSubjectRegistryEntry,
-    ensure_reaction_subject_factory_registry, ensure_reaction_subject_registry,
-    reaction_subject_registry_from_extensions,
+use rustok_core::{
+    MigrationDependencyDescriptor, MigrationSource, ModuleRuntimeExtensions, RusToKModule,
 };
+use rustok_reactions_api::{
+    ensure_reaction_subject_factory_registry, ensure_reaction_subject_registry,
+};
+use sea_orm_migration::MigrationTrait;
 
 pub use rustok_reactions_api as api;
-
-#[derive(Clone)]
-pub struct ReactionsService {
-    subjects: Arc<ReactionSubjectRegistry>,
-}
-
-impl ReactionsService {
-    pub fn from_runtime_extensions(extensions: &ModuleRuntimeExtensions) -> Self {
-        let subjects = reaction_subject_registry_from_extensions(extensions)
-            .unwrap_or_else(|| Arc::new(ReactionSubjectRegistry::default()));
-        Self { subjects }
-    }
-
-    pub fn subject_sources(&self) -> Vec<ReactionSubjectRegistryEntry> {
-        self.subjects.entries()
-    }
-
-    pub fn subject_source_count(&self) -> usize {
-        self.subjects.len()
-    }
-
-    pub fn has_subject_sources(&self) -> bool {
-        !self.subjects.is_empty()
-    }
-}
+pub use service::ReactionsService;
 
 pub struct ReactionsModule;
 
@@ -69,21 +48,33 @@ impl RusToKModule for ReactionsModule {
     }
 }
 
+impl MigrationSource for ReactionsModule {
+    fn migrations(&self) -> Vec<Box<dyn MigrationTrait>> {
+        migrations::migrations()
+    }
+
+    fn migration_dependencies(&self) -> Vec<MigrationDependencyDescriptor> {
+        migrations::migration_dependencies()
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use rustok_core::{ModuleRuntimeExtensions, RusToKModule};
+    use rustok_core::{MigrationSource, ModuleRuntimeExtensions, RusToKModule};
     use rustok_reactions_api::{
         reaction_subject_factory_registry_from_extensions,
         reaction_subject_registry_from_extensions,
     };
 
-    use super::{ReactionsModule, ReactionsService};
+    use super::ReactionsModule;
 
     #[test]
-    fn module_initializes_empty_subject_registries() {
+    fn module_initializes_registries_and_declares_owner_schema() {
         let module = ReactionsModule;
         assert_eq!(module.slug(), "reactions");
         assert_eq!(module.dependencies(), &["outbox"]);
+        assert_eq!(module.migrations().len(), 1);
+        assert_eq!(module.migration_dependencies().len(), 1);
 
         let mut extensions = ModuleRuntimeExtensions::default();
         module
@@ -92,9 +83,5 @@ mod tests {
 
         assert!(reaction_subject_registry_from_extensions(&extensions).is_some());
         assert!(reaction_subject_factory_registry_from_extensions(&extensions).is_some());
-
-        let service = ReactionsService::from_runtime_extensions(&extensions);
-        assert_eq!(service.subject_source_count(), 0);
-        assert!(!service.has_subject_sources());
     }
 }

--- a/crates/rustok-reactions/src/migrations/m20260806_000001_create_reaction_owner_state.rs
+++ b/crates/rustok-reactions/src/migrations/m20260806_000001_create_reaction_owner_state.rs
@@ -1,0 +1,387 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(ReactionSubjects::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(ReactionSubjects::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionSubjects::TenantId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionSubjects::SourceSlug)
+                            .string_len(64)
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionSubjects::SubjectKind)
+                            .string_len(64)
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionSubjects::SubjectId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionSubjects::SubjectRevision)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionSubjects::CurrentCatalogRevision)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionSubjects::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionSubjects::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        for index in [
+            Index::create()
+                .name("ux_reaction_subjects_tenant_identity")
+                .table(ReactionSubjects::Table)
+                .col(ReactionSubjects::TenantId)
+                .col(ReactionSubjects::SourceSlug)
+                .col(ReactionSubjects::SubjectKind)
+                .col(ReactionSubjects::SubjectId)
+                .unique()
+                .to_owned(),
+            Index::create()
+                .name("ux_reaction_subjects_tenant_id")
+                .table(ReactionSubjects::Table)
+                .col(ReactionSubjects::TenantId)
+                .col(ReactionSubjects::Id)
+                .unique()
+                .to_owned(),
+        ] {
+            manager.create_index(index).await?;
+        }
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(ReactionCatalogs::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(ReactionCatalogs::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionCatalogs::TenantId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionCatalogs::ReactionSubjectId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionCatalogs::CatalogRevision)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionCatalogs::CatalogJson)
+                            .json_binary()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionCatalogs::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_reaction_catalogs_tenant_subject")
+                            .from(ReactionCatalogs::Table, ReactionCatalogs::TenantId)
+                            .from_col(ReactionCatalogs::ReactionSubjectId)
+                            .to(ReactionSubjects::Table, ReactionSubjects::TenantId)
+                            .to_col(ReactionSubjects::Id)
+                            .on_update(ForeignKeyAction::Cascade)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("ux_reaction_catalogs_tenant_subject_revision")
+                    .table(ReactionCatalogs::Table)
+                    .col(ReactionCatalogs::TenantId)
+                    .col(ReactionCatalogs::ReactionSubjectId)
+                    .col(ReactionCatalogs::CatalogRevision)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(ReactionActorStates::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(ReactionActorStates::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionActorStates::TenantId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionActorStates::ReactionSubjectId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionActorStates::ActorId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionActorStates::Revision)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionActorStates::SelectedJson)
+                            .json_binary()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionActorStates::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionActorStates::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_reaction_actor_states_tenant_subject")
+                            .from(
+                                ReactionActorStates::Table,
+                                ReactionActorStates::TenantId,
+                            )
+                            .from_col(ReactionActorStates::ReactionSubjectId)
+                            .to(ReactionSubjects::Table, ReactionSubjects::TenantId)
+                            .to_col(ReactionSubjects::Id)
+                            .on_update(ForeignKeyAction::Cascade)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("ux_reaction_actor_states_tenant_subject_actor")
+                    .table(ReactionActorStates::Table)
+                    .col(ReactionActorStates::TenantId)
+                    .col(ReactionActorStates::ReactionSubjectId)
+                    .col(ReactionActorStates::ActorId)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(ReactionAggregates::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(ReactionAggregates::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionAggregates::TenantId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionAggregates::ReactionSubjectId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionAggregates::ReactionKey)
+                            .string_len(64)
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionAggregates::Count)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionAggregates::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .col(
+                        ColumnDef::new(ReactionAggregates::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_reaction_aggregates_tenant_subject")
+                            .from(ReactionAggregates::Table, ReactionAggregates::TenantId)
+                            .from_col(ReactionAggregates::ReactionSubjectId)
+                            .to(ReactionSubjects::Table, ReactionSubjects::TenantId)
+                            .to_col(ReactionSubjects::Id)
+                            .on_update(ForeignKeyAction::Cascade)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("ux_reaction_aggregates_tenant_subject_key")
+                    .table(ReactionAggregates::Table)
+                    .col(ReactionAggregates::TenantId)
+                    .col(ReactionAggregates::ReactionSubjectId)
+                    .col(ReactionAggregates::ReactionKey)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(ReactionAggregates::Table)
+                    .if_exists()
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(ReactionActorStates::Table)
+                    .if_exists()
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(ReactionCatalogs::Table)
+                    .if_exists()
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(ReactionSubjects::Table)
+                    .if_exists()
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum ReactionSubjects {
+    Table,
+    Id,
+    TenantId,
+    SourceSlug,
+    SubjectKind,
+    SubjectId,
+    SubjectRevision,
+    CurrentCatalogRevision,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[derive(DeriveIden)]
+enum ReactionCatalogs {
+    Table,
+    Id,
+    TenantId,
+    ReactionSubjectId,
+    CatalogRevision,
+    CatalogJson,
+    CreatedAt,
+}
+
+#[derive(DeriveIden)]
+enum ReactionActorStates {
+    Table,
+    Id,
+    TenantId,
+    ReactionSubjectId,
+    ActorId,
+    Revision,
+    SelectedJson,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[derive(DeriveIden)]
+enum ReactionAggregates {
+    Table,
+    Id,
+    TenantId,
+    ReactionSubjectId,
+    ReactionKey,
+    Count,
+    CreatedAt,
+    UpdatedAt,
+}

--- a/crates/rustok-reactions/src/migrations/mod.rs
+++ b/crates/rustok-reactions/src/migrations/mod.rs
@@ -1,0 +1,17 @@
+mod m20260806_000001_create_reaction_owner_state;
+
+use rustok_core::MigrationDependencyDescriptor;
+use sea_orm_migration::MigrationTrait;
+
+pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+    vec![Box::new(
+        m20260806_000001_create_reaction_owner_state::Migration,
+    )]
+}
+
+pub fn migration_dependencies() -> Vec<MigrationDependencyDescriptor> {
+    vec![MigrationDependencyDescriptor::new(
+        "m20260806_000001_create_reaction_owner_state",
+        vec!["m20260803_000001_create_owner_operation_receipts"],
+    )]
+}

--- a/crates/rustok-reactions/src/service.rs
+++ b/crates/rustok-reactions/src/service.rs
@@ -1,0 +1,1004 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use rustok_api::{PortActorKind, PortCallPolicy, PortContext, PortError};
+use rustok_outbox::idempotency;
+use rustok_reactions_api::{
+    ApplyReactionCommand, ReactionAction, ReactionActorState, ReactionAggregate, ReactionCatalog,
+    ReactionContractError, ReactionKey, ReactionProviderError, ReactionReadPort,
+    ReactionReadRequest, ReactionSelectionPolicy, ReactionSnapshot, ReactionSubjectAccess,
+    ReactionSubjectAuthorization, ReactionSubjectRef, ReactionSubjectRegistry,
+    ReactionSubjectRegistryEntry, ReactionSubjectRequest, ReactionWritePort, ReactionWriteReceipt,
+};
+use sea_orm::sea_query::{Expr, OnConflict};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, DatabaseTransaction, EntityTrait,
+    QueryFilter, QueryOrder, Set, TransactionTrait,
+};
+use serde::de::DeserializeOwned;
+use uuid::Uuid;
+
+use crate::entities::{actor_state, aggregate, catalog, subject};
+
+const REACTION_OWNER_SLUG: &str = "reactions";
+const APPLY_REACTION_OPERATION: &str = "apply_reaction";
+const ACT_AS_ACTOR_CLAIM: &str = "reactions:act_as_actor";
+
+#[derive(Clone)]
+pub struct ReactionsService {
+    database: DatabaseConnection,
+    subjects: Arc<ReactionSubjectRegistry>,
+}
+
+impl ReactionsService {
+    pub fn new(database: DatabaseConnection, subjects: Arc<ReactionSubjectRegistry>) -> Self {
+        Self { database, subjects }
+    }
+
+    pub fn from_runtime_extensions(
+        database: DatabaseConnection,
+        extensions: &rustok_core::ModuleRuntimeExtensions,
+    ) -> Self {
+        let subjects =
+            rustok_reactions_api::reaction_subject_registry_from_extensions(extensions)
+                .unwrap_or_else(|| Arc::new(ReactionSubjectRegistry::default()));
+        Self::new(database, subjects)
+    }
+
+    pub fn database(&self) -> &DatabaseConnection {
+        &self.database
+    }
+
+    pub fn subject_sources(&self) -> Vec<ReactionSubjectRegistryEntry> {
+        self.subjects.entries()
+    }
+
+    pub fn subject_source_count(&self) -> usize {
+        self.subjects.len()
+    }
+
+    pub fn has_subject_sources(&self) -> bool {
+        !self.subjects.is_empty()
+    }
+
+    async fn authorize_subject(
+        &self,
+        context: &PortContext,
+        subject: ReactionSubjectRef,
+        access: ReactionSubjectAccess,
+    ) -> Result<(ReactionSubjectRef, u64, ReactionCatalog), PortError> {
+        let provider = self.subjects.get(subject.source()).ok_or_else(|| {
+            PortError::unavailable(
+                "reactions.subject_provider_unavailable",
+                "reaction subject provider is unavailable",
+            )
+        })?;
+        if !provider.supported_kinds().contains(subject.kind()) {
+            return Err(PortError::validation(
+                "reactions.subject_kind_unsupported",
+                "reaction subject kind is not supported by its source provider",
+            ));
+        }
+
+        let request = ReactionSubjectRequest { subject, access };
+        request
+            .validate()
+            .map_err(contract_error_to_port_error)?;
+        let authorization = provider
+            .authorize(context.clone(), request.clone())
+            .await
+            .map_err(provider_error_to_port_error)?;
+        authorization
+            .validate_for(&request)
+            .map_err(contract_error_to_port_error)?;
+
+        match authorization {
+            ReactionSubjectAuthorization::Allowed {
+                canonical_subject,
+                catalog,
+            } => {
+                let catalog_revision = canonical_subject.subject_revision();
+                Ok((canonical_subject, catalog_revision, catalog))
+            }
+            ReactionSubjectAuthorization::Unavailable => Err(PortError::not_found(
+                "reactions.subject_unavailable",
+                "reaction subject is unavailable",
+            )),
+        }
+    }
+
+    async fn read_snapshot(
+        &self,
+        subject_ref: ReactionSubjectRef,
+        catalog: ReactionCatalog,
+        actor_id: Option<Uuid>,
+    ) -> Result<ReactionSnapshot, PortError> {
+        let tenant_id = subject_ref.tenant_id();
+        let stored_subject = find_subject(self.database(), &subject_ref).await?;
+        let Some(stored_subject) = stored_subject else {
+            return ReactionSnapshot::try_new(subject_ref, catalog, None, Vec::new())
+                .map_err(contract_error_to_port_error);
+        };
+
+        let aggregates = aggregate::Entity::find()
+            .filter(aggregate::Column::TenantId.eq(tenant_id))
+            .filter(aggregate::Column::ReactionSubjectId.eq(stored_subject.id))
+            .filter(aggregate::Column::Count.gt(0_i64))
+            .order_by_asc(aggregate::Column::ReactionKey)
+            .all(self.database())
+            .await
+            .map_err(database_error)?
+            .into_iter()
+            .map(|row| {
+                let reaction =
+                    ReactionKey::new(row.reaction_key).map_err(contract_error_to_port_error)?;
+                if !catalog.contains(&reaction) {
+                    return Err(PortError::conflict(
+                        "reactions.catalog_reconciliation_required",
+                        "stored reaction aggregate is outside the authorized catalog",
+                    ));
+                }
+                let count = u64::try_from(row.count).map_err(|_| {
+                    PortError::invariant_violation(
+                        "reactions.aggregate_count_invalid",
+                        "stored reaction aggregate count is negative",
+                    )
+                })?;
+                Ok(ReactionAggregate { reaction, count })
+            })
+            .collect::<Result<Vec<_>, PortError>>()?;
+
+        let actor_state = match actor_id {
+            None => None,
+            Some(actor_id) => actor_state::Entity::find()
+                .filter(actor_state::Column::TenantId.eq(tenant_id))
+                .filter(actor_state::Column::ReactionSubjectId.eq(stored_subject.id))
+                .filter(actor_state::Column::ActorId.eq(actor_id))
+                .one(self.database())
+                .await
+                .map_err(database_error)?
+                .map(decode_actor_state)
+                .transpose()?,
+        };
+
+        ReactionSnapshot::try_new(subject_ref, catalog, actor_state, aggregates)
+            .map_err(contract_error_to_port_error)
+    }
+
+    async fn execute_apply(
+        &self,
+        lease: idempotency::Lease,
+        command: &ApplyReactionCommand,
+        canonical_subject: ReactionSubjectRef,
+        catalog_revision: u64,
+        catalog_value: ReactionCatalog,
+    ) -> Result<ReactionWriteReceipt, PortError> {
+        let transaction = self.database.begin().await.map_err(database_error)?;
+        let result = apply_inside_transaction(
+            &transaction,
+            command,
+            canonical_subject,
+            catalog_revision,
+            catalog_value,
+        )
+        .await;
+
+        match result {
+            Ok(receipt) => {
+                idempotency::complete(&transaction, lease, &receipt).await?;
+                transaction.commit().await.map_err(database_error)?;
+                Ok(receipt)
+            }
+            Err(error) => Err(error),
+        }
+    }
+}
+
+#[async_trait]
+impl ReactionReadPort for ReactionsService {
+    async fn read_reactions(
+        &self,
+        context: PortContext,
+        request: ReactionReadRequest,
+    ) -> Result<ReactionSnapshot, PortError> {
+        context.require_policy(PortCallPolicy::read())?;
+        validate_subject_tenant(&context, request.subject())?;
+        if let Some(actor_id) = request.actor_id() {
+            authorize_actor(&context, actor_id)?;
+        }
+
+        let (canonical_subject, _catalog_revision, catalog) = self
+            .authorize_subject(
+                &context,
+                request.subject().clone(),
+                ReactionSubjectAccess::Read {
+                    actor_id: request.actor_id(),
+                },
+            )
+            .await?;
+        self.read_snapshot(canonical_subject, catalog, request.actor_id())
+            .await
+    }
+}
+
+#[async_trait]
+impl ReactionWritePort for ReactionsService {
+    async fn apply_reaction(
+        &self,
+        context: PortContext,
+        command: ApplyReactionCommand,
+    ) -> Result<ReactionWriteReceipt, PortError> {
+        context.require_policy(PortCallPolicy::write())?;
+        validate_subject_tenant(&context, command.subject())?;
+        authorize_actor(&context, command.identity().actor_id())?;
+
+        let expected_key = command.identity().command_id().to_string();
+        if context.idempotency_key.as_deref() != Some(expected_key.as_str()) {
+            return Err(PortError::validation(
+                "reactions.command_idempotency_mismatch",
+                "reaction command UUID must equal the port idempotency key",
+            ));
+        }
+
+        let (canonical_subject, catalog_revision, catalog_value) = self
+            .authorize_subject(
+                &context,
+                command.subject().clone(),
+                ReactionSubjectAccess::Apply {
+                    command: command.clone(),
+                },
+            )
+            .await?;
+        if !catalog_value.contains(command.reaction()) {
+            return Err(PortError::validation(
+                "reactions.reaction_not_allowed",
+                "reaction key is not present in the authorized catalog",
+            ));
+        }
+
+        let lease = match idempotency::admit(
+            self.database(),
+            canonical_subject.tenant_id(),
+            REACTION_OWNER_SLUG,
+            expected_key.as_str(),
+            APPLY_REACTION_OPERATION,
+            &command,
+        )
+        .await?
+        {
+            idempotency::Admission::Run(lease) => lease,
+            idempotency::Admission::Replay(value) => return decode_replay(value),
+            idempotency::Admission::ReplayError(error) => return Err(error),
+        };
+
+        let result = self
+            .execute_apply(
+                lease,
+                &command,
+                canonical_subject,
+                catalog_revision,
+                catalog_value,
+            )
+            .await;
+        if let Err(error) = &result {
+            if let Err(receipt_error) = idempotency::fail(self.database(), lease, error).await {
+                tracing::error!(
+                    operation_id = %lease.operation_id,
+                    error = %receipt_error.message,
+                    "failed to persist Reactions command failure receipt"
+                );
+            }
+        }
+        result
+    }
+}
+
+async fn apply_inside_transaction(
+    transaction: &DatabaseTransaction,
+    command: &ApplyReactionCommand,
+    canonical_subject: ReactionSubjectRef,
+    catalog_revision: u64,
+    catalog_value: ReactionCatalog,
+) -> Result<ReactionWriteReceipt, PortError> {
+    let stored_subject = synchronize_subject(
+        transaction,
+        &canonical_subject,
+        catalog_revision,
+        &catalog_value,
+    )
+    .await?;
+    let actor_id = command.identity().actor_id();
+    let existing_state = actor_state::Entity::find()
+        .filter(actor_state::Column::TenantId.eq(canonical_subject.tenant_id()))
+        .filter(actor_state::Column::ReactionSubjectId.eq(stored_subject.id))
+        .filter(actor_state::Column::ActorId.eq(actor_id))
+        .one(transaction)
+        .await
+        .map_err(database_error)?;
+
+    let state_exists = existing_state.is_some();
+    let (state_id, current_revision, mut selected, created_at) = match existing_state {
+        Some(row) => {
+            let selected = decode_selected(row.selected_json)?;
+            (
+                row.id,
+                i64_to_u64(row.revision, "actor state revision")?,
+                selected,
+                row.created_at,
+            )
+        }
+        None => (
+            Uuid::new_v4(),
+            0,
+            Vec::new(),
+            Utc::now().fixed_offset(),
+        ),
+    };
+
+    if selected.iter().any(|key| !catalog_value.contains(key))
+        || selected.len() > catalog_value.selection().maximum_selected()
+    {
+        return Err(PortError::conflict(
+            "reactions.catalog_reconciliation_required",
+            "stored actor state is outside the authorized catalog",
+        ));
+    }
+
+    let (changed, next_selected, mut deltas) = plan_selection(
+        catalog_value.selection(),
+        &selected,
+        command.reaction(),
+        command.action(),
+    )?;
+    selected = next_selected;
+
+    deltas.retain(|_, delta| *delta != 0);
+    let next_revision = if changed {
+        current_revision.checked_add(1).ok_or_else(|| {
+            PortError::invariant_violation(
+                "reactions.actor_state_revision_exhausted",
+                "reaction actor state revision is exhausted",
+            )
+        })?
+    } else {
+        current_revision
+    };
+
+    if changed {
+        persist_actor_state(
+            transaction,
+            canonical_subject.tenant_id(),
+            stored_subject.id,
+            actor_id,
+            state_id,
+            created_at,
+            next_revision,
+            &selected,
+            state_exists,
+        )
+        .await?;
+        for (reaction, delta) in deltas {
+            apply_aggregate_delta(
+                transaction,
+                canonical_subject.tenant_id(),
+                stored_subject.id,
+                reaction,
+                delta,
+            )
+            .await?;
+        }
+    }
+
+    ReactionWriteReceipt::new(
+        command.identity().command_id(),
+        actor_id,
+        canonical_subject,
+        command.reaction().clone(),
+        command.action(),
+        changed,
+        next_revision,
+    )
+    .map_err(contract_error_to_port_error)
+}
+
+fn plan_selection(
+    policy: ReactionSelectionPolicy,
+    current: &[ReactionKey],
+    reaction: &ReactionKey,
+    action: ReactionAction,
+) -> Result<(bool, Vec<ReactionKey>, BTreeMap<ReactionKey, i64>), PortError> {
+    let mut selected = current.to_vec();
+    let mut deltas = BTreeMap::<ReactionKey, i64>::new();
+    let changed = match action {
+        ReactionAction::Add => match policy {
+            ReactionSelectionPolicy::Single => {
+                if selected.len() == 1 && selected[0] == *reaction {
+                    false
+                } else {
+                    for previous in selected.drain(..) {
+                        *deltas.entry(previous).or_default() -= 1;
+                    }
+                    selected.push(reaction.clone());
+                    *deltas.entry(reaction.clone()).or_default() += 1;
+                    true
+                }
+            }
+            ReactionSelectionPolicy::Multiple { max_selected } => {
+                if selected.contains(reaction) {
+                    false
+                } else {
+                    if selected.len() >= usize::from(max_selected) {
+                        return Err(PortError::conflict(
+                            "reactions.selection_limit_reached",
+                            "actor reaction selection limit has been reached",
+                        ));
+                    }
+                    selected.push(reaction.clone());
+                    selected.sort();
+                    *deltas.entry(reaction.clone()).or_default() += 1;
+                    true
+                }
+            }
+        },
+        ReactionAction::Remove => {
+            if let Some(index) = selected.iter().position(|selected| selected == reaction) {
+                let removed = selected.remove(index);
+                *deltas.entry(removed).or_default() -= 1;
+                true
+            } else {
+                false
+            }
+        }
+    };
+    deltas.retain(|_, delta| *delta != 0);
+    Ok((changed, selected, deltas))
+}
+
+async fn synchronize_subject(
+    transaction: &DatabaseTransaction,
+    canonical_subject: &ReactionSubjectRef,
+    catalog_revision: u64,
+    catalog_value: &ReactionCatalog,
+) -> Result<subject::Model, PortError> {
+    let tenant_id = canonical_subject.tenant_id();
+    let subject_revision = u64_to_i64(
+        canonical_subject.subject_revision(),
+        "reaction subject revision",
+    )?;
+    let catalog_revision = u64_to_i64(catalog_revision, "reaction catalog revision")?;
+    let now = Utc::now().fixed_offset();
+    let candidate_id = Uuid::new_v4();
+
+    subject::Entity::insert(subject::ActiveModel {
+        id: Set(candidate_id),
+        tenant_id: Set(tenant_id),
+        source_slug: Set(canonical_subject.source().to_string()),
+        subject_kind: Set(canonical_subject.kind().to_string()),
+        subject_id: Set(canonical_subject.subject_id()),
+        subject_revision: Set(subject_revision),
+        current_catalog_revision: Set(catalog_revision),
+        created_at: Set(now),
+        updated_at: Set(now),
+    })
+    .on_conflict(
+        OnConflict::columns([
+            subject::Column::TenantId,
+            subject::Column::SourceSlug,
+            subject::Column::SubjectKind,
+            subject::Column::SubjectId,
+        ])
+        .do_nothing()
+        .to_owned(),
+    )
+    .exec_without_returning(transaction)
+    .await
+    .map_err(database_error)?;
+
+    let stored = find_subject(transaction, canonical_subject)
+        .await?
+        .ok_or_else(|| {
+            PortError::invariant_violation(
+                "reactions.subject_insert_missing",
+                "reaction subject row was not observable after admission",
+            )
+        })?;
+
+    subject::Entity::update_many()
+        .col_expr(subject::Column::UpdatedAt, Expr::value(now))
+        .filter(subject::Column::Id.eq(stored.id))
+        .filter(subject::Column::TenantId.eq(tenant_id))
+        .exec(transaction)
+        .await
+        .map_err(database_error)?;
+
+    let stored = subject::Entity::find_by_id(stored.id)
+        .filter(subject::Column::TenantId.eq(tenant_id))
+        .one(transaction)
+        .await
+        .map_err(database_error)?
+        .ok_or_else(|| {
+            PortError::invariant_violation(
+                "reactions.subject_lock_missing",
+                "reaction subject row disappeared during command serialization",
+            )
+        })?;
+
+    if subject_revision < stored.subject_revision {
+        return Err(PortError::conflict(
+            "reactions.subject_revision_stale",
+            "reaction command targets a stale subject revision",
+        ));
+    }
+    if catalog_revision < stored.current_catalog_revision {
+        return Err(PortError::conflict(
+            "reactions.catalog_revision_stale",
+            "reaction command targets a stale catalog revision",
+        ));
+    }
+
+    let catalog_json = serde_json::to_value(catalog_value).map_err(|error| {
+        PortError::invariant_violation("reactions.catalog_encode", error.to_string())
+    })?;
+    if let Some(existing_catalog) = catalog::Entity::find()
+        .filter(catalog::Column::TenantId.eq(tenant_id))
+        .filter(catalog::Column::ReactionSubjectId.eq(stored.id))
+        .filter(catalog::Column::CatalogRevision.eq(catalog_revision))
+        .one(transaction)
+        .await
+        .map_err(database_error)?
+    {
+        if existing_catalog.catalog_json != catalog_json {
+            return Err(PortError::conflict(
+                "reactions.catalog_revision_rebound",
+                "reaction catalog revision is already bound to different content",
+            ));
+        }
+    } else {
+        ensure_catalog_accepts_live_aggregates(
+            transaction,
+            tenant_id,
+            stored.id,
+            catalog_value,
+        )
+        .await?;
+        catalog::Entity::insert(catalog::ActiveModel {
+            id: Set(Uuid::new_v4()),
+            tenant_id: Set(tenant_id),
+            reaction_subject_id: Set(stored.id),
+            catalog_revision: Set(catalog_revision),
+            catalog_json: Set(catalog_json),
+            created_at: Set(now),
+        })
+        .on_conflict(
+            OnConflict::columns([
+                catalog::Column::TenantId,
+                catalog::Column::ReactionSubjectId,
+                catalog::Column::CatalogRevision,
+            ])
+            .do_nothing()
+            .to_owned(),
+        )
+        .exec_without_returning(transaction)
+        .await
+        .map_err(database_error)?;
+
+        let persisted = catalog::Entity::find()
+            .filter(catalog::Column::TenantId.eq(tenant_id))
+            .filter(catalog::Column::ReactionSubjectId.eq(stored.id))
+            .filter(catalog::Column::CatalogRevision.eq(catalog_revision))
+            .one(transaction)
+            .await
+            .map_err(database_error)?
+            .ok_or_else(|| {
+                PortError::invariant_violation(
+                    "reactions.catalog_insert_missing",
+                    "reaction catalog row was not observable after insertion",
+                )
+            })?;
+        if persisted.catalog_json
+            != serde_json::to_value(catalog_value).map_err(|error| {
+                PortError::invariant_violation("reactions.catalog_encode", error.to_string())
+            })?
+        {
+            return Err(PortError::conflict(
+                "reactions.catalog_revision_rebound",
+                "reaction catalog revision is already bound to different content",
+            ));
+        }
+    }
+
+    if subject_revision != stored.subject_revision
+        || catalog_revision != stored.current_catalog_revision
+    {
+        subject::Entity::update_many()
+            .col_expr(
+                subject::Column::SubjectRevision,
+                Expr::value(subject_revision),
+            )
+            .col_expr(
+                subject::Column::CurrentCatalogRevision,
+                Expr::value(catalog_revision),
+            )
+            .col_expr(subject::Column::UpdatedAt, Expr::value(now))
+            .filter(subject::Column::Id.eq(stored.id))
+            .filter(subject::Column::TenantId.eq(tenant_id))
+            .exec(transaction)
+            .await
+            .map_err(database_error)?;
+    }
+
+    subject::Entity::find_by_id(stored.id)
+        .filter(subject::Column::TenantId.eq(tenant_id))
+        .one(transaction)
+        .await
+        .map_err(database_error)?
+        .ok_or_else(|| {
+            PortError::invariant_violation(
+                "reactions.subject_update_missing",
+                "reaction subject row disappeared after catalog synchronization",
+            )
+        })
+}
+
+async fn ensure_catalog_accepts_live_aggregates(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+    reaction_subject_id: Uuid,
+    catalog_value: &ReactionCatalog,
+) -> Result<(), PortError> {
+    let rows = aggregate::Entity::find()
+        .filter(aggregate::Column::TenantId.eq(tenant_id))
+        .filter(aggregate::Column::ReactionSubjectId.eq(reaction_subject_id))
+        .filter(aggregate::Column::Count.gt(0_i64))
+        .all(transaction)
+        .await
+        .map_err(database_error)?;
+    for row in rows {
+        let key = ReactionKey::new(row.reaction_key).map_err(contract_error_to_port_error)?;
+        if !catalog_value.contains(&key) {
+            return Err(PortError::conflict(
+                "reactions.catalog_reconciliation_required",
+                "new reaction catalog removes a key with live aggregate state",
+            ));
+        }
+    }
+    Ok(())
+}
+
+async fn persist_actor_state(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+    reaction_subject_id: Uuid,
+    actor_id: Uuid,
+    state_id: Uuid,
+    created_at: chrono::DateTime<chrono::FixedOffset>,
+    revision: u64,
+    selected: &[ReactionKey],
+    exists: bool,
+) -> Result<(), PortError> {
+    let revision = u64_to_i64(revision, "reaction actor state revision")?;
+    let selected_json = serde_json::to_value(selected).map_err(|error| {
+        PortError::invariant_violation("reactions.actor_state_encode", error.to_string())
+    })?;
+    let now = Utc::now().fixed_offset();
+
+    if exists {
+        let update = actor_state::Entity::update_many()
+            .col_expr(actor_state::Column::Revision, Expr::value(revision))
+            .col_expr(
+                actor_state::Column::SelectedJson,
+                Expr::value(selected_json),
+            )
+            .col_expr(actor_state::Column::UpdatedAt, Expr::value(now))
+            .filter(actor_state::Column::Id.eq(state_id))
+            .filter(actor_state::Column::TenantId.eq(tenant_id))
+            .exec(transaction)
+            .await
+            .map_err(database_error)?;
+        if update.rows_affected != 1 {
+            return Err(PortError::invariant_violation(
+                "reactions.actor_state_update_lost",
+                "reaction actor state update did not affect one row",
+            ));
+        }
+    } else {
+        actor_state::ActiveModel {
+            id: Set(state_id),
+            tenant_id: Set(tenant_id),
+            reaction_subject_id: Set(reaction_subject_id),
+            actor_id: Set(actor_id),
+            revision: Set(revision),
+            selected_json: Set(selected_json),
+            created_at: Set(created_at),
+            updated_at: Set(now),
+        }
+        .insert(transaction)
+        .await
+        .map_err(database_error)?;
+    }
+    Ok(())
+}
+
+async fn apply_aggregate_delta(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+    reaction_subject_id: Uuid,
+    reaction: ReactionKey,
+    delta: i64,
+) -> Result<(), PortError> {
+    let existing = aggregate::Entity::find()
+        .filter(aggregate::Column::TenantId.eq(tenant_id))
+        .filter(aggregate::Column::ReactionSubjectId.eq(reaction_subject_id))
+        .filter(aggregate::Column::ReactionKey.eq(reaction.as_str()))
+        .one(transaction)
+        .await
+        .map_err(database_error)?;
+    let now = Utc::now().fixed_offset();
+
+    match existing {
+        Some(row) => {
+            if row.count < 0 {
+                return Err(PortError::invariant_violation(
+                    "reactions.aggregate_count_invalid",
+                    "stored reaction aggregate count is negative",
+                ));
+            }
+            let next = row.count.checked_add(delta).ok_or_else(|| {
+                PortError::invariant_violation(
+                    "reactions.aggregate_count_exhausted",
+                    "reaction aggregate count overflowed",
+                )
+            })?;
+            if next < 0 {
+                return Err(PortError::invariant_violation(
+                    "reactions.aggregate_count_underflow",
+                    "reaction aggregate count would become negative",
+                ));
+            }
+            if next == 0 {
+                aggregate::Entity::delete_by_id(row.id)
+                    .exec(transaction)
+                    .await
+                    .map_err(database_error)?;
+            } else {
+                let update = aggregate::Entity::update_many()
+                    .col_expr(aggregate::Column::Count, Expr::value(next))
+                    .col_expr(aggregate::Column::UpdatedAt, Expr::value(now))
+                    .filter(aggregate::Column::Id.eq(row.id))
+                    .filter(aggregate::Column::TenantId.eq(tenant_id))
+                    .exec(transaction)
+                    .await
+                    .map_err(database_error)?;
+                if update.rows_affected != 1 {
+                    return Err(PortError::invariant_violation(
+                        "reactions.aggregate_update_lost",
+                        "reaction aggregate update did not affect one row",
+                    ));
+                }
+            }
+        }
+        None if delta > 0 => {
+            aggregate::ActiveModel {
+                id: Set(Uuid::new_v4()),
+                tenant_id: Set(tenant_id),
+                reaction_subject_id: Set(reaction_subject_id),
+                reaction_key: Set(reaction.to_string()),
+                count: Set(delta),
+                created_at: Set(now),
+                updated_at: Set(now),
+            }
+            .insert(transaction)
+            .await
+            .map_err(database_error)?;
+        }
+        None => {
+            return Err(PortError::invariant_violation(
+                "reactions.aggregate_missing",
+                "reaction aggregate row is missing for a decrement",
+            ));
+        }
+    }
+    Ok(())
+}
+
+async fn find_subject<C>(
+    connection: &C,
+    subject_ref: &ReactionSubjectRef,
+) -> Result<Option<subject::Model>, PortError>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    subject::Entity::find()
+        .filter(subject::Column::TenantId.eq(subject_ref.tenant_id()))
+        .filter(subject::Column::SourceSlug.eq(subject_ref.source().as_str()))
+        .filter(subject::Column::SubjectKind.eq(subject_ref.kind().as_str()))
+        .filter(subject::Column::SubjectId.eq(subject_ref.subject_id()))
+        .one(connection)
+        .await
+        .map_err(database_error)
+}
+
+fn decode_actor_state(row: actor_state::Model) -> Result<ReactionActorState, PortError> {
+    let revision = i64_to_u64(row.revision, "reaction actor state revision")?;
+    let selected = decode_selected(row.selected_json)?;
+    ReactionActorState::try_new(revision, selected).map_err(contract_error_to_port_error)
+}
+
+fn decode_selected(value: serde_json::Value) -> Result<Vec<ReactionKey>, PortError> {
+    let selected = serde_json::from_value::<Vec<ReactionKey>>(value).map_err(|error| {
+        PortError::invariant_violation("reactions.actor_state_corrupt", error.to_string())
+    })?;
+    if selected.iter().collect::<BTreeSet<_>>().len() != selected.len() {
+        return Err(PortError::invariant_violation(
+            "reactions.actor_state_corrupt",
+            "stored reaction actor state contains duplicate keys",
+        ));
+    }
+    Ok(selected)
+}
+
+fn validate_subject_tenant(
+    context: &PortContext,
+    subject_ref: &ReactionSubjectRef,
+) -> Result<(), PortError> {
+    let tenant_id = parse_tenant_id(context)?;
+    if tenant_id != subject_ref.tenant_id() {
+        return Err(PortError::forbidden(
+            "reactions.tenant_mismatch",
+            "reaction subject does not belong to the port tenant",
+        ));
+    }
+    Ok(())
+}
+
+fn authorize_actor(context: &PortContext, actor_id: Uuid) -> Result<(), PortError> {
+    match &context.actor.kind {
+        PortActorKind::User => {
+            let context_actor = Uuid::parse_str(&context.actor.id).map_err(|_| {
+                PortError::validation(
+                    "reactions.actor_id_invalid",
+                    "reaction user actor identity must be a UUID",
+                )
+            })?;
+            if context_actor != actor_id {
+                return Err(PortError::forbidden(
+                    "reactions.actor_mismatch",
+                    "reaction actor does not match the authenticated user",
+                ));
+            }
+        }
+        PortActorKind::Service | PortActorKind::System => {
+            if !context.claims.iter().any(|claim| claim == ACT_AS_ACTOR_CLAIM) {
+                return Err(PortError::forbidden(
+                    "reactions.actor_delegation_forbidden",
+                    "service reaction access requires the act-as-actor claim",
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn parse_tenant_id(context: &PortContext) -> Result<Uuid, PortError> {
+    Uuid::parse_str(&context.tenant_id).map_err(|_| {
+        PortError::validation(
+            "reactions.tenant_id_invalid",
+            "reaction port context must carry a UUID tenant_id",
+        )
+    })
+}
+
+fn provider_error_to_port_error(error: ReactionProviderError) -> PortError {
+    match error {
+        ReactionProviderError::CapabilityUnavailable { .. }
+        | ReactionProviderError::Internal { .. } => PortError::unavailable(
+            "reactions.subject_provider_failed",
+            "reaction subject provider is temporarily unavailable",
+        ),
+        ReactionProviderError::InvalidRequest => PortError::validation(
+            "reactions.subject_request_invalid",
+            "reaction subject provider rejected the request shape",
+        ),
+        ReactionProviderError::Unavailable => PortError::not_found(
+            "reactions.subject_unavailable",
+            "reaction subject is unavailable",
+        ),
+        ReactionProviderError::Conflict => PortError::conflict(
+            "reactions.subject_revision_conflict",
+            "reaction subject changed concurrently",
+        ),
+    }
+}
+
+fn contract_error_to_port_error(error: ReactionContractError) -> PortError {
+    PortError::validation("reactions.contract_invalid", error.to_string())
+}
+
+fn database_error(error: sea_orm::DbErr) -> PortError {
+    PortError::unavailable("reactions.database", error.to_string())
+}
+
+fn u64_to_i64(value: u64, label: &'static str) -> Result<i64, PortError> {
+    i64::try_from(value).map_err(|_| {
+        PortError::invariant_violation(
+            "reactions.revision_out_of_range",
+            format!("{label} exceeds the persistence range"),
+        )
+    })
+}
+
+fn i64_to_u64(value: i64, label: &'static str) -> Result<u64, PortError> {
+    u64::try_from(value).map_err(|_| {
+        PortError::invariant_violation(
+            "reactions.revision_invalid",
+            format!("{label} is negative"),
+        )
+    })
+}
+
+fn decode_replay<T: DeserializeOwned>(value: serde_json::Value) -> Result<T, PortError> {
+    serde_json::from_value(value).map_err(|error| {
+        PortError::invariant_violation("outbox.operation_receipt_corrupt", error.to_string())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use rustok_reactions_api::{ReactionAction, ReactionKey, ReactionSelectionPolicy};
+
+    use super::plan_selection;
+
+    fn key(value: &str) -> ReactionKey {
+        ReactionKey::new(value).expect("valid reaction key")
+    }
+
+    #[test]
+    fn single_selection_replaces_the_previous_key_atomically() {
+        let previous = key("like");
+        let next = key("love");
+        let (changed, selected, deltas) = plan_selection(
+            ReactionSelectionPolicy::Single,
+            std::slice::from_ref(&previous),
+            &next,
+            ReactionAction::Add,
+        )
+        .expect("single selection should replace");
+
+        assert!(changed);
+        assert_eq!(selected, vec![next.clone()]);
+        assert_eq!(deltas.get(&previous), Some(&-1));
+        assert_eq!(deltas.get(&next), Some(&1));
+    }
+
+    #[test]
+    fn bounded_multiple_selection_rejects_excess_keys() {
+        let selected = vec![key("like"), key("love")];
+        let error = plan_selection(
+            ReactionSelectionPolicy::multiple(2).expect("policy"),
+            &selected,
+            &key("insightful"),
+            ReactionAction::Add,
+        )
+        .expect_err("selection must remain bounded");
+
+        assert_eq!(error.code, "reactions.selection_limit_reached");
+    }
+
+    #[test]
+    fn removing_an_absent_key_is_an_idempotent_noop() {
+        let selected = vec![key("like")];
+        let (changed, next, deltas) = plan_selection(
+            ReactionSelectionPolicy::Single,
+            &selected,
+            &key("love"),
+            ReactionAction::Remove,
+        )
+        .expect("remove should be accepted");
+
+        assert!(!changed);
+        assert_eq!(next, selected);
+        assert!(deltas.is_empty());
+    }
+}

--- a/scripts/verify/verify-reactions-foundation.mjs
+++ b/scripts/verify/verify-reactions-foundation.mjs
@@ -19,9 +19,9 @@ function read(relativePath) {
   return readFileSync(absolute, "utf8");
 }
 
-if (contract.schema_version !== 1) fail("unsupported contract schema version");
+if (contract.schema_version !== 2) fail("unsupported contract schema version");
 if (contract.module !== "reactions") fail("contract module must be reactions");
-if (contract.contract !== "reactions_foundation_v1") {
+if (contract.contract !== "reactions_foundation_v2") {
   fail("unexpected contract identity");
 }
 
@@ -34,7 +34,10 @@ const apiSource = [
   read("crates/rustok-reactions-api/src/provider.rs"),
 ].join("\n");
 const ownerCargo = read("crates/rustok-reactions/Cargo.toml");
-const ownerSource = read("crates/rustok-reactions/src/lib.rs");
+const ownerSource = [
+  read("crates/rustok-reactions/src/lib.rs"),
+  read("crates/rustok-reactions/src/service.rs"),
+].join("\n");
 
 for (const symbol of contract.required_api_symbols) {
   if (!apiSource.includes(symbol)) fail(`neutral API is missing ${symbol}`);
@@ -49,7 +52,7 @@ for (const dependency of contract.forbidden_api_dependencies) {
 }
 for (const dependency of contract.forbidden_owner_dependencies) {
   if (ownerCargo.includes(dependency)) {
-    fail(`foundation owner imports forbidden dependency ${dependency}`);
+    fail(`owner imports forbidden producer/transport dependency ${dependency}`);
   }
 }
 
@@ -69,15 +72,14 @@ for (const fragment of [
   "ReactionsModule",
   "ensure_reaction_subject_registry",
   "ensure_reaction_subject_factory_registry",
-  "&[\"outbox\"]",
+  '&["outbox"]',
+  "impl ReactionReadPort for ReactionsService",
+  "impl ReactionWritePort for ReactionsService",
 ]) {
-  if (!ownerSource.includes(fragment)) fail(`owner foundation is missing ${fragment}`);
+  if (!ownerSource.includes(fragment)) fail(`owner boundary is missing ${fragment}`);
 }
 
 for (const forbiddenPath of [
-  "crates/rustok-reactions/src/entities",
-  "crates/rustok-reactions/src/migrations",
-  "crates/rustok-reactions/migrations",
   "crates/rustok-reactions/admin",
   "crates/rustok-reactions/storefront",
 ]) {
@@ -92,7 +94,7 @@ if (!/^reactions\s*=\s*\{[^\n]*crate\s*=\s*"rustok-reactions"/mu.test(modules)) 
 }
 const defaultEnabled = modules.match(/default_enabled\s*=\s*\[[\s\S]*?\]/mu)?.[0] ?? "";
 if (/"reactions"/u.test(defaultEnabled)) {
-  fail("reactions must remain outside default_enabled in this foundation slice");
+  fail("reactions must remain outside default_enabled");
 }
 
 const manifest = read("crates/rustok-reactions/rustok-module.toml");
@@ -108,7 +110,8 @@ const forumPlan = read("crates/rustok-forum/docs/implementation-plan.md");
 for (const fragment of [
   "| Reaction catalog, actor reactions and aggregate reaction counts | `rustok-reactions` |",
   "| `FORUM-18` | `in_progress` |",
-  "Add the Forum topic/reply `ReactionSubjectProvider` adapter",
+  "Forum `topic` and `reply`",
+  "`ReactionSubjectProvider`",
   "Existing Forum votes remain Forum semantics",
 ]) {
   if (!forumPlan.includes(fragment)) fail(`Forum plan is missing ${fragment}`);

--- a/scripts/verify/verify-reactions-owner-persistence.mjs
+++ b/scripts/verify/verify-reactions-owner-persistence.mjs
@@ -1,0 +1,136 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-reactions/contracts/reactions-owner-persistence.json";
+
+function fail(message) {
+  throw new Error(`Reactions owner persistence verification failed: ${message}`);
+}
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!existsSync(absolute)) fail(`missing required file ${relativePath}`);
+  return readFileSync(absolute, "utf8");
+}
+
+const contract = JSON.parse(read(contractPath));
+if (contract.schema_version !== 1) fail("unsupported contract schema version");
+if (contract.contract !== "reactions_owner_persistence_v1") {
+  fail("unexpected contract identity");
+}
+
+const cargo = read("crates/rustok-reactions/Cargo.toml");
+const lib = read("crates/rustok-reactions/src/lib.rs");
+const entities = read("crates/rustok-reactions/src/entities.rs");
+const migrationIndex = read("crates/rustok-reactions/src/migrations/mod.rs");
+const migration = read(
+  "crates/rustok-reactions/src/migrations/m20260806_000001_create_reaction_owner_state.rs",
+);
+const service = read("crates/rustok-reactions/src/service.rs");
+const plan = read("crates/rustok-reactions/docs/implementation-plan.md");
+const forumPlan = read("crates/rustok-forum/docs/implementation-plan.md");
+
+for (const dependency of [
+  "rustok-api.workspace = true",
+  "rustok-outbox.workspace = true",
+  "sea-orm.workspace = true",
+  "sea-orm-migration.workspace = true",
+  "serde_json.workspace = true",
+]) {
+  if (!cargo.includes(dependency)) fail(`Cargo boundary is missing ${dependency}`);
+}
+
+for (const table of contract.tables) {
+  if (!entities.includes(`table_name = "${table}"`)) {
+    fail(`owner entity is missing table ${table}`);
+  }
+}
+
+for (const fragment of [
+  "ux_reaction_subjects_tenant_identity",
+  "ux_reaction_subjects_tenant_id",
+  "fk_reaction_catalogs_tenant_subject",
+  "fk_reaction_actor_states_tenant_subject",
+  "fk_reaction_aggregates_tenant_subject",
+  "ux_reaction_catalogs_tenant_subject_revision",
+  "ux_reaction_actor_states_tenant_subject_actor",
+  "ux_reaction_aggregates_tenant_subject_key",
+]) {
+  if (!migration.includes(fragment)) fail(`migration is missing ${fragment}`);
+}
+
+if (!migrationIndex.includes(contract.migration)) {
+  fail("migration index does not register the owner migration");
+}
+if (!migrationIndex.includes(contract.migration_dependency)) {
+  fail("owner migration does not depend on the shared receipt migration");
+}
+for (const fragment of [
+  "impl MigrationSource for ReactionsModule",
+  "migrations::migrations()",
+  "migrations::migration_dependencies()",
+]) {
+  if (!lib.includes(fragment)) fail(`module boundary is missing ${fragment}`);
+}
+
+for (const fragment of [
+  "impl ReactionReadPort for ReactionsService",
+  "impl ReactionWritePort for ReactionsService",
+  "PortCallPolicy::read()",
+  "PortCallPolicy::write()",
+  "reactions.command_idempotency_mismatch",
+  "idempotency::admit(",
+  ".authorize(context.clone(),",
+  "synchronize_subject(",
+  "self.database.begin()",
+  "idempotency::complete(&transaction",
+  "transaction.commit()",
+  "ReactionSelectionPolicy::Single",
+  "ReactionSelectionPolicy::Multiple",
+  "reactions.selection_limit_reached",
+  "reactions.aggregate_count_underflow",
+  "reactions.catalog_revision_rebound",
+  "reactions.catalog_reconciliation_required",
+  "reactions:act_as_actor",
+]) {
+  if (!service.includes(fragment)) fail(`owner service is missing ${fragment}`);
+}
+
+for (const forbidden of [
+  "rustok_forum",
+  "rustok_blog",
+  "rustok_comments",
+  "rustok_profiles",
+  "rustok_media",
+  "async_graphql",
+  "axum::",
+  "leptos::",
+]) {
+  if (service.includes(forbidden) || entities.includes(forbidden)) {
+    fail(`owner persistence imports forbidden dependency ${forbidden}`);
+  }
+}
+
+for (const fragment of [
+  "| `REACTIONS-01` | `in_progress` |",
+  "| `REACTIONS-02` | `in_progress` |",
+  "shared Outbox",
+  "Forum `topic` and `reply` `ReactionSubjectProvider`",
+]) {
+  if (!plan.includes(fragment)) fail(`Reactions plan is missing ${fragment}`);
+}
+
+for (const fragment of [
+  "| `FORUM-18` | `in_progress` |",
+  "tenant-composite persistence",
+  "Forum `topic` and `reply`",
+  "`ReactionSubjectProvider`",
+  "Existing Forum votes remain Forum semantics",
+]) {
+  if (!forumPlan.includes(fragment)) fail(`Forum plan is missing ${fragment}`);
+}
+
+console.log("Reactions owner persistence source contract verified.");


### PR DESCRIPTION
## Summary

Implement the first transport-neutral Reactions owner persistence slice on top of the neutral foundation.

- add PostgreSQL/SQLite-compatible SeaORM owner migrations;
- persist tenant-composite reaction subjects, immutable catalog snapshots, actor state and aggregate counts;
- depend on the shared `m20260803_000001_create_owner_operation_receipts` migration instead of creating a private receipt table;
- implement `ReactionReadPort` and `ReactionWritePort` in `ReactionsService`;
- authorize every read/write through the producer-owned `ReactionSubjectProvider` before storage access;
- require the reaction command UUID to equal `PortContext.idempotency_key`;
- require user callers to act as their own UUID and delegated service/system callers to carry `reactions:act_as_actor`;
- serialize all writes for one subject through the tenant-composite subject row;
- apply actor-state and aggregate deltas in one transaction;
- complete the shared Outbox receipt in the same transaction and retain typed terminal failure replay after rollback;
- enforce bounded single/multiple selection, immutable catalog revision binding and non-negative aggregates;
- update the Reactions and canonical Forum plans plus fail-closed source contracts/verifiers.

## Owner schema

- `reaction_subjects`
- `reaction_catalogs`
- `reaction_actor_states`
- `reaction_aggregates`

Every child row carries `tenant_id` and uses a tenant-composite foreign key. The owner stores no producer routes, content, visibility, titles or profile presentation.

The initial catalog revision is the producer-authorized subject revision. Independent catalog revisioning requires a later explicit API and migration change.

## Deliberate limits

This PR does not add:

- Forum or another producer adapter;
- semantic reaction events or an outbox event catalog;
- aggregate/catalog reconciliation workers;
- GraphQL, REST, native server functions or host routes;
- admin/storefront UI;
- default enablement;
- reputation or achievements;
- migration or reinterpretation of existing Forum votes.

## Main recheck

The branch is based directly on `main@e0451f978e8f533a5949710509ea8327e4a140c0`, one commit ahead and zero behind at PR creation. Intervening main changes were confined to Commerce, Index and Page Builder and did not overlap this slice.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Cargo check, formatting or Clippy;
- Node verifiers;
- SQLite/PostgreSQL migrations or concurrency scenarios;
- workflows or CI.

`Cargo.lock` was not regenerated because the current connector does not provide a safe partial lockfile update and no authenticated local Cargo checkout is available. The first maintainer Cargo run must retain the resulting minimal lock delta before using `--locked`.

Suggested maintainer commands:

```bash
cargo test -p rustok-reactions-api
cargo test -p rustok-reactions
cargo check -p rustok-reactions-api --all-targets
cargo check -p rustok-reactions --all-targets
node scripts/verify/verify-reactions-foundation.mjs
node scripts/verify/verify-reactions-owner-persistence.mjs
git diff --check
```

Source status remains `source_ready_maintainer_execution_pending`.