### PR TITLE
feat(product): add Index refresh canonical writer

### DIFF
--- a/crates/rustok-product/docs/index-refresh-canonical-writer.md
+++ b/crates/rustok-product/docs/index-refresh-canonical-writer.md
@@ -1,0 +1,105 @@
+# Product Index refresh canonical writer
+
+Status: `source_complete_typed_family_and_relay_pending`.
+
+## Purpose
+
+Product locale and ProductVariant refresh ledgers already retain one immutable source row per exact
+Index identity. Each row carries:
+
+- `refresh_id`, reserved as the canonical typed envelope and downstream inbox identity;
+- `root_event_id`, the exact Product lifecycle predecessor;
+- tenant and target identity;
+- the positive trigger-owned source revision.
+
+This slice adds the canonical write-once handoff to `sys_events` without defining the public Product
+refresh event family or starting a relay loop.
+
+## Typed boundary
+
+`ProductIndexRefreshContract` extends the sealed `rustok_events::EventContract`. The trait is owned by
+`rustok-product`, so only Product can implement it for the future Product refresh family. Other
+modules cannot implement `EventContract` for arbitrary payloads and cannot route an unrelated typed
+family through Product ledger identities.
+
+The event must expose one exact target:
+
+- `Locale { product_id, locale, source_version }`; or
+- `Variant { product_id, variant_id, source_version }`.
+
+`ProductIndexRefreshCanonicalWriter` compares those typed facts with the immutable ledger row before
+any outbox write. A target-kind, identity, locale, variant or revision mismatch returns
+`ProductIndexRefreshPublicationError::ContractMismatch`.
+
+## Causal root validation
+
+The refresh ledger intentionally has no foreign key to `sys_events`, so the writer proves causation
+inside the caller-owned transaction before publishing. It reads `root_event_id` from canonical
+`sys_events`, decodes and revalidates the registered root `EventEnvelope`, and requires:
+
+- row ID, envelope ID and ledger `root_event_id` to match;
+- durable row event type and schema version to match the decoded envelope;
+- envelope tenant to match the ledger tenant;
+- the root payload to be `ProductCreated`, `ProductUpdated`, `ProductPublished` or `ProductDeleted`;
+- the root payload Product identity to match the ledger Product identity.
+
+A missing, non-root, corrupt or mismatched predecessor returns
+`ProductIndexRefreshPublicationError::CausationMismatch`. Database read failures remain
+`Unavailable`.
+
+## Canonical envelope identity
+
+For a matching row, causal root and event, the writer calls the shared exact-caused write-once
+boundary with:
+
+```text
+id = correlation_id = refresh_id
+causation_id = root_event_id
+tenant_id = ledger tenant
+actor_id = validated root envelope actor
+```
+
+The derived refresh event does not reconstruct an actor from mutable Product state. It preserves the
+optional actor already retained by the exact causal root envelope.
+
+Exact replay returns the same `refresh_id`. Reuse of that identity for different envelope scope,
+causation or typed facts returns `Conflict`. Validation, serialization and database failures return
+`Unavailable` without leaking infrastructure details.
+
+## Ownership
+
+The writer:
+
+- writes only through the canonical `rustok-outbox` transaction API;
+- does not dispatch directly to local delivery or Iggy;
+- does not own retry, leases, DLQ, retention or acknowledgement;
+- does not mutate the append-only Product refresh ledgers;
+- does not write Index tables or construct `IndexMutation` values;
+- requires a caller-owned database transaction.
+
+Delivery after commit remains owned by the global `OutboxRelay` and the selected
+`outbox_local|outbox_iggy` profile.
+
+## Deliberate limits
+
+This slice does not:
+
+- add `ProductIndexRefreshEvent` to `rustok-events`;
+- change the event registry, transport schema or committed digests;
+- implement the Product trait for an event family that does not yet exist;
+- page the ledgers or persist a relay cursor;
+- register Product or ProductVariant Index routes;
+- start a concrete broker consumer;
+- add retry, DLQ or commit-before-ack evidence;
+- alter or bypass the concrete-repair evidence gate.
+
+## Maintainer verification
+
+```bash
+node scripts/verify/verify-index-product-refresh-canonical-writer.mjs
+cargo check -p rustok-product --all-targets
+git diff --check
+```
+
+No tests, Node verifiers, Cargo checks, formatting, database scenarios, workflows or CI were executed
+by the implementation agent.

