### PR TITLE
test(reactions): add composition profile evidence

### DIFF
--- a/apps/server/tests/reactions_composition_profiles.rs
+++ b/apps/server/tests/reactions_composition_profiles.rs
@@ -1,0 +1,106 @@
+use std::sync::Arc;
+
+use rustok_auth::AuthConfig;
+use rustok_core::{ModuleRegistry, ModuleRuntimeExtensions};
+use rustok_index::IndexModule;
+use rustok_server::common::settings::RustokSettings;
+use rustok_server::error::{Error, Result};
+use rustok_server::services::module_event_dispatcher::build_shared_runtime_extensions_with_host_providers;
+use rustok_server::services::server_runtime_context::ServerRuntimeContext;
+use sea_orm::Database;
+
+const TEST_AUTH_SECRET: &str = "test-secret-key-for-unit-tests-only-32bytes!";
+
+async fn compose(registry: &ModuleRegistry) -> Result<Arc<ModuleRuntimeExtensions>> {
+    let settings = RustokSettings::default();
+    let database = Database::connect("sqlite::memory:").await?;
+    let runtime = ServerRuntimeContext::new(database, settings.clone());
+
+    build_shared_runtime_extensions_with_host_providers(
+        registry,
+        &settings,
+        runtime,
+        AuthConfig::new(TEST_AUTH_SECRET.to_string()),
+    )
+}
+
+#[cfg(all(feature = "mod-forum", not(feature = "mod-reactions")))]
+#[tokio::test]
+async fn forum_without_reactions_keeps_forum_host_composition_available() {
+    let registry = ModuleRegistry::new()
+        .register(IndexModule)
+        .register(rustok_forum::ForumModule);
+
+    let extensions = compose(&registry)
+        .await
+        .expect("Forum-only host composition must remain available");
+
+    assert!(extensions.contains::<rustok_forum::SharedForumAudienceFactsPort>());
+    assert!(
+        extensions.contains::<rustok_forum::SharedForumNotificationRecipientContextPort>()
+    );
+}
+
+#[cfg(all(feature = "mod-reactions", not(feature = "mod-forum")))]
+#[tokio::test]
+async fn reactions_without_forum_materializes_an_empty_subject_registry() {
+    let registry = ModuleRegistry::new()
+        .register(IndexModule)
+        .register(rustok_reactions::ReactionsModule);
+
+    let extensions = compose(&registry)
+        .await
+        .expect("Reactions-only host composition must initialize");
+    let subjects = rustok_reactions::api::reaction_subject_registry_from_extensions(
+        extensions.as_ref(),
+    )
+    .expect("selected Reactions owner must publish a materialized subject registry");
+
+    assert!(subjects.is_empty());
+}
+
+#[cfg(all(feature = "mod-forum", feature = "mod-reactions"))]
+#[tokio::test]
+async fn forum_with_reactions_materializes_topic_and_reply_provider() {
+    let registry = ModuleRegistry::new()
+        .register(IndexModule)
+        .register(rustok_reactions::ReactionsModule)
+        .register(rustok_forum::ForumModule);
+
+    let extensions = compose(&registry)
+        .await
+        .expect("Forum plus Reactions host composition must initialize");
+    let subjects = rustok_reactions::api::reaction_subject_registry_from_extensions(
+        extensions.as_ref(),
+    )
+    .expect("selected Reactions owner must publish a materialized subject registry");
+    let forum = subjects
+        .get_by_str("forum")
+        .expect("Forum producer must materialize when both modules are selected");
+    let mut kinds = forum
+        .supported_kinds()
+        .into_iter()
+        .map(|kind| kind.as_str().to_string())
+        .collect::<Vec<_>>();
+    kinds.sort();
+
+    assert_eq!(subjects.len(), 1);
+    assert_eq!(kinds, vec!["reply".to_string(), "topic".to_string()]);
+}
+
+#[cfg(feature = "mod-reactions")]
+#[tokio::test]
+async fn selected_reactions_feature_fails_when_owner_module_is_missing() {
+    let registry = ModuleRegistry::new().register(IndexModule);
+
+    let error = match compose(&registry).await {
+        Ok(_) => panic!("selected Reactions feature must reject a registry without its owner"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(&error, Error::Message(_)));
+    assert_eq!(
+        error.to_string(),
+        "Reactions feature is selected but ReactionsModule is missing from ModuleRegistry"
+    );
+}

--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -112,10 +112,12 @@ persistence, immutable catalog snapshots, shared Outbox command receipts and
 atomic actor-state/aggregate updates. Forum publishes a source-ready
 `topic`/`reply` provider factory with exact active-state, visibility and current-
 revision authorization plus a bounded single-`like` v1 catalog. Optional owner
-selection and host materialization are now source-ready in the distribution and
-server, after Forum audience and recipient-context providers. Maintainer lockfile
-generation and enabled/disabled runtime evidence remain pending. No reaction
-event/reconciliation layer, transport or UI exists yet.
+selection and host materialization are source-ready in the distribution and
+server, after Forum audience and recipient-context providers. The server now has
+executable source evidence for all three optional profiles plus the selected-
+feature/missing-owner failure. Maintainer lockfile generation and retained
+execution evidence remains pending. No reaction event/reconciliation layer,
+transport or UI exists yet.
 
 ## Program ledger
 
@@ -139,7 +141,7 @@ event/reconciliation layer, transport or UI exists yet.
 | `FORUM-15` | `in_progress` | Profiles supplies `ProfilesReader`. Finish member-card composition, privacy/block behavior, Forum-stat enrichment and no-N+1 evidence. |
 | `FORUM-16` | `in_progress` | Read state, unread projections, bounded bulk owners and transports exist. Visibility-scoped storefront bulk commands and PostgreSQL evidence remain. |
 | `FORUM-17` | `planned` | Forum drafts/bookmarks with optional Notifications reminders and Media references. |
-| `FORUM-18` | `in_progress` | Neutral API, optional owner registration/selection, tenant-composite persistence, shared receipts, atomic actor aggregates, Forum topic/reply provider factory and host materialization are source-ready. Regenerate `Cargo.lock`, retain owner and enabled/disabled composition evidence, then add events/reconciliation, transports/UI and runtime proof; Forum votes remain separate. |
+| `FORUM-18` | `in_progress` | Neutral API, owner selection/persistence, shared receipts, atomic aggregates, Forum provider, host materialization and executable composition-profile tests are source-ready. Regenerate `Cargo.lock`, retain owner/profile runs, then add events/reconciliation, transports/UI and runtime proof; Forum votes remain separate. |
 | `FORUM-19` | `planned` | Integrate `rustok-moderation-api` subject/effect adapters and Forum-local restrictions. Moderation owns cases and audit. |
 | `FORUM-20` | `in_progress` | Rich visibility and recipient-aware source/inbox slices largely exist. Complete remaining reads, Search/SEO/deep links, reconciliation, delivery and PostgreSQL evidence. |
 | `FORUM-21` | `in_progress` | A-X provide move/merge/split/fork/range owners, transports and UI. Retained runtime evidence remains. |
@@ -215,7 +217,10 @@ and recipient-context facts exist.
 The Reactions-disabled Forum composition remains valid: Forum commands and reads
 continue without owner storage or a materialized reaction registry. Reactions
 without Forum materializes an empty source registry; Forum with Reactions
-materializes the `forum` source with `topic` and `reply` kinds.
+materializes the `forum` source with `topic` and `reply` kinds. The public server
+composition entrypoint now has executable tests for each profile and for the
+selected-feature/missing-owner startup failure. Retained execution evidence
+remains pending.
 
 Reputation and achievements remain separate shared capabilities consuming
 semantic facts. Forum trust remains Forum-owned because it controls Forum
@@ -242,7 +247,7 @@ Hosts register/mount packages and do not absorb policy.
 2. Reactions owner persistence/atomic aggregates: source-ready, lockfile and runtime evidence pending.
 3. Forum `topic`/`reply` provider factory and disabled Forum profile: source-ready, maintainer verification pending.
 4. Optional distribution/server selection and host materialization after Forum facts: source-ready, maintainer verification pending.
-5. Retain enabled/disabled host composition and owner persistence evidence.
+5. Executable source evidence for all profiles: source-ready; retain the four maintainer runs and lockfile delta.
 6. Add semantic events/reconciliation and a second producer before freezing shared presentation contracts.
 7. Introduce Reputation/Achievements only after at least two producers agree.
 8. Integrate Forum with `rustok-moderation-api`; never add Forum case queues.
@@ -288,19 +293,23 @@ node scripts/verify/verify-reactions-foundation.mjs
 node scripts/verify/verify-reactions-owner-persistence.mjs
 node scripts/verify/verify-forum-reaction-subject-provider.mjs
 node scripts/verify/verify-reactions-host-composition.mjs
+node scripts/verify/verify-reactions-composition-profiles.mjs
 cargo test -p rustok-reactions-api
 cargo test -p rustok-reactions
 cargo test -p rustok-forum reaction_subject
 cargo check -p rustok-distribution --features "mod-forum mod-reactions"
-cargo check -p rustok-server --no-default-features --features "mod-forum mod-reactions"
+cargo test -p rustok-server --no-default-features --features mod-forum --test reactions_composition_profiles forum_without_reactions_keeps_forum_host_composition_available
+cargo test -p rustok-server --no-default-features --features mod-reactions --test reactions_composition_profiles reactions_without_forum_materializes_an_empty_subject_registry
+cargo test -p rustok-server --no-default-features --features mod-reactions --test reactions_composition_profiles selected_reactions_feature_fails_when_owner_module_is_missing
+cargo test -p rustok-server --no-default-features --features "mod-forum mod-reactions" --test reactions_composition_profiles forum_with_reactions_materializes_topic_and_reply_provider
 cargo xtask module validate forum
 npm run verify:forum:admin-boundary
 npm run verify:forum:storefront-boundary
 git diff --check
 ```
 
-Tests, lockfile generation and runtime evidence are maintainer-run. Source
-contracts do not promote runtime status.
+Tests, lockfile generation and retained runtime evidence are maintainer-run.
+Source contracts do not promote runtime status.
 
 ## Release gates
 
@@ -321,7 +330,6 @@ runtime claims without retained executable evidence.
 
 ## Immediate next action
 
-Retain source/runtime evidence for Forum without Reactions, Reactions without
-Forum and Forum with Reactions, including the selected-feature/missing-registry
-startup failure. Then add semantic reaction events and reconciliation before any
+Retain the four composition-profile runs and regenerate `Cargo.lock`. Then add
+transactional semantic reaction events and bounded reconciliation before any
 transport or UI slice.

--- a/crates/rustok-reactions/contracts/reactions-host-composition.json
+++ b/crates/rustok-reactions/contracts/reactions-host-composition.json
@@ -16,12 +16,14 @@
     "forum_without_reactions": {
       "forum_available": true,
       "owner_registry_materialized": false,
-      "provider_materialized": false
+      "provider_materialized": false,
+      "test": "forum_without_reactions_keeps_forum_host_composition_available"
     },
     "reactions_without_forum": {
       "forum_available": false,
       "owner_registry_materialized": true,
-      "provider_sources": []
+      "provider_sources": [],
+      "test": "reactions_without_forum_materializes_an_empty_subject_registry"
     },
     "forum_with_reactions": {
       "forum_available": true,
@@ -31,8 +33,25 @@
           "source": "forum",
           "kinds": ["topic", "reply"]
         }
-      ]
+      ],
+      "test": "forum_with_reactions_materializes_topic_and_reply_provider"
+    },
+    "selected_feature_without_owner": {
+      "startup_allowed": false,
+      "error": "Reactions feature is selected but ReactionsModule is missing from ModuleRegistry",
+      "test": "selected_reactions_feature_fails_when_owner_module_is_missing"
     }
+  },
+  "executable_evidence": {
+    "test_target": "reactions_composition_profiles",
+    "database": "sqlite::memory:",
+    "retained_execution_required": true,
+    "commands": [
+      "cargo test -p rustok-server --no-default-features --features mod-forum --test reactions_composition_profiles forum_without_reactions_keeps_forum_host_composition_available",
+      "cargo test -p rustok-server --no-default-features --features mod-reactions --test reactions_composition_profiles reactions_without_forum_materializes_an_empty_subject_registry",
+      "cargo test -p rustok-server --no-default-features --features mod-reactions --test reactions_composition_profiles selected_reactions_feature_fails_when_owner_module_is_missing",
+      "cargo test -p rustok-server --no-default-features --features \"mod-forum mod-reactions\" --test reactions_composition_profiles forum_with_reactions_materializes_topic_and_reply_provider"
+    ]
   },
   "required_files": [
     "modules.toml",
@@ -41,8 +60,10 @@
     "crates/rustok-distribution/src/lib.rs",
     "apps/server/Cargo.toml",
     "apps/server/src/services/module_event_dispatcher.rs",
+    "apps/server/tests/reactions_composition_profiles.rs",
     "crates/rustok-reactions/docs/implementation-plan.md",
     "crates/rustok-forum/docs/implementation-plan.md",
-    "scripts/verify/verify-reactions-host-composition.mjs"
+    "scripts/verify/verify-reactions-host-composition.mjs",
+    "scripts/verify/verify-reactions-composition-profiles.mjs"
   ]
 }

--- a/crates/rustok-reactions/docs/implementation-plan.md
+++ b/crates/rustok-reactions/docs/implementation-plan.md
@@ -17,7 +17,7 @@ last_reviewed: 2026-08-06
 | `REACTIONS-00` | `in_progress` | Neutral API, optional owner module, distribution/server feature selection and provider registries are source-ready; maintainer Cargo/Node verification remains. |
 | `REACTIONS-01` | `in_progress` | Tenant-composite owner schema, immutable catalog snapshots, actor uniqueness and shared Outbox command receipts are source-ready. Regenerate `Cargo.lock` and retain SQLite/PostgreSQL execution evidence. |
 | `REACTIONS-02` | `in_progress` | Actor state and aggregate deltas commit atomically behind one subject serialization row. Add semantic events, repair/reconciliation and retained concurrency evidence. |
-| `REACTIONS-03` | `in_progress` | Forum topic/reply provider factory and optional distribution/server host materialization are source-ready. Reactions stays outside default profiles; enabled/disabled runtime evidence remains. |
+| `REACTIONS-03` | `in_progress` | Forum topic/reply provider, optional host materialization and executable composition profile tests are source-ready. Reactions stays outside defaults; retained execution evidence remains pending. |
 | `REACTIONS-04` | `planned` | Second real producer adapter and neutral-contract review. |
 | `REACTIONS-05` | `planned` | Bounded read/write transports and module-owned UI. |
 | `REACTIONS-06` | `planned` | Runtime evidence, FBA contracts, import/reconciliation and release profiles. |
@@ -68,10 +68,12 @@ registered without materializing a Reactions owner runtime.
 
 ## Optional host composition boundary
 
-`mod-reactions` is now an explicit optional feature in `rustok-distribution` and
+`mod-reactions` is an explicit optional feature in `rustok-distribution` and
 `rustok-server`. It registers `ReactionsModule`, contributes the owner migration
 source and materializes the reaction subject registry only after host providers
-have been composed.
+have been composed. The optional distribution/server host materialization is
+source-ready. The enabled/disabled runtime evidence now has executable test
+source, but retained runs remain pending.
 
 The executable host fails closed when the feature is selected but
 `ReactionsModule` is absent from the supplied `ModuleRegistry`. When Forum is
@@ -79,27 +81,41 @@ also selected, materialization happens after Forum audience facts and exact
 recipient-context providers exist, so the Forum factory cannot be built with a
 broader or incomplete authority boundary.
 
-Supported source profiles are explicit:
+Supported profiles are explicit:
 
 - Forum without Reactions: Forum remains available; the neutral factory is not
   materialized into an owner registry.
 - Reactions without Forum: the owner registry materializes with no Forum source.
 - Forum with Reactions: the registry materializes the `forum` source with
   `topic` and `reply` kinds.
+- Selected Reactions feature without `ReactionsModule`: startup fails with the
+  stable owner-missing error before publishing a false runtime.
 
 `mod-forum` does not imply `mod-reactions`, server defaults do not select it and
 `modules.toml` keeps Reactions outside `default_enabled`.
 
+## Executable composition evidence
+
+`apps/server/tests/reactions_composition_profiles.rs` provides executable
+composition profile tests over the public server host-composition entrypoint and
+an isolated SQLite in-memory connection. The test target proves the three
+supported optional profiles plus the selected-feature/missing-owner failure.
+It does not query Forum domain rows or execute reaction commands.
+
+The contract remains `source_ready_maintainer_execution_pending`: retained
+execution evidence remains pending until a maintainer runs and stores the four
+profile results. Source presence alone does not promote `REACTIONS-03` to done.
+
 ## Immediate next action
 
-Retain enabled/disabled runtime evidence for the three composition profiles,
-including a selected-feature/missing-registry startup failure. Then add semantic
-reaction events, catalog/aggregate reconciliation and a second real producer
-before freezing transport or presentation contracts.
+After retaining the four composition-profile runs and regenerating `Cargo.lock`,
+add transactional semantic reaction events and bounded catalog/aggregate
+reconciliation. Then add a second real producer before freezing transport or
+presentation contracts.
 
-Before release, regenerate `Cargo.lock`, execute SQLite and PostgreSQL migrations,
-retain replay/concurrency/rollback evidence, add semantic reaction events and
-provide reconciliation for catalog and aggregate drift.
+Before release, execute SQLite and PostgreSQL migrations, retain replay,
+concurrency and rollback evidence, and provide reconciliation for catalog and
+aggregate drift.
 
 ## Verification
 
@@ -111,12 +127,16 @@ cargo check -p rustok-reactions-api --all-targets
 cargo check -p rustok-reactions --all-targets
 cargo check -p rustok-forum --all-targets
 cargo check -p rustok-distribution --features "mod-forum mod-reactions"
-cargo check -p rustok-server --no-default-features --features "mod-forum mod-reactions"
+cargo test -p rustok-server --no-default-features --features mod-forum --test reactions_composition_profiles forum_without_reactions_keeps_forum_host_composition_available
+cargo test -p rustok-server --no-default-features --features mod-reactions --test reactions_composition_profiles reactions_without_forum_materializes_an_empty_subject_registry
+cargo test -p rustok-server --no-default-features --features mod-reactions --test reactions_composition_profiles selected_reactions_feature_fails_when_owner_module_is_missing
+cargo test -p rustok-server --no-default-features --features "mod-forum mod-reactions" --test reactions_composition_profiles forum_with_reactions_materializes_topic_and_reply_provider
 node scripts/verify/verify-reactions-foundation.mjs
 node scripts/verify/verify-reactions-owner-persistence.mjs
 node scripts/verify/verify-forum-reaction-subject-provider.mjs
 node scripts/verify/verify-reactions-host-composition.mjs
+node scripts/verify/verify-reactions-composition-profiles.mjs
 git diff --check
 ```
 
-Tests, checks, lockfile generation and runtime evidence are maintainer-run.
+Tests, checks, lockfile generation and retained runtime evidence are maintainer-run.

--- a/scripts/verify/verify-forum-reaction-subject-provider.mjs
+++ b/scripts/verify/verify-forum-reaction-subject-provider.mjs
@@ -19,6 +19,10 @@ function read(relativePath) {
   return readFileSync(absolute, "utf8");
 }
 
+function compact(value) {
+  return value.replace(/\s+/gu, " ").trim();
+}
+
 if (contract.schema_version !== 1) fail("unsupported contract schema version");
 if (contract.module !== "forum") fail("contract module must be forum");
 if (contract.contract !== "forum_reaction_subject_provider_v1") {
@@ -39,8 +43,8 @@ const provider = read("crates/rustok-forum/src/reaction_subject.rs");
 const forumLib = read("crates/rustok-forum/src/lib.rs");
 const forumCargo = read("crates/rustok-forum/Cargo.toml");
 const modules = read("modules.toml");
-const forumPlan = read("crates/rustok-forum/docs/implementation-plan.md");
-const reactionsPlan = read("crates/rustok-reactions/docs/implementation-plan.md");
+const forumPlan = compact(read("crates/rustok-forum/docs/implementation-plan.md"));
+const reactionsPlan = compact(read("crates/rustok-reactions/docs/implementation-plan.md"));
 
 for (const fragment of contract.required_source_fragments) {
   if (!provider.includes(fragment)) fail(`provider is missing ${fragment}`);
@@ -76,7 +80,7 @@ if (/"reactions"/u.test(defaultEnabled)) {
 for (const fragment of [
   "topic`/`reply` provider factory",
   "latest captured Forum revision id + 1",
-  "optional owner selection and host materialization",
+  "Optional owner selection and host materialization",
   "node scripts/verify/verify-forum-reaction-subject-provider.mjs",
 ]) {
   if (!forumPlan.includes(fragment)) fail(`Forum plan is missing ${fragment}`);
@@ -84,7 +88,7 @@ for (const fragment of [
 for (const fragment of [
   "| `REACTIONS-03` | `in_progress` |",
   "Forum producer boundary",
-  "outside default profiles",
+  "outside defaults",
 ]) {
   if (!reactionsPlan.includes(fragment)) fail(`Reactions plan is missing ${fragment}`);
 }

--- a/scripts/verify/verify-reactions-composition-profiles.mjs
+++ b/scripts/verify/verify-reactions-composition-profiles.mjs
@@ -1,0 +1,104 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+
+function fail(message) {
+  throw new Error(`Reactions composition profile verification failed: ${message}`);
+}
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!existsSync(absolute)) fail(`missing required file ${relativePath}`);
+  return readFileSync(absolute, "utf8");
+}
+
+function compact(value) {
+  return value.replace(/\s+/gu, " ").trim();
+}
+
+const contract = JSON.parse(
+  read("crates/rustok-reactions/contracts/reactions-host-composition.json"),
+);
+const tests = read("apps/server/tests/reactions_composition_profiles.rs");
+const serverCargo = read("apps/server/Cargo.toml");
+const modules = read("modules.toml");
+const reactionsPlan = compact(read("crates/rustok-reactions/docs/implementation-plan.md"));
+const forumPlan = compact(read("crates/rustok-forum/docs/implementation-plan.md"));
+
+if (contract.schema_version !== 1) fail("unexpected host contract schema");
+if (contract.contract !== "reactions_optional_host_composition_v1") {
+  fail("unexpected host contract identity");
+}
+if (contract.status !== "source_ready_maintainer_execution_pending") {
+  fail("source must not claim retained execution");
+}
+if (contract.executable_evidence?.test_target !== "reactions_composition_profiles") {
+  fail("unexpected test target");
+}
+if (contract.executable_evidence?.database !== "sqlite::memory:") {
+  fail("profile tests must use isolated SQLite in-memory storage");
+}
+if (contract.executable_evidence?.retained_execution_required !== true) {
+  fail("retained maintainer execution must remain required");
+}
+
+const profiles = Object.values(contract.profiles);
+for (const profile of profiles) {
+  if (typeof profile.test !== "string" || !tests.includes(`async fn ${profile.test}()`)) {
+    fail(`missing executable test ${profile.test}`);
+  }
+}
+
+for (const fragment of [
+  '#[cfg(all(feature = "mod-forum", not(feature = "mod-reactions")))]',
+  '#[cfg(all(feature = "mod-reactions", not(feature = "mod-forum")))]',
+  '#[cfg(all(feature = "mod-forum", feature = "mod-reactions"))]',
+  '#[cfg(feature = "mod-reactions")]',
+  'Database::connect("sqlite::memory:")',
+  "SharedForumAudienceFactsPort",
+  "SharedForumNotificationRecipientContextPort",
+  "assert!(subjects.is_empty());",
+  'get_by_str("forum")',
+  'assert_eq!(kinds, vec!["reply".to_string(), "topic".to_string()]);',
+  contract.profiles.selected_feature_without_owner.error,
+]) {
+  if (!tests.includes(fragment)) fail(`test target is missing ${fragment}`);
+}
+
+const commands = contract.executable_evidence.commands;
+if (!Array.isArray(commands) || commands.length !== 4) {
+  fail("exactly four maintainer commands are required");
+}
+for (const profile of profiles) {
+  if (!commands.some((command) => command.includes(profile.test))) {
+    fail(`maintainer command is missing ${profile.test}`);
+  }
+}
+
+const defaultFeatures = serverCargo.match(/^default\s*=\s*\[[\s\S]*?^\]/mu)?.[0] ?? "";
+if (/"mod-reactions"/u.test(defaultFeatures)) {
+  fail("server defaults must not enable Reactions");
+}
+const defaultEnabled = modules.match(/default_enabled\s*=\s*\[[\s\S]*?\]/mu)?.[0] ?? "";
+if (/"reactions"/u.test(defaultEnabled)) {
+  fail("tenant defaults must not enable Reactions");
+}
+
+for (const fragment of [
+  "executable composition profile tests",
+  "retained execution evidence remains pending",
+  "verify-reactions-composition-profiles.mjs",
+]) {
+  if (!reactionsPlan.includes(fragment)) fail(`Reactions plan is missing ${fragment}`);
+}
+for (const fragment of [
+  "executable source evidence for all three optional profiles",
+  "retained execution evidence remains pending",
+  "verify-reactions-composition-profiles.mjs",
+]) {
+  if (!forumPlan.includes(fragment)) fail(`Forum plan is missing ${fragment}`);
+}
+
+console.log("Reactions executable composition profiles verified.");

--- a/scripts/verify/verify-reactions-host-composition.mjs
+++ b/scripts/verify/verify-reactions-host-composition.mjs
@@ -3,11 +3,15 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
-const contractPath = path.join(
-  repoRoot,
-  "crates/rustok-reactions/contracts/reactions-host-composition.json",
+const contract = JSON.parse(
+  readFileSync(
+    path.join(
+      repoRoot,
+      "crates/rustok-reactions/contracts/reactions-host-composition.json",
+    ),
+    "utf8",
+  ),
 );
-const contract = JSON.parse(readFileSync(contractPath, "utf8"));
 
 function fail(message) {
   throw new Error(`Reactions host composition verification failed: ${message}`);
@@ -29,6 +33,10 @@ function defaultFeatureBlock(manifest) {
   return manifest.match(/^default\s*=\s*\[[\s\S]*?^\]/mu)?.[0] ?? "";
 }
 
+function compact(value) {
+  return value.replace(/\s+/gu, " ").trim();
+}
+
 if (contract.schema_version !== 1) fail("unsupported contract schema version");
 if (contract.contract !== "reactions_optional_host_composition_v1") {
   fail("unexpected contract identity");
@@ -40,7 +48,6 @@ if (contract.forum_implies_owner !== false) fail("Forum must not imply the React
 if (contract.status !== "source_ready_maintainer_execution_pending") {
   fail("runtime execution must not be claimed by the source contract");
 }
-
 for (const relativePath of contract.required_files) read(relativePath);
 
 const modules = read("modules.toml");
@@ -49,8 +56,8 @@ const distributionCargo = read("crates/rustok-distribution/Cargo.toml");
 const distributionLib = read("crates/rustok-distribution/src/lib.rs");
 const serverCargo = read("apps/server/Cargo.toml");
 const dispatcher = read("apps/server/src/services/module_event_dispatcher.rs");
-const forumPlan = read("crates/rustok-forum/docs/implementation-plan.md");
-const reactionsPlan = read("crates/rustok-reactions/docs/implementation-plan.md");
+const forumPlan = compact(read("crates/rustok-forum/docs/implementation-plan.md"));
+const reactionsPlan = compact(read("crates/rustok-reactions/docs/implementation-plan.md"));
 
 if (!modules.includes('reactions = { crate = "rustok-reactions"')) {
   fail("modules.toml must retain the optional Reactions module descriptor");
@@ -59,7 +66,6 @@ const defaultEnabled = modules.match(/default_enabled\s*=\s*\[[\s\S]*?\]/mu)?.[0
 if (/"reactions"/u.test(defaultEnabled)) {
   fail("modules.toml default_enabled must not include reactions");
 }
-
 if (!forumCargo.includes('rustok-reactions-api = { path = "../rustok-reactions-api" }')) {
   fail("Forum must resolve the neutral Reactions API through an explicit path dependency");
 }
@@ -67,8 +73,7 @@ if (/^rustok-reactions\s*=/mu.test(forumCargo)) {
   fail("Forum must not depend on the Reactions owner crate");
 }
 
-const distributionFeature = featureLine(distributionCargo, "mod-reactions");
-if (distributionFeature !== 'mod-reactions = ["dep:rustok-reactions"]') {
+if (featureLine(distributionCargo, "mod-reactions") !== 'mod-reactions = ["dep:rustok-reactions"]') {
   fail("distribution mod-reactions feature must select only the owner crate");
 }
 if (!distributionCargo.includes('rustok-reactions = { path = "../rustok-reactions", optional = true }')) {
@@ -79,14 +84,11 @@ for (const fragment of [
   'registry = registry.register(rustok_reactions::ReactionsModule);',
   'module.slug == "reactions"',
 ]) {
-  if (!distributionLib.includes(fragment)) {
-    fail(`distribution registration is missing ${fragment}`);
-  }
+  if (!distributionLib.includes(fragment)) fail(`distribution registration is missing ${fragment}`);
 }
 
-const serverFeature = featureLine(serverCargo, "mod-reactions");
 if (
-  serverFeature !==
+  featureLine(serverCargo, "mod-reactions") !==
   'mod-reactions = ["dep:rustok-reactions", "rustok-distribution/mod-reactions"]'
 ) {
   fail("server mod-reactions feature must select the owner and distribution feature");
@@ -97,12 +99,10 @@ if (!serverCargo.includes('rustok-reactions = { path = "../../crates/rustok-reac
 if (/"mod-reactions"/u.test(defaultFeatureBlock(serverCargo))) {
   fail("server default features must not include mod-reactions");
 }
-const forumFeature = featureLine(serverCargo, "mod-forum") ?? "";
-if (forumFeature.includes("mod-reactions")) {
+if ((featureLine(serverCargo, "mod-forum") ?? "").includes("mod-reactions")) {
   fail("server mod-forum must not imply mod-reactions");
 }
-const distributionForumFeature = featureLine(distributionCargo, "mod-forum") ?? "";
-if (distributionForumFeature.includes("mod-reactions")) {
+if ((featureLine(distributionCargo, "mod-forum") ?? "").includes("mod-reactions")) {
   fail("distribution mod-forum must not imply mod-reactions");
 }
 
@@ -137,7 +137,7 @@ for (const fragment of [
   if (!reactionsPlan.includes(fragment)) fail(`Reactions plan is missing ${fragment}`);
 }
 for (const fragment of [
-  "optional owner selection and host materialization",
+  "Optional owner selection and host materialization",
   "Reactions-disabled Forum composition",
   "node scripts/verify/verify-reactions-host-composition.mjs",
 ]) {


### PR DESCRIPTION
## Summary

Add executable source evidence for the optional Reactions host-composition matrix without enabling Reactions by default or changing runtime ownership.

- add an integration-test target over the public server host-composition entrypoint;
- cover Forum without Reactions;
- cover Reactions without Forum and require an empty materialized subject registry;
- cover Forum with Reactions and require the `forum` source with `topic` and `reply` kinds;
- cover the fail-closed selected-feature/missing-owner configuration error;
- bind all four tests and exact maintainer commands into the existing host-composition contract;
- add a dedicated composition-profile verifier;
- stabilize existing provider/host verifiers against Markdown line wrapping;
- actualize the canonical Forum and Reactions plans while keeping the work `in_progress` until retained execution exists.

## Boundaries

The test target uses an isolated `sqlite::memory:` connection only to compose the runtime graph. It does not run domain migrations, query Forum rows, execute reaction commands, add transports/UI, reinterpret Forum votes or enable Reactions in server/tenant defaults.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Cargo check, formatting or Clippy;
- Node verifiers;
- migrations or database scenarios;
- workflows or CI.

`Cargo.lock` was not regenerated.

Suggested maintainer commands:

```bash
cargo test -p rustok-server --no-default-features --features mod-forum --test reactions_composition_profiles forum_without_reactions_keeps_forum_host_composition_available
cargo test -p rustok-server --no-default-features --features mod-reactions --test reactions_composition_profiles reactions_without_forum_materializes_an_empty_subject_registry
cargo test -p rustok-server --no-default-features --features mod-reactions --test reactions_composition_profiles selected_reactions_feature_fails_when_owner_module_is_missing
cargo test -p rustok-server --no-default-features --features "mod-forum mod-reactions" --test reactions_composition_profiles forum_with_reactions_materializes_topic_and_reply_provider
node scripts/verify/verify-reactions-foundation.mjs
node scripts/verify/verify-reactions-owner-persistence.mjs
node scripts/verify/verify-forum-reaction-subject-provider.mjs
node scripts/verify/verify-reactions-host-composition.mjs
node scripts/verify/verify-reactions-composition-profiles.mjs
git diff --check
```

Source status remains `source_ready_maintainer_execution_pending`.