### PR TITLE
feat(product): retain Index locale refresh ledger

### DIFF
--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -30,6 +30,7 @@ This directory contains the detailed technical architecture documentation for `r
 - [Live Implementation Plan](./implementation-plan.md)
 - [M5 Mutation Event Commit/Ack Contract](./m5-mutation-event-ack-contract.md)
 - [M5 Exact Source Refresh Event Worker](./m5-source-refresh-event.md)
+- [M5 Product Locale Refresh Owner Ledger](../../rustok-product/docs/index-locale-refresh-ledger.md)
 - [M5 Social Graph Production Mutation Route](./m5-social-graph-mutation-route.md)
 - [M5/M6 Source Replay Contract](./m5-m6-source-replay-contract.md)
 - [M6 Explicit Source Absence Watermark](./m6-explicit-source-absence-watermark.md)

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-03.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-03.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-03
 
-Status overlay rechecked against current `main` after Social Graph route merge #3102 and active
-branch `agent/index-m5-product-source-refresh-contract-20260806`.
+Status overlay rechecked against current `main` after exact source-refresh worker merge #3106 and
+active branch `agent/index-m5-product-locale-refresh-ledger-20260806`.
 
 When this dated overlay conflicts with the older canonical plan, this file is the current source of
 truth. Historical architecture and milestone context remain in `implementation-plan.md`.
@@ -40,7 +40,15 @@ A second independent M5 slice adds exact source-refresh orchestration for thin o
 One event identifies an exact `EntityKey`, owner event UUID, and positive minimum source version. The
 worker resolves the immutable route and source, performs one bounded exact load, requires an upsert
 or tombstone at or beyond the event fence, rebinds the canonical mutation to the broker event UUID,
-durably applies it, and only then acknowledges. Product wire events and runtime wiring remain open.
+durably applies it, and only then acknowledges.
+
+A third independent M5 slice makes Product locale owner changes recoverable before the public wire
+contract exists. Product lifecycle publication now retains the exact root envelope UUID and writes
+bounded append-only `(tenant, product, locale, source_version)` refresh rows in the same transaction.
+Live rows use final trigger-owned Product revisions; removed locales and hard deletes use retained
+tombstone revisions. A bounded Product-owned source exposes the ledger without importing Index.
+Typed Product events, route registration, relay/consumer composition, and ProductVariant ownership
+remain open. This source-only work does not advance or bypass the repair evidence cursor.
 
 Concrete missing-entity repair:
 
@@ -83,6 +91,8 @@ remain open.
   `generic_source_complete_social_graph_route_runtime_execution_pending`
 - M5 exact source-refresh event worker:
   `source_complete_owner_event_publication_and_runtime_wiring_pending`
+- M5 Product locale append-only refresh owner ledger and bounded owner source:
+  `owner_source_complete_wire_and_consumer_pending`
 - M5 Social Graph bounded replay source and exact production event route:
   `source_complete_runtime_execution_pending`
 - M5/M6 bounded source replay contract: `source_complete_owner_execution_pending`
@@ -130,10 +140,15 @@ remain open.
 - [x] Reuse the concrete Social Graph Iggy consumer/acknowledger, bounded retry/backoff, DLQ and
       poison receipts, graceful shutdown, and lag/outcome metrics.
 - [x] Materialize selected PostgreSQL sources and mutation event routes atomically.
-- [ ] Define reviewed Product locale and ProductVariant refresh event families with exact owner
-      revision and release-digest updates.
-- [ ] Publish Product/ProductVariant refresh events transactionally from every owner change path.
-- [ ] Register remaining selected production owner routes and concrete consumers.
+- [x] Retain exact Product locale identities and owner revisions in an append-only transactional
+      ledger causally linked to the existing Product lifecycle envelope.
+- [x] Expose the Product locale ledger through one bounded tenant/sequence owner source.
+- [ ] Define the reviewed Product locale refresh event family and update the committed release
+      digests through the canonical generator.
+- [ ] Relay Product locale rows as typed write-once events with `refresh_id` envelope identity.
+- [ ] Register the Product locale production route and concrete consumer/acknowledger.
+- [ ] Add ProductVariant parent identity to retained tombstones and implement the equivalent owner
+      ledger, typed event, route, and consumer path.
 - [ ] Add equivalent concrete consumer policy for every remaining selected owner route.
 - [ ] Retain crash-between-commit-and-ack and redelivery evidence against the generic registered
       route boundary.
@@ -212,8 +227,10 @@ remain open.
 - [x] Add stable replay identities and retained deletes.
 - [x] Add Product-to-ProductVariant graph materialization.
 - [x] Add the generic exact-source refresh worker required by Product/ProductVariant notifications.
-- [ ] Add Product/ProductVariant owner event contracts, transactional publication, production routes,
-      and concrete incremental consumer wiring.
+- [x] Add Product locale append-only owner refresh publication and bounded owner source.
+- [ ] Add Product locale typed event, production route, relay, and concrete incremental consumer.
+- [ ] Add ProductVariant parent-aware tombstones, owner refresh publication, typed event, route, and
+      concrete incremental consumer.
 - [ ] Persist and enforce per-tenant schema readiness.
 - [ ] Complete durable Product-to-SalesChannel relation semantics and retained evidence.
 - [ ] Admit tombstone purge, freshness/outage/restart/backlog recovery, and delete/recreate evidence.
@@ -237,13 +254,16 @@ The owner must run the locked capture command from a clean commit. The retained 
 - normal full-mutation versus exact edge-owner serialization results;
 - complete credential-redacted stdout/stderr and final pass status.
 
-Independent source-only work may continue on Product event publication and remaining M5/M7 owner
-routes, but public repair authorization transport, automatic iteration, time-derived leases, and
-lifecycle auto-resolution remain blocked until admission.
+Independent source-only work may continue on the Product locale typed relay, ProductVariant owner
+identity, and remaining M5/M7 owner routes, but public repair authorization transport, automatic
+iteration, time-derived leases, and lifecycle auto-resolution remain blocked until admission.
 
 ## Owner verification for current source boundaries
 
 ```bash
