### PR TITLE
feat(index): add exact source refresh event worker

### DIFF
--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -29,6 +29,7 @@ This directory contains the detailed technical architecture documentation for `r
 - [Source Module Integration Contract](./module-source-integration.md)
 - [Live Implementation Plan](./implementation-plan.md)
 - [M5 Mutation Event Commit/Ack Contract](./m5-mutation-event-ack-contract.md)
+- [M5 Exact Source Refresh Event Worker](./m5-source-refresh-event.md)
 - [M5 Social Graph Production Mutation Route](./m5-social-graph-mutation-route.md)
 - [M5/M6 Source Replay Contract](./m5-m6-source-replay-contract.md)
 - [M6 Explicit Source Absence Watermark](./m6-explicit-source-absence-watermark.md)

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-03.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-03.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-03
 
-Status overlay rechecked against `main@e0451f978e8f533a5949710509ea8327e4a140c0` and active
-branch `agent/index-m5-social-graph-event-route-20260806`.
+Status overlay rechecked against current `main` after Social Graph route merge #3102 and active
+branch `agent/index-m5-product-source-refresh-contract-20260806`.
 
 When this dated overlay conflicts with the older canonical plan, this file is the current source of
 truth. Historical architecture and milestone context remain in `implementation-plan.md`.
@@ -31,10 +31,16 @@ commands, current source hashes, required case names, bounded database/toolchain
 credential-redacted stdout/stderr, and an atomic terminal pass packet. The packet and logs remain
 absent until the repository owner executes the capture runner.
 
-An independent M5 slice now registers Social Graph as the first exact production mutation route. It
-adds one bounded authoritative replay source over `social_graph_relations`, reuses the existing Iggy
+An independent M5 slice registers Social Graph as the first exact production mutation route. It adds
+one bounded authoritative replay source over `social_graph_relations`, reuses the existing Iggy
 consumer source identity, and atomically materializes the immutable mutation event registry with the
 staged source catalog. This does not advance or bypass the concrete-repair evidence cursor.
+
+A second independent M5 slice adds exact source-refresh orchestration for thin owner change events.
+One event identifies an exact `EntityKey`, owner event UUID, and positive minimum source version. The
+worker resolves the immutable route and source, performs one bounded exact load, requires an upsert
+or tombstone at or beyond the event fence, rebinds the canonical mutation to the broker event UUID,
+durably applies it, and only then acknowledges. Product wire events and runtime wiring remain open.
 
 Concrete missing-entity repair:
 
@@ -75,6 +81,8 @@ remain open.
 - M5 inbox deduplication and monotonic source versions: `complete`
 - M5 mutation event registry and commit-before-ack orchestration:
   `generic_source_complete_social_graph_route_runtime_execution_pending`
+- M5 exact source-refresh event worker:
+  `source_complete_owner_event_publication_and_runtime_wiring_pending`
 - M5 Social Graph bounded replay source and exact production event route:
   `source_complete_runtime_execution_pending`
 - M5/M6 bounded source replay contract: `source_complete_owner_execution_pending`
@@ -117,11 +125,15 @@ remain open.
 - [x] Add a source replay registry with bounded failure classification.
 - [x] Add inbox deduplication and monotonic source versions.
 - [x] Add a database-neutral mutation-source event registry and commit-before-ack orchestration.
+- [x] Add exact one-key source-refresh orchestration with minimum owner revision fencing.
 - [x] Register the Social Graph production event route and bounded replay source.
 - [x] Reuse the concrete Social Graph Iggy consumer/acknowledger, bounded retry/backoff, DLQ and
       poison receipts, graceful shutdown, and lag/outcome metrics.
 - [x] Materialize selected PostgreSQL sources and mutation event routes atomically.
-- [ ] Register remaining selected production owner routes, beginning with Product/ProductVariant.
+- [ ] Define reviewed Product locale and ProductVariant refresh event families with exact owner
+      revision and release-digest updates.
+- [ ] Publish Product/ProductVariant refresh events transactionally from every owner change path.
+- [ ] Register remaining selected production owner routes and concrete consumers.
 - [ ] Add equivalent concrete consumer policy for every remaining selected owner route.
 - [ ] Retain crash-between-commit-and-ack and redelivery evidence against the generic registered
       route boundary.
@@ -199,8 +211,9 @@ remain open.
 - [x] Add Product, ProductVariant, and SalesChannel schemas and bounded current-state sources.
 - [x] Add stable replay identities and retained deletes.
 - [x] Add Product-to-ProductVariant graph materialization.
-- [ ] Add Product/ProductVariant production owner event routes and concrete incremental consumer
-      wiring.
+- [x] Add the generic exact-source refresh worker required by Product/ProductVariant notifications.
+- [ ] Add Product/ProductVariant owner event contracts, transactional publication, production routes,
+      and concrete incremental consumer wiring.
 - [ ] Persist and enforce per-tenant schema readiness.
 - [ ] Complete durable Product-to-SalesChannel relation semantics and retained evidence.
 - [ ] Admit tombstone purge, freshness/outage/restart/backlog recovery, and delete/recreate evidence.
@@ -224,13 +237,16 @@ The owner must run the locked capture command from a clean commit. The retained 
 - normal full-mutation versus exact edge-owner serialization results;
 - complete credential-redacted stdout/stderr and final pass status.
 
-Independent source-only work may continue on remaining M5/M7 owner routes, but public repair
-authorization transport, automatic iteration, time-derived leases, and lifecycle auto-resolution
-remain blocked until admission.
+Independent source-only work may continue on Product event publication and remaining M5/M7 owner
+routes, but public repair authorization transport, automatic iteration, time-derived leases, and
+lifecycle auto-resolution remain blocked until admission.
 
 ## Owner verification for current source boundaries
 
 ```bash
