### PR TITLE
test(pages): align repair publish revision fixtures

### DIFF
--- a/crates/rustok-pages/contracts/evidence/pages-explicit-artifact-repair-cache-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-explicit-artifact-repair-cache-source.json
@@ -9,7 +9,7 @@
     "real_outbox_module_migrations_used": true,
     "real_pages_module_migrations_used": true,
     "real_page_service_publish_rebuild_activation_used": true,
-    "canonical_reviewed_publish_body_revision_used": true,
+    "reviewed_publish_revision_matches_owner_updated_at_snapshot": true,
     "canonical_artifact_snapshot_retained_before_damage": true,
     "canonical_artifact_payload_damaged_before_rebuild": true,
     "rebuild_uses_retained_provenance_not_damaged_artifact_payload": true,
@@ -45,6 +45,7 @@
     "workflows_or_ci_run": false
   },
   "linked_sources": {
+    "reviewed_publish_owner": "crates/rustok-pages/src/services/page/reviewed_publish.rs",
     "rebuild_owner": "crates/rustok-pages/src/services/page/artifact_rebuild.rs",
     "activation_owner": "crates/rustok-pages/src/services/page/artifact_binding_replacement.rs",
     "artifact_owner": "crates/rustok-pages/src/services/page_builder_artifact.rs",

--- a/crates/rustok-pages/contracts/evidence/pages-explicit-artifact-repair-failures-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-explicit-artifact-repair-failures-source.json
@@ -9,7 +9,7 @@
     "real_outbox_sys_events_migration_used": true,
     "real_channel_module_migrations_used": true,
     "real_pages_module_migrations_used": true,
-    "canonical_reviewed_publish_body_revision_used": true,
+    "reviewed_publish_revision_matches_owner_updated_at_snapshot": true,
     "corrupt_provenance_rejected": true,
     "corrupt_provenance_error_code_bound": true,
     "corrupt_provenance_adds_no_rebuild_receipt": true,

--- a/crates/rustok-pages/contracts/evidence/pages-explicit-artifact-repair-postgres-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-explicit-artifact-repair-postgres-source.json
@@ -13,6 +13,7 @@
     "real_pages_module_migrations_used": true,
     "minimal_pages_module_enablement_fixture_used": true,
     "transactional_outbox_transport_used": true,
+    "reviewed_publish_revision_matches_owner_updated_at_snapshot": true,
     "reviewed_publish_creates_rebuild_provenance": true,
     "mutable_current_body_is_not_rebuild_authority": true,
     "corrupted_source_artifact_is_retained": true,
@@ -50,6 +51,7 @@
     "workflows_or_ci_run": false
   },
   "linked_sources": {
+    "reviewed_publish_owner": "crates/rustok-pages/src/services/page/reviewed_publish.rs",
     "rebuild_owner": "crates/rustok-pages/src/services/page/artifact_rebuild.rs",
     "activation_owner": "crates/rustok-pages/src/services/page/artifact_binding_replacement.rs",
     "rebuild_migration": "crates/rustok-pages/src/migrations/m20260806_000014_add_explicit_artifact_rebuild.rs",

--- a/crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-cache.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-cache.mjs
@@ -17,6 +17,9 @@ const evidence = JSON.parse(
 const harness = read(
   "crates/rustok-pages/tests/explicit_artifact_repair_cache_postgres.rs",
 );
+const reviewedPublish = read(
+  "crates/rustok-pages/src/services/page/reviewed_publish.rs",
+);
 const rebuildOwner = read(
   "crates/rustok-pages/src/services/page/artifact_rebuild.rs",
 );
@@ -81,7 +84,7 @@ for (const [key, expected] of Object.entries({
   real_outbox_module_migrations_used: true,
   real_pages_module_migrations_used: true,
   real_page_service_publish_rebuild_activation_used: true,
-  canonical_reviewed_publish_body_revision_used: true,
+  reviewed_publish_revision_matches_owner_updated_at_snapshot: true,
   canonical_artifact_snapshot_retained_before_damage: true,
   canonical_artifact_payload_damaged_before_rebuild: true,
   rebuild_uses_retained_provenance_not_damaged_artifact_payload: true,
@@ -140,8 +143,6 @@ for (const marker of [
   "PagesModule",
   "OutboxTransport::new(db.clone())",
   "PageService::new(db.clone(), event_bus)",
-  "Sha256::digest",
-  'format!("{}\\0{}", body.format, body.content)',
   "struct RecordingCachePort",
   "impl PageCacheInvalidationPort for RecordingCachePort",
   "PageCacheInvalidationEventHandler::new",
@@ -149,6 +150,35 @@ for (const marker of [
 ]) {
   requireText(harness, marker, "repair cache harness foundation");
 }
+requireOrder(
+  harness,
+  [
+    "let revision = draft",
+    ".body",
+    ".as_ref()",
+    ".updated_at",
+    ".clone();",
+    ".publish_reviewed(",
+    "revision,",
+  ],
+  "repair cache reviewed publish revision fixture",
+);
+for (const forbidden of [
+  "Sha256::digest",
+  'format!("{}\\0{}", body.format, body.content)',
+  "use sha2::{Digest, Sha256};",
+]) {
+  forbidText(harness, forbidden, "repair cache reviewed publish revision fixture");
+}
+requireOrder(
+  reviewedPublish,
+  [
+    "fn body_revision_snapshot(bodies: &[page_body::Model]) -> BodyRevisionSnapshot",
+    ".map(|body| (body.locale.clone(), body.updated_at.to_string()))",
+    "revisions.sort();",
+  ],
+  "reviewed publish owner revision snapshot",
+);
 
 requireOrder(
   harness,

--- a/crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-failures.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-failures.mjs
@@ -17,6 +17,9 @@ const evidence = JSON.parse(
 const harness = read(
   "crates/rustok-pages/tests/explicit_artifact_repair_failures_sqlite.rs",
 );
+const reviewedPublish = read(
+  "crates/rustok-pages/src/services/page/reviewed_publish.rs",
+);
 const rebuildOwner = read(
   "crates/rustok-pages/src/services/page/artifact_rebuild.rs",
 );
@@ -93,7 +96,7 @@ for (const [key, expected] of Object.entries({
   real_outbox_sys_events_migration_used: true,
   real_channel_module_migrations_used: true,
   real_pages_module_migrations_used: true,
-  canonical_reviewed_publish_body_revision_used: true,
+  reviewed_publish_revision_matches_owner_updated_at_snapshot: true,
   corrupt_provenance_rejected: true,
   corrupt_provenance_error_code_bound: true,
   corrupt_provenance_adds_no_rebuild_receipt: true,
@@ -157,7 +160,6 @@ for (const marker of [
   "SysEventsMigration.up(&manager).await?",
   "for migration in ChannelModule.migrations()",
   "for migration in PagesModule.migrations()",
-  "Sha256::digest",
   "body.updated_at",
   "struct RepairState",
   "rebuild_receipts: u64",
@@ -170,6 +172,35 @@ for (const marker of [
 ]) {
   requireText(harness, marker, "failure harness foundation");
 }
+requireOrder(
+  harness,
+  [
+    "let revision = draft",
+    ".body",
+    ".as_ref()",
+    ".updated_at",
+    ".clone();",
+    ".publish_reviewed(",
+    "revision,",
+  ],
+  "failure harness reviewed publish revision fixture",
+);
+for (const forbidden of [
+  "Sha256::digest",
+  'format!("{}\\0{}", body.format, body.content)',
+  "use sha2::{Digest, Sha256};",
+]) {
+  forbidText(harness, forbidden, "failure harness reviewed publish revision fixture");
+}
+requireOrder(
+  reviewedPublish,
+  [
+    "fn body_revision_snapshot(bodies: &[page_body::Model]) -> BodyRevisionSnapshot",
+    ".map(|body| (body.locale.clone(), body.updated_at.to_string()))",
+    "revisions.sort();",
+  ],
+  "reviewed publish owner revision snapshot",
+);
 if (countText(harness, "assert_eq!(after, before);") !== 5) {
   failures.push("each of the five rejected commands must preserve the complete RepairState snapshot");
 }

--- a/crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-failures.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-failures.mjs
@@ -160,7 +160,6 @@ for (const marker of [
   "SysEventsMigration.up(&manager).await?",
   "for migration in ChannelModule.migrations()",
   "for migration in PagesModule.migrations()",
-  "body.updated_at",
   "struct RepairState",
   "rebuild_receipts: u64",
   "activation_receipts: u64",

--- a/crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-postgres.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-postgres.mjs
@@ -10,6 +10,7 @@ const files = {
   harness: "crates/rustok-pages/tests/explicit_artifact_repair_postgres.rs",
   evidence: "crates/rustok-pages/contracts/evidence/pages-explicit-artifact-repair-postgres-source.json",
   continuation: "docs/modules/pages-page-builder-repair-postgres-continuation-2026-08-07.md",
+  reviewedPublish: "crates/rustok-pages/src/services/page/reviewed_publish.rs",
   rebuildOwner: "crates/rustok-pages/src/services/page/artifact_rebuild.rs",
   activationOwner: "crates/rustok-pages/src/services/page/artifact_binding_replacement.rs",
   rebuildMigration: "crates/rustok-pages/src/migrations/m20260806_000014_add_explicit_artifact_rebuild.rs",
@@ -90,6 +91,7 @@ for (const key of [
   "real_pages_module_migrations_used",
   "minimal_pages_module_enablement_fixture_used",
   "transactional_outbox_transport_used",
+  "reviewed_publish_revision_matches_owner_updated_at_snapshot",
   "reviewed_publish_creates_rebuild_provenance",
   "mutable_current_body_is_not_rebuild_authority",
   "corrupted_source_artifact_is_retained",
@@ -162,6 +164,33 @@ for (const marker of [
   "SysEvents::find_by_id(rolled_back_event_id)",
   "txn.rollback().await?;",
 ]) need(sources.harness, marker, "PostgreSQL repair harness");
+requireOrder(
+  sources.harness,
+  [
+    "let body_revision = draft",
+    ".body",
+    ".as_ref()",
+    ".updated_at",
+    ".clone();",
+    ".publish_reviewed(",
+    "revision: body_revision,",
+  ],
+  "PostgreSQL repair reviewed publish revision fixture",
+);
+for (const marker of [
+  "Sha256::digest",
+  'format!("{}\\0{}", body.format, body.content)',
+  "use sha2::{Digest, Sha256};",
+]) forbid(sources.harness, marker, "PostgreSQL repair reviewed publish revision fixture");
+requireOrder(
+  sources.reviewedPublish,
+  [
+    "fn body_revision_snapshot(bodies: &[page_body::Model]) -> BodyRevisionSnapshot",
+    ".map(|body| (body.locale.clone(), body.updated_at.to_string()))",
+    "revisions.sort();",
+  ],
+  "reviewed publish owner revision snapshot",
+);
 
 for (const marker of [
   "CREATE TABLE page_artifact_rebuild_operations",

--- a/crates/rustok-pages/tests/explicit_artifact_repair_cache_postgres.rs
+++ b/crates/rustok-pages/tests/explicit_artifact_repair_cache_postgres.rs
@@ -30,7 +30,6 @@ use sea_orm::{
 };
 use sea_orm_migration::SchemaManager;
 use serde_json::json;
-use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 const DATABASE_ENV: &str = "RUSTOK_PAGES_TEST_DATABASE_URL";
@@ -222,19 +221,12 @@ async fn rebuilt_bytes_and_activation_cache_rotate_only_after_committed_events_o
             },
         )
         .await?;
-    let body = draft
+    let revision = draft
         .body
         .as_ref()
-        .ok_or_else(|| std::io::Error::other("draft body is missing"))?;
-    let digest = Sha256::digest(format!("{}\0{}", body.format, body.content).as_bytes());
-    let revision = format!(
-        "{}:{}",
-        body.updated_at,
-        digest
-            .iter()
-            .map(|byte| format!("{byte:02x}"))
-            .collect::<String>()
-    );
+        .ok_or_else(|| std::io::Error::other("draft body is missing"))?
+        .updated_at
+        .clone();
     service
         .publish_reviewed(
             tenant_id,

--- a/crates/rustok-pages/tests/explicit_artifact_repair_failures_sqlite.rs
+++ b/crates/rustok-pages/tests/explicit_artifact_repair_failures_sqlite.rs
@@ -26,7 +26,6 @@ use sea_orm::{
 };
 use sea_orm_migration::{MigrationTrait, SchemaManager};
 use serde_json::json;
-use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
@@ -310,19 +309,12 @@ async fn publish_fixture(
             },
         )
         .await?;
-    let body = draft
+    let revision = draft
         .body
         .as_ref()
-        .ok_or_else(|| std::io::Error::other("draft body is missing"))?;
-    let digest = Sha256::digest(format!("{}\0{}", body.format, body.content).as_bytes());
-    let revision = format!(
-        "{}:{}",
-        body.updated_at,
-        digest
-            .iter()
-            .map(|byte| format!("{byte:02x}"))
-            .collect::<String>()
-    );
+        .ok_or_else(|| std::io::Error::other("draft body is missing"))?
+        .updated_at
+        .clone();
     service
         .publish_reviewed(
             tenant_id,

--- a/crates/rustok-pages/tests/explicit_artifact_repair_postgres.rs
+++ b/crates/rustok-pages/tests/explicit_artifact_repair_postgres.rs
@@ -27,7 +27,6 @@ use sea_orm::{
 };
 use sea_orm_migration::SchemaManager;
 use serde_json::json;
-use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 const DATABASE_ENV: &str = "RUSTOK_PAGES_TEST_DATABASE_URL";
@@ -154,19 +153,12 @@ async fn explicit_repair_receipts_and_activation_are_atomic_on_postgres() -> Tes
             },
         )
         .await?;
-    let body = draft
+    let body_revision = draft
         .body
         .as_ref()
-        .ok_or_else(|| std::io::Error::other("draft body is missing"))?;
-    let body_digest = Sha256::digest(format!("{}\0{}", body.format, body.content).as_bytes());
-    let body_revision = format!(
-        "{}:{}",
-        body.updated_at,
-        body_digest
-            .iter()
-            .map(|byte| format!("{byte:02x}"))
-            .collect::<String>()
-    );
+        .ok_or_else(|| std::io::Error::other("draft body is missing"))?
+        .updated_at
+        .clone();
     service
         .publish_reviewed(
             tenant_id,

--- a/docs/modules/pages-page-builder-repair-cache-continuation-2026-08-07.md
+++ b/docs/modules/pages-page-builder-repair-cache-continuation-2026-08-07.md
@@ -44,15 +44,21 @@ crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-cache.m
 
 The harness is environment-gated by `RUSTOK_PAGES_TEST_DATABASE_URL` with `DATABASE_URL` fallback and accepts PostgreSQL URLs only. It creates an isolated schema, applies the real `OutboxModule` and `PagesModule` migrations, seeds only the Pages module enablement fixture, and drops the schema after the scenario.
 
-## Exact rebuild reproduction packet
+## Reviewed publish revision contract
 
-The harness reviewed-publishes one GrapesJS page through `PageService` using the canonical body revision:
+The repair-cache fixture follows the current production `reviewed_publish::body_revision_snapshot` contract exactly:
 
 ```text
-updated_at:sha256(format\0content)
+body.updated_at.to_string()
 ```
 
-It retains the complete canonical `page_static_landing_artifacts` model in memory before deliberately damaging the persisted canonical HTML/body/CSS payload.
+The harness therefore sends the matching created-body DTO `updated_at` value directly. It does not append a content digest. The source guard reads the production reviewed-publish owner and fails closed if the stale `updated_at:sha256(format\0content)` fixture construction returns.
+
+This correction changes test scaffolding only; production reviewed-publish behavior is unchanged.
+
+## Exact rebuild reproduction packet
+
+The harness reviewed-publishes one GrapesJS page through `PageService`, then retains the complete canonical `page_static_landing_artifacts` model in memory before deliberately damaging the persisted canonical HTML/body/CSS payload.
 
 The explicit rebuild then runs from the retained reviewed provenance. The rebuilt row must match the pre-damage canonical model exactly after normalizing only the three storage-instance fields that are expected to differ:
 
@@ -128,6 +134,7 @@ pages_explicit_artifact_repair_cache_source_unvalidated
 
 | Capability | Source state | Execution state |
 | --- | --- | --- |
+| Reviewed publish revision fixture | Owner-aligned | Execution pending |
 | Explicit rebuild owner | Source-ready | Runtime evidence pending |
 | Rebuild provenance/runtime negative matrix | Harness-ready | SQLite execution pending |
 | PostgreSQL rebuild/activation receipt atomicity | Harness-ready | PostgreSQL execution pending |

--- a/docs/modules/pages-page-builder-repair-revision-fixtures-continuation-2026-08-07.md
+++ b/docs/modules/pages-page-builder-repair-revision-fixtures-continuation-2026-08-07.md
@@ -1,0 +1,76 @@
+# Pages / Page Builder Repair Revision Fixture Continuation
+
+Date: 2026-08-07  
+Status: source-ready / repair-reviewed-publish-revision-fixtures-owner-aligned / execution-pending  
+Scope: align repair PostgreSQL, failure and cache harness publish fences with the current reviewed-publish owner contract
+
+## Rechecked production contract
+
+`PageService::publish_reviewed` compares the caller-provided body revision set against `reviewed_publish::body_revision_snapshot`.
+
+The current owner snapshot is:
+
+```text
+(locale, body.updated_at.to_string())
+```
+
+The repair source packets had drifted from that implementation by constructing:
+
+```text
+updated_at:sha256(format\0content)
+```
+
+That composite value is not the current production owner contract and could reject the fixture before the intended rebuild/activation assertions are reached.
+
+## Corrected source packets
+
+The following harnesses now pass the created body DTO's `updated_at` value directly:
+
+```text
+crates/rustok-pages/tests/explicit_artifact_repair_postgres.rs
+crates/rustok-pages/tests/explicit_artifact_repair_failures_sqlite.rs
+crates/rustok-pages/tests/explicit_artifact_repair_cache_postgres.rs
+```
+
+Their corresponding source guards now read:
+
+```text
+crates/rustok-pages/src/services/page/reviewed_publish.rs
+```
+
+and require the fixture to match `body_revision_snapshot`. The guards also forbid the stale SHA-256 revision construction and SHA-256 import in those repair harnesses.
+
+Machine evidence remains unvalidated and records:
+
+```text
+reviewed_publish_revision_matches_owner_updated_at_snapshot = true
+```
+
+## Preserved boundaries
+
+- No production Rust source is changed.
+- No database migration or schema is changed.
+- No GraphQL/HTTP/OpenAPI surface is changed.
+- No rebuild, activation or cache behavior is changed.
+- No automatic audit-to-rebuild or rebuild-to-activation flow is introduced.
+- No FFA/FBA promotion is made.
+
+## Evidence state
+
+The three repair packets remain source-only:
+
+```text
+pages_explicit_artifact_repair_postgres_source_unvalidated
+pages_explicit_artifact_repair_failures_source_unvalidated
+pages_explicit_artifact_repair_cache_source_unvalidated
+```
+
+Their `execution` arrays remain empty and every validation flag remains false. Tests, source guards, Cargo, PostgreSQL/SQLite scenarios, cache-handler execution, workflows and CI are intentionally not run in this cleanup.
+
+## Next cursor
+
+1. Retain the dedicated reviewed-publish provenance migration/publish packet for exact locale/source capture, aggregate-hash mismatch rollback, artifact-row loss and legacy no-backfill behavior.
+2. Then execute the already source-ready audit and repair owner/transport/PostgreSQL/failure/cache packets and retain accepted evidence.
+3. Retain bounded audit/repair transport execution with current-tenant and Pages Manage fencing.
+4. Execute the broader artifact/HTTP/browser and tenant Wave packets before FFA/FBA promotion.
+5. Keep automatic audit-to-rebuild and rebuild-to-activation chaining absent until accepted execution evidence supports a policy change.


### PR DESCRIPTION
## Summary

- align the explicit repair PostgreSQL atomicity, negative SQLite failure and PostgreSQL cache harnesses with the current production reviewed-publish body revision contract;
- replace the stale `updated_at:sha256(format\0content)` fixture construction with the created body DTO's `updated_at` value;
- remove now-unused SHA-256 imports from all three repair harnesses;
- make each repair source guard read `reviewed_publish.rs`, require the current `body_revision_snapshot` owner contract and fail closed if the stale digest construction returns;
- actualize all three unvalidated machine evidence packets with `reviewed_publish_revision_matches_owner_updated_at_snapshot=true`;
- correct the repair-cache continuation and add one focused repair-revision-fixture continuation whose next source cursor is the dedicated provenance migration/publish packet.

## Rechecked production contract

`reviewed_publish::body_revision_snapshot` currently maps each body to `(locale, body.updated_at.to_string())`. The repair fixtures now pass that matching `updated_at` value directly.

## Preserved boundaries

- no production Rust changes;
- no migration or database-schema changes;
- no GraphQL/HTTP/OpenAPI changes;
- no rebuild, activation, lifecycle or cache behavior changes;
- no automatic audit-to-rebuild or rebuild-to-activation behavior;
- no FFA/FBA promotion.

## Validation

Not run. Evidence remains source-only and unvalidated: no tests, source verifiers, Cargo commands, formatting, SQLite/PostgreSQL scenarios, cache-handler execution, GraphQL/HTTP requests, workflows or CI were executed.

Suggested maintainer commands:

```bash
node crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-postgres.mjs
node crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-failures.mjs
node crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-repair-cache.mjs
RUSTOK_PAGES_TEST_DATABASE_URL=postgres://... cargo test -p rustok-pages --test explicit_artifact_repair_postgres -- --nocapture
cargo test -p rustok-pages --test explicit_artifact_repair_failures_sqlite -- --nocapture
RUSTOK_PAGES_TEST_DATABASE_URL=postgres://... cargo test -p rustok-pages --test explicit_artifact_repair_cache_postgres -- --nocapture
cargo check -p rustok-pages --all-targets
```