--- a/crates/rustok-product/src/lib.rs
+++ b/crates/rustok-product/src/lib.rs
@@ -32,7 +32,9 @@ pub use services::{
     AdminProductList, AdminProductListItem, AdminProductListQuery, CatalogService,
     MAX_PRODUCT_INDEX_LOCALE_REFRESH_PAGE, MAX_PRODUCT_INDEX_VARIANT_REFRESH_PAGE,
     ProductAttributeFilter, ProductCatalogSchemaService, ProductIndexLocaleRefreshRecord,
-    ProductIndexLocaleRefreshSource, ProductIndexVariantRefreshRecord,
+    ProductIndexLocaleRefreshSource, ProductIndexRefreshCanonicalWriter,
+    ProductIndexRefreshContract, ProductIndexRefreshContractTarget,
+    ProductIndexRefreshPublicationError, ProductIndexVariantRefreshRecord,
     ProductIndexVariantRefreshSource, StorefrontProductList, StorefrontProductListItem,
     StorefrontProductListQuery, StorefrontProductSortBy, StorefrontProductSortDirection,
 };

--- a/crates/rustok-product/src/services/index_refresh_publication.rs
+++ b/crates/rustok-product/src/services/index_refresh_publication.rs
@@ -1,0 +1,196 @@
+use rustok_events::{DomainEvent, EventContract, EventEnvelope};
+use rustok_outbox::{ContractEventWriteOnceError, SysEvents, TransactionalEventBus};
+use sea_orm::{DatabaseTransaction, EntityTrait};
+use thiserror::Error;
+use uuid::Uuid;
+
+use super::{ProductIndexLocaleRefreshRecord, ProductIndexVariantRefreshRecord};
+
+/// Exact Product-owned target facts that a typed Index refresh event must expose.
+///
+/// Envelope identity and causation are deliberately absent: they come from the
+/// immutable owner ledger and are never reconstructed from event payload data.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ProductIndexRefreshContractTarget {
+    Locale {
+        product_id: Uuid,
+        locale: String,
+        source_version: u64,
+    },
+    Variant {
+        product_id: Uuid,
+        variant_id: Uuid,
+        source_version: u64,
+    },
+}
+
+/// Product-specific sealed-contract projection used by the canonical writer.
+///
+/// `EventContract` itself is sealed by `rustok-events`. Because this trait is
+/// owned by `rustok-product`, only this crate can implement it for a future
+/// Product refresh event family. Other modules therefore cannot route an
+/// unrelated typed event through Product ledger identities.
+pub trait ProductIndexRefreshContract: EventContract {
+    fn product_index_refresh_target(&self) -> ProductIndexRefreshContractTarget;
+}
+
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum ProductIndexRefreshPublicationError {
+    #[error("Product Index refresh event does not match the immutable owner ledger row")]
+    ContractMismatch,
+    #[error("Product Index refresh ledger causation does not match a Product root envelope")]
+    CausationMismatch,
+    #[error("Product Index refresh envelope identity is already bound to different facts")]
+    Conflict,
+    #[error("Product Index refresh canonical publication is unavailable")]
+    Unavailable,
+}
+
+/// Canonical write-once handoff from Product refresh ledgers to `sys_events`.
+///
+/// This type does not page ledgers, run a loop, own retry state, or dispatch to
+/// a broker. A future relay supplies one validated typed Product refresh event
+/// and one caller-owned transaction. Delivery after commit remains owned by the
+/// shared `OutboxRelay`.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ProductIndexRefreshCanonicalWriter;
+
+impl ProductIndexRefreshCanonicalWriter {
+    pub async fn publish_locale_once_in_transaction<E>(
+        transaction: &DatabaseTransaction,
+        record: &ProductIndexLocaleRefreshRecord,
+        event: E,
+    ) -> Result<Uuid, ProductIndexRefreshPublicationError>
+    where
+        E: ProductIndexRefreshContract,
+    {
+        let expected = ProductIndexRefreshContractTarget::Locale {
+            product_id: record.product_id(),
+            locale: record.locale().to_owned(),
+            source_version: record.source_version(),
+        };
+        if event.product_index_refresh_target() != expected {
+            return Err(ProductIndexRefreshPublicationError::ContractMismatch);
+        }
+
+        publish_once(
+            transaction,
+            record.refresh_id(),
+            record.root_event_id(),
+            record.tenant_id(),
+            record.product_id(),
+            event,
+        )
+        .await
+    }
+
+    pub async fn publish_variant_once_in_transaction<E>(
+        transaction: &DatabaseTransaction,
+        record: &ProductIndexVariantRefreshRecord,
+        event: E,
+    ) -> Result<Uuid, ProductIndexRefreshPublicationError>
+    where
+        E: ProductIndexRefreshContract,
+    {
+        let expected = ProductIndexRefreshContractTarget::Variant {
+            product_id: record.product_id(),
+            variant_id: record.variant_id(),
+            source_version: record.source_version(),
+        };
+        if event.product_index_refresh_target() != expected {
+            return Err(ProductIndexRefreshPublicationError::ContractMismatch);
+        }
+
+        publish_once(
+            transaction,
+            record.refresh_id(),
+            record.root_event_id(),
+            record.tenant_id(),
+            record.product_id(),
+            event,
+        )
+        .await
+    }
+}
+
+async fn publish_once<E>(
+    transaction: &DatabaseTransaction,
+    refresh_id: Uuid,
+    root_event_id: Uuid,
+    tenant_id: Uuid,
+    product_id: Uuid,
+    event: E,
+) -> Result<Uuid, ProductIndexRefreshPublicationError>
+where
+    E: ProductIndexRefreshContract,
+{
+    let actor_id = load_product_root_actor(
+        transaction,
+        root_event_id,
+        tenant_id,
+        product_id,
+    )
+    .await?;
+
+    TransactionalEventBus::publish_contract_once_direct_in_tx_with_envelope_id_and_causation(
+        transaction,
+        refresh_id,
+        tenant_id,
+        actor_id,
+        root_event_id,
+        event,
+    )
+    .await
+    .map_err(map_write_once_error)
+}
+
+async fn load_product_root_actor(
+    transaction: &DatabaseTransaction,
+    root_event_id: Uuid,
+    tenant_id: Uuid,
+    product_id: Uuid,
+) -> Result<Option<Uuid>, ProductIndexRefreshPublicationError> {
+    let stored = SysEvents::find_by_id(root_event_id)
+        .one(transaction)
+        .await
+        .map_err(|_| ProductIndexRefreshPublicationError::Unavailable)?
+        .ok_or(ProductIndexRefreshPublicationError::CausationMismatch)?;
+    let envelope: EventEnvelope = serde_json::from_value(stored.payload)
+        .map_err(|_| ProductIndexRefreshPublicationError::CausationMismatch)?;
+    envelope
+        .validate_registered_schema()
+        .map_err(|_| ProductIndexRefreshPublicationError::CausationMismatch)?;
+
+    let envelope_schema_version = i16::try_from(envelope.schema_version)
+        .map_err(|_| ProductIndexRefreshPublicationError::CausationMismatch)?;
+    if envelope.id != stored.id
+        || envelope.id != root_event_id
+        || envelope.event_type != stored.event_type
+        || envelope_schema_version != stored.schema_version
+        || envelope.tenant_id != tenant_id
+    {
+        return Err(ProductIndexRefreshPublicationError::CausationMismatch);
+    }
+
+    let root_product_id = match &envelope.event {
+        DomainEvent::ProductCreated { product_id }
+        | DomainEvent::ProductUpdated { product_id }
+        | DomainEvent::ProductPublished { product_id }
+        | DomainEvent::ProductDeleted { product_id } => *product_id,
+        _ => return Err(ProductIndexRefreshPublicationError::CausationMismatch),
+    };
+    if root_product_id != product_id {
+        return Err(ProductIndexRefreshPublicationError::CausationMismatch);
+    }
+
+    Ok(envelope.actor_id)
+}
+
+const fn map_write_once_error(
+    error: ContractEventWriteOnceError,
+) -> ProductIndexRefreshPublicationError {
+    match error {
+        ContractEventWriteOnceError::Conflict => ProductIndexRefreshPublicationError::Conflict,
+        ContractEventWriteOnceError::Unavailable => ProductIndexRefreshPublicationError::Unavailable,
+    }
+}

