### PR TITLE
feat(reactions): compose optional host runtime

### DIFF
--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -78,6 +78,7 @@ mod-moderation = ["dep:rustok-moderation", "rustok-distribution/mod-moderation"]
 mod-content   = ["dep:rustok-content", "rustok-content/graphql", "rustok-content-orchestration/mod-content", "rustok-distribution/mod-content"]
 mod-blog      = ["dep:rustok-blog", "dep:rustok-content", "dep:rustok-translation-targets", "mod-comments", "mod-content", "mod-taxonomy", "rustok-content-orchestration/mod-blog", "rustok-distribution/mod-blog"]
 mod-forum     = ["dep:rustok-forum", "mod-content", "mod-taxonomy", "mod-page_builder", "rustok-content-orchestration/mod-forum", "rustok-distribution/mod-forum"]
+mod-reactions = ["dep:rustok-reactions", "rustok-distribution/mod-reactions"]
 mod-notifications = ["dep:rustok-notifications", "rustok-notifications/server", "rustok-distribution/mod-notifications"]
 mod-comments  = ["dep:rustok-comments", "rustok-comments/server", "rustok-content-orchestration/mod-comments", "rustok-distribution/mod-comments"]
 mod-pages     = ["dep:rustok-pages", "mod-content", "mod-page_builder", "rustok-distribution/mod-pages"]
@@ -143,6 +144,7 @@ rustok-comments  = { workspace = true, optional = true }
 rustok-content   = { workspace = true, optional = true }
 rustok-content-orchestration = { workspace = true }
 rustok-forum     = { workspace = true, optional = true }
+rustok-reactions = { path = "../../crates/rustok-reactions", optional = true }
 rustok-notifications = { workspace = true, optional = true }
 rustok-pages     = { workspace = true, optional = true }
 rustok-navigation = { workspace = true, optional = true }

--- a/apps/server/src/services/module_event_dispatcher.rs
+++ b/apps/server/src/services/module_event_dispatcher.rs
@@ -385,6 +385,24 @@ pub fn build_shared_runtime_extensions_with_host_providers(
         extensions.insert(recipient_context);
     }
 
