### PR TITLE
fix(commerce): make marketplace financial integration opt-in

### DIFF
--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -67,6 +67,7 @@ mod-payment   = ["dep:rustok-payment", "rustok-payment/server", "rustok-distribu
 payment-stripe = ["mod-payment", "rustok-payment/stripe"]
 mod-fulfillment = ["dep:rustok-fulfillment", "rustok-distribution/mod-fulfillment"]
 mod-commerce  = ["dep:rustok-commerce", "mod-cart", "mod-customer", "mod-product", "mod-region", "mod-pricing", "mod-inventory", "mod-order", "mod-payment", "mod-fulfillment", "rustok-distribution/mod-commerce"]
+commerce-marketplace-financial = ["mod-commerce", "mod-marketplace_allocation", "mod-marketplace_commission", "mod-marketplace_ledger", "rustok-commerce/marketplace-financial", "rustok-distribution/commerce-marketplace-financial"]
 mod-marketplace_seller = ["dep:rustok-marketplace-seller", "rustok-marketplace-seller/graphql", "rustok-distribution/mod-marketplace_seller"]
 mod-marketplace_listing = ["dep:rustok-marketplace-listing", "rustok-marketplace-listing/graphql", "mod-marketplace_seller", "mod-product", "rustok-distribution/mod-marketplace_listing"]
 mod-marketplace_allocation = ["dep:rustok-marketplace-allocation", "mod-order", "mod-marketplace_seller", "mod-marketplace_listing", "rustok-distribution/mod-marketplace_allocation"]
@@ -130,7 +131,7 @@ rustok-order     = { workspace = true, optional = true }
 rustok-payment   = { workspace = true, optional = true }
 rustok-secrets.workspace = true
 rustok-fulfillment = { workspace = true, optional = true }
-rustok-commerce  = { workspace = true, optional = true }
+rustok-commerce  = { workspace = true, optional = true, default-features = false }
 rustok-marketplace-seller = { workspace = true, optional = true }
 rustok-marketplace-listing = { workspace = true, optional = true }
 rustok-marketplace-allocation = { workspace = true, optional = true }

--- a/apps/server/src/services/commerce_provider_runtime.rs
+++ b/apps/server/src/services/commerce_provider_runtime.rs
@@ -92,7 +92,7 @@ pub fn attach_commerce_provider_registries(
         host.with_shared_value(runtime)
     };
 
-    #[cfg(feature = "mod-commerce")]
+    #[cfg(feature = "commerce-marketplace-financial")]
     let host = {
         let runtime = server
             .shared_get::<rustok_commerce::MarketplaceFinancialRuntime>()
@@ -188,7 +188,10 @@ pub fn attach_commerce_provider_registries(
         host.with_shared_value(runtime)
     };
 
-    #[cfg(all(feature = "mod-commerce", feature = "mod-payment"))]
+    #[cfg(all(
+        feature = "commerce-marketplace-financial",
+        feature = "mod-payment"
+    ))]
     let host = {
         let observers = server
             .shared_get::<rustok_payment::PaymentProviderEventObservers>()

--- a/apps/server/src/services/commerce_provider_runtime.rs
+++ b/apps/server/src/services/commerce_provider_runtime.rs
@@ -1,4 +1,6 @@
 use rustok_api::HostRuntimeContext;
+#[cfg(feature = "mod-marketplace_seller")]
+use std::sync::Arc;
 
 use crate::services::server_runtime_context::ServerRuntimeContext;
 

--- a/apps/server/src/services/mod.rs
+++ b/apps/server/src/services/mod.rs
@@ -69,7 +69,7 @@ pub mod index_replay_runtime_composition;
 pub mod marketplace_catalog;
 pub mod marketplace_catalog_adapter;
 pub mod marketplace_catalog_cache;
-#[cfg(feature = "mod-commerce")]
+#[cfg(feature = "commerce-marketplace-financial")]
 pub mod marketplace_financial_worker;
 pub mod mcp_management;
 pub mod mcp_management_authority;

--- a/apps/server/src/services/module_event_dispatcher.rs
+++ b/apps/server/src/services/module_event_dispatcher.rs
@@ -30,7 +30,7 @@ pub fn spawn_module_event_dispatcher(
 
     #[cfg(feature = "mod-commerce")]
     spawn_paid_order_label_worker_if_enabled(ctx);
-    #[cfg(feature = "mod-commerce")]
+    #[cfg(feature = "commerce-marketplace-financial")]
     spawn_marketplace_financial_worker_if_enabled(ctx);
     #[cfg(feature = "mod-payment")]
     spawn_payment_provider_event_worker_if_enabled(ctx);
@@ -68,7 +68,7 @@ fn enrich_runtime_extensions_after_event_start(
         enriched.insert(rustok_pages::PagesCacheReadRuntime::new(provider));
     }
 
-    #[cfg(feature = "mod-commerce")]
+    #[cfg(feature = "commerce-marketplace-financial")]
     {
         let financial_runtime = ctx
             .shared_get::<rustok_commerce::MarketplaceFinancialRuntime>()
@@ -125,7 +125,7 @@ fn spawn_paid_order_label_worker_if_enabled(ctx: &ServerRuntimeContext) {
     );
 }
 
-#[cfg(feature = "mod-commerce")]
+#[cfg(feature = "commerce-marketplace-financial")]
 fn spawn_marketplace_financial_worker_if_enabled(ctx: &ServerRuntimeContext) {
     if !ctx.settings().runtime.runs_background_workers()
         || ctx.shared_contains::<
@@ -291,7 +291,7 @@ pub fn build_shared_runtime_extensions_with_host_providers(
         extensions.insert(fulfillment_registry);
     }
 
-    #[cfg(feature = "mod-commerce")]
+    #[cfg(feature = "commerce-marketplace-financial")]
     {
         let financial_runtime = runtime_ctx
             .shared_get::<rustok_commerce::MarketplaceFinancialRuntime>()
@@ -609,9 +609,9 @@ mod tests {
                     .is_some()
             );
         }
-        #[cfg(feature = "mod-commerce")]
+        #[cfg(feature = "commerce-marketplace-financial")]
         assert!(extensions.contains::<rustok_commerce::MarketplaceFinancialRuntime>());
-        #[cfg(all(feature = "mod-commerce", feature = "mod-payment"))]
+        #[cfg(all(feature = "commerce-marketplace-financial", feature = "mod-payment"))]
         assert!(extensions.contains::<rustok_payment::PaymentProviderEventObservers>());
     }
 }

--- a/crates/rustok-commerce/Cargo.toml
+++ b/crates/rustok-commerce/Cargo.toml
@@ -6,6 +6,15 @@ license.workspace = true
 description.workspace = true
 autotests = false
 
+[features]
+default = []
+marketplace-financial = [
+    "dep:rustok-marketplace",
+    "dep:rustok-marketplace-allocation",
+    "dep:rustok-marketplace-commission",
+    "dep:rustok-marketplace-ledger",
+]
+
 [dependencies]
 anyhow.workspace = true
 async-graphql = { workspace = true, features = ["decimal"] }
@@ -23,10 +32,10 @@ rustok-order.workspace = true
 rustok-payment.workspace = true
 rustok-fulfillment.workspace = true
 rustok-tenant.workspace = true
-rustok-marketplace = { path = "../rustok-marketplace" }
-rustok-marketplace-allocation = { path = "../rustok-marketplace-allocation" }
-rustok-marketplace-commission = { path = "../rustok-marketplace-commission" }
-rustok-marketplace-ledger = { path = "../rustok-marketplace-ledger" }
+rustok-marketplace = { path = "../rustok-marketplace", optional = true }
+rustok-marketplace-allocation = { path = "../rustok-marketplace-allocation", optional = true }
+rustok-marketplace-commission = { path = "../rustok-marketplace-commission", optional = true }
+rustok-marketplace-ledger = { path = "../rustok-marketplace-ledger", optional = true }
 flex.workspace = true
 async-trait.workspace = true
 axum.workspace = true
@@ -75,6 +84,7 @@ path = "tests/checkout_fulfillment_label_boundary_test.rs"
 [[test]]
 name = "checkout_marketplace_economics_checkpoint"
 path = "tests/checkout_marketplace_economics_checkpoint.rs"
+required-features = ["marketplace-financial"]
 
 [[test]]
 name = "checkout_service_test"
@@ -111,6 +121,7 @@ path = "tests/inventory_service_test.rs"
 [[test]]
 name = "marketplace_reversal_recovery_source"
 path = "tests/marketplace_reversal_recovery_source.rs"
+required-features = ["marketplace-financial"]
 
 [[test]]
 name = "module"

--- a/crates/rustok-commerce/docs/implementation-plan.md
+++ b/crates/rustok-commerce/docs/implementation-plan.md
@@ -1,6 +1,6 @@
 # RusToK ecommerce implementation plan
 
-Last reviewed: 2026-07-30
+Last reviewed: 2026-08-07
 
 ## Source of truth
 
@@ -185,13 +185,18 @@ These are source-contract defects, not verification-only tasks.
 - [x] Confirm that Commerce migrations and `MarketplaceFinancialRuntime` require
   marketplace owners even though `CommerceModule`, `rustok-module.toml`, and the
   `mod-commerce` feature do not declare or enable them.
-- [ ] Make marketplace financial integration an explicit optional Commerce capability;
-  base Commerce must compose and migrate without any marketplace owner.
-- [ ] Align Cargo features, `rustok-module.toml`, `CommerceModule::dependencies`,
-  distribution/server features, migration sources, listeners, GraphQL/REST surfaces,
-  and worker startup with that optional capability.
-- [ ] Add a lightweight source guard for the minimal Commerce topology and retain
-  compiled/migration evidence only when the validation policy allows it.
+- [x] Make marketplace financial integration an explicit optional Commerce capability;
+  base Commerce composes and migrates without any marketplace owner in source.
+- [x] Align the base `rustok-module.toml` / `CommerceModule::dependencies` contract with
+  marketplace-free `mod-commerce`, and align Cargo capability features,
+  distribution/server composition, migration sources, listeners, GraphQL/REST/OpenAPI
+  surfaces, runtime injection, and worker startup with explicit marketplace financial
+  selection.
+- [x] Add `scripts/verify/verify-commerce-marketplace-financial-capability.mjs` as the
+  lightweight source guard for the minimal Commerce topology; it is source-reviewed
+  but not executed in this slice.
+- [ ] Execute the minimal/base and marketplace-financial compile/migration profiles and
+  the new topology guard, then retain evidence when validation policy allows it.
 - [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,
   Payment, and Fulfillment concrete services behind host-composed owner ports.
 - [x] Publish the order-owned `OrderReadPort` for complete order, return, and
@@ -589,6 +594,7 @@ Source inspection is not execution evidence.
 - [ ] `node scripts/verify/verify-commerce-checkout-owner-stage-boundary.mjs`
 - [ ] `node scripts/verify/verify-commerce-storefront-staged-checkout-cutover.mjs`
 - [ ] `node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs`
+- [ ] `node scripts/verify/verify-commerce-marketplace-financial-capability.mjs`
 - [ ] `cargo xtask module validate commerce`
 - [ ] `cargo xtask module validate order`
 - [ ] `cargo xtask module validate payment`
@@ -620,15 +626,18 @@ Source inspection is not execution evidence.
   complete/post-order, and storefront order/return/change cutovers without changing
   mutation, payment, or fulfillment ownership; unmounted admin compatibility GET
   handlers remain explicit source debt.
-- [ ] Execute the new public-error, typed-lifecycle, storefront-cutover, and order-read
-  static guards against a repository checkout and retain their output.
+- [ ] Execute the new public-error, typed-lifecycle, storefront-cutover, order-read,
+  and marketplace-financial topology static guards against a repository checkout and
+  retain their output.
 
 ### Compile/tests
 
-- [ ] `cargo check -p rustok-commerce --lib`
+- [ ] `cargo check -p rustok-commerce --lib --no-default-features`
+- [ ] `cargo check -p rustok-commerce --lib --features marketplace-financial`
 - [ ] `cargo test -p rustok-commerce --test checkout_marketplace_economics_checkpoint`
 - [ ] `cargo check -p rustok-order --all-features`
-- [ ] `cargo check -p rustok-server --features mod-commerce`
+- [ ] `cargo check -p rustok-server --no-default-features --features mod-commerce`
+- [ ] `cargo check -p rustok-server --no-default-features --features commerce-marketplace-financial`
 - [ ] Targeted `OrderReadPort` six-operation, locale fallback, context, typed-error,
   host-composition, admin REST, mounted GraphQL, and storefront HTTP transport tests.
 - [ ] `cargo test -p rustok-order --test order_checkout_identity`
@@ -785,6 +794,10 @@ Source inspection is not execution evidence.
   return/order-change projections, and cut storefront, GraphQL, and mounted admin
   post-order reads while preserving mutations, refunds, unmounted admin compatibility
   GET source, and unvalidated status.
+- [x] Make marketplace financial integration an explicit optional Commerce capability:
+  keep base Commerce marketplace-free, gate financial migrations/transports/listeners/
+  workers, compose owner modules only through explicit capability features, and fail
+  closed before capture when marketplace lines reach a base-only checkout.
 
 ## Change rules
 

--- a/crates/rustok-commerce/src/controllers/mod.rs
+++ b/crates/rustok-commerce/src/controllers/mod.rs
@@ -2,7 +2,9 @@ pub mod admin;
 #[path = "admin/checkout_operations.rs"]
 pub(crate) mod checkout_operations;
 mod common;
+#[cfg(feature = "marketplace-financial")]
 pub(crate) mod marketplace_financial;
+#[cfg(feature = "marketplace-financial")]
 pub(crate) mod marketplace_reversal_financial;
 pub mod products;
 mod reconciliation;
@@ -26,6 +28,7 @@ pub struct CommerceHttpRuntime {
         crate::graphql_runtime::CommerceFulfillmentLifecycleReadRuntime,
     order_read_runtime: crate::graphql_runtime::CommerceOrderReadRuntime,
     product_catalog_read_runtime: rustok_product::ProductCatalogReadRuntime,
+    #[cfg(feature = "marketplace-financial")]
     marketplace_financial_runtime: crate::MarketplaceFinancialRuntime,
 }
 
@@ -79,11 +82,13 @@ impl CommerceHttpRuntime {
         self.product_catalog_read_runtime.read_port()
     }
 
+    #[cfg(feature = "marketplace-financial")]
     fn marketplace_financial_operator_service(&self) -> crate::MarketplaceFinancialOperatorService {
         self.marketplace_financial_runtime
             .operator_service(self.db_clone(), self.event_bus())
     }
 
+    #[cfg(feature = "marketplace-financial")]
     fn marketplace_reversal_operator_service(&self) -> crate::MarketplaceReversalOperatorService {
         self.marketplace_financial_runtime
             .reversal_operator_service(self.db_clone())
@@ -127,11 +132,12 @@ impl CommerceHttpRuntime {
                     "Commerce HTTP routes require ProductCatalogReadRuntime in HostRuntimeContext"
                 )
             })?;
+        #[cfg(feature = "marketplace-financial")]
         let marketplace_financial_runtime = runtime
             .shared_get::<crate::MarketplaceFinancialRuntime>()
             .ok_or_else(|| {
                 anyhow::anyhow!(
-                    "Commerce HTTP routes require MarketplaceFinancialRuntime in HostRuntimeContext"
+                    "Commerce marketplace-financial HTTP routes require MarketplaceFinancialRuntime in HostRuntimeContext"
                 )
             })?;
         Ok(Self {
@@ -147,6 +153,7 @@ impl CommerceHttpRuntime {
             fulfillment_lifecycle_read_runtime,
             order_read_runtime,
             product_catalog_read_runtime,
+            #[cfg(feature = "marketplace-financial")]
             marketplace_financial_runtime,
         })
     }
@@ -154,7 +161,7 @@ impl CommerceHttpRuntime {
 
 pub fn axum_router(runtime: &HostRuntimeContext) -> anyhow::Result<axum::Router> {
     let state = CommerceHttpRuntime::from_host(runtime)?;
-    Ok(axum::Router::new()
+    let router = axum::Router::new()
         .nest("/store", store::axum_router())
         .nest("/admin", admin::axum_router())
         .nest(
@@ -168,11 +175,11 @@ pub fn axum_router(runtime: &HostRuntimeContext) -> anyhow::Result<axum::Router>
         .nest(
             "/admin/fulfillment-provider-operations",
             reconciliation::axum_router(),
-        )
-        .nest(
-            "/admin/marketplace-financial",
-            marketplace_financial::axum_router()
-                .merge(marketplace_reversal_financial::axum_router()),
-        )
-        .with_state(state))
+        );
+    #[cfg(feature = "marketplace-financial")]
+    let router = router.nest(
+        "/admin/marketplace-financial",
+        marketplace_financial::axum_router().merge(marketplace_reversal_financial::axum_router()),
+    );
+    Ok(router.with_state(state))
 }

--- a/crates/rustok-commerce/src/entities/mod.rs
+++ b/crates/rustok-commerce/src/entities/mod.rs
@@ -1,10 +1,15 @@
 pub mod checkout_inventory_reservation;
+#[cfg(feature = "marketplace-financial")]
 pub mod checkout_marketplace_economics_checkpoint;
 pub mod checkout_operation;
 pub mod checkout_order_plan;
+#[cfg(feature = "marketplace-financial")]
 pub mod marketplace_financial_operation;
+#[cfg(feature = "marketplace-financial")]
 pub mod marketplace_paid_event_inbox;
+#[cfg(feature = "marketplace-financial")]
 pub mod marketplace_reversal_adaptation_failure;
+#[cfg(feature = "marketplace-financial")]
 pub mod marketplace_reversal_event_inbox;
 pub mod return_completion_command;
 pub mod return_completion_operation;

--- a/crates/rustok-commerce/src/graphql/mod.rs
+++ b/crates/rustok-commerce/src/graphql/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "marketplace-financial")]
 mod marketplace_financial;
 mod mutations;
 mod product_catalog;
