### PR TITLE
refactor(commerce): route product create update through owner port

### DIFF
--- a/apps/server/src/services/commerce_provider_runtime.rs
+++ b/apps/server/src/services/commerce_provider_runtime.rs
@@ -153,6 +153,30 @@ pub fn attach_commerce_provider_registries(
         }
     };
 
+    #[cfg(feature = "mod-product")]
+    let host = {
+        let runtime = host
+            .shared_get::<rustok_product::ProductCatalogCommandRuntime>()
+            .or_else(|| server.shared_get::<rustok_product::ProductCatalogCommandRuntime>())
+            .or_else(|| {
+                server
+                    .shared_get::<rustok_outbox::TransactionalEventBus>()
+                    .map(|event_bus| {
+                        rustok_product::ProductCatalogCommandRuntime::in_process(
+                            server.db_clone(),
+                            event_bus,
+                        )
+                    })
+            });
+        match runtime {
+            Some(runtime) => {
+                server.shared_insert(runtime.clone());
+                host.with_shared_value(runtime)
+            }
+            None => host,
+        }
+    };
+
     #[cfg(all(
         feature = "mod-marketplace_listing",
         feature = "mod-marketplace_seller",

--- a/crates/rustok-commerce/docs/implementation-plan.md
+++ b/crates/rustok-commerce/docs/implementation-plan.md
@@ -201,11 +201,13 @@ These are source-contract defects, not verification-only tasks.
   Payment, and Fulfillment concrete services behind host-composed owner ports.
 - [x] Publish Product-owned `ProductCatalogCommandPort` / `ProductCatalogCommandRuntime`,
   host-compose embedded or external command providers, and cut mounted admin REST
-  create/update/delete/publish/unpublish over to the owner port with deadline,
-  deterministic write identity, channel, actor, locale, and stable public errors.
-- [ ] Cut remaining mounted Product list/detail/catalog reads and GraphQL product
-  lifecycle/schema operations over to host-composed Product owner ports; direct Product
-  entities, `CatalogService`, and `ProductCatalogSchemaService` remain explicit source debt.
+  product create/update over to the owner port with deadline, payload-bound deterministic
+  write identity, channel, actor, locale, and stable public errors.
+- [ ] Cut remaining mounted Product list/detail/catalog reads, REST
+  delete/publish/unpublish lifecycle commands, and GraphQL product lifecycle/schema
+  operations over to host-composed Product owner ports. Direct Product entities,
+  `CatalogService`, and `ProductCatalogSchemaService` remain explicit source debt;
+  repeatable lifecycle commands need an explicit caller idempotency contract before cutover.
 - [x] Publish the order-owned `OrderReadPort` for complete order, return, and
   order-change detail/list projections with canonical read context/deadline policy,
   stable typed errors, filters, ordering, totals, and explicit unvalidated evidence.
@@ -806,9 +808,9 @@ Source inspection is not execution evidence.
   keep base Commerce marketplace-free, gate financial migrations/transports/listeners/
   workers, compose owner modules only through explicit capability features, and fail
   closed before capture when marketplace lines reach a base-only checkout.
-- [x] Publish and host-compose Product catalog lifecycle command ports, then cut mounted
-  admin REST product create/update/delete/publish/unpublish away from `CatalogService`
-  with deterministic write identity and stable public error mapping.
+- [x] Publish and host-compose Product catalog command ports, then cut mounted admin
+  REST product create/update away from `CatalogService` with payload-bound write
+  identity and stable public error mapping; lifecycle/read/GraphQL cutover remains open.
 
 ## Change rules
 

