### PR TITLE
feat(product): add durable Index refresh relay step

### DIFF
--- a/crates/rustok-product/docs/index-refresh-relay-step.md
+++ b/crates/rustok-product/docs/index-refresh-relay-step.md
@@ -1,0 +1,118 @@
+# Product Index refresh durable relay step
+
+Status: `source_complete_typed_family_and_runtime_pending`.
+
+## Purpose
+
+Product owns two append-only Index refresh ledgers:
+
+- localized Product identities;
+- ProductVariant identities with their parent Product.
+
+The canonical writer validates one ledger row and its exact causal Product root envelope before
+writing a sealed typed contract to `sys_events`. This slice adds one bounded durable relay step
+around that writer without starting a background worker or changing the event wire contract.
+
+## Durable cursor
+
+`product_index_refresh_relay_cursors` stores one row per `(tenant_id, stream_kind)` where
+`stream_kind` is exactly `locale` or `variant`.
+
+The cursor:
+
+- starts at sequence `0`;
+- cannot move backwards;
+- cannot change tenant or stream identity;
+- cannot be deleted;
+- is locked with `FOR UPDATE` before publication;
+- advances only in the same transaction as the canonical outbox write.
+
+The table is Product-owned. It is not an Iggy consumer cursor and does not replace the global
+outbox relay lifecycle.
+
+## One-step algorithm
+
+`ProductIndexRefreshRelayStep` exposes:
+
+- `publish_next_locale(tenant_id)`;
+- `publish_next_variant(tenant_id)`.
+
+Each explicit call:
+
+1. reads the current durable cursor;
+2. requests at most one immutable ledger row after that cursor through the existing bounded source;
+3. starts a Product transaction and locks the exact tenant/stream cursor;
+4. returns `CursorAdvanced` without publication when another caller already advanced the cursor;
+5. returns `Idle` when no row existed at the observation point;
+6. asks `ProductIndexRefreshEventFactory` to build the sealed Product event;
+7. invokes `ProductIndexRefreshCanonicalWriter`;
+8. advances the cursor with an expected-value fence;
+9. commits the typed outbox envelope and cursor together.
+
+The ledger is append-only, so reading the candidate before locking the cursor does not permit the
+candidate facts to change. A concurrent append after an idle observation is handled by the next
+explicit step.
+
+## Identity and atomicity
+
+For a published row:
+
+```text
+outbox envelope id = outbox correlation id = ledger refresh_id
+outbox causation id = ledger root_event_id
+relay cursor = ledger sequence_no
+```
+
+A crash before commit retains neither the outbox write nor cursor movement. A crash after commit
+retains both. Exact write-once admission remains an additional fail-closed guard, not a substitute
+for the transactional cursor.
+
+Concurrent callers may observe the same candidate before taking the lock. Only the caller whose
+observed cursor still matches the locked cursor may publish it. Later callers receive
+`CursorAdvanced` and can retry from the returned sequence.
+
+## Typed factory boundary
+
+`ProductIndexRefreshEventFactory` has separate associated event types and builders for locale and
+variant rows. Both associated types must implement `ProductIndexRefreshContract`, which itself
+extends the sealed platform `EventContract`.
+
+The relay therefore does not accept arbitrary JSON, raw event-type strings or unrelated typed
+families. The future Product event family remains responsible for exposing the exact target facts
+that the canonical writer compares with the immutable ledger row.
+
+## Ownership limits
+
+The relay step does not:
+
+- run a loop, timer, scheduler or spawned task;
+- own a lease or retry schedule;
+- dispatch directly to local delivery or Iggy;
+- acknowledge a broker message;
+- mutate Product ledger rows;
+- write Index entities or links;
+- construct an `IndexMutation`;
+- expose a public repair transport;
+- alter the concrete-repair evidence gate.
+
+Delivery after commit remains owned by the global `OutboxRelay`. Product and ProductVariant broker
+consumption still requires route registration plus a concrete commit-before-ack worker.
+
+## Wire-contract block
+
+This slice deliberately does not add `ProductIndexRefreshEvent` or update event-contract digests.
+The committed digest artifact on current `main` still has the same blob and values as the state
+before the Reactions typed family was added. A maintainer must first regenerate and admit the
+canonical digest artifact through the repository generator; another family must not be layered on
+an already stale release artifact.
+
+## Maintainer verification
+
+```bash
+node scripts/verify/verify-index-product-refresh-relay-step.mjs
+cargo check -p rustok-product --all-targets
+git diff --check
+```
+
+No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows or
+CI were executed by the implementation agent.

