### PR TITLE
feat(index): register Social Graph mutation route

### DIFF
--- a/apps/server/src/services/mod.rs
+++ b/apps/server/src/services/mod.rs
@@ -202,8 +202,8 @@ pub mod module_event_dispatcher {
     mod tests {
         use rustok_core::{ModuleRegistry, ModuleRuntimeExtensions};
         use rustok_index::{
-            IndexModule, SharedIndexQueryRuntime, SharedIndexReplayRuntime,
-            SharedIndexSchemaRegistry,
+            IndexModule, SharedIndexMutationEventRegistry, SharedIndexQueryRuntime,
+            SharedIndexReplayRuntime, SharedIndexSchemaRegistry,
         };
         use sea_orm::Database;
 
@@ -213,7 +213,7 @@ pub mod module_event_dispatcher {
         use crate::services::server_runtime_context::ServerRuntimeContext;
 
         #[tokio::test]
-        async fn host_materializes_index_query_runtime_after_source_registry() {
+        async fn host_materializes_social_graph_index_query_replay_and_event_runtimes() {
             let registry = ModuleRegistry::new()
                 .register(IndexModule)
                 .register(rustok_social_graph::SocialGraphModule);
@@ -233,7 +233,17 @@ pub mod module_event_dispatcher {
 
             assert!(extensions.contains::<SharedIndexSchemaRegistry>());
             assert!(extensions.contains::<SharedIndexQueryRuntime>());
-            assert!(!extensions.contains::<SharedIndexReplayRuntime>());
+            assert!(extensions.contains::<SharedIndexReplayRuntime>());
+            let event_registry = extensions
+                .get::<SharedIndexMutationEventRegistry>()
+                .expect("Social Graph event registry should be materialized");
+            assert!(
+                event_registry
+                    .get(
+                        rustok_social_graph::index_source::SOCIAL_GRAPH_RELATION_INDEX_EVENT_DOMAIN
+                    )
+                    .is_some()
+            );
             #[cfg(feature = "mod-forum")]
             assert!(
                 extensions.contains::<rustok_search::SharedStorefrontSearchCategoryScopePort>()
@@ -253,7 +263,11 @@ pub mod module_event_dispatcher {
             );
             let host = extensions.apply_to_host_runtime(rustok_api::HostRuntimeContext::new(db));
             assert!(host.shared_get::<SharedIndexQueryRuntime>().is_some());
-            assert!(host.shared_get::<SharedIndexReplayRuntime>().is_none());
+            assert!(host.shared_get::<SharedIndexReplayRuntime>().is_some());
+            assert!(
+                host.shared_get::<SharedIndexMutationEventRegistry>()
+                    .is_some()
+            );
             #[cfg(feature = "mod-forum")]
             assert!(
                 host.shared_get::<rustok_search::SharedStorefrontSearchCategoryScopePort>()

--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -28,6 +28,8 @@ This directory contains the detailed technical architecture documentation for `r
 
 - [Source Module Integration Contract](./module-source-integration.md)
 - [Live Implementation Plan](./implementation-plan.md)
+- [M5 Mutation Event Commit/Ack Contract](./m5-mutation-event-ack-contract.md)
+- [M5 Social Graph Production Mutation Route](./m5-social-graph-mutation-route.md)
 - [M5/M6 Source Replay Contract](./m5-m6-source-replay-contract.md)
 - [M6 Explicit Source Absence Watermark](./m6-explicit-source-absence-watermark.md)
 - [M6 Confidential Source Continuation Codec](./m6-source-continuation-codec.md)

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-03.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-03.md
@@ -1,9 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-03
 
-Status overlay rechecked against the current main snapshot retained in
-`implementation-main-delta-2026-08-06-1525.md`, stacked parent PR #3083 at
-`aab4f9418317f965d540adf538ede2e1660785d1`, and active branch
-`agent/index-m6-repair-evidence-admission-20260806`.
+Status overlay rechecked against `main@e0451f978e8f533a5949710509ea8327e4a140c0` and active
+branch `agent/index-m5-social-graph-event-route-20260806`.
 
 When this dated overlay conflicts with the older canonical plan, this file is the current source of
 truth. Historical architecture and milestone context remain in `implementation-plan.md`.
@@ -32,6 +30,11 @@ The clean-commit retained-evidence admission boundary is
 commands, current source hashes, required case names, bounded database/toolchain metadata, complete
 credential-redacted stdout/stderr, and an atomic terminal pass packet. The packet and logs remain
 absent until the repository owner executes the capture runner.
+
+An independent M5 slice now registers Social Graph as the first exact production mutation route. It
+adds one bounded authoritative replay source over `social_graph_relations`, reuses the existing Iggy
+consumer source identity, and atomically materializes the immutable mutation event registry with the
+staged source catalog. This does not advance or bypass the concrete-repair evidence cursor.
 
 Concrete missing-entity repair:
 
@@ -71,7 +74,9 @@ remain open.
 - M4 query planning/compiler/runtime and privacy shadow: `source_complete_owner_execution_pending`
 - M5 inbox deduplication and monotonic source versions: `complete`
 - M5 mutation event registry and commit-before-ack orchestration:
-  `source_complete_broker_wiring_pending`
+  `generic_source_complete_social_graph_route_runtime_execution_pending`
+- M5 Social Graph bounded replay source and exact production event route:
+  `source_complete_runtime_execution_pending`
 - M5/M6 bounded source replay contract: `source_complete_owner_execution_pending`
 - M6 replay jobs, checkpoints, multi-page execution, cancellation, retry/dead-letter, and generic
   host scheduling: `source_complete_owner_execution_pending`
@@ -112,10 +117,14 @@ remain open.
 - [x] Add a source replay registry with bounded failure classification.
 - [x] Add inbox deduplication and monotonic source versions.
 - [x] Add a database-neutral mutation-source event registry and commit-before-ack orchestration.
-- [ ] Register production owner event routes and compose a concrete broker consumer/acknowledger.
-- [ ] Add batch transactions, bounded backoff, dead-letter state, and lag metrics around production
-      event routes.
-- [ ] Retain crash-between-commit-and-ack and redelivery evidence.
+- [x] Register the Social Graph production event route and bounded replay source.
+- [x] Reuse the concrete Social Graph Iggy consumer/acknowledger, bounded retry/backoff, DLQ and
+      poison receipts, graceful shutdown, and lag/outcome metrics.
+- [x] Materialize selected PostgreSQL sources and mutation event routes atomically.
+- [ ] Register remaining selected production owner routes, beginning with Product/ProductVariant.
+- [ ] Add equivalent concrete consumer policy for every remaining selected owner route.
+- [ ] Retain crash-between-commit-and-ack and redelivery evidence against the generic registered
+      route boundary.
 
 ## M6 replay and scheduling
 
@@ -190,7 +199,8 @@ remain open.
 - [x] Add Product, ProductVariant, and SalesChannel schemas and bounded current-state sources.
 - [x] Add stable replay identities and retained deletes.
 - [x] Add Product-to-ProductVariant graph materialization.
-- [ ] Add production owner event routes and concrete incremental consumer wiring.
+- [ ] Add Product/ProductVariant production owner event routes and concrete incremental consumer
+      wiring.
 - [ ] Persist and enforce per-tenant schema readiness.
 - [ ] Complete durable Product-to-SalesChannel relation semantics and retained evidence.
 - [ ] Admit tombstone purge, freshness/outage/restart/backlog recovery, and delete/recreate evidence.
@@ -214,12 +224,17 @@ The owner must run the locked capture command from a clean commit. The retained 
 - normal full-mutation versus exact edge-owner serialization results;
 - complete credential-redacted stdout/stderr and final pass status.
 
-Public authorization transport, automatic iteration, time-derived leases, and lifecycle
-auto-resolution remain separate later slices.
+Independent source-only work may continue on remaining M5/M7 owner routes, but public repair
+authorization transport, automatic iteration, time-derived leases, and lifecycle auto-resolution
+remain blocked until admission.
 
-## Owner verification for this slice
+## Owner verification for current source boundaries
 
 ```bash
+cargo test -p rustok-social-graph --features index-consumer index_source -- --nocapture
+cargo test -p rustok-index source_factory -- --nocapture
+node scripts/verify/verify-index-social-graph-mutation-route.mjs
+
 RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
   node scripts/evidence/capture-index-repair-postgres.mjs
 
@@ -230,9 +245,10 @@ node scripts/verify/verify-index-missing-entity-repair-composition.mjs
 node scripts/verify/verify-index-orphan-link-repair-composition.mjs
 node scripts/verify/verify-index-targeted-drift-repair.mjs
 node scripts/verify/verify-index-query-contract.mjs
+cargo check -p rustok-social-graph --features index-consumer --all-targets
 cargo check -p rustok-index --all-targets
 git diff --check
 ```
 
-No tests, Node verifiers, formatting, Cargo checks, migrations, PostgreSQL/SQLite scenarios,
+No tests, Node verifiers, formatting, Cargo checks, migrations, PostgreSQL/SQLite/Iggy scenarios,
 workflows, or CI were executed by the implementation agent.

--- a/crates/rustok-index/docs/m5-mutation-event-ack-contract.md
+++ b/crates/rustok-index/docs/m5-mutation-event-ack-contract.md
@@ -1,6 +1,6 @@
 # M5 mutation event acknowledgement contract
 
-Status: `registry_and_commit_before_ack_contract_source_complete_broker_wiring_pending`
+Status: `generic_contract_complete_social_graph_route_source_complete_runtime_execution_pending`.
 
 ## Purpose
 
@@ -9,8 +9,10 @@ idempotency, and monotonic source-version persistence. Incremental ingestion nee
 contract because a broker delivery also owns an acknowledgement token and may be redelivered
 when acknowledgement is lost after the database transaction commits.
 
-This slice adds the database-neutral registration and orchestration boundary. It does not select
-or start a broker consumer.
+The database-neutral registration and orchestration boundary is complete. Social Graph is now the
+first owner to register one exact production route and matching bounded replay source. Its existing
+Iggy consumer remains the concrete broker adapter and acknowledgement owner. Product-family routes
+and new retained runtime evidence remain separate work.
 
 ## Event registry
 
@@ -27,9 +29,12 @@ prevents incremental and full replay paths from silently using different mutatio
 schema contracts.
 
 Event domains and source names are bounded machine identifiers. A delivery is rejected before
-persistence when its event UUID, tenant UUID, or entity UUID is nil, when its source version is
-zero, when its event domain is unknown, or when the mutation schema does not match the registered
-route.
+persistence when its event UUID, tenant UUID, or entity UUID is nil, when its source version is zero,
+when its event domain is unknown, or when the mutation schema does not match the registered route.
+
+PostgreSQL source factories and mutation routes are now materialized atomically. Factories register
+into a staged source catalog; route owner/source/schema validation runs against that same staged
+catalog; and neither catalog is published when any factory or route fails.
 
 ## Commit-before-ack ordering
 
@@ -45,37 +50,55 @@ A mutation failure suppresses acknowledgement. Applied, duplicate, and stale out
 terminal deliveries and are acknowledged only after the sink returns.
 
 If acknowledgement fails after durable persistence, the worker returns
-`IndexMutationEventProcessError::Acknowledge`. The broker may redeliver the same logical event.
-The existing inbox UUID deduplication and monotonic source-version checks own safety for that
-redelivery; the worker does not invent a second ordering clock.
+`IndexMutationEventProcessError::Acknowledge`. The broker may redeliver the same logical event. The
+existing inbox UUID deduplication and monotonic source-version checks own safety for that redelivery;
+the worker does not invent a second ordering clock.
 
-The acknowledgement token is an associated broker-adapter type. Index does not parse, log,
-persist, derive, or compare it with the logical event UUID.
+The acknowledgement token is an associated broker-adapter type. Index does not parse, log, persist,
+derive, or compare it with the logical event UUID.
+
+## First production route: Social Graph
+
+Social Graph registers the exact route and source identity:
+
+```text
+event domain: social_graph.relation.state_changed.v1
+source name:  social_graph.relation.state_changed.v1
+schema:       rustok-social-graph/relation/v1
+owner:        social_graph
+```
+
+The bounded source scans and loads authoritative `social_graph_relations` rows. The existing Iggy
+worker already owns persistent receive/ack, retry/backoff, DLQ/poison receipts, graceful shutdown,
+and runtime consumer metrics. The new route prevents that concrete consumer from remaining an
+unregistered side path relative to generic replay ownership.
+
+See [M5 Social Graph production mutation route](./m5-social-graph-mutation-route.md).
 
 ## Failure boundaries
 
 Mutation persistence and acknowledgement failures expose bounded machine-readable codes and a
-retryable/permanent classification. Raw broker payloads, database errors, transport details,
-request context, tenant data, and acknowledgement tokens are not accepted by these failure types.
+retryable/permanent classification. Raw broker payloads, database errors, transport details, request
+context, tenant data, and acknowledgement tokens are not accepted by these failure types.
 
 There is deliberately no distributed transaction between PostgreSQL and the broker. The supported
-boundary is durable database commit followed by acknowledgement, with duplicate-safe redelivery
-when the second step fails or the process exits between the two steps.
+boundary is durable database commit followed by acknowledgement, with duplicate-safe redelivery when
+the second step fails or the process exits between the two steps.
 
-## Explicit non-claims
+## Remaining non-claims
 
-This slice does not add:
+This boundary still does not add:
 
 - Product, ProductVariant, or SalesChannel event routes;
-- an Iggy, Kafka, NATS, AMQP, or other broker adapter;
-- payload decoding or schema evolution for owner event envelopes;
-- consumer groups, partition assignment, polling, tasks, or graceful shutdown;
-- batch transactions, retry scheduling, backoff, dead-letter persistence, or lag metrics;
-- PostgreSQL/broker crash execution evidence;
+- a second Iggy, Kafka, NATS, AMQP, or other generic broker adapter;
+- generic payload decoding or schema evolution for arbitrary owner event envelopes;
+- generic consumer groups, partition assignment, polling tasks, or graceful shutdown;
+- generic batch transactions, retry scheduling, backoff, dead-letter persistence, or lag metrics;
+- new PostgreSQL/broker crash execution evidence for the registered route;
 - persisted per-tenant schema readiness or Storefront cutover.
 
-The M5 implementation-plan item remains open until selected owner modules register real event
-routes and the server composes a broker consumer with retained commit/ack/redelivery evidence.
+The M5 implementation-plan item remains partially open until the remaining selected owners register
+real event routes and retained commit/ack/redelivery evidence is admitted.
 
 ## Maintainer validation
 
@@ -83,6 +106,14 @@ Execution is maintainer-owned. Suggested commands:
 
 ```bash
 cargo test -p rustok-index mutation_event -- --nocapture
-cargo check -p rustok-index --all-targets
+cargo test -p rustok-index source_factory -- --nocapture
+cargo test -p rustok-social-graph --features index-consumer index_source -- --nocapture
 node scripts/verify/verify-index-mutation-event-ack-contract.mjs
+node scripts/verify/verify-index-social-graph-mutation-route.mjs
+cargo check -p rustok-index --all-targets
+cargo check -p rustok-social-graph --features index-consumer --all-targets
+git diff --check
 ```
+
+No tests, Node verifiers, Cargo checks, formatting, PostgreSQL/Iggy scenarios, workflows, or CI were
+run by the implementation agent.

--- a/crates/rustok-index/docs/m5-social-graph-mutation-route.md
+++ b/crates/rustok-index/docs/m5-social-graph-mutation-route.md
@@ -1,0 +1,128 @@
+# M5 Social Graph production mutation route
+
+Status: `source_complete_runtime_execution_pending`.
+
+## Purpose
+
+The generic M5 mutation-event contract already guarantees commit-before-ack ordering, exact schema
+routing, durable inbox deduplication, and monotonic source versions. Social Graph already owns a
+production Iggy consumer with bounded retry/backoff, DLQ handling, raw-poison receipts, graceful
+shutdown, and runtime metrics. The missing boundary was a canonical replay source and an immutable
+`IndexMutationEventCatalog` route tying that live consumer to the same source/schema identity.
+
+This slice closes that source-composition gap without changing the concrete Iggy worker or bypassing
+the separate concrete-repair PostgreSQL evidence gate.
+
+## Registered identities
+
+The Social Graph owner registers:
+
+```text
+owner module:  social_graph
+schema:        rustok-social-graph/relation/v1
+source:        social_graph.relation.state_changed.v1
+event domain:  social_graph.relation.state_changed.v1
+factory:       social-graph-relation-index-source
+```
+
+The source name deliberately matches `SOCIAL_GRAPH_INDEX_SOURCE` in the existing live consumer.
+Incremental deliveries therefore continue to enter `index_inbox` under the same source identity that
+bounded replay uses.
+
+Live broker deliveries retain their sealed owner event UUID. Replay mutations use a separate
+versioned deterministic derivation domain:
+
+```text
+rustok-social-graph.relation-replay-v1
+```
+
+The identities need not be equal. Inbox deduplication protects exact redelivery, while the monotonic
+relation revision protects convergence when replay and live ingestion observe the same logical
+version through different delivery UUIDs.
+
+## Bounded replay source
+
+`SocialGraphRelationPostgresIndexSource` reads the authoritative `social_graph_relations` table.
+
+`scan`:
+
+- requires the exact non-localized relation schema;
+- accepts the generic Index page bound of at most 1,000 rows;
+- uses one source-owned cursor containing only a non-nil relation UUID;
+- filters one exact tenant;
+- orders by relation UUID;
+- fetches `limit + 1` and emits an advancing cursor only when another page exists.
+
+`load`:
+
+- accepts at most 256 exact keys through `IndexSourceLoadRequest`;
+- rejects locale-bearing keys;
+- filters one exact tenant and the requested relation UUID set;
+- returns only existing authoritative rows in deterministic UUID order.
+
+Every row is revalidated before conversion. Tenant, relation, source user, and target user UUIDs must
+be non-nil; source and target users must differ; relation revision must be positive; and relation kind
+must pass the sealed Social Graph event contract. Active rows become upserts and inactive rows become
+revisioned tombstones through the existing owner conversion function.
+
+The source adapter rejects non-PostgreSQL execution. Factory registration itself performs no SQL and
+starts no task.
+
+## Atomic source and route materialization
+
+`materialize_postgres_index_sources` now stages both boundaries together:
+
+1. clone the current runtime extensions;
+2. invoke every selected PostgreSQL source factory into the staged source catalog;
+3. materialize the mutation event registry against that exact staged catalog;
+4. verify every route owner, source name, and schema;
+5. publish the source catalog and immutable event registry only if the complete batch is valid.
+
+A factory failure, unknown source, owner mismatch, or schema mismatch leaves the live extensions
+unchanged. A partially registered production route cannot escape startup composition.
+
+## Existing concrete consumer
+
+The already existing Social Graph Iggy worker remains the concrete transport owner. It provides:
+
+- one persistent contract consumer cursor;
+- sealed envelope decoding and exact-byte poison retention;
+- durable Index mutation commit before source-offset acknowledgement;
+- duplicate-safe redelivery after acknowledgement loss;
+- bounded retry and backoff;
+- durable DLQ/poison receipts;
+- graceful shutdown with an uncommitted in-flight offset;
+- consumer lag, outcome, failure-stage, and termination metrics.
+
+This slice does not duplicate that worker. It supplies the canonical registry/source identities that
+were missing from module and host composition.
+
+## Deliberate limits
+
+This slice does not:
+
+- run the Social Graph worker or broker;
+- retain new PostgreSQL/Iggy runtime output;
+- register Product or ProductVariant incremental routes;
+- add batch mutation transactions beyond the existing per-delivery durable boundary;
+- change retry, DLQ, lag-metric, or poison-receipt policy;
+- expose drift repair through a public command surface;
+- add automatic repair iteration or time-derived repair leases.
+
+The current concrete-repair cursor remains `M6 - execute and admit concrete repair evidence`.
+
+## Maintainer validation
+
+Suggested owner-run commands:
+
+```bash
+cargo test -p rustok-social-graph --features index-consumer index_source -- --nocapture
+cargo test -p rustok-index source_factory -- --nocapture
+node scripts/verify/verify-index-social-graph-mutation-route.mjs
+cargo check -p rustok-social-graph --features index-consumer --all-targets
+cargo check -p rustok-index --all-targets
+git diff --check
+```
+
+No tests, Node verifiers, Cargo checks, formatting, PostgreSQL/Iggy scenarios, workflows, or CI were
+run by the implementation agent.

--- a/crates/rustok-index/src/infrastructure/postgres/source_factory.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_factory.rs
@@ -4,7 +4,10 @@ use rustok_core::ModuleRuntimeExtensions;
 use sea_orm::DatabaseConnection;
 use thiserror::Error;
 
-use crate::IndexSourceCatalog;
+use crate::{
+    IndexMutationEventError, IndexSourceCatalog, SharedIndexMutationEventRegistry,
+    materialize_index_mutation_event_registry,
+};
 
 const MAX_FACTORY_ID_BYTES: usize = 128;
 
@@ -133,6 +136,8 @@ pub enum PostgresIndexSourceFactoryError {
         owner_module: String,
         factory_name: String,
     },
+    #[error("PostgreSQL Index mutation event registry materialization failed")]
+    MutationEventRegistry(#[source] IndexMutationEventError),
 }
 
 /// Publishes one host-database-aware source constructor during module registration.
@@ -152,16 +157,21 @@ where
         .register(owner_module.into(), factory_name.into(), factory)
 }
 
-/// Constructs every selected PostgreSQL replay source and commits the source catalog atomically.
+/// Constructs every selected PostgreSQL replay source and commits the source/event catalogs
+/// atomically.
 ///
 /// The function performs no SQL and starts no task. A cloned source catalog is staged separately so
-/// one failing owner factory cannot leave earlier sources partially registered in the live runtime
-/// extensions. The returned count is the number of factories that were invoked successfully.
+/// one failing owner factory or mutation-route validation cannot leave earlier sources partially
+/// registered in the live runtime extensions. Exact mutation routes are frozen only after every
+/// source exists, allowing the event registry to verify owner, source, and schema identity against
+/// the same staged catalog. The returned count is the number of factories invoked successfully.
 pub fn materialize_postgres_index_sources(
     extensions: &mut ModuleRuntimeExtensions,
     db: DatabaseConnection,
 ) -> Result<usize, PostgresIndexSourceFactoryError> {
-    if extensions.contains::<PostgresIndexSourcesMaterialized>() {
+    if extensions.contains::<PostgresIndexSourcesMaterialized>()
+        || extensions.contains::<SharedIndexMutationEventRegistry>()
+    {
         return Err(PostgresIndexSourceFactoryError::AlreadyMaterialized);
     }
 
@@ -193,6 +203,12 @@ pub fn materialize_postgres_index_sources(
                 factory_name: descriptor.factory_name.clone(),
             });
         }
+    }
+
+    let event_registry = materialize_index_mutation_event_registry(&staged)
+        .map_err(PostgresIndexSourceFactoryError::MutationEventRegistry)?;
+    if let Some(event_registry) = event_registry {
+        staged.insert(event_registry);
     }
 
     let count = factories.len();
@@ -229,8 +245,9 @@ mod tests {
     use sea_orm::Database;
 
     use crate::{
-        IndexSource, IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest,
-        IndexSourcePage, IndexSourceScanRequest, IndexSourceCatalog, register_index_source,
+        IndexMutationEventCatalog, IndexSource, IndexSourceCatalog, IndexSourceFailure,
+        IndexSourceLoadBatch, IndexSourceLoadRequest, IndexSourcePage, IndexSourceScanRequest,
+        SharedIndexMutationEventRegistry, register_index_mutation_event, register_index_source,
     };
 
     use super::*;
@@ -254,6 +271,14 @@ mod tests {
         }
     }
 
+    fn factory_schema() -> crate::SchemaRef {
+        crate::SchemaRef {
+            module: crate::ModuleName::new("factory-owner").unwrap(),
+            entity: crate::EntityName::new("item").unwrap(),
+            version: crate::SchemaVersion::INITIAL,
+        }
+    }
+
     struct NoopFactory;
 
     impl PostgresIndexSourceFactory for NoopFactory {
@@ -262,16 +287,11 @@ mod tests {
             extensions: &mut ModuleRuntimeExtensions,
             _db: DatabaseConnection,
         ) -> Result<(), String> {
-            let schema = crate::SchemaRef {
-                module: crate::ModuleName::new("factory-owner").map_err(|error| error.to_string())?,
-                entity: crate::EntityName::new("item").map_err(|error| error.to_string())?,
-                version: crate::SchemaVersion::INITIAL,
-            };
             register_index_source(
                 extensions,
                 "factory_owner",
                 "factory-owner-primary",
-                [schema],
+                [factory_schema()],
                 NoopSource,
             )
             .map_err(|error| error.to_string())
@@ -309,6 +329,7 @@ mod tests {
             .get::<IndexSourceCatalog>()
             .expect("source catalog")
             .is_empty());
+        assert!(!extensions.contains::<SharedIndexMutationEventRegistry>());
     }
 
     #[tokio::test]
@@ -334,6 +355,74 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    #[tokio::test]
+    async fn valid_event_routes_freeze_with_the_staged_source_catalog() {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        extensions.insert(IndexSourceCatalog::new());
+        extensions.insert(IndexMutationEventCatalog::new());
+        register_postgres_index_source_factory(
+            &mut extensions,
+            "factory_owner",
+            "primary",
+            NoopFactory,
+        )
+        .unwrap();
+        register_index_mutation_event(
+            &mut extensions,
+            "factory_owner",
+            "factory_owner.item.changed.v1",
+            "factory-owner-primary",
+            factory_schema(),
+        )
+        .unwrap();
+
+        materialize_postgres_index_sources(&mut extensions, connection().await).unwrap();
+
+        let registry = extensions
+            .get::<SharedIndexMutationEventRegistry>()
+            .expect("event registry should be materialized with sources");
+        let route = registry
+            .get("factory_owner.item.changed.v1")
+            .expect("exact event route");
+        assert_eq!(route.owner_module(), "factory_owner");
+        assert_eq!(route.source_name(), "factory-owner-primary");
+        assert_eq!(route.schema(), &factory_schema());
+    }
+
+    #[tokio::test]
+    async fn invalid_event_route_aborts_the_staged_source_catalog() {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        extensions.insert(IndexSourceCatalog::new());
+        extensions.insert(IndexMutationEventCatalog::new());
+        register_postgres_index_source_factory(
+            &mut extensions,
+            "factory_owner",
+            "primary",
+            NoopFactory,
+        )
+        .unwrap();
+        register_index_mutation_event(
+            &mut extensions,
+            "another_owner",
+            "factory_owner.item.changed.v1",
+            "factory-owner-primary",
+            factory_schema(),
+        )
+        .unwrap();
+
+        let error = materialize_postgres_index_sources(&mut extensions, connection().await)
+            .expect_err("route owner mismatch must abort composition");
+        assert!(matches!(
+            error,
+            PostgresIndexSourceFactoryError::MutationEventRegistry(_)
+        ));
+        assert!(extensions
+            .get::<IndexSourceCatalog>()
+            .expect("source catalog")
+            .is_empty());
+        assert!(!extensions.contains::<SharedIndexMutationEventRegistry>());
     }
 
     #[tokio::test]

--- a/crates/rustok-social-graph/src/index_source.rs
+++ b/crates/rustok-social-graph/src/index_source.rs
@@ -1,0 +1,332 @@
+use async_trait::async_trait;
+use rustok_core::ModuleRuntimeExtensions;
+use rustok_events::SocialGraphRelationEvent;
+use rustok_index::{
+    IndexMutation, IndexMutationEventError, IndexSource, IndexSourceCursor, IndexSourceFailure,
+    IndexSourceLoadBatch, IndexSourceLoadRequest, IndexSourcePage, IndexSourceScanRequest,
+    PostgresIndexSourceFactory, PostgresIndexSourceFactoryError, SchemaRef,
+    derive_index_source_event_id, register_index_mutation_event, register_index_source,
+    register_postgres_index_source_factory,
+};
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, DatabaseConnection, DbBackend, EntityTrait, QueryFilter,
+    QueryOrder, QuerySelect,
+};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::entities::relation;
+use crate::index::{
+    SocialGraphIndexError, social_graph_relation_index_mutation,
+    social_graph_relation_index_schema,
+};
+
+pub const SOCIAL_GRAPH_RELATION_INDEX_SOURCE: &str =
+    "social_graph.relation.state_changed.v1";
+pub const SOCIAL_GRAPH_RELATION_INDEX_EVENT_DOMAIN: &str =
+    "social_graph.relation.state_changed.v1";
+pub const SOCIAL_GRAPH_RELATION_INDEX_SOURCE_FACTORY: &str =
+    "social-graph-relation-index-source";
+
+const SOCIAL_GRAPH_INDEX_OWNER: &str = "social_graph";
+const SOCIAL_GRAPH_RELATION_REPLAY_EVENT_DOMAIN: &str =
+    "rustok-social-graph.relation-replay-v1";
+
+#[derive(Debug, Error)]
+pub enum SocialGraphIndexSourceRegistrationError {
+    #[error("Social Graph Index schema construction failed")]
+    Schema(#[source] SocialGraphIndexError),
+    #[error("Social Graph PostgreSQL Index source factory registration failed")]
+    Factory(#[source] PostgresIndexSourceFactoryError),
+    #[error("Social Graph Index mutation event route registration failed")]
+    EventRoute(#[source] IndexMutationEventError),
+}
+
+/// Registers the database-aware replay source constructor and the exact incremental event route.
+///
+/// The source and live consumer intentionally share one inbox source identity. Full replay uses a
+/// separate deterministic event-id domain, while live deliveries retain the owner event UUID.
+/// Both paths therefore converge through the same schema and monotonic source-version contract.
+pub fn register_social_graph_index_source_contracts(
+    extensions: &mut ModuleRuntimeExtensions,
+) -> Result<(), SocialGraphIndexSourceRegistrationError> {
+    let schema = relation_schema_ref().map_err(SocialGraphIndexSourceRegistrationError::Schema)?;
+
+    register_postgres_index_source_factory(
+        extensions,
+        SOCIAL_GRAPH_INDEX_OWNER,
+        SOCIAL_GRAPH_RELATION_INDEX_SOURCE_FACTORY,
+        SocialGraphRelationPostgresIndexSourceFactory,
+    )
+    .map_err(SocialGraphIndexSourceRegistrationError::Factory)?;
+
+    register_index_mutation_event(
+        extensions,
+        SOCIAL_GRAPH_INDEX_OWNER,
+        SOCIAL_GRAPH_RELATION_INDEX_EVENT_DOMAIN,
+        SOCIAL_GRAPH_RELATION_INDEX_SOURCE,
+        schema,
+    )
+    .map_err(SocialGraphIndexSourceRegistrationError::EventRoute)
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SocialGraphRelationPostgresIndexSourceFactory;
+
+impl PostgresIndexSourceFactory for SocialGraphRelationPostgresIndexSourceFactory {
+    fn register_source(
+        &self,
+        extensions: &mut ModuleRuntimeExtensions,
+        db: DatabaseConnection,
+    ) -> Result<(), String> {
+        let schema = relation_schema_ref().map_err(|error| error.to_string())?;
+        register_index_source(
+            extensions,
+            SOCIAL_GRAPH_INDEX_OWNER,
+            SOCIAL_GRAPH_RELATION_INDEX_SOURCE,
+            [schema],
+            SocialGraphRelationPostgresIndexSource { db },
+        )
+        .map_err(|error| error.to_string())
+    }
+}
+
+#[derive(Clone, Debug)]
+struct SocialGraphRelationPostgresIndexSource {
+    db: DatabaseConnection,
+}
+
+impl SocialGraphRelationPostgresIndexSource {
+    fn validate_schema(&self, schema: &SchemaRef) -> Result<(), IndexSourceFailure> {
+        if self.db.get_database_backend() != DbBackend::Postgres {
+            return Err(permanent("social_graph_index_postgres_required"));
+        }
+        let expected = relation_schema_ref()
+            .map_err(|_| permanent("social_graph_index_schema_invalid"))?;
+        if schema != &expected {
+            return Err(permanent("social_graph_index_schema_mismatch"));
+        }
+        Ok(())
+    }
+
+    async fn scan_models(
+        &self,
+        request: &IndexSourceScanRequest,
+        cursor: Option<&RelationCursor>,
+    ) -> Result<Vec<relation::Model>, IndexSourceFailure> {
+        let fetch_limit = u64::try_from(request.limit() + 1)
+            .expect("Index source page limit is bounded below u64::MAX");
+        let mut query = relation::Entity::find()
+            .filter(relation::Column::TenantId.eq(request.tenant_id()))
+            .order_by_asc(relation::Column::Id)
+            .limit(fetch_limit);
+        if let Some(cursor) = cursor {
+            query = query.filter(relation::Column::Id.gt(cursor.relation_id));
+        }
+        query
+            .all(&self.db)
+            .await
+            .map_err(|_| retryable("social_graph_index_storage_unavailable"))
+    }
+
+    async fn load_models(
+        &self,
+        request: &IndexSourceLoadRequest,
+    ) -> Result<Vec<relation::Model>, IndexSourceFailure> {
+        if request.keys().iter().any(|key| key.locale.is_some()) {
+            return Err(permanent("social_graph_index_locale_forbidden"));
+        }
+        let relation_ids = request
+            .keys()
+            .iter()
+            .map(|key| key.entity_id)
+            .collect::<Vec<_>>();
+        relation::Entity::find()
+            .filter(relation::Column::TenantId.eq(request.tenant_id()))
+            .filter(relation::Column::Id.is_in(relation_ids))
+            .order_by_asc(relation::Column::Id)
+            .all(&self.db)
+            .await
+            .map_err(|_| retryable("social_graph_index_storage_unavailable"))
+    }
+}
+
+#[async_trait]
+impl IndexSource for SocialGraphRelationPostgresIndexSource {
+    async fn scan(
+        &self,
+        request: IndexSourceScanRequest,
+    ) -> Result<IndexSourcePage, IndexSourceFailure> {
+        self.validate_schema(request.schema())?;
+        let cursor = request
+            .cursor()
+            .map(RelationCursor::decode)
+            .transpose()?;
+        let models = self.scan_models(&request, cursor.as_ref()).await?;
+        let has_more = models.len() > request.limit();
+        let selected = models
+            .into_iter()
+            .take(request.limit())
+            .collect::<Vec<_>>();
+        let next_cursor = if has_more {
+            let relation_id = selected
+                .last()
+                .ok_or_else(|| permanent("social_graph_index_page_invalid"))?
+                .id;
+            Some(RelationCursor { relation_id }.encode()?)
+        } else {
+            None
+        };
+        let mutations = selected
+            .into_iter()
+            .map(|model| model_into_mutation(model, request.tenant_id()))
+            .collect::<Result<Vec<_>, _>>()?;
+        IndexSourcePage::new(&request, mutations, next_cursor)
+            .map_err(|_| permanent("social_graph_index_page_invalid"))
+    }
+
+    async fn load(
+        &self,
+        request: IndexSourceLoadRequest,
+    ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+        self.validate_schema(request.schema())?;
+        let mutations = self
+            .load_models(&request)
+            .await?
+            .into_iter()
+            .map(|model| model_into_mutation(model, request.tenant_id()))
+            .collect::<Result<Vec<_>, _>>()?;
+        IndexSourceLoadBatch::new(&request, mutations)
+            .map_err(|_| permanent("social_graph_index_batch_invalid"))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RelationCursor {
+    relation_id: Uuid,
+}
+
+impl RelationCursor {
+    fn decode(cursor: &IndexSourceCursor) -> Result<Self, IndexSourceFailure> {
+        let decoded: Self = serde_json::from_value(cursor.value().clone())
+            .map_err(|_| permanent("social_graph_index_cursor_invalid"))?;
+        if decoded.relation_id.is_nil() {
+            return Err(permanent("social_graph_index_cursor_invalid"));
+        }
+        Ok(decoded)
+    }
+
+    fn encode(&self) -> Result<IndexSourceCursor, IndexSourceFailure> {
+        if self.relation_id.is_nil() {
+            return Err(permanent("social_graph_index_cursor_invalid"));
+        }
+        let value = serde_json::to_value(self)
+            .map_err(|_| permanent("social_graph_index_cursor_invalid"))?;
+        IndexSourceCursor::new(value)
+            .map_err(|_| permanent("social_graph_index_cursor_invalid"))
+    }
+}
+
+fn model_into_mutation(
+    model: relation::Model,
+    expected_tenant: Uuid,
+) -> Result<IndexMutation, IndexSourceFailure> {
+    if model.tenant_id != expected_tenant
+        || model.tenant_id.is_nil()
+        || model.id.is_nil()
+        || model.source_user_id.is_nil()
+        || model.target_user_id.is_nil()
+        || model.source_user_id == model.target_user_id
+    {
+        return Err(permanent("social_graph_index_record_invalid"));
+    }
+    let source_version = u64::try_from(model.revision)
+        .map_err(|_| permanent("social_graph_index_source_version_invalid"))?;
+    if source_version == 0 {
+        return Err(permanent("social_graph_index_source_version_invalid"));
+    }
+    let event_id = derive_index_source_event_id(
+        SOCIAL_GRAPH_RELATION_REPLAY_EVENT_DOMAIN,
+        model.tenant_id,
+        model.id,
+        None,
+        source_version,
+    )
+    .map_err(|_| permanent("social_graph_index_event_identity_invalid"))?;
+    let event = SocialGraphRelationEvent::RelationStateChanged {
+        relation_id: model.id,
+        source_user_id: model.source_user_id,
+        target_user_id: model.target_user_id,
+        relation_kind: model.relation_kind.as_str().to_owned(),
+        active: model.active,
+        revision: model.revision,
+    };
+    social_graph_relation_index_mutation(model.tenant_id, event_id, event)
+        .map_err(|_| permanent("social_graph_index_record_invalid"))
+}
+
+fn relation_schema_ref() -> Result<SchemaRef, SocialGraphIndexError> {
+    social_graph_relation_index_schema().map(|schema| schema.reference)
+}
+
+fn retryable(code: &'static str) -> IndexSourceFailure {
+    IndexSourceFailure::retryable(code).expect("static retryable source failure code must be valid")
+}
+
+fn permanent(code: &'static str) -> IndexSourceFailure {
+    IndexSourceFailure::permanent(code).expect("static permanent source failure code must be valid")
+}
+
+#[cfg(test)]
+mod tests {
+    use rustok_index::{IndexMutationEventCatalog, PostgresIndexSourceFactoryCatalog};
+
+    use super::*;
+
+    #[test]
+    fn source_contracts_register_one_factory_and_exact_event_route() {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        register_social_graph_index_source_contracts(&mut extensions).unwrap();
+
+        let factories = extensions
+            .get::<PostgresIndexSourceFactoryCatalog>()
+            .expect("source factory catalog");
+        assert_eq!(factories.len(), 1);
+        let factory = factories.iter().next().unwrap();
+        assert_eq!(factory.owner_module(), SOCIAL_GRAPH_INDEX_OWNER);
+        assert_eq!(factory.factory_name(), SOCIAL_GRAPH_RELATION_INDEX_SOURCE_FACTORY);
+
+        let routes = extensions
+            .get::<IndexMutationEventCatalog>()
+            .expect("event route catalog");
+        let route = routes
+            .get(SOCIAL_GRAPH_RELATION_INDEX_EVENT_DOMAIN)
+            .expect("Social Graph event route");
+        assert_eq!(route.owner_module(), SOCIAL_GRAPH_INDEX_OWNER);
+        assert_eq!(route.source_name(), SOCIAL_GRAPH_RELATION_INDEX_SOURCE);
+        assert_eq!(route.schema(), &relation_schema_ref().unwrap());
+    }
+
+    #[test]
+    fn replay_cursor_is_bounded_and_rejects_nil_identity() {
+        let relation_id = Uuid::from_u128(42);
+        let encoded = RelationCursor { relation_id }.encode().unwrap();
+        assert_eq!(RelationCursor::decode(&encoded).unwrap().relation_id, relation_id);
+        assert!(RelationCursor {
+            relation_id: Uuid::nil(),
+        }
+        .encode()
+        .is_err());
+    }
+
+    #[cfg(feature = "index-consumer")]
+    #[test]
+    fn replay_and_live_consumer_share_one_source_identity() {
+        assert_eq!(
+            SOCIAL_GRAPH_RELATION_INDEX_SOURCE,
+            crate::index_consumer::SOCIAL_GRAPH_INDEX_SOURCE
+        );
+    }
+}

--- a/crates/rustok-social-graph/src/lib.rs
+++ b/crates/rustok-social-graph/src/lib.rs
@@ -20,6 +20,8 @@ pub mod index_dlq_receipt;
 pub mod index_privacy;
 #[cfg(feature = "index")]
 pub mod index_privacy_shadow;
+#[cfg(feature = "index")]
+pub mod index_source;
 pub mod maintenance;
 pub mod migrations;
 pub mod model;
@@ -105,6 +107,13 @@ impl RusToKModule for SocialGraphModule {
                     ))
                 },
             )?;
+            index_source::register_social_graph_index_source_contracts(extensions).map_err(
+                |error| {
+                    rustok_core::Error::Validation(format!(
+                        "Social Graph Index source contract registration failed: {error}"
+                    ))
+                },
+            )?;
         }
         #[cfg(not(feature = "index"))]
         let _ = extensions;
@@ -142,11 +151,11 @@ mod tests {
 
     #[cfg(feature = "index")]
     #[test]
-    fn module_publishes_its_index_schema_through_runtime_extensions() {
+    fn module_publishes_complete_index_source_contracts() {
         let mut extensions = ModuleRuntimeExtensions::default();
         SocialGraphModule
             .register_runtime_extensions(&mut extensions)
-            .expect("Social Graph schema source should register");
+            .expect("Social Graph Index contracts should register");
 
         let catalog = extensions
             .get::<rustok_index::IndexSchemaSourceCatalog>()
@@ -157,5 +166,26 @@ mod tests {
             .expect("Social Graph schema should be source-published");
         assert_eq!(descriptor.owner_module, "social_graph");
         assert_eq!(descriptor.schema, schema);
+
+        let factories = extensions
+            .get::<rustok_index::PostgresIndexSourceFactoryCatalog>()
+            .expect("Social Graph replay source factory should be present");
+        assert!(factories.iter().any(|factory| {
+            factory.owner_module() == "social_graph"
+                && factory.factory_name()
+                    == crate::index_source::SOCIAL_GRAPH_RELATION_INDEX_SOURCE_FACTORY
+        }));
+
+        let routes = extensions
+            .get::<rustok_index::IndexMutationEventCatalog>()
+            .expect("Social Graph mutation event catalog should be present");
+        let route = routes
+            .get(crate::index_source::SOCIAL_GRAPH_RELATION_INDEX_EVENT_DOMAIN)
+            .expect("Social Graph relation event route should be present");
+        assert_eq!(
+            route.source_name(),
+            crate::index_source::SOCIAL_GRAPH_RELATION_INDEX_SOURCE
+        );
+        assert_eq!(route.schema(), &schema.reference);
     }
 }

--- a/scripts/verify/verify-index-mutation-event-ack-contract.mjs
+++ b/scripts/verify/verify-index-mutation-event-ack-contract.mjs
@@ -72,16 +72,39 @@ for (const forbidden of [
   }
 }
 
+const sourceFactoryPath =
+  'crates/rustok-index/src/infrastructure/postgres/source_factory.rs';
+const sourceFactory = requireMarkers(sourceFactoryPath, [
+  'materialize_index_mutation_event_registry(&staged)',
+  'SharedIndexMutationEventRegistry',
+  'MutationEventRegistry(#[source] IndexMutationEventError)',
+  '*extensions = staged',
+]);
+if (
+  sourceFactory.indexOf('materialize_index_mutation_event_registry(&staged)') >=
+  sourceFactory.indexOf('*extensions = staged')
+) {
+  fail(`${sourceFactoryPath} must validate event routes before committing staged extensions`);
+}
+
 const docPath = 'crates/rustok-index/docs/m5-mutation-event-ack-contract.md';
 requireMarkers(docPath, [
-  'Status: `registry_and_commit_before_ack_contract_source_complete_broker_wiring_pending`',
+  'Status: `generic_contract_complete_social_graph_route_source_complete_runtime_execution_pending`',
   '`IndexMutationEventCatalog`',
   '`IndexMutationEventWorker`',
   'A mutation failure suppresses acknowledgement',
   'durable database commit followed by acknowledgement',
-  'does not select or start a broker consumer',
-  'The M5 implementation-plan item remains open',
+  'First production route: Social Graph',
+  'Product, ProductVariant, or SalesChannel event routes',
+  'The M5 implementation-plan item remains partially open',
   'Execution is maintainer-owned',
+]);
+
+requireMarkers('crates/rustok-index/docs/m5-social-graph-mutation-route.md', [
+  'source_complete_runtime_execution_pending',
+  'social_graph.relation.state_changed.v1',
+  'Atomic source and route materialization',
+  'existing Social Graph Iggy worker',
 ]);
 
 console.log('[verify-index-mutation-event-ack-contract] OK');

--- a/scripts/verify/verify-index-social-graph-mutation-route.mjs
+++ b/scripts/verify/verify-index-social-graph-mutation-route.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), 'utf8');
+
+const source = read('crates/rustok-social-graph/src/index_source.rs');
+const moduleSource = read('crates/rustok-social-graph/src/lib.rs');
+const liveConsumer = read('crates/rustok-social-graph/src/index_consumer.rs');
+const sourceFactory = read('crates/rustok-index/src/infrastructure/postgres/source_factory.rs');
+const contract = read('crates/rustok-index/docs/m5-social-graph-mutation-route.md');
+const ackContract = read('crates/rustok-index/docs/m5-mutation-event-ack-contract.md');
+
+for (const marker of [
+  'pub const SOCIAL_GRAPH_RELATION_INDEX_SOURCE: &str =',
+  '"social_graph.relation.state_changed.v1"',
+  'pub const SOCIAL_GRAPH_RELATION_INDEX_EVENT_DOMAIN: &str =',
+  'pub const SOCIAL_GRAPH_RELATION_INDEX_SOURCE_FACTORY: &str =',
+  '"social-graph-relation-index-source"',
+  'impl PostgresIndexSourceFactory for SocialGraphRelationPostgresIndexSourceFactory',
+  'impl IndexSource for SocialGraphRelationPostgresIndexSource',
+  'register_postgres_index_source_factory(',
+  'register_index_mutation_event(',
+  'register_index_source(',
+  'derive_index_source_event_id(',
+  'SOCIAL_GRAPH_RELATION_REPLAY_EVENT_DOMAIN',
+  '.filter(relation::Column::TenantId.eq(request.tenant_id()))',
+  '.order_by_asc(relation::Column::Id)',
+  '.limit(fetch_limit)',
+  'request.limit() + 1',
+  'IndexSourcePage::new(&request, mutations, next_cursor)',
+  'IndexSourceLoadBatch::new(&request, mutations)',
+  'social_graph_relation_index_mutation(',
+]) {
+  assert.ok(source.includes(marker), `Social Graph Index source is missing ${marker}`);
+}
+
+assert.ok(
+  moduleSource.includes('pub mod index_source;') &&
+    moduleSource.includes('register_social_graph_index_source_contracts(extensions)') &&
+    moduleSource.includes('PostgresIndexSourceFactoryCatalog') &&
+    moduleSource.includes('IndexMutationEventCatalog'),
+  'SocialGraphModule must publish schema, replay factory, and mutation route together',
+);
+
+const liveSourceMatch = liveConsumer.match(
+  /pub const SOCIAL_GRAPH_INDEX_SOURCE: &str = "([^"]+)";/,
+);
+const replaySourceMatch = source.match(
+  /pub const SOCIAL_GRAPH_RELATION_INDEX_SOURCE: &str =\s*"([^"]+)";/,
+);
+assert.ok(liveSourceMatch, 'live Social Graph Index consumer source identity is missing');
+assert.ok(replaySourceMatch, 'Social Graph replay source identity is missing');
+assert.equal(
+  replaySourceMatch[1],
+  liveSourceMatch[1],
+  'live and replay paths must share one Index inbox source identity',
+);
+for (const marker of [
+  'social_graph_relation_index_mutation(',
+  'MutationDelivery::from_event(SOCIAL_GRAPH_INDEX_SOURCE, mutation)',
+  'pub async fn acknowledge_consumed(',
+  '.acknowledge(consumed)',
+  'self.acknowledge_consumed(&consumed).await?',
+]) {
+  assert.ok(
+    liveConsumer.includes(marker),
+    `live Social Graph consumer is missing canonical projection/ack marker ${marker}`,
+  );
+}
+
+for (const marker of [
+  'materialize_index_mutation_event_registry(&staged)',
+  'SharedIndexMutationEventRegistry',
+  'MutationEventRegistry(#[source] IndexMutationEventError)',
+  'staged.insert(event_registry)',
+  '*extensions = staged',
+]) {
+  assert.ok(
+    sourceFactory.includes(marker),
+    `PostgreSQL source composition is missing atomic event route marker ${marker}`,
+  );
+}
+
+assert.ok(
+  sourceFactory.indexOf('materialize_index_mutation_event_registry(&staged)') <
+    sourceFactory.indexOf('*extensions = staged'),
+  'event routes must validate before staged runtime extensions are committed',
+);
+
+for (const marker of [
+  'source_complete_runtime_execution_pending',
+  'social_graph.relation.state_changed.v1',
+  'rustok-social-graph.relation-replay-v1',
+  'limit + 1',
+  'Atomic source and route materialization',
+  'existing Social Graph Iggy worker',
+]) {
+  assert.ok(contract.includes(marker), `Social Graph mutation route contract is missing ${marker}`);
+}
+
+assert.ok(
+  ackContract.includes('First production route: Social Graph') &&
+    ackContract.includes('./m5-social-graph-mutation-route.md') &&
+    ackContract.includes('Product, ProductVariant, or SalesChannel event routes'),
+  'M5 acknowledgement contract must record the first route without claiming full owner coverage',
+);
+
+assert.ok(
+  !source.includes('tokio::spawn') &&
+    !source.includes('acknowledge(') &&
+    !source.includes('index_entities') &&
+    !source.includes('index_inbox'),
+  'source registration must not start workers, acknowledge brokers, or write Index tables directly',
+);
+
+console.log(
+  '[verify-index-social-graph-mutation-route] bounded Social Graph source and exact event route verified',
+);


### PR DESCRIPTION
## Summary

Register Social Graph as the first exact production owner route for the generic `rustok-index` mutation-event boundary.

- add a bounded PostgreSQL `IndexSource` over authoritative `social_graph_relations` state;
- register one exact source factory and `social_graph.relation.state_changed.v1` mutation-event route from `SocialGraphModule`;
- reuse the existing live Iggy consumer source identity and sealed event-to-mutation conversion;
- derive replay delivery UUIDs through a separate versioned deterministic domain while preserving relation revision as `source_version`;
- materialize PostgreSQL source factories and the immutable mutation event registry atomically;
- publish Social Graph replay and event registries through the existing server host composition;
- update the M5 contract, live implementation plan, architecture index, server assertions, and fail-closed static verifiers.

## Bounded source contract

The source is scoped to the exact non-localized relation schema and one tenant.

- `scan` orders by relation UUID, fetches `limit + 1`, and emits an advancing UUID cursor only when another page exists;
- `load` accepts only the bounded exact key set from `IndexSourceLoadRequest` and rejects locale-bearing keys;
- rows are validated before conversion;
- active relations become upserts and inactive relations become revisioned tombstones through the existing sealed owner conversion;
- source execution is PostgreSQL-only;
- registration performs no SQL and starts no task.

## Source and event identities

```text
owner:        social_graph
schema:       rustok-social-graph/relation/v1
source:       social_graph.relation.state_changed.v1
event domain: social_graph.relation.state_changed.v1
factory:      social-graph-relation-index-source
replay UUID domain: rustok-social-graph.relation-replay-v1
```

The source identity matches the existing concrete Social Graph Iggy consumer. Live deliveries retain their sealed owner event UUID; bounded replay uses deterministic replay UUIDs. Both converge through the same source/schema identity and monotonic relation revision.

## Atomic composition

`materialize_postgres_index_sources` now invokes all selected factories in staged extensions, validates the mutation event registry against the staged source catalog, and commits both only after every route owner/source/schema relationship succeeds.

A source factory failure, unknown source, owner mismatch, or schema mismatch leaves live extensions unchanged.

## Existing concrete consumer

This PR does not add another broker worker. The existing Social Graph Iggy worker remains the concrete transport owner for persistent receive/acknowledgement, bounded retry/backoff, DLQ and raw-poison receipts, graceful shutdown, and lag/outcome metrics.

## Deliberate limits

This PR does not:

- run PostgreSQL or Iggy scenarios;
- retain new runtime evidence;
- register Product/ProductVariant/SalesChannel production routes;
- add a second generic broker adapter;
- change retry, DLQ, lag, poison, or acknowledgement policy;
- expose drift repair through public transport;
- add automatic repair iteration or time-derived repair leases.

The primary cursor remains `M6 - execute and admit concrete repair evidence`. This is independent source-only M5 progress and does not bypass that gate.

## Main recheck

The branch is one commit ahead of `main@bf15d8c09de0f36974a58e5b15f704c39f27cd6e` with exactly ten changed files. The intervening Reactions and Commerce commits do not overlap this slice.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL/SQLite/Iggy scenarios, evidence capture, workflows, or CI were run.