+node scripts/verify/verify-index-product-locale-refresh-ledger.mjs
+cargo check -p rustok-product --all-targets
+
 cargo test -p rustok-index source_refresh_event --lib -- --nocapture
 node scripts/verify/verify-index-source-refresh-event.mjs
 

--- a/crates/rustok-product/docs/index-locale-refresh-ledger.md
+++ b/crates/rustok-product/docs/index-locale-refresh-ledger.md
@@ -1,0 +1,93 @@
+# Product Index locale refresh ledger
+
+Status: `owner_source_complete_wire_and_consumer_pending`.
+
+## Purpose
+
+Product lifecycle events existed before the generic Index mutation route and carry only a
+`product_id`. That payload cannot safely drive localized incremental ingestion because it does not
+identify removed locales or expose the trigger-owned Product `index_revision`.
+
+The Product module now retains one append-only owner row for every exact localized identity affected
+by a Product lifecycle command. The ledger is written in the same database transaction as the
+existing root event and Product mutation.
+
+This is an owner boundary, not an Index table. `rustok-product` still has no dependency on
+`rustok-index` and never creates `IndexMutation` values.
+
+## Row contract
+
+`product_index_locale_refresh_ledger` stores:
+
+- monotonic `sequence_no` for bounded tenant-local paging;
+- unique `refresh_id`, reserved as the future typed event and Index inbox identity;
+- `root_event_id`, the exact durable Product lifecycle envelope that caused the row;
+- exact `tenant_id`, `product_id`, and `locale` identity;
+- positive `source_version` read from Product-owned live or tombstone storage;
+- owner timestamp for diagnostics only.
+
+The database rejects updates and deletes. A root event may produce several rows, but one exact
+`(root_event_id, product_id, locale)` may be recorded only once.
+
+## Transaction order
+
+`ProductWriteTransaction::publish` performs the following steps:
+
+1. classify whether the root event is `ProductCreated`, `ProductUpdated`, `ProductPublished`, or
+   `ProductDeleted`;
+2. write the existing root event through the transactional outbox and retain its envelope UUID;
+3. query exact Product locale state after all owner writes and trigger execution;
+4. insert bounded append-only refresh rows;
+5. allow the caller to commit the Product transaction.
+
+A source query or ledger insert failure rolls back the Product mutation and root event. No refresh
+row can commit independently from its owner command.
+
+## Live and delete versions
+
+For a live translation, the row records the final positive `products.index_revision` after all
+Product and translation triggers have completed.
+
+For a removed locale or hard-deleted Product, the row records the exact positive
+`product_index_tombstones.source_version`. Live identities suppress an older retained tombstone for
+the same locale.
+
+A later Product command may emit an older retained tombstone again. This is deliberate and safe:
+the future generic Index consumer will use a new delivery identity while source-version monotonicity
+classifies the older state as stale.
+
+## Bounded owner API
+
+`ProductIndexLocaleRefreshSource::list` exposes at most 256 rows for one exact tenant after one
+non-negative sequence cursor. It returns only identities, versions, causation, and sequence data.
+It does not return Product payload, execute an Index write, acknowledge a broker delivery, or mark
+ledger rows mutable/consumed.
+
+PostgreSQL is the authoritative production backend. Non-PostgreSQL Product test profiles keep their
+existing root-event behavior but do not claim an Index refresh ledger.
+
+## Deliberate limits
+
+This slice does not:
+
+- add or change a `rustok-events` wire family or committed digest;
+- publish typed Product locale refresh events;
+- register the Product v2 mutation route;
+- start a broker relay or consumer;
+- acknowledge deliveries or implement retry/DLQ policy;
+- cover ProductVariant refresh identities;
+- expose public HTTP, GraphQL, or admin transport;
+- alter the separate concrete-repair evidence gate.
+
+ProductVariant requires a separate owner slice because the current retained variant tombstone does
+not preserve its parent `product_id`, which is needed for product-scoped change enumeration.
+
+## Maintainer verification
+
+```bash
+node scripts/verify/verify-index-product-locale-refresh-ledger.mjs
+cargo check -p rustok-product --all-targets
+git diff --check
+```
+
+No validation command or database scenario was executed by the implementation agent.

