### PR TITLE
feat(reactions): add neutral storefront reaction controls

### DIFF
--- a/crates/rustok-reactions-storefront/Cargo.toml
+++ b/crates/rustok-reactions-storefront/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "rustok-reactions-storefront"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Module-owned neutral storefront controls for shared Reactions"
+
+[lib]
+crate-type = ["rlib"]
+
+[features]
+default = []
+hydrate = ["leptos/hydrate"]
+ssr = ["leptos/ssr"]
+
+[dependencies]
+leptos.workspace = true
+leptos-auth.workspace = true
+rustok-graphql.workspace = true
+rustok-ui-core.workspace = true
+rustok-ui-i18n-leptos.workspace = true
+serde = { workspace = true, features = ["derive"] }
+uuid.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/rustok-reactions-storefront/README.md
+++ b/crates/rustok-reactions-storefront/README.md
@@ -1,0 +1,57 @@
+# rustok-reactions-storefront
+
+Module-owned Leptos presentation for the shared `rustok-reactions` capability.
+
+## Ownership boundary
+
+This package is deliberately producer-neutral. It does not depend on
+`rustok-reactions`, `rustok-forum`, `rustok-blog`, producer persistence, or any
+producer-private table. A producer composition surface must pass an already
+resolved exact `ReactionSubjectUiRef` containing source, kind, subject UUID and
+the positive owner revision expected by the Reactions GraphQL contract.
+
+The component never discovers or guesses a producer revision. In particular,
+Forum and Blog remain authoritative for subject existence, lifecycle,
+visibility and revision.
+
+## Transport behavior
+
+`ReactionBar` reads the canonical `reactionSnapshot` query and applies one
+`applyReaction` mutation through the existing manifest-composed GraphQL
+transport.
+
+- tenant and authenticated actor identity are never accepted as component or
+  GraphQL variables;
+- auth token and tenant slug come from the trusted UI auth context;
+- anonymous snapshots remain read-only because the owner returns no actor state;
+- each click gets a fresh UUID command identity, which the GraphQL adapter also
+  uses as the owner idempotency key;
+- successful writes trigger a canonical snapshot reload instead of maintaining a
+  shadow aggregate or actor-state model in the UI;
+- owner error text is not rendered by this package;
+- aggregate counts and revisions stay decimal strings end to end.
+
+The initial Forum and Blog producers currently expose only `like`, but the UI
+renders the bounded catalog returned by the owner and does not hard-code a
+single storage model.
+
+## Deliberate limits
+
+This source slice does not mount the package into Forum or Blog, add a standalone
+Reactions route, expose producer revisions through unrelated DTOs, add HTTP
+transport, change Reactions storage, change existing Forum votes, or enable
+Reactions by default. Producer composition is a later thin slice once each
+surface has the exact authorized subject revision available at its public UI
+boundary.
+
+## Maintainer verification
+
+No commands are executed by the implementation agent. Suggested checks:
+
+```bash
+cargo test -p rustok-reactions-storefront
+cargo check -p rustok-reactions-storefront --all-targets
+cargo check -p rustok-reactions-storefront --features hydrate --all-targets
+node scripts/verify/verify-reactions-storefront-ui.mjs
+git diff --check
+```

--- a/crates/rustok-reactions-storefront/locales/en.json
+++ b/crates/rustok-reactions-storefront/locales/en.json
@@ -1,0 +1,11 @@
+{
+  "reactions.label": "Reactions",
+  "reactions.loading": "Loading reactions…",
+  "reactions.error.load": "Reactions are temporarily unavailable.",
+  "reactions.error.update": "Could not update this reaction.",
+  "reactions.signIn": "Sign in to react.",
+  "reactions.empty": "No reactions are available for this item.",
+  "reactions.like": "Like",
+  "reactions.selected": "Selected",
+  "reactions.count": "{count}"
+}

