### PR TITLE
feat(forum): add reaction subject provider

### DIFF
--- a/crates/rustok-forum/Cargo.toml
+++ b/crates/rustok-forum/Cargo.toml
@@ -30,6 +30,7 @@ rustok-events.workspace = true
 rustok-notifications-api.workspace = true
 rustok-outbox.workspace = true
 rustok-profiles.workspace = true
+rustok-reactions-api.workspace = true
 rustok-seo-targets.workspace = true
 rustok-media.workspace = true
 rustok-taxonomy.workspace = true

--- a/crates/rustok-forum/contracts/forum-reaction-subject-provider.json
+++ b/crates/rustok-forum/contracts/forum-reaction-subject-provider.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": 1,
+  "module": "forum",
+  "contract": "forum_reaction_subject_provider_v1",
+  "status": "source_ready_maintainer_execution_pending",
+  "source": "forum",
+  "supported_kinds": ["topic", "reply"],
+  "catalog": {
+    "selection": "single",
+    "keys": ["like"]
+  },
+  "required_files": [
+    "crates/rustok-forum/src/reaction_subject.rs",
+    "crates/rustok-forum/src/lib.rs",
+    "crates/rustok-forum/Cargo.toml",
+    "crates/rustok-forum/docs/implementation-plan.md",
+    "crates/rustok-reactions/docs/implementation-plan.md",
+    "scripts/verify/verify-forum-reaction-subject-provider.mjs"
+  ],
+  "required_source_fragments": [
+    "ForumReactionSubjectProviderFactory",
+    "ReactionSubjectProviderFactory",
+    "ReactionSubjectProvider",
+    "FORUM_TOPIC_REACTION_KIND",
+    "FORUM_REPLY_REACTION_KIND",
+    "FORUM_REACTION_V1_KEY",
+    "ForumTopicAudienceVisibilityService",
+    "ForumNotificationRecipientContextResolver",
+    "deleted_at IS NULL",
+    "current_topic_revision",
+    "current_reply_revision",
+    "ReactionProviderError::Conflict",
+    "ReactionSubjectAuthorization::Unavailable"
+  ],
+  "forbidden_source_fragments": [
+    "forum_votes",
+    "ForumVote",
+    "VoteService",
+    "async_graphql",
+    "axum::",
+    "leptos"
+  ],
+  "ownership": {
+    "forum_owns": [
+      "subject existence",
+      "current revision",
+      "visibility",
+      "lifecycle",
+      "reaction policy"
+    ],
+    "reactions_owns": [
+      "actor state",
+      "command receipts",
+      "aggregate counts"
+    ]
+  },
+  "deliberate_limits": [
+    "no executable host materialization",
+    "no default enablement",
+    "no transport",
+    "no UI",
+    "no semantic reaction events",
+    "no reconciliation",
+    "no Forum vote migration"
+  ],
+  "verification": [
+    "cargo test -p rustok-forum reaction_subject",
+    "cargo check -p rustok-forum --all-targets",
+    "node scripts/verify/verify-forum-reaction-subject-provider.mjs",
+    "git diff --check"
+  ]
+}

--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -109,9 +109,11 @@ integrate them instead of cloning their data models.
 The Reactions owner now has neutral bounded API contracts, unique source
 provider/factory registries, PostgreSQL/SQLite-compatible tenant-composite
 persistence, immutable catalog snapshots, shared Outbox command receipts and
-atomic actor-state/aggregate updates. Maintainer lockfile generation and runtime
-execution remain pending. No producer adapter, event/reconciliation layer,
-transport or UI exists yet.
+atomic actor-state/aggregate updates. Forum now publishes a source-ready
+`topic`/`reply` provider factory with exact active-state, visibility and current-
+revision authorization plus a bounded single-`like` v1 catalog. Maintainer
+lockfile generation, executable host materialization and runtime evidence remain
+pending. No reaction event/reconciliation layer, transport or UI exists yet.
 
 ## Program ledger
 
@@ -135,7 +137,7 @@ transport or UI exists yet.
 | `FORUM-15` | `in_progress` | Profiles supplies `ProfilesReader`. Finish member-card composition, privacy/block behavior, Forum-stat enrichment and no-N+1 evidence. |
 | `FORUM-16` | `in_progress` | Read state, unread projections, bounded bulk owners and transports exist. Visibility-scoped storefront bulk commands and PostgreSQL evidence remain. |
 | `FORUM-17` | `planned` | Forum drafts/bookmarks with optional Notifications reminders and Media references. |