--- a/crates/rustok-product/src/lib.rs
+++ b/crates/rustok-product/src/lib.rs
@@ -30,9 +30,10 @@ pub use public_error::{ProductPublicError, map_product_public_error};
 pub use runtime::{ProductCatalogReadProfile, ProductCatalogReadRuntime};
 pub use services::{
     AdminProductList, AdminProductListItem, AdminProductListQuery, CatalogService,
-    ProductAttributeFilter, ProductCatalogSchemaService, StorefrontProductList,
-    StorefrontProductListItem, StorefrontProductListQuery, StorefrontProductSortBy,
-    StorefrontProductSortDirection,
+    MAX_PRODUCT_INDEX_LOCALE_REFRESH_PAGE, ProductAttributeFilter,
+    ProductCatalogSchemaService, ProductIndexLocaleRefreshRecord,
+    ProductIndexLocaleRefreshSource, StorefrontProductList, StorefrontProductListItem,
+    StorefrontProductListQuery, StorefrontProductSortBy, StorefrontProductSortDirection,
 };
 
 /// Typed marker proving that `ProductModule` participated in runtime extension registration.

--- a/crates/rustok-product/src/migrations/m20260806_000005_add_product_index_locale_refresh_ledger.rs
+++ b/crates/rustok-product/src/migrations/m20260806_000005_add_product_index_locale_refresh_ledger.rs
@@ -1,0 +1,110 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::DatabaseBackend;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() != DatabaseBackend::Postgres {
+            return Err(DbErr::Custom(
+                "rustok-product migrations require PostgreSQL".to_owned(),
+            ));
+        }
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+CREATE TABLE product_index_locale_refresh_ledger (
+    sequence_no BIGSERIAL NOT NULL,
+    refresh_id UUID NOT NULL,
+    root_event_id UUID NOT NULL,
+    tenant_id UUID NOT NULL,
+    product_id UUID NOT NULL,
+    locale TEXT NOT NULL,
+    source_version BIGINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_product_index_locale_refresh_ledger PRIMARY KEY (refresh_id),
+    CONSTRAINT uq_product_index_locale_refresh_root_target
+        UNIQUE (root_event_id, product_id, locale),
+    CONSTRAINT uq_product_index_locale_refresh_tenant_sequence
+        UNIQUE (tenant_id, sequence_no),
+    CONSTRAINT chk_product_index_locale_refresh_sequence_positive
+        CHECK (sequence_no > 0),
+    CONSTRAINT chk_product_index_locale_refresh_refresh_id_non_nil
+        CHECK (refresh_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CONSTRAINT chk_product_index_locale_refresh_root_event_id_non_nil
+        CHECK (root_event_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CONSTRAINT chk_product_index_locale_refresh_tenant_id_non_nil
+        CHECK (tenant_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CONSTRAINT chk_product_index_locale_refresh_product_id_non_nil
+        CHECK (product_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CONSTRAINT chk_product_index_locale_refresh_locale_nonempty
+        CHECK (btrim(locale) <> ''),
+    CONSTRAINT chk_product_index_locale_refresh_locale_bounded
+        CHECK (octet_length(locale) <= 128),
+    CONSTRAINT chk_product_index_locale_refresh_source_version_positive
+        CHECK (source_version > 0)
+);
+
+CREATE INDEX idx_product_index_locale_refresh_target
+    ON product_index_locale_refresh_ledger (
+        tenant_id,
+        product_id,
+        locale,
+        source_version DESC,
+        sequence_no DESC
+    );
+
+CREATE OR REPLACE FUNCTION rustok_product_reject_index_locale_refresh_ledger_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'product Index locale refresh ledger is append-only';
+    RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER trg_product_index_locale_refresh_ledger_update
+BEFORE UPDATE ON product_index_locale_refresh_ledger
+FOR EACH ROW
+EXECUTE FUNCTION rustok_product_reject_index_locale_refresh_ledger_mutation();
+
+CREATE TRIGGER trg_product_index_locale_refresh_ledger_delete
+BEFORE DELETE ON product_index_locale_refresh_ledger
+FOR EACH ROW
+EXECUTE FUNCTION rustok_product_reject_index_locale_refresh_ledger_mutation();
+"#,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() != DatabaseBackend::Postgres {
+            return Err(DbErr::Custom(
+                "rustok-product migrations require PostgreSQL".to_owned(),
+            ));
+        }
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+DROP TRIGGER IF EXISTS trg_product_index_locale_refresh_ledger_delete
+    ON product_index_locale_refresh_ledger;
+DROP TRIGGER IF EXISTS trg_product_index_locale_refresh_ledger_update
+    ON product_index_locale_refresh_ledger;
+DROP TABLE IF EXISTS product_index_locale_refresh_ledger;
+DROP FUNCTION IF EXISTS rustok_product_reject_index_locale_refresh_ledger_mutation();
+"#,
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/crates/rustok-product/src/migrations/mod.rs
+++ b/crates/rustok-product/src/migrations/mod.rs
@@ -26,6 +26,7 @@ mod m20260730_000001_add_product_index_revision;
 mod m20260730_000002_add_product_variant_index_revision;
 mod m20260731_000003_bump_product_index_revision_for_variant_membership;
 mod m20260731_000004_add_product_index_tombstones;
+mod m20260806_000005_add_product_index_locale_refresh_ledger;
 
 use rustok_core::MigrationDependencyDescriptor;
 use sea_orm_migration::MigrationTrait;
@@ -58,6 +59,7 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260730_000002_add_product_variant_index_revision::Migration),
         Box::new(m20260731_000003_bump_product_index_revision_for_variant_membership::Migration),
         Box::new(m20260731_000004_add_product_index_tombstones::Migration),
+        Box::new(m20260806_000005_add_product_index_locale_refresh_ledger::Migration),
     ]
 }
 