--- a/crates/rustok-product/src/lib.rs
+++ b/crates/rustok-product/src/lib.rs
@@ -34,7 +34,9 @@ pub use services::{
     ProductAttributeFilter, ProductCatalogSchemaService, ProductIndexLocaleRefreshRecord,
     ProductIndexLocaleRefreshSource, ProductIndexRefreshCanonicalWriter,
     ProductIndexRefreshContract, ProductIndexRefreshContractTarget,
-    ProductIndexRefreshPublicationError, ProductIndexVariantRefreshRecord,
+    ProductIndexRefreshEventFactory, ProductIndexRefreshPublicationError,
+    ProductIndexRefreshRelayError, ProductIndexRefreshRelayStep,
+    ProductIndexRefreshRelayStepOutcome, ProductIndexVariantRefreshRecord,
     ProductIndexVariantRefreshSource, StorefrontProductList, StorefrontProductListItem,
     StorefrontProductListQuery, StorefrontProductSortBy, StorefrontProductSortDirection,
 };

--- a/crates/rustok-product/src/migrations/m20260806_000007_add_product_index_refresh_relay_cursors.rs
+++ b/crates/rustok-product/src/migrations/m20260806_000007_add_product_index_refresh_relay_cursors.rs
@@ -1,0 +1,100 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::DatabaseBackend;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() != DatabaseBackend::Postgres {
+            return Err(DbErr::Custom(
+                "rustok-product migrations require PostgreSQL".to_owned(),
+            ));
+        }
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+CREATE TABLE product_index_refresh_relay_cursors (
+    tenant_id UUID NOT NULL,
+    stream_kind TEXT NOT NULL,
+    last_sequence_no BIGINT NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_product_index_refresh_relay_cursors
+        PRIMARY KEY (tenant_id, stream_kind),
+    CONSTRAINT chk_product_index_refresh_relay_cursor_tenant_non_nil
+        CHECK (tenant_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CONSTRAINT chk_product_index_refresh_relay_cursor_stream_kind
+        CHECK (stream_kind IN ('locale', 'variant')),
+    CONSTRAINT chk_product_index_refresh_relay_cursor_non_negative
+        CHECK (last_sequence_no >= 0)
+);
+
+CREATE OR REPLACE FUNCTION rustok_product_guard_index_refresh_relay_cursor()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.tenant_id <> OLD.tenant_id OR NEW.stream_kind <> OLD.stream_kind THEN
+        RAISE EXCEPTION 'product Index refresh relay cursor identity is immutable';
+    END IF;
+    IF NEW.last_sequence_no < OLD.last_sequence_no THEN
+        RAISE EXCEPTION 'product Index refresh relay cursor cannot move backwards';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION rustok_product_reject_index_refresh_relay_cursor_delete()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'product Index refresh relay cursor cannot be deleted';
+    RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER trg_product_index_refresh_relay_cursor_update
+BEFORE UPDATE ON product_index_refresh_relay_cursors
+FOR EACH ROW
+EXECUTE FUNCTION rustok_product_guard_index_refresh_relay_cursor();
+
+CREATE TRIGGER trg_product_index_refresh_relay_cursor_delete
+BEFORE DELETE ON product_index_refresh_relay_cursors
+FOR EACH ROW
+EXECUTE FUNCTION rustok_product_reject_index_refresh_relay_cursor_delete();
+"#,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() != DatabaseBackend::Postgres {
+            return Err(DbErr::Custom(
+                "rustok-product migrations require PostgreSQL".to_owned(),
+            ));
+        }
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+DROP TRIGGER IF EXISTS trg_product_index_refresh_relay_cursor_delete
+    ON product_index_refresh_relay_cursors;
+DROP TRIGGER IF EXISTS trg_product_index_refresh_relay_cursor_update
+    ON product_index_refresh_relay_cursors;
+DROP TABLE IF EXISTS product_index_refresh_relay_cursors;
+DROP FUNCTION IF EXISTS rustok_product_reject_index_refresh_relay_cursor_delete();
+DROP FUNCTION IF EXISTS rustok_product_guard_index_refresh_relay_cursor();
+"#,
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/crates/rustok-product/src/migrations/mod.rs
+++ b/crates/rustok-product/src/migrations/mod.rs
@@ -28,6 +28,7 @@ mod m20260731_000003_bump_product_index_revision_for_variant_membership;
 mod m20260731_000004_add_product_index_tombstones;
 mod m20260806_000005_add_product_index_locale_refresh_ledger;
 mod m20260806_000006_add_product_variant_index_refresh_ledger;