--- a/crates/rustok-reactions-storefront/locales/ru.json
+++ b/crates/rustok-reactions-storefront/locales/ru.json
@@ -1,0 +1,11 @@
+{
+  "reactions.label": "Реакции",
+  "reactions.loading": "Загрузка реакций…",
+  "reactions.error.load": "Реакции временно недоступны.",
+  "reactions.error.update": "Не удалось обновить реакцию.",
+  "reactions.signIn": "Войдите, чтобы оставить реакцию.",
+  "reactions.empty": "Для этого элемента реакции недоступны.",
+  "reactions.like": "Нравится",
+  "reactions.selected": "Выбрано",
+  "reactions.count": "{count}"
+}

--- a/crates/rustok-reactions-storefront/src/i18n.rs
+++ b/crates/rustok-reactions-storefront/src/i18n.rs
@@ -1,0 +1,13 @@
+use rustok_ui_i18n_leptos::LeptosUiMessages;
+
+static MESSAGES: LeptosUiMessages = LeptosUiMessages::new(
+    "en",
+    &[
+        ("en", include_str!("../locales/en.json")),
+        ("ru", include_str!("../locales/ru.json")),
+    ],
+);
+
+pub fn t(locale: Option<&str>, key: &str, fallback: &str) -> String {
+    MESSAGES.t_for_locale(locale, key, fallback)
+}

--- a/crates/rustok-reactions-storefront/src/lib.rs
+++ b/crates/rustok-reactions-storefront/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod i18n;
+pub mod model;
+pub mod transport;
+pub mod ui;
+
+pub use model::{ReactionAction, ReactionSnapshotView, ReactionSubjectUiRef};
+pub use ui::ReactionBar;

