### PR TITLE
feat(product): retain ProductVariant Index refresh ledger

### DIFF
--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-03.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-03.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-03
 
-Status overlay rechecked against current `main` after exact source-refresh worker merge #3106 and
-active branch `agent/index-m5-product-locale-refresh-ledger-20260806`.
+Status overlay rechecked against current `main` after Product locale owner ledger merge #3111 and
+active branch `agent/index-m5-product-variant-refresh-ledger-20260806`.
 
 When this dated overlay conflicts with the older canonical plan, this file is the current source of
 truth. Historical architecture and milestone context remain in `implementation-plan.md`.
@@ -43,12 +43,19 @@ or tombstone at or beyond the event fence, rebinds the canonical mutation to the
 durably applies it, and only then acknowledges.
 
 A third independent M5 slice makes Product locale owner changes recoverable before the public wire
-contract exists. Product lifecycle publication now retains the exact root envelope UUID and writes
+contract exists. Product lifecycle publication retains the exact root envelope UUID and writes
 bounded append-only `(tenant, product, locale, source_version)` refresh rows in the same transaction.
 Live rows use final trigger-owned Product revisions; removed locales and hard deletes use retained
 tombstone revisions. A bounded Product-owned source exposes the ledger without importing Index.
-Typed Product events, route registration, relay/consumer composition, and ProductVariant ownership
-remain open. This source-only work does not advance or bypass the repair evidence cursor.
+
+A fourth independent M5 slice adds forward parent identity to ProductVariant tombstones and one
+append-only ProductVariant refresh ledger. Product lifecycle publication now records exact live and
+parent-aware retained variant identities in the same owner transaction as the root event and locale
+ledger. Live rows use final trigger-owned variant revisions; deletes use retained tombstone revisions.
+Historical parentless tombstones remain replayable but are excluded from incremental publication
+because their Product causation cannot be reconstructed safely. Typed Product/ProductVariant events,
+route registration, relay/consumer composition, and runtime evidence remain open. These source-only
+slices do not advance or bypass the repair evidence cursor.
 
 Concrete missing-entity repair:
 
@@ -92,6 +99,8 @@ remain open.
 - M5 exact source-refresh event worker:
   `source_complete_owner_event_publication_and_runtime_wiring_pending`
 - M5 Product locale append-only refresh owner ledger and bounded owner source:
+  `owner_source_complete_wire_and_consumer_pending`
+- M5 ProductVariant parent-aware tombstones, append-only refresh ledger, and bounded owner source:
   `owner_source_complete_wire_and_consumer_pending`
 - M5 Social Graph bounded replay source and exact production event route:
   `source_complete_runtime_execution_pending`
@@ -143,12 +152,14 @@ remain open.
 - [x] Retain exact Product locale identities and owner revisions in an append-only transactional
       ledger causally linked to the existing Product lifecycle envelope.
 - [x] Expose the Product locale ledger through one bounded tenant/sequence owner source.
-- [ ] Define the reviewed Product locale refresh event family and update the committed release
-      digests through the canonical generator.
-- [ ] Relay Product locale rows as typed write-once events with `refresh_id` envelope identity.
-- [ ] Register the Product locale production route and concrete consumer/acknowledger.
-- [ ] Add ProductVariant parent identity to retained tombstones and implement the equivalent owner
-      ledger, typed event, route, and consumer path.
+- [x] Retain ProductVariant parent identity for new tombstones and append exact live/delete variant
+      revisions to a Product-scoped owner ledger in the root Product transaction.
+- [x] Expose the ProductVariant ledger through one bounded tenant/sequence owner source.
+- [ ] Define reviewed Product locale and ProductVariant refresh event families and update committed
+      release digests through the canonical generator.
+- [ ] Relay Product locale and ProductVariant rows as typed write-once events with the retained
+      `refresh_id` envelope identities.
+- [ ] Register Product locale and ProductVariant production routes and concrete consumers.
 - [ ] Add equivalent concrete consumer policy for every remaining selected owner route.
 - [ ] Retain crash-between-commit-and-ack and redelivery evidence against the generic registered
       route boundary.
@@ -228,9 +239,10 @@ remain open.
 - [x] Add Product-to-ProductVariant graph materialization.
 - [x] Add the generic exact-source refresh worker required by Product/ProductVariant notifications.
 - [x] Add Product locale append-only owner refresh publication and bounded owner source.
-- [ ] Add Product locale typed event, production route, relay, and concrete incremental consumer.
-- [ ] Add ProductVariant parent-aware tombstones, owner refresh publication, typed event, route, and
-      concrete incremental consumer.
+- [x] Add ProductVariant parent-aware tombstones, append-only owner refresh publication, and bounded
+      owner source for live and retained-delete identities.
+- [ ] Add Product/ProductVariant typed events, production routes, relays, and concrete incremental
+      consumers.
 - [ ] Persist and enforce per-tenant schema readiness.
 - [ ] Complete durable Product-to-SalesChannel relation semantics and retained evidence.
 - [ ] Admit tombstone purge, freshness/outage/restart/backlog recovery, and delete/recreate evidence.
@@ -254,14 +266,15 @@ The owner must run the locked capture command from a clean commit. The retained 
 - normal full-mutation versus exact edge-owner serialization results;
 - complete credential-redacted stdout/stderr and final pass status.
 
