### PR TITLE
feat(reactions): add Blog subject producer

### DIFF
--- a/apps/server/tests/reactions_composition_profiles.rs
+++ b/apps/server/tests/reactions_composition_profiles.rs
@@ -41,7 +41,7 @@ async fn forum_without_reactions_keeps_forum_host_composition_available() {
     );
 }
 
-#[cfg(all(feature = "mod-reactions", not(feature = "mod-forum")))]
+#[cfg(all(feature = "mod-reactions", not(feature = "mod-forum"), not(feature = "mod-blog")))]
 #[tokio::test]
 async fn reactions_without_forum_materializes_an_empty_subject_registry() {
     let registry = ModuleRegistry::new()
@@ -84,8 +84,34 @@ async fn forum_with_reactions_materializes_topic_and_reply_provider() {
         .collect::<Vec<_>>();
     kinds.sort();
 
-    assert_eq!(subjects.len(), 1);
     assert_eq!(kinds, vec!["reply".to_string(), "topic".to_string()]);
+}
+
+#[cfg(all(feature = "mod-blog", feature = "mod-reactions"))]
+#[tokio::test]
+async fn blog_with_reactions_materializes_post_provider() {
+    let registry = ModuleRegistry::new()
+        .register(IndexModule)
+        .register(rustok_reactions::ReactionsModule)
+        .register(rustok_blog::BlogModule);
+
+    let extensions = compose(&registry)
+        .await
+        .expect("Blog plus Reactions host composition must initialize");
+    let subjects = rustok_reactions::api::reaction_subject_registry_from_extensions(
+        extensions.as_ref(),
+    )
+    .expect("selected Reactions owner must publish a materialized subject registry");
+    let blog = subjects
+        .get_by_str("blog")
+        .expect("Blog producer must materialize when both modules are selected");
+    let kinds = blog
+        .supported_kinds()
+        .into_iter()
+        .map(|kind| kind.as_str().to_string())
+        .collect::<Vec<_>>();
+
+    assert_eq!(kinds, vec!["post".to_string()]);
 }
 
 #[cfg(feature = "mod-reactions")]

--- a/crates/rustok-blog/Cargo.toml
+++ b/crates/rustok-blog/Cargo.toml
@@ -20,6 +20,7 @@ rustok-core.workspace = true
 rustok-events.workspace = true
 rustok-outbox.workspace = true
 rustok-profiles.workspace = true
+rustok-reactions-api = { path = "../rustok-reactions-api" }
 rustok-seo-targets.workspace = true
 rustok-translation-targets.workspace = true
 rustok-media.workspace = true

--- a/crates/rustok-blog/contracts/blog-reaction-subject-provider.json
+++ b/crates/rustok-blog/contracts/blog-reaction-subject-provider.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "module": "blog",
+  "contract": "blog_reaction_subject_provider_v1",
+  "status": "source_ready_maintainer_execution_pending",
+  "source": "blog",
+  "supported_kinds": ["post"],
+  "catalog": {
+    "selection": "single",
+    "keys": ["like"]
+  },
+  "visibility": {
+    "lifecycle": "published",
+    "channel_scope": "blog_post_channel_visibility",
+    "missing_or_denied": "unavailable",
+    "revision_conflict_after_visibility": true
+  },
+  "revision": {
+    "owner_field": "blog_posts.version",
+    "must_be_positive": true
+  },
+  "required_files": [
+    "crates/rustok-blog/src/reaction_subject.rs",
+    "crates/rustok-blog/src/lib.rs",
+    "crates/rustok-blog/Cargo.toml",
+    "crates/rustok-reactions/docs/implementation-plan.md",
+    "scripts/verify/verify-blog-reaction-subject-provider.mjs"
+  ],
+  "required_source_fragments": [
+    "BlogReactionSubjectProviderFactory",
+    "ReactionSubjectProviderFactory",
+    "ReactionSubjectProvider",
+    "BLOG_POST_REACTION_KIND",
+    "BLOG_REACTION_V1_KEY",
+    "blog_post::Entity::find()",
+    "blog_post_channel_visibility::Entity::find()",
+    "is_post_visible_for_channel",
+    "blog_post_revision",
+    "ReactionProviderError::Conflict",
+    "ReactionSubjectAuthorization::Unavailable"
+  ],
+  "forbidden_source_fragments": [
+    "rustok_reactions::",
+    "ReactionWritePort",
+    "ReactionReadPort",
+    "async_graphql",
+    "axum::",
+    "leptos"
+  ],
+  "ownership": {
+    "blog_owns": [
+      "post existence",
+      "post version",
+      "publication lifecycle",
+      "channel visibility",
+      "reaction policy"
+    ],
+    "reactions_owns": [
+      "actor state",
+      "command receipts",
+      "aggregate counts",
+      "semantic reaction events",
+      "aggregate reconciliation"
+    ]
+  },
+  "deliberate_limits": [
+    "no Reactions owner dependency from Blog",
+    "no default enablement",
+    "no transport",
+    "no UI",
+    "no profile or actor presentation",
+    "no Blog-owned reaction persistence"
+  ],
+  "verification": [
+    "cargo test -p rustok-blog reaction_subject",
+    "cargo check -p rustok-blog --all-targets",
+    "node scripts/verify/verify-blog-reaction-subject-provider.mjs",
+    "git diff --check"
+  ]
+}