--- a/crates/rustok-reactions-storefront/src/model.rs
+++ b/crates/rustok-reactions-storefront/src/model.rs
@@ -1,0 +1,142 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ReactionSubjectUiRef {
+    pub source: String,
+    pub kind: String,
+    pub subject_id: Uuid,
+    pub subject_revision: String,
+}
+
+impl ReactionSubjectUiRef {
+    pub fn new(
+        source: impl Into<String>,
+        kind: impl Into<String>,
+        subject_id: Uuid,
+        subject_revision: impl Into<String>,
+    ) -> Result<Self, String> {
+        let source = source.into();
+        let kind = kind.into();
+        let subject_revision = subject_revision.into();
+        if source.trim().is_empty() || kind.trim().is_empty() {
+            return Err("reaction subject source and kind are required".to_string());
+        }
+        let revision = subject_revision
+            .trim()
+            .parse::<u64>()
+            .map_err(|_| "reaction subject revision must be a positive u64 string".to_string())?;
+        if revision == 0 {
+            return Err("reaction subject revision must be a positive u64 string".to_string());
+        }
+        Ok(Self {
+            source,
+            kind,
+            subject_id,
+            subject_revision,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ReactionAction {
+    Add,
+    Remove,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ReactionSelectionMode {
+    Single,
+    Multiple,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+pub struct ReactionCatalogView {
+    #[serde(rename = "selectionMode")]
+    pub selection_mode: ReactionSelectionMode,
+    #[serde(rename = "maxSelected")]
+    pub max_selected: i32,
+    pub keys: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+pub struct ReactionActorStateView {
+    pub revision: String,
+    pub selected: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+pub struct ReactionAggregateView {
+    pub reaction: String,
+    pub count: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+pub struct ReactionSnapshotView {
+    pub catalog: ReactionCatalogView,
+    #[serde(rename = "actorState")]
+    pub actor_state: Option<ReactionActorStateView>,
+    pub aggregates: Vec<ReactionAggregateView>,
+}
+
+impl ReactionSnapshotView {
+    pub fn is_selected(&self, reaction: &str) -> bool {
+        self.actor_state
+            .as_ref()
+            .is_some_and(|state| state.selected.iter().any(|key| key == reaction))
+    }
+
+    pub fn aggregate_count(&self, reaction: &str) -> &str {
+        self.aggregates
+            .iter()
+            .find(|aggregate| aggregate.reaction == reaction)
+            .map(|aggregate| aggregate.count.as_str())
+            .unwrap_or("0")
+    }
+
+    pub fn can_mutate(&self) -> bool {
+        self.actor_state.is_some()
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+pub struct ReactionWriteResultView {
+    #[serde(rename = "commandId")]
+    pub command_id: Uuid,
+    pub changed: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ReactionActorStateView, ReactionSnapshotView, ReactionSubjectUiRef};
+    use uuid::Uuid;
+
+    #[test]
+    fn subject_ref_requires_positive_revision() {
+        assert!(ReactionSubjectUiRef::new("forum", "topic", Uuid::new_v4(), "1").is_ok());
+        assert!(ReactionSubjectUiRef::new("forum", "topic", Uuid::new_v4(), "0").is_err());
+        assert!(ReactionSubjectUiRef::new("forum", "topic", Uuid::new_v4(), "-1").is_err());
+    }
+
+    #[test]
+    fn actor_state_controls_mutation_availability() {
+        let mut snapshot = ReactionSnapshotView {
+            catalog: super::ReactionCatalogView {
+                selection_mode: super::ReactionSelectionMode::Single,
+                max_selected: 1,
+                keys: vec!["like".to_string()],
+            },
+            actor_state: None,
+            aggregates: vec![],
+        };
+        assert!(!snapshot.can_mutate());
+        snapshot.actor_state = Some(ReactionActorStateView {
+            revision: "1".to_string(),
+            selected: vec!["like".to_string()],
+        });
+        assert!(snapshot.can_mutate());
+        assert!(snapshot.is_selected("like"));
+    }
+}

--- a/crates/rustok-reactions-storefront/src/transport.rs
+++ b/crates/rustok-reactions-storefront/src/transport.rs
@@ -1,0 +1,237 @@
+#[cfg(target_arch = "wasm32")]
+use leptos::web_sys;
+use leptos::prelude::*;
+use leptos_auth::AuthContext;
+use rustok_graphql::{GraphqlRequest, execute as execute_graphql};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::model::{
+    ReactionAction, ReactionSnapshotView, ReactionSubjectUiRef, ReactionWriteResultView,
+};
+
+pub type ReactionStorefrontTransportError = String;
+
+const SNAPSHOT_QUERY: &str = r#"
+query ReactionStorefrontSnapshot($subject: ReactionSubjectInput!) {
+  reactionSnapshot(subject: $subject) {
+    catalog {
+      selectionMode
+      maxSelected
+      keys
+    }
+    actorState {
+      revision
+      selected
+    }
+    aggregates {
+      reaction
+      count
+    }
+  }
+}
+"#;
+
+const APPLY_MUTATION: &str = r#"
+mutation ReactionStorefrontApply($input: ApplyReactionInput!) {
+  applyReaction(input: $input) {
+    commandId
+    changed
+  }
+}
+"#;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ReactionStorefrontTransportContext {
+    pub access_token: Option<String>,
+    pub tenant_slug: Option<String>,
+}
+
+impl ReactionStorefrontTransportContext {
+    pub fn new(access_token: Option<String>, tenant_slug: Option<String>) -> Self {
+        Self {
+            access_token,
+            tenant_slug,
+        }
+    }
+}
+
+pub fn current_reaction_storefront_transport_context() -> ReactionStorefrontTransportContext {
+    let auth = use_context::<AuthContext>();
+    let access_token = auth.as_ref().and_then(AuthContext::get_token);
+    let tenant_slug = auth
+        .as_ref()
+        .and_then(AuthContext::get_tenant)
+        .or_else(|| option_env!("RUSTOK_TENANT_SLUG").map(str::to_string));
+    ReactionStorefrontTransportContext::new(access_token, tenant_slug)
+}
+
+#[derive(Debug, Serialize)]
+struct SnapshotVariables {
+    subject: SubjectInputWire,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SubjectInputWire {
+    source: String,
+    kind: String,
+    subject_id: Uuid,
+    subject_revision: String,
+}
+
+impl From<ReactionSubjectUiRef> for SubjectInputWire {
+    fn from(subject: ReactionSubjectUiRef) -> Self {
+        Self {
+            source: subject.source,
+            kind: subject.kind,
+            subject_id: subject.subject_id,
+            subject_revision: subject.subject_revision,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ApplyVariables {
+    input: ApplyInputWire,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ApplyInputWire {
+    command_id: Uuid,
+    subject: SubjectInputWire,
+    reaction: String,
+    action: ActionWire,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum ActionWire {
+    Add,
+    Remove,
+}
+
+impl From<ReactionAction> for ActionWire {
+    fn from(action: ReactionAction) -> Self {
+        match action {
+            ReactionAction::Add => Self::Add,
+            ReactionAction::Remove => Self::Remove,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SnapshotResponse {
+    #[serde(rename = "reactionSnapshot")]
+    snapshot: ReactionSnapshotView,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApplyResponse {
+    #[serde(rename = "applyReaction")]
+    result: ReactionWriteResultView,
+}
+
+pub async fn load_reaction_snapshot(
+    context: ReactionStorefrontTransportContext,
+    subject: ReactionSubjectUiRef,
+) -> Result<ReactionSnapshotView, ReactionStorefrontTransportError> {
+    let response: SnapshotResponse = execute_graphql(
+        &graphql_url(),
+        GraphqlRequest::new(
+            SNAPSHOT_QUERY,
+            Some(SnapshotVariables {
+                subject: subject.into(),
+            }),
+        ),
+        context.access_token,
+        context.tenant_slug,
+        None,
+    )
+    .await
+    .map_err(|_| "reaction snapshot is unavailable".to_string())?;
+
+    Ok(response.snapshot)
+}
+
+pub async fn apply_reaction(
+    context: ReactionStorefrontTransportContext,
+    subject: ReactionSubjectUiRef,
+    reaction: String,
+    action: ReactionAction,
+) -> Result<ReactionWriteResultView, ReactionStorefrontTransportError> {
+    let response: ApplyResponse = execute_graphql(
+        &graphql_url(),
+        GraphqlRequest::new(
+            APPLY_MUTATION,
+            Some(ApplyVariables {
+                input: ApplyInputWire {
+                    command_id: Uuid::new_v4(),
+                    subject: subject.into(),
+                    reaction,
+                    action: action.into(),
+                },
+            }),
+        ),
+        context.access_token,
+        context.tenant_slug,
+        None,
+    )
+    .await
+    .map_err(|_| "reaction update is unavailable".to_string())?;
+
+    Ok(response.result)
+}
+
+fn graphql_url() -> String {
+    if let Some(url) = option_env!("RUSTOK_GRAPHQL_URL") {
+        return url.to_string();
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        let origin = web_sys::window()
+            .and_then(|window| window.location().origin().ok())
+            .unwrap_or_else(|| "http://localhost:5150".to_string());
+        format!("{origin}/api/graphql")
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let base =
+            std::env::var("RUSTOK_API_URL").unwrap_or_else(|_| "http://localhost:5150".to_string());
+        format!("{base}/api/graphql")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{APPLY_MUTATION, SNAPSHOT_QUERY, SubjectInputWire};
+    use crate::model::ReactionSubjectUiRef;
+    use uuid::Uuid;
+
+    #[test]
+    fn graphql_inputs_never_accept_tenant_or_actor_identity() {
+        for operation in [SNAPSHOT_QUERY, APPLY_MUTATION] {
+            assert!(!operation.contains("tenantId"));
+            assert!(!operation.contains("actorId"));
+        }
+    }
+
+    #[test]
+    fn mutation_preserves_owner_command_identity_contract() {
+        assert!(APPLY_MUTATION.contains("$input: ApplyReactionInput!"));
+        assert!(APPLY_MUTATION.contains("commandId"));
+        assert!(APPLY_MUTATION.contains("applyReaction"));
+    }
+
+    #[test]
+    fn subject_wire_uses_graphql_camel_case_fields() {
+        let subject = ReactionSubjectUiRef::new("forum", "topic", Uuid::new_v4(), "42")
+            .expect("subject");
+        let value = serde_json::to_value(SubjectInputWire::from(subject)).expect("serialize");
+        assert!(value.get("subjectId").is_some());
+        assert_eq!(value.get("subjectRevision").and_then(|value| value.as_str()), Some("42"));
+        assert!(value.get("tenantId").is_none());
+        assert!(value.get("actorId").is_none());
+    }
+}

--- a/crates/rustok-reactions-storefront/src/ui/leptos.rs
+++ b/crates/rustok-reactions-storefront/src/ui/leptos.rs
@@ -1,0 +1,194 @@
+use leptos::prelude::*;
+use leptos::task::spawn_local;
+use rustok_ui_core::UiRouteContext;
+
+use crate::i18n::t;
+use crate::model::{ReactionAction, ReactionSnapshotView, ReactionSubjectUiRef};
+use crate::transport;
+
+#[component]
+pub fn ReactionBar(subject: ReactionSubjectUiRef) -> impl IntoView {
+    let locale = use_context::<UiRouteContext>().unwrap_or_default().locale;
+    let label = t(locale.as_deref(), "reactions.label", "Reactions");
+    let loading_label = t(locale.as_deref(), "reactions.loading", "Loading reactions…");
+    let load_error_label = t(
+        locale.as_deref(),
+        "reactions.error.load",
+        "Reactions are temporarily unavailable.",
+    );
+    let update_error_label = t(
+        locale.as_deref(),
+        "reactions.error.update",
+        "Could not update this reaction.",
+    );
+    let sign_in_label = t(locale.as_deref(), "reactions.signIn", "Sign in to react.");
+    let empty_label = t(
+        locale.as_deref(),
+        "reactions.empty",
+        "No reactions are available for this item.",
+    );
+    let like_label = t(locale.as_deref(), "reactions.like", "Like");
+    let selected_label = t(locale.as_deref(), "reactions.selected", "Selected");
+
+    let transport_context = transport::current_reaction_storefront_transport_context();
+    let resource_context = transport_context.clone();
+    let mutation_context = transport_context;
+    let resource_subject = subject.clone();
+    let mutation_subject = subject;
+
+    let (refresh_nonce, set_refresh_nonce) = signal(0_u64);
+    let (mutation_busy, set_mutation_busy) = signal(false);
+    let (mutation_error, set_mutation_error) = signal(false);
+
+    let snapshot_resource = Resource::new_blocking(
+        move || (resource_subject.clone(), refresh_nonce.get()),
+        move |(subject, _)| {
+            let context = resource_context.clone();
+            async move { transport::load_reaction_snapshot(context, subject).await }
+        },
+    );
+
+    let on_toggle = Callback::new(move |(reaction, action): (String, ReactionAction)| {
+        let context = mutation_context.clone();
+        let subject = mutation_subject.clone();
+        set_mutation_busy.set(true);
+        set_mutation_error.set(false);
+        spawn_local(async move {
+            match transport::apply_reaction(context, subject, reaction, action).await {
+                Ok(_) => set_refresh_nonce.update(|value| *value += 1),
+                Err(_) => set_mutation_error.set(true),
+            }
+            set_mutation_busy.set(false);
+        });
+    });
+
+    view! {
+        <section class="space-y-2" aria-label=label.clone()>
+            <div class="flex flex-wrap items-center gap-2">
+                <span class="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                    {label}
+                </span>
+                {move || mutation_error.get().then(|| view! {
+                    <span class="text-xs text-destructive" role="status" aria-live="polite">
+                        {update_error_label.clone()}
+                    </span>
+                })}
+            </div>
+
+            <Suspense fallback=move || view! {
+                <div class="inline-flex items-center rounded-full border border-border bg-muted/30 px-3 py-1.5 text-xs text-muted-foreground" role="status" aria-live="polite">
+                    {loading_label.clone()}
+                </div>
+            }>
+                {move || {
+                    let load_error_label = load_error_label.clone();
+                    let sign_in_label = sign_in_label.clone();
+                    let empty_label = empty_label.clone();
+                    let like_label = like_label.clone();
+                    let selected_label = selected_label.clone();
+                    let on_toggle = on_toggle;
+                    Suspend::new(async move {
+                        match snapshot_resource.await {
+                            Ok(snapshot) => view! {
+                                <ReactionButtons
+                                    snapshot
+                                    mutation_busy
+                                    on_toggle
+                                    sign_in_label
+                                    empty_label
+                                    like_label
+                                    selected_label
+                                />
+                            }
+                            .into_any(),
+                            Err(_) => view! {
+                                <p class="text-xs text-muted-foreground" role="status" aria-live="polite">
+                                    {load_error_label}
+                                </p>
+                            }
+                            .into_any(),
+                        }
+                    })
+                }}
+            </Suspense>
+        </section>
+    }
+}
+
+#[component]
+fn ReactionButtons(
+    snapshot: ReactionSnapshotView,
+    mutation_busy: ReadSignal<bool>,
+    on_toggle: Callback<(String, ReactionAction)>,
+    sign_in_label: String,
+    empty_label: String,
+    like_label: String,
+    selected_label: String,
+) -> impl IntoView {
+    if snapshot.catalog.keys.is_empty() {
+        return view! {
+            <p class="text-xs text-muted-foreground">{empty_label}</p>
+        }
+        .into_any();
+    }
+
+    let can_mutate = snapshot.can_mutate();
+    let controls = snapshot
+        .catalog
+        .keys
+        .iter()
+        .map(|reaction| {
+            let reaction = reaction.clone();
+            let selected = snapshot.is_selected(reaction.as_str());
+            let count = snapshot.aggregate_count(reaction.as_str()).to_string();
+            let action = if selected {
+                ReactionAction::Remove
+            } else {
+                ReactionAction::Add
+            };
+            let display_label = if reaction == "like" {
+                like_label.clone()
+            } else {
+                reaction.clone()
+            };
+            let aria_label = if selected {
+                format!("{display_label}, {count}, {selected_label}")
+            } else {
+                format!("{display_label}, {count}")
+            };
+            let reaction_for_click = reaction.clone();
+
+            view! {
+                <button
+                    type="button"
+                    class=move || format!(
+                        "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-60 {}",
+                        if selected {
+                            "border-primary/40 bg-primary/10 text-primary"
+                        } else {
+                            "border-border bg-background text-foreground hover:bg-muted/60"
+                        }
+                    )
+                    aria-pressed=selected.to_string()
+                    aria-label=aria_label
+                    aria-busy=move || mutation_busy.get().to_string()
+                    disabled=move || !can_mutate || mutation_busy.get()
+                    on:click=move |_| on_toggle.run((reaction_for_click.clone(), action))
+                >
+                    <span>{display_label}</span>
+                    <span class="tabular-nums text-xs text-muted-foreground">{count}</span>
+                </button>
+            }
+        })
+        .collect_view();
+
+    view! {
+        <div class="space-y-2">
+            <div class="flex flex-wrap gap-2">{controls}</div>
+            {(!can_mutate).then(|| view! {
+                <p class="text-xs text-muted-foreground">{sign_in_label}</p>
+            })}
+        </div>
+    }
+    .into_any()
+}

--- a/crates/rustok-reactions-storefront/src/ui/mod.rs
+++ b/crates/rustok-reactions-storefront/src/ui/mod.rs
@@ -1,0 +1,3 @@
+pub mod leptos;
+
+pub use leptos::ReactionBar;

--- a/crates/rustok-reactions/docs/implementation-plan.md
+++ b/crates/rustok-reactions/docs/implementation-plan.md
@@ -19,7 +19,7 @@ last_reviewed: 2026-08-07
 | `REACTIONS-02` | `in_progress` | Actor state, aggregate deltas, typed semantic events and completed shared Outbox receipts now share one transaction. Bounded inspect/repair reconciliation is source-ready; retain rollback, replay, concurrency and repair evidence. |
 | `REACTIONS-03` | `in_progress` | Forum topic/reply provider, optional host materialization and executable composition profile tests are source-ready. Reactions stays outside defaults; retained execution evidence remains pending. |
 | `REACTIONS-04` | `in_progress` | Blog `post` producer and Blog+Reactions composition profile are source-ready over Blog-owned publication, channel visibility and owner version. The neutral-contract review now covers Forum and Blog producers; retain Blog provider/host runtime evidence before freezing shared transport or presentation contracts. |
-| `REACTIONS-05` | `in_progress` | Manifest-composed bounded GraphQL read/write transport is source-ready over the neutral owner ports. Retain schema/runtime execution evidence and add module-owned UI; no HTTP transport or presentation contract is frozen by this slice. |
+| `REACTIONS-05` | `in_progress` | Manifest-composed bounded GraphQL read/write transport plus a producer-neutral module-owned Leptos reaction-bar foundation are source-ready. Retain schema/runtime execution evidence and compose exact producer revisions into Forum/Blog UI before freezing the presentation contract; no HTTP transport is frozen by this slice. |
 | `REACTIONS-06` | `planned` | Runtime evidence, FBA contracts, import/reconciliation and release profiles. |
 
 ## Ownership
@@ -202,10 +202,31 @@ The manifest declares query, mutation and a runtime-data factory. The factory
 fails closed unless the host has already materialized
 `Arc<ReactionSubjectRegistry>`, then constructs `ReactionsService` from the host
 DB plus that registry. `rustok-server` enables the crate `graphql` feature only
-when `mod-reactions` is selected. This slice adds no producer-table reads, no
-HTTP-specific policy and no UI. The GraphQL contract remains source-ready rather
-than frozen until maintainer schema/runtime evidence is retained alongside the
+when `mod-reactions` is selected. This slice adds no producer-table reads and no
+HTTP-specific policy. The GraphQL contract remains source-ready rather than
+frozen until maintainer schema/runtime evidence is retained alongside the
 Forum+Blog provider evidence.
+
+## Storefront presentation foundation
+
+`rustok-reactions-storefront` is the first module-owned presentation slice over
+the neutral GraphQL transport. It is a reusable `ReactionBar`, not a standalone
+route and not a producer-specific persistence adapter.
+
+The UI accepts only an exact positive revisioned subject reference consisting of
+source, kind, subject UUID and subject revision. It never discovers or guesses a
+Forum/Blog revision and therefore cannot bypass producer authorization. Tenant
+and actor identity remain outside component/GraphQL input and come from the
+trusted UI auth context. Anonymous snapshots are read-only because the owner
+returns no actor state; each authenticated click creates a fresh command UUID,
+then reloads `reactionSnapshot` after success instead of maintaining a shadow
+aggregate or actor-state projection.
+
+The package intentionally has no dependency on `rustok-reactions`,
+`rustok-forum` or `rustok-blog`. Producer UI composition remains pending until a
+public Forum/Blog boundary can supply the exact current revision without exposing
+private persistence or inventing a parallel revision model. The source guard is
+`scripts/verify/verify-reactions-storefront-ui.mjs`.
 
 ## Executable composition evidence
 
@@ -235,9 +256,10 @@ rollback on event failure, concurrent actor updates, clean/blocked/drift
 reconciliation and receipt replay. Retain Blog provider authorization and
 Blog+Reactions host composition evidence. Retain manifest-composed GraphQL schema
 and runtime evidence for anonymous/authenticated reads, human-user writes,
-tenant mismatch, idempotent replay and stale/denied subjects. Then add the
-module-owned Reactions UI over the neutral transport without moving producer
-storage or presentation ownership into Forum/Blog.
+tenant mismatch, idempotent replay and stale/denied subjects. Retain the new
+storefront package source/runtime evidence, then add thin Forum/Blog composition
+that supplies the exact authorized producer revision without moving producer
+storage or presentation ownership into Reactions.
 
 Before release, execute SQLite and PostgreSQL migrations, retain replay,
 concurrency and rollback evidence, and retain bounded repair evidence for catalog
@@ -250,11 +272,14 @@ cargo test -p rustok-events reactions
 cargo test -p rustok-reactions-api
 cargo test -p rustok-reactions
 cargo test -p rustok-reactions --features graphql graphql
+cargo test -p rustok-reactions-storefront
 cargo test -p rustok-forum reaction_subject
 cargo test -p rustok-blog reaction_subject
 cargo check -p rustok-reactions-api --all-targets
 cargo check -p rustok-reactions --all-targets
 cargo check -p rustok-reactions --features graphql --all-targets
+cargo check -p rustok-reactions-storefront --all-targets
+cargo check -p rustok-reactions-storefront --features hydrate --all-targets
 cargo check -p rustok-forum --all-targets
 cargo check -p rustok-blog --all-targets
 cargo check -p rustok-distribution --features "mod-forum mod-reactions"
@@ -272,6 +297,7 @@ node scripts/verify/verify-blog-reaction-subject-provider.mjs
 node scripts/verify/verify-reactions-host-composition.mjs
 node scripts/verify/verify-reactions-composition-profiles.mjs
 node scripts/verify/verify-reactions-events-reconciliation.mjs
+node scripts/verify/verify-reactions-storefront-ui.mjs
 git diff --check
 ```
 

--- a/scripts/verify/verify-reactions-storefront-ui.mjs
+++ b/scripts/verify/verify-reactions-storefront-ui.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function requireContains(text, needle, message) {
+  if (!text.includes(needle)) {
+    throw new Error(message);
+  }
+}
+
+function requireAbsent(text, needle, message) {
+  if (text.includes(needle)) {
+    throw new Error(message);
+  }
+}
+
+const cargo = read("crates/rustok-reactions-storefront/Cargo.toml");
+const model = read("crates/rustok-reactions-storefront/src/model.rs");
+const transport = read("crates/rustok-reactions-storefront/src/transport.rs");
+const ui = read("crates/rustok-reactions-storefront/src/ui/leptos.rs");
+
+for (const forbidden of ["rustok-forum", "rustok-blog", "rustok-reactions ="]) {
+  requireAbsent(
+    cargo,
+    forbidden,
+    `Reactions storefront must not depend on producer/private owner crate: ${forbidden}`,
+  );
+}
+
+for (const field of ["source", "kind", "subject_id", "subject_revision"]) {
+  requireContains(model, `pub ${field}`, `ReactionSubjectUiRef must expose ${field}`);
+}
+requireContains(
+  model,
+  "revision == 0",
+  "ReactionSubjectUiRef must reject non-positive revisions",
+);
+
+for (const operation of ["reactionSnapshot", "applyReaction"]) {
+  requireContains(transport, operation, `Missing neutral GraphQL operation ${operation}`);
+}
+for (const forbidden of ["tenantId", "actorId"]) {
+  requireAbsent(
+    transport,
+    forbidden,
+    `Storefront GraphQL input must not accept ${forbidden}`,
+  );
+}
+requireContains(
+  transport,
+  "command_id: Uuid::new_v4()",
+  "Each UI write must create a fresh owner command identity",
+);
+requireContains(
+  ui,
+  "set_refresh_nonce.update",
+  "Successful writes must reload canonical owner state",
+);
+requireAbsent(
+  ui,
+  "set_count",
+  "UI must not maintain a shadow aggregate count",
+);
+
+console.log("reactions storefront UI source boundary: ok");


### PR DESCRIPTION
## Summary

Continues the Forum/Reactions implementation cursor from `crates/rustok-forum/docs/implementation-plan.md` / `crates/rustok-reactions/docs/implementation-plan.md` after rechecking the merged neutral owner, Forum/Blog producer, host-composition and GraphQL transport slices.

- add `rustok-reactions-storefront`, a producer-neutral Leptos `ReactionBar` over `reactionSnapshot` / `applyReaction`
- require an exact positive revisioned subject ref instead of guessing Forum/Blog revisions in presentation code
- derive tenant/token from trusted UI auth context; never accept tenant/actor identity as GraphQL variables
- keep anonymous snapshots read-only, generate a fresh command UUID for writes, and reload canonical owner state after success
- add EN/RU presentation copy and a fail-closed source ownership guard
- update the Reactions implementation ledger without promoting runtime-evidence gates to done

## Deliberate limits

This PR does not mount reactions into Forum/Blog yet because the current Forum storefront DTO does not expose the exact owner revision required by the neutral transport. It does not add producer-private reads, an HTTP transport, a standalone Reactions route, default-enable Reactions, or reinterpret existing Forum votes.

## Verification

Not run, per maintainer request. `Cargo.lock`, event digests, Cargo/Node checks, runtime/schema evidence and database scenarios remain maintainer-run as recorded in the implementation plan.
