### PR TITLE
feat(index): fence Product materialized query freshness

### DIFF
--- a/crates/rustok-distribution/src/product_index/mod.rs
+++ b/crates/rustok-distribution/src/product_index/mod.rs
@@ -7,6 +7,7 @@ pub(crate) use absence::PRODUCT_ABSENCE_WATERMARK_FACTORY;
 mod product;
 #[cfg(test)]
 pub(crate) use product::PRODUCT_INDEX_SOURCE;
+mod query_admission;
 pub(crate) mod relation_admission;
 #[path = "../product_variant_index.rs"]
 mod variant;
@@ -19,6 +20,7 @@ pub(crate) fn register(
     product::register(extensions)?;
     variant::register(extensions)?;
     absence::register(extensions)?;
+    query_admission::register(extensions)?;
     channel_relation_convergence::register(extensions)
 }
 
@@ -33,7 +35,7 @@ mod tests {
     };
 
     #[test]
-    fn selected_product_bridge_registers_two_current_schemas_and_three_factories() {
+    fn selected_product_bridge_registers_two_current_schemas_three_factories_and_query_admission() {
         let mut extensions = ModuleRuntimeExtensions::default();
         extensions.insert(rustok_product::ProductRuntimeSelected);
         extensions.insert(rustok_index::IndexSchemaSourceCatalog::new());
@@ -64,6 +66,10 @@ mod tests {
             factory.owner_module() == "product"
                 && factory.factory_name() == PRODUCT_ABSENCE_WATERMARK_FACTORY
         }));
+        let admissions = extensions
+            .get::<rustok_index::PostgresIndexQueryAdmissionCatalog>()
+            .expect("Product selection must publish one query admission rule");
+        assert_eq!(admissions.len(), 1);
         assert!(!extensions.contains::<ModuleWorkRegistrations>());
     }
 