--- a/crates/rustok-blog/src/lib.rs
+++ b/crates/rustok-blog/src/lib.rs
@@ -45,6 +45,7 @@ use rustok_core::{
     MigrationSource, ModuleEventListenerContext, ModuleEventListenerRegistry,
     ModuleRuntimeExtensions, RusToKModule,
 };
+use rustok_reactions_api::register_reaction_subject_provider_factory;
 use rustok_seo_targets::register_seo_target_provider;
 use sea_orm_migration::MigrationTrait;
 
@@ -56,6 +57,7 @@ pub mod graphql;
 pub mod locale;
 pub mod migrations;
 pub mod openapi;
+mod reaction_subject;
 pub mod richtext;
 mod seo_targets;
 pub mod services;
@@ -79,6 +81,10 @@ pub use dto::{
 pub use entities::*;
 pub use error::{BlogError, BlogResult};
 pub use graphql::{BlogMutation, BlogQuery};
+pub use reaction_subject::{
+    BLOG_POST_REACTION_KIND, BLOG_REACTION_SOURCE, BLOG_REACTION_V1_KEY,
+    BlogReactionSubjectProviderFactory,
+};
 pub use rustok_comments::CommentsThreadPort;
 pub use services::{CategoryService, CommentService, PostService, TagService};
 pub use state_machine::{
@@ -138,7 +144,17 @@ impl RusToKModule for BlogModule {
                     "blog SEO target registration failed: {error}"
                 ))
             },
+        )?;
+        register_reaction_subject_provider_factory(
+            extensions,
+            reaction_subject::BlogReactionSubjectProviderFactory,
         )