+mod m20260806_000007_add_product_index_refresh_relay_cursors;
 
 use rustok_core::MigrationDependencyDescriptor;
 use sea_orm_migration::MigrationTrait;
@@ -62,6 +63,7 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260731_000004_add_product_index_tombstones::Migration),
         Box::new(m20260806_000005_add_product_index_locale_refresh_ledger::Migration),
         Box::new(m20260806_000006_add_product_variant_index_refresh_ledger::Migration),
+        Box::new(m20260806_000007_add_product_index_refresh_relay_cursors::Migration),
     ]
 }
 

--- a/crates/rustok-product/src/services/index_refresh_relay.rs
+++ b/crates/rustok-product/src/services/index_refresh_relay.rs
@@ -1,0 +1,371 @@
+use sea_orm::{
+    ConnectionTrait, DatabaseBackend, DatabaseConnection, DatabaseTransaction, DbBackend, Statement,
+    TransactionTrait,
+};
+use thiserror::Error;
+use uuid::Uuid;
+
+use super::{
+    ProductIndexLocaleRefreshRecord, ProductIndexLocaleRefreshSource,
+    ProductIndexRefreshCanonicalWriter, ProductIndexRefreshContract,
+    ProductIndexRefreshPublicationError, ProductIndexVariantRefreshRecord,
+    ProductIndexVariantRefreshSource,
+};
+
+const LOCALE_STREAM_KIND: &str = "locale";
+const VARIANT_STREAM_KIND: &str = "variant";
+
+/// Builds the sealed Product Index refresh family from immutable owner-ledger rows.
+///
+/// The associated events must already implement the Product-owned refresh contract.
+/// No arbitrary JSON or unregistered event type can enter the canonical writer.
+pub trait ProductIndexRefreshEventFactory: Send + Sync {
+    type LocaleEvent: ProductIndexRefreshContract;
+    type VariantEvent: ProductIndexRefreshContract;
+
+    fn locale_event(&self, record: &ProductIndexLocaleRefreshRecord) -> Self::LocaleEvent;
+    fn variant_event(&self, record: &ProductIndexVariantRefreshRecord) -> Self::VariantEvent;
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProductIndexRefreshRelayStepOutcome {
+    /// No row existed after the locked durable cursor at this observation point.
+    Idle { last_sequence_no: i64 },
+    /// Another relay step advanced the cursor after this step read its candidate.
+    CursorAdvanced { last_sequence_no: i64 },
+    /// One exact ledger row and its cursor advancement committed atomically.
+    Published { sequence_no: i64, refresh_id: Uuid },
+}
+
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum ProductIndexRefreshRelayError {
+    #[error("Product Index refresh relay tenant identity is invalid")]
+    InvalidTenant,
+    #[error("Product Index refresh event does not match the immutable owner ledger row")]
+    ContractMismatch,
+    #[error("Product Index refresh ledger causation does not match a Product root envelope")]
+    CausationMismatch,
+    #[error("Product Index refresh envelope identity is already bound to different facts")]
+    Conflict,
+    #[error("Product Index refresh relay step is unavailable")]
+    Unavailable,
+}
+
+/// One explicit, bounded Product refresh relay step.
+///
+/// The step never owns a background loop, lease, retry schedule, broker cursor or
+/// acknowledgement. It reads at most one ledger row. The canonical outbox write
+/// and monotonic tenant/stream cursor advancement commit in the same transaction.
+pub struct ProductIndexRefreshRelayStep<F> {
+    db: DatabaseConnection,
+    factory: F,
+}
+
+impl<F> ProductIndexRefreshRelayStep<F>
+where
+    F: ProductIndexRefreshEventFactory,
+{
+    pub fn new(db: DatabaseConnection, factory: F) -> Self {
+        Self { db, factory }
+    }
+
+    pub async fn publish_next_locale(
+        &self,
+        tenant_id: Uuid,
+    ) -> Result<ProductIndexRefreshRelayStepOutcome, ProductIndexRefreshRelayError> {
+        self.validate_database_and_tenant(tenant_id)?;
+        let observed_cursor = load_cursor(&self.db, tenant_id, LOCALE_STREAM_KIND).await?;
+        let record = ProductIndexLocaleRefreshSource::new(self.db.clone())
+            .list(tenant_id, observed_cursor, 1)
+            .await
+            .map_err(|_| ProductIndexRefreshRelayError::Unavailable)?
+            .into_iter()
+            .next();
+
+        let transaction = self
+            .db
+            .begin()
+            .await
+            .map_err(|_| ProductIndexRefreshRelayError::Unavailable)?;
+        let locked_cursor = lock_cursor(&transaction, tenant_id, LOCALE_STREAM_KIND).await?;
+        if locked_cursor != observed_cursor {
+            transaction
+                .rollback()
+                .await
+                .map_err(|_| ProductIndexRefreshRelayError::Unavailable)?;
+            return Ok(ProductIndexRefreshRelayStepOutcome::CursorAdvanced {
+                last_sequence_no: locked_cursor,
+            });
+        }
+
+        let Some(record) = record else {
+            transaction
+                .commit()
+                .await
+                .map_err(|_| ProductIndexRefreshRelayError::Unavailable)?;
+            return Ok(ProductIndexRefreshRelayStepOutcome::Idle {
+                last_sequence_no: locked_cursor,
+            });
+        };
+
+        let event = self.factory.locale_event(&record);
+        let refresh_id = match ProductIndexRefreshCanonicalWriter::publish_locale_once_in_transaction(
+            &transaction,
+            &record,
+            event,
+        )
+        .await
+        {
+            Ok(refresh_id) => refresh_id,
+            Err(error) => {
+                transaction
+                    .rollback()
+                    .await
+                    .map_err(|_| ProductIndexRefreshRelayError::Unavailable)?;
+                return Err(error.into());
+            }
+        };
+
+        if let Err(error) = advance_cursor(
+            &transaction,
+            tenant_id,
+            LOCALE_STREAM_KIND,
+            locked_cursor,
+            record.sequence_no(),
+        )
+        .await
+        {
+            transaction
+                .rollback()
+                .await
+                .map_err(|_| ProductIndexRefreshRelayError::Unavailable)?;
+            return Err(error);
+        }
+        transaction
+            .commit()
+            .await
+            .map_err(|_| ProductIndexRefreshRelayError::Unavailable)?;
+
+        Ok(ProductIndexRefreshRelayStepOutcome::Published {
+            sequence_no: record.sequence_no(),
+            refresh_id,
+        })
+    }
+
+    pub async fn publish_next_variant(
+        &self,
+        tenant_id: Uuid,
+    ) -> Result<ProductIndexRefreshRelayStepOutcome, ProductIndexRefreshRelayError> {
+        self.validate_database_and_tenant(tenant_id)?;
+        let observed_cursor = load_cursor(&self.db, tenant_id, VARIANT_STREAM_KIND).await?;
+        let record = ProductIndexVariantRefreshSource::new(self.db.clone())
+            .list(tenant_id, observed_cursor, 1)
+            .await
+            .map_err(|_| ProductIndexRefreshRelayError::Unavailable)?
+            .into_iter()
+            .next();
+
+        let transaction = self
+            .db
+            .begin()
+            .await
+            .map_err(|_| ProductIndexRefreshRelayError::Unavailable)?;
+        let locked_cursor = lock_cursor(&transaction, tenant_id, VARIANT_STREAM_KIND).await?;
+        if locked_cursor != observed_cursor {
+            transaction
+                .rollback()
+                .await
+                .map_err(|_| ProductIndexRefreshRelayError::Unavailable)?;
+            return Ok(ProductIndexRefreshRelayStepOutcome::CursorAdvanced {
+                last_sequence_no: locked_cursor,
+            });
+        }
+
+        let Some(record) = record else {
+            transaction
+                .commit()
+                .await
+                .map_err(|_| ProductIndexRefreshRelayError::Unavailable)?;
+            return Ok(ProductIndexRefreshRelayStepOutcome::Idle {
+                last_sequence_no: locked_cursor,
+            });
+        };
+
+        let event = self.factory.variant_event(&record);
+        let refresh_id = match ProductIndexRefreshCanonicalWriter::publish_variant_once_in_transaction(
+            &transaction,
+            &record,
+            event,
+        )
+        .await
+        {
+            Ok(refresh_id) => refresh_id,
+            Err(error) => {
+                transaction
+                    .rollback()
+                    .await
+                    .map_err(|_| ProductIndexRefreshRelayError::Unavailable)?;
+                return Err(error.into());
+            }
+        };
+
+        if let Err(error) = advance_cursor(
+            &transaction,
+            tenant_id,
+            VARIANT_STREAM_KIND,
+            locked_cursor,
+            record.sequence_no(),
+        )
+        .await
+        {
+            transaction
+                .rollback()
+                .await
+                .map_err(|_| ProductIndexRefreshRelayError::Unavailable)?;
+            return Err(error);
+        }
+        transaction
+            .commit()
+            .await
+            .map_err(|_| ProductIndexRefreshRelayError::Unavailable)?;
+
+        Ok(ProductIndexRefreshRelayStepOutcome::Published {
+            sequence_no: record.sequence_no(),
+            refresh_id,
+        })
+    }
+
+    fn validate_database_and_tenant(
+        &self,
+        tenant_id: Uuid,
+    ) -> Result<(), ProductIndexRefreshRelayError> {
+        if tenant_id.is_nil() {
+            return Err(ProductIndexRefreshRelayError::InvalidTenant);
+        }
+        if self.db.get_database_backend() != DatabaseBackend::Postgres {
+            return Err(ProductIndexRefreshRelayError::Unavailable);
+        }
+        Ok(())
+    }
+}
+
+async fn load_cursor(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    stream_kind: &str,
+) -> Result<i64, ProductIndexRefreshRelayError> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+            SELECT last_sequence_no
+            FROM product_index_refresh_relay_cursors
+            WHERE tenant_id = $1 AND stream_kind = $2
+            "#,
+            vec![tenant_id.into(), stream_kind.into()],
+        ))
+        .await
+        .map_err(|_| ProductIndexRefreshRelayError::Unavailable)?;
+    let Some(row) = row else {
+        return Ok(0);
+    };
+    let last_sequence_no: i64 = row
+        .try_get("", "last_sequence_no")
+        .map_err(|_| ProductIndexRefreshRelayError::Unavailable)?;
+    if last_sequence_no < 0 {
+        return Err(ProductIndexRefreshRelayError::Unavailable);
+    }
+    Ok(last_sequence_no)
+}
+
+async fn lock_cursor(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+    stream_kind: &str,
+) -> Result<i64, ProductIndexRefreshRelayError> {
+    transaction
+        .execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+            INSERT INTO product_index_refresh_relay_cursors (
+                tenant_id,
+                stream_kind,
+                last_sequence_no,
+                updated_at
+            ) VALUES ($1, $2, 0, CURRENT_TIMESTAMP)
+            ON CONFLICT (tenant_id, stream_kind) DO NOTHING
+            "#,
+            vec![tenant_id.into(), stream_kind.into()],
+        ))
+        .await
+        .map_err(|_| ProductIndexRefreshRelayError::Unavailable)?;
+
+    let row = transaction
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+            SELECT last_sequence_no
+            FROM product_index_refresh_relay_cursors
+            WHERE tenant_id = $1 AND stream_kind = $2
+            FOR UPDATE
+            "#,
+            vec![tenant_id.into(), stream_kind.into()],
+        ))
+        .await
+        .map_err(|_| ProductIndexRefreshRelayError::Unavailable)?
+        .ok_or(ProductIndexRefreshRelayError::Unavailable)?;
+    let last_sequence_no: i64 = row
+        .try_get("", "last_sequence_no")
+        .map_err(|_| ProductIndexRefreshRelayError::Unavailable)?;
+    if last_sequence_no < 0 {
+        return Err(ProductIndexRefreshRelayError::Unavailable);
+    }
+    Ok(last_sequence_no)
+}
+
+async fn advance_cursor(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+    stream_kind: &str,
+    expected_sequence_no: i64,
+    next_sequence_no: i64,
+) -> Result<(), ProductIndexRefreshRelayError> {
+    if expected_sequence_no < 0 || next_sequence_no <= expected_sequence_no {
+        return Err(ProductIndexRefreshRelayError::Unavailable);
+    }
+    let result = transaction
+        .execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+            UPDATE product_index_refresh_relay_cursors
+            SET last_sequence_no = $4,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE tenant_id = $1
+              AND stream_kind = $2
+              AND last_sequence_no = $3
+            "#,
+            vec![
+                tenant_id.into(),
+                stream_kind.into(),
+                expected_sequence_no.into(),
+                next_sequence_no.into(),
+            ],
+        ))
+        .await
+        .map_err(|_| ProductIndexRefreshRelayError::Unavailable)?;
+    if result.rows_affected() != 1 {
+        return Err(ProductIndexRefreshRelayError::Unavailable);
+    }
+    Ok(())
+}
+
+impl From<ProductIndexRefreshPublicationError> for ProductIndexRefreshRelayError {
+    fn from(error: ProductIndexRefreshPublicationError) -> Self {
+        match error {
+            ProductIndexRefreshPublicationError::ContractMismatch => Self::ContractMismatch,
+            ProductIndexRefreshPublicationError::CausationMismatch => Self::CausationMismatch,
+            ProductIndexRefreshPublicationError::Conflict => Self::Conflict,
+            ProductIndexRefreshPublicationError::Unavailable => Self::Unavailable,
+        }
+    }
+}

