### PR TITLE
test(pages): retain explicit repair failure matrix

### DIFF
--- a/crates/rustok-pages/contracts/evidence/pages-explicit-artifact-repair-failures-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-explicit-artifact-repair-failures-source.json
@@ -1,0 +1,83 @@
+{
+  "format": "pages_explicit_artifact_repair_failures_source_v1",
+  "status": "pages_explicit_artifact_repair_failures_source_unvalidated",
+  "generated_at": "2026-08-07",
+  "scope": "Source-only negative regression harness for explicit immutable artifact rebuild and rebuilt-artifact activation rejection paths",
+  "source_contract": {
+    "harness": "crates/rustok-pages/tests/explicit_artifact_repair_failures_sqlite.rs",
+    "sqlite_isolated_database_per_test": true,
+    "real_outbox_sys_events_migration_used": true,
+    "real_channel_module_migrations_used": true,
+    "real_pages_module_migrations_used": true,
+    "canonical_reviewed_publish_body_revision_used": true,
+    "corrupt_provenance_rejected": true,
+    "corrupt_provenance_error_code_bound": true,
+    "corrupt_provenance_adds_no_rebuild_receipt": true,
+    "corrupt_provenance_adds_no_artifact": true,
+    "corrupt_provenance_preserves_binding_version_status_events": true,
+    "reviewed_runtime_mismatch_rejected": true,
+    "reviewed_runtime_mismatch_adds_no_rebuild_receipt": true,
+    "reviewed_runtime_mismatch_adds_no_artifact": true,
+    "reviewed_runtime_mismatch_preserves_binding_version_status_events": true,
+    "activation_stale_version_rejected": true,
+    "activation_stale_version_adds_no_receipt": true,
+    "activation_stale_version_preserves_binding_version_status_events": true,
+    "activation_invalid_replacement_rejected": true,
+    "activation_invalid_replacement_error_code_bound": true,
+    "activation_invalid_replacement_adds_no_receipt": true,
+    "activation_invalid_replacement_preserves_binding_version_status_events": true,
+    "activation_unpublished_page_rejected": true,
+    "activation_unpublished_error_code_bound": true,
+    "activation_unpublished_adds_no_receipt": true,
+    "activation_unpublished_preserves_binding_version_status_events": true,
+    "activation_failure_fixture_rebuild_emits_no_events": true,
+    "automatic_audit_to_rebuild": false,
+    "automatic_rebuild_to_activation": false,
+    "production_code_changed": false,
+    "database_schema_changed": false,
+    "public_transport_changed": false,
+    "ffa_promoted": false,
+    "fba_promoted": false,
+    "tests_run": false,
+    "source_verifier_run": false,
+    "cargo_run": false,
+    "formatting_run": false,
+    "sqlite_run": false,
+    "workflows_or_ci_run": false
+  },
+  "linked_sources": {
+    "rebuild_owner": "crates/rustok-pages/src/services/page/artifact_rebuild.rs",
+    "activation_owner": "crates/rustok-pages/src/services/page/artifact_binding_replacement.rs",
+    "reviewed_publish_owner": "crates/rustok-pages/src/services/page/reviewed_publish.rs",
+    "rebuild_sqlite_regression": "crates/rustok-pages/tests/explicit_artifact_rebuild_sqlite.rs",
+    "activation_sqlite_regression": "crates/rustok-pages/tests/explicit_artifact_binding_replacement_sqlite.rs",
+    "postgres_atomicity_regression": "crates/rustok-pages/tests/explicit_artifact_repair_postgres.rs"
+  },
+  "harness": {
+    "path": "crates/rustok-pages/tests/explicit_artifact_repair_failures_sqlite.rs",
+    "tests": [
+      "rebuild_rejects_corrupt_provenance_atomically",
+      "rebuild_rejects_reviewed_runtime_mismatch_atomically",
+      "activation_rejects_stale_version_atomically",
+      "activation_rejects_invalid_replacement_atomically",
+      "activation_rejects_unpublished_page_atomically"
+    ]
+  },
+  "suggested_execution": [
+    "node crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-failures.mjs",
+    "cargo test -p rustok-pages --test explicit_artifact_repair_failures_sqlite -- --nocapture",
+    "cargo check -p rustok-pages --all-targets"
+  ],
+  "execution": [],
+  "validation": {
+    "source_guard": false,
+    "sqlite_harness": false,
+    "corrupt_provenance": false,
+    "reviewed_runtime_mismatch": false,
+    "stale_version": false,
+    "invalid_replacement": false,
+    "unpublished_page": false,
+    "zero_side_effect_snapshots": false,
+    "rebuild_no_event_boundary": false
+  }
+}