-| `FORUM-18` | `in_progress` | Neutral API, optional owner registration, provider registry, tenant-composite persistence, immutable catalog snapshots, shared receipts and atomic actor aggregates are source-ready. Regenerate `Cargo.lock`, retain owner evidence, add events/reconciliation, then Forum provider, transports/UI and evidence; Forum votes remain separate. |
+| `FORUM-18` | `in_progress` | Neutral API, optional owner registration, tenant-composite persistence, shared receipts, atomic actor aggregates and the Forum topic/reply provider factory are source-ready. Add optional distribution/host materialization and enabled/disabled evidence, regenerate `Cargo.lock`, retain owner evidence, then add events/reconciliation, transports/UI and runtime proof; Forum votes remain separate. |
 | `FORUM-19` | `planned` | Integrate `rustok-moderation-api` subject/effect adapters and Forum-local restrictions. Moderation owns cases and audit. |
 | `FORUM-20` | `in_progress` | Rich visibility and recipient-aware source/inbox slices largely exist. Complete remaining reads, Search/SEO/deep links, reconciliation, delivery and PostgreSQL evidence. |
 | `FORUM-21` | `in_progress` | A-X provide move/merge/split/fork/range owners, transports and UI. Retained runtime evidence remains. |
@@ -191,10 +193,20 @@ command execution and aggregate projections. Forum owns topic/reply existence,
 current revision, visibility and reaction-policy authorization through its
 provider.
 
-The next integration slice is a Forum `topic` and `reply`
-`ReactionSubjectProvider`. It must use Forum-owned services, return the exact
-current revision and bounded catalog, hide private denial reasons and never let
-Reactions read Forum tables.
+The Forum provider factory supports `topic` and `reply`, checks tenant/source/
+kind, active soft-delete state, approved/open lifecycle and the existing rich
+audience visibility service, and returns one bounded single-selection `like`
+catalog. Its current revision is `latest captured Forum revision id + 1`, so the
+identity advances with captured topic translation/metadata and reply-body edits.
+Missing and denied targets share one `Unavailable` result; revision conflict is
+returned only after current visibility succeeds. Delegated service/system access
+uses the existing exact recipient-context port rather than inventing profile or
+authority storage.
+
+Forum registers only the neutral provider factory. It does not depend on the
+Reactions owner, does not add Reactions to Forum module dependencies, and remains
+fully usable when Reactions is absent. Executable distribution selection and
+host registry materialization remain a separate composition slice.
 
 Reputation and achievements remain separate shared capabilities consuming
 semantic facts. Forum trust remains Forum-owned because it controls Forum
@@ -219,10 +231,11 @@ Hosts register/mount packages and do not absorb policy.
 
 1. Reactions neutral API/optional module foundation: source-ready, maintainer verification pending.
 2. Reactions owner persistence/atomic aggregates: source-ready, lockfile and runtime evidence pending.
-3. Add the Forum `topic` and `reply` `ReactionSubjectProvider` and degraded profile.
-4. Add semantic events/reconciliation and a second producer before freezing shared presentation contracts.
-5. Introduce Reputation/Achievements only after at least two producers agree.
-6. Integrate Forum with `rustok-moderation-api`; never add Forum case queues.
+3. Forum `topic`/`reply` provider factory and disabled Forum profile: source-ready, maintainer verification pending.
+4. Add optional distribution/server selection, materialize providers after host facts, and retain enabled/disabled composition evidence.
+5. Add semantic events/reconciliation and a second producer before freezing shared presentation contracts.
+6. Introduce Reputation/Achievements only after at least two producers agree.
+7. Integrate Forum with `rustok-moderation-api`; never add Forum case queues.
 
 ### Track 2 — close existing Forum work
 
@@ -252,6 +265,8 @@ Hosts register/mount packages and do not absorb policy.
   adapters and degraded profiles are executable and verified.
 - Reactions owner tables contain no Forum routes, content, visibility or copied
   profile data.
+- Forum's neutral Reactions API dependency does not make the Reactions owner a
+  required Forum module dependency.
 
 ## Required verification
 
@@ -259,8 +274,10 @@ Hosts register/mount packages and do not absorb policy.
 node scripts/verify/verify-forum-shared-capability-ownership.mjs
 node scripts/verify/verify-reactions-foundation.mjs
 node scripts/verify/verify-reactions-owner-persistence.mjs
+node scripts/verify/verify-forum-reaction-subject-provider.mjs
 cargo test -p rustok-reactions-api
 cargo test -p rustok-reactions
+cargo test -p rustok-forum reaction_subject
 cargo xtask module validate forum
 npm run verify:forum:admin-boundary
 npm run verify:forum:storefront-boundary
@@ -289,7 +306,7 @@ runtime claims without retained executable evidence.
 
 ## Immediate next action
 
-Add the Forum `topic` and `reply` `ReactionSubjectProvider` in its own PR. The
-adapter must validate current revision, visibility and catalog policy through
-Forum owners, expose no private denial reason, support an explicit Reactions-
-disabled profile and preserve existing vote behavior.
+Add optional `mod-reactions` selection to the distribution and executable host,
+materialize the registered Forum provider only after host audience/recipient
+facts exist, keep it outside default profiles, and retain source/runtime evidence
+for both Reactions-enabled and Reactions-disabled Forum composition.

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -3,6 +3,7 @@ use rustok_api::Permission;
 use rustok_core::search_projection::register_search_projection_source;
 use rustok_core::{MigrationSource, ModuleRuntimeExtensions, RusToKModule};
 use rustok_notifications_api::register_notification_source_provider_factory;