-Independent source-only work may continue on the Product locale typed relay, ProductVariant owner
-identity, and remaining M5/M7 owner routes, but public repair authorization transport, automatic
-iteration, time-derived leases, and lifecycle auto-resolution remain blocked until admission.
+Independent source-only work may continue on the Product/ProductVariant typed relay and remaining
+M5/M7 owner routes, but public repair authorization transport, automatic iteration, time-derived
+leases, and lifecycle auto-resolution remain blocked until admission.
 
 ## Owner verification for current source boundaries
 
 ```bash
 node scripts/verify/verify-index-product-locale-refresh-ledger.mjs
+node scripts/verify/verify-index-product-variant-refresh-ledger.mjs
 cargo check -p rustok-product --all-targets
 
 cargo test -p rustok-index source_refresh_event --lib -- --nocapture

--- a/crates/rustok-product/docs/index-variant-refresh-ledger.md
+++ b/crates/rustok-product/docs/index-variant-refresh-ledger.md
@@ -1,0 +1,93 @@
+# ProductVariant Index refresh ledger
+
+Status: `owner_source_complete_wire_and_consumer_pending`.
+
+## Purpose
+
+ProductVariant replay already uses the trigger-owned `product_variants.index_revision`, but retained
+variant tombstones previously stored only `(tenant_id, variant_id, source_version)`. After physical
+deletion that was insufficient to enumerate the exact variants affected by one Product owner event.
+
+This slice adds forward-only parent identity to ProductVariant tombstones and one append-only owner
+refresh ledger. It remains a Product boundary: `rustok-product` does not depend on `rustok-index`,
+does not create `IndexMutation` values, and does not acknowledge broker deliveries.
+
+## Parent-aware tombstones
+
+New or subsequently rewritten rows in `product_variant_index_tombstones` retain `product_id` together
+with the existing tenant, variant and source version. Delete and identity-move triggers capture the
+old parent before the live row disappears.
+
+Historical tombstones created before this migration keep `product_id = NULL`. They remain valid for
+bounded replay by exact variant identity, but they are excluded from parent-scoped incremental
+publication because their Product causation cannot be reconstructed safely. Reconciliation remains
+the recovery path for those rows.
+
+The tombstone table intentionally has no live Product foreign key so a hard-deleted Product and its
+variants remain replayable.
+
+## Ledger row contract
+
+`product_variant_index_refresh_ledger` stores:
+
+- tenant-local monotonic `sequence_no`;
+- deterministic `refresh_id` derived from tenant, Product, root event and variant identity;
+- `root_event_id`, the exact durable Product lifecycle envelope;
+- exact `tenant_id`, parent `product_id`, and `variant_id`;
+- positive trigger-owned `source_version`;
+- owner timestamp for diagnostics only.
+
+The database rejects nil identities, non-positive versions, updates and deletes. One root Product
+event may record a variant at most once.
+
+## Transaction order
+
+For `ProductCreated`, `ProductUpdated`, `ProductPublished`, and `ProductDeleted`,
+`ProductWriteTransaction::publish` now:
+
+1. writes the existing root event through the transactional outbox;
+2. retains its exact envelope UUID;
+3. records Product locale refresh rows;
+4. records all live and parent-aware retained ProductVariant identities for that Product;
+5. allows the owner transaction to commit.
+
+Variant collection is set-based and scoped to one Product. It does not impose a new maximum variant
+count on existing catalog commands. Any query or ledger-write failure rolls back the Product mutation,
+root event, locale ledger and variant ledger together.
+
+## Live and delete versions
+
+Live variants use the final positive `product_variants.index_revision`. Removed variants use the
+positive `product_variant_index_tombstones.source_version` captured by the Product-owned trigger.
+A live variant suppresses a retained tombstone with the same tenant and variant identity.
+
+## Bounded owner API
+
+`ProductIndexVariantRefreshSource::list` returns at most 256 rows for one tenant after one
+non-negative sequence cursor. Every row is validated fail-closed before it leaves Product ownership.
+The API exposes only identity, revision, causation and paging state; ProductVariant payload remains
+owned by the registered replay/load source.
+
+## Deliberate limits
+
+This slice does not:
+
+- add or change a `rustok-events` wire family or committed digest;
+- publish typed ProductVariant refresh events;
+- register a ProductVariant mutation route;
+- start a relay or broker consumer;
+- add retry, DLQ or acknowledgement policy;
+- claim incremental coverage for historical parentless tombstones;
+- expose HTTP, GraphQL or admin transport;
+- alter or bypass the concrete-repair evidence gate.
+
+## Maintainer verification
+
+```bash
+node scripts/verify/verify-index-product-variant-refresh-ledger.mjs
+cargo check -p rustok-product --all-targets
+git diff --check
+```
+
+No tests, Node verifiers, Cargo checks, formatting, migrations, database scenarios, workflows or CI
+were executed by the implementation agent.

--- a/crates/rustok-product/src/lib.rs
+++ b/crates/rustok-product/src/lib.rs
@@ -30,9 +30,10 @@ pub use public_error::{ProductPublicError, map_product_public_error};
 pub use runtime::{ProductCatalogReadProfile, ProductCatalogReadRuntime};
 pub use services::{
     AdminProductList, AdminProductListItem, AdminProductListQuery, CatalogService,
-    MAX_PRODUCT_INDEX_LOCALE_REFRESH_PAGE, ProductAttributeFilter,
-    ProductCatalogSchemaService, ProductIndexLocaleRefreshRecord,
-    ProductIndexLocaleRefreshSource, StorefrontProductList, StorefrontProductListItem,
+    MAX_PRODUCT_INDEX_LOCALE_REFRESH_PAGE, MAX_PRODUCT_INDEX_VARIANT_REFRESH_PAGE,
+    ProductAttributeFilter, ProductCatalogSchemaService, ProductIndexLocaleRefreshRecord,
+    ProductIndexLocaleRefreshSource, ProductIndexVariantRefreshRecord,
+    ProductIndexVariantRefreshSource, StorefrontProductList, StorefrontProductListItem,
     StorefrontProductListQuery, StorefrontProductSortBy, StorefrontProductSortDirection,
 };
 

--- a/crates/rustok-product/src/migrations/m20260806_000006_add_product_variant_index_refresh_ledger.rs
+++ b/crates/rustok-product/src/migrations/m20260806_000006_add_product_variant_index_refresh_ledger.rs
@@ -1,0 +1,293 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::DatabaseBackend;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() != DatabaseBackend::Postgres {
+            return Err(DbErr::Custom(
+                "rustok-product migrations require PostgreSQL".to_owned(),
+            ));
+        }
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+ALTER TABLE product_variant_index_tombstones
+    ADD COLUMN product_id UUID NULL,
+    ADD CONSTRAINT chk_product_variant_index_tombstones_product_id_non_nil
+        CHECK (product_id IS NULL OR product_id <> '00000000-0000-0000-0000-000000000000'::uuid);
+
+CREATE INDEX idx_product_variant_index_tombstones_parent
+    ON product_variant_index_tombstones (
+        tenant_id,
+        product_id,
+        source_version DESC,
+        variant_id
+    )
+    WHERE product_id IS NOT NULL;
+
+CREATE TABLE product_variant_index_refresh_ledger (
+    sequence_no BIGSERIAL NOT NULL,
+    refresh_id UUID NOT NULL,
+    root_event_id UUID NOT NULL,
+    tenant_id UUID NOT NULL,
+    product_id UUID NOT NULL,
+    variant_id UUID NOT NULL,
+    source_version BIGINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_product_variant_index_refresh_ledger PRIMARY KEY (refresh_id),
+    CONSTRAINT uq_product_variant_index_refresh_root_target
+        UNIQUE (root_event_id, variant_id),
+    CONSTRAINT uq_product_variant_index_refresh_tenant_sequence
+        UNIQUE (tenant_id, sequence_no),
+    CONSTRAINT chk_product_variant_index_refresh_sequence_positive
+        CHECK (sequence_no > 0),
+    CONSTRAINT chk_product_variant_index_refresh_refresh_id_non_nil
+        CHECK (refresh_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CONSTRAINT chk_product_variant_index_refresh_root_event_id_non_nil
+        CHECK (root_event_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CONSTRAINT chk_product_variant_index_refresh_tenant_id_non_nil
+        CHECK (tenant_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CONSTRAINT chk_product_variant_index_refresh_product_id_non_nil
+        CHECK (product_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CONSTRAINT chk_product_variant_index_refresh_variant_id_non_nil
+        CHECK (variant_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CONSTRAINT chk_product_variant_index_refresh_source_version_positive
+        CHECK (source_version > 0)
+);
+
+CREATE INDEX idx_product_variant_index_refresh_target
+    ON product_variant_index_refresh_ledger (
+        tenant_id,
+        product_id,
+        variant_id,
+        source_version DESC,
+        sequence_no DESC
+    );
+
+CREATE OR REPLACE FUNCTION rustok_product_reject_variant_index_refresh_ledger_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'product variant Index refresh ledger is append-only';
+    RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER trg_product_variant_index_refresh_ledger_update
+BEFORE UPDATE ON product_variant_index_refresh_ledger
+FOR EACH ROW
+EXECUTE FUNCTION rustok_product_reject_variant_index_refresh_ledger_mutation();
+
+CREATE TRIGGER trg_product_variant_index_refresh_ledger_delete
+BEFORE DELETE ON product_variant_index_refresh_ledger
+FOR EACH ROW
+EXECUTE FUNCTION rustok_product_reject_variant_index_refresh_ledger_mutation();
+
+CREATE OR REPLACE FUNCTION rustok_product_variant_store_index_tombstone(
+    target_tenant_id UUID,
+    target_product_id UUID,
+    target_variant_id UUID,
+    target_source_version BIGINT
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF target_tenant_id IS NULL
+       OR target_tenant_id = '00000000-0000-0000-0000-000000000000'::uuid
+       OR target_product_id IS NULL
+       OR target_product_id = '00000000-0000-0000-0000-000000000000'::uuid
+       OR target_variant_id IS NULL
+       OR target_variant_id = '00000000-0000-0000-0000-000000000000'::uuid
+       OR target_source_version <= 0 THEN
+        RAISE EXCEPTION 'product variant tombstone identity and source version must be valid';
+    END IF;
+
+    INSERT INTO product_variant_index_tombstones (
+        tenant_id,
+        product_id,
+        variant_id,
+        source_version,
+        deleted_at
+    ) VALUES (
+        target_tenant_id,
+        target_product_id,
+        target_variant_id,
+        target_source_version,
+        CURRENT_TIMESTAMP
+    )
+    ON CONFLICT (tenant_id, variant_id) DO UPDATE
+    SET product_id = CASE
+            WHEN EXCLUDED.source_version >= product_variant_index_tombstones.source_version
+                THEN EXCLUDED.product_id
+            ELSE product_variant_index_tombstones.product_id
+        END,
+        source_version = GREATEST(
+            product_variant_index_tombstones.source_version,
+            EXCLUDED.source_version
+        ),
+        deleted_at = CURRENT_TIMESTAMP;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION rustok_product_variant_capture_index_tombstone()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.index_revision = 9223372036854775807 THEN
+        RAISE EXCEPTION 'product variant index revision exhausted for deleted variant %', OLD.id;
+    END IF;
+
+    PERFORM rustok_product_variant_store_index_tombstone(
+        OLD.tenant_id,
+        OLD.product_id,
+        OLD.id,
+        OLD.index_revision + 1
+    );
+    RETURN OLD;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION rustok_product_variant_move_index_tombstone()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.tenant_id IS NOT DISTINCT FROM NEW.tenant_id
+       AND OLD.id IS NOT DISTINCT FROM NEW.id THEN
+        RETURN NEW;
+    END IF;
+
+    PERFORM rustok_product_variant_store_index_tombstone(
+        OLD.tenant_id,
+        OLD.product_id,
+        OLD.id,
+        NEW.index_revision
+    );
+    PERFORM rustok_product_variant_clear_superseded_index_tombstone(
+        NEW.tenant_id,
+        NEW.id,
+        NEW.index_revision
+    );
+    RETURN NEW;
+END;
+$$;
+
+DROP FUNCTION rustok_product_variant_store_index_tombstone(UUID, UUID, BIGINT);
+"#,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() != DatabaseBackend::Postgres {
+            return Err(DbErr::Custom(
+                "rustok-product migrations require PostgreSQL".to_owned(),
+            ));
+        }
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+CREATE OR REPLACE FUNCTION rustok_product_variant_store_index_tombstone(
+    target_tenant_id UUID,
+    target_variant_id UUID,
+    target_source_version BIGINT
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    INSERT INTO product_variant_index_tombstones (
+        tenant_id,
+        variant_id,
+        source_version,
+        deleted_at
+    ) VALUES (
+        target_tenant_id,
+        target_variant_id,
+        target_source_version,
+        CURRENT_TIMESTAMP
+    )
+    ON CONFLICT (tenant_id, variant_id) DO UPDATE
+    SET source_version = GREATEST(
+            product_variant_index_tombstones.source_version,
+            EXCLUDED.source_version
+        ),
+        deleted_at = CURRENT_TIMESTAMP;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION rustok_product_variant_capture_index_tombstone()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.index_revision = 9223372036854775807 THEN
+        RAISE EXCEPTION 'product variant index revision exhausted for deleted variant %', OLD.id;
+    END IF;
+
+    PERFORM rustok_product_variant_store_index_tombstone(
+        OLD.tenant_id,
+        OLD.id,
+        OLD.index_revision + 1
+    );
+    RETURN OLD;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION rustok_product_variant_move_index_tombstone()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.tenant_id IS NOT DISTINCT FROM NEW.tenant_id
+       AND OLD.id IS NOT DISTINCT FROM NEW.id THEN
+        RETURN NEW;
+    END IF;
+
+    PERFORM rustok_product_variant_store_index_tombstone(
+        OLD.tenant_id,
+        OLD.id,
+        NEW.index_revision
+    );
+    PERFORM rustok_product_variant_clear_superseded_index_tombstone(
+        NEW.tenant_id,
+        NEW.id,
+        NEW.index_revision
+    );
+    RETURN NEW;
+END;
+$$;
+
+DROP FUNCTION rustok_product_variant_store_index_tombstone(UUID, UUID, UUID, BIGINT);
+
+DROP TRIGGER IF EXISTS trg_product_variant_index_refresh_ledger_delete
+    ON product_variant_index_refresh_ledger;
+DROP TRIGGER IF EXISTS trg_product_variant_index_refresh_ledger_update
+    ON product_variant_index_refresh_ledger;
+DROP TABLE IF EXISTS product_variant_index_refresh_ledger;
+DROP FUNCTION IF EXISTS rustok_product_reject_variant_index_refresh_ledger_mutation();
+
+DROP INDEX IF EXISTS idx_product_variant_index_tombstones_parent;
+ALTER TABLE product_variant_index_tombstones
+    DROP CONSTRAINT IF EXISTS chk_product_variant_index_tombstones_product_id_non_nil,
+    DROP COLUMN IF EXISTS product_id;
+"#,
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/crates/rustok-product/src/migrations/mod.rs
+++ b/crates/rustok-product/src/migrations/mod.rs
@@ -27,6 +27,7 @@ mod m20260730_000002_add_product_variant_index_revision;
 mod m20260731_000003_bump_product_index_revision_for_variant_membership;
 mod m20260731_000004_add_product_index_tombstones;
 mod m20260806_000005_add_product_index_locale_refresh_ledger;
+mod m20260806_000006_add_product_variant_index_refresh_ledger;
 
 use rustok_core::MigrationDependencyDescriptor;
 use sea_orm_migration::MigrationTrait;
@@ -60,6 +61,7 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260731_000003_bump_product_index_revision_for_variant_membership::Migration),
         Box::new(m20260731_000004_add_product_index_tombstones::Migration),
         Box::new(m20260806_000005_add_product_index_locale_refresh_ledger::Migration),
+        Box::new(m20260806_000006_add_product_variant_index_refresh_ledger::Migration),
     ]
 }
 

--- a/crates/rustok-product/src/services/index_refresh.rs
+++ b/crates/rustok-product/src/services/index_refresh.rs
@@ -7,6 +7,7 @@ use uuid::Uuid;
 use crate::error::{CommerceError, CommerceResult};
 
 pub const MAX_PRODUCT_INDEX_LOCALE_REFRESH_PAGE: usize = 256;
+pub const MAX_PRODUCT_INDEX_VARIANT_REFRESH_PAGE: usize = 256;
 const MAX_PRODUCT_INDEX_LOCALE_TARGETS_PER_EVENT: usize = 256;
 
 /// One immutable Product-owned instruction to refresh an exact localized Index identity.
@@ -75,26 +76,17 @@ impl ProductIndexLocaleRefreshSource {
         after_sequence_no: i64,
         limit: usize,
     ) -> CommerceResult<Vec<ProductIndexLocaleRefreshRecord>> {
-        if tenant_id.is_nil() {
-            return Err(CommerceError::Validation(
-                "Product Index refresh tenant must not be nil".to_owned(),
-            ));
-        }
-        if after_sequence_no < 0 {
-            return Err(CommerceError::Validation(
-                "Product Index refresh cursor must not be negative".to_owned(),
-            ));
-        }
-        if !(1..=MAX_PRODUCT_INDEX_LOCALE_REFRESH_PAGE).contains(&limit) {
-            return Err(CommerceError::Validation(format!(
-                "Product Index refresh page size must be between 1 and {MAX_PRODUCT_INDEX_LOCALE_REFRESH_PAGE}"
-            )));
-        }
-        if self.db.get_database_backend() != DatabaseBackend::Postgres {
-            return Err(CommerceError::Validation(
-                "Product Index locale refresh source requires PostgreSQL".to_owned(),
-            ));
-        }
+        validate_refresh_page(
+            tenant_id,
+            after_sequence_no,
+            limit,
+            MAX_PRODUCT_INDEX_LOCALE_REFRESH_PAGE,
+            "Product Index locale refresh",
+        )?;
+        ensure_postgres(
+            &self.db,
+            "Product Index locale refresh source requires PostgreSQL",
+        )?;
 
         let rows = self
             .db
@@ -131,12 +123,10 @@ impl ProductIndexLocaleRefreshSource {
                 let row_tenant_id: Uuid = row.try_get("", "tenant_id")?;
                 let product_id: Uuid = row.try_get("", "product_id")?;
                 let locale: String = row.try_get("", "locale")?;
-                let source_version: i64 = row.try_get("", "source_version")?;
-                let source_version = u64::try_from(source_version).map_err(|_| {
-                    CommerceError::Validation(
-                        "Product Index refresh source version must be positive".to_owned(),
-                    )
-                })?;
+                let source_version = positive_source_version(
+                    row.try_get("", "source_version")?,
+                    "Product Index locale refresh",
+                )?;
 
                 if sequence_no <= 0
                     || refresh_id.is_nil()
@@ -145,7 +135,6 @@ impl ProductIndexLocaleRefreshSource {
                     || product_id.is_nil()
                     || locale.trim().is_empty()
                     || locale.len() > 128
-                    || source_version == 0
                 {
                     return Err(CommerceError::Validation(
                         "Product Index refresh source returned an invalid ledger row".to_owned(),
@@ -159,6 +148,151 @@ impl ProductIndexLocaleRefreshSource {
                     tenant_id: row_tenant_id,
                     product_id,
                     locale,
+                    source_version,
+                })
+            })
+            .collect()
+    }
+}
+
+/// One immutable Product-owned instruction to refresh an exact ProductVariant Index identity.
+///
+/// The record deliberately includes the parent Product identity even though the ProductVariant
+/// schema key is the variant UUID. The parent is required to enumerate retained deletes after the
+/// live variant row has disappeared and to preserve Product graph causation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProductIndexVariantRefreshRecord {
+    sequence_no: i64,
+    refresh_id: Uuid,
+    root_event_id: Uuid,
+    tenant_id: Uuid,
+    product_id: Uuid,
+    variant_id: Uuid,
+    source_version: u64,
+}
+
+impl ProductIndexVariantRefreshRecord {
+    pub fn sequence_no(&self) -> i64 {
+        self.sequence_no
+    }
+
+    pub fn refresh_id(&self) -> Uuid {
+        self.refresh_id
+    }
+
+    pub fn root_event_id(&self) -> Uuid {
+        self.root_event_id
+    }
+
+    pub fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub fn product_id(&self) -> Uuid {
+        self.product_id
+    }
+
+    pub fn variant_id(&self) -> Uuid {
+        self.variant_id
+    }
+
+    pub fn source_version(&self) -> u64 {
+        self.source_version
+    }
+}
+
+/// Bounded Product-owned ProductVariant refresh reader.
+///
+/// Writers remain set-based and product-scoped so existing products are not assigned a new variant
+/// count limit. Relays consume the append-only ledger through tenant-local pages of at most 256 rows.
+#[derive(Clone)]
+pub struct ProductIndexVariantRefreshSource {
+    db: DatabaseConnection,
+}
+
+impl ProductIndexVariantRefreshSource {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    pub async fn list(
+        &self,
+        tenant_id: Uuid,
+        after_sequence_no: i64,
+        limit: usize,
+    ) -> CommerceResult<Vec<ProductIndexVariantRefreshRecord>> {
+        validate_refresh_page(
+            tenant_id,
+            after_sequence_no,
+            limit,
+            MAX_PRODUCT_INDEX_VARIANT_REFRESH_PAGE,
+            "ProductVariant Index refresh",
+        )?;
+        ensure_postgres(
+            &self.db,
+            "ProductVariant Index refresh source requires PostgreSQL",
+        )?;
+
+        let rows = self
+            .db
+            .query_all(Statement::from_sql_and_values(
+                DbBackend::Postgres,
+                r#"
+                SELECT
+                    sequence_no,
+                    refresh_id,
+                    root_event_id,
+                    tenant_id,
+                    product_id,
+                    variant_id,
+                    source_version
+                FROM product_variant_index_refresh_ledger
+                WHERE tenant_id = $1
+                  AND sequence_no > $2
+                ORDER BY sequence_no ASC
+                LIMIT $3
+                "#,
+                vec![
+                    tenant_id.into(),
+                    after_sequence_no.into(),
+                    (limit as i64).into(),
+                ],
+            ))
+            .await?;
+
+        rows.into_iter()
+            .map(|row| {
+                let sequence_no: i64 = row.try_get("", "sequence_no")?;
+                let refresh_id: Uuid = row.try_get("", "refresh_id")?;
+                let root_event_id: Uuid = row.try_get("", "root_event_id")?;
+                let row_tenant_id: Uuid = row.try_get("", "tenant_id")?;
+                let product_id: Uuid = row.try_get("", "product_id")?;
+                let variant_id: Uuid = row.try_get("", "variant_id")?;
+                let source_version = positive_source_version(
+                    row.try_get("", "source_version")?,
+                    "ProductVariant Index refresh",
+                )?;
+
+                if sequence_no <= 0
+                    || refresh_id.is_nil()
+                    || root_event_id.is_nil()
+                    || row_tenant_id != tenant_id
+                    || product_id.is_nil()
+                    || variant_id.is_nil()
+                {
+                    return Err(CommerceError::Validation(
+                        "ProductVariant Index refresh source returned an invalid ledger row"
+                            .to_owned(),
+                    ));
+                }
+
+                Ok(ProductIndexVariantRefreshRecord {
+                    sequence_no,
+                    refresh_id,
+                    root_event_id,
+                    tenant_id: row_tenant_id,
+                    product_id,
+                    variant_id,
                     source_version,
                 })
             })
@@ -191,11 +325,7 @@ pub(crate) async fn record_product_locale_refreshes_in_tx(
     if txn.get_database_backend() != DatabaseBackend::Postgres {
         return Ok(());
     }
-    if tenant_id.is_nil() || product_id.is_nil() || root_event_id.is_nil() {
-        return Err(CommerceError::Validation(
-            "Product Index locale refresh identity must not be nil".to_owned(),
-        ));
-    }
+    validate_refresh_identity(tenant_id, product_id, root_event_id, "Product Index locale refresh")?;
 
     let rows = txn
         .query_all(Statement::from_sql_and_values(
@@ -286,4 +416,159 @@ pub(crate) async fn record_product_locale_refreshes_in_tx(
     }
 
     Ok(())
+}
+
+/// Captures every live or retained ProductVariant identity for one Product after the owner command.
+///
+/// The statement is set-based and product-scoped. Live rows use the final trigger-owned variant
+/// revision. Deleted rows use the retained tombstone revision only when the tombstone has a known
+/// parent Product. Historical parentless tombstones remain replayable but are deliberately excluded
+/// from incremental publication because their Product causation cannot be reconstructed safely.
+pub(crate) async fn record_product_variant_refreshes_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    product_id: Uuid,
+    root_event_id: Uuid,
+) -> CommerceResult<()> {
+    if txn.get_database_backend() != DatabaseBackend::Postgres {
+        return Ok(());
+    }
+    validate_refresh_identity(
+        tenant_id,
+        product_id,
+        root_event_id,
+        "ProductVariant Index refresh",
+    )?;
+
+    txn.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+        WITH live_variants AS (
+            SELECT
+                variant.id AS variant_id,
+                variant.index_revision AS source_version
+            FROM product_variants variant
+            WHERE variant.tenant_id = $1
+              AND variant.product_id = $2
+        ),
+        retained_variants AS (
+            SELECT
+                tombstone.variant_id AS variant_id,
+                tombstone.source_version AS source_version
+            FROM product_variant_index_tombstones tombstone
+            WHERE tombstone.tenant_id = $1
+              AND tombstone.product_id = $2
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM product_variants variant
+                  WHERE variant.tenant_id = tombstone.tenant_id
+                    AND variant.id = tombstone.variant_id
+              )
+        ),
+        exact_targets AS (
+            SELECT variant_id, source_version FROM live_variants
+            UNION ALL
+            SELECT variant_id, source_version FROM retained_variants
+        ),
+        identified_targets AS (
+            SELECT
+                variant_id,
+                source_version,
+                md5(
+                    $1::text || ':' ||
+                    $2::text || ':' ||
+                    $3::text || ':' ||
+                    variant_id::text
+                ) AS identity_digest
+            FROM exact_targets
+        )
+        INSERT INTO product_variant_index_refresh_ledger (
+            refresh_id,
+            root_event_id,
+            tenant_id,
+            product_id,
+            variant_id,
+            source_version,
+            created_at
+        )
+        SELECT
+            (
+                substr(identity_digest, 1, 8) || '-' ||
+                substr(identity_digest, 9, 4) || '-' ||
+                substr(identity_digest, 13, 4) || '-' ||
+                substr(identity_digest, 17, 4) || '-' ||
+                substr(identity_digest, 21, 12)
+            )::uuid,
+            $3,
+            $1,
+            $2,
+            variant_id,
+            source_version,
+            CURRENT_TIMESTAMP
+        FROM identified_targets
+        ORDER BY variant_id ASC
+        "#,
+        vec![tenant_id.into(), product_id.into(), root_event_id.into()],
+    ))
+    .await?;
+
+    Ok(())
+}
+
+fn validate_refresh_page(
+    tenant_id: Uuid,
+    after_sequence_no: i64,
+    limit: usize,
+    maximum: usize,
+    boundary: &str,
+) -> CommerceResult<()> {
+    if tenant_id.is_nil() {
+        return Err(CommerceError::Validation(format!(
+            "{boundary} tenant must not be nil"
+        )));
+    }
+    if after_sequence_no < 0 {
+        return Err(CommerceError::Validation(format!(
+            "{boundary} cursor must not be negative"
+        )));
+    }
+    if !(1..=maximum).contains(&limit) {
+        return Err(CommerceError::Validation(format!(
+            "{boundary} page size must be between 1 and {maximum}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_refresh_identity(
+    tenant_id: Uuid,
+    product_id: Uuid,
+    root_event_id: Uuid,
+    boundary: &str,
+) -> CommerceResult<()> {
+    if tenant_id.is_nil() || product_id.is_nil() || root_event_id.is_nil() {
+        return Err(CommerceError::Validation(format!(
+            "{boundary} identity must not be nil"
+        )));
+    }
+    Ok(())
+}
+
+fn ensure_postgres(db: &DatabaseConnection, message: &str) -> CommerceResult<()> {
+    if db.get_database_backend() != DatabaseBackend::Postgres {
+        return Err(CommerceError::Validation(message.to_owned()));
+    }
+    Ok(())
+}
+
+fn positive_source_version(value: i64, boundary: &str) -> CommerceResult<u64> {
+    let value = u64::try_from(value).map_err(|_| {
+        CommerceError::Validation(format!("{boundary} source version must be positive"))
+    })?;
+    if value == 0 {
+        return Err(CommerceError::Validation(format!(
+            "{boundary} source version must be positive"
+        )));
+    }
+    Ok(value)
 }

--- a/crates/rustok-product/src/services/mod.rs
+++ b/crates/rustok-product/src/services/mod.rs
@@ -12,6 +12,7 @@ pub use catalog::{
 pub use catalog_schema::*;
 pub use catalog_schema_service::*;
 pub use index_refresh::{
-    MAX_PRODUCT_INDEX_LOCALE_REFRESH_PAGE, ProductIndexLocaleRefreshRecord,
-    ProductIndexLocaleRefreshSource,
+    MAX_PRODUCT_INDEX_LOCALE_REFRESH_PAGE, MAX_PRODUCT_INDEX_VARIANT_REFRESH_PAGE,
+    ProductIndexLocaleRefreshRecord, ProductIndexLocaleRefreshSource,
+    ProductIndexVariantRefreshRecord, ProductIndexVariantRefreshSource,
 };

--- a/crates/rustok-product/src/services/write_transaction.rs
+++ b/crates/rustok-product/src/services/write_transaction.rs
@@ -4,6 +4,7 @@ use crate::{
     error::CommerceResult,
     services::index_refresh::{
         product_locale_refresh_target, record_product_locale_refreshes_in_tx,
+        record_product_variant_refreshes_in_tx,
     },
 };
 use rustok_events::DomainEvent;
@@ -48,10 +49,17 @@ impl ProductWriteTransaction {
             .await?;
 
         if let Some(product_id) = product_id {
-            // Capture the exact post-command Product source state in the same
-            // transaction as the durable root event. Any source/ledger failure
-            // rolls back both the owner mutation and its event publication.
+            // Capture the exact post-command Product and ProductVariant source state.
+            // Any source/ledger failure rolls back both the owner mutation and its event publication.
+            // The same atomic boundary includes both refresh ledgers.
             record_product_locale_refreshes_in_tx(
+                &self.transaction,
+                tenant_id,
+                product_id,
+                root_event_id,
+            )
+            .await?;
+            record_product_variant_refreshes_in_tx(
                 &self.transaction,
                 tenant_id,
                 product_id,

--- a/scripts/verify/verify-index-product-variant-refresh-ledger.mjs
+++ b/scripts/verify/verify-index-product-variant-refresh-ledger.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-variant-refresh-ledger] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const migrationPath =
+  'crates/rustok-product/src/migrations/m20260806_000006_add_product_variant_index_refresh_ledger.rs';
+const migration = requireMarkers(migrationPath, [
+  'ALTER TABLE product_variant_index_tombstones',
+  'ADD COLUMN product_id UUID NULL',
+  'WHERE product_id IS NOT NULL',
+  'CREATE TABLE product_variant_index_refresh_ledger',
+  'sequence_no BIGSERIAL NOT NULL',
+  'UNIQUE (root_event_id, variant_id)',
+  'UNIQUE (tenant_id, sequence_no)',
+  'product variant Index refresh ledger is append-only',
+  'BEFORE UPDATE ON product_variant_index_refresh_ledger',
+  'BEFORE DELETE ON product_variant_index_refresh_ledger',
+  'target_product_id UUID',
+  'OLD.product_id',
+  'DROP FUNCTION rustok_product_variant_store_index_tombstone(UUID, UUID, BIGINT)',
+]);
+if (migration.includes('REFERENCES products')) {
+  fail(`${migrationPath} must preserve hard-delete identities without a live Product foreign key`);
+}
+
+requireMarkers('crates/rustok-product/src/migrations/mod.rs', [
+  'mod m20260806_000006_add_product_variant_index_refresh_ledger;',
+  'Box::new(m20260806_000006_add_product_variant_index_refresh_ledger::Migration)',
+]);
+
+const sourcePath = 'crates/rustok-product/src/services/index_refresh.rs';
+const source = requireMarkers(sourcePath, [
+  'MAX_PRODUCT_INDEX_VARIANT_REFRESH_PAGE: usize = 256',
+  'pub struct ProductIndexVariantRefreshRecord',
+  'pub struct ProductIndexVariantRefreshSource',
+  'FROM product_variant_index_refresh_ledger',
+  'sequence_no > $2',
+  'ORDER BY sequence_no ASC',
+  'LIMIT $3',
+  'record_product_variant_refreshes_in_tx',
+  'product_variants variant',
+  'product_variant_index_tombstones tombstone',
+  'tombstone.product_id = $2',
+  'NOT EXISTS',
+  'variant.index_revision AS source_version',
+  'tombstone.source_version AS source_version',
+  'md5(',
+  'INSERT INTO product_variant_index_refresh_ledger',
+  'Historical parentless tombstones remain replayable',
+]);
+for (const forbidden of [
+  'rustok_index',
+  'IndexMutation',
+  'index_entities',
+  'index_links',
+  'tokio::spawn',
+  'sleep(',
+]) {
+  if (source.includes(forbidden)) {
+    fail(`${sourcePath} contains forbidden Index/runtime coupling: ${forbidden}`);
+  }
+}
+
+const transactionPath = 'crates/rustok-product/src/services/write_transaction.rs';
+const transaction = requireMarkers(transactionPath, [
+  '.publish_in_tx_with_envelope_id(',
+  'record_product_locale_refreshes_in_tx(',
+  'record_product_variant_refreshes_in_tx(',
+  'root_event_id',
+  'rolls back both the owner mutation and its event publication',
+  'The same atomic boundary includes both refresh ledgers',
+]);
+const rootPosition = transaction.indexOf('.publish_in_tx_with_envelope_id(');
+const localePosition = transaction.indexOf('record_product_locale_refreshes_in_tx(');
+const variantPosition = transaction.indexOf('record_product_variant_refreshes_in_tx(');
+if (
+  rootPosition < 0 ||
+  localePosition <= rootPosition ||
+  variantPosition <= localePosition
+) {
+  fail(`${transactionPath} must publish root, record locale, then record variant rows`);
+}
+
+requireMarkers('crates/rustok-product/src/services/mod.rs', [
+  'MAX_PRODUCT_INDEX_VARIANT_REFRESH_PAGE',
+  'ProductIndexVariantRefreshRecord',
+  'ProductIndexVariantRefreshSource',
+]);
+requireMarkers('crates/rustok-product/src/lib.rs', [
+  'MAX_PRODUCT_INDEX_VARIANT_REFRESH_PAGE',
+  'ProductIndexVariantRefreshRecord',
+  'ProductIndexVariantRefreshSource',
+]);
+
+const cargo = read('crates/rustok-product/Cargo.toml');
+if (cargo.includes('rustok-index')) {
+  fail('rustok-product must not depend on rustok-index');
+}
+
+requireMarkers('crates/rustok-product/docs/index-variant-refresh-ledger.md', [
+  'Status: `owner_source_complete_wire_and_consumer_pending`',
+  'Historical tombstones created before this migration keep `product_id = NULL`',
+  '`refresh_id` derived from tenant, Product, root event and variant identity',
+  '`product_variants.index_revision`',
+  '`product_variant_index_tombstones.source_version`',
+  '`ProductIndexVariantRefreshSource::list` returns at most 256 rows',
+  'does not impose a new maximum variant count',
+  'does not add or change a `rustok-events` wire family',
+  'No tests, Node verifiers, Cargo checks',
+]);
+
+console.log('[verify-index-product-variant-refresh-ledger] ProductVariant owner ledger contract verified');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -60,6 +60,7 @@ const scripts = [
   'verify-index-replay-dead-letter-admission.mjs',
   'verify-index-product-source.mjs',
   'verify-index-product-locale-refresh-ledger.mjs',
+  'verify-index-product-variant-refresh-ledger.mjs',
   'verify-index-product-variant-source.mjs',
   'verify-index-product-graph-source.mjs',
   'verify-index-product-tombstone-source.mjs',


### PR DESCRIPTION
## Summary

Add forward parent identity to ProductVariant tombstones and retain exact live/delete variant refresh rows in the same Product owner transaction as the existing root event and locale ledger.

- add nullable `product_id` to retained ProductVariant tombstones for new and subsequently rewritten rows;
- keep historical parentless tombstones replayable while excluding them from false parent-scoped incremental publication;
- fence tombstone parent replacement by source version so an older replay cannot overwrite the parent attached to a newer retained revision;
- add append-only `product_variant_index_refresh_ledger` with deterministic refresh UUID, root-event causation, exact tenant/Product/variant identity, positive source revision, tenant-scoped sequence paging, and update/delete rejection;
- record live variants from final `product_variants.index_revision` and removed variants from parent-aware tombstones;
- keep writer collection set-based and Product-scoped without imposing a new maximum variant count;
- expose a fail-closed bounded `ProductIndexVariantRefreshSource::list` owner API;
- publish Product locale and ProductVariant owner rows atomically after the existing root outbox envelope;
- add documentation, live-plan status, static verification, and aggregate verifier registration.

## Transaction boundary

For `ProductCreated`, `ProductUpdated`, `ProductPublished`, and `ProductDeleted`, the owner transaction now:

1. writes the existing Product root event and retains its envelope UUID;
2. records exact Product locale refresh rows;
3. records exact live and parent-aware retained ProductVariant rows;
4. commits Product state, root event, locale ledger, and variant ledger together.

Any source or ledger failure rolls back the complete owner transaction.

## Historical tombstones

Existing ProductVariant tombstones cannot be reliably backfilled with a parent Product after the live row has disappeared. They remain valid for exact replay by variant identity with `product_id = NULL`, but are not promoted into parent-scoped incremental rows. Reconciliation remains their recovery path.

## Ownership

`rustok-product` still has no `rustok-index` dependency and creates no `IndexMutation`. The new API exposes only owner identity, source revision, causation, and bounded paging state.

## Deliberate limits

This PR does not:

- change a public `rustok-events` wire contract or committed digest;
- publish typed Product/ProductVariant refresh events;
- register mutation routes;
- start a relay or broker consumer;
- add retry, DLQ, or acknowledgement policy;
- claim incremental coverage for historical parentless tombstones;
- expose public HTTP, GraphQL, or admin transport;
- alter or bypass the concrete-repair evidence gate.

The primary cursor remains `M6 - execute and admit concrete repair evidence`.

## Main recheck

The branch is one commit ahead of `main@67edbf99020ca00f114acd353b3403af1cb73ea8` with exactly 10 changed files. Intervening registry-governance changes do not overlap this Product/Index slice.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL/SQLite scenarios, workflows, or CI were run.