+    #[cfg(feature = "mod-reactions")]
+    {
+        if rustok_reactions::api::reaction_subject_registry_from_extensions(&extensions).is_none() {
+            return Err(Error::Message(
+                "Reactions feature is selected but ReactionsModule is missing from ModuleRegistry"
+                    .to_string(),
+            ));
+        }
+        let host =
+            extensions.apply_to_host_runtime(rustok_api::HostRuntimeContext::new(db.clone()));
+        rustok_reactions::api::materialize_reaction_subject_registry(&mut extensions, &host)
+            .map_err(|error| {
+                Error::Message(format!(
+                    "reaction subject provider materialization failed: {error}"
+                ))
+            })?;
+    }
+
     #[cfg(feature = "mod-notifications")]
     {
         let host =
@@ -461,6 +479,8 @@ mod tests {
     #[tokio::test]
     async fn host_runtime_extensions_register_admin_mutation_providers() {
         let registry = ModuleRegistry::new();
+        #[cfg(feature = "mod-reactions")]
+        let registry = registry.register(rustok_reactions::ReactionsModule);
         let settings = RustokSettings::default();
         let db = Database::connect("sqlite::memory:")
             .await
@@ -536,6 +556,11 @@ mod tests {
         assert!(extensions.contains::<
             crate::services::forum_posting_policy_facts::SharedForumPostingPolicyFactsComposer,
         >());
+        #[cfg(feature = "mod-reactions")]
+        assert!(
+            rustok_reactions::api::reaction_subject_registry_from_extensions(extensions.as_ref())
+                .is_some()
+        );
         #[cfg(feature = "mod-notifications")]
         assert!(
             rustok_notifications::api::notification_source_registry_from_extensions(

--- a/crates/rustok-distribution/Cargo.toml
+++ b/crates/rustok-distribution/Cargo.toml
@@ -29,6 +29,7 @@ mod-marketplace = ["dep:rustok-marketplace", "mod-marketplace_seller", "mod-mark
 mod-moderation = ["dep:rustok-moderation"]
 mod-content = ["dep:rustok-content", "rustok-content/graphql", "rustok-content-orchestration/mod-content"]
 mod-blog = ["dep:rustok-blog", "dep:rustok-content", "mod-comments", "mod-content", "mod-taxonomy", "rustok-content-orchestration/mod-blog"]
+mod-reactions = ["dep:rustok-reactions"]
 mod-forum = ["dep:rustok-forum", "mod-content", "mod-taxonomy", "mod-page_builder", "rustok-content-orchestration/mod-forum"]
 mod-notifications = ["dep:rustok-notifications"]
 mod-comments = ["dep:rustok-comments", "rustok-comments/tcp-transport", "rustok-content-orchestration/mod-comments"]
@@ -85,6 +86,7 @@ rustok-moderation = { workspace = true, optional = true }
 rustok-content = { workspace = true, optional = true }
 rustok-content-orchestration.workspace = true
 rustok-blog = { workspace = true, optional = true }
+rustok-reactions = { path = "../rustok-reactions", optional = true }
 rustok-forum = { workspace = true, optional = true }
 rustok-notifications = { workspace = true, optional = true }
 rustok-comments = { workspace = true, optional = true }

--- a/crates/rustok-distribution/src/lib.rs
+++ b/crates/rustok-distribution/src/lib.rs
@@ -222,6 +222,10 @@ pub fn build_registry() -> ModuleRegistry {
     {
         registry = registry.register(rustok_blog::BlogModule);
     }
+    #[cfg(feature = "mod-reactions")]
+    {
+        registry = registry.register(rustok_reactions::ReactionsModule);
+    }
     #[cfg(feature = "mod-forum")]
     {
         registry = registry.register(rustok_forum::ForumModule);
@@ -410,6 +414,8 @@ mod tests {
                 .iter()
                 .any(|module| module.slug == "social_graph")
         );
+        #[cfg(feature = "mod-reactions")]
+        assert!(first.modules.iter().any(|module| module.slug == "reactions"));
         #[cfg(feature = "mod-ai")]
         assert!(first.modules.iter().any(|module| module.slug == "ai"));
     }

--- a/crates/rustok-forum/Cargo.toml
+++ b/crates/rustok-forum/Cargo.toml
@@ -30,7 +30,7 @@ rustok-events.workspace = true
 rustok-notifications-api.workspace = true
 rustok-outbox.workspace = true
 rustok-profiles.workspace = true
-rustok-reactions-api.workspace = true
+rustok-reactions-api = { path = "../rustok-reactions-api" }
 rustok-seo-targets.workspace = true
 rustok-media.workspace = true
 rustok-taxonomy.workspace = true

--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -109,11 +109,13 @@ integrate them instead of cloning their data models.
 The Reactions owner now has neutral bounded API contracts, unique source
 provider/factory registries, PostgreSQL/SQLite-compatible tenant-composite
 persistence, immutable catalog snapshots, shared Outbox command receipts and
-atomic actor-state/aggregate updates. Forum now publishes a source-ready
+atomic actor-state/aggregate updates. Forum publishes a source-ready
 `topic`/`reply` provider factory with exact active-state, visibility and current-
-revision authorization plus a bounded single-`like` v1 catalog. Maintainer
-lockfile generation, executable host materialization and runtime evidence remain
-pending. No reaction event/reconciliation layer, transport or UI exists yet.
+revision authorization plus a bounded single-`like` v1 catalog. Optional owner
+selection and host materialization are now source-ready in the distribution and
+server, after Forum audience and recipient-context providers. Maintainer lockfile
+generation and enabled/disabled runtime evidence remain pending. No reaction
+event/reconciliation layer, transport or UI exists yet.
 
 ## Program ledger
 
@@ -137,7 +139,7 @@ pending. No reaction event/reconciliation layer, transport or UI exists yet.
 | `FORUM-15` | `in_progress` | Profiles supplies `ProfilesReader`. Finish member-card composition, privacy/block behavior, Forum-stat enrichment and no-N+1 evidence. |
 | `FORUM-16` | `in_progress` | Read state, unread projections, bounded bulk owners and transports exist. Visibility-scoped storefront bulk commands and PostgreSQL evidence remain. |
 | `FORUM-17` | `planned` | Forum drafts/bookmarks with optional Notifications reminders and Media references. |
-| `FORUM-18` | `in_progress` | Neutral API, optional owner registration, tenant-composite persistence, shared receipts, atomic actor aggregates and the Forum topic/reply provider factory are source-ready. Add optional distribution/host materialization and enabled/disabled evidence, regenerate `Cargo.lock`, retain owner evidence, then add events/reconciliation, transports/UI and runtime proof; Forum votes remain separate. |
+| `FORUM-18` | `in_progress` | Neutral API, optional owner registration/selection, tenant-composite persistence, shared receipts, atomic actor aggregates, Forum topic/reply provider factory and host materialization are source-ready. Regenerate `Cargo.lock`, retain owner and enabled/disabled composition evidence, then add events/reconciliation, transports/UI and runtime proof; Forum votes remain separate. |
 | `FORUM-19` | `planned` | Integrate `rustok-moderation-api` subject/effect adapters and Forum-local restrictions. Moderation owns cases and audit. |
 | `FORUM-20` | `in_progress` | Rich visibility and recipient-aware source/inbox slices largely exist. Complete remaining reads, Search/SEO/deep links, reconciliation, delivery and PostgreSQL evidence. |
 | `FORUM-21` | `in_progress` | A-X provide move/merge/split/fork/range owners, transports and UI. Retained runtime evidence remains. |
@@ -203,10 +205,17 @@ returned only after current visibility succeeds. Delegated service/system access
 uses the existing exact recipient-context port rather than inventing profile or
 authority storage.
 
-Forum registers only the neutral provider factory. It does not depend on the
-Reactions owner, does not add Reactions to Forum module dependencies, and remains
-fully usable when Reactions is absent. Executable distribution selection and
-host registry materialization remain a separate composition slice.
+Forum registers only the neutral provider factory and depends only on the API
+crate through an explicit path. It does not depend on the Reactions owner and
+does not add Reactions to Forum module dependencies. The optional `mod-reactions`
+feature selects the owner independently in the distribution/server, remains
+outside defaults, and materializes the Forum provider only after host audience
+and recipient-context facts exist.
+
+The Reactions-disabled Forum composition remains valid: Forum commands and reads
+continue without owner storage or a materialized reaction registry. Reactions
+without Forum materializes an empty source registry; Forum with Reactions
+materializes the `forum` source with `topic` and `reply` kinds.
 
 Reputation and achievements remain separate shared capabilities consuming
 semantic facts. Forum trust remains Forum-owned because it controls Forum
@@ -232,10 +241,11 @@ Hosts register/mount packages and do not absorb policy.
 1. Reactions neutral API/optional module foundation: source-ready, maintainer verification pending.
 2. Reactions owner persistence/atomic aggregates: source-ready, lockfile and runtime evidence pending.
 3. Forum `topic`/`reply` provider factory and disabled Forum profile: source-ready, maintainer verification pending.
-4. Add optional distribution/server selection, materialize providers after host facts, and retain enabled/disabled composition evidence.
-5. Add semantic events/reconciliation and a second producer before freezing shared presentation contracts.
-6. Introduce Reputation/Achievements only after at least two producers agree.
-7. Integrate Forum with `rustok-moderation-api`; never add Forum case queues.
+4. Optional distribution/server selection and host materialization after Forum facts: source-ready, maintainer verification pending.
+5. Retain enabled/disabled host composition and owner persistence evidence.
+6. Add semantic events/reconciliation and a second producer before freezing shared presentation contracts.
+7. Introduce Reputation/Achievements only after at least two producers agree.
+8. Integrate Forum with `rustok-moderation-api`; never add Forum case queues.
 
 ### Track 2 — close existing Forum work
 
@@ -261,12 +271,14 @@ Hosts register/mount packages and do not absorb policy.
   decisions are applied idempotently through an adapter.
 - Profile, Media, Notifications, Reactions, Search and SEO integrations are
   additive; private-table fallbacks are forbidden.
-- Reactions remains optional and outside `default_enabled` until persistence,
-  adapters and degraded profiles are executable and verified.
+- Reactions remains optional and outside server defaults and `default_enabled`
+  until persistence, adapters and degraded profiles are executable and verified.
 - Reactions owner tables contain no Forum routes, content, visibility or copied
   profile data.
 - Forum's neutral Reactions API dependency does not make the Reactions owner a
   required Forum module dependency.
+- Selecting `mod-reactions` without registering `ReactionsModule` is a startup
+  configuration error, not an implicit empty owner.
 
 ## Required verification
 
@@ -275,9 +287,12 @@ node scripts/verify/verify-forum-shared-capability-ownership.mjs
 node scripts/verify/verify-reactions-foundation.mjs
 node scripts/verify/verify-reactions-owner-persistence.mjs
 node scripts/verify/verify-forum-reaction-subject-provider.mjs
+node scripts/verify/verify-reactions-host-composition.mjs
 cargo test -p rustok-reactions-api
 cargo test -p rustok-reactions
 cargo test -p rustok-forum reaction_subject
+cargo check -p rustok-distribution --features "mod-forum mod-reactions"
+cargo check -p rustok-server --no-default-features --features "mod-forum mod-reactions"
 cargo xtask module validate forum
 npm run verify:forum:admin-boundary
 npm run verify:forum:storefront-boundary
@@ -306,7 +321,7 @@ runtime claims without retained executable evidence.
 
 ## Immediate next action
 
-Add optional `mod-reactions` selection to the distribution and executable host,
-materialize the registered Forum provider only after host audience/recipient
-facts exist, keep it outside default profiles, and retain source/runtime evidence
-for both Reactions-enabled and Reactions-disabled Forum composition.
+Retain source/runtime evidence for Forum without Reactions, Reactions without
+Forum and Forum with Reactions, including the selected-feature/missing-registry
+startup failure. Then add semantic reaction events and reconciliation before any
+transport or UI slice.

--- a/crates/rustok-reactions/contracts/reactions-host-composition.json
+++ b/crates/rustok-reactions/contracts/reactions-host-composition.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": 1,
+  "contract": "reactions_optional_host_composition_v1",
+  "owner_module": "reactions",
+  "owner_feature": "mod-reactions",
+  "default_enabled": false,
+  "forum_implies_owner": false,
+  "status": "source_ready_maintainer_execution_pending",
+  "host_materialization": {
+    "requires_owner_registry": true,
+    "after_forum_audience_facts": true,
+    "after_forum_recipient_context": true,
+    "before_notification_source_materialization": true
+  },
+  "profiles": {
+    "forum_without_reactions": {
+      "forum_available": true,
+      "owner_registry_materialized": false,
+      "provider_materialized": false
+    },
+    "reactions_without_forum": {
+      "forum_available": false,
+      "owner_registry_materialized": true,
+      "provider_sources": []
+    },
+    "forum_with_reactions": {
+      "forum_available": true,
+      "owner_registry_materialized": true,
+      "provider_sources": [
+        {
+          "source": "forum",
+          "kinds": ["topic", "reply"]
+        }
+      ]
+    }
+  },
+  "required_files": [
+    "modules.toml",
+    "crates/rustok-forum/Cargo.toml",
+    "crates/rustok-distribution/Cargo.toml",
+    "crates/rustok-distribution/src/lib.rs",
+    "apps/server/Cargo.toml",
+    "apps/server/src/services/module_event_dispatcher.rs",
+    "crates/rustok-reactions/docs/implementation-plan.md",
+    "crates/rustok-forum/docs/implementation-plan.md",
+    "scripts/verify/verify-reactions-host-composition.mjs"
+  ]
+}

--- a/crates/rustok-reactions/docs/implementation-plan.md
+++ b/crates/rustok-reactions/docs/implementation-plan.md
@@ -14,10 +14,10 @@ last_reviewed: 2026-08-06
 
 | Task | Status | Deliverable |
 | --- | --- | --- |
-| `REACTIONS-00` | `in_progress` | Neutral API, optional module registration and provider registry are source-ready; maintainer Cargo/Node verification remains. |
+| `REACTIONS-00` | `in_progress` | Neutral API, optional owner module, distribution/server feature selection and provider registries are source-ready; maintainer Cargo/Node verification remains. |
 | `REACTIONS-01` | `in_progress` | Tenant-composite owner schema, immutable catalog snapshots, actor uniqueness and shared Outbox command receipts are source-ready. Regenerate `Cargo.lock` and retain SQLite/PostgreSQL execution evidence. |
 | `REACTIONS-02` | `in_progress` | Actor state and aggregate deltas commit atomically behind one subject serialization row. Add semantic events, repair/reconciliation and retained concurrency evidence. |
-| `REACTIONS-03` | `in_progress` | Forum topic/reply provider factory, exact current-revision/visibility authorization and the Reactions-disabled Forum profile are source-ready. Add optional distribution/host materialization and retain enabled/disabled runtime evidence. |
+| `REACTIONS-03` | `in_progress` | Forum topic/reply provider factory and optional distribution/server host materialization are source-ready. Reactions stays outside default profiles; enabled/disabled runtime evidence remains. |
 | `REACTIONS-04` | `planned` | Second real producer adapter and neutral-contract review. |
 | `REACTIONS-05` | `planned` | Bounded read/write transports and module-owned UI. |
 | `REACTIONS-06` | `planned` | Runtime evidence, FBA contracts, import/reconciliation and release profiles. |
@@ -66,12 +66,36 @@ Forum registers a neutral `ReactionSubjectProviderFactory` for `topic` and
 Forum remains fully usable when Reactions is absent. The neutral factory may be
 registered without materializing a Reactions owner runtime.
 
+## Optional host composition boundary
+
+`mod-reactions` is now an explicit optional feature in `rustok-distribution` and
+`rustok-server`. It registers `ReactionsModule`, contributes the owner migration
+source and materializes the reaction subject registry only after host providers
+have been composed.
+
+The executable host fails closed when the feature is selected but
+`ReactionsModule` is absent from the supplied `ModuleRegistry`. When Forum is
+also selected, materialization happens after Forum audience facts and exact
+recipient-context providers exist, so the Forum factory cannot be built with a
+broader or incomplete authority boundary.
+
+Supported source profiles are explicit:
+
+- Forum without Reactions: Forum remains available; the neutral factory is not
+  materialized into an owner registry.
+- Reactions without Forum: the owner registry materializes with no Forum source.
+- Forum with Reactions: the registry materializes the `forum` source with
+  `topic` and `reply` kinds.
+
+`mod-forum` does not imply `mod-reactions`, server defaults do not select it and
+`modules.toml` keeps Reactions outside `default_enabled`.
+
 ## Immediate next action
 
-Add optional `mod-reactions` selection to `rustok-distribution` and the server,
-materialize source factories after host facts providers exist, keep Reactions
-outside default profiles, and retain both enabled and disabled Forum composition
-evidence.
+Retain enabled/disabled runtime evidence for the three composition profiles,
+including a selected-feature/missing-registry startup failure. Then add semantic
+reaction events, catalog/aggregate reconciliation and a second real producer
+before freezing transport or presentation contracts.
 
 Before release, regenerate `Cargo.lock`, execute SQLite and PostgreSQL migrations,
 retain replay/concurrency/rollback evidence, add semantic reaction events and
@@ -86,9 +110,12 @@ cargo test -p rustok-forum reaction_subject
 cargo check -p rustok-reactions-api --all-targets
 cargo check -p rustok-reactions --all-targets
 cargo check -p rustok-forum --all-targets
+cargo check -p rustok-distribution --features "mod-forum mod-reactions"
+cargo check -p rustok-server --no-default-features --features "mod-forum mod-reactions"
 node scripts/verify/verify-reactions-foundation.mjs
 node scripts/verify/verify-reactions-owner-persistence.mjs
 node scripts/verify/verify-forum-reaction-subject-provider.mjs
+node scripts/verify/verify-reactions-host-composition.mjs
 git diff --check
 ```
 

--- a/scripts/verify/verify-forum-reaction-subject-provider.mjs
+++ b/scripts/verify/verify-forum-reaction-subject-provider.mjs
@@ -50,7 +50,7 @@ for (const fragment of contract.forbidden_source_fragments) {
 }
 
 for (const fragment of [
-  "rustok-reactions-api.workspace = true",
+  'rustok-reactions-api = { path = "../rustok-reactions-api" }',
   "rustok-notifications-api.workspace = true",
 ]) {
   if (!forumCargo.includes(fragment)) fail(`Forum Cargo boundary is missing ${fragment}`);
@@ -76,7 +76,7 @@ if (/"reactions"/u.test(defaultEnabled)) {
 for (const fragment of [
   "topic`/`reply` provider factory",
   "latest captured Forum revision id + 1",
-  "Executable distribution selection and",
+  "optional owner selection and host materialization",
   "node scripts/verify/verify-forum-reaction-subject-provider.mjs",
 ]) {
   if (!forumPlan.includes(fragment)) fail(`Forum plan is missing ${fragment}`);

--- a/scripts/verify/verify-reactions-foundation.mjs
+++ b/scripts/verify/verify-reactions-foundation.mjs
@@ -110,8 +110,8 @@ const forumPlan = read("crates/rustok-forum/docs/implementation-plan.md");
 for (const fragment of [
   "| Reaction catalog, actor reactions and aggregate reaction counts | `rustok-reactions` |",
   "| `FORUM-18` | `in_progress` |",
-  "Forum `topic` and `reply`",
-  "`ReactionSubjectProvider`",
+  "Forum provider factory supports `topic` and `reply`",
+  "optional `mod-reactions`",
   "Existing Forum votes remain Forum semantics",
 ]) {
   if (!forumPlan.includes(fragment)) fail(`Forum plan is missing ${fragment}`);

--- a/scripts/verify/verify-reactions-host-composition.mjs
+++ b/scripts/verify/verify-reactions-host-composition.mjs
@@ -1,0 +1,147 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath = path.join(
+  repoRoot,
+  "crates/rustok-reactions/contracts/reactions-host-composition.json",
+);
+const contract = JSON.parse(readFileSync(contractPath, "utf8"));
+
+function fail(message) {
+  throw new Error(`Reactions host composition verification failed: ${message}`);
+}
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!existsSync(absolute)) fail(`missing required file ${relativePath}`);
+  return readFileSync(absolute, "utf8");
+}
+
+function featureLine(manifest, feature) {
+  return manifest
+    .split(/\r?\n/u)
+    .find((line) => line.trimStart().startsWith(`${feature} =`));
+}
+
+function defaultFeatureBlock(manifest) {
+  return manifest.match(/^default\s*=\s*\[[\s\S]*?^\]/mu)?.[0] ?? "";
+}
+
+if (contract.schema_version !== 1) fail("unsupported contract schema version");
+if (contract.contract !== "reactions_optional_host_composition_v1") {
+  fail("unexpected contract identity");
+}
+if (contract.owner_module !== "reactions") fail("owner module must be reactions");
+if (contract.owner_feature !== "mod-reactions") fail("owner feature must be mod-reactions");
+if (contract.default_enabled !== false) fail("Reactions must remain disabled by default");
+if (contract.forum_implies_owner !== false) fail("Forum must not imply the Reactions owner");
+if (contract.status !== "source_ready_maintainer_execution_pending") {
+  fail("runtime execution must not be claimed by the source contract");
+}
+
+for (const relativePath of contract.required_files) read(relativePath);
+
+const modules = read("modules.toml");
+const forumCargo = read("crates/rustok-forum/Cargo.toml");
+const distributionCargo = read("crates/rustok-distribution/Cargo.toml");
+const distributionLib = read("crates/rustok-distribution/src/lib.rs");
+const serverCargo = read("apps/server/Cargo.toml");
+const dispatcher = read("apps/server/src/services/module_event_dispatcher.rs");
+const forumPlan = read("crates/rustok-forum/docs/implementation-plan.md");
+const reactionsPlan = read("crates/rustok-reactions/docs/implementation-plan.md");
+
+if (!modules.includes('reactions = { crate = "rustok-reactions"')) {
+  fail("modules.toml must retain the optional Reactions module descriptor");
+}
+const defaultEnabled = modules.match(/default_enabled\s*=\s*\[[\s\S]*?\]/mu)?.[0] ?? "";
+if (/"reactions"/u.test(defaultEnabled)) {
+  fail("modules.toml default_enabled must not include reactions");
+}
+
+if (!forumCargo.includes('rustok-reactions-api = { path = "../rustok-reactions-api" }')) {
+  fail("Forum must resolve the neutral Reactions API through an explicit path dependency");
+}
+if (/^rustok-reactions\s*=/mu.test(forumCargo)) {
+  fail("Forum must not depend on the Reactions owner crate");
+}
+
+const distributionFeature = featureLine(distributionCargo, "mod-reactions");
+if (distributionFeature !== 'mod-reactions = ["dep:rustok-reactions"]') {
+  fail("distribution mod-reactions feature must select only the owner crate");
+}
+if (!distributionCargo.includes('rustok-reactions = { path = "../rustok-reactions", optional = true }')) {
+  fail("distribution must declare rustok-reactions as optional");
+}
+for (const fragment of [
+  '#[cfg(feature = "mod-reactions")]',
+  'registry = registry.register(rustok_reactions::ReactionsModule);',
+  'module.slug == "reactions"',
+]) {
+  if (!distributionLib.includes(fragment)) {
+    fail(`distribution registration is missing ${fragment}`);
+  }
+}
+
+const serverFeature = featureLine(serverCargo, "mod-reactions");
+if (
+  serverFeature !==
+  'mod-reactions = ["dep:rustok-reactions", "rustok-distribution/mod-reactions"]'
+) {
+  fail("server mod-reactions feature must select the owner and distribution feature");
+}
+if (!serverCargo.includes('rustok-reactions = { path = "../../crates/rustok-reactions", optional = true }')) {
+  fail("server must declare rustok-reactions as optional");
+}
+if (/"mod-reactions"/u.test(defaultFeatureBlock(serverCargo))) {
+  fail("server default features must not include mod-reactions");
+}
+const forumFeature = featureLine(serverCargo, "mod-forum") ?? "";
+if (forumFeature.includes("mod-reactions")) {
+  fail("server mod-forum must not imply mod-reactions");
+}
+const distributionForumFeature = featureLine(distributionCargo, "mod-forum") ?? "";
+if (distributionForumFeature.includes("mod-reactions")) {
+  fail("distribution mod-forum must not imply mod-reactions");
+}
+
+for (const fragment of [
+  "reaction_subject_registry_from_extensions(&extensions).is_none()",
+  "Reactions feature is selected but ReactionsModule is missing from ModuleRegistry",
+  "materialize_reaction_subject_registry(&mut extensions, &host)",
+  "reaction subject provider materialization failed",
+]) {
+  if (!dispatcher.includes(fragment)) fail(`host composition is missing ${fragment}`);
+}
+
+const audienceIndex = dispatcher.indexOf("extensions.insert(audience_facts);");
+const recipientIndex = dispatcher.indexOf("extensions.insert(recipient_context);");
+const reactionIndex = dispatcher.indexOf("materialize_reaction_subject_registry");
+const notificationIndex = dispatcher.indexOf("materialize_notification_source_registry");
+if ([audienceIndex, recipientIndex, reactionIndex, notificationIndex].some((index) => index < 0)) {
+  fail("host materialization ordering markers are incomplete");
+}
+if (!(audienceIndex < recipientIndex && recipientIndex < reactionIndex)) {
+  fail("Reactions providers must materialize after Forum audience and recipient facts");
+}
+if (!(reactionIndex < notificationIndex)) {
+  fail("Reactions provider materialization must remain before Notifications source materialization");
+}
+
+for (const fragment of [
+  "optional distribution/server host materialization",
+  "enabled/disabled runtime evidence",
+  "node scripts/verify/verify-reactions-host-composition.mjs",
+]) {
+  if (!reactionsPlan.includes(fragment)) fail(`Reactions plan is missing ${fragment}`);
+}
+for (const fragment of [
+  "optional owner selection and host materialization",
+  "Reactions-disabled Forum composition",
+  "node scripts/verify/verify-reactions-host-composition.mjs",
+]) {
+  if (!forumPlan.includes(fragment)) fail(`Forum plan is missing ${fragment}`);
+}
+
+console.log("Reactions optional host composition source contract verified.");

--- a/scripts/verify/verify-reactions-owner-persistence.mjs
+++ b/scripts/verify/verify-reactions-owner-persistence.mjs
@@ -118,7 +118,8 @@ for (const fragment of [
   "| `REACTIONS-01` | `in_progress` |",
   "| `REACTIONS-02` | `in_progress` |",
   "shared Outbox",
-  "Forum `topic` and `reply` `ReactionSubjectProvider`",
+  "`ReactionSubjectProviderFactory`",
+  "enabled/disabled runtime evidence",
 ]) {
   if (!plan.includes(fragment)) fail(`Reactions plan is missing ${fragment}`);
 }
@@ -126,8 +127,8 @@ for (const fragment of [
 for (const fragment of [
   "| `FORUM-18` | `in_progress` |",
   "tenant-composite persistence",
-  "Forum `topic` and `reply`",
-  "`ReactionSubjectProvider`",
+  "Forum provider factory supports `topic` and `reply`",
+  "optional `mod-reactions`",
   "Existing Forum votes remain Forum semantics",
 ]) {
   if (!forumPlan.includes(fragment)) fail(`Forum plan is missing ${fragment}`);


### PR DESCRIPTION
## Summary

Compose the shared Reactions owner as an explicit optional distribution/server capability and materialize producer providers only after host-owned facts are available.

- resolve Forum's neutral `rustok-reactions-api` dependency through an explicit path boundary;
- add optional `mod-reactions` features to `rustok-distribution` and `rustok-server`;
- register `ReactionsModule` and its migration source only when the feature is selected;
- keep Reactions outside server defaults and `modules.toml.default_enabled`;
- keep `mod-forum` independent from `mod-reactions`;
- fail startup when the server feature is selected but `ReactionsModule` is absent from the supplied registry;
- materialize the reaction subject registry after Forum audience facts and exact recipient-context providers exist;
- support Forum-without-Reactions, Reactions-without-Forum, and Forum-with-Reactions composition profiles;
- add a machine-readable host-composition contract and source verifier;
- actualize the existing Forum provider, Reactions foundation, and owner-persistence verifiers against the implemented boundaries;
- update the canonical Forum and Reactions plans.

## Ownership and degraded profiles

Forum continues to own topic/reply existence, lifecycle, revision, visibility and reaction policy. Reactions owns catalogs, actor state, command receipts and aggregate counts.

Forum depends only on the neutral API crate and remains available when the Reactions owner is not selected. Reactions without Forum materializes an empty producer registry. Forum with Reactions materializes the `forum` source with `topic` and `reply` kinds after the required Forum host providers are composed.

## Deliberate limits

This PR does not add:

- Reactions to server defaults or tenant `default_enabled`;
- GraphQL, REST or native transports;
- admin/storefront UI;
- semantic reaction events;
- catalog or aggregate reconciliation;
- a second producer adapter;
- reputation or achievements;
- runtime execution evidence.

## Main recheck

The branch started from `main@65964d9ae794ba4d00fc63e5099eb403a94d57bb`. Current `main@d8a372804a3f8d2b9e8455ca001dc52090761e59` contains three Commerce/Index/Pages commits with no overlap in this PR's twelve changed files. GitHub mergeability is used as the final conflict check before squash merge.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Cargo check, formatting, Clippy or lockfile generation;
- Node verifiers;
- SQLite/PostgreSQL migrations or runtime scenarios;
- workflows or CI.

`Cargo.lock` was not regenerated. The maintainer Cargo run must retain the minimal package/dependency delta before using `--locked`.

Suggested maintainer commands:

```bash
cargo test -p rustok-reactions-api
cargo test -p rustok-reactions
cargo test -p rustok-forum reaction_subject
cargo check -p rustok-distribution --features "mod-forum mod-reactions"
cargo check -p rustok-server --no-default-features --features "mod-forum mod-reactions"
node scripts/verify/verify-reactions-foundation.mjs
node scripts/verify/verify-reactions-owner-persistence.mjs
node scripts/verify/verify-forum-reaction-subject-provider.mjs
node scripts/verify/verify-reactions-host-composition.mjs
git diff --check
```

Source status remains `source_ready_maintainer_execution_pending`.