+use rustok_reactions_api::register_reaction_subject_provider_factory;
 use rustok_seo_targets::register_seo_target_provider;
 use sea_orm_migration::MigrationTrait;
 
@@ -22,6 +23,7 @@ mod moderation_transport;
 pub mod notification_recipient;
 mod notification_source;
 pub mod openapi;
+mod reaction_subject;
 mod reply_create_transport;
 pub mod reply_read_transport;
 pub mod richtext;
@@ -58,6 +60,10 @@ pub use notification_recipient::{
     FORUM_NOTIFICATION_RECIPIENT_CONTEXT_CAPABILITY_UNAVAILABLE, ForumNotificationRecipientContext,
     ForumNotificationRecipientContextPort, ForumNotificationRecipientContextRequest,
     ForumNotificationRecipientContextResolver, SharedForumNotificationRecipientContextPort,
+};
+pub use reaction_subject::{
+    FORUM_REACTION_SOURCE, FORUM_REACTION_V1_KEY, FORUM_REPLY_REACTION_KIND,
+    FORUM_TOPIC_REACTION_KIND, ForumReactionSubjectProviderFactory,
 };
 pub use reply_read_transport::{
     ForumReplyReadOperation, ForumReplyReadTransport, reply_read_audience_port_context,
@@ -233,6 +239,15 @@ impl RusToKModule for ForumModule {
         .map_err(|error| {
             rustok_core::Error::Validation(format!(
                 "forum topic SEO target registration failed: {error}"
+            ))
+        })?;
+        register_reaction_subject_provider_factory(
+            extensions,
+            reaction_subject::ForumReactionSubjectProviderFactory,
+        )
+        .map_err(|error| {
+            rustok_core::Error::Validation(format!(
+                "forum reaction subject factory registration failed: {error}"
             ))
         })?;
         register_notification_source_provider_factory(

--- a/crates/rustok-forum/src/reaction_subject.rs
+++ b/crates/rustok-forum/src/reaction_subject.rs
@@ -1,0 +1,461 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{HostRuntimeContext, PortActorKind, PortContext, PortError, PortErrorKind};
+use rustok_core::SecurityContext;
+use rustok_reactions_api::{
+    ReactionCatalog, ReactionKey, ReactionProviderError, ReactionProviderResult,
+    ReactionSelectionPolicy, ReactionSourceSlug, ReactionSubjectAccess,
+    ReactionSubjectAuthorization, ReactionSubjectKind, ReactionSubjectProvider,
+    ReactionSubjectProviderFactory, ReactionSubjectRequest,
+};
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder,
+    QuerySelect, Statement,
+};
+use uuid::Uuid;
+
+use crate::audience::SharedForumAudienceFactsPort;
+use crate::entities::{
+    forum_reply, forum_reply_revision, forum_topic, forum_topic_revision,
+};
+use crate::error::ForumError;
+use crate::notification_recipient::{
+    ForumNotificationRecipientContextResolver, SharedForumNotificationRecipientContextPort,
+};
+use crate::services::{ForumTopicAudienceViewer, ForumTopicAudienceVisibilityService};
+use crate::state_machine::{ReplyStatus, TopicStatus};
+
+pub const FORUM_REACTION_SOURCE: &str = "forum";
+pub const FORUM_TOPIC_REACTION_KIND: &str = "topic";
+pub const FORUM_REPLY_REACTION_KIND: &str = "reply";
+pub const FORUM_REACTION_V1_KEY: &str = "like";
+
+#[derive(Clone, Default)]
+pub struct ForumReactionSubjectProviderFactory;
+
+impl ReactionSubjectProviderFactory for ForumReactionSubjectProviderFactory {
+    fn source(&self) -> ReactionSourceSlug {
+        forum_reaction_source()
+    }
+
+    fn build(
+        &self,
+        host: &HostRuntimeContext,
+    ) -> ReactionProviderResult<Arc<dyn ReactionSubjectProvider>> {
+        Ok(Arc::new(ForumReactionSubjectProvider::new(
+            host.db_clone(),
+            host.shared_get::<SharedForumNotificationRecipientContextPort>(),
+            host.shared_get::<SharedForumAudienceFactsPort>(),
+        )))
+    }
+}
+
+#[derive(Clone)]
+struct ForumReactionSubjectProvider {
+    db: DatabaseConnection,
+    recipient_context_port: Option<SharedForumNotificationRecipientContextPort>,
+    facts_port: Option<SharedForumAudienceFactsPort>,
+}
+
+impl ForumReactionSubjectProvider {
+    fn new(
+        db: DatabaseConnection,
+        recipient_context_port: Option<SharedForumNotificationRecipientContextPort>,
+        facts_port: Option<SharedForumAudienceFactsPort>,
+    ) -> Self {
+        Self {
+            db,
+            recipient_context_port,
+            facts_port,
+        }
+    }
+
+    async fn authorize_topic(
+        &self,
+        context: &PortContext,
+        request: &ReactionSubjectRequest,
+        actor_id: Option<Uuid>,
+    ) -> ReactionProviderResult<ReactionSubjectAuthorization> {
+        let subject = &request.subject;
+        let viewer = self
+            .resolve_viewer(context, subject.tenant_id(), actor_id)
+            .await?;
+        if !ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())
+            .is_topic_visible(
+                subject.tenant_id(),
+                subject.subject_id(),
+                context.channel.as_deref(),
+                &viewer,
+            )
+            .await
+            .map_err(map_forum_error)?
+        {
+            return Ok(ReactionSubjectAuthorization::Unavailable);
+        }
+
+        let Some(topic) = self
+            .load_active_topic(subject.tenant_id(), subject.subject_id())
+            .await?
+        else {
+            return Ok(ReactionSubjectAuthorization::Unavailable);
+        };
+        if topic.status != TopicStatus::Open {
+            return Ok(ReactionSubjectAuthorization::Unavailable);
+        }
+
+        let current_revision = self
+            .current_topic_revision(subject.tenant_id(), topic.id)
+            .await?;
+        self.allow_exact_revision(request, current_revision)
+    }
+
+    async fn authorize_reply(
+        &self,
+        context: &PortContext,
+        request: &ReactionSubjectRequest,
+        actor_id: Option<Uuid>,
+    ) -> ReactionProviderResult<ReactionSubjectAuthorization> {
+        let subject = &request.subject;
+        let Some(initial_reply) = self
+            .load_active_reply(subject.tenant_id(), subject.subject_id())
+            .await?
+        else {
+            return Ok(ReactionSubjectAuthorization::Unavailable);
+        };
+        if initial_reply.status != ReplyStatus::Approved {
+            return Ok(ReactionSubjectAuthorization::Unavailable);
+        }
+
+        let viewer = self
+            .resolve_viewer(context, subject.tenant_id(), actor_id)
+            .await?;
+        if !ForumTopicAudienceVisibilityService::new(self.db.clone(), self.facts_port.clone())
+            .is_topic_visible(
+                subject.tenant_id(),
+                initial_reply.topic_id,
+                context.channel.as_deref(),
+                &viewer,
+            )
+            .await
+            .map_err(map_forum_error)?
+        {
+            return Ok(ReactionSubjectAuthorization::Unavailable);
+        }
+
+        let Some(reply) = self
+            .load_active_reply(subject.tenant_id(), subject.subject_id())
+            .await?
+        else {
+            return Ok(ReactionSubjectAuthorization::Unavailable);
+        };
+        if reply.status != ReplyStatus::Approved || reply.topic_id != initial_reply.topic_id {
+            return Ok(ReactionSubjectAuthorization::Unavailable);
+        }
+        let Some(topic) = self
+            .load_active_topic(subject.tenant_id(), reply.topic_id)
+            .await?
+        else {
+            return Ok(ReactionSubjectAuthorization::Unavailable);
+        };
+        if topic.status != TopicStatus::Open {
+            return Ok(ReactionSubjectAuthorization::Unavailable);
+        }
+
+        let current_revision = self
+            .current_reply_revision(subject.tenant_id(), reply.id)
+            .await?;
+        self.allow_exact_revision(request, current_revision)
+    }
+
+    fn allow_exact_revision(
+        &self,
+        request: &ReactionSubjectRequest,
+        current_revision: u64,
+    ) -> ReactionProviderResult<ReactionSubjectAuthorization> {
+        if request.subject.subject_revision() != current_revision {
+            return Err(ReactionProviderError::Conflict);
+        }
+        Ok(ReactionSubjectAuthorization::Allowed {
+            canonical_subject: request.subject.clone(),
+            catalog: forum_reaction_catalog_v1()?,
+        })
+    }
+
+    async fn resolve_viewer(
+        &self,
+        context: &PortContext,
+        tenant_id: Uuid,
+        actor_id: Option<Uuid>,
+    ) -> ReactionProviderResult<ForumTopicAudienceViewer> {
+        let Some(actor_id) = actor_id else {
+            return Ok(ForumTopicAudienceViewer::public());
+        };
+
+        match context.actor.kind {
+            PortActorKind::User => {
+                let context_actor = Uuid::parse_str(&context.actor.id)
+                    .map_err(|_| ReactionProviderError::InvalidRequest)?;
+                if context_actor != actor_id {
+                    return Err(ReactionProviderError::InvalidRequest);
+                }
+                let security = SecurityContext::try_from_port_context(context)
+                    .map_err(map_port_error)?;
+                ForumTopicAudienceViewer::authenticated(security, context.clone())
+                    .map_err(map_forum_error)
+            }
+            PortActorKind::Service | PortActorKind::System => {
+                let recipient = ForumNotificationRecipientContextResolver::new(
+                    self.recipient_context_port.clone(),
+                )
+                .resolve(context.clone(), tenant_id, actor_id)
+                .await
+                .map_err(map_forum_error)?;
+                recipient.into_topic_viewer().map_err(map_forum_error)
+            }
+        }
+    }
+
+    async fn load_active_topic(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+    ) -> ReactionProviderResult<Option<forum_topic::Model>> {
+        let topic = forum_topic::Entity::find()
+            .filter(forum_topic::Column::TenantId.eq(tenant_id))
+            .filter(forum_topic::Column::Id.eq(topic_id))
+            .one(&self.db)
+            .await
+            .map_err(database_error)?;
+        let Some(topic) = topic else {
+            return Ok(None);
+        };
+        if !self
+            .row_is_active("forum_topics", tenant_id, topic_id)
+            .await?
+        {
+            return Ok(None);
+        }
+        Ok(Some(topic))
+    }
+
+    async fn load_active_reply(
+        &self,
+        tenant_id: Uuid,
+        reply_id: Uuid,
+    ) -> ReactionProviderResult<Option<forum_reply::Model>> {
+        let reply = forum_reply::Entity::find()
+            .filter(forum_reply::Column::TenantId.eq(tenant_id))
+            .filter(forum_reply::Column::Id.eq(reply_id))
+            .one(&self.db)
+            .await
+            .map_err(database_error)?;
+        let Some(reply) = reply else {
+            return Ok(None);
+        };
+        if !self
+            .row_is_active("forum_replies", tenant_id, reply_id)
+            .await?
+        {
+            return Ok(None);
+        }
+        Ok(Some(reply))
+    }
+
+    async fn row_is_active(
+        &self,
+        table: &'static str,
+        tenant_id: Uuid,
+        id: Uuid,
+    ) -> ReactionProviderResult<bool> {
+        self.db
+            .query_one(Statement::from_string(
+                self.db.get_database_backend(),
+                format!(
+                    "SELECT 1 AS active FROM {table} WHERE tenant_id = '{tenant_id}' AND id = '{id}' AND deleted_at IS NULL"
+                ),
+            ))
+            .await
+            .map(|row| row.is_some())
+            .map_err(database_error)
+    }
+
+    async fn current_topic_revision(
+        &self,
+        tenant_id: Uuid,
+        topic_id: Uuid,
+    ) -> ReactionProviderResult<u64> {
+        let latest = forum_topic_revision::Entity::find()
+            .select_only()
+            .column(forum_topic_revision::Column::Id)
+            .filter(forum_topic_revision::Column::TenantId.eq(tenant_id))
+            .filter(forum_topic_revision::Column::TopicId.eq(topic_id))
+            .order_by_desc(forum_topic_revision::Column::Id)
+            .into_tuple::<i64>()
+            .one(&self.db)
+            .await
+            .map_err(database_error)?;
+        current_revision_after(latest)
+    }
+
+    async fn current_reply_revision(
+        &self,
+        tenant_id: Uuid,
+        reply_id: Uuid,
+    ) -> ReactionProviderResult<u64> {
+        let latest = forum_reply_revision::Entity::find()
+            .select_only()
+            .column(forum_reply_revision::Column::Id)
+            .filter(forum_reply_revision::Column::TenantId.eq(tenant_id))
+            .filter(forum_reply_revision::Column::ReplyId.eq(reply_id))
+            .order_by_desc(forum_reply_revision::Column::Id)
+            .into_tuple::<i64>()
+            .one(&self.db)
+            .await
+            .map_err(database_error)?;
+        current_revision_after(latest)
+    }
+}
+
+#[async_trait]
+impl ReactionSubjectProvider for ForumReactionSubjectProvider {
+    fn source(&self) -> ReactionSourceSlug {
+        forum_reaction_source()
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Forum"
+    }
+
+    fn supported_kinds(&self) -> Vec<ReactionSubjectKind> {
+        vec![forum_topic_reaction_kind(), forum_reply_reaction_kind()]
+    }
+
+    async fn authorize(
+        &self,
+        context: PortContext,
+        request: ReactionSubjectRequest,
+    ) -> ReactionProviderResult<ReactionSubjectAuthorization> {
+        request
+            .validate()
+            .map_err(|_| ReactionProviderError::InvalidRequest)?;
+        let tenant_id = Uuid::parse_str(&context.tenant_id)
+            .map_err(|_| ReactionProviderError::InvalidRequest)?;
+        if tenant_id != request.subject.tenant_id()
+            || request.subject.source().as_str() != FORUM_REACTION_SOURCE
+        {
+            return Err(ReactionProviderError::InvalidRequest);
+        }
+
+        let actor_id = actor_id_for_access(&request.access);
+        match request.subject.kind().as_str() {
+            FORUM_TOPIC_REACTION_KIND => {
+                self.authorize_topic(&context, &request, actor_id).await
+            }
+            FORUM_REPLY_REACTION_KIND => {
+                self.authorize_reply(&context, &request, actor_id).await
+            }
+            _ => Err(ReactionProviderError::InvalidRequest),
+        }
+    }
+}
+
+fn actor_id_for_access(access: &ReactionSubjectAccess) -> Option<Uuid> {
+    match access {
+        ReactionSubjectAccess::Read { actor_id } => *actor_id,
+        ReactionSubjectAccess::Apply { command } => Some(command.identity().actor_id()),
+    }
+}
+
+fn current_revision_after(latest: Option<i64>) -> ReactionProviderResult<u64> {
+    match latest {
+        None => Ok(1),
+        Some(latest) => u64::try_from(latest)
+            .ok()
+            .and_then(|revision| revision.checked_add(1))
+            .filter(|revision| *revision > 0)
+            .ok_or(ReactionProviderError::Internal { retryable: false }),
+    }
+}
+
+fn forum_reaction_catalog_v1() -> ReactionProviderResult<ReactionCatalog> {
+    ReactionCatalog::try_new(
+        ReactionSelectionPolicy::Single,
+        vec![ReactionKey::new(FORUM_REACTION_V1_KEY)
+            .map_err(|_| ReactionProviderError::Internal { retryable: false })?],
+    )
+    .map_err(|_| ReactionProviderError::Internal { retryable: false })
+}
+
+fn forum_reaction_source() -> ReactionSourceSlug {
+    ReactionSourceSlug::new(FORUM_REACTION_SOURCE)
+        .expect("Forum reaction source constant must remain valid")
+}
+
+fn forum_topic_reaction_kind() -> ReactionSubjectKind {
+    ReactionSubjectKind::new(FORUM_TOPIC_REACTION_KIND)
+        .expect("Forum topic reaction kind constant must remain valid")
+}
+
+fn forum_reply_reaction_kind() -> ReactionSubjectKind {
+    ReactionSubjectKind::new(FORUM_REPLY_REACTION_KIND)
+        .expect("Forum reply reaction kind constant must remain valid")
+}
+
+fn database_error(_error: sea_orm::DbErr) -> ReactionProviderError {
+    ReactionProviderError::Internal { retryable: true }
+}
+
+fn map_port_error(error: PortError) -> ReactionProviderError {
+    match error.kind {
+        PortErrorKind::Validation => ReactionProviderError::InvalidRequest,
+        PortErrorKind::Forbidden | PortErrorKind::NotFound => ReactionProviderError::Unavailable,
+        PortErrorKind::Conflict => ReactionProviderError::Conflict,
+        PortErrorKind::Timeout | PortErrorKind::Unavailable => {
+            ReactionProviderError::CapabilityUnavailable { retryable: true }
+        }
+        PortErrorKind::InvariantViolation => {
+            ReactionProviderError::Internal { retryable: false }
+        }
+    }
+}
+
+fn map_forum_error(error: ForumError) -> ReactionProviderError {
+    match error {
+        ForumError::CapabilityUnavailable { .. } => {
+            ReactionProviderError::CapabilityUnavailable { retryable: false }
+        }
+        ForumError::CapabilityFailure { retryable, .. } => {
+            ReactionProviderError::CapabilityUnavailable { retryable }
+        }
+        ForumError::Validation(_) => ReactionProviderError::InvalidRequest,
+        ForumError::RelationRevisionConflict => ReactionProviderError::Conflict,
+        ForumError::Database(_) | ForumError::Internal(_) => {
+            ReactionProviderError::Internal { retryable: true }
+        }
+        ForumError::Content(_) => ReactionProviderError::Internal { retryable: false },
+        _ => ReactionProviderError::Unavailable,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rustok_reactions_api::ReactionSelectionPolicy;
+
+    use super::*;
+
+    #[test]
+    fn forum_catalog_is_single_like_without_vote_reinterpretation() {
+        let catalog = forum_reaction_catalog_v1().expect("fixed catalog should be valid");
+        assert_eq!(catalog.selection(), ReactionSelectionPolicy::Single);
+        assert_eq!(catalog.keys().len(), 1);
+        assert_eq!(catalog.keys()[0].as_str(), FORUM_REACTION_V1_KEY);
+    }
+
+    #[test]
+    fn current_revision_is_positive_and_advances_after_captured_history() {
+        assert_eq!(current_revision_after(None).expect("initial revision"), 1);
+        assert_eq!(current_revision_after(Some(41)).expect("advanced revision"), 42);
+        assert!(current_revision_after(Some(-1)).is_err());
+    }
+}

--- a/crates/rustok-reactions/docs/implementation-plan.md
+++ b/crates/rustok-reactions/docs/implementation-plan.md
@@ -17,7 +17,7 @@ last_reviewed: 2026-08-06
 | `REACTIONS-00` | `in_progress` | Neutral API, optional module registration and provider registry are source-ready; maintainer Cargo/Node verification remains. |
 | `REACTIONS-01` | `in_progress` | Tenant-composite owner schema, immutable catalog snapshots, actor uniqueness and shared Outbox command receipts are source-ready. Regenerate `Cargo.lock` and retain SQLite/PostgreSQL execution evidence. |
 | `REACTIONS-02` | `in_progress` | Actor state and aggregate deltas commit atomically behind one subject serialization row. Add semantic events, repair/reconciliation and retained concurrency evidence. |
-| `REACTIONS-03` | `planned` | Forum topic/reply subject provider and explicit disabled/unavailable profile. |
+| `REACTIONS-03` | `in_progress` | Forum topic/reply provider factory, exact current-revision/visibility authorization and the Reactions-disabled Forum profile are source-ready. Add optional distribution/host materialization and retain enabled/disabled runtime evidence. |
 | `REACTIONS-04` | `planned` | Second real producer adapter and neutral-contract review. |
 | `REACTIONS-05` | `planned` | Bounded read/write transports and module-owned UI. |
 | `REACTIONS-06` | `planned` | Runtime evidence, FBA contracts, import/reconciliation and release profiles. |
@@ -47,12 +47,31 @@ of command correctness.
 The initial catalog revision is the producer subject revision. Independent
 catalog revisioning is a later explicit API/migration change.
 
+## Forum producer boundary
+
+Forum registers a neutral `ReactionSubjectProviderFactory` for `topic` and
+`reply` without depending on the Reactions owner. The provider:
+
+- validates exact tenant/source/kind identity;
+- hides missing, deleted, lifecycle-denied and audience-denied subjects behind
+  one unavailable result;
+- checks existing Forum rich-audience visibility before returning revision
+  conflicts;
+- uses `latest captured Forum revision id + 1` as the current subject revision;
+- allows only approved replies whose parent topic is currently open and visible;
+- publishes one bounded single-selection `like` catalog for the initial contract;
+- resolves delegated actors through the existing exact recipient-context port;
+- does not read or reinterpret existing Forum vote state.
+
+Forum remains fully usable when Reactions is absent. The neutral factory may be
+registered without materializing a Reactions owner runtime.
+
 ## Immediate next action
 
-Add the Forum `topic` and `reply` `ReactionSubjectProvider` in a separate PR.
-It must resolve current owner revision, visibility and catalog policy through
-Forum-owned services, expose no private denial reason, preserve existing Forum
-vote behavior and support an explicit Reactions-disabled profile.
+Add optional `mod-reactions` selection to `rustok-distribution` and the server,
+materialize source factories after host facts providers exist, keep Reactions
+outside default profiles, and retain both enabled and disabled Forum composition
+evidence.
 
 Before release, regenerate `Cargo.lock`, execute SQLite and PostgreSQL migrations,
 retain replay/concurrency/rollback evidence, add semantic reaction events and
@@ -63,10 +82,13 @@ provide reconciliation for catalog and aggregate drift.
 ```bash
 cargo test -p rustok-reactions-api
 cargo test -p rustok-reactions
+cargo test -p rustok-forum reaction_subject
 cargo check -p rustok-reactions-api --all-targets
 cargo check -p rustok-reactions --all-targets
+cargo check -p rustok-forum --all-targets
 node scripts/verify/verify-reactions-foundation.mjs
 node scripts/verify/verify-reactions-owner-persistence.mjs
+node scripts/verify/verify-forum-reaction-subject-provider.mjs
 git diff --check
 ```
 

--- a/scripts/verify/verify-forum-reaction-subject-provider.mjs
+++ b/scripts/verify/verify-forum-reaction-subject-provider.mjs
@@ -1,0 +1,104 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath = path.join(
+  repoRoot,
+  "crates/rustok-forum/contracts/forum-reaction-subject-provider.json",
+);
+const contract = JSON.parse(readFileSync(contractPath, "utf8"));
+
+function fail(message) {
+  throw new Error(`Forum reaction subject provider verification failed: ${message}`);
+}
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!existsSync(absolute)) fail(`missing required file ${relativePath}`);
+  return readFileSync(absolute, "utf8");
+}
+
+if (contract.schema_version !== 1) fail("unsupported contract schema version");
+if (contract.module !== "forum") fail("contract module must be forum");
+if (contract.contract !== "forum_reaction_subject_provider_v1") {
+  fail("unexpected contract identity");
+}
+if (contract.source !== "forum") fail("provider source must be forum");
+if (JSON.stringify(contract.supported_kinds) !== JSON.stringify(["topic", "reply"])) {
+  fail("provider kinds must remain topic and reply");
+}
+if (contract.catalog.selection !== "single") fail("v1 catalog must remain single-select");
+if (JSON.stringify(contract.catalog.keys) !== JSON.stringify(["like"])) {
+  fail("v1 catalog must contain only like");
+}
+
+for (const relativePath of contract.required_files) read(relativePath);
+
+const provider = read("crates/rustok-forum/src/reaction_subject.rs");
+const forumLib = read("crates/rustok-forum/src/lib.rs");
+const forumCargo = read("crates/rustok-forum/Cargo.toml");
+const modules = read("modules.toml");
+const forumPlan = read("crates/rustok-forum/docs/implementation-plan.md");
+const reactionsPlan = read("crates/rustok-reactions/docs/implementation-plan.md");
+
+for (const fragment of contract.required_source_fragments) {
+  if (!provider.includes(fragment)) fail(`provider is missing ${fragment}`);
+}
+for (const fragment of contract.forbidden_source_fragments) {
+  if (provider.includes(fragment)) fail(`provider contains forbidden fragment ${fragment}`);
+}
+
+for (const fragment of [
+  "rustok-reactions-api.workspace = true",
+  "rustok-notifications-api.workspace = true",
+]) {
+  if (!forumCargo.includes(fragment)) fail(`Forum Cargo boundary is missing ${fragment}`);
+}
+if (/^rustok-reactions\s*=/mu.test(forumCargo)) {
+  fail("Forum must depend only on rustok-reactions-api, not the Reactions owner");
+}
+
+for (const fragment of [
+  "mod reaction_subject;",
+  "register_reaction_subject_provider_factory",
+  "ForumReactionSubjectProviderFactory",
+  '&["content", "taxonomy"]',
+]) {
+  if (!forumLib.includes(fragment)) fail(`Forum module registration is missing ${fragment}`);
+}
+
+const defaultEnabled = modules.match(/default_enabled\s*=\s*\[[\s\S]*?\]/mu)?.[0] ?? "";
+if (/"reactions"/u.test(defaultEnabled)) {
+  fail("Reactions must remain outside default_enabled in the provider-only slice");
+}
+
+for (const fragment of [
+  "topic`/`reply` provider factory",
+  "latest captured Forum revision id + 1",
+  "Executable distribution selection and",
+  "node scripts/verify/verify-forum-reaction-subject-provider.mjs",
+]) {
+  if (!forumPlan.includes(fragment)) fail(`Forum plan is missing ${fragment}`);
+}
+for (const fragment of [
+  "| `REACTIONS-03` | `in_progress` |",
+  "Forum producer boundary",
+  "outside default profiles",
+]) {
+  if (!reactionsPlan.includes(fragment)) fail(`Reactions plan is missing ${fragment}`);
+}
+
+for (const fragment of [
+  "forum_topic::Entity::find()",
+  "forum_reply::Entity::find()",
+  "forum_topic_revision::Entity::find()",
+  "forum_reply_revision::Entity::find()",
+  "ReplyStatus::Approved",
+  "TopicStatus::Open",
+  "context.channel.as_deref()",
+]) {
+  if (!provider.includes(fragment)) fail(`provider owner authorization is missing ${fragment}`);
+}
+
+console.log("Forum reaction subject provider source contract verified.");