+        .map_err(|error| {
+            rustok_core::Error::Validation(format!(
+                "blog reaction subject factory registration failed: {error}"
+            ))
+        })?;
+        Ok(())
     }
 
     fn register_event_listeners(

--- a/crates/rustok-blog/src/reaction_subject.rs
+++ b/crates/rustok-blog/src/reaction_subject.rs
@@ -1,0 +1,178 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{HostRuntimeContext, PortContext};
+use rustok_reactions_api::{
+    ReactionCatalog, ReactionKey, ReactionProviderError, ReactionProviderResult,
+    ReactionSelectionPolicy, ReactionSourceSlug, ReactionSubjectAuthorization, ReactionSubjectKind,
+    ReactionSubjectProvider, ReactionSubjectProviderFactory, ReactionSubjectRequest,
+};
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder};
+
+use crate::entities::{blog_post, blog_post_channel_visibility};
+use crate::services::is_post_visible_for_channel;
+
+pub const BLOG_REACTION_SOURCE: &str = "blog";
+pub const BLOG_POST_REACTION_KIND: &str = "post";
+pub const BLOG_REACTION_V1_KEY: &str = "like";
+const BLOG_POST_PUBLISHED_STATUS: &str = "published";
+
+#[derive(Clone, Default)]
+pub struct BlogReactionSubjectProviderFactory;
+
+impl ReactionSubjectProviderFactory for BlogReactionSubjectProviderFactory {
+    fn source(&self) -> ReactionSourceSlug {
+        blog_reaction_source()
+    }
+
+    fn build(
+        &self,
+        host: &HostRuntimeContext,
+    ) -> ReactionProviderResult<Arc<dyn ReactionSubjectProvider>> {
+        Ok(Arc::new(BlogReactionSubjectProvider::new(host.db_clone())))
+    }
+}
+
+#[derive(Clone)]
+struct BlogReactionSubjectProvider {
+    db: DatabaseConnection,
+}
+
+impl BlogReactionSubjectProvider {
+    fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    async fn authorize_post(
+        &self,
+        context: &PortContext,
+        request: &ReactionSubjectRequest,
+    ) -> ReactionProviderResult<ReactionSubjectAuthorization> {
+        let subject = &request.subject;
+        let Some(post) = blog_post::Entity::find()
+            .filter(blog_post::Column::TenantId.eq(subject.tenant_id()))
+            .filter(blog_post::Column::Id.eq(subject.subject_id()))
+            .one(&self.db)
+            .await
+            .map_err(database_error)?
+        else {
+            return Ok(ReactionSubjectAuthorization::Unavailable);
+        };
+
+        if post.status != BLOG_POST_PUBLISHED_STATUS {
+            return Ok(ReactionSubjectAuthorization::Unavailable);
+        }
+
+        let channel_slugs = blog_post_channel_visibility::Entity::find()
+            .filter(blog_post_channel_visibility::Column::TenantId.eq(subject.tenant_id()))
+            .filter(blog_post_channel_visibility::Column::PostId.eq(post.id))
+            .order_by_asc(blog_post_channel_visibility::Column::ChannelSlug)
+            .all(&self.db)
+            .await
+            .map_err(database_error)?
+            .into_iter()
+            .map(|row| row.channel_slug)
+            .collect::<Vec<_>>();
+        if !is_post_visible_for_channel(&channel_slugs, context.channel.as_deref()) {
+            return Ok(ReactionSubjectAuthorization::Unavailable);
+        }
+
+        let current_revision = blog_post_revision(post.version)?;
+        if subject.subject_revision() != current_revision {
+            return Err(ReactionProviderError::Conflict);
+        }
+
+        Ok(ReactionSubjectAuthorization::Allowed {
+            canonical_subject: subject.clone(),
+            catalog: blog_reaction_catalog_v1()?,
+        })
+    }
+}
+
+#[async_trait]
+impl ReactionSubjectProvider for BlogReactionSubjectProvider {
+    fn source(&self) -> ReactionSourceSlug {
+        blog_reaction_source()
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Blog"
+    }
+
+    fn supported_kinds(&self) -> Vec<ReactionSubjectKind> {
+        vec![blog_post_reaction_kind()]
+    }
+
+    async fn authorize(
+        &self,
+        context: PortContext,
+        request: ReactionSubjectRequest,
+    ) -> ReactionProviderResult<ReactionSubjectAuthorization> {
+        request
+            .validate()
+            .map_err(|_| ReactionProviderError::InvalidRequest)?;
+        let tenant_id = uuid::Uuid::parse_str(&context.tenant_id)
+            .map_err(|_| ReactionProviderError::InvalidRequest)?;
+        if tenant_id != request.subject.tenant_id()
+            || request.subject.source().as_str() != BLOG_REACTION_SOURCE
+        {
+            return Err(ReactionProviderError::InvalidRequest);
+        }
+
+        match request.subject.kind().as_str() {
+            BLOG_POST_REACTION_KIND => self.authorize_post(&context, &request).await,
+            _ => Err(ReactionProviderError::InvalidRequest),
+        }
+    }
+}
+
+fn blog_post_revision(version: i32) -> ReactionProviderResult<u64> {
+    u64::try_from(version)
+        .ok()
+        .filter(|revision| *revision > 0)
+        .ok_or(ReactionProviderError::Internal { retryable: false })
+}
+
+fn blog_reaction_catalog_v1() -> ReactionProviderResult<ReactionCatalog> {
+    ReactionCatalog::try_new(
+        ReactionSelectionPolicy::Single,
+        vec![ReactionKey::new(BLOG_REACTION_V1_KEY)
+            .map_err(|_| ReactionProviderError::Internal { retryable: false })?],
+    )
+    .map_err(|_| ReactionProviderError::Internal { retryable: false })
+}
+
+fn blog_reaction_source() -> ReactionSourceSlug {
+    ReactionSourceSlug::new(BLOG_REACTION_SOURCE)
+        .expect("Blog reaction source constant must remain valid")
+}
+
+fn blog_post_reaction_kind() -> ReactionSubjectKind {
+    ReactionSubjectKind::new(BLOG_POST_REACTION_KIND)
+        .expect("Blog post reaction kind constant must remain valid")
+}
+
+fn database_error(_error: sea_orm::DbErr) -> ReactionProviderError {
+    ReactionProviderError::Internal { retryable: true }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blog_catalog_is_single_like() {
+        let catalog = blog_reaction_catalog_v1().expect("fixed catalog should be valid");
+        assert_eq!(catalog.selection(), ReactionSelectionPolicy::Single);
+        assert_eq!(catalog.keys().len(), 1);
+        assert_eq!(catalog.keys()[0].as_str(), BLOG_REACTION_V1_KEY);
+    }
+
+    #[test]
+    fn blog_post_revision_requires_positive_owner_version() {
+        assert_eq!(blog_post_revision(1).expect("initial version"), 1);
+        assert_eq!(blog_post_revision(42).expect("advanced version"), 42);
+        assert!(blog_post_revision(0).is_err());
+        assert!(blog_post_revision(-1).is_err());
+    }
+}

--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -5,7 +5,7 @@ language: en
 status: active
 owners:
   - rustok-forum
-last_reviewed: 2026-08-06
+last_reviewed: 2026-08-07
 ---
 
 # `rustok-forum` canonical implementation plan
@@ -112,9 +112,11 @@ persistence, immutable catalog snapshots, shared Outbox command receipts,
 atomic actor-state/aggregate updates, sealed semantic reaction events and
 bounded aggregate reconciliation. Forum publishes a source-ready `topic`/`reply`
 provider factory with exact active-state, visibility and current-revision
-authorization plus a bounded single-`like` v1 catalog. Optional owner selection,
-host materialization and executable source evidence for all three optional
-profiles are source-ready. Maintainer lockfile/event-digest generation and
+authorization plus a bounded single-`like` v1 catalog. Blog now supplies the
+second real producer through the same neutral SPI using Blog-owned publication,
+channel visibility and owner version, with a Blog+Reactions composition profile
+in source. Optional owner selection, host materialization and executable source
+evidence are source-ready. Maintainer lockfile/event-digest generation and
 retained execution evidence remains pending. No reaction transport or UI exists.
 
 ## Program ledger