--- a/crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-failures.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-failures.mjs
@@ -1,0 +1,367 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(__filename), "..", "..", "..", "..");
+const read = (relativePath) =>
+  fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+
+const evidence = JSON.parse(
+  read(
+    "crates/rustok-pages/contracts/evidence/pages-explicit-artifact-repair-failures-source.json",
+  ),
+);
+const harness = read(
+  "crates/rustok-pages/tests/explicit_artifact_repair_failures_sqlite.rs",
+);
+const rebuildOwner = read(
+  "crates/rustok-pages/src/services/page/artifact_rebuild.rs",
+);
+const activationOwner = read(
+  "crates/rustok-pages/src/services/page/artifact_binding_replacement.rs",
+);
+const continuation = read(
+  "docs/modules/pages-page-builder-repair-failures-continuation-2026-08-07.md",
+);
+const postgresContinuation = read(
+  "docs/modules/pages-page-builder-repair-postgres-continuation-2026-08-07.md",
+);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const requireOrder = (content, values, label) => {
+  let previous = -1;
+  for (const value of values) {
+    const index = content.indexOf(value, previous + 1);
+    if (index < 0) {
+      failures.push(`${label}: missing or out of order ${value}`);
+      return;
+    }
+    previous = index;
+  }
+};
+const sliceBetween = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  if (startIndex < 0) {
+    failures.push(`${label}: missing ${start}`);
+    return "";
+  }
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (endIndex < 0) {
+    failures.push(`${label}: missing ${end}`);
+    return "";
+  }
+  return content.slice(startIndex, endIndex);
+};
+const countText = (content, value) => content.split(value).length - 1;
+
+if (evidence.status !== "pages_explicit_artifact_repair_failures_source_unvalidated") {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push("execution evidence must remain empty");
+}
+for (const key of [
+  "source_guard",
+  "sqlite_harness",
+  "corrupt_provenance",
+  "reviewed_runtime_mismatch",
+  "stale_version",
+  "invalid_replacement",
+  "unpublished_page",
+  "zero_side_effect_snapshots",
+  "rebuild_no_event_boundary",
+]) {
+  if (evidence.validation?.[key] !== false) {
+    failures.push(`validation.${key} must remain false`);
+  }
+}
+
+for (const [key, expected] of Object.entries({
+  sqlite_isolated_database_per_test: true,
+  real_outbox_sys_events_migration_used: true,
+  real_channel_module_migrations_used: true,
+  real_pages_module_migrations_used: true,
+  canonical_reviewed_publish_body_revision_used: true,
+  corrupt_provenance_rejected: true,
+  corrupt_provenance_error_code_bound: true,
+  corrupt_provenance_adds_no_rebuild_receipt: true,
+  corrupt_provenance_adds_no_artifact: true,
+  corrupt_provenance_preserves_binding_version_status_events: true,
+  reviewed_runtime_mismatch_rejected: true,
+  reviewed_runtime_mismatch_adds_no_rebuild_receipt: true,
+  reviewed_runtime_mismatch_adds_no_artifact: true,
+  reviewed_runtime_mismatch_preserves_binding_version_status_events: true,
+  activation_stale_version_rejected: true,
+  activation_stale_version_adds_no_receipt: true,
+  activation_stale_version_preserves_binding_version_status_events: true,
+  activation_invalid_replacement_rejected: true,
+  activation_invalid_replacement_error_code_bound: true,
+  activation_invalid_replacement_adds_no_receipt: true,
+  activation_invalid_replacement_preserves_binding_version_status_events: true,
+  activation_unpublished_page_rejected: true,
+  activation_unpublished_error_code_bound: true,
+  activation_unpublished_adds_no_receipt: true,
+  activation_unpublished_preserves_binding_version_status_events: true,
+  activation_failure_fixture_rebuild_emits_no_events: true,
+  automatic_audit_to_rebuild: false,
+  automatic_rebuild_to_activation: false,
+  production_code_changed: false,
+  database_schema_changed: false,
+  public_transport_changed: false,
+  ffa_promoted: false,
+  fba_promoted: false,
+  tests_run: false,
+  source_verifier_run: false,
+  cargo_run: false,
+  formatting_run: false,
+  sqlite_run: false,
+  workflows_or_ci_run: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`source_contract.${key} must be ${expected}`);
+  }
+}
+
+if (
+  evidence.harness?.path !==
+  "crates/rustok-pages/tests/explicit_artifact_repair_failures_sqlite.rs"
+) {
+  failures.push("failure harness path is invalid");
+}
+for (const test of [
+  "rebuild_rejects_corrupt_provenance_atomically",
+  "rebuild_rejects_reviewed_runtime_mismatch_atomically",
+  "activation_rejects_stale_version_atomically",
+  "activation_rejects_invalid_replacement_atomically",
+  "activation_rejects_unpublished_page_atomically",
+]) {
+  if (!evidence.harness?.tests?.includes(test)) {
+    failures.push(`failure harness registration is missing ${test}`);
+  }
+  requireText(harness, `async fn ${test}()`, "failure harness");
+}
+
+for (const marker of [
+  "SysEventsMigration.up(&manager).await?",
+  "for migration in ChannelModule.migrations()",
+  "for migration in PagesModule.migrations()",
+  "Sha256::digest",
+  "body.updated_at",
+  "struct RepairState",
+  "rebuild_receipts: u64",
+  "activation_receipts: u64",
+  "artifact_count: u64",
+  "binding_artifact_id: Uuid",
+  "page_version: i32",
+  "page_status: String",
+  "event_count: u64",
+]) {
+  requireText(harness, marker, "failure harness foundation");
+}
+if (countText(harness, "assert_eq!(after, before);") !== 5) {
+  failures.push("each of the five rejected commands must preserve the complete RepairState snapshot");
+}
+
+const corruptProvenance = sliceBetween(
+  harness,
+  "async fn rebuild_rejects_corrupt_provenance_atomically()",
+  "async fn rebuild_rejects_reviewed_runtime_mismatch_atomically()",
+  "corrupt provenance test",
+);
+requireOrder(
+  corruptProvenance,
+  [
+    'source_active.provenance_hash = Set("0".repeat(64));',
+    "let before = repair_state",
+    ".rebuild_immutable_artifact(",
+    "PagesError::PublishOperationIntegrity(message)",
+    "PAGE_ARTIFACT_REBUILD_SOURCE_INVALID",
+    "let after = repair_state",
+    "assert_eq!(after, before);",
+  ],
+  "corrupt provenance rejection ordering",
+);
+
+const runtimeMismatch = sliceBetween(
+  harness,
+  "async fn rebuild_rejects_reviewed_runtime_mismatch_atomically()",
+  "async fn activation_rejects_stale_version_atomically()",
+  "runtime mismatch test",
+);
+requireOrder(
+  runtimeMismatch,
+  [
+    "PageBuilderReviewedPublishRuntime::new(",
+    "let before = repair_state",
+    ".rebuild_immutable_artifact(",
+    "PagesError::PublishRuntimeReviewInvalid",
+    "let after = repair_state",
+    "assert_eq!(after, before);",
+  ],
+  "runtime mismatch rejection ordering",
+);
+
+const staleVersion = sliceBetween(
+  harness,
+  "async fn activation_rejects_stale_version_atomically()",
+  "async fn activation_rejects_invalid_replacement_atomically()",
+  "stale version test",
+);
+requireOrder(
+  staleVersion,
+  [
+    "let before = repair_state",
+    "let stale_version = before.page_version + 1;",
+    ".replace_rebuilt_artifact_binding(",
+    "PagesError::VersionConflict",
+    "let after = repair_state",
+    "assert_eq!(after, before);",
+  ],
+  "stale version rejection ordering",
+);
+
+const invalidReplacement = sliceBetween(
+  harness,
+  "async fn activation_rejects_invalid_replacement_atomically()",
+  "async fn activation_rejects_unpublished_page_atomically()",
+  "invalid replacement test",
+);
+requireOrder(
+  invalidReplacement,
+  [
+    'replacement_active.artifact_hash = Set("0".repeat(64));',
+    "let before = repair_state",
+    ".replace_rebuilt_artifact_binding(",
+    "PAGE_ARTIFACT_BINDING_REPLACEMENT_TARGET_INVALID",
+    "let after = repair_state",
+    "assert_eq!(after, before);",
+  ],
+  "invalid replacement rejection ordering",
+);
+
+const unpublished = sliceBetween(
+  harness,
+  "async fn activation_rejects_unpublished_page_atomically()",
+  "fn page_service(",
+  "unpublished activation test",
+);
+requireOrder(
+  unpublished,
+  [
+    ".unpublish_if_current(",
+    "let before = repair_state",
+    'assert_ne!(before.page_status, "published");',
+    ".replace_rebuilt_artifact_binding(",
+    "PAGE_ARTIFACT_BINDING_REPLACEMENT_CURRENT_CONFLICT",
+    "let after = repair_state",
+    "assert_eq!(after, before);",
+  ],
+  "unpublished activation rejection ordering",
+);
+
+const rebuildFixture = sliceBetween(
+  harness,
+  "async fn rebuild_fixture(",
+  "fn reviewed_input(",
+  "activation rebuild fixture",
+);
+requireOrder(
+  rebuildFixture,
+  [
+    "let before = repair_state",
+    ".rebuild_immutable_artifact(",
+    "let after = repair_state",
+    "after.rebuild_receipts, before.rebuild_receipts + 1",
+    "after.artifact_count, before.artifact_count + 1",
+    "after.binding_artifact_id, before.binding_artifact_id",
+    "after.page_version, before.page_version",
+    "after.event_count, before.event_count",
+  ],
+  "rebuild fixture no-side-effect boundary",
+);
+
+for (const marker of [
+  'pub const PAGE_ARTIFACT_REBUILD_SOURCE_INVALID: &str = "PAGE_ARTIFACT_REBUILD_SOURCE_INVALID"',
+  "verify_source(&source)?;",
+  "if source.review_hash != reviewed.review_hash",
+  "PagesError::publish_runtime_review_invalid(",
+]) {
+  requireText(rebuildOwner, marker, "rebuild owner");
+}
+requireOrder(
+  rebuildOwner,
+  [
+    "verify_source(&source)?;",
+    "if source.provenance_hash != input.expected_provenance_hash",
+    "if source.review_hash != reviewed.review_hash",
+    "let compiled = compile_exact_rebuild(&source, &reviewed)?;",
+  ],
+  "rebuild owner rejection-before-append ordering",
+);
+
+for (const marker of [
+  'pub const PAGE_ARTIFACT_BINDING_REPLACEMENT_CURRENT_CONFLICT: &str =',
+  'pub const PAGE_ARTIFACT_BINDING_REPLACEMENT_TARGET_INVALID: &str =',
+  "enforce_expected_version(Some(input.expected_version), existing_page.version)?;",
+  'if existing_page.status != "published"',
+  "if replacement.instance_key != rebuild.artifact_instance_key",
+  "PageBuilderArtifactService::bind_existing_body_in_tx(",
+]) {
+  requireText(activationOwner, marker, "activation owner");
+}
+requireOrder(
+  activationOwner,
+  [
+    "enforce_expected_version(Some(input.expected_version), existing_page.version)?;",
+    'if existing_page.status != "published"',
+    "let replacement = load_replacement_artifact_in_tx(",
+    "if replacement.instance_key != rebuild.artifact_instance_key",
+    "PageBuilderArtifactService::bind_existing_body_in_tx(",
+  ],
+  "activation owner rejection-before-binding ordering",
+);
+
+for (const marker of [
+  "explicit-artifact-repair-failure-harness-source-ready",
+  "pages_explicit_artifact_repair_failures_source_unvalidated",
+  "five isolated SQLite regressions",
+  "complete snapshot to remain unchanged",
+  "Cache handler execution",
+]) {
+  requireText(continuation, marker, "failure continuation");
+}
+for (const marker of [
+  "explicit-artifact-repair-failure-harness-source-ready",
+  "Rebuild provenance/runtime failure matrix",
+  "Activation stale-version/invalid-target/unpublished matrix",
+  "negative SQLite repair harnesses",
+]) {
+  requireText(postgresContinuation, marker, "PostgreSQL continuation cursor");
+}
+
+for (const forbidden of [
+  "audit_page_artifacts(",
+  "rebuildPageArtifact",
+  "activateRebuiltPageArtifact",
+]) {
+  forbidText(harness, forbidden, "failure harness automatic/transport boundary");
+}
+
+if (failures.length > 0) {
+  console.error("[verify-pages-explicit-artifact-repair-failures] FAIL");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "[verify-pages-explicit-artifact-repair-failures] PASS source_ready=true execution=pending",
+);

