### PR TITLE
fix(commerce): preserve payment retry disposition

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/checkout-payment-stage-error-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/checkout-payment-stage-error-safety-source-review.json
@@ -5,8 +5,11 @@
     "crates/rustok-commerce/src/services/checkout_payment_stages.rs",
     "crates/rustok-commerce/src/services/checkout_payment_stages_legacy.rs",
     "crates/rustok-commerce/src/services/staged_checkout.rs",
+    "crates/rustok-commerce/src/services/checkout_operation.rs",
+    "crates/rustok-commerce/src/services/recovering_staged_checkout.rs",
     "crates/rustok-commerce/docs/checkout-payment-stage-context.md",
     "scripts/verify/verify-commerce-checkout-payment-stage-context.mjs",
+    "scripts/verify/verify-commerce-staged-checkout-payment-retry-disposition.mjs",
     "scripts/verify/verify-commerce-checkout-owner-stage-boundary.mjs",
     "scripts/verify/verify-ecommerce-typed-lifecycle-statuses.mjs"
   ],
@@ -35,7 +38,15 @@
     "typed_lifecycle_guard_updated": true,
     "successful_dtos_changed": false,
     "checkpoint_order_changed": false,
-    "failure_disposition_changed": false,
+    "failure_disposition_changed": true,
+    "retryable_payment_boundary_disposition_retryable": true,
+    "non_retryable_payment_boundary_disposition_compensation_required": true,
+    "retryable_payment_boundary_synchronous_compensation": false,
+    "operation_journal_implementation_changed": false,
+    "recovery_service_implementation_changed": false,
+    "payment_stage_execution_changed": false,
+    "payment_stage_error_code_mapping_changed": false,
+    "source_tests_added": true,
     "http_contract_changed": false,
     "graphql_contract_changed": false,
     "native_contract_changed": false,
@@ -51,11 +62,13 @@
     "format_run": false,
     "provider_calls_run": false,
     "database_scenarios_run": false,
+    "restart_scenarios_run": false,
+    "remote_port_scenarios_run": false,
     "workflow_checks_run": false,
     "ci_run": false,
     "compile_proven": false,
     "runtime_proven": false
   },
   "execution": [],
-  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, provider calls, database scenarios, workflows, or CI were executed."
+  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, provider calls, database scenarios, restart scenarios, remote-port scenarios, workflows, or CI were executed."
 }

--- a/crates/rustok-commerce/docs/checkout-payment-stage-context.md
+++ b/crates/rustok-commerce/docs/checkout-payment-stage-context.md
@@ -4,27 +4,61 @@ Status: **source-reviewed / unvalidated**
 
 ## Scope
 
-This source wave closes the payment-execution mapper gap on the mounted durable
-checkout path.
-
-`checkout_payment_stages.rs` is now a thin facade over the retained
-`checkout_payment_stages_legacy.rs` implementation. The legacy implementation
-keeps the established prepare, authorize, capture, read, checkpoint, replay, and
-collection-validation behavior unchanged. A payment-port adapter now intercepts
-owner failures before they reach the legacy stage mapper.
-
-The adapter covers the four canonical `CheckoutPaymentExecutionPort` calls:
+The mounted payment-execution facade covers the four canonical
+`CheckoutPaymentExecutionPort` calls:
 
 - `prepare_checkout_collection`;
 - `authorize_checkout_collection`;
 - `capture_checkout_collection`;
 - `read_checkout_collection`.
 
-## Public and persisted error policy
+The facade continues to preserve the complete delegated `PortContext`, canonical
+requests and successful responses, exact owner code, typed kind, and owner
+retryability while replacing owner message text with a static Commerce message.
 