@@ -139,7 +141,7 @@ retained execution evidence remains pending. No reaction transport or UI exists.
 | `FORUM-15` | `in_progress` | Profiles supplies `ProfilesReader`. Finish member-card composition, privacy/block behavior, Forum-stat enrichment and no-N+1 evidence. |
 | `FORUM-16` | `in_progress` | Read state, unread projections, bounded bulk owners and transports exist. Visibility-scoped storefront bulk commands and PostgreSQL evidence remain. |
 | `FORUM-17` | `planned` | Forum drafts/bookmarks with optional Notifications reminders and Media references. |
-| `FORUM-18` | `in_progress` | Neutral API, optional owner registration/selection, tenant-composite persistence, shared receipts, atomic actor aggregates, semantic reaction events, bounded aggregate reconciliation, Forum topic/reply provider factory, host materialization and composition tests are source-ready. Regenerate `Cargo.lock` and event digests, retain owner/event/repair/composition evidence, then add a second producer, transports/UI and runtime proof; Forum votes remain separate. |
+| `FORUM-18` | `in_progress` | Neutral API, optional owner registration/selection, tenant-composite persistence, shared receipts, atomic actor aggregates, semantic reaction events, bounded aggregate reconciliation, Forum topic/reply provider, Blog second producer, host materialization and composition-test source are ready. Regenerate `Cargo.lock` and event digests, retain owner/event/repair/Forum+Blog composition evidence, then add transports/UI and runtime proof; Forum votes remain separate. |
 | `FORUM-19` | `planned` | Integrate `rustok-moderation-api` subject/effect adapters and Forum-local restrictions. Moderation owns cases and audit. |
 | `FORUM-20` | `in_progress` | Rich visibility and recipient-aware source/inbox slices largely exist. Complete remaining reads, Search/SEO/deep links, reconciliation, delivery and PostgreSQL evidence. |
 | `FORUM-21` | `in_progress` | A-X provide move/merge/split/fork/range owners, transports and UI. Retained runtime evidence remains. |
@@ -215,10 +217,14 @@ optional owner selection and host materialization boundary.
 
 The Reactions-disabled Forum composition remains valid: Forum commands and reads
 continue without owner storage or a materialized reaction registry. Reactions
-without Forum materializes an empty source registry; Forum with Reactions
-materializes the `forum` source with `topic` and `reply` kinds. Executable source
-evidence exists for these profiles and the selected-feature/missing-owner
-failure, but retained execution evidence remains pending.
+without Forum or Blog materializes an empty source registry; Forum with Reactions
+materializes the `forum` source with `topic` and `reply` kinds. Blog is the
+second real producer and materializes the `blog` source with `post` while using
+Blog-owned positive version, `published` lifecycle and typed channel visibility.
+Forum and Blog both depend only on the neutral API, so no producer implies the
+Reactions owner. Executable source evidence exists for these profiles and the
+selected-feature/missing-owner failure, but retained execution evidence remains
+pending.
 
 A changed Reactions command commits actor state, aggregate deltas, one sealed
 `reactions.actor_state.changed` event and its completed owner receipt atomically.
@@ -254,7 +260,7 @@ Hosts register/mount packages and do not absorb policy.
 3. Forum `topic`/`reply` provider factory and disabled Forum profile: source-ready, maintainer verification pending.
 4. Optional distribution/server selection and host materialization after Forum facts: source-ready, maintainer verification pending.
 5. Executable composition profiles, sealed semantic reaction events and bounded aggregate reconciliation: source-ready; retain execution, rollback, replay and repair evidence.
-6. Add a second producer and review the neutral contract before freezing shared presentation contracts.
+6. Second producer and neutral-contract review: Blog `post` source and Blog+Reactions composition profile are source-ready; retain provider/host execution evidence before freezing shared presentation contracts.
 7. Introduce Reputation/Achievements only after at least two producers agree.
 8. Integrate Forum with `rustok-moderation-api`; never add Forum case queues.
 
@@ -287,7 +293,8 @@ Hosts register/mount packages and do not absorb policy.
 - Reactions owner tables contain no Forum routes, content, visibility or copied
   profile data.
 - Forum's neutral Reactions API dependency does not make the Reactions owner a
-  required Forum module dependency.
+  required Forum module dependency; the same boundary is now proven by Blog as
+  a second producer.
 - Selecting `mod-reactions` without registering `ReactionsModule` is a startup
   configuration error, not an implicit empty owner.
 - Reactions semantic event envelope identity is the admitted owner-operation
@@ -302,6 +309,7 @@ node scripts/verify/verify-forum-shared-capability-ownership.mjs
 node scripts/verify/verify-reactions-foundation.mjs
 node scripts/verify/verify-reactions-owner-persistence.mjs
 node scripts/verify/verify-forum-reaction-subject-provider.mjs
+node scripts/verify/verify-blog-reaction-subject-provider.mjs
 node scripts/verify/verify-reactions-host-composition.mjs
 node scripts/verify/verify-reactions-composition-profiles.mjs
 node scripts/verify/verify-reactions-events-reconciliation.mjs
@@ -309,8 +317,10 @@ cargo test -p rustok-events reactions
 cargo test -p rustok-reactions-api
 cargo test -p rustok-reactions
 cargo test -p rustok-forum reaction_subject
+cargo test -p rustok-blog reaction_subject
 cargo check -p rustok-distribution --features "mod-forum mod-reactions"
 cargo check -p rustok-server --no-default-features --features "mod-forum mod-reactions"