@@ -14,6 +15,7 @@ use sea_orm::DatabaseConnection;
 
 use crate::storefront_channel::is_module_enabled_for_request_channel;
 
+#[cfg(feature = "marketplace-financial")]
 pub use marketplace_financial::{
     MarketplaceFinancialOperationGql, MarketplaceFinancialSweepFailureGql,
     MarketplaceFinancialSweepGql, MarketplacePaidEventGql,
@@ -70,6 +72,7 @@ fn optional_text_shape(value: Option<&str>) -> &'static str {
     }
 }
 
+#[cfg(feature = "marketplace-financial")]
 #[derive(MergedObject, Default)]
 pub struct CommerceQueryRoot(
     query::CommerceQuery,
@@ -77,14 +80,24 @@ pub struct CommerceQueryRoot(
     marketplace_financial::MarketplaceFinancialQuery,
 );
 
+#[cfg(not(feature = "marketplace-financial"))]
+#[derive(MergedObject, Default)]
+pub struct CommerceQueryRoot(query::CommerceQuery, product_catalog::ProductCatalogQuery);
+
 pub type CommerceQuery = CommerceQueryRoot;
 
+#[cfg(feature = "marketplace-financial")]
 #[allow(non_upper_case_globals)]
 pub const CommerceQuery: CommerceQueryRoot = CommerceQueryRoot(
     query::CommerceQuery,
     product_catalog::ProductCatalogQuery,
     marketplace_financial::MarketplaceFinancialQuery,
 );
+
+#[cfg(not(feature = "marketplace-financial"))]
+#[allow(non_upper_case_globals)]
+pub const CommerceQuery: CommerceQueryRoot =
+    CommerceQueryRoot(query::CommerceQuery, product_catalog::ProductCatalogQuery);
 
 pub(crate) const MODULE_SLUG: &str = "commerce";
 pub(crate) const PRODUCT_MODULE_SLUG: &str = "product";

--- a/crates/rustok-commerce/src/graphql/mutations/mod.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/mod.rs
@@ -1,5 +1,6 @@
 use async_graphql::MergedObject;
 
+#[cfg(feature = "marketplace-financial")]
 use super::marketplace_financial::MarketplaceFinancialMutation;
 
 #[path = "safe_cart.rs"]
@@ -32,6 +33,7 @@ mod typed_shipping_enrichment_helper;
 #[path = "typed_shipping_option_helper.rs"]
 mod typed_shipping_option_helper;
 
+#[cfg(feature = "marketplace-financial")]
 #[derive(MergedObject, Default)]
 pub struct CommerceMutation(
     pub cart::CommerceCartMutation,
@@ -44,7 +46,19 @@ pub struct CommerceMutation(
     pub MarketplaceFinancialMutation,
 );
 
-#[cfg(test)]
+#[cfg(not(feature = "marketplace-financial"))]
+#[derive(MergedObject, Default)]
+pub struct CommerceMutation(
+    pub cart::CommerceCartMutation,
+    pub catalog::CommerceCatalogMutation,
+    pub checkout::CommerceCheckoutMutation,
+    pub fulfillment::CommerceFulfillmentMutation,
+    pub pricing::CommercePricingMutation,
+    pub provider_operations::CommerceProviderMutation,
+    pub reconciliation::CommerceReconciliationMutation,
+);
+
+#[cfg(all(test, feature = "marketplace-financial"))]
 mod tests {
     use async_graphql::{EmptySubscription, Schema};
 

--- a/crates/rustok-commerce/src/graphql_runtime.rs
+++ b/crates/rustok-commerce/src/graphql_runtime.rs
@@ -299,6 +299,7 @@ pub(crate) fn product_catalog_read_runtime_for_current_graphql_scope(
 pub struct CommerceGraphqlRuntimeData {
     payment_provider_registry: PaymentProviderRegistry,
     fulfillment_provider_registry: FulfillmentProviderRegistry,
+    #[cfg(feature = "marketplace-financial")]
     marketplace_financial_runtime: crate::MarketplaceFinancialRuntime,
     shipping_option_read_runtime: CommerceShippingOptionReadRuntime,
     fulfillment_lifecycle_read_runtime: CommerceFulfillmentLifecycleReadRuntime,
@@ -315,6 +316,7 @@ impl CommerceGraphqlRuntimeData {
         self.fulfillment_provider_registry.clone()
     }
 
+    #[cfg(feature = "marketplace-financial")]
     pub fn marketplace_financial_runtime(&self) -> crate::MarketplaceFinancialRuntime {
         self.marketplace_financial_runtime.clone()
     }
@@ -347,10 +349,11 @@ pub fn attach_schema_data(
         fulfillment_provider_registry: inputs
             .shared_get::<FulfillmentProviderRegistry>()
             .unwrap_or_else(FulfillmentProviderRegistry::with_manual_provider),
+        #[cfg(feature = "marketplace-financial")]
         marketplace_financial_runtime: inputs
             .shared_get::<crate::MarketplaceFinancialRuntime>()
             .ok_or_else(|| {
-                "commerce GraphQL requires MarketplaceFinancialRuntime in host composition"
+                "commerce marketplace-financial GraphQL requires MarketplaceFinancialRuntime in host composition"
                     .to_string()
             })?,
         shipping_option_read_runtime: inputs

--- a/crates/rustok-commerce/src/lib.rs
+++ b/crates/rustok-commerce/src/lib.rs
@@ -10,10 +10,10 @@
 
 use async_trait::async_trait;
 use rustok_core::{
-    MigrationSource, ModuleEventListenerContext, ModuleEventListenerRegistry,
-    ModuleRuntimeExtensions, RusToKModule,
+    MigrationSource, ModuleEventListenerContext, ModuleEventListenerRegistry, RusToKModule,
 };
 use rustok_fulfillment::providers::FulfillmentProviderRegistry;
+#[cfg(feature = "marketplace-financial")]
 use rustok_outbox::TransactionalEventBus;
 use sea_orm_migration::MigrationTrait;
 
@@ -54,11 +54,9 @@ pub use services::{
     CheckoutInventoryOrderAdoptionResult, CheckoutInventoryOrderAdoptionService,
     CheckoutInventoryReservationError, CheckoutInventoryReservationExecutor,
     CheckoutInventoryReservationJournal, CheckoutInventoryReservationResult,
-    CheckoutInventoryReservationStatus, CheckoutMarketplaceFinancialError,
-    CheckoutMarketplaceFinancialResult, CheckoutMarketplaceFinancialStage,
-    CheckoutOperationCheckpoint, CheckoutOperationError, CheckoutOperationJournal,
-    CheckoutOperationResult, CheckoutOperationStage, CheckoutOperationStatus,
-    CheckoutOrderConfirmationError, CheckoutOrderConfirmationExecutor,
+    CheckoutInventoryReservationStatus, CheckoutOperationCheckpoint, CheckoutOperationError,
+    CheckoutOperationJournal, CheckoutOperationResult, CheckoutOperationStage,
+    CheckoutOperationStatus, CheckoutOrderConfirmationError, CheckoutOrderConfirmationExecutor,
     CheckoutOrderConfirmationResult, CheckoutOrderCreationError, CheckoutOrderCreationExecutor,
     CheckoutOrderCreationResult, CheckoutOrderPlanError, CheckoutOrderPlanJournal,
     CheckoutOrderPlanPayload, CheckoutOrderPlanRecord, CheckoutOrderPlanResult,
@@ -70,9 +68,25 @@ pub use services::{
     CompleteReturnRefundInput, CompleteReturnResolutionInput, CreateReturnDecisionInput,
     DEFAULT_CHECKOUT_LEASE_SECONDS, DEFAULT_RETURN_COMPLETION_LEASE_SECONDS,
     ExchangeDifferenceRefundInput, FulfillmentCreateLabelRecoveryService,
-    FulfillmentReconciliationService, IngestMarketplacePaidEvent, IngestMarketplaceReversalEvent,
-    JournaledCheckoutError, JournaledCheckoutResult, JournaledCheckoutService,
-    MAX_CHECKOUT_LEASE_SECONDS, MAX_RETURN_COMPLETION_LEASE_SECONDS,
+    FulfillmentReconciliationService, JournaledCheckoutError, JournaledCheckoutResult,
+    JournaledCheckoutService, MAX_CHECKOUT_LEASE_SECONDS, MAX_RETURN_COMPLETION_LEASE_SECONDS,
+    OrderChangeOrchestrationService, PaidOrderCreateLabelSweepReport,
+    PaidOrderCreateLabelSweepService, PaymentOrchestrationError, PaymentOrchestrationResult,
+    PaymentOrchestrationService, PlanCheckoutInventoryReservation, PostOrderOrchestrationError,
+    PostOrderOrchestrationService, RecoveringStagedCheckoutError, RecoveringStagedCheckoutResult,
+    RecoveringStagedCheckoutService, RefundReconciliationService, ReturnClaimDecisionInput,
+    ReturnCompletionOperationCheckpoint, ReturnCompletionOperationError,
+    ReturnCompletionOperationJournal, ReturnCompletionOperationResult,
+    ReturnCompletionOperationStage, ReturnCompletionOperationStatus,
+    ReturnCompletionOrchestrationService, ReturnDecisionInput, ReturnDecisionResponse,
+    ReturnExchangeDecisionInput, ReturnRefundDecisionInput, ShippingProfileService,
+    StagedCheckoutError, StagedCheckoutResult, StagedCheckoutService, StoreContextError,
+    StoreContextResult, StoreContextService,
+};
+#[cfg(feature = "marketplace-financial")]
+pub use services::{
+    CheckoutMarketplaceFinancialError, CheckoutMarketplaceFinancialResult,
+    CheckoutMarketplaceFinancialStage, IngestMarketplacePaidEvent, IngestMarketplaceReversalEvent,
     MarketplaceFinancialOperationError, MarketplaceFinancialOperationJournal,
     MarketplaceFinancialOperationOperatorView, MarketplaceFinancialOperationResult,
     MarketplaceFinancialOperationStatus, MarketplaceFinancialOperatorError,
@@ -93,18 +107,7 @@ pub use services::{
     MarketplaceReversalEventOperatorView, MarketplaceReversalEventStatus,
     MarketplaceReversalEventSweepFailure, MarketplaceReversalEventSweepReport,
     MarketplaceReversalOperatorError, MarketplaceReversalOperatorResult,
-    MarketplaceReversalOperatorService, OrderChangeOrchestrationService,
-    PaidOrderCreateLabelSweepReport, PaidOrderCreateLabelSweepService, PaymentOrchestrationError,
-    PaymentOrchestrationResult, PaymentOrchestrationService, PlanCheckoutInventoryReservation,
-    PostOrderOrchestrationError, PostOrderOrchestrationService, RecoveringStagedCheckoutError,
-    RecoveringStagedCheckoutResult, RecoveringStagedCheckoutService, RefundReconciliationService,
-    ReturnClaimDecisionInput, ReturnCompletionOperationCheckpoint, ReturnCompletionOperationError,
-    ReturnCompletionOperationJournal, ReturnCompletionOperationResult,
-    ReturnCompletionOperationStage, ReturnCompletionOperationStatus,
-    ReturnCompletionOrchestrationService, ReturnDecisionInput, ReturnDecisionResponse,
-    ReturnExchangeDecisionInput, ReturnRefundDecisionInput, ShippingProfileService,
-    StagedCheckoutError, StagedCheckoutResult, StagedCheckoutService, StoreContextError,
-    StoreContextResult, StoreContextService,
+    MarketplaceReversalOperatorService,
 };
 pub(crate) use services::{FulfillmentOrchestrationError, FulfillmentOrchestrationService};
 pub(crate) use storefront_checkout_pricing::StorefrontCheckoutPricingResolver;
@@ -161,40 +164,28 @@ impl RusToKModule for CommerceModule {
             fulfillment_registry,
         ));
 
-        let financial_runtime = ctx
-            .extensions
-            .get::<MarketplaceFinancialRuntime>()
-            .cloned()
-            .expect(
-                "commerce module requires MarketplaceFinancialRuntime in ModuleRuntimeExtensions",
-            );
-        let event_bus = ctx
-            .extensions
-            .get::<TransactionalEventBus>()
-            .cloned()
-            .expect("commerce module requires TransactionalEventBus in ModuleRuntimeExtensions");
-        registry.register(services::MarketplacePaidOrderFinancialHandler::new(
-            ctx.db.clone(),
-            event_bus,
-            financial_runtime.ledger_port(),
-        ));
-    }
-
-    fn register_runtime_extensions(
-        &self,
-        extensions: &mut ModuleRuntimeExtensions,
-    ) -> rustok_core::Result<()> {
-        let marketplace_financial_runtime = extensions
-            .get::<MarketplaceFinancialRuntime>()
-            .cloned()
-            .ok_or_else(|| {
-                rustok_core::Error::Validation(
-                    "commerce module requires MarketplaceFinancialRuntime in runtime extensions"
-                        .to_string(),
-                )
-            })?;
-        extensions.insert(marketplace_financial_runtime);
-        Ok(())
+        #[cfg(feature = "marketplace-financial")]
+        {
+            let financial_runtime = ctx
+                .extensions
+                .get::<MarketplaceFinancialRuntime>()
+                .cloned()
+                .expect(
+                    "commerce marketplace-financial capability requires MarketplaceFinancialRuntime in ModuleRuntimeExtensions",
+                );
+            let event_bus = ctx
+                .extensions
+                .get::<TransactionalEventBus>()
+                .cloned()
+                .expect(
+                    "commerce marketplace-financial capability requires TransactionalEventBus in ModuleRuntimeExtensions",
+                );
+            registry.register(services::MarketplacePaidOrderFinancialHandler::new(
+                ctx.db.clone(),
+                event_bus,
+                financial_runtime.ledger_port(),
+            ));
+        }
     }
 }
 

--- a/crates/rustok-commerce/src/migrations/mod.rs
+++ b/crates/rustok-commerce/src/migrations/mod.rs
@@ -23,11 +23,17 @@ mod m20260716_000003_add_order_field_cache_generation_trigger;
 mod m20260716_000004_create_return_completion_operations;
 mod m20260716_000005_enforce_return_completion_resolution_identity;
 mod m20260716_000006_create_return_completion_commands;
+#[cfg(feature = "marketplace-financial")]
 mod m20260721_000001_create_checkout_marketplace_economics_checkpoints;
+#[cfg(feature = "marketplace-financial")]
 mod m20260721_000002_create_marketplace_financial_operations;
+#[cfg(feature = "marketplace-financial")]
 mod m20260721_000003_create_marketplace_paid_event_inbox;
+#[cfg(feature = "marketplace-financial")]
 mod m20260721_000004_create_marketplace_reversal_event_inbox;
+#[cfg(feature = "marketplace-financial")]
 mod m20260721_000005_enforce_marketplace_reversal_event_mysql_integrity;
+#[cfg(feature = "marketplace-financial")]
 mod m20260721_000006_create_marketplace_reversal_adaptation_failures;
 mod m20260721_000007_align_language_agnostic_locale_contract;
 
@@ -35,7 +41,7 @@ use rustok_core::MigrationDependencyDescriptor;
 use sea_orm_migration::MigrationTrait;
 
 pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-    vec![
+    let mut migrations: Vec<Box<dyn MigrationTrait>> = vec![
         Box::new(m20250130_000017_create_commerce_collections::Migration),
         Box::new(m20250130_000018_create_commerce_categories::Migration),
         Box::new(m20260316_000005_create_order_field_definitions::Migration),
@@ -59,18 +65,27 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260716_000004_create_return_completion_operations::Migration),
         Box::new(m20260716_000005_enforce_return_completion_resolution_identity::Migration),
         Box::new(m20260716_000006_create_return_completion_commands::Migration),
-        Box::new(m20260721_000001_create_checkout_marketplace_economics_checkpoints::Migration),
+    ];
+
+    #[cfg(feature = "marketplace-financial")]
+    migrations.extend(vec![
+        Box::new(m20260721_000001_create_checkout_marketplace_economics_checkpoints::Migration)
+            as Box<dyn MigrationTrait>,
         Box::new(m20260721_000002_create_marketplace_financial_operations::Migration),
         Box::new(m20260721_000003_create_marketplace_paid_event_inbox::Migration),
         Box::new(m20260721_000004_create_marketplace_reversal_event_inbox::Migration),
         Box::new(m20260721_000005_enforce_marketplace_reversal_event_mysql_integrity::Migration),
         Box::new(m20260721_000006_create_marketplace_reversal_adaptation_failures::Migration),
-        Box::new(m20260721_000007_align_language_agnostic_locale_contract::Migration),
-    ]
+    ]);
+
+    migrations.push(Box::new(
+        m20260721_000007_align_language_agnostic_locale_contract::Migration,
+    ));
+    migrations
 }
 
 pub fn migration_dependencies() -> Vec<MigrationDependencyDescriptor> {
-    vec![
+    let mut dependencies = vec![
         MigrationDependencyDescriptor::new(
             "m20250130_000017_create_commerce_collections",
             vec!["m20250130_000012_create_commerce_products"],
@@ -177,6 +192,10 @@ pub fn migration_dependencies() -> Vec<MigrationDependencyDescriptor> {
             "m20260716_000006_create_return_completion_commands",
             vec!["m20260716_000005_enforce_return_completion_resolution_identity"],
         ),
+    ];
+
+    #[cfg(feature = "marketplace-financial")]
+    dependencies.extend(vec![
         MigrationDependencyDescriptor::new(
             "m20260721_000001_create_checkout_marketplace_economics_checkpoints",
             vec![
@@ -219,12 +238,14 @@ pub fn migration_dependencies() -> Vec<MigrationDependencyDescriptor> {
                 "m20260714_000117_lock_provider_event_normalized_facts",
             ],
         ),
-        MigrationDependencyDescriptor::new(
-            "m20260721_000007_align_language_agnostic_locale_contract",
-            vec![
-                "m20250130_000017_create_commerce_collections",
-                "m20250130_000018_create_commerce_categories",
-            ],
-        ),
-    ]
+    ]);
+
+    dependencies.push(MigrationDependencyDescriptor::new(
+        "m20260721_000007_align_language_agnostic_locale_contract",
+        vec![
+            "m20250130_000017_create_commerce_collections",
+            "m20250130_000018_create_commerce_categories",
+        ],
+    ));
+    dependencies
 }

--- a/crates/rustok-commerce/src/openapi.rs
+++ b/crates/rustok-commerce/src/openapi.rs
@@ -4,6 +4,10 @@ use utoipa::openapi::request_body::RequestBodyBuilder;
 use utoipa::openapi::response::{ResponseBuilder, ResponsesBuilder};
 use utoipa::openapi::{Content, Ref};
 
+#[cfg(feature = "marketplace-financial")]
+#[path = "openapi_marketplace_financial.rs"]
+mod marketplace_financial;
+
 #[derive(OpenApi)]
 #[openapi(
     paths(
@@ -67,20 +71,6 @@ use utoipa::openapi::{Content, Ref};
         crate::controllers::return_completion_operations::list_return_completion_operations,
         crate::controllers::return_completion_operations::show_return_completion_operation,
         crate::controllers::return_completion_operations::retry_return_completion_operation,
-        crate::controllers::marketplace_financial::list_financial_operator_review,
-        crate::controllers::marketplace_financial::show_financial_operation,
-        crate::controllers::marketplace_financial::retry_financial_operation,
-        crate::controllers::marketplace_financial::list_paid_event_operator_review,
-        crate::controllers::marketplace_financial::show_paid_event,
-        crate::controllers::marketplace_financial::retry_paid_event,
-        crate::controllers::marketplace_financial::run_recovery_sweep,
-        crate::controllers::marketplace_reversal_financial::list_operator_review,
-        crate::controllers::marketplace_reversal_financial::show_event,
-        crate::controllers::marketplace_reversal_financial::retry_event,
-        crate::controllers::marketplace_reversal_financial::run_recovery_sweep,
-        crate::controllers::marketplace_reversal_financial::list_adaptation_failures_operator_review,
-        crate::controllers::marketplace_reversal_financial::show_adaptation_failure,
-        crate::controllers::marketplace_reversal_financial::retry_adaptation_failure,
     ),
     components(
         schemas(
@@ -154,30 +144,22 @@ use utoipa::openapi::{Content, Ref};
             crate::controllers::checkout_operations::AdminCheckoutCompensationSweepResponse,
             crate::controllers::return_completion_operations::AdminListReturnCompletionOperationsParams,
             crate::services::ReturnCompletionOperationResponse,
-            crate::controllers::marketplace_financial::MarketplaceFinancialSweepInput,
-            crate::controllers::marketplace_financial::MarketplaceFinancialOperationResponse,
-            crate::controllers::marketplace_financial::MarketplacePaidEventResponse,
-            crate::controllers::marketplace_financial::MarketplaceFinancialSweepFailureResponse,
-            crate::controllers::marketplace_financial::MarketplaceFinancialSweepResponse,
-            crate::controllers::marketplace_reversal_financial::MarketplaceReversalSweepInput,
-            crate::controllers::marketplace_reversal_financial::MarketplaceReversalEventResponse,
-            crate::controllers::marketplace_reversal_financial::MarketplaceReversalAdaptationFailureResponse,
-            crate::controllers::marketplace_reversal_financial::MarketplaceReversalSweepFailureResponse,
-            crate::controllers::marketplace_reversal_financial::MarketplaceReversalSweepResponse,
         )
     ),
     modifiers(&CommerceOpenApiAddon),
     tags(
         (name = "commerce", description = "Ecommerce endpoints"),
         (name = "store", description = "Storefront ecommerce endpoints"),
-        (name = "admin", description = "Administrative ecommerce endpoints"),
-        (name = "admin-marketplace-financial", description = "Marketplace financial recovery and reconciliation endpoints")
+        (name = "admin", description = "Administrative ecommerce endpoints")
     )
 )]
 pub struct CommerceApiDoc;
 
 pub fn openapi_document() -> utoipa::openapi::OpenApi {
-    CommerceApiDoc::openapi()
+    let mut openapi = CommerceApiDoc::openapi();
+    #[cfg(feature = "marketplace-financial")]
+    openapi.merge(marketplace_financial::openapi_document());
+    openapi
 }
 
 pub struct CommerceOpenApiAddon;

--- a/crates/rustok-commerce/src/openapi_marketplace_financial.rs
+++ b/crates/rustok-commerce/src/openapi_marketplace_financial.rs
@@ -1,0 +1,43 @@
+use utoipa::OpenApi;
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        crate::controllers::marketplace_financial::list_financial_operator_review,
+        crate::controllers::marketplace_financial::show_financial_operation,
+        crate::controllers::marketplace_financial::retry_financial_operation,
+        crate::controllers::marketplace_financial::list_paid_event_operator_review,
+        crate::controllers::marketplace_financial::show_paid_event,
+        crate::controllers::marketplace_financial::retry_paid_event,
+        crate::controllers::marketplace_financial::run_recovery_sweep,
+        crate::controllers::marketplace_reversal_financial::list_operator_review,
+        crate::controllers::marketplace_reversal_financial::show_event,
+        crate::controllers::marketplace_reversal_financial::retry_event,
+        crate::controllers::marketplace_reversal_financial::run_recovery_sweep,
+        crate::controllers::marketplace_reversal_financial::list_adaptation_failures_operator_review,
+        crate::controllers::marketplace_reversal_financial::show_adaptation_failure,
+        crate::controllers::marketplace_reversal_financial::retry_adaptation_failure,
+    ),
+    components(
+        schemas(
+            crate::controllers::marketplace_financial::MarketplaceFinancialSweepInput,
+            crate::controllers::marketplace_financial::MarketplaceFinancialOperationResponse,
+            crate::controllers::marketplace_financial::MarketplacePaidEventResponse,
+            crate::controllers::marketplace_financial::MarketplaceFinancialSweepFailureResponse,
+            crate::controllers::marketplace_financial::MarketplaceFinancialSweepResponse,
+            crate::controllers::marketplace_reversal_financial::MarketplaceReversalSweepInput,
+            crate::controllers::marketplace_reversal_financial::MarketplaceReversalEventResponse,
+            crate::controllers::marketplace_reversal_financial::MarketplaceReversalAdaptationFailureResponse,
+            crate::controllers::marketplace_reversal_financial::MarketplaceReversalSweepFailureResponse,
+            crate::controllers::marketplace_reversal_financial::MarketplaceReversalSweepResponse,
+        )
+    ),
+    tags(
+        (name = "admin-marketplace-financial", description = "Marketplace financial recovery and reconciliation endpoints")
+    )
+)]
+pub struct MarketplaceFinancialApiDoc;
+
+pub fn openapi_document() -> utoipa::openapi::OpenApi {
+    MarketplaceFinancialApiDoc::openapi()
+}

