### PR TITLE
fix(reactions): harden neutral storefront controls

### DIFF
--- a/crates/rustok-reactions-storefront/src/model.rs
+++ b/crates/rustok-reactions-storefront/src/model.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+const MAX_REACTION_SOURCE_SLUG_BYTES: usize = 64;
+const MAX_REACTION_SUBJECT_KIND_BYTES: usize = 64;
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct ReactionSubjectUiRef {
     pub source: String,
@@ -19,15 +22,27 @@ impl ReactionSubjectUiRef {
         let source = source.into();
         let kind = kind.into();
         let subject_revision = subject_revision.into();
-        if source.trim().is_empty() || kind.trim().is_empty() {
-            return Err("reaction subject source and kind are required".to_string());
+        if !valid_segment(
+            source.as_str(),
+            MAX_REACTION_SOURCE_SLUG_BYTES,
+            true,
+            true,
+        ) || !valid_segment(
+            kind.as_str(),
+            MAX_REACTION_SUBJECT_KIND_BYTES,
+            false,
+            true,
+        ) {
+            return Err("reaction subject source or kind is invalid".to_string());
+        }
+        if subject_id.is_nil() {
+            return Err("reaction subject id must be non-nil".to_string());
         }
         let revision = subject_revision
-            .trim()
             .parse::<u64>()
-            .map_err(|_| "reaction subject revision must be a positive u64 string".to_string())?;
-        if revision == 0 {
-            return Err("reaction subject revision must be a positive u64 string".to_string());
+            .map_err(|_| "reaction subject revision must be a positive canonical u64 string".to_string())?;
+        if revision == 0 || revision.to_string() != subject_revision {
+            return Err("reaction subject revision must be a positive canonical u64 string".to_string());
         }
         Ok(Self {
             source,
@@ -36,6 +51,31 @@ impl ReactionSubjectUiRef {
             subject_revision,
         })
     }
+}
+
+fn valid_segment(
+    value: &str,
+    maximum_bytes: usize,
+    allow_hyphen: bool,
+    allow_underscore: bool,
+) -> bool {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > maximum_bytes
+        || value.starts_with('-')
+        || value.starts_with('_')
+        || value.ends_with('-')
+        || value.ends_with('_')
+    {
+        return false;
+    }
+
+    value.bytes().all(|byte| {
+        byte.is_ascii_lowercase()
+            || byte.is_ascii_digit()
+            || (allow_hyphen && byte == b'-')
+            || (allow_underscore && byte == b'_')
+    })
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
@@ -114,10 +154,17 @@ mod tests {
     use uuid::Uuid;
 
     #[test]
-    fn subject_ref_requires_positive_revision() {
+    fn subject_ref_requires_exact_neutral_identity_and_revision() {
         assert!(ReactionSubjectUiRef::new("forum", "topic", Uuid::new_v4(), "1").is_ok());
-        assert!(ReactionSubjectUiRef::new("forum", "topic", Uuid::new_v4(), "0").is_err());
-        assert!(ReactionSubjectUiRef::new("forum", "topic", Uuid::new_v4(), "-1").is_err());
+        for revision in ["0", "-1", "01", " 1 ", "+1"] {
+            assert!(
+                ReactionSubjectUiRef::new("forum", "topic", Uuid::new_v4(), revision).is_err(),
+                "revision {revision:?} must be rejected",
+            );
+        }
+        assert!(ReactionSubjectUiRef::new("Forum", "topic", Uuid::new_v4(), "1").is_err());
+        assert!(ReactionSubjectUiRef::new("forum", "topic-kind", Uuid::new_v4(), "1").is_err());
+        assert!(ReactionSubjectUiRef::new("forum", "topic", Uuid::nil(), "1").is_err());
     }
 
     #[test]

--- a/crates/rustok-reactions-storefront/src/ui/leptos.rs
+++ b/crates/rustok-reactions-storefront/src/ui/leptos.rs
@@ -54,10 +54,16 @@ pub fn ReactionBar(subject: ReactionSubjectUiRef) -> impl IntoView {
         set_mutation_busy.set(true);
         set_mutation_error.set(false);
         spawn_local(async move {
-            match transport::apply_reaction(context, subject, reaction, action).await {
-                Ok(_) => set_refresh_nonce.update(|value| *value += 1),
-                Err(_) => set_mutation_error.set(true),
+            if transport::apply_reaction(context, subject, reaction, action)
+                .await
+                .is_err()
+            {
+                set_mutation_error.set(true);
             }
+            // A failed write may be a stale-revision/conflict response. Always
+            // re-read the producer-authorized canonical owner state instead of
+            // leaving the pre-command snapshot on screen.
+            set_refresh_nonce.update(|value| *value += 1);
             set_mutation_busy.set(false);
         });
     });

--- a/scripts/verify/verify-reactions-storefront-ui.mjs
+++ b/scripts/verify/verify-reactions-storefront-ui.mjs
@@ -21,6 +21,7 @@ function requireAbsent(text, needle, message) {
 const cargo = read("crates/rustok-reactions-storefront/Cargo.toml");
 const model = read("crates/rustok-reactions-storefront/src/model.rs");
 const transport = read("crates/rustok-reactions-storefront/src/transport.rs");
+const transportRuntime = transport.split("#[cfg(test)]", 1)[0];
 const ui = read("crates/rustok-reactions-storefront/src/ui/leptos.rs");
 
 for (const forbidden of ["rustok-forum", "rustok-blog", "rustok-reactions ="]) {
@@ -36,29 +37,39 @@ for (const field of ["source", "kind", "subject_id", "subject_revision"]) {
 }
 requireContains(
   model,
-  "revision == 0",
-  "ReactionSubjectUiRef must reject non-positive revisions",
+  "valid_segment",
+  "ReactionSubjectUiRef must enforce the neutral source/kind segment contract",
+);
+requireContains(
+  model,
+  "subject_id.is_nil()",
+  "ReactionSubjectUiRef must reject nil subject UUIDs",
+);
+requireContains(
+  model,
+  "revision.to_string() != subject_revision",
+  "ReactionSubjectUiRef must require a canonical positive revision string",
 );
 
 for (const operation of ["reactionSnapshot", "applyReaction"]) {
-  requireContains(transport, operation, `Missing neutral GraphQL operation ${operation}`);
+  requireContains(transportRuntime, operation, `Missing neutral GraphQL operation ${operation}`);
 }
 for (const forbidden of ["tenantId", "actorId"]) {
   requireAbsent(
-    transport,
+    transportRuntime,
     forbidden,
     `Storefront GraphQL input must not accept ${forbidden}`,
   );
 }
 requireContains(
-  transport,
+  transportRuntime,
   "command_id: Uuid::new_v4()",
   "Each UI write must create a fresh owner command identity",
 );
 requireContains(
   ui,
   "set_refresh_nonce.update",
-  "Successful writes must reload canonical owner state",
+  "Every UI write attempt must reload canonical owner state",
 );
 requireAbsent(
   ui,


### PR DESCRIPTION
## Summary

Static recheck of merged PR #3134 found two correctness issues in the new module-owned Reactions storefront foundation plus one verifier defect:

- require `ReactionSubjectUiRef` to match the neutral source/kind contract, reject nil UUIDs and accept only canonical positive decimal revision strings;
- re-read canonical `reactionSnapshot` after every write attempt, including conflicts/stale-revision failures, so the UI does not leave a stale pre-command snapshot on screen;
- scope the ownership/source guard to runtime transport code so its own `tenantId` / `actorId` unit-test assertions do not make the verifier fail by construction.

This does not add Forum/Blog composition, producer-private reads, a new transport, or any runtime-evidence claim.

## Verification

Not run per maintainer instruction. Tests/checks/verifiers remain maintainer-run.