### PR TITLE
refactor(commerce): read admin Product GraphQL catalog through owner port

### DIFF
--- a/crates/rustok-commerce/docs/implementation-plan.md
+++ b/crates/rustok-commerce/docs/implementation-plan.md
@@ -212,7 +212,12 @@ These are source-contract defects, not verification-only tasks.
   status/vendor/product-type/search filtering, created-at-desc ordering, pagination,
   locale fallback, empty missing-title projection, normalized/default shipping-profile
   slug, tags, request context, deadline, and public error envelope.
-- [ ] Cut remaining mounted Product catalog reads, REST delete/publish/unpublish
+- [x] Cut mounted admin GraphQL Product catalog reads to the host-selected
+  `ProductCatalogReadRuntime` / `ProductCatalogReadPort`, preserving tenant/permission
+  admission, typed catalog filters, pagination validation, requested/default locale,
+  request channel, authenticated actor, bounded deadline, response projection, and
+  correlation-aware stable public owner errors.
+- [ ] Cut remaining mounted Product storefront catalog reads, REST delete/publish/unpublish
   lifecycle commands, and GraphQL product lifecycle/schema operations over to
   host-composed Product owner ports. Direct Product entities, `CatalogService`, and
   `ProductCatalogSchemaService` remain explicit source debt; repeatable lifecycle
@@ -616,6 +621,7 @@ Source inspection is not execution evidence.
 - [ ] `node scripts/verify/verify-commerce-product-command-port.mjs`
 - [ ] `node scripts/verify/verify-commerce-product-admin-detail-read.mjs`
 - [ ] `node scripts/verify/verify-commerce-product-admin-list-read.mjs`
+- [ ] `node scripts/verify/verify-commerce-product-admin-graphql-read.mjs`
 - [ ] `cargo xtask module validate commerce`
 - [ ] `cargo xtask module validate order`
 - [ ] `cargo xtask module validate payment`
@@ -648,8 +654,9 @@ Source inspection is not execution evidence.
   mutation, payment, or fulfillment ownership; unmounted admin compatibility GET
   handlers remain explicit source debt.
 - [ ] Execute the new public-error, typed-lifecycle, storefront-cutover, order-read,
-  marketplace-financial topology, Product command-port, Product admin-detail read, and
-  Product admin-list read static guards against a repository checkout and retain their output.
+  marketplace-financial topology, Product command-port, Product admin-detail read,
+  Product admin-list read, and Product admin-GraphQL read static guards against a
+  repository checkout and retain their output.
 
 ### Compile/tests
 
@@ -829,6 +836,10 @@ Source inspection is not execution evidence.
   read-port capability while preserving legacy filters, ordering, pagination, locale
   fallback, empty-title/default-shipping envelope, and source compatibility for existing
   Product read-port adapters; GraphQL catalog and lifecycle cutover remain open.
+- [x] Cut mounted admin GraphQL Product catalog reads to the host-selected Product read
+  runtime/port with authenticated actor, request channel/locale context, bounded deadline,
+  existing filter/pagination semantics, unchanged response projection, and safe stable
+  public owner errors; storefront catalog and lifecycle/schema cutover remain open.
 
 ## Change rules
 

--- a/crates/rustok-commerce/src/graphql/product_catalog.rs
+++ b/crates/rustok-commerce/src/graphql/product_catalog.rs
@@ -1,5 +1,8 @@
-use async_graphql::{Context, InputObject, Object, Result, SimpleObject};
-use rustok_api::{Permission, RequestContext, TenantContext, graphql::require_module_enabled};
+use async_graphql::{Context, ErrorExtensions, InputObject, Object, Result, SimpleObject};
+use rustok_api::{
+    Permission, PortActor, PortContext, PortError, PortErrorKind, RequestContext, TenantContext,
+    graphql::require_module_enabled,
+};
 use rustok_outbox::TransactionalEventBus;
 use rustok_product::{AdminProductListQuery, CatalogService, StorefrontProductListQuery};
 use sea_orm::DatabaseConnection;
@@ -10,6 +13,69 @@ use super::{
     map_product_service_error, product_query_tenant, require_commerce_permission,
     require_storefront_channel_enabled,
 };