--- a/crates/rustok-commerce/src/services/checkout_stage_pipeline_owner_ports.rs
+++ b/crates/rustok-commerce/src/services/checkout_stage_pipeline_owner_ports.rs
@@ -2,8 +2,11 @@ use std::sync::Arc;
 
 use rustok_cart::{CartCheckoutPort, PreparedCartCheckoutSnapshot};
 use rustok_inventory::InventoryReservationIdentityPort;
+#[cfg(feature = "marketplace-financial")]
 use rustok_marketplace_allocation::MarketplaceAllocationCommandPort;
+#[cfg(feature = "marketplace-financial")]
 use rustok_marketplace_commission::MarketplaceCommissionCommandPort;
+#[cfg(feature = "marketplace-financial")]
 use rustok_marketplace_ledger::MarketplaceLedgerCommandPort;
 use rustok_outbox::TransactionalEventBus;
 use rustok_payment::providers::PaymentProviderRegistry;
@@ -13,16 +16,20 @@ use uuid::Uuid;
 use super::{
     CheckoutCompletedState, CheckoutFinalizationError, CheckoutFinalizationExecutor,
     CheckoutFulfillmentCreatedState, CheckoutFulfillmentStageError,
-    CheckoutFulfillmentStageExecutor, CheckoutMarketplaceAllocationError,
-    CheckoutMarketplaceAllocationStage, CheckoutMarketplaceCommissionError,
-    CheckoutMarketplaceCommissionStage, CheckoutMarketplaceEconomicsCheckpointError,
-    CheckoutMarketplaceEconomicsCheckpointJournal, CheckoutMarketplaceFinancialError,
-    CheckoutMarketplaceFinancialStage, CheckoutOperationError, CheckoutOperationJournal,
+    CheckoutFulfillmentStageExecutor, CheckoutOperationError, CheckoutOperationJournal,
     CheckoutOperationStage, CheckoutOperationStatus, CheckoutOrderPlanError,
     CheckoutOrderPlanPayload, CheckoutOrderStageError, CheckoutOrderStageExecutor,
     CheckoutPaymentCapturedState, CheckoutPaymentReadyState, CheckoutPaymentStageError,
-    CheckoutPaymentStageExecutor, RecordCheckoutMarketplaceEconomicsCheckpoint,
-    build_marketplace_economics_evidence, validate_marketplace_economics_checkpoint,
+    CheckoutPaymentStageExecutor,
+};
+#[cfg(feature = "marketplace-financial")]
+use super::{
+    CheckoutMarketplaceAllocationError, CheckoutMarketplaceAllocationStage,
+    CheckoutMarketplaceCommissionError, CheckoutMarketplaceCommissionStage,
+    CheckoutMarketplaceEconomicsCheckpointError, CheckoutMarketplaceEconomicsCheckpointJournal,
+    CheckoutMarketplaceFinancialError, CheckoutMarketplaceFinancialStage,
+    RecordCheckoutMarketplaceEconomicsCheckpoint, build_marketplace_economics_evidence,
+    validate_marketplace_economics_checkpoint,
 };
 
 #[derive(Debug, Error)]
