### PR TITLE
refactor(commerce): read admin product detail through owner port

### DIFF
--- a/crates/rustok-commerce/docs/implementation-plan.md
+++ b/crates/rustok-commerce/docs/implementation-plan.md
@@ -203,11 +203,15 @@ These are source-contract defects, not verification-only tasks.
   host-compose embedded or external command providers, and cut mounted admin REST
   product create/update over to the owner port with deadline, payload-bound deterministic
   write identity, channel, actor, locale, and stable public errors.
-- [ ] Cut remaining mounted Product list/detail/catalog reads, REST
-  delete/publish/unpublish lifecycle commands, and GraphQL product lifecycle/schema
-  operations over to host-composed Product owner ports. Direct Product entities,
-  `CatalogService`, and `ProductCatalogSchemaService` remain explicit source debt;
-  repeatable lifecycle commands need an explicit caller idempotency contract before cutover.
+- [x] Cut mounted admin REST Product detail over to the host-selected
+  `ProductCatalogReadPort`, preserving `PRODUCTS_READ`, tenant/actor/channel context,
+  requested locale plus tenant fallback locale, a bounded deadline, and stable public errors.
+- [ ] Cut remaining mounted Product list/catalog reads, REST delete/publish/unpublish
+  lifecycle commands, and GraphQL product lifecycle/schema operations over to
+  host-composed Product owner ports. Direct Product entities, `CatalogService`, and
+  `ProductCatalogSchemaService` remain explicit source debt; repeatable lifecycle
+  commands need an explicit caller idempotency contract before cutover, while admin list
+  needs an owner query contract that preserves vendor/product-type filtering.
 - [x] Publish the order-owned `OrderReadPort` for complete order, return, and
   order-change detail/list projections with canonical read context/deadline policy,
   stable typed errors, filters, ordering, totals, and explicit unvalidated evidence.
@@ -605,6 +609,7 @@ Source inspection is not execution evidence.
 - [ ] `node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs`
 - [ ] `node scripts/verify/verify-commerce-marketplace-financial-capability.mjs`
 - [ ] `node scripts/verify/verify-commerce-product-command-port.mjs`
+- [ ] `node scripts/verify/verify-commerce-product-admin-detail-read.mjs`
 - [ ] `cargo xtask module validate commerce`
 - [ ] `cargo xtask module validate order`
 - [ ] `cargo xtask module validate payment`
@@ -637,8 +642,8 @@ Source inspection is not execution evidence.
   mutation, payment, or fulfillment ownership; unmounted admin compatibility GET
   handlers remain explicit source debt.
 - [ ] Execute the new public-error, typed-lifecycle, storefront-cutover, order-read,
-  marketplace-financial topology, and Product command-port static guards against a
-  repository checkout and retain their output.
+  marketplace-financial topology, Product command-port, and Product admin-detail read
+  static guards against a repository checkout and retain their output.
 
 ### Compile/tests
 
@@ -811,6 +816,9 @@ Source inspection is not execution evidence.
 - [x] Publish and host-compose Product catalog command ports, then cut mounted admin
   REST product create/update away from `CatalogService` with payload-bound write
   identity and stable public error mapping; lifecycle/read/GraphQL cutover remains open.
+- [x] Cut mounted admin REST Product detail over to the host-selected Product read port
+  while preserving locale fallback, request context, permissions, and public envelope;
+  admin list and GraphQL Product reads remain separate source debt.
 
 ## Change rules
 