-The owner code and retryability remain unchanged. The owner message is not copied
-into `CheckoutPaymentStageError::Boundary`, the staged pipeline error string, or
-the checkout operation journal.
+This source slice additionally corrects staged-checkout failure disposition for
+retryable payment-stage owner boundaries.
+
+## Retry disposition
+
+`CheckoutStagePipelineError::PaymentStage` now maps to
+`FailureDisposition::Retryable` only when the contained
+`CheckoutPaymentStageError::Boundary` has `retryable: true`.
+
+That disposition uses the existing `mark_retryable_error` journal transition. A
+later checkout attempt can claim the persisted `retryable_error` operation and
+resume from its current durable stage. `RecoveringStagedCheckoutService` does not
+start synchronous compensation for that status.
+
+Non-retryable payment-stage failures still require compensation. Payment-stage
+conflicts, operation errors, and boundary errors with `retryable: false` continue
+through the fail-closed `CompensationRequired` fallback.
+
+## Preserved payment behavior
+
+This slice does not change:
+
+- payment owner prepare, authorize, capture, or read execution;
+- provider-operation identities or immutable request payloads;
+- owner lifecycle and replay policy;
+- payment stage checkpoint ordering;
+- payment collection identity, status, or captured-amount validation;
+- the operation journal implementation;
+- the recovery service implementation;
+- the payment pipeline error-code mapping;
+- HTTP, GraphQL, or native contracts;
+- Commerce FFA or FBA status.
+
+The retryable payment boundary remains visible to the caller as the same
+`CheckoutStagePipelineError::PaymentStage` value. Only the persisted operation
+status changes from `compensation_required` to `retryable_error` for the explicitly
+retryable boundary case.
+
+## Public and persisted message policy
+
+The owner message is not copied into `CheckoutPaymentStageError::Boundary`, the
+staged pipeline error string, or the checkout operation journal. Static messages
+remain selected from `PortErrorKind`:
 
 | Owner kind | Stage message |
 | --- | --- |
@@ -35,89 +69,27 @@ the checkout operation journal.
 | `Unavailable` / `Timeout` | `Checkout payment service is temporarily unavailable` |
 | `InvariantViolation` | `Checkout payment operation could not be completed safely` |
 
-The existing boundary variant remains structurally compatible:
-
-- `stage` remains the commerce payment stage;
-- `code` remains the payment owner code;
-- `message` is now the static kind-based stage message;
-- `retryable` remains the payment owner value.
-
-This wave intentionally does not change staged-checkout failure disposition.
-Existing pipeline persistence and compensation admission continue to classify the
-same error variants as before.
-
-## Context propagation
-
-The complete canonical `PortContext` is still delegated to the payment owner.
-Correlation, tenant, actor, channel, locale, causation, trace, idempotency, and
-deadline values are therefore preserved for owner policy and remote-adapter
-compatibility.
-
-The Commerce consumer boundary no longer logs those raw values. It records only:
-
-- a diagnostic token whose `Debug` output is `redacted`;
-- owner operation, owner code, typed kind, and retryability;
-- tenant and actor identity shapes;
-- actor kind plus claim and role counts;
-- channel, locale, correlation, causation, trace, and idempotency presence shapes;
-- deadline milliseconds;
-- owner-message presence and character length;
-- the stable boundary `commerce_checkout_payment_execution_adapter`.
-
-Unavailable, timeout, and invariant failures use error severity. Validation,
-not-found, conflict, and forbidden outcomes use warning severity.
-
-## Legacy isolation
-
-The retained legacy source still contains its former local mapper and logger, but
-the mounted facade:
-
-1. supplies a sanitizing payment-port implementation;
-2. converts canonical `PortError` into a bounded private error before delegation
-   returns to the legacy stage;
-3. shadows the legacy tracing macros so the old raw-context event is not emitted;
-4. keeps the legacy module private;
-5. exposes the same public executor methods and canonical
-   `with_payment_port(Arc<dyn CheckoutPaymentExecutionPort>)` builder.
-
-The retained source blob is copied without business-logic edits. It is not a
-second mounted implementation.
-
-## Preserved contracts
-
-This wave does not alter:
-
-- payment owner requests, responses, provider policy, or lifecycle policy;
-- prepare, authorize, capture, or read ordering;
-- write idempotency keys, causation, locale, or deadlines;
-- checkout stage checkpoints or bounded loop behavior;
-- collection identity, status, or captured-amount validation;
-- successful checkout DTOs;
-- public executor method names or canonical custom-port injection;
-- HTTP, GraphQL, or native field/route contracts;
-- Commerce FFA/FBA status.
-
-## Evidence
+## Source evidence
 
 - `crates/rustok-commerce/contracts/evidence/checkout-payment-stage-error-safety-source-review.json`
 - `scripts/verify/verify-commerce-checkout-payment-stage-context.mjs`
