### PR TITLE
test(pages): retain immutable artifact audit sqlite packet

### DIFF
--- a/crates/rustok-pages/contracts/evidence/pages-immutable-artifact-integrity-audit-sqlite-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-immutable-artifact-integrity-audit-sqlite-source.json
@@ -1,0 +1,71 @@
+{
+  "format": "pages_immutable_artifact_integrity_audit_sqlite_source_v1",
+  "status": "pages_immutable_artifact_integrity_audit_sqlite_source_unvalidated",
+  "generated_at": "2026-08-07",
+  "scope": "SQLite source harness for Pages immutable artifact integrity audit authorization, valid canonical/rebuilt records, corruption, partial materialization evidence and bounded truncation",
+  "source_contract": {
+    "sqlite_isolated_database_per_test": true,
+    "real_outbox_sys_events_migration_used": true,
+    "real_channel_module_migrations_used": true,
+    "real_pages_module_migrations_used": true,
+    "real_reviewed_publish_used": true,
+    "real_explicit_rebuild_used": true,
+    "real_audit_owner_used": true,
+    "pages_manage_present_resolves_all": true,
+    "pages_manage_absent_resolves_none": true,
+    "manage_absent_rejected_before_audit_reads": true,
+    "canonical_artifact_audits_valid": true,
+    "rebuilt_artifact_audits_valid": true,
+    "requested_record_limit_sets_truncated": true,
+    "corrupt_payload_reports_hashed_invalid_finding": true,
+    "partial_materialization_reports_hashed_invalid_finding": true,
+    "finding_code_is_static": true,
+    "finding_locale_is_hashed": true,
+    "finding_record_identity_is_hashed": true,
+    "finding_diagnostic_is_hashed": true,
+    "audit_identity_is_hashed": true,
+    "production_code_changed": false,
+    "database_schema_changed": false,
+    "public_transport_changed": false,
+    "automatic_repair_added": false,
+    "ffa_promoted": false,
+    "fba_promoted": false,
+    "tests_run": false,
+    "source_verifier_run": false,
+    "cargo_run": false,
+    "formatting_run": false,
+    "sqlite_run": false,
+    "workflows_or_ci_run": false
+  },
+  "linked_sources": {
+    "audit_owner": "crates/rustok-pages/src/services/page/artifact_integrity_audit.rs",
+    "reviewed_publish_owner": "crates/rustok-pages/src/services/page/reviewed_publish.rs",
+    "rebuild_owner": "crates/rustok-pages/src/services/page/artifact_rebuild.rs",
+    "artifact_entity": "crates/rustok-pages/src/entities/page_static_landing_artifact.rs"
+  },
+  "harness": {
+    "path": "crates/rustok-pages/tests/immutable_artifact_integrity_audit_sqlite.rs",
+    "tests": [
+      "audit_manage_scope_is_all_or_none_and_public_read_is_denied",
+      "audit_accepts_canonical_and_rebuilt_records_and_truncates_at_requested_limit",
+      "audit_reports_corrupted_immutable_payload_with_hashed_finding",
+      "audit_reports_partial_materialization_evidence_without_exposing_payloads"
+    ]
+  },
+  "suggested_execution": [
+    "node crates/rustok-pages/scripts/verify/verify-pages-immutable-artifact-integrity-audit-sqlite.mjs",
+    "cargo test -p rustok-pages --test immutable_artifact_integrity_audit_sqlite -- --nocapture",
+    "cargo check -p rustok-pages --all-targets"
+  ],
+  "execution": [],
+  "validation": {
+    "source_guard": false,
+    "sqlite_harness": false,
+    "authorization_all_none": false,
+    "valid_canonical_and_rebuilt": false,
+    "bounded_truncation": false,
+    "corrupt_payload": false,
+    "partial_materialization": false,
+    "hashed_findings": false
+  }
+}