### PR DESCRIPTION
## Summary

Add the first Forum producer adapter for the shared Reactions owner without coupling Forum to Reactions persistence or changing existing Forum votes.

- add a neutral `ForumReactionSubjectProviderFactory` registered through `rustok-reactions-api`;
- support exact `forum/topic` and `forum/reply` subject identities;
- require tenant/source/kind equality and active soft-delete state;
- reuse `ForumTopicAudienceVisibilityService` for category, channel and richer audience policy;
- allow only currently open topics and approved replies whose parent topic is open and visible;
- resolve public and direct-user viewers through existing Forum security contracts;
- resolve delegated service/system actors through the existing exact recipient-context port;
- hide missing, deleted, lifecycle-denied and audience-denied targets behind one `Unavailable` result;
- return revision conflict only after the subject is currently visible;
- derive the current owner revision as `latest captured Forum revision id + 1`;
- publish one bounded single-selection `like` catalog for the initial producer contract;
- add a machine-readable contract, fail-closed verifier and canonical plan updates.

## Ownership and compatibility

Forum owns subject existence, revision, visibility, lifecycle and reaction policy. `rustok-reactions` continues to own actor state, command receipts and aggregate counts.

Forum depends only on `rustok-reactions-api`. It does not add `rustok-reactions` to Forum module dependencies, does not read Reactions tables and remains fully usable when Reactions is absent.