--- a/crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-failures.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-failures.mjs
@@ -29,6 +29,9 @@ const continuation = read(
 const postgresContinuation = read(
   "docs/modules/pages-page-builder-repair-postgres-continuation-2026-08-07.md",
 );
+const actualization = read(
+  "docs/modules/page-builder-parity-actualization-2026-08-05.md",
+);
 const failures = [];
 
 const requireText = (content, value, label) => {
@@ -346,6 +349,14 @@ for (const marker of [
   "negative SQLite repair harnesses",
 ]) {
   requireText(postgresContinuation, marker, "PostgreSQL continuation cursor");
+}
+for (const marker of [
+  "repair-failure-harness-source-ready",
+  "Rebuild provenance/runtime negative harness",
+  "Activation stale-version/invalid-target/unpublished harness",
+  "negative provenance/runtime failures are now harness-ready",
+]) {
+  requireText(actualization, marker, "canonical parity actualization");
 }
 
 for (const forbidden of [

--- a/crates/rustok-pages/tests/explicit_artifact_repair_failures_sqlite.rs
+++ b/crates/rustok-pages/tests/explicit_artifact_repair_failures_sqlite.rs
@@ -1,0 +1,498 @@
+use std::error::Error;
+use std::sync::Arc;
+
+use rustok_channel::ChannelModule;
+use rustok_core::{CONTENT_FORMAT_GRAPESJS, MigrationSource, SecurityContext};
+use rustok_outbox::{OutboxTransport, SysEvents, SysEventsMigration, TransactionalEventBus};
+use rustok_page_builder::PageBuilderReviewedPublishRuntime;
+use rustok_pages::dto::{
+    CreatePageInput, PageBodyInput, PageBodyRevisionInput, PageTranslationInput, PublishPageInput,
+    RebuildPageArtifactInput, RebuildPageArtifactResult, ReplacePageArtifactBindingInput,
+    ReviewedPagePublishRuntimeInput,
+};
+use rustok_pages::entities::{
+    page, page_artifact_binding_replacement_operation, page_artifact_rebuild_operation,
+    page_publish_rebuild_source, page_published_landing_artifact, page_static_landing_artifact,
+};
+use rustok_pages::services::PageService;
+use rustok_pages::{
+    PAGE_ARTIFACT_BINDING_REPLACEMENT_CURRENT_CONFLICT,
+    PAGE_ARTIFACT_BINDING_REPLACEMENT_TARGET_INVALID, PAGE_ARTIFACT_REBUILD_SOURCE_INVALID,
+    PagesError, PagesModule,
+};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectOptions, ConnectionTrait, Database, DatabaseConnection,
+    DbBackend, EntityTrait, PaginatorTrait, QueryFilter, Set, Statement,
+};
+use sea_orm_migration::{MigrationTrait, SchemaManager};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+#[derive(Debug, Clone)]
+struct PublishedFixture {
+    page_id: Uuid,
+    source: page_publish_rebuild_source::Model,
+    original_artifact_id: Uuid,
+    page_version: i32,
+    reviewed: PageBuilderReviewedPublishRuntime,
+}
+
+#[derive(Debug, Clone)]
+struct RebuiltFixture {
+    published: PublishedFixture,
+    rebuilt: RebuildPageArtifactResult,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RepairState {
+    rebuild_receipts: u64,
+    activation_receipts: u64,
+    artifact_count: u64,
+    binding_artifact_id: Uuid,
+    page_version: i32,
+    page_status: String,
+    event_count: u64,
+}
+
+#[tokio::test]
+async fn rebuild_rejects_corrupt_provenance_atomically() -> TestResult<()> {
+    let tenant_id = Uuid::new_v4();
+    let db = setup_db(tenant_id).await?;
+    let service = page_service(&db);
+    let fixture = publish_fixture(&service, &db, tenant_id).await?;
+
+    let mut source_active: page_publish_rebuild_source::ActiveModel = fixture.source.clone().into();
+    source_active.provenance_hash = Set("0".repeat(64));
+    let corrupted = source_active.update(&db).await?;
+    let before = repair_state(&db, tenant_id, fixture.page_id).await?;
+
+    let result = service
+        .rebuild_immutable_artifact(
+            tenant_id,
+            SecurityContext::system(),
+            fixture.page_id,
+            RebuildPageArtifactInput {
+                source_id: corrupted.id,
+                expected_provenance_hash: corrupted.provenance_hash.clone(),
+                idempotency_key: "repair-failure-corrupt-provenance-v1".to_string(),
+                runtime: reviewed_input(&fixture.reviewed),
+            },
+        )
+        .await;
+    assert!(matches!(
+        result,
+        Err(PagesError::PublishOperationIntegrity(message))
+            if message.contains(PAGE_ARTIFACT_REBUILD_SOURCE_INVALID)
+    ));
+
+    let after = repair_state(&db, tenant_id, fixture.page_id).await?;
+    assert_eq!(after, before);
+    assert_eq!(
+        page_publish_rebuild_source::Entity::find_by_id(corrupted.id)
+            .one(&db)
+            .await?
+            .ok_or_else(|| std::io::Error::other("corrupted rebuild source disappeared"))?
+            .provenance_hash,
+        corrupted.provenance_hash
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn rebuild_rejects_reviewed_runtime_mismatch_atomically() -> TestResult<()> {
+    let tenant_id = Uuid::new_v4();
+    let db = setup_db(tenant_id).await?;
+    let service = page_service(&db);
+    let fixture = publish_fixture(&service, &db, tenant_id).await?;
+    let mismatched = PageBuilderReviewedPublishRuntime::new(
+        "explicit-artifact-repair-failure-mismatch",
+        json!({ "surface": "storefront", "channel": "mobile" }),
+    )?;
+    let before = repair_state(&db, tenant_id, fixture.page_id).await?;
+
+    let result = service
+        .rebuild_immutable_artifact(
+            tenant_id,
+            SecurityContext::system(),
+            fixture.page_id,
+            RebuildPageArtifactInput {
+                source_id: fixture.source.id,
+                expected_provenance_hash: fixture.source.provenance_hash.clone(),
+                idempotency_key: "repair-failure-runtime-mismatch-v1".to_string(),
+                runtime: reviewed_input(&mismatched),
+            },
+        )
+        .await;
+    assert!(matches!(result, Err(PagesError::PublishRuntimeReviewInvalid(_))));
+
+    let after = repair_state(&db, tenant_id, fixture.page_id).await?;
+    assert_eq!(after, before);
+    Ok(())
+}
+
+#[tokio::test]
+async fn activation_rejects_stale_version_atomically() -> TestResult<()> {
+    let tenant_id = Uuid::new_v4();
+    let db = setup_db(tenant_id).await?;
+    let service = page_service(&db);
+    let fixture = rebuild_fixture(&service, &db, tenant_id).await?;
+    let before = repair_state(&db, tenant_id, fixture.published.page_id).await?;
+    let stale_version = before.page_version + 1;
+
+    let result = service
+        .replace_rebuilt_artifact_binding(
+            tenant_id,
+            SecurityContext::system(),
+            fixture.published.page_id,
+            ReplacePageArtifactBindingInput {
+                rebuild_operation_id: fixture.rebuilt.operation_id,
+                expected_version: stale_version,
+                expected_current_artifact_id: fixture.published.original_artifact_id,
+                idempotency_key: "repair-failure-stale-version-v1".to_string(),
+            },
+        )
+        .await;
+    assert!(matches!(
+        result,
+        Err(PagesError::VersionConflict {
+            expected_version,
+            actual_version,
+        }) if expected_version == stale_version && actual_version == before.page_version
+    ));
+
+    let after = repair_state(&db, tenant_id, fixture.published.page_id).await?;
+    assert_eq!(after, before);
+    Ok(())
+}
+
+#[tokio::test]
+async fn activation_rejects_invalid_replacement_atomically() -> TestResult<()> {
+    let tenant_id = Uuid::new_v4();
+    let db = setup_db(tenant_id).await?;
+    let service = page_service(&db);
+    let fixture = rebuild_fixture(&service, &db, tenant_id).await?;
+
+    let replacement = page_static_landing_artifact::Entity::find_by_id(fixture.rebuilt.rebuilt_artifact_id)
+        .one(&db)
+        .await?
+        .ok_or_else(|| std::io::Error::other("rebuilt replacement artifact is missing"))?;
+    let mut replacement_active: page_static_landing_artifact::ActiveModel = replacement.into();
+    replacement_active.artifact_hash = Set("0".repeat(64));
+    replacement_active.update(&db).await?;
+    let before = repair_state(&db, tenant_id, fixture.published.page_id).await?;
+
+    let result = service
+        .replace_rebuilt_artifact_binding(
+            tenant_id,
+            SecurityContext::system(),
+            fixture.published.page_id,
+            ReplacePageArtifactBindingInput {
+                rebuild_operation_id: fixture.rebuilt.operation_id,
+                expected_version: before.page_version,
+                expected_current_artifact_id: fixture.published.original_artifact_id,
+                idempotency_key: "repair-failure-invalid-replacement-v1".to_string(),
+            },
+        )
+        .await;
+    assert!(matches!(
+        result,
+        Err(PagesError::RollbackTargetUnavailable(message))
+            if message.contains(PAGE_ARTIFACT_BINDING_REPLACEMENT_TARGET_INVALID)
+    ));
+
+    let after = repair_state(&db, tenant_id, fixture.published.page_id).await?;
+    assert_eq!(after, before);
+    Ok(())
+}
+
+#[tokio::test]
+async fn activation_rejects_unpublished_page_atomically() -> TestResult<()> {
+    let tenant_id = Uuid::new_v4();
+    let db = setup_db(tenant_id).await?;
+    let service = page_service(&db);
+    let fixture = rebuild_fixture(&service, &db, tenant_id).await?;
+
+    service
+        .unpublish_if_current(
+            tenant_id,
+            SecurityContext::system(),
+            fixture.published.page_id,
+            Some(fixture.published.page_version),
+        )
+        .await?;
+    let before = repair_state(&db, tenant_id, fixture.published.page_id).await?;
+    assert_ne!(before.page_status, "published");
+
+    let result = service
+        .replace_rebuilt_artifact_binding(
+            tenant_id,
+            SecurityContext::system(),
+            fixture.published.page_id,
+            ReplacePageArtifactBindingInput {
+                rebuild_operation_id: fixture.rebuilt.operation_id,
+                expected_version: before.page_version,
+                expected_current_artifact_id: fixture.published.original_artifact_id,
+                idempotency_key: "repair-failure-unpublished-v1".to_string(),
+            },
+        )
+        .await;
+    assert!(matches!(
+        result,
+        Err(PagesError::RollbackTargetUnavailable(message))
+            if message.contains(PAGE_ARTIFACT_BINDING_REPLACEMENT_CURRENT_CONFLICT)
+    ));
+
+    let after = repair_state(&db, tenant_id, fixture.published.page_id).await?;
+    assert_eq!(after, before);
+    Ok(())
+}
+
+fn page_service(db: &DatabaseConnection) -> PageService {
+    PageService::new(
+        db.clone(),
+        TransactionalEventBus::new(Arc::new(OutboxTransport::new(db.clone()))),
+    )
+}
+
+async fn publish_fixture(
+    service: &PageService,
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+) -> TestResult<PublishedFixture> {
+    let reviewed = PageBuilderReviewedPublishRuntime::new(
+        "explicit-artifact-repair-failures",
+        json!({ "surface": "storefront", "channel": "web" }),
+    )?;
+    let project = json!({
+        "pages": [{
+            "id": "home",
+            "flyPageMeta": {
+                "title": "Explicit repair failures",
+                "description": "Negative repair regression",
+                "slug": "home"
+            },
+            "component": {
+                "id": "root",
+                "type": "wrapper",
+                "components": [{
+                    "id": "heading",
+                    "type": "heading",
+                    "tagName": "h1",
+                    "content": "Explicit repair failures"
+                }]
+            }
+        }]
+    });
+    let draft = service
+        .create(
+            tenant_id,
+            SecurityContext::system(),
+            CreatePageInput {
+                translations: vec![PageTranslationInput {
+                    locale: "en".to_string(),
+                    title: "Explicit repair failures".to_string(),
+                    slug: Some("home".to_string()),
+                    meta_title: None,
+                    meta_description: None,
+                }],
+                template: Some("default".to_string()),
+                body: Some(PageBodyInput {
+                    locale: "en".to_string(),
+                    content: serde_json::to_string(&project)?,
+                    format: Some(CONTENT_FORMAT_GRAPESJS.to_string()),
+                    content_json: None,
+                }),
+                channel_slugs: None,
+                publish: false,
+            },
+        )
+        .await?;
+    let body = draft
+        .body
+        .as_ref()
+        .ok_or_else(|| std::io::Error::other("draft body is missing"))?;
+    let digest = Sha256::digest(format!("{}\0{}", body.format, body.content).as_bytes());
+    let revision = format!(
+        "{}:{}",
+        body.updated_at,
+        digest
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>()
+    );
+    service
+        .publish_reviewed(
+            tenant_id,
+            SecurityContext::system(),
+            draft.id,
+            PublishPageInput {
+                expected_version: draft.version,
+                expected_body_revisions: vec![PageBodyRevisionInput {
+                    locale: "en".to_string(),
+                    revision,
+                }],
+                idempotency_key: "repair-failure-publish-v1".to_string(),
+                runtime: reviewed_input(&reviewed),
+            },
+        )
+        .await?;
+
+    let source = page_publish_rebuild_source::Entity::find()
+        .filter(page_publish_rebuild_source::Column::TenantId.eq(tenant_id))
+        .filter(page_publish_rebuild_source::Column::PageId.eq(draft.id))
+        .filter(page_publish_rebuild_source::Column::Locale.eq("en"))
+        .one(db)
+        .await?
+        .ok_or_else(|| std::io::Error::other("publish rebuild source is missing"))?;
+    let binding = page_published_landing_artifact::Entity::find()
+        .filter(page_published_landing_artifact::Column::TenantId.eq(tenant_id))
+        .filter(page_published_landing_artifact::Column::PageId.eq(draft.id))
+        .filter(page_published_landing_artifact::Column::Locale.eq("en"))
+        .one(db)
+        .await?
+        .ok_or_else(|| std::io::Error::other("published binding is missing"))?;
+    let stored_page = page::Entity::find_by_id(draft.id)
+        .one(db)
+        .await?
+        .ok_or_else(|| std::io::Error::other("published page is missing"))?;
+    Ok(PublishedFixture {
+        page_id: draft.id,
+        source,
+        original_artifact_id: binding.artifact_id,
+        page_version: stored_page.version,
+        reviewed,
+    })
+}
+
+async fn rebuild_fixture(
+    service: &PageService,
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+) -> TestResult<RebuiltFixture> {
+    let published = publish_fixture(service, db, tenant_id).await?;
+    let before = repair_state(db, tenant_id, published.page_id).await?;
+    let rebuilt = service
+        .rebuild_immutable_artifact(
+            tenant_id,
+            SecurityContext::system(),
+            published.page_id,
+            RebuildPageArtifactInput {
+                source_id: published.source.id,
+                expected_provenance_hash: published.source.provenance_hash.clone(),
+                idempotency_key: "repair-failure-rebuild-v1".to_string(),
+                runtime: reviewed_input(&published.reviewed),
+            },
+        )
+        .await?;
+    let after = repair_state(db, tenant_id, published.page_id).await?;
+    assert_eq!(after.rebuild_receipts, before.rebuild_receipts + 1);
+    assert_eq!(after.activation_receipts, before.activation_receipts);
+    assert_eq!(after.artifact_count, before.artifact_count + 1);
+    assert_eq!(after.binding_artifact_id, before.binding_artifact_id);
+    assert_eq!(after.page_version, before.page_version);
+    assert_eq!(after.page_status, before.page_status);
+    assert_eq!(after.event_count, before.event_count);
+    Ok(RebuiltFixture { published, rebuilt })
+}
+
+fn reviewed_input(reviewed: &PageBuilderReviewedPublishRuntime) -> ReviewedPagePublishRuntimeInput {
+    ReviewedPagePublishRuntimeInput {
+        format: reviewed.format.clone(),
+        scenario_id: reviewed.scenario_id.clone(),
+        context: reviewed.context.clone(),
+        review_hash: reviewed.review_hash.clone(),
+    }
+}
+
+async fn repair_state(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    page_id: Uuid,
+) -> TestResult<RepairState> {
+    let binding = page_published_landing_artifact::Entity::find()
+        .filter(page_published_landing_artifact::Column::TenantId.eq(tenant_id))
+        .filter(page_published_landing_artifact::Column::PageId.eq(page_id))
+        .filter(page_published_landing_artifact::Column::Locale.eq("en"))
+        .one(db)
+        .await?
+        .ok_or_else(|| std::io::Error::other("published binding is missing"))?;
+    let stored_page = page::Entity::find_by_id(page_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| std::io::Error::other("page is missing"))?;
+    Ok(RepairState {
+        rebuild_receipts: page_artifact_rebuild_operation::Entity::find()
+            .filter(page_artifact_rebuild_operation::Column::TenantId.eq(tenant_id))
+            .filter(page_artifact_rebuild_operation::Column::PageId.eq(page_id))
+            .count(db)
+            .await?,
+        activation_receipts: page_artifact_binding_replacement_operation::Entity::find()
+            .filter(
+                page_artifact_binding_replacement_operation::Column::TenantId.eq(tenant_id),
+            )
+            .filter(page_artifact_binding_replacement_operation::Column::PageId.eq(page_id))
+            .count(db)
+            .await?,
+        artifact_count: page_static_landing_artifact::Entity::find()
+            .filter(page_static_landing_artifact::Column::TenantId.eq(tenant_id))
+            .filter(page_static_landing_artifact::Column::PageId.eq(page_id))
+            .count(db)
+            .await?,
+        binding_artifact_id: binding.artifact_id,
+        page_version: stored_page.version,
+        page_status: stored_page.status,
+        event_count: SysEvents::find().count(db).await?,
+    })
+}
+
+async fn setup_db(tenant_id: Uuid) -> TestResult<DatabaseConnection> {
+    let database_url = format!(
+        "sqlite:file:pages_explicit_artifact_repair_failures_{}?mode=memory&cache=shared",
+        Uuid::new_v4()
+    );
+    let mut options = ConnectOptions::new(database_url);
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    let db = Database::connect(options).await?;
+
+    db.execute(Statement::from_string(
+        DbBackend::Sqlite,
+        "CREATE TABLE tenants (id TEXT PRIMARY KEY NOT NULL)".to_string(),
+    ))
+    .await?;
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        "INSERT INTO tenants (id) VALUES (?)",
+        [tenant_id.into()],
+    ))
+    .await?;
+    db.execute(Statement::from_string(
+        DbBackend::Sqlite,
+        "CREATE TABLE tenant_modules (\
+            id TEXT PRIMARY KEY NOT NULL, \
+            tenant_id TEXT NOT NULL, \
+            module_slug TEXT NOT NULL, \
+            enabled INTEGER NOT NULL, \
+            settings TEXT NOT NULL, \
+            created_at TEXT NOT NULL, \
+            updated_at TEXT NOT NULL\
+        )"
+        .to_string(),
+    ))
+    .await?;
+
+    let manager = SchemaManager::new(&db);
+    SysEventsMigration.up(&manager).await?;
+    for migration in ChannelModule.migrations() {
+        migration.up(&manager).await?;
+    }
+    for migration in PagesModule.migrations() {
+        migration.up(&manager).await?;
+    }
+    Ok(db)
+}

--- a/docs/modules/page-builder-parity-actualization-2026-08-05.md
+++ b/docs/modules/page-builder-parity-actualization-2026-08-05.md
@@ -1,7 +1,7 @@
 # Page Builder / Pages Parity Actualization
 
 Date: 2026-08-07
-Status: current-source-overlay / rebuild-provenance-source-ready / explicit-artifact-rebuild-source-ready / explicit-artifact-binding-replacement-source-ready / explicit-artifact-repair-transport-source-ready / repair-request-contract-harness-source-ready / execution-and-rollout-open
+Status: current-source-overlay / rebuild-provenance-source-ready / explicit-artifact-rebuild-source-ready / explicit-artifact-binding-replacement-source-ready / explicit-artifact-repair-transport-source-ready / repair-request-contract-harness-source-ready / repair-postgres-harness-source-ready / repair-failure-harness-source-ready / execution-and-rollout-open
 
 This overlay reconciles the Page Builder programme with current `main`. It supersedes stale open-checkbox wording in older broad plans where that wording conflicts with merged source. It does not convert source-ready work into executed evidence.
 
@@ -127,6 +127,8 @@ The broad Phase 6 wording should now be read as follows:
 - explicit binding replacement service command: source-ready;
 - bounded tenant-admin repair transports: source-ready;
 - generated transport and request-contract harnesses: source-ready;
+- PostgreSQL repair atomicity harness: source-ready;
+- negative repair failure harness: source-ready;
 - accepted database and transport evidence: pending.
 
 ### Reviewed publish rebuild provenance
@@ -198,6 +200,8 @@ Markers:
 explicit-artifact-repair-transport-source-ready
 explicit-artifact-repair-pages-manage-all-none-actualized
 explicit-artifact-repair-request-contract-harness-source-ready
+explicit-artifact-repair-postgres-harness-source-ready
+explicit-artifact-repair-failure-harness-source-ready
 ```
 
 Pages exposes the two existing repair owner commands through separate bounded adapters.
@@ -228,6 +232,10 @@ Both result shapes omit provenance source id, source publish operation id, stora
 
 A generated contract harness builds the real Pages GraphQL schema and serializes the real Pages OpenAPI document. A separate request-level harness is source-ready to dispatch real GraphQL and Axum requests for both rebuild and activation, covering current-tenant mismatch, missing Manage, Manage-present owner validation and the static public error bodies. Neither harness is counted as execution evidence until the maintainer runs it.
 
+The PostgreSQL repair packet uses isolated schemas and the real Outbox/Pages migrations to retain rebuild/activation receipt constraints, append-only rebuild storage, durable activation lifecycle envelopes and rollback of page/outbox writes when a receipt constraint rejects the transaction.
+
+The negative SQLite repair packet separately retains five owner rejection branches with complete before/after durable state snapshots: corrupt provenance, reviewed-runtime mismatch, stale activation version, invalid replacement artifact and unpublished activation. It does not replace PostgreSQL execution evidence and does not claim any harness has run.
+
 Current repair/rebuild matrix:
 
 | Capability | Source state | Execution state |
@@ -236,7 +244,10 @@ Current repair/rebuild matrix:
 | Explicit append-only repair/rebuild command | Source-ready | SQLite/PostgreSQL and authorization evidence pending |
 | Rebuild idempotent receipt | Source-ready | Replay/conflict evidence pending |
 | Canonical/rebuild storage instance identity | Source-ready | Migration and duplicate-identity evidence pending |
+| PostgreSQL repair receipt/transaction harness | Source-ready | Maintainer PostgreSQL execution pending |
+| Rebuild provenance/runtime negative harness | Source-ready | Maintainer SQLite execution pending |
 | Explicit binding replacement | Source-ready | SQLite/PostgreSQL, fences, lifecycle and cache evidence pending |
+| Activation stale-version/invalid-target/unpublished harness | Source-ready | Maintainer SQLite execution pending |
 | Bounded tenant-admin repair transports | Source-ready | GraphQL/HTTP/OpenAPI execution pending |
 | Generated GraphQL/OpenAPI transport contract harness | Source-ready | Maintainer execution pending |
 | Request-level tenant/Manage/static-error harness | Source-ready | Maintainer execution pending |
@@ -249,18 +260,18 @@ Current repair/rebuild matrix:
 Source parity has advanced, but execution and rollout remain open.
 
 - No new test, source verifier, Cargo, formatting, migration, database, GraphQL, HTTP, OpenAPI, browser, workflow or CI execution is claimed here.
-- No audit, provenance, rebuild, binding replacement, repair transport, request-contract, lifecycle/cache observation or tenant rollout scenario was executed.
+- No audit, provenance, rebuild, binding replacement, repair transport, request-contract, repair-failure, lifecycle/cache observation or tenant rollout scenario was executed.
 - No FFA/FBA promotion is made.
 
 ## Current next cursor
 
-1. Run the generated repair transport and request-contract harnesses plus the immutable artifact audit, provenance, explicit-rebuild, binding-replacement and repair transport/request source guards.
-2. Retain SQLite/PostgreSQL audit evidence for valid canonical/rebuilt records, corruption, partial evidence, Manage present/absent authorization and truncation.
-3. Retain provenance migration/publish evidence for exact locale capture, aggregate-hash mismatch rollback, artifact-row loss and legacy no-backfill behavior.
-4. Retain explicit rebuild evidence for Manage present/absent with `All`/`None` semantics, exact replay, idempotency conflict, provenance corruption, runtime mismatch and byte-for-byte reproduction.
-5. Prove rebuild appends a distinct artifact row while the active binding, page version, lifecycle events and cache generations remain unchanged.
-6. Retain explicit binding replacement evidence for stale page version, stale current artifact, invalid replacement, one-locale mutation, exact replay, one activation per rebuild and unchanged source row.
-7. Observe committed `NodeUpdated`/`NodePublished` processing and route/page/artifact generation changes only after activation commit.
-8. Retain repair transport execution evidence for generated GraphQL/OpenAPI contracts, current-tenant fences, Manage absent/present behavior, static errors and bounded result fields.
-9. Run the static publish resource-limit source guard and accepted real-project policy evidence.
-10. Execute existing metadata conflict/isolation, cache continuity, artifact/HTTP/browser and tenant Wave packets before promotion.
+1. Run the generated repair transport/request-contract harnesses, the PostgreSQL repair atomicity harness and the negative SQLite repair harness; retain accepted execution evidence.
+2. Run their source guards plus the immutable artifact audit, provenance, explicit-rebuild and binding-replacement guards.
+3. Retain SQLite/PostgreSQL audit evidence for valid canonical/rebuilt records, corruption, partial evidence, Manage present/absent authorization and truncation.
+4. Retain provenance migration/publish evidence for exact locale capture, aggregate-hash mismatch rollback, artifact-row loss and legacy no-backfill behavior.
+5. Retain successful explicit rebuild evidence for Manage present/absent with `All`/`None` semantics, exact replay, idempotency conflict and byte-for-byte reproduction; negative provenance/runtime failures are now harness-ready.
+6. Prove rebuild appends a distinct artifact row while the active binding, page version, lifecycle events and cache generations remain unchanged.
+7. Retain successful binding-replacement evidence for stale current artifact, one-locale mutation, exact replay, one activation per rebuild and unchanged source row; stale-version/invalid-target/unpublished failures are now harness-ready.
+8. Observe committed `NodeUpdated`/`NodePublished` processing and route/page/artifact generation changes only after activation commit.
+9. Retain repair transport execution evidence for generated GraphQL/OpenAPI contracts, current-tenant fences, Manage absent/present behavior, static errors and bounded result fields.
+10. Run the static publish resource-limit source guard and accepted real-project policy evidence, then execute existing metadata conflict/isolation, cache continuity, artifact/HTTP/browser and tenant Wave packets before promotion.

--- a/docs/modules/pages-page-builder-repair-failures-continuation-2026-08-07.md
+++ b/docs/modules/pages-page-builder-repair-failures-continuation-2026-08-07.md
@@ -1,0 +1,163 @@
+# Pages / Page Builder Explicit Repair Failure Continuation
+
+Date: 2026-08-07  
+Status: source-ready / explicit-artifact-repair-failure-harness-source-ready / execution-pending  
+Scope: negative owner-command evidence for explicit immutable rebuild and rebuilt-artifact activation
+
+## Rechecked source state
+
+Current `main` already contains:
+
+- retained reviewed publish rebuild provenance;
+- the explicit append-only immutable artifact rebuild owner command;
+- the separate explicit rebuilt-artifact activation owner command;
+- bounded GraphQL/HTTP/OpenAPI repair transports;
+- generated transport and request-level contract harnesses;
+- a PostgreSQL real-migration repair atomicity harness.
+
+The next source gap was the failure matrix that must reject before repair side effects. The existing positive SQLite and PostgreSQL regressions do not retain all five rejection paths in one focused packet.
+
+## Failure harness
+
+Marker:
+
+```text
+explicit-artifact-repair-failure-harness-source-ready
+```
+
+`crates/rustok-pages/tests/explicit_artifact_repair_failures_sqlite.rs` adds five isolated SQLite regressions. Each test creates its own in-memory database, applies the real Pages/Channel migrations plus the canonical `sys_events` migration, creates and reviewed-publishes a Page Builder page using the current canonical body revision shape, and snapshots durable repair state before the rejected command.
+
+The snapshot includes:
+
+- rebuild receipt count;
+- activation receipt count;
+- immutable artifact count;
+- current locale binding artifact id;
+- page version;
+- page lifecycle status;
+- durable outbox row count.
+
+Every negative scenario requires the complete snapshot to remain unchanged across the rejected repair request.
+
+## Rebuild provenance corruption
+
+The retained `page_publish_rebuild_sources.provenance_hash` is deliberately replaced with another syntactically valid SHA-256 value. The request supplies that stored value so validation reaches the retained-source integrity check rather than failing input syntax.
+
+The owner must reject with the `PAGE_ARTIFACT_REBUILD_SOURCE_INVALID` semantic carried by `PagesError::PublishOperationIntegrity`.
+
+The failed rebuild must not:
+
+- insert a rebuild receipt;
+- append an artifact;
+- change the active binding;
+- advance the page version;
+- change lifecycle state;
+- append a durable event;
+- repair or rewrite the corrupted provenance row.
+
+## Reviewed runtime mismatch
+
+A second valid `PageBuilderReviewedPublishRuntime` is created with a different reviewed scenario/context. The selected provenance row itself remains valid.
+
+The rebuild owner must reject the request as `PagesError::PublishRuntimeReviewInvalid` before an artifact or receipt is appended.
+
+The same complete durable state snapshot must remain unchanged.
+
+## Activation stale version
+
+A normal append-only rebuild fixture is created first. The fixture itself asserts the rebuild adds exactly one receipt and one artifact while leaving the binding, page version/status and event count unchanged.
+
+Activation is then called with an expected page version different from the locked current version. The owner must return `PagesError::VersionConflict` with the exact expected and actual values.
+
+No activation receipt, binding mutation, page mutation or event write may occur.
+
+## Activation invalid replacement
+
+A normal rebuilt artifact is deliberately corrupted after rebuild by changing its stored artifact hash while leaving the rebuild receipt intact.
+
+Activation must reject the candidate through `PAGE_ARTIFACT_BINDING_REPLACEMENT_TARGET_INVALID` before `bind_existing_body_in_tx` can switch the locale binding.
+
+The test-owned corruption remains present, but the activation request itself must add no receipt and change no binding, page or outbox state.
+
+## Activation unpublished page
+
+A normal rebuilt fixture is explicitly unpublished through the Pages owner lifecycle before activation. The post-unpublish state is then snapshotted.
+
+Activation supplies the current unpublished page version, so it reaches the published-state fence rather than a stale-version fence. The owner must reject through `PAGE_ARTIFACT_BINDING_REPLACEMENT_CURRENT_CONFLICT`.
+
+The rejected request must leave the post-unpublish binding, page version/status, receipt counts and outbox count unchanged.
+
+## Preserved boundaries
+
+This packet does not:
+
+- change rebuild or activation production code;
+- change migrations or database schema;
+- change GraphQL, HTTP or OpenAPI adapters;
+- execute cache invalidation handling;
+- add automatic audit-to-rebuild behavior;
+- add automatic rebuild-to-activation behavior;
+- promote FFA or FBA.
+
+## Evidence
+
+Machine source evidence:
+
+```text
+crates/rustok-pages/contracts/evidence/pages-explicit-artifact-repair-failures-source.json
+```
+
+Status remains:
+
+```text
+pages_explicit_artifact_repair_failures_source_unvalidated
+```
+
+Execution is empty and every validation flag remains false until maintainer execution.
+
+Fail-closed source guard:
+
+```text
+crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-failures.mjs
+```
+
+The guard is intentionally not run in this slice.
+
+## Updated parity matrix
+
+| Capability | Source state | Execution state |
+| --- | --- | --- |
+| Rebuild provenance corruption rejection | Harness-ready | Execution pending |
+| Rebuild reviewed-runtime mismatch rejection | Harness-ready | Execution pending |
+| Rebuild failure zero-side-effect snapshot | Harness-ready | Execution pending |
+| Activation stale-version rejection | Harness-ready | Execution pending |
+| Activation invalid-replacement rejection | Harness-ready | Execution pending |
+| Activation unpublished-page rejection | Harness-ready | Execution pending |
+| Activation failure zero-side-effect snapshots | Harness-ready | Execution pending |
+| Positive PostgreSQL receipt/transaction atomicity | Harness-ready | Execution pending |
+| Committed activation cache-generation rotation | Source-owned | Observation pending |
+| Automatic repair | Deliberately absent | Not allowed |
+| FFA/FBA promotion | Open | Not promoted |
+
+## Next cursor
+
+1. Run the transport schema, request-contract, PostgreSQL repair and negative SQLite repair harnesses and retain accepted execution evidence.
+2. Run their source guards plus the existing provenance/rebuild/activation guards.
+3. Retain byte-for-byte successful rebuild reproduction evidence alongside the new failure matrix.
+4. Observe a committed successful activation through the real Pages cache invalidation handler and prove route/page/artifact generations rotate only after commit.
+5. Retain browser/tenant rollout evidence and keep automatic audit-to-repair absent before any FFA/FBA promotion.
+
+## Maintainer validation
+
+Suggested commands, intentionally not run in this slice:
+
+```bash
+node crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-failures.mjs
+cargo test -p rustok-pages --test explicit_artifact_repair_failures_sqlite -- --nocapture
+node crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-postgres.mjs
+RUSTOK_PAGES_TEST_DATABASE_URL=postgres://... \
+  cargo test -p rustok-pages --test explicit_artifact_repair_postgres -- --nocapture
+cargo check -p rustok-pages --all-targets
+```
+
+Tests, source verifiers, Cargo commands, formatting, SQLite/PostgreSQL scenarios, lifecycle/cache observation, GraphQL/HTTP requests, workflows and CI were intentionally not run.

--- a/docs/modules/pages-page-builder-repair-postgres-continuation-2026-08-07.md
+++ b/docs/modules/pages-page-builder-repair-postgres-continuation-2026-08-07.md
@@ -1,14 +1,14 @@
 # Pages / Page Builder Explicit Repair PostgreSQL Continuation
 
 Date: 2026-08-07  
-Status: source-ready / explicit-artifact-repair-postgres-harness-source-ready / execution-pending  
+Status: source-ready / explicit-artifact-repair-postgres-harness-source-ready / explicit-artifact-repair-failure-harness-source-ready / execution-pending  
 Scope: PostgreSQL receipt constraints, rebuild/activation transaction atomicity and activation lifecycle evidence
 
 ## Rechecked source state
 
-Current `main` already contains the explicit append-only immutable artifact rebuild command, the separate rebuilt-artifact activation command, bounded GraphQL/HTTP/OpenAPI transports, generated transport-contract coverage and request-level tenant/permission/static-error harnesses.
+Current `main` already contains the explicit append-only immutable artifact rebuild command, the separate rebuilt-artifact activation command, bounded GraphQL/HTTP/OpenAPI transports, generated transport-contract coverage, request-level tenant/permission/static-error harnesses and a focused SQLite negative repair harness.
 
-The remaining database evidence gap is stronger than the existing SQLite regressions: the forward-only rebuild storage identity, rebuild receipt uniqueness, activation receipt uniqueness and event-plus-receipt transaction behavior also need a real PostgreSQL target using the production migrations.
+The PostgreSQL database evidence gap is stronger than the positive SQLite regressions: the forward-only rebuild storage identity, rebuild receipt uniqueness, activation receipt uniqueness and event-plus-receipt transaction behavior also need a real PostgreSQL target using the production migrations. Negative provenance/runtime/version/target/lifecycle rejection paths are now retained separately by the SQLite failure packet and remain execution-pending.
 
 ## PostgreSQL repair harness
 
@@ -106,6 +106,24 @@ After rollback:
 
 This packet proves that a PostgreSQL receipt constraint failure cannot strand a preceding page mutation or durable outbox write from the same owner transaction.
 
+## Negative repair companion packet
+
+Marker:
+
+```text
+explicit-artifact-repair-failure-harness-source-ready
+```
+
+`crates/rustok-pages/tests/explicit_artifact_repair_failures_sqlite.rs` now retains the previously open negative source matrix:
+
+- rebuild provenance corruption rejection;
+- rebuild reviewed-runtime mismatch rejection;
+- activation stale-version rejection;
+- activation invalid-replacement rejection;
+- activation unpublished-page rejection.
+
+Each rejected command is surrounded by a durable state snapshot covering receipts, artifact count, current binding, page version/status and outbox row count. The negative packet does not replace PostgreSQL execution; it separates owner rejection semantics from PostgreSQL constraint/transaction evidence.
+
 ## Evidence boundary
 
 Machine source evidence:
@@ -120,15 +138,28 @@ Status remains:
 pages_explicit_artifact_repair_postgres_source_unvalidated
 ```
 
+Negative source evidence:
+
+```text
+crates/rustok-pages/contracts/evidence/pages-explicit-artifact-repair-failures-source.json
+```
+
+Status remains:
+
+```text
+pages_explicit_artifact_repair_failures_source_unvalidated
+```
+
 Execution is empty. Every validation flag remains false until maintainer execution.
 
-Fail-closed source guard:
+Fail-closed source guards:
 
 ```text
 crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-postgres.mjs
+crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-failures.mjs
 ```
 
-The guard itself is intentionally not run in this slice.
+The guards themselves are intentionally not run in this slice.
 
 ## Updated parity matrix
 
@@ -138,8 +169,10 @@ The guard itself is intentionally not run in this slice.
 | Rebuild PostgreSQL real-migration harness | Source-ready | PostgreSQL execution pending |
 | Rebuild exact replay/conflict on PostgreSQL | Harness-ready | Execution pending |
 | Rebuild receipt unique constraint + rollback | Harness-ready | Execution pending |
+| Rebuild provenance/runtime failure matrix | Harness-ready | SQLite execution pending |
 | Explicit rebuilt-artifact activation | Source-ready | Runtime evidence pending |
 | Activation stale-current fence on PostgreSQL | Harness-ready | Execution pending |
+| Activation stale-version/invalid-target/unpublished matrix | Harness-ready | SQLite execution pending |
 | Activation exact replay/rebuild reuse fence | Harness-ready | Execution pending |
 | Activation receipt unique rebuild constraint | Harness-ready | Execution pending |
 | Activation `NodeUpdated` + `NodePublished` durable pair | Harness-ready | Execution pending |
@@ -150,18 +183,19 @@ The guard itself is intentionally not run in this slice.
 
 ## Next cursor
 
-1. Run the transport schema, request-contract and PostgreSQL repair harnesses and retain accepted execution evidence.
-2. Run the corresponding source guards plus the existing explicit rebuild/activation guards.
-3. Add/retain failure evidence for rebuild provenance corruption and reviewed-runtime mismatch.
-4. Add/retain activation stale-version, invalid replacement and unpublished-page rejection evidence beyond the stale-current/reuse cases in this PostgreSQL packet.
-5. Observe the committed activation lifecycle pair through the real cache invalidation handler and prove route/page/artifact generations rotate only after commit.
-6. Retain tenant/browser rollout evidence and keep automatic audit-to-repair absent before any FFA/FBA promotion.
+1. Run the transport schema, request-contract, PostgreSQL repair and negative SQLite repair harnesses and retain accepted execution evidence.
+2. Run the corresponding source guards plus the existing explicit rebuild/activation/provenance guards.
+3. Retain byte-for-byte successful rebuild reproduction evidence alongside the now source-ready negative matrix.
+4. Observe the committed activation lifecycle pair through the real cache invalidation handler and prove route/page/artifact generations rotate only after commit.
+5. Retain tenant/browser rollout evidence and keep automatic audit-to-repair absent before any FFA/FBA promotion.
 
 ## Maintainer validation
 
 Suggested commands, intentionally not run in this slice:
 
 ```bash
+node crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-failures.mjs
+cargo test -p rustok-pages --test explicit_artifact_repair_failures_sqlite -- --nocapture
 node crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-postgres.mjs
 RUSTOK_PAGES_TEST_DATABASE_URL=postgres://... \
   cargo test -p rustok-pages --test explicit_artifact_repair_postgres -- --nocapture
@@ -172,4 +206,4 @@ node crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-re
 cargo check -p rustok-pages --all-targets
 ```
 
-Tests, source verifiers, Cargo commands, formatting, PostgreSQL execution, lifecycle-handler/cache observation, GraphQL/HTTP requests, workflows and CI were intentionally not run.
+Tests, source verifiers, Cargo commands, formatting, SQLite/PostgreSQL execution, lifecycle-handler/cache observation, GraphQL/HTTP requests, workflows and CI were intentionally not run.


### PR DESCRIPTION
## Summary

- add a focused SQLite negative regression harness for explicit immutable artifact rebuild and rebuilt-artifact activation;
- retain rebuild rejection for corrupted provenance and a different valid reviewed runtime;
- retain activation rejection for stale page version, invalid rebuilt artifact and unpublished page state;
- surround every rejected request with a complete durable state snapshot covering rebuild/activation receipts, immutable artifact count, current locale binding, page version/status and durable outbox count;
- make the activation fixture prove rebuild itself adds one receipt/artifact while leaving binding/version/status/events unchanged;
- add fail-closed source guard and machine evidence that remains explicitly unvalidated;
- actualize the PostgreSQL continuation and canonical Page Builder parity overlay so the negative failure matrix is source-ready rather than still listed as missing.

## Preserved boundaries

- no production Rust service/entity/adapter changes;
- no migration or database-schema changes;
- no GraphQL/HTTP/OpenAPI changes;
- no automatic audit-to-rebuild or rebuild-to-activation behavior;
- no cache-handler execution or generation observation;
- no FFA/FBA promotion.

## Validation

Not run per maintainer instruction. No tests, source verifiers, Cargo commands, formatting, SQLite/PostgreSQL scenarios, lifecycle/cache observation, GraphQL/HTTP requests, workflows or CI were executed.

Suggested maintainer commands:

```bash
node crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-failures.mjs
cargo test -p rustok-pages --test explicit_artifact_repair_failures_sqlite -- --nocapture
node crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-postgres.mjs
RUSTOK_PAGES_TEST_DATABASE_URL=postgres://... cargo test -p rustok-pages --test explicit_artifact_repair_postgres -- --nocapture
cargo check -p rustok-pages --all-targets
```