--- a/crates/rustok-product/src/services/mod.rs
+++ b/crates/rustok-product/src/services/mod.rs
@@ -2,6 +2,7 @@ pub mod catalog;
 pub mod catalog_schema;
 pub mod catalog_schema_service;
 mod index_refresh;
+mod index_refresh_publication;
 mod write_transaction;
 
 pub use catalog::{
@@ -15,4 +16,8 @@ pub use index_refresh::{
     MAX_PRODUCT_INDEX_LOCALE_REFRESH_PAGE, MAX_PRODUCT_INDEX_VARIANT_REFRESH_PAGE,
     ProductIndexLocaleRefreshRecord, ProductIndexLocaleRefreshSource,
     ProductIndexVariantRefreshRecord, ProductIndexVariantRefreshSource,
+};
+pub use index_refresh_publication::{
+    ProductIndexRefreshCanonicalWriter, ProductIndexRefreshContract,
+    ProductIndexRefreshContractTarget, ProductIndexRefreshPublicationError,
 };

--- a/scripts/verify/verify-index-product-refresh-canonical-writer.mjs
+++ b/scripts/verify/verify-index-product-refresh-canonical-writer.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-refresh-canonical-writer] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const writerPath = 'crates/rustok-product/src/services/index_refresh_publication.rs';
+const writer = requireMarkers(writerPath, [
+  'pub enum ProductIndexRefreshContractTarget',
+  'Locale {',
+  'Variant {',
+  'pub trait ProductIndexRefreshContract: EventContract',
+  'fn product_index_refresh_target(&self) -> ProductIndexRefreshContractTarget',
+  'pub enum ProductIndexRefreshPublicationError',
+  'ContractMismatch',
+  'CausationMismatch',
+  'Conflict',
+  'Unavailable',
+  'pub struct ProductIndexRefreshCanonicalWriter',
+  'publish_locale_once_in_transaction',
+  'publish_variant_once_in_transaction',
+  'event.product_index_refresh_target() != expected',
+  'load_product_root_actor(',
+  'SysEvents::find_by_id(root_event_id)',
+  'let envelope: EventEnvelope = serde_json::from_value(stored.payload)',
+  '.validate_registered_schema()',
+  'envelope.id != stored.id',
+  'envelope.id != root_event_id',
+  'envelope.event_type != stored.event_type',
+  'envelope.tenant_id != tenant_id',
+  'DomainEvent::ProductCreated',
+  'DomainEvent::ProductUpdated',
+  'DomainEvent::ProductPublished',
+  'DomainEvent::ProductDeleted',
+  'root_product_id != product_id',
+  'Ok(envelope.actor_id)',
+  'publish_contract_once_direct_in_tx_with_envelope_id_and_causation',
+  'record.refresh_id()',
+  'record.root_event_id()',
+  'record.tenant_id()',
+  'ContractEventWriteOnceError::Conflict',
+  'ContractEventWriteOnceError::Unavailable',
+]);
+
+for (const forbidden of [
+  'serde_json::Value',
+  'OutboxTransport::',
+  'EventTransport::',
+  'IndexMutation',
+  'index_entities',
+  'index_links',
+  'tokio::spawn',
+  'sleep(',
+  'loop {',
+  'acknowledge(',
+  'publish_contract(',
+]) {
+  if (writer.includes(forbidden)) {
+    fail(`${writerPath} contains forbidden runtime or untyped coupling: ${forbidden}`);
+  }
+}
+
+const services = requireMarkers('crates/rustok-product/src/services/mod.rs', [
+  'mod index_refresh_publication;',
+  'ProductIndexRefreshCanonicalWriter',
+  'ProductIndexRefreshContract',
+  'ProductIndexRefreshContractTarget',
+  'ProductIndexRefreshPublicationError',
+]);
+if (services.includes('pub mod index_refresh_publication')) {
+  fail('the implementation module must remain private behind curated exports');
+}
+
+requireMarkers('crates/rustok-product/src/lib.rs', [
+  'ProductIndexRefreshCanonicalWriter',
+  'ProductIndexRefreshContract',
+  'ProductIndexRefreshContractTarget',
+  'ProductIndexRefreshPublicationError',
+]);
+
+const cargo = read('crates/rustok-product/Cargo.toml');
+for (const dependency of ['rustok-events.workspace = true', 'rustok-outbox.workspace = true']) {
+  if (!cargo.includes(dependency)) fail(`rustok-product is missing ${dependency}`);
+}
+if (cargo.includes('rustok-index')) {
+  fail('rustok-product must not depend on rustok-index');
+}
+
+requireMarkers('crates/rustok-product/docs/index-refresh-canonical-writer.md', [
+  'Status: `source_complete_typed_family_and_relay_pending`',
+  '`refresh_id`, reserved as the canonical typed envelope',
+  '`root_event_id`, the exact Product lifecycle predecessor',
+  '`ProductIndexRefreshContract` extends the sealed',
+  '`ProductIndexRefreshPublicationError::ContractMismatch`',
+  '`ProductIndexRefreshPublicationError::CausationMismatch`',
+  'reads `root_event_id` from canonical',
+  'the root payload Product identity to match the ledger Product identity',
+  'id = correlation_id = refresh_id',
+  'causation_id = root_event_id',
+  'actor_id = validated root envelope actor',
+  'global `OutboxRelay`',
+  'does not mutate the append-only Product refresh ledgers',
+  'does not write Index tables',
+  'change the event registry, transport schema or committed digests',
+  'No tests, Node verifiers, Cargo checks',
+]);
+
+console.log('[verify-index-product-refresh-canonical-writer] Product refresh canonical writer contract verified');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -61,6 +61,7 @@ const scripts = [
   'verify-index-product-source.mjs',
   'verify-index-product-locale-refresh-ledger.mjs',
   'verify-index-product-variant-refresh-ledger.mjs',
+  'verify-index-product-refresh-canonical-writer.mjs',
   'verify-index-product-variant-source.mjs',
   'verify-index-product-graph-source.mjs',
   'verify-index-product-tombstone-source.mjs',


### PR DESCRIPTION
## Summary

Add a Product-owned exact typed-target handoff from immutable locale/ProductVariant refresh ledgers into canonical `sys_events`.

- add `ProductIndexRefreshContractTarget` for exact locale or variant identity plus owner revision;
- add `ProductIndexRefreshContract`, extending the sealed platform `EventContract`;
- add `ProductIndexRefreshCanonicalWriter` for one caller-owned transaction;
- compare typed event facts with the immutable ledger row before any outbox write;
- re-read and validate the exact causal Product root envelope from `sys_events`;
- require root row/envelope metadata, tenant and Product identity to match the ledger;
- preserve `refresh_id` as envelope/correlation identity and `root_event_id` as causation;
- preserve the optional actor from the validated root envelope;
- map target mismatch, causal mismatch, write-once conflict and unavailable infrastructure to closed Product errors;
- keep delivery owned by the global `OutboxRelay`;
- add documentation and a fail-closed source verifier registered in the Index aggregate verifier.

## Safety

The new writer accepts only a type that implements both the sealed `rustok_events::EventContract` and the Product-owned `ProductIndexRefreshContract`. Other modules cannot introduce arbitrary payloads or route unrelated typed families through Product ledger identities.

A missing, corrupt, non-Product or mismatched root envelope fails before publication. The writer performs no direct broker delivery, acknowledgement, retry, DLQ, lease or Index-table mutation.

## Deliberate limits

This PR does not:

- add the Product/ProductVariant typed event family;
- change the event registry, transport schemas or committed digests;
- implement ledger paging or a relay cursor;
- register Index mutation routes;
- start a broker consumer;
- add runtime or commit-before-ack evidence;
- alter the concrete-repair evidence gate.

## Main recheck

The branch is one commit ahead of `main@de9fbda91ffa6ea8e5256017b664029a9a02e78d` with exactly six changed files. The concurrent Commerce changes do not overlap this Product/Index slice.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatting, database scenarios, workflows or CI were run.