+cargo test -p rustok-index source_refresh_event --lib -- --nocapture
+node scripts/verify/verify-index-source-refresh-event.mjs
+
 cargo test -p rustok-social-graph --features index-consumer index_source -- --nocapture
 cargo test -p rustok-index source_factory -- --nocapture
 node scripts/verify/verify-index-social-graph-mutation-route.mjs

--- a/crates/rustok-index/docs/m5-source-refresh-event.md
+++ b/crates/rustok-index/docs/m5-source-refresh-event.md
@@ -1,0 +1,106 @@
+# M5 exact source refresh event worker
+
+Status: `source_complete_owner_event_publication_and_runtime_wiring_pending`.
+
+## Purpose
+
+Some owner events should not copy a complete Index record into the transport payload. Product and
+ProductVariant are the motivating examples: their canonical records include localized state,
+relations, retained tombstones, and monotonic owner revisions that already belong to registered
+`IndexSource` adapters.
+
+`IndexSourceRefreshEventWorker` provides a generic bridge from one thin owner change notification to
+one exact authoritative source load. It is independent of Product, any broker SDK, PostgreSQL, and
+server lifecycle code.
+
+## Delivery contract
+
+`IndexSourceRefreshEventDelivery<T>` carries only:
+
+- one registered event domain;
+- one non-nil owner event UUID;
+- one exact `EntityKey` containing tenant, schema, entity, and optional locale;
+- one positive minimum owner source version;
+- one opaque broker acknowledgement token.
+
+The event UUID becomes the durable Index inbox identity. The token remains opaque to Index and is
+used only after durable mutation completion.
+
+The event payload must not contain a copied Index record. The registered owner source remains the
+canonical authority for fields, links, deletion state, and source version.
+
+## Processing order
+
+The worker performs these steps in order:
+
+1. resolve the exact immutable mutation-event route;
+2. require the delivery schema to equal the route schema;
+3. resolve the immutable source for that schema;
+4. require the resolved source name to equal the route source name;
+5. perform one bounded `IndexSourceLoadRequest` for exactly one key;
+6. require exactly one returned upsert or tombstone mutation;
+7. require the loaded source version to be at least the event's minimum owner version;
+8. replace the replay-only mutation UUID with the broker event UUID;
+9. durably apply the mutation through `IndexReplayMutationSink`;
+10. acknowledge the broker token.
+
+A later consumer may observe a source revision newer than the event minimum. That is valid and
+convergent. A missing result or a revision below the event fence is not terminal and suppresses both
+mutation apply and acknowledgement.
+
+Applied, duplicate, and stale mutation outcomes are terminal only after the mutation sink has
+returned successfully. An acknowledgement failure after durable apply is returned to the transport
+owner; redelivery remains safe through the event UUID inbox identity and monotonic source version.
+
+## Fail-closed boundaries
+
+The worker rejects or leaves unacknowledged:
+
+- unknown event domains;
+- schema or source-route mismatches;
+- missing replay sources;
+- source contract/storage failures;
+- empty exact loads;
+- ambiguous exact loads;
+- source revisions behind the owner event fence;
+- mutation persistence failures.
+
+It performs no SQL, starts no task, selects no broker, owns no retry loop, logs no acknowledgement
+token, and exposes no public transport.
+
+## Product follow-up
+
+This slice intentionally does not add Product wire events or publish Product routes. The next owner
+slice must define reviewed Product locale and ProductVariant refresh event families, update the
+committed `rustok-events` release digests, publish exact owner revisions transactionally, and compose
+a concrete consumer/acknowledger around this worker.
+
+Legacy `ProductCreated`, `ProductUpdated`, `ProductDeleted`, `VariantCreated`, `VariantUpdated`, and
+`VariantDeleted` root events are not sufficient because they do not carry the canonical
+`index_revision` fence or exact locale/tombstone identity.
+
+## Deliberate limits
+
+This slice does not:
+
+- add batch refresh events;
+- register Product or ProductVariant production routes;
+- modify the shared event wire schema or release digest artifact;
+- start or configure an Iggy consumer;
+- change retry, DLQ, lag, or poison handling;
+- retain PostgreSQL or broker execution evidence;
+- alter the separate concrete-repair evidence gate.
+
+The primary implementation cursor remains `M6 - execute and admit concrete repair evidence`.
+
+## Maintainer validation
+
+```bash
+cargo test -p rustok-index source_refresh_event --lib -- --nocapture
+node scripts/verify/verify-index-source-refresh-event.mjs
+cargo check -p rustok-index --all-targets
+git diff --check
+```
+
+No tests, Node verifiers, Cargo checks, formatting, database scenarios, workflows, or CI were run by
+the implementation agent.

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -17,6 +17,7 @@ mod registry;
 mod source_absence;
 mod source_continuation;
 mod source_event_id;