--- a/crates/rustok-commerce/src/controllers/admin/products.rs
+++ b/crates/rustok-commerce/src/controllers/admin/products.rs
@@ -288,13 +288,49 @@ pub async fn create_product(
     )
 )]
 pub async fn show_product(
-    state: State<CommerceHttpRuntime>,
+    State(runtime): State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
     request_context: RequestContext,
-    path: Path<Uuid>,
+    Path(id): Path<Uuid>,
 ) -> HttpResult<Json<ProductResponse>> {
-    super::super::products::show_product(state, tenant, auth, request_context, path).await
+    ensure_permissions(
+        &auth,
+        &[Permission::PRODUCTS_READ],
+        "Permission denied: products:read required",
+    )?;
+
+    let port_context = rustok_api::PortContext::new(
+        tenant.id.to_string(),
+        rustok_api::PortActor::user(auth.user_id.to_string()),
+        request_context.locale.as_str(),
+        format!("commerce-admin-product:show:{id}"),
+    )
+    .with_deadline(std::time::Duration::from_secs(2));
+    let port_context = match request_context.channel_slug.as_deref() {
+        Some(channel) => port_context.with_channel(channel),
+        None => port_context,
+    };
+    let product = runtime
+        .product_catalog_read_port()
+        .read_product_projection(
+            port_context.clone(),
+            rustok_product::ProductProjectionRequest {
+                product_id: id,
+                locale: Some(request_context.locale.clone()),
+                fallback_locale: Some(tenant.default_locale.clone()),
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_admin_product_port_error(
+                AdminProductErrorContext::new(tenant.id, auth.user_id, Some(id), "show_product"),
+                &port_context,
+                error,
+            )
+        })?;
+
+    Ok(Json(product))
 }
 
 /// Update admin ecommerce product

--- a/scripts/verify/verify-commerce-product-admin-detail-read.mjs
+++ b/scripts/verify/verify-commerce-product-admin-detail-read.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, "../..");
+const source = fs.readFileSync(
+  path.join(root, "crates/rustok-commerce/src/controllers/admin/products.rs"),
+  "utf8",
+);
+
+function fail(message) {
+  console.error(`commerce product admin-detail read guard failed: ${message}`);
+  process.exitCode = 1;
+}
+
+function showProductSlice() {
+  const start = source.indexOf("pub async fn show_product(");
+  const end = source.indexOf("pub async fn update_product(", start + 1);
+  if (start < 0 || end < 0) {
+    fail("could not isolate mounted show_product handler");
+    return "";
+  }
+  return source.slice(start, end);
+}
+
+const show = showProductSlice();
+for (const required of [
+  ".product_catalog_read_port()",
+  ".read_product_projection(",
+  "rustok_product::ProductProjectionRequest",
+  "fallback_locale: Some(tenant.default_locale.clone())",
+  ".with_deadline(std::time::Duration::from_secs(2))",
+  "map_admin_product_port_error(",
+]) {
+  if (!show.includes(required)) {
+    fail(`show_product must contain ${required}`);
+  }
+}
+
+for (const forbidden of [
+  "CatalogService::new",
+  "super::super::products::show_product",
+  "get_product_with_locale_fallback",
+]) {
+  if (show.includes(forbidden)) {
+    fail(`show_product must not contain ${forbidden}`);
+  }
+}
+
+const listStart = source.indexOf("pub async fn list_products(");
+const createStart = source.indexOf("pub async fn create_product(", listStart + 1);
+const list = source.slice(listStart, createStart);
+if (!list.includes("super::super::products::list_products")) {
+  fail("admin list must remain explicit follow-up debt in this slice");
+}
+
+if (!process.exitCode) {
+  console.log("commerce product admin-detail read guard: source contract OK");
+}


### PR DESCRIPTION
## Summary

- cut mounted `GET /admin/products/{id}` from direct `CatalogService` construction to the host-composed `ProductCatalogReadPort`
- preserve `PRODUCTS_READ`, tenant/actor/channel context, requested locale plus tenant fallback locale, a bounded read deadline, and the existing `ProductResponse` HTTP envelope
- reuse stable Product `PortError` public mapping
- add an unexecuted source guard for the admin detail cutover and update the canonical ecommerce plan

## Scope

Admin product list remains separate because its current Commerce surface supports vendor/product-type filtering that the owner `AdminProductListQuery` does not yet express. REST delete/publish/unpublish and GraphQL Product lifecycle/schema cutovers also remain explicit follow-up work.

## Validation

Source-reviewed only. Tests, source verifiers, Cargo checks, formatting, workflows/CI, and database/runtime scenarios were not run per maintainer instruction. Execution evidence remains open in the plan.