### PR TITLE
feat(reactions): add transactional events and reconciliation

### DIFF
--- a/crates/rustok-events/CRATE_API.md
+++ b/crates/rustok-events/CRATE_API.md
@@ -13,6 +13,7 @@
 - `pub use crate::{ForumSearchProjectionEvent, FORUM_SEARCH_PROJECTION_EVENT_SCHEMAS}`
 - `pub use crate::{MarketplaceListingEvent, MARKETPLACE_LISTING_EVENT_SCHEMAS}`
 - `pub use crate::{MarketplaceSellerEvent, MARKETPLACE_SELLER_EVENT_SCHEMAS}`
+- `pub use crate::{ReactionsEvent, REACTIONS_EVENT_SCHEMAS}`
 - `pub use crate::{SocialGraphRelationEvent, SOCIAL_GRAPH_RELATION_EVENT_SCHEMAS}`
 - `pub use crate::{TranslationWorkflowEvent, TRANSLATION_WORKFLOW_EVENT_SCHEMAS}`
 - `ContractEventEnvelope::new_with_envelope_id(...)` creates a registered typed envelope with one exact non-nil caller-owned durable identity
@@ -45,6 +46,12 @@
   revision, one bounded projection target type, and a target identity only when
   the scope is a category or topic. The exact legacy root envelope identity is
   carried in typed-envelope `causation_id`, not in the payload.
+- `ReactionsEvent` defines v1 `reactions.actor_state.changed` for one committed
+  actor-state transition plus bounded aggregate deltas, and
+  `reactions.subject.reconciled` for one committed bounded aggregate repair.
+  Tenant and actor are envelope metadata. Owner command/repair identities,
+  subject identity, positive revisions and bounded reaction keys are payload
+  facts; producer content, visibility and presentation remain private.
 - `SocialGraphRelationEvent` defines v1 `social_graph.relation.state_changed`
   as an authoritative fact for one persisted relation revision, with relation id,
   source/target user ids, canonical kind, active state, and revision only. Tenant
@@ -81,6 +88,12 @@
 - Adds locale, channel, visibility, rendered content, document payload, reason,
   claims, roles, or Search `ingest_sequence` to the Forum Search invalidation payload.
 - Adds contact data, source body or profile handle snapshots to Forum mention events instead of stable identities.
+- Publishes a Reactions semantic event outside the owner state/aggregate/receipt
+  transaction, emits an event for a no-op or replay, or uses the user command
+  UUID instead of the admitted owner-operation UUID as envelope identity.
+- Adds producer content, visibility denial reasons, profile presentation,
+  claims, roles, locale, channel or free-form repair diagnostics to Reactions
+  events.
 - Adds idempotency keys, expected revisions, request context, claims, roles, locale,
   channel, or receipt snapshots to Social Graph relation events.
 - Treats a replayed Social Graph relation fact as exactly-once or applies a lower
@@ -131,6 +144,12 @@
   `forum`, and require a non-nil `target_id` for category/topic scope.
 - Forum owner revision and Search-owned `ingest_sequence` remain independent
   counters and must never be compared numerically.
+- Reactions actor-state events require non-nil command, subject and actor UUIDs,
+  positive subject/state revisions, one `add|remove` action, unique bounded key
+  arrays, added keys inside the resulting selection and removed keys outside it.
+- Reactions reconciliation events require a non-nil repair command/subject,
+  positive subject/catalog revisions, non-negative scan counts, at least one
+  changed key and a truthful bounded/truncated changed-key sample.
 - Social Graph relation events accept only non-nil distinct source/target ids,
   canonical `block|mute|follow` kind, and a positive monotonic revision.
 - A Social Graph consumer applies by relation id plus monotonic revision, ignores
@@ -145,6 +164,10 @@
 
 ### Events / Outbox Side Effects
 - Owner modules publish sealed contracts through `TransactionalEventBus::publish_contract_in_tx` inside the owner transaction.
+- Exact write-once owner operations may publish with
+  `publish_contract_once_direct_in_tx_with_envelope_id` using the already
+  admitted owner-operation UUID. Event conflict or unavailability must abort the
+  same transaction as owner state and receipt completion.
 - This crate defines exact envelope identity construction but does not perform
   database insertion, replay admission, conflict classification, source-row
   handoff, relay, retry, DLQ, or retention.

--- a/crates/rustok-events/README.md
+++ b/crates/rustok-events/README.md
@@ -17,6 +17,8 @@
   values.
 - Define sealed `TranslationWorkflowEvent` contracts for content-free
   Translation control-plane lifecycle evidence.
+- Define sealed `ReactionsEvent` contracts for committed actor-state changes and
+  bounded aggregate repair without exposing producer content or presentation.
 
 ## Entry points
 
@@ -30,6 +32,8 @@
 - `EVENT_SCHEMAS`
 - `ValidateEvent`
 - `EventValidationError`
+- `ReactionsEvent`
+- `REACTIONS_EVENT_SCHEMAS`
 - `TranslationWorkflowEvent`
 - `TRANSLATION_WORKFLOW_EVENT_SCHEMAS`
 

--- a/crates/rustok-events/src/contract.rs
+++ b/crates/rustok-events/src/contract.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 use crate::{
     BlogCommentsDelegationScheduleAuditEvent, DomainEvent, EventEnvelope, EventValidationError,
     ForumMentionEvent, ForumSearchProjectionEvent, MarketplaceListingEvent,
-    MarketplaceSellerEvent, RbacArtifactPermissionEvent, RbacRoleMutationEvent,
+    MarketplaceSellerEvent, RbacArtifactPermissionEvent, RbacRoleMutationEvent, ReactionsEvent,
     SocialGraphRelationEvent, TranslationWorkflowEvent, ValidateEvent,
 };
 
@@ -51,6 +51,8 @@ pub enum ContractEventPayload {
     RbacArtifactPermission(RbacArtifactPermissionEvent),
     #[serde(rename = "rbac_role_mutation")]
     RbacRoleMutation(RbacRoleMutationEvent),
+    #[serde(rename = "reactions")]
+    Reactions(ReactionsEvent),
     #[serde(rename = "social_graph_relation")]
     SocialGraphRelation(SocialGraphRelationEvent),
     #[serde(rename = "translation_workflow")]
@@ -68,6 +70,7 @@ impl ContractEventPayload {
             Self::MarketplaceSeller(event) => event.event_type(),
             Self::RbacArtifactPermission(event) => event.event_type(),
             Self::RbacRoleMutation(event) => event.event_type(),
+            Self::Reactions(event) => event.event_type(),
             Self::SocialGraphRelation(event) => event.event_type(),
             Self::TranslationWorkflow(event) => event.event_type(),
         }
@@ -83,6 +86,7 @@ impl ContractEventPayload {
             Self::MarketplaceSeller(event) => event.schema_version(),
             Self::RbacArtifactPermission(event) => event.schema_version(),
             Self::RbacRoleMutation(event) => event.schema_version(),
+            Self::Reactions(event) => event.schema_version(),
             Self::SocialGraphRelation(event) => event.schema_version(),
             Self::TranslationWorkflow(event) => event.schema_version(),
         }
@@ -100,6 +104,7 @@ impl ValidateEvent for ContractEventPayload {
             Self::MarketplaceSeller(event) => event.validate(),
             Self::RbacArtifactPermission(event) => event.validate(),
             Self::RbacRoleMutation(event) => event.validate(),
+            Self::Reactions(event) => event.validate(),
             Self::SocialGraphRelation(event) => event.validate(),
             Self::TranslationWorkflow(event) => event.validate(),
         }

--- a/crates/rustok-events/src/lib.rs
+++ b/crates/rustok-events/src/lib.rs
@@ -8,6 +8,7 @@ mod marketplace_listing;
 mod marketplace_seller;
 mod rbac_artifact_permission;
 mod rbac_role_mutation;
+mod reactions;
 mod schema;
 mod social_graph;
 mod translation_workflow;
@@ -43,6 +44,11 @@ pub use rbac_role_mutation::{
     RBAC_EVENT_USER_ROLE_ASSIGNMENT_REPAIRED, RBAC_EVENT_USER_ROLE_REPLACED,
     RBAC_ROLE_MUTATION_EVENT_SCHEMAS, RbacRoleMutationEvent, rbac_role_mutation_event_schema,
 };
+pub use reactions::{
+    MAX_REACTIONS_EVENT_KEYS, REACTIONS_ACTOR_STATE_CHANGED_EVENT_TYPE,
+    REACTIONS_EVENT_SCHEMA_VERSION, REACTIONS_EVENT_SCHEMAS,
+    REACTIONS_SUBJECT_RECONCILED_EVENT_TYPE, ReactionsEvent, reactions_event_schema,
+};
 pub use schema::{
     EVENT_SCHEMAS, EventContractDigests, EventSchema, FieldSchema,
     contract_event_envelope_json_schema, contract_event_payload_json_schema,
@@ -70,6 +76,7 @@ pub fn event_schema(event_type: &str) -> Option<&'static EventSchema> {
         .or_else(|| marketplace_seller_event_schema(event_type))
         .or_else(|| rbac_artifact_permission_event_schema(event_type))
         .or_else(|| rbac_role_mutation_event_schema(event_type))
+        .or_else(|| reactions_event_schema(event_type))
         .or_else(|| social_graph_relation_event_schema(event_type))
         .or_else(|| translation_workflow_event_schema(event_type))
 }
@@ -84,6 +91,7 @@ pub fn event_schemas() -> impl Iterator<Item = &'static EventSchema> {
         .chain(MARKETPLACE_SELLER_EVENT_SCHEMAS.iter())
         .chain(RBAC_ARTIFACT_PERMISSION_EVENT_SCHEMAS.iter())
         .chain(RBAC_ROLE_MUTATION_EVENT_SCHEMAS.iter())
+        .chain(REACTIONS_EVENT_SCHEMAS.iter())
         .chain(SOCIAL_GRAPH_RELATION_EVENT_SCHEMAS.iter())
         .chain(TRANSLATION_WORKFLOW_EVENT_SCHEMAS.iter())
 }