+cargo test -p rustok-server --no-default-features --features "mod-blog mod-reactions" --test reactions_composition_profiles blog_with_reactions_materializes_post_provider
 cargo run -p rustok-events --example event_contract_digests -- --write
 cargo xtask module validate forum
 npm run verify:forum:admin-boundary
@@ -343,5 +353,6 @@ runtime claims without retained executable evidence.
 Regenerate the event-contract digests and `Cargo.lock`, then retain SQLite and
 PostgreSQL evidence for changed/no-op/replayed reaction event cardinality,
 rollback on event failure, concurrent actor writes, clean/blocked/drift bounded
-aggregate reconciliation and repair receipt replay. Add a second real producer
-before any reaction transport or UI slice.
+aggregate reconciliation and repair receipt replay. Retain Blog provider and
+Blog+Reactions composition evidence, then begin bounded reaction transport/UI
+work without moving producer-owned visibility or lifecycle into Reactions.

--- a/crates/rustok-reactions/docs/implementation-plan.md
+++ b/crates/rustok-reactions/docs/implementation-plan.md
@@ -18,7 +18,7 @@ last_reviewed: 2026-08-07
 | `REACTIONS-01` | `in_progress` | Tenant-composite owner schema, immutable catalog snapshots, actor uniqueness and shared Outbox command receipts are source-ready. Regenerate `Cargo.lock` and retain SQLite/PostgreSQL execution evidence. |
 | `REACTIONS-02` | `in_progress` | Actor state, aggregate deltas, typed semantic events and completed shared Outbox receipts now share one transaction. Bounded inspect/repair reconciliation is source-ready; retain rollback, replay, concurrency and repair evidence. |
 | `REACTIONS-03` | `in_progress` | Forum topic/reply provider, optional host materialization and executable composition profile tests are source-ready. Reactions stays outside defaults; retained execution evidence remains pending. |
-| `REACTIONS-04` | `in_progress` | Blog `post` producer is source-ready over Blog-owned publication, channel visibility and owner version. The neutral-contract review now covers Forum and Blog producers; retain Blog host/runtime evidence before freezing shared transport or presentation contracts. |
+| `REACTIONS-04` | `in_progress` | Blog `post` producer and Blog+Reactions composition profile are source-ready over Blog-owned publication, channel visibility and owner version. The neutral-contract review now covers Forum and Blog producers; retain Blog provider/host runtime evidence before freezing shared transport or presentation contracts. |
 | `REACTIONS-05` | `planned` | Bounded read/write transports and module-owned UI. |
 | `REACTIONS-06` | `planned` | Runtime evidence, FBA contracts, import/reconciliation and release profiles. |
 
@@ -137,8 +137,8 @@ models: Forum derives revision from captured topic/reply history and rich audien
 facts, while Blog uses an explicit owner version plus publication/channel scope.
 No API expansion was required for the second producer. This is the source-level
 neutral-contract review gate for `REACTIONS-04`; retained Blog composition and
-runtime execution evidence remains required before shared transport or
-presentation contracts are frozen.
+provider authorization execution evidence remains required before shared
+transport or presentation contracts are frozen.
 
 ## Optional host composition boundary
 
@@ -165,8 +165,8 @@ Supported profiles are explicit:
   producer source.
 - Forum with Reactions: the registry materializes the `forum` source with
   `topic` and `reply` kinds.
-- Blog with Reactions: the generic registry can materialize the `blog` source
-  with the `post` kind; retained executable host evidence is pending.
+- Blog with Reactions: the registry materializes the `blog` source with the
+  `post` kind.
 - Selected Reactions feature without `ReactionsModule`: startup fails with the
   stable owner-missing error before publishing a false runtime.
 
@@ -178,14 +178,16 @@ outside default profiles.
 
 `apps/server/tests/reactions_composition_profiles.rs` provides executable
 composition profile tests over the public server host-composition entrypoint and
-an isolated SQLite in-memory connection. The current target proves the three
-Forum/Reactions optional profiles plus the selected-feature/missing-owner
-failure. It does not query Forum domain rows or execute reaction commands.
+an isolated SQLite in-memory connection. The target has source coverage for the
+three established Forum/Reactions optional profiles, Blog+Reactions producer
+materialization and the selected-feature/missing-owner failure. It does not query
+Forum or Blog domain rows or execute reaction commands.
 
-The Blog producer adds source-level provider and contract evidence in
+The Blog producer also adds source-level provider and contract evidence in
 `crates/rustok-blog/contracts/blog-reaction-subject-provider.json` and
-`scripts/verify/verify-blog-reaction-subject-provider.mjs`. A retained executable
-Blog+Reactions host profile remains part of `REACTIONS-04` completion.
+`scripts/verify/verify-blog-reaction-subject-provider.mjs`. Retained execution of
+the Blog+Reactions host profile and Blog authorization behavior remains part of
+`REACTIONS-04` completion.
 
 The contract remains `source_ready_maintainer_execution_pending`: retained
 execution evidence remains pending until a maintainer runs and stores the