--- a/crates/rustok-pages/scripts/verify/verify-pages-immutable-artifact-integrity-audit-sqlite.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-immutable-artifact-integrity-audit-sqlite.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(__filename), "..", "..", "..", "..");
+const read = (relativePath) => fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+
+const evidence = JSON.parse(read(
+  "crates/rustok-pages/contracts/evidence/pages-immutable-artifact-integrity-audit-sqlite-source.json",
+));
+const harness = read("crates/rustok-pages/tests/immutable_artifact_integrity_audit_sqlite.rs");
+const owner = read("crates/rustok-pages/src/services/page/artifact_integrity_audit.rs");
+const continuation = read(
+  "docs/modules/pages-page-builder-artifact-audit-sqlite-continuation-2026-08-07.md",
+);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const requireOrder = (content, values, label) => {
+  let previous = -1;
+  for (const value of values) {
+    const index = content.indexOf(value, previous + 1);
+    if (index < 0) {
+      failures.push(`${label}: missing or out of order ${value}`);
+      return;
+    }
+    previous = index;
+  }
+};
+
+if (evidence.status !== "pages_immutable_artifact_integrity_audit_sqlite_source_unvalidated") {
+  failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push("execution evidence must remain empty");
+}
+for (const key of [
+  "source_guard",
+  "sqlite_harness",
+  "authorization_all_none",
+  "valid_canonical_and_rebuilt",
+  "bounded_truncation",
+  "corrupt_payload",
+  "partial_materialization",
+  "hashed_findings",
+]) {
+  if (evidence.validation?.[key] !== false) failures.push(`validation.${key} must remain false`);
+}
+for (const [key, expected] of Object.entries({
+  sqlite_isolated_database_per_test: true,
+  real_outbox_sys_events_migration_used: true,
+  real_channel_module_migrations_used: true,
+  real_pages_module_migrations_used: true,
+  real_reviewed_publish_used: true,
+  real_explicit_rebuild_used: true,
+  real_audit_owner_used: true,
+  pages_manage_present_resolves_all: true,
+  pages_manage_absent_resolves_none: true,
+  manage_absent_rejected_before_audit_reads: true,
+  canonical_artifact_audits_valid: true,
+  rebuilt_artifact_audits_valid: true,
+  requested_record_limit_sets_truncated: true,
+  corrupt_payload_reports_hashed_invalid_finding: true,
+  partial_materialization_reports_hashed_invalid_finding: true,
+  finding_code_is_static: true,
+  finding_locale_is_hashed: true,
+  finding_record_identity_is_hashed: true,
+  finding_diagnostic_is_hashed: true,
+  audit_identity_is_hashed: true,
+  production_code_changed: false,
+  database_schema_changed: false,
+  public_transport_changed: false,
+  automatic_repair_added: false,
+  ffa_promoted: false,
+  fba_promoted: false,
+  tests_run: false,
+  source_verifier_run: false,
+  cargo_run: false,
+  formatting_run: false,
+  sqlite_run: false,
+  workflows_or_ci_run: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`source_contract.${key} must be ${expected}`);
+  }
+}
+
+for (const test of [
+  "audit_manage_scope_is_all_or_none_and_public_read_is_denied",
+  "audit_accepts_canonical_and_rebuilt_records_and_truncates_at_requested_limit",
+  "audit_reports_corrupted_immutable_payload_with_hashed_finding",
+  "audit_reports_partial_materialization_evidence_without_exposing_payloads",
+]) {
+  requireText(harness, `async fn ${test}()`, "audit SQLite harness");
+  if (!evidence.harness?.tests?.includes(test)) failures.push(`missing harness registration ${test}`);
+}
+
+for (const marker of [
+  "SysEventsMigration.up(&manager).await?",
+  "for migration in ChannelModule.migrations()",
+  "for migration in PagesModule.migrations()",
+  "SecurityContext::system()",
+  "SecurityContext::public_read()",
+  "PermissionScope::All",
+  "PermissionScope::None",
+  ".publish_reviewed(",
+  ".rebuild_immutable_artifact(",
+  ".audit_immutable_artifact_integrity(",
+  "PAGE_ARTIFACT_INTEGRITY_INVALID",
+]) requireText(harness, marker, "audit SQLite harness foundation");
+
+requireOrder(harness, [
+  "let complete = service",
+  "max_records: Some(2)",
+  "assert_eq!(complete.scanned_artifact_count, 2);",
+  "assert_eq!(complete.valid_artifact_count, 2);",
+  "let bounded = service",
+  "max_records: Some(1)",
+  "assert!(bounded.truncated);",
+], "canonical/rebuilt bounded audit ordering");
+requireOrder(harness, [
+  'active.document_html = Set("<main>corrupted immutable payload</main>".to_string());',
+  ".audit_immutable_artifact_integrity(",
+  "assert_eq!(result.invalid_artifact_count, 1);",
+  "assert_eq!(finding.code, PAGE_ARTIFACT_INTEGRITY_INVALID);",
+], "corruption audit ordering");
+requireOrder(harness, [
+  "assert!(artifact.runtime_snapshots.is_some());",
+  "active.runtime_snapshots = Set(None);",
+  ".audit_immutable_artifact_integrity(",
+  "assert_eq!(result.invalid_artifact_count, 1);",
+], "partial materialization audit ordering");
+
+for (const marker of [
+  "DEFAULT_PAGE_ARTIFACT_AUDIT_RECORDS",
+  "MAX_PAGE_ARTIFACT_AUDIT_RECORDS",
+  "MAX_PAGE_ARTIFACT_AUDIT_FINDINGS",
+  "PermissionScope::All",
+  "let fetch_limit = u64::from(max_records).saturating_add(1);",
+  "let truncated = artifact_ids.len() > max_records as usize;",
+  "PAGE_ARTIFACT_INTEGRITY_INVALID",
+  '"Stored landing materialization evidence is partial"',
+  "hex_sha256(record.locale.as_bytes())",
+  "artifact_record_identity_hash(&record)?",
+  "hex_sha256(error.to_string().as_bytes())",
+]) requireText(owner, marker, "audit owner contract");
+
+for (const marker of [
+  "immutable-artifact-audit-sqlite-harness-source-ready",
+  "pages_immutable_artifact_integrity_audit_sqlite_source_unvalidated",
+  "canonical and rebuilt",
+  "partial materialization",
+  "max_records=1",
+  "intentionally not run",
+]) requireText(continuation, marker, "audit SQLite continuation");
+
+for (const forbidden of [
+  "rebuildPageArtifact",
+  "activateRebuiltPageArtifact",
+  "audit_page_artifacts(",
+]) forbidText(harness, forbidden, "audit harness transport/automatic-repair boundary");
+
+if (failures.length > 0) {
+  console.error("[verify-pages-immutable-artifact-integrity-audit-sqlite] FAIL");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+console.log("[verify-pages-immutable-artifact-integrity-audit-sqlite] PASS source_ready=true execution=pending");

--- a/crates/rustok-pages/scripts/verify/verify-pages-immutable-artifact-integrity-audit-sqlite.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-immutable-artifact-integrity-audit-sqlite.mjs
@@ -152,6 +152,13 @@ for (const marker of [
   "artifact_record_identity_hash(&record)?",
   "hex_sha256(error.to_string().as_bytes())",
 ]) requireText(owner, marker, "audit owner contract");
+requireOrder(owner, [
+  "enforce_tenant_wide_manage(&security)?;",
+  "if tenant_id.is_nil()",
+  "if page_id.is_nil()",
+  "let max_records = normalize_max_records(input.max_records)?;",
+  "let txn = self.db.begin().await?;",
+], "audit owner authorization before database reads");
 
 for (const marker of [
   "immutable-artifact-audit-sqlite-harness-source-ready",

--- a/crates/rustok-pages/tests/immutable_artifact_integrity_audit_sqlite.rs
+++ b/crates/rustok-pages/tests/immutable_artifact_integrity_audit_sqlite.rs
@@ -1,0 +1,371 @@
+use std::error::Error;
+use std::sync::Arc;
+
+use rustok_api::{Action, Resource};
+use rustok_channel::ChannelModule;
+use rustok_core::{
+    CONTENT_FORMAT_GRAPESJS, MigrationSource, PermissionScope, SecurityContext,
+};
+use rustok_outbox::{OutboxTransport, SysEventsMigration, TransactionalEventBus};
+use rustok_page_builder::PageBuilderReviewedPublishRuntime;
+use rustok_pages::dto::{
+    CreatePageInput, PageBodyInput, PageBodyRevisionInput, PageTranslationInput, PublishPageInput,
+    RebuildPageArtifactInput, ReviewedPagePublishRuntimeInput,
+};
+use rustok_pages::entities::{
+    page_publish_rebuild_source, page_static_landing_artifact,
+};
+use rustok_pages::services::PageService;
+use rustok_pages::{
+    AuditPageArtifactsInput, PAGE_ARTIFACT_INTEGRITY_AUDIT_FORMAT,
+    PAGE_ARTIFACT_INTEGRITY_INVALID, PagesError, PagesModule,
+};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectOptions, ConnectionTrait, Database, DatabaseConnection,
+    DbBackend, EntityTrait, QueryFilter, Set, Statement,
+};
+use sea_orm_migration::{MigrationTrait, SchemaManager};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+#[derive(Clone)]
+struct PublishedFixture {
+    page_id: Uuid,
+    source: page_publish_rebuild_source::Model,
+    reviewed: PageBuilderReviewedPublishRuntime,
+}
+
+#[tokio::test]
+async fn audit_manage_scope_is_all_or_none_and_public_read_is_denied() -> TestResult<()> {
+    let tenant_id = Uuid::new_v4();
+    let db = setup_db(tenant_id).await?;
+    let service = page_service(&db);
+    let system = SecurityContext::system();
+    let public = SecurityContext::public_read();
+
+    assert_eq!(
+        system.get_scope(Resource::Pages, Action::Manage),
+        PermissionScope::All
+    );
+    assert_eq!(
+        public.get_scope(Resource::Pages, Action::Manage),
+        PermissionScope::None
+    );
+
+    let result = service
+        .audit_immutable_artifact_integrity(
+            tenant_id,
+            public,
+            Uuid::new_v4(),
+            AuditPageArtifactsInput { max_records: Some(1) },
+        )
+        .await;
+    assert!(matches!(
+        result,
+        Err(PagesError::Forbidden(message))
+            if message == "Immutable artifact audit requires tenant-wide pages:manage"
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn audit_accepts_canonical_and_rebuilt_records_and_truncates_at_requested_limit(
+) -> TestResult<()> {
+    let tenant_id = Uuid::new_v4();
+    let db = setup_db(tenant_id).await?;
+    let service = page_service(&db);
+    let fixture = publish_fixture(&service, &db, tenant_id).await?;
+
+    let rebuilt = service
+        .rebuild_immutable_artifact(
+            tenant_id,
+            SecurityContext::system(),
+            fixture.page_id,
+            RebuildPageArtifactInput {
+                source_id: fixture.source.id,
+                expected_provenance_hash: fixture.source.provenance_hash.clone(),
+                idempotency_key: "artifact-audit-rebuild-v1".to_string(),
+                runtime: reviewed_input(&fixture.reviewed),
+            },
+        )
+        .await?;
+    assert!(!rebuilt.replayed);
+
+    let complete = service
+        .audit_immutable_artifact_integrity(
+            tenant_id,
+            SecurityContext::system(),
+            fixture.page_id,
+            AuditPageArtifactsInput { max_records: Some(2) },
+        )
+        .await?;
+    assert_eq!(complete.format, PAGE_ARTIFACT_INTEGRITY_AUDIT_FORMAT);
+    assert_eq!(complete.page_id, fixture.page_id);
+    assert_eq!(complete.max_records, 2);
+    assert_eq!(complete.scanned_artifact_count, 2);
+    assert_eq!(complete.valid_artifact_count, 2);
+    assert_eq!(complete.invalid_artifact_count, 0);
+    assert!(!complete.truncated);
+    assert!(!complete.findings_truncated);
+    assert!(complete.findings.is_empty());
+    assert_eq!(complete.audit_hash.len(), 64);
+
+    let bounded = service
+        .audit_immutable_artifact_integrity(
+            tenant_id,
+            SecurityContext::system(),
+            fixture.page_id,
+            AuditPageArtifactsInput { max_records: Some(1) },
+        )
+        .await?;
+    assert_eq!(bounded.max_records, 1);
+    assert_eq!(bounded.scanned_artifact_count, 1);
+    assert_eq!(bounded.valid_artifact_count, 1);
+    assert_eq!(bounded.invalid_artifact_count, 0);
+    assert!(bounded.truncated);
+    assert!(!bounded.findings_truncated);
+    assert_eq!(bounded.audit_hash.len(), 64);
+    Ok(())
+}
+
+#[tokio::test]
+async fn audit_reports_corrupted_immutable_payload_with_hashed_finding() -> TestResult<()> {
+    let tenant_id = Uuid::new_v4();
+    let db = setup_db(tenant_id).await?;
+    let service = page_service(&db);
+    let fixture = publish_fixture(&service, &db, tenant_id).await?;
+    let artifact = page_static_landing_artifact::Entity::find_by_id(fixture.source.artifact_id)
+        .one(&db)
+        .await?
+        .ok_or_else(|| std::io::Error::other("canonical artifact is missing"))?;
+    let mut active: page_static_landing_artifact::ActiveModel = artifact.into();
+    active.document_html = Set("<main>corrupted immutable payload</main>".to_string());
+    active.update(&db).await?;
+
+    let result = service
+        .audit_immutable_artifact_integrity(
+            tenant_id,
+            SecurityContext::system(),
+            fixture.page_id,
+            AuditPageArtifactsInput { max_records: Some(1) },
+        )
+        .await?;
+    assert_eq!(result.scanned_artifact_count, 1);
+    assert_eq!(result.valid_artifact_count, 0);
+    assert_eq!(result.invalid_artifact_count, 1);
+    assert!(!result.truncated);
+    assert_eq!(result.findings.len(), 1);
+    let finding = &result.findings[0];
+    assert_eq!(finding.artifact_id, fixture.source.artifact_id);
+    assert_eq!(finding.code, PAGE_ARTIFACT_INTEGRITY_INVALID);
+    assert_eq!(finding.locale_hash.len(), 64);
+    assert_eq!(finding.record_identity_hash.len(), 64);
+    assert_eq!(finding.diagnostic_hash.len(), 64);
+    assert_eq!(result.audit_hash.len(), 64);
+    Ok(())
+}
+
+#[tokio::test]
+async fn audit_reports_partial_materialization_evidence_without_exposing_payloads() -> TestResult<()> {
+    let tenant_id = Uuid::new_v4();
+    let db = setup_db(tenant_id).await?;
+    let service = page_service(&db);
+    let fixture = publish_fixture(&service, &db, tenant_id).await?;
+    let artifact = page_static_landing_artifact::Entity::find_by_id(fixture.source.artifact_id)
+        .one(&db)
+        .await?
+        .ok_or_else(|| std::io::Error::other("canonical artifact is missing"))?;
+    assert!(artifact.materialization_hash.is_some());
+    assert!(artifact.materialization_identity.is_some());
+    assert!(artifact.runtime_snapshots.is_some());
+    let mut active: page_static_landing_artifact::ActiveModel = artifact.into();
+    active.runtime_snapshots = Set(None);
+    active.update(&db).await?;
+
+    let result = service
+        .audit_immutable_artifact_integrity(
+            tenant_id,
+            SecurityContext::system(),
+            fixture.page_id,
+            AuditPageArtifactsInput { max_records: Some(1) },
+        )
+        .await?;
+    assert_eq!(result.scanned_artifact_count, 1);
+    assert_eq!(result.valid_artifact_count, 0);
+    assert_eq!(result.invalid_artifact_count, 1);
+    assert_eq!(result.findings.len(), 1);
+    assert_eq!(result.findings[0].code, PAGE_ARTIFACT_INTEGRITY_INVALID);
+    assert_eq!(result.findings[0].diagnostic_hash.len(), 64);
+    assert_eq!(result.audit_hash.len(), 64);
+    Ok(())
+}
+
+fn page_service(db: &DatabaseConnection) -> PageService {
+    let transport = Arc::new(OutboxTransport::new(db.clone()));
+    PageService::new(db.clone(), TransactionalEventBus::new(transport))
+}
+
+async fn publish_fixture(
+    service: &PageService,
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+) -> TestResult<PublishedFixture> {
+    let reviewed = PageBuilderReviewedPublishRuntime::new(
+        "immutable-artifact-audit-sqlite",
+        json!({ "surface": "storefront", "channel": "web" }),
+    )?;
+    let project = json!({
+        "pages": [{
+            "id": "home",
+            "flyPageMeta": {
+                "title": "Immutable artifact audit",
+                "description": "SQLite audit regression",
+                "slug": "home"
+            },
+            "component": {
+                "id": "root",
+                "type": "wrapper",
+                "components": [{
+                    "id": "heading",
+                    "type": "heading",
+                    "tagName": "h1",
+                    "content": "Immutable artifact audit"
+                }]
+            }
+        }]
+    });
+    let draft = service
+        .create(
+            tenant_id,
+            SecurityContext::system(),
+            CreatePageInput {
+                translations: vec![PageTranslationInput {
+                    locale: "en".to_string(),
+                    title: "Immutable artifact audit".to_string(),
+                    slug: Some("home".to_string()),
+                    meta_title: None,
+                    meta_description: None,
+                }],
+                template: Some("default".to_string()),
+                body: Some(PageBodyInput {
+                    locale: "en".to_string(),
+                    content: serde_json::to_string(&project)?,
+                    format: Some(CONTENT_FORMAT_GRAPESJS.to_string()),
+                    content_json: None,
+                }),
+                channel_slugs: None,
+                publish: false,
+            },
+        )
+        .await?;
+    let body = draft
+        .body
+        .as_ref()
+        .ok_or_else(|| std::io::Error::other("draft body is missing"))?;
+    let digest = Sha256::digest(format!("{}\0{}", body.format, body.content).as_bytes());
+    let revision = format!(
+        "{}:{}",
+        body.updated_at,
+        digest
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>()
+    );
+    service
+        .publish_reviewed(
+            tenant_id,
+            SecurityContext::system(),
+            draft.id,
+            PublishPageInput {
+                expected_version: draft.version,
+                expected_body_revisions: vec![PageBodyRevisionInput {
+                    locale: "en".to_string(),
+                    revision,
+                }],
+                idempotency_key: "artifact-audit-publish-v1".to_string(),
+                runtime: reviewed_input(&reviewed),
+            },
+        )
+        .await?;
+
+    let source = page_publish_rebuild_source::Entity::find()
+        .filter(page_publish_rebuild_source::Column::TenantId.eq(tenant_id))
+        .filter(page_publish_rebuild_source::Column::PageId.eq(draft.id))
+        .filter(page_publish_rebuild_source::Column::Locale.eq("en"))
+        .one(db)
+        .await?
+        .ok_or_else(|| std::io::Error::other("publish rebuild source is missing"))?;
+    Ok(PublishedFixture {
+        page_id: draft.id,
+        source,
+        reviewed,
+    })
+}
+
+fn reviewed_input(reviewed: &PageBuilderReviewedPublishRuntime) -> ReviewedPagePublishRuntimeInput {
+    ReviewedPagePublishRuntimeInput {
+        format: reviewed.format.clone(),
+        scenario_id: reviewed.scenario_id.clone(),
+        context: reviewed.context.clone(),
+        review_hash: reviewed.review_hash.clone(),
+    }
+}
+
+async fn setup_db(tenant_id: Uuid) -> TestResult<DatabaseConnection> {
+    let database_url = format!(
+        "sqlite:file:pages_immutable_artifact_audit_{}?mode=memory&cache=shared",
+        Uuid::new_v4()
+    );
+    let mut options = ConnectOptions::new(database_url);
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    let db = Database::connect(options).await?;
+
+    db.execute(Statement::from_string(
+        DbBackend::Sqlite,
+        "CREATE TABLE tenants (id TEXT PRIMARY KEY NOT NULL)".to_string(),
+    ))
+    .await?;
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        "INSERT INTO tenants (id) VALUES (?)",
+        [tenant_id.into()],
+    ))
+    .await?;
+    db.execute(Statement::from_string(
+        DbBackend::Sqlite,
+        "CREATE TABLE tenant_modules (\
+            id TEXT PRIMARY KEY NOT NULL, \
+            tenant_id TEXT NOT NULL, \
+            module_slug TEXT NOT NULL, \
+            enabled INTEGER NOT NULL, \
+            settings TEXT NOT NULL, \
+            created_at TEXT NOT NULL, \
+            updated_at TEXT NOT NULL\
+        )"
+        .to_string(),
+    ))
+    .await?;
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        "INSERT INTO tenant_modules (id, tenant_id, module_slug, enabled, settings, created_at, updated_at) \
+         VALUES (?, ?, 'pages', 1, '{}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+        [Uuid::new_v4().into(), tenant_id.into()],
+    ))
+    .await?;
+
+    let manager = SchemaManager::new(&db);
+    SysEventsMigration.up(&manager).await?;
+    for migration in ChannelModule.migrations() {
+        migration.up(&manager).await?;
+    }
+    for migration in PagesModule.migrations() {
+        migration.up(&manager).await?;
+    }
+    Ok(db)
+}

--- a/docs/modules/pages-page-builder-artifact-audit-sqlite-continuation-2026-08-07.md
+++ b/docs/modules/pages-page-builder-artifact-audit-sqlite-continuation-2026-08-07.md
@@ -1,0 +1,153 @@
+# Pages / Page Builder Immutable Artifact Audit SQLite Continuation
+
+Date: 2026-08-07  
+Status: source-ready / immutable-artifact-audit-sqlite-harness-source-ready / execution-pending  
+Scope: owner-level SQLite evidence for bounded immutable artifact integrity audit behavior
+
+## Rechecked state
+
+The immutable artifact audit owner and bounded GraphQL/HTTP transports are already merged. The repair programme now also has source-ready request, PostgreSQL atomicity, negative repair and after-commit cache packets. What was still missing from the broader parity cursor was a runnable database harness for the audit owner itself.
+
+This continuation adds that missing SQLite source packet without changing production behavior.
+
+Source marker:
+
+```text
+immutable-artifact-audit-sqlite-harness-source-ready
+```
+
+Harness:
+
+```text
+crates/rustok-pages/tests/immutable_artifact_integrity_audit_sqlite.rs
+```
+
+Machine evidence:
+
+```text
+crates/rustok-pages/contracts/evidence/pages-immutable-artifact-integrity-audit-sqlite-source.json
+```
+
+Fail-closed source guard:
+
+```text
+crates/rustok-pages/scripts/verify/verify-pages-immutable-artifact-integrity-audit-sqlite.mjs
+```
+
+## Covered owner scenarios
+
+The harness uses isolated in-memory SQLite databases plus the real Outbox system-event migration, Channel migrations and Pages migrations. It reviewed-publishes a real GrapesJS page through `PageService` and uses the same retained provenance/rebuild owner path already used by the explicit repair packets.
+
+### Authorization
+
+The current Pages Manage model is retained explicitly:
+
+```text
+pages:manage present  -> PermissionScope::All
+pages:manage absent   -> PermissionScope::None
+```
+
+`SecurityContext::system()` is asserted as `All`; `SecurityContext::public_read()` is asserted as `None`. The no-Manage request is rejected by `audit_immutable_artifact_integrity` before page/artifact reads.
+
+### Valid canonical and rebuilt artifacts
+
+The harness reviewed-publishes one canonical artifact and then appends one explicit rebuilt artifact from retained provenance. A bounded owner audit with `max_records=2` must report:
+
+```text
+scanned = 2
+valid   = 2
+invalid = 0
+truncated = false
+```
+
+This binds both accepted instance identities to the actual owner audit:
+
+```text
+canonical
+rebuild:<operation-id>
+```
+
+### Bounded truncation
+
+The same two-artifact dataset is audited with `max_records=1`. Because the owner fetches at most `max_records + 1`, this small fixture is sufficient to prove the bounded truncation branch:
+
+```text
+scanned = 1
+truncated = true
+```
+
+No artificial hundreds-of-row fixture is needed to retain this contract.
+
+### Corruption
+
+The canonical artifact `document_html` is deliberately changed without updating its immutable integrity identities. The audit must keep the command successful but classify the record invalid and expose only the bounded finding contract:
+
+- artifact UUID;
+- fixed `PAGE_ARTIFACT_INTEGRITY_INVALID` code;
+- SHA-256 locale hash;
+- SHA-256 record-identity hash;
+- SHA-256 diagnostic hash.
+
+The raw locale, HTML, CSS, stored hashes, runtime snapshots and internal error text are not asserted as public output.
+
+### Partial materialization
+
+A current materialized artifact initially has all three materialization fields populated. The harness removes only `runtime_snapshots`, retaining a partial tuple. The audit must classify the record invalid through the existing `Stored landing materialization evidence is partial` owner branch and return the same hashed finding shape.
+
+## Preserved boundaries
+
+- No production service/entity/cache/adapter source is changed.
+- No migration or database schema is changed.
+- No GraphQL/HTTP/OpenAPI surface is changed.
+- Audit remains read-only; it does not repair, rebuild, activate, publish, rollback or invalidate caches.
+- No automatic audit-to-rebuild or rebuild-to-activation behavior is introduced.
+- No FFA/FBA promotion is made.
+
+## Evidence state
+
+Status remains:
+
+```text
+pages_immutable_artifact_integrity_audit_sqlite_source_unvalidated
+```
+
+`execution` is empty and every validation flag is false. The source guard and SQLite harness are intentionally not run in this slice.
+
+## Updated broader cursor
+
+| Capability | Source state | Execution state |
+| --- | --- | --- |
+| Immutable artifact audit owner | Source-ready | Runtime evidence pending |
+| Immutable artifact audit GraphQL/HTTP transports | Source-ready | Transport execution pending |
+| Audit Manage `All`/`None` owner authorization | Harness-ready | SQLite execution pending |
+| Audit valid canonical/rebuilt records | Harness-ready | SQLite execution pending |
+| Audit bounded record truncation (`max_records=1`) | Harness-ready | SQLite execution pending |
+| Audit corrupted immutable payload finding | Harness-ready | SQLite execution pending |
+| Audit partial materialization finding | Harness-ready | SQLite execution pending |
+| Audit PostgreSQL locking/scan evidence | Not yet packeted | PostgreSQL source packet still open |
+| Provenance migration/publish rollback/loss evidence | Source owner exists | Dedicated execution packet still open |
+| Explicit repair owner/transport/cache packets | Source-ready | Maintainer execution pending |
+| Automatic repair | Deliberately absent | Not allowed |
+| FFA/FBA promotion | Open | Not promoted |
+
+## Next cursor
+
+1. Execute the new audit SQLite harness and source guard together with the existing audit owner/transport guards; retain accepted evidence.
+2. Add the separate PostgreSQL audit packet for lock-backed scanning and the same valid/corrupt/partial bounded semantics if PostgreSQL-specific evidence is still required after SQLite acceptance.
+3. Retain provenance migration/publish execution evidence for exact locale capture, aggregate-hash mismatch rollback, artifact-row loss and legacy no-backfill behavior.
+4. Execute the repair transport/request/PostgreSQL/failure/cache packets already source-ready.
+5. Execute artifact/HTTP/browser and tenant Wave packets before FFA/FBA promotion.
+6. Keep automatic audit-to-rebuild and rebuild-to-activation chaining absent until accepted execution evidence supports any policy change.
+
+## Maintainer validation
+
+Suggested commands, intentionally not run here:
+
+```bash
+node crates/rustok-pages/scripts/verify/verify-pages-immutable-artifact-integrity-audit-sqlite.mjs
+node crates/rustok-pages/scripts/verify/verify-pages-immutable-artifact-integrity-audit.mjs
+cargo test -p rustok-pages --test immutable_artifact_integrity_audit_sqlite -- --nocapture
+cargo check -p rustok-pages --all-targets
+```
+
+Tests, source verifiers, Cargo commands, formatting, SQLite/PostgreSQL scenarios, GraphQL/HTTP requests, workflows and CI were intentionally not run.


### PR DESCRIPTION
## Summary

- add a focused SQLite database harness for the existing Pages immutable artifact integrity audit owner;
- use real Outbox system-event, Channel and Pages migrations plus real reviewed publish/rebuild owner paths;
- retain current Pages Manage authorization as `All` when present and `None` when absent, with no-Manage rejection before audit reads;
- audit one canonical plus one explicit rebuilt artifact as valid records;
- prove bounded record truncation with `max_records=1` over the two-record dataset;
- corrupt immutable `document_html` and retain one bounded hashed invalid finding;
- remove only `runtime_snapshots` from otherwise complete materialization evidence and retain the partial-evidence invalid finding;
- keep finding output bounded to artifact UUID, static code and SHA-256 locale/record/diagnostic identities;
- add fail-closed source guard, machine evidence and a new audit continuation cursor.

## Preserved boundaries

- no production Rust service/entity/cache/adapter changes;
- no migration or database-schema changes;
- no GraphQL/HTTP/OpenAPI changes;
- audit remains read-only and does not repair/rebuild/activate automatically;
- no FFA/FBA promotion.

## Validation

Not run per maintainer instruction. No tests, source verifiers, Cargo commands, formatting, SQLite/PostgreSQL scenarios, GraphQL/HTTP requests, workflows or CI were executed.

Suggested maintainer commands:

```bash
node crates/rustok-pages/scripts/verify/verify-pages-immutable-artifact-integrity-audit-sqlite.mjs
node crates/rustok-pages/scripts/verify/verify-pages-immutable-artifact-integrity-audit.mjs
cargo test -p rustok-pages --test immutable_artifact_integrity_audit_sqlite -- --nocapture
cargo check -p rustok-pages --all-targets
```