--- a/crates/rustok-product/src/services/mod.rs
+++ b/crates/rustok-product/src/services/mod.rs
@@ -3,6 +3,7 @@ pub mod catalog_schema;
 pub mod catalog_schema_service;
 mod index_refresh;
 mod index_refresh_publication;
+mod index_refresh_relay;
 mod write_transaction;
 
 pub use catalog::{
@@ -20,4 +21,8 @@ pub use index_refresh::{
 pub use index_refresh_publication::{
     ProductIndexRefreshCanonicalWriter, ProductIndexRefreshContract,
     ProductIndexRefreshContractTarget, ProductIndexRefreshPublicationError,
+};
+pub use index_refresh_relay::{
+    ProductIndexRefreshEventFactory, ProductIndexRefreshRelayError,
+    ProductIndexRefreshRelayStep, ProductIndexRefreshRelayStepOutcome,
 };

--- a/scripts/verify/verify-index-product-refresh-relay-step.mjs
+++ b/scripts/verify/verify-index-product-refresh-relay-step.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-refresh-relay-step] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const relayPath = 'crates/rustok-product/src/services/index_refresh_relay.rs';
+const relay = requireMarkers(relayPath, [
+  'pub trait ProductIndexRefreshEventFactory: Send + Sync',
+  'type LocaleEvent: ProductIndexRefreshContract',
+  'type VariantEvent: ProductIndexRefreshContract',
+  'pub enum ProductIndexRefreshRelayStepOutcome',
+  'Idle { last_sequence_no: i64 }',
+  'CursorAdvanced { last_sequence_no: i64 }',
+  'Published { sequence_no: i64, refresh_id: Uuid }',
+  'pub struct ProductIndexRefreshRelayStep<F>',
+  'pub async fn publish_next_locale',
+  'pub async fn publish_next_variant',
+  '.list(tenant_id, observed_cursor, 1)',
+  'lock_cursor(&transaction, tenant_id, LOCALE_STREAM_KIND)',
+  'lock_cursor(&transaction, tenant_id, VARIANT_STREAM_KIND)',
+  'ProductIndexRefreshCanonicalWriter::publish_locale_once_in_transaction',
+  'ProductIndexRefreshCanonicalWriter::publish_variant_once_in_transaction',
+  'advance_cursor(',
+  'last_sequence_no = $3',
+  'result.rows_affected() != 1',
+  '.commit()',
+  '.rollback()',
+  'FOR UPDATE',
+  'ON CONFLICT (tenant_id, stream_kind) DO NOTHING',
+]);
+
+for (const forbidden of [
+  'serde_json::Value',
+  'OutboxTransport::',
+  'EventTransport::',
+  'IndexMutation',
+  'index_entities',
+  'index_links',
+  'tokio::spawn',
+  'sleep(',
+  'loop {',
+  'acknowledge(',
+  'publish_contract(',
+]) {
+  if (relay.includes(forbidden)) {
+    fail(`${relayPath} contains forbidden runtime or untyped coupling: ${forbidden}`);
+  }
+}
+
+const migrationPath =
+  'crates/rustok-product/src/migrations/m20260806_000007_add_product_index_refresh_relay_cursors.rs';
+requireMarkers(migrationPath, [
+  'CREATE TABLE product_index_refresh_relay_cursors',
+  'PRIMARY KEY (tenant_id, stream_kind)',
+  "CHECK (stream_kind IN ('locale', 'variant'))",
+  'CHECK (last_sequence_no >= 0)',
+  'product Index refresh relay cursor identity is immutable',
+  'product Index refresh relay cursor cannot move backwards',
+  'product Index refresh relay cursor cannot be deleted',
+  'BEFORE UPDATE ON product_index_refresh_relay_cursors',
+  'BEFORE DELETE ON product_index_refresh_relay_cursors',
+]);
+
+requireMarkers('crates/rustok-product/src/migrations/mod.rs', [
+  'mod m20260806_000007_add_product_index_refresh_relay_cursors;',
+  'Box::new(m20260806_000007_add_product_index_refresh_relay_cursors::Migration)',
+]);
+
+const services = requireMarkers('crates/rustok-product/src/services/mod.rs', [
+  'mod index_refresh_relay;',
+  'ProductIndexRefreshEventFactory',
+  'ProductIndexRefreshRelayError',
+  'ProductIndexRefreshRelayStep',
+  'ProductIndexRefreshRelayStepOutcome',
+]);
+if (services.includes('pub mod index_refresh_relay')) {
+  fail('the relay implementation module must remain private behind curated exports');
+}
+
+requireMarkers('crates/rustok-product/src/lib.rs', [
+  'ProductIndexRefreshEventFactory',
+  'ProductIndexRefreshRelayError',
+  'ProductIndexRefreshRelayStep',
+  'ProductIndexRefreshRelayStepOutcome',
+]);
+
+requireMarkers('crates/rustok-product/docs/index-refresh-relay-step.md', [
+  'Status: `source_complete_typed_family_and_runtime_pending`',
+  '`product_index_refresh_relay_cursors`',
+  '`FOR UPDATE`',
+  '`CursorAdvanced`',
+  'outbox envelope id = outbox correlation id = ledger refresh_id',
+  'outbox causation id = ledger root_event_id',
+  'relay cursor = ledger sequence_no',
+  '`ProductIndexRefreshEventFactory`',
+  'does not add `ProductIndexRefreshEvent`',
+  'global `OutboxRelay`',
+  'No tests, Node verifiers, Cargo checks',
+]);
+
+const aggregate = read('scripts/verify/verify-index-query-contract.mjs');
+if (!aggregate.includes("'verify-index-product-refresh-relay-step.mjs'")) {
+  fail('Index aggregate verifier does not include the Product refresh relay step guard');
+}
+
+console.log('[verify-index-product-refresh-relay-step] Product refresh relay step contract verified');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -62,6 +62,7 @@ const scripts = [
   'verify-index-product-locale-refresh-ledger.mjs',
   'verify-index-product-variant-refresh-ledger.mjs',
   'verify-index-product-refresh-canonical-writer.mjs',
+  'verify-index-product-refresh-relay-step.mjs',
   'verify-index-product-variant-source.mjs',
   'verify-index-product-graph-source.mjs',
   'verify-index-product-tombstone-source.mjs',


### PR DESCRIPTION
## Summary

Add one explicit, durable Product Index refresh relay step without starting a background worker or changing the event wire contract.

- add `product_index_refresh_relay_cursors` keyed by tenant and exact `locale|variant` stream;
- enforce non-nil tenant identity, non-negative sequence, immutable cursor identity, monotonic updates, and no deletion;
- add `ProductIndexRefreshEventFactory` with separate sealed locale and variant event types;
- add `ProductIndexRefreshRelayStep::publish_next_locale` and `publish_next_variant`;
- read at most one row through the existing bounded owner sources;
- lock and recheck the durable cursor with `FOR UPDATE`;
- return `CursorAdvanced` instead of publishing after a stale concurrent observation;
- publish through `ProductIndexRefreshCanonicalWriter`;
- commit the canonical outbox envelope and expected-value cursor advancement in the same Product transaction;
- add documentation and a fail-closed source verifier registered in the Index aggregate verifier.

## Crash and concurrency contract

For one published row:

```text
outbox id = correlation id = refresh_id
causation id = root_event_id
cursor = ledger sequence_no
```

A crash before commit retains neither outbox nor cursor movement; a crash after commit retains both. Concurrent callers can observe the same append-only candidate, but only the caller whose observed cursor still matches the locked cursor may publish it.

## Deliberate limits

This PR does not:

- add `ProductIndexRefreshEvent`;
- change the event registry, transport schemas or committed digests;
- start a loop, timer, scheduler or spawned task;
- add relay leases or retry policy;
- dispatch directly to local delivery or Iggy;
- register Product/ProductVariant Index routes;
- start a broker consumer or acknowledge messages;
- add runtime or commit-before-ack evidence;
- alter the concrete-repair evidence gate.

The Product wire family remains blocked until the canonical digest artifact is regenerated and admitted. The current artifact still matches the pre-Reactions blob and values.

## Main recheck

The branch is one commit ahead of `main@8effca6edbc1689693f33958fd167b54dbcad53c` with exactly eight changed files. The concurrent Commerce changes do not overlap this Product/Index slice.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows or CI were run.