+mod source_refresh_event;
 mod source_registry;
 mod source_replay;
 mod source_schema_registry;
@@ -39,6 +40,8 @@ mod postgres_query_result_tests;
 mod query_snapshot_tests;
 #[cfg(test)]
 mod reference;
+#[cfg(test)]
+mod source_refresh_event_tests;
 #[cfg(test)]
 mod source_replay_tests;
 
@@ -136,6 +139,11 @@ pub use source_continuation::{
     IndexSourceContinuationToken,
 };
 pub use source_event_id::{IndexSourceEventIdError, derive_index_source_event_id};
+pub use source_refresh_event::{
+    IndexSourceRefreshEventDelivery, IndexSourceRefreshEventError,
+    IndexSourceRefreshEventProcessError, IndexSourceRefreshEventProcessOutcome,
+    IndexSourceRefreshEventWorker,
+};
 pub use source_registry::{
     IndexSource, IndexSourceCatalog, IndexSourceCursor, IndexSourceDescriptor, IndexSourceError,
     IndexSourceFailure, IndexSourceFailureKind, IndexSourceLoadBatch, IndexSourceLoadRequest,

--- a/crates/rustok-index/src/application/source_refresh_event.rs
+++ b/crates/rustok-index/src/application/source_refresh_event.rs
@@ -1,0 +1,313 @@
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::{EntityKey, IndexMutation, SchemaRef, SchemaRegistry};
+
+use super::{
+    IndexMutationAcknowledgeFailure, IndexMutationEventAcknowledger, IndexReplayFailure,
+    IndexReplayMutationOutcome, IndexReplayMutationSink, IndexSourceError,
+    IndexSourceLoadRequest, SharedIndexMutationEventRegistry, SharedIndexSourceRegistry,
+};
+
+const MAX_EVENT_DOMAIN_BYTES: usize = 128;
+
+/// One broker delivery that requests an exact authoritative source refresh.
+///
+/// The event carries no copied owner payload. The registered source remains authoritative for the
+/// current upsert or tombstone mutation. `minimum_source_version` fences replica lag or an owner
+/// publication bug: acknowledgement is withheld until the source exposes at least the revision
+/// committed by the owner event.
+pub struct IndexSourceRefreshEventDelivery<T> {
+    event_domain: String,
+    event_id: Uuid,
+    key: EntityKey,
+    minimum_source_version: u64,
+    acknowledgement_token: T,
+}
+
+impl<T> IndexSourceRefreshEventDelivery<T> {
+    pub fn new(
+        event_domain: impl Into<String>,
+        event_id: Uuid,
+        key: EntityKey,
+        minimum_source_version: u64,
+        acknowledgement_token: T,
+    ) -> Result<Self, IndexSourceRefreshEventError> {
+        let event_domain = event_domain.into();
+        if !valid_machine_name(&event_domain, MAX_EVENT_DOMAIN_BYTES) {
+            return Err(IndexSourceRefreshEventError::InvalidEventDomain(
+                event_domain,
+            ));
+        }
+        if event_id.is_nil() {
+            return Err(IndexSourceRefreshEventError::NilEventId);
+        }
+        if key.tenant_id.is_nil() {
+            return Err(IndexSourceRefreshEventError::NilTenantId);
+        }
+        if key.entity_id.is_nil() {
+            return Err(IndexSourceRefreshEventError::NilEntityId);
+        }
+        if minimum_source_version == 0 {
+            return Err(IndexSourceRefreshEventError::ZeroMinimumSourceVersion);
+        }
+        Ok(Self {
+            event_domain,
+            event_id,
+            key,
+            minimum_source_version,
+            acknowledgement_token,
+        })
+    }
+
+    pub fn event_domain(&self) -> &str {
+        &self.event_domain
+    }
+
+    pub fn event_id(&self) -> Uuid {
+        self.event_id
+    }
+
+    pub fn key(&self) -> &EntityKey {
+        &self.key
+    }
+
+    pub fn minimum_source_version(&self) -> u64 {
+        self.minimum_source_version
+    }
+
+    pub fn acknowledgement_token(&self) -> &T {
+        &self.acknowledgement_token
+    }
+
+    pub fn into_parts(self) -> (String, Uuid, EntityKey, u64, T) {
+        (
+            self.event_domain,
+            self.event_id,
+            self.key,
+            self.minimum_source_version,
+            self.acknowledgement_token,
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexSourceRefreshEventProcessOutcome {
+    event_id: Uuid,
+    source_name: String,
+    source_version: u64,
+    mutation_outcome: IndexReplayMutationOutcome,
+}
+
+impl IndexSourceRefreshEventProcessOutcome {
+    pub fn event_id(&self) -> Uuid {
+        self.event_id
+    }
+
+    pub fn source_name(&self) -> &str {
+        &self.source_name
+    }
+
+    pub fn source_version(&self) -> u64 {
+        self.source_version
+    }
+
+    pub fn mutation_outcome(&self) -> IndexReplayMutationOutcome {
+        self.mutation_outcome
+    }
+}
+
+/// Source-driven commit-before-ack orchestration for owner change notifications.
+///
+/// The exact event route chooses one schema/source, the delivery chooses one entity key and minimum
+/// owner revision, and the immutable source registry supplies the canonical mutation. The broker
+/// event UUID replaces the replay-only mutation UUID so redelivery is deduplicated by the durable
+/// inbox. A newer source revision is accepted; an older or missing source result is not.
+pub struct IndexSourceRefreshEventWorker<M, A> {
+    mutation_sink: M,
+    acknowledger: A,
+}
+
+impl<M, A> IndexSourceRefreshEventWorker<M, A>
+where
+    M: IndexReplayMutationSink,
+    A: IndexMutationEventAcknowledger,
+{
+    pub fn new(mutation_sink: M, acknowledger: A) -> Self {
+        Self {
+            mutation_sink,
+            acknowledger,
+        }
+    }
+
+    pub async fn process(
+        &self,
+        schema_registry: &SchemaRegistry,
+        source_registry: &SharedIndexSourceRegistry,
+        event_registry: &SharedIndexMutationEventRegistry,
+        delivery: IndexSourceRefreshEventDelivery<A::Token>,
+    ) -> Result<IndexSourceRefreshEventProcessOutcome, IndexSourceRefreshEventProcessError> {
+        let (event_domain, event_id, key, minimum_source_version, acknowledgement_token) =
+            delivery.into_parts();
+        let descriptor = event_registry.get(&event_domain).ok_or_else(|| {
+            IndexSourceRefreshEventProcessError::UnknownEventDomain(event_domain.clone())
+        })?;
+        let expected_schema = descriptor.schema().clone();
+        let expected_source_name = descriptor.source_name().to_owned();
+        if key.schema != expected_schema {
+            return Err(IndexSourceRefreshEventProcessError::EventSchemaMismatch {
+                event_domain,
+                expected: expected_schema,
+                actual: key.schema.clone(),
+            });
+        }
+
+        let source = source_registry
+            .source_for_schema(&key.schema)
+            .ok_or_else(|| IndexSourceRefreshEventProcessError::MissingReplaySource {
+                schema: key.schema.clone(),
+            })?;
+        if source.source_name() != expected_source_name {
+            return Err(IndexSourceRefreshEventProcessError::ReplaySourceMismatch {
+                event_domain,
+                expected: expected_source_name,
+                actual: source.source_name().to_owned(),
+            });
+        }
+
+        let request = IndexSourceLoadRequest::new(vec![key.clone()])
+            .map_err(IndexSourceRefreshEventProcessError::Source)?;
+        let mut mutations = source_registry
+            .load(request)
+            .await
+            .map_err(IndexSourceRefreshEventProcessError::Source)?
+            .into_mutations();
+        let mutation = match mutations.len() {
+            0 => {
+                return Err(IndexSourceRefreshEventProcessError::MissingSourceMutation {
+                    event_domain,
+                    key,
+                });
+            }
+            1 => mutations.pop().expect("single source mutation"),
+            actual => {
+                return Err(IndexSourceRefreshEventProcessError::AmbiguousSourceMutation {
+                    event_domain,
+                    actual,
+                });
+            }
+        };
+        let source_version = mutation.source_version();
+        if source_version < minimum_source_version {
+            return Err(IndexSourceRefreshEventProcessError::SourceVersionBehind {
+                event_domain,
+                minimum: minimum_source_version,
+                actual: source_version,
+            });
+        }
+
+        let mutation = rebind_event_id(mutation, event_id);
+        let mutation_outcome = self
+            .mutation_sink
+            .apply_replay_mutation(schema_registry, &expected_source_name, &mutation)
+            .await
+            .map_err(IndexSourceRefreshEventProcessError::Mutation)?;
+
+        self.acknowledger
+            .acknowledge(&acknowledgement_token)
+            .await
+            .map_err(IndexSourceRefreshEventProcessError::Acknowledge)?;
+
+        Ok(IndexSourceRefreshEventProcessOutcome {
+            event_id,
+            source_name: expected_source_name,
+            source_version,
+            mutation_outcome,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum IndexSourceRefreshEventError {
+    #[error("Index source refresh event domain is invalid: {0}")]
+    InvalidEventDomain(String),
+    #[error("Index source refresh event UUID cannot be nil")]
+    NilEventId,
+    #[error("Index source refresh event tenant UUID cannot be nil")]
+    NilTenantId,
+    #[error("Index source refresh event entity UUID cannot be nil")]
+    NilEntityId,
+    #[error("Index source refresh event minimum source version must be positive")]
+    ZeroMinimumSourceVersion,
+}
+
+#[derive(Debug, Error)]
+pub enum IndexSourceRefreshEventProcessError {
+    #[error("Unknown Index source refresh event domain: {0}")]
+    UnknownEventDomain(String),
+    #[error("Index source refresh event {event_domain} carries schema {actual}, expected {expected}")]
+    EventSchemaMismatch {
+        event_domain: String,
+        expected: SchemaRef,
+        actual: SchemaRef,
+    },
+    #[error("Index source refresh event has no replay source for schema {schema}")]
+    MissingReplaySource { schema: SchemaRef },
+    #[error(
+        "Index source refresh event {event_domain} resolved replay source {actual}, expected {expected}"
+    )]
+    ReplaySourceMismatch {
+        event_domain: String,
+        expected: String,
+        actual: String,
+    },
+    #[error("Index source refresh event source contract failed")]
+    Source(#[source] IndexSourceError),
+    #[error("Index source refresh event {event_domain} returned no mutation for {key:?}")]
+    MissingSourceMutation {
+        event_domain: String,
+        key: EntityKey,
+    },
+    #[error("Index source refresh event {event_domain} returned {actual} mutations for one key")]
+    AmbiguousSourceMutation {
+        event_domain: String,
+        actual: usize,
+    },
+    #[error(
+        "Index source refresh event {event_domain} source version is behind: minimum={minimum}, actual={actual}"
+    )]
+    SourceVersionBehind {
+        event_domain: String,
+        minimum: u64,
+        actual: u64,
+    },
+    #[error("Index source refresh event persistence failed")]
+    Mutation(#[source] IndexReplayFailure),
+    #[error("Index source refresh event acknowledgement failed after durable persistence")]
+    Acknowledge(#[source] IndexMutationAcknowledgeFailure),
+}
+
+fn rebind_event_id(mutation: IndexMutation, event_id: Uuid) -> IndexMutation {
+    match mutation {
+        IndexMutation::Upsert { record, .. } => IndexMutation::Upsert { event_id, record },
+        IndexMutation::Delete {
+            key,
+            source_version,
+            ..
+        } => IndexMutation::Delete {
+            event_id,
+            key,
+            source_version,
+        },
+    }
+}
+
+fn valid_machine_name(value: &str, max_bytes: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= max_bytes
+        && value.bytes().all(|byte| {
+            byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || matches!(byte, b'-' | b'_' | b'.')
+        })
+}

--- a/crates/rustok-index/src/application/source_refresh_event_tests.rs
+++ b/crates/rustok-index/src/application/source_refresh_event_tests.rs
@@ -1,0 +1,319 @@
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+};
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use super::*;
+use crate::{
+    EntityKey, EntityName, FieldCardinality, FieldName, IndexField, IndexMutation,
+    IndexMutationAcknowledgeFailure, IndexMutationEventAcknowledger, IndexMutationEventCatalog,
+    IndexRecord, IndexReplayFailure, IndexReplayMutationOutcome, IndexReplayMutationSink,
+    IndexSchema, IndexSchemaSourceCatalog, IndexSource, IndexSourceCatalog, IndexSourceFailure,
+    IndexSourceLoadBatch, IndexSourceLoadRequest, IndexSourcePage, IndexSourceScanRequest,
+    IndexValue, IndexValueType, LocaleKey, LocaleMode, ModuleName, SchemaRef, SchemaRegistry,
+    SchemaVersion, SharedIndexMutationEventRegistry, SharedIndexSourceRegistry,
+};
+
+const EVENT_DOMAIN: &str = "product.index.product-locale-refresh-v1";
+const SOURCE_NAME: &str = "product-postgres-primary";
+
+#[derive(Clone)]
+struct ExactSource {
+    mutation: Option<IndexMutation>,
+    calls: Arc<Mutex<usize>>,
+}
+
+#[async_trait]
+impl IndexSource for ExactSource {
+    async fn scan(
+        &self,
+        request: IndexSourceScanRequest,
+    ) -> Result<IndexSourcePage, IndexSourceFailure> {
+        Ok(IndexSourcePage::new(&request, Vec::new(), None).expect("valid empty page"))
+    }
+
+    async fn load(
+        &self,
+        request: IndexSourceLoadRequest,
+    ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+        *self.calls.lock().expect("source call lock") += 1;
+        IndexSourceLoadBatch::new(
+            &request,
+            self.mutation.clone().into_iter().collect(),
+        )
+        .map_err(|_| {
+            IndexSourceFailure::permanent("source_refresh_fixture_invalid")
+                .expect("static failure code")
+        })
+    }
+}
+
+#[derive(Clone)]
+struct RecordingSink {
+    calls: Arc<Mutex<Vec<&'static str>>>,
+    observed_event_id: Arc<Mutex<Option<Uuid>>>,
+}
+
+#[async_trait]
+impl IndexReplayMutationSink for RecordingSink {
+    async fn apply_replay_mutation(
+        &self,
+        _registry: &SchemaRegistry,
+        _source_name: &str,
+        mutation: &IndexMutation,
+    ) -> Result<IndexReplayMutationOutcome, IndexReplayFailure> {
+        self.calls.lock().expect("sink call lock").push("apply");
+        *self
+            .observed_event_id
+            .lock()
+            .expect("observed event lock") = Some(mutation.event_id());
+        Ok(IndexReplayMutationOutcome::Applied)
+    }
+}
+
+#[derive(Clone)]
+struct RecordingAcknowledger {
+    calls: Arc<Mutex<Vec<&'static str>>>,
+}
+
+#[async_trait]
+impl IndexMutationEventAcknowledger for RecordingAcknowledger {
+    type Token = String;
+
+    async fn acknowledge(
+        &self,
+        _token: &Self::Token,
+    ) -> Result<(), IndexMutationAcknowledgeFailure> {
+        self.calls.lock().expect("ack call lock").push("ack");
+        Ok(())
+    }
+}
+
+fn schema_ref() -> SchemaRef {
+    SchemaRef {
+        module: ModuleName::new("rustok-product").expect("module"),
+        entity: EntityName::new("product").expect("entity"),
+        version: SchemaVersion::new(2),
+    }
+}
+
+fn schema() -> IndexSchema {
+    IndexSchema {
+        reference: schema_ref(),
+        locale_mode: LocaleMode::Required,
+        fields: vec![IndexField {
+            name: FieldName::new("title").expect("field"),
+            value_type: IndexValueType::String,
+            cardinality: FieldCardinality::One,
+            nullable: false,
+            selectable: true,
+            filterable: true,
+            sortable: true,
+        }],
+        links: Vec::new(),
+    }
+}
+
+fn key() -> EntityKey {
+    EntityKey {
+        tenant_id: Uuid::from_u128(1),
+        schema: schema_ref(),
+        entity_id: Uuid::from_u128(2),
+        locale: Some(LocaleKey::new("en-US").expect("locale")),
+    }
+}
+
+fn mutation(source_version: u64) -> IndexMutation {
+    IndexMutation::Upsert {
+        event_id: Uuid::from_u128(99),
+        record: IndexRecord {
+            key: key(),
+            source_version,
+            fields: BTreeMap::from([(
+                FieldName::new("title").expect("field"),
+                IndexValue::String("Product".to_owned()),
+            )]),
+            links: Vec::new(),
+        },
+    }
+}
+
+fn registries(
+    mutation: Option<IndexMutation>,
+    source_calls: Arc<Mutex<usize>>,
+) -> (SharedIndexSourceRegistry, SharedIndexMutationEventRegistry) {
+    let mut schemas = IndexSchemaSourceCatalog::new();
+    schemas.register("product", schema()).expect("schema owner");
+
+    let mut sources = IndexSourceCatalog::new();
+    sources
+        .register(
+            "product",
+            SOURCE_NAME,
+            [schema_ref()],
+            ExactSource {
+                mutation,
+                calls: source_calls,
+            },
+        )
+        .expect("source");
+    let shared_sources = sources.materialize(&schemas).expect("source registry");
+
+    let mut events = IndexMutationEventCatalog::new();
+    events
+        .register("product", EVENT_DOMAIN, SOURCE_NAME, schema_ref())
+        .expect("event route");
+    let shared_events = events.materialize(&sources).expect("event registry");
+    (shared_sources, shared_events)
+}
+
+fn delivery(minimum_source_version: u64) -> IndexSourceRefreshEventDelivery<String> {
+    IndexSourceRefreshEventDelivery::new(
+        EVENT_DOMAIN,
+        Uuid::from_u128(7),
+        key(),
+        minimum_source_version,
+        "broker-position-7".to_owned(),
+    )
+    .expect("delivery")
+}
+
+#[tokio::test]
+async fn canonical_source_mutation_is_rebound_committed_and_then_acknowledged() {
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let source_calls = Arc::new(Mutex::new(0));
+    let observed_event_id = Arc::new(Mutex::new(None));
+    let (sources, events) = registries(Some(mutation(9)), source_calls.clone());
+    let worker = IndexSourceRefreshEventWorker::new(
+        RecordingSink {
+            calls: calls.clone(),
+            observed_event_id: observed_event_id.clone(),
+        },
+        RecordingAcknowledger {
+            calls: calls.clone(),
+        },
+    );
+
+    let outcome = worker
+        .process(
+            &SchemaRegistry::default(),
+            &sources,
+            &events,
+            delivery(7),
+        )
+        .await
+        .expect("source refresh should commit and acknowledge");
+
+    assert_eq!(outcome.event_id(), Uuid::from_u128(7));
+    assert_eq!(outcome.source_name(), SOURCE_NAME);
+    assert_eq!(outcome.source_version(), 9);
+    assert_eq!(outcome.mutation_outcome(), IndexReplayMutationOutcome::Applied);
+    assert_eq!(*source_calls.lock().expect("source call lock"), 1);
+    assert_eq!(*calls.lock().expect("call lock"), vec!["apply", "ack"]);
+    assert_eq!(
+        *observed_event_id.lock().expect("observed event lock"),
+        Some(Uuid::from_u128(7))
+    );
+}
+
+#[tokio::test]
+async fn missing_or_behind_source_state_suppresses_apply_and_ack() {
+    for source_mutation in [None, Some(mutation(6))] {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let source_calls = Arc::new(Mutex::new(0));
+        let (sources, events) = registries(source_mutation, source_calls.clone());
+        let worker = IndexSourceRefreshEventWorker::new(
+            RecordingSink {
+                calls: calls.clone(),
+                observed_event_id: Arc::new(Mutex::new(None)),
+            },
+            RecordingAcknowledger {
+                calls: calls.clone(),
+            },
+        );
+
+        let result = worker
+            .process(
+                &SchemaRegistry::default(),
+                &sources,
+                &events,
+                delivery(7),
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert_eq!(*source_calls.lock().expect("source call lock"), 1);
+        assert!(calls.lock().expect("call lock").is_empty());
+    }
+}
+
+#[tokio::test]
+async fn schema_mismatch_fails_before_source_load_apply_or_ack() {
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let source_calls = Arc::new(Mutex::new(0));
+    let (sources, events) = registries(Some(mutation(9)), source_calls.clone());
+    let worker = IndexSourceRefreshEventWorker::new(
+        RecordingSink {
+            calls: calls.clone(),
+            observed_event_id: Arc::new(Mutex::new(None)),
+        },
+        RecordingAcknowledger {
+            calls: calls.clone(),
+        },
+    );
+    let mut wrong_key = key();
+    wrong_key.schema.version = SchemaVersion::INITIAL;
+    let wrong_delivery = IndexSourceRefreshEventDelivery::new(
+        EVENT_DOMAIN,
+        Uuid::from_u128(7),
+        wrong_key,
+        7,
+        "broker-position-7".to_owned(),
+    )
+    .expect("structurally valid delivery");
+
+    assert!(
+        worker
+            .process(
+                &SchemaRegistry::default(),
+                &sources,
+                &events,
+                wrong_delivery,
+            )
+            .await
+            .is_err()
+    );
+    assert_eq!(*source_calls.lock().expect("source call lock"), 0);
+    assert!(calls.lock().expect("call lock").is_empty());
+}
+
+#[test]
+fn delivery_rejects_invalid_identity_and_revision() {
+    assert!(matches!(
+        IndexSourceRefreshEventDelivery::new(
+            "BAD DOMAIN",
+            Uuid::from_u128(7),
+            key(),
+            1,
+            (),
+        ),
+        Err(IndexSourceRefreshEventError::InvalidEventDomain(_))
+    ));
+    assert!(matches!(
+        IndexSourceRefreshEventDelivery::new(EVENT_DOMAIN, Uuid::nil(), key(), 1, ()),
+        Err(IndexSourceRefreshEventError::NilEventId)
+    ));
+    assert!(matches!(
+        IndexSourceRefreshEventDelivery::new(
+            EVENT_DOMAIN,
+            Uuid::from_u128(7),
+            key(),
+            0,
+            (),
+        ),
+        Err(IndexSourceRefreshEventError::ZeroMinimumSourceVersion)
+    ));
+}

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -18,6 +18,7 @@ const scripts = [
   'verify-index-query-equivalence-admission.mjs',
   'verify-index-source-schema-registry.mjs',
   'verify-index-source-replay-contract.mjs',
+  'verify-index-source-refresh-event.mjs',
   'verify-index-source-absence-watermark.mjs',
   'verify-index-source-continuation.mjs',
   'verify-index-source-continuation-server.mjs',

--- a/scripts/verify/verify-index-source-refresh-event.mjs
+++ b/scripts/verify/verify-index-source-refresh-event.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-source-refresh-event] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+requireMarkers('crates/rustok-index/src/application/mod.rs', [
+  'mod source_refresh_event;',
+  'mod source_refresh_event_tests;',
+  'IndexSourceRefreshEventDelivery',
+  'IndexSourceRefreshEventWorker',
+  'IndexSourceRefreshEventProcessError',
+]);
+
+const contractPath = 'crates/rustok-index/src/application/source_refresh_event.rs';
+const contract = requireMarkers(contractPath, [
+  'pub struct IndexSourceRefreshEventDelivery<T>',
+  'minimum_source_version: u64',
+  'pub struct IndexSourceRefreshEventWorker<M, A>',
+  'source_registry.source_for_schema(&key.schema)',
+  'IndexSourceLoadRequest::new(vec![key.clone()])',
+  '.load(request)',
+  'source_version < minimum_source_version',
+  'rebind_event_id(mutation, event_id)',
+  '.apply_replay_mutation(',
+  '.acknowledge(&acknowledgement_token)',
+  'MissingSourceMutation',
+  'AmbiguousSourceMutation',
+  'SourceVersionBehind',
+  'ReplaySourceMismatch',
+]);
+
+const routePosition = contract.indexOf('source_registry.source_for_schema(&key.schema)');
+const loadPosition = contract.indexOf('.load(request)');
+const fencePosition = contract.indexOf('source_version < minimum_source_version');
+const applyPosition = contract.indexOf('.apply_replay_mutation(');
+const acknowledgePosition = contract.indexOf('.acknowledge(&acknowledgement_token)');
+if (
+  routePosition < 0 ||
+  loadPosition <= routePosition ||
+  fencePosition <= loadPosition ||
+  applyPosition <= fencePosition ||
+  acknowledgePosition <= applyPosition
+) {
+  fail(`${contractPath} must route, load, fence, durably apply, and then acknowledge`);
+}
+
+for (const forbidden of [
+  'iggy::',
+  'rdkafka::',
+  'async_nats::',
+  'lapin::',
+  'tokio::spawn',
+  'std::thread::spawn',
+  'sleep(',
+  'SELECT ',
+  'INSERT INTO',
+  'UPDATE ',
+  'DELETE FROM',
+  'tracing::',
+  'acknowledgement_token.clone()',
+  'format!("{acknowledgement_token',
+]) {
+  if (contract.includes(forbidden)) {
+    fail(`${contractPath} contains forbidden transport/task/SQL/token coupling: ${forbidden}`);
+  }
+}
+
+requireMarkers('crates/rustok-index/src/application/source_refresh_event_tests.rs', [
+  'canonical_source_mutation_is_rebound_committed_and_then_acknowledged',
+  'missing_or_behind_source_state_suppresses_apply_and_ack',
+  'schema_mismatch_fails_before_source_load_apply_or_ack',
+  'delivery_rejects_invalid_identity_and_revision',
+  'vec!["apply", "ack"]',
+  'Some(Uuid::from_u128(7))',
+]);
+
+requireMarkers('crates/rustok-index/docs/m5-source-refresh-event.md', [
+  'Status: `source_complete_owner_event_publication_and_runtime_wiring_pending`',
+  '`IndexSourceRefreshEventWorker`',
+  'one bounded `IndexSourceLoadRequest` for exactly one key',
+  'replace the replay-only mutation UUID with the broker event UUID',
+  'A missing result or a revision below the event fence',
+  'does not add Product wire events or publish Product routes',
+  'The primary implementation cursor remains `M6 - execute and admit concrete repair evidence`',
+  'No tests, Node verifiers, Cargo checks',
+]);
+
+console.log('[verify-index-source-refresh-event] exact source refresh commit-before-ack contract verified');


### PR DESCRIPTION
## Summary

Add a database-neutral exact source-refresh event boundary for thin owner change notifications.

- introduce `IndexSourceRefreshEventDelivery<T>` with one registered event domain, owner event UUID, exact `EntityKey`, positive minimum owner source version, and opaque acknowledgement token;
- introduce `IndexSourceRefreshEventWorker<M, A>` over the existing immutable mutation-event and source registries;
- resolve one exact route and source, perform one bounded exact source load, and require exactly one canonical upsert or retained tombstone;
- reject missing state and source revisions below the event fence without applying or acknowledging;
- accept a newer source revision for delayed-event convergence;
- replace the replay-only mutation UUID with the broker event UUID so durable inbox deduplication protects redelivery;
- durably apply through `IndexReplayMutationSink` before broker acknowledgement;
- add unit contracts, source-only documentation, a fail-closed static verifier, aggregate verifier registration, and implementation-plan status.

## Processing order

1. Resolve the exact immutable event route.
2. Require exact schema equality.
3. Resolve the exact immutable source for that schema.
4. Require the route and source names to match.
5. Load one exact `EntityKey` through `IndexSourceLoadRequest`.
6. Require one upsert or tombstone mutation.
7. Require `source_version >= minimum_source_version`.
8. Rebind the mutation to the owner/broker event UUID.
9. Durably apply the mutation.
10. Acknowledge the opaque broker token.

## Product follow-up

This is the generic prerequisite for Product/ProductVariant incremental ingestion, but this PR intentionally does not change the `rustok-events` wire schema or committed digest artifact.

A later owner PR must define reviewed Product locale and ProductVariant refresh event families, publish exact owner revisions transactionally, register their routes, and compose a concrete consumer/acknowledger. The legacy ID-only Product root events are not promoted into Index routes.

## Deliberate limits

This PR does not:

- add Product/ProductVariant event contracts or publication;
- register Product production routes;
- start or configure any broker consumer;
- add batch refresh events;
- change retry, DLQ, lag, poison, or acknowledgement policy;
- run database or broker scenarios;
- alter or bypass the separate concrete-repair evidence gate.

The primary cursor remains `M6 - execute and admit concrete repair evidence`.

## Main recheck

The branch is one commit ahead of `main@840ad7df433a0765e2cb9b98d39a1e56e69ae4a2` with exactly eight changed files. Intervening Forum, Pages, Reactions, and Commerce commits do not overlap this slice.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL/SQLite/broker scenarios, workflows, or CI were run.