@@ -197,8 +199,8 @@ profiles. Source presence alone does not promote `REACTIONS-03` or
 Regenerate `Cargo.lock` and the `rustok-events` digest artifact, then retain
 SQLite/PostgreSQL evidence covering changed/no-op/replay event cardinality,
 rollback on event failure, concurrent actor updates, clean/blocked/drift
-reconciliation and receipt replay. Retain a Blog+Reactions host composition run
-and Blog provider authorization evidence. After those gates, review the two
+reconciliation and receipt replay. Retain Blog provider authorization and
+Blog+Reactions host composition evidence. After those gates, review the two
 producer results and begin bounded transports/UI without widening producer
 storage ownership.
 
@@ -223,6 +225,7 @@ cargo test -p rustok-server --no-default-features --features mod-forum --test re
 cargo test -p rustok-server --no-default-features --features mod-reactions --test reactions_composition_profiles reactions_without_forum_materializes_an_empty_subject_registry
 cargo test -p rustok-server --no-default-features --features mod-reactions --test reactions_composition_profiles selected_reactions_feature_fails_when_owner_module_is_missing
 cargo test -p rustok-server --no-default-features --features "mod-forum mod-reactions" --test reactions_composition_profiles forum_with_reactions_materializes_topic_and_reply_provider
+cargo test -p rustok-server --no-default-features --features "mod-blog mod-reactions" --test reactions_composition_profiles blog_with_reactions_materializes_post_provider
 cargo run -p rustok-events --example event_contract_digests -- --write
 node scripts/verify/verify-reactions-foundation.mjs
 node scripts/verify/verify-reactions-owner-persistence.mjs

--- a/crates/rustok-reactions/docs/implementation-plan.md
+++ b/crates/rustok-reactions/docs/implementation-plan.md
@@ -5,7 +5,7 @@ language: en
 status: active
 owners:
   - rustok-reactions
-last_reviewed: 2026-08-06
+last_reviewed: 2026-08-07
 ---
 
 # `rustok-reactions` implementation plan
@@ -18,7 +18,7 @@ last_reviewed: 2026-08-06
 | `REACTIONS-01` | `in_progress` | Tenant-composite owner schema, immutable catalog snapshots, actor uniqueness and shared Outbox command receipts are source-ready. Regenerate `Cargo.lock` and retain SQLite/PostgreSQL execution evidence. |
 | `REACTIONS-02` | `in_progress` | Actor state, aggregate deltas, typed semantic events and completed shared Outbox receipts now share one transaction. Bounded inspect/repair reconciliation is source-ready; retain rollback, replay, concurrency and repair evidence. |
 | `REACTIONS-03` | `in_progress` | Forum topic/reply provider, optional host materialization and executable composition profile tests are source-ready. Reactions stays outside defaults; retained execution evidence remains pending. |
-| `REACTIONS-04` | `planned` | Second real producer adapter and neutral-contract review. |
+| `REACTIONS-04` | `in_progress` | Blog `post` producer is source-ready over Blog-owned publication, channel visibility and owner version. The neutral-contract review now covers Forum and Blog producers; retain Blog host/runtime evidence before freezing shared transport or presentation contracts. |
 | `REACTIONS-05` | `planned` | Bounded read/write transports and module-owned UI. |
 | `REACTIONS-06` | `planned` | Runtime evidence, FBA contracts, import/reconciliation and release profiles. |
 
@@ -110,6 +110,36 @@ Forum registers a neutral `ReactionSubjectProviderFactory` for `topic` and
 Forum remains fully usable when Reactions is absent. The neutral factory may be
 registered without materializing a Reactions owner runtime.
 
+## Blog producer boundary
+
+Blog is the second real producer for the neutral contract. It registers a
+`ReactionSubjectProviderFactory` for `post` while depending only on
+`rustok-reactions-api`. The provider:
+
+- validates exact tenant/source/kind identity;
+- uses the Blog-owned positive `blog_posts.version` as subject revision;
+- allows only owner-state `published` posts;
+- reuses Blog's typed `blog_post_channel_visibility` relation and existing
+  channel visibility helper before exposing a subject;
+- returns the same unavailable result for missing, unpublished and
+  channel-denied posts, and returns revision conflict only after visibility;
+- publishes one bounded single-selection `like` catalog;
+- does not persist actor reaction state, aggregates or presentation in Blog.
+
+The Blog module dependency list does not add the Reactions owner. Blog remains
+usable when Reactions is absent, while a selected Reactions owner can materialize
+the Blog factory through the same generic host registry as Forum.
+
+## Neutral-contract review
+
+Forum and Blog now exercise the same producer SPI with materially different owner
+models: Forum derives revision from captured topic/reply history and rich audience
+facts, while Blog uses an explicit owner version plus publication/channel scope.
+No API expansion was required for the second producer. This is the source-level
+neutral-contract review gate for `REACTIONS-04`; retained Blog composition and
+runtime execution evidence remains required before shared transport or
+presentation contracts are frozen.
+
 ## Optional host composition boundary
 
 `mod-reactions` is an explicit optional feature in `rustok-distribution` and