--- a/crates/rustok-product/src/services/index_refresh.rs
+++ b/crates/rustok-product/src/services/index_refresh.rs
@@ -1,0 +1,289 @@
+use rustok_events::DomainEvent;
+use sea_orm::{
+    ConnectionTrait, DatabaseBackend, DatabaseConnection, DatabaseTransaction, DbBackend, Statement,
+};
+use uuid::Uuid;
+
+use crate::error::{CommerceError, CommerceResult};
+
+pub const MAX_PRODUCT_INDEX_LOCALE_REFRESH_PAGE: usize = 256;
+const MAX_PRODUCT_INDEX_LOCALE_TARGETS_PER_EVENT: usize = 256;
+
+/// One immutable Product-owned instruction to refresh an exact localized Index identity.
+///
+/// `refresh_id` is reserved as the future typed event and inbox identity. `root_event_id`
+/// preserves causation to the existing Product lifecycle envelope. The payload is intentionally
+/// thin: the Product PostgreSQL source remains authoritative for the actual upsert or tombstone.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProductIndexLocaleRefreshRecord {
+    sequence_no: i64,
+    refresh_id: Uuid,
+    root_event_id: Uuid,
+    tenant_id: Uuid,
+    product_id: Uuid,
+    locale: String,
+    source_version: u64,
+}
+
+impl ProductIndexLocaleRefreshRecord {
+    pub fn sequence_no(&self) -> i64 {
+        self.sequence_no
+    }
+
+    pub fn refresh_id(&self) -> Uuid {
+        self.refresh_id
+    }
+
+    pub fn root_event_id(&self) -> Uuid {
+        self.root_event_id
+    }
+
+    pub fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub fn product_id(&self) -> Uuid {
+        self.product_id
+    }
+
+    pub fn locale(&self) -> &str {
+        self.locale.as_str()
+    }
+
+    pub fn source_version(&self) -> u64 {
+        self.source_version
+    }
+}
+
+/// Bounded Product-owned reader used by a future relay/consumer composition.
+///
+/// The reader exposes no Product payload and performs no Index write. Callers page one tenant by
+/// the append-only sequence and later resolve canonical state through the registered Product source.
+#[derive(Clone)]
+pub struct ProductIndexLocaleRefreshSource {
+    db: DatabaseConnection,
+}
+
+impl ProductIndexLocaleRefreshSource {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    pub async fn list(
+        &self,
+        tenant_id: Uuid,
+        after_sequence_no: i64,
+        limit: usize,
+    ) -> CommerceResult<Vec<ProductIndexLocaleRefreshRecord>> {
+        if tenant_id.is_nil() {
+            return Err(CommerceError::Validation(
+                "Product Index refresh tenant must not be nil".to_owned(),
+            ));
+        }
+        if after_sequence_no < 0 {
+            return Err(CommerceError::Validation(
+                "Product Index refresh cursor must not be negative".to_owned(),
+            ));
+        }
+        if !(1..=MAX_PRODUCT_INDEX_LOCALE_REFRESH_PAGE).contains(&limit) {
+            return Err(CommerceError::Validation(format!(
+                "Product Index refresh page size must be between 1 and {MAX_PRODUCT_INDEX_LOCALE_REFRESH_PAGE}"
+            )));
+        }
+        if self.db.get_database_backend() != DatabaseBackend::Postgres {
+            return Err(CommerceError::Validation(
+                "Product Index locale refresh source requires PostgreSQL".to_owned(),
+            ));
+        }
+
+        let rows = self
+            .db
+            .query_all(Statement::from_sql_and_values(
+                DbBackend::Postgres,
+                r#"
+                SELECT
+                    sequence_no,
+                    refresh_id,
+                    root_event_id,
+                    tenant_id,
+                    product_id,
+                    locale,
+                    source_version
+                FROM product_index_locale_refresh_ledger
+                WHERE tenant_id = $1
+                  AND sequence_no > $2
+                ORDER BY sequence_no ASC
+                LIMIT $3
+                "#,
+                vec![
+                    tenant_id.into(),
+                    after_sequence_no.into(),
+                    (limit as i64).into(),
+                ],
+            ))
+            .await?;
+
+        rows.into_iter()
+            .map(|row| {
+                let sequence_no: i64 = row.try_get("", "sequence_no")?;
+                let refresh_id: Uuid = row.try_get("", "refresh_id")?;
+                let root_event_id: Uuid = row.try_get("", "root_event_id")?;
+                let row_tenant_id: Uuid = row.try_get("", "tenant_id")?;
+                let product_id: Uuid = row.try_get("", "product_id")?;
+                let locale: String = row.try_get("", "locale")?;
+                let source_version: i64 = row.try_get("", "source_version")?;
+                let source_version = u64::try_from(source_version).map_err(|_| {
+                    CommerceError::Validation(
+                        "Product Index refresh source version must be positive".to_owned(),
+                    )
+                })?;
+
+                if sequence_no <= 0
+                    || refresh_id.is_nil()
+                    || root_event_id.is_nil()
+                    || row_tenant_id != tenant_id
+                    || product_id.is_nil()
+                    || locale.trim().is_empty()
+                    || locale.len() > 128
+                    || source_version == 0
+                {
+                    return Err(CommerceError::Validation(
+                        "Product Index refresh source returned an invalid ledger row".to_owned(),
+                    ));
+                }
+
+                Ok(ProductIndexLocaleRefreshRecord {
+                    sequence_no,
+                    refresh_id,
+                    root_event_id,
+                    tenant_id: row_tenant_id,
+                    product_id,
+                    locale,
+                    source_version,
+                })
+            })
+            .collect()
+    }
+}
+
+pub(crate) fn product_locale_refresh_target(event: &DomainEvent) -> Option<Uuid> {
+    match event {
+        DomainEvent::ProductCreated { product_id }
+        | DomainEvent::ProductUpdated { product_id }
+        | DomainEvent::ProductPublished { product_id }
+        | DomainEvent::ProductDeleted { product_id } => Some(*product_id),
+        _ => None,
+    }
+}
+
+/// Captures the canonical live and retained-delete state after one Product owner command.
+///
+/// Live locales use the final trigger-owned `products.index_revision`. Deleted locales use their
+/// exact retained tombstone revision. Historical tombstones may be emitted again by a later Product
+/// event; that is safe because the eventual Index worker applies source-version monotonicity while
+/// the per-row `refresh_id` preserves delivery deduplication.
+pub(crate) async fn record_product_locale_refreshes_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    product_id: Uuid,
+    root_event_id: Uuid,
+) -> CommerceResult<()> {
+    if txn.get_database_backend() != DatabaseBackend::Postgres {
+        return Ok(());
+    }
+    if tenant_id.is_nil() || product_id.is_nil() || root_event_id.is_nil() {
+        return Err(CommerceError::Validation(
+            "Product Index locale refresh identity must not be nil".to_owned(),
+        ));
+    }
+
+    let rows = txn
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+            WITH live_locales AS (
+                SELECT
+                    translation.locale AS locale,
+                    product.index_revision AS source_version
+                FROM product_translations translation
+                JOIN products product
+                  ON product.tenant_id = translation.tenant_id
+                 AND product.id = translation.product_id
+                WHERE translation.tenant_id = $1
+                  AND translation.product_id = $2
+            ),
+            retained_locales AS (
+                SELECT
+                    tombstone.locale AS locale,
+                    tombstone.source_version AS source_version
+                FROM product_index_tombstones tombstone
+                WHERE tombstone.tenant_id = $1
+                  AND tombstone.product_id = $2
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM product_translations translation
+                      WHERE translation.tenant_id = tombstone.tenant_id
+                        AND translation.product_id = tombstone.product_id
+                        AND translation.locale = tombstone.locale
+                  )
+            ),
+            exact_targets AS (
+                SELECT locale, source_version FROM live_locales
+                UNION ALL
+                SELECT locale, source_version FROM retained_locales
+            )
+            SELECT locale, source_version
+            FROM exact_targets
+            ORDER BY locale ASC
+            LIMIT $3
+            "#,
+            vec![
+                tenant_id.into(),
+                product_id.into(),
+                ((MAX_PRODUCT_INDEX_LOCALE_TARGETS_PER_EVENT + 1) as i64).into(),
+            ],
+        ))
+        .await?;
+
+    if rows.len() > MAX_PRODUCT_INDEX_LOCALE_TARGETS_PER_EVENT {
+        return Err(CommerceError::Validation(format!(
+            "Product Index locale refresh target count exceeds {MAX_PRODUCT_INDEX_LOCALE_TARGETS_PER_EVENT}"
+        )));
+    }
+
+    for row in rows {
+        let locale: String = row.try_get("", "locale")?;
+        let source_version: i64 = row.try_get("", "source_version")?;
+        if locale.trim().is_empty() || locale.len() > 128 || source_version <= 0 {
+            return Err(CommerceError::Validation(
+                "Product Index locale refresh source returned an invalid target".to_owned(),
+            ));
+        }
+
+        txn.execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+            INSERT INTO product_index_locale_refresh_ledger (
+                refresh_id,
+                root_event_id,
+                tenant_id,
+                product_id,
+                locale,
+                source_version,
+                created_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, CURRENT_TIMESTAMP)
+            "#,
+            vec![
+                Uuid::new_v4().into(),
+                root_event_id.into(),
+                tenant_id.into(),
+                product_id.into(),
+                locale.into(),
+                source_version.into(),
+            ],
+        ))
+        .await?;
+    }
+
+    Ok(())
+}