+- `scripts/verify/verify-commerce-staged-checkout-payment-retry-disposition.mjs`
 
-## Remaining work
+The source includes focused tests for both sides of the policy:
 
-- Execute the focused verifier and compile the Commerce library.
-- Exercise prepare, authorize, capture, and read failure scenarios and inspect the
-  checkout operation journal.
-- Continue payment compensation, order, fulfillment, inventory, promotion, and
-  remaining non-`PortError` mapper cleanup.
-- Remove the retained legacy stage source only after compile, replay, mounted
-  parity, and upgraded-path evidence.
+- retryable payment boundary → `Retryable`;
+- non-retryable payment boundary → `CompensationRequired`.
 
-## Intended checks
+## Intended maintainer checks
 
 ```bash
 node scripts/verify/verify-commerce-checkout-payment-stage-context.mjs
+node scripts/verify/verify-commerce-staged-checkout-payment-retry-disposition.mjs
+cargo test -p rustok-commerce staged_checkout::tests::retryable_payment_stage_boundary_does_not_force_compensation
+cargo test -p rustok-commerce staged_checkout::tests::non_retryable_payment_stage_boundary_requires_compensation
 cargo check -p rustok-commerce --lib
 ```
 
-No tests, Node verifiers, Cargo commands, formatting, payment-provider calls,
-database scenarios, workflows, or CI were executed.
+No tests, Node verifiers, Cargo commands, formatting, provider calls, database
+scenarios, restart scenarios, remote-port scenarios, workflows, or CI were
+executed. Compile and runtime behavior are not claimed.

--- a/crates/rustok-commerce/src/services/staged_checkout.rs
+++ b/crates/rustok-commerce/src/services/staged_checkout.rs
@@ -15,8 +15,8 @@ use super::{
     CheckoutMarketplaceAllocationError, CheckoutMarketplaceCommissionError,
     CheckoutMarketplaceEconomicsCheckpointError, CheckoutOperationCheckpoint,
     CheckoutOperationError, CheckoutOperationJournal, CheckoutOperationStage,
-    CheckoutOperationStatus, CheckoutPlanBuilder, CheckoutStagePipeline,
-    CheckoutStagePipelineError, DEFAULT_CHECKOUT_LEASE_SECONDS,
+    CheckoutOperationStatus, CheckoutPaymentStageError, CheckoutPlanBuilder,
+    CheckoutStagePipeline, CheckoutStagePipelineError, DEFAULT_CHECKOUT_LEASE_SECONDS,
 };
 
 #[derive(Debug, Error)]