@@ -123,41 +153,54 @@ The executable host fails closed when the feature is selected but
 `ReactionsModule` is absent from the supplied `ModuleRegistry`. When Forum is
 also selected, materialization happens after Forum audience facts and exact
 recipient-context providers exist, so the Forum factory cannot be built with a
-broader or incomplete authority boundary.
+broader or incomplete authority boundary. Blog needs no extra host authority
+provider because its reaction scope is derived from Blog-owned publication,
+channel visibility and version state.
 
 Supported profiles are explicit:
 
 - Forum without Reactions: Forum remains available; the neutral factory is not
   materialized into an owner registry.
-- Reactions without Forum: the owner registry materializes with no Forum source.
+- Reactions without Forum or Blog: the owner registry materializes with no
+  producer source.
 - Forum with Reactions: the registry materializes the `forum` source with
   `topic` and `reply` kinds.
+- Blog with Reactions: the generic registry can materialize the `blog` source
+  with the `post` kind; retained executable host evidence is pending.
 - Selected Reactions feature without `ReactionsModule`: startup fails with the
   stable owner-missing error before publishing a false runtime.
 
-`mod-forum` does not imply `mod-reactions`, server defaults do not select it and
-`modules.toml` keeps Reactions outside `default_enabled` and outside default
-profiles.
+Neither `mod-forum` nor `mod-blog` implies `mod-reactions`, server defaults do
+not select it and `modules.toml` keeps Reactions outside `default_enabled` and
+outside default profiles.
 
 ## Executable composition evidence
 
 `apps/server/tests/reactions_composition_profiles.rs` provides executable
 composition profile tests over the public server host-composition entrypoint and
-an isolated SQLite in-memory connection. The test target proves the three
-supported optional profiles plus the selected-feature/missing-owner failure.
-It does not query Forum domain rows or execute reaction commands.
+an isolated SQLite in-memory connection. The current target proves the three
+Forum/Reactions optional profiles plus the selected-feature/missing-owner
+failure. It does not query Forum domain rows or execute reaction commands.
+
+The Blog producer adds source-level provider and contract evidence in
+`crates/rustok-blog/contracts/blog-reaction-subject-provider.json` and
+`scripts/verify/verify-blog-reaction-subject-provider.mjs`. A retained executable
+Blog+Reactions host profile remains part of `REACTIONS-04` completion.
 
 The contract remains `source_ready_maintainer_execution_pending`: retained
-execution evidence remains pending until a maintainer runs and stores the four
-profile results. Source presence alone does not promote `REACTIONS-03` to done.
+execution evidence remains pending until a maintainer runs and stores the
+profiles. Source presence alone does not promote `REACTIONS-03` or
+`REACTIONS-04` to done.
 
 ## Immediate next action
 
 Regenerate `Cargo.lock` and the `rustok-events` digest artifact, then retain
 SQLite/PostgreSQL evidence covering changed/no-op/replay event cardinality,
 rollback on event failure, concurrent actor updates, clean/blocked/drift
-reconciliation and receipt replay. After that, add a second real producer and
-review the neutral contract before freezing transport or presentation contracts.
+reconciliation and receipt replay. Retain a Blog+Reactions host composition run
+and Blog provider authorization evidence. After those gates, review the two
+producer results and begin bounded transports/UI without widening producer
+storage ownership.
 
 Before release, execute SQLite and PostgreSQL migrations, retain replay,
 concurrency and rollback evidence, and retain bounded repair evidence for catalog
@@ -170,9 +213,11 @@ cargo test -p rustok-events reactions
 cargo test -p rustok-reactions-api
 cargo test -p rustok-reactions
 cargo test -p rustok-forum reaction_subject
+cargo test -p rustok-blog reaction_subject
 cargo check -p rustok-reactions-api --all-targets
 cargo check -p rustok-reactions --all-targets
 cargo check -p rustok-forum --all-targets
+cargo check -p rustok-blog --all-targets
 cargo check -p rustok-distribution --features "mod-forum mod-reactions"
 cargo test -p rustok-server --no-default-features --features mod-forum --test reactions_composition_profiles forum_without_reactions_keeps_forum_host_composition_available
 cargo test -p rustok-server --no-default-features --features mod-reactions --test reactions_composition_profiles reactions_without_forum_materializes_an_empty_subject_registry
@@ -182,6 +227,7 @@ cargo run -p rustok-events --example event_contract_digests -- --write
 node scripts/verify/verify-reactions-foundation.mjs
 node scripts/verify/verify-reactions-owner-persistence.mjs
 node scripts/verify/verify-forum-reaction-subject-provider.mjs
+node scripts/verify/verify-blog-reaction-subject-provider.mjs
 node scripts/verify/verify-reactions-host-composition.mjs
 node scripts/verify/verify-reactions-composition-profiles.mjs
 node scripts/verify/verify-reactions-events-reconciliation.mjs