@@ -33,12 +40,16 @@ pub enum CheckoutStagePipelineError {
     Plan(#[from] CheckoutOrderPlanError),
     #[error(transparent)]
     OrderStage(Box<CheckoutOrderStageError>),
+    #[cfg(feature = "marketplace-financial")]
     #[error(transparent)]
     MarketplaceAllocation(#[from] CheckoutMarketplaceAllocationError),
+    #[cfg(feature = "marketplace-financial")]
     #[error(transparent)]
     MarketplaceCommission(#[from] CheckoutMarketplaceCommissionError),
+    #[cfg(feature = "marketplace-financial")]
     #[error(transparent)]
     MarketplaceEconomicsCheckpoint(#[from] CheckoutMarketplaceEconomicsCheckpointError),
+    #[cfg(feature = "marketplace-financial")]
     #[error(transparent)]
     MarketplaceFinancial(#[from] CheckoutMarketplaceFinancialError),
     #[error(transparent)]
@@ -60,12 +71,17 @@ impl From<CheckoutOrderStageError> for CheckoutStagePipelineError {
 }
 
 pub struct CheckoutStagePipeline {
+    #[cfg(feature = "marketplace-financial")]
     db: sea_orm::DatabaseConnection,
     operation_journal: CheckoutOperationJournal,
     order_stage: CheckoutOrderStageExecutor,
+    #[cfg(feature = "marketplace-financial")]
     marketplace_allocation_stage: Option<CheckoutMarketplaceAllocationStage>,
+    #[cfg(feature = "marketplace-financial")]
     marketplace_commission_stage: Option<CheckoutMarketplaceCommissionStage>,
+    #[cfg(feature = "marketplace-financial")]
     marketplace_economics_checkpoint_journal: CheckoutMarketplaceEconomicsCheckpointJournal,
+    #[cfg(feature = "marketplace-financial")]
     marketplace_financial_stage: Option<CheckoutMarketplaceFinancialStage>,
     payment_stage: CheckoutPaymentStageExecutor,
     fulfillment_stage: CheckoutFulfillmentStageExecutor,
@@ -80,6 +96,7 @@ impl CheckoutStagePipeline {
         cart_checkout_port: Arc<dyn CartCheckoutPort>,
     ) -> Self {
         Self {
+            #[cfg(feature = "marketplace-financial")]
             db: db.clone(),
             operation_journal: CheckoutOperationJournal::new(db.clone()),
             order_stage: CheckoutOrderStageExecutor::new(
@@ -87,10 +104,14 @@ impl CheckoutStagePipeline {
                 event_bus.clone(),
                 inventory_port,
             ),
+            #[cfg(feature = "marketplace-financial")]
             marketplace_allocation_stage: None,
+            #[cfg(feature = "marketplace-financial")]
             marketplace_commission_stage: None,
+            #[cfg(feature = "marketplace-financial")]
             marketplace_economics_checkpoint_journal:
                 CheckoutMarketplaceEconomicsCheckpointJournal::new(db.clone()),
+            #[cfg(feature = "marketplace-financial")]
             marketplace_financial_stage: None,
             payment_stage: CheckoutPaymentStageExecutor::new(db.clone()),
             fulfillment_stage: CheckoutFulfillmentStageExecutor::new(db.clone(), event_bus),
@@ -98,6 +119,7 @@ impl CheckoutStagePipeline {
         }
     }
 
+    #[cfg(feature = "marketplace-financial")]
     pub fn with_marketplace_allocation_port(
         mut self,
         marketplace_allocation_port: Arc<dyn MarketplaceAllocationCommandPort>,
@@ -108,6 +130,7 @@ impl CheckoutStagePipeline {
         self
     }
 
+    #[cfg(feature = "marketplace-financial")]
     pub fn with_marketplace_commission_port(
         mut self,
         marketplace_commission_port: Arc<dyn MarketplaceCommissionCommandPort>,
@@ -118,6 +141,7 @@ impl CheckoutStagePipeline {
         self
     }
 
+    #[cfg(feature = "marketplace-financial")]
     pub fn with_marketplace_ledger_port(
         mut self,
         marketplace_ledger_port: Arc<dyn MarketplaceLedgerCommandPort>,
@@ -229,6 +253,7 @@ impl CheckoutStagePipeline {
             .map_err(Into::into)
     }
 
+    #[cfg(feature = "marketplace-financial")]
     async fn ensure_marketplace_economics_before_capture(
         &self,
         tenant_id: Uuid,
@@ -333,6 +358,26 @@ impl CheckoutStagePipeline {
         Ok(())
     }
 
+    #[cfg(not(feature = "marketplace-financial"))]
+    async fn ensure_marketplace_economics_before_capture(
+        &self,
+        _tenant_id: Uuid,
+        _actor_id: Uuid,
+        _operation_id: Uuid,
+        _lease_owner: &str,
+        payment_ready: &CheckoutPaymentReadyState,
+    ) -> CheckoutStagePipelineResult<()> {
+        if payment_ready.plan.payload.marketplace_lines.is_empty() {
+            Ok(())
+        } else {
+            Err(CheckoutStagePipelineError::Conflict(
+                "marketplace checkout lines require the `marketplace-financial` Commerce capability"
+                    .to_string(),
+            ))
+        }
+    }
+
+    #[cfg(feature = "marketplace-financial")]
     async fn ensure_marketplace_financial_after_capture(
         &self,
         tenant_id: Uuid,
@@ -352,6 +397,24 @@ impl CheckoutStagePipeline {
             .post_after_capture_if_present(tenant_id, actor_id, lease_owner, payment_captured)
             .await?;
         Ok(())
+    }
+
+    #[cfg(not(feature = "marketplace-financial"))]
+    async fn ensure_marketplace_financial_after_capture(
+        &self,
+        _tenant_id: Uuid,
+        _actor_id: Uuid,
+        _lease_owner: &str,
+        payment_captured: &CheckoutPaymentCapturedState,
+    ) -> CheckoutStagePipelineResult<()> {
+        if payment_captured.plan.payload.marketplace_lines.is_empty() {
+            Ok(())
+        } else {
+            Err(CheckoutStagePipelineError::Conflict(
+                "marketplace checkout lines require the `marketplace-financial` Commerce capability"
+                    .to_string(),
+            ))
+        }
     }
 
     async fn load_payment_ready_state(

--- a/crates/rustok-commerce/src/services/mod.rs
+++ b/crates/rustok-commerce/src/services/mod.rs
@@ -7,11 +7,16 @@ mod checkout_fulfillment_stages;
 mod checkout_inventory_order_adoption;
 mod checkout_inventory_reservation_executor;
 mod checkout_inventory_reservation_journal;
+#[cfg(feature = "marketplace-financial")]
 mod checkout_marketplace_allocation;
+#[cfg(feature = "marketplace-financial")]
 mod checkout_marketplace_commission;
+#[cfg(feature = "marketplace-financial")]
 mod checkout_marketplace_economics;
+#[cfg(feature = "marketplace-financial")]
 #[path = "checkout_marketplace_financial_hardened.rs"]
 mod checkout_marketplace_financial;
+#[cfg(feature = "marketplace-financial")]
 #[path = "checkout_marketplace_financial.rs"]
 mod checkout_marketplace_financial_legacy;
 mod checkout_operation;
@@ -32,15 +37,25 @@ mod journaled_checkout;
 mod journaled_create_label_provider;
 mod journaled_fulfillment_orchestration;
 mod journaled_payment_provider;
+#[cfg(feature = "marketplace-financial")]
 mod marketplace_financial_operator;
+#[cfg(feature = "marketplace-financial")]
 mod marketplace_financial_runtime;
+#[cfg(feature = "marketplace-financial")]
 mod marketplace_paid_event_inbox;
+#[cfg(feature = "marketplace-financial")]
 mod marketplace_paid_order_financial;
+#[cfg(feature = "marketplace-financial")]
 mod marketplace_provider_paid_event_adapter;
+#[cfg(feature = "marketplace-financial")]
 mod marketplace_provider_reversal_backfill;
+#[cfg(feature = "marketplace-financial")]
 mod marketplace_provider_reversal_event_adapter;
+#[cfg(feature = "marketplace-financial")]
 mod marketplace_reversal_adaptation_failure;
+#[cfg(feature = "marketplace-financial")]
 mod marketplace_reversal_event_inbox;
+#[cfg(feature = "marketplace-financial")]
 mod marketplace_reversal_operator;
 mod order_change_orchestration;
 mod paid_order_create_label;
@@ -86,24 +101,29 @@ pub use checkout_inventory_reservation_journal::{
     CheckoutInventoryReservationResult, CheckoutInventoryReservationStatus,
     PlanCheckoutInventoryReservation,
 };
+#[cfg(feature = "marketplace-financial")]
 pub use checkout_marketplace_allocation::{
     CheckoutMarketplaceAllocationError, CheckoutMarketplaceAllocationResult,
     CheckoutMarketplaceAllocationStage, order_contains_marketplace_lines,
 };
+#[cfg(feature = "marketplace-financial")]
 pub use checkout_marketplace_commission::{
     CheckoutMarketplaceCommissionError, CheckoutMarketplaceCommissionResult,
     CheckoutMarketplaceCommissionStage,
 };
+#[cfg(feature = "marketplace-financial")]
 pub use checkout_marketplace_economics::{
     CheckoutMarketplaceEconomicsCheckpointError, CheckoutMarketplaceEconomicsCheckpointJournal,
     CheckoutMarketplaceEconomicsCheckpointResult, CheckoutMarketplaceEconomicsEvidence,
     RecordCheckoutMarketplaceEconomicsCheckpoint, build_marketplace_economics_evidence,
     validate_marketplace_economics_checkpoint,
 };
+#[cfg(feature = "marketplace-financial")]
 pub use checkout_marketplace_financial::{
     CheckoutMarketplaceFinancialError, CheckoutMarketplaceFinancialResult,
     CheckoutMarketplaceFinancialStage,
 };
+#[cfg(feature = "marketplace-financial")]
 pub use checkout_marketplace_financial_legacy::{
     BeginMarketplaceFinancialOperation, MarketplaceFinancialOperationError,
     MarketplaceFinancialOperationJournal, MarketplaceFinancialOperationResult,
@@ -146,41 +166,51 @@ pub use fulfillment_reconciliation::FulfillmentReconciliationService;
 pub use journaled_checkout::{
     JournaledCheckoutError, JournaledCheckoutResult, JournaledCheckoutService,
 };
+#[cfg(feature = "marketplace-financial")]
 pub use marketplace_financial_operator::{
     MarketplaceFinancialOperationOperatorView, MarketplaceFinancialOperatorError,
     MarketplaceFinancialOperatorResult, MarketplaceFinancialOperatorService,
     MarketplacePaidEventOperatorView,
 };
+#[cfg(feature = "marketplace-financial")]
 pub use marketplace_financial_runtime::MarketplaceFinancialRuntime;
+#[cfg(feature = "marketplace-financial")]
 pub use marketplace_paid_event_inbox::{
     IngestMarketplacePaidEvent, MarketplacePaidEventInboxError, MarketplacePaidEventInboxJournal,
     MarketplacePaidEventInboxResult, MarketplacePaidEventInboxService, MarketplacePaidEventStatus,
     MarketplacePaidEventSweepFailure, MarketplacePaidEventSweepReport,
 };
+#[cfg(feature = "marketplace-financial")]
 pub(crate) use marketplace_paid_order_financial::MarketplacePaidOrderFinancialHandler;
+#[cfg(feature = "marketplace-financial")]
 pub use marketplace_provider_paid_event_adapter::{
     MarketplaceProviderPaidEventAdapter, MarketplaceProviderPaidEventAdapterError,
     MarketplaceProviderPaidEventAdapterResult,
 };
+#[cfg(feature = "marketplace-financial")]
 pub use marketplace_provider_reversal_backfill::{
     MarketplaceProviderReversalBackfillError, MarketplaceProviderReversalBackfillResult,
     MarketplaceProviderReversalBackfillService,
 };
+#[cfg(feature = "marketplace-financial")]
 pub use marketplace_provider_reversal_event_adapter::{
     MarketplaceProviderReversalAdaptFailure, MarketplaceProviderReversalAdaptReport,
     MarketplaceProviderReversalEventAdapter, MarketplaceProviderReversalEventAdapterError,
     MarketplaceProviderReversalEventAdapterResult,
 };
+#[cfg(feature = "marketplace-financial")]
 pub use marketplace_reversal_adaptation_failure::{
     MarketplaceReversalAdaptationFailureError, MarketplaceReversalAdaptationFailureJournal,
     MarketplaceReversalAdaptationFailureResult, MarketplaceReversalAdaptationFailureStatus,
 };
+#[cfg(feature = "marketplace-financial")]
 pub use marketplace_reversal_event_inbox::{
     IngestMarketplaceReversalEvent, MarketplaceReversalEventInboxError,
     MarketplaceReversalEventInboxJournal, MarketplaceReversalEventInboxResult,
     MarketplaceReversalEventInboxService, MarketplaceReversalEventStatus,
     MarketplaceReversalEventSweepFailure, MarketplaceReversalEventSweepReport,
 };
+#[cfg(feature = "marketplace-financial")]
 pub use marketplace_reversal_operator::{
     MarketplaceReversalAdaptationFailureOperatorView, MarketplaceReversalEventOperatorView,
     MarketplaceReversalOperatorError, MarketplaceReversalOperatorResult,

--- a/crates/rustok-commerce/src/storefront_staged_checkout_runtime.rs
+++ b/crates/rustok-commerce/src/storefront_staged_checkout_runtime.rs
@@ -285,30 +285,34 @@ pub async fn complete_storefront_checkout_input_with_product_port(
         inventory_availability,
         product_catalog_read_port,
     );
-    let marketplace_allocation_service = Arc::new(
-        rustok_marketplace_allocation::MarketplaceAllocationService::new(runtime.db_clone()),
-    );
-    let marketplace_commission_service = Arc::new(
-        rustok_marketplace_commission::MarketplaceCommissionService::new(
-            runtime.db_clone(),
-            marketplace_allocation_service.clone(),
-        ),
-    );
-    let marketplace_ledger_service =
-        Arc::new(rustok_marketplace_ledger::MarketplaceLedgerService::new(
-            runtime.db_clone(),
-            marketplace_commission_service.clone(),
-        ));
     let pipeline = crate::CheckoutStagePipeline::new(
         runtime.db_clone(),
         event_bus.clone(),
         reservation_port.clone(),
         atomic_cart.port.clone(),
-    )
-    .with_marketplace_allocation_port(marketplace_allocation_service)
-    .with_marketplace_commission_port(marketplace_commission_service)
-    .with_marketplace_ledger_port(marketplace_ledger_service)
-    .with_payment_provider_registry(payment_provider_registry.clone());
+    );
+    #[cfg(feature = "marketplace-financial")]
+    let pipeline = {
+        let marketplace_allocation_service = Arc::new(
+            rustok_marketplace_allocation::MarketplaceAllocationService::new(runtime.db_clone()),
+        );
+        let marketplace_commission_service = Arc::new(
+            rustok_marketplace_commission::MarketplaceCommissionService::new(
+                runtime.db_clone(),
+                marketplace_allocation_service.clone(),
+            ),
+        );
+        let marketplace_ledger_service =
+            Arc::new(rustok_marketplace_ledger::MarketplaceLedgerService::new(
+                runtime.db_clone(),
+                marketplace_commission_service.clone(),
+            ));
+        pipeline
+            .with_marketplace_allocation_port(marketplace_allocation_service)
+            .with_marketplace_commission_port(marketplace_commission_service)
+            .with_marketplace_ledger_port(marketplace_ledger_service)
+    };
+    let pipeline = pipeline.with_payment_provider_registry(payment_provider_registry.clone());
     let staged = crate::StagedCheckoutService::new(
         plan_builder,
         pipeline,

--- a/crates/rustok-distribution/Cargo.toml
+++ b/crates/rustok-distribution/Cargo.toml
@@ -19,6 +19,7 @@ mod-order = ["dep:rustok-order"]
 mod-payment = ["dep:rustok-payment"]
 mod-fulfillment = ["dep:rustok-fulfillment"]
 mod-commerce = ["dep:rustok-commerce", "mod-cart", "mod-customer", "mod-product", "mod-region", "mod-pricing", "mod-inventory", "mod-order", "mod-payment", "mod-fulfillment"]
+commerce-marketplace-financial = ["mod-commerce", "mod-marketplace_allocation", "mod-marketplace_commission", "mod-marketplace_ledger", "rustok-commerce/marketplace-financial"]
 mod-marketplace_seller = ["dep:rustok-marketplace-seller"]
 mod-marketplace_listing = ["dep:rustok-marketplace-listing", "mod-marketplace_seller", "mod-product"]
 mod-marketplace_allocation = ["dep:rustok-marketplace-allocation", "mod-order", "mod-marketplace_seller", "mod-marketplace_listing"]
@@ -74,7 +75,7 @@ rustok-inventory = { workspace = true, optional = true }
 rustok-order = { workspace = true, optional = true }
 rustok-payment = { workspace = true, optional = true }
 rustok-fulfillment = { workspace = true, optional = true }
-rustok-commerce = { workspace = true, optional = true }
+rustok-commerce = { workspace = true, optional = true, default-features = false }
 rustok-marketplace-seller = { workspace = true, optional = true }
 rustok-marketplace-listing = { workspace = true, optional = true }
 rustok-marketplace-allocation = { workspace = true, optional = true }

--- a/scripts/verify/verify-commerce-marketplace-financial-capability.mjs
+++ b/scripts/verify/verify-commerce-marketplace-financial-capability.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, "../..");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+function fail(message) {
+  console.error(`commerce marketplace-financial capability guard failed: ${message}`);
+  process.exitCode = 1;
+}
+
+function requireMatch(source, pattern, message) {
+  if (!pattern.test(source)) fail(message);
+}
+
+function forbidMatch(source, pattern, message) {
+  if (pattern.test(source)) fail(message);
+}
+
+function featureBody(source, feature) {
+  const escaped = feature.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = source.match(new RegExp(`^${escaped}\\s*=\\s*\\[([^\\]]*)\\]`, "m"));
+  if (!match) {
+    fail(`missing Cargo feature ${feature}`);
+    return "";
+  }
+  return match[1];
+}
+
+const commerceCargo = read("crates/rustok-commerce/Cargo.toml");
+const commerceFeature = featureBody(commerceCargo, "marketplace-financial");
+for (const dependency of [
+  "dep:rustok-marketplace",
+  "dep:rustok-marketplace-allocation",
+  "dep:rustok-marketplace-commission",
+  "dep:rustok-marketplace-ledger",
+]) {
+  if (!commerceFeature.includes(dependency)) {
+    fail(`marketplace-financial must enable ${dependency}`);
+  }
+}
+for (const dependency of [
+  "rustok-marketplace",
+  "rustok-marketplace-allocation",
+  "rustok-marketplace-commission",
+  "rustok-marketplace-ledger",
+]) {
+  requireMatch(
+    commerceCargo,
+    new RegExp(`^${dependency}\\s*=\\s*\\{[^}]*optional\\s*=\\s*true[^}]*\\}`, "m"),
+    `${dependency} must stay optional in rustok-commerce`,
+  );
+}
+requireMatch(
+  commerceCargo,
+  /^default\s*=\s*\[\]\s*$/m,
+  "rustok-commerce default feature set must stay marketplace-free",
+);
+
+const distributionCargo = read("crates/rustok-distribution/Cargo.toml");
+const distributionBase = featureBody(distributionCargo, "mod-commerce");
+if (/marketplace/i.test(distributionBase)) {
+  fail("rustok-distribution/mod-commerce must not enable marketplace owners");
+}
+const distributionCapability = featureBody(
+  distributionCargo,
+  "commerce-marketplace-financial",
+);
+for (const dependency of [
+  "mod-commerce",
+  "mod-marketplace_allocation",
+  "mod-marketplace_commission",
+  "mod-marketplace_ledger",
+  "rustok-commerce/marketplace-financial",
+]) {
+  if (!distributionCapability.includes(dependency)) {
+    fail(`distribution capability must include ${dependency}`);
+  }
+}
+
+const serverCargo = read("apps/server/Cargo.toml");
+const serverBase = featureBody(serverCargo, "mod-commerce");
+if (/marketplace/i.test(serverBase)) {
+  fail("server mod-commerce must not enable marketplace owners");
+}
+const serverCapability = featureBody(serverCargo, "commerce-marketplace-financial");
+for (const dependency of [
+  "mod-commerce",
+  "mod-marketplace_allocation",
+  "mod-marketplace_commission",
+  "mod-marketplace_ledger",
+  "rustok-commerce/marketplace-financial",
+  "rustok-distribution/commerce-marketplace-financial",
+]) {
+  if (!serverCapability.includes(dependency)) {
+    fail(`server capability must include ${dependency}`);
+  }
+}
+
+const commerceLib = read("crates/rustok-commerce/src/lib.rs");
+forbidMatch(
+  commerceLib,
+  /fn\s+register_runtime_extensions\s*\(/,
+  "base CommerceModule must not hard-require MarketplaceFinancialRuntime during runtime extension registration",
+);
+requireMatch(
+  commerceLib,
+  /#\[cfg\(feature = "marketplace-financial"\)\][\s\S]*MarketplaceFinancialRuntime/,
+  "marketplace financial listener/runtime use must be feature-gated in CommerceModule",
+);
+
+const migrations = read("crates/rustok-commerce/src/migrations/mod.rs");
+for (const migration of [
+  "m20260721_000001_create_checkout_marketplace_economics_checkpoints",
+  "m20260721_000002_create_marketplace_financial_operations",
+  "m20260721_000003_create_marketplace_paid_event_inbox",
+  "m20260721_000004_create_marketplace_reversal_event_inbox",
+  "m20260721_000005_enforce_marketplace_reversal_event_mysql_integrity",
+  "m20260721_000006_create_marketplace_reversal_adaptation_failures",
+]) {
+  requireMatch(
+    migrations,
+    new RegExp(`#\\[cfg\\(feature = "marketplace-financial"\\)\\]\\nmod ${migration};`),
+    `${migration} must be excluded from base Commerce migrations`,
+  );
+}
+
+const serviceModules = read("crates/rustok-commerce/src/services/mod.rs");
+for (const moduleName of [
+  "checkout_marketplace_allocation",
+  "checkout_marketplace_commission",
+  "checkout_marketplace_economics",
+  "marketplace_financial_runtime",
+  "marketplace_paid_event_inbox",
+  "marketplace_paid_order_financial",
+  "marketplace_reversal_event_inbox",
+]) {
+  requireMatch(
+    serviceModules,
+    new RegExp(`#\\[cfg\\(feature = "marketplace-financial"\\)\\][\\s\\S]{0,100}(?:mod|pub use) ${moduleName}`),
+    `${moduleName} must be feature-gated`,
+  );
+}
+
+for (const [relativePath, marker] of [
+  ["crates/rustok-commerce/src/controllers/mod.rs", "marketplace_financial"],
+  ["crates/rustok-commerce/src/graphql/mod.rs", "marketplace_financial"],
+  ["crates/rustok-commerce/src/graphql_runtime.rs", "marketplace_financial_runtime"],
+  ["crates/rustok-commerce/src/openapi.rs", "openapi_marketplace_financial.rs"],
+]) {
+  const source = read(relativePath);
+  requireMatch(
+    source,
+    /#\[cfg\(feature = "marketplace-financial"\)\]/,
+    `${relativePath} must contain marketplace-financial gating for ${marker}`,
+  );
+}
+
+const pipeline = read(
+  "crates/rustok-commerce/src/services/checkout_stage_pipeline_owner_ports.rs",
+);
+requireMatch(
+  pipeline,
+  /#\[cfg\(not\(feature = "marketplace-financial"\)\)\][\s\S]*marketplace checkout lines require the `marketplace-financial` Commerce capability/,
+  "base staged checkout must fail closed for marketplace lines before capture",
+);
+
+const storefront = read("crates/rustok-commerce/src/storefront_staged_checkout_runtime.rs");
+requireMatch(
+  storefront,
+  /#\[cfg\(feature = "marketplace-financial"\)\][\s\S]*MarketplaceAllocationService[\s\S]*MarketplaceCommissionService[\s\S]*MarketplaceLedgerService/,
+  "mounted marketplace owner construction must only exist inside the explicit capability",
+);
+
+const providerRuntime = read("apps/server/src/services/commerce_provider_runtime.rs");
+requireMatch(
+  providerRuntime,
+  /#\[cfg\(feature = "commerce-marketplace-financial"\)\][\s\S]*MarketplaceFinancialRuntime/,
+  "server MarketplaceFinancialRuntime composition must be capability-gated",
+);
+
+const dispatcher = read("apps/server/src/services/module_event_dispatcher.rs");
+requireMatch(
+  dispatcher,
+  /#\[cfg\(feature = "commerce-marketplace-financial"\)\]\s*\n\s*spawn_marketplace_financial_worker_if_enabled/,
+  "marketplace financial worker startup must be capability-gated",
+);
+
+const serverServices = read("apps/server/src/services/mod.rs");
+requireMatch(
+  serverServices,
+  /#\[cfg\(feature = "commerce-marketplace-financial"\)\]\s*\n\s*pub mod marketplace_financial_worker;/,
+  "marketplace financial worker module must be capability-gated",
+);
+
+if (!process.exitCode) {
+  console.log("commerce marketplace-financial capability guard: source contract OK");
+}


### PR DESCRIPTION
## Summary

- add an explicit `marketplace-financial` feature to `rustok-commerce` while keeping base Commerce marketplace-free
- make marketplace root/allocation/commission/ledger crate dependencies optional and gate marketplace financial services, entities, migrations, listeners, HTTP/GraphQL/OpenAPI surfaces, runtime data, and worker startup
- keep `mod-commerce` free of marketplace owners and add explicit `commerce-marketplace-financial` forwarding in distribution/server composition
- fail closed before payment capture when marketplace checkout lines reach a base-only Commerce deployment
- add a lightweight source guard for the minimal Commerce topology and update the canonical ecommerce implementation plan without promoting FBA/FFA status

## Source review

This is source-ready but execution-unvalidated. Base `rustok-module.toml` and `CommerceModule::dependencies()` intentionally remain marketplace-free; the optional marketplace financial capability is selected at compile/composition boundaries and explicitly registers the allocation/commission/ledger owner chain.

## Validation

Not run per maintainer instruction: tests, source verifiers, Cargo checks, formatting, workflows/CI, or database/runtime scenarios. The implementation plan keeps the corresponding execution evidence items open.