Existing Forum votes are not read, migrated, reinterpreted or replaced.

## Deliberate limits

This PR does not add:

- executable distribution/server `mod-reactions` selection;
- host materialization of the reaction provider registry;
- Reactions default enablement;
- GraphQL, REST or native transport;
- admin/storefront UI;
- semantic reaction events or reconciliation;
- a second producer adapter;
- reputation or achievements.

## Main recheck

The branch is based directly on `main@3d7d2d44ce760abead04af0fb9b7d434d692b9e7`, one commit ahead and zero behind at PR creation. The intervening main change was Pages-only and did not overlap this slice.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Cargo check, formatting or Clippy;
- Node verifiers;
- SQLite/PostgreSQL scenarios;
- workflows or CI.

`Cargo.lock` was not regenerated. Adding `rustok-reactions-api` to the existing `rustok-forum` package dependency list requires the maintainer Cargo run to retain the minimal lockfile package-entry delta before using `--locked`.

Suggested maintainer commands:

```bash
cargo test -p rustok-forum reaction_subject
cargo check -p rustok-forum --all-targets
node scripts/verify/verify-forum-reaction-subject-provider.mjs
node scripts/verify/verify-forum-shared-capability-ownership.mjs
node scripts/verify/verify-reactions-foundation.mjs
node scripts/verify/verify-reactions-owner-persistence.mjs
git diff --check
```

Source status remains `source_ready_maintainer_execution_pending`.