--- a/crates/rustok-commerce/docs/implementation-plan.md
+++ b/crates/rustok-commerce/docs/implementation-plan.md
@@ -199,6 +199,13 @@ These are source-contract defects, not verification-only tasks.
   the new topology guard, then retain evidence when validation policy allows it.
 - [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,
   Payment, and Fulfillment concrete services behind host-composed owner ports.
+- [x] Publish Product-owned `ProductCatalogCommandPort` / `ProductCatalogCommandRuntime`,
+  host-compose embedded or external command providers, and cut mounted admin REST
+  create/update/delete/publish/unpublish over to the owner port with deadline,
+  deterministic write identity, channel, actor, locale, and stable public errors.
+- [ ] Cut remaining mounted Product list/detail/catalog reads and GraphQL product
+  lifecycle/schema operations over to host-composed Product owner ports; direct Product
+  entities, `CatalogService`, and `ProductCatalogSchemaService` remain explicit source debt.
 - [x] Publish the order-owned `OrderReadPort` for complete order, return, and
   order-change detail/list projections with canonical read context/deadline policy,
   stable typed errors, filters, ordering, totals, and explicit unvalidated evidence.
@@ -595,6 +602,7 @@ Source inspection is not execution evidence.
 - [ ] `node scripts/verify/verify-commerce-storefront-staged-checkout-cutover.mjs`
 - [ ] `node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs`
 - [ ] `node scripts/verify/verify-commerce-marketplace-financial-capability.mjs`
+- [ ] `node scripts/verify/verify-commerce-product-command-port.mjs`
 - [ ] `cargo xtask module validate commerce`
 - [ ] `cargo xtask module validate order`
 - [ ] `cargo xtask module validate payment`
@@ -627,8 +635,8 @@ Source inspection is not execution evidence.
   mutation, payment, or fulfillment ownership; unmounted admin compatibility GET
   handlers remain explicit source debt.
 - [ ] Execute the new public-error, typed-lifecycle, storefront-cutover, order-read,
-  and marketplace-financial topology static guards against a repository checkout and
-  retain their output.
+  marketplace-financial topology, and Product command-port static guards against a
+  repository checkout and retain their output.
 
 ### Compile/tests
 
@@ -798,6 +806,9 @@ Source inspection is not execution evidence.
   keep base Commerce marketplace-free, gate financial migrations/transports/listeners/
   workers, compose owner modules only through explicit capability features, and fail
   closed before capture when marketplace lines reach a base-only checkout.
+- [x] Publish and host-compose Product catalog lifecycle command ports, then cut mounted
+  admin REST product create/update/delete/publish/unpublish away from `CatalogService`
+  with deterministic write identity and stable public error mapping.
 
 ## Change rules
 

--- a/crates/rustok-commerce/src/controllers/admin/products.rs
+++ b/crates/rustok-commerce/src/controllers/admin/products.rs
@@ -4,8 +4,7 @@ use axum::{
     http::StatusCode,
 };
 use rustok_api::Permission;
-use rustok_api::{AuthContext, TenantContext};
-use rustok_product::CatalogService;
+use rustok_api::{AuthContext, RequestContext, TenantContext};
 use rustok_web::{HttpError, HttpResult};
 use uuid::Uuid;
 
@@ -13,7 +12,8 @@ use super::super::{
     CommerceHttpRuntime,
     common::{PaginatedResponse, ensure_permissions},
     products::{
-        AdminProductErrorContext, ListProductsParams, ProductListItem, map_admin_product_error,
+        AdminProductErrorContext, ListProductsParams, ProductListItem,
+        admin_product_command_context, map_admin_product_port_error,
     },
 };
 use crate::{
@@ -209,7 +209,7 @@ pub async fn list_products(
     state: State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
-    request_context: rustok_api::RequestContext,
+    request_context: RequestContext,
     query: Query<ListProductsParams>,
 ) -> HttpResult<Json<PaginatedResponse<ProductListItem>>> {
     super::super::products::list_products(state, tenant, auth, request_context, query).await
@@ -230,6 +230,7 @@ pub async fn create_product(
     State(runtime): State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
     Json(input): Json<CreateProductInput>,
 ) -> HttpResult<(StatusCode, Json<ProductResponse>)> {
     ensure_permissions(
@@ -250,13 +251,16 @@ pub async fn create_product(
     )
     .await?;
 
-    let service = CatalogService::new(runtime.db_clone(), runtime.event_bus());
-    let product = service
-        .create_product(tenant.id, auth.user_id, input)
+    let port_context =
+        admin_product_command_context(tenant.id, &auth, &request_context, None, "create_product");
+    let product = runtime
+        .product_catalog_command_port()
+        .create_product(port_context.clone(), input)
         .await
         .map_err(|error| {
-            map_admin_product_error(
+            map_admin_product_port_error(
                 AdminProductErrorContext::new(tenant.id, auth.user_id, None, "create_product"),
+                &port_context,
                 error,
             )
         })?;
@@ -279,7 +283,7 @@ pub async fn show_product(
     state: State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
-    request_context: rustok_api::RequestContext,
+    request_context: RequestContext,
     path: Path<Uuid>,
 ) -> HttpResult<Json<ProductResponse>> {
     super::super::products::show_product(state, tenant, auth, request_context, path).await
@@ -301,6 +305,7 @@ pub async fn update_product(
     State(runtime): State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
     Path(id): Path<Uuid>,
     Json(input): Json<UpdateProductInput>,
 ) -> HttpResult<Json<ProductResponse>> {
@@ -322,13 +327,21 @@ pub async fn update_product(
     )
     .await?;
 
-    let service = CatalogService::new(runtime.db_clone(), runtime.event_bus());
-    let product = service
-        .update_product(tenant.id, auth.user_id, id, input)
+    let port_context = admin_product_command_context(
+        tenant.id,
+        &auth,
+        &request_context,
+        Some(id),
+        "update_product",
+    );
+    let product = runtime
+        .product_catalog_command_port()
+        .update_product(port_context.clone(), id, input)
         .await
         .map_err(|error| {
-            map_admin_product_error(
+            map_admin_product_port_error(
                 AdminProductErrorContext::new(tenant.id, auth.user_id, Some(id), "update_product"),
+                &port_context,
                 error,
             )
         })?;
@@ -351,9 +364,10 @@ pub async fn delete_product(
     state: State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
     path: Path<Uuid>,
 ) -> HttpResult<StatusCode> {
-    super::super::products::delete_product(state, tenant, auth, path).await
+    super::super::products::delete_product(state, tenant, auth, request_context, path).await
 }
 
 /// Publish admin ecommerce product
@@ -371,9 +385,10 @@ pub async fn publish_product(
     state: State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
     path: Path<Uuid>,
 ) -> HttpResult<Json<ProductResponse>> {
-    super::super::products::publish_product(state, tenant, auth, path).await
+    super::super::products::publish_product(state, tenant, auth, request_context, path).await
 }
 
 /// Unpublish admin ecommerce product
@@ -391,7 +406,8 @@ pub async fn unpublish_product(
     state: State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
     path: Path<Uuid>,
 ) -> HttpResult<Json<ProductResponse>> {
-    super::super::products::unpublish_product(state, tenant, auth, path).await
+    super::super::products::unpublish_product(state, tenant, auth, request_context, path).await
 }

--- a/crates/rustok-commerce/src/controllers/admin/products.rs
+++ b/crates/rustok-commerce/src/controllers/admin/products.rs
@@ -374,10 +374,9 @@ pub async fn delete_product(
     state: State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
-    request_context: RequestContext,
     path: Path<Uuid>,
 ) -> HttpResult<StatusCode> {
-    super::super::products::delete_product(state, tenant, auth, request_context, path).await
+    super::super::products::delete_product(state, tenant, auth, path).await
 }
 
 /// Publish admin ecommerce product
@@ -395,10 +394,9 @@ pub async fn publish_product(
     state: State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
-    request_context: RequestContext,
     path: Path<Uuid>,
 ) -> HttpResult<Json<ProductResponse>> {
-    super::super::products::publish_product(state, tenant, auth, request_context, path).await
+    super::super::products::publish_product(state, tenant, auth, path).await
 }
 
 /// Unpublish admin ecommerce product
@@ -416,8 +414,7 @@ pub async fn unpublish_product(
     state: State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
-    request_context: RequestContext,
     path: Path<Uuid>,
 ) -> HttpResult<Json<ProductResponse>> {
-    super::super::products::unpublish_product(state, tenant, auth, request_context, path).await
+    super::super::products::unpublish_product(state, tenant, auth, path).await
 }

--- a/crates/rustok-commerce/src/controllers/admin/products.rs
+++ b/crates/rustok-commerce/src/controllers/admin/products.rs
@@ -13,7 +13,8 @@ use super::super::{
     common::{PaginatedResponse, ensure_permissions},
     products::{
         AdminProductErrorContext, ListProductsParams, ProductListItem,
-        admin_product_command_context, map_admin_product_port_error,
+        admin_product_command_context, admin_product_command_idempotency_key,
+        map_admin_product_port_error,
     },
 };
 use crate::{
@@ -251,8 +252,15 @@ pub async fn create_product(
     )
     .await?;
 
+    let idempotency_key = admin_product_command_idempotency_key(
+        tenant.id,
+        auth.user_id,
+        None,
+        "create_product",
+        &input,
+    )?;
     let port_context =
-        admin_product_command_context(tenant.id, &auth, &request_context, None, "create_product");
+        admin_product_command_context(tenant.id, &auth, &request_context, idempotency_key);
     let product = runtime
         .product_catalog_command_port()
         .create_product(port_context.clone(), input)
@@ -327,13 +335,15 @@ pub async fn update_product(
     )
     .await?;
 
-    let port_context = admin_product_command_context(
+    let idempotency_key = admin_product_command_idempotency_key(
         tenant.id,
-        &auth,
-        &request_context,
+        auth.user_id,
         Some(id),
         "update_product",
-    );
+        &input,
+    )?;
+    let port_context =
+        admin_product_command_context(tenant.id, &auth, &request_context, idempotency_key);
     let product = runtime
         .product_catalog_command_port()
         .update_product(port_context.clone(), id, input)

--- a/crates/rustok-commerce/src/controllers/mod.rs
+++ b/crates/rustok-commerce/src/controllers/mod.rs
@@ -28,6 +28,7 @@ pub struct CommerceHttpRuntime {
         crate::graphql_runtime::CommerceFulfillmentLifecycleReadRuntime,
     order_read_runtime: crate::graphql_runtime::CommerceOrderReadRuntime,
     product_catalog_read_runtime: rustok_product::ProductCatalogReadRuntime,
+    product_catalog_command_runtime: rustok_product::ProductCatalogCommandRuntime,
     #[cfg(feature = "marketplace-financial")]
     marketplace_financial_runtime: crate::MarketplaceFinancialRuntime,
 }
@@ -82,6 +83,12 @@ impl CommerceHttpRuntime {
         self.product_catalog_read_runtime.read_port()
     }
 
+    fn product_catalog_command_port(
+        &self,
+    ) -> std::sync::Arc<dyn rustok_product::ProductCatalogCommandPort> {
+        self.product_catalog_command_runtime.command_port()
+    }
+
     #[cfg(feature = "marketplace-financial")]
     fn marketplace_financial_operator_service(&self) -> crate::MarketplaceFinancialOperatorService {
         self.marketplace_financial_runtime
@@ -132,6 +139,13 @@ impl CommerceHttpRuntime {
                     "Commerce HTTP routes require ProductCatalogReadRuntime in HostRuntimeContext"
                 )
             })?;
+        let product_catalog_command_runtime = runtime
+            .shared_get::<rustok_product::ProductCatalogCommandRuntime>()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Commerce HTTP routes require ProductCatalogCommandRuntime in HostRuntimeContext"
+                )
+            })?;
         #[cfg(feature = "marketplace-financial")]
         let marketplace_financial_runtime = runtime
             .shared_get::<crate::MarketplaceFinancialRuntime>()
@@ -153,6 +167,7 @@ impl CommerceHttpRuntime {
             fulfillment_lifecycle_read_runtime,
             order_read_runtime,
             product_catalog_read_runtime,
+            product_catalog_command_runtime,
             #[cfg(feature = "marketplace-financial")]
             marketplace_financial_runtime,
         })

--- a/crates/rustok-commerce/src/controllers/products.rs
+++ b/crates/rustok-commerce/src/controllers/products.rs
@@ -199,7 +199,7 @@ pub(crate) fn map_admin_product_port_error(
     port_context: &PortContext,
     error: PortError,
 ) -> HttpError {
-    let (status, code, message, error_kind) = match error.kind {
+    let (status, code, message, error_kind) = match &error.kind {
         PortErrorKind::Validation => (
             StatusCode::BAD_REQUEST,
             "commerce_admin_product_invalid",

--- a/crates/rustok-commerce/src/controllers/products.rs
+++ b/crates/rustok-commerce/src/controllers/products.rs
@@ -543,7 +543,6 @@ pub async fn delete_product(
     State(runtime): State<crate::controllers::CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
-    request_context: RequestContext,
     Path(id): Path<Uuid>,
 ) -> HttpResult<StatusCode> {
     ensure_permissions(
@@ -552,23 +551,13 @@ pub async fn delete_product(
         "Permission denied: products:delete required",
     )?;
 
-    let idempotency_key = admin_product_command_idempotency_key(
-        tenant.id,
-        auth.user_id,
-        Some(id),
-        "delete_product",
-        &(),
-    )?;
-    let port_context =
-        admin_product_command_context(tenant.id, &auth, &request_context, idempotency_key);
-    runtime
-        .product_catalog_command_port()
-        .delete_product(port_context.clone(), id)
+    let service = CatalogService::new(runtime.db_clone(), runtime.event_bus());
+    service
+        .delete_product(tenant.id, auth.user_id, id)
         .await
         .map_err(|error| {
-            map_admin_product_port_error(
+            map_admin_product_error(
                 AdminProductErrorContext::new(tenant.id, auth.user_id, Some(id), "delete_product"),
-                &port_context,
                 error,
             )
         })?;
@@ -581,7 +570,6 @@ pub async fn publish_product(
     State(runtime): State<crate::controllers::CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
-    request_context: RequestContext,
     Path(id): Path<Uuid>,
 ) -> HttpResult<Json<ProductResponse>> {
     ensure_permissions(
@@ -590,23 +578,13 @@ pub async fn publish_product(
         "Permission denied: products:update required",
     )?;
 
-    let idempotency_key = admin_product_command_idempotency_key(
-        tenant.id,
-        auth.user_id,
-        Some(id),
-        "publish_product",
-        &(),
-    )?;
-    let port_context =
-        admin_product_command_context(tenant.id, &auth, &request_context, idempotency_key);
-    let product = runtime
-        .product_catalog_command_port()
-        .publish_product(port_context.clone(), id)
+    let service = CatalogService::new(runtime.db_clone(), runtime.event_bus());
+    let product = service
+        .publish_product(tenant.id, auth.user_id, id)
         .await
         .map_err(|error| {
-            map_admin_product_port_error(
+            map_admin_product_error(
                 AdminProductErrorContext::new(tenant.id, auth.user_id, Some(id), "publish_product"),
-                &port_context,
                 error,
             )
         })?;
@@ -619,7 +597,6 @@ pub async fn unpublish_product(
     State(runtime): State<crate::controllers::CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
-    request_context: RequestContext,
     Path(id): Path<Uuid>,
 ) -> HttpResult<Json<ProductResponse>> {
     ensure_permissions(
@@ -628,28 +605,18 @@ pub async fn unpublish_product(
         "Permission denied: products:update required",
     )?;
 
-    let idempotency_key = admin_product_command_idempotency_key(
-        tenant.id,
-        auth.user_id,
-        Some(id),
-        "unpublish_product",
-        &(),
-    )?;
-    let port_context =
-        admin_product_command_context(tenant.id, &auth, &request_context, idempotency_key);
-    let product = runtime
-        .product_catalog_command_port()
-        .unpublish_product(port_context.clone(), id)
+    let service = CatalogService::new(runtime.db_clone(), runtime.event_bus());
+    let product = service
+        .unpublish_product(tenant.id, auth.user_id, id)
         .await
         .map_err(|error| {
-            map_admin_product_port_error(
+            map_admin_product_error(
                 AdminProductErrorContext::new(
                     tenant.id,
                     auth.user_id,
                     Some(id),
                     "unpublish_product",
                 ),
-                &port_context,
                 error,
             )
         })?;

--- a/crates/rustok-commerce/src/controllers/products.rs
+++ b/crates/rustok-commerce/src/controllers/products.rs
@@ -17,6 +17,8 @@ use rustok_web::{HttpError, HttpResult};
 use sea_orm::{
     ColumnTrait, ConnectionTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect,
 };
+use serde::Serialize;
+use sha2::{Digest, Sha256};
 use std::{collections::HashMap, time::Instant};
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -173,20 +175,58 @@ pub(crate) fn map_admin_product_error(
     HttpError::new(status, code, message)
 }
 
+pub(crate) fn admin_product_command_idempotency_key<T: Serialize>(
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    product_id: Option<Uuid>,
+    operation: &'static str,
+    payload: &T,
+) -> HttpResult<String> {
+    let payload = serde_json::to_vec(payload).map_err(|_| {
+        tracing::error!(
+            owner = ADMIN_PRODUCT_OWNER,
+            tenant_id = %uuid_shape(tenant_id),
+            actor_id = %uuid_shape(actor_id),
+            product_id = %optional_uuid_shape(product_id),
+            operation,
+            error_kind = "request_identity_serialization",
+            public_code = "commerce_admin_product_failed",
+            boundary = ADMIN_PRODUCT_BOUNDARY,
+            "commerce admin product command identity could not be materialized"
+        );
+        HttpError::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_admin_product_failed",
+            "Product operation could not be completed safely",
+        )
+    })?;
+    let mut digest = Sha256::new();
+    digest.update(tenant_id.as_bytes());
+    digest.update(actor_id.as_bytes());
+    digest.update(operation.as_bytes());
+    if let Some(product_id) = product_id {
+        digest.update(product_id.as_bytes());
+    }
+    digest.update(payload);
+    Ok(format!(
+        "commerce-admin-product:{operation}:{}",
+        hex::encode(digest.finalize())
+    ))
+}
+
 pub(crate) fn admin_product_command_context(
     tenant_id: Uuid,
     auth: &AuthContext,
     request_context: &RequestContext,
-    product_id: Option<Uuid>,
-    operation: &'static str,
+    idempotency_key: String,
 ) -> PortContext {
-    let resource_id = product_id.unwrap_or(tenant_id);
     let context = PortContext::new(
         tenant_id.to_string(),
         PortActor::user(auth.user_id.to_string()),
         request_context.locale.as_str(),
-        format!("commerce-admin-product:{operation}:{resource_id}"),
+        idempotency_key.clone(),
     )
+    .with_idempotency_key(idempotency_key)
     .with_deadline(std::time::Duration::from_secs(2));
     match request_context.channel_slug.as_deref() {
         Some(channel) => context.with_channel(channel),
@@ -512,8 +552,15 @@ pub async fn delete_product(
         "Permission denied: products:delete required",
     )?;
 
+    let idempotency_key = admin_product_command_idempotency_key(
+        tenant.id,
+        auth.user_id,
+        Some(id),
+        "delete_product",
+        &(),
+    )?;
     let port_context =
-        admin_product_command_context(tenant.id, &auth, &request_context, Some(id), "delete_product");
+        admin_product_command_context(tenant.id, &auth, &request_context, idempotency_key);
     runtime
         .product_catalog_command_port()
         .delete_product(port_context.clone(), id)
@@ -543,13 +590,15 @@ pub async fn publish_product(
         "Permission denied: products:update required",
     )?;
 
-    let port_context = admin_product_command_context(
+    let idempotency_key = admin_product_command_idempotency_key(
         tenant.id,
-        &auth,
-        &request_context,
+        auth.user_id,
         Some(id),
         "publish_product",
-    );
+        &(),
+    )?;
+    let port_context =
+        admin_product_command_context(tenant.id, &auth, &request_context, idempotency_key);
     let product = runtime
         .product_catalog_command_port()
         .publish_product(port_context.clone(), id)
@@ -579,13 +628,15 @@ pub async fn unpublish_product(
         "Permission denied: products:update required",
     )?;
 
-    let port_context = admin_product_command_context(
+    let idempotency_key = admin_product_command_idempotency_key(
         tenant.id,
-        &auth,
-        &request_context,
+        auth.user_id,
         Some(id),
         "unpublish_product",
-    );
+        &(),
+    )?;
+    let port_context =
+        admin_product_command_context(tenant.id, &auth, &request_context, idempotency_key);
     let product = runtime
         .product_catalog_command_port()
         .unpublish_product(port_context.clone(), id)

--- a/crates/rustok-commerce/src/controllers/products.rs
+++ b/crates/rustok-commerce/src/controllers/products.rs
@@ -5,7 +5,9 @@ use axum::{
 };
 use rustok_api::Permission;
 use rustok_api::locale_tags_match;
-use rustok_api::{AuthContext, RequestContext, TenantContext};
+use rustok_api::{
+    AuthContext, PortActor, PortContext, PortError, PortErrorKind, RequestContext, TenantContext,
+};
 use rustok_product::{
     CatalogService, CommerceError,
     entities::{product, product_translation},
@@ -167,6 +169,102 @@ pub(crate) fn map_admin_product_error(
         status = %status,
         boundary = ADMIN_PRODUCT_BOUNDARY,
         "commerce admin product operation failed"
+    );
+    HttpError::new(status, code, message)
+}
+
+pub(crate) fn admin_product_command_context(
+    tenant_id: Uuid,
+    auth: &AuthContext,
+    request_context: &RequestContext,
+    product_id: Option<Uuid>,
+    operation: &'static str,
+) -> PortContext {
+    let resource_id = product_id.unwrap_or(tenant_id);
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        request_context.locale.as_str(),
+        format!("commerce-admin-product:{operation}:{resource_id}"),
+    )
+    .with_deadline(std::time::Duration::from_secs(2));
+    match request_context.channel_slug.as_deref() {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
+}
+
+pub(crate) fn map_admin_product_port_error(
+    context: AdminProductErrorContext,
+    port_context: &PortContext,
+    error: PortError,
+) -> HttpError {
+    let (status, code, message, error_kind) = match error.kind {
+        PortErrorKind::Validation => (
+            StatusCode::BAD_REQUEST,
+            "commerce_admin_product_invalid",
+            "Product request is invalid",
+            "validation",
+        ),
+        PortErrorKind::NotFound => (
+            StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        PortErrorKind::Conflict if error.code == "product.duplicate_handle" => (
+            StatusCode::CONFLICT,
+            "commerce_admin_product_handle_conflict",
+            "A product with this handle already exists",
+            "duplicate_handle",
+        ),
+        PortErrorKind::Conflict if error.code == "product.duplicate_sku" => (
+            StatusCode::CONFLICT,
+            "commerce_admin_product_sku_conflict",
+            "A product variant with this SKU already exists",
+            "duplicate_sku",
+        ),
+        PortErrorKind::Conflict => (
+            StatusCode::CONFLICT,
+            "commerce_admin_product_state_conflict",
+            "Product operation conflicts with the current state",
+            "state_conflict",
+        ),
+        PortErrorKind::Forbidden => (
+            StatusCode::UNAUTHORIZED,
+            "commerce_permission_denied",
+            "Permission denied",
+            "forbidden",
+        ),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_product_storage_unavailable",
+            "Product storage is temporarily unavailable",
+            "unavailable",
+        ),
+        PortErrorKind::InvariantViolation => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_admin_product_failed",
+            "Product operation could not be completed safely",
+            "invariant_violation",
+        ),
+    };
+    let diagnostic = AdminProductDiagnosticContext::from(&context);
+    tracing::error!(
+        owner = ADMIN_PRODUCT_OWNER,
+        owner_operation = context.operation,
+        correlation_id = %port_context.correlation_id,
+        tenant_id = %diagnostic.tenant_id,
+        actor_id = %diagnostic.actor_id,
+        product_id = ?diagnostic.product_id,
+        operation = %diagnostic.operation,
+        internal_code = %error.code,
+        retryable = error.retryable,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_PRODUCT_BOUNDARY,
+        "commerce admin product owner command failed"
     );
     HttpError::new(status, code, message)
 }
@@ -405,6 +503,7 @@ pub async fn delete_product(
     State(runtime): State<crate::controllers::CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
     Path(id): Path<Uuid>,
 ) -> HttpResult<StatusCode> {
     ensure_permissions(
@@ -413,13 +512,16 @@ pub async fn delete_product(
         "Permission denied: products:delete required",
     )?;
 
-    let service = CatalogService::new(runtime.db_clone(), runtime.event_bus());
-    service
-        .delete_product(tenant.id, auth.user_id, id)
+    let port_context =
+        admin_product_command_context(tenant.id, &auth, &request_context, Some(id), "delete_product");
+    runtime
+        .product_catalog_command_port()
+        .delete_product(port_context.clone(), id)
         .await
         .map_err(|error| {
-            map_admin_product_error(
+            map_admin_product_port_error(
                 AdminProductErrorContext::new(tenant.id, auth.user_id, Some(id), "delete_product"),
+                &port_context,
                 error,
             )
         })?;
@@ -432,6 +534,7 @@ pub async fn publish_product(
     State(runtime): State<crate::controllers::CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
     Path(id): Path<Uuid>,
 ) -> HttpResult<Json<ProductResponse>> {
     ensure_permissions(
@@ -440,13 +543,21 @@ pub async fn publish_product(
         "Permission denied: products:update required",
     )?;
 
-    let service = CatalogService::new(runtime.db_clone(), runtime.event_bus());
-    let product = service
-        .publish_product(tenant.id, auth.user_id, id)
+    let port_context = admin_product_command_context(
+        tenant.id,
+        &auth,
+        &request_context,
+        Some(id),
+        "publish_product",
+    );
+    let product = runtime
+        .product_catalog_command_port()
+        .publish_product(port_context.clone(), id)
         .await
         .map_err(|error| {
-            map_admin_product_error(
+            map_admin_product_port_error(
                 AdminProductErrorContext::new(tenant.id, auth.user_id, Some(id), "publish_product"),
+                &port_context,
                 error,
             )
         })?;
@@ -459,6 +570,7 @@ pub async fn unpublish_product(
     State(runtime): State<crate::controllers::CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
     Path(id): Path<Uuid>,
 ) -> HttpResult<Json<ProductResponse>> {
     ensure_permissions(
@@ -467,18 +579,26 @@ pub async fn unpublish_product(
         "Permission denied: products:update required",
     )?;
 
-    let service = CatalogService::new(runtime.db_clone(), runtime.event_bus());
-    let product = service
-        .unpublish_product(tenant.id, auth.user_id, id)
+    let port_context = admin_product_command_context(
+        tenant.id,
+        &auth,
+        &request_context,
+        Some(id),
+        "unpublish_product",
+    );
+    let product = runtime
+        .product_catalog_command_port()
+        .unpublish_product(port_context.clone(), id)
         .await
         .map_err(|error| {
-            map_admin_product_error(
+            map_admin_product_port_error(
                 AdminProductErrorContext::new(
                     tenant.id,
                     auth.user_id,
                     Some(id),
                     "unpublish_product",
                 ),
+                &port_context,
                 error,
             )
         })?;

--- a/crates/rustok-product/src/catalog_command_port.rs
+++ b/crates/rustok-product/src/catalog_command_port.rs
@@ -1,0 +1,233 @@
+use async_trait::async_trait;
+use rustok_api::{PortCallPolicy, PortContext, PortError};
+use uuid::Uuid;
+
+use crate::dto::{CreateProductInput, ProductResponse, UpdateProductInput};
+use crate::{CatalogService, CommerceError};
+
+/// Transport-neutral owner boundary for Product catalog lifecycle commands.
+///
+/// Consumers must receive this port from host composition instead of constructing
+/// `CatalogService` directly. The embedded adapter remains owner-local and can be
+/// replaced by a remote provider without changing Commerce transports.
+#[async_trait]
+pub trait ProductCatalogCommandPort: Send + Sync {
+    async fn create_product(
+        &self,
+        context: PortContext,
+        input: CreateProductInput,
+    ) -> Result<ProductResponse, PortError>;
+
+    async fn update_product(
+        &self,
+        context: PortContext,
+        product_id: Uuid,
+        input: UpdateProductInput,
+    ) -> Result<ProductResponse, PortError>;
+
+    async fn delete_product(
+        &self,
+        context: PortContext,
+        product_id: Uuid,
+    ) -> Result<(), PortError>;
+
+    async fn publish_product(
+        &self,
+        context: PortContext,
+        product_id: Uuid,
+    ) -> Result<ProductResponse, PortError>;
+
+    async fn unpublish_product(
+        &self,
+        context: PortContext,
+        product_id: Uuid,
+    ) -> Result<ProductResponse, PortError>;
+}
+
+#[async_trait]
+impl ProductCatalogCommandPort for CatalogService {
+    async fn create_product(
+        &self,
+        context: PortContext,
+        input: CreateProductInput,
+    ) -> Result<ProductResponse, PortError> {
+        let operation = "create_product";
+        let (tenant_id, actor_id) = command_scope(&context, operation)?;
+        self.create_product(tenant_id, actor_id, input)
+            .await
+            .map_err(|error| product_command_error(&context, operation, error))
+    }
+
+    async fn update_product(
+        &self,
+        context: PortContext,
+        product_id: Uuid,
+        input: UpdateProductInput,
+    ) -> Result<ProductResponse, PortError> {
+        let operation = "update_product";
+        let (tenant_id, actor_id) = command_scope(&context, operation)?;
+        self.update_product(tenant_id, actor_id, product_id, input)
+            .await
+            .map_err(|error| product_command_error(&context, operation, error))
+    }
+
+    async fn delete_product(
+        &self,
+        context: PortContext,
+        product_id: Uuid,
+    ) -> Result<(), PortError> {
+        let operation = "delete_product";
+        let (tenant_id, actor_id) = command_scope(&context, operation)?;
+        self.delete_product(tenant_id, actor_id, product_id)
+            .await
+            .map_err(|error| product_command_error(&context, operation, error))
+    }
+
+    async fn publish_product(
+        &self,
+        context: PortContext,
+        product_id: Uuid,
+    ) -> Result<ProductResponse, PortError> {
+        let operation = "publish_product";
+        let (tenant_id, actor_id) = command_scope(&context, operation)?;
+        self.publish_product(tenant_id, actor_id, product_id)
+            .await
+            .map_err(|error| product_command_error(&context, operation, error))
+    }
+
+    async fn unpublish_product(
+        &self,
+        context: PortContext,
+        product_id: Uuid,
+    ) -> Result<ProductResponse, PortError> {
+        let operation = "unpublish_product";
+        let (tenant_id, actor_id) = command_scope(&context, operation)?;
+        self.unpublish_product(tenant_id, actor_id, product_id)
+            .await
+            .map_err(|error| product_command_error(&context, operation, error))
+    }
+}
+
+fn command_scope(
+    context: &PortContext,
+    operation: &'static str,
+) -> Result<(Uuid, Uuid), PortError> {
+    context
+        .require_policy(PortCallPolicy::write())
+        .map_err(|error| command_context_error(context, operation, error))?;
+
+    let tenant_id = Uuid::parse_str(context.tenant_id.as_str()).map_err(|_| {
+        tracing::warn!(
+            correlation_id = %context.correlation_id,
+            operation,
+            code = "product.tenant_id_invalid",
+            "product command tenant context is invalid"
+        );
+        PortError::validation(
+            "product.tenant_id_invalid",
+            "product request context is invalid",
+        )
+    })?;
+    let actor_id = Uuid::parse_str(context.actor.id.as_str()).map_err(|_| {
+        tracing::warn!(
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            operation,
+            code = "product.actor_id_invalid",
+            "product command actor context is invalid"
+        );
+        PortError::validation(
+            "product.actor_id_invalid",
+            "product request context is invalid",
+        )
+    })?;
+
+    Ok((tenant_id, actor_id))
+}
+
+fn command_context_error(
+    context: &PortContext,
+    operation: &'static str,
+    error: PortError,
+) -> PortError {
+    tracing::warn!(
+        internal_code = %error.code,
+        retryable = error.retryable,
+        correlation_id = %context.correlation_id,
+        tenant_id = %context.tenant_id,
+        operation,
+        code = "product.context_invalid",
+        "product command call context was rejected"
+    );
+    error
+}
+
+fn product_command_error(
+    context: &PortContext,
+    operation: &'static str,
+    error: CommerceError,
+) -> PortError {
+    let error_kind = product_error_kind(&error);
+    tracing::error!(
+        correlation_id = %context.correlation_id,
+        tenant_id = %context.tenant_id,
+        operation,
+        error_kind,
+        code = product_error_code(&error),
+        "product catalog owner command failed"
+    );
+
+    match error {
+        CommerceError::Database(_) => PortError::unavailable(
+            "product.database_unavailable",
+            "product storage is temporarily unavailable",
+        ),
+        CommerceError::ProductNotFound(_) => {
+            PortError::not_found("product.product_not_found", "product was not found")
+        }
+        CommerceError::DuplicateHandle { .. } => PortError::conflict(
+            "product.duplicate_handle",
+            "product handle conflicts with an existing product",
+        ),
+        CommerceError::DuplicateSku(_) => PortError::conflict(
+            "product.duplicate_sku",
+            "product SKU conflicts with an existing variant",
+        ),
+        CommerceError::Validation(_) | CommerceError::NoVariants => {
+            PortError::validation("product.validation", "product request is invalid")
+        }
+        CommerceError::CannotDeletePublished => PortError::conflict(
+            "product.lifecycle_conflict",
+            "product operation conflicts with the current state",
+        ),
+        CommerceError::Core(_) => PortError::invariant_violation(
+            "product.invariant_violation",
+            "product operation could not be completed safely",
+        ),
+    }
+}
+
+fn product_error_kind(error: &CommerceError) -> &'static str {
+    match error {
+        CommerceError::Database(_) => "database",
+        CommerceError::ProductNotFound(_) => "not_found",
+        CommerceError::DuplicateHandle { .. } => "duplicate_handle",
+        CommerceError::DuplicateSku(_) => "duplicate_sku",
+        CommerceError::Validation(_) => "validation",
+        CommerceError::NoVariants => "no_variants",
+        CommerceError::CannotDeletePublished => "lifecycle_conflict",
+        CommerceError::Core(_) => "core",
+    }
+}
+
+fn product_error_code(error: &CommerceError) -> &'static str {
+    match error {
+        CommerceError::Database(_) => "product.database_unavailable",
+        CommerceError::ProductNotFound(_) => "product.product_not_found",
+        CommerceError::DuplicateHandle { .. } => "product.duplicate_handle",
+        CommerceError::DuplicateSku(_) => "product.duplicate_sku",
+        CommerceError::Validation(_) | CommerceError::NoVariants => "product.validation",
+        CommerceError::CannotDeletePublished => "product.lifecycle_conflict",
+        CommerceError::Core(_) => "product.invariant_violation",
+    }
+}

--- a/crates/rustok-product/src/lib.rs
+++ b/crates/rustok-product/src/lib.rs
@@ -14,6 +14,7 @@ use rustok_core::{MigrationSource, ModuleRuntimeExtensions, RusToKModule};
 use rustok_seo_targets::register_seo_target_provider;
 use sea_orm_migration::MigrationTrait;
 
+mod catalog_command_port;
 pub mod dto;
 pub mod entities;
 pub mod error;
@@ -24,10 +25,14 @@ mod runtime;
 mod seo_targets;
 pub mod services;
 
+pub use catalog_command_port::ProductCatalogCommandPort;
 pub use error::{CommerceError, CommerceResult};
 pub use ports::*;
 pub use public_error::{ProductPublicError, map_product_public_error};
-pub use runtime::{ProductCatalogReadProfile, ProductCatalogReadRuntime};
+pub use runtime::{
+    ProductCatalogCommandProfile, ProductCatalogCommandRuntime, ProductCatalogReadProfile,
+    ProductCatalogReadRuntime,
+};
 pub use services::{
     AdminProductList, AdminProductListItem, AdminProductListQuery, CatalogService,
     MAX_PRODUCT_INDEX_LOCALE_REFRESH_PAGE, MAX_PRODUCT_INDEX_VARIANT_REFRESH_PAGE,

--- a/crates/rustok-product/src/runtime.rs
+++ b/crates/rustok-product/src/runtime.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use rustok_outbox::TransactionalEventBus;
 use sea_orm::DatabaseConnection;
 
-use crate::{CatalogService, ProductCatalogReadPort};
+use crate::{CatalogService, ProductCatalogCommandPort, ProductCatalogReadPort};
 
 /// Host-selected execution profile for the Product catalog read boundary.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -55,6 +55,60 @@ impl ProductCatalogReadRuntime {
     }
 
     pub const fn profile(&self) -> ProductCatalogReadProfile {
+        self.profile
+    }
+}
+
+/// Host-selected execution profile for the Product catalog command boundary.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProductCatalogCommandProfile {
+    EmbeddedNative,
+    External,
+}
+
+impl ProductCatalogCommandProfile {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::EmbeddedNative => "embedded_native",
+            Self::External => "external",
+        }
+    }
+}
+
+/// Canonical host-composed Product catalog lifecycle command capability.
+#[derive(Clone)]
+pub struct ProductCatalogCommandRuntime {
+    command_port: Arc<dyn ProductCatalogCommandPort>,
+    profile: ProductCatalogCommandProfile,
+}
+
+impl ProductCatalogCommandRuntime {
+    pub fn new(
+        command_port: Arc<dyn ProductCatalogCommandPort>,
+        profile: ProductCatalogCommandProfile,
+    ) -> Self {
+        Self {
+            command_port,
+            profile,
+        }
+    }
+
+    pub fn in_process(db: DatabaseConnection, event_bus: TransactionalEventBus) -> Self {
+        Self::new(
+            Arc::new(CatalogService::new(db, event_bus)),
+            ProductCatalogCommandProfile::EmbeddedNative,
+        )
+    }
+
+    pub fn external(command_port: Arc<dyn ProductCatalogCommandPort>) -> Self {
+        Self::new(command_port, ProductCatalogCommandProfile::External)
+    }
+
+    pub fn command_port(&self) -> Arc<dyn ProductCatalogCommandPort> {
+        self.command_port.clone()
+    }
+
+    pub const fn profile(&self) -> ProductCatalogCommandProfile {
         self.profile
     }
 }

--- a/scripts/verify/verify-commerce-product-command-port.mjs
+++ b/scripts/verify/verify-commerce-product-command-port.mjs
@@ -46,6 +46,13 @@ requireText(
   "rustok-product must publish ProductCatalogCommandRuntime",
 );
 
+const commandPort = read("crates/rustok-product/src/catalog_command_port.rs");
+requireText(
+  commandPort,
+  "require_policy(PortCallPolicy::write())",
+  "Product command port must enforce deadline and idempotency write semantics",
+);
+
 const productRuntime = read("crates/rustok-product/src/runtime.rs");
 requireText(
   productRuntime,
@@ -96,12 +103,22 @@ for (const method of ["create_product", "update_product"]) {
   );
   requireText(
     body,
+    "admin_product_command_idempotency_key(",
+    `${method} must bind its request payload into a deterministic write identity`,
+  );
+  requireText(
+    body,
     ".product_catalog_command_port()",
     `${method} must call the host-composed Product command port`,
   );
 }
 
 const sharedProducts = read("crates/rustok-commerce/src/controllers/products.rs");
+requireText(
+  sharedProducts,
+  ".with_idempotency_key(idempotency_key)",
+  "mounted Product command context must carry an idempotency key",
+);
 for (const [method, next] of [
   ["delete_product", "publish_product"],
   ["publish_product", "unpublish_product"],
@@ -112,6 +129,11 @@ for (const [method, next] of [
     body,
     "CatalogService::new",
     `${method} must not construct CatalogService`,
+  );
+  requireText(
+    body,
+    "admin_product_command_idempotency_key(",
+    `${method} must provide deterministic write identity`,
   );
   requireText(
     body,

--- a/scripts/verify/verify-commerce-product-command-port.mjs
+++ b/scripts/verify/verify-commerce-product-command-port.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, "../..");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+function fail(message) {
+  console.error(`commerce product command-port guard failed: ${message}`);
+  process.exitCode = 1;
+}
+
+function requireText(source, text, message) {
+  if (!source.includes(text)) fail(message);
+}
+
+function forbidText(source, text, message) {
+  if (source.includes(text)) fail(message);
+}
+
+function functionSlice(source, name, nextName) {
+  const start = source.indexOf(`pub async fn ${name}(`);
+  if (start < 0) {
+    fail(`missing function ${name}`);
+    return "";
+  }
+  const end = nextName ? source.indexOf(`pub async fn ${nextName}(`, start + 1) : source.length;
+  return source.slice(start, end < 0 ? source.length : end);
+}
+
+const productLib = read("crates/rustok-product/src/lib.rs");
+requireText(
+  productLib,
+  "pub use catalog_command_port::ProductCatalogCommandPort;",
+  "rustok-product must publish ProductCatalogCommandPort",
+);
+requireText(
+  productLib,
+  "ProductCatalogCommandProfile, ProductCatalogCommandRuntime",
+  "rustok-product must publish ProductCatalogCommandRuntime",
+);
+
+const productRuntime = read("crates/rustok-product/src/runtime.rs");
+requireText(
+  productRuntime,
+  "pub struct ProductCatalogCommandRuntime",
+  "product command runtime must be owner-provided",
+);
+requireText(
+  productRuntime,
+  "pub fn external(command_port: Arc<dyn ProductCatalogCommandPort>)",
+  "product command runtime must support host-selected external adapters",
+);
+
+const serverRuntime = read("apps/server/src/services/commerce_provider_runtime.rs");
+requireText(
+  serverRuntime,
+  "shared_get::<rustok_product::ProductCatalogCommandRuntime>()",
+  "server must preserve or compose ProductCatalogCommandRuntime",
+);
+requireText(
+  serverRuntime,
+  "rustok_product::ProductCatalogCommandRuntime::in_process",
+  "server must provide the explicit embedded Product command adapter",
+);
+
+const commerceHttp = read("crates/rustok-commerce/src/controllers/mod.rs");
+requireText(
+  commerceHttp,
+  "product_catalog_command_runtime: rustok_product::ProductCatalogCommandRuntime",
+  "Commerce HTTP runtime must store the host-composed Product command runtime",
+);
+requireText(
+  commerceHttp,
+  "Commerce HTTP routes require ProductCatalogCommandRuntime in HostRuntimeContext",
+  "Commerce HTTP mount must fail closed when Product command runtime is missing",
+);
+
+const adminProducts = read("crates/rustok-commerce/src/controllers/admin/products.rs");
+forbidText(
+  adminProducts,
+  "CatalogService",
+  "mounted admin Product CRUD must not construct or import CatalogService",
+);
+for (const method of ["create_product", "update_product"]) {
+  const body = functionSlice(
+    adminProducts,
+    method,
+    method === "create_product" ? "show_product" : "delete_product",
+  );
+  requireText(
+    body,
+    ".product_catalog_command_port()",
+    `${method} must call the host-composed Product command port`,
+  );
+}
+
+const sharedProducts = read("crates/rustok-commerce/src/controllers/products.rs");
+for (const [method, next] of [
+  ["delete_product", "publish_product"],
+  ["publish_product", "unpublish_product"],
+  ["unpublish_product", null],
+]) {
+  const body = functionSlice(sharedProducts, method, next);
+  forbidText(
+    body,
+    "CatalogService::new",
+    `${method} must not construct CatalogService`,
+  );
+  requireText(
+    body,
+    ".product_catalog_command_port()",
+    `${method} must call the host-composed Product command port`,
+  );
+}
+
+if (!process.exitCode) {
+  console.log("commerce product command-port guard: source contract OK");
+}

--- a/scripts/verify/verify-commerce-product-command-port.mjs
+++ b/scripts/verify/verify-commerce-product-command-port.mjs
@@ -93,7 +93,7 @@ const adminProducts = read("crates/rustok-commerce/src/controllers/admin/product
 forbidText(
   adminProducts,
   "CatalogService",
-  "mounted admin Product CRUD must not construct or import CatalogService",
+  "mounted admin Product create/update must not construct or import CatalogService",
 );
 for (const method of ["create_product", "update_product"]) {
   const body = functionSlice(
@@ -117,30 +117,13 @@ const sharedProducts = read("crates/rustok-commerce/src/controllers/products.rs"
 requireText(
   sharedProducts,
   ".with_idempotency_key(idempotency_key)",
-  "mounted Product command context must carry an idempotency key",
+  "mounted Product create/update command context must carry an idempotency key",
 );
-for (const [method, next] of [
-  ["delete_product", "publish_product"],
-  ["publish_product", "unpublish_product"],
-  ["unpublish_product", null],
-]) {
-  const body = functionSlice(sharedProducts, method, next);
-  forbidText(
-    body,
-    "CatalogService::new",
-    `${method} must not construct CatalogService`,
-  );
-  requireText(
-    body,
-    "admin_product_command_idempotency_key(",
-    `${method} must provide deterministic write identity`,
-  );
-  requireText(
-    body,
-    ".product_catalog_command_port()",
-    `${method} must call the host-composed Product command port`,
-  );
-}
+requireText(
+  sharedProducts,
+  "CatalogService::new(runtime.db_clone(), runtime.event_bus())",
+  "remaining Product read/lifecycle direct construction must stay visible as follow-up source debt",
+);
 
 if (!process.exitCode) {
   console.log("commerce product command-port guard: source contract OK");


### PR DESCRIPTION
## Summary

- publish `ProductCatalogCommandPort` in `rustok-product` with embedded/external `ProductCatalogCommandRuntime`
- host-compose the command runtime in the server and require it when Commerce HTTP mounts
- cut mounted admin REST product `create` / `update` away from direct `CatalogService` construction
- preserve shipping-profile validation and existing public HTTP envelopes while mapping owner `PortError` values to stable public messages
- carry tenant, actor, locale, channel, a bounded deadline, correlation, and payload-bound deterministic write identity across the Product owner call
- add an unexecuted static source guard and update the canonical ecommerce implementation plan

## Scope

This PR intentionally covers only Product create/update. Product list/detail/catalog reads, REST delete/publish/unpublish, and GraphQL lifecycle/schema paths remain explicit follow-up work. Repeatable lifecycle commands need an explicit caller idempotency contract before cutover; the broader Product/Order/Payment/Fulfillment topology P0 remains open.

## Validation

Source-reviewed only. Tests, source verifiers, Cargo checks, formatting, workflows/CI, and database/runtime scenarios were not run per maintainer instruction. The implementation plan keeps execution evidence open.