--- a/crates/rustok-distribution/src/product_index/query_admission.rs
+++ b/crates/rustok-distribution/src/product_index/query_admission.rs
@@ -1,0 +1,128 @@
+use rustok_core::ModuleRuntimeExtensions;
+use rustok_index::{
+    EntityName, ModuleName, PostgresQueryRootAdmission, SchemaRef, SchemaVersion,
+    register_postgres_index_query_admission,
+};
+
+const PRODUCT_QUERY_MATERIALIZED_FRESHNESS: &str = r#"
+EXISTS (
+    SELECT 1
+    FROM products owner_product
+    JOIN LATERAL (
+        SELECT
+            projection.projection_epoch,
+            projection.product_source_version,
+            projection.relation_epoch
+        FROM product_index_graph_projection_snapshots projection
+        WHERE projection.tenant_id = {{root}}.tenant_id
+          AND projection.product_id = {{root}}.entity_id
+        ORDER BY projection.projection_epoch DESC
+        LIMIT 1
+    ) current_projection ON TRUE
+    JOIN LATERAL (
+        SELECT
+            witness.product_source_version,
+            witness.channel_identity_generation
+        FROM product_sales_channel_index_relation_freshness_snapshots witness
+        WHERE witness.tenant_id = {{root}}.tenant_id
+          AND witness.product_id = {{root}}.entity_id
+          AND witness.relation_epoch = current_projection.relation_epoch
+        ORDER BY witness.sequence_no DESC
+        LIMIT 1
+    ) current_freshness ON TRUE
+    WHERE owner_product.tenant_id = {{root}}.tenant_id
+      AND owner_product.id = {{root}}.entity_id
+      AND {{root}}.source_version = current_projection.projection_epoch
+      AND current_projection.product_source_version = owner_product.index_revision
+      AND current_freshness.product_source_version <= owner_product.index_revision
+      AND current_freshness.channel_identity_generation = COALESCE(
+          (
+              SELECT channel_generation.generation
+              FROM channel_index_identity_generations channel_generation
+              WHERE channel_generation.tenant_id = {{root}}.tenant_id
+          ),
+          0
+      )
+      AND NOT EXISTS (
+          SELECT 1
+          FROM product_sales_channel_index_relation_convergence_requests request
+          WHERE request.tenant_id = {{root}}.tenant_id
+            AND request.product_id = {{root}}.entity_id
+            AND request.product_source_version > current_freshness.product_source_version
+      )
+      AND EXISTS (
+          SELECT 1
+          FROM product_translations translation
+          WHERE translation.tenant_id = {{root}}.tenant_id
+            AND translation.product_id = {{root}}.entity_id
+            AND translation.locale = {{root}}.locale_key
+      )
+)
+"#;
+
+pub(crate) fn register(extensions: &mut ModuleRuntimeExtensions) -> rustok_core::Result<()> {
+    if !extensions.contains::<rustok_product::ProductRuntimeSelected>() {
+        return Ok(());
+    }
+    let admission = PostgresQueryRootAdmission::new(PRODUCT_QUERY_MATERIALIZED_FRESHNESS).map_err(
+        |error| {
+            rustok_core::Error::Validation(format!(
+                "selected Product Index query admission construction failed: {error}"
+            ))
+        },
+    )?;
+    register_postgres_index_query_admission(
+        extensions,
+        "product",
+        product_schema_ref()?,
+        admission,
+    )
+    .map_err(|error| {
+        rustok_core::Error::Validation(format!(
+            "selected Product Index query admission registration failed: {error}"
+        ))
+    })
+}
+
+fn product_schema_ref() -> rustok_core::Result<SchemaRef> {
+    Ok(SchemaRef {
+        module: ModuleName::new("rustok-product").map_err(|error| {
+            rustok_core::Error::Validation(format!("Product Index module name is invalid: {error}"))
+        })?,
+        entity: EntityName::new("product").map_err(|error| {
+            rustok_core::Error::Validation(format!("Product Index entity name is invalid: {error}"))
+        })?,
+        version: SchemaVersion::new(3),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn materialized_freshness_predicate_fences_owner_and_locale_state() {
+        for marker in [
+            "product_index_graph_projection_snapshots",
+            "product_sales_channel_index_relation_freshness_snapshots",
+            "channel_index_identity_generations",
+            "product_sales_channel_index_relation_convergence_requests",
+            "{{root}}.source_version = current_projection.projection_epoch",
+            "current_projection.product_source_version = owner_product.index_revision",
+            "request.product_source_version > current_freshness.product_source_version",
+            "translation.locale = {{root}}.locale_key",
+            "LIMIT 1",
+        ] {
+            assert!(
+                PRODUCT_QUERY_MATERIALIZED_FRESHNESS.contains(marker),
+                "missing {marker}"
+            );
+        }
+        for forbidden in ["index_links", "index_entities", "$1", "channel_visibility"] {
+            assert!(
+                !PRODUCT_QUERY_MATERIALIZED_FRESHNESS.contains(forbidden),
+                "forbidden {forbidden}"
+            );
+        }
+    }
+}

--- a/crates/rustok-index/docs/implementation-plan-product-materialized-query-freshness-2026-08-07.md
+++ b/crates/rustok-index/docs/implementation-plan-product-materialized-query-freshness-2026-08-07.md
@@ -1,0 +1,84 @@
+# Product materialized/query freshness continuation — 2026-08-07
+
+Status overlay: `source_complete_runtime_evidence_pending`.
+
+This continuation advances the current M7 Product/ProductVariant/SalesChannel plan after automatic
+Product-to-SalesChannel convergence. The canonical current plan remains the broader M5/M6/M7 execution
+ledger; this document records the source slice that closes its previously open Product root
+materialized/query freshness item.
+
+## Source-complete in this continuation
+
+- generic trusted PostgreSQL root-query admission contract keyed by exact `SchemaRef`;
+- one admission owner per schema and immutable query-runtime snapshot composition;
+- fail-closed compiler root-anchor matching;
+- admission before user filter/cursor/order/limit;
+- the same admission predicate in page and exact-count SQL;
+- canonical Product materialized freshness predicate using existing projection/freshness/convergence
+  evidence;
+- immediate Product/locale delete exclusion from Product root queries;
+- visibility-change exclusion through retained Product convergence request watermarks;
+- Channel identity exclusion through current tenant generation comparison;
+- Product scalar/Variant exclusion through current projection epoch/Product component comparison;
+- no new Product schema, relation membership copy, Index storage column, or typed event family.
+
+## M7 Product root query freshness status
+
+- [x] Source replay fails closed on stale Product relation freshness.
+- [x] Automatic bounded Product visibility / Channel identity relation convergence.
+- [x] Rejected Product poison isolation without making rejected Products source-admissible.
+- [x] Root Product materialized/query freshness fence for source-read -> mutation-apply races.
+- [ ] Execute PostgreSQL page/filter/order/cursor/exact-count race evidence.
+- [ ] Execute automatic-convergence multi-host/restart/rejected-Product evidence.
+- [ ] Prove linked SalesChannel/ProductVariant target availability and complete query equivalence.
+- [ ] Admit canonical Product typed events/routes only after event-contract digest verification.
+- [ ] Move Storefront traffic only after readiness, equivalence, convergence, and query-freshness
+      evidence passes.
+
+## Admission boundary after this slice
+
+A Product root row that is stale relative to current owner Product/locale/projection/visibility/Channel
+identity facts is removed from the root SQL relation before user filtering, ordering, cursor pagination,
+limit, and exact count. A previously valid but later-applied stale Product mutation therefore cannot
+become query-authoritative merely because it reached `index_entities` after the owner changed.
+
+The fence does not recursively prove freshness of every linked target row. Product root relation
+membership is current when admitted, but a missing/stale materialized SalesChannel or ProductVariant
+target can still affect joins/projections. That remains part of Product/Variant/Channel query-equivalence
+and linked-target evidence rather than being conflated with Product root freshness.
+
+## Current execution cursor
+
+Primary M6 owner cursor remains unchanged: execute and admit the locked concrete repair PostgreSQL
+packet.
+
+For M7, the next useful source/evidence slice is a retained PostgreSQL packet that proves the new
+Product root admission across:
+
+- a source-read -> Channel-change -> stale-mutation-apply race;
+- same-membership Channel generation refresh;
+- changed-membership projection advancement;
+- Product visibility change and rejected/corrected visibility;
+- Product scalar/Variant projection advancement;
+- Product and locale deletion/recreation;
+- filter/order/cursor/limit/exact-count exclusion;
+- convergence lease expiry/restart/multi-host contention.
+
+Product typed event work remains separately blocked on canonical event-contract digest admission.
+
+## Maintainer verification
+
+Suggested commands, intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-index-product-materialized-query-freshness.mjs
+node scripts/verify/verify-index-query-runtime-composition.mjs
+node scripts/verify/verify-index-product-channel-relation-convergence.mjs
+node scripts/verify/verify-index-query-contract.mjs
+cargo check -p rustok-index --all-targets
+cargo check -p rustok-distribution --features mod-product --all-targets
+git diff --check
+```
+
+No tests, Node verifiers, Cargo checks, formatting, PostgreSQL scenarios, workflows, or CI were executed
+by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-materialized-query-freshness.md
+++ b/crates/rustok-index/docs/m7-product-materialized-query-freshness.md
@@ -1,0 +1,146 @@
+# M7 Product materialized/query freshness fence
+
+Status: `source_complete_runtime_evidence_pending`.
+
+## Problem closed by this slice
+
+Product source admission already rejects stale Product-to-SalesChannel relation state, and automatic
+convergence re-establishes owner freshness after Product visibility or Channel identity changes. Those
+contracts do not by themselves protect an Index mutation that was produced under a valid source
+snapshot and then applied after owner state changed.
+
+The remaining window is:
+
+1. Product source reads a valid Product projection and freshness witness;
+2. owner Product/Channel state changes;
+3. the already-produced mutation is applied to `index_entities/index_links`;
+4. an Index query executes before the corrective mutation arrives.
+
+A post-result freshness check is insufficient because a stale row can already have changed filtering,
+ordering, cursor pagination, and exact count before the check sees returned rows.
+
+## Generic root query admission
+
+`rustok-index` now owns a trusted schema-scoped PostgreSQL root-admission contract.
+
+`PostgresQueryRootAdmission` accepts a source-code predicate template that:
+
+- must reference the compiler-controlled `{{root}}` alias;
+- cannot contain bind placeholders, SQL statement boundaries, or comments;
+- is bounded to 32 KiB;
+- is applied to the compiler's exact canonical root `index_entities` baseline;
+- fails closed if page or exact-count SQL no longer contains exactly one expected root anchor.
+
+The admission predicate changes no user binds, selected columns, query fingerprint, or cursor contract.
+It is injected into root `WHERE` before user filter/cursor/order/limit semantics. The same predicate is
+injected into exact-count SQL.
+
+`PostgresIndexQueryAdmissionCatalog` owns at most one rule per exact `SchemaRef`. Query runtime
+materialization snapshots that catalog into `PostgresIndexQueryPort`; schemas without a rule retain the
+existing generic behavior.
+
+## Product admission evidence
+
+The selected distribution registers one rule for the canonical Product schema. A materialized Product
+root row is query-admissible only when all of these facts are true in the same PostgreSQL
+`REPEATABLE READ`, `READ ONLY` query snapshot:
+
+- the owner Product still exists;
+- the exact Product locale translation still exists;
+- the materialized `index_entities.source_version` equals the latest Product
+  `product_index_graph_projection_snapshots.projection_epoch`;
+- that projection's Product component equals current `products.index_revision`;
+- a freshness witness exists for the projection's exact `relation_epoch`;
+- the witness Product revision is not ahead of current Product revision;
+- witness Channel identity generation equals current tenant `channel_index_identity_generations`
+  (or generation `0` when no Channel generation row exists);
+- there is no retained Product visibility convergence request with
+  `product_source_version > witness.product_source_version`.
+
+The last condition is the current-visibility proof. Product convergence requests are appended only for
+Product INSERT or canonical `channel_visibility` changes. Therefore an unrelated Product scalar update
+does not falsely invalidate relation freshness, while any later visibility change makes an older
+witness query-inadmissible without re-parsing Product visibility JSON in SQL.
+
+## Why no extra materialized watermark is needed
+
+The existing clocks already carry the required evidence:
+
+- `index_entities.source_version` is Product `projection_epoch`;
+- Product projection state identifies current Product and relation components;
+- the freshness witness identifies the observed Product revision and Channel generation;
+- the convergence request ledger identifies visibility-affecting Product revisions;
+- live Product/translation rows prove the materialized identity/locale still exists.
+
+A new Product schema, duplicate relation membership, query-time visibility parser, or new Index storage
+column would add another authority without improving the proof.
+
+## Important transitions
+
+### Product scalar/Variant change
+
+Product `index_revision` and projection advance. An older materialized row fails the projection epoch
+comparison until the new Product mutation is applied.
+
+### Product visibility change
+
+The Product update advances projection and appends an exact visibility convergence request. An older
+witness cannot satisfy the request-watermark check. The row remains query-inadmissible until resolver
+freshness is current and the new Product projection is materialized.
+
+### Channel identity change
+
+Current tenant Channel generation immediately differs from the old witness, so Product rows are
+query-inadmissible even if an old already-produced mutation applies afterward. Automatic convergence
+then refreshes witness/membership.
+
+If resolved UUID membership is unchanged, `relation_epoch`/`projection_epoch` need not move; updating
+the freshness witness to the current Channel generation is enough to make the unchanged materialized
+Product row query-admissible again.
+
+If membership changes, Product `relation_epoch` and `projection_epoch` advance; the old materialized
+row remains inadmissible until the new Product mutation is applied.
+
+### Product/locale delete
+
+A stale materialized Product row fails immediately because the live Product or exact translation no
+longer exists, even before the retained delete mutation reaches Index storage.
+
+### Rejected Product owner data
+
+A rejected Product remains individually fail-closed. Its retained visibility request stays newer than
+its last valid freshness witness, so query admission excludes it without blocking unrelated valid
+Products in the same tenant.
+
+## Scope and remaining admission
+
+This closes the source-read -> mutation-apply **Product root materialized/query freshness** gap at query
+admission source level. It does not claim successful PostgreSQL execution, latency, query parity, or
+Storefront production readiness.
+
+Still required before cutover:
+
+- retained PostgreSQL evidence proving page/filter/order/cursor/exact-count exclusion across the owner
+  race window;
+- automatic-convergence multi-host/restart/rejected-Product evidence;
+- complete Product/Variant/Channel query equivalence, including linked target availability behavior;
+- canonical Product typed event admission after event-contract digest verification;
+- Storefront cutover evidence after schema readiness, equivalence, convergence, and query-freshness
+  packets pass.
+
+## Maintainer verification
+
+Suggested commands, intentionally not run by the implementation agent:
+
+```bash
+node scripts/verify/verify-index-product-materialized-query-freshness.mjs
+node scripts/verify/verify-index-query-runtime-composition.mjs
+node scripts/verify/verify-index-product-channel-relation-convergence.mjs
+node scripts/verify/verify-index-query-contract.mjs
+cargo check -p rustok-index --all-targets
+cargo check -p rustok-distribution --features mod-product --all-targets
+git diff --check
+```
+
+No tests, Node verifiers, Cargo checks, formatting, PostgreSQL scenarios, workflows, or CI were executed
+by the implementation agent.

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -119,7 +119,8 @@ pub use postgres_compiler::{
     CompiledQueryColumn, PostgresBindValue, PostgresQueryBuildError, PostgresQueryCompileError,
 };
 pub use postgres_query_admission::{
-    PostgresQueryRootAdmission, PostgresQueryRootAdmissionError,
+    PostgresQueryRootAdmission, PostgresQueryRootAdmissionApplyError,
+    PostgresQueryRootAdmissionError,
 };
 pub use postgres_query_result::{
     CompiledPostgresCell, CompiledPostgresPageQuery, CompiledPostgresRow,

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -9,6 +9,7 @@ mod drift_repair_recovery;
 mod mutation_event;
 mod planner;
 mod postgres_compiler;
+mod postgres_query_admission;
 mod postgres_query_result;
 mod postgres_query_sql;
 mod query_port;
@@ -116,6 +117,9 @@ pub use planner::{
 pub use postgres_compiler::{
     CompiledManyRelationColumn, CompiledPostgresCount, CompiledPostgresQuery,
     CompiledQueryColumn, PostgresBindValue, PostgresQueryBuildError, PostgresQueryCompileError,
+};
+pub use postgres_query_admission::{
+    PostgresQueryRootAdmission, PostgresQueryRootAdmissionError,
 };
 pub use postgres_query_result::{
     CompiledPostgresCell, CompiledPostgresPageQuery, CompiledPostgresRow,

--- a/crates/rustok-index/src/application/postgres_query_admission.rs
+++ b/crates/rustok-index/src/application/postgres_query_admission.rs
@@ -129,7 +129,7 @@ fn validate_relation_alias(alias: &str) -> Result<(), PostgresQueryRootAdmission
 fn root_baseline(root_alias: &str) -> String {
     let root = quote_identifier(root_alias);
     format!(
-        "{root}.tenant_id = $1 AND {root}.module_name = $2 AND {root}.entity_name = $3 AND {root}.schema_version = $4 AND {root}.is_deleted = FALSE"
+        "{root}.tenant_id = $1 AND {root}.module_name = $2 AND {root}.entity_name = $3 AND {root}.schema_version = $4 AND {root}.locale_key = $5 AND {root}.is_deleted = FALSE"
     )
 }
 
@@ -177,10 +177,11 @@ mod tests {
     }
 
     #[test]
-    fn admission_anchor_is_exact_and_fail_closed() {
+    fn admission_anchor_matches_locale_scoped_compiler_baseline_and_fails_closed() {
+        let baseline = root_baseline("t0");
+        assert!(baseline.contains("\"t0\".locale_key = $5"));
         let mut sql = format!(
-            "SELECT 1 FROM index_entities AS \"t0\" WHERE {}",
-            root_baseline("t0")
+            "SELECT 1 FROM index_entities AS \"t0\" WHERE {baseline}"
         );
         apply_to_sql(&mut sql, "t0", "\"t0\".source_version > 0").unwrap();
         assert!(sql.contains("AND (\"t0\".source_version > 0)"));

--- a/crates/rustok-index/src/application/postgres_query_admission.rs
+++ b/crates/rustok-index/src/application/postgres_query_admission.rs
@@ -1,0 +1,109 @@
+use thiserror::Error;
+
+use super::postgres_compiler::quote_identifier;
+
+const ROOT_ALIAS_TOKEN: &str = "{{root}}";
+const MAX_ROOT_ADMISSION_BYTES: usize = 32 * 1024;
+
+/// Trusted PostgreSQL predicate applied to the root `index_entities` row before filtering,
+/// ordering, pagination, and exact-count evaluation.
+///
+/// Module-owned admission rules are source code, not user input. They intentionally accept no bind
+/// placeholders: all tenant/entity/locale correlation must flow through the controlled root alias.
+/// This keeps query bind numbering and cursor fingerprints independent of runtime admission state.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PostgresQueryRootAdmission {
+    template: String,
+}
+
+impl PostgresQueryRootAdmission {
+    pub fn new(template: impl Into<String>) -> Result<Self, PostgresQueryRootAdmissionError> {
+        let template = template.into();
+        validate_template(&template)?;
+        Ok(Self { template })
+    }
+
+    pub fn template(&self) -> &str {
+        &self.template
+    }
+
+    pub(crate) fn render(&self, root_alias: &str) -> String {
+        self.template
+            .replace(ROOT_ALIAS_TOKEN, &quote_identifier(root_alias))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Error)]
+pub enum PostgresQueryRootAdmissionError {
+    #[error("PostgreSQL root query admission predicate is empty")]
+    Empty,
+    #[error("PostgreSQL root query admission predicate is too large")]
+    TooLarge,
+    #[error("PostgreSQL root query admission predicate must reference the controlled root alias")]
+    MissingRootAlias,
+    #[error("PostgreSQL root query admission predicate contains a forbidden SQL boundary")]
+    ForbiddenSqlBoundary,
+    #[error("PostgreSQL root query admission predicate contains a bind placeholder")]
+    BindPlaceholderForbidden,
+    #[error("PostgreSQL root query admission predicate contains a control character")]
+    ControlCharacter,
+}
+
+fn validate_template(template: &str) -> Result<(), PostgresQueryRootAdmissionError> {
+    if template.trim().is_empty() {
+        return Err(PostgresQueryRootAdmissionError::Empty);
+    }
+    if template.len() > MAX_ROOT_ADMISSION_BYTES {
+        return Err(PostgresQueryRootAdmissionError::TooLarge);
+    }
+    if !template.contains(ROOT_ALIAS_TOKEN) {
+        return Err(PostgresQueryRootAdmissionError::MissingRootAlias);
+    }
+    if template.contains(';')
+        || template.contains("--")
+        || template.contains("/*")
+        || template.contains("*/")
+    {
+        return Err(PostgresQueryRootAdmissionError::ForbiddenSqlBoundary);
+    }
+    if template.contains('$') {
+        return Err(PostgresQueryRootAdmissionError::BindPlaceholderForbidden);
+    }
+    if template
+        .chars()
+        .any(|character| character.is_control() && !matches!(character, '\n' | '\r' | '\t'))
+    {
+        return Err(PostgresQueryRootAdmissionError::ControlCharacter);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn admission_requires_controlled_alias_without_sql_boundaries_or_binds() {
+        assert!(PostgresQueryRootAdmission::new("{{root}}.source_version > 0").is_ok());
+        for invalid in [
+            "",
+            "TRUE",
+            "{{root}}.source_version = $1",
+            "{{root}}.source_version > 0; SELECT 1",
+            "{{root}}.source_version > 0 -- bypass",
+        ] {
+            assert!(PostgresQueryRootAdmission::new(invalid).is_err(), "{invalid}");
+        }
+    }
+
+    #[test]
+    fn admission_renders_only_the_compiler_owned_root_alias() {
+        let admission = PostgresQueryRootAdmission::new(
+            "EXISTS (SELECT 1 WHERE {{root}}.source_version > 0 AND {{root}}.is_deleted = FALSE)",
+        )
+        .unwrap();
+        let rendered = admission.render("t0");
+        assert!(rendered.contains("\"t0\".source_version"));
+        assert!(!rendered.contains(ROOT_ALIAS_TOKEN));
+    }
+}

--- a/crates/rustok-index/src/application/postgres_query_admission.rs
+++ b/crates/rustok-index/src/application/postgres_query_admission.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use super::postgres_compiler::quote_identifier;
+use super::{CompiledPostgresQuery, CompiledQueryColumn, postgres_compiler::quote_identifier};
 
 const ROOT_ALIAS_TOKEN: &str = "{{root}}";
 const MAX_ROOT_ADMISSION_BYTES: usize = 32 * 1024;
@@ -27,7 +27,34 @@ impl PostgresQueryRootAdmission {
         &self.template
     }
 
-    pub(crate) fn render(&self, root_alias: &str) -> String {
+    /// Applies the trusted predicate to a validated compiler product without changing bind values,
+    /// selected columns, query-plan fingerprint, or cursor semantics.
+    ///
+    /// The compiler-owned root baseline is intentionally treated as a fail-closed anchor. If page or
+    /// exact-count SQL no longer contains exactly one canonical anchor, the query is rejected rather
+    /// than silently running without admission.
+    pub fn apply(
+        &self,
+        compiled: &mut CompiledPostgresQuery,
+    ) -> Result<(), PostgresQueryRootAdmissionApplyError> {
+        let root_alias = compiled
+            .columns
+            .iter()
+            .find_map(|column| match column {
+                CompiledQueryColumn::EntityId { relation_alias, .. } => Some(relation_alias.as_str()),
+                _ => None,
+            })
+            .ok_or(PostgresQueryRootAdmissionApplyError::MissingRootIdentity)?;
+        validate_relation_alias(root_alias)?;
+        let rendered = self.render(root_alias);
+        apply_to_sql(&mut compiled.sql, root_alias, &rendered)?;
+        if let Some(exact_count) = compiled.exact_count.as_mut() {
+            apply_to_sql(&mut exact_count.sql, root_alias, &rendered)?;
+        }
+        Ok(())
+    }
+
+    fn render(&self, root_alias: &str) -> String {
         self.template
             .replace(ROOT_ALIAS_TOKEN, &quote_identifier(root_alias))
     }
@@ -47,6 +74,16 @@ pub enum PostgresQueryRootAdmissionError {
     BindPlaceholderForbidden,
     #[error("PostgreSQL root query admission predicate contains a control character")]
     ControlCharacter,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Error)]
+pub enum PostgresQueryRootAdmissionApplyError {
+    #[error("compiled PostgreSQL query has no root entity identity column")]
+    MissingRootIdentity,
+    #[error("compiled PostgreSQL query root alias is invalid")]
+    InvalidRootAlias,
+    #[error("compiled PostgreSQL query does not contain exactly one canonical root admission anchor")]
+    RootAnchorMismatch,
 }
 
 fn validate_template(template: &str) -> Result<(), PostgresQueryRootAdmissionError> {
@@ -78,6 +115,38 @@ fn validate_template(template: &str) -> Result<(), PostgresQueryRootAdmissionErr
     Ok(())
 }
 
+fn validate_relation_alias(alias: &str) -> Result<(), PostgresQueryRootAdmissionApplyError> {
+    let valid = alias.strip_prefix('t').is_some_and(|suffix| {
+        !suffix.is_empty() && suffix.bytes().all(|byte| byte.is_ascii_digit())
+    });
+    if valid {
+        Ok(())
+    } else {
+        Err(PostgresQueryRootAdmissionApplyError::InvalidRootAlias)
+    }
+}
+
+fn root_baseline(root_alias: &str) -> String {
+    let root = quote_identifier(root_alias);
+    format!(
+        "{root}.tenant_id = $1 AND {root}.module_name = $2 AND {root}.entity_name = $3 AND {root}.schema_version = $4 AND {root}.is_deleted = FALSE"
+    )
+}
+
+fn apply_to_sql(
+    sql: &mut String,
+    root_alias: &str,
+    rendered: &str,
+) -> Result<(), PostgresQueryRootAdmissionApplyError> {
+    let anchor = root_baseline(root_alias);
+    if sql.match_indices(&anchor).count() != 1 {
+        return Err(PostgresQueryRootAdmissionApplyError::RootAnchorMismatch);
+    }
+    let replacement = format!("{anchor} AND ({rendered})");
+    *sql = sql.replacen(&anchor, &replacement, 1);
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -105,5 +174,19 @@ mod tests {
         let rendered = admission.render("t0");
         assert!(rendered.contains("\"t0\".source_version"));
         assert!(!rendered.contains(ROOT_ALIAS_TOKEN));
+    }
+
+    #[test]
+    fn admission_anchor_is_exact_and_fail_closed() {
+        let mut sql = format!(
+            "SELECT 1 FROM index_entities AS \"t0\" WHERE {}",
+            root_baseline("t0")
+        );
+        apply_to_sql(&mut sql, "t0", "\"t0\".source_version > 0").unwrap();
+        assert!(sql.contains("AND (\"t0\".source_version > 0)"));
+        assert_eq!(
+            apply_to_sql(&mut "SELECT 1".to_owned(), "t0", "TRUE"),
+            Err(PostgresQueryRootAdmissionApplyError::RootAnchorMismatch)
+        );
     }
 }

--- a/crates/rustok-index/src/infrastructure/postgres/mod.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/mod.rs
@@ -12,6 +12,7 @@ mod drift_repair_recovery;
 mod drift_snapshot_reader;
 mod mutation_store;
 mod partition_admission;
+mod query_admission;
 mod query_port;
 mod query_runtime;
 mod replay_runtime;
@@ -107,6 +108,10 @@ pub use partition_admission::{
     PartitionAdmissionReason, PartitionBaselineEvidence, PartitionEvidence,
     PartitionMeasurementCoverage, PartitionRelationPlan, PartitionShadowEvidence,
     PartitionShadowPlan, PartitionStrategy, evaluate_partition_admission,
+};
+pub use query_admission::{
+    PostgresIndexQueryAdmissionCatalog, PostgresIndexQueryAdmissionDescriptor,
+    PostgresIndexQueryAdmissionError, register_postgres_index_query_admission,
 };
 pub use query_port::PostgresIndexQueryPort;
 pub use query_runtime::{

--- a/crates/rustok-index/src/infrastructure/postgres/query_admission.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/query_admission.rs
@@ -1,0 +1,155 @@
+use std::collections::BTreeMap;
+
+use rustok_core::ModuleRuntimeExtensions;
+use thiserror::Error;
+
+use crate::{PostgresQueryRootAdmission, PostgresQueryRootAdmissionError, SchemaRef};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PostgresIndexQueryAdmissionDescriptor {
+    owner_module: String,
+    schema: SchemaRef,
+    admission: PostgresQueryRootAdmission,
+}
+
+impl PostgresIndexQueryAdmissionDescriptor {
+    pub fn owner_module(&self) -> &str {
+        &self.owner_module
+    }
+
+    pub fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    pub fn admission(&self) -> &PostgresQueryRootAdmission {
+        &self.admission
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct PostgresIndexQueryAdmissionCatalog {
+    entries: BTreeMap<SchemaRef, PostgresIndexQueryAdmissionDescriptor>,
+}
+
+impl PostgresIndexQueryAdmissionCatalog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn get(&self, schema: &SchemaRef) -> Option<&PostgresIndexQueryAdmissionDescriptor> {
+        self.entries.get(schema)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &PostgresIndexQueryAdmissionDescriptor> {
+        self.entries.values()
+    }
+
+    pub fn register(
+        &mut self,
+        owner_module: impl Into<String>,
+        schema: SchemaRef,
+        admission: PostgresQueryRootAdmission,
+    ) -> Result<(), PostgresIndexQueryAdmissionError> {
+        let owner_module = owner_module.into();
+        validate_owner_module(&owner_module)?;
+        if let Some(existing) = self.entries.get(&schema) {
+            return Err(PostgresIndexQueryAdmissionError::DuplicateSchema {
+                schema,
+                existing_owner: existing.owner_module.clone(),
+                incoming_owner: owner_module,
+            });
+        }
+        self.entries.insert(
+            schema.clone(),
+            PostgresIndexQueryAdmissionDescriptor {
+                owner_module,
+                schema,
+                admission,
+            },
+        );
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Error)]
+pub enum PostgresIndexQueryAdmissionError {
+    #[error("PostgreSQL Index query admission owner module is invalid: {0}")]
+    InvalidOwnerModule(String),
+    #[error(
+        "PostgreSQL Index query admission for {schema} has multiple owners: existing={existing_owner}, incoming={incoming_owner}"
+    )]
+    DuplicateSchema {
+        schema: SchemaRef,
+        existing_owner: String,
+        incoming_owner: String,
+    },
+    #[error(transparent)]
+    InvalidAdmission(#[from] PostgresQueryRootAdmissionError),
+}
+
+pub fn register_postgres_index_query_admission(
+    extensions: &mut ModuleRuntimeExtensions,
+    owner_module: impl Into<String>,
+    schema: SchemaRef,
+    admission: PostgresQueryRootAdmission,
+) -> Result<(), PostgresIndexQueryAdmissionError> {
+    extensions
+        .get_or_insert_with::<PostgresIndexQueryAdmissionCatalog, _>(
+            PostgresIndexQueryAdmissionCatalog::new,
+        )
+        .register(owner_module, schema, admission)
+}
+
+fn validate_owner_module(value: &str) -> Result<(), PostgresIndexQueryAdmissionError> {
+    let valid = !value.is_empty()
+        && value.len() <= 128
+        && value.bytes().all(|byte| {
+            byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || matches!(byte, b'-' | b'_')
+        });
+    if valid {
+        Ok(())
+    } else {
+        Err(PostgresIndexQueryAdmissionError::InvalidOwnerModule(
+            value.to_owned(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EntityName, ModuleName, SchemaVersion};
+
+    fn schema() -> SchemaRef {
+        SchemaRef {
+            module: ModuleName::new("rustok-product").unwrap(),
+            entity: EntityName::new("product").unwrap(),
+            version: SchemaVersion::new(3),
+        }
+    }
+
+    #[test]
+    fn exact_schema_has_one_query_admission_owner() {
+        let admission = PostgresQueryRootAdmission::new("{{root}}.source_version > 0").unwrap();
+        let mut catalog = PostgresIndexQueryAdmissionCatalog::new();
+        catalog
+            .register("product", schema(), admission.clone())
+            .unwrap();
+        assert_eq!(catalog.len(), 1);
+        assert_eq!(catalog.get(&schema()).unwrap().owner_module(), "product");
+        assert!(matches!(
+            catalog.register("other", schema(), admission),
+            Err(PostgresIndexQueryAdmissionError::DuplicateSchema { .. })
+        ));
+    }
+}

--- a/crates/rustok-index/src/infrastructure/postgres/query_port.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/query_port.rs
@@ -18,6 +18,8 @@ use crate::{
     domain::{IndexQuery, SchemaRef},
 };
 
+use super::PostgresIndexQueryAdmissionCatalog;
+
 const EXACT_COUNT_ALIAS: &str = "__exact_count";
 const READ_ONLY_SNAPSHOT_SQL: &str =
     "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY";
@@ -33,18 +35,32 @@ struct RequiredSchemaContract {
 
 /// PostgreSQL execution adapter for the transport-neutral [`IndexQueryPort`].
 ///
-/// The adapter compiles through the owned immutable registry, verifies every schema
-/// touched by the plan against tenant-scoped persisted registration, and executes the
-/// page plus optional exact count inside one read-only repeatable-read snapshot.
+/// The adapter compiles through the owned immutable registry, applies any trusted root-row
+/// admission rule before filter/order/pagination/count execution, verifies every schema touched by
+/// the plan against tenant-scoped persisted registration, and executes the page plus optional exact
+/// count inside one read-only repeatable-read snapshot.
 #[derive(Clone)]
 pub struct PostgresIndexQueryPort {
     db: DatabaseConnection,
     registry: Arc<SchemaRegistry>,
+    admissions: PostgresIndexQueryAdmissionCatalog,
 }
 
 impl PostgresIndexQueryPort {
     pub fn new(db: DatabaseConnection, registry: Arc<SchemaRegistry>) -> Self {
-        Self { db, registry }
+        Self::with_admissions(db, registry, PostgresIndexQueryAdmissionCatalog::new())
+    }
+
+    pub fn with_admissions(
+        db: DatabaseConnection,
+        registry: Arc<SchemaRegistry>,
+        admissions: PostgresIndexQueryAdmissionCatalog,
+    ) -> Self {
+        Self {
+            db,
+            registry,
+            admissions,
+        }
     }
 
     pub fn connection(&self) -> &DatabaseConnection {
@@ -55,11 +71,33 @@ impl PostgresIndexQueryPort {
         &self.registry
     }
 
+    pub fn admissions(&self) -> &PostgresIndexQueryAdmissionCatalog {
+        &self.admissions
+    }
+
+    fn admitted_compiled_query(
+        &self,
+        query: &IndexQuery,
+        page_query: &CompiledPostgresPageQuery,
+    ) -> Result<CompiledPostgresQuery, IndexQueryExecutionError> {
+        let mut compiled = page_query.compiled().clone();
+        if let Some(descriptor) = self.admissions.get(&query.schema) {
+            descriptor
+                .admission()
+                .apply(&mut compiled)
+                .map_err(|error| {
+                    IndexQueryExecutionError::contract_preparation(query.schema.clone(), error)
+                })?;
+        }
+        Ok(compiled)
+    }
+
     async fn execute_in_transaction(
         &self,
         transaction: &DatabaseTransaction,
         query: &IndexQuery,
         page_query: &CompiledPostgresPageQuery,
+        compiled: &CompiledPostgresQuery,
         required_schemas: &[RequiredSchemaContract],
     ) -> Result<IndexQueryPage, IndexQueryExecutionError> {
         transaction
@@ -71,7 +109,6 @@ impl PostgresIndexQueryPort {
 
         verify_persisted_schemas(transaction, query, required_schemas).await?;
 
-        let compiled = page_query.compiled();
         let page_rows = transaction
             .query_all(compiled_statement(compiled))
             .await
@@ -103,13 +140,20 @@ impl IndexQueryPort for PostgresIndexQueryPort {
 
         let required_schemas = required_schema_contracts(&self.registry, &query)?;
         let page_query = self.registry.compile_postgres_page_query(&query)?;
+        let compiled = self.admitted_compiled_query(&query, &page_query)?;
         let transaction = self
             .db
             .begin()
             .await
             .map_err(|error| IndexQueryExecutionError::storage("begin query snapshot", error))?;
         let result = self
-            .execute_in_transaction(&transaction, &query, &page_query, &required_schemas)
+            .execute_in_transaction(
+                &transaction,
+                &query,
+                &page_query,
+                &compiled,
+                &required_schemas,
+            )
             .await;
 
         match result {

--- a/crates/rustok-index/src/infrastructure/postgres/query_runtime.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/query_runtime.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 use crate::application::{SharedIndexQueryRuntime, SharedIndexSchemaRegistry};
 
-use super::PostgresIndexQueryPort;
+use super::{PostgresIndexQueryAdmissionCatalog, PostgresIndexQueryPort};
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum IndexQueryRuntimeCompositionError {
@@ -17,8 +17,10 @@ pub enum IndexQueryRuntimeCompositionError {
 /// Materializes the canonical PostgreSQL-backed query runtime from the complete source registry.
 ///
 /// Absence of a source registry is represented as `Ok(None)` and never produces an empty or
-/// partially useful runtime. The function performs no database I/O and makes no tenant schema
-/// readiness claim; those checks remain inside the query port when a request executes.
+/// partially useful runtime. Trusted schema-scoped root admission rules are snapshotted into the
+/// immutable runtime at materialization time. The function performs no database I/O and makes no
+/// tenant schema-readiness or owner-freshness claim; those checks remain inside the query port when a
+/// request executes.
 pub fn materialize_postgres_index_query_runtime(
     extensions: &mut ModuleRuntimeExtensions,
     db: DatabaseConnection,
@@ -30,10 +32,15 @@ pub fn materialize_postgres_index_query_runtime(
     let Some(registry) = extensions.get::<SharedIndexSchemaRegistry>().cloned() else {
         return Ok(None);
     };
+    let admissions = extensions
+        .get::<PostgresIndexQueryAdmissionCatalog>()
+        .cloned()
+        .unwrap_or_default();
 
-    let runtime = SharedIndexQueryRuntime::new(Arc::new(PostgresIndexQueryPort::new(
+    let runtime = SharedIndexQueryRuntime::new(Arc::new(PostgresIndexQueryPort::with_admissions(
         db,
         registry.shared(),
+        admissions,
     )));
     extensions.insert(runtime.clone());
     Ok(Some(runtime))
@@ -46,8 +53,9 @@ mod tests {
 
     use crate::{
         EntityName, FieldCardinality, FieldName, IndexField, IndexSchema, IndexValueType,
-        LocaleMode, ModuleName, SchemaRef, SchemaVersion, SharedIndexQueryRuntime,
-        materialize_index_schema_registry, register_index_schema_source,
+        LocaleMode, ModuleName, PostgresIndexQueryAdmissionCatalog, PostgresQueryRootAdmission,
+        SchemaRef, SchemaVersion, SharedIndexQueryRuntime, materialize_index_schema_registry,
+        register_index_schema_source, register_postgres_index_query_admission,
     };
 
     use super::{
@@ -113,6 +121,36 @@ mod tests {
                 .expect("runtime should be published")
                 .shared_port(),
         ));
+    }
+
+    #[tokio::test]
+    async fn query_admission_catalog_is_snapshotted_into_runtime_composition() {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        let selected = schema();
+        register_index_schema_source(&mut extensions, "runtime_owner", selected.clone()).unwrap();
+        register_postgres_index_query_admission(
+            &mut extensions,
+            "runtime_owner",
+            selected.reference.clone(),
+            PostgresQueryRootAdmission::new("{{root}}.source_version > 0").unwrap(),
+        )
+        .unwrap();
+        let registry = materialize_index_schema_registry(&extensions)
+            .unwrap()
+            .expect("registry");
+        extensions.insert(registry);
+
+        materialize_postgres_index_query_runtime(&mut extensions, connection().await)
+            .expect("query runtime should materialize")
+            .expect("runtime");
+
+        assert_eq!(
+            extensions
+                .get::<PostgresIndexQueryAdmissionCatalog>()
+                .expect("admission catalog")
+                .len(),
+            1
+        );
     }
 
     #[tokio::test]

--- a/crates/rustok-index/src/infrastructure/postgres/query_runtime.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/query_runtime.rs
@@ -5,6 +5,7 @@ use sea_orm::DatabaseConnection;
 use thiserror::Error;
 
 use crate::application::{SharedIndexQueryRuntime, SharedIndexSchemaRegistry};
+use crate::domain::SchemaRef;
 
 use super::{PostgresIndexQueryAdmissionCatalog, PostgresIndexQueryPort};
 
@@ -12,15 +13,21 @@ use super::{PostgresIndexQueryAdmissionCatalog, PostgresIndexQueryPort};
 pub enum IndexQueryRuntimeCompositionError {
     #[error("shared Index query runtime is already materialized")]
     AlreadyMaterialized,
+    #[error("PostgreSQL Index query admission owner {owner_module} targets unregistered schema {schema}")]
+    AdmissionSchemaMissing {
+        owner_module: String,
+        schema: SchemaRef,
+    },
 }
 
 /// Materializes the canonical PostgreSQL-backed query runtime from the complete source registry.
 ///
 /// Absence of a source registry is represented as `Ok(None)` and never produces an empty or
 /// partially useful runtime. Trusted schema-scoped root admission rules are snapshotted into the
-/// immutable runtime at materialization time. The function performs no database I/O and makes no
-/// tenant schema-readiness or owner-freshness claim; those checks remain inside the query port when a
-/// request executes.
+/// immutable runtime at materialization time. Every rule must target a schema present in the same
+/// complete immutable registry; dangling rules fail composition rather than silently never applying.
+/// The function performs no database I/O and makes no tenant schema-readiness or owner-freshness
+/// claim; those checks remain inside the query port when a request executes.
 pub fn materialize_postgres_index_query_runtime(
     extensions: &mut ModuleRuntimeExtensions,
     db: DatabaseConnection,
@@ -36,6 +43,14 @@ pub fn materialize_postgres_index_query_runtime(
         .get::<PostgresIndexQueryAdmissionCatalog>()
         .cloned()
         .unwrap_or_default();
+    for descriptor in admissions.iter() {
+        if registry.registry().get(descriptor.schema()).is_none() {
+            return Err(IndexQueryRuntimeCompositionError::AdmissionSchemaMissing {
+                owner_module: descriptor.owner_module().to_owned(),
+                schema: descriptor.schema().clone(),
+            });
+        }
+    }
 
     let runtime = SharedIndexQueryRuntime::new(Arc::new(PostgresIndexQueryPort::with_admissions(
         db,
@@ -151,6 +166,40 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    #[tokio::test]
+    async fn dangling_query_admission_schema_fails_composition() {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        let selected = schema();
+        register_index_schema_source(&mut extensions, "runtime_owner", selected).unwrap();
+        let missing = SchemaRef {
+            module: ModuleName::new("runtime-owner").unwrap(),
+            entity: EntityName::new("missing").unwrap(),
+            version: SchemaVersion::INITIAL,
+        };
+        register_postgres_index_query_admission(
+            &mut extensions,
+            "runtime_owner",
+            missing.clone(),
+            PostgresQueryRootAdmission::new("{{root}}.source_version > 0").unwrap(),
+        )
+        .unwrap();
+        let registry = materialize_index_schema_registry(&extensions)
+            .unwrap()
+            .expect("registry");
+        extensions.insert(registry);
+
+        let error = materialize_postgres_index_query_runtime(&mut extensions, connection().await)
+            .expect_err("dangling admission must fail composition");
+        assert_eq!(
+            error,
+            IndexQueryRuntimeCompositionError::AdmissionSchemaMissing {
+                owner_module: "runtime_owner".to_owned(),
+                schema: missing,
+            }
+        );
+        assert!(!extensions.contains::<SharedIndexQueryRuntime>());
     }
 
     #[tokio::test]

--- a/crates/rustok-index/src/lib.rs
+++ b/crates/rustok-index/src/lib.rs
@@ -81,6 +81,11 @@ pub use infrastructure::postgres::{
     PostgresSchemaRegistrationStore, PostgresSecondaryIndexManager,
     RecoveryAwareIndexDriftRepairOwner, RecoveryAwareIndexDriftRepairStore,
     SchemaApplicationLease, SchemaApplicationLeaseRequest, SchemaLeaseAcquireOutcome,
+    SchemaLeaseError, SchemaRegistrationError, SecondaryIndexClaimOutcome,
+    SecondaryIndexError, SecondaryIndexExecutionOutcome, SecondaryIndexKind,
+    SecondaryIndexLease, SecondaryIndexOperation, SecondaryIndexPlan,
+    SecondaryIndexRequest, SecondaryIndexSpec, SharedIndexReplayRuntime,
+    MAX_INDEX_SCHEMA_READINESS_SCHEMAS, INDEX_RECONCILIATION_WORKER,
 };
 
 pub struct IndexModule;
@@ -96,27 +101,26 @@ impl RusToKModule for IndexModule {
     }
 
     fn description(&self) -> &'static str {
-        "Cross-module relational indexing, filtering, sorting, joins and faceting"
+        "Cross-module relational index and query engine."
     }
 
     fn version(&self) -> &'static str {
         env!("CARGO_PKG_VERSION")
     }
 
-    fn dependencies(&self) -> &[&'static str] {
-        &[]
-    }
-
     fn kind(&self) -> ModuleKind {
-        ModuleKind::Infrastructure
+        ModuleKind::Core
     }
 
     fn register_runtime_extensions(
         &self,
         extensions: &mut ModuleRuntimeExtensions,
     ) -> rustok_core::Result<()> {
-        extensions.insert(application::IndexSchemaSourceCatalog::new());
-        extensions.insert(infrastructure::postgres::PostgresIndexSourceFactoryCatalog::new());
+        extensions.get_or_insert_with::<IndexSchemaSourceCatalog, _>(IndexSchemaSourceCatalog::new);
+        extensions.get_or_insert_with::<IndexSourceCatalog, _>(IndexSourceCatalog::new);
+        extensions.get_or_insert_with::<PostgresIndexSourceFactoryCatalog, _>(
+            PostgresIndexSourceFactoryCatalog::new,
+        );
         Ok(())
     }
 }
@@ -130,3 +134,6 @@ impl MigrationSource for IndexModule {
         migrations::migration_dependencies()
     }
 }
+
+#[cfg(test)]
+mod contract_tests;

--- a/crates/rustok-index/src/lib.rs
+++ b/crates/rustok-index/src/lib.rs
@@ -42,7 +42,8 @@ pub use infrastructure::postgres::{
     materialize_postgres_index_drift_repair_store,
     materialize_postgres_index_drift_snapshot_reader, materialize_postgres_index_query_runtime,
     materialize_postgres_index_replay_runtime, materialize_postgres_index_sources,
-    register_postgres_index_reconciliation_work, register_postgres_index_source_factory,
+    register_postgres_index_query_admission, register_postgres_index_reconciliation_work,
+    register_postgres_index_source_factory,
     IndexDriftCandidateCompositionError, IndexDriftCandidateObserverCompositionError,
     IndexDriftConfirmedCandidateNotRecordedReason, IndexDriftConfirmedCandidateRecordError,
     IndexDriftConfirmedCandidateRecordOutcome, IndexDriftSnapshotCompositionError,
@@ -69,7 +70,9 @@ pub use infrastructure::postgres::{
     PostgresIndexDriftMissingEntityEvidenceReader, PostgresIndexDriftMissingEntityRepairOwner,
     PostgresIndexDriftOrphanLinkEvidenceReader, PostgresIndexDriftOrphanLinkRepairOwner,
     PostgresIndexDriftRepairRecoveryStore, PostgresIndexDriftRepairStore,
-    PostgresIndexDriftSnapshotReader, PostgresIndexQueryPort, PostgresIndexSchemaReadinessStore,
+    PostgresIndexDriftSnapshotReader, PostgresIndexQueryAdmissionCatalog,
+    PostgresIndexQueryAdmissionDescriptor, PostgresIndexQueryAdmissionError,
+    PostgresIndexQueryPort, PostgresIndexSchemaReadinessStore,
     PostgresIndexReconciliationRetryStore, PostgresIndexReconciliationRunner,
     PostgresIndexReconciliationWorkAdapter, PostgresIndexReplayCheckpointStore,
     PostgresIndexReplayJobStore, PostgresIndexReplayRunner, PostgresIndexSourceFactory,
@@ -78,11 +81,6 @@ pub use infrastructure::postgres::{
     PostgresSchemaRegistrationStore, PostgresSecondaryIndexManager,
     RecoveryAwareIndexDriftRepairOwner, RecoveryAwareIndexDriftRepairStore,
     SchemaApplicationLease, SchemaApplicationLeaseRequest, SchemaLeaseAcquireOutcome,
-    SchemaLeaseError, SchemaRegistrationError, SecondaryIndexClaimOutcome,
-    SecondaryIndexError, SecondaryIndexExecutionOutcome, SecondaryIndexKind,
-    SecondaryIndexLease, SecondaryIndexOperation, SecondaryIndexPlan,
-    SecondaryIndexRequest, SecondaryIndexSpec, SharedIndexReplayRuntime,
-    MAX_INDEX_SCHEMA_READINESS_SCHEMAS, INDEX_RECONCILIATION_WORKER,
 };
 
 pub struct IndexModule;
@@ -98,26 +96,27 @@ impl RusToKModule for IndexModule {
     }
 
     fn description(&self) -> &'static str {
-        "Cross-module relational index and query engine."
+        "Cross-module relational indexing, filtering, sorting, joins and faceting"
     }
 
     fn version(&self) -> &'static str {
         env!("CARGO_PKG_VERSION")
     }
 
+    fn dependencies(&self) -> &[&'static str] {
+        &[]
+    }
+
     fn kind(&self) -> ModuleKind {
-        ModuleKind::Core
+        ModuleKind::Infrastructure
     }
 
     fn register_runtime_extensions(
         &self,
         extensions: &mut ModuleRuntimeExtensions,
     ) -> rustok_core::Result<()> {
-        extensions.get_or_insert_with::<IndexSchemaSourceCatalog, _>(IndexSchemaSourceCatalog::new);
-        extensions.get_or_insert_with::<IndexSourceCatalog, _>(IndexSourceCatalog::new);
-        extensions.get_or_insert_with::<PostgresIndexSourceFactoryCatalog, _>(
-            PostgresIndexSourceFactoryCatalog::new,
-        );
+        extensions.insert(application::IndexSchemaSourceCatalog::new());
+        extensions.insert(infrastructure::postgres::PostgresIndexSourceFactoryCatalog::new());
         Ok(())
     }
 }
@@ -131,6 +130,3 @@ impl MigrationSource for IndexModule {
         migrations::migration_dependencies()
     }
 }
-
-#[cfg(test)]
-mod contract_tests;

--- a/scripts/verify/verify-index-product-materialized-query-freshness.mjs
+++ b/scripts/verify/verify-index-product-materialized-query-freshness.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-materialized-query-freshness] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+const forbidMarkers = (relative, source, markers) => {
+  for (const marker of markers) {
+    if (source.includes(marker)) fail(`${relative} contains forbidden marker ${marker}`);
+  }
+};
+
+const admissionPath = 'crates/rustok-index/src/application/postgres_query_admission.rs';
+const admission = requireMarkers(admissionPath, [
+  'ROOT_ALIAS_TOKEN: &str = "{{root}}"',
+  'MAX_ROOT_ADMISSION_BYTES: usize = 32 * 1024',
+  'BindPlaceholderForbidden',
+  'RootAnchorMismatch',
+  'pub fn apply(',
+  'compiled.columns.first()',
+  'CompiledQueryColumn::EntityId',
+  'compiled.exact_count.as_mut()',
+  'root_baseline(root_alias)',
+  'sql.match_indices(&anchor).count() != 1',
+  '*sql = sql.replacen(&anchor, &replacement, 1)',
+]);
+forbidMarkers(admissionPath, admission, [
+  'DatabaseConnection',
+  'Statement::',
+  'IndexMutation',
+  'tokio::spawn',
+  'loop {',
+]);
+
+const catalogPath = 'crates/rustok-index/src/infrastructure/postgres/query_admission.rs';
+const catalog = requireMarkers(catalogPath, [
+  'pub struct PostgresIndexQueryAdmissionCatalog',
+  'BTreeMap<SchemaRef, PostgresIndexQueryAdmissionDescriptor>',
+  'pub fn register_postgres_index_query_admission(',
+  'DuplicateSchema',
+  '.get_or_insert_with::<PostgresIndexQueryAdmissionCatalog',
+]);
+forbidMarkers(catalogPath, catalog, ['DatabaseConnection', 'Statement::', 'tokio::spawn']);
+
+const portPath = 'crates/rustok-index/src/infrastructure/postgres/query_port.rs';
+const port = requireMarkers(portPath, [
+  'admissions: PostgresIndexQueryAdmissionCatalog',
+  'pub fn with_admissions(',
+  'let mut compiled = page_query.compiled().clone()',
+  'self.admissions.get(&query.schema)',
+  '.admission()',
+  '.apply(&mut compiled)',
+  'SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY',
+  'verify_persisted_schemas(transaction, query, required_schemas).await?',
+  'compiled_statement(compiled)',
+  'compiled.exact_count.as_ref()',
+  'self.registry.decode_postgres_query_page(query, page_query, page_rows, exact_count_row)',
+]);
+forbidMarkers(portPath, port, ['tokio::spawn', 'IndexMutation::']);
+
+const runtimePath = 'crates/rustok-index/src/infrastructure/postgres/query_runtime.rs';
+requireMarkers(runtimePath, [
+  'PostgresIndexQueryAdmissionCatalog',
+  '.get::<PostgresIndexQueryAdmissionCatalog>()',
+  '.cloned()',
+  '.unwrap_or_default()',
+  'PostgresIndexQueryPort::with_admissions(',
+  'query_admission_catalog_is_snapshotted_into_runtime_composition',
+]);
+
+const productAdmissionPath = 'crates/rustok-distribution/src/product_index/query_admission.rs';
+const productAdmission = requireMarkers(productAdmissionPath, [
+  'PRODUCT_QUERY_MATERIALIZED_FRESHNESS',
+  'FROM products owner_product',
+  'product_index_graph_projection_snapshots',
+  'ORDER BY projection.projection_epoch DESC',
+  'product_sales_channel_index_relation_freshness_snapshots',
+  'witness.relation_epoch = current_projection.relation_epoch',
+  'ORDER BY witness.sequence_no DESC',
+  '{{root}}.source_version = current_projection.projection_epoch',
+  'current_projection.product_source_version = owner_product.index_revision',
+  'current_freshness.product_source_version <= owner_product.index_revision',
+  'channel_index_identity_generations',
+  'current_freshness.channel_identity_generation = COALESCE(',
+  'product_sales_channel_index_relation_convergence_requests',
+  'request.product_source_version > current_freshness.product_source_version',
+  'FROM product_translations translation',
+  'translation.locale = {{root}}.locale_key',
+  'register_postgres_index_query_admission(',
+  'SchemaVersion::new(3)',
+]);
+forbidMarkers(productAdmissionPath, productAdmission, [
+  'index_entities',
+  'index_links',
+  '$1',
+  'channel_visibility',
+  'IndexMutation',
+  'INSERT ',
+  'UPDATE ',
+  'DELETE FROM',
+  'tokio::spawn',
+  'loop {',
+]);
+
+requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
+  'mod query_admission;',
+  'query_admission::register(extensions)?;',
+  'selected_product_bridge_registers_two_current_schemas_three_factories_and_query_admission',
+  'PostgresIndexQueryAdmissionCatalog',
+]);
+requireMarkers('crates/rustok-index/src/lib.rs', [
+  'register_postgres_index_query_admission',
+  'PostgresIndexQueryAdmissionCatalog',
+  'PostgresIndexQueryAdmissionDescriptor',
+]);
+requireMarkers('crates/rustok-index/docs/m7-product-materialized-query-freshness.md', [
+  'Status: `source_complete_runtime_evidence_pending`',
+  'source-read -> mutation-apply',
+  'A post-result freshness check is insufficient',
+  'Generic root query admission',
+  'Product admission evidence',
+  '`index_entities.source_version` is Product `projection_epoch`',
+  'there is no retained Product visibility convergence request',
+  'same predicate is',
+  'exact-count SQL',
+  'Rejected Product owner data',
+]);
+
+const compilerPath = 'crates/rustok-index/src/application/postgres_query_sql.rs';
+requireMarkers(compilerPath, [
+  'columns.push(CompiledQueryColumn::EntityId',
+  'root_baseline_predicates(',
+  'predicates.extend(compile_filter_predicates(',
+  'let exact_count = compile_exact_count(',
+]);
+
+console.log('[verify-index-product-materialized-query-freshness] Product root query freshness fence verified');

--- a/scripts/verify/verify-index-product-materialized-query-freshness.mjs
+++ b/scripts/verify/verify-index-product-materialized-query-freshness.mjs
@@ -30,10 +30,13 @@ const admission = requireMarkers(admissionPath, [
   'BindPlaceholderForbidden',
   'RootAnchorMismatch',
   'pub fn apply(',
-  'compiled.columns.first()',
+  '.columns',
+  '.iter()',
+  '.find_map(',
   'CompiledQueryColumn::EntityId',
   'compiled.exact_count.as_mut()',
   'root_baseline(root_alias)',
+  '.locale_key = $5',
   'sql.match_indices(&anchor).count() != 1',
   '*sql = sql.replacen(&anchor, &replacement, 1)',
 ]);
@@ -141,10 +144,15 @@ requireMarkers('crates/rustok-index/docs/m7-product-materialized-query-freshness
 
 const compilerPath = 'crates/rustok-index/src/application/postgres_query_sql.rs';
 requireMarkers(compilerPath, [
-  'columns.push(CompiledQueryColumn::EntityId',
-  'root_baseline_predicates(',
-  'predicates.extend(compile_filter_predicates(',
-  'let exact_count = compile_exact_count(',
+  'push_identity_column(',
+  '&plan.root_alias,',
+  'let mut predicates = base.predicates;',
+  'predicates.push(compile_filter(plan, filter, &mut bindings)?);',
+  'predicates.push(compile_keyset(plan, cursor, &mut bindings)?);',
+  'let pagination = compile_pagination(&plan.pagination, &mut bindings)?;',
+  'let exact_count = plan',
+  '.then(|| compile_exact_count(plan))',
+  'AND {root_alias}.locale_key = {locale} AND {root_alias}.is_deleted = FALSE',
 ]);
 
 console.log('[verify-index-product-materialized-query-freshness] Product root query freshness fence verified');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -69,6 +69,7 @@ const scripts = [
   'verify-index-product-channel-relation-resolver.mjs',
   'verify-index-product-channel-relation-freshness.mjs',
   'verify-index-product-channel-relation-convergence.mjs',
+  'verify-index-product-materialized-query-freshness.mjs',
   'verify-index-product-graph-projection-ledger.mjs',
   'verify-index-product-variant-source.mjs',
   'verify-index-product-tombstone-source.mjs',

--- a/scripts/verify/verify-index-query-runtime-composition.mjs
+++ b/scripts/verify/verify-index-query-runtime-composition.mjs
@@ -43,13 +43,16 @@ const materializerPath = 'crates/rustok-index/src/infrastructure/postgres/query_
 const materializer = requireMarkers(materializerPath, [
   'pub enum IndexQueryRuntimeCompositionError',
   'AlreadyMaterialized',
+  'AdmissionSchemaMissing',
   'pub fn materialize_postgres_index_query_runtime(',
   'extensions.contains::<SharedIndexQueryRuntime>()',
   'extensions.get::<SharedIndexSchemaRegistry>().cloned()',
-  'extensions',
   '.get::<PostgresIndexQueryAdmissionCatalog>()',
   '.cloned()',
   '.unwrap_or_default()',
+  'for descriptor in admissions.iter()',
+  'registry.registry().get(descriptor.schema()).is_none()',
+  'descriptor.owner_module().to_owned()',
   'PostgresIndexQueryPort::with_admissions(',
   'registry.shared()',
   'admissions,',
@@ -58,6 +61,7 @@ const materializer = requireMarkers(materializerPath, [
   'missing_source_registry_does_not_publish_false_runtime',
   'complete_source_registry_materializes_one_shared_runtime',
   'query_admission_catalog_is_snapshotted_into_runtime_composition',
+  'dangling_query_admission_schema_fails_composition',
   'duplicate_query_runtime_materialization_fails_closed',
 ]);
 for (const forbidden of [

--- a/scripts/verify/verify-index-query-runtime-composition.mjs
+++ b/scripts/verify/verify-index-query-runtime-composition.mjs
@@ -46,12 +46,18 @@ const materializer = requireMarkers(materializerPath, [
   'pub fn materialize_postgres_index_query_runtime(',
   'extensions.contains::<SharedIndexQueryRuntime>()',
   'extensions.get::<SharedIndexSchemaRegistry>().cloned()',
-  'PostgresIndexQueryPort::new(',
+  'extensions',
+  '.get::<PostgresIndexQueryAdmissionCatalog>()',
+  '.cloned()',
+  '.unwrap_or_default()',
+  'PostgresIndexQueryPort::with_admissions(',
   'registry.shared()',
+  'admissions,',
   'extensions.insert(runtime.clone())',
   'return Ok(None);',
   'missing_source_registry_does_not_publish_false_runtime',
   'complete_source_registry_materializes_one_shared_runtime',
+  'query_admission_catalog_is_snapshotted_into_runtime_composition',
   'duplicate_query_runtime_materialization_fails_closed',
 ]);
 for (const forbidden of [
@@ -95,8 +101,10 @@ const server = requireMarkers(serverPath, [
   'extensions.contains::<SharedIndexQueryRuntime>()',
   'host.shared_get::<SharedIndexQueryRuntime>().is_some()',
 ]);
-if (server.includes('PostgresIndexQueryPort::new')) {
-  fail(`${serverPath} must call the Index-owned materializer instead of constructing the port`);
+for (const forbidden of ['PostgresIndexQueryPort::new', 'PostgresIndexQueryPort::with_admissions']) {
+  if (server.includes(forbidden)) {
+    fail(`${serverPath} must call the Index-owned materializer instead of constructing the port`);
+  }
 }
 
 for (const relative of [
@@ -107,8 +115,10 @@ for (const relative of [
   'crates/rustok-social-graph/src/index_privacy_shadow.rs',
 ]) {
   const source = read(relative);
-  if (source.includes('PostgresIndexQueryPort::new')) {
-    fail(`${relative} must not construct the Index query port directly`);
+  for (const forbidden of ['PostgresIndexQueryPort::new', 'PostgresIndexQueryPort::with_admissions']) {
+    if (source.includes(forbidden)) {
+      fail(`${relative} must not construct the Index query port directly`);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- add a generic trusted PostgreSQL root-query admission contract keyed by exact Index `SchemaRef`;
- snapshot schema-scoped admission rules into the canonical `PostgresIndexQueryPort` runtime composition;
- reject dangling admission rules whose exact `SchemaRef` is absent from the same immutable schema registry;
- inject root admission into the compiler-owned `index_entities` baseline before user filter/cursor/order/limit;
- inject the same predicate into exact-count SQL without changing query binds, selected columns, fingerprint, or cursor contract;
- fail closed if the compiler root baseline no longer matches exactly one expected admission anchor;
- register one canonical Product root admission rule from `rustok-distribution`;
- fence Product materialization using existing Product projection/freshness/convergence evidence instead of another schema, relation copy, or Index watermark;
- hide stale Product/locale rows immediately when live owner identity disappears;
- preserve rejected-Product isolation: a rejected Product remains individually query-inadmissible without blocking valid tenant rows.

## Product admission proof

A Product root row is admitted only when, in the same PostgreSQL `REPEATABLE READ, READ ONLY` query snapshot:

- live Product and exact Product translation still exist;
- materialized `index_entities.source_version` equals latest Product `projection_epoch`;
- projection Product component equals current `products.index_revision`;
- a freshness witness exists for the projection's exact relation epoch;
- witness Product revision does not exceed current Product revision;
- witness Channel identity generation equals current tenant Channel generation (or `0` when no Channel generation row exists);
- no Product visibility convergence request is newer than the witness Product revision.

The convergence request check is intentionally the current-visibility watermark: requests are appended only for Product INSERT / canonical `channel_visibility` changes, so unrelated Product updates do not falsely stale relation freshness.

## Why root SQL admission

A post-result freshness check is not sufficient: an unseen stale row can already affect filtering, ordering, cursor pagination, limit, and exact count. This rule is injected into the root relation before those semantics, and exact count uses the same admitted predicate.

## Important transitions

- Product scalar/Variant update: projection epoch advances, old materialized source version is hidden until the new mutation applies.
- Product visibility update: projection advances and a newer convergence request invalidates the old witness.
- Channel generation change with unchanged UUID membership: old row is hidden until a new freshness witness confirms the new generation; no fake relation/projection epoch is required.
- Channel membership change: relation/projection advance, so old materialized row stays hidden until the new Product mutation applies.
- Product/locale delete: live owner/translation absence hides the stale materialized row before the delete mutation reaches Index.
- rejected Product: retained visibility request remains newer than the last valid witness, so only that Product remains fail closed.

## Static recheck fixes before merge

PR-level source review caught and fixed several blockers before merge:

- the new Product admission module is now actually wired into `product_index::register` and Product-only composition asserts one admission rule;
- an accidental unrelated rewrite of `rustok-index/src/lib.rs` was removed, preserving the canonical Index module kind, runtime catalogs, public exports and contract tests;
- the admission compiler anchor now includes the canonical locale predicate (`locale_key = $5`), matching both page and exact-count root baselines;
- the Product freshness verifier now matches the real compiler/source markers and is included in the aggregate Index query contract;
- the existing query-runtime composition verifier now expects the admission-aware constructor and guards dangling admission schemas.

## Generic boundary

`rustok-index` remains module-neutral. `PostgresQueryRootAdmission` accepts only trusted source-code predicates with a compiler-controlled `{{root}}` alias; it rejects bind placeholders, SQL statement boundaries/comments, oversized predicates, and unexpected compiler anchors. `PostgresIndexQueryAdmissionCatalog` allows one owner per exact schema. Runtime composition rejects rules for unregistered schemas. Schemas without a rule retain existing behavior.

The Product predicate contains no `index_entities`/`index_links` access, no user bind placeholders, no `channel_visibility` JSON parser, no writes, and no background runtime.

## Scope

This closes the Product **root** source-read → mutation-apply materialized/query freshness gap at source level. It does not recursively prove freshness/availability of linked SalesChannel/ProductVariant target rows; that remains part of complete Product/Variant/Channel query-equivalence evidence.

Production/Storefront cutover is still blocked on retained PostgreSQL race evidence, convergence multi-host/restart evidence, linked-target/query parity, and the existing schema-readiness/equivalence admission. Product typed events remain separately blocked on event-contract digest admission.

## Main recheck

Before merge, current `main@4c169390bd42e55debd952fe5f666d9af01aebd3` was compared against this PR's base. Intervening Forum #3164 and Commerce #3165 changes are disjoint from all files in this Index/Product freshness slice.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatting, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.