--- a/crates/rustok-product/src/services/mod.rs
+++ b/crates/rustok-product/src/services/mod.rs
@@ -1,6 +1,7 @@
 pub mod catalog;
 pub mod catalog_schema;
 pub mod catalog_schema_service;
+mod index_refresh;
 mod write_transaction;
 
 pub use catalog::{
@@ -10,3 +11,7 @@ pub use catalog::{
 };
 pub use catalog_schema::*;
 pub use catalog_schema_service::*;
+pub use index_refresh::{
+    MAX_PRODUCT_INDEX_LOCALE_REFRESH_PAGE, ProductIndexLocaleRefreshRecord,
+    ProductIndexLocaleRefreshSource,
+};

--- a/crates/rustok-product/src/services/write_transaction.rs
+++ b/crates/rustok-product/src/services/write_transaction.rs
@@ -1,6 +1,11 @@
 use std::ops::Deref;
 
-use crate::error::CommerceResult;
+use crate::{
+    error::CommerceResult,
+    services::index_refresh::{
+        product_locale_refresh_target, record_product_locale_refreshes_in_tx,
+    },
+};
 use rustok_events::DomainEvent;
 use rustok_outbox::TransactionalEventBus;
 use sea_orm::{
@@ -36,9 +41,25 @@ impl ProductWriteTransaction {
         actor_id: Option<Uuid>,
         event: DomainEvent,
     ) -> CommerceResult<()> {
-        self.event_bus
-            .publish_in_tx(&self.transaction, tenant_id, actor_id, event)
+        let product_id = product_locale_refresh_target(&event);
+        let root_event_id = self
+            .event_bus
+            .publish_in_tx_with_envelope_id(&self.transaction, tenant_id, actor_id, event)
             .await?;
+
+        if let Some(product_id) = product_id {
+            // Capture the exact post-command Product source state in the same
+            // transaction as the durable root event. Any source/ledger failure
+            // rolls back both the owner mutation and its event publication.
+            record_product_locale_refreshes_in_tx(
+                &self.transaction,
+                tenant_id,
+                product_id,
+                root_event_id,
+            )
+            .await?;
+        }
+
         Ok(())
     }
 

--- a/scripts/verify/verify-index-product-locale-refresh-ledger.mjs
+++ b/scripts/verify/verify-index-product-locale-refresh-ledger.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-locale-refresh-ledger] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const migrationPath =
+  'crates/rustok-product/src/migrations/m20260806_000005_add_product_index_locale_refresh_ledger.rs';
+const migration = requireMarkers(migrationPath, [
+  'CREATE TABLE product_index_locale_refresh_ledger',
+  'sequence_no BIGSERIAL NOT NULL',
+  'refresh_id UUID NOT NULL',
+  'root_event_id UUID NOT NULL',
+  'UNIQUE (root_event_id, product_id, locale)',
+  'UNIQUE (tenant_id, sequence_no)',
+  'CHECK (source_version > 0)',
+  'product Index locale refresh ledger is append-only',
+  'BEFORE UPDATE ON product_index_locale_refresh_ledger',
+  'BEFORE DELETE ON product_index_locale_refresh_ledger',
+]);
+if (migration.includes('REFERENCES products')) {
+  fail(`${migrationPath} must retain hard-delete identities without a live Product foreign key`);
+}
+
+requireMarkers('crates/rustok-product/src/migrations/mod.rs', [
+  'mod m20260806_000005_add_product_index_locale_refresh_ledger;',
+  'Box::new(m20260806_000005_add_product_index_locale_refresh_ledger::Migration)',
+]);
+
+const sourcePath = 'crates/rustok-product/src/services/index_refresh.rs';
+const source = requireMarkers(sourcePath, [
+  'MAX_PRODUCT_INDEX_LOCALE_REFRESH_PAGE: usize = 256',
+  'MAX_PRODUCT_INDEX_LOCALE_TARGETS_PER_EVENT: usize = 256',
+  'pub struct ProductIndexLocaleRefreshRecord',
+  'pub struct ProductIndexLocaleRefreshSource',
+  'sequence_no > $2',
+  'ORDER BY sequence_no ASC',
+  'LIMIT $3',
+  'pub(crate) fn product_locale_refresh_target',
+  'DomainEvent::ProductCreated',
+  'DomainEvent::ProductUpdated',
+  'DomainEvent::ProductPublished',
+  'DomainEvent::ProductDeleted',
+  'product_translations translation',
+  'products product',
+  'product_index_tombstones tombstone',
+  'NOT EXISTS',
+  'product.index_revision AS source_version',
+  'tombstone.source_version AS source_version',
+  'MAX_PRODUCT_INDEX_LOCALE_TARGETS_PER_EVENT + 1',
+  'INSERT INTO product_index_locale_refresh_ledger',
+  'Uuid::new_v4()',
+]);
+for (const forbidden of [
+  'rustok_index',
+  'IndexMutation',
+  'index_entities',
+  'index_links',
+  'tokio::spawn',
+  'sleep(',
+]) {
+  if (source.includes(forbidden)) {
+    fail(`${sourcePath} contains forbidden Index/runtime coupling: ${forbidden}`);
+  }
+}
+
+const transactionPath = 'crates/rustok-product/src/services/write_transaction.rs';
+const transaction = requireMarkers(transactionPath, [
+  'product_locale_refresh_target(&event)',
+  '.publish_in_tx_with_envelope_id(',
+  'record_product_locale_refreshes_in_tx(',
+  'root_event_id',
+  'rolls back both the owner mutation and its event publication',
+]);
+const publishPosition = transaction.indexOf('.publish_in_tx_with_envelope_id(');
+const recordPosition = transaction.indexOf('record_product_locale_refreshes_in_tx(');
+if (publishPosition < 0 || recordPosition <= publishPosition) {
+  fail(`${transactionPath} must retain the root event UUID before recording refresh rows`);
+}
+
+requireMarkers('crates/rustok-product/src/services/mod.rs', [
+  'mod index_refresh;',
+  'ProductIndexLocaleRefreshRecord',
+  'ProductIndexLocaleRefreshSource',
+]);
+requireMarkers('crates/rustok-product/src/lib.rs', [
+  'MAX_PRODUCT_INDEX_LOCALE_REFRESH_PAGE',
+  'ProductIndexLocaleRefreshRecord',
+  'ProductIndexLocaleRefreshSource',
+]);
+
+const cargo = read('crates/rustok-product/Cargo.toml');
+if (cargo.includes('rustok-index')) {
+  fail('rustok-product must not depend on rustok-index');
+}
+
+requireMarkers('crates/rustok-product/docs/index-locale-refresh-ledger.md', [
+  'Status: `owner_source_complete_wire_and_consumer_pending`',
+  '`refresh_id`, reserved as the future typed event and Index inbox identity',
+  '`root_event_id`, the exact durable Product lifecycle envelope',
+  'final positive `products.index_revision`',
+  '`product_index_tombstones.source_version`',
+  '`ProductIndexLocaleRefreshSource::list` exposes at most 256 rows',
+  'does not add or change a `rustok-events` wire family',
+  'ProductVariant requires a separate owner slice',
+  'No validation command or database scenario was executed',
+]);
+
+console.log('[verify-index-product-locale-refresh-ledger] Product locale owner ledger contract verified');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -59,6 +59,7 @@ const scripts = [
   'verify-index-replay-retry-store.mjs',
   'verify-index-replay-dead-letter-admission.mjs',
   'verify-index-product-source.mjs',
+  'verify-index-product-locale-refresh-ledger.mjs',
   'verify-index-product-variant-source.mjs',
   'verify-index-product-graph-source.mjs',
   'verify-index-product-tombstone-source.mjs',


### PR DESCRIPTION
## Summary

Retain exact Product locale refresh identities and trigger-owned source revisions in one append-only owner ledger.

- add PostgreSQL `product_index_locale_refresh_ledger` with tenant-local sequence paging, unique refresh UUIDs, causal root-event UUIDs, exact Product/locale identity, positive source version, non-nil identity checks, and update/delete rejection;
- keep hard-delete identities independent from live Product foreign keys;
- change `ProductWriteTransaction::publish` to retain the existing root event envelope UUID and capture locale refresh rows in the same owner transaction;
- read live translations at the final `products.index_revision` and removed/hard-deleted locales at the retained `product_index_tombstones.source_version`;
- bound one Product event to at most 256 exact locale targets with one-row lookahead;
- expose `ProductIndexLocaleRefreshSource::list` as a PostgreSQL-only, tenant-scoped, sequence-paged owner API with fail-closed row validation;
- add documentation, live-plan status, a fail-closed static verifier, and aggregate verifier registration.

## Transaction boundary

For `ProductCreated`, `ProductUpdated`, `ProductPublished`, and `ProductDeleted`, the owner transaction now:

1. writes the existing root event to the transactional outbox;
2. retains its exact envelope UUID;
3. reads the post-trigger live/tombstone locale state;
4. appends exact refresh rows causally linked to that root event;
5. commits the Product mutation, root event, and ledger together.

Any source query or ledger insert failure rolls back the complete owner transaction.

## Ownership

`rustok-product` still does not depend on `rustok-index` and does not construct `IndexMutation` values. The ledger contains only Product-owned identities, revisions, causation, and paging state. A later distribution/consumer slice will convert each row into the generic exact-source refresh boundary.

## Deliberate limits

This PR does not:

- change the public `rustok-events` wire schema or committed digest artifact;
- publish typed Product locale refresh events;
- register the Product v2 mutation route;
- start a relay or broker consumer;
- acknowledge deliveries or add retry/DLQ policy;
- implement ProductVariant refresh ownership;
- expose public HTTP, GraphQL, or admin transport;
- alter or bypass the concrete-repair evidence gate.

ProductVariant remains separate because its retained tombstone currently lacks the parent `product_id` needed for parent-scoped change enumeration.

The primary cursor remains `M6 - execute and admit concrete repair evidence`.

## Main recheck

The branch is one commit ahead of `main@e2f947466ef9fc9ebb08a1d6e3d4ccb9fe1d17ba` with exactly 11 changed files. The intervening Commerce compensation commit does not overlap this slice.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL/SQLite scenarios, workflows, or CI were run.