+
+fn admin_product_catalog_port_error(
+    context: &PortContext,
+    error: PortError,
+) -> async_graphql::Error {
+    let (code, message, retryable, error_kind) = match &error.kind {
+        PortErrorKind::Validation => (
+            "PRODUCT_VALIDATION",
+            "Product request is invalid",
+            false,
+            "validation",
+        ),
+        PortErrorKind::NotFound => (
+            "PRODUCT_NOT_FOUND",
+            "Product was not found",
+            false,
+            "not_found",
+        ),
+        PortErrorKind::Conflict => (
+            "PRODUCT_OPERATION_FAILED",
+            "Product operation could not be completed safely",
+            false,
+            "conflict",
+        ),
+        PortErrorKind::Forbidden => (
+            "PRODUCT_ACCESS_DENIED",
+            "Product operation is not permitted",
+            false,
+            "forbidden",
+        ),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+            "PRODUCT_TEMPORARILY_UNAVAILABLE",
+            "Product data is temporarily unavailable",
+            true,
+            "unavailable",
+        ),
+        PortErrorKind::InvariantViolation => (
+            "PRODUCT_OPERATION_FAILED",
+            "Product operation could not be completed safely",
+            false,
+            "invariant_violation",
+        ),
+    };
+
+    tracing::error!(
+        correlation_id = %context.correlation_id,
+        tenant_id = %context.tenant_id,
+        operation = "admin_product_catalog",
+        owner_code = %error.code,
+        owner_kind = error_kind,
+        owner_retryable = error.retryable,
+        public_code = code,
+        retryable,
+        boundary = "commerce_graphql_product",
+        "commerce GraphQL Product admin catalog owner port failed"
+    );
+
+    async_graphql::Error::new(message).extend_with(|_, extensions| {
+        extensions.set("code", code);
+        extensions.set("retryable", retryable);
+        extensions.set("correlation_id", context.correlation_id.to_string());
+    })
+}
 
 #[derive(InputObject, Default)]
 pub struct StorefrontProductCatalogFilter {
@@ -143,7 +209,7 @@ impl ProductCatalogQuery {
         filter: Option<AdminProductCatalogFilter>,
     ) -> Result<AdminProductCatalogList> {
         require_module_enabled(ctx, PRODUCT_MODULE_SLUG).await?;
-        require_commerce_permission(
+        let auth = require_commerce_permission(
             ctx,
             &[Permission::PRODUCTS_LIST, Permission::PRODUCTS_READ],
             "Permission denied: products:list or products:read required",
@@ -162,6 +228,14 @@ impl ProductCatalogQuery {
         let filter = filter.unwrap_or_default();
         let page = filter.page.unwrap_or(1);
         let per_page = filter.per_page.unwrap_or(24);
+        if page == 0 || per_page == 0 || per_page > 100 {
+            return Err(map_product_service_error(
+                rustok_product::CommerceError::Validation(
+                    "page must be at least 1 and per_page must be between 1 and 100".to_string(),
+                ),
+                "admin_product_catalog",
+            ));
+        }
         let list_query = AdminProductListQuery::try_from_transport_with_attribute_filters(
             filter.search,
             filter.status,
@@ -171,17 +245,41 @@ impl ProductCatalogQuery {
             filter.attribute_filters.unwrap_or_default(),
         )
         .map_err(|error| map_product_service_error(error, "admin_product_catalog_input"))?;
-        let products = CatalogService::new(db.clone(), event_bus.clone())
-            .list_admin_products_with_query(
-                tenant_id,
-                requested_locale.as_str(),
-                Some(tenant.default_locale.as_str()),
-                list_query,
-                page,
-                per_page,
+
+        let port_context = PortContext::new(
+            tenant_id.to_string(),
+            PortActor::user(auth.user_id.to_string()),
+            requested_locale.as_str(),
+            format!("commerce-graphql-product:admin-catalog:{page}:{per_page}"),
+        )
+        .with_deadline(std::time::Duration::from_secs(2));
+        let port_context = match request_context.and_then(|context| context.channel_slug.as_deref()) {
+            Some(channel) => port_context.with_channel(channel),
+            None => port_context,
+        };
+        let product_read_runtime =
+            crate::graphql_runtime::product_catalog_read_runtime_for_current_graphql_scope(
+                db.clone(),
+                event_bus.clone(),
+            );
+        let products = product_read_runtime
+            .read_port()
+            .list_admin_products(
+                port_context.clone(),
+                rustok_product::AdminProductsRequest {
+                    locale: Some(requested_locale),
+                    fallback_locale: Some(tenant.default_locale.clone()),
+                    query: list_query,
+                    raw_status: None,
+                    vendor: None,
+                    product_type: None,
+                    empty_missing_title: false,
+                    page,
+                    per_page,
+                },
             )
             .await
-            .map_err(|error| map_product_service_error(error, "admin_product_catalog"))?;
+            .map_err(|error| admin_product_catalog_port_error(&port_context, error))?;
 
         Ok(AdminProductCatalogList {
             total: products.total,

--- a/scripts/verify/verify-commerce-product-admin-graphql-read.mjs
+++ b/scripts/verify/verify-commerce-product-admin-graphql-read.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, "../..");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+function fail(message) {
+  console.error(`commerce Product admin GraphQL read guard failed: ${message}`);
+  process.exitCode = 1;
+}
+
+function requireText(source, text, message) {
+  if (!source.includes(text)) fail(message);
+}
+
+function forbidText(source, text, message) {
+  if (source.includes(text)) fail(message);
+}
+
+function resolverSlice(source, name, nextName) {
+  const start = source.indexOf(`async fn ${name}(`);
+  if (start < 0) {
+    fail(`missing resolver ${name}`);
+    return "";
+  }
+  const end = nextName ? source.indexOf(`async fn ${nextName}(`, start + 1) : -1;
+  return source.slice(start, end < 0 ? source.length : end);
+}
+
+const source = read("crates/rustok-commerce/src/graphql/product_catalog.rs");
+const admin = resolverSlice(source, "admin_product_catalog", null);
+const storefront = resolverSlice(source, "storefront_product_catalog", "admin_product_catalog");
+
+for (const required of [
+  "let auth = require_commerce_permission(",
+  "product_query_tenant(ctx, tenant_id)",
+  "page == 0 || per_page == 0 || per_page > 100",
+  "PortActor::user(auth.user_id.to_string())",
+  ".with_deadline(std::time::Duration::from_secs(2))",
+  "context.channel_slug.as_deref()",
+  "product_catalog_read_runtime_for_current_graphql_scope(",
+  ".read_port()",
+  ".list_admin_products(",
+  "rustok_product::AdminProductsRequest",
+  "fallback_locale: Some(tenant.default_locale.clone())",
+  "raw_status: None",
+  "vendor: None",
+  "product_type: None",
+  "empty_missing_title: false",
+  "admin_product_catalog_port_error(&port_context, error)",
+]) {
+  requireText(admin, required, `admin Product catalog resolver must contain ${required}`);
+}
+
+for (const forbidden of [
+  "CatalogService::new",
+  ".list_admin_products_with_query(",
+  "product::Entity::find",
+  "product_translation::Entity::find",
+]) {
+  forbidText(admin, forbidden, `admin Product catalog resolver must not contain ${forbidden}`);
+}
+
+for (const required of [
+  '"PRODUCT_VALIDATION"',
+  '"PRODUCT_NOT_FOUND"',
+  '"PRODUCT_TEMPORARILY_UNAVAILABLE"',
+  '"PRODUCT_OPERATION_FAILED"',
+  'extensions.set("correlation_id", context.correlation_id.to_string())',
+]) {
+  requireText(source, required, `Product GraphQL PortError mapper must contain ${required}`);
+}
+for (const forbidden of [
+  "Error::new(error.message)",
+  'extensions.set("message", error.message)',
+]) {
+  forbidText(source, forbidden, `Product GraphQL owner errors must not expose ${forbidden}`);
+}
+
+requireText(
+  storefront,
+  "CatalogService::new",
+  "storefront Product catalog must remain explicit follow-up debt in this slice",
+);
+
+const runtime = read("crates/rustok-commerce/src/graphql_runtime.rs");
+for (const required of [
+  "CURRENT_COMMERCE_PRODUCT_CATALOG_READ_RUNTIME",
+  "product_catalog_read_runtime_for_current_graphql_scope(",
+  "runtime_data.product_catalog_read_runtime()",
+]) {
+  requireText(runtime, required, `mounted GraphQL runtime must contain ${required}`);
+}
+
+if (!process.exitCode) {
+  console.log("commerce Product admin GraphQL read guard: source contract OK");
+}


### PR DESCRIPTION
## Summary

- cut mounted admin Product GraphQL catalog reads from direct `CatalogService` construction to the host-selected `ProductCatalogReadRuntime` / `ProductCatalogReadPort`
- preserve current tenant and permission admission, typed search/status/category/sort/attribute filters, page-size validation, requested/default locale fallback, actor/channel/deadline context, and unchanged GraphQL response projection
- preserve prior `page=0` / invalid page-size validation before the owner call
- map owner `PortError` to stable Product GraphQL messages/codes without exposing owner messages, using the request-scoped correlation id
- keep storefront Product GraphQL catalog concrete construction as explicit follow-up debt
- add an unexecuted source guard and update the canonical ecommerce plan without closing the broad topology P0

## Validation

Source-reviewed only. Tests, source verifiers, Cargo checks, formatting, workflows/CI, and database/runtime scenarios were not run. Execution evidence remains open in the canonical plan.