--- a/scripts/verify/verify-blog-reaction-subject-provider.mjs
+++ b/scripts/verify/verify-blog-reaction-subject-provider.mjs
@@ -1,0 +1,88 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath = path.join(
+  repoRoot,
+  "crates/rustok-blog/contracts/blog-reaction-subject-provider.json",
+);
+const contract = JSON.parse(readFileSync(contractPath, "utf8"));
+
+function fail(message) {
+  throw new Error(`Blog reaction subject provider verification failed: ${message}`);
+}
+
+function read(relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!existsSync(absolute)) fail(`missing required file ${relativePath}`);
+  return readFileSync(absolute, "utf8");
+}
+
+function compact(value) {
+  return value.replace(/\s+/gu, " ").trim();
+}
+
+if (contract.schema_version !== 1) fail("unsupported contract schema version");
+if (contract.module !== "blog") fail("contract module must be blog");
+if (contract.contract !== "blog_reaction_subject_provider_v1") {
+  fail("unexpected contract identity");
+}
+if (contract.source !== "blog") fail("provider source must be blog");
+if (JSON.stringify(contract.supported_kinds) !== JSON.stringify(["post"])) {
+  fail("provider kind must remain post");
+}
+if (contract.catalog.selection !== "single") fail("v1 catalog must remain single-select");
+if (JSON.stringify(contract.catalog.keys) !== JSON.stringify(["like"])) {
+  fail("v1 catalog must contain only like");
+}
+
+for (const relativePath of contract.required_files) read(relativePath);
+
+const provider = read("crates/rustok-blog/src/reaction_subject.rs");
+const blogLib = read("crates/rustok-blog/src/lib.rs");
+const blogCargo = read("crates/rustok-blog/Cargo.toml");
+const reactionsPlan = compact(read("crates/rustok-reactions/docs/implementation-plan.md"));
+
+for (const fragment of contract.required_source_fragments) {
+  if (!provider.includes(fragment)) fail(`provider is missing ${fragment}`);
+}
+for (const fragment of contract.forbidden_source_fragments) {
+  if (provider.includes(fragment)) fail(`provider contains forbidden fragment ${fragment}`);
+}
+
+if (!blogCargo.includes('rustok-reactions-api = { path = "../rustok-reactions-api" }')) {
+  fail("Blog must depend on the neutral rustok-reactions-api crate");
+}
+if (/^rustok-reactions\s*=/mu.test(blogCargo)) {
+  fail("Blog must not depend on the Reactions owner crate");
+}
+
+for (const fragment of [
+  "mod reaction_subject;",
+  "register_reaction_subject_provider_factory",
+  "BlogReactionSubjectProviderFactory",
+  '&["content", "comments", "taxonomy", "outbox"]',
+]) {
+  if (!blogLib.includes(fragment)) fail(`Blog module registration is missing ${fragment}`);
+}
+
+for (const fragment of [
+  'post.status != BLOG_POST_PUBLISHED_STATUS',
+  'context.channel.as_deref()',
+  'blog_post_channel_visibility::Column::TenantId.eq(subject.tenant_id())',
+  'blog_post_channel_visibility::Column::PostId.eq(post.id)',
+  'subject.subject_revision() != current_revision',
+]) {
+  if (!provider.includes(fragment)) fail(`provider owner authorization is missing ${fragment}`);
+}
+
+for (const fragment of [
+  "| `REACTIONS-04` | `in_progress` |",
+  "Blog `post` producer",
+  "neutral-contract review",
+]) {
+  if (!reactionsPlan.includes(fragment)) fail(`Reactions plan is missing ${fragment}`);
+}
+
+console.log("Blog reaction subject provider source contract verified.");


### PR DESCRIPTION
## Summary

Continue the canonical Forum/Reactions plan with the next shared-capability gate: add Blog as the second real producer for the neutral Reactions subject SPI.

- add a Blog `post` `ReactionSubjectProviderFactory` that depends only on `rustok-reactions-api`;
- authorize only tenant-matched published posts through Blog-owned channel visibility;
- use positive `blog_posts.version` as the exact subject revision and return conflicts only after current visibility succeeds;
- keep the initial catalog bounded to single-select `like` without moving actor state or aggregates into Blog;
- register the Blog factory through `BlogModule` runtime extensions without adding the Reactions owner as a Blog dependency;
- add a machine-readable Blog provider source contract and verifier;
- add Blog+Reactions host composition test source;
- update the canonical Forum plan and Reactions plan so `REACTIONS-04` / the second-producer gate remains truthfully `in_progress` pending retained execution evidence.

## Recheck of previous Reactions work

Static re-review against current `main` found the existing Forum provider, owner atomic event/reconciliation code and the later Outbox write-once API compatible: `publish_contract_once_direct_in_tx_with_envelope_id` is still present and Reactions still writes actor state, aggregate deltas, semantic event and receipt in the owner transaction. No previous task is promoted to `done`; retained runtime evidence, lockfile/event-digest regeneration and database evidence remain maintainer-run.

## Ownership

Blog owns post existence, publication lifecycle, channel visibility and owner version. Reactions owns actor selections, aggregates, receipts, semantic events and reconciliation. The producer SPI required no API expansion for the second producer.

## Validation

Not run per maintainer instruction:

- Rust tests/checks/format/Clippy;
- Node verifiers;
- SQLite/PostgreSQL scenarios;
- lockfile or event-digest generation;
- workflows/CI.

Suggested maintainer checks are recorded in the updated Forum/Reactions plans, including `cargo test -p rustok-blog reaction_subject` and the Blog+Reactions composition profile.