### PR TITLE
feat(index): add Product SalesChannel relation resolver

### DIFF
--- a/crates/rustok-distribution/src/product_index/channel_relation_resolver.rs
+++ b/crates/rustok-distribution/src/product_index/channel_relation_resolver.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::collections::BTreeSet;
 
 use rustok_product::{
@@ -458,7 +460,10 @@ fn resolve_receipt(
     verified: ProductChannelObservation,
     outcome: ProductSalesChannelIndexRelationWriteOutcome,
 ) -> ProductSalesChannelRelationResolveReceipt {
-    let changed = !matches!(outcome, ProductSalesChannelIndexRelationWriteOutcome::Unchanged(_));
+    let changed = !matches!(
+        &outcome,
+        ProductSalesChannelIndexRelationWriteOutcome::Unchanged(_)
+    );
     let relation_epoch = outcome.record().relation_epoch();
     ProductSalesChannelRelationResolveReceipt {
         tenant_id,

--- a/crates/rustok-distribution/src/product_index/channel_relation_resolver.rs
+++ b/crates/rustok-distribution/src/product_index/channel_relation_resolver.rs
@@ -1,0 +1,534 @@
+use std::collections::BTreeSet;
+
+use rustok_product::{
+    MAX_PRODUCT_SALES_CHANNEL_RELATION_CHANNELS, ProductSalesChannelIndexRelationError,
+    ProductSalesChannelIndexRelationStore, ProductSalesChannelIndexRelationWriteOutcome,
+};
+use sea_orm::{
+    AccessMode, ConnectionTrait, DatabaseConnection, DbBackend, IsolationLevel, QueryResult,
+    Statement, TransactionTrait, Value,
+};
+use serde_json::Value as JsonValue;
+use thiserror::Error;
+use uuid::Uuid;
+
+pub(crate) const MAX_PRODUCT_SALES_CHANNEL_RELATION_RESOLVE_PAGE: usize = 64;
+pub(crate) const MAX_PRODUCT_SALES_CHANNEL_VISIBILITY_SLUGS: usize = 1024;
+pub(crate) const MAX_PRODUCT_SALES_CHANNEL_STABILIZATION_ATTEMPTS: usize = 3;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProductSalesChannelRelationResolveReceipt {
+    tenant_id: Uuid,
+    product_id: Uuid,
+    relation_epoch: u64,
+    channel_ids: Vec<Uuid>,
+    unrestricted: bool,
+    changed: bool,
+}
+
+impl ProductSalesChannelRelationResolveReceipt {
+    pub(crate) fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub(crate) fn product_id(&self) -> Uuid {
+        self.product_id
+    }
+
+    pub(crate) fn relation_epoch(&self) -> u64 {
+        self.relation_epoch
+    }
+
+    pub(crate) fn channel_ids(&self) -> &[Uuid] {
+        &self.channel_ids
+    }
+
+    pub(crate) fn unrestricted(&self) -> bool {
+        self.unrestricted
+    }
+
+    pub(crate) fn changed(&self) -> bool {
+        self.changed
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProductSalesChannelRelationResolvePage {
+    receipts: Vec<ProductSalesChannelRelationResolveReceipt>,
+    gone_products: usize,
+    next_product_id: Option<Uuid>,
+}
+
+impl ProductSalesChannelRelationResolvePage {
+    pub(crate) fn receipts(&self) -> &[ProductSalesChannelRelationResolveReceipt] {
+        &self.receipts
+    }
+
+    pub(crate) fn gone_products(&self) -> usize {
+        self.gone_products
+    }
+
+    pub(crate) fn next_product_id(&self) -> Option<Uuid> {
+        self.next_product_id
+    }
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum ProductSalesChannelRelationResolverError {
+    #[error("Product-SalesChannel resolver tenant identity is invalid")]
+    InvalidTenant,
+    #[error("Product-SalesChannel resolver Product identity is invalid")]
+    InvalidProduct,
+    #[error("Product-SalesChannel resolver Product does not exist")]
+    ProductNotFound,
+    #[error("Product-SalesChannel resolver page cursor is invalid")]
+    InvalidCursor,
+    #[error("Product-SalesChannel resolver page limit is invalid")]
+    InvalidPage,
+    #[error("Product-SalesChannel resolver Product visibility is invalid")]
+    InvalidProductVisibility,
+    #[error("Product-SalesChannel resolver Product visibility contains too many slugs")]
+    TooManyVisibilitySlugs,
+    #[error("Product-SalesChannel resolver resolved too many Channel targets")]
+    TooManyResolvedChannels,
+    #[error("Product-SalesChannel resolver could not stabilize concurrent owner changes")]
+    ConcurrentChange,
+    #[error("Product-SalesChannel resolver storage is unavailable")]
+    Unavailable,
+    #[error(transparent)]
+    RelationOwner(#[from] ProductSalesChannelIndexRelationError),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ProductChannelVisibility {
+    Unrestricted,
+    Restricted(Vec<String>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProductChannelObservation {
+    channel_ids: Vec<Uuid>,
+    unrestricted: bool,
+}
+
+/// Distribution-owned resolver for Product visibility -> current SalesChannel UUID membership.
+///
+/// The resolver deliberately lives outside both owners. It reads Product visibility and Channel
+/// identity storage, then submits only the complete resolved UUID set to the Product-owned relation
+/// store. It does not write Index rows, publish events, mutate Product metadata, or own a task loop.
+#[derive(Clone)]
+pub(crate) struct ProductSalesChannelRelationResolver {
+    db: DatabaseConnection,
+}
+
+impl ProductSalesChannelRelationResolver {
+    pub(crate) fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    /// Reconcile one exact Product. The observed Product/Channel state is read under one
+    /// REPEATABLE READ snapshot, written through the Product owner, and observed again. A bounded
+    /// retry loop closes ordinary cross-owner races without claiming a durable event/watermark.
+    pub(crate) async fn reconcile_product(
+        &self,
+        tenant_id: Uuid,
+        product_id: Uuid,
+    ) -> Result<ProductSalesChannelRelationResolveReceipt, ProductSalesChannelRelationResolverError>
+    {
+        validate_scope(tenant_id, product_id)?;
+        self.ensure_postgres()?;
+        let owner = ProductSalesChannelIndexRelationStore::new(self.db.clone());
+
+        for _ in 0..MAX_PRODUCT_SALES_CHANNEL_STABILIZATION_ATTEMPTS {
+            let observed = self.observe(tenant_id, product_id).await?;
+            let outcome = owner
+                .replace(tenant_id, product_id, observed.channel_ids.iter().copied())
+                .await
+                .map_err(map_relation_error)?;
+            let verified = self.observe(tenant_id, product_id).await?;
+
+            if verified.channel_ids == observed.channel_ids {
+                return Ok(resolve_receipt(tenant_id, product_id, verified, outcome));
+            }
+        }
+
+        Err(ProductSalesChannelRelationResolverError::ConcurrentChange)
+    }
+
+    /// Bounded convergence primitive for Channel create/delete/slug/identity changes and initial
+    /// backfill. Each Product is reconciled independently, so an interrupted page can be retried
+    /// from the same cursor; already committed Products return an idempotent unchanged owner result.
+    pub(crate) async fn reconcile_tenant_page(
+        &self,
+        tenant_id: Uuid,
+        after_product_id: Option<Uuid>,
+        limit: usize,
+    ) -> Result<ProductSalesChannelRelationResolvePage, ProductSalesChannelRelationResolverError>
+    {
+        if tenant_id.is_nil() {
+            return Err(ProductSalesChannelRelationResolverError::InvalidTenant);
+        }
+        if after_product_id.is_some_and(|value| value.is_nil()) {
+            return Err(ProductSalesChannelRelationResolverError::InvalidCursor);
+        }
+        if limit == 0 || limit > MAX_PRODUCT_SALES_CHANNEL_RELATION_RESOLVE_PAGE {
+            return Err(ProductSalesChannelRelationResolverError::InvalidPage);
+        }
+        self.ensure_postgres()?;
+
+        let mut product_ids = self
+            .list_product_ids(tenant_id, after_product_id, limit + 1)
+            .await?;
+        let has_more = product_ids.len() > limit;
+        if has_more {
+            product_ids.truncate(limit);
+        }
+        let next_product_id = has_more.then(|| {
+            *product_ids
+                .last()
+                .expect("lookahead implies at least one processed Product")
+        });
+
+        let mut receipts = Vec::with_capacity(product_ids.len());
+        let mut gone_products = 0usize;
+        for product_id in product_ids {
+            match self.reconcile_product(tenant_id, product_id).await {
+                Ok(receipt) => receipts.push(receipt),
+                Err(ProductSalesChannelRelationResolverError::ProductNotFound) => {
+                    gone_products += 1;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+
+        Ok(ProductSalesChannelRelationResolvePage {
+            receipts,
+            gone_products,
+            next_product_id,
+        })
+    }
+
+    async fn observe(
+        &self,
+        tenant_id: Uuid,
+        product_id: Uuid,
+    ) -> Result<ProductChannelObservation, ProductSalesChannelRelationResolverError> {
+        let transaction = self
+            .db
+            .begin_with_config(
+                Some(IsolationLevel::RepeatableRead),
+                Some(AccessMode::ReadOnly),
+            )
+            .await
+            .map_err(|_| ProductSalesChannelRelationResolverError::Unavailable)?;
+
+        let result = async {
+            let visibility = load_product_visibility(&transaction, tenant_id, product_id).await?;
+            let channel_ids = resolve_channel_ids(&transaction, tenant_id, &visibility).await?;
+            Ok::<_, ProductSalesChannelRelationResolverError>(ProductChannelObservation {
+                unrestricted: matches!(visibility, ProductChannelVisibility::Unrestricted),
+                channel_ids,
+            })
+        }
+        .await;
+
+        match result {
+            Ok(observation) => {
+                transaction
+                    .commit()
+                    .await
+                    .map_err(|_| ProductSalesChannelRelationResolverError::Unavailable)?;
+                Ok(observation)
+            }
+            Err(error) => {
+                let _ = transaction.rollback().await;
+                Err(error)
+            }
+        }
+    }
+
+    async fn list_product_ids(
+        &self,
+        tenant_id: Uuid,
+        after_product_id: Option<Uuid>,
+        limit: usize,
+    ) -> Result<Vec<Uuid>, ProductSalesChannelRelationResolverError> {
+        let limit = i64::try_from(limit).expect("resolver page lookahead is bounded below i64::MAX");
+        let (sql, values) = match after_product_id {
+            Some(after_product_id) => (
+                "SELECT id FROM products WHERE tenant_id = $1 AND id > $2 ORDER BY id ASC LIMIT $3",
+                vec![tenant_id.into(), after_product_id.into(), limit.into()],
+            ),
+            None => (
+                "SELECT id FROM products WHERE tenant_id = $1 ORDER BY id ASC LIMIT $2",
+                vec![tenant_id.into(), limit.into()],
+            ),
+        };
+
+        self.db
+            .query_all(Statement::from_sql_and_values(DbBackend::Postgres, sql, values))
+            .await
+            .map_err(|_| ProductSalesChannelRelationResolverError::Unavailable)?
+            .into_iter()
+            .map(|row| decode_product_id(row, tenant_id))
+            .collect()
+    }
+
+    fn ensure_postgres(&self) -> Result<(), ProductSalesChannelRelationResolverError> {
+        if self.db.get_database_backend() != DbBackend::Postgres {
+            return Err(ProductSalesChannelRelationResolverError::Unavailable);
+        }
+        Ok(())
+    }
+}
+
+async fn load_product_visibility(
+    transaction: &sea_orm::DatabaseTransaction,
+    tenant_id: Uuid,
+    product_id: Uuid,
+) -> Result<ProductChannelVisibility, ProductSalesChannelRelationResolverError> {
+    let row = transaction
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT metadata FROM products WHERE tenant_id = $1 AND id = $2",
+            vec![tenant_id.into(), product_id.into()],
+        ))
+        .await
+        .map_err(|_| ProductSalesChannelRelationResolverError::Unavailable)?
+        .ok_or(ProductSalesChannelRelationResolverError::ProductNotFound)?;
+    let metadata = row
+        .try_get::<JsonValue>("", "metadata")
+        .map_err(|_| ProductSalesChannelRelationResolverError::InvalidProductVisibility)?;
+    decode_product_visibility(&metadata)
+}
+
+async fn resolve_channel_ids(
+    transaction: &sea_orm::DatabaseTransaction,
+    tenant_id: Uuid,
+    visibility: &ProductChannelVisibility,
+) -> Result<Vec<Uuid>, ProductSalesChannelRelationResolverError> {
+    let fetch_limit = i64::try_from(MAX_PRODUCT_SALES_CHANNEL_RELATION_CHANNELS + 1)
+        .expect("relation target limit is bounded below i64::MAX");
+    let (sql, values) = channel_resolution_query(tenant_id, visibility, fetch_limit);
+    let rows = transaction
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            sql,
+            values,
+        ))
+        .await
+        .map_err(|_| ProductSalesChannelRelationResolverError::Unavailable)?;
+    if rows.len() > MAX_PRODUCT_SALES_CHANNEL_RELATION_CHANNELS {
+        return Err(ProductSalesChannelRelationResolverError::TooManyResolvedChannels);
+    }
+
+    let mut channel_ids = Vec::with_capacity(rows.len());
+    for row in rows {
+        let channel_id = row
+            .try_get::<Uuid>("", "id")
+            .map_err(|_| ProductSalesChannelRelationResolverError::Unavailable)?;
+        if channel_id.is_nil()
+            || channel_ids
+                .last()
+                .is_some_and(|previous| channel_id <= *previous)
+        {
+            return Err(ProductSalesChannelRelationResolverError::Unavailable);
+        }
+        channel_ids.push(channel_id);
+    }
+    Ok(channel_ids)
+}
+
+fn channel_resolution_query(
+    tenant_id: Uuid,
+    visibility: &ProductChannelVisibility,
+    fetch_limit: i64,
+) -> (String, Vec<Value>) {
+    match visibility {
+        ProductChannelVisibility::Unrestricted => (
+            "SELECT id FROM channels WHERE tenant_id = $1 ORDER BY id ASC LIMIT $2".to_owned(),
+            vec![tenant_id.into(), fetch_limit.into()],
+        ),
+        ProductChannelVisibility::Restricted(slugs) => {
+            let mut values = Vec::<Value>::with_capacity(slugs.len() + 2);
+            values.push(tenant_id.into());
+            let mut placeholders = Vec::with_capacity(slugs.len());
+            for (offset, slug) in slugs.iter().enumerate() {
+                placeholders.push(format!("${}", offset + 2));
+                values.push(slug.clone().into());
+            }
+            let limit_parameter = slugs.len() + 2;
+            values.push(fetch_limit.into());
+            (
+                format!(
+                    "SELECT id FROM channels WHERE tenant_id = $1 AND lower(btrim(slug)) IN ({}) ORDER BY id ASC LIMIT ${limit_parameter}",
+                    placeholders.join(", ")
+                ),
+                values,
+            )
+        }
+    }
+}
+
+fn decode_product_visibility(
+    metadata: &JsonValue,
+) -> Result<ProductChannelVisibility, ProductSalesChannelRelationResolverError> {
+    let object = metadata
+        .as_object()
+        .ok_or(ProductSalesChannelRelationResolverError::InvalidProductVisibility)?;
+    let Some(channel_visibility) = object.get("channel_visibility") else {
+        return Ok(ProductChannelVisibility::Unrestricted);
+    };
+    let channel_visibility = channel_visibility
+        .as_object()
+        .ok_or(ProductSalesChannelRelationResolverError::InvalidProductVisibility)?;
+    let allowed_channel_slugs = channel_visibility
+        .get("allowed_channel_slugs")
+        .ok_or(ProductSalesChannelRelationResolverError::InvalidProductVisibility)?
+        .as_array()
+        .ok_or(ProductSalesChannelRelationResolverError::InvalidProductVisibility)?;
+    if allowed_channel_slugs.is_empty() {
+        return Ok(ProductChannelVisibility::Unrestricted);
+    }
+    if allowed_channel_slugs.len() > MAX_PRODUCT_SALES_CHANNEL_VISIBILITY_SLUGS {
+        return Err(ProductSalesChannelRelationResolverError::TooManyVisibilitySlugs);
+    }
+
+    let mut canonical = BTreeSet::new();
+    for value in allowed_channel_slugs {
+        let raw = value
+            .as_str()
+            .ok_or(ProductSalesChannelRelationResolverError::InvalidProductVisibility)?;
+        let normalized = raw.trim().to_ascii_lowercase();
+        if normalized.is_empty() || normalized != raw || !canonical.insert(normalized) {
+            return Err(ProductSalesChannelRelationResolverError::InvalidProductVisibility);
+        }
+    }
+    Ok(ProductChannelVisibility::Restricted(
+        canonical.into_iter().collect(),
+    ))
+}
+
+fn decode_product_id(
+    row: QueryResult,
+    tenant_id: Uuid,
+) -> Result<Uuid, ProductSalesChannelRelationResolverError> {
+    if tenant_id.is_nil() {
+        return Err(ProductSalesChannelRelationResolverError::InvalidTenant);
+    }
+    let product_id = row
+        .try_get::<Uuid>("", "id")
+        .map_err(|_| ProductSalesChannelRelationResolverError::Unavailable)?;
+    if product_id.is_nil() {
+        return Err(ProductSalesChannelRelationResolverError::Unavailable);
+    }
+    Ok(product_id)
+}
+
+fn validate_scope(
+    tenant_id: Uuid,
+    product_id: Uuid,
+) -> Result<(), ProductSalesChannelRelationResolverError> {
+    if tenant_id.is_nil() {
+        return Err(ProductSalesChannelRelationResolverError::InvalidTenant);
+    }
+    if product_id.is_nil() {
+        return Err(ProductSalesChannelRelationResolverError::InvalidProduct);
+    }
+    Ok(())
+}
+
+fn map_relation_error(
+    error: ProductSalesChannelIndexRelationError,
+) -> ProductSalesChannelRelationResolverError {
+    match error {
+        ProductSalesChannelIndexRelationError::ProductNotFound => {
+            ProductSalesChannelRelationResolverError::ProductNotFound
+        }
+        ProductSalesChannelIndexRelationError::TooManyChannels { .. } => {
+            ProductSalesChannelRelationResolverError::TooManyResolvedChannels
+        }
+        other => ProductSalesChannelRelationResolverError::RelationOwner(other),
+    }
+}
+
+fn resolve_receipt(
+    tenant_id: Uuid,
+    product_id: Uuid,
+    verified: ProductChannelObservation,
+    outcome: ProductSalesChannelIndexRelationWriteOutcome,
+) -> ProductSalesChannelRelationResolveReceipt {
+    let changed = !matches!(outcome, ProductSalesChannelIndexRelationWriteOutcome::Unchanged(_));
+    let relation_epoch = outcome.record().relation_epoch();
+    ProductSalesChannelRelationResolveReceipt {
+        tenant_id,
+        product_id,
+        relation_epoch,
+        channel_ids: verified.channel_ids,
+        unrestricted: verified.unrestricted,
+        changed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn absent_or_empty_allowlist_is_unrestricted() {
+        assert_eq!(
+            decode_product_visibility(&serde_json::json!({})).unwrap(),
+            ProductChannelVisibility::Unrestricted
+        );
+        assert_eq!(
+            decode_product_visibility(&serde_json::json!({
+                "channel_visibility": { "allowed_channel_slugs": [] }
+            }))
+            .unwrap(),
+            ProductChannelVisibility::Unrestricted
+        );
+    }
+
+    #[test]
+    fn restricted_allowlist_requires_canonical_owner_storage() {
+        assert_eq!(
+            decode_product_visibility(&serde_json::json!({
+                "channel_visibility": { "allowed_channel_slugs": ["mobile", "web"] }
+            }))
+            .unwrap(),
+            ProductChannelVisibility::Restricted(vec!["mobile".to_owned(), "web".to_owned()])
+        );
+        for invalid in [
+            serde_json::json!({ "channel_visibility": { "allowed_channel_slugs": "web" } }),
+            serde_json::json!({ "channel_visibility": { "allowed_channel_slugs": [" Web "] } }),
+            serde_json::json!({ "channel_visibility": { "allowed_channel_slugs": ["web", "web"] } }),
+            serde_json::json!({ "channel_visibility": { "allowed_channel_slugs": [null] } }),
+        ] {
+            assert!(matches!(
+                decode_product_visibility(&invalid),
+                Err(ProductSalesChannelRelationResolverError::InvalidProductVisibility)
+            ));
+        }
+    }
+
+    #[test]
+    fn restricted_resolution_matches_normalized_channel_slug_without_active_filter() {
+        let tenant_id = Uuid::from_u128(1);
+        let visibility = ProductChannelVisibility::Restricted(vec![
+            "mobile".to_owned(),
+            "web".to_owned(),
+        ]);
+        let (sql, values) = channel_resolution_query(tenant_id, &visibility, 1025);
+        assert!(sql.contains("lower(btrim(slug)) IN ($2, $3)"));
+        assert!(!sql.contains("is_active"));
+        assert!(sql.contains("ORDER BY id ASC LIMIT $4"));
+        assert_eq!(values.len(), 4);
+    }
+
+    #[test]
+    fn resolver_bounds_are_explicit() {
+        assert_eq!(MAX_PRODUCT_SALES_CHANNEL_RELATION_RESOLVE_PAGE, 64);
+        assert_eq!(MAX_PRODUCT_SALES_CHANNEL_VISIBILITY_SLUGS, 1024);
+        assert_eq!(MAX_PRODUCT_SALES_CHANNEL_STABILIZATION_ATTEMPTS, 3);
+    }
+}

--- a/crates/rustok-distribution/src/product_index/mod.rs
+++ b/crates/rustok-distribution/src/product_index/mod.rs
@@ -1,4 +1,5 @@
 mod absence;
+pub(crate) mod channel_relation_resolver;
 pub(crate) mod graph;
 #[cfg(test)]
 pub(crate) use absence::PRODUCT_ABSENCE_WATERMARK_FACTORY;

--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -76,6 +76,7 @@ This directory contains the detailed technical architecture documentation for `r
 - [M7 Tenant Schema Readiness Gate](./m7-schema-readiness.md)
 - [M7 Product-SalesChannel Relation Admission](./m7-product-sales-channel-relation-admission.md)
 - [M7 Product-SalesChannel Owner Ledger](../../rustok-product/docs/index-sales-channel-relation-ledger.md)
+- [M7 Product-SalesChannel Cross-owner Resolver](./m7-product-sales-channel-resolver.md)
 - [M4 Source-owned Schema Registry](./m4-source-schema-registry.md)
 - [M4 Query Runtime Composition](./m4-query-runtime-composition.md)
 - [M4 PostgreSQL Query Port Contract](./m4-postgres-query-port.md)

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-07.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-07.md
@@ -1,8 +1,9 @@
 # Current `rustok-index` implementation plan — 2026-08-07
 
-Status overlay rechecked against `main@eb75872bc37adba361c7a1eff1533b71f2a00a3f` and continued on
-`agent/index-m7-product-channel-relation-ledger-20260807`. Intervening #3127 Reactions, #3128 Pages,
-and #3129 Commerce changes do not overlap the Index/Product relation slice.
+Status overlay rechecked against branch base `main@375f7cdb80244570bb5e93405b771e0e8516b1f4` and continued on
+`agent/index-m7-product-channel-resolver-20260807`. Main advanced substantially after #3130 in Events,
+Pages, Reactions, Commerce, module-control-plane, and adjacent surfaces; those changes do not replace
+the Product-to-SalesChannel relation resolver work described here.
 
 This file supersedes the dated 2026-08-03 status overlay. `implementation-plan.md` remains the
 historical milestone/architecture plan, but several of its M5/M6/M7 checklist entries are stale
@@ -34,37 +35,49 @@ Independent source work may continue while that owner-execution gate is pending.
 - ProductVariant parent-aware tombstones plus append-only refresh ledger/source;
 - Product-owned exact refresh canonical writer;
 - durable Product locale/ProductVariant relay cursor and one-step canonical outbox publication;
-- bounded fail-closed per-tenant persisted schema readiness gate.
+- bounded fail-closed per-tenant persisted schema readiness gate;
+- Product-owned append-only Product-to-SalesChannel relation snapshot ledger with independent
+  monotonic epoch, bounded owner reads, live-Product fencing, and retained empty membership;
+- bounded cross-owner Product visibility to Channel UUID resolver in `rustok-distribution` with
+  explicit unrestricted semantics and observe/write/re-observe stabilization.
 
 ### Owner-execution gates that remain open
 
 - concrete repair PostgreSQL retained packet;
 - persisted tenant schema readiness evidence;
 - Product-locale absence/live drift evidence;
+- Product-to-SalesChannel owner/resolver PostgreSQL concurrency and restart evidence;
 - live PostgreSQL/reference query equivalence;
 - retained real PostgreSQL partition packet;
 - multi-host/restart/graceful-shutdown evidence;
 - freshness/outage/backlog/delete-recreate and tombstone-retention evidence.
 
-## Event-contract blocker
+## Event-contract admission status
 
-The Product Index typed refresh family is intentionally blocked.
+The Product Index typed refresh family remains intentionally blocked, but the reason must now be
+stated more precisely than in the previous overlay.
 
-`crates/rustok-events/contracts/event-contract-digests.json` is stale relative to the already merged
-Reactions family. PR #3122 added a maintainer-dispatched canonical digest admission workflow, but it
-did not regenerate or admit the artifact. Product Index events must not be layered on top of stale
-release digests.
+The current digest artifact changed after #3130. Therefore the older source statement that the exact
+committed digest file was definitely still the pre-Reactions stale artifact is no longer current.
+However `crates/rustok-events/docs/event-contract-digest-admission.md` still marks canonical
+maintainer execution pending, and this implementation pass did not run the generator or inspect a
+retained `verify` admission packet. Source inspection alone cannot prove that the current digest hashes
+are canonical and admitted.
 
-Required order:
+Required gate before Product Index typed events:
 
-1. maintainer runs **Event contract digest admission** in `generate_patch` mode;
-2. canonical generated digest changes are reviewed and committed in a separate PR;
-3. `verify` mode is retained against the admitted commit;
-4. only then add the Product Index typed family and regenerate the digests in that wire-contract PR;
-5. register Product/ProductVariant production routes and concrete consumers after the wire contract
-   is admitted.
+1. maintainer establishes the canonical digest status for the current reviewed `main` using the
+   existing Event contract digest admission workflow or the exact locked generator;
+2. if drift exists, review and commit only canonical generator output through the normal event-contract
+   review path;
+3. retain a successful `verify` packet on the admitted commit;
+4. then add the Product Index typed family and regenerate/admit the digest artifact in that reviewed
+   wire-contract change;
+5. only after the wire contract is admitted, register Product/ProductVariant/relation routes and
+   concrete consumers.
 
-The existing owner ledgers, canonical writer, and durable relay step do not bypass this gate.
+The Product owner ledgers, canonical writer, durable relay, relation owner storage, and cross-owner
+resolver do not bypass this gate.
 
 ## M5 incremental ingestion
 
@@ -77,9 +90,9 @@ The existing owner ledgers, canonical writer, and durable relay step do not bypa
 - [x] ProductVariant parent-aware refresh ledger/source.
 - [x] Product exact canonical refresh writer.
 - [x] Durable Product locale/ProductVariant relay cursor and bounded one-step relay.
-- [ ] Admit the canonical event-contract digest baseline.
+- [ ] Retain canonical event-contract digest admission/verify for current main.
 - [ ] Add reviewed Product Index typed event family.
-- [ ] Register Product/ProductVariant routes and concrete consumers.
+- [ ] Register Product/ProductVariant/relation routes and concrete consumers.
 - [ ] Retain crash-between-commit-and-ack/redelivery evidence for the Product route.
 
 ## M6 replay, reconciliation, diagnosis, and repair
@@ -111,67 +124,70 @@ The existing owner ledgers, canonical writer, and durable relay step do not bypa
 - [x] Product-owned append-only Product-to-SalesChannel relation snapshot ledger with a dedicated
       monotonic epoch, live-Product delete fencing, bounded owner readers, idempotent replacement, and
       retained empty membership on Product hard delete.
-- [ ] Run owner verification/evidence for persisted M7 tenant schema readiness and relation storage.
-- [ ] Compose the cross-owner Product visibility to Channel UUID resolver without adding a Channel
-      dependency or Channel SQL to `rustok-product`; explicitly preserve unrestricted Product
-      visibility rather than interpreting an empty slug allowlist as an empty UUID membership.
-- [ ] Add a new Product schema version plus relation replay source and Product-to-SalesChannel
-      `IndexLink`; do not mutate Product v2 in place.
-- [ ] Admit the Product Index typed wire family, routes, and concrete consumers after digest repair.
-- [ ] Retain Channel create/delete/slug-change, Product visibility change, retry, restart,
+- [x] Bounded cross-owner Product visibility to Channel UUID resolver with explicit unrestricted
+      mapping, current Channel identity resolution, 64-Product pages, and three-attempt stabilization.
+- [ ] Run owner verification/evidence for persisted M7 tenant schema readiness, relation storage, and
+      resolver concurrency/restart behavior.
+- [ ] Add Product v3 plus relation replay source and Product-to-SalesChannel `IndexLink`; do not
+      mutate Product v2 in place.
+- [ ] Add durable Product-visibility and Channel-identity convergence triggering or an admitted
+      relation watermark/checkpoint; the source resolver alone is not a continuous consumer.
+- [ ] Admit the Product Index typed wire family, routes, and concrete consumers after digest
+      verification/admission.
+- [ ] Retain Channel create/delete/slug/identity-change, Product visibility change, retry, restart,
       delete/recreate, out-of-order, and locale fan-out evidence for the relation.
 - [ ] Prove complete Product/Variant/Channel query parity and no source-module filtering fan-out.
 - [ ] Move one Storefront query to Index only after all readiness/equivalence/freshness gates pass.
 - [ ] Keep authoritative consumer and production partition cutover forbidden until admission.
 
-## New source slice — Product-owned SalesChannel relation ledger
+## New source slice — cross-owner Product/SalesChannel resolver
 
-The existing database-neutral relation admission contract already proved why Product and Channel
-owner revisions cannot be combined into a safe relation source version. This slice gives that
-relation its first durable owner state without violating module boundaries.
+`rustok-distribution::product_index::channel_relation_resolver` now composes the two owner views without
+moving Channel knowledge into Product.
 
-`product_sales_channel_index_relation_snapshots` stores one immutable complete resolved Channel UUID
-set per relation epoch. For one exact tenant/Product identity:
+For one exact Product it:
 
-- the first epoch is exactly `1`;
-- later membership changes advance exactly by one under an advisory transaction lock;
-- identical membership is an idempotent retry and does not append another epoch;
-- membership is canonical, strictly sorted, unique, non-nil, and bounded to 1024 Channel UUIDs;
-- writes first require the live Product row under `FOR KEY SHARE`, preventing stale post-delete
-  resolver writes;
-- retained snapshots cannot be updated or deleted;
-- Product hard delete appends an empty epoch when the current membership is non-empty;
-- `list_changes` exposes bounded tenant-scoped sequence pages;
-- `scan_current` exposes bounded current Product-order pages;
-- `load_current` exposes bounded exact Product loads.
+- reads `products.metadata.channel_visibility.allowed_channel_slugs` under one PostgreSQL
+  `REPEATABLE READ`, `READ ONLY` observation;
+- treats missing visibility or an empty allowlist as unrestricted;
+- resolves unrestricted visibility to all current tenant Channel identities;
+- resolves restricted visibility by canonical `lower(btrim(channels.slug))` membership;
+- does not filter `channels.is_active`, because runtime availability remains Channel-authority state
+  rather than Product-to-Channel identity membership;
+- bounds visibility input and resolved UUID membership at 1024 entries;
+- calls the Product-owned relation writer with only the complete UUID set;
+- re-observes the cross-owner inputs and succeeds only if the resolved membership is stable;
+- retries at most three times before returning `ConcurrentChange`.
 
-The owner store intentionally knows no Channel schema, Channel table, Index mutation, broker, or
-runtime worker. It receives only an already resolved UUID membership. This keeps `rustok-product`
-installable without `rustok-channel` and makes cross-owner resolution a separate integration concern.
+For initial backfill and Channel-side changes, `reconcile_tenant_page` enumerates at most 64 Product
+UUIDs with keyset ordering and reconciles each independently. A partial page can be retried from the
+same input cursor because owner replacement is idempotent. The page does not claim a global snapshot;
+Products created behind an already consumed cursor still require Product events or a later sweep.
 
-The resolver has one semantic trap that must remain explicit: Product currently treats an empty
-`allowed_channel_slugs` list as unrestricted visibility, whereas an empty resolved UUID membership
-means no relation targets. The next slice must define the reviewed unrestricted resolution policy and
-must not copy the Product slug list mechanically.
+This source slice deliberately does not register a host loop, event route, broker consumer, relation
+watermark, or Index schema. It is a bounded convergence primitive whose durable triggering remains
+open.
+
+Detailed contract: `m7-product-sales-channel-resolver.md`.
 
 ## Next implementation step
 
 Primary owner step: execute and admit the locked concrete-repair PostgreSQL packet.
 
-Next unblocked source step after this ledger slice: compose a bounded cross-owner resolver in
-`rustok-distribution` (or an equivalent selected-module integration layer). It should read current
-Product visibility and current tenant Channel identities, preserve the unrestricted visibility
-semantics, submit the complete resolved UUID set to the Product-owned relation store, and react to
-both Product visibility and Channel identity changes.
+Next unblocked source step after this resolver slice: add Product v3 and a relation replay adapter that
+uses `ProductSalesChannelIndexRelationStore` epochs as the relation source version, fans each current
+relation snapshot out to exact current Product locales, and materializes the SalesChannel UUID link.
+Product v2 must remain immutable.
 
-After that resolver is source complete, add a new Product Index schema version and relation replay
-adapter; Product v2 must remain immutable.
+In parallel, the maintainer must establish current event-contract digest admission before any new
+Product typed event family or durable incremental route is claimed.
 
 ## Maintainer verification for this slice
 
 ```bash
 cargo test -p rustok-product index_channel_relation --lib -- --nocapture
-cargo test -p rustok-distribution product_sales_channel_relation -- --nocapture
+cargo test -p rustok-distribution product_sales_channel -- --nocapture
+node scripts/verify/verify-index-product-channel-relation-resolver.mjs
 node scripts/verify/verify-index-product-channel-relation-ledger.mjs
 node scripts/verify/verify-index-product-channel-relation-admission.mjs
 node scripts/verify/verify-index-schema-readiness.mjs

--- a/crates/rustok-index/docs/m7-product-graph-source.md
+++ b/crates/rustok-index/docs/m7-product-graph-source.md
@@ -3,21 +3,19 @@
 Status: `source_complete_owner_execution_pending`
 
 This slice preserves the published `rustok-product::product@1` and
-`rustok-product::product_variant@1` contracts while adding versioned graph-ready
-schemas:
+`rustok-product::product_variant@1` contracts while adding versioned graph-ready schemas:
 
 - `rustok-product::product@2`
 - `rustok-product::product_variant@2`
 
-The v1 schema fingerprints, source names, cursor shapes, and replay event domains remain
-unchanged. Each schema identity continues to use exactly one stable replay source across all
-versions:
+The v1 schema fingerprints, source names, cursor shapes, and replay event domains remain unchanged.
+Each schema identity continues to use exactly one stable replay source across all versions:
 
 - `product-postgres-primary` serves Product v1 and v2;
 - `product-variant-postgres-primary` serves ProductVariant v1 and v2.
 
-This is required by `IndexSourceCatalog`, which intentionally rejects a replay-source change
-within one schema identity.
+This is required by `IndexSourceCatalog`, which intentionally rejects a replay-source change within
+one schema identity.
 
 ## Product v2
 
@@ -30,9 +28,9 @@ Product v2 remains locale-required and carries every v1 scalar plus:
 - a many-cardinality `variants` link to `product_variant@2.id`.
 
 `allowed_channel_slugs` follows the existing Storefront metadata contract at
-`metadata.channel_visibility.allowed_channel_slugs`: values are trimmed, lowercased,
-deduplicated, and sorted. An absent or empty allowlist means unrestricted visibility, represented
-as `channel_restricted = false` and an empty list. A restricted Product is represented as
+`metadata.channel_visibility.allowed_channel_slugs`: values are trimmed, lowercased, deduplicated,
+and sorted. An absent or empty allowlist means unrestricted visibility, represented as
+`channel_restricted = false` and an empty list. A restricted Product is represented as
 `channel_restricted = true` with the canonical explicit allowlist.
 
 A Storefront channel predicate can therefore preserve the current behavior without runtime
@@ -43,76 +41,89 @@ channel_restricted == false
 OR allowed_channel_slugs CONTAINS canonical_request_channel_slug
 ```
 
-Product v2 scans in stable `(product_id, locale)` order with one-row lookahead. Targeted loads
-require exact locale-bearing Product keys. `index_revision` remains only the mutation
-`source_version`; it is never part of enumeration cursor ordering.
+Product v2 scans in stable `(product_id, locale)` order with one-row lookahead. Targeted loads require
+exact locale-bearing Product keys. `index_revision` remains only the mutation `source_version`; it is
+never part of enumeration cursor ordering.
 
 ## ProductVariant v2
 
-ProductVariant v2 remains non-localized and adds only the stable `id: uuid` identity field to
-the v1 scalar set. It keeps the stable `variant_id` scan cursor and exact non-localized targeted
-loads.
+ProductVariant v2 remains non-localized and adds only the stable `id: uuid` identity field to the v1
+scalar set. It keeps the stable `variant_id` scan cursor and exact non-localized targeted loads.
 
 There is no reverse Variant-to-Product link. A locale-free Variant cannot target one exact
-locale-required Product record without inventing locale semantics, and Product translation
-changes do not advance Variant revision. Queries traverse Product v2 to its Variants instead.
+locale-required Product record without inventing locale semantics, and Product translation changes do
+not advance Variant revision. Queries traverse Product v2 to its Variants instead.
 
 ## Membership revision
 
 Product v2 records contain the complete ordered set of current Variant IDs. A Product-owned
-PostgreSQL trigger therefore advances the parent Product `index_revision` when a Variant is
-inserted, deleted, or moved between Product/tenant identities. Ordinary Variant field updates do
-not advance Product revision because they do not change Product link membership.
+PostgreSQL trigger therefore advances the parent Product `index_revision` when a Variant is inserted,
+deleted, or moved between Product/tenant identities. Ordinary Variant field updates do not advance
+Product revision because they do not change Product link membership.
 
-The existing Product row trigger still enforces exactly `OLD.index_revision + 1` and fails on
-revision exhaustion.
+The existing Product row trigger still enforces exactly `OLD.index_revision + 1` and fails on revision
+exhaustion.
 
 ## Durable hard-delete continuation
 
-The follow-up [Product tombstone replay contract](m7-product-tombstone-source.md) retains exact
-Product translation and ProductVariant identities after physical deletion. The same two stable
-sources now emit versioned `IndexMutation::Delete` values without changing any v1/v2 schema
-fingerprint, source name, cursor shape, or event domain.
+The follow-up [Product tombstone replay contract](m7-product-tombstone-source.md) retains exact Product
+translation and ProductVariant identities after physical deletion. The same two stable sources now
+emit versioned `IndexMutation::Delete` values without changing any v1/v2 schema fingerprint, source
+name, cursor shape, or event domain.
 
-## Why there is no Product-to-SalesChannel link yet
+## Why Product v2 still has no Product-to-SalesChannel link
 
-The current owner-authoritative visibility model stores Channel slugs in Product metadata, not
-durable Channel UUID relations. Resolving those slugs to `channels.id` inside the Product source
-would make Product link targets change when a Channel is created, deleted, or renamed without
-advancing Product `index_revision`. That would violate monotonic mutation ordering and could
-leave stale links.
+The original blocker was that Product metadata owned Channel slugs while Channel identity changes
+could alter resolved UUID targets without advancing `products.index_revision`. Resolving `channels.id`
+inside the Product v2 source would therefore violate monotonic mutation ordering.
 
-This slice therefore publishes exact filterable channel-visibility scalars but no
-Product/ProductVariant-to-SalesChannel `IndexLink`. A future link requires a durable owner
-relation or another explicit cross-owner revision/tombstone contract. The source does not query
-the `channels` table and does not depend on `rustok-channel`.
+That owner-version gap is now source-complete outside Product v2:
+
+- `rustok-product` owns an append-only Product-to-SalesChannel relation ledger with a dedicated
+  monotonic `relation_epoch` independent from Product and Channel revisions;
+- `rustok-distribution` owns a bounded cross-owner resolver that preserves unrestricted Product
+  visibility, resolves current Channel UUID membership, writes through the Product owner, and
+  re-observes membership with bounded stabilization.
+
+Those additions do **not** permit Product v2 to be mutated in place. Its published schema fingerprint
+and replay source contract remain immutable. A real Product-to-SalesChannel `IndexLink` must therefore
+be introduced in Product v3 (or the next reviewed Product schema version) with a relation replay
+adapter that uses the owner `relation_epoch` as the relation source version.
+
+The Product v1/v2 source continues to avoid `channels` SQL and has no `rustok-channel` dependency.
+
+Detailed relation contracts:
+
+- [Product-to-SalesChannel relation admission](m7-product-sales-channel-relation-admission.md)
+- [Cross-owner resolver](m7-product-sales-channel-resolver.md)
+- [Product owner ledger](../../rustok-product/docs/index-sales-channel-relation-ledger.md)
 
 ## Ownership
 
 `rustok-product` owns Product/Variant storage, normalized metadata, monotonic revisions,
-Variant-membership revision, and retained hard-delete identities. It still has no dependency on
-`rustok-index`.
+Variant-membership revision, retained hard-delete identities, and the durable relation epoch/storage.
+It still has no dependency on `rustok-index` or `rustok-channel`.
 
-`rustok-distribution` owns the selected generic conversion adapter because it composes Product
-and Index contracts. Index core and server remain Product-agnostic.
+`rustok-distribution` owns selected cross-module composition: Product/Variant conversion and the
+Product-visibility-to-Channel-identity resolver. Index core and server remain Product-agnostic.
 
 ## Explicitly open
 
-- incremental event ingestion and broker acknowledgement;
+- incremental Product/relation event ingestion and broker acknowledgement;
 - tombstone retention/purge admission after consumer checkpoints are proven newer;
-- a durable Product/ProductVariant-to-SalesChannel relation and revision contract;
-- persisted per-tenant v2 schema application;
-- repeatable-read replay snapshot and concurrent membership reconciliation semantics;
+- Product v3 plus Product-to-SalesChannel relation replay/materialization;
+- durable Product/Channel convergence triggering or an admitted relation watermark/checkpoint;
+- persisted per-tenant schema application/readiness evidence;
+- retained cross-owner resolver concurrency/restart/delete-recreate evidence;
 - authoritative Storefront query cutover;
-- retained PostgreSQL replay, hard-delete/recreate, freshness, restart, drift, and equivalence
-  evidence;
+- retained PostgreSQL replay, freshness, drift, and equivalence evidence;
 - retry/backoff/dead-letter scheduling and graceful host task ownership.
 
-Runtime schema/source presence does not establish persisted schema readiness. Consumers must not
-query Product v2 authoritatively until exact tenant schemas are applied and replay/evidence
+Runtime schema/source presence does not establish persisted schema readiness. Consumers must not query
+Product graph schemas authoritatively until exact tenant schemas are applied and replay/evidence
 admission is complete.
 
 ## Validation ownership
 
-Formatting, Cargo checks/tests, JavaScript guards, PostgreSQL execution, and CI are
-maintainer-run. The implementation agent did not execute them.
+Formatting, Cargo checks/tests, JavaScript guards, PostgreSQL execution, and CI are maintainer-run.
+The implementation agent did not execute them.

--- a/crates/rustok-index/docs/m7-product-sales-channel-relation-admission.md
+++ b/crates/rustok-index/docs/m7-product-sales-channel-relation-admission.md
@@ -1,11 +1,11 @@
 # Product to SalesChannel relation admission
 
-Status: `owner_storage_source_complete_cross_owner_resolution_and_index_wiring_pending`
+Status: `resolver_source_complete_index_wiring_and_runtime_evidence_pending`
 
-Rechecked on 2026-08-07 against the source-complete Product/Variant/Channel graph and the admitted
-pre-persistence relation contract. The Product-owned durable relation snapshot ledger now closes the
-storage/epoch boundary, but cross-owner resolution, a new Product schema version, event wiring, and
-retained PostgreSQL evidence remain open.
+Rechecked on 2026-08-07 against the Product-owned durable relation ledger and the selected-module
+Product/Channel composition boundary. The cross-owner resolver source is complete; a new Product Index
+schema version, replay/materialization wiring, durable incremental triggers, and retained PostgreSQL
+evidence remain open.
 
 ## Problem
 
@@ -40,15 +40,12 @@ separate deterministic Index event identity for each locale.
 
 ## Product-owned durable owner storage
 
-`rustok-product` now owns `product_sales_channel_index_relation_snapshots` and
+`rustok-product` owns `product_sales_channel_index_relation_snapshots` and
 `ProductSalesChannelIndexRelationStore`.
 
 The owner storage is append-only and independent from both owner revision columns. For each exact
-`(tenant_id, product_id)` identity it persists:
-
-- one positive sequence number; change consumption remains tenant-scoped;
-- a positive contiguous relation epoch beginning at `1`;
-- the complete resolved Channel UUID set as canonical bounded JSON.
+`(tenant_id, product_id)` identity it persists one positive sequence number, one positive contiguous
+relation epoch beginning at `1`, and the complete resolved Channel UUID set as canonical bounded JSON.
 
 The writer first requires the exact live Product row under `FOR KEY SHARE`, then serializes one
 relation identity with a PostgreSQL advisory transaction lock. Equal membership is returned as an
@@ -62,87 +59,103 @@ post-delete non-empty relation cannot be appended after the retained empty epoch
 The owner API also provides bounded append-only change pages, current-state scans in Product UUID
 order, and exact current targeted loads. It does not read Channel tables or import Channel types.
 
-A Product hard delete appends an empty membership epoch when the retained current relation is
-non-empty. The relation table intentionally has no Product or Channel foreign key, so physical owner
-row deletion cannot erase replay/reconciliation evidence.
-
 Detailed owner contract: `crates/rustok-product/docs/index-sales-channel-relation-ledger.md`.
 
-## What the storage slice closes
+## Cross-owner resolver
 
-The production admission list is now split more precisely:
+`rustok-distribution::product_index::channel_relation_resolver` now owns the source-level resolution
+boundary. It reads Product metadata and current tenant Channel identities, then calls only
+`ProductSalesChannelIndexRelationStore::replace` with the complete resolved UUID set.
+
+The reviewed policy is explicit:
+
+- missing Product `channel_visibility` or an empty canonical `allowed_channel_slugs` array means
+  unrestricted visibility;
+- unrestricted visibility resolves to every current Channel identity for the tenant;
+- a non-empty allowlist resolves Channel UUIDs by canonical `lower(btrim(slug))` membership;
+- malformed or non-canonical Product visibility fails closed;
+- Channel `is_active` does not alter relation membership; runtime availability remains Channel-owned;
+- Channel create/delete/slug/identity changes can alter the relation and require convergence.
+
+The resolver is bounded to 1024 visibility slugs, 1024 resolved Channel UUIDs, 64 Products per tenant
+page, and three exact Product stabilization attempts.
+
+## Consistency boundary
+
+The resolver deliberately does not claim one atomic Product+Channel transaction. For each exact
+Product it performs bounded optimistic stabilization:
+
+1. observe Product visibility plus Channel membership in one PostgreSQL `REPEATABLE READ`, `READ ONLY`
+   snapshot;
+2. call the Product-owned relation writer;
+3. observe the same relation inputs again in a fresh read-only repeatable-read snapshot;
+4. return only when the resolved UUID set is stable;
+5. retry at most three times, then fail with `ConcurrentChange`.
+
+This closes ordinary source-level races without inventing an unowned cross-owner lock. It remains a
+convergence primitive, not a durable watermark, broker checkpoint, event acknowledgement, or proof
+that every future owner mutation will trigger reconciliation.
+
+The tenant page is likewise bounded and idempotent rather than atomic. If earlier Products commit and
+a later Product fails, the page can be retried from the same input cursor because already converged
+memberships return `Unchanged`.
+
+Detailed resolver contract: `m7-product-sales-channel-resolver.md`.
+
+## Production admission status
 
 1. **Durable epoch storage for exact tenant/Product identity:** source complete.
-2. **Strict increment when resolved membership changes:** source complete inside the Product-owned
-   relation writer; discovering Channel-side changes remains pending.
-3. **Atomic membership + epoch commit:** source complete.
+2. **Strict increment when resolved membership changes:** source complete in the Product owner;
+   Product/Channel membership discovery is source complete in the cross-owner resolver.
+3. **Atomic membership + epoch commit:** source complete in the Product owner.
 4. **Bounded current-state scan and targeted load:** source complete.
 5. **Retained empty-membership state:** source complete for explicit replacement and Product hard
-   delete; Channel-driven removal still requires the resolver.
-6. **Stable event/source-version reuse:** the relation epoch contract is source complete; conversion
-   to locale-specific Index mutations remains unwired.
-7. **Relation event descriptor, route, broker adapter, commit-before-ack worker:** pending.
+   delete; Channel-driven removal converges through resolver source, but durable triggering is pending.
+6. **Stable event/source-version reuse:** relation epoch semantics are source complete; locale-specific
+   Index conversion remains pending.
+7. **Relation event descriptor, owner delivery route, broker adapter, commit-before-ack worker:**
+   pending.
 8. **PostgreSQL concurrency/restart/retry/delete-recreate/out-of-order/locale evidence:** pending.
-
-## Cross-owner resolver requirement
-
-The next source slice must live in a layer that can observe both selected Product and Channel modules.
-It must:
-
-1. read current canonical `metadata.channel_visibility.allowed_channel_slugs` from Product;
-2. resolve the current Channel UUID membership for the same tenant according to the reviewed
-   visibility semantics;
-3. submit the complete resolved UUID set to `ProductSalesChannelIndexRelationStore::replace`;
-4. re-run on Product visibility changes and on Channel create/delete/slug movement that can change a
-   Product's resolved set;
-5. preserve bounded work and idempotent retry behavior;
-6. never move Channel SQL or a `rustok-channel` dependency into `rustok-product`.
-
-A critical semantic boundary remains open for explicit review: the Product contract treats an empty
-`allowed_channel_slugs` list as **unrestricted**, while an empty resolved relation UUID set means
-**no Index link targets**. The resolver must not copy an empty slug allowlist to an empty relation
-snapshot. It must define and preserve how unrestricted Product visibility resolves against the
-current tenant Channel universe.
-
-The resolver may be eventually triggered by owner events, but the relation owner commit itself must
-remain atomic and monotonic.
 
 ## Index schema and wiring requirement
 
 Product v2 cannot be modified in place because its schema fingerprint is already published. The real
-Product-to-SalesChannel `IndexLink` therefore requires a new Product schema version after the owner
-relation source is composed.
+Product-to-SalesChannel `IndexLink` therefore requires Product v3 (or the next reviewed Product schema
+version) plus a relation replay adapter.
 
-That future schema/source slice must fan one relation epoch out to the exact current Product locales,
-use the admitted relation event identity, and materialize SalesChannel UUID targets without querying
-Channel storage from the Product source.
+That future source must consume the Product-owned relation epoch, fan it out to exact current Product
+locales, use the admitted relation event identity, and materialize SalesChannel UUID targets without
+moving Channel SQL into `rustok-product`.
 
-The Product typed incremental event family remains separately blocked by canonical event-contract
-digest admission. This relation owner storage does not bypass that gate.
+Incremental typed event wiring remains separately gated on canonical event-contract digest admission.
+The committed digest artifact changed on `main` after #3130, so the older statement that the exact
+artifact was known stale is no longer source-current. However the maintainer admission document still
+marks canonical generator/verify execution pending; source inspection alone therefore does not prove
+the current hashes are admitted. Product typed events remain blocked until that verification is
+retained.
 
 ## Explicit non-claims
 
 This slice does not yet add:
 
-- the cross-owner Product visibility to Channel UUID resolver;
-- the reviewed unrestricted-visibility resolution policy;
-- Channel create/delete/slug-change integration;
-- initial backfill for existing Products;
-- a new Product Index schema version or Product-to-SalesChannel `IndexLink`;
-- a relation replay source in `rustok-distribution`;
-- a relation mutation-event route, broker consumer, retry policy, or acknowledgement;
+- durable Product/Channel event triggers or a relation watermark/checkpoint;
+- a host-owned resolver loop, lease, retry scheduler, broker cursor, or acknowledgement;
+- one atomic cross-owner Product+Channel snapshot;
+- Product v3 or a Product-to-SalesChannel `IndexLink`;
+- a relation replay source or locale fan-out materializer;
 - retained PostgreSQL runtime evidence;
 - Storefront or production partition cutover.
 
-`allowed_channel_slugs` remains Product-owned desired visibility metadata. The new relation ledger is
-resolved relation owner state only after a resolver writes it; neither one alone proves production
-cutover readiness.
+`allowed_channel_slugs` remains Product-owned desired visibility metadata. The relation ledger is the
+resolved relation owner state, while the distribution resolver is only the current convergence
+mechanism. None of these source-complete pieces alone prove production cutover readiness.
 
 ## Maintainer validation
 
 ```bash
 cargo test -p rustok-product index_channel_relation --lib -- --nocapture
-cargo test -p rustok-distribution product_sales_channel_relation -- --nocapture
+cargo test -p rustok-distribution product_sales_channel -- --nocapture
+node scripts/verify/verify-index-product-channel-relation-resolver.mjs
 node scripts/verify/verify-index-product-channel-relation-ledger.mjs
 node scripts/verify/verify-index-product-channel-relation-admission.mjs
 cargo check -p rustok-product --all-targets

--- a/crates/rustok-index/docs/m7-product-sales-channel-resolver.md
+++ b/crates/rustok-index/docs/m7-product-sales-channel-resolver.md
@@ -1,0 +1,125 @@
+# M7 Product-to-SalesChannel cross-owner resolver
+
+Status: `source_complete_event_wiring_and_atomic_snapshot_evidence_pending`.
+
+## Purpose
+
+The Product owner now persists a dedicated monotonic Product-to-SalesChannel relation epoch, but the
+owner intentionally does not read Channel storage. `rustok-distribution` is the selected-module
+composition layer that already sees both owners, so it is the correct boundary for resolving Product
+visibility metadata into the current tenant SalesChannel UUID set.
+
+`ProductSalesChannelRelationResolver` reads current Product visibility and current Channel identities,
+then submits only the complete resolved UUID membership to
+`ProductSalesChannelIndexRelationStore::replace`. It does not write Index rows, publish events, mutate
+Product metadata, or own a background loop.
+
+## Visibility policy
+
+The resolver preserves the already published Product/Storefront semantics:
+
+- missing `metadata.channel_visibility` is unrestricted visibility;
+- an empty canonical `allowed_channel_slugs` array is unrestricted visibility;
+- unrestricted visibility resolves to every current Channel identity for the tenant;
+- a non-empty allowlist resolves to current Channel UUIDs whose `lower(btrim(slug))` matches one of
+  the canonical Product slugs;
+- malformed, non-canonical, duplicate, or non-string Product visibility fails closed;
+- a deleted Channel is absent from the next observation and therefore leaves the resolved set;
+- an unresolved restricted slug simply contributes no target until a matching Channel exists.
+
+The resolver deliberately does **not** filter `channels.is_active`. Relation membership represents
+identity resolution, while Channel runtime availability remains owned by the trusted Channel authority.
+Toggling active state alone therefore does not create a new relation epoch. Channel create/delete,
+slug movement, or identity movement can change membership and must converge through this resolver.
+
+This distinction also closes the semantic trap from the owner-ledger slice: an empty Product slug
+allowlist does not become an empty relation snapshot. Unrestricted Product visibility resolves against
+the current tenant Channel universe.
+
+## Bounded contract
+
+The source contract is bounded at every externally variable collection:
+
+- at most 1024 canonical Product visibility slugs;
+- at most 1024 resolved Channel UUID targets, matching the Product-owned relation limit;
+- at most 64 Products in one tenant convergence page;
+- at most three exact Product stabilization attempts per reconciliation call.
+
+Tenant sweep enumeration uses stable Product UUID keyset ordering with one-row lookahead. Exact
+Product reconciliation can be used independently for Product-owned visibility changes.
+
+## Cross-owner consistency boundary
+
+There is no single database transaction owned by both Product and Channel domains in this slice.
+Pretending otherwise would overstate the consistency contract.
+
+For one exact Product the resolver instead performs bounded optimistic stabilization:
+
+1. open one PostgreSQL `REPEATABLE READ`, `READ ONLY` transaction;
+2. observe the exact Product visibility and its resolved current tenant Channel UUID set in that one
+   snapshot;
+3. commit the read-only observation;
+4. call the Product-owned relation writer, which atomically advances membership plus relation epoch;
+5. open a fresh `REPEATABLE READ`, `READ ONLY` observation;
+6. if the resolved UUID set is unchanged, return the owner relation epoch;
+7. otherwise repeat the sequence, at most three times, then fail with `ConcurrentChange`.
+
+The Product-owned writer still fences Product hard deletion with its live-row `FOR KEY SHARE` lock.
+If the Product disappears between enumeration, observation, or owner write, exact reconciliation
+returns `ProductNotFound` and a tenant page records the row as gone rather than recreating relation
+state.
+
+This is a convergence primitive, not an atomic cross-owner snapshot, durable watermark, checkpoint,
+or event acknowledgement. A continuously changing owner set can exhaust the bounded attempts and
+must be retried by a future caller.
+
+## Tenant convergence page
+
+`reconcile_tenant_page` provides a bounded initial-backfill and Channel-change convergence primitive.
+It enumerates at most 64 current tenant Products in UUID order and reconciles each exact Product
+independently.
+
+A page is intentionally not all-or-nothing. If a later Product fails after earlier owner epochs have
+committed, rerunning from the same input cursor is safe: already converged Products return the owner
+store's idempotent `Unchanged` result. Products created behind an already passed cursor are not
+claimed as covered forever; durable Product events or a later tenant sweep remain required.
+
+## Module boundary
+
+Channel SQL exists only in `rustok-distribution`, alongside the already existing SalesChannel Index
+source. `rustok-product` remains independent from `rustok-channel` and `rustok-index` and still accepts
+only resolved UUID membership.
+
+The resolver does not import Product Index schema types and does not add a Product-to-SalesChannel
+`IndexLink`. Product v2 remains immutable.
+
+## Still open
+
+This slice does not yet provide:
+
+- durable Product-visibility and Channel-identity event triggers or a relation watermark/checkpoint;
+- a host worker, retry schedule, lease, broker cursor, or acknowledgement;
+- one atomic Product+Channel cross-owner database snapshot;
+- a new Product Index schema version;
+- a relation replay source or locale fan-out adapter;
+- Product-to-SalesChannel `IndexLink` materialization;
+- retained PostgreSQL concurrency/restart/delete-recreate/out-of-order evidence;
+- Storefront or production Index cutover.
+
+The next unblocked source slice is a new Product Index schema version plus a relation replay adapter
+that consumes the Product-owned relation epoch and fans it out to exact current Product locales.
+Incremental typed event wiring remains separately gated on reviewed event-contract digest admission.
+
+## Maintainer verification
+
+```bash
+cargo test -p rustok-distribution product_sales_channel -- --nocapture
+node scripts/verify/verify-index-product-channel-relation-resolver.mjs
+node scripts/verify/verify-index-product-channel-relation-ledger.mjs
+node scripts/verify/verify-index-product-channel-relation-admission.mjs
+cargo check -p rustok-distribution --all-targets
+git diff --check
+```
+
+No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, or CI
+were executed by the implementation agent.

--- a/crates/rustok-product/README.md
+++ b/crates/rustok-product/README.md
@@ -47,6 +47,11 @@
   removed locale, and ProductVariant deletion retains its non-localized key.
   Recreated identities must receive an `index_revision` strictly above the
   retained delete before the tombstone is cleared.
+- Own append-only `product_sales_channel_index_relation_snapshots` with a
+  dedicated monotonic relation epoch, bounded current/change readers,
+  idempotent complete-membership replacement, live-Product delete fencing, and
+  retained empty membership after Product hard delete. Product still does not
+  resolve Channel slugs or depend on `rustok-channel`/`rustok-index`.
 - Publish only a neutral `ProductRuntimeSelected` marker for selected
   cross-module composition. The Product crate does not depend on `rustok-index`
   and does not construct generic Index mutations.
@@ -59,6 +64,12 @@
   identity-ready schemas. Product v2 exposes normalized channel visibility
   scalars and a many-cardinality Product-to-ProductVariant link; ProductVariant
   v2 adds its stable UUID identity field.
+- The selected distribution composition now also resolves Product channel
+  visibility to current tenant Channel UUID membership and writes only through
+  the Product-owned relation store. Unrestricted Product visibility resolves
+  against the current tenant Channel identity universe; Channel runtime active
+  state remains Channel-owned. This resolver is bounded and convergent, not an
+  atomic cross-owner snapshot or continuous event consumer.
 - The selected bridge emits `IndexMutation::Upsert` for live owner rows and
   `IndexMutation::Delete` for retained hard-delete identities without changing
   schema fingerprints, source names, cursor shapes, or replay event domains.
@@ -68,8 +79,9 @@
   does not establish a repeatable-read owner snapshot or close the final-pass
   concurrent-write window.
   Incremental event ingestion, snapshot/watermark admission, tombstone
-  retention/purge admission, durable Product/ProductVariant-to-SalesChannel
-  relations, and authoritative Index consumer cutover remain later slices.
+  retention/purge admission, durable relation convergence triggering, Product
+  v3 Product-to-SalesChannel materialization, and authoritative Index consumer
+  cutover remain later slices.
 - Effective visibility is resolved as tri-state overrides with precedence
   `attribute defaults < schema/category overrides < channel settings`.
 - Virtual categories use a validated, bounded V1 rule contract over product
@@ -144,7 +156,8 @@
   module-owned.
 - Depends on `rustok-outbox` and `rustok-events` for transactional event publishing.
 - Is consumed by the selected distribution bridge for generic Index schema/source
-  composition; Index core and server replay composition remain Product-agnostic.
+  composition and Product-to-Channel relation resolution; Index core and server
+  replay composition remain Product-agnostic.
 - Used by `rustok-commerce` as the umbrella/root module of the ecommerce family.
 - Consumed by `apps/admin` through manifest-driven module UI composition.
 - Consumed by `apps/storefront` through manifest-driven module UI composition.
@@ -161,6 +174,7 @@
 - `ProductRuntimeSelected`
 - `CatalogService`
 - `ProductCatalogReadPort`
+- `ProductSalesChannelIndexRelationStore`
 - `services::catalog_schema::resolve_effective_product_form`
 - `ProductCatalogSchemaService`
 - `admin::ProductAdmin`
@@ -170,5 +184,6 @@ See also `docs/README.md`, the Index
 [M7 Product source contract](../rustok-index/docs/m7-product-source.md),
 [M7 ProductVariant source contract](../rustok-index/docs/m7-product-variant-source.md),
 [M7 versioned Product graph contract](../rustok-index/docs/m7-product-graph-source.md),
+[M7 Product-SalesChannel resolver contract](../rustok-index/docs/m7-product-sales-channel-resolver.md),
 [M7 Product tombstone replay contract](../rustok-index/docs/m7-product-tombstone-source.md), and
 [M7 bounded Product reconciliation contract](../rustok-index/docs/m7-product-reconciliation.md).

--- a/crates/rustok-product/docs/index-sales-channel-relation-ledger.md
+++ b/crates/rustok-product/docs/index-sales-channel-relation-ledger.md
@@ -1,13 +1,12 @@
 # Product-SalesChannel Index relation owner ledger
 
-Status: `owner_storage_source_complete_cross_owner_resolution_and_index_wiring_pending`.
+Status: `owner_storage_source_complete_resolver_composed_index_wiring_pending`.
 
 ## Purpose
 
-The existing M7 admission contract requires a relation version that advances independently from both
-`products.index_revision` and `channels.index_revision`. Product metadata still expresses desired
-visibility with canonical Channel slugs, while the future Index relation must target stable Channel
-UUIDs.
+The M7 admission contract requires a relation version that advances independently from both
+`products.index_revision` and `channels.index_revision`. Product metadata expresses desired visibility
+with canonical Channel slugs, while the future Index relation targets stable Channel UUIDs.
 
 `product_sales_channel_index_relation_snapshots` is the Product-owned durable boundary for that
 resolved UUID membership. It deliberately does not resolve slugs, read Channel tables, construct an
@@ -27,10 +26,9 @@ string, strictly sorted and unique. An empty array is valid and means that the r
 no Channel targets.
 
 An empty resolved UUID membership is not the same thing as an empty Product
-`allowed_channel_slugs` list. The existing Product visibility contract treats an empty slug allowlist
-as unrestricted visibility. A future cross-owner resolver must explicitly translate that visibility
-semantics into the current resolved Channel UUID set rather than copying an empty slug list into an
-empty relation snapshot.
+`allowed_channel_slugs` list. The Product visibility contract treats an empty slug allowlist as
+unrestricted visibility. The distribution-owned resolver now preserves that distinction explicitly by
+resolving unrestricted Products against the current tenant Channel identity universe.
 
 The first persisted epoch is exactly `1`. A later snapshot must be exactly the previous epoch plus
 one and must change membership. Equal membership is an idempotent retry and is not appended.
@@ -64,8 +62,8 @@ The same owner boundary exposes:
 - `scan_current` — current state for at most 256 Products in stable Product UUID order;
 - `load_current` — exact current state for at most 64 Product UUIDs.
 
-These readers expose Product-owned relation facts only. A future distribution adapter remains
-responsible for locale fan-out and conversion to the admitted generic Index relation contract.
+These readers expose Product-owned relation facts only. The distribution layer remains responsible
+for cross-owner resolution, locale fan-out, and eventual conversion to the Index relation contract.
 
 ## Retained empty membership
 
@@ -80,6 +78,19 @@ non-empty relation snapshot.
 The snapshot table has no foreign key to Product or Channel rows. This is intentional: Product and
 Channel physical deletion must not erase the relation evidence needed for replay and reconciliation.
 
+## Cross-owner composition
+
+`rustok-distribution::product_index::channel_relation_resolver` now reads Product visibility plus
+current tenant Channel identities and submits only the complete resolved UUID set to this owner API.
+The Product crate remains unaware of Channel tables and Channel types.
+
+The resolver uses bounded observe/write/re-observe stabilization. That composition does not change the
+owner transaction contract and does not turn Product storage into an atomic cross-owner snapshot.
+Durable event triggers, watermarks/checkpoints, and runtime evidence remain separate admission work.
+
+Detailed resolver contract:
+`crates/rustok-index/docs/m7-product-sales-channel-resolver.md`.
+
 ## Module boundary
 
 `rustok-product` still has no dependency on `rustok-index` or `rustok-channel`. The owner store accepts
@@ -91,12 +102,9 @@ place that owns monotonic relation epochs.
 
 ## Still open
 
-This slice does not yet:
+This owner slice plus resolver composition still do not:
 
-- resolve `metadata.channel_visibility.allowed_channel_slugs` to Channel UUIDs;
-- define the reviewed unrestricted-visibility-to-current-Channel resolution policy;
-- react to Channel create/delete/slug movement or Product visibility changes;
-- initialize relation state for existing Products;
+- register durable Product/Channel relation triggers or checkpoints;
 - register a relation replay source or mutation-event route;
 - add the Product-to-SalesChannel `IndexLink` (that requires a new Product schema version; v2 cannot
   be mutated in place);
@@ -105,18 +113,19 @@ This slice does not yet:
   evidence;
 - authorize Storefront or production Index cutover.
 
-The next source slice should compose a cross-owner resolver in a layer that already sees both selected
-Product and Channel modules. That resolver must re-read current Product visibility plus Channel
-identity, preserve the existing unrestricted visibility semantics explicitly, then call this
-Product-owned store; it must not move Channel SQL into `rustok-product`.
+The next unblocked source slice is a new Product Index schema version plus relation replay adapter in
+the distribution/Index integration boundary. It must consume this owner epoch rather than deriving a
+relation version from Product or Channel revisions.
 
 ## Maintainer verification
 
 ```bash
 cargo test -p rustok-product index_channel_relation --lib -- --nocapture
+cargo test -p rustok-distribution product_sales_channel -- --nocapture
+node scripts/verify/verify-index-product-channel-relation-resolver.mjs
 node scripts/verify/verify-index-product-channel-relation-ledger.mjs
-node scripts/verify/verify-index-product-channel-relation-admission.mjs
 cargo check -p rustok-product --all-targets
+cargo check -p rustok-distribution --all-targets
 git diff --check
 ```
 

--- a/scripts/verify/verify-index-product-channel-relation-resolver.mjs
+++ b/scripts/verify/verify-index-product-channel-relation-resolver.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-channel-relation-resolver] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const resolverPath =
+  'crates/rustok-distribution/src/product_index/channel_relation_resolver.rs';
+const resolver = requireMarkers(resolverPath, [
+  'MAX_PRODUCT_SALES_CHANNEL_RELATION_RESOLVE_PAGE: usize = 64',
+  'MAX_PRODUCT_SALES_CHANNEL_VISIBILITY_SLUGS: usize = 1024',
+  'MAX_PRODUCT_SALES_CHANNEL_STABILIZATION_ATTEMPTS: usize = 3',
+  'pub(crate) struct ProductSalesChannelRelationResolver',
+  'pub(crate) async fn reconcile_product(',
+  'pub(crate) async fn reconcile_tenant_page(',
+  'IsolationLevel::RepeatableRead',
+  'AccessMode::ReadOnly',
+  'ProductSalesChannelIndexRelationStore::new',
+  '.replace(tenant_id, product_id',
+  'lower(btrim(slug)) IN',
+  'SELECT id FROM channels WHERE tenant_id = $1 ORDER BY id ASC LIMIT $2',
+  'ProductChannelVisibility::Unrestricted',
+  'ProductSalesChannelRelationResolverError::TooManyResolvedChannels',
+  'ProductSalesChannelRelationResolverError::ConcurrentChange',
+  'ProductSalesChannelRelationResolverError::ProductNotFound',
+  'assert!(!sql.contains("is_active"))',
+]);
+for (const forbidden of [
+  'IndexMutation',
+  'index_entities',
+  'index_links',
+  'tokio::spawn',
+  'loop {',
+  'sys_events',
+  'TransactionalEventBus',
+  'OutboxRelay',
+]) {
+  if (resolver.includes(forbidden)) {
+    fail(`${resolverPath} contains forbidden Index/event/runtime coupling: ${forbidden}`);
+  }
+}
+
+const ownerPath = 'crates/rustok-product/src/services/index_channel_relation.rs';
+const owner = read(ownerPath);
+for (const forbidden of ['rustok_channel', 'rustok_index', 'FROM channels', 'JOIN channels']) {
+  if (owner.includes(forbidden)) {
+    fail(`${ownerPath} must remain Channel/Index independent: ${forbidden}`);
+  }
+}
+
+requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
+  'pub(crate) mod channel_relation_resolver;',
+]);
+requireMarkers('crates/rustok-index/docs/m7-product-sales-channel-resolver.md', [
+  'Status: `source_complete_event_wiring_and_atomic_snapshot_evidence_pending`',
+  '`REPEATABLE READ`, `READ ONLY`',
+  'at most 64 Products',
+  'at most three exact Product stabilization attempts',
+  'does **not** filter `channels.is_active`',
+  'not an atomic cross-owner snapshot',
+  'new Product Index schema version',
+  'No tests, Node verifiers, Cargo checks',
+]);
+requireMarkers('crates/rustok-index/docs/m7-product-sales-channel-relation-admission.md', [
+  'cross-owner resolver source is complete',
+  'bounded optimistic stabilization',
+  'runtime availability remains Channel-owned',
+]);
+requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-07.md', [
+  'bounded cross-owner Product visibility to Channel UUID resolver',
+  'Product v3',
+  'current digest artifact changed after #3130',
+]);
+
+const aggregate = read('scripts/verify/verify-index-query-contract.mjs');
+if (!aggregate.includes("'verify-index-product-channel-relation-resolver.mjs'")) {
+  fail('Index aggregate verifier does not include the Product-SalesChannel resolver guard');
+}
+
+console.log('[verify-index-product-channel-relation-resolver] Product-SalesChannel resolver contract verified');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -65,6 +65,7 @@ const scripts = [
   'verify-index-product-refresh-canonical-writer.mjs',
   'verify-index-product-refresh-relay-step.mjs',
   'verify-index-product-channel-relation-ledger.mjs',
+  'verify-index-product-channel-relation-resolver.mjs',
   'verify-index-product-variant-source.mjs',
   'verify-index-product-graph-source.mjs',
   'verify-index-product-tombstone-source.mjs',


### PR DESCRIPTION
## Summary

- add a bounded cross-owner Product visibility -> SalesChannel UUID resolver in `rustok-distribution`;
- preserve Product semantics: missing/empty allowlist is unrestricted and resolves to the current tenant Channel identity universe;
- resolve restricted membership by canonical normalized Channel slug without moving Channel SQL or dependencies into `rustok-product`;
- keep Channel `is_active` outside relation membership so runtime availability remains Channel-authority state;
- observe Product+Channel inputs in read-only `REPEATABLE READ`, commit through the Product-owned relation store, then re-observe and retry up to three times instead of claiming an atomic cross-owner snapshot;
- add a bounded 64-Product keyset convergence page for backfill/Channel-side changes, with idempotent partial-page retry through the owner ledger;
- keep Product v2 immutable and leave Product v3 + relation replay/IndexLink as the next source slice;
- actualize the current Index plan: the digest artifact changed after #3130, but canonical generator/verify admission is still unproven, so Product typed events remain blocked;
- refresh stale Product graph/Product owner documentation and add a static resolver guard to the aggregate Index verifier.

## Main recheck

The branch was created from `main@375f7cdb80244570bb5e93405b771e0e8516b1f4`. After PR creation, `main` advanced to `88509617cc2d7d63496661192758542a55aef33a` via #3134. That commit only adds the neutral Reactions storefront package and Reactions plan/verifier changes; it does not overlap this PR's Product/Index/distribution files.

## Boundaries

This PR does not add an Index mutation, Product-to-SalesChannel link, event route, worker loop, broker acknowledgement, watermark/checkpoint, or production cutover. The resolver is a bounded convergence primitive; durable triggering and PostgreSQL runtime evidence remain pending.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, or CI were executed by the implementation agent.