--- a/crates/rustok-events/src/reactions.rs
+++ b/crates/rustok-events/src/reactions.rs
@@ -1,0 +1,282 @@
+use std::collections::BTreeSet;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::contract::{ContractEventPayload, EventContract, sealed};
+use crate::validation::{EventValidationError, ValidateEvent, validators};
+use crate::{EventSchema, FieldSchema};
+
+pub const REACTIONS_ACTOR_STATE_CHANGED_EVENT_TYPE: &str = "reactions.actor_state.changed";
+pub const REACTIONS_SUBJECT_RECONCILED_EVENT_TYPE: &str = "reactions.subject.reconciled";
+pub const REACTIONS_EVENT_SCHEMA_VERSION: u16 = 1;
+pub const MAX_REACTIONS_EVENT_KEYS: usize = 64;
+const MAX_REACTIONS_EVENT_SEGMENT_BYTES: usize = 64;
+
+pub const REACTIONS_EVENT_SCHEMAS: &[EventSchema] = &[
+    EventSchema {
+        event_type: REACTIONS_ACTOR_STATE_CHANGED_EVENT_TYPE,
+        version: REACTIONS_EVENT_SCHEMA_VERSION,
+        description: "A committed tenant-scoped reaction actor-state transition and its bounded aggregate deltas.",
+        fields: REACTIONS_ACTOR_STATE_CHANGED_FIELDS,
+    },
+    EventSchema {
+        event_type: REACTIONS_SUBJECT_RECONCILED_EVENT_TYPE,
+        version: REACTIONS_EVENT_SCHEMA_VERSION,
+        description: "A committed bounded repair of one reaction subject aggregate projection.",
+        fields: REACTIONS_SUBJECT_RECONCILED_FIELDS,
+    },
+];
+
+const REACTIONS_ACTOR_STATE_CHANGED_FIELDS: &[FieldSchema] = &[
+    FieldSchema { name: "command_id", data_type: "uuid", optional: false },
+    FieldSchema { name: "source_slug", data_type: "string", optional: false },
+    FieldSchema { name: "subject_kind", data_type: "string", optional: false },
+    FieldSchema { name: "subject_id", data_type: "uuid", optional: false },
+    FieldSchema { name: "subject_revision", data_type: "int64", optional: false },
+    FieldSchema { name: "actor_id", data_type: "uuid", optional: false },
+    FieldSchema { name: "requested_reaction", data_type: "string", optional: false },
+    FieldSchema { name: "action", data_type: "string", optional: false },
+    FieldSchema { name: "state_revision", data_type: "int64", optional: false },
+    FieldSchema { name: "selected_keys", data_type: "array", optional: false },
+    FieldSchema { name: "added_keys", data_type: "array", optional: false },
+    FieldSchema { name: "removed_keys", data_type: "array", optional: false },
+];
+
+const REACTIONS_SUBJECT_RECONCILED_FIELDS: &[FieldSchema] = &[
+    FieldSchema { name: "repair_command_id", data_type: "uuid", optional: false },
+    FieldSchema { name: "source_slug", data_type: "string", optional: false },
+    FieldSchema { name: "subject_kind", data_type: "string", optional: false },
+    FieldSchema { name: "subject_id", data_type: "uuid", optional: false },
+    FieldSchema { name: "subject_revision", data_type: "int64", optional: false },
+    FieldSchema { name: "catalog_revision", data_type: "int64", optional: false },
+    FieldSchema { name: "actor_states_scanned", data_type: "int64", optional: false },
+    FieldSchema { name: "aggregate_rows_before", data_type: "int64", optional: false },
+    FieldSchema { name: "aggregate_rows_after", data_type: "int64", optional: false },
+    FieldSchema { name: "changed_key_count", data_type: "int64", optional: false },
+    FieldSchema { name: "changed_keys", data_type: "array", optional: false },
+    FieldSchema { name: "changed_keys_truncated", data_type: "bool", optional: false },
+];
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(tag = "type", content = "data")]
+pub enum ReactionsEvent {
+    ActorStateChanged {
+        command_id: Uuid,
+        source_slug: String,
+        subject_kind: String,
+        subject_id: Uuid,
+        subject_revision: i64,
+        actor_id: Uuid,
+        requested_reaction: String,
+        action: String,
+        state_revision: i64,
+        selected_keys: Vec<String>,
+        added_keys: Vec<String>,
+        removed_keys: Vec<String>,
+    },
+    SubjectReconciled {
+        repair_command_id: Uuid,
+        source_slug: String,
+        subject_kind: String,
+        subject_id: Uuid,
+        subject_revision: i64,
+        catalog_revision: i64,
+        actor_states_scanned: i64,
+        aggregate_rows_before: i64,
+        aggregate_rows_after: i64,
+        changed_key_count: i64,
+        changed_keys: Vec<String>,
+        changed_keys_truncated: bool,
+    },
+}
+
+impl ReactionsEvent {
+    pub fn event_type(&self) -> &'static str {
+        match self {
+            Self::ActorStateChanged { .. } => REACTIONS_ACTOR_STATE_CHANGED_EVENT_TYPE,
+            Self::SubjectReconciled { .. } => REACTIONS_SUBJECT_RECONCILED_EVENT_TYPE,
+        }
+    }
+
+    pub const fn schema_version(&self) -> u16 {
+        REACTIONS_EVENT_SCHEMA_VERSION
+    }
+}
+
+impl sealed::Sealed for ReactionsEvent {}
+
+impl EventContract for ReactionsEvent {
+    fn event_type(&self) -> &'static str {
+        ReactionsEvent::event_type(self)
+    }
+
+    fn schema_version(&self) -> u16 {
+        ReactionsEvent::schema_version(self)
+    }
+
+    fn into_contract_payload(self) -> ContractEventPayload {
+        ContractEventPayload::Reactions(self)
+    }
+}
+
+impl ValidateEvent for ReactionsEvent {
+    fn validate(&self) -> Result<(), EventValidationError> {
+        match self {
+            Self::ActorStateChanged {
+                command_id,
+                source_slug,
+                subject_kind,
+                subject_id,
+                subject_revision,
+                actor_id,
+                requested_reaction,
+                action,
+                state_revision,
+                selected_keys,
+                added_keys,
+                removed_keys,
+            } => {
+                validators::validate_not_nil_uuid("command_id", command_id)?;
+                validators::validate_not_nil_uuid("subject_id", subject_id)?;
+                validators::validate_not_nil_uuid("actor_id", actor_id)?;
+                validate_segment("source_slug", source_slug)?;
+                validate_segment("subject_kind", subject_kind)?;
+                validate_segment("requested_reaction", requested_reaction)?;
+                if !matches!(action.as_str(), "add" | "remove") {
+                    return Err(EventValidationError::InvalidValue(
+                        "action",
+                        "must be add or remove".to_string(),
+                    ));
+                }
+                validators::validate_range("subject_revision", *subject_revision, 1, i64::MAX)?;
+                validators::validate_range("state_revision", *state_revision, 1, i64::MAX)?;
+                validate_keys("selected_keys", selected_keys)?;
+                validate_keys("added_keys", added_keys)?;
+                validate_keys("removed_keys", removed_keys)?;
+
+                let selected = selected_keys.iter().collect::<BTreeSet<_>>();
+                let added = added_keys.iter().collect::<BTreeSet<_>>();
+                let removed = removed_keys.iter().collect::<BTreeSet<_>>();
+                if !added.is_subset(&selected) || !added.is_disjoint(&removed) {
+                    return Err(EventValidationError::InvalidValue(
+                        "added_keys",
+                        "added keys must be selected and disjoint from removed keys".to_string(),
+                    ));
+                }
+                if removed.iter().any(|key| selected.contains(key)) {
+                    return Err(EventValidationError::InvalidValue(
+                        "removed_keys",
+                        "removed keys must not remain selected".to_string(),
+                    ));
+                }
+                if added.is_empty() && removed.is_empty() {
+                    return Err(EventValidationError::InvalidValue(
+                        "added_keys",
+                        "a changed actor state must contain an added or removed key".to_string(),
+                    ));
+                }
+                Ok(())
+            }
+            Self::SubjectReconciled {
+                repair_command_id,
+                source_slug,
+                subject_kind,
+                subject_id,
+                subject_revision,
+                catalog_revision,
+                actor_states_scanned,
+                aggregate_rows_before,
+                aggregate_rows_after,
+                changed_key_count,
+                changed_keys,
+                changed_keys_truncated,
+            } => {
+                validators::validate_not_nil_uuid("repair_command_id", repair_command_id)?;
+                validators::validate_not_nil_uuid("subject_id", subject_id)?;
+                validate_segment("source_slug", source_slug)?;
+                validate_segment("subject_kind", subject_kind)?;
+                validators::validate_range("subject_revision", *subject_revision, 1, i64::MAX)?;
+                validators::validate_range("catalog_revision", *catalog_revision, 1, i64::MAX)?;
+                validators::validate_range("actor_states_scanned", *actor_states_scanned, 0, i64::MAX)?;
+                validators::validate_range("aggregate_rows_before", *aggregate_rows_before, 0, i64::MAX)?;
+                validators::validate_range("aggregate_rows_after", *aggregate_rows_after, 0, i64::MAX)?;
+                validators::validate_range("changed_key_count", *changed_key_count, 1, i64::MAX)?;
+                validate_keys("changed_keys", changed_keys)?;
+                if changed_keys.is_empty() {
+                    return Err(EventValidationError::InvalidValue(
+                        "changed_keys",
+                        "a reconciliation event must contain a bounded changed-key sample".to_string(),
+                    ));
+                }
+                if !*changed_keys_truncated && i64::try_from(changed_keys.len()).ok() != Some(*changed_key_count) {
+                    return Err(EventValidationError::InvalidValue(
+                        "changed_key_count",
+                        "untruncated changed-key count must equal the sample length".to_string(),
+                    ));
+                }
+                if *changed_keys_truncated
+                    && i64::try_from(changed_keys.len()).is_ok_and(|length| length >= *changed_key_count)
+                {
+                    return Err(EventValidationError::InvalidValue(
+                        "changed_keys_truncated",
+                        "a truncated sample must be smaller than the changed-key count".to_string(),
+                    ));
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+fn validate_segment(
+    field: &'static str,
+    value: &str,
+) -> Result<(), EventValidationError> {
+    validators::validate_not_empty(field, value)?;
+    validators::validate_max_length(field, value, MAX_REACTIONS_EVENT_SEGMENT_BYTES)?;
+    if value.trim() != value
+        || value.starts_with('-')
+        || value.starts_with('_')
+        || value.ends_with('-')
+        || value.ends_with('_')
+        || !value.bytes().all(|byte| {
+            byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || byte == b'-'
+                || byte == b'_'
+        })
+    {
+        return Err(EventValidationError::InvalidCharacters(field));
+    }
+    Ok(())
+}
+
+fn validate_keys(
+    field: &'static str,
+    keys: &[String],
+) -> Result<(), EventValidationError> {
+    if keys.len() > MAX_REACTIONS_EVENT_KEYS {
+        return Err(EventValidationError::InvalidValue(
+            field,
+            format!("must contain at most {MAX_REACTIONS_EVENT_KEYS} keys"),
+        ));
+    }
+    if keys.iter().collect::<BTreeSet<_>>().len() != keys.len() {
+        return Err(EventValidationError::InvalidValue(
+            field,
+            "must not contain duplicate keys".to_string(),
+        ));
+    }
+    for key in keys {
+        validate_segment(field, key)?;
+    }
+    Ok(())
+}
+
+pub fn reactions_event_schema(event_type: &str) -> Option<&'static EventSchema> {
+    REACTIONS_EVENT_SCHEMAS
+        .iter()
+        .find(|schema| schema.event_type == event_type)
+}

--- a/crates/rustok-events/tests/reactions_contracts.rs
+++ b/crates/rustok-events/tests/reactions_contracts.rs
@@ -1,0 +1,119 @@
+use rustok_events::{
+    ContractEventEnvelope, ContractEventPayload, ReactionsEvent, ValidateEvent, event_schema,
+    event_schemas,
+};
+use uuid::Uuid;
+
+#[test]
+fn reactions_family_registers_both_schema_v1_contracts() {
+    let schemas = event_schemas()
+        .filter(|schema| schema.event_type.starts_with("reactions."))
+        .collect::<Vec<_>>();
+    assert_eq!(schemas.len(), 2);
+    assert!(event_schema("reactions.actor_state.changed").is_some());
+    assert!(event_schema("reactions.subject.reconciled").is_some());
+}
+
+#[test]
+fn reactions_actor_state_change_is_typed_validated_and_enveloped() {
+    let event = ReactionsEvent::ActorStateChanged {
+        command_id: Uuid::new_v4(),
+        source_slug: "forum".to_string(),
+        subject_kind: "topic".to_string(),
+        subject_id: Uuid::new_v4(),
+        subject_revision: 4,
+        actor_id: Uuid::new_v4(),
+        requested_reaction: "love".to_string(),
+        action: "add".to_string(),
+        state_revision: 2,
+        selected_keys: vec!["love".to_string()],
+        added_keys: vec!["love".to_string()],
+        removed_keys: vec!["like".to_string()],
+    };
+    event.validate().unwrap();
+
+    let envelope_id = Uuid::new_v4();
+    let envelope = ContractEventEnvelope::new_with_envelope_id(
+        envelope_id,
+        Uuid::new_v4(),
+        None,
+        event,
+    )
+    .unwrap();
+    assert_eq!(envelope.id(), envelope_id);
+    assert_eq!(envelope.event_type(), "reactions.actor_state.changed");
+    assert!(matches!(
+        envelope.payload().unwrap(),
+        ContractEventPayload::Reactions(ReactionsEvent::ActorStateChanged { .. })
+    ));
+}
+
+#[test]
+fn reactions_actor_state_change_rejects_noop_and_overlapping_deltas() {
+    let noop = ReactionsEvent::ActorStateChanged {
+        command_id: Uuid::new_v4(),
+        source_slug: "forum".to_string(),
+        subject_kind: "reply".to_string(),
+        subject_id: Uuid::new_v4(),
+        subject_revision: 1,
+        actor_id: Uuid::new_v4(),
+        requested_reaction: "like".to_string(),
+        action: "add".to_string(),
+        state_revision: 1,
+        selected_keys: vec!["like".to_string()],
+        added_keys: Vec::new(),
+        removed_keys: Vec::new(),
+    };
+    assert!(noop.validate().is_err());
+
+    let overlapping = ReactionsEvent::ActorStateChanged {
+        command_id: Uuid::new_v4(),
+        source_slug: "forum".to_string(),
+        subject_kind: "reply".to_string(),
+        subject_id: Uuid::new_v4(),
+        subject_revision: 1,
+        actor_id: Uuid::new_v4(),
+        requested_reaction: "like".to_string(),
+        action: "remove".to_string(),
+        state_revision: 2,
+        selected_keys: vec!["like".to_string()],
+        added_keys: Vec::new(),
+        removed_keys: vec!["like".to_string()],
+    };
+    assert!(overlapping.validate().is_err());
+}
+
+#[test]
+fn reactions_reconciled_event_requires_truthful_bounded_sample() {
+    let valid = ReactionsEvent::SubjectReconciled {
+        repair_command_id: Uuid::new_v4(),
+        source_slug: "forum".to_string(),
+        subject_kind: "topic".to_string(),
+        subject_id: Uuid::new_v4(),
+        subject_revision: 9,
+        catalog_revision: 9,
+        actor_states_scanned: 12,
+        aggregate_rows_before: 3,
+        aggregate_rows_after: 2,
+        changed_key_count: 2,
+        changed_keys: vec!["like".to_string(), "love".to_string()],
+        changed_keys_truncated: false,
+    };
+    valid.validate().unwrap();
+
+    let invalid = ReactionsEvent::SubjectReconciled {
+        repair_command_id: Uuid::new_v4(),
+        source_slug: "forum".to_string(),
+        subject_kind: "topic".to_string(),
+        subject_id: Uuid::new_v4(),
+        subject_revision: 9,
+        catalog_revision: 9,
+        actor_states_scanned: 12,
+        aggregate_rows_before: 3,
+        aggregate_rows_after: 2,
+        changed_key_count: 2,
+        changed_keys: vec!["like".to_string()],
+        changed_keys_truncated: false,
+    };
+    assert!(invalid.validate().is_err());
+}

--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -66,7 +66,7 @@ must not copy that owner's source-of-truth data or read its private tables.
 | Public handle, display name, biography, locale and profile privacy | `rustok-profiles` | Batch summaries and compose Forum statistics. |
 | Avatar/banner and all binary asset lifecycle | `rustok-media` | Store typed media references and attachment policy only. |
 | Follow/block relationship facts | `rustok-social-graph` and profile privacy ports | Request exact bounded facts; never read relation tables. |
-| Reaction catalog, actor reactions and aggregate reaction counts | `rustok-reactions` | Publish Forum subject adapter, authorization, events and UI composition. |
+| Reaction catalog, actor reactions and aggregate reaction counts | `rustok-reactions` | Publish Forum subject adapter and authorization; consume permitted semantic facts and compose UI. |
 | Cross-domain reputation ledger and achievements/badges | planned `rustok-reputation` / achievement capability | Publish semantic facts and display permitted projections. |
 | Reports, cases, queues, decisions, appeals and cross-domain audit | `rustok-moderation` through `rustok-moderation-api` | Report subjects and apply validated effects to Forum state. |
 | Notification inbox, fan-out, grouping, preferences, digests and deliveries | `rustok-notifications` | Publish source events/providers and authorize current targets. |
@@ -108,16 +108,14 @@ integrate them instead of cloning their data models.
 
 The Reactions owner now has neutral bounded API contracts, unique source
 provider/factory registries, PostgreSQL/SQLite-compatible tenant-composite
-persistence, immutable catalog snapshots, shared Outbox command receipts and
-atomic actor-state/aggregate updates. Forum publishes a source-ready
-`topic`/`reply` provider factory with exact active-state, visibility and current-
-revision authorization plus a bounded single-`like` v1 catalog. Optional owner
-selection and host materialization are source-ready in the distribution and
-server, after Forum audience and recipient-context providers. The server now has
-executable source evidence for all three optional profiles plus the selected-
-feature/missing-owner failure. Maintainer lockfile generation and retained
-execution evidence remains pending. No reaction event/reconciliation layer,
-transport or UI exists yet.
+persistence, immutable catalog snapshots, shared Outbox command receipts,
+atomic actor-state/aggregate updates, sealed semantic reaction events and
+bounded aggregate reconciliation. Forum publishes a source-ready `topic`/`reply`
+provider factory with exact active-state, visibility and current-revision
+authorization plus a bounded single-`like` v1 catalog. Optional owner selection,
+host materialization and executable source evidence for all three optional
+profiles are source-ready. Maintainer lockfile/event-digest generation and
+retained execution evidence remains pending. No reaction transport or UI exists.
 
 ## Program ledger
 
@@ -141,7 +139,7 @@ transport or UI exists yet.
 | `FORUM-15` | `in_progress` | Profiles supplies `ProfilesReader`. Finish member-card composition, privacy/block behavior, Forum-stat enrichment and no-N+1 evidence. |
 | `FORUM-16` | `in_progress` | Read state, unread projections, bounded bulk owners and transports exist. Visibility-scoped storefront bulk commands and PostgreSQL evidence remain. |
 | `FORUM-17` | `planned` | Forum drafts/bookmarks with optional Notifications reminders and Media references. |
-| `FORUM-18` | `in_progress` | Neutral API, owner selection/persistence, shared receipts, atomic aggregates, Forum provider, host materialization and executable composition-profile tests are source-ready. Regenerate `Cargo.lock`, retain owner/profile runs, then add events/reconciliation, transports/UI and runtime proof; Forum votes remain separate. |
+| `FORUM-18` | `in_progress` | Neutral API, optional owner registration/selection, tenant-composite persistence, shared receipts, atomic actor aggregates, semantic reaction events, bounded aggregate reconciliation, Forum topic/reply provider factory, host materialization and composition tests are source-ready. Regenerate `Cargo.lock` and event digests, retain owner/event/repair/composition evidence, then add a second producer, transports/UI and runtime proof; Forum votes remain separate. |
 | `FORUM-19` | `planned` | Integrate `rustok-moderation-api` subject/effect adapters and Forum-local restrictions. Moderation owns cases and audit. |
 | `FORUM-20` | `in_progress` | Rich visibility and recipient-aware source/inbox slices largely exist. Complete remaining reads, Search/SEO/deep links, reconciliation, delivery and PostgreSQL evidence. |
 | `FORUM-21` | `in_progress` | A-X provide move/merge/split/fork/range owners, transports and UI. Retained runtime evidence remains. |
@@ -193,34 +191,42 @@ revisioned reconciled projection. Forum never stores copied profile source data.
 
 Existing Forum votes remain Forum semantics and must be hardened independently.
 `rustok-reactions` owns reusable reaction catalogs, actor state, shared-receipt
-command execution and aggregate projections. Forum owns topic/reply existence,
-current revision, visibility and reaction-policy authorization through its
-provider.
+command execution, aggregate projections, semantic reaction events and bounded
+aggregate repair. Forum owns topic/reply existence, current revision, visibility
+and reaction-policy authorization through its provider.
 
 The Forum provider factory supports `topic` and `reply`, checks tenant/source/
 kind, active soft-delete state, approved/open lifecycle and the existing rich
 audience visibility service, and returns one bounded single-selection `like`
-catalog. Its current revision is `latest captured Forum revision id + 1`, so the
-identity advances with captured topic translation/metadata and reply-body edits.
-Missing and denied targets share one `Unavailable` result; revision conflict is
-returned only after current visibility succeeds. Delegated service/system access
-uses the existing exact recipient-context port rather than inventing profile or
-authority storage.
+catalog. The `topic`/`reply` provider factory current revision is
+`latest captured Forum revision id + 1`, so the identity advances with captured
+topic translation/metadata and reply-body edits. Missing and denied targets
+share one `Unavailable` result; revision conflict is returned only after current
+visibility succeeds. Delegated service/system access uses the existing exact
+recipient-context port rather than inventing profile or authority storage.
 
 Forum registers only the neutral provider factory and depends only on the API
 crate through an explicit path. It does not depend on the Reactions owner and
-does not add Reactions to Forum module dependencies. The optional `mod-reactions`
-feature selects the owner independently in the distribution/server, remains
-outside defaults, and materializes the Forum provider only after host audience
-and recipient-context facts exist.
+does not add Reactions to Forum module dependencies. The optional
+`mod-reactions` feature selects the owner independently in the
+distribution/server, remains outside defaults, and materializes the Forum
+provider only after host audience and recipient-context facts exist. This is the
+optional owner selection and host materialization boundary.
 
 The Reactions-disabled Forum composition remains valid: Forum commands and reads
 continue without owner storage or a materialized reaction registry. Reactions
 without Forum materializes an empty source registry; Forum with Reactions
-materializes the `forum` source with `topic` and `reply` kinds. The public server
-composition entrypoint now has executable tests for each profile and for the
-selected-feature/missing-owner startup failure. Retained execution evidence
-remains pending.
+materializes the `forum` source with `topic` and `reply` kinds. Executable source
+evidence exists for these profiles and the selected-feature/missing-owner
+failure, but retained execution evidence remains pending.
+
+A changed Reactions command commits actor state, aggregate deltas, one sealed
+`reactions.actor_state.changed` event and its completed owner receipt atomically.
+No-op and receipt replay do not publish another fact. Reactions repair is bounded
+to one exact stored subject and rebuilds only aggregate projection rows from
+valid actor selections under the immutable current catalog. Missing/corrupt
+catalog or actor-state corruption blocks repair; the repair never mutates Forum
+content, visibility, lifecycle, votes or producer-private state.
 
 Reputation and achievements remain separate shared capabilities consuming
 semantic facts. Forum trust remains Forum-owned because it controls Forum
@@ -247,8 +253,8 @@ Hosts register/mount packages and do not absorb policy.
 2. Reactions owner persistence/atomic aggregates: source-ready, lockfile and runtime evidence pending.
 3. Forum `topic`/`reply` provider factory and disabled Forum profile: source-ready, maintainer verification pending.
 4. Optional distribution/server selection and host materialization after Forum facts: source-ready, maintainer verification pending.
-5. Executable source evidence for all profiles: source-ready; retain the four maintainer runs and lockfile delta.
-6. Add semantic events/reconciliation and a second producer before freezing shared presentation contracts.
+5. Executable composition profiles, sealed semantic reaction events and bounded aggregate reconciliation: source-ready; retain execution, rollback, replay and repair evidence.
+6. Add a second producer and review the neutral contract before freezing shared presentation contracts.
 7. Introduce Reputation/Achievements only after at least two producers agree.
 8. Integrate Forum with `rustok-moderation-api`; never add Forum case queues.
 
@@ -284,6 +290,10 @@ Hosts register/mount packages and do not absorb policy.
   required Forum module dependency.
 - Selecting `mod-reactions` without registering `ReactionsModule` is a startup
   configuration error, not an implicit empty owner.
+- Reactions semantic event envelope identity is the admitted owner-operation
+  UUID; it is not a Forum route/revision/vote identity.
+- Reactions bounded reconciliation repairs aggregate projection only and cannot
+  mutate Forum-owned subjects or reinterpret Forum votes.
 
 ## Required verification
 
@@ -294,21 +304,21 @@ node scripts/verify/verify-reactions-owner-persistence.mjs
 node scripts/verify/verify-forum-reaction-subject-provider.mjs
 node scripts/verify/verify-reactions-host-composition.mjs
 node scripts/verify/verify-reactions-composition-profiles.mjs
+node scripts/verify/verify-reactions-events-reconciliation.mjs
+cargo test -p rustok-events reactions
 cargo test -p rustok-reactions-api
 cargo test -p rustok-reactions
 cargo test -p rustok-forum reaction_subject
 cargo check -p rustok-distribution --features "mod-forum mod-reactions"
-cargo test -p rustok-server --no-default-features --features mod-forum --test reactions_composition_profiles forum_without_reactions_keeps_forum_host_composition_available
-cargo test -p rustok-server --no-default-features --features mod-reactions --test reactions_composition_profiles reactions_without_forum_materializes_an_empty_subject_registry
-cargo test -p rustok-server --no-default-features --features mod-reactions --test reactions_composition_profiles selected_reactions_feature_fails_when_owner_module_is_missing
-cargo test -p rustok-server --no-default-features --features "mod-forum mod-reactions" --test reactions_composition_profiles forum_with_reactions_materializes_topic_and_reply_provider
+cargo check -p rustok-server --no-default-features --features "mod-forum mod-reactions"
+cargo run -p rustok-events --example event_contract_digests -- --write
 cargo xtask module validate forum
 npm run verify:forum:admin-boundary
 npm run verify:forum:storefront-boundary
 git diff --check
 ```
 
-Tests, lockfile generation and retained runtime evidence are maintainer-run.
+Tests, lockfile/event-digest generation and runtime evidence are maintainer-run.
 Source contracts do not promote runtime status.
 
 ## Release gates
@@ -330,6 +340,8 @@ runtime claims without retained executable evidence.
 
 ## Immediate next action
 
-Retain the four composition-profile runs and regenerate `Cargo.lock`. Then add
-transactional semantic reaction events and bounded reconciliation before any
-transport or UI slice.
+Regenerate the event-contract digests and `Cargo.lock`, then retain SQLite and
+PostgreSQL evidence for changed/no-op/replayed reaction event cardinality,
+rollback on event failure, concurrent actor writes, clean/blocked/drift bounded
+aggregate reconciliation and repair receipt replay. Add a second real producer
+before any reaction transport or UI slice.

--- a/crates/rustok-reactions/Cargo.toml
+++ b/crates/rustok-reactions/Cargo.toml
@@ -10,6 +10,7 @@ async-trait.workspace = true
 chrono.workspace = true
 rustok-api.workspace = true
 rustok-core.workspace = true
+rustok-events.workspace = true
 rustok-outbox.workspace = true
 rustok-reactions-api = { path = "../rustok-reactions-api" }
 sea-orm.workspace = true

--- a/crates/rustok-reactions/README.md
+++ b/crates/rustok-reactions/README.md
@@ -16,29 +16,40 @@ The module now provides:
 - aggregate counts updated in the same owner transaction as actor state;
 - durable idempotency through the shared `rustok-outbox` owner-operation receipt
   ledger;
+- sealed `rustok-events` semantic facts for changed actor state and committed
+  aggregate repair;
+- bounded owner-only inspection and aggregate reconciliation;
 - transport-neutral `ReactionReadPort` and `ReactionWritePort` implementations.
 
 A reaction command UUID must equal the port idempotency key. The owner admits
 that key through Outbox, authorizes the subject through its producer provider,
-serializes the subject row, applies actor state and aggregate changes, completes
-the receipt in the same transaction, and persists a typed terminal failure after
-rollback when needed.
+serializes the subject row, applies actor state and aggregate changes, writes one
+semantic event for a real change, completes the receipt in the same transaction,
+and persists a typed terminal failure after rollback when needed. Idempotent
+no-op commands and completed receipt replays do not publish another event.
+
+Reconciliation requires exact tenant scope plus `reactions:reconcile`. Inspection
+is read-only. Repair is idempotent, bounded to one stored subject and rebuilds
+only aggregate rows from valid actor states under the immutable current catalog.
+Catalog or actor-state corruption blocks repair rather than silently changing
+user selections.
 
 ## Ownership
 
-Reactions owns catalog snapshots, actor reaction state and aggregate projections.
-Producer modules own subject existence, current revision, visibility, lifecycle
-and reaction policy. Profiles owns actor presentation. Reputation, achievements
-and Notifications are separate capabilities.
+Reactions owns catalog snapshots, actor reaction state, aggregate projections,
+semantic reaction events and aggregate repair. Producer modules own subject
+existence, current revision, visibility, lifecycle and reaction policy. Profiles
+owns actor presentation. Reputation, achievements and Notifications are
+separate capabilities.
 
 The Reactions owner never reads Forum, Blog, Comments, Profiles, Media, Groups
 or Commerce private tables.
 
 ## Deliberate limits
 
-This slice does not add producer adapters, semantic events, reconciliation,
-GraphQL, REST, native server functions, UI packages, default enablement, Forum
-vote migration, reputation or achievements.
+This slice does not add a background reconciliation worker, scheduler, second
+producer adapter, GraphQL, REST, native server functions, UI packages, default
+enablement, Forum vote migration, reputation or achievements.
 
 The initial catalog revision is the producer-authorized subject revision. A
 future independent catalog-revision contract requires an explicit API change and
@@ -55,6 +66,8 @@ Forum votes remain unchanged.
 - `ReactionsModule`
 - `ReactionsService`
 - `rustok_reactions_api::{ReactionReadPort, ReactionWritePort}`
+- `ReactionReconciliationRequest`
+- `RepairReactionSubjectCommand`
 - `migrations::migrations()`
 
 See [module contract](docs/README.md) and

--- a/crates/rustok-reactions/contracts/reactions-events-reconciliation.json
+++ b/crates/rustok-reactions/contracts/reactions-events-reconciliation.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "contract": "reactions_events_reconciliation_v1",
+  "module": "reactions",
+  "status": "source_ready_maintainer_execution_pending",
+  "event_family": {
+    "crate": "rustok-events",
+    "schema_version": 1,
+    "types": [
+      "reactions.actor_state.changed",
+      "reactions.subject.reconciled"
+    ],
+    "envelope_identity": "owner_operation_receipts.id",
+    "write_once": true,
+    "transactional": true
+  },
+  "command_event_invariants": [
+    "actor state, aggregate deltas, semantic event and completed owner receipt share one transaction",
+    "one changed command emits one actor-state event",
+    "idempotent no-op and completed receipt replay emit no new event",
+    "event persistence failure rolls back actor state, aggregates and receipt completion",
+    "payload contains stable identities, bounded reaction keys and revisions only"
+  ],
+  "reconciliation": {
+    "scope": "one tenant-scoped subject per request",
+    "claim": "reactions:reconcile",
+    "max_actor_states": 1000,
+    "max_aggregate_rows": 128,
+    "max_issues": 64,
+    "inspect_is_read_only": true,
+    "repair_is_idempotent": true,
+    "repair_projection": "reaction_aggregates",
+    "repair_source": "valid reaction_actor_states under the immutable current catalog",
+    "blocked_conditions": [
+      "missing or corrupt current catalog",
+      "non-positive actor-state revision",
+      "corrupt or duplicate actor selection",
+      "actor selection outside catalog or selection policy"
+    ],
+    "forbidden_repairs": [
+      "mutating actor selections",
+      "rewriting immutable catalog snapshots",
+      "reading producer-private tables",
+      "guessing producer visibility or lifecycle policy"
+    ]
+  },
+  "required_files": [
+    "crates/rustok-events/CRATE_API.md",
+    "crates/rustok-events/src/reactions.rs",
+    "crates/rustok-events/src/contract.rs",
+    "crates/rustok-events/src/lib.rs",
+    "crates/rustok-events/tests/reactions_contracts.rs",
+    "crates/rustok-reactions/src/service.rs",
+    "crates/rustok-reactions/src/reconciliation.rs",
+    "crates/rustok-reactions/src/lib.rs",
+    "crates/rustok-reactions/docs/implementation-plan.md",
+    "crates/rustok-forum/docs/implementation-plan.md",
+    "scripts/verify/verify-reactions-events-reconciliation.mjs"
+  ],
+  "deliberate_limits": [
+    "no GraphQL, REST or native transport",
+    "no admin or storefront UI",
+    "no background reconciliation worker or scheduler",
+    "no second producer adapter",
+    "no notification, reputation or achievement consumer",
+    "no runtime execution claim",
+    "event contract digest regeneration remains maintainer-run"
+  ],
+  "validation": [
+    "cargo test -p rustok-events reactions",
+    "cargo test -p rustok-reactions",
+    "cargo check -p rustok-reactions --all-targets",
+    "cargo run -p rustok-events --example event_contract_digests -- --write",
+    "node scripts/verify/verify-reactions-events-reconciliation.mjs",
+    "git diff --check"
+  ]
+}

--- a/crates/rustok-reactions/docs/README.md
+++ b/crates/rustok-reactions/docs/README.md
@@ -1,7 +1,8 @@
 # Reactions module contract
 
 `rustok-reactions` is an optional first-party owner. It depends on Outbox for
-the shared durable owner-operation receipt ledger.
+the shared durable owner-operation receipt ledger and on `rustok-events` for the
+sealed semantic event family.
 
 ## Runtime composition
 
@@ -32,13 +33,35 @@ act as their own UUID; service/system callers require `reactions:act_as_actor`.
 
 The service authorizes the producer subject before persistence, admits the
 shared Outbox receipt, synchronizes the immutable catalog snapshot, serializes
-the subject row, updates actor state and aggregate deltas in one transaction, and
-completes the receipt in that transaction. A rolled-back command persists a
-terminal typed receipt failure outside the owner transaction.
+the subject row, updates actor state and aggregate deltas, writes one sealed
+`reactions.actor_state.changed` fact for a real transition and completes the
+receipt in one transaction. The exact envelope UUID is the admitted owner
+operation UUID. Event conflict/unavailability aborts the owner transaction. A
+rolled-back command persists a terminal typed receipt failure only after that
+transaction is released.
 
 Single-selection replaces the previous key atomically. Multiple-selection is
 bounded by the authorized catalog. Removing an absent key and adding an already
-selected key are idempotent no-ops.
+selected key are idempotent no-ops and do not emit events. Completed receipt
+replay also emits no new fact.
+
+## Reconciliation boundary
+
+`inspect_reconciliation` and `repair_reconciliation` require exact tenant scope
+and `reactions:reconcile`. Repair additionally requires a non-nil command UUID
+equal to the write idempotency key and uses the shared receipt ledger.
+
+Inspection is read-only and bounded to one subject, at most 1,000 actor states,
+128 aggregate rows and 64 reported issues. Repair serializes the subject and
+reconstructs only `reaction_aggregates` from valid actor selections under the
+immutable current catalog. A drift repair writes one sealed
+`reactions.subject.reconciled` fact and completes its receipt atomically. A clean
+repair is a receipt-only no-op.
+
+Missing/corrupt current catalog, non-positive actor-state revision, corrupt or
+duplicate selections, selection-limit violations and keys outside the catalog
+block mutation. Repair never changes actor selections, catalog snapshots or
+producer-private state.
 
 ## Catalog compatibility
 
@@ -48,20 +71,23 @@ cannot remove a key with live aggregate state; reconciliation must happen first.
 
 ## Exclusions
 
-No producer adapter, event catalog, outbox event write, reconciliation worker,
-transport, UI, default enablement, reputation, achievement or Forum vote
-migration is included.
+No background repair worker/scheduler, second producer adapter, transport, UI,
+default enablement, reputation, achievement or Forum vote migration is included.
+The committed event-contract digest artifact and `Cargo.lock` remain maintainer-
+generated.
 
 ## Verification
 
 ```bash
+cargo test -p rustok-events reactions
 cargo test -p rustok-reactions-api
 cargo test -p rustok-reactions
 cargo check -p rustok-reactions --all-targets
+cargo run -p rustok-events --example event_contract_digests -- --write
 node scripts/verify/verify-reactions-foundation.mjs
 node scripts/verify/verify-reactions-owner-persistence.mjs
+node scripts/verify/verify-reactions-events-reconciliation.mjs
 git diff --check
 ```
 
-Tests, checks and runtime evidence are maintainer-run. `Cargo.lock` regeneration
-is also maintainer-run for this source slice.
+Tests, checks, digest/lockfile generation and runtime evidence are maintainer-run.

--- a/crates/rustok-reactions/docs/implementation-plan.md
+++ b/crates/rustok-reactions/docs/implementation-plan.md
@@ -16,7 +16,7 @@ last_reviewed: 2026-08-06
 | --- | --- | --- |
 | `REACTIONS-00` | `in_progress` | Neutral API, optional owner module, distribution/server feature selection and provider registries are source-ready; maintainer Cargo/Node verification remains. |
 | `REACTIONS-01` | `in_progress` | Tenant-composite owner schema, immutable catalog snapshots, actor uniqueness and shared Outbox command receipts are source-ready. Regenerate `Cargo.lock` and retain SQLite/PostgreSQL execution evidence. |
-| `REACTIONS-02` | `in_progress` | Actor state and aggregate deltas commit atomically behind one subject serialization row. Add semantic events, repair/reconciliation and retained concurrency evidence. |
+| `REACTIONS-02` | `in_progress` | Actor state, aggregate deltas, typed semantic events and completed shared Outbox receipts now share one transaction. Bounded inspect/repair reconciliation is source-ready; retain rollback, replay, concurrency and repair evidence. |
 | `REACTIONS-03` | `in_progress` | Forum topic/reply provider, optional host materialization and executable composition profile tests are source-ready. Reactions stays outside defaults; retained execution evidence remains pending. |
 | `REACTIONS-04` | `planned` | Second real producer adapter and neutral-contract review. |
 | `REACTIONS-05` | `planned` | Bounded read/write transports and module-owned UI. |
@@ -25,11 +25,11 @@ last_reviewed: 2026-08-06
 ## Ownership
 
 Reactions owns catalog snapshots, actor state, shared-receipt-bound command
-execution and aggregate projections. Producer modules own subject existence,
-current revision, visibility, lifecycle and reaction policy. Profiles owns actor
-presentation. Reputation and achievements consume semantic facts but do not
-mutate reaction state. Notifications may consume future events but are not part
-of command correctness.
+execution, aggregate projections, semantic reaction events and aggregate repair.
+Producer modules own subject existence, current revision, visibility, lifecycle
+and reaction policy. Profiles owns actor presentation. Reputation and
+achievements consume semantic facts but do not mutate reaction state.
+Notifications may consume future events but are not part of command correctness.
 
 ## Persistence invariants
 
@@ -46,6 +46,50 @@ of command correctness.
 
 The initial catalog revision is the producer subject revision. Independent
 catalog revisioning is a later explicit API/migration change.
+
+## Semantic event boundary
+
+`rustok-events::ReactionsEvent` defines two sealed schema-v1 facts:
+
+- `reactions.actor_state.changed` records one committed actor-state transition,
+  the resulting bounded selection and exact added/removed aggregate keys;
+- `reactions.subject.reconciled` records one committed bounded aggregate repair
+  and a bounded/truncated changed-key sample.
+
+The admitted `owner_operation_receipts.id` is the exact typed envelope UUID. A
+changed reaction command writes actor state, aggregate deltas, the semantic event
+and completed shared receipt in one owner transaction. Event conflict or
+unavailability aborts the transaction. Idempotent no-op commands and completed
+receipt replays do not publish another event.
+
+Payloads expose stable tenant-scoped identities through envelope/payload fields,
+positive revisions and bounded reaction keys only. They do not expose producer
+content, visibility denial reasons, profile presentation, claims, roles, locale,
+channel or free-form repair diagnostics.
+
+The typed family is registered in the central closed `ContractEventPayload` and
+schema registry. The committed event-contract digest artifact must be regenerated
+by the maintainer before `--locked` or release evidence is accepted.
+
+## Bounded reconciliation boundary
+
+`ReactionsService` exposes owner-only inspect and repair methods for one exact
+subject. Both require tenant equality and `reactions:reconcile`; repair also
+requires a non-nil command UUID equal to the write idempotency key.
+
+The request supplies an explicit actor-state bound capped at 1,000. Aggregate
+rows are hard-capped at 128 and reported issues at 64. Inspection is read-only.
+Repair is admitted through the shared Outbox receipt ledger, serializes the owner
+subject row and reconstructs `reaction_aggregates` only from valid persisted
+actor selections under the immutable current catalog.
+
+Repair fails closed when the current catalog is missing/corrupt or an actor state
+has a non-positive revision, corrupt/duplicate selection, selection-limit
+violation or key outside the current catalog. It never mutates actor selections,
+rewrites catalog snapshots, reads producer-private tables or guesses producer
+visibility/lifecycle policy. A clean repair is an idempotent receipt-only no-op;
+a drift repair replaces only aggregate rows and publishes one transactional
+`reactions.subject.reconciled` event.
 
 ## Forum producer boundary
 
@@ -92,7 +136,8 @@ Supported profiles are explicit:
   stable owner-missing error before publishing a false runtime.
 
 `mod-forum` does not imply `mod-reactions`, server defaults do not select it and
-`modules.toml` keeps Reactions outside `default_enabled`.
+`modules.toml` keeps Reactions outside `default_enabled` and outside default
+profiles.
 
 ## Executable composition evidence
 
@@ -108,18 +153,20 @@ profile results. Source presence alone does not promote `REACTIONS-03` to done.
 
 ## Immediate next action
 
-After retaining the four composition-profile runs and regenerating `Cargo.lock`,
-add transactional semantic reaction events and bounded catalog/aggregate
-reconciliation. Then add a second real producer before freezing transport or
-presentation contracts.
+Regenerate `Cargo.lock` and the `rustok-events` digest artifact, then retain
+SQLite/PostgreSQL evidence covering changed/no-op/replay event cardinality,
+rollback on event failure, concurrent actor updates, clean/blocked/drift
+reconciliation and receipt replay. After that, add a second real producer and
+review the neutral contract before freezing transport or presentation contracts.
 
 Before release, execute SQLite and PostgreSQL migrations, retain replay,
-concurrency and rollback evidence, and provide reconciliation for catalog and
-aggregate drift.
+concurrency and rollback evidence, and retain bounded repair evidence for catalog
+and aggregate drift.
 
 ## Verification
 
 ```bash
+cargo test -p rustok-events reactions
 cargo test -p rustok-reactions-api
 cargo test -p rustok-reactions
 cargo test -p rustok-forum reaction_subject
@@ -131,12 +178,14 @@ cargo test -p rustok-server --no-default-features --features mod-forum --test re
 cargo test -p rustok-server --no-default-features --features mod-reactions --test reactions_composition_profiles reactions_without_forum_materializes_an_empty_subject_registry
 cargo test -p rustok-server --no-default-features --features mod-reactions --test reactions_composition_profiles selected_reactions_feature_fails_when_owner_module_is_missing
 cargo test -p rustok-server --no-default-features --features "mod-forum mod-reactions" --test reactions_composition_profiles forum_with_reactions_materializes_topic_and_reply_provider
+cargo run -p rustok-events --example event_contract_digests -- --write
 node scripts/verify/verify-reactions-foundation.mjs
 node scripts/verify/verify-reactions-owner-persistence.mjs
 node scripts/verify/verify-forum-reaction-subject-provider.mjs
 node scripts/verify/verify-reactions-host-composition.mjs
 node scripts/verify/verify-reactions-composition-profiles.mjs
+node scripts/verify/verify-reactions-events-reconciliation.mjs
 git diff --check
 ```
 
-Tests, checks, lockfile generation and retained runtime evidence are maintainer-run.
+Tests, checks, lockfile/digest generation and retained runtime evidence are maintainer-run.

--- a/crates/rustok-reactions/src/lib.rs
+++ b/crates/rustok-reactions/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod entities;
 pub mod migrations;
+mod reconciliation;
 mod service;
 
 use async_trait::async_trait;
@@ -11,6 +12,12 @@ use rustok_reactions_api::{
 };
 use sea_orm_migration::MigrationTrait;
 
+pub use reconciliation::{
+    MAX_REACTION_RECONCILIATION_ACTOR_STATES, MAX_REACTION_RECONCILIATION_ISSUES,
+    ReactionAggregateComparison, ReactionReconciliationIssue, ReactionReconciliationReceipt,
+    ReactionReconciliationReport, ReactionReconciliationRequest, ReactionReconciliationStatus,
+    RepairReactionSubjectCommand,
+};
 pub use rustok_reactions_api as api;
 pub use service::ReactionsService;
 

--- a/crates/rustok-reactions/src/reconciliation.rs
+++ b/crates/rustok-reactions/src/reconciliation.rs
@@ -1,0 +1,798 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use chrono::Utc;
+use rustok_api::{PortCallPolicy, PortContext, PortError};
+use rustok_events::{MAX_REACTIONS_EVENT_KEYS, ReactionsEvent};
+use rustok_outbox::{ContractEventWriteOnceError, TransactionalEventBus, idempotency};
+use rustok_reactions_api::{ReactionCatalog, ReactionKey, ReactionSubjectRef};
+use sea_orm::sea_query::Expr;
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseTransaction, EntityTrait,
+    PaginatorTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
+};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use uuid::Uuid;
+
+use crate::ReactionsService;
+use crate::entities::{actor_state, aggregate, catalog, subject};
+
+pub const MAX_REACTION_RECONCILIATION_ACTOR_STATES: u32 = 1_000;
+pub const MAX_REACTION_RECONCILIATION_ISSUES: usize = 64;
+const MAX_REACTION_RECONCILIATION_AGGREGATE_ROWS: u64 = 128;
+const REACTION_OWNER_SLUG: &str = "reactions";
+const RECONCILE_REACTION_SUBJECT_OPERATION: &str = "reconcile_subject";
+const RECONCILE_REACTIONS_CLAIM: &str = "reactions:reconcile";
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReactionReconciliationStatus {
+    Clean,
+    Drift,
+    Blocked,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ReactionReconciliationRequest {
+    pub subject: ReactionSubjectRef,
+    pub max_actor_states: u32,
+}
+
+impl ReactionReconciliationRequest {
+    pub fn new(subject: ReactionSubjectRef, max_actor_states: u32) -> Result<Self, PortError> {
+        let request = Self {
+            subject,
+            max_actor_states,
+        };
+        request.validate()?;
+        Ok(request)
+    }
+
+    fn validate(&self) -> Result<(), PortError> {
+        if self.max_actor_states == 0
+            || self.max_actor_states > MAX_REACTION_RECONCILIATION_ACTOR_STATES
+        {
+            return Err(PortError::validation(
+                "reactions.reconciliation_scope_invalid",
+                format!(
+                    "max_actor_states must be between 1 and {MAX_REACTION_RECONCILIATION_ACTOR_STATES}"
+                ),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct RepairReactionSubjectCommand {
+    pub command_id: Uuid,
+    pub request: ReactionReconciliationRequest,
+}
+
+impl RepairReactionSubjectCommand {
+    pub fn new(
+        command_id: Uuid,
+        request: ReactionReconciliationRequest,
+    ) -> Result<Self, PortError> {
+        if command_id.is_nil() {
+            return Err(PortError::validation(
+                "reactions.reconciliation_command_id_invalid",
+                "reaction reconciliation command UUID must not be nil",
+            ));
+        }
+        request.validate()?;
+        Ok(Self {
+            command_id,
+            request,
+        })
+    }
+
+    fn validate(&self) -> Result<(), PortError> {
+        if self.command_id.is_nil() {
+            return Err(PortError::validation(
+                "reactions.reconciliation_command_id_invalid",
+                "reaction reconciliation command UUID must not be nil",
+            ));
+        }
+        self.request.validate()
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ReactionReconciliationIssue {
+    pub code: String,
+    pub actor_id: Option<Uuid>,
+    pub reaction: Option<ReactionKey>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ReactionAggregateComparison {
+    pub reaction: ReactionKey,
+    pub expected: u64,
+    pub actual: i64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ReactionReconciliationReport {
+    pub subject: ReactionSubjectRef,
+    pub catalog_revision: u64,
+    pub status: ReactionReconciliationStatus,
+    pub actor_states_scanned: u64,
+    pub aggregate_rows_scanned: u64,
+    pub comparisons: Vec<ReactionAggregateComparison>,
+    pub issues: Vec<ReactionReconciliationIssue>,
+    pub issues_truncated: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ReactionReconciliationReceipt {
+    pub command_id: Uuid,
+    pub subject: ReactionSubjectRef,
+    pub changed: bool,
+    pub actor_states_scanned: u64,
+    pub aggregate_rows_before: u64,
+    pub aggregate_rows_after: u64,
+    pub changed_key_count: u64,
+}
+
+struct ReconciliationAnalysis {
+    report: ReactionReconciliationReport,
+    reaction_subject_id: Uuid,
+    expected: BTreeMap<ReactionKey, u64>,
+    changed_key_count: u64,
+    changed_key_sample: Vec<String>,
+}
+
+impl ReactionsService {
+    pub async fn inspect_reconciliation(
+        &self,
+        context: PortContext,
+        request: ReactionReconciliationRequest,
+    ) -> Result<ReactionReconciliationReport, PortError> {
+        context.require_policy(PortCallPolicy::read())?;
+        authorize_reconciliation(&context, &request)?;
+        request.validate()?;
+        Ok(analyze_reconciliation(self.database(), &request)
+            .await?
+            .report)
+    }
+
+    pub async fn repair_reconciliation(
+        &self,
+        context: PortContext,
+        command: RepairReactionSubjectCommand,
+    ) -> Result<ReactionReconciliationReceipt, PortError> {
+        context.require_policy(PortCallPolicy::write())?;
+        command.validate()?;
+        authorize_reconciliation(&context, &command.request)?;
+
+        let expected_key = command.command_id.to_string();
+        if context.idempotency_key.as_deref() != Some(expected_key.as_str()) {
+            return Err(PortError::validation(
+                "reactions.reconciliation_command_idempotency_mismatch",
+                "reaction reconciliation command UUID must equal the port idempotency key",
+            ));
+        }
+
+        let tenant_id = command.request.subject.tenant_id();
+        let lease = match idempotency::admit(
+            self.database(),
+            tenant_id,
+            REACTION_OWNER_SLUG,
+            expected_key.as_str(),
+            RECONCILE_REACTION_SUBJECT_OPERATION,
+            &command,
+        )
+        .await?
+        {
+            idempotency::Admission::Run(lease) => lease,
+            idempotency::Admission::Replay(value) => return decode_replay(value),
+            idempotency::Admission::ReplayError(error) => return Err(error),
+        };
+
+        let actor_id = Uuid::parse_str(&context.actor.id).ok();
+        let result = self.execute_repair(lease, actor_id, &command).await;
+        if let Err(error) = &result {
+            if let Err(receipt_error) = idempotency::fail(self.database(), lease, error).await {
+                tracing::error!(
+                    operation_id = %lease.operation_id,
+                    error = %receipt_error.message,
+                    "failed to persist Reactions reconciliation failure receipt"
+                );
+            }
+        }
+        result
+    }
+
+    async fn execute_repair(
+        &self,
+        lease: idempotency::Lease,
+        actor_id: Option<Uuid>,
+        command: &RepairReactionSubjectCommand,
+    ) -> Result<ReactionReconciliationReceipt, PortError> {
+        let transaction = self.database().begin().await.map_err(database_error)?;
+        let receipt = repair_inside_transaction(
+            &transaction,
+            lease.operation_id,
+            actor_id,
+            command,
+        )
+        .await?;
+        idempotency::complete(&transaction, lease, &receipt).await?;
+        transaction.commit().await.map_err(database_error)?;
+        Ok(receipt)
+    }
+}
+
+async fn repair_inside_transaction(
+    transaction: &DatabaseTransaction,
+    event_envelope_id: Uuid,
+    actor_id: Option<Uuid>,
+    command: &RepairReactionSubjectCommand,
+) -> Result<ReactionReconciliationReceipt, PortError> {
+    serialize_subject(transaction, &command.request.subject).await?;
+    let analysis = analyze_reconciliation(transaction, &command.request).await?;
+
+    if analysis.report.status == ReactionReconciliationStatus::Blocked {
+        return Err(PortError::conflict(
+            "reactions.reconciliation_blocked",
+            "reaction aggregate repair is blocked by catalog or actor-state corruption",
+        ));
+    }
+
+    let aggregate_rows_before = analysis.report.aggregate_rows_scanned;
+    if analysis.report.status == ReactionReconciliationStatus::Clean {
+        return Ok(ReactionReconciliationReceipt {
+            command_id: command.command_id,
+            subject: command.request.subject.clone(),
+            changed: false,
+            actor_states_scanned: analysis.report.actor_states_scanned,
+            aggregate_rows_before,
+            aggregate_rows_after: aggregate_rows_before,
+            changed_key_count: 0,
+        });
+    }
+
+    aggregate::Entity::delete_many()
+        .filter(aggregate::Column::TenantId.eq(command.request.subject.tenant_id()))
+        .filter(aggregate::Column::ReactionSubjectId.eq(analysis.reaction_subject_id))
+        .exec(transaction)
+        .await
+        .map_err(database_error)?;
+
+    let now = Utc::now().fixed_offset();
+    for (reaction, count) in &analysis.expected {
+        if *count == 0 {
+            continue;
+        }
+        aggregate::ActiveModel {
+            id: Set(Uuid::new_v4()),
+            tenant_id: Set(command.request.subject.tenant_id()),
+            reaction_subject_id: Set(analysis.reaction_subject_id),
+            reaction_key: Set(reaction.to_string()),
+            count: Set(u64_to_i64(*count, "reconciliation aggregate count")?),
+            created_at: Set(now),
+            updated_at: Set(now),
+        }
+        .insert(transaction)
+        .await
+        .map_err(database_error)?;
+    }
+
+    let aggregate_rows_after = u64::try_from(
+        analysis.expected.values().filter(|count| **count > 0).count(),
+    )
+    .map_err(|_| {
+        PortError::invariant_violation(
+            "reactions.reconciliation_count_out_of_range",
+            "reaction reconciliation aggregate row count exceeds u64",
+        )
+    })?;
+
+    let event = ReactionsEvent::SubjectReconciled {
+        repair_command_id: command.command_id,
+        source_slug: command.request.subject.source().to_string(),
+        subject_kind: command.request.subject.kind().to_string(),
+        subject_id: command.request.subject.subject_id(),
+        subject_revision: u64_to_i64(
+            command.request.subject.subject_revision(),
+            "reconciliation subject revision",
+        )?,
+        catalog_revision: u64_to_i64(
+            analysis.report.catalog_revision,
+            "reconciliation catalog revision",
+        )?,
+        actor_states_scanned: u64_to_i64(
+            analysis.report.actor_states_scanned,
+            "reconciliation actor-state count",
+        )?,
+        aggregate_rows_before: u64_to_i64(
+            aggregate_rows_before,
+            "reconciliation aggregate rows before",
+        )?,
+        aggregate_rows_after: u64_to_i64(
+            aggregate_rows_after,
+            "reconciliation aggregate rows after",
+        )?,
+        changed_key_count: u64_to_i64(
+            analysis.changed_key_count,
+            "reconciliation changed-key count",
+        )?,
+        changed_keys: analysis.changed_key_sample.clone(),
+        changed_keys_truncated: analysis.changed_key_count
+            > u64::try_from(analysis.changed_key_sample.len()).unwrap_or(u64::MAX),
+    };
+    publish_event_once(
+        transaction,
+        event_envelope_id,
+        command.request.subject.tenant_id(),
+        actor_id,
+        event,
+    )
+    .await?;
+
+    Ok(ReactionReconciliationReceipt {
+        command_id: command.command_id,
+        subject: command.request.subject.clone(),
+        changed: true,
+        actor_states_scanned: analysis.report.actor_states_scanned,
+        aggregate_rows_before,
+        aggregate_rows_after,
+        changed_key_count: analysis.changed_key_count,
+    })
+}
+
+async fn serialize_subject(
+    transaction: &DatabaseTransaction,
+    subject_ref: &ReactionSubjectRef,
+) -> Result<(), PortError> {
+    let update = subject::Entity::update_many()
+        .col_expr(subject::Column::UpdatedAt, Expr::value(Utc::now().fixed_offset()))
+        .filter(subject::Column::TenantId.eq(subject_ref.tenant_id()))
+        .filter(subject::Column::SourceSlug.eq(subject_ref.source().as_str()))
+        .filter(subject::Column::SubjectKind.eq(subject_ref.kind().as_str()))
+        .filter(subject::Column::SubjectId.eq(subject_ref.subject_id()))
+        .exec(transaction)
+        .await
+        .map_err(database_error)?;
+    if update.rows_affected != 1 {
+        return Err(PortError::not_found(
+            "reactions.reconciliation_subject_missing",
+            "reaction subject is not present in owner storage",
+        ));
+    }
+    Ok(())
+}
+
+async fn analyze_reconciliation<C>(
+    connection: &C,
+    request: &ReactionReconciliationRequest,
+) -> Result<ReconciliationAnalysis, PortError>
+where
+    C: ConnectionTrait,
+{
+    request.validate()?;
+    let stored_subject = subject::Entity::find()
+        .filter(subject::Column::TenantId.eq(request.subject.tenant_id()))
+        .filter(subject::Column::SourceSlug.eq(request.subject.source().as_str()))
+        .filter(subject::Column::SubjectKind.eq(request.subject.kind().as_str()))
+        .filter(subject::Column::SubjectId.eq(request.subject.subject_id()))
+        .one(connection)
+        .await
+        .map_err(database_error)?
+        .ok_or_else(|| {
+            PortError::not_found(
+                "reactions.reconciliation_subject_missing",
+                "reaction subject is not present in owner storage",
+            )
+        })?;
+
+    let stored_subject_revision = i64_to_u64(
+        stored_subject.subject_revision,
+        "stored reaction subject revision",
+    )?;
+    if stored_subject_revision != request.subject.subject_revision() {
+        return Err(PortError::conflict(
+            "reactions.reconciliation_subject_revision_stale",
+            "reaction reconciliation targets a stale subject revision",
+        ));
+    }
+    let catalog_revision = i64_to_u64(
+        stored_subject.current_catalog_revision,
+        "stored reaction catalog revision",
+    )?;
+
+    let actor_count = actor_state::Entity::find()
+        .filter(actor_state::Column::TenantId.eq(request.subject.tenant_id()))
+        .filter(actor_state::Column::ReactionSubjectId.eq(stored_subject.id))
+        .count(connection)
+        .await
+        .map_err(database_error)?;
+    if actor_count > u64::from(request.max_actor_states) {
+        return Err(PortError::conflict(
+            "reactions.reconciliation_scope_exceeded",
+            "reaction subject contains more actor states than the requested reconciliation bound",
+        ));
+    }
+
+    let aggregate_count = aggregate::Entity::find()
+        .filter(aggregate::Column::TenantId.eq(request.subject.tenant_id()))
+        .filter(aggregate::Column::ReactionSubjectId.eq(stored_subject.id))
+        .count(connection)
+        .await
+        .map_err(database_error)?;
+    if aggregate_count > MAX_REACTION_RECONCILIATION_AGGREGATE_ROWS {
+        return Err(PortError::conflict(
+            "reactions.reconciliation_scope_exceeded",
+            "reaction subject contains more aggregate rows than the reconciliation bound",
+        ));
+    }
+
+    let mut issues = Vec::new();
+    let mut issues_truncated = false;
+    let stored_catalog = catalog::Entity::find()
+        .filter(catalog::Column::TenantId.eq(request.subject.tenant_id()))
+        .filter(catalog::Column::ReactionSubjectId.eq(stored_subject.id))
+        .filter(catalog::Column::CatalogRevision.eq(stored_subject.current_catalog_revision))
+        .one(connection)
+        .await
+        .map_err(database_error)?;
+    let catalog_value = match stored_catalog {
+        None => {
+            push_issue(
+                &mut issues,
+                &mut issues_truncated,
+                ReactionReconciliationIssue {
+                    code: "current_catalog_missing".to_string(),
+                    actor_id: None,
+                    reaction: None,
+                },
+            );
+            return Ok(ReconciliationAnalysis {
+                report: ReactionReconciliationReport {
+                    subject: request.subject.clone(),
+                    catalog_revision,
+                    status: ReactionReconciliationStatus::Blocked,
+                    actor_states_scanned: 0,
+                    aggregate_rows_scanned: aggregate_count,
+                    comparisons: Vec::new(),
+                    issues,
+                    issues_truncated,
+                },
+                reaction_subject_id: stored_subject.id,
+                expected: BTreeMap::new(),
+                changed_key_count: 0,
+                changed_key_sample: Vec::new(),
+            });
+        }
+        Some(row) => match serde_json::from_value::<ReactionCatalog>(row.catalog_json) {
+            Ok(catalog) => catalog,
+            Err(_) => {
+                push_issue(
+                    &mut issues,
+                    &mut issues_truncated,
+                    ReactionReconciliationIssue {
+                        code: "current_catalog_corrupt".to_string(),
+                        actor_id: None,
+                        reaction: None,
+                    },
+                );
+                return Ok(ReconciliationAnalysis {
+                    report: ReactionReconciliationReport {
+                        subject: request.subject.clone(),
+                        catalog_revision,
+                        status: ReactionReconciliationStatus::Blocked,
+                        actor_states_scanned: 0,
+                        aggregate_rows_scanned: aggregate_count,
+                        comparisons: Vec::new(),
+                        issues,
+                        issues_truncated,
+                    },
+                    reaction_subject_id: stored_subject.id,
+                    expected: BTreeMap::new(),
+                    changed_key_count: 0,
+                    changed_key_sample: Vec::new(),
+                });
+            }
+        },
+    };
+
+    let actor_rows = actor_state::Entity::find()
+        .filter(actor_state::Column::TenantId.eq(request.subject.tenant_id()))
+        .filter(actor_state::Column::ReactionSubjectId.eq(stored_subject.id))
+        .order_by_asc(actor_state::Column::ActorId)
+        .all(connection)
+        .await
+        .map_err(database_error)?;
+    let mut expected = BTreeMap::<ReactionKey, u64>::new();
+    let mut blocked = false;
+    for row in actor_rows {
+        if row.revision <= 0 {
+            blocked = true;
+            push_issue(
+                &mut issues,
+                &mut issues_truncated,
+                issue("actor_revision_invalid", Some(row.actor_id), None),
+            );
+            continue;
+        }
+        let selected = match serde_json::from_value::<Vec<ReactionKey>>(row.selected_json) {
+            Ok(selected) => selected,
+            Err(_) => {
+                blocked = true;
+                push_issue(
+                    &mut issues,
+                    &mut issues_truncated,
+                    issue("actor_state_corrupt", Some(row.actor_id), None),
+                );
+                continue;
+            }
+        };
+        if selected.iter().collect::<BTreeSet<_>>().len() != selected.len() {
+            blocked = true;
+            push_issue(
+                &mut issues,
+                &mut issues_truncated,
+                issue("actor_state_duplicate_keys", Some(row.actor_id), None),
+            );
+            continue;
+        }
+        if selected.len() > catalog_value.selection().maximum_selected() {
+            blocked = true;
+            push_issue(
+                &mut issues,
+                &mut issues_truncated,
+                issue("actor_selection_limit_exceeded", Some(row.actor_id), None),
+            );
+            continue;
+        }
+        if let Some(reaction) = selected
+            .iter()
+            .find(|reaction| !catalog_value.contains(reaction))
+        {
+            blocked = true;
+            push_issue(
+                &mut issues,
+                &mut issues_truncated,
+                issue(
+                    "actor_selection_outside_catalog",
+                    Some(row.actor_id),
+                    Some(reaction.clone()),
+                ),
+            );
+            continue;
+        }
+        for reaction in selected {
+            let count = expected.entry(reaction).or_default();
+            *count = count.checked_add(1).ok_or_else(|| {
+                PortError::invariant_violation(
+                    "reactions.reconciliation_count_exhausted",
+                    "reaction reconciliation expected aggregate count overflowed",
+                )
+            })?;
+        }
+    }
+
+    let aggregate_rows = aggregate::Entity::find()
+        .filter(aggregate::Column::TenantId.eq(request.subject.tenant_id()))
+        .filter(aggregate::Column::ReactionSubjectId.eq(stored_subject.id))
+        .order_by_asc(aggregate::Column::ReactionKey)
+        .all(connection)
+        .await
+        .map_err(database_error)?;
+    let mut actual = BTreeMap::<ReactionKey, i64>::new();
+    let mut changed_keys = BTreeSet::<String>::new();
+    let mut invalid_key_rows = 0_u64;
+    let mut repairable_drift = false;
+    for row in aggregate_rows {
+        let reaction = match ReactionKey::new(row.reaction_key) {
+            Ok(reaction) => reaction,
+            Err(_) => {
+                repairable_drift = true;
+                invalid_key_rows = invalid_key_rows.checked_add(1).ok_or_else(|| {
+                    PortError::invariant_violation(
+                        "reactions.reconciliation_count_exhausted",
+                        "reaction reconciliation invalid-key count overflowed",
+                    )
+                })?;
+                changed_keys.insert("invalid".to_string());
+                push_issue(
+                    &mut issues,
+                    &mut issues_truncated,
+                    issue("aggregate_key_invalid", None, None),
+                );
+                continue;
+            }
+        };
+        if row.count < 0 {
+            repairable_drift = true;
+            changed_keys.insert(reaction.to_string());
+            push_issue(
+                &mut issues,
+                &mut issues_truncated,
+                issue("aggregate_count_negative", None, Some(reaction.clone())),
+            );
+        }
+        if !catalog_value.contains(&reaction) {
+            repairable_drift = true;
+            changed_keys.insert(reaction.to_string());
+            push_issue(
+                &mut issues,
+                &mut issues_truncated,
+                issue("aggregate_outside_catalog", None, Some(reaction.clone())),
+            );
+        }
+        actual.insert(reaction, row.count);
+    }
+
+    let mut comparisons = Vec::with_capacity(catalog_value.keys().len());
+    for reaction in catalog_value.keys() {
+        let expected_count = expected.get(reaction).copied().unwrap_or(0);
+        let actual_count = actual.get(reaction).copied().unwrap_or(0);
+        if actual_count < 0 || u64::try_from(actual_count).ok() != Some(expected_count) {
+            repairable_drift = true;
+            changed_keys.insert(reaction.to_string());
+            push_issue(
+                &mut issues,
+                &mut issues_truncated,
+                issue("aggregate_count_mismatch", None, Some(reaction.clone())),
+            );
+        }
+        comparisons.push(ReactionAggregateComparison {
+            reaction: reaction.clone(),
+            expected: expected_count,
+            actual: actual_count,
+        });
+    }
+
+    let unique_changed_key_count = u64::try_from(changed_keys.len()).map_err(|_| {
+        PortError::invariant_violation(
+            "reactions.reconciliation_count_out_of_range",
+            "reaction reconciliation changed-key count exceeds u64",
+        )
+    })?;
+    let changed_key_count = unique_changed_key_count
+        .checked_add(invalid_key_rows.saturating_sub(u64::from(changed_keys.contains("invalid"))))
+        .ok_or_else(|| {
+            PortError::invariant_violation(
+                "reactions.reconciliation_count_exhausted",
+                "reaction reconciliation changed-key count overflowed",
+            )
+        })?;
+    let changed_key_sample = changed_keys
+        .into_iter()
+        .take(MAX_REACTIONS_EVENT_KEYS)
+        .collect::<Vec<_>>();
+    let status = if blocked {
+        ReactionReconciliationStatus::Blocked
+    } else if repairable_drift {
+        ReactionReconciliationStatus::Drift
+    } else {
+        ReactionReconciliationStatus::Clean
+    };
+
+    Ok(ReconciliationAnalysis {
+        report: ReactionReconciliationReport {
+            subject: request.subject.clone(),
+            catalog_revision,
+            status,
+            actor_states_scanned: actor_count,
+            aggregate_rows_scanned: aggregate_count,
+            comparisons,
+            issues,
+            issues_truncated,
+        },
+        reaction_subject_id: stored_subject.id,
+        expected,
+        changed_key_count,
+        changed_key_sample,
+    })
+}
+
+fn authorize_reconciliation(
+    context: &PortContext,
+    request: &ReactionReconciliationRequest,
+) -> Result<(), PortError> {
+    let tenant_id = Uuid::parse_str(&context.tenant_id).map_err(|_| {
+        PortError::validation(
+            "reactions.tenant_id_invalid",
+            "reaction port context must carry a UUID tenant_id",
+        )
+    })?;
+    if tenant_id != request.subject.tenant_id() {
+        return Err(PortError::forbidden(
+            "reactions.tenant_mismatch",
+            "reaction reconciliation subject does not belong to the port tenant",
+        ));
+    }
+    if !context
+        .claims
+        .iter()
+        .any(|claim| claim == RECONCILE_REACTIONS_CLAIM)
+    {
+        return Err(PortError::forbidden(
+            "reactions.reconciliation_forbidden",
+            "reaction reconciliation requires the reactions:reconcile claim",
+        ));
+    }
+    Ok(())
+}
+
+fn issue(
+    code: &str,
+    actor_id: Option<Uuid>,
+    reaction: Option<ReactionKey>,
+) -> ReactionReconciliationIssue {
+    ReactionReconciliationIssue {
+        code: code.to_string(),
+        actor_id,
+        reaction,
+    }
+}
+
+fn push_issue(
+    issues: &mut Vec<ReactionReconciliationIssue>,
+    truncated: &mut bool,
+    issue: ReactionReconciliationIssue,
+) {
+    if issues.len() < MAX_REACTION_RECONCILIATION_ISSUES {
+        issues.push(issue);
+    } else {
+        *truncated = true;
+    }
+}
+
+async fn publish_event_once(
+    transaction: &DatabaseTransaction,
+    envelope_id: Uuid,
+    tenant_id: Uuid,
+    actor_id: Option<Uuid>,
+    event: ReactionsEvent,
+) -> Result<(), PortError> {
+    match TransactionalEventBus::publish_contract_once_direct_in_tx_with_envelope_id(
+        transaction,
+        envelope_id,
+        tenant_id,
+        actor_id,
+        event,
+    )
+    .await
+    {
+        Ok(_) => Ok(()),
+        Err(ContractEventWriteOnceError::Conflict) => Err(PortError::conflict(
+            "reactions.event_identity_conflict",
+            "reaction semantic event identity is already bound to different facts",
+        )),
+        Err(ContractEventWriteOnceError::Unavailable) => Err(PortError::unavailable(
+            "reactions.event_unavailable",
+            "reaction semantic event could not be persisted",
+        )),
+    }
+}
+
+fn database_error(error: sea_orm::DbErr) -> PortError {
+    PortError::unavailable("reactions.database", error.to_string())
+}
+
+fn u64_to_i64(value: u64, label: &'static str) -> Result<i64, PortError> {
+    i64::try_from(value).map_err(|_| {
+        PortError::invariant_violation(
+            "reactions.revision_out_of_range",
+            format!("{label} exceeds the persistence range"),
+        )
+    })
+}
+
+fn i64_to_u64(value: i64, label: &'static str) -> Result<u64, PortError> {
+    u64::try_from(value).map_err(|_| {
+        PortError::invariant_violation(
+            "reactions.revision_invalid",
+            format!("{label} is negative"),
+        )
+    })
+}
+
+fn decode_replay<T: DeserializeOwned>(value: serde_json::Value) -> Result<T, PortError> {
+    serde_json::from_value(value).map_err(|error| {
+        PortError::invariant_violation("outbox.operation_receipt_corrupt", error.to_string())
+    })
+}

--- a/crates/rustok-reactions/src/service.rs
+++ b/crates/rustok-reactions/src/service.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use chrono::Utc;
 use rustok_api::{PortActorKind, PortCallPolicy, PortContext, PortError};
-use rustok_outbox::idempotency;
+use rustok_events::ReactionsEvent;
+use rustok_outbox::{ContractEventWriteOnceError, TransactionalEventBus, idempotency};
 use rustok_reactions_api::{
     ApplyReactionCommand, ReactionAction, ReactionActorState, ReactionAggregate, ReactionCatalog,
     ReactionContractError, ReactionKey, ReactionProviderError, ReactionReadPort,
@@ -178,6 +179,7 @@ impl ReactionsService {
         let transaction = self.database.begin().await.map_err(database_error)?;
         let result = apply_inside_transaction(
             &transaction,
+            lease.operation_id,
             command,
             canonical_subject,
             catalog_revision,
@@ -297,6 +299,7 @@ impl ReactionWritePort for ReactionsService {
 
 async fn apply_inside_transaction(
     transaction: &DatabaseTransaction,
+    event_envelope_id: Uuid,
     command: &ApplyReactionCommand,
     canonical_subject: ReactionSubjectRef,
     catalog_revision: u64,
@@ -355,6 +358,7 @@ async fn apply_inside_transaction(
     selected = next_selected;
 
     deltas.retain(|_, delta| *delta != 0);
+    let event_deltas = deltas.clone();
     let next_revision = if changed {
         current_revision.checked_add(1).ok_or_else(|| {
             PortError::invariant_violation(
@@ -389,6 +393,16 @@ async fn apply_inside_transaction(
             )
             .await?;
         }
+        publish_actor_state_changed(
+            transaction,
+            event_envelope_id,
+            command,
+            &canonical_subject,
+            next_revision,
+            &selected,
+            &event_deltas,
+        )
+        .await?;
     }
 
     ReactionWriteReceipt::new(
@@ -401,6 +415,68 @@ async fn apply_inside_transaction(
         next_revision,
     )
     .map_err(contract_error_to_port_error)
+}
+
+async fn publish_actor_state_changed(
+    transaction: &DatabaseTransaction,
+    envelope_id: Uuid,
+    command: &ApplyReactionCommand,
+    subject: &ReactionSubjectRef,
+    state_revision: u64,
+    selected: &[ReactionKey],
+    deltas: &BTreeMap<ReactionKey, i64>,
+) -> Result<(), PortError> {
+    let action = match command.action() {
+        ReactionAction::Add => "add",
+        ReactionAction::Remove => "remove",
+    };
+    let added_keys = deltas
+        .iter()
+        .filter(|(_, delta)| **delta > 0)
+        .map(|(reaction, _)| reaction.to_string())
+        .collect();
+    let removed_keys = deltas
+        .iter()
+        .filter(|(_, delta)| **delta < 0)
+        .map(|(reaction, _)| reaction.to_string())
+        .collect();
+    let event = ReactionsEvent::ActorStateChanged {
+        command_id: command.identity().command_id(),
+        source_slug: subject.source().to_string(),
+        subject_kind: subject.kind().to_string(),
+        subject_id: subject.subject_id(),
+        subject_revision: u64_to_i64(
+            subject.subject_revision(),
+            "reaction event subject revision",
+        )?,
+        actor_id: command.identity().actor_id(),
+        requested_reaction: command.reaction().to_string(),
+        action: action.to_string(),
+        state_revision: u64_to_i64(state_revision, "reaction event state revision")?,
+        selected_keys: selected.iter().map(ToString::to_string).collect(),
+        added_keys,
+        removed_keys,
+    };
+
+    match TransactionalEventBus::publish_contract_once_direct_in_tx_with_envelope_id(
+        transaction,
+        envelope_id,
+        subject.tenant_id(),
+        Some(command.identity().actor_id()),
+        event,
+    )
+    .await
+    {
+        Ok(_) => Ok(()),
+        Err(ContractEventWriteOnceError::Conflict) => Err(PortError::conflict(
+            "reactions.event_identity_conflict",
+            "reaction semantic event identity is already bound to different facts",
+        )),
+        Err(ContractEventWriteOnceError::Unavailable) => Err(PortError::unavailable(
+            "reactions.event_unavailable",
+            "reaction semantic event could not be persisted",
+        )),
+    }
 }
 
 fn plan_selection(

--- a/scripts/verify/verify-reactions-events-reconciliation.mjs
+++ b/scripts/verify/verify-reactions-events-reconciliation.mjs
@@ -1,0 +1,256 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath =
+  "crates/rustok-reactions/contracts/reactions-events-reconciliation.json";
+
+function fail(message) {
+  throw new Error(`Reactions events/reconciliation verification failed: ${message}`);
+}
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!existsSync(absolute)) fail(`missing required file ${relativePath}`);
+  return readFileSync(absolute, "utf8");
+}
+
+function normalized(value) {
+  return value.replace(/\s+/gu, " ");
+}
+
+function section(source, start, end) {
+  const startIndex = source.indexOf(start);
+  if (startIndex < 0) fail(`missing section start ${start}`);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (endIndex < 0) fail(`missing section end ${end}`);
+  return source.slice(startIndex, endIndex);
+}
+
+const contract = JSON.parse(read(contractPath));
+if (contract.schema_version !== 1) fail("unsupported contract schema version");
+if (contract.contract !== "reactions_events_reconciliation_v1") {
+  fail("unexpected contract identity");
+}
+if (contract.module !== "reactions") fail("owner module must be reactions");
+if (contract.status !== "source_ready_maintainer_execution_pending") {
+  fail("source contract must not claim retained execution");
+}
+for (const requiredFile of contract.required_files) read(requiredFile);
+
+const eventsCargo = read("crates/rustok-events/Cargo.toml");
+const eventContract = read("crates/rustok-events/src/contract.rs");
+const eventLib = read("crates/rustok-events/src/lib.rs");
+const eventFamily = read("crates/rustok-events/src/reactions.rs");
+const eventTests = read("crates/rustok-events/tests/reactions_contracts.rs");
+const eventApi = read("crates/rustok-events/CRATE_API.md");
+const ownerCargo = read("crates/rustok-reactions/Cargo.toml");
+const ownerLib = read("crates/rustok-reactions/src/lib.rs");
+const service = read("crates/rustok-reactions/src/service.rs");
+const reconciliation = read("crates/rustok-reactions/src/reconciliation.rs");
+const reactionsPlan = normalized(
+  read("crates/rustok-reactions/docs/implementation-plan.md"),
+);
+const forumPlan = normalized(
+  read("crates/rustok-forum/docs/implementation-plan.md"),
+);
+
+if (!ownerCargo.includes("rustok-events.workspace = true")) {
+  fail("Reactions owner must depend on the central typed event contract crate");
+}
+if (eventsCargo.includes("rustok-reactions")) {
+  fail("rustok-events must not depend on the Reactions owner crate");
+}
+
+for (const eventType of contract.event_family.types) {
+  if (!eventFamily.includes(`"${eventType}"`)) {
+    fail(`typed event family is missing ${eventType}`);
+  }
+}
+for (const fragment of [
+  "pub enum ReactionsEvent",
+  "ActorStateChanged",
+  "SubjectReconciled",
+  "impl EventContract for ReactionsEvent",
+  "impl ValidateEvent for ReactionsEvent",
+  "MAX_REACTIONS_EVENT_KEYS",
+  "added keys must be selected and disjoint from removed keys",
+  "a reconciliation event must contain a bounded changed-key sample",
+]) {
+  if (!eventFamily.includes(fragment)) fail(`event family is missing ${fragment}`);
+}
+for (const fragment of [
+  "Reactions(ReactionsEvent)",
+  "Self::Reactions(event) => event.event_type()",
+  "Self::Reactions(event) => event.schema_version()",
+  "Self::Reactions(event) => event.validate()",
+]) {
+  if (!eventContract.includes(fragment)) fail(`closed payload family is missing ${fragment}`);
+}
+for (const fragment of [
+  "mod reactions;",
+  "REACTIONS_EVENT_SCHEMAS",
+  "reactions_event_schema(event_type)",
+  ".chain(REACTIONS_EVENT_SCHEMAS.iter())",
+]) {
+  if (!eventLib.includes(fragment)) fail(`event registry is missing ${fragment}`);
+}
+for (const fragment of [
+  "reactions_family_registers_both_schema_v1_contracts",
+  "actor_state_change_is_typed_validated_and_enveloped",
+  "actor_state_change_rejects_noop_and_overlapping_deltas",
+  "reconciled_event_requires_truthful_bounded_sample",
+]) {
+  if (!eventTests.includes(fragment)) fail(`event tests are missing ${fragment}`);
+}
+for (const fragment of [
+  "ReactionsEvent",
+  "reactions.actor_state.changed",
+  "reactions.subject.reconciled",
+  "owner-operation UUID",
+]) {
+  if (!eventApi.includes(fragment)) fail(`event CRATE_API is missing ${fragment}`);
+}
+
+for (const fragment of [
+  "lease.operation_id",
+  "publish_actor_state_changed(",
+  "TransactionalEventBus::publish_contract_once_direct_in_tx_with_envelope_id(",
+  "ReactionsEvent::ActorStateChanged",
+  "if changed {",
+  "idempotency::complete(&transaction, lease, &receipt)",
+  "transaction.commit()",
+  "reactions.event_identity_conflict",
+  "reactions.event_unavailable",
+]) {
+  if (!service.includes(fragment)) fail(`transactional command path is missing ${fragment}`);
+}
+const executeApply = section(
+  service,
+  "async fn execute_apply(",
+  "#[async_trait]\nimpl ReactionReadPort",
+);
+const applyBody = section(
+  service,
+  "async fn apply_inside_transaction(",
+  "async fn publish_actor_state_changed(",
+);
+const applyCallIndex = executeApply.indexOf("apply_inside_transaction(");
+const completionIndex = executeApply.indexOf(
+  "idempotency::complete(&transaction, lease, &receipt)",
+);
+const commitIndex = executeApply.indexOf("transaction.commit()");
+if (!(applyCallIndex >= 0 && applyCallIndex < completionIndex && completionIndex < commitIndex)) {
+  fail("command mutation/event, receipt completion and commit ordering is not explicit");
+}
+const mutationIndex = applyBody.indexOf("persist_actor_state(");
+const aggregateIndex = applyBody.indexOf("apply_aggregate_delta(");
+const eventIndex = applyBody.indexOf("publish_actor_state_changed(");
+if (!(mutationIndex >= 0 && mutationIndex < aggregateIndex && aggregateIndex < eventIndex)) {
+  fail("actor state, aggregate and event ordering is not explicit");
+}
+if (service.includes("ContractEventEnvelope::new(")) {
+  fail("command path must not generate a second random event identity");
+}
+
+for (const fragment of [
+  "MAX_REACTION_RECONCILIATION_ACTOR_STATES: u32 = 1_000",
+  "MAX_REACTION_RECONCILIATION_ISSUES: usize = 64",
+  "MAX_REACTION_RECONCILIATION_AGGREGATE_ROWS: u64 = 128",
+  'const RECONCILE_REACTIONS_CLAIM: &str = "reactions:reconcile"',
+  "pub async fn inspect_reconciliation",
+  "PortCallPolicy::read()",
+  "pub async fn repair_reconciliation",
+  "PortCallPolicy::write()",
+  "reactions.reconciliation_command_idempotency_mismatch",
+  "idempotency::admit(",
+  "self.execute_repair(lease, actor_id, &command)",
+  "serialize_subject(transaction",
+  "ReactionReconciliationStatus::Blocked",
+  "reaction aggregate repair is blocked by catalog or actor-state corruption",
+  "aggregate::Entity::delete_many()",
+  "ReactionsEvent::SubjectReconciled",
+  "idempotency::complete(&transaction, lease, &receipt)",
+  "transaction.commit()",
+  "row.revision <= 0",
+  "actor_state_duplicate_keys",
+  "actor_selection_limit_exceeded",
+  "actor_selection_outside_catalog",
+  "aggregate_count_mismatch",
+  "issues.len() < MAX_REACTION_RECONCILIATION_ISSUES",
+]) {
+  if (!reconciliation.includes(fragment)) {
+    fail(`bounded reconciliation is missing ${fragment}`);
+  }
+}
+const repairEntry = section(
+  reconciliation,
+  "pub async fn repair_reconciliation(",
+  "async fn execute_repair(",
+);
+if (!repairEntry.includes("self.execute_repair(lease, actor_id, &command).await")) {
+  fail("failure receipt boundary must call the transaction-scoped repair helper");
+}
+if (!repairEntry.includes("idempotency::fail(self.database(), lease, error)")) {
+  fail("repair failure receipt must be persisted after the helper returns");
+}
+if (!ownerLib.includes("mod reconciliation;")) {
+  fail("owner crate does not compile the reconciliation module");
+}
+for (const symbol of [
+  "ReactionReconciliationRequest",
+  "ReactionReconciliationReport",
+  "ReactionReconciliationReceipt",
+  "RepairReactionSubjectCommand",
+]) {
+  if (!ownerLib.includes(symbol)) fail(`owner crate does not export ${symbol}`);
+}
+
+for (const forbidden of [
+  "rustok_forum",
+  "rustok_blog",
+  "rustok_profiles",
+  "async_graphql",
+  "axum::",
+  "leptos::",
+]) {
+  if (service.includes(forbidden) || reconciliation.includes(forbidden)) {
+    fail(`owner event/reconciliation path imports forbidden dependency ${forbidden}`);
+  }
+}
+for (const forbidden of [
+  "visibility",
+  "display_name",
+  "profile_handle",
+  "locale",
+  "channel",
+  "claims",
+  "roles",
+]) {
+  if (eventFamily.includes(`${forbidden}:`)) {
+    fail(`semantic event payload exposes forbidden field ${forbidden}`);
+  }
+}
+
+for (const fragment of [
+  "typed semantic events and completed shared Outbox receipts now share one transaction",
+  "Bounded inspect/repair reconciliation is source-ready",
+  "Idempotent no-op commands and completed receipt replays do not publish another event",
+  "reactions:reconcile",
+  "event_contract_digests",
+  "verify-reactions-events-reconciliation.mjs",
+]) {
+  if (!reactionsPlan.includes(fragment)) fail(`Reactions plan is missing ${fragment}`);
+}
+for (const fragment of [
+  "| `FORUM-18` | `in_progress` |",
+  "semantic reaction events",
+  "bounded aggregate reconciliation",
+  "Existing Forum votes remain Forum semantics",
+  "verify-reactions-events-reconciliation.mjs",
+]) {
+  if (!forumPlan.includes(fragment)) fail(`Forum plan is missing ${fragment}`);
+}
+
+console.log("Reactions transactional events and bounded reconciliation verified.");


### PR DESCRIPTION
## Summary

Add sealed semantic Reactions events and bounded owner-only aggregate reconciliation without introducing transport, UI, background scheduling or another producer.

- add the schema-v1 `rustok-events::ReactionsEvent` family:
  - `reactions.actor_state.changed`;
  - `reactions.subject.reconciled`;
- register the family in the closed typed payload and central event schema registry;
- use the admitted `owner_operation_receipts.id` as the exact write-once event envelope identity;
- commit actor state, aggregate deltas, one semantic event and the completed shared receipt in the same owner transaction;
- emit no event for an idempotent no-op or completed receipt replay;
- roll back state, aggregates and receipt completion when event persistence fails;
- add bounded reconciliation inspection and repair for one exact stored subject;
- require exact tenant scope and `reactions:reconcile`;
- cap actor states at 1,000, aggregate rows at 128 and reported issues at 64;
- reconstruct only `reaction_aggregates` from valid actor selections under the immutable current catalog;
- block mutation on missing/corrupt catalog or corrupt/out-of-policy actor state;
- add a machine-readable contract, event contract tests and source verifier;
- update the Events API docs plus canonical Reactions and Forum plans.

## Ownership

Reactions owns actor state, aggregate projections, semantic reaction events and aggregate repair. Producers continue to own subject existence, revision, visibility, lifecycle and reaction policy.

Reconciliation does not mutate actor selections or catalog snapshots, does not read producer-private tables and does not reinterpret existing Forum votes.

## Deliberate limits

This PR does not add:

- GraphQL, REST or native transport;
- admin/storefront UI;
- background reconciliation worker or scheduler;
- a second producer adapter;
- Notifications, Reputation or Achievements consumers;
- default enablement;
- runtime execution evidence.

## Generated artifacts

`Cargo.lock` and `crates/rustok-events/contracts/event-contract-digests.json` were not regenerated. The maintainer run must retain the minimal lockfile delta and deliberately regenerate/review the event contract digest artifact.

## Validation

Not run per maintainer instruction:

- Rust tests;
- Cargo check, formatting or Clippy;
- Node verifiers;
- event digest generation;
- SQLite/PostgreSQL migrations, command, rollback, replay or reconciliation scenarios;
- workflows or CI.

Suggested maintainer commands:

```bash
cargo test -p rustok-events reactions
cargo test -p rustok-reactions-api
cargo test -p rustok-reactions
cargo check -p rustok-reactions --all-targets
cargo run -p rustok-events --example event_contract_digests -- --write
node scripts/verify/verify-reactions-foundation.mjs
node scripts/verify/verify-reactions-owner-persistence.mjs
node scripts/verify/verify-forum-reaction-subject-provider.mjs
node scripts/verify/verify-reactions-host-composition.mjs
node scripts/verify/verify-reactions-composition-profiles.mjs
node scripts/verify/verify-reactions-events-reconciliation.mjs
git diff --check
```

Source status remains `source_ready_maintainer_execution_pending`.