@@ -365,7 +365,11 @@ fn checkout_failure_disposition(error: &CheckoutError) -> FailureDisposition {
 
 fn pipeline_failure_disposition(error: &CheckoutStagePipelineError) -> FailureDisposition {
     match error {
-        CheckoutStagePipelineError::MarketplaceAllocation(
+        CheckoutStagePipelineError::PaymentStage(CheckoutPaymentStageError::Boundary {
+            retryable: true,
+            ..
+        })
+        | CheckoutStagePipelineError::MarketplaceAllocation(
             CheckoutMarketplaceAllocationError::Boundary {
                 retryable: true, ..
             },
@@ -519,6 +523,39 @@ mod tests {
         assert!(matches!(
             checkout_failure_disposition(&error),
             FailureDisposition::Retryable
+        ));
+    }
+
+    #[test]
+    fn retryable_payment_stage_boundary_does_not_force_compensation() {
+        let error = CheckoutStagePipelineError::PaymentStage(
+            CheckoutPaymentStageError::Boundary {
+                stage: "capture",
+                code: "payment.provider_timeout".to_string(),
+                message: "Checkout payment service is temporarily unavailable".to_string(),
+                retryable: true,
+            },
+        );
+        assert!(matches!(
+            pipeline_failure_disposition(&error),
+            FailureDisposition::Retryable
+        ));
+    }
+
+    #[test]
+    fn non_retryable_payment_stage_boundary_requires_compensation() {
+        let error = CheckoutStagePipelineError::PaymentStage(
+            CheckoutPaymentStageError::Boundary {
+                stage: "capture",
+                code: "payment.capture_conflict".to_string(),
+                message: "Checkout payment state conflicts with the requested operation"
+                    .to_string(),
+                retryable: false,
+            },
+        );
+        assert!(matches!(
+            pipeline_failure_disposition(&error),
+            FailureDisposition::CompensationRequired
         ));
     }
 

--- a/scripts/verify/verify-commerce-checkout-payment-stage-context.mjs
+++ b/scripts/verify/verify-commerce-checkout-payment-stage-context.mjs
@@ -8,31 +8,7 @@ const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
 const root = configuredRoot
   ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
   : new URL('../../', import.meta.url);
-
-const facade = readFileSync(
-  new URL(
-    'crates/rustok-commerce/src/services/checkout_payment_stages.rs',
-    root,
-  ),
-  'utf8',
-);
-const legacy = readFileSync(
-  new URL(
-    'crates/rustok-commerce/src/services/checkout_payment_stages_legacy.rs',
-    root,
-  ),
-  'utf8',
-);
-const evidence = JSON.parse(
-  readFileSync(
-    new URL(
-      'crates/rustok-commerce/contracts/evidence/checkout-payment-stage-error-safety-source-review.json',
-      root,
-    ),
-    'utf8',
-  ),
-);
-
+const read = (file) => readFileSync(new URL(file, root), 'utf8');
 const failures = [];
 const requireText = (source, value, label) => {
   if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
@@ -40,6 +16,13 @@ const requireText = (source, value, label) => {
 const forbidText = (source, value, label) => {
   if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
 };
+
+const facade = read('crates/rustok-commerce/src/services/checkout_payment_stages.rs');
+const legacy = read('crates/rustok-commerce/src/services/checkout_payment_stages_legacy.rs');
+const staged = read('crates/rustok-commerce/src/services/staged_checkout.rs');
+const evidence = JSON.parse(read(
+  'crates/rustok-commerce/contracts/evidence/checkout-payment-stage-error-safety-source-review.json',
+));
 
 for (const [value, label] of [
   ['include!("checkout_payment_stages_legacy.rs");', 'private retained source'],
@@ -54,67 +37,13 @@ for (const [value, label] of [
   ['fn public_message(kind: &PortErrorKind)', 'typed public message policy'],
   ['fn sanitize_owner_error(', 'owner mapper'],
   ['CheckoutPaymentExecutionContextFacts', 'bounded context facts'],
-  ['tenant_id_shape', 'tenant identity shape'],
-  ['actor_kind', 'actor kind'],
-  ['actor_id_shape', 'actor identity shape'],
-  ['claim_count', 'claim count'],
-  ['role_count', 'role count'],
-  ['channel_shape', 'channel shape'],
-  ['locale_shape', 'locale shape'],
-  ['correlation_id_shape', 'correlation shape'],
-  ['causation_id_shape', 'causation shape'],
-  ['traceparent_shape', 'trace shape'],
-  ['idempotency_key_shape', 'idempotency shape'],
-  ['owner_message_shape', 'owner message shape'],
-  ['owner_message_len', 'owner message length'],
-  [
-    'const CHECKOUT_PAYMENT_EXECUTION_ADAPTER_BOUNDARY: &str =\n        "commerce_checkout_payment_execution_adapter";',
-    'stable adapter boundary',
-  ],
   ['message: public_message.to_string()', 'static stage message'],
   ['code: error.code', 'owner code preservation'],
   ['retryable: error.retryable', 'owner retryability preservation'],
-  [
-    'PortErrorKind::Unavailable | PortErrorKind::Timeout | PortErrorKind::InvariantViolation',
-    'technical severity policy',
-  ],
-  ['pub struct CheckoutPaymentStageExecutor {', 'public executor facade'],
-  [
-    'payment_port: Arc<dyn CanonicalCheckoutPaymentExecutionPort>',
-    'canonical custom port API',
-  ],
-  [
-    'wrap_checkout_payment_execution_port(payment_port)',
-    'custom port sanitizing adapter',
-  ],
+  ['wrap_checkout_payment_execution_port(payment_port)', 'custom port adapter'],
   ['advance_to_payment_captured(', 'advance delegation'],
   ['load_payment_captured_state(', 'recovery delegation'],
-  ['with_provider_registry(', 'provider registry builder'],
-  ['with_lease_seconds(', 'lease builder'],
-]) {
-  requireText(facade, value, label);
-}
-
-for (const [kind, message] of [
-  ['PortErrorKind::Validation', 'Checkout payment request is invalid'],
-  ['PortErrorKind::NotFound', 'Checkout payment resource was not found'],
-  [
-    'PortErrorKind::Conflict',
-    'Checkout payment state conflicts with the requested operation',
-  ],
-  ['PortErrorKind::Forbidden', 'Checkout payment operation is not permitted'],
-  [
-    'PortErrorKind::Unavailable | PortErrorKind::Timeout',
-    'Checkout payment service is temporarily unavailable',
-  ],
-  [
-    'PortErrorKind::InvariantViolation',
-    'Checkout payment operation could not be completed safely',
-  ],
-]) {
-  requireText(facade, kind, `${kind} policy`);
-  requireText(facade, message, `${kind} public message`);
-}
+]) requireText(facade, value, label);
 
 for (const operation of [
   'prepare_checkout_collection',
@@ -122,17 +51,8 @@ for (const operation of [
   'capture_checkout_collection',
   'read_checkout_collection',
 ]) {
-  const delegatedCalls = facade.match(new RegExp(`\\.${operation}\\(`, 'g')) ?? [];
-  if (delegatedCalls.length < 2) {
-    failures.push(
-      `${operation}: expected adapter and inner delegations, found ${delegatedCalls.length}`,
-    );
-  }
-  requireText(
-    facade,
-    `"${operation}"`,
-    `${operation} bounded diagnostic operation`,
-  );
+  requireText(facade, `"${operation}"`, `${operation} bounded operation`);
+  requireText(legacy, `${operation}(`, `${operation} retained execution path`);
 }
 
 for (const [value, label] of [
@@ -140,41 +60,19 @@ for (const [value, label] of [
   ['error = ?boundary_error', 'raw legacy PortError diagnostic'],
   ['tenant_id = %context.tenant_id', 'raw tenant diagnostic'],
   ['actor = ?context.actor', 'raw actor diagnostic'],
-  ['channel = ?context.channel', 'raw channel diagnostic'],
-  ['locale = %context.locale', 'raw locale diagnostic'],
   ['correlation_id = %context.correlation_id', 'raw correlation diagnostic'],
-  ['causation_id = ?context.causation_id', 'raw causation diagnostic'],
-  ['traceparent = ?context.traceparent', 'raw trace diagnostic'],
   ['idempotency_key = ?context.idempotency_key', 'raw idempotency diagnostic'],
-]) {
-  forbidText(facade, value, label);
-}
+]) forbidText(facade, value, label);
 
 for (const [value, label] of [
-  ['pub enum CheckoutPaymentStageError', 'legacy stage error'],
-  ['pub struct CheckoutPaymentStageExecutor', 'legacy executor'],
-  ['prepare_checkout_collection(', 'legacy prepare path'],
-  ['authorize_checkout_collection(', 'legacy authorize path'],
-  ['capture_checkout_collection(', 'legacy capture path'],
-  ['read_checkout_collection(', 'legacy read path'],
-  ['expected_stage: CheckoutOperationStage::PaymentReady', 'legacy prepare checkpoint'],
+  ['CheckoutPaymentStageError', 'typed payment stage disposition import'],
   [
-    'next_stage: CheckoutOperationStage::PaymentAuthorized',
-    'legacy authorize checkpoint',
+    'CheckoutStagePipelineError::PaymentStage(CheckoutPaymentStageError::Boundary {\n            retryable: true,',
+    'retryable payment boundary disposition',
   ],
-  [
-    'expected_stage: CheckoutOperationStage::PaymentAuthorized',
-    'legacy capture checkpoint',
-  ],
-  [
-    'next_stage: CheckoutOperationStage::PaymentCaptured',
-    'legacy captured checkpoint',
-  ],
-  ['message: error.message', 'legacy raw message source retained privately'],
-  ['error = ?boundary_error', 'legacy raw logger retained privately'],
-]) {
-  requireText(legacy, value, label);
-}
+  ['fn retryable_payment_stage_boundary_does_not_force_compensation()', 'retryable disposition source test'],
+  ['fn non_retryable_payment_stage_boundary_requires_compensation()', 'non-retryable disposition source test'],
+]) requireText(staged, value, label);
 
 const requiredEvidence = {
   status: 'commerce_checkout_payment_stage_error_safety_source_reviewed_unvalidated',
@@ -188,39 +86,27 @@ const requiredEvidence = {
   raw_context_values_logged: false,
   owner_code_preserved: true,
   owner_retryability_preserved: true,
-  failure_disposition_changed: false,
+  failure_disposition_changed: true,
+  retryable_payment_boundary_disposition_retryable: true,
+  non_retryable_payment_boundary_disposition_compensation_required: true,
+  retryable_payment_boundary_synchronous_compensation: false,
+  operation_journal_implementation_changed: false,
+  recovery_service_implementation_changed: false,
+  payment_stage_execution_changed: false,
   runtime_evidence_claimed: false,
 };
 
 if (evidence.status !== requiredEvidence.status) {
-  failures.push(
-    `evidence status: expected ${requiredEvidence.status}, got ${evidence.status}`,
-  );
+  failures.push(`evidence status: expected ${requiredEvidence.status}, got ${evidence.status}`);
 }
 for (const [key, expected] of Object.entries(requiredEvidence).slice(1)) {
-  const actual = evidence.source_contract?.[key];
-  if (actual !== expected) {
-    failures.push(`evidence ${key}: expected ${expected}, got ${actual}`);
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence ${key}: expected ${expected}, got ${evidence.source_contract?.[key]}`);
   }
 }
-
-for (const key of [
-  'tests_run',
-  'verifier_run',
-  'cargo_run',
-  'format_run',
-  'provider_calls_run',
-  'database_scenarios_run',
-  'workflow_checks_run',
-  'ci_run',
-  'compile_proven',
-  'runtime_proven',
-]) {
-  if (evidence.validation?.[key] !== false) {
-    failures.push(`validation ${key}: expected false`);
-  }
+for (const [key, value] of Object.entries(evidence.validation ?? {})) {
+  if (value !== false) failures.push(`validation ${key}: expected false`);
 }
-
 if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
   failures.push('evidence execution must remain empty');
 }
@@ -231,6 +117,4 @@ if (failures.length > 0) {
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log(
-  '✔ Mounted checkout payment execution errors are static, bounded, and journal-safe',
-);
+console.log('✔ Mounted payment errors stay bounded and retryable boundaries remain resumable');

--- a/scripts/verify/verify-commerce-staged-checkout-payment-retry-disposition.mjs
+++ b/scripts/verify/verify-commerce-staged-checkout-payment-retry-disposition.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (file) => readFileSync(new URL(file, root), 'utf8');
+const failures = [];
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (source, start, end, label) => {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate block`);
+    return '';
+  }
+  return source.slice(startIndex, endIndex);
+};
+
+const staged = read('crates/rustok-commerce/src/services/staged_checkout.rs');
+const paymentStage = read('crates/rustok-commerce/src/services/checkout_payment_stages_legacy.rs');
+const operation = read('crates/rustok-commerce/src/services/checkout_operation.rs');
+const recovery = read('crates/rustok-commerce/src/services/recovering_staged_checkout.rs');
+const doc = read('crates/rustok-commerce/docs/checkout-payment-stage-context.md');
+const evidence = JSON.parse(read(
+  'crates/rustok-commerce/contracts/evidence/checkout-payment-stage-error-safety-source-review.json',
+));
+
+const disposition = between(
+  staged,
+  'fn pipeline_failure_disposition(',
+  'fn checkout_error_code(',
+  'pipeline failure disposition',
+);
+const persistence = between(
+  staged,
+  '    async fn persist_pipeline_failure(',
+  '\n}\n\n#[derive(Clone, Copy)]',
+  'pipeline failure persistence',
+);
+const claimExecution = between(
+  operation,
+  '    pub async fn claim_execution(',
+  '    pub async fn checkpoint(',
+  'execution claim',
+);
+const claimCompensation = between(
+  operation,
+  '    pub async fn claim_compensation(',
+  '    pub async fn mark_compensation_retryable(',
+  'compensation claim',
+);
+
+for (const [source, value, label] of [
+  [staged, 'CheckoutPaymentStageError', 'typed payment stage import'],
+  [
+    disposition,
+    'CheckoutStagePipelineError::PaymentStage(CheckoutPaymentStageError::Boundary {\n            retryable: true,',
+    'retryable payment boundary disposition',
+  ],
+  [disposition, '=> FailureDisposition::Retryable', 'retryable disposition target'],
+  [disposition, '_ => FailureDisposition::CompensationRequired', 'fail-closed fallback'],
+  [persistence, 'FailureDisposition::Retryable', 'retryable persistence branch'],
+  [persistence, '.mark_retryable_error(', 'retryable journal transition'],
+  [persistence, 'FailureDisposition::CompensationRequired', 'compensation persistence branch'],
+  [persistence, '.mark_compensation_required(', 'compensation journal transition'],
+  [
+    staged,
+    'fn retryable_payment_stage_boundary_does_not_force_compensation()',
+    'retryable payment disposition source test',
+  ],
+  [
+    staged,
+    'fn non_retryable_payment_stage_boundary_requires_compensation()',
+    'non-retryable payment disposition source test',
+  ],
+  [claimExecution, 'CheckoutOperationStatus::RetryableError.as_str()', 'retryable execution claim'],
+  [
+    claimCompensation,
+    'CheckoutOperationStatus::CompensationRequired.as_str()',
+    'compensation-only claim admission',
+  ],
+  [
+    recovery,
+    'if operation.status != CheckoutOperationStatus::CompensationRequired.as_str()',
+    'synchronous compensation admission',
+  ],
+  [paymentStage, 'retryable: error.retryable', 'payment owner retryability propagation'],
+]) requireText(source, value, label);
+
+const retryableTest = between(
+  staged,
+  '    fn retryable_payment_stage_boundary_does_not_force_compensation()',
+  '    #[test]\n    fn non_retryable_payment_stage_boundary_requires_compensation()',
+  'retryable payment source test',
+);
+const nonRetryableTest = between(
+  staged,
+  '    fn non_retryable_payment_stage_boundary_requires_compensation()',
+  '    #[test]\n    fn retryable_marketplace_boundary_does_not_force_compensation()',
+  'non-retryable payment source test',
+);
+requireText(retryableTest, 'retryable: true', 'retryable payment fixture');
+requireText(retryableTest, 'FailureDisposition::Retryable', 'retryable payment assertion');
+requireText(nonRetryableTest, 'retryable: false', 'non-retryable payment fixture');
+requireText(
+  nonRetryableTest,
+  'FailureDisposition::CompensationRequired',
+  'non-retryable payment assertion',
+);
+
+const paymentArmIndex = disposition.indexOf('CheckoutStagePipelineError::PaymentStage(');
+const fallbackIndex = disposition.indexOf('_ => FailureDisposition::CompensationRequired');
+if (!(paymentArmIndex >= 0 && paymentArmIndex < fallbackIndex)) {
+  failures.push('retryable payment boundary arm must precede the compensation fallback');
+}
+
+for (const value of [
+  'CheckoutPaymentStageError::Boundary {\n            retryable: false',
+  'CheckoutPaymentStageError::Conflict(_) => FailureDisposition::Retryable',
+  'CheckoutPaymentStageError::Operation(_) => FailureDisposition::Retryable',
+]) forbidText(disposition, value, 'unsafe payment retry broadening');
+
+for (const operationName of [
+  'prepare_checkout_collection',
+  'authorize_checkout_collection',
+  'capture_checkout_collection',
+  'read_checkout_collection',
+]) requireText(paymentStage, operationName, `${operationName} retained payment path`);
+
+for (const [key, expected] of Object.entries({
+  failure_disposition_changed: true,
+  retryable_payment_boundary_disposition_retryable: true,
+  non_retryable_payment_boundary_disposition_compensation_required: true,
+  retryable_payment_boundary_synchronous_compensation: false,
+  operation_journal_implementation_changed: false,
+  recovery_service_implementation_changed: false,
+  payment_stage_execution_changed: false,
+  source_tests_added: true,
+  runtime_evidence_claimed: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+for (const [key, value] of Object.entries(evidence.validation ?? {})) {
+  if (value !== false) failures.push(`evidence validation.${key} must remain false`);
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push('evidence execution must remain empty');
+}
+
+for (const [value, label] of [
+  ['Status: **source-reviewed / unvalidated**', 'truthful document status'],
+  ['retryable payment-stage owner boundaries', 'documented retryable scope'],
+  ['Non-retryable payment-stage failures still require compensation', 'documented fail-closed scope'],
+  ['No tests, Node verifiers, Cargo commands', 'validation disclosure'],
+]) requireText(doc, value, label);
+
+if (failures.length > 0) {
+  console.error('Staged checkout payment retry-disposition verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log('✔ Retryable payment-stage boundaries remain resumable without synchronous compensation');


### PR DESCRIPTION
## Summary

- classify `CheckoutStagePipelineError::PaymentStage(CheckoutPaymentStageError::Boundary { retryable: true, .. })` as `FailureDisposition::Retryable`
- persist that case through the existing `mark_retryable_error` transition so a later checkout attempt can reclaim and resume the durable stage
- keep non-retryable payment boundaries, payment-stage conflicts, and payment-stage operation errors on the existing fail-closed compensation-required path
- preserve payment prepare/authorize/capture/read execution, provider operation identities, stage checkpoints, operation journal implementation, recovery implementation, pipeline error-code mapping, public errors, and transport contracts
- add focused source tests for retryable and non-retryable payment boundary disposition
- add a dedicated static guard and synchronize payment-stage documentation/evidence

## Behavior

Before this change, all payment-stage pipeline failures fell through to `CompensationRequired`, even when the payment owner explicitly returned `retryable: true`.

After this change:

- retryable payment owner boundary → `retryable_error`, no synchronous compensation
- non-retryable payment owner boundary → `compensation_required`
- payment conflict / operation error → unchanged `compensation_required`

`RecoveringStagedCheckoutService` remains unchanged and still invokes synchronous compensation only for `compensation_required`.

## Validation

Not run per maintainer instruction:

- Rust tests
- Node verifiers
- Cargo commands
- formatting
- payment-provider calls
- database scenarios
- restart / remote-port scenarios
- workflows / CI

Suggested maintainer checks:

```bash
node scripts/verify/verify-commerce-checkout-payment-stage-context.mjs
node scripts/verify/verify-commerce-staged-checkout-payment-retry-disposition.mjs
cargo test -p rustok-commerce staged_checkout::tests::retryable_payment_stage_boundary_does_not_force_compensation
cargo test -p rustok-commerce staged_checkout::tests::non_retryable_payment_stage_boundary_requires_compensation
cargo check -p rustok-commerce --lib
```

Status remains `source-reviewed / unvalidated`; compile and runtime behavior are not claimed.